### PR TITLE
Remove package warnings and update MailKit

### DIFF
--- a/DiscordBotCore/DiscordBotCore.csproj
+++ b/DiscordBotCore/DiscordBotCore.csproj
@@ -23,7 +23,6 @@
 	<PackageReference Include="Serilog" Version="4.1.0" />
 	<PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
 	<PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-	<PackageReference Include="System.Net.Security" Version="4.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MudSharp Benchmarks/MudSharp Benchmarks.csproj
+++ b/MudSharp Benchmarks/MudSharp Benchmarks.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageReference Include="BenchmarkDotNet.Annotations" Version="0.15.8" />
-    <PackageReference Include="System.Memory" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MudSharpCore Unit Tests/MudSharpCore Unit Tests.csproj
+++ b/MudSharpCore Unit Tests/MudSharpCore Unit Tests.csproj
@@ -8,7 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Anthropic.SDK" Version="5.8.0" />
-		<PackageReference Include="MailKit" Version="4.14.1" />
+		<PackageReference Include="MailKit" Version="4.16.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 		<PackageReference Include="Moq" Version="4.20.70" />
 		<PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />

--- a/MudSharpCore/MudSharpCore.csproj
+++ b/MudSharpCore/MudSharpCore.csproj
@@ -24,7 +24,7 @@
 	<PackageReference Include="Google.Apis.Drive.v3" Version="1.73.0.3996" />
 	<PackageReference Include="Google.Apis.Oauth2.v2" Version="1.68.0.1869" />
 	<PackageReference Include="Humanizer" Version="3.0.1" />
-	<PackageReference Include="MailKit" Version="4.14.1" />
+	<PackageReference Include="MailKit" Version="4.16.0" />
 	<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.11">
 	  <PrivateAssets>all</PrivateAssets>
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/RPI Engine Worldfile Converter/RPI Engine Worldfile Converter.csproj
+++ b/RPI Engine Worldfile Converter/RPI Engine Worldfile Converter.csproj
@@ -10,9 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Anthropic.SDK" Version="5.8.0" />
-    <PackageReference Include="MailKit" Version="4.14.1" />
-    <PackageReference Include="System.Memory" Version="4.6.0" />
-    <PackageReference Include="System.Text.Json" Version="10.0.1" />
+    <PackageReference Include="MailKit" Version="4.16.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Terrain Planner Blazor WASM/Terrain Planner Blazor WASM.csproj
+++ b/Terrain Planner Blazor WASM/Terrain Planner Blazor WASM.csproj
@@ -11,8 +11,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
-    <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
-    <PackageReference Include="System.Text.Json" Version="10.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Terrain Planner Core/Terrain Planner Core.csproj
+++ b/Terrain Planner Core/Terrain Planner Core.csproj
@@ -19,9 +19,6 @@
     <PackageReference Include="MySql.Data">
       <Version>9.3.0</Version>
     </PackageReference>
-    <PackageReference Include="System.Text.Json">
-      <Version>10.0.1</Version>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/TerrainEditorBlazor/TerrainEditorBlazor.csproj
+++ b/TerrainEditorBlazor/TerrainEditorBlazor.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Removed redundant framework package references that triggered `NU1510` prune warnings.
- Updated `MailKit` to `4.16.0` in the core, test, and converter projects to clear the known vulnerability warnings.

## Testing
- `dotnet restore MudSharp.sln -m:1 -p:RestoreBuildInParallel=false`
- `dotnet build MudSharpCore/MudSharpCore.csproj -c Debug --no-restore -m:1`
- `dotnet build MudSharpCore Unit Tests/MudSharpCore Unit Tests.csproj -c Debug --no-restore -m:1`
- `dotnet build RPI Engine Worldfile Converter/RPI Engine Worldfile Converter.csproj -c Debug --no-restore -m:1`
- `dotnet build DiscordBotCore/DiscordBotCore.csproj -c Debug --no-restore -m:1`
- `dotnet build TerrainEditorBlazor/TerrainEditorBlazor.csproj -c Debug --no-restore -m:1`
- `dotnet build Terrain Planner Core/Terrain Planner Core.csproj -c Debug --no-restore -m:1`
- `dotnet build MudSharp Benchmarks/MudSharp Benchmarks.csproj -c Debug --no-restore -m:1`
- `dotnet build Terrain Planner Blazor WASM/Terrain Planner Blazor WASM.csproj -c Debug --no-restore -m:1` (failed due to an MSBuild WebAssembly task-host issue, unrelated to the package changes)