### PR TITLE
Add fallback NPC name profiles and ethnicity-aware auto-fill defaults

### DIFF
--- a/DatabaseSeeder Unit Tests/CultureSeederNameAndHeightDefaultTests.cs
+++ b/DatabaseSeeder Unit Tests/CultureSeederNameAndHeightDefaultTests.cs
@@ -1,0 +1,310 @@
+#nullable enable
+
+using DatabaseSeeder.Seeders;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Character.Name;
+using MudSharp.Database;
+using MudSharp.Form.Shape;
+using MudSharp.Framework;
+using MudSharp.Models;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using DbNameCulture = MudSharp.Models.NameCulture;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class CultureSeederNameAndHeightDefaultTests
+{
+	[TestMethod]
+	public void CultureSeeder_FallbackProfiles_MakeBaseNameCulturesReadyAndRemainRerunnable()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		context.NameCultures.Add(new DbNameCulture
+		{
+			Name = "Admin",
+			Definition = BuildNameCultureDefinition((NameUsage.BirthName, 1, 1))
+		});
+		context.SaveChanges();
+
+		CultureSeeder seeder = new();
+		RunSimpleNameSeeding(seeder, context);
+		RunSimpleNameSeeding(seeder, context);
+
+		AssertCultureHasReadyCompatibleProfile(context, "Simple", Gender.Male);
+		AssertCultureHasReadyCompatibleProfile(context, "Given and Family", Gender.Male);
+		AssertCultureHasReadyCompatibleProfile(context, "Given and Patronym", Gender.Male);
+		AssertCultureHasReadyCompatibleProfile(context, "Given and Toponym", Gender.Male);
+		AssertCultureHasReadyCompatibleProfile(context, "Admin", Gender.Male);
+
+		Assert.AreEqual(0, context.RandomNameProfiles.Count(x => x.Name == "Simple Fallback"),
+			"Simple should continue using its stock seeded profiles rather than an unnecessary fallback.");
+		Assert.AreEqual(1, context.RandomNameProfiles.Count(x => x.Name == "Given and Family Fallback"));
+		Assert.AreEqual(1, context.RandomNameProfiles.Count(x => x.Name == "Given and Patronym Fallback"));
+		Assert.AreEqual(1, context.RandomNameProfiles.Count(x => x.Name == "Given and Toponym Fallback"));
+		Assert.AreEqual(1, context.RandomNameProfiles.Count(x => x.Name == "Admin Fallback"));
+	}
+
+	[TestMethod]
+	public void MedievalEuropeEthnicityMappings_AssignExpectedNameCulturesWithReadyProfiles()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		Race humanRace = new()
+		{
+			Name = "Human",
+			Description = "Test race",
+			AllowedGenders = "0 1 2 3 4",
+			DiceExpression = "1d1",
+			CommunicationStrategyType = "humanoid",
+			MaximumDragWeightExpression = "1",
+			MaximumLiftWeightExpression = "1",
+			HoldBreathLengthExpression = "1",
+			BreathingVolumeExpression = "1",
+			EatCorpseEmoteText = string.Empty,
+			HandednessOptions = "1"
+		};
+		context.Races.Add(humanRace);
+
+		foreach (string nameCulture in MedievalTargetCultures())
+		{
+			context.NameCultures.Add(new DbNameCulture
+			{
+				Name = nameCulture,
+				Definition = BuildNameCultureDefinition((NameUsage.BirthName, 1, 1), (NameUsage.Surname, 1, 1))
+			});
+		}
+
+		foreach (string ethnicityName in MedievalExpectedMappings().Keys)
+		{
+			context.Ethnicities.Add(new Ethnicity
+			{
+				Name = ethnicityName,
+				ChargenBlurb = string.Empty,
+				ParentRace = humanRace,
+				EthnicGroup = "Test"
+			});
+		}
+
+		context.SaveChanges();
+
+		CultureSeeder seeder = new();
+		SetSeederContext(seeder, context);
+		InvokePrivate(seeder, "EnsureFallbackRandomNameProfiles");
+		InvokePrivate(seeder, "ApplyMedievalEuropeEthnicityNameCultureMappings");
+
+		foreach ((string ethnicityName, (string maleCulture, string femaleCulture)) in MedievalExpectedMappings())
+		{
+			Ethnicity ethnicity = context.Ethnicities.Single(x => x.Name == ethnicityName);
+			List<EthnicitiesNameCultures> links = context.EthnicitiesNameCultures
+				.Where(x => x.EthnicityId == ethnicity.Id)
+				.ToList();
+
+			Assert.AreEqual(5, links.Count, $"Expected five name-culture links for ethnicity {ethnicityName}.");
+			AssertGenderLink(links, Gender.Male, maleCulture);
+			AssertGenderLink(links, Gender.Female, femaleCulture);
+			AssertGenderLink(links, Gender.Neuter, maleCulture);
+			AssertGenderLink(links, Gender.NonBinary, femaleCulture);
+			AssertGenderLink(links, Gender.Indeterminate, maleCulture);
+
+			AssertCultureHasReadyCompatibleProfile(context, maleCulture, Gender.Male);
+			AssertCultureHasReadyCompatibleProfile(context, femaleCulture, Gender.Female);
+		}
+	}
+
+	[TestMethod]
+	public void StockRaceSeeders_AssignDefaultHeightWeightModelsForAdvertisedGenders()
+	{
+		IReadOnlyList<string> animalIssues = AnimalSeeder.ValidateTemplateCatalogForTesting();
+		Assert.AreEqual(0, animalIssues.Count, string.Join("\n", animalIssues));
+
+		IReadOnlyList<string> mythicalIssues = MythicalAnimalSeeder.ValidateTemplateCatalogForTesting();
+		Assert.AreEqual(0, mythicalIssues.Count, string.Join("\n", mythicalIssues));
+
+		IReadOnlyList<string> robotIssues = RobotSeeder.ValidateTemplateCatalogForTesting();
+		Assert.AreEqual(0, robotIssues.Count, string.Join("\n", robotIssues));
+
+		string humanSeederSource = File.ReadAllText(GetSourcePath("DatabaseSeeder", "Seeders", "HumanSeeder.cs"));
+		Assert.IsTrue(
+			humanSeederSource.IndexOf("SetupHeightWeightModels();", StringComparison.Ordinal) <
+			humanSeederSource.IndexOf("SetupRaces(", StringComparison.Ordinal),
+			"HumanSeeder should initialise height-weight models before assigning them as race defaults.");
+		StringAssert.Contains(humanSeederSource, "organicHumanoidRace.DefaultHeightWeightModelMale = _humanMaleHWModel;");
+		StringAssert.Contains(humanSeederSource, "organicHumanoidRace.DefaultHeightWeightModelFemale = _humanFemaleHWModel;");
+		StringAssert.Contains(humanSeederSource, "human.DefaultHeightWeightModelMale = _humanMaleHWModel;");
+		StringAssert.Contains(humanSeederSource, "human.DefaultHeightWeightModelFemale = _humanFemaleHWModel;");
+
+		string cultureHeritageSource = File.ReadAllText(GetSourcePath("DatabaseSeeder", "Seeders", "CultureSeederHeritage.cs"));
+		foreach (string assignment in new[]
+		{
+			"elfRace.DefaultHeightWeightModelMale = elfMaleHWModel;",
+			"elfRace.DefaultHeightWeightModelFemale = elfFemaleHWModel;",
+			"hobbitRace.DefaultHeightWeightModelMale = hobbitMaleHWModel;",
+			"hobbitRace.DefaultHeightWeightModelFemale = hobbitFemaleHWModel;",
+			"dwarfRace.DefaultHeightWeightModelMale = dwarfMaleHWModel;",
+			"dwarfRace.DefaultHeightWeightModelFemale = dwarfFemaleHWModel;",
+			"orcRace.DefaultHeightWeightModelMale = orcMaleHWModel;",
+			"orcRace.DefaultHeightWeightModelFemale = orcFemaleHWModel;",
+			"trollRace.DefaultHeightWeightModelMale = trollFemaleHWModel;",
+			"trollRace.DefaultHeightWeightModelFemale = trollFemaleHWModel;"
+		})
+		{
+			StringAssert.Contains(cultureHeritageSource, assignment);
+		}
+	}
+
+	private static FuturemudDatabaseContext BuildContext()
+	{
+		DbContextOptions<FuturemudDatabaseContext> options = new DbContextOptionsBuilder<FuturemudDatabaseContext>()
+			.UseInMemoryDatabase(Guid.NewGuid().ToString())
+			.Options;
+		return new FuturemudDatabaseContext(options);
+	}
+
+	private static void RunSimpleNameSeeding(CultureSeeder seeder, FuturemudDatabaseContext context)
+	{
+		SetSeederContext(seeder, context);
+		InvokePrivate(seeder, "SeedSimple", context);
+		InvokePrivate(seeder, "EnsureFallbackRandomNameProfiles");
+	}
+
+	private static void SetSeederContext(CultureSeeder seeder, FuturemudDatabaseContext context)
+	{
+		typeof(CultureSeeder)
+			.GetField("_context", BindingFlags.Instance | BindingFlags.NonPublic)!
+			.SetValue(seeder, context);
+	}
+
+	private static object? InvokePrivate(object target, string methodName, params object[] args)
+	{
+		return target.GetType()
+			.GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic)!
+			.Invoke(target, args);
+	}
+
+	private static void AssertCultureHasReadyCompatibleProfile(
+		FuturemudDatabaseContext context,
+		string cultureName,
+		Gender targetGender)
+	{
+		DbNameCulture culture = context.NameCultures.Single(x => x.Name == cultureName);
+		bool hasReadyProfile = context.RandomNameProfiles
+			.Where(x => x.NameCultureId == culture.Id)
+			.AsEnumerable()
+			.Any(x => IsCompatibleGender((Gender)x.Gender, targetGender) && IsReadyProfile(context, x.Id));
+
+		Assert.IsTrue(hasReadyProfile, $"Expected {cultureName} to have a ready random name profile compatible with {targetGender.DescribeEnum()}.");
+	}
+
+	private static bool IsReadyProfile(FuturemudDatabaseContext context, long profileId)
+	{
+		List<int> usages = context.RandomNameProfilesDiceExpressions
+			.Where(x => x.RandomNameProfileId == profileId)
+			.Select(x => x.NameUsage)
+			.Distinct()
+			.ToList();
+		return usages.Count > 0 &&
+		       usages.All(usage => context.RandomNameProfilesElements.Any(x =>
+			       x.RandomNameProfileId == profileId && x.NameUsage == usage));
+	}
+
+	private static bool IsCompatibleGender(Gender profileGender, Gender targetGender)
+	{
+		return profileGender == Gender.NonBinary ||
+		       profileGender == Gender.Indeterminate ||
+		       profileGender == targetGender;
+	}
+
+	private static void AssertGenderLink(
+		IEnumerable<EthnicitiesNameCultures> links,
+		Gender gender,
+		string expectedCulture)
+	{
+		EthnicitiesNameCultures link = links.Single(x => x.Gender == (short)gender);
+		Assert.AreEqual(expectedCulture, link.NameCulture.Name);
+	}
+
+	private static IEnumerable<string> MedievalTargetCultures()
+	{
+		return MedievalExpectedMappings()
+			.SelectMany(x => new[] { x.Value.Male, x.Value.Female })
+			.Distinct(StringComparer.OrdinalIgnoreCase);
+	}
+
+	private static IReadOnlyDictionary<string, (string Male, string Female)> MedievalExpectedMappings()
+	{
+		return new Dictionary<string, (string Male, string Female)>(StringComparer.OrdinalIgnoreCase)
+		{
+			["German"] = ("German", "German"),
+			["Austrian"] = ("German", "German"),
+			["Dutch"] = ("Dutch", "Dutch"),
+			["French"] = ("French", "French"),
+			["Occitan"] = ("French", "French"),
+			["English"] = ("English", "English"),
+			["Venetian"] = ("Italian", "Italian"),
+			["Florentine"] = ("Italian", "Italian"),
+			["Neapolitan"] = ("Italian", "Italian"),
+			["Milanese"] = ("Italian", "Italian"),
+			["Sicilian"] = ("Italian", "Italian"),
+			["Corsican"] = ("Italian", "Italian"),
+			["Sardinian"] = ("Italian", "Italian"),
+			["Castilian"] = ("Iberian", "Iberian"),
+			["Catalan"] = ("Iberian", "Iberian"),
+			["Galicians"] = ("Iberian", "Iberian"),
+			["Portugese"] = ("Iberian", "Iberian"),
+			["Basque"] = ("Basque", "Basque"),
+			["Ashkenazi Jewish"] = ("Jewish Male", "Jewish Female"),
+			["Mizrahi Jewish"] = ("Jewish Male", "Jewish Female"),
+			["Sephardic Jewish"] = ("Jewish Male", "Jewish Female"),
+			["Gaelic"] = ("Irish", "Irish"),
+			["Welsh"] = ("Welsh", "Welsh"),
+			["Breton"] = ("Breton", "Breton"),
+			["Polish"] = ("Polish", "Polish"),
+			["Czech"] = ("Western Slavic", "Western Slavic"),
+			["Slovak"] = ("Western Slavic", "Western Slavic"),
+			["Croat"] = ("Western Slavic", "Western Slavic"),
+			["Serb"] = ("Western Slavic", "Western Slavic"),
+			["Bosniak"] = ("Western Slavic", "Western Slavic"),
+			["Vlach"] = ("Western Slavic", "Western Slavic"),
+			["Ruthenian"] = ("Eastern Slavic", "Eastern Slavic"),
+			["Ukrainian"] = ("Eastern Slavic", "Eastern Slavic"),
+			["Russian"] = ("Eastern Slavic", "Eastern Slavic"),
+			["Lithuanian"] = ("Finno-Ugric", "Finno-Ugric"),
+			["Estonian"] = ("Finno-Ugric", "Finno-Ugric"),
+			["Latvian"] = ("Finno-Ugric", "Finno-Ugric"),
+			["Prussian"] = ("Finno-Ugric", "Finno-Ugric"),
+			["Hungarian"] = ("Hungarian", "Hungarian"),
+			["Norse"] = ("Danish", "Danish"),
+			["Danish"] = ("Danish", "Danish"),
+			["Swedish"] = ("Swedish", "Swedish"),
+			["Icelandic"] = ("Danish", "Danish"),
+			["Roman"] = ("Hellenic", "Hellenic"),
+			["Ottoman"] = ("Turkish", "Turkish"),
+			["Cossack"] = ("Turkish", "Turkish"),
+			["Arabic"] = ("Levantine", "Levantine"),
+			["Persian"] = ("Persian", "Persian"),
+			["Moorish"] = ("Morrocan", "Morrocan"),
+			["North African"] = ("Morrocan", "Morrocan")
+		};
+	}
+
+	private static string BuildNameCultureDefinition(params (NameUsage Usage, int Minimum, int Maximum)[] elements)
+	{
+		return
+			$"<NameCulture><Patterns><Pattern Style=\"0\" Text=\"{{0}}\" Params=\"0\" /><Pattern Style=\"1\" Text=\"{{0}}\" Params=\"0\" /><Pattern Style=\"2\" Text=\"{{0}}\" Params=\"0\" /><Pattern Style=\"3\" Text=\"{{0}}\" Params=\"0\" /><Pattern Style=\"4\" Text=\"{{0}}\" Params=\"0\" /><Pattern Style=\"5\" Text=\"{{0}}\" Params=\"0\" /></Patterns><Elements>{string.Concat(elements.Select(x => $"<Element Usage=\"{(int)x.Usage}\" MinimumCount=\"{x.Minimum}\" MaximumCount=\"{x.Maximum}\" Name=\"{x.Usage}\"><![CDATA[Test]]></Element>"))}</Elements><NameEntryRegex><![CDATA[^(?<birthname>[\\w '-]+)$]]></NameEntryRegex></NameCulture>";
+	}
+
+	private static string GetSourcePath(params string[] parts)
+	{
+		return Path.GetFullPath(Path.Combine(
+			AppContext.BaseDirectory,
+			"..",
+			"..",
+			"..",
+			"..",
+			Path.Combine(parts)));
+	}
+}

--- a/DatabaseSeeder/Seeders/CultureSeeder.NameDefaults.cs
+++ b/DatabaseSeeder/Seeders/CultureSeeder.NameDefaults.cs
@@ -1,0 +1,208 @@
+#nullable enable
+
+using MudSharp.Character.Name;
+using MudSharp.Database;
+using MudSharp.Form.Shape;
+using MudSharp.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace DatabaseSeeder.Seeders;
+
+public partial class CultureSeeder
+{
+	private static readonly IReadOnlyDictionary<string, (string Male, string Female)> MedievalEuropeEthnicityNameCultureMappings =
+		new Dictionary<string, (string Male, string Female)>(StringComparer.OrdinalIgnoreCase)
+		{
+			["German"] = ("German", "German"),
+			["Austrian"] = ("German", "German"),
+			["Dutch"] = ("Dutch", "Dutch"),
+			["French"] = ("French", "French"),
+			["Occitan"] = ("French", "French"),
+			["English"] = ("English", "English"),
+			["Venetian"] = ("Italian", "Italian"),
+			["Florentine"] = ("Italian", "Italian"),
+			["Neapolitan"] = ("Italian", "Italian"),
+			["Milanese"] = ("Italian", "Italian"),
+			["Sicilian"] = ("Italian", "Italian"),
+			["Corsican"] = ("Italian", "Italian"),
+			["Sardinian"] = ("Italian", "Italian"),
+			["Castilian"] = ("Iberian", "Iberian"),
+			["Catalan"] = ("Iberian", "Iberian"),
+			["Galicians"] = ("Iberian", "Iberian"),
+			["Portugese"] = ("Iberian", "Iberian"),
+			["Basque"] = ("Basque", "Basque"),
+			["Ashkenazi Jewish"] = ("Jewish Male", "Jewish Female"),
+			["Mizrahi Jewish"] = ("Jewish Male", "Jewish Female"),
+			["Sephardic Jewish"] = ("Jewish Male", "Jewish Female"),
+			["Gaelic"] = ("Irish", "Irish"),
+			["Welsh"] = ("Welsh", "Welsh"),
+			["Breton"] = ("Breton", "Breton"),
+			["Polish"] = ("Polish", "Polish"),
+			["Czech"] = ("Western Slavic", "Western Slavic"),
+			["Slovak"] = ("Western Slavic", "Western Slavic"),
+			["Ruthenian"] = ("Eastern Slavic", "Eastern Slavic"),
+			["Ukrainian"] = ("Eastern Slavic", "Eastern Slavic"),
+			["Russian"] = ("Eastern Slavic", "Eastern Slavic"),
+			["Croat"] = ("Western Slavic", "Western Slavic"),
+			["Serb"] = ("Western Slavic", "Western Slavic"),
+			["Bosniak"] = ("Western Slavic", "Western Slavic"),
+			["Vlach"] = ("Western Slavic", "Western Slavic"),
+			["Lithuanian"] = ("Finno-Ugric", "Finno-Ugric"),
+			["Estonian"] = ("Finno-Ugric", "Finno-Ugric"),
+			["Latvian"] = ("Finno-Ugric", "Finno-Ugric"),
+			["Prussian"] = ("Finno-Ugric", "Finno-Ugric"),
+			["Hungarian"] = ("Hungarian", "Hungarian"),
+			["Norse"] = ("Danish", "Danish"),
+			["Danish"] = ("Danish", "Danish"),
+			["Swedish"] = ("Swedish", "Swedish"),
+			["Icelandic"] = ("Danish", "Danish"),
+			["Roman"] = ("Hellenic", "Hellenic"),
+			["Ottoman"] = ("Turkish", "Turkish"),
+			["Cossack"] = ("Turkish", "Turkish"),
+			["Arabic"] = ("Levantine", "Levantine"),
+			["Persian"] = ("Persian", "Persian"),
+			["Moorish"] = ("Morrocan", "Morrocan"),
+			["North African"] = ("Morrocan", "Morrocan")
+		};
+
+	private static readonly IReadOnlyList<string> FallbackGivenNames =
+		["Alex", "Sam", "Jamie", "Jordan", "Morgan", "Casey", "Riley", "Taylor"];
+
+	private static readonly IReadOnlyList<string> FallbackSurnames =
+		["Smith", "Brown", "Carter", "Clarke", "Stone", "Rivers"];
+
+	private static readonly IReadOnlyList<string> FallbackPatronyms =
+		["Alexson", "Jamieson", "Jordanson", "Morganson", "Samson"];
+
+	private static readonly IReadOnlyList<string> FallbackToponyms =
+		["of Ash", "of Brookside", "of Rivercross", "of Stoneford", "of Westhaven"];
+
+	private sealed record NameCultureElementSeed(NameUsage Usage, int MinimumCount, int MaximumCount);
+
+	private void ApplyEthnicityNameCultureMappings(
+		IReadOnlyDictionary<string, (string Male, string Female)> mappings)
+	{
+		foreach ((string ethnicityName, (string maleCulture, string femaleCulture)) in mappings)
+		{
+			Ethnicity? ethnicity = _context.Ethnicities.FirstOrDefault(x => x.Name == ethnicityName);
+			if (ethnicity is null)
+			{
+				continue;
+			}
+
+			ReplaceEthnicityNameLinks(
+				ethnicity,
+				(Gender.Male, maleCulture),
+				(Gender.Female, femaleCulture),
+				(Gender.Neuter, maleCulture),
+				(Gender.NonBinary, femaleCulture),
+				(Gender.Indeterminate, maleCulture));
+		}
+	}
+
+	private void ApplyMedievalEuropeEthnicityNameCultureMappings()
+	{
+		ApplyEthnicityNameCultureMappings(MedievalEuropeEthnicityNameCultureMappings);
+	}
+
+	private void EnsureFallbackRandomNameProfiles()
+	{
+		foreach (NameCulture culture in _context.NameCultures.ToList())
+		{
+			if (HasReadyRandomNameProfile(culture))
+			{
+				continue;
+			}
+
+			EnsureFallbackRandomNameProfile(culture);
+		}
+	}
+
+	private bool HasReadyRandomNameProfile(NameCulture culture)
+	{
+		foreach (RandomNameProfile profile in _context.RandomNameProfiles.Where(x => x.NameCultureId == culture.Id).ToList())
+		{
+			List<int> usages = _context.RandomNameProfilesDiceExpressions
+				.Where(x => x.RandomNameProfileId == profile.Id)
+				.Select(x => x.NameUsage)
+				.Distinct()
+				.ToList();
+
+			if (usages.Count == 0)
+			{
+				continue;
+			}
+
+			if (usages.All(usage => _context.RandomNameProfilesElements.Any(x =>
+					x.RandomNameProfileId == profile.Id && x.NameUsage == usage)))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private void EnsureFallbackRandomNameProfile(NameCulture culture)
+	{
+		List<NameCultureElementSeed> elements = ParseNameCultureElements(culture.Definition);
+		if (elements.Count == 0)
+		{
+			return;
+		}
+
+		RandomNameProfile profile = EnsureRandomNameProfile($"{culture.Name} Fallback", Gender.NonBinary, culture);
+		foreach (NameCultureElementSeed element in elements)
+		{
+			AddRandomNameDice(profile, element.Usage, BuildFallbackDiceExpression(element.MinimumCount, element.MaximumCount));
+			foreach (string name in GetFallbackNames(element.Usage))
+			{
+				AddRandomNameElement(profile, element.Usage, name, 100);
+			}
+		}
+
+		_context.SaveChanges();
+	}
+
+	private static List<NameCultureElementSeed> ParseNameCultureElements(string definition)
+	{
+		XElement root = XElement.Parse(definition);
+		return root.Element("Elements")?
+			.Elements("Element")
+			.Select(x => new NameCultureElementSeed(
+				(NameUsage)int.Parse(x.Attribute("Usage")!.Value),
+				int.Parse(x.Attribute("MinimumCount")!.Value),
+				int.Parse(x.Attribute("MaximumCount")!.Value)))
+			.ToList() ?? [];
+	}
+
+	private static string BuildFallbackDiceExpression(int minimumCount, int maximumCount)
+	{
+		if (minimumCount == maximumCount)
+		{
+			return minimumCount.ToString();
+		}
+
+		if (minimumCount == 0)
+		{
+			return $"1d{maximumCount + 1}-1";
+		}
+
+		return $"1d{maximumCount - minimumCount + 1}+{minimumCount - 1}";
+	}
+
+	private static IReadOnlyList<string> GetFallbackNames(NameUsage usage)
+	{
+		return usage switch
+		{
+			NameUsage.Surname => FallbackSurnames,
+			NameUsage.Patronym => FallbackPatronyms,
+			NameUsage.Matronym => FallbackPatronyms,
+			NameUsage.Toponym => FallbackToponyms,
+			_ => FallbackGivenNames
+		};
+	}
+}

--- a/DatabaseSeeder/Seeders/CultureSeeder.Shared.cs
+++ b/DatabaseSeeder/Seeders/CultureSeeder.Shared.cs
@@ -416,11 +416,11 @@ public partial class CultureSeeder
         return culture;
     }
 
-    private void ReplaceCultureNameLinks(Culture culture, params (Gender Gender, string NameCulture)[] mappings)
-    {
-        foreach (CulturesNameCultures? existing in culture.CulturesNameCultures.ToList())
-        {
-            _context.CulturesNameCultures.Remove(existing);
+	private void ReplaceCultureNameLinks(Culture culture, params (Gender Gender, string NameCulture)[] mappings)
+	{
+		foreach (CulturesNameCultures? existing in culture.CulturesNameCultures.ToList())
+		{
+			_context.CulturesNameCultures.Remove(existing);
         }
 
         foreach ((Gender gender, string? cultureName) in mappings)
@@ -433,6 +433,32 @@ public partial class CultureSeeder
             });
         }
 
-        _context.SaveChanges();
-    }
+		_context.SaveChanges();
+	}
+
+	private void ReplaceEthnicityNameLinks(Ethnicity ethnicity, params (Gender Gender, string NameCulture)[] mappings)
+	{
+		foreach (EthnicitiesNameCultures? existing in ethnicity.EthnicitiesNameCultures.ToList())
+		{
+			_context.EthnicitiesNameCultures.Remove(existing);
+		}
+
+		foreach ((Gender gender, string cultureName) in mappings)
+		{
+			NameCulture? nameCulture = _context.NameCultures.FirstOrDefault(x => x.Name == cultureName);
+			if (nameCulture is null)
+			{
+				continue;
+			}
+
+			ethnicity.EthnicitiesNameCultures.Add(new EthnicitiesNameCultures
+			{
+				Ethnicity = ethnicity,
+				NameCulture = nameCulture,
+				Gender = (short)gender
+			});
+		}
+
+		_context.SaveChanges();
+	}
 }

--- a/DatabaseSeeder/Seeders/CultureSeeder.cs
+++ b/DatabaseSeeder/Seeders/CultureSeeder.cs
@@ -60,19 +60,21 @@ Please answer #3yes#f or #3no#f. ", (context, answers) => true,
                 })
         };
 
-    public string SeedData(FuturemudDatabaseContext context, IReadOnlyDictionary<string, string> questionAnswers)
-    {
-        context.Database.BeginTransaction();
-        _context = context;
-        SeedSimple(context);
-        if (!questionAnswers["culturepacks"].EqualToAny("none"))
-        {
-            SeedCulturePacks(context, questionAnswers);
-        }
+	public string SeedData(FuturemudDatabaseContext context, IReadOnlyDictionary<string, string> questionAnswers)
+	{
+		context.Database.BeginTransaction();
+		_context = context;
+		SeedSimple(context);
+		if (!questionAnswers["culturepacks"].EqualToAny("none"))
+		{
+			SeedCulturePacks(context, questionAnswers);
+		}
 
-        context.Database.CommitTransaction();
-        return "Completed successfully.";
-    }
+		EnsureFallbackRandomNameProfiles();
+
+		context.Database.CommitTransaction();
+		return "Completed successfully.";
+	}
 
     public ShouldSeedResult ShouldSeedData(FuturemudDatabaseContext context)
     {

--- a/DatabaseSeeder/Seeders/CultureSeederHeritage.cs
+++ b/DatabaseSeeder/Seeders/CultureSeederHeritage.cs
@@ -1466,6 +1466,7 @@ public partial class CultureSeeder
         AddEthnicityVariable("Moorish", "Eye Colour", "brown_blue_eyes");
         AddEthnicityVariable("North African", "Eye Colour", "brown_blue_eyes");
         #endregion
+        ApplyMedievalEuropeEthnicityNameCultureMappings();
         _context.SaveChanges();
     }
 

--- a/DatabaseSeeder/Seeders/HumanSeeder.cs
+++ b/DatabaseSeeder/Seeders/HumanSeeder.cs
@@ -530,11 +530,11 @@ $?hairstyle[&he has &?a_an[$haircolour $hairstyle]][&he is completely bald].$?fa
 
         SetupSpeeds(humanoidBody);
         SetupBodyparts(humanoidBody, organicBody);
+        SetupHeightWeightModels();
         Race human = SetupRaces(humanoidBody, organicBody, strategy, healthTrait, strengthTrait);
         SeedHumanDisfigurementTemplates(organicBody);
         SetupCharacteristics(questionAnswers["distinctive"].EqualToAny("yes", "y"), human.ParentRace);
         SetupDescriptions();
-        SetupHeightWeightModels();
 
         #region Avatar Creation
         Race race = _context.Races.First(x => x.Name == "Human");

--- a/MudSharpCore Unit Tests/VariableNPCTemplateNameProfileTests.cs
+++ b/MudSharpCore Unit Tests/VariableNPCTemplateNameProfileTests.cs
@@ -1,0 +1,91 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Character.Heritage;
+using MudSharp.Character.Name;
+using MudSharp.Form.Shape;
+using MudSharp.NPC.Templates;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class VariableNPCTemplateNameProfileTests
+{
+	[TestMethod]
+	public void ResolveAutomaticNameProfile_EthnicityCulturePresent_PrefersEthnicityProfile()
+	{
+		Mock<IRandomNameProfile> cultureProfile = CreateProfile("Culture Profile", Gender.Male, true);
+		Mock<IRandomNameProfile> ethnicityProfile = CreateProfile("Ethnicity Profile", Gender.Male, true);
+		Mock<INameCulture> cultureNameCulture = CreateNameCulture(cultureProfile.Object);
+		Mock<INameCulture> ethnicityNameCulture = CreateNameCulture(ethnicityProfile.Object);
+		Mock<ICulture> culture = new();
+		culture.Setup(x => x.NameCultureForGender(Gender.Male)).Returns(cultureNameCulture.Object);
+		Mock<IEthnicity> ethnicity = new();
+		ethnicity.Setup(x => x.NameCultureForGender(Gender.Male)).Returns(ethnicityNameCulture.Object);
+
+		IRandomNameProfile? result = VariableNPCTemplate.ResolveAutomaticNameProfile(culture.Object, ethnicity.Object, Gender.Male);
+
+		Assert.AreSame(ethnicityProfile.Object, result);
+	}
+
+	[TestMethod]
+	public void ResolveAutomaticNameProfile_EthnicityCultureMissing_FallsBackToCultureProfile()
+	{
+		Mock<IRandomNameProfile> cultureProfile = CreateProfile("Culture Profile", Gender.Female, true);
+		Mock<INameCulture> cultureNameCulture = CreateNameCulture(cultureProfile.Object);
+		Mock<ICulture> culture = new();
+		culture.Setup(x => x.NameCultureForGender(Gender.Female)).Returns(cultureNameCulture.Object);
+		Mock<IEthnicity> ethnicity = new();
+		ethnicity.Setup(x => x.NameCultureForGender(Gender.Female)).Returns((INameCulture)null!);
+
+		IRandomNameProfile? result = VariableNPCTemplate.ResolveAutomaticNameProfile(culture.Object, ethnicity.Object, Gender.Female);
+
+		Assert.AreSame(cultureProfile.Object, result);
+	}
+
+	[TestMethod]
+	public void BuilderCommands_CultureAndEthnicity_RefreshAutomaticNameProfiles()
+	{
+		string source = File.ReadAllText(GetSourcePath("MudSharpCore", "NPC", "Templates", "VariableNPCTemplate.cs"));
+		Assert.IsTrue(source.Contains("_culture = culture;") && source.Contains("RefreshAutomaticNameProfiles();"),
+			"Culture changes should immediately refresh auto-selected name profiles.");
+		Assert.IsTrue(source.Contains("_ethnicity = ethnicity;") && source.Contains("RefreshAutomaticNameProfiles();"),
+			"Ethnicity changes should immediately refresh auto-selected name profiles.");
+		Assert.IsFalse(source.Contains("_culture.NameCultureForGender(gender.Value).RandomNameProfiles"),
+			"Culture auto-fill should use the shared ethnicity-first automatic profile resolver.");
+	}
+
+	private static Mock<IRandomNameProfile> CreateProfile(string name, Gender profileGender, bool compatible)
+	{
+		Mock<IRandomNameProfile> mock = new();
+		mock.SetupGet(x => x.Name).Returns(name);
+		mock.SetupGet(x => x.Gender).Returns(profileGender);
+		mock.SetupGet(x => x.IsReady).Returns(true);
+		mock.Setup(x => x.IsCompatibleGender(It.IsAny<Gender>()))
+			.Returns<Gender>(gender => compatible && (profileGender == Gender.NonBinary || profileGender == Gender.Indeterminate || profileGender == gender));
+		return mock;
+	}
+
+	private static Mock<INameCulture> CreateNameCulture(params IRandomNameProfile[] profiles)
+	{
+		Mock<INameCulture> mock = new();
+		mock.SetupGet(x => x.RandomNameProfiles).Returns(profiles.ToList());
+		return mock;
+	}
+
+	private static string GetSourcePath(params string[] parts)
+	{
+		return Path.GetFullPath(Path.Combine(
+			AppContext.BaseDirectory,
+			"..",
+			"..",
+			"..",
+			"..",
+			Path.Combine(parts)));
+	}
+}

--- a/MudSharpCore/NPC/Templates/VariableNPCTemplate.cs
+++ b/MudSharpCore/NPC/Templates/VariableNPCTemplate.cs
@@ -117,6 +117,44 @@ public class VariableNPCTemplate : NPCTemplateBase
 
     public override string FrameworkItemType => "VariableNPCTemplate";
 
+    internal static INameCulture ResolveAutomaticNameCulture(ICulture culture, IEthnicity ethnicity, Gender gender)
+    {
+        return ethnicity?.NameCultureForGender(gender) ?? culture?.NameCultureForGender(gender);
+    }
+
+    internal static IRandomNameProfile ResolveAutomaticNameProfile(ICulture culture, IEthnicity ethnicity, Gender gender)
+    {
+        INameCulture nameCulture = ResolveAutomaticNameCulture(culture, ethnicity, gender);
+        return nameCulture?.RandomNameProfiles
+                          .Where(x => x.IsReady && x.IsCompatibleGender(gender))
+                          .GetRandomElement();
+    }
+
+    private void RefreshAutomaticNameProfiles()
+    {
+        foreach (Gender gender in _nameProfiles.Keys.Where(x => _genderChances.All(y => y.Value != x)).ToList())
+        {
+            _nameProfiles.Remove(gender);
+        }
+
+        if (_culture == null)
+        {
+            return;
+        }
+
+        foreach ((Gender Value, int Weight) gender in _genderChances)
+        {
+            IRandomNameProfile profile = ResolveAutomaticNameProfile(_culture, _ethnicity, gender.Value);
+            if (profile == null)
+            {
+                _nameProfiles.Remove(gender.Value);
+                continue;
+            }
+
+            _nameProfiles[gender.Value] = profile;
+        }
+    }
+
     private void LoadFromXml(XElement root)
     {
         XElement element = root.Element("GenderChances");
@@ -992,7 +1030,7 @@ public class VariableNPCTemplate : NPCTemplateBase
             }
         }
 
-        INameCulture nc = _ethnicity?.NameCultureForGender(gender) ?? _culture.NameCultureForGender(gender);
+        INameCulture nc = ResolveAutomaticNameCulture(_culture, _ethnicity, gender);
         if (nc != profile.Culture)
         {
             actor.OutputHandler.Send(
@@ -1065,10 +1103,7 @@ public class VariableNPCTemplate : NPCTemplateBase
             }
         }
 
-        foreach (Gender gender in _nameProfiles.Keys.Where(x => _genderChances.All(y => y.Value != x)).ToList())
-        {
-            _nameProfiles.Remove(gender);
-        }
+        RefreshAutomaticNameProfiles();
 
         _priorityAttributeDefinitions.RemoveAll(x => !_race.Attributes.Contains(x));
         Changed = true;
@@ -1099,26 +1134,7 @@ public class VariableNPCTemplate : NPCTemplateBase
         }
 
         _culture = culture;
-        _nameProfiles.Clear();
-        foreach ((Gender Value, int Weight) gender in _genderChances)
-        {
-            INameCulture nc =
-                _ethnicity?.NameCultureForGender(gender.Value) ??
-                _culture.NameCultureForGender(gender.Value);
-            if (_nameProfiles.ContainsKey(gender.Value) && nc == _nameProfiles[gender.Value].Culture)
-            {
-                continue;
-            }
-
-            IRandomNameProfile profile =
-                _culture.NameCultureForGender(gender.Value).RandomNameProfiles
-                        .Where(x => x.IsReady && x.IsCompatibleGender(gender.Value)).GetRandomElement();
-
-            if (profile != null)
-            {
-                _nameProfiles[gender.Value] = profile;
-            }
-        }
+        RefreshAutomaticNameProfiles();
 
         Changed = true;
         actor.OutputHandler.Send($"You set the culture of this NPC to {_culture.Name.Proper().Colour(Telnet.Cyan)}.");
@@ -1160,6 +1176,7 @@ public class VariableNPCTemplate : NPCTemplateBase
         }
 
         _ethnicity = ethnicity;
+        RefreshAutomaticNameProfiles();
         Changed = true;
         actor.OutputHandler.Send(
             $"You set the ethnicity of this NPC to {_ethnicity.Name.Proper().Colour(Telnet.Cyan)}.");


### PR DESCRIPTION
## Summary
- add fallback random name profiles for seeded name cultures that do not already have a ready usable profile
- map Medieval Europe ethnicities to existing name cultures so builders inherit usable random naming without manual repair
- fix human seeding order so default height/weight models exist before race defaults are assigned
- update variable NPC auto-fill to prefer ethnicity name cultures and refresh name profiles when race, culture, or ethnicity changes
- add regression coverage for fallback profiles, medieval ethnicity mappings, race height/weight defaults, and variable NPC naming resolution

## Testing
- `dotnet build DatabaseSeeder/DatabaseSeeder.csproj -c Debug -p:NoWarn=NU1902%3BNU1510`
- `dotnet build MudSharpCore/MudSharpCore.csproj -c Debug -p:NoWarn=NU1902%3BNU1510`
- `dotnet test 'DatabaseSeeder Unit Tests/DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore --filter "FullyQualifiedName~CultureSeederNameAndHeightDefaultTests"`
- `dotnet msbuild 'MudSharpCore Unit Tests/MudSharpCore Unit Tests.csproj' /t:Build /p:Configuration=Debug /p:NoWarn=NU1902 /m:1 /v:minimal`
- `dotnet vstest 'MudSharpCore Unit Tests/bin/Debug/net10.0/MudSharpCore Unit Tests.dll' --TestCaseFilter:"FullyQualifiedName~VariableNPCTemplateNameProfileTests"`
- full `DatabaseSeeder Unit Tests` run still shows unrelated pre-existing failures in `EconomySeederTests` and `SeederDisfigurementTemplateUtilityTests`