### PR TITLE
Update seeded animal and robot race defaults

### DIFF
--- a/DatabaseSeeder Unit Tests/AnimalSeederTemplateTests.cs
+++ b/DatabaseSeeder Unit Tests/AnimalSeederTemplateTests.cs
@@ -419,6 +419,15 @@ public class AnimalSeederTemplateTests
     }
 
     [TestMethod]
+    public void AvianCoreWingAliasesForTesting_BirdsRequireBothWingRootsAndFlightSurfaces()
+    {
+        CollectionAssert.AreEquivalent(
+            new[] { "rwingbase", "lwingbase", "rwing", "lwing" },
+            AnimalSeeder.AvianCoreWingAliasesForTesting.ToArray(),
+            "Avian stock bodies should treat both wing roots and both wings as mandatory core anatomy.");
+    }
+
+    [TestMethod]
     public void VenomProfilesForTesting_SeededProfiles_HaveExpectedEffects()
     {
         AnimalSeeder.AnimalVenomProfileTemplate neurotoxic = AnimalSeeder.VenomProfilesForTesting["neurotoxic"];

--- a/DatabaseSeeder Unit Tests/MythicalAnimalSeederTemplateTests.cs
+++ b/DatabaseSeeder Unit Tests/MythicalAnimalSeederTemplateTests.cs
@@ -612,6 +612,38 @@ public class MythicalAnimalSeederTemplateTests
     }
 
     [TestMethod]
+    public void BreathingProfileNameForTesting_KeyMythicFamilies_UseExpectedModels()
+    {
+        Assert.AreEqual("simple-air", MythicalAnimalSeeder.GetBreathingProfileNameForTesting("Dragon"));
+        Assert.AreEqual("marine-amphibious", MythicalAnimalSeeder.GetBreathingProfileNameForTesting("Mermaid"));
+        Assert.AreEqual("marine-amphibious", MythicalAnimalSeeder.GetBreathingProfileNameForTesting("Hippocamp"));
+        Assert.AreEqual("partless-air", MythicalAnimalSeeder.GetBreathingProfileNameForTesting("Giant Spider"));
+        Assert.AreEqual("partless-air", MythicalAnimalSeeder.GetBreathingProfileNameForTesting("Ent"));
+        Assert.AreEqual("partless-air", MythicalAnimalSeeder.GetBreathingProfileNameForTesting("Dryad"));
+    }
+
+    [TestMethod]
+    public void HybridMovementAliasesForTesting_KeyBodies_ExposeExpectedTraversalModes()
+    {
+        CollectionAssert.AreEquivalent(
+            new[] { "slither", "slowslither", "quickslither" },
+            MythicalAnimalSeeder.GetHybridMovementAliasesForTesting("Naga").ToArray(),
+            "Naga should expose serpentine travel speeds.");
+        CollectionAssert.AreEquivalent(
+            new[] { "flop" },
+            MythicalAnimalSeeder.GetHybridMovementAliasesForTesting("Mermaid").ToArray(),
+            "Merfolk should keep a land fallback movement mode in addition to swimming.");
+        CollectionAssert.AreEquivalent(
+            new[] { "stalk", "amble", "pace", "trot", "gallop" },
+            MythicalAnimalSeeder.GetHybridMovementAliasesForTesting("Centaur").ToArray(),
+            "Centaurs should inherit quadruped gait options rather than only humanoid walking verbs.");
+        CollectionAssert.AreEquivalent(
+            new[] { "slowfly", "fly", "franticfly" },
+            MythicalAnimalSeeder.GetHybridMovementAliasesForTesting("Eastern Dragon").ToArray(),
+            "Eastern dragons should retain a dedicated flight profile even without physical wings.");
+    }
+
+    [TestMethod]
     public void TemplatesForTesting_LegacyFantasyRaces_KeepExpectedSapienceAndCharacteristics()
     {
         MythicalAnimalSeeder.MythicalRaceTemplate myconid = MythicalAnimalSeeder.TemplatesForTesting["Myconid"];

--- a/DatabaseSeeder Unit Tests/RobotSeederTemplateTests.cs
+++ b/DatabaseSeeder Unit Tests/RobotSeederTemplateTests.cs
@@ -263,6 +263,13 @@ public class RobotSeederTemplateTests
     }
 
     [TestMethod]
+    public void NonBreathingModelForTesting_RobotsUseExplicitNonBreatherStrategy()
+    {
+        Assert.AreEqual("non-breather", RobotSeeder.NonBreathingModelForTesting,
+            "Robot races should persist the dedicated non-breather model rather than a placeholder lung-breather string.");
+    }
+
+    [TestMethod]
     public void CustomLimbMembershipsForTesting_DerivedRobotBodies_MapExpectedAssemblies()
     {
         CollectionAssert.AreEquivalent(

--- a/DatabaseSeeder/Seeders/AnimalSeeder.Backfill.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.Backfill.cs
@@ -46,6 +46,7 @@ public partial class AnimalSeeder
 	{
 		SetupHeightWeightModels();
 		SetupAttacks(false);
+		RefreshExistingAnimalBaseBodies();
 
 		Dictionary<string, BodyProto> bodyLookup = EnsureBackfillAnimalBodies();
 		MigrateBeetleRace(bodyLookup["Beetle"]);
@@ -59,6 +60,34 @@ public partial class AnimalSeeder
 		}
 
 		ApplyDefaultCombatSettingsToSeededRaces();
+	}
+
+	private void RefreshExistingAnimalBaseBodies()
+	{
+		BodyProto? avianBody = _context.BodyProtos.FirstOrDefault(x => x.Name == "Avian");
+		if (avianBody is null)
+		{
+			return;
+		}
+
+		bool dirty = false;
+		foreach (BodypartProto bodypart in _context.BodypartProtos
+			         .Where(x => x.BodyId == avianBody.Id && AvianCoreWingAliases.Contains(x.Name))
+			         .ToList())
+		{
+			if (bodypart.IsCore)
+			{
+				continue;
+			}
+
+			bodypart.IsCore = true;
+			dirty = true;
+		}
+
+		if (dirty)
+		{
+			_context.SaveChanges();
+		}
 	}
 
 	private Dictionary<string, BodyProto> EnsureBackfillAnimalBodies()

--- a/DatabaseSeeder/Seeders/AnimalSeeder.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.cs
@@ -48,6 +48,13 @@ public partial class AnimalSeeder : IDatabaseSeeder
         new(StringComparer.OrdinalIgnoreCase);
 
     private readonly List<Liquid> _freshWaters = new();
+    private static readonly string[] AvianCoreWingAliases =
+    [
+        "rwingbase",
+        "lwingbase",
+        "rwing",
+        "lwing"
+    ];
 
     private readonly Dictionary<string, HeightWeightModel> _hwModels = new(StringComparer.OrdinalIgnoreCase);
 
@@ -78,6 +85,8 @@ public partial class AnimalSeeder : IDatabaseSeeder
 	private readonly Stopwatch _stopwatch = new();
 	private TraitDefinition _strengthTrait;
 	private Liquid _sweatLiquid;
+
+    internal static IReadOnlyList<string> AvianCoreWingAliasesForTesting => AvianCoreWingAliases;
 
 	private static readonly string[] AnimalMinorSeverKeywords =
 	[
@@ -258,6 +267,7 @@ public partial class AnimalSeeder : IDatabaseSeeder
                 .Where(x => x.Type == 1)
                 .AsEnumerable()
                 .First(x => x.Name.In("Strength", "Physique", "Body", "Upper Body Strength"));
+            RefreshExistingAnimalBaseBodies();
             bool hasMissingCatalogue = HasMissingAnimalCatalogue(_context);
             RefreshExistingAnimalCombatBalance();
 

--- a/DatabaseSeeder/Seeders/AnimalSeederBirds.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeederBirds.cs
@@ -188,16 +188,16 @@ public partial class AnimalSeeder
 
         AddBodypart(avianProto, "rwingbase", "right wing base", "wing base", BodypartTypeEnum.BonyDrapeable, "uback",
             Alignment.FrontRight, Orientation.High, 40, -1, 100, order++, "Flesh", SizeCategory.Normal,
-            "Right Wing", true, isCore: false);
+            "Right Wing", true, isCore: true);
         AddBodypart(avianProto, "lwingbase", "left wing base", "wing base", BodypartTypeEnum.BonyDrapeable, "uback",
             Alignment.FrontLeft, Orientation.High, 40, -1, 100, order++, "Flesh", SizeCategory.Normal, "Left Wing",
-            true, isCore: false);
+            true, isCore: true);
         AddBodypart(avianProto, "rwing", "right wing", "wing", BodypartTypeEnum.Wing, "rwingbase",
             Alignment.FrontRight, Orientation.High, 40, 50, 100, order++, "Flesh", SizeCategory.Normal,
-            "Right Wing", true, isCore: false);
+            "Right Wing", true, isCore: true);
         AddBodypart(avianProto, "lwing", "left wing", "wing", BodypartTypeEnum.Wing, "lwingbase",
             Alignment.FrontLeft, Orientation.High, 40, 50, 100, order++, "Flesh", SizeCategory.Normal, "Left Wing",
-            true, isCore: false);
+            true, isCore: true);
 
         #endregion
 

--- a/DatabaseSeeder/Seeders/MythicalAnimalSeeder.cs
+++ b/DatabaseSeeder/Seeders/MythicalAnimalSeeder.cs
@@ -79,6 +79,8 @@ public partial class MythicalAnimalSeeder : IDatabaseSeeder
     private CorpseModel _humanoidCorpse = null!;
     private CorpseModel _animalCorpse = null!;
     private Liquid _blood = null!;
+    private Liquid _saltWater = null!;
+    private Liquid _brackishWater = null!;
     private Liquid? _sweat;
     private Gas _breathableAir = null!;
     private PopulationBloodModel? _defaultPopulationBloodModel;
@@ -86,6 +88,13 @@ public partial class MythicalAnimalSeeder : IDatabaseSeeder
     private ArmourType? _humanoidNaturalArmour;
     private ArmourType? _animalNaturalArmour;
     private long _nextBodyProtoId;
+    private static readonly string[] WingAliases =
+    [
+        "rwingbase",
+        "lwingbase",
+        "rwing",
+        "lwing"
+    ];
 
     public IEnumerable<(string Id, string Question,
         Func<FuturemudDatabaseContext, IReadOnlyDictionary<string, string>, bool> Filter,
@@ -110,20 +119,21 @@ public partial class MythicalAnimalSeeder : IDatabaseSeeder
         List<MythicalRaceTemplate> templatesToSeed = Templates.Values
             .Where(template => !_context.Races.Any(x => x.Name == template.Name))
             .ToList();
+        Dictionary<string, BodyProto> bodyLookup = BuildBodyCatalogue(Templates.Values);
+        RefreshExistingMythicalRaceDefaults();
         if (templatesToSeed.Count == 0 && !hasMissingDisfigurementTemplates)
         {
             RefreshExistingMythicalCombatBalance();
             _context.Database.CommitTransaction();
-            return "Mythical races are already installed and their combat balance profile has been refreshed.";
+            return "Mythical races are already installed and their breathing, mobility, and combat balance profiles have been refreshed.";
         }
-
-        Dictionary<string, BodyProto> bodyLookup = BuildBodyCatalogue(Templates.Values);
 
         foreach (MythicalRaceTemplate template in templatesToSeed)
         {
             SeedRace(template, bodyLookup[template.BodyKey]);
         }
 
+        RefreshExistingMythicalRaceDefaults();
         SeedMythicalDisfigurementTemplates(bodyLookup);
         RefreshExistingMythicalCombatBalance();
         _context.SaveChanges();
@@ -240,6 +250,8 @@ public partial class MythicalAnimalSeeder : IDatabaseSeeder
         _humanoidCorpse = _context.CorpseModels.First(x => x.Name == "Organic Human Corpse");
         _animalCorpse = _context.CorpseModels.First(x => x.Name == "Organic Animal Corpse");
         _blood = _context.Liquids.First(x => x.Name == "blood");
+        _saltWater = _context.Liquids.First(x => x.Name == "salt water");
+        _brackishWater = _context.Liquids.First(x => x.Name == "brackish water");
         _sweat = _context.Liquids.FirstOrDefault(x => x.Name == "sweat");
         _breathableAir = _context.Gases.AsEnumerable().First(x => x.Name.Contains("Breathable Atmosphere", StringComparison.OrdinalIgnoreCase));
         _defaultPopulationBloodModel = _humanRace.Ethnicities.FirstOrDefault()?.PopulationBloodModel ??
@@ -348,13 +360,8 @@ public partial class MythicalAnimalSeeder : IDatabaseSeeder
 
     private BodyProto GetOrCreateBody(string name, Func<BodyProto> factory)
     {
-        BodyProto? existingBody = _context.BodyProtos.FirstOrDefault(x => x.Name == name);
-        if (existingBody is not null)
-        {
-            return existingBody;
-        }
-
-        BodyProto body = factory();
+        BodyProto body = _context.BodyProtos.FirstOrDefault(x => x.Name == name) ?? factory();
+        RefreshCustomBodyCapabilities(body);
         RepairAndValidateCustomBody(body);
         return body;
     }
@@ -865,16 +872,199 @@ public partial class MythicalAnimalSeeder : IDatabaseSeeder
             .FirstOrDefault();
     }
 
+    private enum MythicalBreathingProfile
+    {
+        SimpleAir,
+        PartlessAir,
+        MarineAmphibious
+    }
+
+    private static MythicalBreathingProfile GetBreathingProfile(MythicalRaceTemplate template)
+    {
+        if (template.Name.EqualToAny("Mermaid", "Hippocamp"))
+        {
+            return MythicalBreathingProfile.MarineAmphibious;
+        }
+
+        if (template.Name.EqualToAny("Myconid", "Plantfolk", "Ent", "Dryad") ||
+            template.BodyKey.EqualToAny("Insectoid", "Arachnid", "Beetle", "Centipede", "Scorpion"))
+        {
+            return MythicalBreathingProfile.PartlessAir;
+        }
+
+        return MythicalBreathingProfile.SimpleAir;
+    }
+
+    internal static string GetBreathingProfileNameForTesting(string raceName)
+    {
+        return GetBreathingProfile(Templates[raceName]) switch
+        {
+            MythicalBreathingProfile.SimpleAir => "simple-air",
+            MythicalBreathingProfile.PartlessAir => "partless-air",
+            MythicalBreathingProfile.MarineAmphibious => "marine-amphibious",
+            _ => "simple-air"
+        };
+    }
+
+    internal static IReadOnlyList<string> GetHybridMovementAliasesForTesting(string bodyName)
+    {
+        return bodyName switch
+        {
+            "Naga" => ["slither", "slowslither", "quickslither"],
+            "Mermaid" => ["flop"],
+            "Centaur" => ["stalk", "amble", "pace", "trot", "gallop"],
+            "Eastern Dragon" => ["slowfly", "fly", "franticfly"],
+            _ => []
+        };
+    }
+
+    private void RefreshCustomBodyCapabilities(BodyProto body)
+    {
+        switch (body.Name)
+        {
+            case "Winged Humanoid":
+                PromoteCoreBodyparts(body, WingAliases);
+                AddFlyMovement(body);
+                break;
+            case "Naga":
+                AddSerpentineMovement(body);
+                AddSwimMovement(body);
+                break;
+            case "Eastern Dragon":
+                body.MinimumWingsToFly = 0;
+                AddFlyMovement(body);
+                break;
+            case "Mermaid":
+                AddFishGroundMovement(body);
+                AddSwimMovement(body);
+                break;
+            case "Centaur":
+                AddQuadrupedMovement(body);
+                break;
+            case "Griffin":
+            case "Hippogriff":
+            case "Manticore":
+            case "Wyvern":
+                PromoteCoreBodyparts(body, WingAliases);
+                AddFlyMovement(body);
+                break;
+            case "Hippocamp":
+                AddSwimMovement(body);
+                break;
+        }
+    }
+
+    private void RefreshExistingMythicalRaceDefaults()
+    {
+        foreach (MythicalRaceTemplate template in Templates.Values)
+        {
+            Race? race = _context.Races.FirstOrDefault(x => x.Name == template.Name);
+            if (race is null)
+            {
+                continue;
+            }
+
+            race.CanClimb = template.CanClimb;
+            race.CanSwim = template.CanSwim;
+            race.MinimumSleepingPosition = 4;
+            ApplyBreathingProfile(race, GetBreathingProfile(template));
+        }
+
+        _context.SaveChanges();
+    }
+
+    private void ApplyBreathingProfile(Race race, MythicalBreathingProfile profile)
+    {
+        _context.RacesBreathableGases.RemoveRange(_context.RacesBreathableGases.Where(x => x.RaceId == race.Id).ToList());
+        _context.RacesBreathableLiquids.RemoveRange(_context.RacesBreathableLiquids.Where(x => x.RaceId == race.Id).ToList());
+
+        race.NeedsToBreathe = true;
+        race.BreathingVolumeExpression = "7";
+        race.HoldBreathLengthExpression = $"90+(5*con:{_healthTrait.Id})";
+
+        _context.RacesBreathableGases.Add(new RacesBreathableGases
+        {
+            Race = race,
+            Gas = _breathableAir,
+            Multiplier = 1.0
+        });
+
+        switch (profile)
+        {
+            case MythicalBreathingProfile.SimpleAir:
+                race.BreathingModel = "simple";
+                break;
+            case MythicalBreathingProfile.PartlessAir:
+                race.BreathingModel = "partless";
+                break;
+            case MythicalBreathingProfile.MarineAmphibious:
+                race.BreathingModel = "partless";
+                _context.RacesBreathableLiquids.Add(new RacesBreathableLiquids
+                {
+                    Race = race,
+                    Liquid = _saltWater,
+                    Multiplier = 1.0
+                });
+                _context.RacesBreathableLiquids.Add(new RacesBreathableLiquids
+                {
+                    Race = race,
+                    Liquid = _brackishWater,
+                    Multiplier = 0.5
+                });
+                break;
+        }
+    }
+
+    private void PromoteCoreBodyparts(BodyProto body, params string[] aliases)
+    {
+        bool dirty = false;
+        foreach (BodypartProto bodypart in _context.BodypartProtos
+                     .Where(x => x.BodyId == body.Id && aliases.Contains(x.Name))
+                     .ToList())
+        {
+            if (bodypart.IsCore)
+            {
+                continue;
+            }
+
+            bodypart.IsCore = true;
+            dirty = true;
+        }
+
+        if (dirty)
+        {
+            _context.SaveChanges();
+        }
+    }
+
     private void AddFlyMovement(BodyProto body)
     {
         EnsurePosition(body, 18);
-        CloneSpeedAliases(_avianBody, body, "fly", "franticfly");
+        CloneSpeedAliases(_avianBody, body, "slowfly", "fly", "franticfly");
     }
 
     private void AddSwimMovement(BodyProto body)
     {
         EnsurePosition(body, 16);
         CloneSpeedAliases(_piscineBody, body, "swim", "slowswim", "quickswim");
+    }
+
+    private void AddFishGroundMovement(BodyProto body)
+    {
+        EnsurePosition(body, 6);
+        CloneSpeedAliases(_piscineBody, body, "flop");
+    }
+
+    private void AddSerpentineMovement(BodyProto body)
+    {
+        EnsurePosition(body, 1);
+        CloneSpeedAliasesToPosition(_serpentineBody, body, 1, "slither", "slowslither", "quickslither");
+    }
+
+    private void AddQuadrupedMovement(BodyProto body)
+    {
+        EnsurePosition(body, 1);
+        CloneSpeedAliases(_quadrupedBody, body, "stalk", "amble", "pace", "trot", "gallop");
     }
 
     private void EnsurePosition(BodyProto body, int positionId)
@@ -893,6 +1083,12 @@ public partial class MythicalAnimalSeeder : IDatabaseSeeder
     }
 
     private void CloneSpeedAliases(BodyProto source, BodyProto target, params string[] aliases)
+    {
+        CloneSpeedAliasesToPosition(source, target, null, aliases);
+    }
+
+    private void CloneSpeedAliasesToPosition(BodyProto source, BodyProto target, int? positionIdOverride,
+        params string[] aliases)
     {
         HashSet<string> existingAliases = _context.MoveSpeeds
             .Where(x => x.BodyProtoId == target.Id)
@@ -914,7 +1110,7 @@ public partial class MythicalAnimalSeeder : IDatabaseSeeder
             {
                 Id = nextId++,
                 BodyProto = target,
-                PositionId = speed.PositionId,
+                PositionId = positionIdOverride ?? speed.PositionId,
                 Alias = speed.Alias,
                 FirstPersonVerb = speed.FirstPersonVerb,
                 ThirdPersonVerb = speed.ThirdPersonVerb,
@@ -1005,13 +1201,7 @@ public partial class MythicalAnimalSeeder : IDatabaseSeeder
                 IsHealthAttribute = attribute.TraitGroup == "Physical"
             });
         }
-
-        _context.RacesBreathableGases.Add(new RacesBreathableGases
-        {
-            Race = race,
-            Gas = _breathableAir,
-            Multiplier = 1.0
-        });
+        ApplyBreathingProfile(race, GetBreathingProfile(template));
 
         Ethnicity ethnicity = SeedEthnicity(race, template);
         SeedAdditionalCharacteristics(race, ethnicity, template);

--- a/DatabaseSeeder/Seeders/RobotSeeder.Races.cs
+++ b/DatabaseSeeder/Seeders/RobotSeeder.Races.cs
@@ -91,7 +91,7 @@ public partial class RobotSeeder
                     CanDefend = true,
 					NaturalArmourType = _robotFrameArmour,
 					NaturalArmourMaterial = _chassisAlloy,
-					NaturalArmourQuality = 4,
+                    NaturalArmourQuality = 4,
                     BloodLiquid = _context.Liquids.First(x => x.Name == template.BloodLiquidName),
                     NeedsToBreathe = false,
                     SweatLiquid = null,
@@ -114,7 +114,7 @@ public partial class RobotSeeder
                     TemperatureRangeCeiling = 120,
                     BodypartSizeModifier = 0,
                     BodypartHealthMultiplier = ResolveRobotHealthMultiplier(template.Size, 1.15),
-                    BreathingModel = "simple",
+                    BreathingModel = NonBreatherBreathingModel,
                     BreathingVolumeExpression = "0",
                     HoldBreathLengthExpression = "999999",
                     CanClimb = template.CanClimb,
@@ -141,23 +141,26 @@ public partial class RobotSeeder
                 _context.SaveChanges();
                 summary.RacesAdded++;
             }
-			else
-			{
-				CharacterCombatSetting defaultCombatSetting = CombatStrategySeederHelper.EnsureCombatStrategy(_context, CombatStrategyFor(template));
-				if (race.DefaultCombatSettingId != defaultCombatSetting.Id)
-				{
-					race.DefaultCombatSetting = defaultCombatSetting;
-				}
+            else
+            {
+                CharacterCombatSetting defaultCombatSetting =
+                    CombatStrategySeederHelper.EnsureCombatStrategy(_context, CombatStrategyFor(template));
+                if (race.DefaultCombatSettingId != defaultCombatSetting.Id)
+                {
+                    race.DefaultCombatSetting = defaultCombatSetting;
+                }
 
-				if (race.NaturalArmourTypeId != _robotFrameArmour.Id)
-				{
-					race.NaturalArmourType = _robotFrameArmour;
-				}
+                if (race.NaturalArmourTypeId != _robotFrameArmour.Id)
+                {
+                    race.NaturalArmourType = _robotFrameArmour;
+                }
 
-				race.NaturalArmourMaterial = _chassisAlloy;
-				race.NaturalArmourQuality = 4;
-				race.BodypartHealthMultiplier = ResolveRobotHealthMultiplier(template.Size, 1.15);
-			}
+                race.NaturalArmourMaterial = _chassisAlloy;
+                race.NaturalArmourQuality = 4;
+                race.BodypartHealthMultiplier = ResolveRobotHealthMultiplier(template.Size, 1.15);
+            }
+
+            ApplyNonBreatherSettings(race);
 
             CopyRaceAttributes(race);
             if (template.UsesHumanoidCharacteristics)
@@ -174,6 +177,17 @@ public partial class RobotSeeder
             SeedRacialBodypartUsages(race, template);
             SeedNaturalAttacks(race, template);
         }
+    }
+
+    private void ApplyNonBreatherSettings(Race race)
+    {
+        race.NeedsToBreathe = false;
+        race.BreathingModel = NonBreatherBreathingModel;
+        race.BreathingVolumeExpression = "0";
+        race.HoldBreathLengthExpression = "999999";
+
+        _context.RacesBreathableGases.RemoveRange(_context.RacesBreathableGases.Where(x => x.RaceId == race.Id).ToList());
+        _context.RacesBreathableLiquids.RemoveRange(_context.RacesBreathableLiquids.Where(x => x.RaceId == race.Id).ToList());
     }
 
     private void CopyRaceAttributes(Race race)

--- a/DatabaseSeeder/Seeders/RobotSeeder.cs
+++ b/DatabaseSeeder/Seeders/RobotSeeder.cs
@@ -44,6 +44,7 @@ public partial class RobotSeeder : IDatabaseSeeder
         "Winged Robot",
         "Jet Robot"
     };
+    private const string NonBreatherBreathingModel = "non-breather";
 
     private readonly Dictionary<string, Tag> _tags = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, MudSharp.Models.Knowledge> _knowledges = new(StringComparer.OrdinalIgnoreCase);
@@ -81,6 +82,8 @@ public partial class RobotSeeder : IDatabaseSeeder
     private FutureProg _robotStaminaRecoveryProg = null!;
     private HealthStrategy _robotArticulatedStrategy = null!;
     private HealthStrategy _robotUtilityStrategy = null!;
+
+    internal static string NonBreathingModelForTesting => NonBreatherBreathingModel;
 
     private sealed class RobotSeedSummary
     {


### PR DESCRIPTION
## Summary
- Promote avian wing roots and wing surfaces to core anatomy in the animal seeder, including backfill refreshes for existing bodies
- Add mythical race breathing and movement profile refreshes for existing records, with dedicated traversal and amphibious breathing models
- Standardize robot races on the non-breather model and clear breathing metadata when reseeding existing races
- Expand unit coverage for the new seeder defaults and helper accessors

## Testing
- Added unit tests covering avian core wing aliases, mythical breathing and movement profiles, and the robot non-breather model
- Not run (not requested)