### PR TITLE
Improve WeightSpellEffect unit handling

### DIFF
--- a/MudSharpCore/Effects/Concrete/SpellEffects/SpellHealingRateEffect.cs
+++ b/MudSharpCore/Effects/Concrete/SpellEffects/SpellHealingRateEffect.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Xml.Linq;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+
+namespace MudSharp.Effects.Concrete.SpellEffects;
+
+public class SpellHealingRateEffect : MagicSpellEffectBase, IHealingRateEffect
+{
+    public static void InitialiseEffectType()
+    {
+        RegisterFactory("SpellHealingRate", (effect, owner) => new SpellHealingRateEffect(effect, owner));
+    }
+
+    public SpellHealingRateEffect(IPerceivable owner, IMagicSpellEffectParent parent, IFutureProg prog, double multiplier, int stages) : base(owner, parent, prog)
+    {
+        HealingRateMultiplier = multiplier;
+        HealingDifficultyStages = stages;
+    }
+
+    protected SpellHealingRateEffect(XElement root, IPerceivable owner) : base(root, owner)
+    {
+        var trueRoot = root.Element("Effect");
+        HealingRateMultiplier = double.Parse(trueRoot.Element("Multiplier").Value);
+        HealingDifficultyStages = int.Parse(trueRoot.Element("Stages").Value);
+    }
+
+    protected override XElement SaveDefinition()
+    {
+        return new XElement("Effect",
+            new XElement("ApplicabilityProg", ApplicabilityProg?.Id ?? 0),
+            new XElement("Multiplier", HealingRateMultiplier),
+            new XElement("Stages", HealingDifficultyStages)
+        );
+    }
+
+    public override string Describe(IPerceiver voyeur)
+    {
+        return $"Healing {1.0 - HealingRateMultiplier:P2} faster and {Math.Abs(HealingDifficultyStages):N0} stages {(HealingDifficultyStages > 0 ? "harder" : "easier")}.";
+    }
+
+    protected override string SpecificEffectType => "SpellHealingRate";
+
+    public double HealingRateMultiplier { get; set; }
+    public int HealingDifficultyStages { get; set; }
+}

--- a/MudSharpCore/Effects/Concrete/SpellEffects/SpellPacifismEffect.cs
+++ b/MudSharpCore/Effects/Concrete/SpellEffects/SpellPacifismEffect.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Xml.Linq;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+
+namespace MudSharp.Effects.Concrete.SpellEffects;
+
+public class SpellPacifismEffect : MagicSpellEffectBase, IPacifismEffect
+{
+    public static void InitialiseEffectType()
+    {
+        RegisterFactory("SpellPacifism", (effect, owner) => new SpellPacifismEffect(effect, owner));
+    }
+
+    public SpellPacifismEffect(IPerceivable owner, IMagicSpellEffectParent parent, IFutureProg prog, double intensity) : base(owner, parent, prog)
+    {
+        IntensityPerGramMass = intensity;
+    }
+
+    protected SpellPacifismEffect(XElement root, IPerceivable owner) : base(root, owner)
+    {
+        var tr = root.Element("Effect");
+        IntensityPerGramMass = double.Parse(tr.Element("Intensity").Value);
+    }
+
+    protected override XElement SaveDefinition()
+    {
+        return new XElement("Effect",
+            new XElement("ApplicabilityProg", ApplicabilityProg?.Id ?? 0),
+            new XElement("Intensity", IntensityPerGramMass)
+        );
+    }
+
+    public override string Describe(IPerceiver voyeur)
+    {
+        return $"Pacifism Intensity {IntensityPerGramMass.ToString("N2", voyeur)}";
+    }
+
+    protected override string SpecificEffectType => "SpellPacifism";
+
+    public double IntensityPerGramMass { get; set; }
+
+    public bool IsPeaceful => IntensityPerGramMass > 5.0;
+    public bool IsSuperPeaceful => IntensityPerGramMass > 10.0;
+}

--- a/MudSharpCore/Effects/Concrete/SpellEffects/SpellRageEffect.cs
+++ b/MudSharpCore/Effects/Concrete/SpellEffects/SpellRageEffect.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Xml.Linq;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+
+namespace MudSharp.Effects.Concrete.SpellEffects;
+
+public class SpellRageEffect : MagicSpellEffectBase, IRageEffect
+{
+    public static void InitialiseEffectType()
+    {
+        RegisterFactory("SpellRage", (effect, owner) => new SpellRageEffect(effect, owner));
+    }
+
+    public SpellRageEffect(IPerceivable owner, IMagicSpellEffectParent parent, IFutureProg prog, double intensity) : base(owner, parent, prog)
+    {
+        IntensityPerGramMass = intensity;
+    }
+
+    protected SpellRageEffect(XElement root, IPerceivable owner) : base(root, owner)
+    {
+        var tr = root.Element("Effect");
+        IntensityPerGramMass = double.Parse(tr.Element("Intensity").Value);
+    }
+
+    protected override XElement SaveDefinition()
+    {
+        return new XElement("Effect",
+            new XElement("ApplicabilityProg", ApplicabilityProg?.Id ?? 0),
+            new XElement("Intensity", IntensityPerGramMass)
+        );
+    }
+
+    public override string Describe(IPerceiver voyeur)
+    {
+        return $"Rage Intensity {IntensityPerGramMass.ToString("N2", voyeur)}";
+    }
+
+    protected override string SpecificEffectType => "SpellRage";
+
+    public double IntensityPerGramMass { get; set; }
+
+    public bool IsRaging => IntensityPerGramMass >= 5.0;
+    public bool IsSuperRaging => IntensityPerGramMass >= 10.0;
+}

--- a/MudSharpCore/Effects/Concrete/SpellEffects/SpellTelepathyEffect.cs
+++ b/MudSharpCore/Effects/Concrete/SpellEffects/SpellTelepathyEffect.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Xml.Linq;
+using MudSharp.Character;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+
+namespace MudSharp.Effects.Concrete.SpellEffects;
+
+public class SpellTelepathyEffect : MagicSpellEffectBase, ITelepathyEffect
+{
+    public static void InitialiseEffectType()
+    {
+        RegisterFactory("SpellTelepathy", (effect, owner) => new SpellTelepathyEffect(effect, owner));
+    }
+
+    public SpellTelepathyEffect(IPerceivable owner, IMagicSpellEffectParent parent, IFutureProg prog, bool showThinks, bool showFeels, bool showEmote) : base(owner, parent, prog)
+    {
+        ShowThinks = showThinks;
+        ShowFeels = showFeels;
+        ShowThinkEmoteFlag = showEmote;
+    }
+
+    protected SpellTelepathyEffect(XElement root, IPerceivable owner) : base(root, owner)
+    {
+        var tr = root.Element("Effect");
+        ShowThinks = bool.Parse(tr.Element("Thinks").Value);
+        ShowFeels = bool.Parse(tr.Element("Feels").Value);
+        ShowThinkEmoteFlag = bool.Parse(tr.Element("Emote").Value);
+    }
+
+    protected override XElement SaveDefinition()
+    {
+        return new XElement("Effect",
+            new XElement("ApplicabilityProg", ApplicabilityProg?.Id ?? 0),
+            new XElement("Thinks", ShowThinks),
+            new XElement("Feels", ShowFeels),
+            new XElement("Emote", ShowThinkEmoteFlag)
+        );
+    }
+
+    public override string Describe(IPerceiver voyeur)
+    {
+        return "Telepathic link";
+    }
+
+    protected override string SpecificEffectType => "SpellTelepathy";
+
+    public bool ShowThinks { get; set; }
+    public bool ShowFeels { get; set; }
+    private bool ShowThinkEmoteFlag { get; set; }
+
+    public bool ShowDescription(ICharacter thinker) => true;
+    public bool ShowName(ICharacter thinker) => false;
+    public bool ShowThinkEmote(ICharacter thinker) => ShowThinkEmoteFlag;
+}

--- a/MudSharpCore/Effects/Concrete/SpellEffects/SpellWeightEffect.cs
+++ b/MudSharpCore/Effects/Concrete/SpellEffects/SpellWeightEffect.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Xml.Linq;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.Framework.Units;
+using MudSharp.FutureProg;
+
+namespace MudSharp.Effects.Concrete.SpellEffects;
+
+public class SpellWeightEffect : MagicSpellEffectBase, IEffectAddsWeight
+{
+    public static void InitialiseEffectType()
+    {
+        RegisterFactory("SpellWeight", (effect, owner) => new SpellWeightEffect(effect, owner));
+    }
+
+    public SpellWeightEffect(IPerceivable owner, IMagicSpellEffectParent parent, IFutureProg prog, double weight) : base(owner, parent, prog)
+    {
+        AddedWeight = weight;
+    }
+
+    protected SpellWeightEffect(XElement root, IPerceivable owner) : base(root, owner)
+    {
+        var tr = root.Element("Effect");
+        AddedWeight = double.Parse(tr.Element("Weight").Value);
+    }
+
+    protected override XElement SaveDefinition()
+    {
+        return new XElement("Effect",
+            new XElement("ApplicabilityProg", ApplicabilityProg?.Id ?? 0),
+            new XElement("Weight", AddedWeight)
+        );
+    }
+
+    public override string Describe(IPerceiver voyeur)
+    {
+        return $"Adds {Gameworld.UnitManager.DescribeExact(AddedWeight, UnitType.Mass, voyeur)} of weight.";
+    }
+
+    protected override string SpecificEffectType => "SpellWeight";
+
+    public double AddedWeight { get; set; }
+}

--- a/MudSharpCore/Magic/SpellEffects/HealingRateSpellEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/HealingRateSpellEffect.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Xml.Linq;
+using System.Linq;
+using MudSharp.Character;
+using MudSharp.Effects.Concrete.SpellEffects;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.RPG.Checks;
+
+namespace MudSharp.Magic.SpellEffects;
+
+public class HealingRateSpellEffect : IMagicSpellEffectTemplate
+{
+    public static void RegisterFactory()
+    {
+        SpellEffectFactory.RegisterLoadTimeFactory("healingrate", (root, spell) => new HealingRateSpellEffect(root, spell));
+        SpellEffectFactory.RegisterBuilderFactory("healingrate", BuilderFactory,
+            "Modifies natural healing rate and difficulty",
+            HelpText,
+            false,
+            true,
+            SpellTriggerFactory.MagicTriggerTypes.Where(x => IsCompatibleWithTrigger(SpellTriggerFactory.BuilderInfoForType(x).TargetTypes)).ToArray());
+    }
+
+    private static (IMagicSpellEffectTemplate Trigger, string Error) BuilderFactory(StringStack commands, IMagicSpell spell)
+    {
+        return (new HealingRateSpellEffect(new XElement("Effect",
+                        new XAttribute("type", "healingrate"),
+                        new XElement("Multiplier", 1.0),
+                        new XElement("Stages", 0)
+                    ), spell), string.Empty);
+    }
+
+    protected HealingRateSpellEffect(XElement root, IMagicSpell spell)
+    {
+        Spell = spell;
+        Multiplier = double.Parse(root.Element("Multiplier")?.Value ?? "1.0");
+        Stages = int.Parse(root.Element("Stages")?.Value ?? "0");
+    }
+
+    public IMagicSpell Spell { get; }
+
+    public double Multiplier { get; set; }
+    public int Stages { get; set; }
+
+    public IFuturemud Gameworld => Spell.Gameworld;
+
+    public XElement SaveToXml()
+    {
+        return new XElement("Effect",
+            new XAttribute("type", "healingrate"),
+            new XElement("Multiplier", Multiplier),
+            new XElement("Stages", Stages)
+        );
+    }
+
+    public const string HelpText = @"You can use the following options with this effect:
+    #3multiplier <##>#0 - sets the healing rate multiplier
+    #3stages <##>#0 - sets the bonus or penalty stages to healing checks";
+
+    public bool BuildingCommand(ICharacter actor, StringStack command)
+    {
+        switch (command.PopSpeech().ToLowerInvariant())
+        {
+            case "multiplier":
+            case "rate":
+                return BuildingCommandMultiplier(actor, command);
+            case "stages":
+            case "difficulty":
+                return BuildingCommandStages(actor, command);
+        }
+
+        actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
+        return false;
+    }
+
+    private bool BuildingCommandMultiplier(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished || !double.TryParse(command.SafeRemainingArgument, out var value))
+        {
+            actor.OutputHandler.Send("You must enter a valid multiplier.");
+            return false;
+        }
+
+        Multiplier = value;
+        Spell.Changed = true;
+        actor.OutputHandler.Send($"The healing rate multiplier is now {Multiplier.ToString("N3", actor).ColourValue()}.");
+        return true;
+    }
+
+    private bool BuildingCommandStages(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished || !int.TryParse(command.SafeRemainingArgument, out var value))
+        {
+            actor.OutputHandler.Send("You must enter a valid integer number of stages.");
+            return false;
+        }
+
+        Stages = value;
+        Spell.Changed = true;
+        actor.OutputHandler.Send($"The healing difficulty adjustment is now {Stages.ToString("N0", actor).ColourValue()} stages.");
+        return true;
+    }
+
+    public string Show(ICharacter actor)
+    {
+        return $"HealingRate - x{Multiplier.ToString("N2", actor)} {(Stages>=0?"+":"")}{Stages}";
+    }
+
+    public bool IsInstantaneous => false;
+    public bool RequiresTarget => true;
+
+    public bool IsCompatibleWithTrigger(IMagicTrigger types) => IsCompatibleWithTrigger(types.TargetTypes);
+    public static bool IsCompatibleWithTrigger(string types)
+    {
+        switch (types)
+        {
+            case "character":
+            case "characters":
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public IMagicSpellEffect GetOrApplyEffect(ICharacter caster, IPerceivable target, OpposedOutcomeDegree outcome, SpellPower power, IMagicSpellEffectParent parent, SpellAdditionalParameter[] additionalParameters)
+    {
+        if (target is not ICharacter ch)
+        {
+            return null;
+        }
+
+        return new SpellHealingRateEffect(ch, parent, null, Multiplier, Stages);
+    }
+
+    public IMagicSpellEffectTemplate Clone() => new HealingRateSpellEffect(SaveToXml(), Spell);
+}

--- a/MudSharpCore/Magic/SpellEffects/PacifismSpellEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/PacifismSpellEffect.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Xml.Linq;
+using System.Linq;
+using MudSharp.Character;
+using MudSharp.Effects.Concrete.SpellEffects;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.RPG.Checks;
+
+namespace MudSharp.Magic.SpellEffects;
+
+public class PacifismSpellEffect : IMagicSpellEffectTemplate
+{
+    public static void RegisterFactory()
+    {
+        SpellEffectFactory.RegisterLoadTimeFactory("pacifism", (root, spell) => new PacifismSpellEffect(root, spell));
+        SpellEffectFactory.RegisterBuilderFactory("pacifism", BuilderFactory,
+            "Induces a magical pacifism in the target",
+            HelpText,
+            false,
+            true,
+            SpellTriggerFactory.MagicTriggerTypes.Where(x => IsCompatibleWithTrigger(SpellTriggerFactory.BuilderInfoForType(x).TargetTypes)).ToArray());
+    }
+
+    private static (IMagicSpellEffectTemplate Trigger, string Error) BuilderFactory(StringStack commands, IMagicSpell spell)
+    {
+        return (new PacifismSpellEffect(new XElement("Effect",
+                        new XAttribute("type", "pacifism"),
+                        new XElement("Intensity", 1.0)
+                    ), spell), string.Empty);
+    }
+
+    protected PacifismSpellEffect(XElement root, IMagicSpell spell)
+    {
+        Spell = spell;
+        Intensity = double.Parse(root.Element("Intensity")?.Value ?? "1.0");
+    }
+
+    public IMagicSpell Spell { get; }
+    public double Intensity { get; set; }
+    public IFuturemud Gameworld => Spell.Gameworld;
+
+    public XElement SaveToXml()
+    {
+        return new XElement("Effect",
+            new XAttribute("type", "pacifism"),
+            new XElement("Intensity", Intensity)
+        );
+    }
+
+    public const string HelpText = @"You can use the following options with this effect:
+    #3intensity <##>#0 - sets the pacifism intensity";
+
+    public bool BuildingCommand(ICharacter actor, StringStack command)
+    {
+        switch (command.PopSpeech().ToLowerInvariant())
+        {
+            case "intensity":
+                return BuildingCommandIntensity(actor, command);
+        }
+
+        actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
+        return false;
+    }
+
+    private bool BuildingCommandIntensity(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished || !double.TryParse(command.SafeRemainingArgument, out var value))
+        {
+            actor.OutputHandler.Send("You must enter a valid intensity.");
+            return false;
+        }
+        Intensity = value;
+        Spell.Changed = true;
+        actor.OutputHandler.Send($"The pacifism intensity is now {Intensity.ToString("N2", actor).ColourValue()}.");
+        return true;
+    }
+
+    public string Show(ICharacter actor)
+    {
+        return $"Pacifism - {Intensity.ToString("N2", actor)}";
+    }
+
+    public bool IsInstantaneous => false;
+    public bool RequiresTarget => true;
+
+    public bool IsCompatibleWithTrigger(IMagicTrigger types) => IsCompatibleWithTrigger(types.TargetTypes);
+    public static bool IsCompatibleWithTrigger(string types)
+    {
+        switch (types)
+        {
+            case "character":
+            case "characters":
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public IMagicSpellEffect GetOrApplyEffect(ICharacter caster, IPerceivable target, OpposedOutcomeDegree outcome, SpellPower power, IMagicSpellEffectParent parent, SpellAdditionalParameter[] additionalParameters)
+    {
+        if (target is not ICharacter ch)
+        {
+            return null;
+        }
+
+        return new SpellPacifismEffect(ch, parent, null, Intensity);
+    }
+
+    public IMagicSpellEffectTemplate Clone() => new PacifismSpellEffect(SaveToXml(), Spell);
+}

--- a/MudSharpCore/Magic/SpellEffects/RageSpellEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/RageSpellEffect.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Xml.Linq;
+using System.Linq;
+using MudSharp.Character;
+using MudSharp.Effects.Concrete.SpellEffects;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.RPG.Checks;
+
+namespace MudSharp.Magic.SpellEffects;
+
+public class RageSpellEffect : IMagicSpellEffectTemplate
+{
+    public static void RegisterFactory()
+    {
+        SpellEffectFactory.RegisterLoadTimeFactory("rage", (root, spell) => new RageSpellEffect(root, spell));
+        SpellEffectFactory.RegisterBuilderFactory("rage", BuilderFactory,
+            "Inflames the target with supernatural rage",
+            HelpText,
+            false,
+            true,
+            SpellTriggerFactory.MagicTriggerTypes.Where(x => IsCompatibleWithTrigger(SpellTriggerFactory.BuilderInfoForType(x).TargetTypes)).ToArray());
+    }
+
+    private static (IMagicSpellEffectTemplate Trigger, string Error) BuilderFactory(StringStack commands, IMagicSpell spell)
+    {
+        return (new RageSpellEffect(new XElement("Effect",
+                        new XAttribute("type", "rage"),
+                        new XElement("Intensity", 1.0)
+                    ), spell), string.Empty);
+    }
+
+    protected RageSpellEffect(XElement root, IMagicSpell spell)
+    {
+        Spell = spell;
+        Intensity = double.Parse(root.Element("Intensity")?.Value ?? "1.0");
+    }
+
+    public IMagicSpell Spell { get; }
+    public double Intensity { get; set; }
+    public IFuturemud Gameworld => Spell.Gameworld;
+
+    public XElement SaveToXml()
+    {
+        return new XElement("Effect",
+            new XAttribute("type", "rage"),
+            new XElement("Intensity", Intensity)
+        );
+    }
+
+    public const string HelpText = @"You can use the following options with this effect:
+    #3intensity <##>#0 - sets the rage intensity";
+
+    public bool BuildingCommand(ICharacter actor, StringStack command)
+    {
+        switch (command.PopSpeech().ToLowerInvariant())
+        {
+            case "intensity":
+                return BuildingCommandIntensity(actor, command);
+        }
+
+        actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
+        return false;
+    }
+
+    private bool BuildingCommandIntensity(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished || !double.TryParse(command.SafeRemainingArgument, out var value))
+        {
+            actor.OutputHandler.Send("You must enter a valid intensity.");
+            return false;
+        }
+        Intensity = value;
+        Spell.Changed = true;
+        actor.OutputHandler.Send($"The rage intensity is now {Intensity.ToString("N2", actor).ColourValue()}.");
+        return true;
+    }
+
+    public string Show(ICharacter actor)
+    {
+        return $"Rage - {Intensity.ToString("N2", actor)}";
+    }
+
+    public bool IsInstantaneous => false;
+    public bool RequiresTarget => true;
+
+    public bool IsCompatibleWithTrigger(IMagicTrigger types) => IsCompatibleWithTrigger(types.TargetTypes);
+    public static bool IsCompatibleWithTrigger(string types)
+    {
+        switch (types)
+        {
+            case "character":
+            case "characters":
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public IMagicSpellEffect GetOrApplyEffect(ICharacter caster, IPerceivable target, OpposedOutcomeDegree outcome, SpellPower power, IMagicSpellEffectParent parent, SpellAdditionalParameter[] additionalParameters)
+    {
+        if (target is not ICharacter ch)
+        {
+            return null;
+        }
+
+        return new SpellRageEffect(ch, parent, null, Intensity);
+    }
+
+    public IMagicSpellEffectTemplate Clone() => new RageSpellEffect(SaveToXml(), Spell);
+}

--- a/MudSharpCore/Magic/SpellEffects/TelepathySpellEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/TelepathySpellEffect.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Xml.Linq;
+using System.Linq;
+using MudSharp.Character;
+using MudSharp.Effects.Concrete.SpellEffects;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.RPG.Checks;
+
+namespace MudSharp.Magic.SpellEffects;
+
+public class TelepathySpellEffect : IMagicSpellEffectTemplate
+{
+    public static void RegisterFactory()
+    {
+        SpellEffectFactory.RegisterLoadTimeFactory("telepathy", (root, spell) => new TelepathySpellEffect(root, spell));
+        SpellEffectFactory.RegisterBuilderFactory("telepathy", BuilderFactory,
+            "Lets the caster hear the target's thoughts or feelings",
+            HelpText,
+            false,
+            true,
+            SpellTriggerFactory.MagicTriggerTypes.Where(x => IsCompatibleWithTrigger(SpellTriggerFactory.BuilderInfoForType(x).TargetTypes)).ToArray());
+    }
+
+    private static (IMagicSpellEffectTemplate Trigger, string Error) BuilderFactory(StringStack commands, IMagicSpell spell)
+    {
+        return (new TelepathySpellEffect(new XElement("Effect",
+                        new XAttribute("type", "telepathy"),
+                        new XElement("Thinks", true),
+                        new XElement("Feels", true),
+                        new XElement("Emote", true)
+                    ), spell), string.Empty);
+    }
+
+    protected TelepathySpellEffect(XElement root, IMagicSpell spell)
+    {
+        Spell = spell;
+        ShowThinks = bool.Parse(root.Element("Thinks")?.Value ?? "true");
+        ShowFeels = bool.Parse(root.Element("Feels")?.Value ?? "true");
+        ShowEmote = bool.Parse(root.Element("Emote")?.Value ?? "true");
+    }
+
+    public IMagicSpell Spell { get; }
+    public bool ShowThinks { get; set; }
+    public bool ShowFeels { get; set; }
+    public bool ShowEmote { get; set; }
+    public IFuturemud Gameworld => Spell.Gameworld;
+
+    public XElement SaveToXml()
+    {
+        return new XElement("Effect",
+            new XAttribute("type", "telepathy"),
+            new XElement("Thinks", ShowThinks),
+            new XElement("Feels", ShowFeels),
+            new XElement("Emote", ShowEmote)
+        );
+    }
+
+    public const string HelpText = @"You can use the following options with this effect:
+    #3thinks#0 - toggles showing target thoughts
+    #3feels#0 - toggles showing target feelings
+    #3emote#0 - toggles showing think emotes";
+
+    public bool BuildingCommand(ICharacter actor, StringStack command)
+    {
+        switch (command.PopSpeech().ToLowerInvariant())
+        {
+            case "thinks":
+                ShowThinks = !ShowThinks;
+                Spell.Changed = true;
+                actor.OutputHandler.Send($"This spell will {(ShowThinks ? "now" : "no longer")} transmit thoughts.");
+                return true;
+            case "feels":
+                ShowFeels = !ShowFeels;
+                Spell.Changed = true;
+                actor.OutputHandler.Send($"This spell will {(ShowFeels ? "now" : "no longer")} transmit feelings.");
+                return true;
+            case "emote":
+                ShowEmote = !ShowEmote;
+                Spell.Changed = true;
+                actor.OutputHandler.Send($"This spell will {(ShowEmote ? "now" : "no longer")} show think emotes.");
+                return true;
+        }
+
+        actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
+        return false;
+    }
+
+    public string Show(ICharacter actor)
+    {
+        return $"Telepathy {(ShowThinks ? "[Thinks]" : "")} {(ShowFeels ? "[Feels]" : "")} {(ShowEmote ? "[Emote]" : "")}";
+    }
+
+    public bool IsInstantaneous => false;
+    public bool RequiresTarget => true;
+
+    public bool IsCompatibleWithTrigger(IMagicTrigger types) => IsCompatibleWithTrigger(types.TargetTypes);
+    public static bool IsCompatibleWithTrigger(string types)
+    {
+        switch (types)
+        {
+            case "character":
+            case "characters":
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public IMagicSpellEffect GetOrApplyEffect(ICharacter caster, IPerceivable target, OpposedOutcomeDegree outcome, SpellPower power, IMagicSpellEffectParent parent, SpellAdditionalParameter[] additionalParameters)
+    {
+        if (target is not ICharacter ch)
+        {
+            return null;
+        }
+
+        return new SpellTelepathyEffect(ch, parent, null, ShowThinks, ShowFeels, ShowEmote);
+    }
+
+    public IMagicSpellEffectTemplate Clone() => new TelepathySpellEffect(SaveToXml(), Spell);
+}

--- a/MudSharpCore/Magic/SpellEffects/WeightSpellEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/WeightSpellEffect.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Xml.Linq;
+using System.Linq;
+using MudSharp.Character;
+using MudSharp.Effects.Concrete.SpellEffects;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.Framework.Units;
+using MudSharp.RPG.Checks;
+
+namespace MudSharp.Magic.SpellEffects;
+
+public class WeightSpellEffect : IMagicSpellEffectTemplate
+{
+    public static void RegisterFactory()
+    {
+        SpellEffectFactory.RegisterLoadTimeFactory("weight", (root, spell) => new WeightSpellEffect(root, spell));
+        SpellEffectFactory.RegisterBuilderFactory("weight", BuilderFactory,
+            "Adds extra weight to the target",
+            HelpText,
+            false,
+            true,
+            SpellTriggerFactory.MagicTriggerTypes.Where(x => IsCompatibleWithTrigger(SpellTriggerFactory.BuilderInfoForType(x).TargetTypes)).ToArray());
+    }
+
+    private static (IMagicSpellEffectTemplate Trigger, string Error) BuilderFactory(StringStack commands, IMagicSpell spell)
+    {
+        return (new WeightSpellEffect(new XElement("Effect",
+                        new XAttribute("type", "weight"),
+                        new XElement("Weight", 1.0 / spell.Gameworld.UnitManager.BaseWeightToKilograms)
+                    ), spell), string.Empty);
+    }
+
+    protected WeightSpellEffect(XElement root, IMagicSpell spell)
+    {
+        Spell = spell;
+        AddedWeight = double.Parse(root.Element("Weight")?.Value ?? "1.0");
+    }
+
+    public IMagicSpell Spell { get; }
+    public double AddedWeight { get; set; }
+    public IFuturemud Gameworld => Spell.Gameworld;
+
+    public XElement SaveToXml()
+    {
+        return new XElement("Effect",
+            new XAttribute("type", "weight"),
+            new XElement("Weight", AddedWeight)
+        );
+    }
+
+    public const string HelpText = @"You can use the following options with this effect:
+    #3weight <##>#0 - sets the weight added";
+
+    public bool BuildingCommand(ICharacter actor, StringStack command)
+    {
+        switch (command.PopSpeech().ToLowerInvariant())
+        {
+            case "weight":
+                return BuildingCommandWeight(actor, command);
+        }
+
+        actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
+        return false;
+    }
+
+    private bool BuildingCommandWeight(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished ||
+            !Gameworld.UnitManager.TryGetBaseUnits(command.SafeRemainingArgument, UnitType.Mass, actor, out var value))
+        {
+            actor.OutputHandler.Send("You must enter a valid weight.");
+            return false;
+        }
+
+        AddedWeight = value;
+        Spell.Changed = true;
+        actor.OutputHandler.Send($"The added weight is now {Gameworld.UnitManager.DescribeExact(AddedWeight, UnitType.Mass, actor).ColourValue()}.");
+        return true;
+    }
+
+    public string Show(ICharacter actor)
+    {
+        return $"Weight +{Gameworld.UnitManager.DescribeExact(AddedWeight, UnitType.Mass, actor)}";
+    }
+
+    public bool IsInstantaneous => false;
+    public bool RequiresTarget => true;
+
+    public bool IsCompatibleWithTrigger(IMagicTrigger types) => IsCompatibleWithTrigger(types.TargetTypes);
+    public static bool IsCompatibleWithTrigger(string types)
+    {
+        switch (types)
+        {
+            case "item":
+            case "items":
+            case "character":
+            case "characters":
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public IMagicSpellEffect GetOrApplyEffect(ICharacter caster, IPerceivable target, OpposedOutcomeDegree outcome, SpellPower power, IMagicSpellEffectParent parent, SpellAdditionalParameter[] additionalParameters)
+    {
+        if (target is not IPerceivable p)
+        {
+            return null;
+        }
+        return new SpellWeightEffect(p, parent, null, AddedWeight);
+    }
+
+    public IMagicSpellEffectTemplate Clone() => new WeightSpellEffect(SaveToXml(), Spell);
+}


### PR DESCRIPTION
## Summary
- parse weight input using `UnitManager`
- store added weight in base units
- show effect weight using player's units

## Testing
- `dotnet build MudSharpCore/MudSharpCore.csproj -nologo`

------
https://chatgpt.com/codex/tasks/task_e_6858fb62808c83238d72036ed64c3a53