### PR TITLE
Add tests for ANSI color utilities

### DIFF
--- a/MudSharpCore Unit Tests/StringUtilitiesTests.cs
+++ b/MudSharpCore Unit Tests/StringUtilitiesTests.cs
@@ -1,0 +1,31 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Framework;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class StringUtilitiesTests
+{
+    [TestMethod]
+    public void SubstituteANSIColour_BasicCodes()
+    {
+        var input = "This is #4blue#0 text.";
+        var expected = $"This is {Telnet.Blue}blue{Telnet.RESETALL} text.";
+        Assert.AreEqual(expected, input.SubstituteANSIColour());
+    }
+
+    [TestMethod]
+    public void SubstituteANSIColour_RGBCodes()
+    {
+        var input = "Colour #`12;34;56;here#0.";
+        var expected = $"Colour \x1b[38;2;12;34;56mhere{Telnet.RESETALL}.";
+        Assert.AreEqual(expected, input.SubstituteANSIColour());
+    }
+
+    [TestMethod]
+    public void StripANSIColour_RemovesSequences()
+    {
+        var coloured = "Test #4blue#0 text".SubstituteANSIColour();
+        Assert.AreEqual("Test blue text", coloured.StripANSIColour());
+    }
+}


### PR DESCRIPTION
## Summary
- add `StringUtilitiesTests` to cover color substitutions and stripping

## Testing
- `dotnet test "MudSharpCore Unit Tests/MudSharpCore Unit Tests.csproj" -v n` *(fails: logger failure)*

------
https://chatgpt.com/codex/tasks/task_e_68412e991a3c8323a42e68547fddb149