### PR TITLE
Add terrain-aware autobuilder seeding and documentation

### DIFF
--- a/DatabaseSeeder Unit Tests/UsefulSeederAutobuilderTests.cs
+++ b/DatabaseSeeder Unit Tests/UsefulSeederAutobuilderTests.cs
@@ -1,0 +1,251 @@
+#nullable enable
+
+using DatabaseSeeder;
+using DatabaseSeeder.Seeders;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Database;
+using MudSharp.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Xml.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class UsefulSeederAutobuilderTests
+{
+	private static FuturemudDatabaseContext BuildContext()
+	{
+		DbContextOptions<FuturemudDatabaseContext> options = new DbContextOptionsBuilder<FuturemudDatabaseContext>()
+			.UseInMemoryDatabase(Guid.NewGuid().ToString())
+			.ConfigureWarnings(x => x.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+			.Options;
+		return new FuturemudDatabaseContext(options);
+	}
+
+	private static void SeedAccount(FuturemudDatabaseContext context)
+	{
+		context.Accounts.Add(new Account
+		{
+			Id = 1,
+			Name = "SeederTest",
+			Password = "password",
+			Salt = 1,
+			AccessStatus = 0,
+			Email = "seeder@example.com",
+			LastLoginIp = "127.0.0.1",
+			FormatLength = 80,
+			InnerFormatLength = 78,
+			UseMxp = false,
+			UseMsp = false,
+			UseMccp = false,
+			ActiveCharactersAllowed = 1,
+			UseUnicode = true,
+			TimeZoneId = "UTC",
+			CultureName = "en-AU",
+			RegistrationCode = string.Empty,
+			IsRegistered = true,
+			RecoveryCode = string.Empty,
+			UnitPreference = "metric",
+			CreationDate = DateTime.UtcNow,
+			PageLength = 22,
+			PromptType = 0,
+			TabRoomDescriptions = false,
+			CodedRoomDescriptionAdditionsOnNewLine = false,
+			CharacterNameOverlaySetting = 0,
+			AppendNewlinesBetweenMultipleEchoesPerPrompt = false,
+			ActLawfully = false,
+			HasBeenActiveInWeek = true,
+			HintsEnabled = true,
+			AutoReacquireTargets = false
+		});
+		context.SaveChanges();
+	}
+
+	private static void SeedMaterials(FuturemudDatabaseContext context)
+	{
+		CoreDataSeeder seeder = new();
+		typeof(CoreDataSeeder)
+			.GetMethod("SeedMaterials", BindingFlags.Instance | BindingFlags.NonPublic)!
+			.Invoke(seeder, [context]);
+	}
+
+	private static void SeedVoidTerrain(FuturemudDatabaseContext context)
+	{
+		context.Terrains.Add(new Terrain
+		{
+			Id = 1,
+			Name = "Void",
+			HideDifficulty = 0,
+			SpotDifficulty = 0,
+			InfectionType = 0,
+			InfectionVirulence = 0,
+			InfectionMultiplier = 0,
+			StaminaCost = 0,
+			TerrainANSIColour = "7",
+			TerrainEditorColour = "#FFFFFFFF",
+			TerrainBehaviourMode = "outdoors",
+			DefaultTerrain = true,
+			MovementRate = 0,
+			ForagableProfileId = 0,
+			AtmosphereType = "Gas",
+			DefaultCellOutdoorsType = 0,
+			TerrainEditorText = "Vo",
+			CanHaveTracks = false,
+			TrackIntensityMultiplierVisual = 1.0,
+			TrackIntensityMultiplierOlfactory = 1.0,
+			TagInformation = string.Empty
+		});
+		context.SaveChanges();
+	}
+
+	private static void SeedTerrainFoundations(FuturemudDatabaseContext context)
+	{
+		SeedMaterials(context);
+		SeedVoidTerrain(context);
+		CoreDataSeeder.SeedTerrainFoundationsForTesting(context);
+	}
+
+	private static Dictionary<string, string> BuildAutobuilderOnlyAnswers()
+	{
+		return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+		{
+			["ai"] = "no",
+			["covers"] = "no",
+			["items"] = "no",
+			["modernitems"] = "no",
+			["tags"] = "no",
+			["autobuilder"] = "yes",
+			["hints"] = "no",
+			["dreams"] = "no"
+		};
+	}
+
+	private static XElement GetTemplateDefinition(FuturemudDatabaseContext context, string templateName)
+	{
+		return XElement.Parse(context.AutobuilderRoomTemplates.Single(x => x.Name == templateName).Definition);
+	}
+
+	[TestMethod]
+	public void ClassifyAutobuilderPackagePresence_NonePartialAndFull_ReturnExpectedStates()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+
+		Assert.AreEqual(ShouldSeedResult.ReadyToInstall, UsefulSeeder.ClassifyAutobuilderPackagePresence(context));
+
+		context.AutobuilderRoomTemplates.Add(new AutobuilderRoomTemplate
+		{
+			Id = 1,
+			Name = UsefulSeeder.StockAutobuilderRoomTemplateNamesForTesting.First(),
+			TemplateType = "room by terrain",
+			Definition = "<Template />"
+		});
+		context.SaveChanges();
+
+		Assert.AreEqual(ShouldSeedResult.ExtraPackagesAvailable, UsefulSeeder.ClassifyAutobuilderPackagePresence(context));
+
+		context.AutobuilderRoomTemplates.RemoveRange(context.AutobuilderRoomTemplates.ToList());
+		context.AutobuilderRoomTemplates.AddRange(
+			UsefulSeeder.StockAutobuilderRoomTemplateNamesForTesting.Select((name, index) => new AutobuilderRoomTemplate
+			{
+				Id = index + 1,
+				Name = name,
+				TemplateType = index == 0 ? "room by terrain" : "room random description",
+				Definition = "<Template />"
+			}));
+		context.SaveChanges();
+
+		Assert.AreEqual(ShouldSeedResult.MayAlreadyBeInstalled, UsefulSeeder.ClassifyAutobuilderPackagePresence(context));
+	}
+
+	[TestMethod]
+	public void SeederQuestions_AutobuilderQuestionAppearsOnlyWhenTerrainCatalogueExistsAndPackageIncomplete()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedAccount(context);
+		UsefulSeeder seeder = new();
+		var question = seeder.SeederQuestions.Single(x => x.Id == "autobuilder");
+
+		Assert.IsFalse(question.Filter(context, new Dictionary<string, string>()));
+
+		SeedTerrainFoundations(context);
+
+		Assert.IsTrue(question.Filter(context, new Dictionary<string, string>()));
+
+		seeder.SeedTerrainAutobuilderForTesting(context);
+
+		Assert.IsFalse(question.Filter(context, new Dictionary<string, string>()));
+	}
+
+	[TestMethod]
+	public void SeedData_AutobuilderOnlyAnswers_InstallsStockTerrainAwareRoomTemplates()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedAccount(context);
+		SeedTerrainFoundations(context);
+		UsefulSeeder seeder = new();
+
+		string result = seeder.SeedData(context, BuildAutobuilderOnlyAnswers());
+
+		Assert.AreEqual("The operation completed successfully.", result);
+		Assert.AreEqual(ShouldSeedResult.MayAlreadyBeInstalled, UsefulSeeder.ClassifyAutobuilderPackagePresence(context));
+
+		foreach (string name in UsefulSeeder.StockAutobuilderRoomTemplateNamesForTesting)
+		{
+			Assert.AreEqual(1, context.AutobuilderRoomTemplates.Count(x => x.Name == name),
+				$"Expected a single autobuilder template named {name}.");
+		}
+
+		XElement baseline = GetTemplateDefinition(context, "Seeded Terrain Baseline");
+		XElement random = GetTemplateDefinition(context, "Seeded Terrain Random Description");
+		List<Terrain> nonVoidTerrains = context.Terrains
+			.Where(x => !string.Equals(x.Name, "Void", StringComparison.OrdinalIgnoreCase))
+			.ToList();
+
+		Assert.AreEqual("room by terrain", context.AutobuilderRoomTemplates.Single(x => x.Name == "Seeded Terrain Baseline").TemplateType);
+		Assert.AreEqual("room random description", context.AutobuilderRoomTemplates.Single(x => x.Name == "Seeded Terrain Random Description").TemplateType);
+		Assert.AreEqual(nonVoidTerrains.Count - 1, baseline.Element("Terrains")!.Elements("Terrain").Count());
+		Assert.AreEqual(nonVoidTerrains.Count - 1, random.Element("Terrains")!.Elements("Terrain").Count());
+		Assert.IsTrue(random.Element("Descriptions")!.Elements("Description").Any());
+		Assert.AreEqual("2+1d2", random.Element("Default")!.Element("NumberOfRandomElements")!.Value);
+		Assert.IsTrue(random.Element("Terrains")!.Elements("Terrain").All(x => x.Element("NumberOfRandomElements") != null));
+		Assert.IsFalse(random
+			.Descendants("DefaultTerrain")
+			.Any(x => x.Value == "1"),
+			"Void terrain should not be part of the seeded autobuilder package.");
+	}
+
+	[TestMethod]
+	public void SeedTerrainAutobuilderForTesting_RerunRepairsTemplatesWithoutDuplicates()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedAccount(context);
+		SeedTerrainFoundations(context);
+		UsefulSeeder seeder = new();
+
+		seeder.SeedTerrainAutobuilderForTesting(context);
+
+		AutobuilderRoomTemplate randomTemplate =
+			context.AutobuilderRoomTemplates.Single(x => x.Name == "Seeded Terrain Random Description");
+		randomTemplate.Definition = "<Template><Descriptions /></Template>";
+		context.AutobuilderRoomTemplates.Remove(
+			context.AutobuilderRoomTemplates.Single(x => x.Name == "Seeded Terrain Baseline"));
+		context.SaveChanges();
+
+		seeder.SeedTerrainAutobuilderForTesting(context);
+
+		foreach (string name in UsefulSeeder.StockAutobuilderRoomTemplateNamesForTesting)
+		{
+			Assert.AreEqual(1, context.AutobuilderRoomTemplates.Count(x => x.Name == name),
+				$"Expected rerun to preserve exactly one autobuilder template named {name}.");
+		}
+
+		XElement repairedRandom = GetTemplateDefinition(context, "Seeded Terrain Random Description");
+		Assert.IsTrue(repairedRandom.Element("Descriptions")!.Elements("Description").Any());
+		Assert.IsTrue(repairedRandom.Element("Terrains")!.Elements("Terrain").All(x => x.Element("NumberOfRandomElements") != null));
+	}
+}

--- a/DatabaseSeeder/Seeders/UsefulSeeder.Autobuilder.cs
+++ b/DatabaseSeeder/Seeders/UsefulSeeder.Autobuilder.cs
@@ -1,0 +1,604 @@
+#nullable enable
+
+using MudSharp.Construction;
+using MudSharp.Database;
+using MudSharp.Framework;
+using MudSharp.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace DatabaseSeeder.Seeders;
+
+public partial class UsefulSeeder
+{
+	private static readonly string[] StockAutobuilderRoomTemplateNames =
+	[
+		"Seeded Terrain Baseline",
+		"Seeded Terrain Random Description"
+	];
+
+	internal static IReadOnlyCollection<string> StockAutobuilderRoomTemplateNamesForTesting =>
+		StockAutobuilderRoomTemplateNames;
+
+	internal static ShouldSeedResult ClassifyAutobuilderPackagePresence(FuturemudDatabaseContext context)
+	{
+		return SeederRepeatabilityHelper.ClassifyByPresence(
+			StockAutobuilderRoomTemplateNames.Select(name => context.AutobuilderRoomTemplates.Any(x => x.Name == name)));
+	}
+
+	internal void SeedTerrainAutobuilderForTesting(FuturemudDatabaseContext context)
+	{
+		SeedTerrainAutobuilderCore(context, new List<string>());
+	}
+
+	private void SeedTerrainAutobuilderCore(FuturemudDatabaseContext context, ICollection<string> errors)
+	{
+		List<Terrain> terrains = context.Terrains
+			.Where(x => !string.Equals(x.Name, "Void", StringComparison.OrdinalIgnoreCase))
+			.OrderBy(x => x.Id)
+			.ToList();
+		if (!terrains.Any())
+		{
+			errors.Add(
+				"Could not seed the terrain autobuilder room templates because no terrains are installed yet. Run the terrain foundations seeding first.");
+			return;
+		}
+
+		Dictionary<long, HashSet<string>> terrainTags = BuildTerrainTagLookup(context, terrains);
+		foreach (AutobuilderRoomTemplateSeedDefinition roomTemplate in BuildStockAutobuilderRoomTemplates(terrains, terrainTags))
+		{
+			EnsureAutobuilderRoomTemplate(context, roomTemplate);
+		}
+
+		context.SaveChanges();
+	}
+
+	private static IReadOnlyList<AutobuilderRoomTemplateSeedDefinition> BuildStockAutobuilderRoomTemplates(
+		IReadOnlyCollection<Terrain> terrains,
+		IReadOnlyDictionary<long, HashSet<string>> terrainTags)
+	{
+		Terrain defaultTerrain = terrains.FirstOrDefault(x => x.DefaultTerrain) ?? terrains.OrderBy(x => x.Id).First();
+		List<XElement> roomInfos = terrains
+			.Select(x => CreateRoomInfoElement(x, x.Name, BuildSeededTerrainBaseDescription(x, terrainTags[x.Id])))
+			.ToList();
+		XElement defaultInfo = roomInfos.First(x => long.Parse(x.Element("DefaultTerrain")!.Value) == defaultTerrain.Id);
+		List<XElement> overrides = roomInfos
+			.Where(x => long.Parse(x.Element("DefaultTerrain")!.Value) != defaultTerrain.Id)
+			.ToList();
+
+		return
+		[
+			new AutobuilderRoomTemplateSeedDefinition(
+				"Seeded Terrain Baseline",
+				"room by terrain",
+				CreateRoomByTerrainTemplateDefinition(
+					"Terrain-aware baseline descriptions for the stock seeded terrain catalogue.",
+					defaultInfo,
+					overrides,
+					applyTagsAsFrameworkTags: true
+				)
+			),
+			new AutobuilderRoomTemplateSeedDefinition(
+				"Seeded Terrain Random Description",
+				"room random description",
+				CreateRandomDescriptionRoomTemplateDefinition(
+					"Terrain-aware random descriptions layered on top of the stock seeded terrain catalogue.",
+					defaultInfo,
+					overrides,
+					BuildStockRandomDescriptionElements(terrains, terrainTags),
+					defaultRandomElementExpression: "2+1d2",
+					applyTagsAsFrameworkTags: true
+				)
+			)
+		];
+	}
+
+	private static IEnumerable<XElement> BuildStockRandomDescriptionElements(
+		IReadOnlyCollection<Terrain> terrains,
+		IReadOnlyDictionary<long, HashSet<string>> terrainTags)
+	{
+		List<XElement> elements = new();
+		List<Terrain> outdoorsTerrains = terrains.Where(IsOutdoorsTerrain).ToList();
+		List<Terrain> indoorsTerrains = terrains.Except(outdoorsTerrains).ToList();
+		List<Terrain> urbanTerrains = GetTerrainsByTag(terrains, terrainTags, "Urban");
+		List<Terrain> ruralTerrains = GetTerrainsByTag(terrains, terrainTags, "Rural");
+		List<Terrain> publicTerrains = GetTerrainsByTag(terrains, terrainTags, "Public");
+		List<Terrain> privateTerrains = GetTerrainsByTag(terrains, terrainTags, "Private");
+		List<Terrain> commercialTerrains = GetTerrainsByTag(terrains, terrainTags, "Commercial");
+		List<Terrain> residentialTerrains = GetTerrainsByTag(terrains, terrainTags, "Residential");
+		List<Terrain> administrativeTerrains = GetTerrainsByTag(terrains, terrainTags, "Administrative");
+		List<Terrain> industrialTerrains = GetTerrainsByTag(terrains, terrainTags, "Industrial");
+		List<Terrain> terrestrialTerrains = GetTerrainsByTag(terrains, terrainTags, "Terrestrial");
+		List<Terrain> aquaticTerrains = GetTerrainsByTag(terrains, terrainTags, "Aquatic");
+		List<Terrain> littoralTerrains = GetTerrainsByTag(terrains, terrainTags, "Littoral");
+		List<Terrain> riparianTerrains = GetTerrainsByTag(terrains, terrainTags, "Riparian");
+		List<Terrain> wetlandTerrains = GetTerrainsByTag(terrains, terrainTags, "Wetland");
+		List<Terrain> aridTerrains = GetTerrainsByTag(terrains, terrainTags, "Arid");
+		List<Terrain> glacialTerrains = GetTerrainsByTag(terrains, terrainTags, "Glacial");
+		List<Terrain> volcanicTerrains = GetTerrainsByTag(terrains, terrainTags, "Volcanic");
+		List<Terrain> lunarTerrains = GetTerrainsByTag(terrains, terrainTags, "Lunar");
+		List<Terrain> spaceTerrains = GetTerrainsByTag(terrains, terrainTags, "Space");
+		List<Terrain> vacuumTerrains = GetTerrainsByTag(terrains, terrainTags, "Vacuum");
+		List<Terrain> diggableTerrains = GetTerrainsByTag(terrains, terrainTags, "Diggable Soil");
+		List<Terrain> sandTerrains = GetTerrainsByTag(terrains, terrainTags, "Foragable Sand");
+		List<Terrain> clayTerrains = GetTerrainsByTag(terrains, terrainTags, "Foragable Clay");
+		List<Terrain> woodedTerrains = terrains.Where(x =>
+			x.TerrainBehaviourMode.Contains("trees", StringComparison.OrdinalIgnoreCase)).ToList();
+		List<Terrain> caveTerrains = terrains.Where(x =>
+			x.TerrainBehaviourMode.Contains("cave", StringComparison.OrdinalIgnoreCase)).ToList();
+		List<Terrain> roadTerrains = terrains.Where(x =>
+				x.Name.Contains("Road", StringComparison.OrdinalIgnoreCase) ||
+				x.Name.Contains("Street", StringComparison.OrdinalIgnoreCase) ||
+				x.Name.Contains("Trail", StringComparison.OrdinalIgnoreCase) ||
+				x.Name.Contains("Alley", StringComparison.OrdinalIgnoreCase))
+			.ToList();
+
+		AddElementIfAny(elements,
+			"Open exposure leaves the location at the mercy of the wider environment.",
+			outdoorsTerrains);
+		AddElementIfAny(elements,
+			"Weather, light, and distant sound from the surrounding area reach this spot with little resistance.",
+			outdoorsTerrains);
+		AddElementIfAny(elements,
+			"Nearby walls and overhead structure keep the space feeling enclosed.",
+			indoorsTerrains);
+		AddElementIfAny(elements,
+			"The surrounding construction contains sound and movement, giving the area a more sheltered feel.",
+			indoorsTerrains);
+		AddElementIfAny(elements,
+			"Worked surfaces and maintained edges give the place an unmistakably urban character.",
+			urbanTerrains);
+		AddElementIfAny(elements,
+			"Scuffs, repairs, and habitual traffic show in the way the space has been worn down over time.",
+			urbanTerrains);
+		AddElementIfAny(elements,
+			"Domestic details hint at private lives carried on nearby.",
+			residentialTerrains);
+		AddElementIfAny(elements,
+			"The layout suggests exchange, visitors, and repeated daily traffic.",
+			commercialTerrains);
+		AddElementIfAny(elements,
+			"Orderly lines and formal fittings lend the location an official air.",
+			administrativeTerrains);
+		AddElementIfAny(elements,
+			"Heavy-duty materials and stubborn residue hint at hard use and regular labour.",
+			industrialTerrains);
+		AddElementIfAny(elements,
+			"Practical construction and rougher boundaries give the area a distinctly rural feel.",
+			ruralTerrains);
+		AddElementIfAny(elements,
+			"The place feels meant to be shared or passed through rather than held privately.",
+			publicTerrains);
+		AddElementIfAny(elements,
+			"The arrangement of the space suggests ownership, oversight, or restricted use.",
+			privateTerrains);
+		AddElementIfAny(elements,
+			"Natural growth and uneven ground keep the place feeling more grown than built.",
+			terrestrialTerrains);
+		AddElementIfAny(elements,
+			"Overhead growth filters the light through leaves, limbs, or tangled branches.",
+			woodedTerrains);
+		AddElementIfAny(elements,
+			"Vegetation crowds in enough to break sightlines and soften the edges of the terrain.",
+			woodedTerrains);
+		AddElementIfAny(elements,
+			"Moisture, motion, and the persistent presence of water dominate the immediate surroundings.",
+			aquaticTerrains);
+		AddElementIfAny(elements,
+			"Debris, spray, or shifting shoreline traces mark the meeting of land and water.",
+			littoralTerrains);
+		AddElementIfAny(elements,
+			"Nearby flowing water leaves the ground damp and the air lively.",
+			riparianTerrains);
+		AddElementIfAny(elements,
+			"Soft footing and trapped water make the terrain feel uncertain underfoot.",
+			wetlandTerrains);
+		AddElementIfAny(elements,
+			"Dry grit and bleached surfaces suggest long heat and very little moisture.",
+			aridTerrains);
+		AddElementIfAny(elements,
+			"Cold brightness and hard frozen surfaces give the area a stark clarity.",
+			glacialTerrains);
+		AddElementIfAny(elements,
+			"Dark stone, ash, or scorched textures lend the ground a volcanic harshness.",
+			volcanicTerrains);
+		AddElementIfAny(elements,
+			"Stone presses close enough here to swallow light and soften distant sounds.",
+			caveTerrains);
+		AddElementIfAny(elements,
+			"The landscape feels exposed and alien, stripped back to stone, dust, and stark sky.",
+			lunarTerrains);
+		AddElementIfAny(elements,
+			"The surrounding void makes even nearby features feel isolated and remote.",
+			spaceTerrains);
+		AddElementIfAny(elements,
+			"The lack of atmosphere leaves the area exposed in a way few environments ever are.",
+			vacuumTerrains);
+		AddElementIfAny(elements,
+			"The ground looks loose enough to be worked, disturbed, or marked by recent activity.",
+			diggableTerrains);
+		AddElementIfAny(elements,
+			"Loose sand shifts with the smallest disturbance and refuses to keep a clean edge for long.",
+			sandTerrains);
+		AddElementIfAny(elements,
+			"Heavier clay and damp earth lend the ground a dense, stubborn texture.",
+			clayTerrains);
+		AddElementIfAny(elements,
+			"The terrain carries the clear suggestion of travel and repeated passage.",
+			roadTerrains);
+		AddElementIfAny(elements,
+			"Repeated movement has worn a clearer route through the surrounding terrain.",
+			roadTerrains,
+			weight: 75.0);
+
+		return elements;
+	}
+
+	private static Dictionary<long, HashSet<string>> BuildTerrainTagLookup(FuturemudDatabaseContext context,
+		IEnumerable<Terrain> terrains)
+	{
+		Dictionary<long, string> tagsById = context.Tags.ToDictionary(x => x.Id, x => x.Name);
+		Dictionary<long, HashSet<string>> result = new();
+		foreach (Terrain terrain in terrains)
+		{
+			HashSet<string> tags = new(StringComparer.OrdinalIgnoreCase);
+			if (!string.IsNullOrWhiteSpace(terrain.TagInformation))
+			{
+				foreach (string value in terrain.TagInformation.Split(',',
+					         StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+				{
+					if (long.TryParse(value, out long tagId) && tagsById.TryGetValue(tagId, out string? tagName))
+					{
+						tags.Add(tagName);
+					}
+				}
+			}
+
+			result[terrain.Id] = tags;
+		}
+
+		return result;
+	}
+
+	private static List<Terrain> GetTerrainsByTag(IEnumerable<Terrain> terrains,
+		IReadOnlyDictionary<long, HashSet<string>> terrainTags, string tag)
+	{
+		return terrains.Where(x => terrainTags[x.Id].Contains(tag)).ToList();
+	}
+
+	private static bool IsOutdoorsTerrain(Terrain terrain)
+	{
+		return (CellOutdoorsType)terrain.DefaultCellOutdoorsType is CellOutdoorsType.Outdoors or
+			CellOutdoorsType.IndoorsClimateExposed;
+	}
+
+	private static string BuildSeededTerrainBaseDescription(Terrain terrain, IReadOnlyCollection<string> tags)
+	{
+		List<string> fragments = new();
+		if (tags.Contains("Urban"))
+		{
+			fragments.Add("worked, human-made surroundings");
+		}
+
+		if (tags.Contains("Rural"))
+		{
+			fragments.Add("practical, lightly developed ground");
+		}
+
+		if (tags.Contains("Aquatic"))
+		{
+			fragments.Add("the immediate presence of water");
+		}
+
+		if (tags.Contains("Wetland"))
+		{
+			fragments.Add("soft, uncertain footing");
+		}
+
+		if (tags.Contains("Arid"))
+		{
+			fragments.Add("dry heat and gritty surfaces");
+		}
+
+		if (tags.Contains("Glacial"))
+		{
+			fragments.Add("cold, bright frozen terrain");
+		}
+
+		if (tags.Contains("Volcanic"))
+		{
+			fragments.Add("dark stone and scorched texture");
+		}
+
+		if (tags.Contains("Lunar") || tags.Contains("Space") || tags.Contains("Vacuum"))
+		{
+			fragments.Add("an exposed, alien environment");
+		}
+
+		string supportingText = fragments.Any()
+			? $"The location immediately suggests {fragments.ListToString()}."
+			: "The terrain establishes the place before any finer details are noticed.";
+
+		return
+			$"{terrain.Name} sets the broad character of this location. {supportingText}";
+	}
+
+	private static void AddElementIfAny(ICollection<XElement> elements, string text, IEnumerable<Terrain> terrains,
+		string roomNameText = "{0}", double weight = 100.0, IEnumerable<string>? tags = null)
+	{
+		List<Terrain> terrainList = terrains.Distinct().ToList();
+		if (!terrainList.Any())
+		{
+			return;
+		}
+
+		elements.Add(CreateRandomDescriptionElement(text, roomNameText, weight, terrainList, tags));
+	}
+
+	private static void EnsureAutobuilderRoomTemplate(FuturemudDatabaseContext context,
+		AutobuilderRoomTemplateSeedDefinition definition)
+	{
+		AutobuilderRoomTemplate template = SeederRepeatabilityHelper.EnsureNamedEntity(
+			context.AutobuilderRoomTemplates,
+			definition.Name,
+			x => x.Name,
+			() =>
+			{
+				AutobuilderRoomTemplate created = new();
+				context.AutobuilderRoomTemplates.Add(created);
+				return created;
+			});
+
+		template.Name = definition.Name;
+		template.TemplateType = definition.TemplateType;
+		template.Definition = definition.Definition.ToString();
+	}
+
+	private static void EnsureAutobuilderAreaTemplate(FuturemudDatabaseContext context,
+		AutobuilderAreaTemplateSeedDefinition definition)
+	{
+		AutobuilderAreaTemplate template = SeederRepeatabilityHelper.EnsureNamedEntity(
+			context.AutobuilderAreaTemplates,
+			definition.Name,
+			x => x.Name,
+			() =>
+			{
+				AutobuilderAreaTemplate created = new();
+				context.AutobuilderAreaTemplates.Add(created);
+				return created;
+			});
+
+		template.Name = definition.Name;
+		template.TemplateType = definition.TemplateType;
+		template.Definition = definition.Definition.ToString();
+	}
+
+	private static XElement CreateRoomInfoElement(Terrain terrain, string roomName, string roomDescription,
+		CellOutdoorsType? outdoorsType = null, double? ambientLightFactor = null, long? foragableProfileId = null)
+	{
+		CellOutdoorsType outdoorType = outdoorsType ?? (CellOutdoorsType)terrain.DefaultCellOutdoorsType;
+		return new XElement("Terrain",
+			new XElement("DefaultTerrain", terrain.Id),
+			new XElement("RoomName", new XCData(roomName)),
+			new XElement("RoomDescription", new XCData(roomDescription)),
+			new XElement("OutdoorsType", (int)outdoorType),
+			new XElement("CellLightMultiplier", ambientLightFactor ?? GetDefaultAmbientLightFactor(outdoorType)),
+			new XElement("ForagableProfile", foragableProfileId ?? terrain.ForagableProfileId)
+		);
+	}
+
+	private static XElement CreateRoomByTerrainTemplateDefinition(string byline, XElement defaultInfo,
+		IEnumerable<XElement> terrainOverrides, bool applyTagsAsFrameworkTags = true)
+	{
+		return new XElement("Template",
+			new XElement("ApplyAutobuilderTagsAsFrameworkTags", applyTagsAsFrameworkTags),
+			new XElement("ShowCommandByline", new XCData(byline)),
+			new XElement("Default", defaultInfo),
+			new XElement("Terrains", terrainOverrides)
+		);
+	}
+
+	private static XElement CreateRandomDescriptionRoomTemplateDefinition(string byline, XElement defaultInfo,
+		IEnumerable<XElement> terrainOverrides, IEnumerable<XElement> descriptionElements,
+		string defaultRandomElementExpression = "2+1d2", bool applyTagsAsFrameworkTags = true,
+		string addToAllRoomDescriptions = "")
+	{
+		List<XElement> overrideElements = terrainOverrides
+			.Select(x =>
+			{
+				XElement clone = new(x);
+				if (clone.Element("NumberOfRandomElements") == null)
+				{
+					clone.Add(new XElement("NumberOfRandomElements", new XCData(defaultRandomElementExpression)));
+				}
+
+				return clone;
+			})
+			.ToList();
+
+		return new XElement("Template",
+			new XElement("ApplyAutobuilderTagsAsFrameworkTags", applyTagsAsFrameworkTags),
+			new XElement("ShowCommandByline", new XCData(byline)),
+			new XElement("AddToAllRoomDescriptions", new XCData(addToAllRoomDescriptions)),
+			new XElement("Default",
+				defaultInfo,
+				new XElement("NumberOfRandomElements", new XCData(defaultRandomElementExpression))
+			),
+			new XElement("Descriptions", descriptionElements),
+			new XElement("Terrains", overrideElements)
+		);
+	}
+
+	private static XElement CreateTerrainRectangleAreaDefinition(string byline, bool connectDiagonals = false)
+	{
+		return new XElement("Template",
+			new XAttribute("connect_diagonals", connectDiagonals),
+			new XElement("ShowCommandByLine", new XCData(byline))
+		);
+	}
+
+	private static XElement CreateTerrainFeatureRectangleAreaDefinition(string byline, bool connectDiagonals = false)
+	{
+		return CreateTerrainRectangleAreaDefinition(byline, connectDiagonals);
+	}
+
+	private static XElement CreateRandomFeaturesAreaDefinition(string byline, IEnumerable<XElement> groups,
+		bool connectDiagonals = false)
+	{
+		XElement template = CreateTerrainRectangleAreaDefinition(byline, connectDiagonals);
+		template.Add(new XElement("Groups", groups));
+		return template;
+	}
+
+	private static XElement CreateRandomDescriptionElement(string text, string roomNameText = "{0}",
+		double weight = 100.0, IEnumerable<Terrain>? terrains = null, IEnumerable<string>? tags = null,
+		bool mandatoryIfValid = false, int mandatoryPosition = 100000)
+	{
+		return new XElement("Description",
+			new XAttribute("mandatory", mandatoryIfValid),
+			new XAttribute("fixedposition", mandatoryPosition),
+			new XElement("Text", new XCData(text)),
+			new XElement("RoomNameText", new XCData(roomNameText)),
+			new XElement("Weight", weight),
+			new XElement("Tags", tags?.ListToCommaSeparatedValues() ?? string.Empty),
+			new XElement("Terrains",
+				from terrain in terrains ?? Enumerable.Empty<Terrain>()
+				select new XElement("Terrain", terrain.Id)
+			)
+		);
+	}
+
+	private static XElement CreateRoadRandomDescriptionElement(string text, string triggerTag,
+		string roomNameText = "{0}", double weight = 100.0, IEnumerable<Terrain>? terrains = null,
+		IEnumerable<string>? additionalTags = null, bool mandatoryIfValid = false, int mandatoryPosition = 100000)
+	{
+		return new XElement("Description",
+			new XAttribute("type", "road"),
+			new XAttribute("mandatory", mandatoryIfValid),
+			new XAttribute("fixedposition", mandatoryPosition),
+			new XElement("Text", new XCData(text)),
+			new XElement("RoomNameText", new XCData(roomNameText)),
+			new XElement("Weight", weight),
+			new XElement("Tags",
+				(new[] { triggerTag }).Concat(additionalTags ?? Enumerable.Empty<string>())
+				.ListToCommaSeparatedValues()),
+			new XElement("Terrains",
+				from terrain in terrains ?? Enumerable.Empty<Terrain>()
+				select new XElement("Terrain", terrain.Id)
+			)
+		);
+	}
+
+	private static XElement CreateRandomDescriptionGroupElement(IEnumerable<XElement> subElements, double weight = 100.0,
+		bool mandatoryIfValid = false, int mandatoryPosition = 100000)
+	{
+		return new XElement("Description",
+			new XAttribute("type", "group"),
+			new XAttribute("mandatory", mandatoryIfValid),
+			new XAttribute("fixedposition", mandatoryPosition),
+			new XElement("Weight", weight),
+			subElements
+		);
+	}
+
+	private static XElement CreateSimpleFeatureGroupElement(double minimumFeatureDensity, double maximumFeatureDensity,
+		int maximumFeaturesPerRoom, IEnumerable<XElement> features)
+	{
+		return new XElement("Group",
+			new XAttribute("type", "simple"),
+			new XElement("MinimumFeatureDensity", minimumFeatureDensity),
+			new XElement("MaximumFeatureDensity", maximumFeatureDensity),
+			new XElement("MaximumFeaturesPerRoom", maximumFeaturesPerRoom),
+			new XElement("Features", features)
+		);
+	}
+
+	private static XElement CreateUniformFeatureGroupElement(int numberOfFeaturesPerRoom, IEnumerable<XElement> features)
+	{
+		return new XElement("Group",
+			new XAttribute("type", "uniform"),
+			new XElement("NumberOfFeaturesPerRoom", numberOfFeaturesPerRoom),
+			new XElement("Features", features)
+		);
+	}
+
+	private static XElement CreateRoadFeatureGroupElement(string baseFeature, string straightRoadFeature,
+		string crossRoadsFeature, string teeIntersectionFeature, string isolatedRoadFeature,
+		string bendInTheRoadFeature, string endOfTheRoadFeature, IEnumerable<Terrain> terrains)
+	{
+		return new XElement("Group",
+			new XAttribute("type", "road"),
+			new XElement("BaseFeature", new XCData(baseFeature)),
+			new XElement("StraightRoadFeature", new XCData(straightRoadFeature)),
+			new XElement("CrossRoadsFeature", new XCData(crossRoadsFeature)),
+			new XElement("TeeIntersectionFeature", new XCData(teeIntersectionFeature)),
+			new XElement("IsolatedRoadFeature", new XCData(isolatedRoadFeature)),
+			new XElement("BendInTheRoadFeature", new XCData(bendInTheRoadFeature)),
+			new XElement("EndOfTheRoadFeature", new XCData(endOfTheRoadFeature)),
+			new XElement("Terrains",
+				from terrain in terrains
+				select new XElement("Terrain", terrain.Id)
+			)
+		);
+	}
+
+	private static XElement CreateFeatureElement(string name, double weighting = 100.0, int minimumCount = 0,
+		int maximumCount = 1, IEnumerable<Terrain>? terrains = null)
+	{
+		return new XElement("Feature",
+			new XAttribute("type", "none"),
+			new XElement("Name", new XCData(name)),
+			new XElement("Weighting", weighting),
+			new XElement("MinimumCount", minimumCount),
+			new XElement("MaximumCount", maximumCount),
+			new XElement("Terrains",
+				from terrain in terrains ?? Enumerable.Empty<Terrain>()
+				select new XElement("Terrain", terrain.Id)
+			)
+		);
+	}
+
+	private static XElement CreateAdjacentFeatureElement(string name, string adjacentFeatureTag, bool ignoreExits = false,
+		double weighting = 100.0, int minimumCount = 0, int maximumCount = 1, IEnumerable<Terrain>? terrains = null,
+		IReadOnlyDictionary<CardinalDirection, string>? directionAdjacencyTags = null)
+	{
+		return new XElement("Feature",
+			new XAttribute("type", "adjacent"),
+			new XElement("Name", new XCData(name)),
+			new XElement("Weighting", weighting),
+			new XElement("MinimumCount", minimumCount),
+			new XElement("MaximumCount", maximumCount),
+			new XElement("Terrains",
+				from terrain in terrains ?? Enumerable.Empty<Terrain>()
+				select new XElement("Terrain", terrain.Id)
+			),
+			new XElement("IgnoreExits", ignoreExits),
+			new XElement("AdjacentFeatureTag", new XCData(adjacentFeatureTag)),
+			new XElement("Adjacents",
+				from tag in directionAdjacencyTags ?? new Dictionary<CardinalDirection, string>()
+				select new XElement("Adjacent",
+					new XAttribute("direction", (int)tag.Key),
+					new XCData(tag.Value))
+			)
+		);
+	}
+
+	private static double GetDefaultAmbientLightFactor(CellOutdoorsType outdoorsType)
+	{
+		return outdoorsType switch
+		{
+			CellOutdoorsType.Indoors => 0.25,
+			CellOutdoorsType.IndoorsWithWindows => 0.35,
+			CellOutdoorsType.Outdoors => 1.0,
+			CellOutdoorsType.IndoorsNoLight => 0.0,
+			CellOutdoorsType.IndoorsClimateExposed => 0.9,
+			_ => 1.0
+		};
+	}
+
+	private sealed record AutobuilderRoomTemplateSeedDefinition(string Name, string TemplateType, XElement Definition);
+
+	private sealed record AutobuilderAreaTemplateSeedDefinition(string Name, string TemplateType, XElement Definition);
+}

--- a/DatabaseSeeder/Seeders/UsefulSeeder.cs
+++ b/DatabaseSeeder/Seeders/UsefulSeeder.cs
@@ -129,8 +129,9 @@ public partial class UsefulSeeder : IDatabaseSeeder
                     if (answer.EqualToAny("yes", "y", "no", "n")) { return (true, string.Empty); } return (false, "Invalid answer");
                 }),
             ("autobuilder",
-                "Do you want to install an auto builder that can generate random areas with randomised room descriptions?\n\nPlease answer #3yes#f or #3no#f: ",
-                (context, questions) => false,
+                "Do you want to install a starter autobuilder package for the stock terrain catalogue? This adds terrain-aware room templates with preset baseline and random descriptions so builders can immediately generate rooms that match the seeded terrains, especially when paired with the core area-shape templates and Terrain Planner.\n\nPlease answer #3yes#f or #3no#f: ",
+                (context, questions) => context.Terrains.Count() > 1 &&
+                                        ClassifyAutobuilderPackagePresence(context) != ShouldSeedResult.MayAlreadyBeInstalled,
                 (answer, context) =>
                 {
                     if (answer.EqualToAny("yes", "y", "no", "n")) { return (true, string.Empty); } return (false, "Invalid answer");
@@ -236,14 +237,23 @@ public partial class UsefulSeeder : IDatabaseSeeder
             return ShouldSeedResult.PrerequisitesNotMet;
         }
 
-        return CombinePackageStates(
+        List<ShouldSeedResult> packageStates =
+        [
             ClassifyAiPackagePresence(context),
             SeederRepeatabilityHelper.ClassifyByPresence(
                 StockItemMarkers.Select(marker => context.GameItemComponentProtos.Any(x => x.Name == marker))),
             ClassifyModernPackagePresence(context),
             context.Tags.Any(x => x.Name == "Functions")
                 ? ShouldSeedResult.MayAlreadyBeInstalled
-                : ShouldSeedResult.ReadyToInstall);
+                : ShouldSeedResult.ReadyToInstall
+        ];
+
+        if (context.Terrains.Count() > 1)
+        {
+            packageStates.Add(ClassifyAutobuilderPackagePresence(context));
+        }
+
+        return CombinePackageStates(packageStates.ToArray());
     }
 
     public int SortOrder => 200;
@@ -350,7 +360,7 @@ Inside the package there are a few numbered #D""Core Item Packages""#3. The reas
     private void SeedTerrainAutobuilder(FuturemudDatabaseContext context,
             IReadOnlyDictionary<string, string> questionAnswers, ICollection<string> errors)
     {
-
+        SeedTerrainAutobuilderCore(context, errors);
     }
 
     private void SeedRangedCovers(FuturemudDatabaseContext context, ICollection<string> errors)

--- a/Design Documents/Autobuilder_Builder_How_To.md
+++ b/Design Documents/Autobuilder_Builder_How_To.md
@@ -1,0 +1,188 @@
+# Autobuilder Builder How-To
+
+## What The Seeders Give You
+
+There are now two different stock autobuilder layers:
+
+- Core seeding gives you shape templates such as `Rectangle`, `Terrain Rectangle`, and `Feature Rectangle`.
+- Useful seeding gives you terrain-aware room templates such as `Seeded Terrain Baseline` and `Seeded Terrain Random Description`.
+
+The intended pairing is:
+
+- core area template for topology
+- useful room template for immediate terrain-matched description text
+
+## Basic Workflow
+
+### 1. Open a cell package
+
+Autobuilders work inside cell overlay packages.
+
+- `cell package new "My New Area"`
+- `cell package open <id|name>`
+
+If you do not have a package open, `cell new <template> ...` will not be useful.
+
+### 2. Inspect the available templates
+
+Use the show commands first:
+
+- `show autoareas`
+- `show autoarea <id|name>`
+- `show autorooms`
+- `show autoroom <id|name>`
+
+Use the edit commands only when you are authoring or customising templates:
+
+- `autoarea list`
+- `autoarea show <id|name>`
+- `autoarea edit <id|name>`
+- `autoroom list`
+- `autoroom show <id|name>`
+- `autoroom edit <id|name>`
+
+## Quick Start With Terrain Planner
+
+### 1. Load terrains into the planner
+
+You have two normal options:
+
+- Clipboard import: copy JSON terrain data and use the clipboard import button.
+- API import: put the endpoint URL into `apiaddress.config` and use the API import button.
+
+The planner reads terrain editor metadata, so the imported terrain list matches the terrain catalogue seeded into the game.
+
+### 2. Paint the map
+
+- Set grid width and height.
+- Use paint or fill mode.
+- Leave any unused positions as `None` if you want holes in the shape.
+
+### 3. Export the mask
+
+The export button copies a comma-separated terrain mask to the clipboard.
+
+Important rules:
+
+- The mask is row-major: top-left across the row, then next row down.
+- `0` means no room should be created at that coordinate.
+- The number of entries must exactly match `height x width`.
+
+## Building An Area
+
+The main command is:
+
+```text
+cell new <area template> ...
+```
+
+For terrain-aware rectangles, the usual shape is:
+
+```text
+cell new "Terrain Rectangle" <height> <width> <room template> <terrain mask>
+```
+
+Example:
+
+```text
+cell new "Terrain Rectangle" 5 7 "Seeded Terrain Random Description" 12,12,12,15,15,15,15,12,12,12,15,15,15,15,0,0,12,12,12,15,15,0,0,12,12,12,15,15,18,18,18,12,12,12,15,18
+```
+
+That will:
+
+- create the cells
+- assign each cell the painted terrain
+- link orthogonal exits
+- ask the room template to generate names and descriptions
+
+If you want diagonal exits too, use the diagonals variant.
+
+## Choosing The Right Pairing
+
+### Fast terrain bootstrap
+
+Use:
+
+- area template: `Terrain Rectangle`
+- room template: `Seeded Terrain Baseline`
+
+This gives predictable terrain-specific names and descriptions with no manual prose required.
+
+### Fast terrain bootstrap with variation
+
+Use:
+
+- area template: `Terrain Rectangle`
+- room template: `Seeded Terrain Random Description`
+
+This is the best default when you want generated rooms to feel less repetitive from the start.
+
+### Manual feature-tag control
+
+Use:
+
+- area template: `Feature Rectangle`
+- room template: `Seeded Terrain Random Description` or a custom random room template
+
+`Feature Rectangle` takes an extra feature mask argument after the terrain mask. Each cell's features are separated with `|`, and cells are still separated with commas.
+
+That lets you drive extra descriptive tags into the room template deliberately.
+
+## Editing Room Templates
+
+`autoroom` is the authoring surface for room templates.
+
+Useful commands:
+
+- `autoroom edit new <name> <type>`
+- `autoroom clone <old> <new>`
+- `autoroom edit <which>`
+- `autoroom set summary <text>`
+- `autoroom set applytags`
+
+For `room by terrain` templates, the most useful edits are:
+
+- default room name
+- default description
+- default terrain
+- default light multiplier
+- outdoors/indoors/cave/shelter mode
+- per-terrain overrides
+
+For `room random description` templates, add these:
+
+- random sentence count expression
+- random description elements
+- grouped elements
+- road-aware elements
+
+## Editing Area Templates
+
+`autoarea` is the authoring surface for area templates.
+
+Useful commands:
+
+- `autoarea edit new <name> <type>`
+- `autoarea clone <old> <new>`
+- `autoarea edit <which>`
+- `autoarea set summary <text>`
+
+Common subtype-specific edits include:
+
+- toggling diagonals on rectangle-based templates
+- adding and editing feature groups on random-feature templates
+
+## Good Practical Defaults
+
+- Start with core stock area templates. They are stable and simple.
+- Start with the Useful seeded room templates if you want immediate usable prose.
+- Clone the stock templates before making game-specific heavy edits.
+- Keep the Useful templates as a fallback reference, even if you later write more tailored ones.
+
+## Common Mistakes
+
+- Forgetting to open a cell package before building.
+- Supplying a mask with the wrong number of entries.
+- Forgetting that `0` in a terrain mask means no room at that coordinate.
+- Expecting feature-based variation from a room template when the chosen area template does not provide any tags.
+- Editing the core shape templates when you really wanted to customise only the descriptive room template.

--- a/Design Documents/Autobuilder_Seeder_Implementation_Guide.md
+++ b/Design Documents/Autobuilder_Seeder_Implementation_Guide.md
@@ -1,0 +1,149 @@
+# Autobuilder Seeder Implementation Guide
+
+## Intent
+
+The autobuilder seeding strategy now has a clear split:
+
+- `CoreDataSeeder` owns structural starter templates.
+- `UsefulSeeder` owns terrain-aware starter room templates that produce immediately usable descriptions.
+
+This guide covers the Useful side only.
+
+## File Layout
+
+The Useful autobuilder architecture lives in:
+
+- `DatabaseSeeder/Seeders/UsefulSeeder.cs`
+- `DatabaseSeeder/Seeders/UsefulSeeder.Autobuilder.cs`
+
+`UsefulSeeder.cs` handles package exposure and installer flow.
+
+`UsefulSeeder.Autobuilder.cs` handles:
+
+- stock template names
+- package classification
+- terrain-tag lookup
+- stock template generation
+- repeatable ensure/update logic
+- reusable XML helper builders for future autobuilder seeding
+
+## Seeding Flow
+
+The installed flow is:
+
+1. `SeederQuestions` exposes the `autobuilder` question only when terrains exist and the package is not fully installed.
+2. `ShouldSeedData(...)` includes autobuilder package state only when the terrain catalogue exists.
+3. `SeedTerrainAutobuilder(...)` delegates to `SeedTerrainAutobuilderCore(...)`.
+4. `SeedTerrainAutobuilderCore(...)`:
+   - excludes the placeholder `Void` terrain
+   - builds terrain tag lookup data
+   - generates stock room template definitions
+   - upserts them by name
+
+This keeps the package rerunnable and safe for partial installs.
+
+## Stock Content Policy
+
+Useful autobuilder seeding is deliberately scoped to room templates.
+
+Current stock templates:
+
+- `Seeded Terrain Baseline`
+- `Seeded Terrain Random Description`
+
+Do not use UsefulSeeder to duplicate the core geometry templates unless the product direction changes intentionally. The current design assumes builders will pair Useful room templates with the shape templates already provided by `CoreDataSeeder`.
+
+## Helper Layers
+
+### Catalogue-level helpers
+
+- `BuildTerrainTagLookup(...)`
+- `GetTerrainsByTag(...)`
+- `IsOutdoorsTerrain(...)`
+- `BuildSeededTerrainBaseDescription(...)`
+
+These convert the terrain catalogue into authoring-friendly categories without hard-coding terrain IDs.
+
+### Template assembly helpers
+
+- `BuildStockAutobuilderRoomTemplates(...)`
+- `BuildStockRandomDescriptionElements(...)`
+
+These functions decide what the stock package actually contains.
+
+### XML utility helpers
+
+These are reusable building blocks for future seeding:
+
+- room info XML
+- `room by terrain` template XML
+- `room random description` template XML
+- simple, road, and group description elements
+- area-template XML
+- feature group XML
+- feature XML
+
+Even though UsefulSeeder currently seeds only room templates, the extra helpers are there so future stock content can be added in a consistent style instead of hand-writing XML strings inline.
+
+## Repeatability Rules
+
+Useful autobuilder seeding must stay idempotent.
+
+Required behaviours:
+
+- rerunning must not duplicate templates
+- rerunning must repair missing templates
+- rerunning must refresh malformed or stale definitions for stock templates
+
+That is why the code uses `SeederRepeatabilityHelper.EnsureNamedEntity(...)` and rewrites the stock definition each run.
+
+## Adding A New Stock Room Template
+
+Use this checklist:
+
+1. Add the template name to `StockAutobuilderRoomTemplateNames`.
+2. Add a new definition in `BuildStockAutobuilderRoomTemplates(...)`.
+3. Prefer building the XML through the helper functions rather than embedding raw XML text.
+4. Derive terrain applicability from seeded terrain tags or terrain behaviour, not from fragile hard-coded IDs.
+5. Add a repeatability test covering install and rerun behaviour.
+
+## Working With Random Description Templates
+
+The main things to preserve are:
+
+- one default room-info block
+- per-terrain overrides
+- a valid random element expression for the default block
+- a valid random element expression for each terrain override
+- at least one description element
+
+One subtle rule matters here: terrain overrides in the random-description template still need a `NumberOfRandomElements` node. If you omit it, runtime fallback becomes `1`, which can silently change the intended behaviour.
+
+## Area Helpers And Future Expansion
+
+`UsefulSeeder.Autobuilder.cs` already includes helpers for:
+
+- terrain rectangle definitions
+- random feature rectangle definitions
+- simple/uniform/road feature groups
+- standard and adjacent features
+
+These exist so future stock autobuilder packages can be added without inventing new XML conventions. For now, they are intentionally not used to seed default Useful area templates.
+
+## Tests To Keep
+
+The unit-test coverage for autobuilder seeding should always include:
+
+- none / partial / full package classification
+- installer question visibility
+- successful seed through the public seeder entry point
+- rerun repair without duplication
+
+When adding new stock templates, update the stock-name assertions and verify the generated XML structure that matters for runtime.
+
+## Practical Guidance For Future Contributors
+
+- Treat `Void` as infrastructure, not player-facing terrain content.
+- Prefer tag-driven descriptive buckets such as `Urban`, `Aquatic`, `Arid`, or `Lunar`.
+- Keep UsefulSeeder focused on starter content that works immediately after install.
+- Push game-specific or highly opinionated prose into cloned templates or downstream game seeders instead of broadening the stock Useful package too far.

--- a/Design Documents/Autobuilder_System_Implementation.md
+++ b/Design Documents/Autobuilder_System_Implementation.md
@@ -1,0 +1,220 @@
+# Autobuilder System Implementation
+
+## Purpose
+
+The autobuilder subsystem exists to let builders generate cells in bulk without hand-linking and hand-describing every location. It is intentionally split into two cooperating models:
+
+- Area templates decide topology: how many cells to create, which cells exist, how exits are linked, and what arguments the builder must supply.
+- Room templates decide presentation: terrain, cell name, description text, light, outdoors behaviour, forage profile, and any description randomisation.
+
+This split is the key design choice to preserve when extending the subsystem.
+
+## Core Contracts
+
+### `IAutobuilderArea`
+
+Area templates are the orchestration layer.
+
+- `Parameters` exposes the ordered argument contract for builders.
+- `TryArguments(...)` validates raw builder input and returns typed arguments.
+- `ExecuteTemplate(...)` creates cells and exits from those arguments.
+- `ShowCommandByLine` is the short summary shown in builder listings.
+- `Clone(...)` creates a persistent copy with its own database row.
+
+`AutobuilderAreaBase` supplies the shared persistence, rename/summary editing, and parameter parsing pipeline.
+
+### `IAutobuilderRoom`
+
+Room templates are the cell materialisation layer.
+
+- `CreateRoom(...)` creates a new cell for a supplied terrain.
+- `RedescribeRoom(...)` updates an already-created cell, typically after area tags/features are known.
+- `ShowCommandByline` is the short summary shown in room-template listings.
+- `Clone(...)` creates a persistent copy with its own database row.
+
+`AutobuilderRoomBase` owns shared save logic and the `ApplyAutobuilderTagsAsFrameworkTags` toggle. When enabled, any autobuilder tag that matches a framework tag name is applied directly to the created cell.
+
+### `IAutobuilderParameter`
+
+Parameters are deliberately simple and ordered.
+
+- They describe one slot in the builder argument list.
+- Validation can inspect already-parsed earlier arguments.
+- This is how terrain masks, feature masks, room-template references, and numeric dimensions are all unified behind the same pipeline.
+
+## Persistence Model
+
+Autobuilders are persisted as data, not code configuration.
+
+- `AutobuilderAreaTemplate` stores `Id`, `Name`, `TemplateType`, and XML `Definition`.
+- `AutobuilderRoomTemplate` stores `Id`, `Name`, `TemplateType`, and XML `Definition`.
+
+The runtime contract is:
+
+1. `TemplateType` selects the concrete loader.
+2. `Definition` is parsed by that loader.
+3. Edits round-trip back into XML via `SaveToXml()`.
+
+There is no schema-version layer in front of these XML definitions, so backward compatibility depends on loaders remaining tolerant of missing elements and sensible defaults.
+
+## Loader Architecture
+
+`AutobuilderFactory` is the registry and dispatch point.
+
+- Concrete template classes expose a static `RegisterAutobuilderLoader()` method.
+- `AutobuilderFactory.InitialiseAutobuilders()` scans the assembly with reflection and invokes those registration methods.
+- Loaders are registered twice:
+  - persisted load by `TemplateType`
+  - builder creation by the short type keyword used in `autoarea edit new ...` or `autoroom edit new ...`
+
+This means any new autobuilder type needs four things:
+
+1. a concrete class
+2. XML load/save support
+3. static registration
+4. a stable `TemplateType` string
+
+## Built-In Template Families
+
+### Room templates
+
+- `simple`: one fixed name/description pair
+- `room by terrain`: deterministic per-terrain overrides
+- `room random description`: per-terrain defaults plus weighted description elements
+
+### Area templates
+
+- `rectangle`
+- `rectangle diagonals`
+- `terrain rectangle`
+- `terrain feature rectangle`
+- `room by terrain random features`
+- `cylinder`
+
+The important distinction is that only the area side knows about masks and exit linking. Only the room side knows about description composition.
+
+## Runtime Flow
+
+The normal execution path is:
+
+1. Builder opens a cell overlay package.
+2. Builder runs `cell new <autoarea> ...`.
+3. The chosen `IAutobuilderArea` parses its ordered parameters.
+4. The area template creates cells, linking exits as it goes.
+5. The area template calls the selected `IAutobuilderRoom` for each created cell.
+6. Some area templates gather feature tags first and call `RedescribeRoom(...)` afterwards so descriptions can react to those tags.
+7. Optional `prog=<prog>` arguments can run post-processing against the generated result set.
+
+This is why area templates should stay focused on structure and room templates on presentation.
+
+## Random Description Pipeline
+
+`AutobuilderRoomRandomDescription` is the descriptive workhorse.
+
+It combines:
+
+- a default `AutobuilderRoomInfo`
+- optional per-terrain `AutobuilderRoomInfo` overrides
+- an expression for how many random elements to pick
+- a weighted list of `IAutobuilderRandomDescriptionElement`
+- an optional fixed sentence appended to all results
+
+Element types currently supported:
+
+- simple description elements
+- road-aware description elements
+- grouped weighted elements
+
+Elements can be:
+
+- terrain-limited
+- tag-limited
+- mandatory if valid
+- fixed to a sentence position
+- weighted relative to siblings
+
+Road elements are special because they interpret one tag as `tag=directions` and expand `$directions`, `$thedirections`, and `$dashdirections` tokens.
+
+## Feature Propagation
+
+There are two different feature/tag paths:
+
+- `terrain feature rectangle` takes an explicit feature mask from the builder.
+- `room by terrain random features` generates features internally through feature groups.
+
+Feature groups currently include:
+
+- simple density-based feature groups
+- uniform per-room feature groups
+- road feature groups
+
+Those features become string tags passed into the room template. If `ApplyAutobuilderTagsAsFrameworkTags` is on, matching framework tags are also written to the cells themselves.
+
+## Seeder Split: Core vs Useful
+
+The seeder intentionally divides responsibilities.
+
+### `CoreDataSeeder`
+
+Core seeding installs the structural baseline:
+
+- `Blank` room template
+- stock area-shape templates such as `Rectangle`, `Terrain Rectangle`, and `Feature Rectangle`
+
+These are about geometry and workflow, not rich stock prose.
+
+### `UsefulSeeder`
+
+Useful seeding now owns the descriptive bootstrap package:
+
+- `Seeded Terrain Baseline`
+- `Seeded Terrain Random Description`
+
+These templates are built from the seeded terrain catalogue and are meant to be usable immediately with the core area templates and the Terrain Planner.
+
+That split matches the intended product model:
+
+- Core package: shape first, manual description later
+- Useful package: ready-to-use terrain-matched starter prose
+
+## Terrain Planner Role
+
+`Terrain Planner Core` is a WPF tool that produces the terrain mask expected by terrain-aware area templates.
+
+- It targets `net10.0-windows7.0`.
+- It paints a grid using terrain colour/text metadata.
+- It exports a row-major comma-separated mask.
+- `0` means no cell at that position.
+
+Terrain data can be imported from:
+
+- clipboard JSON
+- a simple HTTP endpoint, typically the `Terrain API` project's `/Terrain` route
+
+The planner only needs these terrain fields:
+
+- `Id`
+- `Name`
+- `TerrainEditorColour`
+- `TerrainEditorText`
+
+The mask format must match the order expected by `AutobuilderAreaTerrainRectangle`: top-left to right, then row by row downward.
+
+## Extension Guidance
+
+When adding a new autobuilder type:
+
+1. Decide whether it is structural or descriptive. Start from area vs room responsibility, not from convenience.
+2. Reuse `AutobuilderAreaBase` or `AutobuilderRoomBase`.
+3. Keep XML tolerant of missing nodes.
+4. Register a stable loader keyword and template type.
+5. Add or update seeder support only if the type should be part of stock content.
+6. Add repeatability coverage if seeding is involved.
+7. Update the autobuilder design and builder docs in the same change.
+
+## Current Constraints
+
+- XML definitions are versionless and must stay backwards-compatible.
+- Terrain Planner creates terrain masks only; feature masks are still textual/manual unless a custom tool is added.
+- Tag-driven description variation only matters when the chosen area template actually supplies tags.
+- The seeded Useful autobuilder package currently focuses on room templates, not additional stock area templates.

--- a/MudSharpCore/Commands/Modules/RoomBuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/RoomBuilderModule.cs
@@ -4619,7 +4619,7 @@ The syntax for working with areas is as follows:
 The core syntax is as follows:
 
 	#3autoroom list#0 - shows all room templates
-	#3autoroom edit new <name> <school>#0 - creates a new room template
+	#3autoroom edit new <name> <type>#0 - creates a new room template
 	#3autoroom clone <old> <new>#0 - clones an existing room template
 	#3autoroom edit <which>#0 - begins editing a room template
 	#3autoroom close#0 - closes an editing room template
@@ -4643,11 +4643,11 @@ The core syntax is as follows:
 The core syntax is as follows:
 
 	#3autoarea list#0 - shows all area templates
-	#3autoarea edit new <name> <school>#0 - creates a new area template
+	#3autoarea edit new <name> <type>#0 - creates a new area template
 	#3autoarea clone <old> <new>#0 - clones an existing area template
 	#3autoarea edit <which>#0 - begins editing an area template
 	#3autoarea close#0 - closes an editing area template
-	#3autoarea show#0 <which> - shows builder information about a area
+	#3autoarea show <which>#0 - shows builder information about an area
 	#3autoarea show#0 - shows builder information about the currently edited area
 	#3autoarea edit#0 - an alias for area template show (with no args)
 	#3autoarea set <...>#0 - edits the properties of an area template";

--- a/MudSharpCore/Construction/Autobuilder/Areas/AutobuilderAreaTerrainRectangleRandomFeatures.cs
+++ b/MudSharpCore/Construction/Autobuilder/Areas/AutobuilderAreaTerrainRectangleRandomFeatures.cs
@@ -223,12 +223,17 @@ public class AutobuilderAreaTerrainRectangleRandomFeatures : AutobuilderAreaTerr
         builder.OutputHandler.Send($"Applied {count.ToString("N0", builder).ColourValue()} features in total.");
 #endif
 
-        builder.OutputHandler.PrioritySend("Describing the cells...");
-        foreach (ICell cell in cells)
-        {
-            (x, y) = lookup[cell];
-            roomTemplate.RedescribeRoom(cell, features[x, y].ToArray());
-        }
+		builder.OutputHandler.PrioritySend("Describing the cells...");
+		foreach (ICell cell in cells)
+		{
+			if (cell == null)
+			{
+				continue;
+			}
+
+			(x, y) = lookup[cell];
+			roomTemplate.RedescribeRoom(cell, features[x, y].ToArray());
+		}
 
         return cells.OfType<ICell>().ToList();
     }
@@ -302,8 +307,14 @@ public class AutobuilderAreaTerrainRectangleRandomFeatures : AutobuilderAreaTerr
             return true;
         }
 
-        return group.BuildingCommand(actor, this, command);
-    }
+		if (group.BuildingCommand(actor, this, command))
+		{
+			Changed = true;
+			return true;
+		}
+
+		return false;
+	}
 
     private bool BuildingCommandGroupRemove(ICharacter actor, StringStack command)
     {

--- a/MudSharpCore/Construction/Autobuilder/Areas/Features/Feature.cs
+++ b/MudSharpCore/Construction/Autobuilder/Areas/Features/Feature.cs
@@ -221,11 +221,11 @@ public class Feature
             return false;
         }
 
-        Weighting = value;
-        actor.OutputHandler.Send(
-            $"This feature now has a relative weight of {Weighting.ToString("N3", actor).ColourValue()}, which gives it a {(Weighting / parent.Features.Sum(x => x.Weighting)).ToString("P2", actor).ColourValue()} chance to be selected.");
-        throw new NotImplementedException();
-    }
+		Weighting = value;
+		actor.OutputHandler.Send(
+			$"This feature now has a relative weight of {Weighting.ToString("N3", actor).ColourValue()}, which gives it a {(Weighting / parent.Features.Sum(x => x.Weighting)).ToString("P2", actor).ColourValue()} chance to be selected.");
+		return true;
+	}
 
     private bool BuildingCommandName(ICharacter actor, TerrainFeatureGroup parent, StringStack command)
     {

--- a/MudSharpCore/Construction/Autobuilder/Areas/Features/RoadFeatureGroup.cs
+++ b/MudSharpCore/Construction/Autobuilder/Areas/Features/RoadFeatureGroup.cs
@@ -97,14 +97,24 @@ public class RoadFeatureGroup : TerrainFeatureGroup
         int width = cellMap.GetLength(0);
         int height = cellMap.GetLength(1);
 
-        for (int x = 0; x < width; x++)
-        {
-            for (int y = 0; y < height; y++)
-            {
-                ICell cell = cellMap[x, y];
-                List<CardinalDirection> list = new();
-                int count = cellMap.ApplyFunctionToAdjacentsReturnCountWithDirection(x, y, (adj, dir) =>
-                {
+		for (int x = 0; x < width; x++)
+		{
+			for (int y = 0; y < height; y++)
+			{
+				ICell cell = cellMap[x, y];
+				if (cell == null)
+				{
+					continue;
+				}
+
+				if (Terrains.Any() && !Terrains.Contains(cell.Terrain(null)))
+				{
+					continue;
+				}
+
+				List<CardinalDirection> list = new();
+				int count = cellMap.ApplyFunctionToAdjacentsReturnCountWithDirection(x, y, (adj, dir) =>
+				{
                     if (adj == null)
                     {
                         return false;
@@ -217,7 +227,7 @@ public class RoadFeatureGroup : TerrainFeatureGroup
                 return BuildingCommandTerrains(actor, command);
         }
 
-        actor.OutputHandler.Send(@"You can use the following options with this command:
+		actor.OutputHandler.Send(@"You can use the following options with this command:
 
 	name <name> - renames this feature group
 	base <tag> - sets the base tag that applies to all matched rooms
@@ -227,9 +237,9 @@ public class RoadFeatureGroup : TerrainFeatureGroup
 	bend <tag> - the tag that applies when there are 2 adjacent matching rooms not in a straight line
 	tee <tag> - the tag that applies when there are 3 adjacent matching rooms
 	crossroads <tag> - the tag that applies when there are 4+ adjacent matching rooms
-	terrain <terrains...> - toggles a list of terrain for this group to apply to+");
-        return false;
-    }
+	terrain <terrains...> - toggles a list of terrain for this group to apply to");
+		return false;
+	}
 
     private bool BuildingCommandCrossroads(ICharacter actor, StringStack command)
     {

--- a/MudSharpCore/Construction/Autobuilder/Areas/Features/SimpleFeatureGroup.cs
+++ b/MudSharpCore/Construction/Autobuilder/Areas/Features/SimpleFeatureGroup.cs
@@ -76,12 +76,13 @@ public class SimpleFeatureGroup : TerrainFeatureGroup
 
     public IEnumerable<ITerrain> Terrains => Features.SelectMany(x => x.Terrains).Distinct();
 
-    protected bool AppliesToCell(ICell cell)
-    {
-        return
-            Features.Any() &&
-            (!Terrains.Any() || Terrains.Contains(cell.CurrentOverlay?.Terrain));
-    }
+	protected bool AppliesToCell(ICell cell)
+	{
+		return
+			cell != null &&
+			Features.Any() &&
+			(!Terrains.Any() || Terrains.Contains(cell.CurrentOverlay?.Terrain));
+	}
 
     public override void ApplyTerrainFeatures(ICell[,] cellMap, List<string>[,] featureMap)
     {
@@ -89,8 +90,8 @@ public class SimpleFeatureGroup : TerrainFeatureGroup
         int height = cellMap.GetLength(1);
         List<ICell> cells = cellMap.Cast<ICell>().WhereNotNull(x => x).Where(AppliesToCell).ToList();
 
-        int howMany = (int)Math.Round(RandomUtilities.DoubleRandom(MinimumFeatureDensity, MaximumFeatureDensity) *
-                                      height * width);
+		int howMany = (int)Math.Round(RandomUtilities.DoubleRandom(MinimumFeatureDensity, MaximumFeatureDensity) *
+		                              cells.Count);
         Counter<string> counter = new(StringComparer.InvariantCultureIgnoreCase);
         Counter<ICell> groupCounter = new();
         List<Feature> featuresInConsideration = Features.ToList();
@@ -112,12 +113,15 @@ public class SimpleFeatureGroup : TerrainFeatureGroup
                 }
             }
 
-            List<ICell> validCells = cells.Where(x => feature.CanApply(x)).ToList();
-            if (!validCells.Any(x => groupCounter.Count(x) < MaximumFeaturesPerRoom))
-            {
-                featuresInConsideration.Remove(feature);
-                continue;
-            }
+			List<ICell> validCells = cells
+				.Where(x => feature.CanApply(x))
+				.Where(x => groupCounter.Count(x) < MaximumFeaturesPerRoom)
+				.ToList();
+			if (!validCells.Any())
+			{
+				featuresInConsideration.Remove(feature);
+				continue;
+			}
 
             ICell cell = validCells.GetRandomElement();
             (int X, int Y) = cellMap.GetCoordsOfElement(cell);
@@ -137,11 +141,14 @@ public class SimpleFeatureGroup : TerrainFeatureGroup
             int target = feature.MinimumCount - counter.Count(feature.Name);
             while (target > 0)
             {
-                List<ICell> validCells = cells.Where(x => feature.CanApply(x)).ToList();
-                if (!validCells.Any(x => groupCounter.Count(x) > MaximumFeaturesPerRoom))
-                {
-                    break;
-                }
+				List<ICell> validCells = cells
+					.Where(x => feature.CanApply(x))
+					.Where(x => groupCounter.Count(x) < MaximumFeaturesPerRoom)
+					.ToList();
+				if (!validCells.Any())
+				{
+					break;
+				}
 
                 ICell cell = validCells.GetRandomElement();
                 (int X, int Y) = cellMap.GetCoordsOfElement(cell);
@@ -156,7 +163,7 @@ public class SimpleFeatureGroup : TerrainFeatureGroup
     public override string Show(ICharacter builder)
     {
         StringBuilder sb = new();
-        sb.AppendLine($"Uniform Feature Group - {Name.ColourName()}");
+		sb.AppendLine($"Simple Feature Group - {Name.ColourName()}");
         sb.AppendLine();
         sb.AppendLine(
             $"This feature group will apply a random spattering of its features across the whole area based on a range of feature densities (i.e. average number of features from this group per room)."
@@ -332,10 +339,10 @@ public class SimpleFeatureGroup : TerrainFeatureGroup
             return false;
         }
 
-        if (int.TryParse(command.SafeRemainingArgument, out int value) || value < 1)
-        {
-            actor.OutputHandler.Send("You must enter a valid number.");
-            return false;
+		if (!int.TryParse(command.SafeRemainingArgument, out int value) || value < 1)
+		{
+			actor.OutputHandler.Send("You must enter a valid number.");
+			return false;
         }
 
         MaximumFeaturesPerRoom = value;
@@ -366,10 +373,10 @@ public class SimpleFeatureGroup : TerrainFeatureGroup
             return false;
         }
 
-        if (!double.TryParse(command.PopSpeech(), out double max) || min < 0.0)
-        {
-            actor.OutputHandler.Send($"You must enter a valid number for the maximum density.");
-            return false;
+		if (!double.TryParse(command.PopSpeech(), out double max) || max < 0.0)
+		{
+			actor.OutputHandler.Send($"You must enter a valid number for the maximum density.");
+			return false;
         }
 
         if (min > max)

--- a/MudSharpCore/Construction/Autobuilder/Areas/Features/UniformFeatureGroup.cs
+++ b/MudSharpCore/Construction/Autobuilder/Areas/Features/UniformFeatureGroup.cs
@@ -61,12 +61,13 @@ public class UniformFeatureGroup : TerrainFeatureGroup
 
     public IEnumerable<ITerrain> Terrains => Features.SelectMany(x => x.Terrains).Distinct();
 
-    protected bool AppliesToCell(ICell cell)
-    {
-        return
-            Features.Any() &&
-            (!Terrains.Any() || Terrains.Contains(cell.CurrentOverlay?.Terrain));
-    }
+	protected bool AppliesToCell(ICell cell)
+	{
+		return
+			cell != null &&
+			Features.Any() &&
+			(!Terrains.Any() || Terrains.Contains(cell.CurrentOverlay?.Terrain));
+	}
 
     public override List<Feature> Features { get; } = new();
 
@@ -156,16 +157,15 @@ public class UniformFeatureGroup : TerrainFeatureGroup
                 return BuildingCommandFeature(actor, parent, command);
         }
 
-        actor.OutputHandler.Send(@"You can use the following options with this command:
+		actor.OutputHandler.Send(@"You can use the following options with this command:
 
 	name <name> - changes the name of this group
-	density <min> <max> - sets the average features per room for this group
-	max <#> - sets the maximum number of features from this group for a single room
+	count <#> - sets how many features are applied to each applicable room
 	feature <#> ... - edits properties of a feature
 	feature add simple|adjacent <name> - adds a new feature
 	feature remove <#> - removes a feature");
-        return false;
-    }
+		return false;
+	}
 
     private bool BuildingCommandFeatureCount(ICharacter actor, StringStack command)
     {

--- a/MudSharpCore/Construction/Autobuilder/Rooms/AutobuilderRoadRandomDescriptionElement.cs
+++ b/MudSharpCore/Construction/Autobuilder/Rooms/AutobuilderRoadRandomDescriptionElement.cs
@@ -33,10 +33,10 @@ public class AutobuilderRoadRandomDescriptionElement : AutobuilderRandomDescript
         }
     }
 
-    public override IAutobuilderRandomDescriptionElement Clone()
-    {
-        return new AutobuilderRoadRandomDescriptionElement(Gameworld);
-    }
+	public override IAutobuilderRandomDescriptionElement Clone()
+	{
+		return new AutobuilderRoadRandomDescriptionElement(SaveToXml(), Gameworld);
+	}
 
     #region Overrides of AutobuilderRandomDescriptionElement
 

--- a/MudSharpCore/Construction/Autobuilder/Rooms/AutobuilderRoomByTerrain.cs
+++ b/MudSharpCore/Construction/Autobuilder/Rooms/AutobuilderRoomByTerrain.cs
@@ -566,11 +566,12 @@ public class AutobuilderRoomByTerrain : AutobuilderRoomBase
                                      TerrainInfos[terrain].CellDescription.Wrap(actor.InnerLineFormatLength, "\t"));
         }
 
-        actor.OutputHandler.Send(
-            "Enter the description in the editor below. Use $terrain to substitute the terrain name.");
-        actor.EditorMode(PostDefaultTerrainDescription, CancelDefaultTerrainDescription, 1.0);
-        return true;
-    }
+		actor.OutputHandler.Send(
+			"Enter the description in the editor below. Use $terrain to substitute the terrain name.");
+		actor.EditorMode(PostDefaultTerrainDescription, CancelDefaultTerrainDescription, 1.0,
+			suppliedArguments: [terrain]);
+		return true;
+	}
 
     private void CancelDefaultTerrainDescription(IOutputHandler arg1, object[] arg2)
     {

--- a/MudSharpCore/Construction/Autobuilder/Rooms/AutobuilderRoomRandomDescription.cs
+++ b/MudSharpCore/Construction/Autobuilder/Rooms/AutobuilderRoomRandomDescription.cs
@@ -38,10 +38,10 @@ public class AutobuilderRoomRandomDescription : AutobuilderRoomBase
             TerrainInfos.Add(info.Key, (info.Value.Item1, new Expression(info.Value.Item2.OriginalExpression)));
         }
 
-        foreach (IAutobuilderRandomDescriptionElement element in RandomDescriptionElements)
-        {
-            RandomDescriptionElements.Add(element.Clone());
-        }
+		foreach (IAutobuilderRandomDescriptionElement element in rhs.RandomDescriptionElements)
+		{
+			RandomDescriptionElements.Add(element.Clone());
+		}
 
         using (new FMDB())
         {
@@ -96,27 +96,28 @@ public class AutobuilderRoomRandomDescription : AutobuilderRoomBase
     public List<IAutobuilderRandomDescriptionElement> RandomDescriptionElements { get; } = new();
     public string AddToAllRoomDescriptions { get; protected set; }
 
-    protected override void LoadFromXml(XElement root)
-    {
-        ShowCommandByline = root.Element("ShowCommandByline")?.Value ?? "A terrain-specific room without a byline.";
-        AddToAllRoomDescriptions = root.Element("AddToAllRoomDescriptions")?.Value ?? string.Empty;
+	protected override void LoadFromXml(XElement root)
+	{
+		ShowCommandByline = root.Element("ShowCommandByline")?.Value ?? "A terrain-specific room without a byline.";
+		AddToAllRoomDescriptions = root.Element("AddToAllRoomDescriptions")?.Value ?? string.Empty;
+		XElement? defaultElement = root.Element("Default");
 
-        foreach (XElement element in root.Element("Terrains").Elements("Terrain") ?? Enumerable.Empty<XElement>())
-        {
-            ITerrain terrain = Gameworld.Terrains.GetByIdOrName(element.Element("DefaultTerrain").Value);
+		foreach (XElement element in root.Element("Terrains").Elements("Terrain") ?? Enumerable.Empty<XElement>())
+		{
+			ITerrain terrain = Gameworld.Terrains.GetByIdOrName(element.Element("DefaultTerrain").Value);
             if (terrain == null)
             {
                 continue;
             }
 
             AutobuilderRoomInfo roomInfo = new(element, Gameworld);
-            TerrainInfos[terrain] =
-                (roomInfo, new Expression(element.Element("NumberOfRandomElements")?.Value ?? "1"));
-        }
+			TerrainInfos[terrain] =
+				(roomInfo, new Expression(element.Element("NumberOfRandomElements")?.Value ?? "1"));
+		}
 
-        AutobuilderRoomInfo defaultInfo = new(root, Gameworld);
-        DefaultInfo = defaultInfo;
-        NumberOfRandomElements = new Expression(root.Element("NumberOfRandomElements")?.Value ?? "1");
+		AutobuilderRoomInfo defaultInfo = new(defaultElement?.Element("Terrain") ?? root, Gameworld);
+		DefaultInfo = defaultInfo;
+		NumberOfRandomElements = new Expression(defaultElement?.Element("NumberOfRandomElements")?.Value ?? "1");
 
         foreach (XElement element in root.Element("Descriptions")?.Elements() ?? Enumerable.Empty<XElement>())
         {
@@ -128,13 +129,14 @@ public class AutobuilderRoomRandomDescription : AutobuilderRoomBase
 
     protected override XElement SaveToXml()
     {
-        XElement result = new("Template",
-            new XElement("ApplyAutobuilderTagsAsFrameworkTags", ApplyAutobuilderTagsAsFrameworkTags),
-            new XElement("ShowCommandByline", new XCData(ShowCommandByline)),
-            new XElement("Default", DefaultInfo.SaveToXml(),
-                new XElement("NumberOfRandomElements", new XCData(NumberOfRandomElements.OriginalExpression))),
-            new XElement("Descriptions",
-                from item in RandomDescriptionElements select item.SaveToXml()
+		XElement result = new("Template",
+			new XElement("ApplyAutobuilderTagsAsFrameworkTags", ApplyAutobuilderTagsAsFrameworkTags),
+			new XElement("ShowCommandByline", new XCData(ShowCommandByline)),
+			new XElement("AddToAllRoomDescriptions", new XCData(AddToAllRoomDescriptions)),
+			new XElement("Default", DefaultInfo.SaveToXml(),
+				new XElement("NumberOfRandomElements", new XCData(NumberOfRandomElements.OriginalExpression))),
+			new XElement("Descriptions",
+				from item in RandomDescriptionElements select item.SaveToXml()
             )
         );
         XElement terrainElement = new("Terrains");
@@ -164,35 +166,16 @@ public class AutobuilderRoomRandomDescription : AutobuilderRoomBase
         Room room = new(builder, builder.CurrentOverlayPackage);
         ICell cell = room.Cells.First();
         IEditableCellOverlay overlay = cell.GetOrCreateOverlay(builder.CurrentOverlayPackage);
-        (AutobuilderRoomInfo info, Expression expression) = specifiedTerrain != null && TerrainInfos.ContainsKey(specifiedTerrain)
-            ? TerrainInfos[specifiedTerrain]
-            : (DefaultInfo, NumberOfRandomElements);
+		(AutobuilderRoomInfo info, Expression expression) = specifiedTerrain != null && TerrainInfos.ContainsKey(specifiedTerrain)
+			? TerrainInfos[specifiedTerrain]
+			: (DefaultInfo, NumberOfRandomElements);
 
-        overlay.Terrain = specifiedTerrain ?? info.DefaultTerrain;
-        overlay.OutdoorsType = overlay.Terrain.DefaultCellOutdoorsType;
-        switch (overlay.OutdoorsType)
-        {
-            case CellOutdoorsType.Indoors:
-                overlay.AmbientLightFactor = 0.25;
-                break;
-            case CellOutdoorsType.IndoorsWithWindows:
-                overlay.AmbientLightFactor = 0.35;
-                break;
-            case CellOutdoorsType.Outdoors:
-                overlay.AmbientLightFactor = 1.0;
-                break;
-            case CellOutdoorsType.IndoorsNoLight:
-                overlay.AmbientLightFactor = 0.0;
-                break;
-            case CellOutdoorsType.IndoorsClimateExposed:
-                overlay.AmbientLightFactor = 0.9;
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+		overlay.Terrain = specifiedTerrain ?? info.DefaultTerrain;
+		overlay.OutdoorsType = info.OutdoorsType;
+		overlay.AmbientLightFactor = info.AmbientLightFactor;
 
-        cell.ForagableProfile = info.ForagableProfile;
-        ApplyTagsToCell(cell, tags);
+		cell.ForagableProfile = info.ForagableProfile;
+		ApplyTagsToCell(cell, tags);
 
         if (!deferDescription)
         {
@@ -283,14 +266,19 @@ public class AutobuilderRoomRandomDescription : AutobuilderRoomBase
             sb.Append(info.CellDescription);
         }
 
-        foreach ((string Name, string Text) element in texts)
-        {
-            sb.Append(element.Text.LeadingSpaceIfNotEmpty().Fullstop());
-        }
+		foreach ((string Name, string Text) element in texts)
+		{
+			sb.Append(element.Text.LeadingSpaceIfNotEmpty().Fullstop());
+		}
 
-        overlay.CellDescription = sb.ToString();
-        ApplyTagsToCell(cell, tags);
-    }
+		if (!string.IsNullOrWhiteSpace(AddToAllRoomDescriptions))
+		{
+			sb.Append(AddToAllRoomDescriptions.LeadingSpaceIfNotEmpty().Fullstop());
+		}
+
+		overlay.CellDescription = sb.ToString();
+		ApplyTagsToCell(cell, tags);
+	}
 
     protected override string SubtypeHelpText => @"
 Commands pertaining to the Default Room (used if no override is specified):

--- a/MudSharpCore/Construction/Autobuilder/Rooms/AutobuilderRoomSimple.cs
+++ b/MudSharpCore/Construction/Autobuilder/Rooms/AutobuilderRoomSimple.cs
@@ -33,9 +33,9 @@ public class AutobuilderRoomSimple : AutobuilderRoomBase
     public ITerrain DefaultTerrain { get; protected set; }
     public IForagableProfile ForagableProfile { get; protected set; }
 
-    public AutobuilderRoomSimple(IFuturemud gameworld, string name) : base(gameworld, name)
-    {
-        ShowCommandByline = "A Terrain-Specific Room Template";
+	public AutobuilderRoomSimple(IFuturemud gameworld, string name) : base(gameworld, name)
+	{
+		ShowCommandByline = "A Simple Room Template";
         DefaultTerrain = gameworld.Terrains.First(x => x.DefaultTerrain);
         CellName = "An Undescribed Location";
         CellDescription = "This location does not have any description";
@@ -119,10 +119,10 @@ public class AutobuilderRoomSimple : AutobuilderRoomBase
         );
     }
 
-    public override IAutobuilderRoom Clone(string newName)
-    {
-        throw new NotImplementedException();
-    }
+	public override IAutobuilderRoom Clone(string newName)
+	{
+		return new AutobuilderRoomSimple(this, newName);
+	}
 
     public override ICell CreateRoom(ICharacter builder, ITerrain specifiedTerrain, bool deferDescription,
         params string[] tags)
@@ -148,11 +148,11 @@ public class AutobuilderRoomSimple : AutobuilderRoomBase
 	#3fp none#0 - removes a foragable profile
 	#3outdoors|cave|indoors|shelter#0 - sets the outdoor behaviour type";
 
-    public override string Show(ICharacter builder)
-    {
-        return
-            $"{$"Autobuilder Area Template #{Id} ({Name})".Colour(Telnet.Cyan)}\n\nThis template will create the same cell every time. This particular template creates cells with terrain type {DefaultTerrain.Name.Colour(Telnet.Green)}, outdoors type {OutdoorsType.Describe().Colour(Telnet.Green)} and Ambient Light Factor {AmbientLightFactor:N3}. {(ForagableProfile == null ? "It does not have a foragable profile set." : $"It will use the {ForagableProfile.Name.Colour(Telnet.Green)} foragable profile.")}\n\nCell Name: {CellName}\nCell Description:\n\n{CellDescription.Wrap(builder.InnerLineFormatLength, "\t")}";
-    }
+	public override string Show(ICharacter builder)
+	{
+		return
+			$"{$"Autobuilder Room Template #{Id} ({Name})".Colour(Telnet.Cyan)}\n\nThis template will create the same cell every time. This particular template creates cells with terrain type {DefaultTerrain.Name.Colour(Telnet.Green)}, outdoors type {OutdoorsType.Describe().Colour(Telnet.Green)} and Ambient Light Factor {AmbientLightFactor:N3}. {(ForagableProfile == null ? "It does not have a foragable profile set." : $"It will use the {ForagableProfile.Name.Colour(Telnet.Green)} foragable profile.")}\n\nCell Name: {CellName}\nCell Description:\n\n{CellDescription.Wrap(builder.InnerLineFormatLength, "\t")}";
+	}
 
     public override bool BuildingCommand(ICharacter actor, StringStack command)
     {

--- a/Terrain Planner Core/MainWindow.xaml.cs
+++ b/Terrain Planner Core/MainWindow.xaml.cs
@@ -281,62 +281,75 @@ namespace Terrain_Planner_Tool
             };
         }
 
+        private void ApplyImportedTerrains(IEnumerable<ImportTerrain> terrains)
+        {
+            _terrains.Clear();
+            _terrains.Add(new Terrain { Colour = Colors.DarkGray, Id = 0, Name = "None", Text = "" });
+            foreach (ImportTerrain terrain in terrains)
+            {
+                _terrains.Add(terrain.Terrain);
+            }
+
+            foreach (MapCell cell in _cells)
+            {
+                cell.Terrain = _terrains.First();
+            }
+
+            PalettePanel.Children.Clear();
+            foreach (Terrain terrain in _terrains)
+            {
+                Button button = new()
+                {
+                    DataContext = terrain,
+                    Content = terrain.Name,
+                    Background = new SolidColorBrush(terrain.Colour)
+                };
+                button.Click += (senderinternal, args) =>
+                {
+                    _currentBrush = (Terrain)((Button)senderinternal).DataContext;
+                };
+                PalettePanel.Children.Add(button);
+            }
+
+            _currentBrush = _terrains.First();
+        }
+
         private async void Button_Click_Import_Terrains_From_API(object sender, RoutedEventArgs e)
         {
-            await using FileStream fs = new("apiaddress.config", FileMode.OpenOrCreate, FileAccess.ReadWrite);
-            using StreamReader reader = new(fs);
-
-            string address = await reader.ReadLineAsync();
-            if (string.IsNullOrWhiteSpace(address))
+            try
             {
-                MessageBox.Show(
-                    "There was no information specified in the apiaddress.config file pertaining to the web api address. Please fill in this information and try again.");
-                return;
+                await using FileStream fs = new("apiaddress.config", FileMode.OpenOrCreate, FileAccess.ReadWrite);
+                using StreamReader reader = new(fs);
+
+                string address = await reader.ReadLineAsync();
+                if (string.IsNullOrWhiteSpace(address))
+                {
+                    MessageBox.Show(
+                        "There was no information specified in the apiaddress.config file pertaining to the web api address. Please fill in this information and try again.");
+                    return;
+                }
+                HttpClient client = new();
+                HttpResponseMessage response = await client.GetAsync(address);
+                if (response.IsSuccessStatusCode)
+                {
+                    List<ImportTerrain> deserialise = await response.Content.ReadFromJsonAsync<List<ImportTerrain>>();
+                    if (deserialise == null)
+                    {
+                        MessageBox.Show("Invalid terrain information returned.");
+                        return;
+                    }
+
+                    ApplyImportedTerrains(deserialise);
+                    MessageBox.Show("Successfully imported terrains.");
+                    return;
+                }
+
+                MessageBox.Show(response.ReasonPhrase);
             }
-            HttpClient client = new();
-            HttpResponseMessage response = await client.GetAsync(address);
-            if (response.IsSuccessStatusCode)
+            catch (Exception ex)
             {
-                List<ImportTerrain> deserialise = await response.Content.ReadFromJsonAsync<List<ImportTerrain>>();
-                if (deserialise == null)
-                {
-                    MessageBox.Show("Invalid terrain information returned");
-                }
-                _terrains.Clear();
-                _terrains.Add(new Terrain { Colour = Colors.DarkGray, Id = 0, Name = "None", Text = "" });
-                foreach (ImportTerrain terrain in deserialise)
-                {
-                    _terrains.Add(terrain.Terrain);
-                }
-
-                foreach (MapCell cell in _cells)
-                {
-                    cell.Terrain = _terrains.First();
-                }
-
-                PalettePanel.Children.Clear();
-                foreach (Terrain terrain in _terrains)
-                {
-                    Button button = new()
-                    {
-                        DataContext = terrain,
-                        Content = terrain.Name,
-                        Background = new SolidColorBrush(terrain.Colour)
-                    };
-                    button.Click += (senderinternal, args) =>
-                    {
-                        _currentBrush = (Terrain)((Button)senderinternal).DataContext;
-                    };
-                    PalettePanel.Children.Add(button);
-                }
-
-                _currentBrush = _terrains.First();
-                MessageBox.Show("Successfully imported terrains.");
-                return;
+                MessageBox.Show($"Encountered a problem with importing terrains from the API.\n\n{ex.Message}");
             }
-
-            MessageBox.Show(response.ReasonPhrase);
-
         }
 
         private void Button_Click_Import_Terrains(object sender, RoutedEventArgs e)
@@ -346,35 +359,13 @@ namespace Terrain_Planner_Tool
                 string json = Clipboard.GetText();
                 List<ImportTerrain> deserialise =
                     JsonSerializer.Deserialize<List<ImportTerrain>>(json);
-                _terrains.Clear();
-                _terrains.Add(new Terrain { Colour = Colors.DarkGray, Id = 0, Name = "None", Text = "" });
-                foreach (ImportTerrain terrain in deserialise)
+                if (deserialise == null)
                 {
-                    _terrains.Add(terrain.Terrain);
+                    MessageBox.Show("Invalid terrain information returned from your clipboard.");
+                    return;
                 }
 
-                foreach (MapCell cell in _cells)
-                {
-                    cell.Terrain = _terrains.First();
-                }
-
-                PalettePanel.Children.Clear();
-                foreach (Terrain terrain in _terrains)
-                {
-                    Button button = new()
-                    {
-                        DataContext = terrain,
-                        Content = terrain.Name,
-                        Background = new SolidColorBrush(terrain.Colour)
-                    };
-                    button.Click += (senderinternal, args) =>
-                    {
-                        _currentBrush = (Terrain)((Button)senderinternal).DataContext;
-                    };
-                    PalettePanel.Children.Add(button);
-                }
-
-                _currentBrush = _terrains.First();
+                ApplyImportedTerrains(deserialise);
                 MessageBox.Show("Successfully imported terrains.");
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- Added a terrain-aware UsefulSeeder autobuilder package with repeatable helper architecture and XML builders.
- Fixed several autobuilder runtime bugs in room templates, feature groups, and builder help text.
- Updated the Terrain Planner API import path to fail safely and added engine, builder, and seeder docs.

## Testing
- `dotnet build DatabaseSeeder/DatabaseSeeder.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `dotnet test 'DatabaseSeeder Unit Tests/DatabaseSeeder Unit Tests.csproj' -c Debug --no-build --filter UsefulSeederAutobuilderTests`
- `dotnet build MudSharpCore/MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `dotnet build 'Terrain Planner Core/Terrain Planner Core.csproj' -c Debug --no-restore -m:1`
- Full `DatabaseSeeder Unit Tests` run still has 4 unrelated pre-existing failures in snapshot and culture-seeder tests.