### PR TITLE
Add racial hunger and thirst scaling

### DIFF
--- a/Design Documents/Adjacencies_and_Items.md
+++ b/Design Documents/Adjacencies_and_Items.md
@@ -46,6 +46,8 @@ Needs are separated from wounds but still participate in health because they alt
 
 `INeedsModel` is the contract that controls ongoing hunger, thirst, alcohol, water, and related fulfillment or decay behavior.
 
+Race data controls both the rate and capacity of hunger and thirst. `HungerRate` and `ThirstRate` multiply the active heartbeat decay speed, while `MaximumFoodSatiatedHours` and `MaximumDrinkSatiatedHours` cap how many positive satiation hours a character of that race can store. The player-facing labels scale from these caps: food becomes peckish/full/absolutely stuffed at 25/50/75% of the food limit, and drink becomes not thirsty/sated at 50/75% of the drink limit. Builders edit these through the race-building `hunger`, `thirst`, `hungerlimit`, and `thirstlimit` options.
+
 ### Needs model families
 | Needs model | Current behavior | Current stock usage |
 | --- | --- | --- |

--- a/FutureMUDLibrary/Body/Needs/NeedsResultEnum.cs
+++ b/FutureMUDLibrary/Body/Needs/NeedsResultEnum.cs
@@ -19,22 +19,26 @@ namespace MudSharp.Body.Needs
         Starving = 1 << 0,
 
         /// <summary>
-        ///     This result occurs when food satiation changes and the character is hungry afterwards (hours of satiation 0 - 2)
+        ///     This result occurs when food satiation changes and the character is hungry afterwards (positive hours below
+        ///     one quarter of the race's food satiation limit)
         /// </summary>
         Hungry = 1 << 1,
 
         /// <summary>
-        ///     This result occurs when food satiation changes and the character is peckish afterwards (hours of satiation 2 - 4)
+        ///     This result occurs when food satiation changes and the character is peckish afterwards (one quarter to one half
+        ///     of the race's food satiation limit)
         /// </summary>
         Peckish = 1 << 2,
 
         /// <summary>
-        ///     This result occurs when food satiation changes and the character is full afterwards (hours of satiation 4 - 8)
+        ///     This result occurs when food satiation changes and the character is full afterwards (one half to three quarters
+        ///     of the race's food satiation limit)
         /// </summary>
         Full = 1 << 3,
 
         /// <summary>
-        ///     This result occurs when food satiation changes and the character is stuffed afterwards (hours of satiation 8+)
+        ///     This result occurs when food satiation changes and the character is stuffed afterwards (at least three quarters
+        ///     of the race's food satiation limit)
         /// </summary>
         AbsolutelyStuffed = 1 << 4,
 
@@ -45,18 +49,20 @@ namespace MudSharp.Body.Needs
         Parched = 1 << 5,
 
         /// <summary>
-        ///     This result occurs when drink satiation changes and the character is thirsty afterwards (hours of satiation 0 - 2)
+        ///     This result occurs when drink satiation changes and the character is thirsty afterwards (positive hours below
+        ///     one half of the race's drink satiation limit)
         /// </summary>
         Thirsty = 1 << 6,
 
         /// <summary>
-        ///     This result occurs when drink satiation changes and the character is not thirsty afterwards (hours of satiation 2 -
-        ///     4)
+        ///     This result occurs when drink satiation changes and the character is not thirsty afterwards (one half to three
+        ///     quarters of the race's drink satiation limit)
         /// </summary>
         NotThirsty = 1 << 7,
 
         /// <summary>
-        ///     This result occurs when drink satiation changes and the character is not thirsty afterwards (hours of satiation 4+)
+        ///     This result occurs when drink satiation changes and the character is sated afterwards (at least three quarters
+        ///     of the race's drink satiation limit)
         /// </summary>
         Sated = 1 << 8,
 

--- a/FutureMUDLibrary/Character/Heritage/IRace.cs
+++ b/FutureMUDLibrary/Character/Heritage/IRace.cs
@@ -24,6 +24,12 @@ using System.Collections.Generic;
 
 namespace MudSharp.Character.Heritage
 {
+    public static class RacialSatiationDefaults
+    {
+        public const double MaximumFoodSatiatedHours = 16.0;
+        public const double MaximumDrinkSatiatedHours = 8.0;
+    }
+
     public interface IRace : IEditableItem, IProgVariable, IHaveContextualSizeCategory, IHavePositionalSizes
     {
         string Description { get; }
@@ -222,6 +228,8 @@ namespace MudSharp.Character.Heritage
         IRace Clone(string newName);
         double HungerRate { get; }
         double ThirstRate { get; }
+        double MaximumFoodSatiatedHours { get; }
+        double MaximumDrinkSatiatedHours { get; }
         double TrackIntensityVisual { get; }
         double TrackIntensityOlfactory { get; }
         double TrackingAbilityVisual { get; }

--- a/MudSharpCore Unit Tests/ChangingNeedsModelBaseTests.cs
+++ b/MudSharpCore Unit Tests/ChangingNeedsModelBaseTests.cs
@@ -17,6 +17,32 @@ public class ChangingNeedsModelBaseTests
     }
 
     [TestMethod]
+    public void CalculateOversatiationLevel_UsesRacialFoodLimit()
+    {
+        Assert.AreEqual(0.0, ChangingNeedsModelBase.CalculateOversatiationLevel(540.0, 720.0), 1e-6);
+        Assert.AreEqual(60.0, ChangingNeedsModelBase.CalculateOversatiationLevel(600.0, 720.0), 1e-6);
+    }
+
+    [TestMethod]
+    public void GetHungerStatus_ScalesThresholdsWithFoodLimit()
+    {
+        Assert.AreEqual(NeedsResult.AbsolutelyStuffed, ChangingNeedsModelBase.GetHungerStatus(540.0, 720.0));
+        Assert.AreEqual(NeedsResult.Full, ChangingNeedsModelBase.GetHungerStatus(360.0, 720.0));
+        Assert.AreEqual(NeedsResult.Peckish, ChangingNeedsModelBase.GetHungerStatus(180.0, 720.0));
+        Assert.AreEqual(NeedsResult.Hungry, ChangingNeedsModelBase.GetHungerStatus(0.1, 720.0));
+        Assert.AreEqual(NeedsResult.Starving, ChangingNeedsModelBase.GetHungerStatus(0.0, 720.0));
+    }
+
+    [TestMethod]
+    public void GetThirstStatus_ScalesThresholdsWithDrinkLimit()
+    {
+        Assert.AreEqual(NeedsResult.Sated, ChangingNeedsModelBase.GetThirstStatus(180.0, 240.0));
+        Assert.AreEqual(NeedsResult.NotThirsty, ChangingNeedsModelBase.GetThirstStatus(120.0, 240.0));
+        Assert.AreEqual(NeedsResult.Thirsty, ChangingNeedsModelBase.GetThirstStatus(0.1, 240.0));
+        Assert.AreEqual(NeedsResult.Parched, ChangingNeedsModelBase.GetThirstStatus(0.0, 240.0));
+    }
+
+    [TestMethod]
     public void PositiveSatiationRecoverDeficitBeforeCreatingExcess()
     {
         double result = ChangingNeedsModelBase.ApplySatiationReserveFromFulfiller(-3.0, 8.0, 8.0);

--- a/MudSharpCore/Body/Needs/ActiveNeedsModel.cs
+++ b/MudSharpCore/Body/Needs/ActiveNeedsModel.cs
@@ -19,13 +19,14 @@ public class ActiveNeedsModel : ChangingNeedsModelBase
         AlcoholLitres = dbcharacter.AlcoholLitres;
         WaterLitres = dbcharacter.WaterLitres;
         SatiationReserve = dbcharacter.SatiationReserve;
+        NormaliseValues();
     }
 
     public ActiveNeedsModel(ICharacter character)
     {
         Owner = character;
-        DrinkSatiatedHours = 24;
-        FoodSatiatedHours = 24;
+        DrinkSatiatedHours = DrinkSatiationLimit;
+        FoodSatiatedHours = FoodSatiationLimit;
         AlcoholLitres = 0;
         WaterLitres = 3.0;
         SatiationReserve = 0.0;
@@ -66,6 +67,7 @@ public class ActiveNeedsModel : ChangingNeedsModelBase
             SpendSatiationReserve(satiationUse * exertionMultiplier, false);
         }
 
+        NormaliseValues();
         NeedsChanged(oldStatus, true, true, false);
     }
 }

--- a/MudSharpCore/Body/Needs/ChangingNeedsModelBase.cs
+++ b/MudSharpCore/Body/Needs/ChangingNeedsModelBase.cs
@@ -1,5 +1,6 @@
 using MudSharp.Body;
 using MudSharp.Character;
+using MudSharp.Character.Heritage;
 using MudSharp.Effects.Concrete;
 using MudSharp.Effects.Interfaces;
 using MudSharp.Framework;
@@ -16,6 +17,10 @@ public abstract class ChangingNeedsModelBase : INeedsModel
     protected double RealSecondsToInGameSeconds => StaticRealSecondsToInGameSeconds;
 
     public ICharacter Owner { get; init; }
+    protected double FoodSatiationLimit => GetEffectiveFoodSatiationLimit(
+        Owner?.Race?.MaximumFoodSatiatedHours ?? RacialSatiationDefaults.MaximumFoodSatiatedHours);
+    protected double DrinkSatiationLimit => GetEffectiveDrinkSatiationLimit(
+        Owner?.Race?.MaximumDrinkSatiatedHours ?? RacialSatiationDefaults.MaximumDrinkSatiatedHours);
 
     #region INeedsModel Members
 
@@ -35,12 +40,14 @@ public abstract class ChangingNeedsModelBase : INeedsModel
         FoodSatiatedHours += satiationDelta;
         DrinkSatiatedHours += thirstDelta;
         SatiationReserve =
-            ApplySatiationReserveFromFulfiller(SatiationReserve, previousFoodSatiatedHours, satiationDelta);
+            ApplySatiationReserveFromFulfiller(SatiationReserve, previousFoodSatiatedHours, satiationDelta,
+                FoodSatiationLimit);
         if (!ignoreDelays && fulfiller.AlcoholLitres > 0.0)
         {
             AlcoholLitres += fulfiller.AlcoholLitres * 0.25 * drunkMult;
             TimeSpan timespan = TimeSpan.FromMinutes(Math.Max(1.0,
-                15.0 * (1.0 + FoodSatiatedHours / 12.0) * RealSecondsToInGameSeconds));
+                15.0 * (1.0 + FoodSatiatedHours / GetFoodAbsolutelyStuffedThreshold(FoodSatiationLimit)) *
+                RealSecondsToInGameSeconds));
             Owner.Body.AddEffect(new DelayedNeedsFulfillment(Owner.Body,
                 new NeedFulfiller
                 {
@@ -73,24 +80,28 @@ public abstract class ChangingNeedsModelBase : INeedsModel
 
     protected void NormaliseValues()
     {
-        if (FoodSatiatedHours > 16)
+        double foodLimit = FoodSatiationLimit;
+        if (FoodSatiatedHours > foodLimit)
         {
-            FoodSatiatedHours = 16;
+            FoodSatiatedHours = foodLimit;
         }
 
-        if (FoodSatiatedHours < -4)
+        double foodMinimum = -0.25 * foodLimit;
+        if (FoodSatiatedHours < foodMinimum)
         {
-            FoodSatiatedHours = -4;
+            FoodSatiatedHours = foodMinimum;
         }
 
-        if (DrinkSatiatedHours > 8)
+        double drinkLimit = DrinkSatiationLimit;
+        if (DrinkSatiatedHours > drinkLimit)
         {
-            DrinkSatiatedHours = 8;
+            DrinkSatiatedHours = drinkLimit;
         }
 
-        if (DrinkSatiatedHours < -4)
+        double drinkMinimum = -0.5 * drinkLimit;
+        if (DrinkSatiatedHours < drinkMinimum)
         {
-            DrinkSatiatedHours = -4;
+            DrinkSatiatedHours = drinkMinimum;
         }
 
         if (AlcoholLitres < 0)
@@ -262,13 +273,80 @@ public abstract class ChangingNeedsModelBase : INeedsModel
         return Math.Max(0.0, -foodSatiatedHours);
     }
 
-    internal static double CalculateOversatiationLevel(double foodSatiatedHours)
+    internal static double GetEffectiveFoodSatiationLimit(double configuredLimit)
     {
-        return Math.Max(0.0, foodSatiatedHours - 12.0);
+        return GetEffectiveSatiationLimit(configuredLimit, RacialSatiationDefaults.MaximumFoodSatiatedHours);
+    }
+
+    internal static double GetEffectiveDrinkSatiationLimit(double configuredLimit)
+    {
+        return GetEffectiveSatiationLimit(configuredLimit, RacialSatiationDefaults.MaximumDrinkSatiatedHours);
+    }
+
+    private static double GetEffectiveSatiationLimit(double configuredLimit, double fallbackLimit)
+    {
+        if (double.IsNaN(configuredLimit) || double.IsInfinity(configuredLimit) || configuredLimit <= 0.0)
+        {
+            return fallbackLimit;
+        }
+
+        return configuredLimit;
+    }
+
+    internal static double GetFoodAbsolutelyStuffedThreshold(double maximumFoodSatiatedHours =
+        RacialSatiationDefaults.MaximumFoodSatiatedHours)
+    {
+        return GetEffectiveFoodSatiationLimit(maximumFoodSatiatedHours) * 0.75;
+    }
+
+    internal static NeedsResult GetHungerStatus(double foodSatiatedHours,
+        double maximumFoodSatiatedHours = RacialSatiationDefaults.MaximumFoodSatiatedHours)
+    {
+        double foodLimit = GetEffectiveFoodSatiationLimit(maximumFoodSatiatedHours);
+        if (foodSatiatedHours >= foodLimit * 0.75)
+        {
+            return NeedsResult.AbsolutelyStuffed;
+        }
+
+        if (foodSatiatedHours >= foodLimit * 0.5)
+        {
+            return NeedsResult.Full;
+        }
+
+        if (foodSatiatedHours >= foodLimit * 0.25)
+        {
+            return NeedsResult.Peckish;
+        }
+
+        return foodSatiatedHours > 0.0 ? NeedsResult.Hungry : NeedsResult.Starving;
+    }
+
+    internal static NeedsResult GetThirstStatus(double drinkSatiatedHours,
+        double maximumDrinkSatiatedHours = RacialSatiationDefaults.MaximumDrinkSatiatedHours)
+    {
+        double drinkLimit = GetEffectiveDrinkSatiationLimit(maximumDrinkSatiatedHours);
+        if (drinkSatiatedHours >= drinkLimit * 0.75)
+        {
+            return NeedsResult.Sated;
+        }
+
+        if (drinkSatiatedHours >= drinkLimit * 0.5)
+        {
+            return NeedsResult.NotThirsty;
+        }
+
+        return drinkSatiatedHours > 0.0 ? NeedsResult.Thirsty : NeedsResult.Parched;
+    }
+
+    internal static double CalculateOversatiationLevel(double foodSatiatedHours,
+        double maximumFoodSatiatedHours = RacialSatiationDefaults.MaximumFoodSatiatedHours)
+    {
+        return Math.Max(0.0, foodSatiatedHours - GetFoodAbsolutelyStuffedThreshold(maximumFoodSatiatedHours));
     }
 
     internal static double ApplySatiationReserveFromFulfiller(double currentReserve, double previousFoodSatiatedHours,
-        double satiationDelta)
+        double satiationDelta,
+        double maximumFoodSatiatedHours = RacialSatiationDefaults.MaximumFoodSatiatedHours)
     {
         if (satiationDelta <= 0.0)
         {
@@ -288,8 +366,9 @@ public abstract class ChangingNeedsModelBase : INeedsModel
             return currentReserve;
         }
 
-        double oversatiationBefore = CalculateOversatiationLevel(previousFoodSatiatedHours);
-        double oversatiationAfter = CalculateOversatiationLevel(previousFoodSatiatedHours + originalSatiationDelta);
+        double oversatiationBefore = CalculateOversatiationLevel(previousFoodSatiatedHours, maximumFoodSatiatedHours);
+        double oversatiationAfter =
+            CalculateOversatiationLevel(previousFoodSatiatedHours + originalSatiationDelta, maximumFoodSatiatedHours);
         double oversatiationGain = Math.Max(0.0, oversatiationAfter - oversatiationBefore);
         if (oversatiationGain <= 0.0)
         {
@@ -347,43 +426,8 @@ public abstract class ChangingNeedsModelBase : INeedsModel
         get
         {
             NeedsResult result = NeedsResult.None;
-            if (FoodSatiatedHours >= 12)
-            {
-                result |= NeedsResult.AbsolutelyStuffed;
-            }
-            else if (FoodSatiatedHours >= 8)
-            {
-                result |= NeedsResult.Full;
-            }
-            else if (FoodSatiatedHours >= 4)
-            {
-                result |= NeedsResult.Peckish;
-            }
-            else if (FoodSatiatedHours > 0)
-            {
-                result |= NeedsResult.Hungry;
-            }
-            else
-            {
-                result |= NeedsResult.Starving;
-            }
-
-            if (DrinkSatiatedHours >= 6)
-            {
-                result |= NeedsResult.Sated;
-            }
-            else if (DrinkSatiatedHours >= 4)
-            {
-                result |= NeedsResult.NotThirsty;
-            }
-            else if (DrinkSatiatedHours > 0)
-            {
-                result |= NeedsResult.Thirsty;
-            }
-            else
-            {
-                result |= NeedsResult.Parched;
-            }
+            result |= GetHungerStatus(FoodSatiatedHours, FoodSatiationLimit);
+            result |= GetThirstStatus(DrinkSatiatedHours, DrinkSatiationLimit);
 
             double bac = 10.0 * AlcoholLitres / Owner.Body.CurrentBloodVolumeLitres;
             if (bac >= 0.25)
@@ -443,7 +487,7 @@ public abstract class ChangingNeedsModelBase : INeedsModel
 
     public double StarvationLevel => CalculateStarvationLevel(FoodSatiatedHours);
 
-    public double OversatiationLevel => CalculateOversatiationLevel(FoodSatiatedHours);
+    public double OversatiationLevel => CalculateOversatiationLevel(FoodSatiatedHours, FoodSatiationLimit);
 
     public double SatiationExcess => Math.Max(0.0, SatiationReserve);
 

--- a/MudSharpCore/Body/Needs/PassiveNeedsModel.cs
+++ b/MudSharpCore/Body/Needs/PassiveNeedsModel.cs
@@ -13,8 +13,8 @@ public class PassiveNeedsModel : ChangingNeedsModelBase
         Owner = character;
         AlcoholLitres = 0.0;
         WaterLitres = 0.0;
-        FoodSatiatedHours = 16.0;
-        DrinkSatiatedHours = 8.0;
+        FoodSatiatedHours = FoodSatiationLimit;
+        DrinkSatiatedHours = DrinkSatiationLimit;
         SatiationReserve = 0.0;
     }
 

--- a/MudSharpCore/Character/Heritage/Race.cs
+++ b/MudSharpCore/Character/Heritage/Race.cs
@@ -113,6 +113,8 @@ public partial class Race : SaveableItem, IRace
             CorpseModel = ParentRace.CorpseModel;
             HungerRate = ParentRace.HungerRate;
             ThirstRate = ParentRace.ThirstRate;
+            MaximumFoodSatiatedHours = ParentRace.MaximumFoodSatiatedHours;
+            MaximumDrinkSatiatedHours = ParentRace.MaximumDrinkSatiatedHours;
             TrackIntensityOlfactory = ParentRace.TrackIntensityOlfactory;
             TrackIntensityVisual = ParentRace.TrackIntensityVisual;
             TrackingAbilityVisual = ParentRace.TrackingAbilityVisual;
@@ -216,6 +218,8 @@ public partial class Race : SaveableItem, IRace
             CorpseModel = Gameworld.CorpseModels.First();
             HungerRate = 1.0;
             ThirstRate = 1.0;
+            MaximumFoodSatiatedHours = RacialSatiationDefaults.MaximumFoodSatiatedHours;
+            MaximumDrinkSatiatedHours = RacialSatiationDefaults.MaximumDrinkSatiatedHours;
             TrackIntensityOlfactory = 1.0;
             TrackIntensityVisual = 1.0;
             TrackingAbilityVisual = 1.0;
@@ -300,6 +304,8 @@ public partial class Race : SaveableItem, IRace
                 SizeSitting = (int)SizeSitting,
                 HungerRate = HungerRate,
                 ThirstRate = ThirstRate,
+                MaximumFoodSatiatedHours = MaximumFoodSatiatedHours,
+                MaximumDrinkSatiatedHours = MaximumDrinkSatiatedHours,
                 TrackIntensityOlfactory = TrackIntensityOlfactory,
                 TrackIntensityVisual = TrackIntensityVisual,
                 TrackingAbilityOlfactory = TrackingAbilityOlfactory,
@@ -374,6 +380,8 @@ public partial class Race : SaveableItem, IRace
         ButcheryProfile = gameworld.RaceButcheryProfiles.Get(race.RaceButcheryProfileId ?? 0L);
         HungerRate = race.HungerRate;
         ThirstRate = race.ThirstRate;
+        MaximumFoodSatiatedHours = race.MaximumFoodSatiatedHours;
+        MaximumDrinkSatiatedHours = race.MaximumDrinkSatiatedHours;
         TrackIntensityOlfactory = race.TrackIntensityOlfactory;
         TrackIntensityVisual = race.TrackIntensityVisual;
         TrackingAbilityOlfactory = race.TrackingAbilityOlfactory;
@@ -624,6 +632,8 @@ public partial class Race : SaveableItem, IRace
         CorpseModel = rhs.CorpseModel;
         HungerRate = rhs.HungerRate;
         ThirstRate = rhs.ThirstRate;
+        MaximumFoodSatiatedHours = rhs.MaximumFoodSatiatedHours;
+        MaximumDrinkSatiatedHours = rhs.MaximumDrinkSatiatedHours;
         TrackIntensityOlfactory = rhs.TrackIntensityOlfactory;
         TrackIntensityVisual = rhs.TrackIntensityVisual;
         TrackingAbilityOlfactory = rhs.TrackingAbilityOlfactory;
@@ -765,6 +775,8 @@ public partial class Race : SaveableItem, IRace
                 SizeSitting = (int)SizeSitting,
                 HungerRate = HungerRate,
                 ThirstRate = ThirstRate,
+                MaximumFoodSatiatedHours = MaximumFoodSatiatedHours,
+                MaximumDrinkSatiatedHours = MaximumDrinkSatiatedHours,
                 CommunicationStrategyType = CommunicationStrategy.Name,
                 DefaultHandedness = (int)DefaultHandedness,
                 HandednessOptions = HandednessOptions.Select(x => ((int)x).ToString("F0"))
@@ -1182,6 +1194,8 @@ public partial class Race : SaveableItem, IRace
         dbitem.NaturalArmourMaterialId = NaturalArmourMaterial?.Id;
         dbitem.HungerRate = HungerRate;
         dbitem.ThirstRate = ThirstRate;
+        dbitem.MaximumFoodSatiatedHours = MaximumFoodSatiatedHours;
+        dbitem.MaximumDrinkSatiatedHours = MaximumDrinkSatiatedHours;
         dbitem.TrackIntensityOlfactory = TrackIntensityOlfactory;
         dbitem.TrackIntensityVisual = TrackIntensityVisual;
         dbitem.TrackingAbilityOlfactory = TrackingAbilityOlfactory;
@@ -1869,6 +1883,8 @@ public partial class Race : SaveableItem, IRace
 
     public double HungerRate { get; set; }
     public double ThirstRate { get; set; }
+    public double MaximumFoodSatiatedHours { get; set; }
+    public double MaximumDrinkSatiatedHours { get; set; }
     public double TrackIntensityVisual { get; set; }
     public double TrackIntensityOlfactory { get; set; }
     public double TrackingAbilityVisual { get; set; }

--- a/MudSharpCore/Character/Heritage/RaceBuilding.cs
+++ b/MudSharpCore/Character/Heritage/RaceBuilding.cs
@@ -108,6 +108,8 @@ public partial class Race
 
 	#3hunger <%>#0 - sets a percentage multiplier to base rate at which they will get hungry
 	#3thirst <%>#0 - sets a percentage multiplier to base rate at which they will get thirsty
+	#3hungerlimit <hours>#0 - sets the maximum hours of hunger satiation this race can store
+	#3thirstlimit <hours>#0 - sets the maximum hours of thirst satiation this race can store
 	#3caneatcorpses#0 - toggles the race being able to eat corpses directly (without butchering)
 	#3biteweight <weight>#0 - sets the amount of corpse weight eaten per bite
 	#3material add <material>#0 - adds a material definition for corpse-eating
@@ -160,9 +162,23 @@ public partial class Race
             case "hungry":
             case "hunger":
                 return BuildingCommandHunger(actor, command);
+            case "hungerlimit":
+            case "hungercap":
+            case "foodlimit":
+            case "foodcap":
+            case "maxhunger":
+            case "maxfood":
+                return BuildingCommandHungerLimit(actor, command);
             case "thirst":
             case "thirsty":
                 return BuildingCommandThirst(actor, command);
+            case "thirstlimit":
+            case "thirstcap":
+            case "drinklimit":
+            case "drinkcap":
+            case "maxthirst":
+            case "maxdrink":
+                return BuildingCommandThirstLimit(actor, command);
             case "corpse":
             case "corpsemodel":
                 return BuildingCommandCorpseModel(actor, command);
@@ -511,6 +527,23 @@ public partial class Race
         return true;
     }
 
+    private bool BuildingCommandThirstLimit(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished ||
+            !double.TryParse(command.SafeRemainingArgument, actor.Account.Culture, out double value) ||
+            value <= 0.0)
+        {
+            actor.OutputHandler.Send("You must enter a valid number of hours greater than zero.");
+            return false;
+        }
+
+        MaximumDrinkSatiatedHours = value;
+        Changed = true;
+        actor.OutputHandler.Send(
+            $"This race can now store up to {value.ToString("N2", actor).ColourValue()} hours of thirst satiation, with sated at {(value * 0.75).ToString("N2", actor).ColourValue()} hours and not thirsty at {(value * 0.5).ToString("N2", actor).ColourValue()} hours.");
+        return true;
+    }
+
     private bool BuildingCommandHunger(ICharacter actor, StringStack command)
     {
         if (command.IsFinished || !command.SafeRemainingArgument.TryParsePercentage(actor.Account.Culture, out double value))
@@ -522,6 +555,23 @@ public partial class Race
         HungerRate = value;
         Changed = true;
         actor.OutputHandler.Send($"This race will now get hungry at a {value.ToString("P2").ColourValue()} rate compared to baseline.");
+        return true;
+    }
+
+    private bool BuildingCommandHungerLimit(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished ||
+            !double.TryParse(command.SafeRemainingArgument, actor.Account.Culture, out double value) ||
+            value <= 0.0)
+        {
+            actor.OutputHandler.Send("You must enter a valid number of hours greater than zero.");
+            return false;
+        }
+
+        MaximumFoodSatiatedHours = value;
+        Changed = true;
+        actor.OutputHandler.Send(
+            $"This race can now store up to {value.ToString("N2", actor).ColourValue()} hours of hunger satiation, with absolutely stuffed at {(value * 0.75).ToString("N2", actor).ColourValue()} hours, full at {(value * 0.5).ToString("N2", actor).ColourValue()} hours, and peckish at {(value * 0.25).ToString("N2", actor).ColourValue()} hours.");
         return true;
     }
 
@@ -2797,6 +2847,11 @@ public partial class Race
         sb.AppendLineColumns((uint)actor.LineFormatLength, 3,
             $"Hunger Rate: {HungerRate.ToString("P2", actor).ColourValue()}",
             $"Thirst Rate: {ThirstRate.ToString("P2", actor).ColourValue()}",
+            ""
+        );
+        sb.AppendLineColumns((uint)actor.LineFormatLength, 3,
+            $"Hunger Limit: {MaximumFoodSatiatedHours.ToString("N2", actor).ColourValue()} hours",
+            $"Thirst Limit: {MaximumDrinkSatiatedHours.ToString("N2", actor).ColourValue()} hours",
             ""
         );
         sb.AppendLineColumns((uint)actor.LineFormatLength, 3,

--- a/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextConfiguring3.cs
+++ b/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextConfiguring3.cs
@@ -1669,6 +1669,8 @@ namespace MudSharp.Database
                 entity.Property(e => e.HungerRate).HasColumnType("double").HasDefaultValue(1.0);
 
                 entity.Property(e => e.ThirstRate).HasColumnType("double").HasDefaultValue(1.0);
+                entity.Property(e => e.MaximumFoodSatiatedHours).HasColumnType("double").HasDefaultValue(16.0);
+                entity.Property(e => e.MaximumDrinkSatiatedHours).HasColumnType("double").HasDefaultValue(8.0);
                 entity.Property(e => e.TrackIntensityVisual).HasColumnType("double").HasDefaultValue(1.0);
                 entity.Property(e => e.TrackIntensityOlfactory).HasColumnType("double").HasDefaultValue(1.0);
                 entity.Property(e => e.TrackingAbilityVisual).HasColumnType("double").HasDefaultValue(1.0);

--- a/MudsharpDatabaseLibrary/Migrations/20260424035904_RaceSatiationLimits.Designer.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260424035904_RaceSatiationLimits.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MudSharp.Database;
 
@@ -11,9 +12,11 @@ using MudSharp.Database;
 namespace MudSharp.Migrations
 {
     [DbContext(typeof(FuturemudDatabaseContext))]
-    partial class FutureMUDContextModelSnapshot : ModelSnapshot
+    [Migration("20260424035904_RaceSatiationLimits")]
+    partial class RaceSatiationLimits
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MudsharpDatabaseLibrary/Migrations/20260424035904_RaceSatiationLimits.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260424035904_RaceSatiationLimits.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MudSharp.Migrations
+{
+    /// <inheritdoc />
+    public partial class RaceSatiationLimits : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<double>(
+                name: "MaximumDrinkSatiatedHours",
+                table: "Races",
+                type: "double",
+                nullable: false,
+                defaultValue: 8.0);
+
+            migrationBuilder.AddColumn<double>(
+                name: "MaximumFoodSatiatedHours",
+                table: "Races",
+                type: "double",
+                nullable: false,
+                defaultValue: 16.0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MaximumDrinkSatiatedHours",
+                table: "Races");
+
+            migrationBuilder.DropColumn(
+                name: "MaximumFoodSatiatedHours",
+                table: "Races");
+        }
+    }
+}

--- a/MudsharpDatabaseLibrary/Models/Race.cs
+++ b/MudsharpDatabaseLibrary/Models/Race.cs
@@ -85,6 +85,8 @@ namespace MudSharp.Models
 
         public double HungerRate { get; set; }
         public double ThirstRate { get; set; }
+        public double MaximumFoodSatiatedHours { get; set; }
+        public double MaximumDrinkSatiatedHours { get; set; }
         public double TrackIntensityVisual { get; set; }
         public double TrackIntensityOlfactory { get; set; }
         public double TrackingAbilityVisual { get; set; }


### PR DESCRIPTION
## Summary
- Add race-configurable hunger and thirst satiation caps with EF persistence and a migration.
- Scale hunger/thirst status labels and oversatiation calculations from the race limits instead of fixed hours.
- Extend race builder commands and show output to edit and display the new limits.
- Update health docs and add regression tests for the scaled thresholds.

## Testing
- `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 --filter ChangingNeedsModelBaseTests`