### PR TITLE
Fix zero-gravity move speed seeding

### DIFF
--- a/MudSharpCore/Body/Implementations/BodyPrototype.cs
+++ b/MudSharpCore/Body/Implementations/BodyPrototype.cs
@@ -132,7 +132,24 @@ public class BodyPrototype : SaveableItem, IBodyPrototype
                            _speeds.FirstOrDefault();
             if (template is not null)
             {
-                _speeds.Add(new MoveSpeed(template, PositionFloatingInZeroGravity.Instance, "float", "floats", "floating"));
+                var dbSpeed = new Models.MoveSpeed
+                {
+                    Id = FMDB.Context.MoveSpeeds.Select(x => x.Id).AsEnumerable().DefaultIfEmpty(0L).Max() + 1L,
+                    BodyProtoId = proto.Id,
+                    PositionId = PositionFloatingInZeroGravity.Instance.Id,
+                    Alias = "float",
+                    FirstPersonVerb = "float",
+                    ThirdPersonVerb = "floats",
+                    PresentParticiple = "floating",
+                    Multiplier = template.Multiplier,
+                    StaminaMultiplier = template.StaminaMultiplier
+                };
+                FMDB.Context.MoveSpeeds.Add(dbSpeed);
+                FMDB.Context.SaveChanges();
+
+                var gspeed = new MoveSpeed(dbSpeed);
+                Gameworld.Add(gspeed);
+                _speeds.Add(gspeed);
             }
         }
 

--- a/MudSharpCore/Movement/MoveSpeed.cs
+++ b/MudSharpCore/Movement/MoveSpeed.cs
@@ -17,18 +17,6 @@ public class MoveSpeed : FrameworkItem, IMoveSpeed
         Position = PositionState.GetState(speed.PositionId);
     }
 
-    public MoveSpeed(IMoveSpeed template, IPositionState position, string firstPersonVerb, string thirdPersonVerb, string presentParticiple)
-    {
-        _id = 0;
-        _name = position.Name.ToLowerInvariant();
-        Multiplier = template.Multiplier;
-        FirstPersonVerb = firstPersonVerb;
-        ThirdPersonVerb = thirdPersonVerb;
-        PresentParticiple = presentParticiple;
-        StaminaMultiplier = template.StaminaMultiplier;
-        Position = position;
-    }
-
     public override string FrameworkItemType => "MoveSpeed";
 
     public double Multiplier { get; protected set; }


### PR DESCRIPTION
## Summary
- Persist the zero-gravity floating move speed as a database-backed model before adding it to the gameworld
- Remove the unused in-memory MoveSpeed template constructor after switching to the persisted path

## Testing
- Not run (not requested)