### PR TITLE
Add arena command UX and supporting helpers

### DIFF
--- a/FutureMUDLibrary/Framework/IFuturemud.cs
+++ b/FutureMUDLibrary/Framework/IFuturemud.cs
@@ -263,7 +263,8 @@ namespace MudSharp.Framework
 		IUneditableAll<IEconomicZone> EconomicZones { get; }
 		IUneditableAll<IGroupAITemplate> GroupAITemplates { get; }
 		IUneditableAll<IGroupAI> GroupAIs { get; }
-		IUneditableAll<ILineOfCreditAccount> LineOfCreditAccounts { get; }
+                IUneditableAll<ILineOfCreditAccount> LineOfCreditAccounts { get; }
+                IUneditableAll<ICombatArena> CombatArenas { get; }
 		IChargenStoryboard ChargenStoryboard { get; }
 		RankedRange<ICharacteristicValue> RelativeHeightDescriptors { get; }
 		ILanguageScrambler LanguageScrambler { get; }
@@ -297,11 +298,16 @@ namespace MudSharp.Framework
 		MaintenanceModeSetting MaintenanceMode { get; set; }
 
 		IServer Server { get; }
-		IScheduler Scheduler { get; }
-		IArenaLifecycleService ArenaLifecycleService { get; }
-		IArenaScheduler ArenaScheduler { get; }
-		IArenaObservationService ArenaObservationService { get; }
-		IEffectScheduler EffectScheduler { get; }
+                IScheduler Scheduler { get; }
+                IArenaLifecycleService ArenaLifecycleService { get; }
+                IArenaScheduler ArenaScheduler { get; }
+                IArenaObservationService ArenaObservationService { get; }
+                IArenaFinanceService ArenaFinanceService { get; }
+                IArenaBettingService ArenaBettingService { get; }
+                IArenaRatingsService ArenaRatingsService { get; }
+                IArenaNpcService ArenaNpcService { get; }
+                IArenaCommandService ArenaCommandService { get; }
+                IEffectScheduler EffectScheduler { get; }
 		ISaveManager SaveManager { get; }
 		IGameItemComponentManager GameItemComponentManager { get; }
 		IClockManager ClockManager { get; }

--- a/MudSharpCore/Arenas/ArenaCommandService.cs
+++ b/MudSharpCore/Arenas/ArenaCommandService.cs
@@ -1,0 +1,153 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Text;
+using MudSharp.Arenas;
+using MudSharp.Character;
+using MudSharp.Economy.Currency;
+using MudSharp.Framework;
+using MudSharp.PerceptionEngine;
+using MudSharp.Character.Name;
+
+namespace MudSharp.Arenas;
+
+/// <summary>
+///     Provides formatted arena information for commands and builders.
+/// </summary>
+public class ArenaCommandService : IArenaCommandService
+{
+        private readonly IFuturemud _gameworld;
+
+        public ArenaCommandService(IFuturemud gameworld)
+        {
+                _gameworld = gameworld ?? throw new ArgumentNullException(nameof(gameworld));
+        }
+
+        /// <inheritdoc />
+        public void ShowArena(ICharacter actor, ICombatArena arena)
+        {
+                if (actor is null)
+                {
+                        throw new ArgumentNullException(nameof(actor));
+                }
+
+                if (arena is null)
+                {
+                        throw new ArgumentNullException(nameof(arena));
+                }
+
+                actor.OutputHandler.Send(arena.ShowToManager(actor));
+        }
+
+        /// <inheritdoc />
+        public void ShowEvent(ICharacter actor, IArenaEvent arenaEvent)
+        {
+                if (actor is null)
+                {
+                        throw new ArgumentNullException(nameof(actor));
+                }
+
+                if (arenaEvent is null)
+                {
+                        throw new ArgumentNullException(nameof(arenaEvent));
+                }
+
+                var sb = new StringBuilder();
+                sb.AppendLine($"Event {arenaEvent.Name.ColourName()} ({arenaEvent.EventType.Name.ColourName()})");
+                sb.AppendLine($"Arena: {arenaEvent.Arena.Name.ColourName()}");
+                sb.AppendLine($"State: {arenaEvent.State.DescribeEnum().ColourValue()}");
+                sb.AppendLine($"Scheduled: {arenaEvent.ScheduledAt.ToString("f", actor).ColourValue()}");
+                if (arenaEvent.RegistrationOpensAt is { } reg)
+                {
+                        sb.AppendLine($"Registration Opens: {reg.ToString("f", actor).ColourValue()}");
+                }
+                if (arenaEvent.StartedAt is { } started)
+                {
+                        sb.AppendLine($"Started: {started.ToString("f", actor).ColourValue()}");
+                }
+                if (arenaEvent.ResolvedAt is { } resolved)
+                {
+                        sb.AppendLine($"Resolved: {resolved.ToString("f", actor).ColourValue()}");
+                }
+                if (arenaEvent.CompletedAt is { } completed)
+                {
+                        sb.AppendLine($"Completed: {completed.ToString("f", actor).ColourValue()}");
+                }
+
+                sb.AppendLine();
+                sb.AppendLine("Participants:".Colour(Telnet.Cyan));
+                var grouped = arenaEvent.Participants.GroupBy(x => x.SideIndex).OrderBy(x => x.Key);
+                foreach (var group in grouped)
+                {
+                        var side = arenaEvent.EventType.Sides.FirstOrDefault(x => x.Index == group.Key);
+                        var title = side is null
+                                ? $"Side {group.Key}".Colour(Telnet.Yellow)
+                                : side.Index.ToString(actor).ColourValue() + $" - {side.Policy.DescribeEnum().ColourValue()}";
+                        sb.AppendLine(title);
+                        foreach (var participant in group)
+                        {
+                                var name = participant.Character?.PersonalName?.GetName(NameStyle.FullName) ??
+                                           participant.StageName ??
+                                           participant.Character?.Name ?? "NPC";
+                                var className = participant.CombatantClass?.Name ?? "Unknown";
+                                sb.AppendLine(
+                                        $"\t{name.ColourName()} ({className.ColourName()})" +
+                                        (participant.IsNpc ? " [NPC]".Colour(Telnet.Yellow) : string.Empty));
+                        }
+                }
+
+                actor.OutputHandler.Send(sb.ToString());
+        }
+
+        /// <inheritdoc />
+        public void ShowEventType(ICharacter actor, IArenaEventType eventType)
+        {
+                if (actor is null)
+                {
+                        throw new ArgumentNullException(nameof(actor));
+                }
+
+                if (eventType is null)
+                {
+                        throw new ArgumentNullException(nameof(eventType));
+                }
+
+                var sb = new StringBuilder();
+                sb.AppendLine($"Event Type {eventType.Name.ColourName()}");
+                sb.AppendLine($"Arena: {eventType.Arena.Name.ColourName()}");
+                sb.AppendLine($"Bring Your Own: {eventType.BringYourOwn.ToColouredString()}");
+                sb.AppendLine(
+                        $"Registration: {eventType.RegistrationDuration.Describe(actor).ColourValue()}, Preparation: {eventType.PreparationDuration.Describe(actor).ColourValue()}");
+                sb.AppendLine(eventType.TimeLimit is null
+                        ? "Time Limit: None".Colour(Telnet.Green)
+                        : $"Time Limit: {eventType.TimeLimit.Value.Describe(actor).ColourValue()}");
+                sb.AppendLine($"Betting: {eventType.BettingModel.DescribeEnum().ColourValue()}");
+                sb.AppendLine($"Appearance Fee: {DescribeCurrency(eventType.Arena, eventType.AppearanceFee)}");
+                sb.AppendLine($"Victory Fee: {DescribeCurrency(eventType.Arena, eventType.VictoryFee)}");
+
+                sb.AppendLine();
+                sb.AppendLine("Sides:".Colour(Telnet.Cyan));
+                foreach (var side in eventType.Sides.OrderBy(x => x.Index))
+                {
+                        sb.AppendLine($"Side {side.Index.ToString(actor).ColourValue()} (Capacity {side.Capacity.ToString(actor).ColourValue()})");
+                        sb.AppendLine($"\tPolicy: {side.Policy.DescribeEnum().ColourValue()}");
+                        sb.AppendLine($"\tAllow NPC Signup: {side.AllowNpcSignup.ToColouredString()}");
+                        sb.AppendLine($"\tAuto Fill NPC: {side.AutoFillNpc.ToColouredString()}");
+                        if (side.EligibleClasses.Any())
+                        {
+                                sb.AppendLine($"\tEligible Classes: {side.EligibleClasses.Select(x => x.Name.ColourName()).ListToString()}");
+                        }
+                        else
+                        {
+                                sb.AppendLine("\tEligible Classes: None".Colour(Telnet.Red));
+                        }
+                }
+
+                actor.OutputHandler.Send(sb.ToString());
+        }
+
+        private static string DescribeCurrency(ICombatArena arena, decimal amount)
+        {
+                return arena.Currency.Describe(amount, CurrencyDescriptionPatternType.ShortDecimal).ColourValue();
+        }
+}

--- a/MudSharpCore/Arenas/Betting/ArenaBettingService.cs
+++ b/MudSharpCore/Arenas/Betting/ArenaBettingService.cs
@@ -401,7 +401,7 @@ public class ArenaBettingService : IArenaBettingService
 	private static (decimal Pool, decimal TakeRate)? GetPoolQuote(FuturemudDatabaseContext context, long eventId, int? sideIndex)
 	{
 		var pool = context.ArenaBetPools.FirstOrDefault(x => x.ArenaEventId == eventId && x.SideIndex == sideIndex);
-		return pool is null ? (decimal Pool, decimal TakeRate)?null : (pool.TotalStake, pool.TakeRate);
+                return pool is null ? null : (pool.TotalStake, pool.TakeRate);
 	}
 
 	private ArenaBetPool GetOrCreatePool(FuturemudDatabaseContext context, long eventId, int? sideIndex)

--- a/MudSharpCore/Arenas/Finance/ArenaFinanceService.cs
+++ b/MudSharpCore/Arenas/Finance/ArenaFinanceService.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using MudSharp.Arenas;
+using MudSharp.Character;
 using MudSharp.Database;
 using MudSharp.Economy;
 using MudSharp.Framework;

--- a/MudSharpCore/Arenas/Npc/ArenaNpcService.cs
+++ b/MudSharpCore/Arenas/Npc/ArenaNpcService.cs
@@ -66,9 +66,9 @@ public class ArenaNpcService : IArenaNpcService
 
 		var effect = npc.CombinedEffectsOfType<ArenaNpcPreparationEffect>()
 		                .FirstOrDefault(x => x.EventId == arenaEvent.Id);
-		if (effect is null)
-		{
-			effect = new ArenaNpcPreparationEffect(npc, arenaEvent.Id, combatantClass.ResurrectOnReturn);
+                if (effect is null)
+                {
+                        effect = new ArenaNpcPreparationEffect(npc, arenaEvent.Id, combatantClass.ResurrectNpcOnDeath);
 			npc.AddEffect(effect);
 		}
 		else

--- a/MudSharpCore/Commands/Modules/ArenaModule.cs
+++ b/MudSharpCore/Commands/Modules/ArenaModule.cs
@@ -1,0 +1,704 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using MudSharp.Arenas;
+using MudSharp.Character;
+using MudSharp.Commands.Helpers;
+using MudSharp.Construction;
+using MudSharp.Economy.Currency;
+using MudSharp.Database;
+using MudSharp.Framework;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Outputs;
+using MudSharp.PerceptionEngine.Parsers;
+
+namespace MudSharp.Commands.Modules;
+
+internal class ArenaModule : Module<ICharacter>
+{
+        private ArenaModule()
+                : base("Arena")
+        {
+                IsNecessary = true;
+        }
+
+        public static ArenaModule Instance { get; } = new();
+
+        private const string ArenaHelp =
+                @"The #3arena#0 command provides access to combat arena features.
+
+Managers:
+        #3arena list#0 - lists known arenas
+        #3arena show <arena>#0 - shows detailed arena information
+        #3arena events <arena>#0 - lists scheduled and live events for an arena
+
+Players:
+        #3arena observe list#0 - shows events observable from your location
+        #3arena observe enter <event>#0 - begin observing an event
+        #3arena observe leave [<event>]#0 - stop observing events
+        #3arena signup <event> <side> <class>#0 - sign up for an event
+        #3arena withdraw <event>#0 - withdraw from an event
+        #3arena bet odds <event> [<side>|draw]#0 - see betting quote
+        #3arena bet place <event> <side|draw> <amount>#0 - place a wager
+        #3arena bet cancel <event>#0 - cancel your wager
+        #3arena bet pools <event>#0 - view pari-mutuel pools
+        #3arena ratings show [<class>]#0 - view your arena ratings";
+
+        [PlayerCommand("Arena", "arena")]
+        [RequiredCharacterState(CharacterState.Conscious)]
+        [NoCombatCommand]
+        [HelpInfo("arena", ArenaHelp, AutoHelp.HelpArg)]
+        protected static void Arena(ICharacter actor, string command)
+        {
+                var ss = new StringStack(command.RemoveFirstWord());
+                if (ss.IsFinished)
+                {
+                        ShowGeneralHelp(actor);
+                        return;
+                }
+
+                switch (ss.PopForSwitch())
+                {
+                        case "list":
+                                ArenaList(actor);
+                                return;
+                        case "show":
+                                ArenaShow(actor, ss);
+                                return;
+                        case "events":
+                                ArenaEvents(actor, ss);
+                                return;
+                        case "observe":
+                                ArenaObserve(actor, ss);
+                                return;
+                        case "signup":
+                                ArenaSignup(actor, ss);
+                                return;
+                        case "withdraw":
+                                ArenaWithdraw(actor, ss);
+                                return;
+                        case "bet":
+                                ArenaBet(actor, ss);
+                                return;
+                        case "ratings":
+                                ArenaRatings(actor, ss);
+                                return;
+                        default:
+                                ShowGeneralHelp(actor);
+                                return;
+                }
+        }
+
+        private static void ShowGeneralHelp(ICharacter actor)
+        {
+                actor.OutputHandler.Send(ArenaHelp.Wrap(actor.InnerLineFormatLength));
+        }
+
+        private static void ArenaList(ICharacter actor)
+        {
+                var arenas = actor.Gameworld.CombatArenas.ToList();
+                if (!arenas.Any())
+                {
+                        actor.OutputHandler.Send("There are no combat arenas configured.".ColourError());
+                        return;
+                }
+
+                var header = new[] { "Id", "Arena", "Zone", "Currency" };
+                var rows = arenas.Select(arena => new[]
+                {
+                        arena.Id.ToString("N0", actor),
+                        arena.Name.ColourName(),
+                        arena.EconomicZone.Name.ColourName(),
+                        arena.Currency.Name.ColourValue()
+                }).ToList();
+
+                actor.OutputHandler.Send(StringUtilities.GetTextTable(rows, header, actor, Telnet.Yellow));
+        }
+
+        private static void ArenaShow(ICharacter actor, StringStack ss)
+        {
+                if (ss.IsFinished)
+                {
+                        actor.OutputHandler.Send("Which arena do you want to view?".ColourCommand());
+                        return;
+                }
+
+                var arena = GetArena(actor, ss.PopSpeech());
+                if (arena is null)
+                {
+                        actor.OutputHandler.Send("There is no arena matching that description.".ColourError());
+                        return;
+                }
+
+                actor.Gameworld.ArenaCommandService.ShowArena(actor, arena);
+        }
+
+        private static void ArenaEvents(ICharacter actor, StringStack ss)
+        {
+                if (ss.IsFinished)
+                {
+                        actor.OutputHandler.Send("Which arena's events do you want to view?".ColourCommand());
+                        return;
+                }
+
+                var arena = GetArena(actor, ss.PopSpeech());
+                if (arena is null)
+                {
+                        actor.OutputHandler.Send("There is no arena matching that description.".ColourError());
+                        return;
+                }
+
+                var events = arena.ActiveEvents.ToList();
+                if (!events.Any())
+                {
+                        actor.OutputHandler.Send("There are no active or scheduled events for that arena.".ColourError());
+                        return;
+                }
+
+                var header = new[] { "Id", "Name", "Type", "State", "Scheduled" };
+                var rows = events.Select(evt => new[]
+                {
+                        evt.Id.ToString("N0", actor),
+                        evt.Name.ColourName(),
+                        evt.EventType.Name.ColourName(),
+                        evt.State.DescribeEnum().ColourValue(),
+                        evt.ScheduledAt.ToString("f", actor).ColourValue()
+                }).ToList();
+
+                actor.OutputHandler.Send(StringUtilities.GetTextTable(rows, header, actor, Telnet.Cyan));
+        }
+
+        private static void ArenaObserve(ICharacter actor, StringStack ss)
+        {
+                if (ss.IsFinished)
+                {
+                        actor.OutputHandler.Send("Do you want to #3list#0, #3enter#0, or #3leave#0 observation?".ColourCommand());
+                        return;
+                }
+
+                var action = ss.PopForSwitch();
+                switch (action)
+                {
+                        case "list":
+                                ArenaObserveList(actor);
+                                return;
+                        case "enter":
+                                ArenaObserveEnter(actor, ss);
+                                return;
+                        case "leave":
+                                ArenaObserveLeave(actor, ss);
+                                return;
+                        default:
+                                actor.OutputHandler.Send("Valid options are #3list#0, #3enter#0, or #3leave#0.".ColourError());
+                                return;
+                }
+        }
+
+        private static void ArenaObserveList(ICharacter actor)
+        {
+                if (actor.Location is not ICell cell)
+                {
+                        actor.OutputHandler.Send("You must be in a room to observe arena events.".ColourError());
+                        return;
+                }
+
+                var arenas = actor.Gameworld.CombatArenas.Where(x => x.ObservationCells.Contains(cell)).ToList();
+                if (!arenas.Any())
+                {
+                        actor.OutputHandler.Send("This location is not an arena observation room.".ColourError());
+                        return;
+                }
+
+                var events = arenas.SelectMany(x => x.ActiveEvents)
+                        .Where(x => x.State >= ArenaEventState.Staged && x.State < ArenaEventState.Completed)
+                        .Distinct()
+                        .ToList();
+
+                if (!events.Any())
+                {
+                        actor.OutputHandler.Send("There are no events available to observe from here.".ColourError());
+                        return;
+                }
+
+                var header = new[] { "Id", "Arena", "Name", "State" };
+                var rows = events.Select(evt => new[]
+                {
+                        evt.Id.ToString("N0", actor),
+                        evt.Arena.Name.ColourName(),
+                        evt.Name.ColourName(),
+                        evt.State.DescribeEnum().ColourValue()
+                }).ToList();
+
+                        actor.OutputHandler.Send(StringUtilities.GetTextTable(rows, header, actor, Telnet.Green));
+        }
+
+        private static void ArenaObserveEnter(ICharacter actor, StringStack ss)
+        {
+                if (actor.Location is not ICell cell)
+                {
+                        actor.OutputHandler.Send("You must be in a room to observe an event.".ColourError());
+                        return;
+                }
+
+                if (ss.IsFinished)
+                {
+                        actor.OutputHandler.Send("Which event do you want to observe?".ColourCommand());
+                        return;
+                }
+
+                var arenaEvent = GetArenaEvent(actor, ss.PopSpeech());
+                if (arenaEvent is null)
+                {
+                        actor.OutputHandler.Send("There is no arena event matching that description.".ColourError());
+                        return;
+                }
+
+                var (canObserve, reason) = actor.Gameworld.ArenaObservationService.CanObserve(actor, arenaEvent);
+                if (!canObserve)
+                {
+                        actor.OutputHandler.Send(reason.ColourError());
+                        return;
+                }
+
+                actor.Gameworld.ArenaObservationService.StartObserving(actor, arenaEvent, cell);
+                actor.OutputHandler.Handle(new EmoteOutput(new Emote(
+                        $"@ begin|begins observing the {arenaEvent.Name.ColourName()} event.", actor)));
+        }
+
+        private static void ArenaObserveLeave(ICharacter actor, StringStack ss)
+        {
+                if (ss.IsFinished)
+                {
+                        foreach (var arena in actor.Gameworld.CombatArenas)
+                        {
+                                foreach (var activeEvent in arena.ActiveEvents)
+                                {
+                                        actor.Gameworld.ArenaObservationService.StopObserving(actor, activeEvent);
+                                }
+                        }
+
+                        actor.OutputHandler.Send("You stop observing all arena events.".Colour(Telnet.Green));
+                        return;
+                }
+
+                var arenaEvent = GetArenaEvent(actor, ss.PopSpeech());
+                if (arenaEvent is null)
+                {
+                        actor.OutputHandler.Send("There is no arena event matching that description.".ColourError());
+                        return;
+                }
+
+                actor.Gameworld.ArenaObservationService.StopObserving(actor, arenaEvent);
+                actor.OutputHandler.Send($"You stop observing {arenaEvent.Name.ColourName()}.".Colour(Telnet.Green));
+        }
+
+        private static void ArenaSignup(ICharacter actor, StringStack ss)
+        {
+                if (ss.IsFinished)
+                {
+                        actor.OutputHandler.Send("Which event do you want to sign up for?".ColourCommand());
+                        return;
+                }
+
+                var arenaEvent = GetArenaEvent(actor, ss.PopSpeech());
+                if (arenaEvent is null)
+                {
+                        actor.OutputHandler.Send("There is no arena event matching that description.".ColourError());
+                        return;
+                }
+
+                if (ss.IsFinished)
+                {
+                        actor.OutputHandler.Send("Which side do you want to sign up for?".ColourCommand());
+                        return;
+                }
+
+                if (!int.TryParse(ss.PopSpeech(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var sideIndex))
+                {
+                        actor.OutputHandler.Send("You must specify the numeric side index.".ColourError());
+                        return;
+                }
+
+                var side = arenaEvent.EventType.Sides.FirstOrDefault(x => x.Index == sideIndex);
+                if (side is null)
+                {
+                        actor.OutputHandler.Send("That side does not exist for the selected event.".ColourError());
+                        return;
+                }
+
+                if (ss.IsFinished)
+                {
+                        actor.OutputHandler.Send("Which combatant class do you want to use?".ColourCommand());
+                        return;
+                }
+
+                var classArg = ss.PopSpeech();
+                var combatantClass = FindCombatantClass(side.EligibleClasses, classArg);
+                if (combatantClass is null)
+                {
+                        actor.OutputHandler.Send("That combatant class is not eligible for this side.".ColourError());
+                        return;
+                }
+
+                try
+                {
+                        var (allowed, reason) = arenaEvent.CanSignUp(actor, sideIndex, combatantClass);
+                        if (!allowed)
+                        {
+                                actor.OutputHandler.Send(reason.ColourError());
+                                return;
+                        }
+
+                        arenaEvent.SignUp(actor, sideIndex, combatantClass);
+                        actor.OutputHandler.Send(
+                                $"You sign up for {arenaEvent.Name.ColourName()} on side {sideIndex.ToString(actor).ColourValue()} as {combatantClass.Name.ColourName()}".Colour(Telnet.Green));
+                }
+                catch (Exception ex)
+                {
+                        actor.OutputHandler.Send(ex.Message.ColourError());
+                }
+        }
+
+        private static void ArenaWithdraw(ICharacter actor, StringStack ss)
+        {
+                if (ss.IsFinished)
+                {
+                        actor.OutputHandler.Send("Which event do you want to withdraw from?".ColourCommand());
+                        return;
+                }
+
+                var arenaEvent = GetArenaEvent(actor, ss.PopSpeech());
+                if (arenaEvent is null)
+                {
+                        actor.OutputHandler.Send("There is no arena event matching that description.".ColourError());
+                        return;
+                }
+
+                try
+                {
+                        arenaEvent.Withdraw(actor);
+                        actor.OutputHandler.Send($"You withdraw from {arenaEvent.Name.ColourName()}.".Colour(Telnet.Green));
+                }
+                catch (Exception ex)
+                {
+                        actor.OutputHandler.Send(ex.Message.ColourError());
+                }
+        }
+
+        private static void ArenaBet(ICharacter actor, StringStack ss)
+        {
+                if (ss.IsFinished)
+                {
+                        actor.OutputHandler.Send("Do you want to #3odds#0, #3place#0, #3cancel#0, or #3pools#0?".ColourCommand());
+                        return;
+                }
+
+                switch (ss.PopForSwitch())
+                {
+                        case "odds":
+                                ArenaBetOdds(actor, ss);
+                                return;
+                        case "place":
+                                ArenaBetPlace(actor, ss);
+                                return;
+                        case "cancel":
+                                ArenaBetCancel(actor, ss);
+                                return;
+                        case "pools":
+                                ArenaBetPools(actor, ss);
+                                return;
+                        default:
+                                actor.OutputHandler.Send("Valid options are #3odds#0, #3place#0, #3cancel#0, or #3pools#0.".ColourError());
+                                return;
+                }
+        }
+
+        private static void ArenaBetOdds(ICharacter actor, StringStack ss)
+        {
+                if (ss.IsFinished)
+                {
+                        actor.OutputHandler.Send("Which event do you want to get odds for?".ColourCommand());
+                        return;
+                }
+
+                var arenaEvent = GetArenaEvent(actor, ss.PopSpeech());
+                if (arenaEvent is null)
+                {
+                        actor.OutputHandler.Send("There is no arena event matching that description.".ColourError());
+                        return;
+                }
+
+                var sideIndex = ParseSideIndex(arenaEvent, ss.IsFinished ? null : ss.PopSpeech(), actor);
+                if (sideIndex.Invalid)
+                {
+                        actor.OutputHandler.Send(sideIndex.Error.ColourError());
+                        return;
+                }
+
+                var quote = actor.Gameworld.ArenaBettingService.GetQuote(arenaEvent, sideIndex.Value);
+                var sb = new StringBuilder();
+                sb.AppendLine($"Betting for {arenaEvent.Name.ColourName()} ({arenaEvent.EventType.Name.ColourName()}):");
+                if (quote.FixedOdds is { } odds)
+                {
+                        sb.AppendLine($"Fixed Odds: {odds:0.00} to 1");
+                }
+
+                if (quote.PariMutuel is { } pool)
+                {
+                        sb.AppendLine($"Pool: {DescribeCurrency(arenaEvent.Arena, pool.Pool)}, Take Rate: {pool.TakeRate:P0}");
+                }
+
+                if (quote.FixedOdds is null && quote.PariMutuel is null)
+                {
+                        sb.AppendLine("No odds are currently available.".ColourError());
+                }
+
+                actor.OutputHandler.Send(sb.ToString());
+        }
+
+        private static void ArenaBetPlace(ICharacter actor, StringStack ss)
+        {
+                if (ss.IsFinished)
+                {
+                        actor.OutputHandler.Send("Which event do you want to bet on?".ColourCommand());
+                        return;
+                }
+
+                var arenaEvent = GetArenaEvent(actor, ss.PopSpeech());
+                if (arenaEvent is null)
+                {
+                        actor.OutputHandler.Send("There is no arena event matching that description.".ColourError());
+                        return;
+                }
+
+                if (ss.IsFinished)
+                {
+                        actor.OutputHandler.Send("Which side (or draw) do you want to bet on?".ColourCommand());
+                        return;
+                }
+
+                var sideIndex = ParseSideIndex(arenaEvent, ss.PopSpeech(), actor);
+                if (sideIndex.Invalid)
+                {
+                        actor.OutputHandler.Send(sideIndex.Error.ColourError());
+                        return;
+                }
+
+                if (ss.IsFinished)
+                {
+                        actor.OutputHandler.Send("How much do you want to stake?".ColourCommand());
+                        return;
+                }
+
+                var amountText = ss.PopSpeech();
+                if (!arenaEvent.Arena.Currency.TryGetBaseCurrency(amountText, out var amount) || amount <= 0)
+                {
+                        actor.OutputHandler.Send("That is not a valid stake amount.".ColourError());
+                        return;
+                }
+
+                try
+                {
+                        actor.Gameworld.ArenaBettingService.PlaceBet(actor, arenaEvent, sideIndex.Value, amount);
+                        actor.OutputHandler.Send(
+                                $"You stake {DescribeCurrency(arenaEvent.Arena, amount)} on {DescribeSide(arenaEvent, sideIndex.Value)}.".Colour(Telnet.Green));
+                }
+                catch (Exception ex)
+                {
+                        actor.OutputHandler.Send(ex.Message.ColourError());
+                }
+        }
+
+        private static void ArenaBetCancel(ICharacter actor, StringStack ss)
+        {
+                if (ss.IsFinished)
+                {
+                        actor.OutputHandler.Send("Which event do you want to cancel your bet for?".ColourCommand());
+                        return;
+                }
+
+                var arenaEvent = GetArenaEvent(actor, ss.PopSpeech());
+                if (arenaEvent is null)
+                {
+                        actor.OutputHandler.Send("There is no arena event matching that description.".ColourError());
+                        return;
+                }
+
+                try
+                {
+                        actor.Gameworld.ArenaBettingService.CancelBet(actor, arenaEvent);
+                        actor.OutputHandler.Send(
+                                $"You cancel your wager on {arenaEvent.Name.ColourName()} and receive your stake back.".Colour(Telnet.Green));
+                }
+                catch (Exception ex)
+                {
+                        actor.OutputHandler.Send(ex.Message.ColourError());
+                }
+        }
+
+        private static void ArenaBetPools(ICharacter actor, StringStack ss)
+        {
+                if (ss.IsFinished)
+                {
+                        actor.OutputHandler.Send("Which event's pools do you want to view?".ColourCommand());
+                        return;
+                }
+
+                var arenaEvent = GetArenaEvent(actor, ss.PopSpeech());
+                if (arenaEvent is null)
+                {
+                        actor.OutputHandler.Send("There is no arena event matching that description.".ColourError());
+                        return;
+                }
+
+                if (arenaEvent.EventType.BettingModel != BettingModel.PariMutuel)
+                {
+                        actor.OutputHandler.Send("That event does not use pari-mutuel pools.".ColourError());
+                        return;
+                }
+
+                using (new FMDB())
+                {
+                        var context = FMDB.Context;
+                        var pools = context.ArenaBetPools.Where(x => x.ArenaEventId == arenaEvent.Id).ToList();
+                        if (!pools.Any())
+                        {
+                                actor.OutputHandler.Send("There are no active pools for that event.".ColourError());
+                                return;
+                        }
+
+                        var header = new[] { "Side", "Pool" };
+                        var rows = pools.Select(pool => new[]
+                        {
+                                pool.SideIndex?.ToString(actor) ?? "Draw",
+                                DescribeCurrency(arenaEvent.Arena, pool.TotalStake)
+                        }).ToList();
+
+                actor.OutputHandler.Send(StringUtilities.GetTextTable(rows, header, actor, Telnet.Green));
+                }
+        }
+
+        private static void ArenaRatings(ICharacter actor, StringStack ss)
+        {
+                var filter = ss.IsFinished ? null : ss.PopSpeech();
+                var classes = actor.Gameworld.CombatArenas
+                        .SelectMany(x => x.EventTypes)
+                        .SelectMany(x => x.Sides)
+                        .SelectMany(x => x.EligibleClasses)
+                        .Distinct()
+                        .ToList();
+
+                if (!classes.Any())
+                {
+                        actor.OutputHandler.Send("There are no combatant classes defined for arenas.".ColourError());
+                        return;
+                }
+
+                if (!string.IsNullOrEmpty(filter))
+                {
+                        classes = classes.Where(x => x.Name.Equals(filter, StringComparison.InvariantCultureIgnoreCase) ||
+                                                      x.Name.StartsWith(filter, StringComparison.InvariantCultureIgnoreCase)).ToList();
+
+                        if (!classes.Any())
+                        {
+                                actor.OutputHandler.Send("There is no combatant class matching that filter.".ColourError());
+                                return;
+                        }
+                }
+
+                var header = new[] { "Class", "Rating" };
+                var rows = classes.Select(cls => new[]
+                {
+                        cls.Name.ColourName(),
+                        actor.Gameworld.ArenaRatingsService.GetRating(actor, cls).ToString("N2", actor).ColourValue()
+                }).ToList();
+
+                actor.OutputHandler.Send(StringUtilities.GetTextTable(rows, header, actor, Telnet.Cyan));
+        }
+
+        private static ICombatArena? GetArena(ICharacter actor, string text)
+        {
+                if (string.IsNullOrWhiteSpace(text))
+                {
+                        return null;
+                }
+
+                return actor.Gameworld.CombatArenas.GetByIdOrName(text);
+        }
+
+        private static IArenaEvent? GetArenaEvent(ICharacter actor, string text)
+        {
+                if (string.IsNullOrWhiteSpace(text))
+                {
+                        return null;
+                }
+
+                if (long.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var id))
+                {
+                        return actor.Gameworld.CombatArenas.SelectMany(x => x.ActiveEvents).FirstOrDefault(x => x.Id == id);
+                }
+
+                return actor.Gameworld.CombatArenas.SelectMany(x => x.ActiveEvents)
+                        .FirstOrDefault(x => x.Name.Equals(text, StringComparison.InvariantCultureIgnoreCase)) ??
+                       actor.Gameworld.CombatArenas.SelectMany(x => x.ActiveEvents)
+                               .FirstOrDefault(x => x.Name.StartsWith(text, StringComparison.InvariantCultureIgnoreCase));
+        }
+
+        private static (int? Value, bool Invalid, string Error) ParseSideIndex(IArenaEvent arenaEvent, string? text,
+                ICharacter actor)
+        {
+                if (string.IsNullOrWhiteSpace(text) || text.Equals("draw", StringComparison.InvariantCultureIgnoreCase))
+                {
+                        return (null, false, string.Empty);
+                }
+
+                if (!int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
+                {
+                        return (null, true, "You must specify a numeric side or the word draw.");
+                }
+
+                if (arenaEvent.EventType.Sides.All(x => x.Index != value))
+                {
+                        return (null, true, "That side does not exist for this event.");
+                }
+
+                return (value, false, string.Empty);
+        }
+
+        private static ICombatantClass? FindCombatantClass(IEnumerable<ICombatantClass> classes, string text)
+        {
+                if (string.IsNullOrWhiteSpace(text))
+                {
+                        return null;
+                }
+
+                if (long.TryParse(text, out var id))
+                {
+                        return classes.FirstOrDefault(x => x.Id == id);
+                }
+
+                return classes.FirstOrDefault(x => x.Name.Equals(text, StringComparison.InvariantCultureIgnoreCase)) ??
+                       classes.FirstOrDefault(x => x.Name.StartsWith(text, StringComparison.InvariantCultureIgnoreCase));
+        }
+
+        private static string DescribeCurrency(ICombatArena arena, decimal amount)
+        {
+                return arena.Currency.Describe(amount, CurrencyDescriptionPatternType.ShortDecimal).ColourValue();
+        }
+
+        private static string DescribeSide(IArenaEvent arenaEvent, int? sideIndex)
+        {
+                if (!sideIndex.HasValue)
+                {
+                        return "draw".ColourValue();
+                }
+
+                var side = arenaEvent.EventType.Sides.FirstOrDefault(x => x.Index == sideIndex.Value);
+                return side is null
+                        ? sideIndex.Value.ToString(CultureInfo.InvariantCulture).ColourValue()
+                        : $"{sideIndex.Value.ToString(CultureInfo.InvariantCulture).ColourValue()} ({side.Policy.DescribeEnum().ColourValue()})";
+        }
+}

--- a/MudSharpCore/Commands/Trees/ActorCommandTree.cs
+++ b/MudSharpCore/Commands/Trees/ActorCommandTree.cs
@@ -43,9 +43,10 @@ internal class ActorCommandTree : ICharacterCommandTree
 		Commands.AddFrom(MovementModule.Instance.Commands);
 		Commands.AddFrom(CharacterInformationModule.Instance.Commands);
 		Commands.AddFrom(CommunicationsModule.Instance.Commands);
-		Commands.AddFrom(CombatModule.Instance.Commands);
-		Commands.AddFrom(GameModule.Instance.Commands);
-		Commands.AddFrom(InventoryModule.Instance.Commands);
+                Commands.AddFrom(CombatModule.Instance.Commands);
+                Commands.AddFrom(GameModule.Instance.Commands);
+                Commands.AddFrom(ArenaModule.Instance.Commands);
+                Commands.AddFrom(InventoryModule.Instance.Commands);
 		Commands.AddFrom(PerceptionModule.Instance.Commands);
 		Commands.AddFrom(PositionModule.Instance.Commands);
 		Commands.AddFrom(TimeModule.Instance.Commands);

--- a/MudSharpCore/Framework/Futuremud.cs
+++ b/MudSharpCore/Framework/Futuremud.cs
@@ -129,12 +129,17 @@ public sealed partial class Futuremud : IFuturemud, IDisposable
 
 		ClockManager = new ClockManager(this);
 		GameItemComponentManager = new GameItemComponentManager();
-		Scheduler = new Scheduler();
-		ArenaLifecycleService = new ArenaLifecycleService(this);
-		ArenaScheduler = new ArenaScheduler(this, ArenaLifecycleService);
-		ArenaObservationService = new ArenaObservationService(this);
-		SaveManager = new SaveManager();
-		HeartbeatManager = new HeartbeatManager(this);
+                Scheduler = new Scheduler();
+                ArenaLifecycleService = new ArenaLifecycleService(this);
+                ArenaScheduler = new ArenaScheduler(this, ArenaLifecycleService);
+                ArenaObservationService = new ArenaObservationService(this);
+                ArenaFinanceService = new ArenaFinanceService();
+                ArenaBettingService = new ArenaBettingService(this, ArenaFinanceService);
+                ArenaRatingsService = new ArenaRatingsService(this);
+                ArenaNpcService = new ArenaNpcService(this);
+                ArenaCommandService = new ArenaCommandService(this);
+                SaveManager = new SaveManager();
+                HeartbeatManager = new HeartbeatManager(this);
 
 		server?.Bind(_connections, AddConnection);
 
@@ -835,10 +840,15 @@ public sealed partial class Futuremud : IFuturemud, IDisposable
 		_randomNameProfiles.Add(profile);
 	}
 
-	public void Add(ILineOfCreditAccount account)
-	{
-		_lineOfCreditAccounts.Add(account);
-	}
+       public void Add(ILineOfCreditAccount account)
+       {
+               _lineOfCreditAccounts.Add(account);
+       }
+
+       public void Add(ICombatArena arena)
+       {
+               _combatArenas.Add(arena);
+       }
 
 	public void Add(IElection election)
 	{
@@ -1691,10 +1701,15 @@ public sealed partial class Futuremud : IFuturemud, IDisposable
 		_magicSpells.Remove(spell);
 	}
 
-	public void Destroy(ILineOfCreditAccount account)
-	{
-		_lineOfCreditAccounts.Remove(account);
-	}
+       public void Destroy(ILineOfCreditAccount account)
+       {
+               _lineOfCreditAccounts.Remove(account);
+       }
+
+       public void Destroy(ICombatArena arena)
+       {
+               _combatArenas.Remove(arena);
+       }
 
 	public void Destroy(IElection election)
 	{

--- a/MudSharpCore/Framework/FuturemudLoaders.cs
+++ b/MudSharpCore/Framework/FuturemudLoaders.cs
@@ -140,9 +140,14 @@ public sealed partial class Futuremud : IFuturemudLoader, IFuturemud, IDisposabl
 	protected List<IPlayerConnection> _connections = new();
 	public IServer Server { get; protected set; }
 	public IScheduler Scheduler { get; protected set; }
-	public IArenaLifecycleService ArenaLifecycleService { get; protected set; }
-	public IArenaScheduler ArenaScheduler { get; protected set; }
-	public IArenaObservationService ArenaObservationService { get; protected set; }
+        public IArenaLifecycleService ArenaLifecycleService { get; protected set; }
+        public IArenaScheduler ArenaScheduler { get; protected set; }
+        public IArenaObservationService ArenaObservationService { get; protected set; }
+        public IArenaFinanceService ArenaFinanceService { get; protected set; }
+        public IArenaBettingService ArenaBettingService { get; protected set; }
+        public IArenaRatingsService ArenaRatingsService { get; protected set; }
+        public IArenaNpcService ArenaNpcService { get; protected set; }
+        public IArenaCommandService ArenaCommandService { get; protected set; }
 	public IEffectScheduler EffectScheduler { get; protected set; }
 	public ISaveManager SaveManager { get; protected set; }
 	public IGameItemComponentManager GameItemComponentManager { get; protected set; }

--- a/MudSharpCore/Framework/FuturemudVariables.cs
+++ b/MudSharpCore/Framework/FuturemudVariables.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using MudSharp.Accounts;
+using MudSharp.Arenas;
 using MudSharp.Body;
 using MudSharp.Body.Disfigurements;
 using MudSharp.Body.Traits;
@@ -247,7 +248,8 @@ public sealed partial class Futuremud : IDisposable
 	private readonly All<IGroupAITemplate> _groupAITemplates = new();
 	private readonly All<IGroupAI> _groupAIs = new();
 
-	private readonly All<ILineOfCreditAccount> _lineOfCreditAccounts = new();
+        private readonly All<ILineOfCreditAccount> _lineOfCreditAccounts = new();
+        private readonly All<ICombatArena> _combatArenas = new();
 
 	#endregion All<T> Declarations
 
@@ -537,7 +539,8 @@ public sealed partial class Futuremud : IDisposable
 
 	public IUneditableAll<IGroupAI> GroupAIs => _groupAIs;
 
-	public IUneditableAll<ILineOfCreditAccount> LineOfCreditAccounts => _lineOfCreditAccounts;
+        public IUneditableAll<ILineOfCreditAccount> LineOfCreditAccounts => _lineOfCreditAccounts;
+        public IUneditableAll<ICombatArena> CombatArenas => _combatArenas;
 
 	#endregion IUneditableAll<T> Declarations
 


### PR DESCRIPTION
## Summary
- add an Arena command module covering management, observation, signup, betting, and ratings flows
- introduce an ArenaCommandService to centralise arena/event/event-type presentations for commands
- align supporting services with the new command requirements (finance payout signature, NPC resurrection flag)

## Testing
- scripts/test.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69129b2b0b408323befe9ccec6b5b530)