### PR TITLE
Add StringUtilities test coverage

### DIFF
--- a/FutureMUDLibrary/Framework/StringUtilities.cs
+++ b/FutureMUDLibrary/Framework/StringUtilities.cs
@@ -297,7 +297,7 @@ namespace MudSharp.Framework
 					return match.Groups["text"].Value;
 				}
 
-				if (!double.TryParse(match.Groups["value"].Value, out var value))
+                                if (!double.TryParse(match.Groups["difficulty"].Value, out var value))
 				{
 					return match.Groups["text"].Value;
 				}

--- a/MudSharpCore Unit Tests/StringUtilitiesTests.cs
+++ b/MudSharpCore Unit Tests/StringUtilitiesTests.cs
@@ -1,5 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Body.Traits;
+using MudSharp.Communication.Language;
 using MudSharp.Framework;
+using MudSharp.Form.Colour;
+using MudSharp.RPG.Checks;
 
 namespace MudSharp_Unit_Tests;
 
@@ -71,5 +79,112 @@ public class StringUtilitiesTests
     {
         var coloured = "Mix #1red#0 and #4blue#0".SubstituteANSIColour();
         Assert.AreEqual("Mix red and blue", coloured.StripANSIColour());
+    }
+
+    [TestMethod]
+    public void StripANSIColour_NoStripParameter_ReturnsOriginal()
+    {
+        var coloured = "#1Red#0 Text".SubstituteANSIColour();
+        Assert.AreEqual(coloured, coloured.StripANSIColour(strip: false));
+    }
+
+    [TestMethod]
+    public void GetTextTable_TruncatesSpecifiedColumn()
+    {
+        var data = new[]
+        {
+            new[] {"short", "longerthanwidth", "mid"},
+            new[] {"short2", "bigger", "mid2"}
+        };
+        var header = new[] {"Col1", "Col2", "Col3"};
+        var table = StringUtilities.GetTextTable(data, header, 32, bColourTable: false, truncatableColumnIndex: 1)
+            .StripANSIColour();
+        var lines = table.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.IsTrue(lines[1].Contains("Col1"));
+        Assert.AreEqual(lines[1].IndexOf("Col1"), lines[3].IndexOf("short"));
+        Assert.IsTrue(lines[3].Contains("longer..."));
+        Assert.IsTrue(lines[4].Contains("bigger"));
+    }
+
+    [TestMethod]
+    public void SubstituteCheckTrait_SubstitutesAndFallsBack()
+    {
+        var traitDef = new Mock<ITraitDefinition>();
+        traitDef.Setup(x => x.Name).Returns("strength");
+        var traitRepo = new Mock<IUneditableAll<ITraitDefinition>>();
+        traitRepo.Setup(x => x.GetByIdOrName("strength", true)).Returns(traitDef.Object);
+        var game = new Mock<IFuturemud>();
+        game.Setup(x => x.Traits).Returns(traitRepo.Object);
+
+        var high = new Mock<IPerceiver>();
+        high.As<IPerceivableHaveTraits>()
+            .Setup(x => x.TraitValue(traitDef.Object, TraitBonusContext.None))
+            .Returns(10);
+        var low = new Mock<IPerceiver>();
+        low.As<IPerceivableHaveTraits>()
+            .Setup(x => x.TraitValue(traitDef.Object, TraitBonusContext.None))
+            .Returns(1);
+
+        const string input = "check{strength,5}{pass}{fail}";
+        Assert.AreEqual("pass", input.SubstituteCheckTrait(high.Object, game.Object));
+        Assert.AreEqual("fail", input.SubstituteCheckTrait(low.Object, game.Object));
+    }
+
+    [TestMethod]
+    public void SubstituteWrittenLanguage_SubstitutesAndFallsBack()
+    {
+        var traitDef = new Mock<ITraitDefinition>();
+        var language = new Mock<ILanguage>();
+        language.Setup(x => x.Name).Returns("lang");
+        language.Setup(x => x.LinkedTrait).Returns(traitDef.Object);
+        var script = new Mock<IScript>();
+        script.Setup(x => x.Name).Returns("script");
+        script.Setup(x => x.KnownScriptDescription).Returns("known");
+        script.Setup(x => x.UnknownScriptDescription).Returns("unknown");
+        var langRepo = new Mock<IUneditableAll<ILanguage>>();
+        langRepo.Setup(x => x.GetByName("lang")).Returns(language.Object);
+        var scriptRepo = new Mock<IUneditableAll<IScript>>();
+        scriptRepo.Setup(x => x.GetByName("script")).Returns(script.Object);
+        var colour = new Mock<IColour>();
+        colour.Setup(x => x.Name).Returns("white");
+        var colourRepo = new Mock<IUneditableAll<IColour>>();
+        colourRepo.Setup(x => x.Get(0)).Returns(colour.Object);
+        var game = new Mock<IFuturemud>();
+        game.Setup(x => x.Languages).Returns(langRepo.Object);
+        game.Setup(x => x.Scripts).Returns(scriptRepo.Object);
+        game.Setup(x => x.Colours).Returns(colourRepo.Object);
+        game.Setup(x => x.GetStaticInt("DefaultWritingStyleInText")).Returns(0);
+        game.Setup(x => x.GetStaticLong("DefaultWritingColourInText")).Returns(0);
+
+        var trait = new Mock<ITrait>();
+        trait.Setup(x => x.Value).Returns(10);
+
+        var known = new Mock<ILanguagePerceiver>();
+        known.Setup(x => x.Languages).Returns(new[] { language.Object });
+        known.Setup(x => x.Scripts).Returns(new[] { script.Object });
+        known.As<IHaveTraits>().Setup(x => x.GetTrait(traitDef.Object)).Returns(trait.Object);
+
+        var unknown = new Mock<ILanguagePerceiver>();
+        unknown.Setup(x => x.Languages).Returns(Array.Empty<ILanguage>());
+        unknown.Setup(x => x.Scripts).Returns(Array.Empty<IScript>());
+        unknown.As<IHaveTraits>().Setup(x => x.GetTrait(It.IsAny<ITraitDefinition>())).Returns((ITrait)null);
+
+        const string input = "writing{lang,script}{hello}{alt}";
+        Assert.IsTrue(input.SubstituteWrittenLanguage(known.Object, game.Object).Contains("hello"));
+        Assert.IsTrue(input.SubstituteWrittenLanguage(unknown.Object, game.Object).Contains("alt"));
+    }
+
+    [TestMethod]
+    public void IsValidFormatString_AllOverloads()
+    {
+        const string valid = "Value {0} {1}";
+        Assert.IsTrue(valid.IsValidFormatString(2));
+        Assert.IsTrue(valid.IsValidFormatString(new[] { true, true }.AsSpan()));
+        Assert.IsTrue(valid.IsValidFormatString(2, new[] { true, true }.AsSpan()));
+
+        const string invalid = "Value {0} {2}";
+        Assert.IsFalse(invalid.IsValidFormatString(2));
+        Assert.IsFalse(invalid.IsValidFormatString(new[] { true, true, true }.AsSpan()));
+        Assert.IsFalse(invalid.IsValidFormatString(3, new[] { true, true, true }.AsSpan()));
     }
 }


### PR DESCRIPTION
## Summary
- expand StringUtilities tests for ANSI stripping, table formatting, trait checks, language substitution, and format string validation
- correct check trait parsing to use difficulty group

## Testing
- `scripts/test.sh`
- `dotnet test 'MudSharpCore Unit Tests'`


------
https://chatgpt.com/codex/tasks/task_e_6893c9592fa88323b1e05ae7862056ed