### PR TITLE
Refactor clan command handling and fix elections

### DIFF
--- a/Design Documents/Clan_Command_Surface_and_Permissions.md
+++ b/Design Documents/Clan_Command_Surface_and_Permissions.md
@@ -1,0 +1,166 @@
+# Clan Command Surface and Permissions
+
+## Scope
+
+This document describes the intended runtime command architecture for clans after the clan command refactor, with an emphasis on:
+
+- moving player-facing clan operations onto `IClan` / `MudSharp.Community.Clan`;
+- keeping `ClanModule` as an intent router instead of a mega-command implementation;
+- making administrator short-circuit behaviour explicit; and
+- documenting how clan privileges, appointment authority, and vassal control interact.
+
+This document covers runtime command handling, not the full clan builder/edit surface.
+
+## Architectural Split
+
+The clan runtime now follows a thinner command-module pattern:
+
+- `MudSharpCore/Commands/Modules/ClanModule.cs`
+  - parses the top-level player intent;
+  - resolves the target clan from player-visible scope; and
+  - forwards the remaining argument stream to the clan entity.
+- `FutureMUDLibrary/Community/IClan.cs`
+  - exposes the clan-owned runtime command surface.
+- `MudSharpCore/Community/Clan.CommandHandling.cs`
+  - contains the concrete clan-owned implementations.
+- `MudSharpCore/Community/ClanCommandUtilities.cs`
+  - contains shared helper logic for appointment-chain authority, election helper selection, term-limit checks, and appointment-capacity calculations.
+
+The goal is that runtime operations which are fundamentally “things a clan does” live with the clan, rather than in a module that must manually re-implement clan rules for every subcommand.
+
+## Clan-Owned Runtime Commands
+
+The following runtime actions are now owned by `IClan` / `Clan`:
+
+- `Show`
+- `ShowMembers`
+- `DescribeElections`
+- `ShowElectionHistory`
+- `Nominate`
+- `WithdrawNomination`
+- `Vote`
+- `Appoint`
+- `Dismiss`
+- `SubmitControl`
+- `ReleaseControl`
+- `TransferControl`
+- `SetControllingAppointment`
+- `AppointExternal`
+- `DismissExternal`
+
+This is intentionally focused on operational clan behaviour. Builder-oriented commands that mutate multiple related entities or templates still live in `ClanModule` for now.
+
+## Permission Model
+
+### Administrator short-circuit
+
+Administrators at `PermissionLevel.Admin` are intended to bypass almost all runtime clan permission restrictions.
+
+That short-circuit now consistently applies to:
+
+- clan structure visibility;
+- member visibility;
+- election viewing;
+- direct appointment and dismissal;
+- vassal control management; and
+- external appointment management.
+
+Admin access is treated as authoritative override rather than just “another privilege flag”.
+
+### Membership privilege checks
+
+Normal clan authority is resolved from `IClanMembership.NetPrivileges`.
+
+Net privileges combine:
+
+- rank privileges; and
+- appointment privileges held by that membership.
+
+That means a character can gain runtime clan authority through rank, through appointment, or both.
+
+### Visibility privileges
+
+The command surface distinguishes between:
+
+- `CanViewMembers`
+- `CanViewClanOfficeHolders`
+- `CanViewClanStructure`
+- `CanViewClanStructureEqualRankOrLower`
+- `CanViewTreasury`
+
+The view logic now consistently uses those distinctions so that:
+
+- member rosters do not automatically imply full structure visibility;
+- office-holder visibility does not automatically imply financial visibility; and
+- lower-trust members can be limited to equal-or-lower-rank visibility when configured.
+
+### Appointment-chain authority
+
+Some clan actions are intentionally not pure privilege-flag checks.
+
+For appointment hierarchies, authority can also flow through the parent appointment chain. This is used for cases where a role may manage subordinate offices even if the actor does not hold a broad clan-management privilege.
+
+The shared helper is:
+
+- `ClanCommandUtilities.HoldsOrControlsAppointment`
+
+That rule is used in places such as:
+
+- direct appointment to subordinate positions;
+- direct dismissal from subordinate positions; and
+- appointment creation/edit flows that are restricted to “under own” authority.
+
+## External Control Permissions
+
+External clan control has two distinct authority models:
+
+- clan-level control via `CanManageClanVassals`; or
+- appointment-level control via a configured controlling appointment in the liege clan.
+
+If a control relationship has a controlling appointment configured, characters who hold that liege appointment are treated as authorised to manage the controlled vassal appointment, even without the broad vassal-management privilege.
+
+This is the core support for relationships such as:
+
+- a mayor appointing a chief of police in another clan;
+- a king appointing a duke or governor in a subordinate domain clan; or
+- a parent religious or military office appointing a subordinate office across organisational boundaries.
+
+## Runtime Commands for External Control
+
+### Submit
+
+`clan submit <clan> <position> <new liege> [<liege appointment>] [<max appointees>]`
+
+Creates an external-control relationship from the vassal clan to the liege clan.
+
+If a liege appointment is supplied, the control becomes appointment-scoped rather than only clan-scoped.
+
+### Vassal control
+
+`clan vassal control <clan> <position> <liege appointment|none> [<liege clan>]`
+
+Sets or clears the controlling appointment on an existing external-control relationship.
+
+This command is important because the runtime data model already supported controlling appointments, but the command surface previously did not expose a robust way to author or change them.
+
+### Vassal appoint / dismiss
+
+`clan vassal appoint <who> <clan> <position> [<liege clan>]`
+
+`clan vassal dismiss <who> <clan> <position> [<liege clan>]`
+
+These commands operate through the external-control relationship and obey either:
+
+- broad vassal-management authority; or
+- the configured controlling appointment.
+
+## Known Boundaries
+
+The refactor does not yet move the full clan builder/edit surface onto `IClan`. In particular, commands that are primarily administrative authoring tools still remain in `ClanModule`.
+
+That is intentional for now. The priority of this pass was:
+
+- operational runtime correctness;
+- permission consistency;
+- election and external-control reliability; and
+- reducing the amount of duplicated runtime rule logic in `ClanModule`.

--- a/Design Documents/Clan_Elections_and_External_Control.md
+++ b/Design Documents/Clan_Elections_and_External_Control.md
@@ -1,0 +1,181 @@
+# Clan Elections and External Control
+
+## Scope
+
+This document describes the current design of clan elections and external appointment control, including the key invariants that runtime code now enforces.
+
+## Election Model
+
+Election-backed appointments are represented by:
+
+- `IAppointment` / `Appointment`
+- `IElection` / `Election`
+
+Each election-backed appointment can have:
+
+- one primary open election for the regular term cycle; and
+- zero or more by-elections for unfilled positions.
+
+Shared election-selection helpers live in:
+
+- `MudSharpCore/Community/ClanCommandUtilities.cs`
+
+## Election Lifecycle
+
+The election lifecycle is:
+
+1. `Preelection`
+2. `Nomination`
+3. `Voting`
+4. `Preinstallation`
+5. `Finalised`
+
+The stage transitions are time-driven from the appointment configuration:
+
+- nomination period;
+- voting period;
+- election lead time; and
+- election term.
+
+The runtime now uses the correct period when announcing election start:
+
+- the nomination-start message reports `NominationPeriod`;
+- it no longer incorrectly reports `VotingPeriod`.
+
+## Nomination Eligibility
+
+Nomination eligibility is evaluated by `Appointment.CanNominate`.
+
+A nomination is allowed only if all of the following pass:
+
+- the nomination FutureProg, if any;
+- the maximum consecutive term rule, if configured; and
+- the maximum total term rule, if configured.
+
+The term-limit checks now use shared helper logic and correctly treat the total-term limit as inclusive:
+
+- reaching the configured maximum total terms blocks further nomination;
+- it is no longer possible to nominate for one extra term because of a strict `>` check.
+
+By-elections are ignored for the consecutive and total regular-term limit helpers.
+
+## Election Visibility and Voting
+
+Election display and command access use clan office-holder visibility rules.
+
+The refactor also fixes several runtime election bugs:
+
+- election history permission checks now use the intended logic instead of blocking valid non-admin viewers;
+- nomination, withdrawal, and voting command resolution correctly handles either election ids or clan-plus-appointment targeting;
+- actor/member lookups during election finalisation use `MemberId` rather than the membership object id;
+- secret-ballot display resolves dub data from the elected member id rather than the membership id.
+
+## Election Outcome Behaviour
+
+Election victors are determined from recorded votes at or after `Preinstallation`.
+
+Important behaviours:
+
+- nominees with no votes are not elected;
+- if fewer victors exist than positions, the runtime schedules a by-election;
+- if no nominees exist at voting start, the runtime finalises the empty election and creates a by-election;
+- by-elections remain separate from the regular term cycle.
+
+## External Control Model
+
+External control is represented by `IExternalClanControl` / `ExternalClanControl`.
+
+Each relationship has:
+
+- a `VassalClan`
+- a `LiegeClan`
+- a `ControlledAppointment` in the vassal clan
+- an optional `ControllingAppointment` in the liege clan
+- a maximum number of appointment slots granted to the liege clan
+- the list of current appointees occupying those granted slots
+
+This model supports both:
+
+- clan-wide liege authority; and
+- office-specific liege authority.
+
+## Supported Workflow
+
+### Create control
+
+Use:
+
+- `clan submit <clan> <position> <new liege> [<liege appointment>] [<max appointees>]`
+
+If the optional liege appointment is supplied, the control relationship becomes tied to that liege office.
+
+### Adjust controlling appointment
+
+Use:
+
+- `clan vassal control <clan> <position> <liege appointment|none> [<liege clan>]`
+
+This is the command path for setting or clearing appointment-scoped liege authority after the relationship already exists.
+
+### Appoint or dismiss through the relationship
+
+Use:
+
+- `clan vassal appoint ...`
+- `clan vassal dismiss ...`
+
+These commands only operate on characters who are actually within the relationship’s appointee set.
+
+## External Control Invariants
+
+### Ambiguity handling
+
+If multiple liege clans could match the same controlled appointment, the runtime requires the liege clan to be supplied explicitly.
+
+### Two-sided relationship cleanup
+
+External controls are referenced from both clans:
+
+- the vassal clan’s `ExternalControls`;
+- the liege clan’s `ExternalControls`.
+
+Release and transfer logic now removes the relationship from both sides instead of leaving stale references behind on the liege clan.
+
+### Appointee integrity
+
+External dismiss logic now verifies that the target membership is actually in the relationship’s `Appointees` list before mutating the database and clan state.
+
+This prevents removing arbitrary clan members from the appointment when they were not appointed through that specific external relationship.
+
+### Capacity accounting
+
+Appointment-capacity calculations must account for:
+
+- current in-clan holders of the appointment; and
+- unfilled appointment slots already reserved to liege clans.
+
+The shared capacity helper now enforces:
+
+- archived members do not count as active holders;
+- unrelated external-control relationships do not reserve capacity; and
+- already-filled external slots do not reserve extra capacity twice.
+
+This fixes a long-standing bug where capped appointments could appear to have free space when they did not.
+
+## Transfer Semantics
+
+`clan transfer` moves the control relationship to a new liege clan.
+
+The controlling appointment is not automatically rebound across clans, because a liege appointment id from the old liege clan is not valid in the new liege clan.
+
+After transfer, the new liege can use:
+
+- `clan vassal control ...`
+
+to bind the relationship to a new liege appointment if appointment-scoped authority is desired.
+
+## Remaining Practical Notes
+
+- Multi-word appointment names should be quoted when ambiguity is possible.
+- Multi-liege ambiguity should be resolved by supplying the liege clan explicitly.
+- The builder/editor surface for authoring clans is still partly module-owned, but runtime external-control behaviour is now documented and command-addressable.

--- a/FutureMUDLibrary/Community/IClan.cs
+++ b/FutureMUDLibrary/Community/IClan.cs
@@ -66,6 +66,21 @@ namespace MudSharp.Community
         void SetPaygrade(IClanMembership membership, IPaygrade newPaygrade);
         void RemoveMembership(IClanMembership membership);
         void DismissAppointment(IClanMembership membership, IAppointment appointment);
+        void Show(ICharacter actor, StringStack command);
+        void ShowMembers(ICharacter actor);
+        string DescribeElections(ICharacter actor);
+        void ShowElectionHistory(ICharacter actor, StringStack command);
+        void Nominate(ICharacter actor, StringStack command);
+        void WithdrawNomination(ICharacter actor, StringStack command);
+        void Vote(ICharacter actor, StringStack command);
+        void Appoint(ICharacter actor, StringStack command);
+        void Dismiss(ICharacter actor, StringStack command);
+        void SubmitControl(ICharacter actor, StringStack command);
+        void ReleaseControl(ICharacter actor, StringStack command);
+        void TransferControl(ICharacter actor, StringStack command);
+        void SetControllingAppointment(ICharacter actor, StringStack command);
+        void AppointExternal(ICharacter actor, StringStack command);
+        void DismissExternal(ICharacter actor, StringStack command);
 
         bool FreePosition(IAppointment appointment);
         bool FreePosition(IAppointment appointment, IClan liegeClan);

--- a/MudSharpCore Unit Tests/Community/ClanCommandUtilitiesTests.cs
+++ b/MudSharpCore Unit Tests/Community/ClanCommandUtilitiesTests.cs
@@ -1,0 +1,155 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Community;
+using MudSharp.TimeAndDate;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MudSharp_Unit_Tests.Community;
+
+[TestClass]
+public class ClanCommandUtilitiesTests
+{
+	[TestMethod]
+	public void HoldsOrControlsAppointment_WhenMembershipHoldsParentAppointment_ReturnsTrueForChildAppointment()
+	{
+		Mock<IAppointment> parent = new();
+		parent.SetupGet(x => x.ParentPosition).Returns((IAppointment)null);
+
+		Mock<IAppointment> child = new();
+		child.SetupGet(x => x.ParentPosition).Returns(parent.Object);
+
+		Mock<IClanMembership> membership = new();
+		membership.SetupGet(x => x.Appointments).Returns(new List<IAppointment> { parent.Object });
+
+		Assert.IsTrue(ClanCommandUtilities.HoldsOrControlsAppointment(membership.Object, child.Object));
+	}
+
+	[TestMethod]
+	public void HasReachedTotalTermLimit_WhenVictoriesMatchLimit_ReturnsTrue()
+	{
+		List<IElection> elections =
+		[
+			CreateElectionMock(isFinalised: true, isByElection: false, victorIds: [7]).Object,
+			CreateElectionMock(isFinalised: true, isByElection: false, victorIds: [7]).Object
+		];
+
+		Assert.IsTrue(ClanCommandUtilities.HasReachedTotalTermLimit(elections, 7, 2));
+	}
+
+	[TestMethod]
+	public void HasReachedConsecutiveTermLimit_IgnoresByElections_WhenLatestRegularTermsAreWins()
+	{
+		List<IElection> elections =
+		[
+			CreateElectionMock(isFinalised: true, isByElection: false, victorIds: [7]).Object,
+			CreateElectionMock(isFinalised: true, isByElection: true, victorIds: [99]).Object,
+			CreateElectionMock(isFinalised: true, isByElection: false, victorIds: [7]).Object
+		];
+
+		Assert.IsTrue(ClanCommandUtilities.HasReachedConsecutiveTermLimit(elections, 7, 2));
+	}
+
+	[TestMethod]
+	public void HasFreePosition_WhenInternalHoldersAndUnusedExternalReservationsFillCapacity_ReturnsFalse()
+	{
+		Mock<IClan> clan = new();
+
+		Mock<IAppointment> appointment = new();
+		appointment.SetupGet(x => x.Clan).Returns(clan.Object);
+		appointment.SetupGet(x => x.MaximumSimultaneousHolders).Returns(2);
+
+		List<IClanMembership> memberships =
+		[
+			CreateMembershipMock(1, false, appointment.Object).Object
+		];
+
+		List<IExternalClanControl> externalControls =
+		[
+			CreateExternalControlMock(clan.Object, appointment.Object, numberOfAppointments: 1, appointeeCount: 0).Object
+		];
+
+		Assert.IsFalse(ClanCommandUtilities.HasFreePosition(appointment.Object, memberships, externalControls));
+	}
+
+	[TestMethod]
+	public void HasFreePosition_IgnoresArchivedMembersOtherAppointmentsAndFilledReservations()
+	{
+		Mock<IClan> clan = new();
+
+		Mock<IAppointment> appointment = new();
+		appointment.SetupGet(x => x.Clan).Returns(clan.Object);
+		appointment.SetupGet(x => x.MaximumSimultaneousHolders).Returns(3);
+
+		Mock<IAppointment> otherAppointment = new();
+		otherAppointment.SetupGet(x => x.Clan).Returns(clan.Object);
+
+		List<IClanMembership> memberships =
+		[
+			CreateMembershipMock(1, false, appointment.Object).Object,
+			CreateMembershipMock(2, true, appointment.Object).Object
+		];
+
+		List<IExternalClanControl> externalControls =
+		[
+			CreateExternalControlMock(clan.Object, appointment.Object, numberOfAppointments: 1, appointeeCount: 1).Object,
+			CreateExternalControlMock(clan.Object, otherAppointment.Object, numberOfAppointments: 5, appointeeCount: 0).Object
+		];
+
+		Assert.IsTrue(ClanCommandUtilities.HasFreePosition(appointment.Object, memberships, externalControls));
+	}
+
+	[TestMethod]
+	public void OpenElectionHelpers_ReturnExpectedOpenElections()
+	{
+		Mock<IAppointment> appointment = new();
+		Mock<IElection> primaryOpen = CreateElectionMock(isFinalised: false, isByElection: false);
+		Mock<IElection> byElectionOpen = CreateElectionMock(isFinalised: false, isByElection: true);
+		Mock<IElection> finalisedPrimary = CreateElectionMock(isFinalised: true, isByElection: false);
+
+		appointment.SetupGet(x => x.Elections).Returns(
+			[
+				primaryOpen.Object,
+				byElectionOpen.Object,
+				finalisedPrimary.Object
+			]);
+
+		Assert.AreSame(primaryOpen.Object, ClanCommandUtilities.GetPrimaryOpenElection(appointment.Object));
+		Assert.AreSame(byElectionOpen.Object, ClanCommandUtilities.GetFirstOpenByElection(appointment.Object));
+		Assert.AreSame(primaryOpen.Object, ClanCommandUtilities.GetNextOpenElection(appointment.Object));
+	}
+
+	private static Mock<IClanMembership> CreateMembershipMock(long memberId, bool isArchivedMembership,
+		params IAppointment[] appointments)
+	{
+		Mock<IClanMembership> membership = new();
+		membership.SetupGet(x => x.MemberId).Returns(memberId);
+		membership.SetupGet(x => x.IsArchivedMembership).Returns(isArchivedMembership);
+		membership.SetupGet(x => x.Appointments).Returns(appointments.ToList());
+		return membership;
+	}
+
+	private static Mock<IExternalClanControl> CreateExternalControlMock(IClan vassalClan, IAppointment appointment,
+		int numberOfAppointments, int appointeeCount)
+	{
+		Mock<IExternalClanControl> control = new();
+		control.SetupGet(x => x.VassalClan).Returns(vassalClan);
+		control.SetupGet(x => x.ControlledAppointment).Returns(appointment);
+		control.SetupGet(x => x.NumberOfAppointments).Returns(numberOfAppointments);
+		control.SetupGet(x => x.Appointees).Returns(
+			Enumerable.Range(0, appointeeCount)
+			          .Select(x => CreateMembershipMock(x + 100, false).Object)
+			          .ToList());
+		return control;
+	}
+
+	private static Mock<IElection> CreateElectionMock(bool isFinalised, bool isByElection, params long[] victorIds)
+	{
+		Mock<IElection> election = new();
+		election.SetupGet(x => x.IsFinalised).Returns(isFinalised);
+		election.SetupGet(x => x.IsByElection).Returns(isByElection);
+		election.SetupGet(x => x.ResultsInEffectDate).Returns((MudDateTime)null);
+		election.SetupGet(x => x.Victors).Returns(victorIds.Select(x => CreateMembershipMock(x, false).Object).ToList());
+		return election;
+	}
+}

--- a/MudSharpCore/Commands/Modules/ClanModule.cs
+++ b/MudSharpCore/Commands/Modules/ClanModule.cs
@@ -83,7 +83,7 @@ public class ClanModule : Module<ICharacter>
             clans = actor.ClanMemberships.Select(x => x.Clan);
             if (includeTemplatesForPlayers)
             {
-                clans.Concat(actor.Gameworld.Clans.Where(x => x.IsTemplate));
+                clans = clans.Concat(actor.Gameworld.Clans.Where(x => x.IsTemplate));
             }
         }
 
@@ -99,6 +99,31 @@ public class ClanModule : Module<ICharacter>
             clans.FirstOrDefault(x => x.Alias.EqualTo(targetText)) ??
             clans.FirstOrDefault(x => x.Alias.StartsWith(targetText, StringComparison.InvariantCultureIgnoreCase)) ??
             clans.FirstOrDefault(x => x.FullName.StartsWith(targetText, StringComparison.InvariantCultureIgnoreCase));
+    }
+
+    private static IEnumerable<IClan> GetExternallyAccessibleClans(ICharacter actor)
+    {
+        if (actor.IsAdministrator(PermissionLevel.Admin))
+        {
+            return actor.Gameworld.Clans;
+        }
+
+        return actor.ClanMemberships
+                    .Select(x => x.Clan)
+                    .Concat(
+                        actor.ClanMemberships.SelectMany(
+                            x => x.Clan.ExternalControls.Where(y => y.LiegeClan == x.Clan).Select(y => y.VassalClan)))
+                    .Distinct()
+                    .ToList();
+    }
+
+    private static IClan? GetTargetExternallyAccessibleClan(ICharacter actor, string targetText)
+    {
+        var clans = GetExternallyAccessibleClans(actor).ToList();
+        return clans.FirstOrDefault(x => x.FullName.EqualTo(targetText)) ??
+               clans.FirstOrDefault(x => x.Alias.EqualTo(targetText)) ??
+               clans.FirstOrDefault(x => x.Alias.StartsWith(targetText, StringComparison.InvariantCultureIgnoreCase)) ??
+               clans.FirstOrDefault(x => x.FullName.StartsWith(targetText, StringComparison.InvariantCultureIgnoreCase));
     }
 
     public const string ClanHelpText =
@@ -134,9 +159,10 @@ The following clan sub-commands are used to interact with clans:
 	#3clan members <clan>#0 - views the member list for a clan
 	#3clan treasury <clan>#0 - sets your current location as a treasury cell for a clan (ADMIN ONLY)
 	#3clan admin <clan>#0 - sets your current location as an admin cell for a clan (ADMIN ONLY)
-	#3clan vassal appoint <who> <clan> <position>#0 - appoints a person to a clan appointment in a vassal clan
-	#3clan vassal dismiss <who> <clan> <position>#0 - dismisses a person from a clan appointment in a vassal clan
-	#3clan submit <clan> <position> <new liege>#0 - submits a clan appointment to the control of an external clan
+	#3clan vassal appoint <who> <clan> <position> [<liege clan>]#0 - appoints a person to a clan appointment in a vassal clan
+	#3clan vassal dismiss <who> <clan> <position> [<liege clan>]#0 - dismisses a person from a clan appointment in a vassal clan
+	#3clan vassal control <clan> <position> <liege appointment|none> [<liege clan>]#0 - sets which liege appointment controls a vassal appointment
+	#3clan submit <clan> <position> <new liege> [<liege appointment>] [<max appointees>]#0 - submits a clan appointment to the control of an external clan
 	#3clan release <vassal clan> <position> [<liege clan>]#0 - releases a vassal clan from your clan's control
 	#3clan transfer <vassal clan> <position> <new liege> [<old liege>]#0 - transfers a vassal clan relationship to a new clan
 	#3clan disband <clan>#0 - permanently disbands and deletes a clan - warning, cannot be undone
@@ -527,7 +553,7 @@ All of the following commands must happen with an edited clan selected:
             TimeSpan ts = TimeSpan.FromDays(30);
             sb.AppendLine(StringUtilities.GetTextTable(
             from clan in clans
-            let membership = actor.ClanMemberships.FirstOrDefault(x => x.MemberCharacter == actor)
+            let membership = actor.ClanMemberships.FirstOrDefault(x => x.Clan == clan)
             select new List<string>
             {
                 clan.Id.ToString("N0", actor),
@@ -560,7 +586,7 @@ All of the following commands must happen with an edited clan selected:
         {
             sb.AppendLine(StringUtilities.GetTextTable(
             from clan in clans
-            let membership = actor.ClanMemberships.FirstOrDefault(x => x.MemberCharacter == actor)
+            let membership = actor.ClanMemberships.FirstOrDefault(x => x.Clan == clan)
             select new List<string>
             {
                 clan.Id.ToString("N0", actor),
@@ -1325,7 +1351,7 @@ All of the following commands must happen with an edited clan selected:
 
         List<WitnessedClanMemberDeath> effects = actor.CombinedEffectsOfType<WitnessedClanMemberDeath>().Where(x => x.Clan == clan).ToList();
         List<IClanMembership> effectMemberships = effects
-                                .SelectNotNull(x => x.ClanMember.ClanMemberships.FirstOrDefault(x => x.Clan == x.Clan))
+                                .SelectNotNull(x => x.ClanMember.ClanMemberships.FirstOrDefault(y => y.Clan == x.Clan))
                                 .ToList();
 
         if (ss.IsFinished)
@@ -1436,80 +1462,35 @@ All of the following commands must happen with an edited clan selected:
             return;
         }
 
-        IElection election;
-        if (long.TryParse(ss.PopSpeech(), out long value))
+        var firstArg = ss.PopSpeech();
+        if (long.TryParse(firstArg, out var value))
         {
-            election = actor.Gameworld.Elections.Get(value);
-            if (election == null || !actor.ClanMemberships.Any(x => x.Clan == election.Appointment.Clan))
+            var election = actor.Gameworld.Elections.Get(value);
+            if (election == null || (!actor.IsAdministrator() && !actor.ClanMemberships.Any(x => x.Clan == election.Appointment.Clan)))
             {
                 actor.OutputHandler.Send("There is no such election in any of your clans.");
                 return;
             }
-        }
-        else
-        {
-            List<IClan> clans = actor.ClanMemberships.Select(x => x.Clan).ToList();
-            string text = ss.PopSpeech();
-            IClan clan = clans.GetClan(text);
-            if (clan == null)
-            {
-                actor.OutputHandler.Send("You are not a member of any such clan.");
-                return;
-            }
 
-            if (ss.IsFinished)
-            {
-                actor.OutputHandler.Send(
-                    $"Which position within {clan.FullName.ColourName()} do you want to withdraw your nomination from?");
-                return;
-            }
-
-            IAppointment appointment = clan.Appointments.FirstOrDefault(x => x.Name.EqualTo(text)) ??
-                              clan.Appointments.FirstOrDefault(x =>
-                                  x.Name.StartsWith(text, StringComparison.InvariantCultureIgnoreCase));
-            if (appointment == null)
-            {
-                actor.OutputHandler.Send($"{clan.FullName.ColourName()} has no such appointment.");
-                return;
-            }
-
-            if (!appointment.IsAppointedByElection)
-            {
-                actor.OutputHandler.Send(
-                    $"The position {appointment.Name.ColourName()} is not controlled by elections.");
-                return;
-            }
-
-            election = appointment.Elections.Where(x => !x.IsFinalised).OrderBy(x => x.ResultsInEffectDate)
-                                  .FirstOrDefault();
-        }
-
-        switch (election.ElectionStage)
-        {
-            case ElectionStage.Preelection:
-                actor.OutputHandler.Send(
-                    $"The nomination period for the election of {election.Appointment.Title(actor).ColourName()} in {election.Appointment.Clan.FullName.ColourName()} will not begin until {election.NominationStartDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}.");
-                return;
-            case ElectionStage.Nomination:
-                break;
-            case ElectionStage.Voting:
-            case ElectionStage.Preinstallation:
-            case ElectionStage.Finalised:
-                actor.OutputHandler.Send(
-                    $"The nomination period for the election of {election.Appointment.Title(actor).ColourName()} in {election.Appointment.Clan.FullName.ColourName()} has closed.");
-                return;
-        }
-
-        if (!election.Nominees.Any(x => x.MemberId == actor.Id))
-        {
-            actor.OutputHandler.Send(
-                $"You are not a candidate for the election of {election.Appointment.Title(actor).ColourName()} in {election.Appointment.Clan.FullName.ColourName()}.");
+            election.Appointment.Clan.WithdrawNomination(actor, new StringStack(firstArg));
             return;
         }
 
-        election.WithdrawNomination(actor.ClanMemberships.First(x => x.Clan == election.Appointment.Clan));
-        actor.OutputHandler.Send(
-            $"You have withdrawn your candidacy for the election of {election.Appointment.Title(actor).ColourName()} in {election.Appointment.Clan.FullName.ColourName()}.");
+        var clan = actor.ClanMemberships.Select(x => x.Clan).GetClan(firstArg);
+        if (clan == null)
+        {
+            actor.OutputHandler.Send("You are not a member of any such clan.");
+            return;
+        }
+
+        if (ss.IsFinished)
+        {
+            actor.OutputHandler.Send(
+                $"Which position within {clan.FullName.ColourName()} do you want to withdraw your nomination from?");
+            return;
+        }
+
+        clan.WithdrawNomination(actor, ss);
     }
 
     private static void ClanNominate(ICharacter actor, StringStack ss)
@@ -1521,80 +1502,35 @@ All of the following commands must happen with an edited clan selected:
             return;
         }
 
-        IElection election;
-        if (long.TryParse(ss.PopSpeech(), out long value))
+        var firstArg = ss.PopSpeech();
+        if (long.TryParse(firstArg, out var value))
         {
-            election = actor.Gameworld.Elections.Get(value);
-            if (election == null || !actor.ClanMemberships.Any(x => x.Clan == election.Appointment.Clan))
+            var election = actor.Gameworld.Elections.Get(value);
+            if (election == null || (!actor.IsAdministrator() && !actor.ClanMemberships.Any(x => x.Clan == election.Appointment.Clan)))
             {
                 actor.OutputHandler.Send("There is no such election in any of your clans.");
                 return;
             }
-        }
-        else
-        {
-            List<IClan> clans = actor.ClanMemberships.Select(x => x.Clan).ToList();
-            string text = ss.Last;
-            IClan clan = clans.GetClan(text);
-            if (clan == null)
-            {
-                actor.OutputHandler.Send("You are not a member of any such clan.");
-                return;
-            }
 
-            if (ss.IsFinished)
-            {
-                actor.OutputHandler.Send(
-                    $"Which position within {clan.FullName.ColourName()} do you want to nominate yourself for?");
-                return;
-            }
-
-            IAppointment appointment = clan.Appointments.FirstOrDefault(x => x.Name.EqualTo(text)) ??
-                              clan.Appointments.FirstOrDefault(x =>
-                                  x.Name.StartsWith(text, StringComparison.InvariantCultureIgnoreCase));
-            if (appointment == null)
-            {
-                actor.OutputHandler.Send($"{clan.FullName.ColourName()} has no such appointment.");
-                return;
-            }
-
-            if (!appointment.IsAppointedByElection)
-            {
-                actor.OutputHandler.Send(
-                    $"The position {appointment.Name.ColourName()} is not controlled by elections.");
-                return;
-            }
-
-            election = appointment.Elections.Where(x => !x.IsFinalised).OrderBy(x => x.ResultsInEffectDate)
-                                  .FirstOrDefault();
-        }
-
-        switch (election.ElectionStage)
-        {
-            case ElectionStage.Preelection:
-                actor.OutputHandler.Send(
-                    $"The nomination period for the election of {election.Appointment.Title(actor).ColourName()} in {election.Appointment.Clan.FullName.ColourName()} will not begin until {election.NominationStartDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}.");
-                return;
-            case ElectionStage.Nomination:
-                break;
-            case ElectionStage.Voting:
-            case ElectionStage.Preinstallation:
-            case ElectionStage.Finalised:
-                actor.OutputHandler.Send(
-                    $"The nomination period for the election of {election.Appointment.Title(actor).ColourName()} in {election.Appointment.Clan.FullName.ColourName()} has closed.");
-                return;
-        }
-
-        (bool truth, string error) = election.Appointment.CanNominate(actor);
-        if (!truth)
-        {
-            actor.OutputHandler.Send(error);
+            election.Appointment.Clan.Nominate(actor, new StringStack(firstArg));
             return;
         }
 
-        election.Nominate(actor.ClanMemberships.First(x => x.Clan == election.Appointment.Clan));
-        actor.OutputHandler.Send(
-            $"You nominate yourself as a candidate for the position of {election.Appointment.Title(actor).ColourName()} in {election.Appointment.Clan.FullName.ColourName()}.");
+        var clan = actor.ClanMemberships.Select(x => x.Clan).GetClan(firstArg);
+        if (clan == null)
+        {
+            actor.OutputHandler.Send("You are not a member of any such clan.");
+            return;
+        }
+
+        if (ss.IsFinished)
+        {
+            actor.OutputHandler.Send(
+                $"Which position within {clan.FullName.ColourName()} do you want to nominate yourself for?");
+            return;
+        }
+
+        clan.Nominate(actor, ss);
     }
 
     private static void ClanVote(ICharacter actor, StringStack ss)
@@ -1606,136 +1542,35 @@ All of the following commands must happen with an edited clan selected:
             return;
         }
 
-        IElection election;
-        if (long.TryParse(ss.PopSpeech(), out long value))
+        var firstArg = ss.PopSpeech();
+        if (long.TryParse(firstArg, out var value))
         {
-            election = actor.Gameworld.Elections.Get(value);
-            if (election == null || !actor.ClanMemberships.Any(x => x.Clan == election.Appointment.Clan))
+            var election = actor.Gameworld.Elections.Get(value);
+            if (election == null || (!actor.IsAdministrator() && !actor.ClanMemberships.Any(x => x.Clan == election.Appointment.Clan)))
             {
                 actor.OutputHandler.Send("There is no such election in any of your clans.");
                 return;
             }
-        }
-        else
-        {
-            List<IClan> clans = actor.ClanMemberships.Select(x => x.Clan).ToList();
-            string text = ss.Last;
-            IClan clan = clans.GetClan(text);
-            if (clan == null)
-            {
-                actor.OutputHandler.Send("You are not a member of any such clan.");
-                return;
-            }
 
-            if (ss.IsFinished)
-            {
-                actor.OutputHandler.Send(
-                    $"Which position within {clan.FullName.ColourName()} do you want to vote for?");
-                return;
-            }
-
-            IAppointment appointment = clan.Appointments.FirstOrDefault(x => x.Name.EqualTo(text)) ??
-                              clan.Appointments.FirstOrDefault(x =>
-                                  x.Name.StartsWith(text, StringComparison.InvariantCultureIgnoreCase));
-            if (appointment == null)
-            {
-                actor.OutputHandler.Send($"{clan.FullName.ColourName()} has no such appointment.");
-                return;
-            }
-
-            if (!appointment.IsAppointedByElection)
-            {
-                actor.OutputHandler.Send(
-                    $"The position {appointment.Name.ColourName()} is not controlled by elections.");
-                return;
-            }
-
-            election = appointment.Elections.Where(x => !x.IsFinalised).OrderBy(x => x.ResultsInEffectDate)
-                                  .FirstOrDefault();
+            election.Appointment.Clan.Vote(actor, new StringStack($"{firstArg} {ss.RemainingArgument}".Trim()));
+            return;
         }
 
-        switch (election.ElectionStage)
+        var clan = actor.ClanMemberships.Select(x => x.Clan).GetClan(firstArg);
+        if (clan == null)
         {
-            case ElectionStage.Preelection:
-            case ElectionStage.Nomination:
-                actor.OutputHandler.Send(
-                    $"The voting period for the election of {election.Appointment.Name.ColourName()} in {election.Appointment.Clan.FullName.ColourName()} will not begin until {election.VotingStartDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}.");
-                return;
-            case ElectionStage.Voting:
-                break;
-            case ElectionStage.Preinstallation:
-            case ElectionStage.Finalised:
-                actor.OutputHandler.Send(
-                    $"The voting period for the election of {election.Appointment.Name.ColourName()} in {election.Appointment.Clan.FullName.ColourName()} has closed.");
-                return;
-        }
-
-        int votes = election.Appointment.NumberOfVotes(actor);
-        if (votes <= 0)
-        {
-            actor.OutputHandler.Send(
-                $"You are not entitled to vote in the election of {election.Appointment.Name.ColourName()} in {election.Appointment.Clan.FullName.ColourName()}.");
+            actor.OutputHandler.Send("You are not a member of any such clan.");
             return;
         }
 
         if (ss.IsFinished)
         {
-            StringBuilder sb = new();
-            sb.AppendLine(
-                "Which nominee do you want to cast your vote for? There are the following nominations for this position:");
-            sb.AppendLine();
-            foreach (IClanMembership nominee in election.Nominees)
-            {
-                IDub dub = actor.Dubs.FirstOrDefault(x =>
-                    x.FrameworkItemType == "Character" && x.TargetId == nominee.MemberId && !x.WasIdentityConcealed);
-                if (dub != null)
-                {
-                    sb.AppendLine(
-                        $"\t{nominee.PersonalName.GetName(NameStyle.FullName)} ({dub.LastDescription.ColourCharacter()})");
-                }
-                else
-                {
-                    sb.AppendLine($"\t{nominee.PersonalName.GetName(NameStyle.FullName)}");
-                }
-            }
-
-            actor.OutputHandler.Send(sb.ToString());
+            actor.OutputHandler.Send(
+                $"Which position within {clan.FullName.ColourName()} do you want to vote for?");
             return;
         }
 
-        IPersonalName nomineeName = election.Nominees.Select(x => x.PersonalName).GetName(ss.SafeRemainingArgument);
-        if (nomineeName == null)
-        {
-            StringBuilder sb = new();
-            sb.AppendLine(
-                $"The supplied name is not a valid candidate in the election for {election.Appointment.Name.ColourName()} in {election.Appointment.Clan.FullName.ColourName()}.");
-            sb.AppendLine("There are the following nominations for this position:");
-            sb.AppendLine();
-            foreach (IClanMembership nominee in election.Nominees)
-            {
-                IDub dub = actor.Dubs.FirstOrDefault(x =>
-                    x.FrameworkItemType == "Character" && x.TargetId == nominee.MemberId && !x.WasIdentityConcealed);
-                if (dub != null)
-                {
-                    sb.AppendLine(
-                        $"\t{nominee.PersonalName.GetName(NameStyle.FullName)} ({dub.LastDescription.ColourCharacter()})");
-                }
-                else
-                {
-                    sb.AppendLine($"\t{nominee.PersonalName.GetName(NameStyle.FullName)}");
-                }
-            }
-
-            actor.OutputHandler.Send(sb.ToString());
-            return;
-        }
-
-        IClanMembership voteChoice = election.Nominees.First(x => x.PersonalName == nomineeName);
-        string verb = election.Votes.Any(x => x.Voter.MemberId == actor.Id) ? "change" : "cast";
-        string particle = election.Votes.Any(x => x.Voter.MemberId == actor.Id) ? "to" : "for";
-        election.Vote(actor.ClanMemberships.First(x => x.Clan == election.Appointment.Clan), voteChoice, votes);
-        actor.OutputHandler.Send(
-            $"You {verb} your {(votes == 1 ? "vote" : $"{votes.ToString("N0", actor)} votes")} in the election for {election.Appointment.Name.ColourName()} in {election.Appointment.Clan.FullName.ColourName()} {particle} {nomineeName.GetName(NameStyle.FullName)}.");
+        clan.Vote(actor, ss);
     }
 
     private static void ClanElections(ICharacter actor, StringStack ss)
@@ -1757,15 +1592,11 @@ All of the following commands must happen with an edited clan selected:
                 return;
             }
 
-            if (!actor.IsAdministrator() && !actor.ClanMemberships.First(x => x.Clan == clan).NetPrivileges
-                                                  .HasFlag(ClanPrivilegeType.CanViewClanOfficeHolders))
-            {
-                actor.OutputHandler.Send(
-                    $"You do not have sufficient privileges in {clan.FullName.ColourName()} to view elections.");
-                return;
-            }
-
-            clans = new List<IClan> { clan };
+            string description = clan.DescribeElections(actor);
+            actor.OutputHandler.Send(string.IsNullOrWhiteSpace(description)
+                ? $"There are no elections in {clan.FullName.ColourName()}."
+                : description);
+            return;
         }
 
         if (!actor.IsAdministrator())
@@ -1778,96 +1609,13 @@ All of the following commands must happen with an edited clan selected:
         StringBuilder sb = new();
         foreach (IClan clan in clans)
         {
-            List<IAppointment> appointmentsWithElections = clan.Appointments.Where(x => x.IsAppointedByElection).ToList();
-            if (!appointmentsWithElections.Any())
+            string description = clan.DescribeElections(actor);
+            if (string.IsNullOrWhiteSpace(description))
             {
                 continue;
             }
 
-            sb.AppendLine($"Elections in {clan.FullName}".GetLineWithTitle(actor.LineFormatLength,
-                actor.Account.UseUnicode, Telnet.BoldBlue, Telnet.BoldWhite));
-            foreach (IAppointment appointment in appointmentsWithElections)
-            {
-                sb.AppendLine();
-                sb.AppendLine(
-                    $"The {appointment.Name.ColourName()} position elects {appointment.MaximumSimultaneousHolders.ToString("N0", actor).ColourValue()} positions every {appointment.ElectionTerm.Describe(actor).ColourValue()}.");
-                if (appointment.MaximumConsecutiveTerms <= 0 && appointment.MaximumTotalTerms <= 0)
-                {
-                    sb.AppendLine("There are no term limits for electors.");
-                }
-                else if (appointment.MaximumConsecutiveTerms <= 0)
-                {
-                    sb.AppendLine(
-                        $"There is a life-time term limit of {appointment.MaximumTotalTerms.ToString("N0", actor).ColourValue()} term{(appointment.MaximumTotalTerms == 1 ? "" : "s")}.");
-                }
-                else if (appointment.MaximumTotalTerms <= 0)
-                {
-                    sb.AppendLine(
-                        $"There is a term limit of {appointment.MaximumConsecutiveTerms.ToString("N0", actor).ColourValue()} consecutive {(appointment.MaximumConsecutiveTerms == 1 ? "term" : "terms")}.");
-                }
-                else
-                {
-                    sb.AppendLine(
-                        $"There is a life-time term limit of {appointment.MaximumTotalTerms.ToString("N0", actor).ColourValue()} term{(appointment.MaximumTotalTerms == 1 ? "" : "s")} and/or {appointment.MaximumConsecutiveTerms.ToString("N0", actor).ColourValue()} consecutive {(appointment.MaximumConsecutiveTerms == 1 ? "term" : "terms")}.");
-                }
-
-                if (appointment.IsSecretBallot)
-                {
-                    sb.AppendLine($"This is a secret ballot.");
-                }
-                else
-                {
-                    sb.AppendLine($"This is an open ballot and all votes cast are public.");
-                }
-
-                int votes = appointment.NumberOfVotes(actor);
-                sb.AppendLine(
-                    $"You {(appointment.CanNominate(actor).Truth ? "are" : "are not")} eligable to nominate and {(votes <= 0 ? "cannot vote" : $"have {votes.ToString("N0", actor).ColourValue()} vote{(votes == 1 ? "" : "s")}")} in elections for this position.");
-
-                List<IElection> openElections = appointment.Elections.Where(x => !x.IsFinalised).OrderBy(x => x.ResultsInEffectDate)
-                                               .ToList();
-                IElection mainElection = openElections.First(x => !x.IsByElection);
-
-                if (openElections.Count(x => x.IsByElection) > 1)
-                {
-                    IElection byElection = openElections.First(x => x.IsByElection);
-                    switch (byElection.ElectionStage)
-                    {
-                        case ElectionStage.Preelection:
-                            sb.AppendLine(
-                                $"By-election #{byElection.Id.ToString("N0", actor)} for {byElection.NumberOfAppointments.ToString("N0", actor).ColourValue()} {(byElection.NumberOfAppointments == 1 ? "position" : "positions")} opening for nominations on {byElection.NominationStartDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}.");
-                            break;
-                        case ElectionStage.Nomination:
-                            sb.AppendLine(
-                                $"By-election #{byElection.Id.ToString("N0", actor)} for {byElection.NumberOfAppointments.ToString("N0", actor).ColourValue()} {(byElection.NumberOfAppointments == 1 ? "position" : "positions")} is open for nominations, with voting commencing on {byElection.VotingStartDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}.");
-                            break;
-                        case ElectionStage.Voting:
-                            sb.AppendLine(
-                                $"By-election #{byElection.Id.ToString("N0", actor)} for {byElection.NumberOfAppointments.ToString("N0", actor).ColourValue()} {(byElection.NumberOfAppointments == 1 ? "position" : "positions")} is open for voting, with votes closing on {byElection.VotingEndDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}.");
-                            break;
-                    }
-                }
-
-                switch (mainElection.ElectionStage)
-                {
-                    case ElectionStage.Preelection:
-                        sb.AppendLine(
-                            $"The next election will open for nominations on {mainElection.NominationStartDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}.");
-                        break;
-                    case ElectionStage.Nomination:
-                        sb.AppendLine(
-                            $"Election #{mainElection.Id.ToString("N0", actor)} is open for nominations, with voting commencing on {mainElection.VotingStartDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}.");
-                        break;
-                    case ElectionStage.Voting:
-                        sb.AppendLine(
-                            $"Election #{mainElection.Id.ToString("N0", actor)} is open for voting, with votes closing on {mainElection.VotingEndDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}.");
-                        break;
-                    case ElectionStage.Preinstallation:
-                        sb.AppendLine(
-                            $"Election #{mainElection.Id.ToString("N0", actor)} has finished and the elected will commence their terms on {mainElection.ResultsInEffectDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}.");
-                        break;
-                }
-            }
+            sb.Append(description);
         }
 
         if (sb.Length == 0)
@@ -1937,85 +1685,7 @@ All of the following commands must happen with an edited clan selected:
             return;
         }
 
-        if (!actor.IsAdministrator() ||
-            actor.ClanMemberships.All(x => !x.NetPrivileges.HasFlag(ClanPrivilegeType.CanViewClanOfficeHolders)))
-        {
-            actor.OutputHandler.Send($"You are not authorised to view elections in {clan.FullName.ColourName()}.");
-            return;
-        }
-
-        if (clan.Appointments.All(x => !x.IsAppointedByElection))
-        {
-            actor.OutputHandler.Send($"{clan.FullName.ColourName()} does not have elections for any positions.");
-            return;
-        }
-
-        List<IAppointment> appointments = clan.Appointments.Where(x => x.IsAppointedByElection).ToList();
-        if (!ss.IsFinished)
-        {
-            string text = ss.PopSpeech();
-            IAppointment appointment = clan.Appointments.FirstOrDefault(x => x.Name.EqualTo(text)) ??
-                              clan.Appointments.FirstOrDefault(x =>
-                                  x.Name.StartsWith(text, StringComparison.InvariantCultureIgnoreCase));
-            if (appointment == null)
-            {
-                actor.OutputHandler.Send($"{clan.FullName.ColourName()} has no such appointment.");
-                return;
-            }
-
-            if (!appointment.IsAppointedByElection)
-            {
-                actor.OutputHandler.Send(
-                    $"The position {appointment.Name.ColourName()} is not controlled by elections.");
-                return;
-            }
-
-            appointments.Clear();
-            appointments.Add(appointment);
-        }
-
-        StringBuilder sb = new();
-        foreach (IAppointment appointment in appointments)
-        {
-            if (sb.Length > 0)
-            {
-                sb.AppendLine();
-            }
-
-            sb.AppendLine(
-                $"Election history for the {appointment.Name.ColourName()} position in {clan.FullName.ColourName()}:");
-            sb.AppendLine();
-            foreach (IElection election in appointment.Elections.OrderByDescending(x => x.ResultsInEffectDate))
-            {
-                sb.Append(
-                    $"#{election.Id.ToString("N0", actor)}) {(election.IsByElection ? $"By-Election" : "Primary election")} of {election.NumberOfAppointments.ToString("N0", actor)} positions");
-                switch (election.ElectionStage)
-                {
-                    case ElectionStage.Preelection:
-                        sb.AppendLine(
-                            $" due to begin {election.NominationStartDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}");
-                        break;
-                    case ElectionStage.Nomination:
-                        sb.AppendLine(
-                            $" open for nominations until {election.VotingStartDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}");
-                        break;
-                    case ElectionStage.Voting:
-                        sb.AppendLine(
-                            $" open for voting until {election.VotingEndDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}");
-                        break;
-                    case ElectionStage.Preinstallation:
-                        sb.AppendLine(
-                            $" closed, with electors taking office on {election.ResultsInEffectDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}");
-                        break;
-                    case ElectionStage.Finalised:
-                        sb.AppendLine(
-                            $" finished ({election.Victors.Select(x => x.PersonalName.GetName(NameStyle.FullName).ColourName()).DefaultIfEmpty("no victors".Colour(Telnet.Red)).ListToString(conjunction: "", twoItemJoiner: ", ")})");
-                        break;
-                }
-            }
-        }
-
-        actor.OutputHandler.Send(sb.ToString(), false, true);
+        clan.ShowElectionHistory(actor, ss);
     }
 
     [PlayerCommand("Clans", "clans")]
@@ -3790,7 +3460,7 @@ Your next payday is {3}.
             if (actor.AffectedBy<BuilderEditingEffect<IClan>>())
             {
                 IClan editingclan = actor.CombinedEffectsOfType<BuilderEditingEffect<IClan>>().First().EditingItem;
-                ClanViewDefault(actor, editingclan, actor.ClanMemberships.FirstOrDefault(x => x.Clan == editingclan));
+                editingclan.Show(actor, new StringStack(string.Empty));
                 return;
             }
 
@@ -3807,173 +3477,7 @@ Your next payday is {3}.
             return;
         }
 
-        IClanMembership actorMembership = actor.ClanMemberships.FirstOrDefault(x => x.Clan == clan);
-        if (!actor.IsAdministrator(PermissionLevel.Admin) && !clan.IsTemplate && actorMembership != null &&
-            !actorMembership.NetPrivileges.HasFlag(ClanPrivilegeType.CanViewClanStructure) &&
-            !actorMembership.NetPrivileges.HasFlag(ClanPrivilegeType.CanViewClanStructureEqualRankOrLower))
-        {
-            actor.OutputHandler.Send("You are not allowed to view the structure of that clan.");
-            return;
-        }
-
-        bool IsInParentAppointmentPosition(IAppointment appointment)
-        {
-            if (actorMembership == null)
-            {
-                return false;
-            }
-
-            if (actorMembership.Appointments.Contains(appointment))
-            {
-                return true;
-            }
-
-            if (appointment.ParentPosition != null)
-            {
-                return IsInParentAppointmentPosition(appointment.ParentPosition);
-            }
-
-            return false;
-        }
-
-        string extraText = command.PopSpeech();
-        switch (extraText.ToLowerInvariant())
-        {
-            case "":
-                ClanViewDefault(actor, clan, actorMembership);
-                return;
-            case "rank":
-                if (command.IsFinished)
-                {
-                    actor.OutputHandler.Send("Which rank do you wish to view in that clan?");
-                    return;
-                }
-
-                string rankText = command.PopSpeech();
-                IRank rank =
-                    clan.Ranks.FirstOrDefault(
-                        x => x.Name.Equals(rankText, StringComparison.InvariantCultureIgnoreCase));
-                if (rank == null)
-                {
-                    actor.OutputHandler.Send("There is no such rank for you to view.");
-                    return;
-                }
-
-                if (!actor.IsAdministrator() && !clan.IsTemplate &&
-                    !actorMembership.NetPrivileges.HasFlag(ClanPrivilegeType.CanViewClanStructure) &&
-                    rank.RankNumber > actorMembership.Rank.RankNumber)
-                {
-                    actor.OutputHandler.Send("There is no such rank for you to view.");
-                    return;
-                }
-
-                ClanViewRank(actor, clan, actorMembership, rank);
-                return;
-            case "pay grade":
-            case "paygrade":
-                if (command.IsFinished)
-                {
-                    actor.OutputHandler.Send("Which pay grade do you wish to view in that clan?");
-                    return;
-                }
-
-                string paygradeText = command.PopSpeech();
-                IPaygrade paygrade =
-                    clan.Paygrades.FirstOrDefault(
-                        x => x.Name.Equals(paygradeText, StringComparison.InvariantCultureIgnoreCase));
-                if (paygrade == null)
-                {
-                    actor.OutputHandler.Send("There is no such pay grade for you to view.");
-                    return;
-                }
-
-                if (!actor.IsAdministrator() && !clan.IsTemplate &&
-                    !actorMembership.NetPrivileges.HasFlag(ClanPrivilegeType.CanViewClanStructure))
-                {
-                    IRank paygradeRank = clan.Ranks.FirstOrDefault(x => x.Paygrades.Contains(paygrade));
-                    if (paygradeRank != null && paygradeRank.RankNumber > actorMembership.Rank.RankNumber)
-                    {
-                        actor.OutputHandler.Send("There is no such pay grade for you to view.");
-                        return;
-                    }
-
-                    IAppointment paygradeAppointment = clan.Appointments.FirstOrDefault(x => x.Paygrade == paygrade);
-                    if (paygradeAppointment != null && !IsInParentAppointmentPosition(paygradeAppointment))
-                    {
-                        actor.OutputHandler.Send("There is no such pay grade for you to view.");
-                        return;
-                    }
-                }
-
-                ClanViewPaygrade(actor, clan, actorMembership, paygrade);
-                return;
-            case "appointment":
-                if (command.IsFinished)
-                {
-                    actor.OutputHandler.Send("Which appointment do you wish to view in that clan?");
-                    return;
-                }
-
-                string appointmentText = command.PopSpeech();
-                IAppointment appointment =
-                    clan.Appointments.FirstOrDefault(
-                        x => x.Name.Equals(appointmentText, StringComparison.InvariantCultureIgnoreCase));
-                if (appointment == null)
-                {
-                    actor.OutputHandler.Send("There is no such appointment for you to view.");
-                    return;
-                }
-
-                if (!actor.IsAdministrator() && !clan.IsTemplate &&
-                    !actorMembership.NetPrivileges.HasFlag(ClanPrivilegeType.CanViewClanStructure))
-                {
-                    if (!IsInParentAppointmentPosition(appointment))
-                    {
-                        actor.OutputHandler.Send("There is no such appointment for you to view.");
-                        return;
-                    }
-                }
-
-                ClanViewAppointment(actor, clan, actorMembership, appointment);
-                return;
-            case "external":
-            case "external control":
-            case "control":
-                if (command.IsFinished)
-                {
-                    actor.OutputHandler.Send("Which clan's external control do you wish to view in that clan?");
-                    return;
-                }
-
-                string externalClanText = command.PopSpeech();
-                if (command.IsFinished)
-                {
-                    actor.OutputHandler.Send(
-                        "Which position in that clan do you wish to view the other clan's external control over?");
-                    return;
-                }
-
-                string externalPositionText = command.PopSpeech();
-                // TODO - this doesn't seem to respect the position specification it demands
-                IExternalClanControl clanControl =
-                    clan.ExternalControls.FirstOrDefault(
-                        x =>
-                            x.LiegeClan.FullName.Equals(externalClanText,
-                                StringComparison.InvariantCultureIgnoreCase)) ??
-                    clan.ExternalControls.FirstOrDefault(
-                        x => x.LiegeClan.Alias.Equals(externalClanText, StringComparison.InvariantCultureIgnoreCase));
-                if (clanControl == null)
-                {
-                    actor.OutputHandler.Send("There is no such clan exerting any external control over that clan.");
-                    return;
-                }
-
-                ClanViewExternalControl(actor, clan, actorMembership, clanControl);
-                return;
-            default:
-                actor.OutputHandler.Send("That is not a valid option for the clan view command.");
-                return;
-        }
+        clan.Show(actor, command);
     }
 
     #region ClanCreate Subcommands
@@ -4780,7 +4284,8 @@ return 0",
 
         IClanMembership actorMembership = actor.ClanMemberships.FirstOrDefault(x => x.Clan == clan);
         if (!actor.IsAdministrator(PermissionLevel.Admin) && actorMembership != null &&
-            !actorMembership.NetPrivileges.HasFlag(ClanPrivilegeType.CanCreateAppointments))
+            !actorMembership.NetPrivileges.HasFlag(ClanPrivilegeType.CanCreateAppointments) &&
+            !actorMembership.NetPrivileges.HasFlag(ClanPrivilegeType.CanCreateAppointmentsUnderOwn))
         {
             actor.OutputHandler.Send("You are not allowed to create appointments in that clan.");
             return;
@@ -4826,6 +4331,25 @@ return 0",
             {
                 actor.OutputHandler.Send(
                     "There is no such appointment under which you can place this new appointment.");
+                return;
+            }
+        }
+
+        if (!actor.IsAdministrator(PermissionLevel.Admin) &&
+            actorMembership is not null &&
+            !actorMembership.NetPrivileges.HasFlag(ClanPrivilegeType.CanCreateAppointments))
+        {
+            if (targetAppointment is null)
+            {
+                actor.OutputHandler.Send(
+                    "You may only create appointments beneath one of your own controlled appointments in that clan.");
+                return;
+            }
+
+            if (!ClanCommandUtilities.HoldsOrControlsAppointment(actorMembership, targetAppointment))
+            {
+                actor.OutputHandler.Send(
+                    "You may only create appointments beneath one of your own controlled appointments in that clan.");
                 return;
             }
         }
@@ -6961,7 +6485,7 @@ return 0",
 
         if (!actor.IsAdministrator() && actorMembership != null &&
             !actorMembership.NetPrivileges.HasFlag(ClanPrivilegeType.CanCreateAppointments) &&
-            actorMembership.Appointments.All(x => appointment.ParentPosition == x))
+            !ClanCommandUtilities.HoldsOrControlsAppointment(actorMembership, appointment.ParentPosition))
         {
             actor.OutputHandler.Send(
                 "You do not have permission to edit appointments other than those that fall under your own positions in that clan.");
@@ -7288,30 +6812,6 @@ return 0",
 
         string clanText = command.PopSpeech();
 
-        if (command.IsFinished)
-        {
-            actor.OutputHandler.Send("Which appointment in that clan do you wish to submit to external control?");
-            return;
-        }
-
-        string appointmentText = command.PopSpeech();
-
-        if (command.IsFinished)
-        {
-            actor.OutputHandler.Send("Which other clan do you wish to submit control of that appointment to?");
-            return;
-        }
-
-        string otherClanText = command.PopSpeech();
-
-        int maximumNumber = 1;
-        if (!command.IsFinished && (!int.TryParse(command.PopSpeech(), out maximumNumber) || maximumNumber < 0))
-        {
-            actor.OutputHandler.Send(
-                "If you specify a maximum number of appointees for that external control, it must be a valid number.");
-            return;
-        }
-
         IClan clan = GetTargetClan(actor, clanText);
         if (clan == null)
         {
@@ -7321,90 +6821,13 @@ return 0",
             return;
         }
 
-        IClanMembership actorMembership = actor.ClanMemberships.FirstOrDefault(x => x.Clan == clan);
-        if (!actor.IsAdministrator(PermissionLevel.Admin) && actorMembership != null &&
-            !actorMembership.NetPrivileges.HasFlag(ClanPrivilegeType.CanSubmitClan))
+        if (command.IsFinished)
         {
-            actor.OutputHandler.Send("You are not allowed to submit appointments to external control in that clan.");
+            actor.OutputHandler.Send("Which appointment in that clan do you wish to submit to external control?");
             return;
         }
 
-        IAppointment appointment =
-            clan.Appointments.FirstOrDefault(
-                x => x.Name.Equals(appointmentText, StringComparison.InvariantCultureIgnoreCase));
-        if (appointment == null)
-        {
-            actor.OutputHandler.Send("There is no such appointment in that clan for you to submit.");
-            return;
-        }
-
-        if (appointment.MaximumSimultaneousHolders > 0 &&
-            appointment.MaximumSimultaneousHolders -
-            clan.Memberships.Count(x => x.Appointments.Contains(appointment)) - maximumNumber < 0)
-        {
-            actor.OutputHandler.Send(
-                "There are insufficient free appointees for that appointment to submit that number to external control.");
-            return;
-        }
-
-        IClan targetClan =
-            actor.Gameworld.Clans.FirstOrDefault(
-                x => x.FullName.Equals(otherClanText, StringComparison.InvariantCultureIgnoreCase)) ??
-            actor.Gameworld.Clans.FirstOrDefault(
-                x => x.Alias.Equals(otherClanText, StringComparison.InvariantCultureIgnoreCase)) ??
-            actor.Gameworld.Clans.FirstOrDefault(x =>
-                x.Alias.StartsWith(otherClanText, StringComparison.InvariantCultureIgnoreCase)) ??
-            actor.Gameworld.Clans.FirstOrDefault(x =>
-                x.FullName.StartsWith(otherClanText, StringComparison.InvariantCultureIgnoreCase));
-        if (targetClan == null)
-        {
-            actor.OutputHandler.Send("There is no such other clan for you to submit an appointment to.");
-            return;
-        }
-
-        if (targetClan == clan)
-        {
-            actor.OutputHandler.Send("You cannot submit one of a clan's own appointments to itself.");
-            return;
-        }
-
-        actor.OutputHandler.Send(
-            $"Are you sure you wish to submit the control of appointments of the {appointment.Name.TitleCase().ColourName()} position in {clan.FullName.TitleCase().ColourName()} to the {targetClan.FullName.TitleCase().ColourName()} clan? This is irreversible unless they decide to relinquish control. They can also transfer the control to others.\n{Accept.StandardAcceptPhrasing}");
-        actor.AddEffect(new Accept(actor, new GenericProposal
-        {
-            DescriptionString = "Submitting a position in a clan to the control of another",
-            Keywords = new List<string> { "submit", "clan", "external" },
-            ExpireAction = () =>
-            {
-                actor.OutputHandler.Send(
-                    $"You decide not to submit the control of appointments of the {appointment.Name.TitleCase().ColourName()} position in {clan.FullName.TitleCase().ColourName()} to the {targetClan.FullName.TitleCase().ColourName()} clan.");
-            },
-            RejectAction = text =>
-            {
-                actor.OutputHandler.Send(
-                    $"You decide not to submit the control of appointments of the {appointment.Name.TitleCase().ColourName()} position in {clan.FullName.TitleCase().ColourName()} to the {targetClan.FullName.TitleCase().ColourName()} clan.");
-            },
-            AcceptAction = text =>
-            {
-                using (new FMDB())
-                {
-                    Models.ExternalClanControl dbitem = new();
-                    FMDB.Context.ExternalClanControls.Add(dbitem);
-                    dbitem.ControlledAppointmentId = appointment.Id;
-                    dbitem.VassalClanId = clan.Id;
-                    dbitem.LiegeClanId = targetClan.Id;
-                    dbitem.NumberOfAppointments = maximumNumber;
-                    FMDB.Context.SaveChanges();
-                    Community.ExternalClanControl newExternal = new(dbitem, actor.Gameworld);
-                    actor.OutputHandler.Send(string.Format("You submit control of {3}appointment {0} in {1} to {2}.",
-                        appointment.Name.TitleCase().ColourName(),
-                        clan.FullName.TitleCase().ColourName(),
-                        targetClan.FullName.TitleCase().ColourName(),
-                        maximumNumber > 0 ? string.Format(actor, "{0:N0} appointees of ", maximumNumber) : ""
-                    ));
-                }
-            }
-        }), TimeSpan.FromSeconds(120));
+        clan.SubmitControl(actor, command);
     }
 
     private static void ClanDisband(ICharacter actor, StringStack command)
@@ -7465,7 +6888,6 @@ return 0",
             return;
         }
 
-        string appointmentText = command.PopSpeech();
         IClan clan = GetTargetClan(actor, clanText);
         if (clan == null)
         {
@@ -7475,114 +6897,7 @@ return 0",
             return;
         }
 
-        IClanMembership actorMembership = actor.ClanMemberships.FirstOrDefault(x => x.Clan == clan);
-
-        if (!actor.IsAdministrator(PermissionLevel.Admin) && actorMembership != null &&
-            !actorMembership.NetPrivileges.HasFlag(ClanPrivilegeType.CanAppoint))
-        {
-            actor.OutputHandler.Send("You are not allowed to appoint people to positions in that clan.");
-            return;
-        }
-
-        IClanMembership targetMembership;
-        ICharacter targetActor = actor.TargetActor(targetText);
-        if (targetActor != null)
-        {
-            targetMembership = targetActor.ClanMemberships.FirstOrDefault(x => x.Clan == clan);
-        }
-        else
-        {
-            targetMembership =
-                clan.Memberships.FirstOrDefault(
-                    x => !x.IsArchivedMembership &&
-                         x.PersonalName.GetName(NameStyle.FullName)
-                          .Equals(targetText, StringComparison.InvariantCultureIgnoreCase));
-        }
-
-        if (targetMembership == null)
-        {
-            actor.OutputHandler.Send("There is no such member for you to appoint.");
-            return;
-        }
-
-        IAppointment appointment =
-            clan.Appointments.FirstOrDefault(
-                x => x.Name.Equals(appointmentText, StringComparison.InvariantCultureIgnoreCase));
-        if (appointment == null)
-        {
-            actor.OutputHandler.Send("There is no such appointment in that clan.");
-            return;
-        }
-
-        if (appointment.IsAppointedByElection)
-        {
-            actor.OutputHandler.Send(
-                $"The position of {appointment.Name.TitleCase().ColourName()} is controlled by elections rather than direct appointments.");
-            return;
-        }
-
-        if (!actor.IsAdministrator(PermissionLevel.Admin) && appointment.ParentPosition != null &&
-            !actorMembership.Appointments.Contains(appointment.ParentPosition))
-        {
-            actor.OutputHandler.Send(
-                $"The position of {appointment.Name.TitleCase().Colour(Telnet.Green)} can only be appointed by {(appointment.ParentPosition.MaximumSimultaneousHolders > 1 ? appointment.ParentPosition.Name.TitleCase().A_An(colour: Telnet.Green) : appointment.ParentPosition.Name.TitleCase().Colour(Telnet.Green))}.");
-            return;
-        }
-
-        if (!actor.IsAdministrator(PermissionLevel.Admin) && appointment.MinimumRankToAppoint != null &&
-            appointment.MinimumRankToAppoint.RankNumber > actorMembership.Rank.RankNumber &&
-            (appointment.ParentPosition == null ||
-             actorMembership.Appointments.All(x => appointment.ParentPosition != x)))
-        {
-            actor.Send("You must hold at least the rank of {0} before you can appoint them to that position.",
-                appointment.MinimumRankToAppoint.Title(actor).TitleCase().Colour(Telnet.Green));
-            return;
-        }
-
-        if (appointment.MinimumRankToHold != null &&
-            appointment.MinimumRankToHold.RankNumber > targetMembership.Rank.RankNumber)
-        {
-            actor.Send("They must hold at least the rank of {0} before you can appoint them to that position.",
-                appointment.MinimumRankToHold.Name.TitleCase().Colour(Telnet.Green));
-            return;
-        }
-
-        if (targetMembership.Appointments.Contains(appointment))
-        {
-            actor.OutputHandler.Send("They have already been appointed to that position.");
-            return;
-        }
-
-        if (!clan.FreePosition(appointment))
-        {
-            actor.OutputHandler.Send(
-                "They cannot be appointed to that position as there is a limited number of holders at any one time.");
-            return;
-        }
-
-        targetMembership.Appointments.Add(appointment);
-        targetMembership.Changed = true;
-        if (targetActor != null)
-        {
-            actor.OutputHandler.Handle(new FilteredEmoteOutput(new Emote(
-                    $"@ appoint|appoints $0 to the position of {appointment.Title(targetActor).TitleCase().Colour(Telnet.Green)} in {clan.FullName.TitleCase().Colour(Telnet.Green)}.",
-                    actor, targetActor),
-                perceiver =>
-                {
-                    return perceiver is ICharacter pChar &&
-                           (pChar.ClanMemberships.Any(
-                                x => x.Clan == clan) ||
-                            pChar.PermissionLevel >=
-                            PermissionLevel.JuniorAdmin);
-                }
-            ));
-        }
-        else
-        {
-            actor.Send("You appoint {0} to the position of {1} in {2}.",
-                targetMembership.PersonalName.GetName(NameStyle.FullName).Colour(Telnet.Green),
-                appointment.Name.TitleCase().Colour(Telnet.Green), clan.FullName.TitleCase().Colour(Telnet.Green));
-        }
+        clan.Appoint(actor, new StringStack($"\"{targetText}\" {command.RemainingArgument}"));
     }
 
     private static void ClanPay(ICharacter actor, StringStack command)
@@ -7683,7 +6998,6 @@ return 0",
             return;
         }
 
-        string appointmentText = command.PopSpeech();
         IClan clan = GetTargetClan(actor, clanText);
         if (clan == null)
         {
@@ -7693,114 +7007,7 @@ return 0",
             return;
         }
 
-        IClanMembership actorMembership = actor.ClanMemberships.FirstOrDefault(x => x.Clan == clan);
-
-        if (!actor.IsAdministrator(PermissionLevel.Admin) && actorMembership != null &&
-            !actorMembership.NetPrivileges.HasFlag(ClanPrivilegeType.CanDismiss))
-        {
-            actor.OutputHandler.Send("You are not allowed to dismiss people from positions in that clan.");
-            return;
-        }
-
-        IClanMembership targetMembership;
-        ICharacter targetActor = actor.TargetActor(targetText);
-        if (targetActor != null)
-        {
-            targetMembership = targetActor.ClanMemberships.FirstOrDefault(x => x.Clan == clan);
-        }
-        else
-        {
-            targetMembership =
-                clan.Memberships.FirstOrDefault(
-                    x => !x.IsArchivedMembership &&
-                         x.PersonalName.GetName(NameStyle.FullName)
-                          .Equals(targetText, StringComparison.InvariantCultureIgnoreCase));
-        }
-
-        if (targetMembership == null)
-        {
-            actor.OutputHandler.Send("There is no such member for you to dismiss.");
-            return;
-        }
-
-        IAppointment appointment =
-            clan.Appointments.FirstOrDefault(
-                x => x.Name.Equals(appointmentText, StringComparison.InvariantCultureIgnoreCase));
-        if (appointment == null)
-        {
-            actor.OutputHandler.Send("There is no such appointment in that clan.");
-            return;
-        }
-
-        if (appointment.IsAppointedByElection)
-        {
-            actor.OutputHandler.Send(
-                $"The position of {appointment.Name.TitleCase().ColourName()} is controlled by elections rather than direct appointments.");
-            return;
-        }
-
-        if (!actor.IsAdministrator(PermissionLevel.Admin) && appointment.ParentPosition != null &&
-            !actorMembership.Appointments.Contains(appointment.ParentPosition))
-        {
-            actor.OutputHandler.Send(
-                $"The position of {appointment.Name.TitleCase().Colour(Telnet.Green)} can only be dismissed by {(appointment.ParentPosition.MaximumSimultaneousHolders > 1 ? appointment.ParentPosition.Name.TitleCase().A_An(colour: Telnet.Green) : appointment.ParentPosition.Name.TitleCase().Colour(Telnet.Green))}.");
-            return;
-        }
-
-        if (!actor.IsAdministrator(PermissionLevel.Admin) && appointment.MinimumRankToAppoint != null &&
-            appointment.MinimumRankToAppoint.RankNumber > actorMembership.Rank.RankNumber &&
-            (appointment.ParentPosition == null ||
-             actorMembership.Appointments.All(x => appointment.ParentPosition != x)))
-        {
-            actor.Send("You must hold at least the rank of {0} before you can dismiss them from that position.",
-                appointment.MinimumRankToAppoint.Title(actor).TitleCase().Colour(Telnet.Green));
-            return;
-        }
-
-        if (!targetMembership.Appointments.Contains(appointment))
-        {
-            actor.OutputHandler.Send("They have not been appointed to that position.");
-            return;
-        }
-
-        List<IActiveJob> jobs = actor.Gameworld.ActiveJobs
-                        .Where(x =>
-                            !x.IsJobComplete &&
-                            x.Character.Id != targetMembership.MemberId &&
-                            x.Listing.ClanMembership == clan &&
-                            x.Listing.ClanAppointment == appointment
-                        ).ToList();
-        if (jobs.Any())
-        {
-            actor.OutputHandler.Send(
-                $"{targetMembership.MemberCharacter.HowSeen(actor, true)} cannot be dismissed from that appointment as they hold it by virtue of the job{(jobs.Count == 1 ? "" : "s")} {jobs.Select(x => x.Name.ColourValue()).ListToString()}.");
-            return;
-        }
-
-        if (targetActor != null)
-        {
-            actor.OutputHandler.Handle(new FilteredEmoteOutput(new Emote(
-                    $"@ dismiss|dismisses $0 from the position of {appointment.Title(targetActor).TitleCase().Colour(Telnet.Green)} in {clan.FullName.TitleCase().Colour(Telnet.Green)}.",
-                    actor, targetActor),
-                perceiver =>
-                {
-                    return perceiver is ICharacter pChar &&
-                           (pChar.ClanMemberships
-                                 .Any(x => x.Clan == clan) ||
-                            pChar
-                                .PermissionLevel >=
-                            PermissionLevel.JuniorAdmin);
-                }
-            ));
-        }
-        else
-        {
-            actor.Send("You dismiss {0} from the position of {1} in {2}.",
-                targetMembership.PersonalName.GetName(NameStyle.FullName).Colour(Telnet.Green),
-                appointment.Name.TitleCase().Colour(Telnet.Green), clan.FullName.TitleCase().Colour(Telnet.Green));
-        }
-
-        clan.DismissAppointment(targetMembership, appointment);
+        clan.Dismiss(actor, new StringStack($"\"{targetText}\" {command.RemainingArgument}"));
     }
 
     private static void ClanTransfer(ICharacter actor, StringStack command)
@@ -7812,33 +7019,8 @@ return 0",
         }
 
         string clanText = command.PopSpeech();
-        if (command.IsFinished)
-        {
-            actor.OutputHandler.Send("Which appointment in that clan do you wish to release from external control?");
-            return;
-        }
 
-        string appointmentText = command.PopSpeech();
-
-        IEnumerable<IClan> clans;
-        if (actor.IsAdministrator(PermissionLevel.Admin))
-        {
-            clans = actor.Gameworld.Clans;
-        }
-        else
-        {
-            clans =
-                actor.ClanMemberships.Select(x => x.Clan)
-                     .Concat(
-                         actor.ClanMemberships.SelectMany(
-                             x => x.Clan.ExternalControls.Where(y => y.LiegeClan == x.Clan).Select(y => y.VassalClan)));
-        }
-
-        IClan clan =
-            clans.FirstOrDefault(x => x.FullName.Equals(clanText, StringComparison.InvariantCultureIgnoreCase)) ??
-            clans.FirstOrDefault(x => x.Alias.Equals(clanText, StringComparison.InvariantCultureIgnoreCase)) ??
-            clans.FirstOrDefault(x => x.Alias.StartsWith(clanText, StringComparison.InvariantCultureIgnoreCase)) ??
-            clans.FirstOrDefault(x => x.FullName.StartsWith(clanText, StringComparison.InvariantCultureIgnoreCase));
+        IClan clan = GetTargetExternallyAccessibleClan(actor, clanText);
         if (clan == null)
         {
             actor.OutputHandler.Send(actor.IsAdministrator(PermissionLevel.Admin)
@@ -7847,156 +7029,13 @@ return 0",
             return;
         }
 
-        IExternalClanControl appointment =
-            clan.ExternalControls.Where(x => x.VassalClan == clan)
-                .FirstOrDefault(
-                    x =>
-                        x.ControlledAppointment.Name.Equals(appointmentText,
-                            StringComparison.InvariantCultureIgnoreCase));
-        if (appointment == null)
-        {
-            actor.OutputHandler.Send("There are no such appointments available in that clan.");
-            return;
-        }
-
         if (command.IsFinished)
         {
-            actor.OutputHandler.Send("Which other clan do you wish to transfer control of that appointment to?");
+            actor.OutputHandler.Send("Which appointment in that clan do you wish to transfer from external control?");
             return;
         }
 
-        string otherClanText = command.PopSpeech();
-        IClan targetClan =
-            actor.Gameworld.Clans.FirstOrDefault(
-                x => x.FullName.Equals(otherClanText, StringComparison.InvariantCultureIgnoreCase)) ??
-            actor.Gameworld.Clans.FirstOrDefault(
-                x => x.Alias.Equals(otherClanText, StringComparison.InvariantCultureIgnoreCase)) ??
-            actor.Gameworld.Clans.FirstOrDefault(x =>
-                x.Alias.StartsWith(otherClanText, StringComparison.InvariantCultureIgnoreCase)) ??
-            actor.Gameworld.Clans.FirstOrDefault(x =>
-                x.FullName.StartsWith(otherClanText, StringComparison.InvariantCultureIgnoreCase));
-        if (targetClan == null)
-        {
-            actor.OutputHandler.Send("There is no such other clan for you to transfer an appointment to.");
-            return;
-        }
-
-        if (targetClan == clan)
-        {
-            actor.OutputHandler.Send("You cannot transfer one of a clan's own appointments to itself.");
-            return;
-        }
-
-        string liegeClanText = command.PopSpeech();
-        List<IClan> liegeClans =
-            clans.Where(
-                x =>
-                    x.ExternalControls.Any(
-                        y =>
-                            y.VassalClan == clan &&
-                            y.ControlledAppointment == appointment.ControlledAppointment && y.LiegeClan == x)).ToList();
-        IClan liegeClan;
-        if (liegeClans.Count > 1)
-        {
-            liegeClans = liegeClans.Where(x => actor.ClanMemberships.Any(y => y.Clan == x)).ToList();
-
-            if (liegeClans.Count > 1)
-            {
-                if (string.IsNullOrEmpty(liegeClanText))
-                {
-                    actor.OutputHandler.Send(
-                        "The requested appointment is ambiguous, you must supply the name of the liege clan you wish to use.");
-                    return;
-                }
-
-                liegeClan =
-                    liegeClans.FirstOrDefault(
-                        x => x.FullName.Equals(liegeClanText, StringComparison.InvariantCultureIgnoreCase)) ??
-                    liegeClans.FirstOrDefault(
-                        x => x.Alias.Equals(liegeClanText, StringComparison.InvariantCultureIgnoreCase));
-            }
-            else
-            {
-                liegeClan = liegeClans.FirstOrDefault();
-            }
-        }
-        else
-        {
-            liegeClan = liegeClans.FirstOrDefault();
-        }
-
-        if (liegeClan == null)
-        {
-            actor.OutputHandler.Send("There is no such clan, or it is not a valid liege of the vassal clan.");
-            return;
-        }
-
-        if (liegeClan == targetClan)
-        {
-            actor.OutputHandler.Send("You cannot transfer vassalage of one clan within the same clan.");
-            return;
-        }
-
-        IClanMembership actorMembership = liegeClan.Memberships.FirstOrDefault(x => x.MemberId == actor.Id);
-        if (!actor.IsAdministrator(PermissionLevel.Admin) && actorMembership != null &&
-            !actorMembership.NetPrivileges.HasFlag(ClanPrivilegeType.CanManageClanVassals) &&
-            !actorMembership.Appointments.Contains(appointment.ControllingAppointment))
-        {
-            actor.OutputHandler.Send("You are not allowed to manage vassal positions in that clan.");
-            return;
-        }
-
-        actor.OutputHandler.Send(
-            $"Are you sure you wish to transfer the control of appointments of the {appointment.Name.TitleCase().ColourName()} position in {clan.FullName.TitleCase().ColourName()} to the {targetClan.FullName.TitleCase().ColourName()} clan? This is irreversible unless they decide to relinquish control. They can also transfer the control to others.\n{Accept.StandardAcceptPhrasing}");
-        actor.AddEffect(new Accept(actor, new GenericProposal
-        {
-            DescriptionString = "Transferring a position in a clan to the control of another",
-            Keywords = new List<string> { "transfer", "clan", "external" },
-            ExpireAction = () =>
-            {
-                actor.OutputHandler.Send(
-                    $"You decide not to transfer the control of appointments of the {appointment.Name.TitleCase().ColourName()} position in {clan.FullName.TitleCase().ColourName()} to the {targetClan.FullName.TitleCase().ColourName()} clan.");
-            },
-            RejectAction = text =>
-            {
-                actor.OutputHandler.Send(
-                    $"You decide not to transfer the control of appointments of the {appointment.Name.TitleCase().ColourName()} position in {clan.FullName.TitleCase().ColourName()} to the {targetClan.FullName.TitleCase().ColourName()} clan.");
-            },
-            AcceptAction = text =>
-            {
-                using (new FMDB())
-                {
-                    Models.ExternalClanControl dbitem = new();
-                    FMDB.Context.ExternalClanControls.Add(dbitem);
-                    dbitem.ControlledAppointmentId = appointment.Id;
-                    dbitem.VassalClanId = clan.Id;
-                    dbitem.LiegeClanId = targetClan.Id;
-                    dbitem.NumberOfAppointments = appointment.NumberOfAppointments;
-                    foreach (IClanMembership character in appointment.Appointees)
-                    {
-                        dbitem.ExternalClanControlsAppointments.Add(new ExternalClanControlsAppointment
-                        {
-                            VassalClanId = clan.Id,
-                            LiegeClanId = targetClan.Id,
-                            ControlledAppointmentId = appointment.ControlledAppointment.Id,
-                            CharacterId = character.MemberCharacter.Id
-                        });
-                    }
-                    FMDB.Context.SaveChanges();
-                    Community.ExternalClanControl newExternal = new(dbitem, actor.Gameworld);
-                    actor.OutputHandler.Send(string.Format("You transfer control of {3}appointment {0} in {1} to {2}.",
-                        appointment.Name.TitleCase().ColourName(),
-                        clan.FullName.TitleCase().ColourName(),
-                        targetClan.FullName.TitleCase().ColourName(),
-                        appointment.NumberOfAppointments > 0 ? string.Format(actor, "{0:N0} appointees of ", appointment.NumberOfAppointments) : ""
-                    ));
-                }
-
-                clan.ExternalControls.Remove(appointment);
-                liegeClan.ExternalControls.Remove(appointment);
-                appointment.Delete();
-            }
-        }), TimeSpan.FromSeconds(120));
+        clan.TransferControl(actor, command);
     }
 
     private static void ClanRelease(ICharacter actor, StringStack command)
@@ -8008,33 +7047,8 @@ return 0",
         }
 
         string clanText = command.PopSpeech();
-        if (command.IsFinished)
-        {
-            actor.OutputHandler.Send("Which appointment in that clan do you wish to release from external control?");
-            return;
-        }
 
-        string appointmentText = command.PopSpeech();
-
-        IEnumerable<IClan> clans;
-        if (actor.IsAdministrator(PermissionLevel.Admin))
-        {
-            clans = actor.Gameworld.Clans;
-        }
-        else
-        {
-            clans =
-                actor.ClanMemberships.Select(x => x.Clan)
-                     .Concat(
-                         actor.ClanMemberships.SelectMany(
-                             x => x.Clan.ExternalControls.Where(y => y.LiegeClan == x.Clan).Select(y => y.VassalClan)));
-        }
-
-        IClan clan =
-            clans.FirstOrDefault(x => x.FullName.Equals(clanText, StringComparison.InvariantCultureIgnoreCase)) ??
-            clans.FirstOrDefault(x => x.Alias.Equals(clanText, StringComparison.InvariantCultureIgnoreCase)) ??
-            clans.FirstOrDefault(x => x.Alias.StartsWith(clanText, StringComparison.InvariantCultureIgnoreCase)) ??
-            clans.FirstOrDefault(x => x.FullName.StartsWith(clanText, StringComparison.InvariantCultureIgnoreCase));
+        IClan clan = GetTargetExternallyAccessibleClan(actor, clanText);
         if (clan == null)
         {
             actor.OutputHandler.Send(actor.IsAdministrator(PermissionLevel.Admin)
@@ -8043,77 +7057,13 @@ return 0",
             return;
         }
 
-        IExternalClanControl appointment =
-            clan.ExternalControls.Where(x => x.VassalClan == clan)
-                .FirstOrDefault(
-                    x =>
-                        x.ControlledAppointment.Name.Equals(appointmentText,
-                            StringComparison.InvariantCultureIgnoreCase));
-        if (appointment == null)
+        if (command.IsFinished)
         {
-            actor.OutputHandler.Send("There are no such appointments available in that clan.");
+            actor.OutputHandler.Send("Which appointment in that clan do you wish to release from external control?");
             return;
         }
 
-        string liegeClanText = command.PopSpeech();
-        List<IClan> liegeClans =
-            clans.Where(
-                x =>
-                    x.ExternalControls.Any(
-                        y =>
-                            y.VassalClan == clan &&
-                            y.ControlledAppointment == appointment.ControlledAppointment && y.LiegeClan == x)).ToList();
-        IClan liegeClan;
-        if (liegeClans.Count > 1)
-        {
-            liegeClans = liegeClans.Where(x => actor.ClanMemberships.Any(y => y.Clan == x)).ToList();
-
-            if (liegeClans.Count > 1)
-            {
-                if (string.IsNullOrEmpty(liegeClanText))
-                {
-                    actor.OutputHandler.Send(
-                        "The requested appointment is ambiguous, you must supply the name of the liege clan you wish to use.");
-                    return;
-                }
-
-                liegeClan =
-                    liegeClans.FirstOrDefault(
-                        x => x.FullName.Equals(liegeClanText, StringComparison.InvariantCultureIgnoreCase)) ??
-                    liegeClans.FirstOrDefault(
-                        x => x.Alias.Equals(liegeClanText, StringComparison.InvariantCultureIgnoreCase));
-            }
-            else
-            {
-                liegeClan = liegeClans.FirstOrDefault();
-            }
-        }
-        else
-        {
-            liegeClan = liegeClans.FirstOrDefault();
-        }
-
-        if (liegeClan == null)
-        {
-            actor.OutputHandler.Send("There is no such clan, or it is not a valid liege of the vassal clan.");
-            return;
-        }
-
-        IClanMembership actorMembership = liegeClan.Memberships.FirstOrDefault(x => x.MemberId == actor.Id);
-        if (!actor.IsAdministrator(PermissionLevel.Admin) && actorMembership != null &&
-            !actorMembership.NetPrivileges.HasFlag(ClanPrivilegeType.CanManageClanVassals) &&
-            !actorMembership.Appointments.Contains(appointment.ControllingAppointment))
-        {
-            actor.OutputHandler.Send("You are not allowed to manage vassal positions in that clan.");
-            return;
-        }
-
-        clan.ExternalControls.Remove(appointment);
-        appointment.Delete();
-        actor.OutputHandler.Send(string.Format("You release control of appointment {0} in {1} by {2}.",
-                        appointment.Name.TitleCase().ColourName(),
-                        clan.FullName.TitleCase().ColourName(),
-                        liegeClan.FullName.TitleCase().ColourName()));
+        clan.ReleaseControl(actor, command);
     }
 
     private static void ClanMembers(ICharacter actor, StringStack command)
@@ -8133,39 +7083,7 @@ return 0",
             return;
         }
 
-        IClanMembership actorMembership = actor.ClanMemberships.FirstOrDefault(x => x.Clan == clan);
-
-        if (!actor.IsAdministrator(PermissionLevel.Admin) && actor.ClanMemberships.Any(x => x.Clan == clan) &&
-            !actorMembership.NetPrivileges.HasFlag(ClanPrivilegeType.CanViewMembers))
-        {
-            actor.OutputHandler.Send("You are not allowed to view the list of members for that clan.");
-            return;
-        }
-
-        List<IClanMembership> members =
-            (actor.IsAdministrator() || actorMembership.NetPrivileges.HasFlag(ClanPrivilegeType.CanViewClanStructure)
-                ? clan.Memberships.Where(x => !x.IsArchivedMembership)
-                : clan.Memberships.Where(x =>
-                    !x.IsArchivedMembership && x.Rank.RankNumber <= actorMembership.Rank.RankNumber))
-            .OrderByDescending(x => x.Rank.RankNumber)
-            .ThenBy(x => x.JoinDate)
-            .ToList();
-        actor.OutputHandler.Send(
-            StringUtilities.GetTextTable(
-                from member in members
-                select
-                    new[]
-                    {
-                        member.PersonalName.GetName(NameStyle.FullName), member.Rank.Name.TitleCase(),
-                        member.Paygrade != null ? member.Paygrade.Abbreviation : "N/A",
-                        member.Appointments.Select(x => x.Name.TitleCase())
-                              .ListToString(conjunction: "", twoItemJoiner: ", "),
-                        clan.Calendar.DisplayDate(member.JoinDate, CalendarDisplayMode.Short)
-                    },
-                new[] { "Name", "Rank", "Paygrade", "Appointments", "Member Since" },
-                actor.Account.LineFormatLength, colour: Telnet.Green, truncatableColumnIndex: 3
-            )
-        );
+        clan.ShowMembers(actor);
     }
 
     private static void ClanVassalAppoint(ICharacter actor, StringStack command)
@@ -8192,28 +7110,7 @@ return 0",
             return;
         }
 
-        string appointmentText = command.PopSpeech();
-        string liegeClanText = command.PopSpeech(); // Optional
-
-        IEnumerable<IClan> clans;
-        if (actor.IsAdministrator(PermissionLevel.Admin))
-        {
-            clans = actor.Gameworld.Clans;
-        }
-        else
-        {
-            clans =
-                actor.ClanMemberships.Select(x => x.Clan)
-                     .Concat(
-                         actor.ClanMemberships.SelectMany(
-                             x => x.Clan.ExternalControls.Where(y => y.LiegeClan == x.Clan).Select(y => y.VassalClan)));
-        }
-
-        IClan clan =
-            clans.FirstOrDefault(x => x.FullName.Equals(clanText, StringComparison.InvariantCultureIgnoreCase)) ??
-            clans.FirstOrDefault(x => x.Alias.Equals(clanText, StringComparison.InvariantCultureIgnoreCase)) ??
-            clans.FirstOrDefault(x => x.Alias.StartsWith(clanText, StringComparison.InvariantCultureIgnoreCase)) ??
-            clans.FirstOrDefault(x => x.FullName.StartsWith(clanText, StringComparison.InvariantCultureIgnoreCase));
+        IClan clan = GetTargetExternallyAccessibleClan(actor, clanText);
         if (clan == null)
         {
             actor.OutputHandler.Send(actor.IsAdministrator(PermissionLevel.Admin)
@@ -8222,174 +7119,13 @@ return 0",
             return;
         }
 
-        IExternalClanControl appointment =
-            clan.ExternalControls.Where(x => x.VassalClan == clan)
-                .FirstOrDefault(
-                    x =>
-                        x.ControlledAppointment.Name.Equals(appointmentText,
-                            StringComparison.InvariantCultureIgnoreCase));
-        if (appointment == null)
+        if (command.IsFinished)
         {
-            actor.OutputHandler.Send("There are no such appointments available in that clan.");
+            actor.OutputHandler.Send("To which position do you wish to appoint them?");
             return;
         }
 
-        List<IClan> liegeClans =
-            clans.Where(
-                x =>
-                    x.ExternalControls.Any(
-                        y =>
-                            y.VassalClan == clan &&
-                            y.ControlledAppointment == appointment.ControlledAppointment && y.LiegeClan == x)).ToList();
-        IClan liegeClan;
-        if (liegeClans.Count > 1)
-        {
-            liegeClans = liegeClans.Where(x => actor.ClanMemberships.Any(y => y.Clan == x)).ToList();
-
-            if (liegeClans.Count > 1)
-            {
-                if (string.IsNullOrEmpty(liegeClanText))
-                {
-                    actor.OutputHandler.Send(
-                        "The requested appointment is ambiguous, you must supply the name of the liege clan you wish to use.");
-                    return;
-                }
-
-                liegeClan =
-                    liegeClans.FirstOrDefault(
-                        x => x.FullName.Equals(liegeClanText, StringComparison.InvariantCultureIgnoreCase)) ??
-                    liegeClans.FirstOrDefault(
-                        x => x.Alias.Equals(liegeClanText, StringComparison.InvariantCultureIgnoreCase));
-            }
-            else
-            {
-                liegeClan = liegeClans.FirstOrDefault();
-            }
-        }
-        else
-        {
-            liegeClan = liegeClans.FirstOrDefault();
-        }
-
-        if (liegeClan == null)
-        {
-            actor.OutputHandler.Send("There is no such clan, or it is not a valid liege of the vassal clan.");
-            return;
-        }
-
-        IClanMembership actorMembership = liegeClan.Memberships.FirstOrDefault(x => x.MemberId == actor.Id);
-
-        ICharacter targetActor = actor.TargetActor(targetText);
-        if (targetActor == null)
-        {
-            actor.OutputHandler.Send("You do not see anyone like that to appoint to a position.");
-            return;
-        }
-
-        if (!actor.IsAdministrator(PermissionLevel.Admin) &&
-            appointment.ControllingAppointment != null &&
-            actorMembership != null &&
-            !actorMembership.Appointments.Contains(appointment.ControllingAppointment) &&
-            !actorMembership.NetPrivileges.HasFlag(ClanPrivilegeType.CanManageClanVassals)
-            )
-        {
-            if (appointment.ControllingAppointment is not null)
-            {
-                actor.Send("Only someone who holds the {0} position can appoint anyone to that vassal position.",
-                appointment.ControllingAppointment.Name.TitleCase().Colour(Telnet.Green));
-            }
-            else
-            {
-                actor.Send("You are not authorised to appoint anyone to that vassal position.");
-            }
-
-            return;
-        }
-
-        IClanMembership targetMembership =
-            clan.Memberships.FirstOrDefault(x => !x.IsArchivedMembership && x.MemberId == targetActor.Id);
-        if (targetMembership != null && targetMembership.Appointments.Contains(appointment.ControlledAppointment))
-        {
-            actor.OutputHandler.Send("They already hold that position, and so cannot be appointed again.");
-            return;
-        }
-
-        if (appointment.NumberOfAppointments > 0 && appointment.NumberOfAppointments <= appointment.Appointees.Count)
-        {
-            actor.OutputHandler.Send(
-                "The maximum number of appointments to that position through that relationship has been reached. You must first dismiss existing appointees.");
-            return;
-        }
-
-        // If the appointee is not a member of the clan, make them a member with the minimum required rank
-        if (targetMembership == null)
-        {
-            IRank rank = appointment.ControlledAppointment.MinimumRankToHold ?? clan.Ranks.FirstMin(x => x.RankNumber);
-            IClanMembership archived = clan.Memberships.FirstOrDefault(x => x.IsArchivedMembership && x.MemberId == targetActor.Id);
-            if (archived != null)
-            {
-                archived.IsArchivedMembership = false;
-                archived.Changed = true;
-                targetActor.AddMembership(archived);
-                if (archived.Rank.RankNumber < rank.RankNumber)
-                {
-                    archived.Rank = rank;
-                }
-            }
-            else
-            {
-                using (new FMDB())
-                {
-                    Models.ClanMembership dbitem = new()
-                    {
-                        CharacterId = targetActor.Id,
-                        ClanId = clan.Id,
-                        RankId = rank.Id,
-                        PaygradeId = rank.Paygrades.Any() ? rank.Paygrades.First().Id : (long?)null,
-                        PersonalName = targetActor.CurrentName.SaveToXml().ToString(),
-                        JoinDate = clan.Calendar.CurrentDate.GetDateString()
-                    };
-                    FMDB.Context.ClanMemberships.Add(dbitem);
-                    FMDB.Context.SaveChanges();
-                    ClanMembership newMembership = new(dbitem, clan, targetActor.Gameworld);
-                    targetActor.AddMembership(newMembership);
-                    clan.Memberships.Add(newMembership);
-                    targetMembership = newMembership;
-                }
-            }
-        }
-        else if (appointment.ControlledAppointment.MinimumRankToHold != null &&
-                 targetMembership.Rank.RankNumber < appointment.ControlledAppointment.MinimumRankToHold.RankNumber)
-        {
-            clan.SetRank(targetMembership, appointment.ControlledAppointment.MinimumRankToHold);
-        }
-
-        using (new FMDB())
-        {
-            Models.ExternalClanControl dbappointment = FMDB.Context.ExternalClanControls.Find(clan.Id, liegeClan.Id,
-                appointment.ControlledAppointment.Id);
-            ExternalClanControlsAppointment newAppointment = new()
-            {
-                CharacterId = targetActor.Id
-            };
-            dbappointment.ExternalClanControlsAppointments.Add(newAppointment);
-            FMDB.Context.SaveChanges();
-
-            appointment.Appointees.Add(targetMembership);
-            targetMembership.Appointments.Add(appointment.ControlledAppointment);
-            targetMembership.Changed = true;
-        }
-
-        actor.OutputHandler.Handle(new FilteredEmoteOutput(new Emote(
-                $"@ appoint|appoints $0 to the position of {appointment.ControlledAppointment.Title(targetActor).TitleCase().Colour(Telnet.Green)} in {clan.FullName.TitleCase().Colour(Telnet.Green)} on behalf of {liegeClan.FullName.TitleCase().Colour(Telnet.Green)}.",
-                actor, targetActor),
-            perceiver =>
-            {
-                return perceiver is ICharacter pChar &&
-                       (pChar.ClanMemberships.Any(x => x.Clan == clan || x.Clan == liegeClan) ||
-                        pChar.PermissionLevel >= PermissionLevel.JuniorAdmin);
-            }
-        ));
+        clan.AppointExternal(actor, new StringStack($"\"{targetText}\" {command.RemainingArgument}"));
     }
 
     private static void ClanVassalDismiss(ICharacter actor, StringStack command)
@@ -8416,26 +7152,7 @@ return 0",
             return;
         }
 
-        string appointmentText = command.PopSpeech();
-        string liegeClanText = command.PopSpeech(); // Optional
-
-        IEnumerable<IClan> clans;
-        if (actor.IsAdministrator(PermissionLevel.Admin))
-        {
-            clans = actor.Gameworld.Clans;
-        }
-        else
-        {
-            clans =
-                actor.ClanMemberships.Select(x => x.Clan)
-                     .Concat(
-                         actor.ClanMemberships.SelectMany(
-                             x => x.Clan.ExternalControls.Where(y => y.LiegeClan == x.Clan).Select(y => y.VassalClan)));
-        }
-
-        IClan clan =
-            clans.FirstOrDefault(x => x.FullName.Equals(clanText, StringComparison.InvariantCultureIgnoreCase)) ??
-            clans.FirstOrDefault(x => x.Alias.Equals(clanText, StringComparison.InvariantCultureIgnoreCase));
+        IClan clan = GetTargetExternallyAccessibleClan(actor, clanText);
         if (clan == null)
         {
             actor.OutputHandler.Send(actor.IsAdministrator(PermissionLevel.Admin)
@@ -8444,135 +7161,41 @@ return 0",
             return;
         }
 
-        IExternalClanControl appointment =
-            clan.ExternalControls.Where(x => x.VassalClan == clan)
-                .FirstOrDefault(
-                    x =>
-                        x.ControlledAppointment.Name.Equals(appointmentText,
-                            StringComparison.InvariantCultureIgnoreCase));
-        if (appointment == null)
+        if (command.IsFinished)
         {
-            actor.OutputHandler.Send("There are no such appointments available in that clan.");
+            actor.OutputHandler.Send("From which position do you wish to dismiss them?");
             return;
         }
 
-        IEnumerable<IClan> liegeClans =
-            clans.Where(
-                x =>
-                    x.ExternalControls.Any(
-                        y =>
-                            y.VassalClan == clan &&
-                            y.ControlledAppointment == appointment.ControlledAppointment && y.LiegeClan == x));
-        IClan liegeClan;
-        if (liegeClans.Count() > 1)
-        {
-            liegeClans = liegeClans.Where(x => actor.ClanMemberships.Any(y => y.Clan == x));
+        clan.DismissExternal(actor, new StringStack($"\"{targetText}\" {command.RemainingArgument}"));
+    }
 
-            if (liegeClans.Count() > 1)
-            {
-                if (string.IsNullOrEmpty(liegeClanText))
-                {
-                    actor.OutputHandler.Send(
-                        "The requested appointment is ambiguous, you must supply the name of the liege clan you wish to use.");
-                    return;
-                }
-
-                liegeClan =
-                    liegeClans.FirstOrDefault(
-                        x => x.FullName.Equals(liegeClanText, StringComparison.InvariantCultureIgnoreCase)) ??
-                    liegeClans.FirstOrDefault(
-                        x => x.Alias.Equals(liegeClanText, StringComparison.InvariantCultureIgnoreCase));
-            }
-            else
-            {
-                liegeClan = liegeClans.FirstOrDefault();
-            }
-        }
-        else
+    private static void ClanVassalControl(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
         {
-            liegeClan = liegeClans.FirstOrDefault();
-        }
-
-        if (liegeClan == null)
-        {
-            actor.OutputHandler.Send("There is no such clan, or it is not a valid liege of the vassal clan.");
+            actor.OutputHandler.Send("In which vassal clan do you wish to alter the controlling appointment?");
             return;
         }
 
-        IClanMembership actorMembership = liegeClan.Memberships.FirstOrDefault(x => x.MemberId == actor.Id);
-
-        IClanMembership targetMembership;
-        ICharacter targetActor = actor.TargetActor(targetText);
-        if (targetActor != null)
+        string clanText = command.PopSpeech();
+        IClan clan = GetTargetExternallyAccessibleClan(actor, clanText);
+        if (clan == null)
         {
-            targetMembership = targetActor.ClanMemberships.FirstOrDefault(x => x.Clan == clan);
-        }
-        else
-        {
-            targetMembership =
-                appointment.Appointees.FirstOrDefault(
-                    x =>
-                        x.PersonalName.GetName(NameStyle.FullName)
-                         .Equals(targetText, StringComparison.InvariantCultureIgnoreCase));
-        }
-
-        if (targetMembership == null)
-        {
-            actor.OutputHandler.Send("There is no such member for you to dismiss that falls within your remit.");
+            actor.OutputHandler.Send(actor.IsAdministrator(PermissionLevel.Admin)
+                ? "There is no such clan."
+                : "You are not a member (or member of a liege) of any such clan.");
             return;
         }
 
-        if (!actor.IsAdministrator(PermissionLevel.Admin) && appointment.ControllingAppointment != null &&
-            actorMembership != null && !actorMembership.Appointments.Contains(appointment.ControllingAppointment) &&
-            !actorMembership.NetPrivileges.HasFlag(ClanPrivilegeType.CanManageClanVassals))
-        {
-            if (appointment.ControllingAppointment is not null)
-            {
-                actor.Send("Only someone who holds the {0} position can dismiss anyone from that vassal position.",
-                appointment.ControllingAppointment.Name.TitleCase().Colour(Telnet.Green));
-            }
-            else
-            {
-                actor.Send("You are not authorised to dismiss anyone from that vassal position.");
-            }
-            return;
-        }
-
-        using (new FMDB())
-        {
-            Models.ExternalClanControl dbappointment = FMDB.Context.ExternalClanControls.Find(clan.Id, liegeClan.Id,
-                appointment.ControlledAppointment.Id);
-            dbappointment.ExternalClanControlsAppointments.Remove(
-                dbappointment.ExternalClanControlsAppointments.First(
-                    x => x.CharacterId == targetMembership.MemberId));
-            FMDB.Context.SaveChanges();
-
-            appointment.Appointees.Remove(targetMembership);
-            targetMembership.Clan.DismissAppointment(targetMembership, appointment.ControlledAppointment);
-        }
-
-        if (targetActor != null)
-        {
-            actor.OutputHandler.Handle(new FilteredEmoteOutput(new Emote(
-                    $"@ dismiss|dismisses $0 from the position of {appointment.ControlledAppointment.Title(targetActor).TitleCase().Colour(Telnet.Green)} in {clan.FullName.TitleCase().Colour(Telnet.Green)} on behalf of {liegeClan.FullName.TitleCase().Colour(Telnet.Green)}.",
-                    actor, targetActor),
-                perceiver =>
-                {
-                    return perceiver is ICharacter pChar &&
-                           (pChar.ClanMemberships.Any(
-                                x =>
-                                    x.Clan == clan ||
-                                    x.Clan == liegeClan) ||
-                            pChar.PermissionLevel >=
-                            PermissionLevel.JuniorAdmin);
-                }
-            ));
-        }
-        else
+        if (command.IsFinished)
         {
             actor.OutputHandler.Send(
-                $"You dismiss {targetMembership.PersonalName.GetName(NameStyle.FullName).TitleCase().Colour(Telnet.Green)} from the position of {appointment.ControlledAppointment.Name.TitleCase().Colour(Telnet.Green)} in {clan.FullName.TitleCase().Colour(Telnet.Green)} on behalf of {liegeClan.FullName.TitleCase().Colour(Telnet.Green)}.");
+                "Which appointment in that vassal clan do you wish to alter the controlling appointment for?");
+            return;
         }
+
+        clan.SetControllingAppointment(actor, command);
     }
 
     private static void ClanVassal(ICharacter actor, StringStack command)
@@ -8590,6 +7213,9 @@ return 0",
                 break;
             case "dismiss":
                 ClanVassalDismiss(actor, command);
+                break;
+            case "control":
+                ClanVassalControl(actor, command);
                 break;
             default:
                 actor.OutputHandler.Send("That is not a valid option to use with the clan vassal command.");

--- a/MudSharpCore/Community/Appointment.cs
+++ b/MudSharpCore/Community/Appointment.cs
@@ -277,13 +277,8 @@ public class Appointment : SaveableItem, IAppointment
 
         if (MaximumConsecutiveTerms > 0)
         {
-            List<IElection> pastElections = Elections
-                                .Where(x => x.IsFinalised && !x.IsByElection)
-                                .OrderByDescending(x => x.ResultsInEffectDate)
-                                .Take(MaximumConsecutiveTerms)
-                                .ToList();
-            if (pastElections.Count >= MaximumConsecutiveTerms &&
-                pastElections.All(x => x.Victors.Any(y => y.MemberId == character.Id)))
+            if (ClanCommandUtilities.HasReachedConsecutiveTermLimit(Elections, character.Id,
+                    MaximumConsecutiveTerms))
             {
                 return (false,
                     $"You have reached the limit of {MaximumConsecutiveTerms.ToString("N0", character).ColourValue()} consecutive terms as {Title(character).ColourValue()}.");
@@ -292,9 +287,7 @@ public class Appointment : SaveableItem, IAppointment
 
         if (MaximumTotalTerms > 0)
         {
-            if (Elections
-                .Where(x => x.IsFinalised && !x.IsByElection)
-                .Count(x => x.Victors.Any(y => y.MemberId == character.Id)) > MaximumTotalTerms)
+            if (ClanCommandUtilities.HasReachedTotalTermLimit(Elections, character.Id, MaximumTotalTerms))
             {
                 return (false,
                     $"You have reached the life-time limit of {MaximumTotalTerms.ToString("N0", character).ColourValue()} total terms as {Title(character).ColourValue()}.");

--- a/MudSharpCore/Community/Clan.CommandHandling.cs
+++ b/MudSharpCore/Community/Clan.CommandHandling.cs
@@ -1,0 +1,1913 @@
+using MudSharp.Accounts;
+using MudSharp.Character;
+using MudSharp.Character.Name;
+using MudSharp.Database;
+using MudSharp.Economy;
+using MudSharp.Economy.Currency;
+using MudSharp.Effects.Concrete;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.Models;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Outputs;
+using MudSharp.PerceptionEngine.Parsers;
+using MudSharp.TimeAndDate.Date;
+using MudSharp.TimeAndDate.Time;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MudSharp.Community;
+
+public partial class Clan
+{
+	private IClanMembership? ActorMembership(ICharacter actor)
+	{
+		return actor.ClanMemberships.FirstOrDefault(x => x.Clan == this);
+	}
+
+	private bool HasPrivilege(ICharacter actor, ClanPrivilegeType privilege, out IClanMembership? membership)
+	{
+		membership = ActorMembership(actor);
+		return actor.IsAdministrator(PermissionLevel.Admin) ||
+		       membership?.NetPrivileges.HasFlag(privilege) == true;
+	}
+
+	private bool CanViewMembers(ICharacter actor, IClanMembership? membership)
+	{
+		return actor.IsAdministrator(PermissionLevel.Admin) ||
+		       membership?.NetPrivileges.HasFlag(ClanPrivilegeType.CanViewMembers) == true;
+	}
+
+	private bool CanViewOfficeHolders(ICharacter actor, IClanMembership? membership)
+	{
+		return actor.IsAdministrator(PermissionLevel.Admin) ||
+		       membership?.NetPrivileges.HasFlag(ClanPrivilegeType.CanViewClanOfficeHolders) == true;
+	}
+
+	private bool CanViewAboveOwnRank(ICharacter actor, IClanMembership? membership)
+	{
+		return actor.IsAdministrator(PermissionLevel.Admin) ||
+		       membership?.NetPrivileges.HasFlag(ClanPrivilegeType.CanViewClanStructure) == true;
+	}
+
+	private bool CanViewEqualRankOrLower(ICharacter actor, IClanMembership? membership)
+	{
+		return actor.IsAdministrator(PermissionLevel.Admin) ||
+		       membership?.NetPrivileges.HasFlag(ClanPrivilegeType.CanViewClanStructureEqualRankOrLower) == true;
+	}
+
+	private bool CanViewFinances(ICharacter actor, IClanMembership? membership)
+	{
+		return actor.IsAdministrator(PermissionLevel.Admin) ||
+		       membership?.NetPrivileges.HasFlag(ClanPrivilegeType.CanViewTreasury) == true;
+	}
+
+	private bool IsVisibleThroughAppointmentChain(IClanMembership? membership, IAppointment? appointment)
+	{
+		return ClanCommandUtilities.HoldsOrControlsAppointment(membership, appointment);
+	}
+
+	private IClanMembership? GetActiveMembership(string targetText, ICharacter actor, out ICharacter? targetActor)
+	{
+		targetActor = actor.TargetActor(targetText);
+		if (targetActor is not null)
+		{
+			return targetActor.ClanMemberships.FirstOrDefault(x => x.Clan == this && !x.IsArchivedMembership);
+		}
+
+		return Memberships
+			.Where(x => !x.IsArchivedMembership)
+			.GetByNameOrAbbreviation(targetText);
+	}
+
+	private IClanMembership? GetMembershipByName(string targetText)
+	{
+		return Memberships
+			.Where(x => !x.IsArchivedMembership)
+			.GetByNameOrAbbreviation(targetText);
+	}
+
+	private bool TryGetExternalControl(string appointmentText, string? liegeClanText, ICharacter actor,
+		out IExternalClanControl? control, out IClan? liegeClan, out string error)
+	{
+		var matches = ExternalControls
+			.Where(x => x.VassalClan == this)
+			.Where(x => x.ControlledAppointment.Name.EqualTo(appointmentText) ||
+			            x.ControlledAppointment.Name.StartsWith(appointmentText,
+				            StringComparison.InvariantCultureIgnoreCase))
+			.ToList();
+
+		if (!matches.Any())
+		{
+			control = null;
+			liegeClan = null;
+			error = "There are no such appointments available in that clan.";
+			return false;
+		}
+
+		if (!string.IsNullOrEmpty(liegeClanText))
+		{
+			matches = matches
+				.Where(x => x.LiegeClan.FullName.EqualTo(liegeClanText) || x.LiegeClan.Alias.EqualTo(liegeClanText) ||
+				            x.LiegeClan.FullName.StartsWith(liegeClanText, StringComparison.InvariantCultureIgnoreCase) ||
+				            x.LiegeClan.Alias.StartsWith(liegeClanText, StringComparison.InvariantCultureIgnoreCase))
+				.ToList();
+		}
+
+		if (!matches.Any())
+		{
+			control = null;
+			liegeClan = null;
+			error = "There is no such clan, or it is not a valid liege of the vassal clan.";
+			return false;
+		}
+
+		if (matches.Count > 1)
+		{
+			var actorLiegeMatches = actor.IsAdministrator(PermissionLevel.Admin)
+				? matches
+				: matches.Where(x => actor.ClanMemberships.Any(y => y.Clan == x.LiegeClan)).ToList();
+			if (actorLiegeMatches.Count == 1)
+			{
+				matches = actorLiegeMatches;
+			}
+			else
+			{
+				control = null;
+				liegeClan = null;
+				error =
+					"The requested appointment is ambiguous, you must supply the name of the liege clan you wish to use.";
+				return false;
+			}
+		}
+
+		control = matches[0];
+		liegeClan = control.LiegeClan;
+		error = string.Empty;
+		return true;
+	}
+
+	private bool CanManageExternalControl(ICharacter actor, IExternalClanControl control, IClan liegeClan,
+		out IClanMembership? actorMembership)
+	{
+		actorMembership = liegeClan.Memberships.FirstOrDefault(x => x.MemberId == actor.Id);
+		if (actor.IsAdministrator(PermissionLevel.Admin))
+		{
+			return true;
+		}
+
+		if (actorMembership is null)
+		{
+			return false;
+		}
+
+		if (actorMembership.NetPrivileges.HasFlag(ClanPrivilegeType.CanManageClanVassals))
+		{
+			return true;
+		}
+
+		return ClanCommandUtilities.HoldsOrControlsAppointment(actorMembership, control.ControllingAppointment);
+	}
+
+	private bool TryResolveElection(string electionOrAppointmentText, out IElection? election, out string error)
+	{
+		if (long.TryParse(electionOrAppointmentText, out var value))
+		{
+			election = Gameworld.Elections.Get(value);
+			if (election is null || election.Appointment.Clan != this)
+			{
+				error = "There is no such election in that clan.";
+				return false;
+			}
+
+			error = string.Empty;
+			return true;
+		}
+
+		var appointment = Appointments.GetByIdOrName(electionOrAppointmentText);
+		if (appointment is null)
+		{
+			election = null;
+			error = $"{FullName.ColourName()} has no such appointment.";
+			return false;
+		}
+
+		if (!appointment.IsAppointedByElection)
+		{
+			election = null;
+			error = $"The position {appointment.Name.ColourName()} is not controlled by elections.";
+			return false;
+		}
+
+		election = ClanCommandUtilities.GetNextOpenElection(appointment);
+		if (election is null)
+		{
+			error = $"There is no open election for the position of {appointment.Name.ColourName()} in {FullName.ColourName()}.";
+			return false;
+		}
+
+		error = string.Empty;
+		return true;
+	}
+
+	private void ShowElectionNominees(ICharacter actor, IElection election, string? errorMessage = null)
+	{
+		var sb = new StringBuilder();
+		if (!string.IsNullOrEmpty(errorMessage))
+		{
+			sb.AppendLine(errorMessage);
+		}
+
+		sb.AppendLine(
+			$"There are the following nominations for the election of {election.Appointment.Name.ColourName()} in {election.Appointment.Clan.FullName.ColourName()}:");
+		sb.AppendLine();
+		foreach (var nominee in election.Nominees)
+		{
+			var dub = actor.Dubs.FirstOrDefault(x =>
+				x.FrameworkItemType == "Character" && x.TargetId == nominee.MemberId && !x.WasIdentityConcealed);
+			if (dub is not null)
+			{
+				sb.AppendLine(
+					$"\t{nominee.PersonalName.GetName(NameStyle.FullName)} ({dub.LastDescription.ColourCharacter()})");
+				continue;
+			}
+
+			sb.AppendLine($"\t{nominee.PersonalName.GetName(NameStyle.FullName)}");
+		}
+
+		actor.OutputHandler.Send(sb.ToString());
+	}
+
+	public void Show(ICharacter actor, StringStack command)
+	{
+		var actorMembership = ActorMembership(actor);
+		if (!actor.IsAdministrator(PermissionLevel.Admin) && !IsTemplate &&
+		    actorMembership?.NetPrivileges.HasFlag(ClanPrivilegeType.CanViewClanStructure) != true &&
+		    actorMembership?.NetPrivileges.HasFlag(ClanPrivilegeType.CanViewClanStructureEqualRankOrLower) != true)
+		{
+			actor.OutputHandler.Send("You are not allowed to view the structure of that clan.");
+			return;
+		}
+
+		switch (command.PopSpeech().ToLowerInvariant())
+		{
+			case "":
+				ShowDefault(actor, actorMembership);
+				return;
+			case "rank":
+				if (command.IsFinished)
+				{
+					actor.OutputHandler.Send("Which rank do you wish to view in that clan?");
+					return;
+				}
+
+				var rank = Ranks.GetByIdOrName(command.SafeRemainingArgument);
+				if (rank is null)
+				{
+					actor.OutputHandler.Send("There is no such rank for you to view.");
+					return;
+				}
+
+				if (!actor.IsAdministrator(PermissionLevel.Admin) && !IsTemplate &&
+				    !CanViewAboveOwnRank(actor, actorMembership) &&
+				    (actorMembership is null || rank.RankNumber > actorMembership.Rank.RankNumber))
+				{
+					actor.OutputHandler.Send("There is no such rank for you to view.");
+					return;
+				}
+
+				ShowRank(actor, rank);
+				return;
+			case "pay grade":
+			case "paygrade":
+				if (command.IsFinished)
+				{
+					actor.OutputHandler.Send("Which pay grade do you wish to view in that clan?");
+					return;
+				}
+
+				var paygrade = Paygrades.GetByIdOrName(command.SafeRemainingArgument);
+				if (paygrade is null)
+				{
+					actor.OutputHandler.Send("There is no such pay grade for you to view.");
+					return;
+				}
+
+				if (!actor.IsAdministrator(PermissionLevel.Admin) && !IsTemplate &&
+				    !CanViewAboveOwnRank(actor, actorMembership))
+				{
+					var paygradeRank = Ranks.FirstOrDefault(x => x.Paygrades.Contains(paygrade));
+					if (paygradeRank is not null &&
+					    (actorMembership is null || paygradeRank.RankNumber > actorMembership.Rank.RankNumber))
+					{
+						actor.OutputHandler.Send("There is no such pay grade for you to view.");
+						return;
+					}
+
+					var paygradeAppointment = Appointments.FirstOrDefault(x => x.Paygrade == paygrade);
+					if (paygradeAppointment is not null &&
+					    !IsVisibleThroughAppointmentChain(actorMembership, paygradeAppointment))
+					{
+						actor.OutputHandler.Send("There is no such pay grade for you to view.");
+						return;
+					}
+				}
+
+				ShowPaygrade(actor, paygrade);
+				return;
+			case "appointment":
+				if (command.IsFinished)
+				{
+					actor.OutputHandler.Send("Which appointment do you wish to view in that clan?");
+					return;
+				}
+
+				var appointment = Appointments.GetByIdOrName(command.SafeRemainingArgument);
+				if (appointment is null)
+				{
+					actor.OutputHandler.Send("There is no such appointment for you to view.");
+					return;
+				}
+
+				if (!actor.IsAdministrator(PermissionLevel.Admin) && !IsTemplate &&
+				    !CanViewAboveOwnRank(actor, actorMembership) &&
+				    !IsVisibleThroughAppointmentChain(actorMembership, appointment))
+				{
+					actor.OutputHandler.Send("There is no such appointment for you to view.");
+					return;
+				}
+
+				ShowAppointment(actor, appointment);
+				return;
+			case "external":
+			case "externalcontrol":
+			case "external control":
+			case "control":
+				if (command.IsFinished)
+				{
+					actor.OutputHandler.Send("Which clan's external control do you wish to view in that clan?");
+					return;
+				}
+
+				var externalClanText = command.PopSpeech();
+				if (command.IsFinished)
+				{
+					actor.OutputHandler.Send(
+						"Which position in that clan do you wish to view the other clan's external control over?");
+					return;
+				}
+
+				var externalPositionText = command.SafeRemainingArgument;
+				var external = ExternalControls
+					.Where(x => x.VassalClan == this)
+					.Where(x => x.LiegeClan.FullName.EqualTo(externalClanText) || x.LiegeClan.Alias.EqualTo(externalClanText) ||
+					            x.LiegeClan.FullName.StartsWith(externalClanText, StringComparison.InvariantCultureIgnoreCase) ||
+					            x.LiegeClan.Alias.StartsWith(externalClanText, StringComparison.InvariantCultureIgnoreCase))
+					.FirstOrDefault(x => x.ControlledAppointment.Name.EqualTo(externalPositionText) ||
+					                     x.ControlledAppointment.Name.StartsWith(externalPositionText,
+						                     StringComparison.InvariantCultureIgnoreCase));
+				if (external is null)
+				{
+					actor.OutputHandler.Send("There is no such clan exerting any external control over that clan.");
+					return;
+				}
+
+				ShowExternalControl(actor, external);
+				return;
+			default:
+				actor.OutputHandler.Send("That is not a valid option for the clan view command.");
+				return;
+		}
+	}
+
+	public void ShowMembers(ICharacter actor)
+	{
+		var actorMembership = ActorMembership(actor);
+		if (!actor.IsAdministrator(PermissionLevel.Admin) &&
+		    actorMembership?.NetPrivileges.HasFlag(ClanPrivilegeType.CanViewMembers) != true)
+		{
+			actor.OutputHandler.Send("You are not allowed to view the list of members for that clan.");
+			return;
+		}
+
+		var members = (actor.IsAdministrator(PermissionLevel.Admin) || CanViewAboveOwnRank(actor, actorMembership)
+			? Memberships.Where(x => !x.IsArchivedMembership)
+			: Memberships.Where(x => !x.IsArchivedMembership &&
+			                         actorMembership is not null &&
+			                         x.Rank.RankNumber <= actorMembership.Rank.RankNumber))
+			.OrderByDescending(x => x.Rank.RankNumber)
+			.ThenBy(x => x.JoinDate)
+			.ToList();
+
+		actor.OutputHandler.Send(
+			StringUtilities.GetTextTable(
+				from member in members
+				select new[]
+				{
+					member.PersonalName.GetName(NameStyle.FullName),
+					member.Rank.Name.TitleCase(),
+					member.Paygrade?.Abbreviation ?? "N/A",
+					member.Appointments.Select(x => x.Name.TitleCase()).ListToString(conjunction: "", twoItemJoiner: ", "),
+					Calendar.DisplayDate(member.JoinDate, CalendarDisplayMode.Short)
+				},
+				new[] { "Name", "Rank", "Paygrade", "Appointments", "Member Since" },
+				actor.Account.LineFormatLength, colour: Telnet.Green, truncatableColumnIndex: 3));
+	}
+
+	public string DescribeElections(ICharacter actor)
+	{
+		var actorMembership = ActorMembership(actor);
+		if (!actor.IsAdministrator(PermissionLevel.Admin) && !CanViewOfficeHolders(actor, actorMembership))
+		{
+			return $"You do not have sufficient privileges in {FullName.ColourName()} to view elections.";
+		}
+
+		var appointmentsWithElections = Appointments.Where(x => x.IsAppointedByElection).ToList();
+		if (!appointmentsWithElections.Any())
+		{
+			return string.Empty;
+		}
+
+		var sb = new StringBuilder();
+		sb.AppendLine($"Elections in {FullName}".GetLineWithTitle(actor.LineFormatLength,
+			actor.Account.UseUnicode, Telnet.BoldBlue, Telnet.BoldWhite));
+		foreach (var appointment in appointmentsWithElections)
+		{
+			sb.AppendLine();
+			sb.AppendLine(
+				$"The {appointment.Name.ColourName()} position elects {appointment.MaximumSimultaneousHolders.ToString("N0", actor).ColourValue()} positions every {appointment.ElectionTerm.Describe(actor).ColourValue()}.");
+			if (appointment.MaximumConsecutiveTerms <= 0 && appointment.MaximumTotalTerms <= 0)
+			{
+				sb.AppendLine("There are no term limits for electors.");
+			}
+			else if (appointment.MaximumConsecutiveTerms <= 0)
+			{
+				sb.AppendLine(
+					$"There is a life-time term limit of {appointment.MaximumTotalTerms.ToString("N0", actor).ColourValue()} term{(appointment.MaximumTotalTerms == 1 ? "" : "s")}.");
+			}
+			else if (appointment.MaximumTotalTerms <= 0)
+			{
+				sb.AppendLine(
+					$"There is a term limit of {appointment.MaximumConsecutiveTerms.ToString("N0", actor).ColourValue()} consecutive {(appointment.MaximumConsecutiveTerms == 1 ? "term" : "terms")}.");
+			}
+			else
+			{
+				sb.AppendLine(
+					$"There is a life-time term limit of {appointment.MaximumTotalTerms.ToString("N0", actor).ColourValue()} term{(appointment.MaximumTotalTerms == 1 ? "" : "s")} and/or {appointment.MaximumConsecutiveTerms.ToString("N0", actor).ColourValue()} consecutive {(appointment.MaximumConsecutiveTerms == 1 ? "term" : "terms")}.");
+			}
+
+			sb.AppendLine(appointment.IsSecretBallot ? "This is a secret ballot." : "This is an open ballot and all votes cast are public.");
+
+			var votes = appointment.NumberOfVotes(actor);
+			sb.AppendLine(
+				$"You {(appointment.CanNominate(actor).Truth ? "are" : "are not")} eligable to nominate and {(votes <= 0 ? "cannot vote" : $"have {votes.ToString("N0", actor).ColourValue()} vote{(votes == 1 ? "" : "s")}")} in elections for this position.");
+
+			var primaryElection = ClanCommandUtilities.GetPrimaryOpenElection(appointment);
+			var byElection = ClanCommandUtilities.GetFirstOpenByElection(appointment);
+			if (byElection is not null)
+			{
+				switch (byElection.ElectionStage)
+				{
+					case ElectionStage.Preelection:
+						sb.AppendLine(
+							$"By-election #{byElection.Id.ToString("N0", actor)} for {byElection.NumberOfAppointments.ToString("N0", actor).ColourValue()} {(byElection.NumberOfAppointments == 1 ? "position" : "positions")} opening for nominations on {byElection.NominationStartDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}.");
+						break;
+					case ElectionStage.Nomination:
+						sb.AppendLine(
+							$"By-election #{byElection.Id.ToString("N0", actor)} for {byElection.NumberOfAppointments.ToString("N0", actor).ColourValue()} {(byElection.NumberOfAppointments == 1 ? "position" : "positions")} is open for nominations, with voting commencing on {byElection.VotingStartDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}.");
+						break;
+					case ElectionStage.Voting:
+						sb.AppendLine(
+							$"By-election #{byElection.Id.ToString("N0", actor)} for {byElection.NumberOfAppointments.ToString("N0", actor).ColourValue()} {(byElection.NumberOfAppointments == 1 ? "position" : "positions")} is open for voting, with votes closing on {byElection.VotingEndDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}.");
+						break;
+				}
+			}
+
+			if (primaryElection is null)
+			{
+				if (byElection is null)
+				{
+					sb.AppendLine("There is no currently scheduled primary election for this position.");
+				}
+
+				continue;
+			}
+
+			switch (primaryElection.ElectionStage)
+			{
+				case ElectionStage.Preelection:
+					sb.AppendLine(
+						$"The next election will open for nominations on {primaryElection.NominationStartDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}.");
+					break;
+				case ElectionStage.Nomination:
+					sb.AppendLine(
+						$"Election #{primaryElection.Id.ToString("N0", actor)} is open for nominations, with voting commencing on {primaryElection.VotingStartDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}.");
+					break;
+				case ElectionStage.Voting:
+					sb.AppendLine(
+						$"Election #{primaryElection.Id.ToString("N0", actor)} is open for voting, with votes closing on {primaryElection.VotingEndDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}.");
+					break;
+				case ElectionStage.Preinstallation:
+					sb.AppendLine(
+						$"Election #{primaryElection.Id.ToString("N0", actor)} has finished and the elected will commence their terms on {primaryElection.ResultsInEffectDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}.");
+					break;
+			}
+		}
+
+		return sb.ToString();
+	}
+
+	public void ShowElectionHistory(ICharacter actor, StringStack command)
+	{
+		var actorMembership = ActorMembership(actor);
+		if (!actor.IsAdministrator(PermissionLevel.Admin) && !CanViewOfficeHolders(actor, actorMembership))
+		{
+			actor.OutputHandler.Send($"You are not authorised to view elections in {FullName.ColourName()}.");
+			return;
+		}
+
+		if (Appointments.All(x => !x.IsAppointedByElection))
+		{
+			actor.OutputHandler.Send($"{FullName.ColourName()} does not have elections for any positions.");
+			return;
+		}
+
+		var appointments = Appointments.Where(x => x.IsAppointedByElection).ToList();
+		if (!command.IsFinished)
+		{
+			var appointment = Appointments.GetByIdOrName(command.SafeRemainingArgument);
+			if (appointment is null)
+			{
+				actor.OutputHandler.Send($"{FullName.ColourName()} has no such appointment.");
+				return;
+			}
+
+			if (!appointment.IsAppointedByElection)
+			{
+				actor.OutputHandler.Send($"The position {appointment.Name.ColourName()} is not controlled by elections.");
+				return;
+			}
+
+			appointments = [appointment];
+		}
+
+		var sb = new StringBuilder();
+		foreach (var appointment in appointments)
+		{
+			if (sb.Length > 0)
+			{
+				sb.AppendLine();
+			}
+
+			sb.AppendLine($"Election history for the {appointment.Name.ColourName()} position in {FullName.ColourName()}:");
+			sb.AppendLine();
+			foreach (var election in appointment.Elections.OrderByDescending(x => x.ResultsInEffectDate))
+			{
+				sb.Append($"#{election.Id.ToString("N0", actor)}) {(election.IsByElection ? "By-Election" : "Primary election")} of {election.NumberOfAppointments.ToString("N0", actor)} positions");
+				switch (election.ElectionStage)
+				{
+					case ElectionStage.Preelection:
+						sb.AppendLine($" due to begin {election.NominationStartDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}");
+						break;
+					case ElectionStage.Nomination:
+						sb.AppendLine($" open for nominations until {election.VotingStartDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}");
+						break;
+					case ElectionStage.Voting:
+						sb.AppendLine($" open for voting until {election.VotingEndDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}");
+						break;
+					case ElectionStage.Preinstallation:
+						sb.AppendLine($" closed, with electors taking office on {election.ResultsInEffectDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}");
+						break;
+					case ElectionStage.Finalised:
+						sb.AppendLine($" finished ({election.Victors.Select(x => x.PersonalName.GetName(NameStyle.FullName).ColourName()).DefaultIfEmpty("no victors".Colour(Telnet.Red)).ListToString(conjunction: "", twoItemJoiner: ", ")})");
+						break;
+				}
+			}
+		}
+
+		actor.OutputHandler.Send(sb.ToString(), false, true);
+	}
+
+	public void Nominate(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("You must either specify an election ID or a position for which you wish to nominate.");
+			return;
+		}
+
+		if (!TryResolveElection(command.SafeRemainingArgument, out var election, out var error))
+		{
+			actor.OutputHandler.Send(error);
+			return;
+		}
+
+		switch (election!.ElectionStage)
+		{
+			case ElectionStage.Preelection:
+				actor.OutputHandler.Send(
+					$"The nomination period for the election of {election.Appointment.Title(actor).ColourName()} in {election.Appointment.Clan.FullName.ColourName()} will not begin until {election.NominationStartDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}.");
+				return;
+			case ElectionStage.Nomination:
+				break;
+			default:
+				actor.OutputHandler.Send(
+					$"The nomination period for the election of {election.Appointment.Title(actor).ColourName()} in {election.Appointment.Clan.FullName.ColourName()} has closed.");
+				return;
+		}
+
+		var actorMembership = ActorMembership(actor);
+		if (actorMembership is null)
+		{
+			actor.OutputHandler.Send("You are not a member of that clan.");
+			return;
+		}
+
+		if (election.Nominees.Any(x => x.MemberId == actor.Id))
+		{
+			actor.OutputHandler.Send(
+				$"You are already a candidate for the election of {election.Appointment.Title(actor).ColourName()} in {election.Appointment.Clan.FullName.ColourName()}.");
+			return;
+		}
+
+		var (truth, nominationError) = election.Appointment.CanNominate(actor);
+		if (!truth)
+		{
+			actor.OutputHandler.Send(nominationError);
+			return;
+		}
+
+		election.Nominate(actorMembership);
+		actor.OutputHandler.Send(
+			$"You nominate yourself as a candidate for the position of {election.Appointment.Title(actor).ColourName()} in {election.Appointment.Clan.FullName.ColourName()}.");
+	}
+
+	public void WithdrawNomination(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("You must either specify an election ID or a position for which you wish to withdraw your nomination.");
+			return;
+		}
+
+		if (!TryResolveElection(command.SafeRemainingArgument, out var election, out var error))
+		{
+			actor.OutputHandler.Send(error);
+			return;
+		}
+
+		switch (election!.ElectionStage)
+		{
+			case ElectionStage.Preelection:
+				actor.OutputHandler.Send(
+					$"The nomination period for the election of {election.Appointment.Title(actor).ColourName()} in {election.Appointment.Clan.FullName.ColourName()} will not begin until {election.NominationStartDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}.");
+				return;
+			case ElectionStage.Nomination:
+				break;
+			default:
+				actor.OutputHandler.Send(
+					$"The nomination period for the election of {election.Appointment.Title(actor).ColourName()} in {election.Appointment.Clan.FullName.ColourName()} has closed.");
+				return;
+		}
+
+		if (!election.Nominees.Any(x => x.MemberId == actor.Id))
+		{
+			actor.OutputHandler.Send(
+				$"You are not a candidate for the election of {election.Appointment.Title(actor).ColourName()} in {election.Appointment.Clan.FullName.ColourName()}.");
+			return;
+		}
+
+		var actorMembership = ActorMembership(actor);
+		if (actorMembership is null)
+		{
+			actor.OutputHandler.Send("You are not a member of that clan.");
+			return;
+		}
+
+		election.WithdrawNomination(actorMembership);
+		actor.OutputHandler.Send(
+			$"You have withdrawn your candidacy for the election of {election.Appointment.Title(actor).ColourName()} in {election.Appointment.Clan.FullName.ColourName()}.");
+	}
+
+	public void Vote(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("You must either specify an election ID or a position for which you wish to vote.");
+			return;
+		}
+
+		IElection? election;
+		var firstArgument = command.PopSpeech();
+		if (!TryResolveElection(firstArgument, out election, out var error))
+		{
+			actor.OutputHandler.Send(error);
+			return;
+		}
+
+		var nomineeText = command.SafeRemainingArgument;
+
+		switch (election!.ElectionStage)
+		{
+			case ElectionStage.Voting:
+				break;
+			case ElectionStage.Preelection:
+			case ElectionStage.Nomination:
+				actor.OutputHandler.Send(
+					$"The voting period for the election of {election.Appointment.Name.ColourName()} in {election.Appointment.Clan.FullName.ColourName()} will not begin until {election.VotingStartDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}.");
+				return;
+			default:
+				actor.OutputHandler.Send(
+					$"The voting period for the election of {election.Appointment.Name.ColourName()} in {election.Appointment.Clan.FullName.ColourName()} has closed.");
+				return;
+		}
+
+		var votes = election.Appointment.NumberOfVotes(actor);
+		if (votes <= 0)
+		{
+			actor.OutputHandler.Send(
+				$"You are not entitled to vote in the election of {election.Appointment.Name.ColourName()} in {election.Appointment.Clan.FullName.ColourName()}.");
+			return;
+		}
+
+		if (string.IsNullOrWhiteSpace(nomineeText))
+		{
+			ShowElectionNominees(actor, election, "Which nominee do you want to cast your vote for?");
+			return;
+		}
+
+		var nomineeName = election.Nominees.Select(x => x.PersonalName).GetName(nomineeText);
+		if (nomineeName is null)
+		{
+			ShowElectionNominees(actor, election,
+				$"The supplied name is not a valid candidate in the election for {election.Appointment.Name.ColourName()} in {election.Appointment.Clan.FullName.ColourName()}.");
+			return;
+		}
+
+		var actorMembership = ActorMembership(actor);
+		if (actorMembership is null)
+		{
+			actor.OutputHandler.Send("You are not a member of that clan.");
+			return;
+		}
+
+		var voteChoice = election.Nominees.First(x => x.PersonalName == nomineeName);
+		var verb = election.Votes.Any(x => x.Voter.MemberId == actor.Id) ? "change" : "cast";
+		var particle = election.Votes.Any(x => x.Voter.MemberId == actor.Id) ? "to" : "for";
+		election.Vote(actorMembership, voteChoice, votes);
+		actor.OutputHandler.Send(
+			$"You {verb} your {(votes == 1 ? "vote" : $"{votes.ToString("N0", actor)} votes")} in the election for {election.Appointment.Name.ColourName()} in {election.Appointment.Clan.FullName.ColourName()} {particle} {nomineeName.GetName(NameStyle.FullName)}.");
+	}
+
+	public void Appoint(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Who do you want to give an appointment to?");
+			return;
+		}
+
+		var targetText = command.PopSpeech();
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("To which position do you want to appoint them?");
+			return;
+		}
+
+		var appointmentText = command.SafeRemainingArgument;
+		if (!HasPrivilege(actor, ClanPrivilegeType.CanAppoint, out var actorMembership))
+		{
+			actor.OutputHandler.Send("You are not allowed to appoint people to positions in that clan.");
+			return;
+		}
+
+		var targetMembership = GetActiveMembership(targetText, actor, out var targetActor);
+		if (targetMembership is null)
+		{
+			actor.OutputHandler.Send("There is no such member for you to appoint.");
+			return;
+		}
+
+		var appointment = Appointments.GetByIdOrName(appointmentText);
+		if (appointment is null)
+		{
+			actor.OutputHandler.Send("There is no such appointment in that clan.");
+			return;
+		}
+
+		if (appointment.IsAppointedByElection)
+		{
+			actor.OutputHandler.Send(
+				$"The position of {appointment.Name.TitleCase().ColourName()} is controlled by elections rather than direct appointments.");
+			return;
+		}
+
+		if (!actor.IsAdministrator(PermissionLevel.Admin) && appointment.ParentPosition is not null &&
+		    !IsVisibleThroughAppointmentChain(actorMembership, appointment.ParentPosition))
+		{
+			actor.OutputHandler.Send(
+				$"The position of {appointment.Name.TitleCase().Colour(Telnet.Green)} can only be appointed by {(appointment.ParentPosition.MaximumSimultaneousHolders > 1 ? appointment.ParentPosition.Name.TitleCase().A_An(colour: Telnet.Green) : appointment.ParentPosition.Name.TitleCase().Colour(Telnet.Green))}.");
+			return;
+		}
+
+		if (!actor.IsAdministrator(PermissionLevel.Admin) && appointment.MinimumRankToAppoint is not null &&
+		    (actorMembership is null || appointment.MinimumRankToAppoint.RankNumber > actorMembership.Rank.RankNumber) &&
+		    !IsVisibleThroughAppointmentChain(actorMembership, appointment.ParentPosition))
+		{
+			actor.Send("You must hold at least the rank of {0} before you can appoint them to that position.",
+				appointment.MinimumRankToAppoint.Title(actor).TitleCase().Colour(Telnet.Green));
+			return;
+		}
+
+		if (appointment.MinimumRankToHold is not null &&
+		    appointment.MinimumRankToHold.RankNumber > targetMembership.Rank.RankNumber)
+		{
+			actor.Send("They must hold at least the rank of {0} before you can appoint them to that position.",
+				appointment.MinimumRankToHold.Name.TitleCase().Colour(Telnet.Green));
+			return;
+		}
+
+		if (targetMembership.Appointments.Contains(appointment))
+		{
+			actor.OutputHandler.Send("They have already been appointed to that position.");
+			return;
+		}
+
+		if (!FreePosition(appointment))
+		{
+			actor.OutputHandler.Send(
+				"They cannot be appointed to that position as there is a limited number of holders at any one time.");
+			return;
+		}
+
+		targetMembership.Appointments.Add(appointment);
+		targetMembership.Changed = true;
+		if (targetActor is not null)
+		{
+			actor.OutputHandler.Handle(new FilteredEmoteOutput(new Emote(
+					$"@ appoint|appoints $0 to the position of {appointment.Title(targetActor).TitleCase().Colour(Telnet.Green)} in {FullName.TitleCase().Colour(Telnet.Green)}.",
+					actor, targetActor),
+				perceiver => perceiver is ICharacter pChar &&
+				            (pChar.ClanMemberships.Any(x => x.Clan == this) ||
+				             pChar.PermissionLevel >= PermissionLevel.JuniorAdmin)));
+			return;
+		}
+
+		actor.Send("You appoint {0} to the position of {1} in {2}.",
+			targetMembership.PersonalName.GetName(NameStyle.FullName).Colour(Telnet.Green),
+			appointment.Name.TitleCase().Colour(Telnet.Green), FullName.TitleCase().Colour(Telnet.Green));
+	}
+
+	public void Dismiss(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Who do you want to dismiss from an appointment?");
+			return;
+		}
+
+		var targetText = command.PopSpeech();
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("From which position do you want to dismiss them?");
+			return;
+		}
+
+		var appointmentText = command.SafeRemainingArgument;
+		if (!HasPrivilege(actor, ClanPrivilegeType.CanDismiss, out var actorMembership))
+		{
+			actor.OutputHandler.Send("You are not allowed to dismiss people from positions in that clan.");
+			return;
+		}
+
+		var targetMembership = GetActiveMembership(targetText, actor, out var targetActor);
+		if (targetMembership is null)
+		{
+			actor.OutputHandler.Send("There is no such member for you to dismiss.");
+			return;
+		}
+
+		var appointment = Appointments.GetByIdOrName(appointmentText);
+		if (appointment is null)
+		{
+			actor.OutputHandler.Send("There is no such appointment in that clan.");
+			return;
+		}
+
+		if (appointment.IsAppointedByElection)
+		{
+			actor.OutputHandler.Send(
+				$"The position of {appointment.Name.TitleCase().ColourName()} is controlled by elections rather than direct appointments.");
+			return;
+		}
+
+		if (!actor.IsAdministrator(PermissionLevel.Admin) && appointment.ParentPosition is not null &&
+		    !IsVisibleThroughAppointmentChain(actorMembership, appointment.ParentPosition))
+		{
+			actor.OutputHandler.Send(
+				$"The position of {appointment.Name.TitleCase().Colour(Telnet.Green)} can only be dismissed by {(appointment.ParentPosition.MaximumSimultaneousHolders > 1 ? appointment.ParentPosition.Name.TitleCase().A_An(colour: Telnet.Green) : appointment.ParentPosition.Name.TitleCase().Colour(Telnet.Green))}.");
+			return;
+		}
+
+		if (!actor.IsAdministrator(PermissionLevel.Admin) && appointment.MinimumRankToAppoint is not null &&
+		    (actorMembership is null || appointment.MinimumRankToAppoint.RankNumber > actorMembership.Rank.RankNumber) &&
+		    !IsVisibleThroughAppointmentChain(actorMembership, appointment.ParentPosition))
+		{
+			actor.Send("You must hold at least the rank of {0} before you can dismiss them from that position.",
+				appointment.MinimumRankToAppoint.Title(actor).TitleCase().Colour(Telnet.Green));
+			return;
+		}
+
+		if (!targetMembership.Appointments.Contains(appointment))
+		{
+			actor.OutputHandler.Send("They have not been appointed to that position.");
+			return;
+		}
+
+		var jobs = actor.Gameworld.ActiveJobs
+			.Where(x => !x.IsJobComplete &&
+			            x.Character.Id != targetMembership.MemberId &&
+			            x.Listing.ClanMembership == this &&
+			            x.Listing.ClanAppointment == appointment)
+			.ToList();
+		if (jobs.Any())
+		{
+			actor.OutputHandler.Send(
+				$"{targetMembership.MemberCharacter.HowSeen(actor, true)} cannot be dismissed from that appointment as they hold it by virtue of the job{(jobs.Count == 1 ? "" : "s")} {jobs.Select(x => x.Name.ColourValue()).ListToString()}.");
+			return;
+		}
+
+		if (targetActor is not null)
+		{
+			actor.OutputHandler.Handle(new FilteredEmoteOutput(new Emote(
+					$"@ dismiss|dismisses $0 from the position of {appointment.Title(targetActor).TitleCase().Colour(Telnet.Green)} in {FullName.TitleCase().Colour(Telnet.Green)}.",
+					actor, targetActor),
+				perceiver => perceiver is ICharacter pChar &&
+				            (pChar.ClanMemberships.Any(x => x.Clan == this) ||
+				             pChar.PermissionLevel >= PermissionLevel.JuniorAdmin)));
+		}
+		else
+		{
+			actor.Send("You dismiss {0} from the position of {1} in {2}.",
+				targetMembership.PersonalName.GetName(NameStyle.FullName).Colour(Telnet.Green),
+				appointment.Name.TitleCase().Colour(Telnet.Green), FullName.TitleCase().Colour(Telnet.Green));
+		}
+
+		DismissAppointment(targetMembership, appointment);
+	}
+
+	public void SubmitControl(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which appointment in that clan do you wish to submit to external control?");
+			return;
+		}
+
+		var appointmentText = command.PopSpeech();
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which other clan do you wish to submit control of that appointment to?");
+			return;
+		}
+
+		var otherClanText = command.PopSpeech();
+		string? controllingAppointmentText = null;
+		var maximumNumber = 1;
+		if (!command.IsFinished)
+		{
+			var extraText = command.PopSpeech();
+			if (command.IsFinished)
+			{
+				if (!int.TryParse(extraText, out maximumNumber) || maximumNumber < 0)
+				{
+					controllingAppointmentText = extraText;
+					maximumNumber = 1;
+				}
+			}
+			else
+			{
+				controllingAppointmentText = extraText;
+				if (!int.TryParse(command.SafeRemainingArgument, out maximumNumber) || maximumNumber < 0)
+				{
+					actor.OutputHandler.Send(
+						"If you specify a maximum number of appointees for that external control, it must be a valid number.");
+					return;
+				}
+			}
+		}
+
+		if (!HasPrivilege(actor, ClanPrivilegeType.CanSubmitClan, out _))
+		{
+			actor.OutputHandler.Send("You are not allowed to submit appointments to external control in that clan.");
+			return;
+		}
+
+		var appointment = Appointments.GetByIdOrName(appointmentText);
+		if (appointment is null)
+		{
+			actor.OutputHandler.Send("There is no such appointment in that clan for you to submit.");
+			return;
+		}
+
+		var filledSlots = Memberships.Count(x => !x.IsArchivedMembership && x.Appointments.Contains(appointment));
+		if (appointment.MaximumSimultaneousHolders > 0 &&
+		    appointment.MaximumSimultaneousHolders - filledSlots - maximumNumber < 0)
+		{
+			actor.OutputHandler.Send(
+				"There are insufficient free appointees for that appointment to submit that number to external control.");
+			return;
+		}
+
+		var targetClan = actor.Gameworld.Clans.GetClan(otherClanText);
+		if (targetClan is null)
+		{
+			actor.OutputHandler.Send("There is no such other clan for you to submit an appointment to.");
+			return;
+		}
+
+		if (targetClan == this)
+		{
+			actor.OutputHandler.Send("You cannot submit one of a clan's own appointments to itself.");
+			return;
+		}
+
+		IAppointment? controllingAppointment = null;
+		if (!string.IsNullOrEmpty(controllingAppointmentText))
+		{
+			controllingAppointment = targetClan.Appointments.GetByIdOrName(controllingAppointmentText);
+			if (controllingAppointment is null)
+			{
+				actor.OutputHandler.Send(
+					$"{targetClan.FullName.ColourName()} has no such controlling appointment.");
+				return;
+			}
+		}
+
+		if (ExternalControls.Any(x => x.VassalClan == this && x.LiegeClan == targetClan && x.ControlledAppointment == appointment))
+		{
+			actor.OutputHandler.Send("That clan already exerts control over that appointment.");
+			return;
+		}
+
+		actor.OutputHandler.Send(
+			$"Are you sure you wish to submit the control of appointments of the {appointment.Name.TitleCase().ColourName()} position in {FullName.TitleCase().ColourName()} to the {targetClan.FullName.TitleCase().ColourName()} clan? This is irreversible unless they decide to relinquish control. They can also transfer the control to others.\n{Accept.StandardAcceptPhrasing}");
+		actor.AddEffect(new Accept(actor, new GenericProposal
+		{
+			DescriptionString = "Submitting a position in a clan to the control of another",
+			Keywords = new List<string> { "submit", "clan", "external" },
+			ExpireAction = () =>
+			{
+				actor.OutputHandler.Send(
+					$"You decide not to submit the control of appointments of the {appointment.Name.TitleCase().ColourName()} position in {FullName.TitleCase().ColourName()} to the {targetClan.FullName.TitleCase().ColourName()} clan.");
+			},
+			RejectAction = _ =>
+			{
+				actor.OutputHandler.Send(
+					$"You decide not to submit the control of appointments of the {appointment.Name.TitleCase().ColourName()} position in {FullName.TitleCase().ColourName()} to the {targetClan.FullName.TitleCase().ColourName()} clan.");
+			},
+			AcceptAction = _ =>
+			{
+				using (new FMDB())
+				{
+					var dbitem = new MudSharp.Models.ExternalClanControl
+					{
+						ControlledAppointmentId = appointment.Id,
+						VassalClanId = Id,
+						LiegeClanId = targetClan.Id,
+						ControllingAppointmentId = controllingAppointment?.Id,
+						NumberOfAppointments = maximumNumber
+					};
+					FMDB.Context.ExternalClanControls.Add(dbitem);
+					FMDB.Context.SaveChanges();
+					new ExternalClanControl(dbitem, actor.Gameworld);
+				}
+
+				actor.OutputHandler.Send(string.Format("You submit control of {3}appointment {0} in {1} to {2}.",
+					appointment.Name.TitleCase().ColourName(),
+					FullName.TitleCase().ColourName(),
+					targetClan.FullName.TitleCase().ColourName(),
+					maximumNumber > 0 ? string.Format(actor, "{0:N0} appointees of ", maximumNumber) : ""));
+			}
+		}), TimeSpan.FromSeconds(120));
+	}
+
+	public void TransferControl(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which appointment in that clan do you wish to transfer from external control?");
+			return;
+		}
+
+		var appointmentText = command.PopSpeech();
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which other clan do you wish to transfer control of that appointment to?");
+			return;
+		}
+
+		var otherClanText = command.PopSpeech();
+		var liegeClanText = command.SafeRemainingArgument;
+		if (!TryGetExternalControl(appointmentText, liegeClanText, actor, out var control, out var liegeClan, out var error))
+		{
+			actor.OutputHandler.Send(error);
+			return;
+		}
+
+		var targetClan = actor.Gameworld.Clans.GetClan(otherClanText);
+		if (targetClan is null)
+		{
+			actor.OutputHandler.Send("There is no such other clan for you to transfer an appointment to.");
+			return;
+		}
+
+		if (targetClan == this)
+		{
+			actor.OutputHandler.Send("You cannot transfer one of a clan's own appointments to itself.");
+			return;
+		}
+
+		if (targetClan == liegeClan)
+		{
+			actor.OutputHandler.Send("You cannot transfer vassalage of one clan within the same clan.");
+			return;
+		}
+
+		if (!CanManageExternalControl(actor, control!, liegeClan!, out _))
+		{
+			actor.OutputHandler.Send("You are not allowed to manage vassal positions in that clan.");
+			return;
+		}
+
+		actor.OutputHandler.Send(
+			$"Are you sure you wish to transfer the control of appointments of the {control!.ControlledAppointment.Name.TitleCase().ColourName()} position in {FullName.TitleCase().ColourName()} to the {targetClan.FullName.TitleCase().ColourName()} clan? This is irreversible unless they decide to relinquish control. They can also transfer the control to others.\n{Accept.StandardAcceptPhrasing}");
+		actor.AddEffect(new Accept(actor, new GenericProposal
+		{
+			DescriptionString = "Transferring a position in a clan to the control of another",
+			Keywords = new List<string> { "transfer", "clan", "external" },
+			ExpireAction = () =>
+			{
+				actor.OutputHandler.Send(
+					$"You decide not to transfer the control of appointments of the {control.ControlledAppointment.Name.TitleCase().ColourName()} position in {FullName.TitleCase().ColourName()} to the {targetClan.FullName.TitleCase().ColourName()} clan.");
+			},
+			RejectAction = _ =>
+			{
+				actor.OutputHandler.Send(
+					$"You decide not to transfer the control of appointments of the {control.ControlledAppointment.Name.TitleCase().ColourName()} position in {FullName.TitleCase().ColourName()} to the {targetClan.FullName.TitleCase().ColourName()} clan.");
+			},
+			AcceptAction = _ =>
+			{
+				using (new FMDB())
+				{
+					var dbitem = new MudSharp.Models.ExternalClanControl
+					{
+						ControlledAppointmentId = control.ControlledAppointment.Id,
+						VassalClanId = Id,
+						LiegeClanId = targetClan.Id,
+						NumberOfAppointments = control.NumberOfAppointments
+					};
+					foreach (var character in control.Appointees)
+					{
+						dbitem.ExternalClanControlsAppointments.Add(new ExternalClanControlsAppointment
+						{
+							VassalClanId = Id,
+							LiegeClanId = targetClan.Id,
+							ControlledAppointmentId = control.ControlledAppointment.Id,
+							CharacterId = character.MemberId
+						});
+					}
+
+					FMDB.Context.ExternalClanControls.Add(dbitem);
+					FMDB.Context.SaveChanges();
+					new ExternalClanControl(dbitem, actor.Gameworld);
+				}
+
+				ExternalControls.Remove(control);
+				liegeClan.ExternalControls.Remove(control);
+				control.Delete();
+
+				actor.OutputHandler.Send(string.Format("You transfer control of {3}appointment {0} in {1} to {2}.",
+					control.ControlledAppointment.Name.TitleCase().ColourName(),
+					FullName.TitleCase().ColourName(),
+					targetClan.FullName.TitleCase().ColourName(),
+					control.NumberOfAppointments > 0 ? string.Format(actor, "{0:N0} appointees of ", control.NumberOfAppointments) : ""));
+			}
+		}), TimeSpan.FromSeconds(120));
+	}
+
+	public void ReleaseControl(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which appointment in that clan do you wish to release from external control?");
+			return;
+		}
+
+		var appointmentText = command.PopSpeech();
+		var liegeClanText = command.SafeRemainingArgument;
+		if (!TryGetExternalControl(appointmentText, liegeClanText, actor, out var control, out var liegeClan, out var error))
+		{
+			actor.OutputHandler.Send(error);
+			return;
+		}
+
+		if (!CanManageExternalControl(actor, control!, liegeClan!, out _))
+		{
+			actor.OutputHandler.Send("You are not allowed to manage vassal positions in that clan.");
+			return;
+		}
+
+		ExternalControls.Remove(control);
+		liegeClan.ExternalControls.Remove(control);
+		control.Delete();
+		actor.OutputHandler.Send(
+			$"You release control of appointment {control.ControlledAppointment.Name.TitleCase().ColourName()} in {FullName.TitleCase().ColourName()} by {liegeClan.FullName.TitleCase().ColourName()}.");
+	}
+
+	public void SetControllingAppointment(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send(
+				"Which appointment in that vassal clan do you wish to assign a controlling liege appointment to?");
+			return;
+		}
+
+		var appointmentText = command.PopSpeech();
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send(
+				"Which appointment in the liege clan should control that vassal appointment, or none to clear it?");
+			return;
+		}
+
+		var controllingAppointmentText = command.PopSpeech();
+		var liegeClanText = command.SafeRemainingArgument;
+		if (!TryGetExternalControl(appointmentText, liegeClanText, actor, out var control, out var liegeClan, out var error))
+		{
+			actor.OutputHandler.Send(error);
+			return;
+		}
+
+		if (!CanManageExternalControl(actor, control!, liegeClan!, out _))
+		{
+			actor.OutputHandler.Send("You are not allowed to manage vassal positions in that clan.");
+			return;
+		}
+
+		IAppointment? controllingAppointment = null;
+		if (!controllingAppointmentText.EqualTo("none") && !controllingAppointmentText.EqualTo("clear"))
+		{
+			controllingAppointment = liegeClan.Appointments.GetByIdOrName(controllingAppointmentText);
+			if (controllingAppointment is null)
+			{
+				actor.OutputHandler.Send(
+					$"{liegeClan.FullName.ColourName()} has no such appointment to use as the controlling appointment.");
+				return;
+			}
+		}
+
+		control!.ControllingAppointment = controllingAppointment;
+		control.Changed = true;
+		control.Save();
+		actor.OutputHandler.Send(
+			$"The {control.ControlledAppointment.Name.TitleCase().ColourName()} appointment in {FullName.TitleCase().ColourName()} is now controlled by {(controllingAppointment is null ? $"the {liegeClan.FullName.TitleCase().ColourName()} clan as a whole" : $"{controllingAppointment.Name.TitleCase().ColourName()} in {liegeClan.FullName.TitleCase().ColourName()}")}.");
+	}
+
+	public void AppointExternal(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Who do you wish to appoint to a position in that vassal clan?");
+			return;
+		}
+
+		var targetText = command.PopSpeech();
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("To which position do you wish to appoint them?");
+			return;
+		}
+
+		var appointmentText = command.PopSpeech();
+		var liegeClanText = command.SafeRemainingArgument;
+		if (!TryGetExternalControl(appointmentText, liegeClanText, actor, out var control, out var liegeClan, out var error))
+		{
+			actor.OutputHandler.Send(error);
+			return;
+		}
+
+		if (!CanManageExternalControl(actor, control!, liegeClan!, out var actorMembership))
+		{
+			if (control!.ControllingAppointment is not null)
+			{
+				actor.Send("Only someone who holds the {0} position can appoint anyone to that vassal position.",
+					control.ControllingAppointment.Name.TitleCase().Colour(Telnet.Green));
+			}
+			else
+			{
+				actor.Send("You are not authorised to appoint anyone to that vassal position.");
+			}
+
+			return;
+		}
+
+		var targetActor = actor.TargetActor(targetText);
+		if (targetActor is null)
+		{
+			actor.OutputHandler.Send("You do not see anyone like that to appoint to a position.");
+			return;
+		}
+
+		var targetMembership = Memberships.FirstOrDefault(x => !x.IsArchivedMembership && x.MemberId == targetActor.Id);
+		if (targetMembership is not null && targetMembership.Appointments.Contains(control!.ControlledAppointment))
+		{
+			actor.OutputHandler.Send("They already hold that position, and so cannot be appointed again.");
+			return;
+		}
+
+		if (control!.NumberOfAppointments > 0 && control.NumberOfAppointments <= control.Appointees.Count)
+		{
+			actor.OutputHandler.Send(
+				"The maximum number of appointments to that position through that relationship has been reached. You must first dismiss existing appointees.");
+			return;
+		}
+
+		if (targetMembership is null)
+		{
+			var rank = control.ControlledAppointment.MinimumRankToHold ?? Ranks.FirstMin(x => x.RankNumber);
+			var archived = Memberships.FirstOrDefault(x => x.IsArchivedMembership && x.MemberId == targetActor.Id);
+			if (archived is not null)
+			{
+				archived.IsArchivedMembership = false;
+				archived.Changed = true;
+				targetActor.AddMembership(archived);
+				if (archived.Rank.RankNumber < rank.RankNumber)
+				{
+					archived.Rank = rank;
+				}
+
+				targetMembership = archived;
+			}
+			else
+			{
+				using (new FMDB())
+				{
+					var dbitem = new MudSharp.Models.ClanMembership
+					{
+						CharacterId = targetActor.Id,
+						ClanId = Id,
+						RankId = rank.Id,
+						PaygradeId = rank.Paygrades.Any() ? rank.Paygrades.First().Id : (long?)null,
+						PersonalName = targetActor.CurrentName.SaveToXml().ToString(),
+						JoinDate = Calendar.CurrentDate.GetDateString()
+					};
+					FMDB.Context.ClanMemberships.Add(dbitem);
+					FMDB.Context.SaveChanges();
+					targetMembership = new ClanMembership(dbitem, this, targetActor.Gameworld);
+					targetActor.AddMembership(targetMembership);
+					Memberships.Add(targetMembership);
+				}
+			}
+		}
+		else if (control.ControlledAppointment.MinimumRankToHold is not null &&
+		         targetMembership.Rank.RankNumber < control.ControlledAppointment.MinimumRankToHold.RankNumber)
+		{
+			SetRank(targetMembership, control.ControlledAppointment.MinimumRankToHold);
+		}
+
+		using (new FMDB())
+		{
+			var dbappointment = FMDB.Context.ExternalClanControls.Find(Id, liegeClan!.Id, control.ControlledAppointment.Id);
+			dbappointment.ExternalClanControlsAppointments.Add(new ExternalClanControlsAppointment
+			{
+				CharacterId = targetActor.Id
+			});
+			FMDB.Context.SaveChanges();
+		}
+
+		control.Appointees.Add(targetMembership);
+		targetMembership.Appointments.Add(control.ControlledAppointment);
+		targetMembership.Changed = true;
+
+		actor.OutputHandler.Handle(new FilteredEmoteOutput(new Emote(
+				$"@ appoint|appoints $0 to the position of {control.ControlledAppointment.Title(targetActor).TitleCase().Colour(Telnet.Green)} in {FullName.TitleCase().Colour(Telnet.Green)} on behalf of {liegeClan.FullName.TitleCase().Colour(Telnet.Green)}.",
+				actor, targetActor),
+			perceiver => perceiver is ICharacter pChar &&
+			            (pChar.ClanMemberships.Any(x => x.Clan == this || x.Clan == liegeClan) ||
+			             pChar.PermissionLevel >= PermissionLevel.JuniorAdmin)));
+	}
+
+	public void DismissExternal(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Who do you wish to dismiss from a position in that vassal clan?");
+			return;
+		}
+
+		var targetText = command.PopSpeech();
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("From which position do you wish to dismiss them?");
+			return;
+		}
+
+		var appointmentText = command.PopSpeech();
+		var liegeClanText = command.SafeRemainingArgument;
+		if (!TryGetExternalControl(appointmentText, liegeClanText, actor, out var control, out var liegeClan, out var error))
+		{
+			actor.OutputHandler.Send(error);
+			return;
+		}
+
+		if (!CanManageExternalControl(actor, control!, liegeClan!, out _))
+		{
+			if (control!.ControllingAppointment is not null)
+			{
+				actor.Send("Only someone who holds the {0} position can dismiss anyone from that vassal position.",
+					control.ControllingAppointment.Name.TitleCase().Colour(Telnet.Green));
+			}
+			else
+			{
+				actor.Send("You are not authorised to dismiss anyone from that vassal position.");
+			}
+
+			return;
+		}
+
+		var targetActor = actor.TargetActor(targetText);
+		var targetMembership = targetActor is not null
+			? targetActor.ClanMemberships.FirstOrDefault(x => x.Clan == this && !x.IsArchivedMembership)
+			: control!.Appointees.FirstOrDefault(x =>
+				x.PersonalName.GetName(NameStyle.FullName).Equals(targetText, StringComparison.InvariantCultureIgnoreCase));
+		if (targetMembership is null || !control!.Appointees.Contains(targetMembership))
+		{
+			actor.OutputHandler.Send("There is no such member for you to dismiss that falls within your remit.");
+			return;
+		}
+
+		using (new FMDB())
+		{
+			var dbappointment = FMDB.Context.ExternalClanControls.Find(Id, liegeClan!.Id, control.ControlledAppointment.Id);
+			var dbAppointee = dbappointment.ExternalClanControlsAppointments.FirstOrDefault(x => x.CharacterId == targetMembership.MemberId);
+			if (dbAppointee is not null)
+			{
+				dbappointment.ExternalClanControlsAppointments.Remove(dbAppointee);
+				FMDB.Context.SaveChanges();
+			}
+		}
+
+		control.Appointees.Remove(targetMembership);
+		DismissAppointment(targetMembership, control.ControlledAppointment);
+
+		if (targetActor is not null)
+		{
+			actor.OutputHandler.Handle(new FilteredEmoteOutput(new Emote(
+					$"@ dismiss|dismisses $0 from the position of {control.ControlledAppointment.Title(targetActor).TitleCase().Colour(Telnet.Green)} in {FullName.TitleCase().Colour(Telnet.Green)} on behalf of {liegeClan.FullName.TitleCase().Colour(Telnet.Green)}.",
+					actor, targetActor),
+				perceiver => perceiver is ICharacter pChar &&
+				            (pChar.ClanMemberships.Any(x => x.Clan == this || x.Clan == liegeClan) ||
+				             pChar.PermissionLevel >= PermissionLevel.JuniorAdmin)));
+			return;
+		}
+
+		actor.OutputHandler.Send(
+			$"You dismiss {targetMembership.PersonalName.GetName(NameStyle.FullName).TitleCase().Colour(Telnet.Green)} from the position of {control.ControlledAppointment.Name.TitleCase().Colour(Telnet.Green)} in {FullName.TitleCase().Colour(Telnet.Green)} on behalf of {liegeClan.FullName.TitleCase().Colour(Telnet.Green)}.");
+	}
+
+	private void ShowDefault(ICharacter actor, IClanMembership? actorMembership)
+	{
+		var canViewMembers = CanViewMembers(actor, actorMembership);
+		var canViewOffices = CanViewOfficeHolders(actor, actorMembership);
+		var canViewAboveOwnRank = CanViewAboveOwnRank(actor, actorMembership);
+		var canViewFinances = CanViewFinances(actor, actorMembership);
+		var sb = new StringBuilder();
+		sb.AppendLine(FullName.TitleCase().GetLineWithTitleInner(actor, Telnet.Cyan, Telnet.BoldWhite));
+		sb.AppendLine();
+		sb.AppendLine($"Alias: {Alias.Colour(Telnet.Green)}");
+		sb.AppendLine($"Name: {Name.TitleCase().Colour(Telnet.Green)}");
+		sb.AppendLine("Description:");
+		sb.AppendLine();
+		sb.AppendLine(Description.Wrap(80, "\t").NoWrap());
+		sb.AppendLine();
+		if (actor.IsAdministrator(PermissionLevel.Admin))
+		{
+			sb.AppendLine($"Discord Channel: {DiscordChannelId?.ToString("F0", actor).ColourValue() ?? "None".ColourError()}");
+			sb.AppendLine($"Treasury Cells:\n{TreasuryCells.Select(x => x.GetFriendlyReference(actor)).DefaultIfEmpty("None").ListToLines(true)}");
+			sb.AppendLine();
+			sb.AppendLine($"Administration Cells:\n{AdministrationCells.Select(x => x.GetFriendlyReference(actor)).DefaultIfEmpty("None").ListToLines(true)}");
+			sb.AppendLine();
+		}
+
+		sb.AppendLine("Ranks:");
+		var ranks = (canViewAboveOwnRank
+			? Ranks
+			: Ranks.Where(x => x.RankNumber <= (actorMembership?.Rank.RankNumber ?? 0))).ToList();
+		sb.AppendLine(
+			canViewMembers
+				? StringUtilities.GetTextTable(
+					from rank in ranks
+					orderby rank.RankNumber
+					select new[]
+					{
+						rank.RankNumber.ToString(actor),
+						rank.Name.TitleCase(),
+						(rank.RankPath ?? "").TitleCase(),
+						Memberships.Count(x => x.Rank == rank && !x.IsArchivedMembership).ToString(actor),
+						rank.Titles.Except(rank.Name).Select(x => x.TitleCase()).ListToString(conjunction: "", twoItemJoiner: ", "),
+						rank.Paygrades.Select(x => x.Abbreviation).ListToString(conjunction: "", twoItemJoiner: ", ")
+					},
+					new[] { "Rank#", "Name", "Path", "No.", "Alternate Names", "Paygrades" },
+					actor.Account.LineFormatLength, colour: Telnet.Green, truncatableColumnIndex: 5,
+					unicodeTable: actor.Account.UseUnicode)
+				: StringUtilities.GetTextTable(
+					from rank in ranks
+					orderby rank.RankNumber
+					select new[]
+					{
+						rank.RankNumber.ToString(actor),
+						rank.Name.TitleCase(),
+						(rank.RankPath ?? "").TitleCase(),
+						rank.Titles.Except(rank.Name).Select(x => x.TitleCase()).ListToString(conjunction: "", twoItemJoiner: ", "),
+						rank.Paygrades.Select(x => x.Abbreviation).ListToString(conjunction: "", twoItemJoiner: ", ")
+					},
+					new[] { "Rank#", "Name", "Path", "Alternate Names", "Paygrades" },
+					actor.Account.LineFormatLength, colour: Telnet.Green, truncatableColumnIndex: 4,
+					unicodeTable: actor.Account.UseUnicode));
+
+		var appointments = (canViewAboveOwnRank
+			? Appointments
+			: Appointments.Where(x => IsVisibleThroughAppointmentChain(actorMembership, x))).ToList();
+		sb.AppendLine("Appointments:");
+		sb.AppendLine(
+			canViewOffices
+				? StringUtilities.GetTextTable(
+					from appointment in appointments
+					orderby appointment.MinimumRankToHold?.RankNumber ?? -1 descending,
+						appointment.MinimumRankToAppoint?.RankNumber ?? -1 descending
+					select new[]
+					{
+						appointment.Name.TitleCase(),
+						appointment.MinimumRankToHold?.Name.TitleCase() ?? "None",
+						appointment.MinimumRankToAppoint?.Name.TitleCase() ?? "None",
+						appointment.MaximumSimultaneousHolders.ToString(actor),
+						Memberships.Count(x => !x.IsArchivedMembership && x.Appointments.Contains(appointment)).ToString(actor),
+						appointment.Paygrade?.Abbreviation ?? "None",
+						appointment.ParentPosition?.Name.TitleCase() ?? "None",
+						appointment.IsAppointedByElection.ToColouredString()
+					},
+					new[] { "Name", "Min Rank", "Appointer", "Max No.", "No.", "Paygrade", "Parent", "Elected?" },
+					actor.Account.LineFormatLength, colour: Telnet.Green, unicodeTable: actor.Account.UseUnicode)
+				: StringUtilities.GetTextTable(
+					from appointment in appointments
+					orderby appointment.MinimumRankToHold?.RankNumber ?? -1 descending,
+						appointment.MinimumRankToAppoint?.RankNumber ?? -1 descending
+					select new[]
+					{
+						appointment.Name.TitleCase(),
+						appointment.MinimumRankToHold?.Name.TitleCase() ?? "None",
+						appointment.MinimumRankToAppoint?.Name.TitleCase() ?? "None",
+						appointment.MaximumSimultaneousHolders.ToString(actor),
+						appointment.Paygrade?.Abbreviation ?? "None",
+						appointment.ParentPosition?.Name.TitleCase() ?? "None",
+						appointment.IsAppointedByElection.ToColouredString()
+					},
+					new[] { "Name", "Min Rank", "Appointer", "Max No.", "Paygrade", "Parent", "Elected?" },
+					actor.Account.LineFormatLength, colour: Telnet.Green, unicodeTable: actor.Account.UseUnicode));
+
+		var paygrades = (canViewAboveOwnRank
+			? Paygrades
+			: Paygrades.Where(x =>
+				Ranks.Any(y => y.Paygrades.Contains(x) && y.RankNumber <= (actorMembership?.Rank.RankNumber ?? 0)) ||
+				Appointments.Any(y => y.Paygrade == x && IsVisibleThroughAppointmentChain(actorMembership, y)))).ToList();
+		sb.AppendLine("Paygrades:");
+		if (canViewMembers && canViewFinances)
+		{
+			sb.AppendLine(StringUtilities.GetTextTable(
+				from paygrade in paygrades
+				orderby paygrade.PayCurrency.Id, paygrade.PayAmount
+				select new[]
+				{
+					paygrade.Abbreviation,
+					paygrade.Name.TitleCase(),
+					paygrade.PayCurrency.Name.TitleCase(),
+					paygrade.PayCurrency.Describe(paygrade.PayAmount, CurrencyDescriptionPatternType.Short),
+					(Memberships.Count(x => !x.IsArchivedMembership && x.Paygrade == paygrade) +
+					 Memberships.Sum(x => x.Appointments.Count(y => !x.IsArchivedMembership && y.Paygrade == paygrade))).ToString(actor),
+					paygrade.PayCurrency.Describe(
+						paygrade.PayAmount *
+						(Memberships.Count(x => !x.IsArchivedMembership && x.Paygrade == paygrade) +
+						 Memberships.Sum(x => x.Appointments.Count(y => !x.IsArchivedMembership && y.Paygrade == paygrade))),
+						CurrencyDescriptionPatternType.Short)
+				},
+				new[] { "Abbreviation", "Name", "Currency", "Amount", "No.", "Total Per Pay" },
+				actor.Account.LineFormatLength, colour: Telnet.Green, truncatableColumnIndex: 5,
+				unicodeTable: actor.Account.UseUnicode));
+		}
+		else if (canViewMembers)
+		{
+			sb.AppendLine(StringUtilities.GetTextTable(
+				from paygrade in paygrades
+				orderby paygrade.PayCurrency.Id, paygrade.PayAmount
+				select new[]
+				{
+					paygrade.Abbreviation,
+					paygrade.Name.TitleCase(),
+					paygrade.PayCurrency.Name.TitleCase(),
+					paygrade.PayCurrency.Describe(paygrade.PayAmount, CurrencyDescriptionPatternType.Short),
+					(Memberships.Count(x => !x.IsArchivedMembership && x.Paygrade == paygrade) +
+					 Memberships.Sum(x => x.Appointments.Count(y => !x.IsArchivedMembership && y.Paygrade == paygrade))).ToString(actor)
+				},
+				new[] { "Abbreviation", "Name", "Currency", "Amount", "No." },
+				actor.Account.LineFormatLength, colour: Telnet.Green, unicodeTable: actor.Account.UseUnicode));
+		}
+		else if (canViewFinances)
+		{
+			sb.AppendLine(StringUtilities.GetTextTable(
+				from paygrade in paygrades
+				orderby paygrade.PayCurrency.Id, paygrade.PayAmount
+				select new[]
+				{
+					paygrade.Abbreviation,
+					paygrade.Name.TitleCase(),
+					paygrade.PayCurrency.Name.TitleCase(),
+					paygrade.PayCurrency.Describe(paygrade.PayAmount, CurrencyDescriptionPatternType.Short),
+					paygrade.PayCurrency.Describe(
+						paygrade.PayAmount *
+						(Memberships.Count(x => !x.IsArchivedMembership && x.Paygrade == paygrade) +
+						 Memberships.Sum(x => x.Appointments.Count(y => !x.IsArchivedMembership && y.Paygrade == paygrade))),
+						CurrencyDescriptionPatternType.Short)
+				},
+				new[] { "Abbreviation", "Name", "Currency", "Amount", "Total Per Pay" },
+				actor.Account.LineFormatLength, colour: Telnet.Green, unicodeTable: actor.Account.UseUnicode));
+		}
+		else
+		{
+			sb.AppendLine(StringUtilities.GetTextTable(
+				from paygrade in paygrades
+				orderby paygrade.PayCurrency.Id, paygrade.PayAmount
+				select new[]
+				{
+					paygrade.Abbreviation,
+					paygrade.Name.TitleCase(),
+					paygrade.PayCurrency.Name.TitleCase(),
+					paygrade.PayCurrency.Describe(paygrade.PayAmount, CurrencyDescriptionPatternType.Short)
+				},
+				new[] { "Abbreviation", "Name", "Currency", "Amount" },
+				actor.Account.LineFormatLength, colour: Telnet.Green, unicodeTable: actor.Account.UseUnicode));
+		}
+
+		sb.AppendLine();
+		if (ExternalControls.Any(x => x.VassalClan == this))
+		{
+			sb.AppendLine("External Controls (Over This Clan):");
+			sb.AppendLine(StringUtilities.GetTextTable(
+				from external in ExternalControls.Where(x => x.VassalClan == this)
+				select new[]
+				{
+					external.ControlledAppointment.Name.TitleCase(),
+					external.LiegeClan.FullName.TitleCase(),
+					external.ControllingAppointment?.Name.TitleCase() ?? "None",
+					external.NumberOfAppointments > 0 ? external.NumberOfAppointments.ToString("N0", actor) : "Unlimited",
+					external.Appointees.Count.ToString("N0", actor)
+				},
+				new[] { "Appointment", "Liege Clan", "Liege Appointment", "Max No.", "No." },
+				actor.Account.LineFormatLength, colour: Telnet.Green, truncatableColumnIndex: 2,
+				unicodeTable: actor.Account.UseUnicode));
+			sb.AppendLine();
+		}
+
+		if (ExternalControls.Any(x => x.LiegeClan == this))
+		{
+			sb.AppendLine("External Controls (Under This Clan):");
+			sb.AppendLine(StringUtilities.GetTextTable(
+				from external in ExternalControls.Where(x => x.LiegeClan == this)
+				select new[]
+				{
+					external.ControlledAppointment.Name.TitleCase(),
+					external.VassalClan.FullName.TitleCase(),
+					external.ControllingAppointment?.Name.TitleCase() ?? "None",
+					external.NumberOfAppointments > 0 ? external.NumberOfAppointments.ToString("N0", actor) : "Unlimited",
+					external.Appointees.Count.ToString("N0", actor)
+				},
+				new[] { "Appointment", "Vassal Clan", "Liege Appointment", "Max No.", "No." },
+				actor.Account.LineFormatLength, colour: Telnet.Green, truncatableColumnIndex: 2,
+				unicodeTable: actor.Account.UseUnicode));
+			sb.AppendLine();
+		}
+
+		if (canViewFinances)
+		{
+			sb.AppendLine($"Default Bank Account: {ClanBankAccount?.AccountReference.Colour(Telnet.BoldCyan) ?? "None".Colour(Telnet.Red)}");
+			if (ClanBankAccount is not null)
+			{
+				sb.AppendLine(
+					$"Default Account Balance: {ClanBankAccount.Currency.Describe(ClanBankAccount.CurrentBalance, CurrencyDescriptionPatternType.ShortDecimal).ColourValue()}");
+			}
+
+			var currencyPiles = TreasuryCells
+				.SelectMany(x => x.GameItems.SelectMany(y => y.RecursiveGetItems<ICurrencyPile>()))
+				.GroupBy(x => x.Currency)
+				.Select(x => (Currency: x.Key, Value: x.Sum(pile => pile.Coins.Sum(coin => coin.Item1.Value * coin.Item2))))
+				.ToList();
+			if (currencyPiles.Any(x => x.Value > 0.0M))
+			{
+				sb.AppendLine(
+					$"Treasury Balance: {currencyPiles.Select(x => x.Currency.Describe(x.Value, CurrencyDescriptionPatternType.ShortDecimal).ColourValue()).ListToString()}");
+			}
+
+			var accounts = actor.Gameworld.Banks.SelectMany(x => x.BankAccounts.Where(y => y.AccountOwner == this)).ToList();
+			if (accounts.Any())
+			{
+				sb.AppendLine("Clan Bank Accounts:");
+				sb.AppendLine();
+				foreach (var account in accounts)
+				{
+					sb.AppendLine(
+						$"\t{account.AccountReference.Colour(Telnet.BoldCyan)} - {account.Currency.Describe(account.CurrentBalance, CurrencyDescriptionPatternType.ShortDecimal).ColourValue()}");
+				}
+			}
+
+			sb.AppendLine();
+			sb.AppendLine(
+				$"Total Commitment Salary Per Payday: {Paygrades.Select(x => x.PayCurrency).Distinct().Select(x => x.Describe(Paygrades.Where(y => y.PayCurrency == x).Sum(y => y.PayAmount * (Memberships.Count(z => !z.IsArchivedMembership && z.Paygrade == y) + Memberships.Sum(z => z.Appointments.Count(v => !z.IsArchivedMembership && v.Paygrade == y)))), CurrencyDescriptionPatternType.Short)).Select(x => x.Colour(Telnet.Green)).ListToString()}");
+		}
+
+		sb.AppendLine($"Clan Calendar: {Calendar.ShortName.TitleCase().ColourValue()}");
+		sb.AppendLine($"Payday Interval: {PayInterval.Describe(Calendar).ColourValue()}");
+		sb.AppendLine($"Next Payday: {Calendar.DisplayDate(NextPay.Date, CalendarDisplayMode.Short).Colour(Telnet.Green)} at {Calendar.FeedClock.DisplayTime(NextPay.Time, TimeDisplayTypes.Immortal).Colour(Telnet.Green)}");
+		actor.OutputHandler.Send(sb.ToString());
+	}
+
+	private void ShowRank(ICharacter actor, IRank rank)
+	{
+		var sb = new StringBuilder();
+		sb.AppendLine($"Rank {rank.Name.TitleCase().Colour(Telnet.Green)} ID #{rank.Id.ToString().Colour(Telnet.Green)} - {FullName.TitleCase().Colour(Telnet.Green)}");
+		sb.AppendLine();
+		sb.Append(new[]
+		{
+			$"Name: {rank.Name.TitleCase().Colour(Telnet.Green)}",
+			$"Rank Number: {rank.RankNumber.ToString("N0", actor).Colour(Telnet.Green)}"
+		}.ArrangeStringsOntoLines(2, (uint)actor.Account.LineFormatLength));
+		sb.Append(new[]
+		{
+			$"Rank Path: {(rank.RankPath ?? "").Colour(Telnet.Green)}",
+			$"Insignia: {(rank.InsigniaGameItem is not null ? $"#{rank.InsigniaGameItem.Id} rev {rank.InsigniaGameItem.RevisionNumber}".Colour(Telnet.Green) : "None".Colour(Telnet.Red))}"
+		}.ArrangeStringsOntoLines(2, (uint)actor.Account.LineFormatLength));
+		sb.AppendLine();
+		sb.AppendLine("Abbreviations:");
+		foreach (var item in rank.AbbreviationsAndProgs)
+		{
+			sb.AppendLine(
+				$"\tAbbreviation: {item.Item2.Colour(Telnet.Green)} FutureProg: {(item.Item1 is not null ? item.Item1.FunctionName.Colour(Telnet.Cyan).FluentTagMXP("send", $"href='show futureprog {item.Item1.Id}'") : "None".Colour(Telnet.Red))}{(item.Item1 is not null ? $" (#{item.Item1.Id:N0})" : "")}");
+		}
+
+		sb.AppendLine();
+		sb.AppendLine("Rank Names:");
+		foreach (var item in rank.TitlesAndProgs)
+		{
+			sb.AppendLine(
+				$"\tName: {item.Item2.Colour(Telnet.Green)} FutureProg: {(item.Item1 is not null ? item.Item1.FunctionName.Colour(Telnet.Cyan).FluentTagMXP("send", $"href='show futureprog {item.Item1.Id}'") : "None".Colour(Telnet.Red))}{(item.Item1 is not null ? $" (#{item.Item1.Id:N0})" : "")}");
+		}
+
+		sb.AppendLine();
+		sb.AppendLine("Paygrades:");
+		foreach (var item in rank.Paygrades)
+		{
+			sb.AppendLine(
+				$"\tPaygrade {item.Abbreviation.Colour(Telnet.Green)} ({item.Name.TitleCase().Colour(Telnet.Green)}) - {item.PayCurrency.Describe(item.PayAmount, CurrencyDescriptionPatternType.Short)}.");
+		}
+
+		sb.AppendLine();
+		sb.AppendLine("Privileges:");
+		sb.AppendLine("\t" + rank.Privileges);
+		actor.OutputHandler.Send(sb.ToString());
+	}
+
+	private void ShowPaygrade(ICharacter actor, IPaygrade paygrade)
+	{
+		var sb = new StringBuilder();
+		sb.AppendLine($"Paygrade {paygrade.Name.TitleCase().Colour(Telnet.Green)} ID #{paygrade.Id.ToString().Colour(Telnet.Green)} - {FullName.TitleCase().Colour(Telnet.Green)}");
+		sb.AppendLine();
+		sb.Append(new[]
+		{
+			$"Abbreviation: {paygrade.Abbreviation.Colour(Telnet.Green)}",
+			$"Name: {paygrade.Name.TitleCase().Colour(Telnet.Green)}"
+		}.ArrangeStringsOntoLines(2, (uint)actor.Account.LineFormatLength));
+		sb.AppendLine(
+			$"Pays {paygrade.PayCurrency.Describe(paygrade.PayAmount, CurrencyDescriptionPatternType.Short).Colour(Telnet.Green)} in the {paygrade.PayCurrency.Name.Colour(Telnet.Green)} currency.");
+		actor.OutputHandler.Send(sb.ToString());
+	}
+
+	private void ShowAppointment(ICharacter actor, IAppointment appointment)
+	{
+		var sb = new StringBuilder();
+		sb.AppendLine($"Appointment {appointment.Name.TitleCase().Colour(Telnet.Green)} ID #{appointment.Id.ToString().Colour(Telnet.Green)} - {FullName.TitleCase().Colour(Telnet.Green)}");
+		sb.AppendLine();
+		sb.Append(new[]
+		{
+			$"Name: {appointment.Name.TitleCase().Colour(Telnet.Green)}",
+			$"Insignia: {(appointment.InsigniaGameItem is not null ? $"#{appointment.InsigniaGameItem.Id} rev {appointment.InsigniaGameItem.RevisionNumber}".Colour(Telnet.Green) : "None".Colour(Telnet.Red))}"
+		}.ArrangeStringsOntoLines(2, (uint)actor.Account.LineFormatLength));
+		sb.Append(new[]
+		{
+			$"Min Rank: {(appointment.MinimumRankToHold is not null ? appointment.MinimumRankToHold.Name.TitleCase().Colour(Telnet.Green) : "None".Colour(Telnet.Red))}",
+			$"Min Appointer Rank: {(appointment.MinimumRankToAppoint is not null ? appointment.MinimumRankToAppoint.Name.TitleCase().Colour(Telnet.Green) : "None".Colour(Telnet.Red))}"
+		}.ArrangeStringsOntoLines(2, (uint)actor.Account.LineFormatLength));
+		sb.Append(new[]
+		{
+			$"Parent: {(appointment.ParentPosition is not null ? appointment.ParentPosition.Name.TitleCase().Colour(Telnet.Green) : "None".Colour(Telnet.Red))}",
+			$"Max Holders: {appointment.MaximumSimultaneousHolders.ToString("N0", actor).Colour(Telnet.Green)}"
+		}.ArrangeStringsOntoLines(2, (uint)actor.Account.LineFormatLength));
+		sb.AppendLine();
+		if (appointment.IsAppointedByElection)
+		{
+			sb.AppendLine();
+			sb.AppendLine($"Elections ({(appointment.IsSecretBallot ? "by secret ballot" : "by open voting")}):");
+			sb.AppendLine();
+			sb.Append(new[]
+			{
+				$"Term: {appointment.ElectionTerm.Describe(actor).ColourValue()}",
+				$"Lead Time: {appointment.ElectionLeadTime.Describe(actor).ColourValue()}"
+			}.ArrangeStringsOntoLines(2, (uint)actor.Account.LineFormatLength));
+			sb.AppendLine();
+			sb.Append(new[]
+			{
+				$"Nomination Period: {appointment.NominationPeriod.Describe(actor).ColourValue()}",
+				$"Voting Period: {appointment.VotingPeriod.Describe(actor).ColourValue()}"
+			}.ArrangeStringsOntoLines(2, (uint)actor.Account.LineFormatLength));
+			sb.AppendLine();
+			sb.Append(new[]
+			{
+				$"Term Limit (Consecutive): {appointment.MaximumConsecutiveTerms.ToString("N0", actor).ColourValue()}",
+				$"Term Limit (Total): {appointment.MaximumTotalTerms.ToString("N0", actor).ColourValue()}"
+			}.ArrangeStringsOntoLines(2, (uint)actor.Account.LineFormatLength));
+			sb.AppendLine();
+			sb.Append(new[]
+			{
+				$"Nominee Prog: {appointment.CanNominateProg?.MXPClickableFunctionNameWithId() ?? "None".Colour(Telnet.Red)}",
+				$"Votes Prog: {appointment.NumberOfVotesProg?.MXPClickableFunctionNameWithId() ?? "None".Colour(Telnet.Red)}"
+			}.ArrangeStringsOntoLines(2, (uint)actor.Account.LineFormatLength));
+		}
+
+		sb.AppendLine("Abbreviations:");
+		foreach (var item in appointment.AbbreviationsAndProgs)
+		{
+			sb.AppendLine(
+				$"\tAbbreviation: {item.Item2.Colour(Telnet.Green)} FutureProg: {(item.Item1 is not null ? item.Item1.FunctionName.Colour(Telnet.Cyan).FluentTagMXP("send", $"href='show futureprog {item.Item1.Id}'") : "None".Colour(Telnet.Red))}{(item.Item1 is not null ? $" (#{item.Item1.Id:N0})" : "")}");
+		}
+
+		sb.AppendLine();
+		sb.AppendLine("Appointment Names:");
+		foreach (var item in appointment.TitlesAndProgs)
+		{
+			sb.AppendLine(
+				$"\tName: {item.Item2.Colour(Telnet.Green)} FutureProg: {(item.Item1 is not null ? item.Item1.FunctionName.Colour(Telnet.Cyan).FluentTagMXP("send", $"href='show futureprog {item.Item1.Id}'") : "None".Colour(Telnet.Red))}{(item.Item1 is not null ? $" (#{item.Item1.Id:N0})" : "")}");
+		}
+
+		sb.AppendLine();
+		sb.AppendLine(appointment.Paygrade is not null
+			? $"Paygrade: {appointment.Paygrade.Abbreviation.Colour(Telnet.Green)} ({appointment.Paygrade.Name.TitleCase().Colour(Telnet.Green)}) - {appointment.Paygrade.PayCurrency.Describe(appointment.Paygrade.PayAmount, CurrencyDescriptionPatternType.Short)}."
+			: $"Paygrade: {"None".Colour(Telnet.Red)}");
+		sb.AppendLine();
+		sb.AppendLine("Privileges:");
+		sb.AppendLine("\t" + appointment.Privileges);
+		actor.OutputHandler.Send(sb.ToString());
+	}
+
+	private void ShowExternalControl(ICharacter actor, IExternalClanControl external)
+	{
+		var sb = new StringBuilder();
+		sb.AppendLine("External Appointment");
+		sb.AppendLine();
+		sb.AppendLine(new[]
+		{
+			$"Vassal Clan: {external.VassalClan.FullName.TitleCase().Colour(Telnet.Green)}",
+			$"Controlled Appointment: {external.ControlledAppointment.Name.TitleCase().Colour(Telnet.Green)}"
+		}.ArrangeStringsOntoLines(2, (uint)actor.Account.LineFormatLength));
+		sb.AppendLine(new[]
+		{
+			$"Liege Clan: {external.LiegeClan.FullName.TitleCase().Colour(Telnet.Green)}",
+			$"Controlling Appointment: {(external.ControllingAppointment is not null ? external.ControllingAppointment.Name.TitleCase().Colour(Telnet.Green) : "None".Colour(Telnet.Red))}"
+		}.ArrangeStringsOntoLines(2, (uint)actor.Account.LineFormatLength));
+		sb.AppendLine(
+			$"Maximum Appointees: {(external.NumberOfAppointments > 0 ? external.NumberOfAppointments.ToString("N0", actor) : "Unlimited".Colour(Telnet.Red))}");
+		sb.AppendLine();
+		if (external.Appointees.Any())
+		{
+			sb.AppendLine("Current Appointees:");
+			foreach (var appointee in external.Appointees)
+			{
+				sb.AppendLine("\t" + appointee.PersonalName.GetName(NameStyle.FullName));
+			}
+		}
+
+		actor.OutputHandler.Send(sb.ToString());
+	}
+}

--- a/MudSharpCore/Community/Clan.cs
+++ b/MudSharpCore/Community/Clan.cs
@@ -24,7 +24,7 @@ using System.Linq;
 
 namespace MudSharp.Community;
 
-public class Clan : SaveableItem, IClan
+public partial class Clan : SaveableItem, IClan
 {
     private static IFutureProg CanCreateClanProg;
     private static IFutureProg OnCreateClanProg;
@@ -169,14 +169,7 @@ public class Clan : SaveableItem, IClan
 
     public bool FreePosition(IAppointment appointment)
     {
-        return appointment.MaximumSimultaneousHolders < 1 ||
-               appointment.MaximumSimultaneousHolders -
-               Memberships.Where(x => x.Appointments.Contains(appointment))
-                          .Sum(
-                              x =>
-                                  ExternalControls.Any()
-                                      ? ExternalControls.Sum(y => y.NumberOfAppointments - y.Appointees.Count)
-                                      : 0) >= 1;
+        return ClanCommandUtilities.HasFreePosition(appointment, Memberships, ExternalControls);
     }
 
     public bool FreePosition(IAppointment appointment, IClan liegeClan)

--- a/MudSharpCore/Community/ClanCommandUtilities.cs
+++ b/MudSharpCore/Community/ClanCommandUtilities.cs
@@ -1,0 +1,94 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MudSharp.Community;
+
+public static class ClanCommandUtilities
+{
+	public static bool HoldsOrControlsAppointment(IClanMembership? membership, IAppointment? appointment)
+	{
+		if (membership is null || appointment is null)
+		{
+			return false;
+		}
+
+		if (membership.Appointments.Contains(appointment))
+		{
+			return true;
+		}
+
+		return HoldsOrControlsAppointment(membership, appointment.ParentPosition);
+	}
+
+	public static bool HasReachedConsecutiveTermLimit(IEnumerable<IElection> elections, long characterId,
+		int maximumConsecutiveTerms)
+	{
+		if (maximumConsecutiveTerms <= 0)
+		{
+			return false;
+		}
+
+		var pastElections = elections
+			.Where(x => x.IsFinalised && !x.IsByElection)
+			.OrderByDescending(x => x.ResultsInEffectDate)
+			.Take(maximumConsecutiveTerms)
+			.ToList();
+
+		return pastElections.Count >= maximumConsecutiveTerms &&
+		       pastElections.All(x => x.Victors.Any(y => y.MemberId == characterId));
+	}
+
+	public static bool HasReachedTotalTermLimit(IEnumerable<IElection> elections, long characterId, int maximumTotalTerms)
+	{
+		if (maximumTotalTerms <= 0)
+		{
+			return false;
+		}
+
+		return elections
+			.Where(x => x.IsFinalised && !x.IsByElection)
+			.Count(x => x.Victors.Any(y => y.MemberId == characterId)) >= maximumTotalTerms;
+	}
+
+	public static bool HasFreePosition(IAppointment appointment, IEnumerable<IClanMembership> memberships,
+		IEnumerable<IExternalClanControl> externalControls)
+	{
+		if (appointment.MaximumSimultaneousHolders < 1)
+		{
+			return true;
+		}
+
+		var filledSlots = memberships.Count(x => !x.IsArchivedMembership && x.Appointments.Contains(appointment));
+		var reservedExternalSlots = externalControls
+			.Where(x => x.VassalClan == appointment.Clan && x.ControlledAppointment == appointment)
+			.Sum(x => x.NumberOfAppointments > x.Appointees.Count ? x.NumberOfAppointments - x.Appointees.Count : 0);
+
+		return appointment.MaximumSimultaneousHolders - filledSlots - reservedExternalSlots >= 1;
+	}
+
+	public static IElection? GetPrimaryOpenElection(IAppointment appointment)
+	{
+		return appointment.Elections
+			.Where(x => !x.IsFinalised && !x.IsByElection)
+			.OrderBy(x => x.ResultsInEffectDate)
+			.FirstOrDefault();
+	}
+
+	public static IElection? GetFirstOpenByElection(IAppointment appointment)
+	{
+		return appointment.Elections
+			.Where(x => !x.IsFinalised && x.IsByElection)
+			.OrderBy(x => x.ResultsInEffectDate)
+			.FirstOrDefault();
+	}
+
+	public static IElection? GetNextOpenElection(IAppointment appointment)
+	{
+		return appointment.Elections
+			.Where(x => !x.IsFinalised)
+			.OrderBy(x => x.ResultsInEffectDate)
+			.FirstOrDefault();
+	}
+}
+#nullable restore

--- a/MudSharpCore/Community/ClanMembership.cs
+++ b/MudSharpCore/Community/ClanMembership.cs
@@ -215,7 +215,7 @@ public class ClanMembership : SaveableItem, IClanMembership, ILazyLoadDuringIdle
     public void AppointToPosition(IAppointment appointment)
     {
         Appointments.Add(appointment);
-        if (appointment.MinimumRankToHold.RankNumber > Rank.RankNumber)
+        if (appointment.MinimumRankToHold != null && appointment.MinimumRankToHold.RankNumber > Rank.RankNumber)
         {
             SetRank(appointment.MinimumRankToHold);
         }

--- a/MudSharpCore/Community/Election.cs
+++ b/MudSharpCore/Community/Election.cs
@@ -202,7 +202,7 @@ public class Election : SaveableItem, IElection
                     continue;
                 }
 
-                ICharacter? ch = Gameworld.Actors.Get(member.Id);
+                ICharacter? ch = Gameworld.Actors.Get(member.MemberId);
                 ch?.OutputHandler.Send(
                     $"Your term as {Appointment.Title(ch).ColourValue()} in {Appointment.Clan.FullName.ColourName()} has ended.");
                 member.Appointments.Remove(Appointment);
@@ -218,7 +218,7 @@ public class Election : SaveableItem, IElection
 
                 victor.Appointments.Add(Appointment);
                 victor.Changed = true;
-                ICharacter? ch = Gameworld.Actors.Get(victor.Id);
+                ICharacter? ch = Gameworld.Actors.Get(victor.MemberId);
                 ch?.OutputHandler.Send(
                     $"Your term as {Appointment.Title(ch).ColourValue()} in {Appointment.Clan.FullName.ColourName()} has begun.");
             }
@@ -320,7 +320,7 @@ public class Election : SaveableItem, IElection
         if (now >= NominationStartDate)
         {
             string echo =
-                $"An election has begun for the position of {Appointment.Name.ColourValue()} in {Appointment.Clan.FullName.ColourName()}.\nThe nomination period will last for {Appointment.VotingPeriod.Describe().ColourValue()}, after which voting will commence.";
+                $"An election has begun for the position of {Appointment.Name.ColourValue()} in {Appointment.Clan.FullName.ColourName()}.\nThe nomination period will last for {Appointment.NominationPeriod.Describe().ColourValue()}, after which voting will commence.";
             Gameworld.SystemMessage(echo,
                 ch => ch.ClanMemberships.Any(x =>
                     x.Clan == Appointment.Clan && x.NetPrivileges.HasFlag(ClanPrivilegeType.CanViewClanOfficeHolders)));
@@ -506,7 +506,7 @@ public class Election : SaveableItem, IElection
                                 : null ??
                                   actor.Dubs
                                        .FirstOrDefault(x =>
-                                           x.TargetType == "Character" && x.TargetId == nominee.Id &&
+                                           x.TargetType == "Character" && x.TargetId == nominee.MemberId &&
                                            !x.WasIdentityConcealed)?.LastDescription.ColourCharacter();
                             if (!string.IsNullOrEmpty(desc))
                             {


### PR DESCRIPTION
## Summary
- Move core clan runtime command handling onto `IClan`/`Clan` and thin out `ClanModule`
- Fix clan election, appointment, and external-control bugs including capacity accounting and permission checks
- Add focused clan regression tests and design docs for the new command and control model

## Testing
- `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `scripts\test-unit-core.ps1`