### PR TITLE
Add arena ratings service with default Elo

### DIFF
--- a/MudSharpCore Unit Tests/Arenas/ArenaRatingsServiceTests.cs
+++ b/MudSharpCore Unit Tests/Arenas/ArenaRatingsServiceTests.cs
@@ -1,0 +1,155 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Arenas;
+using MudSharp.Character;
+using MudSharp.Database;
+using MudSharp.FutureProg;
+using MudSharp.Framework;
+
+namespace MudSharp_Unit_Tests.Arenas;
+
+[TestClass]
+public class ArenaRatingsServiceTests
+{
+	[TestMethod]
+	public void GetRating_ReturnsDefault_WhenNoRecordExists()
+	{
+		using var context = BuildContext();
+		var service = CreateService(context);
+		var character = new Mock<ICharacter>();
+		character.SetupGet(x => x.Id).Returns(42L);
+		var combatantClass = new Mock<ICombatantClass>();
+		combatantClass.SetupGet(x => x.Id).Returns(7L);
+
+		var rating = service.GetRating(character.Object, combatantClass.Object);
+
+		Assert.AreEqual(1500.0m, rating);
+	}
+
+	[TestMethod]
+	public void UpdateRatings_CreatesAndUpdatesRecords()
+	{
+		using var context = BuildContext();
+		var service = CreateService(context);
+		var arena = new Mock<ICombatArena>();
+		arena.SetupGet(x => x.Id).Returns(11L);
+
+		var participantA = BuildParticipant(10L, 100L, 0, 1500.0m);
+		var participantB = BuildParticipant(20L, 200L, 1, 1500.0m);
+
+		var evt = new Mock<IArenaEvent>();
+		evt.SetupGet(x => x.Arena).Returns(arena.Object);
+		evt.SetupGet(x => x.Participants)
+		   .Returns(new[] { participantA.Participant.Object, participantB.Participant.Object });
+
+		var deltas = new Dictionary<ICharacter, decimal>
+		{
+			{ participantA.Character.Object, 12.5m },
+			{ participantB.Character.Object, -7.5m }
+		};
+
+		service.UpdateRatings(evt.Object, deltas);
+
+		var records = context.ArenaRatings.ToList();
+		Assert.AreEqual(2, records.Count);
+		Assert.AreEqual(1512.50m, records.Single(x => x.CharacterId == 10L).Rating);
+		Assert.AreEqual(1492.50m, records.Single(x => x.CharacterId == 20L).Rating);
+
+		var followUp = new Dictionary<ICharacter, decimal>
+		{
+			{ participantA.Character.Object, -2.5m }
+		};
+
+		service.UpdateRatings(evt.Object, followUp);
+
+		var updated = context.ArenaRatings.Single(x => x.CharacterId == 10L);
+		Assert.AreEqual(1510.00m, updated.Rating);
+	}
+
+	[TestMethod]
+	public void ApplyDefaultElo_ComputesWinnerAndLoserDeltas()
+	{
+		using var context = BuildContext();
+		var service = CreateService(context);
+		var arena = new Mock<ICombatArena>();
+		arena.SetupGet(x => x.Id).Returns(5L);
+
+		var winningParticipant = BuildParticipant(30L, 300L, 0, 1500.0m);
+		var losingParticipant = BuildParticipant(40L, 400L, 1, 1500.0m);
+
+		var evt = new Mock<IArenaEvent>();
+		evt.SetupGet(x => x.Arena).Returns(arena.Object);
+		evt.SetupGet(x => x.Participants)
+		   .Returns(new[] { winningParticipant.Participant.Object, losingParticipant.Participant.Object });
+		evt.Setup(x => x.GetProperty("Outcome"))
+		   .Returns(new TestProgVariable(ArenaOutcome.Win, ProgVariableTypes.Text));
+		evt.Setup(x => x.GetProperty("WinningSides"))
+		   .Returns(new TestProgVariable(new[] { 0 }, ProgVariableTypes.Collection | ProgVariableTypes.Number));
+
+		service.ApplyDefaultElo(evt.Object);
+
+		var ratings = context.ArenaRatings.ToDictionary(x => x.CharacterId, x => x.Rating);
+		Assert.AreEqual(1516.00m, ratings[30L]);
+		Assert.AreEqual(1484.00m, ratings[40L]);
+	}
+
+	private static FuturemudDatabaseContext BuildContext()
+	{
+		var options = new DbContextOptionsBuilder<FuturemudDatabaseContext>()
+		    .UseInMemoryDatabase(Guid.NewGuid().ToString())
+		    .Options;
+		return new FuturemudDatabaseContext(options);
+	}
+
+	private static ArenaRatingsService CreateService(FuturemudDatabaseContext context)
+	{
+		var gameworld = new Mock<IFuturemud>();
+		return new ArenaRatingsService(gameworld.Object, () => context);
+	}
+
+	private static (Mock<IArenaParticipant> Participant, Mock<ICharacter> Character, Mock<ICombatantClass> CombatantClass) BuildParticipant(
+		long characterId,
+		long classId,
+		int sideIndex,
+		decimal? startingRating = null,
+		bool isNpc = false)
+	{
+		var character = new Mock<ICharacter>();
+		character.SetupGet(x => x.Id).Returns(characterId);
+		var combatantClass = new Mock<ICombatantClass>();
+		combatantClass.SetupGet(x => x.Id).Returns(classId);
+		var participant = new Mock<IArenaParticipant>();
+		participant.SetupGet(x => x.Character).Returns(character.Object);
+		participant.SetupGet(x => x.CombatantClass).Returns(combatantClass.Object);
+		participant.SetupGet(x => x.SideIndex).Returns(sideIndex);
+		participant.SetupGet(x => x.IsNpc).Returns(isNpc);
+		participant.SetupGet(x => x.StartingRating).Returns(startingRating);
+		return (participant, character, combatantClass);
+	}
+
+	private sealed class TestProgVariable : IProgVariable
+	{
+		private readonly object _value;
+		private readonly ProgVariableTypes _type;
+
+		public TestProgVariable(object value, ProgVariableTypes type)
+		{
+			_value = value;
+			_type = type;
+		}
+
+		public ProgVariableTypes Type => _type;
+
+		public object GetObject => _value;
+
+		public IProgVariable GetProperty(string property)
+		{
+			throw new NotSupportedException();
+		}
+	}
+}

--- a/MudSharpCore/Arenas/Ratings/ArenaRatingsService.cs
+++ b/MudSharpCore/Arenas/Ratings/ArenaRatingsService.cs
@@ -1,0 +1,352 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MudSharp.Arenas;
+using MudSharp.Character;
+using MudSharp.Database;
+using MudSharp.Framework;
+using MudSharp.Models;
+
+namespace MudSharp.Arenas;
+
+/// <summary>
+/// 	Persists combat arena ratings and provides a default Elo implementation.
+/// </summary>
+public class ArenaRatingsService : IArenaRatingsService
+{
+	private const decimal DefaultRating = 1500.0m;
+	private const decimal DefaultKFactor = 32.0m;
+
+	private readonly IFuturemud _gameworld;
+	private readonly Func<FuturemudDatabaseContext>? _contextFactory;
+
+	public ArenaRatingsService(IFuturemud gameworld, Func<FuturemudDatabaseContext>? contextFactory = null)
+	{
+		_gameworld = gameworld ?? throw new ArgumentNullException(nameof(gameworld));
+		_contextFactory = contextFactory;
+	}
+
+	/// <inheritdoc />
+	public decimal GetRating(ICharacter character, ICombatantClass combatantClass)
+	{
+		if (character is null)
+		{
+			throw new ArgumentNullException(nameof(character));
+		}
+
+		if (combatantClass is null)
+		{
+			throw new ArgumentNullException(nameof(combatantClass));
+		}
+
+		using var scope = BeginContext(out var context);
+		var rating = context.ArenaRatings.FirstOrDefault(x => x.CharacterId == character.Id &&
+		                                               x.CombatantClassId == combatantClass.Id);
+		return rating?.Rating ?? DefaultRating;
+	}
+
+	/// <inheritdoc />
+	public void UpdateRatings(IArenaEvent arenaEvent, IReadOnlyDictionary<ICharacter, decimal> deltas)
+	{
+		if (arenaEvent is null)
+		{
+			throw new ArgumentNullException(nameof(arenaEvent));
+		}
+
+		if (deltas is null)
+		{
+			throw new ArgumentNullException(nameof(deltas));
+		}
+
+		if (deltas.Count == 0)
+		{
+			return;
+		}
+
+		var participantsByCharacterId = arenaEvent.Participants
+		                                     .Where(x => x.Character is not null)
+		                                     .GroupBy(x => x.Character.Id)
+		                                     .ToDictionary(x => x.Key, x => x.First());
+
+		if (participantsByCharacterId.Count == 0)
+		{
+			return;
+		}
+
+		using var scope = BeginContext(out var context);
+		var now = DateTime.UtcNow;
+		foreach (var (character, delta) in deltas)
+		{
+			if (character is null)
+			{
+				continue;
+			}
+
+			if (!participantsByCharacterId.TryGetValue(character.Id, out var participant))
+			{
+				continue;
+			}
+
+			var combatantClass = participant.CombatantClass;
+			if (combatantClass is null)
+			{
+				continue;
+			}
+
+			var rating = context.ArenaRatings.FirstOrDefault(x => x.CharacterId == character.Id &&
+			                                               x.CombatantClassId == combatantClass.Id);
+			if (rating is null)
+			{
+				rating = new ArenaRating
+				{
+					ArenaId = arenaEvent.Arena.Id,
+					CharacterId = character.Id,
+					CombatantClassId = combatantClass.Id,
+					Rating = participant.StartingRating ?? DefaultRating,
+					LastUpdatedAt = now
+				};
+				context.ArenaRatings.Add(rating);
+			}
+
+			rating.Rating = Math.Round(rating.Rating + delta, 2, MidpointRounding.AwayFromZero);
+			rating.LastUpdatedAt = now;
+		}
+
+		context.SaveChanges();
+	}
+
+	/// <inheritdoc />
+	public void ApplyDefaultElo(IArenaEvent arenaEvent)
+	{
+		if (arenaEvent is null)
+		{
+			throw new ArgumentNullException(nameof(arenaEvent));
+		}
+
+		var participants = arenaEvent.Participants
+		                            .Where(x => x.Character is not null && !x.IsNpc)
+		                            .ToList();
+		if (participants.Count < 2)
+		{
+			return;
+		}
+
+		var (outcome, winningSides) = ResolveOutcome(arenaEvent);
+		if (outcome is null || outcome == ArenaOutcome.Aborted)
+		{
+			return;
+		}
+
+		var sideGroups = participants.GroupBy(x => x.SideIndex).ToList();
+		if (sideGroups.Count < 2)
+		{
+			return;
+		}
+
+		var sideRatings = sideGroups.ToDictionary(
+		group => group.Key,
+		group => group.Select(p => p.StartingRating ?? GetRating(p.Character, p.CombatantClass))
+		      .DefaultIfEmpty(DefaultRating)
+		      .Average());
+
+		var deltaByCharacter = new Dictionary<ICharacter, decimal>();
+		var winningSet = winningSides?.ToHashSet() ?? new HashSet<int>();
+
+		foreach (var group in sideGroups)
+		{
+			var actual = ComputeActualScore(outcome.Value, group.Key, winningSet, sideGroups.Count);
+			var expected = ComputeExpectedScore(group.Key, sideRatings);
+			var sideDelta = DefaultKFactor * (actual - expected);
+
+			var members = group.ToList();
+			if (members.Count == 0)
+			{
+				continue;
+			}
+
+			var perParticipantDelta = sideDelta / members.Count;
+			foreach (var participant in members)
+			{
+				var character = participant.Character;
+				if (character is null)
+				{
+					continue;
+				}
+
+				deltaByCharacter[character] = deltaByCharacter.TryGetValue(character, out var existing)
+					? existing + perParticipantDelta
+					: perParticipantDelta;
+			}
+		}
+
+		if (deltaByCharacter.Count == 0)
+		{
+			return;
+		}
+
+		UpdateRatings(arenaEvent, deltaByCharacter);
+	}
+
+	private IDisposable? BeginContext(out FuturemudDatabaseContext context)
+	{
+		if (_contextFactory is not null)
+		{
+			context = _contextFactory();
+			return null;
+		}
+
+		var scope = new FMDB();
+		context = FMDB.Context;
+		return scope;
+	}
+
+	private static (ArenaOutcome?, IReadOnlyCollection<int>?) ResolveOutcome(IArenaEvent arenaEvent)
+	{
+		var outcome = TryExtractOutcome(arenaEvent);
+		var winningSides = TryExtractWinningSides(arenaEvent);
+		return (outcome, winningSides);
+	}
+
+	private static ArenaOutcome? TryExtractOutcome(IArenaEvent arenaEvent)
+	{
+		var property = arenaEvent.GetType().GetProperty("Outcome");
+		if (property is not null)
+		{
+			var value = property.GetValue(arenaEvent);
+			if (TryConvertOutcome(value, out var outcomeFromProperty))
+			{
+				return outcomeFromProperty;
+			}
+		}
+
+		try
+		{
+			var variable = arenaEvent.GetProperty("Outcome");
+			if (variable is not null && TryConvertOutcome(variable.GetObject, out var outcomeFromVariable))
+			{
+				return outcomeFromVariable;
+			}
+		}
+		catch
+		{
+			// ignored -- if the event does not expose an outcome we skip rating adjustments.
+		}
+
+		return null;
+	}
+
+	private static IReadOnlyCollection<int>? TryExtractWinningSides(IArenaEvent arenaEvent)
+	{
+		var property = arenaEvent.GetType().GetProperty("WinningSides");
+		if (property is not null)
+		{
+			var value = property.GetValue(arenaEvent);
+			if (TryConvertWinningSides(value, out var sidesFromProperty))
+			{
+				return sidesFromProperty;
+			}
+		}
+
+		try
+		{
+			var variable = arenaEvent.GetProperty("WinningSides");
+			if (variable is not null && TryConvertWinningSides(variable.GetObject, out var sidesFromVariable))
+			{
+				return sidesFromVariable;
+			}
+		}
+		catch
+		{
+			// ignored -- optional metadata.
+		}
+
+		return null;
+	}
+
+	private static bool TryConvertOutcome(object? value, out ArenaOutcome outcome)
+	{
+		switch (value)
+		{
+			case null:
+				outcome = default;
+				return false;
+			case ArenaOutcome typed:
+				outcome = typed;
+				return true;
+			case string text when Enum.TryParse<ArenaOutcome>(text, true, out var parsed):
+				outcome = parsed;
+				return true;
+			case int numeric when Enum.IsDefined(typeof(ArenaOutcome), numeric):
+				outcome = (ArenaOutcome)numeric;
+				return true;
+			default:
+				outcome = default;
+				return false;
+		}
+	}
+
+	private static bool TryConvertWinningSides(object? value, out IReadOnlyCollection<int> sides)
+	{
+		switch (value)
+		{
+			case null:
+				sides = Array.Empty<int>();
+				return false;
+			case IReadOnlyCollection<int> collection:
+				sides = collection;
+				return true;
+			case IEnumerable<int> enumerable:
+				sides = enumerable.ToList();
+				return true;
+			case IEnumerable<long> longs:
+				sides = longs.Select(x => (int)x).ToList();
+				return true;
+			case IEnumerable<object> objects:
+				sides = objects.Select(Convert.ToInt32).ToList();
+				return true;
+			default:
+				sides = Array.Empty<int>();
+				return false;
+		}
+	}
+
+	private static decimal ComputeActualScore(ArenaOutcome outcome, int sideIndex, IReadOnlySet<int> winningSides, int totalSides)
+	{
+		return outcome switch
+		{
+			ArenaOutcome.Win => winningSides.Count == 0
+				? (totalSides == 2 ? 1.0m : 0.0m)
+				: (winningSides.Contains(sideIndex) ? 1.0m : 0.0m),
+			ArenaOutcome.Draw => 0.5m,
+			_ => 0.0m
+		};
+	}
+
+	private static decimal ComputeExpectedScore(int sideIndex, IReadOnlyDictionary<int, decimal> sideRatings)
+	{
+		var rating = sideRatings.TryGetValue(sideIndex, out var value) ? value : DefaultRating;
+		var total = 0.0m;
+		var comparisons = 0;
+
+		foreach (var (otherSide, otherRating) in sideRatings)
+		{
+			if (otherSide == sideIndex)
+			{
+				continue;
+			}
+
+			comparisons++;
+			var exponent = (double)((otherRating - rating) / 400.0m);
+			var denominator = 1.0 + Math.Pow(10.0, exponent);
+			total += (decimal)(1.0 / denominator);
+		}
+
+		if (comparisons == 0)
+		{
+			return 0.5m;
+		}
+
+		return total / comparisons;
+	}
+}


### PR DESCRIPTION
## Summary
- implement `ArenaRatingsService` to persist combatant ratings, supply lookup/update helpers, and apply a default Elo calculation
- add arena ratings unit tests covering rating persistence and default Elo deltas

## Testing
- `dotnet test 'MudSharpCore Unit Tests/MudSharpCore Unit Tests.csproj' --filter "FullyQualifiedName~ArenaRatingsServiceTests" --logger "console;verbosity=minimal" *(fails: existing build error in MudSharpCore/Arenas/Betting/ArenaBettingService.cs)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691283cfb2208323a23740619352db26)