### PR TITLE
Fix admin avatar language trait seeding and repair stale body traits

### DIFF
--- a/DatabaseSeeder Unit Tests/HumanSeederAdminAvatarLanguageTests.cs
+++ b/DatabaseSeeder Unit Tests/HumanSeederAdminAvatarLanguageTests.cs
@@ -1,0 +1,118 @@
+#nullable enable
+
+using DatabaseSeeder.Seeders;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Models;
+using System.Linq;
+using TraitOwnerScope = MudSharp.Body.Traits.TraitOwnerScope;
+using TraitType = MudSharp.Body.Traits.TraitType;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class HumanSeederAdminAvatarLanguageTests
+{
+	[TestMethod]
+	public void TraitDefinitionStoresOnCharacterForTesting_LegacySkillDefinition_IsCharacterScoped()
+	{
+		TraitDefinition legacySkill = new()
+		{
+			Type = (int)TraitType.Skill,
+			OwnerScope = (int)TraitOwnerScope.Body
+		};
+		TraitDefinition bodyAttribute = new()
+		{
+			Type = (int)TraitType.Attribute,
+			OwnerScope = (int)TraitOwnerScope.Body
+		};
+
+		Assert.IsTrue(HumanSeeder.TraitDefinitionStoresOnCharacterForTesting(legacySkill));
+		Assert.IsFalse(HumanSeeder.TraitDefinitionStoresOnCharacterForTesting(bodyAttribute));
+	}
+
+	[TestMethod]
+	public void AddAdminAvatarLanguageKnowledgeForTesting_SkillLanguage_AddsCharacterTrait()
+	{
+		(Character character, Body body, Language language, Accent accent, TraitDefinition adminSpeechTrait) =
+			BuildAdminAvatarLanguageFixture();
+
+		HumanSeeder.AddAdminAvatarLanguageKnowledgeForTesting(character, language);
+
+		Assert.AreEqual(1, character.CharacterTraits.Count);
+		Assert.AreEqual(0, body.Traits.Count);
+		CharacterTrait trait = character.CharacterTraits.Single();
+		Assert.AreSame(character, trait.Character);
+		Assert.AreSame(adminSpeechTrait, trait.TraitDefinition);
+		Assert.AreEqual(200.0, trait.Value);
+		Assert.AreEqual(1, character.CharactersLanguages.Count);
+		Assert.AreEqual(1, character.CharactersAccents.Count);
+		Assert.AreSame(language, character.CurrentLanguage);
+		Assert.AreSame(accent, character.CurrentAccent);
+	}
+
+	[TestMethod]
+	public void AdminAvatarNeedsLanguageTraitRepairForTesting_StaleBodySkillTrait_IsRepairableMismatch()
+	{
+		(Character character, Body body, Language language, _, TraitDefinition adminSpeechTrait) =
+			BuildAdminAvatarLanguageFixture();
+		character.CharactersLanguages.Add(new CharactersLanguages { Character = character, Language = language });
+		body.Traits.Add(new Trait
+		{
+			Body = body,
+			TraitDefinition = adminSpeechTrait,
+			TraitDefinitionId = adminSpeechTrait.Id,
+			Value = 200
+		});
+
+		Assert.IsTrue(HumanSeeder.AdminAvatarNeedsLanguageTraitRepairForTesting(character));
+
+		character.CharacterTraits.Add(new CharacterTrait
+		{
+			Character = character,
+			TraitDefinition = adminSpeechTrait,
+			TraitDefinitionId = adminSpeechTrait.Id,
+			Value = 200
+		});
+
+		Assert.IsTrue(HumanSeeder.AdminAvatarNeedsLanguageTraitRepairForTesting(character),
+			"Even with the character trait present, the stale body trait should still be removed.");
+
+		body.Traits.Clear();
+
+		Assert.IsFalse(HumanSeeder.AdminAvatarNeedsLanguageTraitRepairForTesting(character));
+	}
+
+	private static (Character Character, Body Body, Language Language, Accent Accent, TraitDefinition Trait)
+		BuildAdminAvatarLanguageFixture()
+	{
+		TraitDefinition adminSpeechTrait = new()
+		{
+			Id = 42,
+			Name = "Admin Speech",
+			Type = (int)TraitType.Skill,
+			OwnerScope = (int)TraitOwnerScope.Body
+		};
+		Language language = new()
+		{
+			Id = 12,
+			Name = "Admin Speech",
+			LinkedTrait = adminSpeechTrait,
+			LinkedTraitId = adminSpeechTrait.Id
+		};
+		Accent accent = new()
+		{
+			Id = 13,
+			Name = "foreign",
+			Language = language,
+			LanguageId = language.Id
+		};
+		language.DefaultLearnerAccent = accent;
+		language.DefaultLearnerAccentId = accent.Id;
+		Body body = new();
+		Character character = new()
+		{
+			Body = body
+		};
+		return (character, body, language, accent, adminSpeechTrait);
+	}
+}

--- a/DatabaseSeeder/Seeders/CultureSeeder.Shared.cs
+++ b/DatabaseSeeder/Seeders/CultureSeeder.Shared.cs
@@ -5,6 +5,7 @@ using MudSharp.Framework;
 using MudSharp.FutureProg;
 using MudSharp.Models;
 using MudSharp.RPG.Checks;
+using TraitOwnerScope = MudSharp.Body.Traits.TraitOwnerScope;
 using MudSharp.RPG.Knowledge;
 using System;
 using System.Collections.Generic;
@@ -142,6 +143,7 @@ public partial class CultureSeeder
 
         trait.Name = name;
         trait.Type = 0;
+        trait.OwnerScope = (int)TraitOwnerScope.Character;
         trait.DecoratorId = decorator.Id;
         trait.TraitGroup = "Language";
         trait.AvailabilityProg = canSelectProg ?? _context.FutureProgs.First(x => x.FunctionName == "AlwaysTrue");

--- a/DatabaseSeeder/Seeders/HumanSeeder.cs
+++ b/DatabaseSeeder/Seeders/HumanSeeder.cs
@@ -6,6 +6,7 @@ using MudSharp.Framework;
 using MudSharp.FutureProg;
 using MudSharp.GameItems;
 using MudSharp.Models;
+using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -216,6 +217,7 @@ Please answer #3yes#F or #3no#F: ", (context, answers) => true,
         {
             RefreshExistingHumanCombatBalance();
 			bool updatedSatiationLimits = RefreshExistingHumanSatiationLimits();
+			bool updatedAdminAvatarLanguageTraits = RefreshExistingAdminAvatarLanguageTraits();
 			bool updatedWearProfiles = false;
 			BodyProto? existingBaseBody = _context.BodyProtos.FirstOrDefault(x => x.Name == "Humanoid");
 			if (existingBaseBody is not null)
@@ -234,6 +236,11 @@ Please answer #3yes#F or #3no#F: ", (context, answers) => true,
 			if (updatedSatiationLimits)
 			{
 				updates.Add("refreshed human satiation limits");
+			}
+
+			if (updatedAdminAvatarLanguageTraits)
+			{
+				updates.Add("repaired admin avatar language traits");
 			}
 
 			if (hasMissingDisfigurementTemplates)
@@ -761,25 +768,7 @@ $?hairstyle[&he has &?a_an[$haircolour $hairstyle]][&he is completely bald].$?fa
         Language? language = _context.Languages.FirstOrDefault();
         if (language != null)
         {
-            character.Body.Traits.Add(new Trait
-            {
-                Body = character.Body,
-                TraitDefinition = language.LinkedTrait,
-                Value = 200,
-                AdditionalValue = 0
-            });
-
-            character.CharactersLanguages.Add(
-                new CharactersLanguages { Character = character, Language = language });
-            character.CharactersAccents.Add(new CharacterAccent
-            {
-                Character = character,
-                Accent = language.DefaultLearnerAccent,
-                Familiarity = 0,
-                IsPreferred = true
-            });
-            character.CurrentLanguage = language;
-            character.CurrentAccent = language.DefaultLearnerAccent;
+            AddAdminAvatarLanguageKnowledge(character, language);
             _context.SaveChanges();
         }
         #endregion
@@ -789,6 +778,147 @@ $?hairstyle[&he has &?a_an[$haircolour $hairstyle]][&he is completely bald].$?fa
         _context.Database.CommitTransaction();
         return "The operation completed successfully";
     }
+
+	private static void AddAdminAvatarLanguageKnowledge(Character character, Language language)
+	{
+		if (language.LinkedTrait is not null)
+		{
+			if (TraitDefinitionStoresOnCharacter(language.LinkedTrait))
+			{
+				character.CharacterTraits.Add(new CharacterTrait
+				{
+					Character = character,
+					TraitDefinition = language.LinkedTrait,
+					TraitDefinitionId = language.LinkedTrait.Id,
+					Value = 200,
+					AdditionalValue = 0
+				});
+			}
+			else
+			{
+				character.Body.Traits.Add(new Trait
+				{
+					Body = character.Body,
+					TraitDefinition = language.LinkedTrait,
+					TraitDefinitionId = language.LinkedTrait.Id,
+					Value = 200,
+					AdditionalValue = 0
+				});
+			}
+		}
+
+		character.CharactersLanguages.Add(
+			new CharactersLanguages { Character = character, Language = language });
+		character.CharactersAccents.Add(new CharacterAccent
+		{
+			Character = character,
+			Accent = language.DefaultLearnerAccent,
+			Familiarity = 0,
+			IsPreferred = true
+		});
+		character.CurrentLanguage = language;
+		character.CurrentAccent = language.DefaultLearnerAccent;
+	}
+
+	private bool RefreshExistingAdminAvatarLanguageTraits()
+	{
+		List<Character> adminAvatars = _context.Characters
+			.Include(x => x.Body)
+			.ThenInclude(x => x.Traits)
+			.Include(x => x.CharacterTraits)
+			.Include(x => x.CharactersLanguages)
+			.ThenInclude(x => x.Language)
+			.ThenInclude(x => x.LinkedTrait)
+			.Where(x => x.IsAdminAvatar)
+			.ToList();
+
+		bool updated = false;
+		foreach (Character character in adminAvatars)
+		{
+			foreach (Language language in character.CharactersLanguages
+				         .Select(x => x.Language)
+				         .Where(x => x.LinkedTrait is not null && TraitDefinitionStoresOnCharacter(x.LinkedTrait)))
+			{
+				TraitDefinition linkedTrait = language.LinkedTrait;
+				Trait? bodyTrait = character.Body.Traits.FirstOrDefault(x => x.TraitDefinitionId == linkedTrait.Id);
+				CharacterTrait? characterTrait =
+					character.CharacterTraits.FirstOrDefault(x => x.TraitDefinitionId == linkedTrait.Id);
+				if (characterTrait is null)
+				{
+					character.CharacterTraits.Add(new CharacterTrait
+					{
+						Character = character,
+						TraitDefinition = linkedTrait,
+						TraitDefinitionId = linkedTrait.Id,
+						Value = bodyTrait?.Value ?? 200,
+						AdditionalValue = bodyTrait?.AdditionalValue ?? 0
+					});
+					updated = true;
+				}
+
+				if (bodyTrait is not null)
+				{
+					character.Body.Traits.Remove(bodyTrait);
+					_context.Traits.Remove(bodyTrait);
+					updated = true;
+				}
+			}
+		}
+
+		if (updated)
+		{
+			_context.SaveChanges();
+		}
+
+		return updated;
+	}
+
+	private static bool HasAdminAvatarLanguageTraitStorageMismatch(FuturemudDatabaseContext context)
+	{
+		return context.Characters
+			.Include(x => x.Body)
+			.ThenInclude(x => x.Traits)
+			.Include(x => x.CharacterTraits)
+			.Include(x => x.CharactersLanguages)
+			.ThenInclude(x => x.Language)
+			.ThenInclude(x => x.LinkedTrait)
+			.Where(x => x.IsAdminAvatar)
+			.AsEnumerable()
+			.Any(AdminAvatarNeedsLanguageTraitRepair);
+	}
+
+	private static bool AdminAvatarNeedsLanguageTraitRepair(Character character)
+	{
+		return character.CharactersLanguages
+			.Select(x => x.Language)
+			.Where(x => x.LinkedTrait is not null && TraitDefinitionStoresOnCharacter(x.LinkedTrait))
+			.Any(x => character.CharacterTraits.All(y => y.TraitDefinitionId != x.LinkedTrait.Id) ||
+			          character.Body.Traits.Any(y => y.TraitDefinitionId == x.LinkedTrait.Id));
+	}
+
+	private static bool TraitDefinitionStoresOnCharacter(TraitDefinition trait)
+	{
+		MudSharp.Body.Traits.TraitType type = (MudSharp.Body.Traits.TraitType)trait.Type;
+		return trait.OwnerScope == (int)MudSharp.Body.Traits.TraitOwnerScope.Character ||
+		       type is MudSharp.Body.Traits.TraitType.Skill
+			       or MudSharp.Body.Traits.TraitType.DerivedSkill
+			       or MudSharp.Body.Traits.TraitType.TheoreticalSkill;
+	}
+
+	internal static bool TraitDefinitionStoresOnCharacterForTesting(TraitDefinition trait)
+	{
+		return TraitDefinitionStoresOnCharacter(trait);
+	}
+
+	internal static bool AdminAvatarNeedsLanguageTraitRepairForTesting(Character character)
+	{
+		return AdminAvatarNeedsLanguageTraitRepair(character);
+	}
+
+	internal static void AddAdminAvatarLanguageKnowledgeForTesting(Character character, Language language)
+	{
+		AddAdminAvatarLanguageKnowledge(character, language);
+	}
 
     public ShouldSeedResult ShouldSeedData(FuturemudDatabaseContext context)
     {
@@ -800,7 +930,7 @@ $?hairstyle[&he has &?a_an[$haircolour $hairstyle]][&he is completely bald].$?fa
         if (context.Races.Any(x => x.Name == "Humanoid"))
         {
             return HasMissingHumanDisfigurementTemplates(context) || HasHumanSatiationLimitUpdates(context) ||
-                   HasMissingHumanWearProfiles(context)
+                   HasAdminAvatarLanguageTraitStorageMismatch(context) || HasMissingHumanWearProfiles(context)
                 ? ShouldSeedResult.ExtraPackagesAvailable
                 : ShouldSeedResult.MayAlreadyBeInstalled;
         }

--- a/DatabaseSeeder/Seeders/SkillSeederBase.cs
+++ b/DatabaseSeeder/Seeders/SkillSeederBase.cs
@@ -1,6 +1,7 @@
 using MudSharp.Database;
 using MudSharp.Models;
 using MudSharp.RPG.Checks;
+using TraitOwnerScope = MudSharp.Body.Traits.TraitOwnerScope;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -356,6 +357,7 @@ public abstract class SkillSeederBase : IDatabaseSeeder
             });
         trait.Name = name;
         update(trait);
+        trait.OwnerScope = (int)TraitOwnerScope.Character;
         return trait;
     }
 


### PR DESCRIPTION
## Summary
- Seed the admin avatar’s language-linked skill on `CharacterTraits` when the linked trait is character-scoped, instead of always writing it to the body.
- Add rerun-safe repair logic so existing seeded worlds with the stale body trait are detected and corrected.
- Normalize new skill/language skill seeding to set `OwnerScope = Character` explicitly.
- Add focused regression tests covering the admin avatar trait placement and repair path.

## Testing
- `dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 --filter HumanSeederAdminAvatarLanguageTests`
- `dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`