### PR TITLE
Add direct documentation for FutureProg built-ins

### DIFF
--- a/MudSharpCore Unit Tests/FutureProgFunctionDocumentationTests.cs
+++ b/MudSharpCore Unit Tests/FutureProgFunctionDocumentationTests.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.FutureProg.Functions;
+using MudSharp.FutureProg.Variables;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class FutureProgFunctionDocumentationTests
+{
+	[TestMethod]
+	public void RegisterFunctionCompiler_AllBuiltInFunctionTypes_ExposeStaticRegistration()
+	{
+		var missing = Futuremud.GetAllTypes()
+			.Where(x => x.IsSubclassOf(typeof(BuiltInFunction)) && !x.IsAbstract)
+			.Where(x => x.GetMethod("RegisterFunctionCompiler", BindingFlags.Public | BindingFlags.Static) is null)
+			.Select(x => x.FullName)
+			.OrderBy(x => x)
+			.ToList();
+
+		Assert.AreEqual(
+			0,
+			missing.Count,
+			$"Built-in FutureProg functions missing public static RegisterFunctionCompiler():{Environment.NewLine}{string.Join(Environment.NewLine, missing)}"
+		);
+	}
+
+	[TestMethod]
+	public void BuiltInFunctionMetadata_AllRegisteredFunctions_AreFullyDocumented()
+	{
+		FutureProgTestBootstrap.EnsureInitialised();
+
+		var failures = FutureProg.GetFunctionCompilerInformations()
+			.SelectMany(ValidateFunction)
+			.ToList();
+
+		Assert.AreEqual(
+			0,
+			failures.Count,
+			$"Built-in FutureProg function documentation gaps:{Environment.NewLine}{string.Join(Environment.NewLine, failures.Take(100))}"
+		);
+	}
+
+	[TestMethod]
+	public void BuiltInFunctionMetadata_DeclaredReturnTypes_MatchCompiledFunctions()
+	{
+		FutureProgTestBootstrap.EnsureInitialised();
+
+		var failures = FutureProg.GetFunctionCompilerInformations()
+			.Select(ValidateDeclaredReturnType)
+			.Where(x => !string.IsNullOrWhiteSpace(x))
+			.ToList();
+
+		Assert.AreEqual(
+			0,
+			failures.Count,
+			$"Built-in FutureProg function return metadata mismatches:{Environment.NewLine}{string.Join(Environment.NewLine, failures.Take(100))}"
+		);
+	}
+
+	private static IEnumerable<string> ValidateFunction(FunctionCompilerInformation function)
+	{
+		var signature = $"{function.FunctionName}({string.Join(", ", function.Parameters.Select(x => x.Describe()))})";
+		var parameters = function.Parameters.ToList();
+		var parameterNames = function.ParameterNames?.ToList();
+		var parameterHelp = function.ParameterHelp?.ToList();
+
+		if (string.IsNullOrWhiteSpace(function.FunctionName))
+		{
+			yield return $"{signature}: missing function name";
+		}
+
+		if (string.IsNullOrWhiteSpace(function.FunctionHelp))
+		{
+			yield return $"{signature}: missing function help";
+		}
+
+		if (string.IsNullOrWhiteSpace(function.Category) || function.Category.EqualTo("Uncategorised"))
+		{
+			yield return $"{signature}: missing category";
+		}
+
+		if (function.ReturnType == ProgVariableTypes.Error)
+		{
+			yield return $"{signature}: missing return type";
+		}
+
+		if (parameterNames is null || parameterNames.Count != parameters.Count)
+		{
+			yield return $"{signature}: parameter name count does not match parameter count";
+		}
+		else
+		{
+			foreach (var name in parameterNames.Where(string.IsNullOrWhiteSpace))
+			{
+				yield return $"{signature}: blank parameter name";
+			}
+
+			foreach (var duplicate in parameterNames.GroupBy(x => x, StringComparer.InvariantCultureIgnoreCase).Where(x => x.Count() > 1))
+			{
+				yield return $"{signature}: duplicate parameter name {duplicate.Key}";
+			}
+		}
+
+		if (parameterHelp is null || parameterHelp.Count != parameters.Count)
+		{
+			yield return $"{signature}: parameter help count does not match parameter count";
+		}
+		else
+		{
+			foreach (var help in parameterHelp.Where(string.IsNullOrWhiteSpace))
+			{
+				yield return $"{signature}: blank parameter help";
+			}
+		}
+	}
+
+	private static string ValidateDeclaredReturnType(FunctionCompilerInformation function)
+	{
+		var signature = $"{function.FunctionName}({string.Join(", ", function.Parameters.Select(x => x.Describe()))})";
+		if (function.FunctionName.EqualTo("getregister"))
+		{
+			return null;
+		}
+
+		if (function.ReturnType == ProgVariableTypes.Anything)
+		{
+			return null;
+		}
+
+		try
+		{
+			var parameters = function.Parameters
+				.Select(x => new ReturnTypeOnlyFunction(x))
+				.Cast<IFunction>()
+				.ToList();
+			var compiled = function.CompilerFunction(parameters, FutureProgTestBootstrap.Gameworld);
+			if (!compiled.ReturnType.CompatibleWith(function.ReturnType) &&
+			    !function.ReturnType.CompatibleWith(compiled.ReturnType))
+			{
+				return $"{signature}: registered return type {function.ReturnType.Describe()} but compiled function returns {compiled.ReturnType.Describe()}";
+			}
+		}
+		catch (Exception ex)
+		{
+			return $"{signature}: compiler threw {ex.GetType().Name}: {ex.Message}";
+		}
+
+		return null;
+	}
+
+	private sealed class ReturnTypeOnlyFunction : IFunction
+	{
+		public ReturnTypeOnlyFunction(ProgVariableTypes returnType)
+		{
+			ReturnType = returnType;
+			Result = returnType.CompatibleWith(ProgVariableTypes.Number)
+				? new NumberVariable(1.0M)
+				: returnType.CompatibleWith(ProgVariableTypes.Text)
+					? new TextVariable("text")
+					: returnType.CompatibleWith(ProgVariableTypes.Boolean)
+						? new BooleanVariable(false)
+						: null;
+		}
+
+		public IProgVariable Result { get; }
+		public ProgVariableTypes ReturnType { get; }
+		public string ErrorMessage => string.Empty;
+		public StatementResult ExpectedResult => StatementResult.Normal;
+
+		public StatementResult Execute(IVariableSpace variables)
+		{
+			return StatementResult.Normal;
+		}
+
+		public bool IsReturnOrContainsReturnOnAllBranches()
+		{
+			return false;
+		}
+	}
+}

--- a/MudSharpCore/FutureProg/Functions/ArtificialIntelligence/AddTerritoryFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/ArtificialIntelligence/AddTerritoryFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Character;
+using MudSharp.Character;
 using MudSharp.Construction;
 using MudSharp.Effects.Concrete;
 using MudSharp.FutureProg.Variables;
@@ -68,13 +68,23 @@ internal class AddTerritoryFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "addterritory",
             new[] { ProgVariableTypes.Character, ProgVariableTypes.Location },
-            (pars, gameworld) => new AddTerritoryFunction(pars)
+            (pars, gameworld) => new AddTerritoryFunction(pars),
+            new List<string> { "character", "location" },
+            new List<string> { "The character whose Territory effect should gain the room.", "The room to add to the character's territory." },
+            "Adds a room to a character's Territory effect, creating the effect if necessary. Optional text flags tag the room for later AI checks. Errors if the character or room is null; otherwise returns true.",
+            "Artificial Intelligence",
+            ProgVariableTypes.Boolean
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "addterritory",
             new[] { ProgVariableTypes.Character, ProgVariableTypes.Location, ProgVariableTypes.Text },
-            (pars, gameworld) => new AddTerritoryFunction(pars, 1)
+            (pars, gameworld) => new AddTerritoryFunction(pars, 1),
+            new List<string> { "character", "location", "flag1" },
+            new List<string> { "The character whose Territory effect should gain the room.", "The room to add to the character's territory.", "A text tag to attach to this territory room for later AI checks." },
+            "Adds a room to a character's Territory effect, creating the effect if necessary. Optional text flags tag the room for later AI checks. Errors if the character or room is null; otherwise returns true.",
+            "Artificial Intelligence",
+            ProgVariableTypes.Boolean
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
@@ -84,7 +94,12 @@ internal class AddTerritoryFunction : BuiltInFunction
                 ProgVariableTypes.Character, ProgVariableTypes.Location, ProgVariableTypes.Text,
                 ProgVariableTypes.Text
             },
-            (pars, gameworld) => new AddTerritoryFunction(pars, 2)
+            (pars, gameworld) => new AddTerritoryFunction(pars, 2),
+            new List<string> { "character", "location", "flag1", "flag2" },
+            new List<string> { "The character whose Territory effect should gain the room.", "The room to add to the character's territory.", "A text tag to attach to this territory room for later AI checks.", "A second text tag to attach to this territory room." },
+            "Adds a room to a character's Territory effect, creating the effect if necessary. Optional text flags tag the room for later AI checks. Errors if the character or room is null; otherwise returns true.",
+            "Artificial Intelligence",
+            ProgVariableTypes.Boolean
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
@@ -94,7 +109,12 @@ internal class AddTerritoryFunction : BuiltInFunction
                 ProgVariableTypes.Character, ProgVariableTypes.Location, ProgVariableTypes.Text,
                 ProgVariableTypes.Text, ProgVariableTypes.Text
             },
-            (pars, gameworld) => new AddTerritoryFunction(pars, 3)
+            (pars, gameworld) => new AddTerritoryFunction(pars, 3),
+            new List<string> { "character", "location", "flag1", "flag2", "flag3" },
+            new List<string> { "The character whose Territory effect should gain the room.", "The room to add to the character's territory.", "A text tag to attach to this territory room for later AI checks.", "A second text tag to attach to this territory room.", "A third text tag to attach to this territory room." },
+            "Adds a room to a character's Territory effect, creating the effect if necessary. Optional text flags tag the room for later AI checks. Errors if the character or room is null; otherwise returns true.",
+            "Artificial Intelligence",
+            ProgVariableTypes.Boolean
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/ArtificialIntelligence/IsTerritoryFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/ArtificialIntelligence/IsTerritoryFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Character;
+using MudSharp.Character;
 using MudSharp.Construction;
 using MudSharp.Effects.Concrete;
 using MudSharp.Framework;
@@ -72,13 +72,23 @@ internal class IsTerritoryFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "isterritory",
             new[] { ProgVariableTypes.Character, ProgVariableTypes.Location },
-            (pars, gameworld) => new IsTerritoryFunction(pars)
+            (pars, gameworld) => new IsTerritoryFunction(pars),
+            new List<string> { "character", "location" },
+            new List<string> { "The character whose Territory effect should be checked.", "The room to test against the character's territory." },
+            "Checks whether a room is in a character's Territory effect and, when flags are supplied, whether all supplied flags are present. Errors if the character or room is null; returns false if the character has no territory effect or any flag is missing.",
+            "Artificial Intelligence",
+            ProgVariableTypes.Boolean
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "isterritory",
             new[] { ProgVariableTypes.Character, ProgVariableTypes.Location, ProgVariableTypes.Text },
-            (pars, gameworld) => new IsTerritoryFunction(pars, 1)
+            (pars, gameworld) => new IsTerritoryFunction(pars, 1),
+            new List<string> { "character", "location", "flag1" },
+            new List<string> { "The character whose Territory effect should be checked.", "The room to test against the character's territory.", "A text tag that must be present on this territory room." },
+            "Checks whether a room is in a character's Territory effect and, when flags are supplied, whether all supplied flags are present. Errors if the character or room is null; returns false if the character has no territory effect or any flag is missing.",
+            "Artificial Intelligence",
+            ProgVariableTypes.Boolean
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
@@ -88,7 +98,12 @@ internal class IsTerritoryFunction : BuiltInFunction
                 ProgVariableTypes.Character, ProgVariableTypes.Location, ProgVariableTypes.Text,
                 ProgVariableTypes.Text
             },
-            (pars, gameworld) => new IsTerritoryFunction(pars, 2)
+            (pars, gameworld) => new IsTerritoryFunction(pars, 2),
+            new List<string> { "character", "location", "flag1", "flag2" },
+            new List<string> { "The character whose Territory effect should be checked.", "The room to test against the character's territory.", "A text tag that must be present on this territory room.", "A second text tag that must be present on this territory room." },
+            "Checks whether a room is in a character's Territory effect and, when flags are supplied, whether all supplied flags are present. Errors if the character or room is null; returns false if the character has no territory effect or any flag is missing.",
+            "Artificial Intelligence",
+            ProgVariableTypes.Boolean
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
@@ -98,7 +113,12 @@ internal class IsTerritoryFunction : BuiltInFunction
                 ProgVariableTypes.Character, ProgVariableTypes.Location, ProgVariableTypes.Text,
                 ProgVariableTypes.Text, ProgVariableTypes.Text
             },
-            (pars, gameworld) => new IsTerritoryFunction(pars, 3)
+            (pars, gameworld) => new IsTerritoryFunction(pars, 3),
+            new List<string> { "character", "location", "flag1", "flag2", "flag3" },
+            new List<string> { "The character whose Territory effect should be checked.", "The room to test against the character's territory.", "A text tag that must be present on this territory room.", "A second text tag that must be present on this territory room.", "A third text tag that must be present on this territory room." },
+            "Checks whether a room is in a character's Territory effect and, when flags are supplied, whether all supplied flags are present. Errors if the character or room is null; returns false if the character has no territory effect or any flag is missing.",
+            "Artificial Intelligence",
+            ProgVariableTypes.Boolean
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/ArtificialIntelligence/WildAnimalHerdRoleFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/ArtificialIntelligence/WildAnimalHerdRoleFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Character;
+using MudSharp.Character;
 using MudSharp.Effects.Concrete;
 using MudSharp.Framework;
 using MudSharp.FutureProg.Variables;
@@ -46,7 +46,12 @@ internal class WildAnimalHerdRoleFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "wildanimalherdrole",
             new[] { ProgVariableTypes.Character },
-            (pars, gameworld) => new WildAnimalHerdRoleFunction(pars)
+            (pars, gameworld) => new WildAnimalHerdRoleFunction(pars),
+            new List<string> { "character" },
+            new List<string> { "The character whose wild animal herd effect should be inspected." },
+            "Returns the character's current wild animal herd role as text, or 'None' if they are not in a herd. Errors if the character parameter is null.",
+            "Artificial Intelligence",
+            ProgVariableTypes.Text
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/BuiltIn/MaxFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/BuiltIn/MaxFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.FutureProg.Variables;
+using MudSharp.FutureProg.Variables;
 using System;
 using System.Collections.Generic;
 
@@ -35,7 +35,12 @@ internal class MaxFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "max",
             new[] { ProgVariableTypes.Number, ProgVariableTypes.Number },
-            (pars, gameworld) => new MaxFunction(pars)
+            (pars, gameworld) => new MaxFunction(pars),
+            new List<string> { "minimum", "maximum" },
+            new List<string> { "The lower numeric bound or first number.", "The upper numeric bound or second number." },
+            "Returns the higher of two numbers.",
+            "Built-In",
+            ProgVariableTypes.Number
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/BuiltIn/MinFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/BuiltIn/MinFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.FutureProg.Variables;
+using MudSharp.FutureProg.Variables;
 using System;
 using System.Collections.Generic;
 
@@ -35,7 +35,12 @@ internal class MinFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "min",
             new[] { ProgVariableTypes.Number, ProgVariableTypes.Number },
-            (pars, gameworld) => new MinFunction(pars)
+            (pars, gameworld) => new MinFunction(pars),
+            new List<string> { "minimum", "maximum" },
+            new List<string> { "The lower numeric bound or first number.", "The upper numeric bound or second number." },
+            "Returns the lower of two numbers.",
+            "Built-In",
+            ProgVariableTypes.Number
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/BuiltIn/RandomFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/BuiltIn/RandomFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Framework;
+using MudSharp.Framework;
 using MudSharp.FutureProg.Variables;
 using System.Collections.Generic;
 
@@ -34,7 +34,12 @@ internal class RandomFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "random",
             new[] { ProgVariableTypes.Number, ProgVariableTypes.Number },
-            (pars, gameworld) => new RandomFunction(pars)
+            (pars, gameworld) => new RandomFunction(pars),
+            new List<string> { "minimum", "maximum" },
+            new List<string> { "The lower numeric bound or first number.", "The upper numeric bound or second number." },
+            "Returns a random whole number between the supplied minimum and maximum bounds. This is the FutureProg random helper for simple integer-range rolls.",
+            "Built-In",
+            ProgVariableTypes.Number
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/BuiltIn/RemoveHookFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/BuiltIn/RemoveHookFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Events.Hooks;
+using MudSharp.Events.Hooks;
 using MudSharp.Framework;
 using MudSharp.FutureProg.Variables;
 using System.Collections.Generic;
@@ -68,7 +68,12 @@ internal class RemoveHookFunction : BuiltInFunction
             new FunctionCompilerInformation(
                 "removehook",
                 new[] { ProgVariableTypes.Perceivable, ProgVariableTypes.Number },
-                (pars, gameworld) => new RemoveHookFunction(pars, gameworld)
+                (pars, gameworld) => new RemoveHookFunction(pars, gameworld),
+                new List<string> { "target", "hookId" },
+                new List<string> { "The target character, item, location, or perceivable for the operation.", "The ID of the hook to remove." },
+                "Removes a named or numbered event hook from a perceivable target. Returns false if the target, hook argument, hook lookup, or perceivable conversion fails; otherwise returns the result of the target's hook removal.",
+                "Built-In",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -76,7 +81,12 @@ internal class RemoveHookFunction : BuiltInFunction
             new FunctionCompilerInformation(
                 "removehook",
                 new[] { ProgVariableTypes.Perceivable, ProgVariableTypes.Text },
-                (pars, gameworld) => new RemoveHookFunction(pars, gameworld)
+                (pars, gameworld) => new RemoveHookFunction(pars, gameworld),
+                new List<string> { "target", "hookName" },
+                new List<string> { "The target character, item, location, or perceivable for the operation.", "The name of the hook to remove." },
+                "Removes a named or numbered event hook from a perceivable target. Returns false if the target, hook argument, hook lookup, or perceivable conversion fails; otherwise returns the result of the target's hook removal.",
+                "Built-In",
+                ProgVariableTypes.Boolean
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/BuiltIn/SameRaceFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/BuiltIn/SameRaceFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Character.Heritage;
+using MudSharp.Character.Heritage;
 using MudSharp.FutureProg.Variables;
 using System.Collections.Generic;
 
@@ -42,7 +42,12 @@ internal class SameRaceFunction : BuiltInFunction
             new FunctionCompilerInformation(
                 "samerace",
                 new[] { ProgVariableTypes.Race, ProgVariableTypes.Race },
-                (pars, gameworld) => new SameRaceFunction(pars)
+                (pars, gameworld) => new SameRaceFunction(pars),
+                new List<string> { "race1", "race2" },
+                new List<string> { "The first race to compare.", "The second race to compare." },
+                "Returns true when both race references point to the same race object. Null races simply compare as not the same.",
+                "Built-In",
+                ProgVariableTypes.Boolean
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/BuiltIn/TextFromUnitFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/BuiltIn/TextFromUnitFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Framework;
+using MudSharp.Framework;
 using MudSharp.Framework.Units;
 using MudSharp.FutureProg.Variables;
 using System.Collections.Generic;
@@ -49,36 +49,66 @@ internal class TextFromUnitFunction : BuiltInFunction, IHaveFuturemud
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "textfromlength",
             new[] { ProgVariableTypes.Number },
-            (pars, gameworld) => new TextFromUnitFunction(pars, gameworld, UnitType.Length)
+            (pars, gameworld) => new TextFromUnitFunction(pars, gameworld, UnitType.Length),
+            new List<string> { "amount" },
+            new List<string> { "The amount to use. Text amounts are parsed using the target system's normal builder/player parsing rules." },
+            "Formats a base-unit length value as player-facing text using the unit manager. This is the inverse of lengthfromtext for builder scripts that need readable units.",
+            "Built-In",
+            ProgVariableTypes.Text
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "textfrommass",
             new[] { ProgVariableTypes.Number },
-            (pars, gameworld) => new TextFromUnitFunction(pars, gameworld, UnitType.Mass)
+            (pars, gameworld) => new TextFromUnitFunction(pars, gameworld, UnitType.Mass),
+            new List<string> { "amount" },
+            new List<string> { "The amount to use. Text amounts are parsed using the target system's normal builder/player parsing rules." },
+            "Formats a base-unit mass value as player-facing text using the unit manager. This is the inverse of massfromtext for builder scripts that need readable units.",
+            "Built-In",
+            ProgVariableTypes.Text
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "textfromfluid",
             new[] { ProgVariableTypes.Number },
-            (pars, gameworld) => new TextFromUnitFunction(pars, gameworld, UnitType.FluidVolume)
+            (pars, gameworld) => new TextFromUnitFunction(pars, gameworld, UnitType.FluidVolume),
+            new List<string> { "amount" },
+            new List<string> { "The amount to use. Text amounts are parsed using the target system's normal builder/player parsing rules." },
+            "Formats a base-unit fluid volume value as player-facing text using the unit manager. This is the inverse of fluid volumefromtext for builder scripts that need readable units.",
+            "Built-In",
+            ProgVariableTypes.Text
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "textfromarea",
             new[] { ProgVariableTypes.Number },
-            (pars, gameworld) => new TextFromUnitFunction(pars, gameworld, UnitType.Area)
+            (pars, gameworld) => new TextFromUnitFunction(pars, gameworld, UnitType.Area),
+            new List<string> { "amount" },
+            new List<string> { "The amount to use. Text amounts are parsed using the target system's normal builder/player parsing rules." },
+            "Formats a base-unit area value as player-facing text using the unit manager. This is the inverse of areafromtext for builder scripts that need readable units.",
+            "Built-In",
+            ProgVariableTypes.Text
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "textfromvolume",
             new[] { ProgVariableTypes.Number },
-            (pars, gameworld) => new TextFromUnitFunction(pars, gameworld, UnitType.Volume)
+            (pars, gameworld) => new TextFromUnitFunction(pars, gameworld, UnitType.Volume),
+            new List<string> { "amount" },
+            new List<string> { "The amount to use. Text amounts are parsed using the target system's normal builder/player parsing rules." },
+            "Formats a base-unit volume value as player-facing text using the unit manager. This is the inverse of volumefromtext for builder scripts that need readable units.",
+            "Built-In",
+            ProgVariableTypes.Text
         ));
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "textfromtemp",
             new[] { ProgVariableTypes.Number },
-            (pars, gameworld) => new TextFromUnitFunction(pars, gameworld, UnitType.Temperature)
+            (pars, gameworld) => new TextFromUnitFunction(pars, gameworld, UnitType.Temperature),
+            new List<string> { "amount" },
+            new List<string> { "The amount to use. Text amounts are parsed using the target system's normal builder/player parsing rules." },
+            "Formats a base-unit temperature value as player-facing text using the unit manager. This is the inverse of temperaturefromtext for builder scripts that need readable units.",
+            "Built-In",
+            ProgVariableTypes.Text
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/BuiltIn/ToItemFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/BuiltIn/ToItemFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.GameItems;
+using MudSharp.GameItems;
 using System.Collections.Generic;
 
 namespace MudSharp.FutureProg.Functions.BuiltIn;
@@ -32,19 +32,34 @@ internal class ToItemFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "toitem",
             new[] { ProgVariableTypes.Perceiver },
-            (pars, gameworld) => new ToItemFunction(pars)
+            (pars, gameworld) => new ToItemFunction(pars),
+            new List<string> { "value" },
+            new List<string> { "The value to convert or inspect." },
+            "Attempts to treat a perceiver, perceivable, or collection item as an item. Returns null when the supplied value is not an item.",
+            "Built-In",
+            ProgVariableTypes.Item
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "toitem",
             new[] { ProgVariableTypes.Perceivable },
-            (pars, gameworld) => new ToItemFunction(pars)
+            (pars, gameworld) => new ToItemFunction(pars),
+            new List<string> { "value" },
+            new List<string> { "The value to convert or inspect." },
+            "Attempts to treat a perceiver, perceivable, or collection item as an item. Returns null when the supplied value is not an item.",
+            "Built-In",
+            ProgVariableTypes.Item
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "toitem",
             new[] { ProgVariableTypes.CollectionItem },
-            (pars, gameworld) => new ToItemFunction(pars)
+            (pars, gameworld) => new ToItemFunction(pars),
+            new List<string> { "value" },
+            new List<string> { "The value to convert or inspect." },
+            "Attempts to treat a perceiver, perceivable, or collection item as an item. Returns null when the supplied value is not an item.",
+            "Built-In",
+            ProgVariableTypes.Item
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/BuiltIn/ToNumberFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/BuiltIn/ToNumberFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.FutureProg.Variables;
+using MudSharp.FutureProg.Variables;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -39,13 +39,23 @@ internal class ToNumberFunction : BuiltInFunction
             new[] { ProgVariableTypes.Text },
             (pars, gameworld) =>
                 new ToNumberFunction(
-                    pars.Concat(new IFunction[] { new ConstantFunction(new NumberVariable(0)) }).ToList())
+                    pars.Concat(new IFunction[] { new ConstantFunction(new NumberVariable(0)) }).ToList()),
+            new List<string> { "text" },
+            new List<string> { "The text to parse." },
+            "Parses text into a number. If parsing fails, the result is 0.",
+            "Built-In",
+            ProgVariableTypes.Number
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "tonumber",
             new[] { ProgVariableTypes.Text, ProgVariableTypes.Number },
-            (pars, gameworld) => new ToNumberFunction(pars)
+            (pars, gameworld) => new ToNumberFunction(pars),
+            new List<string> { "text", "fallback" },
+            new List<string> { "The text to parse.", "The number to return if the text cannot be parsed." },
+            "Parses text into a number, returning the supplied fallback number when parsing fails.",
+            "Built-In",
+            ProgVariableTypes.Number
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/BuiltIn/ToTextFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/BuiltIn/ToTextFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Form.Shape;
+using MudSharp.Form.Shape;
 using MudSharp.FutureProg.Variables;
 using System.Collections.Generic;
 using System.Linq;
@@ -54,19 +54,34 @@ internal class ToTextFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "totext",
             new[] { ProgVariableTypes.Number },
-            (pars, gameworld) => new ToTextFunction(pars)
+            (pars, gameworld) => new ToTextFunction(pars),
+            new List<string> { "value" },
+            new List<string> { "The value to convert or inspect." },
+            "Converts the supplied value to text using the standard FutureProg conversion rules.",
+            "Built-In",
+            ProgVariableTypes.Text
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "totext",
             new[] { ProgVariableTypes.Boolean },
-            (pars, gameworld) => new ToTextFunction(pars)
+            (pars, gameworld) => new ToTextFunction(pars),
+            new List<string> { "value" },
+            new List<string> { "The value to convert or inspect." },
+            "Converts the supplied value to text using the standard FutureProg conversion rules.",
+            "Built-In",
+            ProgVariableTypes.Text
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "totext",
             new[] { ProgVariableTypes.Gender },
-            (pars, gameworld) => new ToTextFunction(pars)
+            (pars, gameworld) => new ToTextFunction(pars),
+            new List<string> { "value" },
+            new List<string> { "The value to convert or inspect." },
+            "Converts the supplied value to text using the standard FutureProg conversion rules.",
+            "Built-In",
+            ProgVariableTypes.Text
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/BuiltIn/UnitFromTextFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/BuiltIn/UnitFromTextFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Framework;
+using MudSharp.Framework;
 using MudSharp.Framework.Units;
 using MudSharp.FutureProg.Variables;
 using System.Collections.Generic;
@@ -56,37 +56,67 @@ internal class UnitFromTextFunction : BuiltInFunction, IHaveFuturemud
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "lengthfromtext",
             new[] { ProgVariableTypes.Text },
-            (pars, gameworld) => new UnitFromTextFunction(pars, gameworld, UnitType.Length)
+            (pars, gameworld) => new UnitFromTextFunction(pars, gameworld, UnitType.Length),
+            new List<string> { "text" },
+            new List<string> { "The text to parse." },
+            "Parses length text into base units using the unit manager. Returns an error if the text is not a valid unit expression.",
+            "Built-In",
+            ProgVariableTypes.Number
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "massfromtext",
             new[] { ProgVariableTypes.Text },
-            (pars, gameworld) => new UnitFromTextFunction(pars, gameworld, UnitType.Mass)
+            (pars, gameworld) => new UnitFromTextFunction(pars, gameworld, UnitType.Mass),
+            new List<string> { "text" },
+            new List<string> { "The text to parse." },
+            "Parses mass text into base units using the unit manager. Returns an error if the text is not a valid unit expression.",
+            "Built-In",
+            ProgVariableTypes.Number
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "fluidfromtext",
             new[] { ProgVariableTypes.Text },
-            (pars, gameworld) => new UnitFromTextFunction(pars, gameworld, UnitType.FluidVolume)
+            (pars, gameworld) => new UnitFromTextFunction(pars, gameworld, UnitType.FluidVolume),
+            new List<string> { "text" },
+            new List<string> { "The text to parse." },
+            "Parses fluid volume text into base units using the unit manager. Returns an error if the text is not a valid unit expression.",
+            "Built-In",
+            ProgVariableTypes.Number
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "areafromtext",
             new[] { ProgVariableTypes.Text },
-            (pars, gameworld) => new UnitFromTextFunction(pars, gameworld, UnitType.Area)
+            (pars, gameworld) => new UnitFromTextFunction(pars, gameworld, UnitType.Area),
+            new List<string> { "text" },
+            new List<string> { "The text to parse." },
+            "Parses area text into base units using the unit manager. Returns an error if the text is not a valid unit expression.",
+            "Built-In",
+            ProgVariableTypes.Number
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "volumefromtext",
             new[] { ProgVariableTypes.Text },
-            (pars, gameworld) => new UnitFromTextFunction(pars, gameworld, UnitType.Volume)
+            (pars, gameworld) => new UnitFromTextFunction(pars, gameworld, UnitType.Volume),
+            new List<string> { "text" },
+            new List<string> { "The text to parse." },
+            "Parses volume text into base units using the unit manager. Returns an error if the text is not a valid unit expression.",
+            "Built-In",
+            ProgVariableTypes.Number
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "tempfromtext",
             new[] { ProgVariableTypes.Text },
-            (pars, gameworld) => new UnitFromTextFunction(pars, gameworld, UnitType.Temperature)
+            (pars, gameworld) => new UnitFromTextFunction(pars, gameworld, UnitType.Temperature),
+            new List<string> { "text" },
+            new List<string> { "The text to parse." },
+            "Parses temperature text into base units using the unit manager. Returns an error if the text is not a valid unit expression.",
+            "Built-In",
+            ProgVariableTypes.Number
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/BuiltIn/WordyNumberFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/BuiltIn/WordyNumberFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Framework;
+using MudSharp.Framework;
 using MudSharp.FutureProg.Variables;
 using System;
 using System.Collections.Generic;
@@ -45,19 +45,34 @@ internal class WordyNumberFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "tonumberwords",
             new[] { ProgVariableTypes.Number },
-            (pars, gameworld) => new WordyNumberFunction(pars, NumberUtilities.ToWordyNumber)
+            (pars, gameworld) => new WordyNumberFunction(pars, NumberUtilities.ToWordyNumber),
+            new List<string> { "number" },
+            new List<string> { "The number to render as words." },
+            "Converts a number to cardinal words, such as one hundred and five.",
+            "Built-In",
+            ProgVariableTypes.Text
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "toordinalwords",
             new[] { ProgVariableTypes.Number },
-            (pars, gameworld) => new WordyNumberFunction(pars, NumberUtilities.ToWordyOrdinal)
+            (pars, gameworld) => new WordyNumberFunction(pars, NumberUtilities.ToWordyOrdinal),
+            new List<string> { "number" },
+            new List<string> { "The number to render as words." },
+            "Converts a number to ordinal words, such as one hundred and fifth.",
+            "Built-In",
+            ProgVariableTypes.Text
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "toordinal",
             new[] { ProgVariableTypes.Number },
-            (pars, gameworld) => new WordyNumberFunction(pars, NumberUtilities.ToOrdinal)
+            (pars, gameworld) => new WordyNumberFunction(pars, NumberUtilities.ToOrdinal),
+            new List<string> { "number" },
+            new List<string> { "The number to render as words." },
+            "Converts a number to ordinal text, such as 1st or 22nd.",
+            "Built-In",
+            ProgVariableTypes.Text
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/Celestials/CelestialPositionFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Celestials/CelestialPositionFunction.cs
@@ -55,13 +55,23 @@ internal class CelestialPositionFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "celestialposition",
             new[] { ProgVariableTypes.Location, ProgVariableTypes.Number },
-            (pars, gameworld) => new CelestialPositionFunction(pars)
+            (pars, gameworld) => new CelestialPositionFunction(pars),
+            new List<string> { "locationOrZone", "celestialId" },
+            new List<string> { "The room or zone whose celestial collection is searched.", "The ID of the celestial object to describe." },
+            "Looks up a celestial object by ID in the supplied room or zone and returns the same descriptive position text used by the celestial system. Returns an empty string if the zone or celestial object cannot be found.",
+            "Celestials",
+            ProgVariableTypes.Text
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "celestialposition",
             new[] { ProgVariableTypes.Zone, ProgVariableTypes.Number },
-            (pars, gameworld) => new CelestialPositionFunction(pars)
+            (pars, gameworld) => new CelestialPositionFunction(pars),
+            new List<string> { "locationOrZone", "celestialId" },
+            new List<string> { "The room or zone whose celestial collection is searched.", "The ID of the celestial object to describe." },
+            "Looks up a celestial object by ID in the supplied room or zone and returns the same descriptive position text used by the celestial system. Returns an empty string if the zone or celestial object cannot be found.",
+            "Celestials",
+            ProgVariableTypes.Text
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/Celestials/MoonPhaseFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Celestials/MoonPhaseFunction.cs
@@ -53,13 +53,23 @@ internal class MoonPhaseFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "moonphase",
             new[] { ProgVariableTypes.Location },
-            (pars, gameworld) => new MoonPhaseFunction(pars)
+            (pars, gameworld) => new MoonPhaseFunction(pars),
+            new List<string> { "location" },
+            new List<string> { "The room whose zone should be used to determine the current moon phase." },
+            "Looks up the first planetary moon associated with the supplied room's zone or zone and returns its current phase text. Returns an empty string if the zone or moon cannot be found.",
+            "Celestials",
+            ProgVariableTypes.Text
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "moonphase",
             new[] { ProgVariableTypes.Zone },
-            (pars, gameworld) => new MoonPhaseFunction(pars)
+            (pars, gameworld) => new MoonPhaseFunction(pars),
+            new List<string> { "zone" },
+            new List<string> { "The zone to use when determining the current moon phase." },
+            "Looks up the first planetary moon associated with the supplied room's zone or zone and returns its current phase text. Returns an empty string if the zone or moon cannot be found.",
+            "Celestials",
+            ProgVariableTypes.Text
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/Characteristics/CharacteristicValueFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Characteristics/CharacteristicValueFunction.cs
@@ -124,7 +124,7 @@ internal class CharacteristicValueFunction : BuiltInFunction
                 },
                 "This function returns the ID of the supplied character's intrinsic characteristic for the supplied definition. E.g. If you supplied the ID number of the colour characteristic, you might get the ID 435 as a return value.",
                 "Characteristics",
-                ProgVariableTypes.Text
+                ProgVariableTypes.Number
             )
         );
 
@@ -144,7 +144,7 @@ internal class CharacteristicValueFunction : BuiltInFunction
                 },
                 "This function returns the ID of the supplied items's intrinsic characteristic for the supplied definition. E.g. If you supplied the ID number of the colour characteristic, you might get the ID 435 as a return value.",
                 "Characteristics",
-                ProgVariableTypes.Text
+                ProgVariableTypes.Number
             )
         );
 
@@ -164,7 +164,7 @@ internal class CharacteristicValueFunction : BuiltInFunction
                 },
                 "This function returns the ID of the supplied character's intrinsic characteristic for the supplied definition. E.g. If you supplied the ID number of the colour characteristic, you might get the ID 435 as a return value.",
                 "Characteristics",
-                ProgVariableTypes.Text
+                ProgVariableTypes.Number
             )
         );
 
@@ -184,7 +184,7 @@ internal class CharacteristicValueFunction : BuiltInFunction
                 },
                 "This function returns the ID of the supplied items's intrinsic characteristic for the supplied definition. E.g. If you supplied the ID number of the colour characteristic, you might get the ID 435 as a return value.",
                 "Characteristics",
-                ProgVariableTypes.Text
+                ProgVariableTypes.Number
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/Chargen/GiveResource.cs
+++ b/MudSharpCore/FutureProg/Functions/Chargen/GiveResource.cs
@@ -58,7 +58,7 @@ namespace MudSharp.FutureProg.Functions.Chargen
 
         public override ProgVariableTypes ReturnType
         {
-            get => ProgVariableTypes.Boolean;
+            get => ProgVariableTypes.Number;
             protected set { }
         }
 

--- a/MudSharpCore/FutureProg/Functions/Clan/IsClanBrotherFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Clan/IsClanBrotherFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Character;
+using MudSharp.Character;
 using MudSharp.Community;
 using MudSharp.FutureProg.Variables;
 using System.Collections.Generic;
@@ -85,7 +85,12 @@ internal class IsClanBrotherFunction : BuiltInFunction
                     ProgVariableTypes.Character, ProgVariableTypes.Character,
                     ProgVariableTypes.Clan
                 },
-                (pars, gameworld) => new IsClanBrotherFunction(pars)
+                (pars, gameworld) => new IsClanBrotherFunction(pars),
+                new List<string> { "character", "target", "excludedClan" },
+                new List<string> { "The first character to compare.", "The second character to compare.", "A clan to ignore when checking for shared membership." },
+                "Checks whether two characters share at least one clan membership after optionally excluding a clan or collection of clans. Use the exclusion overloads to ignore common public clans. Errors if either character is null; returns false if there is no shared qualifying clan.",
+                "Clans",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -93,7 +98,12 @@ internal class IsClanBrotherFunction : BuiltInFunction
             new FunctionCompilerInformation(
                 "isclanbrother",
                 new[] { ProgVariableTypes.Character, ProgVariableTypes.Character },
-                (pars, gameworld) => new IsClanBrotherFunction(pars)
+                (pars, gameworld) => new IsClanBrotherFunction(pars),
+                new List<string> { "character", "target" },
+                new List<string> { "The first character to compare.", "The second character to compare." },
+                "Checks whether two characters share at least one clan membership after optionally excluding a clan or collection of clans. Use the exclusion overloads to ignore common public clans. Errors if either character is null; returns false if there is no shared qualifying clan.",
+                "Clans",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -105,7 +115,12 @@ internal class IsClanBrotherFunction : BuiltInFunction
                     ProgVariableTypes.Character, ProgVariableTypes.Character,
                     ProgVariableTypes.Collection | ProgVariableTypes.Clan
                 },
-                (pars, gameworld) => new IsClanBrotherFunction(pars)
+                (pars, gameworld) => new IsClanBrotherFunction(pars),
+                new List<string> { "character", "target", "excludedClans" },
+                new List<string> { "The first character to compare.", "The second character to compare.", "A collection of clans to ignore when checking for shared membership." },
+                "Checks whether two characters share at least one clan membership after optionally excluding a clan or collection of clans. Use the exclusion overloads to ignore common public clans. Errors if either character is null; returns false if there is no shared qualifying clan.",
+                "Clans",
+                ProgVariableTypes.Boolean
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/Clan/IsClanMemberFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Clan/IsClanMemberFunction.cs
@@ -54,6 +54,18 @@ internal class IsClanMemberFunction : BuiltInFunction
             return StatementResult.Error;
         }
 
+        if (characterFunction.Result?.GetObject is not ICharacter character)
+        {
+            ErrorMessage = "Character was null in IsClanMember Function.";
+            return StatementResult.Error;
+        }
+
+        if (clanFunction.Result?.GetObject is not IClan clan)
+        {
+            ErrorMessage = "Clan was null in IsClanMember Function.";
+            return StatementResult.Error;
+        }
+
         Func<IClanMembership, bool> function;
         if (rankFunction != null)
         {
@@ -73,23 +85,20 @@ internal class IsClanMemberFunction : BuiltInFunction
                     return StatementResult.Error;
                 }
 
-                IRank rank = (IRank)rankFunction.Result;
-                IPaygrade paygrade = (IPaygrade)paygradeFunction.Result;
-
-                if (rank == null)
+                if (rankFunction.Result?.GetObject is not IRank rank)
                 {
                     ErrorMessage = "Rank was null in IsClanMember function.";
                     return StatementResult.Error;
                 }
 
-                if (paygrade == null)
+                if (paygradeFunction.Result?.GetObject is not IPaygrade paygrade)
                 {
                     ErrorMessage = "Paygrade was null in IsClanMember function.";
                     return StatementResult.Error;
                 }
 
                 function = member =>
-                    member.Clan.Equals(clanFunction.Result.GetObject) &&
+                    member.Clan.Equals(clan) &&
                     (rank.RankNumber < member.Rank.RankNumber ||
                      (rank.RankNumber == member.Rank.RankNumber &&
                       rank.Paygrades.IndexOf(member.Paygrade) >= rank.Paygrades.IndexOf(paygrade))
@@ -97,10 +106,15 @@ internal class IsClanMemberFunction : BuiltInFunction
             }
             else
             {
+                if (rankFunction.Result?.GetObject is not IRank rank)
+                {
+                    ErrorMessage = "Rank was null in IsClanMember function.";
+                    return StatementResult.Error;
+                }
+
                 function =
                     member =>
-                        member.Clan.Equals(clanFunction.Result.GetObject) && rankFunction.Result != null &&
-                        ((IRank)rankFunction.Result.GetObject).RankNumber <= member.Rank.RankNumber;
+                        member.Clan.Equals(clan) && rank.RankNumber <= member.Rank.RankNumber;
             }
         }
         else if (appointmentFunction != null)
@@ -112,17 +126,22 @@ internal class IsClanMemberFunction : BuiltInFunction
                 return StatementResult.Error;
             }
 
+            if (appointmentFunction.Result?.GetObject is not IAppointment appointment)
+            {
+                ErrorMessage = "Appointment was null in IsClanMember function.";
+                return StatementResult.Error;
+            }
+
             function =
                 member =>
-                    member.Clan.Equals(clanFunction.Result.GetObject) && appointmentFunction.Result != null &&
-                    member.Appointments.Contains((IAppointment)appointmentFunction.Result.GetObject);
+                    member.Clan.Equals(clan) && member.Appointments.Contains(appointment);
         }
         else
         {
-            function = member => member.Clan.Equals(clanFunction.Result.GetObject);
+            function = member => member.Clan.Equals(clan);
         }
 
-        Result = new BooleanVariable(((ICharacter)characterFunction.Result.GetObject).ClanMemberships.Any(function));
+        Result = new BooleanVariable(character.ClanMemberships.Any(function));
         return StatementResult.Normal;
     }
 
@@ -132,7 +151,12 @@ internal class IsClanMemberFunction : BuiltInFunction
             new FunctionCompilerInformation(
                 "isclanmember",
                 new[] { ProgVariableTypes.Character, ProgVariableTypes.Clan },
-                (pars, gameworld) => new IsClanMemberFunction(pars)
+                (pars, gameworld) => new IsClanMemberFunction(pars),
+                new List<string> { "character", "clan" },
+                new List<string> { "The character whose memberships should be checked.", "The clan to check for membership." },
+                "Checks whether a character is a member of a clan, optionally constrained by minimum rank, appointment, or rank and paygrade. Errors if required character, clan, rank, paygrade, or appointment inputs are null; returns false when the membership requirement is not met.",
+                "Clans",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -144,7 +168,12 @@ internal class IsClanMemberFunction : BuiltInFunction
                     ProgVariableTypes.Character, ProgVariableTypes.Clan,
                     ProgVariableTypes.ClanRank
                 },
-                (pars, gameworld) => new IsClanMemberFunction(pars)
+                (pars, gameworld) => new IsClanMemberFunction(pars),
+                new List<string> { "character", "clan", "rank" },
+                new List<string> { "The character whose memberships should be checked.", "The clan to check for membership.", "The minimum clan rank the character must hold." },
+                "Checks whether a character is a member of a clan, optionally constrained by minimum rank, appointment, or rank and paygrade. Errors if required character, clan, rank, paygrade, or appointment inputs are null; returns false when the membership requirement is not met.",
+                "Clans",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -156,7 +185,12 @@ internal class IsClanMemberFunction : BuiltInFunction
                     ProgVariableTypes.Character, ProgVariableTypes.Clan,
                     ProgVariableTypes.ClanAppointment
                 },
-                (pars, gameworld) => new IsClanMemberFunction(pars)
+                (pars, gameworld) => new IsClanMemberFunction(pars),
+                new List<string> { "character", "clan", "appointment" },
+                new List<string> { "The character whose memberships should be checked.", "The clan to check for membership.", "The clan appointment the character must hold." },
+                "Checks whether a character is a member of a clan, optionally constrained by minimum rank, appointment, or rank and paygrade. Errors if required character, clan, rank, paygrade, or appointment inputs are null; returns false when the membership requirement is not met.",
+                "Clans",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -168,7 +202,12 @@ internal class IsClanMemberFunction : BuiltInFunction
                     ProgVariableTypes.Character, ProgVariableTypes.Clan,
                     ProgVariableTypes.ClanRank, ProgVariableTypes.ClanPaygrade
                 },
-                (pars, gameworld) => new IsClanMemberFunction(pars)
+                (pars, gameworld) => new IsClanMemberFunction(pars),
+                new List<string> { "character", "clan", "rank", "paygrade" },
+                new List<string> { "The character whose memberships should be checked.", "The clan to check for membership.", "The minimum clan rank the character must hold.", "The minimum paygrade within the supplied rank." },
+                "Checks whether a character is a member of a clan, optionally constrained by minimum rank, appointment, or rank and paygrade. Errors if required character, clan, rank, paygrade, or appointment inputs are null; returns false when the membership requirement is not met.",
+                "Clans",
+                ProgVariableTypes.Boolean
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/Clan/OutranksFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Clan/OutranksFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Character;
+using MudSharp.Character;
 using MudSharp.Community;
 using MudSharp.FutureProg.Variables;
 using System.Collections.Generic;
@@ -90,7 +90,12 @@ internal class OutranksFunction : BuiltInFunction
                     ProgVariableTypes.Character, ProgVariableTypes.Character,
                     ProgVariableTypes.Clan
                 },
-                (pars, gameworld) => new OutranksFunction(pars)
+                (pars, gameworld) => new OutranksFunction(pars),
+                new List<string> { "character", "target", "clan" },
+                new List<string> { "The character whose rank should be compared.", "The other character to compare against.", "The clan whose rank hierarchy should be used." },
+                "Checks whether the first character outranks the second in the supplied clan. Errors if either character or the clan is null; returns false if either character is not a valid member in that clan.",
+                "Clans",
+                ProgVariableTypes.Boolean
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/Clan/OutranksOrPeerFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Clan/OutranksOrPeerFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Character;
+using MudSharp.Character;
 using MudSharp.Community;
 using MudSharp.FutureProg.Variables;
 using System.Collections.Generic;
@@ -90,7 +90,12 @@ internal class OutranksOrPeerFunction : BuiltInFunction
                     ProgVariableTypes.Character, ProgVariableTypes.Character,
                     ProgVariableTypes.Clan
                 },
-                (pars, gameworld) => new OutranksOrPeerFunction(pars)
+                (pars, gameworld) => new OutranksOrPeerFunction(pars),
+                new List<string> { "character", "target", "clan" },
+                new List<string> { "The character whose rank should be compared.", "The other character to compare against.", "The clan whose rank hierarchy should be used." },
+                "Checks whether the first character outranks or is at the same rank level as the second in the supplied clan. Errors if either character or the clan is null; returns false if either character is not a valid member in that clan.",
+                "Clans",
+                ProgVariableTypes.Boolean
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/Clan/ToAppointmentFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Clan/ToAppointmentFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Community;
+using MudSharp.Community;
 using MudSharp.Framework;
 using System;
 using System.Collections.Generic;
@@ -36,7 +36,7 @@ internal class ToAppointmentFunction : BuiltInFunction
             return StatementResult.Error;
         }
 
-        Result = ParameterFunctions[0].ReturnType.CompatibleWith(ProgVariableTypes.Text)
+        Result = ParameterFunctions[1].ReturnType.CompatibleWith(ProgVariableTypes.Text)
             ? clan.Appointments.FirstOrDefault(
                 x =>
                     x.Name.Equals((string)ParameterFunctions.ElementAt(1).Result.GetObject,
@@ -52,13 +52,23 @@ internal class ToAppointmentFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "toappointment",
             new[] { ProgVariableTypes.Clan, ProgVariableTypes.Number },
-            (pars, gameworld) => new ToAppointmentFunction(pars, gameworld)
+            (pars, gameworld) => new ToAppointmentFunction(pars, gameworld),
+            new List<string> { "clan", "id" },
+            new List<string> { "The clan whose appointments should be searched.", "The numeric ID of the appointment to find." },
+            "Looks up an appointment within a clan by ID or name. Errors if the clan is null; returns null if no appointment matches.",
+            "Clans",
+            ProgVariableTypes.ClanAppointment
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "toappointment",
             new[] { ProgVariableTypes.Clan, ProgVariableTypes.Text },
-            (pars, gameworld) => new ToAppointmentFunction(pars, gameworld)
+            (pars, gameworld) => new ToAppointmentFunction(pars, gameworld),
+            new List<string> { "clan", "name" },
+            new List<string> { "The clan whose appointments should be searched.", "The appointment name to find, matched case-insensitively." },
+            "Looks up an appointment within a clan by ID or name. Errors if the clan is null; returns null if no appointment matches.",
+            "Clans",
+            ProgVariableTypes.ClanAppointment
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/Clan/ToClanFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Clan/ToClanFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Framework;
+using MudSharp.Framework;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -39,13 +39,23 @@ internal class ToClanFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "toclan",
             new[] { ProgVariableTypes.Number },
-            (pars, gameworld) => new ToClanFunction(pars, gameworld)
+            (pars, gameworld) => new ToClanFunction(pars, gameworld),
+            new List<string> { "id" },
+            new List<string> { "The numeric ID of the clan to look up." },
+            "Looks up a clan by ID or name. Returns null if no clan matches.",
+            "Clans",
+            ProgVariableTypes.Clan
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "toclan",
             new[] { ProgVariableTypes.Text },
-            (pars, gameworld) => new ToClanFunction(pars, gameworld)
+            (pars, gameworld) => new ToClanFunction(pars, gameworld),
+            new List<string> { "name" },
+            new List<string> { "The clan name or alias to look up." },
+            "Looks up a clan by ID or name. Returns null if no clan matches.",
+            "Clans",
+            ProgVariableTypes.Clan
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/Clan/ToPaygradeFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Clan/ToPaygradeFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Community;
+using MudSharp.Community;
 using MudSharp.Framework;
 using System;
 using System.Collections.Generic;
@@ -36,7 +36,7 @@ internal class ToPaygradeFunction : BuiltInFunction
             return StatementResult.Error;
         }
 
-        Result = ParameterFunctions[0].ReturnType.CompatibleWith(ProgVariableTypes.Text)
+        Result = ParameterFunctions[1].ReturnType.CompatibleWith(ProgVariableTypes.Text)
             ? clan.Paygrades.FirstOrDefault(
                   x =>
                       x.Name.Equals((string)ParameterFunctions.ElementAt(1).Result.GetObject,
@@ -56,13 +56,23 @@ internal class ToPaygradeFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "topaygrade",
             new[] { ProgVariableTypes.Clan, ProgVariableTypes.Number },
-            (pars, gameworld) => new ToPaygradeFunction(pars, gameworld)
+            (pars, gameworld) => new ToPaygradeFunction(pars, gameworld),
+            new List<string> { "clan", "id" },
+            new List<string> { "The clan whose paygrades should be searched.", "The numeric ID of the paygrade to find." },
+            "Looks up a paygrade within a clan by ID, name, or abbreviation. Errors if the clan is null; returns null if no paygrade matches.",
+            "Clans",
+            ProgVariableTypes.ClanPaygrade
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "topaygrade",
             new[] { ProgVariableTypes.Clan, ProgVariableTypes.Text },
-            (pars, gameworld) => new ToPaygradeFunction(pars, gameworld)
+            (pars, gameworld) => new ToPaygradeFunction(pars, gameworld),
+            new List<string> { "clan", "name" },
+            new List<string> { "The clan whose paygrades should be searched.", "The paygrade name or abbreviation to find, matched case-insensitively." },
+            "Looks up a paygrade within a clan by ID, name, or abbreviation. Errors if the clan is null; returns null if no paygrade matches.",
+            "Clans",
+            ProgVariableTypes.ClanPaygrade
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/Clan/ToRankFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Clan/ToRankFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Community;
+using MudSharp.Community;
 using MudSharp.Framework;
 using System;
 using System.Collections.Generic;
@@ -51,13 +51,23 @@ internal class ToRankFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "torank",
             new[] { ProgVariableTypes.Clan, ProgVariableTypes.Number },
-            (pars, gameworld) => new ToRankFunction(pars, gameworld)
+            (pars, gameworld) => new ToRankFunction(pars, gameworld),
+            new List<string> { "clan", "id" },
+            new List<string> { "The clan whose ranks should be searched.", "The numeric ID of the rank to find." },
+            "Looks up a rank within a clan by ID or name. Errors if the clan is null; returns null if no rank matches.",
+            "Clans",
+            ProgVariableTypes.ClanRank
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "torank",
             new[] { ProgVariableTypes.Clan, ProgVariableTypes.Text },
-            (pars, gameworld) => new ToRankFunction(pars, gameworld)
+            (pars, gameworld) => new ToRankFunction(pars, gameworld),
+            new List<string> { "clan", "name" },
+            new List<string> { "The clan whose ranks should be searched.", "The rank name to find, matched case-insensitively." },
+            "Looks up a rank within a clan by ID or name. Errors if the clan is null; returns null if no rank matches.",
+            "Clans",
+            ProgVariableTypes.ClanRank
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/Climate/TimeOfDayFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Climate/TimeOfDayFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Celestial;
+using MudSharp.Celestial;
 using MudSharp.Construction;
 using MudSharp.FutureProg.Variables;
 using System;
@@ -62,13 +62,23 @@ internal class TimeOfDayFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "timeofday",
             new[] { ProgVariableTypes.Location },
-            (pars, gameworld) => new TimeOfDayFunction(pars)
+            (pars, gameworld) => new TimeOfDayFunction(pars),
+            new List<string> { "location" },
+            new List<string> { "The room whose zone clock should be used to determine the current time-of-day band." },
+            "Returns the current time-of-day band for a room or zone, such as night or dawn. A null argument falls back to Night.",
+            "Climate",
+            ProgVariableTypes.Text
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "timeofday",
             new[] { ProgVariableTypes.Zone },
-            (pars, gameworld) => new TimeOfDayFunction(pars)
+            (pars, gameworld) => new TimeOfDayFunction(pars),
+            new List<string> { "zone" },
+            new List<string> { "The zone whose clock should be used to determine the current time-of-day band." },
+            "Returns the current time-of-day band for a room or zone, such as night or dawn. A null argument falls back to Night.",
+            "Climate",
+            ProgVariableTypes.Text
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/Currency/CountCurrencyFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Currency/CountCurrencyFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Character;
+using MudSharp.Character;
 using MudSharp.Construction;
 using MudSharp.Economy.Currency;
 using MudSharp.FutureProg.Variables;
@@ -94,7 +94,12 @@ internal class CountCurrencyFunction : BuiltInFunction
             new FunctionCompilerInformation(
                 "countcurrency",
                 new[] { ProgVariableTypes.Character, ProgVariableTypes.Currency },
-                (pars, gameworld) => new CountCurrencyFunction(pars, false)
+                (pars, gameworld) => new CountCurrencyFunction(pars, false),
+                new List<string> { "character", "currency" },
+                new List<string> { "The character whose worn, held, and carried items should be searched.", "The currency definition whose coins should be counted." },
+                "Counts all coins of a currency found on a character, inside an item, or in a room, recursively searching containers without applying get-access rules. Errors if the target or currency is null.",
+                "Currency",
+                ProgVariableTypes.Number
             )
         );
 
@@ -102,7 +107,12 @@ internal class CountCurrencyFunction : BuiltInFunction
             new FunctionCompilerInformation(
                 "countcurrency",
                 new[] { ProgVariableTypes.Item, ProgVariableTypes.Currency },
-                (pars, gameworld) => new CountCurrencyFunction(pars, false)
+                (pars, gameworld) => new CountCurrencyFunction(pars, false),
+                new List<string> { "item", "currency" },
+                new List<string> { "The item to search, including nested container contents.", "The currency definition whose coins should be counted." },
+                "Counts all coins of a currency found on a character, inside an item, or in a room, recursively searching containers without applying get-access rules. Errors if the target or currency is null.",
+                "Currency",
+                ProgVariableTypes.Number
             )
         );
 
@@ -110,7 +120,12 @@ internal class CountCurrencyFunction : BuiltInFunction
             new FunctionCompilerInformation(
                 "countcurrency",
                 new[] { ProgVariableTypes.Location, ProgVariableTypes.Currency },
-                (pars, gameworld) => new CountCurrencyFunction(pars, false)
+                (pars, gameworld) => new CountCurrencyFunction(pars, false),
+                new List<string> { "location", "currency" },
+                new List<string> { "The room whose loose items should be searched.", "The currency definition whose coins should be counted." },
+                "Counts all coins of a currency found on a character, inside an item, or in a room, recursively searching containers without applying get-access rules. Errors if the target or currency is null.",
+                "Currency",
+                ProgVariableTypes.Number
             )
         );
 
@@ -118,7 +133,12 @@ internal class CountCurrencyFunction : BuiltInFunction
             new FunctionCompilerInformation(
                 "countaccessiblecurrency",
                 new[] { ProgVariableTypes.Character, ProgVariableTypes.Currency },
-                (pars, gameworld) => new CountCurrencyFunction(pars, true)
+                (pars, gameworld) => new CountCurrencyFunction(pars, true),
+                new List<string> { "character", "currency" },
+                new List<string> { "The character whose accessible worn, held, and carried items should be searched.", "The currency definition whose coins should be counted." },
+                "Counts coins of a currency found on a character, inside an item, or in a room while respecting normal get-access limits such as closed containers. Errors if the target or currency is null.",
+                "Currency",
+                ProgVariableTypes.Number
             )
         );
 
@@ -126,7 +146,12 @@ internal class CountCurrencyFunction : BuiltInFunction
             new FunctionCompilerInformation(
                 "countaccessiblecurrency",
                 new[] { ProgVariableTypes.Item, ProgVariableTypes.Currency },
-                (pars, gameworld) => new CountCurrencyFunction(pars, true)
+                (pars, gameworld) => new CountCurrencyFunction(pars, true),
+                new List<string> { "item", "currency" },
+                new List<string> { "The item to search, skipping closed containers that normal get rules would block.", "The currency definition whose coins should be counted." },
+                "Counts coins of a currency found on a character, inside an item, or in a room while respecting normal get-access limits such as closed containers. Errors if the target or currency is null.",
+                "Currency",
+                ProgVariableTypes.Number
             )
         );
 
@@ -134,7 +159,12 @@ internal class CountCurrencyFunction : BuiltInFunction
             new FunctionCompilerInformation(
                 "countaccessiblecurrency",
                 new[] { ProgVariableTypes.Location, ProgVariableTypes.Currency },
-                (pars, gameworld) => new CountCurrencyFunction(pars, true)
+                (pars, gameworld) => new CountCurrencyFunction(pars, true),
+                new List<string> { "location", "currency" },
+                new List<string> { "The room whose accessible loose items should be searched.", "The currency definition whose coins should be counted." },
+                "Counts coins of a currency found on a character, inside an item, or in a room while respecting normal get-access limits such as closed containers. Errors if the target or currency is null.",
+                "Currency",
+                ProgVariableTypes.Number
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/Currency/GiveCurrencyFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Currency/GiveCurrencyFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Character;
+using MudSharp.Character;
 using MudSharp.Construction;
 using MudSharp.Economy.Currency;
 using MudSharp.Framework;
@@ -237,7 +237,12 @@ internal class GiveCurrencyFunction : BuiltInFunction
                 ProgVariableTypes.Location | ProgVariableTypes.Character | ProgVariableTypes.Item,
                 ProgVariableTypes.Boolean
             },
-            (IList<IFunction> pars, IFuturemud gameworld) => new GiveCurrencyFunction(pars, gameworld)
+            (IList<IFunction> pars, IFuturemud gameworld) => new GiveCurrencyFunction(pars, gameworld),
+            new List<string> { "currency", "amount", "target", "respectGetRules" },
+            new List<string> { "The currency definition to query, load, give, or count.", "The amount to use. Text amounts are parsed using the target system's normal builder/player parsing rules.", "The target character, item, location, or perceivable for the operation.", "Whether closed containers and other normal get-access restrictions should be respected." },
+            "Adds currency to a character, item, or room, creating a currency pile if needed. The amount can be numeric base currency or text parsed by the currency. Errors on null currency, invalid amount text, or null target; returns true when currency was added.",
+            "Currency",
+            ProgVariableTypes.Boolean
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/Currency/LoadCoinsFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Currency/LoadCoinsFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Economy.Currency;
+using MudSharp.Economy.Currency;
 using MudSharp.Framework;
 using MudSharp.GameItems;
 using MudSharp.GameItems.Prototypes;
@@ -99,7 +99,12 @@ internal class LoadCoinsFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "loadcoins",
             new[] { ProgVariableTypes.Currency, ProgVariableTypes.Text },
-            (pars, gameworld) => new LoadCoinsFunction(pars, gameworld)
+            (pars, gameworld) => new LoadCoinsFunction(pars, gameworld),
+            new List<string> { "currency", "coins" },
+            new List<string> { "The currency definition to query, load, give, or count.", "A text list of coin counts and coin names, such as '3 silver 8 copper'." },
+            "Creates a new currency-pile item from exact coin counts such as '2 crowns 5 pennies'. Errors if the currency is null, the coin text is malformed, or a coin name is invalid.",
+            "Currency",
+            ProgVariableTypes.Item
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/Currency/LoadCurrencyFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Currency/LoadCurrencyFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Economy.Currency;
+using MudSharp.Economy.Currency;
 using MudSharp.Framework;
 using MudSharp.GameItems;
 using MudSharp.GameItems.Prototypes;
@@ -62,13 +62,23 @@ internal class LoadCurrencyFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "loadcurrency",
             new[] { ProgVariableTypes.Currency, ProgVariableTypes.Number },
-            (pars, gameworld) => new LoadCurrencyFunction(pars, gameworld)
+            (pars, gameworld) => new LoadCurrencyFunction(pars, gameworld),
+            new List<string> { "currency", "amount" },
+            new List<string> { "The currency definition to query, load, give, or count.", "The amount to use. Text amounts are parsed using the target system's normal builder/player parsing rules." },
+            "Creates a new currency-pile item worth the supplied numeric or text amount. Errors if the currency is null or the text amount cannot be parsed.",
+            "Currency",
+            ProgVariableTypes.Item
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "loadcurrency",
             new[] { ProgVariableTypes.Currency, ProgVariableTypes.Text },
-            (pars, gameworld) => new LoadCurrencyFunction(pars, gameworld)
+            (pars, gameworld) => new LoadCurrencyFunction(pars, gameworld),
+            new List<string> { "currency", "amount" },
+            new List<string> { "The currency definition to query, load, give, or count.", "The amount to use. Text amounts are parsed using the target system's normal builder/player parsing rules." },
+            "Creates a new currency-pile item worth the supplied numeric or text amount. Errors if the currency is null or the text amount cannot be parsed.",
+            "Currency",
+            ProgVariableTypes.Item
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/Currency/ToCurrencyFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Currency/ToCurrencyFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Framework;
+using MudSharp.Framework;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -39,13 +39,23 @@ internal class ToCurrencyFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "tocurrency",
             new[] { ProgVariableTypes.Number },
-            (pars, gameworld) => new ToCurrencyFunction(pars, gameworld)
+            (pars, gameworld) => new ToCurrencyFunction(pars, gameworld),
+            new List<string> { "id" },
+            new List<string> { "The numeric ID of the currency to look up." },
+            "Looks up a currency by ID or name. Returns null if no currency matches.",
+            "Currency",
+            ProgVariableTypes.Currency
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "tocurrency",
             new[] { ProgVariableTypes.Text },
-            (pars, gameworld) => new ToCurrencyFunction(pars, gameworld)
+            (pars, gameworld) => new ToCurrencyFunction(pars, gameworld),
+            new List<string> { "name" },
+            new List<string> { "The currency name or alias to look up." },
+            "Looks up a currency by ID or name. Returns null if no currency matches.",
+            "Currency",
+            ProgVariableTypes.Currency
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/DateTime/DateToTextFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/DateTime/DateToTextFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.FutureProg.Variables;
+using MudSharp.FutureProg.Variables;
 using MudSharp.TimeAndDate;
 using MudSharp.TimeAndDate.Date;
 using MudSharp.TimeAndDate.Time;
@@ -52,19 +52,34 @@ internal class DateToTextFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "totext",
             new[] { ProgVariableTypes.DateTime },
-            (pars, gameworld) => new DateToTextFunction(pars)
+            (pars, gameworld) => new DateToTextFunction(pars),
+            new List<string> { "value" },
+            new List<string> { "The value to convert or inspect." },
+            "Formats a real-world datetime, optionally with a format string and a character whose culture and account formatting preferences should be used.",
+            "Date/Time",
+            ProgVariableTypes.Text
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "totext",
             new[] { ProgVariableTypes.DateTime, ProgVariableTypes.Toon },
-            (pars, gameworld) => new DateToTextFunction(pars)
+            (pars, gameworld) => new DateToTextFunction(pars),
+            new List<string> { "value", "voyeur" },
+            new List<string> { "The value to convert or inspect.", "The character whose account culture and formatting preferences should be used." },
+            "Formats a real-world datetime, optionally with a format string and a character whose culture and account formatting preferences should be used.",
+            "Date/Time",
+            ProgVariableTypes.Text
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "totext",
             new[] { ProgVariableTypes.DateTime, ProgVariableTypes.Text, ProgVariableTypes.Toon },
-            (pars, gameworld) => new DateToTextFunction(pars)
+            (pars, gameworld) => new DateToTextFunction(pars),
+            new List<string> { "value", "format", "voyeur" },
+            new List<string> { "The value to convert or inspect.", "A .NET date/time format string used to format or parse the date.", "The character whose account culture and formatting preferences should be used." },
+            "Formats a real-world datetime, optionally with a format string and a character whose culture and account formatting preferences should be used.",
+            "Date/Time",
+            ProgVariableTypes.Text
         ));
     }
 }
@@ -104,31 +119,56 @@ internal class MudDateToTextFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "totext",
             new[] { ProgVariableTypes.MudDateTime },
-            (pars, gameworld) => new MudDateToTextFunction(pars, CalendarDisplayMode.Long, TimeDisplayTypes.Long)
+            (pars, gameworld) => new MudDateToTextFunction(pars, CalendarDisplayMode.Long, TimeDisplayTypes.Long),
+            new List<string> { "value" },
+            new List<string> { "The value to convert or inspect." },
+            "Formats an in-game mud datetime with long calendar and time display rules. Null or Never mud datetimes display as Never.",
+            "Date/Time",
+            ProgVariableTypes.Text
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "totextshort",
             new[] { ProgVariableTypes.MudDateTime },
-            (pars, gameworld) => new MudDateToTextFunction(pars, CalendarDisplayMode.Short, TimeDisplayTypes.Short)
+            (pars, gameworld) => new MudDateToTextFunction(pars, CalendarDisplayMode.Short, TimeDisplayTypes.Short),
+            new List<string> { "value" },
+            new List<string> { "The in-game mud datetime to format using short calendar and short time display rules." },
+            "Formats an in-game mud datetime using short calendar and short time display rules. Null or Never mud datetimes display as Never.",
+            "Date/Time",
+            ProgVariableTypes.Text
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "totextwordy",
             new[] { ProgVariableTypes.MudDateTime },
-            (pars, gameworld) => new MudDateToTextFunction(pars, CalendarDisplayMode.Wordy, TimeDisplayTypes.Long)
+            (pars, gameworld) => new MudDateToTextFunction(pars, CalendarDisplayMode.Wordy, TimeDisplayTypes.Long),
+            new List<string> { "value" },
+            new List<string> { "The in-game mud datetime to format with wordy calendar and long time display rules." },
+            "Formats an in-game mud datetime using wordy calendar and long time display rules. Null or Never mud datetimes display as Never.",
+            "Date/Time",
+            ProgVariableTypes.Text
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "totextcrude",
             new[] { ProgVariableTypes.MudDateTime },
-            (pars, gameworld) => new MudDateToTextFunction(pars, CalendarDisplayMode.Long, TimeDisplayTypes.Crude)
+            (pars, gameworld) => new MudDateToTextFunction(pars, CalendarDisplayMode.Long, TimeDisplayTypes.Crude),
+            new List<string> { "value" },
+            new List<string> { "The in-game mud datetime to format with long calendar and crude time display rules." },
+            "Formats an in-game mud datetime using long calendar and crude time display rules. Null or Never mud datetimes display as Never.",
+            "Date/Time",
+            ProgVariableTypes.Text
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "totextvague",
             new[] { ProgVariableTypes.MudDateTime },
-            (pars, gameworld) => new MudDateToTextFunction(pars, CalendarDisplayMode.Long, TimeDisplayTypes.Vague)
+            (pars, gameworld) => new MudDateToTextFunction(pars, CalendarDisplayMode.Long, TimeDisplayTypes.Vague),
+            new List<string> { "value" },
+            new List<string> { "The in-game mud datetime to format with long calendar and vague time display rules." },
+            "Formats an in-game mud datetime using long calendar and vague time display rules. Null or Never mud datetimes display as Never.",
+            "Date/Time",
+            ProgVariableTypes.Text
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/DateTime/GameSecondsPerRealSecondsFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/DateTime/GameSecondsPerRealSecondsFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Framework;
+using MudSharp.Framework;
 using MudSharp.FutureProg.Variables;
 using MudSharp.TimeAndDate.Time;
 using System.Collections.Generic;
@@ -54,7 +54,12 @@ internal class GameSecondsPerRealSecondsFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "gamesecondsperrealseconds",
             new[] { ProgVariableTypes.Text },
-            (pars, gameworld) => new GameSecondsPerRealSecondsFunction(pars, gameworld)
+            (pars, gameworld) => new GameSecondsPerRealSecondsFunction(pars, gameworld),
+            new List<string> { "clock" },
+            new List<string> { "The in-game clock to use, or the clock name where this function accepts text." },
+            "Looks up a clock by name and returns how many in-game seconds pass for each real second. Errors if the clock name is null or does not match a clock.",
+            "Date/Time",
+            ProgVariableTypes.Number
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/DateTime/NowFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/DateTime/NowFunction.cs
@@ -1,4 +1,5 @@
 ﻿using MudSharp.FutureProg.Variables;
+using MudSharp.Framework;
 using MudSharp.TimeAndDate;
 using MudSharp.TimeAndDate.Date;
 using MudSharp.TimeAndDate.Time;
@@ -30,7 +31,12 @@ internal class NowFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "now",
             new ProgVariableTypes[] { },
-            (pars, gameworld) => new NowFunction(pars)
+            (pars, gameworld) => new NowFunction(pars),
+            new List<string>(),
+            new List<string>(),
+            "Returns the current real-world UTC date and time, equivalent to System.DateTime.UtcNow. Use this for real-time expiry or logging rather than in-game calendar time.",
+            "Date/Time",
+            ProgVariableTypes.DateTime
         ));
     }
 }
@@ -57,22 +63,32 @@ internal class MudNowFunction : BuiltInFunction
 
         if (ParameterFunctions[0].Result?.GetObject is not Calendar calendar)
         {
-            Result = new MudDateTime(default, default, default(MudTimeZone));
+            Result = MudDateTime.Never;
             return StatementResult.Normal;
         }
 
-        MudDate date = calendar.CurrentDate;
+        var date = calendar.CurrentDate;
 
-        IClock clock = ParameterFunctions?[1].Result?.GetObject as Clock ?? calendar.FeedClock;
+        var clock = ParameterFunctions.Count > 1
+            ? ParameterFunctions[1].Result?.GetObject as Clock ?? calendar.FeedClock
+            : calendar.FeedClock;
         if (clock == null)
         {
-            Result = new MudDateTime(default, default, default(MudTimeZone));
+            Result = MudDateTime.Never;
             return StatementResult.Normal;
         }
 
-        MudTime time = clock.CurrentTime;
+        var time = clock.CurrentTime;
 
-        IMudTimeZone timezone = ParameterFunctions?[2].Result?.GetObject as MudTimeZone ?? clock.PrimaryTimezone;
+        var timezone = clock.PrimaryTimezone;
+        if (ParameterFunctions.Count > 2)
+        {
+            var timezoneText = ParameterFunctions[2].Result?.GetObject?.ToString();
+            if (!string.IsNullOrWhiteSpace(timezoneText))
+            {
+                timezone = clock.Timezones.GetByIdOrName(timezoneText) ?? clock.PrimaryTimezone;
+            }
+        }
 
         if (timezone != clock.PrimaryTimezone)
         {
@@ -93,19 +109,43 @@ internal class MudNowFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "now",
             new[] { ProgVariableTypes.Calendar },
-            (pars, gameworld) => new MudNowFunction(pars)
+            (pars, gameworld) => new MudNowFunction(pars),
+            new List<string> { "calendar" },
+            new List<string> { "The in-game calendar to use. Its feed clock supplies the time when no clock is specified." },
+            "Returns the current in-game date and time for a calendar using the calendar's feed clock and that clock's primary timezone. Returns the special Never mud datetime if the calendar or clock is null.",
+            "Date/Time",
+            ProgVariableTypes.MudDateTime
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "now",
             new[] { ProgVariableTypes.Calendar, ProgVariableTypes.Clock },
-            (pars, gameworld) => new MudNowFunction(pars)
+            (pars, gameworld) => new MudNowFunction(pars),
+            new List<string> { "calendar", "clock" },
+            new List<string>
+            {
+                "The in-game calendar whose current date is used.",
+                "The in-game clock whose current time is used. If null, the calendar's feed clock is used."
+            },
+            "Returns the current in-game date and time for a calendar and clock using the clock's primary timezone. Returns the special Never mud datetime if the calendar or resolved clock is null.",
+            "Date/Time",
+            ProgVariableTypes.MudDateTime
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "now",
             new[] { ProgVariableTypes.Calendar, ProgVariableTypes.Clock, ProgVariableTypes.Text },
-            (pars, gameworld) => new MudNowFunction(pars)
+            (pars, gameworld) => new MudNowFunction(pars),
+            new List<string> { "calendar", "clock", "timezone" },
+            new List<string>
+            {
+                "The in-game calendar whose current date is used.",
+                "The in-game clock whose current time is used. If null, the calendar's feed clock is used.",
+                "Optional timezone alias or ID from the supplied clock. If omitted or invalid, the clock's primary timezone is used."
+            },
+            "Returns the current in-game date and time for a calendar and clock, adjusted to the supplied timezone when it matches one of the clock's timezones. Returns the special Never mud datetime if the calendar or resolved clock is null.",
+            "Date/Time",
+            ProgVariableTypes.MudDateTime
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/DateTime/TimeSpanToTextFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/DateTime/TimeSpanToTextFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Accounts;
+using MudSharp.Accounts;
 using MudSharp.Framework;
 using MudSharp.FutureProg.Variables;
 using System;
@@ -39,13 +39,23 @@ internal class TimeSpanToTextFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "totext",
             new[] { ProgVariableTypes.TimeSpan },
-            (pars, gameworld) => new TimeSpanToTextFunction(pars)
+            (pars, gameworld) => new TimeSpanToTextFunction(pars),
+            new List<string> { "value" },
+            new List<string> { "The value to convert or inspect." },
+            "Formats a duration as readable text, optionally using the supplied character account culture and formatting preferences.",
+            "Date/Time",
+            ProgVariableTypes.Text
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "totext",
             new[] { ProgVariableTypes.TimeSpan, ProgVariableTypes.Toon },
-            (pars, gameworld) => new TimeSpanToTextFunction(pars)
+            (pars, gameworld) => new TimeSpanToTextFunction(pars),
+            new List<string> { "value", "voyeur" },
+            new List<string> { "The value to convert or inspect.", "The character whose account culture and formatting preferences should be used." },
+            "Formats a duration as readable text, optionally using the supplied character account culture and formatting preferences.",
+            "Date/Time",
+            ProgVariableTypes.Text
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/DateTime/ToDateFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/DateTime/ToDateFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.FutureProg.Variables;
+using MudSharp.FutureProg.Variables;
 using MudSharp.TimeAndDate;
 using MudSharp.TimeAndDate.Time;
 using System.Collections.Generic;
@@ -47,7 +47,12 @@ internal class ToDateFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "todate",
             new[] { ProgVariableTypes.Text, ProgVariableTypes.Text },
-            (pars, gameworld) => new ToDateFunction(pars)
+            (pars, gameworld) => new ToDateFunction(pars),
+            new List<string> { "dateText", "format" },
+            new List<string> { "The real-world date text to parse.", "A .NET date/time format string used to format or parse the date." },
+            "Parses real-world date text using a .NET format mask and invariant culture. Returns an error if the text does not match the supplied format.",
+            "Date/Time",
+            ProgVariableTypes.DateTime
         ));
     }
 }
@@ -97,7 +102,12 @@ internal class ToMudDateFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "todate",
             new[] { ProgVariableTypes.Calendar, ProgVariableTypes.Clock, ProgVariableTypes.Text },
-            (pars, gameworld) => new ToMudDateFunction(pars)
+            (pars, gameworld) => new ToMudDateFunction(pars),
+            new List<string> { "calendar", "clock", "text" },
+            new List<string> { "The in-game calendar to use.", "The in-game clock to use, or the clock name where this function accepts text.", "The text to parse." },
+            "Parses text into an in-game mud datetime using the supplied calendar and clock. Returns the special Never mud datetime when the calendar is null, the text is empty, or parsing fails.",
+            "Date/Time",
+            ProgVariableTypes.MudDateTime
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/DateTime/TodayFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/DateTime/TodayFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.FutureProg.Variables;
+using MudSharp.FutureProg.Variables;
 using System.Collections.Generic;
 
 namespace MudSharp.FutureProg.Functions.DateTime;
@@ -27,7 +27,12 @@ internal class TodayFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "today",
             new ProgVariableTypes[] { },
-            (pars, gameworld) => new TodayFunction(pars)
+            (pars, gameworld) => new TodayFunction(pars),
+            new List<string>(),
+            new List<string>(),
+            "Returns the current real-world UTC date with the time component set to midnight. Use now() when you need the current instant rather than just the date.",
+            "Date/Time",
+            ProgVariableTypes.DateTime
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/Discord/SendDiscordMessageFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Discord/SendDiscordMessageFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Framework;
+using MudSharp.Framework;
 using MudSharp.FutureProg.Variables;
 using System;
 using System.Collections.Generic;
@@ -30,7 +30,12 @@ internal class SendDiscordMessageFunction : BuiltInFunction
             new FunctionCompilerInformation(
                 "senddiscord",
                 new[] { ProgVariableTypes.Number, ProgVariableTypes.Text, ProgVariableTypes.Text },
-                (pars, gameworld) => new SendDiscordMessageFunction(pars, gameworld)
+                (pars, gameworld) => new SendDiscordMessageFunction(pars, gameworld),
+                new List<string> { "channelId", "title", "message" },
+                new List<string> { "The numeric Discord channel ID to send to.", "The title or heading of the outgoing message.", "The body text of the outgoing Discord message." },
+                "Sends a Discord message through the configured Discord connection using channel ID, title, and message text. Returns false if any argument is null; returns true after queueing the send even if no Discord connection is currently configured.",
+                "Discord",
+                ProgVariableTypes.Boolean
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/Echoes/SendAreaFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Echoes/SendAreaFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Construction;
+using MudSharp.Construction;
 using MudSharp.Framework;
 using MudSharp.FutureProg.Variables;
 using MudSharp.PerceptionEngine;
@@ -74,7 +74,12 @@ internal class SendAreaFunction : BuiltInFunction
             new FunctionCompilerInformation(
                 "sendarea",
                 new[] { ProgVariableTypes.Area, ProgVariableTypes.Text },
-                (pars, gameworld) => new SendAreaFunction(pars, gameworld)
+                (pars, gameworld) => new SendAreaFunction(pars, gameworld),
+                new List<string> { "area", "message" },
+                new List<string> { "The area that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -85,7 +90,12 @@ internal class SendAreaFunction : BuiltInFunction
                 {
                     ProgVariableTypes.Area, ProgVariableTypes.Text, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendAreaFunction(pars, gameworld)
+                (pars, gameworld) => new SendAreaFunction(pars, gameworld),
+                new List<string> { "area", "message", "reference1" },
+                new List<string> { "The area that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -97,7 +107,12 @@ internal class SendAreaFunction : BuiltInFunction
                     ProgVariableTypes.Area, ProgVariableTypes.Text, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendAreaFunction(pars, gameworld)
+                (pars, gameworld) => new SendAreaFunction(pars, gameworld),
+                new List<string> { "area", "message", "reference1", "reference2" },
+                new List<string> { "The area that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -109,7 +124,12 @@ internal class SendAreaFunction : BuiltInFunction
                     ProgVariableTypes.Area, ProgVariableTypes.Text, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendAreaFunction(pars, gameworld)
+                (pars, gameworld) => new SendAreaFunction(pars, gameworld),
+                new List<string> { "area", "message", "reference1", "reference2", "reference3" },
+                new List<string> { "The area that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -122,7 +142,12 @@ internal class SendAreaFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendAreaFunction(pars, gameworld)
+                (pars, gameworld) => new SendAreaFunction(pars, gameworld),
+                new List<string> { "area", "message", "reference1", "reference2", "reference3", "reference4" },
+                new List<string> { "The area that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -135,7 +160,12 @@ internal class SendAreaFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendAreaFunction(pars, gameworld)
+                (pars, gameworld) => new SendAreaFunction(pars, gameworld),
+                new List<string> { "area", "message", "reference1", "reference2", "reference3", "reference4", "reference5" },
+                new List<string> { "The area that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -149,7 +179,12 @@ internal class SendAreaFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendAreaFunction(pars, gameworld)
+                (pars, gameworld) => new SendAreaFunction(pars, gameworld),
+                new List<string> { "area", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6" },
+                new List<string> { "The area that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -163,7 +198,12 @@ internal class SendAreaFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendAreaFunction(pars, gameworld)
+                (pars, gameworld) => new SendAreaFunction(pars, gameworld),
+                new List<string> { "area", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7" },
+                new List<string> { "The area that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -178,7 +218,12 @@ internal class SendAreaFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendAreaFunction(pars, gameworld)
+                (pars, gameworld) => new SendAreaFunction(pars, gameworld),
+                new List<string> { "area", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7", "reference8" },
+                new List<string> { "The area that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -187,7 +232,12 @@ internal class SendAreaFunction : BuiltInFunction
             new FunctionCompilerInformation(
                 "sendareafixed",
                 new[] { ProgVariableTypes.Area, ProgVariableTypes.Text },
-                (pars, gameworld) => new SendAreaFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendAreaFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "area", "message" },
+                new List<string> { "The area that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -198,7 +248,12 @@ internal class SendAreaFunction : BuiltInFunction
                 {
                     ProgVariableTypes.Area, ProgVariableTypes.Text, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendAreaFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendAreaFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "area", "message", "reference1" },
+                new List<string> { "The area that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -210,7 +265,12 @@ internal class SendAreaFunction : BuiltInFunction
                     ProgVariableTypes.Area, ProgVariableTypes.Text, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendAreaFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendAreaFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "area", "message", "reference1", "reference2" },
+                new List<string> { "The area that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -222,7 +282,12 @@ internal class SendAreaFunction : BuiltInFunction
                     ProgVariableTypes.Area, ProgVariableTypes.Text, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendAreaFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendAreaFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "area", "message", "reference1", "reference2", "reference3" },
+                new List<string> { "The area that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -235,7 +300,12 @@ internal class SendAreaFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendAreaFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendAreaFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "area", "message", "reference1", "reference2", "reference3", "reference4" },
+                new List<string> { "The area that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -248,7 +318,12 @@ internal class SendAreaFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendAreaFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendAreaFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "area", "message", "reference1", "reference2", "reference3", "reference4", "reference5" },
+                new List<string> { "The area that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -262,7 +337,12 @@ internal class SendAreaFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendAreaFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendAreaFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "area", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6" },
+                new List<string> { "The area that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -276,7 +356,12 @@ internal class SendAreaFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendAreaFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendAreaFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "area", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7" },
+                new List<string> { "The area that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -291,7 +376,12 @@ internal class SendAreaFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendAreaFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendAreaFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "area", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7", "reference8" },
+                new List<string> { "The area that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/Echoes/SendAreaLangFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Echoes/SendAreaLangFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Communication.Language;
+using MudSharp.Communication.Language;
 using MudSharp.Construction;
 using MudSharp.Framework;
 using MudSharp.FutureProg.Variables;
@@ -88,7 +88,12 @@ internal class SendAreaLangFunction : BuiltInFunction
                     ProgVariableTypes.Area, ProgVariableTypes.Text, ProgVariableTypes.Language,
                     ProgVariableTypes.Accent
                 },
-                (pars, gameworld) => new SendAreaLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendAreaLangFunction(pars, gameworld),
+                new List<string> { "area", "message", "language", "accent" },
+                new List<string> { "The area that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -100,7 +105,12 @@ internal class SendAreaLangFunction : BuiltInFunction
                     ProgVariableTypes.Area, ProgVariableTypes.Text, ProgVariableTypes.Language,
                     ProgVariableTypes.Accent, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendAreaLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendAreaLangFunction(pars, gameworld),
+                new List<string> { "area", "message", "language", "accent", "reference1" },
+                new List<string> { "The area that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -113,7 +123,12 @@ internal class SendAreaLangFunction : BuiltInFunction
                     ProgVariableTypes.Accent, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendAreaLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendAreaLangFunction(pars, gameworld),
+                new List<string> { "area", "message", "language", "accent", "reference1", "reference2" },
+                new List<string> { "The area that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -126,7 +141,12 @@ internal class SendAreaLangFunction : BuiltInFunction
                     ProgVariableTypes.Accent, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendAreaLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendAreaLangFunction(pars, gameworld),
+                new List<string> { "area", "message", "language", "accent", "reference1", "reference2", "reference3" },
+                new List<string> { "The area that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -140,7 +160,12 @@ internal class SendAreaLangFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendAreaLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendAreaLangFunction(pars, gameworld),
+                new List<string> { "area", "message", "language", "accent", "reference1", "reference2", "reference3", "reference4" },
+                new List<string> { "The area that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -154,7 +179,12 @@ internal class SendAreaLangFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendAreaLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendAreaLangFunction(pars, gameworld),
+                new List<string> { "area", "message", "language", "accent", "reference1", "reference2", "reference3", "reference4", "reference5" },
+                new List<string> { "The area that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -169,7 +199,12 @@ internal class SendAreaLangFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendAreaLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendAreaLangFunction(pars, gameworld),
+                new List<string> { "area", "message", "language", "accent", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6" },
+                new List<string> { "The area that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -184,7 +219,12 @@ internal class SendAreaLangFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendAreaLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendAreaLangFunction(pars, gameworld),
+                new List<string> { "area", "message", "language", "accent", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7" },
+                new List<string> { "The area that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -200,7 +240,12 @@ internal class SendAreaLangFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendAreaLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendAreaLangFunction(pars, gameworld),
+                new List<string> { "area", "message", "language", "accent", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7", "reference8" },
+                new List<string> { "The area that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/Echoes/SendFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Echoes/SendFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Framework;
+using MudSharp.Framework;
 using MudSharp.FutureProg.Variables;
 using MudSharp.PerceptionEngine;
 using MudSharp.PerceptionEngine.Outputs;
@@ -77,7 +77,12 @@ internal class SendFunction : BuiltInFunction
             new FunctionCompilerInformation(
                 "send",
                 new[] { ProgVariableTypes.Perceiver, ProgVariableTypes.Text },
-                (pars, gameworld) => new SendFunction(pars, gameworld)
+                (pars, gameworld) => new SendFunction(pars, gameworld),
+                new List<string> { "target", "message" },
+                new List<string> { "The target that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -88,7 +93,12 @@ internal class SendFunction : BuiltInFunction
                 {
                     ProgVariableTypes.Perceiver, ProgVariableTypes.Text, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendFunction(pars, gameworld)
+                (pars, gameworld) => new SendFunction(pars, gameworld),
+                new List<string> { "target", "message", "reference1" },
+                new List<string> { "The target that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -100,7 +110,12 @@ internal class SendFunction : BuiltInFunction
                     ProgVariableTypes.Perceiver, ProgVariableTypes.Text,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendFunction(pars, gameworld)
+                (pars, gameworld) => new SendFunction(pars, gameworld),
+                new List<string> { "target", "message", "reference1", "reference2" },
+                new List<string> { "The target that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -113,7 +128,12 @@ internal class SendFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendFunction(pars, gameworld)
+                (pars, gameworld) => new SendFunction(pars, gameworld),
+                new List<string> { "target", "message", "reference1", "reference2", "reference3" },
+                new List<string> { "The target that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -126,7 +146,12 @@ internal class SendFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendFunction(pars, gameworld)
+                (pars, gameworld) => new SendFunction(pars, gameworld),
+                new List<string> { "target", "message", "reference1", "reference2", "reference3", "reference4" },
+                new List<string> { "The target that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -140,7 +165,12 @@ internal class SendFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendFunction(pars, gameworld)
+                (pars, gameworld) => new SendFunction(pars, gameworld),
+                new List<string> { "target", "message", "reference1", "reference2", "reference3", "reference4", "reference5" },
+                new List<string> { "The target that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -154,7 +184,12 @@ internal class SendFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendFunction(pars, gameworld)
+                (pars, gameworld) => new SendFunction(pars, gameworld),
+                new List<string> { "target", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6" },
+                new List<string> { "The target that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -169,7 +204,12 @@ internal class SendFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendFunction(pars, gameworld)
+                (pars, gameworld) => new SendFunction(pars, gameworld),
+                new List<string> { "target", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7" },
+                new List<string> { "The target that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -184,7 +224,12 @@ internal class SendFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendFunction(pars, gameworld)
+                (pars, gameworld) => new SendFunction(pars, gameworld),
+                new List<string> { "target", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7", "reference8" },
+                new List<string> { "The target that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -193,7 +238,12 @@ internal class SendFunction : BuiltInFunction
             new FunctionCompilerInformation(
                 "sendfixed",
                 new[] { ProgVariableTypes.Perceiver, ProgVariableTypes.Text },
-                (pars, gameworld) => new SendFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "target", "message" },
+                new List<string> { "The target that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -204,7 +254,12 @@ internal class SendFunction : BuiltInFunction
                 {
                     ProgVariableTypes.Perceiver, ProgVariableTypes.Text, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "target", "message", "reference1" },
+                new List<string> { "The target that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -216,7 +271,12 @@ internal class SendFunction : BuiltInFunction
                     ProgVariableTypes.Perceiver, ProgVariableTypes.Text,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "target", "message", "reference1", "reference2" },
+                new List<string> { "The target that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -229,7 +289,12 @@ internal class SendFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "target", "message", "reference1", "reference2", "reference3" },
+                new List<string> { "The target that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -242,7 +307,12 @@ internal class SendFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "target", "message", "reference1", "reference2", "reference3", "reference4" },
+                new List<string> { "The target that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -256,7 +326,12 @@ internal class SendFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "target", "message", "reference1", "reference2", "reference3", "reference4", "reference5" },
+                new List<string> { "The target that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -270,7 +345,12 @@ internal class SendFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "target", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6" },
+                new List<string> { "The target that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -285,7 +365,12 @@ internal class SendFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "target", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7" },
+                new List<string> { "The target that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -300,7 +385,12 @@ internal class SendFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "target", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7", "reference8" },
+                new List<string> { "The target that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/Echoes/SendLangFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Echoes/SendLangFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Communication.Language;
+using MudSharp.Communication.Language;
 using MudSharp.Framework;
 using MudSharp.FutureProg.Variables;
 using MudSharp.PerceptionEngine;
@@ -90,7 +90,12 @@ internal class SendLangFunction : BuiltInFunction
                     ProgVariableTypes.Perceiver, ProgVariableTypes.Text, ProgVariableTypes.Language,
                     ProgVariableTypes.Accent
                 },
-                (pars, gameworld) => new SendLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendLangFunction(pars, gameworld),
+                new List<string> { "target", "message", "language", "accent" },
+                new List<string> { "The target that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -102,7 +107,12 @@ internal class SendLangFunction : BuiltInFunction
                     ProgVariableTypes.Perceiver, ProgVariableTypes.Text, ProgVariableTypes.Language,
                     ProgVariableTypes.Accent, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendLangFunction(pars, gameworld),
+                new List<string> { "target", "message", "language", "accent", "reference1" },
+                new List<string> { "The target that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -115,7 +125,12 @@ internal class SendLangFunction : BuiltInFunction
                     ProgVariableTypes.Accent, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendLangFunction(pars, gameworld),
+                new List<string> { "target", "message", "language", "accent", "reference1", "reference2" },
+                new List<string> { "The target that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -128,7 +143,12 @@ internal class SendLangFunction : BuiltInFunction
                     ProgVariableTypes.Accent, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendLangFunction(pars, gameworld),
+                new List<string> { "target", "message", "language", "accent", "reference1", "reference2", "reference3" },
+                new List<string> { "The target that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -142,7 +162,12 @@ internal class SendLangFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendLangFunction(pars, gameworld),
+                new List<string> { "target", "message", "language", "accent", "reference1", "reference2", "reference3", "reference4" },
+                new List<string> { "The target that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -156,7 +181,12 @@ internal class SendLangFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendLangFunction(pars, gameworld),
+                new List<string> { "target", "message", "language", "accent", "reference1", "reference2", "reference3", "reference4", "reference5" },
+                new List<string> { "The target that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -171,7 +201,12 @@ internal class SendLangFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendLangFunction(pars, gameworld),
+                new List<string> { "target", "message", "language", "accent", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6" },
+                new List<string> { "The target that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -186,7 +221,12 @@ internal class SendLangFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendLangFunction(pars, gameworld),
+                new List<string> { "target", "message", "language", "accent", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7" },
+                new List<string> { "The target that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -202,7 +242,12 @@ internal class SendLangFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendLangFunction(pars, gameworld),
+                new List<string> { "target", "message", "language", "accent", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7", "reference8" },
+                new List<string> { "The target that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/Echoes/SendShardFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Echoes/SendShardFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Construction;
+using MudSharp.Construction;
 using MudSharp.Framework;
 using MudSharp.FutureProg.Variables;
 using MudSharp.PerceptionEngine;
@@ -77,7 +77,12 @@ internal class SendShardFunction : BuiltInFunction
             new FunctionCompilerInformation(
                 "sendshard",
                 new[] { ProgVariableTypes.Shard, ProgVariableTypes.Text },
-                (pars, gameworld) => new SendShardFunction(pars, gameworld)
+                (pars, gameworld) => new SendShardFunction(pars, gameworld),
+                new List<string> { "shard", "message" },
+                new List<string> { "The shard that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -88,7 +93,12 @@ internal class SendShardFunction : BuiltInFunction
                 {
                     ProgVariableTypes.Shard, ProgVariableTypes.Text, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendShardFunction(pars, gameworld)
+                (pars, gameworld) => new SendShardFunction(pars, gameworld),
+                new List<string> { "shard", "message", "reference1" },
+                new List<string> { "The shard that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -100,7 +110,12 @@ internal class SendShardFunction : BuiltInFunction
                     ProgVariableTypes.Shard, ProgVariableTypes.Text, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendShardFunction(pars, gameworld)
+                (pars, gameworld) => new SendShardFunction(pars, gameworld),
+                new List<string> { "shard", "message", "reference1", "reference2" },
+                new List<string> { "The shard that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -112,7 +127,12 @@ internal class SendShardFunction : BuiltInFunction
                     ProgVariableTypes.Shard, ProgVariableTypes.Text, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendShardFunction(pars, gameworld)
+                (pars, gameworld) => new SendShardFunction(pars, gameworld),
+                new List<string> { "shard", "message", "reference1", "reference2", "reference3" },
+                new List<string> { "The shard that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -125,7 +145,12 @@ internal class SendShardFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendShardFunction(pars, gameworld)
+                (pars, gameworld) => new SendShardFunction(pars, gameworld),
+                new List<string> { "shard", "message", "reference1", "reference2", "reference3", "reference4" },
+                new List<string> { "The shard that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -138,7 +163,12 @@ internal class SendShardFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendShardFunction(pars, gameworld)
+                (pars, gameworld) => new SendShardFunction(pars, gameworld),
+                new List<string> { "shard", "message", "reference1", "reference2", "reference3", "reference4", "reference5" },
+                new List<string> { "The shard that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -152,7 +182,12 @@ internal class SendShardFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendShardFunction(pars, gameworld)
+                (pars, gameworld) => new SendShardFunction(pars, gameworld),
+                new List<string> { "shard", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6" },
+                new List<string> { "The shard that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -166,7 +201,12 @@ internal class SendShardFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendShardFunction(pars, gameworld)
+                (pars, gameworld) => new SendShardFunction(pars, gameworld),
+                new List<string> { "shard", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7" },
+                new List<string> { "The shard that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -181,7 +221,12 @@ internal class SendShardFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendShardFunction(pars, gameworld)
+                (pars, gameworld) => new SendShardFunction(pars, gameworld),
+                new List<string> { "shard", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7", "reference8" },
+                new List<string> { "The shard that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -190,7 +235,12 @@ internal class SendShardFunction : BuiltInFunction
             new FunctionCompilerInformation(
                 "sendshardfixed",
                 new[] { ProgVariableTypes.Shard, ProgVariableTypes.Text },
-                (pars, gameworld) => new SendShardFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendShardFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "shard", "message" },
+                new List<string> { "The shard that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -201,7 +251,12 @@ internal class SendShardFunction : BuiltInFunction
                 {
                     ProgVariableTypes.Shard, ProgVariableTypes.Text, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendShardFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendShardFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "shard", "message", "reference1" },
+                new List<string> { "The shard that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -213,7 +268,12 @@ internal class SendShardFunction : BuiltInFunction
                     ProgVariableTypes.Shard, ProgVariableTypes.Text, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendShardFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendShardFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "shard", "message", "reference1", "reference2" },
+                new List<string> { "The shard that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -225,7 +285,12 @@ internal class SendShardFunction : BuiltInFunction
                     ProgVariableTypes.Shard, ProgVariableTypes.Text, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendShardFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendShardFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "shard", "message", "reference1", "reference2", "reference3" },
+                new List<string> { "The shard that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -238,7 +303,12 @@ internal class SendShardFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendShardFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendShardFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "shard", "message", "reference1", "reference2", "reference3", "reference4" },
+                new List<string> { "The shard that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -251,7 +321,12 @@ internal class SendShardFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendShardFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendShardFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "shard", "message", "reference1", "reference2", "reference3", "reference4", "reference5" },
+                new List<string> { "The shard that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -265,7 +340,12 @@ internal class SendShardFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendShardFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendShardFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "shard", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6" },
+                new List<string> { "The shard that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -279,7 +359,12 @@ internal class SendShardFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendShardFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendShardFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "shard", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7" },
+                new List<string> { "The shard that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -294,7 +379,12 @@ internal class SendShardFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendShardFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendShardFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "shard", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7", "reference8" },
+                new List<string> { "The shard that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/Echoes/SendShardLangFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Echoes/SendShardLangFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Communication.Language;
+using MudSharp.Communication.Language;
 using MudSharp.Construction;
 using MudSharp.Framework;
 using MudSharp.FutureProg.Variables;
@@ -91,7 +91,12 @@ internal class SendShardLangFunction : BuiltInFunction
                     ProgVariableTypes.Shard, ProgVariableTypes.Text, ProgVariableTypes.Language,
                     ProgVariableTypes.Accent
                 },
-                (pars, gameworld) => new SendShardLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendShardLangFunction(pars, gameworld),
+                new List<string> { "shard", "message", "language", "accent" },
+                new List<string> { "The shard that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -103,7 +108,12 @@ internal class SendShardLangFunction : BuiltInFunction
                     ProgVariableTypes.Shard, ProgVariableTypes.Text, ProgVariableTypes.Language,
                     ProgVariableTypes.Accent, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendShardLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendShardLangFunction(pars, gameworld),
+                new List<string> { "shard", "message", "language", "accent", "reference1" },
+                new List<string> { "The shard that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -116,7 +126,12 @@ internal class SendShardLangFunction : BuiltInFunction
                     ProgVariableTypes.Accent, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendShardLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendShardLangFunction(pars, gameworld),
+                new List<string> { "shard", "message", "language", "accent", "reference1", "reference2" },
+                new List<string> { "The shard that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -129,7 +144,12 @@ internal class SendShardLangFunction : BuiltInFunction
                     ProgVariableTypes.Accent, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendShardLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendShardLangFunction(pars, gameworld),
+                new List<string> { "shard", "message", "language", "accent", "reference1", "reference2", "reference3" },
+                new List<string> { "The shard that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -143,7 +163,12 @@ internal class SendShardLangFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendShardLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendShardLangFunction(pars, gameworld),
+                new List<string> { "shard", "message", "language", "accent", "reference1", "reference2", "reference3", "reference4" },
+                new List<string> { "The shard that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -157,7 +182,12 @@ internal class SendShardLangFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendShardLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendShardLangFunction(pars, gameworld),
+                new List<string> { "shard", "message", "language", "accent", "reference1", "reference2", "reference3", "reference4", "reference5" },
+                new List<string> { "The shard that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -172,7 +202,12 @@ internal class SendShardLangFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendShardLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendShardLangFunction(pars, gameworld),
+                new List<string> { "shard", "message", "language", "accent", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6" },
+                new List<string> { "The shard that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -187,7 +222,12 @@ internal class SendShardLangFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendShardLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendShardLangFunction(pars, gameworld),
+                new List<string> { "shard", "message", "language", "accent", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7" },
+                new List<string> { "The shard that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -203,7 +243,12 @@ internal class SendShardLangFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendShardLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendShardLangFunction(pars, gameworld),
+                new List<string> { "shard", "message", "language", "accent", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7", "reference8" },
+                new List<string> { "The shard that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/Echoes/SendTerrainFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Echoes/SendTerrainFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Construction;
+using MudSharp.Construction;
 using MudSharp.Framework;
 using MudSharp.FutureProg.Variables;
 using MudSharp.PerceptionEngine;
@@ -83,7 +83,12 @@ internal class SendTerrainFunction : BuiltInFunction
             new FunctionCompilerInformation(
                 "sendterrain",
                 new[] { ProgVariableTypes.Terrain, ProgVariableTypes.Text },
-                (pars, gameworld) => new SendTerrainFunction(pars, gameworld)
+                (pars, gameworld) => new SendTerrainFunction(pars, gameworld),
+                new List<string> { "terrain", "message" },
+                new List<string> { "The terrain that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -94,7 +99,12 @@ internal class SendTerrainFunction : BuiltInFunction
                 {
                     ProgVariableTypes.Terrain, ProgVariableTypes.Text, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendTerrainFunction(pars, gameworld)
+                (pars, gameworld) => new SendTerrainFunction(pars, gameworld),
+                new List<string> { "terrain", "message", "reference1" },
+                new List<string> { "The terrain that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -106,7 +116,12 @@ internal class SendTerrainFunction : BuiltInFunction
                     ProgVariableTypes.Terrain, ProgVariableTypes.Text, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendTerrainFunction(pars, gameworld)
+                (pars, gameworld) => new SendTerrainFunction(pars, gameworld),
+                new List<string> { "terrain", "message", "reference1", "reference2" },
+                new List<string> { "The terrain that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -118,7 +133,12 @@ internal class SendTerrainFunction : BuiltInFunction
                     ProgVariableTypes.Terrain, ProgVariableTypes.Text, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendTerrainFunction(pars, gameworld)
+                (pars, gameworld) => new SendTerrainFunction(pars, gameworld),
+                new List<string> { "terrain", "message", "reference1", "reference2", "reference3" },
+                new List<string> { "The terrain that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -131,7 +151,12 @@ internal class SendTerrainFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendTerrainFunction(pars, gameworld)
+                (pars, gameworld) => new SendTerrainFunction(pars, gameworld),
+                new List<string> { "terrain", "message", "reference1", "reference2", "reference3", "reference4" },
+                new List<string> { "The terrain that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -144,7 +169,12 @@ internal class SendTerrainFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendTerrainFunction(pars, gameworld)
+                (pars, gameworld) => new SendTerrainFunction(pars, gameworld),
+                new List<string> { "terrain", "message", "reference1", "reference2", "reference3", "reference4", "reference5" },
+                new List<string> { "The terrain that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -158,7 +188,12 @@ internal class SendTerrainFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendTerrainFunction(pars, gameworld)
+                (pars, gameworld) => new SendTerrainFunction(pars, gameworld),
+                new List<string> { "terrain", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6" },
+                new List<string> { "The terrain that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -172,7 +207,12 @@ internal class SendTerrainFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendTerrainFunction(pars, gameworld)
+                (pars, gameworld) => new SendTerrainFunction(pars, gameworld),
+                new List<string> { "terrain", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7" },
+                new List<string> { "The terrain that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -187,7 +227,12 @@ internal class SendTerrainFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendTerrainFunction(pars, gameworld)
+                (pars, gameworld) => new SendTerrainFunction(pars, gameworld),
+                new List<string> { "terrain", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7", "reference8" },
+                new List<string> { "The terrain that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -196,7 +241,12 @@ internal class SendTerrainFunction : BuiltInFunction
             new FunctionCompilerInformation(
                 "sendterrainfixed",
                 new[] { ProgVariableTypes.Terrain, ProgVariableTypes.Text },
-                (pars, gameworld) => new SendTerrainFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendTerrainFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "terrain", "message" },
+                new List<string> { "The terrain that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -207,7 +257,12 @@ internal class SendTerrainFunction : BuiltInFunction
                 {
                     ProgVariableTypes.Terrain, ProgVariableTypes.Text, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendTerrainFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendTerrainFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "terrain", "message", "reference1" },
+                new List<string> { "The terrain that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -219,7 +274,12 @@ internal class SendTerrainFunction : BuiltInFunction
                     ProgVariableTypes.Terrain, ProgVariableTypes.Text, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendTerrainFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendTerrainFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "terrain", "message", "reference1", "reference2" },
+                new List<string> { "The terrain that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -231,7 +291,12 @@ internal class SendTerrainFunction : BuiltInFunction
                     ProgVariableTypes.Terrain, ProgVariableTypes.Text, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendTerrainFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendTerrainFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "terrain", "message", "reference1", "reference2", "reference3" },
+                new List<string> { "The terrain that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -244,7 +309,12 @@ internal class SendTerrainFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendTerrainFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendTerrainFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "terrain", "message", "reference1", "reference2", "reference3", "reference4" },
+                new List<string> { "The terrain that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -257,7 +327,12 @@ internal class SendTerrainFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendTerrainFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendTerrainFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "terrain", "message", "reference1", "reference2", "reference3", "reference4", "reference5" },
+                new List<string> { "The terrain that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -271,7 +346,12 @@ internal class SendTerrainFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendTerrainFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendTerrainFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "terrain", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6" },
+                new List<string> { "The terrain that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -285,7 +365,12 @@ internal class SendTerrainFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendTerrainFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendTerrainFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "terrain", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7" },
+                new List<string> { "The terrain that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -300,7 +385,12 @@ internal class SendTerrainFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendTerrainFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendTerrainFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "terrain", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7", "reference8" },
+                new List<string> { "The terrain that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/Echoes/SendTerrainLangFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Echoes/SendTerrainLangFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Communication.Language;
+using MudSharp.Communication.Language;
 using MudSharp.Construction;
 using MudSharp.Framework;
 using MudSharp.FutureProg.Variables;
@@ -96,7 +96,12 @@ internal class SendTerrainLangFunction : BuiltInFunction
                     ProgVariableTypes.Terrain, ProgVariableTypes.Text, ProgVariableTypes.Language,
                     ProgVariableTypes.Accent
                 },
-                (pars, gameworld) => new SendTerrainLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendTerrainLangFunction(pars, gameworld),
+                new List<string> { "terrain", "message", "language", "accent" },
+                new List<string> { "The terrain that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -108,7 +113,12 @@ internal class SendTerrainLangFunction : BuiltInFunction
                     ProgVariableTypes.Terrain, ProgVariableTypes.Text, ProgVariableTypes.Language,
                     ProgVariableTypes.Accent, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendTerrainLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendTerrainLangFunction(pars, gameworld),
+                new List<string> { "terrain", "message", "language", "accent", "reference1" },
+                new List<string> { "The terrain that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -121,7 +131,12 @@ internal class SendTerrainLangFunction : BuiltInFunction
                     ProgVariableTypes.Accent, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendTerrainLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendTerrainLangFunction(pars, gameworld),
+                new List<string> { "terrain", "message", "language", "accent", "reference1", "reference2" },
+                new List<string> { "The terrain that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -134,7 +149,12 @@ internal class SendTerrainLangFunction : BuiltInFunction
                     ProgVariableTypes.Accent, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendTerrainLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendTerrainLangFunction(pars, gameworld),
+                new List<string> { "terrain", "message", "language", "accent", "reference1", "reference2", "reference3" },
+                new List<string> { "The terrain that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -148,7 +168,12 @@ internal class SendTerrainLangFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendTerrainLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendTerrainLangFunction(pars, gameworld),
+                new List<string> { "terrain", "message", "language", "accent", "reference1", "reference2", "reference3", "reference4" },
+                new List<string> { "The terrain that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -162,7 +187,12 @@ internal class SendTerrainLangFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendTerrainLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendTerrainLangFunction(pars, gameworld),
+                new List<string> { "terrain", "message", "language", "accent", "reference1", "reference2", "reference3", "reference4", "reference5" },
+                new List<string> { "The terrain that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -177,7 +207,12 @@ internal class SendTerrainLangFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendTerrainLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendTerrainLangFunction(pars, gameworld),
+                new List<string> { "terrain", "message", "language", "accent", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6" },
+                new List<string> { "The terrain that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -192,7 +227,12 @@ internal class SendTerrainLangFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendTerrainLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendTerrainLangFunction(pars, gameworld),
+                new List<string> { "terrain", "message", "language", "accent", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7" },
+                new List<string> { "The terrain that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -208,7 +248,12 @@ internal class SendTerrainLangFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendTerrainLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendTerrainLangFunction(pars, gameworld),
+                new List<string> { "terrain", "message", "language", "accent", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7", "reference8" },
+                new List<string> { "The terrain that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/Echoes/SendZoneFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Echoes/SendZoneFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Construction;
+using MudSharp.Construction;
 using MudSharp.Framework;
 using MudSharp.FutureProg.Variables;
 using MudSharp.PerceptionEngine;
@@ -77,7 +77,12 @@ internal class SendZoneFunction : BuiltInFunction
             new FunctionCompilerInformation(
                 "sendzone",
                 new[] { ProgVariableTypes.Zone, ProgVariableTypes.Text },
-                (pars, gameworld) => new SendZoneFunction(pars, gameworld)
+                (pars, gameworld) => new SendZoneFunction(pars, gameworld),
+                new List<string> { "zone", "message" },
+                new List<string> { "The zone that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -88,7 +93,12 @@ internal class SendZoneFunction : BuiltInFunction
                 {
                     ProgVariableTypes.Zone, ProgVariableTypes.Text, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendZoneFunction(pars, gameworld)
+                (pars, gameworld) => new SendZoneFunction(pars, gameworld),
+                new List<string> { "zone", "message", "reference1" },
+                new List<string> { "The zone that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -100,7 +110,12 @@ internal class SendZoneFunction : BuiltInFunction
                     ProgVariableTypes.Zone, ProgVariableTypes.Text, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendZoneFunction(pars, gameworld)
+                (pars, gameworld) => new SendZoneFunction(pars, gameworld),
+                new List<string> { "zone", "message", "reference1", "reference2" },
+                new List<string> { "The zone that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -112,7 +127,12 @@ internal class SendZoneFunction : BuiltInFunction
                     ProgVariableTypes.Zone, ProgVariableTypes.Text, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendZoneFunction(pars, gameworld)
+                (pars, gameworld) => new SendZoneFunction(pars, gameworld),
+                new List<string> { "zone", "message", "reference1", "reference2", "reference3" },
+                new List<string> { "The zone that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -125,7 +145,12 @@ internal class SendZoneFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendZoneFunction(pars, gameworld)
+                (pars, gameworld) => new SendZoneFunction(pars, gameworld),
+                new List<string> { "zone", "message", "reference1", "reference2", "reference3", "reference4" },
+                new List<string> { "The zone that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -138,7 +163,12 @@ internal class SendZoneFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendZoneFunction(pars, gameworld)
+                (pars, gameworld) => new SendZoneFunction(pars, gameworld),
+                new List<string> { "zone", "message", "reference1", "reference2", "reference3", "reference4", "reference5" },
+                new List<string> { "The zone that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -152,7 +182,12 @@ internal class SendZoneFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendZoneFunction(pars, gameworld)
+                (pars, gameworld) => new SendZoneFunction(pars, gameworld),
+                new List<string> { "zone", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6" },
+                new List<string> { "The zone that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -166,7 +201,12 @@ internal class SendZoneFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendZoneFunction(pars, gameworld)
+                (pars, gameworld) => new SendZoneFunction(pars, gameworld),
+                new List<string> { "zone", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7" },
+                new List<string> { "The zone that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -181,7 +221,12 @@ internal class SendZoneFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendZoneFunction(pars, gameworld)
+                (pars, gameworld) => new SendZoneFunction(pars, gameworld),
+                new List<string> { "zone", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7", "reference8" },
+                new List<string> { "The zone that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -190,7 +235,12 @@ internal class SendZoneFunction : BuiltInFunction
             new FunctionCompilerInformation(
                 "sendzonefixed",
                 new[] { ProgVariableTypes.Zone, ProgVariableTypes.Text },
-                (pars, gameworld) => new SendZoneFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendZoneFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "zone", "message" },
+                new List<string> { "The zone that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -201,7 +251,12 @@ internal class SendZoneFunction : BuiltInFunction
                 {
                     ProgVariableTypes.Zone, ProgVariableTypes.Text, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendZoneFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendZoneFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "zone", "message", "reference1" },
+                new List<string> { "The zone that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -213,7 +268,12 @@ internal class SendZoneFunction : BuiltInFunction
                     ProgVariableTypes.Zone, ProgVariableTypes.Text, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendZoneFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendZoneFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "zone", "message", "reference1", "reference2" },
+                new List<string> { "The zone that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -225,7 +285,12 @@ internal class SendZoneFunction : BuiltInFunction
                     ProgVariableTypes.Zone, ProgVariableTypes.Text, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendZoneFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendZoneFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "zone", "message", "reference1", "reference2", "reference3" },
+                new List<string> { "The zone that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -238,7 +303,12 @@ internal class SendZoneFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendZoneFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendZoneFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "zone", "message", "reference1", "reference2", "reference3", "reference4" },
+                new List<string> { "The zone that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -251,7 +321,12 @@ internal class SendZoneFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendZoneFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendZoneFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "zone", "message", "reference1", "reference2", "reference3", "reference4", "reference5" },
+                new List<string> { "The zone that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -265,7 +340,12 @@ internal class SendZoneFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendZoneFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendZoneFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "zone", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6" },
+                new List<string> { "The zone that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -279,7 +359,12 @@ internal class SendZoneFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendZoneFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendZoneFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "zone", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7" },
+                new List<string> { "The zone that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -294,7 +379,12 @@ internal class SendZoneFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendZoneFunction(pars, gameworld) { FixedFormat = true }
+                (pars, gameworld) => new SendZoneFunction(pars, gameworld) { FixedFormat = true },
+                new List<string> { "zone", "message", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7", "reference8" },
+                new List<string> { "The zone that receives or scopes the echo.", "The fixed-format text to send. ANSI colour substitutions are applied, but emote parsing is bypassed.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Fixed variants bypass emote parsing and send the supplied text as fixed-format output. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/Echoes/SendZoneLangFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Echoes/SendZoneLangFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Communication.Language;
+using MudSharp.Communication.Language;
 using MudSharp.Construction;
 using MudSharp.Framework;
 using MudSharp.FutureProg.Variables;
@@ -91,7 +91,12 @@ internal class SendZoneLangFunction : BuiltInFunction
                     ProgVariableTypes.Zone, ProgVariableTypes.Text, ProgVariableTypes.Language,
                     ProgVariableTypes.Accent
                 },
-                (pars, gameworld) => new SendZoneLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendZoneLangFunction(pars, gameworld),
+                new List<string> { "zone", "message", "language", "accent" },
+                new List<string> { "The zone that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -103,7 +108,12 @@ internal class SendZoneLangFunction : BuiltInFunction
                     ProgVariableTypes.Zone, ProgVariableTypes.Text, ProgVariableTypes.Language,
                     ProgVariableTypes.Accent, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendZoneLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendZoneLangFunction(pars, gameworld),
+                new List<string> { "zone", "message", "language", "accent", "reference1" },
+                new List<string> { "The zone that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -116,7 +126,12 @@ internal class SendZoneLangFunction : BuiltInFunction
                     ProgVariableTypes.Accent, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendZoneLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendZoneLangFunction(pars, gameworld),
+                new List<string> { "zone", "message", "language", "accent", "reference1", "reference2" },
+                new List<string> { "The zone that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -129,7 +144,12 @@ internal class SendZoneLangFunction : BuiltInFunction
                     ProgVariableTypes.Accent, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendZoneLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendZoneLangFunction(pars, gameworld),
+                new List<string> { "zone", "message", "language", "accent", "reference1", "reference2", "reference3" },
+                new List<string> { "The zone that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -143,7 +163,12 @@ internal class SendZoneLangFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendZoneLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendZoneLangFunction(pars, gameworld),
+                new List<string> { "zone", "message", "language", "accent", "reference1", "reference2", "reference3", "reference4" },
+                new List<string> { "The zone that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -157,7 +182,12 @@ internal class SendZoneLangFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendZoneLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendZoneLangFunction(pars, gameworld),
+                new List<string> { "zone", "message", "language", "accent", "reference1", "reference2", "reference3", "reference4", "reference5" },
+                new List<string> { "The zone that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -172,7 +202,12 @@ internal class SendZoneLangFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendZoneLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendZoneLangFunction(pars, gameworld),
+                new List<string> { "zone", "message", "language", "accent", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6" },
+                new List<string> { "The zone that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -187,7 +222,12 @@ internal class SendZoneLangFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendZoneLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendZoneLangFunction(pars, gameworld),
+                new List<string> { "zone", "message", "language", "accent", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7" },
+                new List<string> { "The zone that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
 
@@ -203,7 +243,12 @@ internal class SendZoneLangFunction : BuiltInFunction
                     ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable,
                     ProgVariableTypes.Perceivable
                 },
-                (pars, gameworld) => new SendZoneLangFunction(pars, gameworld)
+                (pars, gameworld) => new SendZoneLangFunction(pars, gameworld),
+                new List<string> { "zone", "message", "language", "accent", "reference1", "reference2", "reference3", "reference4", "reference5", "reference6", "reference7", "reference8" },
+                new List<string> { "The zone that receives or scopes the echo.", "The emote text to send. ANSI colour substitutions are applied and perceivable references can be used by the emote parser.", "The language used for a language-aware echo.", "The accent used for a language-aware echo.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders.", "An optional perceivable reference for the message, used by the emote parser for pronouns and placeholders." },
+                "Sends a FutureProg echo to the supplied scope. Non-fixed variants parse the text as an emote, so supplied perceivable references can be used for pronouns and placeholders. The language variants use the supplied language and accent, equivalent to sending a language-aware echo through the perception system. Returns true when the scope, message, and every supplied perceivable reference are valid; returns false without sending if a required value is null.",
+                "Echoes",
+                ProgVariableTypes.Boolean
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/GameItem/SetLiquidFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/GameItem/SetLiquidFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Form.Material;
+using MudSharp.Form.Material;
 using MudSharp.Framework;
 using MudSharp.FutureProg.Variables;
 using MudSharp.GameItems;
@@ -62,7 +62,12 @@ internal class SetLiquidFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "setliquid",
             new[] { ProgVariableTypes.Item, ProgVariableTypes.Number },
-            (pars, gameworld) => new SetLiquidFunction(pars, gameworld)
+            (pars, gameworld) => new SetLiquidFunction(pars, gameworld),
+            new List<string> { "item", "liquidId" },
+            new List<string> { "The liquid container item to fill or empty.", "The liquid ID to fill the container with. Use 0 or an invalid ID to empty the container." },
+            "Sets a liquid container's contents to a full container of the selected liquid, or empties it if the ID is invalid. Returns false if the item is null or is not a liquid container.",
+            "Items",
+            ProgVariableTypes.Boolean
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/GameItem/SetLitFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/GameItem/SetLitFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.FutureProg.Variables;
+using MudSharp.FutureProg.Variables;
 using MudSharp.GameItems;
 using MudSharp.GameItems.Interfaces;
 using System.Collections.Generic;
@@ -48,7 +48,12 @@ internal class SetLitFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "setlit",
             new[] { ProgVariableTypes.Item, ProgVariableTypes.Boolean },
-            (pars, gameworld) => new SetLitFunction(pars)
+            (pars, gameworld) => new SetLitFunction(pars),
+            new List<string> { "item", "state" },
+            new List<string> { "The lightable item to update.", "Whether the item should be lit after the call." },
+            "Sets the lit state of a lightable item. Returns false if the item is null or does not have a lightable component.",
+            "Items",
+            ProgVariableTypes.Boolean
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/GameItem/SetOnFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/GameItem/SetOnFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.FutureProg.Variables;
+using MudSharp.FutureProg.Variables;
 using MudSharp.GameItems;
 using MudSharp.GameItems.Interfaces;
 using System.Collections.Generic;
@@ -56,7 +56,12 @@ internal class SetOnFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "seton",
             new[] { ProgVariableTypes.Item, ProgVariableTypes.Boolean, ProgVariableTypes.Boolean },
-            (pars, gameworld) => new SetOnFunction(pars)
+            (pars, gameworld) => new SetOnFunction(pars),
+            new List<string> { "item", "state", "echo" },
+            new List<string> { "The item with an on/off component to switch.", "The desired switched-on state.", "Reserved for echo behaviour; the current helper stores the state directly and does not emit switch-command echoes." },
+            "Sets the switched-on state of an on/off item component, equivalent to changing the component's SwitchedOn flag directly rather than running the player switch command. Returns false if the item is null, lacks the component, or was already in the requested state.",
+            "Items",
+            ProgVariableTypes.Boolean
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/GameItem/SetProvidingCoverFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/GameItem/SetProvidingCoverFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.FutureProg.Variables;
+using MudSharp.FutureProg.Variables;
 using MudSharp.GameItems;
 using MudSharp.GameItems.Interfaces;
 using System.Collections.Generic;
@@ -55,7 +55,12 @@ internal class SetProvidingCoverFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "setprovidingcover",
             new[] { ProgVariableTypes.Item, ProgVariableTypes.Boolean },
-            (pars, gameworld) => new SetProvidingCoverFunction(pars)
+            (pars, gameworld) => new SetProvidingCoverFunction(pars),
+            new List<string> { "item", "state" },
+            new List<string> { "The item with a cover-providing component to update.", "Whether the item should actively provide cover after the call." },
+            "Sets whether an item that can provide cover is actively providing cover. Returns false if the item is null, lacks the component, or was already in the requested state.",
+            "Items",
+            ProgVariableTypes.Boolean
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/GameItem/SetVendingBalance.cs
+++ b/MudSharpCore/FutureProg/Functions/GameItem/SetVendingBalance.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Character;
+using MudSharp.Character;
 using MudSharp.Framework;
 using MudSharp.FutureProg;
 using MudSharp.FutureProg.Variables;
@@ -28,7 +28,12 @@ internal class SetVendingBalance : BuiltInFunction
             new FunctionCompilerInformation(
                 "SetVendingBalance".ToLowerInvariant(),
                 new[] { ProgVariableTypes.Item, ProgVariableTypes.Number },
-                (pars, gameworld) => new SetVendingBalance(pars, gameworld)
+                (pars, gameworld) => new SetVendingBalance(pars, gameworld),
+                new List<string> { "item", "balance" },
+                new List<string> { "The vending machine item whose stored balance should be changed.", "The new numeric balance to store on the machine." },
+                "Sets the current balance stored in a vending-machine item component. Returns false if the item is null, is not a vending machine, or the balance is not numeric.",
+                "Items",
+                ProgVariableTypes.Boolean
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/Grids/ConnectToGrid.cs
+++ b/MudSharpCore/FutureProg/Functions/Grids/ConnectToGrid.cs
@@ -37,7 +37,8 @@ internal class ConnectToGrid : BuiltInFunction
                     "The grid-interfacing item you want to connect"
                 },
                 "This function takes a grid-interfacing item like a grid feeder or grid outlet and connects it. Returns true if it succeeded.",
-                "Grids"
+                "Grids",
+                ProgVariableTypes.Boolean
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/Grids/ExtendGrid.cs
+++ b/MudSharpCore/FutureProg/Functions/Grids/ExtendGrid.cs
@@ -36,7 +36,8 @@ internal class ExtendGrid : BuiltInFunction
                     "The location you want to extend the grid to"
                 },
                 "This function allows you to extend a grid (electrical, gas, liquid etc) to a new location. Returns true if the extension happened, false implies the grid was already present or there was another error.",
-                "Grids"
+                "Grids",
+                ProgVariableTypes.Boolean
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/Grids/WithdrawGrid.cs
+++ b/MudSharpCore/FutureProg/Functions/Grids/WithdrawGrid.cs
@@ -36,7 +36,8 @@ internal class WithdrawGrid : BuiltInFunction
                     "The location you want to withdraw the grid from"
                 },
                 "This function allows you to withdraw a grid (electrical, gas, liquid etc) from a new location. Returns true if the withdrawal happened, false implies the grid was not present or there was another error.",
-                "Grids"
+                "Grids",
+                ProgVariableTypes.Boolean
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/Health/DrugEffectIntensityFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Health/DrugEffectIntensityFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Character;
+using MudSharp.Character;
 using MudSharp.Framework;
 using MudSharp.FutureProg.Variables;
 using MudSharp.Health;
@@ -60,7 +60,12 @@ internal class DrugEffectIntensityFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "drugeffectintensity",
             new[] { ProgVariableTypes.Character, ProgVariableTypes.Number },
-            (pars, gameworld) => new DrugEffectIntensityFunction(pars, gameworld)
+            (pars, gameworld) => new DrugEffectIntensityFunction(pars, gameworld),
+            new List<string> { "character", "drugEffect" },
+            new List<string> { "The character whose active drug effects should be inspected.", "The numeric drug effect type to total across the character's active drugs." },
+            "Returns the character's active dosage intensity for a drug effect type, summed across all active drugs and scaled by body weight. Errors if the character or effect type is null.",
+            "Health",
+            ProgVariableTypes.Number
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/Health/DrugIntensityFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Health/DrugIntensityFunction.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Character;
+using MudSharp.Character;
 using MudSharp.Framework;
 using MudSharp.FutureProg.Variables;
 using MudSharp.Health;
@@ -57,7 +57,12 @@ internal class DrugIntensityFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "drugintensity",
             new[] { ProgVariableTypes.Character, ProgVariableTypes.Drug },
-            (pars, gameworld) => new DrugIntensityFunction(pars, gameworld)
+            (pars, gameworld) => new DrugIntensityFunction(pars, gameworld),
+            new List<string> { "character", "drug" },
+            new List<string> { "The character whose active drug effects should be inspected.", "The drug definition to total across the character's active drug effects." },
+            "Returns the character's active dosage intensity for a specific drug, scaled by body weight and base weight units. Errors if the character or drug is null.",
+            "Health",
+            ProgVariableTypes.Number
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/Location/Exits/CustomLinkCells.cs
+++ b/MudSharpCore/FutureProg/Functions/Location/Exits/CustomLinkCells.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Character;
+using MudSharp.Character;
 using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
 using MudSharp.Framework;
@@ -35,7 +35,12 @@ internal class CustomLinkCells : BuiltInFunction
                     ProgVariableTypes.Text, ProgVariableTypes.Text, ProgVariableTypes.Text,
                     ProgVariableTypes.Text
                 },
-                (pars, gameworld) => new CustomLinkCells(pars, gameworld)
+                (pars, gameworld) => new CustomLinkCells(pars, gameworld),
+                new List<string> { "origin", "destination", "overlay", "template", "outboundKeyword", "outboundTarget", "inboundKeyword", "inboundTarget" },
+                new List<string> { "The origin room for the new exit.", "The destination room for the new exit.", "The editable overlay package where the exit should be created or copied.", "The non-cardinal exit template ID to use.", "The primary keyword for the origin-to-destination side.", "The target/sdesc displayed for the origin-to-destination side.", "The primary keyword for the destination-to-origin side.", "The target/sdesc displayed for the destination-to-origin side." },
+                "Creates a custom non-cardinal exit between two rooms in an overlay package, using explicit keywords and targets for both directions. This is equivalent to creating a non-cardinal builder exit from a template. Returns the created exit or null if the rooms, editable package, template, or target text are invalid, or if a conflicting exit already exists.",
+                "Rooms",
+                ProgVariableTypes.Exit
             )
         );
 
@@ -48,7 +53,12 @@ internal class CustomLinkCells : BuiltInFunction
                     ProgVariableTypes.OverlayPackage, ProgVariableTypes.Text, ProgVariableTypes.Text,
                     ProgVariableTypes.Text, ProgVariableTypes.Text, ProgVariableTypes.Text
                 },
-                (pars, gameworld) => new CustomLinkCells(pars, gameworld)
+                (pars, gameworld) => new CustomLinkCells(pars, gameworld),
+                new List<string> { "origin", "destination", "overlay", "template", "outboundKeyword", "outboundTarget", "inboundKeyword", "inboundTarget" },
+                new List<string> { "The origin room for the new exit.", "The destination room for the new exit.", "The editable overlay package where the exit should be created or copied.", "The non-cardinal exit template name to use.", "The primary keyword for the origin-to-destination side.", "The target/sdesc displayed for the origin-to-destination side.", "The primary keyword for the destination-to-origin side.", "The target/sdesc displayed for the destination-to-origin side." },
+                "Creates a custom non-cardinal exit between two rooms in an overlay package, using explicit keywords and targets for both directions. This is equivalent to creating a non-cardinal builder exit from a template. Returns the created exit or null if the rooms, editable package, template, or target text are invalid, or if a conflicting exit already exists.",
+                "Rooms",
+                ProgVariableTypes.Exit
             )
         );
     }
@@ -129,9 +139,9 @@ internal class CustomLinkCells : BuiltInFunction
         }
 
         string outboundkey = ParameterFunctions[4].Result?.GetObject?.ToString() ?? string.Empty;
-        string inboundKey = ParameterFunctions[4].Result?.GetObject?.ToString() ?? string.Empty;
-        string outboundName = ParameterFunctions[4].Result?.GetObject?.ToString() ?? string.Empty;
-        string inboundName = ParameterFunctions[4].Result?.GetObject?.ToString() ?? string.Empty;
+        string outboundName = ParameterFunctions[5].Result?.GetObject?.ToString() ?? string.Empty;
+        string inboundKey = ParameterFunctions[6].Result?.GetObject?.ToString() ?? string.Empty;
+        string inboundName = ParameterFunctions[7].Result?.GetObject?.ToString() ?? string.Empty;
         if (string.IsNullOrWhiteSpace(outboundkey) || string.IsNullOrWhiteSpace(inboundKey) ||
             string.IsNullOrWhiteSpace(outboundName) || string.IsNullOrWhiteSpace(inboundName))
         {

--- a/MudSharpCore/FutureProg/Functions/Location/Exits/GetOrCopyExit.cs
+++ b/MudSharpCore/FutureProg/Functions/Location/Exits/GetOrCopyExit.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Character;
+using MudSharp.Character;
 using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
 using MudSharp.Framework;
@@ -47,7 +47,12 @@ internal class GetOrCopyExit : BuiltInFunction
             new FunctionCompilerInformation(
                 "GetOrCopyExit".ToLowerInvariant(),
                 new[] { ProgVariableTypes.Exit, ProgVariableTypes.OverlayPackage },
-                (pars, gameworld) => new GetOrCopyExit(pars, gameworld)
+                (pars, gameworld) => new GetOrCopyExit(pars, gameworld),
+                new List<string> { "exit", "overlay" },
+                new List<string> { "The existing exit to make editable in the supplied package.", "The overlay package where an editable copy should exist." },
+                "Gets an editable exit for the specified overlay package, copying the underlying exit when the package needs its own overlay-specific version. Returns null if the exit or package is null.",
+                "Rooms",
+                ProgVariableTypes.Exit
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/Location/Exits/InstallDoor.cs
+++ b/MudSharpCore/FutureProg/Functions/Location/Exits/InstallDoor.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Character;
+using MudSharp.Character;
 using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
 using MudSharp.Framework;
@@ -34,7 +34,12 @@ internal class InstallDoor : BuiltInFunction
                     ProgVariableTypes.Exit, ProgVariableTypes.Item, ProgVariableTypes.Location,
                     ProgVariableTypes.Location
                 },
-                (pars, gameworld) => new InstallDoor(pars, gameworld)
+                (pars, gameworld) => new InstallDoor(pars, gameworld),
+                new List<string> { "exit", "door", "origin", "destination" },
+                new List<string> { "The exit that should receive the door.", "The item with a door component to install on the exit.", "The room on the hinge side; if null, the exit origin is used.", "The room on the opening side; if null, the exit destination is used." },
+                "Installs a door item onto an exit between two rooms, uninstalling it from any previous exit first. Returns false if the exit is null, the item is null, the item is not a door, or the exit already has a door.",
+                "Rooms",
+                ProgVariableTypes.Boolean
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/Location/Exits/LinkCells.cs
+++ b/MudSharpCore/FutureProg/Functions/Location/Exits/LinkCells.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Character;
+using MudSharp.Character;
 using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
 using MudSharp.Framework;
@@ -33,7 +33,12 @@ internal class LinkCells : BuiltInFunction
                     ProgVariableTypes.Location, ProgVariableTypes.Location,
                     ProgVariableTypes.OverlayPackage, ProgVariableTypes.Number
                 },
-                (pars, gameworld) => new LinkCells(pars, gameworld)
+                (pars, gameworld) => new LinkCells(pars, gameworld),
+                new List<string> { "origin", "destination", "overlay", "direction" },
+                new List<string> { "The origin room for the new exit.", "The destination room for the new exit.", "The editable overlay package where the exit should be created or copied.", "The outbound cardinal direction as a numeric enum value." },
+                "Creates a standard bidirectional cardinal exit between two rooms in an editable overlay package. This is equivalent to linking rooms with the room builder tools. Returns the created exit from the origin side or null if either room/package is invalid, the package is not editable, the direction is invalid, the rooms are the same, or a conflicting exit already exists.",
+                "Rooms",
+                ProgVariableTypes.Exit
             )
         );
 
@@ -45,7 +50,12 @@ internal class LinkCells : BuiltInFunction
                     ProgVariableTypes.Location, ProgVariableTypes.Location,
                     ProgVariableTypes.OverlayPackage, ProgVariableTypes.Text
                 },
-                (pars, gameworld) => new LinkCells(pars, gameworld)
+                (pars, gameworld) => new LinkCells(pars, gameworld),
+                new List<string> { "origin", "destination", "overlay", "direction" },
+                new List<string> { "The origin room for the new exit.", "The destination room for the new exit.", "The editable overlay package where the exit should be created or copied.", "The outbound cardinal direction name, such as north or up." },
+                "Creates a standard bidirectional cardinal exit between two rooms in an editable overlay package. This is equivalent to linking rooms with the room builder tools. Returns the created exit from the origin side or null if either room/package is invalid, the package is not editable, the direction is invalid, the rooms are the same, or a conflicting exit already exists.",
+                "Rooms",
+                ProgVariableTypes.Exit
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/Location/Exits/RemoveDoor.cs
+++ b/MudSharpCore/FutureProg/Functions/Location/Exits/RemoveDoor.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Character;
+using MudSharp.Character;
 using MudSharp.Construction.Boundary;
 using MudSharp.Framework;
 using MudSharp.FutureProg;
@@ -28,7 +28,12 @@ internal class RemoveDoor : BuiltInFunction
             new FunctionCompilerInformation(
                 "RemoveDoor".ToLowerInvariant(),
                 new[] { ProgVariableTypes.Exit },
-                (pars, gameworld) => new RemoveDoor(pars, gameworld)
+                (pars, gameworld) => new RemoveDoor(pars, gameworld),
+                new List<string> { "exit" },
+                new List<string> { "The exit whose installed door should be removed." },
+                "Removes the installed door from an exit and returns the door item. Returns null if the exit is null or has no installed door.",
+                "Rooms",
+                ProgVariableTypes.Item
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/Location/Exits/SetAcceptsDoor.cs
+++ b/MudSharpCore/FutureProg/Functions/Location/Exits/SetAcceptsDoor.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Character;
+using MudSharp.Character;
 using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
 using MudSharp.Framework;
@@ -34,7 +34,12 @@ internal class SetAcceptsDoor : BuiltInFunction
                     ProgVariableTypes.Exit, ProgVariableTypes.OverlayPackage,
                     ProgVariableTypes.Boolean, ProgVariableTypes.Number
                 },
-                (pars, gameworld) => new SetAcceptsDoor(pars, gameworld)
+                (pars, gameworld) => new SetAcceptsDoor(pars, gameworld),
+                new List<string> { "exit", "overlay", "state", "doorSize" },
+                new List<string> { "The exit to edit or copy into the supplied overlay package.", "The editable overlay package where the change should be made.", "Whether the exit should accept an installed door.", "The maximum door size enum value accepted by this exit." },
+                "Sets whether an exit overlay accepts a door and records the maximum door size. Returns the edited exit or null if the exit/package is null or the package is not editable.",
+                "Rooms",
+                ProgVariableTypes.Exit
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/Location/Exits/SetClimb.cs
+++ b/MudSharpCore/FutureProg/Functions/Location/Exits/SetClimb.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Character;
+using MudSharp.Character;
 using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
 using MudSharp.Framework;
@@ -34,7 +34,12 @@ internal class SetClimb : BuiltInFunction
                     ProgVariableTypes.Exit, ProgVariableTypes.OverlayPackage,
                     ProgVariableTypes.Boolean, ProgVariableTypes.Number
                 },
-                (pars, gameworld) => new SetClimb(pars, gameworld)
+                (pars, gameworld) => new SetClimb(pars, gameworld),
+                new List<string> { "exit", "overlay", "state", "difficulty" },
+                new List<string> { "The exit to edit or copy into the supplied overlay package.", "The editable overlay package where the change should be made.", "Whether the exit should require climbing.", "The climb difficulty enum value to store on the exit." },
+                "Sets whether an exit overlay is a climb exit and records the associated climb difficulty. Returns the edited exit or null if the exit/package is null or the package is not editable.",
+                "Rooms",
+                ProgVariableTypes.Exit
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/Location/Exits/SetExitSize.cs
+++ b/MudSharpCore/FutureProg/Functions/Location/Exits/SetExitSize.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Character;
+using MudSharp.Character;
 using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
 using MudSharp.Framework;
@@ -34,7 +34,12 @@ internal class SetExitSize : BuiltInFunction
                     ProgVariableTypes.Exit, ProgVariableTypes.OverlayPackage,
                     ProgVariableTypes.Number, ProgVariableTypes.Number
                 },
-                (pars, gameworld) => new SetExitSize(pars, gameworld)
+                (pars, gameworld) => new SetExitSize(pars, gameworld),
+                new List<string> { "exit", "overlay", "maximumSize", "uprightSize" },
+                new List<string> { "The exit to edit or copy into the supplied overlay package.", "The editable overlay package where the change should be made.", "The maximum size enum value that can enter the exit at all.", "The maximum size enum value that can enter upright." },
+                "Sets the maximum size and maximum upright size values on an exit overlay. Returns the edited exit or null if the exit/package is null or the package is not editable.",
+                "Rooms",
+                ProgVariableTypes.Exit
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/Location/Exits/SetExitSlowdown.cs
+++ b/MudSharpCore/FutureProg/Functions/Location/Exits/SetExitSlowdown.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Character;
+using MudSharp.Character;
 using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
 using MudSharp.Framework;
@@ -32,7 +32,12 @@ internal class SetExitSlowdown : BuiltInFunction
                 {
                     ProgVariableTypes.Exit, ProgVariableTypes.OverlayPackage, ProgVariableTypes.Number
                 },
-                (pars, gameworld) => new SetExitSlowdown(pars, gameworld)
+                (pars, gameworld) => new SetExitSlowdown(pars, gameworld),
+                new List<string> { "exit", "overlay", "multiplier" },
+                new List<string> { "The exit to edit or copy into the supplied overlay package.", "The editable overlay package where the change should be made.", "The travel-time multiplier to apply to the exit." },
+                "Sets the travel time multiplier on an exit overlay. Returns the edited exit or null if the exit/package is null or the package is not editable.",
+                "Rooms",
+                ProgVariableTypes.Exit
             )
         );
     }

--- a/MudSharpCore/FutureProg/Functions/Location/Exits/SetFall.cs
+++ b/MudSharpCore/FutureProg/Functions/Location/Exits/SetFall.cs
@@ -1,4 +1,4 @@
-﻿using MudSharp.Character;
+using MudSharp.Character;
 using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
 using MudSharp.Framework;
@@ -33,7 +33,12 @@ internal class SetFall : BuiltInFunction
                     ProgVariableTypes.Exit, ProgVariableTypes.OverlayPackage,
                     ProgVariableTypes.Location
                 },
-                (pars, gameworld) => new SetFall(pars, gameworld)
+                (pars, gameworld) => new SetFall(pars, gameworld),
+                new List<string> { "exit", "overlay", "fallLocation" },
+                new List<string> { "The exit to edit or copy into the supplied overlay package.", "The editable overlay package where the change should be made.", "The room characters fall to from this exit; null clears the fall destination." },
+                "Sets or clears the fall destination for an exit overlay. Returns the edited exit or null if the exit/package is null or the package is not editable.",
+                "Rooms",
+                ProgVariableTypes.Exit
             )
         );
     }
@@ -84,7 +89,7 @@ internal class SetFall : BuiltInFunction
 
         exit = GetOrCopyExit.GetOrCopy(exit, package);
 
-        ICell fallto = (ICell)ParameterFunctions[3].Result?.GetObject;
+        ICell fallto = (ICell)ParameterFunctions[2].Result?.GetObject;
         exit.Exit.FallCell = fallto;
         exit.Exit.Changed = true;
         Result = exit;

--- a/MudSharpCore/FutureProg/Functions/Manipulation/TakeFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Manipulation/TakeFunction.cs
@@ -91,7 +91,8 @@ internal class TakeFunction : BuiltInFunction
                 "The item to take"
             },
             "Takes an item from its inventory or container. Returns the item.",
-            "Items"
+            "Items",
+            ProgVariableTypes.Item
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
@@ -110,7 +111,8 @@ internal class TakeFunction : BuiltInFunction
                 "The item to take"
             },
             "Takes an item from its inventory or container and deletes it. Returns null.",
-            "Items"
+            "Items",
+            ProgVariableTypes.Item
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
@@ -131,7 +133,8 @@ internal class TakeFunction : BuiltInFunction
                 "The quantity to take. Use 0 for all"
             },
             "Takes an item from its inventory or container. Returns the new item, which may be the same as the original item if the quantity is equal to the existing quantity.",
-            "Items"
+            "Items",
+            ProgVariableTypes.Item
         ));
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
@@ -140,7 +143,7 @@ internal class TakeFunction : BuiltInFunction
             {
                 ProgVariableTypes.Item, ProgVariableTypes.Number
             },
-            (pars, gameworld) => new TakeFunction(pars, true, false),
+            (pars, gameworld) => new TakeFunction(pars, true, true),
             new List<string>
             {
                 "item",
@@ -152,7 +155,8 @@ internal class TakeFunction : BuiltInFunction
                 "The quantity to take. Use 0 for all"
             },
             "Takes an item from its inventory or container. Deletes the item and returns null.",
-            "Items"
+            "Items",
+            ProgVariableTypes.Item
         ));
     }
 }

--- a/MudSharpCore/FutureProg/Functions/OpenAI/GPTRequest.cs
+++ b/MudSharpCore/FutureProg/Functions/OpenAI/GPTRequest.cs
@@ -100,7 +100,7 @@ internal class GPTRequest : BuiltInFunction
 
     public override ProgVariableTypes ReturnType
     {
-        get => ProgVariableTypes.Text;
+        get => ProgVariableTypes.Boolean;
         protected set { }
     }
 

--- a/MudSharpCore/FutureProg/Functions/Textual/ToRoman.cs
+++ b/MudSharpCore/FutureProg/Functions/Textual/ToRoman.cs
@@ -50,7 +50,7 @@ namespace MudSharp.FutureProg.Functions.Textual
 
         public override ProgVariableTypes ReturnType
         {
-            get => ProgVariableTypes.Boolean;
+            get => ProgVariableTypes.Text;
             protected set { }
         }
 


### PR DESCRIPTION
## Summary
- Filled out `RegisterBuiltInFunctionCompiler` metadata across the FutureProg built-in function set with direct parameter names, parameter help, function help, categories, and return types
- Fixed several correctness issues uncovered during the pass, including a few return-type mismatches and exit/clan helper bugs
- Added regression coverage to verify built-in function documentation completeness and return metadata consistency

## Testing
- `MudSharpCore` build passed locally
- Focused `FutureProgFunctionDocumentationTests` passed locally