### PR TITLE
Handle orphaned items when restoring arena NPC gear

### DIFF
--- a/MudSharpCore/Arenas/Npc/ArenaNpcPreparationEffect.cs
+++ b/MudSharpCore/Arenas/Npc/ArenaNpcPreparationEffect.cs
@@ -1,0 +1,120 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+using MudSharp.Body;
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Effects;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Inventory;
+using MudSharp.Framework;
+
+namespace MudSharp.Arenas;
+
+public sealed class ArenaNpcPreparationEffect : Effect
+{
+	private readonly List<ArenaNpcItemSnapshot> _items = new();
+
+	public ArenaNpcPreparationEffect(ICharacter owner, long eventId, bool resurrectOnReturn)
+		: base(owner)
+	{
+		EventId = eventId;
+		OriginalLocation = owner.Location;
+		OriginalRoomLayer = owner.RoomLayer;
+		ResurrectOnReturn = resurrectOnReturn;
+	}
+
+	public ArenaNpcPreparationEffect(XElement definition, IPerceivable owner)
+		: base(definition, owner)
+	{
+		var element = definition.Element("Effect") ?? throw new ArgumentException("Invalid arena NPC preparation effect.");
+		EventId = long.Parse(element.Attribute("EventId")?.Value ?? "0");
+		var locationId = long.Parse(element.Attribute("LocationId")?.Value ?? "0");
+		OriginalLocation = locationId > 0 ? owner.Gameworld.Cells.Get(locationId) : null;
+		OriginalRoomLayer = (RoomLayer)int.Parse(element.Attribute("RoomLayer")?.Value ?? "0");
+		ResurrectOnReturn = bool.Parse(element.Attribute("ResurrectOnReturn")?.Value ?? bool.FalseString);
+
+		var items = element.Element("Items");
+		if (items is null)
+		{
+			return;
+		}
+
+		foreach (var itemElement in items.Elements("Item"))
+		{
+			var itemId = long.Parse(itemElement.Attribute("Id")?.Value ?? "0");
+			var item = owner.Gameworld.TryGetItem(itemId, true);
+			if (item is null)
+			{
+				continue;
+			}
+
+			var state = (InventoryState)int.Parse(itemElement.Attribute("State")?.Value ?? "0");
+			var wearProfileId = long.Parse(itemElement.Attribute("WearProfileId")?.Value ?? "0");
+			var bodypartId = long.Parse(itemElement.Attribute("BodypartId")?.Value ?? "0");
+			_items.Add(new ArenaNpcItemSnapshot(item, state,
+				wearProfileId > 0 ? wearProfileId : null,
+				bodypartId > 0 ? bodypartId : null));
+		}
+	}
+
+	public long EventId { get; }
+	public ICell? OriginalLocation { get; }
+	public RoomLayer OriginalRoomLayer { get; }
+	public bool ResurrectOnReturn { get; }
+
+	public IEnumerable<ArenaNpcItemSnapshot> Items => _items;
+
+	protected override string SpecificEffectType => "ArenaNpcPreparation";
+
+	public override bool SavingEffect => true;
+
+	public override string Describe(IPerceiver voyeur)
+	{
+		return "Arena NPC Preparation";
+	}
+
+	public void CaptureItem(IGameItem item, InventoryState state, long? wearProfileId, long? bodypartId)
+	{
+		if (item is null)
+		{
+			return;
+		}
+
+		_items.Add(new ArenaNpcItemSnapshot(item, state, wearProfileId, bodypartId));
+	}
+
+	public void ClearCapturedItems()
+	{
+		_items.Clear();
+	}
+
+	public static void InitialiseEffectType()
+	{
+		RegisterFactory("ArenaNpcPreparation", (effect, owner) => new ArenaNpcPreparationEffect(effect, owner));
+	}
+
+	protected override XElement SaveDefinition()
+	{
+		return new XElement("Effect",
+			new XAttribute("EventId", EventId),
+			new XAttribute("LocationId", OriginalLocation?.Id ?? 0),
+			new XAttribute("RoomLayer", (int)OriginalRoomLayer),
+			new XAttribute("ResurrectOnReturn", ResurrectOnReturn),
+			new XElement("Items",
+				from item in _items
+				select new XElement("Item",
+					new XAttribute("Id", item.Item.Id),
+					new XAttribute("State", (int)item.State),
+					new XAttribute("WearProfileId", item.WearProfileId ?? 0),
+					new XAttribute("BodypartId", item.BodypartId ?? 0))));
+	}
+
+	public readonly record struct ArenaNpcItemSnapshot(
+		IGameItem Item,
+		InventoryState State,
+		long? WearProfileId,
+		long? BodypartId);
+}

--- a/MudSharpCore/Arenas/Npc/ArenaNpcService.cs
+++ b/MudSharpCore/Arenas/Npc/ArenaNpcService.cs
@@ -1,0 +1,267 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MudSharp.Arenas;
+using MudSharp.Body;
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.GameItems.Inventory;
+using MudSharp.Framework;
+using MudSharp.Effects;
+using MudSharp.NPC;
+
+namespace MudSharp.Arenas;
+
+public class ArenaNpcService : IArenaNpcService
+{
+	public ArenaNpcService(IFuturemud gameworld)
+	{
+		_ = gameworld ?? throw new ArgumentNullException(nameof(gameworld));
+	}
+
+	public IEnumerable<ICharacter> AutoFill(IArenaEvent arenaEvent, int sideIndex, int slotsNeeded)
+	{
+		if (arenaEvent is null)
+		{
+			throw new ArgumentNullException(nameof(arenaEvent));
+		}
+
+		if (slotsNeeded <= 0)
+		{
+			return Enumerable.Empty<ICharacter>();
+		}
+
+		var side = arenaEvent.EventType.Sides.FirstOrDefault(x => x.Index == sideIndex);
+		if (side?.NpcLoaderProg is null)
+		{
+			return Enumerable.Empty<ICharacter>();
+		}
+
+		return side.NpcLoaderProg.ExecuteCollection<ICharacter>(arenaEvent, sideIndex, slotsNeeded)
+		                     .OfType<INPC>()
+		                     .Cast<ICharacter>()
+		                     .Take(slotsNeeded)
+		                     .ToList();
+	}
+
+	public void PrepareNpc(ICharacter npc, IArenaEvent arenaEvent, int sideIndex, ICombatantClass combatantClass)
+	{
+		if (npc is null)
+		{
+			throw new ArgumentNullException(nameof(npc));
+		}
+
+		if (arenaEvent is null)
+		{
+			throw new ArgumentNullException(nameof(arenaEvent));
+		}
+
+		if (combatantClass is null)
+		{
+			throw new ArgumentNullException(nameof(combatantClass));
+		}
+
+		var effect = npc.CombinedEffectsOfType<ArenaNpcPreparationEffect>()
+		                .FirstOrDefault(x => x.EventId == arenaEvent.Id);
+		if (effect is null)
+		{
+			effect = new ArenaNpcPreparationEffect(npc, arenaEvent.Id, combatantClass.ResurrectOnReturn);
+			npc.AddEffect(effect);
+		}
+		else
+		{
+			effect.ClearCapturedItems();
+		}
+
+		if (!arenaEvent.EventType.BringYourOwn && npc.Body is not null)
+		{
+			StripToArenaLoadout(npc.Body, effect);
+		}
+
+		var waitingCell = SelectArenaCell(arenaEvent.Arena.WaitingCells, sideIndex);
+		if (waitingCell is not null)
+		{
+			npc.Teleport(waitingCell, RoomLayer.GroundLevel, false, false);
+		}
+	}
+
+	public void ReturnNpc(ICharacter npc, IArenaEvent arenaEvent, bool resurrect)
+	{
+		if (npc is null)
+		{
+			throw new ArgumentNullException(nameof(npc));
+		}
+
+		if (arenaEvent is null)
+		{
+			throw new ArgumentNullException(nameof(arenaEvent));
+		}
+
+		var effect = npc.CombinedEffectsOfType<ArenaNpcPreparationEffect>()
+		                .FirstOrDefault(x => x.EventId == arenaEvent.Id);
+		if (effect is null)
+		{
+			return;
+		}
+
+		if (resurrect && npc.State.HasFlag(CharacterState.Dead))
+		{
+			npc.Body?.Resurrect(effect.OriginalLocation ?? npc.Location ?? npc.Gameworld.Cells.Get(1));
+			npc.State = CharacterState.Awake;
+		}
+
+		RestoreInventory(npc.Body, effect);
+
+		if (effect.OriginalLocation is not null)
+		{
+			npc.Teleport(effect.OriginalLocation, effect.OriginalRoomLayer, false, false);
+		}
+
+		npc.RemoveEffect(effect, true);
+	}
+
+	private static void StripToArenaLoadout(IBody body, ArenaNpcPreparationEffect effect)
+	{
+		var directItems = body.DirectItems?.OfType<IGameItem>().ToList();
+		if (directItems is null || directItems.Count == 0)
+		{
+			return;
+		}
+
+		foreach (var item in directItems)
+		{
+			var state = DetermineState(body, item);
+			var wearProfileId = item.GetItemType<IWearable>()?.CurrentProfile?.Id;
+			var bodypartId = body.BodypartLocationOfInventoryItem(item)?.Id;
+			effect.CaptureItem(item, state, wearProfileId, bodypartId);
+			body.Take(item);
+		}
+	}
+
+        private static void RestoreInventory(IBody? body, ArenaNpcPreparationEffect effect)
+        {
+                if (body is null)
+                {
+                        foreach (var snapshot in effect.Items)
+                        {
+                                if (snapshot.Item is { } orphanCandidate)
+                                {
+                                        HandleOrphanedItem(orphanCandidate);
+                                }
+                        }
+
+                        return;
+                }
+
+                foreach (var snapshot in effect.Items)
+                {
+                        var item = snapshot.Item;
+                        if (item is null || item.Deleted)
+                        {
+                                continue;
+                        }
+
+                        body.Get(item, silent: true, ignoreFlags: ItemCanGetIgnore.IgnoreWeight | ItemCanGetIgnore.IgnoreFreeHands);
+
+                        if (HandleOrphanedItem(item))
+                        {
+                                continue;
+                        }
+
+                        switch (snapshot.State)
+                        {
+                                case InventoryState.Worn:
+                                        if (!WearItem(body, item, snapshot.WearProfileId))
+                                        {
+                                                HandleOrphanedItem(item);
+                                        }
+
+                                        break;
+                                case InventoryState.Wielded:
+                                        if (!WieldItem(body, item, snapshot.BodypartId))
+                                        {
+                                                HandleOrphanedItem(item);
+                                        }
+
+                                        break;
+                                case InventoryState.Held:
+                                        HandleOrphanedItem(item);
+                                        break;
+                        }
+
+                        HandleOrphanedItem(item);
+                }
+        }
+
+        private static bool WearItem(IBody body, IGameItem item, long? wearProfileId)
+        {
+                var wearable = item.GetItemType<IWearable>();
+                if (wearable is null)
+                {
+                        return false;
+                }
+
+                var profile = wearProfileId.HasValue
+                        ? wearable.Profiles.FirstOrDefault(x => x.Id == wearProfileId.Value)
+                        : wearable.CurrentProfile;
+
+                if (profile is not null)
+                {
+                        body.Wear(item, profile, null, true);
+                }
+                else
+                {
+                        body.Wear(item, null, true);
+                }
+
+                return body.WornItems.Contains(item);
+        }
+
+        private static bool WieldItem(IBody body, IGameItem item, long? bodypartId)
+        {
+                var hand = bodypartId.HasValue
+                        ? body.Bodyparts.FirstOrDefault(x => x.Id == bodypartId.Value) as IWield
+                        : null;
+
+                return body.Wield(item, hand, null, true, ItemCanWieldFlags.IgnoreFreeHands);
+        }
+
+        private static InventoryState DetermineState(IBody body, IGameItem item)
+        {
+                if (body.WornItems.Contains(item))
+		{
+			return InventoryState.Worn;
+		}
+
+		if (body.WieldedItems.Contains(item))
+		{
+			return InventoryState.Wielded;
+                }
+
+                return InventoryState.Held;
+        }
+
+        private static bool HandleOrphanedItem(IGameItem item)
+        {
+                if (item is null || item.Deleted)
+                {
+                        return true;
+                }
+
+                if (item.InInventoryOf is not null || item.Location is not null || item.ContainedIn is not null)
+                {
+                        return false;
+                }
+
+                item.Delete();
+                return true;
+        }
+
+	private static ICell? SelectArenaCell(IEnumerable<ICell> cells, int sideIndex)
+	{
+		return cells?.ElementAtOrDefault(sideIndex) ?? cells?.FirstOrDefault();
+	}
+}


### PR DESCRIPTION
## Summary
- delete orphaned arena NPC items when inventory restoration cannot reattach them
- add return values to gear restoration helpers so failures trigger cleanup

## Testing
- ./scripts/test.sh *(fails: build currently fails with 1 error and 311 warnings)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69124a278e408323b0d19c94888ddc6d)