### PR TITLE
Fix CoreDataSeeder liquid FK handling

### DIFF
--- a/DatabaseSeeder Unit Tests/CoreDataSeederMaterialTests.cs
+++ b/DatabaseSeeder Unit Tests/CoreDataSeederMaterialTests.cs
@@ -45,6 +45,28 @@ public class CoreDataSeederMaterialTests
             .Invoke(seeder, [context]);
     }
 
+    private static MudSharp.Models.Liquid BuildPlaceholderLiquid(string name)
+    {
+        return new MudSharp.Models.Liquid
+        {
+            Name = name,
+            Description = name,
+            LongDescription = name,
+            TasteText = name,
+            VagueTasteText = name,
+            SmellText = name,
+            VagueSmellText = name,
+            DisplayColour = "blue",
+            DampDescription = name,
+            WetDescription = name,
+            DrenchedDescription = name,
+            DampShortDescription = name,
+            WetShortDescription = name,
+            DrenchedShortDescription = name,
+            SurfaceReactionInfo = string.Empty
+        };
+    }
+
     private static Mock<IFuturemud> CreateGameworld(All<ISolid> materials, FuturemudDatabaseContext context)
     {
         All<ITag> tags = new();
@@ -155,5 +177,33 @@ public class CoreDataSeederMaterialTests
         Assert.IsTrue(context.Materials.Any(x => x.Name == "bone"));
         Assert.IsTrue(context.Materials.Any(x => x.Name == "blood"));
         Assert.IsTrue(context.Materials.Any(x => x.Name == "rosewood"));
+    }
+
+    [TestMethod]
+    public void SeedMaterialsBase_DoesNotAssumeWaterHasLiquidIdOne()
+    {
+        using FuturemudDatabaseContext context = BuildContext();
+        MudSharp.Models.Liquid retiredLiquid = BuildPlaceholderLiquid("retired liquid placeholder");
+        context.Liquids.Add(retiredLiquid);
+        context.SaveChanges();
+        context.Liquids.Remove(retiredLiquid);
+        context.SaveChanges();
+
+        SeedMaterialsBase(context);
+
+        MudSharp.Models.Liquid water = context.Liquids.Single(x => x.Name == "water");
+        MudSharp.Models.Liquid soapyWater = context.Liquids.Single(x => x.Name == "soapy water");
+        MudSharp.Models.Liquid detergent = context.Liquids.Single(x => x.Name == "detergent");
+
+        Assert.AreNotEqual(1L, water.Id, "Test setup should exercise a non-1 water id.");
+        Assert.AreEqual(water.Id, context.Liquids.Single(x => x.Name == "blood").SolventId);
+        Assert.AreEqual(water.Id, context.Liquids.Single(x => x.Name == "sweat").SolventId);
+        Assert.AreEqual(water.Id, context.Liquids.Single(x => x.Name == "vomit").SolventId);
+        Assert.AreEqual(water.Id, context.Liquids.Single(x => x.Name == "lager").SolventId);
+        Assert.AreEqual(water.Id, context.Materials.Single(x => x.Name == "dried blood").SolventId);
+        Assert.AreEqual(water.Id, context.Materials.Single(x => x.Name == "dried Sweat").SolventId);
+        Assert.AreEqual(water.Id, context.Materials.Single(x => x.Name == "dried vomit").SolventId);
+        Assert.AreEqual(soapyWater.Id, context.Liquids.Single(x => x.Name == "olive oil").SolventId);
+        Assert.AreEqual(detergent.Id, context.Liquids.Single(x => x.Name == "kerosene").SolventId);
     }
 }

--- a/DatabaseSeeder/Seeders/CoreDataSeeder.cs
+++ b/DatabaseSeeder/Seeders/CoreDataSeeder.cs
@@ -10353,6 +10353,7 @@ return IsAdmin(@ch)",
 
         Dictionary<string, Liquid> liquids = new(StringComparer.InvariantCultureIgnoreCase);
         Dictionary<Liquid, string> liquidCountsAs = new();
+        Dictionary<Liquid, string> liquidSolvents = new();
 
         void AddLiquid(string name, string description, string longDescription, string taste, string? vagueTaste,
             string smell, string? vagueSmell, double tasteIntensity, double smellIntensity, double alcohol,
@@ -10416,7 +10417,7 @@ return IsAdmin(@ch)",
 
             if (solvent != null)
             {
-                liquid.Solvent = liquids[solvent];
+                liquidSolvents[liquid] = solvent;
             }
 
             foreach (string tag in materialTags)
@@ -10503,6 +10504,7 @@ return IsAdmin(@ch)",
         #endregion
 
         context.SaveChanges();
+        var defaultWater = liquids["water"];
 
         #region Biofluids
 
@@ -10526,7 +10528,7 @@ return IsAdmin(@ch)",
             ShearYield = 1000,
             ShearStrainAtYield = 2,
             YoungsModulus = 0.1,
-            SolventId = 1,
+            SolventId = defaultWater.Id,
             SolventVolumeRatio = 4,
             ResidueDesc = "It is covered in {0}dried blood",
             ResidueColour = "red",
@@ -10563,7 +10565,7 @@ return IsAdmin(@ch)",
             DampShortDescription = "(blood damp)",
             WetShortDescription = "(bloody)",
             DrenchedShortDescription = "(blood drenched)",
-            SolventId = 1,
+            SolventId = defaultWater.Id,
             SolventVolumeRatio = 5,
             InjectionConsequence = (int)LiquidInjectionConsequence.BloodReplacement,
             ResidueVolumePercentage = 0.05,
@@ -10591,7 +10593,7 @@ return IsAdmin(@ch)",
             ShearYield = 1000,
             ShearStrainAtYield = 2,
             YoungsModulus = 0.1,
-            SolventId = 1,
+            SolventId = defaultWater.Id,
             SolventVolumeRatio = 3,
             ResidueDesc = "It is covered in {0}dried sweat",
             ResidueColour = "yellow",
@@ -10628,7 +10630,7 @@ return IsAdmin(@ch)",
             DampShortDescription = "(sweat-damp)",
             WetShortDescription = "(sweaty)",
             DrenchedShortDescription = "(sweat-drenched)",
-            SolventId = 1,
+            SolventId = defaultWater.Id,
             SolventVolumeRatio = 5,
             InjectionConsequence = (int)LiquidInjectionConsequence.Harmful,
             ResidueVolumePercentage = 0.05,
@@ -10656,7 +10658,7 @@ return IsAdmin(@ch)",
             ShearYield = 1000,
             ShearStrainAtYield = 2,
             YoungsModulus = 0.1,
-            SolventId = 1,
+            SolventId = defaultWater.Id,
             SolventVolumeRatio = 3,
             ResidueDesc = "It is covered in {0}dried vomit",
             ResidueColour = "yellow",
@@ -10693,7 +10695,7 @@ return IsAdmin(@ch)",
             DampShortDescription = "(vomit-stained)",
             WetShortDescription = "(vomit-covered)",
             DrenchedShortDescription = "(vomit-drenched)",
-            SolventId = 1,
+            SolventId = defaultWater.Id,
             SolventVolumeRatio = 10,
             InjectionConsequence = (int)LiquidInjectionConsequence.Deadly,
             ResidueVolumePercentage = 0.05,
@@ -11016,6 +11018,11 @@ return IsAdmin(@ch)",
         context.SaveChanges();
 
         foreach (KeyValuePair<Material, string> solvent in solvents)
+        {
+            solvent.Key.SolventId = liquids[solvent.Value].Id;
+        }
+
+        foreach (KeyValuePair<Liquid, string> solvent in liquidSolvents)
         {
             solvent.Key.SolventId = liquids[solvent.Value].Id;
         }


### PR DESCRIPTION
## Summary
- Replaced the CoreDataSeeder assumption that `water` always has liquid id `1` with a lookup of the actual seeded id.
- Deferred liquid solvent assignment until after liquids have been saved, so self-referential solvent links are resolved against real database ids.
- Added a regression test that forces a non-1 liquid id before seeding and verifies the seeded solvent links still resolve correctly.

## Testing
- `DatabaseSeeder Unit Tests` `CoreDataSeederMaterialTests` passed locally after the patch, including the new non-1 water-id regression.