### PR TITLE
Fix SelfCareAI wound treatment flow

### DIFF
--- a/MudSharpCore Unit Tests/NpcAiRegressionTests.cs
+++ b/MudSharpCore Unit Tests/NpcAiRegressionTests.cs
@@ -6,12 +6,17 @@ using MudSharp.Arenas;
 using MudSharp.Body;
 using MudSharp.Character;
 using MudSharp.Construction;
+using MudSharp.Construction.Boundary;
 using MudSharp.Effects.Interfaces;
 using MudSharp.Events;
 using MudSharp.FutureProg;
 using MudSharp.GameItems;
 using MudSharp.GameItems.Interfaces;
+using MudSharp.Health;
+using MudSharp.Movement;
+using MudSharp.NPC;
 using MudSharp.NPC.AI;
+using MudSharp.RPG.Checks;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -161,6 +166,96 @@ public class NpcAiRegressionTests
         Assert.IsTrue(trackingAggressor.HandlesEvent(EventType.CharacterEnterCellWitness));
     }
 
+    [TestMethod]
+    public void SelfCareAI_DetermineRequiredSelfCare_PrefersBindingBeforeSuturing()
+    {
+        Mock<IWound> bleedingWound = CreateWound(BleedStatus.Bleeding);
+        Mock<IWound> traumaControlledWound = CreateWound(BleedStatus.TraumaControlled, Difficulty.Easy);
+
+        SelfCareAI.RequiredSelfCare result = SelfCareAI.DetermineRequiredSelfCare(
+            new[] { bleedingWound.Object, traumaControlledWound.Object },
+            true);
+
+        Assert.AreEqual(SelfCareAI.RequiredSelfCare.Bind, result);
+    }
+
+    [TestMethod]
+    public void SelfCareAI_DetermineRequiredSelfCare_RequiresSuturingCapability()
+    {
+        Mock<IWound> traumaControlledWound = CreateWound(BleedStatus.TraumaControlled, Difficulty.Easy);
+
+        SelfCareAI.RequiredSelfCare withoutTools = SelfCareAI.DetermineRequiredSelfCare(
+            new[] { traumaControlledWound.Object },
+            false);
+        SelfCareAI.RequiredSelfCare withTools = SelfCareAI.DetermineRequiredSelfCare(
+            new[] { traumaControlledWound.Object },
+            true);
+
+        Assert.AreEqual(SelfCareAI.RequiredSelfCare.None, withoutTools);
+        Assert.AreEqual(SelfCareAI.RequiredSelfCare.Suture, withTools);
+    }
+
+    [TestMethod]
+    public void SelfCareAI_CellHasHostileNpcs_IgnoresPausedAggressiveNpcs()
+    {
+        Mock<ICharacter> self = new();
+        Mock<INPC> pausedAggressiveNpc = CreateAggressiveNpc(paused: true);
+        Mock<ICell> cell = new();
+        cell.SetupGet(x => x.Characters).Returns(new ICharacter[] { self.Object, pausedAggressiveNpc.Object });
+
+        bool hasHostiles = SelfCareAI.CellHasHostileNpcs(cell.Object, self.Object);
+
+        Assert.IsFalse(hasHostiles);
+    }
+
+    [TestMethod]
+    public void SelfCareAI_CellHasHostileNpcs_DetectsActiveAggressiveNpcs()
+    {
+        Mock<ICharacter> self = new();
+        Mock<INPC> aggressiveNpc = CreateAggressiveNpc(paused: false);
+        Mock<ICell> cell = new();
+        cell.SetupGet(x => x.Characters).Returns(new ICharacter[] { self.Object, aggressiveNpc.Object });
+
+        bool hasHostiles = SelfCareAI.CellHasHostileNpcs(cell.Object, self.Object);
+
+        Assert.IsTrue(hasHostiles);
+    }
+
+    [TestMethod]
+    public void SelfCareAI_GetSafeExitForSelfCare_SelectsSafeReachableDestination()
+    {
+        Mock<ICharacter> self = new();
+        Mock<ICell> currentCell = new();
+        Mock<ICell> hostileDestination = new();
+        Mock<ICell> safeDestination = new();
+        Mock<ICellExit> hostileExit = new();
+        Mock<ICellExit> safeExit = new();
+
+        Mock<INPC> hostileNpc = CreateAggressiveNpc(paused: false);
+
+        hostileDestination.SetupGet(x => x.Characters).Returns(new ICharacter[] { hostileNpc.Object });
+        safeDestination.SetupGet(x => x.Characters).Returns(Array.Empty<ICharacter>());
+
+        hostileExit.SetupGet(x => x.Destination).Returns(hostileDestination.Object);
+        safeExit.SetupGet(x => x.Destination).Returns(safeDestination.Object);
+
+        currentCell.Setup(x => x.ExitsFor(self.Object, true)).Returns(new[] { hostileExit.Object, safeExit.Object });
+        self.SetupGet(x => x.Location).Returns(currentCell.Object);
+        self.Setup(x => x.CanMove(hostileExit.Object, It.IsAny<CanMoveFlags>())).Returns(new CanMoveResponse
+        {
+            Result = false,
+            ErrorMessage = "blocked",
+            WouldBeAbleToCross = null,
+            HighestMovingPositionState = null,
+            FastestMoveSpeed = null
+        });
+        self.Setup(x => x.CanMove(safeExit.Object, It.IsAny<CanMoveFlags>())).Returns(CanMoveResponse.True);
+
+        ICellExit? chosenExit = SelfCareAI.GetSafeExitForSelfCare(self.Object);
+
+        Assert.AreSame(safeExit.Object, chosenExit);
+    }
+
     private static IArenaParticipant MockParticipant(ICharacter character, int sideIndex)
     {
         Mock<IArenaParticipant> participant = new();
@@ -168,5 +263,25 @@ public class NpcAiRegressionTests
         participant.SetupGet(x => x.CharacterId).Returns(character.Id);
         participant.SetupGet(x => x.SideIndex).Returns(sideIndex);
         return participant.Object;
+    }
+
+    private static Mock<IWound> CreateWound(BleedStatus bleedStatus, Difficulty closeDifficulty = Difficulty.Impossible)
+    {
+        Mock<IWound> wound = new();
+        wound.SetupGet(x => x.BleedStatus).Returns(bleedStatus);
+        wound.Setup(x => x.CanBeTreated(TreatmentType.Close)).Returns(closeDifficulty);
+        return wound;
+    }
+
+    private static Mock<INPC> CreateAggressiveNpc(bool paused)
+    {
+        Mock<IArtificialIntelligence> aggressiveAi = new();
+        aggressiveAi.SetupGet(x => x.CountsAsAggressive).Returns(true);
+
+        Mock<INPC> npc = new();
+        npc.SetupGet(x => x.State).Returns(CharacterState.Able);
+        npc.SetupGet(x => x.AIs).Returns(new[] { aggressiveAi.Object });
+        npc.Setup(x => x.AffectedBy<IPauseAIEffect>()).Returns(paused);
+        return npc;
     }
 }

--- a/MudSharpCore/NPC/AI/SelfCareAI.cs
+++ b/MudSharpCore/NPC/AI/SelfCareAI.cs
@@ -1,13 +1,21 @@
-﻿using MudSharp.Character;
+using MudSharp.Character;
+using MudSharp.Combat;
+using MudSharp.Construction;
+using MudSharp.Construction.Boundary;
 using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
 using MudSharp.Events;
 using MudSharp.Framework;
 using MudSharp.FutureProg.Statements.Manipulation;
+using MudSharp.GameItems.Inventory;
 using MudSharp.Health;
 using MudSharp.Models;
+using MudSharp.Movement;
+using MudSharp.NPC;
 using MudSharp.PerceptionEngine;
 using MudSharp.PerceptionEngine.Outputs;
 using MudSharp.PerceptionEngine.Parsers;
+using MudSharp.RPG.Checks;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -18,311 +26,460 @@ namespace MudSharp.NPC.AI;
 
 public class SelfCareAI : ArtificialIntelligenceBase
 {
-    private readonly List<string> _bleedingEmotes = new();
-    public IEnumerable<string> BleedingEmotes => _bleedingEmotes;
+	internal enum RequiredSelfCare
+	{
+		None,
+		Bind,
+		Suture
+	}
 
-    private SelfCareAI(ArtificialIntelligence ai, IFuturemud gameworld)
-        : base(ai, gameworld)
-    {
-        LoadFromXml(XElement.Parse(ai.Definition));
-    }
+	internal const string SelfCareMedicalAction = "self care medical action";
+	internal const string SelfCareBleedingEmoteAction = "self care bleeding emote";
 
-    private SelfCareAI()
-    {
+	private readonly List<string> _bleedingEmotes = new();
+	public IEnumerable<string> BleedingEmotes => _bleedingEmotes;
 
-    }
+	private SelfCareAI(ArtificialIntelligence ai, IFuturemud gameworld)
+		: base(ai, gameworld)
+	{
+		LoadFromXml(XElement.Parse(ai.Definition));
+	}
 
-    private SelfCareAI(IFuturemud gameworld, string name) : base(gameworld, name, "SelfCare")
-    {
-        BindingDelayDiceExpression = "250+1d2750";
-        BleedingEmoteDelayDiceExpression = "3000+1d2000";
-        DatabaseInitialise();
-    }
+	private SelfCareAI()
+	{
 
-    public string BleedingEmote => BleedingEmotes.GetRandomElement();
-    public string BleedingEmoteDelayDiceExpression { get; set; }
-    public string BindingDelayDiceExpression { get; set; }
+	}
 
-    /// <inheritdoc />
-    public override string Show(ICharacter actor)
-    {
-        StringBuilder sb = new();
-        sb.AppendLine($"Artificial Intelligence #{Id.ToString("N0", actor)} - {Name}".GetLineWithTitle(actor, Telnet.Cyan, Telnet.BoldWhite));
-        sb.AppendLine($"Type: {AIType.ColourValue()}");
-        sb.AppendLine();
-        sb.AppendLine($"Bleeding Emote Delay: {BleedingEmoteDelayDiceExpression.ColourValue()} seconds");
-        sb.AppendLine($"Bind Self Delay: {BindingDelayDiceExpression.ColourValue()} seconds");
-        sb.AppendLine($"Emotes:");
-        sb.AppendLine();
-        if (_bleedingEmotes.Count == 0)
-        {
-            sb.AppendLine($"\tNone");
-        }
-        else
-        {
-            foreach (string emote in _bleedingEmotes)
-            {
-                sb.AppendLine($"\t{emote.ColourCommand()}");
-            }
-        }
-        return sb.ToString();
-    }
+	private SelfCareAI(IFuturemud gameworld, string name) : base(gameworld, name, "SelfCare")
+	{
+		BindingDelayDiceExpression = "250+1d2750";
+		BleedingEmoteDelayDiceExpression = "3000+1d2000";
+		DatabaseInitialise();
+	}
 
-    /// <inheritdoc />
-    protected override string TypeHelpText => @"	#3binddelay <expression>#0 - a dice expression in milliseconds for delay binding self
+	public string BleedingEmote => BleedingEmotes.GetRandomElement();
+	public string BleedingEmoteDelayDiceExpression { get; set; }
+	public string BindingDelayDiceExpression { get; set; }
+
+	/// <inheritdoc />
+	public override string Show(ICharacter actor)
+	{
+		StringBuilder sb = new();
+		sb.AppendLine($"Artificial Intelligence #{Id.ToString("N0", actor)} - {Name}".GetLineWithTitle(actor, Telnet.Cyan, Telnet.BoldWhite));
+		sb.AppendLine($"Type: {AIType.ColourValue()}");
+		sb.AppendLine();
+		sb.AppendLine($"Bleeding Emote Delay: {BleedingEmoteDelayDiceExpression.ColourValue()} milliseconds");
+		sb.AppendLine($"Self Care Command Delay: {BindingDelayDiceExpression.ColourValue()} milliseconds");
+		sb.AppendLine($"Emotes:");
+		sb.AppendLine();
+		if (_bleedingEmotes.Count == 0)
+		{
+			sb.AppendLine($"\tNone");
+		}
+		else
+		{
+			foreach (string emote in _bleedingEmotes)
+			{
+				sb.AppendLine($"\t{emote.ColourCommand()}");
+			}
+		}
+
+		return sb.ToString();
+	}
+
+	/// <inheritdoc />
+	protected override string TypeHelpText => @"	#3binddelay <expression>#0 - a dice expression in milliseconds for delay before binding or suturing
 	#3bleedingdelay <expression>#0 - a dice expression in milliseconds for delay emoting about bleeding
 	#3addemote <emote>#0 - adds a bleeding emote to the list. $0 is the NPC.
 	#3rememote <##>#0 - removes an emote from the list";
 
-    /// <inheritdoc />
-    public override bool BuildingCommand(ICharacter actor, StringStack command)
-    {
-        switch (command.PopForSwitch())
-        {
-            case "binddelay":
-                return BuildingCommandBindDelay(actor, command);
-            case "bleedingdelay":
-                return BuildingCommandBleedingEmoteDelay(actor, command);
-            case "addemote":
-                return BuildingCommandBleedingAddEmote(actor, command);
-            case "deleteemote":
-            case "delemote":
-            case "rememote":
-            case "removeemote":
-                return BuildingCommandBleedingRemoveEmote(actor, command);
-        }
-        return base.BuildingCommand(actor, command.GetUndo());
-    }
+	/// <inheritdoc />
+	public override bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "binddelay":
+				return BuildingCommandBindDelay(actor, command);
+			case "bleedingdelay":
+				return BuildingCommandBleedingEmoteDelay(actor, command);
+			case "addemote":
+				return BuildingCommandBleedingAddEmote(actor, command);
+			case "deleteemote":
+			case "delemote":
+			case "rememote":
+			case "removeemote":
+				return BuildingCommandBleedingRemoveEmote(actor, command);
+		}
 
-    private bool BuildingCommandBleedingRemoveEmote(ICharacter actor, StringStack command)
-    {
-        if (command.IsFinished)
-        {
-            actor.OutputHandler.Send("Which emote would you like to remove?");
-            return false;
-        }
+		return base.BuildingCommand(actor, command.GetUndo());
+	}
 
-        if (!int.TryParse(command.SafeRemainingArgument, out int index) || index < 1 || index > _bleedingEmotes.Count)
-        {
-            actor.OutputHandler.Send($"You must enter a valid number between {1.ToString("N0", actor).ColourValue()} and {_bleedingEmotes.Count.ToString("N0", actor).ColourValue()}.");
-            return false;
-        }
+	private bool BuildingCommandBleedingRemoveEmote(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which emote would you like to remove?");
+			return false;
+		}
 
-        Changed = true;
-        actor.OutputHandler.Send($"You delete the emote {_bleedingEmotes[index - 1].ColourCommand()}.");
-        _bleedingEmotes.RemoveAt(index - 1);
-        return true;
-    }
+		if (!int.TryParse(command.SafeRemainingArgument, out int index) || index < 1 || index > _bleedingEmotes.Count)
+		{
+			actor.OutputHandler.Send($"You must enter a valid number between {1.ToString("N0", actor).ColourValue()} and {_bleedingEmotes.Count.ToString("N0", actor).ColourValue()}.");
+			return false;
+		}
 
-    private bool BuildingCommandBleedingAddEmote(ICharacter actor, StringStack command)
-    {
-        if (command.IsFinished)
-        {
-            actor.OutputHandler.Send("What emote do you want to add?");
-            return false;
-        }
+		Changed = true;
+		actor.OutputHandler.Send($"You delete the emote {_bleedingEmotes[index - 1].ColourCommand()}.");
+		_bleedingEmotes.RemoveAt(index - 1);
+		return true;
+	}
 
-        Emote emote = new(command.SafeRemainingArgument, new DummyPerceiver(), new DummyPerceivable());
-        if (!emote.Valid)
-        {
-            actor.OutputHandler.Send(emote.ErrorMessage);
-            return false;
-        }
+	private bool BuildingCommandBleedingAddEmote(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("What emote do you want to add?");
+			return false;
+		}
 
-        _bleedingEmotes.Add(command.SafeRemainingArgument);
-        Changed = true;
-        actor.OutputHandler.Send($"You add the emote {command.SafeRemainingArgument.ColourCommand()} to the list of emotes.");
-        return true;
-    }
+		Emote emote = new(command.SafeRemainingArgument, new DummyPerceiver(), new DummyPerceivable());
+		if (!emote.Valid)
+		{
+			actor.OutputHandler.Send(emote.ErrorMessage);
+			return false;
+		}
 
-    private bool BuildingCommandBleedingEmoteDelay(ICharacter actor, StringStack command)
-    {
-        if (command.IsFinished)
-        {
-            actor.OutputHandler.Send("You must enter a valid dice expression for milliseconds before emoting about bleeding.");
-            return false;
-        }
+		_bleedingEmotes.Add(command.SafeRemainingArgument);
+		Changed = true;
+		actor.OutputHandler.Send($"You add the emote {command.SafeRemainingArgument.ColourCommand()} to the list of emotes.");
+		return true;
+	}
 
-        if (!Dice.IsDiceExpression(command.SafeRemainingArgument))
-        {
-            actor.OutputHandler.Send($"The text {command.SafeRemainingArgument.ColourCommand()} is not a valid dice expression.");
-            return false;
-        }
+	private bool BuildingCommandBleedingEmoteDelay(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("You must enter a valid dice expression for milliseconds before emoting about bleeding.");
+			return false;
+		}
 
-        BleedingEmoteDelayDiceExpression = command.SafeRemainingArgument;
-        Changed = true;
-        actor.OutputHandler.Send($"This AI will now wait {BleedingEmoteDelayDiceExpression.ColourValue()} milliseconds before emoting about bleeding.");
-        return true;
-    }
+		if (!Dice.IsDiceExpression(command.SafeRemainingArgument))
+		{
+			actor.OutputHandler.Send($"The text {command.SafeRemainingArgument.ColourCommand()} is not a valid dice expression.");
+			return false;
+		}
 
-    private bool BuildingCommandBindDelay(ICharacter actor, StringStack command)
-    {
-        if (command.IsFinished)
-        {
-            actor.OutputHandler.Send("You must enter a valid dice expression for milliseconds before entering the bind command.");
-            return false;
-        }
+		BleedingEmoteDelayDiceExpression = command.SafeRemainingArgument;
+		Changed = true;
+		actor.OutputHandler.Send($"This AI will now wait {BleedingEmoteDelayDiceExpression.ColourValue()} milliseconds before emoting about bleeding.");
+		return true;
+	}
 
-        if (!Dice.IsDiceExpression(command.SafeRemainingArgument))
-        {
-            actor.OutputHandler.Send($"The text {command.SafeRemainingArgument.ColourCommand()} is not a valid dice expression.");
-            return false;
-        }
+	private bool BuildingCommandBindDelay(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("You must enter a valid dice expression for milliseconds before entering the self-care command.");
+			return false;
+		}
 
-        BindingDelayDiceExpression = command.SafeRemainingArgument;
-        Changed = true;
-        actor.OutputHandler.Send($"This AI will now wait {BindingDelayDiceExpression.ColourValue()} milliseconds before binding itself.");
-        return true;
-    }
+		if (!Dice.IsDiceExpression(command.SafeRemainingArgument))
+		{
+			actor.OutputHandler.Send($"The text {command.SafeRemainingArgument.ColourCommand()} is not a valid dice expression.");
+			return false;
+		}
 
-    public static void RegisterLoader()
-    {
-        RegisterAIType("SelfCare", (ai, gameworld) => new SelfCareAI(ai, gameworld));
-        RegisterAIBuilderInformation("selfcare", (gameworld, name) => new SelfCareAI(gameworld, name), new SelfCareAI().HelpText);
-    }
+		BindingDelayDiceExpression = command.SafeRemainingArgument;
+		Changed = true;
+		actor.OutputHandler.Send($"This AI will now wait {BindingDelayDiceExpression.ColourValue()} milliseconds before tending to its own wounds.");
+		return true;
+	}
 
-    private void LoadFromXml(XElement root)
-    {
-        BindingDelayDiceExpression = root.Element("BindingDelayDiceExpression").Value;
-        BleedingEmoteDelayDiceExpression = root.Element("BleedingEmoteDelayDiceExpression").Value;
-        _bleedingEmotes.AddRange(root.Elements("BleedingEmote").Select(x => x.Value));
-    }
+	public static void RegisterLoader()
+	{
+		RegisterAIType("SelfCare", (ai, gameworld) => new SelfCareAI(ai, gameworld));
+		RegisterAIBuilderInformation("selfcare", (gameworld, name) => new SelfCareAI(gameworld, name), new SelfCareAI().HelpText);
+	}
 
-    protected override string SaveToXml()
-    {
-        return new XElement("Definition",
-            new XElement("BindingDelayDiceExpression", new XCData(BindingDelayDiceExpression)),
-            new XElement("BleedingEmoteDelayDiceExpression", new XCData(BleedingEmoteDelayDiceExpression)),
-            from emote in BleedingEmotes select new XElement("BleedingEmote", new XCData(emote))
-        ).ToString();
-    }
+	private void LoadFromXml(XElement root)
+	{
+		BindingDelayDiceExpression = root.Element("BindingDelayDiceExpression")?.Value ?? "250+1d2750";
+		BleedingEmoteDelayDiceExpression = root.Element("BleedingEmoteDelayDiceExpression")?.Value ?? "3000+1d2000";
+		_bleedingEmotes.AddRange(root.Elements("BleedingEmote").Select(x => x.Value));
+	}
 
-    public override bool HandleEvent(EventType type, params dynamic[] arguments)
-    {
-        ICharacter ch = null;
-        switch (type)
-        {
-            case EventType.LeaveCombat:
-            case EventType.NoLongerEngagedInMelee:
-            case EventType.BleedTick:
-                ch = (ICharacter)arguments[0];
-                break;
-            case EventType.NoLongerTargettedInCombat:
-                ch = (ICharacter)arguments[1];
-                break;
-        }
+	protected override string SaveToXml()
+	{
+		return new XElement("Definition",
+			new XElement("BindingDelayDiceExpression", new XCData(BindingDelayDiceExpression)),
+			new XElement("BleedingEmoteDelayDiceExpression", new XCData(BleedingEmoteDelayDiceExpression)),
+			from emote in BleedingEmotes select new XElement("BleedingEmote", new XCData(emote))
+		).ToString();
+	}
 
-        if (ch is null || ch.State.IsDead() || ch.State.IsInStatis())
-        {
-            return false;
-        }
+	public override bool HandleEvent(EventType type, params dynamic[] arguments)
+	{
+		ICharacter ch = null;
+		switch (type)
+		{
+			case EventType.CharacterEnterCellFinish:
+			case EventType.LeaveCombat:
+			case EventType.NoLongerEngagedInMelee:
+			case EventType.BleedTick:
+			case EventType.TenSecondTick:
+				ch = (ICharacter)arguments[0];
+				break;
+			case EventType.NoLongerTargettedInCombat:
+				ch = (ICharacter)arguments[1];
+				break;
+		}
 
-        switch (type)
-        {
-            case EventType.LeaveCombat:
-                return HandleLeaveCombat((ICharacter)arguments[0]);
-            case EventType.NoLongerTargettedInCombat:
-                return HandleNoLongerTargetted((ICharacter)arguments[1]);
-            case EventType.NoLongerEngagedInMelee:
-                return HandleNoLongerEngagedInMelee((ICharacter)arguments[0]);
-            case EventType.BleedTick:
-                return HandleBleedTick((ICharacter)arguments[0], (double)arguments[1]);
-        }
+		if (ch is null || ch.State.IsDead() || ch.State.IsInStatis())
+		{
+			return false;
+		}
 
-        return false;
-    }
+		switch (type)
+		{
+			case EventType.CharacterEnterCellFinish:
+				return HandleCharacterEnterCellFinish((ICharacter)arguments[0]);
+			case EventType.LeaveCombat:
+				return HandleLeaveCombat((ICharacter)arguments[0]);
+			case EventType.NoLongerTargettedInCombat:
+				return HandleNoLongerTargetted((ICharacter)arguments[1]);
+			case EventType.NoLongerEngagedInMelee:
+				return HandleNoLongerEngagedInMelee((ICharacter)arguments[0]);
+			case EventType.BleedTick:
+				return HandleBleedTick((ICharacter)arguments[0], (double)arguments[1]);
+			case EventType.TenSecondTick:
+				return HandleTenSecondTick((ICharacter)arguments[0]);
+		}
 
-    public override bool HandlesEvent(params EventType[] types)
-    {
-        foreach (EventType type in types)
-        {
-            switch (type)
-            {
-                case EventType.LeaveCombat:
-                case EventType.NoLongerTargettedInCombat:
-                case EventType.NoLongerEngagedInMelee:
-                case EventType.BleedTick:
-                    return true;
-            }
-        }
+		return false;
+	}
 
-        return false;
-    }
+	public override bool HandlesEvent(params EventType[] types)
+	{
+		foreach (EventType type in types)
+		{
+			switch (type)
+			{
+				case EventType.CharacterEnterCellFinish:
+				case EventType.LeaveCombat:
+				case EventType.NoLongerTargettedInCombat:
+				case EventType.NoLongerEngagedInMelee:
+				case EventType.BleedTick:
+				case EventType.TenSecondTick:
+					return true;
+			}
+		}
 
-    private bool HandleSelfCare(ICharacter character)
-    {
-        if (character.State.IsDisabled())
-        {
-            return false;
-        }
+		return false;
+	}
 
-        if (character.EffectsOfType<DelayedAction>().Any(x => x.ActionDescription == "self care tick"))
-        {
-            return false;
-        }
+	internal static RequiredSelfCare DetermineRequiredSelfCare(IEnumerable<IWound> wounds, bool canSuture)
+	{
+		var woundList = wounds.ToList();
+		if (woundList.Any(x => x.BleedStatus == BleedStatus.Bleeding))
+		{
+			return RequiredSelfCare.Bind;
+		}
 
-        if (
-            character.VisibleWounds(character, WoundExaminationType.Self)
-                     .Any(x => x.PeekBleed(1.0, character.LongtermExertion) > 0.0))
-        {
-            // TODO - make sure the emote doesn't fire every bleed tick
-            if (BleedingEmotes.Any() &&
-                character.EffectsOfType<DelayedAction>().All(x => x.ActionDescription != "self care tick") &&
-                Dice.Roll("1d6") == 1
-                )
-            {
-                character.AddEffect(
-                    new DelayedAction(character,
-                        x => { character.OutputHandler.Handle(new EmoteOutput(new Emote(BleedingEmote, character))); },
-                        "self care tick"), TimeSpan.FromMilliseconds(Dice.Roll(BleedingEmoteDelayDiceExpression)));
-            }
+		if (canSuture &&
+		    woundList.Any(x => x.BleedStatus == BleedStatus.TraumaControlled &&
+		                       x.CanBeTreated(TreatmentType.Close) != Difficulty.Impossible))
+		{
+			return RequiredSelfCare.Suture;
+		}
 
-            if (character.IsEngagedInMelee)
-            {
-                return false;
-            }
+		return RequiredSelfCare.None;
+	}
 
-            if (character.Effects.Any(x => x.IsBlockingEffect("general")))
-            {
-                return false;
-            }
+	internal static bool CellHasHostileNpcs(ICell cell, ICharacter character)
+	{
+		return cell?.Characters.Any(x =>
+			x != character &&
+			x is INPC npc &&
+			!npc.AffectedBy<IPauseAIEffect>() &&
+			npc.AIs.Any(y => y.CountsAsAggressive)) == true;
+	}
 
-            if (character.Movement != null)
-            {
-                return false;
-            }
+	internal static ICellExit GetSafeExitForSelfCare(ICharacter character)
+	{
+		if (character.Location == null)
+		{
+			return null;
+		}
 
-            if (!CharacterState.Able.HasFlag(character.State))
-            {
-                return false;
-            }
+		return character.Location.ExitsFor(character, true)
+		                .Where(x => !CellHasHostileNpcs(x.Destination, character))
+		                .FirstOrDefault(x => character.CanMove(
+			                    x,
+			                    CanMoveFlags.IgnoreCancellableActionBlockers | CanMoveFlags.IgnoreSafeMovement)
+		                    .Result);
+	}
 
-            character.AddEffect(
-                new DelayedAction(character, x => { character.ExecuteCommand("bind self"); }, "self care tick"),
-                TimeSpan.FromMilliseconds(Dice.Roll(BindingDelayDiceExpression)));
-            return true;
-        }
+	private static IEnumerable<IWound> VisibleWoundsForSelfCare(ICharacter character)
+	{
+		return character.VisibleWounds(character, WoundExaminationType.Examination);
+	}
 
-        return false;
-    }
+	private static bool HasPendingDelayedAction(ICharacter character, string actionDescription)
+	{
+		return character.EffectsOfType<DelayedAction>().Any(x => x.ActionDescription == actionDescription);
+	}
 
-    private bool HandleBleedTick(ICharacter character, double amount)
-    {
-        return HandleSelfCare(character);
-    }
+	private static bool CanSutureSelf(ICharacter character)
+	{
+		return character.Gameworld.SutureInventoryPlanTemplate.CreatePlan(character).PlanIsFeasible() ==
+		       InventoryPlanFeasibility.Feasible;
+	}
 
-    private bool HandleNoLongerEngagedInMelee(ICharacter character)
-    {
-        return HandleSelfCare(character);
-    }
+	private void MaybeScheduleBleedingEmote(ICharacter character, RequiredSelfCare careType)
+	{
+		if (careType != RequiredSelfCare.Bind ||
+		    !BleedingEmotes.Any() ||
+		    HasPendingDelayedAction(character, SelfCareBleedingEmoteAction) ||
+		    Dice.Roll("1d6") != 1)
+		{
+			return;
+		}
 
-    private bool HandleNoLongerTargetted(ICharacter character)
-    {
-        return HandleSelfCare(character);
-    }
+		character.AddEffect(
+			new DelayedAction(character,
+				x => { character.OutputHandler.Handle(new EmoteOutput(new Emote(BleedingEmote, character))); },
+				SelfCareBleedingEmoteAction),
+			TimeSpan.FromMilliseconds(Dice.Roll(BleedingEmoteDelayDiceExpression)));
+	}
 
-    private bool HandleLeaveCombat(ICharacter character)
-    {
-        return HandleSelfCare(character);
-    }
+	private static bool TryLeaveCombatForSelfCare(ICharacter character)
+	{
+		if (character.Combat == null)
+		{
+			return false;
+		}
+
+		if (character.Combat.Friendly)
+		{
+			character.Combat.TruceRequested(character);
+			return true;
+		}
+
+		if (character.Combat.CanFreelyLeaveCombat(character))
+		{
+			character.Combat.LeaveCombat(character);
+			return true;
+		}
+
+		character.CombatStrategyMode = CombatStrategyMode.Flee;
+		return true;
+	}
+
+	private static bool TryMoveToSafeLocationForSelfCare(ICharacter character)
+	{
+		if (character.Location == null || !CellHasHostileNpcs(character.Location, character))
+		{
+			return false;
+		}
+
+		var exit = GetSafeExitForSelfCare(character);
+		return exit != null && character.Move(exit, null, true);
+	}
+
+	private bool QueueSelfCareCommand(ICharacter character, string command)
+	{
+		if (HasPendingDelayedAction(character, SelfCareMedicalAction))
+		{
+			return false;
+		}
+
+		character.AddEffect(
+			new DelayedAction(character, x => { character.ExecuteCommand(command); }, SelfCareMedicalAction),
+			TimeSpan.FromMilliseconds(Dice.Roll(BindingDelayDiceExpression)));
+		return true;
+	}
+
+	private bool HandleSelfCare(ICharacter character)
+	{
+		if (character.State.IsDisabled())
+		{
+			return false;
+		}
+
+		var visibleWounds = VisibleWoundsForSelfCare(character).ToList();
+		var careType = DetermineRequiredSelfCare(visibleWounds, false);
+		if (careType == RequiredSelfCare.None)
+		{
+			careType = DetermineRequiredSelfCare(visibleWounds, CanSutureSelf(character));
+		}
+
+		if (careType == RequiredSelfCare.None)
+		{
+			return false;
+		}
+
+		MaybeScheduleBleedingEmote(character, careType);
+
+		if (character.Combat != null)
+		{
+			return TryLeaveCombatForSelfCare(character);
+		}
+
+		if (character.Movement != null)
+		{
+			return false;
+		}
+
+		if (!character.State.IsAble())
+		{
+			return false;
+		}
+
+		if (TryMoveToSafeLocationForSelfCare(character))
+		{
+			return true;
+		}
+
+		if (character.Effects.Any(x => x.IsBlockingEffect("general")))
+		{
+			return false;
+		}
+
+		return careType switch
+		{
+			RequiredSelfCare.Bind => QueueSelfCareCommand(character, "bind self"),
+			RequiredSelfCare.Suture => QueueSelfCareCommand(character, "suture self"),
+			_ => false
+		};
+	}
+
+	private bool HandleBleedTick(ICharacter character, double amount)
+	{
+		return HandleSelfCare(character);
+	}
+
+	private bool HandleCharacterEnterCellFinish(ICharacter character)
+	{
+		return HandleSelfCare(character);
+	}
+
+	private bool HandleNoLongerEngagedInMelee(ICharacter character)
+	{
+		return HandleSelfCare(character);
+	}
+
+	private bool HandleNoLongerTargetted(ICharacter character)
+	{
+		return HandleSelfCare(character);
+	}
+
+	private bool HandleLeaveCombat(ICharacter character)
+	{
+		return HandleSelfCare(character);
+	}
+
+	private bool HandleTenSecondTick(ICharacter character)
+	{
+		return HandleSelfCare(character);
+	}
 }


### PR DESCRIPTION
## Summary
- Teach `SelfCareAI` to prioritize binding bleeding wounds, then suture trauma-controlled wounds when suturing is available
- Make the AI try to leave combat first, and move toward safer exits when hostile NPCs are present
- Add regression coverage for care selection, hostile-room detection, and safe-exit selection

## Testing
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-build --filter "FullyQualifiedName~NpcAiRegressionTests" -p:NoWarn=NU1902%3BNU1510`
- `scripts\test-unit-core.ps1`