### PR TITLE
Add LegalClass FutureProg support and simplify law tier comparisons

### DIFF
--- a/DatabaseSeeder Unit Tests/SeederRepeatabilityHelperTests.cs
+++ b/DatabaseSeeder Unit Tests/SeederRepeatabilityHelperTests.cs
@@ -472,6 +472,10 @@ public class SeederRepeatabilityHelperTests
         Assert.IsFalse(murderAgainstInferiorLaw.PunishmentStrategy.Contains("type=\"execute\""));
         StringAssert.Contains(murderApplicabilityProg.FunctionText, "isnull(@victim)");
         StringAssert.Contains(murderAgainstInferiorApplicabilityProg.FunctionText, "isnull(@victim)");
+        StringAssert.Contains(murderApplicabilityProg.FunctionText, "LegalClassOutranks(@criminal, @victim, ToLegalAuthority(");
+        StringAssert.Contains(murderAgainstInferiorApplicabilityProg.FunctionText, "LegalClassOutranks(@criminal, @victim, ToLegalAuthority(");
+        Assert.IsFalse(murderApplicabilityProg.FunctionText.Contains("IsLegalClass", StringComparison.Ordinal));
+        Assert.IsFalse(murderAgainstInferiorApplicabilityProg.FunctionText.Contains("IsLegalClass", StringComparison.Ordinal));
 
         Law theftAgainstInferiorLaw = context.Laws.Single(x => x.Name == "Theft Against Inferior");
         StringAssert.Contains(theftAgainstInferiorLaw.PunishmentStrategy, "type=\"fine\"");

--- a/DatabaseSeeder/Seeders/LawSeeder.cs
+++ b/DatabaseSeeder/Seeders/LawSeeder.cs
@@ -20,22 +20,6 @@ public class LawSeeder : IDatabaseSeeder
         "Assault"
     ];
 
-    private static readonly string[] StockTierOrder =
-    [
-        "sovereign",
-        "noble",
-        "officer",
-        "soldier",
-        "enforcer",
-        "citizen",
-        "noncitizen",
-        "felon",
-        "criminal",
-        "slave",
-        "pet",
-        "other"
-    ];
-
     public FuturemudDatabaseContext Context { get; private set; }
     public IReadOnlyDictionary<string, string> QuestionAnswers { get; private set; }
     public string AuthorityName { get; private set; }
@@ -293,29 +277,7 @@ Please enter your penalty unit: ", (context, answers) => true,
 
     private string BuildTierComparisonText(bool offenderOutranksVictim)
     {
-        List<string> conditions = new();
-        List<string> availableClasses = StockTierOrder.Where(Classes.ContainsKey).ToList();
-
-        for (int i = 0; i < availableClasses.Count; i++)
-        {
-            List<string> lowerClasses = availableClasses.Skip(i + 1).ToList();
-            if (!lowerClasses.Any())
-            {
-                continue;
-            }
-
-            string offenderCheck = $"{ProgLookup[$"is{availableClasses[i]}"].FunctionName}(@criminal)";
-            string victimCheck = string.Join(" or ",
-                lowerClasses.Select(x => $"{ProgLookup[$"is{x}"].FunctionName}(@victim)"));
-            conditions.Add($"({offenderCheck} and ({victimCheck}))");
-        }
-
-        if (!conditions.Any())
-        {
-            return $"return {(offenderOutranksVictim ? "false" : "true")}";
-        }
-
-        string outranksCheck = string.Join(" or ", conditions);
+        string outranksCheck = $"LegalClassOutranks(@criminal, @victim, ToLegalAuthority({Authority.Id}))";
         return $@"if (isnull(@victim))
   return false
 end if

--- a/Design Documents/FutureProg_Type_System.md
+++ b/Design Documents/FutureProg_Type_System.md
@@ -21,6 +21,7 @@ The following usage patterns are intentionally preserved:
 It provides:
 
 - static readonly fields for all legacy concrete types and aliases
+- overflow-era exact types such as `ProgVariableTypes.LegalClass` that are no longer constrained by the legacy 64-bit enum bridge
 - bitwise operators `|`, `&`, `^`, `~`
 - equality operators `==`, `!=`
 - compatibility helpers such as `HasFlag(...)`, `CompatibleWith(...)`
@@ -45,6 +46,8 @@ The engine also keeps a legacy enum bridge, `ProgVariableTypeCode`, for two comp
 - legacy-style exact switching in places where a direct `switch` over constants is still the clearest shape
 
 `ProgVariableTypes.LegacyCode` returns a matching `ProgVariableTypeCode` when the value is still representable as a legacy 64-bit value; otherwise it returns `Unknown`.
+
+New exact types added after the legacy bit range, such as `LegalClass`, should generally be handled with `type.ExactKind`, `type == ProgVariableTypes.SomeType`, or other `ProgVariableTypes`-native checks rather than relying on `LegacyCode` switches.
 
 ## Registry
 

--- a/FutureMUDLibrary/FutureProg/ProgTypeKind.cs
+++ b/FutureMUDLibrary/FutureProg/ProgTypeKind.cs
@@ -62,7 +62,8 @@ public enum ProgTypeKind
     Market,
     MarketCategory,
     LiquidMixture,
-    Script,
-    Writing,
-    Area
+	Script,
+	Writing,
+	Area,
+	LegalClass
 }

--- a/FutureMUDLibrary/FutureProg/ProgVariableTypeRegistry.cs
+++ b/FutureMUDLibrary/FutureProg/ProgVariableTypeRegistry.cs
@@ -96,9 +96,10 @@ public static class ProgVariableTypeRegistry
         RegisterExact(ProgTypeKind.Market, ProgVariableTypes.Market, "Market", "market");
         RegisterExact(ProgTypeKind.MarketCategory, ProgVariableTypes.MarketCategory, "MarketCategory", "marketcategory");
         RegisterExact(ProgTypeKind.LiquidMixture, ProgVariableTypes.LiquidMixture, "LiquidMixture", "liquidmixture");
-        RegisterExact(ProgTypeKind.Script, ProgVariableTypes.Script, "Script", "script");
-        RegisterExact(ProgTypeKind.Writing, ProgVariableTypes.Writing, "Writing", "writing");
-        RegisterExact(ProgTypeKind.Area, ProgVariableTypes.Area, "Area", "area");
+		RegisterExact(ProgTypeKind.Script, ProgVariableTypes.Script, "Script", "script");
+		RegisterExact(ProgTypeKind.Writing, ProgVariableTypes.Writing, "Writing", "writing");
+		RegisterExact(ProgTypeKind.Area, ProgVariableTypes.Area, "Area", "area");
+		RegisterExact(ProgTypeKind.LegalClass, ProgVariableTypes.LegalClass, "LegalClass", "legalclass");
 
         RegisterNamed(ProgVariableTypes.CollectionItem, "CollectionItem", false, "collectionitem");
         RegisterNamed(ProgVariableTypes.Perceivable, "Perceivable", false, "perceivable");

--- a/FutureMUDLibrary/FutureProg/ProgVariableTypes.cs
+++ b/FutureMUDLibrary/FutureProg/ProgVariableTypes.cs
@@ -82,17 +82,19 @@ public readonly struct ProgVariableTypes : IEquatable<ProgVariableTypes>
     public static readonly ProgVariableTypes Market = FromLegacyBitIndex(57);
     public static readonly ProgVariableTypes MarketCategory = FromLegacyBitIndex(58);
     public static readonly ProgVariableTypes LiquidMixture = FromLegacyBitIndex(59);
-    public static readonly ProgVariableTypes Script = FromLegacyBitIndex(60);
-    public static readonly ProgVariableTypes Writing = FromLegacyBitIndex(61);
-    public static readonly ProgVariableTypes Area = FromLegacyBitIndex(62);
+	public static readonly ProgVariableTypes Script = FromLegacyBitIndex(60);
+	public static readonly ProgVariableTypes Writing = FromLegacyBitIndex(61);
+	public static readonly ProgVariableTypes Area = FromLegacyBitIndex(62);
+	public static readonly ProgVariableTypes LegalClass = FromLegacyBitIndex(63);
 
     public static readonly ProgVariableTypes CollectionItem =
         Number | Boolean | Gender | Text | DateTime | TimeSpan | Character | Item | Chargen | Location | Zone |
         Shard | Accent | Language | Race | Culture | Trait | Clan | ClanRank | ClanAppointment | ClanPaygrade |
         Currency | Exit | Merit | MudDateTime | Calendar | Clock | Effect | Knowledge | Role | Ethnicity | Drug |
-        WeatherEvent | Shop | Merchandise | Outfit | OutfitItem | OverlayPackage | Terrain | Project | Solid |
-        Liquid | Gas | MagicSchool | MagicCapability | MagicSpell | Bank | BankAccount | BankAccountType |
-        LegalAuthority | Law | Crime | Market | MarketCategory | LiquidMixture | Script | Writing | Area;
+		WeatherEvent | Shop | Merchandise | Outfit | OutfitItem | OverlayPackage | Terrain | Project | Solid |
+		Liquid | Gas | MagicSchool | MagicCapability | MagicSpell | Bank | BankAccount | BankAccountType |
+		LegalAuthority | Law | Crime | Market | MarketCategory | LiquidMixture | Script | Writing | Area |
+		LegalClass;
 
     public static readonly ProgVariableTypes Perceivable = Item | Character | Location | Zone | Shard;
     public static readonly ProgVariableTypes Perceiver = Item | Character;

--- a/FutureMUDLibrary/RPG/Law/ILegalClass.cs
+++ b/FutureMUDLibrary/RPG/Law/ILegalClass.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace MudSharp.RPG.Law
 {
-    public interface ILegalClass : IFrameworkItem, ISaveable, IEditableItem
+    public interface ILegalClass : IFrameworkItem, ISaveable, IEditableItem, IProgVariable
     {
         ILegalAuthority Authority { get; }
         int LegalClassPriority { get; }

--- a/MudSharpCore Unit Tests/LegalClassFutureProgTests.cs
+++ b/MudSharpCore Unit Tests/LegalClassFutureProgTests.cs
@@ -1,0 +1,249 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Character;
+using MudSharp.Commands.Modules;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.FutureProg.Variables;
+using MudSharp.PerceptionEngine;
+using MudSharp.RPG.Law;
+using System;
+using System.Collections.Generic;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class LegalClassFutureProgTests
+{
+	[ClassInitialize]
+	public static void ClassInitialise(TestContext _)
+	{
+		FutureProgTestBootstrap.EnsureInitialised();
+	}
+
+	[TestMethod]
+	public void LegalClassDotReference_ShouldExposeExpectedProperties()
+	{
+		FutureProgVariableCompileInfo compileInfo = ProgVariable.DotReferenceCompileInfos[ProgVariableTypes.LegalClass];
+
+		Assert.AreEqual(ProgVariableTypes.Number, compileInfo.PropertyTypeMap["id"]);
+		Assert.AreEqual(ProgVariableTypes.Text, compileInfo.PropertyTypeMap["name"]);
+		Assert.AreEqual(ProgVariableTypes.LegalAuthority, compileInfo.PropertyTypeMap["legalauthority"]);
+		Assert.AreEqual(ProgVariableTypes.Number, compileInfo.PropertyTypeMap["priority"]);
+		Assert.AreEqual(ProgVariableTypes.Boolean, compileInfo.PropertyTypeMap["canbedetaineduntilfinespaid"]);
+	}
+
+	[TestMethod]
+	public void ToLegalClass_NumberLookup_ShouldResolveLegalClass()
+	{
+		var authority = CreateLegalAuthorityMock(7L, "Test Authority");
+		var legalClass = CreateLegalClassMock(101L, "Citizen", authority.Object, 10, false);
+		var gameworld = CreateGameworld([authority.Object], [legalClass.Object]);
+
+		FutureProg prog = CompileProg(
+			gameworld.Object,
+			"LegalClassNumberLookup",
+			ProgVariableTypes.Number,
+			Array.Empty<Tuple<ProgVariableTypes, string>>(),
+			"return ToLegalClass(101).Priority");
+
+		Assert.AreEqual(10.0m, prog.Execute<decimal>());
+	}
+
+	[TestMethod]
+	public void ToLegalClass_AuthorityScopedNameLookup_ShouldResolveLegalClass()
+	{
+		var authority = CreateLegalAuthorityMock(7L, "Test Authority");
+		var legalClass = CreateLegalClassMock(101L, "Citizen", authority.Object, 10, false);
+		authority.SetupGet(x => x.LegalClasses).Returns([legalClass.Object]);
+		var gameworld = CreateGameworld([authority.Object], [legalClass.Object]);
+
+		FutureProg prog = CompileProg(
+			gameworld.Object,
+			"LegalClassNameLookup",
+			ProgVariableTypes.Text,
+			[Tuple.Create(ProgVariableTypes.LegalAuthority, "authority")],
+			"""return ToLegalClass("Citizen", @authority).Name""");
+
+		Assert.AreEqual("Citizen", prog.ExecuteString(authority.Object));
+	}
+
+	[TestMethod]
+	public void GetLegalClass_AndPriority_ShouldResolveFromAuthority()
+	{
+		var authority = CreateLegalAuthorityMock(7L, "Test Authority");
+		var legalClass = CreateLegalClassMock(101L, "Citizen", authority.Object, 10, false);
+		var character = CreateCharacterMock(1L, "Test Citizen");
+		authority.Setup(x => x.GetLegalClass(character.Object)).Returns(legalClass.Object);
+		var gameworld = CreateGameworld([authority.Object], [legalClass.Object]);
+
+		FutureProg prog = CompileProg(
+			gameworld.Object,
+			"LegalClassCharacterLookup",
+			ProgVariableTypes.Number,
+			[
+				Tuple.Create(ProgVariableTypes.Character, "ch"),
+				Tuple.Create(ProgVariableTypes.LegalAuthority, "authority")
+			],
+			"return GetLegalClass(@ch, @authority).Priority");
+
+		Assert.AreEqual(10.0m, prog.Execute<decimal>(character.Object, authority.Object));
+	}
+
+	[TestMethod]
+	public void LegalClassOutranks_ShouldCompareResolvedCharacterPriorities()
+	{
+		var authority = CreateLegalAuthorityMock(7L, "Test Authority");
+		var sovereign = CreateLegalClassMock(100L, "Sovereign", authority.Object, 100, false);
+		var citizen = CreateLegalClassMock(101L, "Citizen", authority.Object, 10, false);
+		var criminal = CreateCharacterMock(1L, "Criminal");
+		var victim = CreateCharacterMock(2L, "Victim");
+		authority.Setup(x => x.GetLegalClass(criminal.Object)).Returns(sovereign.Object);
+		authority.Setup(x => x.GetLegalClass(victim.Object)).Returns(citizen.Object);
+		var gameworld = CreateGameworld([authority.Object], [sovereign.Object, citizen.Object]);
+
+		FutureProg prog = CompileProg(
+			gameworld.Object,
+			"LegalClassOutranksCharacterLookup",
+			ProgVariableTypes.Boolean,
+			[
+				Tuple.Create(ProgVariableTypes.Character, "criminal"),
+				Tuple.Create(ProgVariableTypes.Character, "victim"),
+				Tuple.Create(ProgVariableTypes.LegalAuthority, "authority")
+			],
+			"return LegalClassOutranks(@criminal, @victim, @authority)");
+
+		Assert.IsTrue(prog.ExecuteBool(criminal.Object, victim.Object, authority.Object));
+	}
+
+	[TestMethod]
+	public void ProgModuleGetArgument_ShouldResolveLegalAuthorityAndLegalClass()
+	{
+		var authority = CreateLegalAuthorityMock(7L, "Test Authority");
+		var legalClass = CreateLegalClassMock(101L, "Citizen", authority.Object, 10, false);
+		var gameworld = CreateGameworld([authority.Object], [legalClass.Object]);
+		var actor = CreateActorForProgModule(gameworld.Object);
+
+		(object authorityResult, bool authoritySuccess) =
+			ProgModule.GetArgument(ProgVariableTypes.LegalAuthority, "Test Authority", 1, actor.Object);
+		(object legalClassResult, bool legalClassSuccess) =
+			ProgModule.GetArgument(ProgVariableTypes.LegalClass, "Citizen", 2, actor.Object);
+
+		Assert.IsTrue(authoritySuccess);
+		Assert.IsTrue(legalClassSuccess);
+		Assert.AreSame(authority.Object, authorityResult);
+		Assert.AreSame(legalClass.Object, legalClassResult);
+	}
+
+	private static FutureProg CompileProg(
+		IFuturemud gameworld,
+		string name,
+		ProgVariableTypes returnType,
+		IEnumerable<Tuple<ProgVariableTypes, string>> parameters,
+		string functionText)
+	{
+		FutureProg prog = new(gameworld, name, returnType, parameters, functionText);
+		prog.Compile();
+		Assert.IsTrue(string.IsNullOrEmpty(prog.CompileError), prog.CompileError);
+		return prog;
+	}
+
+	private static Mock<IFuturemud> CreateGameworld(
+		IEnumerable<ILegalAuthority> legalAuthorities,
+		IEnumerable<ILegalClass> legalClasses)
+	{
+		All<ILegalAuthority> authorityCollection = new();
+		foreach (var authority in legalAuthorities)
+		{
+			authorityCollection.Add(authority);
+		}
+
+		All<ILegalClass> legalClassCollection = new();
+		foreach (var legalClass in legalClasses)
+		{
+			legalClassCollection.Add(legalClass);
+		}
+
+		Mock<IFuturemud> gameworld = new();
+		gameworld.SetupGet(x => x.LegalAuthorities).Returns(authorityCollection);
+		gameworld.SetupGet(x => x.LegalClasses).Returns(legalClassCollection);
+		return gameworld;
+	}
+
+	private static Mock<ILegalAuthority> CreateLegalAuthorityMock(long id, string name)
+	{
+		Mock<ILegalAuthority> mock = new();
+		mock.SetupGet(x => x.Id).Returns(id);
+		mock.SetupGet(x => x.Name).Returns(name);
+		mock.SetupGet(x => x.FrameworkItemType).Returns("LegalAuthority");
+		mock.SetupGet(x => x.LegalClasses).Returns(Array.Empty<ILegalClass>());
+		mock.Setup(x => x.GetProperty(It.IsAny<string>())).Returns((string property) => property.ToLowerInvariant() switch
+		{
+			"id" => new NumberVariable(id),
+			"name" => new TextVariable(name),
+			_ => throw new ApplicationException($"Unexpected legal authority property {property}")
+		});
+		mock.SetupGet(x => x.Type).Returns(ProgVariableTypes.LegalAuthority);
+		mock.SetupGet(x => x.GetObject).Returns(() => mock.Object);
+		return mock;
+	}
+
+	private static Mock<ILegalClass> CreateLegalClassMock(
+		long id,
+		string name,
+		ILegalAuthority authority,
+		int priority,
+		bool canBeDetainedUntilFinesPaid)
+	{
+		Mock<ILegalClass> mock = new();
+		mock.SetupGet(x => x.Id).Returns(id);
+		mock.SetupGet(x => x.Name).Returns(name);
+		mock.SetupGet(x => x.FrameworkItemType).Returns("LegalClass");
+		mock.SetupGet(x => x.Authority).Returns(authority);
+		mock.SetupGet(x => x.LegalClassPriority).Returns(priority);
+		mock.SetupGet(x => x.CanBeDetainedUntilFinesPaid).Returns(canBeDetainedUntilFinesPaid);
+		mock.Setup(x => x.GetProperty(It.IsAny<string>())).Returns((string property) => property.ToLowerInvariant() switch
+		{
+			"id" => new NumberVariable(id),
+			"name" => new TextVariable(name),
+			"legalauthority" => authority,
+			"priority" => new NumberVariable(priority),
+			"canbedetaineduntilfinespaid" => new BooleanVariable(canBeDetainedUntilFinesPaid),
+			_ => throw new ApplicationException($"Unexpected legal class property {property}")
+		});
+		mock.SetupGet(x => x.Type).Returns(ProgVariableTypes.LegalClass);
+		mock.SetupGet(x => x.GetObject).Returns(() => mock.Object);
+		return mock;
+	}
+
+	private static Mock<ICharacter> CreateCharacterMock(long id, string name)
+	{
+		Mock<ICharacter> mock = new();
+		mock.SetupGet(x => x.Id).Returns(id);
+		mock.SetupGet(x => x.Name).Returns(name);
+		mock.SetupGet(x => x.FrameworkItemType).Returns("Character");
+		mock.Setup(x => x.GetProperty(It.IsAny<string>())).Returns((IProgVariable?)null);
+		mock.SetupGet(x => x.Type).Returns(ProgVariableTypes.Character);
+		mock.SetupGet(x => x.GetObject).Returns(() => mock.Object);
+		return mock;
+	}
+
+	private static Mock<ICharacter> CreateActorForProgModule(IFuturemud gameworld)
+	{
+		Mock<IOutputHandler> output = new();
+		output.Setup(x => x.Send(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>())).Returns(true);
+
+		Mock<ICharacter> actor = new();
+		actor.SetupGet(x => x.Gameworld).Returns(gameworld);
+		actor.SetupGet(x => x.OutputHandler).Returns(output.Object);
+		actor.SetupGet(x => x.Id).Returns(500L);
+		actor.SetupGet(x => x.Name).Returns("Builder");
+		actor.SetupGet(x => x.FrameworkItemType).Returns("Character");
+		actor.Setup(x => x.GetProperty(It.IsAny<string>())).Returns((IProgVariable?)null);
+		actor.SetupGet(x => x.Type).Returns(ProgVariableTypes.Character);
+		actor.SetupGet(x => x.GetObject).Returns(() => actor.Object);
+		return actor;
+	}
+}

--- a/MudSharpCore Unit Tests/ProgVariableTypesTests.cs
+++ b/MudSharpCore Unit Tests/ProgVariableTypesTests.cs
@@ -20,12 +20,13 @@ public class ProgVariableTypesTests
     [TestMethod]
     public void StorageString_OverflowType_RoundTrips()
     {
-        const string definition = "v1:800000000000000000";
+        string definition = ProgVariableTypes.LegalClass.ToStorageString();
 
         ProgVariableTypes parsed = ProgVariableTypes.FromStorageString(definition);
 
         Assert.AreEqual(definition, parsed.ToStorageString());
         Assert.AreEqual(ProgVariableTypeCode.Unknown, parsed.LegacyCode);
+        Assert.AreEqual(ProgTypeKind.LegalClass, parsed.ExactKind);
     }
 
     [TestMethod]
@@ -60,6 +61,9 @@ public class ProgVariableTypesTests
         Assert.IsTrue(ProgVariableTypes.TryParse("Terrain", out ProgVariableTypes terrain));
         Assert.AreEqual(ProgVariableTypes.Terrain, terrain);
 
+        Assert.IsTrue(ProgVariableTypes.TryParse("LegalClass", out ProgVariableTypes legalClass));
+        Assert.AreEqual(ProgVariableTypes.LegalClass, legalClass);
+
         Assert.IsTrue(ProgVariableTypes.TryParse("4398046511104", out ProgVariableTypes terrainFromLegacy));
         Assert.AreEqual(ProgVariableTypes.Terrain, terrainFromLegacy);
 
@@ -68,6 +72,12 @@ public class ProgVariableTypesTests
 
         Assert.IsTrue(ProgVariableTypes.TryParse("v1:408", out ProgVariableTypes storageType));
         Assert.AreEqual(ProgVariableTypes.Character | ProgVariableTypes.Collection, storageType);
+
+        Assert.IsTrue(ProgVariableTypes.ReferenceType.HasFlag(ProgVariableTypes.LegalClass));
+        Assert.IsTrue(ProgVariableTypes.CollectionItem.HasFlag(ProgVariableTypes.LegalClass));
+        Assert.IsTrue(ProgVariableTypes.Anything.HasFlag(ProgVariableTypes.LegalClass));
+        Assert.AreEqual("LegalClass", ProgVariableTypes.LegalClass.Describe());
+        Assert.AreEqual(ProgTypeKind.LegalClass, (ProgVariableTypes.LegalClass | ProgVariableTypes.Collection).ElementKind);
     }
 
     [TestMethod]

--- a/MudSharpCore/Commands/Modules/ProgModule.cs
+++ b/MudSharpCore/Commands/Modules/ProgModule.cs
@@ -615,6 +615,11 @@ A function (See PROG HELP FUNCTIONS) can also function as a statement on a line.
             return sb.ToString();
         }
 
+        if (returnType == ProgVariableTypes.LegalClass)
+        {
+            return $"the {((IFrameworkItem)result).Name.ColourValue()} legal class";
+        }
+
         switch (returnType.LegacyCode)
         {
             case ProgVariableTypeCode.Boolean:
@@ -866,6 +871,18 @@ A function (See PROG HELP FUNCTIONS) can also function as a statement on a line.
         }
 
         string parameterArgument = parNumber > 0 ? $" at parameter {parNumber.ToString("N0", actor)}" : "";
+
+        if (type == ProgVariableTypes.LegalClass)
+        {
+            ILegalClass legalClass = actor.Gameworld.LegalClasses.GetByIdOrName(parText);
+            if (legalClass is null)
+            {
+                actor.OutputHandler.Send($"There is no such legal class{parameterArgument}");
+                return (null, false);
+            }
+
+            return (legalClass, true);
+        }
 
         switch (type.LegacyCode)
         {
@@ -1282,7 +1299,7 @@ A function (See PROG HELP FUNCTIONS) can also function as a statement on a line.
 
                 return (gas, true);
             case ProgVariableTypeCode.LegalAuthority:
-                ICellOverlayPackage legal = actor.Gameworld.CellOverlayPackages.GetByIdOrName(parText);
+                ILegalAuthority legal = actor.Gameworld.LegalAuthorities.GetByIdOrName(parText);
                 if (legal is null)
                 {
                     actor.OutputHandler.Send($"There is no such legal authority{parameterArgument}");

--- a/MudSharpCore/FutureProg/Functions/BuiltIn/ToLegalClassFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/BuiltIn/ToLegalClassFunction.cs
@@ -1,0 +1,77 @@
+using MudSharp.Framework;
+using MudSharp.FutureProg.Variables;
+using MudSharp.RPG.Law;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MudSharp.FutureProg.Functions.BuiltIn;
+
+internal class ToLegalClassFunction : BuiltInFunction
+{
+	private readonly IFuturemud _gameworld;
+
+	protected ToLegalClassFunction(IList<IFunction> parameters, IFuturemud gameworld)
+		: base(parameters)
+	{
+		_gameworld = gameworld;
+	}
+
+	public override ProgVariableTypes ReturnType
+	{
+		get => ProgVariableTypes.LegalClass;
+		protected set { }
+	}
+
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		if (base.Execute(variables) == StatementResult.Error)
+		{
+			return StatementResult.Error;
+		}
+
+		ILegalClass result = null;
+		if (ParameterFunctions.Count == 1)
+		{
+			result = _gameworld.LegalClasses.Get((long)(decimal)ParameterFunctions[0].Result.GetObject);
+		}
+		else
+		{
+			var authority = ParameterFunctions[1].Result?.GetObject as ILegalAuthority;
+			if (authority is not null)
+			{
+				var text = (string)ParameterFunctions[0].Result.GetObject;
+				result = authority.LegalClasses.FirstOrDefault(x => x.Name.EqualTo(text));
+			}
+		}
+
+		Result = result is not null
+			? result
+			: new NullVariable(ReturnType);
+		return StatementResult.Normal;
+	}
+
+	public static void RegisterFunctionCompiler()
+	{
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			"tolegalclass",
+			[ProgVariableTypes.Number],
+			(pars, gameworld) => new ToLegalClassFunction(pars, gameworld),
+			["id"],
+			["The ID to look up"],
+			"Converts an ID number into a legal class, if one exists",
+			"Lookup",
+			ProgVariableTypes.LegalClass
+		));
+
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			"tolegalclass",
+			[ProgVariableTypes.Text, ProgVariableTypes.LegalAuthority],
+			(pars, gameworld) => new ToLegalClassFunction(pars, gameworld),
+			["name", "legalauthority"],
+			["The legal class name to look up", "The legal authority that scopes the lookup"],
+			"Converts a name within a legal authority into a legal class, if one exists",
+			"Lookup",
+			ProgVariableTypes.LegalClass
+		));
+	}
+}

--- a/MudSharpCore/FutureProg/Functions/Crime/GetLegalClassFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Crime/GetLegalClassFunction.cs
@@ -1,0 +1,62 @@
+using MudSharp.Character;
+using MudSharp.Framework;
+using MudSharp.FutureProg.Variables;
+using MudSharp.RPG.Law;
+using System.Collections.Generic;
+
+namespace MudSharp.FutureProg.Functions.Crime;
+
+internal class GetLegalClassFunction : BuiltInFunction
+{
+	protected GetLegalClassFunction(IList<IFunction> parameterFunctions, IFuturemud gameworld) : base(parameterFunctions)
+	{
+	}
+
+	public override ProgVariableTypes ReturnType
+	{
+		get => ProgVariableTypes.LegalClass;
+		protected set { }
+	}
+
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		if (base.Execute(variables) == StatementResult.Error)
+		{
+			return StatementResult.Error;
+		}
+
+		if (ParameterFunctions[0].Result?.GetObject is not ICharacter character)
+		{
+			Result = new NullVariable(ReturnType);
+			return StatementResult.Normal;
+		}
+
+		var authority = ParameterFunctions[1].Result?.GetObject as ILegalAuthority;
+		if (authority is null)
+		{
+			Result = new NullVariable(ReturnType);
+			return StatementResult.Normal;
+		}
+
+		Result = authority.GetLegalClass(character) is { } legalClass
+			? legalClass
+			: new NullVariable(ReturnType);
+		return StatementResult.Normal;
+	}
+
+	public static void RegisterFunctionCompiler()
+	{
+		FutureProg.RegisterBuiltInFunctionCompiler(
+			new FunctionCompilerInformation(
+				"getlegalclass",
+				[ProgVariableTypes.Character, ProgVariableTypes.LegalAuthority],
+				(pars, gameworld) => new GetLegalClassFunction(pars, gameworld),
+				["character", "authority"],
+				["The character whose legal class you want to check", "The legal authority to check in"],
+				"Returns the legal class a character belongs to in the specified legal authority",
+				"Crime",
+				ProgVariableTypes.LegalClass
+			)
+		);
+	}
+}

--- a/MudSharpCore/FutureProg/Functions/Crime/LegalClassOutranksFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Crime/LegalClassOutranksFunction.cs
@@ -1,0 +1,87 @@
+using MudSharp.Character;
+using MudSharp.Framework;
+using MudSharp.FutureProg.Variables;
+using MudSharp.RPG.Law;
+using System.Collections.Generic;
+
+namespace MudSharp.FutureProg.Functions.Crime;
+
+internal class LegalClassOutranksFunction : BuiltInFunction
+{
+	protected LegalClassOutranksFunction(IList<IFunction> parameterFunctions, IFuturemud gameworld) : base(parameterFunctions)
+	{
+	}
+
+	public override ProgVariableTypes ReturnType
+	{
+		get => ProgVariableTypes.Boolean;
+		protected set { }
+	}
+
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		if (base.Execute(variables) == StatementResult.Error)
+		{
+			return StatementResult.Error;
+		}
+
+		ILegalClass offenderClass = null;
+		ILegalClass victimClass = null;
+
+		if (ParameterFunctions.Count == 2)
+		{
+			offenderClass = ParameterFunctions[0].Result?.GetObject as ILegalClass;
+			victimClass = ParameterFunctions[1].Result?.GetObject as ILegalClass;
+		}
+		else
+		{
+			var offender = ParameterFunctions[0].Result?.GetObject as ICharacter;
+			var victim = ParameterFunctions[1].Result?.GetObject as ICharacter;
+			var authority = ParameterFunctions[2].Result?.GetObject as ILegalAuthority;
+
+			if (offender is null || victim is null || authority is null)
+			{
+				Result = new BooleanVariable(false);
+				return StatementResult.Normal;
+			}
+
+			offenderClass = authority.GetLegalClass(offender);
+			victimClass = authority.GetLegalClass(victim);
+		}
+
+		Result = new BooleanVariable(
+			offenderClass is not null &&
+			victimClass is not null &&
+			offenderClass.LegalClassPriority > victimClass.LegalClassPriority);
+		return StatementResult.Normal;
+	}
+
+	public static void RegisterFunctionCompiler()
+	{
+		FutureProg.RegisterBuiltInFunctionCompiler(
+			new FunctionCompilerInformation(
+				"legalclassoutranks",
+				[ProgVariableTypes.LegalClass, ProgVariableTypes.LegalClass],
+				(pars, gameworld) => new LegalClassOutranksFunction(pars, gameworld),
+				["offenderclass", "victimclass"],
+				["The legal class to test as the higher-ranked side", "The legal class to test as the lower-ranked side"],
+				"Returns true if the first legal class outranks the second legal class",
+				"Crime",
+				ProgVariableTypes.Boolean
+			)
+		);
+
+		FutureProg.RegisterBuiltInFunctionCompiler(
+			new FunctionCompilerInformation(
+				"legalclassoutranks",
+				[ProgVariableTypes.Character, ProgVariableTypes.Character, ProgVariableTypes.LegalAuthority],
+				(pars, gameworld) => new LegalClassOutranksFunction(pars, gameworld),
+				["offender", "victim", "authority"],
+				["The offender to evaluate", "The victim to evaluate", "The legal authority to resolve the legal classes in"],
+				"Returns true if the first character's legal class outranks the second character's legal class in the specified authority",
+				"Crime",
+				ProgVariableTypes.Boolean
+			)
+		);
+	}
+}

--- a/MudSharpCore/FutureProg/FutureProg.cs
+++ b/MudSharpCore/FutureProg/FutureProg.cs
@@ -741,11 +741,11 @@ public class FutureProg : SaveableItem, IFutureProg
                 : $"\"{functionName}\" is not a valid built in function", null);
     }
 
-    public static IProgVariable GetVariable(ProgVariableTypes type, object value)
-    {
-        if (value == null)
-        {
-            return new NullVariable(type);
+	public static IProgVariable GetVariable(ProgVariableTypes type, object value)
+	{
+		if (value == null)
+		{
+			return new NullVariable(type);
         }
 
         if (type.HasFlag(ProgVariableTypes.Collection))
@@ -784,20 +784,25 @@ public class FutureProg : SaveableItem, IFutureProg
 
         }
 
-        if (type.HasFlag(ProgVariableTypes.CollectionDictionary))
-        {
-            ProgVariableTypes underlyingType = type ^ ProgVariableTypes.CollectionDictionary;
-            if (value is not ICollectionDictionaryWithKey<string> cdString)
-            {
+		if (type.HasFlag(ProgVariableTypes.CollectionDictionary))
+		{
+			ProgVariableTypes underlyingType = type ^ ProgVariableTypes.CollectionDictionary;
+			if (value is not ICollectionDictionaryWithKey<string> cdString)
+			{
                 return new CollectionDictionaryVariable(new CollectionDictionary<string, IProgVariable>(), underlyingType);
             }
 
-            IEnumerable<KeyValuePair<string, List<IProgVariable>>> values = cdString.KeysAndValues.Select(x => new KeyValuePair<string, List<IProgVariable>>(x.Key, x.Value.Select(y => GetVariable(underlyingType, y)).ToList()));
-            return new CollectionDictionaryVariable(new CollectionDictionary<string, IProgVariable>(values), underlyingType);
-        }
+			IEnumerable<KeyValuePair<string, List<IProgVariable>>> values = cdString.KeysAndValues.Select(x => new KeyValuePair<string, List<IProgVariable>>(x.Key, x.Value.Select(y => GetVariable(underlyingType, y)).ToList()));
+			return new CollectionDictionaryVariable(new CollectionDictionary<string, IProgVariable>(values), underlyingType);
+		}
 
-        switch (type.LegacyCode)
-        {
+		if (type == ProgVariableTypes.LegalClass)
+		{
+			return value as IProgVariable;
+		}
+
+		switch (type.LegacyCode)
+		{
             case ProgVariableTypeCode.Text:
                 if (value is Enum evalue)
                 {
@@ -1123,10 +1128,15 @@ public class FutureProg : SaveableItem, IFutureProg
             return sb.ToString();
         }
 
-        ProgVariableTypes type = variable.Type & ~ProgVariableTypes.Literal;
-        IFrameworkItem thing = variable.GetObject as IFrameworkItem;
-        switch (type.LegacyCode)
-        {
+		ProgVariableTypes type = variable.Type & ~ProgVariableTypes.Literal;
+		IFrameworkItem thing = variable.GetObject as IFrameworkItem;
+		if (type == ProgVariableTypes.LegalClass)
+		{
+			return $"Legal Class #{thing.Id} - {thing.Name}";
+		}
+
+		switch (type.LegacyCode)
+		{
             case ProgVariableTypeCode.Text:
                 return $"\"{variable.GetObject}\"";
             case ProgVariableTypeCode.Number:

--- a/MudSharpCore/FutureProg/VariableRegister.cs
+++ b/MudSharpCore/FutureProg/VariableRegister.cs
@@ -636,10 +636,15 @@ internal class VariableRegister : SaveableItem, IVariableRegister
 
         #region IVariableValue Members
 
-        public IProgVariable GetVariable(IFuturemud game)
-        {
-            switch (Type.LegacyCode)
-            {
+		public IProgVariable GetVariable(IFuturemud game)
+		{
+			if (Type == ProgVariableTypes.LegalClass)
+			{
+				return game.LegalClasses.Get(ID);
+			}
+
+			switch (Type.LegacyCode)
+			{
                 case ProgVariableTypeCode.Character:
                     return game.TryGetCharacter(ID, true);
                 case ProgVariableTypeCode.Item:

--- a/MudSharpCore/RPG/Law/LegalClass.cs
+++ b/MudSharpCore/RPG/Law/LegalClass.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace MudSharp.RPG.Law;
 
-public class LegalClass : SaveableItem, ILegalClass
+public partial class LegalClass : SaveableItem, ILegalClass
 {
     public override string FrameworkItemType => "LegalClass";
 

--- a/MudSharpCore/RPG/Law/LegalClassProgs.cs
+++ b/MudSharpCore/RPG/Law/LegalClassProgs.cs
@@ -1,0 +1,55 @@
+using MudSharp.FutureProg;
+using MudSharp.FutureProg.Variables;
+using System;
+using System.Collections.Generic;
+
+namespace MudSharp.RPG.Law;
+
+public partial class LegalClass
+{
+	public ProgVariableTypes Type => ProgVariableTypes.LegalClass;
+	public object GetObject => this;
+
+	public IProgVariable GetProperty(string property)
+	{
+		return property.ToLowerInvariant() switch
+		{
+			"id" => new NumberVariable(Id),
+			"name" => new TextVariable(Name),
+			"legalauthority" => Authority,
+			"priority" => new NumberVariable(LegalClassPriority),
+			"canbedetaineduntilfinespaid" => new BooleanVariable(CanBeDetainedUntilFinesPaid),
+			_ => throw new ApplicationException($"Invalid property {property} requested in LegalClass.GetProperty")
+		};
+	}
+
+	private static IReadOnlyDictionary<string, ProgVariableTypes> DotReferenceHandler()
+	{
+		return new Dictionary<string, ProgVariableTypes>(StringComparer.InvariantCultureIgnoreCase)
+		{
+			{ "id", ProgVariableTypes.Number },
+			{ "name", ProgVariableTypes.Text },
+			{ "legalauthority", ProgVariableTypes.LegalAuthority },
+			{ "priority", ProgVariableTypes.Number },
+			{ "canbedetaineduntilfinespaid", ProgVariableTypes.Boolean }
+		};
+	}
+
+	private static IReadOnlyDictionary<string, string> DotReferenceHelp()
+	{
+		return new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase)
+		{
+			{ "id", "The ID of the legal class" },
+			{ "name", "The name of the legal class" },
+			{ "legalauthority", "The legal authority that owns this legal class" },
+			{ "priority", "The evaluation priority of this legal class" },
+			{ "canbedetaineduntilfinespaid", "Whether members of this legal class can be detained until fines are paid" }
+		};
+	}
+
+	public static void RegisterFutureProgCompiler()
+	{
+		ProgVariable.RegisterDotReferenceCompileInfo(ProgVariableTypes.LegalClass,
+			DotReferenceHandler(), DotReferenceHelp());
+	}
+}


### PR DESCRIPTION
## Summary
- add `LegalClass` as a first-class FutureProg type, including registry, parsing, runtime variable handling, and builder argument resolution
- expose `ILegalClass` to FutureProg with legal-class property access plus built-ins for `ToLegalClass`, `GetLegalClass`, and `LegalClassOutranks`
- simplify `LawSeeder` tiered applicability prog generation to use `LegalClassOutranks(...)` instead of expanding class-specific boolean matrices
- add regression coverage for the new type support and seeded law applicability prog text
- document overflow-era exact type guidance in the FutureProg type system design doc

## Testing
- `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug -p:NoWarn=NU1902%3BNU1510`
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore --filter "FullyQualifiedName~LegalClassFutureProgTests|FullyQualifiedName~ProgVariableTypesTests|FullyQualifiedName~ProgLookupFromBuilderInputTests" -p:NoWarn=NU1902%3BNU1510`
- `dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore --filter "FullyQualifiedName~SeederRepeatabilityHelperTests" -p:NoWarn=NU1902%3BNU1510`