### PR TITLE
Add supernatural seeder metadata and question reuse

### DIFF
--- a/DatabaseSeeder Unit Tests/SupernaturalSeederTemplateTests.cs
+++ b/DatabaseSeeder Unit Tests/SupernaturalSeederTemplateTests.cs
@@ -1,0 +1,243 @@
+#nullable enable
+
+using DatabaseSeeder.Seeders;
+using DatabaseSeeder;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Character;
+using MudSharp.Planes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class SupernaturalSeederTemplateTests
+{
+	private static bool PlanarElementContains(XElement? element, long planeId)
+	{
+		return element?
+			.Elements("Plane")
+			.Any(x => long.Parse(x.Attribute("id")?.Value ?? "0") == planeId) == true;
+	}
+
+	[TestMethod]
+	public void ValidateTemplateCatalogForTesting_CurrentCatalog_HasNoIssues()
+	{
+		IReadOnlyList<string> issues = SupernaturalSeeder.ValidateTemplateCatalogForTesting();
+		Assert.AreEqual(0, issues.Count, string.Join("\n", issues));
+	}
+
+	[TestMethod]
+	public void SeederQuestions_ReusesSharedNonHumanQuestionAnswers()
+	{
+		Dictionary<string, SeederQuestion> questions = ((IDatabaseSeeder)new SupernaturalSeeder()).Questions
+			.ToDictionary(x => x.Id, StringComparer.OrdinalIgnoreCase);
+
+		Assert.AreEqual("nonhuman-health-model", questions["model"].SharedAnswerKey);
+		Assert.AreEqual("damage-randomness", questions["random"].SharedAnswerKey);
+		Assert.AreEqual("combat-message-style", questions["messagestyle"].SharedAnswerKey);
+		Assert.IsTrue(questions.Values.All(x => x.AutoReuseLastAnswer));
+	}
+
+	[TestMethod]
+	public void TemplatesForTesting_Catalogue_HasFortyFiveEntries()
+	{
+		Assert.AreEqual(45, SupernaturalSeeder.TemplatesForTesting.Count,
+			"The supernatural catalogue should match the approved V1 scope.");
+	}
+
+	[TestMethod]
+	public void TemplatesForTesting_AngelsFollowMaimonidesOrder()
+	{
+		CollectionAssert.AreEqual(
+			new[]
+			{
+				"Chayot HaKodesh",
+				"Ophanim",
+				"Erelim",
+				"Hashmallim",
+				"Seraphim",
+				"Malakhim",
+				"Elohim",
+				"Bene Elohim",
+				"Cherubim",
+				"Ishim"
+			},
+			SupernaturalSeeder.AngelicRankOrderForTesting.ToArray());
+
+		CollectionAssert.IsSubsetOf(
+			SupernaturalSeeder.AngelicRankOrderForTesting.ToArray(),
+			SupernaturalSeeder.TemplatesForTesting.Keys.ToArray());
+	}
+
+	[TestMethod]
+	public void TemplatesForTesting_DemonsMirrorFallenRanksAndIncludeCommonTypes()
+	{
+		foreach (string angelRank in SupernaturalSeeder.AngelicRankOrderForTesting)
+		{
+			string fallenName = $"Fallen {angelRank}";
+			Assert.IsTrue(SupernaturalSeeder.TemplatesForTesting.ContainsKey(fallenName),
+				$"Missing fallen rank {fallenName}.");
+		}
+
+		foreach (string demonName in SupernaturalSeeder.CommonDemonNamesForTesting)
+		{
+			Assert.IsTrue(SupernaturalSeeder.TemplatesForTesting.ContainsKey(demonName),
+				$"Missing common demon {demonName}.");
+		}
+	}
+
+	[TestMethod]
+	public void TemplatesForTesting_SupportedUndeadSubset_IsIncluded()
+	{
+		foreach (string undeadName in SupernaturalSeeder.SupportedUndeadNamesForTesting)
+		{
+			Assert.IsTrue(SupernaturalSeeder.TemplatesForTesting.ContainsKey(undeadName),
+				$"Missing supported undead or incorporeal undead entry {undeadName}.");
+		}
+
+		Assert.AreEqual("Supernatural Lich Skeleton", SupernaturalSeeder.TemplatesForTesting["Lich"].BodyKey);
+		Assert.AreEqual("Supernatural Decayed Undead", SupernaturalSeeder.TemplatesForTesting["Zombie"].BodyKey);
+		Assert.AreEqual("Supernatural Spirit Form", SupernaturalSeeder.TemplatesForTesting["Ghost"].BodyKey);
+	}
+
+	[TestMethod]
+	public void TemplatesForTesting_AllRacesAreBuilderOnlyByDefault()
+	{
+		Assert.IsTrue(SupernaturalSeeder.TemplatesForTesting.Values.All(x => !x.PlayableDefault),
+			"Supernatural races should be hidden from normal chargen until builders opt in.");
+	}
+
+	[TestMethod]
+	public void TemplatesForTesting_RepresentativeBodyAssignments_MatchSupernaturalForms()
+	{
+		Assert.AreEqual("Supernatural Ophanic Wheel", SupernaturalSeeder.TemplatesForTesting["Ophanim"].BodyKey);
+		Assert.AreEqual("Supernatural Many-Winged Angel", SupernaturalSeeder.TemplatesForTesting["Seraphim"].BodyKey);
+		Assert.AreEqual("Supernatural Horned Fiend", SupernaturalSeeder.TemplatesForTesting["Fiend"].BodyKey);
+		Assert.AreEqual("Supernatural Familiar", SupernaturalSeeder.TemplatesForTesting["Familiar"].BodyKey);
+		Assert.AreEqual("Supernatural Werewolf Hybrid", SupernaturalSeeder.TemplatesForTesting["Werewolf Hybrid"].BodyKey);
+		Assert.AreEqual("Supernatural Hellhound", SupernaturalSeeder.TemplatesForTesting["Hellhound"].BodyKey);
+	}
+
+	[TestMethod]
+	public void TemplatesForTesting_NeedsProfiles_MatchSupportedMechanics()
+	{
+		string[] living = SupernaturalSeeder.TemplatesForTesting
+			.Where(x => x.Value.NeedsProfile == SupernaturalSeeder.SupernaturalNeedsProfile.Living)
+			.Select(x => x.Key)
+			.OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+			.ToArray();
+
+		CollectionAssert.AreEquivalent(new[] { "Werewolf", "Werewolf Hybrid" }, living);
+		Assert.IsTrue(SupernaturalSeeder.TemplatesForTesting.Values
+			.Where(x => x.Family is not SupernaturalSeeder.SupernaturalFamily.Therianthrope)
+			.All(x => x.NeedsProfile == SupernaturalSeeder.SupernaturalNeedsProfile.NonLiving));
+	}
+
+	[TestMethod]
+	public void TemplatesForTesting_SupernaturalCharacteristics_ArePresentAndBroad()
+	{
+		string[] expectedDefinitions =
+		[
+			"Halo Radiance",
+			"Wing Aspect",
+			"Eye Motif",
+			"Infernal Mark",
+			"Horn Style",
+			"Tail Form",
+			"Death Mark",
+			"Spirit Manifestation",
+			"Corpse Condition",
+			"Bestial Transformation Tell"
+		];
+
+		string[] actualDefinitions = SupernaturalSeeder.TemplatesForTesting.Values
+			.SelectMany(x => x.Characteristics)
+			.Select(x => x.DefinitionName)
+			.Distinct(StringComparer.OrdinalIgnoreCase)
+			.ToArray();
+
+		CollectionAssert.IsSubsetOf(expectedDefinitions, actualDefinitions);
+		Assert.IsTrue(SupernaturalSeeder.TemplatesForTesting.Values.All(x => x.DescriptionVariants.Count >= 2));
+	}
+
+	[TestMethod]
+	public void TemplatesForTesting_AttackKeys_CoverSupernaturalNaturalAttacks()
+	{
+		string[] expectedAttacks =
+		[
+			"Radiant Touch",
+			"Radiant Gaze",
+			"Wing Buffet",
+			"Infernal Claw",
+			"Horn Gore",
+			"Fanged Bite",
+			"Soul Chill",
+			"Grave Claw",
+			"Wheel Crush",
+			"Spectral Touch"
+		];
+
+		string[] actualAttacks = SupernaturalSeeder.TemplatesForTesting.Values
+			.SelectMany(x => x.Attacks)
+			.Select(x => x.AttackName)
+			.Distinct(StringComparer.OrdinalIgnoreCase)
+			.ToArray();
+
+		CollectionAssert.IsSubsetOf(expectedAttacks, actualAttacks);
+	}
+
+	[TestMethod]
+	public void PlanarProfileXml_IncorporealProfile_IsVisibleButNotPhysicalOnPrime()
+	{
+		XElement root = SupernaturalSeeder.BuildPlanarProfileXmlForTesting(1, 2,
+			SupernaturalSeeder.SupernaturalPlanarProfile.Incorporeal);
+
+		Assert.IsTrue(PlanarElementContains(root.Element("Presence"), 2));
+		Assert.IsTrue(PlanarElementContains(root.Element("VisibleTo"), 1));
+		Assert.IsTrue(bool.Parse(root.Element("Flags")!.Attribute("suspendsPhysicalContact")!.Value));
+
+		XElement physical = root.Element("Interactions")!
+			.Elements("Interaction")
+			.Single(x => x.Attribute("kind")?.Value == PlanarInteractionKind.Physical.ToString());
+		Assert.IsFalse(PlanarElementContains(physical, 1));
+		Assert.IsFalse(PlanarElementContains(physical, 2));
+	}
+
+	[TestMethod]
+	public void PlanarProfileXml_DualNaturedProfile_IsPresentAndPhysicalOnBothPlanes()
+	{
+		XElement root = SupernaturalSeeder.BuildPlanarProfileXmlForTesting(1, 2,
+			SupernaturalSeeder.SupernaturalPlanarProfile.DualNatured);
+
+		Assert.IsTrue(PlanarElementContains(root.Element("Presence"), 1));
+		Assert.IsTrue(PlanarElementContains(root.Element("Presence"), 2));
+		XElement physical = root.Element("Interactions")!
+			.Elements("Interaction")
+			.Single(x => x.Attribute("kind")?.Value == PlanarInteractionKind.Physical.ToString());
+		Assert.IsTrue(PlanarElementContains(physical, 1));
+		Assert.IsTrue(PlanarElementContains(physical, 2));
+	}
+
+	[TestMethod]
+	public void AdditionalBodyFormMeritXml_DefaultsToSafeBuilderControlledForms()
+	{
+		SupernaturalSeeder.SupernaturalFormTemplate template =
+			SupernaturalSeeder.FormTemplatesForTesting.Single(x => x.MeritName == "Supernatural Werewolf Hybrid Form");
+
+		XElement root = SupernaturalSeeder.BuildAdditionalBodyFormMeritDefinitionForTesting(
+			template,
+			42,
+			1,
+			2);
+
+		Assert.AreEqual("42", root.Element("Race")!.Value);
+		Assert.AreEqual("hybrid", root.Element("Alias")!.Value);
+		Assert.AreEqual(((int)BodySwitchTraumaMode.Automatic).ToString(), root.Element("TraumaMode")!.Value);
+		Assert.IsTrue(bool.Parse(root.Element("AllowVoluntarySwitch")!.Value));
+		Assert.IsFalse(bool.Parse(root.Element("AutoTransformWhenApplicable")!.Value));
+		Assert.AreEqual("2", root.Element("ChargenAvailableProg")!.Value);
+	}
+}

--- a/DatabaseSeeder/SeederMetadataRegistry.cs
+++ b/DatabaseSeeder/SeederMetadataRegistry.cs
@@ -243,6 +243,34 @@ public static class SeederMetadataRegistry
                 ],
                 RerunSummary: "Reruns install missing stock mythic races without duplicating existing entries."
             ),
+            nameof(SupernaturalSeeder) => new SeederMetadata(
+                SeederRepeatabilityMode.Idempotent,
+                SeederUpdateCapability.RepairExisting,
+                [
+                    Requirement("Human, animal, and mythical body frameworks must already be installed.", context =>
+                        new[] { "Organic Humanoid", "Winged Humanoid", "Horned Humanoid", "Toed Quadruped" }
+                            .All(body => context.BodyProtos.Any(x => x.Name == body))),
+                    Requirement("Human, organic humanoid, and wolf race foundations must already exist.", context =>
+                        new[] { "Human", "Organic Humanoid", "Wolf" }.All(race => context.Races.Any(x => x.Name == race))),
+                    Requirement("Shared humanoid characteristic profiles must already exist.", context =>
+                        new[] { "All Eye Colours", "All Eye Shapes", "All Noses", "All Ears", "All Hair Colours", "All Facial Hair Colours", "All Hair Styles", "All Skin Colours", "All Frames", "Person Word" }
+                            .All(profile =>
+                                context.CharacteristicProfiles.Any(x => x.Name == profile) ||
+                                context.CharacteristicDefinitions.Any(x => x.Name == profile))),
+                    Requirement("Stock natural attacks and non-human health strategies must already exist.", context =>
+                        new[] { "Bite", "Carnivore Bite", "Claw High Swipe", "Claw Low Swipe", "Animal Barge", "Wing Buffet" }
+                            .All(attack => context.WeaponAttacks.Any(x => x.Name == attack)) &&
+                        NonHumanSeederHealthStrategyHelper.AllStrategyNames.All(strategy => context.HealthStrategies.Any(x => x.Name == strategy))),
+                    Requirement("Stock helper progs, corpse models, and at least one calendar must already exist.", context =>
+                        new[] { "AlwaysTrue", "AlwaysFalse", "AlwaysZero" }.All(prog => context.FutureProgs.Any(x => x.FunctionName == prog)) &&
+                        context.CorpseModels.Any(x => x.Name == "Organic Human Corpse") &&
+                        context.CorpseModels.Any(x => x.Name == "Organic Animal Corpse") &&
+                        context.Calendars.Any())
+                ],
+                RerunSummary: "Reruns install or refresh the stock supernatural race catalogue, body prototypes, form merits, cultures, name cultures, attacks, and non-breather settings.",
+                UpdateSummary: "Existing builder-customized worlds keep their records; stock-owned supernatural records are repaired by stable names without deleting custom extensions.",
+                OwnershipSummary: "Supernatural stock content is tracked by stable race, body, culture, name-culture, merit, attack, and corpse-model names."
+            ),
             nameof(WeatherSeeder) => new SeederMetadata(
                 SeederRepeatabilityMode.Idempotent,
                 SeederUpdateCapability.RepairExisting,

--- a/DatabaseSeeder/SeederQuestionRegistry.cs
+++ b/DatabaseSeeder/SeederQuestionRegistry.cs
@@ -54,6 +54,19 @@ public static class SeederQuestionRegistry
                 SharedAnswerKey: "nonhuman-health-model",
                 AutoReuseLastAnswer: true
             ),
+            [BuildKey(nameof(SupernaturalSeeder), "messagestyle")] = new(
+                SharedAnswerKey: "combat-message-style",
+                DefaultAnswerResolver: (context, _) => CombatSeederMessageStyleHelper.GetRecordedChoice(context),
+                AutoReuseLastAnswer: true
+            ),
+            [BuildKey(nameof(SupernaturalSeeder), "random")] = new(
+                SharedAnswerKey: "damage-randomness",
+                AutoReuseLastAnswer: true
+            ),
+            [BuildKey(nameof(SupernaturalSeeder), "model")] = new(
+                SharedAnswerKey: "nonhuman-health-model",
+                AutoReuseLastAnswer: true
+            ),
             [BuildKey(nameof(HumanSeeder), "balance")] = new(
                 SharedAnswerKey: CombatBalanceProfileHelper.SharedAnswerKey,
                 DefaultAnswerResolver: (context, _) => CombatBalanceProfileHelper.GetRecordedChoice(context),

--- a/DatabaseSeeder/Seeders/SupernaturalSeeder.Definitions.cs
+++ b/DatabaseSeeder/Seeders/SupernaturalSeeder.Definitions.cs
@@ -1,0 +1,530 @@
+#nullable enable
+
+using MudSharp.Body;
+using MudSharp.Character;
+using MudSharp.Form.Characteristics;
+using MudSharp.GameItems;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace DatabaseSeeder.Seeders;
+
+public partial class SupernaturalSeeder
+{
+	internal const string NonBreathingModel = "non-breather";
+
+	internal enum SupernaturalFamily
+	{
+		Angel,
+		Demon,
+		Divine,
+		Spirit,
+		Therianthrope,
+		Undead
+	}
+
+	internal enum SupernaturalPlanarProfile
+	{
+		Material,
+		AstralNative,
+		Incorporeal,
+		DualNatured,
+		Manifested
+	}
+
+	internal enum SupernaturalNeedsProfile
+	{
+		Living,
+		NonLiving
+	}
+
+	internal sealed record SupernaturalAgeProfile(
+		int ChildAge,
+		int YouthAge,
+		int YoungAdultAge,
+		int AdultAge,
+		int ElderAge,
+		int VenerableAge
+	);
+
+	internal sealed record SupernaturalAttackTemplate(
+		string AttackName,
+		ItemQuality Quality,
+		IReadOnlyList<string> BodypartAliases
+	);
+
+	internal sealed record SupernaturalBodypartUsageTemplate(
+		string BodypartAlias,
+		string Usage
+	);
+
+	internal sealed record SupernaturalCharacteristicTemplate(
+		string DefinitionName,
+		IReadOnlyList<string> Values,
+		string Usage = "base",
+		CharacteristicType Type = CharacteristicType.Standard
+	);
+
+	internal sealed record SupernaturalRaceTemplate(
+		string Name,
+		SupernaturalFamily Family,
+		string BodyKey,
+		SizeCategory Size,
+		SupernaturalPlanarProfile PlanarProfile,
+		SupernaturalNeedsProfile NeedsProfile,
+		NonHumanAttributeProfile AttributeProfile,
+		string Description,
+		string RoleDescription,
+		IReadOnlyList<StockDescriptionVariant> DescriptionVariants,
+		IReadOnlyList<SupernaturalAttackTemplate> Attacks,
+		IReadOnlyList<SupernaturalCharacteristicTemplate> Characteristics,
+		IReadOnlyList<SupernaturalBodypartUsageTemplate>? BodypartUsages = null,
+		string CultureKey = "Spirit Court",
+		string NameCultureKey = "Spirit Name",
+		string CombatStrategyKey = "Melee (Auto)",
+		bool PlayableDefault = false,
+		bool CanUseWeapons = true,
+		bool CanClimb = true,
+		bool CanSwim = true,
+		bool UsesHumanoidCharacteristics = true,
+		double BodypartHealthMultiplier = 1.0
+	);
+
+	internal sealed record SupernaturalFormTemplate(
+		string MeritName,
+		string TargetRaceName,
+		string Alias,
+		int SortOrder,
+		bool AllowVoluntarySwitch,
+		bool AutoTransformWhenApplicable,
+		BodySwitchTraumaMode TraumaMode,
+		string ChargenBlurb,
+		string DescriptionText
+	);
+
+	internal static IReadOnlyDictionary<string, SupernaturalRaceTemplate> TemplatesForTesting => Templates;
+	internal static IReadOnlyList<string> AngelicRankOrderForTesting => AngelicRankOrder;
+	internal static IReadOnlyList<string> CommonDemonNamesForTesting => CommonDemonNames;
+	internal static IReadOnlyList<string> SupportedUndeadNamesForTesting => SupportedUndeadNames;
+	internal static IReadOnlyList<SupernaturalFormTemplate> FormTemplatesForTesting => FormTemplates;
+	internal static string NonBreathingModelForTesting => NonBreathingModel;
+
+	private static readonly IReadOnlyList<string> AngelicRankOrder =
+	[
+		"Chayot HaKodesh",
+		"Ophanim",
+		"Erelim",
+		"Hashmallim",
+		"Seraphim",
+		"Malakhim",
+		"Elohim",
+		"Bene Elohim",
+		"Cherubim",
+		"Ishim"
+	];
+
+	private static readonly IReadOnlyList<string> CommonDemonNames =
+	[
+		"Incubus",
+		"Succubus",
+		"Fury",
+		"Imp",
+		"Familiar",
+		"Fiend",
+		"Hellhound"
+	];
+
+	private static readonly IReadOnlyList<string> SupportedUndeadNames =
+	[
+		"Ghost",
+		"Wraith",
+		"Vampire",
+		"Lich",
+		"Ghoul",
+		"Zombie",
+		"Skeleton",
+		"Mummy"
+	];
+
+	private static readonly IReadOnlyList<SupernaturalFormTemplate> FormTemplates =
+	[
+		new(
+			"Supernatural Werewolf Hybrid Form",
+			"Werewolf Hybrid",
+			"hybrid",
+			10,
+			true,
+			false,
+			BodySwitchTraumaMode.Automatic,
+			"Grants access to a builder-controlled wolf-man battle form.",
+			"$0 have|has access to a builder-controlled werewolf hybrid form."),
+		new(
+			"Supernatural Werewolf Wolf Form",
+			"Wolf",
+			"wolf",
+			20,
+			true,
+			false,
+			BodySwitchTraumaMode.Automatic,
+			"Grants access to a builder-controlled wolf form when the Animal package is installed.",
+			"$0 have|has access to a builder-controlled wolf form."),
+		new(
+			"Supernatural Ghost Manifestation",
+			"Ghost",
+			"manifested ghost",
+			10,
+			true,
+			false,
+			BodySwitchTraumaMode.Stash,
+			"Grants access to a visible ghostly manifestation form.",
+			"$0 can|can appear in a visible ghostly manifestation."),
+		new(
+			"Supernatural Spirit Manifestation",
+			"Spirit",
+			"manifested spirit",
+			10,
+			true,
+			false,
+			BodySwitchTraumaMode.Stash,
+			"Grants access to a visible spirit manifestation form.",
+			"$0 can|can appear in a visible spirit manifestation."),
+		new(
+			"Supernatural Angelic Manifestation",
+			"Ishim",
+			"angelic manifestation",
+			10,
+			true,
+			false,
+			BodySwitchTraumaMode.Stash,
+			"Grants access to a human-facing angelic manifestation form.",
+			"$0 can|can assume a human-facing angelic manifestation."),
+		new(
+			"Supernatural Demonic Manifestation",
+			"Fiend",
+			"demonic manifestation",
+			10,
+			true,
+			false,
+			BodySwitchTraumaMode.Stash,
+			"Grants access to a human-facing demonic manifestation form.",
+			"$0 can|can assume a human-facing demonic manifestation.")
+	];
+
+	private static readonly IReadOnlyDictionary<string, SupernaturalRaceTemplate> Templates =
+		new ReadOnlyDictionary<string, SupernaturalRaceTemplate>(BuildTemplates());
+
+	private static Dictionary<string, SupernaturalRaceTemplate> BuildTemplates()
+	{
+		static SupernaturalAttackTemplate Attack(string name, ItemQuality quality, params string[] aliases)
+		{
+			return new(name, quality, aliases);
+		}
+
+		static SupernaturalCharacteristicTemplate Characteristic(string name, params string[] values)
+		{
+			return new(name, values);
+		}
+
+		static NonHumanAttributeProfile Stats(
+			int strength,
+			int constitution,
+			int agility,
+			int dexterity,
+			int willpower,
+			int perception,
+			int aura,
+			string? auraDiceExpression = null)
+		{
+			return new(
+				strength,
+				constitution,
+				agility,
+				dexterity,
+				willpower,
+				perception,
+				aura,
+				AuraDiceExpression: auraDiceExpression);
+		}
+
+		static IReadOnlyList<StockDescriptionVariant> Variants(
+			string type,
+			string signature,
+			string bearing)
+		{
+			return SeederDescriptionHelpers.BuildVariantList(
+				(
+					$"a {signature} {type}",
+					SeederDescriptionHelpers.JoinParagraphs(
+						$"This {type} carries a {signature} presence that makes the air around it feel deliberate and charged.",
+						$"Its body language is {bearing}, with small details that give builders a strong first impression without locking the creature to one setting.",
+						"The stock description leaves room for local cosmology, patron, cult, court or curse details to be layered through normal builder tools.")
+				),
+				(
+					$"a {bearing} {type}",
+					SeederDescriptionHelpers.JoinParagraphs(
+						$"This {type} has a {bearing} aspect, marked by controlled movement and a supernatural stillness.",
+						$"The {signature} details are visible enough to distinguish it from ordinary mortal stock while still supporting varied worlds.",
+						"Builders can use this variant as-is or attach more specific description patterns for named orders, hosts, courts or bloodlines.")
+				));
+		}
+
+		static string RaceDescription(string name, string family, string role)
+		{
+			return SeederDescriptionHelpers.JoinParagraphs(
+				$"{name} are part of the stock supernatural {family} catalogue seeded for builders who want powerful non-mortal characters, NPCs, patrons or adversaries.",
+				$"The template focuses on {role}, supplying a complete playable engine shape while leaving cosmology, theology and setting-specific allegiance under builder control.",
+				"By default the race is builder-only in chargen. Its anatomy, needs, planar profile, description variables and combat hooks are installed so it can function immediately once a builder chooses to expose it.");
+		}
+
+		static string RoleDescription(string name, string role)
+		{
+			return SeederDescriptionHelpers.JoinParagraphs(
+				$"{name} are intended for {role}.",
+				"They are seeded as stock examples, not as a statement that every game must use the same mythology.",
+				"Their strongest value is giving builders working examples of supernatural anatomy, planar presence, alternate forms and race-specific description variables.");
+		}
+
+		static SupernaturalRaceTemplate Template(
+			string name,
+			SupernaturalFamily family,
+			string body,
+			SizeCategory size,
+			SupernaturalPlanarProfile planar,
+			SupernaturalNeedsProfile needs,
+			NonHumanAttributeProfile stats,
+			string role,
+			IReadOnlyList<SupernaturalAttackTemplate> attacks,
+			IReadOnlyList<SupernaturalCharacteristicTemplate> characteristics,
+			string culture,
+			string nameCulture,
+			bool weapons = true,
+			bool humanoid = true,
+			string combat = "Melee (Auto)",
+			double health = 1.0)
+		{
+			string familyName = family.ToString().ToLowerInvariant();
+			return new(
+				name,
+				family,
+				body,
+				size,
+				planar,
+				needs,
+				stats,
+				RaceDescription(name, familyName, role),
+				RoleDescription(name, role),
+				Variants(name.ToLowerInvariant(), characteristics.First().Values.First().ToLowerInvariant(), role.ToLowerInvariant()),
+				attacks,
+				characteristics,
+				CultureKey: culture,
+				NameCultureKey: nameCulture,
+				CombatStrategyKey: combat,
+				CanUseWeapons: weapons,
+				CanClimb: humanoid,
+				CanSwim: true,
+				UsesHumanoidCharacteristics: humanoid,
+				BodypartHealthMultiplier: health);
+		}
+
+		var templates = new Dictionary<string, SupernaturalRaceTemplate>(StringComparer.OrdinalIgnoreCase);
+
+		void Add(SupernaturalRaceTemplate template)
+		{
+			templates[template.Name] = template;
+		}
+
+		var radiant = Characteristic("Halo Radiance", "soft aureole", "burning crown", "star-bright nimbus", "hidden glimmer");
+		var wings = Characteristic("Wing Aspect", "snow-white wings", "bronze-edged wings", "many-eyed pinions", "shadowless wings");
+		var eyes = Characteristic("Eye Motif", "golden eyes", "many watchful eyes", "flame-blue eyes", "mirror-bright eyes");
+		var infernal = Characteristic("Infernal Mark", "ember-scored sigils", "blackened veins", "smoke-wreathed aura", "hellish brand");
+		var horns = Characteristic("Horn Style", "swept-back horns", "broken horns", "spiralled horns", "small ivory horns");
+		var tail = Characteristic("Tail Form", "barbed tail", "serpentine tail", "forked tail", "lash-like tail");
+		var death = Characteristic("Death Mark", "grave-pale skin", "ashen stains", "mummified flesh", "bone-white pallor");
+		var spirit = Characteristic("Spirit Manifestation", "mist-thin outline", "lantern glow", "smoke-edged silhouette", "rainbow shimmer");
+		var corpse = Characteristic("Corpse Condition", "freshly dead", "ancient bones", "wrapped and preserved", "restless remains");
+		var beast = Characteristic("Bestial Transformation Tell", "yellow wolf eyes", "coarse hackles", "clawed hands", "muzzled profile");
+
+		var angelAttacks = new[]
+		{
+			Attack("Radiant Touch", ItemQuality.Good, "rhand", "lhand"),
+			Attack("Radiant Gaze", ItemQuality.Good, "reye", "leye")
+		};
+		var wingedAngelAttacks = angelAttacks.Append(Attack("Wing Buffet", ItemQuality.Standard, "rwingbase", "lwingbase")).ToArray();
+		var demonAttacks = new[]
+		{
+			Attack("Infernal Claw", ItemQuality.Good, "rhand", "lhand"),
+			Attack("Horn Gore", ItemQuality.Standard, "rhorn", "lhorn"),
+			Attack("Fanged Bite", ItemQuality.Standard, "mouth")
+		};
+		var spiritAttacks = new[]
+		{
+			Attack("Spectral Touch", ItemQuality.Standard, "rhand", "lhand"),
+			Attack("Soul Chill", ItemQuality.Standard, "rhand", "lhand")
+		};
+		var undeadAttacks = new[]
+		{
+			Attack("Grave Claw", ItemQuality.Standard, "rhand", "lhand"),
+			Attack("Fanged Bite", ItemQuality.Standard, "mouth")
+		};
+
+		foreach ((string rank, int index) in AngelicRankOrder.Select((rank, index) => (rank, index)))
+		{
+			string body = rank switch
+			{
+				"Ophanim" => "Supernatural Ophanic Wheel",
+				"Chayot HaKodesh" or "Seraphim" => "Supernatural Many-Winged Angel",
+				"Ishim" => "Supernatural Angelic Humanoid",
+				_ => "Supernatural Winged Angel"
+			};
+			SupernaturalAttackTemplate[] attacks = rank == "Ophanim"
+				? [Attack("Wheel Crush", ItemQuality.VeryGood, "torso"), Attack("Radiant Gaze", ItemQuality.Good, "reye", "leye")]
+				: wingedAngelAttacks;
+			Add(Template(rank, SupernaturalFamily.Angel, body, index < 2 ? SizeCategory.Large : SizeCategory.Normal,
+				SupernaturalPlanarProfile.DualNatured, SupernaturalNeedsProfile.NonLiving,
+				Stats(2 + Math.Max(0, 4 - index / 2), 2 + Math.Max(0, 4 - index / 2), 1, 1, 4, 3, 5, "2d4+6"),
+				"celestial order and divine emissary play", attacks, [radiant, wings, eyes], "Celestial Host", "Angelic Name",
+				health: 1.2));
+		}
+
+		foreach ((string rank, int index) in AngelicRankOrder.Select((rank, index) => (rank, index)))
+		{
+			string fallenName = $"Fallen {rank}";
+			string body = rank == "Ophanim" ? "Supernatural Ophanic Wheel" : "Supernatural Horned Fiend";
+			SupernaturalAttackTemplate[] attacks = rank == "Ophanim"
+				? [Attack("Wheel Crush", ItemQuality.VeryGood, "torso"), Attack("Soul Chill", ItemQuality.Good, "reye", "leye")]
+				: demonAttacks;
+			Add(Template(fallenName, SupernaturalFamily.Demon, body, index < 2 ? SizeCategory.Large : SizeCategory.Normal,
+				SupernaturalPlanarProfile.AstralNative, SupernaturalNeedsProfile.NonLiving,
+				Stats(3 + Math.Max(0, 3 - index / 3), 2 + Math.Max(0, 3 - index / 3), 1, 1, 4, 2, 4, "2d4+5"),
+				"fallen celestial adversary and infernal court play", attacks, [infernal, horns, tail, eyes], "Fallen Host",
+				"Demonic Name", health: 1.2));
+		}
+
+		Add(Template("Incubus", SupernaturalFamily.Demon, "Supernatural Horned Fiend", SizeCategory.Normal,
+			SupernaturalPlanarProfile.AstralNative, SupernaturalNeedsProfile.NonLiving, Stats(1, 1, 2, 2, 3, 2, 4, "2d4+4"),
+			"social predator and temptation storylines", demonAttacks, [infernal, horns, tail], "Fallen Host", "Demonic Name"));
+		Add(Template("Succubus", SupernaturalFamily.Demon, "Supernatural Horned Fiend", SizeCategory.Normal,
+			SupernaturalPlanarProfile.AstralNative, SupernaturalNeedsProfile.NonLiving, Stats(1, 1, 2, 2, 3, 2, 4, "2d4+4"),
+			"social predator and temptation storylines", demonAttacks, [infernal, horns, tail], "Fallen Host", "Demonic Name"));
+		Add(Template("Fury", SupernaturalFamily.Demon, "Supernatural Horned Fiend", SizeCategory.Normal,
+			SupernaturalPlanarProfile.DualNatured, SupernaturalNeedsProfile.NonLiving, Stats(3, 2, 3, 1, 3, 3, 3, "2d4+3"),
+			"vengeance spirit and relentless hunter play", demonAttacks, [infernal, wings, eyes], "Fallen Host", "Demonic Name",
+			combat: "Beast Brawler"));
+		Add(Template("Imp", SupernaturalFamily.Demon, "Supernatural Familiar", SizeCategory.Small,
+			SupernaturalPlanarProfile.AstralNative, SupernaturalNeedsProfile.NonLiving, Stats(-2, -1, 3, 2, 1, 2, 2, "1d4+2"),
+			"minor demon, spy and nuisance familiar play", demonAttacks, [infernal, horns, tail], "Fallen Host", "Demonic Name",
+			weapons: false, combat: "Beast Skirmisher", health: 0.75));
+		Add(Template("Familiar", SupernaturalFamily.Demon, "Supernatural Familiar", SizeCategory.Small,
+			SupernaturalPlanarProfile.AstralNative, SupernaturalNeedsProfile.NonLiving, Stats(-3, -1, 4, 2, 2, 3, 2, "1d4+2"),
+			"bound companion, spy and occult assistant play", demonAttacks, [infernal, tail, eyes], "Fallen Host", "Demonic Name",
+			weapons: false, combat: "Beast Skirmisher", health: 0.7));
+		Add(Template("Fiend", SupernaturalFamily.Demon, "Supernatural Horned Fiend", SizeCategory.Large,
+			SupernaturalPlanarProfile.AstralNative, SupernaturalNeedsProfile.NonLiving, Stats(5, 4, 0, 0, 3, 2, 3, "2d4+4"),
+			"brutal infernal monster and war-demon play", demonAttacks, [infernal, horns, tail], "Fallen Host", "Demonic Name",
+			combat: "Beast Brawler", health: 1.3));
+		Add(Template("Hellhound", SupernaturalFamily.Demon, "Supernatural Hellhound", SizeCategory.Large,
+			SupernaturalPlanarProfile.Material, SupernaturalNeedsProfile.NonLiving, Stats(4, 3, 2, 0, 2, 4, 2, "1d4+2"),
+			"infernal hunting beast play", [Attack("Fanged Bite", ItemQuality.VeryGood, "mouth"), Attack("Infernal Claw", ItemQuality.Good, "rfclaw", "lfclaw", "rrclaw", "lrclaw")],
+			[infernal, eyes], "Fallen Host", "Demonic Name", weapons: false, humanoid: false, combat: "Beast Brawler", health: 1.2));
+
+		Add(Template("Demigod", SupernaturalFamily.Divine, "Supernatural Divine Humanoid", SizeCategory.Normal,
+			SupernaturalPlanarProfile.DualNatured, SupernaturalNeedsProfile.NonLiving, Stats(3, 3, 1, 1, 3, 2, 5, "2d4+5"),
+			"divine-blooded heroes, avatars and staff-guided legends", angelAttacks, [radiant, eyes], "Celestial Host", "Angelic Name"));
+		Add(Template("Lesser God", SupernaturalFamily.Divine, "Supernatural Many-Winged Angel", SizeCategory.Large,
+			SupernaturalPlanarProfile.DualNatured, SupernaturalNeedsProfile.NonLiving, Stats(6, 6, 2, 2, 6, 4, 8, "2d6+8"),
+			"local deities, patrons and divine NPCs", wingedAngelAttacks, [radiant, wings, eyes], "Celestial Host", "Angelic Name",
+			health: 1.5));
+		Add(Template("Greater God", SupernaturalFamily.Divine, "Supernatural Many-Winged Angel", SizeCategory.VeryLarge,
+			SupernaturalPlanarProfile.DualNatured, SupernaturalNeedsProfile.NonLiving, Stats(8, 8, 2, 2, 8, 5, 10, "2d6+10"),
+			"major deities and administrator-facing divine examples", wingedAngelAttacks, [radiant, wings, eyes], "Celestial Host",
+			"Angelic Name", health: 1.8));
+
+		Add(Template("Spirit", SupernaturalFamily.Spirit, "Supernatural Spirit Form", SizeCategory.Normal,
+			SupernaturalPlanarProfile.Incorporeal, SupernaturalNeedsProfile.NonLiving, Stats(-1, 0, 2, 1, 3, 3, 3, "2d4+3"),
+			"generic incorporeal spirits", spiritAttacks, [spirit, eyes], "Spirit Court", "Spirit Name", combat: "Beast Skirmisher"));
+		Add(Template("Ghost", SupernaturalFamily.Spirit, "Supernatural Spirit Form", SizeCategory.Normal,
+			SupernaturalPlanarProfile.Incorporeal, SupernaturalNeedsProfile.NonLiving, Stats(-2, 0, 2, 1, 3, 3, 3, "2d4+3"),
+			"dead souls and haunting NPCs", spiritAttacks, [spirit, death], "Spirit Court", "Spirit Name", combat: "Beast Skirmisher"));
+		Add(Template("Specter", SupernaturalFamily.Spirit, "Supernatural Spirit Form", SizeCategory.Normal,
+			SupernaturalPlanarProfile.Incorporeal, SupernaturalNeedsProfile.NonLiving, Stats(-1, 1, 3, 2, 4, 4, 3, "2d4+3"),
+			"predatory hauntings and feared incorporeal monsters", spiritAttacks, [spirit, death], "Spirit Court", "Spirit Name",
+			combat: "Beast Skirmisher"));
+		Add(Template("Wraith", SupernaturalFamily.Spirit, "Supernatural Spirit Form", SizeCategory.Normal,
+			SupernaturalPlanarProfile.Incorporeal, SupernaturalNeedsProfile.NonLiving, Stats(0, 1, 3, 2, 4, 4, 4, "2d4+4"),
+			"dangerous deathly spirits", spiritAttacks, [spirit, death], "Spirit Court", "Spirit Name", combat: "Beast Skirmisher"));
+		Add(Template("Ancestral Spirit", SupernaturalFamily.Spirit, "Supernatural Spirit Form", SizeCategory.Normal,
+			SupernaturalPlanarProfile.Incorporeal, SupernaturalNeedsProfile.NonLiving, Stats(-1, 0, 1, 1, 4, 3, 4, "2d4+4"),
+			"ancestor worship, family guardians and cultural spirit play", spiritAttacks, [spirit, eyes], "Spirit Court", "Spirit Name"));
+		Add(Template("Nature Spirit", SupernaturalFamily.Spirit, "Supernatural Spirit Form", SizeCategory.Normal,
+			SupernaturalPlanarProfile.Incorporeal, SupernaturalNeedsProfile.NonLiving, Stats(0, 1, 2, 1, 3, 4, 4, "2d4+4"),
+			"wilderness, grove and land-spirit play", spiritAttacks, [spirit, eyes], "Spirit Court", "Spirit Name"));
+		Add(Template("Elemental Spirit", SupernaturalFamily.Spirit, "Supernatural Spirit Form", SizeCategory.Normal,
+			SupernaturalPlanarProfile.Incorporeal, SupernaturalNeedsProfile.NonLiving, Stats(1, 1, 2, 1, 3, 3, 4, "2d4+4"),
+			"fire, storm, water, earth and other elemental courts", spiritAttacks, [spirit, eyes], "Spirit Court", "Spirit Name"));
+
+		Add(Template("Werewolf", SupernaturalFamily.Therianthrope, "Organic Humanoid", SizeCategory.Normal,
+			SupernaturalPlanarProfile.Material, SupernaturalNeedsProfile.Living, Stats(1, 1, 1, 0, 1, 2, 0),
+			"cursed or hereditary shapeshifter play", [Attack("Fanged Bite", ItemQuality.Standard, "mouth")], [beast],
+			"Therianthrope", "Mortal Name"));
+		Add(Template("Werewolf Hybrid", SupernaturalFamily.Therianthrope, "Supernatural Werewolf Hybrid", SizeCategory.Large,
+			SupernaturalPlanarProfile.Material, SupernaturalNeedsProfile.Living, Stats(4, 3, 2, 0, 2, 3, 0),
+			"wolf-man battle forms and cursed transformation play", [Attack("Fanged Bite", ItemQuality.VeryGood, "mouth"), Attack("Infernal Claw", ItemQuality.Good, "rhand", "lhand")],
+			[beast], "Therianthrope", "Mortal Name", weapons: false, combat: "Beast Brawler", health: 1.25));
+
+		Add(Template("Vampire", SupernaturalFamily.Undead, "Organic Humanoid", SizeCategory.Normal,
+			SupernaturalPlanarProfile.Material, SupernaturalNeedsProfile.NonLiving, Stats(2, 2, 2, 1, 3, 3, 3, "2d4+3"),
+			"deathless social predators without hard-coded feeding mechanics", undeadAttacks, [death, eyes], "Undead Remnant", "Undead Name"));
+		Add(Template("Lich", SupernaturalFamily.Undead, "Supernatural Lich Skeleton", SizeCategory.Normal,
+			SupernaturalPlanarProfile.DualNatured, SupernaturalNeedsProfile.NonLiving, Stats(-1, 1, 0, 1, 6, 4, 6, "2d6+6"),
+			"undead sorcerers, ancient powers and staff-controlled antagonists", undeadAttacks, [death, corpse, eyes], "Undead Remnant", "Undead Name"));
+		Add(Template("Ghoul", SupernaturalFamily.Undead, "Supernatural Decayed Undead", SizeCategory.Normal,
+			SupernaturalPlanarProfile.Material, SupernaturalNeedsProfile.NonLiving, Stats(2, 2, 1, 0, 1, 2, 0),
+			"grave-hungry undead servants without bespoke feeding mechanics", undeadAttacks, [death, corpse], "Undead Remnant", "Undead Name",
+			weapons: false, combat: "Beast Brawler"));
+		Add(Template("Zombie", SupernaturalFamily.Undead, "Supernatural Decayed Undead", SizeCategory.Normal,
+			SupernaturalPlanarProfile.Material, SupernaturalNeedsProfile.NonLiving, Stats(2, 4, -2, -2, -2, -1, 0),
+			"durable animated corpses and simple undead threats", undeadAttacks, [death, corpse], "Undead Remnant", "Undead Name",
+			weapons: false, combat: "Beast Brawler", health: 1.35));
+		Add(Template("Skeleton", SupernaturalFamily.Undead, "Supernatural Skeleton", SizeCategory.Normal,
+			SupernaturalPlanarProfile.Material, SupernaturalNeedsProfile.NonLiving, Stats(0, 1, 1, 0, 0, 1, 0),
+			"animated bones and low-maintenance undead guards", undeadAttacks, [death, corpse], "Undead Remnant", "Undead Name",
+			weapons: true, health: 0.9));
+		Add(Template("Mummy", SupernaturalFamily.Undead, "Supernatural Decayed Undead", SizeCategory.Normal,
+			SupernaturalPlanarProfile.Material, SupernaturalNeedsProfile.NonLiving, Stats(3, 4, -1, -1, 3, 1, 2, "1d4+2"),
+			"preserved cursed dead and ancient tomb guardians", undeadAttacks, [death, corpse], "Undead Remnant", "Undead Name",
+			weapons: true, combat: "Beast Brawler", health: 1.4));
+
+		return templates;
+	}
+
+	internal static string BuildRaceDescriptionForTesting(SupernaturalRaceTemplate template)
+	{
+		return template.Description;
+	}
+
+	internal static string BuildEthnicityDescriptionForTesting(SupernaturalRaceTemplate template)
+	{
+		return SeederDescriptionHelpers.JoinParagraphs(
+			$"{template.Name} Stock is the default supernatural ethnicity installed for the {template.Name} race.",
+			$"It provides characteristic profiles and random description support for {template.RoleDescription.Split('\n')[0].TrimEnd('.')}.",
+			"Games can rename, clone or extend it for specific hosts, courts, bloodlines, cults, pantheons, curses or necromantic traditions.");
+	}
+
+	internal static XElement BuildPlanarProfileXmlForTesting(long primePlaneId, long astralPlaneId,
+		SupernaturalPlanarProfile profile)
+	{
+		return BuildPlanarProfile(primePlaneId, astralPlaneId, profile).SaveToXml();
+	}
+
+	internal static XElement BuildAdditionalBodyFormMeritDefinitionForTesting(
+		SupernaturalFormTemplate template,
+		long raceId,
+		long alwaysTrueProgId,
+		long alwaysFalseProgId)
+	{
+		return BuildAdditionalBodyFormMeritDefinition(template, raceId, alwaysTrueProgId, alwaysFalseProgId);
+	}
+}

--- a/DatabaseSeeder/Seeders/SupernaturalSeeder.Support.cs
+++ b/DatabaseSeeder/Seeders/SupernaturalSeeder.Support.cs
@@ -1,0 +1,700 @@
+#nullable enable
+
+using MudSharp.Character.Name;
+using MudSharp.Form.Material;
+using MudSharp.Form.Shape;
+using MudSharp.FutureProg;
+using MudSharp.Framework;
+using MudSharp.Models;
+using MudSharp.Planes;
+using MudSharp.RPG.Merits;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace DatabaseSeeder.Seeders;
+
+public partial class SupernaturalSeeder
+{
+	private const string SupernaturalUndeadCorpseModelName = "Supernatural Nondecaying Undead Remains";
+	private const string SupernaturalSpiritCorpseModelName = "Supernatural Dissipating Spirit Remains";
+
+	private static readonly IReadOnlyDictionary<string, (string SourceBody, SupernaturalPlanarProfile PlanarProfile)> CustomBodyProfiles =
+		new Dictionary<string, (string SourceBody, SupernaturalPlanarProfile PlanarProfile)>(StringComparer.OrdinalIgnoreCase)
+		{
+			["Supernatural Ophanic Wheel"] = ("Organic Humanoid", SupernaturalPlanarProfile.DualNatured),
+			["Supernatural Many-Winged Angel"] = ("Winged Humanoid", SupernaturalPlanarProfile.DualNatured),
+			["Supernatural Winged Angel"] = ("Winged Humanoid", SupernaturalPlanarProfile.DualNatured),
+			["Supernatural Angelic Humanoid"] = ("Organic Humanoid", SupernaturalPlanarProfile.DualNatured),
+			["Supernatural Divine Humanoid"] = ("Organic Humanoid", SupernaturalPlanarProfile.DualNatured),
+			["Supernatural Horned Fiend"] = ("Horned Humanoid", SupernaturalPlanarProfile.AstralNative),
+			["Supernatural Familiar"] = ("Horned Humanoid", SupernaturalPlanarProfile.AstralNative),
+			["Supernatural Hellhound"] = ("Toed Quadruped", SupernaturalPlanarProfile.Material),
+			["Supernatural Spirit Form"] = ("Organic Humanoid", SupernaturalPlanarProfile.Incorporeal),
+			["Supernatural Werewolf Hybrid"] = ("Organic Humanoid", SupernaturalPlanarProfile.Material),
+			["Supernatural Skeleton"] = ("Organic Humanoid", SupernaturalPlanarProfile.Material),
+			["Supernatural Lich Skeleton"] = ("Organic Humanoid", SupernaturalPlanarProfile.DualNatured),
+			["Supernatural Decayed Undead"] = ("Organic Humanoid", SupernaturalPlanarProfile.Material)
+		};
+
+	private static readonly IReadOnlyDictionary<string, (string DonorName, string Message)> SupernaturalAttackCloneDefinitions =
+		new Dictionary<string, (string DonorName, string Message)>(StringComparer.OrdinalIgnoreCase)
+		{
+			["Radiant Touch"] = ("Bite", "@ sear|sears $1 with a touch of radiant power."),
+			["Radiant Gaze"] = ("Bite", "@ strike|strikes $1 with a radiant gaze."),
+			["Infernal Claw"] = ("Claw High Swipe", "@ rake|rakes $1 with infernal claws."),
+			["Soul Chill"] = ("Bite", "@ chill|chills $1 with deathly spiritual force."),
+			["Grave Claw"] = ("Claw Low Swipe", "@ claw|claws $1 with grave-cold hands."),
+			["Wheel Crush"] = ("Animal Barge", "@ crush|crushes into $1 with a living wheel of eyes and flame."),
+			["Fanged Bite"] = ("Carnivore Bite", "@ bite|bites $1 with supernatural fangs."),
+			["Horn Gore"] = ("Animal Barge", "@ gore|gores $1 with supernatural horns."),
+			["Spectral Touch"] = ("Bite", "@ pass|passes a spectral touch through $1.")
+		};
+
+	private static IReadOnlyCollection<string> SupernaturalAttackNames =>
+		Templates.Values
+			.SelectMany(x => x.Attacks)
+			.Select(x => x.AttackName)
+			.Distinct(StringComparer.OrdinalIgnoreCase)
+			.ToArray();
+
+	private static readonly IReadOnlyDictionary<string, (string PersonWord, string Description, string NameCulture)> SupernaturalCultureDefinitions =
+		new Dictionary<string, (string PersonWord, string Description, string NameCulture)>(StringComparer.OrdinalIgnoreCase)
+		{
+			["Celestial Host"] = ("celestial",
+				SeederDescriptionHelpers.JoinParagraphs(
+					"The Celestial Host culture is a builder-facing stock culture for angels, divine messengers and godlike beings.",
+					"It assumes identities formed around rank, charge, office, oath and manifestation rather than ordinary mortal household structures.",
+					"The culture is intentionally broad so a game can turn it into a holy choir, divine bureaucracy, cosmic court or local pantheon."),
+				"Angelic Name"),
+			["Fallen Host"] = ("fallen one",
+				SeederDescriptionHelpers.JoinParagraphs(
+					"The Fallen Host culture is a stock supernatural culture for demons, fallen angels and infernal courts.",
+					"It frames names and social identity around titles, bindings, legions, temptations, bargains and remembered celestial rank.",
+					"Builders can make it theological, folkloric, occult or entirely setting-specific without needing to rebuild the race support data."),
+				"Demonic Name"),
+			["Spirit Court"] = ("spirit",
+				SeederDescriptionHelpers.JoinParagraphs(
+					"The Spirit Court culture supports ghosts, ancestral spirits, nature spirits and other incorporeal supernatural beings.",
+					"It treats identity as a blend of memory, domain, place, death, obligation and manifestation rather than normal mortal descent.",
+					"The stock setup is useful for hauntings, guardian spirits, animist courts, summoned beings and other metaphysical NPCs."),
+				"Spirit Name"),
+			["Undead Remnant"] = ("undead",
+				SeederDescriptionHelpers.JoinParagraphs(
+					"The Undead Remnant culture represents deathless beings that still retain enough identity to operate as characters.",
+					"It avoids hard-coded feeding, resurrection or corpse-vessel mechanics and instead gives builders a safe social wrapper for playable or NPC undead.",
+					"Games can split this into vampire courts, necromancer legions, lich lineages, grave cults or mummy dynasties as needed."),
+				"Undead Name"),
+			["Therianthrope"] = ("shifter",
+				SeederDescriptionHelpers.JoinParagraphs(
+					"The Therianthrope culture covers hereditary and cursed shapeshifters whose social identity sits between ordinary mortal life and bestial transformation.",
+					"It is deliberately mundane enough to support secret werewolf bloodlines, open shapeshifter clans or isolated curse victims.",
+					"The seeded alternate-form merits give builders practical examples for transformation without forcing one moon-cycle rule into every world."),
+				"Mortal Name")
+		};
+
+	private static readonly IReadOnlyDictionary<string, string[]> SupernaturalNameDefinitions =
+		new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+		{
+			["Angelic Name"] =
+			[
+				"Ariel", "Cassiel", "Eremiel", "Ithuriel", "Lailiel", "Mahanael", "Orifiel", "Sandaliel",
+				"Seraphel", "Tzuriel", "Uriel", "Zahariel"
+			],
+			["Demonic Name"] =
+			[
+				"Ashkavar", "Belthra", "Drazhul", "Ezrakk", "Harketh", "Kazmiel", "Malthera", "Nerezza",
+				"Rhaziel", "Sathra", "Vorkath", "Zerukai"
+			],
+			["Spirit Name"] =
+			[
+				"Ash-Beneath-Reed", "Bright Over Stone", "Cold Lantern", "Dawn in Rain", "Echo of Bells",
+				"Last Ember", "Mist at the Ford", "Old Root", "River Memory", "Salt-Wind", "Seven Leaves", "Winter Glass"
+			],
+			["Undead Name"] =
+			[
+				"Ankharet", "Barrow-King", "Cairn Voss", "Dutiful Remnant", "Grey Haman", "Ioseph the Pale",
+				"Khemra", "Marrow Saint", "Neseret", "Old Silas", "Sepulchre", "Vigil of Dust"
+			],
+			["Mortal Name"] =
+			[
+				"Alex", "Sam", "Morgan", "Rowan", "Casey", "Jordan", "Riley", "Taylor",
+				"Blake", "Devon", "Jamie", "Quinn"
+			]
+		};
+
+	internal static IReadOnlyList<string> ValidateTemplateCatalogForTesting()
+	{
+		List<string> issues = new();
+		HashSet<string> knownBodies = new(StringComparer.OrdinalIgnoreCase)
+		{
+			"Organic Humanoid",
+			"Winged Humanoid",
+			"Horned Humanoid",
+			"Toed Quadruped"
+		};
+		knownBodies.UnionWith(CustomBodyProfiles.Keys);
+
+		foreach ((string name, SupernaturalRaceTemplate template) in Templates)
+		{
+			if (!knownBodies.Contains(template.BodyKey))
+			{
+				issues.Add($"{name} references unknown body key {template.BodyKey}.");
+			}
+
+			if (!SupernaturalCultureDefinitions.ContainsKey(template.CultureKey))
+			{
+				issues.Add($"{name} references unknown culture key {template.CultureKey}.");
+			}
+
+			if (!SupernaturalNameDefinitions.ContainsKey(template.NameCultureKey))
+			{
+				issues.Add($"{name} references unknown name culture key {template.NameCultureKey}.");
+			}
+
+			if (template.Attacks.Count == 0)
+			{
+				issues.Add($"{name} does not define any natural attacks.");
+			}
+
+			foreach (SupernaturalAttackTemplate attack in template.Attacks)
+			{
+				if (!SupernaturalAttackCloneDefinitions.ContainsKey(attack.AttackName) &&
+				    !attack.AttackName.Equals("Wing Buffet", StringComparison.OrdinalIgnoreCase))
+				{
+					issues.Add($"{name} references unknown supernatural attack {attack.AttackName}.");
+				}
+			}
+
+			if (template.Characteristics.Count == 0)
+			{
+				issues.Add($"{name} does not define supernatural characteristics.");
+			}
+
+			if (!SeederDescriptionHelpers.HasMinimumParagraphs(BuildRaceDescriptionForTesting(template)))
+			{
+				issues.Add($"{name} race description should have at least three paragraphs.");
+			}
+
+			if (!SeederDescriptionHelpers.HasMinimumParagraphs(BuildEthnicityDescriptionForTesting(template)))
+			{
+				issues.Add($"{name} ethnicity description should have at least three paragraphs.");
+			}
+
+			if (template.DescriptionVariants.Count < 2)
+			{
+				issues.Add($"{name} should have at least two description variants.");
+			}
+		}
+
+		foreach (SupernaturalFormTemplate form in FormTemplates)
+		{
+			if (!Templates.ContainsKey(form.TargetRaceName) && !form.TargetRaceName.Equals("Wolf", StringComparison.OrdinalIgnoreCase))
+			{
+				issues.Add($"{form.MeritName} targets unknown race {form.TargetRaceName}.");
+			}
+		}
+
+		return issues;
+	}
+
+	private void EnsureSupernaturalMaterials()
+	{
+		if (_context.Materials.Any(x => x.Name == "spirit energy"))
+		{
+			return;
+		}
+
+		_context.Materials.Add(new Material
+		{
+			Name = "spirit energy",
+			MaterialDescription = "spirit energy",
+			BehaviourType = (int)MaterialBehaviourType.Spirit,
+			Type = (int)MaterialType.Solid,
+			Density = 1.0,
+			Organic = false,
+			Absorbency = 0.0,
+			ShearYield = 1000,
+			ImpactYield = 1000,
+			ElectricalConductivity = 0.0001,
+			ThermalConductivity = 0.01,
+			SpecificHeatCapacity = 1000,
+			ResidueColour = "pale",
+			ResidueSdesc = "a trace of spirit energy",
+			ResidueDesc = "It is marked by {0}faint spirit energy",
+			SolventVolumeRatio = 1.0
+		});
+		_context.SaveChanges();
+	}
+
+	private CorpseModel EnsureNonDecayingCorpseModel(string name, string description, string sdesc, string fdesc,
+		string partDesc, string materialName)
+	{
+		Material material = _context.Materials.FirstOrDefault(x => x.Name == materialName) ??
+		                    _context.Materials.First(x => x.Name == "bone");
+		CorpseModel model = SeederRepeatabilityHelper.EnsureNamedEntity(
+			_context.CorpseModels,
+			name,
+			x => x.Name,
+			() =>
+			{
+				CorpseModel created = new();
+				_context.CorpseModels.Add(created);
+				return created;
+			});
+
+		model.Name = name;
+		model.Description = description;
+		model.Type = "NonDecaying";
+		model.Definition = new XElement("CorpseModel",
+			new XElement("SDesc", sdesc),
+			new XElement("FDesc", fdesc),
+			new XElement("PartDesc", partDesc),
+			new XElement("CorpseMaterial", material.Id),
+			new XElement("EdiblePercentage", 0.0)).ToString();
+		_context.SaveChanges();
+		return model;
+	}
+
+	private void EnsureSupernaturalAttacks(SupernaturalSeedSummary summary)
+	{
+		foreach ((string name, (string donorName, string message)) in SupernaturalAttackCloneDefinitions)
+		{
+			if (_context.WeaponAttacks.Any(x => x.Name == name))
+			{
+				continue;
+			}
+
+			WeaponAttack donor = _context.WeaponAttacks.First(x => x.Name == donorName);
+			WeaponAttack attack = new()
+			{
+				Name = name,
+				WeaponTypeId = donor.WeaponTypeId,
+				Verb = donor.Verb,
+				FutureProgId = donor.FutureProgId,
+				BaseAttackerDifficulty = donor.BaseAttackerDifficulty,
+				BaseBlockDifficulty = donor.BaseBlockDifficulty,
+				BaseDodgeDifficulty = donor.BaseDodgeDifficulty,
+				BaseParryDifficulty = donor.BaseParryDifficulty,
+				BaseAngleOfIncidence = donor.BaseAngleOfIncidence,
+				RecoveryDifficultySuccess = donor.RecoveryDifficultySuccess,
+				RecoveryDifficultyFailure = donor.RecoveryDifficultyFailure,
+				MoveType = donor.MoveType,
+				Intentions = donor.Intentions,
+				ExertionLevel = donor.ExertionLevel,
+				DamageType = donor.DamageType,
+				DamageExpressionId = donor.DamageExpressionId,
+				StunExpressionId = donor.StunExpressionId,
+				PainExpressionId = donor.PainExpressionId,
+				Weighting = donor.Weighting,
+				BodypartShapeId = donor.BodypartShapeId,
+				StaminaCost = donor.StaminaCost,
+				BaseDelay = donor.BaseDelay,
+				Orientation = donor.Orientation,
+				Alignment = donor.Alignment,
+				AdditionalInfo = donor.AdditionalInfo,
+				HandednessOptions = donor.HandednessOptions,
+				RequiredPositionStateIds = donor.RequiredPositionStateIds,
+				OnUseProgId = donor.OnUseProgId
+			};
+			_context.WeaponAttacks.Add(attack);
+			_context.SaveChanges();
+
+			CombatMessage combatMessage = new()
+			{
+				Type = donor.MoveType,
+				Message = message,
+				Priority = 50,
+				Verb = donor.Verb,
+				Chance = 1.0,
+				FailureMessage = message
+			};
+			combatMessage.CombatMessagesWeaponAttacks.Add(new CombatMessagesWeaponAttacks
+			{
+				CombatMessage = combatMessage,
+				WeaponAttack = attack
+			});
+			_context.CombatMessages.Add(combatMessage);
+			summary.AttacksAdded++;
+		}
+
+		_context.SaveChanges();
+	}
+
+	private void EnsureSupernaturalCulturesAndNames(SupernaturalSeedSummary summary)
+	{
+		foreach ((string name, string[] names) in SupernaturalNameDefinitions)
+		{
+			NameCulture culture = EnsureNameCulture(name);
+			_nameCultures[name] = culture;
+			EnsureRandomNameProfile(culture, names);
+			summary.NameCulturesRefreshed++;
+		}
+
+		foreach ((string name, (string personWord, string description, string nameCulture)) in SupernaturalCultureDefinitions)
+		{
+			Culture? existing = _context.Cultures.FirstOrDefault(x => x.Name == name);
+			bool created = existing is null;
+			Culture culture = existing ?? new Culture();
+			culture.Name = name;
+			culture.Description = description;
+			culture.PersonWordMale = personWord;
+			culture.PersonWordFemale = personWord;
+			culture.PersonWordNeuter = personWord;
+			culture.PersonWordIndeterminate = personWord;
+			culture.SkillStartingValueProg = _alwaysZero;
+			culture.AvailabilityProg = _alwaysFalse;
+			culture.TolerableTemperatureCeilingEffect = 0;
+			culture.TolerableTemperatureFloorEffect = 0;
+			culture.PrimaryCalendarId = _context.Calendars.First().Id;
+			if (created)
+			{
+				_context.Cultures.Add(culture);
+				summary.CulturesAdded++;
+			}
+
+			_context.SaveChanges();
+			foreach (Gender gender in Enum.GetValues<Gender>())
+			{
+				if (_context.CulturesNameCultures.Any(x =>
+					    x.CultureId == culture.Id &&
+					    x.NameCultureId == _nameCultures[nameCulture].Id &&
+					    x.Gender == (short)gender))
+				{
+					continue;
+				}
+
+				_context.CulturesNameCultures.Add(new CulturesNameCultures
+				{
+					Culture = culture,
+					NameCulture = _nameCultures[nameCulture],
+					Gender = (short)gender
+				});
+			}
+		}
+
+		_context.SaveChanges();
+	}
+
+	private NameCulture EnsureNameCulture(string name)
+	{
+		NameCulture culture = SeederRepeatabilityHelper.EnsureNamedEntity(
+			_context.NameCultures,
+			name,
+			x => x.Name,
+			() =>
+			{
+				NameCulture created = new();
+				_context.NameCultures.Add(created);
+				return created;
+			});
+
+		culture.Name = name;
+		culture.Definition = BuildSimpleNameCultureDefinition(name);
+		_context.SaveChanges();
+		return culture;
+	}
+
+	private static string BuildSimpleNameCultureDefinition(string name)
+	{
+		return new XElement("NameCulture",
+			new XElement("Counts",
+				new XElement("Count",
+					new XAttribute("Usage", (int)NameUsage.BirthName),
+					new XAttribute("Min", 1),
+					new XAttribute("Max", 1))),
+			new XElement("Patterns",
+				Enum.GetValues<NameStyle>()
+					.Select(style => new XElement("Pattern",
+						new XAttribute("Style", (int)style),
+						new XAttribute("Text", "{0}"),
+						new XAttribute("Params", "0")))),
+			new XElement("Elements",
+				new XElement("Element",
+					new XAttribute("Usage", (int)NameUsage.BirthName),
+					new XAttribute("MinimumCount", 1),
+					new XAttribute("MaximumCount", 1),
+					new XAttribute("Name", $"{name} Element"),
+					new XCData($"A stock {name.ToLowerInvariant()} used by the Supernatural Seeder."))),
+			new XElement("NameEntryRegex", new XCData(@"^(?<birthname>[\w '\-]+)$"))).ToString();
+	}
+
+	private void EnsureRandomNameProfile(NameCulture nameCulture, IEnumerable<string> names)
+	{
+		foreach (Gender gender in Enum.GetValues<Gender>())
+		{
+			string profileName = $"{nameCulture.Name} {gender.DescribeEnum()}";
+			RandomNameProfile profile = SeederRepeatabilityHelper.EnsureEntity(
+				_context.RandomNameProfiles,
+				x => x.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase) && x.Gender == (int)gender,
+				x => x.Gender == (int)gender,
+				() =>
+				{
+					RandomNameProfile created = new();
+					_context.RandomNameProfiles.Add(created);
+					return created;
+				});
+
+			profile.Name = profileName;
+			profile.Gender = (int)gender;
+			profile.NameCulture = nameCulture;
+			profile.UseForChargenSuggestionsProg = _alwaysTrue;
+			_context.SaveChanges();
+
+			if (!_context.RandomNameProfilesDiceExpressions.Any(x =>
+				    x.RandomNameProfileId == profile.Id &&
+				    x.NameUsage == (int)NameUsage.BirthName))
+			{
+				_context.RandomNameProfilesDiceExpressions.Add(new RandomNameProfilesDiceExpressions
+				{
+					RandomNameProfile = profile,
+					NameUsage = (int)NameUsage.BirthName,
+					DiceExpression = "1d1"
+				});
+			}
+
+			foreach (string item in names)
+			{
+				if (_context.RandomNameProfilesElements.Any(x =>
+					    x.RandomNameProfileId == profile.Id &&
+					    x.NameUsage == (int)NameUsage.BirthName &&
+					    x.Name == item))
+				{
+					continue;
+				}
+
+				_context.RandomNameProfilesElements.Add(new RandomNameProfilesElements
+				{
+					RandomNameProfile = profile,
+					NameUsage = (int)NameUsage.BirthName,
+					Name = item,
+					Weighting = 1
+				});
+			}
+		}
+
+		_context.SaveChanges();
+	}
+
+	private void ApplyEthnicityNameCulture(Ethnicity ethnicity, SupernaturalRaceTemplate template)
+	{
+		NameCulture culture = _nameCultures[template.NameCultureKey];
+		foreach (Gender gender in Enum.GetValues<Gender>())
+		{
+			if (_context.EthnicitiesNameCultures.Any(x =>
+				    x.EthnicityId == ethnicity.Id &&
+				    x.NameCultureId == culture.Id &&
+				    x.Gender == (short)gender))
+			{
+				continue;
+			}
+
+			_context.EthnicitiesNameCultures.Add(new EthnicitiesNameCultures
+			{
+				Ethnicity = ethnicity,
+				NameCulture = culture,
+				Gender = (short)gender
+			});
+		}
+	}
+
+	private void SeedFormMerits(SupernaturalSeedSummary summary)
+	{
+		foreach (SupernaturalFormTemplate template in FormTemplates)
+		{
+			Race? targetRace = _context.Races.FirstOrDefault(x => x.Name == template.TargetRaceName);
+			if (targetRace is null)
+			{
+				continue;
+			}
+
+			Merit? existing = _context.Merits.FirstOrDefault(x => x.Name == template.MeritName);
+			bool created = existing is null;
+			Merit merit = existing ?? new Merit();
+			merit.Name = template.MeritName;
+			merit.Type = "Additional Body Form";
+			merit.MeritType = (int)MeritType.Merit;
+			merit.MeritScope = (int)MeritScope.Character;
+			merit.ParentId = null;
+			merit.Definition = BuildAdditionalBodyFormMeritDefinition(
+				template,
+				targetRace.Id,
+				_alwaysTrue.Id,
+				_alwaysFalse.Id).ToString();
+			if (created)
+			{
+				_context.Merits.Add(merit);
+				summary.FormMeritsAdded++;
+			}
+			else
+			{
+				summary.FormMeritsRefreshed++;
+			}
+		}
+	}
+
+	private static XElement BuildAdditionalBodyFormMeritDefinition(SupernaturalFormTemplate template, long raceId,
+		long alwaysTrueProgId, long alwaysFalseProgId)
+	{
+		return new XElement("Merit",
+			new XElement("ChargenAvailableProg", alwaysFalseProgId),
+			new XElement("ApplicabilityProg", alwaysTrueProgId),
+			new XElement("ChargenBlurb", new XCData(template.ChargenBlurb)),
+			new XElement("DescriptionText", new XCData(template.DescriptionText)),
+			new XElement("Race", raceId),
+			new XElement("Ethnicity", 0L),
+			new XElement("Gender", -1),
+			new XElement("Alias", template.Alias),
+			new XElement("SortOrder", template.SortOrder),
+			new XElement("TraumaMode", (int)template.TraumaMode),
+			new XElement("TransformationEcho",
+				new XAttribute("mode", "default"),
+				string.Empty),
+			new XElement("AllowVoluntarySwitch", template.AllowVoluntarySwitch),
+			new XElement("CanVoluntarilySwitchProg", alwaysTrueProgId),
+			new XElement("WhyCannotVoluntarilySwitchProg", 0L),
+			new XElement("CanSeeFormProg", alwaysTrueProgId),
+			new XElement("ShortDescriptionPattern", 0L),
+			new XElement("FullDescriptionPattern", 0L),
+			new XElement("AutoTransformWhenApplicable", template.AutoTransformWhenApplicable),
+			new XElement("ForcedTransformationPriorityBand", 0),
+			new XElement("ForcedTransformationPriorityOffset", 0),
+			new XElement("ApplicabilityRecheckCadence", 1));
+	}
+
+	private static PlanarPresenceDefinition BuildPlanarProfile(long primePlaneId, long astralPlaneId,
+		SupernaturalPlanarProfile profile)
+	{
+		long[] primeOnly = [primePlaneId];
+		long[] astralOnly = [astralPlaneId];
+		long[] both = [primePlaneId, astralPlaneId];
+
+		static IDictionary<PlanarInteractionKind, IEnumerable<long>> InteractionMap(
+			IEnumerable<long> nonPhysical,
+			IEnumerable<long> physical)
+		{
+			long[] nonPhysicalArray = nonPhysical.ToArray();
+			long[] physicalArray = physical.ToArray();
+			return Enum.GetValues<PlanarInteractionKind>()
+				.ToDictionary(
+					kind => kind,
+					kind => kind is PlanarInteractionKind.Observe or PlanarInteractionKind.Hear or
+						PlanarInteractionKind.Speak or PlanarInteractionKind.Magic
+							? (IEnumerable<long>)nonPhysicalArray
+							: physicalArray);
+		}
+
+		return profile switch
+		{
+			SupernaturalPlanarProfile.AstralNative => new PlanarPresenceDefinition(
+				astralOnly,
+				astralOnly,
+				both,
+				InteractionMap(both, astralOnly),
+				true,
+				false,
+				true,
+				false,
+				true,
+				true,
+				true,
+				"astral-native"),
+			SupernaturalPlanarProfile.Incorporeal => new PlanarPresenceDefinition(
+				astralOnly,
+				both,
+				both,
+				InteractionMap(both, Array.Empty<long>()),
+				true,
+				false,
+				true,
+				false,
+				true,
+				true,
+				true,
+				"incorporeal"),
+			SupernaturalPlanarProfile.DualNatured => new PlanarPresenceDefinition(
+				both,
+				both,
+				both,
+				InteractionMap(both, both),
+				false,
+				true,
+				false,
+				false,
+				false,
+				false,
+				false,
+				"dual-natured"),
+			SupernaturalPlanarProfile.Manifested => new PlanarPresenceDefinition(
+				primeOnly,
+				primeOnly,
+				both,
+				InteractionMap(both, primeOnly),
+				false,
+				true,
+				false,
+				false,
+				false,
+				false,
+				true,
+				"manifested"),
+			_ => PlanarPresenceDefinition.DefaultMaterial(primePlaneId)
+		};
+	}
+
+	private sealed class SupernaturalSeedSummary
+	{
+		public int BodiesAdded { get; set; }
+		public int BodiesRefreshed { get; set; }
+		public int RacesAdded { get; set; }
+		public int RacesRefreshed { get; set; }
+		public int AttacksAdded { get; set; }
+		public int CulturesAdded { get; set; }
+		public int NameCulturesRefreshed { get; set; }
+		public int FormMeritsAdded { get; set; }
+		public int FormMeritsRefreshed { get; set; }
+		public int DescriptionPatternsAdded { get; set; }
+
+		public string ToMessage(int templateCount)
+		{
+			List<string> parts = new()
+			{
+				RacesAdded > 0
+					? $"installed {RacesAdded} supernatural races"
+					: $"refreshed {RacesRefreshed} existing supernatural races",
+				BodiesAdded > 0
+					? $"created {BodiesAdded} supernatural body prototypes"
+					: $"refreshed {BodiesRefreshed} supernatural body prototypes",
+				$"verified {templateCount} catalogue templates"
+			};
+
+			if (AttacksAdded > 0)
+			{
+				parts.Add($"added {AttacksAdded} supernatural attacks");
+			}
+
+			if (CulturesAdded > 0)
+			{
+				parts.Add($"added {CulturesAdded} cultures");
+			}
+
+			if (NameCulturesRefreshed > 0)
+			{
+				parts.Add($"refreshed {NameCulturesRefreshed} name cultures");
+			}
+
+			if (FormMeritsAdded > 0 || FormMeritsRefreshed > 0)
+			{
+				parts.Add($"prepared {FormMeritsAdded + FormMeritsRefreshed} additional-body-form merits");
+			}
+
+			if (DescriptionPatternsAdded > 0)
+			{
+				parts.Add($"added {DescriptionPatternsAdded} description patterns");
+			}
+
+			return $"{string.Join(", ", parts)}.";
+		}
+	}
+}

--- a/DatabaseSeeder/Seeders/SupernaturalSeeder.cs
+++ b/DatabaseSeeder/Seeders/SupernaturalSeeder.cs
@@ -1,0 +1,787 @@
+#nullable enable
+
+using MudSharp.Body;
+using MudSharp.Body.Traits;
+using MudSharp.CharacterCreation;
+using MudSharp.Character.Name;
+using MudSharp.Database;
+using MudSharp.Form.Characteristics;
+using MudSharp.Form.Material;
+using MudSharp.Form.Shape;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.GameItems;
+using MudSharp.Models;
+using MudSharp.Planes;
+using MudSharp.RPG.Merits;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+namespace DatabaseSeeder.Seeders;
+
+public partial class SupernaturalSeeder : IDatabaseSeeder
+{
+	private FuturemudDatabaseContext _context = null!;
+	private Race _humanRace = null!;
+	private Race _organicHumanoidRace = null!;
+	private BodyProto _organicHumanoidBody = null!;
+	private BodyProto _wingedHumanoidBody = null!;
+	private BodyProto _hornedHumanoidBody = null!;
+	private BodyProto _toedQuadrupedBody = null!;
+	private FutureProg _alwaysTrue = null!;
+	private FutureProg _alwaysFalse = null!;
+	private FutureProg _alwaysZero = null!;
+	private HealthStrategy _healthStrategy = null!;
+	private TraitDefinition _healthTrait = null!;
+	private TraitDefinition _strengthTrait = null!;
+	private CorpseModel _humanoidCorpse = null!;
+	private CorpseModel _animalCorpse = null!;
+	private CorpseModel _undeadCorpse = null!;
+	private CorpseModel _spiritCorpse = null!;
+	private Liquid _blood = null!;
+	private Liquid? _sweat;
+	private Gas _breathableAir = null!;
+	private PopulationBloodModel? _defaultPopulationBloodModel;
+	private CharacteristicDefinition _personWordDefinition = null!;
+	private ArmourType? _humanoidNaturalArmour;
+	private long _primePlaneId;
+	private long _astralPlaneId;
+	private long _nextBodyProtoId;
+	private readonly Dictionary<string, NameCulture> _nameCultures = new(StringComparer.OrdinalIgnoreCase);
+
+	public IEnumerable<(string Id, string Question,
+		Func<FuturemudDatabaseContext, IReadOnlyDictionary<string, string>, bool> Filter,
+		Func<string, FuturemudDatabaseContext, (bool Success, string error)> Validator)> SeederQuestions
+		=> NonHumanSeederQuestions.GetQuestions();
+
+	public int SortOrder => 303;
+	public string Name => "Supernatural Seeder";
+	public string Tagline => "Installs stock supernatural races, forms, planar bodies and undead examples";
+	public string FullDescription =>
+		@"Seeds a builder-facing catalogue of supernatural races including angels, fallen angels, demons, spirits, ghosts, gods, werewolves and supported undead. The package uses existing body, merit, planar and non-human race infrastructure rather than inventing new supernatural mechanics.";
+	public bool SafeToRunMoreThanOnce => true;
+
+	public string SeedData(FuturemudDatabaseContext context, IReadOnlyDictionary<string, string> questionAnswers)
+	{
+		_context = context;
+		_context.Database.BeginTransaction();
+		IReadOnlyDictionary<string, string> effectiveAnswers =
+			CombatBalanceProfileHelper.MergeQuestionAnswersWithRecordedChoice(context, questionAnswers);
+		LoadSharedSeederData(effectiveAnswers);
+
+		var summary = new SupernaturalSeedSummary();
+		Dictionary<string, BodyProto> bodyLookup = BuildBodyCatalogue(summary);
+		EnsureSupernaturalSupport(summary);
+
+		foreach (SupernaturalRaceTemplate template in Templates.Values)
+		{
+			SeedOrRefreshRace(template, bodyLookup[template.BodyKey], summary);
+		}
+
+		SeedFormMerits(summary);
+
+		_context.SaveChanges();
+		_context.Database.CommitTransaction();
+		return summary.ToMessage(Templates.Count);
+	}
+
+	public ShouldSeedResult ShouldSeedData(FuturemudDatabaseContext context)
+	{
+		if (!HasPrerequisites(context))
+		{
+			return ShouldSeedResult.PrerequisitesNotMet;
+		}
+
+		if (Templates.Keys.Any(name => !context.Races.Any(x => x.Name == name)))
+		{
+			return ShouldSeedResult.ReadyToInstall;
+		}
+
+		return HasMissingSupernaturalSupport(context)
+			? ShouldSeedResult.ExtraPackagesAvailable
+			: ShouldSeedResult.MayAlreadyBeInstalled;
+	}
+
+	private static bool HasPrerequisites(FuturemudDatabaseContext context)
+	{
+		string[] requiredBodies =
+		[
+			"Organic Humanoid",
+			"Winged Humanoid",
+			"Horned Humanoid",
+			"Toed Quadruped"
+		];
+		string[] requiredRaces =
+		[
+			"Human",
+			"Organic Humanoid",
+			"Wolf"
+		];
+		string[] requiredCharacteristicProfiles =
+		[
+			"All Eye Colours",
+			"All Eye Shapes",
+			"All Noses",
+			"All Ears",
+			"All Hair Colours",
+			"All Facial Hair Colours",
+			"All Hair Styles",
+			"All Skin Colours",
+			"All Frames",
+			"Person Word"
+		];
+		string[] requiredAttacks =
+		[
+			"Bite",
+			"Carnivore Bite",
+			"Claw High Swipe",
+			"Claw Low Swipe",
+			"Animal Barge",
+			"Wing Buffet"
+		];
+
+		return requiredBodies.All(body => context.BodyProtos.Any(x => x.Name == body)) &&
+		       requiredRaces.All(race => context.Races.Any(x => x.Name == race)) &&
+		       requiredCharacteristicProfiles.All(profile =>
+			       context.CharacteristicProfiles.Any(x => x.Name == profile) ||
+			       context.CharacteristicDefinitions.Any(x => x.Name == profile)) &&
+		       requiredAttacks.All(attack => context.WeaponAttacks.Any(x => x.Name == attack)) &&
+		       context.FutureProgs.Any(x => x.FunctionName == "AlwaysTrue") &&
+		       context.FutureProgs.Any(x => x.FunctionName == "AlwaysFalse") &&
+		       context.FutureProgs.Any(x => x.FunctionName == "AlwaysZero") &&
+		       context.CorpseModels.Any(x => x.Name == "Organic Human Corpse") &&
+		       context.CorpseModels.Any(x => x.Name == "Organic Animal Corpse") &&
+		       context.Calendars.Any() &&
+		       NonHumanSeederHealthStrategyHelper.AllStrategyNames.All(name =>
+			       context.HealthStrategies.Any(x => x.Name == name));
+	}
+
+	private static bool HasMissingSupernaturalSupport(FuturemudDatabaseContext context)
+	{
+		return CustomBodyProfiles.Keys.Any(name => !context.BodyProtos.Any(x => x.Name == name)) ||
+		       SupernaturalAttackNames.Any(name => !context.WeaponAttacks.Any(x => x.Name == name)) ||
+		       SupernaturalCultureDefinitions.Keys.Any(name => !context.Cultures.Any(x => x.Name == name)) ||
+		       SupernaturalNameDefinitions.Keys.Any(name => !context.NameCultures.Any(x => x.Name == name)) ||
+		       FormTemplates.Any(template => !context.Merits.Any(x => x.Name == template.MeritName)) ||
+		       !context.CorpseModels.Any(x => x.Name == SupernaturalUndeadCorpseModelName) ||
+		       !context.CorpseModels.Any(x => x.Name == SupernaturalSpiritCorpseModelName) ||
+		       Templates.Values
+			       .Where(x => x.NeedsProfile == SupernaturalNeedsProfile.NonLiving)
+			       .Any(template =>
+				       context.Races.FirstOrDefault(x => x.Name == template.Name) is { NeedsToBreathe: true });
+	}
+
+	private void LoadSharedSeederData(IReadOnlyDictionary<string, string> answers)
+	{
+		_humanRace = _context.Races.First(x => x.Name == "Human");
+		_organicHumanoidRace = _context.Races.First(x => x.Name == "Organic Humanoid");
+		_organicHumanoidBody = _context.BodyProtos.First(x => x.Name == "Organic Humanoid");
+		_wingedHumanoidBody = _context.BodyProtos.First(x => x.Name == "Winged Humanoid");
+		_hornedHumanoidBody = _context.BodyProtos.First(x => x.Name == "Horned Humanoid");
+		_toedQuadrupedBody = _context.BodyProtos.First(x => x.Name == "Toed Quadruped");
+		_alwaysTrue = _context.FutureProgs.First(x => x.FunctionName == "AlwaysTrue");
+		_alwaysFalse = _context.FutureProgs.First(x => x.FunctionName == "AlwaysFalse");
+		_alwaysZero = _context.FutureProgs.First(x => x.FunctionName == "AlwaysZero");
+		_humanoidCorpse = _context.CorpseModels.First(x => x.Name == "Organic Human Corpse");
+		_animalCorpse = _context.CorpseModels.First(x => x.Name == "Organic Animal Corpse");
+		_blood = _context.Liquids.First(x => x.Name == "blood");
+		_sweat = _context.Liquids.FirstOrDefault(x => x.Name == "sweat");
+		_breathableAir = _context.Gases
+			.AsEnumerable()
+			.First(x => x.Name.Contains("Breathable Atmosphere", StringComparison.OrdinalIgnoreCase));
+		_defaultPopulationBloodModel = _humanRace.Ethnicities.FirstOrDefault()?.PopulationBloodModel ??
+		                               _context.PopulationBloodModels.FirstOrDefault();
+		_personWordDefinition = _context.CharacteristicDefinitions.First(x => x.Name == "Person Word");
+		_humanoidNaturalArmour = _context.ArmourTypes.FirstOrDefault(x => x.Name == "Human Racial Tissue Armour");
+		_nextBodyProtoId = _context.BodyProtos.Select(x => x.Id).AsEnumerable().DefaultIfEmpty(0).Max() + 1;
+		_healthTrait = _context.TraitDefinitions
+			.Where(x => x.Type == (int)TraitType.Attribute)
+			.AsEnumerable()
+			.First(x => x.Name.In("Constitution", "Body", "Physique", "Endurance", "Hardiness", "Stamina"));
+		_strengthTrait = _context.TraitDefinitions
+			.Where(x => x.Type == (int)TraitType.Attribute)
+			.AsEnumerable()
+			.First(x => x.Name.In("Strength", "Physique", "Body", "Upper Body Strength"));
+		_healthStrategy = _context.HealthStrategies.First(x =>
+			x.Name == NonHumanSeederHealthStrategyHelper.GetStrategyName(answers["model"]));
+
+		IReadOnlyDictionary<string, Plane> planes = CoreDataSeeder.SeedDefaultPlanes(_context);
+		_primePlaneId = planes["Prime Material"].Id;
+		_astralPlaneId = planes["Astral Plane"].Id;
+	}
+
+	private void EnsureSupernaturalSupport(SupernaturalSeedSummary summary)
+	{
+		EnsureSupernaturalMaterials();
+		_undeadCorpse = EnsureNonDecayingCorpseModel(
+			SupernaturalUndeadCorpseModelName,
+			"Preserved supernatural remains",
+			"a preserved corpse of {0}",
+			"{0}\n\nThe body shows no ordinary sign of decay. Supernatural force, curse or necromancy keeps it from changing further.",
+			"{0} from a preserved undead body",
+			"bone");
+		_spiritCorpse = EnsureNonDecayingCorpseModel(
+			SupernaturalSpiritCorpseModelName,
+			"Dissipated spirit remains",
+			"a fading spiritual remnant of {0}",
+			"{0}\n\nThe shape is more impression than corpse, a residue of spirit energy lingering where a supernatural form was broken.",
+			"{0} from a dissipated spirit",
+			"spirit energy");
+		EnsureSupernaturalAttacks(summary);
+		EnsureSupernaturalCulturesAndNames(summary);
+	}
+
+	private Dictionary<string, BodyProto> BuildBodyCatalogue(SupernaturalSeedSummary summary)
+	{
+		Dictionary<string, BodyProto> bodies = new(StringComparer.OrdinalIgnoreCase)
+		{
+			["Organic Humanoid"] = _organicHumanoidBody,
+			["Winged Humanoid"] = _wingedHumanoidBody,
+			["Horned Humanoid"] = _hornedHumanoidBody,
+			["Toed Quadruped"] = _toedQuadrupedBody
+		};
+
+		foreach ((string bodyName, (string SourceBody, SupernaturalPlanarProfile PlanarProfile)) in CustomBodyProfiles)
+		{
+			BodyProto source = bodyName switch
+			{
+				"Supernatural Winged Angel" or "Supernatural Many-Winged Angel" => _wingedHumanoidBody,
+				"Supernatural Horned Fiend" => _hornedHumanoidBody,
+				"Supernatural Hellhound" => _toedQuadrupedBody,
+				_ when bodies.TryGetValue(SourceBody, out BodyProto? body) => body,
+				_ => _organicHumanoidBody
+			};
+			bodies[bodyName] = EnsureCustomBody(bodyName, source, PlanarProfile, summary);
+		}
+
+		foreach (string bodyKey in Templates.Values.Select(x => x.BodyKey).Distinct(StringComparer.OrdinalIgnoreCase))
+		{
+			if (!bodies.ContainsKey(bodyKey))
+			{
+				throw new InvalidOperationException($"Supernatural template body key {bodyKey} was not available.");
+			}
+		}
+
+		return bodies;
+	}
+
+	private BodyProto EnsureCustomBody(string name, BodyProto source, SupernaturalPlanarProfile planarProfile,
+		SupernaturalSeedSummary summary)
+	{
+		BodyProto? existing = _context.BodyProtos.FirstOrDefault(x => x.Name == name);
+		bool created = existing is null;
+		BodyProto body = existing ?? new BodyProto
+		{
+			Id = _nextBodyProtoId++,
+			Name = name
+		};
+
+		body.Name = name;
+		body.CountsAs = source;
+		body.CountsAsId = source.Id;
+		body.ConsiderString = source.ConsiderString;
+		body.WielderDescriptionSingle = source.WielderDescriptionSingle;
+		body.WielderDescriptionPlural = source.WielderDescriptionPlural;
+		body.StaminaRecoveryProgId = source.StaminaRecoveryProgId;
+		body.MinimumLegsToStand = source.MinimumLegsToStand;
+		body.MinimumWingsToFly = name.Contains("Wing", StringComparison.OrdinalIgnoreCase) ? Math.Max(2, source.MinimumWingsToFly) : source.MinimumWingsToFly;
+		body.LegDescriptionPlural = source.LegDescriptionPlural;
+		body.LegDescriptionSingular = source.LegDescriptionSingular;
+		body.WearSizeParameterId = source.WearSizeParameterId;
+		body.NameForTracking = name;
+		body.PlanarData = BuildPlanarProfile(_primePlaneId, _astralPlaneId, planarProfile).SaveToXml().ToString();
+
+		if (created)
+		{
+			_context.BodyProtos.Add(body);
+			_context.SaveChanges();
+			SeederBodyUtilities.CloneBodyPositionsAndSpeeds(_context, source, body);
+			summary.BodiesAdded++;
+		}
+		else
+		{
+			summary.BodiesRefreshed++;
+		}
+
+		return body;
+	}
+
+	private void SeedOrRefreshRace(SupernaturalRaceTemplate template, BodyProto body, SupernaturalSeedSummary summary)
+	{
+		Race? race = _context.Races.FirstOrDefault(x => x.Name == template.Name);
+		bool created = race is null;
+		race ??= new Race { Name = template.Name };
+
+		race.Name = template.Name;
+		race.Description = BuildRaceDescriptionForTesting(template);
+		race.BaseBody = body;
+		race.AllowedGenders = _organicHumanoidRace.AllowedGenders;
+		race.ParentRace = template.UsesHumanoidCharacteristics ? _organicHumanoidRace : null;
+		race.AttributeTotalCap = _humanRace.AttributeTotalCap;
+		race.IndividualAttributeCap = _humanRace.IndividualAttributeCap;
+		race.DiceExpression = _humanRace.DiceExpression;
+		race.IlluminationPerceptionMultiplier = 1.0;
+		race.AvailabilityProg = template.PlayableDefault ? _alwaysTrue : _alwaysFalse;
+		race.CorpseModel = template.Family switch
+		{
+			SupernaturalFamily.Spirit => _spiritCorpse,
+			SupernaturalFamily.Undead => _undeadCorpse,
+			_ when template.NeedsProfile == SupernaturalNeedsProfile.NonLiving => _spiritCorpse,
+			_ => template.UsesHumanoidCharacteristics ? _humanoidCorpse : _animalCorpse
+		};
+		race.DefaultHealthStrategy = _healthStrategy;
+		race.DefaultCombatSetting = CombatStrategySeederHelper.EnsureCombatStrategy(_context, template.CombatStrategyKey);
+		race.CanUseWeapons = template.CanUseWeapons;
+		race.CanAttack = true;
+		race.CanDefend = true;
+		race.NaturalArmourType = template.UsesHumanoidCharacteristics ? _humanoidNaturalArmour : null;
+		race.NaturalArmourQuality = template.Family is SupernaturalFamily.Divine or SupernaturalFamily.Demon or SupernaturalFamily.Angel ? 3 : 2;
+		race.NaturalArmourMaterial = null;
+		race.BloodLiquid = _blood;
+		race.BloodModel = _humanRace.BloodModel;
+		race.SizeStanding = (int)template.Size;
+		race.SizeProne = (int)template.Size;
+		race.SizeSitting = (int)template.Size;
+		race.CommunicationStrategyType = "humanoid";
+		race.DefaultHandedness = _humanRace.DefaultHandedness;
+		race.HandednessOptions = template.CanUseWeapons ? _organicHumanoidRace.HandednessOptions : "1 3";
+		race.MaximumDragWeightExpression = $"str:{_strengthTrait.Id}*40000";
+		race.MaximumLiftWeightExpression = $"str:{_strengthTrait.Id}*10000";
+		race.RaceUsesStamina = true;
+		race.CanEatCorpses = false;
+		race.EatCorpseEmoteText = string.Empty;
+		race.CanEatMaterialsOptIn = false;
+		race.BiteWeight = 1000;
+		race.TemperatureRangeFloor = -40;
+		race.TemperatureRangeCeiling = 80;
+		race.BodypartSizeModifier = 0;
+		race.BodypartHealthMultiplier = template.BodypartHealthMultiplier;
+		race.CanClimb = template.CanClimb;
+		race.CanSwim = template.CanSwim;
+		race.MinimumSleepingPosition = _humanRace.MinimumSleepingPosition;
+		race.ChildAge = template.NeedsProfile == SupernaturalNeedsProfile.Living ? 2 : 0;
+		race.YouthAge = template.NeedsProfile == SupernaturalNeedsProfile.Living ? 6 : 0;
+		race.YoungAdultAge = template.NeedsProfile == SupernaturalNeedsProfile.Living ? 12 : 0;
+		race.AdultAge = template.NeedsProfile == SupernaturalNeedsProfile.Living ? 18 : 1;
+		race.ElderAge = template.NeedsProfile == SupernaturalNeedsProfile.Living ? 65 : 1000;
+		race.VenerableAge = template.NeedsProfile == SupernaturalNeedsProfile.Living ? 95 : 10000;
+		race.DefaultHeightWeightModelMale = _humanRace.DefaultHeightWeightModelMale;
+		race.DefaultHeightWeightModelFemale = _humanRace.DefaultHeightWeightModelFemale;
+		race.DefaultHeightWeightModelNeuter = _humanRace.DefaultHeightWeightModelNeuter ?? _humanRace.DefaultHeightWeightModelMale;
+		race.DefaultHeightWeightModelNonBinary = _humanRace.DefaultHeightWeightModelNonBinary ?? _humanRace.DefaultHeightWeightModelFemale;
+		race.MaximumFoodSatiatedHours = _humanRace.MaximumFoodSatiatedHours;
+		race.MaximumDrinkSatiatedHours = _humanRace.MaximumDrinkSatiatedHours;
+		race.TrackIntensityVisual = _humanRace.TrackIntensityVisual;
+		race.TrackIntensityOlfactory = template.Family == SupernaturalFamily.Spirit ? 0.0 : _humanRace.TrackIntensityOlfactory;
+		race.TrackingAbilityVisual = _humanRace.TrackingAbilityVisual;
+		race.TrackingAbilityOlfactory = template.Family == SupernaturalFamily.Spirit ? 0.0 : _humanRace.TrackingAbilityOlfactory;
+
+		ApplyNeedsProfile(race, template);
+
+		if (created)
+		{
+			_context.Races.Add(race);
+			_context.SaveChanges();
+			ApplyNeedsProfile(race, template);
+			summary.RacesAdded++;
+		}
+		else
+		{
+			summary.RacesRefreshed++;
+		}
+
+		SeedRaceAttributes(race, template);
+		Ethnicity ethnicity = SeedOrRefreshEthnicity(race, template);
+		SeedAdditionalCharacteristics(race, ethnicity, template);
+		SeedRacialBodypartUsages(race, template);
+		SeedNaturalAttacks(race, template);
+		SeedDefaultDescriptions(race, template, summary);
+		_context.SaveChanges();
+	}
+
+	private void ApplyNeedsProfile(Race race, SupernaturalRaceTemplate template)
+	{
+		if (template.NeedsProfile == SupernaturalNeedsProfile.NonLiving)
+		{
+			race.NeedsToBreathe = false;
+			race.BreathingModel = NonBreathingModel;
+			race.BreathingVolumeExpression = "0";
+			race.HoldBreathLengthExpression = "999999";
+			race.HungerRate = 0.0;
+			race.ThirstRate = 0.0;
+			race.SweatLiquid = null;
+			race.SweatRateInLitresPerMinute = 0.0;
+			_context.RacesBreathableGases.RemoveRange(_context.RacesBreathableGases.Where(x => x.RaceId == race.Id).ToList());
+			_context.RacesBreathableLiquids.RemoveRange(_context.RacesBreathableLiquids.Where(x => x.RaceId == race.Id).ToList());
+			return;
+		}
+
+		race.NeedsToBreathe = true;
+		race.BreathingModel = "simple";
+		race.BreathingVolumeExpression = "7";
+		race.HoldBreathLengthExpression = $"90+(5*con:{_healthTrait.Id})";
+		race.HungerRate = _humanRace.HungerRate;
+		race.ThirstRate = _humanRace.ThirstRate;
+		race.SweatLiquid = _sweat;
+		race.SweatRateInLitresPerMinute = _sweat is null ? 0.0 : 0.5;
+
+		if (race.Id != 0 &&
+		    !_context.RacesBreathableGases.Any(x => x.RaceId == race.Id && x.GasId == _breathableAir.Id))
+		{
+			_context.RacesBreathableGases.Add(new RacesBreathableGases
+			{
+				Race = race,
+				Gas = _breathableAir,
+				Multiplier = 1.0
+			});
+		}
+	}
+
+	private void SeedRaceAttributes(Race race, SupernaturalRaceTemplate template)
+	{
+		foreach (TraitDefinition attribute in _context.TraitDefinitions
+			         .Where(x => x.Type == (int)TraitType.Attribute || x.Type == (int)TraitType.DerivedAttribute)
+			         .ToList())
+		{
+			RacesAttributes? existing = _context.RacesAttributes
+				.FirstOrDefault(x => x.RaceId == race.Id && x.AttributeId == attribute.Id);
+			if (existing is null)
+			{
+				_context.RacesAttributes.Add(new RacesAttributes
+				{
+					Race = race,
+					Attribute = attribute,
+					IsHealthAttribute = attribute.TraitGroup == "Physical",
+					AttributeBonus = NonHumanAttributeScalingHelper.GetAttributeBonus(attribute, template.AttributeProfile),
+					DiceExpression = NonHumanAttributeScalingHelper.GetAttributeDiceExpression(attribute, template.AttributeProfile)
+				});
+				continue;
+			}
+
+			existing.IsHealthAttribute = attribute.TraitGroup == "Physical";
+			existing.AttributeBonus = NonHumanAttributeScalingHelper.GetAttributeBonus(attribute, template.AttributeProfile);
+			existing.DiceExpression = NonHumanAttributeScalingHelper.GetAttributeDiceExpression(attribute, template.AttributeProfile);
+		}
+	}
+
+	private Ethnicity SeedOrRefreshEthnicity(Race race, SupernaturalRaceTemplate template)
+	{
+		string name = $"{template.Name} Stock";
+		Ethnicity ethnicity = SeederRepeatabilityHelper.EnsureNamedEntity(
+			_context.Ethnicities,
+			name,
+			x => x.Name,
+			() =>
+			{
+				Ethnicity created = new();
+				_context.Ethnicities.Add(created);
+				return created;
+			});
+
+		ethnicity.Name = name;
+		ethnicity.ChargenBlurb = BuildEthnicityDescriptionForTesting(template);
+		ethnicity.AvailabilityProg = _alwaysFalse;
+		ethnicity.ParentRace = race;
+		ethnicity.EthnicGroup = template.Name;
+		ethnicity.EthnicSubgroup = "Stock";
+		ethnicity.PopulationBloodModel = _defaultPopulationBloodModel;
+		ethnicity.TolerableTemperatureFloorEffect = 0;
+		ethnicity.TolerableTemperatureCeilingEffect = 0;
+		_context.SaveChanges();
+
+		if (template.UsesHumanoidCharacteristics)
+		{
+			AddEthnicityCharacteristic(ethnicity, "Eye Colour", "All Eye Colours");
+			AddEthnicityCharacteristic(ethnicity, "Eye Shape", "All Eye Shapes");
+			AddEthnicityCharacteristic(ethnicity, "Nose", "All Noses");
+			AddEthnicityCharacteristic(ethnicity, "Ears", "All Ears");
+			AddEthnicityCharacteristic(ethnicity, "Hair Colour", "All Hair Colours");
+			AddEthnicityCharacteristic(ethnicity, "Facial Hair Colour", "All Facial Hair Colours");
+			AddEthnicityCharacteristic(ethnicity, "Hair Style", "All Hair Styles");
+			AddEthnicityCharacteristic(ethnicity, "Facial Hair Style", "All Facial Hair Styles");
+			AddEthnicityCharacteristic(ethnicity, "Skin Colour", "All Skin Colours");
+			AddEthnicityCharacteristic(ethnicity, "Frame", "All Frames");
+			AddEthnicityCharacteristic(ethnicity, "Person Word",
+				EnsureStandardProfile(_personWordDefinition, $"{template.Name} Person Words",
+					GetPersonWords(template)).Name);
+		}
+
+		ApplyEthnicityNameCulture(ethnicity, template);
+		return ethnicity;
+	}
+
+	private static IReadOnlyList<string> GetPersonWords(SupernaturalRaceTemplate template)
+	{
+		return template.Family switch
+		{
+			SupernaturalFamily.Angel => ["angel", "messenger", "celestial"],
+			SupernaturalFamily.Demon => ["demon", "fiend", "fallen one"],
+			SupernaturalFamily.Divine => ["god", "deity", "avatar"],
+			SupernaturalFamily.Spirit => ["spirit", "shade", "apparition"],
+			SupernaturalFamily.Therianthrope => ["werewolf", "shifter", "wolf-blooded one"],
+			SupernaturalFamily.Undead => ["undead", "deathless one", "corpse"],
+			_ => ["being"]
+		};
+	}
+
+	private void AddEthnicityCharacteristic(Ethnicity ethnicity, string definitionName, string profileName)
+	{
+		CharacteristicDefinition? definition = _context.CharacteristicDefinitions.FirstOrDefault(x => x.Name == definitionName);
+		CharacteristicProfile? profile = _context.CharacteristicProfiles.FirstOrDefault(x => x.Name == profileName);
+		if (definition is null || profile is null)
+		{
+			return;
+		}
+
+		if (_context.EthnicitiesCharacteristics.Any(x =>
+			    x.EthnicityId == ethnicity.Id && x.CharacteristicDefinitionId == definition.Id))
+		{
+			return;
+		}
+
+		_context.EthnicitiesCharacteristics.Add(new EthnicitiesCharacteristics
+		{
+			Ethnicity = ethnicity,
+			CharacteristicDefinition = definition,
+			CharacteristicProfile = profile
+		});
+	}
+
+	private void SeedAdditionalCharacteristics(Race race, Ethnicity ethnicity, SupernaturalRaceTemplate template)
+	{
+		foreach (SupernaturalCharacteristicTemplate characteristic in template.Characteristics)
+		{
+			CharacteristicDefinition definition = EnsureCharacteristicDefinition(
+				characteristic.DefinitionName,
+				$"{characteristic.DefinitionName} for supernatural races",
+				characteristic.Type);
+			CharacteristicProfile profile = EnsureStandardProfile(
+				definition,
+				$"All {characteristic.DefinitionName}",
+				characteristic.Values);
+
+			if (!_context.RacesAdditionalCharacteristics.Any(x =>
+				    x.RaceId == race.Id && x.CharacteristicDefinitionId == definition.Id))
+			{
+				_context.RacesAdditionalCharacteristics.Add(new RacesAdditionalCharacteristics
+				{
+					Race = race,
+					CharacteristicDefinition = definition,
+					Usage = characteristic.Usage
+				});
+			}
+
+			if (!_context.EthnicitiesCharacteristics.Any(x =>
+				    x.EthnicityId == ethnicity.Id && x.CharacteristicDefinitionId == definition.Id))
+			{
+				_context.EthnicitiesCharacteristics.Add(new EthnicitiesCharacteristics
+				{
+					Ethnicity = ethnicity,
+					CharacteristicDefinition = definition,
+					CharacteristicProfile = profile
+				});
+			}
+		}
+	}
+
+	private CharacteristicDefinition EnsureCharacteristicDefinition(string name, string description,
+		CharacteristicType type = CharacteristicType.Standard)
+	{
+		CharacteristicDefinition? existing = _context.CharacteristicDefinitions.FirstOrDefault(x => x.Name == name);
+		if (existing is not null)
+		{
+			return existing;
+		}
+
+		CharacteristicDefinition definition = new()
+		{
+			Name = name,
+			Type = (int)type,
+			Pattern = name.ToLowerInvariant().Replace(" ", string.Empty),
+			Description = description,
+			ChargenDisplayType = (int)CharacterGenerationDisplayType.DisplayAll,
+			Model = "standard",
+			Definition = string.Empty
+		};
+		_context.CharacteristicDefinitions.Add(definition);
+		_context.SaveChanges();
+		return definition;
+	}
+
+	private CharacteristicProfile EnsureStandardProfile(CharacteristicDefinition definition, string profileName,
+		IEnumerable<string> values)
+	{
+		List<string> valueList = values.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+		foreach (string value in valueList)
+		{
+			if (_context.CharacteristicValues.Any(x => x.DefinitionId == definition.Id && x.Name == value))
+			{
+				continue;
+			}
+
+			_context.CharacteristicValues.Add(new CharacteristicValue
+			{
+				Name = value,
+				Definition = definition,
+				Value = value,
+				AdditionalValue = string.Empty,
+				Default = false,
+				Pluralisation = 0
+			});
+		}
+
+		CharacteristicProfile profile = SeederRepeatabilityHelper.EnsureNamedEntity(
+			_context.CharacteristicProfiles,
+			profileName,
+			x => x.Name,
+			() =>
+			{
+				CharacteristicProfile created = new();
+				_context.CharacteristicProfiles.Add(created);
+				return created;
+			});
+
+		StringBuilder definitionXml = new();
+		definitionXml.Append("<Values>");
+		foreach (string value in valueList)
+		{
+			definitionXml.Append($" <Value>{value}</Value>");
+		}
+		definitionXml.Append(" </Values>");
+
+		profile.Name = profileName;
+		profile.TargetDefinition = definition;
+		profile.Type = "Standard";
+		profile.Description = $"Auto-generated profile for {profileName}";
+		profile.Definition = definitionXml.ToString();
+		_context.SaveChanges();
+		return profile;
+	}
+
+	private void SeedRacialBodypartUsages(Race race, SupernaturalRaceTemplate template)
+	{
+		if (template.BodypartUsages is null)
+		{
+			return;
+		}
+
+		foreach (SupernaturalBodypartUsageTemplate usage in template.BodypartUsages)
+		{
+			BodypartProto? bodypart = FindBodypartOnBody(race.BaseBody, usage.BodypartAlias);
+			if (bodypart is null ||
+			    _context.RacesAdditionalBodyparts.Any(x =>
+				    x.RaceId == race.Id && x.BodypartId == bodypart.Id && x.Usage == usage.Usage))
+			{
+				continue;
+			}
+
+			_context.RacesAdditionalBodyparts.Add(new RacesAdditionalBodyparts
+			{
+				Race = race,
+				Bodypart = bodypart,
+				Usage = usage.Usage
+			});
+		}
+	}
+
+	private void SeedNaturalAttacks(Race race, SupernaturalRaceTemplate template)
+	{
+		foreach (SupernaturalAttackTemplate attackTemplate in template.Attacks)
+		{
+			WeaponAttack? attack = _context.WeaponAttacks.FirstOrDefault(x => x.Name == attackTemplate.AttackName);
+			if (attack is null)
+			{
+				continue;
+			}
+
+			foreach (string alias in attackTemplate.BodypartAliases)
+			{
+				BodypartProto? bodypart = FindBodypartOnBody(race.BaseBody, alias);
+				if (bodypart is null ||
+				    _context.RacesWeaponAttacks.Any(x =>
+					    x.RaceId == race.Id && x.BodypartId == bodypart.Id && x.WeaponAttackId == attack.Id))
+				{
+					continue;
+				}
+
+				_context.RacesWeaponAttacks.Add(new RacesWeaponAttacks
+				{
+					Race = race,
+					Bodypart = bodypart,
+					WeaponAttack = attack,
+					Quality = (int)attackTemplate.Quality
+				});
+			}
+		}
+	}
+
+	private BodypartProto? FindBodypartOnBody(BodyProto body, string alias)
+	{
+		return SeederBodyUtilities.FindBodypartOnBodyOrAncestors(_context, body, alias);
+	}
+
+	private void SeedDefaultDescriptions(Race race, SupernaturalRaceTemplate template, SupernaturalSeedSummary summary)
+	{
+		FutureProg prog = EnsureRaceDescriptionApplicabilityProg(race);
+		int before = _context.EntityDescriptionPatterns.Count(x => x.ApplicabilityProgId == prog.Id);
+		EnsureDescriptionVariants(prog, template.DescriptionVariants);
+		int after = _context.EntityDescriptionPatterns.Count(x => x.ApplicabilityProgId == prog.Id);
+		summary.DescriptionPatternsAdded += Math.Max(0, after - before);
+	}
+
+	private FutureProg EnsureRaceDescriptionApplicabilityProg(Race race)
+	{
+		string functionName = $"Is{race.Name.CollapseString()}";
+		FutureProg prog = SeederRepeatabilityHelper.EnsureProg(
+			_context,
+			functionName,
+			"Character",
+			"Descriptions",
+			ProgVariableTypes.Boolean,
+			$"True if the character is a {race.Name}",
+			$"return @ch.Race == ToRace(\"{race.Name}\")",
+			true,
+			false,
+			FutureProgStaticType.NotStatic,
+			(ProgVariableTypes.Toon, "ch"));
+		_context.SaveChanges();
+		return prog;
+	}
+
+	private void EnsureDescriptionVariants(FutureProg prog, IEnumerable<StockDescriptionVariant> variants)
+	{
+		foreach (StockDescriptionVariant variant in variants)
+		{
+			if (!_context.EntityDescriptionPatterns.Any(x =>
+				    x.ApplicabilityProgId == prog.Id &&
+				    x.Type == 0 &&
+				    x.Pattern == variant.ShortDescription))
+			{
+				_context.EntityDescriptionPatterns.Add(new EntityDescriptionPattern
+				{
+					Type = 0,
+					ApplicabilityProg = prog,
+					RelativeWeight = 100,
+					Pattern = variant.ShortDescription
+				});
+			}
+
+			if (!_context.EntityDescriptionPatterns.Any(x =>
+				    x.ApplicabilityProgId == prog.Id &&
+				    x.Type == 1 &&
+				    x.Pattern == variant.FullDescription))
+			{
+				_context.EntityDescriptionPatterns.Add(new EntityDescriptionPattern
+				{
+					Type = 1,
+					ApplicabilityProg = prog,
+					RelativeWeight = 100,
+					Pattern = variant.FullDescription
+				});
+			}
+		}
+	}
+}

--- a/Design Documents/Supernatural_Seeder.md
+++ b/Design Documents/Supernatural_Seeder.md
@@ -1,0 +1,38 @@
+# Supernatural Seeder
+
+## Current Implementation
+
+The Supernatural Seeder installs a builder-facing stock catalogue of angels, fallen angels, demons, gods, spirits, ghosts, werewolves, and mechanically supported undead. It is idempotent and can be rerun to restore missing stock supernatural races, cultures, name cultures, attacks, body prototypes, form merits, corpse models, description patterns, and non-breather settings.
+
+All seeded supernatural races are unavailable to normal chargen by default. Builders can enable them through the usual chargen, role, merit, or staff workflows after deciding how supernatural characters should fit their game.
+
+The angelic catalogue follows Maimonides' ten ranks: Chayot HaKodesh, Ophanim, Erelim, Hashmallim, Seraphim, Malakhim, Elohim, Bene Elohim, Cherubim, and Ishim. The demon catalogue mirrors those fallen ranks and adds common stock demons such as incubus, succubus, fury, imp, familiar, fiend, and hellhound.
+
+## Mechanics Seeded
+
+The seeder uses existing FutureMUD systems rather than adding a new supernatural runtime model:
+
+- Race records carry anatomy, health strategy, communication model, natural attacks, breathing and needs configuration, chargen availability, attributes, ethnicity, and description variables.
+- Body prototypes carry the base planar presence XML for supernatural forms such as incorporeal spirits, dual-natured angels, astral demons, and ordinary material werewolves or undead.
+- Additional body forms are supplied as stock `Additional Body Form` merits. These are examples and builder tools, not automatic race-level transformations.
+- Spirits, ghosts, angels, demons, gods, and undead use explicit non-breather settings with hunger and thirst rates set to zero.
+- Werewolves use living needs and seeded alternate-form merits for hybrid and wolf-form examples.
+- Physical undead use a non-decaying corpse model; spirit-like beings use a non-decaying dissipating-spirit corpse model.
+
+## Builder Workflow
+
+Builders normally use the seeded races as templates:
+
+1. Run the prerequisite Human, Animal, Mythical Animal, Combat, Health, Culture, and Stock Merit support packages.
+2. Run the Supernatural Seeder.
+3. Clone or edit the stock cultures, ethnicities, description patterns, and name cultures for the world's cosmology.
+4. Attach the seeded `Additional Body Form` merits through chargen roles, curses, staff grants, NPC templates, or custom FutureProgs.
+5. Enable individual supernatural races in chargen only when the world is ready for player-facing supernatural play.
+
+The seeded form merits deliberately do not force full-moon or cosmology-specific behavior. Builders can add condition progs and auto-transform settings when their setting defines those rules.
+
+## Boundaries and Future Work
+
+The seeder includes undead only where current mechanics support them as races or body forms. It does not implement post-death ghost creation, possession, remote corpse vessels, vampire feeding, lich phylacteries, automatic werewolf lunar transformation, divine worship economies, or a new race-owned multi-form model.
+
+Those behaviours should be implemented as future runtime features using the existing body-form, merit, effect, FutureProg, plane, needs, and health systems as integration points.


### PR DESCRIPTION
## Summary
- Register SupernaturalSeeder metadata, requirements, and rerun ownership details
- Reuse shared seeder question answers for combat style, randomness, and health model prompts
- Add template coverage and update the supernatural seeder design document

## Testing
- Not run (not requested)