### PR TITLE
Harden TimeAndDate builder surfaces and stored fallbacks

### DIFF
--- a/Design Documents/Time_And_Date_System.md
+++ b/Design Documents/Time_And_Date_System.md
@@ -85,6 +85,28 @@ Shards own available clocks and calendars through shard link tables. Zones choos
 
 Economic zones, clans, boards, weather controllers, celestials, and FutureProg schedules also persist references to clocks, calendars, time zones, or `MudDateTime` round-trip strings.
 
+### Stored Value Fallbacks
+Builder edits to clocks and calendars can make old round-trip strings invalid. Runtime database and XML load paths therefore use explicit stored-value helpers rather than builder/player parsing:
+
+- `MudDateTime.TryParseStored(...)`
+- `MudDateTime.FromStoredStringOrFallback(...)`
+- `ICalendar.GetStoredDateOrFallback(...)`
+- `IClock.GetStoredTimeOrFallback(...)`
+
+These helpers are only for trusted stored engine data. Interactive builder/player input still uses strict parsing and returns explanatory errors.
+
+Fallback policies are chosen by owner semantics:
+
+- active scheduling and cadence state normally falls back to the owning calendar or clock's current date/time
+- optional expiry, closed, end, and "not scheduled" values fall back to `MudDateTime.Never` or `null` where the owning code supports null
+- historical/audit records fall back to current in-game date/time so displays remain stable
+- character birth or join dates fall back to the relevant current calendar date
+- celestial epoch values fall back to the first valid date in the epoch year so movement remains deterministic
+- saved FutureProg `muddatetime` variables fall back to `MudDateTime.Never`
+- calendar current date falls back to the first valid generated date for the current or epoch year
+
+Every fallback attempts to notify admins through `DiscordConnection.NotifyAdmins`. The notification includes the bad stored string, value type, calendar name/id, clock name/id where applicable, owner type/id/name, affected field, fallback value, and parse failure reason. If Discord is unavailable or notification fails, the same payload is written through the server console utility and the load continues.
+
 ## Clock Model
 `IClock` defines a configurable clock rather than assuming Earth time.
 
@@ -402,8 +424,9 @@ The `time` command intentionally routes exactness through checks. A character ma
 ### Builder/Admin-Facing
 Current builder/admin surfaces include:
 
-- `clock`: list, create, edit, clone, close, and show clocks
-- `timezone`: list, create, and edit time zones for a clock
+- `clock`: list, new/create, edit/open, clone, close, show, and set commands
+- `timezone`: list, new/create, edit/open, clone, close, show, and set commands
+- `calendar`: list, new, edit/open, clone, close, show, preview, validate, and set commands
 - `shard set <shard> clocks <clock...>`
 - `shard set <shard> calendars <calendar...>`
 - `zone set <zone> timezone <clock> <timezone>`
@@ -411,7 +434,15 @@ Current builder/admin surfaces include:
 - `show calendars`
 - `show timezones [clock]`
 
-There is robust clock editing support through `EditableItemHelper.ClockHelper`. Calendar editing is less builder-complete and is currently more dependent on seeded or XML-defined calendar definitions.
+Clock, calendar, and mud time-zone editing all use `IEditableItem` and `EditableItemHelperTime.cs`, so they share the standard `list/new/edit/show/set/close/clone` workflow used by other builder-managed engine objects. The legacy `timezone list/create/edit` syntax remains as a compatibility alias, but the generic editing workflow is the canonical surface.
+
+Clock editing supports metadata, display masks, clock units, in-game speed, fixed digit settings, zero-hour behavior, hour intervals, primary time-zone selection, current-time setting through local-time parsing, and crude time interval add/remove/clear.
+
+Time-zone editing supports name/alias, description, and offset hours/minutes. Existing time zones cannot be moved between clocks; builders should clone to the target clock instead.
+
+Calendar editing supports metadata, display masks, feed clock, current date, epoch year and first weekday, era display text, weekday and month editing, normal special/non-weekday days, intercalary days/months, generated-year preview, and validation. Structural edits clear generated-year caches, normalize the current date, and mark the calendar changed.
+
+Builders changing live calendars or clocks should preview and validate before closing the edit session, then watch for Discord fallback notifications after reboot/load cycles. Those notifications identify affected saved objects so humans can repair data that was made invalid by the definition change.
 
 ## Seeder Support
 `TimeSeeder` installs the initial clock, UTC time zone, and selected stock calendar package.
@@ -457,6 +488,8 @@ These are important rules to preserve when changing the system:
 - Temporal listeners consume repeat counts only after successful payload firing.
 - Ordinal recurrence calculations must use generated calendar data rather than Gregorian month/week assumptions.
 - Persistent scheduling should store recurrence/reference data and recreate listeners rather than expecting listeners themselves to persist.
+- Stored-value fallback helpers must be used for persisted round-trip strings that may have been invalidated by builder edits.
+- Fallback reporting must be no-throw; bad telemetry should never prevent the owning object from loading.
 
 ## Test Coverage
 The normal unit-test suites now include focused coverage for:
@@ -465,25 +498,28 @@ The normal unit-test suites now include focused coverage for:
 - `MudDate`, `MudDateTime`, `MudTimeSpan`, calendar weekday math, intercalary weekday edits, and `Never` safety
 - recurring interval parsing, descriptions, round-trip text, forward/backward search, high ordinal weekdays, exact-month skipping, and "or last" fallback
 - runtime listeners, interval extension helpers, and FutureProg date/time helper functions
+- clock, time-zone, and calendar builder command paths for high-value edits
+- stored-value fallback behavior and Discord admin notification payloads
 - every seeded clock/calendar package produced by `TimeSeeder`, including runtime loading and idempotent reruns
 
 ## Current Limitations
 The system is flexible, but there are areas where current support is incomplete or intentionally narrow:
 
-- calendar authoring is not as builder-friendly as clock and time-zone authoring
+- calendar editing is broad but still deliberately command-oriented; there is no graphical calendar designer or bulk import/export workflow
 - time zones are fixed offsets and do not model daylight saving or historical offset changes
 - recurring interval text is richer than the legacy compact form, but it remains a focused recurrence grammar rather than a general cron system
 - listeners are in-memory runtime helpers, so persistence must be implemented by the owning subsystem
 - cross-calendar conversion is based on each calendar's current date anchor, which is useful for live worlds but should be treated carefully for historical absolute chronology
 - `MudTimeSpan` month and year components are calendar-like approximations until applied to a concrete `MudDateTime`
+- major structural edits rely on fallback notification and human repair rather than a bulk migration wizard
 
 ## Future Work
 Useful extensions include:
 
-- a full calendar builder/editor with validation previews for generated years
 - builder-facing calendar import/export tooling for XML definitions
 - additional recurrence validation previews and builder-facing schedule explanation tools
 - daylight saving and date-bounded time-zone transitions
 - a schedule inspection command that shows active listener state alongside persistent recurrence state
 - more FutureProg helper functions for calendar math, such as `daysbetween`, `monthstart`, `monthend`, and `weekdayname`
 - stronger validation for calendars linked to shards, zones, celestials, weather controllers, economies, and clans before deletion or major edits
+- an admin repair/report command that enumerates stored time strings that would currently trigger fallbacks

--- a/FutureMUDLibrary/TimeAndDate/Date/ICalendar.cs
+++ b/FutureMUDLibrary/TimeAndDate/Date/ICalendar.cs
@@ -1,4 +1,5 @@
 ﻿using MudSharp.Framework;
+using MudSharp.Framework.Revision;
 using MudSharp.Framework.Save;
 using MudSharp.FutureProg;
 using MudSharp.TimeAndDate.Time;
@@ -16,7 +17,7 @@ namespace MudSharp.TimeAndDate.Date
 
     public delegate void CalendarEventHandler();
 
-    public interface ICalendar : ISaveable, IXmlSavable, IXmlLoadable, IProgVariable, IHaveMultipleNames
+    public interface ICalendar : ISaveable, IXmlSavable, IXmlLoadable, IProgVariable, IHaveMultipleNames, IEditableItem
     {
         event CalendarEventHandler DaysUpdated;
         event CalendarEventHandler MonthsUpdated;

--- a/FutureMUDLibrary/TimeAndDate/Date/IntercalaryMonth.cs
+++ b/FutureMUDLibrary/TimeAndDate/Date/IntercalaryMonth.cs
@@ -61,7 +61,7 @@ namespace MudSharp.TimeAndDate.Date
 
         public IntercalaryRule Rule
         {
-            get => _rule; protected set => _rule = value;
+            get => _rule; set => _rule = value;
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace MudSharp.TimeAndDate.Date
 
         public MonthDefinition Month
         {
-            get => _month; protected set => _month = value;
+            get => _month; set => _month = value;
         }
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace MudSharp.TimeAndDate.Date
 
         public string InsertPosition
         {
-            get => _insertPosition; protected set => _insertPosition = value;
+            get => _insertPosition; set => _insertPosition = value;
         }
 
         #endregion

--- a/FutureMUDLibrary/TimeAndDate/Date/MonthDefinition.cs
+++ b/FutureMUDLibrary/TimeAndDate/Date/MonthDefinition.cs
@@ -139,7 +139,7 @@ namespace MudSharp.TimeAndDate.Date
 
         public string Alias
         {
-            get => _alias; protected set => _alias = value;
+            get => _alias; set => _alias = value;
         }
 
         // Short Name of the month, e.g. Jul - used in abbreviated date output
@@ -147,7 +147,7 @@ namespace MudSharp.TimeAndDate.Date
 
         public string ShortName
         {
-            get => _shortName; protected set => _shortName = value;
+            get => _shortName; set => _shortName = value;
         }
 
         // Full name of the month, e.g. July
@@ -155,7 +155,7 @@ namespace MudSharp.TimeAndDate.Date
 
         public string FullName
         {
-            get => _fullName; protected set => _fullName = value;
+            get => _fullName; set => _fullName = value;
         }
 
         /// <summary>
@@ -166,7 +166,7 @@ namespace MudSharp.TimeAndDate.Date
 
         public int NominalOrder
         {
-            get => _nominalOrder; protected set => _nominalOrder = value;
+            get => _nominalOrder; set => _nominalOrder = value;
         }
 
         // Ordinary days in the month
@@ -174,7 +174,7 @@ namespace MudSharp.TimeAndDate.Date
 
         public int NormalDays
         {
-            get => _normalDays; protected set => _normalDays = value;
+            get => _normalDays; set => _normalDays = value;
         }
 
         #endregion

--- a/FutureMUDLibrary/TimeAndDate/MudDateTime.cs
+++ b/FutureMUDLibrary/TimeAndDate/MudDateTime.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Linq;
 using System.Numerics;
 using System.Text.RegularExpressions;
 using static System.Runtime.InteropServices.JavaScript.JSType;
@@ -283,6 +284,164 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
             {
                 return false;
             }
+        }
+
+        public static bool TryParseStored(string text, IFuturemud gameworld, out MudDateTime dt, out string error)
+        {
+            dt = null;
+            error = string.Empty;
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                error = "No stored datetime string was supplied.";
+                return false;
+            }
+
+            if (text.Equals("never", StringComparison.InvariantCultureIgnoreCase))
+            {
+                dt = Never;
+                return true;
+            }
+
+            if (gameworld == null)
+            {
+                error = "No gameworld was supplied.";
+                return false;
+            }
+
+            Match match = ParseRegex.Match(text);
+            if (!match.Success)
+            {
+                error = "The stored datetime string did not match the round-trip format.";
+                return false;
+            }
+
+            if (!long.TryParse(match.Groups["calendar"].Value, out var calendarId))
+            {
+                error = "The stored calendar id was not valid.";
+                return false;
+            }
+
+            ICalendar calendar = gameworld.Calendars.Get(calendarId);
+            if (calendar == null)
+            {
+                error = $"The stored calendar id {calendarId:N0} did not resolve.";
+                return false;
+            }
+
+            if (!long.TryParse(match.Groups["clock"].Value, out var clockId))
+            {
+                error = "The stored clock id was not valid.";
+                return false;
+            }
+
+            IClock clock = gameworld.Clocks.Get(clockId);
+            if (clock == null)
+            {
+                error = $"The stored clock id {clockId:N0} did not resolve.";
+                return false;
+            }
+
+            return TryParseStored(match.Groups["date"].Value, match.Groups["time"].Value, calendar, clock, out dt, out error);
+        }
+
+        public static bool TryParseStored(string text, ICalendar calendar, IClock clock, out MudDateTime dt, out string error)
+        {
+            dt = null;
+            error = string.Empty;
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                error = "No stored datetime string was supplied.";
+                return false;
+            }
+
+            if (text.Equals("never", StringComparison.InvariantCultureIgnoreCase))
+            {
+                dt = Never;
+                return true;
+            }
+
+            if (calendar == null || clock == null)
+            {
+                error = "The calendar or clock was not supplied.";
+                return false;
+            }
+
+            string[] splitText = text.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            if (splitText.Length < 3)
+            {
+                error = "The stored datetime string did not include date, timezone and time components.";
+                return false;
+            }
+
+            return TryParseStored(splitText[0], $"{splitText[1]} {splitText[2]}", calendar, clock, out dt, out error);
+        }
+
+        private static bool TryParseStored(string dateText, string timeText, ICalendar calendar, IClock clock, out MudDateTime dt, out string error)
+        {
+            dt = null;
+            if (calendar == null || clock == null)
+            {
+                error = "The calendar or clock was not supplied.";
+                return false;
+            }
+
+            if (!calendar.TryGetDate(dateText, out MudDate date, out error))
+            {
+                return false;
+            }
+
+            if (!MudTime.TryParseLocalTime(timeText, clock, out MudTime time, out error))
+            {
+                return false;
+            }
+
+            dt = new MudDateTime(date, time, time.Timezone);
+            return true;
+        }
+
+        public static MudDateTime FromStoredStringOrFallback(string text, IFuturemud gameworld,
+            StoredMudDateTimeFallback fallback, string ownerType, long? ownerId, string ownerName, string fieldName)
+        {
+            if (TryParseStored(text, gameworld, out var dt, out var error))
+            {
+                return dt;
+            }
+
+            var match = ParseRegex.Match(text ?? string.Empty);
+            var calendar = match.Success && long.TryParse(match.Groups["calendar"].Value, out var calendarId)
+                ? gameworld?.Calendars.Get(calendarId)
+                : gameworld?.Calendars.FirstOrDefault();
+            var clock = match.Success && long.TryParse(match.Groups["clock"].Value, out var clockId)
+                ? gameworld?.Clocks.Get(clockId)
+                : calendar?.FeedClock ?? gameworld?.Clocks.FirstOrDefault();
+            var fallbackValue = fallback switch
+            {
+                StoredMudDateTimeFallback.Never => Never,
+                StoredMudDateTimeFallback.EpochStart => StoredTimeFallbacks.EpochStartOrNever(calendar, clock),
+                _ => StoredTimeFallbacks.CurrentDateTimeOrNever(calendar, clock)
+            };
+            StoredTimeFallbacks.NotifyFallback(gameworld, "datetime", text, calendar, clock,
+                fallbackValue.GetDateTimeString(), ownerType, ownerId, ownerName, fieldName, error);
+            return fallbackValue;
+        }
+
+        public static MudDateTime FromStoredStringOrFallback(string text, ICalendar calendar, IClock clock,
+            StoredMudDateTimeFallback fallback, string ownerType, long? ownerId, string ownerName, string fieldName)
+        {
+            if (TryParseStored(text, calendar, clock, out var dt, out var error))
+            {
+                return dt;
+            }
+
+            var fallbackValue = fallback switch
+            {
+                StoredMudDateTimeFallback.Never => Never,
+                StoredMudDateTimeFallback.EpochStart => StoredTimeFallbacks.EpochStartOrNever(calendar, clock),
+                _ => StoredTimeFallbacks.CurrentDateTimeOrNever(calendar, clock)
+            };
+            StoredTimeFallbacks.NotifyFallback(clock?.Gameworld ?? calendar?.FeedClock?.Gameworld, "datetime", text,
+                calendar, clock, fallbackValue.GetDateTimeString(), ownerType, ownerId, ownerName, fieldName, error);
+            return fallbackValue;
         }
 
         public MudDateTime GetByTimeZone(IMudTimeZone timezone)

--- a/FutureMUDLibrary/TimeAndDate/StoredTimeFallbacks.cs
+++ b/FutureMUDLibrary/TimeAndDate/StoredTimeFallbacks.cs
@@ -1,0 +1,141 @@
+using MudSharp.Framework;
+using MudSharp.TimeAndDate.Date;
+using MudSharp.TimeAndDate.Time;
+using System;
+using System.Linq;
+using System.Text;
+
+namespace MudSharp.TimeAndDate;
+
+public enum StoredMudDateTimeFallback
+{
+	CurrentDateTime,
+	Never,
+	EpochStart
+}
+
+public enum StoredMudDateFallback
+{
+	CurrentDate,
+	EpochStart
+}
+
+public enum StoredMudTimeFallback
+{
+	CurrentTime,
+	MidnightPrimaryTimezone
+}
+
+public static class StoredTimeFallbacks
+{
+	public static MudDate GetStoredDateOrFallback(this ICalendar calendar, string text,
+		StoredMudDateFallback fallback, string ownerType, long? ownerId, string ownerName, string fieldName)
+	{
+		try
+		{
+			return calendar.GetDate(text);
+		}
+		catch (Exception ex)
+		{
+			var fallbackDate = fallback switch
+			{
+				StoredMudDateFallback.EpochStart => FirstValidDate(calendar),
+				_ => calendar.CurrentDate is null ? FirstValidDate(calendar) : new MudDate(calendar.CurrentDate)
+			};
+			NotifyFallback(calendar?.FeedClock?.Gameworld ?? fallbackDate?.Calendar?.FeedClock?.Gameworld,
+				"date", text, calendar, calendar?.FeedClock, fallbackDate?.GetDateString() ?? "null",
+				ownerType, ownerId, ownerName, fieldName, ex.Message);
+			return fallbackDate;
+		}
+	}
+
+	public static MudTime GetStoredTimeOrFallback(this IClock clock, string text,
+		StoredMudTimeFallback fallback, string ownerType, long? ownerId, string ownerName, string fieldName,
+		ICalendar calendar = null)
+	{
+		if (MudTime.TryParseLocalTime(text, clock, out var time, out var error))
+		{
+			return time;
+		}
+
+		var fallbackTime = fallback switch
+		{
+			StoredMudTimeFallback.MidnightPrimaryTimezone => MudTime.FromLocalTime(0, 0, 0, clock.PrimaryTimezone, clock),
+			_ => MudTime.CopyOf(clock.CurrentTime, true)
+		};
+		NotifyFallback(clock?.Gameworld, "time", text, calendar, clock, fallbackTime.GetTimeString(),
+			ownerType, ownerId, ownerName, fieldName, error);
+		return fallbackTime;
+	}
+
+	public static MudDate FirstValidDate(ICalendar calendar)
+	{
+		var yearNumber = calendar?.EpochYear ?? 1;
+		var year = calendar.CreateYear(yearNumber);
+		var month = year.Months.First();
+		return new MudDate(calendar, 1, yearNumber, month, year, false);
+	}
+
+	public static MudDateTime CurrentDateTimeOrNever(ICalendar calendar, IClock clock)
+	{
+		if (calendar?.CurrentDate is null || clock?.CurrentTime is null || clock.PrimaryTimezone is null)
+		{
+			return MudDateTime.Never;
+		}
+
+		var time = clock.CurrentTime.Timezone == clock.PrimaryTimezone
+			? MudTime.CopyOf(clock.CurrentTime, true)
+			: clock.CurrentTime.GetTimeByTimezone(clock.PrimaryTimezone);
+		return new MudDateTime(new MudDate(calendar.CurrentDate), time, clock.PrimaryTimezone);
+	}
+
+	public static MudDateTime EpochStartOrNever(ICalendar calendar, IClock clock)
+	{
+		if (calendar is null || clock?.PrimaryTimezone is null)
+		{
+			return MudDateTime.Never;
+		}
+
+		return new MudDateTime(FirstValidDate(calendar), MudTime.FromLocalTime(0, 0, 0, clock.PrimaryTimezone, clock),
+			clock.PrimaryTimezone);
+	}
+
+	public static void NotifyFallback(IFuturemud gameworld, string valueType, string badValue, ICalendar calendar,
+		IClock clock, string fallbackValue, string ownerType, long? ownerId, string ownerName, string fieldName,
+		string reason)
+	{
+		var ownerText = string.IsNullOrWhiteSpace(ownerName)
+			? $"{ownerType ?? "Unknown"}{(ownerId.HasValue ? $" #{ownerId.Value:N0}" : string.Empty)}"
+			: $"{ownerType ?? "Unknown"}{(ownerId.HasValue ? $" #{ownerId.Value:N0}" : string.Empty)} ({ownerName})";
+		var sb = new StringBuilder();
+		sb.AppendLine("**TimeAndDate stored value fallback used**");
+		sb.AppendLine($"Value Type: {valueType}");
+		sb.AppendLine($"Bad Value: `{badValue ?? "<null>"}`");
+		sb.AppendLine($"Owner: {ownerText}");
+		sb.AppendLine($"Field: {fieldName ?? "Unknown"}");
+		sb.AppendLine($"Calendar: {(calendar is null ? "None" : $"#{calendar.Id:N0} {calendar.Name}")}");
+		sb.AppendLine($"Clock: {(clock is null ? "None" : $"#{clock.Id:N0} {clock.Name}")}");
+		sb.AppendLine($"Fallback: `{fallbackValue ?? "<null>"}`");
+		if (!string.IsNullOrWhiteSpace(reason))
+		{
+			sb.AppendLine($"Reason: {reason}");
+		}
+
+		var message = sb.ToString();
+		try
+		{
+			if (gameworld?.DiscordConnection is null)
+			{
+				ConsoleUtilities.WriteLine(message);
+				return;
+			}
+
+			gameworld.DiscordConnection.NotifyAdmins(message);
+		}
+		catch (Exception ex)
+		{
+			ConsoleUtilities.WriteLine(message);
+			ConsoleUtilities.WriteLine($"TimeAndDate fallback Discord notification failed: {ex}");
+		}
+	}
+}

--- a/FutureMUDLibrary/TimeAndDate/Time/IClock.cs
+++ b/FutureMUDLibrary/TimeAndDate/Time/IClock.cs
@@ -47,6 +47,7 @@ namespace MudSharp.TimeAndDate.Time
         MudTime CurrentTime { get; }
         IEnumerable<IMudTimeZone> Timezones { get; }
         IMudTimeZone PrimaryTimezone { get; }
+        void SetPrimaryTimezone(IMudTimeZone timezone);
         void UpdateSeconds();
         void UpdateMinutes();
         void UpdateHours();

--- a/FutureMUDLibrary/TimeAndDate/Time/IMudTimeZone.cs
+++ b/FutureMUDLibrary/TimeAndDate/Time/IMudTimeZone.cs
@@ -2,7 +2,7 @@
 
 namespace MudSharp.TimeAndDate.Time
 {
-    public interface IMudTimeZone : IHaveMultipleNames
+    public interface IMudTimeZone : IHaveMultipleNames, MudSharp.Framework.Revision.IEditableItem
     {
         int OffsetHours { get; }
         int OffsetMinutes { get; }
@@ -16,6 +16,7 @@ namespace MudSharp.TimeAndDate.Time
         new int OffsetHours { set; }
         new int OffsetMinutes { set; }
         new string Description { set; }
+        new string Alias { set; }
 
     }
 }

--- a/MudSharpCore Unit Tests/MudDateTimeTests.cs
+++ b/MudSharpCore Unit Tests/MudDateTimeTests.cs
@@ -1,7 +1,11 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using MudSharp.Accounts;
+using MudSharp.Character;
+using MudSharp.Discord;
 using MudSharp.Framework;
 using MudSharp.Framework.Save;
+using MudSharp.PerceptionEngine;
 using MudSharp.TimeAndDate;
 using MudSharp.TimeAndDate.Date;
 using MudSharp.TimeAndDate.Intervals;
@@ -75,9 +79,9 @@ public class MudDateTimeTests
         _testClock = new Clock(XElement.Parse(@"<Clock>  <Alias>UTC</Alias>  <Description>Universal Time Clock</Description>  <ShortDisplayString>$j:$m:$s $i</ShortDisplayString>  <SuperDisplayString>$j:$m:$s $i $t</SuperDisplayString>  <LongDisplayString>$c $i</LongDisplayString>  <SecondsPerMinute>60</SecondsPerMinute>  <MinutesPerHour>60</MinutesPerHour>  <HoursPerDay>24</HoursPerDay>  <InGameSecondsPerRealSecond>2</InGameSecondsPerRealSecond>  <SecondFixedDigits>2</SecondFixedDigits>  <MinuteFixedDigits>2</MinuteFixedDigits>  <HourFixedDigits>0</HourFixedDigits>  <NoZeroHour>true</NoZeroHour>  <NumberOfHourIntervals>2</NumberOfHourIntervals>  <HourIntervalNames>    <HourIntervalName>a.m</HourIntervalName>    <HourIntervalName>p.m</HourIntervalName>  </HourIntervalNames>  <HourIntervalLongNames>    <HourIntervalLongName>in the morning</HourIntervalLongName>    <HourIntervalLongName>in the afternoon</HourIntervalLongName>  </HourIntervalLongNames>  <CrudeTimeIntervals>    <CrudeTimeInterval text=""night"" Lower=""-2"" Upper=""4""/>    <CrudeTimeInterval text=""morning"" Lower=""4"" Upper=""12""/>    <CrudeTimeInterval text=""afternoon"" Lower=""12"" Upper=""18""/>    <CrudeTimeInterval text=""evening"" Lower=""18"" Upper=""22""/>  </CrudeTimeIntervals></Clock>"), _gameworld) { Id = 1 };
 
         _testCalendar.FeedClock = _testClock;
-        _utcTimezone = new MudTimeZone(1, 0, 0, "Universal Time Clock", "UTC");
+        _utcTimezone = new MudTimeZone(1, 0, 0, "Universal Time Clock", "UTC", _testClock);
         _testClock.AddTimezone(_utcTimezone);
-        _cstTimezone = new MudTimeZone(2, -6, 0, "Central Time", "CST");
+        _cstTimezone = new MudTimeZone(2, -6, 0, "Central Time", "CST", _testClock);
         _testClock.AddTimezone(_cstTimezone);
         _testClock.SetTime(MudTime.CreatePrimaryTime(0, 0, 0, _utcTimezone, _testClock));
     }
@@ -99,6 +103,98 @@ public class MudDateTimeTests
     // public void MyTestCleanup() { }
     //
     #endregion
+
+    [TestMethod]
+    public void StoredMudDateTimeFallback_UsesCurrentDateTimeAndNotifiesAdmins()
+    {
+        var discord = new Mock<IDiscordConnection>();
+        Mock.Get(_gameworld).SetupGet(x => x.DiscordConnection).Returns(discord.Object);
+
+        var result = MudDateTime.FromStoredStringOrFallback("99/jun/34 UTC 0:0:0", _testCalendar, _testClock,
+            StoredMudDateTimeFallback.CurrentDateTime, "UnitTestOwner", 42, "Broken Date Holder", "BrokenField");
+
+        Assert.AreEqual(_testCalendar.CurrentDate.GetDateString(), result.Date.GetDateString());
+        discord.Verify(x => x.NotifyAdmins(It.Is<string>(text =>
+            text.Contains("99/jun/34 UTC 0:0:0") &&
+            text.Contains("UnitTestOwner #42") &&
+            text.Contains("BrokenField") &&
+            text.Contains("Fallback"))), Times.Once);
+    }
+
+    [TestMethod]
+    public void ClockBuilder_CanSetPrimaryTimezoneCurrentTimeAndCrudeIntervals()
+    {
+        var actor = CreateBuilder();
+        var clock = new Clock(XElement.Parse(_testClock.SaveToXml().ToString()), _gameworld) { Id = 500 };
+        var utc = new MudTimeZone(501, 0, 0, "UTC", "UTC", clock);
+        var cst = new MudTimeZone(502, -6, 0, "Central", "CST", clock);
+        clock.AddTimezone(utc);
+        clock.AddTimezone(cst);
+        clock.SetTime(MudTime.CreatePrimaryTime(0, 0, 0, utc, clock));
+
+        Assert.IsTrue(clock.BuildingCommand(actor.Object, new StringStack("primary CST")));
+        Assert.AreEqual(cst, clock.PrimaryTimezone);
+
+        Assert.IsTrue(clock.BuildingCommand(actor.Object, new StringStack("time CST 6:30:00")));
+        Assert.AreEqual(6, clock.CurrentTime.Hours);
+        Assert.AreEqual(30, clock.CurrentTime.Minutes);
+
+        Assert.IsTrue(clock.BuildingCommand(actor.Object, new StringStack("crude add 6 12 morningish")));
+        Assert.IsTrue(clock.Show(actor.Object).Contains("morningish"));
+    }
+
+    [TestMethod]
+    public void TimezoneBuilder_CanEditAliasNameAndOffset()
+    {
+        var actor = CreateBuilder();
+        var clock = new Clock(XElement.Parse(_testClock.SaveToXml().ToString()), _gameworld) { Id = 510 };
+        var timezone = new MudTimeZone(99, 1, 0, "Offset One", "O1", clock);
+        clock.AddTimezone(timezone);
+
+        Assert.IsTrue(timezone.BuildingCommand(actor.Object, new StringStack("alias O2")));
+        Assert.IsTrue(timezone.BuildingCommand(actor.Object, new StringStack("name Offset Two")));
+        Assert.IsTrue(timezone.BuildingCommand(actor.Object, new StringStack("offset 2 30")));
+
+        Assert.AreEqual("O2", timezone.Alias);
+        Assert.AreEqual("Offset Two", timezone.Description);
+        Assert.AreEqual(2, timezone.OffsetHours);
+        Assert.AreEqual(30, timezone.OffsetMinutes);
+    }
+
+    [TestMethod]
+    public void CalendarBuilder_CanEditWeekdaysMonthsAndPreview()
+    {
+        var actor = CreateBuilder();
+        var calendar = new Calendar(XElement.Parse(_testCalendar.SaveToXml().ToString()), _gameworld) { Id = 520 };
+        calendar.FeedClock = _testClock;
+        calendar.SetDate("27/jun/34");
+
+        Assert.IsTrue(calendar.BuildingCommand(actor.Object, new StringStack("weekday add Bonus Day")));
+        Assert.IsTrue(calendar.Weekdays.Any(x => x.EqualTo("Bonus Day")));
+
+        Assert.IsTrue(calendar.BuildingCommand(actor.Object, new StringStack("month add tst testmonth \"Test Month\" 5 99")));
+        Assert.IsTrue(calendar.Months.Any(x => x.Alias.EqualTo("testmonth")));
+
+        Assert.IsTrue(calendar.BuildingCommand(actor.Object, new StringStack("month nonweekday add testmonth 5")));
+        Assert.IsTrue(calendar.Months.First(x => x.Alias.EqualTo("testmonth")).NonWeekdays.Contains(5));
+
+        Assert.IsFalse(calendar.BuildingCommand(actor.Object, new StringStack("preview 34")));
+    }
+
+    private static Mock<ICharacter> CreateBuilder()
+    {
+        var output = new Mock<IOutputHandler>();
+        output.Setup(x => x.Send(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>())).Returns(true);
+        var account = new Mock<IAccount>();
+        account.SetupGet(x => x.LineFormatLength).Returns(120);
+        account.SetupGet(x => x.UseUnicode).Returns(false);
+        var actor = new Mock<ICharacter>();
+        actor.SetupGet(x => x.Gameworld).Returns(_gameworld);
+        actor.SetupGet(x => x.OutputHandler).Returns(output.Object);
+        actor.SetupGet(x => x.Account).Returns(account.Object);
+        actor.SetupGet(x => x.InnerLineFormatLength).Returns(120);
+        return actor;
+    }
 
     [TestMethod]
     public void TestIntervals()

--- a/MudSharpCore/Body/Disfigurements/Scar.cs
+++ b/MudSharpCore/Body/Disfigurements/Scar.cs
@@ -17,7 +17,8 @@ public class Scar : IScar
 		Gameworld = gameworld;
 		OwnerRace = ownerRace;
 		Bodypart = Gameworld.BodypartPrototypes.Get(long.Parse(root.Element("Bodypart")!.Value));
-		TimeOfScarring = new MudDateTime(root.Element("TimeOfScarring")!.Value, Gameworld);
+		TimeOfScarring = MudDateTime.FromStoredStringOrFallback(root.Element("TimeOfScarring")!.Value, Gameworld,
+			StoredMudDateTimeFallback.CurrentDateTime, "Scar", null, ownerRace?.Name, "TimeOfScarring");
 		BaseShortDescription = root.Element("ShortDescription")?.Value ?? "a scar";
 		BaseFullDescription = root.Element("FullDescription")?.Value ?? "A scar is visible here.";
 		SizeSteps = int.Parse(root.Element("SizeSteps")?.Value ?? "0");

--- a/MudSharpCore/Body/Disfigurements/Tattoo.cs
+++ b/MudSharpCore/Body/Disfigurements/Tattoo.cs
@@ -19,7 +19,8 @@ public class Tattoo : ITattoo
         Bodypart = Gameworld.BodypartPrototypes.Get(long.Parse(root.Element("Bodypart").Value));
         _tattooistId = long.Parse(root.Element("Tattooist").Value);
         TattooistSkill = double.Parse(root.Element("TattooistSkill").Value);
-        TimeOfInscription = new MudDateTime(root.Element("TimeOfInscription").Value, Gameworld);
+        TimeOfInscription = MudDateTime.FromStoredStringOrFallback(root.Element("TimeOfInscription").Value, Gameworld,
+            StoredMudDateTimeFallback.CurrentDateTime, "Tattoo", null, Template?.Name, "TimeOfInscription");
         CompletionPercentage = double.Parse(root.Element("CompletionPercentage").Value);
         HasUnreadableCopyPenalty = bool.Parse(root.Element("HasUnreadableCopyPenalty")?.Value ?? "false");
         foreach (XElement element in root.Element("TextValues")?.Elements("TextValue") ?? Enumerable.Empty<XElement>())

--- a/MudSharpCore/Celestial/NewSun.cs
+++ b/MudSharpCore/Celestial/NewSun.cs
@@ -12,6 +12,7 @@ using MudSharp.FutureProg;
 using MudSharp.GameItems;
 using MudSharp.Health;
 using MudSharp.PerceptionEngine;
+using MudSharp.TimeAndDate;
 using MudSharp.TimeAndDate.Date;
 using MudSharp.TimeAndDate.Time;
 using System;
@@ -98,7 +99,8 @@ public class NewSun : PerceivedItem, ICelestialObject
         KepplerC6Approximant = element.Element("KepplerC6Approximant")?.Value.GetDouble() ?? 0;
         OrbitalEccentricity = element.Element("OrbitalEccentricity")?.Value.GetDouble()
                              ?? (KepplerC1Approximant * 0.5);
-        EpochDate = Calendar.GetDate(element.Element("EpochDate").Value);
+        EpochDate = Calendar.GetStoredDateOrFallback(element.Element("EpochDate").Value,
+            StoredMudDateFallback.EpochStart, "Celestial", Id, Name, "EpochDate");
 
         element = root.Element("Triggers");
         if (element != null)

--- a/MudSharpCore/Celestial/PlanetaryMoon.cs
+++ b/MudSharpCore/Celestial/PlanetaryMoon.cs
@@ -3,6 +3,7 @@ using MudSharp.Effects;
 using MudSharp.Framework;
 using MudSharp.FutureProg;
 using MudSharp.PerceptionEngine;
+using MudSharp.TimeAndDate;
 using MudSharp.TimeAndDate.Date;
 using MudSharp.TimeAndDate.Time;
 using System;
@@ -68,7 +69,8 @@ public class PlanetaryMoon : PerceivedItem, ICelestialObject
         DayNumberAtEpoch = element.Element("DayNumberAtEpoch")?.Value.GetDouble() ?? 0;
         SiderealTimeAtEpoch = element.Element("SiderealTimeAtEpoch")?.Value.GetDouble() ?? 0;
         SiderealTimePerDay = element.Element("SiderealTimePerDay")?.Value.GetDouble() ?? 0;
-        EpochDate = Calendar.GetDate(element.Element("EpochDate").Value);
+        EpochDate = Calendar.GetStoredDateOrFallback(element.Element("EpochDate").Value,
+            StoredMudDateFallback.EpochStart, "Celestial", Id, Name, "EpochDate");
 
         element = root.Element("Triggers");
         if (element != null)

--- a/MudSharpCore/Character/Character.cs
+++ b/MudSharpCore/Character/Character.cs
@@ -1606,7 +1606,9 @@ public partial class Character : PerceiverItem, ICharacter
         _handedness = (Alignment)character.DominantHandAlignment;
 
         Culture = Gameworld.Cultures.Get(character.CultureId);
-        Birthday = Gameworld.Calendars.Get(character.BirthdayCalendarId).GetDate(character.BirthdayDate);
+        var birthdayCalendar = Gameworld.Calendars.Get(character.BirthdayCalendarId);
+        Birthday = birthdayCalendar.GetStoredDateOrFallback(character.BirthdayDate, StoredMudDateFallback.CurrentDate,
+            "Character", character.Id, character.Name, "BirthdayDate");
 
         //TODO: If the Account no longer belongs to an Admin level Authority Group yet this character still has
         //      the IsAdminAvatar bit set to true in the DB, we should clear the bit just to be sure, even

--- a/MudSharpCore/CharacterCreation/Chargen.cs
+++ b/MudSharpCore/CharacterCreation/Chargen.cs
@@ -31,6 +31,7 @@ using MudSharp.PerceptionEngine.Outputs;
 using MudSharp.PerceptionEngine.Parsers;
 using MudSharp.RPG.Knowledge;
 using MudSharp.RPG.Merits;
+using MudSharp.TimeAndDate;
 using MudSharp.TimeAndDate.Date;
 using Newtonsoft.Json.Linq;
 using System;
@@ -1217,7 +1218,8 @@ public partial class Chargen : FrameworkItem, IChargen
             {
                 SelectedBirthday = string.IsNullOrEmpty(root.Element("SelectedBirthday")?.Value)
                     ? null
-                    : SelectedCulture.PrimaryCalendar.GetDate(root.Element("SelectedBirthday").Value);
+                    : SelectedCulture.PrimaryCalendar.GetStoredDateOrFallback(root.Element("SelectedBirthday").Value,
+                        StoredMudDateFallback.CurrentDate, "Chargen", Id, Account?.Name, "SelectedBirthday");
             }
             catch (MUDDateException)
             {
@@ -1226,7 +1228,8 @@ public partial class Chargen : FrameworkItem, IChargen
                 {
                     try
                     {
-                        SelectedBirthday = calendar.GetDate(root.Element("SelectedBirthday").Value);
+                        SelectedBirthday = calendar.GetStoredDateOrFallback(root.Element("SelectedBirthday").Value,
+                            StoredMudDateFallback.CurrentDate, "Chargen", Id, Account?.Name, "SelectedBirthday");
                         break;
                     }
                     catch (MUDDateException)

--- a/MudSharpCore/Commands/Helpers/EditableItemHelperTime.cs
+++ b/MudSharpCore/Commands/Helpers/EditableItemHelperTime.cs
@@ -2,7 +2,10 @@ using MudSharp.Character;
 using MudSharp.Commands.Modules;
 using MudSharp.Effects.Concrete;
 using MudSharp.Framework;
+using MudSharp.Framework.Revision;
+using MudSharp.TimeAndDate.Date;
 using MudSharp.TimeAndDate.Time;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -10,6 +13,27 @@ namespace MudSharp.Commands.Helpers;
 
 public partial class EditableItemHelper
 {
+    private static IMudTimeZone GetTimezoneByIdOrName(ICharacter actor, string input)
+    {
+        if (long.TryParse(input, out var id))
+        {
+            return actor.Gameworld.Clocks.SelectMany(x => x.Timezones).FirstOrDefault(x => x.Id == id);
+        }
+
+        if (input.Contains(':'))
+        {
+            var split = input.Split(':', 2);
+            var clock = actor.Gameworld.Clocks.GetByIdOrNames(split[0]);
+            return clock?.Timezones.GetByIdOrNames(split[1]);
+        }
+
+        var matches = actor.Gameworld.Clocks
+                           .SelectMany(x => x.Timezones)
+                           .Where(x => x.Alias.EqualTo(input) || x.Description.EqualTo(input) || x.Name.EqualTo(input))
+                           .ToList();
+        return matches.Count == 1 ? matches[0] : null;
+    }
+
     public static EditableItemHelper ClockHelper { get; } = new()
     {
         ItemName = "Clock",
@@ -119,6 +143,276 @@ public partial class EditableItemHelper
                                 },
         DefaultCommandHelp = RoomBuilderModule.ClockHelpText,
         GetEditHeader = item => $"Clock #{item.Id:N0} ({item.Name})"
+    };
+
+    public static EditableItemHelper TimezoneHelper { get; } = new()
+    {
+        ItemName = "Timezone",
+        ItemNamePlural = "Timezones",
+        SetEditableItemAction = (actor, item) =>
+        {
+            actor.RemoveAllEffects<BuilderEditingEffect<IMudTimeZone>>();
+            if (item == null)
+            {
+                return;
+            }
+
+            actor.AddEffect(new BuilderEditingEffect<IMudTimeZone>(actor) { EditingItem = (IMudTimeZone)item });
+        },
+        GetEditableItemFunc = actor =>
+            actor.CombinedEffectsOfType<BuilderEditingEffect<IMudTimeZone>>().FirstOrDefault()?.EditingItem,
+        GetAllEditableItems = actor => actor.Gameworld.Clocks.SelectMany(x => x.Timezones).Cast<IEditableItem>().ToList(),
+        GetEditableItemByIdFunc = (actor, id) => actor.Gameworld.Clocks.SelectMany(x => x.Timezones).FirstOrDefault(x => x.Id == id),
+        GetEditableItemByIdOrNameFunc = (actor, input) => GetTimezoneByIdOrName(actor, input),
+        AddItemToGameWorldAction = item => { },
+        CastToType = typeof(IMudTimeZone),
+        EditableNewAction = (actor, input) =>
+        {
+            if (input.IsFinished)
+            {
+                actor.OutputHandler.Send("Which clock should this timezone belong to?");
+                return;
+            }
+
+            var clock = actor.Gameworld.Clocks.GetByIdOrNames(input.PopSpeech());
+            if (clock is null)
+            {
+                actor.OutputHandler.Send("There is no such clock.");
+                return;
+            }
+
+            var alias = input.PopSpeech();
+            if (string.IsNullOrEmpty(alias))
+            {
+                actor.OutputHandler.Send("You must specify an alias for the timezone.");
+                return;
+            }
+
+            if (clock.Timezones.Any(x => x.Alias.EqualTo(alias)))
+            {
+                actor.OutputHandler.Send($"There is already a timezone with the alias {alias.ColourValue()} for that clock.");
+                return;
+            }
+
+            if (input.IsFinished)
+            {
+                actor.OutputHandler.Send("You must specify a name for the timezone.");
+                return;
+            }
+
+            var name = input.PopSpeech().TitleCase();
+            if (input.IsFinished || !int.TryParse(input.PopSpeech(), out var hours))
+            {
+                actor.OutputHandler.Send("You must specify an hour offset.");
+                return;
+            }
+
+            var minutes = 0;
+            if (!input.IsFinished && !int.TryParse(input.PopSpeech(), out minutes))
+            {
+                actor.OutputHandler.Send("The minute offset must be a valid number.");
+                return;
+            }
+
+            var timezone = new MudTimeZone(clock, hours, minutes, name, alias);
+            clock.AddTimezone(timezone);
+            actor.RemoveAllEffects<BuilderEditingEffect<IMudTimeZone>>();
+            actor.AddEffect(new BuilderEditingEffect<IMudTimeZone>(actor) { EditingItem = timezone });
+            actor.OutputHandler.Send($"You create timezone #{timezone.Id.ToStringN0(actor)} ({timezone.Alias.ColourValue()}) for {clock.Name.ColourName()}, which you are now editing.");
+        },
+        EditableCloneAction = (actor, input) =>
+        {
+            if (input.IsFinished)
+            {
+                actor.OutputHandler.Send("Which timezone do you want to clone?");
+                return;
+            }
+
+            var original = GetTimezoneByIdOrName(actor, input.PopSpeech());
+            if (original is null)
+            {
+                actor.OutputHandler.Send("There is no such timezone to clone. Use clock:timezone if the alias is ambiguous.");
+                return;
+            }
+
+            if (input.IsFinished)
+            {
+                actor.OutputHandler.Send("What alias should the cloned timezone have?");
+                return;
+            }
+
+            var alias = input.PopSpeech();
+            var clock = original.Clock;
+            if (!input.IsFinished && actor.Gameworld.Clocks.GetByIdOrNames(input.PeekSpeech()) is { } targetClock)
+            {
+                clock = targetClock;
+                input.PopSpeech();
+            }
+
+            if (clock.Timezones.Any(x => x.Alias.EqualTo(alias)))
+            {
+                actor.OutputHandler.Send($"There is already a timezone with the alias {alias.ColourValue()} for {clock.Name.ColourName()}.");
+                return;
+            }
+
+            var name = input.IsFinished ? original.Description : input.SafeRemainingArgument.TitleCase();
+            var timezone = new MudTimeZone(clock, original.OffsetHours, original.OffsetMinutes, name, alias);
+            clock.AddTimezone(timezone);
+            actor.RemoveAllEffects<BuilderEditingEffect<IMudTimeZone>>();
+            actor.AddEffect(new BuilderEditingEffect<IMudTimeZone>(actor) { EditingItem = timezone });
+            actor.OutputHandler.Send($"You clone timezone {original.Alias.ColourValue()} to #{timezone.Id.ToStringN0(actor)} ({timezone.Alias.ColourValue()}), which you are now editing.");
+        },
+        GetListTableHeaderFunc = character => new List<string>
+        {
+            "Id",
+            "Clock",
+            "Alias",
+            "Name",
+            "Offset",
+            "Primary?"
+        },
+        GetListTableContentsFunc = (character, items) => from timezone in items.OfType<IMudTimeZone>()
+                                                         select new List<string>
+                                                         {
+                                                             timezone.Id.ToString("N0", character),
+                                                             timezone.Clock.Alias,
+                                                             timezone.Alias,
+                                                             timezone.Description,
+                                                             new TimeSpan(0, timezone.OffsetHours, timezone.OffsetMinutes, 0).Describe(),
+                                                             (timezone.Clock.PrimaryTimezone == timezone).ToColouredString()
+                                                         },
+        DefaultCommandHelp = RoomBuilderModule.TimeZoneHelp,
+        GetEditHeader = item => $"Timezone #{item.Id:N0} ({item.Name})"
+    };
+
+    public static EditableItemHelper CalendarHelper { get; } = new()
+    {
+        ItemName = "Calendar",
+        ItemNamePlural = "Calendars",
+        SetEditableItemAction = (actor, item) =>
+        {
+            actor.RemoveAllEffects<BuilderEditingEffect<ICalendar>>();
+            if (item == null)
+            {
+                return;
+            }
+
+            actor.AddEffect(new BuilderEditingEffect<ICalendar>(actor) { EditingItem = (ICalendar)item });
+        },
+        GetEditableItemFunc = actor =>
+            actor.CombinedEffectsOfType<BuilderEditingEffect<ICalendar>>().FirstOrDefault()?.EditingItem,
+        GetAllEditableItems = actor => actor.Gameworld.Calendars.ToList(),
+        GetEditableItemByIdFunc = (actor, id) => actor.Gameworld.Calendars.Get(id),
+        GetEditableItemByIdOrNameFunc = (actor, input) => actor.Gameworld.Calendars.GetByIdOrNames(input),
+        AddItemToGameWorldAction = item => item.Gameworld.Add((ICalendar)item),
+        CastToType = typeof(ICalendar),
+        EditableNewAction = (actor, input) =>
+        {
+            var alias = input.PopSpeech();
+            if (string.IsNullOrEmpty(alias))
+            {
+                actor.OutputHandler.Send("You must specify an alias for the calendar.");
+                return;
+            }
+
+            if (actor.Gameworld.Calendars.Any(x => x.Alias.EqualTo(alias)))
+            {
+                actor.OutputHandler.Send($"There is already a calendar with the alias {alias.ColourValue()}.");
+                return;
+            }
+
+            if (input.IsFinished)
+            {
+                actor.OutputHandler.Send("You must specify a short name for the calendar.");
+                return;
+            }
+
+            var shortName = input.PopSpeech().TitleCase();
+            if (input.IsFinished)
+            {
+                actor.OutputHandler.Send("You must specify the feed clock for the calendar.");
+                return;
+            }
+
+            var clock = actor.Gameworld.Clocks.GetByIdOrNames(input.PopSpeech());
+            if (clock is null)
+            {
+                actor.OutputHandler.Send("There is no such clock.");
+                return;
+            }
+
+            var fullName = input.IsFinished ? shortName : input.SafeRemainingArgument.TitleCase();
+            var calendar = new Calendar(actor.Gameworld, alias, shortName, fullName, clock);
+            actor.Gameworld.Add(calendar);
+            actor.RemoveAllEffects<BuilderEditingEffect<ICalendar>>();
+            actor.AddEffect(new BuilderEditingEffect<ICalendar>(actor) { EditingItem = calendar });
+            actor.OutputHandler.Send($"You create calendar #{calendar.Id.ToStringN0(actor)} ({calendar.Name.ColourName()}), which you are now editing.");
+        },
+        EditableCloneAction = (actor, input) =>
+        {
+            if (input.IsFinished)
+            {
+                actor.OutputHandler.Send("Which calendar do you want to clone?");
+                return;
+            }
+
+            var original = actor.Gameworld.Calendars.GetByIdOrNames(input.PopSpeech());
+            if (original is not Calendar concrete)
+            {
+                actor.OutputHandler.Send("There is no such calendar to clone.");
+                return;
+            }
+
+            var alias = input.PopSpeech();
+            if (string.IsNullOrEmpty(alias))
+            {
+                actor.OutputHandler.Send("You must specify an alias for the cloned calendar.");
+                return;
+            }
+
+            if (actor.Gameworld.Calendars.Any(x => x.Alias.EqualTo(alias)))
+            {
+                actor.OutputHandler.Send($"There is already a calendar with the alias {alias.ColourValue()}.");
+                return;
+            }
+
+            if (input.IsFinished)
+            {
+                actor.OutputHandler.Send("You must specify a short name for the cloned calendar.");
+                return;
+            }
+
+            var shortName = input.PopSpeech().TitleCase();
+            var fullName = input.IsFinished ? shortName : input.SafeRemainingArgument.TitleCase();
+            var clone = concrete.Clone(alias, shortName, fullName);
+            actor.Gameworld.Add(clone);
+            actor.RemoveAllEffects<BuilderEditingEffect<ICalendar>>();
+            actor.AddEffect(new BuilderEditingEffect<ICalendar>(actor) { EditingItem = clone });
+            actor.OutputHandler.Send($"You clone calendar {original.Name.ColourName()} to #{clone.Id.ToStringN0(actor)} ({clone.Name.ColourName()}), which you are now editing.");
+        },
+        GetListTableHeaderFunc = character => new List<string>
+        {
+            "Id",
+            "Alias",
+            "Name",
+            "Clock",
+            "Current Date",
+            "Months",
+            "Weekdays"
+        },
+        GetListTableContentsFunc = (character, items) => from calendar in items.OfType<ICalendar>()
+                                                         select new List<string>
+                                                         {
+                                                             calendar.Id.ToString("N0", character),
+                                                             calendar.Alias,
+                                                             calendar.Name,
+                                                             calendar.FeedClock?.Alias ?? string.Empty,
+                                                             calendar.CurrentDate?.GetDateString() ?? string.Empty,
+                                                             calendar.Months.Count.ToString("N0", character),
+                                                             calendar.Weekdays.Count.ToString("N0", character)
+                                                         },
+        DefaultCommandHelp = RoomBuilderModule.CalendarHelpText,
+        GetEditHeader = item => $"Calendar #{item.Id:N0} ({item.Name})"
     };
 }
 

--- a/MudSharpCore/Commands/Modules/EconomyModule.cs
+++ b/MudSharpCore/Commands/Modules/EconomyModule.cs
@@ -10600,7 +10600,9 @@ The syntax for this command is as follows:
                         select new List<string>
                         {
                             item.DateTime.GetLocalDateString(actor, true),
-                            new MudDateTime(item.MudDateTime, actor.Gameworld).ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short),
+                            MudDateTime.FromStoredStringOrFallback(item.MudDateTime, actor.Gameworld,
+                                StoredMudDateTimeFallback.CurrentDateTime, "ShopTransactionRecord", item.Id, null,
+                                "MudDateTime").ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short),
                             item.LogType,
                             item.LogEntry
                         },

--- a/MudSharpCore/Commands/Modules/PlayerOnlyModule.cs
+++ b/MudSharpCore/Commands/Modules/PlayerOnlyModule.cs
@@ -85,7 +85,8 @@ The syntax for this command is as follows:
                                                  {
                                                      index--.ToString("N0", actor),
                                                      note.Subject.Proper(),
-                                                     new MudDateTime(note.InGameTimeStamp, actor.Gameworld).Date
+                                                     MudDateTime.FromStoredStringOrFallback(note.InGameTimeStamp, actor.Gameworld,
+                                                             StoredMudDateTimeFallback.CurrentDateTime, "AccountNote", note.Id, note.Subject, "InGameTimeStamp").Date
                                                          .Display(TimeAndDate.Date.CalendarDisplayMode.Short)
                                                  },
                                              new[] { "Id", "Subject", "Date" },
@@ -189,7 +190,7 @@ The syntax for this command is as follows:
                     sb.AppendLine(
                         $"The Journal of {characterName.ColourName()}, Entry #{index.ToString("N0", actor)}.");
                     sb.AppendLine(
-                        $"Dated: {new MudDateTime(note.InGameTimeStamp, actor.Gameworld).Date.Display(TimeAndDate.Date.CalendarDisplayMode.Short).Colour(Telnet.Green)}");
+                        $"Dated: {MudDateTime.FromStoredStringOrFallback(note.InGameTimeStamp, actor.Gameworld, StoredMudDateTimeFallback.CurrentDateTime, "AccountNote", note.Id, note.Subject, "InGameTimeStamp").Date.Display(TimeAndDate.Date.CalendarDisplayMode.Short).Colour(Telnet.Green)}");
                     sb.AppendLine();
                     sb.AppendLine(note.Subject.GetLineWithTitle(actor.InnerLineFormatLength, actor.Account.UseUnicode,
                         Telnet.Yellow, Telnet.BoldWhite));
@@ -290,7 +291,8 @@ The syntax for this command is as follows:
                                                      {
                                                          index--.ToString("N0", actor),
                                                          theNote.Subject.Proper(),
-                                                         new MudDateTime(theNote.InGameTimeStamp, actor.Gameworld).Date
+                                                         MudDateTime.FromStoredStringOrFallback(theNote.InGameTimeStamp, actor.Gameworld,
+                                                                 StoredMudDateTimeFallback.CurrentDateTime, "AccountNote", theNote.Id, theNote.Subject, "InGameTimeStamp").Date
                                                              .Display(TimeAndDate.Date.CalendarDisplayMode.Short)
                                                      },
                                                  new[] { "Id", "Subject", "Date" },

--- a/MudSharpCore/Commands/Modules/RoomBuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/RoomBuilderModule.cs
@@ -1653,7 +1653,7 @@ See the #3CELL#0 command for more information about #3CELL PACKAGES#0.";
 
 
 
-    public const string ClockHelpText = @"This command is used to create and edit in-game clocks.
+public const string ClockHelpText = @"This command is used to create and edit in-game clocks.
 
 The syntax for this command is as follows:
 
@@ -1663,7 +1663,10 @@ The syntax for this command is as follows:
 #3clock clone <old> <alias> ""<name>""#0 - clones a clock
 #3clock close#0 - stops editing a clock
 #3clock show <which>#0 - shows information about a clock
-#3clock show#0 - shows information about the currently edited clock";
+#3clock show#0 - shows information about the currently edited clock
+#3clock set primary <timezone>#0 - sets the primary timezone
+#3clock set time <time>#0 - sets the current clock time
+#3clock set crude add <lower> <upper> <text>#0 - adds a crude time display band";
 
     [PlayerCommand("Clock", "clock")]
     [CommandPermission(PermissionLevel.HighAdmin)]
@@ -1673,13 +1676,42 @@ The syntax for this command is as follows:
         BaseBuilderModule.GenericBuildingCommand(actor, new StringStack(input.RemoveFirstWord()), EditableItemHelper.ClockHelper);
     }
 
+    public const string CalendarHelpText = @"This command is used to create and edit in-game calendars.
+
+The syntax for this command is as follows:
+
+#3calendar list#0 - lists all calendars
+#3calendar new <alias> ""<short name>"" <clock> [""<full name>""]#0 - creates a scaffold calendar
+#3calendar clone <old> <alias> ""<short name>"" [""<full name>""]#0 - clones an existing calendar
+#3calendar edit <which>#0 - begins editing a calendar
+#3calendar close#0 - stops editing a calendar
+#3calendar show [<which>]#0 - shows calendar details
+#3calendar set alias|shortname|fullname|desc|plane|clock|date|epoch ...#0 - edits metadata
+#3calendar set weekday add|rename|remove ...#0 - edits weekdays
+#3calendar set month add|rename|alias|short|days|order|remove|nonweekday|special ...#0 - edits months
+#3calendar set intercalary day|month add|remove ...#0 - edits intercalary rules
+#3calendar set preview [year]#0 - previews generated months for a year
+#3calendar set validate#0 - validates calendar generation";
+
+    [PlayerCommand("Calendar", "calendar")]
+    [CommandPermission(PermissionLevel.HighAdmin)]
+    [HelpInfo("calendar", CalendarHelpText, AutoHelp.HelpArgOrNoArg)]
+    protected static void Calendar(ICharacter actor, string input)
+    {
+        BaseBuilderModule.GenericBuildingCommand(actor, new StringStack(input.RemoveFirstWord()), EditableItemHelper.CalendarHelper);
+    }
+
     public const string TimeZoneHelp = @"This command is used to create and edit in-game timezones for a particular clock. Timezones are relative to a standard default timezone for that clock - a real world example would be UTC.
 
 The syntax for this command is as follows:
 
 	#3timezone list [<clock>]#0 - lists all of the time zones
 	#3timezone create <clock> <alias> ""<name>"" <hoursoffset> [<minutesoffset>]#0 - create a new timezone
-	#3timezone edit <clock> <alias> ""<name>"" <hoursoffset> [<minutesoffset>]#0 - edit an existing timezone";
+	#3timezone edit <clock> <alias> ""<name>"" <hoursoffset> [<minutesoffset>]#0 - legacy edit syntax
+	#3timezone new <clock> <alias> ""<name>"" <hoursoffset> [<minutesoffset>]#0 - creates and opens a timezone
+	#3timezone open <id|alias|clock:alias>#0 - opens a timezone for editing
+	#3timezone set alias|name|offset|hours|minutes ...#0 - edits an opened timezone
+	#3timezone clone <old> <alias> [<clock>] [""<name>""]#0 - clones a timezone";
 
     [PlayerCommand("Timezone", "timezone")]
     [CommandPermission(PermissionLevel.Admin)]
@@ -1688,18 +1720,59 @@ The syntax for this command is as follows:
     {
         StringStack ss = new(input.RemoveFirstWord());
 
+        switch (ss.PeekSpeech().ToLowerInvariant())
+        {
+            case "list":
+            case "create":
+            case "update":
+                break;
+            default:
+                BaseBuilderModule.GenericBuildingCommand(actor, ss, EditableItemHelper.TimezoneHelper);
+                return;
+        }
+
         switch (ss.PopForSwitch())
         {
             case "list":
-                TimeZoneList(actor, ss);
+                if (!ss.IsFinished)
+                {
+                    var clock = actor.Gameworld.Clocks.GetByIdOrNames(ss.SafeRemainingArgument);
+                    if (clock is null)
+                    {
+                        actor.OutputHandler.Send("There is no such clock.");
+                        return;
+                    }
+
+                    actor.OutputHandler.Send(StringUtilities.GetTextTable(
+                        from timezone in clock.Timezones
+                        select new List<string>
+                        {
+                            timezone.Id.ToString("N0", actor),
+                            timezone.Alias,
+                            timezone.Description,
+                            new TimeSpan(0, timezone.OffsetHours, timezone.OffsetMinutes, 0).Describe(),
+                            (clock.PrimaryTimezone == timezone).ToColouredString()
+                        },
+                        new List<string> { "Id", "Alias", "Name", "Offset", "Primary?" },
+                        actor.Account.LineFormatLength,
+                        colour: Telnet.Green));
+                    return;
+                }
+
+                BaseBuilderModule.GenericBuildingCommand(actor, new StringStack("list"), EditableItemHelper.TimezoneHelper);
                 return;
             case "create":
-            case "new":
                 TimeZoneCreate(actor, ss);
                 return;
             case "edit":
             case "update":
-                TimeZoneEdit(actor, ss);
+                if (ss.CountRemainingArguments() >= 4)
+                {
+                    TimeZoneEdit(actor, ss);
+                    return;
+                }
+
+                BaseBuilderModule.GenericBuildingCommand(actor, new StringStack($"edit {ss.SafeRemainingArgument}"), EditableItemHelper.TimezoneHelper);
                 return;
             default:
                 actor.OutputHandler.Send(TimeZoneHelp.SubstituteANSIColour());

--- a/MudSharpCore/Community/Boards/BoardPost.cs
+++ b/MudSharpCore/Community/Boards/BoardPost.cs
@@ -30,7 +30,8 @@ public class BoardPost : LateInitialisingItem, IBoardPost
         AuthorId = post.AuthorId;
         AuthorIsCharacter = post.AuthorIsCharacter;
         InGameDateTime = !string.IsNullOrEmpty(post.InGameDateTime)
-            ? new MudDateTime(post.InGameDateTime, Gameworld)
+            ? MudDateTime.FromStoredStringOrFallback(post.InGameDateTime, Gameworld,
+                StoredMudDateTimeFallback.CurrentDateTime, "BoardPost", post.Id, post.Title, "InGameDateTime")
             : null;
         AuthorFullDescription = post.AuthorFullDescription;
         AuthorShortDescription = post.AuthorShortDescription;

--- a/MudSharpCore/Community/Clan.cs
+++ b/MudSharpCore/Community/Clan.cs
@@ -55,9 +55,12 @@ public partial class Clan : SaveableItem, IClan
             SecondaryModifier = clan.PayIntervalOtherSecondary,
             OrdinalFallbackMode = (OrdinalFallbackMode)clan.PayIntervalFallback
         };
-        MudTime payTime = Calendar.FeedClock.GetTime(clan.PayIntervalReferenceTime);
+        MudTime payTime = Calendar.FeedClock.GetStoredTimeOrFallback(clan.PayIntervalReferenceTime,
+            StoredMudTimeFallback.CurrentTime, "Clan", clan.Id, clan.Name, "PayIntervalReferenceTime", Calendar);
+        var payDate = Calendar.GetStoredDateOrFallback(clan.PayIntervalReferenceDate,
+            StoredMudDateFallback.CurrentDate, "Clan", clan.Id, clan.Name, "PayIntervalReferenceDate");
         _nextPay = new MudDateTime(
-            PayInterval.GetNextDate(Calendar, Calendar.GetDate(clan.PayIntervalReferenceDate)), payTime,
+            PayInterval.GetNextDate(Calendar, payDate), payTime,
             payTime.Timezone);
         foreach (ClanTreasuryCell cell in clan.ClansTreasuryCells)
         {

--- a/MudSharpCore/Community/ClanMembership.cs
+++ b/MudSharpCore/Community/ClanMembership.cs
@@ -6,6 +6,7 @@ using MudSharp.Economy.Currency;
 using MudSharp.Framework;
 using MudSharp.Framework.Save;
 using MudSharp.Models;
+using MudSharp.TimeAndDate;
 using MudSharp.TimeAndDate.Date;
 using System.Collections.Generic;
 using System.Linq;
@@ -36,7 +37,8 @@ public class ClanMembership : SaveableItem, IClanMembership, ILazyLoadDuringIdle
         Paygrade = membership.PaygradeId.HasValue
             ? Clan.Paygrades.FirstOrDefault(x => membership.PaygradeId == x.Id)
             : null;
-        JoinDate = clan.Calendar.GetDate(membership.JoinDate);
+        JoinDate = clan.Calendar.GetStoredDateOrFallback(membership.JoinDate, StoredMudDateFallback.CurrentDate,
+            "ClanMembership", membership.CharacterId, clan.Name, "JoinDate");
         ManagerId = membership.ManagerId;
 
         PersonalName = new PersonalName(XElement.Parse(membership.PersonalName), Gameworld);

--- a/MudSharpCore/Community/Election.cs
+++ b/MudSharpCore/Community/Election.cs
@@ -74,10 +74,14 @@ public class Election : SaveableItem, IElection
         IsByElection = election.IsByElection;
         IsFinalised = election.IsFinalised;
         NumberOfAppointments = election.NumberOfAppointments;
-        NominationStartDate = new MudDateTime(election.NominationStartDate, Gameworld);
-        VotingStartDate = new MudDateTime(election.VotingStartDate, Gameworld);
-        VotingEndDate = new MudDateTime(election.VotingEndDate, Gameworld);
-        ResultsInEffectDate = new MudDateTime(election.ResultsInEffectDate, Gameworld);
+        NominationStartDate = MudDateTime.FromStoredStringOrFallback(election.NominationStartDate, Gameworld,
+            StoredMudDateTimeFallback.CurrentDateTime, "Election", election.Id, null, "NominationStartDate");
+        VotingStartDate = MudDateTime.FromStoredStringOrFallback(election.VotingStartDate, Gameworld,
+            StoredMudDateTimeFallback.CurrentDateTime, "Election", election.Id, null, "VotingStartDate");
+        VotingEndDate = MudDateTime.FromStoredStringOrFallback(election.VotingEndDate, Gameworld,
+            StoredMudDateTimeFallback.CurrentDateTime, "Election", election.Id, null, "VotingEndDate");
+        ResultsInEffectDate = MudDateTime.FromStoredStringOrFallback(election.ResultsInEffectDate, Gameworld,
+            StoredMudDateTimeFallback.CurrentDateTime, "Election", election.Id, null, "ResultsInEffectDate");
         ElectionStage = (ElectionStage)election.ElectionStage;
         _id = election.Id;
         foreach (ElectionNominee? nominee in election.ElectionNominees)

--- a/MudSharpCore/Computers/ComputerProgramExecutor.cs
+++ b/MudSharpCore/Computers/ComputerProgramExecutor.cs
@@ -880,7 +880,8 @@ internal static class ComputerProgramExecutor
 			ProgVariableTypeCode.Boolean => bool.Parse(value.Scalar ?? "false"),
 			ProgVariableTypeCode.Number => decimal.Parse(value.Scalar ?? "0", CultureInfo.InvariantCulture),
 			ProgVariableTypeCode.TimeSpan => TimeSpan.FromTicks(long.Parse(value.Scalar ?? "0", CultureInfo.InvariantCulture)),
-			ProgVariableTypeCode.MudDateTime => new MudDateTime(value.Scalar ?? "Never", gameworld),
+			ProgVariableTypeCode.MudDateTime => MudDateTime.FromStoredStringOrFallback(value.Scalar ?? "Never", gameworld,
+				StoredMudDateTimeFallback.Never, "ComputerProgramVariable", null, null, "MudDateTime"),
 			_ => value.Scalar ?? string.Empty
 		};
 

--- a/MudSharpCore/Economy/Auctions/AuctionHouse.cs
+++ b/MudSharpCore/Economy/Auctions/AuctionHouse.cs
@@ -127,8 +127,10 @@ public class AuctionHouse : SaveableItem, IAuctionHouse, IPostCharacterLoadFinal
                 item.Attribute("buyout").Value.Equals("none", StringComparison.InvariantCultureIgnoreCase)
                     ? null
                     : decimal.Parse(item.Attribute("buyout").Value),
-            ListingDateTime = new MudDateTime(item.Attribute("list").Value, Gameworld),
-            FinishingDateTime = new MudDateTime(item.Attribute("finish").Value, Gameworld)
+            ListingDateTime = MudDateTime.FromStoredStringOrFallback(item.Attribute("list").Value, Gameworld,
+                StoredMudDateTimeFallback.CurrentDateTime, "AuctionItem", Id, Name, "ListingDateTime"),
+            FinishingDateTime = MudDateTime.FromStoredStringOrFallback(item.Attribute("finish").Value, Gameworld,
+                StoredMudDateTimeFallback.Never, "AuctionItem", Id, Name, "FinishingDateTime")
         };
     }
 
@@ -172,7 +174,8 @@ public class AuctionHouse : SaveableItem, IAuctionHouse, IPostCharacterLoadFinal
         {
             BidderId = long.Parse(bid.Attribute("bidder").Value),
             Bid = decimal.Parse(bid.Attribute("bid").Value),
-            BidDateTime = new MudDateTime(bid.Attribute("date").Value, gameworld)
+            BidDateTime = MudDateTime.FromStoredStringOrFallback(bid.Attribute("date").Value, gameworld,
+                StoredMudDateTimeFallback.CurrentDateTime, "AuctionBid", null, null, "BidDateTime")
         };
     }
 
@@ -451,7 +454,8 @@ public class AuctionHouse : SaveableItem, IAuctionHouse, IPostCharacterLoadFinal
                 AssetType = result.Attribute("assettype")?.Value ?? "GameItem",
                 Sold = bool.Parse(result.Attribute("sold").Value),
                 SoldToId = long.Parse(result.Attribute("soldto").Value),
-                ResultDateTime = new MudDateTime(result.Element("Date").Value, Gameworld),
+                ResultDateTime = MudDateTime.FromStoredStringOrFallback(result.Element("Date").Value, Gameworld,
+                    StoredMudDateTimeFallback.CurrentDateTime, "AuctionResult", Id, Name, "ResultDateTime"),
                 SalePrice = decimal.Parse(result.Attribute("price").Value),
                 AssetDescription = result.Element("Description").Value,
                 SellerId = long.Parse(result.Attribute("sellerid")?.Value ?? result.Attribute("character")?.Value ?? "0"),

--- a/MudSharpCore/Economy/Banking/BankAccount.cs
+++ b/MudSharpCore/Economy/Banking/BankAccount.cs
@@ -31,7 +31,8 @@ public class BankAccount : SaveableItem, IBankAccount, ILazyLoadDuringIdleTime
         _id = dbitem.Id;
         _name = dbitem.Name;
         Gameworld.Add(this);
-        AccountCreationDate = new MudDateTime(dbitem.AccountCreationDate, Gameworld);
+        AccountCreationDate = MudDateTime.FromStoredStringOrFallback(dbitem.AccountCreationDate, Gameworld,
+            StoredMudDateTimeFallback.CurrentDateTime, "BankAccount", dbitem.Id, dbitem.Name, "AccountCreationDate");
         AccountNumber = dbitem.AccountNumber;
         AccountStatus = (BankAccountStatus)dbitem.AccountStatus;
         BankAccountType = Gameworld.BankAccountTypes.Get(dbitem.BankAccountTypeId);

--- a/MudSharpCore/Economy/Banking/BankManagerAuditLog.cs
+++ b/MudSharpCore/Economy/Banking/BankManagerAuditLog.cs
@@ -19,7 +19,8 @@ public class BankManagerAuditLog : LateInitialisingItem, IBankManagerAuditLog
         _id = dbitem.Id;
         IdInitialised = true;
         Bank = bank;
-        DateTime = new MudDateTime(dbitem.DateTime, Gameworld);
+        DateTime = MudDateTime.FromStoredStringOrFallback(dbitem.DateTime, Gameworld,
+            StoredMudDateTimeFallback.CurrentDateTime, "BankManagerAuditLog", dbitem.Id, bank.Name, "DateTime");
         Detail = dbitem.Detail;
         _characterId = dbitem.CharacterId;
     }

--- a/MudSharpCore/Economy/Banking/BankTransaction.cs
+++ b/MudSharpCore/Economy/Banking/BankTransaction.cs
@@ -21,7 +21,8 @@ public class BankAccountTransaction : LateInitialisingItem, IBankAccountTransact
         TransactionDescription = transaction.TransactionDescription;
         Amount = transaction.Amount;
         AccountBalanceAfter = transaction.AccountBalanceAfter;
-        TransactionTime = new MudDateTime(transaction.TransactionTime, Gameworld);
+        TransactionTime = MudDateTime.FromStoredStringOrFallback(transaction.TransactionTime, Gameworld,
+            StoredMudDateTimeFallback.CurrentDateTime, "BankAccountTransaction", transaction.Id, account.Name, "TransactionTime");
     }
 
     public BankAccountTransaction(IBankAccount account, BankTransactionType type, decimal amount, decimal amountAfter,

--- a/MudSharpCore/Economy/EconomicZone.cs
+++ b/MudSharpCore/Economy/EconomicZone.cs
@@ -215,7 +215,9 @@ public class EconomicZone : SaveableItem, IEconomicZone
 
         FinancialPeriodReferenceClock = gameworld.Clocks.Get(zone.ReferenceClockId);
         FinancialPeriodReferenceCalendar = gameworld.Calendars.Get(zone.ReferenceCalendarId ?? 0);
-        FinancialPeriodReferenceTime = MudTime.ParseLocalTime(zone.ReferenceTime, FinancialPeriodReferenceClock);
+        FinancialPeriodReferenceTime = FinancialPeriodReferenceClock.GetStoredTimeOrFallback(zone.ReferenceTime,
+            StoredMudTimeFallback.CurrentTime, "EconomicZone", zone.Id, zone.Name, "ReferenceTime",
+            FinancialPeriodReferenceCalendar);
         FinancialPeriodTimezone = FinancialPeriodReferenceTime.Timezone;
 
         CurrentFinancialPeriod = _financialPeriods.Get(zone.CurrentFinancialPeriodId ?? 0) ??

--- a/MudSharpCore/Economy/Employment/ActiveJobBase.cs
+++ b/MudSharpCore/Economy/Employment/ActiveJobBase.cs
@@ -25,15 +25,18 @@ public abstract class ActiveJobBase : SaveableItem, IActiveJob, ILazyLoadDuringI
         _id = dbitem.Id;
         Listing = listing;
         _characterId = dbitem.CharacterId;
-        JobCommenced = new MudDateTime(dbitem.JobCommenced, gameworld);
+        JobCommenced = MudDateTime.FromStoredStringOrFallback(dbitem.JobCommenced, gameworld,
+            StoredMudDateTimeFallback.CurrentDateTime, "ActiveJob", dbitem.Id, listing.Name, "JobCommenced");
         JobDueToEnd = string.IsNullOrEmpty(dbitem.JobDueToEnd)
             ? default
-            : new MudDateTime(dbitem.JobDueToEnd, gameworld);
+            : MudDateTime.FromStoredStringOrFallback(dbitem.JobDueToEnd, gameworld,
+                StoredMudDateTimeFallback.Never, "ActiveJob", dbitem.Id, listing.Name, "JobDueToEnd");
         IsJobComplete = dbitem.IsJobComplete;
         AlreadyHadClanPosition = dbitem.AlreadyHadClanPosition;
         JobEnded = string.IsNullOrEmpty(dbitem.JobEnded)
             ? default
-            : new MudDateTime(dbitem.JobEnded, gameworld);
+            : MudDateTime.FromStoredStringOrFallback(dbitem.JobEnded, gameworld,
+                StoredMudDateTimeFallback.Never, "ActiveJob", dbitem.Id, listing.Name, "JobEnded");
         _activeProjectId = dbitem.ActiveProjectId;
         foreach (XElement item in XElement.Parse(dbitem.BackpayOwed).Elements("Pay"))
         {

--- a/MudSharpCore/Economy/Employment/OngoingJobListing.cs
+++ b/MudSharpCore/Economy/Employment/OngoingJobListing.cs
@@ -38,7 +38,8 @@ public class OngoingJobListing : JobListingBase, IOngoingJobListing
         PayInterval = RecurringInterval.Parse(definition.Element("PayInterval")!.Value);
         PayCurrency = Gameworld.Currencies.Get(long.Parse(definition.Element("PayCurrency")!.Value))!;
         PayExpression = new ExpressionEngine.Expression(definition.Element("PayExpression")!.Value);
-        PayReference = new MudDateTime(definition.Element("PayReference")!.Value, Gameworld);
+        PayReference = MudDateTime.FromStoredStringOrFallback(definition.Element("PayReference")!.Value, Gameworld,
+            StoredMudDateTimeFallback.CurrentDateTime, "OngoingJobListing", dbitem.Id, dbitem.Name, "PayReference");
 
         foreach (ActiveJob? dbjob in dbitem.ActiveJobs)
         {

--- a/MudSharpCore/Economy/Estates/Estate.cs
+++ b/MudSharpCore/Economy/Estates/Estate.cs
@@ -260,10 +260,12 @@ public class Estate : SaveableItem, IEstate, ILazyLoadDuringIdleTime
         EconomicZone = gameworld.EconomicZones.Get(estate.EconomicZoneId);
         _characterId = estate.CharacterId;
         EstateStatus = (EstateStatus)estate.EstateStatus;
-        EstateStartTime = new MudDateTime(estate.EstateStartTime, gameworld);
+        EstateStartTime = MudDateTime.FromStoredStringOrFallback(estate.EstateStartTime, gameworld,
+            StoredMudDateTimeFallback.CurrentDateTime, "Estate", estate.Id, null, "EstateStartTime");
         FinalisationDate = string.IsNullOrWhiteSpace(estate.FinalisationDate)
             ? null
-            : new MudDateTime(estate.FinalisationDate, gameworld);
+            : MudDateTime.FromStoredStringOrFallback(estate.FinalisationDate, gameworld,
+                StoredMudDateTimeFallback.Never, "Estate", estate.Id, null, "FinalisationDate");
         if (estate.InheritorId.HasValue && !string.IsNullOrWhiteSpace(estate.InheritorType))
         {
             _inheritorReference = new FrameworkItemReference(estate.InheritorId.Value, estate.InheritorType, gameworld);

--- a/MudSharpCore/Economy/Estates/EstateClaim.cs
+++ b/MudSharpCore/Economy/Estates/EstateClaim.cs
@@ -46,7 +46,8 @@ public class EstateClaim : SaveableItem, IEstateClaim
         _status = (ClaimStatus)claim.ClaimStatus;
         _statusReason = claim.StatusReason;
         IsSecured = claim.IsSecured;
-        ClaimDate = new MudDateTime(claim.ClaimDate, Gameworld);
+        ClaimDate = MudDateTime.FromStoredStringOrFallback(claim.ClaimDate, Gameworld,
+            StoredMudDateTimeFallback.CurrentDateTime, "EstateClaim", claim.Id, null, "ClaimDate");
     }
 
     public EstateClaim(IEstate estate, IFrameworkItem claimant, decimal amount, string reason, ClaimStatus status,

--- a/MudSharpCore/Economy/Estates/EstatePayout.cs
+++ b/MudSharpCore/Economy/Estates/EstatePayout.cs
@@ -16,10 +16,12 @@ public class EstatePayout : SaveableItem, IEstatePayout
         _recipientReference = new FrameworkItemReference(payout.RecipientId, payout.RecipientType, Gameworld);
         Amount = payout.Amount;
         Reason = payout.Reason;
-        CreatedDate = new MudDateTime(payout.CreatedDate, Gameworld);
+        CreatedDate = MudDateTime.FromStoredStringOrFallback(payout.CreatedDate, Gameworld,
+            StoredMudDateTimeFallback.CurrentDateTime, "EstatePayout", payout.Id, null, "CreatedDate");
         _collectedDate = string.IsNullOrWhiteSpace(payout.CollectedDate)
             ? null
-            : new MudDateTime(payout.CollectedDate, Gameworld);
+            : MudDateTime.FromStoredStringOrFallback(payout.CollectedDate, Gameworld,
+                StoredMudDateTimeFallback.Never, "EstatePayout", payout.Id, null, "CollectedDate");
     }
 
     public EstatePayout(IEstate estate, IFrameworkItem recipient, decimal amount, string reason)

--- a/MudSharpCore/Economy/FinancialPeriod.cs
+++ b/MudSharpCore/Economy/FinancialPeriod.cs
@@ -31,8 +31,10 @@ public class FinancialPeriod : LateInitialisingItem, IFinancialPeriod
         _id = period.Id;
         FinancialPeriodStart = period.PeriodStart;
         FinancialPeriodEnd = period.PeriodEnd;
-        FinancialPeriodStartMUD = new MudDateTime(period.MudPeriodStart, gameworld);
-        FinancialPeriodEndMUD = new MudDateTime(period.MudPeriodEnd, gameworld);
+        FinancialPeriodStartMUD = MudDateTime.FromStoredStringOrFallback(period.MudPeriodStart, gameworld,
+            StoredMudDateTimeFallback.CurrentDateTime, "FinancialPeriod", period.Id, null, "MudPeriodStart");
+        FinancialPeriodEndMUD = MudDateTime.FromStoredStringOrFallback(period.MudPeriodEnd, gameworld,
+            StoredMudDateTimeFallback.CurrentDateTime, "FinancialPeriod", period.Id, null, "MudPeriodEnd");
         EconomicZone = zone;
         IdInitialised = true;
     }

--- a/MudSharpCore/Economy/Markets/MarketInfluence.cs
+++ b/MudSharpCore/Economy/Markets/MarketInfluence.cs
@@ -149,8 +149,12 @@ public class MarketInfluence : SaveableItem, IMarketInfluence
 		MarketInfluenceTemplate = Gameworld.MarketInfluenceTemplates.Get(influence.MarketInfluenceTemplateId ?? 0);
 		Description = influence.Description;
 		_name = influence.Name;
-		AppliesFrom = new MudDateTime(influence.AppliesFrom, Gameworld);
-		_appliesUntil = influence.AppliesUntil is not null ? new MudDateTime(influence.AppliesUntil, Gameworld) : null;
+		AppliesFrom = MudDateTime.FromStoredStringOrFallback(influence.AppliesFrom, Gameworld,
+			StoredMudDateTimeFallback.CurrentDateTime, "MarketInfluence", influence.Id, influence.Name, "AppliesFrom");
+		_appliesUntil = influence.AppliesUntil is not null
+			? MudDateTime.FromStoredStringOrFallback(influence.AppliesUntil, Gameworld,
+				StoredMudDateTimeFallback.Never, "MarketInfluence", influence.Id, influence.Name, "AppliesUntil")
+			: null;
 		CharacterKnowsAboutInfluenceProg =
 			Gameworld.FutureProgs.Get(influence.CharacterKnowsAboutInfluenceProgId) ?? Gameworld.AlwaysFalseProg;
 		foreach (var impact in XElement.Parse(influence.Impacts).Elements("Impact"))

--- a/MudSharpCore/Economy/Property/HotelRoom.cs
+++ b/MudSharpCore/Economy/Property/HotelRoom.cs
@@ -77,8 +77,10 @@ public class HotelRoomRental : IHotelRoomRental
 	{
 		_room = room;
 		GuestId = long.Parse(root.Attribute("guest")?.Value ?? "0");
-		StartTime = new MudDateTime(root.Attribute("start")?.Value ?? "Never", room.Property.Gameworld);
-		EndTime = new MudDateTime(root.Attribute("end")?.Value ?? "Never", room.Property.Gameworld);
+		StartTime = MudDateTime.FromStoredStringOrFallback(root.Attribute("start")?.Value ?? "Never", room.Property.Gameworld,
+			StoredMudDateTimeFallback.CurrentDateTime, "HotelRoomRental", null, room.Name, "StartTime");
+		EndTime = MudDateTime.FromStoredStringOrFallback(root.Attribute("end")?.Value ?? "Never", room.Property.Gameworld,
+			StoredMudDateTimeFallback.Never, "HotelRoomRental", null, room.Name, "EndTime");
 		RentalCharge = decimal.Parse(root.Attribute("charge")?.Value ?? "0.0");
 		SecurityDeposit = decimal.Parse(root.Attribute("deposit")?.Value ?? "0.0");
 		TaxCharged = decimal.Parse(root.Attribute("tax")?.Value ?? "0.0");
@@ -169,7 +171,8 @@ public class HotelLostProperty : IHotelLostProperty
 		_room = room;
 		OwnerId = long.Parse(root.Attribute("owner")?.Value ?? "0");
 		BundleId = long.Parse(root.Attribute("bundle")?.Value ?? "0");
-		StoredUntil = new MudDateTime(root.Attribute("until")?.Value ?? "Never", room.Property.Gameworld);
+		StoredUntil = MudDateTime.FromStoredStringOrFallback(root.Attribute("until")?.Value ?? "Never", room.Property.Gameworld,
+			StoredMudDateTimeFallback.Never, "HotelLostProperty", null, room.Name, "StoredUntil");
 		Status = root.Attribute("status")?.Value.TryParseEnum(out HotelLostPropertyStatus status) == true
 			? status
 			: HotelLostPropertyStatus.Held;

--- a/MudSharpCore/Economy/Property/Property.cs
+++ b/MudSharpCore/Economy/Property/Property.cs
@@ -85,7 +85,8 @@ public partial class Property : SaveableItem, IProperty
         _name = property.Name;
         _detailedDescription = property.DetailedDescription;
         _economicZone = Gameworld.EconomicZones.Get(property.EconomicZoneId);
-        _lastChangeOfOwnership = new MudDateTime(property.LastChangeOfOwnership, Gameworld);
+        _lastChangeOfOwnership = MudDateTime.FromStoredStringOrFallback(property.LastChangeOfOwnership, Gameworld,
+            StoredMudDateTimeFallback.CurrentDateTime, "Property", property.Id, property.Name, "LastChangeOfOwnership");
         _applyCriminalCodeInProperty = property.ApplyCriminalCodeInProperty;
         _lastSaleValue = property.LastSaleValue;
         LoadHotelDefinition(property.HotelDefinition);

--- a/MudSharpCore/Economy/Property/PropertyKey.cs
+++ b/MudSharpCore/Economy/Property/PropertyKey.cs
@@ -22,7 +22,8 @@ public class PropertyKey : SaveableItem, IPropertyKey
         _id = key.Id;
         _name = key.Name;
         _isReturned = key.IsReturned;
-        _addedToPropertyOnDate = new MudDateTime(key.AddedToPropertyOnDate, gameworld);
+        _addedToPropertyOnDate = MudDateTime.FromStoredStringOrFallback(key.AddedToPropertyOnDate, gameworld,
+            StoredMudDateTimeFallback.CurrentDateTime, "PropertyKey", key.Id, key.Name, "AddedToPropertyOnDate");
         _costToReplace = key.CostToReplace;
         _gameItem = Gameworld.TryGetItem(key.GameItemId, true);
     }

--- a/MudSharpCore/Economy/Property/PropertyLease.cs
+++ b/MudSharpCore/Economy/Property/PropertyLease.cs
@@ -33,9 +33,12 @@ public class PropertyLease : SaveableItem, IPropertyLease
         _bondPayment = dbitem.BondPayment;
         _bondClaimed = dbitem.BondClaimed;
         _paymentBalance = dbitem.PaymentBalance;
-        _leaseStart = new MudDateTime(dbitem.LeaseStart, Gameworld);
-        _leaseEnd = new MudDateTime(dbitem.LeaseEnd, Gameworld);
-        _lastLeasePayment = new MudDateTime(dbitem.LastLeasePayment, Gameworld);
+        _leaseStart = MudDateTime.FromStoredStringOrFallback(dbitem.LeaseStart, Gameworld,
+            StoredMudDateTimeFallback.CurrentDateTime, "PropertyLease", dbitem.Id, null, "LeaseStart");
+        _leaseEnd = MudDateTime.FromStoredStringOrFallback(dbitem.LeaseEnd, Gameworld,
+            StoredMudDateTimeFallback.Never, "PropertyLease", dbitem.Id, null, "LeaseEnd");
+        _lastLeasePayment = MudDateTime.FromStoredStringOrFallback(dbitem.LastLeasePayment, Gameworld,
+            StoredMudDateTimeFallback.CurrentDateTime, "PropertyLease", dbitem.Id, null, "LastLeasePayment");
         _autoRenew = dbitem.AutoRenew;
         _interval = RecurringInterval.Parse(dbitem.Interval);
         SetupListeners();

--- a/MudSharpCore/Economy/Property/PropertySaleOrder.cs
+++ b/MudSharpCore/Economy/Property/PropertySaleOrder.cs
@@ -20,7 +20,8 @@ public class PropertySaleOrder : SaveableItem, IPropertySaleOrder
         _id = dbitem.Id;
         _property = property;
         _reservePrice = dbitem.ReservePrice;
-        _startOfListing = new MudDateTime(dbitem.StartOfListing, Gameworld);
+        _startOfListing = MudDateTime.FromStoredStringOrFallback(dbitem.StartOfListing, Gameworld,
+            StoredMudDateTimeFallback.CurrentDateTime, "PropertySaleOrder", dbitem.Id, property.Name, "StartOfListing");
         _durationOfListing = TimeSpan.FromDays(dbitem.DurationOfListingDays);
         _orderStatus = (PropertySaleOrderStatus)dbitem.OrderStatus;
         foreach (XElement element in XElement.Parse(dbitem.PropertyOwnerConsentInfo).Elements("Owner"))

--- a/MudSharpCore/Economy/Shoppers/ShopperBase.cs
+++ b/MudSharpCore/Economy/Shoppers/ShopperBase.cs
@@ -108,7 +108,8 @@ internal abstract class ShopperBase : SaveableItem, IShopper
         _name = dbitem.Name;
         EconomicZone = Gameworld.EconomicZones.Get(dbitem.EconomicZoneId);
         ShoppingInterval = RecurringInterval.Parse(dbitem.Interval);
-        NextShop = new MudDateTime(dbitem.NextDate, Gameworld);
+        NextShop = MudDateTime.FromStoredStringOrFallback(dbitem.NextDate, Gameworld,
+            StoredMudDateTimeFallback.CurrentDateTime, "Shopper", dbitem.Id, dbitem.Name, "NextDate");
         LoadFromDefinition(XElement.Parse(dbitem.Definition));
         SetupListener();
     }

--- a/MudSharpCore/Economy/Shops/ShopDeal.cs
+++ b/MudSharpCore/Economy/Shops/ShopDeal.cs
@@ -48,7 +48,10 @@ public class ShopDeal : LateInitialisingItem, IShopDeal
         MinimumQuantity = deal.MinimumQuantity ?? 0;
         Applicability = (ShopDealApplicability)deal.Applicability;
         _eligibilityProg = gameworld.FutureProgs.Get(deal.EligibilityProgId ?? 0);
-        Expiry = string.IsNullOrWhiteSpace(deal.ExpiryDateTime) ? MudDateTime.Never : new MudDateTime(deal.ExpiryDateTime, gameworld);
+        Expiry = string.IsNullOrWhiteSpace(deal.ExpiryDateTime)
+            ? MudDateTime.Never
+            : MudDateTime.FromStoredStringOrFallback(deal.ExpiryDateTime, gameworld,
+                StoredMudDateTimeFallback.Never, "ShopDeal", deal.Id, Name, "ExpiryDateTime");
         IsCumulative = deal.IsCumulative;
     }
 

--- a/MudSharpCore/Economy/Shops/TransactionRecord.cs
+++ b/MudSharpCore/Economy/Shops/TransactionRecord.cs
@@ -80,7 +80,8 @@ public class TransactionRecord : LateInitialisingItem, ITransactionRecord
         Shop = shop;
         EconomicZone = shop.EconomicZone;
         Currency = gameworld.Currencies.Get(record.CurrencyId);
-        MudDateTime = new MudDateTime(record.MudDateTime, gameworld);
+        MudDateTime = MudDateTime.FromStoredStringOrFallback(record.MudDateTime, gameworld,
+            StoredMudDateTimeFallback.CurrentDateTime, "ShopTransactionRecord", record.Id, null, "MudDateTime");
         RealDateTime = record.RealDateTime;
         ThirdPartyId = record.ThirdPartyId;
         PretaxValue = record.PretaxValue;

--- a/MudSharpCore/Economy/Stables/StableLedgerEntry.cs
+++ b/MudSharpCore/Economy/Stables/StableLedgerEntry.cs
@@ -28,7 +28,8 @@ public class StableLedgerEntry : FrameworkItem, IStableLedgerEntry
 		Stable = stay.Stable;
 		Stay = stay;
 		EntryType = (StableLedgerEntryType)entry.EntryType;
-		MudDateTime = new MudDateTime(entry.MudDateTime, Stable.Gameworld);
+		MudDateTime = MudDateTime.FromStoredStringOrFallback(entry.MudDateTime, Stable.Gameworld,
+			StoredMudDateTimeFallback.CurrentDateTime, "StableStayLedgerEntry", entry.Id, Stable.Name, "MudDateTime");
 		ActorId = entry.ActorId;
 		ActorName = entry.ActorName;
 		Amount = entry.Amount;

--- a/MudSharpCore/Economy/Stables/StableStay.cs
+++ b/MudSharpCore/Economy/Stables/StableStay.cs
@@ -72,11 +72,14 @@ public class StableStay : SaveableItem, IStableStay
 		OriginalOwnerName = string.IsNullOrEmpty(stay.OriginalOwnerName)
 			? null
 			: new PersonalName(XElement.Parse(stay.OriginalOwnerName), Gameworld);
-		LodgedDateTime = new MudDateTime(stay.LodgedDateTime, Gameworld);
-		_lastDailyFeeDateTime = new MudDateTime(stay.LastDailyFeeDateTime, Gameworld);
+		LodgedDateTime = MudDateTime.FromStoredStringOrFallback(stay.LodgedDateTime, Gameworld,
+			StoredMudDateTimeFallback.CurrentDateTime, "StableStay", stay.Id, stable.Name, "LodgedDateTime");
+		_lastDailyFeeDateTime = MudDateTime.FromStoredStringOrFallback(stay.LastDailyFeeDateTime, Gameworld,
+			StoredMudDateTimeFallback.CurrentDateTime, "StableStay", stay.Id, stable.Name, "LastDailyFeeDateTime");
 		_closedDateTime = string.IsNullOrEmpty(stay.ClosedDateTime)
 			? null
-			: new MudDateTime(stay.ClosedDateTime, Gameworld);
+			: MudDateTime.FromStoredStringOrFallback(stay.ClosedDateTime, Gameworld,
+				StoredMudDateTimeFallback.Never, "StableStay", stay.Id, stable.Name, "ClosedDateTime");
 		_status = (StableStayStatus)stay.Status;
 		_ticketItemId = stay.TicketItemId;
 		_ticketToken = stay.TicketToken;

--- a/MudSharpCore/Effects/Concrete/AwaitingExecution.cs
+++ b/MudSharpCore/Effects/Concrete/AwaitingExecution.cs
@@ -34,7 +34,8 @@ public class AwaitingExecution : Effect
     {
         XElement root = effect.Element("Effect");
         LegalAuthority = Gameworld.LegalAuthorities.Get(long.Parse(root.Element("LegalAuthority").Value));
-        ExecutionDate = new MudDateTime(root.Element("ExecutionDate").Value, Gameworld);
+        ExecutionDate = MudDateTime.FromStoredStringOrFallback(root.Element("ExecutionDate").Value, Gameworld,
+            StoredMudDateTimeFallback.CurrentDateTime, "Effect:AwaitingExecution", Owner?.Id, Owner?.Name, "ExecutionDate");
     }
 
     #endregion

--- a/MudSharpCore/Effects/Concrete/AwaitingSentencing.cs
+++ b/MudSharpCore/Effects/Concrete/AwaitingSentencing.cs
@@ -42,7 +42,8 @@ public class AwaitingSentencing : Effect, IEffect
     {
         XElement root = effect.Element("Effect");
         LegalAuthority = Gameworld.LegalAuthorities.Get(long.Parse(root.Element("LegalAuthority").Value));
-        ArrestTime = new MudDateTime(root.Element("ArrestTime").Value, Gameworld);
+        ArrestTime = MudDateTime.FromStoredStringOrFallback(root.Element("ArrestTime").Value, Gameworld,
+            StoredMudDateTimeFallback.CurrentDateTime, "Effect:AwaitingSentencing", Owner?.Id, Owner?.Name, "ArrestTime");
     }
 
     #endregion

--- a/MudSharpCore/Effects/Concrete/GoodBehaviourBond.cs
+++ b/MudSharpCore/Effects/Concrete/GoodBehaviourBond.cs
@@ -41,7 +41,8 @@ public class GoodBehaviourBond : Effect, IEffect
         XElement root = effect.Element("Effect");
         Authority = Gameworld.LegalAuthorities.Get(long.Parse(root.Element("LegalAuthority").Value));
         OriginalLength = MudTimeSpan.Parse(root.Element("OriginalLength").Value);
-        DateUntil = new MudDateTime(root.Element("DateUntil").Value, Gameworld);
+        DateUntil = MudDateTime.FromStoredStringOrFallback(root.Element("DateUntil").Value, Gameworld,
+            StoredMudDateTimeFallback.Never, "Effect:GoodBehaviourBond", Owner?.Id, Owner?.Name, "DateUntil");
         RegisterListener();
     }
 

--- a/MudSharpCore/Effects/Concrete/OnBail.cs
+++ b/MudSharpCore/Effects/Concrete/OnBail.cs
@@ -39,7 +39,8 @@ public class OnBail : Effect, IEffect, IScoreAddendumEffect
     {
         XElement root = effect.Element("Effect");
         LegalAuthority = Gameworld.LegalAuthorities.Get(long.Parse(root.Element("LegalAuthority").Value));
-        ArrestTime = new MudDateTime(root.Element("ArrestTime").Value, Gameworld);
+        ArrestTime = MudDateTime.FromStoredStringOrFallback(root.Element("ArrestTime").Value, Gameworld,
+            StoredMudDateTimeFallback.CurrentDateTime, "Effect:OnBail", Owner?.Id, Owner?.Name, "ArrestTime");
     }
 
     #endregion

--- a/MudSharpCore/Effects/Concrete/ServingCustodialSentence.cs
+++ b/MudSharpCore/Effects/Concrete/ServingCustodialSentence.cs
@@ -45,7 +45,8 @@ public class ServingCustodialSentence : Effect, IEffect
         XElement root = effect.Element("Effect");
         LegalAuthority = Gameworld.LegalAuthorities.Get(long.Parse(root.Element("LegalAuthority").Value));
         TotalTime = TimeSpan.FromSeconds(double.Parse(root.Element("TotalTime").Value));
-        ReleaseDate = new MudDateTime(root.Element("ReleaseDate").Value, Gameworld);
+        ReleaseDate = MudDateTime.FromStoredStringOrFallback(root.Element("ReleaseDate").Value, Gameworld,
+            StoredMudDateTimeFallback.Never, "Effect:ServingCustodialSentence", Owner?.Id, Owner?.Name, "ReleaseDate");
     }
 
     #endregion

--- a/MudSharpCore/FutureProg/ProgSchedule.cs
+++ b/MudSharpCore/FutureProg/ProgSchedule.cs
@@ -102,7 +102,9 @@ public class ProgSchedule : SaveableItem, IProgSchedule
             OrdinalFallbackMode = (OrdinalFallbackMode)schedule.IntervalFallback
         };
         Prog = Gameworld.FutureProgs.Get(schedule.FutureProgId);
-        NextReferenceTime = Interval.GetNextDateTime(new MudDateTime(schedule.ReferenceDate, Gameworld));
+        var reference = MudDateTime.FromStoredStringOrFallback(schedule.ReferenceDate, Gameworld,
+            StoredMudDateTimeFallback.CurrentDateTime, "ProgSchedule", schedule.Id, schedule.Name, "ReferenceDate");
+        NextReferenceTime = Interval.GetNextDateTime(reference);
         _listener = Interval.CreateListenerFromInterval(NextReferenceTime, SchedulePayload, null, $"Prog Schedule #{Id} {Name.ColourName()}");
         Changed = true;
     }

--- a/MudSharpCore/FutureProg/VariableRegister.cs
+++ b/MudSharpCore/FutureProg/VariableRegister.cs
@@ -541,7 +541,8 @@ internal class VariableRegister : SaveableItem, IVariableRegister
                     Value = DateTime.Parse(root.Value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
                     break;
                 case ProgVariableTypeCode.MudDateTime:
-                    Value = new MudDateTime(root.Value, gameworld);
+                    Value = MudDateTime.FromStoredStringOrFallback(root.Value, gameworld,
+                        StoredMudDateTimeFallback.Never, "FutureProgVariable", null, null, "MudDateTime");
                     break;
             }
         }

--- a/MudSharpCore/Movement/Track.cs
+++ b/MudSharpCore/Movement/Track.cs
@@ -256,7 +256,8 @@ public class Track : LateInitialisingItem, ITrack
     private MudDateTime? _mudDateTime;
 
     /// <inheritdoc />
-    public MudDateTime MudDateTime => _mudDateTime ??= new MudDateTime(_mudDateTimeText, Gameworld);
+    public MudDateTime MudDateTime => _mudDateTime ??= MudDateTime.FromStoredStringOrFallback(_mudDateTimeText,
+        Gameworld, StoredMudDateTimeFallback.CurrentDateTime, "Track", Id, Name, "MudDateTime");
 
     /// <inheritdoc />
     public double TrackIntensityVisual { get; set; }

--- a/MudSharpCore/NPC/Templates/SimpleNPCTemplate.cs
+++ b/MudSharpCore/NPC/Templates/SimpleNPCTemplate.cs
@@ -23,6 +23,7 @@ using MudSharp.NPC.AI;
 using MudSharp.PerceptionEngine;
 using MudSharp.RPG.Knowledge;
 using MudSharp.RPG.Merits;
+using MudSharp.TimeAndDate;
 using MudSharp.TimeAndDate.Date;
 using System;
 using System.Collections.Generic;
@@ -595,7 +596,8 @@ public class SimpleNPCTemplate : NPCTemplateBase
             {
                 SelectedBirthday = string.IsNullOrEmpty(root.Element("SelectedBirthday")?.Value)
                     ? null
-                    : SelectedCulture.PrimaryCalendar.GetDate(root.Element("SelectedBirthday").Value);
+                    : SelectedCulture.PrimaryCalendar.GetStoredDateOrFallback(root.Element("SelectedBirthday").Value,
+                        StoredMudDateFallback.CurrentDate, "SimpleNPCTemplate", Id, Name, "SelectedBirthday");
             }
             catch (MUDDateException)
             {
@@ -604,7 +606,8 @@ public class SimpleNPCTemplate : NPCTemplateBase
                 {
                     try
                     {
-                        SelectedBirthday = calendar.GetDate(root.Element("SelectedBirthday").Value);
+                        SelectedBirthday = calendar.GetStoredDateOrFallback(root.Element("SelectedBirthday").Value,
+                            StoredMudDateFallback.CurrentDate, "SimpleNPCTemplate", Id, Name, "SelectedBirthday");
                         break;
                     }
                     catch (MUDDateException)

--- a/MudSharpCore/RPG/Law/Crime.cs
+++ b/MudSharpCore/RPG/Law/Crime.cs
@@ -65,10 +65,12 @@ public class Crime : LateInitialisingItem, ICrime
         AccuserId = dbitem.AccuserId;
         RealTimeOfCrime = dbitem.RealTimeOfCrime;
         CrimeLocation = Gameworld.Cells.Get(dbitem.LocationId ?? 0);
-        TimeOfCrime = new MudDateTime(dbitem.TimeOfCrime, Gameworld);
+        TimeOfCrime = MudDateTime.FromStoredStringOrFallback(dbitem.TimeOfCrime, Gameworld,
+            StoredMudDateTimeFallback.CurrentDateTime, "Crime", dbitem.Id, null, "TimeOfCrime");
         TimeOfReport = string.IsNullOrEmpty(dbitem.TimeOfReport)
             ? null
-            : new MudDateTime(dbitem.TimeOfReport, Gameworld);
+            : MudDateTime.FromStoredStringOrFallback(dbitem.TimeOfReport, Gameworld,
+                StoredMudDateTimeFallback.CurrentDateTime, "Crime", dbitem.Id, null, "TimeOfReport");
         HasBeenConvicted = dbitem.ConvictionRecorded;
         _isKnownCrime = dbitem.IsKnownCrime;
         _criminalIdentityIsKnown = dbitem.IsCriminalIdentityKnown;

--- a/MudSharpCore/RPG/Law/LegalAuthority.cs
+++ b/MudSharpCore/RPG/Law/LegalAuthority.cs
@@ -131,7 +131,9 @@ public partial class LegalAuthority : SaveableItem, ILegalAuthority
         foreach (LegalAuthorityFine fine in dbitem.Fines)
         {
             _finesOwed.Add(fine.CharacterId, fine.FinesOwned);
-            _finePaymentDueDates.Add(fine.CharacterId, new MudDateTime(fine.PaymentRequiredBy, Gameworld));
+            _finePaymentDueDates.Add(fine.CharacterId, MudDateTime.FromStoredStringOrFallback(fine.PaymentRequiredBy,
+                Gameworld, StoredMudDateTimeFallback.CurrentDateTime, "LegalAuthorityFine", fine.CharacterId,
+                Name, "PaymentRequiredBy"));
         }
 
         foreach (Models.CorpseRecoveryReport report in dbitem.CorpseRecoveryReports)

--- a/MudSharpCore/TimeAndDate/Date/Calendar.cs
+++ b/MudSharpCore/TimeAndDate/Date/Calendar.cs
@@ -1,5 +1,7 @@
 ﻿using MudSharp.Database;
+using MudSharp.Effects.Concrete;
 using MudSharp.Economy.Currency;
+using MudSharp.Character;
 using MudSharp.Framework;
 using MudSharp.Framework.Save;
 using MudSharp.FutureProg;
@@ -9,6 +11,7 @@ using MudSharp.TimeAndDate.Time;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Linq;
@@ -253,7 +256,9 @@ public class Calendar : SaveableItem, ICalendar
         using (new FMDB())
         {
             Models.Calendar dbcal = FMDB.Context.Calendars.Find(Id);
-            dbcal.Date = CurrentDate.GetDateString();
+            dbcal.Definition = SaveToXml().ToString();
+            dbcal.Date = CurrentDate?.GetDateString() ?? StoredTimeFallbacks.FirstValidDate(this).GetDateString();
+            dbcal.FeedClockId = FeedClock?.Id ?? ClockID;
             FMDB.Context.SaveChanges();
         }
 
@@ -509,14 +514,79 @@ public class Calendar : SaveableItem, ICalendar
         Gameworld = game;
     }
 
+    public Calendar(IFuturemud game, string alias, string shortName, string fullName, IClock clock)
+    {
+        Gameworld = game;
+        Alias = alias;
+        ShortName = shortName;
+        FullName = fullName;
+        Description = fullName;
+        Plane = "earth";
+        ShortString = "$dd/$mm/$yy";
+        LongString = "$nz$ww the $dt of $mf, $yy";
+        WordyString = "$NZ$ww on this $DT day of the month of $mf, in the year $yy";
+        AncientEraShortString = "B.E.";
+        AncientEraLongString = "Before Epoch";
+        ModernEraShortString = "A.E.";
+        ModernEraLongString = "After Epoch";
+        EpochYear = 1;
+        FirstWeekdayAtEpoch = 0;
+        Weekdays.AddRange(["Firstday", "Secondday", "Thirdday", "Fourthday", "Fifthday", "Sixthday", "Seventhday"]);
+        Months.Add(new MonthDefinition("mon", "month", "Month", 1, 30, new Dictionary<int, DayName>(), []));
+        ClockID = clock.Id;
+        CurrentDate = StoredTimeFallbacks.FirstValidDate(this);
+        CurrentDate.IsPrimaryDate = true;
+
+        using (new FMDB())
+        {
+            Models.Calendar dbcal = new();
+            FMDB.Context.Calendars.Add(dbcal);
+            dbcal.Definition = SaveToXml().ToString();
+            dbcal.Date = CurrentDate.GetDateString();
+            dbcal.FeedClockId = clock.Id;
+            FMDB.Context.SaveChanges();
+            _id = dbcal.Id;
+        }
+    }
+
+    private Calendar(Calendar rhs, string alias, string shortName, string fullName)
+    {
+        Gameworld = rhs.Gameworld;
+        LoadFromXml(rhs.SaveToXml());
+        Alias = alias;
+        ShortName = shortName;
+        FullName = fullName;
+        Description = rhs.Description;
+        ClockID = rhs.FeedClock.Id;
+        CurrentDate = new MudDate(rhs.CurrentDate);
+        CurrentDate.IsPrimaryDate = true;
+
+        using (new FMDB())
+        {
+            Models.Calendar dbcal = new();
+            FMDB.Context.Calendars.Add(dbcal);
+            dbcal.Definition = SaveToXml().ToString();
+            dbcal.Date = CurrentDate.GetDateString();
+            dbcal.FeedClockId = FeedClock.Id;
+            FMDB.Context.SaveChanges();
+            _id = dbcal.Id;
+        }
+    }
+
+    public ICalendar Clone(string alias, string shortName, string fullName)
+    {
+        return new Calendar(this, alias, shortName, fullName);
+    }
+
     public Calendar(MudSharp.Models.Calendar calendar, IFuturemud game)
     {
         _id = calendar.Id;
         Gameworld = game;
         LoadFromXml(XElement.Parse(calendar.Definition));
-        CurrentDate = GetDate(calendar.Date);
-        CurrentDate.IsPrimaryDate = true;
         ClockID = calendar.FeedClockId;
+        CurrentDate = this.GetStoredDateOrFallback(calendar.Date, StoredMudDateFallback.EpochStart, "Calendar",
+            calendar.Id, ShortName, "CurrentDate");
+        CurrentDate.IsPrimaryDate = true;
     }
 
     #endregion
@@ -524,6 +594,35 @@ public class Calendar : SaveableItem, ICalendar
     #region Methods
 
     private Dictionary<int, Year> _cachedYears = new();
+
+    private void ClearDateCaches()
+    {
+        _cachedYears.Clear();
+        _cachedWeekdaysInYear.Clear();
+        _cachedDaysInYear.Clear();
+        _cachedDaysBetweenYears.Clear();
+        _cachedFirstWeekday.Clear();
+    }
+
+    private void NormaliseCurrentDate()
+    {
+        try
+        {
+            if (CurrentDate is not null)
+            {
+                CurrentDate = GetDate(CurrentDate.GetDateString());
+                CurrentDate.IsPrimaryDate = true;
+                return;
+            }
+        }
+        catch
+        {
+            // Fall through to the first valid generated date.
+        }
+
+        CurrentDate = StoredTimeFallbacks.FirstValidDate(this);
+        CurrentDate.IsPrimaryDate = true;
+    }
 
     /// <summary>
     ///     Generates a new year (An ordered list of Months) accurate for the given calendar year
@@ -1357,6 +1456,955 @@ You can also use #3/#0, #3-#0 or spaces to separate the three parts of your date
 
         EpochYear = 40800;
         FirstWeekdayAtEpoch = 4;
+    }
+
+    #endregion
+
+    #region IEditableItem Implementation
+
+    public const string BuildingHelpText = @"You can use the following options with this command:
+
+	#3alias <alias>#0 - changes the calendar alias
+	#3shortname <name>#0 - changes the short calendar name
+	#3fullname <name>#0 - changes the full calendar name
+	#3desc <description>#0 - changes the description
+	#3plane <plane>#0 - changes the intended plane alias
+	#3clock <clock>#0 - changes the feed clock
+	#3date <date>#0 - sets the current date
+	#3epoch <year> <weekday>#0 - sets the epoch year and first weekday
+	#3short|long|wordy <mask>#0 - changes display masks
+	#3era <ancient|modern> <short|long> <text>#0 - changes era text
+	#3weekday add|rename|remove ...#0 - edits weekdays
+	#3month add|rename|alias|short|days|order|remove|nonweekday|special ...#0 - edits months
+	#3intercalary day|month ...#0 - edits intercalary day and month rules
+	#3preview [year]#0 - previews a generated year
+	#3validate#0 - validates generated calendar data";
+
+    public bool BuildingCommand(ICharacter actor, StringStack command)
+    {
+        switch (command.PopForSwitch())
+        {
+            case "alias":
+                return BuildingCommandAlias(actor, command);
+            case "name":
+            case "shortname":
+                return BuildingCommandShortName(actor, command);
+            case "fullname":
+            case "full":
+                return BuildingCommandFullName(actor, command);
+            case "desc":
+            case "description":
+                return BuildingCommandDescription(actor, command);
+            case "plane":
+                return BuildingCommandPlane(actor, command);
+            case "clock":
+            case "feedclock":
+                return BuildingCommandClock(actor, command);
+            case "date":
+            case "current":
+                return BuildingCommandDate(actor, command);
+            case "epoch":
+                return BuildingCommandEpoch(actor, command);
+            case "short":
+                return BuildingCommandShortMask(actor, command);
+            case "long":
+                return BuildingCommandLongMask(actor, command);
+            case "wordy":
+                return BuildingCommandWordyMask(actor, command);
+            case "era":
+                return BuildingCommandEra(actor, command);
+            case "weekday":
+            case "weekdays":
+                return BuildingCommandWeekday(actor, command);
+            case "month":
+            case "months":
+                return BuildingCommandMonth(actor, command);
+            case "intercalary":
+            case "intercalaries":
+                return BuildingCommandIntercalary(actor, command);
+            case "preview":
+                return BuildingCommandPreview(actor, command);
+            case "validate":
+                return BuildingCommandValidate(actor, command);
+            default:
+                actor.OutputHandler.Send(BuildingHelpText.SubstituteANSIColour());
+                return false;
+        }
+    }
+
+    private bool BuildingCommandAlias(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("What alias should this calendar have?");
+            return false;
+        }
+
+        var alias = command.PopSpeech();
+        if (Gameworld.Calendars.Any(x => x != this && x.Alias.EqualTo(alias)))
+        {
+            actor.OutputHandler.Send($"There is already a calendar with the alias {alias.ColourValue()}.");
+            return false;
+        }
+
+        Alias = alias;
+        Changed = true;
+        actor.OutputHandler.Send($"This calendar now has the alias {alias.ColourValue()}.");
+        return true;
+    }
+
+    private bool BuildingCommandShortName(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("What short name should this calendar have?");
+            return false;
+        }
+
+        ShortName = command.SafeRemainingArgument.TitleCase();
+        Changed = true;
+        actor.OutputHandler.Send($"This calendar's short name is now {ShortName.ColourName()}.");
+        return true;
+    }
+
+    private bool BuildingCommandFullName(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("What full name should this calendar have?");
+            return false;
+        }
+
+        FullName = command.SafeRemainingArgument.TitleCase();
+        Changed = true;
+        actor.OutputHandler.Send($"This calendar's full name is now {FullName.ColourName()}.");
+        return true;
+    }
+
+    private bool BuildingCommandDescription(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("What description should this calendar have?");
+            return false;
+        }
+
+        Description = command.SafeRemainingArgument;
+        Changed = true;
+        actor.OutputHandler.Send("Description set.");
+        return true;
+    }
+
+    private bool BuildingCommandPlane(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("What plane alias should this calendar use?");
+            return false;
+        }
+
+        Plane = command.PopSpeech();
+        Changed = true;
+        actor.OutputHandler.Send($"This calendar now applies to the {Plane.ColourValue()} plane alias.");
+        return true;
+    }
+
+    private bool BuildingCommandClock(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which clock should feed this calendar?");
+            return false;
+        }
+
+        var clock = Gameworld.Clocks.GetByIdOrNames(command.SafeRemainingArgument);
+        if (clock is null)
+        {
+            actor.OutputHandler.Send("There is no such clock.");
+            return false;
+        }
+
+        return ConfirmStructuralChange(actor, $"change feed clock to {clock.Name}", () =>
+        {
+            FeedClock = clock;
+            ClockID = clock.Id;
+            Changed = true;
+            actor.OutputHandler.Send($"This calendar is now fed by the {clock.Name.ColourName()} clock.");
+        });
+    }
+
+    private bool BuildingCommandDate(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("What date should this calendar be set to?");
+            return false;
+        }
+
+        if (!TryGetDate(command.SafeRemainingArgument, actor, out var date, out var error))
+        {
+            actor.OutputHandler.Send(error);
+            return false;
+        }
+
+        CurrentDate = date;
+        CurrentDate.IsPrimaryDate = true;
+        Changed = true;
+        actor.OutputHandler.Send($"This calendar's current date is now {DisplayDate(CurrentDate, CalendarDisplayMode.Long).ColourValue()}.");
+        return true;
+    }
+
+    private bool BuildingCommandEpoch(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished || !int.TryParse(command.PopSpeech(), out var year))
+        {
+            actor.OutputHandler.Send("You must specify an epoch year.");
+            return false;
+        }
+
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which weekday is the first weekday of the epoch year?");
+            return false;
+        }
+
+        if (!TryGetWeekdayIndex(command.SafeRemainingArgument, out var weekday))
+        {
+            actor.OutputHandler.Send("That is not a valid weekday for this calendar.");
+            return false;
+        }
+
+        return ConfirmStructuralChange(actor, $"change epoch to year {year:N0} and weekday {Weekdays[weekday]}", () =>
+        {
+            EpochYear = year;
+            FirstWeekdayAtEpoch = weekday;
+            ClearDateCaches();
+            NormaliseCurrentDate();
+            Changed = true;
+            actor.OutputHandler.Send($"The epoch year is now {year.ToStringN0(actor).ColourValue()} with first weekday {Weekdays[weekday].ColourValue()}.");
+        });
+    }
+
+    private bool BuildingCommandShortMask(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("What short display mask should this calendar use?");
+            return false;
+        }
+
+        ShortString = command.SafeRemainingArgument;
+        Changed = true;
+        actor.OutputHandler.Send("Short display mask set.");
+        return true;
+    }
+
+    private bool BuildingCommandLongMask(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("What long display mask should this calendar use?");
+            return false;
+        }
+
+        LongString = command.SafeRemainingArgument;
+        Changed = true;
+        actor.OutputHandler.Send("Long display mask set.");
+        return true;
+    }
+
+    private bool BuildingCommandWordyMask(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("What wordy display mask should this calendar use?");
+            return false;
+        }
+
+        WordyString = command.SafeRemainingArgument;
+        Changed = true;
+        actor.OutputHandler.Send("Wordy display mask set.");
+        return true;
+    }
+
+    private bool BuildingCommandEra(ICharacter actor, StringStack command)
+    {
+        var era = command.PopForSwitch();
+        var length = command.PopForSwitch();
+        if (string.IsNullOrEmpty(era) || string.IsNullOrEmpty(length) || command.IsFinished)
+        {
+            actor.OutputHandler.Send("You must specify an era, short/long, and the replacement text.");
+            return false;
+        }
+
+        switch ((era, length))
+        {
+            case ("ancient", "short"):
+                AncientEraShortString = command.SafeRemainingArgument;
+                break;
+            case ("ancient", "long"):
+                AncientEraLongString = command.SafeRemainingArgument;
+                break;
+            case ("modern", "short"):
+                ModernEraShortString = command.SafeRemainingArgument;
+                break;
+            case ("modern", "long"):
+                ModernEraLongString = command.SafeRemainingArgument;
+                break;
+            default:
+                actor.OutputHandler.Send("The era must be ancient or modern, and the type must be short or long.");
+                return false;
+        }
+
+        Changed = true;
+        actor.OutputHandler.Send("Era text set.");
+        return true;
+    }
+
+    private bool BuildingCommandWeekday(ICharacter actor, StringStack command)
+    {
+        switch (command.PopForSwitch())
+        {
+            case "add":
+            case "new":
+                if (command.IsFinished)
+                {
+                    actor.OutputHandler.Send("What weekday name do you want to add?");
+                    return false;
+                }
+
+                var newWeekday = command.SafeRemainingArgument.TitleCase();
+                return ConfirmStructuralChange(actor, $"add weekday {newWeekday}", () =>
+                {
+                    Weekdays.Add(newWeekday);
+                    ClearDateCaches();
+                    NormaliseCurrentDate();
+                    Changed = true;
+                    actor.OutputHandler.Send($"You add weekday {Weekdays.Last().ColourValue()}.");
+                });
+            case "rename":
+            case "name":
+                if (command.IsFinished || !TryGetWeekdayIndex(command.PopSpeech(), out var index))
+                {
+                    actor.OutputHandler.Send("Which weekday do you want to rename?");
+                    return false;
+                }
+
+                if (command.IsFinished)
+                {
+                    actor.OutputHandler.Send("What new name should that weekday have?");
+                    return false;
+                }
+
+                var newName = command.SafeRemainingArgument.TitleCase();
+                return ConfirmStructuralChange(actor, $"rename weekday #{index + 1:N0} to {newName}", () =>
+                {
+                    Weekdays[index] = newName;
+                    ClearDateCaches();
+                    Changed = true;
+                    actor.OutputHandler.Send($"Weekday #{(index + 1).ToStringN0(actor)} is now {Weekdays[index].ColourValue()}.");
+                });
+            case "remove":
+            case "delete":
+            case "del":
+                if (Weekdays.Count <= 1)
+                {
+                    actor.OutputHandler.Send("A calendar must have at least one weekday.");
+                    return false;
+                }
+
+                if (command.IsFinished || !TryGetWeekdayIndex(command.SafeRemainingArgument, out index))
+                {
+                    actor.OutputHandler.Send("Which weekday do you want to remove?");
+                    return false;
+                }
+
+                var old = Weekdays[index];
+                return ConfirmStructuralChange(actor, $"remove weekday {old}", () =>
+                {
+                    Weekdays.RemoveAt(index);
+                    FirstWeekdayAtEpoch = FirstWeekdayAtEpoch.Modulus(Weekdays.Count);
+                    ClearDateCaches();
+                    NormaliseCurrentDate();
+                    Changed = true;
+                    actor.OutputHandler.Send($"You remove the weekday {old.ColourValue()}. Existing weekday-based schedules may need review.");
+                });
+            default:
+                actor.OutputHandler.Send("You must specify add, rename or remove.");
+                return false;
+        }
+    }
+
+    private bool BuildingCommandMonth(ICharacter actor, StringStack command)
+    {
+        switch (command.PopForSwitch())
+        {
+            case "add":
+            case "new":
+                return BuildingCommandMonthAdd(actor, command);
+            case "remove":
+            case "delete":
+            case "del":
+                return BuildingCommandMonthRemove(actor, command);
+            case "rename":
+            case "name":
+                return BuildingCommandMonthRename(actor, command);
+            case "alias":
+                return BuildingCommandMonthAlias(actor, command);
+            case "short":
+            case "shortname":
+                return BuildingCommandMonthShort(actor, command);
+            case "days":
+                return BuildingCommandMonthDays(actor, command);
+            case "order":
+                return BuildingCommandMonthOrder(actor, command);
+            case "nonweekday":
+            case "nonweekdays":
+                return BuildingCommandMonthNonWeekday(actor, command);
+            case "special":
+            case "specialday":
+                return BuildingCommandMonthSpecial(actor, command);
+            default:
+                actor.OutputHandler.Send("You must specify add, remove, rename, alias, short, days, order, nonweekday or special.");
+                return false;
+        }
+    }
+
+    private bool BuildingCommandMonthAdd(ICharacter actor, StringStack command)
+    {
+        var shortName = command.PopSpeech();
+        var alias = command.PopSpeech();
+        if (string.IsNullOrEmpty(shortName) || string.IsNullOrEmpty(alias) || command.IsFinished)
+        {
+            actor.OutputHandler.Send("Syntax: month add <short> <alias> \"<full name>\" <days> [order]");
+            return false;
+        }
+
+        var fullName = command.PopSpeech().TitleCase();
+        if (command.IsFinished || !int.TryParse(command.PopSpeech(), out var days) || days < 1)
+        {
+            actor.OutputHandler.Send("You must specify a positive number of days.");
+            return false;
+        }
+
+        var order = Months.Any() ? Months.Max(x => x.NominalOrder) + 1 : 1;
+        if (!command.IsFinished && (!int.TryParse(command.PopSpeech(), out order) || order < 1))
+        {
+            actor.OutputHandler.Send("The order must be a positive number.");
+            return false;
+        }
+
+        if (Months.Any(x => x.Alias.EqualTo(alias) || x.ShortName.EqualTo(shortName)))
+        {
+            actor.OutputHandler.Send("A month already has that alias or short name.");
+            return false;
+        }
+
+        return ConfirmStructuralChange(actor, $"add month {fullName}", () =>
+        {
+            Months.Add(new MonthDefinition(shortName, alias, fullName, order, days, new Dictionary<int, DayName>(), []));
+            Months.Sort((x, y) => x.NominalOrder.CompareTo(y.NominalOrder));
+            ClearDateCaches();
+            NormaliseCurrentDate();
+            Changed = true;
+            actor.OutputHandler.Send($"You add the month {fullName.ColourName()}.");
+        });
+    }
+
+    private bool BuildingCommandMonthRemove(ICharacter actor, StringStack command)
+    {
+        if (Months.Count <= 1)
+        {
+            actor.OutputHandler.Send("A calendar must have at least one month.");
+            return false;
+        }
+
+        if (command.IsFinished || GetMonth(command.SafeRemainingArgument) is not { } month)
+        {
+            actor.OutputHandler.Send("Which month do you want to remove?");
+            return false;
+        }
+
+        return ConfirmStructuralChange(actor, $"remove month {month.FullName}", () =>
+        {
+            Months.Remove(month);
+            ClearDateCaches();
+            NormaliseCurrentDate();
+            Changed = true;
+            actor.OutputHandler.Send($"You remove the month {month.FullName.ColourName()}. Existing stored dates may need review.");
+        });
+    }
+
+    private bool BuildingCommandMonthRename(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished || GetMonth(command.PopSpeech()) is not { } month || command.IsFinished)
+        {
+            actor.OutputHandler.Send("Syntax: month rename <month> <new full name>");
+            return false;
+        }
+
+        var fullName = command.SafeRemainingArgument.TitleCase();
+        return ConfirmStructuralChange(actor, $"rename month {month.FullName} to {fullName}", () =>
+        {
+            month.FullName = fullName;
+            ClearDateCaches();
+            Changed = true;
+            actor.OutputHandler.Send($"That month is now called {month.FullName.ColourName()}.");
+        });
+    }
+
+    private bool BuildingCommandMonthAlias(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished || GetMonth(command.PopSpeech()) is not { } month || command.IsFinished)
+        {
+            actor.OutputHandler.Send("Syntax: month alias <month> <new alias>");
+            return false;
+        }
+
+        var alias = command.PopSpeech();
+        if (Months.Any(x => x != month && x.Alias.EqualTo(alias)))
+        {
+            actor.OutputHandler.Send("Another month already has that alias.");
+            return false;
+        }
+
+        return ConfirmStructuralChange(actor, $"change month {month.FullName} alias to {alias}", () =>
+        {
+            month.Alias = alias;
+            ClearDateCaches();
+            NormaliseCurrentDate();
+            Changed = true;
+            actor.OutputHandler.Send($"That month now has alias {alias.ColourValue()}.");
+        });
+    }
+
+    private bool BuildingCommandMonthShort(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished || GetMonth(command.PopSpeech()) is not { } month || command.IsFinished)
+        {
+            actor.OutputHandler.Send("Syntax: month short <month> <new short name>");
+            return false;
+        }
+
+        var shortName = command.PopSpeech();
+        return ConfirmStructuralChange(actor, $"change month {month.FullName} short name to {shortName}", () =>
+        {
+            month.ShortName = shortName;
+            ClearDateCaches();
+            Changed = true;
+            actor.OutputHandler.Send($"That month now has short name {month.ShortName.ColourValue()}.");
+        });
+    }
+
+    private bool BuildingCommandMonthDays(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished || GetMonth(command.PopSpeech()) is not { } month ||
+            command.IsFinished || !int.TryParse(command.PopSpeech(), out var days) || days < 1)
+        {
+            actor.OutputHandler.Send("Syntax: month days <month> <positive days>");
+            return false;
+        }
+
+        return ConfirmStructuralChange(actor, $"set month {month.FullName} to {days:N0} days", () =>
+        {
+            month.NormalDays = days;
+            month.NonWeekdays.RemoveAll(x => x > days);
+            foreach (var key in month.SpecialDayNames.Keys.Where(x => x > days).ToList())
+            {
+                month.SpecialDayNames.Remove(key);
+            }
+
+            ClearDateCaches();
+            NormaliseCurrentDate();
+            Changed = true;
+            actor.OutputHandler.Send($"That month now has {days.ToStringN0(actor).ColourValue()} normal days.");
+        });
+    }
+
+    private bool BuildingCommandMonthOrder(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished || GetMonth(command.PopSpeech()) is not { } month ||
+            command.IsFinished || !int.TryParse(command.PopSpeech(), out var order))
+        {
+            actor.OutputHandler.Send("Syntax: month order <month> <order>");
+            return false;
+        }
+
+        return ConfirmStructuralChange(actor, $"set month {month.FullName} order to {order:N0}", () =>
+        {
+            month.NominalOrder = order;
+            Months.Sort((x, y) => x.NominalOrder.CompareTo(y.NominalOrder));
+            ClearDateCaches();
+            NormaliseCurrentDate();
+            Changed = true;
+            actor.OutputHandler.Send($"That month now has nominal order {order.ToStringN0(actor).ColourValue()}.");
+        });
+    }
+
+    private bool BuildingCommandMonthNonWeekday(ICharacter actor, StringStack command)
+    {
+        var action = command.PopForSwitch();
+        if (command.IsFinished || GetMonth(command.PopSpeech()) is not { } month ||
+            command.IsFinished || !int.TryParse(command.PopSpeech(), out var day) || day < 1 || day > month.NormalDays)
+        {
+            actor.OutputHandler.Send("Syntax: month nonweekday add|remove <month> <day>");
+            return false;
+        }
+
+        if (!action.EqualTo("add") && !action.EqualTo("remove") && !action.EqualTo("delete"))
+        {
+            actor.OutputHandler.Send("You must specify add or remove.");
+            return false;
+        }
+
+        return ConfirmStructuralChange(actor, $"{action} non-weekday day {day:N0} for {month.FullName}", () =>
+        {
+            if (action.EqualTo("add"))
+            {
+                if (!month.NonWeekdays.Contains(day))
+                {
+                    month.NonWeekdays.Add(day);
+                }
+            }
+            else
+            {
+                month.NonWeekdays.Remove(day);
+            }
+
+            ClearDateCaches();
+            NormaliseCurrentDate();
+            Changed = true;
+            actor.OutputHandler.Send($"Day {day.ToStringN0(actor)} of {month.FullName.ColourName()} is {(month.NonWeekdays.Contains(day) ? "now" : "no longer")} a non-weekday.");
+        });
+    }
+
+    private bool BuildingCommandMonthSpecial(ICharacter actor, StringStack command)
+    {
+        var action = command.PopForSwitch();
+        if (command.IsFinished || GetMonth(command.PopSpeech()) is not { } month ||
+            command.IsFinished || !int.TryParse(command.PopSpeech(), out var day) || day < 1 || day > month.NormalDays)
+        {
+            actor.OutputHandler.Send("Syntax: month special add|remove <month> <day> [<short> <long>]");
+            return false;
+        }
+
+        if (action.EqualTo("remove") || action.EqualTo("delete"))
+        {
+            return ConfirmStructuralChange(actor, $"remove special day {day:N0} from {month.FullName}", () =>
+            {
+                month.SpecialDayNames.Remove(day);
+                ClearDateCaches();
+                Changed = true;
+                actor.OutputHandler.Send($"Day {day.ToStringN0(actor)} of {month.FullName.ColourName()} no longer has a special name.");
+            });
+        }
+
+        if (!action.EqualTo("add") || command.IsFinished)
+        {
+            actor.OutputHandler.Send("Syntax: month special add <month> <day> <short> <long>");
+            return false;
+        }
+
+        var shortName = command.PopSpeech();
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("What long name should this special day have?");
+            return false;
+        }
+
+        var longName = command.SafeRemainingArgument;
+        return ConfirmStructuralChange(actor, $"add special day {day:N0} to {month.FullName}", () =>
+        {
+            month.SpecialDayNames[day] = new DayName(shortName, longName);
+            ClearDateCaches();
+            Changed = true;
+            actor.OutputHandler.Send($"Day {day.ToStringN0(actor)} of {month.FullName.ColourName()} is now {shortName.ColourValue()}.");
+        });
+    }
+
+    private bool BuildingCommandIntercalary(ICharacter actor, StringStack command)
+    {
+        switch (command.PopForSwitch())
+        {
+            case "day":
+            case "days":
+                return BuildingCommandIntercalaryDay(actor, command);
+            case "month":
+            case "months":
+                return BuildingCommandIntercalaryMonth(actor, command);
+            default:
+                actor.OutputHandler.Send("You must specify whether you are editing intercalary days or months.");
+                return false;
+        }
+    }
+
+    private bool BuildingCommandIntercalaryDay(ICharacter actor, StringStack command)
+    {
+        switch (command.PopForSwitch())
+        {
+            case "add":
+            case "new":
+                if (command.IsFinished || GetMonth(command.PopSpeech()) is not { } month ||
+                    command.IsFinished || !int.TryParse(command.PopSpeech(), out var insertDays) || insertDays < 1 ||
+                    command.IsFinished || !int.TryParse(command.PopSpeech(), out var divisor) || divisor < 1)
+                {
+                    actor.OutputHandler.Send("Syntax: intercalary day add <month> <insertdays> <divisor> [offset]");
+                    return false;
+                }
+
+                var offset = 0;
+                if (!command.IsFinished && !int.TryParse(command.PopSpeech(), out offset))
+                {
+                    actor.OutputHandler.Send("The offset must be a valid number.");
+                    return false;
+                }
+
+                return ConfirmStructuralChange(actor, $"add intercalary day rule to {month.FullName}", () =>
+                {
+                    month.Intercalaries.Add(new IntercalaryDay
+                    {
+                        InsertNumnewDays = insertDays,
+                        Rule = new IntercalaryRule(divisor, offset)
+                    });
+                    ClearDateCaches();
+                    NormaliseCurrentDate();
+                    Changed = true;
+                    actor.OutputHandler.Send($"You add an intercalary day rule to {month.FullName.ColourName()}.");
+                });
+            case "remove":
+            case "delete":
+            case "del":
+                if (command.IsFinished || GetMonth(command.PopSpeech()) is not { } removeMonth ||
+                    command.IsFinished || !int.TryParse(command.PopSpeech(), out var index) ||
+                    index < 1 || index > removeMonth.Intercalaries.Count)
+                {
+                    actor.OutputHandler.Send("Syntax: intercalary day remove <month> <number>");
+                    return false;
+                }
+
+                return ConfirmStructuralChange(actor, $"remove intercalary day rule #{index:N0} from {removeMonth.FullName}", () =>
+                {
+                    removeMonth.Intercalaries.RemoveAt(index - 1);
+                    ClearDateCaches();
+                    NormaliseCurrentDate();
+                    Changed = true;
+                    actor.OutputHandler.Send($"You remove intercalary day rule #{index.ToStringN0(actor)} from {removeMonth.FullName.ColourName()}.");
+                });
+            default:
+                actor.OutputHandler.Send("You must specify add or remove.");
+                return false;
+        }
+    }
+
+    private bool BuildingCommandIntercalaryMonth(ICharacter actor, StringStack command)
+    {
+        switch (command.PopForSwitch())
+        {
+            case "add":
+            case "new":
+                var shortName = command.PopSpeech();
+                var alias = command.PopSpeech();
+                if (string.IsNullOrEmpty(shortName) || string.IsNullOrEmpty(alias) || command.IsFinished)
+                {
+                    actor.OutputHandler.Send("Syntax: intercalary month add <short> <alias> \"<full>\" <days> <position> <divisor> [offset]");
+                    return false;
+                }
+
+                var fullName = command.PopSpeech().TitleCase();
+                if (command.IsFinished || !int.TryParse(command.PopSpeech(), out var days) || days < 1 ||
+                    command.IsFinished)
+                {
+                    actor.OutputHandler.Send("Syntax: intercalary month add <short> <alias> \"<full>\" <days> <position> <divisor> [offset]");
+                    return false;
+                }
+
+                var position = command.PopSpeech();
+                if (command.IsFinished || !int.TryParse(command.PopSpeech(), out var divisor) || divisor < 1)
+                {
+                    actor.OutputHandler.Send("You must specify a positive divisor.");
+                    return false;
+                }
+
+                var offset = 0;
+                if (!command.IsFinished && !int.TryParse(command.PopSpeech(), out offset))
+                {
+                    actor.OutputHandler.Send("The offset must be a valid number.");
+                    return false;
+                }
+
+                return ConfirmStructuralChange(actor, $"add intercalary month {fullName}", () =>
+                {
+                    Intercalaries.Add(new IntercalaryMonth(new IntercalaryRule(divisor, offset),
+                        new MonthDefinition(shortName, alias, fullName, Months.Max(x => x.NominalOrder) + 1, days,
+                            new Dictionary<int, DayName>(), []), position));
+                    ClearDateCaches();
+                    NormaliseCurrentDate();
+                    Changed = true;
+                    actor.OutputHandler.Send($"You add intercalary month {fullName.ColourName()}.");
+                });
+            case "remove":
+            case "delete":
+            case "del":
+                if (command.IsFinished)
+                {
+                    actor.OutputHandler.Send("Which intercalary month do you want to remove?");
+                    return false;
+                }
+
+                var target = Intercalaries.FirstOrDefault(x =>
+                    x.Month.Alias.EqualTo(command.SafeRemainingArgument) ||
+                    x.Month.ShortName.EqualTo(command.SafeRemainingArgument) ||
+                    x.Month.FullName.EqualTo(command.SafeRemainingArgument));
+                if (target is null)
+                {
+                    actor.OutputHandler.Send("There is no such intercalary month.");
+                    return false;
+                }
+
+                return ConfirmStructuralChange(actor, $"remove intercalary month {target.Month.FullName}", () =>
+                {
+                    Intercalaries.Remove(target);
+                    ClearDateCaches();
+                    NormaliseCurrentDate();
+                    Changed = true;
+                    actor.OutputHandler.Send($"You remove intercalary month {target.Month.FullName.ColourName()}.");
+                });
+            default:
+                actor.OutputHandler.Send("You must specify add or remove.");
+                return false;
+        }
+    }
+
+    private bool BuildingCommandPreview(ICharacter actor, StringStack command)
+    {
+        var yearNumber = CurrentDate?.Year ?? EpochYear;
+        if (!command.IsFinished && !int.TryParse(command.PopSpeech(), out yearNumber))
+        {
+            actor.OutputHandler.Send("The year must be a valid number.");
+            return false;
+        }
+
+        var year = CreateYear(yearNumber);
+        var sb = new StringBuilder();
+        sb.AppendLine($"Calendar Preview: {FullName} - Year {yearNumber:N0}".GetLineWithTitle(actor, Telnet.Cyan, Telnet.BoldWhite));
+        foreach (var month in year.Months)
+        {
+            sb.AppendLine($"{month.Alias.ColourValue(),-12} {month.FullName.ColourName(),-30} {month.Days.ToStringN0(actor).ColourValue()} days");
+        }
+
+        actor.OutputHandler.Send(sb.ToString());
+        return false;
+    }
+
+    private bool BuildingCommandValidate(ICharacter actor, StringStack command)
+    {
+        try
+        {
+            if (!Weekdays.Any())
+            {
+                actor.OutputHandler.Send("This calendar is invalid because it has no weekdays.");
+                return false;
+            }
+
+            if (!Months.Any())
+            {
+                actor.OutputHandler.Send("This calendar is invalid because it has no months.");
+                return false;
+            }
+
+            _ = CreateYear(CurrentDate?.Year ?? EpochYear);
+            _ = CurrentDate ?? StoredTimeFallbacks.FirstValidDate(this);
+            actor.OutputHandler.Send("This calendar generated successfully.");
+            return false;
+        }
+        catch (Exception ex)
+        {
+            actor.OutputHandler.Send($"This calendar is not valid: {ex.Message.ColourError()}");
+            return false;
+        }
+    }
+
+    private bool RequiresStructuralConfirmation => Gameworld?.Calendars?.Contains(this) == true;
+
+    private bool ConfirmStructuralChange(ICharacter actor, string description, Action action)
+    {
+        if (!RequiresStructuralConfirmation)
+        {
+            action();
+            return true;
+        }
+
+        actor.OutputHandler.Send(
+            $"{"Warning: this calendar is loaded in the gameworld. This change can invalidate stored dates, schedules, celestials, economy references, clan dates, or other saved time data. Fallbacks will protect load paths and notify admins, but you should preview and validate the calendar after accepting.".ColourError()}\n\nChange: {description.ColourCommand()}\n{Accept.StandardAcceptPhrasing}");
+        actor.AddEffect(new Accept(actor, new GenericProposal
+        {
+            DescriptionString = $"Confirm calendar structural change: {description}",
+            AcceptAction = text =>
+            {
+                action();
+                actor.OutputHandler.Send($"You accept the calendar structural change: {description.ColourCommand()}.");
+            },
+            RejectAction = text => actor.OutputHandler.Send("You decide not to make that calendar change."),
+            ExpireAction = () => actor.OutputHandler.Send("The calendar structural change confirmation expires.")
+        }));
+        return false;
+    }
+
+    private bool TryGetWeekdayIndex(string text, out int index)
+    {
+        if (int.TryParse(text, out var value) && value >= 1 && value <= Weekdays.Count)
+        {
+            index = value - 1;
+            return true;
+        }
+
+        index = Weekdays.FindIndex(x => x.EqualTo(text));
+        return index >= 0;
+    }
+
+    private MonthDefinition GetMonth(string text)
+    {
+        return int.TryParse(text, out var value)
+            ? Months.FirstOrDefault(x => x.NominalOrder == value)
+            : Months.FirstOrDefault(x =>
+                x.Alias.EqualTo(text) ||
+                x.ShortName.EqualTo(text) ||
+                x.FullName.EqualTo(text));
+    }
+
+    public string Show(ICharacter actor)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Calendar #{Id.ToStringN0(actor)} - {ShortName}".GetLineWithTitle(actor, Telnet.Cyan, Telnet.BoldWhite));
+        sb.AppendLine($"Alias: {Alias.ColourValue()}");
+        sb.AppendLine($"Full Name: {FullName.ColourName()}");
+        sb.AppendLine($"Description: {Description.ColourValue()}");
+        sb.AppendLine($"Plane: {Plane.ColourValue()}");
+        sb.AppendLine($"Feed Clock: {FeedClock?.Name.ColourName() ?? "None".ColourError()}");
+        sb.AppendLine($"Current Date: {(CurrentDate is null ? "None".ColourError() : DisplayDate(CurrentDate, CalendarDisplayMode.Long).ColourValue())}");
+        sb.AppendLine($"Epoch: {EpochYear.ToStringN0(actor).ColourValue()} / {(Weekdays.Count > FirstWeekdayAtEpoch ? Weekdays[FirstWeekdayAtEpoch].ColourValue() : "Invalid".ColourError())}");
+        sb.AppendLine($"Short Mask: {ShortString.ColourCommand()}");
+        sb.AppendLine($"Long Mask: {LongString.ColourCommand()}");
+        sb.AppendLine($"Wordy Mask: {WordyString.ColourCommand()}");
+        sb.AppendLine($"Ancient Era: {AncientEraShortString.ColourValue()} / {AncientEraLongString.ColourValue()}");
+        sb.AppendLine($"Modern Era: {ModernEraShortString.ColourValue()} / {ModernEraLongString.ColourValue()}");
+        sb.AppendLine($"Weekdays: {Weekdays.Select((x, i) => $"{(i + 1).ToStringN0(actor)}. {x.ColourValue()}").ListToString()}");
+        sb.AppendLine("Months:");
+        foreach (var month in Months.OrderBy(x => x.NominalOrder))
+        {
+            sb.AppendLine($"\t{month.NominalOrder.ToStringN0(actor)}. {month.ShortName.ColourValue()} / {month.Alias.ColourValue()} - {month.FullName.ColourName()} ({month.NormalDays.ToStringN0(actor)} days, {month.Intercalaries.Count.ToStringN0(actor)} intercalary rules)");
+        }
+
+        if (Intercalaries.Any())
+        {
+            sb.AppendLine("Intercalary Months:");
+            foreach (var intercalary in Intercalaries)
+            {
+                sb.AppendLine($"\t{intercalary.Month.Alias.ColourValue()} - {intercalary.Month.FullName.ColourName()} before {intercalary.InsertPosition.ColourValue()} when {intercalary.Rule}");
+            }
+        }
+
+        return sb.ToString();
     }
 
     #endregion

--- a/MudSharpCore/TimeAndDate/Listeners/DateListener.cs
+++ b/MudSharpCore/TimeAndDate/Listeners/DateListener.cs
@@ -28,7 +28,13 @@ public class DateListener : ListenerBase
         _watchForTimeZone = watchForTimeZone;
         if (WatchForDay != -1 && WatchForYear != -1 && WatchForMonth.Length > 0)
         {
-            _watchDate = new MudDateTime(WatchCalendar.GetDate($"{WatchForDay}-{WatchForMonth}-{WatchForYear}"), WatchCalendar.FeedClock.GetTime($"{watchForTimeZone.Alias} 0:0:0"), watchForTimeZone);
+            var dateText = $"{WatchForDay}-{WatchForMonth}-{WatchForYear}";
+            var date = WatchCalendar.GetStoredDateOrFallback(dateText, StoredMudDateFallback.CurrentDate,
+                "DateListener", null, debuggerReference, "WatchDate");
+            var time = WatchCalendar.FeedClock.GetStoredTimeOrFallback($"{watchForTimeZone.Alias} 0:0:0",
+                StoredMudTimeFallback.MidnightPrimaryTimezone, "DateListener", null, debuggerReference, "WatchTime",
+                WatchCalendar);
+            _watchDate = new MudDateTime(date, time, watchForTimeZone);
         }
         Subscribe();
     }

--- a/MudSharpCore/TimeAndDate/Time/Clock.cs
+++ b/MudSharpCore/TimeAndDate/Time/Clock.cs
@@ -1,5 +1,6 @@
 ﻿using MudSharp.Character;
 using MudSharp.Database;
+using MudSharp.Effects.Concrete;
 using MudSharp.Framework;
 using MudSharp.Framework.Save;
 using MudSharp.FutureProg;
@@ -546,6 +547,43 @@ public class Clock : SaveableItem, IClock
         }
     }
 
+    public void SetPrimaryTimezone(IMudTimeZone timezone)
+    {
+        if (timezone is null)
+        {
+            throw new ArgumentNullException(nameof(timezone));
+        }
+
+        if (!Timezones.Contains(timezone))
+        {
+            throw new ArgumentException("That timezone does not belong to this clock.", nameof(timezone));
+        }
+
+        PrimaryTimezone = timezone;
+        if (CurrentTime is not null && CurrentTime.Timezone != timezone)
+        {
+            var converted = CurrentTime.GetTimeByTimezone(timezone);
+            _currentTime = MudTime.CreatePrimaryTime(converted.Seconds, converted.Minutes, converted.Hours, timezone, this);
+        }
+
+        Changed = true;
+    }
+
+    private void NormaliseCurrentTime()
+    {
+        if (CurrentTime is null || PrimaryTimezone is null)
+        {
+            return;
+        }
+
+        _currentTime = MudTime.CreatePrimaryTime(
+            CurrentTime.Seconds.Modulus(SecondsPerMinute),
+            CurrentTime.Minutes.Modulus(MinutesPerHour),
+            CurrentTime.Hours.Modulus(HoursPerDay),
+            PrimaryTimezone,
+            this);
+    }
+
     #endregion
 
     #region Constructors
@@ -567,7 +605,7 @@ public class Clock : SaveableItem, IClock
             return existing;
         }
 
-        var fallback = new MudTimeZone(0, 0, 0, $"{Alias} Standard Time", Alias);
+        var fallback = new MudTimeZone(0, 0, 0, $"{Alias} Standard Time", Alias, this);
         AddTimezone(fallback);
         return fallback;
     }
@@ -935,6 +973,11 @@ public class Clock : SaveableItem, IClock
 	#3intervals <##>#0 - sets the number of hour intervals
 	#3intervalname <##> <name>#0 - sets a short name for an hour interval
 	#3intervallong <##> <name>#0 - sets a long name for an hour interval
+	#3primary <timezone>#0 - sets the primary timezone
+	#3time <time>#0 - sets the current time
+	#3crude add <lower> <upper> <text>#0 - adds a crude time interval
+	#3crude remove <##>#0 - removes a crude time interval
+	#3crude clear#0 - clears all crude time intervals
 	#3nozero <true|false>#0 - sets whether hour zero is displayed";
 
     public bool BuildingCommand(ICharacter actor, StringStack command)
@@ -981,6 +1024,16 @@ public class Clock : SaveableItem, IClock
             case "nozero":
             case "nozerohour":
                 return BuildingCommandNoZeroHour(actor, command);
+            case "primary":
+            case "primarytimezone":
+            case "timezone":
+                return BuildingCommandPrimaryTimezone(actor, command);
+            case "time":
+            case "current":
+            case "currenttime":
+                return BuildingCommandCurrentTime(actor, command);
+            case "crude":
+                return BuildingCommandCrude(actor, command);
             default:
                 actor.OutputHandler.Send(BuildingHelpText.SubstituteANSIColour());
                 return false;
@@ -1037,6 +1090,32 @@ public class Clock : SaveableItem, IClock
         return true;
     }
 
+    private bool RequiresStructuralConfirmation => Gameworld?.Clocks?.Contains(this) == true;
+
+    private bool ConfirmStructuralChange(ICharacter actor, string description, Action action)
+    {
+        if (!RequiresStructuralConfirmation)
+        {
+            action();
+            return true;
+        }
+
+        actor.OutputHandler.Send(
+            $"{"Warning: this clock is loaded in the gameworld. This change can invalidate stored times, schedules, listener watch points, economy references, clan dates, or other saved time data. Fallbacks will protect load paths and notify admins, but you should review dependent systems after accepting.".ColourError()}\n\nChange: {description.ColourCommand()}\n{Accept.StandardAcceptPhrasing}");
+        actor.AddEffect(new Accept(actor, new GenericProposal
+        {
+            DescriptionString = $"Confirm clock structural change: {description}",
+            AcceptAction = text =>
+            {
+                action();
+                actor.OutputHandler.Send($"You accept the clock structural change: {description.ColourCommand()}.");
+            },
+            RejectAction = text => actor.OutputHandler.Send("You decide not to make that clock change."),
+            ExpireAction = () => actor.OutputHandler.Send("The clock structural change confirmation expires.")
+        }));
+        return false;
+    }
+
     private bool BuildingCommandSecondsPerMinute(ICharacter actor, StringStack command)
     {
         if (command.IsFinished || !int.TryParse(command.PopSpeech(), out int value) || value <= 0)
@@ -1045,10 +1124,13 @@ public class Clock : SaveableItem, IClock
             return false;
         }
 
-        SecondsPerMinute = value;
-        Changed = true;
-        actor.OutputHandler.Send($"This clock now has {value.ToString("N0", actor).ColourValue()} seconds per minute.");
-        return true;
+        return ConfirmStructuralChange(actor, $"set seconds per minute to {value:N0}", () =>
+        {
+            SecondsPerMinute = value;
+            NormaliseCurrentTime();
+            Changed = true;
+            actor.OutputHandler.Send($"This clock now has {value.ToString("N0", actor).ColourValue()} seconds per minute.");
+        });
     }
 
     private bool BuildingCommandMinutesPerHour(ICharacter actor, StringStack command)
@@ -1059,10 +1141,13 @@ public class Clock : SaveableItem, IClock
             return false;
         }
 
-        MinutesPerHour = value;
-        Changed = true;
-        actor.OutputHandler.Send($"This clock now has {value.ToString("N0", actor).ColourValue()} minutes per hour.");
-        return true;
+        return ConfirmStructuralChange(actor, $"set minutes per hour to {value:N0}", () =>
+        {
+            MinutesPerHour = value;
+            NormaliseCurrentTime();
+            Changed = true;
+            actor.OutputHandler.Send($"This clock now has {value.ToString("N0", actor).ColourValue()} minutes per hour.");
+        });
     }
 
     private bool BuildingCommandHoursPerDay(ICharacter actor, StringStack command)
@@ -1079,10 +1164,13 @@ public class Clock : SaveableItem, IClock
             return false;
         }
 
-        HoursPerDay = value;
-        Changed = true;
-        actor.OutputHandler.Send($"This clock now has {value.ToString("N0", actor).ColourValue()} hours per day.");
-        return true;
+        return ConfirmStructuralChange(actor, $"set hours per day to {value:N0}", () =>
+        {
+            HoursPerDay = value;
+            NormaliseCurrentTime();
+            Changed = true;
+            actor.OutputHandler.Send($"This clock now has {value.ToString("N0", actor).ColourValue()} hours per day.");
+        });
     }
 
     private bool BuildingCommandSpeed(ICharacter actor, StringStack command)
@@ -1289,6 +1377,129 @@ public class Clock : SaveableItem, IClock
         NoZeroHour = text.EqualTo("true") || text.EqualTo("yes");
         Changed = true;
         actor.OutputHandler.Send($"This clock will {(NoZeroHour ? "not " : "")}show hour zero.");
+        return true;
+    }
+
+    private bool BuildingCommandPrimaryTimezone(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which timezone should be the primary timezone for this clock?");
+            return false;
+        }
+
+        var timezone = Timezones.GetByIdOrNames(command.SafeRemainingArgument);
+        if (timezone is null)
+        {
+            actor.OutputHandler.Send($"There is no such timezone for this clock. Valid timezones are: {Timezones.Select(x => x.Alias.ColourValue()).ListToString()}.");
+            return false;
+        }
+
+        return ConfirmStructuralChange(actor, $"set primary timezone to {timezone.Alias}", () =>
+        {
+            SetPrimaryTimezone(timezone);
+            actor.OutputHandler.Send($"The primary timezone for this clock is now {timezone.Alias.ColourValue()} ({timezone.Description.ColourName()}).");
+        });
+    }
+
+    private bool BuildingCommandCurrentTime(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("What time should this clock be set to?");
+            return false;
+        }
+
+        if (!MudTime.TryParseLocalTime(command.SafeRemainingArgument, this, out var time, out var error))
+        {
+            actor.OutputHandler.Send(error);
+            return false;
+        }
+
+        var primaryTime = time.Timezone == PrimaryTimezone ? time : time.GetTimeByTimezone(PrimaryTimezone);
+        SetTime(MudTime.CreatePrimaryTime(primaryTime.Seconds, primaryTime.Minutes, primaryTime.Hours, PrimaryTimezone, this));
+        Changed = true;
+        actor.OutputHandler.Send($"This clock is now set to {DisplayTime(CurrentTime, TimeDisplayTypes.Immortal).ColourValue()}.");
+        return true;
+    }
+
+    private bool BuildingCommandCrude(ICharacter actor, StringStack command)
+    {
+        switch (command.PopForSwitch())
+        {
+            case "add":
+            case "new":
+                return BuildingCommandCrudeAdd(actor, command);
+            case "remove":
+            case "delete":
+            case "del":
+                return BuildingCommandCrudeRemove(actor, command);
+            case "clear":
+                while (CrudeTimeIntervals.Ranges.Any())
+                {
+                    CrudeTimeIntervals.RemoveAt(0);
+                }
+                Changed = true;
+                actor.OutputHandler.Send("All crude time intervals have been removed from this clock.");
+                return true;
+            default:
+                actor.OutputHandler.Send("You must specify whether you want to add, remove or clear crude time intervals.");
+                return false;
+        }
+    }
+
+    private bool BuildingCommandCrudeAdd(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished || !double.TryParse(command.PopSpeech(), out var lower))
+        {
+            actor.OutputHandler.Send("You must specify the lower hour bound for this crude time interval.");
+            return false;
+        }
+
+        if (command.IsFinished || !double.TryParse(command.PopSpeech(), out var upper))
+        {
+            actor.OutputHandler.Send("You must specify the upper hour bound for this crude time interval.");
+            return false;
+        }
+
+        if (lower < 0.0 || upper <= lower || upper > HoursPerDay)
+        {
+            actor.OutputHandler.Send($"The crude time bounds must be greater than or equal to 0, increasing, and no more than {HoursPerDay.ToStringN0(actor)}.");
+            return false;
+        }
+
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("What text should this crude time interval display?");
+            return false;
+        }
+
+        CrudeTimeIntervals.Add(new BoundRange<string>(CrudeTimeIntervals, command.SafeRemainingArgument, lower, upper));
+        CrudeTimeIntervals.Sort();
+        Changed = true;
+        actor.OutputHandler.Send($"This clock now has a crude interval from {lower.ToString("N2", actor).ColourValue()} to {upper.ToString("N2", actor).ColourValue()} called {command.SafeRemainingArgument.ColourValue()}.");
+        return true;
+    }
+
+    private bool BuildingCommandCrudeRemove(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished || !int.TryParse(command.PopSpeech(), out var index))
+        {
+            actor.OutputHandler.Send("Which crude time interval do you want to remove?");
+            return false;
+        }
+
+        var count = CrudeTimeIntervals.Ranges.Count();
+        if (index < 1 || index > count)
+        {
+            actor.OutputHandler.Send($"There is no crude time interval numbered {index.ToStringN0(actor)}.");
+            return false;
+        }
+
+        var range = CrudeTimeIntervals.Ranges.ElementAt(index - 1);
+        CrudeTimeIntervals.RemoveAt(index - 1);
+        Changed = true;
+        actor.OutputHandler.Send($"You remove the crude time interval {range.Value.ColourValue()}.");
         return true;
     }
 

--- a/MudSharpCore/TimeAndDate/Time/MudTimeZone.cs
+++ b/MudSharpCore/TimeAndDate/Time/MudTimeZone.cs
@@ -1,8 +1,12 @@
 ﻿using MudSharp.Database;
+using MudSharp.Character;
 using MudSharp.Framework;
 using MudSharp.Framework.Save;
 using MudSharp.Models;
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 
 namespace MudSharp.TimeAndDate.Time;
 
@@ -53,6 +57,13 @@ public class MudTimeZone : SaveableItem, IMudTimeZone
         _name = Alias;
     }
 
+    public MudTimeZone(int id, int offsethours, int offsetminutes, string description, string alias, IClock clock)
+        : this(id, offsethours, offsetminutes, description, alias)
+    {
+        Clock = clock;
+        Gameworld = clock?.Gameworld;
+    }
+
     public MudTimeZone(Timezone zone, IClock clock, IFuturemud game)
     {
         Gameworld = game;
@@ -91,6 +102,7 @@ public class MudTimeZone : SaveableItem, IMudTimeZone
         {
             _alias = value;
             _name = value;
+            Changed = true;
         }
     }
 
@@ -109,6 +121,145 @@ public class MudTimeZone : SaveableItem, IMudTimeZone
     public override string ToString()
     {
         return $"Timezone {Alias} {OffsetHours}h {OffsetMinutes}m";
+    }
+
+    public const string BuildingHelpText = @"You can use the following options with this command:
+
+	#3alias <alias>#0 - changes the timezone alias
+	#3name <name>#0 - changes the timezone display name
+	#3desc <name>#0 - changes the timezone display name
+	#3offset <hours> [<minutes>]#0 - sets the timezone offset
+	#3hours <hours>#0 - sets only the hour offset
+	#3minutes <minutes>#0 - sets only the minute offset";
+
+    public bool BuildingCommand(ICharacter actor, StringStack command)
+    {
+        switch (command.PopForSwitch())
+        {
+            case "alias":
+                return BuildingCommandAlias(actor, command);
+            case "name":
+            case "desc":
+            case "description":
+                return BuildingCommandDescription(actor, command);
+            case "offset":
+                return BuildingCommandOffset(actor, command);
+            case "hours":
+            case "hour":
+                return BuildingCommandHours(actor, command);
+            case "minutes":
+            case "minute":
+                return BuildingCommandMinutes(actor, command);
+            default:
+                actor.OutputHandler.Send(BuildingHelpText.SubstituteANSIColour());
+                return false;
+        }
+    }
+
+    private bool BuildingCommandAlias(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("What alias should this timezone have?");
+            return false;
+        }
+
+        var alias = command.PopSpeech();
+        if (Clock.Timezones.Any(x => x != this && x.Alias.EqualTo(alias)))
+        {
+            actor.OutputHandler.Send($"There is already a timezone with the alias {alias.ColourValue()} for this clock.");
+            return false;
+        }
+
+        Alias = alias;
+        actor.OutputHandler.Send($"This timezone now has the alias {alias.ColourValue()}.");
+        return true;
+    }
+
+    private bool BuildingCommandDescription(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("What display name should this timezone have?");
+            return false;
+        }
+
+        Description = command.SafeRemainingArgument.TitleCase();
+        actor.OutputHandler.Send($"This timezone is now called {Description.ColourName()}.");
+        return true;
+    }
+
+    private bool BuildingCommandOffset(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished || !int.TryParse(command.PopSpeech(), out var hours))
+        {
+            actor.OutputHandler.Send("You must specify an hour offset.");
+            return false;
+        }
+
+        var minutes = 0;
+        if (!command.IsFinished && !int.TryParse(command.PopSpeech(), out minutes))
+        {
+            actor.OutputHandler.Send("The minute offset must be a valid number.");
+            return false;
+        }
+
+        if (Math.Abs(minutes) >= Clock.MinutesPerHour)
+        {
+            actor.OutputHandler.Send($"The minute offset must be between {(-Clock.MinutesPerHour + 1).ToStringN0(actor)} and {(Clock.MinutesPerHour - 1).ToStringN0(actor)}.");
+            return false;
+        }
+
+        OffsetHours = hours;
+        OffsetMinutes = minutes;
+        actor.OutputHandler.Send($"This timezone is now offset by {new TimeSpan(0, hours, minutes, 0).Describe().ColourValue()}.");
+        return true;
+    }
+
+    private bool BuildingCommandHours(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished || !int.TryParse(command.PopSpeech(), out var hours))
+        {
+            actor.OutputHandler.Send("You must specify an hour offset.");
+            return false;
+        }
+
+        OffsetHours = hours;
+        actor.OutputHandler.Send($"This timezone now has an hour offset of {hours.ToStringN0(actor).ColourValue()}.");
+        return true;
+    }
+
+    private bool BuildingCommandMinutes(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished || !int.TryParse(command.PopSpeech(), out var minutes))
+        {
+            actor.OutputHandler.Send("You must specify a minute offset.");
+            return false;
+        }
+
+        if (Math.Abs(minutes) >= Clock.MinutesPerHour)
+        {
+            actor.OutputHandler.Send($"The minute offset must be between {(-Clock.MinutesPerHour + 1).ToStringN0(actor)} and {(Clock.MinutesPerHour - 1).ToStringN0(actor)}.");
+            return false;
+        }
+
+        OffsetMinutes = minutes;
+        actor.OutputHandler.Send($"This timezone now has a minute offset of {minutes.ToStringN0(actor).ColourValue()}.");
+        return true;
+    }
+
+    public string Show(ICharacter actor)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Timezone #{Id.ToStringN0(actor)} - {Alias}".GetLineWithTitle(actor, Telnet.Cyan, Telnet.BoldWhite));
+        sb.AppendLine($"Clock: {Clock.Name.ColourName()} (#{Clock.Id.ToStringN0(actor)})");
+        sb.AppendLine($"Alias: {Alias.ColourValue()}");
+        sb.AppendLine($"Name: {Description.ColourName()}");
+        sb.AppendLine($"Offset Hours: {OffsetHours.ToStringN0(actor).ColourValue()}");
+        sb.AppendLine($"Offset Minutes: {OffsetMinutes.ToStringN0(actor).ColourValue()}");
+        sb.AppendLine($"Offset: {new TimeSpan(0, OffsetHours, OffsetMinutes, 0).Describe().ColourValue()}");
+        sb.AppendLine($"Primary For Clock: {(Clock.PrimaryTimezone == this).ToColouredString()}");
+        return sb.ToString();
     }
 
     // TODO - Daylight savings times


### PR DESCRIPTION
## Summary
- Add editable-item builder workflows for calendars, clocks, and timezones, including helper wiring and expanded command surfaces
- Add safe stored-value fallback helpers for `MudDate`, `MudTime`, and `MudDateTime`, with admin notifications on fallback use
- Update live load paths across economy, clans, celestials, effects, FutureProg, and related systems to avoid throwing on invalid stored time data
- Refresh TimeAndDate design docs and add focused runtime/unit coverage for the new behavior

## Testing
- `MudSharpCore Unit Tests`: focused TimeAndDate and FutureProg datetime tests
- `FutureMUDLibrary Unit Tests`: shared TimeAndDate library tests
- `MudSharpCore` build verification passed