### PR TITLE
Fix historical Pounds currency patterns and use project references in seeder tests

### DIFF
--- a/DatabaseSeeder Unit Tests/CurrencySeederTests.cs
+++ b/DatabaseSeeder Unit Tests/CurrencySeederTests.cs
@@ -1,0 +1,199 @@
+#nullable enable
+
+using DatabaseSeeder.Seeders;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Database;
+using MudSharp.Economy.Currency;
+using MudSharp.Framework;
+using MudSharp.Framework.Save;
+using MudSharp.FutureProg;
+using MudSharp.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using RuntimeCurrency = MudSharp.Economy.Currency.Currency;
+using ModelCurrency = MudSharp.Models.Currency;
+using CultureInfo = System.Globalization.CultureInfo;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class CurrencySeederTests
+{
+	private static FuturemudDatabaseContext BuildContext()
+	{
+		DbContextOptions<FuturemudDatabaseContext> options = new DbContextOptionsBuilder<FuturemudDatabaseContext>()
+			.UseInMemoryDatabase(Guid.NewGuid().ToString())
+			.ConfigureWarnings(x => x.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+			.Options;
+		return new FuturemudDatabaseContext(options);
+	}
+
+	private static RuntimeCurrency LoadRuntimeCurrency(FuturemudDatabaseContext context, string currencyName)
+	{
+		ModelCurrency dbCurrency = context.Currencies
+			.Include(x => x.CurrencyDivisions)
+				.ThenInclude(x => x.CurrencyDivisionAbbreviations)
+			.Include(x => x.CurrencyDescriptionPatterns)
+				.ThenInclude(x => x.CurrencyDescriptionPatternElements)
+					.ThenInclude(x => x.CurrencyDescriptionPatternElementSpecialValues)
+			.Include(x => x.Coins)
+			.Single(x => x.Name == currencyName);
+
+		List<IFutureProg> progs = context.FutureProgs
+			.AsEnumerable()
+			.Select(BuildFutureProg)
+			.ToList();
+		Mock<IUneditableAll<IFutureProg>> progRepository = BuildRepository(progs);
+		Mock<IFuturemud> gameworld = new();
+		gameworld.SetupGet(x => x.FutureProgs).Returns(progRepository.Object);
+		gameworld.SetupGet(x => x.SaveManager).Returns(Mock.Of<ISaveManager>());
+		gameworld.Setup(x => x.Add(It.IsAny<ICoin>()));
+
+		return new RuntimeCurrency(dbCurrency, gameworld.Object);
+	}
+
+	private static IFutureProg BuildFutureProg(MudSharp.Models.FutureProg dbProg)
+	{
+		Mock<IFutureProg> prog = new();
+		prog.SetupGet(x => x.Id).Returns(dbProg.Id);
+		prog.SetupGet(x => x.Name).Returns(dbProg.FunctionName);
+		prog.SetupGet(x => x.FrameworkItemType).Returns("FutureProg");
+		prog.SetupGet(x => x.FunctionName).Returns(dbProg.FunctionName);
+		prog.Setup(x => x.ExecuteBool(It.IsAny<object[]>()))
+			.Returns((object[] values) => ExecuteComparison(dbProg.FunctionText, values));
+		prog.Setup(x => x.ExecuteBool(It.IsAny<bool>(), It.IsAny<object[]>()))
+			.Returns((bool _, object[] values) => ExecuteComparison(dbProg.FunctionText, values));
+		return prog.Object;
+	}
+
+	private static bool ExecuteComparison(string functionText, IReadOnlyList<object> values)
+	{
+		decimal number = Convert.ToDecimal(values[0], CultureInfo.InvariantCulture);
+		if (functionText.StartsWith("return @number < ", StringComparison.Ordinal))
+		{
+			decimal threshold = decimal.Parse(
+				functionText["return @number < ".Length..],
+				CultureInfo.InvariantCulture);
+			return number < threshold;
+		}
+
+		throw new NotSupportedException($"Unsupported FutureProg comparison in test harness: {functionText}");
+	}
+
+	private static Mock<IUneditableAll<T>> BuildRepository<T>(IEnumerable<T> items) where T : class, IFrameworkItem
+	{
+		List<T> list = items.ToList();
+		Dictionary<long, T> byId = list.ToDictionary(x => x.Id, x => x);
+		Mock<IUneditableAll<T>> repository = new();
+		repository.Setup(x => x.Get(It.IsAny<long>()))
+			.Returns((long id) => byId.TryGetValue(id, out T? value) ? value : null);
+		repository.Setup(x => x.GetEnumerator()).Returns(() => list.GetEnumerator());
+		repository.SetupGet(x => x.Count).Returns(list.Count);
+		return repository;
+	}
+
+	[TestMethod]
+	public void SeedData_PoundsCompactPatterns_RenderHistoricalSterlingNotation()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		string result = new CurrencySeeder().SeedData(context, new Dictionary<string, string>
+		{
+			["currency"] = "pounds"
+		});
+
+		Assert.AreEqual("The operation completed successfully.", result);
+
+		RuntimeCurrency currency = LoadRuntimeCurrency(context, "Pounds");
+		Dictionary<decimal, string> expectations = new()
+		{
+			[3.0M] = "¾d",
+			[6.0M] = "1½d",
+			[44.0M] = "11d",
+			[48.0M] = "1/–",
+			[120.0M] = "2/6",
+			[839.0M] = "17/5¾",
+			[1440.0M] = "£1/10/–",
+			[1919.0M] = "£1/19/11¾",
+			[1920.0M] = "£2/–/–"
+		};
+
+		foreach (CurrencyDescriptionPatternType type in new[]
+		         {
+			         CurrencyDescriptionPatternType.Short,
+			         CurrencyDescriptionPatternType.ShortDecimal,
+			         CurrencyDescriptionPatternType.Long
+		         })
+		{
+			foreach ((decimal amount, string expected) in expectations)
+			{
+				Assert.AreEqual(expected, currency.Describe(amount, type), $"{type} failed for {amount}.");
+			}
+		}
+	}
+
+	[TestMethod]
+	public void SeedData_PoundsPatterns_SeedTieredCompactFormatsAndSterlingGlyphSpecials()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		new CurrencySeeder().SeedData(context, new Dictionary<string, string>
+		{
+			["currency"] = "pounds"
+		});
+
+		ModelCurrency currency = context.Currencies
+			.Include(x => x.CurrencyDescriptionPatterns)
+				.ThenInclude(x => x.CurrencyDescriptionPatternElements)
+					.ThenInclude(x => x.CurrencyDescriptionPatternElementSpecialValues)
+			.Include(x => x.CurrencyDescriptionPatterns)
+				.ThenInclude(x => x.FutureProg)
+			.Single(x => x.Name == "Pounds");
+
+		foreach (int type in new[]
+		         {
+			         (int)CurrencyDescriptionPatternType.Short,
+			         (int)CurrencyDescriptionPatternType.ShortDecimal,
+			         (int)CurrencyDescriptionPatternType.Long
+		         })
+		{
+			List<MudSharp.Models.CurrencyDescriptionPattern> patterns = currency.CurrencyDescriptionPatterns
+				.Where(x => x.Type == type)
+				.OrderBy(x => x.Order)
+				.ToList();
+
+			CollectionAssert.AreEqual(new[] { 10, 20, 30 }, patterns.Select(x => x.Order).ToArray());
+			Assert.AreEqual("IsLessThanFortyEight", patterns[0].FutureProg?.FunctionName);
+			Assert.AreEqual("IsLessThanNineHundredSixty", patterns[1].FutureProg?.FunctionName);
+			Assert.IsNull(patterns[2].FutureProg);
+		}
+
+		MudSharp.Models.CurrencyDescriptionPattern shortPattern = currency.CurrencyDescriptionPatterns
+			.Single(x => x.Type == (int)CurrencyDescriptionPatternType.Short && x.Order == 10);
+		MudSharp.Models.CurrencyDescriptionPatternElement penceOnlyElement = shortPattern.CurrencyDescriptionPatternElements.Single();
+		Dictionary<decimal, string> penceGlyphs = penceOnlyElement.CurrencyDescriptionPatternElementSpecialValues
+			.ToDictionary(x => x.Value, x => x.Text);
+		Assert.AreEqual("¾d", penceGlyphs[0.75M]);
+		Assert.AreEqual("1½d", penceGlyphs[1.5M]);
+
+		MudSharp.Models.CurrencyDescriptionPattern slashPattern = currency.CurrencyDescriptionPatterns
+			.Single(x => x.Type == (int)CurrencyDescriptionPatternType.Short && x.Order == 20);
+		MudSharp.Models.CurrencyDescriptionPatternElement slashPenceElement = slashPattern.CurrencyDescriptionPatternElements
+			.Single(x => x.Order == 2);
+		Dictionary<decimal, string> slashGlyphs = slashPenceElement.CurrencyDescriptionPatternElementSpecialValues
+			.ToDictionary(x => x.Value, x => x.Text);
+		Assert.AreEqual("–", slashGlyphs[0.0M]);
+		Assert.AreEqual("5¾", slashGlyphs[5.75M]);
+
+		MudSharp.Models.CurrencyDescriptionPattern wordyPattern = currency.CurrencyDescriptionPatterns
+			.Single(x => x.Type == (int)CurrencyDescriptionPatternType.Wordy);
+		MudSharp.Models.CurrencyDescriptionPatternElement wordyFarthingElement = wordyPattern.CurrencyDescriptionPatternElements
+			.Single(x => x.Order == 4);
+		Dictionary<decimal, string> wordyFarthings = wordyFarthingElement.CurrencyDescriptionPatternElementSpecialValues
+			.ToDictionary(x => x.Value, x => x.Text);
+		Assert.AreEqual("ha'penny", wordyFarthings[2.0M]);
+		Assert.AreEqual("three farthings", wordyFarthings[3.0M]);
+	}
+}

--- a/DatabaseSeeder Unit Tests/DatabaseSeeder Unit Tests.csproj
+++ b/DatabaseSeeder Unit Tests/DatabaseSeeder Unit Tests.csproj
@@ -16,18 +16,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Reference Include="DatabaseSeeder">
-			<HintPath>..\DatabaseSeeder\bin\$(Configuration)\net10.0\DatabaseSeeder.dll</HintPath>
-		</Reference>
-		<Reference Include="FutureMUDLibrary">
-			<HintPath>..\FutureMUDLibrary\bin\$(Configuration)\net10.0\FutureMUDLibrary.dll</HintPath>
-		</Reference>
-		<Reference Include="MudSharp">
-			<HintPath>..\MudSharpCore\bin\$(Configuration)\net10.0\MudSharp.dll</HintPath>
-		</Reference>
-		<Reference Include="MudsharpDatabaseLibrary">
-			<HintPath>..\MudsharpDatabaseLibrary\bin\$(Configuration)\net10.0\MudsharpDatabaseLibrary.dll</HintPath>
-		</Reference>
+		<ProjectReference Include="..\DatabaseSeeder\DatabaseSeeder.csproj" />
+		<ProjectReference Include="..\FutureMUDLibrary\FutureMUDLibrary.csproj" />
+		<ProjectReference Include="..\MudSharpCore\MudSharpCore.csproj" />
+		<ProjectReference Include="..\MudsharpDatabaseLibrary\MudsharpDatabaseLibrary.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/DatabaseSeeder/Seeders/CurrencySeeder.cs
+++ b/DatabaseSeeder/Seeders/CurrencySeeder.cs
@@ -106,11 +106,73 @@ Please make your choice: ",
     public string Name => "Currency";
     public string Tagline => "Set up a currency (or currencies) for your game";
 
-    public string FullDescription =>
-        "This package sets up everything you need to get a currency in game. It is intended to be additive, so reruns can install more stock currency packages. This is required for some of the clan templates.";
+	public string FullDescription =>
+		"This package sets up everything you need to get a currency in game. It is intended to be additive, so reruns can install more stock currency packages. This is required for some of the clan templates.";
 
-    private void SeedDollars(FuturemudDatabaseContext context, ICollection<string> errors)
-    {
+	private static FutureProg EnsureNumericLessThanProg(FuturemudDatabaseContext context, string functionName, string thresholdText)
+	{
+		var prog = context.FutureProgs.FirstOrDefault(x => x.FunctionName == functionName);
+		if (prog is not null)
+		{
+			return prog;
+		}
+
+		prog = new FutureProg
+		{
+			FunctionName = functionName,
+			AcceptsAnyParameters = false,
+			ReturnType = 4,
+			Category = "Core",
+			Subcategory = "Universal",
+			Public = true,
+			FunctionComment = $"Accepts a number and returns true if it is less than {thresholdText}.",
+			FunctionText = $"return @number < {thresholdText}",
+			StaticType = 0
+		};
+		prog.FutureProgsParameters.Add(new FutureProgsParameter
+		{
+			FutureProg = prog,
+			ParameterIndex = 0,
+			ParameterName = "number",
+			ParameterType = 2
+		});
+		context.FutureProgs.Add(prog);
+		context.SaveChanges();
+		return prog;
+	}
+
+	private static void AddSpecialValue(CurrencyDescriptionPatternElement element, decimal value, string text)
+	{
+		element.CurrencyDescriptionPatternElementSpecialValues.Add(new CurrencyDescriptionPatternElementSpecialValues
+		{
+			CurrencyDescriptionPatternElement = element,
+			Value = value,
+			Text = text
+		});
+	}
+
+	private static void AddSterlingFractionalPenceSpecialValues(CurrencyDescriptionPatternElement element, string suffix)
+	{
+		foreach (var (fraction, glyph) in new[]
+		         {
+			         (0.25M, "¼"),
+			         (0.5M, "½"),
+			         (0.75M, "¾")
+		         })
+		{
+			for (var wholePence = 0; wholePence < 12; wholePence++)
+			{
+				var value = wholePence + fraction;
+				var text = wholePence == 0
+					? $"{glyph}{suffix}"
+					: $"{wholePence}{glyph}{suffix}";
+				AddSpecialValue(element, value, text);
+			}
+		}
+	}
+
+	private void SeedDollars(FuturemudDatabaseContext context, ICollection<string> errors)
+	{
         Currency currency = new()
         {
             Name = "Dollars"
@@ -882,258 +944,282 @@ Please make your choice: ",
         context.SaveChanges();
     }
 
-    private void SeedPounds(FuturemudDatabaseContext context, ICollection<string> errors)
-    {
-        Currency currency = new()
-        {
-            Name = "Pounds"
-        };
-        context.Currencies.Add(currency);
-        context.SaveChanges();
+	private void SeedPounds(FuturemudDatabaseContext context, ICollection<string> errors)
+	{
+		var currency = new Currency
+		{
+			Name = "Pounds"
+		};
+		context.Currencies.Add(currency);
+		context.SaveChanges();
 
-        CurrencyDivision division = new()
-        {
-            Currency = currency,
-            Name = "penny",
-            BaseUnitConversionRate = 4.0M
-        };
-        context.CurrencyDivisions.Add(division);
-        CurrencyDivision pennyDivision = division;
-        division.CurrencyDivisionAbbreviations.Add(new CurrencyDivisionAbbreviation
-        { CurrencyDivision = division, Pattern = @"(-?\d+(?:\.\d+)*)(?:\s*(?:penny|pennies|p|d))$" });
-        context.SaveChanges();
+		var division = new CurrencyDivision
+		{
+			Currency = currency,
+			Name = "penny",
+			BaseUnitConversionRate = 4.0M
+		};
+		context.CurrencyDivisions.Add(division);
+		var pennyDivision = division;
+		division.CurrencyDivisionAbbreviations.Add(new CurrencyDivisionAbbreviation
+		{
+			CurrencyDivision = division,
+			Pattern = @"(-?\d+(?:\.\d+)*)(?:\s*(?:penny|pennies|p|d))$"
+		});
+		context.SaveChanges();
 
-        division = new CurrencyDivision
-        {
-            Currency = currency,
-            Name = "shilling",
-            BaseUnitConversionRate = 48.0M
-        };
-        context.CurrencyDivisions.Add(division);
-        CurrencyDivision shillingDivision = division;
-        division.CurrencyDivisionAbbreviations.Add(new CurrencyDivisionAbbreviation
-        { CurrencyDivision = division, Pattern = @"(-?\d+(?:\.\d+)*)(?:\s*(?:shillings|shilling|s))$" });
-        context.SaveChanges();
+		division = new CurrencyDivision
+		{
+			Currency = currency,
+			Name = "shilling",
+			BaseUnitConversionRate = 48.0M
+		};
+		context.CurrencyDivisions.Add(division);
+		var shillingDivision = division;
+		division.CurrencyDivisionAbbreviations.Add(new CurrencyDivisionAbbreviation
+		{
+			CurrencyDivision = division,
+			Pattern = @"(-?\d+(?:\.\d+)*)(?:\s*(?:shillings|shilling|s))$"
+		});
+		context.SaveChanges();
 
-        division = new CurrencyDivision
-        {
-            Currency = currency,
-            Name = "pound",
-            BaseUnitConversionRate = 960.0M
-        };
-        context.CurrencyDivisions.Add(division);
-        CurrencyDivision poundDivision = division;
-        division.CurrencyDivisionAbbreviations.Add(new CurrencyDivisionAbbreviation
-        { CurrencyDivision = division, Pattern = @"(-?\d+(?:\.\d+)*)(?:\s*(?:pounds|pound|l|lb|£))$" });
-        context.SaveChanges();
+		division = new CurrencyDivision
+		{
+			Currency = currency,
+			Name = "pound",
+			BaseUnitConversionRate = 960.0M
+		};
+		context.CurrencyDivisions.Add(division);
+		var poundDivision = division;
+		division.CurrencyDivisionAbbreviations.Add(new CurrencyDivisionAbbreviation
+		{
+			CurrencyDivision = division,
+			Pattern = @"(-?\d+(?:\.\d+)*)(?:\s*(?:pounds|pound|l|lb|£))$"
+		});
+		context.SaveChanges();
 
-        division = new CurrencyDivision
-        {
-            Currency = currency,
-            Name = "farthing",
-            BaseUnitConversionRate = 1.0M
-        };
-        context.CurrencyDivisions.Add(division);
-        CurrencyDivision farthingDivision = division;
-        division.CurrencyDivisionAbbreviations.Add(new CurrencyDivisionAbbreviation
-        { CurrencyDivision = division, Pattern = @"(-?\d+(?:\.\d+)*)(?:\s*(?:farthings|farthing|f))$" });
-        context.SaveChanges();
+		division = new CurrencyDivision
+		{
+			Currency = currency,
+			Name = "farthing",
+			BaseUnitConversionRate = 1.0M
+		};
+		context.CurrencyDivisions.Add(division);
+		var farthingDivision = division;
+		division.CurrencyDivisionAbbreviations.Add(new CurrencyDivisionAbbreviation
+		{
+			CurrencyDivision = division,
+			Pattern = @"(-?\d+(?:\.\d+)*)(?:\s*(?:farthings|farthing|f))$"
+		});
+		context.SaveChanges();
 
-        foreach (CurrencyDescriptionPatternType type in Enum.GetValues(typeof(CurrencyDescriptionPatternType))
-                     .OfType<CurrencyDescriptionPatternType>())
-        {
-            string prefix;
-            switch (type)
-            {
-                case CurrencyDescriptionPatternType.Casual:
-                case CurrencyDescriptionPatternType.Wordy:
-                    prefix = "negative ";
-                    break;
-                case CurrencyDescriptionPatternType.Long:
-                case CurrencyDescriptionPatternType.Short:
-                case CurrencyDescriptionPatternType.ShortDecimal:
-                    prefix = "-";
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
+		var lessThanOneShillingProg = EnsureNumericLessThanProg(context, "IsLessThanFortyEight", "48");
+		var lessThanOnePoundProg = EnsureNumericLessThanProg(context, "IsLessThanNineHundredSixty", "960");
 
-            CurrencyDescriptionPattern pattern = new()
-            {
-                Currency = currency,
-                Type = (int)type,
-                NegativePrefix = prefix,
-                Order = 1,
-                UseNaturalAggregationStyle = true
-            };
-            context.CurrencyDescriptionPatterns.Add(pattern);
-            switch (type)
-            {
-                case CurrencyDescriptionPatternType.Casual:
-                case CurrencyDescriptionPatternType.Wordy:
-                    pattern.CurrencyDescriptionPatternElements.Add(new CurrencyDescriptionPatternElement
-                    {
-                        CurrencyDescriptionPattern = pattern,
-                        Pattern = "{0} pound",
-                        Order = 1,
-                        ShowIfZero = false,
-                        CurrencyDivision = poundDivision,
-                        PluraliseWord = "pound",
-                        RoundingMode = (int)RoundingMode.Truncate,
-                        SpecialValuesOverrideFormat = false
-                    });
-                    pattern.CurrencyDescriptionPatternElements.Add(new CurrencyDescriptionPatternElement
-                    {
-                        CurrencyDescriptionPattern = pattern,
-                        Pattern = "{0} shilling",
-                        Order = 2,
-                        ShowIfZero = false,
-                        CurrencyDivision = shillingDivision,
-                        PluraliseWord = "shilling",
-                        RoundingMode = (int)RoundingMode.Truncate,
-                        SpecialValuesOverrideFormat = false
-                    });
-                    CurrencyDescriptionPatternElement pennyElement = new()
-                    {
-                        CurrencyDescriptionPattern = pattern,
-                        Pattern = "{0} penny",
-                        Order = 3,
-                        ShowIfZero = false,
-                        CurrencyDivision = pennyDivision,
-                        PluraliseWord = "penny",
-                        RoundingMode = (int)RoundingMode.Truncate,
-                        SpecialValuesOverrideFormat = true
-                    };
-                    pattern.CurrencyDescriptionPatternElements.Add(pennyElement);
+		foreach (var type in Enum.GetValues(typeof(CurrencyDescriptionPatternType)).OfType<CurrencyDescriptionPatternType>())
+		{
+			string prefix;
+			switch (type)
+			{
+				case CurrencyDescriptionPatternType.Casual:
+				case CurrencyDescriptionPatternType.Wordy:
+					prefix = "negative ";
+					break;
+				case CurrencyDescriptionPatternType.Long:
+				case CurrencyDescriptionPatternType.Short:
+				case CurrencyDescriptionPatternType.ShortDecimal:
+					prefix = "-";
+					break;
+				default:
+					throw new ArgumentOutOfRangeException();
+			}
 
-                    pennyElement.CurrencyDescriptionPatternElementSpecialValues.Add(
-                        new CurrencyDescriptionPatternElementSpecialValues
-                        {
-                            CurrencyDescriptionPatternElement = pennyElement,
-                            Value = 8.0M,
-                            Text = "tuppence"
-                        });
+			if (type is CurrencyDescriptionPatternType.Casual or CurrencyDescriptionPatternType.Wordy)
+			{
+				var pattern = new CurrencyDescriptionPattern
+				{
+					Currency = currency,
+					Type = (int)type,
+					NegativePrefix = prefix,
+					Order = 1,
+					UseNaturalAggregationStyle = true
+				};
+				context.CurrencyDescriptionPatterns.Add(pattern);
 
-                    pennyElement.CurrencyDescriptionPatternElementSpecialValues.Add(
-                        new CurrencyDescriptionPatternElementSpecialValues
-                        {
-                            CurrencyDescriptionPatternElement = pennyElement,
-                            Value = 12.0M,
-                            Text = "thruppence"
-                        });
+				pattern.CurrencyDescriptionPatternElements.Add(new CurrencyDescriptionPatternElement
+				{
+					CurrencyDescriptionPattern = pattern,
+					Pattern = "{0} pound",
+					Order = 1,
+					ShowIfZero = false,
+					CurrencyDivision = poundDivision,
+					PluraliseWord = "pound",
+					RoundingMode = (int)RoundingMode.Truncate,
+					SpecialValuesOverrideFormat = false
+				});
+				pattern.CurrencyDescriptionPatternElements.Add(new CurrencyDescriptionPatternElement
+				{
+					CurrencyDescriptionPattern = pattern,
+					Pattern = "{0} shilling",
+					Order = 2,
+					ShowIfZero = false,
+					CurrencyDivision = shillingDivision,
+					PluraliseWord = "shilling",
+					RoundingMode = (int)RoundingMode.Truncate,
+					SpecialValuesOverrideFormat = false
+				});
 
-                    pennyElement.CurrencyDescriptionPatternElementSpecialValues.Add(
-                        new CurrencyDescriptionPatternElementSpecialValues
-                        {
-                            CurrencyDescriptionPatternElement = pennyElement,
-                            Value = 16.0M,
-                            Text = "fourpence"
-                        });
+				var pennyElement = new CurrencyDescriptionPatternElement
+				{
+					CurrencyDescriptionPattern = pattern,
+					Pattern = "{0} penny",
+					Order = 3,
+					ShowIfZero = false,
+					CurrencyDivision = pennyDivision,
+					PluraliseWord = "penny",
+					RoundingMode = (int)RoundingMode.Truncate,
+					SpecialValuesOverrideFormat = true
+				};
+				pattern.CurrencyDescriptionPatternElements.Add(pennyElement);
+				AddSpecialValue(pennyElement, 2.0M, "tuppence");
+				AddSpecialValue(pennyElement, 3.0M, "thruppence");
+				AddSpecialValue(pennyElement, 4.0M, "fourpence");
+				AddSpecialValue(pennyElement, 6.0M, "sixpence");
 
-                    pennyElement.CurrencyDescriptionPatternElementSpecialValues.Add(
-                        new CurrencyDescriptionPatternElementSpecialValues
-                        {
-                            CurrencyDescriptionPatternElement = pennyElement,
-                            Value = 24.0M,
-                            Text = "sixpence"
-                        });
+				var farthingElement = new CurrencyDescriptionPatternElement
+				{
+					CurrencyDescriptionPattern = pattern,
+					Pattern = "{0} farthing",
+					Order = 4,
+					ShowIfZero = false,
+					CurrencyDivision = farthingDivision,
+					PluraliseWord = "farthing",
+					RoundingMode = (int)RoundingMode.Truncate,
+					SpecialValuesOverrideFormat = true
+				};
+				pattern.CurrencyDescriptionPatternElements.Add(farthingElement);
+				AddSpecialValue(farthingElement, 1.0M, "farthing");
+				AddSpecialValue(farthingElement, 2.0M, "ha'penny");
+				AddSpecialValue(farthingElement, 3.0M, "three farthings");
+				continue;
+			}
 
-                    CurrencyDescriptionPatternElement farthingElement = new()
-                    {
-                        CurrencyDescriptionPattern = pattern,
-                        Pattern = "{0} farthing",
-                        Order = 4,
-                        ShowIfZero = false,
-                        CurrencyDivision = farthingDivision,
-                        PluraliseWord = "farthing",
-                        RoundingMode = (int)RoundingMode.Truncate,
-                        SpecialValuesOverrideFormat = true
-                    };
-                    pattern.CurrencyDescriptionPatternElements.Add(farthingElement);
+			var pencePattern = new CurrencyDescriptionPattern
+			{
+				Currency = currency,
+				Type = (int)type,
+				NegativePrefix = prefix,
+				Order = 10,
+				UseNaturalAggregationStyle = false,
+				FutureProg = lessThanOneShillingProg
+			};
+			context.CurrencyDescriptionPatterns.Add(pencePattern);
+			var penceElement = new CurrencyDescriptionPatternElement
+			{
+				CurrencyDescriptionPattern = pencePattern,
+				Pattern = "{0:0}d",
+				Order = 1,
+				ShowIfZero = false,
+				CurrencyDivision = pennyDivision,
+				PluraliseWord = "",
+				RoundingMode = (int)RoundingMode.NoRounding,
+				SpecialValuesOverrideFormat = true
+			};
+			pencePattern.CurrencyDescriptionPatternElements.Add(penceElement);
+			AddSterlingFractionalPenceSpecialValues(penceElement, "d");
 
-                    farthingElement.CurrencyDescriptionPatternElementSpecialValues.Add(
-                        new CurrencyDescriptionPatternElementSpecialValues
-                        {
-                            CurrencyDescriptionPatternElement = farthingElement,
-                            Value = 1.0M,
-                            Text = "farthing"
-                        });
+			var shillingPattern = new CurrencyDescriptionPattern
+			{
+				Currency = currency,
+				Type = (int)type,
+				NegativePrefix = prefix,
+				Order = 20,
+				UseNaturalAggregationStyle = false,
+				FutureProg = lessThanOnePoundProg
+			};
+			context.CurrencyDescriptionPatterns.Add(shillingPattern);
+			shillingPattern.CurrencyDescriptionPatternElements.Add(new CurrencyDescriptionPatternElement
+			{
+				CurrencyDescriptionPattern = shillingPattern,
+				Pattern = "{0:0}/",
+				Order = 1,
+				ShowIfZero = false,
+				CurrencyDivision = shillingDivision,
+				PluraliseWord = "",
+				RoundingMode = (int)RoundingMode.Truncate,
+				SpecialValuesOverrideFormat = false
+			});
+			var slashPenceElement = new CurrencyDescriptionPatternElement
+			{
+				CurrencyDescriptionPattern = shillingPattern,
+				Pattern = "{0:0}",
+				Order = 2,
+				ShowIfZero = true,
+				CurrencyDivision = pennyDivision,
+				PluraliseWord = "",
+				RoundingMode = (int)RoundingMode.NoRounding,
+				SpecialValuesOverrideFormat = true
+			};
+			shillingPattern.CurrencyDescriptionPatternElements.Add(slashPenceElement);
+			AddSpecialValue(slashPenceElement, 0.0M, "–");
+			AddSterlingFractionalPenceSpecialValues(slashPenceElement, string.Empty);
 
-                    farthingElement.CurrencyDescriptionPatternElementSpecialValues.Add(
-                        new CurrencyDescriptionPatternElementSpecialValues
-                        {
-                            CurrencyDescriptionPatternElement = farthingElement,
-                            Value = 2.0M,
-                            Text = "hapenny"
-                        });
+			var poundPattern = new CurrencyDescriptionPattern
+			{
+				Currency = currency,
+				Type = (int)type,
+				NegativePrefix = prefix,
+				Order = 30,
+				UseNaturalAggregationStyle = false
+			};
+			context.CurrencyDescriptionPatterns.Add(poundPattern);
+			poundPattern.CurrencyDescriptionPatternElements.Add(new CurrencyDescriptionPatternElement
+			{
+				CurrencyDescriptionPattern = poundPattern,
+				Pattern = "£{0:0}/",
+				Order = 1,
+				ShowIfZero = false,
+				CurrencyDivision = poundDivision,
+				PluraliseWord = "",
+				RoundingMode = (int)RoundingMode.Truncate,
+				SpecialValuesOverrideFormat = false
+			});
+			var poundShillingElement = new CurrencyDescriptionPatternElement
+			{
+				CurrencyDescriptionPattern = poundPattern,
+				Pattern = "{0:0}/",
+				Order = 2,
+				ShowIfZero = true,
+				CurrencyDivision = shillingDivision,
+				PluraliseWord = "",
+				RoundingMode = (int)RoundingMode.Truncate,
+				SpecialValuesOverrideFormat = true
+			};
+			poundPattern.CurrencyDescriptionPatternElements.Add(poundShillingElement);
+			AddSpecialValue(poundShillingElement, 0.0M, "–/");
 
-                    farthingElement.CurrencyDescriptionPatternElementSpecialValues.Add(
-                        new CurrencyDescriptionPatternElementSpecialValues
-                        {
-                            CurrencyDescriptionPatternElement = farthingElement,
-                            Value = 3.0M,
-                            Text = "three farthing"
-                        });
-                    break;
-                case CurrencyDescriptionPatternType.Long:
-                case CurrencyDescriptionPatternType.Short:
-                case CurrencyDescriptionPatternType.ShortDecimal:
-                    pattern.CurrencyDescriptionPatternElements.Add(new CurrencyDescriptionPatternElement
-                    {
-                        CurrencyDescriptionPattern = pattern,
-                        Pattern = "£{0}",
-                        Order = 1,
-                        ShowIfZero = false,
-                        CurrencyDivision = poundDivision,
-                        PluraliseWord = "",
-                        RoundingMode = (int)RoundingMode.Truncate,
-                        SpecialValuesOverrideFormat = false
-                    });
-                    pattern.CurrencyDescriptionPatternElements.Add(new CurrencyDescriptionPatternElement
-                    {
-                        CurrencyDescriptionPattern = pattern,
-                        Pattern = "{0}s",
-                        Order = 2,
-                        ShowIfZero = false,
-                        CurrencyDivision = shillingDivision,
-                        PluraliseWord = "",
-                        RoundingMode = (int)RoundingMode.Truncate,
-                        SpecialValuesOverrideFormat = false
-                    });
-                    pattern.CurrencyDescriptionPatternElements.Add(new CurrencyDescriptionPatternElement
-                    {
-                        CurrencyDescriptionPattern = pattern,
-                        Pattern = "{0}d",
-                        Order = 3,
-                        ShowIfZero = false,
-                        CurrencyDivision = pennyDivision,
-                        PluraliseWord = "",
-                        RoundingMode = (int)RoundingMode.Truncate,
-                        SpecialValuesOverrideFormat = false
-                    });
-                    pattern.CurrencyDescriptionPatternElements.Add(new CurrencyDescriptionPatternElement
-                    {
-                        CurrencyDescriptionPattern = pattern,
-                        Pattern = "{0}f",
-                        Order = 4,
-                        ShowIfZero = false,
-                        CurrencyDivision = farthingDivision,
-                        PluraliseWord = "",
-                        RoundingMode = (int)RoundingMode.Truncate,
-                        SpecialValuesOverrideFormat = false
-                    });
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-        }
+			var poundPenceElement = new CurrencyDescriptionPatternElement
+			{
+				CurrencyDescriptionPattern = poundPattern,
+				Pattern = "{0:0}",
+				Order = 3,
+				ShowIfZero = true,
+				CurrencyDivision = pennyDivision,
+				PluraliseWord = "",
+				RoundingMode = (int)RoundingMode.NoRounding,
+				SpecialValuesOverrideFormat = true
+			};
+			poundPattern.CurrencyDescriptionPatternElements.Add(poundPenceElement);
+			AddSpecialValue(poundPenceElement, 0.0M, "–");
+			AddSterlingFractionalPenceSpecialValues(poundPenceElement, string.Empty);
+		}
 
-        context.SaveChanges();
+		context.SaveChanges();
 
-        Coin coin = new()
-        {
-            Name = "farthing",
-            ShortDescription = "a farthing",
+		var coin = new Coin
+		{
+			Name = "farthing",
+			ShortDescription = "a farthing",
             FullDescription =
                 "This is a small coin made of copper approximately 21mm in diameter. It is worth the least of all of the coins.",
             Value = 1.0M,
@@ -1145,9 +1231,9 @@ Please make your choice: ",
         context.Coins.Add(coin);
         context.SaveChanges();
 
-        coin = new Coin
-        {
-            Name = "ha'penny",
+		coin = new Coin
+		{
+			Name = "ha'penny",
             ShortDescription = "a ha'penny bit",
             FullDescription = "This is a small coin made of copper approximately 26mm in diameter.",
             Value = 2.0M,

--- a/Design Documents/Economy_System_Seeder_State_and_Gaps.md
+++ b/Design Documents/Economy_System_Seeder_State_and_Gaps.md
@@ -21,6 +21,7 @@ The current repository has two dedicated economy seeders:
 
 - stock currency packages such as dollars, pounds, fantasy, roman, bits, and Gondor
 - stock divisions, coins, description patterns, and parsing abbreviations
+- historical compact `£sd` formatting for the stock Pounds package, including sub-shilling `d` notation, slash notation above one shilling, full `£/s/d` notation above one pound, quarter-penny glyph fractions, and `–` zero slots in slash forms
 - supporting FutureProg content for some currency pattern applicability
 - additive rerun behavior so multiple currencies can coexist
 

--- a/Design Documents/Economy_System_Workflows_and_Integration.md
+++ b/Design Documents/Economy_System_Workflows_and_Integration.md
@@ -104,6 +104,7 @@ Practical note:
 - currency design is not only cosmetic
 - regex abbreviations determine what players can type successfully
 - description patterns determine how values are surfaced all across the engine
+- the stock Pounds package now seeds historical compact `£sd` notation, using `d` forms below one shilling, slash forms from one shilling to less than one pound, full `£/s/d` forms above one pound, quarter-penny glyphs (`¼`, `½`, `¾`), and `–` for zero slots in slash notation
 
 ### Economic Zones and Taxes
 Builders use economic zones to define:


### PR DESCRIPTION
## Summary
- update the Pounds currency seeding to use historical `£sd` display patterns
- add seeded special values for quarter-penny glyphs and `–` zero slots in slash notation
- add targeted `CurrencySeeder` tests covering compact sterling formatting and seeded pattern structure
- switch `DatabaseSeeder Unit Tests` from DLL hint paths to project references so tests build against current source
- document the seeded Pounds formatting behavior in the economy design docs

## Testing
- `dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore`
- `dotnet vstest 'DatabaseSeeder Unit Tests\bin\Debug\net10.0\DatabaseSeeder Unit Tests.dll' /TestCaseFilter:'FullyQualifiedName~CurrencySeederTests'`
- full `DatabaseSeeder Unit Tests` suite still reports 11 unrelated pre-existing failures in `EconomySeederTests` and `SeederDisfigurementTemplateUtilityTests`