### PR TITLE
Add build scripts for Codex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Instructions for Codex
+
+To compile the project locally or in automated checks:
+
+1. Run `scripts/setup.sh` once to install the .NET 9 SDK in `~/.dotnet`.
+2. Use `scripts/test.sh` to build the main engine project.
+
+`test.sh` sets `DOTNET_EnableWindowsTargeting` so the build succeeds on Linux.

--- a/MudSharpCore/Effects/Concrete/SpellEffects/SpellWeatherFreezeEffect.cs
+++ b/MudSharpCore/Effects/Concrete/SpellEffects/SpellWeatherFreezeEffect.cs
@@ -2,6 +2,7 @@ using System.Xml.Linq;
 using MudSharp.Climate;
 using MudSharp.Framework;
 using MudSharp.FutureProg;
+using MudSharp.Effects.Interfaces;
 
 namespace MudSharp.Effects.Concrete.SpellEffects;
 

--- a/MudSharpCore/Magic/SpellEffects/DamageEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/DamageEffect.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Xml.Linq;
 using MudSharp.Body.Traits;
+using MudSharp.Body;
 using MudSharp.Character;
 using MudSharp.Effects.Interfaces;
 using MudSharp.Framework;

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+curl -sSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh
+bash /tmp/dotnet-install.sh --channel 9.0 --install-dir "$HOME/.dotnet"
+if ! grep -q "DOTNET_ROOT" ~/.bashrc; then
+  echo 'export DOTNET_ROOT=$HOME/.dotnet' >> ~/.bashrc
+  echo 'export PATH=$HOME/.dotnet:$PATH' >> ~/.bashrc
+fi
+export DOTNET_ROOT=$HOME/.dotnet
+export PATH=$HOME/.dotnet:$PATH

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+export DOTNET_ROOT=$HOME/.dotnet
+export PATH=$HOME/.dotnet:$PATH
+export DOTNET_EnableWindowsTargeting=true
+ dotnet build MudSharpCore/MudSharpCore.csproj -c Release -p:EnableWindowsTargeting=true


### PR DESCRIPTION
## Summary
- add Codex instructions for setting up .NET
- add setup/test scripts to install .NET 9 and build
- fix missing using directives

## Testing
- `./scripts/setup.sh`
- `./scripts/test.sh` *(fails: PlanetaryMoon.SiderealTimePerDay init-only property error and other compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_6860e77d8248832393c0017196da4fcd