### PR TITLE
Fix MultiDifficultyCheck second difficulty

### DIFF
--- a/MudSharpCore/RPG/Checks/OGLCheck.cs
+++ b/MudSharpCore/RPG/Checks/OGLCheck.cs
@@ -51,9 +51,9 @@ public class OGLCheck : StandardCheck
 		var outcome1 = GetOutcome(roll,
 			Modifiers[difficulty1] - TargetNumberExpression.EvaluateWith(checkee, trait, values: customParameters) -
 			bonus);
-		var outcome2 = GetOutcome(roll,
-			Modifiers[difficulty1] - TargetNumberExpression.EvaluateWith(checkee, trait, values: customParameters) -
-			bonus);
+                var outcome2 = GetOutcome(roll,
+                        Modifiers[difficulty2] - TargetNumberExpression.EvaluateWith(checkee, trait, values: customParameters) -
+                        bonus);
 
 		return Tuple.Create(HandleStandardCheck(checkee, target, outcome1, difficulty1, trait, true, traitUseType),
 			HandleStandardCheck(checkee, target, outcome2, difficulty2, trait, true, traitUseType));


### PR DESCRIPTION
## Summary
- ensure OGLCheck's second outcome uses `difficulty2`

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402799f3508323aa48e8ae5271dca0