### PR TITLE
Implement small missing features

### DIFF
--- a/FutureMUDLibrary/Framework/RangeDictionary.cs
+++ b/FutureMUDLibrary/Framework/RangeDictionary.cs
@@ -119,7 +119,25 @@ namespace MudSharp.Framework
 
         public void CopyTo(KeyValuePair<ValueRange, T>[] array, int arrayIndex)
         {
-            throw new NotImplementedException("What is this actually supposed to do?");
+            if (array == null)
+            {
+                throw new ArgumentNullException(nameof(array));
+            }
+
+            if (arrayIndex < 0 || arrayIndex > array.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+            }
+
+            if (array.Length - arrayIndex < _ranges.Length)
+            {
+                throw new ArgumentException("The destination array is too small.", nameof(array));
+            }
+
+            for (var i = 0; i < _ranges.Length; i++)
+            {
+                array[arrayIndex + i] = new KeyValuePair<ValueRange, T>(_ranges[i], _values[i]);
+            }
         }
 
         public bool Remove(KeyValuePair<ValueRange, T> item)

--- a/Futuremud Configuration Tool/Converters/TraitToIdConverter.cs
+++ b/Futuremud Configuration Tool/Converters/TraitToIdConverter.cs
@@ -10,11 +10,19 @@ namespace Futuremud_Configuration_Tool.Converters {
         #region IValueConverter Members
 
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture) {
-            throw new NotImplementedException();
+            if (value == null) {
+                return null;
+            }
+            using (new FMDB()) {
+                return FMDB.Context.Traits.Find((int)value);
+            }
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture) {
-            throw new NotImplementedException();
+            if (value == null) {
+                return null;
+            }
+            return ((FME.Trait)value).Id;
         }
 
         #endregion

--- a/Futuremud Configuration Tool/UI/RegexValidator.cs
+++ b/Futuremud Configuration Tool/UI/RegexValidator.cs
@@ -47,7 +47,7 @@ namespace Futuremud_Configuration_Tool.UI {
 
         public object ConvertBack(object value, Type targetType, object parameter,
             CultureInfo culture) {
-            throw new NotImplementedException();
+            return Binding.DoNothing;
         }
 
         public ValidationErrorsToStringConverter() {

--- a/MudSharpCore/PerceptionEngine/Handlers/PerceptiveItemOutputHandler.cs
+++ b/MudSharpCore/PerceptionEngine/Handlers/PerceptiveItemOutputHandler.cs
@@ -2,46 +2,61 @@
 using MudSharp.Framework;
 using MudSharp.GameItems;
 using MudSharp.PerceptionEngine.Outputs;
+using MudSharp.PerceptionEngine;
 
 namespace MudSharp.PerceptionEngine.Handlers;
 
 public class PerceptiveItemOutputHandler : IOutputHandler
 {
-	public PerceptiveItemOutputHandler(IGameItem item)
-	{
-		//Perceiver = item;
-	}
+        private readonly IGameItem _item;
 
-	public IPerceiver Perceiver { get; protected set; }
+        public PerceptiveItemOutputHandler(IGameItem item)
+        {
+                _item = item;
+                Perceiver = item;
+        }
 
-	public bool HasBufferedOutput => throw new NotImplementedException();
+        public IPerceiver Perceiver { get; protected set; }
 
-	public string BufferedOutput => throw new NotImplementedException();
+        public bool HasBufferedOutput => false;
 
-	public bool Send(string text, bool newline = true, bool nopage = false)
-	{
-		throw new NotImplementedException();
-	}
+        public string BufferedOutput => null;
 
-	public bool Send(IOutput output, bool newline = true, bool nopage = false)
-	{
-		throw new NotImplementedException();
-	}
+        public bool Send(string text, bool newline = true, bool nopage = false)
+        {
+                if (QuietMode || string.IsNullOrEmpty(text))
+                {
+                        return false;
+                }
 
-	public bool SendPrompt()
-	{
-		throw new NotImplementedException();
-	}
+                this.Handle(text, OutputRange.Local);
+                return true;
+        }
 
-	public void Flush()
-	{
-		throw new NotImplementedException();
-	}
+        public bool Send(IOutput output, bool newline = true, bool nopage = false)
+        {
+                if (output == null)
+                {
+                        return false;
+                }
 
-	public bool Register(IPerceiver perceiver)
-	{
-		return false;
-	}
+                this.Handle(output, OutputRange.Local);
+                return true;
+        }
+
+        public bool SendPrompt()
+        {
+                return false;
+        }
+
+        public void Flush()
+        {
+        }
+
+        public bool Register(IPerceiver perceiver)
+        {
+                return false;
+        }
 
 	public bool QuietMode { get; set; }
 

--- a/MudSharpCore/PerceptionEngine/Outputs/LanguageOutput.cs
+++ b/MudSharpCore/PerceptionEngine/Outputs/LanguageOutput.cs
@@ -32,14 +32,23 @@ public class LanguageOutput : Output
 
 	public bool AllValid { get; protected set; }
 
-	public override string RawString => throw new NotImplementedException();
+        public override string RawString =>
+                ((_preLanguageEmote?.RawText ?? string.Empty) +
+                 (_optionalEmote != null && !string.IsNullOrWhiteSpace(_optionalEmote.RawText)
+                         ? ", " + _optionalEmote.RawText
+                         : string.Empty) +
+                 _languageText.RawText).Trim();
 
 	public override string ParseFor(IPerceiver perceiver)
 	{
-		if (perceiver is not ILanguagePerceiver langperceiver)
-		{
-			throw new NotImplementedException();
-		}
+                if (perceiver is not ILanguagePerceiver langperceiver)
+                {
+                        return ((_preLanguageEmote != null ? _preLanguageEmote.ParseFor(perceiver) : "") +
+                                (_optionalEmote != null && _optionalEmote.RawText.Length > 0
+                                        ? ", " + _optionalEmote.ParseFor(perceiver)
+                                        : "") +
+                                _languageText.RawText).Proper();
+                }
 
 		// TODO - how should perceivers without language see language output?
 		return
@@ -88,14 +97,31 @@ public class PriorLanguageOutput : Output
 
 	public bool AllValid { get; protected set; }
 
-	public override string RawString => throw new NotImplementedException();
+        public override string RawString =>
+                ((_optionalEmote != null && !string.IsNullOrWhiteSpace(_optionalEmote.RawText)
+                        ? _optionalEmote.RawText + ", "
+                        : string.Empty) +
+                 (_preLanguageEmote?.RawText ?? string.Empty) +
+                 _languageText.RawText).Trim();
 
 	public override string ParseFor(IPerceiver perceiver)
 	{
-		if (perceiver is not ILanguagePerceiver langperceiver)
-		{
-			throw new NotImplementedException();
-		}
+                if (perceiver is not ILanguagePerceiver langperceiver)
+                {
+                        var sb2 = new StringBuilder();
+                        if (!string.IsNullOrWhiteSpace(_optionalEmote?.RawText))
+                        {
+                                sb2.Append(_optionalEmote.ParseFor(perceiver) + ", ");
+                        }
+
+                        if (!string.IsNullOrWhiteSpace(_preLanguageEmote?.RawText))
+                        {
+                                sb2.Append(_preLanguageEmote.ParseFor(perceiver));
+                        }
+
+                        sb2.Append(_languageText.RawText);
+                        return sb2.ToString().ProperSentences();
+                }
 
 		// TODO - how should perceivers without language see language output?
 		var sb = new StringBuilder();


### PR DESCRIPTION
## Summary
- flesh out LanguageOutput and PriorLanguageOutput classes
- copy items out of `RangeDictionary`
- allow RegexValidator to support ConvertBack
- implement TraitToIdConverter
- implement basic PerceptiveItemOutputHandler

## Testing
- `dotnet build MudSharp.sln -c Release` *(fails: NETSDK1100 Windows targeting not enabled)*

------
https://chatgpt.com/codex/tasks/task_e_6860e7cd77d08323910c19a30df857e0