### PR TITLE
Consider mount state in flee and skirmish speed checks

### DIFF
--- a/MudSharpCore/Combat/CombatExtensions.cs
+++ b/MudSharpCore/Combat/CombatExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using MudSharp.Body.Position;
 using MudSharp.Body.Position.PositionStates;
+using MudSharp.Character;
 using MudSharp.Framework;
 
 namespace MudSharp.Combat;
@@ -14,10 +15,15 @@ public static class CombatExtensions
 	/// </summary>
 	public static BuiltInCombatMoveType[] StandardMeleeWeaponAttacks =
 	{
-		BuiltInCombatMoveType.UseWeaponAttack,
-		BuiltInCombatMoveType.StaggeringBlow,
-		BuiltInCombatMoveType.UnbalancingBlow
+	        BuiltInCombatMoveType.UseWeaponAttack,
+	        BuiltInCombatMoveType.StaggeringBlow,
+	        BuiltInCombatMoveType.UnbalancingBlow
 	};
+
+	public static ICharacter GetCombatMover(this ICharacter character)
+	{
+	        return character.RidingMount ?? character;
+	}
 
 	public static string Describe(this AttackHandednessOptions option)
 	{

--- a/MudSharpCore/Combat/Moves/ChargeToMeleeMove.cs
+++ b/MudSharpCore/Combat/Moves/ChargeToMeleeMove.cs
@@ -139,21 +139,46 @@ public class ChargeToMeleeMove : CombatMoveBase
 			};
 		}
 
-		var oldSpeed = Assailant.CurrentSpeeds[Assailant.PositionState];
-		Assailant.CurrentSpeeds[Assailant.PositionState] =
-			Assailant.Speeds.Where(x => x.Position == Assailant.PositionState).FirstMin(x => x.Multiplier);
-		var speed = Assailant.MoveSpeed(null);
-		Assailant.CurrentSpeeds[Assailant.PositionState] = oldSpeed;
+	        var assailantMover = Assailant.GetCombatMover();
+	        var assailantPosition = assailantMover.PositionState;
+	        var assailantHadSpeed = assailantMover.CurrentSpeeds.TryGetValue(assailantPosition, out var oldAssailantSpeed);
+	        var assailantTempSpeed =
+	                assailantMover.Speeds.Where(x => x.Position == assailantPosition).FirstMin(x => x.Multiplier);
+	        if (assailantTempSpeed != null)
+	        {
+	                assailantMover.CurrentSpeeds[assailantPosition] = assailantTempSpeed;
+	        }
 
-		oldSpeed = target.CurrentSpeeds[target.PositionState];
-		target.CurrentSpeeds[target.PositionState] =
-			target.Speeds.Where(x => x.Position == target.PositionState).FirstMin(x => x.Multiplier);
-		double moveTypeMultiplier;
-		var locationMultiplier = target.CombatSettings.SkirmishToOtherLocations && target.Movement == null
-			? 1.0
-			: 1.25;
-		switch (target.CombatSettings.PreferredMeleeMode)
-		{
+	        var speed = assailantMover.MoveSpeed(null);
+
+	        if (assailantTempSpeed != null)
+	        {
+	                if (assailantHadSpeed)
+	                {
+	                        assailantMover.CurrentSpeeds[assailantPosition] = oldAssailantSpeed;
+	                }
+	                else
+	                {
+	                        assailantMover.CurrentSpeeds.Remove(assailantPosition);
+	                }
+	        }
+
+	        var targetMover = target.GetCombatMover();
+	        var targetPosition = targetMover.PositionState;
+	        var targetHadSpeed = targetMover.CurrentSpeeds.TryGetValue(targetPosition, out var oldTargetSpeed);
+	        var targetTempSpeed =
+	                targetMover.Speeds.Where(x => x.Position == targetPosition).FirstMin(x => x.Multiplier);
+	        if (targetTempSpeed != null)
+	        {
+	                targetMover.CurrentSpeeds[targetPosition] = targetTempSpeed;
+	        }
+	        double moveTypeMultiplier;
+	        var locationMultiplier = target.CombatSettings.SkirmishToOtherLocations && target.Movement == null &&
+	                targetMover.Movement == null
+	                ? 1.0
+	                : 1.25;
+	        switch (target.CombatSettings.PreferredMeleeMode)
+	        {
 			case CombatStrategyMode.Skirmish:
 			case CombatStrategyMode.Swooper:
 				moveTypeMultiplier = 1.3;
@@ -169,8 +194,19 @@ public class ChargeToMeleeMove : CombatMoveBase
 				break;
 		}
 
-		var targetspeed = target.MoveSpeed(null) * moveTypeMultiplier * locationMultiplier;
-		target.CurrentSpeeds[target.PositionState] = oldSpeed;
+	        var targetspeed = targetMover.MoveSpeed(null) * moveTypeMultiplier * locationMultiplier;
+
+	        if (targetTempSpeed != null)
+	        {
+	                if (targetHadSpeed)
+	                {
+	                        targetMover.CurrentSpeeds[targetPosition] = oldTargetSpeed;
+	                }
+	                else
+	                {
+	                        targetMover.CurrentSpeeds.Remove(targetPosition);
+	                }
+	        }
 
 		if (speed <= targetspeed)
 		{
@@ -200,8 +236,8 @@ public class ChargeToMeleeMove : CombatMoveBase
 					Gameworld.CombatMessageManager.GetMessageFor(Assailant, target, null, null,
 						BuiltInCombatMoveType.ChargeToMelee, Outcome.MajorFail, null), Assailant, Assailant, target),
 				style: OutputStyle.CombatMessage, flags: OutputFlags.InnerWrap));
-		if (target.CombatSettings.SkirmishToOtherLocations && target.Movement == null &&
-		    speed <= targetspeed * 1.25)
+	        if (target.CombatSettings.SkirmishToOtherLocations && target.Movement == null && targetMover.Movement == null &&
+	            speed <= targetspeed * 1.25)
 		{
 			var exit = target.Location.ExitsFor(target).Where(x => target.CanCross(x).Success).GetRandomElement();
 			if (exit != null)

--- a/MudSharpCore/Combat/Moves/FireAndAdvanceToMeleeMove.cs
+++ b/MudSharpCore/Combat/Moves/FireAndAdvanceToMeleeMove.cs
@@ -97,21 +97,46 @@ public class FireAndAdvanceToMeleeMove : CombatMoveBase
 			return;
 		}
 
-		var oldSpeed = Assailant.CurrentSpeed;
-		Assailant.CurrentSpeeds[Assailant.PositionState] =
-			Assailant.Speeds.Where(x => x.Position == Assailant.PositionState).FirstMin(x => x.Multiplier);
-		var speed = Assailant.MoveSpeed(null);
-		Assailant.CurrentSpeeds[Assailant.PositionState] = oldSpeed;
+	        var assailantMover = Assailant.GetCombatMover();
+	        var assailantPosition = assailantMover.PositionState;
+	        var assailantHadSpeed = assailantMover.CurrentSpeeds.TryGetValue(assailantPosition, out var oldAssailantSpeed);
+	        var assailantTempSpeed =
+	                assailantMover.Speeds.Where(x => x.Position == assailantPosition).FirstMin(x => x.Multiplier);
+	        if (assailantTempSpeed != null)
+	        {
+	                assailantMover.CurrentSpeeds[assailantPosition] = assailantTempSpeed;
+	        }
 
-		oldSpeed = target.CurrentSpeeds[target.PositionState];
-		target.CurrentSpeeds[target.PositionState] =
-			target.Speeds.Where(x => x.Position == target.PositionState).FirstMin(x => x.Multiplier);
-		double moveTypeMultiplier;
-		var locationMultiplier = target.CombatSettings.SkirmishToOtherLocations && target.Movement == null
-			? 1.0
-			: 1.25;
-		switch (target.CombatSettings.PreferredMeleeMode)
-		{
+	        var speed = assailantMover.MoveSpeed(null);
+
+	        if (assailantTempSpeed != null)
+	        {
+	                if (assailantHadSpeed)
+	                {
+	                        assailantMover.CurrentSpeeds[assailantPosition] = oldAssailantSpeed;
+	                }
+	                else
+	                {
+	                        assailantMover.CurrentSpeeds.Remove(assailantPosition);
+	                }
+	        }
+
+	        var targetMover = target.GetCombatMover();
+	        var targetPosition = targetMover.PositionState;
+	        var targetHadSpeed = targetMover.CurrentSpeeds.TryGetValue(targetPosition, out var oldTargetSpeed);
+	        var targetTempSpeed =
+	                targetMover.Speeds.Where(x => x.Position == targetPosition).FirstMin(x => x.Multiplier);
+	        if (targetTempSpeed != null)
+	        {
+	                targetMover.CurrentSpeeds[targetPosition] = targetTempSpeed;
+	        }
+	        double moveTypeMultiplier;
+	        var locationMultiplier = target.CombatSettings.SkirmishToOtherLocations && target.Movement == null &&
+	                targetMover.Movement == null
+	                ? 1.0
+	                : 1.25;
+	        switch (target.CombatSettings.PreferredMeleeMode)
+	        {
 			case CombatStrategyMode.Skirmish:
 			case CombatStrategyMode.Swooper:
 				moveTypeMultiplier = 1.25;
@@ -127,8 +152,19 @@ public class FireAndAdvanceToMeleeMove : CombatMoveBase
 				break;
 		}
 
-		var targetspeed = target.MoveSpeed(null) * moveTypeMultiplier * locationMultiplier;
-		target.CurrentSpeeds[target.PositionState] = oldSpeed;
+	        var targetspeed = targetMover.MoveSpeed(null) * moveTypeMultiplier * locationMultiplier;
+
+	        if (targetTempSpeed != null)
+	        {
+	                if (targetHadSpeed)
+	                {
+	                        targetMover.CurrentSpeeds[targetPosition] = oldTargetSpeed;
+	                }
+	                else
+	                {
+	                        targetMover.CurrentSpeeds.Remove(targetPosition);
+	                }
+	        }
 
 		if (speed <= targetspeed)
 		{
@@ -149,8 +185,8 @@ public class FireAndAdvanceToMeleeMove : CombatMoveBase
 					Gameworld.CombatMessageManager.GetMessageFor(Assailant, target, null, null,
 						BuiltInCombatMoveType.AdvanceAndFire, Outcome.MajorFail, null), Assailant, Assailant, target),
 				style: OutputStyle.CombatMessage, flags: OutputFlags.InnerWrap));
-		if (target.CombatSettings.SkirmishToOtherLocations && target.Movement == null &&
-		    speed <= targetspeed * 1.25)
+	        if (target.CombatSettings.SkirmishToOtherLocations && target.Movement == null && targetMover.Movement == null &&
+	            speed <= targetspeed * 1.25)
 		{
 			var exit = target.Location.ExitsFor(target).Where(x => target.CanCross(x).Success).GetRandomElement();
 			if (exit != null)

--- a/MudSharpCore/Combat/Moves/MoveToMeleeMove.cs
+++ b/MudSharpCore/Combat/Moves/MoveToMeleeMove.cs
@@ -115,21 +115,46 @@ public class MoveToMeleeMove : CombatMoveBase
 			};
 		}
 
-		var oldSpeed = Assailant.CurrentSpeeds[Assailant.PositionState];
-		Assailant.CurrentSpeeds[Assailant.PositionState] =
-			Assailant.Speeds.Where(x => x.Position == Assailant.PositionState).FirstMin(x => x.Multiplier);
-		var speed = Assailant.MoveSpeed(null);
-		Assailant.CurrentSpeeds[Assailant.PositionState] = oldSpeed;
+	        var assailantMover = Assailant.GetCombatMover();
+	        var assailantPosition = assailantMover.PositionState;
+	        var assailantHadSpeed = assailantMover.CurrentSpeeds.TryGetValue(assailantPosition, out var oldAssailantSpeed);
+	        var assailantTempSpeed =
+	                assailantMover.Speeds.Where(x => x.Position == assailantPosition).FirstMin(x => x.Multiplier);
+	        if (assailantTempSpeed != null)
+	        {
+	                assailantMover.CurrentSpeeds[assailantPosition] = assailantTempSpeed;
+	        }
 
-		oldSpeed = target.CurrentSpeeds[target.PositionState];
-		target.CurrentSpeeds[target.PositionState] =
-			target.Speeds.Where(x => x.Position == target.PositionState).FirstMin(x => x.Multiplier);
-		double moveTypeMultiplier;
-		var locationMultiplier = target.CombatSettings.SkirmishToOtherLocations && target.Movement == null
-			? 1.0
-			: 1.25;
-		switch (target.CombatSettings.PreferredMeleeMode)
-		{
+	        var speed = assailantMover.MoveSpeed(null);
+
+	        if (assailantTempSpeed != null)
+	        {
+	                if (assailantHadSpeed)
+	                {
+	                        assailantMover.CurrentSpeeds[assailantPosition] = oldAssailantSpeed;
+	                }
+	                else
+	                {
+	                        assailantMover.CurrentSpeeds.Remove(assailantPosition);
+	                }
+	        }
+
+	        var targetMover = target.GetCombatMover();
+	        var targetPosition = targetMover.PositionState;
+	        var targetHadSpeed = targetMover.CurrentSpeeds.TryGetValue(targetPosition, out var oldTargetSpeed);
+	        var targetTempSpeed =
+	                targetMover.Speeds.Where(x => x.Position == targetPosition).FirstMin(x => x.Multiplier);
+	        if (targetTempSpeed != null)
+	        {
+	                targetMover.CurrentSpeeds[targetPosition] = targetTempSpeed;
+	        }
+	        double moveTypeMultiplier;
+	        var locationMultiplier = target.CombatSettings.SkirmishToOtherLocations && target.Movement == null &&
+	                targetMover.Movement == null
+	                ? 1.0
+	                : 1.25;
+	        switch (target.CombatSettings.PreferredMeleeMode)
+	        {
 			case CombatStrategyMode.Skirmish:
 			case CombatStrategyMode.Swooper:
 				moveTypeMultiplier = 1.25;
@@ -145,11 +170,22 @@ public class MoveToMeleeMove : CombatMoveBase
 				break;
 		}
 
-		var targetspeed = target.MoveSpeed(null) * moveTypeMultiplier * locationMultiplier;
-		target.CurrentSpeeds[target.PositionState] = oldSpeed;
+	        var targetspeed = targetMover.MoveSpeed(null) * moveTypeMultiplier * locationMultiplier;
 
-		if (speed <= targetspeed)
-		{
+	        if (targetTempSpeed != null)
+	        {
+	                if (targetHadSpeed)
+	                {
+	                        targetMover.CurrentSpeeds[targetPosition] = oldTargetSpeed;
+	                }
+	                else
+	                {
+	                        targetMover.CurrentSpeeds.Remove(targetPosition);
+	                }
+	        }
+
+	        if (speed <= targetspeed)
+	        {
 			Assailant.OutputHandler.Handle(
 				new EmoteOutput(
 					new Emote(
@@ -170,9 +206,9 @@ public class MoveToMeleeMove : CombatMoveBase
 					Gameworld.CombatMessageManager.GetMessageFor(Assailant, target, null, null,
 						BuiltInCombatMoveType.MoveToMelee, Outcome.MajorFail, null), Assailant, Assailant, target),
 				style: OutputStyle.CombatMessage, flags: OutputFlags.InnerWrap));
-		if (target.CombatSettings.SkirmishToOtherLocations && target.Movement == null &&
-		    speed <= targetspeed * 1.25)
-		{
+	        if (target.CombatSettings.SkirmishToOtherLocations && target.Movement == null && targetMover.Movement == null &&
+	            speed <= targetspeed * 1.25)
+	        {
 			var exit = target.Location.ExitsFor(target).Where(x => target.CanCross(x).Success).GetRandomElement();
 			if (exit != null)
 			{


### PR DESCRIPTION
## Summary
- update flee move resolution to evaluate rider movement speed using mounts when present and preserve original speed settings
- ensure skirmish-focused moves temporarily adjust the controlling mover's speed for comparisons and consider mount movement when calculating modifiers

## Testing
- dotnet build MudSharp.sln *(fails: requires EnableWindowsTargeting on non-Windows host)*

------
https://chatgpt.com/codex/tasks/task_e_68daf185e6f883238b9e01905ba971ec