### PR TITLE
Audit and extend butchering profiles across runtime, seeding, and converter paths

### DIFF
--- a/DatabaseSeeder/Seeders/SupernaturalSeeder.cs
+++ b/DatabaseSeeder/Seeders/SupernaturalSeeder.cs
@@ -471,9 +471,9 @@ public partial class SupernaturalSeeder : IDatabaseSeeder
 		race.CanSwim = template.CanSwim;
 		race.MinimumSleepingPosition = _humanRace.MinimumSleepingPosition;
 		race.ChildAge = template.NeedsProfile == SupernaturalNeedsProfile.Living ? 2 : 0;
-		race.YouthAge = template.NeedsProfile == SupernaturalNeedsProfile.Living ? 6 : 0;
-		race.YoungAdultAge = template.NeedsProfile == SupernaturalNeedsProfile.Living ? 12 : 0;
-		race.AdultAge = template.NeedsProfile == SupernaturalNeedsProfile.Living ? 18 : 1;
+		race.YouthAge = template.NeedsProfile == SupernaturalNeedsProfile.Living ? 6 : 1;
+		race.YoungAdultAge = template.NeedsProfile == SupernaturalNeedsProfile.Living ? 12 : 2;
+		race.AdultAge = template.NeedsProfile == SupernaturalNeedsProfile.Living ? 18 : 3;
 		race.ElderAge = template.NeedsProfile == SupernaturalNeedsProfile.Living ? 65 : 1000;
 		race.VenerableAge = template.NeedsProfile == SupernaturalNeedsProfile.Living ? 95 : 10000;
 		race.DefaultHeightWeightModelMale = _humanRace.DefaultHeightWeightModelMale;

--- a/Design Documents/Butchering_System.md
+++ b/Design Documents/Butchering_System.md
@@ -1,0 +1,169 @@
+# Butchering System
+
+## Purpose
+
+The butchering system lets player characters turn corpses and severed bodyparts into authored item products. It supports three player-facing workflows:
+
+- `butcher <corpse|part> [subcategory]` for organic corpses and bodyparts.
+- `salvage <wreck|part> [subcategory]` for non-organic corpse-like remains.
+- `skin <corpse>` for removing pelt, hide, skin, or similar whole-corpse products.
+
+The same runtime objects power butchering and salvage. The race's butchery profile chooses whether the breakdown verb is `butcher` or `salvage`; skinning is available separately when the profile includes pelt products.
+
+## Runtime Model
+
+Butchering data is split into two builder-authored object types:
+
+- Race butchery profiles define the verb, required tool tag, skill checks, staged emotes, and which products can be produced.
+- Butchery products define the target body prototype, required bodyparts, optional subcategory, optional can-produce prog, and the item prototypes loaded by the product.
+
+Races reference one race butchery profile. Corpse and severed-bodypart item components expose `IButcherable`, which gives the runtime access to the original character, original body, remaining parts, decay state, and already-butchered subcategories.
+
+Player commands validate the target before starting a staged effect:
+
+- The target must be an `IButcherable` with an original race that has a butchery profile.
+- The target must not be too decayed.
+- The profile verb must match `butcher` or `salvage`.
+- The profile's required tool plan must be feasible.
+- The target must not already be being butchered, salvaged, or skinned.
+- The selected breakdown path must have both a check and at least one phase emote.
+- If the profile has no required tool, its active emotes must not refer to `$2`, because no tool item is available for that emote token.
+
+When a command starts, it adds a staged action effect to the actor. The effect emits each configured phase emote and blocks general action and movement until completion or cancellation. If the tool is deleted, quits, or leaves the actor's held or wielded inventory state, the action cancels.
+
+On completion, the corpse or severed-bodypart component loads the matching products into the actor's location. Full breakdowns consume the corpse or bodypart. Subcategory breakdowns mark that subcategory as already processed and leave the corpse or bodypart available for other subcategories or final breakdown.
+
+## Product Applicability
+
+A butchery product applies to a corpse or bodypart only when all of the following are true:
+
+- The target's original body prototype counts as the product's target body prototype.
+- The target currently contains every required bodypart for the product.
+- The product's can-produce prog, if any, returns true for the actor and target item.
+- For subcategory commands, the product's subcategory matches the requested subcategory.
+
+This matters most for severed bodyparts and partially dismantled bodies. Products are evaluated against the actual remaining parts exposed by `IButcherable.Parts`, not merely the original race's full body plan.
+
+## Damage And Outcomes
+
+Each product item has a normal result and may also have a damaged result. The runtime computes the damage ratio for the product's matched bodyparts:
+
+- If the damage ratio is at or above the product item's damaged threshold, the damaged proto is produced when one is configured.
+- If the actor's butchery or skinning check is a fail or major fail, the damaged proto is also used when configured.
+- If no damaged proto is configured, the normal proto is produced even when the bodypart is damaged or the check fails.
+
+Stackable product prototypes load as one stack with the configured quantity. Non-stackable prototypes load as separate items.
+
+## Persistence
+
+The database stores profile and product definitions:
+
+- `RaceButcheryProfiles`
+- `RaceButcheryProfiles_BreakdownChecks`
+- `RaceButcheryProfiles_BreakdownEmotes`
+- `RaceButcheryProfiles_SkinningEmotes`
+- `RaceButcheryProfiles_ButcheryProducts`
+- `ButcheryProducts`
+- `ButcheryProducts_BodypartProtos`
+- `ButcheryProductItems`
+
+Runtime corpse and severed-bodypart item component XML stores live progress:
+
+- Corpses store whether they have been skinned.
+- Corpses and severed bodyparts store already-butchered subcategories.
+
+That live progress prevents repeated skinning or repeated subcategory harvesting after a save and reload.
+
+## Builder Workflow
+
+Build butchery data in this order:
+
+1. Build or identify the item prototypes that should be produced.
+2. Create butchery products with `butcheryproduct`.
+3. Create or clone a race butchery profile with `butchery`.
+4. Add checks and phase emotes to the profile.
+5. Attach products to the profile.
+6. Attach the profile to a race with `race set butcher <profile>`.
+
+### Butchery Products
+
+Use `butcheryproduct edit new <name> <body> <bodypart> <proto> [quantity]` to create a product, then refine it with `butcheryproduct set`.
+
+Important settings:
+
+- `category <category>|clear` sets the optional subcategory used by `butcher corpse <subcategory>` or `salvage wreck <subcategory>`.
+- `pelt` toggles whether the product is produced by `skin` instead of `butcher` or `salvage`.
+- `body <body> [parts ...]` changes the target body prototype and required bodyparts.
+- `part <part>` toggles an additional required bodypart. A product must always have at least one required part.
+- `prog <prog>` sets a boolean prog accepting `(character, item)` to decide whether the product can be produced.
+- `item add <quantity> <proto> [<damaged quantity> <damaged proto> <damage%>]` adds an output line.
+- `item <id|number> quantity <quantity>` changes normal quantity.
+- `item <id|number> proto <proto>` changes normal proto.
+- `item <id|number> threshold <damage%>` changes the threshold for damaged output.
+- `item <id|number> damaged <quantity> <proto>` changes damaged output.
+- `item <id|number> nodamaged` clears damaged output.
+
+`butcheryproduct show` displays both the row number and database ID for product items. Builder commands accept either.
+
+### Race Butchery Profiles
+
+Use `butchery edit new <name>` or `butchery clone <old> <name>` to create a profile.
+
+Important settings:
+
+- `verb butcher|salvage` chooses the player command used for breakdown.
+- `tool <tag>|none` sets or clears the required held tool tag.
+- `skindiff <difficulty>` sets the skinning check difficulty.
+- `can <prog>` sets a boolean prog accepting `(character, item)` for overall access.
+- `why <prog>` sets a text prog accepting `(character, item)` for custom failure messaging.
+- `product <product>` toggles a product on the profile.
+- `check main <trait> <difficulty>` sets the full-breakdown check.
+- `check <subcategory> <trait> <difficulty>` sets a subcategory check.
+- `check <subcategory> remove` removes a subcategory check and its emotes.
+
+Phase emotes are required for any runtime path players can use. Use `$0` for the actor, `$1` for the corpse or bodypart, and `$2` for the tool. Only use `$2` when the profile has a required tool.
+
+Skinning phases:
+
+- `skinemote add <seconds> <emote>`
+- `skinemote remove <number>`
+- `skinemote swap <number> <number>`
+- `skinemote edit <number> <emote>`
+- `skinemote delay <number> <seconds>`
+
+Main breakdown phases:
+
+- `emote add <seconds> <emote>`
+- `emote remove <number>`
+- `emote swap <number> <number>`
+- `emote edit <number> <emote>`
+- `emote delay <number> <seconds>`
+
+Subcategory breakdown phases:
+
+- `subemote <subcategory> add <seconds> <emote>`
+- `subemote <subcategory> remove <number>`
+- `subemote <subcategory> swap <number> <number>`
+- `subemote <subcategory> edit <number> <emote>`
+- `subemote <subcategory> delay <number> <seconds>`
+
+## Builder Checklist
+
+Before attaching a profile to a race, verify:
+
+- The profile has the correct verb.
+- The tool tag is set, or all phase emotes avoid `$2`.
+- `check main` exists if full breakdown should be possible.
+- Main breakdown has at least one `emote`.
+- Each product subcategory has a matching `check <subcategory>` and at least one `subemote`.
+- Skinning has at least one pelt product, at least one `skinemote`, and a suitable skinning difficulty.
+- Product required bodyparts exist on the intended target body and represent the actual part that gates the product.
+- Damaged products have sensible thresholds and damaged quantities.
+- Any can-produce or can-butcher progs accept `(character, item)` and return the expected type.
+
+## Current Limitations
+
+- The first staged action tick is currently scheduled by the command's initial delay, while phase delays control time between subsequent phase emotes.
+- Profiles and products are direct editable items rather than revisioned items, so changes affect live content after save.
+- Skinning is only supported on whole corpses, not severed bodyparts.
+- There is no stock-data wizard for generating complete butchery packages from a body prototype; builders author products and profiles explicitly.

--- a/FutureMUDLibrary/Work/Butchering/IRaceButcheryProfile.cs
+++ b/FutureMUDLibrary/Work/Butchering/IRaceButcheryProfile.cs
@@ -42,6 +42,13 @@ namespace MudSharp.Work.Butchering
         (ITraitDefinition Trait, Difficulty CheckDifficulty) BreakdownCheck(string subcategory);
 
         /// <summary>
+        ///     Whether the profile has both a check and at least one staged emote for the nominated breakdown path.
+        /// </summary>
+        /// <param name="subcategory">If specified, the subcategory for which to test the breakdown setup</param>
+        /// <returns>True if the breakdown can be run by players</returns>
+        bool HasBreakdown(string subcategory);
+
+        /// <summary>
         /// The emotes and delays between each phase of skinning
         /// </summary>
         IEnumerable<(string Emote, double Delay)> SkinEmotes { get; }

--- a/MudSharpCore/Commands/Modules/ActivityBuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/ActivityBuilderModule.cs
@@ -41,10 +41,10 @@ You can use the following options with this command:
 	#3butchery edit#0 - an alias for #3butchery show#0 on an opened butchery profile
 	#3butchery clone <which> <name>#0 - clones a butchery profile to a new one
 	#3butchery shallowclone <which> <name>#0 - clones a butchery profile to a new one (excluding products)
-	#3butchery close#0 - closes the currently edited foragable profile
+	#3butchery close#0 - closes the currently edited butchery profile
 	#3butchery set name <name>#0 - renames this profile
 	#3butchery set verb butcher|salvage#0 - changes the verb used for interacting with these corpses
-	#3butchery set tool <tag>#0 - sets the tag of tools required to interact with this
+	#3butchery set tool <tag>|none#0 - sets or clears the tag of tools required to interact with this
 	#3butchery set skindiff <difficulty>#0 - sets the difficulty of the skinning check
 	#3butchery set can <prog>#0 - sets a prog to control whether someone can butcher this
 	#3butchery set why <prog>#0 - sets a prog for a custom error message on can butcher failure
@@ -113,10 +113,48 @@ For all of the below phase emote echoes, you can use #6$0#0 for the actor, #6$1#
 
     protected static void ButcheringList(ICharacter actor, StringStack ss)
     {
-        List<IRaceButcheryProfile> items = actor.Gameworld.RaceButcheryProfiles.ToList();
-        // filters
-        actor.OutputHandler.Send(StringUtilities.GetTextTable(
-            from item in items
+        IEnumerable<IRaceButcheryProfile> items = actor.Gameworld.RaceButcheryProfiles;
+        List<string> filters = new();
+        while (!ss.IsFinished)
+        {
+            string filter = ss.PopSpeech();
+            if (string.IsNullOrWhiteSpace(filter))
+            {
+                continue;
+            }
+
+            string text = filter.Length > 1 ? filter[1..] : string.Empty;
+            switch (filter[0])
+            {
+                case '+':
+                    if (string.IsNullOrWhiteSpace(text))
+                    {
+                        actor.OutputHandler.Send($"The text {filter.ColourCommand()} is not a valid filter.");
+                        return;
+                    }
+
+                    items = items.Where(x => x.Name.Contains(text, StringComparison.InvariantCultureIgnoreCase));
+                    filters.Add($"including {text.ColourCommand()}");
+                    continue;
+                case '-':
+                    if (string.IsNullOrWhiteSpace(text))
+                    {
+                        actor.OutputHandler.Send($"The text {filter.ColourCommand()} is not a valid filter.");
+                        return;
+                    }
+
+                    items = items.Where(x => !x.Name.Contains(text, StringComparison.InvariantCultureIgnoreCase));
+                    filters.Add($"excluding {text.ColourCommand()}");
+                    continue;
+                default:
+                    actor.OutputHandler.Send($"The text {filter.ColourCommand()} is not a valid filter.");
+                    return;
+            }
+        }
+
+        List<IRaceButcheryProfile> itemList = items.ToList();
+        actor.OutputHandler.Send($"Butchery Profiles{(filters.Any() ? $" ({filters.ListToString()})" : "")}:\n" + StringUtilities.GetTextTable(
+            from item in itemList
             select new List<string>
             {
                 item.Id.ToString("N0", actor),
@@ -314,12 +352,12 @@ You can use the following options with this command:
 	#3butcheringproduct set part <which>#0 - toggles requiring the corpse to have this bodypart
 	#3butcheringproduct set prog <which>#0 - sets the prog that controls whether the item is produced
 	#3butcheringproduct set item add <number> <proto> [<number> <damaged> <damage%>]#0 - adds a new item product
-	#3butcheringproduct set item delete <##>#0 - deletes an item product
-	#3butcheringproduct set item <##> quantity <number>#0 - changes the quantity of items produced
-	#3butcheringproduct set item <##> proto <id>#0 - changes the proto produced
-	#3butcheringproduct set item <##> threshold <%>#0 - changes the damage percentage for normal/damaged items
-	#3butcheringproduct set item <##> damaged <quantity> <proto>#0 - changes the damaged proto
-	#3butcheringproduct set item <##> nodamaged#0 - clears the damaged proto";
+	#3butcheringproduct set item delete <id|##>#0 - deletes an item product
+	#3butcheringproduct set item <id|##> quantity <number>#0 - changes the quantity of items produced
+	#3butcheringproduct set item <id|##> proto <id>#0 - changes the proto produced
+	#3butcheringproduct set item <id|##> threshold <%>#0 - changes the damage percentage for normal/damaged items
+	#3butcheringproduct set item <id|##> damaged <quantity> <proto>#0 - changes the damaged proto
+	#3butcheringproduct set item <id|##> nodamaged#0 - clears the damaged proto";
 
     [PlayerCommand("ButcheryProduct", "butcheringproduct", "butcheryproduct")]
     [CommandPermission(PermissionLevel.Admin)]
@@ -356,10 +394,52 @@ You can use the following options with this command:
 
     protected static void ButcheryProductList(ICharacter actor, StringStack ss)
     {
-        List<IButcheryProduct> items = actor.Gameworld.ButcheryProducts.ToList();
-        // filters
-        actor.OutputHandler.Send(StringUtilities.GetTextTable(
-            from item in items
+        IEnumerable<IButcheryProduct> items = actor.Gameworld.ButcheryProducts;
+        List<string> filters = new();
+        while (!ss.IsFinished)
+        {
+            string filter = ss.PopSpeech();
+            if (string.IsNullOrWhiteSpace(filter))
+            {
+                continue;
+            }
+
+            string text = filter.Length > 1 ? filter[1..] : string.Empty;
+            switch (filter[0])
+            {
+                case '+':
+                    if (string.IsNullOrWhiteSpace(text))
+                    {
+                        actor.OutputHandler.Send($"The text {filter.ColourCommand()} is not a valid filter.");
+                        return;
+                    }
+
+                    items = items.Where(x =>
+                        x.Name.Contains(text, StringComparison.InvariantCultureIgnoreCase) ||
+                        (x.Subcategory?.Contains(text, StringComparison.InvariantCultureIgnoreCase) ?? false));
+                    filters.Add($"including {text.ColourCommand()}");
+                    continue;
+                case '-':
+                    if (string.IsNullOrWhiteSpace(text))
+                    {
+                        actor.OutputHandler.Send($"The text {filter.ColourCommand()} is not a valid filter.");
+                        return;
+                    }
+
+                    items = items.Where(x =>
+                        !x.Name.Contains(text, StringComparison.InvariantCultureIgnoreCase) &&
+                        !(x.Subcategory?.Contains(text, StringComparison.InvariantCultureIgnoreCase) ?? false));
+                    filters.Add($"excluding {text.ColourCommand()}");
+                    continue;
+                default:
+                    actor.OutputHandler.Send($"The text {filter.ColourCommand()} is not a valid filter.");
+                    return;
+            }
+        }
+
+        List<IButcheryProduct> itemList = items.ToList();
+        actor.OutputHandler.Send($"Butchery Products{(filters.Any() ? $" ({filters.ListToString()})" : "")}:\n" + StringUtilities.GetTextTable(
+            from item in itemList
             select new List<string>
             {
                 item.Id.ToString("N0", actor),

--- a/MudSharpCore/Commands/Modules/CraftModule.cs
+++ b/MudSharpCore/Commands/Modules/CraftModule.cs
@@ -1432,6 +1432,18 @@ Note: See the closely related #3projects#0 command for information about your cu
 
     #region Butchering
 
+    private static bool ButcheryEmotesNeedMissingTool(IRaceButcheryProfile profile,
+        IEnumerable<(string Emote, double Delay)> emotes)
+    {
+        return profile.RequiredToolTag is null &&
+               emotes.Any(x => x.Emote.Contains("$2", StringComparison.Ordinal));
+    }
+
+    private static IGameItem ButcheryToolFromPlanResults(IEnumerable<InventoryPlanActionResult> results)
+    {
+        return results.FirstOrDefault(x => x.ActionState == DesiredItemState.Held)?.PrimaryTarget;
+    }
+
     [PlayerCommand("Butcher", "butcher")]
     [RequiredCharacterState(CharacterState.Able)]
     [NoCombatCommand]
@@ -1481,10 +1493,10 @@ Note: See the closely related #3projects#0 command for information about your cu
             return;
         }
 
-        string subcategory = ss.PopSpeech();
+        string subcategory = ss.PopSpeech().NormaliseButcherySubcategory();
         if (!string.IsNullOrEmpty(subcategory))
         {
-            if (!profile.Products.Where(x => x.Subcategory.EqualTo(subcategory)).Any(x => x.CanProduce(actor, target)))
+            if (!profile.Products.Where(x => !x.IsPelt && x.AppliesTo(targetAsButcherable) && x.Subcategory.EqualTo(subcategory)).Any(x => x.CanProduce(actor, target)))
             {
                 actor.Send(
                     $"{target.HowSeen(actor, true)} does not contain any such subcategory of things for you to butcher.");
@@ -1499,11 +1511,26 @@ Note: See the closely related #3projects#0 command for information about your cu
             }
         }
 
+        if (!profile.HasBreakdown(subcategory))
+        {
+            actor.Send(
+                $"{target.HowSeen(actor, true)} does not have a complete {(string.IsNullOrEmpty(subcategory) ? "main" : subcategory.ColourName())} butchery breakdown configured.");
+            return;
+        }
+
+        var breakdownEmotes = profile.BreakdownEmotes(subcategory).ToList();
+        if (ButcheryEmotesNeedMissingTool(profile, breakdownEmotes))
+        {
+            actor.Send(
+                $"{target.HowSeen(actor, true)} cannot be butchered because this butchery profile has no required tool but its breakdown emotes refer to a tool.");
+            return;
+        }
+
         IInventoryPlan plan = profile.ToolTemplate.CreatePlan(actor);
         IEnumerable<InventoryPlanActionResult> results = plan.ExecuteWholePlan();
         actor.AddEffect(
             new Butchering(actor, targetAsButcherable, subcategory,
-                results.First(x => x.ActionState == DesiredItemState.Held).PrimaryTarget), TimeSpan.FromSeconds(10));
+                ButcheryToolFromPlanResults(results)), TimeSpan.FromSeconds(10));
         actor.OutputHandler.Handle(new EmoteOutput(new Emote("@ begin|begins to butcher $0.", actor, target)));
         plan.FinalisePlanNoRestore();
     }
@@ -1558,10 +1585,10 @@ Note: See the closely related #3projects#0 command for information about your cu
             return;
         }
 
-        string subcategory = ss.PopSpeech();
+        string subcategory = ss.PopSpeech().NormaliseButcherySubcategory();
         if (!string.IsNullOrEmpty(subcategory))
         {
-            if (!profile.Products.Where(x => x.Subcategory.EqualTo(subcategory)).Any(x => x.CanProduce(actor, target)))
+            if (!profile.Products.Where(x => !x.IsPelt && x.AppliesTo(targetAsButcherable) && x.Subcategory.EqualTo(subcategory)).Any(x => x.CanProduce(actor, target)))
             {
                 actor.Send(
                     $"{target.HowSeen(actor, true)} does not contain any such subcategory of things for you to salvage.");
@@ -1576,11 +1603,26 @@ Note: See the closely related #3projects#0 command for information about your cu
             }
         }
 
+        if (!profile.HasBreakdown(subcategory))
+        {
+            actor.Send(
+                $"{target.HowSeen(actor, true)} does not have a complete {(string.IsNullOrEmpty(subcategory) ? "main" : subcategory.ColourName())} salvage breakdown configured.");
+            return;
+        }
+
+        var breakdownEmotes = profile.BreakdownEmotes(subcategory).ToList();
+        if (ButcheryEmotesNeedMissingTool(profile, breakdownEmotes))
+        {
+            actor.Send(
+                $"{target.HowSeen(actor, true)} cannot be salvaged because this butchery profile has no required tool but its breakdown emotes refer to a tool.");
+            return;
+        }
+
         IInventoryPlan plan = profile.ToolTemplate.CreatePlan(actor);
         IEnumerable<InventoryPlanActionResult> results = plan.ExecuteWholePlan();
         actor.AddEffect(
             new Butchering(actor, targetAsButcherable, subcategory,
-                results.First(x => x.ActionState == DesiredItemState.Held).PrimaryTarget), TimeSpan.FromSeconds(10));
+                ButcheryToolFromPlanResults(results)), TimeSpan.FromSeconds(10));
         actor.OutputHandler.Handle(new EmoteOutput(new Emote("@ begin|begins to salvage $0.", actor, target)));
         plan.FinalisePlanNoRestore();
     }
@@ -1628,7 +1670,7 @@ Note: See the closely related #3projects#0 command for information about your cu
         }
 
         IRaceButcheryProfile profile = targetAsButcherable.OriginalCharacter.Race.ButcheryProfile;
-        if (!profile.Products.Where(x => x.IsPelt).Any(x => x.CanProduce(actor, target)))
+        if (!profile.Products.Where(x => x.IsPelt && x.AppliesTo(targetAsButcherable)).Any(x => x.CanProduce(actor, target)))
         {
             actor.Send($"{target.HowSeen(actor, true)} does not have a pelt that you can remove intact.");
             return;
@@ -1646,12 +1688,27 @@ Note: See the closely related #3projects#0 command for information about your cu
             return;
         }
 
+        var skinEmotes = profile.SkinEmotes.ToList();
+        if (!skinEmotes.Any())
+        {
+            actor.Send($"{target.HowSeen(actor, true)} does not have a complete skinning process configured.");
+            return;
+        }
+
+        if (ButcheryEmotesNeedMissingTool(profile, skinEmotes))
+        {
+            actor.Send(
+                $"{target.HowSeen(actor, true)} cannot be skinned because this butchery profile has no required tool but its skinning emotes refer to a tool.");
+            return;
+        }
+
         IInventoryPlan plan = profile.ToolTemplate.CreatePlan(actor);
         IEnumerable<InventoryPlanActionResult> results = plan.ExecuteWholePlan();
-        IGameItem tool = results.First(x => x.ActionState == DesiredItemState.Held).PrimaryTarget;
+        IGameItem tool = ButcheryToolFromPlanResults(results);
         actor.AddEffect(new Skinning(actor, targetAsButcherable, tool), TimeSpan.FromSeconds(10));
-        actor.OutputHandler.Handle(
-            new EmoteOutput(new Emote("@ begin|begins to skin $0 with $1.", actor, target, tool)));
+        actor.OutputHandler.Handle(tool is null
+            ? new EmoteOutput(new Emote("@ begin|begins to skin $0.", actor, target))
+            : new EmoteOutput(new Emote("@ begin|begins to skin $0 with $1.", actor, target, tool)));
         plan.FinalisePlanNoRestore();
     }
 

--- a/MudSharpCore/Effects/Concrete/Butchering.cs
+++ b/MudSharpCore/Effects/Concrete/Butchering.cs
@@ -77,7 +77,9 @@ public class Butchering : StagedCharacterActionWithTarget, IAffectProximity
         (Trait, CheckDifficulty) = Profile.BreakdownCheck(subcategory);
         List<(string Emote, double Delay)> emotesAndDelays = Profile.BreakdownEmotes(subcategory).ToList();
         Emotes = new Queue<string>(emotesAndDelays.Select(x => x.Emote));
-        TimesBetweenTicks = new Queue<TimeSpan>(emotesAndDelays.Select(x => TimeSpan.FromMilliseconds(x.Delay)));
+        TimesBetweenTicks = new Queue<TimeSpan>(emotesAndDelays
+                                                .Take(Math.Max(0, emotesAndDelays.Count - 1))
+                                                .Select(x => TimeSpan.FromSeconds(x.Delay)));
 
         void IntermediateStepAction(IPerceivable perceivable)
         {

--- a/MudSharpCore/Effects/Concrete/Skinning.cs
+++ b/MudSharpCore/Effects/Concrete/Skinning.cs
@@ -71,7 +71,9 @@ public class Skinning : StagedCharacterActionWithTarget, IAffectProximity
             Profile.DifficultySkin);
         List<(string Emote, double Delay)> emotesAndDelays = Profile.SkinEmotes.ToList();
         Emotes = new Queue<string>(emotesAndDelays.Select(x => x.Emote));
-        TimesBetweenTicks = new Queue<TimeSpan>(emotesAndDelays.Select(x => TimeSpan.FromMilliseconds(x.Delay)));
+        TimesBetweenTicks = new Queue<TimeSpan>(emotesAndDelays
+                                                .Take(Math.Max(0, emotesAndDelays.Count - 1))
+                                                .Select(x => TimeSpan.FromSeconds(x.Delay)));
 
         void IntermediateStepAction(IPerceivable perceivable)
         {
@@ -115,8 +117,11 @@ public class Skinning : StagedCharacterActionWithTarget, IAffectProximity
         base.SetupEventHandlers();
         if (Tool != null)
         {
+            Tool.OnDeleted -= ToolGone;
             Tool.OnDeleted += ToolGone;
+            Tool.OnQuit -= ToolGone;
             Tool.OnQuit += ToolGone;
+            CharacterOwner.Body.OnInventoryChange -= CheckInventoryChange;
             CharacterOwner.Body.OnInventoryChange += CheckInventoryChange;
         }
 
@@ -130,7 +135,7 @@ public class Skinning : StagedCharacterActionWithTarget, IAffectProximity
             return;
         }
 
-        if (newState != InventoryState.Wielded || newState != InventoryState.Held)
+        if (newState != InventoryState.Wielded && newState != InventoryState.Held)
         {
             ToolGone(item);
         }

--- a/MudSharpCore/Framework/FuturemudLoaders.cs
+++ b/MudSharpCore/Framework/FuturemudLoaders.cs
@@ -1667,7 +1667,7 @@ For information on the syntax to use in emotes (such as those included in bracke
         sw.Stop();
         ConsoleUtilities.WriteLine($"Duration: #2{sw.ElapsedMilliseconds}ms#0");
 #endif
-        count = products.Count;
+        count = profiles.Count;
         ConsoleUtilities.WriteLine("Loaded #2{0:N0}#0 {1}.", count, count == 1 ? "Profile" : "Profiles");
     }
 

--- a/MudSharpCore/GameItems/Components/BodypartGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/BodypartGameItemComponent.cs
@@ -135,6 +135,10 @@ public class BodypartGameItemComponent : GameItemComponent, ISeveredBodypart, IL
             new XElement("Tattoos",
                 from item in Tattoos
                 select item.SaveToXml()
+            ),
+            new XElement("ButcheredSubcategories",
+                from item in ButcheredSubcategories
+                select new XElement("Subcategory", item)
             )
         ).ToString();
     }
@@ -189,6 +193,11 @@ public class BodypartGameItemComponent : GameItemComponent, ISeveredBodypart, IL
         {
             _tattoos.Add(new Tattoo(tattoo, Gameworld));
         }
+
+        _butcheredSubcategories.AddRange(
+            definition.Element("ButcheredSubcategories")?.Elements("Subcategory")
+                      .Select(x => x.Value.NormaliseButcherySubcategory())
+                      .Where(x => !string.IsNullOrWhiteSpace(x)) ?? Enumerable.Empty<string>());
     }
 
     #region Constructors
@@ -228,6 +237,7 @@ public class BodypartGameItemComponent : GameItemComponent, ISeveredBodypart, IL
         _implants = rhs._implants.ToList();
         Wounds = rhs.Wounds.ToList();
         Tattoos = rhs.Tattoos.ToList();
+        _butcheredSubcategories.AddRange(rhs._butcheredSubcategories);
         OriginalCharacterId = rhs.OriginalCharacterId;
         _originalCharacter = rhs._originalCharacter;
         _originalBodyId = rhs._originalBodyId;
@@ -690,6 +700,7 @@ public class BodypartGameItemComponent : GameItemComponent, ISeveredBodypart, IL
                 IGameItem newItem = proto.CreateNew(butcher);
                 newItem.RoomLayer = Parent.RoomLayer;
                 newItem.GetItemType<IStackable>().Quantity = quantity;
+                Gameworld.Add(newItem);
                 butcher.Location.Insert(newItem);
                 newItem.HandleEvent(EventType.ItemFinishedLoading, newItem);
                 newItem.Login();
@@ -715,16 +726,16 @@ public class BodypartGameItemComponent : GameItemComponent, ISeveredBodypart, IL
         Butchering effect = butcher.EffectsOfType<Butchering>().First();
 
         foreach (IButcheryProduct product in OriginalCharacter.Race.ButcheryProfile.Products.Where(x =>
-                     !x.IsPelt && x.CanProduce(butcher, Parent) &&
+                     !x.IsPelt && x.AppliesTo(this) && x.CanProduce(butcher, Parent) &&
                      (string.IsNullOrEmpty(subcategory) || x.Subcategory.EqualTo(subcategory))))
         {
-            double damageRatio =
-                Parent.Wounds.Where(x => product.RequiredBodyparts.Contains(x.Bodypart)).Sum(x => x.CurrentDamage) /
-                product.RequiredBodyparts.Sum(x => OriginalBody.HitpointsForBodypart(x));
-            if (double.IsNaN(damageRatio))
-            {
-                damageRatio = 1.0;
-            }
+            List<IBodypart> productParts = product.MatchingBodyparts(this).ToList();
+            double totalHitpoints = productParts.Sum(x => OriginalBody.HitpointsForBodypart(x));
+            double damageRatio = totalHitpoints <= 0.0
+                ? 1.0
+                : Parent.Wounds.Where(x => productParts.Any(y => x.Bodypart.ButcheryBodypartMatches(y)))
+                        .Sum(x => x.CurrentDamage) /
+                  totalHitpoints;
 
             foreach (IButcheryProductItem item in product.ProductItems)
             {
@@ -741,9 +752,9 @@ public class BodypartGameItemComponent : GameItemComponent, ISeveredBodypart, IL
                 LoadItem(item.NormalProto, item.NormalQuantity);
             }
 
-            List<IBodypart> affectedParts = OriginalBody.Bodyparts
+            List<IBodypart> affectedParts = Parts
                                                  .Where(x => product.RequiredBodyparts.Any(y =>
-                                                     x.DownstreamOfPart(x) || y == x)).ToList();
+                                                     x.DownstreamOfPart(y) || x.ButcheryBodypartMatches(y))).ToList();
 
             foreach (IGameItem item in _implants.Where(x => affectedParts.Contains(x.GetItemType<IImplant>()?.TargetBodypart))
                                           .ToList())
@@ -772,7 +783,7 @@ public class BodypartGameItemComponent : GameItemComponent, ISeveredBodypart, IL
 
         if (!string.IsNullOrEmpty(subcategory))
         {
-            _butcheredSubcategories.Add(subcategory);
+            _butcheredSubcategories.Add(subcategory.NormaliseButcherySubcategory());
             Changed = true;
             return false;
         }

--- a/MudSharpCore/GameItems/Components/CorpseGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/CorpseGameItemComponent.cs
@@ -100,6 +100,11 @@ public class CorpseGameItemComponent : GameItemComponent, ICorpse, ILazyLoadDuri
             new XElement("DecayPoints", DecayPoints),
             new XElement("DecayState", (int)Decay),
             new XElement("EatenWeight", EatenWeight),
+            new XElement("Skinned", Skinned),
+            new XElement("ButcheredSubcategories",
+                from item in ButcheredSubcategories
+                select new XElement("Subcategory", item)
+            ),
             new XElement("TimeOfDeath", new XText(TimeOfDeath.ToString(CultureInfo.InvariantCulture)))
         ).ToString();
     }
@@ -114,6 +119,11 @@ public class CorpseGameItemComponent : GameItemComponent, ICorpse, ILazyLoadDuri
         TimeOfDeath = DateTime.Parse(definition.Element("TimeOfDeath").Value, CultureInfo.InvariantCulture,
             DateTimeStyles.AssumeUniversal);
         EatenWeight = double.Parse(definition.Element("EatenWeight")?.Value ?? "0.0");
+        _skinned = bool.Parse(definition.Element("Skinned")?.Value ?? "false");
+        _butcheredSubcategories.AddRange(
+            definition.Element("ButcheredSubcategories")?.Elements("Subcategory")
+                      .Select(x => x.Value.NormaliseButcherySubcategory())
+                      .Where(x => !string.IsNullOrWhiteSpace(x)) ?? Enumerable.Empty<string>());
     }
 
     #region Constructors
@@ -154,6 +164,7 @@ public class CorpseGameItemComponent : GameItemComponent, ICorpse, ILazyLoadDuri
         DecayPoints = rhs.DecayPoints;
         TimeOfDeath = rhs.TimeOfDeath;
         Skinned = rhs.Skinned;
+        _butcheredSubcategories.AddRange(rhs._butcheredSubcategories);
         if (!temporary)
         {
             SetupDecayListener();
@@ -369,6 +380,7 @@ public class CorpseGameItemComponent : GameItemComponent, ICorpse, ILazyLoadDuri
                 IGameItem newItem = proto.CreateNew(butcher);
                 newItem.RoomLayer = Parent.RoomLayer;
                 newItem.GetItemType<IStackable>().Quantity = quantity;
+                Gameworld.Add(newItem);
                 butcher.Location.Insert(newItem);
                 newItem.HandleEvent(EventType.ItemFinishedLoading, newItem);
                 newItem.Login();
@@ -393,16 +405,16 @@ public class CorpseGameItemComponent : GameItemComponent, ICorpse, ILazyLoadDuri
         ICheck check = Gameworld.GetCheck(CheckType.ButcheryCheck);
         Butchering effect = butcher.EffectsOfType<Butchering>().First();
         foreach (IButcheryProduct product in OriginalCharacter.Race.ButcheryProfile.Products.Where(x =>
-                     !x.IsPelt && x.CanProduce(butcher, Parent) &&
+                     !x.IsPelt && x.AppliesTo(this) && x.CanProduce(butcher, Parent) &&
                      (string.IsNullOrEmpty(subcategory) || x.Subcategory.EqualTo(subcategory))))
         {
-            double damageRatio =
-                Parent.Wounds.Where(x => product.RequiredBodyparts.Contains(x.Bodypart)).Sum(x => x.CurrentDamage) /
-                product.RequiredBodyparts.Sum(x => OriginalBody.HitpointsForBodypart(x));
-            if (double.IsNaN(damageRatio))
-            {
-                damageRatio = 1.0;
-            }
+            List<IBodypart> productParts = product.MatchingBodyparts(this).ToList();
+            double totalHitpoints = productParts.Sum(x => OriginalBody.HitpointsForBodypart(x));
+            double damageRatio = totalHitpoints <= 0.0
+                ? 1.0
+                : Parent.Wounds.Where(x => productParts.Any(y => x.Bodypart.ButcheryBodypartMatches(y)))
+                        .Sum(x => x.CurrentDamage) /
+                  totalHitpoints;
 
             foreach (IButcheryProductItem item in product.ProductItems)
             {
@@ -437,7 +449,7 @@ public class CorpseGameItemComponent : GameItemComponent, ICorpse, ILazyLoadDuri
 
         if (!string.IsNullOrEmpty(subcategory))
         {
-            _butcheredSubcategories.Add(subcategory);
+            _butcheredSubcategories.Add(subcategory.NormaliseButcherySubcategory());
             Changed = true;
             return false;
         }
@@ -460,6 +472,7 @@ public class CorpseGameItemComponent : GameItemComponent, ICorpse, ILazyLoadDuri
                 IGameItem newItem = proto.CreateNew(skinner);
                 newItem.RoomLayer = Parent.RoomLayer;
                 newItem.GetItemType<IStackable>().Quantity = quantity;
+                Gameworld.Add(newItem);
                 skinner.Location.Insert(newItem);
                 newItem.HandleEvent(EventType.ItemFinishedLoading, newItem);
                 newItem.Login();
@@ -480,15 +493,15 @@ public class CorpseGameItemComponent : GameItemComponent, ICorpse, ILazyLoadDuri
         ICheck check = Gameworld.GetCheck(CheckType.SkinningCheck);
         Skinning effect = skinner.EffectsOfType<Skinning>().First();
         foreach (IButcheryProduct product in OriginalCharacter.Race.ButcheryProfile.Products.Where(x =>
-                     x.IsPelt && x.CanProduce(skinner, Parent)))
+                     x.IsPelt && x.AppliesTo(this) && x.CanProduce(skinner, Parent)))
         {
-            double damageRatio =
-                Parent.Wounds.Where(x => product.RequiredBodyparts.Contains(x.Bodypart)).Sum(x => x.CurrentDamage) /
-                product.RequiredBodyparts.Sum(x => OriginalBody.HitpointsForBodypart(x));
-            if (double.IsNaN(damageRatio))
-            {
-                damageRatio = 1.0;
-            }
+            List<IBodypart> productParts = product.MatchingBodyparts(this).ToList();
+            double totalHitpoints = productParts.Sum(x => OriginalBody.HitpointsForBodypart(x));
+            double damageRatio = totalHitpoints <= 0.0
+                ? 1.0
+                : Parent.Wounds.Where(x => productParts.Any(y => x.Bodypart.ButcheryBodypartMatches(y)))
+                        .Sum(x => x.CurrentDamage) /
+                  totalHitpoints;
 
             foreach (IButcheryProductItem item in product.ProductItems)
             {

--- a/MudSharpCore/Work/Butchering/ButcheryExtensions.cs
+++ b/MudSharpCore/Work/Butchering/ButcheryExtensions.cs
@@ -1,43 +1,82 @@
-﻿using System;
+using MudSharp.Body;
+using MudSharp.GameItems.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace MudSharp.Work.Butchering;
 
 public static class ButcheryExtensions
 {
-    /// <summary>
-    /// Returns the string representation of the verb, e.g. Butcher, Salvage etc
-    /// </summary>
-    /// <param name="verb"></param>
-    /// <param name="properCase"></param>
-    /// <returns></returns>
-    public static string Describe(this ButcheryVerb verb, bool properCase = true)
-    {
-        switch (verb)
-        {
-            case ButcheryVerb.Butcher:
-                return properCase ? "Butcher" : "butcher";
-            case ButcheryVerb.Salvage:
-                return properCase ? "Salvage" : "salvage";
-        }
+	public static string NormaliseButcherySubcategory(this string subcategory)
+	{
+		return string.IsNullOrWhiteSpace(subcategory) ? string.Empty : subcategory.ToLowerInvariant();
+	}
 
-        throw new ApplicationException("Unknown ButcheryVerb in ButcheryExtensions.Describe");
-    }
+	public static bool ButcheryBodypartMatches(this IBodypart part, IBodypart requiredPart)
+	{
+		return part != null &&
+		       requiredPart != null &&
+		       (part == requiredPart || part.CountsAs(requiredPart) || requiredPart.CountsAs(part));
+	}
 
-    /// <summary>
-    /// Returns the gerund of the verb's action, e.g. butchering, salvaging, etc
-    /// </summary>
-    /// <param name="verb"></param>
-    /// <returns></returns>
-    public static string DescribeGerund(this ButcheryVerb verb)
-    {
-        switch (verb)
-        {
-            case ButcheryVerb.Butcher:
-                return "butchering";
-            case ButcheryVerb.Salvage:
-                return "salvaging";
-        }
+	public static IEnumerable<IBodypart> MatchingBodyparts(this IButcheryProduct product, IButcherable target)
+	{
+		return target.Parts
+		             .Where(part => product.RequiredBodyparts.Any(part.ButcheryBodypartMatches))
+		             .Distinct();
+	}
 
-        throw new ApplicationException("Unknown ButcheryVerb in ButcheryExtensions.DescribeGerund");
-    }
+	public static bool AppliesTo(this IButcheryProduct product, IButcherable target)
+	{
+		if (product.TargetBody is not null && !target.OriginalBody.Prototype.CountsAs(product.TargetBody))
+		{
+			return false;
+		}
+
+		if (!product.RequiredBodyparts.Any())
+		{
+			return false;
+		}
+
+		return product.RequiredBodyparts.All(requiredPart =>
+			target.Parts.Any(part => part.ButcheryBodypartMatches(requiredPart)));
+	}
+
+	/// <summary>
+	/// Returns the string representation of the verb, e.g. Butcher, Salvage etc
+	/// </summary>
+	/// <param name="verb"></param>
+	/// <param name="properCase"></param>
+	/// <returns></returns>
+	public static string Describe(this ButcheryVerb verb, bool properCase = true)
+	{
+		switch (verb)
+		{
+			case ButcheryVerb.Butcher:
+				return properCase ? "Butcher" : "butcher";
+			case ButcheryVerb.Salvage:
+				return properCase ? "Salvage" : "salvage";
+		}
+
+		throw new ApplicationException("Unknown ButcheryVerb in ButcheryExtensions.Describe");
+	}
+
+	/// <summary>
+	/// Returns the gerund of the verb's action, e.g. butchering, salvaging, etc
+	/// </summary>
+	/// <param name="verb"></param>
+	/// <returns></returns>
+	public static string DescribeGerund(this ButcheryVerb verb)
+	{
+		switch (verb)
+		{
+			case ButcheryVerb.Butcher:
+				return "butchering";
+			case ButcheryVerb.Salvage:
+				return "salvaging";
+		}
+
+		throw new ApplicationException("Unknown ButcheryVerb in ButcheryExtensions.DescribeGerund");
+	}
 }

--- a/MudSharpCore/Work/Butchering/ButcheryProduct.cs
+++ b/MudSharpCore/Work/Butchering/ButcheryProduct.cs
@@ -95,7 +95,7 @@ public class ButcheryProduct : SaveableItem, IButcheryProduct
         Gameworld = gameworld;
         _id = product.Id;
         _name = product.Name;
-        Subcategory = product.Subcategory.ToLowerInvariant();
+        Subcategory = product.Subcategory.NormaliseButcherySubcategory();
         TargetBody = gameworld.BodyPrototypes.Get(product.TargetBodyId);
         foreach (ButcheryProductsBodypartProtos item in product.ButcheryProductsBodypartProtos)
         {
@@ -183,12 +183,12 @@ public class ButcheryProduct : SaveableItem, IButcheryProduct
 	#3part <which>#0 - toggles requiring the corpse to have this bodypart
 	#3prog <which>#0 - sets the prog that controls whether the item is produced
 	#3item add <number> <proto> [<number> <damaged> <damage%>]#0 - adds a new item product
-	#3item delete <##>#0 - deletes an item product
-	#3item <##> quantity <number>#0 - changes the quantity of items produced
-	#3item <##> proto <id>#0 - changes the proto produced
-	#3item <##> threshold <%>#0 - changes the damage percentage for normal/damaged items
-	#3item <##> damaged <quantity> <proto>#0 - changes the damaged proto
-	#3item <##> nodamaged#0 - clears the damaged proto";
+	#3item delete <id|##>#0 - deletes an item product
+	#3item <id|##> quantity <number>#0 - changes the quantity of items produced
+	#3item <id|##> proto <id>#0 - changes the proto produced
+	#3item <id|##> threshold <%>#0 - changes the damage percentage for normal/damaged items
+	#3item <id|##> damaged <quantity> <proto>#0 - changes the damaged proto
+	#3item <id|##> nodamaged#0 - clears the damaged proto";
     public bool BuildingCommand(ICharacter actor, StringStack command)
     {
         switch (command.PopForSwitch())
@@ -239,7 +239,7 @@ public class ButcheryProduct : SaveableItem, IButcheryProduct
             return false;
         }
 
-        IButcheryProductItem product = ProductItems.FirstOrDefault(x => x.Id == index);
+        IButcheryProductItem product = GetProductItemByIdOrOrdinal(index);
         if (product is null)
         {
             actor.OutputHandler.Send("This product has no such product item.");
@@ -268,13 +268,25 @@ public class ButcheryProduct : SaveableItem, IButcheryProduct
             default:
                 actor.OutputHandler.Send(@"You can use the following options to edit the product items:
 
-	#3item <##> quantity <number>#0 - changes the quantity of items produced
-	#3item <##> proto <id>#0 - changes the proto produced
-	#3item <##> threshold <%>#0 - changes the damage percentage for normal/damaged items
-	#3item <##> damaged <quantity> <proto>#0 - changes the damaged proto
-	#3item <##> nodamaged#0 - clears the damaged proto".SubstituteANSIColour());
+	#3item <id|##> quantity <number>#0 - changes the quantity of items produced
+	#3item <id|##> proto <id>#0 - changes the proto produced
+	#3item <id|##> threshold <%>#0 - changes the damage percentage for normal/damaged items
+	#3item <id|##> damaged <quantity> <proto>#0 - changes the damaged proto
+	#3item <id|##> nodamaged#0 - clears the damaged proto".SubstituteANSIColour());
                 return false;
         }
+    }
+
+    private IButcheryProductItem GetProductItemByIdOrOrdinal(long value)
+    {
+        IButcheryProductItem product = ProductItems.FirstOrDefault(x => x.Id == value);
+        if (product is not null)
+        {
+            return product;
+        }
+
+        List<IButcheryProductItem> products = ProductItems.ToList();
+        return value >= 1 && value <= products.Count ? products[(int)value - 1] : null;
     }
 
     private bool BuildingCommandNoDamaged(ICharacter actor, StringStack command, IButcheryProductItem product)
@@ -341,9 +353,11 @@ public class ButcheryProduct : SaveableItem, IButcheryProduct
             return false;
         }
 
-        if (!command.SafeRemainingArgument.TryParsePercentage(actor.Account.Culture, out double percentage))
+        if (!command.SafeRemainingArgument.TryParsePercentage(actor.Account.Culture, out double percentage) ||
+            percentage < 0.0 ||
+            percentage > 1.0)
         {
-            actor.OutputHandler.Send("That is not a valid percentage.");
+            actor.OutputHandler.Send("That is not a valid percentage between 0% and 100%.");
             return false;
         }
 
@@ -414,13 +428,13 @@ public class ButcheryProduct : SaveableItem, IButcheryProduct
             return false;
         }
 
-        if (!long.TryParse(command.Last, out long index))
+        if (!long.TryParse(command.PopSpeech(), out long index))
         {
             actor.OutputHandler.Send("That is not a valid ID.");
             return false;
         }
 
-        IButcheryProductItem product = ProductItems.FirstOrDefault(x => x.Id == index);
+        IButcheryProductItem product = GetProductItemByIdOrOrdinal(index);
         if (product is null)
         {
             actor.OutputHandler.Send("This product has no such product item.");
@@ -453,7 +467,7 @@ public class ButcheryProduct : SaveableItem, IButcheryProduct
             return false;
         }
 
-        if (!long.TryParse(command.SafeRemainingArgument, out long id))
+        if (!long.TryParse(command.PopSpeech(), out long id))
         {
             actor.OutputHandler.Send("You must enter a valid ID number for the item prototype.");
             return false;
@@ -488,7 +502,7 @@ public class ButcheryProduct : SaveableItem, IButcheryProduct
                 return false;
             }
 
-            if (!long.TryParse(command.SafeRemainingArgument, out long damagedId))
+            if (!long.TryParse(command.PopSpeech(), out long damagedId))
             {
                 actor.OutputHandler.Send("You must enter a valid ID number for the damaged item prototype.");
                 return false;
@@ -511,16 +525,19 @@ public class ButcheryProduct : SaveableItem, IButcheryProduct
         double percentage = 1.0;
         if (!command.IsFinished)
         {
-            if (!command.SafeRemainingArgument.TryParsePercentage(actor.Account.Culture, out percentage))
+            if (!command.SafeRemainingArgument.TryParsePercentage(actor.Account.Culture, out percentage) ||
+                percentage < 0.0 ||
+                percentage > 1.0)
             {
-                actor.OutputHandler.Send("That is not a valid percentage.");
+                actor.OutputHandler.Send("That is not a valid percentage between 0% and 100%.");
                 return false;
             }
         }
 
         ButcheryProductItem productItem = new(this, proto, quantity, damagedProto, damagedQuantity, percentage);
         _productItems.Add(productItem);
-        actor.OutputHandler.Send($"You create	");
+        actor.OutputHandler.Send(
+            $"You add product item #{productItem.Id.ToString("N0", actor)}: {quantity.ToString("N0", actor)}x {proto.EditHeader().ColourObject()}{(damagedProto is null ? "" : $" or {damagedQuantity.ToString("N0", actor)}x {damagedProto.EditHeader().ColourObject()} above {percentage.ToString("P2", actor).ColourValue()} damage")}.");
         return true;
     }
 
@@ -553,7 +570,7 @@ public class ButcheryProduct : SaveableItem, IButcheryProduct
             return false;
         }
 
-        if (command.SafeRemainingArgument.EqualTo("clear"))
+        if (command.SafeRemainingArgument.EqualToAny("clear", "none", "remove"))
         {
             Subcategory = "";
             Changed = true;
@@ -561,7 +578,7 @@ public class ButcheryProduct : SaveableItem, IButcheryProduct
             return true;
         }
 
-        Subcategory = command.SafeRemainingArgument.ToLowerInvariant();
+        Subcategory = command.SafeRemainingArgument.NormaliseButcherySubcategory();
         Changed = true;
         actor.OutputHandler.Send($"This product now belongs to the {Subcategory.ColourValue()} subcategory.");
         return true;
@@ -656,6 +673,12 @@ public class ButcheryProduct : SaveableItem, IButcheryProduct
 
         if (_requiredBodyparts.Contains(part))
         {
+            if (_requiredBodyparts.Count == 1)
+            {
+                actor.OutputHandler.Send("You cannot remove the last required bodypart from a butchery product.");
+                return false;
+            }
+
             _requiredBodyparts.Remove(part);
             actor.OutputHandler.Send($"This product no longer requires the {part.FullDescription().ColourValue()} bodypart.");
         }
@@ -719,6 +742,7 @@ public class ButcheryProduct : SaveableItem, IButcheryProduct
             select new List<string>
             {
                 i++.ToString("N0", voyeur),
+                product.Id.ToString("N0", voyeur),
                 $"{product.NormalQuantity.ToString("N0", voyeur)}x {product.NormalProto.EditHeader()}",
                 product.DamagedProto != null
                     ? $"{product.DamagedQuantity.ToString("N0", voyeur)}x {product.DamagedProto.EditHeader()}"
@@ -728,6 +752,7 @@ public class ButcheryProduct : SaveableItem, IButcheryProduct
             new List<string>
             {
                 "No.",
+                "Id",
                 "Item",
                 "Damaged Item",
                 "Threshold"

--- a/MudSharpCore/Work/Butchering/RaceButcheryProfile.cs
+++ b/MudSharpCore/Work/Butchering/RaceButcheryProfile.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using static MudSharp.Effects.Concrete.Butchering;
+using static MudSharp.Effects.Concrete.Skinning;
 
 namespace MudSharp.Work.Butchering;
 
@@ -43,7 +44,7 @@ public class RaceButcheryProfile : SaveableItem, IRaceButcheryProfile
         foreach (RaceButcheryProfilesBreakdownChecks item in profile.RaceButcheryProfilesBreakdownChecks)
         {
             _breakdownChecks.Add(
-                string.IsNullOrEmpty(item.Subcageory) ? string.Empty : item.Subcageory.ToLowerInvariant(),
+                item.Subcageory.NormaliseButcherySubcategory(),
                 (gameworld.Traits.Get(item.TraitDefinitionId), (Difficulty)item.Difficulty));
         }
 
@@ -52,10 +53,10 @@ public class RaceButcheryProfile : SaveableItem, IRaceButcheryProfile
             _skinEmotes.Add((item.Emote, item.Delay));
         }
 
-        foreach (IGrouping<string, RaceButcheryProfilesBreakdownEmotes> category in profile.RaceButcheryProfilesBreakdownEmotes.GroupBy(x => x.Subcategory))
+        foreach (IGrouping<string, RaceButcheryProfilesBreakdownEmotes> category in profile.RaceButcheryProfilesBreakdownEmotes.GroupBy(x => x.Subcategory.NormaliseButcherySubcategory()))
         {
             _breakdownEmotes.AddRange(
-                string.IsNullOrEmpty(category.Key) ? string.Empty : category.Key.ToLowerInvariant(),
+                category.Key,
                 category.OrderBy(x => x.Order).Select(item => (item.Emote, item.Delay)).ToList());
         }
 
@@ -203,7 +204,15 @@ public class RaceButcheryProfile : SaveableItem, IRaceButcheryProfile
     /// <returns>The trait and difficulty of the breakdown</returns>
     public (ITraitDefinition Trait, Difficulty CheckDifficulty) BreakdownCheck(string subcategory)
     {
-        return _breakdownChecks[subcategory];
+        return _breakdownChecks[subcategory.NormaliseButcherySubcategory()];
+    }
+
+    public bool HasBreakdown(string subcategory)
+    {
+        var key = subcategory.NormaliseButcherySubcategory();
+        return _breakdownChecks.ContainsKey(key) &&
+               _breakdownEmotes.ContainsKey(key) &&
+               _breakdownEmotes[key].Any();
     }
 
     private readonly List<(string Emote, double Delay)> _skinEmotes = new();
@@ -222,7 +231,7 @@ public class RaceButcheryProfile : SaveableItem, IRaceButcheryProfile
     /// <returns>The emotes and delays for the phases</returns>
     public IEnumerable<(string Emote, double Delay)> BreakdownEmotes(string subcategory)
     {
-        return _breakdownEmotes[subcategory];
+        return _breakdownEmotes[subcategory.NormaliseButcherySubcategory()];
     }
 
     private readonly List<IButcheryProduct> _products = new();
@@ -248,6 +257,11 @@ public class RaceButcheryProfile : SaveableItem, IRaceButcheryProfile
     public bool CanButcher(ICharacter butcher, IGameItem targetItem)
     {
         if (targetItem.EffectsOfType<BeingButchered>().Any())
+        {
+            return false;
+        }
+
+        if (targetItem.EffectsOfType<BeingSkinned>().Any())
         {
             return false;
         }
@@ -278,6 +292,12 @@ public class RaceButcheryProfile : SaveableItem, IRaceButcheryProfile
         {
             return
                 $"You cannot {Verb.Describe(false)} {targetItem.HowSeen(butcher)} because {targetItem.EffectsOfType<BeingButchered>().First().Butcher.HowSeen(butcher)} is already {Verb.DescribeGerund()} it.";
+        }
+
+        if (targetItem.EffectsOfType<BeingSkinned>().Any())
+        {
+            return
+                $"You cannot work on {targetItem.HowSeen(butcher)} because {targetItem.EffectsOfType<BeingSkinned>().First().Skinner.HowSeen(butcher)} is already skinning it.";
         }
 
         IInventoryPlan plan = ToolTemplate.CreatePlan(butcher);
@@ -379,7 +399,7 @@ public class RaceButcheryProfile : SaveableItem, IRaceButcheryProfile
 
 	#3name <name>#0 - renames this profile
 	#3verb butcher|salvage#0 - changes the verb used for interacting with these corpses
-	#3tool <tag>#0 - sets the tag of tools required to interact with this
+	#3tool <tag>|none#0 - sets or clears the tag of tools required to interact with this
 	#3skindiff <difficulty>#0 - sets the difficulty of the skinning check
 	#3can <prog>#0 - sets a prog to control whether someone can butcher this
 	#3why <prog>#0 - sets a prog for a custom error message on can butcher failure
@@ -529,6 +549,15 @@ For all of the below phase emote echoes, you can use #6$0#0 for the actor, #6$1#
             return false;
         }
 
+        if (command.SafeRemainingArgument.EqualToAny("none", "clear", "remove"))
+        {
+            RequiredToolTag = null;
+            RecalculateInventoryPlan();
+            Changed = true;
+            actor.OutputHandler.Send("This butchery profile no longer requires a tool.");
+            return true;
+        }
+
         List<ITag> matchedtags = actor.Gameworld.Tags.FindMatchingTags(command.SafeRemainingArgument);
         if (matchedtags.Count == 0)
         {
@@ -547,13 +576,7 @@ For all of the below phase emote echoes, you can use #6$0#0 for the actor, #6$1#
 
         RequiredToolTag = tag;
         Changed = true;
-        ToolTemplate = new InventoryPlanTemplate(Gameworld, new[]
-        {
-            new InventoryPlanPhaseTemplate(1, new[]
-            {
-                new InventoryPlanActionHold(Gameworld, RequiredToolTag.Id, 0, item => true, null, 1)
-            })
-        });
+        RecalculateInventoryPlan();
         actor.OutputHandler.Send(
             $"Players will now be required to have a tool item with the tag {RequiredToolTag.FullName.ColourName()} in order to {Verb.DescribeEnum().ColourCommand()} corpses and bodyparts with this profile.");
         return true;
@@ -668,7 +691,7 @@ For all of the below phase emote echoes, you can use #6$0#0 for the actor, #6$1#
             return false;
         }
 
-        string subsystem = command.PopSpeech().ToLowerInvariant();
+        string subsystem = command.PopSpeech().NormaliseButcherySubcategory();
         if (subsystem.EqualTo("main"))
         {
             subsystem = string.Empty;
@@ -803,7 +826,7 @@ For all of the below phase emote echoes, you can use #6$0#0 for the actor, #6$1#
             return false;
         }
 
-        if (!double.TryParse(command.PopSpeech(), out double value))
+        if (!double.TryParse(command.PopSpeech(), out double value) || value <= 0.0)
         {
             actor.OutputHandler.Send(
                 $"{command.Last.ColourCommand()} is not a valid number of seconds of delay for this emote.");
@@ -917,6 +940,7 @@ For all of the below phase emote echoes, you can use #6$0#0 for the actor, #6$1#
         _skinEmotes.SwapByIndex(value1 - 1, value2 - 1);
         actor.OutputHandler.Send(
             $"You swap the positions of the {value1.ToOrdinal().ColourValue()} and {value2.ToOrdinal().ColourValue()} skin emotes.");
+        Changed = true;
         return true;
     }
 
@@ -1009,11 +1033,11 @@ For all of the below phase emote echoes, you can use #6$0#0 for the actor, #6$1#
             return false;
         }
 
-        string subsystem = command.PopSpeech().ToLowerInvariant();
+        string subsystem = command.PopSpeech().NormaliseButcherySubcategory();
         if (!_breakdownChecks.ContainsKey(subsystem))
         {
             actor.OutputHandler.Send(
-                $"There is no subsytem defined with a value of {subsystem.ColourCommand()}. You must first define a check for the subsystem before you can add emotes.");
+                $"There is no subsystem defined with a value of {subsystem.ColourCommand()}. You must first define a check for the subsystem before you can add emotes.");
             return false;
         }
 
@@ -1054,7 +1078,7 @@ For all of the below phase emote echoes, you can use #6$0#0 for the actor, #6$1#
             return false;
         }
 
-        if (!double.TryParse(command.PopSpeech(), out double value))
+        if (!double.TryParse(command.PopSpeech(), out double value) || value <= 0.0)
         {
             actor.OutputHandler.Send(
                 $"{command.Last.ColourCommand()} is not a valid number of seconds of delay for this emote.");
@@ -1174,6 +1198,7 @@ For all of the below phase emote echoes, you can use #6$0#0 for the actor, #6$1#
         _breakdownEmotes.Swap(subsystem, value1 - 1, value2 - 1);
         actor.OutputHandler.Send(
             $"You swap the positions of the {value1.ToOrdinal().ColourValue()} and {value2.ToOrdinal().ColourValue()} breakdown emotes{(string.IsNullOrWhiteSpace(subsystem) ? "" : $" for subsystem {subsystem.ColourCommand()}")}.");
+        Changed = true;
         return true;
     }
 
@@ -1197,7 +1222,7 @@ For all of the below phase emote echoes, you can use #6$0#0 for the actor, #6$1#
             return false;
         }
 
-        if (value > _skinEmotes.Count)
+        if (value > _breakdownEmotes[subsystem].Count)
         {
             actor.OutputHandler.Send(
                 $"There are only {_breakdownEmotes[subsystem].Count().ToString("N0", actor).ColourValue()} emotes to choose from.");
@@ -1247,7 +1272,7 @@ For all of the below phase emote echoes, you can use #6$0#0 for the actor, #6$1#
             return false;
         }
 
-        if (value > _skinEmotes.Count)
+        if (value > _breakdownEmotes[subsystem].Count)
         {
             actor.OutputHandler.Send(
                 $"There are only {_breakdownEmotes[subsystem].Count().ToString("N0", actor).ColourValue()} emotes to choose from.");
@@ -1445,8 +1470,8 @@ For all of the below phase emote echoes, you can use #6$0#0 for the actor, #6$1#
                 {
                     item.Id.ToString("N0", voyeur),
                     item.Name,
-                    item.CanProduceProg.MXPClickableFunctionName(),
-                    item.TargetBody.Name,
+                    item.CanProduceProg?.MXPClickableFunctionName() ?? "",
+                    item.TargetBody?.Name ?? "",
                     item.RequiredBodyparts.Select(x => x.Name).ListToCommaSeparatedValues(", "),
                     item.ProductItems.Select(x => $"{x.NormalQuantity.ToString("N0", voyeur)}x {x.NormalProto.EditHeader()}".ColourObject()).ListToCommaSeparatedValues(", ")
                 },

--- a/RPI Engine Worldfile Converter/FutureMudItemImporter.cs
+++ b/RPI Engine Worldfile Converter/FutureMudItemImporter.cs
@@ -86,24 +86,47 @@ public sealed class FutureMudBaselineCatalog
 			.Include(x => x.EditableItem)
 			.Where(x => x.EditableItem == null || x.EditableItem.RevisionStatus == 4)
 			.ToList();
+		var uniqueComponents = components
+			.Where(x => !string.IsNullOrWhiteSpace(x.Name))
+			.GroupBy(x => x.Name, StringComparer.OrdinalIgnoreCase)
+			.Select(x => x
+				.OrderBy(y => y.Id)
+				.ThenBy(y => y.RevisionNumber)
+				.First())
+			.ToList();
 
 		return new FutureMudBaselineCatalog
 		{
-			Components = components.ToDictionary(
+			Components = uniqueComponents.ToDictionary(
 				x => x.Name,
 				x => new FutureMudComponentReference(x.Id, x.RevisionNumber, x.Name, x.Type),
 				StringComparer.OrdinalIgnoreCase),
-			ComponentsByType = components
+			ComponentsByType = uniqueComponents
 				.GroupBy(x => x.Type, StringComparer.OrdinalIgnoreCase)
 				.ToDictionary(
 					x => x.Key,
 					x => x.Select(y => y.Name).OrderBy(y => y, StringComparer.OrdinalIgnoreCase).ToList(),
 					StringComparer.OrdinalIgnoreCase),
-			MaterialIds = context.Materials.ToDictionary(x => x.Name, x => x.Id, StringComparer.OrdinalIgnoreCase),
-			TagIds = context.Tags.ToDictionary(x => x.Name, x => x.Id, StringComparer.OrdinalIgnoreCase),
-			LiquidIds = context.Liquids.ToDictionary(x => x.Name, x => x.Id, StringComparer.OrdinalIgnoreCase),
-			TraitIds = context.TraitDefinitions.ToDictionary(x => x.Name, x => x.Id, StringComparer.OrdinalIgnoreCase)
+			MaterialIds = ToUniqueIdDictionary(context.Materials, x => x.Name, x => x.Id),
+			TagIds = ToUniqueIdDictionary(context.Tags, x => x.Name, x => x.Id),
+			LiquidIds = ToUniqueIdDictionary(context.Liquids, x => x.Name, x => x.Id),
+			TraitIds = ToUniqueIdDictionary(context.TraitDefinitions, x => x.Name, x => x.Id)
 		};
+	}
+
+	private static Dictionary<string, long> ToUniqueIdDictionary<T>(
+		IEnumerable<T> values,
+		Func<T, string?> nameSelector,
+		Func<T, long> idSelector)
+	{
+		return values
+			.Where(x => !string.IsNullOrWhiteSpace(nameSelector(x)))
+			.GroupBy(x => nameSelector(x)!, StringComparer.OrdinalIgnoreCase)
+			.Select(x => x.OrderBy(idSelector).First())
+			.ToDictionary(
+				x => nameSelector(x)!,
+				idSelector,
+				StringComparer.OrdinalIgnoreCase);
 	}
 
 	public bool HasComponent(string name)

--- a/RPI Engine Worldfile Converter/RpiItemConversionMapping.md
+++ b/RPI Engine Worldfile Converter/RpiItemConversionMapping.md
@@ -116,6 +116,7 @@ These still preserve provenance, raw ovals, warnings, and any optional source me
 
 ## Notes
 
+- Baseline catalog lookups tolerate duplicate seeded component, material, tag, liquid, and trait names by choosing the lowest-ID row deterministically.
 - Missing seeded dependencies are surfaced as validation issues rather than silently dropped.
 - The importer deliberately avoids creating new runtime behaviour; if a mapping needs a runtime item system that FutureMUD does not already expose, the item remains a prop in this pass.
 - Export JSON is the recommended interchange format if this work later migrates into code generation for `DatabaseSeeder`.


### PR DESCRIPTION
## Summary
- Added race butchery profile support and wired it into loader, runtime butchering effects, and product handling.
- Updated builder commands and item components so corpse/bodypart workflows respect the new butchery data.
- Brought the seeder, design notes, and RPI importer mapping in line with the new butchering system behavior.

## Testing
- Not run (not requested).