### PR TITLE
Fix stabled mounts from reloading on boot

### DIFF
--- a/Design Documents/Economy_System_Runtime.md
+++ b/Design Documents/Economy_System_Runtime.md
@@ -282,7 +282,7 @@ The current implementation ties each stable to:
 - employee records for proprietors, managers, and employees
 - stable-specific accounts, where positive balance is prepaid credit and negative balance is debt up to a credit limit
 
-Lodging a mount creates a `StableStay`, charges the lodge fee immediately, creates a singleton-generated stable ticket item, records a ledger entry, and quits the mount out of the active world. Whole-day daily fees accrue against open stays by the economic zone calendar. Fee policy changes assess all open stays before applying the new policy, so older days are not repriced retroactively.
+Lodging a mount creates a `StableStay`, charges the lodge fee immediately, creates a singleton-generated stable ticket item, records a ledger entry, and quits the mount out of the active world. During boot, NPC loading excludes mount character ids that belong to active stable stays, so stabled mounts remain offline and in stasis until redeem or manager release restores them. Whole-day daily fees accrue against open stays by the economic zone calendar. Fee policy changes assess all open stays before applying the new policy, so older days are not repriced retroactively.
 
 Redeeming requires a valid stable ticket component whose stored stay id, ticket item id, and token still match an active stay. The redeemer may differ from the original lodger, but outstanding fees must be settled first by cash, bank-payment item, or an authorised stable account. Manager release closes the stay, invalidates existing tickets by changing the token, and logs the mount back into the stable location. Managers can waive outstanding fees or leave debt in the stay history.
 

--- a/Design Documents/Economy_System_Workflows_and_Integration.md
+++ b/Design Documents/Economy_System_Workflows_and_Integration.md
@@ -211,7 +211,7 @@ Builders need:
 - optional access and rejection-text FutureProgs using `(customer, mount)`
 - managers or proprietors if non-admin characters should operate the stable
 
-Player workflows are surfaced through `stable`, `stable quote`, `stable lodge`, `stable redeem`, `stable accountstatus`, and `stable payaccount`. Lodging issues a system-generated stable ticket item and removes the mount from the active world. Redeeming checks the ticket's stay id, item id, and token, then requires any outstanding fees to be settled before the mount is logged back into the stable cell.
+Player workflows are surfaced through `stable`, `stable quote`, `stable lodge`, `stable redeem`, `stable accountstatus`, and `stable payaccount`. Lodging issues a system-generated stable ticket item and removes the mount from the active world. Active stable stays also suppress their mount ids during NPC boot loading, so rebooted servers do not return lodged mounts to the stable room. Redeeming checks the ticket's stay id, item id, and token, then requires any outstanding fees to be settled before the mount is logged back into the stable cell.
 
 Manager workflows include active/history lists, stay inspection, ticketless release, fee setup, account setup, employee management, bank-account assignment, open/close state, and access-prog setup. A property sale or lease can claim stables in the property for the single character controller in the same operational style as property shops.
 

--- a/MudSharpCore Unit Tests/BootLoadingRegressionTests.cs
+++ b/MudSharpCore Unit Tests/BootLoadingRegressionTests.cs
@@ -50,6 +50,26 @@ public class BootLoadingRegressionTests
     }
 
     [TestMethod]
+    public void ShouldLoadNpcAtBoot_ActiveStableStay_ReturnsFalse()
+    {
+        HashSet<long> activeStableMountIds = new() { 123L };
+
+        bool result = Futuremud.ShouldLoadNpcAtBoot(123L, CharacterState.Awake, activeStableMountIds);
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void ShouldLoadNpcAtBoot_NormalLivingNpc_ReturnsTrue()
+    {
+        HashSet<long> activeStableMountIds = new() { 456L };
+
+        bool result = Futuremud.ShouldLoadNpcAtBoot(123L, CharacterState.Awake, activeStableMountIds);
+
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
     public void PropertySaleOrder_DbConstructor_MatchesConsentWithoutDereferencingOwner()
     {
         Mock<IFuturemud> gameworld = new();

--- a/MudSharpCore/Framework/FuturemudLoaders.cs
+++ b/MudSharpCore/Framework/FuturemudLoaders.cs
@@ -2596,6 +2596,12 @@ For information on the syntax to use in emotes (such as those included in bracke
         ConsoleUtilities.WriteLine("Loaded #2{0}#0 NPC Template{1}.", count, count == 1 ? "" : "s");
     }
 
+    internal static bool ShouldLoadNpcAtBoot(long npcCharacterId, CharacterState state, ISet<long> activeStableMountIds)
+    {
+        return !state.HasFlag(CharacterState.Dead) &&
+               !activeStableMountIds.Contains(npcCharacterId);
+    }
+
     void IFuturemudLoader.LoadNPCs()
     {
         ConsoleUtilities.WriteLine("\nLoading #5NPCs#0...");
@@ -2604,6 +2610,11 @@ For information on the syntax to use in emotes (such as those included in bracke
         sw.Start();
 #endif
         DummyAccount.Instance.SetupGameworld(this);
+        var activeStableMountIds = FMDB.Context.StableStays
+                                     .AsNoTracking()
+                                     .Where(x => x.Status == (int)StableStayStatus.Active)
+                                     .Select(x => x.MountId)
+                                     .ToHashSet();
         List<Npc> npcs = (from npc in FMDB.Context.Npcs
                                     .Include(x => x.NpcsArtificialIntelligences)
                                     .Include(x => x.Character)
@@ -2631,8 +2642,12 @@ For information on the syntax to use in emotes (such as those included in bracke
                           */
                           where !((CharacterState)npc.Character.State).HasFlag(CharacterState.Dead)
                           select npc).ToList();
+        List<Npc> loadableNpcs = npcs
+                                 .Where(x => ShouldLoadNpcAtBoot(x.CharacterId,
+                                     (CharacterState)x.Character.State, activeStableMountIds))
+                                 .ToList();
 
-        foreach (Npc npc in npcs)
+        foreach (Npc npc in loadableNpcs)
         {
             ICharacter newNpc = TryGetCharacter(npc.CharacterId);
             if (npc.BodyguardCharacterId != null)
@@ -2660,7 +2675,7 @@ For information on the syntax to use in emotes (such as those included in bracke
         sw.Stop();
         ConsoleUtilities.WriteLine($"Duration: #2{sw.ElapsedMilliseconds}ms#0");
 #endif
-        int count = npcs.Count;
+        int count = loadableNpcs.Count;
         ConsoleUtilities.WriteLine("Loaded #2{0}#0 NPC{1}.", count, count == 1 ? "" : "s");
 
         ConsoleUtilities.WriteLine("\nLoading #5Guests#0...");


### PR DESCRIPTION
## Summary
- Exclude active stable-stay mounts from NPC boot loading so lodged mounts stay offline and in stasis across restarts
- Add regression coverage for the boot-load predicate in the core unit tests
- Update the stable runtime and workflow docs to reflect reboot persistence behavior

## Testing
- `MudSharpCore Unit Tests` passed with the new regression tests
- Verified the core unit test project locally; all tests passed