### PR TITLE
Add arena lifecycle and scheduler unit tests

### DIFF
--- a/MudSharpCore Unit Tests/Arenas/ArenaFinanceServiceTests.cs
+++ b/MudSharpCore Unit Tests/Arenas/ArenaFinanceServiceTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;

--- a/MudSharpCore Unit Tests/Arenas/ArenaLifecycleServiceTests.cs
+++ b/MudSharpCore Unit Tests/Arenas/ArenaLifecycleServiceTests.cs
@@ -1,0 +1,97 @@
+#nullable enable
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Arenas;
+using MudSharp.Framework;
+
+namespace MudSharp_Unit_Tests.Arenas;
+
+[TestClass]
+public class ArenaLifecycleServiceTests
+{
+        private ArenaLifecycleService _service = null!;
+        private Mock<IArenaScheduler> _scheduler = null!;
+        private Mock<IFuturemud> _gameworld = null!;
+
+        [TestInitialize]
+        public void Setup()
+        {
+                _gameworld = new Mock<IFuturemud>();
+                _scheduler = new Mock<IArenaScheduler>();
+                _service = new ArenaLifecycleService(_gameworld.Object);
+                _service.AttachScheduler(_scheduler.Object);
+        }
+
+        [TestMethod]
+        public void Transition_ForwardState_EnforcesAndSchedules()
+        {
+                var arenaEvent = BuildEvent(ArenaEventState.Scheduled);
+
+                _service.Transition(arenaEvent.Object, ArenaEventState.RegistrationOpen);
+
+                arenaEvent.Verify(x => x.EnforceState(ArenaEventState.RegistrationOpen), Times.Once);
+                _scheduler.Verify(x => x.Schedule(arenaEvent.Object), Times.Once);
+        }
+
+        [TestMethod]
+        public void Transition_BackwardOrSameState_NoAction()
+        {
+                var arenaEvent = BuildEvent(ArenaEventState.Preparing);
+
+                _service.Transition(arenaEvent.Object, ArenaEventState.RegistrationOpen);
+                _service.Transition(arenaEvent.Object, ArenaEventState.Preparing);
+
+                arenaEvent.Verify(x => x.EnforceState(It.IsAny<ArenaEventState>()), Times.Never);
+                _scheduler.Verify(x => x.Schedule(It.IsAny<IArenaEvent>()), Times.Never);
+        }
+
+        [TestMethod]
+        public void Transition_FinalStates_CancelsScheduling()
+        {
+                var arenaEvent = BuildEvent(ArenaEventState.Cleanup);
+
+                _service.Transition(arenaEvent.Object, ArenaEventState.Completed);
+
+                arenaEvent.Verify(x => x.EnforceState(ArenaEventState.Completed), Times.Once);
+                _scheduler.Verify(x => x.Cancel(arenaEvent.Object), Times.Once);
+                _scheduler.Verify(x => x.Schedule(It.IsAny<IArenaEvent>()), Times.Never);
+        }
+
+        [TestMethod]
+        public void Transition_Abort_CancelsScheduling()
+        {
+                var arenaEvent = BuildEvent(ArenaEventState.Live);
+
+                _service.Transition(arenaEvent.Object, ArenaEventState.Aborted);
+
+                arenaEvent.Verify(x => x.EnforceState(ArenaEventState.Aborted), Times.Once);
+                _scheduler.Verify(x => x.Cancel(arenaEvent.Object), Times.Once);
+                _scheduler.Verify(x => x.Schedule(It.IsAny<IArenaEvent>()), Times.Never);
+        }
+
+        [TestMethod]
+        public void RebootRecovery_InvokesSchedulerRecovery()
+        {
+                _service.RebootRecovery();
+
+                _scheduler.Verify(x => x.RecoverAfterReboot(), Times.Once);
+        }
+
+        [TestMethod]
+        public void Transition_NullEvent_Throws()
+        {
+                Assert.ThrowsException<ArgumentNullException>(() => _service.Transition(null!, ArenaEventState.Live));
+        }
+
+        private static Mock<IArenaEvent> BuildEvent(ArenaEventState initialState)
+        {
+                var state = initialState;
+                var arenaEvent = new Mock<IArenaEvent>();
+                arenaEvent.SetupGet(x => x.State).Returns(() => state);
+                arenaEvent.Setup(x => x.EnforceState(It.IsAny<ArenaEventState>()))
+                        .Callback<ArenaEventState>(next => state = next);
+                return arenaEvent;
+        }
+}

--- a/MudSharpCore Unit Tests/Arenas/ArenaSchedulerTests.cs
+++ b/MudSharpCore Unit Tests/Arenas/ArenaSchedulerTests.cs
@@ -1,0 +1,133 @@
+#nullable enable
+
+using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Arenas;
+using MudSharp.Framework;
+using MudSharp.Framework.Scheduling;
+
+namespace MudSharp_Unit_Tests.Arenas;
+
+[TestClass]
+public class ArenaSchedulerTests
+{
+        private ArenaScheduler _service = null!;
+        private Mock<IFuturemud> _gameworld = null!;
+        private Mock<IScheduler> _scheduler = null!;
+        private Mock<IArenaLifecycleService> _lifecycle = null!;
+
+        [TestInitialize]
+        public void Setup()
+        {
+                _gameworld = new Mock<IFuturemud>();
+                _scheduler = new Mock<IScheduler>();
+                _lifecycle = new Mock<IArenaLifecycleService>();
+                _gameworld.SetupGet(x => x.Scheduler).Returns(_scheduler.Object);
+                _service = new ArenaScheduler(_gameworld.Object, _lifecycle.Object);
+        }
+
+        [TestMethod]
+        public void Schedule_DraftState_QueuesTransitionToScheduled()
+        {
+                var now = DateTime.UtcNow;
+                var scheduledAt = now.AddMinutes(10);
+                var eventType = BuildEventType();
+                var arenaEvent = new Mock<IArenaEvent>();
+                arenaEvent.SetupGet(x => x.State).Returns(ArenaEventState.Draft);
+                arenaEvent.SetupGet(x => x.ScheduledAt).Returns(scheduledAt);
+                arenaEvent.SetupGet(x => x.CreatedAt).Returns(now);
+                arenaEvent.SetupGet(x => x.RegistrationOpensAt).Returns((DateTime?)null);
+                arenaEvent.SetupGet(x => x.EventType).Returns(eventType.Object);
+                arenaEvent.SetupGet(x => x.Id).Returns(5L);
+
+                ISchedule? captured = null;
+                _scheduler.Setup(x => x.AddSchedule(It.IsAny<ISchedule>()))
+                        .Callback<ISchedule>(schedule => captured = schedule);
+
+                _service.Schedule(arenaEvent.Object);
+
+                _scheduler.Verify(x => x.Destroy(arenaEvent.Object, ScheduleType.ArenaEvent), Times.Once);
+                Assert.IsNotNull(captured, "Expected a schedule to be created for the next transition.");
+                var typed = captured as Schedule<IArenaEvent>;
+                Assert.IsNotNull(typed, "Expected an ArenaEvent schedule instance.");
+                Assert.AreSame(arenaEvent.Object, typed!.Parameter1);
+                Assert.AreEqual(ScheduleType.ArenaEvent, typed.Type);
+                Assert.IsTrue(Math.Abs((typed.TriggerETA - scheduledAt).TotalSeconds) < 0.5,
+                        $"Trigger should align with the scheduled start. Expected {scheduledAt:o}, got {typed.TriggerETA:o}.");
+                Assert.AreEqual(0, _lifecycle.Invocations.Count);
+
+                typed.Action(typed.Parameter1);
+
+                var invocation = _lifecycle.Invocations.Single();
+                Assert.AreEqual("Transition", invocation.Method.Name);
+                Assert.AreSame(arenaEvent.Object, invocation.Arguments[0]);
+                Assert.AreEqual(ArenaEventState.Scheduled, invocation.Arguments[1]);
+        }
+
+        [TestMethod]
+        public void Schedule_ScheduledPastRegistration_TransitionsImmediately()
+        {
+                var now = DateTime.UtcNow;
+                var eventType = BuildEventType();
+                var arenaEvent = new Mock<IArenaEvent>();
+                arenaEvent.SetupGet(x => x.State).Returns(ArenaEventState.Scheduled);
+                arenaEvent.SetupGet(x => x.ScheduledAt).Returns(now.AddMinutes(30));
+                arenaEvent.SetupGet(x => x.CreatedAt).Returns(now.AddHours(-1));
+                arenaEvent.SetupGet(x => x.RegistrationOpensAt).Returns(now.AddMinutes(-5));
+                arenaEvent.SetupGet(x => x.EventType).Returns(eventType.Object);
+                arenaEvent.SetupGet(x => x.Id).Returns(6L);
+
+                _service.Schedule(arenaEvent.Object);
+
+                _scheduler.Verify(x => x.Destroy(arenaEvent.Object, ScheduleType.ArenaEvent), Times.Once);
+                _scheduler.Verify(x => x.AddSchedule(It.IsAny<ISchedule>()), Times.Never);
+                _lifecycle.Verify(x => x.Transition(arenaEvent.Object, ArenaEventState.RegistrationOpen), Times.Once);
+        }
+
+        [TestMethod]
+        public void Schedule_LiveWithoutTimeLimit_DoesNotSchedule()
+        {
+                var now = DateTime.UtcNow;
+                var eventType = BuildEventType();
+                eventType.SetupGet(x => x.TimeLimit).Returns((TimeSpan?)null);
+                var arenaEvent = new Mock<IArenaEvent>();
+                arenaEvent.SetupGet(x => x.State).Returns(ArenaEventState.Live);
+                arenaEvent.SetupGet(x => x.StartedAt).Returns(now.AddMinutes(-2));
+                arenaEvent.SetupGet(x => x.EventType).Returns(eventType.Object);
+                arenaEvent.SetupGet(x => x.Id).Returns(7L);
+
+                _service.Schedule(arenaEvent.Object);
+
+                _scheduler.Verify(x => x.Destroy(arenaEvent.Object, ScheduleType.ArenaEvent), Times.Once);
+                _scheduler.Verify(x => x.AddSchedule(It.IsAny<ISchedule>()), Times.Never);
+                _lifecycle.Verify(x => x.Transition(It.IsAny<IArenaEvent>(), It.IsAny<ArenaEventState>()), Times.Never);
+        }
+
+        [TestMethod]
+        public void Schedule_CompletedState_OnlyCancels()
+        {
+                var eventType = BuildEventType();
+                var arenaEvent = new Mock<IArenaEvent>();
+                arenaEvent.SetupGet(x => x.State).Returns(ArenaEventState.Completed);
+                arenaEvent.SetupGet(x => x.EventType).Returns(eventType.Object);
+                arenaEvent.SetupGet(x => x.Id).Returns(8L);
+
+                _service.Schedule(arenaEvent.Object);
+
+                _scheduler.Verify(x => x.Destroy(arenaEvent.Object, ScheduleType.ArenaEvent), Times.Once);
+                _scheduler.Verify(x => x.AddSchedule(It.IsAny<ISchedule>()), Times.Never);
+                _lifecycle.Verify(x => x.Transition(It.IsAny<IArenaEvent>(), It.IsAny<ArenaEventState>()), Times.Never);
+        }
+
+        private static Mock<IArenaEventType> BuildEventType()
+        {
+                var eventType = new Mock<IArenaEventType>();
+                eventType.SetupGet(x => x.RegistrationDuration).Returns(TimeSpan.FromMinutes(15));
+                eventType.SetupGet(x => x.PreparationDuration).Returns(TimeSpan.FromMinutes(5));
+                eventType.SetupGet(x => x.TimeLimit).Returns(TimeSpan.FromMinutes(20));
+                eventType.SetupGet(x => x.Sides).Returns(Array.Empty<IArenaEventTypeSide>());
+                return eventType;
+        }
+}

--- a/MudSharpCore Unit Tests/Arenas/ArenaWatcherEffectTests.cs
+++ b/MudSharpCore Unit Tests/Arenas/ArenaWatcherEffectTests.cs
@@ -1,11 +1,13 @@
 #nullable enable
 
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using MudSharp.Arenas;
 using MudSharp.Character;
 using MudSharp.Construction;
 using MudSharp.Effects;
+using MudSharp.Form.Shape;
 using MudSharp.Framework;
 using MudSharp.PerceptionEngine;
 using MudSharp.PerceptionEngine.Outputs;
@@ -28,7 +30,7 @@ public class ArenaWatcherEffectTests
                 _gameworld = new Mock<IFuturemud>();
                 _arenaCell = new Mock<ICell>();
                 _arenaCell.SetupGet(x => x.Gameworld).Returns(_gameworld.Object);
-                _arenaCell.Setup(x => x.RemoveEffect(It.IsAny<IEffect>()));
+                _arenaCell.Setup(x => x.RemoveEffect(It.IsAny<IEffect>(), It.IsAny<bool>()));
                 _arenaCell.Setup(x => x.HowSeen(It.IsAny<IPerceiver>(), It.IsAny<bool>(), It.IsAny<DescriptionType>(),
                         It.IsAny<bool>(), It.IsAny<PerceiveIgnoreFlags>())).Returns("the arena floor");
 
@@ -74,7 +76,8 @@ public class ArenaWatcherEffectTests
                 watcherLocation = observationCell2.Object;
                 _effect.HandleOutput(_output.Object, _arenaCell.Object);
 
-                outputHandler.Verify(x => x.Send(It.IsAny<IOutput>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Once());
+                Assert.AreEqual(1, outputHandler.Invocations.Count);
+                Assert.AreEqual("Send", outputHandler.Invocations.Single().Method.Name);
         }
 
         [TestMethod]
@@ -98,7 +101,7 @@ public class ArenaWatcherEffectTests
                 watcherLocation = otherCell.Object;
                 _effect.HandleOutput(_output.Object, _arenaCell.Object);
 
-                outputHandler.Verify(x => x.Send(It.IsAny<IOutput>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Never());
-                _arenaCell.Verify(x => x.RemoveEffect(_effect), Times.Once());
+                Assert.AreEqual(0, outputHandler.Invocations.Count);
+                _arenaCell.Verify(x => x.RemoveEffect(_effect, It.IsAny<bool>()), Times.Once());
         }
 }


### PR DESCRIPTION
## Summary
- add unit coverage for the arena lifecycle service to ensure forward-only transitions and scheduler integration
- verify arena scheduler timing, immediate transitions, and cancellation behaviours via new unit tests
- update existing arena finance and watcher tests to include required imports and non-optional verifications

## Testing
- `dotnet test 'MudSharpCore Unit Tests/MudSharpCore Unit Tests.csproj' --no-build --logger "console;verbosity=minimal"` *(fails: ScatterStrategyUtilitiesTests.GetCellInfos_ReturnsDistancesAndDirections expected 3 actual 5)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691399355a4483238439d00d89f53330)