### PR TITLE
Fix currency retrieval with exact amounts

### DIFF
--- a/MudSharpCore/Body/Implementations/BodyInventory.cs
+++ b/MudSharpCore/Body/Implementations/BodyInventory.cs
@@ -3548,7 +3548,7 @@ public partial class Body
                                            Tuple.Create(x, targetCoins.Sum(y => y.Value.Where(z => z.Key == x).Sum(z => z.Value)))),
                         true);
 
-                return CanGet(tempItem, container, 0, ItemCanGetIgnore.None);
+                return CanGet(tempItem, container, 0, ItemCanGetIgnore.IgnoreInContainer);
 	}
 
 	public string WhyCannotGet(ICurrency currency, decimal amount, bool exact)
@@ -3615,7 +3615,7 @@ public partial class Body
                                    .Select(x =>
                                            Tuple.Create(x, targetCoins.Sum(y => y.Value.Where(z => z.Key == x).Sum(z => z.Value)))),
                         true);
-                return WhyCannotGet(tempItem, container, 0, ItemCanGetIgnore.None);
+                return WhyCannotGet(tempItem, container, 0, ItemCanGetIgnore.IgnoreInContainer);
 	}
 
 	public void Get(ICurrency currency, IGameItem containerItem, decimal amount, bool exact, IEmote playerEmote = null,


### PR DESCRIPTION
## Summary
- ensure temporary currency piles ignore container presence checks when verifying retrieval

## Testing
- `scripts/test.sh` *(fails: Build FAILED with 0 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686332be11a48323b604f113a4532ae0