### PR TITLE
Add selective ranged cover seeding

### DIFF
--- a/DatabaseSeeder/Seeders/UsefulSeeder.cs
+++ b/DatabaseSeeder/Seeders/UsefulSeeder.cs
@@ -43,19 +43,27 @@ public class UsefulSeeder : IDatabaseSeeder
 					if (answer.EqualToAny("yes", "y", "no", "n")) return (true, string.Empty);
 					return (false, "Invalid answer");
 				}),
-			("terrain",
-				"Do you want to install a collection of terrestrial terrain types?\n\nPlease answer #3yes#f or #3no#f: ",
-				(context, questions) => context.Terrains.Count() <= 1,
-				(answer, context) =>
-				{
-					if (answer.EqualToAny("yes", "y", "no", "n")) return (true, string.Empty);
-					return (false, "Invalid answer");
-				}),
-			("items",
-				"#DItem Package 1#F\n\nItem Package 1 includes some commonly used item component types, including a wide selection of containers, liquid containers, doors, locks, keys and basic writing implements.\n\nShall we install this package? Please answer #3yes#f or #3no#f: ",
-				(context, questions) => context.GameItemComponentProtos.All(x => x.Name != "Container_Table"),
-				(answer, context) =>
-				{
+                        ("terrain",
+                                "Do you want to install a collection of terrestrial terrain types?\n\nPlease answer #3yes#f or #3no#f: ",
+                                (context, questions) => context.Terrains.Count() <= 1,
+                                (answer, context) =>
+                                {
+                                        if (answer.EqualToAny("yes", "y", "no", "n")) return (true, string.Empty);
+                                        return (false, "Invalid answer");
+                                }),
+                        ("covers",
+                                "Do you want to install a collection of sample ranged covers?\n\nPlease answer #3yes#f or #3no#f: ",
+                                (context, questions) => context.RangedCovers.Count() <= 1,
+                                (answer, context) =>
+                                {
+                                        if (answer.EqualToAny("yes", "y", "no", "n")) return (true, string.Empty);
+                                        return (false, "Invalid answer");
+                                }),
+                        ("items",
+                                "#DItem Package 1#F\n\nItem Package 1 includes some commonly used item component types, including a wide selection of containers, liquid containers, doors, locks, keys and basic writing implements.\n\nShall we install this package? Please answer #3yes#f or #3no#f: ",
+                                (context, questions) => context.GameItemComponentProtos.All(x => x.Name != "Container_Table"),
+                                (answer, context) =>
+                                {
 					if (answer.EqualToAny("yes", "y", "no", "n")) return (true, string.Empty);
 					return (false, "Invalid answer");
 				}),
@@ -144,12 +152,14 @@ Please answer here: ",
 
 		if (questionAnswers["modernitems"].EqualToAny("yes", "y")) SeedModernItems(context, errors);
 
-		if (questionAnswers["terrain"].EqualToAny("yes", "y")) SeedTerrain(context, errors);
+                if (questionAnswers["terrain"].EqualToAny("yes", "y")) SeedTerrain(context, errors);
 
-		if (questionAnswers["autobuilder"].EqualToAny("yes", "y"))
-		{
-			SeedTerrainAutobuilder(context, questionAnswers, errors);
-		}
+                if (questionAnswers["covers"].EqualToAny("yes", "y")) SeedRangedCovers(context, errors);
+
+                if (questionAnswers["autobuilder"].EqualToAny("yes", "y"))
+                {
+                        SeedTerrainAutobuilder(context, questionAnswers, errors);
+                }
 
 		context.Database.CommitTransaction();
 
@@ -8687,11 +8697,171 @@ SetRegister @ch ""NicotineUntil"" (@NicotineUntil + 5m)",
 		context.SaveChanges();
 	}
 
-	private void SeedTerrainAutobuilder(FuturemudDatabaseContext context,
-		IReadOnlyDictionary<string, string> questionAnswers, ICollection<string> errors)
-	{
+        private void SeedTerrainAutobuilder(FuturemudDatabaseContext context,
+                IReadOnlyDictionary<string, string> questionAnswers, ICollection<string> errors)
+        {
 
-	}
+        }
+
+        private void SeedRangedCovers(FuturemudDatabaseContext context, ICollection<string> errors)
+        {
+                if (context.RangedCovers.Any())
+                {
+                        errors.Add("Detected that ranged covers were already installed. Did not seed any covers.");
+                        return;
+                }
+
+                var covers = new List<(string Name, int Type, int Extent, int Position, string Desc, string Action, int Max, bool Moving)>
+                {
+                        ("Uneven Ground", 0, 0, 6, "prone, using the uneven ground as cover", "$0 go|goes prone and begin|begins to use the uneven ground as cover", 0, true),
+                        ("Corridor Doorway", 0, 0, 1, "using a doorway as cover", "$0 duck|ducks into a doorway and begin|begins to use it as cover", 0, false),
+                        ("Large Crater", 0, 1, 6, "prone, using the edge of a large crater as cover", "$0 go|goes prone and begin|begins to use the edge of a large crater as cover", 0, false),
+                        ("Chunk of Rubble", 1, 1, 12, "slumped up against $?0|$0|a large chunk of rubble|$ as cover", "$0 slump|slumps up against $?1|$1|a large chunk of rubble|$ and begin|begins to use it as cover", 2, false),
+                        ("Tree", 1, 1, 1, "hiding behind $?0|$0|a tree|$ for cover", "$0 slip|slips behind $?1|$1|a tree|$ and use|uses it to protect &0's vital areas", 1, false),
+                        ("Bush", 0, 1, 3, "hiding behind $?0|$0|a bush|$ for cover", "$0 take|takes position behind $?1|$1|a bush|$ and use|uses it to obscure &0's profile", 1, false),
+                        ("Refuse Heap", 1, 1, 6, "half-hidden within $?0|$0|a pile of refuse|$, using it as cover", "$0 dive|dives into $?1|$1|a pile of refuse|$, using it to provide cover", 0, false),
+                        ("Upright Table", 1, 0, 1, "using $?0|$0|a table|$ as cover", "$0 move|moves behind $?1|$1|a nearby table|$ and use|uses it to obscure &0's profile", 3, false),
+                        ("Overturned Table", 1, 1, 3, "hiding behind $?0|$0|an overturned table|$ as cover", "$0 duck|ducks behind $?1|$1|an overturned table|$ and begin|begins to use it as cover", 3, false),
+                        ("Smoke", 0, 1, 1, "obscured by $?0|$0|the smoke|$", "$0 move|moves into $?1|$1|the smoke|$ and uses it to obscure &0's form", 0, true),
+                        ("Sandbag", 1, 1, 3, "hiding behind $?0|$0|a sandbag barricade|$, using it as cover", "$0 take|takes position behind $?1|$1|a sandbag barricade|$ and begin|begins to use it as cover", 5, false),
+                        ("Stone Wall", 1, 2, 1, "hiding behind $?0|$0|a stone wall|$ for cover", "$0 slip|slips behind $?1|$1|a stone wall|$ and use|uses it for protection", 0, false),
+                        ("Rubble Wall", 1, 2, 1, "hiding behind $?0|$0|a rubble wall|$ for cover", "$0 hide|hides behind $?1|$1|a rubble wall|$", 0, false),
+                        ("Small Rock", 1, 0, 3, "crouched behind $?0|$0|a small rock|$", "$0 crouch|crouches behind $?1|$1|a small rock|$", 1, false),
+                        ("Large Rock", 1, 1, 3, "hiding behind $?0|$0|a large rock|$", "$0 slip|slips behind $?1|$1|a large rock|$", 1, false),
+                        ("Fallen Log", 1, 1, 3, "hiding behind $?0|$0|a fallen log|$", "$0 slip|slips behind $?1|$1|a fallen log|$", 1, false),
+                        ("Pile of Crates", 1, 1, 1, "hiding behind $?0|$0|a pile of crates|$", "$0 hide|hides behind $?1|$1|a pile of crates|$", 2, false),
+                        ("Barrel Stack", 1, 1, 1, "hiding behind $?0|$0|a stack of barrels|$", "$0 slip|slips behind $?1|$1|a stack of barrels|$", 2, false),
+                        ("Low Hedge", 0, 0, 1, "hiding behind $?0|$0|a low hedge|$", "$0 duck|ducks behind $?1|$1|a low hedge|$", 1, false),
+                        ("Thick Hedge", 0, 1, 1, "hiding behind $?0|$0|a thick hedge|$", "$0 take|takes cover behind $?1|$1|a thick hedge|$", 1, false),
+                        ("Tall Grass", 0, 1, 6, "hiding in $?0|$0|tall grass|$", "$0 slip|slips into $?1|$1|tall grass|$", 2, true),
+                        ("Shrubs", 0, 1, 3, "hiding behind $?0|$0|some shrubs|$", "$0 crouch|crouches behind $?1|$1|some shrubs|$", 1, false),
+                        ("Vehicle", 1, 2, 1, "using $?0|$0|a vehicle|$ as cover", "$0 take|takes cover behind $?1|$1|a vehicle|$", 2, false),
+                        ("Broken Vehicle", 1, 2, 3, "hiding behind $?0|$0|a broken vehicle|$", "$0 crouch|crouches behind $?1|$1|a broken vehicle|$", 2, false),
+                        ("Collapsed Building", 1, 2, 5, "sheltering in $?0|$0|a collapsed building|$", "$0 dive|dives into $?1|$1|a collapsed building|$", 0, false),
+                        ("Window Frame", 1, 0, 1, "using $?0|$0|a window frame|$ as cover", "$0 use|uses $?1|$1|a window frame|$ for cover", 1, false),
+                        ("Ruined Wall", 1, 2, 1, "hiding behind $?0|$0|a ruined wall|$", "$0 take|takes cover behind $?1|$1|a ruined wall|$", 0, false),
+                        ("Stalagmites", 1, 1, 1, "hiding among $?0|$0|stalagmites|$", "$0 dart|darts among $?1|$1|stalagmites|$", 2, false),
+                        ("Pile of Junk", 1, 1, 3, "hiding behind $?0|$0|a pile of junk|$", "$0 crouch|crouches behind $?1|$1|a pile of junk|$", 1, false),
+                        ("Pile of Bones", 1, 0, 3, "hiding behind $?0|$0|a pile of bones|$", "$0 crouch|crouches behind $?1|$1|a pile of bones|$", 1, false),
+                        ("Dead Body", 1, 0, 3, "using $?0|$0|a dead body|$ as cover", "$0 crouch|crouches behind $?1|$1|a dead body|$", 1, false),
+                        ("Sand Dune", 0, 1, 1, "hiding behind $?0|$0|a sand dune|$", "$0 use|uses $?1|$1|a sand dune|$ for cover", 0, true),
+                        ("Snow Drift", 0, 1, 1, "hiding behind $?0|$0|a snow drift|$", "$0 hide|hides behind $?1|$1|a snow drift|$", 0, true),
+                        ("Fallen Statue", 1, 1, 3, "hiding behind $?0|$0|a fallen statue|$", "$0 crouch|crouches behind $?1|$1|a fallen statue|$", 1, false),
+                        ("Street Corner", 1, 2, 1, "using $?0|$0|a street corner|$ as cover", "$0 lean|leans around $?1|$1|a street corner|$", 0, false),
+                        ("Alley Trash Bin", 1, 1, 1, "hiding behind $?0|$0|a trash bin|$", "$0 duck|ducks behind $?1|$1|a trash bin|$", 1, false),
+                        ("Park Bench", 1, 0, 1, "using $?0|$0|a park bench|$ as cover", "$0 sit|sits behind $?1|$1|a park bench|$", 1, false),
+                        ("Street Lamp", 1, 0, 1, "using $?0|$0|a street lamp|$ as cover", "$0 dodge|dodges behind $?1|$1|a street lamp|$", 1, false),
+                        ("Old Well", 1, 2, 1, "using $?0|$0|an old well|$ as cover", "$0 hide|hides by $?1|$1|an old well|$", 1, false),
+                        ("Rock Outcropping", 1, 2, 1, "hiding behind $?0|$0|a rock outcropping|$", "$0 slip|slips behind $?1|$1|a rock outcropping|$", 1, false),
+                        ("Fallen Tree", 1, 1, 3, "hiding behind $?0|$0|a fallen tree|$", "$0 duck|ducks behind $?1|$1|a fallen tree|$", 1, false),
+                        ("Fallen Pillar", 1, 1, 3, "hiding behind $?0|$0|a fallen pillar|$", "$0 duck|ducks behind $?1|$1|a fallen pillar|$", 1, false),
+                        ("Thick Smoke", 0, 2, 1, "obscured by $?0|$0|thick smoke|$", "$0 move|moves into $?1|$1|thick smoke|$", 0, true),
+                        ("Dense Fog", 0, 2, 1, "obscured by $?0|$0|dense fog|$", "$0 move|moves into $?1|$1|dense fog|$", 0, true),
+                        ("Tall Reeds", 0, 1, 6, "hiding in $?0|$0|tall reeds|$", "$0 slip|slips into $?1|$1|tall reeds|$", 2, true),
+                        ("Dense Vegetation", 0, 2, 3, "hiding in $?0|$0|dense vegetation|$", "$0 move|moves into $?1|$1|dense vegetation|$", 2, true),
+                        ("Boulder Cluster", 1, 2, 3, "hiding behind $?0|$0|a cluster of boulders|$", "$0 move|moves behind $?1|$1|a cluster of boulders|$", 2, false),
+                        ("Abandoned Cart", 1, 1, 1, "hiding behind $?0|$0|an abandoned cart|$", "$0 duck|ducks behind $?1|$1|an abandoned cart|$", 1, false),
+                        ("Bushy Tree", 1, 1, 1, "hiding behind $?0|$0|a bushy tree|$", "$0 slip|slips behind $?1|$1|a bushy tree|$", 1, false),
+                        ("Shrubbery", 0, 1, 1, "hiding behind $?0|$0|some shrubbery|$", "$0 duck|ducks behind $?1|$1|some shrubbery|$", 1, false),
+                        ("Counter", 1, 0, 1, "using $?0|$0|a counter|$ as cover", "$0 duck|ducks behind $?1|$1|a counter|$", 2, false),
+                        ("Desk", 1, 0, 1, "using $?0|$0|a desk|$ as cover", "$0 duck|ducks behind $?1|$1|a desk|$", 1, false),
+                        ("Staircase", 1, 1, 3, "hiding behind $?0|$0|a staircase|$", "$0 duck|ducks behind $?1|$1|a staircase|$", 1, false),
+                        ("Corner", 1, 2, 1, "using $?0|$0|a corner|$ as cover", "$0 press|presses into $?1|$1|a corner|$", 0, false)
+                };
+
+                foreach (var item in covers)
+                {
+                        context.RangedCovers.Add(new RangedCover
+                        {
+                                Name = item.Name,
+                                CoverType = item.Type,
+                                CoverExtent = item.Extent,
+                                HighestPositionState = item.Position,
+                                DescriptionString = item.Desc,
+                                ActionDescriptionString = item.Action,
+                                MaximumSimultaneousCovers = item.Max,
+                                CoverStaysWhileMoving = item.Moving
+                        });
+                }
+                context.SaveChanges();
+
+                var coversByName = context.RangedCovers.ToDictionary(x => x.Name, x => x);
+                var tagsById = context.Tags.ToDictionary(x => x.Id, x => x.Name);
+
+                var coversForTags = new Dictionary<string, string[]>
+                {
+                        ["Urban"] = new[]
+                        {
+                                "Corridor Doorway", "Upright Table", "Overturned Table", "Window Frame",
+                                "Counter", "Desk", "Staircase", "Corner", "Street Corner", "Alley Trash Bin",
+                                "Park Bench", "Street Lamp", "Vehicle", "Broken Vehicle", "Abandoned Cart",
+                                "Collapsed Building", "Rubble Wall", "Pile of Crates", "Barrel Stack", "Pile of Junk",
+                                "Pile of Bones", "Dead Body", "Fallen Statue", "Sandbag"
+                        },
+                        ["Rural"] = new[]
+                        {
+                                "Tree", "Bush", "Bushy Tree", "Shrubbery", "Fallen Log", "Fallen Tree",
+                                "Old Well"
+                        },
+                        ["Terrestrial"] = new[]
+                        {
+                                "Uneven Ground", "Large Crater", "Stone Wall", "Rubble Wall", "Small Rock",
+                                "Large Rock", "Boulder Cluster", "Rock Outcropping", "Sand Dune", "Snow Drift",
+                                "Low Hedge", "Thick Hedge", "Tall Grass", "Shrubs", "Fallen Pillar"
+                        },
+                        ["Aquatic"] = new[] { "Tall Reeds", "Dense Vegetation" },
+                        ["Littoral"] = new[] { "Sand Dune", "Tall Reeds" },
+                        ["Riparian"] = new[] { "Tall Reeds", "Dense Vegetation" }
+                };
+
+                var defaultCovers = new[] { "Smoke", "Thick Smoke", "Dense Fog" };
+
+                foreach (var terrain in context.Terrains.ToList())
+                {
+                        var tagNames = terrain.TagInformation?.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                                .Select(x => long.TryParse(x, out var val) && tagsById.ContainsKey(val)
+                                        ? tagsById[val]
+                                        : null)
+                                .Where(x => x != null)
+                                .ToList() ?? new List<string>();
+
+                        var coverIds = new HashSet<long>();
+                        foreach (var tag in tagNames)
+                        {
+                                if (!coversForTags.TryGetValue(tag!, out var names))
+                                {
+                                        continue;
+                                }
+
+                                foreach (var name in names)
+                                {
+                                        if (coversByName.TryGetValue(name, out var cover))
+                                        {
+                                                coverIds.Add(cover.Id);
+                                        }
+                                }
+                        }
+
+                        foreach (var name in defaultCovers)
+                        {
+                                if (coversByName.TryGetValue(name, out var cover))
+                                {
+                                        coverIds.Add(cover.Id);
+                                }
+                        }
+
+                        foreach (var id in coverIds)
+                        {
+                                context.TerrainsRangedCovers.Add(new TerrainsRangedCovers
+                                {
+                                        TerrainId = terrain.Id,
+                                        RangedCoverId = id
+                                });
+                        }
+                }
+
+                context.SaveChanges();
+        }
 
 	private void SeedAIPart1(FuturemudDatabaseContext context, ICollection<string> errors)
 	{

--- a/FutureMUDLibrary/Combat/IRangedCover.cs
+++ b/FutureMUDLibrary/Combat/IRangedCover.cs
@@ -1,6 +1,7 @@
 ﻿using MudSharp.Body.Position;
 using MudSharp.Character;
 using MudSharp.Framework;
+using MudSharp.Framework.Revision;
 using MudSharp.PerceptionEngine;
 using MudSharp.RPG.Checks;
 
@@ -20,7 +21,7 @@ namespace MudSharp.Combat
         Total
     }
 
-    public interface IRangedCover : IKeywordedItem
+    public interface IRangedCover : IKeywordedItem, IEditableItem
     {
         CoverType CoverType { get; }
         CoverExtent CoverExtent { get; }

--- a/FutureMUDLibrary/Framework/IFuturemud.cs
+++ b/FutureMUDLibrary/Framework/IFuturemud.cs
@@ -447,8 +447,9 @@ namespace MudSharp.Framework
 		void Add(IWearProfile profile);
 		void Add(ILimb limb);
 		void Add(IWeaponType type);
-		void Add(IRangedWeaponType type);
-		void Add(IAmmunitionType type);
+                void Add(IRangedWeaponType type);
+                void Add(IRangedCover cover);
+                void Add(IAmmunitionType type);
 		void Add(IWearableSize size);
 		void Add(ICharacterCombatSettings setting);
 		void Add(IProgSchedule schedule);
@@ -572,8 +573,9 @@ namespace MudSharp.Framework
 		void Destroy(IWearProfile profile);
 		void Destroy(IWeaponType type);
 		void Destroy(ILimb limb);
-		void Destroy(IRangedWeaponType type);
-		void Destroy(IAmmunitionType type);
+                void Destroy(IRangedWeaponType type);
+                void Destroy(IRangedCover cover);
+                void Destroy(IAmmunitionType type);
 		void Destroy(IWearableSize size);
 		void Destroy(ICharacterCombatSettings setting);
 		void Destroy(IProgSchedule schedule);

--- a/MudSharpCore/Combat/RangedCover.cs
+++ b/MudSharpCore/Combat/RangedCover.cs
@@ -1,30 +1,97 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using MudSharp.Body.Position;
+using MudSharp.Body.Position.PositionStates;
 using MudSharp.Character;
 using MudSharp.Framework;
 using MudSharp.PerceptionEngine;
 using MudSharp.PerceptionEngine.Outputs;
 using MudSharp.PerceptionEngine.Parsers;
 using MudSharp.RPG.Checks;
+using MudSharp.Database;
+using MudSharp.Framework.Save;
 
 namespace MudSharp.Combat;
 
-public class RangedCover : FrameworkItem, IRangedCover
+public class RangedCover : SaveableItem, IRangedCover
 {
-	public RangedCover(MudSharp.Models.RangedCover cover)
-	{
-		_id = cover.Id;
-		_name = cover.Name;
-		CoverType = (CoverType)cover.CoverType;
-		CoverExtent = (CoverExtent)cover.CoverExtent;
-		HighestPositionState = PositionState.GetState(cover.HighestPositionState);
-		DescriptionString = cover.DescriptionString;
-		ActionDescriptionString = cover.ActionDescriptionString;
-		MaximumSimultaneousCovers = cover.MaximumSimultaneousCovers;
-		CoverStaysWhileMoving = cover.CoverStaysWhileMoving;
-	}
+        public RangedCover(IFuturemud gameworld, MudSharp.Models.RangedCover cover)
+        {
+                Gameworld = gameworld;
+                _id = cover.Id;
+                _name = cover.Name;
+                CoverType = (CoverType)cover.CoverType;
+                CoverExtent = (CoverExtent)cover.CoverExtent;
+                HighestPositionState = PositionState.GetState(cover.HighestPositionState);
+                DescriptionString = cover.DescriptionString;
+                ActionDescriptionString = cover.ActionDescriptionString;
+                MaximumSimultaneousCovers = cover.MaximumSimultaneousCovers;
+                CoverStaysWhileMoving = cover.CoverStaysWhileMoving;
+        }
+
+        public RangedCover(IFuturemud gameworld, string name)
+        {
+                Gameworld = gameworld;
+                _name = name;
+                CoverType = CoverType.Soft;
+                CoverExtent = CoverExtent.Marginal;
+                HighestPositionState = PositionStanding.Instance;
+                DescriptionString = "using $0 as cover";
+                ActionDescriptionString = "@ take|takes cover behind $1";
+                MaximumSimultaneousCovers = 0;
+                CoverStaysWhileMoving = false;
+
+                using (new FMDB())
+                {
+                        var dbitem = new Models.RangedCover
+                        {
+                                Name = name,
+                                CoverType = (int)CoverType,
+                                CoverExtent = (int)CoverExtent,
+                                HighestPositionState = (int)HighestPositionState.Id,
+                                DescriptionString = DescriptionString,
+                                ActionDescriptionString = ActionDescriptionString,
+                                MaximumSimultaneousCovers = MaximumSimultaneousCovers,
+                                CoverStaysWhileMoving = CoverStaysWhileMoving
+                        };
+                        FMDB.Context.RangedCovers.Add(dbitem);
+                        FMDB.Context.SaveChanges();
+                        _id = dbitem.Id;
+                }
+        }
+
+        public RangedCover(RangedCover rhs, string name)
+        {
+                Gameworld = rhs.Gameworld;
+                _name = name;
+                CoverType = rhs.CoverType;
+                CoverExtent = rhs.CoverExtent;
+                HighestPositionState = rhs.HighestPositionState;
+                DescriptionString = rhs.DescriptionString;
+                ActionDescriptionString = rhs.ActionDescriptionString;
+                MaximumSimultaneousCovers = rhs.MaximumSimultaneousCovers;
+                CoverStaysWhileMoving = rhs.CoverStaysWhileMoving;
+
+                using (new FMDB())
+                {
+                        var dbitem = new Models.RangedCover
+                        {
+                                Name = name,
+                                CoverType = (int)CoverType,
+                                CoverExtent = (int)CoverExtent,
+                                HighestPositionState = (int)HighestPositionState.Id,
+                                DescriptionString = DescriptionString,
+                                ActionDescriptionString = ActionDescriptionString,
+                                MaximumSimultaneousCovers = MaximumSimultaneousCovers,
+                                CoverStaysWhileMoving = CoverStaysWhileMoving
+                        };
+                        FMDB.Context.RangedCovers.Add(dbitem);
+                        FMDB.Context.SaveChanges();
+                        _id = dbitem.Id;
+                }
+        }
 
 	public CoverType CoverType { get; set; }
 	public CoverExtent CoverExtent { get; set; }
@@ -32,7 +99,7 @@ public class RangedCover : FrameworkItem, IRangedCover
 	public string DescriptionString { get; set; }
 	public string ActionDescriptionString { get; set; }
 	public int MaximumSimultaneousCovers { get; set; }
-	public bool CoverStaysWhileMoving { get; set; }
+        public bool CoverStaysWhileMoving { get; set; }
 
 	public string Describe(ICharacter covered, IPerceivable coverProvider, IPerceiver voyeur)
 	{
@@ -44,9 +111,9 @@ public class RangedCover : FrameworkItem, IRangedCover
 		return new Emote(ActionDescriptionString, covered, covered, coverProvider);
 	}
 
-	public override string FrameworkItemType => "RangedCover";
+        public override string FrameworkItemType => "RangedCover";
 
-	public Difficulty MinimumRangedDifficulty
+        public Difficulty MinimumRangedDifficulty
 	{
 		get
 		{
@@ -66,9 +133,233 @@ public class RangedCover : FrameworkItem, IRangedCover
 		}
 	}
 
-	#region Implementation of IKeyworded
+        #region Implementation of IKeyworded
 
-	public IEnumerable<string> Keywords => Name.Split(' ').ToList();
+        public IEnumerable<string> Keywords => Name.Split(' ').ToList();
 
-	#endregion
+        #endregion
+
+        #region Implementation of IEditableItem
+
+        public const string HelpText = @"You can use the following options with this command:
+
+        #3name <name>#0 - renames this cover type
+        #3type <hard|soft>#0 - sets the cover type
+        #3extent <marginal|partial|neartotal|total>#0 - sets the extent of cover
+        #3position <position>#0 - sets the highest position state for cover
+        #3desc <emote>#0 - sets the description emote ($0 is the cover item)
+        #3action <emote>#0 - sets the action emote ($0 is the character, $1 is the cover item)
+        #3max <number>#0 - sets the maximum simultaneous covers (0 for unlimited)
+        #3moving#0 - toggles cover staying while moving
+
+For information on emote syntax see #3help emote#0.";
+
+        public bool BuildingCommand(ICharacter actor, StringStack command)
+        {
+                switch (command.PopForSwitch())
+                {
+                        case "name":
+                                return BuildingCommandName(actor, command);
+                        case "type":
+                                return BuildingCommandType(actor, command);
+                        case "extent":
+                                return BuildingCommandExtent(actor, command);
+                        case "position":
+                                return BuildingCommandPosition(actor, command);
+                        case "desc":
+                        case "description":
+                                return BuildingCommandDesc(actor, command);
+                        case "action":
+                                return BuildingCommandAction(actor, command);
+                        case "max":
+                                return BuildingCommandMax(actor, command);
+                        case "moving":
+                                return BuildingCommandMoving(actor);
+                        default:
+                                actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
+                                return false;
+                }
+        }
+
+        private bool BuildingCommandName(ICharacter actor, StringStack command)
+        {
+                if (command.IsFinished)
+                {
+                        actor.OutputHandler.Send("What new name do you want to give to this cover type?");
+                        return false;
+                }
+
+                var name = command.SafeRemainingArgument.TitleCase();
+                if (Gameworld.RangedCovers.Except(this).Any(x => x.Name.EqualTo(name)))
+                {
+                        actor.OutputHandler.Send($"There is already a ranged cover called {name.ColourName()}. Names must be unique.");
+                        return false;
+                }
+
+                _name = name;
+                Changed = true;
+                actor.OutputHandler.Send($"You rename the cover to {name.ColourName()}.");
+                return true;
+        }
+
+        private bool BuildingCommandType(ICharacter actor, StringStack command)
+        {
+                if (command.IsFinished)
+                {
+                        actor.OutputHandler.Send($"What type should this cover be? The options are {Enum.GetValues<CoverType>().Select(x => x.Describe().ColourName()).ListToString()}.");
+                        return false;
+                }
+
+                if (!command.SafeRemainingArgument.TryParseEnum<CoverType>(out var type))
+                {
+                        actor.OutputHandler.Send($"That is not a valid cover type. The options are {Enum.GetValues<CoverType>().Select(x => x.Describe().ColourName()).ListToString()}.");
+                        return false;
+                }
+
+                CoverType = type;
+                Changed = true;
+                actor.OutputHandler.Send($"This cover is now of the {type.Describe().ColourValue()} type.");
+                return true;
+        }
+
+        private bool BuildingCommandExtent(ICharacter actor, StringStack command)
+        {
+                if (command.IsFinished)
+                {
+                        actor.OutputHandler.Send($"What extent should this cover be? The options are {Enum.GetValues<CoverExtent>().Select(x => x.Describe().ColourName()).ListToString()}.");
+                        return false;
+                }
+
+                if (!command.SafeRemainingArgument.TryParseEnum<CoverExtent>(out var extent))
+                {
+                        actor.OutputHandler.Send($"That is not a valid cover extent. The options are {Enum.GetValues<CoverExtent>().Select(x => x.Describe().ColourName()).ListToString()}.");
+                        return false;
+                }
+
+                CoverExtent = extent;
+                Changed = true;
+                actor.OutputHandler.Send($"This cover now provides {extent.Describe().ColourValue()} cover.");
+                return true;
+        }
+
+        private bool BuildingCommandPosition(ICharacter actor, StringStack command)
+        {
+                if (command.IsFinished)
+                {
+                        actor.OutputHandler.Send("Which position state should be the highest for this cover?");
+                        return false;
+                }
+
+                var state = PositionState.GetState(command.SafeRemainingArgument);
+                if (state == null || state == PositionUndefined.Instance)
+                {
+                        actor.OutputHandler.Send("That is not a valid position state.");
+                        return false;
+                }
+
+                HighestPositionState = state;
+                Changed = true;
+                actor.OutputHandler.Send($"The highest position state for this cover is now {state.Name.ColourValue()}.");
+                return true;
+        }
+
+       private bool BuildingCommandDesc(ICharacter actor, StringStack command)
+       {
+               if (command.IsFinished)
+               {
+                       actor.OutputHandler.Send("What should the description string be?");
+                       return false;
+               }
+
+               var text = command.SafeRemainingArgument;
+               var emote = new NoFormatEmote(text, new DummyPerceiver(), null);
+               if (!emote.Valid)
+               {
+                       actor.OutputHandler.Send(emote.ErrorMessage);
+                       return false;
+               }
+
+               DescriptionString = text;
+               Changed = true;
+               actor.OutputHandler.Send("Description string set.");
+               return true;
+       }
+
+       private bool BuildingCommandAction(ICharacter actor, StringStack command)
+       {
+               if (command.IsFinished)
+               {
+                       actor.OutputHandler.Send("What should the action description string be?");
+                       return false;
+               }
+
+               var text = command.SafeRemainingArgument;
+               var emote = new Emote(text, new DummyPerceiver(), null);
+               if (!emote.Valid)
+               {
+                       actor.OutputHandler.Send(emote.ErrorMessage);
+                       return false;
+               }
+
+               ActionDescriptionString = text;
+               Changed = true;
+               actor.OutputHandler.Send("Action description string set.");
+               return true;
+       }
+
+        private bool BuildingCommandMax(ICharacter actor, StringStack command)
+        {
+                if (command.IsFinished)
+                {
+                        actor.OutputHandler.Send("How many characters can use this cover simultaneously? (0 for unlimited)");
+                        return false;
+                }
+
+                if (!int.TryParse(command.SafeRemainingArgument, out var value) || value < 0)
+                {
+                        actor.OutputHandler.Send("You must enter a valid number 0 or greater.");
+                        return false;
+                }
+
+                MaximumSimultaneousCovers = value;
+                Changed = true;
+                actor.OutputHandler.Send($"Maximum simultaneous covers is now {value.ToString("N0", actor).ColourValue()}.");
+                return true;
+        }
+
+        private bool BuildingCommandMoving(ICharacter actor)
+        {
+                CoverStaysWhileMoving = !CoverStaysWhileMoving;
+                Changed = true;
+                actor.OutputHandler.Send($"This cover will {(CoverStaysWhileMoving ? "now" : "no longer")} remain when moving.");
+                return true;
+        }
+
+        public string Show(ICharacter actor)
+        {
+                var sb = new StringBuilder();
+                sb.AppendLine($"Ranged Cover #{Id.ToString("N0", actor)} - {Name}".GetLineWithTitle(actor, Telnet.Cyan, Telnet.BoldWhite));
+                sb.AppendLine($"Type: {CoverType.Describe().ColourValue()}  Extent: {CoverExtent.Describe().ColourValue()}");
+                sb.AppendLine($"Highest Position: {HighestPositionState.Name.ColourValue()}");
+                sb.AppendLine($"Max Covers: {MaximumSimultaneousCovers.ToString("N0", actor)}  Moving: {CoverStaysWhileMoving.ToColouredString()}");
+                sb.AppendLine($"Description: {DescriptionString.SubstituteANSIColour()}");
+                sb.AppendLine($"Action: {ActionDescriptionString.SubstituteANSIColour()}");
+                return sb.ToString();
+        }
+
+        public override void Save()
+        {
+                var dbitem = FMDB.Context.RangedCovers.Find(Id);
+                dbitem.Name = Name;
+                dbitem.CoverType = (int)CoverType;
+                dbitem.CoverExtent = (int)CoverExtent;
+                dbitem.HighestPositionState = (int)HighestPositionState.Id;
+                dbitem.DescriptionString = DescriptionString;
+                dbitem.ActionDescriptionString = ActionDescriptionString;
+                dbitem.MaximumSimultaneousCovers = MaximumSimultaneousCovers;
+                dbitem.CoverStaysWhileMoving = CoverStaysWhileMoving;
+                Changed = false;
+        }
+
+        #endregion
 }

--- a/MudSharpCore/Commands/Modules/CombatBuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/CombatBuilderModule.cs
@@ -1305,9 +1305,42 @@ Additionally, absorb formulas can use the following parameter:
 	[PlayerCommand("Armour", "armour", "armor")]
 	[CommandPermission(PermissionLevel.Admin)]
 	[HelpInfo("Armour", ArmourTypeHelp, AutoHelp.HelpArgOrNoArg)]
-	protected static void Armour(ICharacter actor, string command)
-	{
-		GenericBuildingCommand(actor, new StringStack(command.RemoveFirstWord()), EditableItemHelper.ArmourTypeHelper);
-	}
-	#endregion	
+        protected static void Armour(ICharacter actor, string command)
+        {
+                GenericBuildingCommand(actor, new StringStack(command.RemoveFirstWord()), EditableItemHelper.ArmourTypeHelper);
+        }
+        #endregion
+
+        #region Ranged Cover
+
+        public const string RangedCoverHelp = @"The #3cover#0 command is used to create and edit ranged cover types.
+
+You can use the following syntax with this command:
+
+        #3cover list#0 - lists all covers
+        #3cover edit <id|name>#0 - begins editing a cover
+        #3cover edit new <name>#0 - creates a new cover
+        #3cover close#0 - stops editing a cover
+        #3cover clone <id|name> <name>#0 - clones an existing cover
+        #3cover show <id|name>#0 - shows a cover
+        #3cover set name <name>#0 - renames the cover
+        #3cover set type <type>#0 - sets the cover type (hard or soft)
+        #3cover set extent <extent>#0 - sets the cover extent
+        #3cover set position <position>#0 - sets the highest position state
+        #3cover set desc <emote>#0 - sets the description emote ($0 is the cover item)
+        #3cover set action <emote>#0 - sets the action emote ($0 is the character, $1 is the cover item)
+        #3cover set max <##>#0 - sets the maximum simultaneous covers
+        #3cover set moving#0 - toggles the moving flag
+
+For information on emote syntax see #3help emote#0.";
+
+        [PlayerCommand("Cover", "cover")]
+        [CommandPermission(PermissionLevel.Admin)]
+        [HelpInfo("Cover", RangedCoverHelp, AutoHelp.HelpArgOrNoArg)]
+        protected static void Cover(ICharacter actor, string command)
+        {
+                GenericBuildingCommand(actor, new StringStack(command.RemoveFirstWord()), EditableItemHelper.RangedCoverHelper);
+        }
+
+        #endregion
 }

--- a/MudSharpCore/Framework/Futuremud.cs
+++ b/MudSharpCore/Framework/Futuremud.cs
@@ -1085,15 +1085,20 @@ public sealed partial class Futuremud : IFuturemud, IDisposable
 		_weaponTypes.Add(type);
 	}
 
-	public void Add(IRangedWeaponType type)
-	{
-		_rangedWeaponTypes.Add(type);
-	}
+        public void Add(IRangedWeaponType type)
+        {
+                _rangedWeaponTypes.Add(type);
+        }
 
-	public void Add(IAmmunitionType type)
-	{
-		_ammunitionTypes.Add(type);
-	}
+        public void Add(IRangedCover cover)
+        {
+                _rangedCovers.Add(cover);
+        }
+
+        public void Add(IAmmunitionType type)
+        {
+                _ammunitionTypes.Add(type);
+        }
 
 	public void Add(IWearableSize size)
 	{
@@ -1860,15 +1865,20 @@ public sealed partial class Futuremud : IFuturemud, IDisposable
 		_limbs.Remove(limb);
 	}
 
-	public void Destroy(IRangedWeaponType type)
-	{
-		_rangedWeaponTypes.Remove(type);
-	}
+        public void Destroy(IRangedWeaponType type)
+        {
+                _rangedWeaponTypes.Remove(type);
+        }
 
-	public void Destroy(IAmmunitionType type)
-	{
-		_ammunitionTypes.Remove(type);
-	}
+        public void Destroy(IRangedCover cover)
+        {
+                _rangedCovers.Remove(cover);
+        }
+
+        public void Destroy(IAmmunitionType type)
+        {
+                _ammunitionTypes.Remove(type);
+        }
 
 	public void Destroy(IWearableSize size)
 	{

--- a/MudSharpCore/Framework/FuturemudLoaders.cs
+++ b/MudSharpCore/Framework/FuturemudLoaders.cs
@@ -1575,10 +1575,10 @@ For information on the syntax to use in emotes (such as those included in bracke
 		sw.Start();
 #endif
 		var covers = FMDB.Context.RangedCovers.AsNoTracking().ToList();
-		foreach (var cover in covers)
-		{
-			_rangedCovers.Add(new RangedCover(cover));
-		}
+                foreach (var cover in covers)
+                {
+                        _rangedCovers.Add(new RangedCover(this, cover));
+                }
 #if DEBUG
 		sw.Stop();
 		ConsoleUtilities.WriteLine($"Duration: #2{sw.ElapsedMilliseconds}ms#0");


### PR DESCRIPTION
## Summary
- seed sample ranged covers only to appropriate terrains
- validate cover action emote with null item

## Testing
- `scripts/setup.sh`
- `scripts/test.sh` *(fails: Build FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_6879c4b7c0008323bf5ff1c934f9f583