### PR TITLE
Add FrameworkItemEquals extension unit tests

### DIFF
--- a/MudSharpCore Unit Tests/FrameworkItemExtensionsTests.cs
+++ b/MudSharpCore Unit Tests/FrameworkItemExtensionsTests.cs
@@ -1,0 +1,43 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Framework;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class FrameworkItemExtensionsTests
+{
+    [TestMethod]
+    public void FrameworkItemEquals_TrueWhenItemIdAndTypeMatch()
+    {
+        var item = new FrameworkItemStub { Id = 1 };
+        Assert.IsTrue(item.FrameworkItemEquals(1, "Stub"));
+    }
+
+    [TestMethod]
+    public void FrameworkItemEquals_FalseWhenIdDiffers()
+    {
+        var item = new FrameworkItemStub { Id = 1 };
+        Assert.IsFalse(item.FrameworkItemEquals(2, "Stub"));
+    }
+
+    [TestMethod]
+    public void FrameworkItemEquals_FalseWhenTypeDiffers()
+    {
+        var item = new FrameworkItemStub { Id = 1 };
+        Assert.IsFalse(item.FrameworkItemEquals(1, "Other"));
+    }
+
+    [TestMethod]
+    public void FrameworkItemEquals_TrueWhenItemNullAndIdNull()
+    {
+        IFrameworkItem item = null;
+        Assert.IsTrue(item.FrameworkItemEquals(null, "Stub"));
+    }
+
+    [TestMethod]
+    public void FrameworkItemEquals_FalseWhenItemNullAndIdNonNull()
+    {
+        IFrameworkItem item = null;
+        Assert.IsFalse(item.FrameworkItemEquals(1, "Stub"));
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests verifying FrameworkItemEquals for matching item, differing id/type, and null handling

## Testing
- `scripts/test.sh`
- `dotnet test 'MudSharpCore Unit Tests/MudSharpCore Unit Tests.csproj'`

------
https://chatgpt.com/codex/tasks/task_e_6893c94ecbf0832385c26dc1ee9d452c