### PR TITLE
Improve weather transitions and performance

### DIFF
--- a/MudSharpCore/Climate/WeatherController.cs
+++ b/MudSharpCore/Climate/WeatherController.cs
@@ -136,10 +136,11 @@ public class WeatherController : SaveableItem, IWeatherController
 
         public void SetWeather(IWeatherEvent newEvent)
         {
-		var oldEvent = CurrentWeatherEvent;
-		CurrentWeatherEvent = newEvent;
-		Changed = true;
-		var echo = newEvent.DescribeTransitionTo(oldEvent)?.SubstituteANSIColour();
+                var oldEvent = CurrentWeatherEvent;
+                CurrentWeatherEvent = newEvent;
+                ConsecutiveUnchangedPeriods = 0;
+                Changed = true;
+                var echo = newEvent.DescribeTransitionTo(oldEvent)?.SubstituteANSIColour();
 		if (!string.IsNullOrEmpty(echo))
 		{
 			WeatherEcho?.Invoke(this, echo);
@@ -210,6 +211,7 @@ public class WeatherController : SaveableItem, IWeatherController
                                         var echo = weather.DescribeTransitionTo(CurrentWeatherEvent)?.SubstituteANSIColour();
                                         var oldWeather = CurrentWeatherEvent;
                                         CurrentWeatherEvent = weather;
+                                        ConsecutiveUnchangedPeriods = 0;
                                         if (!string.IsNullOrEmpty(echo))
                                         {
                                                 WeatherEcho?.Invoke(this, echo);


### PR DESCRIPTION
## Summary
- ensure weather controller resets stable period counter when weather changes
- add caching and fallback selection for climate model weather transitions
- mark climate model season additions as changed and recalc caches

## Testing
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_689eea7bda348323a02b4dc41e27ab00