### PR TITLE
Fix clan election IDs and by-election duplication

### DIFF
--- a/Design Documents/Clan_Elections_and_External_Control.md
+++ b/Design Documents/Clan_Elections_and_External_Control.md
@@ -52,6 +52,8 @@ A nomination is allowed only if all of the following pass:
 - the maximum consecutive term rule, if configured; and
 - the maximum total term rule, if configured.
 
+Members who already hold an appointment can stand again in the regular election cycle, but they cannot nominate in a by-election for an unfilled seat in that same appointment. A by-election cannot grant a duplicate copy of the same appointment, so allowing current holders to win would leave the vacancy unresolved.
+
 The term-limit checks now use shared helper logic and correctly treat the total-term limit as inclusive:
 
 - reaching the configured maximum total terms blocks further nomination;
@@ -63,9 +65,12 @@ By-elections are ignored for the consecutive and total regular-term limit helper
 
 Election display and command access use clan office-holder visibility rules.
 
+The default `clan elections` display includes election ids for scheduled, nomination, voting, and preinstallation primary elections, and for all open by-elections. Players need these ids for `clan nominate`, `clan withdrawnomination`, `clan vote`, and `clan election view` when an appointment name is ambiguous or when multiple elections exist for the same appointment.
+
 The refactor also fixes several runtime election bugs:
 
 - election history permission checks now use the intended logic instead of blocking valid non-admin viewers;
+- `clan election history <election id>` resolves the election's appointment history, matching the documented player syntax;
 - nomination, withdrawal, and voting command resolution correctly handles either election ids or clan-plus-appointment targeting;
 - actor/member lookups during election finalisation use `MemberId` rather than the membership object id;
 - secret-ballot display resolves dub data from the elected member id rather than the membership id.
@@ -80,6 +85,10 @@ Important behaviours:
 - if fewer victors exist than positions, the runtime schedules a by-election;
 - if no nominees exist at voting start, the runtime finalises the empty election and creates a by-election;
 - by-elections remain separate from the regular term cycle.
+
+By-elections fill uncovered appointment vacancies rather than replacing the whole office. During by-election finalisation, existing holders of the same appointment keep their positions unless they are separately removed by another workflow. Victors are only installed while free appointment slots remain, so a stale or manually superseded by-election cannot overfill the appointment.
+
+The appointment vacancy check also accounts for already-open by-elections. If an existing by-election already covers the vacant slots, repeated dismissal or membership-cleanup paths do not create duplicate by-elections for the same vacancy. If a primary election is already close enough to seat winners no later than a newly-created by-election would, the vacancy check leaves the primary election to resolve the office instead of scheduling a redundant by-election.
 
 ## External Control Model
 

--- a/MudSharpCore Unit Tests/Community/ClanCommandUtilitiesTests.cs
+++ b/MudSharpCore Unit Tests/Community/ClanCommandUtilitiesTests.cs
@@ -100,6 +100,64 @@ public class ClanCommandUtilitiesTests
 	}
 
 	[TestMethod]
+	public void GetUncoveredAppointmentVacancies_SubtractsOpenByElectionSeats()
+	{
+		Mock<IClan> clan = new();
+
+		Mock<IAppointment> appointment = new();
+		appointment.SetupGet(x => x.Clan).Returns(clan.Object);
+		appointment.SetupGet(x => x.MaximumSimultaneousHolders).Returns(3);
+
+		Mock<IElection> openByElection = CreateElectionMock(isFinalised: false, isByElection: true,
+			numberOfAppointments: 1);
+		appointment.SetupGet(x => x.Elections).Returns([openByElection.Object]);
+
+		List<IClanMembership> memberships =
+		[
+			CreateMembershipMock(1, false, appointment.Object).Object
+		];
+
+		Assert.AreEqual(1,
+			ClanCommandUtilities.GetUncoveredAppointmentVacancies(appointment.Object, memberships, []));
+	}
+
+	[TestMethod]
+	public void GetUncoveredAppointmentVacancies_ReturnsZeroWhenExistingByElectionCoversVacancy()
+	{
+		Mock<IClan> clan = new();
+
+		Mock<IAppointment> appointment = new();
+		appointment.SetupGet(x => x.Clan).Returns(clan.Object);
+		appointment.SetupGet(x => x.MaximumSimultaneousHolders).Returns(2);
+
+		Mock<IElection> openByElection = CreateElectionMock(isFinalised: false, isByElection: true,
+			numberOfAppointments: 1);
+		appointment.SetupGet(x => x.Elections).Returns([openByElection.Object]);
+
+		List<IClanMembership> memberships =
+		[
+			CreateMembershipMock(1, false, appointment.Object).Object
+		];
+
+		Assert.AreEqual(0,
+			ClanCommandUtilities.GetUncoveredAppointmentVacancies(appointment.Object, memberships, []));
+	}
+
+	[TestMethod]
+	public void ElectionNeedsContestedVote_UsesElectionSeatCount()
+	{
+		var nominees = new[]
+		{
+			CreateMembershipMock(1, false).Object,
+			CreateMembershipMock(2, false).Object
+		};
+		Mock<IElection> election = CreateElectionMock(isFinalised: false, isByElection: true,
+			numberOfAppointments: 2, nominees: nominees);
+
+		Assert.IsFalse(ClanCommandUtilities.ElectionNeedsContestedVote(election.Object));
+	}
+
+	[TestMethod]
 	public void OpenElectionHelpers_ReturnExpectedOpenElections()
 	{
 		Mock<IAppointment> appointment = new();
@@ -117,6 +175,8 @@ public class ClanCommandUtilitiesTests
 		Assert.AreSame(primaryOpen.Object, ClanCommandUtilities.GetPrimaryOpenElection(appointment.Object));
 		Assert.AreSame(byElectionOpen.Object, ClanCommandUtilities.GetFirstOpenByElection(appointment.Object));
 		Assert.AreSame(primaryOpen.Object, ClanCommandUtilities.GetNextOpenElection(appointment.Object));
+		CollectionAssert.AreEqual(new[] { byElectionOpen.Object },
+			ClanCommandUtilities.GetOpenByElections(appointment.Object).ToArray());
 	}
 
 	private static Mock<IClanMembership> CreateMembershipMock(long memberId, bool isArchivedMembership,
@@ -145,9 +205,17 @@ public class ClanCommandUtilitiesTests
 
 	private static Mock<IElection> CreateElectionMock(bool isFinalised, bool isByElection, params long[] victorIds)
 	{
+		return CreateElectionMock(isFinalised, isByElection, 0, [], victorIds);
+	}
+
+	private static Mock<IElection> CreateElectionMock(bool isFinalised, bool isByElection, int numberOfAppointments,
+		IEnumerable<IClanMembership> nominees = null, params long[] victorIds)
+	{
 		Mock<IElection> election = new();
 		election.SetupGet(x => x.IsFinalised).Returns(isFinalised);
 		election.SetupGet(x => x.IsByElection).Returns(isByElection);
+		election.SetupGet(x => x.NumberOfAppointments).Returns(numberOfAppointments);
+		election.SetupGet(x => x.Nominees).Returns(nominees ?? []);
 		election.SetupGet(x => x.ResultsInEffectDate).Returns((MudDateTime)null);
 		election.SetupGet(x => x.Victors).Returns(victorIds.Select(x => CreateMembershipMock(x, false).Object).ToList());
 		return election;

--- a/MudSharpCore/Commands/Modules/ClanModule.cs
+++ b/MudSharpCore/Commands/Modules/ClanModule.cs
@@ -1642,7 +1642,7 @@ All of the following commands must happen with an edited clan selected:
         }
 
         actor.OutputHandler.Send(
-            $"The two valid syntaxes for this command are {"clan election view <id>".ColourCommand()} and {"clan election history <clan> [<position>]".ColourCommand()}.");
+            $"The valid syntaxes for this command are {"clan election view <id>".ColourCommand()}, {"clan election history <id>".ColourCommand()}, and {"clan election history <clan> [<position>]".ColourCommand()}.");
     }
 
     private static void ClanElectionView(ICharacter actor, StringStack ss)
@@ -1679,7 +1679,23 @@ All of the following commands must happen with an edited clan selected:
             return;
         }
 
-        IClan clan = GetTargetClan(actor, ss.PopSpeech());
+        var targetText = ss.PopSpeech();
+        if (long.TryParse(targetText, out var value))
+        {
+            var election = actor.Gameworld.Elections.Get(value);
+            if (election == null || (!actor.IsAdministrator() && !actor.ClanMemberships.Any(x =>
+                    x.Clan == election.Appointment.Clan &&
+                    x.NetPrivileges.HasFlag(ClanPrivilegeType.CanViewClanOfficeHolders))))
+            {
+                actor.OutputHandler.Send("There is no such election.");
+                return;
+            }
+
+            election.Appointment.Clan.ShowElectionHistory(actor, new StringStack(election.Appointment.Id.ToString()));
+            return;
+        }
+
+        IClan clan = GetTargetClan(actor, targetText);
         if (clan == null)
         {
             actor.OutputHandler.Send(actor.IsAdministrator()

--- a/MudSharpCore/Community/Appointment.cs
+++ b/MudSharpCore/Community/Appointment.cs
@@ -205,18 +205,26 @@ public class Appointment : SaveableItem, IAppointment
             return;
         }
 
-        if (Elections.Any(x =>
-                !x.IsFinalised && x.ElectionStage != ElectionStage.Preelection && !x.IsByElection))
+        var uncoveredVacancies = ClanCommandUtilities.GetUncoveredAppointmentVacancies(this, Clan.Memberships,
+            Clan.ExternalControls);
+        if (uncoveredVacancies <= 0)
         {
             return;
         }
 
-        int count = Clan.Memberships.Count(x => !x.IsArchivedMembership && x.Appointments.Contains(this));
-        if (count < MaximumSimultaneousHolders)
+        var primaryElection = ClanCommandUtilities.GetPrimaryOpenElection(this);
+        if (primaryElection is not null)
         {
-            Election election = new(this, true, MaximumSimultaneousHolders - count, null);
-            _elections.Add(election);
+            var earliestByElectionResult = Clan.Calendar.CurrentDateTime + NominationPeriod + VotingPeriod + ElectionLeadTime;
+            if (primaryElection.ElectionStage != ElectionStage.Preelection ||
+                primaryElection.ResultsInEffectDate <= earliestByElectionResult)
+            {
+                return;
+            }
         }
+
+        Election election = new(this, true, uncoveredVacancies, null);
+        _elections.Add(election);
     }
 
     public void SetName(string name)

--- a/MudSharpCore/Community/Clan.CommandHandling.cs
+++ b/MudSharpCore/Community/Clan.CommandHandling.cs
@@ -466,11 +466,11 @@ public partial class Clan
 
 			var votes = appointment.NumberOfVotes(actor);
 			sb.AppendLine(
-				$"You {(appointment.CanNominate(actor).Truth ? "are" : "are not")} eligable to nominate and {(votes <= 0 ? "cannot vote" : $"have {votes.ToString("N0", actor).ColourValue()} vote{(votes == 1 ? "" : "s")}")} in elections for this position.");
+				$"You {(appointment.CanNominate(actor).Truth ? "are" : "are not")} eligible to nominate and {(votes <= 0 ? "cannot vote" : $"have {votes.ToString("N0", actor).ColourValue()} vote{(votes == 1 ? "" : "s")}")} in elections for this position.");
 
 			var primaryElection = ClanCommandUtilities.GetPrimaryOpenElection(appointment);
-			var byElection = ClanCommandUtilities.GetFirstOpenByElection(appointment);
-			if (byElection is not null)
+			var byElections = ClanCommandUtilities.GetOpenByElections(appointment).ToList();
+			foreach (var byElection in byElections)
 			{
 				switch (byElection.ElectionStage)
 				{
@@ -486,12 +486,16 @@ public partial class Clan
 						sb.AppendLine(
 							$"By-election #{byElection.Id.ToString("N0", actor)} for {byElection.NumberOfAppointments.ToString("N0", actor).ColourValue()} {(byElection.NumberOfAppointments == 1 ? "position" : "positions")} is open for voting, with votes closing on {byElection.VotingEndDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}.");
 						break;
+					case ElectionStage.Preinstallation:
+						sb.AppendLine(
+							$"By-election #{byElection.Id.ToString("N0", actor)} for {byElection.NumberOfAppointments.ToString("N0", actor).ColourValue()} {(byElection.NumberOfAppointments == 1 ? "position" : "positions")} has finished and the elected will commence their terms on {byElection.ResultsInEffectDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}.");
+						break;
 				}
 			}
 
 			if (primaryElection is null)
 			{
-				if (byElection is null)
+				if (!byElections.Any())
 				{
 					sb.AppendLine("There is no currently scheduled primary election for this position.");
 				}
@@ -503,7 +507,7 @@ public partial class Clan
 			{
 				case ElectionStage.Preelection:
 					sb.AppendLine(
-						$"The next election will open for nominations on {primaryElection.NominationStartDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}.");
+						$"Election #{primaryElection.Id.ToString("N0", actor)} will open for nominations on {primaryElection.NominationStartDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}.");
 					break;
 				case ElectionStage.Nomination:
 					sb.AppendLine(
@@ -626,6 +630,13 @@ public partial class Clan
 		if (actorMembership is null)
 		{
 			actor.OutputHandler.Send("You are not a member of that clan.");
+			return;
+		}
+
+		if (election.IsByElection && actorMembership.Appointments.Contains(election.Appointment))
+		{
+			actor.OutputHandler.Send(
+				$"You already hold the position of {election.Appointment.Title(actor).ColourName()} in {election.Appointment.Clan.FullName.ColourName()}, so you cannot nominate in a by-election for an unfilled seat in that same position.");
 			return;
 		}
 

--- a/MudSharpCore/Community/ClanCommandUtilities.cs
+++ b/MudSharpCore/Community/ClanCommandUtilities.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -54,17 +55,51 @@ public static class ClanCommandUtilities
 	public static bool HasFreePosition(IAppointment appointment, IEnumerable<IClanMembership> memberships,
 		IEnumerable<IExternalClanControl> externalControls)
 	{
-		if (appointment.MaximumSimultaneousHolders < 1)
-		{
-			return true;
-		}
+		return GetVacantAppointmentSlots(appointment, memberships, externalControls) >= 1;
+	}
 
-		var filledSlots = memberships.Count(x => !x.IsArchivedMembership && x.Appointments.Contains(appointment));
-		var reservedExternalSlots = externalControls
+	public static int GetActiveAppointmentHolderCount(IAppointment appointment,
+		IEnumerable<IClanMembership> memberships)
+	{
+		return memberships.Count(x => !x.IsArchivedMembership && x.Appointments.Contains(appointment));
+	}
+
+	public static int GetReservedExternalAppointmentSlots(IAppointment appointment,
+		IEnumerable<IExternalClanControl> externalControls)
+	{
+		return externalControls
 			.Where(x => x.VassalClan == appointment.Clan && x.ControlledAppointment == appointment)
 			.Sum(x => x.NumberOfAppointments > x.Appointees.Count ? x.NumberOfAppointments - x.Appointees.Count : 0);
+	}
 
-		return appointment.MaximumSimultaneousHolders - filledSlots - reservedExternalSlots >= 1;
+	public static int GetVacantAppointmentSlots(IAppointment appointment, IEnumerable<IClanMembership> memberships,
+		IEnumerable<IExternalClanControl> externalControls)
+	{
+		if (appointment.MaximumSimultaneousHolders < 1)
+		{
+			return 0;
+		}
+
+		return Math.Max(0,
+			appointment.MaximumSimultaneousHolders -
+			GetActiveAppointmentHolderCount(appointment, memberships) -
+			GetReservedExternalAppointmentSlots(appointment, externalControls));
+	}
+
+	public static int GetOpenByElectionAppointmentSlots(IAppointment appointment, IElection? excludingElection = null)
+	{
+		return appointment.Elections
+			.Where(x => x != excludingElection && !x.IsFinalised && x.IsByElection)
+			.Sum(x => x.NumberOfAppointments);
+	}
+
+	public static int GetUncoveredAppointmentVacancies(IAppointment appointment,
+		IEnumerable<IClanMembership> memberships, IEnumerable<IExternalClanControl> externalControls,
+		IElection? excludingElection = null)
+	{
+		return Math.Max(0,
+			GetVacantAppointmentSlots(appointment, memberships, externalControls) -
+			GetOpenByElectionAppointmentSlots(appointment, excludingElection));
 	}
 
 	public static IElection? GetPrimaryOpenElection(IAppointment appointment)
@@ -77,10 +112,16 @@ public static class ClanCommandUtilities
 
 	public static IElection? GetFirstOpenByElection(IAppointment appointment)
 	{
+		return GetOpenByElections(appointment)
+			.FirstOrDefault();
+	}
+
+	public static IEnumerable<IElection> GetOpenByElections(IAppointment appointment)
+	{
 		return appointment.Elections
 			.Where(x => !x.IsFinalised && x.IsByElection)
 			.OrderBy(x => x.ResultsInEffectDate)
-			.FirstOrDefault();
+			.ToList();
 	}
 
 	public static IElection? GetNextOpenElection(IAppointment appointment)
@@ -89,6 +130,11 @@ public static class ClanCommandUtilities
 			.Where(x => !x.IsFinalised)
 			.OrderBy(x => x.ResultsInEffectDate)
 			.FirstOrDefault();
+	}
+
+	public static bool ElectionNeedsContestedVote(IElection election)
+	{
+		return election.Nominees.Count() > election.NumberOfAppointments;
 	}
 }
 #nullable restore

--- a/MudSharpCore/Community/Election.cs
+++ b/MudSharpCore/Community/Election.cs
@@ -147,7 +147,6 @@ public class Election : SaveableItem, IElection
         if (now >= VotingEndDate && ElectionStage < ElectionStage.Preinstallation)
         {
             ElectionStage = ElectionStage.Preinstallation;
-            Counter<IClanMembership> votes = VotesByNominee;
             List<IClanMembership> victors = Victors.ToList();
             string victorsText;
             if (victors.Any())
@@ -192,49 +191,66 @@ public class Election : SaveableItem, IElection
         {
             ElectionStage = ElectionStage.Finalised;
 
-            Counter<IClanMembership> votes = VotesByNominee;
             List<IClanMembership> victors = Victors.ToList();
-            foreach (IClanMembership? member in Appointment.Clan.Memberships.Where(x => x.Appointments.Contains(Appointment))
-                                              .ToList())
+            if (!IsByElection)
             {
-                if (victors.Contains(member))
+                foreach (IClanMembership? member in Appointment.Clan.Memberships
+                                                  .Where(x => x.Appointments.Contains(Appointment))
+                                                  .ToList())
                 {
-                    continue;
+                    if (victors.Contains(member))
+                    {
+                        continue;
+                    }
+
+                    ICharacter? ch = Gameworld.Actors.Get(member.MemberId);
+                    ch?.OutputHandler.Send(
+                        $"Your term as {Appointment.Title(ch).ColourValue()} in {Appointment.Clan.FullName.ColourName()} has ended.");
+                    member.Appointments.Remove(Appointment);
+                    member.Changed = true;
                 }
 
-                ICharacter? ch = Gameworld.Actors.Get(member.MemberId);
-                ch?.OutputHandler.Send(
-                    $"Your term as {Appointment.Title(ch).ColourValue()} in {Appointment.Clan.FullName.ColourName()} has ended.");
-                member.Appointments.Remove(Appointment);
-                member.Changed = true;
-            }
-
-            foreach (IClanMembership? victor in victors)
-            {
-                if (victor.Appointments.Contains(Appointment))
+                foreach (IClanMembership? victor in victors)
                 {
-                    continue;
+                    if (victor.Appointments.Contains(Appointment))
+                    {
+                        continue;
+                    }
+
+                    victor.Appointments.Add(Appointment);
+                    victor.Changed = true;
+                    ICharacter? ch = Gameworld.Actors.Get(victor.MemberId);
+                    ch?.OutputHandler.Send(
+                        $"Your term as {Appointment.Title(ch).ColourValue()} in {Appointment.Clan.FullName.ColourName()} has begun.");
                 }
-
-                victor.Appointments.Add(Appointment);
-                victor.Changed = true;
-                ICharacter? ch = Gameworld.Actors.Get(victor.MemberId);
-                ch?.OutputHandler.Send(
-                    $"Your term as {Appointment.Title(ch).ColourValue()} in {Appointment.Clan.FullName.ColourName()} has begun.");
             }
-
-            int appointees = Appointment.Clan.Memberships.Count(x => x.Appointments.Contains(Appointment));
-
-            // Do we need a run-off election?
-            if (appointees < NumberOfAppointments)
+            else
             {
-                int officeHolders = Appointment.Clan.Memberships.Count(x => x.Appointments.Contains(Appointment));
-                Election runoff = new(Appointment, true, Appointment.MaximumSimultaneousHolders - officeHolders,
-                    Appointment.Clan.Calendar.CurrentDateTime + Appointment.NominationPeriod +
-                    Appointment.VotingPeriod + Appointment.ElectionLeadTime);
-                Appointment.AddElection(runoff);
+                var vacancies = ClanCommandUtilities.GetVacantAppointmentSlots(Appointment, Appointment.Clan.Memberships,
+                    Appointment.Clan.ExternalControls);
+                foreach (IClanMembership? victor in victors)
+                {
+                    if (vacancies <= 0)
+                    {
+                        break;
+                    }
+
+                    if (victor.Appointments.Contains(Appointment))
+                    {
+                        continue;
+                    }
+
+                    victor.Appointments.Add(Appointment);
+                    victor.Changed = true;
+                    vacancies--;
+                    ICharacter? ch = Gameworld.Actors.Get(victor.MemberId);
+                    ch?.OutputHandler.Send(
+                        $"Your term as {Appointment.Title(ch).ColourValue()} in {Appointment.Clan.FullName.ColourName()} has begun.");
+                }
             }
 
+            IsFinalised = true;
+            Appointment.CheckForByElections();
             if (!IsByElection)
             {
                 Election next = new(Appointment, false, Appointment.MaximumSimultaneousHolders,
@@ -243,19 +259,13 @@ public class Election : SaveableItem, IElection
             }
 
             _activeListener = null;
-            IsFinalised = true;
             Changed = true;
             return true;
         }
 
         if (now >= VotingStartDate)
         {
-            if ((!IsByElection && Nominees.Count() > NumberOfAppointments) || (IsByElection &&
-                                                                               Nominees.Count() >
-                                                                               NumberOfAppointments -
-                                                                               Appointment.Clan.Memberships.Count(x =>
-                                                                                   x.Appointments
-                                                                                       .Contains(Appointment))))
+            if (ClanCommandUtilities.ElectionNeedsContestedVote(this))
             {
                 string echo =
                     $"Voting has begun in the election for the position of {Appointment.Name.ColourValue()} in {Appointment.Clan.FullName.ColourName()}. The nominees are {Nominees.Select(x => x.PersonalName.GetName(NameStyle.FullName).ColourName()).ListToString()}.\nThe voting period will last for {Appointment.VotingPeriod.Describe().ColourValue()}.";
@@ -287,8 +297,16 @@ public class Election : SaveableItem, IElection
             }
             else
             {
+                var followUpSeats = IsByElection
+                    ? ClanCommandUtilities.GetUncoveredAppointmentVacancies(Appointment, Appointment.Clan.Memberships,
+                        Appointment.Clan.ExternalControls, this)
+                    : Math.Max(0,
+                        NumberOfAppointments -
+                        ClanCommandUtilities.GetOpenByElectionAppointmentSlots(Appointment, this));
                 string echo =
-                    $"There were no nominees in the election for the position of {Appointment.Name.ColourValue()} in {Appointment.Clan.FullName.ColourName()}. A by-election will be automatically triggered.";
+                    followUpSeats > 0
+                        ? $"There were no nominees in the election for the position of {Appointment.Name.ColourValue()} in {Appointment.Clan.FullName.ColourName()}. A by-election will be automatically triggered."
+                        : $"There were no nominees in the election for the position of {Appointment.Name.ColourValue()} in {Appointment.Clan.FullName.ColourName()}, but no additional by-election is required.";
                 Gameworld.SystemMessage(echo,
                     ch => ch.ClanMemberships.Any(x =>
                         x.Clan == Appointment.Clan &&
@@ -300,10 +318,14 @@ public class Election : SaveableItem, IElection
                         $"Runoff Election Notification", echo.RawText());
                 }
 
-                Election runoff = new(Appointment, true, NumberOfAppointments,
-                    Appointment.Clan.Calendar.CurrentDateTime + Appointment.NominationPeriod +
-                    Appointment.VotingPeriod + Appointment.ElectionLeadTime);
-                Appointment.AddElection(runoff);
+                if (followUpSeats > 0)
+                {
+                    Election runoff = new(Appointment, true, followUpSeats,
+                        Appointment.Clan.Calendar.CurrentDateTime + Appointment.NominationPeriod +
+                        Appointment.VotingPeriod + Appointment.ElectionLeadTime);
+                    Appointment.AddElection(runoff);
+                }
+
                 ElectionStage = ElectionStage.Finalised;
                 Changed = true;
                 _activeListener = null;


### PR DESCRIPTION
## Summary
- Show election IDs in the default clan elections view so players can target the right election for nominate, withdraw, vote, and view.
- Prevent redundant by-elections by accounting for existing open by-elections and uncovered vacancies before creating new ones.
- Preserve existing holders during by-election finalisation, and block current holders from nominating in by-elections for the same appointment.
- Align clan election history help text and command handling with the implemented election-id syntax.
- Add regression coverage for vacancy counting, open by-election selection, and contested-vote helper logic.

## Testing
- `dotnet build MudSharpCore/MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `scripts/test-unit-core.ps1`
- Added focused unit tests for election vacancy accounting and by-election helper behavior.