### PR TITLE
Fix seeder defaults and trait-dependent merit seeding

### DIFF
--- a/DatabaseSeeder Unit Tests/CelestialSeederTests.cs
+++ b/DatabaseSeeder Unit Tests/CelestialSeederTests.cs
@@ -307,6 +307,38 @@ public class CelestialSeederTests
     }
 
     [TestMethod]
+    public void ResolveMoonEpochDisplay_MiddleEarthCalendar_UsesTwentyFirstDayOfYearAndRichGuidance()
+    {
+        using FuturemudDatabaseContext context = BuildContext();
+        long calendarId = SeedCalendar(context, "middle-earth", "3019", "3");
+
+        ConsoleQuestionDisplay display = CelestialSeeder.ResolveMoonEpochDisplay(context, new Dictionary<string, string>
+        {
+            ["mooncalendar"] = calendarId.ToString(System.Globalization.CultureInfo.InvariantCulture)
+        });
+
+        StringAssert.Contains(display.Prompt, "21st day of the year");
+        StringAssert.Contains(display.Prompt, "20/tuile/year");
+        Assert.AreEqual("20/tuile/3019", display.DefaultAnswer);
+    }
+
+    [TestMethod]
+    public void ResolveGasGiantMoonEpochDisplay_MissionCalendar_ShowsCalendarSpecificExampleAndDefault()
+    {
+        using FuturemudDatabaseContext context = BuildContext();
+        long calendarId = SeedCalendar(context, "mission", "77");
+
+        ConsoleQuestionDisplay display = CelestialSeeder.ResolveGasGiantMoonEpochDisplay(context, new Dictionary<string, string>
+        {
+            ["gasgiantcalendar"] = calendarId.ToString(System.Globalization.CultureInfo.InvariantCulture)
+        });
+
+        StringAssert.Contains(display.Prompt, "epoch-aligned");
+        StringAssert.Contains(display.Prompt, "01/ignis/year");
+        Assert.AreEqual("01/ignis/77", display.DefaultAnswer);
+    }
+
+    [TestMethod]
     public void ResolveMoonEpochDefaults_UseStockReferenceDatesForSeededCalendars()
     {
         using FuturemudDatabaseContext gregorianContext = BuildContext();
@@ -316,6 +348,15 @@ public class CelestialSeederTests
             CelestialSeeder.ResolveMoonEpochDefault(gregorianContext, new Dictionary<string, string>
             {
                 ["mooncalendar"] = gregorianCalendarId.ToString(System.Globalization.CultureInfo.InvariantCulture)
+            }));
+
+        using FuturemudDatabaseContext middleEarthContext = BuildContext();
+        long middleEarthCalendarId = SeedCalendar(middleEarthContext, "middle-earth", "3019", "3");
+        Assert.AreEqual(
+            "20/tuile/3019",
+            CelestialSeeder.ResolveMoonEpochDefault(middleEarthContext, new Dictionary<string, string>
+            {
+                ["mooncalendar"] = middleEarthCalendarId.ToString(System.Globalization.CultureInfo.InvariantCulture)
             }));
 
         using FuturemudDatabaseContext missionContext = BuildContext();

--- a/DatabaseSeeder Unit Tests/StockMeritsSeederTests.cs
+++ b/DatabaseSeeder Unit Tests/StockMeritsSeederTests.cs
@@ -144,8 +144,9 @@ public class StockMeritsSeederTests
             int.Parse(XElement.Parse(x.Definition).Attribute("verb")?.Value ?? "-1") == (int)verb);
     }
 
-    private static void SeedPrerequisites(FuturemudDatabaseContext context)
+    private static void SeedPrerequisites(FuturemudDatabaseContext context, params string[] omittedTraitNames)
     {
+        HashSet<string> omittedTraits = new(omittedTraitNames, StringComparer.OrdinalIgnoreCase);
         SeedAccount(context);
         context.FutureProgs.Add(CreateProg(1, "AlwaysTrue", ProgVariableTypes.Boolean, "return true"));
         context.Races.Add(new Race
@@ -174,6 +175,13 @@ public class StockMeritsSeederTests
             CreateTraitDefinition(2, "Constitution", "attribute", 0),
             CreateTraitDefinition(3, "Perception", "attribute", 0),
             CreateTraitDefinition(4, "Willpower", "attribute", 0));
+        foreach (TraitDefinition trait in context.TraitDefinitions.Local.ToList())
+        {
+            if (omittedTraits.Contains(trait.Name))
+            {
+                context.TraitDefinitions.Remove(trait);
+            }
+        }
 
         BodyProto body = CreateBodyProto(1, "Humanoid");
         context.BodyProtos.Add(body);
@@ -246,6 +254,20 @@ public class StockMeritsSeederTests
         {
             Assert.AreEqual(1, context.FutureProgs.Count(x => x.FunctionName == progName), $"Expected a single helper prog named {progName}.");
         }
+    }
+
+    [TestMethod]
+    public void SeedData_MissingPerceptionAttribute_SkipsInapplicableTraitMeritAndStillCountsAsInstalled()
+    {
+        using FuturemudDatabaseContext context = BuildContext();
+        SeedPrerequisites(context, "Perception");
+        StockMeritsSeeder seeder = new();
+
+        seeder.SeedData(context, new Dictionary<string, string>());
+
+        Assert.IsFalse(context.Merits.Any(x => x.Name == "Keen-Eyed"));
+        Assert.IsTrue(context.Merits.Any(x => x.Name == "Weak-Willed"));
+        Assert.AreEqual(ShouldSeedResult.MayAlreadyBeInstalled, seeder.ShouldSeedData(context));
     }
 
     [TestMethod]

--- a/DatabaseSeeder/Seeders/CelestialSeeder.cs
+++ b/DatabaseSeeder/Seeders/CelestialSeeder.cs
@@ -1,6 +1,7 @@
 using MudSharp.Database;
 using MudSharp.Framework;
 using MudSharp.Models;
+using MudSharp.TimeAndDate.Date;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -128,7 +129,7 @@ What epoch date do you want to use?",
             (context, answers) => AnswerIsYes(answers, "installmoon"),
             (answer, context) => (true, string.Empty)),
         ("moonepoch",
-            @"What epoch date should be used for the moon? This is a date that is known to be a full moon. For Earth, you could use 21/jan/2000.",
+            @"What epoch date should be used for the moon? This is a date that is known to be a full moon. For the stock Earth moon package, the suggested default is the 21st day of the year in the calendar you selected.",
             (context, answers) => AnswerIsYes(answers, "installmoon"),
             ValidateDate),
         ("installgasgiantmoon",
@@ -144,7 +145,7 @@ What epoch date do you want to use?",
             (context, answers) => AnswerIsYes(answers, "installgasgiantmoon"),
             ValidateDate),
         ("gasgiantmoonepoch",
-            @"What epoch date should be used for Ganymede? This should be a date that is known to be a full Ganymede as seen from Jupiter.",
+            @"What epoch date should be used for Ganymede? This should be a date that is known to be a full Ganymede as seen from Jupiter. The stock package uses an epoch-aligned default at the start of the selected calendar year.",
             (context, answers) => AnswerIsYes(answers, "installgasgiantmoon"),
             ValidateDate)
     ];
@@ -240,7 +241,8 @@ What epoch date do you want to use?",
             "You must now enter a valid date for the 'epoch' of your Earth-facing sun.",
             "Generally you'll want this to be whatever date is equivalent to the 1st of the first month in your calendar, in the same year that your game's current date uses.",
             "A sensible stock default for this package is the first day of the first month.",
-            1);
+            1,
+            example => $"For this calendar, a start-of-year example would look like {example}.");
     }
 
     internal static ConsoleQuestionDisplay ResolveMoonEpochDisplay(FuturemudDatabaseContext context,
@@ -251,9 +253,10 @@ What epoch date do you want to use?",
             answers,
             "mooncalendar",
             "What epoch date should be used for the moon?",
-            "This should be a date that is known to be a full moon in the calendar you selected.",
-            "The stock Earth moon package uses day 21 of the first month as its known full-moon reference.",
-            21);
+            "This should be a date that is known to be a full moon in the calendar you selected. For the stock Earth moon package, that reference point is the 21st day of the year rather than simply the 21st day of the first month.",
+            "A sensible stock default for this package is the 21st day of the year in your selected calendar.",
+            21,
+            example => $"For this calendar, the 21st day of the year would be written as {example}.");
     }
 
     internal static ConsoleQuestionDisplay ResolveGasGiantSunEpochDisplay(FuturemudDatabaseContext context,
@@ -266,7 +269,8 @@ What epoch date do you want to use?",
             "What epoch date should be used for the Jupiter-facing Sun?",
             "This should be the start-of-year epoch for your chosen calendar.",
             "A sensible stock default for this package is the first day of the first month.",
-            1);
+            1,
+            example => $"For this calendar, a start-of-year example would look like {example}.");
     }
 
     internal static ConsoleQuestionDisplay ResolveGasGiantMoonEpochDisplay(FuturemudDatabaseContext context,
@@ -277,9 +281,10 @@ What epoch date do you want to use?",
             answers,
             "gasgiantcalendar",
             "What epoch date should be used for Ganymede?",
-            "This is the stock epoch-aligned reference date used by the seeded Jupiter/Ganymede package.",
+            "This should be a date that is known to be a full Ganymede as seen from Jupiter. The seeded package uses an epoch-aligned reference at the start of the selected calendar year.",
             "The seeded default uses the first day of the first month so the package lines up with the authored epoch constants.",
-            1);
+            1,
+            example => $"For this calendar, an epoch-aligned example would look like {example}.");
     }
 
     private static bool AnswerIsYes(IReadOnlyDictionary<string, string> answers, string key)
@@ -302,9 +307,14 @@ What epoch date do you want to use?",
     private static string? ResolveEpochDefault(FuturemudDatabaseContext context,
         IReadOnlyDictionary<string, string> answers,
         string calendarAnswerKey,
-        int day)
+        int dayOfYear)
     {
-        return TryGetCalendarDateFormat(context, answers, calendarAnswerKey, day, out string? formattedDate)
+        if (!TryGetCalendarPromptInfo(context, answers, calendarAnswerKey, out CalendarPromptInfo? info))
+        {
+            return null;
+        }
+
+        return TryFormatCalendarDayOfYear(info, dayOfYear, info.CurrentYear, out string? formattedDate)
             ? formattedDate
             : null;
     }
@@ -316,7 +326,8 @@ What epoch date do you want to use?",
         string heading,
         string guidance,
         string stockDefaultExplanation,
-        int defaultDay)
+        int defaultDayOfYear,
+        Func<string, string> exampleTextFactory)
     {
         if (!TryGetCalendarPromptInfo(context, answers, calendarAnswerKey, out CalendarPromptInfo? info))
         {
@@ -329,13 +340,12 @@ Please enter the epoch date using the format of the calendar you selected.",
                 null);
         }
 
-        string monthExample = FormatCalendarDate(info, 1, info.FirstMonthAlias, "year");
-        string moonExample = FormatCalendarDate(info, 21, info.FirstMonthAlias, "year");
-        string? defaultAnswer = ResolveEpochDefault(context, answers, calendarAnswerKey, defaultDay);
-
-        string exampleText = defaultDay == 21
-            ? $"For this calendar, a first-month full-moon style example would look like {moonExample}."
-            : $"For this calendar, a start-of-year example would look like {monthExample}.";
+        string? defaultAnswer = TryFormatCalendarDayOfYear(info, defaultDayOfYear, info.CurrentYear, out string? formattedDefault)
+            ? formattedDefault
+            : null;
+        string exampleText = TryFormatCalendarDayOfYear(info, defaultDayOfYear, "year", out string? formattedExample)
+            ? exampleTextFactory(formattedExample!)
+            : "Please enter the epoch date using the format of the calendar you selected.";
 
         return new ConsoleQuestionDisplay(
             $@"{heading}
@@ -348,16 +358,27 @@ The selected calendar is {info.CalendarName}.
             defaultAnswer);
     }
 
-    private static bool TryGetCalendarDateFormat(FuturemudDatabaseContext context,
-        IReadOnlyDictionary<string, string> answers,
-        string calendarAnswerKey,
-        int day,
+    private static bool TryFormatCalendarDayOfYear(CalendarPromptInfo info,
+        int dayOfYear,
+        string year,
         out string? formattedDate)
     {
-        if (TryGetCalendarPromptInfo(context, answers, calendarAnswerKey, out CalendarPromptInfo? info))
+        if (dayOfYear < 1)
         {
-            formattedDate = FormatCalendarDate(info, day, info.FirstMonthAlias, info.CurrentYear);
-            return true;
+            formattedDate = null;
+            return false;
+        }
+
+        int remainingDays = dayOfYear;
+        foreach (Month month in info.Months)
+        {
+            if (remainingDays <= month.Days)
+            {
+                formattedDate = FormatCalendarDate(info.Calendar, remainingDays, month.Alias, year);
+                return true;
+            }
+
+            remainingDays -= month.Days;
         }
 
         formattedDate = null;
@@ -379,10 +400,6 @@ The selected calendar is {info.CalendarName}.
         }
 
         XElement definition = XElement.Parse(calendar.Definition);
-        string firstMonthAlias = definition.Descendants("month")
-                                 .Select(x => x.Element("alias")?.Value)
-                                 .FirstOrDefault(x => !string.IsNullOrWhiteSpace(x)) ??
-                             "january";
         string calendarName = definition.Element("fullname")?.Value ??
                            definition.Element("shortname")?.Value ??
                            definition.Element("alias")?.Value ??
@@ -399,8 +416,61 @@ The selected calendar is {info.CalendarName}.
             return false;
         }
 
-        info = new CalendarPromptInfo(calendar, calendarName, firstMonthAlias, calendar.Date, parts[yearIndex]);
+        if (!int.TryParse(parts[yearIndex], NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture,
+                out int currentYear) ||
+            !TryLoadCalendarMonths(definition, currentYear, out List<Month> months))
+        {
+            return false;
+        }
+
+        info = new CalendarPromptInfo(calendar, calendarName, parts[yearIndex], months);
         return true;
+    }
+
+    private static bool TryLoadCalendarMonths(XElement definition, int currentYear, out List<Month> months)
+    {
+        months = new List<Month>();
+        try
+        {
+            XElement? monthsElement = definition.Element("months");
+            if (monthsElement?.HasElements != true)
+            {
+                return false;
+            }
+
+            months.AddRange(monthsElement.Elements("month")
+                .Select(element =>
+                {
+                    MonthDefinition monthDefinition = new();
+                    monthDefinition.LoadFromXml(element);
+                    return new Month(monthDefinition, currentYear);
+                }));
+
+            XElement? intercalariesElement = definition.Element("intercalarymonths");
+            if (intercalariesElement?.HasElements == true)
+            {
+                months.AddRange(intercalariesElement.Elements("intercalarymonth")
+                    .Select(element =>
+                    {
+                        IntercalaryMonth intercalaryMonth = new();
+                        intercalaryMonth.LoadFromXml(element);
+                        return intercalaryMonth;
+                    })
+                    .Where(x => x.Rule.IsIntercalaryYear(currentYear))
+                    .Select(x => new Month(x.Month, currentYear)));
+            }
+
+            months = months
+                .OrderBy(x => x.NominalOrder)
+                .ToList();
+
+            return months.Count > 0;
+        }
+        catch
+        {
+            months = new List<Month>();
+            return false;
+        }
     }
 
     internal static string FormatCalendarDate(Calendar calendar, int day, string monthAlias, string year)
@@ -425,11 +495,6 @@ The selected calendar is {info.CalendarName}.
         rendered[dayIndex] = day.ToString($"D{Math.Max(2, parts[dayIndex].Length)}", System.Globalization.CultureInfo.InvariantCulture);
         rendered[monthIndex] = monthAlias;
         return $"{rendered[0]}{separators[0]}{rendered[1]}{separators[1]}{rendered[2]}";
-    }
-
-    private static string FormatCalendarDate(CalendarPromptInfo info, int day, string monthAlias, string year)
-    {
-        return FormatCalendarDate(info.Calendar, day, monthAlias, year);
     }
 
     private static List<string> SplitDateParts(string value)
@@ -480,9 +545,8 @@ The selected calendar is {info.CalendarName}.
     private sealed record CalendarPromptInfo(
         Calendar Calendar,
         string CalendarName,
-        string FirstMonthAlias,
-        string CurrentDate,
-        string CurrentYear);
+        string CurrentYear,
+        IReadOnlyList<Month> Months);
 
     private static (bool Success, string error) ValidateCalendar(string answer, FuturemudDatabaseContext context)
     {

--- a/DatabaseSeeder/Seeders/StockMeritsSeeder.cs
+++ b/DatabaseSeeder/Seeders/StockMeritsSeeder.cs
@@ -191,11 +191,13 @@ public class StockMeritsSeeder : IDatabaseSeeder
         new("Sturdy Frame", "Multi Trait Bonus", MeritType.Merit,
             context => MultiTraitMerit(context, 1.0, ["Strength", "Constitution"],
                 "You are naturally stronger and hardier than average.",
-                "$0 have|has a sturdy frame.")),
+                "$0 have|has a sturdy frame."),
+            ["Strength", "Constitution"]),
         new("Frail Frame", "Multi Trait Bonus", MeritType.Flaw,
             context => MultiTraitMerit(context, -1.0, ["Strength", "Constitution"],
                 "You are lighter-framed and less robust than average.",
-                "$0 have|has a frail frame.")),
+                "$0 have|has a frail frame."),
+            ["Strength", "Constitution"]),
 
         new("Mute", "Mute", MeritType.Flaw,
             context => MuteMerit(context, PermitLanguageOptions.LanguageIsMuffling,
@@ -389,11 +391,13 @@ public class StockMeritsSeeder : IDatabaseSeeder
         new("Keen-Eyed", "Specific Trait Bonus", MeritType.Merit,
             context => SpecificTraitMerit(context, "Perception", 1.0,
                 "You pick up details other people often miss.",
-                "$0 are|is keen-eyed.")),
+                "$0 are|is keen-eyed."),
+            ["Perception"]),
         new("Weak-Willed", "Specific Trait Bonus", MeritType.Flaw,
             context => SpecificTraitMerit(context, "Willpower", -1.0,
                 "You find it harder than most people to hold firm under pressure.",
-                "$0 are|is weak-willed.")),
+                "$0 are|is weak-willed."),
+            ["Willpower"]),
 
         new("Tidy Surgeon", "Surgery Finalisation", MeritType.Merit,
             context => SurgeryMerit(context, 2,
@@ -475,9 +479,12 @@ The included examples emphasise conditional terrain- and darkness-based merits, 
             return ShouldSeedResult.PrerequisitesNotMet;
         }
 
+        StockMeritContext stockContext = new(context, 0);
         return SeederRepeatabilityHelper.ClassifyByPresence(
             HelperProgNames.Select(name => context.FutureProgs.Any(x => x.FunctionName == name))
-                .Concat(StockMerits.Select(merit => context.Merits.Any(x => x.Name == merit.Name))));
+                .Concat(StockMerits
+                    .Where(merit => merit.IsApplicable(stockContext))
+                    .Select(merit => context.Merits.Any(x => x.Name == merit.Name))));
     }
 
     private static bool HasMeritSelectionStoryboard(FuturemudDatabaseContext context)
@@ -594,6 +601,17 @@ The included examples emphasise conditional terrain- and darkness-based merits, 
     private static void EnsureCharacterMerit(FuturemudDatabaseContext context, StockMeritBlueprint blueprint,
         StockMeritContext stockContext)
     {
+        if (!blueprint.IsApplicable(stockContext))
+        {
+            return;
+        }
+
+        XElement? definition = blueprint.Definition(stockContext);
+        if (definition is null)
+        {
+            return;
+        }
+
         Merit merit = SeederRepeatabilityHelper.EnsureNamedEntity(
             context.Merits,
             blueprint.Name,
@@ -610,7 +628,7 @@ The included examples emphasise conditional terrain- and darkness-based merits, 
         merit.MeritType = (int)blueprint.MeritType;
         merit.MeritScope = (int)MeritScope.Character;
         merit.ParentId = null;
-        merit.Definition = blueprint.Definition(stockContext).ToString();
+        merit.Definition = definition.ToString();
     }
 
     private static XElement SimpleMerit(StockMeritContext context, string blurb, string description,
@@ -706,13 +724,24 @@ The included examples emphasise conditional terrain- and darkness-based merits, 
                 checkTypes.Select(check => new XElement("Check", new XAttribute("type", (int)check)))));
     }
 
-    private static XElement MultiTraitMerit(StockMeritContext context, double bonus, IEnumerable<string> traitNames,
+    private static XElement? MultiTraitMerit(StockMeritContext context, double bonus, IEnumerable<string> traitNames,
         string blurb, string description, long? applicabilityProgId = null, params TraitBonusContext[] contexts)
     {
+        List<long> traitIds = new();
+        foreach (string traitName in traitNames)
+        {
+            if (!context.TryTrait(traitName, out long traitId))
+            {
+                return null;
+            }
+
+            traitIds.Add(traitId);
+        }
+
         return MeritRoot(context, blurb, description, applicabilityProgId,
             new XAttribute("bonus", bonus),
             new XElement("Traits",
-                traitNames.Select(traitName => new XElement("Trait", new XAttribute("id", context.Trait(traitName))))),
+                traitIds.Select(traitId => new XElement("Trait", new XAttribute("id", traitId)))),
             new XElement("Contexts",
                 contexts.Distinct().Select(item => new XElement("Context", (int)item))));
     }
@@ -827,12 +856,17 @@ The included examples emphasise conditional terrain- and darkness-based merits, 
                 speeds.Select(speed => new XElement("Speed", new XAttribute("id", context.MoveSpeed(speed))))));
     }
 
-    private static XElement SpecificTraitMerit(StockMeritContext context, string traitName, double bonus, string blurb,
+    private static XElement? SpecificTraitMerit(StockMeritContext context, string traitName, double bonus, string blurb,
         string description, long? applicabilityProgId = null, params TraitBonusContext[] contexts)
     {
+        if (!context.TryTrait(traitName, out long traitId))
+        {
+            return null;
+        }
+
         return MeritRoot(context, blurb, description, applicabilityProgId,
             new XAttribute("bonus", bonus),
-            new XAttribute("trait", context.Trait(traitName)),
+            new XAttribute("trait", traitId),
             new XElement("Contexts",
                 contexts.Distinct().Select(item => new XElement("Context", (int)item))));
     }
@@ -884,7 +918,14 @@ The included examples emphasise conditional terrain- and darkness-based merits, 
         string Name,
         string Type,
         MeritType MeritType,
-        Func<StockMeritContext, XElement> Definition);
+        Func<StockMeritContext, XElement?> Definition,
+        IReadOnlyCollection<string>? RequiredTraits = null)
+    {
+        public bool IsApplicable(StockMeritContext context)
+        {
+            return RequiredTraits?.All(context.HasTrait) != false;
+        }
+    }
 
     private sealed class StockMeritContext
     {
@@ -910,6 +951,26 @@ The included examples emphasise conditional terrain- and darkness-based merits, 
             return _context.TraitDefinitions.AsEnumerable()
                 .First(x => x.Name.Equals(traitName, StringComparison.OrdinalIgnoreCase))
                 .Id;
+        }
+
+        public bool HasTrait(string traitName)
+        {
+            return _context.TraitDefinitions.AsEnumerable()
+                .Any(x => x.Name.Equals(traitName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        public bool TryTrait(string traitName, out long traitId)
+        {
+            TraitDefinition? trait = _context.TraitDefinitions.AsEnumerable()
+                .FirstOrDefault(x => x.Name.Equals(traitName, StringComparison.OrdinalIgnoreCase));
+            if (trait is null)
+            {
+                traitId = 0;
+                return false;
+            }
+
+            traitId = trait.Id;
+            return true;
         }
 
         public long MoveSpeed(string aliasOrName)


### PR DESCRIPTION
## Summary
- Skip stock trait-dependent merits when the required attribute trait is absent, and keep repeatability detection aligned with what can actually seed.
- Compute moon defaults from the real calendar structure so the 21st day-of-year resolves correctly on calendars with short first months.
- Expand moon and gas-giant moon guidance to match the richer sun prompts.

## Testing
- `dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore`
- Result: 167/168 passed; the remaining failure is unrelated (`BlankDatabaseSnapshotManifest_TracksLatestMigration`).