### PR TITLE
Update core data seeding for units, materials, and terrains

### DIFF
--- a/DatabaseSeeder Unit Tests/CoreDataSeederMaterialTests.cs
+++ b/DatabaseSeeder Unit Tests/CoreDataSeederMaterialTests.cs
@@ -37,6 +37,14 @@ public class CoreDataSeederMaterialTests
             .Invoke(seeder, [context]);
     }
 
+    private static void SeedMaterialsBase(FuturemudDatabaseContext context)
+    {
+        CoreDataSeeder seeder = new();
+        typeof(CoreDataSeeder)
+            .GetMethod("SeedMaterialsBase", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(seeder, [context]);
+    }
+
     private static Mock<IFuturemud> CreateGameworld(All<ISolid> materials, FuturemudDatabaseContext context)
     {
         All<ITag> tags = new();
@@ -92,5 +100,60 @@ public class CoreDataSeederMaterialTests
 
         Assert.AreEqual("mild steel", materials.GetByName("steel")?.Name);
         Assert.AreEqual("high-density polyethylene", materials.GetByName("hdpe")?.Name);
+    }
+
+    [TestMethod]
+    public void SeedMaterials_CorrectsKnownIssuesAndExpandsCatalogue()
+    {
+        using FuturemudDatabaseContext baselineContext = BuildContext();
+        SeedMaterialsBase(baselineContext);
+        int baselineCount = baselineContext.Materials.Count();
+
+        using FuturemudDatabaseContext context = BuildContext();
+        SeedMaterials(context);
+
+        MudSharp.Models.Material coachwood = context.Materials
+            .Include(x => x.MaterialAliases)
+            .Include(x => x.MaterialsTags)
+            .ThenInclude(x => x.Tag)
+            .Single(x => x.Name == "coachwood");
+        MudSharp.Models.Material aubergine = context.Materials
+            .Include(x => x.MaterialAliases)
+            .Include(x => x.MaterialsTags)
+            .ThenInclude(x => x.Tag)
+            .Single(x => x.Name == "aubergine");
+        MudSharp.Models.Material paper = context.Materials
+            .Include(x => x.MaterialsTags)
+            .ThenInclude(x => x.Tag)
+            .Single(x => x.Name == "paper");
+        MudSharp.Models.Material soap = context.Materials
+            .Include(x => x.MaterialsTags)
+            .ThenInclude(x => x.Tag)
+            .Single(x => x.Name == "soap");
+        MudSharp.Models.Material paraffinWax = context.Materials
+            .Include(x => x.MaterialsTags)
+            .ThenInclude(x => x.Tag)
+            .Single(x => x.Name == "paraffin wax");
+        MudSharp.Models.Material salt = context.Materials.Single(x => x.Name == "salt");
+        MudSharp.Models.Material guano = context.Materials.Single(x => x.Name == "guano");
+        MudSharp.Models.Material cream = context.Materials.Single(x => x.Name == "cream");
+
+        Assert.IsTrue(context.Materials.Count() >= Math.Ceiling(baselineCount * 1.25),
+            $"Expected at least a 25% material increase over the baseline catalogue of {baselineCount} materials.");
+        Assert.IsFalse(context.Tags.Any(x => x.Name == "Water Soluable"));
+        Assert.IsTrue(context.Tags.Any(x => x.Name == "Water Soluble"));
+        Assert.IsTrue(coachwood.MaterialAliases.Any(x => x.Alias == "coach"));
+        Assert.IsTrue(aubergine.MaterialAliases.Any(x => x.Alias == "eggplant"));
+        Assert.IsTrue(aubergine.MaterialAliases.Any(x => x.Alias == "brinjal"));
+        Assert.AreEqual((int)MaterialBehaviourType.Feces, guano.BehaviourType);
+        Assert.IsFalse(salt.Organic);
+        Assert.IsTrue(cream.Organic);
+        Assert.IsTrue(paper.MaterialsTags.Any(x => x.Tag.Name == "Paper Product"));
+        Assert.IsTrue(soap.MaterialsTags.Any(x => x.Tag.Name == "Manufactured Materials"));
+        Assert.IsFalse(soap.MaterialsTags.Any(x => x.Tag.Name == "Natural Materials"));
+        Assert.IsFalse(paraffinWax.MaterialsTags.Any(x => x.Tag.Name == "Natural Materials"));
+        Assert.IsTrue(context.Materials.Any(x => x.Name == "bone"));
+        Assert.IsTrue(context.Materials.Any(x => x.Name == "blood"));
+        Assert.IsTrue(context.Materials.Any(x => x.Name == "rosewood"));
     }
 }

--- a/DatabaseSeeder Unit Tests/CoreDataSeederTerrainTests.cs
+++ b/DatabaseSeeder Unit Tests/CoreDataSeederTerrainTests.cs
@@ -109,6 +109,21 @@ public class CoreDataSeederTerrainTests
         CoreDataSeeder.SeedTerrainFoundationsForTesting(context);
     }
 
+    private static HashSet<string> GetTerrainTagNames(FuturemudDatabaseContext context, Terrain terrain)
+    {
+        if (string.IsNullOrWhiteSpace(terrain.TagInformation))
+        {
+            return [];
+        }
+
+        Dictionary<long, string> tags = context.Tags.ToDictionary(x => x.Id, x => x.Name);
+        return terrain.TagInformation
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(long.Parse)
+            .Select(x => tags[x])
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
     [TestMethod]
     public void SeedTerrainFoundationsForTesting_SeedsTerrainTagsAndCatalogue()
     {
@@ -158,5 +173,53 @@ public class CoreDataSeederTerrainTests
 
         Assert.IsFalse(ids.Contains("terrain"));
         Assert.AreEqual(ShouldSeedResult.ReadyToInstall, seeder.ShouldSeedData(context));
+    }
+
+    [TestMethod]
+    public void SeedTerrainFoundationsForTesting_CorrectsTerrainBehavioursAndAddsExtraterrestrialTerrains()
+    {
+        using FuturemudDatabaseContext context = BuildContext();
+
+        SeedTerrainFoundations(context);
+
+        Terrain cave = context.Terrains.Single(x => x.Name == "Cave");
+        Terrain cavePool = context.Terrains.Single(x => x.Name == "Cave Pool");
+        Terrain undergroundWater = context.Terrains.Single(x => x.Name == "Underground Water");
+        Terrain villageStreet = context.Terrains.Single(x => x.Name == "Village Street");
+        Terrain ruralStreet = context.Terrains.Single(x => x.Name == "Rural Street");
+        Terrain mudflat = context.Terrains.Single(x => x.Name == "Mudflat");
+        long springWaterId = context.Liquids.Single(x => x.Name == "spring water").Id;
+
+        Assert.AreEqual("cave", cave.TerrainBehaviourMode);
+        Assert.AreEqual($"shallowwatercave {springWaterId}", cavePool.TerrainBehaviourMode);
+        Assert.AreEqual($"deepwatercave {springWaterId}", undergroundWater.TerrainBehaviourMode);
+
+        HashSet<string> villageStreetTags = GetTerrainTagNames(context, villageStreet);
+        HashSet<string> ruralStreetTags = GetTerrainTagNames(context, ruralStreet);
+        HashSet<string> mudflatTags = GetTerrainTagNames(context, mudflat);
+
+        Assert.IsTrue(villageStreetTags.Contains("Rural"));
+        Assert.IsFalse(villageStreetTags.Contains("Urban"));
+        Assert.IsTrue(ruralStreetTags.Contains("Rural"));
+        Assert.IsFalse(ruralStreetTags.Contains("Urban"));
+        Assert.IsTrue(mudflatTags.Contains("Littoral"));
+        Assert.IsTrue(mudflatTags.Contains("Wetland"));
+        Assert.IsFalse(mudflatTags.Contains("Aquatic"));
+
+        foreach (string tagName in new[]
+                 { "Extraterrestrial", "Lunar", "Space", "Vacuum", "Arid", "Glacial", "Volcanic", "Wetland" })
+        {
+            Assert.IsTrue(context.Tags.Any(x => x.Name == tagName), $"Expected terrain tag {tagName} to be seeded.");
+        }
+
+        foreach (string terrainName in new[]
+                 {
+                     "Chaparral", "Badlands", "Salt Flat", "Fen", "Marsh", "Oasis", "Volcanic Plain", "Glacier",
+                     "Moon Surface", "Lunar Mare", "Lunar Crater", "Interstellar Space", "Intergalactic Space"
+                 })
+        {
+            Assert.IsTrue(context.Terrains.Any(x => x.Name == terrainName),
+                $"Expected terrain {terrainName} to be present in the stock catalogue.");
+        }
     }
 }

--- a/DatabaseSeeder Unit Tests/CoreDataSeederUnitsTests.cs
+++ b/DatabaseSeeder Unit Tests/CoreDataSeederUnitsTests.cs
@@ -1,0 +1,77 @@
+#nullable enable
+
+using DatabaseSeeder.Seeders;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Database;
+using MudSharp.Framework.Units;
+using MudSharp.Models;
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class CoreDataSeederUnitsTests
+{
+	private static FuturemudDatabaseContext BuildContext()
+	{
+		DbContextOptions<FuturemudDatabaseContext> options = new DbContextOptionsBuilder<FuturemudDatabaseContext>()
+			.UseInMemoryDatabase(Guid.NewGuid().ToString())
+			.ConfigureWarnings(x => x.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+			.Options;
+		return new FuturemudDatabaseContext(options);
+	}
+
+	private static void SeedUnitsOfMeasure(FuturemudDatabaseContext context)
+	{
+		typeof(CoreDataSeeder)
+			.GetMethod("SeedUnitsOfMeasure", BindingFlags.Static | BindingFlags.NonPublic)!
+			.Invoke(null, [context]);
+		context.SaveChanges();
+	}
+
+	[TestMethod]
+	public void SeedUnitsOfMeasure_SeedsImperialUkAndCorrectsLegacyIssues()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedUnitsOfMeasure(context);
+
+		Assert.IsTrue(context.UnitsOfMeasure.Any(x => x.System == "Imperial-UK"));
+		Assert.IsTrue(context.UnitsOfMeasure.Any(x => x.System == "Imperial" && x.Name == "short ton"));
+		Assert.IsFalse(context.UnitsOfMeasure.Any(x => x.System == "Imperial" && x.Name == "tonne"));
+		Assert.AreEqual("ML", context.UnitsOfMeasure.Single(x => x.System == "Metric" && x.Name == "megalitre").PrimaryAbbreviation);
+		Assert.AreEqual("ug", context.UnitsOfMeasure.Single(x => x.System == "Metric" && x.Name == "microgram").PrimaryAbbreviation);
+
+		UnitOfMeasure imperialThou = context.UnitsOfMeasure.Single(x => x.System == "Imperial" && x.Name == "thou");
+		UnitOfMeasure imperialBmi = context.UnitsOfMeasure.Single(x => x.System == "Imperial" && x.Type == (int)UnitType.BMI);
+		UnitOfMeasure usGallon = context.UnitsOfMeasure.Single(x => x.System == "Imperial" && x.Name == "gallon");
+		UnitOfMeasure ukGallon = context.UnitsOfMeasure.Single(x => x.System == "Imperial-UK" && x.Name == "gallon");
+
+		Assert.AreEqual((int)UnitType.Length, imperialThou.Type);
+		Assert.AreEqual(703.06957964, imperialBmi.BaseMultiplier, 0.0000001);
+		Assert.AreEqual(4.54609, ukGallon.BaseMultiplier, 0.0000001);
+		Assert.IsTrue(ukGallon.BaseMultiplier > usGallon.BaseMultiplier);
+	}
+
+	[TestMethod]
+	public void SeedUnitsOfMeasure_SeedsExpectedDisplayDefaultsPerSystem()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedUnitsOfMeasure(context);
+
+		string[] systems = context.UnitsOfMeasure
+			.Select(x => x.System)
+			.Distinct()
+			.OrderBy(x => x)
+			.ToArray();
+
+		CollectionAssert.AreEqual(new[] { "Imperial", "Imperial-UK", "Metric" }, systems);
+		Assert.IsTrue(context.UnitsOfMeasure.Any(x => x.System == "Imperial-UK" && x.DefaultUnitForSystem && x.Name == "pint"));
+		Assert.IsTrue(context.UnitsOfMeasure.Any(x => x.System == "Imperial-UK" && x.DefaultUnitForSystem && x.Name == "celsius"));
+		Assert.IsTrue(context.UnitsOfMeasure.Any(x => x.System == "Imperial" && x.DefaultUnitForSystem && x.Name == "fahrenheit"));
+		Assert.IsTrue(context.UnitsOfMeasure.Any(x => x.System == "Metric" && x.DefaultUnitForSystem && x.Name == "kg/m2"));
+	}
+}

--- a/DatabaseSeeder/Seeders/CoreDataSeeder.Materials.cs
+++ b/DatabaseSeeder/Seeders/CoreDataSeeder.Materials.cs
@@ -1,0 +1,355 @@
+#nullable enable
+
+using Microsoft.EntityFrameworkCore;
+using MudSharp.Database;
+using MudSharp.Form.Material;
+using MudSharp.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DatabaseSeeder.Seeders;
+
+public partial class CoreDataSeeder
+{
+	private void SeedMaterials(FuturemudDatabaseContext context)
+	{
+		SeedMaterialsBase(context);
+
+		var tags = context.Tags
+			.AsEnumerable()
+			.ToDictionary(x => x.Name, x => x, StringComparer.InvariantCultureIgnoreCase);
+		var materials = context.Materials
+			.Include(x => x.MaterialAliases)
+			.Include(x => x.MaterialsTags)
+			.AsEnumerable()
+			.ToDictionary(x => x.Name, x => x, StringComparer.InvariantCultureIgnoreCase);
+
+		if (tags.Remove("Water Soluable", out var waterSolubleTag))
+		{
+			waterSolubleTag.Name = "Water Soluble";
+			tags[waterSolubleTag.Name] = waterSolubleTag;
+		}
+
+		void EnsureTag(Material material, string tagName)
+		{
+			var tag = tags[tagName];
+			if (material.MaterialsTags.Any(x => x.TagId == tag.Id))
+			{
+				return;
+			}
+
+			material.MaterialsTags.Add(new MaterialsTags
+			{
+				Material = material,
+				Tag = tag
+			});
+		}
+
+		void RemoveTag(Material material, string tagName)
+		{
+			if (!tags.TryGetValue(tagName, out var tag))
+			{
+				return;
+			}
+
+			foreach (var relation in material.MaterialsTags.Where(x => x.TagId == tag.Id).ToList())
+			{
+				material.MaterialsTags.Remove(relation);
+				context.MaterialsTags.Remove(relation);
+			}
+		}
+
+		void EnsureAlias(Material material, params string[] aliases)
+		{
+			foreach (var alias in aliases)
+			{
+				var canonicalAlias = alias.ToLowerInvariant();
+				if (material.MaterialAliases.Any(x => x.Alias.Equals(canonicalAlias, StringComparison.InvariantCultureIgnoreCase)))
+				{
+					continue;
+				}
+
+				material.MaterialAliases.Add(new MaterialAlias
+				{
+					Material = material,
+					Alias = canonicalAlias
+				});
+			}
+		}
+
+		void RenameMaterial(string currentName, string newName, params string[] aliases)
+		{
+			var material = materials[currentName];
+			materials.Remove(currentName);
+			material.Name = newName;
+			material.MaterialDescription = newName;
+			materials[newName] = material;
+			EnsureAlias(material, aliases);
+		}
+
+		void AddMaterial(string name, MaterialBehaviourType type, double relativeDensity, bool organic,
+			double shearStrength, double impactStrength, double absorbency, double thermalConductivity,
+			double electricalConductivity, double specificHeatCapacity, params string[] materialTags)
+		{
+			if (materials.ContainsKey(name))
+			{
+				return;
+			}
+
+			var material = new Material
+			{
+				Name = name,
+				MaterialDescription = name,
+				BehaviourType = (int)type,
+				Type = (int)MaterialType.Solid,
+				Density = 1000 * relativeDensity,
+				Organic = organic,
+				Absorbency = absorbency,
+				ShearYield = shearStrength,
+				ImpactYield = impactStrength > 0.0 ? impactStrength : shearStrength * 2.2,
+				ElectricalConductivity = electricalConductivity,
+				ThermalConductivity = thermalConductivity,
+				SpecificHeatCapacity = specificHeatCapacity,
+				ResidueColour = "white",
+				SolventVolumeRatio = 1.0
+			};
+
+			context.Materials.Add(material);
+			materials[name] = material;
+			foreach (var tag in materialTags)
+			{
+				EnsureTag(material, tag);
+			}
+		}
+
+		RenameMaterial("coach", "coachwood", "coach");
+		RenameMaterial("aubergene", "aubergine", "aubergene", "eggplant", "brinjal");
+
+		materials["salt"].Organic = false;
+		materials["guano"].BehaviourType = (int)MaterialBehaviourType.Feces;
+		materials["cream"].Organic = true;
+
+		EnsureTag(materials["cardboard"], "Paper Product");
+		EnsureTag(materials["paper"], "Paper Product");
+		EnsureTag(materials["papyrus"], "Paper Product");
+		EnsureTag(materials["soap"], "Manufactured Materials");
+		EnsureTag(materials["paraffin wax"], "Manufactured Materials");
+		EnsureTag(materials["calcium hydroxide"], "Manufactured Materials");
+		EnsureTag(materials["calcium oxide"], "Manufactured Materials");
+		EnsureTag(materials["lye"], "Manufactured Materials");
+		EnsureTag(materials["portland cement"], "Manufactured Materials");
+		EnsureTag(materials["roman cement"], "Manufactured Materials");
+		EnsureTag(materials["slaked lime"], "Manufactured Materials");
+
+		RemoveTag(materials["soap"], "Natural Materials");
+		RemoveTag(materials["soap"], "Animal Product");
+		RemoveTag(materials["paraffin wax"], "Natural Materials");
+		RemoveTag(materials["calcium hydroxide"], "Natural Materials");
+		RemoveTag(materials["calcium oxide"], "Natural Materials");
+		RemoveTag(materials["lye"], "Natural Materials");
+		RemoveTag(materials["portland cement"], "Natural Materials");
+		RemoveTag(materials["roman cement"], "Natural Materials");
+		RemoveTag(materials["slaked lime"], "Natural Materials");
+
+		foreach (var name in new[]
+		{
+			"duck", "goose", "goat", "turkey", "boar", "buffalo", "bison", "elk", "horse", "pigeon", "quail",
+			"ostrich", "mutton", "kangaroo", "alligator"
+		})
+		{
+			AddMaterial(name, MaterialBehaviourType.Meat, 1.3, true, 10000, 10000, 0.0, 0.14, 0.0001, 500, "Meat");
+		}
+
+		foreach (var name in new[]
+		{
+			"cherry", "fig", "date", "coconut", "guava", "grapefruit", "mandarin", "tangerine", "persimmon",
+			"quince", "cranberry", "raspberry", "blackberry", "strawberry", "blueberry", "watermelon",
+			"cantaloupe", "honeydew", "lychee", "papaya", "kiwi fruit", "passionfruit", "currant", "dragonfruit"
+		})
+		{
+			AddMaterial(name, MaterialBehaviourType.Food, 1.0, true, 1000, 1000, 0.0, 0.14, 0.0001, 500, "Fruit");
+		}
+
+		EnsureAlias(materials["kiwi fruit"], "kiwi");
+
+		foreach (var name in new[]
+		{
+			"celery", "asparagus", "artichoke", "kale", "chard", "parsnip", "rutabaga", "okra", "cassava", "taro",
+			"plantain", "mushroom", "brussels sprout", "shallot", "bok choy", "watercress", "radicchio",
+			"fennel bulb"
+		})
+		{
+			AddMaterial(name, MaterialBehaviourType.Food, 1.0, true, 1000, 1000, 0.0, 0.14, 0.0001, 500,
+				"Vegetable");
+		}
+
+		foreach (var name in new[]
+		{
+			"chive", "marjoram", "lemongrass", "bay leaf", "tarragon", "savory", "chamomile", "lavender", "sorrel",
+			"nettle"
+		})
+		{
+			AddMaterial(name, MaterialBehaviourType.Plant, 1.0, true, 1000, 1000, 0.0, 0.14, 0.0001, 500, "Herb");
+		}
+
+		foreach (var name in new[]
+		{
+			"cardamom", "allspice", "anise", "star anise", "caraway", "fenugreek", "mustard seed", "vanilla",
+			"sumac", "sesame seed", "poppy seed", "mace", "wasabi", "white pepper"
+		})
+		{
+			AddMaterial(name, MaterialBehaviourType.Powder, 1.0, true, 1000, 1000, 0.0, 0.14, 0.0001, 500, "Spice");
+		}
+
+		foreach (var name in new[]
+		{
+			"flatbread", "biscuit", "cracker", "cake", "muffin", "bagel", "bun", "tortilla", "croissant",
+			"dumpling"
+		})
+		{
+			AddMaterial(name, MaterialBehaviourType.Food, 1.0, true, 1000, 1000, 0.0, 0.14, 0.0001, 500,
+				"Baked Good");
+		}
+
+		foreach (var name in new[]
+		{
+			"butter", "ghee", "cream cheese", "cottage cheese", "curd", "whey", "clotted cream", "buttermilk"
+		})
+		{
+			AddMaterial(name, MaterialBehaviourType.Food, 1.0, true, 1000, 1000, 0.0, 0.14, 0.0001, 500, "Food",
+				"Animal Product");
+		}
+
+		foreach (var name in new[]
+		{
+			"oat", "millet", "quinoa", "buckwheat", "sugarcane", "cacao", "coffee bean", "tea leaf", "hop",
+			"alfalfa"
+		})
+		{
+			AddMaterial(name, MaterialBehaviourType.Food, 1.0, true, 1000, 1000, 0.0, 0.14, 0.0001, 500,
+				"Food Crop");
+		}
+
+		foreach (var name in new[] { "cotton crop", "hemp crop", "jute crop", "ramie", "sisal" })
+		{
+			AddMaterial(name, MaterialBehaviourType.Plant, 1.0, true, 1000, 1000, 0.0, 0.14, 0.0001, 500,
+				"Fiber Crop");
+		}
+
+		foreach (var name in new[] { "canola", "rapeseed", "sesame", "sunflower", "safflower", "peanut crop", "olive crop" })
+		{
+			AddMaterial(name, MaterialBehaviourType.Plant, 1.0, true, 1000, 1000, 0.0, 0.14, 0.0001, 500,
+				"Oil Crop");
+		}
+
+		foreach (var name in new[]
+		{
+			"acacia", "applewood", "birch", "blackwood", "cypress", "holly", "hornbeam", "juniper", "larch",
+			"linden", "olive wood", "pearwood", "poplar", "redwood", "rowan", "sycamore", "tamarind wood",
+			"wenge", "ironwood", "jacaranda", "rosewood"
+		})
+		{
+			AddMaterial(name, MaterialBehaviourType.Wood, 0.5, true, 40000, 10000, 0.05, 0.14, 0.0001, 420,
+				"Hardwood");
+		}
+
+		foreach (var name in new[]
+		{
+			"travertine", "serpentine", "pumice", "tuff", "scoria", "soapstone", "flint", "breccia", "dolostone",
+			"arkose", "laterite", "marlstone", "trachyte", "komatiite", "anorthosite"
+		})
+		{
+			AddMaterial(name, MaterialBehaviourType.Stone, 2.8, false, 10000, 200000, 0.0, 0.14, 0.0001, 500,
+				"Stone");
+		}
+
+		foreach (var name in new[]
+		{
+			"garnet", "zircon", "labradorite", "fluorite", "iolite", "kunzite", "morganite", "chrysoberyl",
+			"bloodstone", "smoky quartz", "amazonite", "rhodonite", "charoite", "larimar", "tiger's eye",
+			"unakite"
+		})
+		{
+			AddMaterial(name, MaterialBehaviourType.Stone, 3.5, false, 60000000, 200000, 0.0, 0.14, 0.0001, 500,
+				"Gemstone");
+		}
+
+		foreach (var name in new[]
+		{
+			"satin", "velvet", "lace", "muslin", "corduroy", "flannel", "gabardine", "seersucker", "twill",
+			"cambric"
+		})
+		{
+			AddMaterial(name, MaterialBehaviourType.Fabric, 1.5, true, 10000, 25000, 2.0, 0.14, 0.0001, 500,
+				"Natural Fiber Fabric");
+		}
+
+		foreach (var name in new[]
+		{
+			"rayon", "viscose", "chiffon", "organza", "fleece", "jersey knit", "aramid fiber", "olefin fabric"
+		})
+		{
+			AddMaterial(name, MaterialBehaviourType.Fabric, 1.3, false, 10000, 25000, 0.0, 0.14, 0.0001, 500,
+				"Synthetic Fiber Fabric");
+		}
+
+		foreach (var name in new[]
+		{
+			"ceramic tile", "stone tile", "porcelain tile", "mortar", "grout", "clinker", "firebrick",
+			"glazed ceramic", "enamelware", "refractory brick"
+		})
+		{
+			AddMaterial(name, MaterialBehaviourType.Ceramic, 2.0, false, 40000, 100000, 0.0, 0.002, 0.0001, 500,
+				"Ceramic");
+		}
+
+		foreach (var name in new[]
+		{
+			"acetal", "epoxy resin", "phenolic resin", "PTFE", "ethylene-vinyl acetate", "neoprene",
+			"silicone rubber", "vinyl ester resin", "polyethylene foam"
+		})
+		{
+			AddMaterial(name, MaterialBehaviourType.Plastic, 1.0, false, 25000, 55000, 0.0, 0.2, 0.0001, 1200,
+				"Plastic");
+		}
+
+		AddMaterial("bone", MaterialBehaviourType.Bone, 1.8, true, 25000, 60000, 0.05, 0.32, 0.0001, 1300,
+			"Animal Product");
+		AddMaterial("muscle", MaterialBehaviourType.Muscle, 1.05, true, 12000, 15000, 0.05, 0.5, 0.0001, 3400,
+			"Animal Product");
+		AddMaterial("blood", MaterialBehaviourType.Blood, 1.06, true, 1000, 1000, 0.0, 0.5, 0.7, 3600,
+			"Animal Product");
+		AddMaterial("skin", MaterialBehaviourType.Skin, 1.1, true, 12000, 15000, 0.2, 0.14, 0.0001, 2500,
+			"Animal Skin");
+		AddMaterial("claw", MaterialBehaviourType.Claw, 1.2, true, 20000, 50000, 0.05, 0.14, 0.0001, 500,
+			"Animal Product");
+		AddMaterial("beak", MaterialBehaviourType.Beak, 1.2, true, 20000, 50000, 0.05, 0.14, 0.0001, 500,
+			"Animal Product");
+		AddMaterial("resin", MaterialBehaviourType.Paste, 1.1, true, 8000, 12000, 0.0, 0.19, 0.0001, 1800,
+			"Natural Materials");
+		AddMaterial("pitch", MaterialBehaviourType.Paste, 1.2, false, 8000, 12000, 0.0, 0.15, 0.0001, 1700,
+			"Manufactured Materials");
+		AddMaterial("tar", MaterialBehaviourType.Grease, 1.15, false, 8000, 12000, 0.0, 0.12, 0.0001, 1600,
+			"Manufactured Materials");
+		AddMaterial("shellac", MaterialBehaviourType.Paste, 1.1, true, 8000, 12000, 0.0, 0.18, 0.0001, 1700,
+			"Animal Product");
+		AddMaterial("latex", MaterialBehaviourType.Elastomer, 0.95, true, 12000, 25000, 0.0, 0.14, 0.0001, 2000,
+			"Elastomer");
+		AddMaterial("charcoal", MaterialBehaviourType.Powder, 0.4, true, 2000, 2000, 0.2, 0.08, 0.0001, 1000,
+			"Natural Materials");
+		AddMaterial("soot", MaterialBehaviourType.Powder, 0.25, true, 1000, 1000, 0.2, 0.08, 0.0001, 900,
+			"Natural Materials");
+		AddMaterial("chalk dust", MaterialBehaviourType.Powder, 0.7, false, 1000, 1000, 0.1, 0.16, 0.0001, 900,
+			"Stone");
+		AddMaterial("sponge", MaterialBehaviourType.Fabric, 0.3, true, 2000, 5000, 5.0, 0.05, 0.0001, 600,
+			"Natural Materials");
+
+		EnsureAlias(materials["PTFE"], "teflon");
+		EnsureAlias(materials["silicone rubber"], "silicone");
+		EnsureAlias(materials["ethylene-vinyl acetate"], "eva");
+		EnsureAlias(materials["olefin fabric"], "polyolefin fabric");
+
+		context.SaveChanges();
+	}
+}

--- a/DatabaseSeeder/Seeders/CoreDataSeeder.Terrain.cs
+++ b/DatabaseSeeder/Seeders/CoreDataSeeder.Terrain.cs
@@ -35,7 +35,15 @@ public partial class CoreDataSeeder
         ("Terrestrial", "Wild"),
         ("Riparian", "Wild"),
         ("Littoral", "Wild"),
-        ("Aquatic", "Wild")
+        ("Aquatic", "Wild"),
+        ("Extraterrestrial", "Wild"),
+        ("Lunar", "Extraterrestrial"),
+        ("Space", "Extraterrestrial"),
+        ("Vacuum", "Terrain"),
+        ("Arid", "Terrain"),
+        ("Glacial", "Terrain"),
+        ("Volcanic", "Terrain"),
+        ("Wetland", "Terrain")
     ];
 
     internal static IReadOnlyCollection<string> StockTerrainTagNamesForTesting =>
@@ -222,9 +230,9 @@ public partial class CoreDataSeeder
         AddTerrain("Wealthy Street", "outdoors", 0.75, 7.0, Difficulty.Easy, Difficulty.Automatic,
                 "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Gainsboro, tags: ["Urban", "Public"]);
         AddTerrain("Village Street", "outdoors", 0.75, 7.0, Difficulty.Easy, Difficulty.Automatic,
-                "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.LightGray, tags: ["Urban", "Public"]);
+                "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.LightGray, tags: ["Rural"]);
         AddTerrain("Rural Street", "outdoors", 0.75, 7.0, Difficulty.Easy, Difficulty.Automatic,
-                "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.WhiteSmoke, tags: ["Urban", "Public"]);
+                "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.WhiteSmoke, tags: ["Rural"]);
 
         AddTerrain("Marketplace", "outdoors", 1.0, 7.0, Difficulty.Easy, Difficulty.VeryEasy, "Breathable Atmosphere",
                 CellOutdoorsType.Outdoors, Color.SlateGray, tags: ["Urban", "Commercial", "Public"]);
@@ -307,7 +315,13 @@ public partial class CoreDataSeeder
         AddTerrain("Tundra", "outdoors", 2.0, 15.0, Difficulty.Normal, Difficulty.Automatic, "Breathable Atmosphere",
             CellOutdoorsType.Outdoors, Color.LightGreen, tags: ["Terrestrial", "Diggable Soil"]);
         AddTerrain("Flood Plain", "outdoors", 2.0, 15.0, Difficulty.Normal, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.LightGreen, tags: ["Terrestrial", "Diggable Soil", "Foragable Clay"]);
+            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.LightGreen, tags: ["Terrestrial", "Riparian", "Diggable Soil", "Foragable Clay"]);
+        AddTerrain("Chaparral", "outdoors", 2.5, 18.0, Difficulty.Normal, Difficulty.Automatic,
+            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.OliveDrab, tags: ["Terrestrial", "Arid", "Diggable Soil"]);
+        AddTerrain("Badlands", "outdoors", 3.5, 18.0, Difficulty.Hard, Difficulty.Automatic,
+            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.SandyBrown, tags: ["Terrestrial", "Arid"]);
+        AddTerrain("Salt Flat", "outdoors", 2.5, 18.0, Difficulty.Hard, Difficulty.Automatic,
+            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Linen, tags: ["Terrestrial", "Arid", "Foragable Sand"]);
 
         AddTerrain("Hills", "outdoors", 3.0, 15.0, Difficulty.Easy, Difficulty.Automatic, "Breathable Atmosphere",
             CellOutdoorsType.Outdoors, Color.OrangeRed, tags: ["Terrestrial", "Diggable Soil"]);
@@ -333,6 +347,14 @@ public partial class CoreDataSeeder
             CellOutdoorsType.Outdoors, Color.OrangeRed, tags: ["Terrestrial", "Diggable Soil"]);
         AddTerrain("Dunes", "outdoors", 3.0, 15.0, Difficulty.Easy, Difficulty.Automatic, "Breathable Atmosphere",
             CellOutdoorsType.Outdoors, Color.OrangeRed, tags: ["Terrestrial", "Diggable Soil", "Foragable Sand"]);
+        AddTerrain("Plateau", "outdoors", 3.0, 15.0, Difficulty.Easy, Difficulty.Automatic,
+            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Peru, tags: ["Terrestrial", "Diggable Soil"]);
+        AddTerrain("Escarpment", "cliff", 4.5, 22.0, Difficulty.VeryHard, Difficulty.Automatic,
+            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.IndianRed, tags: ["Terrestrial"]);
+        AddTerrain("Scree Slope", "outdoors", 4.0, 25.0, Difficulty.Hard, Difficulty.Automatic,
+            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkKhaki, tags: ["Terrestrial"]);
+        AddTerrain("Talus Field", "outdoors", 4.0, 25.0, Difficulty.Hard, Difficulty.Automatic,
+            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkGoldenrod, tags: ["Terrestrial"]);
 
         AddTerrain("Mountainside", "outdoors", 4.0, 20.0, Difficulty.ExtremelyEasy, Difficulty.Automatic,
             "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Red, tags: ["Terrestrial", "Diggable Soil"]);
@@ -386,37 +408,57 @@ public partial class CoreDataSeeder
             "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkGreen, tags: ["Rural", "Diggable Soil"]);
 
         AddTerrain("Bog", $"shallowwatertrees {swampwater.Id}", 4.0, 30.0, Difficulty.VeryEasy,
-            Difficulty.ExtremelyEasy, "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Purple, tags: ["Terrestrial", "Diggable Soil", "Foragable Clay"]);
+            Difficulty.ExtremelyEasy, "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Purple, tags: ["Terrestrial", "Wetland", "Diggable Soil", "Foragable Clay"]);
+        AddTerrain("Fen", $"shallowwater {swampwater.Id}", 4.0, 30.0, Difficulty.VeryEasy,
+            Difficulty.ExtremelyEasy, "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.MediumPurple, tags: ["Terrestrial", "Wetland", "Riparian", "Diggable Soil", "Foragable Clay"]);
+        AddTerrain("Marsh", $"shallowwater {swampwater.Id}", 4.0, 30.0, Difficulty.VeryEasy,
+            Difficulty.ExtremelyEasy, "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkMagenta, tags: ["Terrestrial", "Wetland", "Riparian", "Diggable Soil", "Foragable Clay"]);
         AddTerrain("Salt Marsh", $"shallowwater {brackishwater.Id}", 4.0, 30.0, Difficulty.VeryEasy,
-            Difficulty.ExtremelyEasy, "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Purple, tags: ["Terrestrial", "Diggable Soil"]);
+            Difficulty.ExtremelyEasy, "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Purple, tags: ["Terrestrial", "Littoral", "Wetland", "Diggable Soil", "Foragable Clay", "Foragable Sand"]);
         AddTerrain("Mangrove Swamp", $"shallowwatertrees {brackishwater.Id}", 4.0, 30.0, Difficulty.VeryEasy,
-            Difficulty.ExtremelyEasy, "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Purple, tags: ["Terrestrial", "Diggable Soil", "Foragable Sand"]);
+            Difficulty.ExtremelyEasy, "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Purple, tags: ["Terrestrial", "Littoral", "Wetland", "Diggable Soil", "Foragable Sand"]);
         AddTerrain("Wetland", $"shallowwater {swampwater.Id}", 4.0, 30.0, Difficulty.VeryEasy, Difficulty.ExtremelyEasy,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Purple, tags: ["Terrestrial", "Diggable Soil", "Foragable Clay"]);
+            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Purple, tags: ["Terrestrial", "Wetland", "Diggable Soil", "Foragable Clay"]);
         AddTerrain("Swamp Forest", $"shallowwatertrees {swampwater.Id}", 4.0, 30.0, Difficulty.VeryEasy,
-            Difficulty.ExtremelyEasy, "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Purple, tags: ["Terrestrial", "Diggable Soil", "Foragable Clay"]);
+            Difficulty.ExtremelyEasy, "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Purple, tags: ["Terrestrial", "Wetland", "Diggable Soil", "Foragable Clay"]);
         AddTerrain("Tropical Freshwater Swamp", $"shallowwatertrees {swampwater.Id}", 4.0, 30.0, Difficulty.VeryEasy,
-            Difficulty.ExtremelyEasy, "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Purple, tags: ["Terrestrial", "Diggable Soil", "Foragable Clay"]);
+            Difficulty.ExtremelyEasy, "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Purple, tags: ["Terrestrial", "Wetland", "Diggable Soil", "Foragable Clay"]);
         AddTerrain("Temperate Freshwater Swamp", $"shallowwatertrees {swampwater.Id}", 4.0, 30.0, Difficulty.VeryEasy,
-            Difficulty.ExtremelyEasy, "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Purple, tags: ["Terrestrial", "Diggable Soil", "Foragable Clay"]);
+            Difficulty.ExtremelyEasy, "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Purple, tags: ["Terrestrial", "Wetland", "Diggable Soil", "Foragable Clay"]);
 
         AddTerrain("Sandy Desert", "outdoors", 4.0, 20.0, Difficulty.VeryHard, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Yellow, tags: ["Terrestrial", "Diggable Soil", "Foragable Sand"]);
+            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Yellow, tags: ["Terrestrial", "Arid", "Diggable Soil", "Foragable Sand"]);
         AddTerrain("Rocky Desert", "outdoors", 4.0, 20.0, Difficulty.VeryHard, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Yellow, tags: ["Terrestrial", "Diggable Soil"]);
+            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Yellow, tags: ["Terrestrial", "Arid", "Diggable Soil"]);
         AddTerrain("Coastal Desert", "outdoors", 4.0, 20.0, Difficulty.VeryHard, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Yellow, tags: ["Terrestrial", "Diggable Soil", "Foragable Sand"]);
+            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Yellow, tags: ["Terrestrial", "Arid", "Diggable Soil", "Foragable Sand"]);
+        AddTerrain("Oasis", "trees", 2.0, 12.0, Difficulty.Easy, Difficulty.Automatic, "Breathable Atmosphere",
+            CellOutdoorsType.Outdoors, Color.MediumSeaGreen, tags: ["Terrestrial", "Arid", "Diggable Soil"]);
+        AddTerrain("Volcanic Plain", "outdoors", 3.5, 20.0, Difficulty.Hard, Difficulty.Automatic,
+            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Firebrick, tags: ["Terrestrial", "Volcanic"]);
+        AddTerrain("Lava Field", "outdoors", 4.0, 25.0, Difficulty.Hard, Difficulty.Automatic,
+            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkRed, tags: ["Terrestrial", "Volcanic"]);
+        AddTerrain("Caldera", "outdoors", 3.5, 20.0, Difficulty.Normal, Difficulty.Automatic,
+            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.IndianRed, tags: ["Terrestrial", "Volcanic"]);
+        AddTerrain("Crater", "outdoors", 3.5, 20.0, Difficulty.Normal, Difficulty.Automatic,
+            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.BurlyWood, tags: ["Terrestrial"]);
+        AddTerrain("Glacier", "outdoors", 4.0, 22.0, Difficulty.Hard, Difficulty.Automatic,
+            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.LightCyan, tags: ["Terrestrial", "Glacial"]);
+        AddTerrain("Ice Field", "outdoors", 3.0, 18.0, Difficulty.Hard, Difficulty.Automatic,
+            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.AliceBlue, tags: ["Terrestrial", "Glacial"]);
+        AddTerrain("Snowfield", "outdoors", 3.0, 18.0, Difficulty.Normal, Difficulty.Automatic,
+            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.WhiteSmoke, tags: ["Terrestrial", "Glacial"]);
 
         AddTerrain("Cave Entrance", "indoors", 3.0, 20.0, Difficulty.Normal, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.LightGreen, tags: ["Terrestrial"]);
-        AddTerrain("Cave", "indoors", 3.0, 20.0, Difficulty.Normal, Difficulty.Automatic, "Breathable Atmosphere",
-            CellOutdoorsType.Outdoors, Color.LightGreen, tags: ["Terrestrial"]);
-        AddTerrain("Cavern", "outdoors", 3.0, 20.0, Difficulty.Normal, Difficulty.Automatic, "Breathable Atmosphere",
-            CellOutdoorsType.Outdoors, Color.LightGreen, tags: ["Terrestrial"]);
-        AddTerrain("Cave Pool", $"watercave {springwater.Id}", 3.0, 10.0, Difficulty.Normal, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.LightGreen, tags: ["Aquatic"]);
-        AddTerrain("Underground Water", $"deepunderwater {springwater.Id}", 3.0, 10.0, Difficulty.Normal,
-            Difficulty.Automatic, "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.LightGreen, tags: ["Aquatic"]);
+            "Breathable Atmosphere", CellOutdoorsType.IndoorsClimateExposed, Color.LightGreen, tags: ["Terrestrial"]);
+        AddTerrain("Cave", "cave", 3.0, 20.0, Difficulty.Normal, Difficulty.Automatic, "Breathable Atmosphere",
+            CellOutdoorsType.IndoorsNoLight, Color.LightGreen, tags: ["Terrestrial"]);
+        AddTerrain("Cavern", "cave", 3.0, 20.0, Difficulty.Normal, Difficulty.Automatic, "Breathable Atmosphere",
+            CellOutdoorsType.IndoorsNoLight, Color.DarkSeaGreen, tags: ["Terrestrial"]);
+        AddTerrain("Cave Pool", $"shallowwatercave {springwater.Id}", 3.0, 10.0, Difficulty.Normal,
+            Difficulty.Automatic, "Breathable Atmosphere", CellOutdoorsType.IndoorsNoLight, Color.LightGreen, tags: ["Terrestrial", "Aquatic"]);
+        AddTerrain("Underground Water", $"deepwatercave {springwater.Id}", 3.0, 10.0, Difficulty.Normal,
+            Difficulty.Automatic, "Breathable Atmosphere", CellOutdoorsType.IndoorsNoLight, Color.LightGreen, tags: ["Terrestrial", "Aquatic"]);
 
         #endregion
 
@@ -434,13 +476,13 @@ public partial class CoreDataSeeder
             "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Yellow, tags: ["Littoral", "Diggable Soil", "Foragable Clay", "Foragable Sand"]);
 
         AddTerrain("Ocean Shallows", $"shallowwater {saltwater.Id}", 3.0, 10.0, Difficulty.Insane, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Sand"]);
+            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Littoral", "Foragable Sand"]);
         AddTerrain("Ocean Surf", $"water {saltwater.Id}", 3.0, 10.0, Difficulty.Insane, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Sand"]);
+            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Littoral", "Foragable Sand"]);
         AddTerrain("Ocean", $"deepwater {saltwater.Id}", 3.0, 10.0, Difficulty.Insane, Difficulty.Automatic,
             "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Sand"]);
-        AddTerrain("Mudflat", $"shallowwater {saltwater.Id}", 3.0, 10.0, Difficulty.Insane, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Sand"]);
+        AddTerrain("Mudflat", "outdoors", 4.0, 30.0, Difficulty.VeryHard, Difficulty.Automatic,
+            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.SaddleBrown, tags: ["Littoral", "Wetland", "Diggable Soil", "Foragable Clay", "Foragable Sand"]);
         AddTerrain("Bay", $"water {saltwater.Id}", 3.0, 10.0, Difficulty.Insane, Difficulty.Automatic,
             "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Sand"]);
         AddTerrain("Lagoon", $"water {brackishwater.Id}", 3.0, 10.0, Difficulty.Insane, Difficulty.Automatic,
@@ -473,6 +515,29 @@ public partial class CoreDataSeeder
             "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Clay", "Foragable Sand"]);
         AddTerrain("Deep Ocean", $"verydeepunderwater {saltwater.Id}", 3.0, 10.0, Difficulty.Insane,
             Difficulty.Automatic, null, CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Sand"]);
+
+        #endregion
+
+        #region Extraterrestrial
+
+        AddTerrain("Moon Surface", "outdoors", 2.5, 18.0, Difficulty.Hard, Difficulty.Automatic, null,
+            CellOutdoorsType.Outdoors, Color.LightSlateGray, tags: ["Extraterrestrial", "Lunar", "Vacuum"]);
+        AddTerrain("Lunar Mare", "outdoors", 2.5, 18.0, Difficulty.Hard, Difficulty.Automatic, null,
+            CellOutdoorsType.Outdoors, Color.DimGray, tags: ["Extraterrestrial", "Lunar", "Vacuum", "Volcanic"]);
+        AddTerrain("Lunar Highlands", "outdoors", 3.0, 20.0, Difficulty.Hard, Difficulty.Automatic, null,
+            CellOutdoorsType.Outdoors, Color.Gainsboro, tags: ["Extraterrestrial", "Lunar", "Vacuum"]);
+        AddTerrain("Lunar Crater", "outdoors", 3.5, 22.0, Difficulty.Hard, Difficulty.Automatic, null,
+            CellOutdoorsType.Outdoors, Color.Gray, tags: ["Extraterrestrial", "Lunar", "Vacuum"]);
+        AddTerrain("Asteroid Surface", "outdoors", 4.0, 25.0, Difficulty.Hard, Difficulty.Automatic, null,
+            CellOutdoorsType.Outdoors, Color.DarkSlateGray, tags: ["Extraterrestrial", "Vacuum"]);
+        AddTerrain("Orbital Space", "outdoors", 1.0, 5.0, Difficulty.Insane, Difficulty.Automatic, null,
+            CellOutdoorsType.Outdoors, Color.Black, tags: ["Extraterrestrial", "Space", "Vacuum"]);
+        AddTerrain("Interplanetary Space", "outdoors", 1.0, 5.0, Difficulty.Insane, Difficulty.Automatic, null,
+            CellOutdoorsType.Outdoors, Color.Black, tags: ["Extraterrestrial", "Space", "Vacuum"]);
+        AddTerrain("Interstellar Space", "outdoors", 1.0, 5.0, Difficulty.Insane, Difficulty.Automatic, null,
+            CellOutdoorsType.Outdoors, Color.Black, tags: ["Extraterrestrial", "Space", "Vacuum"]);
+        AddTerrain("Intergalactic Space", "outdoors", 1.0, 5.0, Difficulty.Insane, Difficulty.Automatic, null,
+            CellOutdoorsType.Outdoors, Color.Black, tags: ["Extraterrestrial", "Space", "Vacuum"]);
 
         #endregion
 

--- a/DatabaseSeeder/Seeders/CoreDataSeeder.Units.cs
+++ b/DatabaseSeeder/Seeders/CoreDataSeeder.Units.cs
@@ -1,0 +1,281 @@
+#nullable enable
+
+using MudSharp.Database;
+using MudSharp.Framework.Units;
+using MudSharp.Models;
+
+namespace DatabaseSeeder.Seeders;
+
+public partial class CoreDataSeeder
+{
+	private static void SeedUnitsOfMeasure(FuturemudDatabaseContext context)
+	{
+		const string metricSystem = "Metric";
+		const string imperialUsSystem = "Imperial";
+		const string imperialUkSystem = "Imperial-UK";
+
+		void AddUnit(long id, string name, string primaryAbbreviation, string abbreviations, double baseMultiplier,
+			double preMultiplierBaseOffset, double postMultiplierBaseOffset, UnitType type, bool describer,
+			bool spaceBetween, string system, bool defaultUnitForSystem)
+		{
+			context.UnitsOfMeasure.Add(new UnitOfMeasure
+			{
+				Id = id,
+				Name = name,
+				PrimaryAbbreviation = primaryAbbreviation,
+				Abbreviations = abbreviations,
+				BaseMultiplier = baseMultiplier,
+				PreMultiplierBaseOffset = preMultiplierBaseOffset,
+				PostMultiplierBaseOffset = postMultiplierBaseOffset,
+				Type = (int)type,
+				Describer = describer,
+				SpaceBetween = spaceBetween,
+				System = system,
+				DefaultUnitForSystem = defaultUnitForSystem
+			});
+		}
+
+		AddUnit(1, "gram", "g", "gram grams g", 1.0, 0.0, 0.0, UnitType.Mass, true, true, metricSystem, true);
+		AddUnit(2, "kilogram", "kg", "kilogram kilograms kilo kilos kg", 1000.0, 0.0, 0.0, UnitType.Mass, true,
+			true, metricSystem, false);
+		AddUnit(3, "tonne", "t", "tonne tonnes metricton metrictons t", 1000000.0, 0.0, 0.0, UnitType.Mass, true,
+			true, metricSystem, false);
+		AddUnit(4, "pound", "lb", "pound pounds lb lbs", 453.59237, 0.0, 0.0, UnitType.Mass, true, true,
+			imperialUsSystem, true);
+		AddUnit(5, "ounce", "oz", "ounce ounces oz", 28.349523125, 0.0, 0.0, UnitType.Mass, true, true,
+			imperialUsSystem, false);
+		AddUnit(6, "centimetre", "cm", "centimetre centimetres centimeter centimeters cm cms", 1.0, 0.0, 0.0,
+			UnitType.Length, true, true, metricSystem, false);
+		AddUnit(7, "metre", "m", "metre metres meter meters m", 100.0, 0.0, 0.0, UnitType.Length, true, true,
+			metricSystem, true);
+		AddUnit(8, "millimetre", "mm", "millimetre millimetres millimeter millimeters mm", 0.1, 0.0, 0.0,
+			UnitType.Length, false, true, metricSystem, false);
+		AddUnit(9, "foot", "ft", "foot feet ft '", 30.48, 0.0, 0.0, UnitType.Length, true, true, imperialUsSystem,
+			true);
+		AddUnit(10, "inch", "in", "inch inches in \"", 2.54, 0.0, 0.0, UnitType.Length, true, true,
+			imperialUsSystem, false);
+		AddUnit(11, "short ton", "tn", "shortton shorttons ton tons tn", 907184.74, 0.0, 0.0, UnitType.Mass, true,
+			true, imperialUsSystem, false);
+		AddUnit(12, "kilotonne", "kt", "kilotonne kilotonnes kilotons kt", 1000000000.0, 0.0, 0.0, UnitType.Mass,
+			true, true, metricSystem, false);
+		AddUnit(13, "stone", "st", "stone stones st", 6350.29318, 0.0, 0.0, UnitType.Mass, false, true,
+			imperialUsSystem, false);
+		AddUnit(14, "chain", "ch", "chain chains ch", 2011.68, 0.0, 0.0, UnitType.Length, false, true,
+			imperialUsSystem, false);
+		AddUnit(15, "mile", "mi", "mile miles mi", 160934.4, 0.0, 0.0, UnitType.Length, false, true,
+			imperialUsSystem, false);
+		AddUnit(16, "kilometre", "km", "kilometre kilometres kilometer kilometers km kms", 100000.0, 0.0, 0.0,
+			UnitType.Length, false, true, metricSystem, false);
+		AddUnit(17, "furlong", "fur", "furlong furlongs fur", 20116.8, 0.0, 0.0, UnitType.Length, false, true,
+			imperialUsSystem, false);
+		AddUnit(18, "league", "lea", "league leagues lea", 482803.2, 0.0, 0.0, UnitType.Length, false, true,
+			imperialUsSystem, false);
+		AddUnit(19, "link", "lnk", "link links lnk", 20.1168, 0.0, 0.0, UnitType.Length, false, true,
+			imperialUsSystem, false);
+		AddUnit(20, "rod", "rd", "rod rods rd perch perches pole poles", 502.92, 0.0, 0.0, UnitType.Length, false,
+			true, imperialUsSystem, false);
+		AddUnit(21, "litre", "l", "litre litres liter liters l", 1.0, 0.0, 0.0, UnitType.FluidVolume, true, true,
+			metricSystem, true);
+		AddUnit(22, "millilitre", "ml", "millilitre millilitres milliliter milliliters ml mls", 0.001, 0.0, 0.0,
+			UnitType.FluidVolume, true, true, metricSystem, false);
+		AddUnit(23, "fluid ounce", "fl oz", "fluidounce fluidounces floz fl oz ounce ounces", 0.0295735295625, 0.0,
+			0.0, UnitType.FluidVolume, true, true, imperialUsSystem, true);
+		AddUnit(24, "fluid dram", "fl dr", "fluiddram fluiddrams fldr fl dr dram drams", 0.0036966911953125, 0.0,
+			0.0, UnitType.FluidVolume, true, true, imperialUsSystem, false);
+		AddUnit(25, "cup", "cp", "cup cups cp cps", 0.2365882365, 0.0, 0.0, UnitType.FluidVolume, false, true,
+			imperialUsSystem, false);
+		AddUnit(26, "pint", "pt", "pint pints p pt pts", 0.473176473, 0.0, 0.0, UnitType.FluidVolume, false, true,
+			imperialUsSystem, false);
+		AddUnit(27, "quart", "qt", "quart quarts qt qts", 0.946352946, 0.0, 0.0, UnitType.FluidVolume, false, true,
+			imperialUsSystem, false);
+		AddUnit(28, "gallon", "gal", "gallon gallons gal gals", 3.785411784, 0.0, 0.0, UnitType.FluidVolume, true,
+			true, imperialUsSystem, false);
+		AddUnit(29, "kilolitre", "kl", "kilolitre kilolitres kiloliter kiloliters kl", 1000.0, 0.0, 0.0,
+			UnitType.FluidVolume, true, true, metricSystem, false);
+		AddUnit(30, "megalitre", "ML", "megalitre megalitres megaliter megaliters ML", 1000000.0, 0.0, 0.0,
+			UnitType.FluidVolume, true, true, metricSystem, false);
+		AddUnit(31, "gigalitre", "GL", "gigalitre gigalitres gigaliter gigaliters GL", 1000000000.0, 0.0, 0.0,
+			UnitType.FluidVolume, true, true, metricSystem, false);
+		AddUnit(32, "square metre", "m2", "squaremetre squaremetres squaremeter squaremeters sqm sqms m2", 1.0, 0.0,
+			0.0, UnitType.Area, true, true, metricSystem, true);
+		AddUnit(33, "square foot", "ft2", "squarefoot squarefeet sqft sqf f2 ft2", 0.09290304, 0.0, 0.0,
+			UnitType.Area, true, true, imperialUsSystem, true);
+		AddUnit(34, "acre", "ac", "acre acres ac", 4046.8564224, 0.0, 0.0, UnitType.Area, true, true,
+			imperialUsSystem, false);
+		AddUnit(35, "hectare", "ha", "hectare hectares ha", 10000.0, 0.0, 0.0, UnitType.Area, true, true,
+			metricSystem, false);
+		AddUnit(36, "cubic metre", "m3", "cubicmetre cubicmetres cubicmeter cubicmeters m3 cbm cbms", 1.0, 0.0, 0.0,
+			UnitType.Volume, true, true, metricSystem, true);
+		AddUnit(37, "cubic foot", "cu ft", "cubicfoot cubicfeet cuft cft ft3 f3 cu ft", 0.028316846592, 0.0, 0.0,
+			UnitType.Volume, true, true, imperialUsSystem, true);
+		AddUnit(38, "celsius", "C", "celsius centigrade C c", 1.0, 0.0, 0.0, UnitType.Temperature, true, false,
+			metricSystem, true);
+		AddUnit(39, "fahrenheit", "F", "fahrenheit F f", 0.5555555555555556, 0.0, 32.0, UnitType.Temperature, true,
+			false, imperialUsSystem, true);
+		AddUnit(40, "perch", "per", "perch perches per", 25.29285264, 0.0, 0.0, UnitType.Area, false, true,
+			imperialUkSystem, false);
+		AddUnit(41, "rood", "rood", "rood roods", 1011.7141056, 0.0, 0.0, UnitType.Area, false, true,
+			imperialUkSystem, false);
+		AddUnit(42, "acre", "ac", "acre acres ac", 4046.8564224, 0.0, 0.0, UnitType.Area, true, true,
+			imperialUkSystem, false);
+		AddUnit(43, "drachm", "dr", "drachm drachms dr", 1.7718451953125, 0.0, 0.0, UnitType.Mass, false, true,
+			imperialUsSystem, false);
+		AddUnit(44, "grain", "gr", "grain grains gr", 0.06479891, 0.0, 0.0, UnitType.Mass, false, true,
+			imperialUsSystem, false);
+		AddUnit(45, "thou", "th", "thou thous th mil mils", 0.00254, 0.0, 0.0, UnitType.Length, false, true,
+			imperialUsSystem, false);
+		AddUnit(46, "milligram", "mg", "milligram milligrams mg", 0.001, 0.0, 0.0, UnitType.Mass, true, true,
+			metricSystem, false);
+		AddUnit(47, "celsius", "C", "celsius centigrade C c", 1.0, 0.0, 0.0, UnitType.TemperatureDelta, true, false,
+			metricSystem, true);
+		AddUnit(48, "fahrenheit", "F", "fahrenheit F f", 0.5555555555555556, 0.0, 0.0, UnitType.TemperatureDelta,
+			true, false, imperialUsSystem, true);
+		AddUnit(49, "newton", "N", "newton newtons N", 1.0, 0.0, 0.0, UnitType.Force, true, false, metricSystem,
+			true);
+		AddUnit(50, "kilonewton", "kN", "kilonewton kilonewtons kN", 1000.0, 0.0, 0.0, UnitType.Force, true, false,
+			metricSystem, false);
+		AddUnit(51, "meganewton", "MN", "meganewton meganewtons MN", 1000000.0, 0.0, 0.0, UnitType.Force, true,
+			false, metricSystem, false);
+		AddUnit(52, "pound-force", "lbf", "poundforce pound-force poundforces pound-forces lbf", 4.4482216152605, 0.0,
+			0.0, UnitType.Force, true, false, imperialUsSystem, true);
+		AddUnit(53, "pascal", "Pa", "pascal pascals Pa pa", 1.0, 0.0, 0.0, UnitType.Stress, true, false, metricSystem,
+			true);
+		AddUnit(54, "kilopascal", "kPa", "kilopascal kilopascals kPa kpa", 1000.0, 0.0, 0.0, UnitType.Stress, true,
+			false, metricSystem, false);
+		AddUnit(55, "megapascal", "MPa", "megapascal megapascals MPa mpa", 1000000.0, 0.0, 0.0, UnitType.Stress, true,
+			false, metricSystem, false);
+		AddUnit(56, "gigapascal", "GPa", "gigapascal gigapascals GPa gpa", 1000000000.0, 0.0, 0.0, UnitType.Stress,
+			true, false, metricSystem, false);
+		AddUnit(57, "psi", "psi", "psi poundspersquareinch poundpersquareinch", 6894.757293168, 0.0, 0.0,
+			UnitType.Stress, true, false, imperialUsSystem, true);
+		AddUnit(58, "ksi", "ksi", "ksi kpsi kilopsi", 6894757.293168, 0.0, 0.0, UnitType.Stress, true, false,
+			imperialUsSystem, false);
+		AddUnit(59, "mpsi", "mpsi", "mpsi megapsi", 6894757293.168, 0.0, 0.0, UnitType.Stress, true, false,
+			imperialUsSystem, false);
+		AddUnit(60, "gpsi", "gpsi", "gpsi gigapsi", 6894757293168.0, 0.0, 0.0, UnitType.Stress, true, false,
+			imperialUsSystem, false);
+		AddUnit(61, "kg/m2", "kg/m2", "kg/m2 kgm2 kgsqm bmi", 1.0, 0.0, 0.0, UnitType.BMI, true, false,
+			metricSystem, true);
+		AddUnit(62, "lb/in2", "lb/in2", "lb/in2 lbin2 lbsqin bmiimperial", 703.06957964, 0.0, 0.0, UnitType.BMI,
+			true, false, imperialUsSystem, true);
+
+		AddUnit(63, "microgram", "ug", "microgram micrograms ug", 0.000001, 0.0, 0.0, UnitType.Mass, false, true,
+			metricSystem, false);
+		AddUnit(64, "metric megatonne", "Mt", "megatonne megatonnes megaton metricmegaton metricmegatons Mt",
+			1000000000000.0, 0.0, 0.0, UnitType.Mass, true, true, metricSystem, false);
+		AddUnit(65, "hundredweight", "cwt", "hundredweight hundredweights cwt ushundredweight", 45359.237, 0.0, 0.0,
+			UnitType.Mass, false, true, imperialUsSystem, false);
+		AddUnit(66, "yard", "yd", "yard yards yd", 91.44, 0.0, 0.0, UnitType.Length, false, true, imperialUsSystem,
+			false);
+		AddUnit(67, "fathom", "ftm", "fathom fathoms ftm", 182.88, 0.0, 0.0, UnitType.Length, false, true,
+			imperialUsSystem, false);
+		AddUnit(68, "nautical mile", "nmi", "nauticalmile nauticalmiles nmi nm", 185200.0, 0.0, 0.0, UnitType.Length,
+			false, true, imperialUsSystem, false);
+		AddUnit(69, "gill", "gi", "gill gills gi", 0.11829411825, 0.0, 0.0, UnitType.FluidVolume, false, true,
+			imperialUsSystem, false);
+		AddUnit(70, "tablespoon", "tbsp", "tablespoon tablespoons tbsp tbs", 0.01478676478125, 0.0, 0.0,
+			UnitType.FluidVolume, false, true, imperialUsSystem, false);
+		AddUnit(71, "teaspoon", "tsp", "teaspoon teaspoons tsp", 0.00492892159375, 0.0, 0.0, UnitType.FluidVolume,
+			false, true, imperialUsSystem, false);
+		AddUnit(72, "square centimetre", "cm2",
+			"squarecentimetre squarecentimetres squarecentimeter squarecentimeters cm2 sqcm sqcms", 0.0001, 0.0, 0.0,
+			UnitType.Area, false, true, metricSystem, false);
+		AddUnit(73, "square kilometre", "km2",
+			"squarekilometre squarekilometres squarekilometer squarekilometers km2 sqkm sqkms", 1000000.0, 0.0, 0.0,
+			UnitType.Area, false, true, metricSystem, false);
+		AddUnit(74, "square inch", "in2", "squareinch squareinches in2 sqin sqins", 0.00064516, 0.0, 0.0,
+			UnitType.Area, false, true, imperialUsSystem, false);
+		AddUnit(75, "square yard", "yd2", "squareyard squareyards yd2 sqyd sqyds", 0.83612736, 0.0, 0.0,
+			UnitType.Area, false, true, imperialUsSystem, false);
+		AddUnit(76, "square mile", "mi2", "squaremile squaremiles mi2 sqmi sqmis", 2589988.110336, 0.0, 0.0,
+			UnitType.Area, false, true, imperialUsSystem, false);
+		AddUnit(77, "cubic centimetre", "cm3",
+			"cubiccentimetre cubiccentimetres cubiccentimeter cubiccentimeters cm3 cc", 0.000001, 0.0, 0.0,
+			UnitType.Volume, false, true, metricSystem, false);
+		AddUnit(78, "cubic inch", "in3", "cubicinch cubicinches in3 cuin", 0.000016387064, 0.0, 0.0, UnitType.Volume,
+			false, true, imperialUsSystem, false);
+		AddUnit(79, "cubic yard", "yd3", "cubicyard cubicyards yd3 cuyd", 0.764554857984, 0.0, 0.0, UnitType.Volume,
+			false, true, imperialUsSystem, false);
+		AddUnit(80, "kip", "kip", "kip kips", 4448.2216152605, 0.0, 0.0, UnitType.Force, false, false,
+			imperialUsSystem, false);
+
+		AddUnit(81, "pound", "lb", "pound pounds lb lbs", 453.59237, 0.0, 0.0, UnitType.Mass, true, true,
+			imperialUkSystem, true);
+		AddUnit(82, "ounce", "oz", "ounce ounces oz", 28.349523125, 0.0, 0.0, UnitType.Mass, false, true,
+			imperialUkSystem, false);
+		AddUnit(83, "stone", "st", "stone stones st", 6350.29318, 0.0, 0.0, UnitType.Mass, true, true,
+			imperialUkSystem, false);
+		AddUnit(84, "long ton", "lt", "longton longtons ton tons lt", 1016046.9088, 0.0, 0.0, UnitType.Mass, true,
+			true, imperialUkSystem, false);
+		AddUnit(85, "hundredweight", "cwt", "hundredweight hundredweights cwt britishhundredweight", 50802.34544, 0.0,
+			0.0, UnitType.Mass, false, true, imperialUkSystem, false);
+		AddUnit(86, "drachm", "dr", "drachm drachms dr", 1.7718451953125, 0.0, 0.0, UnitType.Mass, false, true,
+			imperialUkSystem, false);
+		AddUnit(87, "grain", "gr", "grain grains gr", 0.06479891, 0.0, 0.0, UnitType.Mass, false, true,
+			imperialUkSystem, false);
+		AddUnit(88, "foot", "ft", "foot feet ft '", 30.48, 0.0, 0.0, UnitType.Length, true, true, imperialUkSystem,
+			true);
+		AddUnit(89, "inch", "in", "inch inches in \"", 2.54, 0.0, 0.0, UnitType.Length, true, true, imperialUkSystem,
+			false);
+		AddUnit(90, "yard", "yd", "yard yards yd", 91.44, 0.0, 0.0, UnitType.Length, false, true, imperialUkSystem,
+			false);
+		AddUnit(91, "chain", "ch", "chain chains ch", 2011.68, 0.0, 0.0, UnitType.Length, false, true,
+			imperialUkSystem, false);
+		AddUnit(92, "furlong", "fur", "furlong furlongs fur", 20116.8, 0.0, 0.0, UnitType.Length, false, true,
+			imperialUkSystem, false);
+		AddUnit(93, "mile", "mi", "mile miles mi", 160934.4, 0.0, 0.0, UnitType.Length, false, true, imperialUkSystem,
+			false);
+		AddUnit(94, "link", "lnk", "link links lnk", 20.1168, 0.0, 0.0, UnitType.Length, false, true,
+			imperialUkSystem, false);
+		AddUnit(95, "rod", "rd", "rod rods rd perch perches pole poles", 502.92, 0.0, 0.0, UnitType.Length, false,
+			true, imperialUkSystem, false);
+		AddUnit(96, "fathom", "ftm", "fathom fathoms ftm", 182.88, 0.0, 0.0, UnitType.Length, false, true,
+			imperialUkSystem, false);
+		AddUnit(97, "nautical mile", "nmi", "nauticalmile nauticalmiles nmi nm", 185200.0, 0.0, 0.0, UnitType.Length,
+			false, true, imperialUkSystem, false);
+		AddUnit(98, "thou", "th", "thou thous th mil mils", 0.00254, 0.0, 0.0, UnitType.Length, false, true,
+			imperialUkSystem, false);
+		AddUnit(99, "fluid ounce", "fl oz", "fluidounce fluidounces floz fl oz ounce ounces", 0.0284130625, 0.0, 0.0,
+			UnitType.FluidVolume, true, true, imperialUkSystem, false);
+		AddUnit(100, "fluid dram", "fl dr", "fluiddram fluiddrams fldr fl dr dram drams", 0.0035516328125, 0.0, 0.0,
+			UnitType.FluidVolume, false, true, imperialUkSystem, false);
+		AddUnit(101, "gill", "gi", "gill gills gi", 0.1420653125, 0.0, 0.0, UnitType.FluidVolume, false, true,
+			imperialUkSystem, false);
+		AddUnit(102, "pint", "pt", "pint pints p pt pts", 0.56826125, 0.0, 0.0, UnitType.FluidVolume, true, true,
+			imperialUkSystem, true);
+		AddUnit(103, "quart", "qt", "quart quarts qt qts", 1.1365225, 0.0, 0.0, UnitType.FluidVolume, false, true,
+			imperialUkSystem, false);
+		AddUnit(104, "gallon", "gal", "gallon gallons gal gals", 4.54609, 0.0, 0.0, UnitType.FluidVolume, true, true,
+			imperialUkSystem, false);
+		AddUnit(105, "tablespoon", "tbsp", "tablespoon tablespoons tbsp tbs", 0.01420653125, 0.0, 0.0,
+			UnitType.FluidVolume, false, true, imperialUkSystem, false);
+		AddUnit(106, "teaspoon", "tsp", "teaspoon teaspoons tsp", 0.00473551041666667, 0.0, 0.0,
+			UnitType.FluidVolume, false, true, imperialUkSystem, false);
+		AddUnit(107, "square foot", "ft2", "squarefoot squarefeet sqft sqf f2 ft2", 0.09290304, 0.0, 0.0,
+			UnitType.Area, true, true, imperialUkSystem, true);
+		AddUnit(108, "square inch", "in2", "squareinch squareinches in2 sqin sqins", 0.00064516, 0.0, 0.0,
+			UnitType.Area, false, true, imperialUkSystem, false);
+		AddUnit(109, "square yard", "yd2", "squareyard squareyards yd2 sqyd sqyds", 0.83612736, 0.0, 0.0,
+			UnitType.Area, false, true, imperialUkSystem, false);
+		AddUnit(110, "square mile", "mi2", "squaremile squaremiles mi2 sqmi sqmis", 2589988.110336, 0.0, 0.0,
+			UnitType.Area, false, true, imperialUkSystem, false);
+		AddUnit(111, "cubic foot", "cu ft", "cubicfoot cubicfeet cuft cft ft3 f3 cu ft", 0.028316846592, 0.0, 0.0,
+			UnitType.Volume, true, true, imperialUkSystem, true);
+		AddUnit(112, "cubic inch", "in3", "cubicinch cubicinches in3 cuin", 0.000016387064, 0.0, 0.0, UnitType.Volume,
+			false, true, imperialUkSystem, false);
+		AddUnit(113, "cubic yard", "yd3", "cubicyard cubicyards yd3 cuyd", 0.764554857984, 0.0, 0.0, UnitType.Volume,
+			false, true, imperialUkSystem, false);
+		AddUnit(114, "celsius", "C", "celsius centigrade C c", 1.0, 0.0, 0.0, UnitType.Temperature, true, false,
+			imperialUkSystem, true);
+		AddUnit(115, "celsius", "C", "celsius centigrade C c", 1.0, 0.0, 0.0, UnitType.TemperatureDelta, true, false,
+			imperialUkSystem, true);
+		AddUnit(116, "pound-force", "lbf", "poundforce pound-force poundforces pound-forces lbf", 4.4482216152605, 0.0,
+			0.0, UnitType.Force, true, false, imperialUkSystem, true);
+		AddUnit(117, "psi", "psi", "psi poundspersquareinch poundpersquareinch", 6894.757293168, 0.0, 0.0,
+			UnitType.Stress, true, false, imperialUkSystem, true);
+		AddUnit(118, "ksi", "ksi", "ksi kpsi kilopsi", 6894757.293168, 0.0, 0.0, UnitType.Stress, true, false,
+			imperialUkSystem, false);
+		AddUnit(119, "kg/m2", "kg/m2", "kg/m2 kgm2 kgsqm bmi", 1.0, 0.0, 0.0, UnitType.BMI, true, false,
+			imperialUkSystem, true);
+	}
+}

--- a/DatabaseSeeder/Seeders/CoreDataSeeder.cs
+++ b/DatabaseSeeder/Seeders/CoreDataSeeder.cs
@@ -1354,7 +1354,7 @@ Among many other small but necessary things, it does the following:
 8) Sets up socials
 9) Sets up units of measure";
 
-    private static void SeedUnitsOfMeasure(FuturemudDatabaseContext context)
+    private static void SeedUnitsOfMeasureLegacy(FuturemudDatabaseContext context)
     {
         context.UnitsOfMeasure.Add(new UnitOfMeasure
         {
@@ -2564,7 +2564,7 @@ Do you want to use Unicode? (y/n): "
             Id = "CreateAccountUnitPreference",
             Text = @"#3Unit Preference#0
 
-When viewing any quantity units (height, weight, length, volume, etc.) in game, you will see the quantity in the style of your preference. For example, your character's height and weight could be displayed in Imperial (feet/inches and pounds), or Metric (metres and kilograms). Regardless of what system you choose, you can enter quantities in the MUD in any system, this setting only affects how they are displayed to you.
+When viewing any quantity units (height, weight, length, volume, etc.) in game, you will see the quantity in the style of your preference. For example, your character's height and weight could be displayed in the Imperial system (US customary feet/inches and pounds), Imperial-UK (feet/inches and stone or pounds), or Metric (metres and kilograms). Regardless of what system you choose, you can enter quantities in the MUD in any system, this setting only affects how they are displayed to you.
 
 The following systems are available for selection:
 
@@ -8871,7 +8871,7 @@ return IsAdmin(@ch)",
         context.SaveChanges();
     }
 
-    private void SeedMaterials(FuturemudDatabaseContext context)
+    private void SeedMaterialsBase(FuturemudDatabaseContext context)
     {
         #region Tags
 


### PR DESCRIPTION
## Summary
- add and correct seeded units of measure, including a dedicated `Imperial-UK` system and fixes to legacy imperial defaults
- review and expand seeded materials, correcting aliases, tags, behaviour data, and missing catalogue entries
- revise terrain seeding with terrestrial additions, cave/wetland fixes, and new lunar and space terrains
- add DatabaseSeeder regression tests covering unit, material, and terrain seeding changes

## Testing
- `dotnet build DatabaseSeeder\DatabaseSeeder.csproj -c Debug -p:NoWarn=NU1902%3BNU1510`
- `dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore`
- existing unrelated failure remains in `BlankDatabaseSnapshotTests.CommittedBlankSnapshotManifest_TracksLatestMigration`