### PR TITLE
Add Utilities unit tests

### DIFF
--- a/FutureMUDLibrary/Framework/Utilities.cs
+++ b/FutureMUDLibrary/Framework/Utilities.cs
@@ -272,19 +272,19 @@ namespace MudSharp.Framework {
 			return sb.AppendLine(string.Format(text, parameters));
 		}
 
-		private static Dictionary<Type, ConstructorInfo> _genericListConstructors = new();
-		public static List<T> CreateList<T>(this T type) where T : Type
-		{
-			if (_genericListConstructors.ContainsKey(type))
-			{
-				return (List<T>)_genericListConstructors[type].Invoke(new object[] { });
-			}
-			Type listGenericType = typeof(List<>);
-			Type listType = listGenericType.MakeGenericType(type);
-			ConstructorInfo ci = listType.GetConstructor(new Type[] { });
-			_genericListConstructors[type] = ci;
-			return (List<T>)ci.Invoke(new object[] { });
-		}
+               private static readonly Dictionary<Type, ConstructorInfo> _genericListConstructors = new();
+               public static System.Collections.IList CreateList(this Type type)
+               {
+                       if (_genericListConstructors.TryGetValue(type, out var ctor))
+                       {
+                               return (System.Collections.IList)ctor.Invoke(Array.Empty<object>());
+                       }
+
+                       var listType = typeof(List<>).MakeGenericType(type);
+                       var ci = listType.GetConstructor(Type.EmptyTypes);
+                       _genericListConstructors[type] = ci;
+                       return (System.Collections.IList)ci.Invoke(Array.Empty<object>());
+               }
 
 		public static string InnerXML(this XElement el)
 		{

--- a/MudSharpCore Unit Tests/UtilitiesTests.cs
+++ b/MudSharpCore Unit Tests/UtilitiesTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Framework;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class UtilitiesTests
+{
+    private enum SampleEnum
+    {
+        Alpha = 0,
+        Beta = 1,
+        Gamma = 2
+    }
+
+    [TestMethod]
+    public void SplitDelimiter_PreserveDelimiter()
+    {
+        var input = Encoding.ASCII.GetBytes("A,B,C");
+        var parts = input.SplitDelimiter(new byte[] { (byte)',' }, Utilities.ByteSplitOptions.PreserveDelimiter)
+                          .Select(b => Encoding.ASCII.GetString(b)).ToList();
+        CollectionAssert.AreEqual(new List<string> { "A,", "B,", "C" }, parts);
+    }
+
+    [TestMethod]
+    public void SplitDelimiter_DiscardDelimiter()
+    {
+        var input = Encoding.ASCII.GetBytes("A,B,C");
+        var parts = input.SplitDelimiter(new byte[] { (byte)',' }, Utilities.ByteSplitOptions.DiscardDelimiter)
+                          .Select(b => Encoding.ASCII.GetString(b)).ToList();
+        CollectionAssert.AreEqual(new List<string> { "A", "B", "C" }, parts);
+    }
+
+    [TestMethod]
+    public void TryParseEnum_ValidAndInvalid()
+    {
+        Assert.IsTrue("Beta".TryParseEnum<SampleEnum>(out var result));
+        Assert.AreEqual(SampleEnum.Beta, result);
+
+        Assert.IsTrue("2".TryParseEnum<SampleEnum>(out result));
+        Assert.AreEqual(SampleEnum.Gamma, result);
+
+        Assert.IsFalse("Delta".TryParseEnum<SampleEnum>(out result));
+        Assert.AreEqual(default(SampleEnum), result);
+    }
+
+    [TestMethod]
+    public void ParseEnumWithDefault_ReturnsFallbackForInvalid()
+    {
+        var value = "Gamma".ParseEnumWithDefault(SampleEnum.Alpha);
+        Assert.AreEqual(SampleEnum.Gamma, value);
+
+        value = "Unknown".ParseEnumWithDefault(SampleEnum.Alpha);
+        Assert.AreEqual(SampleEnum.Alpha, value);
+    }
+
+    [TestMethod]
+    public void CreateList_Reflective()
+    {
+        var list = (List<string>)Utilities.CreateList(typeof(string));
+        Assert.AreEqual(0, list.Count);
+        list.Add("hello");
+        Assert.AreEqual("hello", list[0]);
+    }
+
+    [TestMethod]
+    public void NowNoLonger_ReturnsCorrectStrings()
+    {
+        Assert.AreEqual("now", true.NowNoLonger());
+        Assert.AreEqual("no longer", false.NowNoLonger());
+    }
+}


### PR DESCRIPTION
## Summary
- add missing `UtilitiesTests` for byte splitting, enum parsing, list creation and boolean extension
- fix `Utilities.CreateList` implementation to actually create list for a runtime type

## Testing
- `dotnet test "MudSharpCore Unit Tests/MudSharpCore Unit Tests.csproj" --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_68412e9361248323aeae7218441addb7