### PR TITLE
Enhance AGENTS guidelines across projects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ using (new FMDB())
    // Code accesses FMDB.Context static method only within this using block. 
 }
 
-- [Project FutureMUDDaabaseLibrary](./FutureMUDDatabaseLibrary/AGENTS.md)
+- [Project MudsharpDatabaseLibrary](./MudsharpDatabaseLibrary/AGENTS.md)
 
 ###ExpressionEngine Project
 
@@ -106,6 +106,8 @@ The discord bot is a bot designed to run alongside the engine to provide some di
 - Name classes, methods, and properties in **PascalCase**. Private fields use camelCase with a leading underscore.
 - Prefer `var` for local variables when the type is clear and favour early returns for validation.
 - Use string interpolation over string format functions were possible. Prefer verbatim strings over normal strings with special characters.
+- Enable nullable reference types (`#nullable enable`) in new files and annotate nullable references with `?`.
+- Prefer `async`/`await` for I/O-bound work and return `Task` or `Task<T>` rather than `void`.
 - Important helper methods are found in the FutureMUDLibrary project under the MudSharp.Framework namespace.
 - Use LINQ where possible unless you're being instructed to optimise a particular high-bottleneck section of code. Prefer to put your LINQ statements on separate lines for clarity and don't be afraid to break up logic into multiple steps (e.g. having multiple .Where calls rather than cramming all your logic into one lambda)
 - Interface-first design - if you're introducing a new feature get the interface first, implement the logic to work with the interface and then do the implementation last.

--- a/DatabaseSeeder/AGENTS.md
+++ b/DatabaseSeeder/AGENTS.md
@@ -7,12 +7,14 @@ It inherits from the [Solution-Level AGENTS.md](../AGENTS.md).
 - Precedence: **Module > Project > Solution**.
 
 ## Purpose of Project
-
-To be filled out
+Interactive installer that seeds initial database data and configuration for a new FutureMUD world.
 
 ## Key Architectural Principles
-
-To be filled out
+* Seed steps reside in the `Seeders/` folder and implement `IDatabaseSeeder`.
+* Seeders should be idempotent so they can be safely rerun.
+* Use `FuturemudDatabaseContext` for data access and dispose contexts with `using`.
+* Interactions occur via the console; keep prompts and output clear for users.
+* Register new seeders in `Program` so they are included in the workflow.
 
 ## Notes
 - All modules inherit both the solution-level and project-level rules unless explicitly overridden.

--- a/DiscordBotCore/AGENTS.md
+++ b/DiscordBotCore/AGENTS.md
@@ -9,12 +9,14 @@ It inherits from the [Solution-Level AGENTS.md](../AGENTS.md).
 * Precedence: **Module > Project > Solution**.
 
 ## Purpose of Project
-
-To be filled out
+Provides a standalone Discord bot that interacts with the FutureMUD engine via DSharpPlus.
 
 ## Key Architectural Principles
-
-To be filled out
+* `DiscordBot` is a singleton that manages the connection and any TCP bridges to the game server.
+* Commands and features live in the `Modules/` folder and use DSharpPlus CommandNext.
+* Operations should be asynchronous; avoid blocking the event loop.
+* Configuration is read from `DiscordBotSettings`; keep tokens and secrets out of source control.
+* Logging is handled through Serilog and `Microsoft.Extensions.Logging`.
 
 ## Notes
 

--- a/ExpressionEngine/AGENTS.md
+++ b/ExpressionEngine/AGENTS.md
@@ -9,12 +9,14 @@ It inherits from the [Solution-Level AGENTS.md](../AGENTS.md).
 * Precedence: **Module > Project > Solution**.
 
 ## Purpose of Project
-
-To be filled out
+Provides NCalc-based expression parsing and evaluation for user-supplied formulas used throughout the engine.
 
 ## Key Architectural Principles
-
-To be filled out
+* Exposes `IExpression` to abstract expression evaluation.
+* `Expression` wraps NCalc and adds custom functions such as `rand`, `drand`, `dice`, and `not`.
+* Parameters are passed via a dictionary; enums are converted to numeric values before evaluation.
+* Errors are logged and published through the `ExpressionError` event so callers can respond.
+* Random behaviour uses a shared `RandomInstance`; consider thread safety when extending functionality.
 
 ## Notes
 

--- a/FutureMUDLibrary/AGENTS.md
+++ b/FutureMUDLibrary/AGENTS.md
@@ -9,12 +9,14 @@ It inherits from the [Solution-Level AGENTS.md](../AGENTS.md).
 * Precedence: **Module > Project > Solution**.
 
 ## Purpose of Project
-
-To be filled out
+Provide shared interfaces, extension methods, and utility types used across multiple FutureMUD products. Code here is engine-agnostic so that other projects can implement or reuse these abstractions.
 
 ## Key Architectural Principles
-
-To be filled out
+* Keep the library free of concrete engine logic—only abstractions and helpers.
+* Interface definitions belong here; names start with `I` and live under the appropriate domain folder.
+* Extension methods are implemented as static classes alongside their related interfaces.
+* Avoid direct database or network access. Depend only on the standard library and other solution libraries.
+* Public APIs should remain stable to avoid breaking downstream projects.
 
 ## Notes
 

--- a/MudSharpCore Unit Tests/AGENTS.md
+++ b/MudSharpCore Unit Tests/AGENTS.md
@@ -9,12 +9,14 @@ It inherits from the [Solution-Level AGENTS.md](../AGENTS.md).
 * Precedence: **Module > Project > Solution**.
 
 ## Purpose of Project
-
-To be filled out
+Contains MSTest-based unit tests for MudSharpCore and shared utilities.
 
 ## Key Architectural Principles
-
-To be filled out
+* Use MSTest attributes `[TestClass]` and `[TestMethod]`.
+* Employ `Moq` or similar libraries for mocking dependencies.
+* Tests must be deterministic and avoid reliance on external state or ordering.
+* Mirror the namespace or module of the code under test for organisation.
+* Name test methods in the `Method_Scenario_ExpectedResult` format when practical.
 
 ## Notes
 

--- a/MudSharpCore/AGENTS.md
+++ b/MudSharpCore/AGENTS.md
@@ -9,12 +9,16 @@ It inherits from the [Solution-Level AGENTS.md](../AGENTS.md).
 * Precedence: **Module > Project > Solution**.
 
 ## Purpose of Project
-
-To be filled out
+Implements the core FutureMUD game engine and console server handling gameplay, networking, and runtime systems.
 
 ## Key Architectural Principles
-
-To be filled out
+* Code is organised by domain (Accounts, Body, Combat, etc.); place new features in the appropriate folder.
+* Implement interfaces from `FutureMUDLibrary`; create new interfaces there before adding concrete types here.
+* Access the database via the `FMDB` helper and wrap interactions in `using (new FMDB())` blocks.
+* Command implementations live under `Commands/` and integrate with the command tree framework.
+* Use partial classes to keep large classes manageable and to separate concerns.
+* Prefer asynchronous patterns for networking and long-running operations.
+* Use the engine's logging abstractions rather than `Console.WriteLine` for output.
 
 ## Notes
 

--- a/MudsharpDatabaseLibrary/AGENTS.md
+++ b/MudsharpDatabaseLibrary/AGENTS.md
@@ -9,12 +9,14 @@ It inherits from the [Solution-Level AGENTS.md](../AGENTS.md).
 * Precedence: **Module > Project > Solution**.
 
 ## Purpose of Project
-
-To be filled out
+Houses the Entity Framework Core `DbContext`, models, and migrations for the FutureMUD database.
 
 ## Key Architectural Principles
-
-To be filled out
+* Model classes map directly to database tables; avoid introducing game logic here.
+* Use partial classes to extend generated models without altering scaffolded code.
+* `FuturemudDatabaseContext` configures MySQL with lazy-loading proxies.
+* Migrations reside in the `Migrations/` folder and should be created via EF Core tooling.
+* Connection strings are provided at runtime—do not commit credentials.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- flesh out project-level AGENTS files with purpose and architectural notes
- tighten solution-level guidance with null-safety and async tips
- fix reference to MudsharpDatabaseLibrary

## Testing
- `scripts/setup.sh`
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68ad985fcb8c83238e184d4450382aad