### PR TITLE
Add stable account list filters

### DIFF
--- a/Design Documents/Economy_System_Workflows_and_Integration.md
+++ b/Design Documents/Economy_System_Workflows_and_Integration.md
@@ -213,7 +213,7 @@ Builders need:
 
 Player workflows are surfaced through `stable`, `stable quote`, `stable lodge`, `stable redeem`, `stable accountstatus`, and `stable payaccount`. Lodging issues a system-generated stable ticket item and removes the mount from the active world. Active stable stays also suppress their mount ids during NPC boot loading, so rebooted servers do not return lodged mounts to the stable room. Redeeming checks the ticket's stay id, item id, and token, then requires any outstanding fees to be settled before the mount is logged back into the stable cell.
 
-Manager workflows include active/history lists, stay inspection, ticketless release, fee setup, account setup, employee management, bank-account assignment, open/close state, and access-prog setup. A property sale or lease can claim stables in the property for the single character controller in the same operational style as property shops.
+Manager workflows include active/history lists, stay inspection, ticketless release, fee setup, account setup, filtered account triage, employee management, bank-account assignment, open/close state, and access-prog setup. `stable account list [<filters>]` accepts composable filters for routine account operations: `suspended`, `active`, `overlimit` or `over limit`, `owing`, `prepaid` or `credit`, `owner <text>`, `name <text>`, `user <text>`, and `search <text>`. A property sale or lease can claim stables in the property for the single character controller in the same operational style as property shops.
 
 ### Auctions
 Auction houses currently fit worlds that want formal auction spaces separate from ordinary shops.

--- a/MudSharpCore Unit Tests/StableAccountListFilterTests.cs
+++ b/MudSharpCore Unit Tests/StableAccountListFilterTests.cs
@@ -1,0 +1,172 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Character.Name;
+using MudSharp.Commands.Modules;
+using MudSharp.Economy;
+using MudSharp.Economy.Stables;
+using MudSharp.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+using DbStableAccount = MudSharp.Models.StableAccount;
+using DbStableAccountUser = MudSharp.Models.StableAccountUser;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class StableAccountListFilterTests
+{
+	[TestMethod]
+	public void StableAccountListFilters_StatusAndOverLimitFilters_SelectIntersection()
+	{
+		var accounts = new List<IStableAccount>
+		{
+			CreateAccount(1L, "settled", "Alice Owner", 0.0M, 100.0M),
+			CreateAccount(2L, "suspended debt", "Ben Owner", -25.0M, 100.0M, isSuspended: true),
+			CreateAccount(3L, "suspended overdue", "Cara Owner", -125.0M, 100.0M, isSuspended: true),
+			CreateAccount(4L, "working overdue", "Dane Owner", -150.0M, 100.0M)
+		};
+		var filters = ParseFilters("suspended over limit");
+
+		var matches = filters.Apply(accounts).Select(x => x.Id).ToList();
+
+		CollectionAssert.AreEqual(new List<long> { 3L }, matches);
+	}
+
+	[TestMethod]
+	public void StableAccountListFilters_BalanceFilters_SelectOwingAndPrepaidAccounts()
+	{
+		var accounts = new List<IStableAccount>
+		{
+			CreateAccount(1L, "settled", "Alice Owner", 0.0M, 100.0M),
+			CreateAccount(2L, "owing", "Ben Owner", -10.0M, 100.0M),
+			CreateAccount(3L, "prepaid", "Cara Owner", 25.0M, 100.0M)
+		};
+
+		var owingMatches = ParseFilters("owing").Apply(accounts).Select(x => x.Id).ToList();
+		var prepaidMatches = ParseFilters("credit").Apply(accounts).Select(x => x.Id).ToList();
+
+		CollectionAssert.AreEqual(new List<long> { 2L }, owingMatches);
+		CollectionAssert.AreEqual(new List<long> { 3L }, prepaidMatches);
+	}
+
+	[TestMethod]
+	public void StableAccountListFilters_OwnerAndAccountNameFilters_MatchCaseInsensitiveText()
+	{
+		var accounts = new List<IStableAccount>
+		{
+			CreateAccount(1L, "Courier House", "Alder Stone", 0.0M, 100.0M),
+			CreateAccount(2L, "Merchant House", "Alder Stone", 0.0M, 100.0M),
+			CreateAccount(3L, "Courier House", "Birch Reed", 0.0M, 100.0M)
+		};
+		var filters = ParseFilters("owner \"alder stone\" name courier");
+
+		var matches = filters.Apply(accounts).Select(x => x.Id).ToList();
+
+		CollectionAssert.AreEqual(new List<long> { 1L }, matches);
+	}
+
+	[TestMethod]
+	public void StableAccountListFilters_SearchFilter_MatchesAuthorisedUsers()
+	{
+		var accounts = new List<IStableAccount>
+		{
+			CreateAccount(1L, "Courier House", "Alder Stone", 0.0M, 100.0M, false, "Mira Penn"),
+			CreateAccount(2L, "Merchant House", "Birch Reed", 0.0M, 100.0M, false, "Toma Grey")
+		};
+		var filters = ParseFilters("search mira");
+
+		var matches = filters.Apply(accounts).Select(x => x.Id).ToList();
+
+		CollectionAssert.AreEqual(new List<long> { 1L }, matches);
+	}
+
+	[TestMethod]
+	public void StableAccountListFilters_UnknownFilter_ReturnsHelpfulError()
+	{
+		var parsed = EconomyModule.TryParseStableAccountListFilters(
+			new StringStack("mystery"),
+			out _,
+			out var error);
+
+		Assert.IsFalse(parsed);
+		StringAssert.Contains(error, "not a valid stable account list filter");
+		StringAssert.Contains(error, "stable account list");
+	}
+
+	private static EconomyModule.StableAccountListFilterSet ParseFilters(string text)
+	{
+		var parsed = EconomyModule.TryParseStableAccountListFilters(
+			new StringStack(text),
+			out var filters,
+			out var error);
+
+		Assert.IsTrue(parsed, error);
+		return filters;
+	}
+
+	private static StableAccount CreateAccount(
+		long id,
+		string accountName,
+		string ownerName,
+		decimal balance,
+		decimal creditLimit,
+		bool isSuspended = false,
+		params string[] additionalUsers)
+	{
+		var gameworld = new Mock<IFuturemud>();
+		var cultures = new All<INameCulture>();
+		var culture = new Mock<INameCulture>();
+		culture.SetupGet(x => x.Id).Returns(1L);
+		culture.SetupGet(x => x.Name).Returns("test culture");
+		culture.Setup(x => x.NamePattern(It.IsAny<NameStyle>()))
+			.Returns(Tuple.Create("{0}", new List<NameUsage> { NameUsage.BirthName }));
+		cultures.Add(culture.Object);
+		gameworld.SetupGet(x => x.NameCultures).Returns(cultures);
+
+		var stable = new Mock<IStable>();
+		stable.SetupGet(x => x.Id).Returns(1L);
+		stable.SetupGet(x => x.Name).Returns("test stable");
+		stable.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+
+		var dbAccount = new DbStableAccount
+		{
+			Id = id,
+			StableId = 1L,
+			AccountName = accountName,
+			AccountOwnerId = id * 10L,
+			AccountOwnerName = NameXml(ownerName),
+			Balance = balance,
+			CreditLimit = creditLimit,
+			IsSuspended = isSuspended
+		};
+		dbAccount.AccountUsers.Add(new DbStableAccountUser
+		{
+			StableAccountId = dbAccount.Id,
+			AccountUserId = dbAccount.AccountOwnerId,
+			AccountUserName = NameXml(ownerName)
+		});
+
+		var nextUserId = dbAccount.AccountOwnerId + 1L;
+		foreach (var user in additionalUsers)
+		{
+			dbAccount.AccountUsers.Add(new DbStableAccountUser
+			{
+				StableAccountId = dbAccount.Id,
+				AccountUserId = nextUserId++,
+				AccountUserName = NameXml(user)
+			});
+		}
+
+		return new StableAccount(dbAccount, stable.Object);
+	}
+
+	private static string NameXml(string name)
+	{
+		return new XElement("Name",
+			new XAttribute("culture", 1L),
+			new XElement("Element", new XAttribute("usage", NameUsage.BirthName), new XCData(name))
+		).ToString();
+	}
+}

--- a/MudSharpCore/Commands/Modules/EconomyModule.Stables.cs
+++ b/MudSharpCore/Commands/Modules/EconomyModule.Stables.cs
@@ -26,6 +26,18 @@ namespace MudSharp.Commands.Modules;
 
 internal partial class EconomyModule
 {
+	private const string StableAccountListFilterHelp = @"You can use the following filters with #3stable account list#0:
+
+	#3suspended#0 - only suspended accounts
+	#3active#0 - only non-suspended accounts
+	#3overlimit#0 or #3over limit#0 - only accounts beyond their credit limit
+	#3owing#0 - only accounts with a negative balance
+	#3prepaid#0 or #3credit#0 - only accounts with a positive balance
+	#3owner <text>#0 - owner name contains the text
+	#3name <text>#0 - account name contains the text
+	#3user <text>#0 - authorised-user name contains the text
+	#3search <text>#0 - account, owner, or authorised-user name contains the text";
+
 	private const string StableHelp = @"You can use the following options with the stable command:
 
 	#3stable#0 - shows information about the stable here
@@ -43,7 +55,7 @@ Stable managers can use the following additional commands:
 	#3stable release <stay> [waive]#0 - releases a mount without a ticket
 	#3stable bank <account|none>#0 - sets the stable bank account for proprietors
 	#3stable fee lodge|daily <amount|prog <prog>|none>#0 - sets stable fees for proprietors
-	#3stable account list#0 - lists all accounts
+	#3stable account list [<filters>]#0 - lists all accounts, optionally filtered
 	#3stable account show <id|name>#0 - shows a particular credit account
 	#3stable account create <name> <ownership> <credit limit>#0 - creates a new credit account for a customer
 	#3stable account limit <id|name> <limit>#0 - sets a new credit limit for an account
@@ -970,47 +982,230 @@ Administrators can also use:
 				return;
 		}
 
-		actor.OutputHandler.Send(@"You can use the following options with the account subcommand:
+		actor.OutputHandler.Send((@"You can use the following options with the account subcommand:
 
-	#3list#0 - lists all accounts
+	#3list [<filters>]#0 - lists all accounts, optionally filtered
 	#3show <id|name>#0 - shows a particular credit account
 	#3create <name> <ownership> <credit limit>#0 - creates a new credit account for a customer
 	#3limit <id|name> <limit>#0 - sets a new credit limit for an account
 	#3suspend <id|name>#0 - toggles suspension of a credit account
 	#3authorise <id|name> <person> <limit>#0 - authorises an additional person to access a credit account
-	#3unauthorise <id|name> <person>#0 - removes an authorisation of an additional person on a credit account".SubstituteANSIColour());
+	#3unauthorise <id|name> <person>#0 - removes an authorisation of an additional person on a credit account
+
+" + StableAccountListFilterHelp).SubstituteANSIColour());
 	}
+
+	internal sealed class StableAccountListFilterSet
+	{
+		private readonly List<Func<IStableAccount, bool>> _predicates = new();
+		private readonly List<string> _descriptions = new();
+
+		public IReadOnlyList<string> Descriptions => _descriptions;
+
+		public bool Matches(IStableAccount account)
+		{
+			return _predicates.All(predicate => predicate(account));
+		}
+
+		public IEnumerable<IStableAccount> Apply(IEnumerable<IStableAccount> accounts)
+		{
+			return accounts.Where(Matches);
+		}
+
+		internal void Add(string description, Func<IStableAccount, bool> predicate)
+		{
+			_descriptions.Add(description);
+			_predicates.Add(predicate);
+		}
+	}
+
+	internal static bool TryParseStableAccountListFilters(StringStack ss, out StableAccountListFilterSet filters, out string error)
+	{
+		filters = new StableAccountListFilterSet();
+		error = string.Empty;
+
+		while (!ss.IsFinished)
+		{
+			var cmd = ss.PopSpeech().ToLowerInvariant();
+			switch (cmd)
+			{
+				case "suspended":
+				case "suspend":
+					filters.Add("suspended", account => account.IsSuspended);
+					continue;
+				case "active":
+				case "unsuspended":
+				case "open":
+					filters.Add("active", account => !account.IsSuspended);
+					continue;
+				case "over":
+					if (!ss.IsFinished && ss.PeekSpeech().EqualTo("limit"))
+					{
+						ss.PopSpeech();
+					}
+
+					filters.Add("over limit", account => account.CreditAvailable < 0.0M);
+					continue;
+				case "overlimit":
+				case "over-limit":
+				case "overbalanced":
+					filters.Add("over limit", account => account.CreditAvailable < 0.0M);
+					continue;
+				case "owing":
+				case "owed":
+				case "debt":
+				case "negative":
+					filters.Add("owing balance", account => account.Balance < 0.0M);
+					continue;
+				case "prepaid":
+				case "credit":
+				case "positive":
+					filters.Add("prepaid balance", account => account.Balance > 0.0M);
+					continue;
+				case "owner":
+					if (!TryPopStableAccountListFilterText(ss, "owner", out var ownerText, out error))
+					{
+						return false;
+					}
+
+					filters.Add($"owner matching \"{ownerText}\"", account => StableAccountOwnerNameMatches(account, ownerText));
+					continue;
+				case "name":
+				case "account":
+					if (!TryPopStableAccountListFilterText(ss, "name", out var nameText, out error))
+					{
+						return false;
+					}
+
+					filters.Add($"account name matching \"{nameText}\"", account => StableAccountNameMatches(account, nameText));
+					continue;
+				case "user":
+				case "authorised":
+				case "authorized":
+					if (!TryPopStableAccountListFilterText(ss, "user", out var userText, out error))
+					{
+						return false;
+					}
+
+					filters.Add($"authorised user matching \"{userText}\"", account => StableAccountUserNameMatches(account, userText));
+					continue;
+				case "search":
+				case "match":
+					if (!TryPopStableAccountListFilterText(ss, "search", out var searchText, out error))
+					{
+						return false;
+					}
+
+					filters.Add($"matching \"{searchText}\"", account =>
+						StableAccountNameMatches(account, searchText) ||
+						StableAccountOwnerNameMatches(account, searchText) ||
+						StableAccountUserNameMatches(account, searchText));
+					continue;
+			}
+
+			error = $"The text {cmd.ColourCommand()} is not a valid stable account list filter.\n\n{StableAccountListFilterHelp}";
+			return false;
+		}
+
+		return true;
+	}
+
+	private static bool TryPopStableAccountListFilterText(StringStack ss, string filterName, out string text, out string error)
+	{
+		text = string.Empty;
+		error = string.Empty;
+		if (ss.IsFinished)
+		{
+			error = $"The {filterName.ColourCommand()} filter needs matching text.\n\n{StableAccountListFilterHelp}";
+			return false;
+		}
+
+		text = ss.PopSpeech();
+		if (!string.IsNullOrWhiteSpace(text))
+		{
+			return true;
+		}
+
+		error = $"The {filterName.ColourCommand()} filter needs matching text.\n\n{StableAccountListFilterHelp}";
+		return false;
+	}
+
+	private static bool StableAccountNameMatches(IStableAccount account, string text)
+	{
+		return account.AccountName.Contains(text, StringComparison.InvariantCultureIgnoreCase);
+	}
+
+	private static bool StableAccountOwnerNameMatches(IStableAccount account, string text)
+	{
+		return account.AccountOwnerName.GetName(NameStyle.FullName).Contains(text, StringComparison.InvariantCultureIgnoreCase) ||
+		       account.AccountOwnerName.GetName(NameStyle.SimpleFull).Contains(text, StringComparison.InvariantCultureIgnoreCase);
+	}
+
+	private static bool StableAccountUserNameMatches(IStableAccount account, string text)
+	{
+		return account.AccountUsers.Any(user =>
+			user.PersonalName.GetName(NameStyle.FullName).Contains(text, StringComparison.InvariantCultureIgnoreCase) ||
+			user.PersonalName.GetName(NameStyle.SimpleFull).Contains(text, StringComparison.InvariantCultureIgnoreCase));
+	}
+
 	private static void StableAccountList(ICharacter actor, IStable stable, StringStack ss)
 	{
-		var accounts = stable.StableAccounts.ToList();
-		// TODO - filtering criteria
+		if (!TryParseStableAccountListFilters(ss, out var filters, out var error))
+		{
+			actor.OutputHandler.Send(error.SubstituteANSIColour());
+			return;
+		}
 
-		actor.OutputHandler.Send(StringUtilities.GetTextTable(
-			from account in accounts select new List<string>
+		var allAccounts = stable.StableAccounts.ToList();
+		var accounts = filters.Apply(allAccounts)
+			.OrderBy(account => account.AccountName, StringComparer.InvariantCultureIgnoreCase)
+			.ToList();
+
+		StringBuilder sb = new();
+		sb.AppendLine($"Stable accounts for {stable.Name.TitleCase().ColourName()}");
+		if (filters.Descriptions.Any())
+		{
+			sb.AppendLine($"Filters: {filters.Descriptions.Select(x => x.ColourCommand()).ListToString()}");
+		}
+
+		sb.AppendLine($"Showing {accounts.Count.ToStringN0(actor)} of {allAccounts.Count.ToStringN0(actor)} {"account".Pluralise(allAccounts.Count != 1)}.");
+		if (!accounts.Any())
+		{
+			sb.AppendLine("No stable accounts match those filters.");
+			actor.OutputHandler.Send(sb.ToString());
+			return;
+		}
+
+		sb.AppendLine(StringUtilities.GetTextTable(
+			from account in accounts
+			select new List<string>
 			{
 				account.Id.ToStringN0(actor),
 				account.AccountName,
 				account.AccountOwnerName.GetName(NameStyle.SimpleFull),
 				account.IsSuspended.ToColouredString(),
 				stable.Currency.Describe(account.Balance, CurrencyDescriptionPatternType.ShortDecimal).ColourValue(),
-                stable.Currency.Describe(account.CreditLimit, CurrencyDescriptionPatternType.ShortDecimal).ColourValue(),
-                stable.Currency.Describe(account.CreditAvailable, CurrencyDescriptionPatternType.ShortDecimal).ColourValue(),
+				stable.Currency.Describe(account.CreditLimit, CurrencyDescriptionPatternType.ShortDecimal).ColourValue(),
+				stable.Currency.Describe(account.CreditAvailable, CurrencyDescriptionPatternType.ShortDecimal).ColourValue(),
 				account.AccountUsers.Count().ToStringN0(actor)
-            },
+			},
 			new List<string>
 			{
 				"Id",
-				"Accn Name",
-				"Owner Name",
-				"Suspended?",
+				"Account",
+				"Owner",
+				"Susp?",
 				"Balance",
 				"Limit",
 				"Available",
 				"Users"
 			},
-			actor,
-			Telnet.Yellow
+			actor.LineFormatLength,
+			colour: Telnet.Yellow,
+			truncatableColumnIndex: 1,
+			unicodeTable: actor.Account.UseUnicode
 		));
+		actor.OutputHandler.Send(sb.ToString());
 	}
 
 	private static void StableAccountCreate(ICharacter actor, IStable stable, StringStack ss)


### PR DESCRIPTION
## Summary
- Add manager-side `stable account list` filters for suspended, active, over limit, owing, prepaid/credit, owner, name, user, and search matching.
- Keep list output readable with a summary header, active filter echo, and stable ordering.
- Update the economy workflow doc to reflect the visible command syntax.

## Testing
- Added focused MSTest coverage for filter parsing and account selection behavior.
- Ran the `MudSharpCore Unit Tests` suite filtered to stable account tests; all targeted tests passed.