### PR TITLE
Add map tests

### DIFF
--- a/MudSharpCore Unit Tests/MapTests.cs
+++ b/MudSharpCore Unit Tests/MapTests.cs
@@ -15,8 +15,8 @@ namespace MudSharp_Unit_Tests;
 [TestClass]
 public class MapTests
 {
-	public static ICell[,] GetMapTestCells
-	{
+        public static ICell[,] GetMapTestCells
+        {
 		get
 		{
 			var id = 457;
@@ -126,7 +126,37 @@ public class MapTests
 					returnMap[i, j] = cellMap[i, j]?.GetObject(cellMocks);
 				}
 			}
-			return returnMap;
-		}
-	}
+                        return returnMap;
+                }
+        }
+
+        [TestMethod]
+        public void BasicExitLinking()
+        {
+                var map = GetMapTestCells;
+                var cellA = map[2, 2];
+                var cellB = map[3, 2];
+
+                Assert.IsNotNull(cellA, "Cell 2,2 should exist");
+                Assert.IsNotNull(cellB, "Cell 3,2 should exist");
+
+                var exitA = cellA.ExitsFor(null, true).FirstOrDefault(x => x.OutboundDirection == CardinalDirection.East);
+                Assert.IsNotNull(exitA, "Cell 2,2 should have an east exit");
+                Assert.AreSame(cellB, exitA.Destination, "East exit from 2,2 should lead to 3,2");
+
+                var exitB = cellB.ExitsFor(null, true).FirstOrDefault(x => x.OutboundDirection == CardinalDirection.West);
+                Assert.IsNotNull(exitB, "Cell 3,2 should have a west exit");
+                Assert.AreSame(cellA, exitB.Destination, "West exit from 3,2 should lead to 2,2");
+        }
+
+        [TestMethod]
+        public void SimplePathFinding()
+        {
+                var map = GetMapTestCells;
+                var source = new PerceivableStub { Location = map[2, 2] }.ToMock();
+                var target = new PerceivableStub { Location = map[5, 2] }.ToMock();
+
+                var path = source.PathBetween(target, 10, false).ToList();
+                Assert.AreEqual(3, path.Count, $"Expected a path of length 3 but got {path.Count}. Path: {string.Join(", ", path.Select(x => x.OutboundDirection.DescribeBrief()))}");
+        }
 }


### PR DESCRIPTION
## Summary
- add two map tests validating exit linking and path finding

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684027ac56748323bc36dd906acf8a9a