### PR TITLE
Expand UsefulSeeder item component coverage

### DIFF
--- a/DatabaseSeeder Unit Tests/UsefulSeederItemPackageTests.cs
+++ b/DatabaseSeeder Unit Tests/UsefulSeederItemPackageTests.cs
@@ -1,0 +1,194 @@
+#nullable enable
+
+using DatabaseSeeder;
+using DatabaseSeeder.Seeders;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Database;
+using MudSharp.Models;
+using System;
+using System.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class UsefulSeederItemPackageTests
+{
+	private static FuturemudDatabaseContext BuildContext()
+	{
+		DbContextOptions<FuturemudDatabaseContext> options = new DbContextOptionsBuilder<FuturemudDatabaseContext>()
+			.UseInMemoryDatabase(Guid.NewGuid().ToString())
+			.ConfigureWarnings(x => x.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+			.Options;
+		return new FuturemudDatabaseContext(options);
+	}
+
+	private static void SeedAccount(FuturemudDatabaseContext context)
+	{
+		context.Accounts.Add(new Account
+		{
+			Id = 1,
+			Name = "SeederTest",
+			Password = "password",
+			Salt = 1,
+			AccessStatus = 0,
+			Email = "seeder@example.com",
+			LastLoginIp = "127.0.0.1",
+			FormatLength = 80,
+			InnerFormatLength = 78,
+			UseMxp = false,
+			UseMsp = false,
+			UseMccp = false,
+			ActiveCharactersAllowed = 1,
+			UseUnicode = true,
+			TimeZoneId = "UTC",
+			CultureName = "en-AU",
+			RegistrationCode = string.Empty,
+			IsRegistered = true,
+			RecoveryCode = string.Empty,
+			UnitPreference = "metric",
+			CreationDate = DateTime.UtcNow,
+			PageLength = 22,
+			PromptType = 0,
+			TabRoomDescriptions = false,
+			CodedRoomDescriptionAdditionsOnNewLine = false,
+			CharacterNameOverlaySetting = 0,
+			AppendNewlinesBetweenMultipleEchoesPerPrompt = false,
+			ActLawfully = false,
+			HasBeenActiveInWeek = true,
+			HintsEnabled = true,
+			AutoReacquireTargets = false
+		});
+	}
+
+	private static void SeedGeneralPrerequisites(FuturemudDatabaseContext context)
+	{
+		SeedAccount(context);
+
+		context.Liquids.Add(new Liquid
+		{
+			Id = 1,
+			Name = "water",
+			Description = "water",
+			LongDescription = "water",
+			TasteText = "water",
+			VagueTasteText = "water",
+			SmellText = "water",
+			VagueSmellText = "water",
+			DisplayColour = "blue",
+			DampDescription = "water-damp",
+			WetDescription = "water-wet",
+			DrenchedDescription = "water-drenched",
+			DampShortDescription = "water-damp",
+			WetShortDescription = "water-wet",
+			DrenchedShortDescription = "water-drenched",
+			SurfaceReactionInfo = "water"
+		});
+
+		context.Clocks.Add(new Clock
+		{
+			Id = 1,
+			Definition = "<Clock />",
+			Seconds = 0,
+			Minutes = 0,
+			Hours = 12,
+			PrimaryTimezoneId = 1
+		});
+		context.Timezones.Add(new Timezone
+		{
+			Id = 1,
+			Name = "UTC",
+			Description = "Test timezone",
+			OffsetHours = 0,
+			OffsetMinutes = 0,
+			ClockId = 1
+		});
+
+		context.SaveChanges();
+	}
+
+	private static GameItemComponentProto CreateComponentMarker(long id, string name, string type = "Test")
+	{
+		return new GameItemComponentProto
+		{
+			Id = id,
+			Name = name,
+			Type = type,
+			Description = $"{name} marker",
+			Definition = "<Definition />",
+			RevisionNumber = 0,
+			EditableItem = new EditableItem
+			{
+				RevisionNumber = 0,
+				RevisionStatus = 4,
+				BuilderAccountId = 1,
+				BuilderDate = DateTime.UtcNow,
+				BuilderComment = "test",
+				ReviewerAccountId = 1,
+				ReviewerComment = "test",
+				ReviewerDate = DateTime.UtcNow
+			}
+		};
+	}
+
+	[TestMethod]
+	public void ClassifyItemPackagePresence_NonePartialAndFull_ReturnExpectedStates()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedGeneralPrerequisites(context);
+
+		Assert.AreEqual(ShouldSeedResult.ReadyToInstall, UsefulSeeder.ClassifyItemPackagePresence(context));
+
+		context.GameItemComponentProtos.Add(CreateComponentMarker(10, UsefulSeeder.StockItemMarkersForTesting.First()));
+		context.SaveChanges();
+		Assert.AreEqual(ShouldSeedResult.ExtraPackagesAvailable, UsefulSeeder.ClassifyItemPackagePresence(context));
+
+		context.GameItemComponentProtos.RemoveRange(context.GameItemComponentProtos.ToList());
+		long id = 20L;
+		foreach (string name in UsefulSeeder.StockItemMarkersForTesting)
+		{
+			context.GameItemComponentProtos.Add(CreateComponentMarker(id++, name));
+		}
+
+		context.SaveChanges();
+
+		Assert.AreEqual(ShouldSeedResult.MayAlreadyBeInstalled, UsefulSeeder.ClassifyItemPackagePresence(context));
+	}
+
+	[TestMethod]
+	public void SeedGeneralCoverageForTesting_RerunDoesNotDuplicateAndCreatesExpandedCoverage()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedGeneralPrerequisites(context);
+		UsefulSeeder seeder = new();
+
+		seeder.SeedGeneralCoverageForTesting(context);
+		seeder.SeedGeneralCoverageForTesting(context);
+
+		string[] expectedNames =
+		[
+			"Smokeable_Cigar",
+			"Smokeable_Cigarillo",
+			"Smokeable_PipeBowl",
+			"DragAid_Stretcher",
+			"DragAid_Sled",
+			"DragAid_Travois",
+			"Treatment_AntiInflammatory_Single",
+			"Treatment_AntiInflammatory_Kit",
+			"TimePiece_PocketWatch",
+			"TimePiece_WallClock"
+		];
+
+		foreach (string name in expectedNames)
+		{
+			Assert.AreEqual(1, context.GameItemComponentProtos.Count(x => x.Name == name), $"Expected a single general component named {name}.");
+		}
+
+		Assert.AreEqual(1, context.GameItemComponentProtos.Count(x => x.Name == "Cigarette"));
+		Assert.AreEqual(1, context.FutureProgs.Count(x => x.FunctionName == "OnSmokeCigarette"));
+		Assert.AreEqual(1, context.VariableDefinitions.Count(x => x.Property == "nicotineuntil"));
+		Assert.AreEqual(1, context.VariableDefaults.Count(x => x.Property == "nicotineuntil"));
+		Assert.AreEqual(0, context.GameItemComponentProtos.Count(x => x.Name.StartsWith("Food_")));
+	}
+}

--- a/DatabaseSeeder Unit Tests/UsefulSeederModernPackageTests.cs
+++ b/DatabaseSeeder Unit Tests/UsefulSeederModernPackageTests.cs
@@ -5,6 +5,7 @@ using DatabaseSeeder.Seeders;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Body;
 using MudSharp.Database;
 using MudSharp.Models;
 using System;
@@ -25,7 +26,7 @@ public class UsefulSeederModernPackageTests
         return new FuturemudDatabaseContext(options);
     }
 
-    private static void SeedModernPrerequisites(FuturemudDatabaseContext context)
+    private static void SeedAccount(FuturemudDatabaseContext context)
     {
         context.Accounts.Add(new Account
         {
@@ -61,12 +62,108 @@ public class UsefulSeederModernPackageTests
             HintsEnabled = true,
             AutoReacquireTargets = false
         });
+    }
 
-        context.StaticConfigurations.Add(new StaticConfiguration
+    private static void SeedModernStaticConfiguration(FuturemudDatabaseContext context)
+    {
+        context.StaticConfigurations.AddRange(
+            new StaticConfiguration
+            {
+                SettingName = "DefaultPowerSocketType",
+                Definition = "NEMA 5-15"
+            },
+            new StaticConfiguration
+            {
+                SettingName = "DefaultGasSocketType",
+                Definition = "BSP 5mm"
+            },
+            new StaticConfiguration
+            {
+                SettingName = "DefaultExternalOrganVenousConnector",
+                Definition = "2-LargeVenousCatheter"
+            },
+            new StaticConfiguration
+            {
+                SettingName = "DefaultExternalOrganArterialConnector",
+                Definition = "2-LargeArterialCatheter"
+            });
+    }
+
+    private static Gas CreateGas(long id, string name)
+    {
+        return new Gas
         {
-            SettingName = "DefaultPowerSocketType",
-            Definition = "NEMA 5-15"
-        });
+            Id = id,
+            Name = name,
+            Description = name,
+            Density = 1.0,
+            ThermalConductivity = 0.01,
+            ElectricalConductivity = 0.0,
+            Organic = false,
+            SpecificHeatCapacity = 1.0,
+            BoilingPoint = -100.0,
+            DisplayColour = "white",
+            SmellIntensity = 0.0,
+            SmellText = name,
+            VagueSmellText = name,
+            Viscosity = 0.0,
+            DrugGramsPerUnitVolume = 0.0,
+            OxidationFactor = 0.0
+        };
+    }
+
+	private static void SeedExternalOrganPrerequisites(FuturemudDatabaseContext context)
+	{
+		BodyProto body = new()
+		{
+			Id = 1,
+			Name = "Organic Humanoid",
+			ConsiderString = string.Empty,
+			LegDescriptionPlural = "legs",
+			LegDescriptionSingular = "leg",
+			WielderDescriptionPlural = "hands",
+			WielderDescriptionSingle = "hand",
+			NameForTracking = "Organic Humanoid"
+		};
+        context.BodyProtos.Add(body);
+        context.BodypartProtos.AddRange(
+            new BodypartProto
+            {
+                Id = 10,
+                Body = body,
+                BodyId = body.Id,
+                Name = "heart",
+                Description = "heart",
+                BodypartType = (int)BodypartTypeEnum.Heart,
+                IsOrgan = 1
+            },
+            new BodypartProto
+            {
+                Id = 11,
+                Body = body,
+                BodyId = body.Id,
+                Name = "lung",
+                Description = "lung",
+                BodypartType = (int)BodypartTypeEnum.Lung,
+                IsOrgan = 1
+            },
+            new BodypartProto
+            {
+                Id = 12,
+                Body = body,
+                BodyId = body.Id,
+                Name = "kidney",
+                Description = "kidney",
+                BodypartType = (int)BodypartTypeEnum.Kidney,
+                IsOrgan = 1
+            });
+    }
+
+    private static void SeedModernPrerequisites(FuturemudDatabaseContext context, bool includeGases = false,
+        bool includeExternalOrgans = false)
+    {
+        SeedAccount(context);
+        SeedModernStaticConfiguration(context);
 
         Tag fuelTag = new() { Id = 1, Name = "Fuel" };
         context.Tags.Add(fuelTag);
@@ -136,52 +233,26 @@ public class UsefulSeederModernPackageTests
 
         context.Liquids.AddRange(gasoline, kerosene, water);
         context.LiquidsTags.AddRange(gasolineTag, keroseneTag);
+
+        if (includeGases)
+        {
+            context.Gases.AddRange(
+                CreateGas(10, "Bronchodilator"),
+                CreateGas(11, "General Anaesthetic"));
+        }
+
+        if (includeExternalOrgans)
+        {
+            SeedExternalOrganPrerequisites(context);
+        }
+
         context.SaveChanges();
     }
 
     private static void SeedModernBaseContext(FuturemudDatabaseContext context)
     {
-        context.Accounts.Add(new Account
-        {
-            Id = 1,
-            Name = "SeederTest",
-            Password = "password",
-            Salt = 1,
-            AccessStatus = 0,
-            Email = "seeder@example.com",
-            LastLoginIp = "127.0.0.1",
-            FormatLength = 80,
-            InnerFormatLength = 78,
-            UseMxp = false,
-            UseMsp = false,
-            UseMccp = false,
-            ActiveCharactersAllowed = 1,
-            UseUnicode = true,
-            TimeZoneId = "UTC",
-            CultureName = "en-AU",
-            RegistrationCode = string.Empty,
-            IsRegistered = true,
-            RecoveryCode = string.Empty,
-            UnitPreference = "metric",
-            CreationDate = DateTime.UtcNow,
-            PageLength = 22,
-            PromptType = 0,
-            TabRoomDescriptions = false,
-            CodedRoomDescriptionAdditionsOnNewLine = false,
-            CharacterNameOverlaySetting = 0,
-            AppendNewlinesBetweenMultipleEchoesPerPrompt = false,
-            ActLawfully = false,
-            HasBeenActiveInWeek = true,
-            HintsEnabled = true,
-            AutoReacquireTargets = false
-        });
-
-        context.StaticConfigurations.Add(new StaticConfiguration
-        {
-            SettingName = "DefaultPowerSocketType",
-            Definition = "NEMA 5-15"
-        });
-
+        SeedAccount(context);
+        SeedModernStaticConfiguration(context);
         context.SaveChanges();
     }
 
@@ -236,10 +307,10 @@ public class UsefulSeederModernPackageTests
     }
 
     [TestMethod]
-    public void SeedModernItemsForTesting_RerunDoesNotDuplicateAndCreatesFuelGeneratorsForTaggedLiquids()
+    public void SeedModernItemsForTesting_RerunDoesNotDuplicateAndCreatesExpandedModernCoverage()
     {
         using FuturemudDatabaseContext context = BuildContext();
-        SeedModernPrerequisites(context);
+        SeedModernPrerequisites(context, includeGases: true, includeExternalOrgans: true);
         UsefulSeeder seeder = new();
 
         seeder.SeedModernItemsForTesting(context);
@@ -250,9 +321,76 @@ public class UsefulSeederModernPackageTests
             Assert.AreEqual(1, context.GameItemComponentProtos.Count(x => x.Name == name), $"Expected a single modern marker named {name}.");
         }
 
+        string[] additionalModernCoverage =
+        [
+            "Battery_LiIon_Pack",
+            "BatteryPowered_1xLiIon",
+            "BatteryPowered_2xLiIon",
+            "BatteryCharger_LiIon_Single",
+            "BatteryCharger_LiIon_Quad",
+            "ElectricGridOutlet_Single",
+            "ElectricGridOutlet_Quad",
+            "GridPowerSupply_HighDraw",
+            "UnlimitedGenerator_Admin",
+            "CellularPhone_Smartphone",
+            "CellPhoneTower_Local",
+            "CellPhoneTower_Regional",
+            "AnsweringMachine_Standard",
+            "Tape_Cassette30",
+            "Tape_Microcassette10",
+            "ComputerHost_Server",
+            "ComputerStorage_Portable",
+            "ComputerStorage_Fixed",
+            "ComputerTerminal_Desk",
+            "ComputerTerminal_Kiosk",
+            "NetworkAdapter_Wired",
+            "NetworkSwitch_4Port",
+            "NetworkSwitch_8Port",
+            "WirelessModem_Local",
+            "AutomationHousing_JunctionBox",
+            "AutomationMountHost_2Bay",
+            "AutomationMountHost_4Bay",
+            "FileSignalGenerator_Text",
+            "PushButton_Doorbell",
+            "ToggleSwitch_Wall",
+            "MotionSensor_Room",
+            "MotionSensor_Perimeter",
+            "LightSensor_Daylight",
+            "RainSensor_Outdoor",
+            "TemperatureSensor_Thermostat",
+            "TimerSensor_Repeating",
+            "Keypad_4Digit",
+            "Keypad_6Digit",
+            "SignalLight_Indicator",
+            "SignalLight_Beacon",
+            "RelaySwitch_Inline",
+            "AlarmSiren_Indoor",
+            "AlarmSiren_Outdoor",
+            "ElectronicDoor_AutoSlide",
+            "ElectronicLock_Maglock",
+            "Microcontroller_Basic",
+            "GasContainer_OxygenLarge",
+            "GasContainer_Anaesthetic",
+            "Rebreather_Standard",
+            "Rebreather_Watertight",
+            "ExternalInhaler_Medical",
+            "InhalerGasCanister_Bronchodilator",
+            "InhalerGasCanister_Anaesthetic",
+            "IntegratedInhaler_Emergency",
+            "Defibrillator_Clinical",
+            "ExternalOrgan_HeartLungSupport_Human",
+            "ExternalOrgan_Dialysis_Human"
+        ];
+
+        foreach (string name in additionalModernCoverage)
+        {
+            Assert.AreEqual(1, context.GameItemComponentProtos.Count(x => x.Name == name), $"Expected a single modern component named {name}.");
+        }
+
         Assert.AreEqual(1, context.GameItemComponentProtos.Count(x => x.Name == "FuelGenerator_gasoline"));
         Assert.AreEqual(1, context.GameItemComponentProtos.Count(x => x.Name == "FuelGenerator_kerosene"));
         Assert.AreEqual(0, context.GameItemComponentProtos.Count(x => x.Name == "FuelGenerator_water"));
+        Assert.AreEqual(0, context.GameItemComponentProtos.Count(x => x.Name.StartsWith("Food_")));
         Assert.AreEqual(2, context.GameItemComponentProtos.Count(x => x.Type == "Fuel Generator"));
         Assert.AreEqual(4, context.GameItemComponentProtos.Count(x => x.Type == "ElectricHeaterCooler"));
         Assert.AreEqual(3, context.GameItemComponentProtos.Count(x => x.Type == "ConsumableHeaterCooler"));
@@ -271,6 +409,11 @@ public class UsefulSeederModernPackageTests
         GameItemComponentProto fireplace = context.GameItemComponentProtos.Single(x => x.Name == "SolidFuelHeaterCooler_Fireplace");
         XElement fireplaceDefinition = XElement.Parse(fireplace.Definition);
         Assert.AreEqual("1", fireplaceDefinition.Element("FuelTag")?.Value);
+
+        GameItemComponentProto heartLungSupport = context.GameItemComponentProtos.Single(x => x.Name == "ExternalOrgan_HeartLungSupport_Human");
+        XElement heartLungDefinition = XElement.Parse(heartLungSupport.Definition);
+        Assert.AreEqual("1", heartLungDefinition.Element("Body")?.Value);
+        Assert.IsTrue((heartLungDefinition.Element("Organs")?.Elements("Organ").Count() ?? 0) >= 2);
     }
 
     [TestMethod]
@@ -288,5 +431,24 @@ public class UsefulSeederModernPackageTests
         context.SaveChanges();
 
         Assert.AreEqual(ShouldSeedResult.MayAlreadyBeInstalled, UsefulSeeder.ClassifyModernPackagePresence(context));
+    }
+
+    [TestMethod]
+    public void SeedModernItemsForTesting_MissingGasAndBodyPrerequisites_SkipsConditionalMedicalCoverage()
+    {
+        using FuturemudDatabaseContext context = BuildContext();
+        SeedModernPrerequisites(context);
+        UsefulSeeder seeder = new();
+
+        seeder.SeedModernItemsForTesting(context);
+
+        Assert.AreEqual(1, context.GameItemComponentProtos.Count(x => x.Name == "GasContainer_OxygenSmall"));
+        Assert.AreEqual(1, context.GameItemComponentProtos.Count(x => x.Name == "Rebreather_Standard"));
+        Assert.AreEqual(1, context.GameItemComponentProtos.Count(x => x.Name == "ExternalInhaler_Medical"));
+        Assert.AreEqual(0, context.GameItemComponentProtos.Count(x => x.Name == "InhalerGasCanister_Bronchodilator"));
+        Assert.AreEqual(0, context.GameItemComponentProtos.Count(x => x.Name == "InhalerGasCanister_Anaesthetic"));
+        Assert.AreEqual(0, context.GameItemComponentProtos.Count(x => x.Name == "IntegratedInhaler_Emergency"));
+        Assert.AreEqual(0, context.GameItemComponentProtos.Count(x => x.Name == "ExternalOrgan_HeartLungSupport_Human"));
+        Assert.AreEqual(0, context.GameItemComponentProtos.Count(x => x.Name == "ExternalOrgan_Dialysis_Human"));
     }
 }

--- a/DatabaseSeeder/Seeders/UsefulSeeder.ItemComponents.cs
+++ b/DatabaseSeeder/Seeders/UsefulSeeder.ItemComponents.cs
@@ -2,11 +2,13 @@
 using MudSharp.Body;
 using MudSharp.Body.Traits;
 using MudSharp.Database;
+using MudSharp.Form.Audio;
 using MudSharp.Form.Material;
 using MudSharp.Form.Shape;
 using MudSharp.Framework;
 using MudSharp.FutureProg;
 using MudSharp.GameItems;
+using MudSharp.GameItems.Components;
 using MudSharp.GameItems.Interfaces;
 using MudSharp.Health;
 using MudSharp.Models;
@@ -151,6 +153,18 @@ public partial class UsefulSeeder
         context.SaveChanges();
     }
 
+    internal void SeedGeneralCoverageForTesting(FuturemudDatabaseContext context)
+    {
+        _context = context;
+        PrepareItemProtoCache(context);
+        DateTime now = DateTime.UtcNow;
+        Account dbaccount = context.Accounts.First();
+        long nextId = context.GameItemComponentProtos.Any() ? context.GameItemComponentProtos.Max(x => x.Id) + 1 : 1;
+        SeedAdditionalBuilderExamples(context, now, dbaccount, ref nextId);
+        SeedSmokeables(context, now, dbaccount, ref nextId);
+        context.SaveChanges();
+    }
+
     private void SeedModernItems(FuturemudDatabaseContext context, ICollection<string> errors)
     {
         DateTime now = DateTime.UtcNow;
@@ -159,6 +173,15 @@ public partial class UsefulSeeder
         string mainsSocketType = context.StaticConfigurations
             .FirstOrDefault(x => x.SettingName == "DefaultPowerSocketType")
             ?.Definition ?? "NEMA 5-15";
+        string gasSocketType = context.StaticConfigurations
+            .FirstOrDefault(x => x.SettingName == "DefaultGasSocketType")
+            ?.Definition ?? "BSP 5mm";
+        string externalVenousConnector = context.StaticConfigurations
+            .FirstOrDefault(x => x.SettingName == "DefaultExternalOrganVenousConnector")
+            ?.Definition ?? "2-LargeVenousCatheter";
+        string externalArterialConnector = context.StaticConfigurations
+            .FirstOrDefault(x => x.SettingName == "DefaultExternalOrganArterialConnector")
+            ?.Definition ?? "2-LargeArterialCatheter";
         Tag? fuelTag = context.Tags.FirstOrDefault(x => x.Name == "Fuel");
 
         GameItemComponentProto CreateModernComponent(string type, string name, string description, XElement definition)
@@ -322,6 +345,59 @@ public partial class UsefulSeeder
                     new XElement("Wattage", wattage)));
         }
 
+        XElement ConnectorsElement(params ConnectorType[] connectors)
+        {
+            return new XElement("Connectors",
+                from connector in connectors
+                select new XElement("Connection",
+                    new XAttribute("gender", (short)connector.Gender),
+                    new XAttribute("type", connector.ConnectionType),
+                    new XAttribute("powered", connector.Powered)
+                ));
+        }
+
+        XElement PoweredMachineDefinition(double wattage, double wattageDiscount, bool switchable,
+            bool useMountHostPowerSource, string powerOnEmote, string powerOffEmote, params object[] extraElements)
+        {
+            return new XElement("Definition",
+                new XElement("Wattage", wattage),
+                new XElement("WattageDiscount", wattageDiscount),
+                new XElement("Switchable", switchable),
+                new XElement("UseMountHostPowerSource", useMountHostPowerSource),
+                new XElement("PowerOnEmote", new XCData(powerOnEmote)),
+                new XElement("PowerOffEmote", new XCData(powerOffEmote)),
+                new XElement("OnPoweredProg", 0),
+                new XElement("OnUnpoweredProg", 0),
+                extraElements);
+        }
+
+        Gas? FindGas(params string[] candidates)
+        {
+            return context.Gases.AsEnumerable()
+                       .FirstOrDefault(x => candidates.Any(candidate =>
+                           x.Name.Equals(candidate, StringComparison.OrdinalIgnoreCase))) ??
+                   context.Gases.AsEnumerable()
+                       .FirstOrDefault(x => candidates.Any(candidate =>
+                           x.Name.Contains(candidate, StringComparison.OrdinalIgnoreCase)));
+        }
+
+        BodyProto? FindHumanoidExternalOrganBody()
+        {
+            return context.BodyProtos.FirstOrDefault(x => x.Name == "Organic Humanoid") ??
+                   context.BodyProtos.FirstOrDefault(x => x.Name == "Humanoid");
+        }
+
+        List<BodypartProto> FindExternalOrgans(BodyProto body, params BodypartTypeEnum[] organTypes)
+        {
+            HashSet<int> desiredTypes = organTypes.Select(x => (int)x).ToHashSet();
+            return context.BodypartProtos
+                .Where(x => x.BodyId == body.Id)
+                .Where(x => x.IsOrgan != 0)
+                .Where(x => desiredTypes.Contains(x.BodypartType))
+                .OrderBy(x => x.Id)
+                .ToList();
+        }
+
         string SanitizeComponentName(string text)
         {
             return new string(text
@@ -347,6 +423,20 @@ public partial class UsefulSeeder
         CreateBattery("ButtonCell", 0.18, 0.01, true);
         CreateBattery("CarBattery", 480.0, 20.0, false);
         CreateBattery("CarBattery", 420.0, 15.0, true);
+        CreateModernComponent("Battery", "Battery_LiIon_Cell",
+            "Turns an item into a rechargeable lithium-ion cell battery.",
+            new XElement("Definition",
+                new XElement("BatteryType", new XCData("Li-Ion")),
+                new XElement("BaseWattHours", 12.0),
+                new XElement("WattHoursPerQuality", 1.2),
+                new XElement("Rechargable", true)));
+        CreateModernComponent("Battery", "Battery_LiIon_Pack",
+            "Turns an item into a rechargeable lithium-ion battery pack for larger electronics.",
+            new XElement("Definition",
+                new XElement("BatteryType", new XCData("Li-Ion")),
+                new XElement("BaseWattHours", 60.0),
+                new XElement("WattHoursPerQuality", 6.0),
+                new XElement("Rechargable", true)));
 
         CreateBatteryPowered("ButtonCell", 1, true);
         CreateBatteryPowered("ButtonCell", 2, true);
@@ -370,6 +460,28 @@ public partial class UsefulSeeder
         CreateBatteryPowered("D", 4, true);
         CreateBatteryPowered("D", 6, true);
         CreateBatteryPowered("CarBattery", 1, true, false, "in");
+        CreateModernComponent("BatteryPowered", "BatteryPowered_1xLiIon",
+            "Turns an item into a single-cell lithium-ion battery powered device.",
+            new XElement("Definition",
+                new XElement("BatteryType", "Li-Ion"),
+                new XElement("BatteryQuantity", 1),
+                new XElement("BatteriesInSeries", true),
+                new XElement("ChargeWattage", 30.0),
+                new XElement("Transparent", false),
+                new XElement("ContentsPreposition", "in"),
+                ConnectorsElement(
+                    new ConnectorType(Gender.Female, "USB-C", true))));
+        CreateModernComponent("BatteryPowered", "BatteryPowered_2xLiIon",
+            "Turns an item into a dual-cell lithium-ion battery powered device.",
+            new XElement("Definition",
+                new XElement("BatteryType", "Li-Ion"),
+                new XElement("BatteryQuantity", 2),
+                new XElement("BatteriesInSeries", true),
+                new XElement("ChargeWattage", 65.0),
+                new XElement("Transparent", false),
+                new XElement("ContentsPreposition", "in"),
+                ConnectorsElement(
+                    new ConnectorType(Gender.Female, "USB-C", true))));
 
         CreateBatteryCharger("ButtonCell", 2, 1.0, 0.82);
         CreateBatteryCharger("9V", 2, 8.0, 0.85);
@@ -383,6 +495,24 @@ public partial class UsefulSeeder
         CreateBatteryCharger("C", 4, 30.0, 0.87, false);
         CreateBatteryCharger("D", 4, 50.0, 0.86, false);
         CreateBatteryCharger("CarBattery", 1, 180.0, 0.84, false, "Workshop");
+        CreateModernComponent("BatteryCharger", "BatteryCharger_LiIon_Single",
+            "Turns an item into a single-bay lithium-ion battery charger.",
+            new XElement("Definition",
+                new XElement("BatteryType", "Li-Ion"),
+                new XElement("BatteryQuantity", 1),
+                new XElement("Wattage", 45.0),
+                new XElement("Efficiency", 0.92),
+                new XElement("ContentsPreposition", "in"),
+                new XElement("Transparent", false)));
+        CreateModernComponent("BatteryCharger", "BatteryCharger_LiIon_Quad",
+            "Turns an item into a four-bay lithium-ion battery charger.",
+            new XElement("Definition",
+                new XElement("BatteryType", "Li-Ion"),
+                new XElement("BatteryQuantity", 4),
+                new XElement("Wattage", 180.0),
+                new XElement("Efficiency", 0.94),
+                new XElement("ContentsPreposition", "in"),
+                new XElement("Transparent", false)));
 
         CreateModernComponent("Connectable", "Connectable_Male_To_MainsPlug",
             "Turns an item into a male connection to a standard mains plug.",
@@ -409,6 +539,46 @@ public partial class UsefulSeeder
         {
             CreatePowerSupply(wattage);
         }
+
+        foreach ((string Name, int Count, string Description) outlet in new[]
+                 {
+                     ("ElectricGridOutlet_Single", 1, "Turns an item into a single-socket electrical grid outlet."),
+                     ("ElectricGridOutlet_Double", 2, "Turns an item into a double-socket electrical grid outlet."),
+                     ("ElectricGridOutlet_Quad", 4, "Turns an item into a quad-socket electrical grid outlet.")
+                 })
+        {
+            CreateModernComponent("ElectricGridOutlet", outlet.Name, outlet.Description,
+                new XElement("Definition",
+                    ConnectorsElement(
+                        Enumerable.Range(0, outlet.Count)
+                            .Select(_ => new ConnectorType(Gender.Female, mainsSocketType, true))
+                            .ToArray())));
+        }
+
+        CreateModernComponent("GridPowerSupply", "GridPowerSupply_Standard",
+            "Turns an item into a standard grid power tap for ordinary appliances.",
+            new XElement("Definition",
+                new XElement("Wattage", 240.0)));
+        CreateModernComponent("GridPowerSupply", "GridPowerSupply_HighDraw",
+            "Turns an item into a high-draw grid power tap for heavier equipment.",
+            new XElement("Definition",
+                new XElement("Wattage", 2400.0)));
+        CreateModernComponent("UnlimitedGenerator", "UnlimitedGenerator_SetPiece",
+            "Turns an item into a set-piece generator that provides a large stable power feed.",
+            new XElement("Definition",
+                new XElement("SwitchOnEmote", new XCData("@ thrum|thrums to life and begin|begins feeding power.")),
+                new XElement("SwitchOffEmote", new XCData("@ wind|winds down and stop|stops feeding power.")),
+                new XElement("WattageProvided", 5000.0),
+                new XElement("SwitchOnProg", 0),
+                new XElement("SwitchOffProg", 0)));
+        CreateModernComponent("UnlimitedGenerator", "UnlimitedGenerator_Admin",
+            "Turns an item into an effectively unlimited administrative power source.",
+            new XElement("Definition",
+                new XElement("SwitchOnEmote", new XCData("@ surge|surges with inexhaustible power.")),
+                new XElement("SwitchOffEmote", new XCData("@ fall|falls quiet as its impossible power feed ceases.")),
+                new XElement("WattageProvided", 1000000.0),
+                new XElement("SwitchOnProg", 0),
+                new XElement("SwitchOffProg", 0)));
 
         CreateModernComponent("ElectricLight", "ElectricLight_Low",
             "Turns an item into a low power electric light source.",
@@ -509,6 +679,498 @@ public partial class UsefulSeeder
             "Turns an item into a standard telephone.",
             ConnectorDefinition(
                 new ConnectorType(Gender.Male, "TelephoneLine", true)));
+        CreateModernComponent("CellularPhone", "CellularPhone_Standard",
+            "Turns an item into a standard mobile phone that relies on cell tower coverage.",
+            new XElement("Definition",
+                new XElement("Wattage", 2.0),
+                new XElement("RingEmote", new XCData("@ chirp|chirps insistently.")),
+                new XElement("TransmitPremote", new XCData("@ speak|speaks into $1 and say|says")),
+                new XElement("RingVolume", (int)AudioVolume.Decent)));
+        CreateModernComponent("CellularPhone", "CellularPhone_Smartphone",
+            "Turns an item into a smartphone-style cellular handset.",
+            new XElement("Definition",
+                new XElement("Wattage", 4.0),
+                new XElement("RingEmote", new XCData("@ vibrate|vibrates and play|plays a gentle chime.")),
+                new XElement("TransmitPremote", new XCData("@ speak|speaks into $1 and say|says")),
+                new XElement("RingVolume", (int)AudioVolume.Quiet)));
+        CreateModernComponent("CellPhoneTower", "CellPhoneTower_Local",
+            "Turns an item into a local cellular tower that serves its surrounding zone.",
+            new XElement("Definition",
+                new XElement("Wattage", 250.0)));
+        CreateModernComponent("CellPhoneTower", "CellPhoneTower_Regional",
+            "Turns an item into a higher-power regional cellular tower.",
+            new XElement("Definition",
+                new XElement("Wattage", 1200.0)));
+        CreateModernComponent("AnsweringMachine", "AnsweringMachine_Standard",
+            "Turns an item into a daisy-chain answering machine with a standard ring delay.",
+            new XElement("Definition",
+                new XElement("Wattage", 6.0),
+                new XElement("RingEmote", new XCData("@ ring|rings insistently.")),
+                new XElement("TransmitPremote", new XCData("@ speak|speaks into $1 and say|says")),
+                new XElement("RingVolume", (int)AudioVolume.Loud),
+                new XElement("DefaultAutoAnswerRings", 4),
+                ConnectorsElement(
+                    new ConnectorType(Gender.Male, "TelephoneLine", true),
+                    new ConnectorType(Gender.Female, "TelephoneLine", true))));
+        CreateModernComponent("Tape", "Tape_Cassette30",
+            "Turns an item into a standard thirty-minute cassette tape.",
+            new XElement("Definition",
+                new XElement("CapacityMs", (long)TimeSpan.FromMinutes(30).TotalMilliseconds)));
+        CreateModernComponent("Tape", "Tape_Microcassette10",
+            "Turns an item into a compact ten-minute microcassette.",
+            new XElement("Definition",
+                new XElement("CapacityMs", (long)TimeSpan.FromMinutes(10).TotalMilliseconds)));
+
+        GameItemComponentProto computerHostPersonal = CreateModernComponent("Computer Host", "ComputerHost_Personal",
+            "Turns an item into a personal computer host with modest internal storage.",
+            PoweredMachineDefinition(120.0, 12.0, true, false,
+                "@ hum|hums to life as it boots.",
+                "@ click|clicks down and goes dark.",
+                new XElement("StorageCapacityInBytes", 1_048_576L),
+                new XElement("StoragePorts", 2),
+                new XElement("TerminalPorts", 1),
+                new XElement("NetworkPorts", 1)));
+        CreateModernComponent("Computer Host", "ComputerHost_Server",
+            "Turns an item into a larger server-style computer host.",
+            PoweredMachineDefinition(420.0, 20.0, true, false,
+                "@ thrum|thrums steadily as the server rack powers up.",
+                "@ wind|winds down in a descending fan whine.",
+                new XElement("StorageCapacityInBytes", 16_777_216L),
+                new XElement("StoragePorts", 8),
+                new XElement("TerminalPorts", 8),
+                new XElement("NetworkPorts", 4)));
+        CreateModernComponent("Computer Storage", "ComputerStorage_Portable",
+            "Turns an item into portable removable computer storage.",
+            new XElement("Definition",
+                new XElement("StorageCapacityInBytes", 4_194_304L)));
+        CreateModernComponent("Computer Storage", "ComputerStorage_Fixed",
+            "Turns an item into higher-capacity fixed computer storage.",
+            new XElement("Definition",
+                new XElement("StorageCapacityInBytes", 67_108_864L)));
+        CreateModernComponent("Computer Terminal", "ComputerTerminal_Desk",
+            "Turns an item into a standard desk terminal for a computer host.",
+            PoweredMachineDefinition(85.0, 8.0, true, false,
+                "@ flicker|flickers to life as the screen powers on.",
+                "@ dim|dims to black as it powers off."));
+        CreateModernComponent("Computer Terminal", "ComputerTerminal_Kiosk",
+            "Turns an item into a public kiosk terminal.",
+            PoweredMachineDefinition(140.0, 12.0, false, false,
+                "@ wake|wakes with a bright status screen.",
+                "@ blank|blanks out as power is lost."));
+        CreateModernComponent("Network Adapter", "NetworkAdapter_Wired",
+            "Turns an item into a wired network adapter for a computer host.",
+            PoweredMachineDefinition(18.0, 2.0, true, true,
+                "@ blink|blinks as the network adapter comes online.",
+                "@ dim|dims as the network adapter drops offline.",
+                new XElement("PreferredNetworkAddress", new XCData(string.Empty)),
+                new XElement("PublicNetworkEnabled", true),
+                new XElement("ExchangeSubnetId", new XCData(string.Empty)),
+                new XElement("VpnNetworkIds")));
+        CreateModernComponent("Network Switch", "NetworkSwitch_4Port",
+            "Turns an item into a compact four-port network switch.",
+            PoweredMachineDefinition(15.0, 1.5, true, false,
+                "@ blink|blinks as the switch powers up.",
+                "@ dim|dims as the switch powers down.",
+                new XElement("PortCount", 4)));
+        CreateModernComponent("Network Switch", "NetworkSwitch_8Port",
+            "Turns an item into a standard eight-port network switch.",
+            PoweredMachineDefinition(25.0, 2.5, true, false,
+                "@ blink|blinks as the switch powers up.",
+                "@ dim|dims as the switch powers down.",
+                new XElement("PortCount", 8)));
+        CreateModernComponent("Wireless Modem", "WirelessModem_Local",
+            "Turns an item into a cellular-backed wireless modem for a computer host.",
+            PoweredMachineDefinition(8.0, 1.0, true, true,
+                "@ blink|blinks as the modem starts searching for a network.",
+                "@ dim|dims and loses its signal.",
+                new XElement("PreferredNetworkAddress", new XCData(string.Empty)),
+                new XElement("PublicNetworkEnabled", true),
+                new XElement("ExchangeSubnetId", new XCData(string.Empty)),
+                new XElement("VpnNetworkIds")));
+
+        GameItemComponentProto automationHousingPanel = CreateModernComponent("Automation Housing",
+            "AutomationHousing_Panel",
+            "Turns an item into a compact lockable automation service panel.",
+            new XElement("Definition",
+                new XAttribute("Weight", 25_000),
+                new XAttribute("MaxSize", (int)SizeCategory.Small),
+                new XAttribute("Preposition", "in"),
+                new XAttribute("Transparent", false),
+                new XElement("ForceDifficulty", (int)Difficulty.Hard),
+                new XElement("PickDifficulty", (int)Difficulty.Normal),
+                new XElement("LockEmote", new XCData("@ lock|locks $1$?2| with $2||$.")),
+                new XElement("UnlockEmote", new XCData("@ unlock|unlocks $1$?2| with $2||$.")),
+                new XElement("LockEmoteNoActor", new XCData("@ click|clicks shut.")),
+                new XElement("UnlockEmoteNoActor", new XCData("@ click|clicks open.")),
+                new XElement("LockType", "Cam Lock"),
+                new XElement("AllowCableSegments", true),
+                new XElement("AllowMountableModules", true),
+                new XElement("AllowSignalItems", true)));
+        CreateModernComponent("Automation Housing", "AutomationHousing_JunctionBox",
+            "Turns an item into a larger junction box style automation housing.",
+            new XElement("Definition",
+                new XAttribute("Weight", 80_000),
+                new XAttribute("MaxSize", (int)SizeCategory.Normal),
+                new XAttribute("Preposition", "in"),
+                new XAttribute("Transparent", false),
+                new XElement("ForceDifficulty", (int)Difficulty.VeryHard),
+                new XElement("PickDifficulty", (int)Difficulty.Hard),
+                new XElement("LockEmote", new XCData("@ secure|secures $1$?2| with $2||$.")),
+                new XElement("UnlockEmote", new XCData("@ release|releases $1$?2| with $2||$.")),
+                new XElement("LockEmoteNoActor", new XCData("@ thunk|thunks shut.")),
+                new XElement("UnlockEmoteNoActor", new XCData("@ clunk|clunks open.")),
+                new XElement("LockType", "Panel Lock"),
+                new XElement("AllowCableSegments", true),
+                new XElement("AllowMountableModules", true),
+                new XElement("AllowSignalItems", true)));
+        CreateModernComponent("Automation Mount Host", "AutomationMountHost_2Bay",
+            "Turns an item into an automation mount host with two module bays.",
+            new XElement("Definition",
+                new XElement("Bays",
+                    new XElement("Bay",
+                        new XAttribute("name", "bay1"),
+                        new XAttribute("mounttype", "Microcontroller")),
+                    new XElement("Bay",
+                        new XAttribute("name", "bay2"),
+                        new XAttribute("mounttype", "Microcontroller"))),
+                new XElement("AccessPanelPrototypeId", automationHousingPanel.Id),
+                new XElement("AccessPanelPrototypeName", new XCData(automationHousingPanel.Name))));
+        CreateModernComponent("Automation Mount Host", "AutomationMountHost_4Bay",
+            "Turns an item into an automation mount host with four module bays.",
+            new XElement("Definition",
+                new XElement("Bays",
+                    new XElement("Bay",
+                        new XAttribute("name", "bay1"),
+                        new XAttribute("mounttype", "Microcontroller")),
+                    new XElement("Bay",
+                        new XAttribute("name", "bay2"),
+                        new XAttribute("mounttype", "Microcontroller")),
+                    new XElement("Bay",
+                        new XAttribute("name", "bay3"),
+                        new XAttribute("mounttype", "Microcontroller")),
+                    new XElement("Bay",
+                        new XAttribute("name", "bay4"),
+                        new XAttribute("mounttype", "Microcontroller"))),
+                new XElement("AccessPanelPrototypeId", automationHousingPanel.Id),
+                new XElement("AccessPanelPrototypeName", new XCData(automationHousingPanel.Name))));
+        CreateModernComponent("Signal Cable Segment", "SignalCableSegment_Standard",
+            "Turns an item into a standard one-hop signal cable segment.",
+            new XElement("Definition"));
+        CreateModernComponent("File Signal Generator", "FileSignalGenerator_Text",
+            "Turns an item into a file-backed signal generator for text-authored automation values.",
+            PoweredMachineDefinition(40.0, 0.0, true, true,
+                "@ hum|hums briefly as it powers on",
+                "@ shudder|shudders as it powers down.",
+                new XElement("SignalFileName", new XCData("signal.txt")),
+                new XElement("InitialFileContents", new XCData("0")),
+                new XElement("FileCapacityInBytes", 4096L),
+                new XElement("PubliclyAccessibleByDefault", false)));
+        CreateModernComponent("Push Button", "PushButton_Doorbell",
+            "Turns an item into a push-button style trigger such as a doorbell or request button.",
+            new XElement("Definition",
+                new XElement("Keyword", new XCData("doorbell")),
+                new XElement("SignalValue", 1.0),
+                new XElement("SignalDurationSeconds", 2.0),
+                new XElement("PressEmote", new XCData("@ press|presses $1."))));
+        GameItemComponentProto toggleSwitchWall = CreateModernComponent("Toggle Switch", "ToggleSwitch_Wall",
+            "Turns an item into a wall-mounted toggle switch.",
+            new XElement("Definition",
+                new XElement("OnValue", 1.0),
+                new XElement("OffValue", 0.0),
+                new XElement("InitiallyOn", false)));
+        GameItemComponentProto motionSensorRoom = CreateModernComponent("Motion Sensor", "MotionSensor_Room",
+            "Turns an item into a general indoor motion sensor.",
+            PoweredMachineDefinition(40.0, 0.0, true, true,
+                "@ hum|hums briefly as it powers on",
+                "@ shudder|shudders as it powers down.",
+                new XElement("SignalValue", 1.0),
+                new XElement("SignalDurationSeconds", 5.0),
+                new XElement("MinimumSize", (int)SizeCategory.Small),
+                new XElement("DetectionMode", 0)));
+        GameItemComponentProto motionSensorPerimeter = CreateModernComponent("Motion Sensor", "MotionSensor_Perimeter",
+            "Turns an item into a perimeter motion sensor focused on arrivals.",
+            PoweredMachineDefinition(55.0, 0.0, true, true,
+                "@ hum|hums briefly as it powers on",
+                "@ shudder|shudders as it powers down.",
+                new XElement("SignalValue", 1.0),
+                new XElement("SignalDurationSeconds", 12.0),
+                new XElement("MinimumSize", (int)SizeCategory.Normal),
+                new XElement("DetectionMode", 2)));
+        GameItemComponentProto lightSensorDaylight = CreateModernComponent("Light Sensor", "LightSensor_Daylight",
+            "Turns an item into a powered ambient light sensor.",
+            PoweredMachineDefinition(25.0, 0.0, true, true,
+                "@ hum|hums briefly as it powers on",
+                "@ shudder|shudders as it powers down."));
+        CreateModernComponent("Rain Sensor", "RainSensor_Outdoor",
+            "Turns an item into a powered outdoor rain sensor.",
+            PoweredMachineDefinition(25.0, 0.0, true, true,
+                "@ hum|hums briefly as it powers on",
+                "@ shudder|shudders as it powers down."));
+        CreateModernComponent("Temperature Sensor", "TemperatureSensor_Thermostat",
+            "Turns an item into a powered ambient temperature sensor.",
+            PoweredMachineDefinition(25.0, 0.0, true, true,
+                "@ hum|hums briefly as it powers on",
+                "@ shudder|shudders as it powers down."));
+        GameItemComponentProto timerSensorRepeating = CreateModernComponent("Timer Sensor", "TimerSensor_Repeating",
+            "Turns an item into a repeating timer sensor for periodic automation.",
+            PoweredMachineDefinition(20.0, 0.0, true, true,
+                "@ hum|hums briefly as it powers on",
+                "@ shudder|shudders as it powers down.",
+                new XElement("ActiveValue", 1.0),
+                new XElement("InactiveValue", 0.0),
+                new XElement("ActiveDurationSeconds", 5.0),
+                new XElement("InactiveDurationSeconds", 55.0),
+                new XElement("StartActive", false)));
+        GameItemComponentProto keypad4Digit = CreateModernComponent("Keypad", "Keypad_4Digit",
+            "Turns an item into a four-digit access keypad.",
+            PoweredMachineDefinition(35.0, 0.0, true, true,
+                "@ hum|hums briefly as it powers on",
+                "@ shudder|shudders as it powers down.",
+                new XElement("Code", new XCData("1234")),
+                new XElement("SignalValue", 1.0),
+                new XElement("SignalDurationSeconds", 2.0),
+                new XElement("EntryEmote", new XCData("@ tap|taps digits into $1"))));
+        CreateModernComponent("Keypad", "Keypad_6Digit",
+            "Turns an item into a six-digit security keypad.",
+            PoweredMachineDefinition(35.0, 0.0, true, true,
+                "@ hum|hums briefly as it powers on",
+                "@ shudder|shudders as it powers down.",
+                new XElement("Code", new XCData("246810")),
+                new XElement("SignalValue", 1.0),
+                new XElement("SignalDurationSeconds", 2.0),
+                new XElement("EntryEmote", new XCData("@ tap|taps digits into $1"))));
+        CreateModernComponent("Signal Light", "SignalLight_Indicator",
+            "Turns an item into a small indicator light driven by a switch or controller.",
+            new XElement("Definition",
+                new XElement("IlluminationProvided", 60.0),
+                new XElement("SourceComponentId", toggleSwitchWall.Id),
+                new XElement("SourceComponentName", new XCData(toggleSwitchWall.Name)),
+                new XElement("SourceEndpointKey", new XCData("signal")),
+                new XElement("ActivationThreshold", 0.5),
+                new XElement("LitWhenAboveThreshold", true),
+                new XElement("LightOnEmote", new XCData("@ light|lights up.")),
+                new XElement("LightOffEmote", new XCData("@ go|goes dark."))));
+        CreateModernComponent("Signal Light", "SignalLight_Beacon",
+            "Turns an item into a repeating signal beacon driven by a timer.",
+            new XElement("Definition",
+                new XElement("IlluminationProvided", 220.0),
+                new XElement("SourceComponentId", timerSensorRepeating.Id),
+                new XElement("SourceComponentName", new XCData(timerSensorRepeating.Name)),
+                new XElement("SourceEndpointKey", new XCData("signal")),
+                new XElement("ActivationThreshold", 0.5),
+                new XElement("LitWhenAboveThreshold", true),
+                new XElement("LightOnEmote", new XCData("@ flash|flashes brightly.")),
+                new XElement("LightOffEmote", new XCData("@ dim|dims."))));
+        CreateModernComponent("Relay Switch", "RelaySwitch_Inline",
+            "Turns an item into a signal-driven inline relay switch.",
+            new XElement("Definition",
+                new XElement("Wattage", 5.0),
+                new XElement("SourceComponentId", toggleSwitchWall.Id),
+                new XElement("SourceComponentName", new XCData(toggleSwitchWall.Name)),
+                new XElement("SourceEndpointKey", new XCData("signal")),
+                new XElement("ActivationThreshold", 0.5),
+                new XElement("ClosedWhenAboveThreshold", true)));
+        CreateModernComponent("Alarm Siren", "AlarmSiren_Indoor",
+            "Turns an item into an indoor alarm siren driven by a motion sensor.",
+            PoweredMachineDefinition(60.0, 0.0, true, true,
+                "@ hum|hums briefly as it powers on",
+                "@ shudder|shudders as it powers down.",
+                new XElement("SourceComponentId", motionSensorRoom.Id),
+                new XElement("SourceComponentName", new XCData(motionSensorRoom.Name)),
+                new XElement("SourceEndpointKey", new XCData("signal")),
+                new XElement("ActivationThreshold", 0.5),
+                new XElement("SoundWhenAboveThreshold", true),
+                new XElement("AlarmVolume", (int)AudioVolume.VeryLoud),
+                new XElement("AlarmEmote", new XCData("@ blare|blares with a piercing alarm tone."))));
+        CreateModernComponent("Alarm Siren", "AlarmSiren_Outdoor",
+            "Turns an item into an outdoor perimeter alarm siren.",
+            PoweredMachineDefinition(120.0, 0.0, true, true,
+                "@ hum|hums briefly as it powers on",
+                "@ shudder|shudders as it powers down.",
+                new XElement("SourceComponentId", motionSensorPerimeter.Id),
+                new XElement("SourceComponentName", new XCData(motionSensorPerimeter.Name)),
+                new XElement("SourceEndpointKey", new XCData("signal")),
+                new XElement("ActivationThreshold", 0.5),
+                new XElement("SoundWhenAboveThreshold", true),
+                new XElement("AlarmVolume", (int)AudioVolume.DangerouslyLoud),
+                new XElement("AlarmEmote", new XCData("@ wail|wails across the area with a shrill alarm."))));
+        CreateModernComponent("Electronic Door", "ElectronicDoor_AutoSlide",
+            "Turns an item into a motion-triggered automatic sliding door.",
+            new XElement("Definition",
+                new XAttribute("SeeThrough", false),
+                new XAttribute("CanFireThrough", false),
+                new XElement("InstalledExitDescription", "automatic door"),
+                new XElement("CanBeOpenedByPlayers", false),
+                new XElement("Uninstall",
+                    new XAttribute("CanPlayersUninstall", false),
+                    new XAttribute("UninstallDifficultyHingeSide", (int)Difficulty.Impossible),
+                    new XAttribute("UninstallDifficultyNotHingeSide", (int)Difficulty.Impossible),
+                    new XAttribute("UninstallTrait", 0)),
+                new XElement("Smash",
+                    new XAttribute("CanPlayersSmash", false),
+                    new XAttribute("SmashDifficulty", (int)Difficulty.Impossible)),
+                new XElement("SourceComponentId", motionSensorRoom.Id),
+                new XElement("SourceComponentName", new XCData(motionSensorRoom.Name)),
+                new XElement("SourceEndpointKey", new XCData("signal")),
+                new XElement("ActivationThreshold", 0.5),
+                new XElement("OpenWhenAboveThreshold", true),
+                new XElement("OpenEmoteNoActor", new XCData("@ slide|slides open.")),
+                new XElement("CloseEmoteNoActor", new XCData("@ slide|slides closed."))));
+        CreateModernComponent("Electronic Lock", "ElectronicLock_Maglock",
+            "Turns an item into a magnetic lock released by a keypad signal.",
+            new XElement("Definition",
+                new XElement("ForceDifficulty", (int)Difficulty.ExtremelyHard),
+                new XElement("PickDifficulty", (int)Difficulty.Impossible),
+                new XElement("LockEmoteNoActor", new XCData("@ lock|locks with a solid magnetic thunk.")),
+                new XElement("UnlockEmoteNoActor", new XCData("@ unlock|unlocks with a sharp magnetic click.")),
+                new XElement("LockEmoteOtherSide", new XCData("@ hear|hears the maglock engage on $1.")),
+                new XElement("UnlockEmoteOtherSide", new XCData("@ hear|hears the maglock release on $1.")),
+                new XElement("LockType", "Maglock"),
+                new XElement("SourceComponentId", keypad4Digit.Id),
+                new XElement("SourceComponentName", new XCData(keypad4Digit.Name)),
+                new XElement("SourceEndpointKey", new XCData("signal")),
+                new XElement("ActivationThreshold", 0.5),
+                new XElement("LockWhenAboveThreshold", false)));
+        CreateModernComponent("Microcontroller", "Microcontroller_Basic",
+            "Turns an item into a simple programmable microcontroller with a daylight input example.",
+            PoweredMachineDefinition(20.0, 0.0, true, true,
+                "@ hum|hums briefly as it powers on",
+                "@ shudder|shudders as it powers down.",
+                new XElement("Input",
+                    new XAttribute("variable", "daylight"),
+                    new XAttribute("sourceid", lightSensorDaylight.Id),
+                    new XAttribute("source", lightSensorDaylight.Name),
+                    new XAttribute("endpoint", "signal")),
+                new XElement("LogicText", new XCData("return @daylight"))));
+
+        CreateModernComponent("GasContainer", "GasContainer_OxygenSmall",
+            "Turns an item into a small oxygen cylinder.",
+            new XElement("Definition",
+                new XElement("MaximumGasCapacity", 450.0),
+                new XElement("ShowGasLevels", true),
+                ConnectorsElement(new ConnectorType(Gender.Female, gasSocketType, false))));
+        CreateModernComponent("GasContainer", "GasContainer_OxygenLarge",
+            "Turns an item into a larger oxygen cylinder.",
+            new XElement("Definition",
+                new XElement("MaximumGasCapacity", 1800.0),
+                new XElement("ShowGasLevels", true),
+                ConnectorsElement(new ConnectorType(Gender.Female, gasSocketType, false))));
+        CreateModernComponent("GasContainer", "GasContainer_Anaesthetic",
+            "Turns an item into a gas cylinder suitable for anaesthetic or specialist breathing mixes.",
+            new XElement("Definition",
+                new XElement("MaximumGasCapacity", 900.0),
+                new XElement("ShowGasLevels", true),
+                ConnectorsElement(new ConnectorType(Gender.Female, gasSocketType, false))));
+        CreateModernComponent("Rebreather", "Rebreather_Standard",
+            "Turns an item into a standard rebreather or breathing mask connection.",
+            new XElement("Definition",
+                new XElement("WaterTight", false),
+                new XElement("Connection",
+                    new XAttribute("gender", (short)Gender.Male),
+                    new XAttribute("type", gasSocketType),
+                    new XAttribute("powered", false))));
+        CreateModernComponent("Rebreather", "Rebreather_Watertight",
+            "Turns an item into a watertight rebreather or dive mask connection.",
+            new XElement("Definition",
+                new XElement("WaterTight", true),
+                new XElement("Connection",
+                    new XAttribute("gender", (short)Gender.Male),
+                    new XAttribute("type", gasSocketType),
+                    new XAttribute("powered", false))));
+        CreateModernComponent("ExternalInhaler", "ExternalInhaler_Medical",
+            "Turns an item into an external inhaler that accepts metered-dose canisters.",
+            new XElement("Definition",
+                new XElement("GasPerPuff", 0.25),
+                new XElement("CanisterType", "MeteredDose"),
+                new XElement("Connector",
+                    new XAttribute("gender", (short)Gender.Female),
+                    new XAttribute("type", "inhaler"),
+                    new XAttribute("powered", false))));
+
+        Gas? bronchodilatorGas = FindGas("Bronchodilator");
+        Gas? anaestheticGas = FindGas("General Anaesthetic", "Anaesthetic", "Ether Anaesthetic");
+        if (bronchodilatorGas is not null)
+        {
+            CreateModernComponent("InhalerGasCanister", "InhalerGasCanister_Bronchodilator",
+                "Turns an item into a metered-dose bronchodilator inhaler canister.",
+                new XElement("Definition",
+                    new XElement("CanisterType", "MeteredDose"),
+                    new XElement("InitialGas", bronchodilatorGas.Id)));
+            CreateModernComponent("IntegratedInhaler", "IntegratedInhaler_Emergency",
+                "Turns an item into a self-contained emergency bronchodilator inhaler.",
+                new XElement("Definition",
+                    new XElement("GasPerPuff", 0.25),
+                    new XElement("InitialGas", bronchodilatorGas.Id)));
+        }
+
+        if (anaestheticGas is not null)
+        {
+            CreateModernComponent("InhalerGasCanister", "InhalerGasCanister_Anaesthetic",
+                "Turns an item into a metered-dose anaesthetic inhaler canister.",
+                new XElement("Definition",
+                    new XElement("CanisterType", "MeteredDose"),
+                    new XElement("InitialGas", anaestheticGas.Id)));
+        }
+
+        CreateModernComponent("Defibrillator", "Defibrillator_AED",
+            "Turns an item into an automated external defibrillator.",
+            new XElement("Definition",
+                new XElement("WattagePerShock", 6000.0),
+                new XElement("DefibrillationEmote",
+                    new XCData("$0 place|places $2's pads against $1's chest and deliver|delivers a controlled shock."))));
+        CreateModernComponent("Defibrillator", "Defibrillator_Clinical",
+            "Turns an item into a clinical defibrillator with a stronger discharge.",
+            new XElement("Definition",
+                new XElement("WattagePerShock", 15000.0),
+                new XElement("DefibrillationEmote",
+                    new XCData("$0 charge|charges $2 and then press|presses the paddles to $1's chest, delivering a hard shock."))));
+
+        BodyProto? externalOrganBody = FindHumanoidExternalOrganBody();
+        if (externalOrganBody is not null)
+        {
+            List<BodypartProto> heartLungOrgans = FindExternalOrgans(externalOrganBody, BodypartTypeEnum.Heart, BodypartTypeEnum.Lung);
+            bool hasHeart = heartLungOrgans.Any(x => x.BodypartType == (int)BodypartTypeEnum.Heart);
+            bool hasLung = heartLungOrgans.Any(x => x.BodypartType == (int)BodypartTypeEnum.Lung);
+            if (hasHeart && hasLung)
+            {
+                CreateModernComponent("ExternalOrgan", "ExternalOrgan_HeartLungSupport_Human",
+                    "Turns an item into an external heart-lung support machine for humanoids.",
+                    new XElement("Definition",
+                        new XElement("Body", externalOrganBody.Id),
+                        new XElement("OxygenatesBlood", true),
+                        new XElement("Addendum", new XCData("It hums steadily while circulating and oxygenating blood.")),
+                        new XElement("VenousConnection", externalVenousConnector),
+                        new XElement("ArterialConnection", externalArterialConnector),
+                        new XElement("BasePowerConsumptionInWatts", 650.0),
+                        new XElement("PowerConsumptionDiscountPerQuality", 30.0),
+                        new XElement("SwitchOnEmote", new XCData("@ rumble|rumbles to life as pumps and oxygenators come online.")),
+                        new XElement("SwitchOffEmote", new XCData("@ wind|winds down as the circulation system powers off.")),
+                        new XElement("Organs",
+                            from organ in heartLungOrgans
+                            select new XElement("Organ", organ.Id))));
+            }
+
+            List<BodypartProto> kidneyOrgans = FindExternalOrgans(externalOrganBody, BodypartTypeEnum.Kidney);
+            if (kidneyOrgans.Count > 0)
+            {
+                CreateModernComponent("ExternalOrgan", "ExternalOrgan_Dialysis_Human",
+                    "Turns an item into a humanoid dialysis support machine.",
+                    new XElement("Definition",
+                        new XElement("Body", externalOrganBody.Id),
+                        new XElement("OxygenatesBlood", false),
+                        new XElement("Addendum", new XCData("It cycles blood through a filtration assembly.")),
+                        new XElement("VenousConnection", externalVenousConnector),
+                        new XElement("ArterialConnection", externalArterialConnector),
+                        new XElement("BasePowerConsumptionInWatts", 320.0),
+                        new XElement("PowerConsumptionDiscountPerQuality", 18.0),
+                        new XElement("SwitchOnEmote", new XCData("@ hum|hums to life as filtration pumps begin cycling.")),
+                        new XElement("SwitchOffEmote", new XCData("@ slow|slows and falls silent as filtration stops.")),
+                        new XElement("Organs",
+                            from organ in kidneyOrgans
+                            select new XElement("Organ", organ.Id))));
+            }
+        }
+
         CreateModernComponent("ElectricGridFeeder", "ElectricGridFeeder_Standard",
             "Turns an item into a feeder for the electrical grid.",
             ConnectorDefinition(
@@ -5637,6 +6299,21 @@ public partial class UsefulSeeder
             new XElement("Definition",
                 new XElement("MaximumUsers", 4),
                 new XElement("EffortMultiplier", 2.5)));
+        AddExtraComponent("DragAid", "DragAid_Stretcher",
+            "Turns an item into a stretcher or litter for coordinated casualty dragging.",
+            new XElement("Definition",
+                new XElement("MaximumUsers", 4),
+                new XElement("EffortMultiplier", 3.0)));
+        AddExtraComponent("DragAid", "DragAid_Sled",
+            "Turns an item into a hauling sled or skid.",
+            new XElement("Definition",
+                new XElement("MaximumUsers", 2),
+                new XElement("EffortMultiplier", 2.0)));
+        AddExtraComponent("DragAid", "DragAid_Travois",
+            "Turns an item into a travois-style drag aid for rough travel.",
+            new XElement("Definition",
+                new XElement("MaximumUsers", 2),
+                new XElement("EffortMultiplier", 2.25)));
 
         AddExtraComponent("WaterSource", "WaterSource_Canteen",
             "Turns an item into a transparent closable refill-on-toggle canteen.",
@@ -5738,6 +6415,20 @@ public partial class UsefulSeeder
                 new XElement("TreatmentType", 3),
                 new XElement("TreatmentType", 4),
                 new XElement("TreatmentType", 11)));
+        AddExtraComponent("Treatment", "Treatment_AntiInflammatory_Single",
+            "Turns the item into a single-use anti-inflammatory treatment example.",
+            new XElement("Definition",
+                new XElement("MaximumUses", 1),
+                new XElement("Refillable", false),
+                new XElement("DifficultyStages", 0),
+                new XElement("TreatmentType", (int)TreatmentType.AntiInflammatory)));
+        AddExtraComponent("Treatment", "Treatment_AntiInflammatory_Kit",
+            "Turns the item into a refillable anti-inflammatory treatment kit.",
+            new XElement("Definition",
+                new XElement("MaximumUses", 12),
+                new XElement("Refillable", true),
+                new XElement("DifficultyStages", 2),
+                new XElement("TreatmentType", (int)TreatmentType.AntiInflammatory)));
 
         BodyProto? prostheticBody = context.BodyProtos.FirstOrDefault(x => x.Name == "Organic Humanoid") ??
                             context.BodyProtos.FirstOrDefault(x => x.Name == "Humanoid");
@@ -5794,6 +6485,20 @@ public partial class UsefulSeeder
                     new XElement("TimeZone", defaultTimeZone.Id),
                     new XElement("PlayersCanSetTime", true),
                     new XElement("TimeDisplayString", "$h:$m:$s $t")));
+            AddExtraComponent("TimePiece", "TimePiece_PocketWatch",
+                "Turns an item into a pocket watch style timepiece.",
+                new XElement("Definition",
+                    new XElement("Clock", primaryClock.Id),
+                    new XElement("TimeZone", defaultTimeZone.Id),
+                    new XElement("PlayersCanSetTime", false),
+                    new XElement("TimeDisplayString", "$j:$m $i")));
+            AddExtraComponent("TimePiece", "TimePiece_WallClock",
+                "Turns an item into a fixed wall clock style timepiece.",
+                new XElement("Definition",
+                    new XElement("Clock", primaryClock.Id),
+                    new XElement("TimeZone", defaultTimeZone.Id),
+                    new XElement("PlayersCanSetTime", false),
+                    new XElement("TimeDisplayString", "$h:$m")));
         }
 
         nextId = currentId;
@@ -5805,7 +6510,7 @@ public partial class UsefulSeeder
     {
         #region Smokeables
 
-        GameItemComponentProto component;
+        long currentId = nextId;
         bool saveChangesRequired = false;
         string characterTypeDefinition = ProgVariableTypes.Character.ToStorageString();
         if (!context.VariableDefinitions.Any(x => x.OwnerTypeDefinition == characterTypeDefinition && x.Property == "nicotineuntil"))
@@ -5862,36 +6567,50 @@ SetRegister @ch ""NicotineUntil"" (@NicotineUntil + 5m)",
         {
             context.SaveChanges();
         }
-        component = new GameItemComponentProto
+        GameItemComponentProto CreateSmokeable(string name, string description, int secondsOfFuel, int secondsPerDrag,
+            int secondsOfEffectPerSecondOfFuel, string playerDescription, string roomDescription)
         {
-            Id = nextId++,
-            RevisionNumber = 0,
-            EditableItem = new EditableItem
-            {
-                RevisionNumber = 0,
-                RevisionStatus = 4,
-                BuilderAccountId = dbaccount.Id,
-                BuilderDate = now,
-                BuilderComment = "Auto-generated by the system",
-                ReviewerAccountId = dbaccount.Id,
-                ReviewerComment = "Auto-generated by the system",
-                ReviewerDate = now
-            },
-            Type = "Smokeable",
-            Name = "Cigarette",
-            Description = "Turns an item into a smokeable tobacco cigarette",
-            Definition = @$"<Definition>
-   <SecondsOfFuel>600</SecondsOfFuel>
-   <SecondsPerDrag>10</SecondsPerDrag>
-   <SecondsOfEffectPerSecondOfFuel>5</SecondsOfEffectPerSecondOfFuel>
-   <OnDragProg>{smokeProg.Id}</OnDragProg>
-   <PlayerDescriptionEffectString>The lingering, acrid smell of tobacco clings to this individual.</PlayerDescriptionEffectString>
-   <RoomDescriptionEffectString>The lingering, acrid smell of tobacco hangs in the air here.</RoomDescriptionEffectString>
-   <Drug>0</Drug>
-   <GramsPerDrag>0</GramsPerDrag>
- </Definition>"
-        };
-        AddGameItemComponent(context, component);
+            return CreateComponent(context, ref currentId, dbaccount, now, "Smokeable", name, description,
+                new XElement("Definition",
+                    new XElement("SecondsOfFuel", secondsOfFuel),
+                    new XElement("SecondsPerDrag", secondsPerDrag),
+                    new XElement("SecondsOfEffectPerSecondOfFuel", secondsOfEffectPerSecondOfFuel),
+                    new XElement("OnDragProg", smokeProg.Id),
+                    new XElement("PlayerDescriptionEffectString", new XCData(playerDescription)),
+                    new XElement("RoomDescriptionEffectString", new XCData(roomDescription)),
+                    new XElement("Drug", 0),
+                    new XElement("GramsPerDrag", 0)).ToString());
+        }
+
+        CreateSmokeable("Cigarette",
+            "Turns an item into a smokeable tobacco cigarette.",
+            600,
+            10,
+            5,
+            "The lingering, acrid smell of tobacco clings to this individual.",
+            "The lingering, acrid smell of tobacco hangs in the air here.");
+        CreateSmokeable("Smokeable_Cigar",
+            "Turns an item into a longer-burning smokeable tobacco cigar.",
+            5400,
+            60,
+            5,
+            "The rich, heavy smell of cigar smoke clings to this individual.",
+            "The rich, heavy smell of cigar smoke hangs in the air here.");
+        CreateSmokeable("Smokeable_Cigarillo",
+            "Turns an item into a compact smokeable cigarillo.",
+            1800,
+            30,
+            5,
+            "A sweet, lingering cigarillo scent clings to this individual.",
+            "A sweet, lingering cigarillo scent hangs in the air here.");
+        CreateSmokeable("Smokeable_PipeBowl",
+            "Turns an item into a prepared bowl of pipe tobacco for smoking.",
+            3600,
+            45,
+            5,
+            "The warm, aromatic smell of pipe smoke clings to this individual.",
+            "The warm, aromatic smell of pipe smoke hangs in the air here.");
+        nextId = currentId;
         #endregion
         context.SaveChanges();
     }

--- a/DatabaseSeeder/Seeders/UsefulSeeder.cs
+++ b/DatabaseSeeder/Seeders/UsefulSeeder.cs
@@ -49,7 +49,11 @@ public partial class UsefulSeeder : IDatabaseSeeder
         "Container_Table",
         "Insulation_Minor",
         "Destroyable_Misc",
-        "Torch_Infinite"
+        "Torch_Infinite",
+        "Smokeable_Cigar",
+        "DragAid_Stretcher",
+        "Treatment_AntiInflammatory_Single",
+        "TimePiece_PocketWatch"
     ];
 
     private static readonly string[] StockModernItemMarkers =
@@ -72,10 +76,20 @@ public partial class UsefulSeeder : IDatabaseSeeder
         "LiquidConsumingProp_Standard",
         "LiquidConsumingProp_Basin",
         "BatteryPowered_LaptopStyle",
+        "Battery_LiIon_Cell",
+        "ElectricGridOutlet_Double",
+        "GridPowerSupply_Standard",
+        "UnlimitedGenerator_SetPiece",
         "PowerSocket_Mains_Double",
         "PowerSupply_60W",
         "ElectricLight_Medium",
         "HandheldRadio_Standard",
+        "CellularPhone_Standard",
+        "ComputerHost_Personal",
+        "AutomationHousing_Panel",
+        "SignalCableSegment_Standard",
+        "GasContainer_OxygenSmall",
+        "Defibrillator_AED",
         "ElectricHeaterCooler_SpaceHeater",
         "ElectricHeaterCooler_PortableCooler",
         "ConsumableHeaterCooler_SmallFire",
@@ -108,14 +122,14 @@ public partial class UsefulSeeder : IDatabaseSeeder
                         if (answer.EqualToAny("yes", "y", "no", "n")) { return (true, string.Empty); } return (false, "Invalid answer");
                 }),
             ("items",
-                "#DItem Package 1#F\n\nDo you want to include a package of standard item definitions, which includes some commonly used item component types, including a wide selection of containers, liquid containers, doors, locks, keys, basic writing implements, insulation for clothing, components that let worn clothing hide or change characteristics (wigs, coloured contacts, etc), components that correct for myopia flaws, as well as identity obscurers (hoods, full helmets, niqabs, cloaks, etc.), destroyables, colour variables, further writing implements, tables and chairs, ranged covers, medical items, prosthetic limbs, dice, torches and lanterns, repair kits, water sources and smokeable tobacco.\n\nShall we install this package? Please answer #3yes#f or #3no#f: ",
+                "#DItem Package 1#F\n\nDo you want to include a package of standard item definitions, which includes some commonly used item component types, including a wide selection of containers, liquid containers, doors, locks, keys, basic writing implements, insulation for clothing, components that let worn clothing hide or change characteristics (wigs, coloured contacts, etc), components that correct for myopia flaws, as well as identity obscurers (hoods, full helmets, niqabs, cloaks, etc.), destroyables, colour variables, further writing implements, tables and chairs, ranged covers, medical items, prosthetic limbs, dice, torches and lanterns, repair kits, water sources, smokeable tobacco, drag aids and timepieces.\n\nShall we install this package? Please answer #3yes#f or #3no#f: ",
                 (context, questions) => true,
                 (answer, context) =>
                 {
                     if (answer.EqualToAny("yes", "y", "no", "n")) { return (true, string.Empty); } return (false, "Invalid answer");
                 }),
             ("modernitems",
-                "Do you want to install some common modern setting item component types like batteries, chargers, power plugs, powered lights, radios, electric heaters and coolers, fireplaces, campfires, grid creators, telephones, liquid grids and fuel generators?\n\nPlease answer #3yes#f or #3no#f: ",
+                "Do you want to install some common modern setting item component types like batteries, chargers, power plugs, powered lights, radios, electrical outlets and generators, telephones and cellular devices, computer and automation components, breathing and emergency medical gear, electric heaters and coolers, fireplaces, campfires, grid creators, liquid grids and fuel generators?\n\nPlease answer #3yes#f or #3no#f: ",
                 (context, questions) => ClassifyModernPackagePresence(context) != ShouldSeedResult.MayAlreadyBeInstalled,
                 (answer, context) =>
                 {
@@ -240,8 +254,7 @@ public partial class UsefulSeeder : IDatabaseSeeder
         List<ShouldSeedResult> packageStates =
         [
             ClassifyAiPackagePresence(context),
-            SeederRepeatabilityHelper.ClassifyByPresence(
-                StockItemMarkers.Select(marker => context.GameItemComponentProtos.Any(x => x.Name == marker))),
+            ClassifyItemPackagePresence(context),
             ClassifyModernPackagePresence(context),
             context.Tags.Any(x => x.Name == "Functions")
                 ? ShouldSeedResult.MayAlreadyBeInstalled
@@ -280,7 +293,14 @@ Inside the package there are a few numbered #D""Core Item Packages""#3. The reas
     }
 
     internal static IReadOnlyCollection<string> StockAiExampleNamesForTesting => StockAiExampleNames;
+    internal static IReadOnlyCollection<string> StockItemMarkersForTesting => StockItemMarkers;
     internal static IReadOnlyCollection<string> StockModernItemMarkersForTesting => StockModernItemMarkers;
+
+    internal static ShouldSeedResult ClassifyItemPackagePresence(FuturemudDatabaseContext context)
+    {
+        return SeederRepeatabilityHelper.ClassifyByPresence(
+            StockItemMarkers.Select(name => context.GameItemComponentProtos.Any(x => x.Name == name)));
+    }
 
     internal static ShouldSeedResult ClassifyModernPackagePresence(FuturemudDatabaseContext context)
     {

--- a/Design Documents/DatabaseSeeder_System_Gap_Audit.md
+++ b/Design Documents/DatabaseSeeder_System_Gap_Audit.md
@@ -260,12 +260,12 @@ Fully operational games do not strictly require arenas, but worlds that use stru
 ### Items, Item Components, and Crafting Scaffolds
 Fully operational games need generic props, tools, consumables, components, and at least some crafting scaffolding so core loops are usable.
 
-- `Current State`: `UsefulSeeder` and `ItemSeeder` provide a large stock item and component baseline, and `ItemSeederCrafting` shows that the item seeder already touches crafting-adjacent support. The item runtime itself is much broader and heavily builder-driven.
-- `Runtime Breadth vs Seeder Breadth`: the engine supports a very large item-component catalogue, revisioned prototypes, skins, groups, telecoms, implants, thermal sources, and rich crafting/project systems that the seeder only samples.
+- `Current State`: `UsefulSeeder` and `ItemSeeder` provide a large stock item and component baseline, and `ItemSeederCrafting` shows that the item seeder already touches crafting-adjacent support. `UsefulSeeder` now also covers a broader modern template slice with lithium battery ecosystems, grid outlets and generators, cellular and answering-machine endpoints, computer and network starter components, signal automation and security examples, gas containers, rebreathers, inhalers, defibrillators, and conditional external-organ support machines.
+- `Runtime Breadth vs Seeder Breadth`: the engine still supports a much larger item-component catalogue, revisioned prototypes, skins, groups, implants, finished merchandise families, and rich crafting/project systems than stock seeding provides. Even after the modern UsefulSeeder expansion, food presets, fax-machine ecosystems, breathing-filter cartridge families, and many profession-specific item lines remain intentionally unseeded.
 - `Seeder Fit`: `Strong`
 - `Template Strategy`: generic item and component libraries by tech level, plus example craft packs
 - `Recommended Seeder Scope`: `Template Library`
-- `Notes / Risks`: stock generic toolkits belong in the seeder. Full merchandise catalogues, bespoke shop stock, and complete profession trees do not. Crafting should focus on sample patterns and reusable primitives, not exhaustive content.
+- `Notes / Risks`: stock generic toolkits belong in the seeder. Full merchandise catalogues, bespoke shop stock, and complete profession trees do not. Crafting should focus on sample patterns and reusable primitives, not exhaustive content. The remaining skipped modern gaps are mostly the families that need companion consumable or stock-item ecosystems to feel complete, such as food, fax supplies, and breathing-filter consumables.
 
 ### NPC AI and Group AI
 Fully operational games benefit from reusable AI definitions and group behaviours so builders are not starting every NPC ecosystem from zero.

--- a/Design Documents/Item_System_Content_Workflows.md
+++ b/Design Documents/Item_System_Content_Workflows.md
@@ -55,6 +55,20 @@ Signal-automation examples now include:
 - `comp edit new relayswitch`
 - `comp edit new alarmsiren`
 
+Power, telecom, and modern medical examples also include:
+- `comp edit new electricgridoutlet`
+- `comp edit new gridpowersupply`
+- `comp edit new unlimitedgenerator`
+- `comp edit new gascontainer`
+- `comp edit new rebreather`
+- `comp edit new externalinhaler`
+- `comp edit new inhalergascanister`
+- `comp edit new integratedinhaler`
+- `comp edit new defibrillator`
+- `comp edit new externalorgan`
+
+`UsefulSeeder` now ships stock component examples across those modern families, including lithium batteries, cellular devices, answering-machine tapes, computer/network gear, signal automation, gas containers, rebreathers, inhalers, defibrillators, and external-organ support machines. This pass still intentionally leaves food presets, fax-machine examples, and breathing-filter cartridge ecosystems to later dedicated content passes.
+
 This goes through `GameItemComponentManager`, so failure here often means:
 - the type was not registered
 - the builder loader name is wrong
@@ -187,6 +201,13 @@ For the current signal-automation slice, also validate:
 - whether abject failure on electrical work produces the intended shock echo and electrical damage
 - whether switched-on mounted powered machines recover host-derived power after reboot or late topology initialisation without requiring a manual off/on cycle
 - whether motion sensors ignore administrator movement when the mover is using `IImmwalkEffect`
+
+For the current modern breathing and emergency-medicine slice, also validate:
+- whether `gascontainer` and `rebreather` connector genders and socket types match the intended gas-line ecosystem
+- whether `externalinhaler` and `inhalergascanister` agree on canister type, and whether gas-bearing presets only exist when the required stock gas was seeded
+- whether `integratedinhaler` starts with the intended gas and consumes the expected amount per puff
+- whether `defibrillator` power draw and shock emotes match the intended medical tier
+- whether `externalorgan` presets only exist when the target body and organ set are present, and whether their venous and arterial connector types match the expected cannula ecosystem
 
 ### Manual load restrictions
 Some components set `PreventManualLoad`, and item prototypes surface that through `PreventManualLoad`.


### PR DESCRIPTION
## Summary
- Expand `UsefulSeeder` general coverage with broader smokeable, drag-aid, anti-inflammatory, and timepiece presets.
- Add modern presets for lithium batteries, grid power, telecom, computers, automation, and breathing/emergency medical items.
- Keep conditional seeding for prerequisite-sensitive modern items and update docs to reflect the new coverage and intentional deferrals.
- Add focused DatabaseSeeder unit tests for repeatability, package classification, conditional skips, and no-food coverage.

## Testing
- Passed focused `DatabaseSeeder Unit Tests` for the new `UsefulSeederItemPackageTests` and `UsefulSeederModernPackageTests` coverage.