### PR TITLE
Add builder commands for blood type editing

### DIFF
--- a/FutureMUDLibrary/Health/IBloodtype.cs
+++ b/FutureMUDLibrary/Health/IBloodtype.cs
@@ -1,16 +1,13 @@
-﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using MudSharp.Framework;
+using MudSharp.Framework.Revision;
 
-namespace MudSharp.Health
+namespace MudSharp.Health;
+
+public interface IBloodtype : IEditableItem
 {
-    public interface IBloodtype : IFrameworkItem
-    {
-        IEnumerable<IBloodtypeAntigen> Antigens { get; }
+    IEnumerable<IBloodtypeAntigen> Antigens { get; }
 
-        bool IsCompatibleWithDonorBlood(IBloodtype donorBloodtype);
-    }
+    bool IsCompatibleWithDonorBlood(IBloodtype donorBloodtype);
 }
+

--- a/FutureMUDLibrary/Health/IBloodtypeAntigen.cs
+++ b/FutureMUDLibrary/Health/IBloodtypeAntigen.cs
@@ -1,13 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using MudSharp.Framework;
+using MudSharp.Framework.Revision;
 
-namespace MudSharp.Health
+namespace MudSharp.Health;
+
+public interface IBloodtypeAntigen : IEditableItem
 {
-    public interface IBloodtypeAntigen : IFrameworkItem
-    {
-    }
 }
+

--- a/FutureMUDLibrary/Health/IPopulationBloodModel.cs
+++ b/FutureMUDLibrary/Health/IPopulationBloodModel.cs
@@ -1,17 +1,14 @@
-﻿using MudSharp.CharacterCreation;
-using MudSharp.Framework;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using MudSharp.CharacterCreation;
+using MudSharp.Framework;
+using MudSharp.Framework.Revision;
 
-namespace MudSharp.Health
+namespace MudSharp.Health;
+
+public interface IPopulationBloodModel : IEditableItem
 {
-	public interface IPopulationBloodModel : IFrameworkItem
-	{
-		IBloodtype GetBloodType(ICharacterTemplate character);
-		IEnumerable<(IBloodtype Bloodtype, double Weight)> BloodTypes { get; }
-		IBloodModel BloodModel {get;}
-	}
+    IBloodtype GetBloodType(ICharacterTemplate character);
+    IEnumerable<(IBloodtype Bloodtype, double Weight)> BloodTypes { get; }
+    IBloodModel? BloodModel { get; }
 }
+

--- a/MudSharpCore/Commands/Helpers/EditableItemHelperHealth.cs
+++ b/MudSharpCore/Commands/Helpers/EditableItemHelperHealth.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MudSharp.Commands.Modules;
+using MudSharp.Effects;
+using MudSharp.Effects.Concrete;
+using MudSharp.Framework;
+using MudSharp.Health;
+using MudSharp.Health.Bloodtypes;
+
+namespace MudSharp.Commands.Helpers;
+
+public partial class EditableItemHelper
+{
+    public static EditableItemHelper BloodtypeAntigenHelper { get; } = new()
+    {
+        ItemName = "Blood Antigen",
+        ItemNamePlural = "Blood Antigens",
+        SetEditableItemAction = (actor, item) =>
+        {
+            actor.RemoveAllEffects<BuilderEditingEffect<IBloodtypeAntigen>>();
+            if (item == null)
+            {
+                return;
+            }
+
+            actor.AddEffect(new BuilderEditingEffect<IBloodtypeAntigen>(actor) { EditingItem = (IBloodtypeAntigen)item });
+        },
+        GetEditableItemFunc = actor =>
+            actor.CombinedEffectsOfType<BuilderEditingEffect<IBloodtypeAntigen>>().FirstOrDefault()?.EditingItem,
+        GetAllEditableItems = actor => actor.Gameworld.BloodtypeAntigens.ToList(),
+        GetEditableItemByIdFunc = (actor, id) => actor.Gameworld.BloodtypeAntigens.Get(id),
+        GetEditableItemByIdOrNameFunc = (actor, input) => actor.Gameworld.BloodtypeAntigens.GetByIdOrName(input),
+        AddItemToGameWorldAction = item => item.Gameworld.Add((IBloodtypeAntigen)item),
+        CastToType = typeof(IBloodtypeAntigen),
+        EditableNewAction = (actor, input) =>
+        {
+            if (input.IsFinished)
+            {
+                actor.OutputHandler.Send("You must specify a name for the blood antigen.");
+                return;
+            }
+
+            var name = input.SafeRemainingArgument.TitleCase();
+            if (actor.Gameworld.BloodtypeAntigens.Any(x => x.Name.EqualTo(name)))
+            {
+                actor.OutputHandler.Send($"There is already a blood antigen called {name.ColourValue()}.");
+                return;
+            }
+
+            var antigen = new BloodtypeAntigen(actor.Gameworld, name);
+            actor.Gameworld.Add(antigen);
+            actor.RemoveAllEffects<BuilderEditingEffect<IBloodtypeAntigen>>();
+            actor.AddEffect(new BuilderEditingEffect<IBloodtypeAntigen>(actor) { EditingItem = antigen });
+            actor.OutputHandler.Send($"You create blood antigen #{antigen.Id.ToStringN0(actor)} ({antigen.Name.ColourName()}), which you are now editing.");
+        },
+        EditableCloneAction = null,
+        GetListTableHeaderFunc = character => new List<string>
+        {
+            "Id",
+            "Name"
+        },
+        GetListTableContentsFunc = (character, protos) => from proto in protos.OfType<IBloodtypeAntigen>()
+                                                          select new List<string>
+                                                          {
+                                                              proto.Id.ToString("N0", character),
+                                                              proto.Name
+                                                          },
+        CustomSearch = (protos, keyword, gameworld) => protos,
+        DefaultCommandHelp = BuilderModule.BloodAntigenHelpText,
+        GetEditHeader = item => $"Blood Antigen #{item.Id:N0} ({item.Name})"
+    };
+
+    public static EditableItemHelper BloodtypeHelper { get; } = new()
+    {
+        ItemName = "Blood Type",
+        ItemNamePlural = "Blood Types",
+        SetEditableItemAction = (actor, item) =>
+        {
+            actor.RemoveAllEffects<BuilderEditingEffect<IBloodtype>>();
+            if (item == null)
+            {
+                return;
+            }
+
+            actor.AddEffect(new BuilderEditingEffect<IBloodtype>(actor) { EditingItem = (IBloodtype)item });
+        },
+        GetEditableItemFunc = actor =>
+            actor.CombinedEffectsOfType<BuilderEditingEffect<IBloodtype>>().FirstOrDefault()?.EditingItem,
+        GetAllEditableItems = actor => actor.Gameworld.Bloodtypes.ToList(),
+        GetEditableItemByIdFunc = (actor, id) => actor.Gameworld.Bloodtypes.Get(id),
+        GetEditableItemByIdOrNameFunc = (actor, input) => actor.Gameworld.Bloodtypes.GetByIdOrName(input),
+        AddItemToGameWorldAction = item => item.Gameworld.Add((IBloodtype)item),
+        CastToType = typeof(IBloodtype),
+        EditableNewAction = (actor, input) =>
+        {
+            if (input.IsFinished)
+            {
+                actor.OutputHandler.Send("You must specify a name for the blood type.");
+                return;
+            }
+
+            var name = input.SafeRemainingArgument.TitleCase();
+            if (actor.Gameworld.Bloodtypes.Any(x => x.Name.EqualTo(name)))
+            {
+                actor.OutputHandler.Send($"There is already a blood type called {name.ColourValue()}.");
+                return;
+            }
+
+            var type = new Bloodtype(actor.Gameworld, name);
+            actor.Gameworld.Add(type);
+            actor.RemoveAllEffects<BuilderEditingEffect<IBloodtype>>();
+            actor.AddEffect(new BuilderEditingEffect<IBloodtype>(actor) { EditingItem = type });
+            actor.OutputHandler.Send($"You create blood type #{type.Id.ToStringN0(actor)} ({type.Name.ColourName()}), which you are now editing.");
+        },
+        EditableCloneAction = null,
+        GetListTableHeaderFunc = character => new List<string>
+        {
+            "Id",
+            "Name",
+            "Antigens"
+        },
+        GetListTableContentsFunc = (character, protos) => from proto in protos.OfType<IBloodtype>()
+                                                          select new List<string>
+                                                          {
+                                                              proto.Id.ToString("N0", character),
+                                                              proto.Name,
+                                                              proto.Antigens.Select(x => x.Name).ListToCommaSeparatedValues(", ")
+                                                          },
+        CustomSearch = (protos, keyword, gameworld) => protos,
+        DefaultCommandHelp = BuilderModule.BloodTypeHelpText,
+        GetEditHeader = item => $"Blood Type #{item.Id:N0} ({item.Name})"
+    };
+
+    public static EditableItemHelper PopulationBloodModelHelper { get; } = new()
+    {
+        ItemName = "Population Blood Model",
+        ItemNamePlural = "Population Blood Models",
+        SetEditableItemAction = (actor, item) =>
+        {
+            actor.RemoveAllEffects<BuilderEditingEffect<IPopulationBloodModel>>();
+            if (item == null)
+            {
+                return;
+            }
+
+            actor.AddEffect(new BuilderEditingEffect<IPopulationBloodModel>(actor) { EditingItem = (IPopulationBloodModel)item });
+        },
+        GetEditableItemFunc = actor =>
+            actor.CombinedEffectsOfType<BuilderEditingEffect<IPopulationBloodModel>>().FirstOrDefault()?.EditingItem,
+        GetAllEditableItems = actor => actor.Gameworld.PopulationBloodModels.ToList(),
+        GetEditableItemByIdFunc = (actor, id) => actor.Gameworld.PopulationBloodModels.Get(id),
+        GetEditableItemByIdOrNameFunc = (actor, input) => actor.Gameworld.PopulationBloodModels.GetByIdOrName(input),
+        AddItemToGameWorldAction = item => item.Gameworld.Add((IPopulationBloodModel)item),
+        CastToType = typeof(IPopulationBloodModel),
+        EditableNewAction = (actor, input) =>
+        {
+            if (input.IsFinished)
+            {
+                actor.OutputHandler.Send("You must specify a name for the population blood model.");
+                return;
+            }
+
+            var name = input.SafeRemainingArgument.TitleCase();
+            if (actor.Gameworld.PopulationBloodModels.Any(x => x.Name.EqualTo(name)))
+            {
+                actor.OutputHandler.Send($"There is already a population blood model called {name.ColourValue()}.");
+                return;
+            }
+
+            var model = new PopulationBloodModel(actor.Gameworld, name);
+            actor.Gameworld.Add(model);
+            actor.RemoveAllEffects<BuilderEditingEffect<IPopulationBloodModel>>();
+            actor.AddEffect(new BuilderEditingEffect<IPopulationBloodModel>(actor) { EditingItem = model });
+            actor.OutputHandler.Send($"You create population blood model #{model.Id.ToStringN0(actor)} ({model.Name.ColourName()}), which you are now editing.");
+        },
+        EditableCloneAction = null,
+        GetListTableHeaderFunc = character => new List<string>
+        {
+            "Id",
+            "Name",
+            "Blood Model",
+            "Blood Types"
+        },
+        GetListTableContentsFunc = (character, protos) => from proto in protos.OfType<IPopulationBloodModel>()
+                                                          let weight = proto.BloodTypes.Sum(x => x.Weight)
+                                                          select new List<string>
+                                                          {
+                                                              proto.Id.ToString("N0", character),
+                                                              proto.Name,
+                                                              proto.BloodModel?.Name ?? "None",
+                                                              proto.BloodTypes.OrderByDescending(x => x.Weight).Select(x => $"{x.Bloodtype.Name} ({(x.Weight / weight):P2})").ListToCommaSeparatedValues(", ")
+                                                          },
+        CustomSearch = (protos, keyword, gameworld) => protos,
+        DefaultCommandHelp = BuilderModule.PopulationBloodModelHelpText,
+        GetEditHeader = item => $"Population Blood Model #{item.Id:N0} ({item.Name})"
+    };
+}
+

--- a/MudSharpCore/Commands/Modules/BuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/BuilderModule.cs
@@ -4602,7 +4602,74 @@ The syntax is as follows:
 	}
 	#endregion
 
-	#region Drugs
+        #region Blood Types
+
+        public const string BloodAntigenHelpText = @"The #3bloodantigen#0 command is used to view, edit and create blood antigens.
+
+You can use the following syntax:
+
+#3bloodantigen list#0 - lists all of the blood antigens
+#3bloodantigen edit <which>#0 - begins editing a blood antigen
+#3bloodantigen edit new <name>#0 - creates a new blood antigen
+#3bloodantigen close#0 - stops editing a blood antigen
+#3bloodantigen show <which>#0 - views information about a blood antigen
+#3bloodantigen show#0 - views information about your currently editing blood antigen
+#3bloodantigen set name <name>#0 - renames this blood antigen";
+
+        [PlayerCommand("BloodAntigen", "bloodantigen", "bantigen")]
+        [CommandPermission(PermissionLevel.Admin)]
+        [HelpInfo("BloodAntigen", BloodAntigenHelpText, AutoHelp.HelpArgOrNoArg)]
+        protected static void BloodAntigen(ICharacter actor, string input)
+        {
+                GenericBuildingCommand(actor, new StringStack(input.RemoveFirstWord()), EditableItemHelper.BloodtypeAntigenHelper);
+        }
+
+        public const string BloodTypeHelpText = @"The #3bloodtype#0 command is used to view, edit and create blood types.
+
+The syntax is as follows:
+
+#3bloodtype list#0 - lists all of the blood types
+#3bloodtype edit <which>#0 - begins editing a blood type
+#3bloodtype edit new <name>#0 - creates a new blood type
+#3bloodtype close#0 - stops editing a blood type
+#3bloodtype show <which>#0 - views information about a blood type
+#3bloodtype show#0 - views information about your currently editing blood type
+#3bloodtype set name <name>#0 - renames this blood type
+#3bloodtype set antigen <antigen>#0 - toggles an antigen for this blood type";
+
+        [PlayerCommand("BloodType", "bloodtype")]
+        [CommandPermission(PermissionLevel.Admin)]
+        [HelpInfo("BloodType", BloodTypeHelpText, AutoHelp.HelpArgOrNoArg)]
+        protected static void BloodType(ICharacter actor, string input)
+        {
+                GenericBuildingCommand(actor, new StringStack(input.RemoveFirstWord()), EditableItemHelper.BloodtypeHelper);
+        }
+
+        public const string PopulationBloodModelHelpText = @"The #3popbloodmodel#0 command is used to view, edit and create population blood models.
+
+The syntax is as follows:
+
+#3popbloodmodel list#0 - lists all of the population blood models
+#3popbloodmodel edit <which>#0 - begins editing a population blood model
+#3popbloodmodel edit new <name>#0 - creates a new population blood model
+#3popbloodmodel close#0 - stops editing a population blood model
+#3popbloodmodel show <which>#0 - views information about a population blood model
+#3popbloodmodel show#0 - views information about your currently editing population blood model
+#3popbloodmodel set name <name>#0 - renames this model
+#3popbloodmodel set type <bloodtype> <weight>#0 - adds or sets a blood type with a weight
+#3popbloodmodel set remove <bloodtype>#0 - removes a blood type from this model";
+
+        [PlayerCommand("PopBloodModel", "popbloodmodel", "pbloodmodel")]
+        [CommandPermission(PermissionLevel.Admin)]
+        [HelpInfo("PopBloodModel", PopulationBloodModelHelpText, AutoHelp.HelpArgOrNoArg)]
+        protected static void PopBloodModel(ICharacter actor, string input)
+        {
+                GenericBuildingCommand(actor, new StringStack(input.RemoveFirstWord()), EditableItemHelper.PopulationBloodModelHelper);
+        }
+
+        #endregion
+
+        #region Drugs
 
 	public const string DrugsHelp = @"The #3drug#0 command is used to view, edit and create drugs. Drugs can be added to food, liquid and attacks.
 

--- a/MudSharpCore/Health/Bloodtypes/Bloodtype.cs
+++ b/MudSharpCore/Health/Bloodtypes/Bloodtype.cs
@@ -1,37 +1,142 @@
-﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
+using MudSharp.Character;
+using MudSharp.Database;
 using MudSharp.Framework;
+using MudSharp.Framework.Save;
+using MudSharp.PerceptionEngine;
 
 namespace MudSharp.Health.Bloodtypes;
 
-public class Bloodtype : FrameworkItem, IBloodtype
+#nullable enable
+public class Bloodtype : SaveableItem, IBloodtype
 {
-	public Bloodtype(MudSharp.Models.Bloodtype dbitem, IFuturemud gameworld)
-	{
-		_id = dbitem.Id;
-		_name = dbitem.Name;
-		_antigens.AddRange(gameworld.BloodtypeAntigens.Where(x =>
-			dbitem.BloodtypesBloodtypeAntigens.Any(y => y.BloodtypeAntigenId == x.Id)));
-	}
+    public Bloodtype(MudSharp.Models.Bloodtype dbitem, IFuturemud gameworld)
+    {
+        Gameworld = gameworld;
+        _id = dbitem.Id;
+        _name = dbitem.Name;
+        _antigens.AddRange(gameworld.BloodtypeAntigens.Where(x =>
+            dbitem.BloodtypesBloodtypeAntigens.Any(y => y.BloodtypeAntigenId == x.Id)));
+    }
 
-	#region Overrides of Item
+    public Bloodtype(IFuturemud gameworld, string name)
+    {
+        Gameworld = gameworld;
+        _name = name;
+        using (new FMDB())
+        {
+            var dbitem = new MudSharp.Models.Bloodtype { Name = name };
+            FMDB.Context.Bloodtypes.Add(dbitem);
+            FMDB.Context.SaveChanges();
+            _id = dbitem.Id;
+        }
+    }
 
-	public override string FrameworkItemType => "Bloodtype";
+    public override string FrameworkItemType => "Bloodtype";
 
-	#endregion
+    public override void Save()
+    {
+        var dbitem = FMDB.Context.Bloodtypes.Find(Id);
+        dbitem.Name = Name;
+        FMDB.Context.BloodtypesBloodtypeAntigens.RemoveRange(dbitem.BloodtypesBloodtypeAntigens);
+        foreach (var antigen in _antigens)
+        {
+            dbitem.BloodtypesBloodtypeAntigens.Add(new MudSharp.Models.BloodtypesBloodtypeAntigens
+            {
+                BloodtypeId = Id,
+                BloodtypeAntigenId = antigen.Id
+            });
+        }
 
-	#region Implementation of IBloodtype
+        Changed = false;
+    }
 
-	private readonly List<IBloodtypeAntigen> _antigens = new();
-	public IEnumerable<IBloodtypeAntigen> Antigens => _antigens;
+    private readonly List<IBloodtypeAntigen> _antigens = new();
+    public IEnumerable<IBloodtypeAntigen> Antigens => _antigens;
 
-	public bool IsCompatibleWithDonorBlood(IBloodtype donorBloodtype)
-	{
-		return donorBloodtype.Antigens.All(x => Antigens.Contains(x));
-	}
+    public bool IsCompatibleWithDonorBlood(IBloodtype donorBloodtype) =>
+        donorBloodtype.Antigens.All(x => _antigens.Contains(x));
 
-	#endregion
+    public const string HelpText = @"You can use the following options with this command:
+
+name <name> - renames this blood type
+antigen <antigen> - toggles an antigen for this blood type";
+
+    public bool BuildingCommand(ICharacter actor, StringStack command)
+    {
+        switch (command.PopForSwitch())
+        {
+            case "name":
+                return BuildingCommandName(actor, command);
+            case "antigen":
+            case "ant":
+                return BuildingCommandAntigen(actor, command);
+        }
+
+        actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
+        return false;
+    }
+
+    private bool BuildingCommandName(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("What new name should this blood type have?");
+            return false;
+        }
+
+        var name = command.SafeRemainingArgument.TitleCase();
+        if (Gameworld.Bloodtypes.Any(x => x.Name.EqualTo(name)))
+        {
+            actor.OutputHandler.Send($"There is already a blood type named {name.ColourName()}.");
+            return false;
+        }
+
+        _name = name;
+        Changed = true;
+        actor.OutputHandler.Send($"This blood type is now called {name.ColourName()}.");
+        return true;
+    }
+
+    private bool BuildingCommandAntigen(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which antigen do you want to toggle?");
+            return false;
+        }
+
+        var antigen = Gameworld.BloodtypeAntigens.GetByIdOrName(command.SafeRemainingArgument);
+        if (antigen is null)
+        {
+            actor.OutputHandler.Send($"There is no blood antigen identified by {command.SafeRemainingArgument.ColourCommand()}.");
+            return false;
+        }
+
+        if (_antigens.Contains(antigen))
+        {
+            _antigens.Remove(antigen);
+            actor.OutputHandler.Send($"This blood type no longer has the {antigen.Name.ColourName()} antigen.");
+        }
+        else
+        {
+            _antigens.Add(antigen);
+            actor.OutputHandler.Send($"This blood type now has the {antigen.Name.ColourName()} antigen.");
+        }
+
+        Changed = true;
+        return true;
+    }
+
+    public string Show(ICharacter actor)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Blood Type #{Id.ToStringN0(actor)} - {Name}".GetLineWithTitleInner(actor, Telnet.Cyan, Telnet.BoldWhite));
+        sb.AppendLine();
+        sb.AppendLine($"Antigens: {_antigens.Select(x => x.Name.ColourValue()).ListToString()}");
+        return sb.ToString();
+    }
 }
+

--- a/MudSharpCore/Health/Bloodtypes/BloodtypeAntigen.cs
+++ b/MudSharpCore/Health/Bloodtypes/BloodtypeAntigen.cs
@@ -1,23 +1,87 @@
-﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
+using MudSharp.Character;
+using MudSharp.Database;
 using MudSharp.Framework;
+using MudSharp.Framework.Save;
+using MudSharp.PerceptionEngine;
 
 namespace MudSharp.Health.Bloodtypes;
 
-public class BloodtypeAntigen : FrameworkItem, IBloodtypeAntigen
+#nullable enable
+public class BloodtypeAntigen : SaveableItem, IBloodtypeAntigen
 {
-	public BloodtypeAntigen(MudSharp.Models.BloodtypeAntigen dbitem, IFuturemud gameworld)
-	{
-		_id = dbitem.Id;
-		_name = dbitem.Name;
-	}
+    public BloodtypeAntigen(MudSharp.Models.BloodtypeAntigen dbitem, IFuturemud gameworld)
+    {
+        Gameworld = gameworld;
+        _id = dbitem.Id;
+        _name = dbitem.Name;
+    }
 
-	#region Overrides of Item
+    public BloodtypeAntigen(IFuturemud gameworld, string name)
+    {
+        Gameworld = gameworld;
+        _name = name;
+        using (new FMDB())
+        {
+            var dbitem = new MudSharp.Models.BloodtypeAntigen { Name = name };
+            FMDB.Context.BloodtypeAntigens.Add(dbitem);
+            FMDB.Context.SaveChanges();
+            _id = dbitem.Id;
+        }
+    }
 
-	public override string FrameworkItemType => "BloodtypeAntigen";
+    public override string FrameworkItemType => "BloodtypeAntigen";
 
-	#endregion
+    public override void Save()
+    {
+        var dbitem = FMDB.Context.BloodtypeAntigens.Find(Id);
+        dbitem.Name = Name;
+        Changed = false;
+    }
+
+    public const string HelpText = @"You can use the following options with this command:
+
+name <name> - renames this blood antigen";
+
+    public bool BuildingCommand(ICharacter actor, StringStack command)
+    {
+        switch (command.PopForSwitch())
+        {
+            case "name":
+                return BuildingCommandName(actor, command);
+        }
+
+        actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
+        return false;
+    }
+
+    private bool BuildingCommandName(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("What new name should this blood antigen have?");
+            return false;
+        }
+
+        var name = command.SafeRemainingArgument.TitleCase();
+        if (Gameworld.BloodtypeAntigens.Any(x => x.Name.EqualTo(name)))
+        {
+            actor.OutputHandler.Send($"There is already a blood antigen named {name.ColourName()}.");
+            return false;
+        }
+
+        _name = name;
+        Changed = true;
+        actor.OutputHandler.Send($"This blood antigen is now called {name.ColourName()}.");
+        return true;
+    }
+
+    public string Show(ICharacter actor)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Blood Antigen #{Id.ToStringN0(actor)} - {Name}".GetLineWithTitleInner(actor, Telnet.Cyan, Telnet.BoldWhite));
+        return sb.ToString();
+    }
 }
+

--- a/MudSharpCore/Health/Bloodtypes/PopulationBloodModel.cs
+++ b/MudSharpCore/Health/Bloodtypes/PopulationBloodModel.cs
@@ -1,47 +1,216 @@
-﻿using MudSharp.CharacterCreation;
-using MudSharp.Framework;
-using MudSharp.RPG.Merits.Interfaces;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
+using MudSharp.Character;
+using MudSharp.CharacterCreation;
+using MudSharp.Database;
+using MudSharp.Framework;
+using MudSharp.Framework.Save;
+using MudSharp.PerceptionEngine;
+using MudSharp.RPG.Merits.Interfaces;
 
 namespace MudSharp.Health.Bloodtypes;
 
-public class PopulationBloodModel : FrameworkItem, IPopulationBloodModel
+#nullable enable
+public class PopulationBloodModel : SaveableItem, IPopulationBloodModel
 {
-	public PopulationBloodModel(MudSharp.Models.PopulationBloodModel model, IFuturemud gameworld)
-	{
-		_id = model.Id;
-		_name = model.Name;
-		foreach (var type in model.PopulationBloodModelsBloodtypes)
-		{
-			_bloodTypes.Add((gameworld.Bloodtypes.Get(type.BloodtypeId), type.Weight));
-		}
+    private readonly List<(IBloodtype Bloodtype, double Weight)> _bloodTypes = new();
 
-		BloodModel = gameworld.BloodModels.First(x => x.Bloodtypes.Any(y => _bloodTypes.Any(z => z.Bloodtype == y)));
-	}
+    public PopulationBloodModel(MudSharp.Models.PopulationBloodModel model, IFuturemud gameworld)
+    {
+        Gameworld = gameworld;
+        _id = model.Id;
+        _name = model.Name;
+        foreach (var type in model.PopulationBloodModelsBloodtypes)
+        {
+            _bloodTypes.Add((gameworld.Bloodtypes.Get(type.BloodtypeId), type.Weight));
+        }
 
-	private readonly List<(IBloodtype Bloodtype, double Weight)> _bloodTypes = new();
+        if (_bloodTypes.Any())
+        {
+            BloodModel = gameworld.BloodModels.First(x => x.Bloodtypes.Any(y => _bloodTypes.Any(z => z.Bloodtype == y)));
+        }
+    }
 
-	public IEnumerable<(IBloodtype Bloodtype, double Weight)> BloodTypes => _bloodTypes;
+    public PopulationBloodModel(IFuturemud gameworld, string name)
+    {
+        Gameworld = gameworld;
+        _name = name;
+        using (new FMDB())
+        {
+            var dbitem = new MudSharp.Models.PopulationBloodModel { Name = name };
+            FMDB.Context.PopulationBloodModels.Add(dbitem);
+            FMDB.Context.SaveChanges();
+            _id = dbitem.Id;
+        }
+    }
 
-	public IBloodModel BloodModel { get; }
+    public override string FrameworkItemType => "PopulationBloodModel";
 
-	public IBloodtype GetBloodType(ICharacterTemplate character)
-	{
-		if (character?.SelectedMerits.OfType<IFixedBloodTypeMerit>().Any() == true)
-		{
-			var bloodtype = character.SelectedMerits.OfType<IFixedBloodTypeMerit>().First().Bloodtype;
-			if (_bloodTypes.Any(x => x.Bloodtype == bloodtype))
-			{
-				return bloodtype;
-			}
-		}
+    public override void Save()
+    {
+        var dbitem = FMDB.Context.PopulationBloodModels.Find(Id);
+        dbitem.Name = Name;
+        FMDB.Context.PopulationBloodModelsBloodtypes.RemoveRange(dbitem.PopulationBloodModelsBloodtypes);
+        foreach (var (bloodtype, weight) in _bloodTypes)
+        {
+            dbitem.PopulationBloodModelsBloodtypes.Add(new MudSharp.Models.PopulationBloodModelsBloodtype
+            {
+                PopulationBloodModelId = Id,
+                BloodtypeId = bloodtype.Id,
+                Weight = weight
+            });
+        }
 
-		return _bloodTypes.GetWeightedRandom(x => x.Weight).Bloodtype;
-	}
+        Changed = false;
+    }
 
-	public override string FrameworkItemType => "PopulationBloodModel";
+    public IEnumerable<(IBloodtype Bloodtype, double Weight)> BloodTypes => _bloodTypes;
+
+    public IBloodModel? BloodModel { get; private set; }
+
+    public IBloodtype GetBloodType(ICharacterTemplate character)
+    {
+        if (character?.SelectedMerits.OfType<IFixedBloodTypeMerit>().Any() == true)
+        {
+            var bloodtype = character.SelectedMerits.OfType<IFixedBloodTypeMerit>().First().Bloodtype;
+            if (_bloodTypes.Any(x => x.Bloodtype == bloodtype))
+            {
+                return bloodtype;
+            }
+        }
+
+        return _bloodTypes.GetWeightedRandom(x => x.Weight).Bloodtype;
+    }
+
+    public const string HelpText = @"You can use the following options with this command:
+
+name <name> - renames this population blood model
+type <bloodtype> <weight> - adds or sets a blood type with a relative weight
+remove <bloodtype> - removes a blood type from this model";
+
+    public bool BuildingCommand(ICharacter actor, StringStack command)
+    {
+        switch (command.PopForSwitch())
+        {
+            case "name":
+                return BuildingCommandName(actor, command);
+            case "type":
+            case "bloodtype":
+                return BuildingCommandType(actor, command);
+            case "remove":
+            case "delete":
+                return BuildingCommandRemove(actor, command);
+        }
+
+        actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
+        return false;
+    }
+
+    private bool BuildingCommandName(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("What new name should this population blood model have?");
+            return false;
+        }
+
+        var name = command.SafeRemainingArgument.TitleCase();
+        if (Gameworld.PopulationBloodModels.Any(x => x.Name.EqualTo(name)))
+        {
+            actor.OutputHandler.Send($"There is already a population blood model named {name.ColourName()}.");
+            return false;
+        }
+
+        _name = name;
+        Changed = true;
+        actor.OutputHandler.Send($"This population blood model is now called {name.ColourName()}.");
+        return true;
+    }
+
+    private bool BuildingCommandType(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which blood type and weight?");
+            return false;
+        }
+
+        var bt = Gameworld.Bloodtypes.GetByIdOrName(command.PopSpeech());
+        if (bt is null)
+        {
+            actor.OutputHandler.Send("That is not a valid blood type.");
+            return false;
+        }
+
+        if (command.IsFinished || !double.TryParse(command.SafeRemainingArgument, out var weight) || weight <= 0)
+        {
+            actor.OutputHandler.Send("You must supply a positive weight.");
+            return false;
+        }
+
+        if (BloodModel is null)
+        {
+            BloodModel = Gameworld.BloodModels.First(x => x.Bloodtypes.Contains(bt));
+        }
+        else if (!BloodModel.Bloodtypes.Contains(bt))
+        {
+            actor.OutputHandler.Send("That blood type does not belong to this model's blood model.");
+            return false;
+        }
+
+        _bloodTypes.RemoveAll(x => x.Bloodtype == bt);
+        _bloodTypes.Add((bt, weight));
+        Changed = true;
+        actor.OutputHandler.Send($"This model now has {bt.Name.ColourValue()} with weight {weight.ToStringN2Colour(actor)}.");
+        return true;
+    }
+
+    private bool BuildingCommandRemove(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which blood type should be removed?");
+            return false;
+        }
+
+        var bt = Gameworld.Bloodtypes.GetByIdOrName(command.SafeRemainingArgument);
+        if (bt is null)
+        {
+            actor.OutputHandler.Send("That is not a valid blood type.");
+            return false;
+        }
+
+        var removed = _bloodTypes.RemoveAll(x => x.Bloodtype == bt);
+        if (removed == 0)
+        {
+            actor.OutputHandler.Send("That blood type is not part of this model.");
+            return false;
+        }
+
+        Changed = true;
+        if (_bloodTypes.Count == 0)
+        {
+            BloodModel = null;
+        }
+
+        actor.OutputHandler.Send($"This model no longer includes {bt.Name.ColourValue()}.");
+        return true;
+    }
+
+    public string Show(ICharacter actor)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Population Blood Model #{Id.ToStringN0(actor)} - {Name}".GetLineWithTitleInner(actor, Telnet.Cyan, Telnet.BoldWhite));
+        sb.AppendLine();
+        sb.AppendLine($"Blood Model: {BloodModel?.Name.ColourValue() ?? "None"}");
+        var total = _bloodTypes.Sum(x => x.Weight);
+        foreach (var (blood, weight) in _bloodTypes.OrderByDescending(x => x.Weight))
+        {
+            sb.AppendLine($"{blood.Name.ColourValue(),-20} {(weight / total).ToStringP2Colour(actor)}");
+        }
+
+        return sb.ToString();
+    }
 }
+


### PR DESCRIPTION
## Summary
- make blood type interfaces editable and add save/show operations
- add building logic and constructors for blood antigens, blood types, and population blood models
- provide builder helpers and commands for managing blood typing data

## Testing
- `scripts/setup.sh`
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68aff54c32708323bd21e2ee0796a6a5