### PR TITLE
Update economy seeder with weighted stock baskets

### DIFF
--- a/DatabaseSeeder Unit Tests/EconomySeederTests.cs
+++ b/DatabaseSeeder Unit Tests/EconomySeederTests.cs
@@ -25,11 +25,11 @@ public class EconomySeederTests
     private const string StandardScale = "Standard";
     private const string HelperProgPrefix = "EconomySeeder";
     private const string ExternalTemplatePrefix = "EconomySeeder External ";
-    private static readonly IReadOnlySet<string> StockCombinationFamilies =
-        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            "Medicine",
-            "Writing Materials",
+	private static readonly IReadOnlySet<string> StockCombinationFamilies =
+		new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+		{
+			"Medicine",
+			"Writing Materials",
             "Clothing",
             "Intoxicants",
             "Household Goods",
@@ -37,9 +37,87 @@ public class EconomySeederTests
             "Entertainment",
             "Personal Services",
             "Communications",
-            "Military Goods",
-            "Professional Tools"
-        };
+			"Military Goods",
+			"Professional Tools"
+		};
+
+	private static readonly IReadOnlyDictionary<string, IReadOnlyList<(string CategoryName, decimal Weight)>> StockCombinationWeights =
+		new Dictionary<string, IReadOnlyList<(string CategoryName, decimal Weight)>>(StringComparer.OrdinalIgnoreCase)
+		{
+			["Medicine"] =
+			[
+				("Simple Medicine", 0.55m),
+				("Standard Medicine", 0.30m),
+				("High-Quality Medicine", 0.15m)
+			],
+			["Writing Materials"] =
+			[
+				("Wax Tablets", 0.15m),
+				("Parchment", 0.35m),
+				("Paper", 0.30m),
+				("Ink", 0.20m)
+			],
+			["Clothing"] =
+			[
+				("Simple Clothing", 0.55m),
+				("Standard Clothing", 0.30m),
+				("Luxury Clothing", 0.15m)
+			],
+			["Intoxicants"] =
+			[
+				("Beer", 0.65m),
+				("Wine", 0.35m)
+			],
+			["Household Goods"] =
+			[
+				("Simple Wares", 0.20m),
+				("Standard Wares", 0.15m),
+				("Simple Furniture", 0.18m),
+				("Standard Furniture", 0.15m),
+				("Luxury Furniture", 0.10m),
+				("Standard Decorations", 0.12m),
+				("Luxury Decorations", 0.10m)
+			],
+			["Hospitality"] =
+			[
+				("Standard Lodging", 0.70m),
+				("Luxury Lodging", 0.30m)
+			],
+			["Entertainment"] =
+			[
+				("Cheap Entertainment", 0.50m),
+				("Standard Entertainment", 0.35m),
+				("Luxury Entertainment", 0.15m)
+			],
+			["Personal Services"] =
+			[
+				("Bathing Services", 0.35m),
+				("Domestic Services", 0.30m),
+				("Barbering", 0.20m),
+				("Laundry Services", 0.15m)
+			],
+			["Communications"] =
+			[
+				("Messenger Services", 0.30m),
+				("Courier Services", 0.30m),
+				("Postal Services", 0.25m),
+				("Printed News", 0.15m)
+			],
+			["Military Goods"] =
+			[
+				("Weapons", 0.35m),
+				("Armour", 0.25m),
+				("Ammunition", 0.25m),
+				("Military Uniforms", 0.15m)
+			],
+			["Professional Tools"] =
+			[
+				("Primitive Tools", 0.25m),
+				("Simple Tools", 0.30m),
+				("Standard Tools", 0.30m),
+				("High-Quality Tools", 0.15m)
+			]
+		};
 
     private static readonly IReadOnlyDictionary<string, string[]> FamilyTags =
         new Dictionary<string, string[]>
@@ -365,13 +443,22 @@ public class EconomySeederTests
         }
     }
 
-    private static List<long> GetCombinationComponentIds(MarketCategory category)
-    {
-        return XElement.Parse(category.CombinationCategories ?? "<Components />")
-            .Elements("Component")
-            .Select(x => long.Parse(x.Attribute("category")!.Value, CultureInfo.InvariantCulture))
-            .ToList();
-    }
+	private static List<long> GetCombinationComponentIds(MarketCategory category)
+	{
+		return GetCombinationComponents(category)
+			.Select(x => x.CategoryId)
+			.ToList();
+	}
+
+	private static List<(long CategoryId, decimal Weight)> GetCombinationComponents(MarketCategory category)
+	{
+		return XElement.Parse(category.CombinationCategories ?? "<Components />")
+			.Elements("Component")
+			.Select(x => (
+				CategoryId: long.Parse(x.Attribute("category")!.Value, CultureInfo.InvariantCulture),
+				Weight: decimal.Parse(x.Attribute("weight")!.Value, CultureInfo.InvariantCulture)))
+			.ToList();
+	}
 
     private static List<XElement> GetPopulationIncomeImpacts(MarketInfluenceTemplate template)
     {
@@ -551,23 +638,39 @@ public class EconomySeederTests
             .AsEnumerable()
             .ToDictionary(x => x.Id);
 
-        foreach ((string familyName, string[] leafNames) in FamilyTags
-                     .Where(x => StockCombinationFamilies.Contains(x.Key)))
-        {
-            MarketCategory familyCategory = context.MarketCategories.Single(x => x.Name == familyName);
-            Assert.AreEqual(1, familyCategory.MarketCategoryType, $"{familyName} should seed as a combination category example.");
+		foreach ((string familyName, string[] leafNames) in FamilyTags
+				     .Where(x => StockCombinationFamilies.Contains(x.Key)))
+		{
+			MarketCategory familyCategory = context.MarketCategories.Single(x => x.Name == familyName);
+			Assert.AreEqual(1, familyCategory.MarketCategoryType, $"{familyName} should seed as a combination category example.");
 
-            List<string> componentNames = GetCombinationComponentIds(familyCategory)
-                .Select(id => categoriesById[id].Name)
-                .OrderBy(x => x)
-                .ToList();
-            CollectionAssert.AreEquivalent(leafNames, componentNames, $"{familyName} should be composed of its direct seeded child categories.");
+			List<(long CategoryId, decimal Weight)> components = GetCombinationComponents(familyCategory);
+			List<string> componentNames = components
+				.Select(x => categoriesById[x.CategoryId].Name)
+				.OrderBy(x => x)
+				.ToList();
+			CollectionAssert.AreEquivalent(leafNames, componentNames, $"{familyName} should be composed of its direct seeded child categories.");
 
-            foreach (XElement component in XElement.Parse(familyCategory.CombinationCategories).Elements("Component"))
-            {
-                Assert.AreEqual(1.0m, decimal.Parse(component.Attribute("weight")!.Value, CultureInfo.InvariantCulture), $"{familyName} should seed equal-weight component examples.");
-            }
-        }
+			Dictionary<string, decimal> actualWeightsByName = components.ToDictionary(
+				x => categoriesById[x.CategoryId].Name,
+				x => x.Weight,
+				StringComparer.OrdinalIgnoreCase);
+			Assert.AreEqual(
+				StockCombinationWeights[familyName].Count,
+				actualWeightsByName.Count,
+				$"{familyName} should seed the expected number of weighted components.");
+			foreach ((string categoryName, decimal expectedWeight) in StockCombinationWeights[familyName])
+			{
+				Assert.AreEqual(
+					expectedWeight,
+					actualWeightsByName[categoryName],
+					$"{familyName} should seed {categoryName} with its expected component weight.");
+			}
+
+			Assert.IsTrue(
+				actualWeightsByName.Values.Distinct().Count() > 1,
+				$"{familyName} should seed non-equal component weights.");
+		}
 
         foreach (string familyName in new[] { "Nourishment", "Domestic Heating", "Luxury Drinks", "Transportation" })
         {

--- a/DatabaseSeeder/Seeders/EconomySeeder.cs
+++ b/DatabaseSeeder/Seeders/EconomySeeder.cs
@@ -64,11 +64,11 @@ public class EconomySeeder : IDatabaseSeeder
         .Distinct(StringComparer.OrdinalIgnoreCase)
         .ToArray();
 
-    private static readonly IReadOnlySet<string> StockCombinationFamilyExamples =
-        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            "Medicine",
-            "Writing Materials",
+	private static readonly IReadOnlySet<string> StockCombinationFamilyExamples =
+		new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+		{
+			"Medicine",
+			"Writing Materials",
             "Clothing",
             "Intoxicants",
             "Household Goods",
@@ -76,9 +76,87 @@ public class EconomySeeder : IDatabaseSeeder
             "Entertainment",
             "Personal Services",
             "Communications",
-            "Military Goods",
-            "Professional Tools"
-        };
+			"Military Goods",
+			"Professional Tools"
+		};
+
+	private static readonly IReadOnlyDictionary<string, IReadOnlyList<(string CategoryName, decimal Weight)>> StockCombinationCategoryWeights =
+		new Dictionary<string, IReadOnlyList<(string CategoryName, decimal Weight)>>(StringComparer.OrdinalIgnoreCase)
+		{
+			["Medicine"] =
+			[
+				("Simple Medicine", 0.55m),
+				("Standard Medicine", 0.30m),
+				("High-Quality Medicine", 0.15m)
+			],
+			["Writing Materials"] =
+			[
+				("Wax Tablets", 0.15m),
+				("Parchment", 0.35m),
+				("Paper", 0.30m),
+				("Ink", 0.20m)
+			],
+			["Clothing"] =
+			[
+				("Simple Clothing", 0.55m),
+				("Standard Clothing", 0.30m),
+				("Luxury Clothing", 0.15m)
+			],
+			["Intoxicants"] =
+			[
+				("Beer", 0.65m),
+				("Wine", 0.35m)
+			],
+			["Household Goods"] =
+			[
+				("Simple Wares", 0.20m),
+				("Standard Wares", 0.15m),
+				("Simple Furniture", 0.18m),
+				("Standard Furniture", 0.15m),
+				("Luxury Furniture", 0.10m),
+				("Standard Decorations", 0.12m),
+				("Luxury Decorations", 0.10m)
+			],
+			["Hospitality"] =
+			[
+				("Standard Lodging", 0.70m),
+				("Luxury Lodging", 0.30m)
+			],
+			["Entertainment"] =
+			[
+				("Cheap Entertainment", 0.50m),
+				("Standard Entertainment", 0.35m),
+				("Luxury Entertainment", 0.15m)
+			],
+			["Personal Services"] =
+			[
+				("Bathing Services", 0.35m),
+				("Domestic Services", 0.30m),
+				("Barbering", 0.20m),
+				("Laundry Services", 0.15m)
+			],
+			["Communications"] =
+			[
+				("Messenger Services", 0.30m),
+				("Courier Services", 0.30m),
+				("Postal Services", 0.25m),
+				("Printed News", 0.15m)
+			],
+			["Military Goods"] =
+			[
+				("Weapons", 0.35m),
+				("Armour", 0.25m),
+				("Ammunition", 0.25m),
+				("Military Uniforms", 0.15m)
+			],
+			["Professional Tools"] =
+			[
+				("Primitive Tools", 0.25m),
+				("Simple Tools", 0.30m),
+				("Standard Tools", 0.30m),
+				("High-Quality Tools", 0.15m)
+			]
+		};
 
     private static readonly IReadOnlyList<EraDefinition> EraDefinitions =
     [
@@ -1653,12 +1731,15 @@ It is intended to be additive across eras and safe to rerun to restore or refres
                 continue;
             }
 
-            MarketCategory category = result[tag.Id];
-            category.Description =
-                $"{CategoryPrefix}: seeded aggregate {tag.Name} basket priced as an equal-weight combination of {string.Join(", ", componentCategories.Select(x => x.Name))}.";
-            category.MarketCategoryType = 1;
-            category.CombinationCategories = SaveCombinationCategories(componentCategories.Select(x => x.Id));
-        }
+			IReadOnlyList<(MarketCategory Category, decimal Weight)> weightedComponents =
+				GetStockCombinationComponents(tag.Name, componentCategories);
+
+			MarketCategory category = result[tag.Id];
+			category.Description =
+				$"{CategoryPrefix}: seeded aggregate {tag.Name} basket priced as a weighted combination of {DescribeCombinationComponents(weightedComponents)}.";
+			category.MarketCategoryType = 1;
+			category.CombinationCategories = SaveCombinationCategories(weightedComponents);
+		}
 
         return result;
     }
@@ -2370,13 +2451,57 @@ It is intended to be additive across eras and safe to rerun to restore or refres
                 new XAttribute("expenditure", need.BaseExpenditure.ToString(CultureInfo.InvariantCulture))))).ToString();
     }
 
-    private static string SaveCombinationCategories(IEnumerable<long> categoryIds)
-    {
-        return new XElement("Components",
-            categoryIds.Select(categoryId => new XElement("Component",
-                new XAttribute("category", categoryId),
-                new XAttribute("weight", 1.0m.ToString(CultureInfo.InvariantCulture))))).ToString();
-    }
+	private static IReadOnlyList<(MarketCategory Category, decimal Weight)> GetStockCombinationComponents(
+		string familyName,
+		IEnumerable<MarketCategory> componentCategories)
+	{
+		if (!StockCombinationCategoryWeights.TryGetValue(familyName, out IReadOnlyList<(string CategoryName, decimal Weight)>? definitions))
+		{
+			throw new InvalidOperationException($"No stock combination category weights are defined for {familyName}.");
+		}
+
+		Dictionary<string, MarketCategory> categoriesByName =
+			componentCategories.ToDictionary(x => x.Name, StringComparer.OrdinalIgnoreCase);
+		List<string> missingCategoryNames = definitions
+			.Select(x => x.CategoryName)
+			.Where(x => !categoriesByName.ContainsKey(x))
+			.OrderBy(x => x)
+			.ToList();
+		if (missingCategoryNames.Any())
+		{
+			throw new InvalidOperationException(
+				$"The stock combination category {familyName} is missing weighted child categories: {missingCategoryNames.ListToString()}.");
+		}
+
+		List<string> unexpectedCategoryNames = categoriesByName.Keys
+			.Where(x => definitions.All(y => !y.CategoryName.Equals(x, StringComparison.OrdinalIgnoreCase)))
+			.OrderBy(x => x)
+			.ToList();
+		if (unexpectedCategoryNames.Any())
+		{
+			throw new InvalidOperationException(
+				$"The stock combination category {familyName} has no seeded weights for direct child categories: {unexpectedCategoryNames.ListToString()}.");
+		}
+
+		return definitions
+			.Select(x => (Category: categoriesByName[x.CategoryName], Weight: x.Weight))
+			.ToList();
+	}
+
+	private static string DescribeCombinationComponents(IEnumerable<(MarketCategory Category, decimal Weight)> components)
+	{
+		return components
+			.Select(x => $"{x.Category.Name} ({x.Weight.ToString("P0", CultureInfo.InvariantCulture)})")
+			.ListToString();
+	}
+
+	private static string SaveCombinationCategories(IEnumerable<(MarketCategory Category, decimal Weight)> components)
+	{
+		return new XElement("Components",
+			components.Select(component => new XElement("Component",
+				new XAttribute("category", component.Category.Id),
+				new XAttribute("weight", component.Weight.ToString(CultureInfo.InvariantCulture))))).ToString();
+	}
 
     private static string SaveStressPoints(IEnumerable<StressPointValue> stressPoints)
     {

--- a/Design Documents/Economy_System_Runtime.md
+++ b/Design Documents/Economy_System_Runtime.md
@@ -391,7 +391,7 @@ Verified current active behavior:
 - standalone categories still calculate supply, demand, and flat-price pressure directly from active influences
 - combination categories now read cached per-market weighted averages of their constituent categories rather than recursively querying live child prices on every access
 - item market pricing still selects the highest applicable category multiplier, and combination categories participate in that same max-selection logic when their tags match an item
-- the stock seeder now demonstrates this with family-level combination categories such as `Medicine`, `Writing Materials`, `Clothing`, `Household Goods`, `Hospitality`, `Entertainment`, `Personal Services`, `Communications`, `Military Goods`, and `Professional Tools`, while leaving more world-specific baskets such as `Nourishment` for builders to tune themselves
+- the stock seeder now demonstrates this with family-level combination categories such as `Medicine`, `Writing Materials`, `Clothing`, `Intoxicants`, `Household Goods`, `Hospitality`, `Entertainment`, `Personal Services`, `Communications`, `Military Goods`, and `Professional Tools`, using non-equal stock weights that lean toward common or standard child categories while leaving more world-specific baskets such as `Nourishment` for builders to tune themselves
 - a population's effective income factor is now `(base income factor + additive impacts) * multiplicative impacts`, clamped to zero or above
 - population savings and savings caps are stored as budget-cycle multiples rather than literal time spans
 

--- a/Design Documents/Economy_System_Seeder_State_and_Gaps.md
+++ b/Design Documents/Economy_System_Seeder_State_and_Gaps.md
@@ -30,7 +30,7 @@ The current repository has two dedicated economy seeders:
 - a new stock `EconomicZone` shell tied to a chosen currency and physical zone
 - a stock market attached to that zone
 - market categories for every seeded tag beneath the `UsefulSeeder` `Market` tag root, including intermediate and leaf tags such as later-era communications (`Postal Services`, `Printed News`) and personal-service (`Barbering`, `Laundry Services`) needs
-- stock combination-category examples for setting-agnostic family baskets such as `Medicine`, `Writing Materials`, `Clothing`, `Household Goods`, `Hospitality`, `Entertainment`, `Personal Services`, `Communications`, `Military Goods`, and `Professional Tools`, each seeded as an equal-weight roll-up of its direct child categories
+- stock combination-category examples for setting-agnostic family baskets such as `Medicine`, `Writing Materials`, `Clothing`, `Intoxicants`, `Household Goods`, `Hospitality`, `Entertainment`, `Personal Services`, `Communications`, `Military Goods`, and `Professional Tools`, each seeded as a deterministic non-equal roll-up of its direct child categories with heavier emphasis on common or standard goods
 - a reusable library of external market influence templates grouped by sector family, with substantially broader positive and negative scenario coverage than the first pass
 - per-category tariff and subsidy templates for all seeded market categories, using flat percentage price pressure rather than supply or demand pressure
 - dedicated income-focused influence templates for each seeded era, covering wage squeezes, hiring booms, credit crunches, patronage windfalls, and similar household-income shocks
@@ -166,7 +166,7 @@ The market and shopper subsystems are also good seeder targets because they are 
 Feasible seed content:
 
 - broad food, seasonings, medicine, writing-material, luxury, industrial, military, logistics, and raw-material categories
-- seeded combination categories for the more setting-agnostic family groups, plus standalone parent categories where the stock seeder deliberately avoids imposing a world-specific basket definition
+- seeded combination categories for the more setting-agnostic family groups, using stock weights that bias toward practical or common child categories, plus standalone parent categories where the stock seeder deliberately avoids imposing a world-specific basket definition
 - event-style influence templates such as harvest failure, bumper harvest, embargo, caravan surplus, piracy, mining trouble, and war mobilisation
 - price-only adjustment templates such as tariffs, duties, and subsidies that should act as flat percentage pressure on final price
 - income-focused templates that target specific household archetypes without changing supply or demand

--- a/Design Documents/Economy_System_Workflows_and_Integration.md
+++ b/Design Documents/Economy_System_Workflows_and_Integration.md
@@ -34,7 +34,7 @@ Most economy content is authored as world data, not hard-coded content. The engi
 The current stock seeder path now covers two useful starting points:
 
 - `CurrencySeeder` for currencies, divisions, coins, and parsing/description patterns
-- `EconomySeeder` for a template economic zone shell, one market, market categories derived from `UsefulSeeder` market tags, seeded combination-category examples for setting-agnostic family baskets, stock influence templates, broader era-specific populations including priestly and monastic households, and matching `SimpleShopper` records
+- `EconomySeeder` for a template economic zone shell, one market, market categories derived from `UsefulSeeder` market tags, seeded weighted combination-category examples for setting-agnostic family baskets, stock influence templates, broader era-specific populations including priestly and monastic households, and matching `SimpleShopper` records
 
 ## Minimum Viable Economy Setup
 The current runtime supports a lot of optional depth, but the minimum viable path is smaller.
@@ -160,7 +160,7 @@ Practical note on the stock seeder package:
 - market influence templates and live influences can now express both flat percentage price pressure and direct income pressure on named populations
 - combination categories let builders create higher-level sectors such as staple foods or luxury baskets without duplicating direct pricing data on the aggregate category itself
 - combination-targeted influences are applied to the constituent standalone categories in normalized proportion, so builders can target a broad basket while still moving the underlying goods
-- the stock seeder now uses that pattern directly for family categories such as `Medicine`, `Writing Materials`, `Clothing`, `Household Goods`, `Hospitality`, `Entertainment`, `Personal Services`, `Communications`, `Military Goods`, and `Professional Tools`
+- the stock seeder now uses that pattern directly for family categories such as `Medicine`, `Writing Materials`, `Clothing`, `Intoxicants`, `Household Goods`, `Hospitality`, `Entertainment`, `Personal Services`, `Communications`, `Military Goods`, and `Professional Tools`, with stock weights biased toward common or standard goods rather than treating every child category equally
 - seeded sector-wide external and stress templates now target either those aggregate family categories or the remaining standalone families, so builders can inspect working examples of combination-aware influence authoring
 - tariff and subsidy style templates now model flat percentage price adjustments rather than trying to fake those effects through supply or demand alone
 - the seeded populations assume medicine is a universal household need and now use seasonings tags such as `Salt` and `Spices`, writing-material tags such as `Wax Tablets`, `Parchment`, `Paper`, and `Ink`, plus hospitality / entertainment / communications / personal-service tags in later eras where appropriate


### PR DESCRIPTION
## Summary
- Replace equal-weight stock combination categories with explicit non-equal weights in `EconomySeeder`
- Update economy seeder tests to assert the seeded component weights and prevent regressions back to uniform weights
- Refresh the economy design docs to describe the weighted stock baskets and the added `Intoxicants` family example

## Testing
- `dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-build --filter "ClassName=MudSharp_Unit_Tests.EconomySeederTests"`
- Full `DatabaseSeeder Unit Tests` run still has one unrelated existing failure in `BlankDatabaseSnapshotTests` around the latest migration manifest