### PR TITLE
Fix watcher handling in room-range messages

### DIFF
--- a/MudSharpCore/PerceptionEngine/OutputExtensions.cs
+++ b/MudSharpCore/PerceptionEngine/OutputExtensions.cs
@@ -319,17 +319,22 @@ public static class OutputExtensions
 
 				break;
 
-			case OutputRange.Room:
-				foreach (var character in location?.Characters ?? Enumerable.Empty<ICharacter>())
-				{
-					character.OutputHandler?.Send(output, newline, nopage);
-				}
+                        case OutputRange.Room:
+                                foreach (var character in location?.Characters ?? Enumerable.Empty<ICharacter>())
+                                {
+                                        character.OutputHandler?.Send(output, newline, nopage);
+                                }
 
-				foreach (var cell in location?.Room.Cells ?? Enumerable.Empty<ICell>())
-				foreach (var effect in cell.EffectsOfType<IRemoteObservationEffect>().ToList())
-				{
-					effect.HandleOutput(output, cell);
-				}
+                                if (!output.Flags.HasFlag(OutputFlags.IgnoreWatchers))
+                                {
+                                        foreach (var cell in location?.Room.Cells ?? Enumerable.Empty<ICell>())
+                                        {
+                                                foreach (var effect in cell.EffectsOfType<IRemoteObservationEffect>().ToList())
+                                                {
+                                                        effect.HandleOutput(output, cell);
+                                                }
+                                        }
+                                }
 
 				break;
 


### PR DESCRIPTION
## Summary
- respect IgnoreWatchers flag for room-range output

## Testing
- `bash scripts/test.sh` *(fails: Build FAILED with 0 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686157b2d2bc83239697e9275ff7ed8a