### PR TITLE
Add builder command support for hearing profiles

### DIFF
--- a/FutureMUDLibrary/Framework/CircularRange.cs
+++ b/FutureMUDLibrary/Framework/CircularRange.cs
@@ -74,19 +74,49 @@ namespace MudSharp.Framework
             }
         }
 
-        public void Add(BoundRange<T> value)
-        {
-            _ranges.Add(value);
-        }
+		public void Add(BoundRange<T> value)
+		{
+			_ranges.Add(value);
+		}
 
-        public void Sort()
-        {
-            _ranges.Sort((x, y) => x.LowerLimit.CompareTo(y.LowerLimit));
-            Floor = _ranges.Min(x => x.LowerLimit);
-            Ceiling = _ranges.Max(x => x.UpperLimit);
-            Circumference = Ceiling - Floor;
-        }
-    }
+		public bool Remove(BoundRange<T> value)
+		{
+			var result = _ranges.Remove(value);
+			if (result)
+			{
+				ResetBounds();
+			}
+
+			return result;
+		}
+
+		public void RemoveAt(int index)
+		{
+			_ranges.RemoveAt(index);
+			ResetBounds();
+		}
+
+		private void ResetBounds()
+		{
+			if (!_ranges.Any())
+			{
+				Floor = 0.0;
+				Ceiling = 1.0;
+				Circumference = 1.0;
+				return;
+			}
+
+			Floor = _ranges.Min(x => x.LowerLimit);
+			Ceiling = _ranges.Max(x => x.UpperLimit);
+			Circumference = Ceiling - Floor;
+		}
+
+		public void Sort()
+		{
+			_ranges.Sort((x, y) => x.LowerLimit.CompareTo(y.LowerLimit));
+			ResetBounds();
+		}
+	}
 
     public class BoundRange<T>
     {

--- a/MudSharpCore/Commands/Helpers/EditableItemHelper.cs
+++ b/MudSharpCore/Commands/Helpers/EditableItemHelper.cs
@@ -2810,9 +2810,62 @@ public partial class EditableItemHelper
             actor.AddEffect(new BuilderEditingEffect<IHearingProfile>(actor) { EditingItem = profile });
             actor.OutputHandler.Send($"You create a new {type} hearing profile called {name.ColourValue()}, which you are now editing.");
         },
-        GetListTableHeaderFunc = character => new List<string> { "Id", "Name", "Type" },
+        EditableCloneAction = (actor, input) =>
+        {
+            if (input.IsFinished)
+            {
+                actor.OutputHandler.Send("Which hearing profile do you want to clone?");
+                return;
+            }
+
+            HearingProfile profile = actor.Gameworld.HearingProfiles.GetByIdOrName(input.PopSpeech()) as HearingProfile;
+            if (profile is null)
+            {
+                actor.OutputHandler.Send($"There is no hearing profile identified by the text {input.Last.ColourCommand()}.");
+                return;
+            }
+
+            if (input.IsFinished)
+            {
+                actor.OutputHandler.Send("You must specify a name for your new hearing profile.");
+                return;
+            }
+
+            string name = input.SafeRemainingArgument.TitleCase();
+            if (actor.Gameworld.HearingProfiles.Any(x => x.Name.EqualTo(name)))
+            {
+                actor.OutputHandler.Send($"There is already a hearing profile called {name.ColourName()}.");
+                return;
+            }
+
+            HearingProfile clone = profile.Clone(name);
+            actor.Gameworld.Add(clone);
+            actor.RemoveAllEffects<BuilderEditingEffect<IHearingProfile>>();
+            actor.AddEffect(new BuilderEditingEffect<IHearingProfile>(actor) { EditingItem = clone });
+            actor.OutputHandler.Send(
+                $"You clone a new hearing profile called {clone.Name.ColourName()} from {profile.Name.ColourName()}, which you are now editing.");
+        },
+        GetListTableHeaderFunc = character => new List<string> { "Id", "Name", "Type", "Survey Description" },
         GetListTableContentsFunc = (character, protos) => from proto in protos.OfType<IHearingProfile>()
-                                                          select new List<string> { proto.Id.ToString("N0", character), proto.Name, (proto as HearingProfile)?.Type ?? "" },
+                                                          select new List<string>
+                                                          {
+                                                              proto.Id.ToString("N0", character),
+                                                              proto.Name,
+                                                              (proto as HearingProfile)?.Type ?? "",
+                                                              proto.SurveyDescription ?? ""
+                                                          },
+        CustomSearch = (protos, keyword, gameworld) =>
+        {
+            return protos
+                   .OfType<IHearingProfile>()
+                   .Where(x =>
+                       x.Name.Contains(keyword, StringComparison.InvariantCultureIgnoreCase) ||
+                       ((x as HearingProfile)?.Type.Contains(keyword, StringComparison.InvariantCultureIgnoreCase) ??
+                        false) ||
+                       (x.SurveyDescription?.Contains(keyword, StringComparison.InvariantCultureIgnoreCase) ?? false))
+                   .Cast<IEditableItem>()
+                   .ToList();
+        },
         DefaultCommandHelp = BuilderModule.HearingProfileHelpText,
         GetEditHeader = item => $"Hearing Profile #{item.Id:N0} ({item.Name})"
     };

--- a/MudSharpCore/Commands/Modules/BuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/BuilderModule.cs
@@ -4513,13 +4513,14 @@ You can use the following syntax with this command:
 
 You can use the following syntax with this command:
 
-		#3hearprof list#0 - lists all hearing profiles
-		#3hearprof edit <which>#0 - begins editing a profile
-		#3hearprof edit new <type> <name>#0 - creates a new profile
-		#3hearprof close#0 - stops editing a profile
-		#3hearprof show <which>#0 - views a profile
-		#3hearprof show#0 - views your currently editing profile
-		#3hearprof set ...#0 - edits the profile";
+	#3hearprof list#0 - lists all hearing profiles
+	#3hearprof edit <which>#0 - begins editing a profile
+	#3hearprof edit new <simple|temporal|weekday> <name>#0 - creates a new profile
+	#3hearprof clone <which> <name>#0 - clones an existing profile
+	#3hearprof close#0 - stops editing a profile
+	#3hearprof show <which>#0 - views a profile
+	#3hearprof show#0 - views your currently editing profile
+	#3hearprof set ...#0 - edits the profile. See the type-specific help text for each profile kind.";
 
     [PlayerCommand("HearProf", "hearprof", "hprof")]
     [CommandPermission(PermissionLevel.Admin)]

--- a/MudSharpCore/Form/Audio/HearingProfiles/HearingProfile.cs
+++ b/MudSharpCore/Form/Audio/HearingProfiles/HearingProfile.cs
@@ -1,4 +1,3 @@
-﻿using MudSharp.Character;
 using MudSharp.Character;
 using MudSharp.Construction;
 using MudSharp.Database;
@@ -13,139 +12,157 @@ namespace MudSharp.Form.Audio.HearingProfiles;
 
 public abstract class HearingProfile : SaveableItem, IHearingProfile
 {
-    protected HearingProfile(MudSharp.Models.HearingProfile profile)
-    {
-        _id = profile.Id;
-        _name = profile.Name;
-        SurveyDescription = profile.SurveyDescription;
-    }
+	protected HearingProfile(MudSharp.Models.HearingProfile profile, IFuturemud game)
+	{
+		Gameworld = game;
+		_id = profile.Id;
+		_name = profile.Name;
+		SurveyDescription = profile.SurveyDescription;
+	}
 
-    protected HearingProfile(IFuturemud game, string name, string type)
-    {
-        Gameworld = game;
-        _name = name;
-        SurveyDescription = string.Empty;
-        using (new FMDB())
-        {
-            Models.HearingProfile dbitem = new()
-            {
-                Name = name,
-                Type = type,
-                SurveyDescription = SurveyDescription,
-                Definition = "<Definition />"
-            };
-            FMDB.Context.HearingProfiles.Add(dbitem);
-            FMDB.Context.SaveChanges();
-            _id = dbitem.Id;
-        }
-    }
+	protected HearingProfile(IFuturemud game, string name, string type)
+	{
+		Gameworld = game;
+		_name = name;
+		SurveyDescription = string.Empty;
+		using (new FMDB())
+		{
+			Models.HearingProfile dbitem = new()
+			{
+				Name = name,
+				Type = type,
+				SurveyDescription = SurveyDescription,
+				Definition = "<Definition />"
+			};
+			FMDB.Context.HearingProfiles.Add(dbitem);
+			FMDB.Context.SaveChanges();
+			_id = dbitem.Id;
+		}
+	}
 
-    public abstract void Initialise(MudSharp.Models.HearingProfile profile, IFuturemud game);
+	public abstract void Initialise(MudSharp.Models.HearingProfile profile, IFuturemud game);
 
-    public static HearingProfile LoadProfile(MudSharp.Models.HearingProfile profile)
-    {
-        switch (profile.Type)
-        {
-            case "Simple":
-                return new SimpleHearingProfile(profile);
-            case "Temporal":
-                return new TemporalHearingProfile(profile);
-            case "Weekday":
-                return new WeekdayHearingProfile(profile);
-            default:
-                throw new NotSupportedException("Invalid HearingProfile type in HearingProfile.LoadProfile");
-        }
-    }
+	public static HearingProfile LoadProfile(MudSharp.Models.HearingProfile profile, IFuturemud game)
+	{
+		switch (profile.Type)
+		{
+			case "Simple":
+				return new SimpleHearingProfile(profile, game);
+			case "Temporal":
+				return new TemporalHearingProfile(profile, game);
+			case "Weekday":
+				return new WeekdayHearingProfile(profile, game);
+			default:
+				throw new NotSupportedException("Invalid HearingProfile type in HearingProfile.LoadProfile");
+		}
+	}
 
-    #region IHearingProfile Members
+	#region IHearingProfile Members
 
-    public abstract Difficulty AudioDifficulty(ILocation location, AudioVolume volume, Proximity proximity);
+	public abstract Difficulty AudioDifficulty(ILocation location, AudioVolume volume, Proximity proximity);
 
-    public string SurveyDescription { get; set; }
+	public abstract HearingProfile Clone(string name);
 
-    public virtual IHearingProfile CurrentProfile(ILocation location)
-    {
-        return this;
-    }
+	public string SurveyDescription { get; set; }
 
-    public abstract string Type { get; }
+	public virtual IHearingProfile CurrentProfile(ILocation location)
+	{
+		return this;
+	}
 
-    protected abstract string SaveDefinition();
+	public virtual bool DependsOn(IHearingProfile profile)
+	{
+		return ReferenceEquals(this, profile);
+	}
 
-    public override void Save()
-    {
-        Models.HearingProfile dbitem = FMDB.Context.HearingProfiles.Find(Id);
-        dbitem.Name = Name;
-        dbitem.SurveyDescription = SurveyDescription;
-        dbitem.Definition = SaveDefinition();
-        dbitem.Type = Type;
-        Changed = false;
-    }
+	public abstract string Type { get; }
 
-    public virtual string HelpText => @"You can use the following options with this item:
+	protected abstract string SaveDefinition();
 
-        #3name <name>#0 - renames this hearing profile
-        #3survey <text>#0 - sets the survey description";
+	public override void Save()
+	{
+		Models.HearingProfile dbitem = FMDB.Context.HearingProfiles.Find(Id);
+		dbitem.Name = Name;
+		dbitem.SurveyDescription = SurveyDescription;
+		dbitem.Definition = SaveDefinition();
+		dbitem.Type = Type;
+		Changed = false;
+	}
 
-    public virtual bool BuildingCommand(ICharacter actor, StringStack command)
-    {
-        switch (command.PopForSwitch())
-        {
-            case "name":
-                return BuildingCommandName(actor, command);
-            case "survey":
-            case "description":
-            case "desc":
-                return BuildingCommandSurvey(actor, command);
-            default:
-                actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
-                return false;
-        }
-    }
+	protected void CopyBaseSettingsFrom(HearingProfile rhs)
+	{
+		SurveyDescription = rhs.SurveyDescription;
+	}
 
-    private bool BuildingCommandName(ICharacter actor, StringStack command)
-    {
-        if (command.IsFinished)
-        {
-            actor.OutputHandler.Send("What name do you want to give to this hearing profile?");
-            return false;
-        }
+	public virtual string HelpText => @"You can use the following options with this item:
 
-        string name = command.SafeRemainingArgument.TitleCase();
-        if (Gameworld.HearingProfiles.Any(x => x.Name.EqualTo(name)))
-        {
-            actor.OutputHandler.Send($"There is already a hearing profile called {name.ColourName()}. Names must be unique.");
-            return false;
-        }
+	#3name <name>#0 - renames this hearing profile
+	#3survey <text>#0 - sets the survey description";
 
-        actor.OutputHandler.Send($"You rename the hearing profile {_name.ColourName()} to {name.ColourName()}.");
-        _name = name;
-        Changed = true;
-        return true;
-    }
+	public virtual bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "name":
+				return BuildingCommandName(actor, command);
+			case "survey":
+			case "description":
+			case "desc":
+				return BuildingCommandSurvey(actor, command);
+			default:
+				actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
+				return false;
+		}
+	}
 
-    private bool BuildingCommandSurvey(ICharacter actor, StringStack command)
-    {
-        if (command.IsFinished)
-        {
-            actor.OutputHandler.Send("What survey description do you want to set?");
-            return false;
-        }
+	private bool BuildingCommandName(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("What name do you want to give to this hearing profile?");
+			return false;
+		}
 
-        SurveyDescription = command.SafeRemainingArgument;
-        actor.OutputHandler.Send("Survey description set.");
-        Changed = true;
-        return true;
-    }
+		string name = command.SafeRemainingArgument.TitleCase();
+		if (Gameworld.HearingProfiles.Any(x => x.Name.EqualTo(name)))
+		{
+			actor.OutputHandler.Send(
+				$"There is already a hearing profile called {name.ColourName()}. Names must be unique.");
+			return false;
+		}
 
-    public virtual string Show(ICharacter actor)
-    {
-        StringBuilder sb = new();
-        sb.AppendLine($"Hearing Profile #{Id.ToString("N0", actor)} - {Name.ColourName()}");
-        sb.AppendLine($"Type: {Type.ColourValue()}");
-        sb.AppendLine($"Survey Description: {SurveyDescription.ColourCommand()}");
-        return sb.ToString();
-    }
+		actor.OutputHandler.Send($"You rename the hearing profile {_name.ColourName()} to {name.ColourName()}.");
+		_name = name;
+		Changed = true;
+		return true;
+	}
 
-    #endregion
+	private bool BuildingCommandSurvey(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("What survey description do you want to set?");
+			return false;
+		}
+
+		SurveyDescription = command.SafeRemainingArgument;
+		actor.OutputHandler.Send("Survey description set.");
+		Changed = true;
+		return true;
+	}
+
+	public virtual string Show(ICharacter actor)
+	{
+		StringBuilder sb = new();
+		sb.AppendLine(
+			$"Hearing Profile #{Id.ToString("N0", actor)} - {Name}".GetLineWithTitle(actor, Telnet.Cyan,
+				Telnet.BoldWhite));
+		sb.AppendLine();
+		sb.AppendLine($"Type: {Type.ColourValue()}");
+		sb.AppendLine(
+			$"Survey Description: {(string.IsNullOrEmpty(SurveyDescription) ? "None".ColourError() : SurveyDescription.ColourCommand())}");
+		return sb.ToString();
+	}
+
+	#endregion
 }

--- a/MudSharpCore/Form/Audio/HearingProfiles/SimpleHearingProfile.cs
+++ b/MudSharpCore/Form/Audio/HearingProfiles/SimpleHearingProfile.cs
@@ -21,8 +21,8 @@ public class SimpleHearingProfile : HearingProfile
 
     private Difficulty _defaultDifficulty;
 
-    public SimpleHearingProfile(MudSharp.Models.HearingProfile profile)
-            : base(profile)
+    public SimpleHearingProfile(MudSharp.Models.HearingProfile profile, IFuturemud game)
+            : base(profile, game)
     {
     }
 
@@ -32,9 +32,27 @@ public class SimpleHearingProfile : HearingProfile
         _defaultDifficulty = Difficulty.Automatic;
     }
 
+    private SimpleHearingProfile(SimpleHearingProfile rhs, string name)
+            : base(rhs.Gameworld, name, rhs.Type)
+    {
+        CopyBaseSettingsFrom(rhs);
+        _defaultDifficulty = rhs._defaultDifficulty;
+        foreach (KeyValuePair<Tuple<AudioVolume, Proximity>, Difficulty> item in rhs._difficultyMap)
+        {
+            _difficultyMap[item.Key] = item.Value;
+        }
+
+        Changed = true;
+    }
+
     public override string FrameworkItemType => "SimpleHearingProfile";
 
     public override string Type => "Simple";
+
+    public override HearingProfile Clone(string name)
+    {
+        return new SimpleHearingProfile(this, name);
+    }
 
     public override Difficulty AudioDifficulty(ILocation location, AudioVolume volume, Proximity proximity)
     {
@@ -147,11 +165,34 @@ public class SimpleHearingProfile : HearingProfile
     {
         StringBuilder sb = new();
         sb.Append(base.Show(actor));
+        sb.AppendLine();
         sb.AppendLine($"Default Difficulty: {_defaultDifficulty.Describe().ColourValue()}");
-        foreach (KeyValuePair<Tuple<AudioVolume, Proximity>, Difficulty> item in _difficultyMap)
+        sb.AppendLine();
+        if (_difficultyMap.Any())
         {
-            sb.AppendLine($"{item.Key.Item1.Describe(),-15} {item.Key.Item2.Describe(),-15} : {item.Value.Describe().ColourValue()}");
+            sb.AppendLine(StringUtilities.GetTextTable(
+                from item in _difficultyMap.OrderBy(x => x.Key.Item1).ThenBy(x => x.Key.Item2)
+                select new List<string>
+                {
+                    item.Key.Item1.Describe(),
+                    item.Key.Item2.Describe(),
+                    item.Value.Describe().ColourValue()
+                },
+                new List<string>
+                {
+                    "Volume",
+                    "Proximity",
+                    "Difficulty"
+                },
+                actor,
+                Telnet.Green
+            ));
         }
+        else
+        {
+            sb.AppendLine("No specific volume or proximity difficulties are configured.");
+        }
+
         return sb.ToString();
     }
 

--- a/MudSharpCore/Form/Audio/HearingProfiles/TemporalHearingProfile.cs
+++ b/MudSharpCore/Form/Audio/HearingProfiles/TemporalHearingProfile.cs
@@ -4,6 +4,7 @@ using MudSharp.Framework;
 using MudSharp.RPG.Checks;
 using MudSharp.TimeAndDate.Time;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Xml.Linq;
@@ -20,8 +21,8 @@ public class TemporalHearingProfile : HearingProfile
 
     private IClock _clock;
 
-    public TemporalHearingProfile(MudSharp.Models.HearingProfile profile)
-            : base(profile)
+    public TemporalHearingProfile(MudSharp.Models.HearingProfile profile, IFuturemud game)
+            : base(profile, game)
     {
     }
 
@@ -30,18 +31,57 @@ public class TemporalHearingProfile : HearingProfile
     {
     }
 
+    private TemporalHearingProfile(TemporalHearingProfile rhs, string name)
+            : base(rhs.Gameworld, name, rhs.Type)
+    {
+        CopyBaseSettingsFrom(rhs);
+        _clock = rhs._clock;
+        foreach (BoundRange<SimpleHearingProfile> range in rhs._timeRanges.Ranges)
+        {
+            _timeRanges.Add(new BoundRange<SimpleHearingProfile>(_timeRanges, range.Value, range.LowerLimit,
+                range.UpperLimit));
+        }
+
+        if (_timeRanges.Ranges.Any())
+        {
+            _timeRanges.Sort();
+        }
+
+        Changed = true;
+    }
+
     public override string FrameworkItemType => "TemporalHearingProfile";
 
     public override string Type => "Temporal";
 
     public override IHearingProfile CurrentProfile(ILocation location)
     {
-        return _timeRanges.Get(location.Time(_clock).TimeFraction);
+        if (_clock is null || !_timeRanges.Ranges.Any())
+        {
+            return this;
+        }
+
+        return _timeRanges.Get(location.Time(_clock)?.TimeFraction ?? 0.0);
     }
 
     public override Difficulty AudioDifficulty(ILocation location, AudioVolume volume, Proximity proximity)
     {
+        if (_clock is null || !_timeRanges.Ranges.Any())
+        {
+            return Difficulty.Automatic;
+        }
+
         return CurrentProfile(location).AudioDifficulty(location, volume, proximity);
+    }
+
+    public override HearingProfile Clone(string name)
+    {
+        return new TemporalHearingProfile(this, name);
+    }
+
+    public override bool DependsOn(IHearingProfile profile)
+    {
+        return base.DependsOn(profile) || _timeRanges.Ranges.Any(x => x.Value.DependsOn(profile));
     }
 
     protected override string SaveDefinition()
@@ -59,9 +99,9 @@ public class TemporalHearingProfile : HearingProfile
 
     public override string HelpText => base.HelpText + @"
 
-        #3clock <which>#0 - sets the clock used
-        #3time add <lower> <upper> <profile>#0 - adds a time range
-        #3time remove <##>#0 - removes a time range";
+	#3clock <which>#0 - sets the clock used
+	#3time add <lower> <upper> <profile>#0 - adds a time range using fractions of a day from 0.0 to 1.0
+	#3time remove <##>#0 - removes a time range";
 
     public override bool BuildingCommand(ICharacter actor, StringStack command)
     {
@@ -132,6 +172,18 @@ public class TemporalHearingProfile : HearingProfile
             return false;
         }
 
+        if (lower < 0.0 || lower > 1.0 || upper < 0.0 || upper > 1.0)
+        {
+            actor.OutputHandler.Send("Time bounds must both be between 0.0 and 1.0.");
+            return false;
+        }
+
+        if (Math.Abs(lower - upper) < 0.000001)
+        {
+            actor.OutputHandler.Send("The lower and upper bounds must not be the same.");
+            return false;
+        }
+
         SimpleHearingProfile profile = actor.Gameworld.HearingProfiles.GetByIdOrName(command.SafeRemainingArgument) as SimpleHearingProfile;
         if (profile == null)
         {
@@ -148,20 +200,60 @@ public class TemporalHearingProfile : HearingProfile
 
     private bool BuildingCommandTimeRemove(ICharacter actor, StringStack command)
     {
-        actor.OutputHandler.Send("Removing time ranges is not currently supported.");
-        return false;
+        if (command.IsFinished || !int.TryParse(command.PopSpeech(), out int index))
+        {
+            actor.OutputHandler.Send("Which numbered time range do you want to remove?");
+            return false;
+        }
+
+        List<BoundRange<SimpleHearingProfile>> ranges = _timeRanges.Ranges.ToList();
+        if (index < 1 || index > ranges.Count)
+        {
+            actor.OutputHandler.Send("There is no such numbered time range.");
+            return false;
+        }
+
+        BoundRange<SimpleHearingProfile> range = ranges[index - 1];
+        _timeRanges.RemoveAt(index - 1);
+        Changed = true;
+        actor.OutputHandler.Send(
+            $"You remove time range #{index.ToString("N0", actor)}, from {range.LowerLimit.ToString("N2", actor).ColourValue()} to {range.UpperLimit.ToString("N2", actor).ColourValue()}, which pointed at {range.Value.Name.ColourName()}.");
+        return true;
     }
 
     public override string Show(ICharacter actor)
     {
         StringBuilder sb = new();
         sb.Append(base.Show(actor));
-        sb.AppendLine($"Clock: {_clock?.Name ?? "None"}");
-        int i = 1;
-        foreach (BoundRange<SimpleHearingProfile> range in _timeRanges.Ranges)
+        sb.AppendLine();
+        sb.AppendLine($"Clock: {_clock?.Name.ColourName() ?? "None".ColourError()}");
+        sb.AppendLine();
+        if (_timeRanges.Ranges.Any())
         {
-            sb.AppendLine($"{i++,3}. {range.LowerLimit:F2}-{range.UpperLimit:F2} -> {range.Value.Name.ColourValue()}");
+            sb.AppendLine(StringUtilities.GetTextTable(
+                _timeRanges.Ranges.Select((range, index) => new List<string>
+                {
+                    (index + 1).ToString("N0", actor),
+                    range.LowerLimit.ToString("N2", actor),
+                    range.UpperLimit.ToString("N2", actor),
+                    range.Value.Name.ColourName()
+                }),
+                new List<string>
+                {
+                    "#",
+                    "Lower",
+                    "Upper",
+                    "Profile"
+                },
+                actor,
+                Telnet.Green
+            ));
         }
+        else
+        {
+            sb.AppendLine("No time ranges are configured.");
+        }
+
         return sb.ToString();
     }
 

--- a/MudSharpCore/Form/Audio/HearingProfiles/WeekdayHearingProfile.cs
+++ b/MudSharpCore/Form/Audio/HearingProfiles/WeekdayHearingProfile.cs
@@ -4,6 +4,7 @@ using MudSharp.Framework;
 using MudSharp.RPG.Checks;
 using MudSharp.TimeAndDate.Date;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Xml.Linq;
@@ -20,8 +21,8 @@ public class WeekdayHearingProfile : HearingProfile
 
     private ICalendar _calendar;
 
-    public WeekdayHearingProfile(MudSharp.Models.HearingProfile profile)
-            : base(profile)
+    public WeekdayHearingProfile(MudSharp.Models.HearingProfile profile, IFuturemud game)
+            : base(profile, game)
     {
     }
 
@@ -30,18 +31,58 @@ public class WeekdayHearingProfile : HearingProfile
     {
     }
 
+    private WeekdayHearingProfile(WeekdayHearingProfile rhs, string name)
+            : base(rhs.Gameworld, name, rhs.Type)
+    {
+        CopyBaseSettingsFrom(rhs);
+        _calendar = rhs._calendar;
+        foreach (BoundRange<IHearingProfile> range in rhs._weekdayRanges.Ranges)
+        {
+            _weekdayRanges.Add(new BoundRange<IHearingProfile>(_weekdayRanges, range.Value, range.LowerLimit,
+                range.UpperLimit));
+        }
+
+        if (_weekdayRanges.Ranges.Any())
+        {
+            _weekdayRanges.Sort();
+        }
+
+        Changed = true;
+    }
+
     public override string FrameworkItemType => "WeekdayHearingProfile";
 
     public override string Type => "Weekday";
 
     public override IHearingProfile CurrentProfile(ILocation location)
     {
-        return _weekdayRanges.Get(location.Date(_calendar).WeekdayIndex);
+        if (_calendar is null || !_weekdayRanges.Ranges.Any())
+        {
+            return this;
+        }
+
+        return _weekdayRanges.Get(location.Date(_calendar)?.WeekdayIndex ?? 0);
     }
 
     public override Difficulty AudioDifficulty(ILocation location, AudioVolume volume, Proximity proximity)
     {
+        if (_calendar is null || !_weekdayRanges.Ranges.Any())
+        {
+            return Difficulty.Automatic;
+        }
+
         return CurrentProfile(location).AudioDifficulty(location, volume, proximity);
+    }
+
+    public override HearingProfile Clone(string name)
+    {
+        return new WeekdayHearingProfile(this, name);
+    }
+
+    public override bool DependsOn(IHearingProfile profile)
+    {
+        return base.DependsOn(profile) ||
+               _weekdayRanges.Ranges.Any(x => x.Value is HearingProfile hearingProfile && hearingProfile.DependsOn(profile));
     }
 
     protected override string SaveDefinition()
@@ -59,9 +100,9 @@ public class WeekdayHearingProfile : HearingProfile
 
     public override string HelpText => base.HelpText + @"
 
-        #3calendar <which>#0 - sets the calendar used
-        #3weekday add <lower> <upper> <profile>#0 - adds a weekday range
-        #3weekday remove <##>#0 - removes a weekday range";
+	#3calendar <which>#0 - sets the calendar used
+	#3weekday add <lower> <upper> <profile>#0 - adds a weekday range using weekday indexes from the selected calendar
+	#3weekday remove <##>#0 - removes a weekday range";
 
     public override bool BuildingCommand(ICharacter actor, StringStack command)
     {
@@ -114,6 +155,12 @@ public class WeekdayHearingProfile : HearingProfile
 
     private bool BuildingCommandWeekdayAdd(ICharacter actor, StringStack command)
     {
+        if (_calendar is null)
+        {
+            actor.OutputHandler.Send("You must set a calendar before you can add weekday ranges.");
+            return false;
+        }
+
         if (command.CountRemainingArguments() < 3)
         {
             actor.OutputHandler.Send("You must specify a lower bound, upper bound and profile.");
@@ -132,10 +179,29 @@ public class WeekdayHearingProfile : HearingProfile
             return false;
         }
 
-        IHearingProfile profile = actor.Gameworld.HearingProfiles.GetByIdOrName(command.SafeRemainingArgument);
+        if (lower < 0.0 || lower > _calendar.Weekdays.Count || upper < 0.0 || upper > _calendar.Weekdays.Count)
+        {
+            actor.OutputHandler.Send(
+                $"Weekday bounds must both be between 0 and {_calendar.Weekdays.Count.ToString("N0", actor)}.");
+            return false;
+        }
+
+        if (Math.Abs(lower - upper) < 0.000001)
+        {
+            actor.OutputHandler.Send("The lower and upper bounds must not be the same.");
+            return false;
+        }
+
+        HearingProfile profile = actor.Gameworld.HearingProfiles.GetByIdOrName(command.SafeRemainingArgument) as HearingProfile;
         if (profile == null)
         {
             actor.OutputHandler.Send("There is no such hearing profile.");
+            return false;
+        }
+
+        if (profile.DependsOn(this))
+        {
+            actor.OutputHandler.Send("You cannot create a cyclical hearing profile reference.");
             return false;
         }
 
@@ -148,20 +214,60 @@ public class WeekdayHearingProfile : HearingProfile
 
     private bool BuildingCommandWeekdayRemove(ICharacter actor, StringStack command)
     {
-        actor.OutputHandler.Send("Removing weekday ranges is not currently supported.");
-        return false;
+        if (command.IsFinished || !int.TryParse(command.PopSpeech(), out int index))
+        {
+            actor.OutputHandler.Send("Which numbered weekday range do you want to remove?");
+            return false;
+        }
+
+        List<BoundRange<IHearingProfile>> ranges = _weekdayRanges.Ranges.ToList();
+        if (index < 1 || index > ranges.Count)
+        {
+            actor.OutputHandler.Send("There is no such numbered weekday range.");
+            return false;
+        }
+
+        BoundRange<IHearingProfile> range = ranges[index - 1];
+        _weekdayRanges.RemoveAt(index - 1);
+        Changed = true;
+        actor.OutputHandler.Send(
+            $"You remove weekday range #{index.ToString("N0", actor)}, from {range.LowerLimit.ToString("N2", actor).ColourValue()} to {range.UpperLimit.ToString("N2", actor).ColourValue()}, which pointed at {range.Value.Name.ColourName()}.");
+        return true;
     }
 
     public override string Show(ICharacter actor)
     {
         StringBuilder sb = new();
         sb.Append(base.Show(actor));
-        sb.AppendLine($"Calendar: {_calendar?.Name ?? "None"}");
-        int i = 1;
-        foreach (BoundRange<IHearingProfile> range in _weekdayRanges.Ranges)
+        sb.AppendLine();
+        sb.AppendLine($"Calendar: {_calendar?.Name.ColourName() ?? "None".ColourError()}");
+        sb.AppendLine();
+        if (_weekdayRanges.Ranges.Any())
         {
-            sb.AppendLine($"{i++,3}. {range.LowerLimit}-{range.UpperLimit} -> {range.Value.Name.ColourValue()}");
+            sb.AppendLine(StringUtilities.GetTextTable(
+                _weekdayRanges.Ranges.Select((range, index) => new List<string>
+                {
+                    (index + 1).ToString("N0", actor),
+                    range.LowerLimit.ToString("N2", actor),
+                    range.UpperLimit.ToString("N2", actor),
+                    range.Value.Name.ColourName()
+                }),
+                new List<string>
+                {
+                    "#",
+                    "Lower",
+                    "Upper",
+                    "Profile"
+                },
+                actor,
+                Telnet.Green
+            ));
         }
+        else
+        {
+            sb.AppendLine("No weekday ranges are configured.");
+        }
+
         return sb.ToString();
     }
 

--- a/MudSharpCore/Framework/FuturemudLoaders.cs
+++ b/MudSharpCore/Framework/FuturemudLoaders.cs
@@ -3067,7 +3067,7 @@ For information on the syntax to use in emotes (such as those included in bracke
         Dictionary<long, Tuple<HearingProfile, Form.Audio.HearingProfiles.HearingProfile>> stagingtable = new();
         foreach (HearingProfile profile in profiles)
         {
-            Form.Audio.HearingProfiles.HearingProfile newprofile = Form.Audio.HearingProfiles.HearingProfile.LoadProfile(profile);
+            Form.Audio.HearingProfiles.HearingProfile newprofile = Form.Audio.HearingProfiles.HearingProfile.LoadProfile(profile, this);
             stagingtable.Add(profile.Id, Tuple.Create(profile, newprofile));
             _hearingProfiles.Add(newprofile);
         }


### PR DESCRIPTION
## Summary
- extend `hearprof` editing with clone, richer list output, and keyword search over type and survey description
- add cloning, dependency checks, and more complete `show` output across simple, temporal, and weekday hearing profiles
- support removing configured circular ranges and use that in temporal and weekday hearing profile builders
- update hearing profile loading to pass the gameworld into concrete profile constructors and refresh command help text

## Testing
- `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug -p:NoWarn=NU1902%3BNU1510`
- `powershell -ExecutionPolicy Bypass -File scripts\test-unit-core.ps1`