### PR TITLE
Update the magic parity report for planes and body-form progress

### DIFF
--- a/Design Documents/Armageddon_Magic_Psionics_Gap_Report.md
+++ b/Design Documents/Armageddon_Magic_Psionics_Gap_Report.md
@@ -24,6 +24,7 @@ and the current runtime implementations under `MudSharpCore/Magic`.
 - A handful of Armageddon entries are under-specified in the dump (`Daylight`, `Empower`, `Drown`, `Cause Disease`, `Acid Spray`, some passive psionics). I counted those conservatively unless the name clearly maps to an existing FutureMUD primitive.
 - Status update as of 2026-04-21: the Phase 1 implementation slice from this report has now shipped. `teleport` accepts `room` / `rooms` triggers, the reusable Phase 1 statuses are implemented as standalone spell-effect templates with matching removals, `MagicResourceDeltaEffect`, `SpellArmourEffect`, and `roomflag` / `removeroomflag` are live, and the underlying runtime hooks for additive perception grants, selective poison or disease cleanup, and early room flags are in place.
 - Status update as of 2026-05-01: the plane/corporeality and multiple-body-form work changes the blocker picture again. `IPlane`, `PlanarPresenceDefinition`, `planarstate`, `planeshift`, `removeplanarstate`, planar FutureProg functions, the `corporeality` admin command, and the `transformform` spell effect are live. Simple ethereal states, noncorporeal manifestation, single-active-body transformation, and straightforward "move this target to another plane" spells are now buildable with first-class primitives. Simultaneous bodies, remote vessels, possessed corpses, descriptor handoff, and persistent portal topology remain blocked.
+- Status update as of 2026-05-01 Engine V1: generic magic tags, FutureProg tag queries, first-class item and corpse magic effects, transient paired magical portals, safe command-forcing, and caster-scoped subjective description overrides are now implemented as engine primitives. This moves marks, rune anchors, basic portals, item damage/destruction/enchantment, corpse preservation/consumption/spawn, and the safest coercion/subjective-description cases out of the blocked bucket. Persistent portal topology, general dispel, true possession/projection, passive psionic traffic, and identity-concealment systems remain open.
 
 > Note: the top-line parity counts and family summary in this report predate the Phase 1, Phase 2, plane/corporeality, and body-form implementation work. If exact current counts are needed, rerun the family-by-family classification pass. The implementation-plan and primitive-gap sections below reflect the current runtime state.
 
@@ -41,7 +42,7 @@ Key takeaways:
 - The current system is already strong at direct damage, healing, stamina/need adjustment, item or liquid conjuration, NPC summoning, invisibility, telepathy, self-only magical armour, planar state shifts, and single-active-body transformation.
 - Phase 2 now closes three medium-difficulty primitive gaps: local exit targeting, prog-resolved summon-style remote targeting, and reusable room or personal wards with shared spell and power interception.
 - The plane and body-form work moves several old blockers into the buildable bucket: `Ethereal`, `Detect Ethereal`, `Dispel Ethereal`, simple `Planeshift`, ghostly manifestation, and polymorph-style transformations can now use first-class effects rather than bespoke tags.
-- The biggest remaining parity blockers are item/corpse enchantment, magic metadata and anchors, richer portal topology, coercive psionics, subjective perception, and true "dual body" mechanics like possession or shadow projection.
+- The biggest remaining parity blockers are persistent portal topology, general dispel/effect shortening, passive psionic traffic and identity concealment, richer illusion stacking, and true "dual body" mechanics like possession or shadow projection.
 - Psionics are only partially covered today. The current mind-link stack handles contact, barriers, mind-looking, audits, expulsion, sense, messaging, and direct mental attacks, but most coercion, concealment, remote eavesdropping, and passive-traffic powers still need new runtime support.
 
 ## Family Summary
@@ -54,9 +55,9 @@ Key takeaways:
 | Wind | 5 | 11 | 7 | Flying, long-range forced movement, detection or cleanse effects |
 | Shadow | 3 | 5 | 9 | Ethereal state, anti-curse cleanses, fear, projection |
 | Lightning | 5 | 7 | 3 | Sleep immunity, paralysis, tracked footprint effects |
-| Void | 6 | 5 | 17 | Portals, possession, item/corpse enchantment, resource drain |
+| Void | 6 | 5 | 17 | Persistent portals, possession, advanced corpse/vessel semantics, resource drain |
 | Unspecified / incomplete magic | 1 | 0 | 3 | Source material is incomplete |
-| Psionics | 10 | 8 | 19 | Command-forcing, concealment, passive traffic, identity masking |
+| Psionics | 10 | 8 | 19 | Concealment, passive traffic, identity masking, advanced coercion policy |
 
 ## Where FutureMUD Is Already Strong
 
@@ -73,6 +74,10 @@ The current system already has good coverage for:
 - room ambience changes through `roomlight`, `roomtemperature`, `roomatmosphere`, and weather effects
 - planar state changes through `planarstate`, `planeshift`, `removeplanarstate`, planar merits, planar drugs, and planar FutureProg helpers
 - spell-driven alternate body forms through `transformform`, including stable form keys, first-creation race or description defaults, trauma handling, transformation echoes, and forced-transformation priority
+- information-bearing spell metadata through `magictag` / `removemagictag` and FutureProg helpers `hasmagictag`, `magictagvalue`, `magictagvalues`, and `magictags`
+- item/corpse magic through `itemdamage`, `destroyitem`, `itemenchant`, `corpsemark`, `corpsepreserve`, `corpseconsume`, and `corpsespawn`
+- transient paired magical portals through `portal`, backed by effect-owned exit-manager registration rather than permanent database exits
+- Coercion V1 through `forcecommand`, `subjectivedesc`, and `subjectivesdesc`
 
 ## Current Reclassification From Planes And Body Forms
 
@@ -82,11 +87,11 @@ The old blocker list bundled "ethereal", "projection", "possession", "planeshift
 | --- | --- | --- |
 | Ethereal or noncorporeal state | Use `planarstate` / `planeshift` on characters, items, or other perceivables. Plane data handles room presentation, remote observation tags, perception, interaction checks, noncorporeal physiology, inventory propagation, and closed-door bypass where configured. | Plane-specific travel graphs, custom transition trauma, and any spell that requires a separate acting shell rather than changing the target's own planar presence. |
 | Detect or dispel ethereal | Use `detectethereal` / `removedetectethereal` for perception grants and `removeplanarstate` for spell-owned or saved planar overlays. | A general dispel engine that shortens arbitrary effects by strength, school, or contest result. |
-| Planeshift | Simple "target moves to configured plane/state" is now first-class with `planeshift`. | Multi-step planar travel with anchors, unsafe destinations, paired portals, or persistent world topology. |
+| Planeshift | Simple "target moves to configured plane/state" is now first-class with `planeshift`. | Multi-step planar travel with unsafe destinations, persistent world topology, or portal networks that should survive beyond an effect duration. |
 | Shadowwalk-style movement | If the intended behaviour is "enter a shadow/astral/ethereal plane and move normally", use plane definitions plus `planeshift`. | If the intended behaviour is remote projection, leaving a body behind, or moving a second body independently, it remains blocked. |
 | Polymorph, animal form, statue-like form, or spirit form | Use `transformform` for single-active-body transformation, with `Additional Body Form` merits for intrinsic or racial forms. | Turning a character into a true item, making two bodies act at once, using a corpse as the exact vessel, or continuously syncing spell XML to later form metadata. |
 | Possession, disembodying, and send-shadow projection | Use `planeshift` or `transformform` only for simplified content where the original character becomes the new form/state. | True possession and projection still need simultaneous presence, command routing, source-body vulnerability, disconnect handling, staff visibility, and death semantics. |
-| Marks, runes, anchors, and hidden magical facts | Add a generic magic-tag effect for information-bearing metadata that other effects and progs can query. | Behavioural effects should still get first-class support when the tag would be pretending to be a combat, movement, portal, item-damage, resource, or perception system. |
+| Marks, runes, anchors, and hidden magical facts | Use `magictag` / `removemagictag` plus the magic-tag FutureProg helpers for information-bearing metadata. The `portal` effect can consume caster-owned room anchors. | Behavioural effects should still get first-class support when the tag would be pretending to be combat, movement, persistent portal topology, item damage, resource changes, or perception. |
 
 ## Main Gaps By Primitive
 
@@ -187,7 +192,7 @@ This still blocks or complicates:
 
 - `Hands Of Wind` if it needs more than "move target to chosen room" semantics
 - `Transference`
-- persistent paired-gate or anchor topology for `Travel Gate` and `Portal`
+- persistent paired-gate topology for `Travel Gate` and `Portal`; transient paired exits and caster-owned room-tag anchors are now live
 
 ### 5. Room wards and anti-magic / anti-psionics interception
 
@@ -217,13 +222,14 @@ Remaining limitation:
 
 ### 6. Item and corpse enchantment, magic tags, and anchors
 
-Armageddon leans heavily on item-state mutation and corpse-state mutation. FutureMUD can create items and affect some item properties indirectly, but it does not have a generic enchant-or-tag-item spell effect family.
+Status: implemented for Engine V1 metadata, destructive item magic, basic item enchantment, and corpse lifecycle helpers.
 
-There should be a generic information-bearing magic-tag effect. It should be explicitly framed as metadata, not as a universal behaviour substitute. A good shape would be:
+FutureMUD now has a generic information-bearing magic-tag effect. It is explicitly metadata, not a universal behaviour substitute:
 
-- `magictag` / `removemagictag` spell effects that attach a spell-owned key, optional value, optional school/source metadata, and duration to a room, item, corpse, character, or perceivable.
-- FutureProg helpers such as `hasmagictag`, `magictagvalue`, and `magictags` so content can check anchors, rune keys, ritual state, and bespoke conditional effects.
-- Dispel/removal rules that can remove tags by key, school, source spell, or parent effect, without forcing every tagged behaviour to become a generic tag.
+- `magictag` / `removemagictag` attach spell-owned key/value metadata to characters, items, rooms, and other perceivables.
+- The active effect exposes `Tag`, `Value`, `Caster`, and `Spell` through `IMagicTagEffect`.
+- FutureProg helpers `hasmagictag`, `magictagvalue`, `magictagvalues`, and `magictags` let progs query anchors, rune keys, ritual state, signatures, and bespoke conditional effects.
+- `portal` can use caster-owned magic-tag room anchors as one destination mode.
 
 This is appropriate for:
 
@@ -234,9 +240,17 @@ This is appropriate for:
 - one-off builder-authored information read by a prog
 - "this corpse has been spoken to" or "this item bears a magical signature" style facts
 
-This should not replace first-class support for effects with real runtime behaviour. `Vampiric Blade`, `Rot Items`, `Shatter`, `Animate Dead`, and persistent portal topology need dedicated item, corpse, combat, or movement logic even if they also use tags as supporting metadata.
+First-class item and corpse effects now cover the common runtime behaviours that should not be faked with tags:
 
-This blocks or complicates:
+- `itemdamage` applies normal item wound/health damage.
+- `destroyitem` deletes item targets with purge-warning safeguards.
+- `itemenchant` supplies visible aura text, optional glow, conditional-prog gating, and weapon/armour combat hooks through `IMagicWeaponEnhancementEffect` and `IMagicArmourEnhancementEffect`.
+- `corpsemark` marks corpse items with magic metadata.
+- `corpsepreserve` pauses corpse decay through the corpse heartbeat.
+- `corpseconsume` cleanly deletes corpse items.
+- `corpsespawn` loads configured NPCs or items at the corpse location and can optionally consume the corpse.
+
+This now unlocks or materially improves:
 
 - `Glyph`
 - `Mark`
@@ -247,6 +261,12 @@ This blocks or complicates:
 - `Pseudo Death`
 - `Hero Sword`
 - `Sand Statue`
+
+Remaining limitations:
+
+- `itemenchant` has first-class weapon/armour hooks, but more specialised hooks may still be needed for projectile payload mutation, tool/crafting bonuses, fuel/power interactions, and item-specific scripting.
+- General dispel/removal by school, strength, caster, or effect family is still not implemented.
+- Persistent runes, standing portals, and world-topology edits should not be modelled as only temporary magic tags.
 
 ### 7. Body transformation, dual-body, possession, and projection mechanics
 
@@ -276,25 +296,33 @@ This blocks:
 
 ### 8. Subjective perception and coercive psionics
 
-FutureMUD already has good mind-link primitives, but it does not yet have a reusable system for:
+Status: Coercion V1 is implemented, but deeper psionic identity and traffic systems remain open.
 
-- forcing player commands
+FutureMUD already has good mind-link primitives and now has:
+
+- `forcecommand`, which runs as the target's own command context through `ExecuteCommand`, respects `IIgnoreForceEffect`, blocks staff/editor/account-destructive command roots, and emits wiz-only audit output.
+- `subjectivedesc`, which applies a spell-owned full-description override.
+- `subjectivesdesc`, which applies a spell-owned short-description override.
+- caster-scoped subjective-description support through fixed-viewer handling.
+
+This now covers the safest command-forcing and "one viewer sees a different description" cases. It does not yet cover:
+
 - injecting emotions or compulsions
 - hiding a psionic identity from trace/contact flows
-- giving one perceiver a fake appearance while leaving everyone else on the real one
+- passive thought-traffic/eavesdropping powers
+- robust refusal/consent policy beyond the hard safety block list
+- illusion stacking policy beyond ordinary override-description precedence
 
-This blocks:
+This still blocks or complicates:
 
-- `Control`
-- `Compel`
-- `Suggest`
-- `Coerce`
 - `Conceal`
 - `Masquerade`
 - `Imitate`
 - `Vanish`
 - `Thoughtsense`
 - `Immersion`
+
+`Control`, `Compel`, `Suggest`, and `Coerce` are now buildable for non-staff, non-account-destructive command roots, but content authors should still treat them as policy-sensitive spells and pair them with clear messaging or setting rules.
 
 ## Prioritised Implementation Plan
 
@@ -335,18 +363,17 @@ These are the next-best return once the basic statuses exist.
    - This is now the cleanest path for `Summon` and the room-targeted portions of richer gate logic, but not yet full swap or portal-topology behavior.
 
 3. Add first-class item enchantment and item damage effects.
-   - `EnchantItemEffect`
-   - `DamageItemEffect`
-   - `TagItemEffect` or generic effect metadata on items/corpses
-   - This unlocks `Glyph`, `Mark`, `Vampiric Blade`, `Rot Items`, `Shatter`, and a cleaner path for corpse magic.
+   - Completed in Engine V1 with `itemdamage`, `destroyitem`, `itemenchant`, generic `magictag`, and corpse-specific helpers.
+   - This unlocks or materially improves `Glyph`, `Mark`, `Vampiric Blade`, `Rot Items`, `Shatter`, and a cleaner path for corpse magic.
 
 4. Add room wards and personal ward effects with interception hooks.
    - Completed in the current runtime as school-based wards with shared spell and power interception hooks.
    - This unlocks `Forbid Elements`, `Turn Element`, `Shield Of Nilaz`, `Elemental Fog`, and `Dome`.
 
 5. Add a command-safe psionic coercion framework.
-   - One reusable power family should cover same-room domination, contact-range compulsion, suggestion, and coercion.
-   - It needs explicit policy hooks for player agency, logging, staff review, and refusal messages.
+   - Completed for Coercion V1 with `forcecommand`.
+   - The current implementation executes through the target's own `ExecuteCommand`, respects `IIgnoreForceEffect`, blocks staff/editor/account-destructive roots, and emits wiz-only audit output.
+   - Deeper consent/refusal semantics, emotion injection, and psionic identity concealment remain future work.
 
 ### Phase 3: Tricky Design Work
 
@@ -368,11 +395,11 @@ These are the parity items with the most engine-level uncertainty.
    - `Travel Gate`
    - `Portal`
    - `Create Rune`
-   - Status: simple room-target teleport and simple planar shifting are live; persistent paired gates, anchors, and portal objects are not.
-   - Design questions:
-     - Are anchors objects, locations, or both?
-     - Are portals represented as temporary exits, room effects, or paired perceivables?
-     - How do you validate destination safety, plane compatibility, and persistence?
+   - Status: simple room-target teleport, simple planar shifting, caster-owned tag anchors, and transient effect-owned paired exits are live.
+   - Remaining work:
+     - persistent paired gates, standing rune networks, and portal objects
+     - item/object anchors rather than room-only magic-tag anchors
+     - richer destination safety models, world-topology persistence, and builder-facing inspection commands
 
 3. Subjective illusions and perception overrides.
    - `Masquerade`
@@ -384,10 +411,12 @@ These are the parity items with the most engine-level uncertainty.
    - `Delusion`
    - `Shadowplay`
    - `Illuminant`
-   - Design questions:
-     - Is the illusion objective room state or per-viewer filtered state?
-     - Do effects target a room, a perceiver, or a perceivable as seen by one perceiver?
-     - How should stacked illusions resolve?
+   - Status: caster-scoped subjective short/full description overrides are live through `subjectivesdesc` and `subjectivedesc`.
+   - Remaining work:
+     - objective room-state illusions
+     - multi-viewer or group-scoped illusions
+     - identity masking in psionic contact/trace flows
+     - explicit stacking and priority rules beyond the existing override-description effect ordering
 
 4. World-model-specific metaphysics.
    - `Determine Relationship`
@@ -397,37 +426,34 @@ These are the parity items with the most engine-level uncertainty.
    - `Cathexis`
    - These are only partly magic-system problems. They also require a clean model for "relationship to the land", elemental planes, and any clan- or tribe-keyed psionic identity mechanics.
 
-## Recommended Next Shipping Slice
+## Recommended Next Shipping Slice: Engine V2
 
-The current runtime already includes exit targeting, summon-style remote targeting, generic room or personal wards, planar overlays, and single-active-body transformations. If the goal is to maximise "Armageddon-feeling parity" quickly from here, the next phase should focus on anchors and item/corpse magic before trying to solve simultaneous possession.
+Engine V1 has shipped the metadata, item/corpse, transient portal, and safest coercion/perception primitives. The next slice should turn those primitives into deeper parity without jumping straight to simultaneous-body possession.
 
-1. Add a generic magic-tag primitive.
-   - Implement `magictag` / `removemagictag` as metadata-bearing spell effects for characters, items, corpses, rooms, and perceivables.
-   - Add FutureProg query helpers so later spell effects and builder progs can check tags without parsing effect XML.
-   - Keep tags informational: use them for anchors, runes, marks, ritual state, signatures, and conditional content.
+1. Add a general dispel and effect-shortening framework.
+   - Support removal or duration reduction by spell, school, child school, caster, tag key, and effect interface.
+   - Reuse it for `Dispel Magick`, `Dispel Ethereal`, rune cleanup, enchantment stripping, and anti-magic maintenance spells.
+   - Keep policy explicit for hostile dispels versus owner/caster cleanup.
 
-2. Add first-class item and corpse magic effects.
-   - Add item-damage or item-destruction effects for `Shatter`, `Rot Items`, and similar destructive magic.
-   - Add item enchantment effects for weapon, armour, glow, aura, and conditional-prog behaviours that need runtime hooks beyond a tag.
-   - Add corpse-targeted helpers that can mark, consume, preserve, or spawn from a corpse cleanly, rather than relying on a freeform prog to fake all corpse lifecycle semantics.
+2. Deepen portals from transient spell exits to authored topology.
+   - Add builder-visible inspection for active transient portals and magic-tag anchors.
+   - Add persistent standing-gate/rune support only after deciding whether the durable object is a room effect, item, exit overlay, or dedicated gate definition.
+   - Extend anchors from room-only metadata to item/object anchors where the setting needs portable marks.
 
-3. Package the newly unblocked plane and form spells.
-   - Author stock examples for `Ethereal`, `Dispel Ethereal`, `Planeshift`, shadow/astral walking as planar movement, and polymorph-style transformations using `planarstate`, `removeplanarstate`, `planeshift`, and `transformform`.
-   - Add tests that prove planar spell effects target characters/items/perceivables correctly and that spell transforms persist, expire, and revert through the forced-transformation resolver.
+3. Broaden item enchantment hooks where real content needs them.
+   - Add projectile payload mutation, ranged damage bonuses, tool/crafting bonuses, power/fuel interactions, and item-specific scripted hooks as first-class interfaces when concrete spells demand them.
+   - Avoid routing those behaviours through generic tags except as supporting metadata.
 
-4. Build anchor-aware portal topology.
-   - Use magic tags for `Mark` / `Create Rune` anchor metadata, but implement portal creation as a first-class movement primitive.
-   - Decide whether portals are temporary exits, room effects, item-like perceivables, or a dedicated paired-gate effect.
-   - Validate destination safety, plane compatibility, cross-zone constraints, expiration, and interdiction.
+4. Package plane/form spell recipes and tests.
+   - Document builder recipes for `Ethereal`, `Dispel Ethereal`, `Planeshift`, shadow/astral walking, and polymorph using `planarstate`, `removeplanarstate`, `planeshift`, and `transformform`.
+   - Keep examples as engine documentation/tests unless stock magic seeding is explicitly desired.
 
-5. Design psionic coercion and subjective perception as a separate phase.
-   - Command-forcing and subjective identity masking need policy, logging, consent/refusal hooks, and staff review visibility.
-   - Do not model them as generic tags; tags can support identity or trace metadata, but the agency and perception changes need first-class runtime paths.
+5. Design psionic identity, concealment, and passive traffic.
+   - Extend beyond `forcecommand` into `Conceal`, `Thoughtsense`, `Immersion`, trace masking, passive eavesdropping, and contact identity policy.
+   - These should be first-class mind-link/telepathy behaviours, not magic tags.
 
 6. Defer true possession and projection until the simultaneous-body model is designed.
    - The existing form system deliberately supports one active body. Possession, send-shadow projection, and body-left-behind disembodiment require command routing, remote presence, body vulnerability, inventory rules, death rules, reconnect behaviour, and admin observability.
-
-That order uses the newly shipped plane and body-form work immediately, adds the generic metadata primitive the spell system genuinely needs, and still reserves first-class engine work for behaviours that should not be reduced to tags.
 
 ## Appendix: Classification By Family
 

--- a/Design Documents/Armageddon_Magic_Psionics_Gap_Report.md
+++ b/Design Documents/Armageddon_Magic_Psionics_Gap_Report.md
@@ -23,8 +23,9 @@ and the current runtime implementations under `MudSharpCore/Magic`.
 - Existing powers count as valid coverage even when Armageddon exposed the original ability as a spell. If you want strict `cast`-spell parity rather than "same subsystem can do it", several defensive entries would slide from `Native now` to `Needs engine work`.
 - A handful of Armageddon entries are under-specified in the dump (`Daylight`, `Empower`, `Drown`, `Cause Disease`, `Acid Spray`, some passive psionics). I counted those conservatively unless the name clearly maps to an existing FutureMUD primitive.
 - Status update as of 2026-04-21: the Phase 1 implementation slice from this report has now shipped. `teleport` accepts `room` / `rooms` triggers, the reusable Phase 1 statuses are implemented as standalone spell-effect templates with matching removals, `MagicResourceDeltaEffect`, `SpellArmourEffect`, and `roomflag` / `removeroomflag` are live, and the underlying runtime hooks for additive perception grants, selective poison or disease cleanup, and early room flags are in place.
+- Status update as of 2026-05-01: the plane/corporeality and multiple-body-form work changes the blocker picture again. `IPlane`, `PlanarPresenceDefinition`, `planarstate`, `planeshift`, `removeplanarstate`, planar FutureProg functions, the `corporeality` admin command, and the `transformform` spell effect are live. Simple ethereal states, noncorporeal manifestation, single-active-body transformation, and straightforward "move this target to another plane" spells are now buildable with first-class primitives. Simultaneous bodies, remote vessels, possessed corpses, descriptor handoff, and persistent portal topology remain blocked.
 
-> Note: the top-line parity counts in this report predate the Phase 1 implementation work. If exact current counts are needed, rerun the family-by-family classification pass. The implementation-plan and primitive-gap sections below reflect the current runtime state.
+> Note: the top-line parity counts and family summary in this report predate the Phase 1, Phase 2, plane/corporeality, and body-form implementation work. If exact current counts are needed, rerun the family-by-family classification pass. The implementation-plan and primitive-gap sections below reflect the current runtime state.
 
 ## Executive Summary
 
@@ -37,9 +38,10 @@ and the current runtime implementations under `MudSharpCore/Magic`.
 Key takeaways:
 
 - `110 / 189` Armageddon entries are reachable today if we allow ordinary FutureProg and prototype scaffolding.
-- The current system is already strong at direct damage, healing, stamina/need adjustment, item or liquid conjuration, NPC summoning, invisibility, telepathy, and self-only magical armour.
+- The current system is already strong at direct damage, healing, stamina/need adjustment, item or liquid conjuration, NPC summoning, invisibility, telepathy, self-only magical armour, planar state shifts, and single-active-body transformation.
 - Phase 2 now closes three medium-difficulty primitive gaps: local exit targeting, prog-resolved summon-style remote targeting, and reusable room or personal wards with shared spell and power interception.
-- The biggest parity blockers are reusable status effects, status removal, item/corpse enchantment, magic-resource drain, richer portal or anchor topology, coercive psionics, and "dual body" mechanics like possession or shadow projection.
+- The plane and body-form work moves several old blockers into the buildable bucket: `Ethereal`, `Detect Ethereal`, `Dispel Ethereal`, simple `Planeshift`, ghostly manifestation, and polymorph-style transformations can now use first-class effects rather than bespoke tags.
+- The biggest remaining parity blockers are item/corpse enchantment, magic metadata and anchors, richer portal topology, coercive psionics, subjective perception, and true "dual body" mechanics like possession or shadow projection.
 - Psionics are only partially covered today. The current mind-link stack handles contact, barriers, mind-looking, audits, expulsion, sense, messaging, and direct mental attacks, but most coercion, concealment, remote eavesdropping, and passive-traffic powers still need new runtime support.
 
 ## Family Summary
@@ -69,6 +71,22 @@ The current system already has good coverage for:
 - school-based room and personal wards through `roomward` and `personalward`
 - prog-resolved remote character or item targeting for summon-style spells through `progcharacter`, `progitem`, `progcharacterroom`, and `progitemroom`
 - room ambience changes through `roomlight`, `roomtemperature`, `roomatmosphere`, and weather effects
+- planar state changes through `planarstate`, `planeshift`, `removeplanarstate`, planar merits, planar drugs, and planar FutureProg helpers
+- spell-driven alternate body forms through `transformform`, including stable form keys, first-creation race or description defaults, trauma handling, transformation echoes, and forced-transformation priority
+
+## Current Reclassification From Planes And Body Forms
+
+The old blocker list bundled "ethereal", "projection", "possession", "planeshift", and "shape change" together. The live runtime now supports some of those as first-class mechanics, but not all of them.
+
+| Old blocker theme | Current path forward | Still blocked |
+| --- | --- | --- |
+| Ethereal or noncorporeal state | Use `planarstate` / `planeshift` on characters, items, or other perceivables. Plane data handles room presentation, remote observation tags, perception, interaction checks, noncorporeal physiology, inventory propagation, and closed-door bypass where configured. | Plane-specific travel graphs, custom transition trauma, and any spell that requires a separate acting shell rather than changing the target's own planar presence. |
+| Detect or dispel ethereal | Use `detectethereal` / `removedetectethereal` for perception grants and `removeplanarstate` for spell-owned or saved planar overlays. | A general dispel engine that shortens arbitrary effects by strength, school, or contest result. |
+| Planeshift | Simple "target moves to configured plane/state" is now first-class with `planeshift`. | Multi-step planar travel with anchors, unsafe destinations, paired portals, or persistent world topology. |
+| Shadowwalk-style movement | If the intended behaviour is "enter a shadow/astral/ethereal plane and move normally", use plane definitions plus `planeshift`. | If the intended behaviour is remote projection, leaving a body behind, or moving a second body independently, it remains blocked. |
+| Polymorph, animal form, statue-like form, or spirit form | Use `transformform` for single-active-body transformation, with `Additional Body Form` merits for intrinsic or racial forms. | Turning a character into a true item, making two bodies act at once, using a corpse as the exact vessel, or continuously syncing spell XML to later form metadata. |
+| Possession, disembodying, and send-shadow projection | Use `planeshift` or `transformform` only for simplified content where the original character becomes the new form/state. | True possession and projection still need simultaneous presence, command routing, source-body vulnerability, disconnect handling, staff visibility, and death semantics. |
+| Marks, runes, anchors, and hidden magical facts | Add a generic magic-tag effect for information-bearing metadata that other effects and progs can query. | Behavioural effects should still get first-class support when the tag would be pretending to be a combat, movement, portal, item-damage, resource, or perception system. |
 
 ## Main Gaps By Primitive
 
@@ -145,7 +163,7 @@ Remaining limitation:
 
 - there is still no first-class `OpenOrClosedExitImpact` primitive, so exit state mutation beyond blocking passage still needs bespoke work
 
-### 4. World-target movement and swap effects
+### 4. World-target movement, planar movement, and swap effects
 
 Status: partially implemented in the current runtime.
 
@@ -163,6 +181,7 @@ This now unlocks or materially improves:
 - `Summon`
 - parts of `Travel Gate`
 - parts of `Portal`
+- simple `Planeshift` when the desired behaviour is a planar overlay on the target rather than a portal network
 
 This still blocks or complicates:
 
@@ -196,9 +215,26 @@ Remaining limitation:
 
 - wards are school-based rather than freeform tag-based, so future item- or rune-specific anti-magic still wants a deeper enchantment layer
 
-### 6. Item and corpse enchantment as first-class spell targets
+### 6. Item and corpse enchantment, magic tags, and anchors
 
 Armageddon leans heavily on item-state mutation and corpse-state mutation. FutureMUD can create items and affect some item properties indirectly, but it does not have a generic enchant-or-tag-item spell effect family.
+
+There should be a generic information-bearing magic-tag effect. It should be explicitly framed as metadata, not as a universal behaviour substitute. A good shape would be:
+
+- `magictag` / `removemagictag` spell effects that attach a spell-owned key, optional value, optional school/source metadata, and duration to a room, item, corpse, character, or perceivable.
+- FutureProg helpers such as `hasmagictag`, `magictagvalue`, and `magictags` so content can check anchors, rune keys, ritual state, and bespoke conditional effects.
+- Dispel/removal rules that can remove tags by key, school, source spell, or parent effect, without forcing every tagged behaviour to become a generic tag.
+
+This is appropriate for:
+
+- `Mark`
+- `Create Rune`
+- anchor state for later `Portal` or `Travel Gate`
+- ritual prerequisites
+- one-off builder-authored information read by a prog
+- "this corpse has been spoken to" or "this item bears a magical signature" style facts
+
+This should not replace first-class support for effects with real runtime behaviour. `Vampiric Blade`, `Rot Items`, `Shatter`, `Animate Dead`, and persistent portal topology need dedicated item, corpse, combat, or movement logic even if they also use tags as supporting metadata.
 
 This blocks or complicates:
 
@@ -212,9 +248,20 @@ This blocks or complicates:
 - `Hero Sword`
 - `Sand Statue`
 
-### 7. Dual-body, possession, and projection mechanics
+### 7. Body transformation, dual-body, possession, and projection mechanics
 
-These are the hardest parity items. They are not just "apply a timed effect"; they need a coherent answer for agency, perception, inventory, death, disconnects, and admin visibility.
+Status: partially unblocked.
+
+The `transformform` spell effect and the multiple-body-form system now give FutureMUD a first-class answer for temporary or persistent single-active-body transformations. This supports spells that can honestly be represented as "the character becomes a different body for a duration" rather than "the character controls another body while the original remains elsewhere."
+
+This now unlocks or materially improves:
+
+- polymorph-style magic
+- animal, monster, elemental, ghost, or spirit body forms
+- some simplified `Pseudo Death` or `Sand Statue` interpretations if they are authored as a body form rather than a true corpse/item state
+- shadow or astral form spells where the caster becomes that form
+
+The remaining hard cases are still not just timed effects. They need a coherent answer for agency, perception, inventory, death, disconnects, source-body vulnerability, and admin visibility.
 
 This blocks:
 
@@ -224,6 +271,8 @@ This blocks:
 - `Disembody`
 - `Burrow` to a lesser extent
 - pieces of `Portal` and `Planeshift`
+
+`Shadowwalk`, `Disembody`, and `Planeshift` should be split by intended semantics. If they mean "change this target's planar presence", they are now buildable. If they mean "leave one body behind and operate another", they remain blocked by simultaneous-body mechanics.
 
 ### 8. Subjective perception and coercive psionics
 
@@ -308,6 +357,7 @@ These are the parity items with the most engine-level uncertainty.
    - `Shadowwalk`
    - `Possess Corpse`
    - `Disembody`
+   - Status: single-active-body transformations are now supported through `transformform`; true projection and possession remain blocked.
    - Design questions:
      - Is the projected self a second body, a descriptor handoff, or a temporary NPC shell?
      - What happens to inventory, combat, death, and disconnects?
@@ -318,6 +368,7 @@ These are the parity items with the most engine-level uncertainty.
    - `Travel Gate`
    - `Portal`
    - `Create Rune`
+   - Status: simple room-target teleport and simple planar shifting are live; persistent paired gates, anchors, and portal objects are not.
    - Design questions:
      - Are anchors objects, locations, or both?
      - Are portals represented as temporary exits, room effects, or paired perceivables?
@@ -348,19 +399,39 @@ These are the parity items with the most engine-level uncertainty.
 
 ## Recommended Next Shipping Slice
 
-The current runtime already includes exit targeting, summon-style remote targeting, and generic room or personal wards. If the goal is to maximise "Armageddon-feeling parity" quickly from here, I would ship in this order:
+The current runtime already includes exit targeting, summon-style remote targeting, generic room or personal wards, planar overlays, and single-active-body transformations. If the goal is to maximise "Armageddon-feeling parity" quickly from here, the next phase should focus on anchors and item/corpse magic before trying to solve simultaneous possession.
 
-1. Teleport fix plus generic status application/removal.
-2. Magic-resource deltas.
-3. A reusable armour spell effect.
-4. Item enchantment and corpse-tagging.
-5. Psionic command/control framework.
-6. Projection, possession, and portal topology.
-7. Deeper anchor or marked-destination gate work.
+1. Add a generic magic-tag primitive.
+   - Implement `magictag` / `removemagictag` as metadata-bearing spell effects for characters, items, corpses, rooms, and perceivables.
+   - Add FutureProg query helpers so later spell effects and builder progs can check tags without parsing effect XML.
+   - Keep tags informational: use them for anchors, runes, marks, ritual state, signatures, and conditional content.
 
-That order gets the broadest number of iconic elemental spells online before tackling the truly knotty psionic and void-magic mechanics that still lack a shared engine answer.
+2. Add first-class item and corpse magic effects.
+   - Add item-damage or item-destruction effects for `Shatter`, `Rot Items`, and similar destructive magic.
+   - Add item enchantment effects for weapon, armour, glow, aura, and conditional-prog behaviours that need runtime hooks beyond a tag.
+   - Add corpse-targeted helpers that can mark, consume, preserve, or spawn from a corpse cleanly, rather than relying on a freeform prog to fake all corpse lifecycle semantics.
+
+3. Package the newly unblocked plane and form spells.
+   - Author stock examples for `Ethereal`, `Dispel Ethereal`, `Planeshift`, shadow/astral walking as planar movement, and polymorph-style transformations using `planarstate`, `removeplanarstate`, `planeshift`, and `transformform`.
+   - Add tests that prove planar spell effects target characters/items/perceivables correctly and that spell transforms persist, expire, and revert through the forced-transformation resolver.
+
+4. Build anchor-aware portal topology.
+   - Use magic tags for `Mark` / `Create Rune` anchor metadata, but implement portal creation as a first-class movement primitive.
+   - Decide whether portals are temporary exits, room effects, item-like perceivables, or a dedicated paired-gate effect.
+   - Validate destination safety, plane compatibility, cross-zone constraints, expiration, and interdiction.
+
+5. Design psionic coercion and subjective perception as a separate phase.
+   - Command-forcing and subjective identity masking need policy, logging, consent/refusal hooks, and staff review visibility.
+   - Do not model them as generic tags; tags can support identity or trace metadata, but the agency and perception changes need first-class runtime paths.
+
+6. Defer true possession and projection until the simultaneous-body model is designed.
+   - The existing form system deliberately supports one active body. Possession, send-shadow projection, and body-left-behind disembodiment require command routing, remote presence, body vulnerability, inventory rules, death rules, reconnect behaviour, and admin observability.
+
+That order uses the newly shipped plane and body-form work immediately, adds the generic metadata primitive the spell system genuinely needs, and still reserves first-class engine work for behaviours that should not be reduced to tags.
 
 ## Appendix: Classification By Family
+
+This appendix is the historical family-by-family classification from the first pass. Use the current-runtime sections above for planning decisions until the exact counts are refreshed.
 
 ### Fire
 

--- a/FutureMUDLibrary/Construction/Boundary/IExitManager.cs
+++ b/FutureMUDLibrary/Construction/Boundary/IExitManager.cs
@@ -60,6 +60,8 @@ namespace MudSharp.Construction.Boundary
         IEnumerable<ICellExit> GetAllExits(ICell cell);
 
         IExit GetExitByID(long id);
+        void RegisterTransientExit(IExit exit);
+        void UnregisterTransientExit(IExit exit);
 
         /// <summary>
         ///     This function is called by the CellOverlay when it changes which exits it uses. It ensures that the ExitManager

--- a/FutureMUDLibrary/Effects/Interfaces/ICorpsePreservationEffect.cs
+++ b/FutureMUDLibrary/Effects/Interfaces/ICorpsePreservationEffect.cs
@@ -1,0 +1,8 @@
+#nullable enable
+
+namespace MudSharp.Effects.Interfaces;
+
+public interface ICorpsePreservationEffect : IEffectSubtype
+{
+	bool PreserveCorpse { get; }
+}

--- a/FutureMUDLibrary/Effects/Interfaces/IMagicArmourEnhancementEffect.cs
+++ b/FutureMUDLibrary/Effects/Interfaces/IMagicArmourEnhancementEffect.cs
@@ -1,0 +1,10 @@
+#nullable enable
+
+using MudSharp.Health;
+
+namespace MudSharp.Effects.Interfaces;
+
+public interface IMagicArmourEnhancementEffect : IEffectSubtype, IAbsorbDamage
+{
+	double ArmourDamageReduction { get; }
+}

--- a/FutureMUDLibrary/Effects/Interfaces/IMagicTagEffect.cs
+++ b/FutureMUDLibrary/Effects/Interfaces/IMagicTagEffect.cs
@@ -1,0 +1,14 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Magic;
+
+namespace MudSharp.Effects.Interfaces;
+
+public interface IMagicTagEffect : IEffectSubtype
+{
+	string Tag { get; }
+	string Value { get; }
+	ICharacter? Caster { get; }
+	IMagicSpell Spell { get; }
+}

--- a/FutureMUDLibrary/Effects/Interfaces/IMagicWeaponEnhancementEffect.cs
+++ b/FutureMUDLibrary/Effects/Interfaces/IMagicWeaponEnhancementEffect.cs
@@ -1,0 +1,17 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Framework;
+using MudSharp.GameItems;
+
+namespace MudSharp.Effects.Interfaces;
+
+public interface IMagicWeaponEnhancementEffect : IEffectSubtype
+{
+	double AttackCheckBonus { get; }
+	double QualityBonus { get; }
+	double DamageBonus { get; }
+	double PainBonus { get; }
+	double StunBonus { get; }
+	bool AppliesToWeaponAttack(ICharacter attacker, IPerceivable target, IGameItem weapon);
+}

--- a/MudSharpCore Unit Tests/MagicPhase3Tests.cs
+++ b/MudSharpCore Unit Tests/MagicPhase3Tests.cs
@@ -1,0 +1,289 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Construction.Boundary;
+using MudSharp.Effects.Concrete.SpellEffects;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.GameItems;
+using MudSharp.Health;
+using MudSharp.Magic;
+using MudSharp.Magic.SpellEffects;
+using MudSharp.Magic.SpellTriggers;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class MagicPhase3Tests
+{
+	private static readonly string[] Phase3EffectTypes =
+	[
+		"magictag",
+		"removemagictag",
+		"itemdamage",
+		"destroyitem",
+		"itemenchant",
+		"corpsemark",
+		"corpsepreserve",
+		"corpseconsume",
+		"corpsespawn",
+		"portal",
+		"forcecommand",
+		"subjectivedesc",
+		"subjectivesdesc"
+	];
+
+	[TestInitialize]
+	public void TestInitialize()
+	{
+		SpellTriggerFactory.SetupFactory();
+		SpellEffectFactory.SetupFactory();
+	}
+
+	[TestMethod]
+	public void SpellEffectFactory_RegistersPhase3EffectTypes()
+	{
+		var spell = CreateSpellMock();
+		foreach (var type in Phase3EffectTypes)
+		{
+			var (effect, error) = SpellEffectFactory.LoadEffectFromBuilderInput(type, new StringStack(string.Empty),
+				spell.Object);
+
+			Assert.AreEqual(string.Empty, error, $"Unexpected builder error for {type}.");
+			Assert.IsNotNull(effect, $"No builder effect was created for {type}.");
+			Assert.AreEqual(type, effect!.SaveToXml().Attribute("type")?.Value);
+			Assert.IsTrue(SpellEffectFactory.BuilderInfoForType(type).MatchingTriggers.Any());
+		}
+	}
+
+	[TestMethod]
+	public void PlaneAndFormRecipeEffects_RemainBuilderVisibleForEngineV1()
+	{
+		Assert.IsTrue(PlanarStateSpellEffect.IsCompatibleWithTrigger("character"));
+		Assert.IsTrue(PlanarStateSpellEffect.IsCompatibleWithTrigger("item"));
+		Assert.IsTrue(PlanarStateSpellEffect.IsCompatibleWithTrigger("perceivables"));
+		Assert.IsTrue(TransformFormEffect.IsCompatibleWithTrigger("character"));
+
+		CollectionAssert.Contains(SpellEffectFactory.BuilderInfoForType("planarstate").MatchingTriggers, "character");
+		CollectionAssert.Contains(SpellEffectFactory.BuilderInfoForType("planeshift").MatchingTriggers, "item");
+		CollectionAssert.Contains(SpellEffectFactory.BuilderInfoForType("removeplanarstate").MatchingTriggers, "character");
+		Assert.IsTrue(SpellEffectFactory.BuilderInfoForType("transformform").MatchingTriggers.Any());
+	}
+
+	[TestMethod]
+	public void SpellEffectFactory_LoadEffect_RoundTripsPhase3Xml()
+	{
+		var spell = CreateSpellMock();
+		foreach (var definition in Phase3Definitions())
+		{
+			var effect = SpellEffectFactory.LoadEffect(definition, spell.Object);
+			var saved = effect.SaveToXml();
+
+			Assert.AreEqual(definition.Attribute("type")?.Value, saved.Attribute("type")?.Value);
+		}
+	}
+
+	[TestMethod]
+	public void SpellMagicTagEffect_ExposesCasterSpellAndMetadata()
+	{
+		var caster = new Mock<ICharacter>();
+		var spell = CreateSpellMock();
+		var parent = new Mock<IMagicSpellEffectParent>();
+		parent.SetupGet(x => x.Caster).Returns(caster.Object);
+		parent.SetupGet(x => x.Spell).Returns(spell.Object);
+		var owner = CreatePerceivable(CreateGameworld().Object);
+
+		var effect = new SpellMagicTagEffect(owner.Object, parent.Object, "anchor", "north");
+
+		Assert.AreEqual("anchor", effect.Tag);
+		Assert.AreEqual("north", effect.Value);
+		Assert.AreSame(caster.Object, effect.Caster);
+		Assert.AreSame(spell.Object, effect.Spell);
+	}
+
+	[TestMethod]
+	public void ItemEnchantmentEffect_ImplementsCombatAndArmourHooks()
+	{
+		var owner = CreatePerceivable(CreateGameworld().Object);
+		var parent = CreateParent();
+		var effect = new SpellItemEnchantmentEffect(owner.Object, parent.Object, "(glowing)",
+			"It glows.", Telnet.BoldMagenta, 2.5, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+
+		Assert.AreEqual(1.0, effect.AttackCheckBonus);
+		Assert.AreEqual(2.0, effect.QualityBonus);
+		Assert.AreEqual(2.5, effect.ProvidedLux);
+
+		var wounds = new List<IWound>();
+		var reduced = effect.PassiveSufferDamage(new Damage
+		{
+			DamageAmount = 10.0,
+			PainAmount = 9.0,
+			StunAmount = 8.0,
+			DamageType = DamageType.Crushing,
+			PenetrationOutcome = Outcome.NotTested
+		}, ref wounds);
+
+		Assert.AreEqual(4.0, reduced.DamageAmount);
+		Assert.AreEqual(3.0, reduced.PainAmount);
+		Assert.AreEqual(2.0, reduced.StunAmount);
+	}
+
+	[TestMethod]
+	public void TransientExitManager_RegistersAndRemovesPortalExitWithoutDatabaseId()
+	{
+		var gameworld = CreateGameworld();
+		var manager = new ExitManager(gameworld.Object);
+		gameworld.SetupGet(x => x.ExitManager).Returns(manager);
+		var origin = CreateCell(1, "Origin", gameworld.Object);
+		var destination = CreateCell(2, "Destination", gameworld.Object);
+
+		var exit = new TransientExit(gameworld.Object, origin.Object, destination.Object, "enter", "portal", "portal",
+			"a bright portal", "a bright portal", "through", "through", 1.0);
+
+		manager.RegisterTransientExit(exit);
+
+		Assert.AreSame(exit, manager.GetExitByID(exit.Id));
+		Assert.AreSame(destination.Object, exit.CellExitFor(origin.Object)!.Destination);
+
+		manager.UnregisterTransientExit(exit);
+
+		Assert.IsNull(manager.GetExitByID(exit.Id));
+	}
+
+	[TestMethod]
+	public void ForceCommandEffect_RespectsIgnoreForceEffect()
+	{
+		var spell = CreateSpellMock();
+		var effect = SpellEffectFactory.LoadEffect(new XElement("Effect",
+			new XAttribute("type", "forcecommand"),
+			new XElement("Command", new XCData("look"))), spell.Object);
+		var caster = new Mock<ICharacter>();
+		var target = new Mock<ICharacter>();
+		target.Setup(x => x.AffectedBy<IIgnoreForceEffect>()).Returns(true);
+
+		effect.GetOrApplyEffect(caster.Object, target.Object, OpposedOutcomeDegree.None, SpellPower.Insignificant,
+			CreateParent().Object, []);
+
+		target.Verify(x => x.ExecuteCommand(It.IsAny<string>()), Times.Never);
+	}
+
+	private static IEnumerable<XElement> Phase3Definitions()
+	{
+		yield return new XElement("Effect", new XAttribute("type", "magictag"),
+			new XElement("Tag", new XCData("anchor")), new XElement("Value", new XCData("north")),
+			new XElement("ReplaceExisting", true));
+		yield return new XElement("Effect", new XAttribute("type", "removemagictag"),
+			new XElement("Tag", new XCData("anchor")), new XElement("Value", new XCData("north")),
+			new XElement("MatchValue", true));
+		yield return new XElement("Effect", new XAttribute("type", "itemdamage"),
+			new XElement("DamageFormula", new XCData("power * 7")), new XElement("PainFormula", new XCData("1")),
+			new XElement("StunFormula", new XCData("2")), new XElement("DamageType", (int)DamageType.Crushing));
+		yield return new XElement("Effect", new XAttribute("type", "destroyitem"),
+			new XElement("RespectPurgeWarnings", true));
+		yield return new XElement("Effect", new XAttribute("type", "itemenchant"),
+			new XElement("SDescAddendum", new XCData("(enchanted)")),
+			new XElement("DescAddendum", new XCData("It shines.")), new XElement("Colour", "bold magenta"),
+			new XElement("GlowLux", 1.0), new XElement("AttackCheckBonus", 1.0),
+			new XElement("QualityBonus", 1.0), new XElement("DamageBonus", 1.0), new XElement("PainBonus", 1.0),
+			new XElement("StunBonus", 1.0), new XElement("ArmourDamageReduction", 1.0),
+			new XElement("ApplicabilityProg", 0));
+		yield return new XElement("Effect", new XAttribute("type", "corpsemark"),
+			new XElement("Tag", new XCData("corpsemark")), new XElement("Value", new XCData("")),
+			new XElement("ReplaceExisting", true));
+		yield return new XElement("Effect", new XAttribute("type", "corpsepreserve"));
+		yield return new XElement("Effect", new XAttribute("type", "corpseconsume"));
+		yield return new XElement("Effect", new XAttribute("type", "corpsespawn"),
+			new XElement("NPCPrototypeId", 0), new XElement("ItemPrototypeId", 0), new XElement("Quantity", 1),
+			new XElement("ConsumeCorpse", false));
+		yield return new XElement("Effect", new XAttribute("type", "portal"),
+			new XElement("Verb", new XCData("enter")), new XElement("OutboundKeyword", new XCData("portal")),
+			new XElement("InboundKeyword", new XCData("portal")),
+			new XElement("OutboundTarget", new XCData("a portal")),
+			new XElement("InboundTarget", new XCData("a portal")),
+			new XElement("OutboundDescription", new XCData("through")),
+			new XElement("InboundDescription", new XCData("through")),
+			new XElement("TimeMultiplier", 1.0), new XElement("AllowCrossZone", false),
+			new XElement("AnchorTag", new XCData("anchor")), new XElement("AnchorValue", new XCData("north")),
+			new XElement("DestinationProg", 0));
+		yield return new XElement("Effect", new XAttribute("type", "forcecommand"),
+			new XElement("Command", new XCData("look")));
+		yield return new XElement("Effect", new XAttribute("type", "subjectivedesc"),
+			new XElement("Description", new XCData("A changed description.")), new XElement("FixedViewer", true),
+			new XElement("ApplicabilityProg", 0));
+		yield return new XElement("Effect", new XAttribute("type", "subjectivesdesc"),
+			new XElement("Description", new XCData("someone changed")), new XElement("FixedViewer", true),
+			new XElement("ApplicabilityProg", 0));
+	}
+
+	private static Mock<IMagicSpellEffectParent> CreateParent()
+	{
+		var parent = new Mock<IMagicSpellEffectParent>();
+		parent.SetupGet(x => x.Spell).Returns(CreateSpellMock().Object);
+		return parent;
+	}
+
+	private static Mock<IPerceivable> CreatePerceivable(IFuturemud gameworld)
+	{
+		var perceivable = new Mock<IPerceivable>();
+		perceivable.SetupGet(x => x.Gameworld).Returns(gameworld);
+		perceivable.SetupProperty(x => x.EffectsChanged);
+		perceivable.Setup(x => x.EffectsOfType<IMagicInterdictionEffect>(It.IsAny<Predicate<IMagicInterdictionEffect>>()))
+		          .Returns([]);
+		return perceivable;
+	}
+
+	private static Mock<ICell> CreateCell(long id, string name, IFuturemud gameworld)
+	{
+		var cell = new Mock<ICell>();
+		cell.SetupGet(x => x.Id).Returns(id);
+		cell.SetupGet(x => x.Name).Returns(name);
+		cell.SetupGet(x => x.Gameworld).Returns(gameworld);
+		return cell;
+	}
+
+	private static Mock<IFuturemud> CreateGameworld()
+	{
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.FutureProgs).Returns(CreateCollectionMock<IFutureProg>().Object);
+		gameworld.SetupGet(x => x.MagicSchools).Returns(CreateCollectionMock<IMagicSchool>().Object);
+		return gameworld;
+	}
+
+	private static Mock<IMagicSchool> CreateSchool()
+	{
+		var school = new Mock<IMagicSchool>();
+		school.SetupGet(x => x.Id).Returns(1);
+		school.SetupGet(x => x.Name).Returns("Magic");
+		school.SetupGet(x => x.PowerListColour).Returns(Telnet.Green);
+		return school;
+	}
+
+	private static Mock<IMagicSpell> CreateSpellMock()
+	{
+		var spell = new Mock<IMagicSpell>();
+		spell.SetupGet(x => x.Gameworld).Returns(CreateGameworld().Object);
+		spell.SetupGet(x => x.School).Returns(CreateSchool().Object);
+		spell.SetupProperty(x => x.Changed);
+		return spell;
+	}
+
+	private static Mock<IUneditableAll<T>> CreateCollectionMock<T>(params T[] items) where T : class, IFrameworkItem
+	{
+		var byId = items.ToDictionary(x => x.Id, x => x);
+		var collection = new Mock<IUneditableAll<T>>();
+		collection.SetupGet(x => x.Count).Returns(items.Length);
+		collection.Setup(x => x.Get(It.IsAny<long>())).Returns<long>(id => byId.GetValueOrDefault(id));
+		collection.Setup(x => x.GetByIdOrName(It.IsAny<string>(), It.IsAny<bool>())).Returns((T?)null);
+		collection.Setup(x => x.GetEnumerator()).Returns(((IEnumerable<T>)items).GetEnumerator());
+		return collection;
+	}
+}

--- a/MudSharpCore/Combat/Moves/MeleeWeaponAttack.cs
+++ b/MudSharpCore/Combat/Moves/MeleeWeaponAttack.cs
@@ -94,10 +94,14 @@ public class MeleeWeaponAttack : WeaponAttackMove
         }
 
         WorsenCombatPosition(defenderMove.Assailant, Assailant);
+        var magicAttackBonus = Weapon.Parent
+                                      .EffectsOfType<IMagicWeaponEnhancementEffect>(x =>
+                                          x.AppliesToWeaponAttack(Assailant, defenderMove.Assailant, Weapon.Parent))
+                                      .Sum(x => x.AttackCheckBonus);
         Dictionary<Difficulty, CheckOutcome> attackRoll = Gameworld.GetCheck(Check)
                                   .CheckAgainstAllDifficulties(Assailant, CheckDifficulty,
                                       Weapon.WeaponType.AttackTrait,
-                                      defenderMove.Assailant, Assailant.OffensiveAdvantage);
+                                      defenderMove.Assailant, Assailant.OffensiveAdvantage + magicAttackBonus);
         Assailant.OffensiveAdvantage = 0;
         if (defenderMove.Assailant is not IHaveWounds defenderHaveWounds)
         {

--- a/MudSharpCore/Combat/Moves/RangedWeaponAttackBase.cs
+++ b/MudSharpCore/Combat/Moves/RangedWeaponAttackBase.cs
@@ -3,6 +3,7 @@ using MudSharp.Body;
 using MudSharp.Body.Position;
 using MudSharp.Body.Position.PositionStates;
 using MudSharp.Character;
+using MudSharp.Effects.Interfaces;
 using MudSharp.Framework;
 using MudSharp.GameItems;
 using MudSharp.GameItems.Interfaces;
@@ -222,6 +223,10 @@ public abstract class RangedWeaponAttackBase : CombatMoveBase, IRangedWeaponAtta
                     Weapon.WeaponType.FireTrait,
                     // Bonuses
                     Weapon.WeaponType.AccuracyBonusExpression.Evaluate(Assailant, Weapon.WeaponType.FireTrait) +
+                    Weapon.Parent
+                          .EffectsOfType<IMagicWeaponEnhancementEffect>(x =>
+                              x.AppliesToWeaponAttack(Assailant, target, Weapon.Parent))
+                          .Sum(x => x.AttackCheckBonus) +
                     GetPenaltyForTargeting(targetHb.Body, range) +
                     noPressureBonus +
                     positionBonus +

--- a/MudSharpCore/Combat/Moves/WeaponAttackMove.cs
+++ b/MudSharpCore/Combat/Moves/WeaponAttackMove.cs
@@ -185,19 +185,27 @@ public abstract class WeaponAttackMove : CombatMoveBase, IWeaponAttackMove
         double relativeHardness =
             CalculateRelativeHardnessForWeapon(weapon, Attack.Profile.DamageType, outcome, target, targetBodypart);
 
+        var magicEnhancements = weapon.Parent
+            .EffectsOfType<IMagicWeaponEnhancementEffect>(x => x.AppliesToWeaponAttack(Assailant, target, weapon.Parent))
+            .ToList();
+        var effectiveQuality = (int)weapon.Parent.Quality + (int)Math.Round(magicEnhancements.Sum(x => x.QualityBonus));
+
         Attack.Profile.DamageExpression.Formula.Parameters["degree"] = (int)degree;
-        Attack.Profile.DamageExpression.Formula.Parameters["quality"] = (int)weapon.Parent.Quality;
+        Attack.Profile.DamageExpression.Formula.Parameters["quality"] = effectiveQuality;
         Attack.Profile.StunExpression.Formula.Parameters["degree"] = (int)degree;
-        Attack.Profile.StunExpression.Formula.Parameters["quality"] = (int)weapon.Parent.Quality;
+        Attack.Profile.StunExpression.Formula.Parameters["quality"] = effectiveQuality;
         Attack.Profile.PainExpression.Formula.Parameters["degree"] = (int)degree;
-        Attack.Profile.PainExpression.Formula.Parameters["quality"] = (int)weapon.Parent.Quality;
+        Attack.Profile.PainExpression.Formula.Parameters["quality"] = effectiveQuality;
 
         double damageResult =
-            Attack.Profile.DamageExpression.Evaluate(Assailant, context: TraitBonusContext.ArmedDamageCalculation);
+            Attack.Profile.DamageExpression.Evaluate(Assailant, context: TraitBonusContext.ArmedDamageCalculation) +
+            magicEnhancements.Sum(x => x.DamageBonus);
         double stunResult =
-            Attack.Profile.DamageExpression.Evaluate(Assailant, context: TraitBonusContext.ArmedDamageCalculation);
+            Attack.Profile.StunExpression.Evaluate(Assailant, context: TraitBonusContext.ArmedDamageCalculation) +
+            magicEnhancements.Sum(x => x.StunBonus);
         double painResult =
-            Attack.Profile.DamageExpression.Evaluate(Assailant, context: TraitBonusContext.ArmedDamageCalculation);
+            Attack.Profile.PainExpression.Evaluate(Assailant, context: TraitBonusContext.ArmedDamageCalculation) +
+            magicEnhancements.Sum(x => x.PainBonus);
 
         if (!Gameworld.GetStaticBool("WeaponsTakeDamageFromAttacks"))
         {

--- a/MudSharpCore/Construction/Boundary/CellExit.cs
+++ b/MudSharpCore/Construction/Boundary/CellExit.cs
@@ -34,6 +34,17 @@ public class CellExit : ICellExit
         _keywords = new Lazy<List<string>>(() => new List<string> { OutboundDirection.Describe().ToLowerInvariant() });
     }
 
+    public CellExit(IExit parent, ICell origin, ICell destination, CardinalDirection outboundDirection,
+        CardinalDirection inboundDirection)
+    {
+        Exit = parent;
+        Origin = origin;
+        Destination = destination;
+        InboundDirection = inboundDirection;
+        OutboundDirection = outboundDirection;
+        _keywords = new Lazy<List<string>>(() => new List<string> { OutboundDirection.Describe().ToLowerInvariant() });
+    }
+
     public override string ToString()
     {
         return $"CellExit {OutboundDirection.Describe()} to {Destination.Name} ({Destination.Id:N0})";

--- a/MudSharpCore/Construction/Boundary/ExitManager.cs
+++ b/MudSharpCore/Construction/Boundary/ExitManager.cs
@@ -11,6 +11,8 @@ public class ExitManager : IExitManager, IHaveFuturemud
     protected readonly CollectionDictionary<(ICell Cell, ICellOverlay Overlay), IExit> CellExitDictionary =
         new();
 
+    protected readonly CollectionDictionary<ICell, IExit> TransientExitDictionary = new();
+
     protected readonly DictionaryWithDefault<long, IExit> MasterExitList = new();
 
     public ExitManager(IFuturemud gameworld)
@@ -86,9 +88,10 @@ public class ExitManager : IExitManager, IHaveFuturemud
         InitialiseCell(cell, overlay);
 
         IExit exit =
-            CellExitDictionary[(cell, overlay)].Where(x => overlay.ExitIDs.Contains(x.Id))
-                                                           .FirstOrDefault(x =>
-                                                               x.CellExitFor(cell).OutboundDirection == direction);
+            CellExitDictionary[(cell, overlay)]
+                .Where(x => overlay.ExitIDs.Contains(x.Id))
+                .Concat(TransientExitDictionary[cell])
+                .FirstOrDefault(x => x.CellExitFor(cell).OutboundDirection == direction);
         ICellExit cellExit = exit?.CellExitFor(cell);
         if (cellExit?.MovementTransition(voyeur).TransitionType ==
             CellMovementTransition.NoViableTransition)
@@ -113,7 +116,9 @@ public class ExitManager : IExitManager, IHaveFuturemud
 
         List<IExit> exits =
             CellExitDictionary[(cell, overlay)]
-                .Where(x => overlay.ExitIDs.Contains(x.Id) && x.IsExit(cell, verb) && voyeur.CanSee(x))
+                .Where(x => overlay.ExitIDs.Contains(x.Id))
+                .Concat(TransientExitDictionary[cell])
+                .Where(x => x.IsExit(cell, verb) && voyeur.CanSee(x))
                 .OrderBy(x => x.CellExitFor(cell).OutboundDirection.ExitCommandPriority())
                 .ToList();
         ICellExit exit = null;
@@ -148,7 +153,9 @@ public class ExitManager : IExitManager, IHaveFuturemud
 
         List<IExit> exits =
             CellExitDictionary[(cell, overlay)]
-                .Where(x => overlay.ExitIDs.Contains(x.Id) && x.IsExitKeyword(cell, keyword) && voyeur.CanSee(x))
+                .Where(x => overlay.ExitIDs.Contains(x.Id))
+                .Concat(TransientExitDictionary[cell])
+                .Where(x => x.IsExitKeyword(cell, keyword) && voyeur.CanSee(x))
                 .OrderBy(x => x.CellExitFor(cell).OutboundDirection.ExitCommandPriority())
                 .ToList();
         ICellExit cellExit = exits.FirstOrDefault()?.CellExitFor(cell);
@@ -173,6 +180,7 @@ public class ExitManager : IExitManager, IHaveFuturemud
         return
             CellExitDictionary[(cell, overlay)]
                 .Where(x => overlay.ExitIDs.Contains(x.Id))
+                .Concat(TransientExitDictionary[cell])
                 .Select(x => x.CellExitFor(cell))
                 .Where(x => layer == null || x.WhichLayersExitAppears().Contains(layer.Value))
                 .ToList();
@@ -196,6 +204,7 @@ public class ExitManager : IExitManager, IHaveFuturemud
 
         return
             CellExitDictionary[(cell, overlay)].Where(x => overlay.ExitIDs.Contains(x.Id))
+                                                           .Concat(TransientExitDictionary[cell])
                                                            .Select(x => x.CellExitFor(cell))
                                                            .Where(x => layer == null || x.WhichLayersExitAppears()
                                                                .Contains(layer.Value))
@@ -225,13 +234,44 @@ public class ExitManager : IExitManager, IHaveFuturemud
         return
             CellExitDictionary.Where(x => x.Key.Item1 == cell)
                               .SelectMany(x => x.Value)
+                              .Concat(TransientExitDictionary[cell])
                               .Distinct()
                               .Select(x => x.CellExitFor(cell));
     }
 
     public IExit GetExitByID(long id)
     {
-        return MasterExitList.GetValueOrDefault(id);
+        return MasterExitList.GetValueOrDefault(id) ??
+               TransientExitDictionary.SelectMany(x => x.Value).FirstOrDefault(x => x.Id == id);
+    }
+
+    public void RegisterTransientExit(IExit exit)
+    {
+        if (exit is null)
+        {
+            return;
+        }
+
+        foreach (var cell in exit.Cells)
+        {
+            if (!TransientExitDictionary[cell].Contains(exit))
+            {
+                TransientExitDictionary.Add(cell, exit);
+            }
+        }
+    }
+
+    public void UnregisterTransientExit(IExit exit)
+    {
+        if (exit is null)
+        {
+            return;
+        }
+
+        foreach (var cell in exit.Cells)
+        {
+            TransientExitDictionary.Remove(cell, exit);
+        }
     }
 
     public void UpdateCellOverlayExits(ICell cell, ICellOverlay overlay)

--- a/MudSharpCore/Construction/Boundary/NonCardinalCellExit.cs
+++ b/MudSharpCore/Construction/Boundary/NonCardinalCellExit.cs
@@ -34,6 +34,20 @@ public class NonCardinalCellExit : CellExit, INonCardinalCellExit
         PrimaryKeyword = exit.PrimaryKeyword;
     }
 
+    public NonCardinalCellExit(IExit parent, ICell origin, ICell destination, string verb, string primaryKeyword,
+        IEnumerable<string> keywords, string outboundDescription, string outboundTarget, string inboundDescription,
+        string inboundTarget)
+        : base(parent, origin, destination, CardinalDirection.Unknown, CardinalDirection.Unknown)
+    {
+        InboundDescription = inboundDescription;
+        InboundTarget = inboundTarget;
+        OutboundDescription = outboundDescription;
+        OutboundTarget = outboundTarget;
+        Verb = verb;
+        PrimaryKeyword = primaryKeyword;
+        _keywords = new Lazy<List<string>>(() => keywords.Distinct(StringComparer.InvariantCultureIgnoreCase).ToList());
+    }
+
     public override string ToString()
     {
         return $"NonCardinalCellExit {OutboundMovementSuffix} to {Destination.Name} ({Destination.Id:N0})";

--- a/MudSharpCore/Construction/Boundary/TransientExit.cs
+++ b/MudSharpCore/Construction/Boundary/TransientExit.cs
@@ -1,0 +1,138 @@
+#nullable enable
+
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.PerceptionEngine;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace MudSharp.Construction.Boundary;
+
+public class TransientExit : PerceivedItem, IExit
+{
+	private static long _nextId;
+	private readonly List<ICell> _cells = new();
+	private readonly ICellExit[] _cellExits = new ICellExit[2];
+	private readonly List<RoomLayer> _blockedLayers = new();
+
+	public TransientExit(IFuturemud gameworld, ICell origin, ICell destination, string verb, string outboundKeyword,
+		string inboundKeyword, string outboundTarget, string inboundTarget, string outboundDescription,
+		string inboundDescription, double timeMultiplier)
+	{
+		Gameworld = gameworld;
+		_id = Interlocked.Decrement(ref _nextId);
+		IdInitialised = true;
+		_name = $"transient portal {Math.Abs(_id):N0}";
+		_cells.Add(origin);
+		_cells.Add(destination);
+		TimeMultiplier = timeMultiplier;
+		MaximumSizeToEnter = SizeCategory.Titanic;
+		MaximumSizeToEnterUpright = SizeCategory.Titanic;
+		AcceptsDoor = false;
+		ClimbDifficulty = Difficulty.Normal;
+
+		var outboundKeywords = KeywordsFor(outboundTarget, outboundKeyword);
+		var inboundKeywords = KeywordsFor(inboundTarget, inboundKeyword);
+		_cellExits[0] = new NonCardinalCellExit(this, origin, destination, verb, outboundKeyword, outboundKeywords,
+			outboundDescription, outboundTarget, inboundDescription, inboundTarget);
+		_cellExits[1] = new NonCardinalCellExit(this, destination, origin, verb, inboundKeyword, inboundKeywords,
+			outboundDescription, inboundTarget, inboundDescription, outboundTarget);
+	}
+
+	private static IEnumerable<string> KeywordsFor(string target, string keyword)
+	{
+		return target
+			.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+			.Select(x => x.Trim().ToLowerInvariant())
+			.Where(x => x.Length > 1 && x != "a" && x != "an" && x != "the")
+			.Concat([keyword.ToLowerInvariant()])
+			.Distinct(StringComparer.InvariantCultureIgnoreCase);
+	}
+
+	public override string FrameworkItemType => "TransientExit";
+	public override ICell Location => _cellExits[0].Origin;
+	public override ProgVariableTypes Type => ProgVariableTypes.Error;
+
+	public bool AcceptsDoor { get; set; }
+	public SizeCategory DoorSize { get; set; }
+	public IDoor? Door { get; set; }
+	public double TimeMultiplier { get; set; }
+	public SizeCategory MaximumSizeToEnterUpright { get; set; }
+	public SizeCategory MaximumSizeToEnter { get; set; }
+	public IEnumerable<ICell> Cells => _cells;
+	public ICell? FallCell { get; set; }
+	public bool IsClimbExit { get; set; }
+	public Difficulty ClimbDifficulty { get; set; }
+	public IEnumerable<RoomLayer> BlockedLayers => _blockedLayers;
+
+	public ICellExit? CellExitFor(ICell cell)
+	{
+		return _cellExits.FirstOrDefault(x => ReferenceEquals(x.Origin, cell) || x.Origin.Id == cell.Id);
+	}
+
+	public ICell? Opposite(ICell cell)
+	{
+		return CellExitFor(cell)?.Destination;
+	}
+
+	public bool IsExit(ICell cell, string verb)
+	{
+		return CellExitFor(cell)?.IsExit(verb) == true;
+	}
+
+	public bool IsExitKeyword(ICell cell, string keyword)
+	{
+		return CellExitFor(cell)?.IsExitKeyword(keyword) == true;
+	}
+
+	public IExit Clone()
+	{
+		throw new NotSupportedException("Transient exits cannot be cloned.");
+	}
+
+	public void PostLoadTasks(MudSharp.Models.Exit exit)
+	{
+	}
+
+	public void AddBlockedLayer(RoomLayer layer)
+	{
+		if (!_blockedLayers.Contains(layer))
+		{
+			_blockedLayers.Add(layer);
+		}
+	}
+
+	public void RemoveBlockedLayer(RoomLayer layer)
+	{
+		_blockedLayers.Remove(layer);
+	}
+
+	public void Delete()
+	{
+		Gameworld.ExitManager.UnregisterTransientExit(this);
+	}
+
+	public override void Register(IOutputHandler handler)
+	{
+	}
+
+	public override object DatabaseInsert()
+	{
+		throw new NotSupportedException("Transient exits are never saved to the database.");
+	}
+
+	public override void SetIDFromDatabase(object dbitem)
+	{
+		throw new NotSupportedException("Transient exits do not load database IDs.");
+	}
+
+	public override void Save()
+	{
+		Changed = false;
+	}
+}

--- a/MudSharpCore/Effects/Concrete/SpellEffects/SpellCorpsePreservationEffect.cs
+++ b/MudSharpCore/Effects/Concrete/SpellEffects/SpellCorpsePreservationEffect.cs
@@ -1,0 +1,34 @@
+#nullable enable
+
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using System.Xml.Linq;
+
+namespace MudSharp.Effects.Concrete.SpellEffects;
+
+public class SpellCorpsePreservationEffect : SimpleSpellStatusEffectBase, ICorpsePreservationEffect
+{
+	public static void InitialiseEffectType()
+	{
+		RegisterFactory("SpellCorpsePreservation", (effect, owner) => new SpellCorpsePreservationEffect(effect, owner));
+	}
+
+	public SpellCorpsePreservationEffect(IPerceivable owner, IMagicSpellEffectParent parent, IFutureProg? prog = null)
+		: base(owner, parent, prog)
+	{
+	}
+
+	private SpellCorpsePreservationEffect(XElement root, IPerceivable owner) : base(root, owner)
+	{
+	}
+
+	public bool PreserveCorpse => true;
+
+	public override string Describe(IPerceiver voyeur)
+	{
+		return "Magically preserved from corpse decay.";
+	}
+
+	protected override string SpecificEffectType => "SpellCorpsePreservation";
+}

--- a/MudSharpCore/Effects/Concrete/SpellEffects/SpellItemEnchantmentEffect.cs
+++ b/MudSharpCore/Effects/Concrete/SpellEffects/SpellItemEnchantmentEffect.cs
@@ -1,0 +1,151 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.GameItems;
+using MudSharp.Health;
+using System;
+using System.Collections.Generic;
+using System.Xml.Linq;
+
+namespace MudSharp.Effects.Concrete.SpellEffects;
+
+public class SpellItemEnchantmentEffect : MagicSpellEffectBase, IDescriptionAdditionEffect, ISDescAdditionEffect,
+	IProduceIllumination, IMagicWeaponEnhancementEffect, IMagicArmourEnhancementEffect
+{
+	public static void InitialiseEffectType()
+	{
+		RegisterFactory("SpellItemEnchantment", (effect, owner) => new SpellItemEnchantmentEffect(effect, owner));
+	}
+
+	public SpellItemEnchantmentEffect(IPerceivable owner, IMagicSpellEffectParent parent, string sdescAddendum,
+		string descAddendum, ANSIColour colour, double glowLux, double attackCheckBonus, double qualityBonus,
+		double damageBonus, double painBonus, double stunBonus, double armourDamageReduction, IFutureProg? prog = null)
+		: base(owner, parent, prog)
+	{
+		SDescAddendum = sdescAddendum;
+		DescAddendum = descAddendum;
+		GlowAddendumColour = colour;
+		ProvidedLux = glowLux;
+		AttackCheckBonus = attackCheckBonus;
+		QualityBonus = qualityBonus;
+		DamageBonus = damageBonus;
+		PainBonus = painBonus;
+		StunBonus = stunBonus;
+		ArmourDamageReduction = armourDamageReduction;
+	}
+
+	private SpellItemEnchantmentEffect(XElement root, IPerceivable owner) : base(root, owner)
+	{
+		var trueRoot = root.Element("Effect");
+		SDescAddendum = trueRoot?.Element("SDescAddendum")?.Value ?? string.Empty;
+		DescAddendum = trueRoot?.Element("DescAddendum")?.Value ?? string.Empty;
+		GlowAddendumColour = Telnet.GetColour(trueRoot?.Element("Colour")?.Value ?? "bold magenta") ?? Telnet.BoldMagenta;
+		ProvidedLux = double.Parse(trueRoot?.Element("GlowLux")?.Value ?? "0");
+		AttackCheckBonus = double.Parse(trueRoot?.Element("AttackCheckBonus")?.Value ?? "0");
+		QualityBonus = double.Parse(trueRoot?.Element("QualityBonus")?.Value ?? "0");
+		DamageBonus = double.Parse(trueRoot?.Element("DamageBonus")?.Value ?? "0");
+		PainBonus = double.Parse(trueRoot?.Element("PainBonus")?.Value ?? "0");
+		StunBonus = double.Parse(trueRoot?.Element("StunBonus")?.Value ?? "0");
+		ArmourDamageReduction = double.Parse(trueRoot?.Element("ArmourDamageReduction")?.Value ?? "0");
+	}
+
+	public string SDescAddendum { get; }
+	public string DescAddendum { get; }
+	public ANSIColour GlowAddendumColour { get; }
+	public double ProvidedLux { get; }
+	public double AttackCheckBonus { get; }
+	public double QualityBonus { get; }
+	public double DamageBonus { get; }
+	public double PainBonus { get; }
+	public double StunBonus { get; }
+	public double ArmourDamageReduction { get; }
+
+	protected override XElement SaveDefinition()
+	{
+		return new XElement("Effect",
+			new XElement("ApplicabilityProg", ApplicabilityProg?.Id ?? 0),
+			new XElement("SDescAddendum", new XCData(SDescAddendum)),
+			new XElement("DescAddendum", new XCData(DescAddendum)),
+			new XElement("Colour", GlowAddendumColour.Name),
+			new XElement("GlowLux", ProvidedLux),
+			new XElement("AttackCheckBonus", AttackCheckBonus),
+			new XElement("QualityBonus", QualityBonus),
+			new XElement("DamageBonus", DamageBonus),
+			new XElement("PainBonus", PainBonus),
+			new XElement("StunBonus", StunBonus),
+			new XElement("ArmourDamageReduction", ArmourDamageReduction)
+		);
+	}
+
+	public string AddendumText => SDescAddendum;
+
+	public string GetAddendumText(bool colour)
+	{
+		return colour ? SDescAddendum.Colour(GlowAddendumColour) : SDescAddendum;
+	}
+
+	public string GetAdditionalText(IPerceiver voyeur, bool colour)
+	{
+		return colour ? DescAddendum.Colour(GlowAddendumColour) : DescAddendum;
+	}
+
+	public bool PlayerSet => false;
+
+	public bool AppliesToWeaponAttack(ICharacter attacker, IPerceivable target, IGameItem weapon)
+	{
+		return ReferenceEquals(Owner, weapon) &&
+		       (ApplicabilityProg?.ExecuteBool(weapon, attacker, target) ?? true);
+	}
+
+	public IDamage SufferDamage(IDamage damage, ref List<IWound> wounds)
+	{
+		return ReduceDamage(damage);
+	}
+
+	public IDamage PassiveSufferDamage(IDamage damage, ref List<IWound> wounds)
+	{
+		return ReduceDamage(damage);
+	}
+
+	public void ProcessPassiveWound(IWound wound)
+	{
+	}
+
+	private IDamage ReduceDamage(IDamage damage)
+	{
+		if (damage is null)
+		{
+			return null!;
+		}
+
+		if (ArmourDamageReduction <= 0.0)
+		{
+			return damage;
+		}
+
+		var reducedDamage = Math.Max(0.0, damage.DamageAmount - ArmourDamageReduction);
+		var reducedPain = Math.Max(0.0, damage.PainAmount - ArmourDamageReduction);
+		var reducedStun = Math.Max(0.0, damage.StunAmount - ArmourDamageReduction);
+		if (reducedDamage <= 0.0 && reducedPain <= 0.0 && reducedStun <= 0.0)
+		{
+			return null!;
+		}
+
+		return new Damage(damage)
+		{
+			DamageAmount = reducedDamage,
+			PainAmount = reducedPain,
+			StunAmount = reducedStun
+		};
+	}
+
+	public override string Describe(IPerceiver voyeur)
+	{
+		return "Magically enchanted item.";
+	}
+
+	protected override string SpecificEffectType => "SpellItemEnchantment";
+}

--- a/MudSharpCore/Effects/Concrete/SpellEffects/SpellMagicTagEffect.cs
+++ b/MudSharpCore/Effects/Concrete/SpellEffects/SpellMagicTagEffect.cs
@@ -1,0 +1,50 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using System.Xml.Linq;
+
+namespace MudSharp.Effects.Concrete.SpellEffects;
+
+public class SpellMagicTagEffect : SimpleSpellStatusEffectBase, IMagicTagEffect
+{
+	public static void InitialiseEffectType()
+	{
+		RegisterFactory("SpellMagicTag", (effect, owner) => new SpellMagicTagEffect(effect, owner));
+	}
+
+	public SpellMagicTagEffect(IPerceivable owner, IMagicSpellEffectParent parent, string tag, string value,
+		IFutureProg? prog = null) : base(owner, parent, prog)
+	{
+		Tag = tag.Trim();
+		Value = value;
+	}
+
+	private SpellMagicTagEffect(XElement root, IPerceivable owner) : base(root, owner)
+	{
+		var trueRoot = root.Element("Effect");
+		Tag = trueRoot?.Element("Tag")?.Value ?? string.Empty;
+		Value = trueRoot?.Element("Value")?.Value ?? string.Empty;
+	}
+
+	public string Tag { get; }
+	public string Value { get; }
+	public ICharacter? Caster => ParentEffect?.Caster;
+
+	protected override XElement SaveDefinition()
+	{
+		return SimpleSaveDefinition(
+			new XElement("Tag", new XCData(Tag)),
+			new XElement("Value", new XCData(Value))
+		);
+	}
+
+	public override string Describe(IPerceiver voyeur)
+	{
+		return $"Magic tag {Tag.ColourName()} = {Value.ColourValue()}";
+	}
+
+	protected override string SpecificEffectType => "SpellMagicTag";
+}

--- a/MudSharpCore/Effects/Concrete/SpellEffects/SpellPortalEffect.cs
+++ b/MudSharpCore/Effects/Concrete/SpellEffects/SpellPortalEffect.cs
@@ -1,0 +1,134 @@
+#nullable enable
+
+using MudSharp.Construction;
+using MudSharp.Construction.Boundary;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.Magic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace MudSharp.Effects.Concrete.SpellEffects;
+
+public class SpellPortalEffect : MagicSpellEffectBase
+{
+	private IExit? _registeredExit;
+
+	public static void InitialiseEffectType()
+	{
+		RegisterFactory("SpellPortal", (effect, owner) => new SpellPortalEffect(effect, owner));
+	}
+
+	public SpellPortalEffect(IPerceivable owner, IMagicSpellEffectParent parent, ICell source, ICell destination,
+		string verb, string outboundKeyword, string inboundKeyword, string outboundTarget, string inboundTarget,
+		string outboundDescription, string inboundDescription, double timeMultiplier, IFutureProg? prog = null)
+		: base(owner, parent, prog)
+	{
+		SourceCellId = source.Id;
+		DestinationCellId = destination.Id;
+		Verb = verb;
+		OutboundKeyword = outboundKeyword;
+		InboundKeyword = inboundKeyword;
+		OutboundTarget = outboundTarget;
+		InboundTarget = inboundTarget;
+		OutboundDescription = outboundDescription;
+		InboundDescription = inboundDescription;
+		TimeMultiplier = timeMultiplier;
+	}
+
+	private SpellPortalEffect(XElement root, IPerceivable owner) : base(root, owner)
+	{
+		var trueRoot = root.Element("Effect");
+		SourceCellId = long.Parse(trueRoot?.Element("SourceCell")?.Value ?? "0");
+		DestinationCellId = long.Parse(trueRoot?.Element("DestinationCell")?.Value ?? "0");
+		Verb = trueRoot?.Element("Verb")?.Value ?? "enter";
+		OutboundKeyword = trueRoot?.Element("OutboundKeyword")?.Value ?? "portal";
+		InboundKeyword = trueRoot?.Element("InboundKeyword")?.Value ?? "portal";
+		OutboundTarget = trueRoot?.Element("OutboundTarget")?.Value ?? "a shimmering portal";
+		InboundTarget = trueRoot?.Element("InboundTarget")?.Value ?? "a shimmering portal";
+		OutboundDescription = trueRoot?.Element("OutboundDescription")?.Value ?? "through";
+		InboundDescription = trueRoot?.Element("InboundDescription")?.Value ?? "through";
+		TimeMultiplier = double.Parse(trueRoot?.Element("TimeMultiplier")?.Value ?? "1.0");
+	}
+
+	public long SourceCellId { get; }
+	public long DestinationCellId { get; }
+	public string Verb { get; }
+	public string OutboundKeyword { get; }
+	public string InboundKeyword { get; }
+	public string OutboundTarget { get; }
+	public string InboundTarget { get; }
+	public string OutboundDescription { get; }
+	public string InboundDescription { get; }
+	public double TimeMultiplier { get; }
+
+	private ICell? SourceCell => Gameworld.Cells.Get(SourceCellId);
+	private ICell? DestinationCell => Gameworld.Cells.Get(DestinationCellId);
+
+	public override void InitialEffect()
+	{
+		base.InitialEffect();
+		RegisterPortal();
+	}
+
+	public override void Login()
+	{
+		base.Login();
+		RegisterPortal();
+	}
+
+	private void RegisterPortal()
+	{
+		if (_registeredExit is not null)
+		{
+			return;
+		}
+
+		var source = SourceCell;
+		var destination = DestinationCell;
+		if (source is null || destination is null)
+		{
+			return;
+		}
+
+		_registeredExit = new TransientExit(Gameworld, source, destination, Verb, OutboundKeyword, InboundKeyword,
+			OutboundTarget, InboundTarget, OutboundDescription, InboundDescription, TimeMultiplier);
+		Gameworld.ExitManager.RegisterTransientExit(_registeredExit);
+	}
+
+	public override void RemovalEffect()
+	{
+		if (_registeredExit is not null)
+		{
+			Gameworld.ExitManager.UnregisterTransientExit(_registeredExit);
+			_registeredExit = null;
+		}
+
+		base.RemovalEffect();
+	}
+
+	protected override XElement SaveDefinition()
+	{
+		return new XElement("Effect",
+			new XElement("ApplicabilityProg", ApplicabilityProg?.Id ?? 0),
+			new XElement("SourceCell", SourceCellId),
+			new XElement("DestinationCell", DestinationCellId),
+			new XElement("Verb", new XCData(Verb)),
+			new XElement("OutboundKeyword", new XCData(OutboundKeyword)),
+			new XElement("InboundKeyword", new XCData(InboundKeyword)),
+			new XElement("OutboundTarget", new XCData(OutboundTarget)),
+			new XElement("InboundTarget", new XCData(InboundTarget)),
+			new XElement("OutboundDescription", new XCData(OutboundDescription)),
+			new XElement("InboundDescription", new XCData(InboundDescription)),
+			new XElement("TimeMultiplier", TimeMultiplier)
+		);
+	}
+
+	public override string Describe(IPerceiver voyeur)
+	{
+		return $"Maintaining a magical portal from room #{SourceCellId:N0} to room #{DestinationCellId:N0}.";
+	}
+
+	protected override string SpecificEffectType => "SpellPortal";
+}

--- a/MudSharpCore/Effects/Concrete/SpellEffects/SpellSubjectiveDescriptionEffect.cs
+++ b/MudSharpCore/Effects/Concrete/SpellEffects/SpellSubjectiveDescriptionEffect.cs
@@ -1,0 +1,68 @@
+#nullable enable
+
+using MudSharp.Effects.Interfaces;
+using MudSharp.Form.Shape;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using System.Xml.Linq;
+
+namespace MudSharp.Effects.Concrete.SpellEffects;
+
+public class SpellSubjectiveDescriptionEffect : MagicSpellEffectBase, IOverrideDescEffect
+{
+	public static void InitialiseEffectType()
+	{
+		RegisterFactory("SpellSubjectiveDescription",
+			(effect, owner) => new SpellSubjectiveDescriptionEffect(effect, owner));
+	}
+
+	public SpellSubjectiveDescriptionEffect(IPerceivable owner, IMagicSpellEffectParent parent,
+		DescriptionType descriptionType, string description, long fixedPerceiverId, IFutureProg? prog = null)
+		: base(owner, parent, prog)
+	{
+		DescriptionType = descriptionType;
+		DescriptionText = description;
+		FixedPerceiverId = fixedPerceiverId;
+	}
+
+	private SpellSubjectiveDescriptionEffect(XElement root, IPerceivable owner) : base(root, owner)
+	{
+		var trueRoot = root.Element("Effect");
+		DescriptionType = (DescriptionType)int.Parse(trueRoot?.Element("DescriptionType")?.Value ?? "0");
+		DescriptionText = trueRoot?.Element("Description")?.Value ?? string.Empty;
+		FixedPerceiverId = long.Parse(trueRoot?.Element("FixedPerceiver")?.Value ?? "0");
+	}
+
+	public DescriptionType DescriptionType { get; }
+	public string DescriptionText { get; }
+	public long FixedPerceiverId { get; }
+
+	protected override XElement SaveDefinition()
+	{
+		return new XElement("Effect",
+			new XElement("ApplicabilityProg", ApplicabilityProg?.Id ?? 0),
+			new XElement("DescriptionType", (int)DescriptionType),
+			new XElement("Description", new XCData(DescriptionText)),
+			new XElement("FixedPerceiver", FixedPerceiverId)
+		);
+	}
+
+	public bool OverrideApplies(IPerceiver voyeur, DescriptionType type)
+	{
+		return type == DescriptionType &&
+		       (FixedPerceiverId == 0 || voyeur?.Id == FixedPerceiverId) &&
+		       Applies(voyeur);
+	}
+
+	public string Description(DescriptionType type, bool colour)
+	{
+		return DescriptionText;
+	}
+
+	public override string Describe(IPerceiver voyeur)
+	{
+		return $"Magically overridden {DescriptionType.DescribeEnum().ToLowerInvariant()} description.";
+	}
+
+	protected override string SpecificEffectType => "SpellSubjectiveDescription";
+}

--- a/MudSharpCore/FutureProg/Functions/Magic/MagicTagFunctions.cs
+++ b/MudSharpCore/FutureProg/Functions/Magic/MagicTagFunctions.cs
@@ -1,0 +1,162 @@
+#nullable enable
+
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.FutureProg.Variables;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MudSharp.FutureProg.Functions.Magic;
+
+internal abstract class MagicTagFunctionBase : BuiltInFunction
+{
+	protected MagicTagFunctionBase(IList<IFunction> parameterFunctions) : base(parameterFunctions)
+	{
+	}
+
+	protected static IEnumerable<IMagicTagEffect> TagsFor(IPerceivable? perceivable)
+	{
+		return perceivable?.EffectsOfType<IMagicTagEffect>(x => x.Applies()) ?? [];
+	}
+}
+
+internal class HasMagicTagFunction : MagicTagFunctionBase
+{
+	public static void RegisterFunctionCompiler()
+	{
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			"hasmagictag",
+			new[] { ProgVariableTypes.Perceivable, ProgVariableTypes.Text },
+			(pars, _) => new HasMagicTagFunction(pars),
+			new[] { "perceivable", "tag" },
+			new[] { "The perceivable to inspect", "The magic tag key" },
+			"Returns true if the perceivable has an active magic tag with the specified key.",
+			"Magic",
+			ProgVariableTypes.Boolean));
+	}
+
+	private HasMagicTagFunction(IList<IFunction> parameterFunctions) : base(parameterFunctions)
+	{
+	}
+
+	public override ProgVariableTypes ReturnType { get => ProgVariableTypes.Boolean; protected set { } }
+
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		if (base.Execute(variables) == StatementResult.Error)
+		{
+			return StatementResult.Error;
+		}
+
+		var perceivable = ParameterFunctions[0].Result?.GetObject as IPerceivable;
+		var tag = ParameterFunctions[1].Result?.GetObject?.ToString() ?? string.Empty;
+		Result = new BooleanVariable(TagsFor(perceivable).Any(x => x.Tag.EqualTo(tag)));
+		return StatementResult.Normal;
+	}
+}
+
+internal class MagicTagValueFunction : MagicTagFunctionBase
+{
+	public static void RegisterFunctionCompiler()
+	{
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			"magictagvalue",
+			new[] { ProgVariableTypes.Perceivable, ProgVariableTypes.Text },
+			(pars, _) => new MagicTagValueFunction(pars),
+			new[] { "perceivable", "tag" },
+			new[] { "The perceivable to inspect", "The magic tag key" },
+			"Returns the first active magic tag value for the specified key, or empty text.",
+			"Magic",
+			ProgVariableTypes.Text));
+	}
+
+	private MagicTagValueFunction(IList<IFunction> parameterFunctions) : base(parameterFunctions)
+	{
+	}
+
+	public override ProgVariableTypes ReturnType { get => ProgVariableTypes.Text; protected set { } }
+
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		if (base.Execute(variables) == StatementResult.Error)
+		{
+			return StatementResult.Error;
+		}
+
+		var perceivable = ParameterFunctions[0].Result?.GetObject as IPerceivable;
+		var tag = ParameterFunctions[1].Result?.GetObject?.ToString() ?? string.Empty;
+		Result = new TextVariable(TagsFor(perceivable).FirstOrDefault(x => x.Tag.EqualTo(tag))?.Value ?? string.Empty);
+		return StatementResult.Normal;
+	}
+}
+
+internal class MagicTagValuesFunction : MagicTagFunctionBase
+{
+	public static void RegisterFunctionCompiler()
+	{
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			"magictagvalues",
+			new[] { ProgVariableTypes.Perceivable, ProgVariableTypes.Text },
+			(pars, _) => new MagicTagValuesFunction(pars),
+			new[] { "perceivable", "tag" },
+			new[] { "The perceivable to inspect", "The magic tag key" },
+			"Returns all active magic tag values for the specified key.",
+			"Magic",
+			ProgVariableTypes.Collection | ProgVariableTypes.Text));
+	}
+
+	private MagicTagValuesFunction(IList<IFunction> parameterFunctions) : base(parameterFunctions)
+	{
+	}
+
+	public override ProgVariableTypes ReturnType { get => ProgVariableTypes.Collection | ProgVariableTypes.Text; protected set { } }
+
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		if (base.Execute(variables) == StatementResult.Error)
+		{
+			return StatementResult.Error;
+		}
+
+		var perceivable = ParameterFunctions[0].Result?.GetObject as IPerceivable;
+		var tag = ParameterFunctions[1].Result?.GetObject?.ToString() ?? string.Empty;
+		Result = new CollectionVariable(TagsFor(perceivable).Where(x => x.Tag.EqualTo(tag)).Select(x => x.Value).ToList(),
+			ProgVariableTypes.Text);
+		return StatementResult.Normal;
+	}
+}
+
+internal class MagicTagsFunction : MagicTagFunctionBase
+{
+	public static void RegisterFunctionCompiler()
+	{
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			"magictags",
+			new[] { ProgVariableTypes.Perceivable },
+			(pars, _) => new MagicTagsFunction(pars),
+			new[] { "perceivable" },
+			new[] { "The perceivable to inspect" },
+			"Returns all active magic tag keys on the perceivable.",
+			"Magic",
+			ProgVariableTypes.Collection | ProgVariableTypes.Text));
+	}
+
+	private MagicTagsFunction(IList<IFunction> parameterFunctions) : base(parameterFunctions)
+	{
+	}
+
+	public override ProgVariableTypes ReturnType { get => ProgVariableTypes.Collection | ProgVariableTypes.Text; protected set { } }
+
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		if (base.Execute(variables) == StatementResult.Error)
+		{
+			return StatementResult.Error;
+		}
+
+		var perceivable = ParameterFunctions[0].Result?.GetObject as IPerceivable;
+		Result = new CollectionVariable(TagsFor(perceivable).Select(x => x.Tag).Distinct().ToList(),
+			ProgVariableTypes.Text);
+		return StatementResult.Normal;
+	}
+}

--- a/MudSharpCore/GameItems/Components/CorpseGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/CorpseGameItemComponent.cs
@@ -3,6 +3,7 @@ using MudSharp.Body;
 using MudSharp.Character;
 using MudSharp.Construction;
 using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
 using MudSharp.Events;
 using MudSharp.Form.Material;
 using MudSharp.Form.Shape;
@@ -166,7 +167,11 @@ public class CorpseGameItemComponent : GameItemComponent, ICorpse, ILazyLoadDuri
 
     private void HeartbeatManagerOnMinuteHeartbeat()
     {
-        // TODO - check for effects that halt or arrest decay
+        if (Parent.AffectedBy<ICorpsePreservationEffect>())
+        {
+            return;
+        }
+
         if (!Parent.TrueLocations.Any())
         {
             Console.WriteLine("Corpse did not have any true location.");

--- a/MudSharpCore/GameItems/GameItemHealth.cs
+++ b/MudSharpCore/GameItems/GameItemHealth.cs
@@ -2,6 +2,7 @@
 using MudSharp.Character;
 using MudSharp.Construction;
 using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
 using MudSharp.Events;
 using MudSharp.Framework;
 using MudSharp.GameItems.Components;
@@ -141,8 +142,14 @@ public partial class GameItem : IHaveWounds
             damage = resistance.SufferDamage(damage, new List<IWound>());
         }
 
-        damage = destroyable?.GetActualDamage(damage) ?? damage;
         List<IWound> wounds = new();
+        damage = ApplyMagicArmourEnhancements(damage, wounds, true);
+        if (damage is null)
+        {
+            return wounds;
+        }
+
+        damage = destroyable?.GetActualDamage(damage) ?? damage;
         List<IWound> newWounds = HealthStrategy.SufferDamage(this, damage, null).ToList();
         foreach (IWound newWound in newWounds.ToArray())
         {
@@ -262,6 +269,7 @@ public partial class GameItem : IHaveWounds
                 List<IDamage> damages = damageToPassOn.ReferenceDamages
                                             .SelectNotNull(x =>
                                                 armour.ArmourType.AbsorbDamage(x, armour, this, ref wounds, true))
+                                            .SelectNotNull(x => ApplyMagicArmourEnhancements(x, wounds, true))
                                             .ToList();
                 damage = new ExplosiveDamage(damages, 0.0, damage.ExplosionSize, damage.MaximumProximity);
                 damageToPassOn = new ExplosiveDamage(damages, 0.0, damage.ExplosionSize, damage.MaximumProximity,
@@ -319,6 +327,7 @@ public partial class GameItem : IHaveWounds
                 List<IDamage> damages = damageToPassOn.ReferenceDamages
                                             .SelectNotNull(x =>
                                                 armour.ArmourType.AbsorbDamage(x, armour, this, ref wounds, true))
+                                            .SelectNotNull(x => ApplyMagicArmourEnhancements(x, wounds, true))
                                             .ToList();
                 damage = new ExplosiveDamage(damages, 0.0, damage.ExplosionSize, damage.MaximumProximity);
                 damageToPassOn = new ExplosiveDamage(damages, 0.0, damage.ExplosionSize, damage.MaximumProximity,
@@ -372,6 +381,22 @@ public partial class GameItem : IHaveWounds
         wounds.ProcessPassiveWounds();
         StartHealthTick();
         return wounds;
+    }
+
+    private IDamage ApplyMagicArmourEnhancements(IDamage damage, List<IWound> wounds, bool passive)
+    {
+        foreach (IMagicArmourEnhancementEffect effect in EffectsOfType<IMagicArmourEnhancementEffect>(x => x.Applies()).ToList())
+        {
+            damage = passive
+                ? effect.PassiveSufferDamage(damage, ref wounds)
+                : effect.SufferDamage(damage, ref wounds);
+            if (damage is null)
+            {
+                return null;
+            }
+        }
+
+        return damage;
     }
 
     public WoundSeverity GetSeverityFor(IWound wound)

--- a/MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs
+++ b/MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs
@@ -1,0 +1,1562 @@
+#nullable enable
+
+using ExpressionEngine;
+using MudSharp.Accounts;
+using MudSharp.Body.Position.PositionStates;
+using MudSharp.Character;
+using MudSharp.Commands;
+using MudSharp.Construction;
+using MudSharp.Effects.Concrete.SpellEffects;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Events;
+using MudSharp.Form.Shape;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.Health;
+using MudSharp.NPC.Templates;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Outputs;
+using MudSharp.PerceptionEngine.Parsers;
+using MudSharp.Planes;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace MudSharp.Magic.SpellEffects;
+
+public class MagicTagEffect : IMagicSpellEffectTemplate
+{
+	public static void RegisterFactory()
+	{
+		SpellEffectFactory.RegisterLoadTimeFactory("magictag", (root, spell) => new MagicTagEffect(root, spell));
+		SpellEffectFactory.RegisterBuilderFactory("magictag", BuilderFactory,
+			"Applies informational magic metadata tags",
+			HelpText,
+			false,
+			true,
+			SpellTriggerFactory.MagicTriggerTypes
+				.Where(x => IsCompatibleWithTrigger(SpellTriggerFactory.BuilderInfoForType(x).TargetTypes))
+				.ToArray());
+	}
+
+	private static (IMagicSpellEffectTemplate Trigger, string Error) BuilderFactory(StringStack commands,
+		IMagicSpell spell)
+	{
+		return (new MagicTagEffect(new XElement("Effect",
+			new XAttribute("type", "magictag"),
+			new XElement("Tag", new XCData("magic")),
+			new XElement("Value", new XCData("")),
+			new XElement("ReplaceExisting", true)
+		), spell), string.Empty);
+	}
+
+	protected MagicTagEffect(XElement root, IMagicSpell spell)
+	{
+		Spell = spell;
+		Tag = root.Element("Tag")?.Value ?? "magic";
+		Value = root.Element("Value")?.Value ?? string.Empty;
+		ReplaceExisting = bool.Parse(root.Element("ReplaceExisting")?.Value ?? "true");
+	}
+
+	public IMagicSpell Spell { get; }
+	public IFuturemud Gameworld => Spell.Gameworld;
+	public string Tag { get; private set; }
+	public string Value { get; private set; }
+	public bool ReplaceExisting { get; private set; }
+
+	public virtual XElement SaveToXml()
+	{
+		return new XElement("Effect",
+			new XAttribute("type", "magictag"),
+			new XElement("Tag", new XCData(Tag)),
+			new XElement("Value", new XCData(Value)),
+			new XElement("ReplaceExisting", ReplaceExisting)
+		);
+	}
+
+	public bool IsInstantaneous => false;
+	public bool RequiresTarget => true;
+
+	public static bool IsCompatibleWithTrigger(string types)
+	{
+		return types is "character" or "characters" or "item" or "items" or "room" or "rooms" or "perceivable" or
+			"perceivables";
+	}
+
+	public virtual bool IsCompatibleWithTrigger(IMagicTrigger types)
+	{
+		return IsCompatibleWithTrigger(types.TargetTypes);
+	}
+
+	public virtual IMagicSpellEffect? GetOrApplyEffect(ICharacter caster, IPerceivable? target, OpposedOutcomeDegree outcome,
+		SpellPower power, IMagicSpellEffectParent parent, SpellAdditionalParameter[] additionalParameters)
+	{
+		if (target is null)
+		{
+			return null;
+		}
+
+		if (ReplaceExisting)
+		{
+			target.RemoveAllEffects<IMagicTagEffect>(x => x.Tag.EqualTo(Tag), true);
+		}
+
+		return new SpellMagicTagEffect(target, parent, Tag, Value);
+	}
+
+	public virtual IMagicSpellEffectTemplate Clone()
+	{
+		return new MagicTagEffect(SaveToXml(), Spell);
+	}
+
+	public const string HelpText = @"You can use the following options with this effect:
+
+	#3tag <key>#0 - sets the tag key
+	#3value <value>#0 - sets the tag value
+	#3replace#0 - toggles replacing existing tags with the same key";
+
+	public bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopSpeech().ToLowerInvariant())
+		{
+			case "tag":
+			case "key":
+				if (command.IsFinished)
+				{
+					actor.OutputHandler.Send("Which magic tag key should this effect apply?");
+					return false;
+				}
+
+				Tag = command.SafeRemainingArgument;
+				Spell.Changed = true;
+				actor.OutputHandler.Send($"This effect will apply the magic tag key {Tag.ColourName()}.");
+				return true;
+			case "value":
+				Value = command.SafeRemainingArgument;
+				Spell.Changed = true;
+				actor.OutputHandler.Send($"This effect will apply the magic tag value {Value.ColourValue()}.");
+				return true;
+			case "replace":
+				ReplaceExisting = !ReplaceExisting;
+				Spell.Changed = true;
+				actor.OutputHandler.Send($"This effect will {ReplaceExisting.NowNoLonger()} replace existing matching tags.");
+				return true;
+		}
+
+		actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
+		return false;
+	}
+
+	public string Show(ICharacter actor)
+	{
+		return $"MagicTag - {Tag.ColourName()} = {Value.ColourValue()} - Replace: {ReplaceExisting.ToColouredString()}";
+	}
+}
+
+public class RemoveMagicTagEffect : IMagicSpellEffectTemplate
+{
+	public static void RegisterFactory()
+	{
+		SpellEffectFactory.RegisterLoadTimeFactory("removemagictag",
+			(root, spell) => new RemoveMagicTagEffect(root, spell));
+		SpellEffectFactory.RegisterBuilderFactory("removemagictag", BuilderFactory,
+			"Removes informational magic metadata tags",
+			HelpText,
+			true,
+			true,
+			SpellTriggerFactory.MagicTriggerTypes
+				.Where(x => MagicTagEffect.IsCompatibleWithTrigger(SpellTriggerFactory.BuilderInfoForType(x).TargetTypes))
+				.ToArray());
+	}
+
+	private static (IMagicSpellEffectTemplate Trigger, string Error) BuilderFactory(StringStack commands,
+		IMagicSpell spell)
+	{
+		return (new RemoveMagicTagEffect(new XElement("Effect",
+			new XAttribute("type", "removemagictag"),
+			new XElement("Tag", new XCData("magic")),
+			new XElement("Value", new XCData("")),
+			new XElement("MatchValue", false)
+		), spell), string.Empty);
+	}
+
+	protected RemoveMagicTagEffect(XElement root, IMagicSpell spell)
+	{
+		Spell = spell;
+		Tag = root.Element("Tag")?.Value ?? "magic";
+		Value = root.Element("Value")?.Value ?? string.Empty;
+		MatchValue = bool.Parse(root.Element("MatchValue")?.Value ?? "false");
+	}
+
+	public IMagicSpell Spell { get; }
+	public IFuturemud Gameworld => Spell.Gameworld;
+	public string Tag { get; private set; }
+	public string Value { get; private set; }
+	public bool MatchValue { get; private set; }
+
+	public XElement SaveToXml()
+	{
+		return new XElement("Effect",
+			new XAttribute("type", "removemagictag"),
+			new XElement("Tag", new XCData(Tag)),
+			new XElement("Value", new XCData(Value)),
+			new XElement("MatchValue", MatchValue)
+		);
+	}
+
+	public bool IsInstantaneous => true;
+	public bool RequiresTarget => true;
+
+	public bool IsCompatibleWithTrigger(IMagicTrigger types)
+	{
+		return MagicTagEffect.IsCompatibleWithTrigger(types.TargetTypes);
+	}
+
+	public IMagicSpellEffect? GetOrApplyEffect(ICharacter caster, IPerceivable? target, OpposedOutcomeDegree outcome,
+		SpellPower power, IMagicSpellEffectParent parent, SpellAdditionalParameter[] additionalParameters)
+	{
+		if (target is null)
+		{
+			return null;
+		}
+
+		target.RemoveAllEffects<IMagicTagEffect>(x =>
+			x.Tag.EqualTo(Tag) && (!MatchValue || x.Value.EqualTo(Value)), true);
+		return null;
+	}
+
+	public IMagicSpellEffectTemplate Clone()
+	{
+		return new RemoveMagicTagEffect(SaveToXml(), Spell);
+	}
+
+	public const string HelpText = @"You can use the following options with this effect:
+
+	#3tag <key>#0 - sets the tag key
+	#3value <value>#0 - sets the optional value match
+	#3matchvalue#0 - toggles requiring the value to match too";
+
+	public bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopSpeech().ToLowerInvariant())
+		{
+			case "tag":
+			case "key":
+				Tag = command.SafeRemainingArgument;
+				Spell.Changed = true;
+				actor.OutputHandler.Send($"This effect will remove magic tags with key {Tag.ColourName()}.");
+				return true;
+			case "value":
+				Value = command.SafeRemainingArgument;
+				Spell.Changed = true;
+				actor.OutputHandler.Send($"This effect will match the magic tag value {Value.ColourValue()}.");
+				return true;
+			case "matchvalue":
+				MatchValue = !MatchValue;
+				Spell.Changed = true;
+				actor.OutputHandler.Send($"This effect will {MatchValue.NowNoLonger()} require the value to match.");
+				return true;
+		}
+
+		actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
+		return false;
+	}
+
+	public string Show(ICharacter actor)
+	{
+		return $"RemoveMagicTag - {Tag.ColourName()} - Value: {(MatchValue ? Value.ColourValue() : "any".ColourValue())}";
+	}
+}
+
+public class ItemDamageEffect : IMagicSpellEffectTemplate
+{
+	public static void RegisterFactory()
+	{
+		SpellEffectFactory.RegisterLoadTimeFactory("itemdamage", (root, spell) => new ItemDamageEffect(root, spell));
+		SpellEffectFactory.RegisterBuilderFactory("itemdamage", BuilderFactory,
+			"Inflicts normal item damage on target items",
+			HelpText,
+			true,
+			true,
+			SpellTriggerFactory.MagicTriggerTypes
+				.Where(x => IsCompatibleWithTrigger(SpellTriggerFactory.BuilderInfoForType(x).TargetTypes))
+				.ToArray());
+	}
+
+	private static (IMagicSpellEffectTemplate Trigger, string Error) BuilderFactory(StringStack commands,
+		IMagicSpell spell)
+	{
+		return (new ItemDamageEffect(new XElement("Effect",
+			new XAttribute("type", "itemdamage"),
+			new XElement("DamageFormula", new XCData("power * 5")),
+			new XElement("PainFormula", new XCData("0")),
+			new XElement("StunFormula", new XCData("0")),
+			new XElement("DamageType", (int)DamageType.Crushing)
+		), spell), string.Empty);
+	}
+
+	protected ItemDamageEffect(XElement root, IMagicSpell spell)
+	{
+		Spell = spell;
+		DamageFormula = new Expression(root.Element("DamageFormula")?.Value ?? "power * 5");
+		PainFormula = new Expression(root.Element("PainFormula")?.Value ?? "0");
+		StunFormula = new Expression(root.Element("StunFormula")?.Value ?? "0");
+		DamageType = (DamageType)int.Parse(root.Element("DamageType")?.Value ?? ((int)DamageType.Crushing).ToString());
+	}
+
+	public IMagicSpell Spell { get; }
+	public IFuturemud Gameworld => Spell.Gameworld;
+	public Expression DamageFormula { get; private set; }
+	public Expression PainFormula { get; private set; }
+	public Expression StunFormula { get; private set; }
+	public DamageType DamageType { get; private set; }
+
+	public XElement SaveToXml()
+	{
+		return new XElement("Effect",
+			new XAttribute("type", "itemdamage"),
+			new XElement("DamageFormula", new XCData(DamageFormula.OriginalExpression)),
+			new XElement("PainFormula", new XCData(PainFormula.OriginalExpression)),
+			new XElement("StunFormula", new XCData(StunFormula.OriginalExpression)),
+			new XElement("DamageType", (int)DamageType)
+		);
+	}
+
+	public bool IsInstantaneous => true;
+	public bool RequiresTarget => true;
+
+	public static bool IsCompatibleWithTrigger(string types)
+	{
+		return types is "item" or "items" or "perceivable" or "perceivables";
+	}
+
+	public bool IsCompatibleWithTrigger(IMagicTrigger types)
+	{
+		return IsCompatibleWithTrigger(types.TargetTypes);
+	}
+
+	public IMagicSpellEffect? GetOrApplyEffect(ICharacter caster, IPerceivable? target, OpposedOutcomeDegree outcome,
+		SpellPower power, IMagicSpellEffectParent parent, SpellAdditionalParameter[] additionalParameters)
+	{
+		if (target is not IGameItem item || item.Deleted)
+		{
+			return null;
+		}
+
+		foreach (var expression in new[] { DamageFormula, PainFormula, StunFormula })
+		{
+			expression.Parameters["power"] = (int)power;
+			expression.Parameters["outcome"] = (int)outcome;
+		}
+
+		item.SufferDamage(new Damage
+		{
+			ActorOrigin = caster,
+			ToolOrigin = null,
+			DamageType = DamageType,
+			DamageAmount = DamageFormula.EvaluateDouble(),
+			PainAmount = PainFormula.EvaluateDouble(),
+			ShockAmount = 0,
+			StunAmount = StunFormula.EvaluateDouble(),
+			PenetrationOutcome = Outcome.NotTested
+		});
+		return null;
+	}
+
+	public IMagicSpellEffectTemplate Clone()
+	{
+		return new ItemDamageEffect(SaveToXml(), Spell);
+	}
+
+	public const string HelpText = @"You can use the following options with this effect:
+
+	#3damage <formula>#0 - sets the item damage formula
+	#3pain <formula>#0 - sets the pain formula
+	#3stun <formula>#0 - sets the stun formula
+	#3type <which>#0 - sets the damage type";
+
+	public bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		var which = command.PopSpeech().ToLowerInvariant();
+		if (which is "damage" or "pain" or "stun")
+		{
+			var expression = new Expression(command.SafeRemainingArgument);
+			if (expression.HasErrors())
+			{
+				actor.OutputHandler.Send(expression.Error);
+				return false;
+			}
+
+			if (which == "damage")
+			{
+				DamageFormula = expression;
+			}
+			else if (which == "pain")
+			{
+				PainFormula = expression;
+			}
+			else
+			{
+				StunFormula = expression;
+			}
+
+			Spell.Changed = true;
+			actor.OutputHandler.Send($"The {which} formula is now {expression.OriginalExpression.ColourCommand()}.");
+			return true;
+		}
+
+		if (which is "type")
+		{
+			if (!command.SafeRemainingArgument.TryParseEnum<DamageType>(out var type))
+			{
+				actor.OutputHandler.Send($"That is not a valid damage type. Valid types are {Enum.GetValues<DamageType>().ListToColouredString()}.");
+				return false;
+			}
+
+			DamageType = type;
+			Spell.Changed = true;
+			actor.OutputHandler.Send($"The damage type is now {DamageType.DescribeEnum().ColourValue()}.");
+			return true;
+		}
+
+		actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
+		return false;
+	}
+
+	public string Show(ICharacter actor)
+	{
+		return $"ItemDamage - {DamageType.DescribeEnum().ColourValue()} - Dmg {DamageFormula.OriginalExpression.ColourCommand()}";
+	}
+}
+
+public class DestroyItemEffect : IMagicSpellEffectTemplate
+{
+	public static void RegisterFactory()
+	{
+		SpellEffectFactory.RegisterLoadTimeFactory("destroyitem", (root, spell) => new DestroyItemEffect(root, spell));
+		SpellEffectFactory.RegisterBuilderFactory("destroyitem", BuilderFactory,
+			"Safely deletes target items",
+			HelpText,
+			true,
+			true,
+			SpellTriggerFactory.MagicTriggerTypes
+				.Where(x => ItemDamageEffect.IsCompatibleWithTrigger(SpellTriggerFactory.BuilderInfoForType(x).TargetTypes))
+				.ToArray());
+	}
+
+	private static (IMagicSpellEffectTemplate Trigger, string Error) BuilderFactory(StringStack commands,
+		IMagicSpell spell)
+	{
+		return (new DestroyItemEffect(new XElement("Effect",
+			new XAttribute("type", "destroyitem"),
+			new XElement("RespectPurgeWarnings", true)
+		), spell), string.Empty);
+	}
+
+	protected DestroyItemEffect(XElement root, IMagicSpell spell)
+	{
+		Spell = spell;
+		RespectPurgeWarnings = bool.Parse(root.Element("RespectPurgeWarnings")?.Value ?? "true");
+	}
+
+	public IMagicSpell Spell { get; }
+	public IFuturemud Gameworld => Spell.Gameworld;
+	public bool RespectPurgeWarnings { get; private set; }
+
+	public XElement SaveToXml()
+	{
+		return new XElement("Effect",
+			new XAttribute("type", "destroyitem"),
+			new XElement("RespectPurgeWarnings", RespectPurgeWarnings)
+		);
+	}
+
+	public bool IsInstantaneous => true;
+	public bool RequiresTarget => true;
+
+	public bool IsCompatibleWithTrigger(IMagicTrigger types)
+	{
+		return ItemDamageEffect.IsCompatibleWithTrigger(types.TargetTypes);
+	}
+
+	public IMagicSpellEffect? GetOrApplyEffect(ICharacter caster, IPerceivable? target, OpposedOutcomeDegree outcome,
+		SpellPower power, IMagicSpellEffectParent parent, SpellAdditionalParameter[] additionalParameters)
+	{
+		if (target is not IGameItem item || item.Deleted || (RespectPurgeWarnings && item.WarnBeforePurge))
+		{
+			return null;
+		}
+
+		item.Delete();
+		return null;
+	}
+
+	public IMagicSpellEffectTemplate Clone()
+	{
+		return new DestroyItemEffect(SaveToXml(), Spell);
+	}
+
+	public const string HelpText = "#3warnings#0 - toggles respecting purge-warning safeguards";
+
+	public bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		if (!command.PopSpeech().EqualTo("warnings"))
+		{
+			actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
+			return false;
+		}
+
+		RespectPurgeWarnings = !RespectPurgeWarnings;
+		Spell.Changed = true;
+		actor.OutputHandler.Send($"This effect will {RespectPurgeWarnings.NowNoLonger()} skip items with purge warnings.");
+		return true;
+	}
+
+	public string Show(ICharacter actor)
+	{
+		return $"DestroyItem - Respect Warnings: {RespectPurgeWarnings.ToColouredString()}";
+	}
+}
+
+public class ItemEnchantEffect : IMagicSpellEffectTemplate
+{
+	public static void RegisterFactory()
+	{
+		SpellEffectFactory.RegisterLoadTimeFactory("itemenchant", (root, spell) => new ItemEnchantEffect(root, spell));
+		SpellEffectFactory.RegisterBuilderFactory("itemenchant", BuilderFactory,
+			"Adds magical item descriptions, glow, and combat hooks",
+			HelpText,
+			false,
+			true,
+			SpellTriggerFactory.MagicTriggerTypes
+				.Where(x => ItemDamageEffect.IsCompatibleWithTrigger(SpellTriggerFactory.BuilderInfoForType(x).TargetTypes))
+				.ToArray());
+	}
+
+	private static (IMagicSpellEffectTemplate Trigger, string Error) BuilderFactory(StringStack commands,
+		IMagicSpell spell)
+	{
+		return (new ItemEnchantEffect(new XElement("Effect",
+			new XAttribute("type", "itemenchant"),
+			new XElement("SDescAddendum", new XCData("(enchanted)")),
+			new XElement("DescAddendum", new XCData("It hums with a palpable magical aura.")),
+			new XElement("Colour", "bold magenta"),
+			new XElement("GlowLux", 0.0),
+			new XElement("AttackCheckBonus", 0.0),
+			new XElement("QualityBonus", 0.0),
+			new XElement("DamageBonus", 0.0),
+			new XElement("PainBonus", 0.0),
+			new XElement("StunBonus", 0.0),
+			new XElement("ArmourDamageReduction", 0.0),
+			new XElement("ApplicabilityProg", 0)
+		), spell), string.Empty);
+	}
+
+	protected ItemEnchantEffect(XElement root, IMagicSpell spell)
+	{
+		Spell = spell;
+		SDescAddendum = root.Element("SDescAddendum")?.Value ?? "(enchanted)";
+		DescAddendum = root.Element("DescAddendum")?.Value ?? "It hums with a palpable magical aura.";
+		Colour = Telnet.GetColour(root.Element("Colour")?.Value ?? "bold magenta") ?? Telnet.BoldMagenta;
+		GlowLux = double.Parse(root.Element("GlowLux")?.Value ?? "0");
+		AttackCheckBonus = double.Parse(root.Element("AttackCheckBonus")?.Value ?? "0");
+		QualityBonus = double.Parse(root.Element("QualityBonus")?.Value ?? "0");
+		DamageBonus = double.Parse(root.Element("DamageBonus")?.Value ?? "0");
+		PainBonus = double.Parse(root.Element("PainBonus")?.Value ?? "0");
+		StunBonus = double.Parse(root.Element("StunBonus")?.Value ?? "0");
+		ArmourDamageReduction = double.Parse(root.Element("ArmourDamageReduction")?.Value ?? "0");
+		ApplicabilityProg = Gameworld.FutureProgs.Get(long.Parse(root.Element("ApplicabilityProg")?.Value ?? "0"));
+	}
+
+	public IMagicSpell Spell { get; }
+	public IFuturemud Gameworld => Spell.Gameworld;
+	public string SDescAddendum { get; private set; }
+	public string DescAddendum { get; private set; }
+	public ANSIColour Colour { get; private set; }
+	public double GlowLux { get; private set; }
+	public double AttackCheckBonus { get; private set; }
+	public double QualityBonus { get; private set; }
+	public double DamageBonus { get; private set; }
+	public double PainBonus { get; private set; }
+	public double StunBonus { get; private set; }
+	public double ArmourDamageReduction { get; private set; }
+	public IFutureProg? ApplicabilityProg { get; private set; }
+
+	public XElement SaveToXml()
+	{
+		return new XElement("Effect",
+			new XAttribute("type", "itemenchant"),
+			new XElement("SDescAddendum", new XCData(SDescAddendum)),
+			new XElement("DescAddendum", new XCData(DescAddendum)),
+			new XElement("Colour", Colour.Name),
+			new XElement("GlowLux", GlowLux),
+			new XElement("AttackCheckBonus", AttackCheckBonus),
+			new XElement("QualityBonus", QualityBonus),
+			new XElement("DamageBonus", DamageBonus),
+			new XElement("PainBonus", PainBonus),
+			new XElement("StunBonus", StunBonus),
+			new XElement("ArmourDamageReduction", ArmourDamageReduction),
+			new XElement("ApplicabilityProg", ApplicabilityProg?.Id ?? 0)
+		);
+	}
+
+	public bool IsInstantaneous => false;
+	public bool RequiresTarget => true;
+
+	public bool IsCompatibleWithTrigger(IMagicTrigger types)
+	{
+		return ItemDamageEffect.IsCompatibleWithTrigger(types.TargetTypes);
+	}
+
+	public IMagicSpellEffect? GetOrApplyEffect(ICharacter caster, IPerceivable? target, OpposedOutcomeDegree outcome,
+		SpellPower power, IMagicSpellEffectParent parent, SpellAdditionalParameter[] additionalParameters)
+	{
+		return target is IGameItem
+			? new SpellItemEnchantmentEffect(target, parent, SDescAddendum, DescAddendum, Colour, GlowLux,
+				AttackCheckBonus, QualityBonus, DamageBonus, PainBonus, StunBonus, ArmourDamageReduction,
+				ApplicabilityProg)
+			: null;
+	}
+
+	public IMagicSpellEffectTemplate Clone()
+	{
+		return new ItemEnchantEffect(SaveToXml(), Spell);
+	}
+
+	public const string HelpText = @"You can use the following options with this effect:
+
+	#3sdesc <text>#0 - sets the short-description addendum
+	#3desc <text>#0 - sets the full-description addendum
+	#3colour <colour>#0 - sets the addendum colour
+	#3glow <lux>#0 - sets glow lux
+	#3attack <bonus>#0 - sets weapon attack check bonus
+	#3quality <bonus>#0 - sets virtual weapon quality bonus
+	#3damage <bonus>#0 - sets weapon damage bonus
+	#3pain <bonus>#0 - sets weapon pain bonus
+	#3stun <bonus>#0 - sets weapon stun bonus
+	#3armour <amount>#0 - sets armour damage reduction
+	#3prog <prog|none>#0 - gates whether the enchantment applies";
+
+	public bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		var which = command.PopSpeech().ToLowerInvariant();
+		switch (which)
+		{
+			case "sdesc":
+				SDescAddendum = command.SafeRemainingArgument;
+				break;
+			case "desc":
+				DescAddendum = command.SafeRemainingArgument;
+				break;
+			case "colour":
+			case "color":
+				var colour = Telnet.GetColour(command.SafeRemainingArgument);
+				if (colour is null)
+				{
+					actor.OutputHandler.Send($"That is not a valid colour. The options are:\n\n{Telnet.GetColourOptions.Select(x => x.Colour(Telnet.GetColour(x))).ListToLines(true)}");
+					return false;
+				}
+
+				Colour = colour;
+				break;
+			case "glow":
+			case "attack":
+			case "quality":
+			case "damage":
+			case "pain":
+			case "stun":
+			case "armour":
+				if (!double.TryParse(command.SafeRemainingArgument, out var value))
+				{
+					actor.OutputHandler.Send("You must enter a valid number.");
+					return false;
+				}
+
+				SetNumeric(which, value);
+				break;
+			case "prog":
+				if (command.SafeRemainingArgument.EqualTo("none"))
+				{
+					ApplicabilityProg = null;
+					break;
+				}
+
+				ApplicabilityProg = new ProgLookupFromBuilderInput(actor, command.SafeRemainingArgument,
+					ProgVariableTypes.Boolean,
+					[
+						[ProgVariableTypes.Item],
+						[ProgVariableTypes.Item, ProgVariableTypes.Character],
+						[ProgVariableTypes.Item, ProgVariableTypes.Character, ProgVariableTypes.Perceivable]
+					]).LookupProg();
+				if (ApplicabilityProg is null)
+				{
+					return false;
+				}
+
+				break;
+			default:
+				actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
+				return false;
+		}
+
+		Spell.Changed = true;
+		actor.OutputHandler.Send("The item enchantment has been updated.");
+		return true;
+	}
+
+	private void SetNumeric(string which, double value)
+	{
+		switch (which)
+		{
+			case "glow":
+				GlowLux = value;
+				return;
+			case "attack":
+				AttackCheckBonus = value;
+				return;
+			case "quality":
+				QualityBonus = value;
+				return;
+			case "damage":
+				DamageBonus = value;
+				return;
+			case "pain":
+				PainBonus = value;
+				return;
+			case "stun":
+				StunBonus = value;
+				return;
+			case "armour":
+				ArmourDamageReduction = value;
+				return;
+		}
+	}
+
+	public string Show(ICharacter actor)
+	{
+		return $"ItemEnchant - {SDescAddendum.Colour(Colour)} - Glow {GlowLux.ToString("N2", actor).ColourValue()} - Attack {AttackCheckBonus.ToBonusString(actor)} - Armour {ArmourDamageReduction.ToString("N2", actor).ColourValue()}";
+	}
+}
+
+public class CorpseMarkEffect : MagicTagEffect
+{
+	public static new void RegisterFactory()
+	{
+		SpellEffectFactory.RegisterLoadTimeFactory("corpsemark", (root, spell) => new CorpseMarkEffect(root, spell));
+		SpellEffectFactory.RegisterBuilderFactory("corpsemark", BuilderFactory,
+			"Applies a magic metadata tag to a corpse",
+			HelpText,
+			false,
+			true,
+			SpellTriggerFactory.MagicTriggerTypes
+				.Where(x => SpellTriggerFactory.BuilderInfoForType(x).TargetTypes == "item")
+				.ToArray());
+	}
+
+	private static (IMagicSpellEffectTemplate Trigger, string Error) BuilderFactory(StringStack commands,
+		IMagicSpell spell)
+	{
+		return (new CorpseMarkEffect(new XElement("Effect",
+			new XAttribute("type", "corpsemark"),
+			new XElement("Tag", new XCData("corpsemark")),
+			new XElement("Value", new XCData("")),
+			new XElement("ReplaceExisting", true)
+		), spell), string.Empty);
+	}
+
+	protected CorpseMarkEffect(XElement root, IMagicSpell spell) : base(root, spell)
+	{
+	}
+
+	public override XElement SaveToXml()
+	{
+		var xml = base.SaveToXml();
+		xml.SetAttributeValue("type", "corpsemark");
+		return xml;
+	}
+
+	public override bool IsCompatibleWithTrigger(IMagicTrigger types)
+	{
+		return types.TargetTypes == "item";
+	}
+
+	public override IMagicSpellEffect? GetOrApplyEffect(ICharacter caster, IPerceivable? target, OpposedOutcomeDegree outcome,
+		SpellPower power, IMagicSpellEffectParent parent, SpellAdditionalParameter[] additionalParameters)
+	{
+		return target is IGameItem item && item.GetItemType<ICorpse>() is not null
+			? base.GetOrApplyEffect(caster, target, outcome, power, parent, additionalParameters)
+			: null;
+	}
+
+	public override IMagicSpellEffectTemplate Clone()
+	{
+		return new CorpseMarkEffect(SaveToXml(), Spell);
+	}
+}
+
+public class CorpsePreserveEffect : IMagicSpellEffectTemplate
+{
+	public static void RegisterFactory()
+	{
+		SpellEffectFactory.RegisterLoadTimeFactory("corpsepreserve",
+			(root, spell) => new CorpsePreserveEffect(root, spell));
+		SpellEffectFactory.RegisterBuilderFactory("corpsepreserve", BuilderFactory,
+			"Halts corpse decay while the spell lasts",
+			string.Empty,
+			false,
+			true,
+			SpellTriggerFactory.MagicTriggerTypes
+				.Where(x => SpellTriggerFactory.BuilderInfoForType(x).TargetTypes == "item")
+				.ToArray());
+	}
+
+	private static (IMagicSpellEffectTemplate Trigger, string Error) BuilderFactory(StringStack commands,
+		IMagicSpell spell)
+	{
+		return (new CorpsePreserveEffect(new XElement("Effect", new XAttribute("type", "corpsepreserve")), spell),
+			string.Empty);
+	}
+
+	protected CorpsePreserveEffect(XElement root, IMagicSpell spell)
+	{
+		Spell = spell;
+	}
+
+	public IMagicSpell Spell { get; }
+	public IFuturemud Gameworld => Spell.Gameworld;
+
+	public XElement SaveToXml()
+	{
+		return new XElement("Effect", new XAttribute("type", "corpsepreserve"));
+	}
+
+	public bool IsInstantaneous => false;
+	public bool RequiresTarget => true;
+
+	public bool IsCompatibleWithTrigger(IMagicTrigger types)
+	{
+		return types.TargetTypes == "item";
+	}
+
+	public IMagicSpellEffect? GetOrApplyEffect(ICharacter caster, IPerceivable? target, OpposedOutcomeDegree outcome,
+		SpellPower power, IMagicSpellEffectParent parent, SpellAdditionalParameter[] additionalParameters)
+	{
+		return target is IGameItem item && item.GetItemType<ICorpse>() is not null
+			? new SpellCorpsePreservationEffect(target, parent)
+			: null;
+	}
+
+	public IMagicSpellEffectTemplate Clone()
+	{
+		return new CorpsePreserveEffect(SaveToXml(), Spell);
+	}
+
+	public bool BuildingCommand(ICharacter actor, StringStack command) => false;
+	public string Show(ICharacter actor) => "CorpsePreserve";
+}
+
+public class CorpseConsumeEffect : IMagicSpellEffectTemplate
+{
+	public static void RegisterFactory()
+	{
+		SpellEffectFactory.RegisterLoadTimeFactory("corpseconsume", (root, spell) => new CorpseConsumeEffect(root, spell));
+		SpellEffectFactory.RegisterBuilderFactory("corpseconsume", BuilderFactory,
+			"Consumes and deletes a corpse",
+			string.Empty,
+			true,
+			true,
+			SpellTriggerFactory.MagicTriggerTypes
+				.Where(x => SpellTriggerFactory.BuilderInfoForType(x).TargetTypes == "item")
+				.ToArray());
+	}
+
+	private static (IMagicSpellEffectTemplate Trigger, string Error) BuilderFactory(StringStack commands,
+		IMagicSpell spell)
+	{
+		return (new CorpseConsumeEffect(new XElement("Effect", new XAttribute("type", "corpseconsume")), spell),
+			string.Empty);
+	}
+
+	protected CorpseConsumeEffect(XElement root, IMagicSpell spell)
+	{
+		Spell = spell;
+	}
+
+	public IMagicSpell Spell { get; }
+	public IFuturemud Gameworld => Spell.Gameworld;
+	public XElement SaveToXml() => new("Effect", new XAttribute("type", "corpseconsume"));
+	public bool IsInstantaneous => true;
+	public bool RequiresTarget => true;
+	public bool IsCompatibleWithTrigger(IMagicTrigger types) => types.TargetTypes == "item";
+
+	public IMagicSpellEffect? GetOrApplyEffect(ICharacter caster, IPerceivable? target, OpposedOutcomeDegree outcome,
+		SpellPower power, IMagicSpellEffectParent parent, SpellAdditionalParameter[] additionalParameters)
+	{
+		if (target is IGameItem item && item.GetItemType<ICorpse>() is not null && !item.Deleted)
+		{
+			item.Delete();
+		}
+
+		return null;
+	}
+
+	public IMagicSpellEffectTemplate Clone() => new CorpseConsumeEffect(SaveToXml(), Spell);
+	public bool BuildingCommand(ICharacter actor, StringStack command) => false;
+	public string Show(ICharacter actor) => "CorpseConsume";
+}
+
+public class CorpseSpawnEffect : IMagicSpellEffectTemplate
+{
+	public static void RegisterFactory()
+	{
+		SpellEffectFactory.RegisterLoadTimeFactory("corpsespawn", (root, spell) => new CorpseSpawnEffect(root, spell));
+		SpellEffectFactory.RegisterBuilderFactory("corpsespawn", BuilderFactory,
+			"Spawns configured NPCs or items from a corpse",
+			HelpText,
+			true,
+			true,
+			SpellTriggerFactory.MagicTriggerTypes
+				.Where(x => SpellTriggerFactory.BuilderInfoForType(x).TargetTypes == "item")
+				.ToArray());
+	}
+
+	private static (IMagicSpellEffectTemplate Trigger, string Error) BuilderFactory(StringStack commands,
+		IMagicSpell spell)
+	{
+		return (new CorpseSpawnEffect(new XElement("Effect",
+			new XAttribute("type", "corpsespawn"),
+			new XElement("NPCPrototypeId", 0),
+			new XElement("ItemPrototypeId", 0),
+			new XElement("Quantity", 1),
+			new XElement("ConsumeCorpse", false)
+		), spell), string.Empty);
+	}
+
+	protected CorpseSpawnEffect(XElement root, IMagicSpell spell)
+	{
+		Spell = spell;
+		NPCPrototypeId = long.Parse(root.Element("NPCPrototypeId")?.Value ?? "0");
+		ItemPrototypeId = long.Parse(root.Element("ItemPrototypeId")?.Value ?? "0");
+		Quantity = int.Parse(root.Element("Quantity")?.Value ?? "1");
+		ConsumeCorpse = bool.Parse(root.Element("ConsumeCorpse")?.Value ?? "false");
+	}
+
+	public IMagicSpell Spell { get; }
+	public IFuturemud Gameworld => Spell.Gameworld;
+	public long NPCPrototypeId { get; private set; }
+	public long ItemPrototypeId { get; private set; }
+	public int Quantity { get; private set; }
+	public bool ConsumeCorpse { get; private set; }
+
+	public XElement SaveToXml()
+	{
+		return new XElement("Effect",
+			new XAttribute("type", "corpsespawn"),
+			new XElement("NPCPrototypeId", NPCPrototypeId),
+			new XElement("ItemPrototypeId", ItemPrototypeId),
+			new XElement("Quantity", Quantity),
+			new XElement("ConsumeCorpse", ConsumeCorpse)
+		);
+	}
+
+	public bool IsInstantaneous => true;
+	public bool RequiresTarget => true;
+	public bool IsCompatibleWithTrigger(IMagicTrigger types) => types.TargetTypes == "item";
+
+	public IMagicSpellEffect? GetOrApplyEffect(ICharacter caster, IPerceivable? target, OpposedOutcomeDegree outcome,
+		SpellPower power, IMagicSpellEffectParent parent, SpellAdditionalParameter[] additionalParameters)
+	{
+		if (target is not IGameItem item || item.GetItemType<ICorpse>() is null)
+		{
+			return null;
+		}
+
+		var cell = item.TrueLocations.FirstOrDefault() ?? caster.Location;
+		if (NPCPrototypeId > 0 && Gameworld.NpcTemplates.Get(NPCPrototypeId) is INPCTemplate template)
+		{
+			var ch = template.CreateNewCharacter(cell);
+			Gameworld.Add(ch, true);
+			ch.RoomLayer = item.RoomLayer;
+			template.OnLoadProg?.Execute(ch);
+			if (ch.Location.IsSwimmingLayer(ch.RoomLayer) && ch.Race.CanSwim)
+			{
+				ch.PositionState = PositionSwimming.Instance;
+			}
+			else if (ch.RoomLayer.IsHigherThan(RoomLayer.GroundLevel) && ch.CanFly().Truth)
+			{
+				ch.PositionState = PositionFlying.Instance;
+			}
+
+			ch.Location.Login(ch);
+			ch.HandleEvent(EventType.NPCOnGameLoadFinished, ch);
+		}
+
+		if (ItemPrototypeId > 0 && Gameworld.ItemProtos.Get(ItemPrototypeId) is IGameItemProto proto)
+		{
+			foreach (var newItem in proto.CreateNew(caster, null!, Quantity, string.Empty))
+			{
+				cell.Insert(newItem, true);
+				newItem.HandleEvent(EventType.ItemFinishedLoading, newItem);
+				newItem.Login();
+			}
+		}
+
+		if (ConsumeCorpse && !item.Deleted)
+		{
+			item.Delete();
+		}
+
+		return null;
+	}
+
+	public IMagicSpellEffectTemplate Clone() => new CorpseSpawnEffect(SaveToXml(), Spell);
+
+	public const string HelpText = @"You can use the following options with this effect:
+
+	#3npc <proto|none>#0 - sets the NPC prototype to spawn
+	#3item <proto|none>#0 - sets the item prototype to spawn
+	#3quantity <##>#0 - sets item quantity
+	#3consume#0 - toggles consuming the corpse afterwards";
+
+	public bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopSpeech().ToLowerInvariant())
+		{
+			case "npc":
+				if (command.SafeRemainingArgument.EqualTo("none"))
+				{
+					NPCPrototypeId = 0;
+					break;
+				}
+
+				var npc = Gameworld.NpcTemplates.GetByIdOrName(command.SafeRemainingArgument);
+				if (npc is null)
+				{
+					actor.OutputHandler.Send($"There is no NPC prototype identified by {command.SafeRemainingArgument.ColourCommand()}.");
+					return false;
+				}
+
+				NPCPrototypeId = npc.Id;
+				break;
+			case "item":
+				if (command.SafeRemainingArgument.EqualTo("none"))
+				{
+					ItemPrototypeId = 0;
+					break;
+				}
+
+				var item = Gameworld.ItemProtos.GetByIdOrName(command.SafeRemainingArgument);
+				if (item is null)
+				{
+					actor.OutputHandler.Send($"There is no item prototype identified by {command.SafeRemainingArgument.ColourCommand()}.");
+					return false;
+				}
+
+				ItemPrototypeId = item.Id;
+				break;
+			case "quantity":
+				if (!int.TryParse(command.SafeRemainingArgument, out var quantity) || quantity < 1)
+				{
+					actor.OutputHandler.Send("You must enter a positive integer quantity.");
+					return false;
+				}
+
+				Quantity = quantity;
+				break;
+			case "consume":
+				ConsumeCorpse = !ConsumeCorpse;
+				break;
+			default:
+				actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
+				return false;
+		}
+
+		Spell.Changed = true;
+		actor.OutputHandler.Send("The corpse spawn effect has been updated.");
+		return true;
+	}
+
+	public string Show(ICharacter actor)
+	{
+		return $"CorpseSpawn - NPC #{NPCPrototypeId.ToString("N0", actor)} Item #{ItemPrototypeId.ToString("N0", actor)} x{Quantity.ToString("N0", actor)} Consume: {ConsumeCorpse.ToColouredString()}";
+	}
+}
+
+public class PortalSpellEffect : IMagicSpellEffectTemplate
+{
+	public static void RegisterFactory()
+	{
+		SpellEffectFactory.RegisterLoadTimeFactory("portal", (root, spell) => new PortalSpellEffect(root, spell));
+		SpellEffectFactory.RegisterBuilderFactory("portal", BuilderFactory,
+			"Creates a transient paired magical portal exit",
+			HelpText,
+			false,
+			true,
+			SpellTriggerFactory.MagicTriggerTypes
+				.Where(x => IsCompatibleWithTrigger(SpellTriggerFactory.BuilderInfoForType(x).TargetTypes))
+				.ToArray());
+	}
+
+	private static (IMagicSpellEffectTemplate Trigger, string Error) BuilderFactory(StringStack commands,
+		IMagicSpell spell)
+	{
+		return (new PortalSpellEffect(new XElement("Effect",
+			new XAttribute("type", "portal"),
+			new XElement("Verb", new XCData("enter")),
+			new XElement("OutboundKeyword", new XCData("portal")),
+			new XElement("InboundKeyword", new XCData("portal")),
+			new XElement("OutboundTarget", new XCData("a shimmering portal")),
+			new XElement("InboundTarget", new XCData("a shimmering portal")),
+			new XElement("OutboundDescription", new XCData("through")),
+			new XElement("InboundDescription", new XCData("through")),
+			new XElement("TimeMultiplier", 1.0),
+			new XElement("AllowCrossZone", false),
+			new XElement("AnchorTag", new XCData("portal-anchor")),
+			new XElement("AnchorValue", new XCData("")),
+			new XElement("DestinationProg", 0)
+		), spell), string.Empty);
+	}
+
+	protected PortalSpellEffect(XElement root, IMagicSpell spell)
+	{
+		Spell = spell;
+		Verb = root.Element("Verb")?.Value ?? "enter";
+		OutboundKeyword = root.Element("OutboundKeyword")?.Value ?? "portal";
+		InboundKeyword = root.Element("InboundKeyword")?.Value ?? "portal";
+		OutboundTarget = root.Element("OutboundTarget")?.Value ?? "a shimmering portal";
+		InboundTarget = root.Element("InboundTarget")?.Value ?? "a shimmering portal";
+		OutboundDescription = root.Element("OutboundDescription")?.Value ?? "through";
+		InboundDescription = root.Element("InboundDescription")?.Value ?? "through";
+		TimeMultiplier = double.Parse(root.Element("TimeMultiplier")?.Value ?? "1.0");
+		AllowCrossZone = bool.Parse(root.Element("AllowCrossZone")?.Value ?? "false");
+		AnchorTag = root.Element("AnchorTag")?.Value ?? "portal-anchor";
+		AnchorValue = root.Element("AnchorValue")?.Value ?? string.Empty;
+		DestinationProg = Gameworld.FutureProgs.Get(long.Parse(root.Element("DestinationProg")?.Value ?? "0"));
+	}
+
+	public IMagicSpell Spell { get; }
+	public IFuturemud Gameworld => Spell.Gameworld;
+	public string Verb { get; private set; }
+	public string OutboundKeyword { get; private set; }
+	public string InboundKeyword { get; private set; }
+	public string OutboundTarget { get; private set; }
+	public string InboundTarget { get; private set; }
+	public string OutboundDescription { get; private set; }
+	public string InboundDescription { get; private set; }
+	public double TimeMultiplier { get; private set; }
+	public bool AllowCrossZone { get; private set; }
+	public string AnchorTag { get; private set; }
+	public string AnchorValue { get; private set; }
+	public IFutureProg? DestinationProg { get; private set; }
+
+	public XElement SaveToXml()
+	{
+		return new XElement("Effect",
+			new XAttribute("type", "portal"),
+			new XElement("Verb", new XCData(Verb)),
+			new XElement("OutboundKeyword", new XCData(OutboundKeyword)),
+			new XElement("InboundKeyword", new XCData(InboundKeyword)),
+			new XElement("OutboundTarget", new XCData(OutboundTarget)),
+			new XElement("InboundTarget", new XCData(InboundTarget)),
+			new XElement("OutboundDescription", new XCData(OutboundDescription)),
+			new XElement("InboundDescription", new XCData(InboundDescription)),
+			new XElement("TimeMultiplier", TimeMultiplier),
+			new XElement("AllowCrossZone", AllowCrossZone),
+			new XElement("AnchorTag", new XCData(AnchorTag)),
+			new XElement("AnchorValue", new XCData(AnchorValue)),
+			new XElement("DestinationProg", DestinationProg?.Id ?? 0)
+		);
+	}
+
+	public bool IsInstantaneous => false;
+	public bool RequiresTarget => true;
+
+	public static bool IsCompatibleWithTrigger(string types)
+	{
+		return types is "room" or "rooms" or "character" or "perceivable" or "character&room";
+	}
+
+	public bool IsCompatibleWithTrigger(IMagicTrigger types) => IsCompatibleWithTrigger(types.TargetTypes);
+
+	public IMagicSpellEffect? GetOrApplyEffect(ICharacter caster, IPerceivable? target, OpposedOutcomeDegree outcome,
+		SpellPower power, IMagicSpellEffectParent parent, SpellAdditionalParameter[] additionalParameters)
+	{
+		var source = caster.Location;
+		var destination = target as ICell ??
+		                  additionalParameters.FirstOrDefault(x => x.ParameterName.EqualTo("room"))?.Item as ICell ??
+		                  AnchorDestination(caster);
+		if (source is null || destination is null || ReferenceEquals(source, destination))
+		{
+			return null;
+		}
+
+		if (!AllowCrossZone && !ReferenceEquals(source.Zone, destination.Zone))
+		{
+			return null;
+		}
+
+		if (!source.CanInteractPlanar(destination, PlanarInteractionKind.Magic))
+		{
+			return null;
+		}
+
+		if (DestinationProg is not null && !DestinationProg.ExecuteBool(caster, source, destination))
+		{
+			return null;
+		}
+
+		return new SpellPortalEffect(target ?? destination, parent, source, destination, Verb, OutboundKeyword, InboundKeyword,
+			OutboundTarget, InboundTarget, OutboundDescription, InboundDescription, TimeMultiplier);
+	}
+
+	private ICell? AnchorDestination(ICharacter caster)
+	{
+		return Gameworld.Cells
+			.Where(x => x != caster.Location)
+			.SingleOrDefault(x => x.EffectsOfType<IMagicTagEffect>(tag =>
+				tag.Caster?.Id == caster.Id &&
+				tag.Tag.EqualTo(AnchorTag) &&
+				(string.IsNullOrEmpty(AnchorValue) || tag.Value.EqualTo(AnchorValue))).Any());
+	}
+
+	public IMagicSpellEffectTemplate Clone() => new PortalSpellEffect(SaveToXml(), Spell);
+
+	public const string HelpText = @"You can use the following options with this effect:
+
+	#3verb <verb>#0 - sets the movement verb, e.g. enter
+	#3outkey <keyword>#0 - sets the outbound keyword
+	#3inkey <keyword>#0 - sets the inbound keyword
+	#3outtarget <text>#0 - sets the outbound target text
+	#3intarget <text>#0 - sets the inbound target text
+	#3outdesc <text>#0 - sets the outbound movement preposition
+	#3indesc <text>#0 - sets the inbound movement preposition
+	#3speed <multiplier>#0 - sets the movement time multiplier
+	#3crosszone#0 - toggles cross-zone portals
+	#3anchor <tag> [value]#0 - sets the caster-owned tag anchor lookup
+	#3prog <prog|none>#0 - gates valid destinations";
+
+	public bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		var which = command.PopSpeech().ToLowerInvariant();
+		switch (which)
+		{
+			case "verb":
+				Verb = command.SafeRemainingArgument;
+				break;
+			case "outkey":
+				OutboundKeyword = command.SafeRemainingArgument;
+				break;
+			case "inkey":
+				InboundKeyword = command.SafeRemainingArgument;
+				break;
+			case "outtarget":
+				OutboundTarget = command.SafeRemainingArgument;
+				break;
+			case "intarget":
+				InboundTarget = command.SafeRemainingArgument;
+				break;
+			case "outdesc":
+				OutboundDescription = command.SafeRemainingArgument;
+				break;
+			case "indesc":
+				InboundDescription = command.SafeRemainingArgument;
+				break;
+			case "speed":
+				if (!double.TryParse(command.SafeRemainingArgument, out var speed) || speed <= 0.0)
+				{
+					actor.OutputHandler.Send("You must enter a positive speed multiplier.");
+					return false;
+				}
+
+				TimeMultiplier = speed;
+				break;
+			case "crosszone":
+				AllowCrossZone = !AllowCrossZone;
+				break;
+			case "anchor":
+				AnchorTag = command.PopSpeech();
+				AnchorValue = command.SafeRemainingArgument;
+				break;
+			case "prog":
+				if (command.SafeRemainingArgument.EqualTo("none"))
+				{
+					DestinationProg = null;
+					break;
+				}
+
+				DestinationProg = new ProgLookupFromBuilderInput(actor, command.SafeRemainingArgument,
+					ProgVariableTypes.Boolean,
+					[
+						[ProgVariableTypes.Character, ProgVariableTypes.Location, ProgVariableTypes.Location]
+					]).LookupProg();
+				if (DestinationProg is null)
+				{
+					return false;
+				}
+
+				break;
+			default:
+				actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
+				return false;
+		}
+
+		Spell.Changed = true;
+		actor.OutputHandler.Send("The portal effect has been updated.");
+		return true;
+	}
+
+	public string Show(ICharacter actor)
+	{
+		return $"Portal - {Verb.ColourCommand()} {OutboundKeyword.ColourCommand()} - Cross Zone: {AllowCrossZone.ToColouredString()} - Anchor {AnchorTag.ColourName()}={AnchorValue.ColourValue()}";
+	}
+}
+
+public class ForceCommandEffect : IMagicSpellEffectTemplate
+{
+	private static readonly HashSet<string> BlockedRoots = new(StringComparer.InvariantCultureIgnoreCase)
+	{
+		"account", "admin", "authorize", "builder", "chargen", "delete", "email", "force", "password", "prog",
+		"purge", "quit", "reboot", "reload", "save", "shutdown", "snoop", "switch", "user", "wiz"
+	};
+
+	public static void RegisterFactory()
+	{
+		SpellEffectFactory.RegisterLoadTimeFactory("forcecommand", (root, spell) => new ForceCommandEffect(root, spell));
+		SpellEffectFactory.RegisterBuilderFactory("forcecommand", BuilderFactory,
+			"Forces target characters to execute a non-staff command",
+			HelpText,
+			true,
+			true,
+			SpellTriggerFactory.MagicTriggerTypes
+				.Where(x => SpellTriggerFactory.BuilderInfoForType(x).TargetTypes is "character" or "characters")
+				.ToArray());
+	}
+
+	private static (IMagicSpellEffectTemplate Trigger, string Error) BuilderFactory(StringStack commands,
+		IMagicSpell spell)
+	{
+		return (new ForceCommandEffect(new XElement("Effect",
+			new XAttribute("type", "forcecommand"),
+			new XElement("Command", new XCData("look"))
+		), spell), string.Empty);
+	}
+
+	protected ForceCommandEffect(XElement root, IMagicSpell spell)
+	{
+		Spell = spell;
+		Command = root.Element("Command")?.Value ?? "look";
+	}
+
+	public IMagicSpell Spell { get; }
+	public IFuturemud Gameworld => Spell.Gameworld;
+	public string Command { get; private set; }
+
+	public XElement SaveToXml()
+	{
+		return new XElement("Effect",
+			new XAttribute("type", "forcecommand"),
+			new XElement("Command", new XCData(Command))
+		);
+	}
+
+	public bool IsInstantaneous => true;
+	public bool RequiresTarget => true;
+	public bool IsCompatibleWithTrigger(IMagicTrigger types) => types.TargetTypes is "character" or "characters";
+
+	public IMagicSpellEffect? GetOrApplyEffect(ICharacter caster, IPerceivable? target, OpposedOutcomeDegree outcome,
+		SpellPower power, IMagicSpellEffectParent parent, SpellAdditionalParameter[] additionalParameters)
+	{
+		if (target is not ICharacter character || character.AffectedBy<IIgnoreForceEffect>() ||
+		    !IsCommandAllowed(character, Command))
+		{
+			return null;
+		}
+
+		Gameworld.SystemMessage(new EmoteOutput(new Emote(
+			$"@ magically compel|compels $0 to execute '{Command}'", caster, character),
+			flags: OutputFlags.WizOnly), true);
+		character.ExecuteCommand(Command);
+		return null;
+	}
+
+	private static bool IsCommandAllowed(ICharacter character, string commandText)
+	{
+		var stack = new StringStack(commandText);
+		if (stack.IsFinished)
+		{
+			return false;
+		}
+
+		var root = stack.PopSpeech();
+		if (BlockedRoots.Contains(root))
+		{
+			return false;
+		}
+
+		var lookup = commandText;
+		var command = character.CommandTree.Commands.LocateCommand(character, ref lookup);
+		return command is null || command.PermissionRequired < PermissionLevel.JuniorAdmin;
+	}
+
+	public IMagicSpellEffectTemplate Clone() => new ForceCommandEffect(SaveToXml(), Spell);
+
+	public const string HelpText = "#3command <command>#0 - sets the command the target will execute";
+
+	public bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		if (!command.PopSpeech().EqualTo("command"))
+		{
+			actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
+			return false;
+		}
+
+		Command = command.SafeRemainingArgument;
+		Spell.Changed = true;
+		actor.OutputHandler.Send($"This effect will force the target to execute {Command.ColourCommand()}.");
+		return true;
+	}
+
+	public string Show(ICharacter actor) => $"ForceCommand - {Command.ColourCommand()}";
+}
+
+public class SubjectiveDescriptionEffect : IMagicSpellEffectTemplate
+{
+	public static void RegisterFactory()
+	{
+		SpellEffectFactory.RegisterLoadTimeFactory("subjectivedesc",
+			(root, spell) => new SubjectiveDescriptionEffect(root, spell, DescriptionType.Full));
+		SpellEffectFactory.RegisterLoadTimeFactory("subjectivesdesc",
+			(root, spell) => new SubjectiveDescriptionEffect(root, spell, DescriptionType.Short));
+		SpellEffectFactory.RegisterBuilderFactory("subjectivedesc",
+			(commands, spell) => BuilderFactory(commands, spell, DescriptionType.Full, "subjectivedesc"),
+			"Overrides the full description for a fixed perceiver",
+			HelpText,
+			false,
+			true,
+			CompatibleTriggers());
+		SpellEffectFactory.RegisterBuilderFactory("subjectivesdesc",
+			(commands, spell) => BuilderFactory(commands, spell, DescriptionType.Short, "subjectivesdesc"),
+			"Overrides the short description for a fixed perceiver",
+			HelpText,
+			false,
+			true,
+			CompatibleTriggers());
+	}
+
+	private static string[] CompatibleTriggers()
+	{
+		return SpellTriggerFactory.MagicTriggerTypes
+			.Where(x => SpellTriggerFactory.BuilderInfoForType(x).TargetTypes is "character" or "item" or "perceivable")
+			.ToArray();
+	}
+
+	private static (IMagicSpellEffectTemplate Trigger, string Error) BuilderFactory(StringStack commands,
+		IMagicSpell spell, DescriptionType type, string effectType)
+	{
+		return (new SubjectiveDescriptionEffect(new XElement("Effect",
+			new XAttribute("type", effectType),
+			new XElement("Description", new XCData(type == DescriptionType.Short ? "someone altered by magic" : "They appear different through magic.")),
+			new XElement("FixedViewer", true),
+			new XElement("ApplicabilityProg", 0)
+		), spell, type), string.Empty);
+	}
+
+	protected SubjectiveDescriptionEffect(XElement root, IMagicSpell spell, DescriptionType type)
+	{
+		Spell = spell;
+		DescriptionType = type;
+		EffectType = root.Attribute("type")?.Value ?? (type == DescriptionType.Short ? "subjectivesdesc" : "subjectivedesc");
+		Description = root.Element("Description")?.Value ?? string.Empty;
+		FixedViewer = bool.Parse(root.Element("FixedViewer")?.Value ?? "true");
+		ApplicabilityProg = Gameworld.FutureProgs.Get(long.Parse(root.Element("ApplicabilityProg")?.Value ?? "0"));
+	}
+
+	public IMagicSpell Spell { get; }
+	public IFuturemud Gameworld => Spell.Gameworld;
+	public DescriptionType DescriptionType { get; }
+	public string EffectType { get; }
+	public string Description { get; private set; }
+	public bool FixedViewer { get; private set; }
+	public IFutureProg? ApplicabilityProg { get; private set; }
+
+	public XElement SaveToXml()
+	{
+		return new XElement("Effect",
+			new XAttribute("type", EffectType),
+			new XElement("Description", new XCData(Description)),
+			new XElement("FixedViewer", FixedViewer),
+			new XElement("ApplicabilityProg", ApplicabilityProg?.Id ?? 0)
+		);
+	}
+
+	public bool IsInstantaneous => false;
+	public bool RequiresTarget => true;
+	public bool IsCompatibleWithTrigger(IMagicTrigger types) => types.TargetTypes is "character" or "item" or "perceivable";
+
+	public IMagicSpellEffect? GetOrApplyEffect(ICharacter caster, IPerceivable? target, OpposedOutcomeDegree outcome,
+		SpellPower power, IMagicSpellEffectParent parent, SpellAdditionalParameter[] additionalParameters)
+	{
+		return target is not null
+			? new SpellSubjectiveDescriptionEffect(target, parent, DescriptionType, Description,
+				FixedViewer ? caster.Id : 0, ApplicabilityProg)
+			: null;
+	}
+
+	public IMagicSpellEffectTemplate Clone() => new SubjectiveDescriptionEffect(SaveToXml(), Spell, DescriptionType);
+
+	public const string HelpText = @"You can use the following options with this effect:
+
+	#3description <text>#0 - sets the replacement description
+	#3fixedviewer#0 - toggles whether only the caster sees it
+	#3prog <prog|none>#0 - gates whether the override applies";
+
+	public bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopSpeech().ToLowerInvariant())
+		{
+			case "description":
+			case "desc":
+			case "sdesc":
+				Description = command.SafeRemainingArgument;
+				break;
+			case "fixedviewer":
+				FixedViewer = !FixedViewer;
+				break;
+			case "prog":
+				if (command.SafeRemainingArgument.EqualTo("none"))
+				{
+					ApplicabilityProg = null;
+					break;
+				}
+
+				ApplicabilityProg = new ProgLookupFromBuilderInput(actor, command.SafeRemainingArgument,
+					ProgVariableTypes.Boolean,
+					[
+						[ProgVariableTypes.Perceivable],
+						[ProgVariableTypes.Perceivable, ProgVariableTypes.Perceiver]
+					]).LookupProg();
+				if (ApplicabilityProg is null)
+				{
+					return false;
+				}
+
+				break;
+			default:
+				actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
+				return false;
+		}
+
+		Spell.Changed = true;
+		actor.OutputHandler.Send("The subjective description effect has been updated.");
+		return true;
+	}
+
+	public string Show(ICharacter actor)
+	{
+		return $"{EffectType} - Fixed Viewer: {FixedViewer.ToColouredString()} - {Description.ColourValue()}";
+	}
+}


### PR DESCRIPTION
## Summary
- Reclassifies the old Armageddon magic blockers against the now-shipped plane/corporeality and body-form primitives.
- Adds a current path forward for `planarstate`, `planeshift`, `transformform`, and a generic metadata-first `magictag` concept.
- Narrows the remaining blockers to the cases that still need first-class engine support: true projection, possession, portal topology, item/corpse enchantment, and coercive psionics.

## Testing
- Not run (not requested)
- Performed a documentation consistency pass after editing the report