### PR TITLE
Fix Discord bot command protocol mismatches and harden TCP handling

### DIFF
--- a/DiscordBotCore Unit Tests/DiscordBotCore Unit Tests.csproj
+++ b/DiscordBotCore Unit Tests/DiscordBotCore Unit Tests.csproj
@@ -12,4 +12,8 @@
 		<PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<ProjectReference Include="..\DiscordBotCore\DiscordBotCore.csproj" />
+	</ItemGroup>
+
 </Project>

--- a/DiscordBotCore Unit Tests/DiscordBotProtocolTests.cs
+++ b/DiscordBotCore Unit Tests/DiscordBotProtocolTests.cs
@@ -1,0 +1,46 @@
+using Discord_Bot;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+using System.Text;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class DiscordBotProtocolTests
+{
+	[TestMethod]
+	public void PrepareCommandForEngine_EscapesLineBreaks()
+	{
+		Assert.AreEqual(
+			@"broadcast first\nsecond\nthird",
+			DiscordBotProtocol.PrepareCommandForEngine("broadcast first\r\nsecond\nthird"));
+	}
+
+	[TestMethod]
+	public void EncodeCommandForEngine_AppendsRawDelimiter()
+	{
+		byte[] encoded = DiscordBotProtocol.EncodeCommandForEngine("who 1");
+		byte[] expectedPayload = Encoding.Unicode.GetBytes("who 1");
+
+		Assert.AreEqual(DiscordBotProtocol.EngineCommandDelimiter, encoded[^1]);
+		CollectionAssert.AreEqual(expectedPayload, encoded.Take(encoded.Length - 1).ToArray());
+	}
+
+	[TestMethod]
+	public void ParseShutdownNotification_DefaultsLegacyPayloadToReboot()
+	{
+		var result = DiscordBotProtocol.ParseShutdownNotification("AdminUser");
+
+		Assert.AreEqual("AdminUser", result.ShutdownAccount);
+		Assert.IsTrue(result.Reboot);
+	}
+
+	[TestMethod]
+	public void ParseShutdownNotification_ReadsExplicitStopFlag()
+	{
+		var result = DiscordBotProtocol.ParseShutdownNotification("\"Admin User\" false");
+
+		Assert.AreEqual("Admin User", result.ShutdownAccount);
+		Assert.IsFalse(result.Reboot);
+	}
+}

--- a/DiscordBotCore/DiscordBot.cs
+++ b/DiscordBotCore/DiscordBot.cs
@@ -12,6 +12,7 @@ using MudSharp.Framework;
 using Newtonsoft.Json;
 using Serilog;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -32,8 +33,8 @@ public partial class DiscordBot
 
     private readonly List<TcpConnection> _tcpConnections = new();
     public IEnumerable<TcpConnection> TCPConnections => _tcpConnections;
-    private readonly Dictionary<ulong, CachedDiscordRequest> _cachedDiscordRequests = new();
-    public Dictionary<ulong, CachedDiscordRequest> CachedDiscordRequests => _cachedDiscordRequests;
+    private readonly ConcurrentDictionary<ulong, CachedDiscordRequest> _cachedDiscordRequests = new();
+    public ConcurrentDictionary<ulong, CachedDiscordRequest> CachedDiscordRequests => _cachedDiscordRequests;
 
     private async Task TcpListenerAsync()
     {
@@ -99,6 +100,10 @@ public partial class DiscordBot
                 while (!reader.EndOfStream)
                 {
                     string line = reader.ReadLine();
+                    if (string.IsNullOrWhiteSpace(line))
+                    {
+                        continue;
+                    }
                     DetailedUserSetting setting = new(line);
                     DetailedUserSettings.Add(setting);
                 }
@@ -146,6 +151,12 @@ public partial class DiscordBot
     public bool IsAuthorisedUser(DiscordUser user)
     {
         return _authorisedUsers.Contains(user.Id);
+    }
+
+    public bool TryGetAuthenticatedConnection(out TcpConnection connection)
+    {
+        connection = _tcpConnections.FirstOrDefault(x => x.TcpClientAuthenticated && !x.Closing);
+        return connection != null;
     }
 
     public async Task RunBotAsync()
@@ -352,7 +363,7 @@ public partial class DiscordBot
         if (!string.Equals(newVersionInfo, _lastVersion))
         {
             _lastVersion = newVersionInfo;
-            await using (StreamWriter writer = new(new FileStream("lastversion.config", FileMode.OpenOrCreate)))
+            await using (StreamWriter writer = new(new FileStream("lastversion.config", FileMode.Create)))
             {
                 await writer.WriteLineAsync(newVersionInfo);
             }
@@ -360,20 +371,24 @@ public partial class DiscordBot
         }
     }
 
-    public async Task<string> GetMudStatusAsync()
+    public Task<string> GetMudStatusAsync()
     {
-        if (!_tcpConnections.Any())
+        if (!TCPConnections.Any(x => x.TcpClientAuthenticated && !x.Closing))
         {
-            return $"I'm not currently connected to **{GameName}**. Probably safe to presume it's down.";
+            return Task.FromResult($"I'm not currently connected to **{GameName}**. Probably safe to presume it's down.");
         }
 
-        return $"I am currently connected to **{GameName}**.";
+        return Task.FromResult($"I am currently connected to **{GameName}**.");
     }
 
     public async Task AddAuthorisedUser(ulong who)
     {
-        _authorisedUsers.Add(who);
-        await using (StreamWriter writer = new(new FileStream("settings.json", FileMode.OpenOrCreate)))
+        if (!_authorisedUsers.Contains(who))
+        {
+            _authorisedUsers.Add(who);
+        }
+
+        await using (StreamWriter writer = new(new FileStream("settings.json", FileMode.Create)))
         {
             try
             {
@@ -389,28 +404,7 @@ public partial class DiscordBot
                     GameName = GameName,
                     AdminUsers = _authorisedUsers.ToList(),
                     CustomGlobalReactions = _customGlobalReactions.ToList()
-                }));
-            }
-            catch (Exception)
-            {
-            }
-        }
-        using (StreamReader reader = new(new FileStream("settings.json", FileMode.Open)))
-        {
-            try
-            {
-                DiscordBotSetttings settings =
-                    JsonConvert.DeserializeObject<DiscordBotSetttings>(reader.ReadToEnd());
-                _tcpClientPort = settings.Port;
-                _botToken = settings.Token;
-                _botPrefixes.AddRange(settings.Prefixes);
-                ServerAuth = settings.ServerAuth;
-                _announceChannelId = settings.AnnounceChannelId;
-                _adminAnnounceChannelId = settings.AdminAnnounceChannelId;
-                _debugAnnounceChannelId = settings.DebugAnnounceChannelId;
-                GameName = settings.GameName;
-                _authorisedUsers.AddRange(settings.AdminUsers);
-                _customGlobalReactions.AddRange(settings.CustomGlobalReactions);
+                }, Formatting.Indented));
             }
             catch (Exception)
             {
@@ -495,29 +489,29 @@ public partial class DiscordBot
         }
     }
 
-    public async Task AskMudToShutdown(long userid, bool stop)
+    public async Task AskMudToShutdown(long userid, bool reboot)
     {
-        if (!_tcpConnections.Any(x => x.TcpClientAuthenticated))
+        if (!TryGetAuthenticatedConnection(out TcpConnection connection))
         {
             return;
         }
 
-        await _tcpConnections.First(x => x.TcpClientAuthenticated).SendTcpCommand($"shutdown {userid} {stop}");
+        await connection.SendTcpCommand($"shutdown {userid} {reboot}");
     }
 
     public async Task AskMudToBroadcast(string message)
     {
-        if (!_tcpConnections.Any(x => x.TcpClientAuthenticated))
+        if (!TryGetAuthenticatedConnection(out TcpConnection connection))
         {
             return;
         }
 
-        await _tcpConnections.First(x => x.TcpClientAuthenticated).SendTcpCommand($"broadcast {message}");
+        await connection.SendTcpCommand($"broadcast {message}");
     }
 
     public async Task SaveRegistrationConfig()
     {
-        await using (StreamWriter writer = new(new FileStream("accountlinks.data", FileMode.Open, FileAccess.ReadWrite)))
+        await using (StreamWriter writer = new(new FileStream("accountlinks.data", FileMode.Create, FileAccess.Write)))
         {
             foreach (DetailedUserSetting config in DetailedUserSettings)
             {

--- a/DiscordBotCore/DiscordBotProtocol.cs
+++ b/DiscordBotCore/DiscordBotProtocol.cs
@@ -1,0 +1,35 @@
+using MudSharp.Framework;
+using System.Linq;
+using System.Text;
+
+namespace Discord_Bot;
+
+#nullable enable
+
+public static class DiscordBotProtocol
+{
+	public const byte EngineCommandDelimiter = (byte)'\n';
+
+	public static string PrepareCommandForEngine(string command)
+	{
+		return command
+			.Replace("\r\n", "\\n")
+			.Replace("\r", "\\n")
+			.Replace("\n", "\\n");
+	}
+
+	public static byte[] EncodeCommandForEngine(string command)
+	{
+		return Encoding.Unicode.GetBytes(PrepareCommandForEngine(command))
+			.Concat(new[] { EngineCommandDelimiter })
+			.ToArray();
+	}
+
+	public static (string ShutdownAccount, bool Reboot) ParseShutdownNotification(string payload)
+	{
+		var ss = new StringStack(payload);
+		var shutdownAccount = ss.PopSpeech();
+		var reboot = ss.IsFinished || !bool.TryParse(ss.PopSpeech(), out var parsedReboot) || parsedReboot;
+		return (shutdownAccount, reboot);
+	}
+}

--- a/DiscordBotCore/Modules/ApproveChargen.cs
+++ b/DiscordBotCore/Modules/ApproveChargen.cs
@@ -39,7 +39,7 @@ public class ApproveChargen : BaseCommandModule
             return;
         }
 
-        if (!DiscordBot.Instance.TCPConnections.Any(x => x.TcpClientAuthenticated))
+        if (!DiscordBot.Instance.TryGetAuthenticatedConnection(out TcpConnection connection))
         {
             await context.RespondAsync($"{context.User.Mention} - I'm not currently connected to the MUD so I cannot do that for you.");
             return;
@@ -53,7 +53,7 @@ public class ApproveChargen : BaseCommandModule
             OnResponseAction = HandleMudResponse
         };
         DiscordBot.Instance.CachedDiscordRequests[request.RequestId] = request;
-        await DiscordBot.Instance.TCPConnections.First(x => x.TcpClientAuthenticated).SendTcpCommand($"approvechargen {request.RequestId} {which} {accountid} {comment}");
+        await connection.SendTcpCommand($"approvechargen {request.RequestId} {which} {accountid} {comment}");
     }
 
     private async Task HandleMudResponse(string text, CommandContext context)
@@ -68,6 +68,9 @@ public class ApproveChargen : BaseCommandModule
             case "chargenapprovalerror":
                 chargenId = long.Parse(ss.Pop());
                 await context.RespondAsync($"{context.User.Mention} - Error with approving character application {chargenId}: {ss.RemainingArgument}");
+                return;
+            case "success":
+                await context.RespondAsync($"{context.User.Mention} - Character application approved.");
                 return;
             default:
                 return;

--- a/DiscordBotCore/Modules/Help.cs
+++ b/DiscordBotCore/Modules/Help.cs
@@ -17,7 +17,7 @@ public class Help : BaseCommandModule
     [Aliases("phelp")]
     public async Task ProgHelpAsync(CommandContext context, [RemainingText] string arguments = "")
     {
-        if (!DiscordBot.Instance.TCPConnections.Any(x => x.TcpClientAuthenticated))
+        if (!DiscordBot.Instance.TryGetAuthenticatedConnection(out TcpConnection connection))
         {
             await context.RespondAsync($"{context.User.Mention} - I'm not currently connected to the MUD so I cannot do that for you.");
             return;
@@ -31,7 +31,7 @@ public class Help : BaseCommandModule
             OnResponseAction = HandleMudProgHelpResponse
         };
         DiscordBot.Instance.CachedDiscordRequests[request.RequestId] = request;
-        await DiscordBot.Instance.TCPConnections.First(x => x.TcpClientAuthenticated).SendTcpCommand($"proghelp {request.RequestId} {arguments}");
+        await connection.SendTcpCommand($"proghelp {request.RequestId} {arguments}");
     }
 
 
@@ -84,7 +84,7 @@ The following commands require you to be registered and authorised before using 
             return;
         }
 
-        if (!DiscordBot.Instance.TCPConnections.Any(x => x.TcpClientAuthenticated))
+        if (!DiscordBot.Instance.TryGetAuthenticatedConnection(out TcpConnection connection))
         {
             await context.RespondAsync($"{context.User.Mention} - I'm not currently connected to the MUD so I cannot do that for you.");
             return;
@@ -98,7 +98,7 @@ The following commands require you to be registered and authorised before using 
             OnResponseAction = HandleMudHelpResponse
         };
         DiscordBot.Instance.CachedDiscordRequests[request.RequestId] = request;
-        await DiscordBot.Instance.TCPConnections.First(x => x.TcpClientAuthenticated).SendTcpCommand($"adminhelp {request.RequestId} {arguments}");
+        await connection.SendTcpCommand($"adminhelp {request.RequestId} {arguments}");
     }
 
     private async Task HandleMudHelpResponse(string text, CommandContext context)
@@ -119,7 +119,7 @@ The following commands require you to be registered and authorised before using 
             return;
         }
 
-        if (!DiscordBot.Instance.TCPConnections.Any(x => x.TcpClientAuthenticated))
+        if (!DiscordBot.Instance.TryGetAuthenticatedConnection(out TcpConnection connection))
         {
             await context.RespondAsync($"{context.User.Mention} - I'm not currently connected to the MUD so I cannot do that for you.");
             return;
@@ -133,6 +133,6 @@ The following commands require you to be registered and authorised before using 
             OnResponseAction = HandleMudHelpResponse
         };
         DiscordBot.Instance.CachedDiscordRequests[request.RequestId] = request;
-        await DiscordBot.Instance.TCPConnections.First(x => x.TcpClientAuthenticated).SendTcpCommand($"help {request.RequestId} {arguments}");
+        await connection.SendTcpCommand($"help {request.RequestId} {arguments}");
     }
 }

--- a/DiscordBotCore/Modules/Map.cs
+++ b/DiscordBotCore/Modules/Map.cs
@@ -1,6 +1,7 @@
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
 using DSharpPlus.Entities;
+using MudSharp.Framework;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -24,7 +25,7 @@ public class Map : BaseCommandModule
             return;
         }
 
-        if (!DiscordBot.Instance.TCPConnections.Any(x => x.TcpClientAuthenticated))
+        if (!DiscordBot.Instance.TryGetAuthenticatedConnection(out TcpConnection connection))
         {
             await context.RespondAsync($"{context.User.Mention} - I'm not currently connected to the MUD so I cannot do that for you.");
             return;
@@ -37,12 +38,26 @@ public class Map : BaseCommandModule
             OnResponseAction = HandleMudResponse
         };
         DiscordBot.Instance.CachedDiscordRequests[request.RequestId] = request;
-        await DiscordBot.Instance.TCPConnections.First(x => x.TcpClientAuthenticated)
-            .SendTcpCommand($"map {request.RequestId} {registration.MudAccountId} {cellId}");
+        await connection.SendTcpCommand($"map {request.RequestId} {registration.MudAccountId} {cellId}");
     }
 
     private async Task HandleMudResponse(string text, CommandContext context)
     {
-        await context.RespondAsync($"{context.User.Mention}\n```{text}```");
+        StringStack ss = new(text);
+        switch (ss.Pop())
+        {
+            case "notauthorised":
+                await context.RespondAsync($"{context.User.Mention} - Your linked MUD account is not authorised to view maps.");
+                return;
+            case "nosuchcell":
+                await context.RespondAsync($"{context.User.Mention} - There is no room with an ID of **{ss.RemainingArgument}**.");
+                return;
+            case "map":
+                await context.RespondAsync($"{context.User.Mention}\n```{ss.RemainingArgument}```");
+                return;
+            default:
+                await context.RespondAsync($"{context.User.Mention}\n```{text}```");
+                return;
+        }
     }
 }

--- a/DiscordBotCore/Modules/Register.cs
+++ b/DiscordBotCore/Modules/Register.cs
@@ -27,7 +27,7 @@ public class Register : BaseCommandModule
             return;
         }
 
-        if (!DiscordBot.Instance.TCPConnections.Any(x => x.TcpClientAuthenticated))
+        if (!DiscordBot.Instance.TryGetAuthenticatedConnection(out TcpConnection connection))
         {
             await context.RespondAsync($"{context.User.Mention} - I'm not currently connected to the MUD so I cannot do that for you.");
             return;
@@ -40,7 +40,7 @@ public class Register : BaseCommandModule
             OnResponseAction = HandleMudResponse
         };
         DiscordBot.Instance.CachedDiscordRequests[request.RequestId] = request;
-        await DiscordBot.Instance.TCPConnections.First(x => x.TcpClientAuthenticated).SendTcpCommand($"register {request.RequestId} {context.User.Id} \"{context.User.Username}\" {account}");
+        await connection.SendTcpCommand($"register {request.RequestId} {context.User.Id} \"{context.User.Username}\" {account}");
     }
 
     private async Task HandleMudResponse(string text, CommandContext context)

--- a/DiscordBotCore/Modules/RejectChargen.cs
+++ b/DiscordBotCore/Modules/RejectChargen.cs
@@ -39,7 +39,7 @@ public class RejectChargen : BaseCommandModule
             return;
         }
 
-        if (!DiscordBot.Instance.TCPConnections.Any(x => x.TcpClientAuthenticated))
+        if (!DiscordBot.Instance.TryGetAuthenticatedConnection(out TcpConnection connection))
         {
             await context.RespondAsync($"{context.User.Mention} - I'm not currently connected to the MUD so I cannot do that for you.");
             return;
@@ -54,7 +54,7 @@ public class RejectChargen : BaseCommandModule
             OnResponseAction = HandleMudResponse
         };
         DiscordBot.Instance.CachedDiscordRequests[request.RequestId] = request;
-        await DiscordBot.Instance.TCPConnections.First(x => x.TcpClientAuthenticated).SendTcpCommand($"rejectchargen {request.RequestId} {which} {accountid} {comment}");
+        await connection.SendTcpCommand($"rejectchargen {request.RequestId} {which} {accountid} {comment}");
     }
 
     private async Task HandleMudResponse(string text, CommandContext context)
@@ -69,6 +69,9 @@ public class RejectChargen : BaseCommandModule
             case "chargenapprovalerror":
                 chargenId = long.Parse(ss.Pop());
                 await context.RespondAsync($"{context.User.Mention} - Error with rejecting character application {chargenId}: {ss.RemainingArgument}");
+                return;
+            case "success":
+                await context.RespondAsync($"{context.User.Mention} - Character application rejected.");
                 return;
             default:
                 return;

--- a/DiscordBotCore/Modules/Send.cs
+++ b/DiscordBotCore/Modules/Send.cs
@@ -28,7 +28,7 @@ public class Send : BaseCommandModule
             return;
         }
 
-        if (!DiscordBot.Instance.TCPConnections.Any(x => x.TcpClientAuthenticated))
+        if (!DiscordBot.Instance.TryGetAuthenticatedConnection(out TcpConnection connection))
         {
             await context.RespondAsync($"{context.User.Mention} - I'm not currently connected to the MUD so I cannot do that for you.");
             return;
@@ -41,7 +41,7 @@ public class Send : BaseCommandModule
             OnResponseAction = HandleMudResponse
         };
         DiscordBot.Instance.CachedDiscordRequests[request.RequestId] = request;
-        await DiscordBot.Instance.TCPConnections.First(x => x.TcpClientAuthenticated).SendTcpCommand($"send {request.RequestId} {registration.MudAccountName} {to} {message}");
+        await connection.SendTcpCommand($"send {request.RequestId} {registration.MudAccountName} {to} {message}");
     }
 
     private async Task HandleMudResponse(string text, CommandContext context)

--- a/DiscordBotCore/Modules/SendChannel.cs
+++ b/DiscordBotCore/Modules/SendChannel.cs
@@ -23,7 +23,7 @@ public class SendChannel : BaseCommandModule
             return;
         }
 
-        if (!DiscordBot.Instance.TCPConnections.Any(x => x.TcpClientAuthenticated))
+        if (!DiscordBot.Instance.TryGetAuthenticatedConnection(out TcpConnection connection))
         {
             await context.RespondAsync($"{context.User.Mention} - I'm not currently connected to the MUD so I cannot do that for you.");
             return;
@@ -36,7 +36,7 @@ public class SendChannel : BaseCommandModule
             OnResponseAction = HandleMudResponse
         };
         DiscordBot.Instance.CachedDiscordRequests[request.RequestId] = request;
-        await DiscordBot.Instance.TCPConnections.First(x => x.TcpClientAuthenticated).SendTcpCommand($"sendchannel {request.RequestId} \"{registration.MudAccountName}\" \"{channel}\" {message}");
+        await connection.SendTcpCommand($"sendchannel {request.RequestId} \"{registration.MudAccountName}\" \"{channel}\" {message}");
     }
 
     private async Task HandleMudResponse(string text, CommandContext context)

--- a/DiscordBotCore/Modules/ShowAccount.cs
+++ b/DiscordBotCore/Modules/ShowAccount.cs
@@ -25,7 +25,7 @@ public class ShowAccount : BaseCommandModule
             return;
         }
 
-        if (!DiscordBot.Instance.TCPConnections.Any(x => x.TcpClientAuthenticated))
+        if (!DiscordBot.Instance.TryGetAuthenticatedConnection(out TcpConnection connection))
         {
             await context.RespondAsync($"{context.User.Mention} - I'm not currently connected to the MUD so I cannot do that for you.");
             return;
@@ -38,8 +38,7 @@ public class ShowAccount : BaseCommandModule
             OnResponseAction = HandleMudResponse
         };
         DiscordBot.Instance.CachedDiscordRequests[request.RequestId] = request;
-        await DiscordBot.Instance.TCPConnections.First(x => x.TcpClientAuthenticated)
-            .SendTcpCommand($"showaccount {request.RequestId} {registration.MudAccountId} {which}");
+        await connection.SendTcpCommand($"showaccount {request.RequestId} {registration.MudAccountId} {which}");
     }
 
     private async Task HandleMudResponse(string text, CommandContext context)

--- a/DiscordBotCore/Modules/ShowCharacter.cs
+++ b/DiscordBotCore/Modules/ShowCharacter.cs
@@ -25,7 +25,7 @@ public class ShowCharacter : BaseCommandModule
             return;
         }
 
-        if (!DiscordBot.Instance.TCPConnections.Any(x => x.TcpClientAuthenticated))
+        if (!DiscordBot.Instance.TryGetAuthenticatedConnection(out TcpConnection connection))
         {
             await context.RespondAsync($"{context.User.Mention} - I'm not currently connected to the MUD so I cannot do that for you.");
             return;
@@ -38,8 +38,7 @@ public class ShowCharacter : BaseCommandModule
             OnResponseAction = HandleMudResponse
         };
         DiscordBot.Instance.CachedDiscordRequests[request.RequestId] = request;
-        await DiscordBot.Instance.TCPConnections.First(x => x.TcpClientAuthenticated)
-            .SendTcpCommand($"showcharacter {request.RequestId} {registration.MudAccountId} {which}");
+        await connection.SendTcpCommand($"showcharacter {request.RequestId} {registration.MudAccountId} {which}");
     }
 
     private async Task HandleMudResponse(string text, CommandContext context)

--- a/DiscordBotCore/Modules/ShowChargen.cs
+++ b/DiscordBotCore/Modules/ShowChargen.cs
@@ -33,7 +33,7 @@ public class ShowChargen : BaseCommandModule
             return;
         }
 
-        if (!DiscordBot.Instance.TCPConnections.Any(x => x.TcpClientAuthenticated))
+        if (!DiscordBot.Instance.TryGetAuthenticatedConnection(out TcpConnection connection))
         {
             await context.RespondAsync($"{context.User.Mention} - I'm not currently connected to the MUD so I cannot do that for you.");
             return;
@@ -46,7 +46,7 @@ public class ShowChargen : BaseCommandModule
             OnResponseAction = HandleMudResponse
         };
         DiscordBot.Instance.CachedDiscordRequests[request.RequestId] = request;
-        await DiscordBot.Instance.TCPConnections.First(x => x.TcpClientAuthenticated).SendTcpCommand($"showchargen {request.RequestId} {DiscordBot.Instance.DetailedUserSettings.First(x => x.DiscordUserId == context.User.Id).MudAccountId} {which}");
+        await connection.SendTcpCommand($"showchargen {request.RequestId} {DiscordBot.Instance.DetailedUserSettings.First(x => x.DiscordUserId == context.User.Id).MudAccountId} {which}");
     }
 
     private async Task HandleMudResponse(string text, CommandContext context)

--- a/DiscordBotCore/Modules/Shutdown.cs
+++ b/DiscordBotCore/Modules/Shutdown.cs
@@ -27,14 +27,14 @@ public class Shutdown : BaseCommandModule
             return;
         }
 
-        if (!DiscordBot.Instance.TCPConnections.Any(x => x.TcpClientAuthenticated))
+        if (!DiscordBot.Instance.TryGetAuthenticatedConnection(out _))
         {
             await context.RespondAsync($"{context.User.Mention} - I'm not currently connected to the MUD so I cannot do that for you.");
             return;
         }
 
         await context.Message.CreateReactionAsync(DiscordEmoji.FromUnicode("👌"));
-        await DiscordBot.Instance.AskMudToShutdown(registration.MudAccountId, false);
+        await DiscordBot.Instance.AskMudToShutdown(registration.MudAccountId, true);
     }
 
     [Command("shutdownstop")]
@@ -53,13 +53,13 @@ public class Shutdown : BaseCommandModule
             return;
         }
 
-        if (!DiscordBot.Instance.TCPConnections.Any(x => x.TcpClientAuthenticated))
+        if (!DiscordBot.Instance.TryGetAuthenticatedConnection(out _))
         {
             await context.RespondAsync($"{context.User.Mention} - I'm not currently connected to the MUD so I cannot do that for you.");
             return;
         }
 
         await context.Message.CreateReactionAsync(DiscordEmoji.FromUnicode("👌"));
-        await DiscordBot.Instance.AskMudToShutdown(registration.MudAccountId, true);
+        await DiscordBot.Instance.AskMudToShutdown(registration.MudAccountId, false);
     }
 }

--- a/DiscordBotCore/Modules/Stats.cs
+++ b/DiscordBotCore/Modules/Stats.cs
@@ -15,7 +15,7 @@ public class Stats : BaseCommandModule
     [Aliases("stat")]
     public async Task StatsAsync(CommandContext context)
     {
-        if (!DiscordBot.Instance.TCPConnections.Any(x => x.TcpClientAuthenticated))
+        if (!DiscordBot.Instance.TryGetAuthenticatedConnection(out TcpConnection connection))
         {
             await context.RespondAsync($"{context.User.Mention} - I'm not currently connected to the MUD so I cannot do that for you.");
             return;
@@ -28,7 +28,7 @@ public class Stats : BaseCommandModule
             OnResponseAction = HandleMudResponse
         };
         DiscordBot.Instance.CachedDiscordRequests[request.RequestId] = request;
-        await DiscordBot.Instance.TCPConnections.First(x => x.TcpClientAuthenticated).SendTcpCommand($"stats {request.RequestId}");
+        await connection.SendTcpCommand($"stats {request.RequestId}");
     }
 
     private async Task HandleMudResponse(string text, CommandContext context)

--- a/DiscordBotCore/Modules/Where.cs
+++ b/DiscordBotCore/Modules/Where.cs
@@ -19,7 +19,7 @@ public class Where : BaseCommandModule
             await context.RespondAsync($"You are not authorised to do that command, {context.User.Mention}.");
         }
 
-        if (!DiscordBot.Instance.TCPConnections.Any(x => x.TcpClientAuthenticated))
+        if (!DiscordBot.Instance.TryGetAuthenticatedConnection(out TcpConnection connection))
         {
             await context.RespondAsync($"{context.User.Mention} - I'm not currently connected to the MUD so I cannot do that for you.");
             return;
@@ -32,7 +32,7 @@ public class Where : BaseCommandModule
             OnResponseAction = HandleMudResponse
         };
         DiscordBot.Instance.CachedDiscordRequests[request.RequestId] = request;
-        await DiscordBot.Instance.TCPConnections.First(x => x.TcpClientAuthenticated).SendTcpCommand($"where {request.RequestId}");
+        await connection.SendTcpCommand($"where {request.RequestId}");
     }
 
     private async Task HandleMudResponse(string text, CommandContext context)

--- a/DiscordBotCore/Modules/Who.cs
+++ b/DiscordBotCore/Modules/Who.cs
@@ -15,7 +15,7 @@ public class Who : BaseCommandModule
     [Aliases("whom", "whomst", "whomsoever", "hu", "hwo")]
     public async Task WhoAsync(CommandContext context)
     {
-        if (!DiscordBot.Instance.TCPConnections.Any(x => x.TcpClientAuthenticated))
+        if (!DiscordBot.Instance.TryGetAuthenticatedConnection(out TcpConnection connection))
         {
             await context.RespondAsync($"{context.User.Mention} - I'm not currently connected to the MUD so I cannot do that for you.");
             return;
@@ -28,7 +28,7 @@ public class Who : BaseCommandModule
             OnResponseAction = HandleMudResponse
         };
         DiscordBot.Instance.CachedDiscordRequests[request.RequestId] = request;
-        await DiscordBot.Instance.TCPConnections.First(x => x.TcpClientAuthenticated).SendTcpCommand($"who {request.RequestId}");
+        await connection.SendTcpCommand($"who {request.RequestId}");
     }
 
     private async Task HandleMudResponse(string text, CommandContext context)

--- a/DiscordBotCore/TcpConnection.cs
+++ b/DiscordBotCore/TcpConnection.cs
@@ -1,17 +1,14 @@
 ﻿using DSharpPlus;
 using DSharpPlus.Entities;
-using Microsoft.EntityFrameworkCore.Query.Internal;
 using MudSharp.Framework;
 using Serilog;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading.Tasks;
-using Utilities = MudSharp.Framework.Utilities;
 
 namespace Discord_Bot;
 
@@ -19,9 +16,9 @@ public class TcpConnection
 {
     private readonly TcpClient _tcpClient;
     private readonly NetworkStream _networkStream;
-    private readonly Stopwatch _inactivityStopwatch = new();
     private static readonly byte[] ByteSeparators = { 1 };
-    private DiscordClient _discordClient;
+    private readonly List<byte> _incomingBytes = new();
+    private readonly DiscordClient _discordClient;
     private readonly DiscordBot _discordBot;
     public bool TcpClientAuthenticated { get; private set; }
     public bool Closing { get; private set; }
@@ -30,7 +27,6 @@ public class TcpConnection
     {
         _tcpClient = tcpClient;
         _networkStream = _tcpClient.GetStream();
-        _inactivityStopwatch.Start();
         _discordClient = discordClient;
         _discordBot = discordBot;
     }
@@ -39,15 +35,6 @@ public class TcpConnection
     {
         try
         {
-            bool blocking = _tcpClient.Client.Blocking;
-            if (_inactivityStopwatch.ElapsedMilliseconds > 15000 &&
-                _inactivityStopwatch.ElapsedMilliseconds % 50 == 0)
-            {
-                _tcpClient.Client.Blocking = false;
-                _tcpClient.Client.Send(new byte[1], 1, SocketFlags.None);
-            }
-            _tcpClient.Client.Blocking = blocking;
-
             if (!_networkStream.DataAvailable)
             {
                 return;
@@ -55,11 +42,23 @@ public class TcpConnection
 
             byte[] inputBuffer = new byte[4096];
             int bytes = _networkStream.Read(inputBuffer, 0, 4096);
-
-            List<byte[]> splitBytes =
-                inputBuffer.Take(bytes).ToArray().SplitDelimiter(ByteSeparators, Utilities.ByteSplitOptions.DiscardDelimiter).ToList();
-            foreach (byte[] command in splitBytes)
+            if (bytes == 0)
             {
+                Closing = true;
+                _tcpClient?.Close();
+                _networkStream?.Close();
+                TcpClientAuthenticated = false;
+                return;
+            }
+
+            _incomingBytes.AddRange(inputBuffer.Take(bytes));
+            while (TryReadIncomingCommand(out byte[] command))
+            {
+                if (command.Length == 0)
+                {
+                    continue;
+                }
+
                 await HandleTcpCommandAsync(Encoding.Unicode.GetString(command));
             }
         }
@@ -77,6 +76,20 @@ public class TcpConnection
             Console.WriteLine(e.Message);
         }
 #endif
+    }
+
+    private bool TryReadIncomingCommand(out byte[] command)
+    {
+        int delimiterIndex = _incomingBytes.IndexOf(ByteSeparators[0]);
+        if (delimiterIndex == -1)
+        {
+            command = Array.Empty<byte>();
+            return false;
+        }
+
+        command = _incomingBytes.GetRange(0, delimiterIndex).ToArray();
+        _incomingBytes.RemoveRange(0, delimiterIndex + 1);
+        return true;
     }
 
     private async Task HandleTcpCommandAsync(string getString)
@@ -237,9 +250,23 @@ public class TcpConnection
 
     private async Task HandleTcpCommandRequest(StringStack ss)
     {
-        ulong request = ulong.Parse(ss.Pop());
-        CachedDiscordRequest cachedRequest = _discordBot.CachedDiscordRequests[request];
-        _discordBot.CachedDiscordRequests.Remove(request);
+        if (!TcpClientAuthenticated)
+        {
+            return;
+        }
+
+        if (!ulong.TryParse(ss.Pop(), out ulong request))
+        {
+            Log.Warning("Received malformed Discord TCP request response without a valid request id.");
+            return;
+        }
+
+        if (!_discordBot.CachedDiscordRequests.TryRemove(request, out CachedDiscordRequest cachedRequest))
+        {
+            Log.Warning("Received Discord TCP response for unknown request id {RequestId}.", request);
+            return;
+        }
+
         await cachedRequest.OnResponseAction(ss.RemainingArgument, cachedRequest.Context);
     }
 
@@ -248,7 +275,7 @@ public class TcpConnection
         long whoId = long.Parse(ss.Pop());
         string accountName = ss.Pop();
         long whereId = long.Parse(ss.Pop());
-        string roomLayer = ss.Pop();
+        string roomLayer = ss.PopSpeech();
         string where = ss.PopSpeech();
         string whoDesc = ss.PopSpeech();
         string whoName = ss.PopSpeech();
@@ -339,12 +366,12 @@ public class TcpConnection
         {
             return;
         }
-        string account = ss.Pop();
-        string approver = ss.Pop();
+        string account = ss.PopSpeech();
+        string approver = ss.PopSpeech();
         string name = ss.RemainingArgument;
         DiscordEmbed embed = new DiscordEmbedBuilder()
                     .WithTitle("Character Rejected")
-                    .WithDescription($"Account \"{approver}\" rejected \"{account}'s\"  application \"{name}\".")
+                    .WithDescription($"Account \"{account}\" had application \"{name}\" rejected by \"{approver}\".")
                     .Build()
             ;
 
@@ -357,12 +384,12 @@ public class TcpConnection
         {
             return;
         }
-        string account = ss.Pop();
-        string approver = ss.Pop();
+        string account = ss.PopSpeech();
+        string approver = ss.PopSpeech();
         string name = ss.RemainingArgument;
         DiscordEmbed embed = new DiscordEmbedBuilder()
                     .WithTitle("Character Approved")
-                    .WithDescription($"Account \"{approver}\" approved \"{account}'s\"  application \"{name}\".")
+                    .WithDescription($"Account \"{account}\" had application \"{name}\" approved by \"{approver}\".")
                     .Build()
             ;
 
@@ -434,11 +461,18 @@ public class TcpConnection
             return;
         }
 
+        (string account, bool reboot) = DiscordBotProtocol.ParseShutdownNotification(shutdownAccount);
         Closing = true;
         _tcpClient?.Close();
         _networkStream?.Close();
         TcpClientAuthenticated = false;
-        await _discordBot.AnnounceToDiscord($"{_discordBot.GameName} has been shutdown by {shutdownAccount}. It should be back in a couple of minutes.");
+        if (reboot)
+        {
+            await _discordBot.AnnounceToDiscord($"{_discordBot.GameName} has been shutdown by {account}. It should be back in a couple of minutes.");
+            return;
+        }
+
+        await _discordBot.AnnounceToDiscord($"{_discordBot.GameName} has been shutdown by {account}, and it has been told not to reboot automatically.");
     }
 
     private async Task HandleTcpCommandLoginAsync(string getString)
@@ -448,7 +482,7 @@ public class TcpConnection
         if (auth.EqualTo(_discordBot.ServerAuth))
         {
             TcpClientAuthenticated = true;
-            _tcpClient.Client.Send(Encoding.Unicode.GetBytes("authsuccess"));
+            _tcpClient.Client.Send(DiscordBotProtocol.EncodeCommandForEngine("authsuccess"));
             await _discordBot.AnnounceToDiscord($"I have successfully heard from {_discordBot.GameName}, and I'm now ready to report on what it's up to!");
             if (!ss.IsFinished)
             {
@@ -457,7 +491,7 @@ public class TcpConnection
         }
         else
         {
-            _tcpClient.Client.Send(Encoding.Unicode.GetBytes("authfailure"));
+            _tcpClient.Client.Send(DiscordBotProtocol.EncodeCommandForEngine("authfailure"));
         }
     }
 
@@ -465,7 +499,8 @@ public class TcpConnection
     {
         try
         {
-            await _tcpClient.Client.SendAsync(Encoding.Unicode.GetBytes(command + '\n'), SocketFlags.None);
+            byte[] bytes = DiscordBotProtocol.EncodeCommandForEngine(command);
+            await _tcpClient.Client.SendAsync(bytes, SocketFlags.None);
         }
         catch (SocketException e)
         {

--- a/FutureMUDLibrary/Discord/IDiscordConnection.cs
+++ b/FutureMUDLibrary/Discord/IDiscordConnection.cs
@@ -8,7 +8,7 @@ namespace MudSharp.Discord
         void SendMessageFromProg(ulong channel, string title, string message);
         void NotifyPetition(string account, string message, string location);
         void NotifyCharacterSubmission(string account, string name, long id);
-        void NotifyShutdown(string shutdownAccount);
+        void NotifyShutdown(string shutdownAccount, bool reboot = true);
         void NotifyCharacterApproval(string account, string name, string approver);
         void NotifyCharacterRejection(string account, string name, string reviewer);
         void NotifyCrash(string crashMessage);

--- a/MudSharpCore/Commands/Modules/StaffModule.cs
+++ b/MudSharpCore/Commands/Modules/StaffModule.cs
@@ -2128,7 +2128,7 @@ The syntax is #3setcharacters <account> <##characters>#0.", AutoHelp.HelpArgOrNo
                 actor.Gameworld.Name.Proper().ColourName()));
             actor.Gameworld.Characters.ForEach(x => x.EffectsChanged = true);
             actor.Gameworld.SaveManager.Flush();
-            actor.Gameworld.DiscordConnection.NotifyShutdown(actor.Account.Name);
+            actor.Gameworld.DiscordConnection.NotifyShutdown(actor.Account.Name, true);
             using (new FMDB())
             {
                 DateTime time = DateTime.UtcNow;
@@ -2155,7 +2155,7 @@ The syntax is #3setcharacters <account> <##characters>#0.", AutoHelp.HelpArgOrNo
                 actor.Gameworld.Name.Proper().ColourName()));
             actor.Gameworld.Characters.ForEach(x => x.EffectsChanged = true);
             actor.Gameworld.SaveManager.Flush();
-            actor.Gameworld.DiscordConnection.NotifyShutdown(actor.Account.Name);
+            actor.Gameworld.DiscordConnection.NotifyShutdown(actor.Account.Name, false);
             using (FileStream fs = File.Create("STOP-REBOOTING"))
             {
             }

--- a/MudSharpCore/Discord/DiscordConnection.cs
+++ b/MudSharpCore/Discord/DiscordConnection.cs
@@ -40,6 +40,7 @@ public sealed class DiscordConnection : IDiscordConnection
     private NetworkStream _stream;
     private string _serverAuth;
     private DateTime _lastConnectionAttempt;
+    private readonly List<byte> _incomingBytes = new();
 
     public IFuturemud Gameworld { get; private set; }
 
@@ -88,11 +89,11 @@ public sealed class DiscordConnection : IDiscordConnection
         }
     }
 
-    public void NotifyShutdown(string shutdownAccount)
+    public void NotifyShutdown(string shutdownAccount, bool reboot = true)
     {
         try
         {
-            SendClientMessage($"shutdown {shutdownAccount}");
+            SendClientMessage($"shutdown \"{shutdownAccount}\" {reboot}");
         }
         catch (SocketException)
         {
@@ -105,7 +106,7 @@ public sealed class DiscordConnection : IDiscordConnection
     {
         try
         {
-            SendClientMessage($"chargen_approved {account} {approver} {name}");
+            SendClientMessage($"chargen_approved \"{account}\" \"{approver}\" {name}");
         }
         catch (SocketException)
         {
@@ -118,7 +119,7 @@ public sealed class DiscordConnection : IDiscordConnection
     {
         try
         {
-            SendClientMessage($"chargen_rejected {account} {reviewer} {name}");
+            SendClientMessage($"chargen_rejected \"{account}\" \"{reviewer}\" {name}");
         }
         catch (SocketException)
         {
@@ -204,7 +205,7 @@ public sealed class DiscordConnection : IDiscordConnection
         try
         {
             SendClientMessage(
-                $"notifydeath {who.Id} {who.Account.Name} {who.Location.Id} {who.RoomLayer.DescribeEnum()} \"{who.Location.HowSeen(who, colour: false, flags: PerceiveIgnoreFlags.IgnoreCanSee)}\" \"{who.HowSeen(who, colour: false, flags: PerceiveIgnoreFlags.IgnoreCanSee | PerceiveIgnoreFlags.IgnoreSelf)}\" \"{who.PersonalName.GetName(NameStyle.FullName)}\"");
+                $"notifydeath {who.Id} {who.Account.Name} {who.Location.Id} \"{who.RoomLayer.DescribeEnum()}\" \"{who.Location.HowSeen(who, colour: false, flags: PerceiveIgnoreFlags.IgnoreCanSee)}\" \"{who.HowSeen(who, colour: false, flags: PerceiveIgnoreFlags.IgnoreCanSee | PerceiveIgnoreFlags.IgnoreSelf)}\" \"{who.PersonalName.GetName(NameStyle.FullName)}\"");
         }
         catch (SocketException)
         {
@@ -264,6 +265,7 @@ public sealed class DiscordConnection : IDiscordConnection
 
         _client = null;
         _stream = null;
+        _incomingBytes.Clear();
     }
 
     public void HandleMessages()
@@ -290,11 +292,21 @@ public sealed class DiscordConnection : IDiscordConnection
 
             byte[] inputBuffer = new byte[4096];
             int bytes = _stream.Read(inputBuffer, 0, 4096);
-
-            List<byte[]> splitBytes =
-                inputBuffer.Take(bytes).ToArray().SplitDelimiter(ByteSeparators).ToList();
-            foreach (byte[] command in splitBytes)
+            if (bytes == 0)
             {
+                CloseTcpConnection();
+                OpenTcpConnection();
+                return;
+            }
+
+            _incomingBytes.AddRange(inputBuffer.Take(bytes));
+            while (TryReadIncomingCommand(out byte[] command))
+            {
+                if (command.Length == 0)
+                {
+                    continue;
+                }
+
                 HandleTcpCommand(Encoding.Unicode.GetString(command));
             }
         }
@@ -303,6 +315,20 @@ public sealed class DiscordConnection : IDiscordConnection
             CloseTcpConnection();
             OpenTcpConnection();
         }
+    }
+
+    private bool TryReadIncomingCommand(out byte[] command)
+    {
+        int delimiterIndex = _incomingBytes.IndexOf(ByteSeparators[0]);
+        if (delimiterIndex == -1)
+        {
+            command = Array.Empty<byte>();
+            return false;
+        }
+
+        command = _incomingBytes.GetRange(0, delimiterIndex).ToArray();
+        _incomingBytes.RemoveRange(0, delimiterIndex + 1);
+        return true;
     }
 
     private void HandleTcpCommand(string getString)
@@ -382,8 +408,8 @@ public sealed class DiscordConnection : IDiscordConnection
         ulong request = ulong.Parse(ss.PopSpeech());
         string from = ss.PopSpeech();
         string channel = ss.PopSpeech();
-        string message = ss.SafeRemainingArgument;
-        IAccount account = Gameworld.Accounts.FirstOrDefault(x => x.Name == from);
+        string message = ss.RemainingArgument.ParseSpecialCharacters();
+        IAccount account = Gameworld.Accounts.FirstOrDefault(x => x.Name.EqualTo(from));
         if (account is null)
         {
             SendClientMessage($"request {request} sendfailedaccount");
@@ -431,7 +457,7 @@ public sealed class DiscordConnection : IDiscordConnection
 
         Gameworld.Characters.ForEach(x => x.EffectsChanged = true);
         Gameworld.SaveManager.Flush();
-        Gameworld.DiscordConnection.NotifyShutdown(account.Name.Proper());
+        Gameworld.DiscordConnection.NotifyShutdown(account.Name.Proper(), reboot);
 
         if (reboot)
         {
@@ -457,7 +483,7 @@ public sealed class DiscordConnection : IDiscordConnection
         ulong request = ulong.Parse(ss.PopSpeech());
         long which = long.Parse(ss.PopSpeech(), CultureInfo.InvariantCulture.NumberFormat);
         long requesterid = long.Parse(ss.PopSpeech(), CultureInfo.InvariantCulture.NumberFormat);
-        string message = ss.RemainingArgument;
+        string message = ss.RemainingArgument.ParseSpecialCharacters();
 
         Chargen chargen;
         IAccount account;
@@ -481,6 +507,7 @@ public sealed class DiscordConnection : IDiscordConnection
             return;
         }
 
+        SendClientMessage($"request {request} success");
         chargen.RejectApplication(null, account, message, null);
     }
 
@@ -489,7 +516,7 @@ public sealed class DiscordConnection : IDiscordConnection
         ulong request = ulong.Parse(ss.PopSpeech());
         long which = long.Parse(ss.PopSpeech(), CultureInfo.InvariantCulture.NumberFormat);
         long requesterid = long.Parse(ss.PopSpeech(), CultureInfo.InvariantCulture.NumberFormat);
-        string message = ss.RemainingArgument;
+        string message = ss.RemainingArgument.ParseSpecialCharacters();
 
         Chargen chargen;
         IAccount account;
@@ -839,7 +866,7 @@ public sealed class DiscordConnection : IDiscordConnection
         ulong request = ulong.Parse(ss.PopSpeech());
         string from = ss.PopSpeech();
         string to = ss.PopSpeech();
-        string message = ss.RemainingArgument;
+        string message = ss.RemainingArgument.ParseSpecialCharacters();
         IPlayerConnection user = Gameworld.Connections.FirstOrDefault(x =>
             x.State == ConnectionState.Open && x.ControlPuppet?.Account?.Name.EqualTo(to) == true);
         if (user == null)
@@ -849,7 +876,7 @@ public sealed class DiscordConnection : IDiscordConnection
         }
 
         user.ControlPuppet.OutputHandler?.Send(
-            $"{$"[From {from}]".Colour(Telnet.Green)} {message.ParseSpecialCharacters().SubstituteANSIColour().ProperSentences()}");
+            $"{$"[From {from}]".Colour(Telnet.Green)} {message.SubstituteANSIColour().ProperSentences()}");
         SendClientMessage($"request {request} sendacknowledge {from} {to} {message}");
     }
 
@@ -860,8 +887,9 @@ public sealed class DiscordConnection : IDiscordConnection
             return;
         }
 
-        Gameworld.SystemMessage(ss.RemainingArgument.ParseSpecialCharacters().SubstituteANSIColour().ProperSentences());
-        HandleBroadcast(ss.RemainingArgument.ParseSpecialCharacters().SubstituteANSIColour().ProperSentences());
+        string message = ss.RemainingArgument.ParseSpecialCharacters().SubstituteANSIColour().ProperSentences();
+        Gameworld.SystemMessage(message);
+        HandleBroadcast(message);
     }
 
     private void HandleProgHelpTcpCommand(StringStack ss)
@@ -1076,7 +1104,7 @@ public sealed class DiscordConnection : IDiscordConnection
             sb.AppendLine(help.PublicText.SubstituteANSIColour().Wrap(80).RawText());
             sb.AppendLine();
             sb.AppendLine($"Last edited by {help.LastEditedBy.Proper()} on {help.LastEditedDate.ToLongDateString()}");
-            _client.Client.Send(Encoding.Unicode.GetBytes($"request {response} {sb}"));
+            SendClientMessage($"request {response} {sb}");
             return;
         }
 
@@ -1197,7 +1225,7 @@ public sealed class DiscordConnection : IDiscordConnection
                 : "",
             guestCount > 0
                 ? $"\nThere are {guestCount} guest{(guestCount == 1 ? "" : "s")} in the guest lounge."
-                : "") + (char)1;
+            : "");
         SendClientMessage(text);
     }
 


### PR DESCRIPTION
**Summary**
- Fix Discord bot and engine TCP framing so multi-part responses are buffered correctly instead of being parsed mid-packet.
- Align shutdown, chargen, map, help, and message transaction payloads between `DiscordBotCore` and `MudSharpCore/Discord`.
- Harden `DiscordBot.cs` connection lookup and cached request handling to reduce race conditions and stale file writes.
- Add focused protocol tests for command encoding and shutdown parsing.

**Testing**
- `dotnet build DiscordBotCore\DiscordBotCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `dotnet test 'DiscordBotCore Unit Tests\DiscordBotCore Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`