### PR TITLE
Add project system documentation suite

### DIFF
--- a/Design Documents/Projects_System_Builder_Workflows.md
+++ b/Design Documents/Projects_System_Builder_Workflows.md
@@ -207,11 +207,9 @@ If both are missing, the labour requirement cannot be submitted.
 `supervision` exposes:
 - `project set phase <phase> labour <labour> multiplier <percent>`
 
-Current implementation warning:
-- the multiplier is editable in game
-- it is not currently persisted correctly across reloads
-
-Treat supervision labour as something that must be tested carefully after a reboot or fresh load.
+Current compatibility note:
+- the multiplier now persists correctly
+- older supervision definitions that were saved before this fix load missing multiplier data as `100%`
 
 ### 5. Add labour impacts
 Use:
@@ -234,10 +232,6 @@ Impact hours control when the effect begins after the worker has remained on the
 | `healing` | Modifies healing checks, healing rate, and infection chance | `bonus`, `multiplier`, `infection` |
 | `job` | Adds ongoing-job performance effort each project tick | `expression` |
 | `cap` | Modifies a trait cap | `trait`, `bonus` |
-
-Builder warning for `healing`:
-- the current implementation has inconsistencies in how infection settings are edited and consumed
-- treat it as a current quirk and verify behavior in play before relying on it
 
 ### 6. Add material requirements
 Use:
@@ -277,10 +271,8 @@ Use:
 | `skilluse` | Grants free checks against a trait when the phase completes | `trait`, `checks`, `difficulty` |
 
 Current implementation warning:
-- `sort` is saved and shown to builders
-- action execution is not currently sorted by that value at runtime
-
-Do not assume the numeric sort order changes execution order unless the runtime is updated to consume it.
+- actions execute in ascending `sort` order
+- ties fall back to stable id order
 
 ## Compact Type Keyword Reference
 ### Project families
@@ -342,9 +334,8 @@ The same applies after some phase transitions, especially for local projects, wh
 ### Queueing is not working
 That is expected. `project queue` is currently a stub and is not implemented.
 
-### Multiple mandatory requirements are behaving strangely
-Current implementation warning:
-- phase completion currently tracks only populated labour and material progress entries
-- untouched requirements may not reliably block completion until they have received progress
-
-For now, test multi-requirement projects in play rather than assuming the current implementation enforces every authored requirement exactly as intended.
+### Multiple requirements are behaving differently than expected
+Current completion rules are:
+- only mandatory labour requirements block phase completion
+- only mandatory material requirements block phase completion
+- optional labour and optional material requirements can still exist, but they do not stop the phase from advancing

--- a/Design Documents/Projects_System_Builder_Workflows.md
+++ b/Design Documents/Projects_System_Builder_Workflows.md
@@ -23,6 +23,7 @@ Use `projects` to see:
 - your active personal projects
 - active local projects in your current cell
 - the labour role you are currently working on, if any
+- both labour-continuity hours and project-continuity hours for your current assignment
 - any labour impacts attached to that role, including how many hours remain before gated impacts kick in
 
 This is the fastest way to confirm the live state after starting, joining, supplying, or cancelling a project.
@@ -61,6 +62,7 @@ Current behavior:
 Use `project quit <project>` to stop working on that active project.
 
 This does not cancel the active project. It only removes your current labour assignment from it.
+If your queue has a ready next assignment, the engine immediately tries to join it after you quit.
 
 ### `project details <project>`
 Use `project details <project>` to inspect the live active project in its current phase.
@@ -91,11 +93,24 @@ With a requirement argument, it:
 Use `project cancel` to destroy an active project.
 
 Current rules:
-- personal projects usually can be cancelled, except when an active job depends on that project definition
-- local projects can currently only be cancelled by the owner or an administrator
+- a personal project cannot be cancelled while an unfinished active job still depends on that exact active project instance
+- administrators bypass builder-authored cancellation progs, but not the active-job invariant
+- if no custom cancel progs are configured, both personal and local projects fall back to owner-only cancellation
 
 ### `project queue`
-This command exists in the player command surface but is currently not implemented. It only replies with `Coming soon.`
+Use `project queue` to manage what labour role you want to auto-join next.
+
+Current syntax:
+- `project queue`
+- `project queue <project> [labour]`
+- `project queue remove <index>`
+- `project queue clear`
+
+Current behavior:
+- entries only target the active project's current phase
+- only the first queued entry is considered when you become idle
+- blocked entries remain queued and show statuses such as `Waiting For Slot`, `Waiting For Qualification`, or `Waiting For Location`
+- stale entries are removed automatically when the project disappears or the queued labour is no longer part of the current phase
 
 ## Admin And Revision Workflow
 ### List and inspect definitions
@@ -149,6 +164,10 @@ Optional hooks are:
 - `project set start <prog>`
 - `project set finish <prog>`
 - `project set cancel <prog>`
+- `project set cancancel <prog>`
+- `project set cancancel clear`
+- `project set whycancel <prog>`
+- `project set whycancel clear`
 
 Required signatures:
 - `appear`: returns boolean, takes one `character`
@@ -157,6 +176,8 @@ Required signatures:
 - `start`: takes one `project`
 - `finish`: takes one `project`
 - `cancel`: takes one `project`
+- `cancancel`: returns boolean, takes `character, project`
+- `whycancel`: returns text, takes `character, project`
 
 ### 3. Build the phase structure
 Use:
@@ -222,8 +243,9 @@ Shared impact settings:
 - `project set phase <phase> labour <labour> impact <impact> name <name>`
 - `project set phase <phase> labour <labour> impact <impact> description <description>`
 - `project set phase <phase> labour <labour> impact <impact> hours <hours>`
+- `project set phase <phase> labour <labour> impact <impact> scope labour|project`
 
-Impact hours control when the effect begins after the worker has remained on the same current labour role long enough.
+Impact hours control when the effect begins. `scope labour` keys off continuity on the exact current labour role; `scope project` keys off continuity on the current active project even if the worker changes labour roles inside that project.
 
 ### Impact type reference
 | Keyword | What it does in play | Common extra commands |
@@ -312,7 +334,7 @@ Check:
 - whether the named labour is part of the current phase
 
 ### Personal-project cancellation fails
-Current behavior blocks cancellation when an active ongoing job depends on that project definition. This is how job-linked personal projects avoid being cancelled out from under employment logic.
+Current behavior blocks cancellation when an unfinished active ongoing job depends on that exact active personal-project instance. If you have also configured `cancancel` / `whycancel`, those run only after this hard engine invariant.
 
 ### Material supply is choosing the "wrong" item
 `project preview` and `project supply` use the requirement's inventory plan and then take the first feasible target it scouts.
@@ -332,7 +354,12 @@ Remember:
 The same applies after some phase transitions, especially for local projects, which clear active labour and require workers to join again.
 
 ### Queueing is not working
-That is expected. `project queue` is currently a stub and is not implemented.
+Check:
+- the queued labour is still part of the active project's current phase
+- you are idle; the queue does not activate while you already have a `CurrentProject`
+- for local projects, you are in the same cell when the queue entry reaches the front
+- the queued labour still has a free worker slot
+- you still qualify for that labour
 
 ### Multiple requirements are behaving differently than expected
 Current completion rules are:

--- a/Design Documents/Projects_System_Builder_Workflows.md
+++ b/Design Documents/Projects_System_Builder_Workflows.md
@@ -1,0 +1,350 @@
+# FutureMUD Projects System Builder Workflows
+
+## Purpose
+This document explains how builders and admins currently create, revise, approve, and operate projects through the in-game command surface.
+
+This is a builder-facing guide. It describes the command workflows that exist today, including current limitations and implementation quirks.
+
+## Builder Mental Model
+Keep these three layers separate in your head:
+- A catalogue project is the revisioned template that players see in `project catalog`.
+- An active project is the live runtime instance created when someone starts that template.
+- A current labour role is the single task a character is presently assigned to inside one active project.
+
+Important current behavior:
+- a character can have active personal projects without currently working on one of them
+- a local project can exist in a room with no active workers
+- starting a project does not auto-join labour
+- a character can only have one selected `CurrentProject` labour role at a time
+
+## Player-Facing Usage
+### `projects`
+Use `projects` to see:
+- your active personal projects
+- active local projects in your current cell
+- the labour role you are currently working on, if any
+- any labour impacts attached to that role, including how many hours remain before gated impacts kick in
+
+This is the fastest way to confirm the live state after starting, joining, supplying, or cancelling a project.
+
+### `project catalog`
+Use `project catalog` to list project templates currently visible to that character.
+
+Catalogue visibility requires the project to be:
+- on a `Current` revision
+- allowed by its `AppearInProjectListProg`
+
+### `project view <name>`
+Use `project view <name>` to inspect a catalogue project before starting it.
+
+This shows the project type, tagline, phase structure, labour requirements, impacts, materials, and completion actions from the approved template revision.
+
+### `project start <name>`
+Use `project start <name>` to create a live project instance.
+
+Current behavior:
+- only catalogue-visible current revisions can be started
+- `CanInitiateProg` must allow it
+- personal projects cannot be started twice from the same project definition id
+- starting does not auto-join labour
+
+### `project join <project> [labour]`
+Use `project join` to start working on a labour requirement in the current phase.
+
+Current behavior:
+- if exactly one labour requirement is joinable, it can be inferred
+- if multiple labour requirements are joinable, the command requires an explicit labour name
+- qualification and worker-cap checks are enforced
+- joining a new project labour automatically leaves whatever `CurrentProject` labour you were already working on
+
+### `project quit <project>`
+Use `project quit <project>` to stop working on that active project.
+
+This does not cancel the active project. It only removes your current labour assignment from it.
+
+### `project details <project>`
+Use `project details <project>` to inspect the live active project in its current phase.
+
+This is the command to use when you need to see:
+- current workers
+- mandatory status
+- progress already accrued
+- current-phase material requirements
+
+### `project preview <project> <requirement>`
+Use `project preview` to see what item would be supplied if you used `project supply`.
+
+The current implementation uses the requirement's inventory plan and previews the first feasible target it scouts.
+
+### `project supply <project> [requirement]`
+Use `project supply` to contribute materials to the current phase.
+
+With no requirement argument, it lists the current phase's material requirements.
+
+With a requirement argument, it:
+1. builds the requirement's inventory plan
+2. finds a feasible item automatically
+3. consumes or splits that item
+4. adds the supplied quantity to the active project
+
+### `project cancel <project>`
+Use `project cancel` to destroy an active project.
+
+Current rules:
+- personal projects usually can be cancelled, except when an active job depends on that project definition
+- local projects can currently only be cancelled by the owner or an administrator
+
+### `project queue`
+This command exists in the player command surface but is currently not implemented. It only replies with `Coming soon.`
+
+## Admin And Revision Workflow
+### List and inspect definitions
+Use:
+- `project list`
+- `project list all`
+- `project show <project>`
+
+`project list` shows current revisions.
+`project list all` includes older revisions.
+
+### Create or edit a definition
+Use:
+- `project edit <project>`
+- `project edit new <type>`
+
+Current project type keywords are:
+- `personal`
+- `local`
+
+After opening a project for editing, use `project set ...` against that current editing session to modify it.
+
+### Submit and review
+Use:
+- `project edit submit`
+- `project review all`
+- `project review mine`
+
+For a project to appear in the player catalogue, it must end up on a `Current` revision after the normal submit and review workflow.
+
+## Authoring Workflow
+### 1. Create the project shell
+Start with:
+- `project edit new personal`
+- `project edit new local`
+
+Then set the basics:
+- `project set name <name>`
+- `project set tagline <tagline>`
+
+For personal projects that should be attachable to ongoing jobs, also toggle:
+- `project set jobs`
+
+### 2. Configure the gating and hook progs
+Projects require three gating progs before they can be submitted:
+- `project set appear <prog>`
+- `project set can <prog>`
+- `project set why <prog>`
+
+Optional hooks are:
+- `project set start <prog>`
+- `project set finish <prog>`
+- `project set cancel <prog>`
+
+Required signatures:
+- `appear`: returns boolean, takes one `character`
+- `can`: returns boolean, takes one `character`
+- `why`: returns text, takes one `character`
+- `start`: takes one `project`
+- `finish`: takes one `project`
+- `cancel`: takes one `project`
+
+### 3. Build the phase structure
+Use:
+- `project set phase add`
+- `project set phase remove <phase>`
+- `project set phase duplicate <phase>`
+- `project set phase swap <phase1> <phase2>`
+- `project set phase <phase> description <description>`
+
+Use numeric phase numbers, `first`, or `last` where supported by the underlying phase selector.
+
+Every submitted project must have at least one phase, and every phase must have at least one labour or material requirement.
+
+### 4. Add labour requirements
+Use:
+- `project set phase <phase> labour add <type> [name]`
+- `project set phase <phase> labour remove <labour>`
+- `project set phase <phase> labour duplicate <labour>`
+- `project set phase <phase> labour <labour> show`
+
+Common labour settings:
+- `project set phase <phase> labour <labour> name <name>`
+- `project set phase <phase> labour <labour> description <description>`
+- `project set phase <phase> labour <labour> progress <man-hours>`
+- `project set phase <phase> labour <labour> workers <amount>`
+- `project set phase <phase> labour <labour> mandatory`
+- `project set phase <phase> labour <labour> trait <trait>`
+- `project set phase <phase> labour <labour> trait none`
+- `project set phase <phase> labour <labour> minskill <amount>`
+- `project set phase <phase> labour <labour> difficulty <difficulty>`
+- `project set phase <phase> labour <labour> prog <prog>`
+- `project set phase <phase> labour <labour> prog none`
+
+Qualification is currently trait-or-prog based:
+- builders must set a required trait, or
+- builders must set a qualification prog
+
+If both are missing, the labour requirement cannot be submitted.
+
+### Labour type reference
+| Keyword | What it does in play | Builder notes |
+| --- | --- | --- |
+| `simple` | Produces normal progress toward phase completion | Use for standard work measured in man-hours |
+| `endless` | Never completes and does not produce real phase progress | Use only for ongoing roles that should not finish a phase by themselves |
+| `supervision` | Produces no direct progress and multiplies other workers' output | Always non-mandatory in current behavior |
+
+### Supervision labour note
+`supervision` exposes:
+- `project set phase <phase> labour <labour> multiplier <percent>`
+
+Current implementation warning:
+- the multiplier is editable in game
+- it is not currently persisted correctly across reloads
+
+Treat supervision labour as something that must be tested carefully after a reboot or fresh load.
+
+### 5. Add labour impacts
+Use:
+- `project set phase <phase> labour <labour> impact add <type> [name]`
+- `project set phase <phase> labour <labour> impact duplicate <impact>`
+- `project set phase <phase> labour <labour> impact delete <impact>`
+- `project set phase <phase> labour <labour> impact <impact> show`
+
+Shared impact settings:
+- `project set phase <phase> labour <labour> impact <impact> name <name>`
+- `project set phase <phase> labour <labour> impact <impact> description <description>`
+- `project set phase <phase> labour <labour> impact <impact> hours <hours>`
+
+Impact hours control when the effect begins after the worker has remained on the same current labour role long enough.
+
+### Impact type reference
+| Keyword | What it does in play | Common extra commands |
+| --- | --- | --- |
+| `trait` | Modifies one trait, optionally only in one bonus context | `trait`, `bonus`, `context` |
+| `healing` | Modifies healing checks, healing rate, and infection chance | `bonus`, `multiplier`, `infection` |
+| `job` | Adds ongoing-job performance effort each project tick | `expression` |
+| `cap` | Modifies a trait cap | `trait`, `bonus` |
+
+Builder warning for `healing`:
+- the current implementation has inconsistencies in how infection settings are edited and consumed
+- treat it as a current quirk and verify behavior in play before relying on it
+
+### 6. Add material requirements
+Use:
+- `project set phase <phase> material add <type>`
+- `project set phase <phase> material remove <material>`
+- `project set phase <phase> material duplicate <material>`
+- `project set phase <phase> material <material> show`
+
+Shared material settings:
+- `project set phase <phase> material <material> name <name>`
+- `project set phase <phase> material <material> description <description>`
+
+### Material type reference
+| Keyword | What it does in play | Common extra commands |
+| --- | --- | --- |
+| `simple` | Counts discrete items by tag and minimum quality | `tag`, `amount`, `quality` |
+| `commodity` | Counts commodity mass by material, optional tag, and quality | `material`, `tag`, `amount`, `quality` |
+
+Builder notes:
+- `simple` requires a tag before submit
+- `commodity` requires a material before submit
+- `commodity` `amount` uses the game's mass parser, not a raw item count
+
+### 7. Add completion actions
+Use:
+- `project set phase <phase> action add <type>`
+- `project set phase <phase> action remove <action>`
+- `project set phase <phase> action duplicate <action>`
+- `project set phase <phase> action <action> name <name>`
+- `project set phase <phase> action <action> description <description>`
+- `project set phase <phase> action <action> sort <number>`
+
+### Action type reference
+| Keyword | What it does in play | Common extra commands |
+| --- | --- | --- |
+| `prog` | Executes a FutureProg when the phase completes | `prog <prog>` |
+| `skilluse` | Grants free checks against a trait when the phase completes | `trait`, `checks`, `difficulty` |
+
+Current implementation warning:
+- `sort` is saved and shown to builders
+- action execution is not currently sorted by that value at runtime
+
+Do not assume the numeric sort order changes execution order unless the runtime is updated to consume it.
+
+## Compact Type Keyword Reference
+### Project families
+| Family | Keywords |
+| --- | --- |
+| Project | `personal`, `local` |
+| Labour | `simple`, `endless`, `supervision` |
+| Material | `simple`, `commodity` |
+| Action | `prog`, `skilluse` |
+| Impact | `trait`, `healing`, `job`, `cap` |
+
+## Troubleshooting
+### A project will not submit
+Check these first:
+- at least one phase exists
+- every phase has at least one labour or material requirement
+- `appear`, `can`, and `why` progs are all set
+- each labour, material, action, and impact subtype has its required fields filled in
+
+### A project is approved but not visible in `project catalog`
+Check:
+- the revision is actually `Current`
+- `AppearInProjectListProg` returns true for that character
+
+### `project start` says the character cannot begin it
+Check:
+- `CanInitiateProg`
+- `WhyCannotInitiateProg`
+- whether the character already has another personal project from the same project definition id
+
+### Workers cannot join a labour role
+Check:
+- trait qualification
+- minimum trait value
+- qualification prog
+- worker cap
+- whether the named labour is part of the current phase
+
+### Personal-project cancellation fails
+Current behavior blocks cancellation when an active ongoing job depends on that project definition. This is how job-linked personal projects avoid being cancelled out from under employment logic.
+
+### Material supply is choosing the "wrong" item
+`project preview` and `project supply` use the requirement's inventory plan and then take the first feasible target it scouts.
+
+Practical implication:
+- if multiple eligible items are available, the chosen item is an implementation detail of the current plan and scout order
+
+Use `project preview` before supplying if the exact item choice matters.
+
+### A project exists but nobody is working on it
+This is valid current behavior.
+
+Remember:
+- `project start` creates the active project
+- `project join` assigns a labour role
+
+The same applies after some phase transitions, especially for local projects, which clear active labour and require workers to join again.
+
+### Queueing is not working
+That is expected. `project queue` is currently a stub and is not implemented.
+
+### Multiple mandatory requirements are behaving strangely
+Current implementation warning:
+- phase completion currently tracks only populated labour and material progress entries
+- untouched requirements may not reliably block completion until they have received progress
+
+For now, test multi-requirement projects in play rather than assuming the current implementation enforces every authored requirement exactly as intended.

--- a/Design Documents/Projects_System_Overview.md
+++ b/Design Documents/Projects_System_Overview.md
@@ -1,0 +1,374 @@
+# FutureMUD Projects System Overview
+
+## Purpose
+This document describes the current implementation of the projects system that lives under `MudSharp.Work.Projects` and the closely related runtime surfaces that consume it.
+
+The intended audience is engine developers, maintainers, and agents working on the FutureMUD codebase. This is a current-state document, not an aspirational redesign. Where the implementation has TODOs, stubs, or quirks, they are called out explicitly.
+
+## Document Map
+- [Projects System Builder Workflows](./Projects_System_Builder_Workflows.md) explains the in-game builder and admin command surface for authoring and operating projects.
+
+## Core Idea
+Projects model long-running, mostly off-screen work.
+
+They differ from short-lived craft actions in three important ways:
+- project definitions are revisioned builder content, not ad hoc runtime state
+- active projects persist over time and advance on a scheduled tick
+- a character can have multiple active projects available, but only one currently selected labour role in `CurrentProject`
+
+The system is composed from five layers:
+- `IProject` is the revisioned template that builders approve and players browse from the catalogue
+- `IActiveProject` is the live runtime instance created from a specific project revision
+- `IProjectPhase` partitions the project into sequential stages
+- `IProjectLabourRequirement` and `IProjectMaterialRequirement` define what a phase needs
+- `IProjectAction` and `ILabourImpact` define side effects on completion and while working
+
+## Public Contracts
+### Template and active-project contracts
+- `IProject` exposes catalogue visibility, initiation gating, start/cancel/finish hooks, player presentation, cancellation rules, and the ordered phase list.
+- `IActiveProject` exposes the project definition, current phase, labour progress, material progress, active workers, join/leave/cancel operations, tick processing, and player-facing display.
+- `IPersonalProject` is a marker for active projects owned by a single character.
+- `ILocalProject` is a marker for active projects attached to a cell and worked on by multiple people in that location.
+
+### Phase and requirement contracts
+- `IProjectPhase` owns its phase number, description, labour requirements, material requirements, completion actions, duplication, deletion, and submit validation.
+- `IProjectLabourRequirement` owns qualification logic, hourly progress, worker caps, mandatory status, hours remaining, builder commands, submit validation, and the attached labour impacts.
+- `IProjectMaterialRequirement` owns item matching, supply logic, preview logic, quantity description, inventory-plan generation, builder commands, and submit validation.
+- `IProjectAction` owns phase-completion side effects plus builder commands, duplication, and submit validation.
+- `ILabourImpact` owns builder editing, duplication, apply gating via minimum hours, and presentation for the `projects` command.
+
+### Project FutureProg surface
+Active projects register `ProgVariableTypes.Project` and currently expose these dot references:
+- `id`
+- `name`
+- `location`
+- `owner`
+- `workers`
+
+These are implemented by `ActiveProject.RegisterFutureProgCompiler()` and returned from `ActiveProject.GetProperty`.
+
+## Implemented Types
+`ProjectFactory` is the central registry for all currently shipped project-family types.
+
+### Project types
+| Builder keyword | Runtime type | Purpose |
+| --- | --- | --- |
+| `personal` | `PersonalProject` / `ActivePersonalProject` | Private long-running work owned by one character |
+| `local` | `LocalProject` / `ActiveLocalProject` | Cell-bound group work visible in the local area |
+
+### Labour requirement types
+| Builder keyword | Runtime type | Purpose |
+| --- | --- | --- |
+| `simple` | `SimpleProjectLabour` | Ordinary progress-producing labour |
+| `endless` | `EndlessProjectLabour` | Labour that never completes and contributes no direct phase progress |
+| `supervision` | `SupervisionProjectLabour` | Labour that contributes no direct progress and instead multiplies other workers' output |
+
+### Material requirement types
+| Builder keyword | Runtime type | Purpose |
+| --- | --- | --- |
+| `simple` | `SimpleProjectMaterial` | Counted items matched by tag and minimum quality |
+| `commodity` | `CommodityProjectMaterial` | Weighted commodity inputs matched by material, optional tag, and quality |
+
+### Completion action types
+| Builder keyword | Runtime type | Purpose |
+| --- | --- | --- |
+| `prog` | `ProgAction` | Executes a FutureProg when the phase completes |
+| `skilluse` | `SkillUseAction` | Grants one or more free skill checks to the project owner when the phase completes |
+
+### Labour impact types
+| Builder keyword | Runtime type | Purpose |
+| --- | --- | --- |
+| `trait` | `TraitImpact` | Adds or subtracts trait bonus values, optionally gated to a specific bonus context |
+| `healing` | `HealingImpact` | Modifies healing checks, healing rate, and infection chance |
+| `job` | `JobEffortImpact` | Converts project work into ongoing-job performance effort each project tick |
+| `cap` | `TraitCapImpact` | Modifies trait caps while the impact applies |
+
+## Runtime Model
+### Revisioned definitions versus live instances
+Project templates are revisioned content:
+- `Project` derives from `EditableItem`
+- projects are created, edited, submitted, and reviewed through `EditableRevisableItemHelper.ProjectHelper`
+- active projects store both `ProjectId` and `ProjectRevisionNumber`, so a live instance is pinned to the exact revision it was started from
+
+Live project state is separate:
+- `ActiveProject` and its subclasses track the current phase, active workers, and accumulated progress
+- live progress is not written back to the project definition
+- cancelling or finishing an active project destroys only the runtime instance
+
+### Phases as the unit of progression
+Each `IProject` contains an ordered phase list.
+
+Each phase may contain:
+- labour requirements
+- material requirements
+- completion actions
+
+Phase completion moves the active project to the next phase or finishes the project if no further phase exists.
+
+### Labour, materials, actions, and impacts
+Labour requirements answer:
+- who is qualified
+- how fast they progress
+- how many workers can contribute at once
+- what temporary or ongoing impacts apply while working
+
+Material requirements answer:
+- what items count
+- how much must be supplied
+- how the `project supply` and `project preview` commands locate items automatically
+
+Actions run when the current phase completes.
+
+Impacts apply while a character is working on a labour role and are consumed elsewhere in the codebase through marker interfaces such as:
+- `ILabourImpactTraits`
+- `ILabourImpactTraitCaps`
+- `ILabourImpactHealing`
+- `ILabourImpactActionAtTick`
+
+## Lifecycle
+### Loading and factory registration
+Project data is loaded by `IFuturemudLoader.LoadProjects()` in `FuturemudLoaders`.
+
+The loader:
+- loads revisioned project definitions, their phases, and nested actions, labour requirements, impacts, and materials
+- reconstructs concrete template types through `ProjectFactory.LoadProject`
+- loads active runtime instances through `ProjectFactory.LoadActiveProject`
+
+Factory registration currently lives entirely in `ProjectFactory`, which is the authoritative list of valid builder keywords.
+
+### Catalogue visibility and initiation gating
+`Project` stores these gating hooks in its definition XML:
+- `AppearInProjectListProg`
+- `CanInitiateProg`
+- `WhyCannotInitiateProg`
+- optional `OnStartProg`
+- optional `OnFinishProg`
+- optional `OnCancelProg`
+
+Catalogue visibility currently requires:
+- the project revision status is `Current`
+- `AppearInProjectListProg(character)` returns true
+
+Initiation currently requires:
+- the project revision status is `Current`
+- `CanInitiateProg(character)` returns true
+- the character does not already have another personal project from the same definition id
+
+### Active instance creation
+Starting a project creates a concrete active instance:
+- `PersonalProject.InitiateProject` creates `ActivePersonalProject`, adds it to the gameworld, and adds it to the character's personal projects
+- `LocalProject.InitiateProject` creates `ActiveLocalProject`, adds it to the gameworld, and registers it on the current cell
+
+`OnStartProg(project)` is executed from the active-project constructor.
+
+Starting a project does not automatically join any labour role. It is normal for an active project to exist with no currently active workers.
+
+### Labour joining, switching, and qualification
+`project join` works against the current phase only.
+
+Join rules are enforced by:
+- `CharacterIsQualified`
+- `MaximumSimultaneousWorkers`
+- current phase membership
+
+Joining one project labour automatically calls `Leave` on the character's previously selected `CurrentProject.Project` before assigning the new one.
+
+This means the system models:
+- many active projects existing at once
+- exactly one currently selected labour role per character
+
+### Material supply
+Material supply is driven by `IProjectMaterialRequirement.GetPlanForCharacter`.
+
+The current flow is:
+1. The material requirement creates an inventory plan.
+2. `project preview` or `project supply` scouts the first feasible target with original reference `target`.
+3. The requirement decides how much of that item counts.
+4. `FulfilMaterial` increments active-project progress for that requirement.
+
+Supply is always against the current phase only.
+
+### Scheduled ticking and labour progress
+Active projects advance in the main scheduler loop.
+
+The current tick path is:
+1. `FuturemudLoaders` schedules `"Main ActiveProjects Tick"` every `ProjectTickMinutes`.
+2. Each active project runs `DoProjectsTick()`.
+3. Every active labour entry contributes progress using `HourlyProgress(actor) * ProjectProgressMultiplier`.
+4. Supervision-style multipliers are folded in through `ProgressMultiplierForOtherLabourPerPercentageComplete`.
+5. After progress, each worker gains `CurrentProjectHours += ProjectProgressMultiplier`.
+6. Any `ILabourImpactActionAtTick` impacts execute.
+
+The default static settings currently include:
+- `ProjectTickMinutes = 15`
+- `ProjectProgressMultiplier = 0.25`
+
+The standard labour check driving progress is `CheckType.ProjectLabourCheck`.
+
+### Phase transition and finish behavior
+When a phase is considered complete:
+- each `IProjectAction` in `CurrentPhase.CompletionActions` is executed
+- the active project either advances to the next phase or finishes entirely
+- labour and material progress dictionaries are cleared for the new phase
+
+The two active-project families behave differently:
+- personal projects may automatically rejoin the owner to the first qualified labour in the new phase if they were already working when the phase flipped
+- local projects clear all active labour on phase transition and require workers to join again manually
+
+When the last phase completes:
+- `OnFinishProg(project)` executes
+- the runtime active project is destroyed
+- the project is removed from the character or cell container
+
+### Cancellation
+Cancellation rules are delegated to the template definition:
+- personal projects currently block cancellation if any active job references that same project definition as its job-linked project
+- local projects currently allow cancellation only by the project owner or an administrator
+
+When cancellation succeeds:
+- `OnCancelProg(project)` executes
+- the runtime active project is destroyed
+
+## Persistence and Revisioning
+### Builder content
+Project definitions persist across these EF models:
+- `Project`
+- `ProjectPhase`
+- `ProjectLabourRequirement`
+- `ProjectLabourImpact`
+- `ProjectMaterialRequirement`
+- `ProjectAction`
+
+Common properties such as names, descriptions, sort order, mandatory flags, and counts live in table columns.
+
+Subtype-specific configuration is XML-backed in `Definition` fields:
+- project-level FutureProg ids and tagline live in `Project.Definition`
+- labour subtype configuration lives in `ProjectLabourRequirement.Definition`
+- material subtype configuration lives in `ProjectMaterialRequirement.Definition`
+- action subtype configuration lives in `ProjectAction.Definition`
+- impact subtype configuration lives in `ProjectLabourImpact.Definition`
+
+### Active runtime state
+Active runtime instances persist separately in:
+- `ActiveProject`
+- `ActiveProjectLabour`
+- `ActiveProjectMaterial`
+
+Character-side links are stored through:
+- `Character.CurrentProjectId`
+- `Character.CurrentProjectLabourId`
+- `Character.CurrentProjectHours`
+- the character's `ActiveProjects` collection for owned personal projects
+
+Local projects persist their owning cell id.
+Personal projects persist their owning character id.
+
+## Integration Points
+### Command surface
+The player and admin interaction layer is the `project` command in `CraftModule`, plus the summary `projects` command.
+
+These commands cover:
+- catalogue browsing
+- initiation
+- joining and leaving labour
+- cancellation
+- material preview and supply
+- admin list/show/edit/set/review flows
+
+### Character work state
+`CharacterWork` persists and restores:
+- `PersonalProjects`
+- `CurrentProject`
+- `CurrentProjectHours`
+
+Multiple subsystems consume `CurrentProject` directly, so project work is not isolated inside the work namespace.
+
+### Cell-local project registration
+`Cell` maintains `LocalProjects`.
+
+This is how:
+- local projects are shown in `projects`
+- `project details`, `project join`, `project supply`, and similar commands find local active instances
+- local project lifecycle messages are scoped to a physical location
+
+### Employment integration
+Ongoing jobs can point at a personal project definition when `AppearInJobsList` is enabled.
+
+Current job integration points are:
+- `OngoingJobListing` exposes builder commands to choose a personal project definition for the job
+- applying for such a job creates an `ActivePersonalProject`
+- `JobEffortImpact` adds effort into `ActiveJob.CurrentPerformance`
+- ending the employment attempts to cancel the linked active personal project
+
+Active project names also replace `@job` with the linked active job's name through `ActiveProject.Name`.
+
+### Trait, trait-cap, healing, and infection consumers
+Project labour impacts currently feed into:
+- `BodyTraits` for `ILabourImpactTraits`
+- `BodyTraits` for `ILabourImpactTraitCaps`
+- `BodyBiology` for healing rate and healing bonus modifiers
+- `SimpleOrganicWound` for infection chance
+
+The free skill-check action uses `CheckType.ProjectSkillUseAction`.
+
+## Extending the System
+Start in `FutureMUDLibrary` if the new feature needs a new public contract. Concrete implementations belong in `MudSharpCore`.
+
+### Adding a new project type
+1. Add or extend the public interface if the type needs new public surface.
+2. Implement the template subclass of `Project`.
+3. Implement the active runtime subclass of `ActiveProject`.
+4. Implement load, create, `SaveDefinition`, `Show`, `ShowToPlayer`, `InitiateProject`, `CanCancelProject`, and `LoadActiveProject`.
+5. Register the new builder keyword in `ProjectFactory.CreateProject`, `LoadProject`, and `ValidProjectTypes`.
+6. Wire any extra runtime containers similar to personal-project character registration or local-project cell registration.
+
+### Adding a new labour type
+1. Prefer inheriting from `ProjectLabourBase`.
+2. Implement subtype persistence, duplication, `Show`, `ShowToPlayer`, `HoursRemaining`, and any subtype-specific builder commands.
+3. Make sure `CanSubmit` validates all required subtype data.
+4. Register create/load keywords in `ProjectFactory`.
+5. If the labour changes how other labour behaves, implement `ProgressMultiplierForOtherLabourPerPercentageComplete` or other overrides deliberately.
+
+### Adding a new material type
+1. Prefer inheriting from `MaterialRequirementBase`.
+2. Implement item matching, supply, preview, quantity description, inventory-plan location, duplication, builder commands, and submit validation.
+3. Persist subtype data in `SaveDefinition`.
+4. Register create/load keywords in `ProjectFactory`.
+
+### Adding a new action type
+1. Prefer inheriting from `BaseAction`.
+2. Implement subtype persistence, builder commands, submit validation, and `CompleteAction`.
+3. Register create/load keywords in `ProjectFactory`.
+4. If action ordering matters, do not assume `SortOrder` already enforces it. Either consume `SortOrder` explicitly or document the current behavior.
+
+### Adding a new impact type
+1. Prefer inheriting from `BaseImpact`.
+2. Implement subtype persistence, builder commands, submit validation, and display methods.
+3. Register create/load keywords in `ProjectFactory`.
+4. If the impact should affect other systems, add or reuse a marker interface and wire the consuming subsystem to query that interface.
+5. If the impact should act each tick, implement `ILabourImpactActionAtTick`.
+
+### Cross-cutting expectations
+For every new family member, the expected minimum implementation work is:
+- load
+- save
+- duplicate
+- builder editing help and subcommands
+- player and builder presentation
+- submit validation
+- factory registration
+- any required integration consumers
+
+## Known Quirks And Edge Cases
+- `project queue` is currently stubbed and only replies with `Coming soon.`
+- Local-project cancellation policy is currently hardcoded to owner-or-admin in `LocalProject.CanCancelProject`; there is a `TODO - configurable` comment rather than a content-driven rule.
+- `CurrentProjectHours` resets whenever `Character.CurrentProject` changes, including normal leave/join transitions between labour roles and projects.
+- Phase completion currently checks `_labourProgress.All(...)` and `_materialProgress.All(...)` on the populated progress dictionaries rather than iterating the authoritative requirement lists. Untouched requirements may therefore fail to block completion if they never received a progress entry.
+- `ProjectAction.SortOrder` is persisted and builder-editable, but phase completion currently executes `CurrentPhase.CompletionActions` in collection order without sorting by `SortOrder`.
+- `SupervisionProjectLabour.MultiplierForOtherLabours` has subtype behavior and builder editing, but no subtype-specific XML save/load implementation. In practice the multiplier is not persisted reliably across reloads.
+- `HealingImpact` currently has multiple inconsistencies:
+  - the `infection` builder command writes to `HealingCheckBonus` instead of `InfectionChanceMultiplier`
+  - the player-facing infection text is derived from the healing-rate multiplier rather than the infection multiplier
+  - infection chance consumption in `SimpleOrganicWound` does not filter impacts through `Applies(actor)`, so minimum-hours gating is not applied consistently there
+- `JobEffortImpact` is created from the builder keyword `job`, but its concrete type stores and loads using the runtime type string `JobEffort`. Treat the builder keyword list in `ProjectFactory` as the source of truth for authoring.
+- Starting a project does not auto-join labour. A project may be active, visible in `projects`, and still have nobody currently working on any labour requirement.

--- a/Design Documents/Projects_System_Overview.md
+++ b/Design Documents/Projects_System_Overview.md
@@ -61,7 +61,7 @@ These are implemented by `ActiveProject.RegisterFutureProgCompiler()` and return
 | --- | --- | --- |
 | `simple` | `SimpleProjectLabour` | Ordinary progress-producing labour |
 | `endless` | `EndlessProjectLabour` | Labour that never completes and contributes no direct phase progress |
-| `supervision` | `SupervisionProjectLabour` | Labour that contributes no direct progress and instead multiplies other workers' output |
+| `supervision` | `SupervisionProjectLabour` | Labour that contributes no direct progress, multiplies other workers' output, and is always treated as non-mandatory |
 
 ### Material requirement types
 | Builder keyword | Runtime type | Purpose |
@@ -207,9 +207,10 @@ The standard labour check driving progress is `CheckType.ProjectLabourCheck`.
 
 ### Phase transition and finish behavior
 When a phase is considered complete:
-- each `IProjectAction` in `CurrentPhase.CompletionActions` is executed
+- each `IProjectAction` in `CurrentPhase.CompletionActions` is executed in ascending `SortOrder` and then id order
 - the active project either advances to the next phase or finishes entirely
 - labour and material progress dictionaries are cleared for the new phase
+- only mandatory labour and material requirements gate phase completion
 
 The two active-project families behave differently:
 - personal projects may automatically rejoin the owner to the first qualified labour in the new phase if they were already working when the phase flipped
@@ -309,6 +310,8 @@ Project labour impacts currently feed into:
 - `BodyBiology` for healing rate and healing bonus modifiers
 - `SimpleOrganicWound` for infection chance
 
+Healing-impact minimum-hours gating is now applied consistently to infection chance in the same way it is already applied to healing-rate and healing-check modifiers.
+
 The free skill-check action uses `CheckType.ProjectSkillUseAction`.
 
 ## Extending the System
@@ -339,7 +342,7 @@ Start in `FutureMUDLibrary` if the new feature needs a new public contract. Conc
 1. Prefer inheriting from `BaseAction`.
 2. Implement subtype persistence, builder commands, submit validation, and `CompleteAction`.
 3. Register create/load keywords in `ProjectFactory`.
-4. If action ordering matters, do not assume `SortOrder` already enforces it. Either consume `SortOrder` explicitly or document the current behavior.
+4. If action ordering matters, preserve the current ascending `SortOrder` behavior or deliberately document any change.
 
 ### Adding a new impact type
 1. Prefer inheriting from `BaseImpact`.
@@ -363,12 +366,6 @@ For every new family member, the expected minimum implementation work is:
 - `project queue` is currently stubbed and only replies with `Coming soon.`
 - Local-project cancellation policy is currently hardcoded to owner-or-admin in `LocalProject.CanCancelProject`; there is a `TODO - configurable` comment rather than a content-driven rule.
 - `CurrentProjectHours` resets whenever `Character.CurrentProject` changes, including normal leave/join transitions between labour roles and projects.
-- Phase completion currently checks `_labourProgress.All(...)` and `_materialProgress.All(...)` on the populated progress dictionaries rather than iterating the authoritative requirement lists. Untouched requirements may therefore fail to block completion if they never received a progress entry.
-- `ProjectAction.SortOrder` is persisted and builder-editable, but phase completion currently executes `CurrentPhase.CompletionActions` in collection order without sorting by `SortOrder`.
-- `SupervisionProjectLabour.MultiplierForOtherLabours` has subtype behavior and builder editing, but no subtype-specific XML save/load implementation. In practice the multiplier is not persisted reliably across reloads.
-- `HealingImpact` currently has multiple inconsistencies:
-  - the `infection` builder command writes to `HealingCheckBonus` instead of `InfectionChanceMultiplier`
-  - the player-facing infection text is derived from the healing-rate multiplier rather than the infection multiplier
-  - infection chance consumption in `SimpleOrganicWound` does not filter impacts through `Applies(actor)`, so minimum-hours gating is not applied consistently there
+- Older supervision labour definitions that predate multiplier persistence may have no saved multiplier value. Those now load with a safe default of `100%` rather than preserving the prior broken zero-multiplier behavior.
 - `JobEffortImpact` is created from the builder keyword `job`, but its concrete type stores and loads using the runtime type string `JobEffort`. Treat the builder keyword list in `ProjectFactory` as the source of truth for authoring.
 - Starting a project does not auto-join labour. A project may be active, visible in `projects`, and still have nobody currently working on any labour requirement.

--- a/Design Documents/Projects_System_Overview.md
+++ b/Design Documents/Projects_System_Overview.md
@@ -35,7 +35,8 @@ The system is composed from five layers:
 - `IProjectLabourRequirement` owns qualification logic, hourly progress, worker caps, mandatory status, hours remaining, builder commands, submit validation, and the attached labour impacts.
 - `IProjectMaterialRequirement` owns item matching, supply logic, preview logic, quantity description, inventory-plan generation, builder commands, and submit validation.
 - `IProjectAction` owns phase-completion side effects plus builder commands, duplication, and submit validation.
-- `ILabourImpact` owns builder editing, duplication, apply gating via minimum hours, and presentation for the `projects` command.
+- `ILabourImpact` owns builder editing, duplication, apply gating via minimum hours, minimum-hours scope, and presentation for the `projects` command.
+- `IProjectLabourQueueEntry` owns a queued project labour assignment, its queue order, queued timestamp, and readiness state.
 
 ### Project FutureProg surface
 Active projects register `ProgVariableTypes.Project` and currently expose these dot references:
@@ -141,6 +142,8 @@ Factory registration currently lives entirely in `ProjectFactory`, which is the 
 - `AppearInProjectListProg`
 - `CanInitiateProg`
 - `WhyCannotInitiateProg`
+- optional `CanCancelProg`
+- optional `WhyCannotCancelProg`
 - optional `OnStartProg`
 - optional `OnFinishProg`
 - optional `OnCancelProg`
@@ -177,6 +180,24 @@ This means the system models:
 - many active projects existing at once
 - exactly one currently selected labour role per character
 
+### Queueing next labour
+`project queue` is now implemented as a conservative character-owned FIFO queue.
+
+The shipped behavior is:
+- queue entries target an existing active project plus one current-phase labour requirement
+- queue entries are evaluated only when the character is idle
+- only the first queued entry is considered at a time
+- blocked entries stay queued with a status such as `Waiting For Slot`, `Waiting For Qualification`, or `Waiting For Location`
+- stale entries are removed automatically if the project disappears or the labour is no longer in the current phase
+
+Queue activation is re-evaluated when it matters, including:
+- after `project quit`
+- after labour completion clears the worker's active role
+- after a project finishes or is cancelled
+- after a local-project slot opens
+- on login
+- when an idle character enters a cell
+
 ### Material supply
 Material supply is driven by `IProjectMaterialRequirement.GetPlanForCharacter`.
 
@@ -196,7 +217,7 @@ The current tick path is:
 2. Each active project runs `DoProjectsTick()`.
 3. Every active labour entry contributes progress using `HourlyProgress(actor) * ProjectProgressMultiplier`.
 4. Supervision-style multipliers are folded in through `ProgressMultiplierForOtherLabourPerPercentageComplete`.
-5. After progress, each worker gains `CurrentProjectHours += ProjectProgressMultiplier`.
+5. After progress, each worker gains both `CurrentProjectHours += ProjectProgressMultiplier` and `CurrentProjectProjectHours += ProjectProgressMultiplier`.
 6. Any `ILabourImpactActionAtTick` impacts execute.
 
 The default static settings currently include:
@@ -223,12 +244,17 @@ When the last phase completes:
 
 ### Cancellation
 Cancellation rules are delegated to the template definition:
-- personal projects currently block cancellation if any active job references that same project definition as its job-linked project
-- local projects currently allow cancellation only by the project owner or an administrator
+- hard engine invariants run first
+- administrators bypass builder-authored cancel rules, but not hard invariants
+- optional `CanCancelProg(character, project)` and `WhyCannotCancelProg(character, project)` can author content-driven policy
+- if no cancel progs are set, both personal and local projects fall back to owner-only cancellation
 
 When cancellation succeeds:
 - `OnCancelProg(project)` executes
 - the runtime active project is destroyed
+
+The current hard invariant is:
+- a personal project cannot be cancelled while any unfinished active job still references that exact active project instance
 
 ## Persistence and Revisioning
 ### Builder content
@@ -259,6 +285,8 @@ Character-side links are stored through:
 - `Character.CurrentProjectId`
 - `Character.CurrentProjectLabourId`
 - `Character.CurrentProjectHours`
+- `Character.CurrentProjectProjectHours`
+- `ProjectLabourQueue`
 - the character's `ActiveProjects` collection for owned personal projects
 
 Local projects persist their owning cell id.
@@ -272,6 +300,7 @@ These commands cover:
 - catalogue browsing
 - initiation
 - joining and leaving labour
+- queueing next labour
 - cancellation
 - material preview and supply
 - admin list/show/edit/set/review flows
@@ -281,6 +310,8 @@ These commands cover:
 - `PersonalProjects`
 - `CurrentProject`
 - `CurrentProjectHours`
+- `CurrentProjectProjectHours`
+- `ProjectLabourQueue`
 
 Multiple subsystems consume `CurrentProject` directly, so project work is not isolated inside the work namespace.
 
@@ -310,6 +341,10 @@ Project labour impacts currently feed into:
 - `BodyBiology` for healing rate and healing bonus modifiers
 - `SimpleOrganicWound` for infection chance
 
+Each impact now chooses whether its minimum-hours gate is measured against:
+- labour continuity through `CurrentProjectHours`
+- project continuity through `CurrentProjectProjectHours`
+
 Healing-impact minimum-hours gating is now applied consistently to infection chance in the same way it is already applied to healing-rate and healing-check modifiers.
 
 The free skill-check action uses `CheckType.ProjectSkillUseAction`.
@@ -321,7 +356,7 @@ Start in `FutureMUDLibrary` if the new feature needs a new public contract. Conc
 1. Add or extend the public interface if the type needs new public surface.
 2. Implement the template subclass of `Project`.
 3. Implement the active runtime subclass of `ActiveProject`.
-4. Implement load, create, `SaveDefinition`, `Show`, `ShowToPlayer`, `InitiateProject`, `CanCancelProject`, and `LoadActiveProject`.
+4. Implement load, create, `SaveDefinition`, `Show`, `ShowToPlayer`, `InitiateProject`, the cancellation fallback or invariant hooks, and `LoadActiveProject`.
 5. Register the new builder keyword in `ProjectFactory.CreateProject`, `LoadProject`, and `ValidProjectTypes`.
 6. Wire any extra runtime containers similar to personal-project character registration or local-project cell registration.
 
@@ -363,9 +398,8 @@ For every new family member, the expected minimum implementation work is:
 - any required integration consumers
 
 ## Known Quirks And Edge Cases
-- `project queue` is currently stubbed and only replies with `Coming soon.`
-- Local-project cancellation policy is currently hardcoded to owner-or-admin in `LocalProject.CanCancelProject`; there is a `TODO - configurable` comment rather than a content-driven rule.
-- `CurrentProjectHours` resets whenever `Character.CurrentProject` changes, including normal leave/join transitions between labour roles and projects.
+- Queue entries are intentionally current-phase-only. If a local project advances phase, old queued labour entries for the previous phase become stale and are removed rather than being remapped.
+- For backwards compatibility, characters loaded from worlds that predate `CurrentProjectProjectHours` bootstrap that value from `CurrentProjectHours` if they are already assigned to a current project.
 - Older supervision labour definitions that predate multiplier persistence may have no saved multiplier value. Those now load with a safe default of `100%` rather than preserving the prior broken zero-multiplier behavior.
 - `JobEffortImpact` is created from the builder keyword `job`, but its concrete type stores and loads using the runtime type string `JobEffort`. Treat the builder keyword list in `ProjectFactory` as the source of truth for authoring.
 - Starting a project does not auto-join labour. A project may be active, visible in `projects`, and still have nobody currently working on any labour requirement.

--- a/FutureMUDLibrary/Character/ICharacter.cs
+++ b/FutureMUDLibrary/Character/ICharacter.cs
@@ -437,7 +437,13 @@ namespace MudSharp.Character
         IEnumerable<IPersonalProject> PersonalProjects { get; }
         (IActiveProject Project, IProjectLabourRequirement Labour) CurrentProject { get; set; }
         double CurrentProjectHours { get; set; }
+        double CurrentProjectProjectHours { get; set; }
+        IEnumerable<IProjectLabourQueueEntry> ProjectLabourQueue { get; }
         void AddPersonalProject(IActiveProject project);
         void RemovePersonalProject(IActiveProject project);
+        IProjectLabourQueueEntry QueueProjectLabour(IActiveProject project, IProjectLabourRequirement labour);
+        bool RemoveProjectQueueEntry(int position);
+        void ClearProjectQueue();
+        bool TryJoinQueuedProjectLabour();
     }
 }

--- a/FutureMUDLibrary/Work/Projects/ILabourImpact.cs
+++ b/FutureMUDLibrary/Work/Projects/ILabourImpact.cs
@@ -3,13 +3,14 @@ using MudSharp.Framework;
 
 namespace MudSharp.Work.Projects
 {
-    public interface ILabourImpact : IFrameworkItem
-    {
-        string DescriptionForProjectsCommand { get; }
+	public interface ILabourImpact : IFrameworkItem
+	{
+		string DescriptionForProjectsCommand { get; }
+		ProjectImpactHoursReference HoursReference { get; }
 
-        void Delete();
-        ILabourImpact Duplicate(IProjectLabourRequirement requirement);
-        bool BuildingCommand(ICharacter actor, StringStack command, IProjectLabourRequirement requirement);
+		void Delete();
+		ILabourImpact Duplicate(IProjectLabourRequirement requirement);
+		bool BuildingCommand(ICharacter actor, StringStack command, IProjectLabourRequirement requirement);
         (bool Truth, string Error) CanSubmit();
         string Show(ICharacter actor);
         string ShowFull(ICharacter actor);

--- a/FutureMUDLibrary/Work/Projects/IProject.cs
+++ b/FutureMUDLibrary/Work/Projects/IProject.cs
@@ -5,22 +5,25 @@ using System.Collections.Generic;
 
 namespace MudSharp.Work.Projects
 {
-    public interface IProject : IEditableRevisableItem
-    {
-        bool AppearInJobsList { get; }
-        string Tagline { get; }
-        IFutureProg OnStartProg { get; }
-        IFutureProg OnCancelProg { get; }
-        IFutureProg OnFinishProg { get; }
-        IEnumerable<string> ProjectCatalogueColumns(ICharacter actor);
-        bool AppearInProjectList(ICharacter actor);
-        bool CanInitiateProject(ICharacter actor);
-        string WhyCannotInitiateProject(ICharacter actor);
-        string ShowToPlayer(ICharacter actor);
-        void InitiateProject(ICharacter actor);
-        bool CanCancelProject(ICharacter actor, IActiveProject local);
-        IActiveProject LoadActiveProject(Models.ActiveProject project);
+	public interface IProject : IEditableRevisableItem
+	{
+		bool AppearInJobsList { get; }
+		string Tagline { get; }
+		IFutureProg OnStartProg { get; }
+		IFutureProg CanCancelProg { get; }
+		IFutureProg WhyCannotCancelProg { get; }
+		IFutureProg OnCancelProg { get; }
+		IFutureProg OnFinishProg { get; }
+		IEnumerable<string> ProjectCatalogueColumns(ICharacter actor);
+		bool AppearInProjectList(ICharacter actor);
+		bool CanInitiateProject(ICharacter actor);
+		string WhyCannotInitiateProject(ICharacter actor);
+		string ShowToPlayer(ICharacter actor);
+		void InitiateProject(ICharacter actor);
+		bool CanCancelProject(ICharacter actor, IActiveProject local);
+		string WhyCannotCancelProject(ICharacter actor, IActiveProject local);
+		IActiveProject LoadActiveProject(Models.ActiveProject project);
 
-        IEnumerable<IProjectPhase> Phases { get; }
-    }
+		IEnumerable<IProjectPhase> Phases { get; }
+	}
 }

--- a/FutureMUDLibrary/Work/Projects/IProjectLabourQueueEntry.cs
+++ b/FutureMUDLibrary/Work/Projects/IProjectLabourQueueEntry.cs
@@ -1,0 +1,16 @@
+#nullable enable
+using MudSharp.Character;
+using System;
+
+namespace MudSharp.Work.Projects;
+
+public interface IProjectLabourQueueEntry
+{
+	long Id { get; }
+	ICharacter Character { get; }
+	IActiveProject Project { get; }
+	IProjectLabourRequirement Labour { get; }
+	int QueueOrder { get; }
+	DateTime QueuedAt { get; }
+	ProjectLabourQueueStatus Status { get; }
+}

--- a/FutureMUDLibrary/Work/Projects/ProjectImpactHoursReference.cs
+++ b/FutureMUDLibrary/Work/Projects/ProjectImpactHoursReference.cs
@@ -1,0 +1,9 @@
+#nullable enable
+
+namespace MudSharp.Work.Projects;
+
+public enum ProjectImpactHoursReference
+{
+	Labour = 0,
+	Project = 1
+}

--- a/FutureMUDLibrary/Work/Projects/ProjectLabourQueueStatus.cs
+++ b/FutureMUDLibrary/Work/Projects/ProjectLabourQueueStatus.cs
@@ -1,0 +1,12 @@
+#nullable enable
+
+namespace MudSharp.Work.Projects;
+
+public enum ProjectLabourQueueStatus
+{
+	Ready = 0,
+	WaitingForSlot = 1,
+	WaitingForQualification = 2,
+	WaitingForLocation = 3,
+	Stale = 4
+}

--- a/MudSharpCore/Character/Character.cs
+++ b/MudSharpCore/Character/Character.cs
@@ -1481,6 +1481,8 @@ public partial class Character : PerceiverItem, ICharacter
 
         dbitem.CurrentProjectId = CurrentProject.Project?.Id;
         dbitem.CurrentProjectLabourId = CurrentProject.Labour?.Id;
+        dbitem.CurrentProjectHours = CurrentProjectHours;
+        dbitem.CurrentProjectProjectHours = CurrentProjectProjectHours;
         FMDB.Context.Characters.Add(dbitem);
         return dbitem;
     }

--- a/MudSharpCore/Character/CharacterWork.cs
+++ b/MudSharpCore/Character/CharacterWork.cs
@@ -1,86 +1,223 @@
-﻿using MudSharp.Economy;
+using MudSharp.Database;
+using MudSharp.Economy;
+using MudSharp.Framework;
 using MudSharp.Work.Projects;
-using System;
+using MudSharp.Work.Projects.ConcreteTypes;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MudSharp.Character;
 
 public partial class Character
 {
-    private void SaveProjects(MudSharp.Models.Character character)
-    {
-        character.CurrentProjectId = _currentProject.Project?.Id;
-        character.CurrentProjectLabourId = _currentProject.Labour?.Id;
-        character.CurrentProjectHours = CurrentProjectHours;
-    }
+	private void SaveProjects(MudSharp.Models.Character character)
+	{
+		character.CurrentProjectId = _currentProject.Project?.Id;
+		character.CurrentProjectLabourId = _currentProject.Labour?.Id;
+		character.CurrentProjectHours = CurrentProjectHours;
+		character.CurrentProjectProjectHours = CurrentProjectProjectHours;
 
-    private void LoadProjects(MudSharp.Models.Character character)
-    {
-        _personalProjects.AddRange(character.ActiveProjects.Select(x => Gameworld.ActiveProjects.Get(x.Id)));
-        IActiveProject project = Gameworld.ActiveProjects.Get(character.CurrentProjectId ?? 0);
-        _currentProject = (project,
-            project?.CurrentPhase.LabourRequirements.First(x => x.Id == character.CurrentProjectLabourId));
-        _currentProjectHours = character.CurrentProjectHours;
-    }
+		FMDB.Context.ProjectLabourQueues.RemoveRange(character.ProjectLabourQueues);
+		foreach (var entry in _projectLabourQueue.OrderBy(x => x.QueueOrder))
+		{
+			if (entry.Project == null || entry.Labour == null)
+			{
+				continue;
+			}
 
-    private readonly List<IActiveJob> _activeJobs = new();
-    public IEnumerable<IActiveJob> ActiveJobs => _activeJobs;
+			character.ProjectLabourQueues.Add(new MudSharp.Models.ProjectLabourQueue
+			{
+				Character = character,
+				ActiveProjectId = entry.ProjectId,
+				ProjectLabourRequirementId = entry.LabourId,
+				QueueOrder = entry.QueueOrder,
+				QueuedAt = entry.QueuedAt
+			});
+		}
+	}
 
-    public void AddJob(IActiveJob job)
-    {
-        _activeJobs.Add(job);
-        Changed = true;
-    }
+	private void LoadProjects(MudSharp.Models.Character character)
+	{
+		_personalProjects.AddRange(character.ActiveProjects.Select(x => Gameworld.ActiveProjects.Get(x.Id)).Where(x => x != null));
+		var project = Gameworld.ActiveProjects.Get(character.CurrentProjectId ?? 0);
+		_currentProject = (project,
+			project?.CurrentPhase.LabourRequirements.FirstOrDefault(x => x.Id == character.CurrentProjectLabourId));
+		_currentProjectHours = character.CurrentProjectHours;
+		_currentProjectProjectHours = character.CurrentProjectId.HasValue &&
+		                              character.CurrentProjectProjectHours <= 0.0
+			? character.CurrentProjectHours
+			: character.CurrentProjectProjectHours;
+		_projectLabourQueue.Clear();
+		foreach (var queue in character.ProjectLabourQueues.OrderBy(x => x.QueueOrder))
+		{
+			_projectLabourQueue.Add(new ProjectLabourQueueEntry(queue, Gameworld, this));
+		}
+	}
 
-    public void RemoveJob(IActiveJob job)
-    {
-        _activeJobs.Remove(job);
-        Changed = true;
-    }
+	private readonly List<IActiveJob> _activeJobs = new();
+	public IEnumerable<IActiveJob> ActiveJobs => _activeJobs;
 
-    private readonly List<IActiveProject> _personalProjects = new();
-    public IEnumerable<IPersonalProject> PersonalProjects => _personalProjects.OfType<IPersonalProject>();
+	public void AddJob(IActiveJob job)
+	{
+		_activeJobs.Add(job);
+		Changed = true;
+	}
 
-    private (IActiveProject Project, IProjectLabourRequirement Labour) _currentProject;
+	public void RemoveJob(IActiveJob job)
+	{
+		_activeJobs.Remove(job);
+		Changed = true;
+	}
 
-    public (IActiveProject Project, IProjectLabourRequirement Labour) CurrentProject
-    {
-        get => _currentProject;
-        set
-        {
-            _currentProject = value;
-            _currentProjectHours = 0.0;
-            Changed = true;
-        }
-    }
+	private readonly List<IActiveProject> _personalProjects = new();
+	public IEnumerable<IPersonalProject> PersonalProjects => _personalProjects.OfType<IPersonalProject>();
+	private readonly List<ProjectLabourQueueEntry> _projectLabourQueue = new();
+	public IEnumerable<IProjectLabourQueueEntry> ProjectLabourQueue => _projectLabourQueue.OrderBy(x => x.QueueOrder);
 
-    private double _currentProjectHours;
+	private (IActiveProject Project, IProjectLabourRequirement Labour) _currentProject;
 
-    public double CurrentProjectHours
-    {
-        get => _currentProjectHours;
-        set
-        {
-            _currentProjectHours = value;
-            Changed = true;
-        }
-    }
+	public (IActiveProject Project, IProjectLabourRequirement Labour) CurrentProject
+	{
+		get => _currentProject;
+		set
+		{
+			var oldProject = _currentProject.Project;
+			var oldLabour = _currentProject.Labour;
+			_currentProject = value;
+			if (oldProject != value.Project)
+			{
+				_currentProjectHours = 0.0;
+				_currentProjectProjectHours = 0.0;
+			}
+			else if (oldLabour != value.Labour)
+			{
+				_currentProjectHours = 0.0;
+			}
 
-    public void AddPersonalProject(IActiveProject project)
-    {
-        _personalProjects.Add(project);
-    }
+			Changed = true;
+		}
+	}
 
-    public void RemovePersonalProject(IActiveProject project)
-    {
-        _personalProjects.Remove(project);
-        if (CurrentProject.Project == project)
-        {
-            CurrentProject = (null, null);
-            CurrentProjectHours = 0.0;
-        }
-    }
+	private double _currentProjectHours;
+
+	public double CurrentProjectHours
+	{
+		get => _currentProjectHours;
+		set
+		{
+			_currentProjectHours = value;
+			Changed = true;
+		}
+	}
+
+	private double _currentProjectProjectHours;
+
+	public double CurrentProjectProjectHours
+	{
+		get => _currentProjectProjectHours;
+		set
+		{
+			_currentProjectProjectHours = value;
+			Changed = true;
+		}
+	}
+
+	public void AddPersonalProject(IActiveProject project)
+	{
+		_personalProjects.Add(project);
+	}
+
+	public void RemovePersonalProject(IActiveProject project)
+	{
+		_personalProjects.Remove(project);
+		if (CurrentProject.Project == project)
+		{
+			CurrentProject = (null, null);
+			CurrentProjectHours = 0.0;
+			CurrentProjectProjectHours = 0.0;
+		}
+	}
+
+	public IProjectLabourQueueEntry QueueProjectLabour(IActiveProject project, IProjectLabourRequirement labour)
+	{
+		var existing = _projectLabourQueue.FirstOrDefault(x => x.Project == project && x.Labour == labour);
+		if (existing != null)
+		{
+			return existing;
+		}
+
+		var entry = new ProjectLabourQueueEntry(this, project, labour, _projectLabourQueue.Count + 1);
+		_projectLabourQueue.Add(entry);
+		Changed = true;
+		return entry;
+	}
+
+	public bool RemoveProjectQueueEntry(int position)
+	{
+		var entry = _projectLabourQueue
+			.OrderBy(x => x.QueueOrder)
+			.ElementAtOrDefault(position - 1);
+		if (entry == null)
+		{
+			return false;
+		}
+
+		_projectLabourQueue.Remove(entry);
+		RenumberProjectQueue();
+		Changed = true;
+		return true;
+	}
+
+	public void ClearProjectQueue()
+	{
+		if (!_projectLabourQueue.Any())
+		{
+			return;
+		}
+
+		_projectLabourQueue.Clear();
+		Changed = true;
+	}
+
+	public bool TryJoinQueuedProjectLabour()
+	{
+		if (CurrentProject.Project != null)
+		{
+			return false;
+		}
+
+		while (_projectLabourQueue.Any())
+		{
+			var next = _projectLabourQueue.OrderBy(x => x.QueueOrder).First();
+			switch (next.Status)
+			{
+				case ProjectLabourQueueStatus.Stale:
+					OutputHandler.Send(
+						$"Your queued project labour entry for {(next.Project?.Name ?? "an unknown project").ColourName()} / {(next.Labour?.Name ?? "an unknown labour requirement").ColourValue()} has become stale and has been removed.");
+					_projectLabourQueue.Remove(next);
+					RenumberProjectQueue();
+					Changed = true;
+					continue;
+				case ProjectLabourQueueStatus.Ready:
+					_projectLabourQueue.Remove(next);
+					RenumberProjectQueue();
+					Changed = true;
+					next.Project.Join(this, next.Labour);
+					return true;
+				default:
+					return false;
+			}
+		}
+
+		return false;
+	}
+
+	private void RenumberProjectQueue()
+	{
+		var i = 0;
+		foreach (var entry in _projectLabourQueue.OrderBy(x => x.QueueOrder))
+		{
+			entry.QueueOrder = ++i;
+		}
+	}
 }

--- a/MudSharpCore/Commands/Modules/CraftModule.cs
+++ b/MudSharpCore/Commands/Modules/CraftModule.cs
@@ -17,6 +17,7 @@ using MudSharp.PerceptionEngine.Parsers;
 using MudSharp.Work.Butchering;
 using MudSharp.Work.Crafts;
 using MudSharp.Work.Projects;
+using MudSharp.Work.Projects.ConcreteTypes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -519,8 +520,20 @@ The full list of filters for craft list is below:
         {
             sb.AppendLine(
                 $"You are currently working on {actor.CurrentProject.Labour.Name.ColourValue()} from the {actor.CurrentProject.Project.Name.Colour(Telnet.Cyan)} project [#{actor.CurrentProject.Project.Id.ToString("N0", actor)}].");
+            sb.AppendLine(
+                $"Continuity: labour {actor.CurrentProjectHours.ToString("N2", actor).ColourValue()} hours, project {actor.CurrentProjectProjectHours.ToString("N2", actor).ColourValue()} hours.");
             List<(ILabourImpact x, double)> impacts = actor.CurrentProject.Labour.LabourImpacts.Select(x =>
-                (x, x.Applies(actor) ? 0.0 : x.MinimumHoursForImpactToKickIn - actor.CurrentProjectHours)).ToList();
+            {
+                var currentHours = x.HoursReference == ProjectImpactHoursReference.Project
+                    ? actor.CurrentProjectProjectHours
+                    : actor.CurrentProjectHours;
+                return (
+                    x,
+                    x.Applies(actor)
+                        ? 0.0
+                        : Math.Max(0.0, x.MinimumHoursForImpactToKickIn - currentHours)
+                );
+            }).ToList();
             if (impacts.Any())
             {
                 sb.AppendLine();
@@ -531,7 +544,7 @@ The full list of filters for craft list is below:
                     if (hours > 0.0)
                     {
                         sb.AppendLine(
-                            $"\t{impact.DescriptionForProjectsCommand.SubstituteANSIColour()} {$"[in {hours.ToString("N2", actor)}hrs]".ColourError()}");
+                            $"\t{impact.DescriptionForProjectsCommand.SubstituteANSIColour()} {$"[{impact.HoursReference.DescribeEnum()} continuity, {hours.ToString("N2", actor)}hrs remaining]".ColourError()}");
                         continue;
                     }
 
@@ -550,7 +563,7 @@ The full list of filters for craft list is below:
 
 You can only work on one project at a time, but you're always working on it, even when you're offline. In this manner, it differs from crafts in that it represents what you're doing ""off screen"". 
 
-Some projects, particularly personal projects, have ""impacts"" that have some effect on you. Many of these impacts require you to be working on the same project for some period of time before they kick in, so changing between projects too often is not advisable.
+Some projects, particularly personal projects, have ""impacts"" that have some effect on you. Depending on the impact, the minimum-hours gate may be based on your current labour role or your continuity on the overall active project.
 
 You can use the following player options with this command:
 
@@ -559,6 +572,10 @@ You can use the following player options with this command:
 	#3start <name>#0 - starts a new project
 	#3join <project>#0 - joins an active project
 	#3quit <project>#0 - quits an active project you are working on
+	#3queue#0 - shows your queued project labour assignments
+	#3queue <project> [<labour>]#0 - queues a project labour assignment for when you are next idle
+	#3queue remove <index>#0 - removes a queued assignment
+	#3queue clear#0 - clears your queued assignments
 	#3cancel <project>#0 - cancels an active project
 	#3supply <project> <req>#0 - supplies material for a particular material requirement
 	#3preview <project> <req>#0 - shows you what material you would submit if you did #3project supply#0
@@ -586,7 +603,7 @@ Note: See the closely related #3projects#0 command for information about your cu
 
 You can only work on one project at a time, but you're always working on it, even when you're offline. In this manner, it differs from crafts in that it represents what you're doing ""off screen"". 
 
-Some projects, particularly personal projects, have ""impacts"" that have some effect on you. Many of these impacts require you to be working on the same project for some period of time before they kick in, so changing between projects too often is not advisable.
+Some projects, particularly personal projects, have ""impacts"" that have some effect on you. Depending on the impact, the minimum-hours gate may be based on your current labour role or your continuity on the overall active project.
 
 You can use the following options with this command:
 
@@ -595,6 +612,10 @@ You can use the following options with this command:
 	#3start <name>#0 - starts a new project
 	#3join <project>#0 - joins an active project
 	#3quit <project>#0 - quits an active project you are working on
+	#3queue#0 - shows your queued project labour assignments
+	#3queue <project> [<labour>]#0 - queues a project labour assignment for when you are next idle
+	#3queue remove <index>#0 - removes a queued assignment
+	#3queue clear#0 - clears your queued assignments
 	#3cancel <project>#0 - cancels an active project
 	#3supply <project> <req>#0 - supplies material for a particular material requirement
 	#3preview <project> <req>#0 - shows you what material you would submit if you did #3project supply#0
@@ -734,9 +755,10 @@ Note: See the closely related #3projects#0 command for information about your cu
             return;
         }
 
-        if (!project.ProjectDefinition.CanCancelProject(actor, project))
+        var why = project.ProjectDefinition.WhyCannotCancelProject(actor, project);
+        if (!string.IsNullOrEmpty(why))
         {
-            actor.OutputHandler.Send("You are not allowed to cancel that project.");
+            actor.OutputHandler.Send(why);
             return;
         }
 
@@ -746,9 +768,10 @@ Note: See the closely related #3projects#0 command for information about your cu
         {
             AcceptAction = text =>
             {
-                if (!project.ProjectDefinition.CanCancelProject(actor, project))
+                var whyCannot = project.ProjectDefinition.WhyCannotCancelProject(actor, project);
+                if (!string.IsNullOrEmpty(whyCannot))
                 {
-                    actor.OutputHandler.Send("You are not allowed to cancel that project.");
+                    actor.OutputHandler.Send(whyCannot);
                     return;
                 }
 
@@ -918,7 +941,39 @@ Note: See the closely related #3projects#0 command for information about your cu
 
     private static void ProjectQueue(ICharacter actor, StringStack ss)
     {
-        actor.OutputHandler.Send("Coming soon.");
+        if (ss.IsFinished)
+        {
+            ShowProjectQueue(actor);
+            return;
+        }
+
+        switch (ss.PeekSpeech().ToLowerInvariant())
+        {
+            case "show":
+            case "list":
+                ss.PopSpeech();
+                ShowProjectQueue(actor);
+                return;
+            case "clear":
+                ss.PopSpeech();
+                ProjectQueueClear(actor);
+                return;
+            case "remove":
+            case "delete":
+            case "rem":
+            case "del":
+                ss.PopSpeech();
+                ProjectQueueRemove(actor, ss);
+                return;
+            case "?":
+            case "help":
+                actor.OutputHandler.Send(
+                    "The syntax is PROJECT QUEUE, PROJECT QUEUE <project> [<labour>], PROJECT QUEUE REMOVE <index>, or PROJECT QUEUE CLEAR.");
+                return;
+            default:
+                ProjectQueueAdd(actor, ss);
+                return;
+        }
     }
 
     private static void ProjectJoin(ICharacter actor, StringStack ss)
@@ -1015,6 +1070,149 @@ Note: See the closely related #3projects#0 command for information about your cu
         }
 
         project.Leave(actor);
+        actor.TryJoinQueuedProjectLabour();
+    }
+
+    private static void ShowProjectQueue(ICharacter actor)
+    {
+        var queue = actor.ProjectLabourQueue
+            .OfType<ProjectLabourQueueEntry>()
+            .OrderBy(x => x.QueueOrder)
+            .ToList();
+        if (!queue.Any())
+        {
+            actor.OutputHandler.Send("You do not currently have any queued project labour assignments.");
+            return;
+        }
+
+        actor.OutputHandler.Send(
+            StringUtilities.GetTextTable(
+                queue.Select(x => new[]
+                {
+                    x.QueueOrder.ToString("N0", actor),
+                    x.Project?.Name ?? $"Project #{x.ProjectId.ToString("N0", actor)}",
+                    x.Labour?.Name ?? $"Labour #{x.LabourId.ToString("N0", actor)}",
+                    x.Status.DescribeEnum(),
+                    x.QueuedAt.ToString("g", actor)
+                }),
+                new[] { "#", "Project", "Labour", "Status", "Queued" },
+                actor.LineFormatLength,
+                colour: Telnet.Green,
+                unicodeTable: actor.Account.UseUnicode)
+        );
+    }
+
+    private static void ProjectQueueClear(ICharacter actor)
+    {
+        if (!actor.ProjectLabourQueue.Any())
+        {
+            actor.OutputHandler.Send("You do not currently have any queued project labour assignments.");
+            return;
+        }
+
+        actor.ClearProjectQueue();
+        actor.OutputHandler.Send("You clear all your queued project labour assignments.");
+    }
+
+    private static void ProjectQueueRemove(ICharacter actor, StringStack ss)
+    {
+        if (ss.IsFinished)
+        {
+            actor.OutputHandler.Send("Which queue position do you want to remove?");
+            return;
+        }
+
+        if (!int.TryParse(ss.PopSpeech(), out var position) || position < 1)
+        {
+            actor.OutputHandler.Send("You must specify a valid positive queue position.");
+            return;
+        }
+
+        if (!actor.RemoveProjectQueueEntry(position))
+        {
+            actor.OutputHandler.Send("There is no queued project labour assignment in that position.");
+            return;
+        }
+
+        actor.OutputHandler.Send($"You remove queue entry #{position.ToString("N0", actor).ColourValue()}.");
+    }
+
+    private static void ProjectQueueAdd(ICharacter actor, StringStack ss)
+    {
+        if (ss.IsFinished)
+        {
+            ShowProjectQueue(actor);
+            return;
+        }
+
+        List<IActiveProject> projects = actor.PersonalProjects.OfType<IActiveProject>().Concat(actor.Location.LocalProjects).ToList();
+        IActiveProject project = projects.GetByIdOrName(ss.PopSpeech());
+        if (project == null)
+        {
+            actor.OutputHandler.Send("You are not aware of any such project.");
+            return;
+        }
+
+        IProjectLabourRequirement labour = null;
+        if (ss.IsFinished)
+        {
+            List<IProjectLabourRequirement> potentiallyQueueable = project.CurrentPhase.LabourRequirements
+                .Where(x => x.CharacterIsQualified(actor))
+                .ToList();
+            if (potentiallyQueueable.Count == 0)
+            {
+                actor.OutputHandler.Send(
+                    "You are not qualified to queue any of the labour requirements for that project.");
+                return;
+            }
+
+            if (potentiallyQueueable.Count > 1)
+            {
+                actor.OutputHandler.Send(
+                    $"You are qualified for more than one of the labour requirements for that project, so you must specify which one you want to queue. Your options are {potentiallyQueueable.Select(x => x.Name.ColourValue()).ListToString()}.");
+                return;
+            }
+
+            labour = potentiallyQueueable.Single();
+        }
+        else
+        {
+            string labourText = ss.PopSpeech();
+            labour = project.CurrentPhase.LabourRequirements.FirstOrDefault(x => x.Name.EqualTo(labourText)) ??
+                     project.CurrentPhase.LabourRequirements.FirstOrDefault(x =>
+                         x.Name.StartsWith(labourText, StringComparison.InvariantCultureIgnoreCase));
+            if (labour == null)
+            {
+                actor.OutputHandler.Send(
+                    "The current phase of that project does not have any such labour requirement.");
+                return;
+            }
+
+            if (!labour.CharacterIsQualified(actor))
+            {
+                actor.OutputHandler.Send(
+                    $"You are not qualified to do the {labour.Name.ColourValue()} labour requirement for that project.");
+                return;
+            }
+        }
+
+        var existing = actor.ProjectLabourQueue
+            .OfType<ProjectLabourQueueEntry>()
+            .FirstOrDefault(x => x.ProjectId == project.Id && x.LabourId == labour.Id);
+        if (existing != null)
+        {
+            actor.OutputHandler.Send(
+                $"You already have {labour.Name.ColourValue()} on {project.Name.ColourName()} queued at position #{existing.QueueOrder.ToString("N0", actor).ColourValue()}.");
+            return;
+        }
+
+        var entry = actor.QueueProjectLabour(project, labour);
+        actor.OutputHandler.Send(
+            $"You queue {labour.Name.ColourValue()} on {project.Name.ColourName()} at position #{entry.QueueOrder.ToString("N0", actor).ColourValue()}. It is currently {entry.Status.DescribeEnum().ColourValue()}.");
+        if (actor.CurrentProject.Project == null)
+        {
+            actor.TryJoinQueuedProjectLabour();
+        }
     }
 
     private static void ProjectStart(ICharacter actor, StringStack ss)

--- a/MudSharpCore/Construction/Cell.cs
+++ b/MudSharpCore/Construction/Cell.cs
@@ -683,6 +683,10 @@ public partial class Cell : Location, IDisposable, ICell
         }
 
         CheckFallExitStatus();
+        if (movingCharacter.CurrentProject.Project == null)
+        {
+            movingCharacter.TryJoinQueuedProjectLabour();
+        }
     }
 
     private RoomLayer HandleEnterLayers(ICharacter movingCharacter)

--- a/MudSharpCore/Health/Wounds/SimpleOrganicWound.cs
+++ b/MudSharpCore/Health/Wounds/SimpleOrganicWound.cs
@@ -1787,7 +1787,8 @@ public class SimpleOrganicWound : PerceivedItem, IWound
         double chance = Gameworld.GetStaticDouble("BaseInfectionChance");
         chance *= GetInfectionChanceDamageMultiplier();
 
-        chance *= ch.CurrentProject.Labour?.LabourImpacts.OfType<ILabourImpactHealing>()
+        chance *= ch.CurrentProject.Labour?.LabourImpacts.Where(x => x.Applies(ch))
+                    .OfType<ILabourImpactHealing>()
                     .Aggregate(1.0, (sum, x) => sum * x.InfectionChanceMultiplier) ?? 1.0;
         chance *= terrain.InfectionMultiplier;
 

--- a/MudSharpCore/Work/Projects/ConcreteTypes/ActiveLocalProject.cs
+++ b/MudSharpCore/Work/Projects/ConcreteTypes/ActiveLocalProject.cs
@@ -29,12 +29,14 @@ public class ActiveLocalProject : ActiveProject, ILocalProject
 
     public override void Cancel(ICharacter actor)
     {
+        var locationCharacters = Location?.Characters.ToList() ?? new List<ICharacter>();
         actor.OutputHandler.Handle(new EmoteOutput(new Emote(
             $"@ cancel|cancels the {ProjectDefinition.Name.Colour(Telnet.Cyan)} local project.", actor, actor)));
         ProjectDefinition.OnCancelProg?.Execute(this);
         ClearWorkersFromProject();
         Location.RemoveProject(this);
         Delete();
+        TryJoinQueuedProjectLabourFor(locationCharacters);
     }
 
     private void ClearWorkersFromProject()
@@ -71,16 +73,18 @@ public class ActiveLocalProject : ActiveProject, ILocalProject
                 Changed = true;
                 Location.Handle(
                     $"The {ProjectDefinition.Name.Colour(Telnet.Cyan)} local project has entered the {CurrentPhase.Name.ColourBold(Telnet.White)} phase.");
-                // TODO - queueing multiple jobs
+                TryJoinQueuedProjectLabourFor(Location.Characters.ToList());
                 return true;
             }
 
+            var locationCharacters = Location.Characters.ToList();
             Location.Handle(
                 $"The {ProjectDefinition.Name.Colour(Telnet.Cyan)} local project has been completed.");
             ProjectDefinition.OnFinishProg?.Execute(this);
             ClearWorkersFromProject();
             Location.RemoveProject(this);
             Delete();
+            TryJoinQueuedProjectLabourFor(locationCharacters);
             return true;
         }
 
@@ -104,7 +108,13 @@ public class ActiveLocalProject : ActiveProject, ILocalProject
             }
 
             _activeLabour.RemoveAll(x => x.Labour == labour);
-            return CheckForProjectCompletion();
+            var changedProjectState = CheckForProjectCompletion();
+            if (!changedProjectState)
+            {
+                TryJoinQueuedProjectLabourFor(Location.Characters.ToList());
+            }
+
+            return changedProjectState;
         }
 
         return false;
@@ -141,6 +151,7 @@ public class ActiveLocalProject : ActiveProject, ILocalProject
         actor.OutputHandler.Handle(new EmoteOutput(new Emote(
             $"@ stop|stops all work on the {ProjectDefinition.Name.Colour(Telnet.Cyan)} local project.", actor,
             actor)));
+        TryJoinQueuedProjectLabourFor(Location.Characters.Where(x => x != actor).ToList());
     }
 
     protected override void DatabaseInsert(MudSharp.Models.ActiveProject project)

--- a/MudSharpCore/Work/Projects/ConcreteTypes/ActiveLocalProject.cs
+++ b/MudSharpCore/Work/Projects/ConcreteTypes/ActiveLocalProject.cs
@@ -32,16 +32,29 @@ public class ActiveLocalProject : ActiveProject, ILocalProject
         actor.OutputHandler.Handle(new EmoteOutput(new Emote(
             $"@ cancel|cancels the {ProjectDefinition.Name.Colour(Telnet.Cyan)} local project.", actor, actor)));
         ProjectDefinition.OnCancelProg?.Execute(this);
+        ClearWorkersFromProject();
         Location.RemoveProject(this);
         Delete();
     }
 
+    private void ClearWorkersFromProject()
+    {
+        foreach ((ICharacter character, _) in _activeLabour.ToList())
+        {
+            if (character.CurrentProject.Project == this)
+            {
+                character.CurrentProject = (null, null);
+            }
+        }
+
+        _activeLabour.Clear();
+    }
+
     private bool CheckForProjectCompletion()
     {
-        if (_labourProgress.All(x => x.Value >= x.Key.TotalProgressRequired) &&
-            _materialProgress.All(x => x.Value >= x.Key.QuantityRequired))
+        if (AreCurrentPhaseCompletionRequirementsMet())
         {
-            foreach (IProjectAction action in CurrentPhase.CompletionActions)
+            foreach (IProjectAction action in OrderedCompletionActions())
             {
                 action.CompleteAction(this);
             }
@@ -54,7 +67,7 @@ public class ActiveLocalProject : ActiveProject, ILocalProject
                 CurrentPhase = nextPhase;
                 _labourProgress.Clear();
                 _materialProgress.Clear();
-                _activeLabour.Clear();
+                ClearWorkersFromProject();
                 Changed = true;
                 Location.Handle(
                     $"The {ProjectDefinition.Name.Colour(Telnet.Cyan)} local project has entered the {CurrentPhase.Name.ColourBold(Telnet.White)} phase.");
@@ -65,6 +78,7 @@ public class ActiveLocalProject : ActiveProject, ILocalProject
             Location.Handle(
                 $"The {ProjectDefinition.Name.Colour(Telnet.Cyan)} local project has been completed.");
             ProjectDefinition.OnFinishProg?.Execute(this);
+            ClearWorkersFromProject();
             Location.RemoveProject(this);
             Delete();
             return true;
@@ -146,10 +160,11 @@ public class ActiveLocalProject : ActiveProject, ILocalProject
         sb.Append(" - ");
         sb.Append(
             $"{CurrentPhase.LabourRequirements.Sum(x => x.HoursRemaining(this)).ToString("N2", actor).ColourValue()} hours of work remain");
-        if (CurrentPhase.MaterialRequirements.Any())
+        var mandatoryMaterialCompletion = MandatoryMaterialCompletionRatio();
+        if (mandatoryMaterialCompletion.HasValue)
         {
             sb.Append(
-                $", materials {(CurrentPhase.MaterialRequirements.Where(x => x.IsMandatoryForProjectCompletion).Sum(x => MaterialProgress[x]) / CurrentPhase.MaterialRequirements.Where(x => x.IsMandatoryForProjectCompletion).Sum(x => x.QuantityRequired)).ToString("P0", actor).ColourValue()} complete");
+                $", materials {mandatoryMaterialCompletion.Value.ToString("P0", actor).ColourValue()} complete");
         }
 
         return sb.ToString();

--- a/MudSharpCore/Work/Projects/ConcreteTypes/ActivePersonalProject.cs
+++ b/MudSharpCore/Work/Projects/ConcreteTypes/ActivePersonalProject.cs
@@ -37,6 +37,7 @@ public class ActivePersonalProject : ActiveProject, IPersonalProject
         ProjectDefinition.OnCancelProg?.Execute(this);
         CharacterOwner.RemovePersonalProject(this);
         Delete();
+        CharacterOwner.TryJoinQueuedProjectLabour();
     }
 
     private bool CheckForProjectCompletion(bool alreadyWorkingOnProject)
@@ -83,6 +84,11 @@ public class ActivePersonalProject : ActiveProject, IPersonalProject
                     }
                 }
 
+                if (CharacterOwner.CurrentProject.Project == null)
+                {
+                    CharacterOwner.TryJoinQueuedProjectLabour();
+                }
+
                 return true;
             }
 
@@ -95,6 +101,7 @@ public class ActivePersonalProject : ActiveProject, IPersonalProject
             ProjectDefinition.OnFinishProg?.Execute(this);
             CharacterOwner.RemovePersonalProject(this);
             Delete();
+            CharacterOwner.TryJoinQueuedProjectLabour();
             return true;
         }
 
@@ -116,7 +123,13 @@ public class ActivePersonalProject : ActiveProject, IPersonalProject
 
             CharacterOwner.CurrentProject = (null, null);
             _activeLabour.Clear();
-            return CheckForProjectCompletion(true);
+            var changedProjectState = CheckForProjectCompletion(true);
+            if (!changedProjectState)
+            {
+                CharacterOwner.TryJoinQueuedProjectLabour();
+            }
+
+            return changedProjectState;
         }
 
         return false;

--- a/MudSharpCore/Work/Projects/ConcreteTypes/ActivePersonalProject.cs
+++ b/MudSharpCore/Work/Projects/ConcreteTypes/ActivePersonalProject.cs
@@ -41,10 +41,9 @@ public class ActivePersonalProject : ActiveProject, IPersonalProject
 
     private bool CheckForProjectCompletion(bool alreadyWorkingOnProject)
     {
-        if (_labourProgress.All(x => x.Value >= x.Key.TotalProgressRequired) &&
-            _materialProgress.All(x => x.Value >= x.Key.QuantityRequired))
+        if (AreCurrentPhaseCompletionRequirementsMet())
         {
-            foreach (IProjectAction action in CurrentPhase.CompletionActions)
+            foreach (IProjectAction action in OrderedCompletionActions())
             {
                 action.CompleteAction(this);
             }
@@ -54,6 +53,13 @@ public class ActivePersonalProject : ActiveProject, IPersonalProject
                                                             1);
             if (nextPhase != null)
             {
+                var ownerWasWorkingOnThisProject = alreadyWorkingOnProject;
+                _activeLabour.Clear();
+                if (CharacterOwner.CurrentProject.Project == this)
+                {
+                    CharacterOwner.CurrentProject = (null, null);
+                }
+
                 CurrentPhase = nextPhase;
                 _labourProgress.Clear();
                 _materialProgress.Clear();
@@ -66,7 +72,7 @@ public class ActivePersonalProject : ActiveProject, IPersonalProject
 
                 IProjectLabourRequirement newLabour =
                     CurrentPhase.LabourRequirements.FirstOrDefault(x => x.CharacterIsQualified(CharacterOwner));
-                if (alreadyWorkingOnProject && newLabour != null)
+                if (ownerWasWorkingOnThisProject && newLabour != null)
                 {
                     _activeLabour.Add((CharacterOwner, newLabour));
                     CharacterOwner.CurrentProject = (this, newLabour);
@@ -160,10 +166,11 @@ public class ActivePersonalProject : ActiveProject, IPersonalProject
         sb.Append(" - ");
         sb.Append(
             $"{CurrentPhase.LabourRequirements.Sum(x => x.HoursRemaining(this)).ToString("N2", actor).ColourValue()} hours of work remain");
-        if (CurrentPhase.MaterialRequirements.Any())
+        var mandatoryMaterialCompletion = MandatoryMaterialCompletionRatio();
+        if (mandatoryMaterialCompletion.HasValue)
         {
             sb.Append(
-                $", materials {(CurrentPhase.MaterialRequirements.Where(x => x.IsMandatoryForProjectCompletion).Sum(x => MaterialProgress[x]) / CurrentPhase.MaterialRequirements.Where(x => x.IsMandatoryForProjectCompletion).Sum(x => x.QuantityRequired)).ToString("P0", actor).ColourValue()} complete");
+                $", materials {mandatoryMaterialCompletion.Value.ToString("P0", actor).ColourValue()} complete");
         }
 
         return sb.ToString();

--- a/MudSharpCore/Work/Projects/ConcreteTypes/ActiveProject.cs
+++ b/MudSharpCore/Work/Projects/ConcreteTypes/ActiveProject.cs
@@ -148,6 +148,52 @@ public abstract class ActiveProject : LateInitialisingItem, IActiveProject, ILaz
 
     public abstract void Leave(ICharacter actor);
 
+    protected bool AreMandatoryLabourRequirementsComplete()
+    {
+        return CurrentPhase.LabourRequirements
+            .Where(x => x.IsMandatoryForProjectCompletion)
+            .All(x => LabourProgress[x] >= x.TotalProgressRequired);
+    }
+
+    protected bool AreMandatoryMaterialRequirementsComplete()
+    {
+        return CurrentPhase.MaterialRequirements
+            .Where(x => x.IsMandatoryForProjectCompletion)
+            .All(x => MaterialProgress[x] >= x.QuantityRequired);
+    }
+
+    protected bool AreCurrentPhaseCompletionRequirementsMet()
+    {
+        return AreMandatoryLabourRequirementsComplete() &&
+               AreMandatoryMaterialRequirementsComplete();
+    }
+
+    protected IEnumerable<IProjectAction> OrderedCompletionActions()
+    {
+        return CurrentPhase.CompletionActions
+            .OrderBy(x => x.SortOrder)
+            .ThenBy(x => x.Id);
+    }
+
+    protected double? MandatoryMaterialCompletionRatio()
+    {
+        var mandatoryMaterials = CurrentPhase.MaterialRequirements
+            .Where(x => x.IsMandatoryForProjectCompletion)
+            .ToList();
+        if (!mandatoryMaterials.Any())
+        {
+            return null;
+        }
+
+        var totalRequired = mandatoryMaterials.Sum(x => x.QuantityRequired);
+        if (totalRequired <= 0.0)
+        {
+            return null;
+        }
+
+        return mandatoryMaterials.Sum(x => MaterialProgress[x]) / totalRequired;
+    }
+
     public sealed override void Save()
     {
         Models.ActiveProject dbitem = FMDB.Context.ActiveProjects.Find(Id);

--- a/MudSharpCore/Work/Projects/ConcreteTypes/ActiveProject.cs
+++ b/MudSharpCore/Work/Projects/ConcreteTypes/ActiveProject.cs
@@ -175,6 +175,17 @@ public abstract class ActiveProject : LateInitialisingItem, IActiveProject, ILaz
             .ThenBy(x => x.Id);
     }
 
+    protected void TryJoinQueuedProjectLabourFor(IEnumerable<ICharacter> characters)
+    {
+        foreach (var character in characters
+                     .Where(x => x != null)
+                     .Distinct()
+                     .Where(x => x.CurrentProject.Project == null))
+        {
+            character.TryJoinQueuedProjectLabour();
+        }
+    }
+
     protected double? MandatoryMaterialCompletionRatio()
     {
         var mandatoryMaterials = CurrentPhase.MaterialRequirements
@@ -306,6 +317,7 @@ public abstract class ActiveProject : LateInitialisingItem, IActiveProject, ILaz
         foreach ((ICharacter Character, IProjectLabourRequirement Labour) labour in ActiveLabour)
         {
             labour.Character.CurrentProjectHours += 1.0 * multiplier;
+            labour.Character.CurrentProjectProjectHours += 1.0 * multiplier;
             foreach (ILabourImpactActionAtTick impact in labour.Labour.LabourImpacts.OfType<ILabourImpactActionAtTick>())
             {
                 impact.DoAction(labour.Character, this, labour.Labour);

--- a/MudSharpCore/Work/Projects/ConcreteTypes/LocalProject.cs
+++ b/MudSharpCore/Work/Projects/ConcreteTypes/LocalProject.cs
@@ -75,10 +75,11 @@ public class LocalProject : Project
         Gameworld.Add(project);
     }
 
-    public override bool CanCancelProject(ICharacter actor, IActiveProject local)
+    protected override string WhyCannotCancelProjectFallback(ICharacter actor, IActiveProject local)
     {
-        // TODO - configurable
-        return actor == local.CharacterOwner || actor.IsAdministrator();
+        return actor == local.CharacterOwner
+            ? string.Empty
+            : "Only the owner of that local project can cancel it.";
     }
 
     protected override XElement SaveDefinition(XElement baseDefinition)
@@ -103,6 +104,10 @@ public class LocalProject : Project
             $"CanInitiateProg: {CanInitiateProg?.MXPClickableFunctionNameWithId() ?? "None".Colour(Telnet.Red)}");
         sb.AppendLine(
             $"WhyCannotInitiateProg: {WhyCannotInitiateProg?.MXPClickableFunctionNameWithId() ?? "None".Colour(Telnet.Red)}");
+        sb.AppendLine(
+            $"CanCancelProg: {CanCancelProg?.MXPClickableFunctionNameWithId() ?? "None".Colour(Telnet.Red)}");
+        sb.AppendLine(
+            $"WhyCannotCancelProg: {WhyCannotCancelProg?.MXPClickableFunctionNameWithId() ?? "None".Colour(Telnet.Red)}");
         sb.AppendLine($"Tagline: {Tagline}");
         sb.AppendLine("Phases".GetLineWithTitle(actor.LineFormatLength, actor.Account.UseUnicode, Telnet.Cyan,
             Telnet.BoldYellow));

--- a/MudSharpCore/Work/Projects/ConcreteTypes/PersonalProject.cs
+++ b/MudSharpCore/Work/Projects/ConcreteTypes/PersonalProject.cs
@@ -37,15 +37,21 @@ public class PersonalProject : Project
         actor.AddPersonalProject(project);
     }
 
-    public override bool CanCancelProject(ICharacter actor, IActiveProject local)
+    protected override string WhyCannotCancelProjectInvariant(ICharacter actor, IActiveProject local)
     {
-        if (actor.ActiveJobs.Any(x => x.ActiveProject?.ProjectDefinition == this))
+        if (Gameworld.ActiveJobs.Any(x => !x.IsJobComplete && x.ActiveProject == local))
         {
-            return false;
+            return "You cannot cancel that personal project while an active job still depends on it.";
         }
 
-        // Personal Projects can otherwise always be cancelled
-        return true;
+        return string.Empty;
+    }
+
+    protected override string WhyCannotCancelProjectFallback(ICharacter actor, IActiveProject local)
+    {
+        return actor == local.CharacterOwner
+            ? string.Empty
+            : "Only the owner of that personal project can cancel it.";
     }
 
     public override string ShowToPlayer(ICharacter actor)
@@ -100,6 +106,10 @@ public class PersonalProject : Project
             $"CanInitiateProg: {CanInitiateProg?.MXPClickableFunctionNameWithId() ?? "None".Colour(Telnet.Red)}");
         sb.AppendLine(
             $"WhyCannotInitiateProg: {WhyCannotInitiateProg?.MXPClickableFunctionNameWithId() ?? "None".Colour(Telnet.Red)}");
+        sb.AppendLine(
+            $"CanCancelProg: {CanCancelProg?.MXPClickableFunctionNameWithId() ?? "None".Colour(Telnet.Red)}");
+        sb.AppendLine(
+            $"WhyCannotCancelProg: {WhyCannotCancelProg?.MXPClickableFunctionNameWithId() ?? "None".Colour(Telnet.Red)}");
         sb.AppendLine($"Appear in Job List: {AppearInJobsList.ToColouredString()}");
         sb.AppendLine($"Tagline: {Tagline}");
         sb.AppendLine("Phases".GetLineWithTitle(actor.LineFormatLength, actor.Account.UseUnicode, Telnet.Cyan,

--- a/MudSharpCore/Work/Projects/ConcreteTypes/Project.cs
+++ b/MudSharpCore/Work/Projects/ConcreteTypes/Project.cs
@@ -134,6 +134,42 @@ public abstract class Project : EditableItem, IProject
                     $"Project definition {Id} specified a OnCancelProg that does not accept only a single project as a parameter.");
             }
         }
+
+        CanCancelProg = long.TryParse(root.Element("CanCancelProg")?.Value ?? "0", out value)
+            ? Gameworld.FutureProgs.Get(value)
+            : Gameworld.FutureProgs.GetByName(root.Element("CanCancelProg")?.Value);
+        if (CanCancelProg != null)
+        {
+            if (!CanCancelProg.ReturnType.CompatibleWith(ProgVariableTypes.Boolean))
+            {
+                throw new ApplicationException(
+                    $"Project definition {Id} specified a CanCancelProg that does not return a boolean.");
+            }
+
+            if (!CanCancelProg.MatchesParameters(new[] { ProgVariableTypes.Character, ProgVariableTypes.Project }))
+            {
+                throw new ApplicationException(
+                    $"Project definition {Id} specified a CanCancelProg that does not accept a character and a project as parameters.");
+            }
+        }
+
+        WhyCannotCancelProg = long.TryParse(root.Element("WhyCannotCancelProg")?.Value ?? "0", out value)
+            ? Gameworld.FutureProgs.Get(value)
+            : Gameworld.FutureProgs.GetByName(root.Element("WhyCannotCancelProg")?.Value);
+        if (WhyCannotCancelProg != null)
+        {
+            if (!WhyCannotCancelProg.ReturnType.CompatibleWith(ProgVariableTypes.Text))
+            {
+                throw new ApplicationException(
+                    $"Project definition {Id} specified a WhyCannotCancelProg that does not return text.");
+            }
+
+            if (!WhyCannotCancelProg.MatchesParameters(new[] { ProgVariableTypes.Character, ProgVariableTypes.Project }))
+            {
+                throw new ApplicationException(
+                    $"Project definition {Id} specified a WhyCannotCancelProg that does not accept a character and a project as parameters.");
+            }
+        }
     }
 
     protected Project(IAccount originator, string type) : base(originator)
@@ -179,7 +215,9 @@ public abstract class Project : EditableItem, IProject
             new XElement("WhyCannotInitiateProg", WhyCannotInitiateProg?.Id ?? 0),
             new XElement("OnStartProg", OnStartProg?.Id ?? 0),
             new XElement("OnFinishProg", OnFinishProg?.Id ?? 0),
-            new XElement("OnCancelProg", OnCancelProg?.Id ?? 0)
+            new XElement("OnCancelProg", OnCancelProg?.Id ?? 0),
+            new XElement("CanCancelProg", CanCancelProg?.Id ?? 0),
+            new XElement("WhyCannotCancelProg", WhyCannotCancelProg?.Id ?? 0)
         ));
     }
 
@@ -192,6 +230,8 @@ public abstract class Project : EditableItem, IProject
     public IFutureProg WhyCannotInitiateProg { get; protected set; }
 
     public IFutureProg OnStartProg { get; protected set; }
+    public IFutureProg CanCancelProg { get; protected set; }
+    public IFutureProg WhyCannotCancelProg { get; protected set; }
     public IFutureProg OnCancelProg { get; protected set; }
     public IFutureProg OnFinishProg { get; protected set; }
     public bool AppearInJobsList { get; protected set; }
@@ -231,7 +271,49 @@ public abstract class Project : EditableItem, IProject
 
     public abstract void InitiateProject(ICharacter actor);
 
-    public abstract bool CanCancelProject(ICharacter actor, IActiveProject local);
+    public bool CanCancelProject(ICharacter actor, IActiveProject local)
+    {
+        return string.IsNullOrEmpty(WhyCannotCancelProject(actor, local));
+    }
+
+    public string WhyCannotCancelProject(ICharacter actor, IActiveProject local)
+    {
+        if (local == null || local.ProjectDefinition != this)
+        {
+            return "You are not allowed to cancel that project.";
+        }
+
+        var invariantFailure = WhyCannotCancelProjectInvariant(actor, local);
+        if (!string.IsNullOrEmpty(invariantFailure))
+        {
+            return invariantFailure;
+        }
+
+        if (actor.IsAdministrator())
+        {
+            return string.Empty;
+        }
+
+        if (CanCancelProg != null)
+        {
+            if (CanCancelProg.Execute<bool?>(actor, local) == true)
+            {
+                return string.Empty;
+            }
+
+            return WhyCannotCancelProg?.Execute<string>(actor, local) ??
+                   "You are not allowed to cancel that project.";
+        }
+
+        return WhyCannotCancelProjectFallback(actor, local);
+    }
+
+    protected virtual string WhyCannotCancelProjectInvariant(ICharacter actor, IActiveProject local)
+    {
+        return string.Empty;
+    }
+
+    protected abstract string WhyCannotCancelProjectFallback(ICharacter actor, IActiveProject local);
 
     private readonly List<IProjectPhase> _phases = new();
     public IEnumerable<IProjectPhase> Phases => _phases;
@@ -249,6 +331,10 @@ public abstract class Project : EditableItem, IProject
 	#3finish clear#0 - clears the OnFinishProg
 	#3cancel <prog>#0 - sets the OnCancelProg
 	#3cancel clear#0 - clears the OnCancelProg
+	#3cancancel <prog>#0 - sets the CanCancelProg
+	#3cancancel clear#0 - clears the CanCancelProg
+	#3whycancel <prog>#0 - sets the WhyCannotCancelProg
+	#3whycancel clear#0 - clears the WhyCannotCancelProg
 
 Editing Phases:
 
@@ -337,6 +423,24 @@ Editing Actions:
             case "cancel":
             case "oncancel":
                 return BuildingCommandOnCancelProg(actor, command);
+            case "cancancel":
+            case "can cancel":
+            case "can_cancel":
+            case "cancelcan":
+            case "cancel can":
+            case "cancel_can":
+            case "cancancelprog":
+            case "cancelprog":
+            case "cancel prog":
+            case "cancel_prog":
+                return BuildingCommandCanCancel(actor, command);
+            case "whycancel":
+            case "why cancel":
+            case "why_cancel":
+            case "whycancelprog":
+            case "why cancelprog":
+            case "why_cancelprog":
+                return BuildingCommandWhyCannotCancel(actor, command);
             case "can":
             case "caninitiate":
             case "initiate":
@@ -370,6 +474,98 @@ Editing Actions:
 
         actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
         return false;
+    }
+
+    private bool BuildingCommandCanCancel(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send(
+                "You must either specify a prog or use 'clear' to remove the existing one.");
+            return false;
+        }
+
+        if (command.Peek().EqualToAny("clear", "none", "delete", "remove"))
+        {
+            CanCancelProg = null;
+            Changed = true;
+            actor.OutputHandler.Send("This project will now use its legacy cancellation rules.");
+            return true;
+        }
+
+        IFutureProg prog = long.TryParse(command.PopSpeech(), out long value)
+            ? actor.Gameworld.FutureProgs.Get(value)
+            : actor.Gameworld.FutureProgs.GetByName(command.Last);
+        if (prog == null)
+        {
+            actor.OutputHandler.Send("There is no such prog.");
+            return false;
+        }
+
+        if (prog.ReturnType != ProgVariableTypes.Boolean)
+        {
+            actor.OutputHandler.Send("The CanCancelProg must return a boolean value.");
+            return false;
+        }
+
+        if (!prog.MatchesParameters(new[] { ProgVariableTypes.Character, ProgVariableTypes.Project }))
+        {
+            actor.OutputHandler.Send(
+                "The CanCancelProg must be compatible with a character and a project parameter.");
+            return false;
+        }
+
+        CanCancelProg = prog;
+        Changed = true;
+        actor.OutputHandler.Send(
+            $"This project will now use the {prog.MXPClickableFunctionNameWithId()} prog to determine whether a character can cancel an active project instance.");
+        return true;
+    }
+
+    private bool BuildingCommandWhyCannotCancel(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send(
+                "You must either specify a prog or use 'clear' to remove the existing one.");
+            return false;
+        }
+
+        if (command.Peek().EqualToAny("clear", "none", "delete", "remove"))
+        {
+            WhyCannotCancelProg = null;
+            Changed = true;
+            actor.OutputHandler.Send("This project will no longer have a custom cancellation error prog.");
+            return true;
+        }
+
+        IFutureProg prog = long.TryParse(command.PopSpeech(), out long value)
+            ? actor.Gameworld.FutureProgs.Get(value)
+            : actor.Gameworld.FutureProgs.GetByName(command.Last);
+        if (prog == null)
+        {
+            actor.OutputHandler.Send("There is no such prog.");
+            return false;
+        }
+
+        if (prog.ReturnType != ProgVariableTypes.Text)
+        {
+            actor.OutputHandler.Send("The WhyCannotCancelProg must return a text value.");
+            return false;
+        }
+
+        if (!prog.MatchesParameters(new[] { ProgVariableTypes.Character, ProgVariableTypes.Project }))
+        {
+            actor.OutputHandler.Send(
+                "The WhyCannotCancelProg must be compatible with a character and a project parameter.");
+            return false;
+        }
+
+        WhyCannotCancelProg = prog;
+        Changed = true;
+        actor.OutputHandler.Send(
+            $"This project will now use the {prog.MXPClickableFunctionNameWithId()} prog to explain failed cancellation attempts.");
+        return true;
     }
 
     private bool BuildingCommandOnStartProg(ICharacter actor, StringStack command)

--- a/MudSharpCore/Work/Projects/ConcreteTypes/ProjectLabourQueueEntry.cs
+++ b/MudSharpCore/Work/Projects/ConcreteTypes/ProjectLabourQueueEntry.cs
@@ -1,0 +1,87 @@
+#nullable enable
+using MudSharp.Character;
+using MudSharp.Framework;
+using System;
+using System.Linq;
+
+namespace MudSharp.Work.Projects.ConcreteTypes;
+
+public class ProjectLabourQueueEntry : IProjectLabourQueueEntry
+{
+	private readonly ICharacter _character;
+	private readonly long _projectId;
+	private readonly long _labourId;
+	private IActiveProject? _project;
+	private IProjectLabourRequirement? _labour;
+
+	public ProjectLabourQueueEntry(ICharacter character, IActiveProject project, IProjectLabourRequirement labour,
+		int queueOrder)
+	{
+		_character = character;
+		_project = project;
+		_projectId = project.Id;
+		_labour = labour;
+		_labourId = labour.Id;
+		QueueOrder = queueOrder;
+		QueuedAt = DateTime.UtcNow;
+	}
+
+	public ProjectLabourQueueEntry(MudSharp.Models.ProjectLabourQueue queue, IFuturemud gameworld, ICharacter character)
+	{
+		Id = queue.Id;
+		_character = character;
+		_projectId = queue.ActiveProjectId;
+		_project = gameworld.ActiveProjects.Get(queue.ActiveProjectId);
+		_labourId = queue.ProjectLabourRequirementId;
+		_labour = _project?.ProjectDefinition.Phases
+			.SelectMany(x => x.LabourRequirements)
+			.FirstOrDefault(x => x.Id == queue.ProjectLabourRequirementId);
+		QueueOrder = queue.QueueOrder;
+		QueuedAt = queue.QueuedAt;
+	}
+
+	public long Id { get; }
+	public ICharacter Character => _character;
+	public IActiveProject Project => _project!;
+	public IProjectLabourRequirement Labour => _labour!;
+	public int QueueOrder { get; set; }
+	public DateTime QueuedAt { get; }
+
+	public long ProjectId => _projectId;
+	public long LabourId => _labourId;
+
+	public ProjectLabourQueueStatus Status
+	{
+		get
+		{
+			if (_project == null || _labour == null || _project.CurrentPhase == null)
+			{
+				return ProjectLabourQueueStatus.Stale;
+			}
+
+			if (!_project.CurrentPhase.LabourRequirements.Contains(_labour))
+			{
+				return ProjectLabourQueueStatus.Stale;
+			}
+
+			if (_project is ActiveProject activeProject &&
+				_project is ILocalProject &&
+				activeProject.Location != _character.Location)
+			{
+				return ProjectLabourQueueStatus.WaitingForLocation;
+			}
+
+			if (!_labour.CharacterIsQualified(_character))
+			{
+				return ProjectLabourQueueStatus.WaitingForQualification;
+			}
+
+			if (_project.ActiveLabour.Count(x => x.Labour == _labour) >= _labour.MaximumSimultaneousWorkers)
+			{
+				return ProjectLabourQueueStatus.WaitingForSlot;
+			}
+
+			return ProjectLabourQueueStatus.Ready;
+		}
+	}
+}

--- a/MudSharpCore/Work/Projects/Impacts/BaseImpact.cs
+++ b/MudSharpCore/Work/Projects/Impacts/BaseImpact.cs
@@ -3,6 +3,7 @@ using MudSharp.Database;
 using MudSharp.Framework;
 using MudSharp.Framework.Save;
 using MudSharp.Models;
+using System;
 using System.Linq;
 using System.Text;
 using System.Xml.Linq;
@@ -19,6 +20,12 @@ public abstract class BaseImpact : SaveableItem, ILabourImpact
         DescriptionForProjectsCommand = impact.Description;
         MinimumHoursForImpactToKickIn = impact.MinimumHoursForImpactToKickIn;
         _typeName = impact.Type;
+        XElement root = XElement.Parse(impact.Definition);
+        HoursReference =
+            Enum.TryParse<ProjectImpactHoursReference>(root.Element("HoursReference")?.Value ?? string.Empty, true,
+                out var reference)
+                ? reference
+                : ProjectImpactHoursReference.Labour;
     }
 
     protected BaseImpact(BaseImpact rhs, IProjectLabourRequirement newLabour, string type)
@@ -35,6 +42,7 @@ public abstract class BaseImpact : SaveableItem, ILabourImpact
 
         DescriptionForProjectsCommand = rhs.DescriptionForProjectsCommand;
         MinimumHoursForImpactToKickIn = rhs.MinimumHoursForImpactToKickIn;
+        HoursReference = rhs.HoursReference;
         _typeName = type;
         using (new FMDB())
         {
@@ -57,6 +65,7 @@ public abstract class BaseImpact : SaveableItem, ILabourImpact
         _name = requirement.LabourImpacts.Select(x => x.Name).NameOrAppendNumberToName(name);
         _typeName = type;
         DescriptionForProjectsCommand = "#3Impacting on your character in an undescribed way#0";
+        HoursReference = ProjectImpactHoursReference.Labour;
         using (new FMDB())
         {
             ProjectLabourImpact dbitem = new();
@@ -72,10 +81,17 @@ public abstract class BaseImpact : SaveableItem, ILabourImpact
     }
 
     protected abstract XElement SaveDefinition();
+    protected XElement SaveDefinitionWithHoursReference(XElement root)
+    {
+        root.Add(new XElement("HoursReference", HoursReference.DescribeEnum()));
+        return root;
+    }
+
     private string _typeName;
     public string DescriptionForProjectsCommand { get; protected set; }
 
     public double MinimumHoursForImpactToKickIn { get; protected set; }
+    public ProjectImpactHoursReference HoursReference { get; protected set; }
 
     public void Delete()
     {
@@ -101,7 +117,8 @@ public abstract class BaseImpact : SaveableItem, ILabourImpact
 	#3show#0 - view detailed information about this impact
 	#3name <name>#0 - rename this impact
 	#3description <description>#0 - sets the description
-	#3hours <hours>#0 - hours before this impact kicks in";
+	#3hours <hours>#0 - hours before this impact kicks in
+	#3scope labour|project#0 - whether the hours are measured on the current labour role or the overall project";
 
     public virtual bool BuildingCommand(ICharacter actor, StringStack command, IProjectLabourRequirement requirement)
     {
@@ -120,6 +137,12 @@ public abstract class BaseImpact : SaveableItem, ILabourImpact
             case "minimum hours":
             case "minimum_hours":
                 return BuildingCommandMinimumHours(actor, command);
+            case "scope":
+            case "reference":
+            case "hourscope":
+            case "hour scope":
+            case "hour_scope":
+                return BuildingCommandHoursScope(actor, command);
             case "show":
                 actor.OutputHandler.Send(Show(actor));
                 return true;
@@ -127,6 +150,29 @@ public abstract class BaseImpact : SaveableItem, ILabourImpact
 
         actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
         return false;
+    }
+
+    private bool BuildingCommandHoursScope(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send(
+                $"Which hours scope should this impact use? Valid values are {Enum.GetNames(typeof(ProjectImpactHoursReference)).Select(x => x.ColourCommand()).ListToString()}.");
+            return false;
+        }
+
+        if (!command.SafeRemainingArgument.TryParseEnum<ProjectImpactHoursReference>(out var value))
+        {
+            actor.OutputHandler.Send(
+                $"That is not a valid hours scope. Valid values are {Enum.GetNames(typeof(ProjectImpactHoursReference)).Select(x => x.ColourCommand()).ListToString()}.");
+            return false;
+        }
+
+        HoursReference = value;
+        Changed = true;
+        actor.OutputHandler.Send(
+            $"This impact will now use {HoursReference.DescribeEnum().ColourValue()} continuity hours for its minimum-hours gate.");
+        return true;
     }
 
     private bool BuildingCommandMinimumHours(ICharacter actor, StringStack command)
@@ -190,7 +236,9 @@ public abstract class BaseImpact : SaveableItem, ILabourImpact
 
     public bool Applies(ICharacter actor)
     {
-        return actor.CurrentProjectHours >= MinimumHoursForImpactToKickIn;
+        return (HoursReference == ProjectImpactHoursReference.Project
+                   ? actor.CurrentProjectProjectHours
+                   : actor.CurrentProjectHours) >= MinimumHoursForImpactToKickIn;
     }
 
     public virtual (bool Truth, string Error) CanSubmit()
@@ -205,6 +253,7 @@ public abstract class BaseImpact : SaveableItem, ILabourImpact
         sb.AppendLine($"Type: {_typeName.ColourValue()}");
         sb.AppendLine($"Description: {DescriptionForProjectsCommand.SubstituteANSIColour()}");
         sb.AppendLine($"Minimum Hours: {MinimumHoursForImpactToKickIn.ToString("N2", actor).ColourValue()}");
+        sb.AppendLine($"Hours Scope: {HoursReference.DescribeEnum().ColourValue()}");
         return sb.ToString();
     }
 

--- a/MudSharpCore/Work/Projects/Impacts/HealingImpact.cs
+++ b/MudSharpCore/Work/Projects/Impacts/HealingImpact.cs
@@ -32,11 +32,11 @@ public class HealingImpact : BaseImpact, ILabourImpactHealing
 
     protected override XElement SaveDefinition()
     {
-        return new XElement("Impact",
+        return SaveDefinitionWithHoursReference(new XElement("Impact",
             new XElement("HealingCheckBonus", HealingCheckBonus),
             new XElement("HealingRateMultiplier", HealingRateMultiplier),
             new XElement("InfectionChanceMultiplier", InfectionChanceMultiplier)
-        );
+        ));
     }
 
     public override ILabourImpact Duplicate(IProjectLabourRequirement requirement)

--- a/MudSharpCore/Work/Projects/Impacts/HealingImpact.cs
+++ b/MudSharpCore/Work/Projects/Impacts/HealingImpact.cs
@@ -63,7 +63,7 @@ public class HealingImpact : BaseImpact, ILabourImpactHealing
     public override string ShowToPlayer(ICharacter actor)
     {
         return
-            $"A {(HealingCheckBonus >= 0.0 ? "bonus" : "penalty")} to healing checks, a {(HealingRateMultiplier >= 1.0 ? "bonus" : "penalty")} to healing rate and a {(HealingRateMultiplier >= 1.0 ? "bonus" : "penalty")} to infection chance";
+            $"A {(HealingCheckBonus >= 0.0 ? "bonus" : "penalty")} to healing checks, a {(HealingRateMultiplier >= 1.0 ? "bonus" : "penalty")} to healing rate and a {(InfectionChanceMultiplier <= 1.0 ? "reduction" : "increase")} to infection chance";
     }
 
     protected override string HelpText => $@"{base.HelpText}
@@ -121,7 +121,7 @@ public class HealingImpact : BaseImpact, ILabourImpactHealing
             return false;
         }
 
-        HealingCheckBonus = value;
+        InfectionChanceMultiplier = value;
         Changed = true;
         actor.OutputHandler.Send(
             $"This impact will now give a multiplier to infection chance of {value.ToString("P2", actor).ColourValue()}.");

--- a/MudSharpCore/Work/Projects/Impacts/JobEffortImpact.cs
+++ b/MudSharpCore/Work/Projects/Impacts/JobEffortImpact.cs
@@ -42,9 +42,9 @@ public class JobEffortImpact : BaseImpact, ILabourImpactActionAtTick
     /// <inheritdoc />
     protected override XElement SaveDefinition()
     {
-        return new XElement("Impact",
+        return SaveDefinitionWithHoursReference(new XElement("Impact",
             new XElement("Expression", new XCData(EffortPerTickExpressionString ?? "variable / 10"))
-        );
+        ));
     }
 
     /// <inheritdoc />

--- a/MudSharpCore/Work/Projects/Impacts/TraitCapImpact.cs
+++ b/MudSharpCore/Work/Projects/Impacts/TraitCapImpact.cs
@@ -43,10 +43,10 @@ public class TraitCapImpact : BaseImpact, ILabourImpactTraitCaps
 
     protected override XElement SaveDefinition()
     {
-        return new XElement("Impact",
+        return SaveDefinitionWithHoursReference(new XElement("Impact",
             new XElement("Trait", Trait?.Id ?? 0),
             new XElement("TraitChange", TraitCapChange)
-        );
+        ));
     }
 
     public override ILabourImpact Duplicate(IProjectLabourRequirement requirement)

--- a/MudSharpCore/Work/Projects/Impacts/TraitImpact.cs
+++ b/MudSharpCore/Work/Projects/Impacts/TraitImpact.cs
@@ -54,11 +54,11 @@ public class TraitImpact : BaseImpact, ILabourImpactTraits
 
     protected override XElement SaveDefinition()
     {
-        return new XElement("Impact",
+        return SaveDefinitionWithHoursReference(new XElement("Impact",
             new XElement("Trait", Trait?.Id ?? 0),
             new XElement("TraitChange", TraitChange),
             new XElement("TraitBonusContext", (int)TraitBonusContext)
-        );
+        ));
     }
 
     public override ILabourImpact Duplicate(IProjectLabourRequirement requirement)

--- a/MudSharpCore/Work/Projects/LabourRequirements/SupervisionProjectLabour.cs
+++ b/MudSharpCore/Work/Projects/LabourRequirements/SupervisionProjectLabour.cs
@@ -3,6 +3,7 @@ using MudSharp.Framework;
 using MudSharp.RPG.Checks;
 using System.Linq;
 using System.Text;
+using System.Xml.Linq;
 
 namespace MudSharp.Work.Projects.LabourRequirements;
 
@@ -11,15 +12,25 @@ public class SupervisionProjectLabour : ProjectLabourBase
     public SupervisionProjectLabour(Models.ProjectLabourRequirement labour, IFuturemud gameworld) : base(labour,
         gameworld)
     {
+        XElement root = XElement.Parse(labour.Definition);
+        MultiplierForOtherLabours =
+            double.TryParse(root.Element("MultiplierForOtherLabours")?.Value, out var value) ? value : 1.0;
+        IsMandatoryForProjectCompletion = false;
     }
 
     public SupervisionProjectLabour(ProjectLabourBase rhs, IProjectPhase newPhase) : base(rhs, newPhase, "supervision")
     {
+        MultiplierForOtherLabours = rhs is SupervisionProjectLabour supervision
+            ? supervision.MultiplierForOtherLabours
+            : 1.0;
+        IsMandatoryForProjectCompletion = false;
     }
 
     public SupervisionProjectLabour(IFuturemud gameworld, IProjectPhase phase, string name) : base(gameworld, phase,
         "supervision", name)
     {
+        MultiplierForOtherLabours = 1.0;
+        IsMandatoryForProjectCompletion = false;
     }
 
     public override IProjectLabourRequirement Duplicate(IProjectPhase newPhase)
@@ -50,6 +61,13 @@ public class SupervisionProjectLabour : ProjectLabourBase
     public override double HoursRemaining(IActiveProject project)
     {
         return double.PositiveInfinity;
+    }
+
+    protected override XElement SaveDefinition()
+    {
+        var root = base.SaveDefinition();
+        root.Add(new XElement("MultiplierForOtherLabours", MultiplierForOtherLabours));
+        return root;
     }
 
     public override string Show(ICharacter actor)
@@ -102,7 +120,7 @@ public class SupervisionProjectLabour : ProjectLabourBase
         switch (command.PopSpeech().ToLowerInvariant())
         {
             case "mandatory":
-                actor.OutputHandler.Send("Supervisory labours area always non-mandatory.");
+                actor.OutputHandler.Send("Supervisory labours are always non-mandatory.");
                 return false;
             case "multiplier":
             case "mult":

--- a/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContext.cs
+++ b/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContext.cs
@@ -38,6 +38,7 @@ namespace MudSharp.Database
         public virtual DbSet<ActiveProjectLabour> ActiveProjectLabours { get; set; }
         public virtual DbSet<ActiveProjectMaterial> ActiveProjectMaterials { get; set; }
         public virtual DbSet<ActiveProject> ActiveProjects { get; set; }
+        public virtual DbSet<ProjectLabourQueue> ProjectLabourQueues { get; set; }
         public virtual DbSet<AIStoryteller> AIStorytellers { get; set; }
         public virtual DbSet<AIStorytellerReferenceDocument> AIStorytellerReferenceDocuments { get; set; }
         public virtual DbSet<AIStorytellerSituation> AIStorytellerSituations { get; set; }

--- a/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextConfiguring1.cs
+++ b/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextConfiguring1.cs
@@ -389,6 +389,52 @@ namespace MudSharp.Database
                     .HasConstraintName("FK_ActiveProjects_Projects");
             });
 
+            modelBuilder.Entity<ProjectLabourQueue>(entity =>
+            {
+                entity.HasIndex(e => e.ActiveProjectId)
+                    .HasDatabaseName("FK_ProjectLabourQueues_ActiveProjects_idx");
+
+                entity.HasIndex(e => e.CharacterId)
+                    .HasDatabaseName("FK_ProjectLabourQueues_Characters_idx");
+
+                entity.HasIndex(e => new { e.CharacterId, e.QueueOrder })
+                    .HasDatabaseName("IX_ProjectLabourQueues_Character_QueueOrder")
+                    .IsUnique();
+
+                entity.HasIndex(e => e.ProjectLabourRequirementId)
+                    .HasDatabaseName("FK_ProjectLabourQueues_ProjectLabourRequirements_idx");
+
+                entity.Property(e => e.Id).HasColumnType("bigint(20)");
+
+                entity.Property(e => e.ActiveProjectId).HasColumnType("bigint(20)");
+
+                entity.Property(e => e.CharacterId).HasColumnType("bigint(20)");
+
+                entity.Property(e => e.ProjectLabourRequirementId).HasColumnType("bigint(20)");
+
+                entity.Property(e => e.QueueOrder).HasColumnType("int(11)");
+
+                entity.Property(e => e.QueuedAt).HasColumnType("datetime");
+
+                entity.HasOne(d => d.ActiveProject)
+                    .WithMany(p => p.ProjectLabourQueues)
+                    .HasForeignKey(d => d.ActiveProjectId)
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .HasConstraintName("FK_ProjectLabourQueues_ActiveProjects");
+
+                entity.HasOne(d => d.Character)
+                    .WithMany(p => p.ProjectLabourQueues)
+                    .HasForeignKey(d => d.CharacterId)
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .HasConstraintName("FK_ProjectLabourQueues_Characters");
+
+                entity.HasOne(d => d.ProjectLabourRequirement)
+                    .WithMany(p => p.ProjectLabourQueues)
+                    .HasForeignKey(d => d.ProjectLabourRequirementId)
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .HasConstraintName("FK_ProjectLabourQueues_ProjectLabourRequirements");
+            });
+
             modelBuilder.Entity<Ally>(entity =>
             {
                 entity.HasKey(e => new { e.CharacterId, e.AllyId })
@@ -2878,6 +2924,8 @@ namespace MudSharp.Database
                 entity.Property(e => e.CurrentProjectId).HasColumnType("bigint(20)");
 
                 entity.Property(e => e.CurrentProjectLabourId).HasColumnType("bigint(20)");
+
+                entity.Property(e => e.CurrentProjectProjectHours).HasColumnType("double");
 
                 entity.Property(e => e.CurrentScriptId).HasColumnType("bigint(20)");
 

--- a/MudsharpDatabaseLibrary/Migrations/20260421064024_ProjectQueueAndCancellationContinuity.Designer.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260421064024_ProjectQueueAndCancellationContinuity.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MudSharp.Database;
 
@@ -11,9 +12,11 @@ using MudSharp.Database;
 namespace MudSharp.Migrations
 {
     [DbContext(typeof(FuturemudDatabaseContext))]
-    partial class FutureMUDContextModelSnapshot : ModelSnapshot
+    [Migration("20260421064024_ProjectQueueAndCancellationContinuity")]
+    partial class ProjectQueueAndCancellationContinuity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MudsharpDatabaseLibrary/Migrations/20260421064024_ProjectQueueAndCancellationContinuity.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260421064024_ProjectQueueAndCancellationContinuity.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MudSharp.Migrations
+{
+    /// <inheritdoc />
+    public partial class ProjectQueueAndCancellationContinuity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<double>(
+                name: "CurrentProjectProjectHours",
+                table: "Characters",
+                type: "double",
+                nullable: false,
+                defaultValue: 0.0);
+
+            migrationBuilder.CreateTable(
+                name: "ProjectLabourQueues",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint(20)", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    CharacterId = table.Column<long>(type: "bigint(20)", nullable: false),
+                    ActiveProjectId = table.Column<long>(type: "bigint(20)", nullable: false),
+                    ProjectLabourRequirementId = table.Column<long>(type: "bigint(20)", nullable: false),
+                    QueueOrder = table.Column<int>(type: "int(11)", nullable: false),
+                    QueuedAt = table.Column<DateTime>(type: "datetime", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProjectLabourQueues", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ProjectLabourQueues_ActiveProjects",
+                        column: x => x.ActiveProjectId,
+                        principalTable: "ActiveProjects",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ProjectLabourQueues_Characters",
+                        column: x => x.CharacterId,
+                        principalTable: "Characters",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ProjectLabourQueues_ProjectLabourRequirements",
+                        column: x => x.ProjectLabourRequirementId,
+                        principalTable: "ProjectLabourRequirements",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_ProjectLabourQueues_ActiveProjects_idx",
+                table: "ProjectLabourQueues",
+                column: "ActiveProjectId");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_ProjectLabourQueues_Characters_idx",
+                table: "ProjectLabourQueues",
+                column: "CharacterId");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_ProjectLabourQueues_ProjectLabourRequirements_idx",
+                table: "ProjectLabourQueues",
+                column: "ProjectLabourRequirementId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectLabourQueues_Character_QueueOrder",
+                table: "ProjectLabourQueues",
+                columns: new[] { "CharacterId", "QueueOrder" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ProjectLabourQueues");
+
+            migrationBuilder.DropColumn(
+                name: "CurrentProjectProjectHours",
+                table: "Characters");
+        }
+    }
+}

--- a/MudsharpDatabaseLibrary/Models/ActiveProjects.cs
+++ b/MudsharpDatabaseLibrary/Models/ActiveProjects.cs
@@ -10,6 +10,7 @@ namespace MudSharp.Models
             ActiveProjectLabours = new HashSet<ActiveProjectLabour>();
             ActiveProjectMaterials = new HashSet<ActiveProjectMaterial>();
             Characters = new HashSet<Character>();
+            ProjectLabourQueues = new HashSet<ProjectLabourQueue>();
         }
 
         public long Id { get; set; }
@@ -26,5 +27,6 @@ namespace MudSharp.Models
         public virtual ICollection<ActiveProjectLabour> ActiveProjectLabours { get; set; }
         public virtual ICollection<ActiveProjectMaterial> ActiveProjectMaterials { get; set; }
         public virtual ICollection<Character> Characters { get; set; }
+        public virtual ICollection<ProjectLabourQueue> ProjectLabourQueues { get; set; }
     }
 }

--- a/MudsharpDatabaseLibrary/Models/Character.cs
+++ b/MudsharpDatabaseLibrary/Models/Character.cs
@@ -39,6 +39,7 @@ public partial class Character
         WritingsAuthor = new HashSet<Writing>();
         WritingsTrueAuthor = new HashSet<Writing>();
         Patrols = new HashSet<Patrol>();
+        ProjectLabourQueues = new HashSet<ProjectLabourQueue>();
         GPTMessages = new HashSet<GPTMessage>();
         ScriptedEvents = new HashSet<ScriptedEvent>();
         Tracks = new HashSet<Track>();
@@ -93,6 +94,7 @@ public partial class Character
     public long? CurrentProjectLabourId { get; set; }
     public long? CurrentProjectId { get; set; }
     public double CurrentProjectHours { get; set; }
+    public double CurrentProjectProjectHours { get; set; }
     public string NameInfo { get; set; }
     public int RoomLayer { get; set; }
     public bool NoMercy { get; set; }
@@ -114,6 +116,7 @@ public partial class Character
     public virtual Guest Guest { get; set; }
     public virtual ICollection<ActiveProject> ActiveProjects { get; set; }
     public virtual ICollection<ActiveJob> ActiveJobs { get; set; }
+    public virtual ICollection<ProjectLabourQueue> ProjectLabourQueues { get; set; }
     public virtual ICollection<Ally> AlliesAlly { get; set; }
     public virtual ICollection<Ally> AlliesCharacter { get; set; }
     public virtual ICollection<CharacterCombatSetting> CharacterCombatSettings { get; set; }

--- a/MudsharpDatabaseLibrary/Models/ProjectLabourQueues.cs
+++ b/MudsharpDatabaseLibrary/Models/ProjectLabourQueues.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace MudSharp.Models;
+
+public partial class ProjectLabourQueue
+{
+	public long Id { get; set; }
+	public long CharacterId { get; set; }
+	public long ActiveProjectId { get; set; }
+	public long ProjectLabourRequirementId { get; set; }
+	public int QueueOrder { get; set; }
+	public DateTime QueuedAt { get; set; }
+
+	public virtual ActiveProject ActiveProject { get; set; }
+	public virtual Character Character { get; set; }
+	public virtual ProjectLabourRequirement ProjectLabourRequirement { get; set; }
+}

--- a/MudsharpDatabaseLibrary/Models/ProjectLabourRequirement.cs
+++ b/MudsharpDatabaseLibrary/Models/ProjectLabourRequirement.cs
@@ -10,6 +10,7 @@ namespace MudSharp.Models
             ActiveProjectLabours = new HashSet<ActiveProjectLabour>();
             Characters = new HashSet<Character>();
             ProjectLabourImpacts = new HashSet<ProjectLabourImpact>();
+            ProjectLabourQueues = new HashSet<ProjectLabourQueue>();
         }
 
         public long Id { get; set; }
@@ -25,5 +26,6 @@ namespace MudSharp.Models
         public virtual ICollection<ActiveProjectLabour> ActiveProjectLabours { get; set; }
         public virtual ICollection<Character> Characters { get; set; }
         public virtual ICollection<ProjectLabourImpact> ProjectLabourImpacts { get; set; }
+        public virtual ICollection<ProjectLabourQueue> ProjectLabourQueues { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- Add a developer-focused overview for `MudSharp.Work.Projects` covering the runtime model, implemented types, persistence, integration points, and extension guidance.
- Add a builder-facing workflows guide for in-game project authoring, administration, and troubleshooting.
- Document the current implementation quirks and stubs explicitly so the docs reflect shipped behavior rather than idealized design.

## Testing
- Not run (not requested)