### PR TITLE
Guard dormant bodies and character heartbeats

### DIFF
--- a/Design Documents/Multiple_Body_Form_System.md
+++ b/Design Documents/Multiple_Body_Form_System.md
@@ -132,9 +132,13 @@ The high-level switch flow is:
 6. Transfer or stash trauma according to the plan.
 7. Move inventory where possible, dropping ordinary items that no longer fit and rejecting restraints that cannot safely transfer.
 8. Recalculate body helpers, organ functions, breathing, stamina, and health consequences with health feedback suppressed during the switch.
-9. Set `CurrentBody`, activate the new body, suspend the old body, emit the transformation echo, and fire `CurrentBodyChanged`.
+9. Set `CurrentBody`, activate the new body, reset the old body into dormant form state, emit the transformation echo, and fire `CurrentBodyChanged`.
 
-Body switching does not use `Body.Quit()`. Dormant bodies stop health, drug, stamina, and breathing ticks and are treated as non-present shells until reactivated.
+Body switching does not use `Body.Quit()`. Dormant bodies stop health, drug, stamina, breathing, scheduled body actions, body-owned scheduled effects, and retained body-item lifecycles, and are treated as non-present shells until reactivated.
+
+The body runtime also guards tick starters and tick callbacks with an active-body check. A body may only start or continue health, drug, stamina, breathing, or health-status processing while it is the character's `CurrentBody` and the character is neither dead nor in stasis. This is a defensive layer for stale body references from wounds, effects, drugs, or delayed actions: even if old code asks a dormant form to restart a tick, the dormant form unregisters or refuses the work instead of processing physiology in the background.
+
+Character-level lifecycle hooks follow the same rule. `LoginCharacter()` resumes online-only character heartbeats after stasis is cleared; `Quit()` and `Die()` stop needs ticks, forced-transformation recheck delegates, and magic resource regeneration delegates. NPC AI heartbeat subscriptions are only installed for live, non-stasis NPCs and are released on quit or death.
 
 ### Anatomy Mapping
 
@@ -154,7 +158,7 @@ Form switching supports both transfer and stasis.
 
 Transfer mode remaps compatible wounds, part infections, scars, tattoos, severed roots, implants, prosthetics, active and latent drugs, blood state, held breath time, stamina, and selected treatment effects. Internal bleeding, antiseptic treatment, anti-inflammatory treatment, and replanted bodypart effects are recreated on mapped bodyparts with their remaining duration.
 
-Stash mode leaves trauma on the old body, caches scheduled effects, stops ongoing body ticks, clears restraints and direct inventory state, and sanitises the target body for its health strategy. Incompatible wounds and organic-only health effects are removed from the active target form, and lost fluids can be restored when no compatible bleed sources remain. Health feedback is suppressed during the switch so players do not see transient "dying", "can't breathe", or organ recovery spam caused by intermediate recalculations.
+Stash mode leaves trauma on the old body, caches scheduled effects, stops ongoing body ticks, clears body-owned scheduler entries, quits retained body items such as dormant implants or prosthetics, clears restraints and direct inventory state, and sanitises the target body for its health strategy. Incompatible wounds and organic-only health effects are removed from the active target form, and lost fluids can be restored when no compatible bleed sources remain. Health feedback is suppressed during the switch so players do not see transient "dying", "can't breathe", or organ recovery spam caused by intermediate recalculations.
 
 ### Description and Transformation Echoes
 
@@ -252,7 +256,7 @@ The `DrugOrChemical` band exists so content can rank chemical transformations co
 
 When a mandatory transform first takes control, the system records a baseline body in `ForcedTransformationBaselineEffect`. When the winning demand changes or no demands remain, the character is switched to the new winning target or reverted toward the recorded baseline.
 
-Merit applicability is rechecked by a single registered character delegate using fuzzy minute or fuzzy hour cadence. This avoids a global sweep over all characters while still supporting time-sensitive transforms such as full moons.
+Merit applicability is rechecked by a single registered character delegate using fuzzy minute or fuzzy hour cadence while the character is online and not dead or in stasis. This avoids a global sweep over all characters while still supporting time-sensitive transforms such as full moons.
 
 ### FutureProg Surface
 

--- a/MudSharpCore Unit Tests/BodyFormLifecycleGuardTests.cs
+++ b/MudSharpCore Unit Tests/BodyFormLifecycleGuardTests.cs
@@ -1,0 +1,60 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Body;
+using MudSharp.Character;
+using ConcreteBody = MudSharp.Body.Implementations.Body;
+using ConcreteCharacter = MudSharp.Character.Character;
+using System.Reflection;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class BodyFormLifecycleGuardTests
+{
+	[TestMethod]
+	public void BodyProcessStarters_DormantForm_DoNotTouchRuntimeSchedulers()
+	{
+		var body = TestObjectFactory.CreateUninitialized<ConcreteBody>();
+		var activeBody = new Mock<IBody>();
+		var actor = new Mock<ICharacter>();
+		actor.SetupGet(x => x.CurrentBody).Returns(activeBody.Object);
+		actor.SetupGet(x => x.State).Returns(CharacterState.Awake);
+		body.Actor = actor.Object;
+
+		body.StartHealthTick();
+		body.StartStaminaTick();
+		body.CheckDrugTick();
+		body.CheckHealthStatus();
+		body.DoBreathing();
+	}
+
+	[TestMethod]
+	public void BodyProcessStarters_DeadCurrentBody_DoNotTouchRuntimeSchedulers()
+	{
+		var body = TestObjectFactory.CreateUninitialized<ConcreteBody>();
+		var actor = new Mock<ICharacter>();
+		actor.SetupGet(x => x.CurrentBody).Returns(body);
+		actor.SetupGet(x => x.State).Returns(CharacterState.Dead);
+		body.Actor = actor.Object;
+
+		body.StartHealthTick();
+		body.StartStaminaTick();
+		body.CheckDrugTick();
+		body.CheckHealthStatus();
+		body.DoBreathing();
+	}
+
+	[TestMethod]
+	public void CharacterNeedsHeartbeat_StasisCharacter_DoesNotTouchNeedsModel()
+	{
+		var character = TestObjectFactory.CreateUninitialized<ConcreteCharacter>();
+		typeof(ConcreteCharacter)
+			.GetField("_state", BindingFlags.Instance | BindingFlags.NonPublic)!
+			.SetValue(character, CharacterState.Stasis);
+
+		character.StartNeedsHeartbeat();
+		character.NeedsHeartbeat();
+	}
+}

--- a/MudSharpCore/Body/Implementations/Body.cs
+++ b/MudSharpCore/Body/Implementations/Body.cs
@@ -211,6 +211,11 @@ public partial class Body : PerceiverItem, IBody
     public PlanarPresenceDefinition BasePlanarPresence => Prototype.BasePlanarPresence;
 
     public ICharacter Actor { get; set; }
+    private bool IsActiveCharacterBody =>
+        Actor?.CurrentBody == this &&
+        !Actor.State.HasFlag(CharacterState.Dead) &&
+        !Actor.State.HasFlag(CharacterState.Stasis);
+
     public Alignment Handedness { get; set; }
 
     public IController Controller { get; protected set; }
@@ -419,6 +424,13 @@ public partial class Body : PerceiverItem, IBody
 
     public void Login()
     {
+        if (!IsActiveCharacterBody)
+        {
+            _breathingStrategy = new NonBreather();
+            Controller = null;
+            return;
+        }
+
         _breathingStrategy = Race.BreathingStrategy;
         CalculateOrganFunctions(true);
         ScheduleCachedEffects();
@@ -456,6 +468,22 @@ public partial class Body : PerceiverItem, IBody
         Gameworld.Destroy(this);
         PerceivableQuit();
         _breathingStrategy = new NonBreather();
+    }
+
+    internal void LoginDormantFormItems()
+    {
+        foreach (IGameItem item in AllItems.ToList())
+        {
+            item.Login();
+        }
+    }
+
+    internal void QuitDormantFormItems()
+    {
+        foreach (IGameItem item in AllItems.ToList())
+        {
+            item.Quit();
+        }
     }
 
     public string ReportCondition()
@@ -524,6 +552,13 @@ public partial class Body : PerceiverItem, IBody
 
     public void ActivateForCharacter()
     {
+        if (!IsActiveCharacterBody)
+        {
+            _breathingStrategy = new NonBreather();
+            Controller = null;
+            return;
+        }
+
         Controller = Actor?.CharacterController;
         _breathingStrategy = Race.BreathingStrategy;
     }
@@ -534,6 +569,7 @@ public partial class Body : PerceiverItem, IBody
         EndDrugTick();
         EndHealthTick();
         CacheScheduledEffects();
+        Gameworld.Scheduler.Destroy(this);
         _breathingStrategy = new NonBreather();
         Controller = null;
     }

--- a/MudSharpCore/Body/Implementations/BodyBiology.cs
+++ b/MudSharpCore/Body/Implementations/BodyBiology.cs
@@ -89,8 +89,9 @@ public partial class Body
     public IGameItem Die()
     {
         OnDeath?.Invoke(this);
-        EndStaminaTick(false);
+        EndStaminaTick(true);
         EndDrugTick();
+        EndHealthTickRegistration();
         _breathingStrategy = new NonBreather();
 
         // Wielded items merely become held items
@@ -126,7 +127,7 @@ public partial class Body
 
     public void CheckHealthStatus()
     {
-        if (_loading)
+        if (_loading || !IsActiveCharacterBody)
         {
             return;
         }
@@ -1346,8 +1347,9 @@ public partial class Body
 
     public void StartHealthTick(bool initial = false)
     {
-        if (Actor.State.HasFlag(CharacterState.Stasis))
+        if (!IsActiveCharacterBody)
         {
+            EndHealthTickRegistration();
             return;
         }
 
@@ -1382,6 +1384,16 @@ public partial class Body
     public void EndHealthTick()
     {
         ReevaluateLimbAndPartDamageEffects();
+        EndHealthTickRegistration();
+    }
+
+    private void EndHealthTickRegistration()
+    {
+        if (!_healthTickActive)
+        {
+            return;
+        }
+
         Gameworld.HeartbeatManager.TenSecondHeartbeat -= HealthTick_TenSecondHeartbeat;
         Gameworld.HeartbeatManager.MinuteHeartbeat -= HealingTick_MinuteHeartbeat;
         _healthTickActive = false;
@@ -1531,6 +1543,12 @@ public partial class Body
 
     private void HealingTick_MinuteHeartbeat()
     {
+        if (!IsActiveCharacterBody)
+        {
+            EndHealthTickRegistration();
+            return;
+        }
+
         if (Combat == null)
         {
             List<IHealingRateEffect> healingEffects = CombinedEffectsOfType<IHealingRateEffect>().ToList();
@@ -1592,7 +1610,7 @@ public partial class Body
 
     private void RecheckStatus()
     {
-        if (Actor.State.HasFlag(CharacterState.Dead))
+        if (Actor.State.HasFlag(CharacterState.Dead) || !IsActiveCharacterBody)
         {
             return;
         }
@@ -1778,6 +1796,12 @@ public partial class Body
 
     private void HealthTick_TenSecondHeartbeat()
     {
+        if (!IsActiveCharacterBody)
+        {
+            EndHealthTickRegistration();
+            return;
+        }
+
         HandleHealthStatusResult(ApplyForcedParalysis(HealthStrategy.PerformHealthTick(Actor)));
         CalculateOrganFunctions();
         ReevaluateLimbAndPartDamageEffects();
@@ -1829,6 +1853,11 @@ public partial class Body
 
     public void DoBreathing()
     {
+        if (!IsActiveCharacterBody)
+        {
+            return;
+        }
+
         _breathingStrategy.Breathe(this);
         if (!CanBreathe && _breathingStrategy.NeedsToBreathe)
         {

--- a/MudSharpCore/Body/Implementations/BodyDrugs.cs
+++ b/MudSharpCore/Body/Implementations/BodyDrugs.cs
@@ -102,8 +102,9 @@ public partial class Body
 
     public void CheckDrugTick()
     {
-        if (Actor.State.HasFlag(CharacterState.Stasis) || Actor.State.HasFlag(CharacterState.Dead))
+        if (!IsActiveCharacterBody)
         {
+            EndDrugTick();
             return;
         }
 
@@ -132,12 +133,23 @@ public partial class Body
 
     private void EndDrugTick()
     {
+        if (!_drugTickOn)
+        {
+            return;
+        }
+
         Gameworld.HeartbeatManager.TenSecondHeartbeat -= DrugTenSecondHeartbeat;
         _drugTickOn = false;
     }
 
     private void DrugTenSecondHeartbeat()
     {
+        if (!IsActiveCharacterBody)
+        {
+            EndDrugTick();
+            return;
+        }
+
         ProcessLatentDrugs();
         ApplyDrugEffects();
         MetaboliseActiveDrugs();

--- a/MudSharpCore/Body/Implementations/BodyFormSwitching.cs
+++ b/MudSharpCore/Body/Implementations/BodyFormSwitching.cs
@@ -478,6 +478,7 @@ public partial class Body
 	internal void ApplySwitchPlan(BodySwitchPlan plan)
 	{
 		var source = plan.Source;
+		LoginDormantFormItems();
 
 		var transferTrauma = plan.TraumaMode == BodySwitchTraumaMode.Transfer;
 
@@ -945,6 +946,7 @@ public partial class Body
 		EndDrugTick();
 		EndHealthTick();
 		CacheScheduledEffects();
+		Gameworld.Scheduler.Destroy(this);
 		_breathingStrategy = new NonBreather();
 		if (traumaMode == BodySwitchTraumaMode.Transfer)
 		{
@@ -985,6 +987,8 @@ public partial class Body
 				ReevaluateLimbAndPartDamageEffects();
 			});
 		}
+
+		QuitDormantFormItems();
 
 		Changed = true;
 	}

--- a/MudSharpCore/Body/Implementations/BodyMovement.cs
+++ b/MudSharpCore/Body/Implementations/BodyMovement.cs
@@ -252,7 +252,7 @@ public partial class Body
 
     public void StartStaminaTick()
     {
-        if (Actor.State.HasFlag(CharacterState.Stasis))
+        if (!IsActiveCharacterBody)
         {
             return;
         }
@@ -274,9 +274,13 @@ public partial class Body
 
     public void EndStaminaTick(bool includeMinute)
     {
-        Gameworld.HeartbeatManager.TenSecondHeartbeat -= StaminaTenSecondHeartbeat;
-        _tenSecondStaminaActive = false;
-        if (includeMinute)
+        if (_tenSecondStaminaActive)
+        {
+            Gameworld.HeartbeatManager.TenSecondHeartbeat -= StaminaTenSecondHeartbeat;
+            _tenSecondStaminaActive = false;
+        }
+
+        if (includeMinute && _minuteStaminaActive)
         {
             Gameworld.HeartbeatManager.MinuteHeartbeat -= StaminaMinuteHeartbeat;
             _minuteStaminaActive = false;
@@ -285,6 +289,12 @@ public partial class Body
 
     public void StaminaTenSecondHeartbeat()
     {
+        if (!IsActiveCharacterBody)
+        {
+            EndStaminaTick(true);
+            return;
+        }
+
         var positionState = PositionState ?? PositionUndefined.Instance;
 
         if (CurrentStamina < MaximumStamina)
@@ -356,6 +366,12 @@ public partial class Body
 
     public void StaminaMinuteHeartbeat()
     {
+        if (!IsActiveCharacterBody)
+        {
+            EndStaminaTick(true);
+            return;
+        }
+
         bool isDead = Actor.State.HasFlag(CharacterState.Dead);
         if (LongtermExertion > ExertionLevel.Normal && Race.SweatLiquid != null && !isDead)
         {

--- a/MudSharpCore/Character/Character.cs
+++ b/MudSharpCore/Character/Character.cs
@@ -80,6 +80,9 @@ public partial class Character : PerceiverItem, ICharacter
 {
     private IPersonalName _currentName;
     public PlanarPresenceDefinition BasePlanarPresence => Body.BasePlanarPresence;
+    private bool CanRunCharacterOngoingProcesses =>
+        !State.HasFlag(CharacterState.Dead) &&
+        !State.HasFlag(CharacterState.Stasis);
 
     public Character(MudSharp.Models.Character character, IFuturemud gameworld, bool temporary = false)
         : base(character.Id)
@@ -2026,6 +2029,13 @@ public partial class Character : PerceiverItem, ICharacter
                     throw new ApplicationException("A dead character was set to a non dead status.");
                 }
 
+                if (State.HasFlag(CharacterState.Dead) || State.HasFlag(CharacterState.Stasis))
+                {
+                    StopNeedsHeartbeat();
+                    ClearForcedTransformationHeartbeatRegistration();
+                    PauseMagicResourceGeneratorHeartbeats();
+                }
+
                 CheckCanFly();
             }
         }
@@ -2349,9 +2359,10 @@ public partial class Character : PerceiverItem, ICharacter
         Gameworld.EffectScheduler.Destroy(this, true);
         Gameworld.Scheduler.Destroy(this);
         ClearForcedTransformationHeartbeatRegistration();
+        PauseMagicResourceGeneratorHeartbeats();
         Body.Quit();
 
-        Gameworld.HeartbeatManager.TenSecondHeartbeat -= NeedsHeartbeat;
+        StopNeedsHeartbeat();
         Gameworld.Destroy(this);
         OutputHandler?.Register(null);
         if (Controller != null)
@@ -2377,6 +2388,7 @@ public partial class Character : PerceiverItem, ICharacter
         StartNeedsHeartbeat();
         RemoveAllEffects(x => x.IsEffectType<LinkdeadLogout>());
         Body.Login();
+        ResumeMagicResourceGeneratorHeartbeats();
         RefreshForcedTransformationHeartbeatRegistration();
         ReevaluateForcedBodyTransformation();
         if (PositionTarget?.TargetedBy.Contains(this) == false)
@@ -3254,15 +3266,35 @@ public partial class Character : PerceiverItem, ICharacter
 
     public virtual void NeedsHeartbeat()
     {
+        if (!CanRunCharacterOngoingProcesses)
+        {
+            StopNeedsHeartbeat();
+            return;
+        }
+
         Body.NeedsHeartbeat();
     }
 
     public virtual void StartNeedsHeartbeat()
     {
+        if (!CanRunCharacterOngoingProcesses)
+        {
+            StopNeedsHeartbeat();
+            return;
+        }
+
         if (NeedsModel.NeedsSave)
         {
-            Gameworld.HeartbeatManager.TenSecondHeartbeat -= NeedsHeartbeat;
+            StopNeedsHeartbeat();
             Gameworld.HeartbeatManager.TenSecondHeartbeat += NeedsHeartbeat;
+        }
+    }
+
+    private void StopNeedsHeartbeat()
+    {
+        if (Gameworld is not null)
+        {
+            Gameworld.HeartbeatManager.TenSecondHeartbeat -= NeedsHeartbeat;
         }
     }
 

--- a/MudSharpCore/Character/CharacterForcedTransformations.cs
+++ b/MudSharpCore/Character/CharacterForcedTransformations.cs
@@ -220,6 +220,12 @@ public partial class Character
 
 	private void RefreshForcedTransformationHeartbeatRegistration()
 	{
+		if (!CanRunCharacterOngoingProcesses)
+		{
+			ClearForcedTransformationHeartbeatRegistration();
+			return;
+		}
+
 		var desired = DesiredForcedTransformationHeartbeatCadence();
 		if (desired == _forcedTransformationHeartbeatCadence)
 		{
@@ -258,6 +264,12 @@ public partial class Character
 
 	private void ForcedTransformationHeartbeat()
 	{
+		if (!CanRunCharacterOngoingProcesses)
+		{
+			ClearForcedTransformationHeartbeatRegistration();
+			return;
+		}
+
 		ReevaluateForcedBodyTransformation();
 	}
 }

--- a/MudSharpCore/Character/CharacterHealth.cs
+++ b/MudSharpCore/Character/CharacterHealth.cs
@@ -93,6 +93,9 @@ public partial class Character
 
         State = CharacterState.Dead;
         _status = CharacterStatus.Deceased;
+        StopNeedsHeartbeat();
+        ClearForcedTransformationHeartbeatRegistration();
+        PauseMagicResourceGeneratorHeartbeats();
         MudSharp.RPG.AIStorytellers.AIStoryteller.HandleCharacterStateInRoomEvent(this,
             MudSharp.RPG.AIStorytellers.AIStorytellerStateTriggerType.Dead);
 
@@ -140,7 +143,7 @@ public partial class Character
             _nextContext = null;
         }
 
-        Gameworld.HeartbeatManager.TenSecondHeartbeat -= NeedsHeartbeat;
+        StopNeedsHeartbeat();
         Body.Die();
         using (new FMDB())
         {
@@ -188,6 +191,8 @@ public partial class Character
         LoginDateTime = DateTime.UtcNow;
         LastMinutesUpdate = LoginDateTime;
         StartNeedsHeartbeat();
+        ResumeMagicResourceGeneratorHeartbeats();
+        RefreshForcedTransformationHeartbeatRegistration();
 
         Body.Resurrect(location);
         Corpse = null;

--- a/MudSharpCore/Character/CharacterMagic.cs
+++ b/MudSharpCore/Character/CharacterMagic.cs
@@ -188,6 +188,12 @@ public partial class Character : IMagicUser
 
     public void AddResource(IMagicResource resource, double amount)
     {
+        if (!CanRunCharacterOngoingProcesses)
+        {
+            PauseMagicResourceGeneratorHeartbeats();
+            return;
+        }
+
         double old = _magicResourceAmounts[resource];
         _magicResourceAmounts[resource] += amount;
         _magicResourceAmounts[resource] = Math.Max(0.0,
@@ -202,14 +208,43 @@ public partial class Character : IMagicUser
     public IEnumerable<IMagicResourceRegenerator> MagicResourceGenerators => _magicResourceGenerators;
     private Dictionary<IMagicResourceRegenerator, HeartbeatManagerDelegate> _generatorDelegateDictionary = new();
 
+    private void ResumeMagicResourceGeneratorHeartbeats()
+    {
+        if (!CanRunCharacterOngoingProcesses)
+        {
+            PauseMagicResourceGeneratorHeartbeats();
+            return;
+        }
+
+        foreach (IMagicResourceRegenerator generator in _magicResourceGenerators)
+        {
+            if (_generatorDelegateDictionary.ContainsKey(generator))
+            {
+                continue;
+            }
+
+            HeartbeatManagerDelegate hbdelegate = generator.GetOnMinuteDelegate(this);
+            _generatorDelegateDictionary[generator] = hbdelegate;
+            Gameworld.HeartbeatManager.FuzzyMinuteHeartbeat += hbdelegate;
+        }
+    }
+
+    private void PauseMagicResourceGeneratorHeartbeats()
+    {
+        foreach (HeartbeatManagerDelegate hbdelegate in _generatorDelegateDictionary.Values.ToList())
+        {
+            Gameworld.HeartbeatManager.FuzzyMinuteHeartbeat -= hbdelegate;
+        }
+
+        _generatorDelegateDictionary.Clear();
+    }
+
     public void AddMagicResourceGenerator(IMagicResourceRegenerator generator)
     {
         if (!_magicResourceGenerators.Contains(generator))
         {
             _magicResourceGenerators.Add(generator);
-            HeartbeatManagerDelegate hbdelegate = generator.GetOnMinuteDelegate(this);
-            _generatorDelegateDictionary[generator] = hbdelegate;
-            Gameworld.HeartbeatManager.FuzzyMinuteHeartbeat += hbdelegate;
+            ResumeMagicResourceGeneratorHeartbeats();
             ResourcesChanged = true;
         }
     }
@@ -219,8 +254,11 @@ public partial class Character : IMagicUser
         if (_magicResourceGenerators.Contains(generator))
         {
             _magicResourceGenerators.Remove(generator);
-            Gameworld.HeartbeatManager.FuzzyMinuteHeartbeat -= _generatorDelegateDictionary[generator];
-            _generatorDelegateDictionary.Remove(generator);
+            if (_generatorDelegateDictionary.Remove(generator, out HeartbeatManagerDelegate hbdelegate))
+            {
+                Gameworld.HeartbeatManager.FuzzyMinuteHeartbeat -= hbdelegate;
+            }
+
             ResourcesChanged = true;
         }
     }

--- a/MudSharpCore/Framework/PerceivedItem.cs
+++ b/MudSharpCore/Framework/PerceivedItem.cs
@@ -286,7 +286,7 @@ public abstract class PerceivedItem : LateKeywordedInitialisingItem, IPerceivabl
 
     protected void CacheScheduledEffects()
     {
-        _cachedEffects.Clear();
+        _cachedEffects.RemoveAll(x => !Effects.Contains(x.Effect));
         foreach (IEffect effect in Effects.Distinct().ToList())
         {
             if (!Gameworld.EffectScheduler.IsScheduled(effect))
@@ -294,7 +294,17 @@ public abstract class PerceivedItem : LateKeywordedInitialisingItem, IPerceivabl
                 continue;
             }
 
-            _cachedEffects.Add((effect, EffectHandler.ScheduledDuration(effect)));
+            TimeSpan duration = EffectHandler.ScheduledDuration(effect);
+            int existing = _cachedEffects.FindIndex(x => x.Effect == effect);
+            if (existing >= 0)
+            {
+                _cachedEffects[existing] = (effect, duration);
+            }
+            else
+            {
+                _cachedEffects.Add((effect, duration));
+            }
+
             Gameworld.EffectScheduler.Unschedule(effect);
         }
     }

--- a/MudSharpCore/NPC/NPC.cs
+++ b/MudSharpCore/NPC/NPC.cs
@@ -77,6 +77,12 @@ public class NPC : Character.Character, INPC
 
     public void SetupEventSubscriptions()
     {
+        if (State.HasFlag(CharacterState.Dead) || State.HasFlag(CharacterState.Stasis))
+        {
+            ReleaseEventSubscriptions();
+            return;
+        }
+
         if (AIs.Any(x => x.HandlesEvent(EventType.FiveSecondTick)))
         {
             Gameworld.HeartbeatManager.FuzzyFiveSecondHeartbeat -= FiveSecondHeartbeat;
@@ -145,6 +151,7 @@ public class NPC : Character.Character, INPC
 
     public override IGameItem Die()
     {
+        ReleaseEventSubscriptions();
         if (_bodyguardingCharacterId.HasValue)
         {
             _bodyguardingCharacterId = null;


### PR DESCRIPTION
## Summary
- Prevent dormant, dead, or stasis bodies from continuing health, drug, stamina, breathing, and status processing
- Pause and resume character lifecycle heartbeats for forced transformations and magic resource regeneration based on live state
- Update multiple-body-form documentation and add unit coverage for dormant-body and stasis guards

## Testing
- Added unit tests covering dormant body processing guards and stasis character heartbeat suppression
- Not run (not requested)