### PR TITLE
Add date and weekday FutureProg helpers

### DIFF
--- a/MudSharpCore Unit Tests/FutureProgDateTimeFunctionTests.cs
+++ b/MudSharpCore Unit Tests/FutureProgDateTimeFunctionTests.cs
@@ -1,0 +1,215 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Framework;
+using MudSharp.Framework.Save;
+using MudSharp.FutureProg;
+using MudSharp.TimeAndDate;
+using MudSharp.TimeAndDate.Date;
+using MudSharp.TimeAndDate.Time;
+using System;
+using System.Collections.Generic;
+using System.Xml.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class FutureProgDateTimeFunctionTests
+{
+	private static IFuturemud _gameworld = null!;
+	private static ICalendar _calendar = null!;
+	private static IClock _clock = null!;
+	private static IMudTimeZone _timezone = null!;
+
+	[ClassInitialize]
+	public static void ClassInitialize(TestContext testContext)
+	{
+		FutureProgTestBootstrap.EnsureInitialised();
+		_gameworld = FutureProgTestBootstrap.Gameworld;
+
+		var saveManager = new Mock<ISaveManager>();
+		saveManager.Setup(x => x.Add(It.IsAny<ISaveable>()));
+
+		var clocks = new All<IClock>();
+		var calendars = new All<ICalendar>();
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.Clocks).Returns(clocks);
+		gameworld.SetupGet(x => x.Calendars).Returns(calendars);
+		gameworld.SetupGet(x => x.SaveManager).Returns(saveManager.Object);
+
+		_clock = new Clock(XElement.Parse(
+			@"<Clock><Alias>UTC</Alias><Description>Universal Time Clock</Description><ShortDisplayString>$j:$m:$s $i</ShortDisplayString><SuperDisplayString>$j:$m:$s $i $t</SuperDisplayString><LongDisplayString>$c $i</LongDisplayString><SecondsPerMinute>60</SecondsPerMinute><MinutesPerHour>60</MinutesPerHour><HoursPerDay>24</HoursPerDay><InGameSecondsPerRealSecond>1</InGameSecondsPerRealSecond><SecondFixedDigits>2</SecondFixedDigits><MinuteFixedDigits>2</MinuteFixedDigits><HourFixedDigits>0</HourFixedDigits><NoZeroHour>true</NoZeroHour><NumberOfHourIntervals>2</NumberOfHourIntervals><HourIntervalNames><HourIntervalName>a.m</HourIntervalName><HourIntervalName>p.m</HourIntervalName></HourIntervalNames><HourIntervalLongNames><HourIntervalLongName>in the morning</HourIntervalLongName><HourIntervalLongName>in the afternoon</HourIntervalLongName></HourIntervalLongNames><CrudeTimeIntervals><CrudeTimeInterval text=""day"" Lower=""0"" Upper=""24"" /></CrudeTimeIntervals></Clock>"),
+			gameworld.Object)
+		{
+			Id = 1
+		};
+		_timezone = new MudTimeZone(1, 0, 0, "Universal Time Clock", "UTC");
+		_clock.AddTimezone(_timezone);
+		_clock.SetTime(new MudTime(0, 0, 0, _timezone, _clock, true));
+		clocks.Add(_clock);
+
+		var calendar = new Calendar(1, gameworld.Object);
+		calendar.SetNoSave(true);
+		calendar.SetupTestData();
+		calendar.SetDate("1/jan/2026");
+		calendars.Add(calendar);
+		_calendar = calendar;
+	}
+
+	[TestMethod]
+	public void NextWeekday_SystemDateTime_ReturnsNthWeekday()
+	{
+		var prog = Compile<DateTime>(
+			"NextSystemWeekday",
+			ProgVariableTypes.DateTime,
+			[
+				Tuple.Create(ProgVariableTypes.DateTime, "date")
+			],
+			@"return NextWeekday(@date, ""Monday"", 2)");
+
+		var result = prog.Execute<System.DateTime>(new System.DateTime(2026, 4, 22, 15, 30, 0, DateTimeKind.Utc));
+
+		Assert.AreEqual(new System.DateTime(2026, 5, 4, 15, 30, 0, DateTimeKind.Utc), result);
+	}
+
+	[TestMethod]
+	public void NextWeekday_SystemDateTime_NegativeOccurrenceReturnsPreviousWeekday()
+	{
+		var prog = Compile<DateTime>(
+			"NextSystemWeekdayNegative",
+			ProgVariableTypes.DateTime,
+			[
+				Tuple.Create(ProgVariableTypes.DateTime, "date")
+			],
+			@"return NextWeekday(@date, ""Mon"", -1)");
+
+		var result = prog.Execute<System.DateTime>(new System.DateTime(2026, 4, 22, 15, 30, 0, DateTimeKind.Utc));
+
+		Assert.AreEqual(new System.DateTime(2026, 4, 20, 15, 30, 0, DateTimeKind.Utc), result);
+	}
+
+	[TestMethod]
+	public void LastWeekday_MudDateTime_ReturnsPreviousWeekday()
+	{
+		var prog = Compile<MudDateTime>(
+			"LastMudWeekday",
+			ProgVariableTypes.MudDateTime,
+			[
+				Tuple.Create(ProgVariableTypes.MudDateTime, "date")
+			],
+			@"return LastWeekday(@date, ""Friday"")");
+		var reference = new MudDateTime(_calendar.GetDate("8/apr/2026"),
+			new MudTime(0, 0, 9, _timezone, _clock, false), _timezone);
+
+		var result = prog.Execute<MudDateTime>(reference);
+
+		Assert.AreEqual("6/april/2026", result.Date.GetDateString());
+		Assert.AreEqual("Friday", result.Date.Weekday);
+		Assert.AreEqual(9, result.Time.Hours);
+	}
+
+	[TestMethod]
+	public void NextWeekday_MudDateTime_NegativeOccurrenceReturnsPreviousWeekday()
+	{
+		var prog = Compile<MudDateTime>(
+			"NextMudWeekdayNegative",
+			ProgVariableTypes.MudDateTime,
+			[
+				Tuple.Create(ProgVariableTypes.MudDateTime, "date")
+			],
+			@"return NextWeekday(@date, ""Friday"", -1)");
+		var reference = new MudDateTime(_calendar.GetDate("8/apr/2026"),
+			new MudTime(0, 0, 9, _timezone, _clock, false), _timezone);
+
+		var result = prog.Execute<MudDateTime>(reference);
+
+		Assert.AreEqual("6/april/2026", result.Date.GetDateString());
+		Assert.AreEqual("Friday", result.Date.Weekday);
+	}
+
+	[TestMethod]
+	public void Between_Number_IsInclusiveAndOrderInsensitive()
+	{
+		var prog = Compile<bool>(
+			"BetweenNumber",
+			ProgVariableTypes.Boolean,
+			[
+				Tuple.Create(ProgVariableTypes.Number, "value")
+			],
+			"return Between(@value, 10, 1)");
+
+		Assert.IsTrue(prog.ExecuteBool(10M));
+		Assert.IsTrue(prog.ExecuteBool(5M));
+		Assert.IsFalse(prog.ExecuteBool(11M));
+	}
+
+	[TestMethod]
+	public void Between_DateTime_IsInclusiveAndOrderInsensitive()
+	{
+		var prog = Compile<bool>(
+			"BetweenDateTime",
+			ProgVariableTypes.Boolean,
+			[
+				Tuple.Create(ProgVariableTypes.DateTime, "date"),
+				Tuple.Create(ProgVariableTypes.DateTime, "low"),
+				Tuple.Create(ProgVariableTypes.DateTime, "high")
+			],
+			"return Between(@date, @high, @low)");
+		var low = new System.DateTime(2026, 4, 20, 0, 0, 0, DateTimeKind.Utc);
+		var high = new System.DateTime(2026, 4, 22, 0, 0, 0, DateTimeKind.Utc);
+
+		Assert.IsTrue(prog.ExecuteBool(low, low, high));
+		Assert.IsTrue(prog.ExecuteBool(new System.DateTime(2026, 4, 21, 0, 0, 0, DateTimeKind.Utc), low, high));
+		Assert.IsFalse(prog.ExecuteBool(new System.DateTime(2026, 4, 23, 0, 0, 0, DateTimeKind.Utc), low, high));
+	}
+
+	[TestMethod]
+	public void Between_MudDateTime_IsInclusiveAndOrderInsensitive()
+	{
+		var prog = Compile<bool>(
+			"BetweenMudDateTime",
+			ProgVariableTypes.Boolean,
+			[
+				Tuple.Create(ProgVariableTypes.MudDateTime, "date"),
+				Tuple.Create(ProgVariableTypes.MudDateTime, "low"),
+				Tuple.Create(ProgVariableTypes.MudDateTime, "high")
+			],
+			"return Between(@date, @high, @low)");
+		var low = new MudDateTime(_calendar.GetDate("20/apr/2026"),
+			new MudTime(0, 0, 0, _timezone, _clock, false), _timezone);
+		var middle = new MudDateTime(_calendar.GetDate("21/apr/2026"),
+			new MudTime(0, 0, 0, _timezone, _clock, false), _timezone);
+		var high = new MudDateTime(_calendar.GetDate("22/apr/2026"),
+			new MudTime(0, 0, 0, _timezone, _clock, false), _timezone);
+		var outside = new MudDateTime(_calendar.GetDate("23/apr/2026"),
+			new MudTime(0, 0, 0, _timezone, _clock, false), _timezone);
+
+		Assert.IsTrue(prog.ExecuteBool(low, low, high));
+		Assert.IsTrue(prog.ExecuteBool(middle, low, high));
+		Assert.IsFalse(prog.ExecuteBool(outside, low, high));
+	}
+
+	[TestMethod]
+	public void Between_TimeSpan_IsInclusiveAndOrderInsensitive()
+	{
+		var prog = Compile<bool>(
+			"BetweenTimeSpan",
+			ProgVariableTypes.Boolean,
+			[
+				Tuple.Create(ProgVariableTypes.TimeSpan, "duration"),
+				Tuple.Create(ProgVariableTypes.TimeSpan, "low"),
+				Tuple.Create(ProgVariableTypes.TimeSpan, "high")
+			],
+			"return Between(@duration, @high, @low)");
+
+		Assert.IsTrue(prog.ExecuteBool(TimeSpan.FromHours(2), TimeSpan.FromHours(1), TimeSpan.FromHours(3)));
+		Assert.IsFalse(prog.ExecuteBool(TimeSpan.FromHours(4), TimeSpan.FromHours(1), TimeSpan.FromHours(3)));
+	}
+
+	private static FutureProg Compile<T>(string name, ProgVariableTypes returnType,
+		IEnumerable<Tuple<ProgVariableTypes, string>> parameters, string functionText)
+	{
+		var prog = new FutureProg(_gameworld, name, returnType, parameters, functionText);
+		Assert.IsTrue(prog.Compile(), prog.CompileError);
+		return prog;
+	}
+}

--- a/MudSharpCore/FutureProg/Functions/DateTime/BetweenFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/DateTime/BetweenFunction.cs
@@ -1,0 +1,117 @@
+using MudSharp.FutureProg.Variables;
+using MudSharp.TimeAndDate;
+using System;
+using System.Collections.Generic;
+
+namespace MudSharp.FutureProg.Functions.DateTime;
+
+internal class BetweenFunction : BuiltInFunction
+{
+	private readonly ProgVariableTypes _comparisonType;
+
+	private BetweenFunction(IList<IFunction> parameters, ProgVariableTypes comparisonType)
+		: base(parameters)
+	{
+		_comparisonType = comparisonType;
+	}
+
+	public override ProgVariableTypes ReturnType
+	{
+		get => ProgVariableTypes.Boolean;
+		protected set { }
+	}
+
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		if (base.Execute(variables) == StatementResult.Error)
+		{
+			return StatementResult.Error;
+		}
+
+		if (ParameterFunctions[0].Result?.GetObject is null ||
+		    ParameterFunctions[1].Result?.GetObject is null ||
+		    ParameterFunctions[2].Result?.GetObject is null)
+		{
+			Result = new BooleanVariable(false);
+			return StatementResult.Normal;
+		}
+
+		Result = new BooleanVariable(_comparisonType.LegacyCode switch
+		{
+			ProgVariableTypeCode.Number => Between(
+				(decimal)ParameterFunctions[0].Result.GetObject,
+				(decimal)ParameterFunctions[1].Result.GetObject,
+				(decimal)ParameterFunctions[2].Result.GetObject),
+			ProgVariableTypeCode.TimeSpan => Between(
+				(TimeSpan)ParameterFunctions[0].Result.GetObject,
+				(TimeSpan)ParameterFunctions[1].Result.GetObject,
+				(TimeSpan)ParameterFunctions[2].Result.GetObject),
+			ProgVariableTypeCode.DateTime => Between(
+				(System.DateTime)ParameterFunctions[0].Result.GetObject,
+				(System.DateTime)ParameterFunctions[1].Result.GetObject,
+				(System.DateTime)ParameterFunctions[2].Result.GetObject),
+			ProgVariableTypeCode.MudDateTime => Between(
+				(MudDateTime)ParameterFunctions[0].Result.GetObject,
+				(MudDateTime)ParameterFunctions[1].Result.GetObject,
+				(MudDateTime)ParameterFunctions[2].Result.GetObject),
+			_ => false
+		});
+
+		return StatementResult.Normal;
+	}
+
+	private static bool Between(decimal value, decimal lower, decimal upper)
+	{
+		return lower <= upper
+			? value >= lower && value <= upper
+			: value >= upper && value <= lower;
+	}
+
+	private static bool Between(TimeSpan value, TimeSpan lower, TimeSpan upper)
+	{
+		return lower <= upper
+			? value >= lower && value <= upper
+			: value >= upper && value <= lower;
+	}
+
+	private static bool Between(System.DateTime value, System.DateTime lower, System.DateTime upper)
+	{
+		return lower <= upper
+			? value >= lower && value <= upper
+			: value >= upper && value <= lower;
+	}
+
+	private static bool Between(MudDateTime value, MudDateTime lower, MudDateTime upper)
+	{
+		return lower <= upper
+			? value >= lower && value <= upper
+			: value >= upper && value <= lower;
+	}
+
+	public static void RegisterFunctionCompiler()
+	{
+		RegisterForType(ProgVariableTypes.Number);
+		RegisterForType(ProgVariableTypes.TimeSpan);
+		RegisterForType(ProgVariableTypes.DateTime);
+		RegisterForType(ProgVariableTypes.MudDateTime);
+	}
+
+	private static void RegisterForType(ProgVariableTypes type)
+	{
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			"between",
+			new[] { type, type, type },
+			(pars, gameworld) => new BetweenFunction(pars, type),
+			new[] { "Value", "Bound1", "Bound2" },
+			new[]
+			{
+				"The value to test.",
+				"One inclusive bound of the range.",
+				"The other inclusive bound of the range."
+			},
+			"Returns true if the first value is inclusively between the other two values. The bounds may be supplied in either order.",
+			"DateTime",
+			ProgVariableTypes.Boolean
+		));
+	}
+}

--- a/MudSharpCore/FutureProg/Functions/DateTime/WeekdayFunctions.cs
+++ b/MudSharpCore/FutureProg/Functions/DateTime/WeekdayFunctions.cs
@@ -1,0 +1,247 @@
+using MudSharp.Framework;
+using MudSharp.FutureProg.Variables;
+using MudSharp.TimeAndDate;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace MudSharp.FutureProg.Functions.DateTime;
+
+internal class WeekdayFunction : BuiltInFunction
+{
+	private readonly int _direction;
+	private readonly ProgVariableTypes _returnType;
+
+	private WeekdayFunction(IList<IFunction> parameters, int direction, ProgVariableTypes returnType)
+		: base(parameters)
+	{
+		_direction = direction;
+		_returnType = returnType;
+	}
+
+	public override ProgVariableTypes ReturnType
+	{
+		get => _returnType;
+		protected set { }
+	}
+
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		if (base.Execute(variables) == StatementResult.Error)
+		{
+			return StatementResult.Error;
+		}
+
+		var count = _direction * GetOccurrenceCount();
+		if (count == 0)
+		{
+			ErrorMessage = $"{FunctionName} must be supplied a non-zero occurrence number.";
+			return StatementResult.Error;
+		}
+
+		switch ((_returnType & ~ProgVariableTypes.Literal).LegacyCode)
+		{
+			case ProgVariableTypeCode.DateTime:
+				return ExecuteSystemDateTime(count);
+			case ProgVariableTypeCode.MudDateTime:
+				return ExecuteMudDateTime(count);
+			default:
+				throw new NotSupportedException($"Unsupported weekday function return type {_returnType.Describe()}.");
+		}
+	}
+
+	private string FunctionName => _direction > 0 ? "NextWeekday" : "LastWeekday";
+
+	private int GetOccurrenceCount()
+	{
+		if (ParameterFunctions.Count == 2)
+		{
+			return 1;
+		}
+
+		if (ParameterFunctions[2].Result?.GetObject is not decimal value ||
+		    decimal.Truncate(value) != value ||
+		    value > int.MaxValue ||
+		    value <= int.MinValue)
+		{
+			return 0;
+		}
+
+		return (int)value;
+	}
+
+	private StatementResult ExecuteSystemDateTime(int count)
+	{
+		if (ParameterFunctions[0].Result?.GetObject is not System.DateTime date)
+		{
+			ErrorMessage = $"{FunctionName} must be supplied a non-null DateTime.";
+			return StatementResult.Error;
+		}
+
+		if (!TryGetSystemWeekday(ParameterFunctions[1].Result?.GetObject?.ToString(), out var weekday))
+		{
+			ErrorMessage = $"{FunctionName} could not identify the supplied weekday name.";
+			return StatementResult.Error;
+		}
+
+		try
+		{
+			Result = new DateTimeVariable(GetSystemWeekday(date, weekday, count));
+			return StatementResult.Normal;
+		}
+		catch (ArgumentOutOfRangeException)
+		{
+			ErrorMessage = $"{FunctionName} would produce a DateTime outside the supported range.";
+			return StatementResult.Error;
+		}
+	}
+
+	private StatementResult ExecuteMudDateTime(int count)
+	{
+		if (ParameterFunctions[0].Result?.GetObject is not MudDateTime dateTime || dateTime.Date is null)
+		{
+			Result = MudDateTime.Never;
+			return StatementResult.Normal;
+		}
+
+		if (!TryGetMudWeekday(dateTime, ParameterFunctions[1].Result?.GetObject?.ToString(), out var weekday))
+		{
+			ErrorMessage = $"{FunctionName} could not identify the supplied weekday name for that calendar.";
+			return StatementResult.Error;
+		}
+
+		Result = GetMudWeekday(dateTime, weekday, count);
+		return StatementResult.Normal;
+	}
+
+	private static System.DateTime GetSystemWeekday(System.DateTime date, DayOfWeek weekday, int count)
+	{
+		var occurrences = Math.Abs(count);
+		var direction = Math.Sign(count);
+		var current = (int)date.DayOfWeek;
+		var target = (int)weekday;
+		var delta = direction > 0
+			? (target - current + 7) % 7
+			: (current - target + 7) % 7;
+
+		if (delta == 0)
+		{
+			delta = 7;
+		}
+
+		return date.AddDays(direction * (delta + (occurrences - 1) * 7));
+	}
+
+	private static MudDateTime GetMudWeekday(MudDateTime dateTime, int weekday, int count)
+	{
+		var result = new MudDateTime(dateTime);
+		result.Time.DaysOffsetFromDatum = 0;
+		var occurrences = Math.Abs(count);
+		var direction = Math.Sign(count);
+
+		while (occurrences > 0)
+		{
+			result.Date.AdvanceDays(direction);
+			if (result.Date.WeekdayIndex == weekday)
+			{
+				occurrences--;
+			}
+		}
+
+		return result;
+	}
+
+	private static bool TryGetSystemWeekday(string text, out DayOfWeek weekday)
+	{
+		if (!string.IsNullOrWhiteSpace(text) &&
+		    Enum.TryParse(text, ignoreCase: true, out weekday) &&
+		    Enum.IsDefined(weekday))
+		{
+			return true;
+		}
+
+		var dateFormat = CultureInfo.InvariantCulture.DateTimeFormat;
+		for (var i = 0; i < dateFormat.DayNames.Length; i++)
+		{
+			if (dateFormat.DayNames[i].EqualTo(text) || dateFormat.AbbreviatedDayNames[i].EqualTo(text))
+			{
+				weekday = (DayOfWeek)i;
+				return true;
+			}
+		}
+
+		weekday = default;
+		return false;
+	}
+
+	private static bool TryGetMudWeekday(MudDateTime dateTime, string text, out int weekday)
+	{
+		weekday = dateTime.Calendar.Weekdays.FindIndex(x => x.EqualTo(text));
+		if (weekday >= 0)
+		{
+			return true;
+		}
+
+		var matches = dateTime.Calendar.Weekdays
+		                      .Select((value, index) => (Value: value, Index: index))
+		                      .Where(x => x.Value.StartsWith(text ?? string.Empty,
+			                      StringComparison.InvariantCultureIgnoreCase))
+		                      .ToList();
+
+		if (matches.Count != 1)
+		{
+			return false;
+		}
+
+		weekday = matches[0].Index;
+		return true;
+	}
+
+	public static void RegisterFunctionCompiler()
+	{
+		Register("nextweekday", 1);
+		Register("lastweekday", -1);
+	}
+
+	private static void Register(string name, int direction)
+	{
+		RegisterForType(name, direction, ProgVariableTypes.DateTime);
+		RegisterForType(name, direction, ProgVariableTypes.MudDateTime);
+	}
+
+	private static void RegisterForType(string name, int direction, ProgVariableTypes type)
+	{
+		var returnType = type;
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			name,
+			new[] { type, ProgVariableTypes.Text },
+			(pars, gameworld) => new WeekdayFunction(pars, direction, returnType),
+			new[] { "Date", "Weekday" },
+			new[]
+			{
+				"The date to use as the exclusive starting point.",
+				"The weekday name to seek."
+			},
+			$"Returns the {(direction > 0 ? "next" : "last")} matching weekday after the supplied date.",
+			"DateTime",
+			returnType
+		));
+
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			name,
+			new[] { type, ProgVariableTypes.Text, ProgVariableTypes.Number },
+			(pars, gameworld) => new WeekdayFunction(pars, direction, returnType),
+			new[] { "Date", "Weekday", "Occurrences" },
+			new[]
+			{
+				"The date to use as the exclusive starting point.",
+				"The weekday name to seek.",
+				"The nth matching weekday to seek. Negative values reverse the direction."
+			},
+			$"Returns the nth {(direction > 0 ? "next" : "last")} matching weekday after the supplied date.",
+			"DateTime",
+			returnType
+		));
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Between` FutureProg support for number, `TimeSpan`, `DateTime`, and `MudDateTime` values with order-insensitive inclusive bounds
- Add `NextWeekday` and `LastWeekday` helpers for `DateTime` and `MudDateTime`, including nth-occurrence support and weekday name matching
- Cover the new functions with focused unit tests

## Testing
- Added unit tests for inclusive `Between` behavior across supported types
- Added unit tests for weekday lookup and negative occurrence handling