### PR TITLE
Fix SetCover error message typo

### DIFF
--- a/MudSharpCore/FutureProg/Statements/Manipulation/SetCover.cs
+++ b/MudSharpCore/FutureProg/Statements/Manipulation/SetCover.cs
@@ -118,11 +118,11 @@ internal class SetCover : Statement
 			return StatementResult.Error;
 		}
 
-		if (ItemFunction.Result is not IGameItem item)
-		{
-			ErrorMessage = "SetCover recieved a null item.";
-			return StatementResult.Error;
-		}
+                if (ItemFunction.Result is not IGameItem item)
+                {
+                        ErrorMessage = "SetCover received a null item.";
+                        return StatementResult.Error;
+                }
 
 		var coverItem = item.GetItemType<IProvideCover>();
 		if (coverItem == null)


### PR DESCRIPTION
## Summary
- correct the spelling of "received" in `SetCover`

## Testing
- `dotnet build MudSharp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402526351c832385ab4e6c9376f8f4