### PR TITLE
Add item system documentation and fix Visual Studio templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,6 +238,25 @@ When changing a subsystem that has a design document in `Design Documents/`:
 2. Ensure the document reflects the new runtime behavior, command surface, and persistence implications.
 3. Call out the documentation update in your task summary.
 
+## Item System Design Document Reference
+
+When changing item-related systems, treat the following documents as the primary design references and keep them in sync with the code:
+
+- [Item System Overview](./Design%20Documents/Item_System_Overview.md)
+- [Item System Runtime Model](./Design%20Documents/Item_System_Runtime_Model.md)
+- [Item System Component Authoring](./Design%20Documents/Item_System_Component_Authoring.md)
+- [Item System Content Workflows](./Design%20Documents/Item_System_Content_Workflows.md)
+- [Item System Presentation and Integration](./Design%20Documents/Item_System_Presentation_and_Integration.md)
+
+For the purposes of this instruction, "item-related" includes work in or directly coupled to:
+
+- `MudSharpCore/GameItems`
+- `FutureMUDLibrary/GameItems`
+- item builder commands and editable-item helpers
+- item-related FutureProg functions
+- item skins and item groups
+- item templates in `Item Templates/`
+
 ## Economy Design Document Reference
 
 When changing economy-related systems, treat the following documents as the primary design references and keep them in sync with the code:

--- a/Design Documents/Item_System_Component_Authoring.md
+++ b/Design Documents/Item_System_Component_Authoring.md
@@ -1,0 +1,195 @@
+# FutureMUD Item System Component Authoring
+
+## Scope
+This document explains how to add a new item capability through the component system.
+
+It is the primary implementation guide for creating new item "types" in FutureMUD.
+
+## The Real Workflow
+Adding a new item capability usually means all of the following:
+1. Decide whether there should be a public interface in `FutureMUDLibrary`.
+2. Create or update the component prototype class in `MudSharpCore/GameItems/Prototypes`.
+3. Create or update the runtime component class in `MudSharpCore/GameItems/Components`.
+4. Register the component type with `GameItemComponentManager`.
+5. Add builder help and any custom component editing commands.
+6. Attach the component prototype to one or more item prototypes with builder commands.
+7. Load and test the resulting items in-game.
+
+The template in `Item Templates/GameItem` helps with steps 2 through 4, but it does not solve the design work, interface design, or gameplay integration for you.
+
+## Step 1: Decide on the Public Contract
+### Reuse an existing interface when possible
+Many item systems already query for public interfaces in `FutureMUDLibrary/GameItems/Interfaces`.
+
+If your new item capability is just another implementation of an existing concept, reuse the existing interface. Examples:
+- a new kind of container should still satisfy `IContainer`
+- a new kind of light source should satisfy `IProduceLight`
+- a new kind of weapon should satisfy the relevant weapon interfaces
+
+### Add a new interface when the capability is new
+If the capability is genuinely new and other systems need to query for it, add a new interface in `FutureMUDLibrary` first.
+
+That interface should:
+- describe the behaviour other systems care about
+- avoid binding callers to a concrete component class
+- stay focused on the game-facing contract, not internal XML or builder details
+
+The runtime component in `MudSharpCore` should then implement that interface.
+
+## Step 2: Start from the GameItem Template
+The repaired `Item Templates/GameItem` template should now generate a coherent pair:
+- `ExampleGameItemComponent`
+- `ExampleGameItemComponentProto`
+
+Use it as the first scaffold, then immediately adapt it to the real feature.
+
+What the template gives you:
+- a correctly named component class
+- a correctly named component proto class
+- matching constructors and `Copy(...)`
+- registration hooks for builder and database loading
+- XML load/save hooks
+- default builder help and `ComponentDescriptionOLC(...)`
+
+What the template does not decide for you:
+- whether a public interface is required
+- what runtime state belongs on the component
+- what builder-editable configuration belongs on the proto
+- whether the component decorates descriptions
+- whether it affects weight, movement, position, destruction, morphing, or purge warnings
+- whether it should be primary, read-only, or manually loadable
+
+## Step 3: Build the Component Proto
+### Responsibilities of the proto
+The component proto is the builder-authored and revisioned definition.
+
+Put the following here:
+- editable configuration values
+- XML serialisation and deserialisation
+- builder commands for changing the configuration
+- help text that appears through `comp typehelp` and `comp set help`
+- `CreateNew(...)` and `LoadComponent(...)`
+- registration through `RegisterComponentInitialiser(...)`
+
+### Registration requirements
+Every normal component proto must register itself with `GameItemComponentManager` using a static `RegisterComponentInitialiser(...)`.
+
+Typical registration includes:
+- `AddBuilderLoader(...)` for `comp edit new <type>`
+- `AddDatabaseLoader(...)` for boot-time loading from the stored type string
+- `AddTypeHelpInfo(...)` for type listings and builder help
+
+Use the builder loader names intentionally:
+- one primary name should be the main builder-facing type keyword
+- optional aliases can be added as non-primary names
+
+### Example: Container proto
+`ContainerGameItemComponentProto` is a good reference because it shows the common editable-proto pattern:
+- several builder-editable properties
+- XML persistence for those properties
+- targeted building commands
+- readable `ComponentDescriptionOLC(...)`
+- standard registration and factory methods
+
+## Step 4: Build the Runtime Component
+### Responsibilities of the component
+The runtime component should hold live behaviour and live state.
+
+Typical responsibilities include:
+- implementing the public gameplay interface
+- storing runtime state that changes per live item
+- reacting to morph, destruction, or swap flows
+- contributing to description decoration
+- exposing movement or reposition restrictions
+- managing contained, attached, or connected sub-items
+
+### Common overrides to consider
+Not every component needs these, but authors should deliberately consider them:
+- `Copy(...)`
+- `UpdateComponentNewPrototype(...)`
+- `SaveToXml()`
+- `LoadFromXml(...)`
+- `DescriptionDecorator(...)`
+- `Decorate(...)`
+- `Delete()`
+- `Quit()`
+- `Login()`
+- `Take(...)`
+- `SwapInPlace(...)`
+- `HandleDieOrMorph(...)`
+- `PreventsMovement()`
+- `PreventsRepositioning()`
+- `ComponentWeight`
+- `ComponentWeightMultiplier`
+- `ComponentBuoyancy(...)`
+- `WarnBeforePurge`
+
+### Runtime state versus proto state
+Use this rule consistently:
+- if the value is authored once and reused by many items, it belongs on the proto
+- if the value changes per live item, it belongs on the runtime component
+
+For example:
+- container capacity belongs on the proto
+- current contents belong on the runtime component
+
+## Step 5: Attach the Capability to Item Prototypes
+Once the component proto exists and is current, attach it to item prototypes through builder workflows:
+- create or edit the component with `comp`
+- create or edit an item prototype with `item`
+- attach the component to the item with `item set add <id|name>`
+
+The item prototype then becomes the reusable content definition that creates live items carrying the runtime component.
+
+## Step 6: Test with Builder Workflows
+At minimum, validate:
+- the component can be created with `comp edit new <type>`
+- the component can be edited and submitted
+- the item prototype can attach and detach the component
+- the item can be loaded with `item load`
+- the loaded live item actually exposes the expected interface and behaviour
+
+If the component sets `PreventManualLoad`, also validate the expected restrictions around builder loading and prog loading.
+
+## Special Cases
+### Read-only framework components
+Some components are framework primitives rather than normal builder-authored components.
+
+`HoldableGameItemComponentProto` is the main example:
+- read-only
+- auto-initialised
+- not opened for ordinary editing
+
+Do not use these as the model for a normal component authoring flow.
+
+### When to add custom initialisation
+If a component type must always exist or must be created programmatically for engine reasons, provide a static initialiser such as `InitialiseItemType(...)` in addition to normal registration.
+
+Use this sparingly. Most new item capabilities should be ordinary component types authored through `comp`.
+
+## Example Authoring Checklist
+Use this checklist when adding a new capability:
+
+1. Add or reuse a public interface in `FutureMUDLibrary`.
+2. Generate a starting scaffold from `Item Templates/GameItem`.
+3. Rename and align the generated pair with the real gameplay concept.
+4. Move reusable definition to the proto and live state to the component.
+5. Implement XML save/load on both sides where required.
+6. Implement registration through `RegisterComponentInitialiser(...)`.
+7. Add builder help and focused building commands.
+8. Implement any necessary runtime interfaces and behaviour.
+9. Attach the component to an item prototype and load a test item.
+10. Validate update, morph, and destruction implications if the feature is stateful.
+
+## Common Mistakes
+- Putting gameplay queries against the concrete component class instead of a public interface.
+- Storing authored definition on the runtime component instead of the proto.
+- Forgetting to register the database loader, which breaks boot-time loading.
+- Forgetting to update `ComponentDescriptionOLC(...)` and type help, leaving builders without guidance.
+- Ignoring copy or morph behaviour for stateful components.
+- Assuming the template is enough on its own. It is only the skeleton.
+
+## Recommended Reference Implementations
+- `ContainerGameItemComponentProto` and `ContainerGameItemComponent`
+- `WearableGameItemComponentProto` and `WearableGameItemComponent`
+- `HoldableGameItemComponentProto` and `HoldableGameItemComponent` for the read-only special-case pattern

--- a/Design Documents/Item_System_Content_Workflows.md
+++ b/Design Documents/Item_System_Content_Workflows.md
@@ -1,0 +1,164 @@
+# FutureMUD Item System Content Workflows
+
+## Scope
+This document explains the builder-facing workflows developers use when creating, revising, attaching, loading, and validating item content.
+
+The focus is not general builder onboarding. The focus is the minimum command surface developers need when implementing or testing item-system changes.
+
+## Working with Component Prototypes
+### Discover available component types
+Use:
+- `comp types`
+- `comp typehelp <type>`
+
+This is the fastest way to verify:
+- the registration worked
+- the builder-facing type keyword is correct
+- the help text is useful
+
+### Create a new component prototype
+Use:
+- `comp edit new <type>`
+
+This goes through `GameItemComponentManager`, so failure here often means:
+- the type was not registered
+- the builder loader name is wrong
+- the template output was not fully integrated into the codebase
+
+### Edit, submit, review, and obsolete component prototypes
+Key workflows:
+- `comp edit <id>`
+- `comp set ...`
+- `comp edit submit`
+- `comp review ...`
+- `comp edit obsolete`
+
+Because component prototypes are revisioned content, do not think of them as raw code-only artifacts. They are also builder-managed content definitions.
+
+## Working with Item Prototypes
+### Create or edit an item prototype
+Use:
+- `item edit new`
+- `item edit <id>`
+- `item clone <id>`
+
+### Attach or detach components
+Use:
+- `item set add <id|name>`
+- `item set remove <id|name>`
+
+This is the key step that turns a generic item prototype into something functional.
+
+### Important item settings for developers
+Commonly relevant commands include:
+- `item set noun`
+- `item set sdesc`
+- `item set ldesc`
+- `item set desc`
+- `item set size`
+- `item set weight`
+- `item set material`
+- `item set quality`
+- `item set cost`
+- `item set group`
+- `item set strategy`
+- `item set morph`
+- `item set destroyed`
+- `item set onload`
+- `item set register`
+- `item set canskin`
+- `item set hidden`
+- `item set preserve`
+
+These matter because many component features only make sense in combination with item-level settings. For example:
+- item groups affect room presentation
+- morph and destroyed settings affect component replacement behaviour
+- registers and on-load progs can feed variable-style components
+- skinnability affects how content can be customised by players
+
+## Loading and Testing Live Items
+### Manual load workflow
+Use:
+- `item load [<quantity>] <id> [<extra args>]`
+
+This is the normal developer validation path for checking whether a prototype, its components, and its runtime behaviour work together.
+
+### Extra arguments
+The builder-facing load flow supports:
+- skin selection
+- register variable overrides
+- quantity for stackable content
+
+Developers should use these to validate:
+- variable-driven item behaviour
+- stackable behaviour
+- skin overrides
+
+### Manual load restrictions
+Some components set `PreventManualLoad`, and item prototypes surface that through `PreventManualLoad`.
+
+That flag exists for content that should only enter the world through controlled runtime systems, such as:
+- corpses
+- bodyparts
+- currency-style special cases
+
+If a newly added component sets this flag, developers should verify the restriction is intentional and documented.
+
+## Revision and Update Workflows
+### Why revisions matter
+Items and components are not a simple "edit in place" system. Revisions matter because the world may already contain:
+- current live items
+- older item prototype revisions
+- older component prototype revisions
+
+### Updating prototypes and live items
+The `comp update` workflow exists to reconcile:
+- item prototypes that reference outdated component prototype revisions
+- live items whose item or component definitions have moved forward
+
+Use:
+- `comp update`
+- `comp update all`
+
+This is especially important after changing component prototype structure or moving a current component into a new revision.
+
+## Skins, Groups, and Related Content
+### Skins
+Skins are item-prototype-adjacent content that override presentation details such as:
+- item name
+- short description
+- long description
+- full description
+- quality
+
+From a workflow perspective, skins matter when:
+- the base item prototype is intentionally generic
+- builders need controlled presentation variants without duplicating item behaviour
+
+### Item groups
+Item groups are content-side presentation tools for rooms. They let many similar items collapse into grouped room descriptions instead of flooding room output.
+
+Use them when validating:
+- new high-volume item content
+- environmental props
+- grouped furniture or clutter
+
+## Recommended Developer Workflow
+When adding a new item capability, the most reliable end-to-end workflow is:
+
+1. Implement and register the component code.
+2. Use `comp types` and `comp typehelp` to confirm registration.
+3. Create a test component with `comp edit new <type>`.
+4. Configure and submit the component.
+5. Create or clone a test item prototype.
+6. Attach the component with `item set add`.
+7. Configure item-level settings.
+8. Load a live test item with `item load`.
+9. Exercise the runtime behaviour in-game.
+10. Run `comp update` when revision churn has occurred.
+
+## Failure Patterns to Watch
+- `comp edit new <type>` fails: registration problem.
+- item loads but does nothing: the item probably lacks the component or the runtime component is not implementing the expected interface.
+- boot-time load fails: likely missing or mismatched database loader registration.
+- updated component changes do not appear on old content: update workflow was not run or the update hooks are incomplete.

--- a/Design Documents/Item_System_Overview.md
+++ b/Design Documents/Item_System_Overview.md
@@ -1,0 +1,34 @@
+# FutureMUD Item System Overview
+
+## Purpose
+This document set explains how the FutureMUD item system is structured, how item behaviour is composed through components, and how developers should add or extend item functionality.
+
+The intended audience is engine developers. Builder commands and content workflows are included where they matter for implementing, validating, and shipping item work.
+
+## Document Map
+- [Item System Runtime Model](./Item_System_Runtime_Model.md) explains the core runtime abstractions, instance-versus-prototype model, persistence, revisions, and update flows.
+- [Item System Component Authoring](./Item_System_Component_Authoring.md) explains how to add a new item capability or "item type" through interfaces, component prototypes, runtime components, registration, and content attachment.
+- [Item System Content Workflows](./Item_System_Content_Workflows.md) explains the builder-facing `item` and `comp` workflows developers rely on when testing and shipping content.
+- [Item System Presentation and Integration](./Item_System_Presentation_and_Integration.md) explains how items present themselves to players and how they integrate with inventory, grouping, skins, health, magic, and other runtime systems.
+
+## Core Idea
+FutureMUD items are composed rather than inherited.
+
+At runtime:
+- `IGameItem` is the live perceivable object in the world.
+- `IGameItemProto` is the revisioned definition used to create live items.
+- `IGameItemComponent` adds a concrete slice of runtime behaviour to a live item.
+- `IGameItemComponentProto` is the revisioned, reusable definition for a component.
+
+Most gameplay-facing item behaviour is discovered by checking whether an item contains a component that implements some public interface such as `IContainer`, `IWearable`, `IMeleeWeapon`, `IProduceLight`, or `IImplant`.
+
+## Recommended Reading Order
+1. Start with [Item System Runtime Model](./Item_System_Runtime_Model.md) if you need to understand how items actually work.
+2. Continue with [Item System Component Authoring](./Item_System_Component_Authoring.md) if you are adding a new item capability.
+3. Use [Item System Content Workflows](./Item_System_Content_Workflows.md) when you need to create, revise, attach, load, or review content.
+4. Use [Item System Presentation and Integration](./Item_System_Presentation_and_Integration.md) when working on descriptions, grouping, skins, or cross-subsystem behaviour.
+
+## Important Notes
+- The fastest way to add a new item capability is usually to add a new component prototype and component pair, not a new `GameItem` subclass.
+- The `Item Templates/GameItem` template is intended to be a starting skeleton, not a complete implementation. The authoring document calls out the manual work the template does not solve.
+- Some component types are special cases. For example, `Holdable` is a read-only auto-initialised component type and should be treated differently from ordinary editable component prototypes.

--- a/Design Documents/Item_System_Presentation_and_Integration.md
+++ b/Design Documents/Item_System_Presentation_and_Integration.md
@@ -1,0 +1,169 @@
+# FutureMUD Item System Presentation and Integration
+
+## Scope
+This document explains how item behaviour is presented to players and how items integrate with adjacent runtime systems.
+
+The focus is on:
+- descriptions and decorators
+- inventory, containment, and location behaviour
+- item groups and skins
+- cross-system integration points such as health and magic
+
+## Description Model
+### Item-level descriptions
+Item prototypes provide the base descriptive layer:
+- noun
+- short description
+- full description
+- optional long description override
+- extra descriptions gated by progs
+
+Skins can override several of these presentation values without replacing the underlying item behaviour.
+
+### Component-driven description decoration
+Components can decorate item descriptions by overriding:
+- `DescriptionDecorator(...)`
+- `Decorate(...)`
+- `DecorationPriority`
+- `WrapFullDescription`
+
+This is how components add behavioural presentation without forcing all description logic into `GameItem` itself.
+
+Examples include:
+- containers showing fullness, open state, and contents
+- locks or connections contributing extra information
+- effects such as glow adding descriptive layers through adjacent systems
+
+### Decoration ordering
+Decoration ordering matters:
+- non-negative priorities are applied before colour processing
+- negative priorities are applied after colour processing in descending order
+
+When adding a decorator component, choose a priority deliberately so its output composes cleanly with existing decorators.
+
+## Containment, Inventory, and Location
+### Items are not only "in a room"
+Items may be:
+- directly in a cell
+- held or worn by a body
+- inside containers
+- attached to belts or other items
+- installed as doors or furniture-adjacent objects
+- implanted or prosthetic
+- connected into power or grid systems
+
+Because of this, the item system exposes:
+- `TrueLocations`
+- `LocationLevelPerceivable`
+- `ContainedIn`
+- `InInventoryOf`
+- deep and shallow item traversal helpers
+
+### Why this matters for component authors
+Any component that changes where an item effectively "is" in the world needs to consider:
+- location resolution
+- movement
+- morph and destruction transfer
+- inventory change propagation
+
+Common examples:
+- `IContainer`
+- `IBelt` and `IBeltable`
+- `IConnectable`
+- `IDoor`
+- `IHoldable`
+- `IWearable`
+- `IImplant`
+- `IProsthetic`
+
+## Item Groups
+### Purpose
+Item groups exist to control room presentation when many similar items are present.
+
+Instead of showing every item individually, a group can provide a form-based grouped description appropriate to the cell.
+
+### Developer relevance
+Item groups matter when:
+- your new item type is likely to exist in large numbers
+- room clutter would otherwise drown out important content
+- you need controlled presentation for furniture-heavy or prop-heavy spaces
+
+From the item side, the prototype simply references an `IGameItemGroup`. The grouping logic itself is separate from component behaviour.
+
+## Skins
+### Purpose
+Skins provide presentation variation without duplicating item behaviour definitions.
+
+An item skin can override:
+- item name
+- short description
+- long description
+- full description
+- quality
+
+### Developer relevance
+Skins are important whenever:
+- behaviour should stay constant but appearance should vary
+- players or builders need cosmetic variants
+- content should be customised without cloning behaviour-heavy item prototypes
+
+When changing item presentation flows, remember that skins may override prototype text.
+
+## Health, Magic, and Other System Integrations
+### Health integration
+Items participate in the health system more directly than many engines would expect:
+- `GameItem` has health strategy integration
+- item components can act as corpses, medical tools, implants, prosthetics, breathing support, or treatment systems
+
+This means item features often have consequences for:
+- wound handling
+- destruction
+- surgery
+- breathing
+- body-state modelling
+
+### Magic integration
+Items also integrate with magic through:
+- item-owned effects and magic resources
+- magic-aware item methods and persistence
+- spell effects that can target items
+
+Any new component that changes item descriptions, energy state, or visibility may end up interacting with spell effects and magic systems.
+
+### FutureProg integration
+Items and components can be discovered and manipulated through FutureProg-facing systems, while item prototypes can execute on-load progs and hold default register values.
+
+Variable-driven items are a common integration point between item content and scripting.
+
+## Real Example: Container as Presentation + Integration
+The container implementation is a strong example because it touches both presentation and system integration.
+
+Presentation:
+- adds full-description detail about openness and fullness
+- contributes contents lists
+- exposes lock information
+
+Integration:
+- manages contained items and lock items
+- affects weight and buoyancy
+- handles morph and destruction transfer
+- changes what items are shallowly accessible
+
+It is a good reference whenever a new component needs to both change behaviour and explain that behaviour to players.
+
+## Special-Case Components
+Read-only framework components such as `Holdable` still participate in presentation and integration even though they are not ordinary builder-authored component types.
+
+They are important because they establish foundational assumptions:
+- whether an item can be picked up
+- whether the item should fall
+- whether inventory-oriented commands are even meaningful
+
+When troubleshooting strange item behaviour, always verify whether one of these framework-level components is part of the composition.
+
+## Guidance for New Work
+- If a feature changes what a player should understand about an item, consider description decoration.
+- If a feature changes where the item functionally exists, consider location-level behaviour and movement.
+- If a feature is mostly about room clutter and presentation, consider item groups before inventing bespoke logic.
+- If a feature is cosmetic-only, consider skins before cloning prototypes.
+- If a feature touches health, magic, or scripted behaviour, document the integration explicitly rather than treating it as incidental.

--- a/Design Documents/Item_System_Runtime_Model.md
+++ b/Design Documents/Item_System_Runtime_Model.md
@@ -1,0 +1,218 @@
+# FutureMUD Item System Runtime Model
+
+## Scope
+This document explains how the item system is structured in code and at runtime:
+
+- live items versus revisioned definitions
+- item composition through components
+- persistence and load flows
+- revision updates
+- morph and destruction behaviour
+
+## Primary Abstractions
+### `IGameItem`
+`IGameItem` is the live object that exists in the world. It extends perceiver and body-adjacent interfaces, so items are not just data records; they are active world objects with descriptions, location, health, events, and effects.
+
+Important responsibilities include:
+- holding runtime component instances through `Components`
+- exposing convenience queries like `IsItemType<T>()`, `GetItemType<T>()`, and `GetItemTypes<T>()`
+- tracking containment, inventory ownership, and true locations
+- handling save/load, deletion, quitting, login, morphing, and update checks
+- aggregating behaviour from components rather than owning all behaviour directly
+
+In practice, `GameItem` is the orchestration layer. Components provide most specialised behaviour, while `GameItem` coordinates persistence, description composition, movement, inventory state, wound handling, and world integration.
+
+### `IGameItemProto`
+`IGameItemProto` is the revisioned prototype for creating items.
+
+It owns the reusable definition of:
+- name and descriptive text
+- base quality, weight, material, and size
+- health strategy
+- default registers
+- attached component prototypes
+- item group
+- morph and destroyed-item setup
+- on-load progs
+- skin permissions and visibility flags
+
+Prototype methods like `CreateNew(...)` instantiate a `GameItem`, create one runtime component per attached component prototype, apply variable initialisation, and execute on-load progs.
+
+### `IGameItemComponent`
+`IGameItemComponent` is the runtime slice of behaviour attached to a live item.
+
+A component may:
+- implement gameplay interfaces such as `IContainer`, `IOpenable`, `IWearable`, or `IRangedWeapon`
+- participate in saving/loading
+- decorate descriptions
+- block movement or repositioning
+- react to morph/destruction
+- manage contained, attached, or connected sub-items
+- override material, weight contribution, buoyancy, and purge warnings
+
+Runtime item behaviour is usually discovered by interface lookup on components. Code commonly asks questions like:
+- does this item have an `IContainer`?
+- does this item have an `IProduceLight`?
+- does this item have an `IImplant`?
+
+### `IGameItemComponentProto`
+`IGameItemComponentProto` is the revisioned reusable definition of a component type instance.
+
+It owns:
+- builder-editable configuration
+- XML persistence for that configuration
+- the factory methods that create and load runtime components
+- type help and builder help text
+- flags such as `WarnBeforePurge` and `PreventManualLoad`
+
+## Composition Model
+### Components define capabilities
+The item system is intentionally interface-first and component-driven.
+
+A live item becomes "a container" because one of its components implements `IContainer`. It becomes "a wearable" because one of its components implements `IWearable`. It becomes "a radio", "a corpse", "a battery-powered machine", or "a prosthetic" for the same reason.
+
+This has two important consequences:
+- most game logic should depend on interfaces from `FutureMUDLibrary`, not concrete component classes
+- adding a new capability usually means adding a new component pair, not adding a new item class
+
+### `GameItem` aggregates component behaviour
+`GameItem` delegates and aggregates a large amount of behaviour:
+- movement prevention is aggregated across components
+- description decoration is ordered by `DecorationPriority`
+- material can be overridden by components
+- attached and connected item relationships are exposed through component-provided interfaces
+- location resolution checks components such as chairs, doors, belts, connectables, worn items, implants, and prosthetics
+
+This aggregation layer is why item code often looks simple at the call site even when item behaviour is complex.
+
+## Prototypes, Revisions, and Live Items
+### Revisioned content model
+Item prototypes and component prototypes are editable revisable items. They move through the normal FutureMUD revision flow:
+- under design
+- pending revision
+- current
+- obsolete
+
+Items loaded into the world are instances of specific current definitions at the time of creation, but both item prototypes and live items have update paths to move to newer component or prototype revisions.
+
+### Prototype composition
+A prototype stores attached component prototypes through the many-to-many revision-aware relationship between item prototypes and component prototypes.
+
+When a prototype creates a new item:
+1. a `GameItem` instance is created
+2. each attached component prototype creates one runtime component instance
+3. variable or stackable setup runs if applicable
+4. skin overrides are applied if provided
+5. on-load progs execute
+
+## Save and Load Flow
+### Loading prototypes
+At boot, `FuturemudLoaders` loads:
+1. item component prototypes
+2. item prototypes
+3. special auto-initialised item types
+4. item skins
+
+The ordering matters:
+- component prototypes must exist before item prototypes
+- special auto-initialisers such as `HoldableGameItemComponentProto.InitialiseItemType` run after item prototypes load
+
+### Loading live items
+When a live item is loaded:
+- the `GameItem` is created from database data
+- each stored component row is mapped back to its component proto and runtime component type
+- component `FinaliseLoad()` hooks run after broader object availability is established
+- item-level late initialisation and effect restoration complete
+
+### Saving live items
+`GameItem.Save()` is responsible for item-level persistence such as:
+- prototype revision references
+- quality, material, ownership, morph progress, and position
+- effect and magic data
+
+Each component persists its own XML definition through `GameItemComponent.Save()` and `SaveToXml()`.
+
+## Update Behaviour
+### Prototype update checks
+`GameItemProto.CheckForComponentPrototypeUpdates()` updates a prototype if any attached component prototype has moved from current to revised or obsolete.
+
+That process:
+- swaps old component prototype references to the newest current revision
+- updates the persisted mapping rows
+- keeps the prototype definition aligned with the latest component prototype revisions
+
+### Live item update checks
+`GameItem.CheckPrototypeForUpdate()` updates live items when:
+- the parent item prototype has been revised or obsoleted
+- attached component membership has changed
+- a component prototype revision has changed
+
+It can:
+- swap the item to a newer prototype revision
+- create runtime components that newly exist on the prototype
+- remove runtime components that no longer belong
+- ask each runtime component to update itself to a newer prototype revision
+
+The builder-facing `comp update` workflow exists to force these update passes across prototypes and items.
+
+## Morphing, Destruction, and Replacement
+### Morphing
+Item prototypes can define morph behaviour:
+- morph into another item after a timespan
+- disappear after a timespan
+- emit a morph emote
+
+Morph timing is tracked on live items, and new items may preserve register values depending on prototype settings.
+
+### Destroyed items
+Item prototypes can also define a replacement prototype to load when the item is destroyed.
+
+This allows patterns such as:
+- intact item -> wreckage
+- living body item -> corpse-style remains
+- powered machine -> broken shell
+
+### Component participation
+Components can influence these transitions through:
+- `HandleDieOrMorph`
+- `SwapInPlace`
+- `Take`
+- `AffectsLocationOnDestruction`
+- `ComponentDieOrder`
+
+Container-style components are a good example: they often need to decide what happens to contents or locks when the parent item morphs or dies.
+
+## Real Example: Container
+`ContainerGameItemComponentProto` is a representative example of a typical editable component proto:
+- stores builder-editable values like weight limit, max size, transparency, and preposition
+- loads and saves its configuration as XML
+- registers itself with `GameItemComponentManager`
+- exposes type help and component-specific builder help
+- creates and loads the runtime `ContainerGameItemComponent`
+
+`ContainerGameItemComponent` then provides runtime behaviour by implementing `IContainer`, `IOpenable`, and `ILockable`.
+
+It demonstrates several common component patterns:
+- internal runtime state layered on top of a proto definition
+- description decoration
+- handling contained child items
+- weight and buoyancy contribution
+- destruction and morph transfer logic
+- `Copy(...)` support for deep-copy item creation
+
+## Special Cases
+### Read-only or auto-initialised component types
+Not every component type behaves like a normal editable component proto.
+
+`HoldableGameItemComponentProto` is a key example:
+- it is read-only
+- it is auto-initialised through a static `InitialiseItemType`
+- it is used as an always-available foundational capability when configured by world settings
+
+When documenting or extending the system, treat these as framework-level special cases rather than normal builder-authored component content.
+
+## Practical Guidance
+- Reach for interfaces in `FutureMUDLibrary` first. Runtime systems should usually depend on `IContainer`, `IReadable`, `ITransmit`, and similar interfaces.
+- Treat `GameItem` as the composition shell, not the place to add every feature directly.
+- Put configuration on the component proto and runtime state on the component.
+- Expect update, morph, and destruction flows to matter for any non-trivial item behaviour.

--- a/Item Templates/FutureProg Function/Function.cs
+++ b/Item Templates/FutureProg Function/Function.cs
@@ -1,63 +1,51 @@
-﻿using System;
+#nullable enable
 using System.Collections.Generic;
-$if$ ($targetframeworkversion$ >= 3.5)using System.Linq;
-$endif$using System.Text;
-$if$ ($targetframeworkversion$ >= 4.5)using System.Threading.Tasks;
-$endif$
-using System.Xml.Linq;
-using MudSharp.Character;
-using MudSharp.FutureProg.Variables;
 using MudSharp.Framework;
-using MudSharp.FutureProg;
-using MudSharp.PerceptionEngine;
-using MudSharp.PerceptionEngine.Outputs;
-using MudSharp.PerceptionEngine.Parsers;
+using MudSharp.FutureProg.Variables;
 
-namespace $rootnamespace$
+namespace $rootnamespace$;
+
+internal class $safeitemrootname$ : BuiltInFunction
 {
-    internal class $safeitemrootname$ : BuiltInFunction {
-		public IFuturemud Gameworld { get; set; }
-		#region Static Initialisation
-		public static void RegisterFunctionCompiler()
-        {
-            FutureProg.RegisterBuiltInFunctionCompiler(
-                new FunctionCompilerInformation(
-                    "$safeitemrootname$".ToLowerInvariant(),
-                    new[] { FutureProgVariableTypes.Number }, // the parameters the function takes
-                    (pars, gameworld) => new $safeitemrootname$(pars, gameworld),
-					new List<string>{ }, // parameter names
-                    new List<string>{ }, // parameter help text
-                    "", // help text for the function,
-                    "", // the category to which this function belongs,
-                    FutureProgVariableTypes.Boolean // the return type of the function
-                )
-            );
-        }
-		#endregion
-		
-		#region Constructors
-		protected $safeitemrootname$(IList<IFunction> parameterFunctions, IFuturemud gameworld) : base(parameterFunctions)
-        {
-            Gameworld = gameworld;
-        }
-		#endregion
-		
-		public override FutureProgVariableTypes ReturnType {
-            get { return FutureProgVariableTypes.Boolean; }
-            protected set { }
-        }
-		
-		public override StatementResult Execute(IVariableSpace variables)
-        {
-            if (base.Execute(variables) == StatementResult.Error)
-            {
-                return StatementResult.Error;
-            }
-			
-			// Your logic here
+	private readonly IFuturemud _gameworld;
 
-            Result = new BooleanVariable(true);
-            return StatementResult.Normal;
-        }
-    }
+	private $safeitemrootname$(IList<IFunction> parameterFunctions, IFuturemud gameworld)
+		: base(parameterFunctions)
+	{
+		_gameworld = gameworld;
+	}
+
+	public override ProgVariableTypes ReturnType
+	{
+		get => ProgVariableTypes.Boolean;
+		protected set { }
+	}
+
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		if (base.Execute(variables) == StatementResult.Error)
+		{
+			return StatementResult.Error;
+		}
+
+		// Use _gameworld and ParameterFunctions here.
+		Result = new BooleanVariable(true);
+		return StatementResult.Normal;
+	}
+
+	public static void RegisterFunctionCompiler()
+	{
+		FutureProg.RegisterBuiltInFunctionCompiler(
+			new FunctionCompilerInformation(
+				"$safeitemrootname$".ToLowerInvariant(),
+				[ProgVariableTypes.Number],
+				(pars, gameworld) => new $safeitemrootname$(pars, gameworld),
+				["value"],
+				["The input value for this function."],
+				"Describe what this function returns.",
+				"General",
+				ProgVariableTypes.Boolean
+			)
+		);
+	}
 }

--- a/Item Templates/FutureProg Function/Function.vstemplate
+++ b/Item Templates/FutureProg Function/Function.vstemplate
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" Type="Item" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005">
   <TemplateData>
     <Name>FutureProg Function</Name>
@@ -6,10 +6,8 @@
     <Icon Package="{FAE04EC1-301F-11d3-BF4B-00C04F79EFBC}" ID="4515" />
     <ProjectType>CSharp</ProjectType>
     <SortOrder>1</SortOrder>
-    <RequiredFrameworkVersion>4.5</RequiredFrameworkVersion>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <DefaultName>FunctionName</DefaultName>
-    <AppIdFilter>blend</AppIdFilter>
   </TemplateData>
   <TemplateContent>
     <References>

--- a/Item Templates/GameItem/GameItem.cs
+++ b/Item Templates/GameItem/GameItem.cs
@@ -1,56 +1,56 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+#nullable enable
 using System.Xml.Linq;
 using MudSharp.Framework;
-using MudSharp.GameItems.Interfaces;
-using MudSharp.GameItems.Prototypes;
-using MudSharp.PerceptionEngine;
-using MudSharp.PerceptionEngine.Outputs;
-using MudSharp.PerceptionEngine.Parsers;
 
-namespace $rootnamespace$.Components
+namespace $rootnamespace$.Components;
+
+public class $safeitemrootname$GameItemComponent : GameItemComponent
 {
-    public class $safeitemrootname$ : GameItemComponent
-    {
-		protected $safeitemrootname$Proto _prototype;
-		public override IGameItemComponentProto Prototype => _prototype;
-		
-		protected override void UpdateComponentNewPrototype(IGameItemComponentProto newProto){
-			_prototype = ($safeitemrootname$Proto)newProto;
-		}
-		
-		#region Constructors
-		public $safeitemrootname$($safeitemrootname$Proto proto, IGameItem parent, bool temporary = false) : base(parent, proto, temporary){
-			_prototype = proto;
-		}
-		
-		public $safeitemrootname$(Models.GameItemComponent component, $safeitemrootname$Proto proto, IGameItem parent) : base(component, parent) {
-			_prototype = proto;
-			_noSave = true;
-			LoadFromXml(XElement.Parse(component.Definition));
-			_noSave = false;
-		}
-		
-		public $safeitemrootname$($safeitemrootname$ rhs, IGameItem newParent, bool temporary = false) : base(rhs, newParent, temporary) {
-			_prototype = rhs._prototype;
-		}
-		
-		protected void LoadFromXml(XElement root){
-			// TODO
-		}
-		
-		public override IGameItemComponent Copy(IGameItem newParent, bool temporary = false){
-			return new $safeitemrootname$(this, newParent, temporary);
-		}
-		#endregion
-		
-		#region Saving
-		protected override string SaveToXml(){
-			return new XElement("Definition").ToString();
-		}
-		#endregion
-    }
+	protected $safeitemrootname$GameItemComponentProto _prototype;
+
+	public $safeitemrootname$GameItemComponent($safeitemrootname$GameItemComponentProto proto, IGameItem parent,
+		bool temporary = false)
+		: base(parent, proto, temporary)
+	{
+		_prototype = proto;
+	}
+
+	public $safeitemrootname$GameItemComponent(MudSharp.Models.GameItemComponent component,
+		$safeitemrootname$GameItemComponentProto proto, IGameItem parent)
+		: base(component, parent)
+	{
+		_prototype = proto;
+		_noSave = true;
+		LoadFromXml(XElement.Parse(component.Definition));
+		_noSave = false;
+	}
+
+	public $safeitemrootname$GameItemComponent($safeitemrootname$GameItemComponent rhs, IGameItem newParent,
+		bool temporary = false)
+		: base(rhs, newParent, temporary)
+	{
+		_prototype = rhs._prototype;
+	}
+
+	public override IGameItemComponentProto Prototype => _prototype;
+
+	public override IGameItemComponent Copy(IGameItem newParent, bool temporary = false)
+	{
+		return new $safeitemrootname$GameItemComponent(this, newParent, temporary);
+	}
+
+	protected override void UpdateComponentNewPrototype(IGameItemComponentProto newProto)
+	{
+		_prototype = ($safeitemrootname$GameItemComponentProto)newProto;
+	}
+
+	protected virtual void LoadFromXml(XElement root)
+	{
+		// Load runtime state here if the component persists per-item data.
+	}
+
+	protected override string SaveToXml()
+	{
+		return new XElement("Definition").ToString();
+	}
 }

--- a/Item Templates/GameItem/GameItem.vstemplate
+++ b/Item Templates/GameItem/GameItem.vstemplate
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" Type="Item" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005">
   <TemplateData>
     <Name>Game Item Component Type</Name>
@@ -8,7 +8,6 @@
     <SortOrder>2</SortOrder>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <DefaultName>ItemType</DefaultName>
-    <AppIdFilter>blend</AppIdFilter>
   </TemplateData>
   <TemplateContent>
     <References>
@@ -17,7 +16,7 @@
       </Reference>
     </References>
 
-    <ProjectItem ReplaceParameters="true" TargetFileName="Components\$fileinputname$GameItemComponent.cs">GameItem.cs</ProjectItem>
-	<ProjectItem ReplaceParameters="true" TargetFileName="Prototypes\$fileinputname$GameItemComponentProto.cs">GameItemProto.cs</ProjectItem>
+    <ProjectItem ReplaceParameters="true" TargetFileName="Components\$safeitemrootname$GameItemComponent.cs">GameItem.cs</ProjectItem>
+    <ProjectItem ReplaceParameters="true" TargetFileName="Prototypes\$safeitemrootname$GameItemComponentProto.cs">GameItemProto.cs</ProjectItem>
   </TemplateContent>
 </VSTemplate>

--- a/Item Templates/GameItem/GameItemProto.cs
+++ b/Item Templates/GameItem/GameItemProto.cs
@@ -1,92 +1,91 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+#nullable enable
 using System.Xml.Linq;
 using MudSharp.Accounts;
 using MudSharp.Character;
 using MudSharp.Framework;
 using MudSharp.Framework.Revision;
 using MudSharp.GameItems.Components;
-using MudSharp.PerceptionEngine;
-using MudSharp.PerceptionEngine.Outputs;
-using MudSharp.PerceptionEngine.Parsers;
 
-namespace $rootnamespace$.Prototypes
+namespace $rootnamespace$.Prototypes;
+
+public class $safeitemrootname$GameItemComponentProto : GameItemComponentProto
 {
-    public class $safeitemrootname$ : GameItemComponentProto {
-		public override string TypeDescription => "$fileinputname$";
-		
-		#region Constructors
-		protected $safeitemrootname$(IFuturemud gameworld, IAccount originator) : base(gameworld, originator, "$fileinputname$") {
-		}
-		
-		protected $safeitemrootname$(Models.GameItemComponentProto proto, IFuturemud gameworld) : base(proto, gameworld){
-		}
-		
-		protected override void LoadFromXml(XElement root){
-			// TODO
-		}
-		#endregion
-		
-		#region Saving
-		protected override string SaveToXml(){
-			return new XElement("Definition",
-					new XElement("Example")
-				).ToString();
-		}
-		#endregion
-		
-		#region Component Instance Initialising Functions
-		public override IGameItemComponent CreateNew(IGameItem parent, ICharacter loader = null, bool temporary = false){
-			return new $fileinputname$GameItemComponent(this, parent, temporary);
-		}
-		
-		public override IGameItemComponent LoadComponent(Models.GameItemComponent component, IGameItem parent){
-			return new $fileinputname$GameItemComponent(component, this, parent);
-		}
-		#endregion
-		
-		#region Initialisation Tasks
-		public static void RegisterComponentInitialiser(GameItemComponentManager manager){
-			manager.AddBuilderLoader("$fileinputname$".ToLowerInvariant(), true, (gameworld, account) => new $safeitemrootname$(gameworld,account));
-			manager.AddDatabaseLoader("$fileinputname$", (proto, gameworld) => new $safeitemrootname$(proto, gameworld));
-			manager.AddTypeHelpInfo(
-				"$fileinputname$", 
-				$"A short description of what the item type does", 
-				BuildingHelpText
-			);
-		}
-		
-		public override IEditableItem CreateNewRevision(ICharacter initiator){
-			return CreateNewRevision(initiator, (proto, gameworld) => new $safeitemrootname$(proto, gameworld));
-		}
-		#endregion
-		
-		#region Building Commands
+	public override string TypeDescription => "$safeitemrootname$";
 
-private const string BuildingHelpText = @"You can use the following options with this component:
+	protected $safeitemrootname$GameItemComponentProto(IFuturemud gameworld, IAccount originator)
+		: base(gameworld, originator, "$safeitemrootname$")
+	{
+	}
 
-	<name> - sets the name of the component
-	desc <desc> - sets the description of the component";
-		public override string ShowBuildingHelp => BuildingHelpText;
-		
-		public override bool BuildingCommand(ICharacter actor, StringStack command) {
-			switch (command.PopSpeech().ToLowerInvariant().CollapseString()){
-				default:
-					return base.BuildingCommand(actor, command);
-			}
+	protected $safeitemrootname$GameItemComponentProto(MudSharp.Models.GameItemComponentProto proto,
+		IFuturemud gameworld)
+		: base(proto, gameworld)
+	{
+	}
+
+	public static void RegisterComponentInitialiser(GameItemComponentManager manager)
+	{
+		manager.AddBuilderLoader("$safeitemrootname$".ToLowerInvariant(), true,
+			(gameworld, account) => new $safeitemrootname$GameItemComponentProto(gameworld, account));
+		manager.AddDatabaseLoader("$safeitemrootname$",
+			(proto, gameworld) => new $safeitemrootname$GameItemComponentProto(proto, gameworld));
+		manager.AddTypeHelpInfo(
+			"$safeitemrootname$",
+			"A short description of what this item component does.",
+			BuildingHelpText
+		);
+	}
+
+	public override IGameItemComponent CreateNew(IGameItem parent, ICharacter loader = null, bool temporary = false)
+	{
+		return new $safeitemrootname$GameItemComponent(this, parent, temporary);
+	}
+
+	public override IGameItemComponent LoadComponent(MudSharp.Models.GameItemComponent component, IGameItem parent)
+	{
+		return new $safeitemrootname$GameItemComponent(component, this, parent);
+	}
+
+	public override IEditableRevisableItem CreateNewRevision(ICharacter initiator)
+	{
+		return CreateNewRevision(initiator,
+			(proto, gameworld) => new $safeitemrootname$GameItemComponentProto(proto, gameworld));
+	}
+
+	private const string BuildingHelpText = @"You can use the following options with this component:
+
+	#3name <name>#0 - sets the name of the component
+	#3desc <desc>#0 - sets the description of the component";
+
+	public override string ShowBuildingHelp => BuildingHelpText;
+
+	public override bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopSpeech().ToLowerInvariant().CollapseString())
+		{
+			default:
+				return base.BuildingCommand(actor, command);
 		}
-		#endregion
-		
-		public override string ComponentDescriptionOLC(ICharacter actor) {
-            return string.Format(actor, "{0} (#{1:N0}r{2:N0}, {3})\r\n\r\nThis item needs a description.",
-                "$fileinputname$ Game Item Component".Colour(Telnet.Cyan),
-                ID,
-                RevisionNumber,
-                Name
-                );
-        }
-    }
+	}
+
+	public override string ComponentDescriptionOLC(ICharacter actor)
+	{
+		return string.Format(actor,
+			"{0} (#{1:N0}r{2:N0}, {3})\n\nThis item component needs a specific description.",
+			"$safeitemrootname$ Game Item Component".Colour(Telnet.Cyan),
+			Id,
+			RevisionNumber,
+			Name
+		);
+	}
+
+	protected override void LoadFromXml(XElement root)
+	{
+		// Load builder-authored definition data here.
+	}
+
+	protected override string SaveToXml()
+	{
+		return new XElement("Definition").ToString();
+	}
 }

--- a/Item Templates/Non-Saving Effect/Effect.cs
+++ b/Item Templates/Non-Saving Effect/Effect.cs
@@ -1,27 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-$if$ ($targetframeworkversion$ >= 3.5)using System.Linq;
-$endif$using System.Text;
-$if$ ($targetframeworkversion$ >= 4.5)using System.Threading.Tasks;
-$endif$
-using System.Xml.Linq;
-using MudSharp.Character;
+#nullable enable
 using MudSharp.Framework;
 using MudSharp.FutureProg;
-using MudSharp.PerceptionEngine;
-using MudSharp.PerceptionEngine.Outputs;
-using MudSharp.PerceptionEngine.Parsers;
 
-namespace $rootnamespace$.Concrete
+namespace $rootnamespace$.Concrete;
+
+public class $safeitemrootname$ : Effect, IEffect
 {
-    public class $safeitemrootname$ : Effect, IEffect {
-		public $safeitemrootname$(IPerceivable owner, IFutureProg applicabilityProg = null) : base(owner, applicabilityProg) {
-		}
-		
-		protected override string SpecificEffectType => "$fileinputname$";
-		
-		public override string Describe(IPerceiver voyeur){
-			return "An undescribed effect of type $fileinputname$.";
-		}
-    }
+	public $safeitemrootname$(IPerceivable owner, IFutureProg applicabilityProg = null)
+		: base(owner, applicabilityProg)
+	{
+	}
+
+	protected override string SpecificEffectType => "$safeitemrootname$";
+
+	public override string Describe(IPerceiver voyeur)
+	{
+		return "An undescribed effect.";
+	}
 }

--- a/Item Templates/Non-Saving Effect/Effect.vstemplate
+++ b/Item Templates/Non-Saving Effect/Effect.vstemplate
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" Type="Item" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005">
   <TemplateData>
     <Name>Non-Saving Effect</Name>
@@ -6,10 +6,8 @@
     <Icon Package="{FAE04EC1-301F-11d3-BF4B-00C04F79EFBC}" ID="4515" />
     <ProjectType>CSharp</ProjectType>
     <SortOrder>1</SortOrder>
-    <RequiredFrameworkVersion>4.5</RequiredFrameworkVersion>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <DefaultName>EffectType</DefaultName>
-    <AppIdFilter>blend</AppIdFilter>
   </TemplateData>
   <TemplateContent>
     <References>

--- a/Item Templates/Saving Effect/Effect.cs
+++ b/Item Templates/Saving Effect/Effect.cs
@@ -1,51 +1,41 @@
-﻿using System;
-using System.Collections.Generic;
-$if$ ($targetframeworkversion$ >= 3.5)using System.Linq;
-$endif$using System.Text;
-$if$ ($targetframeworkversion$ >= 4.5)using System.Threading.Tasks;
-$endif$
+#nullable enable
 using System.Xml.Linq;
-using MudSharp.Character;
 using MudSharp.Framework;
 using MudSharp.FutureProg;
-using MudSharp.PerceptionEngine;
-using MudSharp.PerceptionEngine.Outputs;
-using MudSharp.PerceptionEngine.Parsers;
 
-namespace $rootnamespace$.Concrete
+namespace $rootnamespace$.Concrete;
+
+public class $safeitemrootname$ : Effect, IEffect
 {
-    public class $safeitemrootname$ : Effect, IEffect {
-		#region Static Initialisation
-		public static void InitialiseEffectType() {
-            RegisterFactory("$safeitemrootname$", (effect, owner) => new $safeitemrootname$(effect, owner));
-        }
-		#endregion
-		
-		#region Constructors
-		public $safeitemrootname$(IPerceivable owner, IFutureProg applicabilityProg = null) : base(owner, applicabilityProg) {
-		}
-		
-		protected $safeitemrootname$(XElement effect, IPerceivable owner) : base(effect, owner) {
-			var root = effect.Element("Effect");
-        }
-		#endregion
-		
-		// Note: You can safely delete this entire region if your effect acts more like a flag and doesn't actually save any specific data on it (e.g. immwalk, admin telepathy, etc)
-		#region Saving and Loading
-		protected override XElement SaveDefinition()
-        {
-            return SaveToXml(new XElement("Example", 0));
-        }
-		#endregion
-		
-		#region Overrides of Effect
-		protected override string SpecificEffectType => "$safeitemrootname$";
-		
-		public override string Describe(IPerceiver voyeur){
-			return "An undescribed effect of type $fileinputname$.";
-		}
-		
-		public override bool SavingEffect => true;
-		#endregion
-    }
+	public static void InitialiseEffectType()
+	{
+		RegisterFactory("$safeitemrootname$", (effect, owner) => new $safeitemrootname$(effect, owner));
+	}
+
+	public $safeitemrootname$(IPerceivable owner, IFutureProg applicabilityProg = null)
+		: base(owner, applicabilityProg)
+	{
+	}
+
+	protected $safeitemrootname$(XElement effect, IPerceivable owner)
+		: base(effect, owner)
+	{
+		var root = effect.Element("Effect");
+	}
+
+	protected override XElement SaveDefinition()
+	{
+		return new XElement("Effect",
+			new XElement("ApplicabilityProg", ApplicabilityProg?.Id ?? 0)
+		);
+	}
+
+	protected override string SpecificEffectType => "$safeitemrootname$";
+
+	public override string Describe(IPerceiver voyeur)
+	{
+		return "An undescribed saving effect.";
+	}
+
+	public override bool SavingEffect => true;
 }

--- a/Item Templates/Saving Effect/Effect.vstemplate
+++ b/Item Templates/Saving Effect/Effect.vstemplate
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" Type="Item" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005">
   <TemplateData>
     <Name>Saving Effect</Name>
@@ -6,10 +6,8 @@
     <Icon Package="{FAE04EC1-301F-11d3-BF4B-00C04F79EFBC}" ID="4515" />
     <ProjectType>CSharp</ProjectType>
     <SortOrder>1</SortOrder>
-    <RequiredFrameworkVersion>4.5</RequiredFrameworkVersion>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <DefaultName>EffectType</DefaultName>
-    <AppIdFilter>blend</AppIdFilter>
   </TemplateData>
   <TemplateContent>
     <References>

--- a/Item Templates/Spell Effect/Effect.cs
+++ b/Item Templates/Spell Effect/Effect.cs
@@ -1,26 +1,25 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+#nullable enable
 using System.Xml.Linq;
 using MudSharp.Effects.Interfaces;
 using MudSharp.Framework;
 using MudSharp.FutureProg;
 
 namespace MudSharp.Effects.Concrete.SpellEffects;
-	public class $safefilerootname$ : MagicSpellEffectBase
+
+public class Spell$safeitemrootname$Effect : MagicSpellEffectBase
+{
+	public static void InitialiseEffectType()
 	{
-	public static void InitialiseEffectType() {
-		RegisterFactory("$safeitemrootname$SpellEffect", (effect, owner) => new $safefilerootname$(effect, owner));
+		RegisterFactory("Spell$safeitemrootname$", (effect, owner) => new Spell$safeitemrootname$Effect(effect, owner));
 	}
 
-#region Constructors and Saving
-	public $safefilerootname$(IPerceivable owner, IMagicSpellEffectParent parent, IFutureProg prog) : base(owner, parent, prog)
+	public Spell$safeitemrootname$Effect(IPerceivable owner, IMagicSpellEffectParent parent, IFutureProg prog)
+		: base(owner, parent, prog)
 	{
 	}
 
-	protected $safefilerootname$(XElement root, IPerceivable owner) : base(root, owner)
+	protected Spell$safeitemrootname$Effect(XElement root, IPerceivable owner)
+		: base(root, owner)
 	{
 		var trueRoot = root.Element("Effect");
 	}
@@ -28,16 +27,14 @@ namespace MudSharp.Effects.Concrete.SpellEffects;
 	protected override XElement SaveDefinition()
 	{
 		return new XElement("Effect",
-			new XElement("ApplicabilityProg", ApplicabilityProg?.Id ?? 0),
-			// Other XElements
+			new XElement("ApplicabilityProg", ApplicabilityProg?.Id ?? 0)
 		);
 	}
-#endregion
 
 	public override string Describe(IPerceiver voyeur)
 	{
-		return $"$safeitemrootname$SpellEffect";
+		return "A spell effect.";
 	}
 
-	protected override string SpecificEffectType => "$safeitemrootname$SpellEffect";
+	protected override string SpecificEffectType => "Spell$safeitemrootname$";
 }

--- a/Item Templates/Spell Effect/SpellEffect.cs
+++ b/Item Templates/Spell Effect/SpellEffect.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+#nullable enable
 using System.Xml.Linq;
 using MudSharp.Character;
 using MudSharp.Effects.Concrete.SpellEffects;
@@ -12,73 +8,65 @@ using MudSharp.RPG.Checks;
 
 namespace MudSharp.Magic.SpellEffects;
 
-public class $safeitemrootname$ : IMagicSpellEffectTemplate
+public class $safeitemrootname$Effect : IMagicSpellEffectTemplate
 {
-	public IFuturemud Gameworld => Spell.Gameworld;
 	public static void RegisterFactory()
 	{
-		SpellEffectFactory.RegisterLoadTimeFactory("$safeitemrootname$".ToLowerInvariant(), (root, spell) => new $safeitemrootname$(root, spell));
-		SpellEffectFactory.RegisterBuilderFactory("$safeitemrootname$".ToLowerInvariant(), BuilderFactory);
+		SpellEffectFactory.RegisterLoadTimeFactory("$safeitemrootname$".ToLowerInvariant(),
+			(root, spell) => new $safeitemrootname$Effect(root, spell));
+		SpellEffectFactory.RegisterBuilderFactory("$safeitemrootname$".ToLowerInvariant(), BuilderFactory,
+			"Describe this spell effect.",
+			HelpText,
+			false,
+			true,
+			SpellTriggerFactory.MagicTriggerTypes);
 	}
-	
+
 	private static (IMagicSpellEffectTemplate Trigger, string Error) BuilderFactory(StringStack commands,
 		IMagicSpell spell)
 	{
-		return (new GlowEffect(new XElement("Effect",
-			new XAttribute("type", "$safeitemrootname$".ToLowerInvariant())
-			), spell), string.Empty);
+		return (new $safeitemrootname$Effect(
+			new XElement("Effect", new XAttribute("type", "$safeitemrootname$".ToLowerInvariant())),
+			spell), string.Empty);
+	}
+
+	public $safeitemrootname$Effect(XElement root, IMagicSpell spell)
+	{
+		Spell = spell;
+		// Load template configuration from XML here.
 	}
 
 	public IMagicSpell Spell { get; }
+	public IFuturemud Gameworld => Spell.Gameworld;
 	public bool IsInstantaneous => false;
 	public bool RequiresTarget => true;
-
-#region Constructors and Saving
-
-	public $safeitemrootname$(XElement root, IMagicSpell spell)
-	{
-		Spell = spell;
-		// Load all the different properties
-	}
 
 	public XElement SaveToXml()
 	{
 		return new XElement("Effect",
-			new XAttribute("type", "$safeitemrootname$")
-			// Further xattributes
+			new XAttribute("type", "$safeitemrootname$".ToLowerInvariant())
 		);
 	}
 
 	public IMagicSpellEffectTemplate Clone()
 	{
-		return new $safeitemrootname$(SaveToXml(), Spell);
+		return new $safeitemrootname$Effect(SaveToXml(), Spell);
 	}
-#endregion
 
 	public IMagicSpellEffect GetOrApplyEffect(ICharacter caster, IPerceivable target, OpposedOutcomeDegree outcome,
-			SpellPower power, IMagicSpellEffectParent parent)
+		SpellPower power, IMagicSpellEffectParent parent, SpellAdditionalParameter[] additionalParameters)
 	{
-		// Return null if no spell effect
-
-		// Remove or change if target is not character
-		if (target is not ICharacter)
-		{
-			return null;
-		}
-
-		return new $safeitemrootname$(target, parent, null);
+		return new Spell$safeitemrootname$Effect(target, parent, null);
 	}
 
-#region Building Commands
 	public string Show(ICharacter actor)
 	{
-		// A one-line description of the spell effect
-		return $"$safeitemrootname$";
+		return "$safeitemrootname$Effect";
 	}
 
-	public const string HelpText = @"You can use the following options with this spell effect:
+	public const string HelpText = @"You can use the following options with this effect:
 
-	#3command info#0 - explanation";
+	#3command info#0 - explain what this option should do";
 
 	public bool BuildingCommand(ICharacter actor, StringStack command)
 	{
@@ -89,5 +77,4 @@ public class $safeitemrootname$ : IMagicSpellEffectTemplate
 				return false;
 		}
 	}
-#endregion
 }

--- a/Item Templates/Spell Effect/SpellEffect.vstemplate
+++ b/Item Templates/Spell Effect/SpellEffect.vstemplate
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <VSTemplate Version="3.0.0" Type="Item" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005">
   <TemplateData>
     <Name>Spell Effect Type</Name>
@@ -8,7 +8,6 @@
     <SortOrder>2</SortOrder>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <DefaultName>SpellEffect</DefaultName>
-    <AppIdFilter>blend</AppIdFilter>
   </TemplateData>
   <TemplateContent>
     <References>
@@ -17,7 +16,7 @@
       </Reference>
     </References>
 
-    <ProjectItem ReplaceParameters="true" TargetFileName="Magic\SpellEffects\$fileinputname$Effect.cs">SpellEffect.cs</ProjectItem>
-    <ProjectItem ReplaceParameters="true" TargetFileName="Effects\Concrete\SpellEffects\Spell$fileinputname$Effect.cs">Effect.cs</ProjectItem>
+    <ProjectItem ReplaceParameters="true" TargetFileName="Magic\SpellEffects\$safeitemrootname$Effect.cs">SpellEffect.cs</ProjectItem>
+    <ProjectItem ReplaceParameters="true" TargetFileName="Effects\Concrete\SpellEffects\Spell$safeitemrootname$Effect.cs">Effect.cs</ProjectItem>
   </TemplateContent>
 </VSTemplate>


### PR DESCRIPTION
## Summary
- add a new item system documentation set covering runtime model, component authoring, content workflows, and presentation/integration
- link the new item docs from `AGENTS.md` as the primary item-system reference
- repair the `Item Templates` scaffolds for game item components, spell effects, FutureProg functions, and saving/non-saving effects
- remove stale template metadata and align generated code with current FutureMUD patterns

## Testing
- Not run (not requested)