### PR TITLE
Allow arena spectators to move between observation rooms

### DIFF
--- a/FutureMUDLibrary/Framework/IFuturemud.cs
+++ b/FutureMUDLibrary/Framework/IFuturemud.cs
@@ -300,6 +300,7 @@ namespace MudSharp.Framework
 		IScheduler Scheduler { get; }
 		IArenaLifecycleService ArenaLifecycleService { get; }
 		IArenaScheduler ArenaScheduler { get; }
+		IArenaObservationService ArenaObservationService { get; }
 		IEffectScheduler EffectScheduler { get; }
 		ISaveManager SaveManager { get; }
 		IGameItemComponentManager GameItemComponentManager { get; }

--- a/MudSharpCore Unit Tests/Arenas/ArenaObservationServiceTests.cs
+++ b/MudSharpCore Unit Tests/Arenas/ArenaObservationServiceTests.cs
@@ -1,0 +1,119 @@
+#nullable enable
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Arenas;
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Framework;
+
+namespace MudSharp_Unit_Tests.Arenas;
+
+[TestClass]
+public class ArenaObservationServiceTests
+{
+	private ArenaObservationService _service = null!;
+	private Mock<IFuturemud> _gameworld = null!;
+
+	[TestInitialize]
+	public void Setup()
+	{
+		_gameworld = new Mock<IFuturemud>();
+		_service = new ArenaObservationService(_gameworld.Object);
+	}
+
+	[TestMethod]
+	public void CanObserve_WhenNotInObservationCell_ReturnsFalse()
+	{
+		var observer = new Mock<ICharacter>();
+		observer.SetupGet(x => x.State).Returns(CharacterState.Conscious);
+		var observationCell = new Mock<ICell>();
+		var otherCell = new Mock<ICell>();
+		observer.SetupGet(x => x.Location).Returns(otherCell.Object);
+		var arena = new Mock<ICombatArena>();
+		arena.Setup(x => x.ObservationCells).Returns(new[] { observationCell.Object });
+		var arenaEvent = new Mock<IArenaEvent>();
+		arenaEvent.Setup(x => x.Arena).Returns(arena.Object);
+		arenaEvent.Setup(x => x.State).Returns(ArenaEventState.Live);
+		arenaEvent.Setup(x => x.Participants).Returns(Array.Empty<IArenaParticipant>());
+		var result = _service.CanObserve(observer.Object, arenaEvent.Object);
+		Assert.IsFalse(result.Truth);
+		StringAssert.Contains(result.Reason, "observation rooms");
+	}
+
+	[TestMethod]
+	public void CanObserve_WhenEventNotStaged_ReturnsFalse()
+	{
+		var observer = new Mock<ICharacter>();
+		observer.SetupGet(x => x.State).Returns(CharacterState.Conscious);
+		var observationCell = new Mock<ICell>();
+		observer.SetupGet(x => x.Location).Returns(observationCell.Object);
+		var arena = new Mock<ICombatArena>();
+		arena.Setup(x => x.ObservationCells).Returns(new[] { observationCell.Object });
+		var arenaEvent = new Mock<IArenaEvent>();
+		arenaEvent.Setup(x => x.Arena).Returns(arena.Object);
+		arenaEvent.Setup(x => x.State).Returns(ArenaEventState.Scheduled);
+		arenaEvent.Setup(x => x.Participants).Returns(Array.Empty<IArenaParticipant>());
+		var result = _service.CanObserve(observer.Object, arenaEvent.Object);
+		Assert.IsFalse(result.Truth);
+		StringAssert.Contains(result.Reason, "not been staged");
+	}
+
+	[TestMethod]
+	public void CanObserve_WhenObserverIsParticipant_ReturnsFalse()
+	{
+		var observer = new Mock<ICharacter>();
+		observer.SetupGet(x => x.State).Returns(CharacterState.Conscious);
+		var observationCell = new Mock<ICell>();
+		observer.SetupGet(x => x.Location).Returns(observationCell.Object);
+		var arena = new Mock<ICombatArena>();
+		arena.Setup(x => x.ObservationCells).Returns(new[] { observationCell.Object });
+		var participant = new Mock<IArenaParticipant>();
+		participant.SetupGet(x => x.Character).Returns(observer.Object);
+		var arenaEvent = new Mock<IArenaEvent>();
+		arenaEvent.Setup(x => x.Arena).Returns(arena.Object);
+		arenaEvent.Setup(x => x.State).Returns(ArenaEventState.Live);
+		arenaEvent.Setup(x => x.Participants).Returns(new[] { participant.Object });
+		var result = _service.CanObserve(observer.Object, arenaEvent.Object);
+		Assert.IsFalse(result.Truth);
+		StringAssert.Contains(result.Reason, "Participants");
+	}
+
+	[TestMethod]
+	public void CanObserve_WhenNoObservationRoomsConfigured_ReturnsFalse()
+	{
+		var observer = new Mock<ICharacter>();
+		observer.SetupGet(x => x.State).Returns(CharacterState.Conscious);
+		var observationCell = new Mock<ICell>();
+		observer.SetupGet(x => x.Location).Returns(observationCell.Object);
+		var arena = new Mock<ICombatArena>();
+		arena.Setup(x => x.Name).Returns("Test Arena");
+		arena.Setup(x => x.ObservationCells).Returns(Array.Empty<ICell>());
+		var arenaEvent = new Mock<IArenaEvent>();
+		arenaEvent.Setup(x => x.Arena).Returns(arena.Object);
+		arenaEvent.Setup(x => x.State).Returns(ArenaEventState.Live);
+		arenaEvent.Setup(x => x.Participants).Returns(Array.Empty<IArenaParticipant>());
+		var result = _service.CanObserve(observer.Object, arenaEvent.Object);
+		Assert.IsFalse(result.Truth);
+		StringAssert.Contains(result.Reason, "does not have any observation rooms configured");
+	}
+
+	[TestMethod]
+	public void CanObserve_WhenObserverIsInObservationCell_ReturnsTrue()
+	{
+		var observer = new Mock<ICharacter>();
+		observer.SetupGet(x => x.State).Returns(CharacterState.Conscious);
+		var observationCell = new Mock<ICell>();
+		observer.SetupGet(x => x.Location).Returns(observationCell.Object);
+		var arena = new Mock<ICombatArena>();
+		arena.Setup(x => x.ObservationCells).Returns(new[] { observationCell.Object });
+		var arenaEvent = new Mock<IArenaEvent>();
+		arenaEvent.Setup(x => x.Arena).Returns(arena.Object);
+		arenaEvent.Setup(x => x.State).Returns(ArenaEventState.Live);
+		arenaEvent.Setup(x => x.Participants).Returns(Array.Empty<IArenaParticipant>());
+		var result = _service.CanObserve(observer.Object, arenaEvent.Object);
+		Assert.IsTrue(result.Truth);
+		Assert.AreEqual(string.Empty, result.Reason);
+	}
+}

--- a/MudSharpCore Unit Tests/Arenas/ArenaWatcherEffectTests.cs
+++ b/MudSharpCore Unit Tests/Arenas/ArenaWatcherEffectTests.cs
@@ -1,0 +1,104 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Arenas;
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Effects;
+using MudSharp.Framework;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Outputs;
+
+namespace MudSharp_Unit_Tests.Arenas;
+
+[TestClass]
+public class ArenaWatcherEffectTests
+{
+        private Mock<IFuturemud> _gameworld = null!;
+        private Mock<ICell> _arenaCell = null!;
+        private Mock<IArenaEvent> _arenaEvent = null!;
+        private Mock<ICombatArena> _arena = null!;
+        private Mock<IOutput> _output = null!;
+        private ArenaWatcherEffect _effect = null!;
+
+        [TestInitialize]
+        public void Setup()
+        {
+                _gameworld = new Mock<IFuturemud>();
+                _arenaCell = new Mock<ICell>();
+                _arenaCell.SetupGet(x => x.Gameworld).Returns(_gameworld.Object);
+                _arenaCell.Setup(x => x.RemoveEffect(It.IsAny<IEffect>()));
+                _arenaCell.Setup(x => x.HowSeen(It.IsAny<IPerceiver>(), It.IsAny<bool>(), It.IsAny<DescriptionType>(),
+                        It.IsAny<bool>(), It.IsAny<PerceiveIgnoreFlags>())).Returns("the arena floor");
+
+                _arena = new Mock<ICombatArena>();
+                _arena.SetupGet(x => x.Name).Returns("The Pit");
+
+                _arenaEvent = new Mock<IArenaEvent>();
+                _arenaEvent.SetupGet(x => x.Arena).Returns(_arena.Object);
+                _arenaEvent.SetupGet(x => x.State).Returns(ArenaEventState.Live);
+
+                _output = new Mock<IOutput>();
+                _output.SetupGet(x => x.Flags).Returns(OutputFlags.Normal);
+                _output.Setup(x => x.ShouldSee(It.IsAny<ICharacter>())).Returns(true);
+
+                _effect = new ArenaWatcherEffect(_arenaCell.Object, _arenaEvent.Object);
+        }
+
+        [TestMethod]
+        public void HandleOutput_WatcherMovesWithinObservationRooms_RetainsSubscription()
+        {
+                var observationCell1 = new Mock<ICell>();
+                observationCell1.SetupGet(x => x.Gameworld).Returns(_gameworld.Object);
+                var observationCell2 = new Mock<ICell>();
+                observationCell2.SetupGet(x => x.Gameworld).Returns(_gameworld.Object);
+                _arena.Setup(x => x.ObservationCells).Returns(new[]
+                {
+                        observationCell1.Object,
+                        observationCell2.Object
+                });
+
+                var watcherLocation = observationCell1.Object as ICell;
+                var outputHandler = new Mock<IOutputHandler>();
+                var watcher = new Mock<ICharacter>();
+                watcher.SetupGet(x => x.State).Returns(CharacterState.Conscious);
+                watcher.SetupGet(x => x.OutputHandler).Returns(outputHandler.Object);
+                watcher.SetupGet(x => x.Location).Returns(() => watcherLocation);
+
+                _effect.AddWatcher(watcher.Object, observationCell1.Object);
+
+                _effect.HandleOutput(_output.Object, _arenaCell.Object);
+                outputHandler.Invocations.Clear();
+
+                watcherLocation = observationCell2.Object;
+                _effect.HandleOutput(_output.Object, _arenaCell.Object);
+
+                outputHandler.Verify(x => x.Send(It.IsAny<IOutput>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Once());
+        }
+
+        [TestMethod]
+        public void HandleOutput_WatcherLeavesObservationRooms_RemovesSubscription()
+        {
+                var observationCell = new Mock<ICell>();
+                observationCell.SetupGet(x => x.Gameworld).Returns(_gameworld.Object);
+                var otherCell = new Mock<ICell>();
+                otherCell.SetupGet(x => x.Gameworld).Returns(_gameworld.Object);
+                _arena.Setup(x => x.ObservationCells).Returns(new[] { observationCell.Object });
+
+                var watcherLocation = observationCell.Object as ICell;
+                var outputHandler = new Mock<IOutputHandler>();
+                var watcher = new Mock<ICharacter>();
+                watcher.SetupGet(x => x.State).Returns(CharacterState.Conscious);
+                watcher.SetupGet(x => x.OutputHandler).Returns(outputHandler.Object);
+                watcher.SetupGet(x => x.Location).Returns(() => watcherLocation);
+
+                _effect.AddWatcher(watcher.Object, observationCell.Object);
+
+                watcherLocation = otherCell.Object;
+                _effect.HandleOutput(_output.Object, _arenaCell.Object);
+
+                outputHandler.Verify(x => x.Send(It.IsAny<IOutput>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Never());
+                _arenaCell.Verify(x => x.RemoveEffect(_effect), Times.Once());
+        }
+}

--- a/MudSharpCore/Arenas/Observation/ArenaObservationService.cs
+++ b/MudSharpCore/Arenas/Observation/ArenaObservationService.cs
@@ -1,0 +1,125 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Effects;
+using MudSharp.Framework;
+
+namespace MudSharp.Arenas;
+
+/// <summary>
+/// 	Manages the linkage between arena events and remote observation rooms.
+/// </summary>
+public class ArenaObservationService : IArenaObservationService
+{
+	private readonly IFuturemud _gameworld;
+
+	public ArenaObservationService(IFuturemud gameworld)
+	{
+		_gameworld = gameworld ?? throw new ArgumentNullException(nameof(gameworld));
+	}
+
+	public (bool Truth, string Reason) CanObserve(ICharacter observer, IArenaEvent arenaEvent)
+	{
+		if (observer is null)
+		{
+			return (false, "There is no observer to watch the arena.");
+		}
+
+		if (arenaEvent is null)
+		{
+			return (false, "There is no such arena event to observe.");
+		}
+
+		if (!observer.State.HasFlag(CharacterState.Conscious))
+		{
+			return (false, "You must be conscious to observe the arena.");
+		}
+
+		if (arenaEvent.State is ArenaEventState.Completed or ArenaEventState.Aborted)
+		{
+			return (false, "That arena event is no longer running.");
+		}
+
+		if (arenaEvent.State < ArenaEventState.Staged)
+		{
+			return (false, "The event has not been staged for observation yet.");
+		}
+
+		if (arenaEvent.Participants.Any(x => x.Character == observer))
+		{
+			return (false, "Participants cannot observe the event from the observation rooms.");
+		}
+
+		var observationCells = arenaEvent.Arena.ObservationCells.ToList();
+		if (!observationCells.Any())
+		{
+			return (false, $"{arenaEvent.Arena.Name} does not have any observation rooms configured.");
+		}
+
+		if (observer.Location is not ICell currentCell || !observationCells.Contains(currentCell))
+		{
+			return (false, "You must be in one of the arena's observation rooms to observe the event.");
+		}
+
+		return (true, string.Empty);
+	}
+
+	public void StartObserving(ICharacter observer, IArenaEvent arenaEvent, ICell observationCell)
+	{
+		if (observer is null)
+		{
+			throw new ArgumentNullException(nameof(observer));
+		}
+
+		if (arenaEvent is null)
+		{
+			throw new ArgumentNullException(nameof(arenaEvent));
+		}
+
+		if (observationCell is null)
+		{
+			throw new ArgumentNullException(nameof(observationCell));
+		}
+
+		if (!arenaEvent.Arena.ObservationCells.Contains(observationCell))
+		{
+			throw new InvalidOperationException("The specified cell is not configured as an observation room for this arena.");
+		}
+
+		foreach (var cell in arenaEvent.Arena.ArenaCells)
+		{
+			var effect = cell.EffectsOfType<ArenaWatcherEffect>()
+				.FirstOrDefault(x => ReferenceEquals(x.ArenaEvent, arenaEvent));
+
+			if (effect is null)
+			{
+				effect = new ArenaWatcherEffect(cell, arenaEvent);
+				cell.AddEffect(effect);
+			}
+
+			effect.AddWatcher(observer, observationCell);
+		}
+	}
+
+	public void StopObserving(ICharacter observer, IArenaEvent arenaEvent)
+	{
+		if (observer is null || arenaEvent is null)
+		{
+			return;
+		}
+
+		foreach (var cell in arenaEvent.Arena.ArenaCells)
+		{
+			foreach (var effect in cell.EffectsOfType<ArenaWatcherEffect>()
+				.Where(x => ReferenceEquals(x.ArenaEvent, arenaEvent))
+				.ToList())
+			{
+				effect.RemoveWatcher(observer);
+			}
+		}
+	}
+}

--- a/MudSharpCore/Arenas/Observation/ArenaWatcherEffect.cs
+++ b/MudSharpCore/Arenas/Observation/ArenaWatcherEffect.cs
@@ -1,0 +1,279 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Effects;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.Health;
+using MudSharp.Movement;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Outputs;
+using MudSharp.RPG.Checks;
+
+namespace MudSharp.Arenas;
+
+/// <summary>
+/// 	Mirrors arena combat output into observation rooms while enforcing perception gating.
+/// </summary>
+public sealed class ArenaWatcherEffect : Effect, IRemoteObservationEffect
+{
+	private const int AdditionalNoticeStages = 2;
+
+	private readonly IArenaEvent _arenaEvent;
+	private readonly Dictionary<ICharacter, ICell> _watchers = new();
+
+	public ArenaWatcherEffect(ICell owner, IArenaEvent arenaEvent) : base(owner)
+	{
+		_arenaEvent = arenaEvent ?? throw new ArgumentNullException(nameof(arenaEvent));
+	}
+
+	public IArenaEvent ArenaEvent => _arenaEvent;
+
+	protected override string SpecificEffectType => "ArenaWatcher";
+
+	public override string Describe(IPerceiver voyeur)
+	{
+		return $"Mirroring arena event {_arenaEvent.Name.ColourName()} to observation rooms.";
+	}
+
+        public void AddWatcher(ICharacter watcher, ICell observationCell)
+        {
+                if (watcher is null)
+                {
+                        return;
+                }
+
+                if (observationCell is null)
+                {
+                        throw new ArgumentNullException(nameof(observationCell));
+                }
+
+                var effectiveCell = observationCell;
+                if (watcher.Location is ICell currentCell &&
+                        _arenaEvent.Arena.ObservationCells.Contains(currentCell))
+                {
+                        effectiveCell = currentCell;
+                }
+
+                if (_watchers.ContainsKey(watcher))
+                {
+                        _watchers[watcher] = effectiveCell;
+                        return;
+                }
+
+                _watchers.Add(watcher, effectiveCell);
+                RegisterWatcher(watcher);
+        }
+
+	public void RemoveWatcher(ICharacter watcher)
+	{
+		if (watcher is null)
+		{
+			return;
+		}
+
+		if (!_watchers.Remove(watcher))
+		{
+			return;
+		}
+
+		UnregisterWatcher(watcher);
+		TryDeactivate();
+	}
+
+	public override void RemovalEffect()
+	{
+		foreach (var watcher in _watchers.Keys.ToList())
+		{
+			UnregisterWatcher(watcher);
+		}
+
+		_watchers.Clear();
+	}
+
+	public void HandleOutput(IOutput output, ILocation location)
+	{
+		if (output is null)
+		{
+			return;
+		}
+
+		if (_arenaEvent.State is ArenaEventState.Completed or ArenaEventState.Aborted)
+		{
+			Owner.RemoveEffect(this);
+			return;
+		}
+
+		PruneInvalidWatchers();
+		if (_watchers.Count == 0)
+		{
+			TryDeactivate();
+			return;
+		}
+
+		var forwarded = PrepareForwardedOutput(output);
+		var forwardedEmote = forwarded as EmoteOutput;
+
+		foreach (var watcher in _watchers.Keys.ToList())
+		{
+			if (!forwarded.ShouldSee(watcher))
+			{
+				continue;
+			}
+
+			if (forwardedEmote is not null)
+			{
+				watcher.SeeTarget(forwardedEmote.DefaultSource as IMortalPerceiver);
+			}
+
+			var prefix = BuildPrefix(watcher, location);
+			watcher.OutputHandler.Send(new PrependOutputWrapper(forwarded, prefix));
+		}
+	}
+
+	private void PruneInvalidWatchers()
+	{
+		var removed = false;
+		foreach (var (watcher, observationCell) in _watchers.ToList())
+		{
+			if (!IsWatcherValid(watcher, observationCell))
+			{
+				_watchers.Remove(watcher);
+				UnregisterWatcher(watcher);
+				removed = true;
+			}
+		}
+
+		if (removed)
+		{
+			TryDeactivate();
+		}
+	}
+
+        private bool IsWatcherValid(ICharacter watcher, ICell observationCell)
+        {
+                if (!watcher.State.HasFlag(CharacterState.Conscious))
+                {
+                        return false;
+                }
+
+                if (watcher.Location is not ICell currentCell)
+                {
+                        return false;
+                }
+
+                if (!_arenaEvent.Arena.ObservationCells.Contains(currentCell))
+                {
+                        return false;
+                }
+
+                if (!ReferenceEquals(currentCell, observationCell))
+                {
+                        _watchers[watcher] = currentCell;
+                }
+
+                return true;
+        }
+
+	private void RegisterWatcher(ICharacter watcher)
+	{
+		watcher.OnQuit -= WatcherInvalidated;
+		watcher.OnQuit += WatcherInvalidated;
+		watcher.OnDeleted -= WatcherInvalidated;
+		watcher.OnDeleted += WatcherInvalidated;
+		watcher.OnDeath -= WatcherInvalidated;
+		watcher.OnDeath += WatcherInvalidated;
+		watcher.OnStateChanged -= WatcherStateChanged;
+		watcher.OnStateChanged += WatcherStateChanged;
+		watcher.OnMoved -= WatcherMoved;
+		watcher.OnMoved += WatcherMoved;
+	}
+
+	private void UnregisterWatcher(ICharacter watcher)
+	{
+		watcher.OnQuit -= WatcherInvalidated;
+		watcher.OnDeleted -= WatcherInvalidated;
+		watcher.OnDeath -= WatcherInvalidated;
+		watcher.OnStateChanged -= WatcherStateChanged;
+		watcher.OnMoved -= WatcherMoved;
+	}
+
+	private void WatcherInvalidated(IPerceivable owner)
+	{
+		if (owner is ICharacter watcher)
+		{
+			RemoveWatcher(watcher);
+		}
+	}
+
+	private void WatcherStateChanged(IPerceivable owner)
+	{
+		if (owner is ICharacter watcher && _watchers.ContainsKey(watcher) &&
+			!watcher.State.HasFlag(CharacterState.Conscious))
+		{
+			RemoveWatcher(watcher);
+		}
+	}
+
+        private void WatcherMoved(object? sender, MoveEventArgs e)
+        {
+                if (sender is not ICharacter watcher)
+                {
+                        return;
+                }
+
+                if (!_watchers.ContainsKey(watcher))
+                {
+                        return;
+                }
+
+                if (watcher.Location is ICell currentCell &&
+                        _arenaEvent.Arena.ObservationCells.Contains(currentCell))
+                {
+                        _watchers[watcher] = currentCell;
+                        return;
+                }
+
+                RemoveWatcher(watcher);
+        }
+
+	private IOutput PrepareForwardedOutput(IOutput original)
+	{
+		if (original is not EmoteOutput emote)
+		{
+			return original;
+		}
+
+		var forwarded = new EmoteOutput(emote);
+		if (forwarded.Flags.HasFlag(OutputFlags.NoticeCheckRequired))
+		{
+			forwarded.NoticeCheckDifficulty = forwarded.NoticeCheckDifficulty.StageUp(AdditionalNoticeStages);
+		}
+		else if (forwarded.Flags.HasFlag(OutputFlags.PurelyAudible))
+		{
+			forwarded.Flags |= OutputFlags.NoticeCheckRequired;
+			forwarded.NoticeCheckDifficulty = Difficulty.Normal.StageUp(AdditionalNoticeStages);
+		}
+
+		return forwarded;
+	}
+
+	private string BuildPrefix(ICharacter watcher, ILocation location)
+	{
+		var arenaName = _arenaEvent.Arena.Name.ColourName();
+		var cellName = (location?.HowSeen(watcher) ?? "the arena floor").ColourName();
+		return $"[{arenaName} @ {cellName}] ";
+	}
+
+	private void TryDeactivate()
+	{
+		if (_watchers.Count == 0)
+		{
+			Owner.RemoveEffect(this);
+		}
+	}
+}

--- a/MudSharpCore/Framework/Futuremud.cs
+++ b/MudSharpCore/Framework/Futuremud.cs
@@ -132,6 +132,7 @@ public sealed partial class Futuremud : IFuturemud, IDisposable
 		Scheduler = new Scheduler();
 		ArenaLifecycleService = new ArenaLifecycleService(this);
 		ArenaScheduler = new ArenaScheduler(this, ArenaLifecycleService);
+		ArenaObservationService = new ArenaObservationService(this);
 		SaveManager = new SaveManager();
 		HeartbeatManager = new HeartbeatManager(this);
 

--- a/MudSharpCore/Framework/FuturemudLoaders.cs
+++ b/MudSharpCore/Framework/FuturemudLoaders.cs
@@ -142,6 +142,7 @@ public sealed partial class Futuremud : IFuturemudLoader, IFuturemud, IDisposabl
 	public IScheduler Scheduler { get; protected set; }
 	public IArenaLifecycleService ArenaLifecycleService { get; protected set; }
 	public IArenaScheduler ArenaScheduler { get; protected set; }
+	public IArenaObservationService ArenaObservationService { get; protected set; }
 	public IEffectScheduler EffectScheduler { get; protected set; }
 	public ISaveManager SaveManager { get; protected set; }
 	public IGameItemComponentManager GameItemComponentManager { get; protected set; }


### PR DESCRIPTION
## Summary
- let the arena watcher effect follow spectators as they move between observation rooms while staying conscious
- update watcher pruning so leaving the observation area removes the subscription immediately
- add unit tests that cover the watcher effect for both valid movement and leaving the observation rooms

## Testing
- dotnet test --no-build 'MudSharpCore Unit Tests/MudSharpCore Unit Tests.csproj' *(fails: Microsoft.Build.Exceptions.InternalLoggerException from TerminalLogger.WrapText)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69125e042968832395a5893ceb09d0bd)