### PR TITLE
Expand celestial seeder packages and document the celestial system

### DIFF
--- a/Design Documents/Celestial_System_Overview.md
+++ b/Design Documents/Celestial_System_Overview.md
@@ -1,0 +1,222 @@
+# FutureMUD Celestial System Overview
+
+## Purpose
+The celestial system answers a specific world-simulation question: "what is in the sky from here, right now?"
+
+In FutureMUD, celestial objects are not just lore labels. They are runtime objects that:
+
+- convert a shard and zone's geography into apparent sky position
+- expose elevation and azimuth for a specific observer latitude and longitude
+- contribute illumination to zone light levels
+- emit movement and threshold triggers as time advances
+- provide player-facing descriptions for commands like `time`
+- give weather and seasonal systems a consistent astronomical reference
+
+The core design goal is geography-first sky positioning. A sun, moon, or planet is only meaningful in play once the engine can answer where it appears relative to a particular zone's `GeographicCoordinate`.
+
+## Document Map
+- [Celestial System Seeder](./Celestial_System_Seeder.md) explains the supported stock authoring path in `DatabaseSeeder`.
+- [Celestial System Tests](./Celestial_System_Tests.md) explains the automated coverage split and current gaps.
+- [Celestial Type: OldSun](./Celestial_Type_OldSun.md) documents the legacy solar implementation that is still loadable for existing worlds.
+- [Celestial Type: Sun](./Celestial_Type_Sun.md) documents the current `NewSun` implementation and `SunV2` seeder format.
+- [Celestial Type: PlanetaryMoon](./Celestial_Type_PlanetaryMoon.md) documents moons viewed from the parent planet.
+- [Celestial Type: PlanetFromMoon](./Celestial_Type_PlanetFromMoon.md) documents parent planets viewed from a moon.
+- [Celestial Type: SunFromPlanetaryMoon](./Celestial_Type_SunFromPlanetaryMoon.md) documents the moon-local representation of a linked root sun.
+
+## Core Runtime Shape
+At the interface level, a celestial is anything implementing `ICelestialObject`. The important outputs are:
+
+- `CurrentElevationAngle(GeographicCoordinate geography)`
+- `CurrentAzimuthAngle(GeographicCoordinate geography, double elevationAngle)`
+- `CurrentIllumination(GeographicCoordinate geography)`
+- `CurrentPosition(GeographicCoordinate geography)`
+- `CurrentTimeOfDay(GeographicCoordinate geography)`
+- `MinuteUpdateEvent`
+
+`CelestialInformation` is the cached per-location result. It stores:
+
+- the originating celestial
+- the last azimuth angle
+- the last ascension angle, which is effectively the local elevation/altitude angle in this subsystem's naming
+- the movement direction, ascending or descending
+
+That cached object is what rooms, zones, and player-facing commands actually consume most of the time.
+
+## Shards, Zones, Cells, and Viewers
+The ownership and application model is:
+
+| Layer | Responsibility |
+| --- | --- |
+| `Shard` | Chooses which celestial objects exist for that world-space body or plane |
+| `Zone` | Applies geography, timezone, and weather context to the shard's celestials |
+| `Cell` / room | Exposes zone and shard celestial data to gameplay surfaces |
+| Viewer | Sees descriptions and time-of-day consequences derived from the zone cache |
+
+The important relationship boundaries are:
+
+- Shards own the celestial list through `ShardsCelestials`.
+- `Zone.Celestials` delegates to `Shard.Celestials`.
+- Zones apply `GeographicCoordinate` values such as latitude, longitude, elevation, and the shard radius.
+- Cells and locations surface that zone-specific data to players and systems.
+
+This means a shard decides which sky objects exist, while a zone decides how they appear from a particular place.
+
+## Celestial Flow Through the Runtime
+The main runtime flow is:
+
+1. A shard is assigned one or more celestial objects.
+2. Each zone in that shard calls `InitialiseCelestials()`.
+3. The zone subscribes to every celestial's `MinuteUpdateEvent`.
+4. The zone computes an initial `CelestialInformation` entry for each celestial at the zone's geography.
+5. The zone computes a per-celestial illumination contribution and stores it in `LightLevelDictionary`.
+6. The zone recalculates total light level from celestial illumination plus ambient light pollution and other zone context.
+7. As clocks advance, celestial objects raise minute updates.
+8. The zone refreshes cached `CelestialInformation`, refreshes illumination, and recalculates light again.
+
+Because zones cache this data, sky queries during normal gameplay are cheap. The expensive orbital math happens when time changes or when a system explicitly recomputes.
+
+## Celestial Information and Light
+Celestials do more than provide descriptive text. Their illumination feeds directly into zone lighting and therefore into:
+
+- ambient visibility
+- `DescribeSky`
+- room and outdoor presentation
+- weather and season heuristics that care about day versus night
+- player perception of dawn, dusk, sunrise, moonrise, and similar transitions
+
+The zone owns the current light level because illumination is geography-dependent. The same shard celestial can therefore produce different apparent conditions in two zones on the same shard at the same moment.
+
+## One Physical Body, Multiple Game Representations
+A single physical astronomical object may have multiple game representations.
+
+This is intentional and central to the subsystem.
+
+Examples:
+
+- A root `Sun` represents a star from the point of view of a planetary surface.
+- `SunFromPlanetaryMoon` represents that same star from the point of view of an observer standing on a moon.
+- `PlanetaryMoon` represents the moon from a planet observer's sky.
+- `PlanetFromMoon` represents the parent planet from the moon observer's sky.
+
+These are not duplicate astrophysical bodies. They are alternate observer-frame representations that let the engine answer different local-sky questions without forcing every celestial type into one giant generic model.
+
+This matters when seeding and testing:
+
+- linked representations must stay synchronized
+- authoring one representation does not automatically make another visible on a shard
+- weather and season systems should bind to the representation that matches the intended world frame
+
+## Link Between Celestials and Shards
+Builders attach celestials to shards with:
+
+- `shard set <shard> celestials <celestial1> ... [<celestialn>]`
+
+That command controls which celestial objects a shard exposes. When the shard's celestial list changes:
+
+- existing zones deregister old celestial subscriptions
+- the shard's editable celestial list is replaced
+- zones reinitialise their celestial caches
+
+This is the point where seeded celestial definitions become live world-space content.
+
+## Link Between Celestials and Zones
+Zones do not own independent celestial lists. They inherit from the shard and then provide the context that makes the shard's celestials meaningful:
+
+- latitude
+- longitude
+- elevation
+- shard spherical radius
+- timezone per clock
+- ambient light pollution
+- weather controller assignment
+
+The main builder workflow is:
+
+- create or edit the shard and assign celestials
+- create or edit zones in that shard
+- set zone latitude, longitude, elevation, and timezones
+- attach a weather controller if the zone needs one
+
+Useful commands include:
+
+- `zone set <which> latitude <degrees>`
+- `zone set <which> longitude <degrees>`
+- `zone set <which> elevation <amount>`
+- `zone set <which> timezone <clock> <tz>`
+- `zone set <which> weather <wc>`
+
+Without zone geography, a celestial can still exist in the database, but it cannot produce meaningful sky positions for gameplay.
+
+## Interaction With Weather Controllers
+Weather controllers use a celestial as their astronomical anchor.
+
+The main builder command is:
+
+- `wc set celestial <which>`
+
+That celestial provides the runtime concept of day versus night for the controller. The controller also keeps a `GeographyForTimeOfDay`, so weather logic can ask the chosen celestial for `CurrentTimeOfDay(...)` using an explicit geography rather than an arbitrary room.
+
+This is why picking the correct representation matters:
+
+- a planetary weather controller should usually bind to a root `Sun`
+- a moon-based climate or analysis context may need the moon-local representation instead
+
+## Interaction With Seasons
+Seasons also bind to a celestial:
+
+- `season set celestial <id|name>`
+
+That binding tells the seasonal logic which sky object defines the relevant astronomical cycle for the season record. In ordinary Earth-like worlds this is typically the planetary `Sun`, but the system is flexible enough to support other contexts.
+
+## Player-Facing Interaction
+The player-facing `time` command pulls the current location's celestial list and cached celestial information. It reports:
+
+- the current time of day
+- visible celestial descriptions
+- time and date information from visible calendars and clocks
+
+In practice this means celestial objects affect what players are told about the world every day, not just admin tooling.
+
+## Implementor and Analysis Tooling
+The celestial system also has explicit implementor/debug surfaces:
+
+- `celestials` runs a long-form celestial analysis/debug pass
+- weather analysis tools flatten linked celestial graphs so that derived objects are included in simulation context
+
+This is especially important for linked types like `PlanetFromMoon` and `SunFromPlanetaryMoon`, because they depend on root objects and should be treated as part of one connected astronomical graph during analysis.
+
+## Interaction With Other MUD Systems
+The celestial system currently intersects with other systems in the following ways:
+
+| System | Interaction |
+| --- | --- |
+| Shards | Choose which celestials exist in a world-space context |
+| Zones | Apply geography, timezones, and light recalculation |
+| Weather controllers | Use one celestial root to determine time-of-day behavior |
+| Seasons | Bind to a celestial for seasonal progression |
+| Time/date presentation | `time` command reports visible celestial state |
+| Perception and room presentation | Sky descriptions and outdoor echoes depend on celestial cache and visibility |
+| Ambient light | Zone light levels include celestial illumination |
+| Implementor analysis | Debug and weather analysis tools inspect or flatten celestial graphs |
+
+## Builder Workflow Summary
+The usual end-to-end builder workflow is:
+
+1. Seed stock celestial definitions or hand-author custom ones.
+2. Attach the chosen celestials to a shard with `shard set <shard> celestials ...`.
+3. Create or edit zones in that shard.
+4. Configure zone latitude, longitude, elevation, and timezones.
+5. Attach weather controllers to zones and bind controllers to the appropriate celestial.
+6. Bind seasons to the same intended celestial frame.
+7. Use `time` and implementor analysis commands to verify the sky behaves as intended.
+
+## Current Supported Loadable Types
+The current loadable celestial families are:
+
+- `OldSun`, loaded by the legacy `Sun` class
+- `Sun`, loaded by `NewSun`
+- `PlanetaryMoon`
+- `PlanetFromMoon`
+- `SunFromPlanetaryMoon`
+
+The remainder of this documentation suite describes each type in more detail, including property mapping and the exact calculation pipelines used by the runtime.

--- a/Design Documents/Celestial_System_Seeder.md
+++ b/Design Documents/Celestial_System_Seeder.md
@@ -1,0 +1,241 @@
+# FutureMUD Celestial System Seeder
+
+## Purpose
+`DatabaseSeeder/Seeders/CelestialSeeder.cs` is the supported stock authoring path for new celestial content shipped with the engine.
+
+Its job is not to solve every astronomy use case. Its job is to provide coherent, repeatable, linked stock packages that:
+
+- create working celestial definitions
+- keep linked moon-view representations synchronized
+- remain safe to install on reruns
+- give builders a trustworthy starting point before they attach celestials to shards in game
+
+## Package Model
+The current seeder supports three stock packages.
+
+| Package | Purpose | Self-contained | Objects created |
+| --- | --- | --- | --- |
+| `EarthSun` | Earth-facing root sun package | Yes | `Sun` |
+| `EarthMoonView` | Earth moon-view package | No, requires Earth-facing sun | `PlanetaryMoon`, `PlanetFromMoon`, `SunFromPlanetaryMoon` |
+| `GasGiantMoonView` | Ganymede/Jupiter/Sol package | Yes | Jupiter-facing `Sun`, `PlanetaryMoon`, `PlanetFromMoon`, `SunFromPlanetaryMoon` |
+
+The package model is explicit. The seeder no longer relies on incidental side effects to create linked moon-view objects.
+
+## Earth-Facing Sun Package
+The Earth-facing sun package creates the modern `Sun` implementation using the `SunV2` data shape.
+
+The seeder asks for:
+
+- whether to install the Earth-facing sun package
+- the calendar that should feed the celestial
+- the celestial name
+- the epoch date to use for the orbital data
+
+This package is intended for planetary-surface gameplay and is the required root for the Earth moon-view package.
+
+## Earth Moon-View Package
+The Earth moon-view package is a linked package representing the Earth-Moon-Sun relationship from two observer frames.
+
+It creates:
+
+- a `PlanetaryMoon` representing Earth's Moon as seen from Earth
+- a `PlanetFromMoon` representing Earth as seen from the Moon
+- a `SunFromPlanetaryMoon` representing the same physical sun as the root Earth-facing `Sun`, but transformed into the Moon observer's frame
+
+The seeder asks for:
+
+- whether to install the Earth moon-view package
+- the calendar for the moon package
+- the moon name
+- the full moon epoch date
+
+This package is strict about root-sun resolution:
+
+- if the same seeder run just created the Earth-facing `Sun`, that new object is used
+- otherwise the seeder searches for exactly one matching Earth-facing sun candidate already in the database
+- if no candidate exists, installation is blocked
+- if multiple candidates exist, installation is blocked rather than guessed
+
+That strictness exists to keep the linked moon-view objects deterministic.
+
+## Gas Giant Moon Package
+The gas giant package is self-contained and does not depend on the Earth-facing sun package.
+
+It creates:
+
+- a Jupiter-facing root `Sun`
+- a `PlanetaryMoon` named `Ganymede`
+- a `PlanetFromMoon` named `Jupiter`
+- a `SunFromPlanetaryMoon` named `Sol`
+
+The seeder asks for:
+
+- whether to install the gas giant package
+- the calendar for the package
+- the epoch date for the Jupiter-facing sun
+- the epoch date for the Ganymede moon phase reference
+
+This package exists because a sun object in FutureMUD is a surface-observer representation, not a universal "one star for the whole solar system" singleton. Jupiter therefore needs its own root `Sun` data.
+
+## How Calendars, Clocks, and Epochs Are Chosen
+The seeder resolves the selected calendar first. The celestial then uses the selected calendar's `FeedClockId`.
+
+This means:
+
+- the calendar controls the date progression used by the celestial
+- the feed clock controls the time fraction used by orbital math
+- the zone timezone determines how that clock is interpreted locally when gameplay asks a zone for time
+
+Epoch dates are author-supplied seeder answers rather than fixed engine constants. The seeder stores:
+
+- the chosen epoch date as the celestial's `EpochDate`
+- the orbital constants associated with the package
+- the numeric day number at epoch used by the runtime formulae
+
+For the stock packages, the numeric day number at epoch is J2000-based `2451545.0`.
+
+## Package Markers and Repeatability
+The seeder is intentionally safe to run more than once.
+
+Each supported stock definition is marked in its XML with:
+
+- `SeederPackage`
+- `SeederRole`
+
+Those markers let the seeder distinguish:
+
+- package identity
+- object role inside a package
+- new-style seeded packages from older content
+
+Repeatability is not based only on object counts. The seeder also includes legacy compatibility checks, especially for the original Earth-facing sun and Earth moon package, so that older worlds can still be recognized as containing equivalent stock content even if they predate the marker system.
+
+## ShouldSeedData Behavior
+`ShouldSeedData` currently reports one of the normal seeder states.
+
+For celestial content the important outcomes are:
+
+| Result | Meaning |
+| --- | --- |
+| `ReadyToInstall` | None of the supported stock packages are present |
+| `ExtraPackagesAvailable` | Some, but not all, supported stock packages are present |
+| `MayAlreadyBeInstalled` | All supported stock packages are present |
+
+This allows the seeder to behave additively over time as new stock celestial packages are introduced.
+
+## Builder Implications
+The seeder only creates celestial definitions in the database. It does not attach them to a shard automatically.
+
+After seeding, builders still need to:
+
+1. attach the created celestial objects to a shard with `shard set <shard> celestials ...`
+2. configure zones in that shard with the right geography and timezones
+3. bind weather controllers with `wc set celestial <which>`
+4. bind seasons with `season set celestial <id|name>`
+
+Important package implications:
+
+- the Earth moon package depends on a matching Earth-facing root sun
+- the gas giant package includes its own root sun and is self-contained
+- `PlanetFromMoon` and `SunFromPlanetaryMoon` are linked representations and should remain on the same shard as their companion root objects unless a custom world design deliberately wants otherwise
+
+## Stock Data Reference
+The following table records the stock constants that ship today.
+
+### Earth-facing Sun
+
+| Field | Value |
+| --- | --- |
+| `CelestialDaysPerYear` | `365.24` |
+| `MeanAnomalyAngleAtEpoch` | `6.24006` |
+| `AnomalyChangeAnglePerDay` | `0.017202` |
+| `EclipticLongitude` | `1.796595` |
+| `EquatorialObliquity` | `0.409093` |
+| `DayNumberAtEpoch` | `2451545.0` |
+| `SiderealTimeAtEpoch` | `4.889488` |
+| `SiderealTimePerDay` | `6.300388` |
+| `PeakIllumination` | `98000.0` |
+| `AlphaScatteringConstant` | `0.05` |
+| `BetaScatteringConstant` | `0.035` |
+| `PlanetaryRadius` | `6378.0` |
+| `AtmosphericDensityScalingFactor` | `6.35` |
+
+### Earth Moon Package
+
+| Object | Field | Value |
+| --- | --- | --- |
+| `PlanetaryMoon` | `CelestialDaysPerYear` | `29.530588` |
+| `PlanetaryMoon` | `MeanAnomalyAngleAtEpoch` | `2.355556` |
+| `PlanetaryMoon` | `AnomalyChangeAnglePerDay` | `0.228027` |
+| `PlanetaryMoon` | `ArgumentOfPeriapsis` | `5.552765` |
+| `PlanetaryMoon` | `LongitudeOfAscendingNode` | `2.18244` |
+| `PlanetaryMoon` | `OrbitalInclination` | `0.0898` |
+| `PlanetaryMoon` | `OrbitalEccentricity` | `0.0549` |
+| `PlanetaryMoon` | `DayNumberAtEpoch` | `2451545.0` |
+| `PlanetaryMoon` | `SiderealTimeAtEpoch` | `4.889488` |
+| `PlanetaryMoon` | `SiderealTimePerDay` | `0.228027` |
+| `PlanetaryMoon` | `FullMoonReferenceDay` | `0.0` |
+| `PlanetFromMoon` | `AngularRadius` | `0.0165` |
+
+The Earth `PlanetFromMoon` is named `Earth`, and its linked `SunFromPlanetaryMoon` uses the linked root sun's actual name rather than a hard-coded label.
+
+### Gas Giant Moon Package
+
+| Object | Field | Value |
+| --- | --- | --- |
+| Jupiter-facing `Sun` | `CelestialDaysPerYear` | `10475.8818867393` |
+| Jupiter-facing `Sun` | `MeanAnomalyAngleAtEpoch` | `0.343270671018783` |
+| Jupiter-facing `Sun` | `AnomalyChangeAnglePerDay` | `0.000599776264672575` |
+| Jupiter-facing `Sun` | `EclipticLongitude` | `0.257060466847075` |
+| Jupiter-facing `Sun` | `EquatorialObliquity` | `0.0546288055874225` |
+| Jupiter-facing `Sun` | `DayNumberAtEpoch` | `2451545.0` |
+| Jupiter-facing `Sun` | `SiderealTimeAtEpoch` | `4.97331570355784` |
+| Jupiter-facing `Sun` | `SiderealTimePerDay` | `6.28378508344426` |
+| Jupiter-facing `Sun` | `KepplerC1Approximant` | `0.0967569879178372` |
+| Jupiter-facing `Sun` | `KepplerC2Approximant` | `0.0029273119273445` |
+| Jupiter-facing `Sun` | `KepplerC3Approximant` | `0.000122772356038737` |
+| Jupiter-facing `Sun` | `PeakIllumination` | `3619.8` |
+| Jupiter-facing `Sun` | `PlanetaryRadius` | `69911.0` |
+| `PlanetaryMoon` (`Ganymede`) | `CelestialDaysPerYear` | `7.16683557838692` |
+| `PlanetaryMoon` (`Ganymede`) | `MeanAnomalyAngleAtEpoch` | `0.82944303060139` |
+| `PlanetaryMoon` (`Ganymede`) | `AnomalyChangeAnglePerDay` | `0.878153082764442` |
+| `PlanetaryMoon` (`Ganymede`) | `ArgumentOfPeriapsis` | `4.87986552021969` |
+| `PlanetaryMoon` (`Ganymede`) | `LongitudeOfAscendingNode` | `5.96372010319795` |
+| `PlanetaryMoon` (`Ganymede`) | `OrbitalInclination` | `0.0355727108921961` |
+| `PlanetaryMoon` (`Ganymede`) | `OrbitalEccentricity` | `0.00158762974782861` |
+| `PlanetaryMoon` (`Ganymede`) | `DayNumberAtEpoch` | `2451545.0` |
+| `PlanetaryMoon` (`Ganymede`) | `SiderealTimeAtEpoch` | `4.889488` |
+| `PlanetaryMoon` (`Ganymede`) | `SiderealTimePerDay` | `0.878153082764442` |
+| `PlanetaryMoon` (`Ganymede`) | `FullMoonReferenceDay` | `0.0` |
+| `PlanetFromMoon` (`Jupiter`) | `AngularRadius` | `0.0653594916439514` |
+
+The gas giant package names the moon-local solar representation `Sol`.
+
+## Linked Object IDs
+The seeder creates linked celestial packages deterministically:
+
+- `PlanetFromMoon` stores the ID of its source `PlanetaryMoon`
+- `PlanetFromMoon` also stores the ID of its linked root `Sun`
+- `SunFromPlanetaryMoon` stores both the source moon ID and the linked root sun ID
+
+This keeps the package coherent even across reruns or later shard assignment.
+
+## Implementation Notes for Future Seeder Additions
+When adding a new stock celestial package, keep the following rules:
+
+1. Decide whether the package is self-contained or depends on an existing root celestial.
+2. Mark every seeded object with a package name and a role.
+3. Store linked object IDs explicitly in the derived object definitions.
+4. Reuse illumination from the root `Sun` when creating `SunFromPlanetaryMoon` unless there is a deliberate reason not to.
+5. Add `ShouldSeedData` detection for both new-style markers and any legacy equivalent package you still want to recognize.
+6. Add seeder tests for creation, repeatability, and any package dependency failure path.
+7. Document the package here when the stock data ships.
+
+## Builder Checklist After Seeding
+After running the seeder, verify the package in game:
+
+1. list the created celestial objects and confirm the expected names exist
+2. attach them to the target shard with `shard set <shard> celestials ...`
+3. configure zone latitude, longitude, elevation, and timezone
+4. bind weather controllers and seasons to the correct root celestial
+5. use `time` and implementor analysis to confirm the sky descriptions match the intended world frame

--- a/Design Documents/Celestial_System_Tests.md
+++ b/Design Documents/Celestial_System_Tests.md
@@ -1,0 +1,185 @@
+# FutureMUD Celestial System Tests
+
+## Purpose
+This document explains the current automated coverage for the celestial subsystem and where that coverage lives.
+
+The celestial system has two main kinds of tests:
+
+- runtime tests in `MudSharpCore Unit Tests`
+- seeder tests in `DatabaseSeeder Unit Tests`
+
+Both matter. Celestial work is usually a combination of numeric orbital math and linked content authoring, and those two concerns fail in different ways.
+
+## Current Coverage Split
+
+| Test project | Scope |
+| --- | --- |
+| `MudSharpCore Unit Tests` | Runtime celestial math, visibility behavior, phase behavior, time-of-day logic, trigger behavior, and non-24x60 clock support |
+| `DatabaseSeeder Unit Tests` | Stock package creation, linkage correctness, dependency rules, and repeatability state |
+
+## Runtime Coverage
+The runtime celestial tests are currently concentrated in four files.
+
+### `CelestialTests.cs`
+This suite covers the current `Sun` implementation, which is the `NewSun` runtime class.
+
+The suite verifies:
+
+- orbital math regression for the modern solar implementation
+- mean anomaly continuity across fractional day progression
+- support for `CurrentDayNumberOffset`
+- direction sampling using actual clock length instead of a hard-coded `1440`
+- trigger selection behavior
+
+These tests are the numeric safety net for changes to `NewSun`.
+
+### `PlanetaryMoonTests.cs`
+This suite covers the moon viewed from a parent planet.
+
+The suite verifies:
+
+- phase cycle classification
+- illumination behavior at key points such as full and new moon
+- trigger selection behavior
+- direction sampling using actual clock length
+
+These tests protect the phase math, the local sky transform, and the recent clock-length fix.
+
+### `PlanetFromMoonTests.cs`
+This suite covers the parent planet viewed from the moon.
+
+The suite verifies:
+
+- right-ascension and declination opposition relative to the linked moon
+- illumination complement relative to the moon phase
+- eclipse detection against the linked root sun
+- tidally locked behavior assumptions
+- direction sampling using actual clock length
+
+These tests are especially important because `PlanetFromMoon` is mostly derived behavior rather than standalone orbital data.
+
+### `SunFromPlanetaryMoonTests.cs`
+This suite covers the moon-local sun representation.
+
+The suite verifies:
+
+- altitude changes over time
+- time-of-day classification
+- direction sampling using actual clock length
+
+These tests protect the linked-object transformation from root solar coordinates into a moon-local sky frame.
+
+## Seeder Coverage
+The seeder coverage currently lives in `DatabaseSeeder Unit Tests/CelestialSeederTests.cs`.
+
+That suite verifies:
+
+- Earth moon package creation creates all three linked objects
+- Earth moon package blocks when no suitable Earth-facing sun exists
+- gas giant moon package is self-contained and creates all expected linked objects
+- `ShouldSeedData` reports partial-package installations as `ExtraPackagesAvailable`
+
+These tests are the protection against broken stock content, broken linked IDs, and regressions in rerun behavior.
+
+## What the Current Suite Proves
+The current test suite gives a reasonable level of confidence in five areas.
+
+| Area | What is currently proven |
+| --- | --- |
+| `NewSun` orbital math | The modern solar pipeline still produces expected numeric behavior |
+| Moon phase and illumination | `PlanetaryMoon` phase and light output remain consistent |
+| Parent-planet inversion | `PlanetFromMoon` remains the inverted representation of the linked moon |
+| Moon-local solar frame | `SunFromPlanetaryMoon` stays synchronized with the linked root sun and moon timing |
+| Seeder package coherence | Stock celestial packages remain linked, repeatable, and dependency-aware |
+
+## Known Gaps
+The current gaps should be treated as real documentation of current state, not as implied future commitments.
+
+### `OldSun` gap
+No dedicated unit-test suite was found for the legacy `OldSun` implementation.
+
+That means:
+
+- the legacy type is documented and still loadable
+- its current behavior is mostly protected by runtime stability and manual compatibility, not by a comparable modern numeric regression suite
+
+Any change to `OldSun` should therefore be treated conservatively.
+
+### Zone and cache integration gap
+There is not currently a dedicated focused unit-test suite for:
+
+- zone celestial cache initialization
+- zone light recalculation across minute updates
+- shard-to-zone celestial reassignment behavior
+
+Those behaviors are exercised by runtime use, but not isolated by a dedicated celestial integration suite.
+
+### Command-surface gap
+The player and builder command surfaces that consume celestial data are not primarily tested in the celestial suites.
+
+Examples:
+
+- `time`
+- `shard set <shard> celestials ...`
+- `wc set celestial ...`
+- `season set celestial ...`
+
+Those commands are important integration points, but the core celestial tests do not attempt to prove command text or builder workflow behavior end to end.
+
+## When to Add Numeric Regression Coverage
+Add or expand runtime numeric tests when a change touches:
+
+- any orbital equation
+- any angle normalization rule
+- phase or illumination formulas
+- time-of-day classification thresholds
+- coordinate transforms between equatorial and local sky frames
+- `CurrentDayNumber`, `CurrentCelestialDay`, or sidereal timing rules
+- linked-object behavior where one celestial derives from another
+
+As a rule, if a code change alters how a celestial computes an angle or illumination value, it should come with at least one deterministic numeric regression test.
+
+## When Seeder Changes Need Tests
+Add or expand seeder tests when a change touches:
+
+- package detection
+- linked object creation
+- package dependency rules
+- package markers
+- stock constants
+- rerun behavior
+- legacy compatibility detection
+
+Seeder changes are especially prone to silent regressions because they often operate on XML authoring rules rather than runtime behavior. Tests should therefore assert actual generated definitions and link relationships.
+
+## When Non-24x60 Clock Scenarios Must Be Tested
+FutureMUD supports clocks that are not exactly 24 hours by 60 minutes.
+
+Whenever a change touches:
+
+- minute sampling for direction detection
+- day fractions
+- current-time calculations
+- celestial motion logic that implicitly assumes a fixed day length
+
+you should add or update non-24x60 clock coverage.
+
+The recent direction-sampling fix is a good example: it needed explicit tests because a hidden `1 / 1440` assumption would otherwise look correct on ordinary Earth-like clocks while still being wrong for custom worlds.
+
+## Recommended Test Strategy for Future Celestial Types
+For any new celestial type, aim to add three layers of coverage:
+
+1. numeric runtime tests for the local sky calculation pipeline
+2. linkage tests if the type depends on other celestial objects
+3. seeder tests if the type ships as stock content
+
+If the type can drive time-of-day or illumination, add those tests too.
+
+## Practical Verification Guidance
+For day-to-day development:
+
+- run the relevant targeted `MudSharpCore Unit Tests` when changing runtime celestial code
+- run `DatabaseSeeder Unit Tests` when changing seeder packages or authoring rules
+- use implementor celestial analysis or weather analysis when you need broader integration sanity checking
+
+The test suite is strongest when changes are small and covered close to the formulas they affect.

--- a/Design Documents/Celestial_Type_OldSun.md
+++ b/Design Documents/Celestial_Type_OldSun.md
@@ -1,0 +1,157 @@
+# Celestial Type: OldSun
+
+## Status
+`OldSun` is a legacy implementation.
+
+It is still loadable and supported for compatibility with existing worlds, but it is not the modern stock default. New seeded content should use the current `Sun` implementation documented in [Celestial Type: Sun](./Celestial_Type_Sun.md).
+
+## Concept and Real-World Analogy
+`OldSun` represents a star viewed from the surface of a rotating planet.
+
+The closest Earth analogue is "the Sun as seen from Earth," but the implementation is older and more approximation-driven than the modern `NewSun` class. Rather than building the local sky position from a more explicit ephemeris-style chain of mean anomaly, true anomaly, ecliptic longitude, right ascension, and declination, `OldSun` uses an analemma-oriented approximation and minute-based yearly progression.
+
+This makes it useful for legacy content, but less convenient for builders who want to map fields directly from modern astronomy tables.
+
+## Data Model and Properties
+The persisted XML shape is centered on three main sections:
+
+- `Configuration`
+- `Illumination`
+- `Orbital`
+
+### Configuration properties
+
+| Property | Meaning |
+| --- | --- |
+| `MinutesPerDay` | Number of clock minutes in one local day |
+| `MinutesPerYear` | Number of clock minutes in one local year |
+| `MinutesPerYearFraction` | Fractional-minute correction used for year drift handling |
+| `OrbitalDaysPerYear` | Number of orbital day units in a year |
+| `YearsBetweenFractionBumps` | Interval for applying the fractional-year correction |
+
+### Illumination properties
+
+| Property | Meaning |
+| --- | --- |
+| `PeakIllumination` | Peak direct illumination when the sun is effectively overhead |
+| `AlphaScatteringConstant` | Atmospheric attenuation coefficient for direct light |
+| `BetaScatteringConstant` | Atmospheric attenuation coefficient for scattered light |
+| `PlanetaryRadius` | Planet radius used by the light-scattering model |
+| `AtmosphericDensityScalingFactor` | Effective atmosphere depth term used by the light model |
+
+### Orbital properties
+
+| Property | Meaning |
+| --- | --- |
+| `OrbitalEccentricity` | Eccentricity of the orbit |
+| `OrbitalInclination` | Axial tilt relative to the orbital plane in the old model's terminology |
+| `OrbitalRotationPerDay` | Planet rotation per day in radians |
+| `AltitudeOfSolarDisc` | Apparent solar disc altitude adjustment used by legacy logic |
+| `DayNumberOfVernalEquinox` | Day number reference used by the analemma Y-axis calculation |
+| `DayNumberStaticOffsetAxial` | Static phase offset for the axial component |
+| `DayNumberStaticOffsetElliptical` | Static phase offset for the elliptical component |
+
+## Mapping to Real Astronomical Data
+`OldSun` is harder to author directly from modern almanacs than `NewSun`.
+
+Builders can still approximate the values from real data:
+
+- `OrbitalEccentricity` maps directly to standard orbital eccentricity.
+- `OrbitalInclination` is used as the effective obliquity or axial tilt term in the model.
+- `OrbitalRotationPerDay` should be the planet's rotation in radians per solar day.
+- `MinutesPerDay` and `MinutesPerYear` should match the in-game clock and calendar model, not necessarily a real civil clock.
+- `DayNumberOfVernalEquinox`, `DayNumberStaticOffsetAxial`, and `DayNumberStaticOffsetElliptical` are calibration values rather than standard published ephemeris fields.
+
+For Earth-like content, these phase-offset fields were historically tuned to make the apparent yearly solar motion look correct in game rather than copied from a modern astronomical ephemeris.
+
+## Calculation Pipeline
+The legacy solar pipeline is built around minute counters and correction terms.
+
+### 1. Convert minutes into a day number
+`CalculateDayNumber(minutes)` returns:
+
+`1.0 + minutes / MinutesPerDay`
+
+This day number is then used as the phase input for the yearly approximation functions.
+
+### 2. Compute elliptical correction
+The old model computes:
+
+- `lambda = 2*pi / OrbitalDaysPerYear * wrapped(day + DayNumberStaticOffsetElliptical)`
+- `sigma = lambda + 2*e*sin(lambda)`
+
+The elliptical noon correction is:
+
+`(lambda - sigma) * (MinutesPerDay / OrbitalRotationPerDay)`
+
+This is the old model's correction for orbital eccentricity.
+
+### 3. Compute axial tilt correction
+The model computes an axial phase term `E` and then applies:
+
+`(E - atan(sin(E) * cos(OrbitalInclination) / cos(E))) * (MinutesPerDay / OrbitalRotationPerDay)`
+
+This is the old model's correction for the planet's axial tilt.
+
+### 4. Combine noon error
+`CalculateNoonError()` is the sum of the elliptical and axial corrections.
+
+### 5. Compute local hour angle
+The model computes a local time fraction from:
+
+- current minute of day
+- local longitude
+
+and converts it to a local hour angle.
+
+### 6. Compute analemma Y axis
+The model computes:
+
+`asin(sin(sigma(day) - sigma(vernalEquinoxDay)) * sin(OrbitalInclination))`
+
+This is the effective solar declination term in the old model.
+
+### 7. Compute elevation angle
+The current elevation uses the local hour angle, the analemma Y-axis term, zone latitude, and an elevation-above-sea-level correction.
+
+### 8. Compute azimuth angle
+Azimuth is derived from the same local hour angle and analemma Y-axis value, with the sign branch depending on whether the hour angle is east or west of noon.
+
+### 9. Compute illumination
+`OldSun` uses the same general illumination family as the modern solar implementations:
+
+- `U`
+- `L`
+- `H`
+- `RhoH`
+- `E1`
+- `E2`
+
+The direct and scattered light components are summed to produce current illumination.
+
+### 10. Determine movement direction and time of day
+Movement direction is determined by comparing the current elevation to the value one minute earlier.
+
+Time of day is then inferred from:
+
+- elevation sign
+- disc altitude threshold
+- whether the object is currently ascending or descending
+
+## Seeder and Testing Considerations
+`OldSun` is not the modern seeded default.
+
+That means:
+
+- new stock seeder content should not target this type
+- custom worlds that still use it should treat it as legacy-supported
+- changes to `OldSun` should be conservative because there is no dedicated modern numeric regression suite comparable to `NewSun`
+
+If you must seed or hand-author one for a legacy world, prefer copying from a known-good existing definition and adjusting only a small number of parameters.
+
+## Known Caveats and Implementation Notes
+- `OldSun` is minute-driven rather than explicitly calendar-date-and-time-fraction driven in the same way as `NewSun`.
+- Several fields are calibration offsets rather than straightforward almanac values.
+- The type is still useful for backwards compatibility, but it is not the easiest type for new builder-facing authoring.
+- Illumination uses the same broad scattering model family as the newer solar types, so light-level behavior is more modern-looking than the orbital approximation beneath it.
+- If you are deciding between `OldSun` and `Sun` for new work, choose `Sun` unless you explicitly need legacy behavior.

--- a/Design Documents/Celestial_Type_PlanetFromMoon.md
+++ b/Design Documents/Celestial_Type_PlanetFromMoon.md
@@ -1,0 +1,162 @@
+# Celestial Type: PlanetFromMoon
+
+## Concept and Real-World Analogy
+`PlanetFromMoon` represents the parent planet as seen from the surface of one of its moons.
+
+The Earth-system example is Earth as seen from the Moon. The gas giant stock package uses the same type for Jupiter as seen from Ganymede.
+
+This is not an independent orbit solver. It is a derived representation built from:
+
+- a linked `PlanetaryMoon`
+- a linked root `Sun`
+
+It exists because the parent planet and the moon are two sides of the same observer-frame relationship.
+
+## Data Model and Properties
+### Linked properties
+
+| Property | Meaning |
+| --- | --- |
+| `Moon` | The linked `PlanetaryMoon` that defines the shared orbital cycle |
+| `Sun` | The linked root `Sun` used for time-of-day and eclipse checks |
+
+### Author-entered properties
+
+| Property | Meaning | Real-world source |
+| --- | --- | --- |
+| `Name` | Display name of the planet | Builder-facing label |
+| `PeakIllumination` | Peak reflected-light contribution | Tuned gameplay value |
+| `AngularRadius` | Apparent angular radius of the parent planet in the moon sky | Derived from physical radius and observer distance |
+
+### Derived properties
+
+| Property | Source |
+| --- | --- |
+| `CurrentDayNumber` | Delegated from `Moon.CurrentDayNumber` |
+| `CurrentCelestialDay` | Delegated from `Moon.CurrentCelestialDay` |
+| `CelestialDaysPerYear` | Delegated from `Moon.CelestialDaysPerYear` |
+
+## Mapping to Real Astronomical Data
+Most of this type is derived rather than directly authored.
+
+Builders mainly need to supply:
+
+- a valid linked moon
+- a valid linked root sun
+- the apparent angular radius of the parent planet from the moon
+- a peak illumination target
+
+### Calculating angular radius
+If you know the parent planet radius `R` and the observer distance `d` from the planet center, a good approximation is:
+
+`AngularRadius = asin(R / d)`
+
+For small angles you can also approximate with `R / d`, but the exact inverse-sine form is safer for large apparent discs such as Jupiter from Ganymede.
+
+### Phase relationship
+You do not author an independent phase cycle for the planet. The implementation treats the planet phase as the complement of the linked moon phase.
+
+That matches the Earth-from-Moon example:
+
+- when the Moon is full as seen from Earth, Earth is new as seen from the Moon
+- when the Moon is new as seen from Earth, Earth is full as seen from the Moon
+
+## Calculation Pipeline
+### 1. Inherit the lunar timing model
+This type reuses the linked moon's:
+
+- current day number
+- current celestial day
+- cycle length
+- sidereal reference values
+
+It therefore stays locked to the same orbital cycle as the moon by construction.
+
+### 2. Invert equatorial coordinates
+The core coordinate rule is:
+
+- `PlanetRA = MoonRA + pi`
+- `PlanetDec = -MoonDec`
+
+This makes the parent planet the sky-opposite of the moon representation in the shared orbital frame.
+
+### 3. Compute local sidereal time and hour angle
+The type uses the linked moon's sidereal timing:
+
+`LST = Moon.SiderealTimeAtEpoch + Moon.SiderealTimePerDay * (dayNumber - Moon.DayNumberAtEpoch) + longitude`
+
+Then:
+
+`HA = LST - PlanetRA`
+
+### 4. Convert to elevation and azimuth
+The local sky conversion is the same standard transform used elsewhere:
+
+`Elevation = asin(sin(phi)*sin(Dec) + cos(phi)*cos(Dec)*cos(HA))`
+
+`Azimuth = atan2(sin(HA), cos(HA)*sin(phi) - tan(Dec)*cos(phi))`
+
+### 5. Compute phase complement
+The type computes the moon's cycle fraction, converts it to a moon phase angle, and then adds `pi`:
+
+`PlanetPhaseAngle = MoonPhaseAngle + pi`
+
+wrapped into `[0, 2*pi)`.
+
+### 6. Compute illumination
+Illumination uses the same simple Lambertian phase model as `PlanetaryMoon`:
+
+`Illumination = PeakIllumination * (1 + cos(PlanetPhaseAngle)) / 2`
+
+Because the phase angle is shifted by `pi`, the resulting illumination complements the moon's illumination.
+
+### 7. Compute named phase
+The implementation maps the linked moon's current phase to its opposite:
+
+- Moon New -> Planet Full
+- Moon Waxing Crescent -> Planet Waning Gibbous
+- Moon First Quarter -> Planet Last Quarter
+- Moon Waxing Gibbous -> Planet Waning Crescent
+- Moon Full -> Planet New
+- Moon Waning Gibbous -> Planet Waxing Crescent
+- Moon Last Quarter -> Planet First Quarter
+- Moon Waning Crescent -> Planet Waxing Gibbous
+
+### 8. Eclipse test against the linked sun
+`IsSunEclipsed(...)` compares:
+
+- the current local sky position of the parent planet
+- the current local sky position of the linked root sun
+
+It computes the angular separation between those two directions and returns true when:
+
+`separation < AngularRadius`
+
+This is a simple disc-overlap test from the moon observer's perspective.
+
+### 9. Time of day
+`CurrentTimeOfDay(...)` delegates to the linked root `Sun`.
+
+This is deliberate. The planet does not define the world's day/night cycle.
+
+## Seeder and Testing Considerations
+This type should almost always be seeded or authored together with its linked `PlanetaryMoon` and root `Sun`.
+
+Seeder guidance:
+
+- store both linked IDs explicitly
+- keep the package name and role markers consistent with the companion objects
+- do not treat this as a standalone celestial package unless you are also resolving or creating the required links
+
+Test guidance:
+
+- verify equatorial opposition against the linked moon
+- verify illumination complement
+- verify eclipse behavior for the chosen angular radius
+- verify non-24x60 clock direction sampling if timing logic changes
+
+## Known Caveats and Implementation Notes
+- This type is a derived observer-frame representation, not a generic planet ephemeris model.
+- A bad linked moon definition will produce a bad `PlanetFromMoon` sky.
+- The eclipse model is intentionally simple and based on angular overlap rather than a full umbra/penumbra simulation.
+- If you need a planet seen from a planetary surface rather than from a moon surface, this is the wrong type.

--- a/Design Documents/Celestial_Type_PlanetaryMoon.md
+++ b/Design Documents/Celestial_Type_PlanetaryMoon.md
@@ -1,0 +1,164 @@
+# Celestial Type: PlanetaryMoon
+
+## Concept and Real-World Analogy
+`PlanetaryMoon` represents a moon seen from the surface of its parent planet.
+
+The canonical example is Earth's Moon as seen from Earth. The gas giant stock package uses the same type for Ganymede as seen from Jupiter.
+
+This type is the "planet observer looking up at the moon" half of the linked moon-view model.
+
+## Data Model and Properties
+### Identity and timing properties
+
+| Property | Meaning |
+| --- | --- |
+| `Name` | Display name of the moon |
+| `Calendar` | Calendar used to determine current date |
+| `Clock` | Feed clock used to determine current time fraction |
+| `EpochDate` | Date associated with the orbital element epoch |
+
+### Orbital properties
+
+| Property | Meaning | Real-world source |
+| --- | --- | --- |
+| `CelestialDaysPerYear` | Phase/orbital cycle length used by the model | Synodic or chosen lunar cycle length |
+| `MeanAnomalyAngleAtEpoch` | Mean anomaly at the epoch | Ephemeris mean anomaly |
+| `AnomalyChangeAnglePerDay` | Mean anomaly change per day | Mean motion |
+| `ArgumentOfPeriapsis` | Argument of periapsis | Standard orbital element |
+| `LongitudeOfAscendingNode` | Longitude of ascending node | Standard orbital element |
+| `OrbitalInclination` | Inclination to the reference plane | Standard orbital element |
+| `OrbitalEccentricity` | Orbital eccentricity | Standard orbital element |
+| `DayNumberAtEpoch` | Numeric day number at epoch | Usually J2000-like day count |
+| `SiderealTimeAtEpoch` | Sidereal reference at epoch | Derived from the parent world's rotation model |
+| `SiderealTimePerDay` | Sidereal advance per day | Parent-world sidereal motion |
+| `FullMoonReferenceDay` | Day in the local lunar cycle considered full moon | Phase anchor, often chosen from an epoch almanac |
+
+### Illumination and presentation properties
+
+| Property | Meaning |
+| --- | --- |
+| `PeakIllumination` | Peak light contribution at full moon |
+| `Triggers` | Elevation-angle trigger thresholds and echoes |
+
+## Mapping to Real Astronomical Data
+Builders can usually source most of this type directly from published lunar or satellite orbital elements.
+
+Useful mapping rules:
+
+- `MeanAnomalyAngleAtEpoch` maps directly to the moon's mean anomaly at the chosen epoch.
+- `ArgumentOfPeriapsis`, `LongitudeOfAscendingNode`, `OrbitalInclination`, and `OrbitalEccentricity` are standard classical orbital elements.
+- `AnomalyChangeAnglePerDay` is the moon's mean motion in radians per day.
+- `SiderealTimeAtEpoch` and `SiderealTimePerDay` should match the parent planet's local sidereal rotation model.
+- `FullMoonReferenceDay` is not usually a published element. It is a gameplay phase anchor. You derive it by choosing a known full-moon date and ensuring the model's cycle day at that date maps to zero.
+
+For Earth's Moon, astronomy almanacs and common ephemeris tables usually provide enough data to populate all fields except the chosen gameplay phase anchor.
+
+## Calculation Pipeline
+### 1. Current day number and cycle day
+The type derives its current day number from calendar date, clock time fraction, epoch date, and day number at epoch.
+
+`CurrentCelestialDay` is then wrapped by `CelestialDaysPerYear`.
+
+### 2. Mean anomaly
+The moon computes:
+
+`M = MeanAnomalyAngleAtEpoch + AnomalyChangeAnglePerDay * (dayNumber - DayNumberAtEpoch)`
+
+and wraps the result into `[0, 2*pi)`.
+
+### 3. True anomaly
+The implementation uses a simple second-order approximation:
+
+`v = M + 2*e*sin(M) + 1.25*e^2*sin(2M)`
+
+where `e` is `OrbitalEccentricity`.
+
+### 4. Equatorial coordinates
+The type then rotates the orbital position into equatorial coordinates.
+
+It computes:
+
+- `wv = v + ArgumentOfPeriapsis`
+- Cartesian orbital-plane components using `LongitudeOfAscendingNode`, `wv`, and `OrbitalInclination`
+- `RA = atan2(y, x)`
+- `Dec = asin(z)`
+
+This gives the moon's right ascension and declination in the parent planet observer's frame.
+
+### 5. Sidereal time
+Local sidereal time is:
+
+`LST = SiderealTimeAtEpoch + SiderealTimePerDay * (dayNumber - DayNumberAtEpoch) + longitude`
+
+wrapped into `[0, 2*pi)`.
+
+### 6. Hour angle
+The hour angle is:
+
+`HA = LST - RA`
+
+### 7. Elevation and azimuth
+The local sky conversion uses the same standard form as the sun types:
+
+`Elevation = asin(sin(phi)*sin(Dec) + cos(phi)*cos(Dec)*cos(HA))`
+
+`Azimuth = atan2(sin(HA), cos(HA)*sin(phi) - tan(Dec)*cos(phi))`
+
+### 8. Phase angle
+The phase cycle is anchored to `FullMoonReferenceDay`.
+
+The runtime computes:
+
+- `cycleDay = (CurrentCelestialDay - FullMoonReferenceDay) mod CelestialDaysPerYear`
+- `PhaseAngle = 2*pi*(cycleDay / CelestialDaysPerYear)`
+
+This means the reference day is treated as full moon.
+
+### 9. Illumination
+The type uses a simple Lambertian phase model:
+
+`Illumination = PeakIllumination * (1 + cos(PhaseAngle)) / 2`
+
+This gives:
+
+- peak illumination at full moon
+- minimum illumination at new moon
+
+### 10. Named moon phases
+The type converts the cycle fraction into the eight stock phase names:
+
+- Full
+- Waxing Gibbous
+- First Quarter
+- Waxing Crescent
+- New
+- Waning Crescent
+- Last Quarter
+- Waning Gibbous
+
+### 11. Direction
+Movement direction is determined by comparing the current elevation to the elevation one in-game minute earlier, using the actual clock length rather than a hard-coded Earth minute fraction.
+
+## Seeder and Testing Considerations
+The stock seeder currently uses this type for:
+
+- Earth's Moon in the Earth moon-view package
+- Ganymede in the gas giant moon-view package
+
+When implementing new seeded moons:
+
+1. keep the moon's `Calendar` and `Clock` consistent with the intended world frame
+2. choose `FullMoonReferenceDay` from a known full-moon epoch
+3. if you are also seeding `PlanetFromMoon` or `SunFromPlanetaryMoon`, create those linked objects in the same package and store the linked IDs explicitly
+
+Test considerations:
+
+- changes to phase math need regression tests around full and new moon
+- changes to sidereal or local sky transforms need numeric angle tests
+- changes to minute sampling need non-24x60 clock tests
+
+## Known Caveats and Implementation Notes
+- `CurrentTimeOfDay(...)` always returns `Night` for this type because a moon does not define the zone's day/night cycle.
+- The illumination model is intentionally simple and phase-based; it does not attempt a full reflected-light or eclipse model on its own.
+- The type assumes the supplied orbital elements are already in the coordinate convention expected by the implementation.
+- If you need the parent planet or the same star from the moon observer's frame, use the linked types rather than overloading this one.

--- a/Design Documents/Celestial_Type_Sun.md
+++ b/Design Documents/Celestial_Type_Sun.md
@@ -1,0 +1,198 @@
+# Celestial Type: Sun
+
+## Concept and Real-World Analogy
+The current `Sun` celestial type is implemented by `NewSun`.
+
+It represents a star as seen from the surface of a rotating planetary body. The canonical Earth example is "the Sun as seen from Earth." The gas giant stock package also uses the same type to represent "the Sun as seen from Jupiter."
+
+This type is the modern stock solar model and the default choice for new planetary-surface worlds.
+
+## Data Model and Properties
+The modern seeder emits the `SunV2` XML shape for this type.
+
+The important groups are:
+
+- calendar and clock feed
+- orbital parameters
+- illumination parameters
+- trigger and description ranges
+
+### Identity and timing properties
+
+| Property | Meaning |
+| --- | --- |
+| `Name` | Display name of the celestial |
+| `Calendar` | Calendar used to determine the current date |
+| `Clock` | Feed clock used to determine the fractional time of day |
+| `EpochDate` | Calendar date associated with the orbital epoch |
+
+### Orbital properties
+
+| Property | Meaning | Real-world source |
+| --- | --- | --- |
+| `CelestialDaysPerYear` | Orbital cycle length used by the model | Sidereal or tropical year equivalent chosen for the desired world model |
+| `MeanAnomalyAngleAtEpoch` | Mean anomaly at the selected epoch | Almanac or ephemeris mean anomaly at epoch |
+| `AnomalyChangeAnglePerDay` | Mean anomaly advance per day | Mean motion in radians per day |
+| `EclipticLongitude` | Longitude term added to the true anomaly to reach solar ecliptic longitude in the implementation's convention | Derived from longitude of perihelion or equivalent orbital longitude convention |
+| `EquatorialObliquity` | Obliquity between orbital and equatorial planes | Axial tilt / obliquity |
+| `DayNumberAtEpoch` | Numeric day count at epoch | Commonly J2000 day number such as `2451545.0` |
+| `CurrentDayNumberOffset` | Additional offset added to the calculated current day number | Runtime calibration term; defaults to legacy-compatible `0.5` |
+| `SiderealTimeAtEpoch` | Local sidereal time at the epoch day number | Almanac sidereal time at epoch |
+| `SiderealTimePerDay` | Sidereal advance per day | Derived from the planet's rotation relative to the stars |
+| `KepplerC1Approximant` through `KepplerC6Approximant` | Coefficients used by the true anomaly approximation | Derived from orbital eccentricity or fitted approximation coefficients |
+
+### Illumination properties
+
+| Property | Meaning | Real-world source |
+| --- | --- | --- |
+| `PeakIllumination` | Maximum direct illumination in lux-like game units | Surface insolation target or chosen gameplay value |
+| `AlphaScatteringConstant` | Direct atmospheric attenuation coefficient | Tuned atmospheric parameter |
+| `BetaScatteringConstant` | Scattered-light attenuation coefficient | Tuned atmospheric parameter |
+| `AtmosphericDensityScalingFactor` | Effective atmospheric depth scale | Tuned atmospheric parameter |
+| `PlanetaryRadius` | Planet radius used in the scattering equations | Planet radius in km-like units consistent with the model |
+
+### Presentation properties
+
+| Property | Meaning |
+| --- | --- |
+| `Triggers` | Elevation-angle thresholds for rise, set, and other sky echoes |
+| `ElevationDescriptions` | Human-facing phrases keyed by elevation |
+| `AzimuthDescriptions` | Human-facing phrases keyed by azimuth |
+
+## Mapping to Real Astronomical Data
+This type is intentionally builder-friendly. Most of its orbital fields correspond to values you can obtain directly from astronomical almanacs, ephemerides, or orbital-element tables.
+
+Practical mapping guidance:
+
+- `MeanAnomalyAngleAtEpoch` is the mean anomaly `M` at the chosen epoch.
+- `AnomalyChangeAnglePerDay` is the mean motion `n`.
+- `EclipticLongitude` is the implementation's longitude term that, together with `TrueAnomaly + pi`, yields the sun's apparent ecliptic longitude. In practice you usually derive it from the longitude of perihelion or equivalent heliocentric/orbital longitude convention being used by the source data.
+- `EquatorialObliquity` is the planet's obliquity.
+- `SiderealTimeAtEpoch` and `SiderealTimePerDay` come from the planet's sidereal rotation model.
+- `DayNumberAtEpoch` should match the date numbering convention used by the source ephemeris.
+- `CurrentDayNumberOffset` is usually left at the default unless you have a specific reason to alter the day-number convention.
+
+For Earth-like content, J2000-derived element tables are usually the easiest source.
+
+## Calculation Pipeline
+The runtime pipeline is explicit and mirrors standard astronomy steps.
+
+### 1. Current day number
+The type computes:
+
+`CurrentDayNumber = (Calendar.CurrentDate - EpochDate).Days + Clock.CurrentTime.TimeFraction + DayNumberAtEpoch + CurrentDayNumberOffset`
+
+This is the fundamental time input for the orbital calculations.
+
+`CurrentCelestialDay` is also computed from the same date-and-time source but wrapped by `CelestialDaysPerYear`.
+
+### 2. Mean anomaly
+The mean anomaly is:
+
+`M = MeanAnomalyAngleAtEpoch + AnomalyChangeAnglePerDay * (dayNumber - DayNumberAtEpoch)`
+
+The result is wrapped into `[0, 2*pi)`.
+
+### 3. True anomaly
+The type does not numerically solve Kepler's equation on every call. Instead it applies a configurable trigonometric approximation:
+
+`v = M + C1*sin(M) + C2*sin(2M) + C3*sin(3M) + C4*sin(4M) + C5*sin(5M) + C6*sin(6M)`
+
+The coefficients are the `KepplerC*Approximant` fields.
+
+### 4. Ecliptic longitude of the sun
+The runtime computes:
+
+`lambda_sun = v + EclipticLongitude + pi`
+
+and wraps the result into `[0, 2*pi)`.
+
+### 5. Right ascension
+The type converts ecliptic longitude to right ascension using the obliquity:
+
+`RA = atan2(sin(lambda_sun) * cos(obliquity), cos(lambda_sun))`
+
+### 6. Declination
+Declination is:
+
+`Dec = asin(sin(lambda_sun) * sin(obliquity))`
+
+### 7. Sidereal time
+Local sidereal time is:
+
+`LST = SiderealTimeAtEpoch + SiderealTimePerDay * (dayNumber - DayNumberAtEpoch) + longitude`
+
+wrapped into `[0, 2*pi)`.
+
+### 8. Hour angle
+The hour angle is:
+
+`HA = LST - RA`
+
+### 9. Altitude
+For a zone latitude `phi`:
+
+`Altitude = asin(sin(phi)*sin(Dec) + cos(phi)*cos(Dec)*cos(HA))`
+
+In this subsystem, the cached field name `LastAscensionAngle` stores this local altitude/elevation angle.
+
+### 10. Azimuth
+Azimuth is computed as:
+
+`Azimuth = atan2(sin(HA), cos(HA)*sin(phi) - tan(Dec)*cos(phi))`
+
+### 11. Illumination
+The modern sun types use a two-part atmosphere/scattering model:
+
+- `U`
+- `L`
+- `H`
+- `RhoH`
+- `E1`
+- `E2`
+
+The final illumination is:
+
+`CurrentIllumination = E1 + E2`
+
+Conceptually:
+
+- `E1` is the direct sunlight term
+- `E2` is the atmospheric scattering term
+
+### 12. Movement direction
+Direction is determined by comparing current altitude to the altitude one in-game minute earlier.
+
+The minute fraction is derived from:
+
+`Clock.HoursPerDay * Clock.MinutesPerHour`
+
+with a legacy safety fallback to `1 / 1440` if the clock data is unavailable.
+
+### 13. Time of day
+`CurrentTimeOfDay(...)` uses:
+
+- current altitude sign
+- small threshold bands near the horizon
+- whether the object is ascending or descending
+
+to classify the result as morning, afternoon, dawn, dusk, or night.
+
+## Seeder and Testing Considerations
+This is the type used by the stock seeder for:
+
+- the Earth-facing sun package
+- the Jupiter-facing sun inside the gas giant moon package
+
+When authoring or testing this type:
+
+- verify the chosen calendar and feed clock make sense together
+- verify `EpochDate`, `DayNumberAtEpoch`, and `CurrentDayNumberOffset` are internally consistent
+- add numeric regression tests if you change any step of the calculation chain
+- add non-24x60 clock tests if you touch motion or time-fraction logic
+
+## Known Caveats and Implementation Notes
+- `CurrentDayNumberOffset` exists to preserve legacy-compatible day-number behavior while making the assumption configurable.
+- `EclipticLongitude` is the field most likely to confuse builders because source data often publishes related but not identically named longitude terms.
+- The type models a star from one planetary-surface frame. If you need the same star from a moon frame, use `SunFromPlanetaryMoon` rather than trying to reuse this object directly.
+- Time-of-day classification is a gameplay-oriented interpretation layered on top of the astronomy math.

--- a/Design Documents/Celestial_Type_SunFromPlanetaryMoon.md
+++ b/Design Documents/Celestial_Type_SunFromPlanetaryMoon.md
@@ -1,0 +1,153 @@
+# Celestial Type: SunFromPlanetaryMoon
+
+## Concept and Real-World Analogy
+`SunFromPlanetaryMoon` represents the same physical star as a linked root `Sun`, but transformed into the local sky frame of an observer standing on a moon.
+
+The Earth-system analogy is "the Sun as seen from the Moon," derived from:
+
+- the root Earth-facing `Sun`
+- the linked `PlanetaryMoon`
+
+The gas giant stock package uses the same model for Sol as seen from Ganymede, derived from the Jupiter-facing root sun plus the linked Ganymede moon object.
+
+## Data Model and Properties
+### Linked properties
+
+| Property | Meaning |
+| --- | --- |
+| `Moon` | Linked `PlanetaryMoon` providing the moon observer's sidereal timing |
+| `Sun` | Linked root `NewSun` providing the base solar orbit and illumination defaults |
+
+### Illumination properties
+
+| Property | Meaning |
+| --- | --- |
+| `PeakIllumination` | Usually copied from the linked root sun |
+| `AlphaScatteringConstant` | Usually copied from the linked root sun |
+| `BetaScatteringConstant` | Usually copied from the linked root sun |
+| `AtmosphericDensityScalingFactor` | Usually copied from the linked root sun |
+| `PlanetaryRadius` | Usually copied from the linked root sun |
+
+If the XML does not include an explicit illumination block, the type copies these values from the linked root `Sun`.
+
+### Derived timing properties
+
+| Property | Source |
+| --- | --- |
+| `CurrentDayNumber` | Delegated from `Sun.CurrentDayNumber` |
+| `CurrentCelestialDay` | Delegated from `Sun.CurrentCelestialDay` |
+| `CelestialDaysPerYear` | Delegated from `Sun.CelestialDaysPerYear` |
+
+## Mapping to Real Astronomical Data
+This type is mostly derived and should not be authored as though it were an independent star model.
+
+The builder-facing data work is:
+
+- author or seed a correct root `Sun` for the planetary frame
+- author or seed a correct `PlanetaryMoon` for the moon frame
+- link them
+- optionally override illumination values if the moon-local atmosphere should differ from the root sun's defaults
+
+In most cases, illumination should stay synchronized with the root sun unless there is a deliberate gameplay reason to diverge.
+
+## Calculation Pipeline
+### 1. Reuse the root sun's day number
+The type reuses the linked `Sun` for:
+
+- current day number
+- current celestial day
+- year/cycle length
+
+This keeps the star's orbital position synchronized with the root planetary-surface representation.
+
+### 2. Reuse the moon's sidereal frame
+The type reuses the linked moon for:
+
+- `SiderealTimeAtEpoch`
+- `SiderealTimePerDay`
+- `DayNumberAtEpoch`
+
+This lets the same physical star be seen using the moon observer's local rotation model.
+
+### 3. Build root-space Cartesian vectors
+The type gets:
+
+- moon `RA` and `Dec` from `Moon.EquatorialCoordinates(dayNumber)`
+- sun `RA` and `Dec` from `Sun.RightAscension(dayNumber)` and `Sun.Declension(dayNumber)`
+
+Each pair is converted into unit Cartesian components.
+
+### 4. Subtract the moon vector from the sun vector
+The implementation computes:
+
+- `x = sunX - moonX`
+- `y = sunY - moonY`
+- `z = sunZ - moonZ`
+
+This creates the moon-local direction vector to the star.
+
+### 5. Convert back to equatorial coordinates
+The type computes:
+
+- `r = sqrt(x*x + y*y + z*z)`
+- `RA = atan2(y, x)`
+- `Dec = asin(z / r)`
+
+This gives the moon-local apparent equatorial position of the star.
+
+### 6. Compute local sidereal time and hour angle
+Using the linked moon's sidereal terms:
+
+`LST = Moon.SiderealTimeAtEpoch + Moon.SiderealTimePerDay * (dayNumber - Moon.DayNumberAtEpoch) + longitude`
+
+Then:
+
+`HA = LST - RA`
+
+### 7. Convert to elevation and azimuth
+The local sky conversion is the same standard transform used by the other modern celestial types:
+
+`Elevation = asin(sin(phi)*sin(Dec) + cos(phi)*cos(Dec)*cos(HA))`
+
+`Azimuth = atan2(sin(HA), cos(HA)*sin(phi) - tan(Dec)*cos(phi))`
+
+### 8. Compute illumination
+Illumination uses the same atmospheric/scattering pipeline as `NewSun`:
+
+- `U`
+- `L`
+- `H`
+- `RhoH`
+- `E1`
+- `E2`
+
+The final result is:
+
+`Illumination = E1 + E2`
+
+### 9. Determine direction and time of day
+Direction is determined by comparing current elevation to the moon-local value one in-game minute earlier, using the actual clock length from the linked moon's clock.
+
+`CurrentTimeOfDay(...)` then uses the resulting elevation and direction in the same gameplay-oriented way as a root `Sun`.
+
+## Seeder and Testing Considerations
+This type should be created as part of a linked package rather than as an isolated one-off object.
+
+Seeder guidance:
+
+- always store both the moon ID and the root sun ID
+- default the illumination block from the linked root sun unless there is a deliberate override
+- keep the moon-local sun in the same seeder package as its linked moon-view objects
+
+Test guidance:
+
+- verify the type remains synchronized with the linked root sun's day-number progression
+- verify local sky position changes when the linked moon's sidereal frame changes
+- verify time-of-day classification remains correct
+- verify non-24x60 clock direction sampling
+
+## Known Caveats and Implementation Notes
+- This is not an independent astrophysical star model.
+- A wrong root sun or wrong linked moon will produce a wrong moon-local sun.
+- The illumination model is solar-like and copied from the root sun by default, which is usually what you want for linked packages.
+- If you are authoring this by hand, treat it as a view transform over two linked inputs, not as a standalone orbital data source.


### PR DESCRIPTION
## Summary
- add explicit Earth sun, Earth moon-view, and gas giant moon-view seeder packages, including linked `PlanetFromMoon` and `SunFromPlanetaryMoon` definitions
- add a Jupiter-facing root `Sun` package for the Ganymede/Jupiter/Sol setup and preserve linked celestial relationships in seeder repeatability checks
- make `NewSun` day-number offset configurable, update celestial direction sampling to use actual clock length, and preserve the new field in analyzer clones
- extend runtime and seeder tests for the new celestial package behavior and add a full celestial documentation suite under `Design Documents/`

## Testing
- Not run (not requested)