### PR TITLE
Fix flare components not resuming heartbeat on login

### DIFF
--- a/MudSharpCore/GameItems/Components/FlareGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/FlareGameItemComponent.cs
@@ -176,11 +176,20 @@ public class FlareGameItemComponent : GameItemComponent, ILightable, IProduceLig
 				.ToString();
 	}
 
-	protected void LoadFromXml(XElement root)
-	{
-		RemainingFuel = int.Parse(root.Element("RemainingFuel").Value);
-		Lit = bool.Parse(root.Element("Lit").Value);
-	}
+        protected void LoadFromXml(XElement root)
+        {
+                RemainingFuel = int.Parse(root.Element("RemainingFuel").Value);
+                _lit = bool.Parse(root.Element("Lit").Value);
+        }
+
+        public override void Login()
+        {
+                base.Login();
+                if (Lit)
+                {
+                        Gameworld.HeartbeatManager.SecondHeartbeat += HeartbeatManager_SecondHeartbeat;
+                }
+        }
 
 	#endregion
 

--- a/MudSharpCore/GameItems/Components/FuseGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/FuseGameItemComponent.cs
@@ -49,11 +49,20 @@ public class FuseGameItemComponent : GameItemComponent, ILightable
 		_prototype = rhs._prototype;
 	}
 
-	protected void LoadFromXml(XElement root)
-	{
-		BurnTimeRemaining = TimeSpan.FromSeconds(double.Parse(root.Element("BurnTimeRemaining").Value));
-		Lit = bool.Parse(root.Element("Lit").Value);
-	}
+       protected void LoadFromXml(XElement root)
+       {
+               BurnTimeRemaining = TimeSpan.FromSeconds(double.Parse(root.Element("BurnTimeRemaining").Value));
+               _lit = bool.Parse(root.Element("Lit").Value);
+       }
+
+       public override void Login()
+       {
+               base.Login();
+               if (Lit)
+               {
+                       Gameworld.HeartbeatManager.SecondHeartbeat += HeartbeatManager_SecondHeartbeat;
+               }
+       }
 
 	public override IGameItemComponent Copy(IGameItem newParent, bool temporary = false)
 	{

--- a/MudSharpCore/GameItems/Components/SmokeableGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/SmokeableGameItemComponent.cs
@@ -233,11 +233,20 @@ public class SmokeableGameItemComponent : GameItemComponent, ISmokeable
 				.ToString();
 	}
 
-	protected void LoadFromXml(XElement root)
-	{
-		RemainingFuel = int.Parse(root.Element("RemainingFuel")?.Value ?? "0");
-		Lit = bool.Parse(root.Element("Lit")?.Value ?? "false");
-	}
+        protected void LoadFromXml(XElement root)
+        {
+                RemainingFuel = int.Parse(root.Element("RemainingFuel")?.Value ?? "0");
+                _lit = bool.Parse(root.Element("Lit")?.Value ?? "false");
+        }
+
+        public override void Login()
+        {
+                base.Login();
+                if (Lit)
+                {
+                        Gameworld.HeartbeatManager.SecondHeartbeat += HeartbeatManager_SecondHeartbeat;
+                }
+        }
 
 	#endregion
 


### PR DESCRIPTION
## Summary
- fix flare component to subscribe to heartbeat on login
- avoid subscribing during load
- handle Fuse and Smokeable components to log in/out correctly

## Testing
- `dotnet build MudSharp.sln` *(fails: NETSDK1100)*

------
https://chatgpt.com/codex/tasks/task_e_685a2b85a3c08323b67470af0a711baf