### PR TITLE
Add race-specific satiation limits for seeded races

### DIFF
--- a/DatabaseSeeder Unit Tests/AnimalSeederTemplateTests.cs
+++ b/DatabaseSeeder Unit Tests/AnimalSeederTemplateTests.cs
@@ -159,6 +159,8 @@ public class AnimalSeederTemplateTests
                 BodypartHealthMultiplier = 1.0,
                 BreathingVolumeExpression = "1",
                 HoldBreathLengthExpression = "1",
+                MaximumFoodSatiatedHours = template.MaximumFoodSatiatedHours,
+                MaximumDrinkSatiatedHours = template.MaximumDrinkSatiatedHours,
                 CanClimb = false,
                 CanSwim = true,
                 MinimumSleepingPosition = 1,
@@ -180,6 +182,18 @@ public class AnimalSeederTemplateTests
         return text
             .Split(["\r\n\r\n", "\n\n"], System.StringSplitOptions.RemoveEmptyEntries)
             .Length;
+    }
+
+    private static void AssertSatiationCadence(
+        (double MaximumFoodSatiatedHours, double MaximumDrinkSatiatedHours) limits,
+        double expectedFoodHours,
+        double expectedDrinkHours)
+    {
+        const double thresholdFraction = 0.75;
+        Assert.AreEqual(expectedFoodHours / thresholdFraction, limits.MaximumFoodSatiatedHours, 0.0001,
+            "Food satiation maxima should preserve the intended cadence before starvation.");
+        Assert.AreEqual(expectedDrinkHours / thresholdFraction, limits.MaximumDrinkSatiatedHours, 0.0001,
+            "Drink satiation maxima should preserve the intended cadence before becoming parched.");
     }
 
     [TestMethod]
@@ -263,6 +277,51 @@ public class AnimalSeederTemplateTests
         Assert.AreEqual("Beast Swooper", AnimalSeeder.RaceTemplatesForTesting["Eagle"].CombatStrategyKey);
         Assert.AreEqual("Beast Clincher", AnimalSeeder.RaceTemplatesForTesting["Python"].CombatStrategyKey);
         Assert.AreEqual("Beast Behemoth", AnimalSeeder.RaceTemplatesForTesting["Elephant"].CombatStrategyKey);
+    }
+
+    [TestMethod]
+    public void RaceTemplatesForTesting_RepresentativeAnimals_UseExpectedSatiationCadences()
+    {
+        AssertSatiationCadence(
+            AnimalSeeder.GetAnimalSatiationLimitsForTesting(AnimalSeeder.RaceTemplatesForTesting["Mouse"]),
+            2.0,
+            2.0);
+        AssertSatiationCadence(
+            AnimalSeeder.GetAnimalSatiationLimitsForTesting(AnimalSeeder.RaceTemplatesForTesting["Camel"]),
+            48.0,
+            168.0);
+        AssertSatiationCadence(
+            AnimalSeeder.GetAnimalSatiationLimitsForTesting(AnimalSeeder.RaceTemplatesForTesting["Tortoise"]),
+            1440.0,
+            720.0);
+        AssertSatiationCadence(
+            AnimalSeeder.GetAnimalSatiationLimitsForTesting(AnimalSeeder.RaceTemplatesForTesting["Python"]),
+            720.0,
+            168.0);
+        AssertSatiationCadence(
+            AnimalSeeder.GetAnimalSatiationLimitsForTesting(AnimalSeeder.RaceTemplatesForTesting["Frog"]),
+            48.0,
+            12.0);
+        AssertSatiationCadence(
+            AnimalSeeder.GetAnimalSatiationLimitsForTesting(AnimalSeeder.RaceTemplatesForTesting["Sparrow"]),
+            2.0,
+            2.0);
+        AssertSatiationCadence(
+            AnimalSeeder.GetAnimalSatiationLimitsForTesting(AnimalSeeder.RaceTemplatesForTesting["Eagle"]),
+            24.0,
+            8.0);
+        AssertSatiationCadence(
+            AnimalSeeder.GetAnimalSatiationLimitsForTesting(AnimalSeeder.RaceTemplatesForTesting["Shark"]),
+            168.0,
+            72.0);
+        AssertSatiationCadence(
+            AnimalSeeder.GetAnimalSatiationLimitsForTesting(AnimalSeeder.RaceTemplatesForTesting["Baleen Whale"]),
+            336.0,
+            168.0);
+        AssertSatiationCadence(
+            AnimalSeeder.GetAnimalSatiationLimitsForTesting(AnimalSeeder.RaceTemplatesForTesting["Spider"]),
+            336.0,
+            168.0);
     }
 
     [TestMethod]
@@ -511,6 +570,19 @@ public class AnimalSeederTemplateTests
 
         Assert.AreEqual(ShouldSeedResult.ExtraPackagesAvailable, new AnimalSeeder().ShouldSeedData(context),
             "A legacy beetle race that still points at the insectoid body should trigger the rerun path.");
+    }
+
+    [TestMethod]
+    public void ShouldSeedData_ExistingCatalogueWithLegacySatiationLimits_ReturnsExtraPackagesAvailable()
+    {
+        using FuturemudDatabaseContext context = BuildExpandedAnimalCatalogueContext();
+        Race camel = context.Races.Single(x => x.Name == "Camel");
+        camel.MaximumFoodSatiatedHours = 16.0;
+        camel.MaximumDrinkSatiatedHours = 8.0;
+        context.SaveChanges();
+
+        Assert.AreEqual(ShouldSeedResult.ExtraPackagesAvailable, new AnimalSeeder().ShouldSeedData(context),
+            "Legacy animal races using baseline satiation limits should trigger the rerun repair path.");
     }
 
     [TestMethod]

--- a/DatabaseSeeder Unit Tests/CultureSeederNameAndHeightDefaultTests.cs
+++ b/DatabaseSeeder Unit Tests/CultureSeederNameAndHeightDefaultTests.cs
@@ -36,6 +36,25 @@ public class CultureSeederNameAndHeightDefaultTests
 	}
 
 	[TestMethod]
+	public void CultureRaceSatiationLimitsForTesting_FantasyDefaults_UseExpectedCadences()
+	{
+		IReadOnlyDictionary<string, (double MaximumFoodSatiatedHours, double MaximumDrinkSatiatedHours)> limits =
+			CultureSeeder.CultureRaceSatiationLimitsForTesting;
+
+		AssertSatiationCadence(limits["Elf"], 24.0, 12.0);
+		AssertSatiationCadence(limits["Hobbit"], 8.0, 5.0);
+		AssertSatiationCadence(limits["Dwarf"], 18.0, 9.0);
+		AssertSatiationCadence(limits["Orc"], 8.0, 5.0);
+		AssertSatiationCadence(limits["Troll"], 6.0, 4.0);
+	}
+
+	[TestMethod]
+	public void HumanBaselineSatiationLimitsForTesting_PreservesEstablishedGameplayCadence()
+	{
+		AssertSatiationCadence(HumanSeeder.HumanBaselineSatiationLimitsForTesting, 12.0, 6.0);
+	}
+
+	[TestMethod]
 	public void CultureSeeder_FallbackProfiles_MakeBaseNameCulturesReadyAndRemainRerunnable()
 	{
 		using FuturemudDatabaseContext context = BuildContext();
@@ -264,6 +283,18 @@ public class CultureSeederNameAndHeightDefaultTests
 			.UseInMemoryDatabase(Guid.NewGuid().ToString())
 			.Options;
 		return new FuturemudDatabaseContext(options);
+	}
+
+	private static void AssertSatiationCadence(
+		(double MaximumFoodSatiatedHours, double MaximumDrinkSatiatedHours) limits,
+		double expectedFoodHours,
+		double expectedDrinkHours)
+	{
+		const double thresholdFraction = 0.75;
+		Assert.AreEqual(expectedFoodHours / thresholdFraction, limits.MaximumFoodSatiatedHours, 0.0001,
+			"Food satiation maxima should preserve the intended cadence before starvation.");
+		Assert.AreEqual(expectedDrinkHours / thresholdFraction, limits.MaximumDrinkSatiatedHours, 0.0001,
+			"Drink satiation maxima should preserve the intended cadence before becoming parched.");
 	}
 
 	private static void RunSimpleNameSeeding(CultureSeeder seeder, FuturemudDatabaseContext context)

--- a/DatabaseSeeder Unit Tests/MythicalAnimalSeederTemplateTests.cs
+++ b/DatabaseSeeder Unit Tests/MythicalAnimalSeederTemplateTests.cs
@@ -27,6 +27,18 @@ public class MythicalAnimalSeederTemplateTests
         return new FuturemudDatabaseContext(options);
     }
 
+    private static void AssertSatiationCadence(
+        (double MaximumFoodSatiatedHours, double MaximumDrinkSatiatedHours) limits,
+        double expectedFoodHours,
+        double expectedDrinkHours)
+    {
+        const double thresholdFraction = 0.75;
+        Assert.AreEqual(expectedFoodHours / thresholdFraction, limits.MaximumFoodSatiatedHours, 0.0001,
+            "Food satiation maxima should preserve the intended cadence before starvation.");
+        Assert.AreEqual(expectedDrinkHours / thresholdFraction, limits.MaximumDrinkSatiatedHours, 0.0001,
+            "Drink satiation maxima should preserve the intended cadence before becoming parched.");
+    }
+
     [TestMethod]
     public void ValidateTemplateCatalogForTesting_CurrentCatalog_HasNoIssues()
     {
@@ -649,6 +661,47 @@ public class MythicalAnimalSeederTemplateTests
         Assert.AreEqual("partless-air", MythicalAnimalSeeder.GetBreathingProfileNameForTesting("Giant Spider"));
         Assert.AreEqual("partless-air", MythicalAnimalSeeder.GetBreathingProfileNameForTesting("Ent"));
         Assert.AreEqual("partless-air", MythicalAnimalSeeder.GetBreathingProfileNameForTesting("Dryad"));
+    }
+
+    [TestMethod]
+    public void TemplatesForTesting_RepresentativeMythicalRaces_UseExpectedSatiationCadences()
+    {
+        AssertSatiationCadence(
+            MythicalAnimalSeeder.GetMythicalSatiationLimitsForTesting(MythicalAnimalSeeder.TemplatesForTesting["Dragon"]),
+            720.0,
+            168.0);
+        AssertSatiationCadence(
+            MythicalAnimalSeeder.GetMythicalSatiationLimitsForTesting(MythicalAnimalSeeder.TemplatesForTesting["Warg"]),
+            12.0,
+            8.0);
+        AssertSatiationCadence(
+            MythicalAnimalSeeder.GetMythicalSatiationLimitsForTesting(MythicalAnimalSeeder.TemplatesForTesting["Basilisk"]),
+            720.0,
+            168.0);
+        AssertSatiationCadence(
+            MythicalAnimalSeeder.GetMythicalSatiationLimitsForTesting(MythicalAnimalSeeder.TemplatesForTesting["Mermaid"]),
+            24.0,
+            48.0);
+        AssertSatiationCadence(
+            MythicalAnimalSeeder.GetMythicalSatiationLimitsForTesting(MythicalAnimalSeeder.TemplatesForTesting["Giant Spider"]),
+            336.0,
+            168.0);
+        AssertSatiationCadence(
+            MythicalAnimalSeeder.GetMythicalSatiationLimitsForTesting(MythicalAnimalSeeder.TemplatesForTesting["Colossal Worm"]),
+            720.0,
+            336.0);
+        AssertSatiationCadence(
+            MythicalAnimalSeeder.GetMythicalSatiationLimitsForTesting(MythicalAnimalSeeder.TemplatesForTesting["Ent"]),
+            720.0,
+            168.0);
+        AssertSatiationCadence(
+            MythicalAnimalSeeder.GetMythicalSatiationLimitsForTesting(MythicalAnimalSeeder.TemplatesForTesting["Dryad"]),
+            72.0,
+            48.0);
+        AssertSatiationCadence(
+            MythicalAnimalSeeder.GetMythicalSatiationLimitsForTesting(MythicalAnimalSeeder.TemplatesForTesting["Centaur"]),
+            12.0,
+            8.0);
     }
 
     [TestMethod]

--- a/DatabaseSeeder/Seeders/AnimalSeeder.Backfill.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.Backfill.cs
@@ -33,6 +33,16 @@ public partial class AnimalSeeder
 			return true;
 		}
 
+		if (RaceTemplates.Values.Any(template =>
+			    context.Races.FirstOrDefault(x => x.Name == template.Name) is { } race &&
+			    !SatiationLimitSeederHelper.MatchesLimits(
+				    race,
+				    template.MaximumFoodSatiatedHours,
+				    template.MaximumDrinkSatiatedHours)))
+		{
+			return true;
+		}
+
 		Race? beetleRace = context.Races.FirstOrDefault(x => x.Name == "Beetle");
 		if (beetleRace is not null && context.BodyProtos.FirstOrDefault(x => x.Id == beetleRace.BaseBodyId)?.Name != "Beetle")
 		{

--- a/DatabaseSeeder/Seeders/AnimalSeeder.Definitions.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.Definitions.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using MudSharp.Body;
+using MudSharp.Character.Heritage;
 using MudSharp.Combat;
 using MudSharp.Form.Material;
 using MudSharp.GameItems;
@@ -154,7 +155,9 @@ public partial class AnimalSeeder
         string? BodyAuditKey = null,
         IReadOnlyList<AnimalBodypartUsageTemplate>? AdditionalBodypartUsages = null,
         string CombatStrategyKey = "Beast Brawler",
-        IReadOnlyList<SeederTattooTemplateDefinition>? TattooTemplates = null
+        IReadOnlyList<SeederTattooTemplateDefinition>? TattooTemplates = null,
+		double MaximumFoodSatiatedHours = RacialSatiationDefaults.MaximumFoodSatiatedHours,
+		double MaximumDrinkSatiatedHours = RacialSatiationDefaults.MaximumDrinkSatiatedHours
     );
 
     internal static IReadOnlyDictionary<string, AnimalAgeProfileTemplate> AgeProfilesForTesting => AgeProfiles;
@@ -205,4 +208,10 @@ public partial class AnimalSeeder
         new ReadOnlyDictionary<string, AnimalRaceTemplate>(
             BuildRaceTemplates()
         );
+
+	internal static (double MaximumFoodSatiatedHours, double MaximumDrinkSatiatedHours) GetAnimalSatiationLimitsForTesting(
+		AnimalRaceTemplate template)
+	{
+		return (template.MaximumFoodSatiatedHours, template.MaximumDrinkSatiatedHours);
+	}
 }

--- a/DatabaseSeeder/Seeders/AnimalSeeder.TemplateUtilities.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.TemplateUtilities.cs
@@ -2,6 +2,7 @@
 
 using MudSharp.Body;
 using MudSharp.Combat;
+using MudSharp.GameItems;
 using MudSharp.Models;
 using System;
 using System.Collections.Generic;
@@ -20,8 +21,85 @@ public partial class AnimalSeeder
             .Concat(GetInsectRaceTemplates())
             .Concat(GetArachnidRaceTemplates())
             .Concat(GetReptileAmphibianRaceTemplates())
+			.Select(ApplyAnimalSatiationLimits)
             .ToDictionary(x => x.Name, x => x, StringComparer.OrdinalIgnoreCase);
     }
+
+	private static AnimalRaceTemplate ApplyAnimalSatiationLimits(AnimalRaceTemplate template)
+	{
+		(double foodHours, double drinkHours) = GetAnimalSatiationCadence(template);
+		(double maximumFood, double maximumDrink) =
+			SatiationLimitSeederHelper.MaximumLimitsForCadence(foodHours, drinkHours);
+		return template with
+		{
+			MaximumFoodSatiatedHours = maximumFood,
+			MaximumDrinkSatiatedHours = maximumDrink
+		};
+	}
+
+	private static (double FoodHours, double DrinkHours) GetAnimalSatiationCadence(AnimalRaceTemplate template)
+	{
+		return template.Name switch
+		{
+			"Mouse" or "Shrew" or "Hamster" => (2.0, 2.0),
+			"Rat" or "Guinea Pig" => (4.0, 3.0),
+			"Rabbit" or "Hare" => (4.0, 3.0),
+			"Ferret" or "Stoat" or "Weasel" or "Polecat" or "Mink" => (6.0, 4.0),
+			"Beaver" or "Otter" => (8.0, 12.0),
+			"Cat" or "Fox" or "Jackal" => (12.0, 6.0),
+			"Dog" or "Coyote" or "Hyena" => (16.0, 8.0),
+			"Wolf" or "Lion" or "Tiger" or "Sabretooth Tiger" or "Cheetah" or "Leopard" or "Panther" or "Jaguar" => (24.0, 12.0),
+			"Bear" => (72.0, 24.0),
+			"Pig" or "Boar" or "Warthog" => (12.0, 6.0),
+			"Sheep" or "Goat" or "Deer" or "Moose" or "Elk" or "Reindeer" or "Cow" or "Ox" or "Bison" or "Buffalo" or "Horse" => (10.0, 6.0),
+			"Llama" or "Alpaca" => (18.0, 24.0),
+			"Camel" => (48.0, 168.0),
+			"Rhinocerous" or "Elephant" or "Mammoth" => (24.0, 12.0),
+			"Hippopotamus" => (12.0, 4.0),
+			"Giraffe" => (14.0, 24.0),
+			"Sparrow" or "Finch" or "Robin" or "Wren" or "Swallow" => (2.0, 2.0),
+			"Pigeon" or "Parrot" or "Quail" or "Duck" or "Grouse" or "Pheasant" or "Chicken" or "Seagull" or "Crow" or "Raven" or "Woodpecker" or "Kingfisher" => (6.0, 4.0),
+			"Goose" or "Swan" or "Turkey" or "Heron" or "Crane" or "Flamingo" or "Peacock" or "Ibis" or "Pelican" or "Stork" or "Penguin" => (10.0, 8.0),
+			"Albatross" => (18.0, 16.0),
+			"Emu" or "Ostrich" or "Moa" => (12.0, 8.0),
+			"Vulture" => (72.0, 12.0),
+			"Hawk" or "Eagle" or "Falcon" or "Owl" => (24.0, 8.0),
+			"Python" or "Tree Python" or "Boa" or "Anaconda" or "Cobra" or "Adder" or "Rattlesnake" or "Viper" or "Mamba" or "Coral Snake" or "Moccasin" => (720.0, 168.0),
+			"Lizard" or "Gecko" or "Skink" => (168.0, 72.0),
+			"Iguana" or "Monitor Lizard" => (336.0, 96.0),
+			"Turtle" => (720.0, 336.0),
+			"Tortoise" => (1440.0, 720.0),
+			"Crocodile" or "Alligator" => (720.0, 240.0),
+			"Frog" or "Toad" => (48.0, 12.0),
+			"Shark" => (168.0, 72.0),
+			"Dolphin" or "Porpoise" or "Orca" => (48.0, 48.0),
+			"Baleen Whale" or "Toothed Whale" => (336.0, 168.0),
+			"Sea Lion" or "Seal" or "Walrus" => (24.0, 24.0),
+			"Small Crab" or "Shrimp" or "Prawn" or "Crayfish" => (24.0, 24.0),
+			"Crab" or "Giant Crab" or "Lobster" => (48.0, 36.0),
+			"Jellyfish" => (24.0, 48.0),
+			"Octopus" or "Squid" => (48.0, 36.0),
+			"Giant Squid" => (168.0, 72.0),
+			"Ant" or "Bee" or "Butterfly" or "Moth" or "Grasshopper" or "Cockroach" => (24.0, 12.0),
+			"Dragonfly" or "Wasp" or "Hornet" => (18.0, 8.0),
+			"Beetle" or "Mantis" or "Centipede" => (72.0, 24.0),
+			"Spider" => (336.0, 168.0),
+			"Tarantula" => (720.0, 336.0),
+			"Scorpion" => (720.0, 336.0),
+			_ when template.BodyKey is "Piscine" => template.Size >= SizeCategory.Normal ? (72.0, 48.0) : (24.0, 24.0),
+			_ when template.BodyKey is "Serpentine" => (720.0, 168.0),
+			_ when template.BodyKey is "Reptilian" or "Chelonian" or "Crocodilian" => (336.0, 96.0),
+			_ when template.BodyKey is "Anuran" => (48.0, 12.0),
+			_ when template.BodyKey.Contains("Insectoid", StringComparison.OrdinalIgnoreCase) => (24.0, 12.0),
+			_ when template.BodyKey is "Arachnid" or "Scorpion" => (336.0, 168.0),
+			_ when template.BodyKey is "Decapod" or "Malacostracan" or "Cephalopod" or "Jellyfish" => (48.0, 36.0),
+			_ when template.BodyKey is "Cetacean" => (168.0, 96.0),
+			_ when template.BodyKey is "Pinniped" => (24.0, 24.0),
+			_ => template.Size <= SizeCategory.VerySmall ? (6.0, 4.0) :
+				template.Size >= SizeCategory.Large ? (24.0, 12.0) :
+				(12.0, 6.0)
+		};
+	}
 
     private static Dictionary<string, AnimalHeightWeightTemplate> BuildHeightWeightTemplates()
     {

--- a/DatabaseSeeder/Seeders/AnimalSeeder.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.cs
@@ -4083,6 +4083,8 @@ Warning: There is an enormous amount of data contained in this seeder, and it ma
             HoldBreathLengthExpression = $"90+(5*con:{_healthTrait.Id})",
             MaximumLiftWeightExpression = $"str:{_strengthTrait.Id}*10000",
             MaximumDragWeightExpression = $"str:{_strengthTrait.Id}*40000",
+			MaximumFoodSatiatedHours = raceTemplate?.MaximumFoodSatiatedHours ?? SatiationLimitSeederHelper.MaximumFoodHoursForCadence(12.0),
+			MaximumDrinkSatiatedHours = raceTemplate?.MaximumDrinkSatiatedHours ?? SatiationLimitSeederHelper.MaximumDrinkHoursForCadence(6.0),
             DefaultHeightWeightModelMale = _hwModels[hwMale],
             DefaultHeightWeightModelNeuter = _hwModels[hwMale],
             DefaultHeightWeightModelFemale = _hwModels[hwFemale],
@@ -9113,7 +9115,11 @@ Warning: There is an enormous amount of data contained in this seeder, and it ma
                 ResolveAnimalRaceHealthMultiplier(template, template.Size, template.BodypartHealthMultiplier);
             bool needsUpdate = race.DefaultCombatSettingId != setting.Id ||
                                race.NaturalArmourTypeId != _naturalArmour?.Id ||
-                               Math.Abs(race.BodypartHealthMultiplier - expectedHealthMultiplier) > 0.0001;
+                               Math.Abs(race.BodypartHealthMultiplier - expectedHealthMultiplier) > 0.0001 ||
+							   !SatiationLimitSeederHelper.MatchesLimits(
+								   race,
+								   template.MaximumFoodSatiatedHours,
+								   template.MaximumDrinkSatiatedHours);
             if (!needsUpdate)
             {
                 continue;
@@ -9122,6 +9128,10 @@ Warning: There is an enormous amount of data contained in this seeder, and it ma
             race.DefaultCombatSetting = setting;
             race.NaturalArmourType = _naturalArmour;
             race.BodypartHealthMultiplier = expectedHealthMultiplier;
+			SatiationLimitSeederHelper.ApplyLimits(
+				race,
+				template.MaximumFoodSatiatedHours,
+				template.MaximumDrinkSatiatedHours);
         }
 
         _context.SaveChanges();

--- a/DatabaseSeeder/Seeders/CultureSeeder.cs
+++ b/DatabaseSeeder/Seeders/CultureSeeder.cs
@@ -70,6 +70,7 @@ Please answer #3yes#f or #3no#f. ", (context, answers) => true,
 			SeedCulturePacks(context, questionAnswers);
 		}
 
+		RefreshExistingCultureRaceSatiationLimits();
 		EnsureFallbackRandomNameProfiles();
 
 		context.Database.CommitTransaction();
@@ -88,13 +89,20 @@ Please answer #3yes#f or #3no#f. ", (context, answers) => true,
             return ShouldSeedResult.PrerequisitesNotMet;
         }
 
-        return SeederRepeatabilityHelper.ClassifyByPresence(
+        ShouldSeedResult repeatability = SeederRepeatabilityHelper.ClassifyByPresence(
             StockNameCultureMarkers.Select(marker => context.NameCultures.Any(x => x.Name == marker))
                 .Concat(StockRandomProfileMarkers.Select(marker => context.RandomNameProfiles.Any(x => x.Name == marker)))
                 .Concat(StockCulturePackageMarkers.Select(marker =>
                     context.Languages.Any(x => x.Name == marker) ||
                     context.Ethnicities.Any(x => x.Name == marker) ||
                     context.Cultures.Any(x => x.Name == marker))));
+		if (repeatability == ShouldSeedResult.MayAlreadyBeInstalled &&
+		    HasCultureRaceSatiationLimitUpdates(context))
+		{
+			return ShouldSeedResult.ExtraPackagesAvailable;
+		}
+
+		return repeatability;
     }
 
     public int SortOrder => 101;

--- a/DatabaseSeeder/Seeders/CultureSeederHeritage.cs
+++ b/DatabaseSeeder/Seeders/CultureSeederHeritage.cs
@@ -9,11 +9,25 @@ using System.Linq;
 using System.Xml.Linq;
 
 using MudSharp.Body.Traits;
+using MudSharp.Database;
 
 namespace DatabaseSeeder.Seeders;
 
 public partial class CultureSeeder
 {
+	private static readonly IReadOnlyDictionary<string, (double MaximumFoodSatiatedHours, double MaximumDrinkSatiatedHours)> CultureRaceSatiationLimits =
+		new Dictionary<string, (double MaximumFoodSatiatedHours, double MaximumDrinkSatiatedHours)>(StringComparer.OrdinalIgnoreCase)
+		{
+			["Elf"] = SatiationLimitSeederHelper.MaximumLimitsForCadence(24.0, 12.0),
+			["Hobbit"] = SatiationLimitSeederHelper.MaximumLimitsForCadence(8.0, 5.0),
+			["Dwarf"] = SatiationLimitSeederHelper.MaximumLimitsForCadence(18.0, 9.0),
+			["Orc"] = SatiationLimitSeederHelper.MaximumLimitsForCadence(8.0, 5.0),
+			["Troll"] = SatiationLimitSeederHelper.MaximumLimitsForCadence(6.0, 4.0)
+		};
+
+	internal static IReadOnlyDictionary<string, (double MaximumFoodSatiatedHours, double MaximumDrinkSatiatedHours)> CultureRaceSatiationLimitsForTesting =>
+		CultureRaceSatiationLimits;
+
     private readonly Dictionary<string, FutureProg> _cultureProgs =
         new(StringComparer.OrdinalIgnoreCase);
 
@@ -27,6 +41,40 @@ public partial class CultureSeeder
         new(StringComparer.OrdinalIgnoreCase);
 
     private readonly Dictionary<string, Race> _races = new(StringComparer.OrdinalIgnoreCase);
+
+	private static bool HasCultureRaceSatiationLimitUpdates(FuturemudDatabaseContext context)
+	{
+		return CultureRaceSatiationLimits
+			.Select(x => (Race: context.Races.FirstOrDefault(race => race.Name == x.Key), Limits: x.Value))
+			.Any(x => x.Race is not null &&
+			          !SatiationLimitSeederHelper.MatchesLimits(
+				          x.Race,
+				          x.Limits.MaximumFoodSatiatedHours,
+				          x.Limits.MaximumDrinkSatiatedHours));
+	}
+
+	private void RefreshExistingCultureRaceSatiationLimits()
+	{
+		bool dirty = false;
+		foreach ((string raceName, (double MaximumFoodSatiatedHours, double MaximumDrinkSatiatedHours) limits) in CultureRaceSatiationLimits)
+		{
+			Race? race = _context.Races.FirstOrDefault(x => x.Name == raceName);
+			if (race is null)
+			{
+				continue;
+			}
+
+			dirty |= SatiationLimitSeederHelper.ApplyLimits(
+				race,
+				limits.MaximumFoodSatiatedHours,
+				limits.MaximumDrinkSatiatedHours);
+		}
+
+		if (dirty)
+		{
+			_context.SaveChanges();
+		}
+	}
 
     internal static IReadOnlyDictionary<string, NonHumanAttributeProfile> CultureRaceAttributeProfilesForTesting =>
         CultureRaceAttributeProfiles;
@@ -2965,7 +3013,9 @@ Elves are divided into several different clans, each with their own distinct cul
             NaturalArmourMaterial = humanoid.NaturalArmourMaterial,
             NaturalArmourType = humanoid.NaturalArmourType,
             RaceButcheryProfile = null,
-            SweatLiquid = elfSweat
+            SweatLiquid = elfSweat,
+			MaximumFoodSatiatedHours = CultureRaceSatiationLimits["Elf"].MaximumFoodSatiatedHours,
+			MaximumDrinkSatiatedHours = CultureRaceSatiationLimits["Elf"].MaximumDrinkSatiatedHours
         };
         _context.Races.Add(elfRace);
         AddRaceAttributeAlterations(elfRace, CultureRaceAttributeProfiles["Elf"]);
@@ -3632,7 +3682,9 @@ Hobbits are divided into several different clans, each with its own distinct cul
             NaturalArmourMaterial = humanoid.NaturalArmourMaterial,
             NaturalArmourType = humanoid.NaturalArmourType,
             RaceButcheryProfile = null,
-            SweatLiquid = hobbitSweat
+            SweatLiquid = hobbitSweat,
+			MaximumFoodSatiatedHours = CultureRaceSatiationLimits["Hobbit"].MaximumFoodSatiatedHours,
+			MaximumDrinkSatiatedHours = CultureRaceSatiationLimits["Hobbit"].MaximumDrinkSatiatedHours
         };
         _context.Races.Add(hobbitRace);
         AddRaceAttributeAlterations(hobbitRace, CultureRaceAttributeProfiles["Hobbit"]);
@@ -3993,7 +4045,9 @@ Dwarves are divided into several different clans, each with its own distinct cul
             NaturalArmourMaterial = humanoid.NaturalArmourMaterial,
             NaturalArmourType = humanoid.NaturalArmourType,
             RaceButcheryProfile = null,
-            SweatLiquid = dwarfSweat
+            SweatLiquid = dwarfSweat,
+			MaximumFoodSatiatedHours = CultureRaceSatiationLimits["Dwarf"].MaximumFoodSatiatedHours,
+			MaximumDrinkSatiatedHours = CultureRaceSatiationLimits["Dwarf"].MaximumDrinkSatiatedHours
         };
         _context.Races.Add(dwarfRace);
         AddRaceAttributeAlterations(dwarfRace, CultureRaceAttributeProfiles["Dwarf"]);
@@ -4403,7 +4457,9 @@ Orcish cultural practices are centered around warfare and domination. Orcs are c
             NaturalArmourMaterial = humanoid.NaturalArmourMaterial,
             NaturalArmourType = humanoid.NaturalArmourType,
             RaceButcheryProfile = null,
-            SweatLiquid = orcSweat
+            SweatLiquid = orcSweat,
+			MaximumFoodSatiatedHours = CultureRaceSatiationLimits["Orc"].MaximumFoodSatiatedHours,
+			MaximumDrinkSatiatedHours = CultureRaceSatiationLimits["Orc"].MaximumDrinkSatiatedHours
         };
         _context.Races.Add(orcRace);
         AddRaceAttributeAlterations(orcRace, CultureRaceAttributeProfiles["Orc"]);
@@ -4747,7 +4803,9 @@ Trolls are primarily scavengers and predators, and will eat anything they can ca
             NaturalArmourMaterial = humanoid.NaturalArmourMaterial,
             NaturalArmourType = humanoid.NaturalArmourType,
             RaceButcheryProfile = null,
-            SweatLiquid = trollSweat
+            SweatLiquid = trollSweat,
+			MaximumFoodSatiatedHours = CultureRaceSatiationLimits["Troll"].MaximumFoodSatiatedHours,
+			MaximumDrinkSatiatedHours = CultureRaceSatiationLimits["Troll"].MaximumDrinkSatiatedHours
         };
         _context.Races.Add(trollRace);
         AddRaceAttributeAlterations(trollRace, CultureRaceAttributeProfiles["Troll"]);

--- a/DatabaseSeeder/Seeders/HumanSeeder.cs
+++ b/DatabaseSeeder/Seeders/HumanSeeder.cs
@@ -15,6 +15,19 @@ namespace DatabaseSeeder.Seeders;
 
 public partial class HumanSeeder : IDatabaseSeeder
 {
+	private static readonly (double MaximumFoodSatiatedHours, double MaximumDrinkSatiatedHours) HumanBaselineSatiationLimits =
+		SatiationLimitSeederHelper.MaximumLimitsForCadence(12.0, 6.0);
+
+	internal static (double MaximumFoodSatiatedHours, double MaximumDrinkSatiatedHours) HumanBaselineSatiationLimitsForTesting =>
+		HumanBaselineSatiationLimits;
+
+	private static readonly string[] HumanSatiationRaceNames =
+	[
+		"Humanoid",
+		"Organic Humanoid",
+		"Human"
+	];
+
     private FuturemudDatabaseContext _context;
     private HeightWeightModel _humanFemaleHWModel;
 
@@ -202,6 +215,7 @@ Please answer #3yes#F or #3no#F: ", (context, answers) => true,
         if (_context.Races.Any(x => x.Name == "Humanoid"))
         {
             RefreshExistingHumanCombatBalance();
+			bool updatedSatiationLimits = RefreshExistingHumanSatiationLimits();
             BodyProto? existingOrganicBody = _context.BodyProtos.FirstOrDefault(x => x.Name == "Organic Humanoid");
             if (hasMissingDisfigurementTemplates && existingOrganicBody is not null)
             {
@@ -209,9 +223,19 @@ Please answer #3yes#F or #3no#F: ", (context, answers) => true,
             }
 
             _context.Database.CommitTransaction();
-            return hasMissingDisfigurementTemplates
-                ? "Updated the human combat balance profile and installed additional human disfigurement templates."
-                : "Updated the human combat balance profile.";
+			if (hasMissingDisfigurementTemplates && updatedSatiationLimits)
+			{
+				return "Updated the human combat balance profile, refreshed human satiation limits, and installed additional human disfigurement templates.";
+			}
+
+			if (hasMissingDisfigurementTemplates)
+			{
+				return "Updated the human combat balance profile and installed additional human disfigurement templates.";
+			}
+
+			return updatedSatiationLimits
+				? "Updated the human combat balance profile and refreshed human satiation limits."
+				: "Updated the human combat balance profile.";
         }
 
         // Start by determining the appropriate health strategy
@@ -764,13 +788,45 @@ $?hairstyle[&he has &?a_an[$haircolour $hairstyle]][&he is completely bald].$?fa
 
         if (context.Races.Any(x => x.Name == "Humanoid"))
         {
-            return HasMissingHumanDisfigurementTemplates(context)
+            return HasMissingHumanDisfigurementTemplates(context) || HasHumanSatiationLimitUpdates(context)
                 ? ShouldSeedResult.ExtraPackagesAvailable
                 : ShouldSeedResult.MayAlreadyBeInstalled;
         }
 
         return ShouldSeedResult.ReadyToInstall;
     }
+
+	private static bool HasHumanSatiationLimitUpdates(FuturemudDatabaseContext context)
+	{
+		return HumanSatiationRaceNames
+			.Select(name => context.Races.FirstOrDefault(x => x.Name == name))
+			.OfType<Race>()
+			.Any(race => !SatiationLimitSeederHelper.MatchesLimits(
+				race,
+				HumanBaselineSatiationLimits.MaximumFoodSatiatedHours,
+				HumanBaselineSatiationLimits.MaximumDrinkSatiatedHours));
+	}
+
+	private bool RefreshExistingHumanSatiationLimits()
+	{
+		bool dirty = false;
+		foreach (Race race in HumanSatiationRaceNames
+			         .Select(name => _context.Races.FirstOrDefault(x => x.Name == name))
+			         .OfType<Race>())
+		{
+			dirty |= SatiationLimitSeederHelper.ApplyLimits(
+				race,
+				HumanBaselineSatiationLimits.MaximumFoodSatiatedHours,
+				HumanBaselineSatiationLimits.MaximumDrinkSatiatedHours);
+		}
+
+		if (dirty)
+		{
+			_context.SaveChanges();
+		}
+
+		return dirty;
+	}
 
     public int SortOrder => 50;
     public string Name => "Human Seeder";
@@ -1764,6 +1820,8 @@ $?hairstyle[&he has &?a_an[$haircolour $hairstyle]][&he is completely bald].$?fa
             BiteWeight = 1000,
             EatCorpseEmoteText = "",
             RaceUsesStamina = true,
+			MaximumFoodSatiatedHours = HumanBaselineSatiationLimits.MaximumFoodSatiatedHours,
+			MaximumDrinkSatiatedHours = HumanBaselineSatiationLimits.MaximumDrinkSatiatedHours,
             NaturalArmourQuality = 2,
             NaturalArmourType = _racialNaturalArmour,
             SweatLiquid = sweat,
@@ -1821,6 +1879,8 @@ $?hairstyle[&he has &?a_an[$haircolour $hairstyle]][&he is completely bald].$?fa
             BiteWeight = 1000,
             EatCorpseEmoteText = "",
             RaceUsesStamina = true,
+			MaximumFoodSatiatedHours = HumanBaselineSatiationLimits.MaximumFoodSatiatedHours,
+			MaximumDrinkSatiatedHours = HumanBaselineSatiationLimits.MaximumDrinkSatiatedHours,
             NaturalArmourQuality = 2,
             NaturalArmourType = _racialNaturalArmour,
             SweatLiquid = sweat,
@@ -1883,6 +1943,8 @@ $?hairstyle[&he has &?a_an[$haircolour $hairstyle]][&he is completely bald].$?fa
             BiteWeight = 1000,
             EatCorpseEmoteText = "",
             RaceUsesStamina = true,
+			MaximumFoodSatiatedHours = HumanBaselineSatiationLimits.MaximumFoodSatiatedHours,
+			MaximumDrinkSatiatedHours = HumanBaselineSatiationLimits.MaximumDrinkSatiatedHours,
             NaturalArmourQuality = 2,
             NaturalArmourType = _racialNaturalArmour,
             SweatLiquid = sweat,

--- a/DatabaseSeeder/Seeders/MythicalAnimalSeeder.Definitions.cs
+++ b/DatabaseSeeder/Seeders/MythicalAnimalSeeder.Definitions.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using MudSharp.Body;
+using MudSharp.Character.Heritage;
 using MudSharp.Form.Characteristics;
 using MudSharp.GameItems;
 using System;
@@ -63,7 +64,9 @@ public partial class MythicalAnimalSeeder
         IReadOnlyList<MythicalCharacteristicTemplate>? AdditionalCharacteristics = null,
         IReadOnlyList<StockDescriptionVariant>? OverlayDescriptionVariants = null,
         string CombatStrategyKey = "Beast Brawler",
-        IReadOnlyList<SeederTattooTemplateDefinition>? TattooTemplates = null
+        IReadOnlyList<SeederTattooTemplateDefinition>? TattooTemplates = null,
+		double MaximumFoodSatiatedHours = RacialSatiationDefaults.MaximumFoodSatiatedHours,
+		double MaximumDrinkSatiatedHours = RacialSatiationDefaults.MaximumDrinkSatiatedHours
     );
 
     internal static IReadOnlyDictionary<string, MythicalRaceTemplate> TemplatesForTesting => Templates;
@@ -258,7 +261,7 @@ public partial class MythicalAnimalSeeder
                     );
         }
 
-        return new Dictionary<string, MythicalRaceTemplate>(StringComparer.OrdinalIgnoreCase)
+        Dictionary<string, MythicalRaceTemplate> templates = new(StringComparer.OrdinalIgnoreCase)
         {
             ["Dragon"] = BeastRace(
                 "Dragon",
@@ -1177,7 +1180,63 @@ public partial class MythicalAnimalSeeder
                 combatStrategyKey: "Beast Swooper"
             )
         };
+
+		return templates
+			.Select(x => ApplyMythicalSatiationLimits(x.Value))
+			.ToDictionary(x => x.Name, x => x, StringComparer.OrdinalIgnoreCase);
     }
+
+	private static MythicalRaceTemplate ApplyMythicalSatiationLimits(MythicalRaceTemplate template)
+	{
+		(double foodHours, double drinkHours) = GetMythicalSatiationCadence(template);
+		(double maximumFood, double maximumDrink) =
+			SatiationLimitSeederHelper.MaximumLimitsForCadence(foodHours, drinkHours);
+		return template with
+		{
+			MaximumFoodSatiatedHours = maximumFood,
+			MaximumDrinkSatiatedHours = maximumDrink
+		};
+	}
+
+	private static (double FoodHours, double DrinkHours) GetMythicalSatiationCadence(MythicalRaceTemplate template)
+	{
+		return template.Name switch
+		{
+			"Dragon" or "Eastern Dragon" => (720.0, 168.0),
+			"Griffin" or "Hippogriff" or "Pegasus" or "Pegacorn" => (24.0, 12.0),
+			"Unicorn" => (48.0, 24.0),
+			"Warg" => (12.0, 8.0),
+			"Dire-Wolf" => (18.0, 8.0),
+			"Dire-Bear" => (96.0, 36.0),
+			"Minotaur" => (10.0, 6.0),
+			"Naga" or "Basilisk" or "Cockatrice" => (720.0, 168.0),
+			"Mermaid" or "Selkie" or "Hippocamp" => (24.0, 48.0),
+			"Manticore" => (16.0, 8.0),
+			"Wyvern" => (168.0, 72.0),
+			"Phoenix" => (48.0, 24.0),
+			"Giant Beetle" or "Giant Ant" or "Giant Mantis" => (72.0, 24.0),
+			"Giant Spider" => (336.0, 168.0),
+			"Giant Scorpion" => (720.0, 336.0),
+			"Giant Centipede" or "Ankheg" => (168.0, 72.0),
+			"Giant Worm" => (336.0, 168.0),
+			"Colossal Worm" => (720.0, 336.0),
+			"Myconid" => (168.0, 72.0),
+			"Plantfolk" => (96.0, 48.0),
+			"Ent" => (720.0, 168.0),
+			"Dryad" => (72.0, 48.0),
+			"Owlkin" or "Avian Person" => (10.0, 6.0),
+			"Centaur" => (12.0, 8.0),
+			_ when template.HumanoidVariety => (12.0, 6.0),
+			_ when template.Size >= SizeCategory.Large => (24.0, 12.0),
+			_ => (12.0, 6.0)
+		};
+	}
+
+	internal static (double MaximumFoodSatiatedHours, double MaximumDrinkSatiatedHours) GetMythicalSatiationLimitsForTesting(
+		MythicalRaceTemplate template)
+	{
+		return (template.MaximumFoodSatiatedHours, template.MaximumDrinkSatiatedHours);
+	}
 
     internal static string BuildRaceDescriptionForTesting(MythicalRaceTemplate template)
     {

--- a/DatabaseSeeder/Seeders/MythicalAnimalSeeder.cs
+++ b/DatabaseSeeder/Seeders/MythicalAnimalSeeder.cs
@@ -165,13 +165,23 @@ public partial class MythicalAnimalSeeder : IDatabaseSeeder
 
         if (Templates.Keys.All(name => context.Races.Any(x => x.Name == name)))
         {
-            return HasMissingMythicalDisfigurementTemplates(context)
+            return HasMissingMythicalDisfigurementTemplates(context) || HasMythicalSatiationLimitUpdates(context)
                 ? ShouldSeedResult.ExtraPackagesAvailable
                 : ShouldSeedResult.MayAlreadyBeInstalled;
         }
 
         return ShouldSeedResult.ReadyToInstall;
     }
+
+	private static bool HasMythicalSatiationLimitUpdates(FuturemudDatabaseContext context)
+	{
+		return Templates.Values.Any(template =>
+			context.Races.FirstOrDefault(x => x.Name == template.Name) is { } race &&
+			!SatiationLimitSeederHelper.MatchesLimits(
+				race,
+				template.MaximumFoodSatiatedHours,
+				template.MaximumDrinkSatiatedHours));
+	}
 
     private static bool HasPrerequisites(FuturemudDatabaseContext context)
     {
@@ -967,6 +977,10 @@ public partial class MythicalAnimalSeeder : IDatabaseSeeder
             race.CanClimb = template.CanClimb;
             race.CanSwim = template.CanSwim;
             race.MinimumSleepingPosition = 4;
+			SatiationLimitSeederHelper.ApplyLimits(
+				race,
+				template.MaximumFoodSatiatedHours,
+				template.MaximumDrinkSatiatedHours);
             ApplyBreathingProfile(race, GetBreathingProfile(template));
         }
 
@@ -1180,6 +1194,8 @@ public partial class MythicalAnimalSeeder : IDatabaseSeeder
             HoldBreathLengthExpression = $"90+(5*con:{_healthTrait.Id})",
             MaximumLiftWeightExpression = $"str:{_strengthTrait.Id}*10000",
             MaximumDragWeightExpression = $"str:{_strengthTrait.Id}*40000",
+			MaximumFoodSatiatedHours = template.MaximumFoodSatiatedHours,
+			MaximumDrinkSatiatedHours = template.MaximumDrinkSatiatedHours,
             DefaultHeightWeightModelMale = _context.HeightWeightModels.First(x => x.Name == template.MaleHeightWeightModel),
 			DefaultHeightWeightModelFemale = _context.HeightWeightModels.First(x => x.Name == template.FemaleHeightWeightModel),
 			DefaultHeightWeightModelNeuter = _context.HeightWeightModels.First(x => x.Name == template.MaleHeightWeightModel),

--- a/DatabaseSeeder/Seeders/SatiationLimitSeederHelper.cs
+++ b/DatabaseSeeder/Seeders/SatiationLimitSeederHelper.cs
@@ -1,0 +1,50 @@
+#nullable enable
+
+using MudSharp.Models;
+using System;
+
+namespace DatabaseSeeder.Seeders;
+
+internal static class SatiationLimitSeederHelper
+{
+	private const double FullySatedThresholdFraction = 0.75;
+	private const double Tolerance = 0.0001;
+
+	internal static double MaximumFoodHoursForCadence(double hoursUntilStarvingFromFullyFed)
+	{
+		return hoursUntilStarvingFromFullyFed / FullySatedThresholdFraction;
+	}
+
+	internal static double MaximumDrinkHoursForCadence(double hoursUntilParchedFromFullySated)
+	{
+		return hoursUntilParchedFromFullySated / FullySatedThresholdFraction;
+	}
+
+	internal static (double MaximumFoodSatiatedHours, double MaximumDrinkSatiatedHours) MaximumLimitsForCadence(
+		double hoursUntilStarvingFromFullyFed,
+		double hoursUntilParchedFromFullySated)
+	{
+		return (
+			MaximumFoodHoursForCadence(hoursUntilStarvingFromFullyFed),
+			MaximumDrinkHoursForCadence(hoursUntilParchedFromFullySated)
+		);
+	}
+
+	internal static bool MatchesLimits(Race race, double maximumFoodSatiatedHours, double maximumDrinkSatiatedHours)
+	{
+		return Math.Abs(race.MaximumFoodSatiatedHours - maximumFoodSatiatedHours) < Tolerance &&
+		       Math.Abs(race.MaximumDrinkSatiatedHours - maximumDrinkSatiatedHours) < Tolerance;
+	}
+
+	internal static bool ApplyLimits(Race race, double maximumFoodSatiatedHours, double maximumDrinkSatiatedHours)
+	{
+		if (MatchesLimits(race, maximumFoodSatiatedHours, maximumDrinkSatiatedHours))
+		{
+			return false;
+		}
+
+		race.MaximumFoodSatiatedHours = maximumFoodSatiatedHours;
+		race.MaximumDrinkSatiatedHours = maximumDrinkSatiatedHours;
+		return true;
+	}
+}


### PR DESCRIPTION
## Summary
- Set human, culture, animal, and mythical race satiation maxima to match intended food and drink cadences.
- Added rerun/backfill detection so existing worlds with legacy baseline limits are flagged for repair.
- Added focused regression tests for human baseline, culture defaults, representative animal and mythic cadences, and legacy rerun detection.

## Testing
- Ran the focused `DatabaseSeeder Unit Tests` slice for `AnimalSeederTemplateTests`, `MythicalAnimalSeederTemplateTests`, and `CultureSeederNameAndHeightDefaultTests`.
- Result: passed, including the new satiation-limit coverage.