### PR TITLE
Add markup design docs and AGENTS references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,12 @@ This project contains the long-running climate and weather regression checks use
 - The interface IPerceiver is used as a base for a small number of things that can see echoes and perceive things around them, such as characters and items. It extends IPerceivable.
 - When creating text for an IEmote, refer to [Emote System](./Design Documents/Emote System.md)
 
+## Text Markup Reference
+- [Emote System](./Design%20Documents/Emote%20System.md)
+- [Character Description System](./Design%20Documents/Character_Description_System.md)
+- [Human Seeder Description Patterns](./Design%20Documents/Human_Seeder_Description_Patterns.md)
+- [Room Description Markup](./Design%20Documents/Room_Description_Markup.md)
+
 ## Style Preferences and Internal Helper Conventions
 - Always prefer to present numbers, times, dates and the like using localised formatting where you know the IPerceiver the message is being presented to. Conventionally an IPerceiver passed to a method for this reason is called a `voyeur`. 
 - IPerceivers are IFormatProviders and so can be passed into functions like ToString in the same way as CultureInfo objects.

--- a/DatabaseSeeder/AGENTS.md
+++ b/DatabaseSeeder/AGENTS.md
@@ -36,5 +36,9 @@ Interactive installer that seeds initial database data and configuration for a n
   - [../Design Documents/Economy_System_Seeder_State_and_Gaps.md](../Design%20Documents/Economy_System_Seeder_State_and_Gaps.md)
 - `CurrencySeeder` is currently the only dedicated economy seeder. Treat broader economy seeding as an explicit product decision and ground new work in the seeder opportunity matrix documented above.
 
+## Text Markup Reference
+- [Character Description System](../Design%20Documents/Character_Description_System.md)
+- [Human Seeder Description Patterns](../Design%20Documents/Human_Seeder_Description_Patterns.md)
+
 ## Notes
 - All modules inherit both the solution-level and project-level rules unless explicitly overridden.

--- a/DatabaseSeeder/Seeders/AGENTS.md
+++ b/DatabaseSeeder/Seeders/AGENTS.md
@@ -26,6 +26,10 @@ It inherits from:
 - `MudSharpCore/Community/Election.cs`
   Handles nomination, voting, installation, and runoff logic for elected appointments.
 
+## Text Markup Reference
+- [Character Description System](../../Design%20Documents/Character_Description_System.md)
+- [Human Seeder Description Patterns](../../Design%20Documents/Human_Seeder_Description_Patterns.md)
+
 ## Design Guidance
 - Prefer rank to represent a member's durable place in the organisation.
 - Prefer appointment to represent a billet, office, post, or special duty that may change without changing core rank.

--- a/Design Documents/Character_Description_System.md
+++ b/Design Documents/Character_Description_System.md
@@ -1,0 +1,365 @@
+# Character Description System
+
+## Scope
+
+This document describes FutureMUD's generic character-description system as implemented by:
+
+- `FutureMUDLibrary/Form/Characteristics/IHaveCharacteristics.cs`
+- `FutureMUDLibrary/Form/Shape/IEntityDescriptionPattern.cs`
+- `FutureMUDLibrary/CharacterCreation/ICharacterTemplate.cs`
+- `MudSharpCore/Body/Implementations/BodyPerception.cs`
+- `MudSharpCore/Body/Implementations/BodyCharacteristics.cs`
+
+It covers:
+
+- short, possessive, long, and full character descriptions
+- the precedence rules between custom text, selected patterns, disguises, obscurers, and runtime addenda
+- the generic description-pattern grammar used by sdescs and fdescs
+
+Human-seeder specifics live in [Human Seeder Description Patterns](./Human_Seeder_Description_Patterns.md).
+
+## Description Modes
+
+FutureMUD uses the following description modes for characters:
+
+| Mode | Runtime purpose |
+| --- | --- |
+| `Short` | Nominal sdesc, such as `a short, blue-eyed man` |
+| `Possessive` | Possessive version of the short description, such as `your` or `a short, blue-eyed man's` |
+| `Long` | Scenic presence text, such as `A short, blue-eyed man is standing here.` |
+| `Full` | Detailed look text |
+
+`Contents` and `Evaluate` exist on the enum for other perceivables, but the key character-description authoring targets are `Short`, `Possessive`, `Long`, and `Full`.
+
+## Runtime Rendering Pipeline
+
+### High-Level Precedence
+
+When a character is rendered, the engine applies these layers in order:
+
+1. top-level override effects
+2. identity-obscurer overrides, where applicable
+3. selected entity description pattern text, if one is chosen
+4. raw custom text stored on the body/template
+5. characteristic parsing
+6. written-language substitution where that mode uses it
+7. spacing, sentence, wrapping, and runtime addenda
+
+### Override Effects
+
+`BodyPerception.HowSeen` checks `IOverrideDescEffect` before the normal description pipeline. If an effect says it overrides the requested description type for that perceiver, and the perceiver can see the target, that override wins immediately.
+
+This sits above normal pattern/custom-text rendering.
+
+### Short Description
+
+For `DescriptionType.Short`, the runtime flow is:
+
+1. visibility checks and corpse redirects happen first
+2. the engine chooses the base text in this order:
+   - `IObscureIdentity.OverriddenShortDescription`
+   - selected short-description pattern
+   - stored short-description text
+3. the text is parsed through `ParseCharacteristics`
+4. the result is passed through `SubstituteWrittenLanguage`
+5. spacing is normalised
+6. proper-casing is applied when requested
+7. `ProcessDescriptionAdditions` overlays dubs/admin name display and `ISDescAdditionEffect` text
+
+`ProcessDescriptionAdditions` is also where account name-overlay settings and dubs can replace or extend the raw sdesc.
+
+### Possessive Description
+
+For `DescriptionType.Possessive`:
+
+- self-viewers get `your` or `Your`
+- everyone else gets the rendered short description, parsed again for characteristics, with `'s` appended
+
+This means possessive mode is built from the short-description pipeline rather than maintained as separate author-authored text.
+
+### Long Description
+
+For `DescriptionType.Long`, the engine builds a scenic sentence from the short description plus context such as:
+
+- current position
+- riding / being ridden
+- combat state
+- `ILDescSuffixEffect` text
+
+In practice this is the line that appears in room listings and look output when a character is present in the scene.
+
+### Full Description
+
+For `DescriptionType.Full`, the runtime flow is:
+
+1. if the viewer cannot see the character, return `You cannot make out their features.`
+2. choose the base text in this order:
+   - `IObscureIdentity.OverriddenFullDescription`
+   - selected full-description pattern
+   - stored full-description text
+3. run `SubstituteWrittenLanguage`
+4. run `ParseCharacteristics`
+5. append every applicable `IDescriptionAdditionEffect`
+6. normalise spacing, sentence-case, and wrapping
+
+This order differs slightly from short descriptions: full descriptions run written-language substitution before characteristic parsing.
+
+## Pattern Selection Versus Raw Text
+
+Both chargen templates and live bodies can carry:
+
+- raw stored sdesc/fdesc text
+- selected `IEntityDescriptionPattern` references
+
+Current runtime prefers the selected pattern text when present:
+
+- short descriptions use `_shortDescriptionPattern?.Pattern ?? _shortDescription`
+- full descriptions use `_fullDescriptionPattern?.Pattern ?? _fullDescription`
+
+That makes pattern selection the effective canonical source once a pattern is chosen.
+
+## Obscurers and Disguises
+
+Two different systems can change what is shown:
+
+- `IObscureIdentity`
+  Replaces the whole short or full description with an override string.
+- `IObscureCharacteristics`
+  Leaves the description pattern in place, but changes how individual characteristic variables render.
+
+`BodyCharacteristics.GetObscurer` currently returns the last worn visible item whose `IObscureCharacteristics` component says it obscures that definition.
+
+So if multiple worn items obscure the same characteristic, the last applicable one wins.
+
+## Chargen Preview Behaviour
+
+Chargen/template preview uses `ParseCharacteristicsAbsolute`, not the live-body obscurer-aware pipeline.
+
+Important consequences:
+
+- it operates on the selected characteristics passed into the template
+- it does not use worn obscurers
+- it does not need a live body instance
+- it still resolves the same generic grammar
+
+This is why chargen help and preview can show a faithful pattern expansion before the character exists as a live body in the world.
+
+## Generic Pattern Grammar
+
+### Characteristic Variables
+
+The base forms are:
+
+| Form | Meaning |
+| --- | --- |
+| `$var` | ordinary form |
+| `$varbasic` | basic form |
+| `$varfancy` | fancy form |
+
+What "ordinary", "basic", and "fancy" mean depends on the specific characteristic value implementation. The generic system does not hardcode the prose; it asks the characteristic value for `GetValue`, `GetBasicValue`, and `GetFancyValue`.
+
+### Obscurer-Aware Variable Branches
+
+Form:
+
+```text
+$var[visible text][obscured text]
+```
+
+Behaviour:
+
+- if the characteristic is not obscured, the first branch is used
+- if it is obscured, the second branch is used
+- if only one branch is supplied, only that branch exists
+
+Branch placeholders:
+
+| Placeholder | Meaning inside the branch |
+| --- | --- |
+| `@` | the characteristic text |
+| `$` | obscuring item `Name`, lower-cased |
+| `*` | obscuring item sdesc |
+
+Examples:
+
+```text
+$eyecolour[@ eyes][eyes hidden behind $]
+$hairstyle[@ hair][hair hidden beneath *]
+```
+
+### Default-or-Missing Checks
+
+Form:
+
+```text
+$?var[present text][default-or-missing text]
+```
+
+Behaviour:
+
+- if the characteristic is missing or still at its default value, the second branch is used
+- otherwise the first branch is used
+
+This is the normal way to gate things like hair style, facial hair, or optional seeded characteristics.
+
+### Bodypart-Count Grammar
+
+Form:
+
+```text
+%var[normal][n:text][n-m:text][x:text]
+```
+
+This grammar is only meaningful for `IBodypartSpecificCharacteristicDefinition` values.
+
+Behaviour:
+
+- if the owner has the characteristic definition's ordinary bodypart count, the `normal` branch is used
+- otherwise up to three alternate branches can be matched by exact count or inclusive range
+- if no alternate matches, the normal branch is reused
+
+Branch placeholders inside `%var[...]`:
+
+| Placeholder | Meaning |
+| --- | --- |
+| `@` | rewrites to `$var` |
+| `%` | numeric count |
+| `*` | wordy count |
+
+Example:
+
+```text
+%eyecolour[$eyecolour eyes][1:one $eyecolour eye][0:no eyes]
+```
+
+### Articles
+
+Forms:
+
+```text
+&a_an[content]
+&?a_an[content]
+```
+
+Behaviour:
+
+- `&a_an[...]` always applies `a` or `an` to the expanded content
+- `&?a_an[...]` first checks whether the expanded content is grammatically plural; if so it leaves the content alone, otherwise it applies `a` or `an`
+
+Examples:
+
+```text
+&a_an[$person]
+&?a_an[$ears[%ears[$earsbasic][1:one-eared][0:earless] ][]$person]
+```
+
+### Pronoun-Number Alternates
+
+Form:
+
+```text
+&pronoun|plural text|singular text&
+```
+
+Behaviour:
+
+- plural text is used for indeterminate and non-binary pronoun-number handling
+- singular text is used for the standard singular pronoun cases
+
+This is separate from `&he`, `&him`, and similar direct pronoun helpers.
+
+### Extra Variables
+
+The generic parser also supports these extra variables:
+
+| Variable | Meaning |
+| --- | --- |
+| `&he` | subjective pronoun |
+| `&him` | objective pronoun |
+| `&his` | possessive pronoun |
+| `&himself` | reflexive pronoun |
+| `&male` | gender class word |
+| `&race` | race name |
+| `&culture` | culture name |
+| `&ethnicity` | ethnicity name |
+| `&ethnicgroup` | ethnic group |
+| `&personword` | culture person word |
+| `&age` | age category |
+| `&height` | exact height string via the unit manager |
+| `&tattoos` | tattoo summary, or blank |
+| `&withtattoos` | alternate tattoo summary, or blank |
+| `&scars` | scar summary, or blank |
+| `&withscars` | alternate scar summary, or blank |
+
+Important distinction:
+
+- `$height` is the relative-height descriptor characteristic
+- `&height` is the exact measured height string
+
+They are not interchangeable.
+
+### Tattoo and Scar Helpers
+
+The tattoo and scar helpers are generated dynamically from visible marks.
+
+Current runtime:
+
+- checks visible and exposed tattoos or scars
+- honours special overrides where a tattoo/scar template provides one
+- otherwise falls back to stock summary strings such as "scarred", "heavily scarred", "inked", and their `with...` variants
+
+These helpers are useful in sdescs because they compress many visible marks into short readable phrases.
+
+## Advanced Deferred Parsing
+
+The parser also supports a deferred inner form using `!`, such as:
+
+- `$!var[...]`
+- `&!a_an[...]`
+
+This leaves part of the markup for a later parsing pass instead of resolving it immediately. It is mostly useful in engine-authored nested templates and is not usually needed for ordinary builder-authored sdescs or fdescs.
+
+## Examples
+
+### Short Description Pattern
+
+```text
+&a_an[$haircolourbasic[@-haired ][]$person]
+```
+
+Typical expansion:
+
+- `a black-haired man`
+- `a grey-haired woman`
+
+### Optional Hair Style
+
+```text
+$?hairstyle[&his hair is $haircolourfancy and styled into &?a_an[$hairstylefancy]][&his head is bald]
+```
+
+### Relative Height Versus Exact Height
+
+```text
+This $person is &height tall and $?height[$height relative to you][about the same height as you].
+```
+
+Typical expansion:
+
+- `This woman is 172 cm tall and taller relative to you.`
+- or `This man is 5'10" tall and about the same height as you.`
+
+### Bodypart Count
+
+```text
+$ears[%ears[&his ears are $earsfancy][1:&he only has one ear, which is $earsfancy][0:&he has no ears]]
+```
+
+## Practical Guidance
+
+- Keep sdescs concise. Use basic forms more often there than fancy forms.
+- Use fancy forms in fdescs where extra prose pays off.
+- Use `$?var[...]` for truly optional details instead of leaving awkward blanks in the sentence.
+- Use `%var[...]` whenever the characteristic is tied to a bodypart count that might vary.
+- Prefer `&?a_an[...]` when plurality can vary after expansion.
+- When documenting or editing a specific seeded family, keep the generic rules here separate from the seeder-specific examples in the human-seeder extension document.

--- a/Design Documents/Emote System.md
+++ b/Design Documents/Emote System.md
@@ -1,69 +1,255 @@
-# Emote Markup
-- The `Emote` class in `MudSharp.PerceptionEngine` provides a lightweight markup language for dynamically tailored messages.
-- Prefer to use Emotes and Emote Markup anywhere you need to dynamically build echoes that involve characters or items.
-- Emotes substitute placeholders at parse time so each viewer sees a grammatically correct perspective of the same event. 
-- The string passed to an `Emote` **must not** contain raw `{` characters
-- Targets referenced in the text must be supplied to the constructor in the same order.
+# Emote System
 
-## Source Token
-`@` represents the source of the emote.
+## Scope
 
-- `@` – short description of the source.
-- `@#` – subject pronoun (he/she/they).
-- `@!` – object pronoun (him/her/them).
-- `@'s` – possessive form.
-If the emote lacks `@`, setting `forceSourceInclusion` prepends the source description automatically.
+This document is the canonical reference for FutureMUD's emote markup as implemented by:
 
-## Referencing Perceivables (internal `$` tokens)
-Internal tokens refer to perceivables passed to the constructor (`$0`, `$1`, …).
+- `MudSharpCore/PerceptionEngine/Parsers/Emote.cs`
+- `MudSharpCore/PerceptionEngine/Parsers/EmoteTokens.cs`
 
-- `$0` – description of target 0 / “you”.
-- `$0's` – possessive form.
-- `!0` – description without article / “you”.
-- `&0` – object pronoun (“him/her/them”) / “you”.
-- `#0` – subject pronoun (“he/she/they”) / “you”.
-- `%0` – reflexive (“himself/herself/itself”) / “yourself”.
+It covers engine-authored emotes, player-authored emotes, speech handling, and the current runtime behaviour of the parser. It does not cover the character-description markup or room-description markup; those live in separate design documents.
+
+## Core Classes
+
+- `Emote`
+  The normal parser for engine-authored echoes. It expects internal numeric target references such as `$0`.
+- `PlayerEmote`
+  The player-facing variant. It still uses the same token engine, but it additionally resolves live target lookups such as `~guard` and `*sword`.
+- `NoFormatEmote`
+  Despite the name, this is not a separate markup language. It still scouts targets and still ultimately uses `string.Format` with the parsed token list. In current runtime behaviour it should be treated as an `Emote` with the same token support.
+
+Related variants exist for language handling:
+
+- `NoLanguageEmote`
+- `FixedLanguageEmote`
+
+## Authoring Rules
+
+- Raw `{` characters are reserved. `Emote` rewrites recognised tokens into `{0}`, `{1}`, and so on before formatting.
+- Internal target order matters. `$0`, `$1`, `$2`, etc. refer to perceivables passed to the constructor in that order.
+- `forceSourceInclusion` prepends the source token if the emote text never explicitly included a plain `@`.
+- The parser auto-closes an odd number of quote characters by appending a trailing `"`.
+- Quoted speech is tokenised before the normal emote tokens.
+- Player emotes are sanitised before parsing.
+
+## Parsing Model
+
+The parser resolves tokens into a single shared raw format string, then renders that string separately for each perceiver. That is why the same emote can show `you`, `your`, `him`, `herself`, or a full sdesc depending on who is viewing it.
+
+The practical split is:
+
+- engine-authored/internal tokens for code that already knows the exact targets
+- player lookup tokens for pmotes, omotes, socials, and other free-form player text
+
+## Engine-Authored Tokens
+
+### Source Tokens
+
+`@` refers to the emote source.
+
+| Token | Meaning |
+| --- | --- |
+| `@` | source description, or `you` for the source viewer |
+| `@!` | source objective pronoun |
+| `@#` | source subjective pronoun |
+| `@'s` | source noun possessive |
+| `@!'s` | source possessive pronoun |
+| `@#'s` | source possessive pronoun |
+
+Notes:
+
+- Current runtime accepts `@!` and `@#`, even though some older help text says source tokens cannot be modified.
+- `@!'s` and `@#'s` both resolve to the possessive pronoun form.
+
+### Target Tokens
+
+Internal target tokens point at constructor-supplied perceivables by index.
+
+| Token | Meaning |
+| --- | --- |
+| `$0` | description / `you` |
+| `$0's` | noun possessive / `your` |
+| `!0` | description without leading article / `you` |
+| `!0's` | bare noun possessive / `your` |
+| `&0` | objective pronoun / `you` |
+| `&0's` | possessive pronoun / `your` |
+| `#0` | subjective pronoun / `you` |
+| `%0` | reflexive / `yourself` |
+
+The same forms work for any index: `$1`, `&2`, `!3's`, and so on.
+
+### First/Third-Person Alternates
+
+These are used when one viewer should see a different literal string than everyone else.
+
+| Token | Meaning |
+| --- | --- |
+| `verb|verbs` | source viewer sees `verb`, everyone else sees `verbs` |
+| `$0|your|his` | target 0 sees `your`, everyone else sees `his` |
+
+Notes:
+
+- Bare `verb|verbs` is tied to the source.
+- `$0|first|third` is the normal engine-authored targeted form.
+
+### Plurality and Pronoun-Number Alternates
+
+These are different systems.
+
+| Token | Meaning |
+| --- | --- |
+| `&0|is|are` | chooses by whether target 0 is a single entity |
+| `%0|stop|stops` | chooses by pronoun number: `you/they stop`, `he/she/it stops` |
+
+That distinction matters for groups. A grouped perceivable can be plural even when its displayed noun phrase is not simply a normal pronoun case.
+
+### Optional and Self-Collapse Tokens
+
+| Token | Meaning |
+| --- | --- |
+| `$?2|on $2||$` | if perceivable 2 exists, emit `on $2`, otherwise emit the null branch |
+| `$0=1` | if targets 0 and 1 are the same entity, collapse to reflexive wording |
+| `$0=1's` | if targets 0 and 1 are the same entity, collapse to reflexive possessive wording |
+
+Notes:
+
+- `$0=1` produces reflexive-style output such as `yourself` or the target's reflexive pronoun when the two references are the same entity.
+- `$0=1's` produces reflexive possessive output such as `your own`.
+- The null-perceivable token reparses its chosen branch as a nested emote, so the branch text can itself contain normal emote tokens.
 
 ## Player Lookup Tokens
-When parsing free-form text from players, lookups use `~` for characters and `*` for items.
-These forms accept the same modifiers as internal tokens and target strings such as `2.tall.man`.
 
-- `~tall.man` – description / “you”.
-- `~!tall.man` – object pronoun.
-- `~#tall.man` – subject pronoun.
-- `~?tall.man` – reflexive.
-- `~tall.man's` or `~!tall.man's` – possessive (“man's” / “your” or “his” / “your”).
+`PlayerEmote` adds live target lookup tokens based on the source character's normal targeting rules.
 
-## First/Third Person Variants
-Use `|` to supply alternative text for the referenced perceiver versus everyone else.
+- `~...` targets characters
+- `*...` targets items
 
-- `verb1|verb2` – first person for the source, third person for others (`@ smile|smiles`).
-- `$0|your|his` or `~tall.man|your|his` – “your” for the target, “his” for others.
+The lookup portion can be a normal MUD target string such as `guard`, `2.guard`, `tall.man`, or `3.long.sword`.
 
-## Plurality and Pronoun Number
-- `&0|is|are` – uses “is” when token 0 is singular, “are” when plural.
-- `%0|stop|stops` – conjugates based on the pronoun number of token 0 (“stop” for you/they, “stops” for he/she/it).
+### Player Lookup Forms
 
-## Optional and Conditional Tokens
-- `$?2|on $2||$` – includes `on $2` only if perceivable 2 exists.
-- `$0=1` – if tokens 0 and 1 refer to the same entity, outputs “yourself”; `$0=1's` gives “your own”.
+| Token | Meaning |
+| --- | --- |
+| `~guard` | character description / `you` |
+| `~!guard` | objective pronoun |
+| `~#guard` | subjective pronoun |
+| `~?guard` | reflexive |
+| `~guard's` | noun possessive |
+| `~!guard's` | possessive pronoun |
+| `~#guard's` | possessive pronoun |
+| `*sword` | item description / `you` if appropriate |
+| `*!sword` | item pronoun form |
+| `*sword's` | item possessive |
 
-## Speech and Culture
-- Text inside quotes (`"spoken text"`) is parsed as speech and routed through language handling.
-- Culture-specific text can be written as `&cultureA,cultureB:text|fallback&`.
+The same first/third-person alternate syntax exists in player mode:
+
+- `smile|smiles`
+- `~guard|your|his`
+- `*sword|your|its`
+
+Notes:
+
+- In player mode the parser only accepts one optional modifier before the lookup key: `!`, `#`, or `?`.
+- For possessives, `!` and `#` both collapse to possessive-pronoun output.
+
+## Speech Handling
+
+Quoted speech such as `"hello there"` becomes a language token before the rest of the emote is parsed.
+
+Current behaviour:
+
+- If language output is permitted, the speech is rendered through the source's current language and accent.
+- If the caller uses `PermitLanguageOptions.IgnoreLanguage`, the raw quoted text is left alone.
+- If the caller uses one of the restrictive language modes, the speech becomes the relevant replacement such as muffled, choking, gasping, or clicking output.
+- If speech is forbidden with `PermitLanguageOptions.LanguageIsError`, parsing fails.
+
+## Culture Tokens
+
+`EmoteTokens.cs` defines a regex for culture tokens in this format:
+
+`&culture1,culture2:text if culture|fallback&`
+
+However, current runtime does not actually apply `CultureTokenRegex` anywhere in `ScoutTargets`. In other words:
+
+- the syntax is documented in code comments
+- the regex exists
+- the parser does not currently process it
+
+Treat culture tokens as non-functional unless the runtime is changed.
 
 ## Examples
+
+### Engine Authored Echo
+
 ```csharp
 new Emote("@ smile|smiles at $0.", actor, target);
-// actor: "You smile at Bob."
-// target: "Alice smiles at you."
-// others: "Alice smiles at Bob."
-
-new Emote("@ pat|pats $0 on &0 shoulder.", actor, target);
-// actor: "You pat Bob on his shoulder."
-// target: "Alice pats you on your shoulder."
-
-new Emote("$0 %0|stop|stops here.", actor, group);
-// group: "You stop here."
-// others: "The guards stop here."
 ```
+
+Typical output:
+
+- source sees: `You smile at Bob.`
+- target sees: `Alice smiles at you.`
+- others see: `Alice smiles at Bob.`
+
+### Possessives and Pronouns
+
+```csharp
+new Emote("@ pat|pats &0 on &0's shoulder.", actor, target);
+```
+
+Typical output:
+
+- source sees: `You pat him on his shoulder.`
+- target sees: `Alice pats you on your shoulder.`
+- others see: `Alice pats him on his shoulder.`
+
+### Optional Target
+
+```csharp
+new Emote("@ lock|locks $0 $?1|with $1||$.", actor, door, maybeKey);
+```
+
+Typical output:
+
+- with a key: `Alice locks the iron door with a brass key.`
+- without a key: `Alice locks the iron door.`
+
+### Self-Collapse
+
+```csharp
+new Emote("@ point|points $0=0.", actor, actor);
+```
+
+Typical output:
+
+- source sees: `You point yourself.`
+- others see reflexive wording for the source rather than a repeated noun phrase
+
+### Player Pmote or Omote
+
+Player text:
+
+```text
+smile|smiles at ~guard and tap|taps ~!guard's spear.
+```
+
+Typical output:
+
+- source sees first-person verbs and `you` forms when appropriate
+- the guard sees `you`
+- bystanders see third-person verbs and the guard's normal sdesc/pronoun forms
+
+### Speech
+
+```csharp
+new Emote("@ say|says, \"Stay back.\"", actor);
+```
+
+The quoted speech is rendered as spoken language output, not as plain literal text, unless the caller intentionally suppresses language parsing.
+
+## Runtime Caveats Worth Remembering
+
+- `NoFormatEmote` is not presently a "skip emote markup" mode.
+- Culture tokens are currently defined but not executed.
+- Older help for player emotes is incomplete around source modifiers and some possessive forms.
+- The canonical truth for supported tokens is `EmoteTokens.cs`, not the shorter command help text.

--- a/Design Documents/Human_Seeder_Description_Patterns.md
+++ b/Design Documents/Human_Seeder_Description_Patterns.md
@@ -1,0 +1,280 @@
+# Human Seeder Description Patterns
+
+## Scope
+
+This document extends [Character Description System](./Character_Description_System.md) with the human-specific seeded description grammar and vocabulary implemented by:
+
+- `DatabaseSeeder/Seeders/HumanSeederCharacteristics.cs`
+- `DatabaseSeeder/Seeders/HumanSeeder.cs`
+- `MudSharpCore/Form/Characteristics/CharacteristicValue.cs`
+- `MudSharpCore/Form/Characteristics/MultiformCharacteristicValue.cs`
+- `MudSharpCore/Form/Characteristics/ColourCharacteristicValue.cs`
+- `MudSharpCore/Form/Characteristics/GrowableCharacteristicValue.cs`
+
+It is intentionally seeder-specific. The generic parser rules live in the main character-description document.
+
+## Seeded Human Variables
+
+The human seeder defines these description variables:
+
+| Variable | Pattern / aliases | Notes |
+| --- | --- | --- |
+| `eyecolour` | `^eyecolou?r` | bodypart-specific, ordinary count 2 |
+| `eyeshape` | `^eyeshape` | bodypart-specific, ordinary count 2 |
+| `nose` | `^nose` | bodypart-specific, ordinary count 1 |
+| `ears` | `^ears` | bodypart-specific, ordinary count 2 |
+| `haircolour` | `^haircolou?r` | colour-backed |
+| `facialhaircolour` | `^facialhaircolou?r` | colour-backed, seeded for male usage |
+| `hairstyle` | `^hairstyle` | styleable / growable |
+| `facialhairstyle` | `^facialhairstyle` | styleable / growable, seeded for male usage |
+| `skincolour` / `skintone` | `^skin(colou?r|tone)` | colour-backed alias pair |
+| `frame` | `^frame` | weighted by body build progs |
+| `person` | `^person` | seeded person-word vocabulary |
+| `distinctivefeature` | `^(distinctive)?feature` | optional seeder choice |
+
+## Seeded Value Model
+
+The human pack relies on the generic `GetValue`, `GetBasicValue`, and `GetFancyValue` surfaces, but the concrete meaning depends on the characteristic value class.
+
+### Standard and Multiform Values
+
+For the helper used by `AddCharacteristicValue(id, definition, name, value, additionalValue, ...)`:
+
+- ordinary form = `Name`
+- basic form = `Value`
+- fancy form = `AdditionalValue`
+
+That is the key rule behind patterns like:
+
+- `$frame` -> `burly`
+- `$framebasic` -> `muscular`
+- `$framefancy` -> `broad and squat, with a thickly muscular frame...`
+
+### Colour-Backed Values
+
+For colour characteristics such as eye colour, hair colour, facial hair colour, and skin colour:
+
+- ordinary form = colour `Name`
+- basic form = colour basic enum name, lower-cased
+- fancy form = colour fancy string
+
+So the same value can expose:
+
+- `$eyecolour` -> `blue-grey`
+- `$eyecolourbasic` -> `blue`
+- `$eyecolourfancy` -> `a cold, pale blue-grey`
+
+The exact strings depend on the seeded colour library.
+
+### Styleable / Growable Values
+
+Hair styles and facial hair styles use a growable/styleable value model, but the description surfaces still map cleanly:
+
+- ordinary form = `Name`
+- basic form = `Value`
+- fancy form = the prose portion stored inside `AdditionalValue`
+
+That is why seeded patterns can use:
+
+- `$hairstyle` for the plain named style
+- `$hairstylebasic` for compact sdesc wording
+- `$hairstylefancy` for richer fdesc prose
+
+## Person Word Seeding
+
+`person` is not a single static noun. The seeder adds many weighted, prog-gated values through `AddPersonWord(name, basic, prog, weight)`.
+
+Important consequences:
+
+- the ordinary form is the seeded surface noun such as `woman`, `maiden`, `geezer`, or `child`
+- the basic form groups those into a more stable family such as `woman`, `man`, `person`, `youth`, or `old woman`
+- the fancy form is blank for these values
+- the associated FutureProg controls which age/gender bucket can receive the word
+- the weight controls how likely that term is when the pack chooses among eligible values
+
+Examples:
+
+- `woman` and `lady` both map to a basic form of `woman`
+- `maiden` also maps to `woman`, but is gated to young-woman logic
+- `geezer` maps to `old man`
+
+### Extra Person Words
+
+If the seeder answer `includeextraperson` is enabled, additional informal words are added, such as:
+
+- `dude`
+- `gal`
+- `wench`
+- `stud`
+- `punk`
+
+If that option is disabled, those looser-tone values are not seeded at all.
+
+## Optional Distinctive Features
+
+`distinctivefeature` only exists if the seeder answer `distinctive` is enabled.
+
+When it is disabled:
+
+- the definition is not seeded
+- any patterns that rely on `$distinctivefeature...` should be considered part of the "distinctive-enabled" branch of the stock pack, not universally available runtime vocabulary
+
+## Stock Human Pattern Conventions
+
+The human pack follows a few strong conventions.
+
+### 1. Sdescs Stay Short and Searchable
+
+Stock sdesc patterns usually combine:
+
+- one anchor feature
+- one supporting feature or summary mark
+- a person word
+
+Typical shapes include:
+
+```text
+&a_an[$eyeshape[%eyeshape[$eyeshape-eyed][1:one-eyed][0:eyeless] ][]$person] with $eyecolour[%eyecolour[$eyecolour eyes][1:one $eyecolour eye][0:no eyes]][$]
+&a_an[$frame[@ ][]$person] with $eyeshape[%eyeshape[$eyeshape eyes][1:one $eyeshape eye][0:no eyes]][$]
+&a_an[$haircolourbasic[@-haired ][]$person]
+&a_an[&tattoos $person]
+&a_an[$distinctivefeaturebasic[@ ][]$person] &withscars
+```
+
+The goal is discoverability first. The pack avoids stuffing full prose into sdescs.
+
+### 2. Basic Forms Carry the Sdesc Load
+
+The seeded human sdescs lean heavily on:
+
+- `$...basic`
+- compact `%...` branches
+- short mark summaries such as `&withscars` and `&withtattoos`
+
+This keeps sdescs readable in room listings and easier to target by keyword.
+
+### 3. Fancy Forms Belong in Fdescs
+
+The stock full descriptions use fancy values far more often:
+
+- `$framefancy`
+- `$eyecolourfancy`
+- `$nosefancy`
+- `$hairstylefancy`
+- `$distinctivefeaturefancy`
+
+That is the basic style split of the seeded pack:
+
+- basic for short descriptions
+- fancy for full descriptions
+
+### 4. Relative Height Uses Both Exact and Comparative Grammar
+
+The stock human fdescs use both height systems together:
+
+```text
+This $person is &a_an[&male] &race that is &height tall and $?height[$height relative to you][about the same height as you].
+```
+
+That pairing is deliberate:
+
+- `&height` gives the exact measured height string
+- `$?height[...]` gives relative wording only when the relative-height descriptor is not the default
+
+### 5. Bodypart-Count Grammar Is Used Aggressively
+
+Eyes, ears, and nose all use `%var[...]` branches so the stock pack still reads naturally when the body is damaged, missing parts, or otherwise unusual.
+
+Representative examples:
+
+```text
+%eyecolour[&he has $eyecolourbasic $eyeshape eyes that are $eyecolourfancy][2-3:&he has % $eyecolourbasic $eyeshape eyes that are $eyecolourfancy][1:&he has a single $eyecolourbasic $eyeshape eye that is $eyecolourfancy][0:&he has no eyes, only empty sockets]
+%ears[&his ears are $earsfancy][1:&he only has one ear, which is $earsfancy][0:&he has no ears, just scars where the ears should be]
+%nose[$nosefancy][0:a gaping hole where &his nose used to be]
+```
+
+### 6. Facial Hair Is Explicitly Gated
+
+Facial hair patterns are not simply "sometimes blank". The stock pack uses different applicability progs:
+
+- `IsHumanoidFemale`
+- `IsHumanoidNonFemale`
+
+So male and non-female branches can carry facial hair clauses while female branches omit them entirely.
+
+### 7. Distinctive Features Are Gated Twice
+
+Distinctive features are controlled by:
+
+- seeder-time installation choice
+- actual characteristic presence at runtime
+
+The pack uses both plain and optional forms depending on the pattern:
+
+- `$distinctivefeaturebasic[@ ][]$person`
+- `&he has $distinctivefeaturefancy.`
+
+If you extend the pack, be deliberate about whether a distinctive feature is meant to be core to the sentence or an optional flourish.
+
+## Representative Stock Patterns
+
+### Compact Sdesc
+
+```text
+&a_an[$skincolour[@-skinned ][]$person]
+```
+
+Typical output:
+
+- `a dark-skinned woman`
+- `a pale-skinned man`
+
+### Scar-Aware Sdesc
+
+```text
+&a_an[$eyecolour[%eyecolour[$eyecolourbasic-eyed][1:one-eyed][0:eyeless] ][]$person] &withscars
+```
+
+Typical output:
+
+- `a green-eyed man scarred across the face`
+- `a one-eyed woman with prominent scars`
+
+### Full Description Skeleton
+
+```text
+This $person is &a_an[&male] &race that is &height tall and $?height[$height relative to you][about the same height as you]. You would describe &him as $frame, as &he is $framefancy.
+```
+
+This shows the stock rhythm:
+
+- person word
+- race/gender class
+- exact height
+- comparative height
+- compact frame label
+- fancy frame prose
+
+### Hair and Facial Hair Gating
+
+```text
+$hairstyle[$?hairstyle[&his hair is $haircolourfancy, and has been styled so that &he has &?a_an[$hairstylefancy]][&his head is bald, with no hair at all]][You cannot tell what sort of hair style or even hair colour &he has because &he is wearing $].
+$?facialhairstyle[&he has &?a_an[$facialhairstyle], which is $facialhaircolourfancy][&he does not have any facial hair, with a clean, smooth chin].
+```
+
+This is a good example of stock human style:
+
+- the outer `$hairstyle[...]` handles obscuring items
+- the inner `$?hairstyle[...]` handles bald/default versus styled hair
+- facial hair uses optional presence grammar instead of forcing a blank noun phrase
+
+## Guidance for Extending the Human Pack
+
+- Keep the generic grammar rules in the generic character-description doc. Put only human-specific conventions here.
+- Preserve the ordinary/basic/fancy split. If a new value needs rich prose, put it in the fancy surface and keep the basic surface short.
+- Add new bodypart-specific definitions with a sensible ordinary count, then update patterns to use `%var[...]` instead of assuming the normal anatomy.
+- Keep sdescs short enough to remain good targeting text in busy rooms.
+- Prefer full descriptions for elaborate prose and sentence flow.
+- If you add new informal person words, wire them through the `includeextraperson` choice unless they are meant to be part of the baseline tone.
+- If you add new gendered or age-gated person words, follow the existing prog-gated approach rather than hardcoding assumptions in prose.
+- If you add a new optional descriptive family similar to `distinctivefeature`, decide up front whether it should affect both sdesc and fdesc pattern pools.

--- a/Design Documents/Room_Description_Markup.md
+++ b/Design Documents/Room_Description_Markup.md
@@ -1,0 +1,329 @@
+# Room Description Markup
+
+## Scope
+
+This document describes the inline markup language used in cell and room descriptions as implemented by:
+
+- `MudSharpCore/Construction/CellDescription.cs`
+- `FutureMUDLibrary/Framework/StringUtilities.cs`
+- `MudSharpCore/Commands/Modules/RoomBuilderModule.cs`
+
+It covers the text builders can place directly into cell names and cell descriptions. It does not cover character description markup or emote markup.
+
+## Where This Markup Runs
+
+`CellDescription.SubstituteDescriptionVariables` currently applies the room markup pipeline in this order:
+
+1. `environment{...}` weather/light/time substitution
+2. ANSI colour substitution
+3. `@shop`
+4. `check{trait,minvalue}{pass}{fail}`
+5. `writing{language,script,...}{readable}{unreadable}`
+
+Important consequence:
+
+- the same substitution path is used for both the room name and the room description body
+
+So builders can use the same inline markup in either place.
+
+## Supported Markup
+
+### `environment{conditions=text}...{fallback}`
+
+This is the weather/light/time/season selector implemented in `CellDescription.cs`.
+
+Form:
+
+```text
+environment{qualifiers=text}{qualifiers=text}...{fallback}
+```
+
+Current runtime supports:
+
+- up to 8 conditional branches
+- one optional fallback branch with no `=` inside it
+- comma-separated qualifier lists inside each conditional branch
+
+All qualifiers in a branch must match for that branch to fire.
+
+Example:
+
+```text
+environment{night,dim=Moonlight leaks through the broken roof.}{rain=Rain drips steadily from the beams.}{The roof above is broken in several places.}
+```
+
+#### Time Qualifiers
+
+Supported time keywords:
+
+- `day`
+- `night`
+- `morning`
+- `afternoon`
+- `dusk`
+- `dawn`
+- `notnight`
+
+`day` currently means morning or afternoon.
+
+#### Season Qualifiers
+
+Season matching is not hardcoded to a fixed English list. The parser compares the qualifier against the current regional climate season names.
+
+That means custom climate season names are valid here.
+
+#### Precipitation Qualifiers
+
+Supported precipitation words are the strings recognised by `PrecipitationFromString`, including:
+
+- `parched`
+- `dry`
+- `humid`
+- `lightrain` / `lrain`
+- `rain`
+- `heavyrain` / `hrain`
+- `torrentialrain` / `torrential` / `torrent` / `train`
+- `lightsnow` / `lsnow`
+- `snow`
+- `heavysnow` / `hsnow`
+- `blizzard`
+- `sleet`
+
+#### Recent Precipitation
+
+Prefix a precipitation qualifier with `*` to check recent maximum precipitation instead of the current weather event.
+
+Example:
+
+```text
+environment{*rain=Everything here still glistens with recent rain.}
+```
+
+Current runtime treats this as `highest recent precipitation >= requested level`.
+
+#### Negation
+
+Prefix any qualifier with `!` to negate it.
+
+Examples:
+
+```text
+environment{!night=Sunlight still reaches the far wall.}
+environment{!rain,!snow=The courtyard remains dry.}
+```
+
+#### Threshold Checks
+
+Prefix light or precipitation qualifiers with `>` or `<`.
+
+Current runtime semantics are:
+
+- `>qualifier` means `>=` the threshold
+- `<qualifier` means `<` the threshold
+
+This applies to:
+
+- precipitation levels
+- light descriptions resolved through the light model
+
+Examples:
+
+```text
+environment{>dim=Only the broadest outlines can be made out.}
+environment{<bright=The corners remain in shadow.}
+environment{>rain=Water runs in thin rivulets along the floor.}
+```
+
+#### Light Qualifiers
+
+Light text is matched through the current light model, not through a hardcoded list inside `CellDescription.cs`.
+
+In other words:
+
+- the qualifier strings must match the light model's description names
+- `>` and `<` compare against the minimum illumination threshold for that named description
+
+Builder help currently prints the common stock list, but runtime truth comes from the active light model.
+
+### `writing{language,script,...}{readable}{unreadable}`
+
+This is the written-language markup implemented by `StringUtilities.SubstituteWrittenLanguage`.
+
+Form:
+
+```text
+writing{language,script,skill=...,style=...,colour=...}{text if readable}{text if unreadable}
+```
+
+Language and script can be supplied by:
+
+- numeric id
+- name
+
+Recognised attributes are:
+
+- `skill`
+- `style`
+- `colour`
+- `color`
+
+Examples:
+
+```text
+writing{english,latin}{The label reads "Poison."}{something written in a familiar script}
+writing{english,latin,skill=45,style=block,colour=red}{Danger: Do not drink}{a red warning label}
+```
+
+#### Runtime Behaviour
+
+Current behaviour is:
+
+- if the viewer has no language interface, the readable text is returned
+- if the language or script entry is malformed or unknown, the readable text is returned
+- if the viewer knows both the language and the script and meets the required skill, the readable text is shown
+- if the viewer knows the script but not the language, the unreadable text is shown
+- if the viewer knows the language and script but lacks the required skill, the unreadable text is shown
+- if the alternate text is omitted, the engine uses `DefaultAlternateTextValue`
+
+#### Important Mismatch: `minskill` Versus `skill`
+
+Some builder help still says this syntax uses `minskill`.
+
+Current runtime parser truth is:
+
+- the recognised attribute name is `skill`
+- `minskill` is not parsed
+
+So this works:
+
+```text
+writing{english,latin,skill=45}{readable text}{fallback text}
+```
+
+And this does not do what builder help claims:
+
+```text
+writing{english,latin,minskill=45}{readable text}{fallback text}
+```
+
+#### Attribute Operators
+
+The attribute regex allows operators such as `=`, `>`, and `<`, but current implementation only reads the numeric or named value and ignores the operator itself.
+
+So:
+
+- `skill=45`
+- `skill>45`
+- `skill<45`
+
+all currently end up behaving as though the value is simply `45`.
+
+That is runtime truth, even though it is easy to assume otherwise from the syntax.
+
+### `check{trait,minvalue}{pass}{fail}`
+
+This is the trait-check markup implemented by `StringUtilities.SubstituteCheckTrait`.
+
+Form:
+
+```text
+check{trait,minvalue}{text if trait >= value}{text if trait < value}
+```
+
+`trait` can be supplied by id or name.
+
+Current runtime behaviour:
+
+- if the viewer does not expose traits, the pass text is returned
+- if the trait cannot be found, the pass text is returned
+- if the difficulty value cannot be parsed, the pass text is returned
+- if the viewer's trait value is `>= minvalue`, the pass text is returned
+- otherwise the fail text is returned
+- if the fail text is omitted, the failed branch becomes blank
+
+Example:
+
+```text
+check{appraisal,35}{You notice the maker's stamp worked into the metal.}{At a glance it looks ordinary.}
+```
+
+### `@shop`
+
+`@shop` is a simple literal replacement inside `SubstituteDescriptionVariables`.
+
+Current behaviour:
+
+- if `Cell.Shop` is set, it substitutes the shop name
+- otherwise it substitutes `An Empty Shop`
+
+Important nuance:
+
+- this inline replacement only checks `Cell.Shop`
+- later room-description notices also detect shop stalls and other coded room services
+
+So `@shop` and the later "A shop is here..." notice do not use exactly the same detection path.
+
+## Full Room Description Render Order
+
+`CellFullDescription` builds the visible room output in this order:
+
+1. room short name, already passed through the markup pipeline
+2. admin info line for administrators, otherwise a blank spacer line
+3. exits
+4. processed builder-authored room description text
+5. coded illumination, weather addenda, and `IDescriptionAdditionEffect` text
+6. coded notices for shop, bank, auction house, property, jobs, estate, and morgue functions
+7. trial notice, if applicable
+
+After that broader look output continues elsewhere with characters and items rendered through their own long descriptions.
+
+That means:
+
+- builder-authored room markup controls the cell's own name and prose block
+- engine-appended notices are a separate later layer
+- character and item long descriptions, including pmote/omote influenced output, are not part of the room-markup system itself
+
+## Weather and Light Addenda Versus Builder Text
+
+The base builder-authored room description is processed first. Illumination text, weather addenda, and description-addition effects are appended after that.
+
+Depending on account settings:
+
+- coded additions may appear inline on the same paragraph
+- or they may be emitted on fresh lines
+
+So when you are writing a room description, do not assume your text is the final paragraph in the rendered output.
+
+## Examples
+
+### Time and Weather
+
+```text
+environment{dawn=Thin gold light spills through the eastern shutters.}{night=The room lies in soft darkness, broken only by starlight.}{The shutters are half-open.}
+```
+
+### Literacy and Script
+
+```text
+A brass plaque reads writing{english,latin,skill=30}{Property of the Guild Archive}{writing you cannot quite decipher}.
+```
+
+### Trait-Gated Detail
+
+```text
+check{forensics,55}{You spot a faint brown smear near the skirting board.}{}
+```
+
+### Shop Name
+
+```text
+The painted board above the door reads @shop.
+```
+
+## Practical Guidance
+
+- Use `environment` for genuinely dynamic environmental prose, not for every sentence.
+- Use `writing` when the text should be readable only to the right viewers; keep the alternate text natural enough that it still reads well in context.
+- Use `check` for small observational details, not for major information gates that should be handled by separate mechanics.
+- Prefer short, robust fallback text. Rooms should still read well when none of the specialised branches trigger.
+- Remember that builder help still says `minskill`, but the parser currently recognises `skill`.

--- a/Design Documents/Room_Description_Markup.md
+++ b/Design Documents/Room_Description_Markup.md
@@ -185,24 +185,19 @@ Current behaviour is:
 - if the viewer knows the language and script but lacks the required skill, the unreadable text is shown
 - if the alternate text is omitted, the engine uses `DefaultAlternateTextValue`
 
-#### Important Mismatch: `minskill` Versus `skill`
+#### `skill` and `minskill`
 
-Some builder help still says this syntax uses `minskill`.
+Current runtime now supports both attribute names:
 
-Current runtime parser truth is:
+- `skill`
+- `minskill`
 
-- the recognised attribute name is `skill`
-- `minskill` is not parsed
+They are treated as aliases and feed the same required-skill threshold.
 
-So this works:
+So both of these work:
 
 ```text
 writing{english,latin,skill=45}{readable text}{fallback text}
-```
-
-And this does not do what builder help claims:
-
-```text
 writing{english,latin,minskill=45}{readable text}{fallback text}
 ```
 
@@ -326,4 +321,4 @@ The painted board above the door reads @shop.
 - Use `writing` when the text should be readable only to the right viewers; keep the alternate text natural enough that it still reads well in context.
 - Use `check` for small observational details, not for major information gates that should be handled by separate mechanics.
 - Prefer short, robust fallback text. Rooms should still read well when none of the specialised branches trigger.
-- Remember that builder help still says `minskill`, but the parser currently recognises `skill`.
+- `skill` and `minskill` are both accepted for written-language thresholds.

--- a/FutureMUDLibrary Unit Tests/StringUtilitiesTests.cs
+++ b/FutureMUDLibrary Unit Tests/StringUtilitiesTests.cs
@@ -340,6 +340,46 @@ public class StringUtilitiesTests
     }
 
     [TestMethod]
+    public void SubstituteWrittenLanguage_MinSkillAlias_UsesAlternateText()
+    {
+        Mock<ITraitDefinition> traitDef = new();
+        Mock<ILanguage> language = new();
+        language.Setup(x => x.Name).Returns("lang");
+        language.Setup(x => x.LinkedTrait).Returns(traitDef.Object);
+        Mock<IScript> script = new();
+        script.Setup(x => x.Name).Returns("script");
+        script.Setup(x => x.KnownScriptDescription).Returns("known");
+        script.Setup(x => x.UnknownScriptDescription).Returns("unknown");
+        Mock<IUneditableAll<ILanguage>> langRepo = new();
+        langRepo.Setup(x => x.GetByName("lang")).Returns(language.Object);
+        Mock<IUneditableAll<IScript>> scriptRepo = new();
+        scriptRepo.Setup(x => x.GetByName("script")).Returns(script.Object);
+        Mock<IColour> colour = new();
+        colour.Setup(x => x.Name).Returns("white");
+        Mock<IUneditableAll<IColour>> colourRepo = new();
+        colourRepo.Setup(x => x.Get(0)).Returns(colour.Object);
+        Mock<IFuturemud> game = new();
+        game.Setup(x => x.Languages).Returns(langRepo.Object);
+        game.Setup(x => x.Scripts).Returns(scriptRepo.Object);
+        game.Setup(x => x.Colours).Returns(colourRepo.Object);
+        game.Setup(x => x.GetStaticInt("DefaultWritingStyleInText")).Returns(0);
+        game.Setup(x => x.GetStaticLong("DefaultWritingColourInText")).Returns(0);
+
+        Mock<ITrait> trait = new();
+        trait.Setup(x => x.Value).Returns(1);
+
+        Mock<ILanguagePerceiver> perceiver = new();
+        perceiver.Setup(x => x.Languages).Returns(new[] { language.Object });
+        perceiver.Setup(x => x.Scripts).Returns(new[] { script.Object });
+        perceiver.As<IHaveTraits>().Setup(x => x.GetTrait(traitDef.Object)).Returns(trait.Object);
+
+        const string input = "writing{lang,script,minskill>5}{hello}{alt}";
+        string result = input.SubstituteWrittenLanguage(perceiver.Object, game.Object);
+        Assert.IsTrue(result.Contains("alt", StringComparison.Ordinal));
+        Assert.IsTrue(result.Contains("Skill not high enough to understand.", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
     public void SubstituteWrittenLanguage_KnownScriptUnknownLanguage_UsesUnknownLanguageHint()
     {
         Mock<ILanguage> language = new();

--- a/FutureMUDLibrary/Framework/StringUtilities.cs
+++ b/FutureMUDLibrary/Framework/StringUtilities.cs
@@ -29,7 +29,7 @@ namespace MudSharp.Framework
         /// </summary>
         private static readonly Regex _substituteANSIColourRGBRegex = new(@"(?<=(?:##){0,})#`(?<red>[0-9]+);(?<green>[0-9]+);(?<blue>[0-9]+);", RegexOptions.IgnoreCase);
         private static readonly Regex _stripANSIRegex = new(@"\e\[(.*?)m");
-        // Form is: writing{language,script,style=???,colour=???,skill>???}{text if can understand}{optional text if can't understand}
+        // Form is: writing{language,script,style=???,colour=???,skill>???|minskill>???}{text if can understand}{optional text if can't understand}
         private static readonly Regex LanguageReplacementRegex = new(@"writing\{(?<details>[a-z0-9 ,><=\.\-]+)\}\{(?<text>[^}]+)\}(?:\{(?<alt>[^}]+)\}){0,1}", RegexOptions.IgnoreCase);
         private static readonly Regex LanguageReplacementAttributeRegex = new(@"(?<attr>[a-z0-9 \-]+)(?<operator>[=><]+)(?<value>[a-z0-9 -]+)", RegexOptions.IgnoreCase);
         private static readonly Regex CheckReplacementRegex = new(@"check\{(?<trait>[^,]+),(?<difficulty>[0-9\.\,]+)\}\{(?<text>[^}]+)\}(?:\{(?<alt>[^}]+)\}){0,1}", RegexOptions.IgnoreCase);
@@ -360,6 +360,7 @@ namespace MudSharp.Framework
                     switch (im.Groups["attr"].Value.ToLowerInvariant())
                     {
                         case "skill":
+                        case "minskill":
                             double.TryParse(im.Groups["value"].Value, out requiredSkill);
                             continue;
                         case "style":

--- a/FutureMUDLibrary/FutureProg/AGENTS.md
+++ b/FutureMUDLibrary/FutureProg/AGENTS.md
@@ -4,6 +4,7 @@
 
 ## Table of Contents
 - [Purpose and Scope](#purpose-and-scope)
+- [Text Markup Reference](#text-markup-reference)
 - [How FutureProg Fits Into FutureMUD](#how-futureprog-fits-into-futuremud)
   - [Engine integration points](#engine-integration-points)
   - [Lifecycle from authoring to execution](#lifecycle-from-authoring-to-execution)
@@ -83,6 +84,12 @@
 - [Additional Resources and Next Steps](#additional-resources-and-next-steps)
 
 ---
+
+## Text Markup Reference
+
+- [Emote System](../../Design%20Documents/Emote%20System.md)
+- [Character Description System](../../Design%20Documents/Character_Description_System.md)
+- [Room Description Markup](../../Design%20Documents/Room_Description_Markup.md)
 
 ## Purpose and Scope
 

--- a/MudSharpCore/AGENTS.md
+++ b/MudSharpCore/AGENTS.md
@@ -31,6 +31,11 @@ Implements the core FutureMUD game engine and console server handling gameplay, 
   * `../Design Documents/Economy_System_Seeder_State_and_Gaps.md`
 * This applies to changes in `MudSharpCore/Economy`, economy command modules, economy-related FutureProg functions, and economy-related game-item or effect integrations.
 
+## Text Markup Reference
+* [Emote System](../Design%20Documents/Emote%20System.md)
+* [Character Description System](../Design%20Documents/Character_Description_System.md)
+* [Room Description Markup](../Design%20Documents/Room_Description_Markup.md)
+
 ## Notes
 
 * All modules inherit both the solution-level and project-level rules unless explicitly overridden.

--- a/MudSharpCore/Commands/AGENTS.md
+++ b/MudSharpCore/Commands/AGENTS.md
@@ -34,6 +34,11 @@ It inherits from:
 - Avoid side-effecting pops inside LINQ predicates/selectors. Pop into a temporary variable first, or use Peek/PeekSpeech and then pop once when you intentionally advance the stack.
 - Regular expressions are allowed only when whole-input shape branching is substantially clearer than StringStack parsing.
 
+## Text Markup Reference
+- [Emote System](../../Design%20Documents/Emote%20System.md)
+- [Character Description System](../../Design%20Documents/Character_Description_System.md)
+- [Room Description Markup](../../Design%20Documents/Room_Description_Markup.md)
+
 
 ## Notes
 

--- a/MudSharpCore/Commands/Modules/RoomBuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/RoomBuilderModule.cs
@@ -2047,7 +2047,7 @@ You can use the following subcommands:
         sb.AppendLine();
         sb.AppendLine($"Your response should only use characters from the ISO-8859-1 page (i.e. Latin1). The engine uses a few special markup formats that you can employ if you choose, which help it dynamically parse for the situation at the time like current weather, literacy of the viewer etc. They are listed below.");
         sb.AppendLine();
-        sb.AppendLine(@$"Written Text: writing{{language,script,style=...,colour=...,minskill}}{{text if you understand}}{{text if you cant}}
+        sb.AppendLine(@$"Written Text: writing{{language,script,style=...,colour=...,skill|minskill}}{{text if you understand}}{{text if you cant}}
 {(actor.Location.Shop is not null ? "Name of the Shop at this location: @shop\n" : "")}Weather/Light/Time: environment{{conditions=text}}{{optional more conditions up to 8 times=text}}{{fallback if none triggered}}
 
 Conditions for 'environment' include:
@@ -3345,7 +3345,7 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
         sb.AppendLine(
             $"{"Check Skills/Attributes".ColourName()}: {"check{trait,minvalue}{text if the trait is >= value}{text if not}".ColourCommand()}");
         sb.AppendLine(
-            $"{"Written Text".ColourName()}: {"writing{language,script,style=...,colour=...,minskill}{text if you understand}{text if you cant}".ColourCommand()}");
+            $"{"Written Text".ColourName()}: {"writing{language,script,style=...,colour=...,skill|minskill}{text if you understand}{text if you cant}".ColourCommand()}");
         if (actor.Location.Shop is not null)
         {
             sb.AppendLine($"{"Shop Name".ColourName()}: {"@shop".ColourCommand()}");


### PR DESCRIPTION
## Summary
- Expanded the emote system doc into the canonical reference for engine and player emote markup.
- Added new design docs for character descriptions, human seeder description patterns, and room description markup.
- Added a shared `Text Markup Reference` hook to the relevant `AGENTS.md` files for easier lookup.

## Testing
- Not run (not requested)