### PR TITLE
Fix reroll bug in dice

### DIFF
--- a/FutureMUDLibrary/Framework/Dice.cs
+++ b/FutureMUDLibrary/Framework/Dice.cs
@@ -178,10 +178,12 @@ public static class Dice {
 						break;
 				}
 
-				if (rerollReference == sides)
-				{
-					return 0;
-				}
+                                // Avoid infinite loops when rerolling until a
+                                // result higher than the die can provide
+                                if (isRerollUntil && rerollReference >= sides)
+                                {
+                                        return 0;
+                                }
 
 
 				var rolls = new List<int>(sides);


### PR DESCRIPTION
## Summary
- prevent infinite loop when rerolling dice

## Testing
- `dotnet test -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe561fd848323b52e0aabba3bfa0d