### PR TITLE
Add moon echo tests

### DIFF
--- a/DatabaseSeeder/Seeders/CelestialSeeder.cs
+++ b/DatabaseSeeder/Seeders/CelestialSeeder.cs
@@ -236,10 +236,14 @@ What epoch date do you want to use?", (context, answers) => answers["installsun"
 		<SiderealTimePerDay>6.300388</SiderealTimePerDay>
 		<EpochDate>{epoch}</EpochDate>
 	</Orbital>
-	<Illumination>
-		<PeakIllumination>1.0</PeakIllumination>
-		<FullMoonReferenceDay>0</FullMoonReferenceDay>
-	</Illumination>
+        <Illumination>
+                <PeakIllumination>1.0</PeakIllumination>
+                <FullMoonReferenceDay>0</FullMoonReferenceDay>
+        </Illumination>
+        <Triggers>
+          <Trigger angle="-0.015184" direction="Ascending"><![CDATA[The moon rises above the horizon.]]></Trigger>
+          <Trigger angle="-0.015184" direction="Descending"><![CDATA[The moon sets on the horizon.]]></Trigger>
+        </Triggers>
 </PlanetaryMoon>"
 		});
 	}

--- a/MudSharpCore Unit Tests/PlanetaryMoonTests.cs
+++ b/MudSharpCore Unit Tests/PlanetaryMoonTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using MudSharp.Celestial;
@@ -258,8 +259,8 @@ public class PlanetaryMoonTests
 	}
 
 	[TestMethod]
-	public void TestMoonPhaseCycle()
-	{
+        public void TestMoonPhaseCycle()
+        {
 		_calendar.SetDate("1/dec/1999");
 		var sb = new StringBuilder();
 		for (var i = 0; i < 100; i++)
@@ -281,7 +282,24 @@ public class PlanetaryMoonTests
 		TryTest("21/jan/2000", MoonPhase.Full);
 		TryTest("4/jan/2000", MoonPhase.WaningCrescent);
 		TryTest("7/jan/2000", MoonPhase.New);
-		TryTest("15/jan/2000", MoonPhase.FirstQuarter);
-		TryTest("17/jan/2000", MoonPhase.WaxingGibbous);
-	}
+                TryTest("15/jan/2000", MoonPhase.FirstQuarter);
+                TryTest("17/jan/2000", MoonPhase.WaxingGibbous);
+        }
+
+        [TestMethod]
+        public void TestTriggerEchoSelection()
+        {
+                _moon.Triggers.Clear();
+                _moon.Triggers.Add(new CelestialTrigger(-0.015184, CelestialMoveDirection.Ascending, "rise"));
+                _moon.Triggers.Add(new CelestialTrigger(-0.015184, CelestialMoveDirection.Descending, "set"));
+
+                var oldStatus = new CelestialInformation(_moon, 0.0, -0.03, CelestialMoveDirection.Ascending);
+                var newStatus = new CelestialInformation(_moon, 0.0, 0.0, CelestialMoveDirection.Ascending);
+
+                Assert.IsTrue(_moon.ShouldEcho(oldStatus, newStatus));
+
+                var method = typeof(PlanetaryMoon).GetMethod("GetZoneDisplayTrigger", BindingFlags.NonPublic | BindingFlags.Instance);
+                var trigger = (CelestialTrigger)method.Invoke(_moon, new object[] { oldStatus, newStatus });
+                Assert.AreEqual("rise", trigger.Echo);
+        }
 }

--- a/MudSharpCore/Celestial/PlanetaryMoon.cs
+++ b/MudSharpCore/Celestial/PlanetaryMoon.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
 using MudSharp.Construction;
 using MudSharp.Effects;
 using MudSharp.Framework;
@@ -33,15 +36,84 @@ public class PlanetaryMoon : PerceivedItem, ICelestialObject
 	public double SiderealTimeAtEpoch { get; init; }
 	public double SiderealTimePerDay { get; init; }
 
-	public double PeakIllumination { get; init; }
-	public double FullMoonReferenceDay { get; init; }
+        public double PeakIllumination { get; init; }
+        public double FullMoonReferenceDay { get; init; }
 
-	public PlanetaryMoon(ICalendar calendar, IClock clock)
-	{
-		Calendar = calendar;
-		Clock = clock;
-		Clock.MinutesUpdated += AddMinutes;
-	}
+        public List<CelestialTrigger> Triggers { get; } = new();
+        protected readonly CircularRange<string> AzimuthDescriptions = new();
+        protected readonly CircularRange<string> ElevationDescriptions = new();
+
+        private void LoadFromXml(XElement root)
+        {
+                var element = root.Element("Illumination");
+                if (element != null)
+                {
+                        PeakIllumination = element.Element("PeakIllumination")?.Value.GetDouble() ?? 0;
+                        FullMoonReferenceDay = element.Element("FullMoonReferenceDay")?.Value.GetDouble() ?? 0;
+                }
+
+                element = root.Element("Calendar");
+                Calendar = Gameworld.Calendars.Get(long.Parse(element.Value));
+
+                element = root.Element("Orbital");
+                CelestialDaysPerYear = element.Element("CelestialDaysPerYear")?.Value.GetDouble() ?? 0;
+                MeanAnomalyAngleAtEpoch = element.Element("MeanAnomalyAngleAtEpoch")?.Value.GetDouble() ?? 0;
+                AnomalyChangeAnglePerDay = element.Element("AnomalyChangeAnglePerDay")?.Value.GetDouble() ?? 0;
+                ArgumentOfPeriapsis = element.Element("ArgumentOfPeriapsis")?.Value.GetDouble() ?? 0;
+                LongitudeOfAscendingNode = element.Element("LongitudeOfAscendingNode")?.Value.GetDouble() ?? 0;
+                OrbitalInclination = element.Element("OrbitalInclination")?.Value.GetDouble() ?? 0;
+                OrbitalEccentricity = element.Element("OrbitalEccentricity")?.Value.GetDouble() ?? 0;
+                DayNumberAtEpoch = element.Element("DayNumberAtEpoch")?.Value.GetDouble() ?? 0;
+                SiderealTimeAtEpoch = element.Element("SiderealTimeAtEpoch")?.Value.GetDouble() ?? 0;
+                SiderealTimePerDay = element.Element("SiderealTimePerDay")?.Value.GetDouble() ?? 0;
+                EpochDate = Calendar.GetDate(element.Element("EpochDate").Value);
+
+                element = root.Element("Triggers");
+                if (element != null)
+                {
+                        foreach (var sub in element.Elements("Trigger"))
+                        {
+                                Triggers.Add(
+                                        new CelestialTrigger(
+                                                sub.Attribute("angle").Value.GetDouble() ?? 0,
+                                                sub.Attribute("direction").Value == "Ascending"
+                                                        ? CelestialMoveDirection.Ascending
+                                                        : CelestialMoveDirection.Descending,
+                                                sub.Value));
+                        }
+                }
+
+                element = root.Element("Name");
+                if (element != null)
+                {
+                        _name = element.Value;
+                }
+        }
+
+        public PlanetaryMoon(ICalendar calendar, IClock clock)
+        {
+                Calendar = calendar;
+                Clock = clock;
+                Clock.MinutesUpdated += AddMinutes;
+        }
+
+        public PlanetaryMoon(XElement root, IClock clock, IFuturemud game)
+        {
+                Gameworld = game;
+                Clock = clock;
+                Clock.MinutesUpdated += AddMinutes;
+                LoadFromXml(root);
+        }
+
+        public PlanetaryMoon(MudSharp.Models.Celestial celestial, IFuturemud game)
+        {
+                IdInitialised = true;
+                _id = celestial.Id;
+                Gameworld = game;
+                Clock = Gameworld.Clocks.Get(celestial.FeedClockId);
+                Clock.MinutesUpdated += AddMinutes;
+                LoadFromXml(XElement.Parse(celestial.Definition));
+        }
 
 	public override void Register(IOutputHandler handler)
 	{
@@ -77,10 +149,20 @@ public class PlanetaryMoon : PerceivedItem, ICelestialObject
 		// No internal state to track
 	}
 
-	public void AddMinutes()
-	{
-		MinuteUpdateEvent?.Invoke(this);
-	}
+        public void AddMinutes()
+        {
+                MinuteUpdateEvent?.Invoke(this);
+        }
+
+        private static readonly double OneMinuteTimeFraction = 1.0 / 1440.0;
+
+        protected CelestialMoveDirection CurrentDirection(GeographicCoordinate geography)
+        {
+                var dn = CurrentDayNumber;
+                var current = ElevationAngle(dn, geography);
+                var former = ElevationAngle(dn - OneMinuteTimeFraction, geography);
+                return current >= former ? CelestialMoveDirection.Ascending : CelestialMoveDirection.Descending;
+        }
 
 	private double MeanAnomaly(double dayNumber)
 	{
@@ -123,23 +205,32 @@ public class PlanetaryMoon : PerceivedItem, ICelestialObject
 		return SiderealTime(dayNumber, coordinate) - rightAscension;
 	}
 
-	public double CurrentElevationAngle(GeographicCoordinate geography)
-	{
-		var day = CurrentDayNumber;
-		var (ra, dec) = EquatorialCoordinates(day);
-		var ha = HourAngle(day, geography, ra);
-		return Math.Asin(Math.Sin(geography.Latitude) * Math.Sin(dec) +
-						 Math.Cos(geography.Latitude) * Math.Cos(dec) * Math.Cos(ha));
-	}
+        private double ElevationAngle(double dayNumber, GeographicCoordinate geography)
+        {
+                var (ra, dec) = EquatorialCoordinates(dayNumber);
+                var ha = HourAngle(dayNumber, geography, ra);
+                return Math.Asin(Math.Sin(geography.Latitude) * Math.Sin(dec) +
+                                 Math.Cos(geography.Latitude) * Math.Cos(dec) * Math.Cos(ha));
+        }
 
-	public double CurrentAzimuthAngle(GeographicCoordinate geography, double elevationAngle)
-	{
-		var day = CurrentDayNumber;
-		var (ra, dec) = EquatorialCoordinates(day);
-		var ha = HourAngle(day, geography, ra);
-		return Math.Atan2(Math.Sin(ha), Math.Cos(ha) * Math.Sin(geography.Latitude) -
-										Math.Tan(dec) * Math.Cos(geography.Latitude));
-	}
+        private double AzimuthAngle(double dayNumber, GeographicCoordinate geography)
+        {
+                var (ra, dec) = EquatorialCoordinates(dayNumber);
+                var ha = HourAngle(dayNumber, geography, ra);
+                return Math.Atan2(Math.Sin(ha),
+                                   Math.Cos(ha) * Math.Sin(geography.Latitude) -
+                                   Math.Tan(dec) * Math.Cos(geography.Latitude));
+        }
+
+        public double CurrentElevationAngle(GeographicCoordinate geography)
+        {
+                return ElevationAngle(CurrentDayNumber, geography);
+        }
+
+        public double CurrentAzimuthAngle(GeographicCoordinate geography, double elevationAngle)
+        {
+                return AzimuthAngle(CurrentDayNumber, geography);
+        }
 
 	public double CurrentIllumination(GeographicCoordinate geography)
 	{
@@ -148,19 +239,35 @@ public class PlanetaryMoon : PerceivedItem, ICelestialObject
 		return PeakIllumination * (1 + Math.Cos(phaseAngle)) / 2.0;
 	}
 
-	public CelestialInformation CurrentPosition(GeographicCoordinate geography)
-	{
-		var elevation = CurrentElevationAngle(geography);
-		var azimuth = CurrentAzimuthAngle(geography, elevation);
-		var direction = CelestialMoveDirection.Ascending; // Simplified
-		return new CelestialInformation(this, azimuth, elevation, direction);
-	}
+        public CelestialInformation CurrentPosition(GeographicCoordinate geography)
+        {
+                var elevation = CurrentElevationAngle(geography);
+                var azimuth = CurrentAzimuthAngle(geography, elevation);
+                return new CelestialInformation(this, azimuth, elevation, CurrentDirection(geography));
+        }
 
-	public CelestialInformation ReturnNewCelestialInformation(ILocation location,
-		CelestialInformation celestialStatus, GeographicCoordinate coordinate)
-	{
-		return CurrentPosition(coordinate);
-	}
+        public CelestialInformation ReturnNewCelestialInformation(ILocation location,
+                CelestialInformation celestialStatus, GeographicCoordinate coordinate)
+        {
+                var newStatus = CurrentPosition(coordinate);
+
+                if (celestialStatus == null)
+                {
+                        newStatus.Direction = CelestialMoveDirection.Ascending;
+                        return newStatus;
+                }
+
+                newStatus.Direction = celestialStatus.LastAscensionAngle > newStatus.LastAscensionAngle
+                        ? CelestialMoveDirection.Descending
+                        : CelestialMoveDirection.Ascending;
+
+                if (ShouldEcho(celestialStatus, newStatus))
+                {
+                        EchoTriggerToZone(GetZoneDisplayTrigger(celestialStatus, newStatus), location);
+                }
+
+                return newStatus;
+        }
 
 	public string Describe(CelestialInformation info)
 	{
@@ -181,9 +288,9 @@ public class PlanetaryMoon : PerceivedItem, ICelestialObject
 		return 2 * Math.PI * (cycleDay / CelestialDaysPerYear);
 	}
 
-	public MoonPhase CurrentPhase()
-	{
-		var frac = (CurrentCelestialDay - FullMoonReferenceDay).Modulus(CelestialDaysPerYear) / CelestialDaysPerYear;
+        public MoonPhase CurrentPhase()
+        {
+                var frac = (CurrentCelestialDay - FullMoonReferenceDay).Modulus(CelestialDaysPerYear) / CelestialDaysPerYear;
 
 		if (frac < 0.0625 || frac >= 0.9375) return MoonPhase.Full;
 		if (frac < 0.1875) return MoonPhase.WaxingGibbous;
@@ -191,8 +298,46 @@ public class PlanetaryMoon : PerceivedItem, ICelestialObject
 		if (frac < 0.4375) return MoonPhase.WaxingCrescent;
 		if (frac < 0.5625) return MoonPhase.New;
 		if (frac < 0.6875) return MoonPhase.WaningCrescent;
-		if (frac < 0.8125) return MoonPhase.LastQuarter;
-		return MoonPhase.WaningGibbous;
-	}
+                if (frac < 0.8125) return MoonPhase.LastQuarter;
+                return MoonPhase.WaningGibbous;
+        }
+
+        protected CelestialTrigger GetZoneDisplayTrigger(CelestialInformation oldStatus, CelestialInformation newStatus)
+        {
+                return
+                        Triggers.First(
+                                x =>
+                                        x.Threshold.Between(oldStatus.LastAscensionAngle, newStatus.LastAscensionAngle) &&
+                                        x.Direction == newStatus.Direction);
+        }
+
+        public bool ShouldEcho(CelestialInformation oldStatus, CelestialInformation newStatus)
+        {
+                return
+                        Triggers.Any(
+                                x =>
+                                        x.Threshold.Between(oldStatus.LastAscensionAngle, newStatus.LastAscensionAngle) &&
+                                        x.Direction == newStatus.Direction);
+        }
+
+        public void EchoTriggerToZone(CelestialTrigger trigger, ILocation location)
+        {
+                var echo = $"{trigger.Echo.Fullstop().SubstituteANSIColour().ProperSentences()}";
+                foreach (var ch in location.Characters)
+                {
+                        if (!ch.CanSee(this))
+                        {
+                                continue;
+                        }
+
+                        if (ch.Location.OutdoorsType(ch).In(CellOutdoorsType.Outdoors))
+                        {
+                                ch.OutputHandler.Send(echo);
+                                continue;
+                        }
+
+                        ch.OutputHandler.Send($"{"[Outside]".ColourValue()} {echo}");
+                }
+        }
 }
 


### PR DESCRIPTION
## Summary
- support echo triggers in `PlanetaryMoon`
- load moon data from XML/DB
- add default moonrise/moonset triggers in seeder
- test trigger selection logic for moons

## Testing
- `dotnet test --no-build` *(fails: Microsoft.Portable.CSharp.targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ea480d2d08323b91d4fab77a09b56