### PR TITLE
Enable clock editing commands

### DIFF
--- a/FutureMUDLibrary/TimeAndDate/Time/IClock.cs
+++ b/FutureMUDLibrary/TimeAndDate/Time/IClock.cs
@@ -7,65 +7,66 @@ using MudSharp.FutureProg;
 namespace MudSharp.TimeAndDate.Time
 {
     /// <summary>
-    ///     Controls the behaviour of Display Time function
+    ///	    Controls the behaviour of Display Time function
     /// </summary>
     public enum TimeDisplayTypes {
-        Short,
-        Long,
-        Immortal,
-        Vague,
-        Crude
+	Short,
+	Long,
+	Immortal,
+	Vague,
+	Crude
     }
 
     public delegate void ClockEventHandler();
 
     public delegate void ClockAdvanceDaysEventHandler(int arg);
 
-    public interface IClock : IHaveMultipleNames, IXmlSavable, IXmlLoadable, IProgVariable, ISaveable
+    public interface IClock : IHaveMultipleNames, IXmlSavable, IXmlLoadable, IProgVariable, ISaveable, IEditableItem
     {
-        event ClockEventHandler SecondsUpdated;
-        event ClockEventHandler MinutesUpdated;
-        event ClockEventHandler HoursUpdated;
-        event ClockAdvanceDaysEventHandler DaysUpdated;
-        string Alias { get; }
-        string Description { get; }
-        int SecondsPerMinute { get; }
-        int MinutesPerHour { get; }
-        int HoursPerDay { get; }
-        double InGameSecondsPerRealSecond { get; }
-        int HourFixedDigits { get; }
-        int MinuteFixedDigits { get; }
-        int SecondFixedDigits { get; }
-        string ShortDisplayString { get; }
-        string LongDisplayString { get; }
-        string SuperDisplayString { get; }
-        int NumberOfHourIntervals { get; }
-        List<string> HourIntervalNames { get; }
-        List<string> HourIntervalLongNames { get; }
-        bool NoZeroHour { get; }
-        MudTime CurrentTime { get; }
-        IUneditableAll<IMudTimeZone> Timezones { get; }
-        IMudTimeZone PrimaryTimezone { get; }
-        void UpdateSeconds();
-        void UpdateMinutes();
-        void UpdateHours();
-        void AdvanceDays(int days);
-        void AddTimezone(IMudTimeZone timezone);
+	event ClockEventHandler SecondsUpdated;
+	event ClockEventHandler MinutesUpdated;
+	event ClockEventHandler HoursUpdated;
+	event ClockAdvanceDaysEventHandler DaysUpdated;
+	string Alias { get; }
+	string Description { get; }
+	int SecondsPerMinute { get; }
+	int MinutesPerHour { get; }
+	int HoursPerDay { get; }
+	double InGameSecondsPerRealSecond { get; }
+	int HourFixedDigits { get; }
+	int MinuteFixedDigits { get; }
+	int SecondFixedDigits { get; }
+	string ShortDisplayString { get; }
+	string LongDisplayString { get; }
+	string SuperDisplayString { get; }
+	int NumberOfHourIntervals { get; }
+	List<string> HourIntervalNames { get; }
+	List<string> HourIntervalLongNames { get; }
+	bool NoZeroHour { get; }
+	MudTime CurrentTime { get; }
+	IUneditableAll<IMudTimeZone> Timezones { get; }
+	IMudTimeZone PrimaryTimezone { get; }
+	void UpdateSeconds();
+	void UpdateMinutes();
+	void UpdateHours();
+	void AdvanceDays(int days);
+	void AddTimezone(IMudTimeZone timezone);
 
-        /// <summary>
-        ///     Some examples of Display times and their expected outputs:
-        ///     "$h$m hours" - 1630 hours
-        ///     "$j:$m$i" - 4:30pm
-        ///     "$c $l" - half past four in the afternoon
-        /// </summary>
-        /// <param name="theTime"></param>
-        /// <param name="brief"></param>
-        /// <returns></returns>
-        string DisplayTime(MudTime theTime, string timeString);
+	/// <summary>
+	///	Some examples of Display times and their expected outputs:
+	///	"$h$m hours" - 1630 hours
+	///	"$j:$m$i" - 4:30pm
+	///	"$c $l" - half past four in the afternoon
+	/// </summary>
+	/// <param name="theTime"></param>
+	/// <param name="brief"></param>
+	/// <returns></returns>
+	string DisplayTime(MudTime theTime, string timeString);
 
-        string DisplayTime(MudTime theTime, TimeDisplayTypes type);
-        string DisplayTime(TimeDisplayTypes type);
-        MudTime GetTime(string timeString);
-        void SetTime(MudTime time);
+	string DisplayTime(MudTime theTime, TimeDisplayTypes type);
+	string DisplayTime(TimeDisplayTypes type);
+	MudTime GetTime(string timeString);
+	void SetTime(MudTime time);
+	IClock Clone(string name, string alias);
     }
 }

--- a/MudSharpCore/Commands/Helpers/EditableItemHelperTime.cs
+++ b/MudSharpCore/Commands/Helpers/EditableItemHelperTime.cs
@@ -1,0 +1,124 @@
+using System.Collections.Generic;
+using System.Linq;
+using MudSharp.Character;
+using MudSharp.Commands.Modules;
+using MudSharp.Effects.Concrete;
+using MudSharp.Framework;
+using MudSharp.TimeAndDate.Time;
+
+namespace MudSharp.Commands.Helpers;
+
+public partial class EditableItemHelper
+{
+	public static EditableItemHelper ClockHelper { get; } = new()
+	{
+		ItemName = "Clock",
+		ItemNamePlural = "Clocks",
+		SetEditableItemAction = (actor, item) =>
+		{
+			actor.RemoveAllEffects<BuilderEditingEffect<IClock>>();
+			if (item == null)
+			{
+				return;
+			}
+
+			actor.AddEffect(new BuilderEditingEffect<IClock>(actor) { EditingItem = (IClock)item });
+		},
+		GetEditableItemFunc = actor =>
+			actor.CombinedEffectsOfType<BuilderEditingEffect<IClock>>().FirstOrDefault()?.EditingItem,
+		GetAllEditableItems = actor => actor.Gameworld.Clocks.ToList(),
+		GetEditableItemByIdFunc = (actor, id) => actor.Gameworld.Clocks.Get(id),
+		GetEditableItemByIdOrNameFunc = (actor, input) => actor.Gameworld.Clocks.GetByIdOrNames(input),
+		AddItemToGameWorldAction = item => item.Gameworld.Add((IClock)item),
+		CastToType = typeof(IClock),
+		EditableNewAction = (actor, input) =>
+		{
+			var alias = input.PopSpeech();
+			if (string.IsNullOrEmpty(alias))
+			{
+				actor.OutputHandler.Send("You must specify an alias for the clock.");
+				return;
+			}
+
+			if (actor.Gameworld.Clocks.Any(x => x.Alias.EqualTo(alias)))
+			{
+				actor.OutputHandler.Send($"There is already a clock with the alias {alias.ColourValue()}.");
+				return;
+			}
+
+			if (input.IsFinished)
+			{
+				actor.OutputHandler.Send("You must specify a name for the clock.");
+				return;
+			}
+
+			var name = input.SafeRemainingArgument.TitleCase();
+			var clock = new Clock(actor.Gameworld, name, alias);
+			actor.Gameworld.Add(clock);
+			actor.RemoveAllEffects<BuilderEditingEffect<IClock>>();
+			actor.AddEffect(new BuilderEditingEffect<IClock>(actor) { EditingItem = clock });
+			actor.OutputHandler.Send($"You create clock #{clock.Id.ToStringN0(actor)} ({clock.Name.ColourName()}), which you are now editing.");
+		},
+		EditableCloneAction = (actor, input) =>
+		{
+			if (input.IsFinished)
+			{
+				actor.OutputHandler.Send("Which clock do you want to clone?");
+				return;
+			}
+
+			var original = actor.Gameworld.Clocks.GetByIdOrNames(input.PopSpeech());
+			if (original is null)
+			{
+				actor.OutputHandler.Send("There is no such clock to clone.");
+				return;
+			}
+
+			var alias = input.PopSpeech();
+			if (string.IsNullOrEmpty(alias))
+			{
+				actor.OutputHandler.Send("You must specify an alias for the cloned clock.");
+				return;
+			}
+
+			if (actor.Gameworld.Clocks.Any(x => x.Alias.EqualTo(alias)))
+			{
+				actor.OutputHandler.Send($"There is already a clock with the alias {alias.ColourValue()}.");
+				return;
+			}
+
+			if (input.IsFinished)
+			{
+				actor.OutputHandler.Send("You must specify a name for the cloned clock.");
+				return;
+			}
+
+			var name = input.SafeRemainingArgument.TitleCase();
+			var clone = original.Clone(name, alias);
+			actor.Gameworld.Add(clone);
+			actor.RemoveAllEffects<BuilderEditingEffect<IClock>>();
+			actor.AddEffect(new BuilderEditingEffect<IClock>(actor) { EditingItem = clone });
+			actor.OutputHandler.Send($"You clone clock {original.Name.ColourName()} to new clock #{clone.Id.ToStringN0(actor)} ({clone.Name.ColourName()}), which you are now editing.");
+		},
+		GetListTableHeaderFunc = character => new List<string>
+		{
+			"Id",
+			"Alias",
+			"Name",
+			"Primary TZ",
+			"Current Time"
+		},
+		GetListTableContentsFunc = (character, items) => from clock in items.OfType<IClock>()
+								select new List<string>
+								{
+									clock.Id.ToString("N0", character),
+									clock.Alias,
+									clock.Name,
+									clock.PrimaryTimezone?.Alias ?? string.Empty,
+									clock.DisplayTime(clock.CurrentTime, TimeDisplayTypes.Immortal)
+								},
+		DefaultCommandHelp = RoomBuilderModule.ClockHelpText,
+		GetEditHeader = item => $"Clock #{item.Id:N0} ({item.Name})"
+	};
+}
+

--- a/MudSharpCore/Commands/Modules/RoomBuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/RoomBuilderModule.cs
@@ -669,7 +669,7 @@ Enter your text below:");
 		var overlay = actor.Location.GetOrCreateOverlay(actor.CurrentOverlayPackage);
 		if (
 			actor.Gameworld.ExitManager.GetExitsFor(actor.Location, overlay)
-				 .Any(x => x.OutboundDirection == direction))
+				.Any(x => x.OutboundDirection == direction))
 		{
 			actor.OutputHandler.Send("This Cell Overlay already contains an exit in that direction.");
 			return;
@@ -710,8 +710,8 @@ Enter your text below:");
 		if (!match.Success)
 		{
 			actor.OutputHandler.Send("You must supply an argument in this form: " +
-									 "cell ndig <template> <outbound keyword> <inbound keyword> \"<outbound name>\" \"<inbound name>\""
-										 .Colour(Telnet.Yellow));
+									"cell ndig <template> <outbound keyword> <inbound keyword> \"<outbound name>\" \"<inbound name>\""
+										.Colour(Telnet.Yellow));
 			return;
 		}
 
@@ -998,7 +998,7 @@ Possible filter options include:
 					rooms = rooms.Where(x =>
 						x.HowSeen(actor, colour: false).Contains(arg1, StringComparison.InvariantCultureIgnoreCase) ||
 						x.HowSeen(actor, colour: false, type: DescriptionType.Full)
-						 .Contains(arg1, StringComparison.InvariantCultureIgnoreCase)
+						.Contains(arg1, StringComparison.InvariantCultureIgnoreCase)
 					);
 					filterDescs.Add($"containing keyword {arg1.ColourCommand()}");
 					continue;
@@ -1012,7 +1012,7 @@ Possible filter options include:
 					rooms = rooms.Where(x =>
 						!x.HowSeen(actor, colour: false).Contains(arg1, StringComparison.InvariantCultureIgnoreCase) &&
 						!x.HowSeen(actor, colour: false, type: DescriptionType.Full)
-						  .Contains(arg1, StringComparison.InvariantCultureIgnoreCase)
+						.Contains(arg1, StringComparison.InvariantCultureIgnoreCase)
 					);
 					filterDescs.Add($"excluding keyword {arg1.ColourCommand()}");
 					continue;
@@ -1286,9 +1286,9 @@ See the #3CELL#0 command for more information about #3CELL PACKAGES#0.";
 		var clock = long.TryParse(clockText, out var value)
 			? actor.Gameworld.Clocks.Get(value)
 			: actor.Gameworld.Clocks.FirstOrDefault(
-				  x => x.Alias.Equals(clockText, StringComparison.InvariantCultureIgnoreCase)) ??
-			  actor.Gameworld.Clocks.FirstOrDefault(
-				  x => x.Description.Equals(clockText, StringComparison.InvariantCultureIgnoreCase));
+				x => x.Alias.Equals(clockText, StringComparison.InvariantCultureIgnoreCase)) ??
+			actor.Gameworld.Clocks.FirstOrDefault(
+				x => x.Description.Equals(clockText, StringComparison.InvariantCultureIgnoreCase));
 		if (clock == null)
 		{
 			actor.Send("There is no such clock.");
@@ -1626,7 +1626,27 @@ See the #3CELL#0 command for more information about #3CELL PACKAGES#0.";
 
 
 
-	public const string TimeZoneHelp = @"This command is used to create and edit in-game timezones for a particular clock. Timezones are relative to a standard default timezone for that clock - a real world example would be UTC.
+	public const string ClockHelpText = @"This command is used to create and edit in-game clocks.
+
+The syntax for this command is as follows:
+
+#3clock list#0 - lists all of the clocks
+#3clock new <alias> ""<name>""#0 - creates a new clock
+#3clock edit <which>#0 - begins editing a clock
+#3clock clone <old> <alias> ""<name>""#0 - clones a clock
+#3clock close#0 - stops editing a clock
+#3clock show <which>#0 - shows information about a clock
+#3clock show#0 - shows information about the currently edited clock";
+
+       [PlayerCommand("Clock", "clock")]
+       [CommandPermission(PermissionLevel.HighAdmin)]
+       [HelpInfo("clock", ClockHelpText, AutoHelp.HelpArgOrNoArg)]
+       protected static void Clock(ICharacter actor, string input)
+       {
+BaseBuilderModule.GenericBuildingCommand(actor, new StringStack(input.RemoveFirstWord()), EditableItemHelper.ClockHelper);
+}
+
+public const string TimeZoneHelp = @"This command is used to create and edit in-game timezones for a particular clock. Timezones are relative to a standard default timezone for that clock - a real world example would be UTC.
 
 The syntax for this command is as follows:
 
@@ -1965,7 +1985,7 @@ You can use the following subcommands:
 				break;
 			default:
 				actor.OutputHandler.Send("That is not a valid option for the " + "cell edit".Colour(Telnet.Cyan) +
-										 " command.");
+										" command.");
 				return;
 		}
 	}
@@ -2294,11 +2314,11 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
 
 			var existingNonDoorExit =
 				actor.Gameworld.ExitManager.GetAllExits(actor.Location)
-					 .FirstOrDefault(
-						 x =>
-							 x.Origin == exit.Origin && x.Destination == exit.Destination &&
-							 x.InboundDirection == exit.InboundDirection &&
-							 x.OutboundDirection == exit.OutboundDirection && !x.Exit.AcceptsDoor);
+					.FirstOrDefault(
+						x =>
+							x.Origin == exit.Origin && x.Destination == exit.Destination &&
+							x.InboundDirection == exit.InboundDirection &&
+							x.OutboundDirection == exit.OutboundDirection && !x.Exit.AcceptsDoor);
 			if (existingNonDoorExit != null)
 			{
 				newExit = existingNonDoorExit.Exit;
@@ -2536,7 +2556,7 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
 		}
 
 		actor.OutputHandler.Send("You set the Terrain for this cell to \"" +
-								 terrain.Name.TitleCase().Colour(Telnet.Green) + "\"");
+								terrain.Name.TitleCase().Colour(Telnet.Green) + "\"");
 	}
 
 	private static void CellEditHearingProfile(ICharacter actor, StringStack input)
@@ -2558,7 +2578,7 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
 		var overlay = actor.Location.GetOrCreateOverlay(actor.CurrentOverlayPackage);
 		overlay.HearingProfile = profile;
 		actor.OutputHandler.Send("You set the Hearing Profile for this cell to \"" +
-								 profile.Name.TitleCase().Colour(Telnet.Green) + "\"");
+								profile.Name.TitleCase().Colour(Telnet.Green) + "\"");
 	}
 
 	private static void CellExit(ICharacter actor, StringStack input)
@@ -2573,7 +2593,7 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
 				: "")}:
 
 {(from exit in exits
-							 select exit.BuilderInformationString(actor)
+							select exit.BuilderInformationString(actor)
 									+
 									(overlay != null && overlay.ExitIDs.Contains(exit.Exit.Id)
 										? "[x]"
@@ -2737,7 +2757,7 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
 			otherOverlay.RemoveExit(texit);
 
 			actor.OutputHandler.Send("You remove the Exit with ID " + texit.Id +
-									 " from this Location's Cell Overlay.");
+									" from this Location's Cell Overlay.");
 		}
 	}
 
@@ -3155,7 +3175,7 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
 		var overlay = actor.Location.GetOrCreateOverlay(actor.CurrentOverlayPackage);
 		if (
 			actor.Gameworld.ExitManager.GetExitsFor(actor.Location, overlay)
-				 .Any(x => x.OutboundDirection == direction))
+				.Any(x => x.OutboundDirection == direction))
 		{
 			actor.OutputHandler.Send("This Cell Overlay already contains an exit in that direction.");
 			return;
@@ -3171,7 +3191,7 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
 		var oppositeDirection = direction.Opposite();
 		if (
 			actor.Gameworld.ExitManager.GetExitsFor(cell, otherOverlay)
-				 .Any(x => x.OutboundDirection == oppositeDirection))
+				.Any(x => x.OutboundDirection == oppositeDirection))
 		{
 			actor.OutputHandler.Send("The target cell already has an exit in the opposite direction.");
 			return;
@@ -3184,7 +3204,7 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
 		actor.Gameworld.ExitManager.UpdateCellOverlayExits(actor.Location, overlay);
 		actor.Gameworld.ExitManager.UpdateCellOverlayExits(cell, otherOverlay);
 		actor.OutputHandler.Send("You create a two-way exit to the " + direction.Describe() + " to cell \"" +
-								 cell.HowSeen(actor) + "\"");
+								cell.HowSeen(actor) + "\"");
 	}
 
 	private static readonly Regex CellEditNLinkRegex =
@@ -3199,8 +3219,8 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
 		if (!match.Success)
 		{
 			actor.OutputHandler.Send("You must supply an argument in this form: " +
-									 "cell nlink <template> <cellid> <outbound keyword> <inbound keyword> \"<outbound description>\" \"<inbound description>\""
-										 .Colour(Telnet.Yellow));
+									"cell nlink <template> <cellid> <outbound keyword> <inbound keyword> \"<outbound description>\" \"<inbound description>\""
+										.Colour(Telnet.Yellow));
 			return;
 		}
 
@@ -3277,7 +3297,7 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
 		var overlay = actor.Location.GetOrCreateOverlay(actor.CurrentOverlayPackage);
 		overlay.CellDescription = description;
 		handler.Send("You set the Cell Description to:\n\n" +
-					 overlay.CellDescription.Wrap(actor.InnerLineFormatLength));
+					overlay.CellDescription.Wrap(actor.InnerLineFormatLength));
 	}
 
 	private static void DoCellDescCancel(IOutputHandler handler, object[] arguments)
@@ -3673,14 +3693,14 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
 		if (actor.CurrentOverlayPackage.Status != RevisionStatus.UnderDesign)
 		{
 			actor.OutputHandler.Send("Your Cell Overlay Package is not in the " +
-									 "Under Design".Colour(Telnet.Yellow) + " status.");
+									"Under Design".Colour(Telnet.Yellow) + " status.");
 			return;
 		}
 
 		actor.CurrentOverlayPackage.ChangeStatus(RevisionStatus.PendingRevision, input.SafeRemainingArgument,
 			actor.Account);
 		actor.OutputHandler.Send("You submit the Cell Overlay Package \"" + actor.CurrentOverlayPackage.Name +
-								 "\" for review.");
+								"\" for review.");
 		actor.CurrentOverlayPackage = null;
 	}
 
@@ -3863,7 +3883,7 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
 		actor.OutputHandler.Send(
 			("You are reviewing " + packages.Count() + " Cell Overlay Package" + (packages.Count() == 1 ? "" : "s"))
 			.Colour(Telnet.Red) + "\n\nTo approve these Cell Overlay Package" +
-			(packages.Count() == 1 ? "" : "s") + ",  type " + "accept edit <your comments>".Colour(Telnet.Yellow) +
+			(packages.Count() == 1 ? "" : "s") + ",	 type " + "accept edit <your comments>".Colour(Telnet.Yellow) +
 			" or " + "decline edit <your comments>".Colour(Telnet.Yellow) +
 			" to reject.\nIf you do not wish to approve or decline, your request will time out in 120 seconds.");
 		actor.AddEffect(
@@ -3910,10 +3930,10 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
 		}
 
 		actor.OutputHandler.Send(("You are reviewing " + package.EditHeader()).Colour(Telnet.Red) + "\n\n" +
-								 package.Show(actor) + "\n\nTo approve this Cell Overlay Package, type " +
-								 "accept edit <your comments>".Colour(Telnet.Yellow) + " or " +
-								 "decline edit <your comments>".Colour(Telnet.Yellow) +
-								 " to reject.\nIf you do not wish to approve or decline, your request will time out in 120 seconds.");
+								package.Show(actor) + "\n\nTo approve this Cell Overlay Package, type " +
+								"accept edit <your comments>".Colour(Telnet.Yellow) + " or " +
+								"decline edit <your comments>".Colour(Telnet.Yellow) +
+								" to reject.\nIf you do not wish to approve or decline, your request will time out in 120 seconds.");
 		actor.AddEffect(
 			new Accept(actor,
 				new EditableItemReviewProposal<ICellOverlayPackage>(actor, new List<ICellOverlayPackage> { package })),
@@ -3939,10 +3959,10 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
 			actor.Gameworld.SaveManager.Flush();
 			// We must first delete all of the CellOverlays linked to this CellOverlayPackage, because the Overlays have a foreign key constraint of the Package ID.
 			var dboverlayproto = FMDB.Context.CellOverlays
-									 .Where(x => x.CellOverlayPackageId == actor.CurrentOverlayPackage.Id)
-									 .Where(x => x.CellOverlayPackageRevisionNumber ==
-												 actor.CurrentOverlayPackage.RevisionNumber)
-									 .ToList();
+									.Where(x => x.CellOverlayPackageId == actor.CurrentOverlayPackage.Id)
+									.Where(x => x.CellOverlayPackageRevisionNumber ==
+												actor.CurrentOverlayPackage.RevisionNumber)
+									.ToList();
 
 			foreach (var overlay in dboverlayproto)
 			{
@@ -3953,7 +3973,7 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
 			}
 
 			var dbpackageproto = FMDB.Context.CellOverlayPackages
-									 .Find(actor.CurrentOverlayPackage.Id, actor.CurrentOverlayPackage.RevisionNumber);
+									.Find(actor.CurrentOverlayPackage.Id, actor.CurrentOverlayPackage.RevisionNumber);
 			if (dbpackageproto != null)
 			{
 				FMDB.Context.CellOverlayPackages.Remove(dbpackageproto);
@@ -3982,7 +4002,7 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
 
 		actor.CurrentOverlayPackage.ChangeStatus(RevisionStatus.Obsolete, input.SafeRemainingArgument, actor.Account);
 		actor.OutputHandler.Send("You mark " + actor.CurrentOverlayPackage.EditHeader() +
-								 " as an obsolete prototype.");
+								" as an obsolete prototype.");
 		actor.CurrentOverlayPackage = null;
 	}
 
@@ -4049,9 +4069,9 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
 			var clock = long.TryParse(input.PopSpeech(), out var value)
 				? actor.Gameworld.Clocks.Get(value)
 				: actor.Gameworld.Clocks.FirstOrDefault(
-					  x => x.Name.Equals(input.Last, StringComparison.InvariantCultureIgnoreCase)) ??
-				  actor.Gameworld.Clocks.FirstOrDefault(
-					  x => x.Alias.Equals(input.Last, StringComparison.InvariantCultureIgnoreCase));
+					x => x.Name.Equals(input.Last, StringComparison.InvariantCultureIgnoreCase)) ??
+				actor.Gameworld.Clocks.FirstOrDefault(
+					x => x.Alias.Equals(input.Last, StringComparison.InvariantCultureIgnoreCase));
 			if (clock == null)
 			{
 				actor.Send("There is no clock identified by {0}.", input.Last);
@@ -4070,7 +4090,7 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
 		actor.Send(
 			"The shard now has the following clocks:\n{0}Note: Don't forget to set up timezones for the new clocks in any zones in this shard.",
 			clocks.Select(x => "\t" + x.Name.TitleCase().ColourValue())
-				  .ListToString(separator: "\n", twoItemJoiner: "\n", conjunction: ""));
+				.ListToString(separator: "\n", twoItemJoiner: "\n", conjunction: ""));
 	}
 
 	private static void ShardEditCalendars(ICharacter actor, StringStack input, IShard shard)
@@ -4088,9 +4108,9 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
 			var calendar = long.TryParse(input.PopSpeech(), out var value)
 				? actor.Gameworld.Calendars.Get(value)
 				: actor.Gameworld.Calendars.FirstOrDefault(
-					  x => x.ShortName.Equals(input.Last, StringComparison.InvariantCultureIgnoreCase)) ??
-				  actor.Gameworld.Calendars.FirstOrDefault(
-					  x => x.Alias.Equals(input.Last, StringComparison.InvariantCultureIgnoreCase));
+					x => x.ShortName.Equals(input.Last, StringComparison.InvariantCultureIgnoreCase)) ??
+				actor.Gameworld.Calendars.FirstOrDefault(
+					x => x.Alias.Equals(input.Last, StringComparison.InvariantCultureIgnoreCase));
 			if (calendar == null)
 			{
 				actor.Send("There is no calendar identified by {0}.", input.Last);
@@ -4109,7 +4129,7 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
 		actor.Send(
 			"The shard now has the following calendars:\n{0}",
 			calendars.Select(x => "\t" + x.ShortName.TitleCase().ColourValue())
-					 .ListToString(separator: "\n", twoItemJoiner: "\n", conjunction: ""));
+					.ListToString(separator: "\n", twoItemJoiner: "\n", conjunction: ""));
 	}
 
 	private static void ShardEditCelestials(ICharacter actor, StringStack input, IShard shard)
@@ -4155,7 +4175,7 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
 		shard.Changed = true;
 		actor.Send("The shard now has the following celestials:\n{0}",
 			celestials.Select(x => "\t" + x.Name.TitleCase())
-					  .ListToString(separator: "\n", twoItemJoiner: "\n", conjunction: ""));
+					.ListToString(separator: "\n", twoItemJoiner: "\n", conjunction: ""));
 	}
 
 	private static void ShardEditLux(ICharacter actor, StringStack input, IShard shard)
@@ -4280,15 +4300,15 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
 
 		actor.OutputHandler.Send(
 			StringUtilities.GetTextTable(from area in areas
-										 select new[]
-										 {
-											 area.Id.ToString("N0", actor),
-											 area.Name,
-											 area.WeatherController?.RegionalClimate.Name.Colour(Telnet.Cyan) ?? "Default",
-											 area.Zones.Select(x => x.Name)
-												 .ListToString(conjunction: "", twoItemJoiner: ", "),
-											 area.Cells.Count().ToString("N0", actor)
-										 },
+										select new[]
+										{
+											area.Id.ToString("N0", actor),
+											area.Name,
+											area.WeatherController?.RegionalClimate.Name.Colour(Telnet.Cyan) ?? "Default",
+											area.Zones.Select(x => x.Name)
+												.ListToString(conjunction: "", twoItemJoiner: ", "),
+											area.Cells.Count().ToString("N0", actor)
+										},
 				new[] { "Id", "Name", "Weather", "Zones", "Cells" },
 				actor.LineFormatLength,
 				colour: Telnet.Green,
@@ -4549,7 +4569,7 @@ The syntax for working with areas is as follows:
 		var area = long.TryParse(ss.PopSpeech(), out var value)
 			? actor.Gameworld.Areas.Get(value)
 			: actor.Gameworld.Areas.GetByName(ss.Last) ??
-			  actor.Gameworld.Areas.FirstOrDefault(x => x.Name.StartsWith(ss.Last, StringComparison.OrdinalIgnoreCase));
+			actor.Gameworld.Areas.FirstOrDefault(x => x.Name.StartsWith(ss.Last, StringComparison.OrdinalIgnoreCase));
 
 		if (area == null)
 		{

--- a/MudSharpCore/TimeAndDate/Time/Clock.cs
+++ b/MudSharpCore/TimeAndDate/Time/Clock.cs
@@ -1,14 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Linq;
 using MudSharp.Database;
+using MudSharp.Character;
 using MudSharp.Framework;
 using MudSharp.Framework.Save;
 using MudSharp.FutureProg;
 using MudSharp.FutureProg.Variables;
+using MudSharp.Models;
 
 namespace MudSharp.TimeAndDate.Time;
 
@@ -300,15 +303,17 @@ public class Clock : SaveableItem, IClock
 
 	public override void Save()
 	{
-		using (new FMDB())
-		{
-			var dbclock = FMDB.Context.Clocks.Find(Id);
-			dbclock.Hours = CurrentTime.Hours;
-			dbclock.Minutes = CurrentTime.Minutes;
-			dbclock.Seconds = CurrentTime.Seconds;
-		}
+	using (new FMDB())
+	{
+		var dbclock = FMDB.Context.Clocks.Find(Id);
+		dbclock.Hours = CurrentTime.Hours;
+		dbclock.Minutes = CurrentTime.Minutes;
+		dbclock.Seconds = CurrentTime.Seconds;
+		dbclock.PrimaryTimezoneId = PrimaryTimezone?.Id ?? dbclock.PrimaryTimezoneId;
+		dbclock.Definition = SaveToXml().ToString();
+	}
 
-		Changed = false;
+	Changed = false;
 	}
 
 	#endregion
@@ -351,7 +356,7 @@ public class Clock : SaveableItem, IClock
 	#region Descriptive Properties
 
 	/// <summary>
-	///     This alias is a unique string reference to the Clock
+	///	This alias is a unique string reference to the Clock
 	/// </summary>
 	protected string _alias;
 
@@ -362,7 +367,7 @@ public class Clock : SaveableItem, IClock
 	}
 
 	/// <summary>
-	///     This is a brief summary description of the clock, e.g. "The UTC Clock for Earth circa 2012"
+	///	This is a brief summary description of the clock, e.g. "The UTC Clock for Earth circa 2012"
 	/// </summary>
 	protected string _description;
 
@@ -415,7 +420,7 @@ public class Clock : SaveableItem, IClock
 	#region Display Properties
 
 	/// <summary>
-	///     Number of digits to fix the display of hours to, e.g. 2 makes hours appear as 06
+	///	Number of digits to fix the display of hours to, e.g. 2 makes hours appear as 06
 	/// </summary>
 	protected int _hourFixedDigits;
 
@@ -426,7 +431,7 @@ public class Clock : SaveableItem, IClock
 	}
 
 	/// <summary>
-	///     Number of digits to fix the display of minutes to, e.g. 2 makes minutes appear 06
+	///	Number of digits to fix the display of minutes to, e.g. 2 makes minutes appear 06
 	/// </summary>
 	protected int _minuteFixedDigits;
 
@@ -437,7 +442,7 @@ public class Clock : SaveableItem, IClock
 	}
 
 	/// <summary>
-	///     Number of digits to fix the display of seconds to, e.g. 2 makes seconds appear 06
+	///	Number of digits to fix the display of seconds to, e.g. 2 makes seconds appear 06
 	/// </summary>
 	protected int _secondFixedDigits;
 
@@ -449,9 +454,9 @@ public class Clock : SaveableItem, IClock
 
 
 	/// <summary>
-	///     The short version of the time display string.
-	///     E.g.
-	///     $hh:$m$i would display 11:34pm
+	///	The short version of the time display string.
+	///	E.g.
+	///	$hh:$m$i would display 11:34pm
 	/// </summary>
 	protected string _shortDisplayString;
 
@@ -470,7 +475,7 @@ public class Clock : SaveableItem, IClock
 	}
 
 	/// <summary>
-	///     Display string for "super" users, e.g. admins and log files
+	///	Display string for "super" users, e.g. admins and log files
 	/// </summary>
 	protected string _superDisplayString;
 
@@ -481,9 +486,9 @@ public class Clock : SaveableItem, IClock
 	}
 
 	/// <summary>
-	///     This property describes how many discrete intervals of hours are in a one day period - for instance, in the common
-	///     clock, there are 2 - a.m and p.m
-	///     The total number of hours must be equally divisible by this number
+	///	This property describes how many discrete intervals of hours are in a one day period - for instance, in the common
+	///	clock, there are 2 - a.m and p.m
+	///	The total number of hours must be equally divisible by this number
 	/// </summary>
 	protected int _numberOfHourIntervals;
 
@@ -494,21 +499,21 @@ public class Clock : SaveableItem, IClock
 	}
 
 	/// <summary>
-	///     Display names for intervals of hours, e.g. "a.m.", "p.m."
+	///	Display names for intervals of hours, e.g. "a.m.", "p.m."
 	/// </summary>
 	protected List<string> _hourIntervalNames = new();
 
 	public List<string> HourIntervalNames => _hourIntervalNames;
 
 	/// <summary>
-	///     Long names for intervals of hours, e.g. "in the afternoon", "in the morning"
+	///	Long names for intervals of hours, e.g. "in the afternoon", "in the morning"
 	/// </summary>
 	protected List<string> _hourIntervalLongNames = new();
 
 	public List<string> HourIntervalLongNames => _hourIntervalLongNames;
 
 	/// <summary>
-	///     Whether or not the clock displays hour 0 as 0 - for instance, in the standard clock hour zero is actually 12am
+	///	Whether or not the clock displays hour 0 as 0 - for instance, in the standard clock hour zero is actually 12am
 	/// </summary>
 	protected bool _noZeroHour;
 
@@ -544,6 +549,98 @@ public class Clock : SaveableItem, IClock
 	#endregion
 
 	#region Constructors
+
+	public Clock(IFuturemud gameworld, string name, string alias)
+	{
+		Gameworld = gameworld;
+		_name = name;
+		Alias = alias;
+		Description = name;
+		SecondsPerMinute = 60;
+		MinutesPerHour = 60;
+		HoursPerDay = 24;
+		InGameSecondsPerRealSecond = 1.0;
+		HourFixedDigits = 2;
+		MinuteFixedDigits = 2;
+		SecondFixedDigits = 2;
+		ShortDisplayString = "$j:$m$i";
+		LongDisplayString = "$c $l";
+		SuperDisplayString = "$h:$m:$s $t";
+		NumberOfHourIntervals = 2;
+		HourIntervalNames.AddRange(new[] { "am", "pm" });
+		HourIntervalLongNames.AddRange(new[] { "in the morning", "in the afternoon" });
+		NoZeroHour = true;
+		using (new FMDB())
+		{
+			var dbclock = new Models.Clock();
+			FMDB.Context.Clocks.Add(dbclock);
+			dbclock.Definition = string.Empty;
+			dbclock.Hours = 0;
+			dbclock.Minutes = 0;
+			dbclock.Seconds = 0;
+			dbclock.PrimaryTimezoneId = 0;
+			FMDB.Context.SaveChanges();
+			_id = dbclock.Id;
+		}
+
+		var timezone = new MudTimeZone(this, 0, 0, $"{Name} Standard Time", alias);
+		AddTimezone(timezone);
+		PrimaryTimezone = timezone;
+		CurrentTime = new MudTime(0, 0, 0, timezone, this, true);
+		Save();
+	}
+
+	private Clock(Clock rhs, string name, string alias)
+	{
+		Gameworld = rhs.Gameworld;
+		_name = name;
+		Alias = alias;
+		Description = rhs.Description;
+		SecondsPerMinute = rhs.SecondsPerMinute;
+		MinutesPerHour = rhs.MinutesPerHour;
+		HoursPerDay = rhs.HoursPerDay;
+		InGameSecondsPerRealSecond = rhs.InGameSecondsPerRealSecond;
+		HourFixedDigits = rhs.HourFixedDigits;
+		MinuteFixedDigits = rhs.MinuteFixedDigits;
+		SecondFixedDigits = rhs.SecondFixedDigits;
+		ShortDisplayString = rhs.ShortDisplayString;
+		LongDisplayString = rhs.LongDisplayString;
+		SuperDisplayString = rhs.SuperDisplayString;
+		NumberOfHourIntervals = rhs.NumberOfHourIntervals;
+		HourIntervalNames.AddRange(rhs.HourIntervalNames);
+		HourIntervalLongNames.AddRange(rhs.HourIntervalLongNames);
+		NoZeroHour = rhs.NoZeroHour;
+		foreach (var range in rhs.CrudeTimeIntervals.Ranges)
+		{
+			CrudeTimeIntervals.Add(new BoundRange<string>(CrudeTimeIntervals, range.Value, range.LowerLimit, range.UpperLimit));
+		}
+
+		using (new FMDB())
+		{
+			var dbclock = new Models.Clock();
+			FMDB.Context.Clocks.Add(dbclock);
+			dbclock.Definition = string.Empty;
+			dbclock.Hours = rhs.CurrentTime.Hours;
+			dbclock.Minutes = rhs.CurrentTime.Minutes;
+			dbclock.Seconds = rhs.CurrentTime.Seconds;
+			dbclock.PrimaryTimezoneId = 0;
+			FMDB.Context.SaveChanges();
+			_id = dbclock.Id;
+		}
+
+		foreach (var timezone in rhs.Timezones)
+		{
+			var tz = new MudTimeZone(this, timezone.OffsetHours, timezone.OffsetMinutes, timezone.Description, timezone.Alias);
+			AddTimezone(tz);
+			if (timezone == rhs.PrimaryTimezone)
+			{
+				PrimaryTimezone = tz;
+			}
+		}
+
+		CurrentTime = new MudTime(rhs.CurrentTime.Seconds, rhs.CurrentTime.Minutes, rhs.CurrentTime.Hours, PrimaryTimezone, this, true);
+		Save();
+	}
 
 	public Clock(XElement loadfile, MudTimeZone primaryTimeZone = null, int hours = 0, int minutes = 0, int seconds = 0)
 	{
@@ -586,6 +683,11 @@ public class Clock : SaveableItem, IClock
 
 		PrimaryTimezone = _timezones.Get(clock.PrimaryTimezoneId);
 		CurrentTime = new MudTime(clock.Seconds, clock.Minutes, clock.Hours, PrimaryTimezone, this, true);
+	}
+
+	public IClock Clone(string name, string alias)
+	{
+		return new Clock(this, name, alias);
 	}
 
 	#endregion
@@ -670,10 +772,10 @@ public class Clock : SaveableItem, IClock
 	public static Regex timeRegex = new(@"\$([a-zA-Z])");
 
 	/// <summary>
-	///     Some examples of Display times and their expected outputs:
-	///     "$h$m hours" - 1630 hours
-	///     "$j:$m$i" - 4:30pm
-	///     "$c $L" - half past four in the afternoon
+	///	Some examples of Display times and their expected outputs:
+	///	"$h$m hours" - 1630 hours
+	///	"$j:$m$i" - 4:30pm
+	///	"$c $L" - half past four in the afternoon
 	/// </summary>
 	/// <param name="theTime"></param>
 	/// <returns></returns>
@@ -807,6 +909,419 @@ public class Clock : SaveableItem, IClock
 	public void SetTime(MudTime time)
 	{
 		_currentTime = time;
+	}
+
+	#endregion
+
+	#region IEditableItem Implementation
+
+	public const string BuildingHelpText = @"You can use the following options with this command:
+
+	#3name <name>#0 - sets the name of the clock
+	#3alias <alias>#0 - sets the alias of the clock
+	#3desc <description>#0 - sets the description
+	#3spm <##>#0 - sets the number of seconds per minute
+	#3mph <##>#0 - sets the number of minutes per hour
+	#3hpd <##>#0 - sets the number of hours per day
+	#3speed <number>#0 - sets the in-game seconds per real second
+	#3hourdigits <##>#0 - sets the fixed digits for hours
+	#3minutedigits <##>#0 - sets the fixed digits for minutes
+	#3seconddigits <##>#0 - sets the fixed digits for seconds
+	#3short <string>#0 - sets the short display string
+	#3long <string>#0 - sets the long display string
+	#3super <string>#0 - sets the superuser display string
+	#3intervals <##>#0 - sets the number of hour intervals
+	#3intervalname <##> <name>#0 - sets a short name for an hour interval
+	#3intervallong <##> <name>#0 - sets a long name for an hour interval
+	#3nozero <true|false>#0 - sets whether hour zero is displayed";
+
+	public bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+	switch (command.PopForSwitch())
+	{
+		case "name":
+			return BuildingCommandName(actor, command);
+		case "alias":
+			return BuildingCommandAlias(actor, command);
+		case "desc":
+		case "description":
+			return BuildingCommandDescription(actor, command);
+		case "spm":
+		case "secondsperminute":
+			return BuildingCommandSecondsPerMinute(actor, command);
+		case "mph":
+		case "minutesperhour":
+			return BuildingCommandMinutesPerHour(actor, command);
+		case "hpd":
+		case "hoursperday":
+			return BuildingCommandHoursPerDay(actor, command);
+		case "speed":
+			return BuildingCommandSpeed(actor, command);
+		case "hourdigits":
+			return BuildingCommandHourDigits(actor, command);
+		case "minutedigits":
+			return BuildingCommandMinuteDigits(actor, command);
+		case "seconddigits":
+			return BuildingCommandSecondDigits(actor, command);
+		case "short":
+			return BuildingCommandShort(actor, command);
+		case "long":
+			return BuildingCommandLong(actor, command);
+		case "super":
+			return BuildingCommandSuper(actor, command);
+		case "intervals":
+			return BuildingCommandIntervals(actor, command);
+		case "intervalname":
+			return BuildingCommandIntervalName(actor, command);
+		case "intervallong":
+		case "intervallongname":
+			return BuildingCommandIntervalLongName(actor, command);
+		case "nozero":
+		case "nozerohour":
+			return BuildingCommandNoZeroHour(actor, command);
+		default:
+			actor.OutputHandler.Send(BuildingHelpText.SubstituteANSIColour());
+			return false;
+	}
+	}
+
+	private bool BuildingCommandName(ICharacter actor, StringStack command)
+	{
+	if (command.IsFinished)
+	{
+		actor.OutputHandler.Send("What name should this clock have?");
+		return false;
+	}
+
+	var name = command.SafeRemainingArgument.TitleCase();
+	_name = name;
+	Changed = true;
+	actor.OutputHandler.Send($"This clock is now named {name.ColourName()}.");
+	return true;
+       }
+
+	private bool BuildingCommandAlias(ICharacter actor, StringStack command)
+	{
+	if (command.IsFinished)
+	{
+		actor.OutputHandler.Send("What alias should this clock have?");
+		return false;
+	}
+
+	var alias = command.PopSpeech();
+	if (Gameworld.Clocks.Any(x => x != this && x.Alias.EqualTo(alias)))
+	{
+		actor.OutputHandler.Send($"There is already a clock with the alias {alias.ColourValue()}.");
+		return false;
+	}
+
+	Alias = alias;
+	Changed = true;
+	actor.OutputHandler.Send($"This clock now has the alias {alias.ColourValue()}.");
+	return true;
+	}
+
+	private bool BuildingCommandDescription(ICharacter actor, StringStack command)
+	{
+	if (command.IsFinished)
+	{
+		actor.OutputHandler.Send("What description should this clock have?");
+		return false;
+	}
+
+	Description = command.SafeRemainingArgument;
+	Changed = true;
+	actor.OutputHandler.Send("Description set.");
+	return true;
+	}
+
+	private bool BuildingCommandSecondsPerMinute(ICharacter actor, StringStack command)
+	{
+	if (command.IsFinished || !int.TryParse(command.PopSpeech(), out var value) || value <= 0)
+	{
+		actor.OutputHandler.Send("You must specify a positive number of seconds per minute.");
+		return false;
+	}
+
+	SecondsPerMinute = value;
+	Changed = true;
+	actor.OutputHandler.Send($"This clock now has {value.ToString("N0", actor).ColourValue()} seconds per minute.");
+	return true;
+	}
+
+	private bool BuildingCommandMinutesPerHour(ICharacter actor, StringStack command)
+	{
+	if (command.IsFinished || !int.TryParse(command.PopSpeech(), out var value) || value <= 0)
+	{
+		actor.OutputHandler.Send("You must specify a positive number of minutes per hour.");
+		return false;
+	}
+
+	MinutesPerHour = value;
+	Changed = true;
+	actor.OutputHandler.Send($"This clock now has {value.ToString("N0", actor).ColourValue()} minutes per hour.");
+	return true;
+	}
+
+	private bool BuildingCommandHoursPerDay(ICharacter actor, StringStack command)
+	{
+	if (command.IsFinished || !int.TryParse(command.PopSpeech(), out var value) || value <= 0)
+	{
+		actor.OutputHandler.Send("You must specify a positive number of hours per day.");
+		return false;
+	}
+
+	if (value % NumberOfHourIntervals != 0)
+	{
+		actor.OutputHandler.Send($"The value must be divisible by the number of hour intervals ({NumberOfHourIntervals}).");
+		return false;
+	}
+
+	HoursPerDay = value;
+	Changed = true;
+	actor.OutputHandler.Send($"This clock now has {value.ToString("N0", actor).ColourValue()} hours per day.");
+	return true;
+	}
+
+	private bool BuildingCommandSpeed(ICharacter actor, StringStack command)
+	{
+	if (command.IsFinished || !double.TryParse(command.PopSpeech(), out var value) || value <= 0.0)
+	{
+		actor.OutputHandler.Send("You must specify a positive number of in-game seconds per real second.");
+		return false;
+	}
+
+	InGameSecondsPerRealSecond = value;
+	Changed = true;
+	actor.OutputHandler.Send($"This clock now advances {value.ToString("N3", actor).ColourValue()} seconds each real second.");
+	return true;
+	}
+
+	private bool BuildingCommandHourDigits(ICharacter actor, StringStack command)
+	{
+	if (command.IsFinished || !int.TryParse(command.PopSpeech(), out var value) || value < 0)
+	{
+		actor.OutputHandler.Send("You must specify a non-negative number of digits.");
+		return false;
+	}
+
+	HourFixedDigits = value;
+	Changed = true;
+	actor.OutputHandler.Send($"This clock will now use {value.ToString("N0", actor).ColourValue()} digits for hours.");
+	return true;
+	}
+
+	private bool BuildingCommandMinuteDigits(ICharacter actor, StringStack command)
+	{
+	if (command.IsFinished || !int.TryParse(command.PopSpeech(), out var value) || value < 0)
+	{
+		actor.OutputHandler.Send("You must specify a non-negative number of digits.");
+		return false;
+	}
+
+	MinuteFixedDigits = value;
+	Changed = true;
+	actor.OutputHandler.Send($"This clock will now use {value.ToString("N0", actor).ColourValue()} digits for minutes.");
+	return true;
+	}
+
+	private bool BuildingCommandSecondDigits(ICharacter actor, StringStack command)
+	{
+	if (command.IsFinished || !int.TryParse(command.PopSpeech(), out var value) || value < 0)
+	{
+		actor.OutputHandler.Send("You must specify a non-negative number of digits.");
+		return false;
+	}
+
+	SecondFixedDigits = value;
+	Changed = true;
+	actor.OutputHandler.Send($"This clock will now use {value.ToString("N0", actor).ColourValue()} digits for seconds.");
+	return true;
+	}
+
+	private bool BuildingCommandShort(ICharacter actor, StringStack command)
+	{
+	if (command.IsFinished)
+	{
+		actor.OutputHandler.Send("What short display string should this clock use?");
+		return false;
+	}
+
+	ShortDisplayString = command.SafeRemainingArgument;
+	Changed = true;
+	actor.OutputHandler.Send("Short display string set.");
+	return true;
+	}
+
+	private bool BuildingCommandLong(ICharacter actor, StringStack command)
+	{
+	if (command.IsFinished)
+	{
+		actor.OutputHandler.Send("What long display string should this clock use?");
+		return false;
+	}
+
+	LongDisplayString = command.SafeRemainingArgument;
+	Changed = true;
+	actor.OutputHandler.Send("Long display string set.");
+	return true;
+	}
+
+	private bool BuildingCommandSuper(ICharacter actor, StringStack command)
+	{
+	if (command.IsFinished)
+	{
+		actor.OutputHandler.Send("What superuser display string should this clock use?");
+		return false;
+	}
+
+	SuperDisplayString = command.SafeRemainingArgument;
+	Changed = true;
+	actor.OutputHandler.Send("Super display string set.");
+	return true;
+	}
+
+	private bool BuildingCommandIntervals(ICharacter actor, StringStack command)
+	{
+	if (command.IsFinished || !int.TryParse(command.PopSpeech(), out var value) || value <= 0)
+	{
+		actor.OutputHandler.Send("You must specify a positive number of intervals.");
+		return false;
+	}
+
+	if (HoursPerDay % value != 0)
+	{
+		actor.OutputHandler.Send($"The value must divide evenly into the hours per day ({HoursPerDay}).");
+		return false;
+	}
+
+	NumberOfHourIntervals = value;
+	while (HourIntervalNames.Count < value)
+	{
+		HourIntervalNames.Add($"Interval {HourIntervalNames.Count + 1}");
+	}
+
+	while (HourIntervalNames.Count > value)
+	{
+		HourIntervalNames.RemoveAt(HourIntervalNames.Count - 1);
+	}
+
+	while (HourIntervalLongNames.Count < value)
+	{
+		HourIntervalLongNames.Add($"Interval {HourIntervalLongNames.Count + 1}");
+	}
+
+	while (HourIntervalLongNames.Count > value)
+	{
+		HourIntervalLongNames.RemoveAt(HourIntervalLongNames.Count - 1);
+	}
+
+	Changed = true;
+	actor.OutputHandler.Send($"This clock will now have {value.ToString("N0", actor).ColourValue()} hour intervals.");
+	return true;
+	}
+
+	private bool BuildingCommandIntervalName(ICharacter actor, StringStack command)
+	{
+	if (command.IsFinished || !int.TryParse(command.PopSpeech(), out var index))
+	{
+		actor.OutputHandler.Send("Which interval do you want to name?");
+		return false;
+	}
+
+	if (index < 1 || index > HourIntervalNames.Count)
+	{
+		actor.OutputHandler.Send("There is no such interval.");
+		return false;
+	}
+
+	if (command.IsFinished)
+	{
+		actor.OutputHandler.Send("What name should this interval have?");
+		return false;
+	}
+
+	var name = command.SafeRemainingArgument;
+	HourIntervalNames[index - 1] = name;
+	Changed = true;
+	actor.OutputHandler.Send($"Interval {index} will now be called {name.ColourValue()}.");
+	return true;
+	}
+
+	private bool BuildingCommandIntervalLongName(ICharacter actor, StringStack command)
+	{
+	if (command.IsFinished || !int.TryParse(command.PopSpeech(), out var index))
+	{
+		actor.OutputHandler.Send("Which interval do you want to name?");
+		return false;
+	}
+
+	if (index < 1 || index > HourIntervalLongNames.Count)
+	{
+		actor.OutputHandler.Send("There is no such interval.");
+		return false;
+	}
+
+	if (command.IsFinished)
+	{
+		actor.OutputHandler.Send("What long name should this interval have?");
+		return false;
+	}
+
+	var name = command.SafeRemainingArgument;
+	HourIntervalLongNames[index - 1] = name;
+	Changed = true;
+	actor.OutputHandler.Send($"Interval {index} will now have long name {name.ColourValue()}.");
+	return true;
+	}
+
+	private bool BuildingCommandNoZeroHour(ICharacter actor, StringStack command)
+	{
+	var text = command.PopSpeech();
+	if (!text.EqualTo("true") && !text.EqualTo("false") && !text.EqualTo("yes") && !text.EqualTo("no"))
+	{
+		actor.OutputHandler.Send("Do you want this clock to skip zero hour? (true/false)");
+		return false;
+	}
+
+	NoZeroHour = text.EqualTo("true") || text.EqualTo("yes");
+	Changed = true;
+	actor.OutputHandler.Send($"This clock will {(NoZeroHour ? "not " : "")}show hour zero.");
+	return true;
+       }
+
+	public string Show(ICharacter actor)
+	{
+	var sb = new StringBuilder();
+	sb.AppendLine($"Clock #{Id.ToString("N0", actor)} - {Name}".GetLineWithTitle(actor, Telnet.Cyan, Telnet.BoldWhite));
+	sb.AppendLine($"Alias: {Alias.ColourValue()}");
+	sb.AppendLine($"Description: {Description.ColourValue()}");
+	sb.AppendLine($"Seconds/Minute: {SecondsPerMinute.ToString("N0", actor).ColourValue()}");
+	sb.AppendLine($"Minutes/Hour: {MinutesPerHour.ToString("N0", actor).ColourValue()}");
+	sb.AppendLine($"Hours/Day: {HoursPerDay.ToString("N0", actor).ColourValue()}");
+	sb.AppendLine($"IG Seconds/Real Second: {InGameSecondsPerRealSecond.ToString("N3", actor).ColourValue()}");
+	sb.AppendLine($"Hour Digits: {HourFixedDigits.ToString("N0", actor).ColourValue()}");
+	sb.AppendLine($"Minute Digits: {MinuteFixedDigits.ToString("N0", actor).ColourValue()}");
+	sb.AppendLine($"Second Digits: {SecondFixedDigits.ToString("N0", actor).ColourValue()}");
+	sb.AppendLine($"Short Display: {ShortDisplayString.ColourCommand()}");
+	sb.AppendLine($"Long Display: {LongDisplayString.ColourCommand()}");
+	sb.AppendLine($"Super Display: {SuperDisplayString.ColourCommand()}");
+	sb.AppendLine($"Number of Intervals: {NumberOfHourIntervals.ToString("N0", actor).ColourValue()}");
+	sb.AppendLine($"Interval Names: {HourIntervalNames.Select((x, i) => $"[{i + 1}] {x}").ListToCommaSeparatedValues(", ")}");
+	sb.AppendLine($"Interval Long Names: {HourIntervalLongNames.Select((x, i) => $"[{i + 1}] {x}").ListToCommaSeparatedValues(", ")}");
+	sb.AppendLine($"No Zero Hour: {NoZeroHour.ToColouredString()}");
+	sb.AppendLine($"Primary Timezone: {PrimaryTimezone?.Alias.ColourValue() ?? "None"}");
+	sb.AppendLine($"Timezones: {Timezones.Select(x => x.Alias.ColourValue()).ListToString()}");
+	if (CrudeTimeIntervals.Ranges.Any())
+	{
+		sb.AppendLine("Crude Time Intervals:");
+		var i = 1;
+		foreach (var range in CrudeTimeIntervals.Ranges)
+		{
+			sb.AppendLine($"\t{i++.ToString("N0", actor)}. {range.LowerLimit.ToString("N2", actor)} - {range.UpperLimit.ToString("N2", actor)}: {range.Value.ColourValue()}");
+		}
+	}
+	return sb.ToString();
 	}
 
 	#endregion


### PR DESCRIPTION
## Summary
- allow clocks to be edited in-engine with building commands
- add helper and command wiring for clock editing
- support creating and cloning clocks with default timezone

## Testing
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68bfa1224efc832380f161fb13db70e2