### PR TITLE
Add prepared food cooking system

### DIFF
--- a/DatabaseSeeder Unit Tests/CookingSeederTests.cs
+++ b/DatabaseSeeder Unit Tests/CookingSeederTests.cs
@@ -1,0 +1,184 @@
+#nullable enable
+
+using DatabaseSeeder;
+using DatabaseSeeder.Seeders;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Database;
+using MudSharp.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class CookingSeederTests
+{
+	private static FuturemudDatabaseContext BuildContext()
+	{
+		DbContextOptions<FuturemudDatabaseContext> options = new DbContextOptionsBuilder<FuturemudDatabaseContext>()
+			.UseInMemoryDatabase(Guid.NewGuid().ToString())
+			.ConfigureWarnings(x => x.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+			.Options;
+		return new FuturemudDatabaseContext(options);
+	}
+
+	private static void SeedPrerequisites(FuturemudDatabaseContext context)
+	{
+		context.Accounts.Add(new Account
+		{
+			Id = 1,
+			Name = "SeederTest",
+			Password = "password",
+			Salt = 1,
+			AccessStatus = 0,
+			Email = "seeder@example.com",
+			LastLoginIp = "127.0.0.1",
+			FormatLength = 80,
+			InnerFormatLength = 78,
+			UseMxp = false,
+			UseMsp = false,
+			UseMccp = false,
+			ActiveCharactersAllowed = 1,
+			UseUnicode = true,
+			TimeZoneId = "UTC",
+			CultureName = "en-AU",
+			RegistrationCode = string.Empty,
+			IsRegistered = true,
+			RecoveryCode = string.Empty,
+			UnitPreference = "metric",
+			CreationDate = DateTime.UtcNow,
+			PageLength = 22,
+			PromptType = 0,
+			TabRoomDescriptions = false,
+			CodedRoomDescriptionAdditionsOnNewLine = false,
+			CharacterNameOverlaySetting = 0,
+			AppendNewlinesBetweenMultipleEchoesPerPrompt = false,
+			ActLawfully = false,
+			HasBeenActiveInWeek = true,
+			HintsEnabled = true,
+			AutoReacquireTargets = false
+		});
+
+		context.GameItemComponentProtos.Add(Component(1, "Holdable"));
+		context.GameItemComponentProtos.Add(Component(2, "Stack_Number", "Stackable"));
+		context.Materials.Add(Material(1, "apple"));
+		context.Materials.Add(Material(2, "blueberry"));
+		context.Materials.Add(Material(3, "mushroom"));
+		context.Materials.Add(Material(4, "muffin"));
+		context.TraitDefinitions.Add(new TraitDefinition
+		{
+			Id = 1,
+			Name = "Cooking",
+			Type = 0,
+			OwnerScope = 0,
+			TraitGroup = "Crafting",
+			ChargenBlurb = string.Empty,
+			ValueExpression = string.Empty
+		});
+		context.SaveChanges();
+	}
+
+	private static MudSharp.Models.GameItemComponentProto Component(long id, string name, string type = "Test")
+	{
+		return new MudSharp.Models.GameItemComponentProto
+		{
+			Id = id,
+			Name = name,
+			Type = type,
+			Description = $"{name} marker",
+			Definition = "<Definition />",
+			RevisionNumber = 0,
+			EditableItem = Editable()
+		};
+	}
+
+	private static Material Material(long id, string name)
+	{
+		return new Material
+		{
+			Id = id,
+			Name = name,
+			MaterialDescription = name,
+			Type = 0,
+			BehaviourType = 0,
+			Density = 1.0,
+			Organic = true,
+			ResidueSdesc = string.Empty,
+			ResidueDesc = string.Empty,
+			ResidueColour = "green"
+		};
+	}
+
+	private static EditableItem Editable()
+	{
+		return new EditableItem
+		{
+			RevisionNumber = 0,
+			RevisionStatus = 4,
+			BuilderAccountId = 1,
+			BuilderDate = DateTime.UtcNow,
+			BuilderComment = "test",
+			ReviewerAccountId = 1,
+			ReviewerComment = "test",
+			ReviewerDate = DateTime.UtcNow
+		};
+	}
+
+	[TestMethod]
+	public void CookingSeeder_InstallsPreparedFoodDirectItemsAndRecipeWithoutLegacyFood()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedPrerequisites(context);
+		CookingSeeder seeder = new();
+
+		Assert.AreEqual(ShouldSeedResult.ExtraPackagesAvailable, seeder.ShouldSeedData(context));
+
+		seeder.SeedData(context, new Dictionary<string, string>());
+		seeder.SeedData(context, new Dictionary<string, string>());
+
+		Assert.AreEqual(1, context.GameItemComponentProtos.Count(x => x.Name == "PreparedFood_Apple"));
+		Assert.AreEqual(1, context.GameItemComponentProtos.Count(x => x.Name == "PreparedFood_Berry_Stack"));
+		Assert.AreEqual(1, context.GameItemComponentProtos.Count(x => x.Name == "PreparedFood_Baked_Apple"));
+		Assert.AreEqual(0, context.GameItemComponentProtos.Count(x => x.Type == "Food"));
+
+		var berryDefinition = XElement.Parse(context.GameItemComponentProtos.Single(x => x.Name == "PreparedFood_Berry_Stack").Definition);
+		Assert.AreEqual("PerStackUnit", berryDefinition.Attribute("ServingScope")!.Value);
+		Assert.IsTrue(berryDefinition.Element("Full")!.Value.Contains("They are made of"));
+		var appleDefinition = XElement.Parse(context.GameItemComponentProtos.Single(x => x.Name == "PreparedFood_Apple").Definition);
+		Assert.IsTrue(appleDefinition.Element("Full")!.Value.Contains("It is made of"));
+		var mushroomDefinition = XElement.Parse(context.GameItemComponentProtos.Single(x => x.Name == "PreparedFood_Mushroom_Stack").Definition);
+		Assert.IsTrue(mushroomDefinition.Element("Full")!.Value.Contains("They are made of"));
+
+		var apple = context.GameItemProtos.Single(x => x.ShortDescription == "a crisp red apple");
+		Assert.IsTrue(apple.GameItemProtosGameItemComponentProtos.Any(x => x.GameItemComponent.Name == "PreparedFood_Apple"));
+		Assert.IsTrue(apple.GameItemProtosTags.Any(x => x.Tag.Name == "Forageable Food"));
+
+		var berries = context.GameItemProtos.Single(x => x.ShortDescription == "a handful of blueberries");
+		Assert.IsTrue(berries.GameItemProtosGameItemComponentProtos.Any(x => x.GameItemComponent.Name == "Stack_Number"));
+		Assert.IsTrue(berries.GameItemProtosGameItemComponentProtos.Any(x => x.GameItemComponent.Name == "PreparedFood_Berry_Stack"));
+
+		var craft = context.Crafts.Single(x => x.Name == "bake apple");
+		Assert.AreEqual("Cooking", craft.Category);
+		Assert.AreEqual(1, craft.CraftProducts.Count(x => x.ProductType == "CookedFoodProduct"));
+		Assert.AreEqual(1, craft.CraftInputs.Count(x => x.InputType == "Tag"));
+		var productDefinition = XElement.Parse(craft.CraftProducts.Single(x => x.ProductType == "CookedFoodProduct").Definition);
+		Assert.AreEqual("false", productDefinition.Element("RemoveDrugsAndFoodEffects")!.Value);
+
+		Assert.AreEqual(ShouldSeedResult.MayAlreadyBeInstalled, seeder.ShouldSeedData(context));
+	}
+
+	[TestMethod]
+	public void CookingSeeder_BlocksWhenUsefulItemComponentsAreMissing()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedPrerequisites(context);
+		context.GameItemComponentProtos.RemoveRange(context.GameItemComponentProtos);
+		context.SaveChanges();
+
+		Assert.AreEqual(ShouldSeedResult.PrerequisitesNotMet, new CookingSeeder().ShouldSeedData(context));
+	}
+}

--- a/DatabaseSeeder/SeederMetadataRegistry.cs
+++ b/DatabaseSeeder/SeederMetadataRegistry.cs
@@ -175,6 +175,22 @@ public static class SeederMetadataRegistry
                 UpdateSummary: "Reruns also refresh the stock wilderness autobuilder room template, area template, and supporting terrain-feature tags by stable names.",
                 OwnershipSummary: "Kickstart now owns stock items, AI, helper tags, the wilderness autobuilder room+area starter package, ranged covers, hints, and dream content; core terrain foundations are seeded separately."
             ),
+            nameof(CookingSeeder) => new SeederMetadata(
+                SeederRepeatabilityMode.Idempotent,
+                SeederUpdateCapability.InstallMissing,
+                [
+                    Requirement("The Core seeder must have created at least one account.", context => context.Accounts.Any()),
+                    Requirement("Useful item components must already include Holdable and Stack_Number.", context =>
+                        context.GameItemComponentProtos.Any(x => x.Name == "Holdable") &&
+                        context.GameItemComponentProtos.Any(x => x.Name == "Stack_Number")),
+                    Requirement("Core food materials must already exist.", context =>
+                        new[] { "apple", "blueberry", "mushroom", "muffin" }.All(material => context.Materials.Any(x => x.Name == material))),
+                    Requirement("At least one trait definition must exist for cooking craft quality checks.", context => context.TraitDefinitions.Any())
+                ],
+                RerunSummary: "Reruns install missing prepared-food stock records without mutating the legacy Food component.",
+                UpdateSummary: "This package owns direct prepared-food examples, stackable serving examples, and stock CookedFoodProduct recipe examples by stable names.",
+                OwnershipSummary: "Stock prepared-food content is tracked by CookingSeeder component names, item short descriptions, tags, and recipe names."
+            ),
             nameof(AIStorytellerSeeder) => new SeederMetadata(
                 SeederRepeatabilityMode.Idempotent,
                 SeederUpdateCapability.RepairExisting,

--- a/DatabaseSeeder/Seeders/CookingSeeder.cs
+++ b/DatabaseSeeder/Seeders/CookingSeeder.cs
@@ -1,0 +1,530 @@
+using MudSharp.Database;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.GameItems;
+using MudSharp.Models;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+using CraftPhase = MudSharp.Models.CraftPhase;
+
+#nullable enable
+
+namespace DatabaseSeeder.Seeders;
+
+public class CookingSeeder : IDatabaseSeeder
+{
+	private const string StockPrefix = "CookingSeeder";
+
+	public IEnumerable<(string Id, string Question, Func<FuturemudDatabaseContext, IReadOnlyDictionary<string, string>, bool> Filter, Func<string, FuturemudDatabaseContext, (bool Success, string error)> Validator)> SeederQuestions =>
+		Enumerable.Empty<(string Id, string Question, Func<FuturemudDatabaseContext, IReadOnlyDictionary<string, string>, bool> Filter, Func<string, FuturemudDatabaseContext, (bool Success, string error)> Validator)>();
+
+	public int SortOrder => 390;
+	public string Name => "Prepared Food and Cooking";
+	public string Tagline => "Prepared-food prototypes, direct food items and sample cooking recipes";
+	public bool SafeToRunMoreThanOnce => true;
+
+	public string FullDescription => @"This package installs stock prepared-food component prototypes, directly loadable prepared food items, stackable serving examples, and sample cooking crafts that output CookedFoodProduct records.
+
+It intentionally leaves the legacy Food component untouched. The direct items can be loaded, sold, foraged, or created by progs and spells without passing through any craft.";
+
+	public ShouldSeedResult ShouldSeedData(FuturemudDatabaseContext context)
+	{
+		if (!PrerequisitesMet(context))
+		{
+			return ShouldSeedResult.PrerequisitesNotMet;
+		}
+
+		return MissingStockRecords(context).Any()
+			? ShouldSeedResult.ExtraPackagesAvailable
+			: ShouldSeedResult.MayAlreadyBeInstalled;
+	}
+
+	public string SeedData(FuturemudDatabaseContext context, IReadOnlyDictionary<string, string> questionAnswers)
+	{
+		if (!PrerequisitesMet(context))
+		{
+			return "Prepared food and cooking prerequisites are not installed.";
+		}
+
+		var created = new List<string>();
+		var now = DateTime.UtcNow;
+		var account = context.Accounts.First();
+		var tags = context.Tags.ToDictionary(x => x.Name, StringComparer.OrdinalIgnoreCase);
+		var components = context.GameItemComponentProtos.ToDictionary(x => x.Name, StringComparer.OrdinalIgnoreCase);
+		var materials = context.Materials.ToDictionary(x => x.Name, StringComparer.OrdinalIgnoreCase);
+
+		var foodTag = EnsureTag(context, tags, "Food", null);
+		var preparedFoodTag = EnsureTag(context, tags, "Prepared Food", foodTag);
+		var forageFoodTag = EnsureTag(context, tags, "Forageable Food", preparedFoodTag);
+		var cookingIngredientTag = EnsureTag(context, tags, "Cooking Ingredient", preparedFoodTag);
+		var stockCookingAppleTag = EnsureTag(context, tags, "Stock Cooking Apple", cookingIngredientTag);
+		var stockCookingFruitTag = EnsureTag(context, tags, "Stock Cooking Fruit", cookingIngredientTag);
+
+		var appleComponent = EnsurePreparedFoodComponent(context, components, account, now, "PreparedFood_Apple",
+			"Stock prepared-food profile for a directly loaded apple.",
+			FoodDefinition("WholeItem", 2.0, 0.08, 1.0, 0.0, 4.0, 0.08, 0.25, 0.0, 0.01, 14, 28,
+				"It tastes crisp, sweet, and faintly tart.",
+				"{freshness} {primary}",
+				"A {quality} apple. It is made of {ingredients}.",
+				("primary", "apple", "fresh apple")));
+		if (appleComponent.WasCreated)
+		{
+			created.Add("apple prepared-food component");
+		}
+
+		var berryComponent = EnsurePreparedFoodComponent(context, components, account, now, "PreparedFood_Berry_Stack",
+			"Stock prepared-food profile for stackable berries.",
+			FoodDefinition("PerStackUnit", 0.35, 0.015, 0.2, 0.0, 1.0, 0.08, 0.25, 0.0, 0.003, 5, 9,
+				"It tastes like a small burst of sweet berry juice.",
+				"{servings} {freshness} berries",
+				"These berries are a stackable prepared food. Each unit is its own serving. They are made of {ingredients}.",
+				("primary", "blueberry", "sweet berry")));
+		if (berryComponent.WasCreated)
+		{
+			created.Add("berry stack prepared-food component");
+		}
+
+		var mushroomComponent = EnsurePreparedFoodComponent(context, components, account, now, "PreparedFood_Mushroom_Stack",
+			"Stock prepared-food profile for stackable forage mushrooms.",
+			FoodDefinition("PerStackUnit", 0.6, 0.01, 0.0, 0.0, 2.0, 0.08, 0.15, 0.0, 0.004, 3, 6,
+				"It tastes earthy and damp.",
+				"{servings} {freshness} mushrooms",
+				"These mushrooms are food items suitable for foraging examples. They are made of {ingredients}.",
+				("primary", "mushroom", "earthy mushroom")));
+		if (mushroomComponent.WasCreated)
+		{
+			created.Add("mushroom stack prepared-food component");
+		}
+
+		var muffinComponent = EnsurePreparedFoodComponent(context, components, account, now, "PreparedFood_Muffin_Template",
+			"Stock prepared-food profile for recipe-created muffins.",
+			FoodDefinition("WholeItem", 4.0, 0.03, 0.0, 0.0, 5.0, 0.1, 0.3, 0.0, 0.02, 3, 7,
+				"It tastes of baked grain, soft crumb, and {additives}.",
+				"a {quality} muffin with {additives}",
+				"This muffin was created with the prepared-food system. Its ingredient ledger records {ingredients}.",
+				("base", "muffin batter", "baked muffin")));
+		if (muffinComponent.WasCreated)
+		{
+			created.Add("muffin prepared-food component");
+		}
+
+		var bakedAppleComponent = EnsurePreparedFoodComponent(context, components, account, now, "PreparedFood_Baked_Apple",
+			"Stock prepared-food profile for a cooked apple recipe product.",
+			FoodDefinition("WholeItem", 2.3, 0.06, 0.5, 0.0, 4.0, 0.1, 0.3, 0.0, 0.015, 4, 8,
+				"It tastes soft, sweet, and warmly cooked, with traces of {ingredients}.",
+				"a baked apple with a soft split skin",
+				"This baked apple is a recipe-initialised prepared food. Its ledger records {ingredients}.",
+				("base", "baked apple", "warm baked apple")));
+		if (bakedAppleComponent.WasCreated)
+		{
+			created.Add("baked apple prepared-food component");
+		}
+
+		var apple = EnsureItem(context, account, now, materials["apple"], "apple", "a crisp red apple",
+			"A crisp red apple lies here.",
+			"The apple is round and firm-skinned, with a red blush over pale green undertones.",
+			120, 2.0M,
+			[preparedFoodTag, forageFoodTag, cookingIngredientTag, stockCookingAppleTag, stockCookingFruitTag],
+			[components["Holdable"], appleComponent.Component]);
+		if (apple.WasCreated)
+		{
+			created.Add("direct apple item");
+		}
+
+		var berries = EnsureItem(context, account, now, materials["blueberry"], "berries", "a handful of blueberries",
+			"A handful of blueberries have been scattered here.",
+			"The blueberries are small, dark, and slightly dusty-skinned.",
+			50, 1.5M,
+			[preparedFoodTag, forageFoodTag, cookingIngredientTag, stockCookingFruitTag],
+			[components["Holdable"], components["Stack_Number"], berryComponent.Component]);
+		if (berries.WasCreated)
+		{
+			created.Add("stackable berry item");
+		}
+
+		var mushrooms = EnsureItem(context, account, now, materials["mushroom"], "mushrooms", "a handful of edible mushrooms",
+			"A handful of edible mushrooms have been left here.",
+			"The mushrooms are pale brown and irregularly shaped, with slightly damp gills.",
+			80, 1.0M,
+			[preparedFoodTag, forageFoodTag, cookingIngredientTag],
+			[components["Holdable"], components["Stack_Number"], mushroomComponent.Component]);
+		if (mushrooms.WasCreated)
+		{
+			created.Add("stackable mushroom item");
+		}
+
+		var muffin = EnsureItem(context, account, now, materials["muffin"], "muffin", "a plain muffin",
+			"A plain muffin rests here.",
+			"The muffin has a rounded top and a dense, golden crumb.",
+			110, 3.0M,
+			[preparedFoodTag, cookingIngredientTag],
+			[components["Holdable"], muffinComponent.Component]);
+		if (muffin.WasCreated)
+		{
+			created.Add("muffin recipe target item");
+		}
+
+		var bakedApple = EnsureItem(context, account, now, materials["apple"], "baked apple", "a baked apple with a soft split skin",
+			"A baked apple with a soft split skin rests here.",
+			"The apple has collapsed slightly from cooking, its split skin revealing soft, fragrant flesh.",
+			105, 3.0M,
+			[preparedFoodTag],
+			[components["Holdable"], bakedAppleComponent.Component]);
+		if (bakedApple.WasCreated)
+		{
+			created.Add("baked apple recipe target item");
+		}
+
+		var craft = EnsureBakedAppleCraft(context, account, now, stockCookingAppleTag, bakedApple.Item);
+		if (craft)
+		{
+			created.Add("sample CookedFoodProduct recipe");
+		}
+
+		context.SaveChanges();
+		return created.Any()
+			? $"Installed {created.ListToString()}."
+			: "Prepared food and cooking stock records were already installed.";
+	}
+
+	private static bool PrerequisitesMet(FuturemudDatabaseContext context)
+	{
+		return context.Accounts.Any() &&
+		       context.GameItemComponentProtos.Any(x => x.Name == "Holdable") &&
+		       context.GameItemComponentProtos.Any(x => x.Name == "Stack_Number") &&
+		       new[] { "apple", "blueberry", "mushroom", "muffin" }.All(material => context.Materials.Any(x => x.Name == material)) &&
+		       context.TraitDefinitions.Any();
+	}
+
+	private static IEnumerable<string> MissingStockRecords(FuturemudDatabaseContext context)
+	{
+		foreach (var name in new[]
+		         {
+			         "PreparedFood_Apple", "PreparedFood_Berry_Stack", "PreparedFood_Mushroom_Stack",
+			         "PreparedFood_Muffin_Template", "PreparedFood_Baked_Apple"
+		         })
+		{
+			if (!context.GameItemComponentProtos.Any(x => x.Name == name && x.Type == "PreparedFood"))
+			{
+				yield return name;
+			}
+		}
+
+		foreach (var sdesc in new[]
+		         {
+			         "a crisp red apple", "a handful of blueberries", "a handful of edible mushrooms",
+			         "a plain muffin", "a baked apple with a soft split skin"
+		         })
+		{
+			if (!context.GameItemProtos.Any(x => x.ShortDescription == sdesc))
+			{
+				yield return sdesc;
+			}
+		}
+
+		if (!context.Crafts.Any(x => x.Name == "bake apple"))
+		{
+			yield return "bake apple";
+		}
+	}
+
+	private static Tag EnsureTag(FuturemudDatabaseContext context, IDictionary<string, Tag> tags, string name, Tag? parent)
+	{
+		if (tags.TryGetValue(name, out var tag))
+		{
+			return tag;
+		}
+
+		tag = new Tag
+		{
+			Id = tags.Values.Any() ? tags.Values.Max(x => x.Id) + 1 : 1,
+			Name = name,
+			Parent = parent,
+			ParentId = parent?.Id
+		};
+		context.Tags.Add(tag);
+		tags[name] = tag;
+		return tag;
+	}
+
+	private static (GameItemComponentProto Component, bool WasCreated) EnsurePreparedFoodComponent(
+		FuturemudDatabaseContext context,
+		IDictionary<string, GameItemComponentProto> components,
+		Account account,
+		DateTime now,
+		string name,
+		string description,
+		string definition)
+	{
+		if (components.TryGetValue(name, out var component))
+		{
+			return (component, false);
+		}
+
+		component = new GameItemComponentProto
+		{
+			Id = components.Values.Any() ? components.Values.Max(x => x.Id) + 1 : 1,
+			Name = name,
+			Description = description,
+			Type = "PreparedFood",
+			RevisionNumber = 0,
+			Definition = definition,
+			EditableItem = Editable(account, now)
+		};
+		context.GameItemComponentProtos.Add(component);
+		components[name] = component;
+		return (component, true);
+	}
+
+	private static string FoodDefinition(string scope, double satiation, double water, double thirst, double alcohol,
+		double bites, double qualityScale, double staleMultiplier, double spoiledMultiplier, double absorption,
+		int staleDays, int spoilDays, string taste, string shortTemplate, string fullTemplate,
+		(string Role, string Description, string Taste) ingredient)
+	{
+		return new XElement("Definition",
+			new XAttribute("ServingScope", scope),
+			new XAttribute("Satiation", satiation),
+			new XAttribute("Water", water),
+			new XAttribute("Thirst", thirst),
+			new XAttribute("Alcohol", alcohol),
+			new XAttribute("Bites", bites),
+			new XAttribute("QualityScale", qualityScale),
+			new XAttribute("StaleMultiplier", staleMultiplier),
+			new XAttribute("SpoiledMultiplier", spoiledMultiplier),
+			new XAttribute("LiquidAbsorption", absorption),
+			new XAttribute("StaleAfterSeconds", TimeSpan.FromDays(staleDays).TotalSeconds),
+			new XAttribute("SpoilAfterSeconds", TimeSpan.FromDays(spoilDays).TotalSeconds),
+			new XAttribute("Decorator", 0),
+			new XElement("Taste", new XCData(taste)),
+			new XElement("Short", new XCData(shortTemplate)),
+			new XElement("Full", new XCData(fullTemplate)),
+			new XElement("OnEatProg", 0),
+			new XElement("OnStaleProg", 0),
+			new XElement("Ingredients",
+				new XElement("Ingredient",
+					new XAttribute("role", ingredient.Role),
+					new XAttribute("source", 0),
+					new XAttribute("material", 0),
+					new XAttribute("liquid", 0),
+					new XAttribute("weight", 0),
+					new XAttribute("volume", 0),
+					new XAttribute("quality", (int)ItemQuality.Standard),
+					new XElement("Description", new XCData(ingredient.Description)),
+					new XElement("Taste", new XCData(ingredient.Taste))
+				)
+			),
+			new XElement("DrugDoses"),
+			new XElement("StaleDrugDoses")
+		).ToString();
+	}
+
+	private static (GameItemProto Item, bool WasCreated) EnsureItem(
+		FuturemudDatabaseContext context,
+		Account account,
+		DateTime now,
+		Material material,
+		string noun,
+		string sdesc,
+		string ldesc,
+		string fdesc,
+		double weight,
+		decimal cost,
+		IEnumerable<Tag> tags,
+		IEnumerable<GameItemComponentProto> components)
+	{
+		var existing = context.GameItemProtos.FirstOrDefault(x => x.ShortDescription == sdesc);
+		if (existing is not null)
+		{
+			return (existing, false);
+		}
+
+		var item = new GameItemProto
+		{
+			Id = NextGameItemProtoId(context),
+			Name = noun,
+			Keywords = sdesc.Strip_A_An().Split(' ', StringSplitOptions.RemoveEmptyEntries).Distinct().ListToCommaSeparatedValues(" "),
+			MaterialId = material.Id,
+			EditableItem = Editable(account, now),
+			RevisionNumber = 0,
+			Size = (int)SizeCategory.Small,
+			Weight = weight,
+			ReadOnly = false,
+			LongDescription = ldesc,
+			BaseItemQuality = (int)ItemQuality.Standard,
+			MorphEmote = "$0 $?1|morphs into $1|decays into nothing$.",
+			ShortDescription = sdesc,
+			FullDescription = fdesc,
+			PermitPlayerSkins = true,
+			CostInBaseCurrency = cost,
+			IsHiddenFromPlayers = false
+		};
+		foreach (var tag in tags.DistinctBy(x => x.Id))
+		{
+			item.GameItemProtosTags.Add(new GameItemProtosTags
+			{
+				GameItemProto = item,
+				Tag = tag,
+				TagId = tag.Id,
+				GameItemProtoRevisionNumber = 0
+			});
+		}
+
+		foreach (var component in components.DistinctBy(x => x.Id))
+		{
+			item.GameItemProtosGameItemComponentProtos.Add(new GameItemProtosGameItemComponentProtos
+			{
+				GameItemProto = item,
+				GameItemComponent = component,
+				GameItemComponentProtoId = component.Id,
+				GameItemComponentRevision = component.RevisionNumber,
+				GameItemProtoRevision = 0
+			});
+		}
+
+		context.GameItemProtos.Add(item);
+		return (item, true);
+	}
+
+	private static bool EnsureBakedAppleCraft(FuturemudDatabaseContext context, Account account, DateTime now, Tag appleTag,
+		GameItemProto bakedApple)
+	{
+		if (context.Crafts.Any(x => x.Name == "bake apple"))
+		{
+			return false;
+		}
+
+		var appearProg = EnsureAppearProg(context, account, now);
+		if (appearProg.Id == 0)
+		{
+			context.SaveChanges();
+		}
+		var trait = context.TraitDefinitions
+		                   .FirstOrDefault(x => x.Name == "Cooking" || x.Name == "Cook") ??
+		            context.TraitDefinitions.First();
+		var craft = new Craft
+		{
+			Id = NextCraftId(context),
+			RevisionNumber = 0,
+			EditableItem = Editable(account, now),
+			Name = "bake apple",
+			Category = "Cooking",
+			Blurb = "bake an apple into a simple prepared-food example",
+			ActionDescription = "baking an apple",
+			ActiveCraftItemSdesc = "an apple-baking process",
+			AppearInCraftsListProg = appearProg,
+			AppearInCraftsListProgId = appearProg.Id,
+			CheckTrait = trait,
+			CheckTraitId = trait.Id,
+			CheckDifficulty = (int)Difficulty.Trivial,
+			FailThreshold = (int)Outcome.MajorFail,
+			FreeSkillChecks = 1,
+			FailPhase = 2,
+			Interruptable = true,
+			QualityFormula = "5 + (outcome/3) + (variable/20)",
+			CheckQualityWeighting = 1.0,
+			InputQualityWeighting = 1.0,
+			ToolQualityWeighting = 1.0,
+			IsPracticalCheck = true
+		};
+		craft.CraftPhases.Add(new CraftPhase
+		{
+			Craft = craft,
+			PhaseNumber = 1,
+			PhaseLengthInSeconds = 30,
+			Echo = "$0 wash|washes and score|scores $i1, preparing it for heat.",
+			FailEcho = "$0 mishandle|mishandles $i1 while preparing it."
+		});
+		craft.CraftPhases.Add(new CraftPhase
+		{
+			Craft = craft,
+			PhaseNumber = 2,
+			PhaseLengthInSeconds = 60,
+			Echo = "$0 cook|cooks $i1 until the skin splits and the flesh softens.",
+			FailEcho = "$0 overcook|overcooks $i1, ruining the example."
+		});
+		craft.CraftInputs.Add(new CraftInput
+		{
+			Craft = craft,
+			InputQualityWeight = 1.0,
+			OriginalAdditionTime = now,
+			InputType = "Tag",
+			Definition = new XElement("Definition",
+				new XElement("TargetTagId", appleTag.Id),
+				new XElement("Quantity", 1)
+			).ToString()
+		});
+		craft.CraftProducts.Add(new CraftProduct
+		{
+			Craft = craft,
+			IsFailProduct = false,
+			OriginalAdditionTime = now,
+			ProductType = "CookedFoodProduct",
+			Definition = new XElement("Definition",
+				new XElement("ProductProducedId", bakedApple.Id),
+				new XElement("Quantity", 1),
+				new XElement("Skin", 0),
+				new XElement("RemoveDrugsAndFoodEffects", false),
+				new XElement("IngredientSlots")
+			).ToString()
+		});
+		context.Crafts.Add(craft);
+		return true;
+	}
+
+	private static FutureProg EnsureAppearProg(FuturemudDatabaseContext context, Account account, DateTime now)
+	{
+		var existing = context.FutureProgs.FirstOrDefault(x => x.FunctionName == "AlwaysTrue") ??
+		               context.FutureProgs.FirstOrDefault(x => x.FunctionName == $"{StockPrefix}AlwaysTrue");
+		if (existing is not null)
+		{
+			return existing;
+		}
+
+		var prog = new FutureProg
+		{
+			FunctionName = $"{StockPrefix}AlwaysTrue",
+			Category = "Crafting",
+			Subcategory = "Cooking",
+			ReturnType = (long)ProgVariableTypes.Boolean,
+			FunctionComment = "Used by the cooking seeder to make stock cooking examples visible.",
+			FunctionText = "return true",
+			StaticType = (int)FutureProgStaticType.NotStatic,
+			AcceptsAnyParameters = false
+		};
+		context.FutureProgs.Add(prog);
+		return prog;
+	}
+
+	private static EditableItem Editable(Account account, DateTime now)
+	{
+		return new EditableItem
+		{
+			RevisionNumber = 0,
+			RevisionStatus = 4,
+			BuilderAccountId = account.Id,
+			BuilderDate = now,
+			BuilderComment = "Auto-generated by the system",
+			ReviewerAccountId = account.Id,
+			ReviewerComment = "Auto-generated by the system",
+			ReviewerDate = now
+		};
+	}
+
+	private static long NextGameItemProtoId(FuturemudDatabaseContext context)
+	{
+		var existing = context.GameItemProtos.Any() ? context.GameItemProtos.Max(x => x.Id) : 0;
+		var local = context.GameItemProtos.Local.Any() ? context.GameItemProtos.Local.Max(x => x.Id) : 0;
+		return Math.Max(existing, local) + 1;
+	}
+
+	private static long NextCraftId(FuturemudDatabaseContext context)
+	{
+		var existing = context.Crafts.Any() ? context.Crafts.Max(x => x.Id) : 0;
+		var local = context.Crafts.Local.Any() ? context.Crafts.Local.Max(x => x.Id) : 0;
+		return Math.Max(existing, local) + 1;
+	}
+}

--- a/Design Documents/Crafting_System_Overview.md
+++ b/Design Documents/Crafting_System_Overview.md
@@ -12,6 +12,7 @@ The intended audience for this head document is:
 ## Document Map
 - [Crafting System Runtime and Extensibility](./Crafting_System_Runtime_and_Extensibility.md) covers runtime behaviour, persistence, implemented types, extension seams, and cross-system integration.
 - [Crafting System Builder Workflows](./Crafting_System_Builder_Workflows.md) covers the in-game authoring and review workflow, command surface, and builder-facing reference material.
+- [Food And Cooking System](./Food_and_Cooking_System.md) covers prepared-food components, `CookedFoodProduct`, and the `cook` facade over ordinary crafts.
 
 ## What Crafts Are
 In FutureMUD, a craft is a revisioned, builder-authored definition for an on-screen, phase-based activity performed by a character in the world.
@@ -36,6 +37,7 @@ Important distinctions:
 - Crafts versus projects: crafts are on-screen, time-phased actions a character is actively performing in the room right now. Projects model longer-lived labour and supply workflows that continue as broader works rather than as a single visible action sequence.
 - Crafts versus butchery and salvage: `butcher`, `salvage`, and `skin` are separate command-driven subsystems with their own runtime logic. They are adjacent in purpose, but they are not implemented as `ICraft`.
 - Crafts versus one-shot spawning: some craft products load ordinary items, but the craft system itself is about staged execution, not just spawning outputs.
+- Cooking versus direct food creation: cooking crafts can produce `PreparedFood` through `CookedFoodProduct`, but prepared-food item prototypes are also complete direct-load foods for forage, shops, spells, and FutureProgs.
 
 ## Subsystem Map
 | Layer | Current responsibility | Typical locations |
@@ -54,6 +56,7 @@ Important distinctions:
 - Inputs: `ICraftInput` implementations that know how to find, reserve, consume, and describe required materials or target items.
 - Tools: `ICraftTool` implementations that know how to find, score, and optionally consume tool durability during the craft.
 - Products versus fail products: normal products are produced on the success branch; fail products are produced once the craft has failed and the fail echoes advance.
+- Cooked food products: `CookedFoodProduct` loads an ordinary prepared-food item prototype and appends recipe-derived ingredient ledgers, doses, and transferable effects from consumed inputs.
 - Active craft progress item: a system-generated game item carrying `IActiveCraftGameItemComponent` that stores reserved inputs, produced outputs, phase state, and craft revision linkage.
 - Availability, can-use, and callback progs: FutureProg hooks control whether a craft appears in lists, whether it can currently be started, why it cannot be started, and what happens on start, cancel, or completion.
 

--- a/Design Documents/Crafting_System_Runtime_and_Extensibility.md
+++ b/Design Documents/Crafting_System_Runtime_and_Extensibility.md
@@ -334,6 +334,7 @@ All tool types inherit shared builder options from `BaseTool`:
 | Builder alias | Runtime type | Purpose | Key builder options | Important notes |
 | --- | --- | --- | --- | --- |
 | `simple` | `SimpleProduct` | Load one or more ordinary item prototypes | `item`, `skin`, `quantity`, `material` | Optional craft-aware skin support through `IGameItemSkin.CanUseSkin(..., craft)` |
+| `cookedfood` | `CookedFoodProduct` | Load a prepared-food item prototype and initialise its ingredient ledger from consumed inputs | `item`, `skin`, `quantity`, `purify`, `ingredient` | Uses the same `PreparedFood` runtime component as direct-load food; `purify` removes input drugs and transferable food effects; the `cook` command filters to crafts with this product type |
 | `variable` | `SimpleVariableProduct` | Load items whose characteristic values come from `IVariableInput` sources | `item`, `skin`, `quantity`, `variable <definition> <input#>` | Each mapped input must be an `IVariableInput` that supplies the definition |
 | `inputvariable` | `InputVariableProduct` | Load items whose variable values depend on which item proto was used for an input | `item`, `skin`, `quantity`, `variable ...` | Supports per-input-index and per-item-to-value mappings |
 | `commodity` | `CommodityProduct` | Produce a commodity pile of a material, mass, and optional tag | `commodity`, `weight`, `tag`, `material` | Useful for intermediate materials and scrap |

--- a/Design Documents/Food_and_Cooking_System.md
+++ b/Design Documents/Food_and_Cooking_System.md
@@ -1,0 +1,92 @@
+# FutureMUD Food And Cooking System
+
+## Scope
+This document describes the current new-style food system centred on `PreparedFood`, recipe-initialised prepared foods, and the `cook` command facade over crafts.
+
+The legacy `Food` component still exists for old content. It is intentionally not mutated by the prepared-food implementation.
+
+## Runtime Model
+`IPreparedFood` extends `IEdible` and is implemented by the `PreparedFood` item component. The same component is used for:
+
+- directly loaded food items such as apples, berries, summoned bread, shop stock, and forageable prototype yields
+- foods created by crafts through `CookedFoodProduct`
+- prepared foods later used as ingredients in another cooking craft
+
+Direct foods are complete as soon as their ordinary item prototype is loaded. They store base nutrition, bites, serving scope, taste/short/full templates, a default ingredient ledger, default drug doses, quality scaling, shelf life, stale/spoiled behaviour, and liquid absorption limits on the component prototype.
+
+Recipe-created foods still load an ordinary prepared-food item prototype. The craft product then appends ingredient ledger entries, drug doses, liquid contributions, freshness information, and approved transferable effects from the craft inputs. The product is an initializer, not a second food implementation.
+
+`CookedFoodProduct` can optionally remove input drugs and transferable food effects while still recording the consumed ingredients. This is intended for processes such as boiling, filtering, or otherwise purifying food and liquids before they become the final prepared food. The flag is off by default so ordinary recipes preserve ingredient doses and effects.
+
+## Serving Scope
+Prepared food has two serving scopes:
+
+- `WholeItem`: one item is one food serving, such as one apple, one loaf, or one muffin.
+- `PerStackUnit`: each stack unit is one serving, such as berries, nuts, mushrooms, roots, or ration pieces.
+
+The eating path allows `PerStackUnit` prepared foods to be eaten from a stack without first splitting off a single item. Nutrition, bites, drug dose delivery, and serving depletion are per stack unit. When the current unit is fully eaten, the stack quantity is decremented and the next unit starts with a fresh bite count.
+
+## Freshness
+Prepared food stores `CreatedAt`, optional stale and spoiled timers, stale/spoiled nutrition multipliers, and stale/spoiled drug doses. Freshness is evaluated lazily at consumption and display time.
+
+By default, stale food is less useful nutritionally and spoiled food can be made nutritionally worthless. Builders can make stale or spoiled food actively harmful by configuring stale drug doses or a stale-eat FutureProg.
+
+## Taste And Description Templates
+Prepared food renders taste, short-description, and full-description templates lazily against the live item. This matters for direct `loaditem`, spell-created items, shop stock, and FutureProg-created variants because item variables may be applied after component construction.
+
+Supported template tokens include:
+
+- `{quality}`
+- `{freshness}`
+- `{primary}`
+- `{ingredients}`
+- `{additives}`
+- `{ingredient:<role>}`
+- `{var:<definition name>}`
+- `{bites}`
+- `{servings}`
+
+The `{var:...}` token reads the parent item's `IVariable` component at render time.
+
+## Drugs And Liquids
+Prepared food can carry ingested drug doses from three sources:
+
+- default profile doses authored on the component prototype
+- recipe-propagated doses from prepared-food or liquid inputs
+- later liquid exposure absorbed by the prepared food
+
+Food and liquid drinking both use the shared ingested-dose helper. Only drugs that support the `Ingested` vector are delivered by eating or drinking.
+
+Liquid exposure is handled before ordinary contamination. Prepared food absorbs up to its configured limit and turns absorbed liquid into ingredient ledger entries and ingested-capable drug doses. Any overflow continues through normal item contamination.
+
+Cooking recipes that enable `CookedFoodProduct` purification omit propagated drug doses from prepared-food and liquid inputs and suppress `IIngredientTransferEffect` transfer from consumed item inputs. The output prototype's own default profile doses and stale doses are still honoured.
+
+## Cooking Crafts
+Cooking uses the existing craft system. `CookedFoodProduct` is a craft product type that loads a prepared-food item prototype and initializes the same runtime component from consumed craft inputs.
+
+Builders can use:
+
+- `cook list`
+- `cook <recipe>`
+- `cook begin <recipe>`
+- `cook resume <progress item>`
+- `cook view <recipe>`
+- `cook preview <recipe>`
+
+The `cook` command only filters and dispatches cooking crafts. Tools, phases, echoes, checks, availability progs, and interruption behaviour remain ordinary craft behaviour.
+
+## Foraging And Direct Creation
+Forageable item yields do not need a new forage process. Point the `Foragable` at a prepared-food item prototype, and the normal forage item-loading path produces usable food.
+
+Likewise, FutureProg `loaditem`, spell `createitem`, shop prototype loading, and direct builder load all work with prepared food because the item prototype itself owns a complete food profile.
+
+## Stock Data
+`CookingSeeder` installs starter content:
+
+- direct prepared-food component profiles
+- direct apple, berry, mushroom, muffin, and baked-apple item prototypes
+- stackable per-unit berry and mushroom examples
+- stock cooking and forageable food tags
+- a sample `bake apple` craft with `CookedFoodProduct`
+
+The package is idempotent and tracks its own records by stable component names, item short descriptions, tags, and recipe names.

--- a/Design Documents/Item_System_Content_Workflows.md
+++ b/Design Documents/Item_System_Content_Workflows.md
@@ -67,7 +67,15 @@ Power, telecom, and modern medical examples also include:
 - `comp edit new defibrillator`
 - `comp edit new externalorgan`
 
-`UsefulSeeder` now ships stock component examples across those modern families, including lithium batteries, cellular devices, answering-machine tapes, computer/network gear, signal automation, gas containers, rebreathers, inhalers, defibrillators, and external-organ support machines. This pass still intentionally leaves food presets, fax-machine examples, and breathing-filter cartridge ecosystems to later dedicated content passes.
+`UsefulSeeder` now ships stock component examples across those modern families, including lithium batteries, cellular devices, answering-machine tapes, computer/network gear, signal automation, gas containers, rebreathers, inhalers, defibrillators, and external-organ support machines. Food presets now live in the dedicated `CookingSeeder` package, which installs `PreparedFood` examples for direct load, forageable stock, stackable servings, and cooking recipe products. Fax-machine examples and breathing-filter cartridge ecosystems remain later dedicated content passes.
+
+Prepared-food examples include:
+- `comp edit new preparedfood`
+- direct-load profiles for apples, berries, mushrooms, and muffins
+- stackable `per-stack-unit` serving profiles for berries and mushrooms
+- recipe target profiles for `CookedFoodProduct`
+
+See [Food And Cooking System](./Food_and_Cooking_System.md) for the runtime model and builder-facing template tokens.
 
 This goes through `GameItemComponentManager`, so failure here often means:
 - the type was not registered

--- a/Design Documents/Item_System_Runtime_Model.md
+++ b/Design Documents/Item_System_Runtime_Model.md
@@ -76,6 +76,8 @@ The item system is intentionally interface-first and component-driven.
 
 A live item becomes "a container" because one of its components implements `IContainer`. It becomes "a wearable" because one of its components implements `IWearable`. It becomes "a radio", "a telephone", "a cell tower", "a corpse", "a battery-powered machine", or "a prosthetic" for the same reason.
 
+New-style food follows the same rule. A live item becomes prepared food because one component implements `IPreparedFood`, which extends `IEdible` with ingredient ledgers, freshness, serving scope, quality-scaled nutrition, and ingested drug doses. The legacy `Food` component remains available for old content, while `PreparedFood` is the current component for direct loadable foods and recipe-initialised foods.
+
 This has two important consequences:
 - most game logic should depend on interfaces from `FutureMUDLibrary`, not concrete component classes
 - adding a new capability usually means adding a new component pair, not adding a new item class

--- a/FutureMUDLibrary/Effects/Interfaces/IIngredientTransferEffect.cs
+++ b/FutureMUDLibrary/Effects/Interfaces/IIngredientTransferEffect.cs
@@ -1,0 +1,10 @@
+using MudSharp.GameItems.Interfaces;
+
+#nullable enable
+
+namespace MudSharp.Effects.Interfaces;
+
+public interface IIngredientTransferEffect : IEffect
+{
+	void TransferToFood(IPreparedFood food, double proportion);
+}

--- a/FutureMUDLibrary/GameItems/Interfaces/IPreparedFood.cs
+++ b/FutureMUDLibrary/GameItems/Interfaces/IPreparedFood.cs
@@ -1,0 +1,202 @@
+using MudSharp.Body;
+using MudSharp.Form.Material;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.GameItems.Decorators;
+using MudSharp.Health;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Xml.Linq;
+
+#nullable enable
+
+namespace MudSharp.GameItems.Interfaces;
+
+public enum FoodServingScope
+{
+	WholeItem,
+	PerStackUnit
+}
+
+public enum FoodFreshness
+{
+	Fresh,
+	Stale,
+	Spoiled
+}
+
+public class FoodIngredientInstance
+{
+	public string Role { get; set; } = "ingredient";
+	public string Description { get; set; } = string.Empty;
+	public string TasteText { get; set; } = string.Empty;
+	public long SourceItemProtoId { get; set; }
+	public long MaterialId { get; set; }
+	public long LiquidId { get; set; }
+	public double Weight { get; set; }
+	public double Volume { get; set; }
+	public ItemQuality Quality { get; set; } = ItemQuality.Standard;
+
+	public FoodIngredientInstance Clone()
+	{
+		return new FoodIngredientInstance
+		{
+			Role = Role,
+			Description = Description,
+			TasteText = TasteText,
+			SourceItemProtoId = SourceItemProtoId,
+			MaterialId = MaterialId,
+			LiquidId = LiquidId,
+			Weight = Weight,
+			Volume = Volume,
+			Quality = Quality
+		};
+	}
+
+	public XElement SaveToXml()
+	{
+		return new XElement("Ingredient",
+			new XAttribute("role", Role),
+			new XAttribute("source", SourceItemProtoId),
+			new XAttribute("material", MaterialId),
+			new XAttribute("liquid", LiquidId),
+			new XAttribute("weight", Weight),
+			new XAttribute("volume", Volume),
+			new XAttribute("quality", (int)Quality),
+			new XElement("Description", new XCData(Description)),
+			new XElement("Taste", new XCData(TasteText))
+		);
+	}
+
+	public static FoodIngredientInstance LoadFromXml(XElement root)
+	{
+		return new FoodIngredientInstance
+		{
+			Role = root.Attribute("role")?.Value ?? "ingredient",
+			SourceItemProtoId = long.Parse(root.Attribute("source")?.Value ?? "0"),
+			MaterialId = long.Parse(root.Attribute("material")?.Value ?? "0"),
+			LiquidId = long.Parse(root.Attribute("liquid")?.Value ?? "0"),
+			Weight = double.Parse(root.Attribute("weight")?.Value ?? "0", CultureInfo.InvariantCulture),
+			Volume = double.Parse(root.Attribute("volume")?.Value ?? "0", CultureInfo.InvariantCulture),
+			Quality = (ItemQuality)int.Parse(root.Attribute("quality")?.Value ?? ((int)ItemQuality.Standard).ToString()),
+			Description = root.Element("Description")?.Value ?? string.Empty,
+			TasteText = root.Element("Taste")?.Value ?? string.Empty
+		};
+	}
+}
+
+public class FoodDrugDose
+{
+	public IDrug? Drug { get; set; }
+	public double Grams { get; set; }
+	public string Source { get; set; } = string.Empty;
+
+	public FoodDrugDose Clone()
+	{
+		return new FoodDrugDose
+		{
+			Drug = Drug,
+			Grams = Grams,
+			Source = Source
+		};
+	}
+
+	public FoodDrugDose Clone(double multiplier)
+	{
+		return new FoodDrugDose
+		{
+			Drug = Drug,
+			Grams = Grams * multiplier,
+			Source = Source
+		};
+	}
+
+	public XElement SaveToXml(string elementName = "Dose")
+	{
+		return new XElement(elementName,
+			new XAttribute("drug", Drug?.Id ?? 0),
+			new XAttribute("grams", Grams),
+			new XAttribute("source", Source)
+		);
+	}
+
+	public static FoodDrugDose LoadFromXml(XElement root, IFuturemud gameworld)
+	{
+		return new FoodDrugDose
+		{
+			Drug = gameworld.Drugs.Get(long.Parse(root.Attribute("drug")?.Value ?? "0")),
+			Grams = double.Parse(root.Attribute("grams")?.Value ?? "0", CultureInfo.InvariantCulture),
+			Source = root.Attribute("source")?.Value ?? string.Empty
+		};
+	}
+}
+
+public class PreparedFoodProfile
+{
+	public FoodServingScope ServingScope { get; set; } = FoodServingScope.WholeItem;
+	public double SatiationPoints { get; set; } = 6.0;
+	public double WaterLitres { get; set; } = 0.05;
+	public double ThirstPoints { get; set; }
+	public double AlcoholLitres { get; set; }
+	public double Bites { get; set; } = 1.0;
+	public double QualityNutritionMultiplierPerStep { get; set; } = 0.08;
+	public double StaleNutritionMultiplier { get; set; } = 0.25;
+	public double SpoiledNutritionMultiplier { get; set; }
+	public double LiquidAbsorptionLitres { get; set; } = 0.02;
+	public TimeSpan? StaleAfter { get; set; }
+	public TimeSpan? SpoilAfter { get; set; }
+	public string TasteTemplate { get; set; } = "It has an unremarkable taste";
+	public string ShortDescriptionTemplate { get; set; } = string.Empty;
+	public string FullDescriptionTemplate { get; set; } = string.Empty;
+	public IStackDecorator? Decorator { get; set; }
+	public IFutureProg? OnEatProg { get; set; }
+	public IFutureProg? OnStaleProg { get; set; }
+	public List<FoodIngredientInstance> Ingredients { get; } = new();
+	public List<FoodDrugDose> DrugDoses { get; } = new();
+	public List<FoodDrugDose> StaleDrugDoses { get; } = new();
+
+	public PreparedFoodProfile Clone()
+	{
+		var profile = new PreparedFoodProfile
+		{
+			ServingScope = ServingScope,
+			SatiationPoints = SatiationPoints,
+			WaterLitres = WaterLitres,
+			ThirstPoints = ThirstPoints,
+			AlcoholLitres = AlcoholLitres,
+			Bites = Bites,
+			QualityNutritionMultiplierPerStep = QualityNutritionMultiplierPerStep,
+			StaleNutritionMultiplier = StaleNutritionMultiplier,
+			SpoiledNutritionMultiplier = SpoiledNutritionMultiplier,
+			LiquidAbsorptionLitres = LiquidAbsorptionLitres,
+			StaleAfter = StaleAfter,
+			SpoilAfter = SpoilAfter,
+			TasteTemplate = TasteTemplate,
+			ShortDescriptionTemplate = ShortDescriptionTemplate,
+			FullDescriptionTemplate = FullDescriptionTemplate,
+			Decorator = Decorator,
+			OnEatProg = OnEatProg,
+			OnStaleProg = OnStaleProg
+		};
+		profile.Ingredients.AddRange(Ingredients.Select(x => x.Clone()));
+		profile.DrugDoses.AddRange(DrugDoses.Select(x => x.Clone()));
+		profile.StaleDrugDoses.AddRange(StaleDrugDoses.Select(x => x.Clone()));
+		return profile;
+	}
+}
+
+public interface IPreparedFood : IEdible
+{
+	FoodServingScope ServingScope { get; }
+	FoodFreshness Freshness { get; }
+	DateTime CreatedAt { get; set; }
+	IEnumerable<FoodIngredientInstance> Ingredients { get; }
+	IEnumerable<FoodDrugDose> DrugDoses { get; }
+	void ApplyPreparedFoodProfile(PreparedFoodProfile profile, bool replaceIngredientsAndDoses = true);
+	void AddIngredient(FoodIngredientInstance ingredient);
+	void AddDrugDose(FoodDrugDose dose);
+	void AddStaleDrugDose(FoodDrugDose dose);
+	void AbsorbLiquid(LiquidMixture mixture, string source, bool includeDrugDoses = true);
+}

--- a/FutureMUDLibrary/Health/IngestedDrugExtensions.cs
+++ b/FutureMUDLibrary/Health/IngestedDrugExtensions.cs
@@ -1,0 +1,55 @@
+using MudSharp.Body;
+using MudSharp.Form.Material;
+using MudSharp.GameItems.Interfaces;
+using System.Collections.Generic;
+using System.Linq;
+
+#nullable enable
+
+namespace MudSharp.Health;
+
+public static class IngestedDrugExtensions
+{
+	public static void ApplyIngestedDrugDoses(this IBody body, IEnumerable<FoodDrugDose> doses, double proportion, object? originator)
+	{
+		foreach (var dose in doses)
+		{
+			if (dose.Drug is null || dose.Grams <= 0.0 || proportion <= 0.0)
+			{
+				continue;
+			}
+
+			if (!dose.Drug.DrugVectors.HasFlag(DrugVector.Ingested))
+			{
+				continue;
+			}
+
+			body.Dose(dose.Drug, DrugVector.Ingested, dose.Grams * proportion, originator);
+		}
+	}
+
+	public static void ApplyIngestedDrugDoses(this IBody body, LiquidMixture mixture, object? originator)
+	{
+		if (mixture is null || mixture.TotalVolume <= 0.0)
+		{
+			return;
+		}
+
+		foreach (var instance in mixture.Instances.Where(x => x.Liquid?.Drug is not null))
+		{
+			var drug = instance.Liquid.Drug;
+			if (!drug.DrugVectors.HasFlag(DrugVector.Ingested))
+			{
+				continue;
+			}
+
+			var grams = instance.Amount * instance.Liquid.DrugGramsPerUnitVolume;
+			if (grams <= 0.0)
+			{
+				continue;
+			}
+
+			body.Dose(drug, DrugVector.Ingested, grams, originator);
+		}
+	}
+}

--- a/MudSharpCore/Body/Implementations/BodyNeeds.cs
+++ b/MudSharpCore/Body/Implementations/BodyNeeds.cs
@@ -7,6 +7,7 @@ using MudSharp.Form.Material;
 using MudSharp.Framework;
 using MudSharp.GameItems;
 using MudSharp.GameItems.Interfaces;
+using MudSharp.Health;
 using MudSharp.PerceptionEngine;
 using MudSharp.PerceptionEngine.Outputs;
 using MudSharp.PerceptionEngine.Parsers;
@@ -206,7 +207,8 @@ public partial class Body : IHaveNeeds, IEat
         }
 
         // If the item is a stackable, split one off
-        if (edible.Parent.IsItemType<IStackable>() && edible.Parent.GetItemType<IStackable>().Quantity > 1)
+        if (edible.Parent.IsItemType<IStackable>() && edible.Parent.GetItemType<IStackable>().Quantity > 1 &&
+            edible is not IPreparedFood { ServingScope: FoodServingScope.PerStackUnit })
         {
             Actor.Send("You must first take a single item out of the stack before you can eat any of them.");
             return false;
@@ -573,6 +575,7 @@ public partial class Body : IHaveNeeds, IEat
         Actor.Send(container.LiquidMixture.TasteString(Actor).Fullstop().Colour(Telnet.Yellow));
 
         LiquidMixture sip = new(container.LiquidMixture, quantity);
+        this.ApplyIngestedDrugDoses(sip, container.Parent);
         FulfilNeeds(sip.GetNeedFulfiller());
 
         sip.OnDraught(Actor, container);
@@ -598,6 +601,7 @@ public partial class Body : IHaveNeeds, IEat
         Actor.Send(container.LiquidMixture.TasteString(Actor).Colour(Telnet.Yellow));
 
         LiquidMixture sip = new(container.LiquidMixture, quantity);
+        this.ApplyIngestedDrugDoses(sip, container.Parent);
         FulfilNeeds(sip.GetNeedFulfiller());
 
         sip.OnDraught(Actor, container);

--- a/MudSharpCore/Commands/Modules/CraftModule.cs
+++ b/MudSharpCore/Commands/Modules/CraftModule.cs
@@ -16,6 +16,7 @@ using MudSharp.PerceptionEngine.Outputs;
 using MudSharp.PerceptionEngine.Parsers;
 using MudSharp.Work.Butchering;
 using MudSharp.Work.Crafts;
+using MudSharp.Work.Crafts.Products;
 using MudSharp.Work.Projects;
 using MudSharp.Work.Projects.ConcreteTypes;
 using System;
@@ -475,6 +476,192 @@ The full list of filters for craft list is below:
     protected static void Materials(ICharacter actor, string input)
     {
         CraftPreview(actor, new StringStack(input.RemoveFirstWord()));
+    }
+
+    private const string CookHelp = @"The cook command is a cooking-focused facade over crafts that produce prepared food.
+
+You can use the following syntax:
+
+	#3cook list [filters]#0 - lists cooking recipes you know
+	#3cook <recipe>#0 - begins cooking the specified recipe
+	#3cook begin <recipe>#0 - begins cooking the specified recipe
+	#3cook resume <targetitem>#0 - resumes an in-progress cooking craft
+	#3cook view <recipe>#0 - shows information about a recipe
+	#3cook preview <recipe>#0 - shows tools and materials consumed by a recipe";
+
+    [PlayerCommand("Cook", "cook")]
+    [HelpInfo("cook", CookHelp, AutoHelp.HelpArgOrNoArg)]
+    protected static void Cook(ICharacter actor, string input)
+    {
+        StringStack ss = new(input.RemoveFirstWord());
+        var command = ss.PopSpeech().ToLowerInvariant();
+        switch (command)
+        {
+            case "":
+            case "list":
+            case "recipes":
+                CookList(actor, ss);
+                return;
+            case "begin":
+            case "start":
+                CookBegin(actor, ss);
+                return;
+            case "resume":
+            case "restart":
+                CraftResume(actor, ss);
+                return;
+            case "view":
+            case "show":
+                CookShow(actor, ss);
+                return;
+            case "preview":
+            case "materials":
+                CookPreview(actor, ss);
+                return;
+            default:
+                ss = new StringStack(command + " " + ss.SafeRemainingArgument);
+                CookBegin(actor, ss);
+                return;
+        }
+    }
+
+    private static List<ICraft> VisibleCookingCrafts(ICharacter actor)
+    {
+        return (actor.IsAdministrator()
+                   ? actor.Gameworld.Crafts
+                   : actor.Gameworld.Crafts.Where(x => x.AppearInCraftsList(actor)))
+               .Where(x => x.Status == RevisionStatus.Current)
+               .Where(IsCookingCraft)
+               .ToList();
+    }
+
+    private static bool IsCookingCraft(ICraft craft)
+    {
+        return craft.Products.Concat(craft.FailProducts)
+                    .Any(x => x is CookedFoodProduct || x.ProductType.EqualTo("CookedFoodProduct"));
+    }
+
+    private static void CookList(ICharacter actor, StringStack ss)
+    {
+        var crafts = VisibleCookingCrafts(actor);
+        var parameters = false;
+        while (!ss.IsFinished)
+        {
+            parameters = true;
+            var arg = ss.PopSpeech();
+            if (arg[0] == '+')
+            {
+                crafts = crafts
+                         .Where(x => x.Name.Contains(arg[1..], StringComparison.InvariantCultureIgnoreCase))
+                         .ToList();
+                continue;
+            }
+
+            if (arg[0] == '-')
+            {
+                crafts = crafts.Where(x =>
+                    !x.Name.Contains(arg[1..], StringComparison.InvariantCultureIgnoreCase)).ToList();
+                continue;
+            }
+
+            crafts = crafts.Where(x => x.Category.StartsWith(arg, StringComparison.InvariantCultureIgnoreCase))
+                           .ToList();
+        }
+
+        if (!crafts.Any())
+        {
+            actor.Send($"You do not know any cooking recipes{(parameters ? " with those parameters" : "")}.");
+            return;
+        }
+
+        actor.Send(StringUtilities.GetTextTable(
+            crafts.OrderBy(x => x.Category).ThenBy(x => x.Name).Select(x => new[]
+            {
+                x.Name,
+                x.Blurb,
+                x.Category,
+                x.CheckTrait is ISkillDefinition sd
+                    ? sd.Improver.CanImprove(actor, actor.GetTrait(x.CheckTrait), x.CheckDifficulty,
+                        TraitUseType.Practical, true).ToColouredString()
+                    : "N/A"
+            }),
+            new[] { "Recipe", "Blurb", "Category", "Can Skill Up?" },
+            actor.LineFormatLength, colour: Telnet.Green, truncatableColumnIndex: 1,
+            unicodeTable: actor.Account.UseUnicode));
+    }
+
+    private static void CookBegin(ICharacter actor, StringStack ss)
+    {
+        if (ss.IsFinished)
+        {
+            actor.Send("Which recipe do you want to cook? See COOK LIST for a list of cooking recipes that you can do.");
+            return;
+        }
+
+        if (!actor.State.IsAble())
+        {
+            actor.OutputHandler.Send($"You cannot cook while you are {actor.State.DescribeEnum(true, Telnet.Red)}.");
+            return;
+        }
+
+        if (actor.Effects.Any(x => x.IsBlockingEffect("general")))
+        {
+            actor.OutputHandler.Send(
+                $"You must first stop {actor.Effects.Where(x => x.IsBlockingEffect("general")).Select(x => x.BlockingDescription("general", actor)).ListToString()}");
+            return;
+        }
+
+        var craft = VisibleCookingCrafts(actor).GetByNameOrAbbreviation(ss.SafeRemainingArgument.Trim());
+        if (craft is null)
+        {
+            actor.Send("You don't know any such cooking recipe. See COOK LIST for a list of cooking recipes that you can do.");
+            return;
+        }
+
+        var (success, error) = craft.CanDoCraft(actor, null, true, false);
+        if (!success)
+        {
+            actor.Send(error);
+            return;
+        }
+
+        craft.BeginCraft(actor);
+    }
+
+    private static void CookShow(ICharacter actor, StringStack ss)
+    {
+        if (ss.IsFinished)
+        {
+            actor.Send("Which recipe do you want to show? See COOK LIST for a list of recipes that you can do.");
+            return;
+        }
+
+        var craft = VisibleCookingCrafts(actor).GetByIdOrName(ss.SafeRemainingArgument.Trim());
+        if (craft is null)
+        {
+            actor.Send("You don't know any such cooking recipe. See COOK LIST for a list of recipes that you can do.");
+            return;
+        }
+
+        actor.OutputHandler.Send(craft.DisplayCraft(actor));
+    }
+
+    private static void CookPreview(ICharacter actor, StringStack ss)
+    {
+        if (ss.IsFinished)
+        {
+            actor.Send("Which recipe do you want to preview? See COOK LIST for a list of recipes that you can do.");
+            return;
+        }
+
+        var craft = VisibleCookingCrafts(actor).GetByNameOrAbbreviation(ss.SafeRemainingArgument);
+        if (craft is null)
+        {
+            actor.Send("You don't know any such cooking recipe. See COOK LIST for a list of recipes that you can do.");
+            return;
+        }
+
+        actor.OutputHandler.Send(craft.GetMaterialPreview(actor));
     }
 
     [PlayerCommand("Projects", "projects")]

--- a/MudSharpCore/Effects/Concrete/LiquidContamination.cs
+++ b/MudSharpCore/Effects/Concrete/LiquidContamination.cs
@@ -5,6 +5,7 @@ using MudSharp.Framework;
 using MudSharp.FutureProg;
 using MudSharp.GameItems;
 using MudSharp.GameItems.Components;
+using MudSharp.GameItems.Interfaces;
 using MudSharp.GameItems.Prototypes;
 using MudSharp.Health;
 using MudSharp.PerceptionEngine;
@@ -19,7 +20,7 @@ using System.Xml.Linq;
 namespace MudSharp.Effects.Concrete;
 
 public class LiquidContamination : Effect, ILiquidContaminationEffect, IDescriptionAdditionEffect, IEffectAddsWeight,
-    ISDescAdditionEffect
+    ISDescAdditionEffect, IIngredientTransferEffect
 {
     private static TimeSpan BaseEffectDuration =>
         TimeSpan.FromSeconds(Futuremud.Games.First().GetStaticDouble("LiquidContaminationEffectDuration"));
@@ -586,6 +587,20 @@ public class LiquidContamination : Effect, ILiquidContaminationEffect, IDescript
     #region Implementation of IEffectAddsWeight
 
     public double AddedWeight => ContaminatingLiquid?.TotalWeight ?? 0.0;
+
+    #endregion
+
+    #region Implementation of IIngredientTransferEffect
+
+    public void TransferToFood(IPreparedFood food, double proportion)
+    {
+        if (ContaminatingLiquid is null || ContaminatingLiquid.IsEmpty || proportion <= 0.0)
+        {
+            return;
+        }
+
+        food.AbsorbLiquid(ContaminatingLiquid.Clone(ContaminatingLiquid.TotalVolume * proportion), "transferred liquid contamination");
+    }
 
     #endregion
 }

--- a/MudSharpCore/Effects/Concrete/ResidueContamination.cs
+++ b/MudSharpCore/Effects/Concrete/ResidueContamination.cs
@@ -4,6 +4,7 @@ using MudSharp.Framework;
 using MudSharp.FutureProg;
 using MudSharp.GameItems;
 using MudSharp.GameItems.Decorators;
+using MudSharp.GameItems.Interfaces;
 using System;
 using System.Linq;
 using System.Xml.Linq;
@@ -11,7 +12,7 @@ using System.Xml.Linq;
 namespace MudSharp.Effects.Concrete;
 
 public class ResidueContamination : Effect, ICleanableEffect, ISDescAdditionEffect, IDescriptionAdditionEffect,
-    IEffectAddsWeight
+    IEffectAddsWeight, IIngredientTransferEffect
 {
     private static IStackDecorator _stackDecorator;
     private double _weight;
@@ -172,6 +173,28 @@ public class ResidueContamination : Effect, ICleanableEffect, ISDescAdditionEffe
     #region Implementation of IEffectAddsWeight
 
     public double AddedWeight => Weight;
+
+    #endregion
+
+    #region Implementation of IIngredientTransferEffect
+
+    public void TransferToFood(IPreparedFood food, double proportion)
+    {
+        if (Material is null || Weight <= 0.0 || proportion <= 0.0)
+        {
+            return;
+        }
+
+        food.AddIngredient(new FoodIngredientInstance
+        {
+            Role = "residue",
+            Description = Material.MaterialDescription,
+            TasteText = Material.MaterialDescription,
+            MaterialId = Material.Id,
+            Weight = Weight * proportion,
+            Quality = ItemQuality.Standard
+        });
+    }
 
     #endregion
 }

--- a/MudSharpCore/GameItems/Components/PreparedFoodGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/PreparedFoodGameItemComponent.cs
@@ -1,0 +1,525 @@
+using MudSharp.Body;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Form.Material;
+using MudSharp.Form.Shape;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.GameItems.Decorators;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.GameItems.Prototypes;
+using MudSharp.Health;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+#nullable enable
+
+namespace MudSharp.GameItems.Components;
+
+public class PreparedFoodGameItemComponent : GameItemComponent, IPreparedFood
+{
+	private PreparedFoodGameItemComponentProto _prototype;
+	private FoodServingScope _servingScope;
+	private double _satiationPoints;
+	private double _waterLitres;
+	private double _thirstPoints;
+	private double _alcoholLitres;
+	private double _totalBites;
+	private double _bitesRemaining;
+	private double _qualityNutritionMultiplierPerStep;
+	private double _staleNutritionMultiplier;
+	private double _spoiledNutritionMultiplier;
+	private double _liquidAbsorptionLitres;
+	private TimeSpan? _staleAfter;
+	private TimeSpan? _spoilAfter;
+	private string _tasteTemplate = string.Empty;
+	private string _shortDescriptionTemplate = string.Empty;
+	private string _fullDescriptionTemplate = string.Empty;
+	private IStackDecorator? _decorator;
+	private IFutureProg? _onEatProg;
+	private IFutureProg? _onStaleProg;
+	private readonly List<FoodIngredientInstance> _ingredients = new();
+	private readonly List<FoodDrugDose> _drugDoses = new();
+	private readonly List<FoodDrugDose> _staleDrugDoses = new();
+
+	public override IGameItemComponentProto Prototype => _prototype;
+
+	public FoodServingScope ServingScope => _servingScope;
+
+	public DateTime CreatedAt { get; set; }
+
+	public FoodFreshness Freshness
+	{
+		get
+		{
+			var now = DateTime.UtcNow;
+			if (_spoilAfter is not null && CreatedAt + _spoilAfter.Value <= now)
+			{
+				return FoodFreshness.Spoiled;
+			}
+
+			if (_staleAfter is not null && CreatedAt + _staleAfter.Value <= now)
+			{
+				return FoodFreshness.Stale;
+			}
+
+			return FoodFreshness.Fresh;
+		}
+	}
+
+	public IEnumerable<FoodIngredientInstance> Ingredients => _ingredients;
+	public IEnumerable<FoodDrugDose> DrugDoses => _drugDoses;
+
+	public double SatiationPoints => _satiationPoints * QualityMultiplier * FreshnessNutritionMultiplier;
+	public double WaterLitres => _waterLitres * QualityMultiplier * FreshnessNutritionMultiplier;
+	public double ThirstPoints => _thirstPoints * QualityMultiplier * FreshnessNutritionMultiplier;
+	public double AlcoholLitres => _alcoholLitres;
+	public string TasteString => RenderTemplate(_tasteTemplate);
+	public double TotalBites => Math.Max(1.0, _totalBites);
+
+	public double BitesRemaining
+	{
+		get => Math.Min(_bitesRemaining, TotalBites);
+		set
+		{
+			_bitesRemaining = Math.Max(0.0, Math.Min(value, TotalBites));
+			if (_bitesRemaining > 0.0)
+			{
+				Changed = true;
+				HandleDescriptionUpdate();
+				return;
+			}
+
+			CompleteCurrentServing();
+		}
+	}
+
+	private double QualityMultiplier
+	{
+		get
+		{
+			var multiplier = 1.0 + ((int)Parent.Quality - (int)ItemQuality.Standard) * _qualityNutritionMultiplierPerStep;
+			return Math.Max(0.0, multiplier);
+		}
+	}
+
+	private double FreshnessNutritionMultiplier
+	{
+		get
+		{
+			return Freshness switch
+			{
+				FoodFreshness.Stale => Math.Max(0.0, _staleNutritionMultiplier),
+				FoodFreshness.Spoiled => Math.Max(0.0, _spoiledNutritionMultiplier),
+				_ => 1.0
+			};
+		}
+	}
+
+	private static string DoubleString(double value)
+	{
+		return value.ToString("R", CultureInfo.InvariantCulture);
+	}
+
+	private static double LoadDouble(XElement root, string attribute, double defaultValue)
+	{
+		return double.Parse(root.Attribute(attribute)?.Value ?? DoubleString(defaultValue), CultureInfo.InvariantCulture);
+	}
+
+	private static TimeSpan? LoadTimeSpanSeconds(XElement root, string attribute)
+	{
+		var text = root.Attribute(attribute)?.Value;
+		if (string.IsNullOrWhiteSpace(text))
+		{
+			return null;
+		}
+
+		var seconds = double.Parse(text, CultureInfo.InvariantCulture);
+		return seconds <= 0.0 ? null : TimeSpan.FromSeconds(seconds);
+	}
+
+	private void ApplyProfileInternal(PreparedFoodProfile profile, bool replaceIngredientsAndDoses)
+	{
+		_servingScope = profile.ServingScope;
+		_satiationPoints = profile.SatiationPoints;
+		_waterLitres = profile.WaterLitres;
+		_thirstPoints = profile.ThirstPoints;
+		_alcoholLitres = profile.AlcoholLitres;
+		_totalBites = Math.Max(1.0, profile.Bites);
+		_qualityNutritionMultiplierPerStep = profile.QualityNutritionMultiplierPerStep;
+		_staleNutritionMultiplier = profile.StaleNutritionMultiplier;
+		_spoiledNutritionMultiplier = profile.SpoiledNutritionMultiplier;
+		_liquidAbsorptionLitres = profile.LiquidAbsorptionLitres;
+		_staleAfter = profile.StaleAfter;
+		_spoilAfter = profile.SpoilAfter;
+		_tasteTemplate = profile.TasteTemplate;
+		_shortDescriptionTemplate = profile.ShortDescriptionTemplate;
+		_fullDescriptionTemplate = profile.FullDescriptionTemplate;
+		_decorator = profile.Decorator;
+		_onEatProg = profile.OnEatProg;
+		_onStaleProg = profile.OnStaleProg;
+		if (!replaceIngredientsAndDoses)
+		{
+			return;
+		}
+
+		_ingredients.Clear();
+		_ingredients.AddRange(profile.Ingredients.Select(x => x.Clone()));
+		_drugDoses.Clear();
+		_drugDoses.AddRange(profile.DrugDoses.Select(x => x.Clone()));
+		_staleDrugDoses.Clear();
+		_staleDrugDoses.AddRange(profile.StaleDrugDoses.Select(x => x.Clone()));
+	}
+
+	public void ApplyPreparedFoodProfile(PreparedFoodProfile profile, bool replaceIngredientsAndDoses = true)
+	{
+		ApplyProfileInternal(profile, replaceIngredientsAndDoses);
+		_bitesRemaining = Math.Min(Math.Max(_bitesRemaining <= 0.0 ? _totalBites : _bitesRemaining, 0.0), TotalBites);
+		Changed = true;
+		HandleDescriptionUpdate();
+	}
+
+	public void AddIngredient(FoodIngredientInstance ingredient)
+	{
+		_ingredients.Add(ingredient.Clone());
+		Changed = true;
+		HandleDescriptionUpdate();
+	}
+
+	public void AddDrugDose(FoodDrugDose dose)
+	{
+		if (dose.Drug is null || dose.Grams <= 0.0)
+		{
+			return;
+		}
+
+		_drugDoses.Add(dose.Clone());
+		Changed = true;
+	}
+
+	public void AddStaleDrugDose(FoodDrugDose dose)
+	{
+		if (dose.Drug is null || dose.Grams <= 0.0)
+		{
+			return;
+		}
+
+		_staleDrugDoses.Add(dose.Clone());
+		Changed = true;
+	}
+
+	public void AbsorbLiquid(LiquidMixture mixture, string source, bool includeDrugDoses = true)
+	{
+		foreach (var instance in mixture.Instances)
+		{
+			_ingredients.Add(new FoodIngredientInstance
+			{
+				Role = source,
+				Description = instance.Liquid.MaterialDescription,
+				TasteText = instance.Liquid.TasteText,
+				LiquidId = instance.Liquid.Id,
+				Volume = instance.Amount,
+				Quality = ItemQuality.Standard
+			});
+
+			if (!includeDrugDoses || instance.Liquid.Drug is null || !instance.Liquid.Drug.DrugVectors.HasFlag(DrugVector.Ingested))
+			{
+				continue;
+			}
+
+			var grams = instance.Amount * instance.Liquid.DrugGramsPerUnitVolume;
+			if (grams > 0.0)
+			{
+				_drugDoses.Add(new FoodDrugDose
+				{
+					Drug = instance.Liquid.Drug,
+					Grams = grams,
+					Source = source
+				});
+			}
+		}
+
+		Changed = true;
+		HandleDescriptionUpdate();
+	}
+
+	public void Eat(IBody body, double bites)
+	{
+		var proportion = Math.Max(0.0, Math.Min(bites, BitesRemaining)) / TotalBites;
+		body.ApplyIngestedDrugDoses(_drugDoses, proportion, Parent);
+		if (Freshness != FoodFreshness.Fresh)
+		{
+			body.ApplyIngestedDrugDoses(_staleDrugDoses, proportion, Parent);
+			_onStaleProg?.Execute(body.Actor, Parent, bites, Freshness.DescribeEnum());
+		}
+
+		_onEatProg?.Execute(body.Actor, Parent, bites);
+		BitesRemaining -= bites;
+	}
+
+	public override bool ExposeToLiquid(LiquidMixture mixture)
+	{
+		if (_liquidAbsorptionLitres <= 0.0 || mixture.TotalVolume <= 0.0)
+		{
+			return false;
+		}
+
+		var capacity = _liquidAbsorptionLitres / (Gameworld.UnitManager?.BaseFluidToLitres ?? 1.0);
+		var absorbedVolume = Math.Min(mixture.TotalVolume, capacity);
+		var absorbed = mixture.RemoveLiquidVolume(absorbedVolume);
+		if (absorbed is not null && !absorbed.IsEmpty)
+		{
+			AbsorbLiquid(absorbed, "liquid exposure");
+		}
+
+		return mixture.TotalVolume <= 0.0;
+	}
+
+	private void CompleteCurrentServing()
+	{
+		if (_servingScope == FoodServingScope.PerStackUnit && Parent.GetItemType<IStackable>() is { } stackable &&
+		    stackable.Quantity > 1)
+		{
+			stackable.Quantity -= 1;
+			_bitesRemaining = TotalBites;
+			Changed = true;
+			HandleDescriptionUpdate();
+			return;
+		}
+
+		Parent.Delete();
+	}
+
+	public override double ComponentWeightMultiplier
+	{
+		get
+		{
+			var biteMultiplier = BitesRemaining / TotalBites;
+			if (_servingScope != FoodServingScope.PerStackUnit || Parent.GetItemType<IStackable>() is not { } stackable ||
+			    stackable.Quantity <= 1)
+			{
+				return biteMultiplier;
+			}
+
+			return Math.Max(0.0, (stackable.Quantity - 1 + biteMultiplier) / stackable.Quantity);
+		}
+	}
+
+	public override bool PreventsMerging(IGameItemComponent component)
+	{
+		return component is PreparedFoodGameItemComponent other &&
+		       (BitesRemaining != other.BitesRemaining ||
+		        CreatedAt != other.CreatedAt ||
+		        Freshness != other.Freshness ||
+		        !_ingredients.Select(x => x.Description).SequenceEqual(other._ingredients.Select(x => x.Description)) ||
+		        !_drugDoses.Select(x => (x.Drug?.Id ?? 0, x.Grams)).SequenceEqual(other._drugDoses.Select(x => (x.Drug?.Id ?? 0, x.Grams))));
+	}
+
+	public override bool DescriptionDecorator(DescriptionType type)
+	{
+		return type is DescriptionType.Short or DescriptionType.Full;
+	}
+
+	public override int DecorationPriority => 100;
+
+	public override string Decorate(IPerceiver voyeur, string name, string description, DescriptionType type,
+		bool colour, PerceiveIgnoreFlags flags)
+	{
+		switch (type)
+		{
+			case DescriptionType.Short:
+				if (!string.IsNullOrWhiteSpace(_shortDescriptionTemplate))
+				{
+					return RenderTemplate(_shortDescriptionTemplate);
+				}
+
+				return _decorator is null ? description : _decorator.Describe(name, description, 100.0 * BitesRemaining / TotalBites);
+			case DescriptionType.Full:
+				var baseDescription = string.IsNullOrWhiteSpace(_fullDescriptionTemplate)
+					? description
+					: RenderTemplate(_fullDescriptionTemplate);
+				var freshness = Freshness == FoodFreshness.Fresh
+					? string.Empty
+					: $"\n\nIt is {Freshness.DescribeEnum().ToLowerInvariant()}.";
+				return string.Format(voyeur, "{0}\n\nIt has {1:N0} out of {2:N0} bites remaining.{3}", baseDescription,
+					BitesRemaining, TotalBites, freshness);
+		}
+
+		return description;
+	}
+
+	private string RenderTemplate(string template)
+	{
+		if (string.IsNullOrWhiteSpace(template))
+		{
+			return string.Empty;
+		}
+
+		var result = template;
+		result = ReplaceIgnoreCase(result, "{quality}", Parent.Quality.Describe());
+		result = ReplaceIgnoreCase(result, "{freshness}", Freshness.DescribeEnum().ToLowerInvariant());
+		result = ReplaceIgnoreCase(result, "{primary}", _ingredients.FirstOrDefault()?.Description ?? string.Empty);
+		result = ReplaceIgnoreCase(result, "{ingredients}", _ingredients.Select(x => x.Description).Where(x => !string.IsNullOrWhiteSpace(x)).Distinct().ListToString());
+		result = ReplaceIgnoreCase(result, "{additives}", _ingredients.Where(x => x.Role.EqualTo("additive")).Select(x => x.Description).Where(x => !string.IsNullOrWhiteSpace(x)).Distinct().ListToString());
+		result = ReplaceIgnoreCase(result, "{bites}", BitesRemaining.ToString("N0", CultureInfo.InvariantCulture));
+		result = ReplaceIgnoreCase(result, "{servings}", Parent.Quantity.ToString("N0", CultureInfo.InvariantCulture));
+
+		result = Regex.Replace(result, @"\{ingredient:([^}]+)\}", match =>
+		{
+			var role = match.Groups[1].Value;
+			return _ingredients.Where(x => x.Role.EqualTo(role))
+			                   .Select(x => x.Description)
+			                   .Where(x => !string.IsNullOrWhiteSpace(x))
+			                   .Distinct()
+			                   .ListToString();
+		}, RegexOptions.IgnoreCase);
+
+		result = Regex.Replace(result, @"\{var:([^}]+)\}", match =>
+		{
+			var name = match.Groups[1].Value;
+			var variable = Parent.GetItemType<IVariable>();
+			var definition = variable?.CharacteristicDefinitions.FirstOrDefault(x => x.Name.EqualTo(name));
+			return definition is null ? string.Empty : variable!.GetCharacteristic(definition)?.GetValue ?? string.Empty;
+		}, RegexOptions.IgnoreCase);
+
+		return result;
+	}
+
+	private static string ReplaceIgnoreCase(string text, string oldValue, string newValue)
+	{
+		return Regex.Replace(text, Regex.Escape(oldValue), newValue.Replace("$", "$$"), RegexOptions.IgnoreCase);
+	}
+
+	protected override void UpdateComponentNewPrototype(IGameItemComponentProto newProto)
+	{
+		_prototype = (PreparedFoodGameItemComponentProto)newProto;
+	}
+
+	public override IGameItemComponent Copy(IGameItem newParent, bool temporary = false)
+	{
+		return new PreparedFoodGameItemComponent(this, newParent, temporary);
+	}
+
+	public PreparedFoodGameItemComponent(PreparedFoodGameItemComponent rhs, IGameItem newParent, bool temporary = false)
+		: base(rhs, newParent, temporary)
+	{
+		_prototype = rhs._prototype;
+		CreatedAt = rhs.CreatedAt;
+		_servingScope = rhs._servingScope;
+		_satiationPoints = rhs._satiationPoints;
+		_waterLitres = rhs._waterLitres;
+		_thirstPoints = rhs._thirstPoints;
+		_alcoholLitres = rhs._alcoholLitres;
+		_totalBites = rhs._totalBites;
+		_bitesRemaining = rhs._bitesRemaining;
+		_qualityNutritionMultiplierPerStep = rhs._qualityNutritionMultiplierPerStep;
+		_staleNutritionMultiplier = rhs._staleNutritionMultiplier;
+		_spoiledNutritionMultiplier = rhs._spoiledNutritionMultiplier;
+		_liquidAbsorptionLitres = rhs._liquidAbsorptionLitres;
+		_staleAfter = rhs._staleAfter;
+		_spoilAfter = rhs._spoilAfter;
+		_tasteTemplate = rhs._tasteTemplate;
+		_shortDescriptionTemplate = rhs._shortDescriptionTemplate;
+		_fullDescriptionTemplate = rhs._fullDescriptionTemplate;
+		_decorator = rhs._decorator;
+		_onEatProg = rhs._onEatProg;
+		_onStaleProg = rhs._onStaleProg;
+		_ingredients.AddRange(rhs._ingredients.Select(x => x.Clone()));
+		_drugDoses.AddRange(rhs._drugDoses.Select(x => x.Clone()));
+		_staleDrugDoses.AddRange(rhs._staleDrugDoses.Select(x => x.Clone()));
+	}
+
+	public PreparedFoodGameItemComponent(PreparedFoodGameItemComponentProto proto, IGameItem parent, bool temporary = false)
+		: base(parent, proto, temporary)
+	{
+		_prototype = proto;
+		CreatedAt = DateTime.UtcNow;
+		ApplyProfileInternal(proto.Profile, true);
+		_bitesRemaining = TotalBites;
+	}
+
+	public PreparedFoodGameItemComponent(MudSharp.Models.GameItemComponent component, PreparedFoodGameItemComponentProto proto,
+		IGameItem parent) : base(component, parent)
+	{
+		_prototype = proto;
+		_noSave = true;
+		ApplyProfileInternal(proto.Profile, true);
+		LoadFromXml(XElement.Parse(component.Definition));
+		_noSave = false;
+	}
+
+	private void LoadFromXml(XElement root)
+	{
+		CreatedAt = DateTime.Parse(root.Attribute("created")?.Value ?? DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture),
+			CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+		_servingScope = Enum.Parse<FoodServingScope>(root.Attribute("scope")?.Value ?? _servingScope.ToString());
+		_satiationPoints = LoadDouble(root, "satiation", _satiationPoints);
+		_waterLitres = LoadDouble(root, "water", _waterLitres);
+		_thirstPoints = LoadDouble(root, "thirst", _thirstPoints);
+		_alcoholLitres = LoadDouble(root, "alcohol", _alcoholLitres);
+		_totalBites = Math.Max(1.0, LoadDouble(root, "totalBites", _totalBites));
+		_bitesRemaining = Math.Min(_totalBites, LoadDouble(root, "bitesRemaining", _totalBites));
+		_qualityNutritionMultiplierPerStep = LoadDouble(root, "qualityScale", _qualityNutritionMultiplierPerStep);
+		_staleNutritionMultiplier = LoadDouble(root, "staleMultiplier", _staleNutritionMultiplier);
+		_spoiledNutritionMultiplier = LoadDouble(root, "spoiledMultiplier", _spoiledNutritionMultiplier);
+		_liquidAbsorptionLitres = LoadDouble(root, "absorbLitres", _liquidAbsorptionLitres);
+		_staleAfter = LoadTimeSpanSeconds(root, "staleSeconds") ?? _staleAfter;
+		_spoilAfter = LoadTimeSpanSeconds(root, "spoilSeconds") ?? _spoilAfter;
+		_tasteTemplate = root.Element("Taste")?.Value ?? _tasteTemplate;
+		_shortDescriptionTemplate = root.Element("Short")?.Value ?? _shortDescriptionTemplate;
+		_fullDescriptionTemplate = root.Element("Full")?.Value ?? _fullDescriptionTemplate;
+		_decorator = Gameworld.StackDecorators.Get(long.Parse(root.Attribute("decorator")?.Value ?? (_decorator?.Id ?? 0).ToString()));
+		_onEatProg = Gameworld.FutureProgs.Get(long.Parse(root.Element("OnEatProg")?.Value ?? (_onEatProg?.Id ?? 0).ToString()));
+		_onStaleProg = Gameworld.FutureProgs.Get(long.Parse(root.Element("OnStaleProg")?.Value ?? (_onStaleProg?.Id ?? 0).ToString()));
+
+		if (root.Element("Ingredients") is { } ingredients)
+		{
+			_ingredients.Clear();
+			_ingredients.AddRange(ingredients.Elements("Ingredient").Select(FoodIngredientInstance.LoadFromXml));
+		}
+
+		if (root.Element("DrugDoses") is { } doses)
+		{
+			_drugDoses.Clear();
+			_drugDoses.AddRange(doses.Elements("Dose").Select(x => FoodDrugDose.LoadFromXml(x, Gameworld)));
+		}
+
+		if (root.Element("StaleDrugDoses") is { } staleDoses)
+		{
+			_staleDrugDoses.Clear();
+			_staleDrugDoses.AddRange(staleDoses.Elements("Dose").Select(x => FoodDrugDose.LoadFromXml(x, Gameworld)));
+		}
+	}
+
+	protected override string SaveToXml()
+	{
+		return new XElement("Definition",
+			new XAttribute("created", CreatedAt.ToString("o", CultureInfo.InvariantCulture)),
+			new XAttribute("scope", _servingScope),
+			new XAttribute("satiation", DoubleString(_satiationPoints)),
+			new XAttribute("water", DoubleString(_waterLitres)),
+			new XAttribute("thirst", DoubleString(_thirstPoints)),
+			new XAttribute("alcohol", DoubleString(_alcoholLitres)),
+			new XAttribute("totalBites", DoubleString(_totalBites)),
+			new XAttribute("bitesRemaining", DoubleString(_bitesRemaining)),
+			new XAttribute("qualityScale", DoubleString(_qualityNutritionMultiplierPerStep)),
+			new XAttribute("staleMultiplier", DoubleString(_staleNutritionMultiplier)),
+			new XAttribute("spoiledMultiplier", DoubleString(_spoiledNutritionMultiplier)),
+			new XAttribute("absorbLitres", DoubleString(_liquidAbsorptionLitres)),
+			new XAttribute("staleSeconds", DoubleString(_staleAfter?.TotalSeconds ?? 0.0)),
+			new XAttribute("spoilSeconds", DoubleString(_spoilAfter?.TotalSeconds ?? 0.0)),
+			new XAttribute("decorator", _decorator?.Id ?? 0),
+			new XElement("Taste", new XCData(_tasteTemplate)),
+			new XElement("Short", new XCData(_shortDescriptionTemplate)),
+			new XElement("Full", new XCData(_fullDescriptionTemplate)),
+			new XElement("OnEatProg", _onEatProg?.Id ?? 0),
+			new XElement("OnStaleProg", _onStaleProg?.Id ?? 0),
+			new XElement("Ingredients", _ingredients.Select(x => x.SaveToXml())),
+			new XElement("DrugDoses", _drugDoses.Select(x => x.SaveToXml())),
+			new XElement("StaleDrugDoses", _staleDrugDoses.Select(x => x.SaveToXml()))
+		).ToString();
+	}
+}

--- a/MudSharpCore/GameItems/Prototypes/PreparedFoodGameItemComponentProto.cs
+++ b/MudSharpCore/GameItems/Prototypes/PreparedFoodGameItemComponentProto.cs
@@ -1,0 +1,709 @@
+using MudSharp.Accounts;
+using MudSharp.Character;
+using MudSharp.Database;
+using MudSharp.Framework;
+using MudSharp.Framework.Revision;
+using MudSharp.Framework.Units;
+using MudSharp.FutureProg;
+using MudSharp.GameItems.Components;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.Health;
+using MudSharp.PerceptionEngine;
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+#nullable enable
+
+namespace MudSharp.GameItems.Prototypes;
+
+public class PreparedFoodGameItemComponentProto : GameItemComponentProto
+{
+	public PreparedFoodProfile Profile { get; private set; } = new();
+
+	public override string TypeDescription => "PreparedFood";
+
+	public override IEditableRevisableItem CreateNewRevision(ICharacter initiator)
+	{
+		return CreateNewRevision(initiator, (proto, gameworld) => new PreparedFoodGameItemComponentProto(proto, gameworld));
+	}
+
+	public static void RegisterComponentInitialiser(GameItemComponentManager manager)
+	{
+		manager.AddBuilderLoader("preparedfood", true,
+			(gameworld, account) => new PreparedFoodGameItemComponentProto(gameworld, account));
+		manager.AddBuilderLoader("prepared food", false,
+			(gameworld, account) => new PreparedFoodGameItemComponentProto(gameworld, account));
+		manager.AddDatabaseLoader("PreparedFood", (proto, gameworld) => new PreparedFoodGameItemComponentProto(proto, gameworld));
+		manager.AddTypeHelpInfo(
+			"PreparedFood",
+			"Turns an item into new-style prepared food with freshness, ingredient ledgers and drug doses",
+			BuildingHelpText
+		);
+	}
+
+	public override bool CanSubmit()
+	{
+		return Profile.Bites > 0.0;
+	}
+
+	public override string ComponentDescriptionOLC(ICharacter actor)
+	{
+		var sb = new StringBuilder();
+		sb.AppendLine($"{ "Prepared Food Item Component".Colour(Telnet.Cyan)} (#{Id.ToString("N0", actor)}r{RevisionNumber.ToString("N0", actor)}, {Name})");
+		sb.AppendLine();
+		sb.AppendLine($"Scope: {Profile.ServingScope.DescribeEnum().ColourName()}");
+		sb.AppendLine($"Nutrition: {Profile.SatiationPoints.ToString("N1", actor).ColourValue()} hunger hours, {Profile.ThirstPoints.ToString("N1", actor).ColourValue()} thirst hours, {actor.Gameworld.UnitManager.Describe(Profile.WaterLitres / actor.Gameworld.UnitManager.BaseFluidToLitres, UnitType.FluidVolume, actor).ColourValue()} water, {actor.Gameworld.UnitManager.Describe(Profile.AlcoholLitres / actor.Gameworld.UnitManager.BaseFluidToLitres, UnitType.FluidVolume, actor).ColourValue()} alcohol");
+		sb.AppendLine($"Bites per serving: {Profile.Bites.ToString("N2", actor).ColourValue()}");
+		sb.AppendLine($"Quality nutrition scaling: {(Profile.QualityNutritionMultiplierPerStep * 100.0).ToString("N1", actor).ColourValue()}% per quality step");
+		sb.AppendLine($"Freshness: stale after {DescribeTime(Profile.StaleAfter, actor).ColourValue()}, spoiled after {DescribeTime(Profile.SpoilAfter, actor).ColourValue()}");
+		sb.AppendLine($"Stale nutrition: {(Profile.StaleNutritionMultiplier * 100.0).ToString("N1", actor).ColourValue()}%, spoiled nutrition: {(Profile.SpoiledNutritionMultiplier * 100.0).ToString("N1", actor).ColourValue()}%");
+		sb.AppendLine($"Liquid absorption: {actor.Gameworld.UnitManager.Describe(Profile.LiquidAbsorptionLitres / actor.Gameworld.UnitManager.BaseFluidToLitres, UnitType.FluidVolume, actor).ColourValue()}");
+		sb.AppendLine($"Decorator: {(Profile.Decorator is null ? "none".ColourError() : Profile.Decorator.Name.ColourName())}");
+		sb.AppendLine($"Taste template: {Profile.TasteTemplate.ColourCommand()}");
+		sb.AppendLine($"Short template: {(string.IsNullOrWhiteSpace(Profile.ShortDescriptionTemplate) ? "none".ColourError() : Profile.ShortDescriptionTemplate.ColourCommand())}");
+		sb.AppendLine($"Full template: {(string.IsNullOrWhiteSpace(Profile.FullDescriptionTemplate) ? "none".ColourError() : Profile.FullDescriptionTemplate.ColourCommand())}");
+		sb.AppendLine($"On-eat prog: {(Profile.OnEatProg is null ? "none".ColourError() : $"#{Profile.OnEatProg.Id.ToString("N0", actor)} ({Profile.OnEatProg.Name})".ColourName())}");
+		sb.AppendLine($"On-stale prog: {(Profile.OnStaleProg is null ? "none".ColourError() : $"#{Profile.OnStaleProg.Id.ToString("N0", actor)} ({Profile.OnStaleProg.Name})".ColourName())}");
+		sb.AppendLine();
+		sb.AppendLine($"Default ingredients: {(Profile.Ingredients.Any() ? Profile.Ingredients.Select(x => $"{x.Role}: {x.Description}").ListToString() : "none")}");
+		sb.AppendLine($"Default drug doses: {(Profile.DrugDoses.Any() ? Profile.DrugDoses.Select(x => $"{x.Drug?.Name ?? "unknown"} {x.Grams.ToString("N4", actor)}g").ListToString() : "none")}");
+		sb.AppendLine($"Stale drug doses: {(Profile.StaleDrugDoses.Any() ? Profile.StaleDrugDoses.Select(x => $"{x.Drug?.Name ?? "unknown"} {x.Grams.ToString("N4", actor)}g").ListToString() : "none")}");
+		return sb.ToString();
+	}
+
+	private static string DescribeTime(TimeSpan? span, IPerceiver voyeur)
+	{
+		return span is null ? "never" : span.Value.Describe(voyeur);
+	}
+
+	protected override void LoadFromXml(XElement root)
+	{
+		var profile = new PreparedFoodProfile
+		{
+			ServingScope = Enum.Parse<FoodServingScope>(root.Attribute("ServingScope")?.Value ?? FoodServingScope.WholeItem.ToString()),
+			SatiationPoints = LoadDouble(root, "Satiation", 6.0),
+			WaterLitres = LoadDouble(root, "Water", 0.05),
+			ThirstPoints = LoadDouble(root, "Thirst", 0.0),
+			AlcoholLitres = LoadDouble(root, "Alcohol", 0.0),
+			Bites = Math.Max(1.0, LoadDouble(root, "Bites", 1.0)),
+			QualityNutritionMultiplierPerStep = LoadDouble(root, "QualityScale", 0.08),
+			StaleNutritionMultiplier = LoadDouble(root, "StaleMultiplier", 0.25),
+			SpoiledNutritionMultiplier = LoadDouble(root, "SpoiledMultiplier", 0.0),
+			LiquidAbsorptionLitres = LoadDouble(root, "LiquidAbsorption", 0.02),
+			StaleAfter = LoadTime(root, "StaleAfterSeconds"),
+			SpoilAfter = LoadTime(root, "SpoilAfterSeconds"),
+			TasteTemplate = root.Element("Taste")?.Value ?? "It has an unremarkable taste",
+			ShortDescriptionTemplate = root.Element("Short")?.Value ?? string.Empty,
+			FullDescriptionTemplate = root.Element("Full")?.Value ?? string.Empty,
+			Decorator = Gameworld.StackDecorators.Get(long.Parse(root.Attribute("Decorator")?.Value ?? "0")),
+			OnEatProg = Gameworld.FutureProgs.Get(long.Parse(root.Element("OnEatProg")?.Value ?? "0")),
+			OnStaleProg = Gameworld.FutureProgs.Get(long.Parse(root.Element("OnStaleProg")?.Value ?? "0"))
+		};
+		if (root.Element("Ingredients") is { } ingredients)
+		{
+			profile.Ingredients.AddRange(ingredients.Elements("Ingredient").Select(FoodIngredientInstance.LoadFromXml));
+		}
+
+		if (root.Element("DrugDoses") is { } doses)
+		{
+			profile.DrugDoses.AddRange(doses.Elements("Dose").Select(x => FoodDrugDose.LoadFromXml(x, Gameworld)));
+		}
+
+		if (root.Element("StaleDrugDoses") is { } staleDoses)
+		{
+			profile.StaleDrugDoses.AddRange(staleDoses.Elements("Dose").Select(x => FoodDrugDose.LoadFromXml(x, Gameworld)));
+		}
+
+		Profile = profile;
+	}
+
+	private static double LoadDouble(XElement root, string attribute, double defaultValue)
+	{
+		return double.Parse(root.Attribute(attribute)?.Value ?? defaultValue.ToString("R", CultureInfo.InvariantCulture), CultureInfo.InvariantCulture);
+	}
+
+	private static TimeSpan? LoadTime(XElement root, string attribute)
+	{
+		var text = root.Attribute(attribute)?.Value;
+		if (string.IsNullOrWhiteSpace(text))
+		{
+			return null;
+		}
+
+		var seconds = double.Parse(text, CultureInfo.InvariantCulture);
+		return seconds <= 0.0 ? null : TimeSpan.FromSeconds(seconds);
+	}
+
+	protected override string SaveToXml()
+	{
+		return new XElement("Definition",
+			new XAttribute("ServingScope", Profile.ServingScope),
+			new XAttribute("Satiation", Profile.SatiationPoints.ToString("R", CultureInfo.InvariantCulture)),
+			new XAttribute("Water", Profile.WaterLitres.ToString("R", CultureInfo.InvariantCulture)),
+			new XAttribute("Thirst", Profile.ThirstPoints.ToString("R", CultureInfo.InvariantCulture)),
+			new XAttribute("Alcohol", Profile.AlcoholLitres.ToString("R", CultureInfo.InvariantCulture)),
+			new XAttribute("Bites", Profile.Bites.ToString("R", CultureInfo.InvariantCulture)),
+			new XAttribute("QualityScale", Profile.QualityNutritionMultiplierPerStep.ToString("R", CultureInfo.InvariantCulture)),
+			new XAttribute("StaleMultiplier", Profile.StaleNutritionMultiplier.ToString("R", CultureInfo.InvariantCulture)),
+			new XAttribute("SpoiledMultiplier", Profile.SpoiledNutritionMultiplier.ToString("R", CultureInfo.InvariantCulture)),
+			new XAttribute("LiquidAbsorption", Profile.LiquidAbsorptionLitres.ToString("R", CultureInfo.InvariantCulture)),
+			new XAttribute("StaleAfterSeconds", (Profile.StaleAfter?.TotalSeconds ?? 0.0).ToString("R", CultureInfo.InvariantCulture)),
+			new XAttribute("SpoilAfterSeconds", (Profile.SpoilAfter?.TotalSeconds ?? 0.0).ToString("R", CultureInfo.InvariantCulture)),
+			new XAttribute("Decorator", Profile.Decorator?.Id ?? 0),
+			new XElement("Taste", new XCData(Profile.TasteTemplate)),
+			new XElement("Short", new XCData(Profile.ShortDescriptionTemplate)),
+			new XElement("Full", new XCData(Profile.FullDescriptionTemplate)),
+			new XElement("OnEatProg", Profile.OnEatProg?.Id ?? 0),
+			new XElement("OnStaleProg", Profile.OnStaleProg?.Id ?? 0),
+			new XElement("Ingredients", Profile.Ingredients.Select(x => x.SaveToXml())),
+			new XElement("DrugDoses", Profile.DrugDoses.Select(x => x.SaveToXml())),
+			new XElement("StaleDrugDoses", Profile.StaleDrugDoses.Select(x => x.SaveToXml()))
+		).ToString();
+	}
+
+	public override IGameItemComponent CreateNew(IGameItem parent, ICharacter? loader = null, bool temporary = false)
+	{
+		return new PreparedFoodGameItemComponent(this, parent, temporary);
+	}
+
+	public override IGameItemComponent LoadComponent(MudSharp.Models.GameItemComponent component, IGameItem parent)
+	{
+		return new PreparedFoodGameItemComponent(component, this, parent);
+	}
+
+	protected PreparedFoodGameItemComponentProto(MudSharp.Models.GameItemComponentProto proto, IFuturemud gameworld)
+		: base(proto, gameworld)
+	{
+	}
+
+	protected PreparedFoodGameItemComponentProto(IFuturemud gameworld, IAccount originator)
+		: base(gameworld, originator, "PreparedFood")
+	{
+		var stringValue = gameworld.GetStaticConfiguration("DefaultFoodStackDecorator");
+		if (stringValue is not null)
+		{
+			Profile.Decorator = Gameworld.StackDecorators.Get(long.Parse(stringValue));
+		}
+
+		Changed = true;
+	}
+
+	private const string BuildingHelpText = @"You can use the following options with this component:
+	#3name <name>#0 - sets the name of the component
+	#3desc <desc>#0 - sets the description of the component
+	#3hunger <hours>#0 - the hours of food satiation from eating one serving
+	#3thirst <hours>#0 - the hours of thirst satiation from eating one serving
+	#3water <amount>#0 - the liquid volume of water from eating one serving
+	#3alcohol <amount>#0 - the liquid volume of alcohol from eating one serving
+	#3bites <#>#0 - the number of bites in one serving
+	#3scope whole|stack#0 - whether this is one food item or one serving per stack unit
+	#3quality <multiplier>#0 - sets nutrition scaling per quality step, e.g. 0.08
+	#3stale <seconds|none>#0 - how long before it becomes stale
+	#3spoil <seconds|none>#0 - how long before it becomes spoiled
+	#3stalemult <multiplier>#0 - nutrition multiplier while stale
+	#3spoiledmult <multiplier>#0 - nutrition multiplier while spoiled
+	#3absorb <amount>#0 - liquid volume absorbed into the food before overflow contamination
+	#3taste <template>#0 - taste text, with tokens like {quality}, {freshness}, {ingredients}, {var:name}
+	#3short <template|clear>#0 - optional short-description template
+	#3full <template|clear>#0 - optional full-description template
+	#3ingredient add <role> <text>#0 - adds a default ingredient ledger entry
+	#3ingredient clear#0 - clears default ingredient entries
+	#3drug <drug> <grams>#0 - adds an ingested default drug dose
+	#3drug clear#0 - clears default drug doses
+	#3staledrug <drug> <grams>#0 - adds an ingested stale/spoiled drug dose
+	#3staledrug clear#0 - clears stale/spoiled drug doses
+	#3prog <which|clear>#0 - sets or clears the on-eat prog
+	#3staleprog <which|clear>#0 - sets or clears the stale-eat prog";
+
+	public override string ShowBuildingHelp => BuildingHelpText;
+
+	public override bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopSpeech().ToLowerInvariant())
+		{
+			case "satiation":
+			case "hunger":
+			case "hours":
+				return BuildingCommandSatiation(actor, command);
+			case "thirst":
+				return BuildingCommandThirst(actor, command);
+			case "water":
+				return BuildingCommandWater(actor, command);
+			case "alcohol":
+				return BuildingCommandAlcohol(actor, command);
+			case "taste":
+				return BuildingCommandTaste(actor, command);
+			case "short":
+			case "sdesc":
+				return BuildingCommandShort(actor, command);
+			case "full":
+			case "descstring":
+			case "fdesc":
+				return BuildingCommandFull(actor, command);
+			case "bites":
+				return BuildingCommandBites(actor, command);
+			case "scope":
+			case "serving":
+				return BuildingCommandScope(actor, command);
+			case "quality":
+			case "qualityscale":
+				return BuildingCommandQuality(actor, command);
+			case "stale":
+			case "staleafter":
+				return BuildingCommandStale(actor, command);
+			case "spoil":
+			case "spoilafter":
+				return BuildingCommandSpoil(actor, command);
+			case "stalemult":
+			case "stalemultiplier":
+				return BuildingCommandStaleMultiplier(actor, command);
+			case "spoiledmult":
+			case "spoiledmultiplier":
+				return BuildingCommandSpoiledMultiplier(actor, command);
+			case "absorb":
+			case "absorption":
+				return BuildingCommandAbsorb(actor, command);
+			case "ingredient":
+				return BuildingCommandIngredient(actor, command);
+			case "drug":
+			case "dose":
+				return BuildingCommandDrug(actor, command, false);
+			case "staledrug":
+			case "staledose":
+				return BuildingCommandDrug(actor, command, true);
+			case "prog":
+				return BuildingCommandProg(actor, command, false);
+			case "staleprog":
+				return BuildingCommandProg(actor, command, true);
+			default:
+				return base.BuildingCommand(actor, command);
+		}
+	}
+
+	private bool BuildingCommandSatiation(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !double.TryParse(command.PopSpeech(), out var value))
+		{
+			actor.Send("How many hours of satiation should one serving provide?");
+			return false;
+		}
+
+		Profile.SatiationPoints = value;
+		Changed = true;
+		actor.Send($"One serving now provides {value.ToString("N1", actor).ColourValue()} hours of satiation.");
+		return true;
+	}
+
+	private bool BuildingCommandThirst(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !double.TryParse(command.PopSpeech(), out var value))
+		{
+			actor.Send("How many hours of thirst satiation should one serving provide?");
+			return false;
+		}
+
+		Profile.ThirstPoints = value;
+		Changed = true;
+		actor.Send($"One serving now provides {value.ToString("N1", actor).ColourValue()} hours of thirst satiation.");
+		return true;
+	}
+
+	private bool BuildingCommandWater(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.Send("What volume of water should one serving provide?");
+			return false;
+		}
+
+		var value = actor.Gameworld.UnitManager.GetBaseUnits(command.SafeRemainingArgument, UnitType.FluidVolume, out var success);
+		if (!success)
+		{
+			actor.Send("That is not a valid fluid volume.");
+			return false;
+		}
+
+		Profile.WaterLitres = value * actor.Gameworld.UnitManager.BaseFluidToLitres;
+		Changed = true;
+		actor.Send($"One serving now provides {actor.Gameworld.UnitManager.Describe(value, UnitType.FluidVolume, actor).ColourValue()} of water.");
+		return true;
+	}
+
+	private bool BuildingCommandAlcohol(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.Send("What volume of alcohol should one serving provide?");
+			return false;
+		}
+
+		var value = actor.Gameworld.UnitManager.GetBaseUnits(command.SafeRemainingArgument, UnitType.FluidVolume, out var success);
+		if (!success)
+		{
+			actor.Send("That is not a valid fluid volume.");
+			return false;
+		}
+
+		Profile.AlcoholLitres = value * actor.Gameworld.UnitManager.BaseFluidToLitres;
+		Changed = true;
+		actor.Send($"One serving now provides {actor.Gameworld.UnitManager.Describe(value, UnitType.FluidVolume, actor).ColourValue()} of alcohol.");
+		return true;
+	}
+
+	private bool BuildingCommandBites(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !double.TryParse(command.PopSpeech(), out var value) || value <= 0.0)
+		{
+			actor.Send("How many bites should one serving contain?");
+			return false;
+		}
+
+		Profile.Bites = value;
+		Changed = true;
+		actor.Send($"One serving now contains {value.ToString("N2", actor).ColourValue()} bites.");
+		return true;
+	}
+
+	private bool BuildingCommandScope(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.Send("Should this food be scoped to the whole item or each stack unit?");
+			return false;
+		}
+
+		switch (command.PopSpeech().ToLowerInvariant())
+		{
+			case "whole":
+			case "item":
+			case "wholeitem":
+				Profile.ServingScope = FoodServingScope.WholeItem;
+				break;
+			case "stack":
+			case "unit":
+			case "perunit":
+			case "per-stack-unit":
+				Profile.ServingScope = FoodServingScope.PerStackUnit;
+				break;
+			default:
+				actor.Send("The valid scopes are WHOLE and STACK.");
+				return false;
+		}
+
+		Changed = true;
+		actor.Send($"This food now uses {Profile.ServingScope.DescribeEnum().ColourName()} serving scope.");
+		return true;
+	}
+
+	private bool BuildingCommandQuality(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !double.TryParse(command.PopSpeech(), out var value))
+		{
+			actor.Send("What nutrition multiplier per quality step should this food use? For example, 0.08.");
+			return false;
+		}
+
+		Profile.QualityNutritionMultiplierPerStep = value;
+		Changed = true;
+		actor.Send($"Nutrition now scales by {(value * 100.0).ToString("N1", actor).ColourValue()}% per quality step.");
+		return true;
+	}
+
+	private bool BuildingCommandStale(ICharacter actor, StringStack command)
+	{
+		return BuildingCommandTime(actor, command, true);
+	}
+
+	private bool BuildingCommandSpoil(ICharacter actor, StringStack command)
+	{
+		return BuildingCommandTime(actor, command, false);
+	}
+
+	private bool BuildingCommandTime(ICharacter actor, StringStack command, bool stale)
+	{
+		if (command.IsFinished)
+		{
+			actor.Send(stale ? "How many seconds before this food becomes stale? Use NONE for never." : "How many seconds before this food becomes spoiled? Use NONE for never.");
+			return false;
+		}
+
+		if (command.PeekSpeech().EqualToAny("none", "never", "clear", "0"))
+		{
+			if (stale)
+			{
+				Profile.StaleAfter = null;
+			}
+			else
+			{
+				Profile.SpoilAfter = null;
+			}
+			Changed = true;
+			actor.Send(stale ? "This food will no longer become stale by age." : "This food will no longer become spoiled by age.");
+			return true;
+		}
+
+		if (!double.TryParse(command.PopSpeech(), out var seconds) || seconds <= 0.0)
+		{
+			actor.Send("You must enter a positive number of seconds, or NONE.");
+			return false;
+		}
+
+		if (stale)
+		{
+			Profile.StaleAfter = TimeSpan.FromSeconds(seconds);
+		}
+		else
+		{
+			Profile.SpoilAfter = TimeSpan.FromSeconds(seconds);
+		}
+		Changed = true;
+		actor.Send(stale ? $"This food now becomes stale after {TimeSpan.FromSeconds(seconds).Describe(actor).ColourValue()}." : $"This food now becomes spoiled after {TimeSpan.FromSeconds(seconds).Describe(actor).ColourValue()}.");
+		return true;
+	}
+
+	private bool BuildingCommandStaleMultiplier(ICharacter actor, StringStack command)
+	{
+		return BuildingCommandMultiplier(actor, command, true);
+	}
+
+	private bool BuildingCommandSpoiledMultiplier(ICharacter actor, StringStack command)
+	{
+		return BuildingCommandMultiplier(actor, command, false);
+	}
+
+	private bool BuildingCommandMultiplier(ICharacter actor, StringStack command, bool stale)
+	{
+		if (command.IsFinished || !double.TryParse(command.PopSpeech(), out var value) || value < 0.0)
+		{
+			actor.Send("You must enter a non-negative multiplier.");
+			return false;
+		}
+
+		if (stale)
+		{
+			Profile.StaleNutritionMultiplier = value;
+		}
+		else
+		{
+			Profile.SpoiledNutritionMultiplier = value;
+		}
+		Changed = true;
+		actor.Send(stale ? $"Stale food now gives {(value * 100.0).ToString("N1", actor).ColourValue()}% nutrition." : $"Spoiled food now gives {(value * 100.0).ToString("N1", actor).ColourValue()}% nutrition.");
+		return true;
+	}
+
+	private bool BuildingCommandAbsorb(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.Send("How much liquid can this food absorb before overflow contamination?");
+			return false;
+		}
+
+		var value = actor.Gameworld.UnitManager.GetBaseUnits(command.SafeRemainingArgument, UnitType.FluidVolume, out var success);
+		if (!success || value < 0.0)
+		{
+			actor.Send("That is not a valid non-negative fluid volume.");
+			return false;
+		}
+
+		Profile.LiquidAbsorptionLitres = value * actor.Gameworld.UnitManager.BaseFluidToLitres;
+		Changed = true;
+		actor.Send($"This food can now absorb {actor.Gameworld.UnitManager.Describe(value, UnitType.FluidVolume, actor).ColourValue()} before overflow contamination.");
+		return true;
+	}
+
+	private bool BuildingCommandTaste(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.Send("What taste template should this food use?");
+			return false;
+		}
+
+		Profile.TasteTemplate = command.SafeRemainingArgument;
+		Changed = true;
+		actor.Send($"This food now uses the taste template:\n\n{Profile.TasteTemplate.Wrap(80, "\t").ColourCommand()}");
+		return true;
+	}
+
+	private bool BuildingCommandShort(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.Send("What short-description template should this food use? Use CLEAR for none.");
+			return false;
+		}
+
+		if (command.PeekSpeech().EqualToAny("clear", "none", "remove"))
+		{
+			Profile.ShortDescriptionTemplate = string.Empty;
+			Changed = true;
+			actor.Send("This food will no longer override its short description.");
+			return true;
+		}
+
+		Profile.ShortDescriptionTemplate = command.SafeRemainingArgument;
+		Changed = true;
+		actor.Send($"This food now uses the short template:\n\n{Profile.ShortDescriptionTemplate.ColourCommand()}");
+		return true;
+	}
+
+	private bool BuildingCommandFull(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.Send("What full-description template should this food use? Use CLEAR for none.");
+			return false;
+		}
+
+		if (command.PeekSpeech().EqualToAny("clear", "none", "remove"))
+		{
+			Profile.FullDescriptionTemplate = string.Empty;
+			Changed = true;
+			actor.Send("This food will no longer override its full description.");
+			return true;
+		}
+
+		Profile.FullDescriptionTemplate = command.SafeRemainingArgument;
+		Changed = true;
+		actor.Send($"This food now uses the full template:\n\n{Profile.FullDescriptionTemplate.Wrap(80, "\t").ColourCommand()}");
+		return true;
+	}
+
+	private bool BuildingCommandIngredient(ICharacter actor, StringStack command)
+	{
+		switch (command.PopSpeech().ToLowerInvariant())
+		{
+			case "add":
+				if (command.IsFinished)
+				{
+					actor.Send("What role should this ingredient have?");
+					return false;
+				}
+
+				var role = command.PopSpeech().ToLowerInvariant();
+				if (command.IsFinished)
+				{
+					actor.Send("What text should describe this ingredient?");
+					return false;
+				}
+
+				Profile.Ingredients.Add(new FoodIngredientInstance
+				{
+					Role = role,
+					Description = command.SafeRemainingArgument,
+					TasteText = command.SafeRemainingArgument
+				});
+				Changed = true;
+				actor.Send($"This food now includes {role.ColourName()} ingredient {Profile.Ingredients.Last().Description.ColourCommand()}.");
+				return true;
+			case "clear":
+				Profile.Ingredients.Clear();
+				Changed = true;
+				actor.Send("This food no longer has any default ingredient ledger entries.");
+				return true;
+			default:
+				actor.Send("Use INGREDIENT ADD <role> <text> or INGREDIENT CLEAR.");
+				return false;
+		}
+	}
+
+	private bool BuildingCommandDrug(ICharacter actor, StringStack command, bool stale)
+	{
+		var list = stale ? Profile.StaleDrugDoses : Profile.DrugDoses;
+		if (command.IsFinished)
+		{
+			actor.Send(stale ? "Which stale/spoiled drug should be added, or CLEAR?" : "Which default drug should be added, or CLEAR?");
+			return false;
+		}
+
+		if (command.PeekSpeech().EqualTo("clear"))
+		{
+			list.Clear();
+			Changed = true;
+			actor.Send(stale ? "This food no longer applies any stale/spoiled drug doses." : "This food no longer applies any default drug doses.");
+			return true;
+		}
+
+		var text = command.PopSpeech();
+		var drug = long.TryParse(text, out var value) ? Gameworld.Drugs.Get(value) : Gameworld.Drugs.GetByName(text);
+		if (drug is null)
+		{
+			actor.Send("There is no such drug.");
+			return false;
+		}
+
+		if (!drug.DrugVectors.HasFlag(DrugVector.Ingested))
+		{
+			actor.Send("That drug does not support the ingested vector.");
+			return false;
+		}
+
+		if (command.IsFinished || !double.TryParse(command.PopSpeech(), out var grams) || grams <= 0.0)
+		{
+			actor.Send("How many grams of this drug should one serving contain?");
+			return false;
+		}
+
+		list.Add(new FoodDrugDose { Drug = drug, Grams = grams, Source = stale ? "stale food" : "default profile" });
+		Changed = true;
+		actor.Send(stale ? $"Stale/spoiled servings now apply {grams.ToString("N4", actor).ColourValue()}g of {drug.Name.ColourName()}." : $"Each serving now applies {grams.ToString("N4", actor).ColourValue()}g of {drug.Name.ColourName()}.");
+		return true;
+	}
+
+	private bool BuildingCommandProg(ICharacter actor, StringStack command, bool stale)
+	{
+		if (command.IsFinished)
+		{
+			actor.Send("You can either CLEAR to remove the existing prog, or specify a prog name or ID to add.");
+			return false;
+		}
+
+		if (command.PeekSpeech().EqualTo("clear"))
+		{
+			if (stale)
+			{
+				Profile.OnStaleProg = null;
+			}
+			else
+			{
+				Profile.OnEatProg = null;
+			}
+			Changed = true;
+			actor.Send(stale ? "This food will no longer execute a stale-eat prog." : "This food will no longer execute an on-eat prog.");
+			return true;
+		}
+
+		var prog = Gameworld.FutureProgs.GetByIdOrName(command.SafeRemainingArgument);
+		if (prog is null)
+		{
+			actor.Send("There is no such prog.");
+			return false;
+		}
+
+		var expected = stale
+			? new[] { ProgVariableTypes.Character, ProgVariableTypes.Item, ProgVariableTypes.Number, ProgVariableTypes.Text }
+			: new[] { ProgVariableTypes.Character, ProgVariableTypes.Item, ProgVariableTypes.Number };
+		if (!prog.MatchesParameters(expected))
+		{
+			actor.Send(stale ? "The stale prog should accept a character, item, number and text." : "The prog should accept a character, item and number.");
+			return false;
+		}
+
+		if (stale)
+		{
+			Profile.OnStaleProg = prog;
+		}
+		else
+		{
+			Profile.OnEatProg = prog;
+		}
+		Changed = true;
+		actor.Send(stale ? $"This food will now execute the {prog.Name.ColourName()} stale-eat prog." : $"This food will now execute the {prog.Name.ColourName()} on-eat prog.");
+		return true;
+	}
+}

--- a/MudSharpCore/Work/Crafts/Products/CookedFoodProduct.cs
+++ b/MudSharpCore/Work/Crafts/Products/CookedFoodProduct.cs
@@ -1,0 +1,490 @@
+using MudSharp.Character;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Events;
+using MudSharp.Form.Material;
+using MudSharp.Framework;
+using MudSharp.Framework.Revision;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Components;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.GameItems.Prototypes;
+using MudSharp.Models;
+using MudSharp.PerceptionEngine.Lists;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+#nullable enable
+
+namespace MudSharp.Work.Crafts.Products;
+
+public class CookedFoodProduct : BaseProduct
+{
+	private readonly List<(long InputId, string Role)> _ingredientSlots = new();
+
+	protected CookedFoodProduct(CraftProduct product, ICraft craft, IFuturemud gameworld) : base(product, craft, gameworld)
+	{
+		var root = XElement.Parse(product.Definition);
+		Quantity = int.Parse(root.Element("Quantity")?.Value ?? "1");
+		ProductProducedId = long.Parse(root.Element("ProductProducedId")?.Value ?? "0");
+		Skin = gameworld.ItemSkins.Get(long.Parse(root.Element("Skin")?.Value ?? "0"));
+		RemoveDrugsAndFoodEffects =
+			bool.TryParse(root.Element("RemoveDrugsAndFoodEffects")?.Value, out var removeEffects) && removeEffects;
+		foreach (var element in root.Element("IngredientSlots")?.Elements("Slot") ?? Enumerable.Empty<XElement>())
+		{
+			_ingredientSlots.Add((long.Parse(element.Attribute("input")?.Value ?? "0"), element.Attribute("role")?.Value ?? "ingredient"));
+		}
+	}
+
+	protected CookedFoodProduct(ICraft craft, IFuturemud gameworld, bool failproduct) : base(craft, gameworld, failproduct)
+	{
+		Quantity = 1;
+	}
+
+	public long ProductProducedId { get; set; }
+	public int Quantity { get; set; }
+	public IGameItemSkin? Skin { get; set; }
+	public bool RemoveDrugsAndFoodEffects { get; set; }
+
+	public override string ProductType => "CookedFoodProduct";
+
+	public override string Name =>
+		$"{Quantity}x cooked {Skin?.ShortDescription ?? Gameworld.ItemProtos.Get(ProductProducedId)?.ShortDescription ?? "an unspecified prepared food".Colour(Telnet.Red)}";
+
+	public static void RegisterCraftProduct()
+	{
+		CraftProductFactory.RegisterCraftProductType("CookedFoodProduct",
+			(product, craft, game) => new CookedFoodProduct(product, craft, game));
+		CraftProductFactory.RegisterCraftProductTypeForBuilders("cookedfood",
+			(craft, game, fail) => new CookedFoodProduct(craft, game, fail));
+		CraftProductFactory.RegisterCraftProductTypeForBuilders("cooked food",
+			(craft, game, fail) => new CookedFoodProduct(craft, game, fail));
+	}
+
+	public override bool IsItem(IGameItem item)
+	{
+		return ProductProducedId == item.Prototype.Id && Skin?.Id == item.Skin?.Id;
+	}
+
+	public override bool RefersToItemProto(long id)
+	{
+		return ProductProducedId == id;
+	}
+
+	public override ICraftProductData ProduceProduct(IActiveCraftGameItemComponent component,
+		ItemQuality referenceQuality)
+	{
+		var proto = Gameworld.ItemProtos.Get(ProductProducedId);
+		if (proto is null)
+		{
+			throw new ApplicationException("Couldn't find a valid proto for cooked food craft product to load.");
+		}
+
+		var material = DetermineOverrideMaterial(component);
+		if (Quantity > 1 && proto.IsItemType<StackableGameItemComponentProto>())
+		{
+			var item = CreateOneItem(component, proto, referenceQuality, material);
+			item.GetItemType<IStackable>().Quantity = Quantity;
+			InitialisePreparedFood(component, item);
+			item.HandleEvent(EventType.ItemFinishedLoading, item);
+			return new SimpleProductData(new[] { item });
+		}
+
+		var items = new List<IGameItem>();
+		for (var i = 0; i < Quantity; i++)
+		{
+			var item = CreateOneItem(component, proto, referenceQuality, material);
+			InitialisePreparedFood(component, item);
+			item.HandleEvent(EventType.ItemFinishedLoading, item);
+			items.Add(item);
+		}
+
+		return new SimpleProductData(items);
+	}
+
+	private IGameItem CreateOneItem(IActiveCraftGameItemComponent component, IGameItemProto proto, ItemQuality referenceQuality,
+		ISolid? material)
+	{
+		var item = proto.CreateNew();
+		item.Skin = Skin;
+		item.RoomLayer = component.Parent.RoomLayer;
+		Gameworld.Add(item);
+		if (!Gameworld.GetStaticBool("DisableCraftQualityCalculation"))
+		{
+			item.Quality = referenceQuality;
+		}
+
+		if (material is not null)
+		{
+			item.Material = material;
+		}
+
+		return item;
+	}
+
+	private void InitialisePreparedFood(IActiveCraftGameItemComponent component, IGameItem item)
+	{
+		var prepared = item.GetItemType<IPreparedFood>();
+		if (prepared is null)
+		{
+			return;
+		}
+
+		foreach (var entry in SelectedInputData(component))
+		{
+			if (entry.Data is ICraftInputConsumeLiquidData liquidData)
+			{
+				prepared.AbsorbLiquid(liquidData.ConsumedMixture.Clone(), entry.Role, !RemoveDrugsAndFoodEffects);
+			}
+
+			foreach (var inputItem in ExtractItems(entry.Input, entry.Data))
+			{
+				TransferItemToFood(inputItem, prepared, entry.Role);
+			}
+		}
+	}
+
+	private IEnumerable<(ICraftInput Input, ICraftInputData Data, string Role)> SelectedInputData(IActiveCraftGameItemComponent component)
+	{
+		foreach (var pair in component.ConsumedInputs)
+		{
+			if (_ingredientSlots.Count == 0)
+			{
+				yield return (pair.Key, pair.Value.Data, "ingredient");
+				continue;
+			}
+
+			foreach (var slot in _ingredientSlots.Where(x => x.InputId == pair.Key.Id))
+			{
+				yield return (pair.Key, pair.Value.Data, slot.Role);
+			}
+		}
+	}
+
+	private static IEnumerable<IGameItem> ExtractItems(ICraftInput input, ICraftInputData data)
+	{
+		if (data is ICraftInputDataWithItems itemData)
+		{
+			return itemData.ConsumedItems;
+		}
+
+		return data.Perceivable switch
+		{
+			IGameItem item => new[] { item },
+			PerceivableGroup group => group.Members.OfType<IGameItem>(),
+			_ => Enumerable.Empty<IGameItem>()
+		};
+	}
+
+	private void TransferItemToFood(IGameItem inputItem, IPreparedFood prepared, string role)
+	{
+		var servingMultiplier = inputItem.GetItemType<IPreparedFood>() is { ServingScope: FoodServingScope.PerStackUnit } ? inputItem.Quantity : 1;
+		if (inputItem.GetItemType<IPreparedFood>() is { } preparedInput)
+		{
+			foreach (var ingredient in preparedInput.Ingredients)
+			{
+				var clone = ingredient.Clone();
+				clone.Role = string.IsNullOrWhiteSpace(clone.Role) ? role : clone.Role;
+				clone.Weight *= servingMultiplier;
+				clone.Volume *= servingMultiplier;
+				prepared.AddIngredient(clone);
+			}
+
+			if (!RemoveDrugsAndFoodEffects)
+			{
+				foreach (var dose in preparedInput.DrugDoses)
+				{
+					prepared.AddDrugDose(dose.Clone(servingMultiplier));
+				}
+			}
+		}
+		else
+		{
+			prepared.AddIngredient(new FoodIngredientInstance
+			{
+				Role = role,
+				Description = inputItem.Prototype.ShortDescription,
+				TasteText = inputItem.Prototype.ShortDescription,
+				SourceItemProtoId = inputItem.Prototype.Id,
+				MaterialId = inputItem.Material?.Id ?? 0,
+				Weight = inputItem.Prototype.Weight * inputItem.Quantity,
+				Quality = inputItem.Quality
+			});
+		}
+
+		if (RemoveDrugsAndFoodEffects)
+		{
+			return;
+		}
+
+		foreach (var effect in inputItem.EffectsOfType<IIngredientTransferEffect>())
+		{
+			effect.TransferToFood(prepared, servingMultiplier);
+		}
+	}
+
+	public override string HowSeen(IPerceiver voyeur)
+	{
+		if (Skin is not null && voyeur is ICharacter ch && ch.IsAdministrator())
+		{
+			return
+				$"{Quantity}x {Skin.ShortDescription.ConcatIfNotEmpty($" [re-skinned: #{Skin.Id.ToString("N0", voyeur)}]")}";
+		}
+
+		return
+			$"{Quantity}x {Gameworld.ItemProtos.Get(ProductProducedId)?.ShortDescription ?? "an unspecified prepared food".Colour(Telnet.Red)}";
+	}
+
+	protected override string SaveDefinition()
+	{
+		return new XElement("Definition",
+			new XElement("ProductProducedId", ProductProducedId),
+			new XElement("Quantity", Quantity),
+			new XElement("Skin", Skin?.Id ?? 0),
+			new XElement("RemoveDrugsAndFoodEffects", RemoveDrugsAndFoodEffects),
+			new XElement("IngredientSlots",
+				_ingredientSlots.Select(x => new XElement("Slot",
+					new XAttribute("input", x.InputId),
+					new XAttribute("role", x.Role)
+				))
+			)
+		).ToString();
+	}
+
+	protected override string SaveDefinitionForRevision(Dictionary<long, long> inputIdMap, Dictionary<long, long> toolIdMap)
+	{
+		return new XElement("Definition",
+			new XElement("ProductProducedId", ProductProducedId),
+			new XElement("Quantity", Quantity),
+			new XElement("Skin", Skin?.Id ?? 0),
+			new XElement("RemoveDrugsAndFoodEffects", RemoveDrugsAndFoodEffects),
+			new XElement("IngredientSlots",
+				_ingredientSlots.Select(x => new XElement("Slot",
+					new XAttribute("input", inputIdMap.ValueOrDefault(x.InputId, x.InputId)),
+					new XAttribute("role", x.Role)
+				))
+			)
+		).ToString();
+	}
+
+	protected override string BuildingHelpText => $@"{base.BuildingHelpText}
+	#3item <id|name>#0 - sets the prepared-food item prototype to be loaded
+	#3skin <id|name>#0 - sets a skin to go with the item prototype
+	#3skin clear#0 - clears the skin
+	#3quantity <amount>#0 - sets the quantity of that item to be loaded
+	#3purify [on|off]#0 - toggles whether input drugs and transferable food effects are removed
+	#3ingredient add <input index> <role>#0 - maps a consumed craft input into the food ledger with a role
+	#3ingredient clear#0 - uses all consumed inputs as generic ingredients";
+
+	public override bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopSpeech().ToLowerInvariant())
+		{
+			case "item":
+				return BuildingCommandItem(actor, command);
+			case "quantity":
+			case "amount":
+			case "number":
+			case "num":
+				return BuildingCommandQuantity(actor, command);
+			case "skin":
+				return BuildingCommandSkin(actor, command);
+			case "purify":
+			case "removedrugs":
+			case "removeeffects":
+			case "cleanse":
+				return BuildingCommandPurify(actor, command);
+			case "ingredient":
+				return BuildingCommandIngredient(actor, command);
+			default:
+				return base.BuildingCommand(actor, command);
+		}
+	}
+
+	private bool BuildingCommandItem(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("What prepared-food item prototype should this product load?");
+			return false;
+		}
+
+		var proto = long.TryParse(command.SafeRemainingArgument, out var value)
+			? Gameworld.ItemProtos.Get(value)
+			: Gameworld.ItemProtos.GetByName(command.SafeRemainingArgument);
+		if (proto is null)
+		{
+			actor.OutputHandler.Send("There is no such item prototype.");
+			return false;
+		}
+
+		if (!proto.IsItemType<PreparedFoodGameItemComponentProto>())
+		{
+			actor.OutputHandler.Send("That item prototype does not have a PreparedFood component.");
+			return false;
+		}
+
+		ProductProducedId = proto.Id;
+		Skin = null;
+		ProductChanged = true;
+		actor.OutputHandler.Send(
+			$"This product will now target prepared-food prototype #{ProductProducedId.ToString("N0", actor)} ({proto.ShortDescription.ColourObject()}).");
+		return true;
+	}
+
+	private bool BuildingCommandQuantity(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !int.TryParse(command.PopSpeech(), out var value) || value <= 0)
+		{
+			actor.OutputHandler.Send("You must enter a valid amount of this item to be loaded.");
+			return false;
+		}
+
+		Quantity = value;
+		ProductChanged = true;
+		actor.OutputHandler.Send($"This product will now produce {Quantity.ToString("N0", actor).ColourValue()} of the target item.");
+		return true;
+	}
+
+	private bool BuildingCommandSkin(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send(
+				$"You must specify a skin to go with this product or use {"clear".ColourCommand()} to clear an existing one.");
+			return false;
+		}
+
+		if (ProductProducedId == 0)
+		{
+			actor.OutputHandler.Send("You must first set an item prototype before you can set any skins.");
+			return false;
+		}
+
+		if (command.PeekSpeech().EqualToAny("clear", "delete", "remove", "none"))
+		{
+			Skin = null;
+			ProductChanged = true;
+			actor.OutputHandler.Send("This product will no longer apply any skin to the loaded item.");
+			return true;
+		}
+
+		var skin = long.TryParse(command.SafeRemainingArgument, out var value)
+			? Gameworld.ItemSkins.Get(value)
+			: Gameworld.ItemSkins.Where(x => x.ItemProto.Id == ProductProducedId)
+			           .GetByNameOrAbbreviation(command.SafeRemainingArgument);
+		if (skin is null)
+		{
+			actor.OutputHandler.Send("There is no such item skin.");
+			return false;
+		}
+
+		if (skin.ItemProto.Id != ProductProducedId)
+		{
+			actor.OutputHandler.Send(
+				$"{skin.EditHeader().ColourName()} is not designed to work with {Gameworld.ItemProtos.Get(ProductProducedId).EditHeader().ColourObject()}.");
+			return false;
+		}
+
+		if (skin.Status != RevisionStatus.Current)
+		{
+			actor.OutputHandler.Send($"{skin.EditHeader().ColourName()} is not approved for use.");
+			return false;
+		}
+
+		Skin = skin;
+		ProductChanged = true;
+		actor.OutputHandler.Send($"This product will now apply {skin.EditHeader().ColourName()} to the loaded item.");
+		return true;
+	}
+
+	private bool BuildingCommandPurify(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			RemoveDrugsAndFoodEffects = !RemoveDrugsAndFoodEffects;
+		}
+		else
+		{
+			switch (command.PopSpeech().ToLowerInvariant())
+			{
+				case "true":
+				case "yes":
+				case "on":
+					RemoveDrugsAndFoodEffects = true;
+					break;
+				case "false":
+				case "no":
+				case "off":
+					RemoveDrugsAndFoodEffects = false;
+					break;
+				default:
+					actor.OutputHandler.Send("Use ON or OFF to specify whether this product removes input drugs and transferable food effects.");
+					return false;
+			}
+		}
+
+		ProductChanged = true;
+		actor.OutputHandler.Send(RemoveDrugsAndFoodEffects
+			? "This product will now remove drugs and transferable food effects from consumed inputs."
+			: "This product will now preserve drugs and transferable food effects from consumed inputs.");
+		return true;
+	}
+
+	private bool BuildingCommandIngredient(ICharacter actor, StringStack command)
+	{
+		switch (command.PopSpeech().ToLowerInvariant())
+		{
+			case "add":
+				if (command.IsFinished || !int.TryParse(command.PopSpeech(), out var value))
+				{
+					actor.OutputHandler.Send("Which input number should be treated as an ingredient?");
+					return false;
+				}
+
+				var input = Craft.Inputs.ElementAtOrDefault(value - 1);
+				if (input is null)
+				{
+					actor.OutputHandler.Send("There is no such input for this craft.");
+					return false;
+				}
+
+				if (command.IsFinished)
+				{
+					actor.OutputHandler.Send("What role should this input have in the food ledger?");
+					return false;
+				}
+
+				var role = command.SafeRemainingArgument.ToLowerInvariant();
+				_ingredientSlots.Add((input.Id, role));
+				ProductChanged = true;
+				actor.OutputHandler.Send($"Input {value.ToString("N0", actor).ColourValue()} now transfers to the food ledger as {role.ColourName()}.");
+				return true;
+			case "clear":
+				_ingredientSlots.Clear();
+				ProductChanged = true;
+				actor.OutputHandler.Send("This product will now use all consumed craft inputs as generic food ingredients.");
+				return true;
+			default:
+				actor.OutputHandler.Send("Use INGREDIENT ADD <input index> <role> or INGREDIENT CLEAR.");
+				return false;
+		}
+	}
+
+	public override bool IsValid()
+	{
+		return ProductProducedId != 0 &&
+		       Gameworld.ItemProtos.Get(ProductProducedId)?.IsItemType<PreparedFoodGameItemComponentProto>() == true;
+	}
+
+	public override string WhyNotValid()
+	{
+		if (ProductProducedId == 0)
+		{
+			return "You must first set a prepared-food item prototype for this product to load.";
+		}
+
+		return "The selected item prototype must have a PreparedFood component.";
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `PreparedFood` as the new food runtime path for direct-load items and recipe-initialised foods.
- Introduces `CookedFoodProduct` with optional purification to drop propagated drugs and transferable food effects.
- Adds `cook` as a crafting facade, new cooking seeder stock content, and updated food/crafting design docs.

## Testing
- `dotnet build MudSharpCore\\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `dotnet build DatabaseSeeder\\DatabaseSeeder.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `dotnet test 'DatabaseSeeder Unit Tests\\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 --filter CookingSeederTests`