### PR TITLE
Move racial attribute bonuses to race attribute rows

### DIFF
--- a/DatabaseSeeder Unit Tests/AnimalSeederTemplateTests.cs
+++ b/DatabaseSeeder Unit Tests/AnimalSeederTemplateTests.cs
@@ -255,10 +255,37 @@ public class AnimalSeederTemplateTests
     {
         Assert.AreEqual("Beast Coward", AnimalSeeder.RaceTemplatesForTesting["Rabbit"].CombatStrategyKey);
         Assert.AreEqual("Beast Skirmisher", AnimalSeeder.RaceTemplatesForTesting["Cheetah"].CombatStrategyKey);
+        Assert.AreEqual("Beast Skirmisher", AnimalSeeder.RaceTemplatesForTesting["Horse"].CombatStrategyKey);
+        Assert.AreEqual("Beast Coward", AnimalSeeder.RaceTemplatesForTesting["Cow"].CombatStrategyKey);
+        Assert.AreEqual("Beast Skirmisher", AnimalSeeder.RaceTemplatesForTesting["Giraffe"].CombatStrategyKey);
+        Assert.AreEqual("Beast Skirmisher", AnimalSeeder.RaceTemplatesForTesting["Ostrich"].CombatStrategyKey);
         Assert.AreEqual("Beast Artillery", AnimalSeeder.RaceTemplatesForTesting["Llama"].CombatStrategyKey);
         Assert.AreEqual("Beast Swooper", AnimalSeeder.RaceTemplatesForTesting["Eagle"].CombatStrategyKey);
         Assert.AreEqual("Beast Clincher", AnimalSeeder.RaceTemplatesForTesting["Python"].CombatStrategyKey);
         Assert.AreEqual("Beast Behemoth", AnimalSeeder.RaceTemplatesForTesting["Elephant"].CombatStrategyKey);
+    }
+
+    [TestMethod]
+    public void RaceTemplatesForTesting_SecondPassAttributeProfiles_AdjustOutliers()
+    {
+        Assert.AreEqual(new NonHumanAttributeProfile(-1, -1, 4, 2),
+            AnimalSeeder.GetAnimalAttributeProfileForTesting(AnimalSeeder.RaceTemplatesForTesting["Cheetah"]),
+            "Cheetahs should read as high-agility pursuit cats rather than generic heavy predators.");
+        Assert.AreEqual(new NonHumanAttributeProfile(7, 8, 2, -1),
+            AnimalSeeder.GetAnimalAttributeProfileForTesting(AnimalSeeder.RaceTemplatesForTesting["Horse"]),
+            "Horses should keep large-animal power while adding athletic mobility.");
+        Assert.AreEqual(new NonHumanAttributeProfile(7, 8, -1, -2),
+            AnimalSeeder.GetAnimalAttributeProfileForTesting(AnimalSeeder.RaceTemplatesForTesting["Cow"]),
+            "Cows should be durable stock animals without inheriting apex-behemoth combat assumptions.");
+        Assert.AreEqual(new NonHumanAttributeProfile(9, 8, 1, -3),
+            AnimalSeeder.GetAnimalAttributeProfileForTesting(AnimalSeeder.RaceTemplatesForTesting["Giraffe"]),
+            "Giraffes should be dangerous by reach and size without becoming generic slow tanks.");
+        Assert.AreEqual(new NonHumanAttributeProfile(3, 2, 4, -1),
+            AnimalSeeder.GetAnimalAttributeProfileForTesting(AnimalSeeder.RaceTemplatesForTesting["Ostrich"]),
+            "Ostriches should be fast, kicking flightless birds.");
+        Assert.AreEqual(new NonHumanAttributeProfile(2, 1, 2, -1),
+            AnimalSeeder.GetAnimalAttributeProfileForTesting(AnimalSeeder.RaceTemplatesForTesting["Deer"]),
+            "Deer should favour flight and agility over brute herbivore scaling.");
     }
 
     [TestMethod]

--- a/DatabaseSeeder Unit Tests/AnimalSeederTemplateTests.cs
+++ b/DatabaseSeeder Unit Tests/AnimalSeederTemplateTests.cs
@@ -129,7 +129,6 @@ public class AnimalSeederTemplateTests
                 Description = $"{raceName} test race",
                 BaseBodyId = baseBody.Id,
                 AllowedGenders = "1 2 3 4",
-                AttributeBonusProgId = 1,
                 AttributeTotalCap = 1,
                 IndividualAttributeCap = 1,
                 DiceExpression = "1",
@@ -305,6 +304,28 @@ public class AnimalSeederTemplateTests
             "Baleen whales should have a head ram attack.");
         Assert.IsTrue(whaleLoadout.AliasAttacks?.Any(x => x.AttackKey == "tailslap") == true,
             "Baleen whales should have a tail slap attack.");
+    }
+
+    [TestMethod]
+    public void NonHumanAttributeScalingHelper_AlternateAttributeModelNames_MapToProfileBonuses()
+    {
+        NonHumanAttributeProfile profile = new(4, 2, -1, -2);
+
+        static TraitDefinition Attribute(string name)
+        {
+            return new TraitDefinition
+            {
+                Name = name
+            };
+        }
+
+        Assert.AreEqual(4, NonHumanAttributeScalingHelper.GetAttributeBonus(Attribute("Strength"), profile));
+        Assert.AreEqual(2, NonHumanAttributeScalingHelper.GetAttributeBonus(Attribute("Endurance"), profile));
+        Assert.AreEqual(3, NonHumanAttributeScalingHelper.GetAttributeBonus(Attribute("Body"), profile));
+        Assert.AreEqual(3, NonHumanAttributeScalingHelper.GetAttributeBonus(Attribute("Physique"), profile));
+        Assert.AreEqual(-1, NonHumanAttributeScalingHelper.GetAttributeBonus(Attribute("Agility"), profile));
+        Assert.AreEqual(-2, NonHumanAttributeScalingHelper.GetAttributeBonus(Attribute("Dexterity"), profile));
+        Assert.AreEqual(0, NonHumanAttributeScalingHelper.GetAttributeBonus(Attribute("Willpower"), profile));
     }
 
     [TestMethod]

--- a/DatabaseSeeder Unit Tests/ChargenSeederTests.cs
+++ b/DatabaseSeeder Unit Tests/ChargenSeederTests.cs
@@ -105,7 +105,6 @@ public class ChargenSeederTests
 			Description = "Human test race",
 			BaseBodyId = 1,
 			AllowedGenders = "Male Female Neuter NonBinary",
-			AttributeBonusProgId = 1,
 			DiceExpression = "1d100",
 			CorpseModelId = 0,
 			DefaultHealthStrategyId = 0,

--- a/DatabaseSeeder Unit Tests/CultureSeederNameAndHeightDefaultTests.cs
+++ b/DatabaseSeeder Unit Tests/CultureSeederNameAndHeightDefaultTests.cs
@@ -21,6 +21,21 @@ namespace MudSharp_Unit_Tests;
 public class CultureSeederNameAndHeightDefaultTests
 {
 	[TestMethod]
+	public void CultureRaceAttributeProfilesForTesting_SecondPassFantasyDefaults_AreDistinct()
+	{
+		IReadOnlyDictionary<string, NonHumanAttributeProfile> profiles =
+			CultureSeeder.CultureRaceAttributeProfilesForTesting;
+
+		Assert.AreEqual(new NonHumanAttributeProfile(-1, 0, 2, 3), profiles["Elf"]);
+		Assert.AreEqual(new NonHumanAttributeProfile(-3, 2, 1, 2), profiles["Hobbit"]);
+		Assert.AreEqual(new NonHumanAttributeProfile(2, 4, -1, 0), profiles["Dwarf"]);
+		Assert.AreEqual(new NonHumanAttributeProfile(3, 2, 0, -1), profiles["Orc"]);
+		Assert.AreEqual(new NonHumanAttributeProfile(9, 8, -3, -4), profiles["Troll"]);
+		Assert.IsTrue(profiles["Troll"].StrengthBonus > profiles["Orc"].StrengthBonus);
+		Assert.IsTrue(profiles["Elf"].DexterityBonus > profiles["Dwarf"].DexterityBonus);
+	}
+
+	[TestMethod]
 	public void CultureSeeder_FallbackProfiles_MakeBaseNameCulturesReadyAndRemainRerunnable()
 	{
 		using FuturemudDatabaseContext context = BuildContext();

--- a/DatabaseSeeder Unit Tests/HealthSeederTests.cs
+++ b/DatabaseSeeder Unit Tests/HealthSeederTests.cs
@@ -77,7 +77,6 @@ public class HealthSeederTests
             Description = "Organic Humanoid test race",
             BaseBodyId = 0,
             AllowedGenders = "Male Female Neuter NonBinary",
-            AttributeBonusProgId = 0,
             DiceExpression = "1d100",
             CorpseModelId = 0,
             DefaultHealthStrategyId = 0,

--- a/DatabaseSeeder Unit Tests/MythicalAnimalSeederTemplateTests.cs
+++ b/DatabaseSeeder Unit Tests/MythicalAnimalSeederTemplateTests.cs
@@ -566,7 +566,7 @@ public class MythicalAnimalSeederTemplateTests
     {
         Assert.AreEqual("Beast Artillery", MythicalAnimalSeeder.TemplatesForTesting["Dragon"].CombatStrategyKey);
         Assert.AreEqual("Beast Swooper", MythicalAnimalSeeder.TemplatesForTesting["Griffin"].CombatStrategyKey);
-        Assert.AreEqual("Beast Behemoth", MythicalAnimalSeeder.TemplatesForTesting["Unicorn"].CombatStrategyKey);
+        Assert.AreEqual("Beast Skirmisher", MythicalAnimalSeeder.TemplatesForTesting["Unicorn"].CombatStrategyKey);
         Assert.AreEqual("Beast Clincher", MythicalAnimalSeeder.TemplatesForTesting["Basilisk"].CombatStrategyKey);
         Assert.AreEqual("Beast Artillery", MythicalAnimalSeeder.TemplatesForTesting["Wyvern"].CombatStrategyKey);
         Assert.AreEqual("Beast Skirmisher", MythicalAnimalSeeder.TemplatesForTesting["Warg"].CombatStrategyKey);
@@ -580,6 +580,35 @@ public class MythicalAnimalSeederTemplateTests
         Assert.AreEqual("Beast Clincher", MythicalAnimalSeeder.TemplatesForTesting["Giant Centipede"].CombatStrategyKey);
         Assert.AreEqual("Beast Artillery", MythicalAnimalSeeder.TemplatesForTesting["Ankheg"].CombatStrategyKey);
         Assert.AreEqual("Melee (Auto)", MythicalAnimalSeeder.TemplatesForTesting["Centaur"].CombatStrategyKey);
+    }
+
+    [TestMethod]
+    public void TemplatesForTesting_SecondPassAttributeProfiles_ReflectMythicBodyPlans()
+    {
+        Assert.AreEqual(new NonHumanAttributeProfile(12, 11, 0, -2),
+            MythicalAnimalSeeder.TemplatesForTesting["Dragon"].AttributeProfile,
+            "True dragons should remain the top brute-force mythic baseline.");
+        Assert.AreEqual(new NonHumanAttributeProfile(10, 9, 2, 0),
+            MythicalAnimalSeeder.TemplatesForTesting["Eastern Dragon"].AttributeProfile,
+            "Eastern dragons should be less blocky and more sinuous than western dragons.");
+        Assert.AreEqual(new NonHumanAttributeProfile(6, 5, 4, 1),
+            MythicalAnimalSeeder.TemplatesForTesting["Unicorn"].AttributeProfile,
+            "Unicorns should read as powerful but unusually graceful equines.");
+        Assert.AreEqual(new NonHumanAttributeProfile(5, 4, 5, 1),
+            MythicalAnimalSeeder.TemplatesForTesting["Pegasus"].AttributeProfile,
+            "Pegasi should be driven more by flight athletics than raw mass.");
+        Assert.AreEqual(new NonHumanAttributeProfile(2, 2, 5, 3),
+            MythicalAnimalSeeder.TemplatesForTesting["Phoenix"].AttributeProfile,
+            "Phoenixes should be high-agility aerial threats rather than heavy bruisers.");
+        Assert.AreEqual(new NonHumanAttributeProfile(7, 9, -3, -3),
+            MythicalAnimalSeeder.TemplatesForTesting["Ent"].AttributeProfile,
+            "Ents should be massively strong and durable but ponderous.");
+        Assert.AreEqual(new NonHumanAttributeProfile(-1, 1, 2, 2),
+            MythicalAnimalSeeder.TemplatesForTesting["Dryad"].AttributeProfile,
+            "Dryads should favour grace and finesse over raw strength.");
+        Assert.AreEqual(new NonHumanAttributeProfile(6, 5, 2, 0),
+            MythicalAnimalSeeder.TemplatesForTesting["Centaur"].AttributeProfile,
+            "Centaurs should preserve horse-body strength while gaining open-country mobility.");
     }
 
     [TestMethod]

--- a/DatabaseSeeder Unit Tests/RobotSeederTemplateTests.cs
+++ b/DatabaseSeeder Unit Tests/RobotSeederTemplateTests.cs
@@ -49,7 +49,7 @@ public class RobotSeederTemplateTests
         };
     }
 
-    private static Race CreateRace(long id, string name, long baseBodyId, long corpseModelId, long attributeBonusProgId)
+    private static Race CreateRace(long id, string name, long baseBodyId, long corpseModelId)
     {
         return new Race
         {
@@ -58,7 +58,6 @@ public class RobotSeederTemplateTests
             Description = $"{name} test race",
             BaseBodyId = baseBodyId,
             AllowedGenders = "Male Female Neuter NonBinary",
-            AttributeBonusProgId = attributeBonusProgId,
             DiceExpression = "1d100",
             CorpseModelId = corpseModelId,
             DefaultHealthStrategyId = 1,
@@ -409,8 +408,8 @@ public class RobotSeederTemplateTests
             Definition = "<Definition />"
         });
         context.Races.AddRange(
-            CreateRace(1, "Human", 1, 1, 1),
-            CreateRace(2, "Humanoid", 1, 2, 1));
+            CreateRace(1, "Human", 1, 1),
+            CreateRace(2, "Humanoid", 1, 2));
         context.CharacteristicDefinitions.AddRange(
             CreateCharacteristicDefinition(1, "All Eye Colours"),
             CreateCharacteristicDefinition(2, "All Eye Shapes"),

--- a/DatabaseSeeder Unit Tests/RobotSeederTemplateTests.cs
+++ b/DatabaseSeeder Unit Tests/RobotSeederTemplateTests.cs
@@ -162,6 +162,29 @@ public class RobotSeederTemplateTests
     }
 
     [TestMethod]
+    public void TemplatesForTesting_SecondPassAttributeProfiles_DifferentiateRobotChassis()
+    {
+        Assert.AreEqual(new NonHumanAttributeProfile(6, 5, -1, -2),
+            RobotSeeder.GetRobotAttributeProfileForTesting(RobotSeeder.TemplatesForTesting["Pneumatic Hammer Robot"]),
+            "Hammer robots should be strong and shock-resistant but clumsy.");
+        Assert.AreEqual(new NonHumanAttributeProfile(3, 2, 2, 2),
+            RobotSeeder.GetRobotAttributeProfileForTesting(RobotSeeder.TemplatesForTesting["Sword-Hand Robot"]),
+            "Sword-hand robots should favour articulated attack precision.");
+        Assert.AreEqual(new NonHumanAttributeProfile(1, 1, 3, 1),
+            RobotSeeder.GetRobotAttributeProfileForTesting(RobotSeeder.TemplatesForTesting["Winged Robot"]),
+            "Winged robots should trade raw frame mass for aerial agility.");
+        Assert.AreEqual(new NonHumanAttributeProfile(4, 5, -2, -2),
+            RobotSeeder.GetRobotAttributeProfileForTesting(RobotSeeder.TemplatesForTesting["Tracked Robot"]),
+            "Tracked humanoid robots should be sturdy and forceful rather than nimble.");
+        Assert.AreEqual(new NonHumanAttributeProfile(-4, 1, 2, 0),
+            RobotSeeder.GetRobotAttributeProfileForTesting(RobotSeeder.TemplatesForTesting["Roomba Robot"]),
+            "Roombas should be weak maintenance drones with modest evasive mobility.");
+        Assert.AreEqual(new NonHumanAttributeProfile(-4, 3, 4, 1),
+            RobotSeeder.GetRobotAttributeProfileForTesting(RobotSeeder.TemplatesForTesting["Robot Cockroach"]),
+            "Robot cockroaches should be small, fast and surprisingly hard-wearing for their scale.");
+    }
+
+    [TestMethod]
     public void TemplatesForTesting_AttachmentVariants_UseIntegratedWeaponBodies()
     {
         RobotSeeder.RobotRaceTemplate sawRobot = RobotSeeder.TemplatesForTesting["Circular Saw Robot"];

--- a/DatabaseSeeder Unit Tests/StockMeritsSeederTests.cs
+++ b/DatabaseSeeder Unit Tests/StockMeritsSeederTests.cs
@@ -156,7 +156,6 @@ public class StockMeritsSeederTests
             Description = "Human test race",
             BaseBodyId = 1,
             AllowedGenders = "Male Female Neuter NonBinary",
-            AttributeBonusProgId = 1,
             DiceExpression = "1d100",
             CorpseModelId = 0,
             DefaultHealthStrategyId = 0,

--- a/DatabaseSeeder/Seeders/AnimalSeeder.AttributeScaling.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.AttributeScaling.cs
@@ -22,12 +22,12 @@ public partial class AnimalSeeder
 			["wolfpack"] = new(3, 2, 1, 1),
 			["big-cat"] = new(4, 3, 2, 1),
 			["bear"] = new(5, 5, -1, -1),
-			["goat"] = new(1, 2, 0, -1),
-			["herbivore-charge"] = new(3, 4, -1, -1),
-			["tusked-herbivore"] = new(4, 4, -1, -1),
-			["camelid-spitter"] = new(1, 2, 0, 0),
-			["antlered-herbivore"] = new(2, 3, 0, -1),
-			["bovid"] = new(2, 3, -1, -1),
+			["goat"] = new(1, 1, 1, 0),
+			["herbivore-charge"] = new(3, 3, 1, -1),
+			["tusked-herbivore"] = new(5, 4, 0, -1),
+			["camelid-spitter"] = new(1, 1, 1, 0),
+			["antlered-herbivore"] = new(2, 2, 1, -1),
+			["bovid"] = new(3, 3, 0, -1),
 			["hippo"] = new(5, 5, -2, -2),
 			["rhino"] = new(6, 5, -2, -2),
 			["elephant"] = new(7, 7, -2, -2),
@@ -45,7 +45,7 @@ public partial class AnimalSeeder
 			["bird-small"] = new(-2, -2, 3, 2),
 			["bird-fowl"] = new(-1, -1, 1, 0),
 			["bird-raptor"] = new(1, 0, 3, 2),
-			["bird-flightless"] = new(1, 2, 1, -1),
+			["bird-flightless"] = new(2, 2, 2, -1),
 			["serpent-constrictor"] = new(2, 4, 0, -1),
 			["serpent-neurotoxic"] = new(1, 0, 2, 1),
 			["serpent-hemotoxic"] = new(1, 0, 2, 1),
@@ -76,7 +76,16 @@ public partial class AnimalSeeder
 			["Lion"] = new(2, 1, 0, 0),
 			["Tiger"] = new(3, 2, 0, 0),
 			["Sabretooth Tiger"] = new(4, 3, -1, -1),
+			["Cheetah"] = new(-3, -2, 2, 0),
+			["Leopard"] = new(0, 0, 1, 0),
+			["Panther"] = new(0, 0, 1, 0),
+			["Jaguar"] = new(1, 1, 0, -1),
+			["Deer"] = new(-1, -1, 1, 0),
 			["Bear"] = new(2, 2, -1, -1),
+			["Sheep"] = new(-2, -1, 0, 0),
+			["Horse"] = new(-1, -1, 2, 1),
+			["Cow"] = new(-1, -1, 0, 0),
+			["Giraffe"] = new(-1, -2, 2, 0),
 			["Moose"] = new(2, 2, -1, -1),
 			["Rhinocerous"] = new(2, 2, -1, -1),
 			["Hippopotamus"] = new(3, 3, -1, -1),
@@ -88,10 +97,18 @@ public partial class AnimalSeeder
 			["Baleen Whale"] = new(1, 3, -1, -1),
 			["Giant Squid"] = new(2, 1, 0, 0),
 			["Crocodile"] = new(2, 2, 0, -1),
-			["Alligator"] = new(1, 1, 0, -1)
+			["Alligator"] = new(1, 1, 0, -1),
+			["Emu"] = new(-1, -1, 2, 0),
+			["Ostrich"] = new(0, 0, 2, 0),
+			["Moa"] = new(2, 2, 0, -1)
 		};
 
-	private NonHumanAttributeProfile GetAnimalAttributeProfile(AnimalRaceTemplate template)
+	internal static NonHumanAttributeProfile GetAnimalAttributeProfileForTesting(AnimalRaceTemplate template)
+	{
+		return GetAnimalAttributeProfile(template);
+	}
+
+	private static NonHumanAttributeProfile GetAnimalAttributeProfile(AnimalRaceTemplate template)
 	{
 		var profile = GetAnimalSizeProfile(template.Size)
 			.Add(GetAnimalBodypartHealthProfile(template.BodypartHealthMultiplier));

--- a/DatabaseSeeder/Seeders/AnimalSeeder.AttributeScaling.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.AttributeScaling.cs
@@ -1,8 +1,6 @@
 #nullable enable
 
 using MudSharp.Body.Traits;
-using MudSharp.Framework;
-using MudSharp.FutureProg;
 using MudSharp.GameItems;
 using MudSharp.Models;
 using System;
@@ -136,32 +134,4 @@ public partial class AnimalSeeder
 		return new(strengthBonus, constitutionBonus, 0, 0);
 	}
 
-	private FutureProg CreateAnimalAttributeBonusProg(string raceName, NonHumanAttributeProfile profile)
-	{
-		var progText = NonHumanAttributeScalingHelper.BuildAttributeBonusProgText(
-			_context.TraitDefinitions.Where(x => x.Type == (int)TraitType.Attribute),
-			profile);
-
-		var attributeBonusProg = new FutureProg
-		{
-			FunctionName = $"{raceName.CollapseString()}AttributeBonus",
-			FunctionComment = $"Racial attribute bonuses for the {raceName} race",
-			AcceptsAnyParameters = false,
-			Category = "Character",
-			Subcategory = "Attributes",
-			ReturnType = (long)ProgVariableTypes.Number,
-			FunctionText = progText
-		};
-
-		attributeBonusProg.FutureProgsParameters.Add(new FutureProgsParameter
-		{
-			FutureProg = attributeBonusProg,
-			ParameterIndex = 0,
-			ParameterName = "trait",
-			ParameterType = (long)ProgVariableTypes.Trait
-		});
-
-		_context.FutureProgs.Add(attributeBonusProg);
-		return attributeBonusProg;
-	}
 }

--- a/DatabaseSeeder/Seeders/AnimalSeeder.BirdTemplates.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.BirdTemplates.cs
@@ -205,14 +205,14 @@ public partial class AnimalSeeder
                 "Its narrow head and powerful thighs make it look built for speed over rough ground.",
                 "It seems more likely to outrun danger than to rise above it.",
                 "scrubland and open plain"),
-            combatStrategyKey: "Beast Behemoth");
+            combatStrategyKey: "Beast Skirmisher");
         yield return Bird("Ostrich", SizeCategory.Normal, 0.8, "Flightless Bird", "bird-flightless",
             BirdPack("an ostrich chick", "a young ostrich", "an ostrich",
                 "It is huge, long-necked and massively legged, its body topped by soft black-and-white plumage.",
                 "Its feet and legs are terrifyingly strong for any creature willing to stand in kicking distance.",
                 "It carries itself with wary hauteur and tremendous athletic tension.",
                 "savannah and dry open plain"),
-            combatStrategyKey: "Beast Behemoth");
+            combatStrategyKey: "Beast Skirmisher");
         yield return Bird("Moa", SizeCategory.Normal, 0.8, "Flightless Bird", "bird-flightless",
             BirdPack("a moa chick", "a young moa", "a moa",
                 "It is immense and heavy-bodied, with stout legs and a thick neck.",

--- a/DatabaseSeeder/Seeders/AnimalSeeder.CombatRebalance.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.CombatRebalance.cs
@@ -34,6 +34,7 @@ public partial class AnimalSeeder
 				["Animal Mandible Damage"] = $"0.24 * (str:{_strengthTrait.Id} + (2 * quality)) * sqrt(degree+1)",
 				["Animal Ram Damage"] = $"0.48 * (str:{_strengthTrait.Id} + (2 * quality)) * sqrt(degree+1)",
 				["Animal Smash Damage"] = $"0.44 * (str:{_strengthTrait.Id} + (2 * quality)) * sqrt(degree+1)",
+				["Dragonfire Breath Damage"] = "0.44 * (24 + (3 * quality)) * sqrt(degree+1)",
 				["Animal Coup De Grace Damage"] = $"0.90 * str:{_strengthTrait.Id} * quality * sqrt(degree+1)",
 				["Snake Bite Damage"] = $"0.30 * (str:{_strengthTrait.Id} + (3 * quality)) * sqrt(degree+1)"
 			};
@@ -63,6 +64,7 @@ public partial class AnimalSeeder
 			["Animal Mandible Damage"] = $"0.35 * (str:{_strengthTrait.Id} + (2 * quality)) * sqrt(degree+1){randomPortion}",
 			["Animal Ram Damage"] = $"0.9 * (str:{_strengthTrait.Id} + (2 * quality)) * sqrt(degree+1){randomPortion}",
 			["Animal Smash Damage"] = $"0.8 * (str:{_strengthTrait.Id} + (2 * quality)) * sqrt(degree+1){randomPortion}",
+			["Dragonfire Breath Damage"] = $"0.65 * (24 + (3 * quality)) * sqrt(degree+1){randomPortion}",
 			["Animal Coup De Grace Damage"] = $"1.5 * str:{_strengthTrait.Id} * quality * sqrt(degree+1){randomPortion}",
 			["Snake Bite Damage"] = $"0.5 * (str:{_strengthTrait.Id} + (3 * quality)) * sqrt(degree+1){randomPortion}"
 		};
@@ -282,6 +284,8 @@ public partial class AnimalSeeder
 			EnsureAnimalDamageExpression(formula.Key, formula.Value);
 		}
 
+		RefreshDragonfireBreathDamageExpression(expressions);
+
 		foreach (string bodyName in new[]
 		         {
 			         "Quadruped Base",
@@ -320,5 +324,21 @@ public partial class AnimalSeeder
 
 		ApplyDefaultCombatSettingsToSeededRaces();
 		_context.SaveChanges();
+	}
+
+	private void RefreshDragonfireBreathDamageExpression(IReadOnlyDictionary<string, string> expressions)
+	{
+		TraitExpression dragonfireDamage = EnsureAnimalDamageExpression(
+			"Dragonfire Breath Damage",
+			expressions["Dragonfire Breath Damage"]);
+		WeaponAttack? dragonfire = _context.WeaponAttacks.FirstOrDefault(x => x.Name == "Dragonfire Breath");
+		if (dragonfire is null)
+		{
+			return;
+		}
+
+		dragonfire.DamageExpression = dragonfireDamage;
+		dragonfire.PainExpression = dragonfireDamage;
+		dragonfire.StunExpression = dragonfireDamage;
 	}
 }

--- a/DatabaseSeeder/Seeders/AnimalSeeder.Mammals.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.Mammals.cs
@@ -286,7 +286,7 @@ public partial class AnimalSeeder
                 "Its beard, angular skull and sweeping horns give it a stubbornly self-possessed look.",
                 "It looks happiest when climbing where other animals should not.",
                 "crags, rough pasture and broken hills"),
-            "Goats", usages: hornedFemale, combatStrategyKey: "Beast Behemoth");
+            "Goats", usages: hornedFemale, combatStrategyKey: "Beast Skirmisher");
         yield return Mammal("Llama", "Llama", "Ungulate", SizeCategory.Normal, 1.0, "Large Ungulate",
             "stock-mammal", "camelid-spitter",
             MammalPack("a cria", "a young male llama", "a young female llama", "a male llama", "a female llama",
@@ -421,7 +421,7 @@ public partial class AnimalSeeder
                 "Its calm eyes and sweeping ribs speak of a lifetime spent grazing and ruminating.",
                 "It has the placid, heavy patience of domestic stock.",
                 "pasture, open field and cattle yard"),
-            "Cows", bloodProfile: "bovine", usages: hornedFemale, combatStrategyKey: "Beast Behemoth");
+            "Cows", bloodProfile: "bovine", usages: hornedFemale, combatStrategyKey: "Beast Coward");
         yield return Mammal("Ox", "Ox", "Ungulate", SizeCategory.Large, 1.7, "Large Ungulate",
             "stock-mammal", "bovid",
             MammalPack("a calf", "a young bull", "a young cow", "an ox", "a cow",
@@ -429,7 +429,7 @@ public partial class AnimalSeeder
                 "Its sheer frame suggests hauling power rather than speed or elegance.",
                 "It stands with the settled endurance of a working beast.",
                 "field, road and draft yard"),
-            "Oxen", usages: hornedFemale, combatStrategyKey: "Beast Behemoth");
+            "Oxen", usages: hornedFemale, combatStrategyKey: "Beast Brawler");
         yield return Mammal("Bison", "Bison", "Ungulate", SizeCategory.Large, 1.5, "Large Ungulate",
             "stock-mammal", "bovid",
             MammalPack("a bison calf", "a young bull bison", "a young cow bison", "a bull bison", "a cow bison",
@@ -453,7 +453,7 @@ public partial class AnimalSeeder
                 "Its long face, lively ears and large dark eyes give it an intelligent, responsive look.",
                 "It carries itself with a mixture of high-strung energy and practiced athleticism.",
                 "plain, pasture and stable"),
-            "Horse", canClimb: false, bloodProfile: "equine", usages: udder, combatStrategyKey: "Beast Behemoth");
+            "Horse", canClimb: false, bloodProfile: "equine", usages: udder, combatStrategyKey: "Beast Skirmisher");
         yield return Mammal("Rhinocerous", "Ceratorhine", "Ungulate", SizeCategory.Large, 1.5, "Pachyderm",
             "large-hooved", "rhino",
             MammalPack("a rhino calf", "a young bull rhino", "a young cow rhino", "a bull rhino", "a cow rhino",
@@ -493,6 +493,6 @@ public partial class AnimalSeeder
                 "Its small horn-like ossicones and impossibly elevated head give it a peculiar dignity.",
                 "It lopes rather than walks, with an awkward grace all its own.",
                 "dry savannah and scattered acacia country"),
-            combatStrategyKey: "Beast Behemoth");
+            combatStrategyKey: "Beast Skirmisher");
     }
 }

--- a/DatabaseSeeder/Seeders/AnimalSeeder.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.cs
@@ -3867,11 +3867,9 @@ Warning: There is an enormous amount of data contained in this seeder, and it ma
             }
         }
 
-        FutureProg attributeBonusProg = CreateAnimalAttributeBonusProg(
-            name,
-            raceTemplate is not null
-                ? GetAnimalAttributeProfile(raceTemplate)
-                : new NonHumanAttributeProfile(0, 0, 0, 0));
+        NonHumanAttributeProfile attributeProfile = raceTemplate is not null
+            ? GetAnimalAttributeProfile(raceTemplate)
+            : new NonHumanAttributeProfile(0, 0, 0, 0);
 
         Material driedBlood = new()
         {
@@ -4030,7 +4028,6 @@ Warning: There is an enormous amount of data contained in this seeder, and it ma
                             : description,
             BaseBody = body,
             AllowedGenders = "2 3",
-            AttributeBonusProg = attributeBonusProg,
             AttributeTotalCap = _context.TraitDefinitions.Count(x => x.Type == 1) * 12,
             IndividualAttributeCap = 20,
             DiceExpression = "3d6+1",
@@ -4087,7 +4084,12 @@ Warning: There is an enormous amount of data contained in this seeder, and it ma
         foreach (TraitDefinition attribute in _attributes)
         {
             _context.RacesAttributes.Add(new RacesAttributes
-            { Race = race, Attribute = attribute, IsHealthAttribute = attribute.TraitGroup == "Physical" });
+            {
+                Race = race,
+                Attribute = attribute,
+                IsHealthAttribute = attribute.TraitGroup == "Physical",
+                AttributeBonus = NonHumanAttributeScalingHelper.GetAttributeBonus(attribute, attributeProfile)
+            });
         }
 
         CreateEthnicitiesForRace(race);

--- a/DatabaseSeeder/Seeders/AnimalSeeder.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.cs
@@ -1783,6 +1783,7 @@ Warning: There is an enormous amount of data contained in this seeder, and it ma
             GetOrCreateExpression("Animal Smash Damage", damageExpressions["Animal Smash Damage"]);
             GetOrCreateExpression("Animal Coup De Grace Damage",
                 damageExpressions["Animal Coup De Grace Damage"]);
+            RefreshDragonfireBreathDamageExpression(damageExpressions);
             _snakeBiteDamage = GetOrCreateExpression("Snake Bite Damage",
                 damageExpressions["Snake Bite Damage"]);
 
@@ -1992,6 +1993,14 @@ Warning: There is an enormous amount of data contained in this seeder, and it ma
                 Expression = damageExpressions["Animal Smash Damage"]
             };
             _context.TraitExpressions.Add(smashDamage);
+            _context.SaveChanges();
+
+            TraitExpression dragonfireDamage = new()
+            {
+                Name = "Dragonfire Breath Damage",
+                Expression = damageExpressions["Dragonfire Breath Damage"]
+            };
+            _context.TraitExpressions.Add(dragonfireDamage);
             _context.SaveChanges();
 
             TraitExpression coupDamage = new()
@@ -2413,7 +2422,7 @@ Warning: There is an enormous amount of data contained in this seeder, and it ma
             _attacks["dragonfirebreath"] = _context.WeaponAttacks.FirstOrDefault(x => x.Name == "Dragonfire Breath") ??
                 AddAttack("Dragonfire Breath", BuiltInCombatMoveType.BreathWeaponAttack,
                     MeleeWeaponVerb.Blast, Difficulty.Hard, Difficulty.Hard, Difficulty.Hard, Difficulty.Hard,
-                    Alignment.Front, Orientation.High, 10.0, 1.6, mouthshape, smashDamage,
+                    Alignment.Front, Orientation.High, 10.0, 1.6, mouthshape, dragonfireDamage,
                     $"@ rear|rears up and unleash|unleashes a roaring cone of dragonfire at $1{attackAddendum}", DamageType.Burning,
                     intentions: CombatMoveIntentions.Attack | CombatMoveIntentions.Wound | CombatMoveIntentions.Burning | CombatMoveIntentions.Hard | CombatMoveIntentions.Slow,
                     additionalInfo: BreathAttackData(2, RangedScatterType.Light, 3, 2, 0.35, "Dragonfire", 0.45, 0.35, 0.1, 2.5, 0.2, 0.05, true));

--- a/DatabaseSeeder/Seeders/CultureSeederHeritage.cs
+++ b/DatabaseSeeder/Seeders/CultureSeederHeritage.cs
@@ -8,6 +8,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
 
+using MudSharp.Body.Traits;
+
 namespace DatabaseSeeder.Seeders;
 
 public partial class CultureSeeder
@@ -31,6 +33,27 @@ public partial class CultureSeeder
         string description = "")
     {
         EnsureEthnicity(race, name, group, bloodGroup, tempFloor, tempCeiling, subgroup, available, description);
+    }
+
+    private void AddRaceAttributeAlterations(Race race, NonHumanAttributeProfile profile)
+    {
+        foreach (TraitDefinition attribute in _context.TraitDefinitions
+                     .Where(x => x.Type == (int)TraitType.Attribute || x.Type == (int)TraitType.DerivedAttribute)
+                     .ToList())
+        {
+            if (_context.RacesAttributes.Any(x => x.Race == race && x.Attribute == attribute))
+            {
+                continue;
+            }
+
+            _context.RacesAttributes.Add(new RacesAttributes
+            {
+                Race = race,
+                Attribute = attribute,
+                IsHealthAttribute = attribute.TraitGroup == "Physical",
+                AttributeBonus = NonHumanAttributeScalingHelper.GetAttributeBonus(attribute, profile)
+            });
+        }
     }
 
     public void AddEthnicityVariable(string ethnicity, string feature, string profile)
@@ -2869,31 +2892,6 @@ return true"
             ParameterName = "ch"
         });
         _context.FutureProgs.Add(canSelectElfProg);
-        FutureProg elfAttributeProg = new()
-        {
-            FunctionName = "ElfBonusAttributes",
-            Category = "Character",
-            Subcategory = "Attributes",
-            FunctionComment =
-                "This prog is called for each attribute for elves at chargen time and the resulting value is applied as a modifier to that attribute.",
-            ReturnType = (long)ProgVariableTypes.Number,
-            StaticType = 0,
-            FunctionText = @"// You might consider a switch on attributes like so:
-//
-// switch (@trait.Name)
-//   case (""Dexterity"")
-//     return 2
-// end switch
-return 0"
-        };
-        elfAttributeProg.FutureProgsParameters.Add(new FutureProgsParameter
-        {
-            FutureProg = elfAttributeProg,
-            ParameterName = "trait",
-            ParameterIndex = 0,
-            ParameterType = 16384
-        });
-        _context.FutureProgs.Add(elfAttributeProg);
         _context.SaveChanges();
 
         (Liquid? elfBlood, Liquid? elfSweat, Material? driedElfBlood, Material? driedElfSweat) = CreateBloodAndSweat("Elven");
@@ -2947,7 +2945,6 @@ Elves are divided into several different clans, each with their own distinct cul
             AdultAge = 200,
             ElderAge = 1000,
             VenerableAge = 3000,
-            AttributeBonusProg = elfAttributeProg,
             AvailabilityProg = canSelectElfProg,
             BaseBody = body,
             BloodLiquid = elfBlood,
@@ -2958,6 +2955,7 @@ Elves are divided into several different clans, each with their own distinct cul
             SweatLiquid = elfSweat
         };
         _context.Races.Add(elfRace);
+        AddRaceAttributeAlterations(elfRace, new NonHumanAttributeProfile(-1, -1, 2, 2));
 
         HeightWeightModel elfMaleHWModel = new()
         {
@@ -3559,31 +3557,6 @@ return true"
             ParameterName = "ch"
         });
         _context.FutureProgs.Add(canSelectHobbitProg);
-        FutureProg hobbitAttributeProg = new()
-        {
-            FunctionName = "HobbitBonusAttributes",
-            Category = "Character",
-            Subcategory = "Attributes",
-            FunctionComment =
-                "This prog is called for each attribute for hobbits at chargen time and the resulting value is applied as a modifier to that attribute.",
-            ReturnType = (long)ProgVariableTypes.Number,
-            StaticType = 0,
-            FunctionText = @"// You might consider a switch on attributes like so:
-//
-// switch (@trait.Name)
-//   case (""Dexterity"")
-//     return 2
-// end switch
-return 0"
-        };
-        hobbitAttributeProg.FutureProgsParameters.Add(new FutureProgsParameter
-        {
-            FutureProg = hobbitAttributeProg,
-            ParameterName = "trait",
-            ParameterIndex = 0,
-            ParameterType = 16384
-        });
-        _context.FutureProgs.Add(hobbitAttributeProg);
         _context.SaveChanges();
 
         (Liquid? hobbitBlood, Liquid? hobbitSweat, Material _, Material _) = CreateBloodAndSweat("Hobbit");
@@ -3639,7 +3612,6 @@ Hobbits are divided into several different clans, each with its own distinct cul
             AdultAge = 30,
             ElderAge = 70,
             VenerableAge = 100,
-            AttributeBonusProg = hobbitAttributeProg,
             AvailabilityProg = canSelectHobbitProg,
             BaseBody = body,
             BloodLiquid = hobbitBlood,
@@ -3650,6 +3622,7 @@ Hobbits are divided into several different clans, each with its own distinct cul
             SweatLiquid = hobbitSweat
         };
         _context.Races.Add(hobbitRace);
+        AddRaceAttributeAlterations(hobbitRace, new NonHumanAttributeProfile(-2, 1, 0, 1));
         HeightWeightModel hobbitMaleHWModel = new()
         {
             Name = "Hobbit Male",
@@ -3945,31 +3918,6 @@ return true"
             ParameterName = "ch"
         });
         _context.FutureProgs.Add(canSelectDwarfProg);
-        FutureProg dwarfAttributeProg = new()
-        {
-            FunctionName = "DwarfBonusAttributes",
-            Category = "Character",
-            Subcategory = "Attributes",
-            FunctionComment =
-                "This prog is called for each attribute for dwarves at chargen time and the resulting value is applied as a modifier to that attribute.",
-            ReturnType = (long)ProgVariableTypes.Number,
-            StaticType = 0,
-            FunctionText = @"// You might consider a switch on attributes like so:
-//
-// switch (@trait.Name)
-//   case (""Strength"")
-//     return 2
-// end switch
-return 0"
-        };
-        dwarfAttributeProg.FutureProgsParameters.Add(new FutureProgsParameter
-        {
-            FutureProg = dwarfAttributeProg,
-            ParameterName = "trait",
-            ParameterIndex = 0,
-            ParameterType = 16384
-        });
-        _context.FutureProgs.Add(dwarfAttributeProg);
         _context.SaveChanges();
 
         (Liquid? dwarfBlood, Liquid? dwarfSweat, Material _, Material _) = CreateBloodAndSweat("Dwarf");
@@ -4025,7 +3973,6 @@ Dwarves are divided into several different clans, each with its own distinct cul
             AdultAge = 75,
             ElderAge = 200,
             VenerableAge = 300,
-            AttributeBonusProg = dwarfAttributeProg,
             AvailabilityProg = canSelectDwarfProg,
             BaseBody = body,
             BloodLiquid = dwarfBlood,
@@ -4036,6 +3983,7 @@ Dwarves are divided into several different clans, each with its own distinct cul
             SweatLiquid = dwarfSweat
         };
         _context.Races.Add(dwarfRace);
+        AddRaceAttributeAlterations(dwarfRace, new NonHumanAttributeProfile(2, 3, -1, 0));
         HeightWeightModel dwarfMaleHWModel = new()
         {
             Name = "Dwarf Male",
@@ -4380,31 +4328,6 @@ return true"
             ParameterName = "ch"
         });
         _context.FutureProgs.Add(canSelectOrcProg);
-        FutureProg orcAttributeProg = new()
-        {
-            FunctionName = "OrcBonusAttributes",
-            Category = "Character",
-            Subcategory = "Attributes",
-            FunctionComment =
-                "This prog is called for each attribute for orcs at chargen time and the resulting value is applied as a modifier to that attribute.",
-            ReturnType = (long)ProgVariableTypes.Number,
-            StaticType = 0,
-            FunctionText = @"// You might consider a switch on attributes like so:
-//
-// switch (@trait.Name)
-//   case (""Strength"")
-//     return 2
-// end switch
-return 0"
-        };
-        orcAttributeProg.FutureProgsParameters.Add(new FutureProgsParameter
-        {
-            FutureProg = orcAttributeProg,
-            ParameterName = "trait",
-            ParameterIndex = 0,
-            ParameterType = 16384
-        });
-        _context.FutureProgs.Add(orcAttributeProg);
         _context.SaveChanges();
 
         (Liquid? orcBlood, Liquid? orcSweat, Material _, Material _) = CreateBloodAndSweat("Orc");
@@ -4460,7 +4383,6 @@ Orcish cultural practices are centered around warfare and domination. Orcs are c
             AdultAge = 22,
             ElderAge = 40,
             VenerableAge = 60,
-            AttributeBonusProg = orcAttributeProg,
             AvailabilityProg = canSelectOrcProg,
             BaseBody = body,
             BloodLiquid = orcBlood,
@@ -4471,6 +4393,7 @@ Orcish cultural practices are centered around warfare and domination. Orcs are c
             SweatLiquid = orcSweat
         };
         _context.Races.Add(orcRace);
+        AddRaceAttributeAlterations(orcRace, new NonHumanAttributeProfile(2, 1, 0, -1));
         HeightWeightModel orcMaleHWModel = new()
         {
             Name = "Orc Male",
@@ -4749,31 +4672,6 @@ return true"
             ParameterName = "ch"
         });
         _context.FutureProgs.Add(canSelectTrollProg);
-        FutureProg trollAttributeProg = new()
-        {
-            FunctionName = "TrollBonusAttributes",
-            Category = "Character",
-            Subcategory = "Attributes",
-            FunctionComment =
-                "This prog is called for each attribute for trolls at chargen time and the resulting value is applied as a modifier to that attribute.",
-            ReturnType = (long)ProgVariableTypes.Number,
-            StaticType = 0,
-            FunctionText = @"// You might consider a switch on attributes like so:
-//
-// switch (@trait.Name)
-//   case (""Strength"")
-//     return 2
-// end switch
-return 0"
-        };
-        trollAttributeProg.FutureProgsParameters.Add(new FutureProgsParameter
-        {
-            FutureProg = trollAttributeProg,
-            ParameterName = "trait",
-            ParameterIndex = 0,
-            ParameterType = 16384
-        });
-        _context.FutureProgs.Add(trollAttributeProg);
         _context.SaveChanges();
 
         (Liquid? trollBlood, Liquid? trollSweat, Material _, Material _) = CreateBloodAndSweat("Troll");
@@ -4829,7 +4727,6 @@ Trolls are primarily scavengers and predators, and will eat anything they can ca
             AdultAge = 22,
             ElderAge = 40,
             VenerableAge = 60,
-            AttributeBonusProg = trollAttributeProg,
             AvailabilityProg = canSelectTrollProg,
             BaseBody = body,
             BloodLiquid = trollBlood,
@@ -4840,6 +4737,7 @@ Trolls are primarily scavengers and predators, and will eat anything they can ca
             SweatLiquid = trollSweat
         };
         _context.Races.Add(trollRace);
+        AddRaceAttributeAlterations(trollRace, new NonHumanAttributeProfile(8, 7, -3, -3));
         HeightWeightModel trollMaleHWModel = new()
         {
             Name = "Troll Male",

--- a/DatabaseSeeder/Seeders/CultureSeederHeritage.cs
+++ b/DatabaseSeeder/Seeders/CultureSeederHeritage.cs
@@ -28,6 +28,19 @@ public partial class CultureSeeder
 
     private readonly Dictionary<string, Race> _races = new(StringComparer.OrdinalIgnoreCase);
 
+    internal static IReadOnlyDictionary<string, NonHumanAttributeProfile> CultureRaceAttributeProfilesForTesting =>
+        CultureRaceAttributeProfiles;
+
+    private static readonly IReadOnlyDictionary<string, NonHumanAttributeProfile> CultureRaceAttributeProfiles =
+        new Dictionary<string, NonHumanAttributeProfile>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Elf"] = new(-1, 0, 2, 3),
+            ["Hobbit"] = new(-3, 2, 1, 2),
+            ["Dwarf"] = new(2, 4, -1, 0),
+            ["Orc"] = new(3, 2, 0, -1),
+            ["Troll"] = new(9, 8, -3, -4)
+        };
+
     public void AddEthnicity(Race race, string name, string group, string bloodGroup,
         double tempFloor = 0.0, double tempCeiling = 0.0, string subgroup = "", FutureProg? available = null,
         string description = "")
@@ -2955,7 +2968,7 @@ Elves are divided into several different clans, each with their own distinct cul
             SweatLiquid = elfSweat
         };
         _context.Races.Add(elfRace);
-        AddRaceAttributeAlterations(elfRace, new NonHumanAttributeProfile(-1, -1, 2, 2));
+        AddRaceAttributeAlterations(elfRace, CultureRaceAttributeProfiles["Elf"]);
 
         HeightWeightModel elfMaleHWModel = new()
         {
@@ -3622,7 +3635,7 @@ Hobbits are divided into several different clans, each with its own distinct cul
             SweatLiquid = hobbitSweat
         };
         _context.Races.Add(hobbitRace);
-        AddRaceAttributeAlterations(hobbitRace, new NonHumanAttributeProfile(-2, 1, 0, 1));
+        AddRaceAttributeAlterations(hobbitRace, CultureRaceAttributeProfiles["Hobbit"]);
         HeightWeightModel hobbitMaleHWModel = new()
         {
             Name = "Hobbit Male",
@@ -3983,7 +3996,7 @@ Dwarves are divided into several different clans, each with its own distinct cul
             SweatLiquid = dwarfSweat
         };
         _context.Races.Add(dwarfRace);
-        AddRaceAttributeAlterations(dwarfRace, new NonHumanAttributeProfile(2, 3, -1, 0));
+        AddRaceAttributeAlterations(dwarfRace, CultureRaceAttributeProfiles["Dwarf"]);
         HeightWeightModel dwarfMaleHWModel = new()
         {
             Name = "Dwarf Male",
@@ -4393,7 +4406,7 @@ Orcish cultural practices are centered around warfare and domination. Orcs are c
             SweatLiquid = orcSweat
         };
         _context.Races.Add(orcRace);
-        AddRaceAttributeAlterations(orcRace, new NonHumanAttributeProfile(2, 1, 0, -1));
+        AddRaceAttributeAlterations(orcRace, CultureRaceAttributeProfiles["Orc"]);
         HeightWeightModel orcMaleHWModel = new()
         {
             Name = "Orc Male",
@@ -4737,7 +4750,7 @@ Trolls are primarily scavengers and predators, and will eat anything they can ca
             SweatLiquid = trollSweat
         };
         _context.Races.Add(trollRace);
-        AddRaceAttributeAlterations(trollRace, new NonHumanAttributeProfile(8, 7, -3, -3));
+        AddRaceAttributeAlterations(trollRace, CultureRaceAttributeProfiles["Troll"]);
         HeightWeightModel trollMaleHWModel = new()
         {
             Name = "Troll Male",

--- a/DatabaseSeeder/Seeders/HumanSeeder.cs
+++ b/DatabaseSeeder/Seeders/HumanSeeder.cs
@@ -1330,36 +1330,6 @@ $?hairstyle[&he has &?a_an[$haircolour $hairstyle]][&he is completely bald].$?fa
 
         #endregion region
 
-        #region Progs
-
-        FutureProg attributeBonusProg = new()
-        {
-            FunctionName = "HumanAttributeBonus",
-            FunctionComment =
-                "This prog is called for each attribute for humans at chargen time and the resulting value is applied as a modifier to that attribute.",
-            Category = "Character",
-            Subcategory = "Race",
-            ReturnType = 2,
-            AcceptsAnyParameters = false,
-            StaticType = 0,
-            FunctionText =
-                @"// Replace this below example with your specific modifiers
-if (@trait.Name == ""Example"")
-  return 2
-end if
-return 0"
-        };
-        attributeBonusProg.FutureProgsParameters.Add(new FutureProgsParameter
-        {
-            FutureProg = attributeBonusProg,
-            ParameterName = "trait",
-            ParameterIndex = 0,
-            ParameterType = 16384
-        });
-        _context.FutureProgs.Add(attributeBonusProg);
-
-        #endregion
-
         #region Blood Models
 
         BloodModel bloodModel = new()
@@ -1759,7 +1729,6 @@ return 0"
                 "The base humanoid race. This race should never be the final race of something; it is designed to be a base race for other humanoids.",
             BaseBody = baseBody,
             AllowedGenders = "2 3",
-            AttributeBonusProg = _context.FutureProgs.First(x => x.FunctionName == "AlwaysZero"),
             AttributeTotalCap = _context.TraitDefinitions.Count(x => x.Type == 1) * 12,
             IndividualAttributeCap = 20,
             DiceExpression = "3d6+1",
@@ -1817,7 +1786,6 @@ return 0"
                 "The base organic humanoid race. This race should never be the final race of something; it is designed to be a base race for other organic humanoids.",
             BaseBody = baseBody,
             AllowedGenders = "2 3",
-            AttributeBonusProg = _context.FutureProgs.First(x => x.FunctionName == "AlwaysZero"),
             AttributeTotalCap = _context.TraitDefinitions.Count(x => x.Type == 1) * 12,
             IndividualAttributeCap = 20,
             DiceExpression = "3d6+1",
@@ -1880,7 +1848,6 @@ return 0"
                 "In the reckonings of most worlds, humans are the youngest of the common races, late to arrive on the world scene and short-lived in comparison to dwarves, elves, and dragons. Perhaps it is because of their shorter lives that they strive to achieve as much as they can in the years they are given. Or maybe they feel they have something to prove to the elder races, and that’s why they build their mighty empires on the foundation of conquest and trade. Whatever drives them, humans are the innovators, the achievers, and the pioneers of the worlds.",
             BaseBody = organicBody,
             AllowedGenders = useNonBinary ? "2 3 4" : "2 3",
-            AttributeBonusProg = attributeBonusProg,
             AttributeTotalCap = _context.TraitDefinitions.Count(x => x.Type == 1) * 12,
             IndividualAttributeCap = 20,
             DiceExpression = "3d6+1",
@@ -1943,7 +1910,8 @@ return 0"
             {
                 Race = organicHumanoidRace,
                 Attribute = attribute,
-                IsHealthAttribute = attribute.TraitGroup == "Physical"
+                IsHealthAttribute = attribute.TraitGroup == "Physical",
+                AttributeBonus = 0.0
             });
         }
 

--- a/DatabaseSeeder/Seeders/MythicalAnimalSeeder.AttributeScaling.cs
+++ b/DatabaseSeeder/Seeders/MythicalAnimalSeeder.AttributeScaling.cs
@@ -1,41 +1,13 @@
 #nullable enable
 
-using MudSharp.Body.Traits;
-using MudSharp.Framework;
-using MudSharp.FutureProg;
 using MudSharp.Models;
-using System.Linq;
 
 namespace DatabaseSeeder.Seeders;
 
 public partial class MythicalAnimalSeeder
 {
-	private FutureProg CreateMythicalAttributeBonusProg(MythicalRaceTemplate template)
+	private static int GetMythicalAttributeBonus(TraitDefinition attribute, MythicalRaceTemplate template)
 	{
-		var progText = NonHumanAttributeScalingHelper.BuildAttributeBonusProgText(
-			_context.TraitDefinitions.Where(x => x.Type == (int)TraitType.Attribute),
-			template.AttributeProfile);
-
-		var attributeBonusProg = new FutureProg
-		{
-			FunctionName = $"{template.Name.CollapseString()}AttributeBonus",
-			FunctionComment = $"Racial attribute bonuses for the {template.Name} race",
-			AcceptsAnyParameters = false,
-			Category = "Character",
-			Subcategory = "Attributes",
-			ReturnType = (long)ProgVariableTypes.Number,
-			FunctionText = progText
-		};
-
-		attributeBonusProg.FutureProgsParameters.Add(new FutureProgsParameter
-		{
-			FutureProg = attributeBonusProg,
-			ParameterIndex = 0,
-			ParameterName = "trait",
-			ParameterType = (long)ProgVariableTypes.Trait
-		});
-
-		_context.FutureProgs.Add(attributeBonusProg);
-		return attributeBonusProg;
+		return NonHumanAttributeScalingHelper.GetAttributeBonus(attribute, template.AttributeProfile);
 	}
 }

--- a/DatabaseSeeder/Seeders/MythicalAnimalSeeder.Definitions.cs
+++ b/DatabaseSeeder/Seeders/MythicalAnimalSeeder.Definitions.cs
@@ -344,7 +344,7 @@ public partial class MythicalAnimalSeeder
                     Attack("Hoof Stomp", ItemQuality.Good, "rfhoof", "lfhoof", "rrhoof", "lrhoof"),
                     Attack("Wing Buffet", ItemQuality.Standard, "rwingbase", "lwingbase")
                 ],
-                attributeProfile: Stats(6, 5, 2, 0),
+                attributeProfile: Stats(6, 5, 3, 1),
                 bodypartHealthMultiplier: 1.5,
                 combatStrategyKey: "Beast Swooper"
             ),
@@ -370,9 +370,9 @@ public partial class MythicalAnimalSeeder
                 [
                     Usage("horn", "general")
                 ],
-                attributeProfile: Stats(7, 6, 2, 0),
+                attributeProfile: Stats(6, 5, 4, 1),
                 bodypartHealthMultiplier: 1.6,
-                combatStrategyKey: "Beast Behemoth"
+                combatStrategyKey: "Beast Skirmisher"
             ),
             ["Pegasus"] = BeastRace(
                 "Pegasus",
@@ -400,7 +400,7 @@ public partial class MythicalAnimalSeeder
                     Usage("rwing", "general"),
                     Usage("lwing", "general")
                 ],
-                attributeProfile: Stats(6, 5, 3, 0),
+                attributeProfile: Stats(5, 4, 5, 1),
                 bodypartHealthMultiplier: 1.5,
                 combatStrategyKey: "Beast Swooper"
             ),
@@ -496,7 +496,7 @@ public partial class MythicalAnimalSeeder
                     Usage("rhorn", "general"),
                     Usage("lhorn", "general")
                 ],
-                attributeProfile: Stats(5, 4, -1, -1),
+                attributeProfile: Stats(6, 5, -1, -1),
                 bodypartHealthMultiplier: 1.2
             ),
             ["Eastern Dragon"] = BeastRace(
@@ -520,7 +520,7 @@ public partial class MythicalAnimalSeeder
                     Attack("Claw Swipe", ItemQuality.Great, "rfpaw", "lfpaw", "rrpaw", "lrpaw"),
                     Attack("Tail Slap", ItemQuality.Good, "ltail")
                 ],
-                attributeProfile: Stats(11, 10, 1, -1),
+                attributeProfile: Stats(10, 9, 2, 0),
                 bodypartHealthMultiplier: 2.3,
                 additionalCharacteristics:
                 [
@@ -547,7 +547,7 @@ public partial class MythicalAnimalSeeder
                     ("a coiled naga", "This naga presents a recognisably humanoid upper torso above a long serpentine lower body, the whole figure poised in smooth, deliberate coils."),
                     ("a serpent-bodied naga", "This naga's human-like arms and shoulders rise from a scaled, sinuous body whose coiling strength and low centre of gravity suggest sudden violence.")
                 ),
-                attributeProfile: Stats(1, 2, 1, 1),
+                attributeProfile: Stats(1, 3, 2, 1),
                 bodypartHealthMultiplier: 1.15,
                 canClimb: true,
                 combatStrategyKey: "Melee (Auto)"
@@ -571,7 +571,7 @@ public partial class MythicalAnimalSeeder
                     ("a fin-tailed merfolk", "This merfolk body combines a humanoid upper torso with a powerful scaled tail, built more for darting turns and long swims than for any life on land."),
                     ("a sea-borne merfolk", "This merfolk's shoulders and arms are recognisably person-like, but the gleam of scales and the muscular sweep of the tail place them firmly in the water's domain.")
                 ),
-                attributeProfile: Stats(0, 1, 1, 1),
+                attributeProfile: Stats(0, 1, 2, 1),
                 bodypartHealthMultiplier: 1.0,
                 combatStrategyKey: "Melee (Auto)"
             ),
@@ -604,7 +604,7 @@ public partial class MythicalAnimalSeeder
                     Usage("lwing", "general"),
                     Usage("stinger", "general")
                 ],
-                attributeProfile: Stats(8, 6, 2, 0),
+                attributeProfile: Stats(8, 6, 3, 0),
                 bodypartHealthMultiplier: 1.8,
                 combatStrategyKey: "Beast Artillery"
             ),
@@ -630,7 +630,7 @@ public partial class MythicalAnimalSeeder
                     Attack("Tail Slap", ItemQuality.Standard, "tail"),
                     Attack("Wing Buffet", ItemQuality.Standard, "rwingbase", "lwingbase")
                 ],
-                attributeProfile: Stats(8, 6, 2, 0),
+                attributeProfile: Stats(8, 6, 3, 0),
                 bodypartHealthMultiplier: 1.7,
                 combatStrategyKey: "Beast Artillery"
             ),
@@ -653,7 +653,7 @@ public partial class MythicalAnimalSeeder
                     Attack("Beak Bite", ItemQuality.Standard, "beak"),
                     Attack("Talon Strike", ItemQuality.Good, "rtalons", "ltalons")
                 ],
-                attributeProfile: Stats(3, 3, 4, 2),
+                attributeProfile: Stats(2, 2, 5, 3),
                 bodypartHealthMultiplier: 1.1,
                 combatStrategyKey: "Beast Swooper"
             ),
@@ -676,7 +676,7 @@ public partial class MythicalAnimalSeeder
                     Attack("Bite", ItemQuality.Standard, "mouth"),
                     Attack("Tail Slap", ItemQuality.Standard, "tail")
                 ],
-                attributeProfile: Stats(6, 6, 1, 0),
+                attributeProfile: Stats(5, 6, 2, 0),
                 bodypartHealthMultiplier: 1.5,
                 combatStrategyKey: "Beast Clincher"
             ),
@@ -933,9 +933,9 @@ public partial class MythicalAnimalSeeder
                     Attack("Hoof Stomp", ItemQuality.Standard, "rfhoof", "lfhoof"),
                     Attack("Tail Slap", ItemQuality.Good, "caudalfin")
                 ],
-                attributeProfile: Stats(7, 6, 1, -1),
+                attributeProfile: Stats(6, 5, 3, 0),
                 bodypartHealthMultiplier: 1.6,
-                combatStrategyKey: "Beast Behemoth"
+                combatStrategyKey: "Beast Skirmisher"
             ),
             ["Selkie"] = HumanoidRace(
                 "Selkie",
@@ -955,7 +955,7 @@ public partial class MythicalAnimalSeeder
                     ("a seal-blooded selkie", "This selkie has a recognisably humanoid frame softened by an aquatic grace, the race's seal-blooded heritage evident in the smooth lines and sea-going poise."),
                     ("a sea-graceful selkie", "This selkie carries themself with the easy balance of someone more at home on wave-washed rock and in cold surf than on dry inland roads.")
                 ),
-                attributeProfile: Stats(0, 1, 1, 0),
+                attributeProfile: Stats(0, 1, 2, 1),
                 bodypartHealthMultiplier: 1.0,
                 combatStrategyKey: "Melee (Auto)"
             ),
@@ -982,7 +982,7 @@ public partial class MythicalAnimalSeeder
                 [
                     Characteristic("Fungus Colour", "white", "brown", "red", "purple")
                 ],
-                attributeProfile: Stats(-1, 2, -1, -2),
+                attributeProfile: Stats(-1, 3, -1, -2),
                 bodypartHealthMultiplier: 1.1,
                 combatStrategyKey: "Melee (Auto)"
             ),
@@ -1028,7 +1028,7 @@ public partial class MythicalAnimalSeeder
                     Attack("Jab", ItemQuality.Standard, "rhand", "lhand"),
                     Attack("Elbow", ItemQuality.Bad, "relbow", "lelbow")
                 ],
-                attributeProfile: Stats(5, 8, -2, -2),
+                attributeProfile: Stats(7, 9, -3, -3),
                 bodypartHealthMultiplier: 1.6,
                 canSwim: false,
                 additionalCharacteristics:
@@ -1056,7 +1056,7 @@ public partial class MythicalAnimalSeeder
                     ("a blossom-haired dryad", "This dryad carries a largely humanoid form, but bark-soft skin, leaf-wrought hair and a faint scent of living wood mark the figure unmistakably as a spirit of the grove."),
                     ("a leaf-veiled dryad", "This dryad moves like a person taught by branches and wind, every line of the figure softened by petals, bark-grain and the quiet poise of old trees.")
                 ),
-                attributeProfile: Stats(0, 1, 1, 1),
+                attributeProfile: Stats(-1, 1, 2, 2),
                 bodypartHealthMultiplier: 1.0,
                 canClimb: true,
                 canSwim: false,
@@ -1087,7 +1087,7 @@ public partial class MythicalAnimalSeeder
                     Usage("rwing", "general"),
                     Usage("lwing", "general")
                 ],
-                attributeProfile: Stats(0, 0, 1, 1),
+                attributeProfile: Stats(-1, 0, 2, 2),
                 bodypartHealthMultiplier: 1.0,
                 canClimb: true,
                 facialHairProfile: "No_Facial_Hair",
@@ -1117,7 +1117,7 @@ public partial class MythicalAnimalSeeder
                     Usage("rwing", "general"),
                     Usage("lwing", "general")
                 ],
-                attributeProfile: Stats(0, 0, 1, 1),
+                attributeProfile: Stats(-1, 0, 2, 2),
                 bodypartHealthMultiplier: 1.0,
                 canClimb: true,
                 facialHairProfile: "No_Facial_Hair",
@@ -1142,7 +1142,7 @@ public partial class MythicalAnimalSeeder
                     ("a deep-chested centaur", "This centaur combines a humanoid torso and arms with a powerful equine lower body, making the whole figure look fast, stable and difficult to dislodge."),
                     ("a long-striding centaur", "This centaur's human upper body rises from a broad horse-frame whose musculature and stance suggest endurance, mobility and hard impact.")
                 ),
-                attributeProfile: Stats(6, 5, 1, 0),
+                attributeProfile: Stats(6, 5, 2, 0),
                 bodypartHealthMultiplier: 1.5,
                 combatStrategyKey: "Melee (Auto)"
             ),
@@ -1172,7 +1172,7 @@ public partial class MythicalAnimalSeeder
                     Usage("rwing", "general"),
                     Usage("lwing", "general")
                 ],
-                attributeProfile: Stats(8, 7, 2, 0),
+                attributeProfile: Stats(7, 6, 4, 1),
                 bodypartHealthMultiplier: 1.7,
                 combatStrategyKey: "Beast Swooper"
             )

--- a/DatabaseSeeder/Seeders/MythicalAnimalSeeder.cs
+++ b/DatabaseSeeder/Seeders/MythicalAnimalSeeder.cs
@@ -1127,7 +1127,6 @@ public partial class MythicalAnimalSeeder : IDatabaseSeeder
     {
         bool usesHumanoidDefaults = template.HumanoidVariety ||
                                   (template.CanUseWeapons && template.BodyKey.EqualTo("Organic Humanoid"));
-        FutureProg attributeBonusProg = CreateMythicalAttributeBonusProg(template);
         Race race = new()
         {
             Name = template.Name,
@@ -1135,7 +1134,6 @@ public partial class MythicalAnimalSeeder : IDatabaseSeeder
             BaseBody = body,
             AllowedGenders = usesHumanoidDefaults ? _organicHumanoidRace.AllowedGenders : "2 3",
             ParentRace = template.HumanoidVariety ? _organicHumanoidRace : null,
-            AttributeBonusProg = attributeBonusProg,
             AttributeTotalCap = _context.TraitDefinitions.Count(x => x.Type == (int)TraitType.Attribute) * 12,
             IndividualAttributeCap = 20,
             DiceExpression = "3d6+1",
@@ -1192,13 +1190,15 @@ public partial class MythicalAnimalSeeder : IDatabaseSeeder
         _context.Races.Add(race);
         _context.SaveChanges();
 
-        foreach (TraitDefinition? attribute in _context.TraitDefinitions.Where(x => x.Type == (int)TraitType.Attribute))
+        foreach (TraitDefinition? attribute in _context.TraitDefinitions
+                     .Where(x => x.Type == (int)TraitType.Attribute || x.Type == (int)TraitType.DerivedAttribute))
         {
             _context.RacesAttributes.Add(new RacesAttributes
             {
                 Race = race,
                 Attribute = attribute,
-                IsHealthAttribute = attribute.TraitGroup == "Physical"
+                IsHealthAttribute = attribute.TraitGroup == "Physical",
+                AttributeBonus = GetMythicalAttributeBonus(attribute, template)
             });
         }
         ApplyBreathingProfile(race, GetBreathingProfile(template));

--- a/DatabaseSeeder/Seeders/NonHumanAttributeScalingHelper.cs
+++ b/DatabaseSeeder/Seeders/NonHumanAttributeScalingHelper.cs
@@ -3,8 +3,6 @@
 using MudSharp.Models;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace DatabaseSeeder.Seeders;
 
@@ -67,24 +65,12 @@ internal static class NonHumanAttributeScalingHelper
 		"Dexterity"
 	};
 
-	internal static string BuildAttributeBonusProgText(IEnumerable<TraitDefinition> attributes, NonHumanAttributeProfile profile)
+	internal static int GetAttributeBonus(TraitDefinition attribute, NonHumanAttributeProfile profile)
 	{
 		var physicalHybridBonus = (int)Math.Round(
 			(profile.StrengthBonus + profile.ConstitutionBonus) / 2.0,
 			MidpointRounding.AwayFromZero);
-
-		var sb = new StringBuilder();
-		sb.AppendLine("switch (@trait.Name)");
-
-		foreach (var attribute in attributes.OrderBy(x => x.Id))
-		{
-			sb.AppendLine($"  case (\"{attribute.Name}\")");
-			sb.AppendLine($"    return {GetAttributeBonus(attribute.Name, profile, physicalHybridBonus)}");
-		}
-
-		sb.AppendLine("end switch");
-		sb.AppendLine("return 0");
-		return sb.ToString();
+		return GetAttributeBonus(attribute.Name, profile, physicalHybridBonus);
 	}
 
 	private static int GetAttributeBonus(string attributeName, NonHumanAttributeProfile profile, int physicalHybridBonus)

--- a/DatabaseSeeder/Seeders/RobotSeeder.Races.cs
+++ b/DatabaseSeeder/Seeders/RobotSeeder.Races.cs
@@ -3,7 +3,6 @@
 using MudSharp.Body.Traits;
 using MudSharp.Form.Shape;
 using MudSharp.Framework;
-using MudSharp.FutureProg;
 using MudSharp.GameItems;
 using MudSharp.Models;
 using System.Collections.Generic;
@@ -77,7 +76,6 @@ public partial class RobotSeeder
                     ParentRace = template.ParentRaceName is null
                         ? null
                         : _context.Races.FirstOrDefault(x => x.Name == template.ParentRaceName),
-                    AttributeBonusProg = _humanRace.AttributeBonusProg,
                     AttributeTotalCap = _humanRace.AttributeTotalCap,
                     IndividualAttributeCap = _humanRace.IndividualAttributeCap,
                     DiceExpression = _humanRace.DiceExpression,
@@ -162,7 +160,7 @@ public partial class RobotSeeder
 
             ApplyNonBreatherSettings(race);
 
-            CopyRaceAttributes(race);
+            CopyRaceAttributes(race, template);
             if (template.UsesHumanoidCharacteristics)
             {
                 CopyHumanAdditionalCharacteristics(race);
@@ -190,13 +188,36 @@ public partial class RobotSeeder
         _context.RacesBreathableLiquids.RemoveRange(_context.RacesBreathableLiquids.Where(x => x.RaceId == race.Id).ToList());
     }
 
-    private void CopyRaceAttributes(Race race)
+    private static NonHumanAttributeProfile GetRobotAttributeProfile(RobotRaceTemplate template)
     {
-        Dictionary<long, bool> humanHealthAttributes = _context.RacesAttributes
+        NonHumanAttributeProfile profile = template.Size switch
+        {
+            SizeCategory.Nanoscopic => new(-10, -8, 4, 3),
+            SizeCategory.Microscopic => new(-9, -7, 4, 3),
+            SizeCategory.Miniscule => new(-8, -6, 3, 2),
+            SizeCategory.Tiny => new(-6, -4, 2, 1),
+            SizeCategory.VerySmall => new(-4, -2, 1, 1),
+            SizeCategory.Small => new(-1, 0, 1, 0),
+            SizeCategory.Normal => new(2, 2, 0, 0),
+            SizeCategory.Large => new(5, 5, -1, -1),
+            SizeCategory.VeryLarge => new(8, 8, -2, -2),
+            SizeCategory.Huge => new(12, 10, -3, -3),
+            SizeCategory.Enormous => new(15, 12, -4, -4),
+            SizeCategory.Gigantic => new(18, 14, -5, -5),
+            SizeCategory.Titanic => new(20, 16, -6, -6),
+            _ => new(2, 2, 0, 0)
+        };
+        return profile.Clamp(-10, 20);
+    }
+
+    private void CopyRaceAttributes(Race race, RobotRaceTemplate template)
+    {
+        Dictionary<long, RacesAttributes> humanAttributes = _context.RacesAttributes
             .Where(x => x.RaceId == _humanRace.Id)
-            .ToDictionary(x => x.AttributeId, x => x.IsHealthAttribute);
+            .ToDictionary(x => x.AttributeId);
+        var profile = GetRobotAttributeProfile(template);
         foreach (TraitDefinition? attribute in _context.TraitDefinitions
-                     .Where(x => x.Type == (int)TraitType.Attribute)
+                     .Where(x => x.Type == (int)TraitType.Attribute || x.Type == (int)TraitType.DerivedAttribute)
                      .ToList())
         {
             if (_context.RacesAttributes.Any(x => x.RaceId == race.Id && x.AttributeId == attribute.Id))
@@ -208,7 +229,10 @@ public partial class RobotSeeder
             {
                 Race = race,
                 Attribute = attribute,
-                IsHealthAttribute = humanHealthAttributes.GetValueOrDefault(attribute.Id)
+                IsHealthAttribute = humanAttributes.TryGetValue(attribute.Id, out RacesAttributes? humanAttribute) &&
+                                    humanAttribute.IsHealthAttribute,
+                AttributeBonus = NonHumanAttributeScalingHelper.GetAttributeBonus(attribute, profile),
+                DiceExpression = humanAttribute?.DiceExpression
             });
         }
 

--- a/DatabaseSeeder/Seeders/RobotSeeder.Races.cs
+++ b/DatabaseSeeder/Seeders/RobotSeeder.Races.cs
@@ -5,6 +5,7 @@ using MudSharp.Form.Shape;
 using MudSharp.Framework;
 using MudSharp.GameItems;
 using MudSharp.Models;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -188,6 +189,30 @@ public partial class RobotSeeder
         _context.RacesBreathableLiquids.RemoveRange(_context.RacesBreathableLiquids.Where(x => x.RaceId == race.Id).ToList());
     }
 
+    private static readonly IReadOnlyDictionary<string, NonHumanAttributeProfile> RobotSpecificProfiles =
+        new Dictionary<string, NonHumanAttributeProfile>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Spider Crawler Robot"] = new(0, 1, 2, 0),
+            ["Circular Saw Robot"] = new(2, 1, 0, 1),
+            ["Pneumatic Hammer Robot"] = new(4, 3, -1, -2),
+            ["Sword-Hand Robot"] = new(1, 0, 2, 2),
+            ["Winged Robot"] = new(-1, -1, 3, 1),
+            ["Jet Robot"] = new(0, -1, 4, 0),
+            ["Mandible Robot"] = new(2, 1, 0, -1),
+            ["Wheeled Robot"] = new(-1, 0, 2, 0),
+            ["Tracked Robot"] = new(2, 3, -2, -2),
+            ["Cyborg"] = new(-1, -1, 1, 1),
+            ["Roomba Robot"] = new(-3, 1, 1, 0),
+            ["Tracked Utility Robot"] = new(0, 3, -1, -1),
+            ["Robot Dog"] = new(1, 1, 2, 0),
+            ["Robot Cockroach"] = new(-3, 3, 3, 1)
+        };
+
+    internal static NonHumanAttributeProfile GetRobotAttributeProfileForTesting(RobotRaceTemplate template)
+    {
+        return GetRobotAttributeProfile(template);
+    }
+
     private static NonHumanAttributeProfile GetRobotAttributeProfile(RobotRaceTemplate template)
     {
         NonHumanAttributeProfile profile = template.Size switch
@@ -207,6 +232,12 @@ public partial class RobotSeeder
             SizeCategory.Titanic => new(20, 16, -6, -6),
             _ => new(2, 2, 0, 0)
         };
+
+        if (RobotSpecificProfiles.TryGetValue(template.Name, out var specificProfile))
+        {
+            profile = profile.Add(specificProfile);
+        }
+
         return profile.Clamp(-10, 20);
     }
 

--- a/Design Documents/Damage_Balance_Animal_Mythic_Attribute_Scaling_Report.md
+++ b/Design Documents/Damage_Balance_Animal_Mythic_Attribute_Scaling_Report.md
@@ -23,6 +23,26 @@ This pass focused specifically on seeded animal and mythical race physical scali
 - Runtime lookup applies the race bonus from the active body at trait lookup time instead of adding it to the stored chargen or NPC attribute value.
 - Missing race-attribute rows, or rows without a specific bonus, are treated as zero-bonus legacy data.
 
+### 2026 second-pass seeded bonus tuning
+- Herbivore loadouts now reserve more of their profile for mobility or charge identity instead of pushing almost everything into strength and constitution.
+- Explicit animal outliers were moved into species profiles rather than broadening whole loadouts:
+  - `Cheetah`: `Strength -1`, `Constitution -1`, `Agility +4`, `Dexterity +2`
+  - `Horse`: `Strength +7`, `Constitution +8`, `Agility +2`, `Dexterity -1`
+  - `Cow`: `Strength +7`, `Constitution +8`, `Agility -1`, `Dexterity -2`
+  - `Giraffe`: `Strength +9`, `Constitution +8`, `Agility +1`, `Dexterity -3`
+  - `Ostrich`: `Strength +3`, `Constitution +2`, `Agility +4`, `Dexterity -1`
+  - `Deer`: `Strength +2`, `Constitution +1`, `Agility +2`, `Dexterity -1`
+- Large but non-aggressive animals such as cows, horses, giraffes, goats, emus, and ostriches now use less relentlessly aggressive default combat strategies while keeping credible damage if cornered.
+- Mythic profiles were split more sharply by body plan:
+  - `Unicorn`: `Strength +6`, `Constitution +5`, `Agility +4`, `Dexterity +1`
+  - `Pegasus`: `Strength +5`, `Constitution +4`, `Agility +5`, `Dexterity +1`
+  - `Eastern Dragon`: `Strength +10`, `Constitution +9`, `Agility +2`, `Dexterity +0`
+  - `Phoenix`: `Strength +2`, `Constitution +2`, `Agility +5`, `Dexterity +3`
+  - `Ent`: `Strength +7`, `Constitution +9`, `Agility -3`, `Dexterity -3`
+  - `Dryad`: `Strength -1`, `Constitution +1`, `Agility +2`, `Dexterity +2`
+  - `Centaur`: `Strength +6`, `Constitution +5`, `Agility +2`, `Dexterity +0`
+- `Dragonfire Breath` now uses a dedicated `Dragonfire Breath Damage` expression keyed to quality and degree, not the attacker's raw strength. Physical dragon strength still matters for bites, claws, horns, and tail strikes, but breath damage is no longer inflated simply because the same race is physically massive.
+
 ## Why it changed
 The old seeding model flattened almost all non-human physical attributes.
 
@@ -80,8 +100,7 @@ The strongest comparison from the deterministic run:
 - existing ordinary animal `BodypartHealthMultiplier` values, except that they now contribute to attribute-derived durability more meaningfully
 - ordinary wound severity bands
 
-## Second-pass considerations
-- Review whether some herbivores should gain more explicit agility or charge-specialisation rather than mostly scaling through strength and constitution.
-- Check whether a few large but non-aggressive animals should have lower default combat aggression despite now having more believable damage if forced to fight.
-- Consider whether some mythical attacks such as `Dragonfire Breath` should get an explicit second-pass review independent of physical strength scaling.
+## Follow-up considerations after the second pass
+- Keep an eye on broad bovid and pachyderm outcomes during playtest; they now split domestic, wild, and giant examples more clearly, but still share some loadout DNA.
+- Review whether the dedicated `Dragonfire Breath Damage` expression wants separate western dragon, eastern dragon, and wyvern variants once breath attacks have real combat logs behind them.
 - If future testing shows outliers, move more animals from heuristic scaling into explicit per-species profiles rather than inflating the general tables.

--- a/Design Documents/Damage_Balance_Animal_Mythic_Attribute_Scaling_Report.md
+++ b/Design Documents/Damage_Balance_Animal_Mythic_Attribute_Scaling_Report.md
@@ -4,7 +4,7 @@
 This pass focused specifically on seeded animal and mythical race physical scaling.
 
 ### Animals
-- Ordinary animals no longer seed an all-zero racial attribute bonus prog.
+- Ordinary animals now seed row-backed racial attribute bonuses instead of an all-zero creation-time bonus prog.
 - `AnimalSeeder` now builds racial physical bonuses from:
 - `SizeCategory`
 - attack-loadout role
@@ -12,11 +12,16 @@ This pass focused specifically on seeded animal and mythical race physical scali
 - Selected species also get small explicit overrides where the generic rule would undersell or oversell them.
 
 ### Mythics
-- Mythical races no longer use `_alwaysZero` for `AttributeBonusProg`.
+- Mythical races now seed row-backed racial attribute bonuses instead of `_alwaysZero` creation-time prog wiring.
 - `MythicalRaceTemplate` now carries:
 - an explicit `NonHumanAttributeProfile`
 - an explicit `BodypartHealthMultiplier`
 - `SeedRace` now applies both directly to the seeded race.
+
+### 2026 row-backed race attribute update
+- Racial attribute alterations now live on `Races_Attributes` as `AttributeBonus` plus an optional per-attribute `DiceExpression`.
+- Runtime lookup applies the race bonus from the active body at trait lookup time instead of adding it to the stored chargen or NPC attribute value.
+- Missing race-attribute rows, or rows without a specific bonus, are treated as zero-bonus legacy data.
 
 ## Why it changed
 The old seeding model flattened almost all non-human physical attributes.

--- a/Design Documents/Damage_Balance_NonHuman_First_Pass_Report.md
+++ b/Design Documents/Damage_Balance_NonHuman_First_Pass_Report.md
@@ -46,6 +46,22 @@ The work stayed in seeder and static-data authoring. It did not change the runti
   - eyes / sensors / antennae / similar minor externals cap to `18`
   - larger positive severables cap to `27`
 
+### 2026 second-pass race attribute tuning
+
+- Robot racial attribute bonuses are no longer size-only. Chassis role now adjusts the size baseline:
+  - `Pneumatic Hammer Robot`: `Strength +6`, `Constitution +5`, `Agility -1`, `Dexterity -2`
+  - `Sword-Hand Robot`: `Strength +3`, `Constitution +2`, `Agility +2`, `Dexterity +2`
+  - `Winged Robot`: `Strength +1`, `Constitution +1`, `Agility +3`, `Dexterity +1`
+  - `Tracked Robot`: `Strength +4`, `Constitution +5`, `Agility -2`, `Dexterity -2`
+  - `Roomba Robot`: `Strength -4`, `Constitution +1`, `Agility +2`, `Dexterity +0`
+  - `Robot Cockroach`: `Strength -4`, `Constitution +3`, `Agility +4`, `Dexterity +1`
+- Culture-specific fantasy races now have explicit row-backed defaults rather than inline one-off calls:
+  - `Elf`: `Strength -1`, `Constitution +0`, `Agility +2`, `Dexterity +3`
+  - `Hobbit`: `Strength -3`, `Constitution +2`, `Agility +1`, `Dexterity +2`
+  - `Dwarf`: `Strength +2`, `Constitution +4`, `Agility -1`, `Dexterity +0`
+  - `Orc`: `Strength +3`, `Constitution +2`, `Agility +0`, `Dexterity -1`
+  - `Troll`: `Strength +9`, `Constitution +8`, `Agility -3`, `Dexterity -4`
+
 ## Validation Snapshot
 Validation used [nonhuman-damage-balance-first-pass.ps1](/C:/Users/luker/OneDrive/source/repos/FutureMUD/scripts/nonhuman-damage-balance-first-pass.ps1), which applies deterministic seeded formulas in static mode.
 

--- a/Design Documents/Damage_System_Design.md
+++ b/Design Documents/Damage_System_Design.md
@@ -244,7 +244,7 @@ The `combat-rebalance` profile does additionally overwrite the shared stock weap
 ## Non-Human Stock Notes
 
 ### Animal offensive and durability scaling
-Seeded ordinary animals no longer use an all-zero racial attribute bonus prog.
+Seeded ordinary animals now use row-backed racial attribute bonuses rather than a creation-time bonus prog.
 
 Current stock animal scaling is now authored in three layers:
 
@@ -337,13 +337,13 @@ Humanoid-default mythics still inherit the human racial/bodypart/cranial split t
 Under `combat-rebalance`, reruns also refresh mythic bodyparts in place from their reference humanoid or animal bodies so the profile's HP, hit-chance, armour, and sever-formula tuning propagates without seeding duplicate races.
 
 ## Mythical Offensive and Durability Scaling
-Seeded mythical races no longer use the shared `_alwaysZero` racial attribute prog.
+Seeded mythical races now use row-backed racial attribute bonuses rather than the old shared all-zero prog.
 
 Current stock mythical tuning is explicit per race:
 
 - every mythic race now carries a seeded `NonHumanAttributeProfile`
 - every mythic race now carries an intentional `BodypartHealthMultiplier`
-- `SeedRace` turns that profile into the race's actual `AttributeBonusProg`
+- `SeedRace` turns that profile into per-attribute `Races_Attributes.AttributeBonus` rows
 
 This means mythical catalogue entries now have distinct physical ceilings instead of sharing the same baseline:
 

--- a/FutureMUDLibrary/Character/Heritage/IRace.cs
+++ b/FutureMUDLibrary/Character/Heritage/IRace.cs
@@ -55,11 +55,13 @@ namespace MudSharp.Character.Heritage
         IEnumerable<Gender> AllowedGenders { get; }
 
         IEnumerable<IAttributeDefinition> Attributes { get; }
-        void AddAttributeFromPromotion(IAttributeDefinition definition);
-        void AddAttributeFromDemotion(IAttributeDefinition definition);
+        void AddAttributeFromPromotion(IAttributeDefinition definition, double bonus = 0.0, string diceExpression = null);
+        void AddAttributeFromDemotion(IAttributeDefinition definition, double bonus = 0.0, string diceExpression = null);
         void RemoveAttribute(IAttributeDefinition definition);
 
-        IFutureProg AttributeBonusProg { get; }
+        double AttributeBonus(IAttributeDefinition definition);
+
+        string AttributeDiceExpression(IAttributeDefinition definition);
 
         string DiceExpression { get; }
 

--- a/MudSharpCore/Body/Implementations/BodyTraits.cs
+++ b/MudSharpCore/Body/Implementations/BodyTraits.cs
@@ -1,4 +1,5 @@
 ﻿using MudSharp.Body.Traits;
+using MudSharp.Body.Traits.Subtypes;
 using MudSharp.Communication.Language;
 using MudSharp.Database;
 using MudSharp.Effects.Interfaces;
@@ -28,6 +29,11 @@ public partial class Body
 
         ITrait trait = _traits.FirstOrDefault(x => x.Definition == definition);
         double baseValue = trait?.Value ?? 0.0;
+        if (definition is IAttributeDefinition attribute)
+        {
+            baseValue += Race?.AttributeBonus(attribute) ?? 0.0;
+        }
+
         baseValue +=
             Merits.OfType<ITraitBonusMerit>().Where(x => x.Applies(Actor))
                   .Sum(x => x.BonusForTrait(definition, context));

--- a/MudSharpCore/Character/Character.cs
+++ b/MudSharpCore/Character/Character.cs
@@ -1159,7 +1159,7 @@ public partial class Character : PerceiverItem, ICharacter
             sb.AppendLine($"Project: {"None".ColourError()}");
         }
         sb.AppendLine();
-        sb.AppendLine($"Stats: {TraitsOfType(TraitType.Attribute).Select(x => $"{x.Definition.Name.ColourName()} [{x.Value.ToString("N0", voyeur).ColourValue()}]").ListToString(separator: " ", conjunction: "")}");
+        sb.AppendLine($"Stats: {TraitsOfType(TraitType.Attribute).Select(x => $"{x.Definition.Name.ColourName()} [{TraitValue(x.Definition).ToString("N0", voyeur).ColourValue()}]").ListToString(separator: " ", conjunction: "")}");
         sb.AppendLine();
         sb.AppendLine($"Skills:");
         sb.AppendLine();

--- a/MudSharpCore/Character/Heritage/Race.cs
+++ b/MudSharpCore/Character/Heritage/Race.cs
@@ -103,7 +103,6 @@ public partial class Race : SaveableItem, IRace
         {
             DiceExpression = ParentRace.DiceExpression;
             _allowedGenders.AddRange(ParentRace.AllowedGenders);
-            AttributeBonusProg = ParentRace.AttributeBonusProg;
             AttributeTotalCap = ParentRace.AttributeTotalCap;
             IndividualAttributeCap = ParentRace.IndividualAttributeCap;
             IlluminationPerceptionMultiplier = ParentRace.IlluminationPerceptionMultiplier;
@@ -202,8 +201,11 @@ public partial class Race : SaveableItem, IRace
             DiceExpression = "3d6";
             _allowedGenders.Add(Gender.Male);
             _allowedGenders.Add(Gender.Female);
-            AttributeBonusProg = Gameworld.FutureProgs.GetByName("AlwaysZero");
             _attributes.AddRange(Gameworld.Traits.OfType<IAttributeDefinition>());
+            foreach (var attribute in _attributes)
+            {
+                EnsureAttributeAlteration(attribute);
+            }
             AttributeTotalCap = _attributes.Count * 13;
             IndividualAttributeCap = 18;
             IlluminationPerceptionMultiplier = 1.0;
@@ -274,7 +276,6 @@ public partial class Race : SaveableItem, IRace
                 BaseBodyId = BaseBody.Id,
                 AllowedGenders = _allowedGenders.Select(x => ((int)x).ToString("F0")).ListToCommaSeparatedValues(" "),
                 ParentRaceId = ParentRace?.Id,
-                AttributeBonusProgId = AttributeBonusProg.Id,
                 AttributeTotalCap = AttributeTotalCap,
                 IndividualAttributeCap = IndividualAttributeCap,
                 DiceExpression = DiceExpression,
@@ -338,6 +339,17 @@ public partial class Race : SaveableItem, IRace
                     _defaultHeightWeightModels.ValueOrDefault(Gender.NonBinary, null)?.Id
             };
             FMDB.Context.Races.Add(dbitem);
+            foreach (IAttributeDefinition item in _attributes)
+            {
+                dbitem.RacesAttributes.Add(new RacesAttributes
+                {
+                    Race = dbitem,
+                    AttributeId = item.Id,
+                    IsHealthAttribute = _healthTraits.Contains(item),
+                    AttributeBonus = LocalAttributeBonus(item),
+                    DiceExpression = LocalAttributeDiceExpression(item)
+                });
+            }
             FMDB.Context.SaveChanges();
             _id = dbitem.Id;
         }
@@ -353,7 +365,6 @@ public partial class Race : SaveableItem, IRace
         DiceExpression = race.DiceExpression;
         AttributeTotalCap = race.AttributeTotalCap;
         IndividualAttributeCap = race.IndividualAttributeCap;
-        AttributeBonusProg = gameworld.FutureProgs.Get(race.AttributeBonusProgId);
         IlluminationPerceptionMultiplier = race.IlluminationPerceptionMultiplier;
         AvailabilityProg = gameworld.FutureProgs.Get(race.AvailabilityProgId ?? 0);
         CorpseModel = gameworld.CorpseModels.Get(race.CorpseModelId);
@@ -435,6 +446,9 @@ public partial class Race : SaveableItem, IRace
         {
             IAttributeDefinition attribute = (IAttributeDefinition)gameworld.Traits.Get(item.AttributeId);
             _attributes.Add(attribute);
+            var alteration = EnsureAttributeAlteration(attribute);
+            alteration.Bonus = item.AttributeBonus;
+            alteration.DiceExpression = item.DiceExpression;
             if (item.IsHealthAttribute)
             {
                 _healthTraits.Add(attribute);
@@ -600,7 +614,6 @@ public partial class Race : SaveableItem, IRace
         AvailabilityProg = rhs.AvailabilityProg;
         Description = rhs.Description;
         DiceExpression = rhs.DiceExpression;
-        AttributeBonusProg = rhs.AttributeBonusProg;
         AttributeTotalCap = rhs.AttributeTotalCap;
         IndividualAttributeCap = rhs.IndividualAttributeCap;
         IlluminationPerceptionMultiplier = rhs.IlluminationPerceptionMultiplier;
@@ -694,6 +707,12 @@ public partial class Race : SaveableItem, IRace
         }
 
         _attributes.AddRange(rhs._attributes);
+        foreach (var attribute in _attributes)
+        {
+            var alteration = EnsureAttributeAlteration(attribute);
+            alteration.Bonus = rhs.LocalAttributeBonus(attribute);
+            alteration.DiceExpression = rhs.LocalAttributeDiceExpression(attribute);
+        }
         _baseCharacteristics.AddRange(rhs._baseCharacteristics);
         _maleOnlyAdditions.AddRange(rhs._maleOnlyAdditions);
         _femaleOnlyAdditions.AddRange(rhs._femaleOnlyAdditions);
@@ -722,7 +741,6 @@ public partial class Race : SaveableItem, IRace
                 BaseBodyId = BaseBody.Id,
                 AllowedGenders = _allowedGenders.Select(x => ((int)x).ToString("F0")).ListToCommaSeparatedValues(" "),
                 ParentRaceId = ParentRace?.Id,
-                AttributeBonusProgId = AttributeBonusProg.Id,
                 AttributeTotalCap = AttributeTotalCap,
                 IndividualAttributeCap = IndividualAttributeCap,
                 DiceExpression = DiceExpression,
@@ -862,7 +880,9 @@ public partial class Race : SaveableItem, IRace
                 {
                     Race = dbitem,
                     AttributeId = item.Id,
-                    IsHealthAttribute = _healthTraits.Contains(item)
+                    IsHealthAttribute = _healthTraits.Contains(item),
+                    AttributeBonus = LocalAttributeBonus(item),
+                    DiceExpression = LocalAttributeDiceExpression(item)
                 });
             }
 
@@ -1146,7 +1166,6 @@ public partial class Race : SaveableItem, IRace
         dbitem.BaseBodyId = BaseBody.Id;
         dbitem.AllowedGenders = _allowedGenders.Select(x => ((int)x).ToString("F0")).ListToCommaSeparatedValues(" ");
         dbitem.ParentRaceId = ParentRace?.Id;
-        dbitem.AttributeBonusProgId = AttributeBonusProg.Id;
         dbitem.AttributeTotalCap = AttributeTotalCap;
         dbitem.IndividualAttributeCap = IndividualAttributeCap;
         dbitem.DiceExpression = DiceExpression;
@@ -1288,7 +1307,9 @@ public partial class Race : SaveableItem, IRace
             {
                 Race = dbitem,
                 AttributeId = item.Id,
-                IsHealthAttribute = _healthTraits.Contains(item)
+                IsHealthAttribute = _healthTraits.Contains(item),
+                AttributeBonus = LocalAttributeBonus(item),
+                DiceExpression = LocalAttributeDiceExpression(item)
             });
         }
 
@@ -1524,18 +1545,97 @@ public partial class Race : SaveableItem, IRace
     public bool CanClimb { get; }
     public bool CanSwim { get; }
 
+    private sealed class RacialAttributeAlteration
+    {
+        public double Bonus { get; set; }
+        public string DiceExpression { get; set; }
+    }
+
     private readonly List<IAttributeDefinition> _attributes = new();
+
+    private readonly Dictionary<IAttributeDefinition, RacialAttributeAlteration> _attributeAlterations = new();
 
     public IEnumerable<IAttributeDefinition> Attributes =>
         ParentRace?.Attributes.Concat(_attributes).Distinct() ?? _attributes;
-
-    public IFutureProg AttributeBonusProg { get; protected set; }
 
     public int AttributeTotalCap { get; protected set; }
 
     public int IndividualAttributeCap { get; protected set; }
 
     public string DiceExpression { get; protected set; }
+
+    private RacialAttributeAlteration EnsureAttributeAlteration(IAttributeDefinition definition)
+    {
+        if (_attributeAlterations.TryGetValue(definition, out var alteration))
+        {
+            return alteration;
+        }
+
+        alteration = new RacialAttributeAlteration();
+        _attributeAlterations[definition] = alteration;
+        return alteration;
+    }
+
+    private double LocalAttributeBonus(IAttributeDefinition definition)
+    {
+        return _attributeAlterations.TryGetValue(definition, out var alteration) ? alteration.Bonus : 0.0;
+    }
+
+    private string LocalAttributeDiceExpression(IAttributeDefinition definition)
+    {
+        return _attributeAlterations.TryGetValue(definition, out var alteration) ? alteration.DiceExpression : null;
+    }
+
+    private RacialAttributeAlteration EnsureOwnAttributeAlteration(IAttributeDefinition definition)
+    {
+        if (!_attributes.Contains(definition))
+        {
+            var inheritedBonus = ParentRace?.Attributes.Contains(definition) == true
+                ? ParentRace.AttributeBonus(definition)
+                : 0.0;
+            var inheritedDice = ParentRace?.Attributes.Contains(definition) == true
+                ? ParentRace.AttributeDiceExpression(definition)
+                : DiceExpression;
+            if (ParentRace is not null && inheritedDice.EqualTo(ParentRace.DiceExpression))
+            {
+                inheritedDice = DiceExpression;
+            }
+
+            _attributes.Add(definition);
+            var inheritedAlteration = EnsureAttributeAlteration(definition);
+            inheritedAlteration.Bonus = inheritedBonus;
+            inheritedAlteration.DiceExpression = inheritedDice?.EqualTo(DiceExpression) == true ? null : inheritedDice;
+            return inheritedAlteration;
+        }
+
+        return EnsureAttributeAlteration(definition);
+    }
+
+    public double AttributeBonus(IAttributeDefinition definition)
+    {
+        if (_attributeAlterations.TryGetValue(definition, out var alteration))
+        {
+            return alteration.Bonus;
+        }
+
+        return ParentRace?.Attributes.Contains(definition) == true ? ParentRace.AttributeBonus(definition) : 0.0;
+    }
+
+    public string AttributeDiceExpression(IAttributeDefinition definition)
+    {
+        if (_attributeAlterations.TryGetValue(definition, out var alteration))
+        {
+            return string.IsNullOrWhiteSpace(alteration.DiceExpression) ? DiceExpression : alteration.DiceExpression;
+        }
+
+        if (ParentRace?.Attributes.Contains(definition) != true)
+        {
+            return DiceExpression;
+        }
+
+        var parentExpression = ParentRace.AttributeDiceExpression(definition);
+        return parentExpression.EqualTo(ParentRace.DiceExpression) ? DiceExpression : parentExpression;
+    }
 
     public double IlluminationPerceptionMultiplier { get; protected set; }
 
@@ -1898,22 +1998,30 @@ public partial class Race : SaveableItem, IRace
         return ParentRace?.DefaultHeightWeightModel(gender);
     }
 
-    public void AddAttributeFromPromotion(IAttributeDefinition definition)
+    public void AddAttributeFromPromotion(IAttributeDefinition definition, double bonus = 0.0, string diceExpression = null)
     {
         _attributes.Add(definition);
+        var alteration = EnsureAttributeAlteration(definition);
+        alteration.Bonus = bonus;
+        alteration.DiceExpression = diceExpression?.EqualTo(DiceExpression) == true ? null : diceExpression;
         Changed = true;
         RecalculateCharactersBecauseOfRaceChange();
     }
 
-    public void AddAttributeFromDemotion(IAttributeDefinition definition)
+    public void AddAttributeFromDemotion(IAttributeDefinition definition, double bonus = 0.0, string diceExpression = null)
     {
         _attributes.Add(definition);
+        var alteration = EnsureAttributeAlteration(definition);
+        alteration.Bonus = bonus;
+        alteration.DiceExpression = diceExpression?.EqualTo(DiceExpression) == true ? null : diceExpression;
         Changed = true;
     }
 
     public void RemoveAttribute(IAttributeDefinition definition)
     {
         _attributes.Remove(definition);
+        _attributeAlterations.Remove(definition);
+        _healthTraits.Remove(definition);
         Changed = true;
     }
 

--- a/MudSharpCore/Character/Heritage/RaceBuilding.cs
+++ b/MudSharpCore/Character/Heritage/RaceBuilding.cs
@@ -72,11 +72,12 @@ public partial class Race
 	#3variable promote <characteristic>#0 - pushes a characteristic up to the parent race
 	#3variable demote <characteristic>#0 - pushes a characteristic down to all child races (and remove from this)
 	#3attribute <which>#0 - toggles this race having the specified attribute
+	#3attribute bonus <which> <amount>#0 - sets a racial lookup-time bonus for an attribute
+	#3attribute dice <which> <dice|default>#0 - overrides the default chargen dice expression for an attribute
 	#3attribute promote <which>#0 - pushes this attribute up to the parent race
 	#3attribute demote <which>#0 - pushes this attribute down to all child races (and remove from this)
 	#3roll <dice>#0 - the dice roll expression (#6xdy+z#0) for attributes for this race
 	#3cap <number>#0 - the total cap on the sum of attributes for this race
-	#3bonusprog <which>#0 - sets the prog that controls attribute bonuses
 	#3corpse <model>#0 - changes the corpse model of the race
 	#3health <model>#0 - changes the health mode of the race
 	#3perception <%>#0 - sets the light-percetion multiplier of the race (higher is better)
@@ -243,7 +244,7 @@ public partial class Race
             case "bonusprog":
             case "attributeprog":
             case "attrbonusprog":
-                return BuildingCommandAttributeBonusProg(actor, command);
+                return BuildingCommandObsoleteAttributeBonusProg(actor);
             case "caneatcorpses":
             case "eatcorpses":
             case "caneatcorpse":
@@ -1226,31 +1227,11 @@ public partial class Race
         return true;
     }
 
-    private bool BuildingCommandAttributeBonusProg(ICharacter actor, StringStack command)
+    private bool BuildingCommandObsoleteAttributeBonusProg(ICharacter actor)
     {
-        if (command.IsFinished)
-        {
-            actor.OutputHandler.Send("Which prog should be used to determine the attribute bonuses for this race?");
-            return false;
-        }
-
-        IFutureProg prog = new ProgLookupFromBuilderInput(Gameworld, actor, command.SafeRemainingArgument,
-            ProgVariableTypes.Number,
-            [
-                [ProgVariableTypes.Trait],
-                [ProgVariableTypes.Trait, ProgVariableTypes.Chargen]
-            ]
-            ).LookupProg();
-        if (prog is null)
-        {
-            return false;
-        }
-
-        AttributeBonusProg = prog;
-        Changed = true;
         actor.OutputHandler.Send(
-            $"This race now uses the {prog.MXPClickableFunctionName()} prog to determine its attribute bonuses.");
-        return true;
+            $"Racial attribute bonuses are now configured directly on the race. Use {"attribute bonus <attribute> <amount>".ColourCommand()} instead.");
+        return false;
     }
 
     private bool BuildingCommandAttributeCap(ICharacter actor, StringStack command)
@@ -1300,12 +1281,21 @@ public partial class Race
             return false;
         }
 
-        switch (command.SafeRemainingArgument.ToLowerInvariant().CollapseString())
+        switch (command.PeekSpeech().ToLowerInvariant().CollapseString())
         {
             case "promote":
+                command.PopSpeech();
                 return BuildingCommandAttributePromote(actor, command);
             case "demote":
+                command.PopSpeech();
                 return BuildingCommandAttributeDemote(actor, command);
+            case "bonus":
+                command.PopSpeech();
+                return BuildingCommandAttributeBonus(actor, command);
+            case "dice":
+            case "roll":
+                command.PopSpeech();
+                return BuildingCommandAttributeDice(actor, command);
         }
 
         IAttributeDefinition attribute = Gameworld.Traits.GetByIdOrName(command.SafeRemainingArgument) as IAttributeDefinition;
@@ -1317,25 +1307,36 @@ public partial class Race
 
         if (!_attributes.Contains(attribute))
         {
-            _attributes.Add(attribute);
+            var alreadyInherited = ParentRace?.Attributes.Contains(attribute) == true;
+            EnsureOwnAttributeAlteration(attribute);
             Changed = true;
-            actor.OutputHandler.Send(
-                $"This race now has the {attribute.Name.ColourName()} attribute. All existing characters have been given a value of {10.ToString("N0", actor).ColourValue()} in this attribute.");
-            RecalculateCharactersBecauseOfRaceChange();
+            actor.OutputHandler.Send(alreadyInherited
+                ? $"This race now has its own local settings for the inherited {attribute.Name.ColourName()} attribute."
+                : $"This race now has the {attribute.Name.ColourName()} attribute. All existing characters have been given a value of {10.ToString("N0", actor).ColourValue()} in this attribute.");
+            if (!alreadyInherited)
+            {
+                RecalculateCharactersBecauseOfRaceChange();
+            }
             return true;
         }
 
-        actor.OutputHandler.Send(
-            $"Are you sure you want to remove the {attribute.Name.ColourName()} attribute from the {Name.ColourName()} race? This will irrevocably remove the existing value of this attribute from all existing characters.\n{Accept.StandardAcceptPhrasing}");
+        var remainsInherited = ParentRace?.Attributes.Contains(attribute) == true;
+        actor.OutputHandler.Send(remainsInherited
+            ? $"Are you sure you want to remove the local settings for the inherited {attribute.Name.ColourName()} attribute from the {Name.ColourName()} race?\n{Accept.StandardAcceptPhrasing}"
+            : $"Are you sure you want to remove the {attribute.Name.ColourName()} attribute from the {Name.ColourName()} race? This will irrevocably remove the existing value of this attribute from all existing characters.\n{Accept.StandardAcceptPhrasing}");
         actor.AddEffect(new Accept(actor, new GenericProposal
         {
             AcceptAction = text =>
             {
-                _attributes.Remove(attribute);
+                RemoveAttribute(attribute);
                 Changed = true;
-                RecalculateCharactersBecauseOfRaceChange();
-                actor.OutputHandler.Send(
-                    $"You remove the {attribute.Name.ColourName()} attribute from the {Name.ColourName()} race.");
+                if (!remainsInherited)
+                {
+                    RecalculateCharactersBecauseOfRaceChange();
+                }
+                actor.OutputHandler.Send(remainsInherited
+                    ? $"You remove the local settings for the inherited {attribute.Name.ColourName()} attribute from the {Name.ColourName()} race."
+                    : $"You remove the {attribute.Name.ColourName()} attribute from the {Name.ColourName()} race.");
             },
             RejectAction = text =>
             {
@@ -1350,7 +1351,96 @@ public partial class Race
             Keywords = new List<string> { "attribute", "remove", attribute.Name.ToLowerInvariant() },
             DescriptionString =
                 $"Removing the {attribute.Name.ColourName()} attribute from the {Name.ColourName()} race"
-        }));
+        })); 
+        return true;
+    }
+
+    private bool BuildingCommandAttributeBonus(ICharacter actor, StringStack command)
+    {
+        if (command.CountRemainingArguments() < 2)
+        {
+            actor.OutputHandler.Send(
+                $"Which attribute do you want to set a racial bonus for, and what bonus should it have? The syntax is {"attribute bonus <attribute> <amount>".ColourCommand()}.");
+            return false;
+        }
+
+        var text = command.SafeRemainingArgument;
+        var lastSpace = text.LastIndexOf(' ');
+        if (lastSpace <= 0 || !double.TryParse(text[(lastSpace + 1)..], out var value))
+        {
+            actor.OutputHandler.Send(
+                $"You must enter a valid numeric bonus after the attribute name, e.g. {"attribute bonus strength 2".ColourCommand()}.");
+            return false;
+        }
+
+        var attributeText = text[..lastSpace];
+        if (Gameworld.Traits.GetByIdOrName(attributeText) is not IAttributeDefinition attribute)
+        {
+            actor.OutputHandler.Send("There is no such attribute like that.");
+            return false;
+        }
+
+        var alreadyHadAttribute = Attributes.Contains(attribute);
+        var alteration = EnsureOwnAttributeAlteration(attribute);
+        alteration.Bonus = value;
+        Changed = true;
+        if (!alreadyHadAttribute)
+        {
+            RecalculateCharactersBecauseOfRaceChange();
+        }
+
+        actor.OutputHandler.Send(
+            $"This race now applies a {value.ToString("N2", actor).ColourValue()} racial bonus to {attribute.Name.ColourName()} at lookup time.");
+        return true;
+    }
+
+    private bool BuildingCommandAttributeDice(ICharacter actor, StringStack command)
+    {
+        if (command.CountRemainingArguments() < 2)
+        {
+            actor.OutputHandler.Send(
+                $"Which attribute do you want to set a dice override for, and what dice expression should it use? The syntax is {"attribute dice <attribute> <dice|default>".ColourCommand()}.");
+            return false;
+        }
+
+        var text = command.SafeRemainingArgument;
+        var lastSpace = text.LastIndexOf(' ');
+        if (lastSpace <= 0)
+        {
+            actor.OutputHandler.Send(
+                $"You must enter a valid dice expression after the attribute name, e.g. {"attribute dice strength 1d10+25".ColourCommand()}.");
+            return false;
+        }
+
+        var attributeText = text[..lastSpace];
+        var diceText = text[(lastSpace + 1)..];
+        if (Gameworld.Traits.GetByIdOrName(attributeText) is not IAttributeDefinition attribute)
+        {
+            actor.OutputHandler.Send("There is no such attribute like that.");
+            return false;
+        }
+
+        var alteration = EnsureOwnAttributeAlteration(attribute);
+        if (diceText.EqualTo("default") || diceText.EqualTo("none") || diceText.EqualTo("clear"))
+        {
+            alteration.DiceExpression = null;
+            Changed = true;
+            actor.OutputHandler.Send(
+                $"The {attribute.Name.ColourName()} attribute now uses this race's default attribute dice expression of {DiceExpression.ColourCommand()}.");
+            return true;
+        }
+
+        if (!Dice.IsDiceExpression(diceText))
+        {
+            actor.OutputHandler.Send(
+                $"The text {diceText.ColourCommand()} is not a valid dice expression.");
+            return false;
+        }
+
+        alteration.DiceExpression = diceText;
+        Changed = true;
+        actor.OutputHandler.Send(
+            $"The {attribute.Name.ColourName()} attribute now rolls {diceText.ColourCommand()} for this race instead of the default {DiceExpression.ColourCommand()}.");
         return true;
     }
 
@@ -1376,12 +1466,14 @@ public partial class Race
             return false;
         }
 
+        var bonus = AttributeBonus(attribute);
+        var diceExpression = AttributeDiceExpression(attribute);
         foreach (IRace child in children)
         {
-            child.AddAttributeFromDemotion(attribute);
+            child.AddAttributeFromDemotion(attribute, bonus, diceExpression);
         }
 
-        _attributes.Remove(attribute);
+        RemoveAttribute(attribute);
         Changed = true;
         actor.OutputHandler.Send(
             $"The {attribute.Name.ColourName()} attribute has now been demoted to being on all of the child races.");
@@ -1411,11 +1503,13 @@ public partial class Race
             return false;
         }
 
-        _attributes.Remove(attribute);
+        var bonus = AttributeBonus(attribute);
+        var diceExpression = AttributeDiceExpression(attribute);
+        RemoveAttribute(attribute);
         Changed = true;
         actor.OutputHandler.Send(
             $"You push the {attribute.Name.ColourName()} attribute up to the parent race. Those without the attribute will start with a new value of {10.ToString("N0", actor).ColourValue()}.");
-        ParentRace.AddAttributeFromPromotion(attribute);
+        ParentRace.AddAttributeFromPromotion(attribute, bonus, diceExpression);
         return true;
     }
 
@@ -2327,6 +2421,11 @@ public partial class Race
                         {
                             _attributes.Add(attribute);
                         }
+
+                        var alteration = EnsureAttributeAlteration(attribute);
+                        alteration.Bonus = ParentRace.AttributeBonus(attribute);
+                        var diceExpression = ParentRace.AttributeDiceExpression(attribute);
+                        alteration.DiceExpression = diceExpression.EqualTo(DiceExpression) ? null : diceExpression;
                     }
 
                     foreach ((Gender Gender, Form.Characteristics.ICharacteristicDefinition Definition) characteristic in ParentRace.GenderedCharacteristics)
@@ -2668,22 +2767,29 @@ public partial class Race
             $"Attribute Cap: {IndividualAttributeCap.ToString("N0", actor).Colour(Telnet.Green)}",
             $"Total Cap: {AttributeTotalCap.ToString("N0", actor).Colour(Telnet.Green)}"
         );
-        sb.AppendLineColumns((uint)actor.LineFormatLength, 3,
-            $"Bonus Prog: {(AttributeBonusProg == null ? "None".Colour(Telnet.Red) : string.Format("{0} (#{1:N0})".FluentTagMXP("send", $"href='show futureprog {AttributeBonusProg.Id}'"), AttributeBonusProg.FunctionName, AttributeBonusProg.Id))}",
-            $"",
-            ""
-        );
         sb.AppendLine();
-        foreach (IAttributeDefinition attribute in Attributes)
-        {
-            if (!_attributes.Contains(attribute))
+        sb.AppendLine(StringUtilities.GetTextTable(
+            from attribute in Attributes.OrderBy(x => x.DisplayOrder).ThenBy(x => x.Name)
+            let local = _attributes.Contains(attribute)
+            select new List<string>
             {
-                sb.AppendLine($"\t{attribute.Name.ColourName()} {"(From Parent)".Colour(Telnet.BoldMagenta)}");
-                continue;
-            }
-
-            sb.AppendLine($"\t{attribute.Name.ColourName()}");
-        }
+                attribute.Name,
+                AttributeBonus(attribute).ToString("N2", actor),
+                AttributeDiceExpression(attribute),
+                HealthTraits.Contains(attribute).ToColouredString(),
+                local ? "Local" : "Parent"
+            },
+            new List<string>
+            {
+                "Attribute",
+                "Bonus",
+                "Dice",
+                "Health?",
+                "Source"
+            },
+            actor,
+            Telnet.Green
+        ));
 
         sb.AppendLine();
         sb.AppendLine("Nourishment".GetLineWithTitleInner(actor, Telnet.Blue, Telnet.BoldWhite));

--- a/MudSharpCore/CharacterCreation/Screens/AttributeOrdererScreen.cs
+++ b/MudSharpCore/CharacterCreation/Screens/AttributeOrdererScreen.cs
@@ -206,14 +206,28 @@ public class AttributeOrdererScreenStoryboard : ChargenScreenStoryboard
                 selectedAttributes.Add(attribute);
             }
 
-            List<int> stats = RollRandomStats(split.Length, Chargen.SelectedRace.AttributeTotalCap,
-                Chargen.SelectedRace.IndividualAttributeCap, Chargen.SelectedRace.DiceExpression);
+            List<int> stats = RollRandomStats(selectedAttributes, Chargen.SelectedRace.AttributeTotalCap,
+                Chargen.SelectedRace.IndividualAttributeCap);
             Chargen.SelectedAttributes = selectedAttributes.Select(x =>
-                TraitFactory.LoadAttribute(x, null, stats[selectedAttributes.IndexOf(x)] +
-                                                    Convert.ToDouble(Chargen.SelectedRace.AttributeBonusProg.Execute(x, Chargen))
-                )).ToList<ITrait>();
+                TraitFactory.LoadAttribute(x, null, stats[selectedAttributes.IndexOf(x)])
+                ).ToList<ITrait>();
             State = ChargenScreenState.Complete;
             return "\n";
+        }
+
+        private List<int> RollRandomStats(IReadOnlyList<IAttributeDefinition> attributes, int totalCap, int individualCap)
+        {
+            List<string> diceExpressions = attributes
+                .Select(x => Chargen.SelectedRace.AttributeDiceExpression(x))
+                .ToList();
+            if (diceExpressions.Distinct(StringComparer.InvariantCultureIgnoreCase).Count() == 1)
+            {
+                return RollRandomStats(attributes.Count, totalCap, individualCap, diceExpressions[0]);
+            }
+
+            List<int> results = diceExpressions.Select(Dice.Roll).ToList();
+            BalanceRandomStats(results, totalCap, individualCap);
+            return results;
         }
 
         private List<int> RollRandomStats(int numberOfStats, int totalCap, int individualCap, string diceExpression)
@@ -224,6 +238,14 @@ public class AttributeOrdererScreenStoryboard : ChargenScreenStoryboard
                 results.Add(Dice.Roll(diceExpression));
             }
 
+            BalanceRandomStats(results, totalCap, individualCap);
+            results.Sort();
+            results.Reverse();
+            return results;
+        }
+
+        private void BalanceRandomStats(List<int> results, int totalCap, int individualCap)
+        {
             int difference = totalCap - results.Sum();
             if (difference < 0)
             {
@@ -255,10 +277,6 @@ public class AttributeOrdererScreenStoryboard : ChargenScreenStoryboard
                 whichStat = Constants.Random.Next(0, results.Count);
                 results[whichStat] = results[whichStat] + 1;
             }
-
-            results.Sort();
-            results.Reverse();
-            return results;
         }
     }
 

--- a/MudSharpCore/CharacterCreation/Screens/AttributePointBuyScreen.cs
+++ b/MudSharpCore/CharacterCreation/Screens/AttributePointBuyScreen.cs
@@ -168,12 +168,11 @@ public class AttributePointBuyScreenStoryboard : ChargenScreenStoryboard
     {
         int totalNonFreeBoosts = 0;
         int remainingFreeBoosts = (int)FreeBoostsProg.ExecuteDouble(chargen);
-        foreach (ITrait attribute in chargen.SelectedAttributes)
-        {
-            int boosts =
-                (int)Math.Round(
-                    attribute.RawValue - AttributeBaseValueProg.ExecuteDouble(chargen, attribute.Definition) -
-                    chargen.SelectedRace.AttributeBonusProg.ExecuteDouble(attribute.Definition, chargen), 0);
+            foreach (ITrait attribute in chargen.SelectedAttributes)
+            {
+                int boosts =
+                    (int)Math.Round(
+                    attribute.RawValue - AttributeBaseValueProg.ExecuteDouble(chargen, attribute.Definition), 0);
             int nonFreeBoosts = Math.Max(0,
                 boosts - (int)(MaximumFreeBoostsProg?.ExecuteDouble(chargen, attribute.Definition) ?? 0.0));
             totalNonFreeBoosts += nonFreeBoosts;
@@ -230,8 +229,7 @@ public class AttributePointBuyScreenStoryboard : ChargenScreenStoryboard
             foreach (IAttributeDefinition attribute in _baseValues.Keys)
             {
                 selectedAttributes.Add(TraitFactory.LoadAttribute(attribute, null,
-                    _baseValues[attribute] + _numberOfBoosts[attribute] +
-                    Chargen.SelectedRace.AttributeBonusProg.ExecuteDouble(attribute, Chargen)));
+                    _baseValues[attribute] + _numberOfBoosts[attribute]));
             }
 
             Chargen.SelectedAttributes = selectedAttributes;
@@ -252,7 +250,7 @@ public class AttributePointBuyScreenStoryboard : ChargenScreenStoryboard
             foreach (IAttributeDefinition attribute in _baseValues.Keys.OrderBy(x => x.Name))
             {
                 double current = _baseValues[attribute] + _numberOfBoosts[attribute] +
-                              Chargen.SelectedRace.AttributeBonusProg.ExecuteDouble(attribute, Chargen);
+                                 Chargen.SelectedRace.AttributeBonus(attribute);
                 string boostString = "";
                 if (_numberOfBoosts[attribute] > 0)
                 {

--- a/MudSharpCore/Commands/Modules/ShowModule.cs
+++ b/MudSharpCore/Commands/Modules/ShowModule.cs
@@ -1758,19 +1758,12 @@ public class ShowModule : Module<ICharacter>
                 $"Armour Quality: {race.NaturalArmourQuality.Describe().Colour(Telnet.Green)}"
             }
             .ArrangeStringsOntoLines(3U, (uint)actor.LineFormatLength));
-        sb.AppendLine($"Attributes: {race.Attributes.Select(x => x.Name.Colour(Telnet.Green)).ListToString()}");
+        sb.AppendLine($"Attributes: {race.Attributes.Select(x => $"{x.Name.Colour(Telnet.Green)} ({race.AttributeBonus(x).ToString("N2", actor).ColourValue()}, {race.AttributeDiceExpression(x).ColourCommand()})").ListToString()}");
         sb.AppendLine(new[]
             {
                 $"Attribute Roll: {race.DiceExpression.Colour(Telnet.Green)}",
                 $"Attribute Cap: {race.IndividualAttributeCap.ToString("N0", actor).Colour(Telnet.Green)}",
                 $"Total Cap: {race.AttributeTotalCap.ToString("N0", actor).Colour(Telnet.Green)}"
-            }
-            .ArrangeStringsOntoLines(3U, (uint)actor.LineFormatLength));
-        sb.AppendLine(new[]
-            {
-                $"Bonus Prog: {(race.AttributeBonusProg == null ? "None".Colour(Telnet.Red) : string.Format("{0} (#{1:N0})".FluentTagMXP("send", $"href='show futureprog {race.AttributeBonusProg.Id}'"), race.AttributeBonusProg.FunctionName, race.AttributeBonusProg.Id))}",
-                "",
-                ""
             }
             .ArrangeStringsOntoLines(3U, (uint)actor.LineFormatLength));
         sb.AppendLine(new[]

--- a/MudSharpCore/NPC/Templates/NPCTemplateBase.cs
+++ b/MudSharpCore/NPC/Templates/NPCTemplateBase.cs
@@ -1,5 +1,8 @@
 ﻿using MudSharp.Accounts;
+using MudSharp.Body.Traits;
+using MudSharp.Body.Traits.Subtypes;
 using MudSharp.Character;
+using MudSharp.Character.Heritage;
 using MudSharp.CharacterCreation;
 using MudSharp.Combat;
 using MudSharp.Construction;
@@ -300,6 +303,30 @@ public abstract class NPCTemplateBase : EditableItem, INPCTemplate
             results.Add(Dice.Roll(diceExpression));
         }
 
+        BalanceRandomStats(results, totalCap, individualCap);
+        results.Sort();
+        results.Reverse();
+        return results;
+    }
+
+    protected static List<int> RollRandomStats(IReadOnlyList<IAttributeDefinition> attributes, IRace race,
+        int totalCap, int individualCap)
+    {
+        List<string> diceExpressions = attributes
+            .Select(race.AttributeDiceExpression)
+            .ToList();
+        if (diceExpressions.Distinct(StringComparer.InvariantCultureIgnoreCase).Count() == 1)
+        {
+            return RollRandomStats(attributes.Count, totalCap, individualCap, diceExpressions[0]);
+        }
+
+        List<int> results = diceExpressions.Select(Dice.Roll).ToList();
+        BalanceRandomStats(results, totalCap, individualCap);
+        return results;
+    }
+
+    private static void BalanceRandomStats(List<int> results, int totalCap, int individualCap)
+    {
         int difference = totalCap - results.Sum();
         if (difference < 0)
         {
@@ -331,10 +358,6 @@ public abstract class NPCTemplateBase : EditableItem, INPCTemplate
             whichStat = Constants.Random.Next(0, results.Count);
             results[whichStat] += 1;
         }
-
-        results.Sort();
-        results.Reverse();
-        return results;
     }
 
     #region INPCTemplate Members

--- a/MudSharpCore/NPC/Templates/SimpleNPCTemplate.cs
+++ b/MudSharpCore/NPC/Templates/SimpleNPCTemplate.cs
@@ -1218,11 +1218,10 @@ public class SimpleNPCTemplate : NPCTemplateBase
             return false;
         }
 
-        List<int> statrolls = RollRandomStats(SelectedRace.Attributes.Count(),
-            SelectedRace.AttributeTotalCap, SelectedRace.IndividualAttributeCap,
-            SelectedRace.DiceExpression);
         SelectedAttributes.Clear();
         List<IAttributeDefinition> attributeOrder = SelectedRace.Attributes.Shuffle().ToList();
+        List<int> statrolls = RollRandomStats(attributeOrder, SelectedRace,
+            SelectedRace.AttributeTotalCap, SelectedRace.IndividualAttributeCap);
         for (int i = 0; i < attributeOrder.Count; i++)
         {
             SelectedAttributes.Add(TraitFactory.LoadAttribute(attributeOrder[i], null, statrolls[i]));

--- a/MudSharpCore/NPC/Templates/VariableNPCTemplate.cs
+++ b/MudSharpCore/NPC/Templates/VariableNPCTemplate.cs
@@ -412,9 +412,6 @@ public class VariableNPCTemplate : NPCTemplateBase
         Gender rolledGender = _genderChances.GetWeightedRandom();
         (double, double) rolledHeightWeight = _heightWeightModels[rolledGender].GetRandomHeightWeight();
         int rolledAge = Constants.Random.Next(_minimumAge, _maximumAge + 1);
-        List<int> statrolls = RollRandomStats(_race.Attributes.Count(),
-            _attributeTotal ?? _race.AttributeTotalCap, _race.IndividualAttributeCap,
-            _race.DiceExpression);
         List<IAttributeDefinition> attributeOrder =
             _race.Attributes.OrderBy(
                      x =>
@@ -422,9 +419,10 @@ public class VariableNPCTemplate : NPCTemplateBase
                              ? _priorityAttributeDefinitions.IndexOf(x)
                              : Dice.Roll("1d100+100"))
                  .ToList();
+        List<int> statrolls = RollRandomStats(attributeOrder, _race,
+            _attributeTotal ?? _race.AttributeTotalCap, _race.IndividualAttributeCap);
         List<ITrait> assignedStats = attributeOrder.Select(x => TraitFactory.LoadAttribute(x, null,
-                                              statrolls[attributeOrder.IndexOf(x)] +
-                                              Convert.ToDouble(_race.AttributeBonusProg.Execute(x, this))))
+                                              statrolls[attributeOrder.IndexOf(x)]))
                                           .ToList<ITrait>();
         List<(ITraitDefinition Trait, double)> rolledSkills = _skillTemplates.Where(x => Constants.Random.NextDouble() <= x.Chance)
                                           .Select(y => (y.Trait,

--- a/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextConfiguring3.cs
+++ b/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextConfiguring3.cs
@@ -1605,9 +1605,6 @@ namespace MudSharp.Database
 
             modelBuilder.Entity<Race>(entity =>
             {
-                entity.HasIndex(e => e.AttributeBonusProgId)
-                    .HasDatabaseName("FK_Races_AttributeBonusProg");
-
                 entity.HasIndex(e => e.AvailabilityProgId)
                     .HasDatabaseName("FK_Races_AvailabilityProg");
 
@@ -1652,8 +1649,6 @@ namespace MudSharp.Database
                     .HasColumnType("varchar(255)")
                     .HasCharSet("utf8")
                     .UseCollation("utf8_general_ci");
-
-                entity.Property(e => e.AttributeBonusProgId).HasColumnType("bigint(20)");
 
                 entity.Property(e => e.AttributeTotalCap).HasColumnType("int(11)");
 
@@ -1879,13 +1874,6 @@ namespace MudSharp.Database
                     .HasForeignKey(d => d.DefaultHeightWeightModelNonBinaryId)
                     .HasConstraintName("FK_Races_HeightWeightModelsNonBinary");
 
-
-                entity.HasOne(d => d.AttributeBonusProg)
-                    .WithMany(p => p.RacesAttributeBonusProg)
-                    .HasForeignKey(d => d.AttributeBonusProgId)
-                    .OnDelete(DeleteBehavior.ClientSetNull)
-                    .HasConstraintName("FK_Races_AttributeBonusProg");
-
                 entity.HasOne(d => d.AvailabilityProg)
                     .WithMany(p => p.RacesAvailabilityProg)
                     .HasForeignKey(d => d.AvailabilityProgId)
@@ -2036,6 +2024,14 @@ namespace MudSharp.Database
                 entity.Property(e => e.RaceId).HasColumnType("bigint(20)");
 
                 entity.Property(e => e.AttributeId).HasColumnType("bigint(20)");
+
+                entity.Property(e => e.AttributeBonus).HasColumnType("double");
+
+                entity.Property(e => e.DiceExpression)
+                    .HasMaxLength(255)
+                    .HasColumnType("varchar(255)")
+                    .HasCharSet("utf8")
+                    .UseCollation("utf8_general_ci");
 
                 entity.Property(e => e.IsHealthAttribute)
                     .HasColumnType("bit(1)")

--- a/MudsharpDatabaseLibrary/Migrations/20260424000000_RaceAttributeAlterations.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260424000000_RaceAttributeAlterations.cs
@@ -1,0 +1,75 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using MudSharp.Database;
+
+#nullable disable
+
+namespace MudSharp.Migrations
+{
+	[DbContext(typeof(FuturemudDatabaseContext))]
+	[Migration("20260424000000_RaceAttributeAlterations")]
+	public partial class RaceAttributeAlterations : Migration
+	{
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.DropForeignKey(
+				name: "FK_Races_AttributeBonusProg",
+				table: "Races");
+
+			migrationBuilder.DropIndex(
+				name: "FK_Races_AttributeBonusProg",
+				table: "Races");
+
+			migrationBuilder.DropColumn(
+				name: "AttributeBonusProgId",
+				table: "Races");
+
+			migrationBuilder.AddColumn<double>(
+				name: "AttributeBonus",
+				table: "Races_Attributes",
+				type: "double",
+				nullable: false,
+				defaultValue: 0.0);
+
+			migrationBuilder.AddColumn<string>(
+				name: "DiceExpression",
+				table: "Races_Attributes",
+				type: "varchar(255)",
+				maxLength: 255,
+				nullable: true,
+				collation: "utf8_general_ci")
+				.Annotation("MySql:CharSet", "utf8");
+		}
+
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.DropColumn(
+				name: "AttributeBonus",
+				table: "Races_Attributes");
+
+			migrationBuilder.DropColumn(
+				name: "DiceExpression",
+				table: "Races_Attributes");
+
+			migrationBuilder.AddColumn<long>(
+				name: "AttributeBonusProgId",
+				table: "Races",
+				type: "bigint(20)",
+				nullable: false,
+				defaultValue: 1L);
+
+			migrationBuilder.CreateIndex(
+				name: "FK_Races_AttributeBonusProg",
+				table: "Races",
+				column: "AttributeBonusProgId");
+
+			migrationBuilder.AddForeignKey(
+				name: "FK_Races_AttributeBonusProg",
+				table: "Races",
+				column: "AttributeBonusProgId",
+				principalTable: "FutureProgs",
+				principalColumn: "Id",
+				onDelete: ReferentialAction.Cascade);
+		}
+	}
+}

--- a/MudsharpDatabaseLibrary/Migrations/FutureMUDContextModelSnapshot.cs
+++ b/MudsharpDatabaseLibrary/Migrations/FutureMUDContextModelSnapshot.cs
@@ -14094,9 +14094,6 @@ namespace MudSharp.Migrations
 
                     MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("AllowedGenders"), "utf8");
 
-                    b.Property<long>("AttributeBonusProgId")
-                        .HasColumnType("bigint(20)");
-
                     b.Property<int>("AttributeTotalCap")
                         .HasColumnType("int(11)");
 
@@ -14400,9 +14397,6 @@ namespace MudSharp.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("AttributeBonusProgId")
-                        .HasDatabaseName("FK_Races_AttributeBonusProg");
-
                     b.HasIndex("AvailabilityProgId")
                         .HasDatabaseName("FK_Races_AvailabilityProg");
 
@@ -14694,6 +14688,16 @@ namespace MudSharp.Migrations
 
                     b.Property<long>("AttributeId")
                         .HasColumnType("bigint(20)");
+
+                    b.Property<double>("AttributeBonus")
+                        .HasColumnType("double");
+
+                    b.Property<string>("DiceExpression")
+                        .HasMaxLength(255)
+                        .HasColumnType("varchar(255)")
+                        .UseCollation("utf8_general_ci");
+
+                    MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("DiceExpression"), "utf8");
 
                     b.Property<ulong>("IsHealthAttribute")
                         .ValueGeneratedOnAdd()
@@ -24183,12 +24187,6 @@ namespace MudSharp.Migrations
 
             modelBuilder.Entity("MudSharp.Models.Race", b =>
                 {
-                    b.HasOne("MudSharp.Models.FutureProg", "AttributeBonusProg")
-                        .WithMany("RacesAttributeBonusProg")
-                        .HasForeignKey("AttributeBonusProgId")
-                        .IsRequired()
-                        .HasConstraintName("FK_Races_AttributeBonusProg");
-
                     b.HasOne("MudSharp.Models.FutureProg", "AvailabilityProg")
                         .WithMany("RacesAvailabilityProg")
                         .HasForeignKey("AvailabilityProgId")
@@ -24278,8 +24276,6 @@ namespace MudSharp.Migrations
                         .HasForeignKey("SweatLiquidId")
                         .OnDelete(DeleteBehavior.SetNull)
                         .HasConstraintName("FK_Races_Liqiuds_Sweat");
-
-                    b.Navigation("AttributeBonusProg");
 
                     b.Navigation("AvailabilityProg");
 
@@ -26862,8 +26858,6 @@ namespace MudSharp.Migrations
                     b.Navigation("RaceButcheryProfilesCanButcherProg");
 
                     b.Navigation("RaceButcheryProfilesWhyCannotButcherProg");
-
-                    b.Navigation("RacesAttributeBonusProg");
 
                     b.Navigation("RacesAvailabilityProg");
 

--- a/MudsharpDatabaseLibrary/Models/FutureProg.cs
+++ b/MudsharpDatabaseLibrary/Models/FutureProg.cs
@@ -47,7 +47,6 @@ namespace MudSharp.Models
             ProgSchedules = new HashSet<ProgSchedule>();
             RaceButcheryProfilesCanButcherProg = new HashSet<RaceButcheryProfile>();
             RaceButcheryProfilesWhyCannotButcherProg = new HashSet<RaceButcheryProfile>();
-            RacesAttributeBonusProg = new HashSet<Race>();
             RacesAvailabilityProg = new HashSet<Race>();
             RanksAbbreviations = new HashSet<RanksAbbreviations>();
             RanksTitles = new HashSet<RanksTitle>();
@@ -128,7 +127,6 @@ namespace MudSharp.Models
         public virtual ICollection<ProgSchedule> ProgSchedules { get; set; }
         public virtual ICollection<RaceButcheryProfile> RaceButcheryProfilesCanButcherProg { get; set; }
         public virtual ICollection<RaceButcheryProfile> RaceButcheryProfilesWhyCannotButcherProg { get; set; }
-        public virtual ICollection<Race> RacesAttributeBonusProg { get; set; }
         public virtual ICollection<Race> RacesAvailabilityProg { get; set; }
         public virtual ICollection<RanksAbbreviations> RanksAbbreviations { get; set; }
         public virtual ICollection<RanksTitle> RanksTitles { get; set; }

--- a/MudsharpDatabaseLibrary/Models/Race.cs
+++ b/MudsharpDatabaseLibrary/Models/Race.cs
@@ -29,7 +29,6 @@ namespace MudSharp.Models
         public long BaseBodyId { get; set; }
         public string AllowedGenders { get; set; }
         public long? ParentRaceId { get; set; }
-        public long AttributeBonusProgId { get; set; }
         public int AttributeTotalCap { get; set; }
         public int IndividualAttributeCap { get; set; }
         public string DiceExpression { get; set; }
@@ -95,7 +94,6 @@ namespace MudSharp.Models
         public virtual HeightWeightModel DefaultHeightWeightModelFemale { get; set; }
         public virtual HeightWeightModel DefaultHeightWeightModelNeuter { get; set; }
         public virtual HeightWeightModel DefaultHeightWeightModelNonBinary { get; set; }
-        public virtual FutureProg AttributeBonusProg { get; set; }
         public virtual FutureProg AvailabilityProg { get; set; }
         public virtual BodyProto BaseBody { get; set; }
         public virtual Liquid BloodLiquid { get; set; }

--- a/MudsharpDatabaseLibrary/Models/RacesAttributes.cs
+++ b/MudsharpDatabaseLibrary/Models/RacesAttributes.cs
@@ -8,6 +8,8 @@ namespace MudSharp.Models
         public long RaceId { get; set; }
         public long AttributeId { get; set; }
         public bool IsHealthAttribute { get; set; }
+        public double AttributeBonus { get; set; }
+        public string DiceExpression { get; set; }
 
         public virtual TraitDefinition Attribute { get; set; }
         public virtual Race Race { get; set; }


### PR DESCRIPTION
## Summary
- Replace creation-time race attribute bonus progs with row-backed `Races_Attributes.AttributeBonus` values
- Update animal, mythical, human, and robot seeding to seed per-attribute bonuses directly
- Apply race attribute bonuses during body trait lookup and refresh related design docs and tests

## Testing
- Updated seeder unit tests to reflect the new race-attribute model
- Added coverage for alternate non-human attribute name mapping
- Not run (not requested)