### PR TITLE
Add map + account/character lookup commands

### DIFF
--- a/DiscordBotCore/Modules/Help.cs
+++ b/DiscordBotCore/Modules/Help.cs
@@ -73,6 +73,9 @@ The following commands require you to be registered and authorised before using 
     **approvechargen <id> <message>** - approves a character application
     **rejectchargen <id> <message>** - rejects a character application
     **where** - shows the WHERE output from the MUD
+    **map <cell>** - shows the MAP output for a specific cell
+    **showaccount <name|id>** - shows an account's details
+    **showcharacter <id>** - shows a character's details
     **send <account> <message>** - sends a message to an account in-game, equivalent to SEND command
     **broadcast <message>** - broadcasts a system message (same as using BROADCAST in game)
     **shutdown** - shuts down the MUD

--- a/DiscordBotCore/Modules/Map.cs
+++ b/DiscordBotCore/Modules/Map.cs
@@ -1,0 +1,48 @@
+using System.Linq;
+using System.Threading.Tasks;
+using DSharpPlus.CommandsNext;
+using DSharpPlus.CommandsNext.Attributes;
+using DSharpPlus.Entities;
+
+namespace Discord_Bot.Modules;
+
+public class Map : BaseCommandModule
+{
+    [Command("map")]
+    public async Task MapAsync(CommandContext context, long cellId)
+    {
+        if (!DiscordBot.Instance.IsAuthorisedUser(context.User))
+        {
+            await context.RespondAsync($"You are not authorised to do that command, {context.User.Mention}.");
+            return;
+        }
+
+        var registration = DiscordBot.Instance.DetailedUserSettings.FirstOrDefault(x => x.DiscordUserId == context.User.Id);
+        if (registration is null)
+        {
+            await context.RespondAsync($"You have not yet linked your MUD account and discord account, which is a necessary prerequisite of this command.");
+            return;
+        }
+
+        if (!DiscordBot.Instance.TCPConnections.Any(x => x.TcpClientAuthenticated))
+        {
+            await context.RespondAsync($"{context.User.Mention} - I'm not currently connected to the MUD so I cannot do that for you.");
+            return;
+        }
+
+        await context.Message.CreateReactionAsync(DiscordEmoji.FromUnicode("👌"));
+        var request = new CachedDiscordRequest
+        {
+            Context = context,
+            OnResponseAction = HandleMudResponse
+        };
+        DiscordBot.Instance.CachedDiscordRequests[request.RequestId] = request;
+        DiscordBot.Instance.TCPConnections.First(x => x.TcpClientAuthenticated)
+            .SendTcpCommand($"map {request.RequestId} {registration.MudAccountId} {cellId}");
+    }
+
+    private async Task HandleMudResponse(string text, CommandContext context)
+    {
+        await context.RespondAsync($"{context.User.Mention}\n```{text}```");
+    }
+}

--- a/DiscordBotCore/Modules/ShowAccount.cs
+++ b/DiscordBotCore/Modules/ShowAccount.cs
@@ -1,0 +1,63 @@
+using System.Linq;
+using System.Threading.Tasks;
+using DSharpPlus.CommandsNext;
+using DSharpPlus.CommandsNext.Attributes;
+using DSharpPlus.Entities;
+using MudSharp.Framework;
+
+namespace Discord_Bot.Modules;
+
+public class ShowAccount : BaseCommandModule
+{
+    [Command("showaccount")]
+    public async Task ShowAccountAsync(CommandContext context, string which)
+    {
+        if (!DiscordBot.Instance.IsAuthorisedUser(context.User))
+        {
+            await context.RespondAsync($"You are not authorised to do that command, {context.User.Mention}.");
+            return;
+        }
+
+        var registration = DiscordBot.Instance.DetailedUserSettings.FirstOrDefault(x => x.DiscordUserId == context.User.Id);
+        if (registration is null)
+        {
+            await context.RespondAsync($"You have not yet linked your MUD account and discord account, which is a necessary prerequisite of this command.");
+            return;
+        }
+
+        if (!DiscordBot.Instance.TCPConnections.Any(x => x.TcpClientAuthenticated))
+        {
+            await context.RespondAsync($"{context.User.Mention} - I'm not currently connected to the MUD so I cannot do that for you.");
+            return;
+        }
+
+        await context.Message.CreateReactionAsync(DiscordEmoji.FromUnicode("👌"));
+        var request = new CachedDiscordRequest
+        {
+            Context = context,
+            OnResponseAction = HandleMudResponse
+        };
+        DiscordBot.Instance.CachedDiscordRequests[request.RequestId] = request;
+        DiscordBot.Instance.TCPConnections.First(x => x.TcpClientAuthenticated)
+            .SendTcpCommand($"showaccount {request.RequestId} {registration.MudAccountId} {which}");
+    }
+
+    private async Task HandleMudResponse(string text, CommandContext context)
+    {
+        var ss = new StringStack(text);
+        var type = ss.Pop();
+        switch (type)
+        {
+            case "nosuchaccount":
+                await context.RespondAsync($"{context.User.Mention} - There is no account with the name or id **{ss.RemainingArgument}**.");
+                return;
+            case "accountinfo":
+                var message = ss.RemainingArgument;
+                foreach (var part in message.SplitStringsForDiscord())
+                {
+                    await context.RespondAsync($"```{part}```");
+                }
+                return;
+        }
+    }
+}

--- a/DiscordBotCore/Modules/ShowCharacter.cs
+++ b/DiscordBotCore/Modules/ShowCharacter.cs
@@ -1,0 +1,63 @@
+using System.Linq;
+using System.Threading.Tasks;
+using DSharpPlus.CommandsNext;
+using DSharpPlus.CommandsNext.Attributes;
+using DSharpPlus.Entities;
+using MudSharp.Framework;
+
+namespace Discord_Bot.Modules;
+
+public class ShowCharacter : BaseCommandModule
+{
+    [Command("showcharacter")]
+    public async Task ShowCharacterAsync(CommandContext context, string which)
+    {
+        if (!DiscordBot.Instance.IsAuthorisedUser(context.User))
+        {
+            await context.RespondAsync($"You are not authorised to do that command, {context.User.Mention}.");
+            return;
+        }
+
+        var registration = DiscordBot.Instance.DetailedUserSettings.FirstOrDefault(x => x.DiscordUserId == context.User.Id);
+        if (registration is null)
+        {
+            await context.RespondAsync($"You have not yet linked your MUD account and discord account, which is a necessary prerequisite of this command.");
+            return;
+        }
+
+        if (!DiscordBot.Instance.TCPConnections.Any(x => x.TcpClientAuthenticated))
+        {
+            await context.RespondAsync($"{context.User.Mention} - I'm not currently connected to the MUD so I cannot do that for you.");
+            return;
+        }
+
+        await context.Message.CreateReactionAsync(DiscordEmoji.FromUnicode("👌"));
+        var request = new CachedDiscordRequest
+        {
+            Context = context,
+            OnResponseAction = HandleMudResponse
+        };
+        DiscordBot.Instance.CachedDiscordRequests[request.RequestId] = request;
+        DiscordBot.Instance.TCPConnections.First(x => x.TcpClientAuthenticated)
+            .SendTcpCommand($"showcharacter {request.RequestId} {registration.MudAccountId} {which}");
+    }
+
+    private async Task HandleMudResponse(string text, CommandContext context)
+    {
+        var ss = new StringStack(text);
+        var type = ss.Pop();
+        switch (type)
+        {
+            case "nosuchcharacter":
+                await context.RespondAsync($"{context.User.Mention} - There is no character with that ID.");
+                return;
+            case "characterinfo":
+                var message = ss.RemainingArgument;
+                foreach (var part in message.SplitStringsForDiscord())
+                {
+                    await context.RespondAsync($"```{part}```");
+                }
+                return;
+        }
+    }
+}

--- a/FutureMUDLibrary/Framework/StringUtilities.cs
+++ b/FutureMUDLibrary/Framework/StringUtilities.cs
@@ -402,7 +402,7 @@ namespace MudSharp.Framework
 			return text;
 		}
 
-		public static string DrawMap(ICharacter actor, int maxX, int maxY, ICell[,] cells, bool[,] hasNonCompass, bool[,] hasCartesianClashes, bool[,] hasBank, bool[,] hasShop, bool[,] hasAuctionHouse, bool[,] hasPlayers, bool[,] hasHostiles)
+                public static string DrawMap(IPerceiver actor, int maxX, int maxY, ICell[,] cells, bool[,] hasNonCompass, bool[,] hasCartesianClashes, bool[,] hasBank, bool[,] hasShop, bool[,] hasAuctionHouse, bool[,] hasPlayers, bool[,] hasHostiles)
 		{
 			var sb = new StringBuilder();
 			sb.AppendLine($"Map of the surrounds of {actor.Location.GetFriendlyReference(actor)}");


### PR DESCRIPTION
## Summary
- implement new Discord bot commands for map, showaccount and showcharacter
- expose helper `BuildAccountInfo` and use it for Show command
- integrate bot request handling on the engine side
- update help text to describe new commands
- refine map command to require a cell ID rather than assuming a logged-in character

## Testing
- `bash scripts/setup.sh`
- `bash scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6879a11bba248323a72675c730ae9569