### PR TITLE
Add TimeAndDate runtime hardening

### DIFF
--- a/DatabaseSeeder Unit Tests/TimeSeederTests.cs
+++ b/DatabaseSeeder Unit Tests/TimeSeederTests.cs
@@ -4,18 +4,42 @@ using DatabaseSeeder.Seeders;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 using MudSharp.Database;
+using MudSharp.Framework;
+using MudSharp.Framework.Save;
 using MudSharp.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
+using RuntimeCalendar = MudSharp.TimeAndDate.Date.Calendar;
+using RuntimeClock = MudSharp.TimeAndDate.Time.Clock;
+using RuntimeICalendar = MudSharp.TimeAndDate.Date.ICalendar;
+using RuntimeIClock = MudSharp.TimeAndDate.Time.IClock;
 
 namespace MudSharp_Unit_Tests;
 
 [TestClass]
 public class TimeSeederTests
 {
+    private static readonly string[] Modes =
+    [
+        "gregorian-us",
+        "gregorian-uk",
+        "gregorian-us-ce",
+        "gregorian-uk-ce",
+        "julian",
+        "latin-7day",
+        "latin-8day",
+        "latin-ancient",
+        "middle-earth",
+        "republicain",
+        "tranquility",
+        "mission",
+        "seasonal-360"
+    ];
+
     private static FuturemudDatabaseContext BuildContext()
     {
         DbContextOptions<FuturemudDatabaseContext> options = new DbContextOptionsBuilder<FuturemudDatabaseContext>()
@@ -23,6 +47,109 @@ public class TimeSeederTests
             .ConfigureWarnings(x => x.Ignore(InMemoryEventId.TransactionIgnoredWarning))
             .Options;
         return new FuturemudDatabaseContext(options);
+    }
+
+    [TestMethod]
+    public void SeedData_AllModes_CreateLoadableClockAndCalendarContent()
+    {
+        foreach (string mode in Modes)
+        {
+            using FuturemudDatabaseContext context = BuildContext();
+            TimeSeeder seeder = new();
+
+            seeder.SeedData(context, Answers(mode));
+
+            Assert.IsTrue(context.Clocks.Any(), $"{mode}: no clocks were seeded.");
+            Assert.IsTrue(context.Timezones.Any(), $"{mode}: no timezones were seeded.");
+            Assert.IsTrue(context.Calendars.Any(), $"{mode}: no calendars were seeded.");
+
+            foreach (Clock clock in context.Clocks)
+            {
+                XElement definition = XElement.Parse(clock.Definition);
+                AssertHasValue(definition, "Alias", mode);
+                AssertHasValue(definition, "ShortDisplayString", mode);
+                AssertHasValue(definition, "LongDisplayString", mode);
+                AssertHasValue(definition, "SuperDisplayString", mode);
+                Assert.IsTrue(definition.Element("CrudeTimeIntervals")!.Elements("CrudeTimeInterval").Any(),
+                    $"{mode}: clock {clock.Id} has no crude time intervals.");
+            }
+
+            foreach (Calendar calendar in context.Calendars)
+            {
+                XElement definition = XElement.Parse(calendar.Definition);
+                AssertHasValue(definition, "alias", mode);
+                AssertHasValue(definition, "shortstring", mode);
+                AssertHasValue(definition, "longstring", mode);
+                AssertHasValue(definition, "wordystring", mode);
+                Assert.IsTrue(definition.Element("weekdays")!.Elements("weekday").Any(),
+                    $"{mode}: calendar {calendar.Id} has no weekdays.");
+                Assert.IsTrue(definition.Element("months")!.Elements("month").Any() ||
+                              definition.Element("intercalarymonths")!.Elements("intercalarymonth").Any(),
+                    $"{mode}: calendar {calendar.Id} has no months.");
+                Assert.IsFalse(string.IsNullOrWhiteSpace(calendar.Date), $"{mode}: calendar {calendar.Id} has no current date.");
+            }
+
+            AssertRuntimeLoadable(context, mode);
+        }
+    }
+
+    [TestMethod]
+    public void SeedData_AllModes_HaveExpectedCalendarShapes()
+    {
+        foreach (string mode in Modes)
+        {
+            using FuturemudDatabaseContext context = BuildContext();
+            TimeSeeder seeder = new();
+
+            seeder.SeedData(context, Answers(mode));
+
+            List<XElement> calendars = context.Calendars
+                .Select(x => XElement.Parse(x.Definition))
+                .ToList();
+            List<XElement> clocks = context.Clocks
+                .Select(x => XElement.Parse(x.Definition))
+                .ToList();
+
+            switch (mode)
+            {
+                case "latin-8day":
+                    Assert.IsTrue(calendars.Any(x => x.Element("weekdays")!.Elements("weekday").Count() == 8),
+                        $"{mode}: expected an eight-day week.");
+                    break;
+                case "mission":
+                case "seasonal-360":
+                    Assert.IsTrue(calendars.Any(x => x.Element("weekdays")!.Elements("weekday").Count() == 6),
+                        $"{mode}: expected a six-day week.");
+                    break;
+                case "middle-earth":
+                    Assert.IsTrue(calendars.Count > 1, $"{mode}: expected multiple Tolkien calendars.");
+                    break;
+                case "republicain":
+                    Assert.IsTrue(clocks.Any(x => x.Element("HoursPerDay")?.Value == "10" &&
+                                                  x.Element("SecondsPerMinute")?.Value == "100"),
+                        $"{mode}: expected the decimal clock.");
+                    break;
+            }
+        }
+    }
+
+    [TestMethod]
+    public void SeedData_MissionCalendar_RerunIsIdempotent()
+    {
+        using FuturemudDatabaseContext context = BuildContext();
+        TimeSeeder seeder = new();
+        Dictionary<string, string> answers = Answers("mission");
+
+        seeder.SeedData(context, answers);
+        int clockCount = context.Clocks.Count();
+        int timezoneCount = context.Timezones.Count();
+        int calendarCount = context.Calendars.Count();
+
+        seeder.SeedData(context, answers);
+
+        Assert.AreEqual(clockCount, context.Clocks.Count());
+        Assert.AreEqual(timezoneCount, context.Timezones.Count());
+        Assert.AreEqual(calendarCount, context.Calendars.Count());
     }
 
     [TestMethod]
@@ -65,5 +192,54 @@ public class TimeSeederTests
         Assert.IsTrue(months.All(x => x.Element("normaldays")?.Value == "30"));
         Assert.IsTrue(months.All(x => !x.Element("intercalarydays")!.Elements().Any()));
         Assert.IsFalse(definition.Element("intercalarymonths")!.Elements().Any());
+    }
+
+    private static Dictionary<string, string> Answers(string mode)
+    {
+        return new Dictionary<string, string>
+        {
+            ["secondsmultiplier"] = "2",
+            ["mode"] = mode,
+            ["startyear"] = "1200",
+            ["ardaage"] = "3"
+        };
+    }
+
+    private static void AssertHasValue(XElement definition, string elementName, string mode)
+    {
+        Assert.IsFalse(string.IsNullOrWhiteSpace(definition.Element(elementName)?.Value),
+            $"{mode}: missing or empty {elementName}.");
+    }
+
+    private static void AssertRuntimeLoadable(FuturemudDatabaseContext context, string mode)
+    {
+        All<RuntimeIClock> clocks = new();
+        All<RuntimeICalendar> calendars = new();
+        Mock<ISaveManager> saveManager = new();
+        saveManager.Setup(x => x.Add(It.IsAny<ISaveable>()));
+        Mock<IFuturemud> gameworld = new();
+        gameworld.SetupGet(x => x.Clocks).Returns(clocks);
+        gameworld.SetupGet(x => x.Calendars).Returns(calendars);
+        gameworld.SetupGet(x => x.SaveManager).Returns(saveManager.Object);
+
+        foreach (Clock clockModel in context.Clocks.Include(x => x.Timezones).OrderBy(x => x.Id))
+        {
+            RuntimeClock clock = new(clockModel, gameworld.Object);
+            Assert.IsNotNull(clock.PrimaryTimezone, $"{mode}: runtime clock {clockModel.Id} did not load a primary timezone.");
+            Assert.IsNotNull(clock.CurrentTime, $"{mode}: runtime clock {clockModel.Id} did not load a current time.");
+            clocks.Add(clock);
+        }
+
+        foreach (Calendar calendarModel in context.Calendars.OrderBy(x => x.Id))
+        {
+            RuntimeCalendar calendar = new(calendarModel, gameworld.Object);
+            calendar.FeedClock = clocks.Get(calendar.ClockID);
+            Assert.IsNotNull(calendar.FeedClock, $"{mode}: runtime calendar {calendarModel.Id} did not resolve its feed clock.");
+            Assert.IsNotNull(calendar.CurrentDate, $"{mode}: runtime calendar {calendarModel.Id} did not load a current date.");
+            Assert.IsTrue(calendar.Weekdays.Any(), $"{mode}: runtime calendar {calendarModel.Id} did not load weekdays.");
+            Assert.IsTrue(calendar.CreateYear(calendar.CurrentDate.Year).Months.Any(),
+                $"{mode}: runtime calendar {calendarModel.Id} could not generate the current year.");
+            calendars.Add(calendar);
+        }
     }
 }

--- a/DatabaseSeeder/Seeders/EconomySeeder.cs
+++ b/DatabaseSeeder/Seeders/EconomySeeder.cs
@@ -1811,6 +1811,8 @@ It is intended to be additive across eras and safe to rerun to restore or refres
         economicZone.IntervalType = (int)IntervalType.Monthly;
         economicZone.IntervalAmount = 1;
         economicZone.IntervalModifier = 0;
+        economicZone.IntervalOther = 0;
+        economicZone.IntervalFallback = 0;
         economicZone.PreviousFinancialPeriodsToKeep = 24;
         economicZone.PermitTaxableLosses = false;
         economicZone.OutstandingTaxesOwed = 0.0m;

--- a/Design Documents/Time_And_Date_System.md
+++ b/Design Documents/Time_And_Date_System.md
@@ -1,0 +1,448 @@
+# FutureMUD Time And Date System
+
+## Scope
+This document describes the verified current implementation of FutureMUD's in-game time and date system.
+
+It covers the shared value types in `FutureMUDLibrary/TimeAndDate`, the concrete runtime classes in `MudSharpCore/TimeAndDate`, and the integration points that make time useful to the rest of the engine:
+
+- clocks, time zones, and clock advancement
+- calendars, years, months, intercalaries, weekdays, and date display
+- `MudDate`, `MudTime`, `MudDateTime`, and `MudTimeSpan`
+- temporal listeners and recurring intervals
+- FutureProg date/time support
+- player, builder, seeder, persistence, and boot integration
+
+The document is intentionally current-state focused. Future work is listed separately near the end.
+
+## Design Goals
+The system exists to let worlds define fictional time models without hard-coding Earth Gregorian assumptions into game logic.
+
+The important design goals are:
+
+- support multiple clocks and calendars in the same game
+- support non-standard clocks, such as decimal time or non-24-hour days
+- support non-standard calendars, including unusual week lengths, leap days, intercalary months, and named special days
+- keep builder-facing display and parsing driven by clock/calendar definitions
+- provide stable value objects for scheduling, FutureProg, economy, clans, weather, celestial objects, and world presentation
+- allow player-facing precision to depend on character knowledge and perception rather than always showing exact machine time
+
+## Layered Shape
+The subsystem is split between shared contracts/value objects and concrete runtime implementation.
+
+| Layer | Responsibility | Typical locations |
+| --- | --- | --- |
+| Contracts and value objects | Interfaces, `MudDate`, `MudTime`, `MudDateTime`, `MudTimeSpan`, calendar parts, intervals | `FutureMUDLibrary/TimeAndDate` |
+| Runtime implementations | `Calendar`, `Clock`, `MudTimeZone`, listeners, interval listener adapters, builder editing | `MudSharpCore/TimeAndDate` |
+| Persistence | EF models for calendars, clocks, time zones, shard links, zone time zones, and scheduled FutureProgs | `MudsharpDatabaseLibrary/Models` |
+| Builder/player commands | `time`, `calendar`, `clock`, `timezone`, shard/zone clock and calendar assignment | `MudSharpCore/Commands/Modules` and `MudSharpCore/Commands/Helpers` |
+| Seeding | stock clocks, time zones, and calendar definitions | `DatabaseSeeder/Seeders/TimeSeeder.cs` |
+| Automation | temporal listeners, recurring intervals, and FutureProg schedules | `MudSharpCore/TimeAndDate/Listeners`, `MudSharpCore/TimeAndDate/Intervals`, `MudSharpCore/FutureProg/ProgSchedule.cs` |
+
+## Boot And Runtime Advancement
+Clocks and calendars are early world infrastructure.
+
+During boot:
+
+- clocks load before calendars, celestials, listeners, world cells, and climate
+- calendars load after clocks because each calendar has a feed clock
+- celestials, weather, shards, zones, clans, economy, jobs, and player-facing world presentation can then resolve time references safely
+- `ClockManager.Initialise()` runs near the end of boot and starts real-time advancement unless the `TimeIsFrozen` static configuration is set
+
+`ClockManager` keeps an in-memory dictionary of each loaded clock and the next real-world UTC instant at which that clock should tick. On each engine update it advances a clock by one in-game second while the stored next-tick time is in the past, then moves the next-tick time forward by:
+
+```text
+1000ms / clock.InGameSecondsPerRealSecond
+```
+
+The implementor commands can freeze and unfreeze time. Freezing clears the manager's tick dictionary and persists `TimeIsFrozen=true`; unfreezing rebuilds tick state for all loaded clocks and persists `TimeIsFrozen=false`.
+
+## Persistence Model
+Time definitions are persisted separately from their current positions.
+
+### Clocks
+The `Clocks` table stores:
+
+- `Definition`: XML defining clock display strings, units, hour intervals, crude time intervals, and rate
+- `Hours`, `Minutes`, `Seconds`: current position in the primary time zone
+- `PrimaryTimezoneId`: the default time zone for the clock
+
+Each clock has one or more `Timezones` rows. A time zone stores:
+
+- `Name`: the alias used in parsing and display
+- `Description`: the long display name
+- `OffsetHours` and `OffsetMinutes`
+- `ClockId`
+
+### Calendars
+The `Calendars` table stores:
+
+- `Definition`: XML defining calendar names, display masks, eras, weekdays, months, intercalary rules, and feed clock
+- `Date`: current date as parseable calendar text
+- `FeedClockId`: the clock normally used for current date/time combinations
+
+### World Links
+Shards own available clocks and calendars through shard link tables. Zones choose one time zone per relevant clock, so the same clock can be displayed differently in different areas.
+
+Economic zones, clans, boards, weather controllers, celestials, and FutureProg schedules also persist references to clocks, calendars, time zones, or `MudDateTime` round-trip strings.
+
+## Clock Model
+`IClock` defines a configurable clock rather than assuming Earth time.
+
+Important properties include:
+
+- `SecondsPerMinute`
+- `MinutesPerHour`
+- `HoursPerDay`
+- `InGameSecondsPerRealSecond`
+- fixed digit settings for hours, minutes, and seconds
+- `NumberOfHourIntervals`
+- short interval names such as `am` and `pm`
+- long interval names such as `in the morning`
+- crude time ranges such as `night`, `morning`, `afternoon`, and `evening`
+- display masks for short, long, and superuser output
+
+`Clock.DisplayTime` turns a `MudTime` into player-facing text using a mask or a display type:
+
+- `Short`
+- `Long`
+- `Immortal`
+- `Vague`
+- `Crude`
+
+The player `time` command chooses exact, vague, or crude display depending on checks such as `ExactTimeCheck` and `VagueTimeCheck`, and can also display visible timepiece items.
+
+## Time Zones And MudTime
+`MudTime` represents a time-of-day on a specific clock and time zone. It stores:
+
+- seconds
+- minutes
+- hours
+- time zone
+- clock
+- `DaysOffsetFromDatum`
+- whether it is the primary clock time
+
+The primary clock time is the canonical advancing time for a clock. When a primary `MudTime` crosses a day boundary, it raises the clock's day advancement event. Non-primary times instead record day rollover in `DaysOffsetFromDatum`, so callers can apply the rollover to a `MudDate` when building a full `MudDateTime`.
+
+There are two important construction patterns:
+
+- `new MudTime(seconds, minutes, hours, timezone, clock, true)` creates the primary feeder time for a clock.
+- `new MudTime(seconds, minutes, hours, timezone, clock, daysOffset)` creates a local wall time already expressed in that time zone.
+
+The boolean constructor with `isprimarytime=false` applies time-zone offset logic. It should be used with care because it treats the supplied components as a datum that needs adjustment. Parser and scheduling code that accepts local wall time should use the `daysOffset` constructor or `Clock.GetTime`.
+
+`MudTime.GetTimeByTimezone` converts between time zones on the same clock and preserves any day rollover through `DaysOffsetFromDatum`.
+
+## Calendar Model
+`ICalendar` defines a named calendar, its feed clock, display masks, eras, weekdays, month definitions, and intercalary months.
+
+A calendar definition includes:
+
+- alias, short name, full name, and description
+- display masks for short, long, and wordy date display
+- plane text
+- feed clock id
+- epoch year and first weekday at epoch
+- ancient and modern era strings
+- ordered weekday names
+- base month definitions
+- intercalary month definitions
+
+The concrete `Calendar` creates generated `Year` instances as needed. Generated years are cached by year number. Calendar day counts, weekday counts, days-between-year counts, and first-weekday calculations are also cached.
+
+The first weekday of a year is computed from:
+
+- the epoch year
+- the first weekday at epoch
+- the count of weekday-counting days between the target year and epoch
+- the actual number of weekdays in the calendar, not an assumed seven-day week
+
+This is what allows calendars with five-day, six-day, eight-day, or other custom week lengths to work correctly.
+
+## Months, Intercalaries, And Weekdays
+`MonthDefinition` is the authored month template. `Month` is the generated month for a specific year.
+
+A month definition contains:
+
+- alias
+- short name
+- full name
+- nominal order
+- normal day count
+- special day names
+- non-weekday day numbers
+- intercalary day rules
+
+Intercalary days can:
+
+- insert extra days into a month
+- add special day names
+- remove special day names
+- add non-weekday dates
+- remove non-weekday dates
+
+Intercalary months are separate month definitions that appear only when their intercalary rule matches the generated year.
+
+`MudDate.SetWeekday` uses the generated year's first weekday, the weekday-counting days in earlier generated months, and the current month's non-weekday list. Dates marked as non-weekdays have an empty weekday string and `WeekdayIndex = -1`.
+
+## MudDate
+`MudDate` represents a date in a calendar. It stores:
+
+- calendar
+- day
+- month
+- year number
+- generated `Year`
+- weekday string and weekday index
+- whether it is the primary calendar date
+
+Primary dates update the owning calendar when advanced. Copied or parsed dates are non-primary value objects.
+
+`MudDate` supports:
+
+- day, month, and year advancement
+- forward and backward weekday seeking
+- conversion to another calendar by day difference from each calendar's current date
+- date difference and year difference operations
+- round-trip parse text
+- display through calendar masks
+
+`MudDate.AdvanceToNextWeekday` is exclusive of the current date. A positive occurrence count moves forward; a negative count moves backward; zero is a no-op.
+
+## MudDateTime
+`MudDateTime` combines a `MudDate`, `MudTime`, and `IMudTimeZone`.
+
+It is the main value type for in-game scheduling and FutureProg mud date/time operations. It supports:
+
+- parsing from player input
+- parsing from round-trip storage text
+- display through calendar and clock display modes
+- time-zone conversion
+- calendar conversion
+- comparison across time zones
+- addition and subtraction of `MudTimeSpan` or `TimeSpan`
+- FutureProg dot references
+
+### Never
+`MudDateTime.Never` is a sentinel value represented by a null date, time, and time zone.
+
+Current behavior treats `Never` as less than all real mud datetimes and equal to other `Never` values. Copying, comparison, round-tripping, calendar conversion, object equality, and the FutureProg `midnight` property preserve the sentinel.
+
+Callers should check `Date == null` or use the FutureProg `isnever` dot reference rather than assuming all `MudDateTime` values have live date/time components.
+
+### Parsing
+The actor-facing parser accepts:
+
+- `never`
+- `now`
+- `soon`
+- dates in the supported calendar parse forms
+- times such as `3:15pm`, `15:15:00`, and `15:15:00 UTC`
+- optional clock hour interval text
+- optional time-zone aliases
+
+When a time zone is specified, the parsed time is treated as local wall time in that time zone. Unknown time zones or meridian/period text are rejected cleanly.
+
+`ToMudDateFunction` in FutureProg uses this parser and returns `MudDateTime.Never` for invalid text, missing calendars, missing clocks, or empty input.
+
+## MudTimeSpan
+`MudTimeSpan` is the engine's in-game duration type. It can represent:
+
+- years
+- months
+- weeks
+- days
+- hours
+- minutes
+- seconds
+- milliseconds
+
+Years and months are calendar-like duration components. Weeks are interpreted relative to the target calendar's weekday count when applying a span to `MudDateTime`. Smaller components are stored as milliseconds.
+
+Important property conventions:
+
+- `Seconds`, `Minutes`, and `Hours` are total duration values.
+- `SecondComponentOnly`, `MinuteComponentOnly`, and `HourComponentOnly` are component remainders.
+- `DayComponentOnly` is the day component carried by the millisecond portion.
+- `TotalSeconds`, `TotalMinutes`, `TotalHours`, and `TotalDays` expose double totals.
+
+When applying a `MudTimeSpan` to `MudDateTime`, time components adjust the `MudTime`, any day rollover is applied to the date, then week/month/year components are applied to the date.
+
+## Recurring Intervals
+`RecurringInterval` is a compact recurrence description used by clans, economy, property, shoppers, jobs, and FutureProg schedules.
+
+It supports interval types:
+
+- minutely
+- hourly
+- daily
+- monthly
+- specific weekday
+- weekly
+- yearly
+
+The parser accepts text like:
+
+```text
+every 3 days
+every 1 month
+every weekday 4
+```
+
+For `SpecificWeekday`, `Modifier` is the weekday index in the calendar. For other interval types, `Modifier` is usually zero.
+
+Recurring intervals can:
+
+- describe themselves in player-facing text
+- find the next date/time after the current game time
+- find the last date/time relative to current game time
+- find adjacent date/times around current game time
+- create listeners through the `IntervalExtensions` helpers
+
+Weekday intervals use the owning calendar's weekday list and support both forward and backward movement.
+
+## Temporal Listeners
+Temporal listeners are in-memory callback objects that subscribe to clock or calendar events.
+
+The main listener types are:
+
+- `DateListener`
+- `TimeListener`
+- `WeekdayListener`
+- `WeekdayTimeListener`
+
+`ListenerFactory` is the normal construction surface. It creates listeners for absolute date/time targets, offsets, weekday targets, and combined date/time targets.
+
+Listener repeat counts follow the existing one-shot convention:
+
+- `repeatTimes = 0` means fire once and unsubscribe after the successful payload.
+- `repeatTimes = 1` also fires once and unsubscribes after the successful payload.
+- values above one fire that many successful payloads.
+
+The shared listener trigger path invokes the payload, decrements the repeat count, unsubscribes when exhausted, and removes the listener from the gameworld.
+
+Listeners are not themselves the long-term persistence model. Persistent behaviors such as FutureProg schedules store their recurrence/reference data and recreate listeners on load or after each fire.
+
+## FutureProg Integration
+FutureProg exposes three related date/time surfaces:
+
+- real-world UTC `DateTime`
+- real-world `TimeSpan`
+- in-game `MudDateTime`
+
+`MudDateTime` dot references include:
+
+- `second`
+- `minute`
+- `hour`
+- `day`
+- `month`
+- `year`
+- `isnever`
+- `midnight`
+- `calendar`
+- `clock`
+- `timezone`
+
+Important built-in Date/Time functions include:
+
+- `now()` for real-world UTC `DateTime`
+- `now(calendar)`, `now(calendar, clock)`, and `now(calendar, clock, timezone)` for in-game `MudDateTime`
+- `todate(text, mask)` for real-world `DateTime`
+- `todate(calendar, clock, text)` for in-game `MudDateTime`
+- `totext(...)` overloads for date/time text output
+- `nextweekday(...)` and `lastweekday(...)` for real-world and mud date/time values
+- `between(...)` for `TimeSpan`, `DateTime`, and `MudDateTime`
+- arithmetic operators for date/time plus or minus spans
+- `GameSecondsPerRealSeconds(clock)` for clock speed introspection
+
+FutureProg schedules persist a recurrence, a reference `MudDateTime`, and the target FutureProg. On load, a schedule advances the persisted reference to the next future occurrence and creates an in-memory listener. When the listener fires, the schedule executes the FutureProg, computes the next reference time, creates the next listener, and marks itself changed.
+
+## Player And Builder Surfaces
+### Player-Facing
+Players primarily interact with time through:
+
+- `time`: current perceived time, date, season, celestial information, and visible timepiece items
+- `calendar`: calendar definition or generated year view
+- object interactions such as timepieces
+
+The `time` command intentionally routes exactness through checks. A character may receive exact time, vague time, or crude time depending on game mechanics.
+
+### Builder/Admin-Facing
+Current builder/admin surfaces include:
+
+- `clock`: list, create, edit, clone, close, and show clocks
+- `timezone`: list, create, and edit time zones for a clock
+- `shard set <shard> clocks <clock...>`
+- `shard set <shard> calendars <calendar...>`
+- `zone set <zone> timezone <clock> <timezone>`
+- `show clocks`
+- `show calendars`
+- `show timezones [clock]`
+
+There is robust clock editing support through `EditableItemHelper.ClockHelper`. Calendar editing is less builder-complete and is currently more dependent on seeded or XML-defined calendar definitions.
+
+## Seeder Support
+`TimeSeeder` installs the initial clock, UTC time zone, and selected stock calendar package.
+
+It asks for:
+
+- in-game seconds per real second
+- the calendar mode/package
+- starting year
+- additional package-specific choices, such as Middle-earth age selection
+
+The seeder includes stock calendars such as Gregorian, Julian, Roman, Tranquility, French Republican, Mission, Seasonal 360, and several Tolkien-inspired calendars.
+
+The seeder is repair-capable for canonical stock time data. Other seeders rely on at least one clock and calendar being present.
+
+## Integration Points
+The time and date system is used broadly across FutureMUD:
+
+- rooms, zones, and shards expose local calendars, clocks, and time zones
+- celestial objects use calendars and clocks for sky positions and cycles
+- climate and weather controllers use clocks and time zones for weather progression
+- economies use calendars, clocks, and time zones for financial periods and recurring policy events
+- clans use calendars and recurring intervals for pay cycles and elections
+- shoppers, jobs, property leases, hotels, stables, and estate systems use recurring intervals and mud datetimes
+- effects can schedule expiration or behavior with date/time listeners
+- FutureProg schedules use recurring intervals and persistent `MudDateTime` references
+- player presentation uses clocks, calendars, timepieces, and perception checks
+
+## Invariants And Implementation Notes
+These are important rules to preserve when changing the system:
+
+- Clocks must load before calendars.
+- Calendars should use their feed clock for current `MudDateTime` unless a caller explicitly supplies another clock.
+- Non-primary `MudTime` day rollover must be applied to `MudDate` exactly once.
+- A parsed time with an explicit time zone is local wall time in that time zone.
+- `MudDateTime.Never` must be safe to copy, compare, convert, display, and use in FutureProg dot references.
+- Calendar weekday math must use `Weekdays.Count`, not a hard-coded seven-day week.
+- Intercalary non-weekday additions and removals must match both generated month behavior and yearly weekday counts.
+- `MudDate` copies must preserve generated-year weekday state.
+- Temporal listeners consume repeat counts only after successful payload firing.
+- Persistent scheduling should store recurrence/reference data and recreate listeners rather than expecting listeners themselves to persist.
+
+## Current Limitations
+The system is flexible, but there are areas where current support is incomplete or intentionally narrow:
+
+- calendar authoring is not as builder-friendly as clock and time-zone authoring
+- time zones are fixed offsets and do not model daylight saving or historical offset changes
+- `MudTime` has constructor overloads with subtly different offset semantics, so call sites must choose carefully
+- recurring interval text is compact but limited; it does not yet support richer expressions like "last day of month" or "third Monday"
+- listeners are in-memory runtime helpers, so persistence must be implemented by the owning subsystem
+- cross-calendar conversion is based on each calendar's current date anchor, which is useful for live worlds but should be treated carefully for historical absolute chronology
+- `MudTimeSpan` month and year components are calendar-like approximations until applied to a concrete `MudDateTime`
+
+## Future Work
+Useful extensions include:
+
+- a full calendar builder/editor with validation previews for generated years
+- builder-facing calendar import/export tooling for XML definitions
+- richer recurring interval grammar and validation messages
+- daylight saving and date-bounded time-zone transitions
+- clearer `MudTime` construction APIs that distinguish datum conversion from local wall time
+- design-time tests for every stock seeded calendar, including non-seven-day weeks and intercalaries
+- a schedule inspection command that shows active listener state alongside persistent recurrence state
+- more FutureProg helper functions for calendar math, such as `daysbetween`, `monthstart`, `monthend`, and `weekdayname`
+- stronger validation for calendars linked to shards, zones, celestials, weather controllers, economies, and clans before deletion or major edits

--- a/Design Documents/Time_And_Date_System.md
+++ b/Design Documents/Time_And_Date_System.md
@@ -126,10 +126,13 @@ The primary clock time is the canonical advancing time for a clock. When a prima
 
 There are two important construction patterns:
 
-- `new MudTime(seconds, minutes, hours, timezone, clock, true)` creates the primary feeder time for a clock.
-- `new MudTime(seconds, minutes, hours, timezone, clock, daysOffset)` creates a local wall time already expressed in that time zone.
+- `MudTime.CreatePrimaryTime(seconds, minutes, hours, timezone, clock)` creates the authoritative feeder time for a clock.
+- `MudTime.FromPrimaryTime(seconds, minutes, hours, timezone, clock)` converts a primary/datum time into a timezone-local time.
+- `MudTime.FromLocalTime(seconds, minutes, hours, timezone, clock, daysOffset)` creates a local wall time already expressed in that time zone.
+- `MudTime.ParseLocalTime(text, clock)` and `MudTime.TryParseLocalTime(text, clock, out time, out error)` parse builder/player-entered local wall time.
+- `MudTime.CopyOf(time, resetDaysOffsetFromDatum)` copies a time without preserving primary-clock behavior.
 
-The boolean constructor with `isprimarytime=false` applies time-zone offset logic. It should be used with care because it treats the supplied components as a datum that needs adjustment. Parser and scheduling code that accepts local wall time should use the `daysOffset` constructor or `Clock.GetTime`.
+The named factories centralize component validation, time-zone ownership checks, and the distinction between datum conversion and local wall time. `Clock.GetTime(string)` remains as a facade over `MudTime.ParseLocalTime`.
 
 `MudTime.GetTimeByTimezone` converts between time zones on the same clock and preserves any day rollover through `DaysOffsetFromDatum`.
 
@@ -277,6 +280,8 @@ It supports interval types:
 - hourly
 - daily
 - monthly
+- ordinal day of month
+- ordinal weekday of month
 - specific weekday
 - weekly
 - yearly
@@ -287,9 +292,24 @@ The parser accepts text like:
 every 3 days
 every 1 month
 every weekday 4
+every month on day 15
+every 2 months on the 15th
+every month on last day
+every month on the 5th Wednesday
+every month on the 5th or last Wednesday
+every 3 months on the 12th or last Marketday
 ```
 
 For `SpecificWeekday`, `Modifier` is the weekday index in the calendar. For other interval types, `Modifier` is usually zero.
+
+For ordinal month intervals:
+
+- `OrdinalDayOfMonth` uses `Modifier` as the target day. `-1` means the last day of the month.
+- `OrdinalWeekdayOfMonth` uses `Modifier` as the ordinal occurrence and `SecondaryModifier` as the calendar weekday index.
+- `OrdinalFallbackMode.ExactOnly` skips months where the requested weekday occurrence does not exist.
+- `OrdinalFallbackMode.OrLast` uses the requested occurrence when present, otherwise the last matching weekday in that month.
+
+Day-of-month recurrences clamp to the last valid day in shorter months. Ordinal weekday recurrences accept any positive ordinal; the search uses generated calendar months and weekday names, so non-seven-day weeks and long fictional months are supported. The search is bounded and throws if no valid occurrence can be found inside the conservative month-search horizon.
 
 Recurring intervals can:
 
@@ -300,6 +320,17 @@ Recurring intervals can:
 - create listeners through the `IntervalExtensions` helpers
 
 Weekday intervals use the owning calendar's weekday list and support both forward and backward movement.
+
+### Interval Persistence
+Persistent recurring interval owners store the primary recurrence type, amount, modifier, secondary modifier, fallback mode, and reference date/time needed to recreate runtime listeners.
+
+Current interval persistence includes:
+
+- `ProgSchedules.IntervalOtherSecondary` and `ProgSchedules.IntervalFallback`
+- `EconomicZones.IntervalOther` and `EconomicZones.IntervalFallback`
+- `Clans.PayIntervalOtherSecondary` and `Clans.PayIntervalFallback`
+
+The new fields default to `0`, so existing rows continue to load with legacy recurrence semantics. String and XML interval persistence still round-trips through `RecurringInterval.ToString()` and `RecurringInterval.Parse`.
 
 ## Temporal Listeners
 Temporal listeners are in-memory callback objects that subscribe to clock or calendar events.
@@ -396,6 +427,8 @@ The seeder includes stock calendars such as Gregorian, Julian, Roman, Tranquilit
 
 The seeder is repair-capable for canonical stock time data. Other seeders rely on at least one clock and calendar being present.
 
+Seeder regression tests cover all stock `TimeSeeder` modes, including XML shape, runtime loading of generated clock/calendar rows, non-seven-day week packages, decimal clocks, Middle-earth multi-calendar output, and idempotent reruns.
+
 ## Integration Points
 The time and date system is used broadly across FutureMUD:
 
@@ -420,16 +453,26 @@ These are important rules to preserve when changing the system:
 - Calendar weekday math must use `Weekdays.Count`, not a hard-coded seven-day week.
 - Intercalary non-weekday additions and removals must match both generated month behavior and yearly weekday counts.
 - `MudDate` copies must preserve generated-year weekday state.
+- `MudTime` construction should go through the named factories so datum conversion and local wall-time construction remain explicit.
 - Temporal listeners consume repeat counts only after successful payload firing.
+- Ordinal recurrence calculations must use generated calendar data rather than Gregorian month/week assumptions.
 - Persistent scheduling should store recurrence/reference data and recreate listeners rather than expecting listeners themselves to persist.
+
+## Test Coverage
+The normal unit-test suites now include focused coverage for:
+
+- `MudTime` factory validation, parsing, copy behavior, and primary-time day rollover
+- `MudDate`, `MudDateTime`, `MudTimeSpan`, calendar weekday math, intercalary weekday edits, and `Never` safety
+- recurring interval parsing, descriptions, round-trip text, forward/backward search, high ordinal weekdays, exact-month skipping, and "or last" fallback
+- runtime listeners, interval extension helpers, and FutureProg date/time helper functions
+- every seeded clock/calendar package produced by `TimeSeeder`, including runtime loading and idempotent reruns
 
 ## Current Limitations
 The system is flexible, but there are areas where current support is incomplete or intentionally narrow:
 
 - calendar authoring is not as builder-friendly as clock and time-zone authoring
 - time zones are fixed offsets and do not model daylight saving or historical offset changes
-- `MudTime` has constructor overloads with subtly different offset semantics, so call sites must choose carefully
-- recurring interval text is compact but limited; it does not yet support richer expressions like "last day of month" or "third Monday"
+- recurring interval text is richer than the legacy compact form, but it remains a focused recurrence grammar rather than a general cron system
 - listeners are in-memory runtime helpers, so persistence must be implemented by the owning subsystem
 - cross-calendar conversion is based on each calendar's current date anchor, which is useful for live worlds but should be treated carefully for historical absolute chronology
 - `MudTimeSpan` month and year components are calendar-like approximations until applied to a concrete `MudDateTime`
@@ -439,10 +482,8 @@ Useful extensions include:
 
 - a full calendar builder/editor with validation previews for generated years
 - builder-facing calendar import/export tooling for XML definitions
-- richer recurring interval grammar and validation messages
+- additional recurrence validation previews and builder-facing schedule explanation tools
 - daylight saving and date-bounded time-zone transitions
-- clearer `MudTime` construction APIs that distinguish datum conversion from local wall time
-- design-time tests for every stock seeded calendar, including non-seven-day weeks and intercalaries
 - a schedule inspection command that shows active listener state alongside persistent recurrence state
 - more FutureProg helper functions for calendar math, such as `daysbetween`, `monthstart`, `monthend`, and `weekdayname`
 - stronger validation for calendars linked to shards, zones, celestials, weather controllers, economies, and clans before deletion or major edits

--- a/FutureMUDLibrary Unit Tests/MudTimeFactoryTests.cs
+++ b/FutureMUDLibrary Unit Tests/MudTimeFactoryTests.cs
@@ -1,0 +1,155 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.TimeAndDate.Time;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class MudTimeFactoryTests
+{
+	[TestMethod]
+	public void FromPrimaryTime_AppliesTimezoneOffset()
+	{
+		var (clock, _, cst) = CreateClock();
+
+		var time = MudTime.FromPrimaryTime(0, 0, 12, cst, clock);
+
+		Assert.AreEqual(6, time.Hours);
+		Assert.AreEqual(0, time.Minutes);
+		Assert.AreEqual(0, time.Seconds);
+		Assert.AreEqual(0, time.DaysOffsetFromDatum);
+		Assert.AreEqual(cst, time.Timezone);
+		Assert.IsFalse(time.IsPrimaryTime);
+	}
+
+	[TestMethod]
+	public void FromLocalTime_PreservesWallClockTime()
+	{
+		var (clock, _, cst) = CreateClock();
+
+		var time = MudTime.FromLocalTime(0, 0, 6, cst, clock);
+
+		Assert.AreEqual(6, time.Hours);
+		Assert.AreEqual(0, time.Minutes);
+		Assert.AreEqual(0, time.Seconds);
+		Assert.AreEqual(cst, time.Timezone);
+		Assert.IsFalse(time.IsPrimaryTime);
+	}
+
+	[TestMethod]
+	public void ParseLocalTime_UsesNamedTimezoneAndMeridianAsWallTime()
+	{
+		var (clock, _, cst) = CreateClock();
+
+		var time = MudTime.ParseLocalTime("CST 3:15:30 p.m", clock);
+
+		Assert.AreEqual(cst, time.Timezone);
+		Assert.AreEqual(15, time.Hours);
+		Assert.AreEqual(15, time.Minutes);
+		Assert.AreEqual(30, time.Seconds);
+	}
+
+	[TestMethod]
+	public void TryParseLocalTime_RejectsUnknownPeriodCleanly()
+	{
+		var (clock, _, _) = CreateClock();
+
+		var result = MudTime.TryParseLocalTime("UTC 3:15:30xm", clock, out var time, out var error);
+
+		Assert.IsFalse(result);
+		Assert.IsNull(time);
+		StringAssert.Contains(error, "hour period");
+	}
+
+	[TestMethod]
+	public void CopyOf_CopiesAndCanResetDatumOffset()
+	{
+		var (clock, utc, _) = CreateClock();
+		var time = MudTime.FromLocalTime(10, 20, 3, utc, clock, 2);
+
+		var copy = MudTime.CopyOf(time);
+		var reset = MudTime.CopyOf(time, true);
+
+		Assert.AreEqual(2, copy.DaysOffsetFromDatum);
+		Assert.AreEqual(0, reset.DaysOffsetFromDatum);
+		Assert.AreEqual(time.Hours, reset.Hours);
+		Assert.AreEqual(time.Minutes, reset.Minutes);
+		Assert.AreEqual(time.Seconds, reset.Seconds);
+		Assert.IsFalse(copy.IsPrimaryTime);
+		Assert.IsFalse(reset.IsPrimaryTime);
+	}
+
+	[TestMethod]
+	public void CreatePrimaryTime_AdvancingPastMidnightNotifiesClock()
+	{
+		var (clock, utc, _) = CreateClock(out var clockMock);
+		var time = MudTime.CreatePrimaryTime(0, 0, 23, utc, clock);
+
+		time.AddHours(2);
+
+		Assert.AreEqual(1, time.Hours);
+		clockMock.Verify(x => x.AdvanceDays(1), Times.Once);
+		clockMock.VerifySet(x => x.Changed = true, Times.AtLeastOnce);
+	}
+
+	[TestMethod]
+	public void Factories_RejectOutOfRangeComponents()
+	{
+		var (clock, utc, _) = CreateClock();
+
+		Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
+			MudTime.FromLocalTime(60, 0, 0, utc, clock));
+		Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
+			MudTime.FromLocalTime(0, 60, 0, utc, clock));
+		Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
+			MudTime.FromLocalTime(0, 0, 24, utc, clock));
+	}
+
+	private static (IClock Clock, IMudTimeZone Utc, IMudTimeZone Cst) CreateClock()
+	{
+		return CreateClock(out _);
+	}
+
+	private static (IClock Clock, IMudTimeZone Utc, IMudTimeZone Cst) CreateClock(out Mock<IClock> clockMock)
+	{
+		var timezones = new List<IMudTimeZone>();
+		clockMock = new Mock<IClock>();
+		var clock = clockMock.Object;
+		var utc = CreateTimezone(1, "UTC", "Universal Time", 0, 0, clock);
+		var cst = CreateTimezone(2, "CST", "Central Standard Time", -6, 0, clock);
+		timezones.Add(utc);
+		timezones.Add(cst);
+
+		clockMock.SetupGet(x => x.SecondsPerMinute).Returns(60);
+		clockMock.SetupGet(x => x.MinutesPerHour).Returns(60);
+		clockMock.SetupGet(x => x.HoursPerDay).Returns(24);
+		clockMock.SetupGet(x => x.NumberOfHourIntervals).Returns(2);
+		clockMock.SetupGet(x => x.NoZeroHour).Returns(true);
+		clockMock.SetupGet(x => x.HourIntervalNames).Returns(["a.m", "p.m"]);
+		clockMock.SetupGet(x => x.Timezones).Returns(timezones);
+		clockMock.SetupGet(x => x.PrimaryTimezone).Returns(utc);
+		clockMock.SetupProperty(x => x.Changed);
+
+		return (clock, utc, cst);
+	}
+
+	private static IMudTimeZone CreateTimezone(long id, string alias, string name, int hours, int minutes, IClock clock)
+	{
+		var mock = new Mock<IMudTimeZone>();
+		mock.SetupGet(x => x.Id).Returns(id);
+		mock.SetupGet(x => x.Name).Returns(alias);
+		mock.SetupGet(x => x.FrameworkItemType).Returns("Timezone");
+		mock.SetupGet(x => x.Names).Returns(new[] { alias, name });
+		mock.SetupGet(x => x.Alias).Returns(alias);
+		mock.SetupGet(x => x.Description).Returns(name);
+		mock.SetupGet(x => x.OffsetHours).Returns(hours);
+		mock.SetupGet(x => x.OffsetMinutes).Returns(minutes);
+		mock.SetupGet(x => x.Clock).Returns(clock);
+		return mock.Object;
+	}
+}

--- a/FutureMUDLibrary Unit Tests/RecurringIntervalTests.cs
+++ b/FutureMUDLibrary Unit Tests/RecurringIntervalTests.cs
@@ -1,0 +1,99 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.TimeAndDate.Date;
+using MudSharp.TimeAndDate.Intervals;
+using System.Collections.Generic;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class RecurringIntervalTests
+{
+	[TestMethod]
+	public void TryParse_OrdinalDayForms()
+	{
+		Assert.IsTrue(RecurringInterval.TryParse("every month on day 15", out var dayInterval));
+		Assert.AreEqual(IntervalType.OrdinalDayOfMonth, dayInterval.Type);
+		Assert.AreEqual(1, dayInterval.IntervalAmount);
+		Assert.AreEqual(15, dayInterval.Modifier);
+
+		Assert.IsTrue(RecurringInterval.TryParse("every 2 months on the 15th", out var ordinalInterval));
+		Assert.AreEqual(IntervalType.OrdinalDayOfMonth, ordinalInterval.Type);
+		Assert.AreEqual(2, ordinalInterval.IntervalAmount);
+		Assert.AreEqual(15, ordinalInterval.Modifier);
+
+		Assert.IsTrue(RecurringInterval.TryParse("every month on last day", out var lastInterval));
+		Assert.AreEqual(IntervalType.OrdinalDayOfMonth, lastInterval.Type);
+		Assert.AreEqual(-1, lastInterval.Modifier);
+	}
+
+	[TestMethod]
+	public void TryParse_OrdinalWeekdayUsesCalendarWeekdayNames()
+	{
+		var calendar = CreateCalendar("Marketday", "Moonday", "Starday", "Fireday", "Waterday", "Restday");
+
+		Assert.IsTrue(RecurringInterval.TryParse("every 3 months on the 12th or last Marketday", calendar, out var interval, out var error), error);
+
+		Assert.AreEqual(IntervalType.OrdinalWeekdayOfMonth, interval.Type);
+		Assert.AreEqual(3, interval.IntervalAmount);
+		Assert.AreEqual(12, interval.Modifier);
+		Assert.AreEqual(0, interval.SecondaryModifier);
+		Assert.AreEqual(OrdinalFallbackMode.OrLast, interval.OrdinalFallbackMode);
+	}
+
+	[TestMethod]
+	public void TryParse_CustomWeekdayNameRequiresCalendar()
+	{
+		Assert.IsFalse(RecurringInterval.TryParse("every month on the 5th Marketday", out var interval));
+		Assert.IsNull(interval);
+	}
+
+	[TestMethod]
+	public void ToString_RoundTripsOrdinalWeekdayWithoutCalendar()
+	{
+		var calendar = CreateCalendar("Marketday", "Moonday", "Starday");
+		Assert.IsTrue(RecurringInterval.TryParse("every month on the 5th or last Marketday", calendar, out var interval, out var error), error);
+
+		var roundTrip = RecurringInterval.Parse(interval.ToString());
+
+		Assert.AreEqual(interval.Type, roundTrip.Type);
+		Assert.AreEqual(interval.IntervalAmount, roundTrip.IntervalAmount);
+		Assert.AreEqual(interval.Modifier, roundTrip.Modifier);
+		Assert.AreEqual(interval.SecondaryModifier, roundTrip.SecondaryModifier);
+		Assert.AreEqual(interval.OrdinalFallbackMode, roundTrip.OrdinalFallbackMode);
+	}
+
+	[TestMethod]
+	public void TryParse_LastWeekdayUsesFallbackModeExactOnly()
+	{
+		var calendar = CreateCalendar("Marketday", "Moonday", "Starday");
+
+		Assert.IsTrue(RecurringInterval.TryParse("every month on last Moonday", calendar, out var interval, out var error), error);
+
+		Assert.AreEqual(IntervalType.OrdinalWeekdayOfMonth, interval.Type);
+		Assert.AreEqual(-1, interval.Modifier);
+		Assert.AreEqual(1, interval.SecondaryModifier);
+		Assert.AreEqual(OrdinalFallbackMode.ExactOnly, interval.OrdinalFallbackMode);
+	}
+
+	[TestMethod]
+	public void Describe_UsesCalendarWeekdayNames()
+	{
+		var calendar = CreateCalendar("Marketday", "Moonday", "Starday");
+		Assert.IsTrue(RecurringInterval.TryParse("every month on the 5th or last Marketday", calendar, out var interval, out var error), error);
+
+		Assert.AreEqual("every month on the 5th or last Marketday", interval.Describe(calendar));
+	}
+
+	private static ICalendar CreateCalendar(params string[] weekdays)
+	{
+		var mock = new Mock<ICalendar>();
+		mock.SetupGet(x => x.Weekdays).Returns(new List<string>(weekdays));
+		mock.SetupGet(x => x.Name).Returns("Calendar");
+		mock.SetupGet(x => x.ShortName).Returns("Calendar");
+		mock.SetupGet(x => x.FrameworkItemType).Returns("Calendar");
+		return mock.Object;
+	}
+}

--- a/FutureMUDLibrary/TimeAndDate/Date/Month.cs
+++ b/FutureMUDLibrary/TimeAndDate/Date/Month.cs
@@ -27,6 +27,14 @@ namespace MudSharp.TimeAndDate.Date
             {
                 i.RemoveSpecialDayNames.ForEach(x => _dayNames.Remove(x));
                 i.SpecialDayNames.ToList().ForEach(x => _dayNames.Add(x.Key, x.Value));
+                i.RemoveNonWeekdays.ForEach(x => _nonWeekdays.Remove(x));
+                i.NonWeekdays.ForEach(x =>
+                {
+                    if (!_nonWeekdays.Contains(x))
+                    {
+                        _nonWeekdays.Add(x);
+                    }
+                });
                 _days += i.InsertNumnewDays;
             });
         }

--- a/FutureMUDLibrary/TimeAndDate/Date/MudDate.cs
+++ b/FutureMUDLibrary/TimeAndDate/Date/MudDate.cs
@@ -792,7 +792,7 @@ public class MudDate : IComparable
     public MudDateTime ToDateTime()
     {
         return new MudDateTime(this,
-            new MudTime(0, 0, 0, Calendar.FeedClock.PrimaryTimezone, Calendar.FeedClock, false),
+            MudTime.FromPrimaryTime(0, 0, 0, Calendar.FeedClock.PrimaryTimezone, Calendar.FeedClock),
             Calendar.FeedClock.PrimaryTimezone);
     }
 }

--- a/FutureMUDLibrary/TimeAndDate/Date/MudDate.cs
+++ b/FutureMUDLibrary/TimeAndDate/Date/MudDate.cs
@@ -234,17 +234,24 @@ public class MudDate : IComparable
             throw new ArgumentException("AdvanceToNextWeekday called with out of range weekday.");
         }
 
-        while (times > 0)
+        if (times == 0)
+        {
+            return;
+        }
+
+        int direction = Math.Sign(times);
+        int remaining = Math.Abs(times);
+        while (remaining > 0)
         {
             while (true)
             {
-                AdvanceDays(1);
+                AdvanceDays(direction);
                 if (WeekdayIndex == whichWeekday)
                 {
                     break;
                 }
             }
-            times--;
+            remaining--;
         }
     }
 

--- a/FutureMUDLibrary/TimeAndDate/Date/Year.cs
+++ b/FutureMUDLibrary/TimeAndDate/Date/Year.cs
@@ -52,6 +52,7 @@ namespace MudSharp.TimeAndDate.Date
             _year = copyYear._year;
             _months = new List<Month>(copyYear._months);
             _calendar = copyYear._calendar;
+            _firstWeekdayIndex = copyYear._firstWeekdayIndex;
         }
 
         #endregion

--- a/FutureMUDLibrary/TimeAndDate/Intervals/IntervalType.cs
+++ b/FutureMUDLibrary/TimeAndDate/Intervals/IntervalType.cs
@@ -8,6 +8,14 @@
         Yearly,
         SpecificWeekday,
         Hourly,
-        Minutely
+        Minutely,
+        OrdinalDayOfMonth,
+        OrdinalWeekdayOfMonth
+    }
+
+    public enum OrdinalFallbackMode
+    {
+        ExactOnly = 0,
+        OrLast = 1
     }
 }

--- a/FutureMUDLibrary/TimeAndDate/Intervals/RecurringInterval.cs
+++ b/FutureMUDLibrary/TimeAndDate/Intervals/RecurringInterval.cs
@@ -1,6 +1,5 @@
-﻿using MudSharp.Framework;
+using MudSharp.Framework;
 using MudSharp.TimeAndDate.Date;
-using MudSharp.TimeAndDate.Listeners;
 using MudSharp.TimeAndDate.Time;
 using System;
 using System.Linq;
@@ -10,26 +9,47 @@ namespace MudSharp.TimeAndDate.Intervals
 {
     public class RecurringInterval
     {
-        private static readonly Regex ParseRegex =
-            new(
-                @"every\s*(?<amount>[0-9]+)*\s*(?<interval>minutes?|hours?|days?|months?|weekdays?|weeks?|years?)(?:\s(?<modifier>.+))*");
+        private const int MaxOrdinalMonthSearches = 10000;
+
+        private static readonly Regex LegacyParseRegex =
+            new(@"^every\s*(?<amount>[0-9]+)*\s*(?<interval>minutes?|hours?|days?|months?|weekdays?|weeks?|years?)(?:\s+(?<modifier>[+-]?\d+))*\s*$",
+                RegexOptions.IgnoreCase);
+
+        private static readonly Regex OrdinalDayParseRegex =
+            new(@"^every\s*(?<amount>[0-9]+)*\s*months?\s+on\s+(?:the\s+)?(?:(?<last>last)\s+day|day\s+(?<day>\d+)|(?<ordinal>\d+)(?:st|nd|rd|th)?)\s*$",
+                RegexOptions.IgnoreCase);
+
+        private static readonly Regex OrdinalWeekdayParseRegex =
+            new(@"^every\s*(?<amount>[0-9]+)*\s*months?\s+on\s+(?:the\s+)?(?<ordinal>\d+)(?:st|nd|rd|th)?(?<orlast>\s+or\s+last)?\s+(?<weekday>.+?)\s*$",
+                RegexOptions.IgnoreCase);
+
+        private static readonly Regex LastWeekdayParseRegex =
+            new(@"^every\s*(?<amount>[0-9]+)*\s*months?\s+on\s+(?:the\s+)?last\s+(?<weekday>.+?)\s*$",
+                RegexOptions.IgnoreCase);
 
         public IntervalType Type { get; init; }
         public int IntervalAmount { get; init; }
         public int Modifier { get; init; }
-
-        #region Overrides of Object
+        public int SecondaryModifier { get; init; }
+        public OrdinalFallbackMode OrdinalFallbackMode { get; init; }
 
         public override string ToString()
         {
-            return $"every {IntervalAmount:F0} {Type switch { IntervalType.Daily => "days", IntervalType.Hourly => "hours", IntervalType.Minutely => "minutes", IntervalType.Monthly => "months", IntervalType.SpecificWeekday => "weekdays", IntervalType.Weekly => "weeks", IntervalType.Yearly => "years", _ => "days" }} {Modifier:+000}";
+            return Type switch
+            {
+                IntervalType.OrdinalDayOfMonth => Modifier == -1
+                    ? $"every {IntervalAmount:F0} months on last day"
+                    : $"every {IntervalAmount:F0} months on day {Modifier:F0}",
+                IntervalType.OrdinalWeekdayOfMonth => Modifier == -1
+                    ? $"every {IntervalAmount:F0} months on last weekday {SecondaryModifier:F0}"
+                    : $"every {IntervalAmount:F0} months on the {Modifier:F0}{(OrdinalFallbackMode == OrdinalFallbackMode.OrLast ? " or last" : "")} weekday {SecondaryModifier:F0}",
+                _ => $"every {IntervalAmount:F0} {Type switch { IntervalType.Daily => "days", IntervalType.Hourly => "hours", IntervalType.Minutely => "minutes", IntervalType.Monthly => "months", IntervalType.SpecificWeekday => "weekdays", IntervalType.Weekly => "weeks", IntervalType.Yearly => "years", _ => "days" }} {Modifier:+000}"
+            };
         }
-
-        #endregion
 
         public static RecurringInterval Parse(string text)
         {
-            if (!TryParse(text, out RecurringInterval interval))
+            if (!TryParse(text, null, out RecurringInterval interval, out _))
             {
                 throw new ArgumentOutOfRangeException(nameof(text));
             }
@@ -39,21 +59,63 @@ namespace MudSharp.TimeAndDate.Intervals
 
         public static bool TryParse(string text, out RecurringInterval interval)
         {
-            Match match = ParseRegex.Match(text);
-            if (!match.Success)
+            return TryParse(text, null, out interval, out _);
+        }
+
+        public static bool TryParse(string text, ICalendar calendar, out RecurringInterval interval)
+        {
+            return TryParse(text, calendar, out interval, out _);
+        }
+
+        public static bool TryParse(string text, ICalendar calendar, out RecurringInterval interval, out string error)
+        {
+            interval = null;
+            error = string.Empty;
+            if (string.IsNullOrWhiteSpace(text))
             {
-                interval = null;
+                error = "No interval text was supplied.";
                 return false;
             }
 
-            int amount = 1;
-            if (match.Groups["amount"].Length > 0)
+            text = text.Trim();
+            if (TryParseOrdinalDay(text, out interval, out error))
             {
-                amount = int.Parse(match.Groups["amount"].Value);
+                return true;
+            }
+
+            if (TryParseLastWeekday(text, calendar, out interval, out error))
+            {
+                return true;
+            }
+
+            if (TryParseOrdinalWeekday(text, calendar, out interval, out error))
+            {
+                return true;
+            }
+
+            return TryParseLegacy(text, out interval, out error);
+        }
+
+        private static bool TryParseLegacy(string text, out RecurringInterval interval, out string error)
+        {
+            interval = null;
+            error = string.Empty;
+            Match match = LegacyParseRegex.Match(text);
+            if (!match.Success)
+            {
+                error = "The interval did not match a known interval grammar.";
+                return false;
+            }
+
+            int amount = ParseAmount(match);
+            if (amount <= 0)
+            {
+                error = "The interval amount must be greater than zero.";
+                return false;
             }
 
             IntervalType intervalType;
-            switch (match.Groups["interval"].Value)
+            switch (match.Groups["interval"].Value.ToLowerInvariant())
             {
                 case "minute":
                 case "minutes":
@@ -84,30 +146,177 @@ namespace MudSharp.TimeAndDate.Intervals
                     intervalType = IntervalType.SpecificWeekday;
                     break;
                 default:
-#if DEBUG
-                    throw new ApplicationException($"Invalid interval type \"{match.Groups["interval"].Value}\" in RecurringInterval.TryParse");
-#else
-					interval = null;
-					return false;
-#endif
+                    error = $"Invalid interval type \"{match.Groups["interval"].Value}\".";
+                    return false;
             }
 
             int modifier = 0;
-            if (match.Groups["modifier"].Length > 0)
+            if (match.Groups["modifier"].Length > 0 && !int.TryParse(match.Groups["modifier"].Value, out modifier))
             {
-                if (!int.TryParse(match.Groups["modifier"].Value, out modifier))
-                {
-#if DEBUG
-                    throw new ApplicationException($"Invalid interval modifier \"{match.Groups["modifier"].Value}\" in RecurringInterval.TryParse");
-#else
-					interval = null;
-					return false;
-#endif
-                }
+                error = $"Invalid interval modifier \"{match.Groups["modifier"].Value}\".";
+                return false;
             }
 
             interval = new RecurringInterval { IntervalAmount = amount, Modifier = modifier, Type = intervalType };
             return true;
+        }
+
+        private static bool TryParseOrdinalDay(string text, out RecurringInterval interval, out string error)
+        {
+            interval = null;
+            error = string.Empty;
+            Match match = OrdinalDayParseRegex.Match(text);
+            if (!match.Success)
+            {
+                return false;
+            }
+
+            int amount = ParseAmount(match);
+            if (amount <= 0)
+            {
+                error = "The interval amount must be greater than zero.";
+                return false;
+            }
+
+            int day;
+            if (match.Groups["last"].Success)
+            {
+                day = -1;
+            }
+            else
+            {
+                string value = match.Groups["day"].Success ? match.Groups["day"].Value : match.Groups["ordinal"].Value;
+                day = int.Parse(value);
+                if (day <= 0)
+                {
+                    error = "The day of month must be greater than zero.";
+                    return false;
+                }
+            }
+
+            interval = new RecurringInterval
+            {
+                IntervalAmount = amount,
+                Type = IntervalType.OrdinalDayOfMonth,
+                Modifier = day
+            };
+            return true;
+        }
+
+        private static bool TryParseLastWeekday(string text, ICalendar calendar, out RecurringInterval interval, out string error)
+        {
+            interval = null;
+            error = string.Empty;
+            Match match = LastWeekdayParseRegex.Match(text);
+            if (!match.Success)
+            {
+                return false;
+            }
+
+            int amount = ParseAmount(match);
+            if (amount <= 0)
+            {
+                error = "The interval amount must be greater than zero.";
+                return false;
+            }
+
+            if (!TryParseWeekday(match.Groups["weekday"].Value, calendar, out int weekday, out error))
+            {
+                return false;
+            }
+
+            interval = new RecurringInterval
+            {
+                IntervalAmount = amount,
+                Type = IntervalType.OrdinalWeekdayOfMonth,
+                Modifier = -1,
+                SecondaryModifier = weekday
+            };
+            return true;
+        }
+
+        private static bool TryParseOrdinalWeekday(string text, ICalendar calendar, out RecurringInterval interval, out string error)
+        {
+            interval = null;
+            error = string.Empty;
+            Match match = OrdinalWeekdayParseRegex.Match(text);
+            if (!match.Success)
+            {
+                return false;
+            }
+
+            int amount = ParseAmount(match);
+            if (amount <= 0)
+            {
+                error = "The interval amount must be greater than zero.";
+                return false;
+            }
+
+            int ordinal = int.Parse(match.Groups["ordinal"].Value);
+            if (ordinal <= 0)
+            {
+                error = "The ordinal must be greater than zero.";
+                return false;
+            }
+
+            if (!TryParseWeekday(match.Groups["weekday"].Value, calendar, out int weekday, out error))
+            {
+                return false;
+            }
+
+            interval = new RecurringInterval
+            {
+                IntervalAmount = amount,
+                Type = IntervalType.OrdinalWeekdayOfMonth,
+                Modifier = ordinal,
+                SecondaryModifier = weekday,
+                OrdinalFallbackMode = match.Groups["orlast"].Success
+                    ? OrdinalFallbackMode.OrLast
+                    : OrdinalFallbackMode.ExactOnly
+            };
+            return true;
+        }
+
+        private static int ParseAmount(Match match)
+        {
+            return match.Groups["amount"].Length > 0 ? int.Parse(match.Groups["amount"].Value) : 1;
+        }
+
+        private static bool TryParseWeekday(string text, ICalendar calendar, out int weekday, out string error)
+        {
+            error = string.Empty;
+            weekday = -1;
+            text = text.Trim();
+            if (text.StartsWith("weekday ", StringComparison.InvariantCultureIgnoreCase))
+            {
+                text = text[8..].Trim();
+            }
+
+            if (int.TryParse(text, out weekday))
+            {
+                if (calendar == null || weekday >= 0 && weekday < calendar.Weekdays.Count)
+                {
+                    return true;
+                }
+
+                error = $"The weekday index {weekday.ToString("N0")} is outside this calendar's weekday range.";
+                return false;
+            }
+
+            if (calendar == null)
+            {
+                error = "Weekday names require a calendar-aware interval parser.";
+                return false;
+            }
+
+            weekday = calendar.Weekdays.FindIndex(x => x.EqualTo(text) || x.Pluralise().EqualTo(text));
+            if (weekday >= 0)
+            {
+                return true;
+            }
+
+            error = $"The weekday \"{text}\" does not exist in the {calendar.ShortName} calendar.";
+            return false;
         }
 
         public string Describe(ICalendar whichCalendar)
@@ -130,112 +339,39 @@ namespace MudSharp.TimeAndDate.Intervals
                     return IntervalAmount == 1 ? "every week" : $"every {IntervalAmount} weeks";
                 case IntervalType.Yearly:
                     return IntervalAmount == 1 ? "every year" : $"every {IntervalAmount} years";
+                case IntervalType.OrdinalDayOfMonth:
+                    return Modifier == -1
+                        ? IntervalAmount == 1 ? "every month on the last day" : $"every {IntervalAmount} months on the last day"
+                        : IntervalAmount == 1 ? $"every month on the {Modifier.ToOrdinal()}" : $"every {IntervalAmount} months on the {Modifier.ToOrdinal()}";
+                case IntervalType.OrdinalWeekdayOfMonth:
+                    var weekday = whichCalendar != null && SecondaryModifier >= 0 && SecondaryModifier < whichCalendar.Weekdays.Count
+                        ? whichCalendar.Weekdays[SecondaryModifier]
+                        : $"weekday {SecondaryModifier}";
+                    var ordinalText = Modifier == -1 ? "last" : Modifier.ToOrdinal();
+                    var fallbackText = OrdinalFallbackMode == OrdinalFallbackMode.OrLast ? " or last" : string.Empty;
+                    return IntervalAmount == 1
+                        ? $"every month on the {ordinalText}{fallbackText} {weekday}"
+                        : $"every {IntervalAmount} months on the {ordinalText}{fallbackText} {weekday}";
                 default:
-                    throw new NotSupportedException("RecurringInveral.Describe found an unknown IntervalType.");
+                    throw new NotSupportedException("RecurringInterval.Describe found an unknown IntervalType.");
             }
         }
 
         public MudDateTime GetNextAdjacentToCurrent(MudDateTime referenceDateTime)
         {
-            ICalendar calendar = referenceDateTime.Calendar;
-            MudDateTime newDate = new(referenceDateTime);
-            MudDateTime currentDateTime = new MudDateTime(referenceDateTime.Calendar.CurrentDate,
-                referenceDateTime.Clock.CurrentTime, referenceDateTime.Clock.PrimaryTimezone).GetByTimeZone(
-                referenceDateTime.TimeZone);
-            newDate.Time.DaysOffsetFromDatum = 0;
-            currentDateTime.Time.DaysOffsetFromDatum = 0;
-
-            while (newDate > currentDateTime)
-            {
-                switch (Type)
-                {
-                    case IntervalType.Minutely:
-                        newDate.Time.DaysOffsetFromDatum = 0;
-                        newDate.Time.AddMinutes(-1 * IntervalAmount);
-                        if (newDate.Time.DaysOffsetFromDatum < 0)
-                        {
-                            newDate.Date.AdvanceDays(newDate.Time.DaysOffsetFromDatum);
-                            newDate.Time.DaysOffsetFromDatum = 0;
-                        }
-                        break;
-                    case IntervalType.Hourly:
-                        newDate.Time.DaysOffsetFromDatum = 0;
-                        newDate.Time.AddHours(-1 * IntervalAmount);
-                        if (newDate.Time.DaysOffsetFromDatum < 0)
-                        {
-                            newDate.Date.AdvanceDays(newDate.Time.DaysOffsetFromDatum);
-                            newDate.Time.DaysOffsetFromDatum = 0;
-                        }
-                        break;
-                    case IntervalType.Daily:
-                        newDate.Date.AdvanceDays(-1 * IntervalAmount);
-                        break;
-                    case IntervalType.Monthly:
-                        newDate.Date.AdvanceMonths(-1 * IntervalAmount, true, true);
-                        break;
-                    case IntervalType.SpecificWeekday:
-                        newDate.Date.AdvanceToNextWeekday(Modifier, -1 * IntervalAmount);
-                        break;
-                    case IntervalType.Weekly:
-                        newDate.Date.AdvanceDays(-1 * IntervalAmount * calendar.Weekdays.Count);
-                        break;
-                    case IntervalType.Yearly:
-                        newDate.Date.AdvanceYears(-1 * IntervalAmount, true);
-                        break;
-                }
-            }
-
-            return GetNextDateTime(newDate);
+            return GetNextDateTime(GetLastDateTime(referenceDateTime));
         }
 
         public MudDateTime GetLastDateTime(MudDateTime referenceDateTime)
         {
-            ICalendar calendar = referenceDateTime.Calendar;
-            MudDateTime newDate = new(referenceDateTime);
-            MudDateTime currentDateTime = new MudDateTime(referenceDateTime.Calendar.CurrentDate,
-                referenceDateTime.Clock.CurrentTime, referenceDateTime.Clock.PrimaryTimezone).GetByTimeZone(
-                referenceDateTime.TimeZone);
-            newDate.Time.DaysOffsetFromDatum = 0;
-            currentDateTime.Time.DaysOffsetFromDatum = 0;
+            MudDateTime newDate = IsOrdinalMonthly
+                ? AlignOrdinalDateTime(referenceDateTime, -1)
+                : new MudDateTime(referenceDateTime);
+            MudDateTime currentDateTime = CurrentDateTimeFor(referenceDateTime);
 
             while (newDate > currentDateTime)
             {
-                switch (Type)
-                {
-                    case IntervalType.Minutely:
-                        newDate.Time.DaysOffsetFromDatum = 0;
-                        newDate.Time.AddMinutes(-1 * IntervalAmount);
-                        if (newDate.Time.DaysOffsetFromDatum < 0)
-                        {
-                            newDate.Date.AdvanceDays(newDate.Time.DaysOffsetFromDatum);
-                            newDate.Time.DaysOffsetFromDatum = 0;
-                        }
-                        break;
-                    case IntervalType.Hourly:
-                        newDate.Time.DaysOffsetFromDatum = 0;
-                        newDate.Time.AddHours(-1 * IntervalAmount);
-                        if (newDate.Time.DaysOffsetFromDatum < 0)
-                        {
-                            newDate.Date.AdvanceDays(newDate.Time.DaysOffsetFromDatum);
-                            newDate.Time.DaysOffsetFromDatum = 0;
-                        }
-                        break;
-                    case IntervalType.Daily:
-                        newDate.Date.AdvanceDays(-1 * IntervalAmount);
-                        break;
-                    case IntervalType.Monthly:
-                        newDate.Date.AdvanceMonths(-1 * IntervalAmount, true, true);
-                        break;
-                    case IntervalType.SpecificWeekday:
-                        newDate.Date.AdvanceToNextWeekday(Modifier, -1 * IntervalAmount);
-                        break;
-                    case IntervalType.Weekly:
-                        newDate.Date.AdvanceDays(-1 * IntervalAmount * calendar.Weekdays.Count);
-                        break;
-                    case IntervalType.Yearly:
-                        newDate.Date.AdvanceYears(-1 * IntervalAmount, true);
-                        break;
-                }
+                newDate = MoveDateTimeByInterval(newDate, -1);
             }
 
             return newDate;
@@ -248,8 +384,10 @@ namespace MudSharp.TimeAndDate.Intervals
                 case IntervalType.Daily:
                     return referenceDateTime.AddDays(IntervalAmount);
                 case IntervalType.Weekly:
-                    return referenceDateTime.AddDays(7);
+                    return referenceDateTime.AddDays(7 * IntervalAmount);
                 case IntervalType.Monthly:
+                case IntervalType.OrdinalDayOfMonth:
+                case IntervalType.OrdinalWeekdayOfMonth:
                     return referenceDateTime.AddMonths(IntervalAmount);
                 case IntervalType.Yearly:
                     return referenceDateTime.AddYears(IntervalAmount);
@@ -260,12 +398,7 @@ namespace MudSharp.TimeAndDate.Intervals
                         result = result.AddDays(1);
                         if (result.DayOfWeek == (DayOfWeek)Modifier)
                         {
-                            if (IntervalAmount > 1)
-                            {
-                                return result.AddDays(7 * IntervalAmount);
-                            }
-
-                            return result;
+                            return IntervalAmount > 1 ? result.AddDays(7 * (IntervalAmount - 1)) : result;
                         }
                     }
 
@@ -276,84 +409,31 @@ namespace MudSharp.TimeAndDate.Intervals
                     return referenceDateTime.AddMinutes(IntervalAmount);
             }
 
-            throw new NotSupportedException("The IntervalType was not supported in RecurringInverval.GetNextDateTime");
+            throw new NotSupportedException("The IntervalType was not supported in RecurringInterval.GetNextDateTime");
         }
 
         public MudDateTime GetNextDateTime(MudDateTime referenceDateTime)
         {
-            ICalendar calendar = referenceDateTime.Calendar;
-            MudDateTime newDate = new(referenceDateTime);
-            MudDateTime currentDateTime = new MudDateTime(referenceDateTime.Calendar.CurrentDate,
-                referenceDateTime.Clock.CurrentTime, referenceDateTime.Clock.PrimaryTimezone).GetByTimeZone(
-                referenceDateTime.TimeZone);
-            newDate.Time.DaysOffsetFromDatum = 0;
-            currentDateTime.Time.DaysOffsetFromDatum = 0;
+            MudDateTime newDate = IsOrdinalMonthly
+                ? AlignOrdinalDateTime(referenceDateTime, 1)
+                : new MudDateTime(referenceDateTime);
+            MudDateTime currentDateTime = CurrentDateTimeFor(referenceDateTime);
 
             while (newDate <= currentDateTime)
             {
-                switch (Type)
-                {
-                    case IntervalType.Minutely:
-                        newDate.Time.DaysOffsetFromDatum = 0;
-                        newDate.Time.AddMinutes(IntervalAmount);
-                        if (newDate.Time.DaysOffsetFromDatum > 0)
-                        {
-                            newDate.Date.AdvanceDays(newDate.Time.DaysOffsetFromDatum);
-                            newDate.Time.DaysOffsetFromDatum = 0;
-                        }
-                        break;
-                    case IntervalType.Hourly:
-                        newDate.Time.DaysOffsetFromDatum = 0;
-                        newDate.Time.AddHours(IntervalAmount);
-                        if (newDate.Time.DaysOffsetFromDatum > 0)
-                        {
-                            newDate.Date.AdvanceDays(newDate.Time.DaysOffsetFromDatum);
-                            newDate.Time.DaysOffsetFromDatum = 0;
-                        }
-                        break;
-                    case IntervalType.Daily:
-                        newDate.Date.AdvanceDays(IntervalAmount);
-                        break;
-                    case IntervalType.Monthly:
-                        newDate.Date.AdvanceMonths(IntervalAmount, true, true);
-                        break;
-                    case IntervalType.SpecificWeekday:
-                        newDate.Date.AdvanceToNextWeekday(Modifier, IntervalAmount);
-                        break;
-                    case IntervalType.Weekly:
-                        newDate.Date.AdvanceDays(IntervalAmount * calendar.Weekdays.Count);
-                        break;
-                    case IntervalType.Yearly:
-                        newDate.Date.AdvanceYears(IntervalAmount, true);
-                        break;
-                }
+                newDate = MoveDateTimeByInterval(newDate, 1);
             }
             return newDate;
         }
 
         public MudDate GetNextDateExclusive(ICalendar whichCalendar, MudDate referenceDate)
         {
-            MudDate newDate = new(referenceDate);
+            MudDate newDate = IsOrdinalMonthly
+                ? AlignOrdinalDate(referenceDate, 1)
+                : new MudDate(referenceDate);
             while (newDate <= whichCalendar.CurrentDate)
             {
-                switch (Type)
-                {
-                    case IntervalType.Daily:
-                        newDate.AdvanceDays(IntervalAmount);
-                        break;
-                    case IntervalType.Monthly:
-                        newDate.AdvanceMonths(IntervalAmount, true, true);
-                        break;
-                    case IntervalType.SpecificWeekday:
-                        newDate.AdvanceToNextWeekday(Modifier, IntervalAmount);
-                        break;
-                    case IntervalType.Weekly:
-                        newDate.AdvanceDays(IntervalAmount * whichCalendar.Weekdays.Count);
-                        break;
-                    case IntervalType.Yearly:
-                        newDate.AdvanceYears(IntervalAmount, true);
-                        break;
-                }
+                newDate = MoveDateByInterval(newDate, 1);
             }
 
             return newDate;
@@ -361,29 +441,12 @@ namespace MudSharp.TimeAndDate.Intervals
 
         public MudDate GetNextDate(ICalendar whichCalendar, MudDate referenceDate)
         {
-            MudDate newDate = new(referenceDate);
+            MudDate newDate = IsOrdinalMonthly
+                ? AlignOrdinalDate(referenceDate, 1)
+                : new MudDate(referenceDate);
             while (newDate < whichCalendar.CurrentDate)
             {
-                switch (Type)
-                {
-                    case IntervalType.Minutely:
-                    case IntervalType.Hourly:
-                    case IntervalType.Daily:
-                        newDate.AdvanceDays(IntervalAmount);
-                        break;
-                    case IntervalType.Monthly:
-                        newDate.AdvanceMonths(IntervalAmount, true, true);
-                        break;
-                    case IntervalType.SpecificWeekday:
-                        newDate.AdvanceToNextWeekday(Modifier, IntervalAmount);
-                        break;
-                    case IntervalType.Weekly:
-                        newDate.AdvanceDays(IntervalAmount * whichCalendar.Weekdays.Count);
-                        break;
-                    case IntervalType.Yearly:
-                        newDate.AdvanceYears(IntervalAmount, true);
-                        break;
-                }
+                newDate = MoveDateByInterval(newDate, 1);
             }
 
             return newDate;
@@ -399,6 +462,8 @@ namespace MudSharp.TimeAndDate.Intervals
                 case IntervalType.SpecificWeekday:
                     return calendar.Weekdays.Count * IntervalAmount;
                 case IntervalType.Monthly:
+                case IntervalType.OrdinalDayOfMonth:
+                case IntervalType.OrdinalWeekdayOfMonth:
                     return calendar.CurrentDate.ThisYear.Months.Average(x => x.Days) * IntervalAmount;
                 case IntervalType.Yearly:
                     return calendar.CountDaysInYear(calendar.EpochYear) * IntervalAmount;
@@ -409,7 +474,157 @@ namespace MudSharp.TimeAndDate.Intervals
                 default:
                     throw new ArgumentOutOfRangeException();
             }
+        }
 
+        private bool IsOrdinalMonthly => Type is IntervalType.OrdinalDayOfMonth or IntervalType.OrdinalWeekdayOfMonth;
+
+        private static MudDateTime CurrentDateTimeFor(MudDateTime referenceDateTime)
+        {
+            var currentDateTime = new MudDateTime(referenceDateTime.Calendar.CurrentDate,
+                referenceDateTime.Clock.CurrentTime, referenceDateTime.Clock.PrimaryTimezone).GetByTimeZone(
+                referenceDateTime.TimeZone);
+            currentDateTime.Time.DaysOffsetFromDatum = 0;
+            return currentDateTime;
+        }
+
+        private MudDateTime AlignOrdinalDateTime(MudDateTime referenceDateTime, int direction)
+        {
+            var date = AlignOrdinalDate(referenceDateTime.Date, direction);
+            return new MudDateTime(date, MudTime.CopyOf(referenceDateTime.Time, true), referenceDateTime.TimeZone);
+        }
+
+        private MudDate AlignOrdinalDate(MudDate referenceDate, int direction)
+        {
+            var candidate = ResolveOrdinalDateInMonth(referenceDate.Calendar, referenceDate.ThisYear, referenceDate.Month);
+            if (candidate != null && (direction > 0 ? candidate >= referenceDate : candidate <= referenceDate))
+            {
+                return candidate;
+            }
+
+            return MoveOrdinalDate(referenceDate, direction);
+        }
+
+        private MudDateTime MoveDateTimeByInterval(MudDateTime referenceDateTime, int direction)
+        {
+            var newDate = MoveDateByInterval(referenceDateTime.Date, direction);
+            var newTime = MudTime.CopyOf(referenceDateTime.Time);
+            if (Type == IntervalType.Minutely)
+            {
+                newDate = new MudDate(referenceDateTime.Date);
+                newTime.DaysOffsetFromDatum = 0;
+                newTime.AddMinutes(direction * IntervalAmount);
+                ApplyTimeDayOffset(newDate, newTime);
+            }
+            else if (Type == IntervalType.Hourly)
+            {
+                newDate = new MudDate(referenceDateTime.Date);
+                newTime.DaysOffsetFromDatum = 0;
+                newTime.AddHours(direction * IntervalAmount);
+                ApplyTimeDayOffset(newDate, newTime);
+            }
+
+            return new MudDateTime(newDate, newTime, referenceDateTime.TimeZone);
+        }
+
+        private static void ApplyTimeDayOffset(MudDate newDate, MudTime newTime)
+        {
+            if (newTime.DaysOffsetFromDatum != 0)
+            {
+                newDate.AdvanceDays(newTime.DaysOffsetFromDatum);
+                newTime.DaysOffsetFromDatum = 0;
+            }
+        }
+
+        private MudDate MoveDateByInterval(MudDate referenceDate, int direction)
+        {
+            var newDate = new MudDate(referenceDate);
+            switch (Type)
+            {
+                case IntervalType.Minutely:
+                case IntervalType.Hourly:
+                case IntervalType.Daily:
+                    newDate.AdvanceDays(direction * IntervalAmount);
+                    break;
+                case IntervalType.Monthly:
+                    newDate.AdvanceMonths(direction * IntervalAmount, true, true);
+                    break;
+                case IntervalType.SpecificWeekday:
+                    newDate.AdvanceToNextWeekday(Modifier, direction * IntervalAmount);
+                    break;
+                case IntervalType.Weekly:
+                    newDate.AdvanceDays(direction * IntervalAmount * referenceDate.Calendar.Weekdays.Count);
+                    break;
+                case IntervalType.Yearly:
+                    newDate.AdvanceYears(direction * IntervalAmount, true);
+                    break;
+                case IntervalType.OrdinalDayOfMonth:
+                case IntervalType.OrdinalWeekdayOfMonth:
+                    return MoveOrdinalDate(referenceDate, direction);
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+
+            return newDate;
+        }
+
+        private MudDate MoveOrdinalDate(MudDate referenceDate, int direction)
+        {
+            var cursor = new MudDate(referenceDate);
+            for (int i = 0; i < MaxOrdinalMonthSearches; i++)
+            {
+                cursor.AdvanceMonths(direction * IntervalAmount, true, true);
+                var candidate = ResolveOrdinalDateInMonth(cursor.Calendar, cursor.ThisYear, cursor.Month);
+                if (candidate != null)
+                {
+                    return candidate;
+                }
+            }
+
+            throw new InvalidOperationException($"Could not find a valid {Describe(referenceDate.Calendar)} occurrence within {MaxOrdinalMonthSearches.ToString("N0")} searched months.");
+        }
+
+        private MudDate ResolveOrdinalDateInMonth(ICalendar calendar, Year year, Month month)
+        {
+            return Type switch
+            {
+                IntervalType.OrdinalDayOfMonth => ResolveOrdinalDayOfMonth(calendar, year, month),
+                IntervalType.OrdinalWeekdayOfMonth => ResolveOrdinalWeekdayOfMonth(calendar, year, month),
+                _ => throw new InvalidOperationException("ResolveOrdinalDateInMonth called for a non-ordinal interval.")
+            };
+        }
+
+        private MudDate ResolveOrdinalDayOfMonth(ICalendar calendar, Year year, Month month)
+        {
+            var day = Modifier == -1 ? month.Days : Math.Min(Modifier, month.Days);
+            return new MudDate(calendar, day, year.YearName, month, year, false);
+        }
+
+        private MudDate ResolveOrdinalWeekdayOfMonth(ICalendar calendar, Year year, Month month)
+        {
+            MudDate lastMatch = null;
+            var seen = 0;
+            for (int day = 1; day <= month.Days; day++)
+            {
+                var candidate = new MudDate(calendar, day, year.YearName, month, year, false);
+                if (candidate.WeekdayIndex != SecondaryModifier)
+                {
+                    continue;
+                }
+
+                lastMatch = candidate;
+                seen++;
+                if (Modifier > 0 && seen == Modifier)
+                {
+                    return candidate;
+                }
+            }
+
+            if (Modifier == -1 || OrdinalFallbackMode == OrdinalFallbackMode.OrLast)
+            {
+                return lastMatch;
+            }
+
+            return null;
         }
     }
 }

--- a/FutureMUDLibrary/TimeAndDate/MudDateTime.cs
+++ b/FutureMUDLibrary/TimeAndDate/MudDateTime.cs
@@ -172,7 +172,7 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
                     (clock.HoursPerDay / clock.NumberOfHourIntervals);
             }
 
-            MudTime time = new(second, minute, hour, tz, clock, 0);
+            MudTime time = MudTime.FromLocalTime(second, minute, hour, tz, clock);
             dt = new MudDateTime(date, time, tz);
             return true;
         }
@@ -308,7 +308,7 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
                 return Never;
             }
 
-            return new MudDateTime(Date.ConvertToOtherCalendar(convert), new MudTime(Time), TimeZone);
+            return new MudDateTime(Date.ConvertToOtherCalendar(convert), MudTime.CopyOf(Time), TimeZone);
         }
 
         public string ToString(CalendarDisplayMode calendarMode, TimeDisplayTypes clockMode)
@@ -358,7 +358,7 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
             }
 
             Date = new MudDate(rhs.Date);
-            Time = rhs.Time == null ? null : new MudTime(rhs.Time);
+            Time = rhs.Time == null ? null : MudTime.CopyOf(rhs.Time);
             TimeZone = rhs?.TimeZone;
             Gameworld = rhs?.Gameworld ?? Clock?.Gameworld;
         }
@@ -462,7 +462,7 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
                 return Never;
             }
 
-            MudTime newTime = new(dt.Time);
+            MudTime newTime = MudTime.CopyOf(dt.Time);
             newTime.AddSeconds(ts.SecondComponentOnly);
             newTime.AddMinutes(ts.MinuteComponentOnly);
             newTime.AddHours(ts.HourComponentOnly);
@@ -485,7 +485,7 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
                 return Never;
             }
 
-            MudTime newTime = new(dt.Time);
+            MudTime newTime = MudTime.CopyOf(dt.Time);
             newTime.AddSeconds(-1 * ts.SecondComponentOnly);
             newTime.AddMinutes(-1 * ts.MinuteComponentOnly);
             newTime.AddHours(-1 * ts.HourComponentOnly);
@@ -665,7 +665,7 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
                 case "isnever":
                     return new BooleanVariable(Date == null);
                 case "midnight":
-                    return Date == null ? Never : new MudDateTime(Date, new MudTime(0, 0, 0, TimeZone, Clock, 0), TimeZone);
+                    return Date == null ? Never : new MudDateTime(Date, MudTime.FromLocalTime(0, 0, 0, TimeZone, Clock), TimeZone);
                 case "calendar":
                     return Calendar;
                 case "clock":

--- a/FutureMUDLibrary/TimeAndDate/MudDateTime.cs
+++ b/FutureMUDLibrary/TimeAndDate/MudDateTime.cs
@@ -8,6 +8,7 @@ using MudSharp.TimeAndDate.Time;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Numerics;
 using System.Text.RegularExpressions;
 using static System.Runtime.InteropServices.JavaScript.JSType;
@@ -33,9 +34,17 @@ namespace MudSharp.TimeAndDate
 
         public static string TryParseHelpText(ICharacter actor, MudDate date, MudTime time, IMudTimeZone tz)
         {
+            IFormatProvider format = actor as IFormatProvider ?? CultureInfo.InvariantCulture;
+            string exampleDate = date == null
+                ? "1/jan/1"
+                : $"{date.Day.ToString("N0", format)}/{date.Month.Alias}/{date.Year}";
+            string exampleTime = time == null
+                ? "0:0:0"
+                : $"{time.Hours.ToString("N0", format)}:{time.Minutes.ToString("N0", format)}:{time.Seconds.ToString("N0", format)}";
+            string timezoneName = tz?.Name ?? "UTC";
             return $@"Valid input is in the form #3<date> <time>#0, where the components are explained below. 
 
-For example, this is one way that you could enter the current date and time: #3{date.Day.ToString("N0", actor)}/{date.Month.Alias}/{date.Year} {time.Hours.ToString("N0", actor)}:{time.Minutes.ToString("N0", actor)}:{time.Seconds.ToString("N0", actor)} {tz.Name}#0
+For example, this is one way that you could enter the current date and time: #3{exampleDate} {exampleTime} {timezoneName}#0
 You can also enter the special values #3never#0 and #3now#0.
 
 #6Dates#0
@@ -59,8 +68,20 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
 
         public static string TryParseHelpText(ICharacter actor)
         {
+            if (actor?.Location == null)
+            {
+                return TryParseHelpText(actor, null, null, null);
+            }
+
             return TryParseHelpText(actor, actor.Location.Date(null), actor.Location.Time(null),
                 actor.Location.TimeZone(null));
+        }
+
+        private static string TryParseHelpText(ICharacter actor, ICalendar calendar, IClock clock)
+        {
+            return actor == null
+                ? TryParseHelpText(actor, calendar?.CurrentDate, clock?.CurrentTime, clock?.PrimaryTimezone)
+                : TryParseHelpText(actor);
         }
 
         public static string TryParseHelpText(ICharacter actor, IEconomicZone zone)
@@ -82,10 +103,22 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
         {
             dt = null;
             error = string.Empty;
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                error = TryParseHelpText(actor, calendar, clock);
+                return false;
+            }
+
             if (text.Equals("never", StringComparison.InvariantCultureIgnoreCase))
             {
                 dt = Never;
                 return true;
+            }
+
+            if ((calendar == null) || (clock == null))
+            {
+                error = TryParseHelpText(actor, calendar, clock);
+                return false;
             }
 
             if (text.Equals("now", StringComparison.InvariantCultureIgnoreCase))
@@ -100,16 +133,10 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
                 return true;
             }
 
-            if (string.IsNullOrEmpty(text) || (calendar == null) || (clock == null))
-            {
-                error = TryParseHelpText(actor);
-                return false;
-            }
-
             Match regexMatch = AlternatePlayerParseRegex.Match(text);
             if (!regexMatch.Success)
             {
-                error = TryParseHelpText(actor);
+                error = TryParseHelpText(actor, calendar, clock);
                 return false;
             }
 
@@ -121,16 +148,31 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
             int hour = int.Parse(regexMatch.Groups["hour"].Value);
             int minute = int.Parse(regexMatch.Groups["minute"].Value);
             int second = regexMatch.Groups["second"].Length > 0 ? int.Parse(regexMatch.Groups["second"].Value) : 0;
-            IMudTimeZone tz = regexMatch.Groups["timezone"].Length > 0 ? clock.Timezones.GetByIdOrName(regexMatch.Groups["timezone"].Value) ?? clock.PrimaryTimezone : clock.PrimaryTimezone;
+            IMudTimeZone tz = regexMatch.Groups["timezone"].Length > 0
+                ? clock.Timezones.GetByIdOrName(regexMatch.Groups["timezone"].Value)
+                : clock.PrimaryTimezone;
+            if (tz == null)
+            {
+                error = $"The timezone \"{regexMatch.Groups["timezone"].Value}\" is not valid.";
+                return false;
+            }
+
             if (regexMatch.Groups["period"].Length > 0)
             {
+                int hourInterval = clock.HourIntervalNames.FindIndex(
+                    x => x.Equals(regexMatch.Groups["period"].Value, StringComparison.InvariantCultureIgnoreCase));
+                if (hourInterval < 0)
+                {
+                    error = $"The hour period \"{regexMatch.Groups["period"].Value}\" is not valid.";
+                    return false;
+                }
+
                 hour +=
-                    clock.HourIntervalNames.FindIndex(
-                        x => x.Equals(regexMatch.Groups["period"].Value, StringComparison.InvariantCultureIgnoreCase)) *
+                    hourInterval *
                     (clock.HoursPerDay / clock.NumberOfHourIntervals);
             }
 
-            MudTime time = new(second, minute, hour, tz, clock, false);
+            MudTime time = new(second, minute, hour, tz, clock, 0);
             dt = new MudDateTime(date, time, tz);
             return true;
         }
@@ -147,20 +189,28 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
         {
 
             dt = null;
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return false;
+            }
+
             if (text.Equals("never", StringComparison.InvariantCultureIgnoreCase))
             {
                 dt = Never;
                 return true;
             }
-            if (text.Equals("now", StringComparison.InvariantCultureIgnoreCase))
-            {
-                dt = calendar.CurrentDateTime;
-            }
 
-            if (string.IsNullOrEmpty(text) || (calendar == null) || (clock == null))
+            if ((calendar == null) || (clock == null))
             {
                 return false;
             }
+
+            if (text.Equals("now", StringComparison.InvariantCultureIgnoreCase))
+            {
+                dt = calendar.CurrentDateTime;
+                return true;
+            }
+
             Match match = PlayerParseRegex.Match(text);
             if (!match.Success)
             {
@@ -176,7 +226,7 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
                 {
                     return false;
                 }
-                MudTime time = clock.GetTime(match.Groups["time"].Value);
+                MudTime time = clock.GetTime($"{timezone.Alias} {match.Groups["time"].Value}");
                 dt = new MudDateTime(date, time, timezone);
                 return true;
             }
@@ -188,12 +238,17 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
         public static bool TryParse(string text, IFuturemud gameworld, out MudDateTime dt)
         {
             dt = null;
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return false;
+            }
+
             if (text.Equals("never", StringComparison.InvariantCultureIgnoreCase))
             {
                 dt = Never;
                 return true;
             }
-            if (string.IsNullOrEmpty(text) || (gameworld == null))
+            if (gameworld == null)
             {
                 return false;
             }
@@ -248,6 +303,11 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
 
         public MudDateTime ConvertToOtherCalendar(ICalendar convert)
         {
+            if (Date == null)
+            {
+                return Never;
+            }
+
             return new MudDateTime(Date.ConvertToOtherCalendar(convert), new MudTime(Time), TimeZone);
         }
 
@@ -288,19 +348,30 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
 
         public MudDateTime(MudDateTime rhs)
         {
-            Date = new MudDate(rhs?.Date);
-            Time = new MudTime(rhs?.Time);
-            TimeZone = rhs?.TimeZone;
-            Gameworld = Clock.Gameworld;
-        }
-
-        public MudDateTime(string text, ICalendar calendar, IClock clock)
-        {
-            if (text.Equals("Never"))
+            if (rhs?.Date == null)
             {
                 Date = null;
                 Time = null;
                 TimeZone = null;
+                Gameworld = rhs?.Gameworld;
+                return;
+            }
+
+            Date = new MudDate(rhs.Date);
+            Time = rhs.Time == null ? null : new MudTime(rhs.Time);
+            TimeZone = rhs?.TimeZone;
+            Gameworld = rhs?.Gameworld ?? Clock?.Gameworld;
+        }
+
+        public MudDateTime(string text, ICalendar calendar, IClock clock)
+        {
+            Gameworld = clock?.Gameworld;
+            if (text.Equals("Never", StringComparison.InvariantCultureIgnoreCase))
+            {
+                Date = null;
+                Time = null;
+                TimeZone = null;
+                return;
             }
             else
             {
@@ -309,14 +380,12 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
                 TimeZone = clock.Timezones.GetByIdOrName(splitText[1]);
                 Time = clock.GetTime($"{splitText[1]} {splitText[2]}");
             }
-
-            Gameworld = Clock.Gameworld;
         }
 
         public MudDateTime(string text, IFuturemud gameworld)
         {
             Gameworld = gameworld;
-            if (text.Equals("Never"))
+            if (text.Equals("Never", StringComparison.InvariantCultureIgnoreCase))
             {
                 Date = null;
                 Time = null;
@@ -378,7 +447,7 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
                 return Equals(this, objAsDateTime);
             }
 
-            return obj is MudDate objAsDate && Date.Equals(objAsDate);
+            return obj is MudDate objAsDate && Date?.Equals(objAsDate) == true;
         }
 
         public override int GetHashCode()
@@ -400,6 +469,7 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
 
             MudDate newDate = new(dt.Date);
             newDate.AdvanceDays(newTime.DaysOffsetFromDatum);
+            newTime.DaysOffsetFromDatum = 0;
             newDate.AdvanceDays(ts.DayComponentOnly);
             newDate.AdvanceDays(newDate.Calendar.Weekdays.Count * ts.Weeks);
             newDate.AdvanceMonths(ts.Months, false, true);
@@ -416,12 +486,13 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
             }
 
             MudTime newTime = new(dt.Time);
-            newTime.AddSeconds(-1 * ts.Seconds);
-            newTime.AddMinutes(-1 * ts.Minutes);
-            newTime.AddHours(-1 * ts.Hours);
+            newTime.AddSeconds(-1 * ts.SecondComponentOnly);
+            newTime.AddMinutes(-1 * ts.MinuteComponentOnly);
+            newTime.AddHours(-1 * ts.HourComponentOnly);
 
             MudDate newDate = new(dt.Date);
             newDate.AdvanceDays(newTime.DaysOffsetFromDatum);
+            newTime.DaysOffsetFromDatum = 0;
             newDate.AdvanceDays(-1 * ts.DayComponentOnly);
             newDate.AdvanceDays(-1 * newDate.Calendar.Weekdays.Count * ts.Weeks);
             newDate.AdvanceMonths(-1 * ts.Months, false, true);
@@ -594,7 +665,7 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
                 case "isnever":
                     return new BooleanVariable(Date == null);
                 case "midnight":
-                    return new MudDateTime(Date, new MudTime(0, 0, 0, TimeZone, Clock, false), TimeZone);
+                    return Date == null ? Never : new MudDateTime(Date, new MudTime(0, 0, 0, TimeZone, Clock, 0), TimeZone);
                 case "calendar":
                     return Calendar;
                 case "clock":
@@ -699,9 +770,9 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
 
         public static int CompareTo(MudDateTime left, MudDateTime right)
         {
-            if (left is null)
+            if (left?.Date == null)
             {
-                if (right is null)
+                if (right?.Date == null)
                 {
                     return 0;
                 }
@@ -709,7 +780,7 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
                 return -1;
             }
 
-            if (right is null)
+            if (right?.Date == null)
             {
                 return 1;
             }

--- a/FutureMUDLibrary/TimeAndDate/MudTimeSpan.cs
+++ b/FutureMUDLibrary/TimeAndDate/MudTimeSpan.cs
@@ -47,15 +47,15 @@ namespace MudSharp.TimeAndDate
 
         public int MillisecondComponentOnly => (int)_milliseconds;
 
-        public int Seconds => (int)(Milliseconds % SecondsPerMillisecond);
+        public int Seconds => (int)(Milliseconds / MillisecondsPerSecond);
 
         public int SecondComponentOnly => (int)(_milliseconds % MillisecondsPerMinute / MillisecondsPerSecond);
 
-        public int Minutes => (int)(Milliseconds % MillisecondsPerMinute);
+        public int Minutes => (int)(Milliseconds / MillisecondsPerMinute);
 
         public int MinuteComponentOnly => (int)(_milliseconds % MillisecondsPerHour / MillisecondsPerMinute);
 
-        public int Hours => (int)(Milliseconds % MillisecondsPerHour);
+        public int Hours => (int)(Milliseconds / MillisecondsPerHour);
 
         public int HourComponentOnly => (int)((_milliseconds % MillisecondsPerDay) / MillisecondsPerHour);
 

--- a/FutureMUDLibrary/TimeAndDate/Time/Time.cs
+++ b/FutureMUDLibrary/TimeAndDate/Time/Time.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using MudSharp.Framework;
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace MudSharp.TimeAndDate.Time
 {
@@ -146,11 +146,192 @@ namespace MudSharp.TimeAndDate.Time
 
         #region Constructors
 
-        public MudTime(string timestring, IClock clock)
+        private static readonly Regex TimeTokenRegex =
+            new(@"^(?<hours>\d+):(?<minutes>\d+)(?::(?<seconds>\d+)){0,1}(?<meridian>[a-z]+){0,1}$",
+                RegexOptions.IgnoreCase);
+
+        private static void ValidateComponents(int seconds, int minutes, int hours, IMudTimeZone timezone, IClock clock)
+        {
+            if (clock == null)
+            {
+                throw new ArgumentNullException(nameof(clock));
+            }
+
+            if (timezone == null)
+            {
+                throw new ArgumentNullException(nameof(timezone));
+            }
+
+            if (timezone.Clock != null && !ReferenceEquals(timezone.Clock, clock) && !clock.Timezones.Contains(timezone))
+            {
+                throw new ArgumentException("The timezone does not belong to the specified clock.", nameof(timezone));
+            }
+
+            if (seconds < 0 || seconds >= clock.SecondsPerMinute)
+            {
+                throw new ArgumentOutOfRangeException(nameof(seconds));
+            }
+
+            if (minutes < 0 || minutes >= clock.MinutesPerHour)
+            {
+                throw new ArgumentOutOfRangeException(nameof(minutes));
+            }
+
+            if (hours < 0 || hours >= clock.HoursPerDay)
+            {
+                throw new ArgumentOutOfRangeException(nameof(hours));
+            }
+        }
+
+        public static MudTime CreatePrimaryTime(int seconds, int minutes, int hours, IMudTimeZone timezone, IClock clock)
+        {
+            ValidateComponents(seconds, minutes, hours, timezone, clock);
+            return new MudTime(seconds, minutes, hours, timezone, clock, true);
+        }
+
+        public static MudTime FromPrimaryTime(int seconds, int minutes, int hours, IMudTimeZone timezone, IClock clock)
+        {
+            ValidateComponents(seconds, minutes, hours, timezone, clock);
+            return new MudTime(seconds, minutes, hours, timezone, clock, false);
+        }
+
+        public static MudTime FromLocalTime(int seconds, int minutes, int hours, IMudTimeZone timezone, IClock clock, int daysOffsetFromDatum = 0)
+        {
+            ValidateComponents(seconds, minutes, hours, timezone, clock);
+            return new MudTime(seconds, minutes, hours, timezone, clock, daysOffsetFromDatum);
+        }
+
+        public static MudTime CopyOf(MudTime rhs, bool resetDaysOffsetFromDatum = false)
+        {
+            if (rhs == null)
+            {
+                throw new ArgumentNullException(nameof(rhs));
+            }
+
+            var copy = new MudTime(rhs);
+            if (resetDaysOffsetFromDatum)
+            {
+                copy._daysOffsetFromDatum = 0;
+            }
+
+            return copy;
+        }
+
+        public static MudTime ParseLocalTime(string timestring, IClock clock)
+        {
+            if (!TryParseLocalTime(timestring, clock, out var time, out var error))
+            {
+                throw new ArgumentException(error, nameof(timestring));
+            }
+
+            return time;
+        }
+
+        public static bool TryParseLocalTime(string timestring, IClock clock, out MudTime time, out string error)
+        {
+            time = null;
+            error = string.Empty;
+            if (clock == null)
+            {
+                error = "No clock was supplied.";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(timestring))
+            {
+                error = "No time string was supplied.";
+                return false;
+            }
+
+            var tokens = timestring.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries).ToList();
+            var timeIndex = tokens.FindIndex(x => x.Contains(':'));
+            if (timeIndex < 0)
+            {
+                error = "The time string does not contain a time component.";
+                return false;
+            }
+
+            var match = TimeTokenRegex.Match(tokens[timeIndex]);
+            if (!match.Success)
+            {
+                error = "The time component was not valid.";
+                return false;
+            }
+
+            var meridian = match.Groups["meridian"].Success ? match.Groups["meridian"].Value : string.Empty;
+            var timezoneText = string.Empty;
+            foreach (var token in tokens.Where((_, index) => index != timeIndex))
+            {
+                if (string.IsNullOrEmpty(meridian) &&
+                    clock.HourIntervalNames.Any(x => x.Equals(token, StringComparison.InvariantCultureIgnoreCase)))
+                {
+                    meridian = token;
+                    continue;
+                }
+
+                if (!string.IsNullOrEmpty(timezoneText))
+                {
+                    error = "The time string contained more than one timezone or unknown token.";
+                    return false;
+                }
+
+                timezoneText = token;
+            }
+
+            var timezone = string.IsNullOrEmpty(timezoneText)
+                ? clock.PrimaryTimezone
+                : clock.Timezones.GetByIdOrName(timezoneText);
+            if (timezone == null)
+            {
+                error = $"The timezone \"{timezoneText}\" is not valid.";
+                return false;
+            }
+
+            var hours = int.Parse(match.Groups["hours"].Value);
+            var minutes = int.Parse(match.Groups["minutes"].Value);
+            var seconds = match.Groups["seconds"].Success ? int.Parse(match.Groups["seconds"].Value) : 0;
+
+            if (!string.IsNullOrEmpty(meridian))
+            {
+                var hourInterval = clock.HourIntervalNames.FindIndex(
+                    x => x.Equals(meridian, StringComparison.InvariantCultureIgnoreCase));
+                if (hourInterval < 0)
+                {
+                    error = $"The hour period \"{meridian}\" is not valid.";
+                    return false;
+                }
+
+                var intervalLength = clock.HoursPerDay / clock.NumberOfHourIntervals;
+                if (clock.NoZeroHour && hours == intervalLength)
+                {
+                    hours = 0;
+                }
+
+                hours += hourInterval * intervalLength;
+            }
+
+            try
+            {
+                time = FromLocalTime(seconds, minutes, hours, timezone, clock);
+                return true;
+            }
+            catch (ArgumentOutOfRangeException ex)
+            {
+                error = $"The {ex.ParamName} component is out of range for this clock.";
+                return false;
+            }
+            catch (ArgumentException ex)
+            {
+                error = ex.Message;
+                return false;
+            }
+        }
+
+        private MudTime(string timestring, IClock clock)
         {
             string[] split1 = timestring.Split(' ');
             _timezone = clock.Timezones.First(x => x.Name.EqualTo(split1[0]));
-            List<int> split = split1[1].Split(':').Select(int.Parse).ToList();
+            var split = split1[1].Split(':').Select(int.Parse).ToList();
             _seconds = split[2];
             _minutes = split[1];
             _hours = split[0];
@@ -158,7 +339,7 @@ namespace MudSharp.TimeAndDate.Time
             _isPrimaryTime = false;
         }
 
-        public MudTime(int seconds, int minutes, int hours, IMudTimeZone timezone, IClock clock, bool isprimarytime)
+        private MudTime(int seconds, int minutes, int hours, IMudTimeZone timezone, IClock clock, bool isprimarytime)
         {
             _seconds = seconds;
             _minutes = minutes;
@@ -182,7 +363,7 @@ namespace MudSharp.TimeAndDate.Time
             }
         }
 
-        public MudTime(int seconds, int minutes, int hours, IMudTimeZone timezone, IClock clock, int daysOffset)
+        private MudTime(int seconds, int minutes, int hours, IMudTimeZone timezone, IClock clock, int daysOffset)
         {
             _seconds = seconds;
             _minutes = minutes;
@@ -197,7 +378,7 @@ namespace MudSharp.TimeAndDate.Time
         ///     Copy Constructor
         /// </summary>
         /// <param name="rhs">Time to copy</param>
-        public MudTime(MudTime rhs)
+        private MudTime(MudTime rhs)
         {
             _seconds = rhs.Seconds;
             _minutes = rhs.Minutes;
@@ -442,7 +623,7 @@ namespace MudSharp.TimeAndDate.Time
             // C# % operator is simple remainder not actual modulus. Hence the extension method.
             newMinutes = newMinutes.Modulus(Clock.MinutesPerHour);
             newHours = newHours.Modulus(Clock.HoursPerDay);
-            return new MudTime(Seconds, newMinutes, newHours, timezone, Clock,
+            return FromLocalTime(Seconds, newMinutes, newHours, timezone, Clock,
                 daysOffset);
         }
 
@@ -525,7 +706,7 @@ namespace MudSharp.TimeAndDate.Time
 
         public static MudTime operator +(MudTime time, TimeSpan ts)
         {
-            time = new MudTime(time) { _daysOffsetFromDatum = 0 };
+            time = CopyOf(time, true);
             time.AddSeconds(ts.Seconds);
             time.AddMinutes(ts.Minutes);
             time.AddHours(ts.Hours);
@@ -534,7 +715,7 @@ namespace MudSharp.TimeAndDate.Time
 
         public static MudTime operator -(MudTime time, TimeSpan ts)
         {
-            time = new MudTime(time) { _daysOffsetFromDatum = 0 };
+            time = CopyOf(time, true);
             time.AddSeconds(-1 * ts.Seconds);
             time.AddMinutes(-1 * ts.Minutes);
             time.AddHours(-1 * ts.Hours);

--- a/MudSharpCore Unit Tests/FutureProgDateTimeFunctionTests.cs
+++ b/MudSharpCore Unit Tests/FutureProgDateTimeFunctionTests.cs
@@ -102,7 +102,7 @@ public class FutureProgDateTimeFunctionTests
 
 		var result = prog.Execute<MudDateTime>(reference);
 
-		Assert.AreEqual("6/april/2026", result.Date.GetDateString());
+		Assert.AreEqual("3/april/2026", result.Date.GetDateString());
 		Assert.AreEqual("Friday", result.Date.Weekday);
 		Assert.AreEqual(9, result.Time.Hours);
 	}
@@ -122,7 +122,7 @@ public class FutureProgDateTimeFunctionTests
 
 		var result = prog.Execute<MudDateTime>(reference);
 
-		Assert.AreEqual("6/april/2026", result.Date.GetDateString());
+		Assert.AreEqual("3/april/2026", result.Date.GetDateString());
 		Assert.AreEqual("Friday", result.Date.Weekday);
 	}
 
@@ -203,6 +203,23 @@ public class FutureProgDateTimeFunctionTests
 
 		Assert.IsTrue(prog.ExecuteBool(TimeSpan.FromHours(2), TimeSpan.FromHours(1), TimeSpan.FromHours(3)));
 		Assert.IsFalse(prog.ExecuteBool(TimeSpan.FromHours(4), TimeSpan.FromHours(1), TimeSpan.FromHours(3)));
+	}
+
+	[TestMethod]
+	public void ToMudDate_InvalidText_ReturnsNever()
+	{
+		var prog = Compile<MudDateTime>(
+			"ToMudDateInvalidText",
+			ProgVariableTypes.MudDateTime,
+			[
+				Tuple.Create(ProgVariableTypes.Calendar, "calendar"),
+				Tuple.Create(ProgVariableTypes.Clock, "clock")
+			],
+			@"return ToDate(@calendar, @clock, ""not-a-date"")");
+
+		var result = prog.Execute<MudDateTime>(_calendar, _clock);
+
+		Assert.IsTrue(result.Equals(MudDateTime.Never));
 	}
 
 	private static FutureProg Compile<T>(string name, ProgVariableTypes returnType,

--- a/MudSharpCore Unit Tests/FutureProgDateTimeFunctionTests.cs
+++ b/MudSharpCore Unit Tests/FutureProgDateTimeFunctionTests.cs
@@ -44,7 +44,7 @@ public class FutureProgDateTimeFunctionTests
 		};
 		_timezone = new MudTimeZone(1, 0, 0, "Universal Time Clock", "UTC");
 		_clock.AddTimezone(_timezone);
-		_clock.SetTime(new MudTime(0, 0, 0, _timezone, _clock, true));
+		_clock.SetTime(MudTime.CreatePrimaryTime(0, 0, 0, _timezone, _clock));
 		clocks.Add(_clock);
 
 		var calendar = new Calendar(1, gameworld.Object);
@@ -98,7 +98,7 @@ public class FutureProgDateTimeFunctionTests
 			],
 			@"return LastWeekday(@date, ""Friday"")");
 		var reference = new MudDateTime(_calendar.GetDate("8/apr/2026"),
-			new MudTime(0, 0, 9, _timezone, _clock, false), _timezone);
+			MudTime.FromLocalTime(0, 0, 9, _timezone, _clock), _timezone);
 
 		var result = prog.Execute<MudDateTime>(reference);
 
@@ -118,7 +118,7 @@ public class FutureProgDateTimeFunctionTests
 			],
 			@"return NextWeekday(@date, ""Friday"", -1)");
 		var reference = new MudDateTime(_calendar.GetDate("8/apr/2026"),
-			new MudTime(0, 0, 9, _timezone, _clock, false), _timezone);
+			MudTime.FromLocalTime(0, 0, 9, _timezone, _clock), _timezone);
 
 		var result = prog.Execute<MudDateTime>(reference);
 
@@ -175,13 +175,13 @@ public class FutureProgDateTimeFunctionTests
 			],
 			"return Between(@date, @high, @low)");
 		var low = new MudDateTime(_calendar.GetDate("20/apr/2026"),
-			new MudTime(0, 0, 0, _timezone, _clock, false), _timezone);
+			MudTime.FromLocalTime(0, 0, 0, _timezone, _clock), _timezone);
 		var middle = new MudDateTime(_calendar.GetDate("21/apr/2026"),
-			new MudTime(0, 0, 0, _timezone, _clock, false), _timezone);
+			MudTime.FromLocalTime(0, 0, 0, _timezone, _clock), _timezone);
 		var high = new MudDateTime(_calendar.GetDate("22/apr/2026"),
-			new MudTime(0, 0, 0, _timezone, _clock, false), _timezone);
+			MudTime.FromLocalTime(0, 0, 0, _timezone, _clock), _timezone);
 		var outside = new MudDateTime(_calendar.GetDate("23/apr/2026"),
-			new MudTime(0, 0, 0, _timezone, _clock, false), _timezone);
+			MudTime.FromLocalTime(0, 0, 0, _timezone, _clock), _timezone);
 
 		Assert.IsTrue(prog.ExecuteBool(low, low, high));
 		Assert.IsTrue(prog.ExecuteBool(middle, low, high));

--- a/MudSharpCore Unit Tests/MudDateTimeTests.cs
+++ b/MudSharpCore Unit Tests/MudDateTimeTests.cs
@@ -79,7 +79,7 @@ public class MudDateTimeTests
         _testClock.AddTimezone(_utcTimezone);
         _cstTimezone = new MudTimeZone(2, -6, 0, "Central Time", "CST");
         _testClock.AddTimezone(_cstTimezone);
-        _testClock.SetTime(new MudTime(0, 0, 0, _utcTimezone, _testClock, true));
+        _testClock.SetTime(MudTime.CreatePrimaryTime(0, 0, 0, _utcTimezone, _testClock));
     }
     //
     // Use ClassCleanup to run code after all tests in a class have run
@@ -91,7 +91,7 @@ public class MudDateTimeTests
     public void MyTestInitialize()
     {
         _testCalendar.SetDate("27/jun/34");
-        _testClock.SetTime(new MudTime(0, 0, 0, _utcTimezone, _testClock, true));
+        _testClock.SetTime(MudTime.CreatePrimaryTime(0, 0, 0, _utcTimezone, _testClock));
     }
 
     // Use TestCleanup to run code after each test has run
@@ -901,10 +901,10 @@ public class MudDateTimeTests
     public void RecurringInterval_SpecificWeekday_BackwardReturnsPriorWeekday()
     {
         _testCalendar.SetDate("7/jung/34");
-        _testClock.SetTime(new MudTime(0, 0, 10, _utcTimezone, _testClock, true));
+        _testClock.SetTime(MudTime.CreatePrimaryTime(0, 0, 10, _utcTimezone, _testClock));
         MudDate priorMatchingDate = _testCalendar.CurrentDate;
         MudDateTime reference = new(_testCalendar.GetDate("8/jung/34"),
-            new MudTime(0, 0, 9, _utcTimezone, _testClock, 0), _utcTimezone);
+            MudTime.FromLocalTime(0, 0, 9, _utcTimezone, _testClock), _utcTimezone);
         RecurringInterval interval = new()
         {
             IntervalAmount = 1,
@@ -936,7 +936,7 @@ public class MudDateTimeTests
     public void MudDateTime_AddSubtractTimeSpan_RoundTripsAcrossBoundaries()
     {
         MudDateTime start = new(_testCalendar.GetDate("27/jung/34"),
-            new MudTime(30, 59, 23, _utcTimezone, _testClock, 0), _utcTimezone);
+            MudTime.FromLocalTime(30, 59, 23, _utcTimezone, _testClock), _utcTimezone);
         MudTimeSpan duration = MudTimeSpan.FromMinutes(2);
 
         MudDateTime advanced = start + duration;
@@ -990,6 +990,90 @@ public class MudDateTimeTests
         Assert.AreEqual(calendar.CountWeekdaysInYear(1), year.Months.Sum(x => x.CountWeekdays()));
     }
 
+    [TestMethod]
+    public void RecurringInterval_HighOrdinalWeekday_UsesCalendarWeekAndLongMonth()
+    {
+        Calendar calendar = CreateOrdinalCalendar();
+        calendar.SetDate("1/long/1");
+        _testClock.SetTime(MudTime.CreatePrimaryTime(0, 0, 0, _utcTimezone, _testClock));
+        Assert.IsTrue(RecurringInterval.TryParse("every month on the 12th Marketday", calendar, out RecurringInterval interval, out string error), error);
+
+        MudDateTime reference = new(calendar.CurrentDate,
+            MudTime.FromLocalTime(0, 0, 0, _utcTimezone, _testClock), _utcTimezone);
+        MudDateTime result = interval.GetNextDateTime(reference);
+
+        Assert.AreEqual("long", result.Date.Month.Alias);
+        Assert.AreEqual(67, result.Date.Day);
+        Assert.AreEqual("Marketday", result.Date.Weekday);
+    }
+
+    [TestMethod]
+    public void RecurringInterval_ExactOrdinalWeekday_SkipsMonthsWithoutOccurrence()
+    {
+        Calendar calendar = CreateOrdinalCalendar();
+        calendar.SetDate("1/short/1");
+        _testClock.SetTime(MudTime.CreatePrimaryTime(0, 0, 0, _utcTimezone, _testClock));
+        Assert.IsTrue(RecurringInterval.TryParse("every month on the 3rd Marketday", calendar, out RecurringInterval interval, out string error), error);
+
+        MudDateTime reference = new(calendar.CurrentDate,
+            MudTime.FromLocalTime(0, 0, 0, _utcTimezone, _testClock), _utcTimezone);
+        MudDateTime result = interval.GetNextDateTime(reference);
+
+        Assert.AreEqual("long", result.Date.Month.Alias);
+        Assert.AreEqual(13, result.Date.Day);
+        Assert.AreEqual("Marketday", result.Date.Weekday);
+    }
+
+    [TestMethod]
+    public void RecurringInterval_OrdinalWeekdayOrLast_FallsBackInShortMonths()
+    {
+        Calendar calendar = CreateOrdinalCalendar();
+        calendar.SetDate("1/short/1");
+        _testClock.SetTime(MudTime.CreatePrimaryTime(0, 0, 0, _utcTimezone, _testClock));
+        Assert.IsTrue(RecurringInterval.TryParse("every month on the 3rd or last Marketday", calendar, out RecurringInterval interval, out string error), error);
+
+        MudDateTime reference = new(calendar.CurrentDate,
+            MudTime.FromLocalTime(0, 0, 0, _utcTimezone, _testClock), _utcTimezone);
+        MudDateTime result = interval.GetNextDateTime(reference);
+
+        Assert.AreEqual("short", result.Date.Month.Alias);
+        Assert.AreEqual(7, result.Date.Day);
+        Assert.AreEqual("Marketday", result.Date.Weekday);
+    }
+
+    [TestMethod]
+    public void RecurringInterval_OrdinalDayOfMonth_ClampsToLastValidDay()
+    {
+        Calendar calendar = CreateOrdinalCalendar();
+        calendar.SetDate("1/short/1");
+        _testClock.SetTime(MudTime.CreatePrimaryTime(0, 0, 0, _utcTimezone, _testClock));
+        Assert.IsTrue(RecurringInterval.TryParse("every month on day 15", calendar, out RecurringInterval interval, out string error), error);
+
+        MudDateTime reference = new(calendar.CurrentDate,
+            MudTime.FromLocalTime(0, 0, 0, _utcTimezone, _testClock), _utcTimezone);
+        MudDateTime result = interval.GetNextDateTime(reference);
+
+        Assert.AreEqual("short", result.Date.Month.Alias);
+        Assert.AreEqual(12, result.Date.Day);
+    }
+
+    [TestMethod]
+    public void RecurringInterval_OrdinalWeekday_BackwardSearchFindsPriorOccurrence()
+    {
+        Calendar calendar = CreateOrdinalCalendar();
+        calendar.SetDate("1/short/2");
+        _testClock.SetTime(MudTime.CreatePrimaryTime(0, 0, 0, _utcTimezone, _testClock));
+        Assert.IsTrue(RecurringInterval.TryParse("every month on the 3rd Marketday", calendar, out RecurringInterval interval, out string error), error);
+
+        MudDateTime reference = new(calendar.CurrentDate,
+            MudTime.FromLocalTime(0, 0, 0, _utcTimezone, _testClock), _utcTimezone);
+        MudDateTime result = interval.GetLastDateTime(reference);
+
+        Assert.AreEqual(1, result.Date.Year);
+        Assert.AreEqual("long", result.Date.Month.Alias);
+        Assert.AreEqual(13, result.Date.Day);
+    }
+
     private static Calendar CreateFiveWeekdayCalendar()
     {
         return new Calendar(XElement.Parse(@"<calendar>
@@ -1031,6 +1115,62 @@ public class MudDateTimeTests
 </calendar>"), _gameworld)
         {
             Id = 101,
+            FeedClock = _testClock
+        };
+    }
+
+    private static Calendar CreateOrdinalCalendar()
+    {
+        return new Calendar(XElement.Parse(@"<calendar>
+  <alias>ordinal</alias>
+  <shortname>Ordinal Calendar</shortname>
+  <fullname>Ordinal Calendar</fullname>
+  <description>Calendar with a six day week and long months.</description>
+  <shortstring>$dd/$mo/$yy</shortstring>
+  <longstring>$dd/$mo/$yy</longstring>
+  <wordystring>$dd/$mo/$yy</wordystring>
+  <plane>test</plane>
+  <feedclock>0</feedclock>
+  <epochyear>1</epochyear>
+  <weekdayatepoch>0</weekdayatepoch>
+  <ancienterashortstring>BT</ancienterashortstring>
+  <ancienteralongstring>before test</ancienteralongstring>
+  <modernerashortstring>AT</modernerashortstring>
+  <moderneralongstring>after test</moderneralongstring>
+  <weekdays>
+    <weekday>Marketday</weekday>
+    <weekday>Moonday</weekday>
+    <weekday>Starday</weekday>
+    <weekday>Fireday</weekday>
+    <weekday>Waterday</weekday>
+    <weekday>Restday</weekday>
+  </weekdays>
+  <months>
+    <month>
+      <alias>short</alias>
+      <shortname>short</shortname>
+      <fullname>Short</fullname>
+      <nominalorder>1</nominalorder>
+      <normaldays>12</normaldays>
+      <intercalarydays />
+      <specialdays />
+      <nonweekdays />
+    </month>
+    <month>
+      <alias>long</alias>
+      <shortname>long</shortname>
+      <fullname>Long</fullname>
+      <nominalorder>2</nominalorder>
+      <normaldays>72</normaldays>
+      <intercalarydays />
+      <specialdays />
+      <nonweekdays />
+    </month>
+  </months>
+  <intercalarymonths />
+</calendar>"), _gameworld)
+        {
+            Id = 103,
             FeedClock = _testClock
         };
     }
@@ -1102,16 +1242,16 @@ public class MudDateTimeTests
     [TestMethod]
     public void TestTimeDescribers()
     {
-        Assert.AreEqual("1:38:49 a.m", _testClock.DisplayTime(new MudTime(49, 38, 1, _utcTimezone, _testClock, 0), "$j:$m:$s $i"));
-        Assert.AreEqual("12:00:00 a.m", _testClock.DisplayTime(new MudTime(0, 0, 0, _utcTimezone, _testClock, 0), "$j:$m:$s $i"));
-        Assert.AreEqual("12:00:01 a.m", _testClock.DisplayTime(new MudTime(1, 0, 0, _utcTimezone, _testClock, 0), "$j:$m:$s $i"));
-        Assert.AreEqual("11:59:59 p.m", _testClock.DisplayTime(new MudTime(59, 59, 23, _utcTimezone, _testClock, 0), "$j:$m:$s $i"));
-        Assert.AreEqual("23:59:59", _testClock.DisplayTime(new MudTime(59, 59, 23, _utcTimezone, _testClock, 0), "$h:$m:$s"));
-        Assert.AreEqual("1:38:49", _testClock.DisplayTime(new MudTime(49, 38, 1, _utcTimezone, _testClock, 0), "$h:$m:$s"));
-        Assert.AreEqual("twelve o'clock a.m", _testClock.DisplayTime(new MudTime(59, 59, 23, _utcTimezone, _testClock, 0), "$c $l"));
-        Assert.AreEqual("twelve o'clock a.m", _testClock.DisplayTime(new MudTime(0, 0, 0, _utcTimezone, _testClock, 0), "$c $l"));
+        Assert.AreEqual("1:38:49 a.m", _testClock.DisplayTime(MudTime.FromLocalTime(49, 38, 1, _utcTimezone, _testClock), "$j:$m:$s $i"));
+        Assert.AreEqual("12:00:00 a.m", _testClock.DisplayTime(MudTime.FromLocalTime(0, 0, 0, _utcTimezone, _testClock), "$j:$m:$s $i"));
+        Assert.AreEqual("12:00:01 a.m", _testClock.DisplayTime(MudTime.FromLocalTime(1, 0, 0, _utcTimezone, _testClock), "$j:$m:$s $i"));
+        Assert.AreEqual("11:59:59 p.m", _testClock.DisplayTime(MudTime.FromLocalTime(59, 59, 23, _utcTimezone, _testClock), "$j:$m:$s $i"));
+        Assert.AreEqual("23:59:59", _testClock.DisplayTime(MudTime.FromLocalTime(59, 59, 23, _utcTimezone, _testClock), "$h:$m:$s"));
+        Assert.AreEqual("1:38:49", _testClock.DisplayTime(MudTime.FromLocalTime(49, 38, 1, _utcTimezone, _testClock), "$h:$m:$s"));
+        Assert.AreEqual("twelve o'clock a.m", _testClock.DisplayTime(MudTime.FromLocalTime(59, 59, 23, _utcTimezone, _testClock), "$c $l"));
+        Assert.AreEqual("twelve o'clock a.m", _testClock.DisplayTime(MudTime.FromLocalTime(0, 0, 0, _utcTimezone, _testClock), "$c $l"));
 
         // Testing the incorrect one
-        Assert.AreEqual("twelve o'clock p.m", _testClock.DisplayTime(new MudTime(59, 59, 23, _utcTimezone, _testClock, 0), "$c $i"));
+        Assert.AreEqual("twelve o'clock p.m", _testClock.DisplayTime(MudTime.FromLocalTime(59, 59, 23, _utcTimezone, _testClock), "$c $i"));
     }
 }

--- a/MudSharpCore Unit Tests/MudDateTimeTests.cs
+++ b/MudSharpCore Unit Tests/MudDateTimeTests.cs
@@ -443,6 +443,10 @@ public class MudDateTimeTests
 
         mts = MudTimeSpan.FromMonths(3, 14.357);
         Assert.IsTrue(mts.Equals(MudTimeSpan.Parse(mts.GetRoundTripParseText)), "The round-tripped MudTimeSpan was not equal to itself");
+
+        Assert.AreEqual(120, MudTimeSpan.FromMinutes(2).Seconds);
+        Assert.AreEqual(2, MudTimeSpan.FromMinutes(2).Minutes);
+        Assert.AreEqual(2, MudTimeSpan.FromHours(2).Hours);
     }
 
     [TestMethod]
@@ -864,6 +868,235 @@ public class MudDateTimeTests
         MudDate date1to2 = calendar1.CurrentDate.ConvertToOtherCalendar(calendar2);
         Assert.IsTrue(date1to2.Equals(calendar2.CurrentDate));
 
+    }
+
+    [TestMethod]
+    public void MudDate_CopyConstructor_PreservesWeekdayState()
+    {
+        MudDate original = _testCalendar.GetDate("1/archimedes/34");
+        MudDate copy = new(original);
+
+        Assert.AreEqual(original.WeekdayIndex, copy.WeekdayIndex);
+        Assert.AreEqual(original.Weekday, copy.Weekday);
+    }
+
+    [TestMethod]
+    public void MudDateTime_Never_CopyCompareRoundTripAndMidnight_DoNotThrow()
+    {
+        MudDateTime never = MudDateTime.Never;
+        MudDateTime copy = new(never);
+        MudDateTime roundTrip = new("Never", _testCalendar, _testClock);
+        MudDateTime converted = copy.ConvertToOtherCalendar(_testCalendar);
+        MudDateTime midnight = (MudDateTime)copy.GetProperty("midnight");
+
+        Assert.IsTrue(copy.Equals(MudDateTime.Never));
+        Assert.IsTrue(roundTrip.Equals(MudDateTime.Never));
+        Assert.IsTrue(converted.Equals(MudDateTime.Never));
+        Assert.IsTrue(midnight.Equals(MudDateTime.Never));
+        Assert.AreEqual(0, copy.CompareTo(MudDateTime.Never));
+        Assert.IsFalse(copy.Equals(_testCalendar.CurrentDate));
+    }
+
+    [TestMethod]
+    public void RecurringInterval_SpecificWeekday_BackwardReturnsPriorWeekday()
+    {
+        _testCalendar.SetDate("7/jung/34");
+        _testClock.SetTime(new MudTime(0, 0, 10, _utcTimezone, _testClock, true));
+        MudDate priorMatchingDate = _testCalendar.CurrentDate;
+        MudDateTime reference = new(_testCalendar.GetDate("8/jung/34"),
+            new MudTime(0, 0, 9, _utcTimezone, _testClock, 0), _utcTimezone);
+        RecurringInterval interval = new()
+        {
+            IntervalAmount = 1,
+            Modifier = priorMatchingDate.WeekdayIndex,
+            Type = IntervalType.SpecificWeekday
+        };
+
+        MudDateTime result = interval.GetLastDateTime(reference);
+
+        Assert.AreEqual(priorMatchingDate.GetDateString(), result.Date.GetDateString());
+        Assert.AreEqual(priorMatchingDate.Weekday, result.Date.Weekday);
+        Assert.AreEqual(9, result.Time.Hours);
+    }
+
+    [TestMethod]
+    public void TimeListener_RepeatZero_FiresOnce()
+    {
+        int fireCount = 0;
+        TimeListener listener = new(_testClock, 0, -1, -1, 0, _ => fireCount++, Array.Empty<object>());
+
+        _testClock.UpdateSeconds();
+        _testClock.UpdateSeconds();
+        listener.CancelListener();
+
+        Assert.AreEqual(1, fireCount);
+    }
+
+    [TestMethod]
+    public void MudDateTime_AddSubtractTimeSpan_RoundTripsAcrossBoundaries()
+    {
+        MudDateTime start = new(_testCalendar.GetDate("27/jung/34"),
+            new MudTime(30, 59, 23, _utcTimezone, _testClock, 0), _utcTimezone);
+        MudTimeSpan duration = MudTimeSpan.FromMinutes(2);
+
+        MudDateTime advanced = start + duration;
+        MudDateTime roundTrip = advanced - duration;
+
+        Assert.AreEqual("28/jung/34", advanced.Date.GetDateString());
+        Assert.AreEqual(0, advanced.Time.Hours);
+        Assert.AreEqual(1, advanced.Time.Minutes);
+        Assert.AreEqual(30, advanced.Time.Seconds);
+        Assert.IsTrue(start.Equals(roundTrip));
+    }
+
+    [TestMethod]
+    public void MudDateTime_TryParseTimezoneWallTime_ConvertsToExpectedUtcInstant()
+    {
+        Assert.IsTrue(MudDateTime.TryParse("27/jung/34 3:00:00 CST", _testCalendar, _testClock, null,
+            out MudDateTime parsed, out string error), error);
+
+        MudDateTime utc = parsed.GetByTimeZone(_utcTimezone);
+
+        Assert.AreEqual(_cstTimezone, parsed.TimeZone);
+        Assert.AreEqual(3, parsed.Time.Hours);
+        Assert.AreEqual(9, utc.Time.Hours);
+        Assert.AreEqual(parsed.Date.GetDateString(), utc.Date.GetDateString());
+        Assert.IsFalse(MudDateTime.TryParse("27/jung/34 3:00:00 moontime", _testCalendar, _testClock, null,
+            out _, out _));
+        Assert.IsFalse(MudDateTime.TryParse("27/jung/34 3:00:00zz", _testCalendar, _testClock, null,
+            out _, out _));
+    }
+
+    [TestMethod]
+    public void Calendar_GetFirstWeekday_NonSevenDayCalendarPreEpochUsesModulo()
+    {
+        Calendar calendar = CreateFiveWeekdayCalendar();
+
+        int firstWeekday = calendar.GetFirstWeekday(9);
+
+        Assert.AreEqual(0, firstWeekday);
+        Assert.IsTrue(firstWeekday < calendar.Weekdays.Count);
+    }
+
+    [TestMethod]
+    public void Month_IntercalaryNonweekdayEdits_AffectGeneratedMonth()
+    {
+        Calendar calendar = CreateIntercalaryNonweekdayCalendar();
+        Year year = calendar.CreateYear(1);
+        Month month = year.Months.Single();
+
+        Assert.IsFalse(month.NonWeekdays.Contains(2));
+        Assert.IsTrue(month.NonWeekdays.Contains(4));
+        Assert.AreEqual(calendar.CountWeekdaysInYear(1), year.Months.Sum(x => x.CountWeekdays()));
+    }
+
+    private static Calendar CreateFiveWeekdayCalendar()
+    {
+        return new Calendar(XElement.Parse(@"<calendar>
+  <alias>fiveweek</alias>
+  <shortname>Five Week Calendar</shortname>
+  <fullname>Five Week Calendar</fullname>
+  <description>Calendar with five weekdays.</description>
+  <shortstring>$dd/$mo/$yy</shortstring>
+  <longstring>$dd/$mo/$yy</longstring>
+  <wordystring>$dd/$mo/$yy</wordystring>
+  <plane>test</plane>
+  <feedclock>0</feedclock>
+  <epochyear>10</epochyear>
+  <weekdayatepoch>1</weekdayatepoch>
+  <ancienterashortstring>BT</ancienterashortstring>
+  <ancienteralongstring>before test</ancienteralongstring>
+  <modernerashortstring>AT</modernerashortstring>
+  <moderneralongstring>after test</moderneralongstring>
+  <weekdays>
+    <weekday>One</weekday>
+    <weekday>Two</weekday>
+    <weekday>Three</weekday>
+    <weekday>Four</weekday>
+    <weekday>Five</weekday>
+  </weekdays>
+  <months>
+    <month>
+      <alias>one</alias>
+      <shortname>one</shortname>
+      <fullname>One</fullname>
+      <nominalorder>1</nominalorder>
+      <normaldays>6</normaldays>
+      <intercalarydays />
+      <specialdays />
+      <nonweekdays />
+    </month>
+  </months>
+  <intercalarymonths />
+</calendar>"), _gameworld)
+        {
+            Id = 101,
+            FeedClock = _testClock
+        };
+    }
+
+    private static Calendar CreateIntercalaryNonweekdayCalendar()
+    {
+        return new Calendar(XElement.Parse(@"<calendar>
+  <alias>intercalary-edit</alias>
+  <shortname>Intercalary Edit Calendar</shortname>
+  <fullname>Intercalary Edit Calendar</fullname>
+  <description>Calendar with intercalary weekday edits.</description>
+  <shortstring>$dd/$mo/$yy</shortstring>
+  <longstring>$dd/$mo/$yy</longstring>
+  <wordystring>$dd/$mo/$yy</wordystring>
+  <plane>test</plane>
+  <feedclock>0</feedclock>
+  <epochyear>1</epochyear>
+  <weekdayatepoch>0</weekdayatepoch>
+  <ancienterashortstring>BT</ancienterashortstring>
+  <ancienteralongstring>before test</ancienteralongstring>
+  <modernerashortstring>AT</modernerashortstring>
+  <moderneralongstring>after test</moderneralongstring>
+  <weekdays>
+    <weekday>One</weekday>
+    <weekday>Two</weekday>
+    <weekday>Three</weekday>
+  </weekdays>
+  <months>
+    <month>
+      <alias>one</alias>
+      <shortname>one</shortname>
+      <fullname>One</fullname>
+      <nominalorder>1</nominalorder>
+      <normaldays>3</normaldays>
+      <intercalarydays>
+        <intercalary>
+          <insertdays>1</insertdays>
+          <nonweekdays>
+            <nonweekday>4</nonweekday>
+          </nonweekdays>
+          <removenonweekdays>
+            <removenonweekday>2</removenonweekday>
+          </removenonweekdays>
+          <specialdays />
+          <removespecialdays />
+          <intercalaryrule>
+            <offset>0</offset>
+            <divisor>1</divisor>
+            <exceptions />
+            <ands />
+            <ors />
+          </intercalaryrule>
+        </intercalary>
+      </intercalarydays>
+      <specialdays />
+      <nonweekdays>
+        <nonweekday>2</nonweekday>
+      </nonweekdays>
+    </month>
+  </months>
+  <intercalarymonths />
+</calendar>"), _gameworld)
+        {
+            Id = 102,
+            FeedClock = _testClock
+        };
     }
 
     [TestMethod]

--- a/MudSharpCore/Commands/Modules/ClanModule.cs
+++ b/MudSharpCore/Commands/Modules/ClanModule.cs
@@ -486,14 +486,14 @@ All of the following commands must happen with an edited clan selected:
 
         if (ss.IsFinished)
         {
-            actor.OutputHandler.Send($"What should the pay interval be for this clan?\n{"Use the following form: every <x> hours|days|weekdays|weeks|months|years [<from time>]".ColourCommand()}");
+            actor.OutputHandler.Send($"What should the pay interval be for this clan?\n{"Use forms like: every <x> hours|days|weekdays|weeks|months|years [<from time>], every month on day 15, or every month on the 5th or last Wednesday".ColourCommand()}");
             return;
         }
 
-        if (!RecurringInterval.TryParse(ss.PopSpeech(), out RecurringInterval interval))
+        if (!RecurringInterval.TryParse(ss.PopSpeech(), clan.Calendar, out RecurringInterval interval, out string intervalError))
         {
             actor.OutputHandler.Send(
-                $"That is not a valid interval.\n{"Use the following form: every <x> hours|days|weekdays|weeks|months|years [<from time>]".ColourCommand()}");
+                $"That is not a valid interval: {intervalError}\n{"Use forms like: every <x> hours|days|weekdays|weeks|months|years [<from time>], every month on day 15, or every month on the 5th or last Wednesday".ColourCommand()}");
             return;
         }
 
@@ -3547,6 +3547,8 @@ Your next payday is {3}.
             dbclan.PayIntervalType = 0;
             dbclan.PayIntervalModifier = 1;
             dbclan.PayIntervalOther = 0;
+            dbclan.PayIntervalOtherSecondary = 0;
+            dbclan.PayIntervalFallback = 0;
             dbclan.PayIntervalReferenceDate = actor.Culture.PrimaryCalendar.CurrentDate.GetDateString();
             dbclan.PayIntervalReferenceTime = "0:0:0";
 

--- a/MudSharpCore/Commands/Modules/ProgModule.cs
+++ b/MudSharpCore/Commands/Modules/ProgModule.cs
@@ -3126,10 +3126,10 @@ If no datetime argument is supplied with the #3schedule add#0 command, the curre
                 }
 
                 string intervalText = ss.PopSpeech();
-                if (!RecurringInterval.TryParse(intervalText, out RecurringInterval interval))
+                if (!RecurringInterval.TryParse(intervalText, actor.Location.Calendars.First(), out RecurringInterval interval, out string intervalError))
                 {
                     actor.OutputHandler.Send(
-                        $"That is not a valid interval.\n{"Use the following form: every <x> minutes|hours|days|weekdays|weeks|months|years <offset>".ColourCommand()}");
+                        $"That is not a valid interval: {intervalError}\n{"Use forms like: every <x> minutes|hours|days|weekdays|weeks|months|years <offset>, every month on day 15, or every month on the 5th or last Wednesday".ColourCommand()}");
                     return;
                 }
 

--- a/MudSharpCore/Commands/Modules/PropertyModule.cs
+++ b/MudSharpCore/Commands/Modules/PropertyModule.cs
@@ -1405,10 +1405,10 @@ The following commands are specific to those who own a property (or who are mana
             return;
         }
 
-        if (!RecurringInterval.TryParse(ss.SafeRemainingArgument, out RecurringInterval interval))
+        if (!RecurringInterval.TryParse(ss.SafeRemainingArgument, property.EconomicZone.FinancialPeriodReferenceCalendar, out RecurringInterval interval, out string intervalError))
         {
             actor.OutputHandler.Send(
-                $"That is not a valid interval.\n{"Use the following form: every <x> hours|days|weekdays|weeks|months|years <offset>".ColourCommand()}");
+                $"That is not a valid interval: {intervalError}\n{"Use forms like: every <x> hours|days|weekdays|weeks|months|years <offset>, every month on day 15, or every month on the 5th or last Wednesday".ColourCommand()}");
             return;
         }
 

--- a/MudSharpCore/Community/Clan.cs
+++ b/MudSharpCore/Community/Clan.cs
@@ -51,7 +51,9 @@ public partial class Clan : SaveableItem, IClan
         {
             Type = (IntervalType)clan.PayIntervalType,
             IntervalAmount = clan.PayIntervalModifier,
-            Modifier = clan.PayIntervalOther
+            Modifier = clan.PayIntervalOther,
+            SecondaryModifier = clan.PayIntervalOtherSecondary,
+            OrdinalFallbackMode = (OrdinalFallbackMode)clan.PayIntervalFallback
         };
         MudTime payTime = Calendar.FeedClock.GetTime(clan.PayIntervalReferenceTime);
         _nextPay = new MudDateTime(
@@ -105,6 +107,8 @@ public partial class Clan : SaveableItem, IClan
             clan.PayIntervalType = (int)PayInterval.Type;
             clan.PayIntervalModifier = PayInterval.IntervalAmount;
             clan.PayIntervalOther = PayInterval.Modifier;
+            clan.PayIntervalOtherSecondary = PayInterval.SecondaryModifier;
+            clan.PayIntervalFallback = (int)PayInterval.OrdinalFallbackMode;
             clan.PayIntervalReferenceDate = NextPay.Date.GetDateString();
             clan.PayIntervalReferenceTime = NextPay.Time.GetTimeString();
             clan.BankAccountId = _clanBankAccountId;

--- a/MudSharpCore/Economy/EconomicZone.cs
+++ b/MudSharpCore/Economy/EconomicZone.cs
@@ -112,7 +112,7 @@ public class EconomicZone : SaveableItem, IEconomicZone
         FinancialPeriodReferenceCalendar.DaysUpdated += ReferenceCalendarOnDaysUpdated;
         FinancialPeriodTimezone = zone.TimeZone(FinancialPeriodReferenceClock);
         FinancialPeriodReferenceTime =
-            new MudTime(0, 0, 0, FinancialPeriodTimezone, FinancialPeriodReferenceClock, false);
+            MudTime.FromLocalTime(0, 0, 0, FinancialPeriodTimezone, FinancialPeriodReferenceClock);
         EstatesEnabled = true;
         EstateDefaultDiscoverTime = MudTimeSpan.FromDays(28);
         EstateClaimPeriodLength = MudTimeSpan.FromDays(14);
@@ -121,6 +121,8 @@ public class EconomicZone : SaveableItem, IEconomicZone
             Models.EconomicZone dbitem = new()
             {
                 IntervalModifier = FinancialPeriodInterval.Modifier,
+                IntervalOther = FinancialPeriodInterval.SecondaryModifier,
+                IntervalFallback = (int)FinancialPeriodInterval.OrdinalFallbackMode,
                 IntervalType = (int)FinancialPeriodInterval.Type,
                 IntervalAmount = FinancialPeriodInterval.IntervalAmount,
                 CurrencyId = Currency.Id,
@@ -206,12 +208,14 @@ public class EconomicZone : SaveableItem, IEconomicZone
         {
             IntervalAmount = zone.IntervalAmount,
             Modifier = zone.IntervalModifier,
+            SecondaryModifier = zone.IntervalOther,
+            OrdinalFallbackMode = (OrdinalFallbackMode)zone.IntervalFallback,
             Type = (IntervalType)zone.IntervalType
         };
 
         FinancialPeriodReferenceClock = gameworld.Clocks.Get(zone.ReferenceClockId);
         FinancialPeriodReferenceCalendar = gameworld.Calendars.Get(zone.ReferenceCalendarId ?? 0);
-        FinancialPeriodReferenceTime = new MudTime(zone.ReferenceTime, FinancialPeriodReferenceClock);
+        FinancialPeriodReferenceTime = MudTime.ParseLocalTime(zone.ReferenceTime, FinancialPeriodReferenceClock);
         FinancialPeriodTimezone = FinancialPeriodReferenceTime.Timezone;
 
         CurrentFinancialPeriod = _financialPeriods.Get(zone.CurrentFinancialPeriodId ?? 0) ??
@@ -380,6 +384,8 @@ public class EconomicZone : SaveableItem, IEconomicZone
             {
                 CurrentFinancialPeriodId = CurrentFinancialPeriod?.Id,
                 IntervalModifier = FinancialPeriodInterval.Modifier,
+                IntervalOther = FinancialPeriodInterval.SecondaryModifier,
+                IntervalFallback = (int)FinancialPeriodInterval.OrdinalFallbackMode,
                 IntervalType = (int)FinancialPeriodInterval.Type,
                 IntervalAmount = FinancialPeriodInterval.IntervalAmount,
                 CurrencyId = Currency.Id,
@@ -424,6 +430,8 @@ public class EconomicZone : SaveableItem, IEconomicZone
         Models.EconomicZone dbitem = FMDB.Context.EconomicZones.Find(Id);
         dbitem.CurrentFinancialPeriodId = CurrentFinancialPeriod?.Id;
         dbitem.IntervalModifier = FinancialPeriodInterval.Modifier;
+        dbitem.IntervalOther = FinancialPeriodInterval.SecondaryModifier;
+        dbitem.IntervalFallback = (int)FinancialPeriodInterval.OrdinalFallbackMode;
         dbitem.IntervalType = (int)FinancialPeriodInterval.Type;
         dbitem.IntervalAmount = FinancialPeriodInterval.IntervalAmount;
         dbitem.CurrencyId = Currency.Id;
@@ -735,7 +743,7 @@ public class EconomicZone : SaveableItem, IEconomicZone
 	#3currency <currency>#0 - changes the currency used in this zone
 	#3clock <clock>#0 - changes the clock used in this zone
 	#3calendar <calendar>#0 - changes the calendar used in this zone
-	#3interval <type> <amount> <offset>#0 - sets the interval for financial periods
+	#3interval <interval>#0 - sets the interval for financial periods
 	#3time <time>#0 - sets the reference time for financial periods
 	#3timezone <tz>#0 - sets the reference timezone for this zone
 	#3zone <zone>#0 - sets the physical zone used as a reference for current time
@@ -1372,14 +1380,14 @@ public class EconomicZone : SaveableItem, IEconomicZone
         if (command.IsFinished)
         {
             actor.OutputHandler.Send(
-                $"What do you want to set the financial period interval to?\n{"Use the following form: every <x> hours|days|weekdays|weeks|months|years <offset>".ColourCommand()}");
+                $"What do you want to set the financial period interval to?\n{"Use forms like: every <x> hours|days|weekdays|weeks|months|years <offset>, every month on day 15, or every month on the 5th or last Wednesday".ColourCommand()}");
             return false;
         }
 
-        if (!RecurringInterval.TryParse(command.SafeRemainingArgument, out RecurringInterval interval))
+        if (!RecurringInterval.TryParse(command.SafeRemainingArgument, FinancialPeriodReferenceCalendar, out RecurringInterval interval, out string intervalError))
         {
             actor.OutputHandler.Send(
-                $"That is not a valid financial period interval.\n{"Use the following form: every <x> hours|days|weekdays|weeks|months|years <offset>".ColourCommand()}");
+                $"That is not a valid financial period interval: {intervalError}\n{"Use forms like: every <x> hours|days|weekdays|weeks|months|years <offset>, every month on day 15, or every month on the 5th or last Wednesday".ColourCommand()}");
             return false;
         }
 
@@ -1408,9 +1416,9 @@ public class EconomicZone : SaveableItem, IEconomicZone
         }
 
         Match match = regex.Match(command.SafeRemainingArgument);
-        FinancialPeriodReferenceTime = new MudTime(int.Parse(match.Groups["seconds"].Value),
+        FinancialPeriodReferenceTime = MudTime.FromLocalTime(int.Parse(match.Groups["seconds"].Value),
             int.Parse(match.Groups["minutes"].Value), int.Parse(match.Groups["hours"].Value),
-            ZoneForTimePurposes.TimeZone(FinancialPeriodReferenceClock), FinancialPeriodReferenceClock, false);
+            ZoneForTimePurposes.TimeZone(FinancialPeriodReferenceClock), FinancialPeriodReferenceClock);
         Changed = true;
         actor.OutputHandler.Send(
             $"The {Name.ColourName()} economic zone will now use {FinancialPeriodReferenceTime.Display(TimeDisplayTypes.Short).ColourValue()} as its reference time.");
@@ -1438,9 +1446,9 @@ public class EconomicZone : SaveableItem, IEconomicZone
         ZoneForTimePurposes = zone;
         FinancialPeriodReferenceCalendar = zone.Calendars.First();
         FinancialPeriodReferenceClock = zone.Clocks.First();
-        FinancialPeriodReferenceTime = new MudTime(FinancialPeriodReferenceTime.Seconds,
+        FinancialPeriodReferenceTime = MudTime.FromLocalTime(FinancialPeriodReferenceTime.Seconds,
             FinancialPeriodReferenceTime.Minutes, FinancialPeriodReferenceTime.Hours,
-            zone.TimeZone(FinancialPeriodReferenceClock), FinancialPeriodReferenceClock, false);
+            zone.TimeZone(FinancialPeriodReferenceClock), FinancialPeriodReferenceClock);
         // TODO - should we be redoing listeners here?
         Changed = true;
         actor.OutputHandler.Send(

--- a/MudSharpCore/Economy/Employment/OngoingJobListing.cs
+++ b/MudSharpCore/Economy/Employment/OngoingJobListing.cs
@@ -541,14 +541,14 @@ You will be paid {PayDescriptionForJobListing()}.{(PersonalProject is not null ?
         if (command.IsFinished)
         {
             actor.OutputHandler.Send(
-                $"What interval do you want to set for payroll? Use an expression like {"every <x> hours|days|weekdays|weeks|months|years <offset>".ColourCommand()}.");
+                $"What interval do you want to set for payroll? Use forms like {"every <x> hours|days|weekdays|weeks|months|years <offset>".ColourCommand()}, {"every month on day 15".ColourCommand()}, or {"every month on the 5th or last Wednesday".ColourCommand()}.");
             return false;
         }
 
-        if (!RecurringInterval.TryParse(command.SafeRemainingArgument, out RecurringInterval? interval))
+        if (!RecurringInterval.TryParse(command.SafeRemainingArgument, PayReference.Calendar, out RecurringInterval? interval, out string intervalError))
         {
             actor.OutputHandler.Send(
-                $"That is not a valid interval. Use an expression like {"every <x> hours|days|weekdays|weeks|months|years <offset>".ColourCommand()}.");
+                $"That is not a valid interval: {intervalError}. Use forms like {"every <x> hours|days|weekdays|weeks|months|years <offset>".ColourCommand()}, {"every month on day 15".ColourCommand()}, or {"every month on the 5th or last Wednesday".ColourCommand()}.");
             return false;
         }
 

--- a/MudSharpCore/Economy/Shoppers/ShopperBase.cs
+++ b/MudSharpCore/Economy/Shoppers/ShopperBase.cs
@@ -245,13 +245,13 @@ internal abstract class ShopperBase : SaveableItem, IShopper
     {
         if (command.IsFinished)
         {
-            actor.OutputHandler.Send($"You must enter an interval.\nUse the following form: #3every <x> hours|days|weekdays|weeks|months|years <offset>#0".SubstituteANSIColour());
+            actor.OutputHandler.Send($"You must enter an interval.\nUse forms like: #3every <x> hours|days|weekdays|weeks|months|years <offset>#0, #3every month on day 15#0, or #3every month on the 5th or last Wednesday#0".SubstituteANSIColour());
             return false;
         }
 
-        if (!RecurringInterval.TryParse(command.SafeRemainingArgument, out RecurringInterval interval))
+        if (!RecurringInterval.TryParse(command.SafeRemainingArgument, EconomicZone.FinancialPeriodReferenceCalendar, out RecurringInterval interval, out string intervalError))
         {
-            actor.OutputHandler.Send($"The text {command.SafeRemainingArgument.ColourCommand()} is not a valid interval.\nUse the following form: #3every <x> hours|days|weekdays|weeks|months|years <offset>#0".SubstituteANSIColour());
+            actor.OutputHandler.Send($"The text {command.SafeRemainingArgument.ColourCommand()} is not a valid interval: {intervalError}\nUse forms like: #3every <x> hours|days|weekdays|weeks|months|years <offset>#0, #3every month on day 15#0, or #3every month on the 5th or last Wednesday#0".SubstituteANSIColour());
             return false;
         }
 

--- a/MudSharpCore/FutureProg/Functions/DateTime/NowFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/DateTime/NowFunction.cs
@@ -92,7 +92,7 @@ internal class MudNowFunction : BuiltInFunction
 
         if (timezone != clock.PrimaryTimezone)
         {
-            time = new MudTime(time).GetTimeByTimezone(timezone);
+            time = MudTime.CopyOf(time).GetTimeByTimezone(timezone);
             if (time.DaysOffsetFromDatum != 0)
             {
                 date = new MudDate(date);

--- a/MudSharpCore/FutureProg/ProgSchedule.cs
+++ b/MudSharpCore/FutureProg/ProgSchedule.cs
@@ -21,6 +21,8 @@ public class ProgSchedule : SaveableItem, IProgSchedule
             dbitem.IntervalType = (int)interval.Type;
             dbitem.IntervalModifier = interval.IntervalAmount;
             dbitem.IntervalOther = interval.Modifier;
+            dbitem.IntervalOtherSecondary = interval.SecondaryModifier;
+            dbitem.IntervalFallback = (int)interval.OrdinalFallbackMode;
             dbitem.ReferenceDate = referencetime.GetDateTimeString();
             dbitem.ReferenceTime = string.Empty;
             dbitem.FutureProgId = prog.Id;
@@ -95,7 +97,9 @@ public class ProgSchedule : SaveableItem, IProgSchedule
         {
             Type = (IntervalType)schedule.IntervalType,
             IntervalAmount = schedule.IntervalModifier,
-            Modifier = schedule.IntervalOther
+            Modifier = schedule.IntervalOther,
+            SecondaryModifier = schedule.IntervalOtherSecondary,
+            OrdinalFallbackMode = (OrdinalFallbackMode)schedule.IntervalFallback
         };
         Prog = Gameworld.FutureProgs.Get(schedule.FutureProgId);
         NextReferenceTime = Interval.GetNextDateTime(new MudDateTime(schedule.ReferenceDate, Gameworld));

--- a/MudSharpCore/TimeAndDate/Date/Calendar.cs
+++ b/MudSharpCore/TimeAndDate/Date/Calendar.cs
@@ -681,10 +681,8 @@ public class Calendar : SaveableItem, ICalendar
         }
 
         int day = whichYear > EpochYear
-            ? (FirstWeekdayAtEpoch + daysBetween) % Weekdays.Count
-            : Weekdays.Count - Math.Abs((FirstWeekdayAtEpoch - daysBetween) % Weekdays.Count) == 7
-                ? 0
-                : Weekdays.Count - Math.Abs((FirstWeekdayAtEpoch - daysBetween) % Weekdays.Count);
+            ? (FirstWeekdayAtEpoch + daysBetween).Modulus(Weekdays.Count)
+            : (FirstWeekdayAtEpoch - daysBetween).Modulus(Weekdays.Count);
         _cachedFirstWeekday[whichYear] = day;
         return day;
     }

--- a/MudSharpCore/TimeAndDate/Intervals/IntervalExtensions.cs
+++ b/MudSharpCore/TimeAndDate/Intervals/IntervalExtensions.cs
@@ -36,6 +36,8 @@ public static class IntervalExtensions
                     referenceTime.Date.Day, referenceTime.Date.Month.Alias, referenceTime.Date.Year, referenceTime.TimeZone, 1,
                     payload, objects, debuggerReference);
             case IntervalType.Monthly:
+            case IntervalType.OrdinalDayOfMonth:
+            case IntervalType.OrdinalWeekdayOfMonth:
                 return ListenerFactory.CreateDateTimeListener(referenceTime.Clock,
                     referenceTime.Time.Seconds, referenceTime.Time.Minutes, referenceTime.Time.Hours,
                     referenceTime.Calendar,
@@ -85,6 +87,8 @@ public static class IntervalExtensions
                     date.Day, date.Month.Alias, date.Year, referenceTimezone, 1,
                     payload, objects, debuggerReference);
             case IntervalType.Monthly:
+            case IntervalType.OrdinalDayOfMonth:
+            case IntervalType.OrdinalWeekdayOfMonth:
                 return ListenerFactory.CreateDateTimeListener(whichCalendar.FeedClock,
                     recurringTime.Seconds, recurringTime.Minutes, recurringTime.Hours, whichCalendar,
                     date.Day, date.Month.Alias, date.Year, referenceTimezone, 1,
@@ -141,7 +145,7 @@ public static class IntervalExtensions
                     objects1 =>
                     {
                         MudDate newDate = new(date);
-                        MudTime newTime = new MudTime(recurringTime).GetTimeByTimezone(referenceTimeZone);
+                        MudTime newTime = MudTime.CopyOf(recurringTime).GetTimeByTimezone(referenceTimeZone);
                         newTime.AddMinutes(interval.IntervalAmount);
                         if (newTime.DaysOffsetFromDatum != 0)
                         {
@@ -158,7 +162,7 @@ public static class IntervalExtensions
                     objects1 =>
                     {
                         MudDate newDate = new(date);
-                        MudTime newTime = new MudTime(recurringTime).GetTimeByTimezone(referenceTimeZone);
+                        MudTime newTime = MudTime.CopyOf(recurringTime).GetTimeByTimezone(referenceTimeZone);
                         newTime.AddHours(interval.IntervalAmount);
                         if (newTime.DaysOffsetFromDatum != 0)
                         {
@@ -180,14 +184,21 @@ public static class IntervalExtensions
                         interval.CreateListenerFromInterval(whichCalendar, newDate, recurringTime, referenceTimeZone, payload, objects1, debuggerReference);
                     }, objects, debuggerReference);
             case IntervalType.Monthly:
+            case IntervalType.OrdinalDayOfMonth:
+            case IntervalType.OrdinalWeekdayOfMonth:
                 return ListenerFactory.CreateDateTimeListener(whichCalendar.FeedClock,
                     recurringTime.Seconds, recurringTime.Minutes, recurringTime.Hours, whichCalendar,
                     date.Day, date.Month.Alias, date.Year, referenceTimeZone, 1,
                     objects1 =>
                     {
                         payload(objects1);
-                        MudDate newDate = new(date);
-                        newDate.AdvanceMonths(interval.IntervalAmount, true, true);
+                        MudDate newDate = interval.Type == IntervalType.Monthly
+                            ? new MudDate(date)
+                            : interval.GetNextDateExclusive(whichCalendar, date);
+                        if (interval.Type == IntervalType.Monthly)
+                        {
+                            newDate.AdvanceMonths(interval.IntervalAmount, true, true);
+                        }
                         interval.CreateListenerFromInterval(whichCalendar, newDate, recurringTime, referenceTimeZone, payload, objects1, debuggerReference);
                     }, objects, debuggerReference);
             case IntervalType.SpecificWeekday:

--- a/MudSharpCore/TimeAndDate/Listeners/DateListener.cs
+++ b/MudSharpCore/TimeAndDate/Listeners/DateListener.cs
@@ -91,8 +91,7 @@ public class DateListener : ListenerBase
     {
         if (DateIsRight())
         {
-            Payload?.Invoke(Objects);
-            RepeatTimes--;
+            TriggerPayload();
         }
     }
 

--- a/MudSharpCore/TimeAndDate/Listeners/ListenerBase.cs
+++ b/MudSharpCore/TimeAndDate/Listeners/ListenerBase.cs
@@ -25,6 +25,12 @@ public abstract class ListenerBase : FrameworkItem, ITemporalListener
 
     public Action<object[]> Payload { get; protected set; }
 
+    protected void TriggerPayload()
+    {
+        Payload?.Invoke(Objects);
+        RepeatTimes--;
+    }
+
     public int RepeatTimes
     {
         get => _repeatTimes;

--- a/MudSharpCore/TimeAndDate/Listeners/ListenerFactory.cs
+++ b/MudSharpCore/TimeAndDate/Listeners/ListenerFactory.cs
@@ -46,7 +46,7 @@ public static class ListenerFactory
     public static ITemporalListener CreateTimeOffsetListener(IClock watchClock, int secondsOffset, int minutesOffset,
         int hoursOffset, int repeatTimes, Action<object[]> payload, object[] objects)
     {
-        MudTime newTime = new(watchClock.CurrentTime);
+        MudTime newTime = MudTime.CopyOf(watchClock.CurrentTime);
         newTime.AddSeconds(secondsOffset);
         newTime.AddMinutes(minutesOffset);
         newTime.AddHours(hoursOffset);
@@ -78,7 +78,7 @@ public static class ListenerFactory
         int minutesOffset, int hoursOffset, ICalendar watchCalendar, int daysOffset, int monthsOffset,
         int yearsOffset, bool ignoreIntercalaries, IMudTimeZone watchForTimeZone, int repeatTimes, Action<object[]> payload, object[] objects, string debuggerReference)
     {
-        MudTime newTime = new(watchClock.CurrentTime);
+        MudTime newTime = MudTime.CopyOf(watchClock.CurrentTime);
         newTime.AddSeconds(secondsOffset);
         newTime.AddMinutes(minutesOffset);
         newTime.AddHours(hoursOffset);

--- a/MudSharpCore/TimeAndDate/Listeners/TimeListener.cs
+++ b/MudSharpCore/TimeAndDate/Listeners/TimeListener.cs
@@ -62,11 +62,7 @@ public class TimeListener : ListenerBase
     {
         if (TimeIsRight())
         {
-            Payload(Objects);
-            if (RepeatTimes > 0)
-            {
-                RepeatTimes--;
-            }
+            TriggerPayload();
         }
     }
 

--- a/MudSharpCore/TimeAndDate/Listeners/WeekdayListener.cs
+++ b/MudSharpCore/TimeAndDate/Listeners/WeekdayListener.cs
@@ -48,11 +48,7 @@ public class WeekdayListener : ListenerBase
         if (WatchCalendar.CurrentDate.WeekdayIndex != -1 &&
             Weekdays.Contains(WatchCalendar.CurrentDate.Weekday))
         {
-            Payload(Objects);
-            if (RepeatTimes > 0)
-            {
-                RepeatTimes--;
-            }
+            TriggerPayload();
         }
     }
 

--- a/MudSharpCore/TimeAndDate/Listeners/WeekdayTimeListener.cs
+++ b/MudSharpCore/TimeAndDate/Listeners/WeekdayTimeListener.cs
@@ -130,11 +130,7 @@ public class WeekdayTimeListener : ListenerBase
             TimeIsRight()
            )
         {
-            Payload(Objects);
-            if (RepeatTimes > 0)
-            {
-                RepeatTimes--;
-            }
+            TriggerPayload();
         }
     }
 

--- a/MudSharpCore/TimeAndDate/Time/Clock.cs
+++ b/MudSharpCore/TimeAndDate/Time/Clock.cs
@@ -550,6 +550,28 @@ public class Clock : SaveableItem, IClock
 
     #region Constructors
 
+    private IMudTimeZone ResolvePrimaryTimezone(IMudTimeZone primaryTimezone = null)
+    {
+        if (primaryTimezone is not null)
+        {
+            if (!_timezones.Contains(primaryTimezone))
+            {
+                AddTimezone(primaryTimezone);
+            }
+
+            return primaryTimezone;
+        }
+
+        if (_timezones.FirstOrDefault() is { } existing)
+        {
+            return existing;
+        }
+
+        var fallback = new MudTimeZone(0, 0, 0, $"{Alias} Standard Time", Alias);
+        AddTimezone(fallback);
+        return fallback;
+    }
+
     public Clock(IFuturemud gameworld, string name, string alias)
     {
         Gameworld = gameworld;
@@ -586,7 +608,7 @@ public class Clock : SaveableItem, IClock
         MudTimeZone timezone = new(this, 0, 0, $"{Name} Standard Time", alias);
         AddTimezone(timezone);
         PrimaryTimezone = timezone;
-        CurrentTime = new MudTime(0, 0, 0, timezone, this, true);
+        CurrentTime = MudTime.CreatePrimaryTime(0, 0, 0, timezone, this);
         Save();
     }
 
@@ -638,7 +660,7 @@ public class Clock : SaveableItem, IClock
             }
         }
 
-        CurrentTime = new MudTime(rhs.CurrentTime.Seconds, rhs.CurrentTime.Minutes, rhs.CurrentTime.Hours, PrimaryTimezone, this, true);
+        CurrentTime = MudTime.CreatePrimaryTime(rhs.CurrentTime.Seconds, rhs.CurrentTime.Minutes, rhs.CurrentTime.Hours, PrimaryTimezone, this);
         Save();
     }
 
@@ -646,8 +668,8 @@ public class Clock : SaveableItem, IClock
     {
         LoadFromXml(loadfile);
         _name = Alias;
-        PrimaryTimezone = primaryTimeZone;
-        CurrentTime = new MudTime(seconds, minutes, hours, PrimaryTimezone, this, true);
+        PrimaryTimezone = ResolvePrimaryTimezone(primaryTimeZone);
+        CurrentTime = MudTime.CreatePrimaryTime(seconds, minutes, hours, PrimaryTimezone, this);
         ;
     }
 
@@ -656,8 +678,8 @@ public class Clock : SaveableItem, IClock
         Gameworld = gameworld;
         LoadFromXml(loadfile);
         _name = Alias;
-        PrimaryTimezone = primaryTimeZone;
-        CurrentTime = new MudTime(seconds, minutes, hours, PrimaryTimezone, this, true);
+        PrimaryTimezone = ResolvePrimaryTimezone(primaryTimeZone);
+        CurrentTime = MudTime.CreatePrimaryTime(seconds, minutes, hours, PrimaryTimezone, this);
         ;
     }
 
@@ -666,8 +688,8 @@ public class Clock : SaveableItem, IClock
         Gameworld = gameworld;
         LoadFromXml(loadfile);
         _name = Alias;
-        PrimaryTimezone = _timezones.FirstOrDefault();
-        CurrentTime = new MudTime(0, 0, 0, PrimaryTimezone, this, true);
+        PrimaryTimezone = ResolvePrimaryTimezone();
+        CurrentTime = MudTime.CreatePrimaryTime(0, 0, 0, PrimaryTimezone, this);
     }
 
     public Clock(MudSharp.Models.Clock clock, IFuturemud game)
@@ -682,7 +704,7 @@ public class Clock : SaveableItem, IClock
         }
 
         PrimaryTimezone = _timezones.Get(clock.PrimaryTimezoneId);
-        CurrentTime = new MudTime(clock.Seconds, clock.Minutes, clock.Hours, PrimaryTimezone, this, true);
+        CurrentTime = MudTime.CreatePrimaryTime(clock.Seconds, clock.Minutes, clock.Hours, PrimaryTimezone, this);
     }
 
     public IClock Clone(string name, string alias)
@@ -881,29 +903,9 @@ public class Clock : SaveableItem, IClock
         return DisplayTime(CurrentTime, type);
     }
 
-    private static readonly Regex TimeStringRegex =
-        new(
-            @"^(?<timezone>[a-z]+){0,}\s*(?<hours>\d+){1}:(?<minutes>\d+){1}:(?<seconds>\d+){1}\s*(?<meridian>[a-z]+){0,}$",
-            RegexOptions.IgnoreCase);
-
     public MudTime GetTime(string timeString)
     {
-        Match match = TimeStringRegex.Match(timeString);
-        if (!match.Success)
-        {
-            throw new ArgumentException("The time string supplied did not match the time regex.");
-        }
-
-        return new MudTime(int.Parse(match.Groups["seconds"].Value), int.Parse(match.Groups["minutes"].Value),
-            match.Groups["meridian"].Success
-                ? HourIntervalNames.FindIndex(
-                    x => x.Equals(match.Groups["meridian"].Value, StringComparison.InvariantCultureIgnoreCase)) *
-                (HoursPerDay / NumberOfHourIntervals) + int.Parse(match.Groups["hours"].Value)
-                : int.Parse(match.Groups["hours"].Value),
-            match.Groups["timezone"].Success
-                ? Timezones.FirstOrDefault(
-                    x => x.Alias.Equals(match.Groups["timezone"].Value, StringComparison.InvariantCultureIgnoreCase))
-                : PrimaryTimezone, this, 0);
+        return MudTime.ParseLocalTime(timeString, this);
     }
 
     public void SetTime(MudTime time)

--- a/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextConfiguring2.cs
+++ b/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextConfiguring2.cs
@@ -306,6 +306,10 @@ namespace MudSharp.Database
 
                 entity.Property(e => e.PayIntervalOther).HasColumnType("int(11)");
 
+                entity.Property(e => e.PayIntervalOtherSecondary).HasColumnType("int(11)");
+
+                entity.Property(e => e.PayIntervalFallback).HasColumnType("int(11)");
+
                 entity.Property(e => e.PayIntervalReferenceDate)
                     .IsRequired()
                     .HasColumnType("varchar(100)")
@@ -1884,6 +1888,10 @@ namespace MudSharp.Database
                     .HasDefaultValueSql("'1'");
 
                 entity.Property(e => e.IntervalModifier).HasColumnType("int(11)");
+
+                entity.Property(e => e.IntervalOther).HasColumnType("int(11)");
+
+                entity.Property(e => e.IntervalFallback).HasColumnType("int(11)");
 
                 entity.Property(e => e.IntervalType)
                     .HasColumnType("int(11)")

--- a/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextConfiguring3.cs
+++ b/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextConfiguring3.cs
@@ -948,6 +948,10 @@ namespace MudSharp.Database
 
                 entity.Property(e => e.IntervalOther).HasColumnType("int(11)");
 
+                entity.Property(e => e.IntervalOtherSecondary).HasColumnType("int(11)");
+
+                entity.Property(e => e.IntervalFallback).HasColumnType("int(11)");
+
                 entity.Property(e => e.IntervalType).HasColumnType("int(11)");
 
                 entity.Property(e => e.Name)

--- a/MudsharpDatabaseLibrary/Migrations/20260427110022_RecurringIntervalOrdinalFields.Designer.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260427110022_RecurringIntervalOrdinalFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MudSharp.Database;
 
@@ -11,9 +12,11 @@ using MudSharp.Database;
 namespace MudSharp.Migrations
 {
     [DbContext(typeof(FuturemudDatabaseContext))]
-    partial class FutureMUDContextModelSnapshot : ModelSnapshot
+    [Migration("20260427110022_RecurringIntervalOrdinalFields")]
+    partial class RecurringIntervalOrdinalFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MudsharpDatabaseLibrary/Migrations/20260427110022_RecurringIntervalOrdinalFields.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260427110022_RecurringIntervalOrdinalFields.cs
@@ -1,0 +1,84 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MudSharp.Migrations
+{
+    /// <inheritdoc />
+    public partial class RecurringIntervalOrdinalFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "IntervalFallback",
+                table: "ProgSchedules",
+                type: "int(11)",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "IntervalOtherSecondary",
+                table: "ProgSchedules",
+                type: "int(11)",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "IntervalFallback",
+                table: "EconomicZones",
+                type: "int(11)",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "IntervalOther",
+                table: "EconomicZones",
+                type: "int(11)",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PayIntervalFallback",
+                table: "Clans",
+                type: "int(11)",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PayIntervalOtherSecondary",
+                table: "Clans",
+                type: "int(11)",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IntervalFallback",
+                table: "ProgSchedules");
+
+            migrationBuilder.DropColumn(
+                name: "IntervalOtherSecondary",
+                table: "ProgSchedules");
+
+            migrationBuilder.DropColumn(
+                name: "IntervalFallback",
+                table: "EconomicZones");
+
+            migrationBuilder.DropColumn(
+                name: "IntervalOther",
+                table: "EconomicZones");
+
+            migrationBuilder.DropColumn(
+                name: "PayIntervalFallback",
+                table: "Clans");
+
+            migrationBuilder.DropColumn(
+                name: "PayIntervalOtherSecondary",
+                table: "Clans");
+        }
+    }
+}

--- a/MudsharpDatabaseLibrary/Models/Clan.cs
+++ b/MudsharpDatabaseLibrary/Models/Clan.cs
@@ -28,6 +28,8 @@ namespace MudSharp.Models
         public int PayIntervalType { get; set; }
         public int PayIntervalModifier { get; set; }
         public int PayIntervalOther { get; set; }
+        public int PayIntervalOtherSecondary { get; set; }
+        public int PayIntervalFallback { get; set; }
         public long CalendarId { get; set; }
         public string PayIntervalReferenceDate { get; set; }
         public string PayIntervalReferenceTime { get; set; }

--- a/MudsharpDatabaseLibrary/Models/EconomicZone.cs
+++ b/MudsharpDatabaseLibrary/Models/EconomicZone.cs
@@ -35,6 +35,8 @@ namespace MudSharp.Models
         public string ReferenceTime { get; set; }
         public int IntervalType { get; set; }
         public int IntervalModifier { get; set; }
+        public int IntervalOther { get; set; }
+        public int IntervalFallback { get; set; }
         public int IntervalAmount { get; set; }
         public decimal TotalRevenueHeld { get; set; }
         public long? ControllingClanId { get; set; }

--- a/MudsharpDatabaseLibrary/Models/ProgSchedule.cs
+++ b/MudsharpDatabaseLibrary/Models/ProgSchedule.cs
@@ -10,6 +10,8 @@ namespace MudSharp.Models
         public int IntervalType { get; set; }
         public int IntervalModifier { get; set; }
         public int IntervalOther { get; set; }
+        public int IntervalOtherSecondary { get; set; }
+        public int IntervalFallback { get; set; }
         public string ReferenceTime { get; set; }
         public string ReferenceDate { get; set; }
         public long FutureProgId { get; set; }


### PR DESCRIPTION
## Summary
- Fix weekday copying, backward weekday advancement, non-seven-day calendar math, and intercalary weekday edits
- Correct MudTimeSpan totals, MudDateTime Never handling, timezone parsing, and MudDateTime span arithmetic
- Make listener repeat handling consistent and add focused FutureProg and MudDateTime regressions
- Add a design document for the in-game time and date system

## Testing
- `MudSharpCore Unit Tests`: targeted `MudDateTimeTests` and `FutureProgDateTimeFunctionTests` passed
- `MudSharpCore` build passed with `-c Debug --no-restore -m:1`