### PR TITLE
Add crafting system design docs

### DIFF
--- a/Design Documents/Crafting_System_Builder_Workflows.md
+++ b/Design Documents/Crafting_System_Builder_Workflows.md
@@ -1,0 +1,329 @@
+# Crafting System Builder Workflows
+
+## Purpose
+This document explains the practical builder workflow for creating, revising, validating, and testing crafts in game.
+
+The intended audience is builders and staff users working through the `craft` command family rather than editing code directly.
+
+## Mental Model
+When you build a craft, you are authoring a staged work definition.
+
+You are not just saying "this input becomes this item". You are defining:
+
+- who can see or use the craft
+- what the active progress item looks like
+- which tools must be present, worn, wielded, or merely nearby
+- which materials or target items the craft reserves and consumes
+- which phase performs the success check
+- what the crafter visibly does during each phase
+- what comes out on success and on failure
+
+If a craft feels wrong in play, the problem is often in one of those behavioural choices rather than in the final product alone.
+
+## Normal Authoring Workflow
+1. Find an existing craft to inspect, or create/clone one with `craft list`, `craft show`, `craft edit new`, or `craft clone`.
+2. Set craft-wide metadata such as name, category, blurb, action text, progress-item text, and check settings.
+3. Author the ordered phases with their timings, echoes, fail echoes, exertion, and stamina settings.
+4. Add and configure inputs, tools, products, and fail products.
+5. Assign availability and callback progs.
+6. Validate with `craft show` and fix any errors shown at the bottom.
+7. Test from the player side with `craft view`, `craft preview` or `materials`, and `craft begin`.
+8. Submit and review through the normal revisable workflow once the craft is valid.
+
+## Main Command Surface
+
+### Player-facing commands
+Use these to test the craft as a player would see it:
+
+- `crafts`
+- `craft begin <craft>`
+- `craft resume <progress item>`
+- `craft view <craft>`
+- `craft preview <craft>`
+- `materials <craft>`
+- `craft categories`
+- `craft find <item>`
+
+### Builder-facing commands
+Use these to author and review craft content:
+
+- `craft list [filters]`
+- `craft show <craft>`
+- `craft edit <craft>`
+- `craft edit new`
+- `craft edit close`
+- `craft edit submit`
+- `craft review <id>|all|mine`
+- `craft clone <craft> <newName>`
+- `craft set <...>`
+
+Important note:
+
+- `craft set` is the general edit entry point once you have the craft open for editing.
+
+## Craft-Wide Command Reference
+The following options are the core `craft set` workflow.
+
+| Command | What it sets | Notes |
+| --- | --- | --- |
+| `name <text>` | Craft name | Must remain globally unique across approved and in-design crafts |
+| `category <text>` | Craft category | Used by craft list and category browsing |
+| `blurb <text>` | Short player-facing description | Shown in the `crafts` list |
+| `action <gerund text>` | Current-action description | Should read like `forging a sword blade` |
+| `item <passive text>` or `progress <passive text>` | Active progress item short description | Should read like `a sword being forged` |
+| `check <free rolls> <trait> <difficulty>` | Main craft outcome check | Controls skill gate and free extra improvement rolls |
+| `practical` | Toggle practical versus theoretical check | Affects trait-use type on the outcome check |
+| `threshold <outcome>` | Failure threshold | Outcome at or below this threshold fails the craft |
+| `failphase <number>` | Phase where success/failure split occurs | Must be a real phase |
+| `interruptable` | Toggle whether interruption pauses or cancels | Non-interruptable crafts are cancelled when interrupted |
+| `appear <prog>` | Craft-list visibility prog | Required for craft validity |
+| `canuse <prog>` | Start-permission prog | Must return boolean for one character |
+| `whycannotuse <prog>` | Failure-message prog | Must return text for one character |
+| `onstart <prog>` | Start callback | Must accept one character |
+| `onfinish <prog>` | Completion callback | Must accept one character |
+| `oncancel <prog>` | Cancellation callback | Must accept one character |
+
+## Phase Authoring
+
+### Phase commands
+| Command | Purpose |
+| --- | --- |
+| `phase add <seconds> "<echo>" ["<failecho>"]` | Add a new phase |
+| `phase edit <number> <seconds> "<echo>" ["<failecho>"]` | Replace an existing phase |
+| `phase remove <number>` | Delete a phase |
+| `phase swap <phase1> <phase2>` | Reorder two phases |
+| `phase exertion <phase> <level>` | Set minimum exertion for that phase |
+| `phase stamina <phase> <value>` | Set stamina cost for that phase |
+
+Important current behaviour:
+
+- if you omit the fail echo when adding or editing a phase, it defaults to the normal echo
+- the fail phase is not a separate phase list; it is the phase where the check happens and the craft then follows either the success or failure branch
+
+### Token meanings
+Craft echoes are functional, not just cosmetic.
+
+| Token | Meaning |
+| --- | --- |
+| `$iN` | input number `N` |
+| `$tN` | tool number `N` |
+| `$pN` | normal product number `N` |
+| `$fN` | fail product number `N` |
+
+### Why token placement matters
+The engine uses token placement to decide timing.
+
+Current verified rules:
+
+- the first success-echo use of `$iN` decides when that input becomes consumed
+- the presence of `$tN` in a phase makes that tool part of that phase's tool plan
+- the first success-echo use of `$pN` decides when that normal product is produced
+- the first fail-echo use of `$fN` decides when that fail product is produced
+
+Defaulting rules if you never reference something:
+
+- an unreferenced input is treated as consumed at phase 1
+- an unreferenced tool is treated as required in every normal phase
+- an unreferenced normal product defaults to the fail phase
+- an unreferenced fail product defaults to the fail phase
+
+Important fail-echo rule:
+
+- fail products must only appear as `$fN` in fail echoes, never in normal echoes
+
+## Inputs, Tools, Products, and Fail Products
+
+### Inputs
+Use:
+
+- `input add <type>`
+- `input remove <number>`
+- `input <number> <subcommand>`
+
+### Tools
+Use:
+
+- `tool add <type>`
+- `tool remove <number>`
+- `tool <number> <subcommand>`
+
+### Products
+Use:
+
+- `product add <type>`
+- `product remove <number>`
+- `product <number> <subcommand>`
+
+### Fail products
+Use:
+
+- `failproduct add <type>`
+- `failproduct remove <number>`
+- `failproduct <number> <subcommand>`
+
+## Builder Reference: Inputs
+| Alias | What it is for | Main subcommands | Important constraints |
+| --- | --- | --- | --- |
+| `simple` | Exact item prototype input | `item`, `quantity`, `quality` | Must set a target item |
+| `simplematerial` | Items made from an exact material or material tag | `material`, `tag`, `quantity`, `quality` | Must set either the exact material or the material tag |
+| `tag` | Tagged item input | `tag`, `quantity`, `quality` | Best for generic consumables like thread or padding |
+| `tagvariable` | Tagged item input that also supplies characteristics | `tag`, `quantity`, `variable`, `quality` | Item must expose every declared characteristic definition |
+| `commodity` | Exact-material commodity pile input | `material`, `weight`, optional `tag`, `quality` | Must set exact material and positive weight |
+| `commoditytag` | Material-tagged commodity pile input | `material`, `weight`, optional `tag`, `quality` | Uses a material tag rather than one exact solid |
+| `liquid` | Specific liquid input | `liquid`, `amount`, `quality` | Must set liquid and positive amount |
+| `tagliquid` | Liquid input from a tagged source | `tag`, `amount`, `quality` | Useful for tagged vessels or apparatus |
+| `repair` | Target item to repair | `tag`, `repair`, `quality` | Targets a tagged item and repairs condition by a percentage |
+
+## Builder Reference: Tools
+All tools also support the shared base tool options:
+
+- `held`
+- `worn`
+- `wield`
+- `room`
+- `quality`
+- `usetool`
+
+| Alias | What it is for | Type-specific subcommands | Important constraints |
+| --- | --- | --- | --- |
+| `simple` | Require one exact item proto | `item` | Use when one specific prototype must be present |
+| `tag` | Require any item matching a tag | `tag` | Use for tool families such as hammer, anvil, pliers, or sewing needle |
+
+## Builder Reference: Products
+| Alias | What it is for | Main subcommands | Important constraints |
+| --- | --- | --- | --- |
+| `simple` | Load ordinary items | `item`, `skin`, `quantity`, `material` | Must set an item proto; skin must match that proto and be approved |
+| `variable` | Load items with characteristics coming from variable-aware inputs | `item`, `skin`, `quantity`, `variable <definition> <input#>` | Source input must be an `IVariableInput` that provides the definition |
+| `inputvariable` | Load items whose characteristics depend on which item was used for an input | `item`, `skin`, `quantity`, `variable ...` | Requires explicit input index and per-item value mappings |
+| `commodity` | Load commodity piles | `commodity`, `weight`, `tag`, `material` | Requires material and positive weight |
+| `money` | Produce money | `currency`, `amount` | Requires currency and positive amount |
+| `npc` | Spawn NPCs from a template | `template`, `quantity`, optional `prog` | Template must be approved; optional prog must be `void(Character)` |
+| `prog` | Let a prog decide which items to load | `prog` | Prog must match the runtime signature expected by the product |
+| `progvariable` | Load an item and fill characteristics from progs | `item`, `quantity`, `variable <definition> <prog>` | Use when characteristic values are better derived by code than by input lookup |
+| `unusedinput` | Return a portion of a consumed item input | `input`, `percentage` | Target input must consume items or item groups |
+| `scrap` | Convert part of an input into scrap commodity | `input`, `percentage`, `tag`, `material` | Good for salvage-style fail outputs |
+| `dnatest` | Compare two liquid inputs | `input1`, `input2` | Both targeted inputs must consume liquids and must be different |
+| `bloodtyping` | Test one liquid input against a blood model | `input`, `bloodmodel` | Requires a valid blood model plus a liquid-consuming input |
+
+## Review and Debugging Workflow
+
+### Inspect the craft definition
+Use:
+
+- `craft show <craft>`
+- `craft show` while editing
+
+This is the most important builder command because it shows:
+
+- current settings
+- phase ordering
+- current input, tool, product, and fail-product numbering
+- validity state
+- specific validation errors at the bottom when something is wrong
+
+### Inspect discoverability
+Use:
+
+- `craft list [filters]`
+- `craft categories`
+- `craft find <item>`
+
+Useful list filters:
+
+- `+keyword`
+- `-keyword`
+- category name
+- `*<item proto id>`
+- `&<tag>`
+- `^<liquid>`
+
+### Inspect player feasibility
+Use:
+
+- `craft view <craft>`
+- `craft preview <craft>`
+- `materials <craft>`
+
+Interpretation:
+
+- missing tools usually means wrong tool state, wrong tool definition, or not enough wielders/hands
+- missing materials usually means the input definitions do not match what the test character actually has access to
+
+### Test actual execution
+Use:
+
+- `craft begin <craft>`
+- `craft resume <progress item>`
+
+Watch for:
+
+- the active progress item description
+- whether the correct phase echoes fire
+- whether the right tools are required in the right phases
+- whether products and fail products appear when expected
+
+## Practical Examples
+
+### Simple item assembly
+The seeded assembly crafts are the clearest pattern for multi-input, multi-tool item output.
+
+Typical shape:
+
+- `tag` inputs for components
+- `tag` or `simple` tools
+- `simple` output product
+- phase echoes that reference inputs and tools in the order they are used
+
+### Material-driven output
+Use this when the output should inherit material from an input rather than always loading in its base proto material.
+
+Typical pattern:
+
+- a material-bearing input such as `commodity` or another item-consuming input
+- a `simple` product
+- `product <n> material <input#>` to tie the output material to that input
+
+### Fail-product salvage
+This is common in seeded metalworking examples.
+
+Typical pattern:
+
+- a normal success product such as a finished blade
+- a fail product such as a twisted hunk of metal or an `unusedinput` return
+- fail echo uses `$fN` to show the salvage result
+
+### Room tool requirements
+Forge-style crafts are a good example.
+
+Typical pattern:
+
+- several `tag` tools
+- tools set to `room` state
+- phase echoes reference the appropriate room tools
+
+This is the right model for anvils, forges, bellows, and other stationary apparatus.
+
+## Common Mistakes
+- Forgetting to set the appear prog. A craft without it is invalid even if everything else looks complete.
+- Using the wrong FutureProg signature for `appear`, `canuse`, `whycannotuse`, `onstart`, `onfinish`, or `oncancel`.
+- Referencing `$iN`, `$tN`, `$pN`, or `$fN` numbers that do not exist after reordering or deleting child entries.
+- Using fail products in regular echoes instead of only in fail echoes.
+- Expecting a product to inherit material automatically without setting its material-defining input.
+- Forgetting that tools not referenced in normal echoes are treated as needed in every normal phase.
+- Forgetting that inputs not referenced in normal echoes default to phase 1 consumption.
+- Choosing the wrong tool state and then reading the problem as a missing-item issue rather than a hold, wield, wear, or room-placement issue.
+- Setting a skin before setting the item proto, or choosing a skin that belongs to a different item proto.
+- Confusing player commands such as `craft view` and `craft preview` with builder editing commands such as `craft set`.
+- Renaming or cloning a craft into a name that is already in use by another approved or in-design craft.
+
+## Final Builder Checklist
+Before submitting a craft for review, confirm all of the following:
+
+- `craft show` says the craft is valid
+- the appear prog is set
+- the fail phase is correct
+- the progress-item description reads naturally
+- each input, tool, product, and fail product is configured and numbered as expected
+- phase echoes reference the right `$i`, `$t`, `$p`, and `$f` tokens
+- `craft preview` shows the intended tools and materials
+- a real `craft begin` test behaves as expected on both success and interruption

--- a/Design Documents/Crafting_System_Overview.md
+++ b/Design Documents/Crafting_System_Overview.md
@@ -1,0 +1,68 @@
+# FutureMUD Crafting System Overview
+
+## Purpose
+This document suite explains the verified current implementation of FutureMUD crafting centred on `MudSharp.Work.Crafts` and the related systems that make crafts usable in play and editable in game.
+
+The intended audience for this head document is:
+
+- engine developers
+- Codex agents and other AI assistants working in this repository
+- technical builders who need a fast orientation before diving into the deeper runtime or builder workflow documents
+
+## Document Map
+- [Crafting System Runtime and Extensibility](./Crafting_System_Runtime_and_Extensibility.md) covers runtime behaviour, persistence, implemented types, extension seams, and cross-system integration.
+- [Crafting System Builder Workflows](./Crafting_System_Builder_Workflows.md) covers the in-game authoring and review workflow, command surface, and builder-facing reference material.
+
+## What Crafts Are
+In FutureMUD, a craft is a revisioned, builder-authored definition for an on-screen, phase-based activity performed by a character in the world.
+
+A craft combines:
+
+- availability and permission logic
+- tools that must be present in particular states
+- inputs that are found, reserved, consumed, or transformed during execution
+- one or more timed phases with visible echoes
+- an outcome check at a designated fail phase
+- normal products and fail products
+- optional start, cancel, and completion callbacks through FutureProg
+
+At runtime, starting a craft does not instantly create the final result. Instead, the engine creates a system-generated in-progress craft item, applies an active effect to the crafter, and advances the work through timed phases until the craft completes, fails, or is interrupted.
+
+## Scope Boundaries
+Crafts are not the only work-oriented subsystem in FutureMUD.
+
+Important distinctions:
+
+- Crafts versus projects: crafts are on-screen, time-phased actions a character is actively performing in the room right now. Projects model longer-lived labour and supply workflows that continue as broader works rather than as a single visible action sequence.
+- Crafts versus butchery and salvage: `butcher`, `salvage`, and `skin` are separate command-driven subsystems with their own runtime logic. They are adjacent in purpose, but they are not implemented as `ICraft`.
+- Crafts versus one-shot spawning: some craft products load ordinary items, but the craft system itself is about staged execution, not just spawning outputs.
+
+## Subsystem Map
+| Layer | Current responsibility | Typical locations |
+| --- | --- | --- |
+| Contracts | Public interfaces and shared abstractions for crafts, inputs, tools, products, phases, and active craft state | `FutureMUDLibrary/Work/Crafts`, `FutureMUDLibrary/GameItems/Interfaces`, `FutureMUDLibrary/Effects/Interfaces` |
+| Runtime logic | Craft execution, validation, builder editing, phase handling, tool and input scouting, quality calculation, active effect behaviour | `MudSharpCore/Work/Crafts`, `MudSharpCore/Commands/Modules/CraftModule.cs` |
+| Persistence | Revisioned craft rows plus child phase/input/tool/product rows | `MudsharpDatabaseLibrary/Models/Craft*.cs` |
+| Command surface | Player craft use, builder craft editing, review workflow, list and search helpers | `MudSharpCore/Commands/Modules/CraftModule.cs`, `MudSharpCore/Commands/Helpers/EditableRevisableItemHelper.cs` |
+| Active in-world tracking | System-only active craft item prototype/component plus active character effect | `MudSharpCore/GameItems/Prototypes/ActiveCraftGameItemComponentProto.cs`, `MudSharpCore/GameItems/Components/ActiveCraftGameItemComponent.cs`, `MudSharpCore/Effects/Concrete/ActiveCraft.cs` |
+| Seeder and examples | Stock FutureProgs and seeded craft definitions that demonstrate common patterns | `DatabaseSeeder/Seeders/ItemSeederCrafting.cs` |
+| Cross-system integrations | Item skins, tool items, tags, materials, liquids, NPC templates, AI, inventory plans, review framework, economy search surfaces | multiple runtime locations; see the runtime document for the verified list |
+
+## Core Concepts
+- Craft definition: a single revisable `ICraft` record with metadata, check settings, phases, inputs, tools, products, and fail products.
+- Phases: ordered `ICraftPhase` records with duration, success echo, fail echo, exertion level, and stamina cost.
+- Inputs: `ICraftInput` implementations that know how to find, reserve, consume, and describe required materials or target items.
+- Tools: `ICraftTool` implementations that know how to find, score, and optionally consume tool durability during the craft.
+- Products versus fail products: normal products are produced on the success branch; fail products are produced once the craft has failed and the fail echoes advance.
+- Active craft progress item: a system-generated game item carrying `IActiveCraftGameItemComponent` that stores reserved inputs, produced outputs, phase state, and craft revision linkage.
+- Availability, can-use, and callback progs: FutureProg hooks control whether a craft appears in lists, whether it can currently be started, why it cannot be started, and what happens on start, cancel, or completion.
+
+## Important Implementation Truths
+- Crafts are revisable editable items and participate in the repository's standard build-review-submit workflow rather than being ad hoc runtime objects.
+- Craft validity depends on more than field presence. A craft can have all its child records and still be invalid because of bad echo references, a missing appear prog, an invalid fail phase, or invalid subtype configuration.
+- Echo tokens drive behaviour. References such as `$i1`, `$t2`, `$p1`, and `$f1` are not only presentation text; they also control when inputs are consumed, when tools are required, and when products become available.
+- Active craft items are system-generated, read-only support objects. They are not intended to be manually built, manually loaded, or used as ordinary content prototypes.
+
+## Recommended Reading Order
+1. Read [Crafting System Runtime and Extensibility](./Crafting_System_Runtime_and_Extensibility.md) if you need to change code, understand lifecycle and persistence, or add a new craft subtype.
+2. Read [Crafting System Builder Workflows](./Crafting_System_Builder_Workflows.md) if you need to create, revise, validate, test, or review craft content in game.

--- a/Design Documents/Crafting_System_Runtime_and_Extensibility.md
+++ b/Design Documents/Crafting_System_Runtime_and_Extensibility.md
@@ -1,0 +1,514 @@
+# FutureMUD Crafting System: Runtime and Extensibility
+
+## Scope
+This document explains the verified current implementation of the FutureMUD crafting subsystem.
+
+It focuses on the code centred on `MudSharp.Work.Crafts`, but it also includes the adjacent contracts, persistence, commands, item integrations, and AI hooks required to understand how crafts actually work in the live engine.
+
+This document is intentionally current-state focused. Where it gives extension guidance rather than describing existing runtime behaviour, that guidance is explicitly called out as inferred from the present implementation style.
+
+## Layered Shape
+Crafting is not implemented as a single isolated module. It is a distributed subsystem with one dominant runtime namespace and a supporting ring of contracts, persistence, commands, item integrations, and seeded content.
+
+| Layer | Current responsibility | Typical locations |
+| --- | --- | --- |
+| Contracts | Public craft, input, tool, product, phase, and active-state interfaces | `FutureMUDLibrary/Work/Crafts`, `FutureMUDLibrary/GameItems/Interfaces`, `FutureMUDLibrary/Effects/Interfaces` |
+| Runtime | Concrete craft execution, editing, phase orchestration, subtype implementations, active craft item behaviour | `MudSharpCore/Work/Crafts`, `MudSharpCore/GameItems/Components`, `MudSharpCore/Effects/Concrete` |
+| Persistence | Revisioned craft tables and child records for phases, inputs, products, and tools | `MudsharpDatabaseLibrary/Models/Craft.cs`, `CraftPhase.cs`, `CraftInput.cs`, `CraftTool.cs`, `CraftProduct.cs` |
+| Boot and loading | Craft loading and registration timing within world startup | `MudSharpCore/Framework/FuturemudLoaders.cs` |
+| Commands and review | Player use, builder editing, listing, filtering, cloning, and review | `MudSharpCore/Commands/Modules/CraftModule.cs`, `MudSharpCore/Commands/Helpers/EditableRevisableItemHelper.cs` |
+| Seeder and stock examples | Seeded FutureProgs and stock craft content | `DatabaseSeeder/Seeders/ItemSeederCrafting.cs` |
+| Cross-system integration | Item skins, tool items, tags, liquids, NPC templates, AI, inventory plans, economy search | multiple runtime locations described below |
+
+## Main Public Contracts
+The crafting subsystem is anchored around the following public interfaces:
+
+- `ICraft`
+- `ICraftPhase`
+- `ICraftInput`
+- `ICraftTool`
+- `ICraftProduct`
+- `IVariableInput`
+- `IActiveCraftEffect`
+- `IActiveCraftGameItemComponent`
+
+Important contract consequences:
+
+- `ICraft` is the top-level revisable definition and exposes the player-facing lifecycle methods such as `CanDoCraft`, `BeginCraft`, `PauseCraft`, `CanResumeCraft`, `ResumeCraft`, `HandleCraftPhase`, `DisplayCraft`, and `CalculateCraftIsValid`.
+- `ICraftInput`, `ICraftTool`, and `ICraftProduct` are polymorphic extension seams. Most builder-visible craft variety comes from subtype instances rather than from branching inside `Craft` itself.
+- `IVariableInput` is the bridge for inputs that can supply characteristic values to variable-aware products.
+- `IActiveCraftGameItemComponent` is the persisted runtime state holder for a live craft in progress.
+
+## Boot and Load Order
+Crafts are loaded as part of the normal game boot sequence.
+
+Verified current load order details:
+
+- `LoadCrafts()` runs after FutureProgs are loaded, so craft progs can be resolved during craft construction.
+- `LoadCrafts()` runs before world items are loaded, which matters because active craft item components refer back to craft definitions by id and revision.
+- the craft loader reads `Models.Craft` rows, orders them as needed, and materialises live `MudSharp.Work.Crafts.Craft` instances into `Gameworld.Crafts`
+
+This ordering is important because crafts depend on several already-loaded domains:
+
+- FutureProgs for availability and callback hooks
+- traits for outcome checks
+- tags, materials, liquids, item prototypes, skins, and NPC templates for subtype definitions
+
+## Persistence Model
+The persistence model is fully revision-aware.
+
+### Top-level craft row
+Each craft revision is stored in `MudsharpDatabaseLibrary/Models/Craft.cs` with fields for:
+
+- id and revision number
+- editable item linkage
+- name, blurb, category, action description, and active craft item short description
+- quality weighting fields
+- free check count
+- check trait and difficulty
+- fail threshold and fail phase
+- quality formula text
+- practical versus theoretical flag
+- appear/can-use/why-cannot-use/start/complete/cancel prog ids
+- interruptable flag
+
+### Child records
+Each craft revision owns child rows for:
+
+- `CraftPhase`
+- `CraftInput`
+- `CraftTool`
+- `CraftProduct`
+
+Important child-record details:
+
+- phases are regular structured rows
+- inputs, tools, and products persist subtype-specific settings in XML `Definition` blobs
+- products also persist `IsFailProduct`
+- products optionally persist `MaterialDefiningInputIndex`
+- child records store `OriginalAdditionTime`, which the runtime uses to preserve builder order across load and revision clone paths
+
+### Revision cloning behaviour
+The craft clone and create-new-revision paths do more than duplicate top-level data:
+
+- phases are copied as full phase records
+- inputs and tools are cloned first so the new child ids exist
+- products are then cloned, with input and tool id remapping available where needed
+- subtype implementations that store child ids in their XML definitions can override revision-save behaviour to rewrite those ids safely
+
+This remapping step is important for products such as:
+
+- `UnusedInputProduct`
+- `ScrapInputProduct`
+- `DNATestProduct`
+- any future subtype that stores input or tool ids inside its persisted definition
+
+## Runtime Registration and Type Discovery
+Craft subtypes are loaded through three reflection-backed factories:
+
+- `CraftInputFactory`
+- `CraftToolFactory`
+- `CraftProductFactory`
+
+Verified current pattern:
+
+- each factory scans the executing assembly for types implementing the relevant interface
+- each discovered type may expose a public static registration method with a fixed name:
+  - `RegisterCraftInput`
+  - `RegisterCraftTool`
+  - `RegisterCraftProduct`
+- that method registers:
+  - a database type name used when loading persisted rows
+  - a builder alias used by in-game craft authoring commands
+
+This means subtype registration is data-driven once the concrete class is compiled into `MudSharpCore`; there is no central switch statement in `Craft` itself.
+
+## Runtime Lifecycle
+The main craft lifecycle is distributed across `Craft`, `ActiveCraftGameItemComponent`, and `ActiveCraftEffect`.
+
+### 1. Listing and visibility
+`ICraft.AppearInCraftsList(actor)` returns true only when all of the following hold:
+
+- the craft is the current approved revision
+- the craft is valid
+- the appear prog returns true for the actor, unless the actor is an administrator
+
+This is why a craft can exist in the database yet still be invisible to normal players.
+
+### 2. Feasibility check
+`ICraft.CanDoCraft(character, component, allowStartOnly, ignoreToolAndMaterialFailure)` checks:
+
+- character state, combat, and movement blockers
+- `CanUseProg`, if one is configured
+- tool feasibility through inventory plans
+- input feasibility through scouting and clash resolution
+
+Important behaviour:
+
+- interruptable crafts can be allowed to start or resume when only the immediate next phase is currently feasible
+- failures distinguish between missing tools, missing wielders/hands, and missing materials
+
+### 3. Starting a craft
+`BeginCraft` performs the following actions:
+
+1. create a system-generated active craft item via `ActiveCraftGameItemComponentProto.LoadActiveCraft`
+2. place it in the current cell and room layer
+3. create an `ActiveCraftEffect` on the character
+4. subscribe the effect to character and item interruption events
+5. schedule the first effect expiry after 5 seconds
+6. echo the beginning of the craft
+7. execute `OnUseProgStart`, if configured
+
+### 4. Active craft item state
+`ActiveCraftGameItemComponent` stores the live craft state:
+
+- `Craft`
+- `Phase`
+- `HasFailed`
+- `CheckOutcome`
+- `QualityCheckOutcome`
+- `ConsumedInputs`
+- `ProducedProducts`
+- `UsedToolQualities`
+
+It also serializes:
+
+- craft id and revision
+- current phase
+- check outcome
+- reserved input data
+
+The component decorates the in-progress item's short and full description so the progress item visibly represents the craft.
+
+### 5. Phase execution
+Each effect expiry calls `DoNextPhase`, which in turn calls `Craft.HandleCraftPhase`.
+
+`HandleCraftPhase` currently does the following:
+
+1. scout tools and inputs for the requested phase
+2. pause or cancel if required tools or materials are no longer available
+3. enforce per-phase stamina cost
+4. raise character exertion to the phase minimum
+5. execute the phase inventory plan
+6. apply tool duration usage and phase time multipliers
+7. reserve and store newly consumed inputs if their consumption phase has been reached
+8. perform the craft outcome check at the configured fail phase
+9. calculate the reference quality from check, tool, and input quality sources
+10. produce newly available normal or fail products
+11. emit the phase or fail echo
+12. set the next reschedule duration to the computed phase length
+
+### 6. Success and failure branching
+Failure is not a separate mini-craft. The existing craft continues after `HasFailed` is set.
+
+Once the craft has failed:
+
+- fail echoes are used instead of normal echoes
+- fail products are produced according to their resolved production phases
+- normal products stop being produced unless they were already produced before failure
+
+### 7. Pause, cancel, and resume
+`PauseCraft` is called when the active effect is cancelled by interruption.
+
+Current verified behaviour:
+
+- if the craft is not interruptable, pausing immediately becomes cancellation
+- cancellation releases products, executes `OnUseProgCancel`, and deletes the active craft item
+- interruptable crafts keep the active craft item so they can be resumed later
+
+`CanResumeCraft` and `ResumeCraft` then:
+
+- re-check whether upcoming phases are currently feasible
+- recreate and subscribe an `ActiveCraftEffect`
+- schedule the effect again after 5 seconds
+
+### 8. Completion and cleanup
+When the last phase completes:
+
+- stored products are released into the room
+- any releasable input-side items are also released
+- `OnUseProgComplete` is executed
+- the active craft item is deleted
+
+## Skill and Quality Model
+Crafting has two separate but related check concepts.
+
+### Outcome check
+The outcome check happens at `FailPhase`.
+
+It uses:
+
+- `CheckTrait`
+- `CheckDifficulty`
+- `IsPracticalCheck`
+- `FailThreshold`
+
+If the rolled outcome is at or below the fail threshold, the craft enters the failure branch.
+
+### Free skill checks
+`FreeSkillChecks` are extra improvement rolls using the same trait and difficulty after the main outcome check has happened.
+
+### Quality check
+Reference product quality is determined by combining:
+
+- the result of the craft quality check and `QualityFormula`
+- net tool quality weighted by `ToolQualityWeighting`
+- net input quality weighted by `InputQualityWeighting`
+- the outcome-quality contribution weighted by `CheckQualityWeighting`
+
+Current verified notes:
+
+- the quality formula receives the `outcome` variable, and craft checks may also consult the trait context
+- if `DisableCraftQualityCalculation` is set globally, item products skip applying the computed reference quality
+
+## Phase Semantics and Echo Tokens
+Phases are more than timed messages. The engine parses token references in phase echoes and fail echoes to determine when craft elements come into play.
+
+### Tokens
+| Token | Meaning | Current effect |
+| --- | --- | --- |
+| `$iN` | input reference | first valid success-echo appearance sets the phase when that input is considered consumed |
+| `$tN` | tool reference | marks that tool as required in that phase's inventory plan |
+| `$pN` | normal product reference | first valid appearance sets the phase when that product becomes produced |
+| `$fN` | fail product reference | only valid in fail echoes; first valid appearance sets the fail-product production phase |
+
+### Important defaulting rules
+If no token assigns a phase explicitly:
+
+- unreferenced inputs default to consumed phase 1
+- unreferenced normal products default to `FailPhase`
+- unreferenced fail products default to `FailPhase`
+- tools not referenced in any normal echo are treated as required in every normal phase
+
+### Fail-echo rules
+Fail echoes have stricter validity requirements:
+
+- they may reference only inputs that were already consumable on the success path
+- they may reference only tools that actually exist
+- they may reference normal products only if those products are already valid on the normal path
+- they may reference fail products with `$fN`
+- using `$fN` in a normal echo is invalid
+
+### Duration, exertion, and stamina
+Each phase carries:
+
+- `PhaseLengthInSeconds`
+- `ExertionLevel`
+- `StaminaUsage`
+
+At runtime:
+
+- phase duration starts from the configured phase length
+- each participating tool may multiply that duration
+- stamina must be available at phase execution time or the craft pauses/cancels
+- character exertion is raised to at least the phase exertion level
+
+## Implemented Type Catalogue
+
+### Inputs
+| Builder alias | Runtime type | Purpose | Key builder options | Important notes |
+| --- | --- | --- | --- | --- |
+| `simple` | `SimpleItemInput` | Consume an exact item prototype | `item`, `quantity`, `quality` | Valid only after a target item is set |
+| `simplematerial` | `SimpleMaterialInput` | Consume items made of a specific solid or a material tag | `material`, `tag`, `quantity`, `quality` | Accepts either an exact material or a material tag |
+| `tag` | `TagInput` | Consume items with a specified tag | `tag`, `quantity`, `quality` | Basic tag-driven input |
+| `tagvariable` | `TagVariableInput` | Consume tagged items that also supply characteristic definitions | `tag`, `quantity`, `variable`, `quality` | Implements `IVariableInput`; item must expose each declared definition |
+| `commodity` | `CommodityInput` | Consume a commodity pile of a specific solid and mass | `material`, `weight`, optional `tag`, `quality` | Requires both exact material and positive mass |
+| `commoditytag` | `CommodityTagInput` | Consume a commodity pile whose material matches a tag | `material`, `weight`, optional `tag`, `quality` | Uses a material tag instead of one exact solid |
+| `liquid` | `LiquidUseInput` | Consume a specific liquid amount | `liquid`, `amount`, `quality` | Valid only with a target liquid and positive amount |
+| `tagliquid` | `LiquidTagUseInput` | Consume liquid from a tagged source item | `tag`, `amount`, `quality` | Useful for containers or apparatus tagged for the craft |
+| `repair` | `ConditionRepairInput` | Target an item to repair by condition percentage | `tag`, `repair`, `quality` | Uses a tagged input item as a repair target rather than raw material |
+
+### Tools
+All tool types inherit shared builder options from `BaseTool`:
+
+- desired state: `held`, `worn`, `wield`, `room`
+- `quality` / `qualityweight`
+- `usetool` to toggle duration consumption on `IToolItem`
+
+| Builder alias | Runtime type | Purpose | Type-specific options | Important notes |
+| --- | --- | --- | --- | --- |
+| `simple` | `SimpleTool` | Require one exact item prototype | `item` | Best when the specific prototype matters |
+| `tag` | `TagTool` | Require any tool item matching a tag | `tag` | Works well with tool families such as hammers, anvils, or sewing needles |
+
+### Products
+| Builder alias | Runtime type | Purpose | Key builder options | Important notes |
+| --- | --- | --- | --- | --- |
+| `simple` | `SimpleProduct` | Load one or more ordinary item prototypes | `item`, `skin`, `quantity`, `material` | Optional craft-aware skin support through `IGameItemSkin.CanUseSkin(..., craft)` |
+| `variable` | `SimpleVariableProduct` | Load items whose characteristic values come from `IVariableInput` sources | `item`, `skin`, `quantity`, `variable <definition> <input#>` | Each mapped input must be an `IVariableInput` that supplies the definition |
+| `inputvariable` | `InputVariableProduct` | Load items whose variable values depend on which item proto was used for an input | `item`, `skin`, `quantity`, `variable ...` | Supports per-input-index and per-item-to-value mappings |
+| `commodity` | `CommodityProduct` | Produce a commodity pile of a material, mass, and optional tag | `commodity`, `weight`, `tag`, `material` | Useful for intermediate materials and scrap |
+| `money` | `MoneyProduct` | Produce money in a chosen currency | `currency`, `amount` | Valid only with currency plus positive amount |
+| `npc` | `NPCProduct` | Spawn one or more NPCs from an approved NPC template | `template`, `quantity`, optional `prog` | Optional on-load prog must be `void(Character)` |
+| `prog` | `ProgProduct` | Let a FutureProg decide which item or items are produced | `prog` | Prog must return item or collection of items and accept item/liquid input collections |
+| `progvariable` | `ProgVariableProduct` | Load an item and fill characteristics through per-definition progs | `item`, `quantity`, `variable <definition> <prog>` | Uses progs instead of input indexes for characteristic resolution |
+| `unusedinput` | `UnusedInputProduct` | Return copies of an unused portion of a consumed item input | `input`, `percentage` | Target input must consume items or item groups |
+| `scrap` | `ScrapInputProduct` | Convert part of a consumed item input into commodity scrap | `input`, `percentage`, `tag`, `material` | Target input must consume items; output is commodity-like salvage |
+| `dnatest` | `DNATestProduct` | Compare two liquid-consuming inputs and report whether they match | `input1`, `input2` | Both targeted inputs must consume liquids and must be different |
+| `bloodtyping` | `BloodTypingProduct` | Analyse one liquid-consuming input against a blood model and report the result | `input`, `bloodmodel` | Requires a configured `IBloodModel` plus a liquid-consuming input |
+
+## Extension Workflow
+The following extension guidance is inferred from the current implementation style and is the safest pattern to follow when adding a new craft subtype.
+
+1. Decide whether a new shared capability is needed.
+If the new type needs a reusable public contract, add that interface to `FutureMUDLibrary`. If it is only concrete runtime behaviour, keep the new class in `MudSharpCore`.
+
+2. Place the concrete type in the correct runtime folder.
+Use one of:
+
+- `MudSharpCore/Work/Crafts/Inputs`
+- `MudSharpCore/Work/Crafts/Tools`
+- `MudSharpCore/Work/Crafts/Products`
+
+3. Persist subtype-specific state through XML definitions.
+Implement constructor load from `Models.CraftInput`, `Models.CraftTool`, or `Models.CraftProduct` and persist state through `SaveDefinition()`. If the subtype stores input or tool ids, also handle revision remapping.
+
+4. Register both the persisted type name and builder alias.
+Expose a public static registration method with the exact expected name and register:
+
+- the persisted database type string
+- the builder alias used by `craft set input/tool/product add <type>`
+
+5. Implement builder editing and help.
+Every subtype should provide:
+
+- builder help text
+- subtype-specific `BuildingCommand(...)`
+- `IsValid()` and `WhyNotValid()`
+- `HowSeen(...)`
+
+6. Implement search/reference helpers where applicable.
+If the subtype refers to item protos, tags, or liquids, implement:
+
+- `RefersToItemProto`
+- `RefersToTag`
+- `RefersToLiquid`
+
+These power craft searching and filtering outside the craft namespace.
+
+7. Handle runtime data carefully.
+Choose the correct runtime data behaviour:
+
+- inputs reserve and possibly own consumed items or liquid mixtures
+- products may release items, spawn NPCs, or emit informational results
+- variable-aware products may need `IVariableInput` support or FutureProg support
+
+8. Add verification coverage.
+Prefer unit coverage for non-trivial runtime behaviour. The current suite already contains craft tool usage tests and DenBuilder AI regression coverage that treats active crafts as real runtime state, not as a purely builder concern.
+
+## Integration Points
+
+### FutureProg integration
+Crafts integrate with FutureProg at multiple levels.
+
+Craft-wide progs:
+
+- `AppearInCraftsListProg`: must return boolean and accept one `Character`
+- `CanUseProg`: must return boolean and accept one `Character`
+- `WhyCannotUseProg`: must return text and accept one `Character`
+- `OnUseProgStart`: must accept one `Character`
+- `OnUseProgComplete`: must accept one `Character`
+- `OnUseProgCancel`: must accept one `Character`
+
+Subtype-specific prog use also exists in products such as:
+
+- `ProgProduct`
+- `ProgVariableProduct`
+- `NPCProduct`
+
+### Item system integration
+Crafting leans heavily on the item system.
+
+Verified touchpoints include:
+
+- item prototypes for simple item inputs, tools, and products
+- tags for tag-based inputs and tools
+- materials and liquids for commodity and liquid subtypes
+- `IToolItem` for optional tool-duration usage
+- `IGameItemSkin` for craft-aware skin application
+- `IVariable` and characteristic definitions for variable-aware products
+
+### Inventory plans and desired item states
+Tool handling uses inventory plans, not ad hoc item grabs.
+
+This is why tool definitions include desired states such as:
+
+- held
+- worn
+- wielded
+- in room
+
+The engine checks feasibility against character anatomy and current context before allowing a craft to proceed.
+
+### Character state, stamina, and exertion
+Crafts are blocked or interrupted by:
+
+- inability states
+- movement
+- melee engagement
+- blocking effects
+- loss of required tools or materials mid-craft
+- insufficient stamina for a phase
+
+### Revision and review framework
+Crafts are not special-cased outside the normal revisable-content workflow.
+
+They use:
+
+- `EditableRevisableItemHelper.CraftHelper`
+- standard edit/show/list/review/submit flows
+- unique name enforcement across approved and in-design craft records
+
+### Seeder content
+`DatabaseSeeder/Seeders/ItemSeederCrafting.cs` seeds:
+
+- stock availability and gating progs
+- large numbers of example crafts
+- common patterns such as room-bound forge tools, material-driven outputs, fail salvage, and multi-phase assembly
+
+These seeded crafts are the best current examples of how the subsystem is expected to be used in real games.
+
+### AI integration
+`MudSharpCore/NPC/AI/DenBuilderAI.cs` treats crafts as reusable work definitions.
+
+Verified current behaviour:
+
+- the AI stores one selected `DenCraft`
+- it can start or resume that craft
+- it deliberately ignores active craft items when looking for den-anchor items
+
+### Economy and search surfaces
+Crafts are referenced outside the craft namespace for discovery and debugging.
+
+Examples include:
+
+- `EconomyModule`, which surfaces crafts related to an item
+- `CraftModule craft find`, which searches by input, tool, or product relation
+- `EditableRevisableItemHelper` custom search filters for tags, liquids, item protos, and category
+- `ImplementorModule exportcrafts`, which exports craft metadata and child data for debugging
+
+## Gotchas and Edge Cases
+- `AppearInCraftsListProg` is required for craft validity, not merely for optional visibility filtering.
+- `FailPhase` must point at a real phase. A craft with no valid fail phase cannot be submitted.
+- Invalid echo references make the whole craft invalid. A typo such as `$i9` when only three inputs exist is enough to block submission.
+- Fail echoes cannot introduce new unconsumed inputs or undeclared fail products.
+- Tools default to every normal phase if they never appear in any normal echo.
+- Inputs default to consumed phase 1 if they never appear in any normal echo.
+- Normal products and fail products default to `FailPhase` if no earlier token reference sets their phase.
+- Interruptable crafts still have to pass per-phase feasibility checks when starting or resuming; interruptability is not a bypass around tool or material scouting.
+- Active craft items are system-only. `ActiveCraftGameItemComponentProto` is read-only and prevents manual load.
+- Material-defining product inputs only work when the chosen input actually consumes game items or item groups.
+- Tool durability or tool-time usage can be applied every phase in which the tool participates.
+- Player interruption is event-driven. Movement, death, state change, item removal, and similar events can stop a craft even if no one explicitly typed a cancel command.
+- Non-interruptable crafts do not survive interruption as paused craft items; they are cancelled.
+- Craft names must remain unique across live and in-design entries, so cloning or renaming into an occupied name fails.
+- `craft show` is the authoritative validation view. The error block there is part of the runtime contract builders depend on, not just a cosmetic summary.
+
+## Inferred Guidance
+The current system strongly suggests a preferred implementation style for future work:
+
+1. keep craft behaviour polymorphic through subtype classes instead of growing `Craft` with new special-case branches
+2. keep shared contracts in `FutureMUDLibrary` and concrete behaviour in `MudSharpCore`
+3. preserve in-game authoring by always registering a builder alias and providing builder help
+4. design new products and inputs so they participate in existing search, review, and revision flows
+
+That guidance is inferred from the present codebase rather than enforced by one single base class, but it matches how the subsystem already works.


### PR DESCRIPTION
## Summary
- Add a new crafting system overview for fast orientation
- Document builder workflows, command surface, and validation steps
- Document runtime behavior, extensibility points, and implemented craft types

## Testing
- Not run (not requested)