### PR TITLE
Add time-of-day hearing profiles and seed richer default soundscapes

### DIFF
--- a/DatabaseSeeder Unit Tests/CoreDataSeederHearingProfileTests.cs
+++ b/DatabaseSeeder Unit Tests/CoreDataSeederHearingProfileTests.cs
@@ -1,0 +1,77 @@
+#nullable enable
+
+using DatabaseSeeder.Seeders;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Database;
+using MudSharp.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class CoreDataSeederHearingProfileTests
+{
+	private static FuturemudDatabaseContext BuildContext()
+	{
+		DbContextOptions<FuturemudDatabaseContext> options = new DbContextOptionsBuilder<FuturemudDatabaseContext>()
+			.UseInMemoryDatabase(Guid.NewGuid().ToString())
+			.ConfigureWarnings(x => x.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+			.Options;
+		return new FuturemudDatabaseContext(options);
+	}
+
+	[TestMethod]
+	public void SeedDefaultHearingProfiles_SeedsRequestedSimpleAndCompositeProfiles()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+
+		CoreDataSeeder.SeedDefaultHearingProfiles(context);
+
+		Assert.IsTrue(context.HearingProfiles.Any(x => x.Name == "Universal" && x.Type == "Simple"));
+		Assert.IsTrue(context.HearingProfiles.Any(x => x.Name == "Near Waterfall" && x.Type == "Simple"));
+		Assert.IsTrue(context.HearingProfiles.Any(x => x.Name == "Near River" && x.Type == "Simple"));
+		Assert.IsTrue(context.HearingProfiles.Any(x => x.Name == "Near Ocean" && x.Type == "Simple"));
+		Assert.IsTrue(context.HearingProfiles.Any(x => x.Name == "Near Industrial Machinery" && x.Type == "Simple"));
+		Assert.IsTrue(context.HearingProfiles.Any(x => x.Name == "Commercial Workday Cycle" && x.Type == "TimeOfDay"));
+		Assert.IsTrue(context.HearingProfiles.Any(x => x.Name == "Entertainment Weekday Cycle" && x.Type == "TimeOfDay"));
+		Assert.IsTrue(context.HearingProfiles.Any(x => x.Name == "Commercial District" && x.Type == "WeekdayTimeOfDay"));
+		Assert.IsTrue(context.HearingProfiles.Any(x => x.Name == "Entertainment District" && x.Type == "WeekdayTimeOfDay"));
+	}
+
+	[TestMethod]
+	public void SeedDefaultHearingProfiles_CompositeProfilesReferenceExpectedChildren()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+
+		CoreDataSeeder.SeedDefaultHearingProfiles(context);
+
+		HearingProfile commercialDistrict = context.HearingProfiles.Single(x => x.Name == "Commercial District");
+		HearingProfile entertainmentDistrict = context.HearingProfiles.Single(x => x.Name == "Entertainment District");
+
+		List<string> commercialChildren = ResolveReferencedProfileNames(context, commercialDistrict);
+		List<string> entertainmentChildren = ResolveReferencedProfileNames(context, entertainmentDistrict);
+
+		CollectionAssert.AreEquivalent(
+			new[] { "Commercial Workday Cycle", "Commercial Weekend Cycle" },
+			commercialChildren);
+		CollectionAssert.AreEquivalent(
+			new[] { "Entertainment Weekday Cycle", "Entertainment Weekend Cycle" },
+			entertainmentChildren);
+	}
+
+	private static List<string> ResolveReferencedProfileNames(FuturemudDatabaseContext context, HearingProfile profile)
+	{
+		XElement definition = XElement.Parse(profile.Definition);
+		return definition
+			.Descendants()
+			.Attributes("ProfileID")
+			.Select(x => long.Parse(x.Value))
+			.Select(id => context.HearingProfiles.Single(x => x.Id == id).Name)
+			.ToList();
+	}
+}

--- a/DatabaseSeeder/Seeders/CoreDataSeeder.cs
+++ b/DatabaseSeeder/Seeders/CoreDataSeeder.cs
@@ -1,56 +1,260 @@
 ﻿using Humanizer;
 using Microsoft.EntityFrameworkCore.Storage;
+using MudSharp.Construction;
 using MudSharp.Database;
 using MudSharp.Email;
+using MudSharp.Form.Audio;
 using MudSharp.Form.Material;
 using MudSharp.Framework;
 using MudSharp.GameItems;
 using MudSharp.Models;
+using MudSharp.RPG.Checks;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Xml.Linq;
 using TimeZoneInfo = MudSharp.Models.TimeZoneInfo;
+using TimeOfDay = MudSharp.Celestial.TimeOfDay;
 
 namespace DatabaseSeeder.Seeders;
 
 public partial class CoreDataSeeder : IDatabaseSeeder
 {
-    private static readonly Regex EmailRegex =
-        new(
-            @"^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+(?:[A-Z]{2}|com|org|net|edu|gov|us|mil|biz|info|mobi|name|aero|asia|jobs|museum)$",
-            RegexOptions.IgnoreCase);
+	private static readonly Regex EmailRegex =
+		new(
+			@"^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+(?:[A-Z]{2}|com|org|net|edu|gov|us|mil|biz|info|mobi|name|aero|asia|jobs|museum)$",
+			RegexOptions.IgnoreCase);
 
-    public string SeedData(FuturemudDatabaseContext context, IReadOnlyDictionary<string, string> questionAnswers)
-    {
-        DateTime now = DateTime.UtcNow;
+	private static Difficulty ClampHearingDifficulty(int value)
+	{
+		return (Difficulty)Math.Clamp(value, (int)Difficulty.Automatic, (int)Difficulty.Impossible);
+	}
 
-        IDbContextTransaction transaction = context.Database.BeginTransaction();
-        // Set up account authorities
-        AuthorityGroup producer = SeedAuthorities(context);
+	private static string BuildSimpleHearingProfileDefinition(
+		Difficulty defaultDifficulty,
+		IEnumerable<(AudioVolume Volume, Proximity Proximity, Difficulty Difficulty)> difficulties)
+	{
+		return new XElement("Definition",
+				new XElement("DefaultDifficulty", (int)defaultDifficulty),
+				new XElement("Difficulties",
+					from item in difficulties
+					select new XElement("Difficulty",
+						new XAttribute("Volume", (int)item.Volume),
+						new XAttribute("Proximity", (int)item.Proximity),
+						(int)item.Difficulty)))
+			.ToString();
+	}
 
-        // God Account
+	private static string BuildTimeOfDayHearingProfileDefinition(
+		IEnumerable<(TimeOfDay TimeOfDay, HearingProfile Profile)> mappings)
+	{
+		return new XElement("Definition",
+				new XElement("TimeOfDays",
+					from item in mappings
+					select new XElement("TimeOfDay",
+						new XAttribute("Value", (int)item.TimeOfDay),
+						new XAttribute("ProfileID", item.Profile.Id))))
+			.ToString();
+	}
 
-        Account dbaccount = new()
-        {
-            Name = questionAnswers["account"],
-            Salt = 8675309,
-            Password = SecurityUtilities.GetPasswordHash(questionAnswers["password"], 8675309),
-            FormatLength = 180,
-            InnerFormatLength = 80,
-            PageLength = 100,
-            CultureName = "en-US",
-            TimeZoneId = "Eastern Standard Time",
-            UseUnicode = false,
-            Email = questionAnswers["email"],
-            IsRegistered = true,
-            UnitPreference = "metric",
-            ActiveCharactersAllowed = 100,
-            CreationDate = now,
-            RegistrationCode = "abcdefgh",
-            AuthorityGroup = producer
-        };
-        context.Accounts.Add(dbaccount);
+	private static string BuildWeekdayTimeOfDayHearingProfileDefinition(
+		long calendarId,
+		IEnumerable<(double Lower, double Upper, HearingProfile Profile)> ranges)
+	{
+		return new XElement("Definition",
+				new XElement("CalendarID", calendarId),
+				new XElement("Weekdays",
+					from item in ranges
+					select new XElement("Weekday",
+						new XAttribute("ProfileID", item.Profile.Id),
+						new XAttribute("Lower", item.Lower),
+						new XAttribute("Upper", item.Upper))))
+			.ToString();
+	}
+
+	private static HearingProfile SeedHearingProfile(
+		FuturemudDatabaseContext context,
+		string name,
+		string type,
+		string surveyDescription,
+		string definition)
+	{
+		var profile = new HearingProfile
+		{
+			Name = name,
+			Type = type,
+			SurveyDescription = surveyDescription,
+			Definition = definition
+		};
+		context.HearingProfiles.Add(profile);
+		return profile;
+	}
+
+	internal static IReadOnlyDictionary<string, HearingProfile> SeedDefaultHearingProfiles(
+		FuturemudDatabaseContext context)
+	{
+		var universalDifficulties = new[]
+		{
+			(Volume: AudioVolume.Silent, Proximity: Proximity.Intimate, Difficulty: Difficulty.ExtremelyEasy),
+			(Volume: AudioVolume.Faint, Proximity: Proximity.Intimate, Difficulty: Difficulty.Trivial),
+			(Volume: AudioVolume.Silent, Proximity: Proximity.Immediate, Difficulty: Difficulty.VeryEasy),
+			(Volume: AudioVolume.Faint, Proximity: Proximity.Immediate, Difficulty: Difficulty.ExtremelyEasy),
+			(Volume: AudioVolume.Quiet, Proximity: Proximity.Immediate, Difficulty: Difficulty.Trivial),
+			(Volume: AudioVolume.Silent, Proximity: Proximity.Proximate, Difficulty: Difficulty.Easy),
+			(Volume: AudioVolume.Faint, Proximity: Proximity.Proximate, Difficulty: Difficulty.VeryEasy),
+			(Volume: AudioVolume.Quiet, Proximity: Proximity.Proximate, Difficulty: Difficulty.ExtremelyEasy),
+			(Volume: AudioVolume.Silent, Proximity: Proximity.Distant, Difficulty: Difficulty.VeryHard),
+			(Volume: AudioVolume.Faint, Proximity: Proximity.Distant, Difficulty: Difficulty.Hard),
+			(Volume: AudioVolume.Quiet, Proximity: Proximity.Distant, Difficulty: Difficulty.Normal),
+			(Volume: AudioVolume.Decent, Proximity: Proximity.Distant, Difficulty: Difficulty.Easy),
+			(Volume: AudioVolume.Loud, Proximity: Proximity.Distant, Difficulty: Difficulty.VeryEasy),
+			(Volume: AudioVolume.VeryLoud, Proximity: Proximity.Distant, Difficulty: Difficulty.ExtremelyEasy),
+			(Volume: AudioVolume.ExtremelyLoud, Proximity: Proximity.Distant, Difficulty: Difficulty.Trivial)
+		};
+
+		IEnumerable<(AudioVolume Volume, Proximity Proximity, Difficulty Difficulty)> ShiftDifficulties(int shift)
+		{
+			return universalDifficulties.Select(item =>
+				(item.Volume, item.Proximity, ClampHearingDifficulty((int)item.Difficulty + shift)));
+		}
+
+		var seededHearingProfiles = new Dictionary<string, HearingProfile>(StringComparer.InvariantCultureIgnoreCase);
+
+		void AddSimpleProfile(string name, string surveyDescription, Difficulty defaultDifficulty, int shift)
+		{
+			seededHearingProfiles[name] = SeedHearingProfile(
+				context,
+				name,
+				"Simple",
+				surveyDescription,
+				BuildSimpleHearingProfileDefinition(defaultDifficulty, ShiftDifficulties(shift)));
+		}
+
+		AddSimpleProfile("Universal", "The noise level is generally low and otherwise unremarkable.",
+			Difficulty.Automatic, 0);
+		AddSimpleProfile("Extremely Quiet",
+			"The surrounding area is exceptionally still and even subtle sounds carry clearly.", Difficulty.Automatic,
+			-2);
+		AddSimpleProfile("Bustling Daytime",
+			"Steady daytime activity makes it harder to pick out softer or more distant sounds.", Difficulty.Trivial, 2);
+		AddSimpleProfile("Nightlife Crowd",
+			"Conversation, music and late-night activity compete with most softer sounds.", Difficulty.VeryEasy, 3);
+		AddSimpleProfile("Near River", "The steady rush of nearby water masks softer sounds.", Difficulty.Trivial, 1);
+		AddSimpleProfile("Near Ocean",
+			"Breaking surf and coastal wind make quieter sounds harder to catch.", Difficulty.ExtremelyEasy, 2);
+		AddSimpleProfile("Near Waterfall", "The roar of falling water overwhelms almost every softer noise.",
+			Difficulty.Easy, 4);
+		AddSimpleProfile("Near Industrial Machinery",
+			"Grinding, clanging machinery dominates the soundscape almost constantly.", Difficulty.Hard, 5);
+		context.SaveChanges();
+
+		void AddTimeOfDayProfile(
+			string name,
+			string surveyDescription,
+			params (TimeOfDay TimeOfDay, string ProfileName)[] mappings)
+		{
+			seededHearingProfiles[name] = SeedHearingProfile(
+				context,
+				name,
+				"TimeOfDay",
+				surveyDescription,
+				BuildTimeOfDayHearingProfileDefinition(
+					from item in mappings
+					select (item.TimeOfDay, seededHearingProfiles[item.ProfileName])));
+		}
+
+		AddTimeOfDayProfile("Commercial Workday Cycle",
+			"Busiest through the working day, winding down after dusk and becoming extremely quiet overnight.",
+			(TimeOfDay.Night, "Extremely Quiet"),
+			(TimeOfDay.Dawn, "Universal"),
+			(TimeOfDay.Morning, "Bustling Daytime"),
+			(TimeOfDay.Afternoon, "Bustling Daytime"),
+			(TimeOfDay.Dusk, "Universal"));
+		AddTimeOfDayProfile("Commercial Weekend Cycle",
+			"A gentler daytime hum with very quiet nights and calmer dawns.",
+			(TimeOfDay.Night, "Extremely Quiet"),
+			(TimeOfDay.Dawn, "Extremely Quiet"),
+			(TimeOfDay.Morning, "Universal"),
+			(TimeOfDay.Afternoon, "Universal"),
+			(TimeOfDay.Dusk, "Universal"));
+		AddTimeOfDayProfile("Entertainment Weekday Cycle",
+			"Quieter through weekday mornings and afternoons, rising sharply after dusk and into the night.",
+			(TimeOfDay.Night, "Nightlife Crowd"),
+			(TimeOfDay.Dawn, "Universal"),
+			(TimeOfDay.Morning, "Extremely Quiet"),
+			(TimeOfDay.Afternoon, "Universal"),
+			(TimeOfDay.Dusk, "Nightlife Crowd"));
+		AddTimeOfDayProfile("Entertainment Weekend Cycle",
+			"Weekend afternoons are busier and the nightlife stays loud well into the night.",
+			(TimeOfDay.Night, "Nightlife Crowd"),
+			(TimeOfDay.Dawn, "Universal"),
+			(TimeOfDay.Morning, "Universal"),
+			(TimeOfDay.Afternoon, "Bustling Daytime"),
+			(TimeOfDay.Dusk, "Nightlife Crowd"));
+		context.SaveChanges();
+
+		var defaultCalendarId = context.Calendars.OrderBy(x => x.Id).Select(x => x.Id).FirstOrDefault();
+
+		void AddWeekdayTimeOfDayProfile(
+			string name,
+			string surveyDescription,
+			params (double Lower, double Upper, string ProfileName)[] ranges)
+		{
+			seededHearingProfiles[name] = SeedHearingProfile(
+				context,
+				name,
+				"WeekdayTimeOfDay",
+				surveyDescription,
+				BuildWeekdayTimeOfDayHearingProfileDefinition(
+					defaultCalendarId,
+					from item in ranges
+					select (item.Lower, item.Upper, seededHearingProfiles[item.ProfileName])));
+		}
+
+		AddWeekdayTimeOfDayProfile("Commercial District",
+			"Assuming a seven-day week, this place is noisy during weekday daylight hours, extremely quiet at night, and less noisy across the weekend days.",
+			(0.0, 5.0, "Commercial Workday Cycle"),
+			(5.0, 7.0, "Commercial Weekend Cycle"));
+		AddWeekdayTimeOfDayProfile("Entertainment District",
+			"Assuming a seven-day week, this place is comparatively quiet through weekday days but becomes much louder at night and across the weekend.",
+			(0.0, 5.0, "Entertainment Weekday Cycle"),
+			(5.0, 7.0, "Entertainment Weekend Cycle"));
+		context.SaveChanges();
+
+		return seededHearingProfiles;
+	}
+
+	public string SeedData(FuturemudDatabaseContext context, IReadOnlyDictionary<string, string> questionAnswers)
+	{
+		DateTime now = DateTime.UtcNow;
+
+		IDbContextTransaction transaction = context.Database.BeginTransaction();
+		// Set up account authorities
+		AuthorityGroup producer = SeedAuthorities(context);
+
+		// God Account
+
+		Account dbaccount = new()
+		{
+			Name = questionAnswers["account"],
+			Salt = 8675309,
+			Password = SecurityUtilities.GetPasswordHash(questionAnswers["password"], 8675309),
+			FormatLength = 180,
+			InnerFormatLength = 80,
+			PageLength = 100,
+			CultureName = "en-US",
+			TimeZoneId = "Eastern Standard Time",
+			UseUnicode = false,
+			Email = questionAnswers["email"],
+			IsRegistered = true,
+			UnitPreference = "metric",
+			ActiveCharactersAllowed = 100,
+			CreationDate = now,
+			RegistrationCode = "abcdefgh",
+			AuthorityGroup = producer
+		};
+		context.Accounts.Add(dbaccount);
 
         SeedCulturesAndTimezoneInfos(context);
 
@@ -648,33 +852,8 @@ public partial class CoreDataSeeder : IDatabaseSeeder
         context.GameItemProtos.Add(commodityItem);
         context.SaveChanges();
 
-        // Add Universal Hearing Profile
-        HearingProfile hearing = new()
-        {
-            Name = "Universal",
-            Type = "Simple",
-            SurveyDescription = "The noise level is generally low and otherwise unremarkable.",
-            Definition = @"<Definition>
-   <Difficulties>
-	 <Difficulty Volume=""0"" Proximity=""0"">2</Difficulty>
-	 <Difficulty Volume=""1"" Proximity=""0"">1</Difficulty>
-	 <Difficulty Volume=""0"" Proximity=""1"">3</Difficulty>
-	 <Difficulty Volume=""1"" Proximity=""1"">2</Difficulty>
-	 <Difficulty Volume=""2"" Proximity=""1"">1</Difficulty>
-	 <Difficulty Volume=""0"" Proximity=""2"">4</Difficulty>
-	 <Difficulty Volume=""1"" Proximity=""2"">3</Difficulty>
-	 <Difficulty Volume=""2"" Proximity=""2"">2</Difficulty>
-	 <Difficulty Volume=""0"" Proximity=""3"">7</Difficulty>
-	 <Difficulty Volume=""1"" Proximity=""3"">6</Difficulty>
-	 <Difficulty Volume=""2"" Proximity=""3"">5</Difficulty>
-	 <Difficulty Volume=""3"" Proximity=""3"">4</Difficulty>
-	 <Difficulty Volume=""4"" Proximity=""3"">3</Difficulty>
-	 <Difficulty Volume=""5"" Proximity=""3"">2</Difficulty>
-	 <Difficulty Volume=""6"" Proximity=""3"">1</Difficulty>
-   </Difficulties>
- </Definition>"
-        };
-        context.HearingProfiles.Add(hearing);
+		// Add default hearing profiles
+		IReadOnlyDictionary<string, HearingProfile> seededHearingProfiles = SeedDefaultHearingProfiles(context);
 
         // Default Item Group
         ItemGroup itemGroup = new()
@@ -953,7 +1132,7 @@ public partial class CoreDataSeeder : IDatabaseSeeder
             CellOverlayPackage = package,
             Terrain = terrain,
             AddedLight = 0,
-            HearingProfile = hearing,
+            HearingProfile = seededHearingProfiles["Universal"],
             OutdoorsType = 0,
             AmbientLightFactor = 1.0,
             CellId = cell.Id

--- a/MudSharpCore/Commands/Helpers/EditableItemHelper.cs
+++ b/MudSharpCore/Commands/Helpers/EditableItemHelper.cs
@@ -2779,7 +2779,7 @@ public partial class EditableItemHelper
         {
             if (input.CountRemainingArguments() < 2)
             {
-                actor.OutputHandler.Send("You must specify a type (simple|temporal|weekday) and a name.");
+                actor.OutputHandler.Send("You must specify a type (simple|temporal|timeofday|weekday|weekdaytimeofday) and a name.");
                 return;
             }
 
@@ -2795,13 +2795,16 @@ public partial class EditableItemHelper
             {
                 "simple" => new SimpleHearingProfile(actor.Gameworld, name),
                 "temporal" => new TemporalHearingProfile(actor.Gameworld, name),
+                "timeofday" => new TimeOfDayHearingProfile(actor.Gameworld, name),
                 "weekday" => new WeekdayHearingProfile(actor.Gameworld, name),
+                "weekdaytimeofday" => new WeekdayTimeOfDayHearingProfile(actor.Gameworld, name),
+                "weekdaytime" => new WeekdayTimeOfDayHearingProfile(actor.Gameworld, name),
                 _ => null
             };
 
             if (profile == null)
             {
-                actor.OutputHandler.Send("The type must be simple, temporal or weekday.");
+                actor.OutputHandler.Send("The type must be simple, temporal, timeofday, weekday or weekdaytimeofday.");
                 return;
             }
 

--- a/MudSharpCore/Commands/Modules/BuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/BuilderModule.cs
@@ -4515,7 +4515,7 @@ You can use the following syntax with this command:
 
 	#3hearprof list#0 - lists all hearing profiles
 	#3hearprof edit <which>#0 - begins editing a profile
-	#3hearprof edit new <simple|temporal|weekday> <name>#0 - creates a new profile
+	#3hearprof edit new <simple|temporal|timeofday|weekday|weekdaytimeofday> <name>#0 - creates a new profile
 	#3hearprof clone <which> <name>#0 - clones an existing profile
 	#3hearprof close#0 - stops editing a profile
 	#3hearprof show <which>#0 - views a profile

--- a/MudSharpCore/Form/Audio/HearingProfiles/HearingProfile.cs
+++ b/MudSharpCore/Form/Audio/HearingProfiles/HearingProfile.cs
@@ -50,8 +50,12 @@ public abstract class HearingProfile : SaveableItem, IHearingProfile
 				return new SimpleHearingProfile(profile, game);
 			case "Temporal":
 				return new TemporalHearingProfile(profile, game);
+			case "TimeOfDay":
+				return new TimeOfDayHearingProfile(profile, game);
 			case "Weekday":
 				return new WeekdayHearingProfile(profile, game);
+			case "WeekdayTimeOfDay":
+				return new WeekdayTimeOfDayHearingProfile(profile, game);
 			default:
 				throw new NotSupportedException("Invalid HearingProfile type in HearingProfile.LoadProfile");
 		}

--- a/MudSharpCore/Form/Audio/HearingProfiles/TimeOfDayHearingProfile.cs
+++ b/MudSharpCore/Form/Audio/HearingProfiles/TimeOfDayHearingProfile.cs
@@ -1,0 +1,247 @@
+#nullable enable
+
+using MudSharp.Celestial;
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Framework;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+namespace MudSharp.Form.Audio.HearingProfiles;
+
+/// <summary>
+/// 	A TimeOfDayHearingProfile is an implementation of IHearingProfile that provides a different SimpleHearingProfile
+/// 	result based on the local time of day enum for the location.
+/// </summary>
+public class TimeOfDayHearingProfile : HearingProfile
+{
+	private readonly Dictionary<TimeOfDay, SimpleHearingProfile> _timeOfDayProfiles = new();
+
+	public TimeOfDayHearingProfile(MudSharp.Models.HearingProfile profile, IFuturemud game)
+		: base(profile, game)
+	{
+	}
+
+	public TimeOfDayHearingProfile(IFuturemud game, string name)
+		: base(game, name, "TimeOfDay")
+	{
+	}
+
+	private TimeOfDayHearingProfile(TimeOfDayHearingProfile rhs, string name)
+		: base(rhs.Gameworld, name, rhs.Type)
+	{
+		CopyBaseSettingsFrom(rhs);
+		foreach (var item in rhs._timeOfDayProfiles)
+		{
+			_timeOfDayProfiles[item.Key] = item.Value;
+		}
+
+		Changed = true;
+	}
+
+	public override string FrameworkItemType => "TimeOfDayHearingProfile";
+
+	public override string Type => "TimeOfDay";
+
+	private static TimeOfDay GetCurrentTimeOfDay(ILocation location)
+	{
+		return location switch
+		{
+			ICell cell => cell.CurrentTimeOfDay,
+			IRoom room => room.CurrentTimeOfDay,
+			IZone zone => zone.CurrentTimeOfDay,
+			IArea area => area.CurrentTimeOfDay,
+			_ => TimeOfDay.Night
+		};
+	}
+
+	private SimpleHearingProfile? GetCurrentProfile(ILocation location)
+	{
+		return _timeOfDayProfiles.GetValueOrDefault(GetCurrentTimeOfDay(location));
+	}
+
+	public override IHearingProfile CurrentProfile(ILocation location)
+	{
+		var profile = GetCurrentProfile(location);
+		return profile is not null ? profile : this;
+	}
+
+	public override Difficulty AudioDifficulty(ILocation location, AudioVolume volume, Proximity proximity)
+	{
+		return GetCurrentProfile(location)?.AudioDifficulty(location, volume, proximity) ?? Difficulty.Automatic;
+	}
+
+	public override HearingProfile Clone(string name)
+	{
+		return new TimeOfDayHearingProfile(this, name);
+	}
+
+	public override bool DependsOn(IHearingProfile profile)
+	{
+		return base.DependsOn(profile) || _timeOfDayProfiles.Values.Any(x => x.DependsOn(profile));
+	}
+
+	protected override string SaveDefinition()
+	{
+		return new XElement("Definition",
+				new XElement("TimeOfDays",
+					from item in _timeOfDayProfiles.OrderBy(x => x.Key)
+					select new XElement("TimeOfDay",
+						new XAttribute("Value", (int)item.Key),
+						new XAttribute("ProfileID", item.Value.Id))))
+			.ToString();
+	}
+
+	public override string HelpText => base.HelpText + @"
+
+	#3timeofday set <timeofday> <profile>#0 - sets the profile used for a specific time of day
+	#3timeofday clear <timeofday>#0 - clears the profile used for a specific time of day";
+
+	public override bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "timeofday":
+			case "time":
+				return BuildingCommandTimeOfDay(actor, command);
+			default:
+				return base.BuildingCommand(actor, command.GetUndo());
+		}
+	}
+
+	private bool BuildingCommandTimeOfDay(ICharacter actor, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "set":
+			case "add":
+				return BuildingCommandTimeOfDaySet(actor, command);
+			case "clear":
+			case "remove":
+				return BuildingCommandTimeOfDayClear(actor, command);
+			default:
+				actor.OutputHandler.Send("You must specify set or clear.");
+				return false;
+		}
+	}
+
+	private bool TryGetTimeOfDay(ICharacter actor, StringStack command, out TimeOfDay timeOfDay)
+	{
+		timeOfDay = default;
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send(
+				$"Which time of day do you want to use? Valid options are {Enum.GetValues<TimeOfDay>().Select(x => x.DescribeColour()).ListToString()}.");
+			return false;
+		}
+
+		if (!command.PopSpeech().TryParseEnum<TimeOfDay>(out timeOfDay))
+		{
+			actor.OutputHandler.Send(
+				$"That is not a valid time of day. Valid options are {Enum.GetValues<TimeOfDay>().Select(x => x.DescribeColour()).ListToString()}.");
+			return false;
+		}
+
+		return true;
+	}
+
+	private bool BuildingCommandTimeOfDaySet(ICharacter actor, StringStack command)
+	{
+		if (!TryGetTimeOfDay(actor, command, out var timeOfDay))
+		{
+			return false;
+		}
+
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which simple hearing profile should be used for that time of day?");
+			return false;
+		}
+
+		var profile = actor.Gameworld.HearingProfiles.GetByIdOrName(command.SafeRemainingArgument) as SimpleHearingProfile;
+		if (profile is null)
+		{
+			actor.OutputHandler.Send("You must specify a simple hearing profile.");
+			return false;
+		}
+
+		_timeOfDayProfiles[timeOfDay] = profile;
+		Changed = true;
+		actor.OutputHandler.Send(
+			$"This profile now uses {profile.Name.ColourName()} during {timeOfDay.DescribeColour()}.");
+		return true;
+	}
+
+	private bool BuildingCommandTimeOfDayClear(ICharacter actor, StringStack command)
+	{
+		if (!TryGetTimeOfDay(actor, command, out var timeOfDay))
+		{
+			return false;
+		}
+
+		if (_timeOfDayProfiles.Remove(timeOfDay))
+		{
+			Changed = true;
+			actor.OutputHandler.Send($"This profile no longer has a specific mapping for {timeOfDay.DescribeColour()}.");
+			return true;
+		}
+
+		actor.OutputHandler.Send($"There was no specific mapping for {timeOfDay.DescribeColour()}.");
+		return false;
+	}
+
+	public override string Show(ICharacter actor)
+	{
+		var sb = new StringBuilder();
+		sb.Append(base.Show(actor));
+		sb.AppendLine();
+		sb.AppendLine(StringUtilities.GetTextTable(
+			from time in Enum.GetValues<TimeOfDay>()
+			select new List<string>
+			{
+				time.DescribeColour(),
+				_timeOfDayProfiles.TryGetValue(time, out var profile) ? profile.Name.ColourName() : "None".ColourError()
+			},
+			new List<string>
+			{
+				"Time Of Day",
+				"Profile"
+			},
+			actor,
+			Telnet.Green
+		));
+		return sb.ToString();
+	}
+
+	public override void Initialise(MudSharp.Models.HearingProfile profile, IFuturemud game)
+	{
+		var root = XElement.Parse(profile.Definition);
+		var element = root.Element("TimeOfDays");
+		if (element is null)
+		{
+			return;
+		}
+
+		foreach (var sub in element.Elements("TimeOfDay"))
+		{
+			var profileIdText = sub.Attribute("ProfileID")?.Value;
+			var timeOfDayText = sub.Attribute("Value")?.Value ?? sub.Attribute("TimeOfDay")?.Value;
+			if (!long.TryParse(profileIdText, out var profileId) || !int.TryParse(timeOfDayText, out var value))
+			{
+				continue;
+			}
+
+			var loadedProfile = game.HearingProfiles.Get(profileId) as SimpleHearingProfile;
+			if (loadedProfile is null)
+			{
+				continue;
+			}
+
+			_timeOfDayProfiles[(TimeOfDay)value] = loadedProfile;
+		}
+	}
+}

--- a/MudSharpCore/Form/Audio/HearingProfiles/WeekdayTimeOfDayHearingProfile.cs
+++ b/MudSharpCore/Form/Audio/HearingProfiles/WeekdayTimeOfDayHearingProfile.cs
@@ -1,0 +1,318 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Framework;
+using MudSharp.RPG.Checks;
+using MudSharp.TimeAndDate.Date;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+namespace MudSharp.Form.Audio.HearingProfiles;
+
+/// <summary>
+/// 	A WeekdayTimeOfDayHearingProfile is an implementation of IHearingProfile that provides a different
+/// 	TimeOfDayHearingProfile for different days of the week.
+/// </summary>
+public class WeekdayTimeOfDayHearingProfile : HearingProfile
+{
+	private readonly CircularRange<TimeOfDayHearingProfile> _weekdayRanges = new();
+
+	private ICalendar? _calendar;
+
+	public WeekdayTimeOfDayHearingProfile(MudSharp.Models.HearingProfile profile, IFuturemud game)
+		: base(profile, game)
+	{
+	}
+
+	public WeekdayTimeOfDayHearingProfile(IFuturemud game, string name)
+		: base(game, name, "WeekdayTimeOfDay")
+	{
+	}
+
+	private WeekdayTimeOfDayHearingProfile(WeekdayTimeOfDayHearingProfile rhs, string name)
+		: base(rhs.Gameworld, name, rhs.Type)
+	{
+		CopyBaseSettingsFrom(rhs);
+		_calendar = rhs._calendar;
+		foreach (var range in rhs._weekdayRanges.Ranges)
+		{
+			_weekdayRanges.Add(new BoundRange<TimeOfDayHearingProfile>(_weekdayRanges, range.Value, range.LowerLimit,
+				range.UpperLimit));
+		}
+
+		if (_weekdayRanges.Ranges.Any())
+		{
+			_weekdayRanges.Sort();
+		}
+
+		Changed = true;
+	}
+
+	public override string FrameworkItemType => "WeekdayTimeOfDayHearingProfile";
+
+	public override string Type => "WeekdayTimeOfDay";
+
+	private ICalendar? GetCalendar(ILocation location)
+	{
+		return _calendar ?? location.Calendars.FirstOrDefault();
+	}
+
+	private TimeOfDayHearingProfile? GetWeekdayProfile(ILocation location)
+	{
+		var calendar = GetCalendar(location);
+		if (calendar is null || !_weekdayRanges.Ranges.Any())
+		{
+			return null;
+		}
+
+		return _weekdayRanges.Get(location.Date(calendar)?.WeekdayIndex ?? 0);
+	}
+
+	public override IHearingProfile CurrentProfile(ILocation location)
+	{
+		return GetWeekdayProfile(location)?.CurrentProfile(location) ?? this;
+	}
+
+	public override Difficulty AudioDifficulty(ILocation location, AudioVolume volume, Proximity proximity)
+	{
+		return GetWeekdayProfile(location)?.AudioDifficulty(location, volume, proximity) ?? Difficulty.Automatic;
+	}
+
+	public override HearingProfile Clone(string name)
+	{
+		return new WeekdayTimeOfDayHearingProfile(this, name);
+	}
+
+	public override bool DependsOn(IHearingProfile profile)
+	{
+		return base.DependsOn(profile) || _weekdayRanges.Ranges.Any(x => x.Value.DependsOn(profile));
+	}
+
+	protected override string SaveDefinition()
+	{
+		return new XElement("Definition",
+				new XElement("CalendarID", _calendar?.Id ?? 0),
+				new XElement("Weekdays",
+					from range in _weekdayRanges.Ranges
+					select new XElement("Weekday",
+						new XAttribute("ProfileID", range.Value.Id),
+						new XAttribute("Lower", range.LowerLimit),
+						new XAttribute("Upper", range.UpperLimit))))
+			.ToString();
+	}
+
+	public override string HelpText => base.HelpText + @"
+
+	#3calendar <which>#0 - sets the calendar used for editing this profile
+	#3weekday add <lower> <upper> <profile>#0 - adds a weekday range using weekday indexes from the selected calendar
+	#3weekday remove <##>#0 - removes a weekday range
+
+If no calendar is set, this profile uses the first calendar available on the current location at runtime.";
+
+	public override bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "calendar":
+				return BuildingCommandCalendar(actor, command);
+			case "weekday":
+				return BuildingCommandWeekday(actor, command);
+			default:
+				return base.BuildingCommand(actor, command.GetUndo());
+		}
+	}
+
+	private bool BuildingCommandCalendar(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which calendar should this profile use while editing weekday ranges?");
+			return false;
+		}
+
+		var calendar = actor.Gameworld.Calendars.GetByIdOrName(command.SafeRemainingArgument);
+		if (calendar is null)
+		{
+			actor.OutputHandler.Send("There is no such calendar.");
+			return false;
+		}
+
+		_calendar = calendar;
+		Changed = true;
+		actor.OutputHandler.Send($"This profile now uses the {_calendar.Name.ColourValue()} calendar.");
+		return true;
+	}
+
+	private bool BuildingCommandWeekday(ICharacter actor, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "add":
+				return BuildingCommandWeekdayAdd(actor, command);
+			case "remove":
+				return BuildingCommandWeekdayRemove(actor, command);
+			default:
+				actor.OutputHandler.Send("You must specify add or remove.");
+				return false;
+		}
+	}
+
+	private bool BuildingCommandWeekdayAdd(ICharacter actor, StringStack command)
+	{
+		if (_calendar is null)
+		{
+			actor.OutputHandler.Send("You must set a calendar before you can add weekday ranges.");
+			return false;
+		}
+
+		if (command.CountRemainingArguments() < 3)
+		{
+			actor.OutputHandler.Send("You must specify a lower bound, upper bound and profile.");
+			return false;
+		}
+
+		if (!double.TryParse(command.PopSpeech(), out var lower))
+		{
+			actor.OutputHandler.Send("Invalid lower bound.");
+			return false;
+		}
+
+		if (!double.TryParse(command.PopSpeech(), out var upper))
+		{
+			actor.OutputHandler.Send("Invalid upper bound.");
+			return false;
+		}
+
+		if (lower < 0.0 || lower > _calendar.Weekdays.Count || upper < 0.0 || upper > _calendar.Weekdays.Count)
+		{
+			actor.OutputHandler.Send(
+				$"Weekday bounds must both be between 0 and {_calendar.Weekdays.Count.ToString("N0", actor)}.");
+			return false;
+		}
+
+		if (Math.Abs(lower - upper) < 0.000001)
+		{
+			actor.OutputHandler.Send("The lower and upper bounds must not be the same.");
+			return false;
+		}
+
+		var profile = actor.Gameworld.HearingProfiles.GetByIdOrName(command.SafeRemainingArgument) as TimeOfDayHearingProfile;
+		if (profile is null)
+		{
+			actor.OutputHandler.Send("You must specify a time-of-day hearing profile.");
+			return false;
+		}
+
+		if (profile.DependsOn(this))
+		{
+			actor.OutputHandler.Send("You cannot create a cyclical hearing profile reference.");
+			return false;
+		}
+
+		_weekdayRanges.Add(new BoundRange<TimeOfDayHearingProfile>(_weekdayRanges, profile, lower, upper));
+		_weekdayRanges.Sort();
+		Changed = true;
+		actor.OutputHandler.Send("Weekday range added.");
+		return true;
+	}
+
+	private bool BuildingCommandWeekdayRemove(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !int.TryParse(command.PopSpeech(), out var index))
+		{
+			actor.OutputHandler.Send("Which numbered weekday range do you want to remove?");
+			return false;
+		}
+
+		var ranges = _weekdayRanges.Ranges.ToList();
+		if (index < 1 || index > ranges.Count)
+		{
+			actor.OutputHandler.Send("There is no such numbered weekday range.");
+			return false;
+		}
+
+		var range = ranges[index - 1];
+		_weekdayRanges.RemoveAt(index - 1);
+		Changed = true;
+		actor.OutputHandler.Send(
+			$"You remove weekday range #{index.ToString("N0", actor)}, from {range.LowerLimit.ToString("N2", actor).ColourValue()} to {range.UpperLimit.ToString("N2", actor).ColourValue()}, which pointed at {range.Value.Name.ColourName()}.");
+		return true;
+	}
+
+	public override string Show(ICharacter actor)
+	{
+		var sb = new StringBuilder();
+		sb.Append(base.Show(actor));
+		sb.AppendLine();
+		sb.AppendLine(
+			$"Calendar: {(_calendar?.Name.ColourName() ?? "Auto (first location calendar)".ColourValue())}");
+		sb.AppendLine();
+		if (_weekdayRanges.Ranges.Any())
+		{
+			sb.AppendLine(StringUtilities.GetTextTable(
+				_weekdayRanges.Ranges.Select((range, index) => new List<string>
+				{
+					(index + 1).ToString("N0", actor),
+					range.LowerLimit.ToString("N2", actor),
+					range.UpperLimit.ToString("N2", actor),
+					range.Value.Name.ColourName()
+				}),
+				new List<string>
+				{
+					"#",
+					"Lower",
+					"Upper",
+					"Profile"
+				},
+				actor,
+				Telnet.Green
+			));
+		}
+		else
+		{
+			sb.AppendLine("No weekday ranges are configured.");
+		}
+
+		return sb.ToString();
+	}
+
+	public override void Initialise(MudSharp.Models.HearingProfile profile, IFuturemud game)
+	{
+		var root = XElement.Parse(profile.Definition);
+		var element = root.Element("CalendarID");
+		if (element is not null && long.TryParse(element.Value, out var calendarId) && calendarId > 0)
+		{
+			_calendar = game.Calendars.Get(calendarId);
+		}
+
+		element = root.Element("Weekdays");
+		if (element is null)
+		{
+			return;
+		}
+
+		foreach (var sub in element.Elements("Weekday"))
+		{
+			var loadedProfile = game.HearingProfiles.Get(long.Parse(sub.Attribute("ProfileID")!.Value)) as TimeOfDayHearingProfile;
+			if (loadedProfile is null)
+			{
+				continue;
+			}
+
+			_weekdayRanges.Add(
+				new BoundRange<TimeOfDayHearingProfile>(_weekdayRanges,
+					loadedProfile,
+					Convert.ToDouble(sub.Attribute("Lower")!.Value),
+					Convert.ToDouble(sub.Attribute("Upper")!.Value)));
+		}
+
+		if (_weekdayRanges.Ranges.Any())
+		{
+			_weekdayRanges.Sort();
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `TimeOfDay` and `WeekdayTimeOfDay` hearing profile types, loader support, and builder command integration
- extend hearing profile editing for temporal and weekday variants, including improved profile management and range handling
- seed additional default hearing profiles for always-noisy locations and weekday/time-of-day commercial and entertainment patterns
- add regression coverage for seeded hearing profile definitions

## Testing
- `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug -p:NoWarn=NU1902%3BNU1510`
- `dotnet build DatabaseSeeder\DatabaseSeeder.csproj -c Debug -p:NoWarn=NU1902%3BNU1510`
- `powershell -ExecutionPolicy Bypass -File scripts\test-unit-core.ps1`
- `dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore`  
  Fails due to pre-existing unrelated tests:
  - `BlankDatabaseSnapshotTests.CommittedBlankSnapshotManifest_TracksLatestMigration`
  - `SeederDisfigurementTemplateUtilityTests.HumanSeeder_DefaultDisfigurementHooks_AreEmptyByDefault`