### PR TITLE
Normalize clan alias resolution across the RPI worldfile converter

### DIFF
--- a/RPI Engine Worldfile Converter Tests/RpiClanConversionTests.cs
+++ b/RPI Engine Worldfile Converter Tests/RpiClanConversionTests.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -46,8 +47,7 @@ public class RpiClanConversionTests
 		var conversion = transformer.Convert(source, references);
 		var converted = conversion.ConvertedClans.ToDictionary(x => x.CanonicalAlias, StringComparer.OrdinalIgnoreCase);
 
-		Assert.IsTrue(conversion.UnresolvedAliasCounts.ContainsKey("com-priests"));
-		Assert.AreEqual(1, conversion.UnresolvedAliasCounts["com-priests"]);
+		Assert.IsFalse(conversion.UnresolvedAliasCounts.ContainsKey("com-priests"));
 
 		var ithilien = converted["ithilien_battalion"];
 		CollectionAssert.AreEquivalent(
@@ -117,6 +117,12 @@ public class RpiClanConversionTests
 			new[] { RpiClanRankSlot.Apprentice },
 			healers.Ranks.Select(x => x.Slot).ToArray());
 
+		var priests = converted["com_priests"];
+		Assert.AreEqual("Cult of Morgoth Priests", priests.FullName);
+		CollectionAssert.AreEquivalent(
+			new[] { RpiClanRankSlot.Membership },
+			priests.Ranks.Select(x => x.Slot).ToArray());
+
 		var sergeant = ithilien.Ranks.Single(x => x.Slot == RpiClanRankSlot.Sergeant);
 		var captain = ithilien.Ranks.Single(x => x.Slot == RpiClanRankSlot.Captain);
 		var membership = mordor.Ranks.Single(x => x.Slot == RpiClanRankSlot.Membership);
@@ -138,6 +144,85 @@ public class RpiClanConversionTests
 			},
 			conversion.ConvertedClans);
 		Assert.IsFalse(validation.Any(x => x.Severity.Equals("error", StringComparison.OrdinalIgnoreCase)));
+	}
+
+	[TestMethod]
+	public void ClanTransformer_CollapsesAliasPunctuationVariants()
+	{
+		var source = new RpiClanSourceDocument(
+			"synthetic",
+			[
+				new RpiClanHeaderEntry(1, "Black Watch", "black-watch"),
+				new RpiClanHeaderEntry(2, "Black Watch", "black_watch")
+			],
+			new Dictionary<string, RpiClanAliasSource>(StringComparer.OrdinalIgnoreCase),
+			Array.Empty<string>());
+		var references = new RpiClanReferenceIndex(
+			new Dictionary<string, RpiClanReferenceRecord>(StringComparer.OrdinalIgnoreCase)
+			{
+				["blackwatch"] = new(
+					"blackwatch",
+					3,
+					[RpiClanRankSlot.Membership],
+					Array.Empty<string>())
+			});
+
+		var conversion = new FutureMudClanTransformer().Convert(source, references);
+		var blackWatch = conversion.ConvertedClans.Single(x => x.CanonicalAlias.Equals("blackwatch", StringComparison.OrdinalIgnoreCase));
+
+		Assert.AreEqual("blackwatch", blackWatch.CanonicalAlias);
+		Assert.AreEqual("Black Watch", blackWatch.FullName);
+		CollectionAssert.AreEquivalent(
+			new[] { "black-watch", "black_watch" },
+			blackWatch.LegacyAliases.Where(x => !x.Equals("blackwatch", StringComparison.OrdinalIgnoreCase)).ToArray());
+		CollectionAssert.AreEquivalent(
+			new[] { RpiClanRankSlot.Membership },
+			blackWatch.Ranks.Select(x => x.Slot).ToArray());
+	}
+
+	[TestMethod]
+	public void ClanTransformer_UsesKnownAliasRepairRules_ForBuilderTypos()
+	{
+		var source = new RpiClanSourceDocument(
+			"synthetic",
+			Array.Empty<RpiClanHeaderEntry>(),
+			new Dictionary<string, RpiClanAliasSource>(StringComparer.OrdinalIgnoreCase),
+			Array.Empty<string>());
+		var references = new RpiClanReferenceIndex(
+			new Dictionary<string, RpiClanReferenceRecord>(StringComparer.OrdinalIgnoreCase)
+			{
+				["tecouncil"] = new("tecouncil", 11, Array.Empty<RpiClanRankSlot>(), Array.Empty<string>()),
+				["metalsmithsfellow"] = new("metalsmithsfellow", 6, Array.Empty<RpiClanRankSlot>(), Array.Empty<string>()),
+				["mm_slaves"] = new("mm_slaves", 2, Array.Empty<RpiClanRankSlot>(), Array.Empty<string>()),
+				["mt_ratcatchers"] = new("mt_ratcatchers", 2, Array.Empty<RpiClanRankSlot>(), Array.Empty<string>()),
+				["osgi_ratcatchers"] = new("osgi_ratcatchers", 2, Array.Empty<RpiClanRankSlot>(), Array.Empty<string>()),
+				["witchking_horse"] = new("witchking_horse", 1, [RpiClanRankSlot.Membership], Array.Empty<string>()),
+				["withchking_horde"] = new("withchking_horde", 1, [RpiClanRankSlot.Membership], Array.Empty<string>()),
+				["pel_pelenor"] = new("pel_pelenor", 1, [RpiClanRankSlot.Membership], Array.Empty<string>()),
+				["osgi_citizensmember"] = new("osgi_citizensmember", 1, [RpiClanRankSlot.Membership], Array.Empty<string>())
+			});
+
+		var conversion = new FutureMudClanTransformer().Convert(source, references);
+		var converted = conversion.ConvertedClans.ToDictionary(x => x.CanonicalAlias, StringComparer.OrdinalIgnoreCase);
+
+		Assert.AreEqual("Tur Edendor Council", converted["tecouncil"].FullName);
+		Assert.AreEqual("Metalsmiths Fellowship", converted["metalsmiths_fellowship"].FullName);
+		Assert.AreEqual("Minas Morgul Slaves", converted["mm_slaves"].FullName);
+		Assert.AreEqual("Minas Tirith Ratcatchers", converted["mt_ratcatchers"].FullName);
+		Assert.AreEqual("Osgiliath Rat Catchers", converted["osgi_ratcatchers"].FullName);
+		Assert.AreEqual("Witchking's Horde", converted["witchkings_horde"].FullName);
+		CollectionAssert.Contains(converted["witchkings_horde"].LegacyAliases.ToList(), "witchking_horse");
+		Assert.AreEqual("Pel Pelennor", converted["pel_pelennor"].FullName);
+		Assert.AreEqual("Osgi Citizens", converted["osgi_citizens"].FullName);
+		Assert.IsFalse(conversion.UnresolvedAliasCounts.Any());
+
+		foreach (var clan in converted
+			         .Where(x => references.ReferencesByAlias.ContainsKey(x.Key) ||
+			                     x.Value.LegacyAliases.Any(references.ReferencesByAlias.ContainsKey))
+			         .Select(x => x.Value))
+		{
+			Assert.IsTrue(clan.Ranks.Any(x => x.Slot == RpiClanRankSlot.Membership));
+		}
 	}
 
 	private static string GetClanSourcePath()

--- a/RPI Engine Worldfile Converter Tests/RpiCraftConversionTests.cs
+++ b/RPI Engine Worldfile Converter Tests/RpiCraftConversionTests.cs
@@ -141,6 +141,13 @@ public class RpiCraftConversionTests
 			},
 			ClansByAlias = new Dictionary<string, FutureMudCraftClanReference>(StringComparer.OrdinalIgnoreCase)
 			{
+				["rangers"] = new FutureMudCraftClanReference(
+					1,
+					"Rangers",
+					new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase)
+					{
+						["trusted"] = 1,
+					}),
 				["Rangers"] = new FutureMudCraftClanReference(
 					1,
 					"Rangers",

--- a/RPI Engine Worldfile Converter/FutureMUDItemTransformer.cs
+++ b/RPI Engine Worldfile Converter/FutureMUDItemTransformer.cs
@@ -789,7 +789,9 @@ public sealed class FutureMUDItemTransformer
 
 		var clanRestrictions = item.Clans
 			.Where(x => !string.IsNullOrWhiteSpace(x.Name))
-			.Select(x => new FutureMudBoardClanRestriction(x.Name.Trim(), x.Rank.Trim()))
+			.Select(x => new FutureMudBoardClanRestriction(
+				RpiClanAliasResolver.ResolveCanonicalRule(x.Name.Trim()).CanonicalAlias,
+				x.Rank.Trim()))
 			.GroupBy(x => $"{x.ClanAlias}\n{x.RankName}", StringComparer.OrdinalIgnoreCase)
 			.Select(x => x.First())
 			.ToList();

--- a/RPI Engine Worldfile Converter/FutureMudClanImporter.cs
+++ b/RPI Engine Worldfile Converter/FutureMudClanImporter.cs
@@ -139,18 +139,24 @@ public sealed class FutureMudClanImporter
 		var existingAliases = _context.Clans
 			.Select(x => x.Alias)
 			.ToHashSet(StringComparer.OrdinalIgnoreCase);
+		var existingCollapsedAliases = existingAliases
+			.Select(RpiClanAliasResolver.CollapseAlias)
+			.ToHashSet(StringComparer.OrdinalIgnoreCase);
 		var skippedExistingCount = 0;
 		var insertedCount = 0;
 
 		foreach (var definition in ordered)
 		{
-			if (existingAliases.Contains(definition.CanonicalAlias))
+			if (existingAliases.Contains(definition.CanonicalAlias) ||
+			    existingCollapsedAliases.Contains(RpiClanAliasResolver.CollapseAlias(definition.CanonicalAlias)))
 			{
 				skippedExistingCount++;
 				continue;
 			}
 
-			var conflictingLegacyAlias = definition.LegacyAliases.FirstOrDefault(existingAliases.Contains);
+			var conflictingLegacyAlias = definition.LegacyAliases.FirstOrDefault(alias =>
+				existingAliases.Contains(alias) ||
+				existingCollapsedAliases.Contains(RpiClanAliasResolver.CollapseAlias(alias)));
 			if (!string.IsNullOrWhiteSpace(conflictingLegacyAlias))
 			{
 				issues.Add(new FutureMudClanValidationIssue(
@@ -214,6 +220,7 @@ public sealed class FutureMudClanImporter
 			_context.Clans.Add(clan);
 			_context.SaveChanges();
 			existingAliases.Add(definition.CanonicalAlias);
+			existingCollapsedAliases.Add(RpiClanAliasResolver.CollapseAlias(definition.CanonicalAlias));
 			insertedCount++;
 		}
 

--- a/RPI Engine Worldfile Converter/FutureMudClanTransformer.cs
+++ b/RPI Engine Worldfile Converter/FutureMudClanTransformer.cs
@@ -4,27 +4,8 @@ using MudSharp.Community;
 
 namespace RPI_Engine_Worldfile_Converter;
 
-internal sealed record CanonicalClanRule(string CanonicalAlias, string? FullNameOverride, IReadOnlyList<string> LegacyAliases);
-
 public sealed class FutureMudClanTransformer
 {
-	private static readonly IReadOnlyDictionary<string, CanonicalClanRule> CanonicalRules =
-		new Dictionary<string, CanonicalClanRule>(StringComparer.OrdinalIgnoreCase)
-		{
-			["mordor_char"] = new("mordor_char", "Minas Morgul", ["mm_denizens"]),
-			["mm_denizens"] = new("mordor_char", "Minas Morgul", ["mm_denizens"]),
-			["malred"] = new("malred", "Malred Family", ["housemalred"]),
-			["housemalred"] = new("malred", "Malred Family", ["housemalred"]),
-			["rogues"] = new("rogues", "Rogues' Fellowship", ["rouges"]),
-			["rouges"] = new("rogues", "Rogues' Fellowship", ["rouges"]),
-			["hawk_dove_2"] = new("hawk_dove_2", "Hawk and Dove", ["hawk_and_dove"]),
-			["hawk_and_dove"] = new("hawk_dove_2", "Hawk and Dove", ["hawk_and_dove"]),
-			["seekers"] = new("seekers", "Seekers", Array.Empty<string>()),
-			["shadow-cult"] = new("shadow-cult", "Shadow Cult", Array.Empty<string>()),
-			["tirithguard"] = new("tirithguard", "Minas Tirith Guard", Array.Empty<string>()),
-			["eradan_battalion"] = new("eradan_battalion", "Eradan Battalion", Array.Empty<string>()),
-		};
-
 	private static readonly IReadOnlyList<string> AliasOnlyClans =
 	[
 		"seekers",
@@ -43,7 +24,7 @@ public sealed class FutureMudClanTransformer
 
 		var importedAliases = BuildImportedAliasSet(sourceClans);
 		var unresolved = references.ReferencesByAlias
-			.Where(x => !importedAliases.Contains(ResolveCanonicalRule(x.Key).CanonicalAlias))
+			.Where(x => !importedAliases.Contains(RpiClanAliasResolver.ResolveCanonicalRule(x.Key).CanonicalAlias))
 			.OrderByDescending(x => x.Value.AliasReferenceCount)
 			.ThenBy(x => x.Key, StringComparer.OrdinalIgnoreCase)
 			.ToDictionary(
@@ -59,11 +40,13 @@ public sealed class FutureMudClanTransformer
 		RpiClanReferenceIndex references)
 	{
 		var importedCanonicalAliases = sourceDocument.HeaderEntries
-			.Select(x => ResolveCanonicalRule(x.Alias).CanonicalAlias)
-			.Concat(AliasOnlyClans.Select(x => ResolveCanonicalRule(x).CanonicalAlias))
+			.Select(x => RpiClanAliasResolver.ResolveCanonicalRule(x.Alias).CanonicalAlias)
+			.Concat(AliasOnlyClans.Select(x => RpiClanAliasResolver.ResolveCanonicalRule(x).CanonicalAlias))
 			.Concat(references.ReferencesByAlias
-				.Where(x => x.Value.ObservedSlots.Any(y => y.IsImportable()))
-				.Select(x => ResolveCanonicalRule(x.Key).CanonicalAlias))
+				.Where(x =>
+					x.Value.ObservedSlots.Any(y => y.IsImportable()) ||
+					RpiClanAliasResolver.ResolveCanonicalRule(x.Key).ImportFromUnrankedReferences)
+				.Select(x => RpiClanAliasResolver.ResolveCanonicalRule(x.Key).CanonicalAlias))
 			.Distinct(StringComparer.OrdinalIgnoreCase)
 			.OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
 			.ToList();
@@ -71,11 +54,14 @@ public sealed class FutureMudClanTransformer
 		List<RpiClanDefinition> definitions = [];
 		foreach (var canonicalAlias in importedCanonicalAliases)
 		{
-			var rule = ResolveCanonicalRule(canonicalAlias);
-			var aliases = sourceDocument.AliasSources.Keys
-				.Where(x => ResolveCanonicalRule(x).CanonicalAlias.Equals(canonicalAlias, StringComparison.OrdinalIgnoreCase))
+			var rule = RpiClanAliasResolver.ResolveCanonicalRule(canonicalAlias);
+			var aliases = sourceDocument.HeaderEntries
+				.Select(x => x.Alias)
+				.Where(x => RpiClanAliasResolver.ResolveCanonicalRule(x).CanonicalAlias.Equals(canonicalAlias, StringComparison.OrdinalIgnoreCase))
+				.Concat(sourceDocument.AliasSources.Keys
+					.Where(x => RpiClanAliasResolver.ResolveCanonicalRule(x).CanonicalAlias.Equals(canonicalAlias, StringComparison.OrdinalIgnoreCase)))
 				.Concat(references.ReferencesByAlias.Keys
-					.Where(x => ResolveCanonicalRule(x).CanonicalAlias.Equals(canonicalAlias, StringComparison.OrdinalIgnoreCase)))
+					.Where(x => RpiClanAliasResolver.ResolveCanonicalRule(x).CanonicalAlias.Equals(canonicalAlias, StringComparison.OrdinalIgnoreCase)))
 				.Concat(rule.LegacyAliases)
 				.Append(canonicalAlias)
 				.Distinct(StringComparer.OrdinalIgnoreCase)
@@ -84,12 +70,12 @@ public sealed class FutureMudClanTransformer
 				.ToList();
 
 			var headerEntry = sourceDocument.HeaderEntries
-				.FirstOrDefault(x => ResolveCanonicalRule(x.Alias).CanonicalAlias.Equals(canonicalAlias, StringComparison.OrdinalIgnoreCase));
+				.FirstOrDefault(x => RpiClanAliasResolver.ResolveCanonicalRule(x.Alias).CanonicalAlias.Equals(canonicalAlias, StringComparison.OrdinalIgnoreCase));
 
 			List<string> warnings = [];
 			var fullName = rule.FullNameOverride ??
 			               headerEntry?.FullName ??
-			               DiscoverFullName(canonicalAlias, references) ??
+			               DiscoverFullName(canonicalAlias, aliases, references) ??
 			               RpiClanRankSlots.TitleCaseAlias(canonicalAlias);
 
 			if (headerEntry is null && rule.FullNameOverride is null)
@@ -281,6 +267,12 @@ public sealed class FutureMudClanTransformer
 			}
 		}
 
+		if (imported.Count == 0 &&
+		    RpiClanAliasResolver.ResolveCanonicalRule(clan.CanonicalAlias).ImportFromUnrankedReferences)
+		{
+			imported.Add(RpiClanRankSlot.Membership);
+		}
+
 		return imported.OrderBy(x => x.SortOrder()).ToList();
 	}
 
@@ -366,25 +358,29 @@ public sealed class FutureMudClanTransformer
 		return "normalization-rule";
 	}
 
-	private static string? DiscoverFullName(string canonicalAlias, RpiClanReferenceIndex references)
+	private static string? DiscoverFullName(
+		string canonicalAlias,
+		IReadOnlyCollection<string> aliases,
+		RpiClanReferenceIndex references)
 	{
-		return canonicalAlias switch
+		var explicitName = canonicalAlias switch
 		{
 			"seekers" => "Seekers",
 			"shadow-cult" => "Shadow Cult",
 			"tirithguard" => "Minas Tirith Guard",
 			"eradan_battalion" => "Eradan Battalion",
-			_ => references.ReferencesByAlias.ContainsKey(canonicalAlias)
-				? RpiClanRankSlots.TitleCaseAlias(canonicalAlias)
-				: null,
+			_ => null,
 		};
-	}
 
-	private static CanonicalClanRule ResolveCanonicalRule(string alias)
-	{
-		return CanonicalRules.TryGetValue(alias, out var rule)
-			? rule
-			: new CanonicalClanRule(alias, null, Array.Empty<string>());
+		if (!string.IsNullOrWhiteSpace(explicitName))
+		{
+			return explicitName;
+		}
+
+		var referenceAlias = aliases.FirstOrDefault(references.ReferencesByAlias.ContainsKey);
+		return referenceAlias is not null
+			? RpiClanRankSlots.TitleCaseAlias(referenceAlias)
+			: null;
 	}
 
 	private static HashSet<string> BuildImportedAliasSet(IEnumerable<RpiClanDefinition> clans)

--- a/RPI Engine Worldfile Converter/FutureMudCraftImporter.cs
+++ b/RPI Engine Worldfile Converter/FutureMudCraftImporter.cs
@@ -112,25 +112,7 @@ public sealed class FutureMudCraftBaselineCatalog
 			.Where(x => x.vnum.HasValue && x.reference is not null)
 			.ToDictionary(x => x.vnum!.Value, x => x.reference!, EqualityComparer<int>.Default);
 
-		var clans = context.Clans
-			.Include(x => x.Ranks)
-				.ThenInclude(x => x.RanksTitles)
-			.Include(x => x.Ranks)
-				.ThenInclude(x => x.RanksAbbreviations)
-			.ToList()
-			.ToDictionary(
-				x => x.Alias,
-				x => new FutureMudCraftClanReference(
-					x.Id,
-					x.Alias,
-					x.Ranks
-						.SelectMany(rank =>
-							rank.RanksTitles.Select(title => (name: title.Title, rank.Id))
-								.Concat(rank.RanksAbbreviations.Select(abbreviation => (name: abbreviation.Abbreviation, rank.Id)))
-								.Append((name: rank.Name, Id: rank.Id)))
-						.GroupBy(y => y.name, StringComparer.OrdinalIgnoreCase)
-						.ToDictionary(y => y.Key, y => y.First().Id, StringComparer.OrdinalIgnoreCase)),
-				StringComparer.OrdinalIgnoreCase);
+		var clans = LoadClansByAlias(context);
 
 		return new FutureMudCraftBaselineCatalog
 		{
@@ -150,6 +132,54 @@ public sealed class FutureMudCraftBaselineCatalog
 	public bool TryGetWeatherId(string weatherName, out long id)
 	{
 		return WeatherIdsByNormalisedName.TryGetValue(NormaliseLookupKey(weatherName), out id);
+	}
+
+	private static Dictionary<string, FutureMudCraftClanReference> LoadClansByAlias(FuturemudDatabaseContext context)
+	{
+		var result = new Dictionary<string, FutureMudCraftClanReference>(StringComparer.OrdinalIgnoreCase);
+		var clans = context.Clans
+			.Include(x => x.Ranks)
+				.ThenInclude(x => x.RanksTitles)
+			.Include(x => x.Ranks)
+				.ThenInclude(x => x.RanksAbbreviations)
+			.ToList()
+			.Where(x => !string.IsNullOrWhiteSpace(x.Alias))
+			.GroupBy(x => x.Alias, StringComparer.OrdinalIgnoreCase)
+			.Select(x => x.OrderBy(y => y.Id).First());
+
+		foreach (var clan in clans)
+		{
+			var reference = new FutureMudCraftClanReference(
+				clan.Id,
+				clan.Alias,
+				clan.Ranks
+					.SelectMany(rank =>
+						rank.RanksTitles.Select(title => (name: title.Title, rank.Id))
+							.Concat(rank.RanksAbbreviations.Select(abbreviation => (name: abbreviation.Abbreviation, rank.Id)))
+							.Append((name: rank.Name, Id: rank.Id)))
+					.Where(y => !string.IsNullOrWhiteSpace(y.name))
+					.GroupBy(y => y.name, StringComparer.OrdinalIgnoreCase)
+					.ToDictionary(y => y.Key, y => y.First().Id, StringComparer.OrdinalIgnoreCase));
+
+			TryRegisterClanReference(result, clan.Alias, reference);
+			TryRegisterClanReference(result, RpiClanAliasResolver.CollapseAlias(clan.Alias), reference);
+			TryRegisterClanReference(result, RpiClanAliasResolver.ResolveCanonicalRule(clan.Alias).CanonicalAlias, reference);
+		}
+
+		return result;
+	}
+
+	private static void TryRegisterClanReference(
+		IDictionary<string, FutureMudCraftClanReference> clans,
+		string alias,
+		FutureMudCraftClanReference reference)
+	{
+		if (string.IsNullOrWhiteSpace(alias) || clans.ContainsKey(alias))
+		{
+			return;
+		}
+
+		clans[alias] = reference;
 	}
 
 	internal static string NormaliseLookupKey(string value)

--- a/RPI Engine Worldfile Converter/FutureMudCraftTransformer.cs
+++ b/RPI Engine Worldfile Converter/FutureMudCraftTransformer.cs
@@ -152,8 +152,6 @@ public sealed record CraftConversionResult(
 	IReadOnlyList<GeneratedCraftTagDefinition> GeneratedTags,
 	IReadOnlyDictionary<string, int> DeferredReasonCounts);
 
-internal sealed record NormalisedClanRule(string CanonicalAlias, string? FullNameOverride, IReadOnlyList<string> LegacyAliases);
-
 internal sealed record ResolvedCraftRequirement(
 	string Type,
 	int Quantity,
@@ -395,23 +393,6 @@ public sealed class FutureMudCraftTransformer
 			["26"] = "Uruk",
 			["27"] = "Human",
 			["28"] = "Human",
-		};
-
-	private static readonly IReadOnlyDictionary<string, NormalisedClanRule> CanonicalClanRules =
-		new Dictionary<string, NormalisedClanRule>(StringComparer.OrdinalIgnoreCase)
-		{
-			["mordor_char"] = new("mordor_char", "Minas Morgul", ["mm_denizens"]),
-			["mm_denizens"] = new("mordor_char", "Minas Morgul", ["mm_denizens"]),
-			["malred"] = new("malred", "Malred Family", ["housemalred"]),
-			["housemalred"] = new("malred", "Malred Family", ["housemalred"]),
-			["rogues"] = new("rogues", "Rogues' Fellowship", ["rouges"]),
-			["rouges"] = new("rogues", "Rogues' Fellowship", ["rouges"]),
-			["hawk_dove_2"] = new("hawk_dove_2", "Hawk and Dove", ["hawk_and_dove"]),
-			["hawk_and_dove"] = new("hawk_dove_2", "Hawk and Dove", ["hawk_and_dove"]),
-			["seekers"] = new("seekers", "Seekers", Array.Empty<string>()),
-			["shadow-cult"] = new("shadow-cult", "Shadow Cult", Array.Empty<string>()),
-			["tirithguard"] = new("tirithguard", "Minas Tirith Guard", Array.Empty<string>()),
-			["eradan_battalion"] = new("eradan_battalion", "Eradan Battalion", Array.Empty<string>()),
 		};
 
 	private static readonly IReadOnlyDictionary<string, string[]> SeasonMonthAliases =
@@ -1203,9 +1184,7 @@ public sealed class FutureMudCraftTransformer
 
 	private static ConvertedCraftClanRequirement NormaliseClanRequirement(RpiCraftClanRequirement requirement)
 	{
-		var rule = CanonicalClanRules.TryGetValue(requirement.ClanAlias, out var canonical)
-			? canonical
-			: new NormalisedClanRule(requirement.ClanAlias, RpiClanRankSlots.TitleCaseAlias(requirement.ClanAlias), Array.Empty<string>());
+		var rule = RpiClanAliasResolver.ResolveCanonicalRule(requirement.ClanAlias);
 		return new ConvertedCraftClanRequirement(
 			rule.CanonicalAlias,
 			rule.FullNameOverride ?? RpiClanRankSlots.TitleCaseAlias(rule.CanonicalAlias),

--- a/RPI Engine Worldfile Converter/FutureMudItemImporter.cs
+++ b/RPI Engine Worldfile Converter/FutureMudItemImporter.cs
@@ -166,7 +166,8 @@ public sealed class FutureMudBaselineCatalog
 
 	private static Dictionary<string, FutureMudClanReference> LoadClansByAlias(FuturemudDatabaseContext context)
 	{
-		return context.Clans
+		var result = new Dictionary<string, FutureMudClanReference>(StringComparer.OrdinalIgnoreCase);
+		var clans = context.Clans
 			.Include(x => x.Ranks)
 				.ThenInclude(x => x.RanksTitles)
 			.Include(x => x.Ranks)
@@ -174,21 +175,41 @@ public sealed class FutureMudBaselineCatalog
 			.ToList()
 			.Where(x => !string.IsNullOrWhiteSpace(x.Alias))
 			.GroupBy(x => x.Alias, StringComparer.OrdinalIgnoreCase)
-			.Select(x => x.OrderBy(y => y.Id).First())
-			.ToDictionary(
-				x => x.Alias,
-				x => new FutureMudClanReference(
-					x.Id,
-					x.Alias,
-					x.Ranks
-						.SelectMany(rank =>
-							rank.RanksTitles.Select(title => (name: title.Title, rank.Id))
-								.Concat(rank.RanksAbbreviations.Select(abbreviation => (name: abbreviation.Abbreviation, rank.Id)))
-								.Append((name: rank.Name, Id: rank.Id)))
-						.Where(y => !string.IsNullOrWhiteSpace(y.name))
-						.GroupBy(y => y.name, StringComparer.OrdinalIgnoreCase)
-						.ToDictionary(y => y.Key, y => y.First().Id, StringComparer.OrdinalIgnoreCase)),
-				StringComparer.OrdinalIgnoreCase);
+			.Select(x => x.OrderBy(y => y.Id).First());
+
+		foreach (var clan in clans)
+		{
+			var reference = new FutureMudClanReference(
+				clan.Id,
+				clan.Alias,
+				clan.Ranks
+					.SelectMany(rank =>
+						rank.RanksTitles.Select(title => (name: title.Title, rank.Id))
+							.Concat(rank.RanksAbbreviations.Select(abbreviation => (name: abbreviation.Abbreviation, rank.Id)))
+							.Append((name: rank.Name, Id: rank.Id)))
+					.Where(y => !string.IsNullOrWhiteSpace(y.name))
+					.GroupBy(y => y.name, StringComparer.OrdinalIgnoreCase)
+					.ToDictionary(y => y.Key, y => y.First().Id, StringComparer.OrdinalIgnoreCase));
+
+			TryRegisterClanReference(result, clan.Alias, reference);
+			TryRegisterClanReference(result, RpiClanAliasResolver.CollapseAlias(clan.Alias), reference);
+			TryRegisterClanReference(result, RpiClanAliasResolver.ResolveCanonicalRule(clan.Alias).CanonicalAlias, reference);
+		}
+
+		return result;
+	}
+
+	private static void TryRegisterClanReference(
+		IDictionary<string, FutureMudClanReference> clans,
+		string alias,
+		FutureMudClanReference reference)
+	{
+		if (string.IsNullOrWhiteSpace(alias) || clans.ContainsKey(alias))
+		{
+			return;
+		}
+
+		clans[alias] = reference;
 	}
 
 	private static Dictionary<string, long> ToUniqueIdDictionary<T>(

--- a/RPI Engine Worldfile Converter/FutureMudNpcTransformer.cs
+++ b/RPI Engine Worldfile Converter/FutureMudNpcTransformer.cs
@@ -208,7 +208,12 @@ public sealed class FutureMudNpcTransformer
 			Shop = npc.Shop,
 			Venom = npc.Venom,
 			Morph = npc.Morph,
-			ClanMemberships = npc.ClanMemberships,
+			ClanMemberships = npc.ClanMemberships
+				.Select(x => new RpiNpcClanMembershipRecord(
+					x.RankName,
+					RpiClanAliasResolver.ResolveCanonicalRule(x.ClanAlias).CanonicalAlias))
+				.DistinctBy(x => $"{x.ClanAlias}\n{x.RankName}", StringComparer.OrdinalIgnoreCase)
+				.ToList(),
 		};
 	}
 

--- a/RPI Engine Worldfile Converter/RpiClanAliasResolver.cs
+++ b/RPI Engine Worldfile Converter/RpiClanAliasResolver.cs
@@ -1,0 +1,134 @@
+#nullable enable
+
+using MudSharp.Framework;
+
+namespace RPI_Engine_Worldfile_Converter;
+
+public sealed record RpiCanonicalClanRule(
+	string CanonicalAlias,
+	string? FullNameOverride,
+	IReadOnlyList<string> LegacyAliases,
+	bool ImportFromUnrankedReferences = false);
+
+public static class RpiClanAliasResolver
+{
+	private static readonly IReadOnlyList<RpiCanonicalClanRule> CanonicalRuleList =
+	[
+		new("mordor_char", "Minas Morgul", ["mm_denizens"]),
+		new("malred", "Malred Family", ["housemalred"]),
+		new("rogues", "Rogues' Fellowship", ["rouges"]),
+		new("hawk_dove_2", "Hawk and Dove", ["hawk_and_dove"]),
+		new("seekers", "Seekers", Array.Empty<string>()),
+		new("shadow-cult", "Shadow Cult", Array.Empty<string>()),
+		new("tirithguard", "Minas Tirith Guard", Array.Empty<string>()),
+		new("eradan_battalion", "Eradan Battalion", ["eradan_battalions"]),
+		new("ithilien_battalion", "Ithilien Battalion", ["ithilien_battalions"]),
+
+		new("com_priests", "Cult of Morgoth Priests", ["com-priests"], true),
+		new("tecouncil", "Tur Edendor Council", Array.Empty<string>(), true),
+		new("metalsmiths_fellowship", "Metalsmiths Fellowship", ["metalsmithsfellow"], true),
+		new("mm_slaves", "Minas Morgul Slaves", Array.Empty<string>(), true),
+		new("mt_ratcatchers", "Minas Tirith Ratcatchers", Array.Empty<string>(), true),
+		new("osgi_ratcatchers", "Osgiliath Rat Catchers", Array.Empty<string>(), true),
+
+		new("witchkings_horde", "Witchking's Horde",
+			["witchking_horde", "witchkinghorde", "witchkings_horde", "withchking_horde", "witchking_horse"]),
+		new("pel_pelennor", "Pel Pelennor", ["pel_pelenor"]),
+		new("osgi_citizens", "Osgi Citizens", ["osgi_citizen", "osgi_citizensmember", "osgi_citzens"]),
+
+		new("abominations", "Abominations", ["abomination"]),
+		new("carnivores", "Carnivores", ["carnivore"]),
+		new("cobra_enforcers", "Cobra Enforcers", ["cobra_enforcer"]),
+		new("fahad_slummers", "Fahad Slummers", ["fahad_slummer"]),
+		new("harlequins", "Harlequins", ["harlequin"]),
+		new("mineworkers", "Mineworkers", ["mineworker"]),
+		new("mordor_slavers", "Mordor Slavers", ["mordor_slaver"]),
+		new("moria_hordes", "Moria Hordes", ["moria_horde"]),
+		new("outpost_guilds", "Outpost Guilds", ["outpost_guild"]),
+		new("scorpions", "Scorpions", ["scorpion"]),
+		new("slavers", "Slavers", ["slaver"]),
+		new("watchers", "Watchers", ["watcher"]),
+	];
+
+	private static readonly IReadOnlyDictionary<string, RpiCanonicalClanRule> RulesByAlias = BuildRulesByAlias();
+
+	private static readonly IReadOnlyDictionary<string, RpiCanonicalClanRule> RulesByCollapsedAlias =
+		BuildRulesByCollapsedAlias();
+
+	public static string CollapseAlias(string alias)
+	{
+		return alias.Trim().ToLowerInvariant().CollapseString();
+	}
+
+	public static RpiCanonicalClanRule ResolveCanonicalRule(string alias)
+	{
+		if (string.IsNullOrWhiteSpace(alias))
+		{
+			return new RpiCanonicalClanRule(string.Empty, null, Array.Empty<string>());
+		}
+
+		var trimmed = alias.Trim();
+		if (RulesByAlias.TryGetValue(trimmed, out var rule))
+		{
+			return rule;
+		}
+
+		var collapsed = CollapseAlias(trimmed);
+		if (RulesByCollapsedAlias.TryGetValue(collapsed, out rule))
+		{
+			return rule;
+		}
+
+		return new RpiCanonicalClanRule(collapsed, null, Array.Empty<string>());
+	}
+
+	public static bool AreAliasesEquivalent(string lhs, string rhs)
+	{
+		return ResolveCanonicalRule(lhs).CanonicalAlias.Equals(
+			ResolveCanonicalRule(rhs).CanonicalAlias,
+			StringComparison.OrdinalIgnoreCase);
+	}
+
+	private static IReadOnlyDictionary<string, RpiCanonicalClanRule> BuildRulesByAlias()
+	{
+		var result = new Dictionary<string, RpiCanonicalClanRule>(StringComparer.OrdinalIgnoreCase);
+		foreach (var rule in CanonicalRuleList)
+		{
+			RegisterRuleAlias(result, rule.CanonicalAlias, rule);
+			foreach (var alias in rule.LegacyAliases)
+			{
+				RegisterRuleAlias(result, alias, rule);
+			}
+		}
+
+		return result;
+	}
+
+	private static IReadOnlyDictionary<string, RpiCanonicalClanRule> BuildRulesByCollapsedAlias()
+	{
+		var result = new Dictionary<string, RpiCanonicalClanRule>(StringComparer.OrdinalIgnoreCase);
+		foreach (var rule in CanonicalRuleList)
+		{
+			RegisterRuleAlias(result, CollapseAlias(rule.CanonicalAlias), rule);
+			foreach (var alias in rule.LegacyAliases)
+			{
+				RegisterRuleAlias(result, CollapseAlias(alias), rule);
+			}
+		}
+
+		return result;
+	}
+
+	private static void RegisterRuleAlias(
+		IDictionary<string, RpiCanonicalClanRule> rules,
+		string alias,
+		RpiCanonicalClanRule rule)
+	{
+		if (string.IsNullOrWhiteSpace(alias) || rules.ContainsKey(alias))
+		{
+			return;
+		}
+
+		rules[alias] = rule;
+	}
+}

--- a/RPI Engine Worldfile Converter/RpiClanConversionMapping.md
+++ b/RPI Engine Worldfile Converter/RpiClanConversionMapping.md
@@ -27,7 +27,11 @@ It deliberately ignores:
 
 ## Canonical Alias Rules
 
-The importer prefers the in-world alias used by code and region data as the canonical FutureMUD alias. Legacy aliases are preserved for provenance and idempotency checks.
+The importer collapses aliases using the FutureMUD-style `CollapseString` rule before deciding whether two aliases represent the same clan. Spaces, underscores, and dashes therefore do not create separate imported clans.
+
+The importer still preserves raw legacy aliases for provenance and idempotency checks. If there is no explicit rule, the canonical FutureMUD alias is the collapsed lowercase alias.
+
+The same resolver is used by craft, item-board, and NPC clan references so later import phases bind to the canonical clan IDs produced by `apply-clans`.
 
 Canonical mappings:
 
@@ -39,6 +43,20 @@ Canonical mappings:
   - Legacy alias: `rouges`
 - `hawk_dove_2` => `Hawk and Dove`
   - Legacy alias: `hawk_and_dove`
+- `com_priests` => `Cult of Morgoth Priests`
+  - Legacy alias: `com-priests`
+- `tecouncil` => `Tur Edendor Council`
+- `metalsmiths_fellowship` => `Metalsmiths Fellowship`
+  - Legacy alias: `metalsmithsfellow`
+- `mm_slaves` => `Minas Morgul Slaves`
+- `mt_ratcatchers` => `Minas Tirith Ratcatchers`
+- `osgi_ratcatchers` => `Osgiliath Rat Catchers`
+- `witchkings_horde` => `Witchking's Horde`
+  - Legacy aliases: `witchking_horde`, `witchkinghorde`, `withchking_horde`, `witchking_horse`
+- `pel_pelennor` => `Pel Pelennor`
+  - Legacy alias: `pel_pelenor`
+- `osgi_citizens` => `Osgi Citizens`
+  - Legacy aliases: `osgi_citizen`, `osgi_citizensmember`, `osgi_citzens`
 
 Alias-only clans imported even without header-table rows:
 
@@ -56,7 +74,7 @@ Examples:
 
 These inferred clans:
 
-- use the observed alias as the canonical alias unless an explicit normalization rule applies
+- use the collapsed observed alias as the canonical alias unless an explicit normalization rule applies
 - use a title-cased alias as the full name unless a better authoritative name is available
 - preserve a source warning noting that the clan was synthesized from structured worldfile references
 


### PR DESCRIPTION
## Summary
- Centralised clan alias normalization into a shared resolver and expanded it with punctuation-collapsing and typo-repair rules.
- Updated clan, craft, item, board, and NPC conversion paths to resolve aliases through the new canonical mapping instead of ad hoc string handling.
- Improved importer/catalog loading so alias collisions are handled consistently, including collapsed variants and legacy aliases.
- Added and updated converter tests to cover punctuation variants, repaired builder typos, and clan reference/import behavior.

## Testing
- Updated unit coverage for clan and craft conversion scenarios.
- Not run (not requested).