### PR TITLE
Expand supernatural seeder attack catalogue

### DIFF
--- a/DatabaseSeeder Unit Tests/SupernaturalSeederTemplateTests.cs
+++ b/DatabaseSeeder Unit Tests/SupernaturalSeederTemplateTests.cs
@@ -4,6 +4,7 @@ using DatabaseSeeder.Seeders;
 using DatabaseSeeder;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MudSharp.Character;
+using MudSharp.Combat;
 using MudSharp.Planes;
 using System;
 using System.Collections.Generic;
@@ -177,16 +178,186 @@ public class SupernaturalSeederTemplateTests
 			"Soul Chill",
 			"Grave Claw",
 			"Wheel Crush",
-			"Spectral Touch"
+			"Spectral Touch",
+			"Heavenly Choir",
+			"Canticle of Awe",
+			"Trumpet Peal",
+			"Word of Command",
+			"Crown of Stars",
+			"Starfire Breath",
+			"Seraphic Wingstorm",
+			"Mercy-Searing Grasp",
+			"Wheel of Judgment",
+			"Many-Eyed Ray",
+			"Hellfire Breath",
+			"Brimstone Spit",
+			"Infernal Trip",
+			"Damnation Barge",
+			"Hellish Headbutt",
+			"Soul Hook",
+			"Abyssal Chain Lash",
+			"Sinner's Clinch",
+			"Barbed Tail Slap",
+			"Fallen Choir",
+			"Wailing Dirge",
+			"Grave Drag",
+			"Grasp of the Dead",
+			"Bone Rattle",
+			"Crypt Dust Breath",
+			"Deathly Pall",
+			"Raking Maul",
+			"Hamstring Snap",
+			"Crushing Pounce",
+			"Wolf Trip"
 		];
 
-		string[] actualAttacks = SupernaturalSeeder.TemplatesForTesting.Values
-			.SelectMany(x => x.Attacks)
-			.Select(x => x.AttackName)
-			.Distinct(StringComparer.OrdinalIgnoreCase)
+		string[] actualAttacks = SupernaturalSeeder.SupernaturalAttackNamesForTesting
 			.ToArray();
 
 		CollectionAssert.IsSubsetOf(expectedAttacks, actualAttacks);
+		Assert.AreEqual(40, actualAttacks.Length);
+		Assert.IsTrue(actualAttacks.Length >= 30);
+		Assert.AreEqual(expectedAttacks.Length, actualAttacks.Length);
+	}
+
+	[TestMethod]
+	public void AttackDefinitionsForTesting_CategoriesCoverSpecialMoveFamilies()
+	{
+		string[] expectedCategories =
+		[
+			"sonic",
+			"ranged",
+			"breath",
+			"spit",
+			"trip",
+			"unbalance",
+			"stagger",
+			"pushback",
+			"clinch",
+			"forced movement",
+			"buffeting",
+			"bite",
+			"claw",
+			"horn",
+			"radiant",
+			"infernal",
+			"spirit",
+			"undead",
+			"therianthrope"
+		];
+
+		string[] actualCategories = SupernaturalSeeder.SupernaturalAttackDefinitionsForTesting.Values
+			.SelectMany(x => x.Categories)
+			.Distinct(StringComparer.OrdinalIgnoreCase)
+			.ToArray();
+
+		CollectionAssert.IsSubsetOf(expectedCategories, actualCategories);
+	}
+
+	[TestMethod]
+	public void AttackDefinitionsForTesting_SonicAttacksUseScreechAndMouthAliases()
+	{
+		string[] sonicAttackNames = SupernaturalSeeder.SupernaturalAttackDefinitionsForTesting
+			.Where(x => x.Value.Categories.Contains("sonic", StringComparer.OrdinalIgnoreCase))
+			.Select(x => x.Key)
+			.ToArray();
+
+		Assert.IsTrue(sonicAttackNames.Contains("Heavenly Choir", StringComparer.OrdinalIgnoreCase));
+		Assert.IsTrue(sonicAttackNames.Contains("Canticle of Awe", StringComparer.OrdinalIgnoreCase));
+		Assert.IsTrue(sonicAttackNames.Contains("Word of Command", StringComparer.OrdinalIgnoreCase));
+
+		foreach (string attackName in sonicAttackNames)
+		{
+			SupernaturalSeeder.SupernaturalAttackDefinition definition =
+				SupernaturalSeeder.SupernaturalAttackDefinitionsForTesting[attackName];
+
+			Assert.AreEqual(BuiltInCombatMoveType.ScreechAttack, definition.MoveTypeOverride);
+			Assert.AreEqual("Ear", definition.FixedTargetBodypartShape);
+			Assert.IsFalse(definition.Message.Contains("$1", StringComparison.Ordinal),
+				$"{attackName} should not reference a single defender.");
+		}
+
+		foreach (SupernaturalSeeder.SupernaturalAttackTemplate templateAttack in SupernaturalSeeder.TemplatesForTesting.Values
+			         .SelectMany(x => x.Attacks)
+			         .Where(x => sonicAttackNames.Contains(x.AttackName, StringComparer.OrdinalIgnoreCase)))
+		{
+			CollectionAssert.AreEqual(new[] { "mouth" }, templateAttack.BodypartAliases.ToArray(),
+				$"{templateAttack.AttackName} should be voiced from the mouth.");
+		}
+	}
+
+	[TestMethod]
+	public void TemplatesForTesting_AngelsUseChoirsAndOphanimUseWheelAttacks()
+	{
+		foreach (SupernaturalSeeder.SupernaturalRaceTemplate template in SupernaturalSeeder.TemplatesForTesting.Values
+			         .Where(x => x.Family == SupernaturalSeeder.SupernaturalFamily.Angel))
+		{
+			Assert.IsTrue(template.Attacks.Any(x => x.AttackName == "Heavenly Choir"),
+				$"{template.Name} should have a heavenly choir attack.");
+		}
+
+		SupernaturalSeeder.SupernaturalRaceTemplate ophanim = SupernaturalSeeder.TemplatesForTesting["Ophanim"];
+		Assert.IsTrue(ophanim.Attacks.Any(x => x.AttackName == "Wheel of Judgment"));
+		Assert.IsTrue(ophanim.Attacks.Any(x => x.AttackName == "Many-Eyed Ray"));
+		Assert.IsFalse(ophanim.Attacks.Any(x => x.AttackName == "Seraphic Wingstorm"));
+	}
+
+	[TestMethod]
+	public void TemplatesForTesting_FallenRanksMirrorAngelicAttackExpansion()
+	{
+		foreach (string angelRank in SupernaturalSeeder.AngelicRankOrderForTesting)
+		{
+			string fallenName = $"Fallen {angelRank}";
+			SupernaturalSeeder.SupernaturalRaceTemplate template = SupernaturalSeeder.TemplatesForTesting[fallenName];
+
+			Assert.IsTrue(template.Attacks.Any(x => x.AttackName == "Fallen Choir"),
+				$"{fallenName} should have a fallen choir attack.");
+		}
+
+		SupernaturalSeeder.SupernaturalRaceTemplate fallenOphanim = SupernaturalSeeder.TemplatesForTesting["Fallen Ophanim"];
+		Assert.IsTrue(fallenOphanim.Attacks.Any(x => x.AttackName == "Wheel of Judgment"));
+		Assert.IsTrue(fallenOphanim.Attacks.Any(x => x.AttackName == "Many-Eyed Ray"));
+		Assert.IsFalse(fallenOphanim.Attacks.Any(x => x.AttackName == "Barbed Tail Slap"));
+	}
+
+	[TestMethod]
+	public void TemplatesForTesting_CommonDemonsUndeadSpiritsAndWerewolvesHaveBroaderAttackCoverage()
+	{
+		foreach (string demonName in SupernaturalSeeder.CommonDemonNamesForTesting)
+		{
+			Assert.IsTrue(SupernaturalSeeder.TemplatesForTesting[demonName].Attacks.Count >= 8,
+				$"{demonName} should have expanded demon attack coverage.");
+		}
+
+		foreach (string undeadName in SupernaturalSeeder.SupportedUndeadNamesForTesting
+			         .Where(x => SupernaturalSeeder.TemplatesForTesting[x].Family == SupernaturalSeeder.SupernaturalFamily.Undead))
+		{
+			Assert.IsTrue(SupernaturalSeeder.TemplatesForTesting[undeadName].Attacks.Count >= 7,
+				$"{undeadName} should have expanded undead attack coverage.");
+		}
+
+		Assert.IsTrue(SupernaturalSeeder.TemplatesForTesting["Ghost"].Attacks.Count >= 5);
+		Assert.IsTrue(SupernaturalSeeder.TemplatesForTesting["Werewolf"].Attacks.Count >= 4);
+		Assert.IsTrue(SupernaturalSeeder.TemplatesForTesting["Werewolf Hybrid"].Attacks.Any(x => x.AttackName == "Raking Maul"));
+	}
+
+	[TestMethod]
+	public void BodyAdditionsForTesting_HornedFiendsAndFamiliarsExposeTailAliases()
+	{
+		string[] expectedTailAliases = ["utail", "mtail", "ltail"];
+
+		CollectionAssert.AreEquivalent(expectedTailAliases,
+			SupernaturalSeeder.SupernaturalBodyAdditionalAliasesForTesting["Supernatural Horned Fiend"]);
+		CollectionAssert.AreEquivalent(expectedTailAliases,
+			SupernaturalSeeder.SupernaturalBodyAdditionalAliasesForTesting["Supernatural Familiar"]);
+
+		foreach (string demonName in new[] { "Fiend", "Imp", "Familiar", "Incubus", "Succubus" })
+		{
+			Assert.IsTrue(SupernaturalSeeder.TemplatesForTesting[demonName].Attacks.Any(x =>
+					x.AttackName == "Barbed Tail Slap" &&
+					expectedTailAliases.All(alias => x.BodypartAliases.Contains(alias, StringComparer.OrdinalIgnoreCase))),
+				$"{demonName} should use the seeded tail aliases for Barbed Tail Slap.");
+		}
 	}
 
 	[TestMethod]

--- a/DatabaseSeeder/Seeders/SupernaturalSeeder.Definitions.cs
+++ b/DatabaseSeeder/Seeders/SupernaturalSeeder.Definitions.cs
@@ -350,24 +350,105 @@ public partial class SupernaturalSeeder
 		var angelAttacks = new[]
 		{
 			Attack("Radiant Touch", ItemQuality.Good, "rhand", "lhand"),
-			Attack("Radiant Gaze", ItemQuality.Good, "reye", "leye")
+			Attack("Radiant Gaze", ItemQuality.Good, "reye", "leye"),
+			Attack("Heavenly Choir", ItemQuality.Good, "mouth"),
+			Attack("Canticle of Awe", ItemQuality.Good, "mouth"),
+			Attack("Word of Command", ItemQuality.Good, "mouth"),
+			Attack("Crown of Stars", ItemQuality.Good, "reye", "leye"),
+			Attack("Mercy-Searing Grasp", ItemQuality.Good, "rhand", "lhand")
 		};
-		var wingedAngelAttacks = angelAttacks.Append(Attack("Wing Buffet", ItemQuality.Standard, "rwingbase", "lwingbase")).ToArray();
+		var wingedAngelAttacks = angelAttacks.Concat(
+		[
+			Attack("Wing Buffet", ItemQuality.Standard, "rwingbase", "lwingbase"),
+			Attack("Seraphic Wingstorm", ItemQuality.Good, "rwingbase", "lwingbase")
+		]).ToArray();
+		var highAngelAttacks = wingedAngelAttacks.Concat(
+		[
+			Attack("Trumpet Peal", ItemQuality.VeryGood, "mouth"),
+			Attack("Starfire Breath", ItemQuality.VeryGood, "mouth")
+		]).ToArray();
+		var ophanicAngelAttacks = new[]
+		{
+			Attack("Wheel Crush", ItemQuality.VeryGood, "abdomen"),
+			Attack("Wheel of Judgment", ItemQuality.VeryGood, "abdomen"),
+			Attack("Radiant Gaze", ItemQuality.Good, "reye", "leye"),
+			Attack("Many-Eyed Ray", ItemQuality.Good, "reye", "leye"),
+			Attack("Crown of Stars", ItemQuality.Good, "reye", "leye"),
+			Attack("Heavenly Choir", ItemQuality.Good, "mouth"),
+			Attack("Word of Command", ItemQuality.Good, "mouth")
+		};
 		var demonAttacks = new[]
 		{
 			Attack("Infernal Claw", ItemQuality.Good, "rhand", "lhand"),
 			Attack("Horn Gore", ItemQuality.Standard, "rhorn", "lhorn"),
-			Attack("Fanged Bite", ItemQuality.Standard, "mouth")
+			Attack("Fanged Bite", ItemQuality.Standard, "mouth"),
+			Attack("Brimstone Spit", ItemQuality.Standard, "mouth"),
+			Attack("Infernal Trip", ItemQuality.Standard, "rfoot", "lfoot"),
+			Attack("Damnation Barge", ItemQuality.Standard, "abdomen"),
+			Attack("Hellish Headbutt", ItemQuality.Standard, "forehead"),
+			Attack("Soul Hook", ItemQuality.Good, "rhand", "lhand"),
+			Attack("Sinner's Clinch", ItemQuality.Good, "rhand", "lhand"),
+			Attack("Barbed Tail Slap", ItemQuality.Standard, "utail", "mtail", "ltail"),
+			Attack("Fallen Choir", ItemQuality.Good, "mouth")
+		};
+		var highDemonAttacks = demonAttacks.Concat(
+		[
+			Attack("Hellfire Breath", ItemQuality.VeryGood, "mouth"),
+			Attack("Abyssal Chain Lash", ItemQuality.Good, "rhand", "lhand")
+		]).ToArray();
+		var fallenOphanicAttacks = new[]
+		{
+			Attack("Wheel Crush", ItemQuality.VeryGood, "abdomen"),
+			Attack("Wheel of Judgment", ItemQuality.VeryGood, "abdomen"),
+			Attack("Soul Chill", ItemQuality.Good, "reye", "leye"),
+			Attack("Many-Eyed Ray", ItemQuality.Good, "reye", "leye"),
+			Attack("Hellfire Breath", ItemQuality.VeryGood, "mouth"),
+			Attack("Infernal Trip", ItemQuality.Standard, "rfoot", "lfoot"),
+			Attack("Fallen Choir", ItemQuality.Good, "mouth")
+		};
+		var hellhoundAttacks = new[]
+		{
+			Attack("Fanged Bite", ItemQuality.VeryGood, "mouth"),
+			Attack("Infernal Claw", ItemQuality.Good, "rfclaw", "lfclaw", "rrclaw", "lrclaw"),
+			Attack("Hellfire Breath", ItemQuality.Good, "mouth"),
+			Attack("Brimstone Spit", ItemQuality.Standard, "mouth"),
+			Attack("Damnation Barge", ItemQuality.Good, "abdomen"),
+			Attack("Hellish Headbutt", ItemQuality.Standard, "head"),
+			Attack("Infernal Trip", ItemQuality.Standard, "rfpaw", "lfpaw", "rrpaw", "lrpaw"),
+			Attack("Barbed Tail Slap", ItemQuality.Standard, "utail", "mtail", "ltail")
 		};
 		var spiritAttacks = new[]
 		{
 			Attack("Spectral Touch", ItemQuality.Standard, "rhand", "lhand"),
-			Attack("Soul Chill", ItemQuality.Standard, "rhand", "lhand")
+			Attack("Soul Chill", ItemQuality.Standard, "rhand", "lhand"),
+			Attack("Wailing Dirge", ItemQuality.Good, "mouth"),
+			Attack("Grave Drag", ItemQuality.Standard, "rhand", "lhand"),
+			Attack("Deathly Pall", ItemQuality.Standard, "mouth")
 		};
 		var undeadAttacks = new[]
 		{
 			Attack("Grave Claw", ItemQuality.Standard, "rhand", "lhand"),
-			Attack("Fanged Bite", ItemQuality.Standard, "mouth")
+			Attack("Fanged Bite", ItemQuality.Standard, "mouth"),
+			Attack("Grasp of the Dead", ItemQuality.Standard, "rhand", "lhand"),
+			Attack("Grave Drag", ItemQuality.Standard, "rhand", "lhand"),
+			Attack("Bone Rattle", ItemQuality.Standard, "forehead"),
+			Attack("Crypt Dust Breath", ItemQuality.Standard, "mouth"),
+			Attack("Deathly Pall", ItemQuality.Standard, "mouth")
+		};
+		var werewolfAttacks = new[]
+		{
+			Attack("Fanged Bite", ItemQuality.Standard, "mouth"),
+			Attack("Hamstring Snap", ItemQuality.Standard, "mouth"),
+			Attack("Wolf Trip", ItemQuality.Standard, "rfoot", "lfoot"),
+			Attack("Crushing Pounce", ItemQuality.Standard, "abdomen")
+		};
+		var werewolfHybridAttacks = new[]
+		{
+			Attack("Fanged Bite", ItemQuality.VeryGood, "mouth"),
+			Attack("Hamstring Snap", ItemQuality.Good, "mouth"),
+			Attack("Wolf Trip", ItemQuality.Good, "rfoot", "lfoot"),
+			Attack("Crushing Pounce", ItemQuality.Good, "abdomen"),
+			Attack("Raking Maul", ItemQuality.Good, "rhand", "lhand")
 		};
 
 		foreach ((string rank, int index) in AngelicRankOrder.Select((rank, index) => (rank, index)))
@@ -379,9 +460,13 @@ public partial class SupernaturalSeeder
 				"Ishim" => "Supernatural Angelic Humanoid",
 				_ => "Supernatural Winged Angel"
 			};
-			SupernaturalAttackTemplate[] attacks = rank == "Ophanim"
-				? [Attack("Wheel Crush", ItemQuality.VeryGood, "torso"), Attack("Radiant Gaze", ItemQuality.Good, "reye", "leye")]
-				: wingedAngelAttacks;
+			SupernaturalAttackTemplate[] attacks = rank switch
+			{
+				"Ophanim" => ophanicAngelAttacks,
+				"Chayot HaKodesh" or "Erelim" or "Hashmallim" or "Seraphim" => highAngelAttacks,
+				"Ishim" => angelAttacks,
+				_ => wingedAngelAttacks
+			};
 			Add(Template(rank, SupernaturalFamily.Angel, body, index < 2 ? SizeCategory.Large : SizeCategory.Normal,
 				SupernaturalPlanarProfile.DualNatured, SupernaturalNeedsProfile.NonLiving,
 				Stats(2 + Math.Max(0, 4 - index / 2), 2 + Math.Max(0, 4 - index / 2), 1, 1, 4, 3, 5, "2d4+6"),
@@ -394,8 +479,10 @@ public partial class SupernaturalSeeder
 			string fallenName = $"Fallen {rank}";
 			string body = rank == "Ophanim" ? "Supernatural Ophanic Wheel" : "Supernatural Horned Fiend";
 			SupernaturalAttackTemplate[] attacks = rank == "Ophanim"
-				? [Attack("Wheel Crush", ItemQuality.VeryGood, "torso"), Attack("Soul Chill", ItemQuality.Good, "reye", "leye")]
-				: demonAttacks;
+				? fallenOphanicAttacks
+				: index < 4
+					? highDemonAttacks
+					: demonAttacks;
 			Add(Template(fallenName, SupernaturalFamily.Demon, body, index < 2 ? SizeCategory.Large : SizeCategory.Normal,
 				SupernaturalPlanarProfile.AstralNative, SupernaturalNeedsProfile.NonLiving,
 				Stats(3 + Math.Max(0, 3 - index / 3), 2 + Math.Max(0, 3 - index / 3), 1, 1, 4, 2, 4, "2d4+5"),
@@ -411,7 +498,7 @@ public partial class SupernaturalSeeder
 			"social predator and temptation storylines", demonAttacks, [infernal, horns, tail], "Fallen Host", "Demonic Name"));
 		Add(Template("Fury", SupernaturalFamily.Demon, "Supernatural Horned Fiend", SizeCategory.Normal,
 			SupernaturalPlanarProfile.DualNatured, SupernaturalNeedsProfile.NonLiving, Stats(3, 2, 3, 1, 3, 3, 3, "2d4+3"),
-			"vengeance spirit and relentless hunter play", demonAttacks, [infernal, wings, eyes], "Fallen Host", "Demonic Name",
+			"vengeance spirit and relentless hunter play", highDemonAttacks, [infernal, wings, eyes], "Fallen Host", "Demonic Name",
 			combat: "Beast Brawler"));
 		Add(Template("Imp", SupernaturalFamily.Demon, "Supernatural Familiar", SizeCategory.Small,
 			SupernaturalPlanarProfile.AstralNative, SupernaturalNeedsProfile.NonLiving, Stats(-2, -1, 3, 2, 1, 2, 2, "1d4+2"),
@@ -423,11 +510,11 @@ public partial class SupernaturalSeeder
 			weapons: false, combat: "Beast Skirmisher", health: 0.7));
 		Add(Template("Fiend", SupernaturalFamily.Demon, "Supernatural Horned Fiend", SizeCategory.Large,
 			SupernaturalPlanarProfile.AstralNative, SupernaturalNeedsProfile.NonLiving, Stats(5, 4, 0, 0, 3, 2, 3, "2d4+4"),
-			"brutal infernal monster and war-demon play", demonAttacks, [infernal, horns, tail], "Fallen Host", "Demonic Name",
+			"brutal infernal monster and war-demon play", highDemonAttacks, [infernal, horns, tail], "Fallen Host", "Demonic Name",
 			combat: "Beast Brawler", health: 1.3));
 		Add(Template("Hellhound", SupernaturalFamily.Demon, "Supernatural Hellhound", SizeCategory.Large,
 			SupernaturalPlanarProfile.Material, SupernaturalNeedsProfile.NonLiving, Stats(4, 3, 2, 0, 2, 4, 2, "1d4+2"),
-			"infernal hunting beast play", [Attack("Fanged Bite", ItemQuality.VeryGood, "mouth"), Attack("Infernal Claw", ItemQuality.Good, "rfclaw", "lfclaw", "rrclaw", "lrclaw")],
+			"infernal hunting beast play", hellhoundAttacks,
 			[infernal, eyes], "Fallen Host", "Demonic Name", weapons: false, humanoid: false, combat: "Beast Brawler", health: 1.2));
 
 		Add(Template("Demigod", SupernaturalFamily.Divine, "Supernatural Divine Humanoid", SizeCategory.Normal,
@@ -435,11 +522,11 @@ public partial class SupernaturalSeeder
 			"divine-blooded heroes, avatars and staff-guided legends", angelAttacks, [radiant, eyes], "Celestial Host", "Angelic Name"));
 		Add(Template("Lesser God", SupernaturalFamily.Divine, "Supernatural Many-Winged Angel", SizeCategory.Large,
 			SupernaturalPlanarProfile.DualNatured, SupernaturalNeedsProfile.NonLiving, Stats(6, 6, 2, 2, 6, 4, 8, "2d6+8"),
-			"local deities, patrons and divine NPCs", wingedAngelAttacks, [radiant, wings, eyes], "Celestial Host", "Angelic Name",
+			"local deities, patrons and divine NPCs", highAngelAttacks, [radiant, wings, eyes], "Celestial Host", "Angelic Name",
 			health: 1.5));
 		Add(Template("Greater God", SupernaturalFamily.Divine, "Supernatural Many-Winged Angel", SizeCategory.VeryLarge,
 			SupernaturalPlanarProfile.DualNatured, SupernaturalNeedsProfile.NonLiving, Stats(8, 8, 2, 2, 8, 5, 10, "2d6+10"),
-			"major deities and administrator-facing divine examples", wingedAngelAttacks, [radiant, wings, eyes], "Celestial Host",
+			"major deities and administrator-facing divine examples", highAngelAttacks, [radiant, wings, eyes], "Celestial Host",
 			"Angelic Name", health: 1.8));
 
 		Add(Template("Spirit", SupernaturalFamily.Spirit, "Supernatural Spirit Form", SizeCategory.Normal,
@@ -467,11 +554,11 @@ public partial class SupernaturalSeeder
 
 		Add(Template("Werewolf", SupernaturalFamily.Therianthrope, "Organic Humanoid", SizeCategory.Normal,
 			SupernaturalPlanarProfile.Material, SupernaturalNeedsProfile.Living, Stats(1, 1, 1, 0, 1, 2, 0),
-			"cursed or hereditary shapeshifter play", [Attack("Fanged Bite", ItemQuality.Standard, "mouth")], [beast],
+			"cursed or hereditary shapeshifter play", werewolfAttacks, [beast],
 			"Therianthrope", "Mortal Name"));
 		Add(Template("Werewolf Hybrid", SupernaturalFamily.Therianthrope, "Supernatural Werewolf Hybrid", SizeCategory.Large,
 			SupernaturalPlanarProfile.Material, SupernaturalNeedsProfile.Living, Stats(4, 3, 2, 0, 2, 3, 0),
-			"wolf-man battle forms and cursed transformation play", [Attack("Fanged Bite", ItemQuality.VeryGood, "mouth"), Attack("Infernal Claw", ItemQuality.Good, "rhand", "lhand")],
+			"wolf-man battle forms and cursed transformation play", werewolfHybridAttacks,
 			[beast], "Therianthrope", "Mortal Name", weapons: false, combat: "Beast Brawler", health: 1.25));
 
 		Add(Template("Vampire", SupernaturalFamily.Undead, "Organic Humanoid", SizeCategory.Normal,

--- a/DatabaseSeeder/Seeders/SupernaturalSeeder.Support.cs
+++ b/DatabaseSeeder/Seeders/SupernaturalSeeder.Support.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using MudSharp.Combat;
 using MudSharp.Character.Name;
 using MudSharp.Form.Material;
 using MudSharp.Form.Shape;
@@ -20,6 +21,14 @@ public partial class SupernaturalSeeder
 	private const string SupernaturalUndeadCorpseModelName = "Supernatural Nondecaying Undead Remains";
 	private const string SupernaturalSpiritCorpseModelName = "Supernatural Dissipating Spirit Remains";
 
+	internal sealed record SupernaturalAttackDefinition(
+		string DonorName,
+		string Message,
+		IReadOnlyList<string> Categories,
+		BuiltInCombatMoveType? MoveTypeOverride = null,
+		string? FixedTargetBodypartShape = null,
+		bool SharedStockAttack = false);
+
 	private static readonly IReadOnlyDictionary<string, (string SourceBody, SupernaturalPlanarProfile PlanarProfile)> CustomBodyProfiles =
 		new Dictionary<string, (string SourceBody, SupernaturalPlanarProfile PlanarProfile)>(StringComparer.OrdinalIgnoreCase)
 		{
@@ -38,19 +47,139 @@ public partial class SupernaturalSeeder
 			["Supernatural Decayed Undead"] = ("Organic Humanoid", SupernaturalPlanarProfile.Material)
 		};
 
-	private static readonly IReadOnlyDictionary<string, (string DonorName, string Message)> SupernaturalAttackCloneDefinitions =
-		new Dictionary<string, (string DonorName, string Message)>(StringComparer.OrdinalIgnoreCase)
+	private static readonly IReadOnlyDictionary<string, string[]> CustomBodyAdditionalAliases =
+		new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
 		{
-			["Radiant Touch"] = ("Bite", "@ sear|sears $1 with a touch of radiant power."),
-			["Radiant Gaze"] = ("Bite", "@ strike|strikes $1 with a radiant gaze."),
-			["Infernal Claw"] = ("Claw High Swipe", "@ rake|rakes $1 with infernal claws."),
-			["Soul Chill"] = ("Bite", "@ chill|chills $1 with deathly spiritual force."),
-			["Grave Claw"] = ("Claw Low Swipe", "@ claw|claws $1 with grave-cold hands."),
-			["Wheel Crush"] = ("Animal Barge", "@ crush|crushes into $1 with a living wheel of eyes and flame."),
-			["Fanged Bite"] = ("Carnivore Bite", "@ bite|bites $1 with supernatural fangs."),
-			["Horn Gore"] = ("Animal Barge", "@ gore|gores $1 with supernatural horns."),
-			["Spectral Touch"] = ("Bite", "@ pass|passes a spectral touch through $1.")
+			["Supernatural Horned Fiend"] = ["utail", "mtail", "ltail"],
+			["Supernatural Familiar"] = ["utail", "mtail", "ltail"]
 		};
+
+	internal static IReadOnlyDictionary<string, string[]> SupernaturalBodyAdditionalAliasesForTesting =>
+		CustomBodyAdditionalAliases;
+
+	private static SupernaturalAttackDefinition AttackDefinition(string donorName, string message,
+		params string[] categories)
+	{
+		return new SupernaturalAttackDefinition(donorName, message, categories);
+	}
+
+	private static SupernaturalAttackDefinition SonicAttackDefinition(string donorName, string message,
+		params string[] categories)
+	{
+		return new SupernaturalAttackDefinition(donorName, message, categories,
+			BuiltInCombatMoveType.ScreechAttack, "Ear");
+	}
+
+	private static SupernaturalAttackDefinition SharedAttackDefinition(string donorName, string message,
+		params string[] categories)
+	{
+		return new SupernaturalAttackDefinition(donorName, message, categories, SharedStockAttack: true);
+	}
+
+	private static readonly IReadOnlyDictionary<string, SupernaturalAttackDefinition> SupernaturalAttackCloneDefinitions =
+		new Dictionary<string, SupernaturalAttackDefinition>(StringComparer.OrdinalIgnoreCase)
+		{
+			["Radiant Touch"] = AttackDefinition("Bite",
+				"@ sear|sears $1 with a touch of radiant power.", "radiant", "clinch"),
+			["Radiant Gaze"] = AttackDefinition("Bite",
+				"@ strike|strikes $1 with a radiant gaze.", "radiant"),
+			["Wing Buffet"] = SharedAttackDefinition("Wing Buffet",
+				"@ beat|beats &0's {0} and buffet|buffets $1 with a crashing gust.", "buffeting"),
+			["Infernal Claw"] = AttackDefinition("Claw High Swipe",
+				"@ rake|rakes $1 with infernal claws.", "infernal", "claw"),
+			["Horn Gore"] = SharedAttackDefinition("Horn Gore",
+				"@ gore|gores $1 with supernatural horns.", "horn"),
+			["Fanged Bite"] = AttackDefinition("Carnivore Bite",
+				"@ bite|bites $1 with supernatural fangs.", "bite"),
+			["Soul Chill"] = AttackDefinition("Bite",
+				"@ chill|chills $1 with deathly spiritual force.", "spirit", "clinch"),
+			["Grave Claw"] = AttackDefinition("Claw Low Swipe",
+				"@ claw|claws $1 with grave-cold hands.", "undead", "claw"),
+			["Wheel Crush"] = AttackDefinition("Animal Barge",
+				"@ crush|crushes into $1 with a living wheel of eyes and flame.", "stagger", "wheel"),
+			["Spectral Touch"] = AttackDefinition("Bite",
+				"@ pass|passes a spectral touch through $1.", "spirit", "clinch"),
+
+			["Heavenly Choir"] = SonicAttackDefinition("Bite",
+				"@ open|opens &0's {0} and a choir of heavenly voices pour|pours through the air.",
+				"sonic", "radiant", "angelic"),
+			["Canticle of Awe"] = SonicAttackDefinition("Bite",
+				"@ sing|sings through &0's {0}, filling the air with a many-voiced canticle of awe.",
+				"sonic", "radiant", "angelic"),
+			["Trumpet Peal"] = SonicAttackDefinition("Bite",
+				"@ sound|sounds a trumpet-bright note from &0's {0}, bright as a choir at dawn.",
+				"sonic", "radiant", "angelic"),
+			["Word of Command"] = SonicAttackDefinition("Bite",
+				"@ speak|speaks a word of command from &0's {0}, layered with impossible voices.",
+				"sonic", "radiant", "angelic"),
+			["Crown of Stars"] = AttackDefinition("Tail Spike",
+				"@ loose|looses a star-bright ray from &0's {0} toward $1.", "ranged", "radiant"),
+			["Starfire Breath"] = AttackDefinition("Dragonfire Breath",
+				"@ breathe|breathes a cone of white starfire from &0's {0} toward $1.", "breath", "radiant"),
+			["Seraphic Wingstorm"] = AttackDefinition("Wing Buffet",
+				"@ beat|beats &0's {0}, driving a storm of radiant wind into $1.", "buffeting", "radiant"),
+			["Mercy-Searing Grasp"] = AttackDefinition("Tree Haul",
+				"@ seize|seizes $1 with &0's {0} and haul|hauls &1 through searing mercy.",
+				"forced movement", "radiant"),
+			["Wheel of Judgment"] = AttackDefinition("Animal Barge Pushback",
+				"@ thunder|thunders into $1 as a wheel of judgment and drive|drives &1 back.",
+				"pushback", "radiant", "wheel"),
+			["Many-Eyed Ray"] = AttackDefinition("Tail Spike",
+				"@ focus|focuses many watchful eyes and lance|lances $1 with a radiant ray.", "ranged", "radiant"),
+
+			["Hellfire Breath"] = AttackDefinition("Dragonfire Breath",
+				"@ breathe|breathes a cone of hellfire from &0's {0} toward $1.", "breath", "infernal"),
+			["Brimstone Spit"] = AttackDefinition("Acid Spit",
+				"@ spit|spits a burning gobbet of brimstone from &0's {0} at $1.", "spit", "infernal"),
+			["Infernal Trip"] = AttackDefinition("Tusk Sweep",
+				"@ sweep|sweeps &0's {0} low, trying to trip $1 with infernal force.",
+				"trip", "unbalance", "infernal"),
+			["Damnation Barge"] = AttackDefinition("Animal Barge Pushback",
+				"@ drive|drives into $1 with damnation's weight and force|forces &1 back.",
+				"pushback", "infernal"),
+			["Hellish Headbutt"] = AttackDefinition("Headbutt",
+				"@ crack|cracks &0's {0} into $1 with hellish force.", "stagger", "infernal"),
+			["Soul Hook"] = AttackDefinition("Tree Haul",
+				"@ hook|hooks $1 with &0's {0} and drag|drags &1 with soul-deep force.",
+				"forced movement", "infernal"),
+			["Abyssal Chain Lash"] = AttackDefinition("Water Drag",
+				"@ lash|lashes out from &0's {0} with abyssal force and drag|drags at $1.",
+				"forced movement", "infernal"),
+			["Sinner's Clinch"] = AttackDefinition("Claw Clamp",
+				"@ clamp|clamps &0's {0} onto $1 with pitiless strength.", "clinch", "infernal"),
+			["Barbed Tail Slap"] = AttackDefinition("Tail Slap",
+				"@ whip|whips &0's {0} around in a barbed slap at $1.", "stagger", "infernal"),
+			["Fallen Choir"] = SonicAttackDefinition("Bite",
+				"@ open|opens &0's {0} and a ruined choir of fallen voices tear|tears through the air.",
+				"sonic", "infernal"),
+
+			["Wailing Dirge"] = SonicAttackDefinition("Bite",
+				"@ wail|wails through &0's {0}, a mourning dirge that scrapes at every ear.",
+				"sonic", "spirit"),
+			["Grave Drag"] = AttackDefinition("Water Drag",
+				"@ drag|drags at $1 with grave-cold force from &0's {0}.", "forced movement", "undead"),
+			["Grasp of the Dead"] = AttackDefinition("Claw Clamp",
+				"@ clamp|clamps &0's {0} onto $1 with the grasp of the dead.", "clinch", "undead"),
+			["Bone Rattle"] = AttackDefinition("Head Ram",
+				"@ rattle|rattles forward and slam|slams &0's {0} into $1.", "stagger", "undead"),
+			["Crypt Dust Breath"] = AttackDefinition("Dragonfire Breath",
+				"@ breathe|breathes a choking cloud of crypt dust from &0's {0} toward $1.",
+				"breath", "undead"),
+			["Deathly Pall"] = AttackDefinition("Llama Spit",
+				"@ exhale|exhales a deathly pall from &0's {0} toward $1.", "spit", "spirit", "undead"),
+
+			["Raking Maul"] = AttackDefinition("Claw High Swipe",
+				"@ maul|mauls $1 with a raking swipe of &0's {0}.", "claw", "therianthrope"),
+			["Hamstring Snap"] = AttackDefinition("Carnivore Low Bite",
+				"@ snap|snaps low at $1 with a hamstringing bite from &0's {0}.", "bite", "therianthrope"),
+			["Crushing Pounce"] = AttackDefinition("Animal Barge",
+				"@ pounce|pounces into $1 with crushing bestial force.", "stagger", "therianthrope"),
+			["Wolf Trip"] = AttackDefinition("Tusk Sweep",
+				"@ sweep|sweeps &0's {0} low, trying to send $1 sprawling.", "trip", "unbalance", "therianthrope")
+		};
+
+	internal static IReadOnlyDictionary<string, SupernaturalAttackDefinition> SupernaturalAttackDefinitionsForTesting =>
+		SupernaturalAttackCloneDefinitions;
 
 	private static IReadOnlyCollection<string> SupernaturalAttackNames =>
 		Templates.Values
@@ -58,6 +187,8 @@ public partial class SupernaturalSeeder
 			.Select(x => x.AttackName)
 			.Distinct(StringComparer.OrdinalIgnoreCase)
 			.ToArray();
+
+	internal static IReadOnlyCollection<string> SupernaturalAttackNamesForTesting => SupernaturalAttackNames;
 
 	private static readonly IReadOnlyDictionary<string, (string PersonWord, string Description, string NameCulture)> SupernaturalCultureDefinitions =
 		new Dictionary<string, (string PersonWord, string Description, string NameCulture)>(StringComparer.OrdinalIgnoreCase)
@@ -160,8 +291,7 @@ public partial class SupernaturalSeeder
 
 			foreach (SupernaturalAttackTemplate attack in template.Attacks)
 			{
-				if (!SupernaturalAttackCloneDefinitions.ContainsKey(attack.AttackName) &&
-				    !attack.AttackName.Equals("Wing Buffet", StringComparison.OrdinalIgnoreCase))
+				if (!SupernaturalAttackCloneDefinitions.ContainsKey(attack.AttackName))
 				{
 					issues.Add($"{name} references unknown supernatural attack {attack.AttackName}.");
 				}
@@ -259,14 +389,18 @@ public partial class SupernaturalSeeder
 
 	private void EnsureSupernaturalAttacks(SupernaturalSeedSummary summary)
 	{
-		foreach ((string name, (string donorName, string message)) in SupernaturalAttackCloneDefinitions)
+		foreach ((string name, SupernaturalAttackDefinition definition) in SupernaturalAttackCloneDefinitions)
 		{
 			if (_context.WeaponAttacks.Any(x => x.Name == name))
 			{
 				continue;
 			}
 
-			WeaponAttack donor = _context.WeaponAttacks.First(x => x.Name == donorName);
+			WeaponAttack donor = _context.WeaponAttacks.First(x => x.Name == definition.DonorName);
+			int moveType = (int)(definition.MoveTypeOverride ?? (BuiltInCombatMoveType)donor.MoveType);
+			string additionalInfo = definition.FixedTargetBodypartShape is null
+				? donor.AdditionalInfo
+				: _context.BodypartShapes.First(x => x.Name == definition.FixedTargetBodypartShape).Id.ToString();
 			WeaponAttack attack = new()
 			{
 				Name = name,
@@ -280,7 +414,7 @@ public partial class SupernaturalSeeder
 				BaseAngleOfIncidence = donor.BaseAngleOfIncidence,
 				RecoveryDifficultySuccess = donor.RecoveryDifficultySuccess,
 				RecoveryDifficultyFailure = donor.RecoveryDifficultyFailure,
-				MoveType = donor.MoveType,
+				MoveType = moveType,
 				Intentions = donor.Intentions,
 				ExertionLevel = donor.ExertionLevel,
 				DamageType = donor.DamageType,
@@ -293,7 +427,7 @@ public partial class SupernaturalSeeder
 				BaseDelay = donor.BaseDelay,
 				Orientation = donor.Orientation,
 				Alignment = donor.Alignment,
-				AdditionalInfo = donor.AdditionalInfo,
+				AdditionalInfo = additionalInfo,
 				HandednessOptions = donor.HandednessOptions,
 				RequiredPositionStateIds = donor.RequiredPositionStateIds,
 				OnUseProgId = donor.OnUseProgId
@@ -303,12 +437,12 @@ public partial class SupernaturalSeeder
 
 			CombatMessage combatMessage = new()
 			{
-				Type = donor.MoveType,
-				Message = message,
+				Type = moveType,
+				Message = definition.Message,
 				Priority = 50,
 				Verb = donor.Verb,
 				Chance = 1.0,
-				FailureMessage = message
+				FailureMessage = definition.Message
 			};
 			combatMessage.CombatMessagesWeaponAttacks.Add(new CombatMessagesWeaponAttacks
 			{

--- a/DatabaseSeeder/Seeders/SupernaturalSeeder.cs
+++ b/DatabaseSeeder/Seeders/SupernaturalSeeder.cs
@@ -137,10 +137,24 @@ public partial class SupernaturalSeeder : IDatabaseSeeder
 		[
 			"Bite",
 			"Carnivore Bite",
+			"Carnivore Low Bite",
 			"Claw High Swipe",
 			"Claw Low Swipe",
 			"Animal Barge",
-			"Wing Buffet"
+			"Animal Barge Pushback",
+			"Horn Gore",
+			"Wing Buffet",
+			"Tail Spike",
+			"Acid Spit",
+			"Llama Spit",
+			"Dragonfire Breath",
+			"Tusk Sweep",
+			"Head Ram",
+			"Headbutt",
+			"Claw Clamp",
+			"Tree Haul",
+			"Water Drag",
+			"Tail Slap"
 		];
 
 		return requiredBodies.All(body => context.BodyProtos.Any(x => x.Name == body)) &&
@@ -250,11 +264,14 @@ public partial class SupernaturalSeeder : IDatabaseSeeder
 			{
 				"Supernatural Winged Angel" or "Supernatural Many-Winged Angel" => _wingedHumanoidBody,
 				"Supernatural Horned Fiend" => _hornedHumanoidBody,
+				"Supernatural Familiar" => _hornedHumanoidBody,
 				"Supernatural Hellhound" => _toedQuadrupedBody,
 				_ when bodies.TryGetValue(SourceBody, out BodyProto? body) => body,
 				_ => _organicHumanoidBody
 			};
-			bodies[bodyName] = EnsureCustomBody(bodyName, source, PlanarProfile, summary);
+			BodyProto supernaturalBody = EnsureCustomBody(bodyName, source, PlanarProfile, summary);
+			EnsureCustomBodyAdditions(bodyName, supernaturalBody);
+			bodies[bodyName] = supernaturalBody;
 		}
 
 		foreach (string bodyKey in Templates.Values.Select(x => x.BodyKey).Distinct(StringComparer.OrdinalIgnoreCase))
@@ -307,6 +324,81 @@ public partial class SupernaturalSeeder : IDatabaseSeeder
 		}
 
 		return body;
+	}
+
+	private void EnsureCustomBodyAdditions(string bodyName, BodyProto body)
+	{
+		if (!CustomBodyAdditionalAliases.ContainsKey(bodyName))
+		{
+			return;
+		}
+
+		EnsureHumanoidTail(body);
+	}
+
+	private void EnsureHumanoidTail(BodyProto body)
+	{
+		if (FindBodypartOnBody(body, "utail") is null)
+		{
+			SeederBodyUtilities.CloneBodypartSubtree(_context, _toedQuadrupedBody, body, "utail", "lback");
+		}
+
+		EnsureBodypartLimb(body, "Tail", LimbType.Appendage, "utail", "utail", "mtail", "ltail");
+	}
+
+	private void EnsureBodypartLimb(BodyProto body, string limbName, LimbType limbType, string rootAlias,
+		params string[] aliases)
+	{
+		Limb? limb = _context.Limbs.FirstOrDefault(x => x.RootBodyId == body.Id && x.Name == limbName);
+		if (limb is null)
+		{
+			BodypartProto? root = FindBodypartOnBody(body, rootAlias);
+			if (root is null)
+			{
+				return;
+			}
+
+			limb = new Limb
+			{
+				Name = limbName,
+				LimbType = (int)limbType,
+				RootBody = body,
+				RootBodypart = root,
+				LimbDamageThresholdMultiplier = 0.5,
+				LimbPainThresholdMultiplier = 0.5
+			};
+			_context.Limbs.Add(limb);
+			_context.SaveChanges();
+		}
+
+		HashSet<long> existing = _context.LimbsBodypartProto
+			.Where(x => x.LimbId == limb.Id)
+			.Select(x => x.BodypartProtoId)
+			.ToHashSet();
+		List<long> bodyIds = SeederBodyUtilities.GetBodyAndAncestorIds(_context, body);
+		IReadOnlyDictionary<string, IReadOnlyList<BodypartProto>> lookup = SeederBodyUtilities.BuildBodypartAliasLookup(
+			_context.BodypartProtos
+				.Where(x => bodyIds.Contains(x.BodyId) && aliases.Contains(x.Name))
+				.ToList());
+
+		foreach (string alias in aliases)
+		{
+			if (!lookup.TryGetValue(alias, out IReadOnlyList<BodypartProto>? matchingParts))
+			{
+				continue;
+			}
+
+			foreach (BodypartProto part in matchingParts.Where(x => existing.Add(x.Id)))
+			{
+				_context.LimbsBodypartProto.Add(new LimbBodypartProto
+				{
+					Limb = limb,
+					BodypartProto = part
+				});
+			}
+		}
+
+		_context.SaveChanges();
 	}
 
 	private void SeedOrRefreshRace(SupernaturalRaceTemplate template, BodyProto body, SupernaturalSeedSummary summary)

--- a/Design Documents/Supernatural_Seeder.md
+++ b/Design Documents/Supernatural_Seeder.md
@@ -13,7 +13,11 @@ The angelic catalogue follows Maimonides' ten ranks: Chayot HaKodesh, Ophanim, E
 The seeder uses existing FutureMUD systems rather than adding a new supernatural runtime model:
 
 - Race records carry anatomy, health strategy, communication model, natural attacks, breathing and needs configuration, chargen availability, attributes, ethnicity, and description variables.
+- The natural attack catalogue contains forty stock supernatural attacks. These use existing combat move types for sonic screeches, ranged natural attacks, spitting, breath weapons, trips, staggering blows, pushback, clinches, forced movement, and wing buffeting.
+- Angelic sonic attacks such as `Heavenly Choir`, `Canticle of Awe`, `Trumpet Peal`, and `Word of Command` use the existing area-style `ScreechAttack` mechanic, target ear-shaped bodyparts, and are written as choir or command-voice effects rather than single-target strikes.
+- Demonic, spirit, undead, and therianthrope attacks are cloned from existing animal or unarmed donor attacks so builders get varied examples without the seeder adding new combat engine mechanics.
 - Body prototypes carry the base planar presence XML for supernatural forms such as incorporeal spirits, dual-natured angels, astral demons, and ordinary material werewolves or undead.
+- Horned fiend and familiar supernatural bodies add stock tail aliases so tail attacks such as `Barbed Tail Slap` have real bodyparts to bind to.
 - Additional body forms are supplied as stock `Additional Body Form` merits. These are examples and builder tools, not automatic race-level transformations.
 - Spirits, ghosts, angels, demons, gods, and undead use explicit non-breather settings with hunger and thirst rates set to zero.
 - Werewolves use living needs and seeded alternate-form merits for hybrid and wolf-form examples.
@@ -33,6 +37,6 @@ The seeded form merits deliberately do not force full-moon or cosmology-specific
 
 ## Boundaries and Future Work
 
-The seeder includes undead only where current mechanics support them as races or body forms. It does not implement post-death ghost creation, possession, remote corpse vessels, vampire feeding, lich phylacteries, automatic werewolf lunar transformation, divine worship economies, or a new race-owned multi-form model.
+The seeder includes undead only where current mechanics support them as races or body forms. It does not implement post-death ghost creation, possession, remote corpse vessels, vampire feeding, lich phylacteries, automatic werewolf lunar transformation, divine worship economies, new combat engine move types, or a new race-owned multi-form model.
 
 Those behaviours should be implemented as future runtime features using the existing body-form, merit, effect, FutureProg, plane, needs, and health systems as integration points.


### PR DESCRIPTION
## Summary
- Expand the stock supernatural attack catalogue to 40 names with broader coverage for sonic, ranged, breath, spit, trip, stagger, pushback, clinch, forced movement, and buffeting attacks.
- Add angelic choir attacks that use the existing `ScreechAttack` mechanic and update angel, fallen, demon, spirit, undead, and therianthrope templates to use the richer sets.
- Repair tail body support for horned fiends and familiars, and document the expanded catalogue and its boundaries.

## Testing
- Added and extended `SupernaturalSeederTemplateTests` coverage for attack count, categories, sonic behavior, family-specific attack sets, and tail aliases.
- Built `DatabaseSeeder` and `DatabaseSeeder Unit Tests` successfully.
- Ran the `SupernaturalSeederTemplateTests` test filter successfully.