### PR TITLE
Wire arena lifecycle services into runtime

### DIFF
--- a/FutureMUDLibrary/Framework/IFuturemud.cs
+++ b/FutureMUDLibrary/Framework/IFuturemud.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using MudSharp.Accounts;
+using MudSharp.Arenas;
 using MudSharp.Body;
 using MudSharp.Body.Disfigurements;
 using MudSharp.Body.Traits;
@@ -297,6 +298,8 @@ namespace MudSharp.Framework
 
 		IServer Server { get; }
 		IScheduler Scheduler { get; }
+		IArenaLifecycleService ArenaLifecycleService { get; }
+		IArenaScheduler ArenaScheduler { get; }
 		IEffectScheduler EffectScheduler { get; }
 		ISaveManager SaveManager { get; }
 		IGameItemComponentManager GameItemComponentManager { get; }

--- a/FutureMUDLibrary/Framework/Scheduling/ScheduleType.cs
+++ b/FutureMUDLibrary/Framework/Scheduling/ScheduleType.cs
@@ -13,6 +13,7 @@
         Morph = 7,
         MorphSaving = 8,
         CharacterIntro = 9,
-        CrimeReport = 10
+        CrimeReport = 10,
+        ArenaEvent = 11
     }
 }

--- a/MudSharpCore/Arenas/Lifecycle/ArenaLifecycleService.cs
+++ b/MudSharpCore/Arenas/Lifecycle/ArenaLifecycleService.cs
@@ -1,0 +1,75 @@
+#nullable enable
+using System;
+using MudSharp.Framework;
+
+namespace MudSharp.Arenas;
+
+/// <summary>
+///     Coordinates arena event state transitions and arranges follow-up scheduling.
+/// </summary>
+public class ArenaLifecycleService : IArenaLifecycleService
+{
+	private IArenaScheduler? _scheduler;
+
+	public ArenaLifecycleService(IFuturemud gameworld)
+	{
+		// Retained for future integrations requiring the game context.
+		_ = gameworld;
+	}
+
+	/// <summary>
+	///     Links the lifecycle service with the arena scheduler implementation.
+	/// </summary>
+	/// <param name="scheduler">Scheduler responsible for timed transitions.</param>
+	public void AttachScheduler(IArenaScheduler scheduler)
+	{
+		_scheduler = scheduler;
+	}
+
+	/// <inheritdoc />
+	public void Transition(IArenaEvent arenaEvent, ArenaEventState targetState)
+	{
+		if (arenaEvent is null)
+		{
+			throw new ArgumentNullException(nameof(arenaEvent));
+		}
+
+		var initialState = arenaEvent.State;
+		if (!IsForwardTransition(initialState, targetState))
+		{
+			return;
+		}
+
+		arenaEvent.EnforceState(targetState);
+		var currentState = arenaEvent.State;
+
+		if (currentState is ArenaEventState.Completed or ArenaEventState.Aborted)
+		{
+			_scheduler?.Cancel(arenaEvent);
+			return;
+		}
+
+		_scheduler?.Schedule(arenaEvent);
+	}
+
+	/// <inheritdoc />
+	public void RebootRecovery()
+	{
+		_scheduler?.RecoverAfterReboot();
+	}
+
+	private static bool IsForwardTransition(ArenaEventState current, ArenaEventState target)
+	{
+		if (current == target)
+		{
+			return false;
+		}
+
+		if (target == ArenaEventState.Aborted)
+		{
+			return true;
+		}
+
+		return current is not (ArenaEventState.Aborted or ArenaEventState.Completed) && target > current;
+	}
+}

--- a/MudSharpCore/Arenas/Lifecycle/ArenaScheduler.cs
+++ b/MudSharpCore/Arenas/Lifecycle/ArenaScheduler.cs
@@ -1,0 +1,141 @@
+#nullable enable
+using System;
+using MudSharp.Framework;
+using MudSharp.Framework.Scheduling;
+
+namespace MudSharp.Arenas;
+
+/// <summary>
+///     Schedules arena event transitions using the global game scheduler.
+/// </summary>
+public class ArenaScheduler : IArenaScheduler
+{
+	private readonly IFuturemud _gameworld;
+	private readonly IArenaLifecycleService _lifecycleService;
+
+	public ArenaScheduler(IFuturemud gameworld, IArenaLifecycleService lifecycleService)
+	{
+		_gameworld = gameworld;
+		_lifecycleService = lifecycleService;
+		if (lifecycleService is ArenaLifecycleService concrete)
+		{
+			concrete.AttachScheduler(this);
+		}
+	}
+
+	/// <inheritdoc />
+	public void Schedule(IArenaEvent arenaEvent)
+	{
+		if (arenaEvent is null)
+		{
+			throw new ArgumentNullException(nameof(arenaEvent));
+		}
+
+		if (arenaEvent.State is ArenaEventState.Completed or ArenaEventState.Aborted)
+		{
+			Cancel(arenaEvent);
+			return;
+		}
+
+		Cancel(arenaEvent);
+		if (!TryGetNextTransition(arenaEvent, out var nextState, out var trigger))
+		{
+			return;
+		}
+
+		if (trigger <= DateTime.UtcNow)
+		{
+			_lifecycleService.Transition(arenaEvent, nextState);
+			return;
+		}
+
+		var pendingState = nextState;
+		var schedule = new Schedule<IArenaEvent>(arenaEvent, evt => _lifecycleService.Transition(evt, pendingState),
+			ScheduleType.ArenaEvent, trigger - DateTime.UtcNow,
+			$"ArenaEvent #{arenaEvent.Id} -> {pendingState}");
+		_gameworld.Scheduler.AddSchedule(schedule);
+	}
+
+	/// <inheritdoc />
+	public void Cancel(IArenaEvent arenaEvent)
+	{
+		if (arenaEvent is null)
+		{
+			return;
+		}
+
+		_gameworld.Scheduler.Destroy(arenaEvent, ScheduleType.ArenaEvent);
+	}
+
+	/// <inheritdoc />
+	public void RecoverAfterReboot()
+	{
+		// Concrete arena loading will reschedule active events once they are reconstructed.
+	}
+
+	private static bool TryGetNextTransition(IArenaEvent arenaEvent, out ArenaEventState nextState, out DateTime trigger)
+	{
+		var now = DateTime.UtcNow;
+		trigger = DateTime.MinValue;
+		nextState = arenaEvent.State;
+		switch (arenaEvent.State)
+		{
+			case ArenaEventState.Draft:
+				nextState = ArenaEventState.Scheduled;
+				trigger = arenaEvent.ScheduledAt;
+				break;
+			case ArenaEventState.Scheduled:
+				nextState = ArenaEventState.RegistrationOpen;
+				trigger = ResolveRegistrationOpen(arenaEvent);
+				break;
+			case ArenaEventState.RegistrationOpen:
+				nextState = ArenaEventState.Preparing;
+				trigger = ResolveRegistrationOpen(arenaEvent) + arenaEvent.EventType.RegistrationDuration;
+				break;
+			case ArenaEventState.Preparing:
+				nextState = ArenaEventState.Staged;
+				trigger = ResolveRegistrationOpen(arenaEvent) + arenaEvent.EventType.RegistrationDuration + arenaEvent.EventType.PreparationDuration;
+				break;
+			case ArenaEventState.Staged:
+				nextState = ArenaEventState.Live;
+				trigger = arenaEvent.ScheduledAt;
+				break;
+			case ArenaEventState.Live:
+				if (arenaEvent.EventType.TimeLimit is { } limit && arenaEvent.StartedAt.HasValue)
+				{
+					nextState = ArenaEventState.Resolving;
+					trigger = arenaEvent.StartedAt.Value + limit;
+					break;
+				}
+				return false;
+			case ArenaEventState.Resolving:
+				nextState = ArenaEventState.Cleanup;
+				trigger = now;
+				break;
+			case ArenaEventState.Cleanup:
+				nextState = ArenaEventState.Completed;
+				trigger = now;
+				break;
+			default:
+				return false;
+		}
+
+		if (trigger < now)
+		{
+			trigger = now;
+		}
+
+		return true;
+	}
+
+	private static DateTime ResolveRegistrationOpen(IArenaEvent arenaEvent)
+	{
+		if (arenaEvent.RegistrationOpensAt.HasValue)
+		{
+			return arenaEvent.RegistrationOpensAt.Value;
+		}
+
+		var fallback = arenaEvent.ScheduledAt - arenaEvent.EventType.PreparationDuration - arenaEvent.EventType.RegistrationDuration;
+		return fallback > arenaEvent.CreatedAt ? fallback : arenaEvent.CreatedAt;
+	}
+}

--- a/MudSharpCore/Framework/Futuremud.cs
+++ b/MudSharpCore/Framework/Futuremud.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using MudSharp.Accounts;
+using MudSharp.Arenas;
 using MudSharp.Body;
 using MudSharp.Celestial;
 using MudSharp.Character;
@@ -129,6 +130,8 @@ public sealed partial class Futuremud : IFuturemud, IDisposable
 		ClockManager = new ClockManager(this);
 		GameItemComponentManager = new GameItemComponentManager();
 		Scheduler = new Scheduler();
+		ArenaLifecycleService = new ArenaLifecycleService(this);
+		ArenaScheduler = new ArenaScheduler(this, ArenaLifecycleService);
 		SaveManager = new SaveManager();
 		HeartbeatManager = new HeartbeatManager(this);
 

--- a/MudSharpCore/Framework/FuturemudLoaders.cs
+++ b/MudSharpCore/Framework/FuturemudLoaders.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Xml.Linq;
 using MudSharp.Models;
 using MudSharp.Accounts;
+using MudSharp.Arenas;
 using MudSharp.Body;
 using MudSharp.Body.Disfigurements;
 using MudSharp.Body.Implementations;
@@ -139,6 +140,8 @@ public sealed partial class Futuremud : IFuturemudLoader, IFuturemud, IDisposabl
 	protected List<IPlayerConnection> _connections = new();
 	public IServer Server { get; protected set; }
 	public IScheduler Scheduler { get; protected set; }
+	public IArenaLifecycleService ArenaLifecycleService { get; protected set; }
+	public IArenaScheduler ArenaScheduler { get; protected set; }
 	public IEffectScheduler EffectScheduler { get; protected set; }
 	public ISaveManager SaveManager { get; protected set; }
 	public IGameItemComponentManager GameItemComponentManager { get; protected set; }
@@ -403,7 +406,8 @@ public sealed partial class Futuremud : IFuturemudLoader, IFuturemud, IDisposabl
 		ConsoleUtilities.WriteLine("#C========================================#0");
 		ConsoleUtilities.WriteLine("\n#EScheduling core system tasks...#0");
 		ClockManager.Initialise();
-		// Scheduler.AddSchedule(new RepeatingSchedule<Game>(this, this, fm => fm.SaveManager.Flush(), ScheduleType.System, new TimeSpan(0, 0, 10), "Main Save Loop"));
+		ArenaLifecycleService.RebootRecovery();
+                // Scheduler.AddSchedule(new RepeatingSchedule<Game>(this, this, fm => fm.SaveManager.Flush(), ScheduleType.System, new TimeSpan(0, 0, 10), "Main Save Loop"));
 		//Scheduler.AddSchedule(new RepeatingSchedule<Game>(this, this, fm => new Monitoring.DuplicationMonitor(this).AuditCharacters(), ScheduleType.System, TimeSpan.FromHours(1)));
 		Scheduler.AddSchedule(new RepeatingSchedule<IFuturemud>(this, this, fm =>
 			{


### PR DESCRIPTION
## Summary
- expose the arena lifecycle and scheduler services on `IFuturemud` and instantiate them in the FutureMUD runtime
- schedule arena lifecycle recovery during boot and add the arena event schedule type
- add the arena lifecycle service implementation alongside the scheduler hookup

## Testing
- `dotnet test "MudSharpCore Unit Tests/MudSharpCore Unit Tests.csproj" --filter FullyQualifiedName~ArenaSchedulerTests` *(fails: existing `ArenaSchedulerTests` assigns the read-only `IArenaEvent.State` property)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911ab2f437083239149f7a43f2367af)