### PR TITLE
Implement arena participation reliability controls

### DIFF
--- a/FutureMUDLibrary/Arenas/IArenaServices.cs
+++ b/FutureMUDLibrary/Arenas/IArenaServices.cs
@@ -68,16 +68,27 @@ public interface IArenaFinanceService {
 /// Provides NPC auto-fill, outfitting, and restoration flows.
 /// </summary>
 public interface IArenaNpcService {
-	IEnumerable<ICharacter> AutoFill(IArenaEvent arenaEvent, int sideIndex, int slotsNeeded);
-	void PrepareNpc(ICharacter npc, IArenaEvent arenaEvent, int sideIndex, ICombatantClass combatantClass);
-	void ReturnNpc(ICharacter npc, IArenaEvent arenaEvent, bool resurrect);
+        IEnumerable<ICharacter> AutoFill(IArenaEvent arenaEvent, int sideIndex, int slotsNeeded);
+        void PrepareNpc(ICharacter npc, IArenaEvent arenaEvent, int sideIndex, ICombatantClass combatantClass);
+        void ReturnNpc(ICharacter npc, IArenaEvent arenaEvent, bool resurrect);
+}
+
+/// <summary>
+/// Applies participation locks that keep players in the arena until the event concludes.
+/// </summary>
+public interface IArenaParticipationService {
+        void EnsureParticipation(ICharacter participant, IArenaEvent arenaEvent);
+        void EnsureParticipation(IArenaEvent arenaEvent);
+        bool HasParticipation(ICharacter participant, IArenaEvent arenaEvent);
+        void ClearParticipation(ICharacter participant, IArenaEvent arenaEvent);
+        void ClearParticipation(IArenaEvent arenaEvent);
 }
 
 /// <summary>
 /// Centralises arena-related output helpers for commands and builders.
 /// </summary>
 public interface IArenaCommandService {
-	void ShowArena(ICharacter actor, ICombatArena arena);
+        void ShowArena(ICharacter actor, ICombatArena arena);
 	void ShowEvent(ICharacter actor, IArenaEvent arenaEvent);
 	void ShowEventType(ICharacter actor, IArenaEventType eventType);
 }

--- a/FutureMUDLibrary/Framework/IFuturemud.cs
+++ b/FutureMUDLibrary/Framework/IFuturemud.cs
@@ -306,6 +306,7 @@ namespace MudSharp.Framework
                 IArenaBettingService ArenaBettingService { get; }
                 IArenaRatingsService ArenaRatingsService { get; }
                 IArenaNpcService ArenaNpcService { get; }
+                IArenaParticipationService ArenaParticipationService { get; }
                 IArenaCommandService ArenaCommandService { get; }
                 IEffectScheduler EffectScheduler { get; }
 		ISaveManager SaveManager { get; }

--- a/MudSharpCore Unit Tests/Arenas/ArenaParticipationServiceTests.cs
+++ b/MudSharpCore Unit Tests/Arenas/ArenaParticipationServiceTests.cs
@@ -1,0 +1,119 @@
+#nullable enable
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Arenas;
+using MudSharp.Character;
+using MudSharp.Effects;
+using MudSharp.Effects.Concrete;
+using MudSharp.Framework;
+
+namespace MudSharp_Unit_Tests.Arenas;
+
+[TestClass]
+public class ArenaParticipationServiceTests
+{
+        private ArenaParticipationService _service = null!;
+        private Mock<IFuturemud> _gameworld = null!;
+
+        [TestInitialize]
+        public void Setup()
+        {
+                _gameworld = new Mock<IFuturemud>();
+                _service = new ArenaParticipationService(_gameworld.Object);
+        }
+
+        [TestMethod]
+        public void EnsureParticipation_AddsEffectAndRemovesLinkdead()
+        {
+                var participant = new Mock<ICharacter>();
+                participant.SetupGet(x => x.IsPlayerCharacter).Returns(true);
+                participant.SetupGet(x => x.Gameworld).Returns(_gameworld.Object);
+                participant.Setup(x => x.CombinedEffectsOfType<ArenaParticipationEffect>())
+                        .Returns(Array.Empty<ArenaParticipationEffect>());
+
+                Predicate<IEffect>? predicate = null;
+                participant.Setup(x => x.RemoveAllEffects(It.IsAny<Predicate<IEffect>>(), It.IsAny<bool>()))
+                        .Callback<Predicate<IEffect>, bool>((pred, _) => predicate = pred);
+
+                IEffect? capturedEffect = null;
+                participant.Setup(x => x.AddEffect(It.IsAny<IEffect>()))
+                        .Callback<IEffect>(effect => capturedEffect = effect);
+
+                var arenaEvent = new Mock<IArenaEvent>();
+                arenaEvent.SetupGet(x => x.Id).Returns(42);
+                arenaEvent.SetupGet(x => x.Name).Returns("Test Event");
+
+                _service.EnsureParticipation(participant.Object, arenaEvent.Object);
+
+                participant.Verify(x => x.AddEffect(It.IsAny<ArenaParticipationEffect>()), Times.Once);
+                participant.Verify(x => x.RemoveAllEffects(It.IsAny<Predicate<IEffect>>(), It.IsAny<bool>()), Times.Once);
+                Assert.IsNotNull(capturedEffect);
+                Assert.IsInstanceOfType(capturedEffect, typeof(ArenaParticipationEffect));
+                Assert.IsNotNull(predicate, "Expected Linkdead cleanup predicate to be provided.");
+                var linkdead = new LinkdeadLogout(participant.Object);
+                Assert.IsTrue(predicate!(linkdead), "Predicate should match linkdead effects.");
+        }
+
+        [TestMethod]
+        public void EnsureParticipation_WhenEffectExists_DoesNotDuplicate()
+        {
+                var participant = new Mock<ICharacter>();
+                participant.SetupGet(x => x.IsPlayerCharacter).Returns(true);
+                participant.SetupGet(x => x.Gameworld).Returns(_gameworld.Object);
+
+                var arenaEvent = new Mock<IArenaEvent>();
+                arenaEvent.SetupGet(x => x.Id).Returns(99);
+                arenaEvent.SetupGet(x => x.Name).Returns("Existing Event");
+
+                var existingEffect = new ArenaParticipationEffect(participant.Object, arenaEvent.Object);
+                participant.Setup(x => x.CombinedEffectsOfType<ArenaParticipationEffect>())
+                        .Returns(new[] { existingEffect });
+
+                _service.EnsureParticipation(participant.Object, arenaEvent.Object);
+
+                participant.Verify(x => x.AddEffect(It.IsAny<IEffect>()), Times.Never);
+                participant.Verify(x => x.RemoveAllEffects(It.IsAny<Predicate<IEffect>>(), It.IsAny<bool>()), Times.Never);
+        }
+
+        [TestMethod]
+        public void ClearParticipation_RemovesEffect()
+        {
+                var participant = new Mock<ICharacter>();
+                participant.SetupGet(x => x.IsPlayerCharacter).Returns(true);
+                participant.SetupGet(x => x.Gameworld).Returns(_gameworld.Object);
+
+                var arenaEvent = new Mock<IArenaEvent>();
+                arenaEvent.SetupGet(x => x.Id).Returns(7);
+                arenaEvent.SetupGet(x => x.Name).Returns("Cleanup Event");
+
+                var effect = new ArenaParticipationEffect(participant.Object, arenaEvent.Object);
+                participant.Setup(x => x.CombinedEffectsOfType<ArenaParticipationEffect>())
+                        .Returns(new[] { effect });
+
+                _service.ClearParticipation(participant.Object, arenaEvent.Object);
+
+                participant.Verify(x => x.RemoveEffect(effect, true), Times.Once);
+        }
+
+        [TestMethod]
+        public void HasParticipation_ReturnsTrueWhenEffectPresent()
+        {
+                var participant = new Mock<ICharacter>();
+                participant.SetupGet(x => x.IsPlayerCharacter).Returns(true);
+                participant.SetupGet(x => x.Gameworld).Returns(_gameworld.Object);
+
+                var arenaEvent = new Mock<IArenaEvent>();
+                arenaEvent.SetupGet(x => x.Id).Returns(13);
+                arenaEvent.SetupGet(x => x.Name).Returns("Status Event");
+
+                var effect = new ArenaParticipationEffect(participant.Object, arenaEvent.Object);
+                participant.Setup(x => x.CombinedEffectsOfType<ArenaParticipationEffect>())
+                        .Returns(new[] { effect });
+
+                var result = _service.HasParticipation(participant.Object, arenaEvent.Object);
+
+                Assert.IsTrue(result);
+        }
+}

--- a/MudSharpCore/Arenas/Participation/ArenaParticipationEffect.cs
+++ b/MudSharpCore/Arenas/Participation/ArenaParticipationEffect.cs
@@ -1,0 +1,109 @@
+#nullable enable
+
+using System;
+using System.Linq;
+using System.Xml.Linq;
+using MudSharp.Arenas;
+using MudSharp.Character;
+using MudSharp.Effects;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+
+namespace MudSharp.Arenas;
+
+/// <summary>
+///     Marks a player as an active arena participant, preventing logout until the event ends.
+/// </summary>
+public sealed class ArenaParticipationEffect : Effect, INoQuitEffect
+{
+        private readonly long _arenaEventId;
+        private IArenaEvent? _arenaEvent;
+
+        public ArenaParticipationEffect(ICharacter owner, IArenaEvent arenaEvent) : base(owner)
+        {
+                if (owner is null)
+                {
+                        throw new ArgumentNullException(nameof(owner));
+                }
+
+                _arenaEvent = arenaEvent ?? throw new ArgumentNullException(nameof(arenaEvent));
+                _arenaEventId = arenaEvent.Id;
+        }
+
+        private ArenaParticipationEffect(XElement root, IPerceivable owner) : base(root, owner)
+        {
+                if (root is null)
+                {
+                        throw new ArgumentNullException(nameof(root));
+                }
+
+                _arenaEventId = long.Parse(root.Element("ArenaEventId")?.Value
+                                          ?? throw new ArgumentException("ArenaEventId element missing."));
+                _arenaEvent = ResolveEvent();
+        }
+
+        public static void InitialiseEffectType()
+        {
+                RegisterFactory("ArenaParticipation",
+                        (effect, owner) => new ArenaParticipationEffect(effect, owner));
+        }
+
+        public long ArenaEventId => _arenaEventId;
+
+        public IArenaEvent? ArenaEvent => ResolveEvent();
+
+        protected override string SpecificEffectType => "ArenaParticipation";
+
+        public override bool SavingEffect => true;
+
+        public string NoQuitReason =>
+                $"You cannot quit while you are participating in {DescribeEventName()}.";
+
+        public override string Describe(IPerceiver voyeur)
+        {
+                return $"Participating in {DescribeEventName()}.";
+        }
+
+        internal bool Matches(IArenaEvent arenaEvent)
+        {
+                return arenaEvent is not null && arenaEvent.Id == _arenaEventId;
+        }
+
+        internal void AttachToEvent(IArenaEvent arenaEvent)
+        {
+                if (arenaEvent is null || arenaEvent.Id != _arenaEventId)
+                {
+                        return;
+                }
+
+                _arenaEvent = arenaEvent;
+        }
+
+        protected override XElement SaveDefinition()
+        {
+                return new XElement("Definition", new XElement("ArenaEventId", _arenaEventId));
+        }
+
+        private IArenaEvent? ResolveEvent()
+        {
+                if (_arenaEvent is not null)
+                {
+                        return _arenaEvent;
+                }
+
+                _arenaEvent = Gameworld?.CombatArenas.SelectMany(x => x.ActiveEvents)
+                        .FirstOrDefault(x => x.Id == _arenaEventId);
+                return _arenaEvent;
+        }
+
+        private string DescribeEventName()
+        {
+                var arenaEvent = ResolveEvent();
+                if (arenaEvent is null)
+                {
+                        return $"arena event #{_arenaEventId}";
+                }
+
+                return arenaEvent.Name;
+        }
+}

--- a/MudSharpCore/Arenas/Participation/ArenaParticipationService.cs
+++ b/MudSharpCore/Arenas/Participation/ArenaParticipationService.cs
@@ -1,0 +1,114 @@
+#nullable enable
+
+using System;
+using System.Linq;
+using MudSharp.Arenas;
+using MudSharp.Character;
+using MudSharp.Effects.Concrete;
+using MudSharp.Framework;
+
+namespace MudSharp.Arenas;
+
+/// <summary>
+///     Coordinates participation effects for arena combatants, ensuring reliability under disconnects.
+/// </summary>
+public class ArenaParticipationService : IArenaParticipationService
+{
+        public ArenaParticipationService(IFuturemud gameworld)
+        {
+                _ = gameworld ?? throw new ArgumentNullException(nameof(gameworld));
+        }
+
+        public void EnsureParticipation(ICharacter participant, IArenaEvent arenaEvent)
+        {
+                if (participant is null)
+                {
+                        throw new ArgumentNullException(nameof(participant));
+                }
+
+                if (arenaEvent is null)
+                {
+                        throw new ArgumentNullException(nameof(arenaEvent));
+                }
+
+                if (!participant.IsPlayerCharacter)
+                {
+                        return;
+                }
+
+                var existing = participant.CombinedEffectsOfType<ArenaParticipationEffect>()
+                        .FirstOrDefault(x => x.Matches(arenaEvent));
+                if (existing is not null)
+                {
+                        existing.AttachToEvent(arenaEvent);
+                        return;
+                }
+
+                participant.RemoveAllEffects(effect => effect.IsEffectType<LinkdeadLogout>());
+                var effect = new ArenaParticipationEffect(participant, arenaEvent);
+                participant.AddEffect(effect);
+        }
+
+        public void EnsureParticipation(IArenaEvent arenaEvent)
+        {
+                if (arenaEvent is null)
+                {
+                        throw new ArgumentNullException(nameof(arenaEvent));
+                }
+
+                foreach (var participant in arenaEvent.Participants
+                                 .Select(x => x.Character)
+                                 .OfType<ICharacter>())
+                {
+                        EnsureParticipation(participant, arenaEvent);
+                }
+        }
+
+        public bool HasParticipation(ICharacter participant, IArenaEvent arenaEvent)
+        {
+                if (participant is null || arenaEvent is null)
+                {
+                        return false;
+                }
+
+                return participant.CombinedEffectsOfType<ArenaParticipationEffect>()
+                        .Any(x => x.Matches(arenaEvent));
+        }
+
+        public void ClearParticipation(ICharacter participant, IArenaEvent arenaEvent)
+        {
+                if (participant is null || arenaEvent is null)
+                {
+                        return;
+                }
+
+                if (!participant.IsPlayerCharacter)
+                {
+                        return;
+                }
+
+                var effect = participant.CombinedEffectsOfType<ArenaParticipationEffect>()
+                        .FirstOrDefault(x => x.Matches(arenaEvent));
+                if (effect is null)
+                {
+                        return;
+                }
+
+                participant.RemoveEffect(effect, true);
+        }
+
+        public void ClearParticipation(IArenaEvent arenaEvent)
+        {
+                if (arenaEvent is null)
+                {
+                        throw new ArgumentNullException(nameof(arenaEvent));
+                }
+
+                foreach (var participant in arenaEvent.Participants
+                                 .Select(x => x.Character)
+                                 .OfType<ICharacter>())
+                {
+                        ClearParticipation(participant, arenaEvent);
+                }
+        }
+}

--- a/MudSharpCore/Framework/Futuremud.cs
+++ b/MudSharpCore/Framework/Futuremud.cs
@@ -137,6 +137,7 @@ public sealed partial class Futuremud : IFuturemud, IDisposable
                 ArenaBettingService = new ArenaBettingService(this, ArenaFinanceService);
                 ArenaRatingsService = new ArenaRatingsService(this);
                 ArenaNpcService = new ArenaNpcService(this);
+                ArenaParticipationService = new ArenaParticipationService(this);
                 ArenaCommandService = new ArenaCommandService(this);
                 SaveManager = new SaveManager();
                 HeartbeatManager = new HeartbeatManager(this);

--- a/MudSharpCore/Framework/FuturemudLoaders.cs
+++ b/MudSharpCore/Framework/FuturemudLoaders.cs
@@ -147,6 +147,7 @@ public sealed partial class Futuremud : IFuturemudLoader, IFuturemud, IDisposabl
         public IArenaBettingService ArenaBettingService { get; protected set; }
         public IArenaRatingsService ArenaRatingsService { get; protected set; }
         public IArenaNpcService ArenaNpcService { get; protected set; }
+        public IArenaParticipationService ArenaParticipationService { get; protected set; }
         public IArenaCommandService ArenaCommandService { get; protected set; }
 	public IEffectScheduler EffectScheduler { get; protected set; }
 	public ISaveManager SaveManager { get; protected set; }


### PR DESCRIPTION
## Summary
- add an arena participation effect and service to keep combatants from quitting mid-event
- expose the participation service through the gameworld and adjust disconnect handling for active participants
- cover the participation logic with unit tests

## Testing
- ./scripts/test.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912a6b03a1483238bc2b5ae51582f62)