### PR TITLE
Add comprehensive Utilities tests

### DIFF
--- a/MudSharpCore Unit Tests/UtilitiesTests.cs
+++ b/MudSharpCore Unit Tests/UtilitiesTests.cs
@@ -74,4 +74,71 @@ public class UtilitiesTests
         Assert.AreEqual("now", true.NowNoLonger());
         Assert.AreEqual("no longer", false.NowNoLonger());
     }
+
+    [Flags]
+    private enum FlagEnum
+    {
+        None = 0,
+        One = 1,
+        Two = 2,
+        Four = 4
+    }
+
+    private enum CamelCaseEnum
+    {
+        SomeValue
+    }
+
+    private class InfoAttribute : Attribute
+    {
+        public string Name { get; }
+        public InfoAttribute(string name) => Name = name;
+    }
+
+    private enum InfoEnum
+    {
+        [Info("Alpha")] Alpha,
+        Beta
+    }
+
+    [TestMethod]
+    public void In_ReturnsExpectedResults()
+    {
+        Assert.IsTrue(5.In(1, 3, 5));
+        Assert.IsFalse(4.In(1, 2, 3));
+
+        string value = null;
+        Assert.IsTrue(value.In(null, "other"));
+    }
+
+    [TestMethod]
+    public void AppendLineFormat_AppendsWithFormatProvider()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLineFormat("Hello {0}", "World");
+        Assert.AreEqual($"Hello World{Environment.NewLine}", sb.ToString());
+
+        sb.Clear();
+        sb.AppendLineFormat(new System.Globalization.CultureInfo("fr-FR"), "Value {0:N1}", 12.5);
+        Assert.AreEqual($"Value 12,5{Environment.NewLine}", sb.ToString());
+    }
+
+    [TestMethod]
+    public void DescribeEnum_FlagCombination()
+    {
+        var combined = FlagEnum.One | FlagEnum.Two;
+        Assert.AreEqual("One and Two", combined.DescribeEnum());
+
+        Assert.AreEqual("Some Value", CamelCaseEnum.SomeValue.DescribeEnum(true));
+    }
+
+    [TestMethod]
+    public void GetAttribute_ReturnsCustomAttribute()
+    {
+        var attr = InfoEnum.Alpha.GetAttribute<InfoAttribute>();
+        Assert.IsNotNull(attr);
+        Assert.AreEqual("Alpha", attr.Name);
+
+        Assert.IsNull(InfoEnum.Beta.GetAttribute<InfoAttribute>());
+    }
 }


### PR DESCRIPTION
## Summary
- expand `UtilitiesTests` with coverage for `In`, `DescribeEnum`, `GetAttribute`, and `AppendLineFormat`
- include new helper enums and attribute for testing

## Testing
- `./scripts/test.sh` *(fails: Build FAILED without errors)*

------
https://chatgpt.com/codex/tasks/task_e_6861e347227c8323ac99fd3867dd7415