### PR TITLE
Fix Supernatural horned fiend tail cloning from the wrong body prototype

### DIFF
--- a/DatabaseSeeder Unit Tests/SupernaturalSeederTemplateTests.cs
+++ b/DatabaseSeeder Unit Tests/SupernaturalSeederTemplateTests.cs
@@ -2,13 +2,19 @@
 
 using DatabaseSeeder.Seeders;
 using DatabaseSeeder;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Body;
 using MudSharp.Character;
 using MudSharp.Combat;
+using MudSharp.Database;
+using MudSharp.GameItems;
+using MudSharp.Models;
 using MudSharp.Planes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Xml.Linq;
 
 namespace MudSharp_Unit_Tests;
@@ -21,6 +27,51 @@ public class SupernaturalSeederTemplateTests
 		return element?
 			.Elements("Plane")
 			.Any(x => long.Parse(x.Attribute("id")?.Value ?? "0") == planeId) == true;
+	}
+
+	private static FuturemudDatabaseContext BuildContext()
+	{
+		DbContextOptions<FuturemudDatabaseContext> options = new DbContextOptionsBuilder<FuturemudDatabaseContext>()
+			.UseInMemoryDatabase(Guid.NewGuid().ToString())
+			.Options;
+		return new FuturemudDatabaseContext(options);
+	}
+
+	private static BodyProto CreateBody(long id, string name, BodyProto? countsAs = null)
+	{
+		return new BodyProto
+		{
+			Id = id,
+			Name = name,
+			CountsAs = countsAs,
+			CountsAsId = countsAs?.Id,
+			ConsiderString = string.Empty,
+			WielderDescriptionSingle = "hand",
+			WielderDescriptionPlural = "hands",
+			LegDescriptionSingular = "leg",
+			LegDescriptionPlural = "legs"
+		};
+	}
+
+	private static BodypartProto CreateBodypart(long id, BodyProto body, string alias, string description, int order)
+	{
+		return new BodypartProto
+		{
+			Id = id,
+			Body = body,
+			BodyId = body.Id,
+			Name = alias,
+			Description = description,
+			BodypartType = (int)BodypartTypeEnum.Wear,
+			DisplayOrder = order,
+			MaxLife = 100,
+			SeveredThreshold = 100,
+			PainModifier = 1.0,
+			BleedModifier = 1.0,
+			RelativeHitChance = 100,
+			MaxSingleSize = (int)SizeCategory.Normal,
+			IsCore = true
+		};
 	}
 
 	[TestMethod]
@@ -346,6 +397,8 @@ public class SupernaturalSeederTemplateTests
 	{
 		string[] expectedTailAliases = ["utail", "mtail", "ltail"];
 
+		Assert.AreEqual("Quadruped Base", SupernaturalSeeder.SupernaturalHumanoidTailDonorBodyNameForTesting,
+			"Supernatural humanoid tails must clone from the body that directly owns the stock tail aliases.");
 		CollectionAssert.AreEquivalent(expectedTailAliases,
 			SupernaturalSeeder.SupernaturalBodyAdditionalAliasesForTesting["Supernatural Horned Fiend"]);
 		CollectionAssert.AreEquivalent(expectedTailAliases,
@@ -358,6 +411,73 @@ public class SupernaturalSeederTemplateTests
 					expectedTailAliases.All(alias => x.BodypartAliases.Contains(alias, StringComparer.OrdinalIgnoreCase))),
 				$"{demonName} should use the seeded tail aliases for Barbed Tail Slap.");
 		}
+	}
+
+	[TestMethod]
+	public void BodyAdditionsForTesting_HumanoidTailClonesFromQuadrupedBaseOwner()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		BodyProto quadrupedBase = CreateBody(1, "Quadruped Base");
+		BodyProto toedQuadruped = CreateBody(2, "Toed Quadruped", quadrupedBase);
+		BodyProto hornedFiend = CreateBody(3, "Supernatural Horned Fiend");
+		context.BodyProtos.AddRange(quadrupedBase, toedQuadruped, hornedFiend);
+
+		BodypartProto quadrupedBack = CreateBodypart(1, quadrupedBase, "lback", "lower back", 1);
+		BodypartProto upperTail = CreateBodypart(2, quadrupedBase, "utail", "upper tail", 2);
+		BodypartProto middleTail = CreateBodypart(3, quadrupedBase, "mtail", "middle tail", 3);
+		BodypartProto lowerTail = CreateBodypart(4, quadrupedBase, "ltail", "lower tail", 4);
+		BodypartProto fiendBack = CreateBodypart(5, hornedFiend, "lback", "lower back", 1);
+		context.BodypartProtos.AddRange(quadrupedBack, upperTail, middleTail, lowerTail, fiendBack);
+		context.BodypartProtoBodypartProtoUpstream.AddRange(
+			new BodypartProtoBodypartProtoUpstream
+			{
+				Child = upperTail.Id,
+				Parent = quadrupedBack.Id,
+				ChildNavigation = upperTail,
+				ParentNavigation = quadrupedBack
+			},
+			new BodypartProtoBodypartProtoUpstream
+			{
+				Child = middleTail.Id,
+				Parent = upperTail.Id,
+				ChildNavigation = middleTail,
+				ParentNavigation = upperTail
+			},
+			new BodypartProtoBodypartProtoUpstream
+			{
+				Child = lowerTail.Id,
+				Parent = middleTail.Id,
+				ChildNavigation = lowerTail,
+				ParentNavigation = middleTail
+			});
+		context.SaveChanges();
+
+		var seeder = new SupernaturalSeeder();
+		typeof(SupernaturalSeeder).GetField("_context", BindingFlags.Instance | BindingFlags.NonPublic)!
+			.SetValue(seeder, context);
+		typeof(SupernaturalSeeder).GetField("_quadrupedBody", BindingFlags.Instance | BindingFlags.NonPublic)!
+			.SetValue(seeder, quadrupedBase);
+		typeof(SupernaturalSeeder).GetField("_toedQuadrupedBody", BindingFlags.Instance | BindingFlags.NonPublic)!
+			.SetValue(seeder, toedQuadruped);
+
+		typeof(SupernaturalSeeder).GetMethod("EnsureHumanoidTail", BindingFlags.Instance | BindingFlags.NonPublic)!
+			.Invoke(seeder, new object[] { hornedFiend });
+
+		string[] clonedAliases = context.BodypartProtos
+			.Where(x => x.BodyId == hornedFiend.Id)
+			.Select(x => x.Name)
+			.AsEnumerable()
+			.OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+			.ToArray();
+
+		CollectionAssert.IsSubsetOf(new[] { "utail", "mtail", "ltail" }, clonedAliases);
+		Assert.IsTrue(context.BodypartProtoBodypartProtoUpstream.Any(x =>
+			x.ChildNavigation.Name == "utail" &&
+			x.ParentNavigation.Id == fiendBack.Id));
+		Assert.IsTrue(context.Limbs.Any(x =>
+			x.RootBodyId == hornedFiend.Id &&
+			x.Name == "Tail" &&
+			x.RootBodypart.Name == "utail"));
 	}
 
 	[TestMethod]

--- a/DatabaseSeeder/SeederMetadataRegistry.cs
+++ b/DatabaseSeeder/SeederMetadataRegistry.cs
@@ -248,7 +248,7 @@ public static class SeederMetadataRegistry
                 SeederUpdateCapability.RepairExisting,
                 [
                     Requirement("Human, animal, and mythical body frameworks must already be installed.", context =>
-                        new[] { "Organic Humanoid", "Winged Humanoid", "Horned Humanoid", "Toed Quadruped" }
+                        new[] { "Organic Humanoid", "Winged Humanoid", "Horned Humanoid", "Quadruped Base", "Toed Quadruped" }
                             .All(body => context.BodyProtos.Any(x => x.Name == body))),
                     Requirement("Human, organic humanoid, and wolf race foundations must already exist.", context =>
                         new[] { "Human", "Organic Humanoid", "Wolf" }.All(race => context.Races.Any(x => x.Name == race))),

--- a/DatabaseSeeder/Seeders/SupernaturalSeeder.Support.cs
+++ b/DatabaseSeeder/Seeders/SupernaturalSeeder.Support.cs
@@ -20,6 +20,7 @@ public partial class SupernaturalSeeder
 {
 	private const string SupernaturalUndeadCorpseModelName = "Supernatural Nondecaying Undead Remains";
 	private const string SupernaturalSpiritCorpseModelName = "Supernatural Dissipating Spirit Remains";
+	private const string SupernaturalHumanoidTailDonorBodyName = "Quadruped Base";
 
 	internal sealed record SupernaturalAttackDefinition(
 		string DonorName,
@@ -56,6 +57,9 @@ public partial class SupernaturalSeeder
 
 	internal static IReadOnlyDictionary<string, string[]> SupernaturalBodyAdditionalAliasesForTesting =>
 		CustomBodyAdditionalAliases;
+
+	internal static string SupernaturalHumanoidTailDonorBodyNameForTesting =>
+		SupernaturalHumanoidTailDonorBodyName;
 
 	private static SupernaturalAttackDefinition AttackDefinition(string donorName, string message,
 		params string[] categories)

--- a/DatabaseSeeder/Seeders/SupernaturalSeeder.cs
+++ b/DatabaseSeeder/Seeders/SupernaturalSeeder.cs
@@ -30,6 +30,7 @@ public partial class SupernaturalSeeder : IDatabaseSeeder
 	private BodyProto _organicHumanoidBody = null!;
 	private BodyProto _wingedHumanoidBody = null!;
 	private BodyProto _hornedHumanoidBody = null!;
+	private BodyProto _quadrupedBody = null!;
 	private BodyProto _toedQuadrupedBody = null!;
 	private FutureProg _alwaysTrue = null!;
 	private FutureProg _alwaysFalse = null!;
@@ -112,6 +113,7 @@ public partial class SupernaturalSeeder : IDatabaseSeeder
 			"Organic Humanoid",
 			"Winged Humanoid",
 			"Horned Humanoid",
+			"Quadruped Base",
 			"Toed Quadruped"
 		];
 		string[] requiredRaces =
@@ -208,6 +210,7 @@ public partial class SupernaturalSeeder : IDatabaseSeeder
 		_organicHumanoidBody = _context.BodyProtos.First(x => x.Name == "Organic Humanoid");
 		_wingedHumanoidBody = _context.BodyProtos.First(x => x.Name == "Winged Humanoid");
 		_hornedHumanoidBody = _context.BodyProtos.First(x => x.Name == "Horned Humanoid");
+		_quadrupedBody = _context.BodyProtos.First(x => x.Name == SupernaturalHumanoidTailDonorBodyName);
 		_toedQuadrupedBody = _context.BodyProtos.First(x => x.Name == "Toed Quadruped");
 		_alwaysTrue = _context.FutureProgs.First(x => x.FunctionName == "AlwaysTrue");
 		_alwaysFalse = _context.FutureProgs.First(x => x.FunctionName == "AlwaysFalse");
@@ -353,7 +356,7 @@ public partial class SupernaturalSeeder : IDatabaseSeeder
 	{
 		if (FindBodypartOnBody(body, "utail") is null)
 		{
-			SeederBodyUtilities.CloneBodypartSubtree(_context, _toedQuadrupedBody, body, "utail", "lback");
+			SeederBodyUtilities.CloneBodypartSubtree(_context, _quadrupedBody, body, "utail", "lback");
 		}
 
 		EnsureBodypartLimb(body, "Tail", LimbType.Appendage, "utail", "utail", "mtail", "ltail");

--- a/Design Documents/Supernatural_Seeder.md
+++ b/Design Documents/Supernatural_Seeder.md
@@ -17,7 +17,7 @@ The seeder uses existing FutureMUD systems rather than adding a new supernatural
 - Angelic sonic attacks such as `Heavenly Choir`, `Canticle of Awe`, `Trumpet Peal`, and `Word of Command` use the existing area-style `ScreechAttack` mechanic, target ear-shaped bodyparts, and are written as choir or command-voice effects rather than single-target strikes.
 - Demonic, spirit, undead, and therianthrope attacks are cloned from existing animal or unarmed donor attacks so builders get varied examples without the seeder adding new combat engine mechanics.
 - Body prototypes carry the base planar presence XML for supernatural forms such as incorporeal spirits, dual-natured angels, astral demons, and ordinary material werewolves or undead.
-- Horned fiend and familiar supernatural bodies add stock tail aliases so tail attacks such as `Barbed Tail Slap` have real bodyparts to bind to.
+- Horned fiend and familiar supernatural bodies add stock tail aliases so tail attacks such as `Barbed Tail Slap` have real bodyparts to bind to. The tail subtree is cloned from `Quadruped Base`, where the stock quadruped tail aliases are directly authored, rather than from the inherited `Toed Quadruped` child body.
 - Additional body forms are supplied as stock `Additional Body Form` merits. These are examples and builder tools, not automatic race-level transformations.
 - Spirits, ghosts, angels, demons, gods, and undead use explicit non-breather settings with hunger and thirst rates set to zero.
 - Werewolves use living needs and seeded alternate-form merits for hybrid and wolf-form examples.


### PR DESCRIPTION
## Summary
- Switched horned fiend and familiar tail cloning to use `Quadruped Base`, where the stock `utail` lineage actually lives.
- Added the missing `Quadruped Base` prerequisite to the supernatural seeder metadata so readiness checks match the runtime dependency.
- Added a focused regression test that exercises the real tail-ensure path against an inherited `Toed Quadruped -> Quadruped Base` setup.
- Updated the supernatural seeder design doc to reflect the correct donor body for tail support.

## Testing
- `dotnet build DatabaseSeeder\DatabaseSeeder.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 --filter "FullyQualifiedName~SupernaturalSeederTemplateTests"`
- `git diff --check`