### PR TITLE
Ship Engine V2 magic and psionics runtime slice

### DIFF
--- a/Design Documents/Armageddon_Magic_Psionics_Gap_Report.md
+++ b/Design Documents/Armageddon_Magic_Psionics_Gap_Report.md
@@ -25,6 +25,7 @@ and the current runtime implementations under `MudSharpCore/Magic`.
 - Status update as of 2026-04-21: the Phase 1 implementation slice from this report has now shipped. `teleport` accepts `room` / `rooms` triggers, the reusable Phase 1 statuses are implemented as standalone spell-effect templates with matching removals, `MagicResourceDeltaEffect`, `SpellArmourEffect`, and `roomflag` / `removeroomflag` are live, and the underlying runtime hooks for additive perception grants, selective poison or disease cleanup, and early room flags are in place.
 - Status update as of 2026-05-01: the plane/corporeality and multiple-body-form work changes the blocker picture again. `IPlane`, `PlanarPresenceDefinition`, `planarstate`, `planeshift`, `removeplanarstate`, planar FutureProg functions, the `corporeality` admin command, and the `transformform` spell effect are live. Simple ethereal states, noncorporeal manifestation, single-active-body transformation, and straightforward "move this target to another plane" spells are now buildable with first-class primitives. Simultaneous bodies, remote vessels, possessed corpses, descriptor handoff, and persistent portal topology remain blocked.
 - Status update as of 2026-05-01 Engine V1: generic magic tags, FutureProg tag queries, first-class item and corpse magic effects, transient paired magical portals, safe command-forcing, and caster-scoped subjective description overrides are now implemented as engine primitives. This moves marks, rune anchors, basic portals, item damage/destruction/enchantment, corpse preservation/consumption/spawn, and the safest coercion/subjective-description cases out of the blocked bucket. Persistent portal topology, general dispel, true possession/projection, passive psionic traffic, and identity-concealment systems remain open.
+- Status update as of 2026-05-02 Engine V2: `dispelmagic`, `mindconceal`, transient portal inspection, item/object portal anchors, and first-class item enchantment hooks for projectile payloads, crafting tools, power/fuel modifiers, and item event progs are now live. Passive psionic traffic can use the existing `telepathy` flow with `mindconceal` identity policy. Persistent gates still use saved effects rather than a dedicated gate table, and true simultaneous-body possession/projection remains deferred.
 
 > Note: the top-line parity counts and family summary in this report predate the Phase 1, Phase 2, plane/corporeality, and body-form implementation work. If exact current counts are needed, rerun the family-by-family classification pass. The implementation-plan and primitive-gap sections below reflect the current runtime state.
 
@@ -42,8 +43,8 @@ Key takeaways:
 - The current system is already strong at direct damage, healing, stamina/need adjustment, item or liquid conjuration, NPC summoning, invisibility, telepathy, self-only magical armour, planar state shifts, and single-active-body transformation.
 - Phase 2 now closes three medium-difficulty primitive gaps: local exit targeting, prog-resolved summon-style remote targeting, and reusable room or personal wards with shared spell and power interception.
 - The plane and body-form work moves several old blockers into the buildable bucket: `Ethereal`, `Detect Ethereal`, `Dispel Ethereal`, simple `Planeshift`, ghostly manifestation, and polymorph-style transformations can now use first-class effects rather than bespoke tags.
-- The biggest remaining parity blockers are persistent portal topology, general dispel/effect shortening, passive psionic traffic and identity concealment, richer illusion stacking, and true "dual body" mechanics like possession or shadow projection.
-- Psionics are only partially covered today. The current mind-link stack handles contact, barriers, mind-looking, audits, expulsion, sense, messaging, and direct mental attacks, but most coercion, concealment, remote eavesdropping, and passive-traffic powers still need new runtime support.
+- The biggest remaining parity blockers are durable portal topology beyond saved effects, richer illusion stacking, advanced coercion policy, and true "dual body" mechanics like possession or shadow projection.
+- Psionics are only partially covered today. The current mind-link stack handles contact, barriers, mind-looking, audits, expulsion, sense, messaging, direct mental attacks, passive thought/feeling traffic, and identity concealment, but advanced coercion, trace consequences, and projection-style powers still need new runtime support.
 
 ## Family Summary
 
@@ -55,9 +56,9 @@ Key takeaways:
 | Wind | 5 | 11 | 7 | Flying, long-range forced movement, detection or cleanse effects |
 | Shadow | 3 | 5 | 9 | Ethereal state, anti-curse cleanses, fear, projection |
 | Lightning | 5 | 7 | 3 | Sleep immunity, paralysis, tracked footprint effects |
-| Void | 6 | 5 | 17 | Persistent portals, possession, advanced corpse/vessel semantics, resource drain |
+| Void | 6 | 5 | 17 | Durable portal networks, possession, advanced corpse/vessel semantics, resource drain |
 | Unspecified / incomplete magic | 1 | 0 | 3 | Source material is incomplete |
-| Psionics | 10 | 8 | 19 | Concealment, passive traffic, identity masking, advanced coercion policy |
+| Psionics | 10 | 8 | 19 | Advanced coercion policy, trace consequences, projection/remote-presence semantics |
 
 ## Where FutureMUD Is Already Strong
 
@@ -75,8 +76,10 @@ The current system already has good coverage for:
 - planar state changes through `planarstate`, `planeshift`, `removeplanarstate`, planar merits, planar drugs, and planar FutureProg helpers
 - spell-driven alternate body forms through `transformform`, including stable form keys, first-creation race or description defaults, trauma handling, transformation echoes, and forced-transformation priority
 - information-bearing spell metadata through `magictag` / `removemagictag` and FutureProg helpers `hasmagictag`, `magictagvalue`, `magictagvalues`, and `magictags`
-- item/corpse magic through `itemdamage`, `destroyitem`, `itemenchant`, `corpsemark`, `corpsepreserve`, `corpseconsume`, and `corpsespawn`
-- transient paired magical portals through `portal`, backed by effect-owned exit-manager registration rather than permanent database exits
+- item/corpse magic through `itemdamage`, `destroyitem`, `itemenchant`, `corpsemark`, `corpsepreserve`, `corpseconsume`, and `corpsespawn`, including projectile, craft-tool, powered-item, fuel-use, and item event hooks for enchantments
+- general spell cleanup through `dispelmagic`, including remove or shorten modes and criteria for caster policy, spell, school/subschool, magic tags, and approved effect/interface keys
+- transient paired magical portals through `portal`, backed by effect-owned exit-manager registration rather than permanent database exits, with active inspection and caster-owned room or item/object anchors
+- psionic identity concealment and passive thought/feeling traffic through `mindconceal` and the existing `telepathy` flow
 - Coercion V1 through `forcecommand`, `subjectivedesc`, and `subjectivesdesc`
 
 ## Current Reclassification From Planes And Body Forms
@@ -86,12 +89,12 @@ The old blocker list bundled "ethereal", "projection", "possession", "planeshift
 | Old blocker theme | Current path forward | Still blocked |
 | --- | --- | --- |
 | Ethereal or noncorporeal state | Use `planarstate` / `planeshift` on characters, items, or other perceivables. Plane data handles room presentation, remote observation tags, perception, interaction checks, noncorporeal physiology, inventory propagation, and closed-door bypass where configured. | Plane-specific travel graphs, custom transition trauma, and any spell that requires a separate acting shell rather than changing the target's own planar presence. |
-| Detect or dispel ethereal | Use `detectethereal` / `removedetectethereal` for perception grants and `removeplanarstate` for spell-owned or saved planar overlays. | A general dispel engine that shortens arbitrary effects by strength, school, or contest result. |
-| Planeshift | Simple "target moves to configured plane/state" is now first-class with `planeshift`. | Multi-step planar travel with unsafe destinations, persistent world topology, or portal networks that should survive beyond an effect duration. |
+| Detect or dispel ethereal | Use `detectethereal` / `removedetectethereal` for perception grants, `removeplanarstate` for spell-owned or saved planar overlays, or `dispelmagic effect planarstate` when the spell should share general anti-magic rules. | Strength-contested dispel math beyond the existing spell/resist/ward flow. |
+| Planeshift | Simple "target moves to configured plane/state" is now first-class with `planeshift`. | Multi-step planar travel with unsafe destinations or durable portal networks that should survive beyond an effect duration. |
 | Shadowwalk-style movement | If the intended behaviour is "enter a shadow/astral/ethereal plane and move normally", use plane definitions plus `planeshift`. | If the intended behaviour is remote projection, leaving a body behind, or moving a second body independently, it remains blocked. |
 | Polymorph, animal form, statue-like form, or spirit form | Use `transformform` for single-active-body transformation, with `Additional Body Form` merits for intrinsic or racial forms. | Turning a character into a true item, making two bodies act at once, using a corpse as the exact vessel, or continuously syncing spell XML to later form metadata. |
 | Possession, disembodying, and send-shadow projection | Use `planeshift` or `transformform` only for simplified content where the original character becomes the new form/state. | True possession and projection still need simultaneous presence, command routing, source-body vulnerability, disconnect handling, staff visibility, and death semantics. |
-| Marks, runes, anchors, and hidden magical facts | Use `magictag` / `removemagictag` plus the magic-tag FutureProg helpers for information-bearing metadata. The `portal` effect can consume caster-owned room anchors. | Behavioural effects should still get first-class support when the tag would be pretending to be combat, movement, persistent portal topology, item damage, resource changes, or perception. |
+| Marks, runes, anchors, and hidden magical facts | Use `magictag` / `removemagictag` plus the magic-tag FutureProg helpers for information-bearing metadata. The `portal` effect can consume caster-owned room or item/object anchors, and active portal/anchor state is inspectable with `magic portals` and `magic anchors`. | Behavioural effects should still get first-class support when the tag would be pretending to be combat, movement, durable portal topology, item damage, resource changes, or perception. |
 
 ## Main Gaps By Primitive
 
@@ -124,7 +127,7 @@ The remaining gap inside this primitive family is now the unimplemented edge set
 - `detect poison`
 - `insomnia`
 - cure blindness
-- general dispel / effect shortening
+- strength-contested dispel math beyond the current `dispelmagic` criteria model
 
 ### 2. Magic and psionic resource delta effects
 
@@ -222,14 +225,14 @@ Remaining limitation:
 
 ### 6. Item and corpse enchantment, magic tags, and anchors
 
-Status: implemented for Engine V1 metadata, destructive item magic, basic item enchantment, and corpse lifecycle helpers.
+Status: implemented for Engine V2 metadata, destructive item magic, first-class item enchantment hooks, portal anchors, and corpse lifecycle helpers.
 
 FutureMUD now has a generic information-bearing magic-tag effect. It is explicitly metadata, not a universal behaviour substitute:
 
 - `magictag` / `removemagictag` attach spell-owned key/value metadata to characters, items, rooms, and other perceivables.
 - The active effect exposes `Tag`, `Value`, `Caster`, and `Spell` through `IMagicTagEffect`.
 - FutureProg helpers `hasmagictag`, `magictagvalue`, `magictagvalues`, and `magictags` let progs query anchors, rune keys, ritual state, signatures, and bespoke conditional effects.
-- `portal` can use caster-owned magic-tag room anchors as one destination mode.
+- `portal` can use caster-owned magic-tag room anchors or item/object anchors as destination modes.
 
 This is appropriate for:
 
@@ -244,7 +247,7 @@ First-class item and corpse effects now cover the common runtime behaviours that
 
 - `itemdamage` applies normal item wound/health damage.
 - `destroyitem` deletes item targets with purge-warning safeguards.
-- `itemenchant` supplies visible aura text, optional glow, conditional-prog gating, and weapon/armour combat hooks through `IMagicWeaponEnhancementEffect` and `IMagicArmourEnhancementEffect`.
+- `itemenchant` supplies visible aura text, optional glow, conditional-prog gating, weapon/armour combat hooks, projectile payload bonuses, craft-tool bonuses, power/fuel modifiers, and optional item event progs through first-class interfaces.
 - `corpsemark` marks corpse items with magic metadata.
 - `corpsepreserve` pauses corpse decay through the corpse heartbeat.
 - `corpseconsume` cleanly deletes corpse items.
@@ -264,9 +267,8 @@ This now unlocks or materially improves:
 
 Remaining limitations:
 
-- `itemenchant` has first-class weapon/armour hooks, but more specialised hooks may still be needed for projectile payload mutation, tool/crafting bonuses, fuel/power interactions, and item-specific scripting.
-- General dispel/removal by school, strength, caster, or effect family is still not implemented.
-- Persistent runes, standing portals, and world-topology edits should not be modelled as only temporary magic tags.
+- `dispelmagic` matches by authored criteria and uses the normal spell/ward/resist flow; there is not yet a separate strength-contested dispel formula layer.
+- Persistent runes, standing portals, and durable world-topology edits should not be modelled as only temporary magic tags. Engine V2 keeps gates/runes as saved effects and transient exits rather than adding a gate table or permanent database exits.
 
 ### 7. Body transformation, dual-body, possession, and projection mechanics
 
@@ -363,7 +365,7 @@ These are the next-best return once the basic statuses exist.
    - This is now the cleanest path for `Summon` and the room-targeted portions of richer gate logic, but not yet full swap or portal-topology behavior.
 
 3. Add first-class item enchantment and item damage effects.
-   - Completed in Engine V1 with `itemdamage`, `destroyitem`, `itemenchant`, generic `magictag`, and corpse-specific helpers.
+   - Completed through Engine V2 with `itemdamage`, `destroyitem`, expanded `itemenchant`, generic `magictag`, and corpse-specific helpers.
    - This unlocks or materially improves `Glyph`, `Mark`, `Vampiric Blade`, `Rot Items`, `Shatter`, and a cleaner path for corpse magic.
 
 4. Add room wards and personal ward effects with interception hooks.
@@ -373,7 +375,7 @@ These are the next-best return once the basic statuses exist.
 5. Add a command-safe psionic coercion framework.
    - Completed for Coercion V1 with `forcecommand`.
    - The current implementation executes through the target's own `ExecuteCommand`, respects `IIgnoreForceEffect`, blocks staff/editor/account-destructive roots, and emits wiz-only audit output.
-   - Deeper consent/refusal semantics, emotion injection, and psionic identity concealment remain future work.
+   - Deeper consent/refusal semantics, emotion injection, trace consequences, and non-command coercion remain future work.
 
 ### Phase 3: Tricky Design Work
 
@@ -395,11 +397,10 @@ These are the parity items with the most engine-level uncertainty.
    - `Travel Gate`
    - `Portal`
    - `Create Rune`
-   - Status: simple room-target teleport, simple planar shifting, caster-owned tag anchors, and transient effect-owned paired exits are live.
+   - Status: simple room-target teleport, simple planar shifting, caster-owned room or item/object tag anchors, transient effect-owned paired exits, and active portal/anchor inspection are live.
    - Remaining work:
-     - persistent paired gates, standing rune networks, and portal objects
-     - item/object anchors rather than room-only magic-tag anchors
-     - richer destination safety models, world-topology persistence, and builder-facing inspection commands
+     - persistent paired gates, standing rune networks, and portal objects beyond saved effects
+     - richer destination safety models and world-topology persistence
 
 3. Subjective illusions and perception overrides.
    - `Masquerade`
@@ -426,34 +427,47 @@ These are the parity items with the most engine-level uncertainty.
    - `Cathexis`
    - These are only partly magic-system problems. They also require a clean model for "relationship to the land", elemental planes, and any clan- or tribe-keyed psionic identity mechanics.
 
-## Recommended Next Shipping Slice: Engine V2
+## Engine V2 Shipped Runtime Slice
 
-Engine V1 has shipped the metadata, item/corpse, transient portal, and safest coercion/perception primitives. The next slice should turn those primitives into deeper parity without jumping straight to simultaneous-body possession.
+Engine V2 has shipped the deeper parity layer without jumping into simultaneous-body possession.
 
-1. Add a general dispel and effect-shortening framework.
-   - Support removal or duration reduction by spell, school, child school, caster, tag key, and effect interface.
-   - Reuse it for `Dispel Magick`, `Dispel Ethereal`, rune cleanup, enchantment stripping, and anti-magic maintenance spells.
-   - Keep policy explicit for hostile dispels versus owner/caster cleanup.
+1. General dispel and effect shortening.
+   - `dispelmagic` can remove or shorten matching spell-parent effects.
+   - Matching supports specific spell, school, child school, caster policy, magic tag key/value, and approved effect/interface keys.
+   - The default is caster-owned cleanup. Hostile dispels must opt in and then use the ordinary spell targeting, ward, and resistance flow.
 
-2. Deepen portals from transient spell exits to authored topology.
-   - Add builder-visible inspection for active transient portals and magic-tag anchors.
-   - Add persistent standing-gate/rune support only after deciding whether the durable object is a room effect, item, exit overlay, or dedicated gate definition.
-   - Extend anchors from room-only metadata to item/object anchors where the setting needs portable marks.
+2. Saved-effect portal topology.
+   - `portal` still creates effect-owned transient exits, not permanent database exits.
+   - Active portals are inspectable through `magic portals`, backed by `IExitManager.TransientExits` and `IMagicPortalExit`.
+   - Active anchors are inspectable through `magic anchors [tag]`.
+   - Anchor resolution now supports caster-owned room tags and caster-owned item/object tags, using the tagged item's current location.
 
-3. Broaden item enchantment hooks where real content needs them.
-   - Add projectile payload mutation, ranged damage bonuses, tool/crafting bonuses, power/fuel interactions, and item-specific scripted hooks as first-class interfaces when concrete spells demand them.
-   - Avoid routing those behaviours through generic tags except as supporting metadata.
+3. Broader item enchantment hooks.
+   - `itemenchant` now exposes first-class projectile/ranged payload bonuses, craft-tool bonuses, power/fuel modifiers, and optional item event progs.
+   - These behaviours should not be authored as generic magic tags except where a tag is only supporting metadata.
 
-4. Package plane/form spell recipes and tests.
-   - Document builder recipes for `Ethereal`, `Dispel Ethereal`, `Planeshift`, shadow/astral walking, and polymorph using `planarstate`, `removeplanarstate`, `planeshift`, and `transformform`.
-   - Keep examples as engine documentation/tests unless stock magic seeding is explicitly desired.
+4. Plane/form recipes and regression coverage.
+   - `Ethereal`, `Dispel Ethereal`, `Planeshift`, shadow/astral walking, and polymorph-style configurations are covered by builder-loadable recipe tests.
+   - The intended primitives are `planarstate`, `removeplanarstate`, `planeshift`, `dispelmagic`, and `transformform`.
 
-5. Design psionic identity, concealment, and passive traffic.
-   - Extend beyond `forcecommand` into `Conceal`, `Thoughtsense`, `Immersion`, trace masking, passive eavesdropping, and contact identity policy.
-   - These should be first-class mind-link/telepathy behaviours, not magic tags.
+5. Psionic identity and passive traffic.
+   - `mindconceal` supplies the sustained identity-concealment effect and audit difficulty modifier.
+   - `connectmind`, `mindsay`, `mindbroadcast`, `mindaudit`, `mindexpel`, and passive `think`/`feel` telepathy now consult the shared concealment contract.
+   - Thoughtsense/Immersion-style passive traffic should use the existing `telepathy` `thinks` / `feels` / `thinkemote` flow.
 
-6. Defer true possession and projection until the simultaneous-body model is designed.
-   - The existing form system deliberately supports one active body. Possession, send-shadow projection, and body-left-behind disembodiment require command routing, remote presence, body vulnerability, inventory rules, death rules, reconnect behaviour, and admin observability.
+6. Still deferred.
+   - True possession, send-shadow projection, and body-left-behind disembodiment remain out of scope until the simultaneous-body model is designed.
+   - The existing form system deliberately supports one active body. Possession/projection still needs command routing, remote presence, body vulnerability, inventory rules, death rules, reconnect behavior, and admin observability.
+
+## Recommended Next Shipping Slice After Engine V2
+
+The next work should focus on the pieces Engine V2 deliberately left outside the slice:
+
+- durable portal/rune topology if saved effects and transient exits are not enough for standing gate networks
+- strength-contested dispel math if author criteria plus normal spell resistance is not enough
+- richer illusion stacking and perception policy
+- advanced psionic coercion and trace consequences
+- the simultaneous-body possession/projection model
 
 ## Appendix: Classification By Family
 

--- a/Design Documents/Magic_System_Implemented_Types.md
+++ b/Design Documents/Magic_System_Implemented_Types.md
@@ -48,6 +48,7 @@ It is intended for:
 | `mindaudit` | `MindAuditPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/MindAuditPower.cs` via `MagicPowerFactory` | Yes | Audits or inspects a mind |
 | `mindbarrier` | `MindBarrierPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/MindBarrierPower.cs` via `MagicPowerFactory` | Yes | Creates a mental barrier |
 | `mindbroadcast` | `MindBroadcastPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/MindBroadcastPower.cs` via `MagicPowerFactory` | Yes | Broadcasts mind-to-mind communication |
+| `mindconceal` | `MindConcealPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/MindConcealPower.cs` via `MagicPowerFactory` | Yes | Sustains a concealed mind-contact identity and audit difficulty modifier |
 | `mindexpel` | `MindExpelPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/MindExpelPower.cs` via `MagicPowerFactory` | Yes | Expels a connection or presence |
 | `mindlook` | `MindLookPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/MindLookPower.cs` via `MagicPowerFactory` | Yes | Observes through mind mechanics |
 | `mindsay` | `MindSayPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/MindSayPower.cs` via `MagicPowerFactory` | Yes | Sends directed mind speech |
@@ -97,6 +98,8 @@ It is intended for:
 | `detectinvisible` | `DetectInvisibleEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/StandaloneStatusSpellEffects.cs` via `SpellEffectFactory` | Yes | Grants magical vision that can pierce ordinary invisibility |
 | `detectmagick` | `DetectMagickEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/StandaloneStatusSpellEffects.cs` via `SpellEffectFactory` | Yes | Grants magical sensing and exposes detectable magical auras in normal descriptions |
 | `disease` | `DiseaseEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/StandaloneStatusSpellEffects.Configured.cs` via `SpellEffectFactory` | Yes | Applies a configurable spell-owned systemic infection payload |
+| `dispelmagic` | `DispelMagicEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/DispelMagicEffect.cs` via `SpellEffectFactory` | Yes | Removes or shortens matching spell-parent effects by caster policy, spell, school/subschool, tag, or approved effect key |
+| `destroyitem` | `DestroyItemEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs` via `SpellEffectFactory` | Yes | Deletes item targets with purge-warning safeguards |
 | `executeprog` | `ExecuteProgEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/ExecuteProgEffect.cs` via `SpellEffectFactory` | Yes | Executes a supporting prog |
 | `exitbarrier` | `ExitBarrierEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/ExitBarrierEffect.cs` via `SpellEffectFactory` | Yes | Applies a persistent magical barrier to a targeted shared `IExit` so crossing that exit can be blocked |
 | `forcedexitmovement` | `ForcedExitMovementEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/ForcedExitMovementEffect.cs` via `SpellEffectFactory` | Yes | Forces a targeted character through the trigger-supplied `exit` when movement and crossing checks allow it |
@@ -107,6 +110,9 @@ It is intended for:
 | `healingrate` | `HealingRateSpellEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/HealingRateSpellEffect.cs` via `SpellEffectFactory` | Yes | Alters healing rate |
 | `infravision` | `InfravisionEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/StandaloneStatusSpellEffects.cs` via `SpellEffectFactory` | Yes | Grants infrared vision and a darkness difficulty floor |
 | `invisibility` | `InvisibilityEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/InvisibilityEffect.cs` via `SpellEffectFactory` | Yes | Applies invisibility |
+| `itemdamage` | `ItemDamageEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs` via `SpellEffectFactory` | Yes | Applies ordinary item damage using configured damage, pain, stun, and damage-type formulas |
+| `itemenchant` | `ItemEnchantEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs` via `SpellEffectFactory` | Yes | Adds item aura text, glow, weapon/armour hooks, projectile bonuses, craft-tool bonuses, power/fuel modifiers, and optional item event progs |
+| `magictag` | `MagicTagEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs` via `SpellEffectFactory` | Yes | Adds spell-owned key/value metadata for marks, anchors, runes, signatures, and FutureProg queries |
 | `magicresourcedelta` | `MagicResourceDeltaEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/MagicResourceDeltaEffect.cs` via `SpellEffectFactory` | Yes | Adds or removes a configured magic resource from a character, item, or room |
 | `mend` | `MendEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/MendEffect.cs` via `SpellEffectFactory` | Yes | Mends damage or wear |
 | `needdelta` | `NeedDeltaEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/NeedDeltaEffect.cs` via `SpellEffectFactory` | Yes | Changes a need immediately |
@@ -115,6 +121,7 @@ It is intended for:
 | `personalward` | `PersonalWardEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/PersonalWardEffect.cs` via `SpellEffectFactory` | Yes | Applies a school-based personal ward that can fail or reflect matching incoming or outgoing magic |
 | `paralysis` | `ParalysisEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/StandaloneStatusSpellEffects.cs` via `SpellEffectFactory` | Yes | Applies forced paralysis through the health effect system |
 | `poison` | `PoisonEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/StandaloneStatusSpellEffects.Configured.cs` via `SpellEffectFactory` | Yes | Applies a configurable spell-owned drug payload |
+| `portal` | `PortalSpellEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs` via `SpellEffectFactory` | Yes | Creates effect-owned paired transient exits between the caster's room and a target room, room anchor, or item/object anchor |
 | `rage` | `RageSpellEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/RageSpellEffect.cs` via `SpellEffectFactory` | Yes | Applies rage |
 | `relocate` | `RelocateEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/RelocateEffect.cs` via `SpellEffectFactory` | Yes | Relocates a target |
 | `removecomprehendlanguage` | `RemoveComprehendLanguageEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/StandaloneStatusSpellEffects.cs` via `SpellEffectFactory` | Yes | Removes magical language-comprehension effects |
@@ -126,6 +133,7 @@ It is intended for:
 | `removefear` | `RemoveFearEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/StandaloneStatusSpellEffects.cs` via `SpellEffectFactory` | Yes | Removes magical fear effects |
 | `removeflying` | `RemoveFlyingEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/StandaloneStatusSpellEffects.cs` via `SpellEffectFactory` | Yes | Removes magical flight-granting effects |
 | `removeinfravision` | `RemoveInfravisionEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/StandaloneStatusSpellEffects.cs` via `SpellEffectFactory` | Yes | Removes magical infravision effects |
+| `removemagictag` | `RemoveMagicTagEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs` via `SpellEffectFactory` | Yes | Removes matching spell-owned magic tags by key and optional value |
 | `removeparalysis` | `RemoveParalysisEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/StandaloneStatusSpellEffects.cs` via `SpellEffectFactory` | Yes | Removes magical paralysis effects |
 | `removepoison` | `RemovePoisonEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/StandaloneStatusSpellEffects.Configured.cs` via `SpellEffectFactory` | Yes | Removes a matching spell-owned poison payload |
 | `removeroomflag` | `RemoveRoomFlagEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/RoomFlagEffect.cs` via `SpellEffectFactory` | Yes | Removes a configured magical room flag |
@@ -148,6 +156,8 @@ It is intended for:
 | `telepathy` | `TelepathySpellEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/TelepathySpellEffect.cs` via `SpellEffectFactory` | Yes | Applies telepathic linkage |
 | `teleport` | `TeleportEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/TeleportEffect.cs` via `SpellEffectFactory` | Yes | Teleports the caster to a room or cell target |
 | `teleporttarget` | `TeleportTargetEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/TeleportTargetEffect.cs` via `SpellEffectFactory` | Yes | Teleports a target selected by the spell |
+| `subjectivedesc` | `SubjectiveDescriptionEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs` via `SpellEffectFactory` | Yes | Adds caster-scoped subjective full-description replacement |
+| `subjectivesdesc` | `SubjectiveSDescEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs` via `SpellEffectFactory` | Yes | Adds caster-scoped subjective short-description replacement |
 | `transformform` | `TransformFormEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/TransformFormEffect.cs` via `SpellEffectFactory` | Yes | Ensures or reuses a keyed alternate body form, applies first-creation defaults such as description patterns and transformation echo, contributes a priority-ranked forced transformation demand, and reuses the shared baseline-form revert path when the demand ends |
 | `waterbreathing` | `WaterBreathingEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/StandaloneStatusSpellEffects.cs` via `SpellEffectFactory` | Yes | Grants additional breathable fluids for the target |
 | `weatherchange` | `WeatherChangeEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/WeatherChangeEffect.cs` via `SpellEffectFactory` | Yes | Changes weather |
@@ -163,6 +173,18 @@ It is intended for:
 | `fail`, `reflect` | `MagicInterdictionMode` | Ward mode enum that decides whether a matching invocation fizzles or reflects where the runtime supports reflection |
 | n/a | `IMagicInterdictionEffect` | Shared runtime contract used by room and personal wards so spells and powers can consult the same interception rules |
 | n/a | `IExitBarrierEffect` | Shared runtime contract used by movement logic so magical exit barriers can block `Character.CanCross` |
+
+## Engine V2 Support Types
+
+| Token or API | Class or interface | Role |
+| --- | --- | --- |
+| `IExitManager.TransientExits` | `IEnumerable<IExit>` | Read-only enumeration of registered transient exits for builder/admin inspection |
+| n/a | `IMagicPortalExit` | Optional metadata contract implemented by transient magical portals for source, destination, caster, spell, source effect, and portal command text |
+| n/a | `IMagicProjectilePayloadEffect` | First-class projectile/ranged payload enhancement contract used by ammunition, power packs, and thrown weapons |
+| n/a | `IMagicCraftToolEnhancementEffect` | First-class craft-tool enhancement contract for tool fitness, phase speed, and tool usage multipliers |
+| n/a | `IMagicPowerOrFuelEnhancementEffect` | First-class powered-item enhancement contract for production, consumption, and fuel-use multipliers |
+| n/a | `IMagicItemEventEffect` | First-class item event callback contract for enchanted items |
+| n/a | `IMindContactConcealmentEffect` | Shared psionic identity-concealment contract used by mind links, mind speech, broadcasts, audits, expulsion text, and passive telepathic traffic |
 
 ## Notes
 - Schools are first-class records rather than subtype-driven types, so they are documented in the overview and backbone docs rather than listed here as a type family.

--- a/Design Documents/Magic_System_Powers.md
+++ b/Design Documents/Magic_System_Powers.md
@@ -209,6 +209,7 @@ These are the currently builder-creatable power tokens registered through `Magic
 | `mindaudit` | `MindAuditPower` | Mind-reading or auditing style power |
 | `mindbarrier` | `MindBarrierPower` | Mental barrier or protection effect |
 | `mindbroadcast` | `MindBroadcastPower` | Broadcast-style mind communication |
+| `mindconceal` | `MindConcealPower` | Sustained psionic identity concealment for mind contacts, passive traffic, and audit difficulty |
 | `mindexpel` | `MindExpelPower` | Expels connected minds or effects |
 | `mindlook` | `MindLookPower` | Observe or inspect through mind-link mechanics |
 | `mindsay` | `MindSayPower` | Directed mind-to-mind speech |
@@ -218,6 +219,20 @@ These are the currently builder-creatable power tokens registered through `Magic
 Important current-state note:
 
 - `MagicArmourPower` also registers a runtime load alias of `armor` in addition to the builder-facing `armour` token. That alias matters to developers and seeder authors working with persisted `PowerModel` values, but it is not exposed as a distinct builder creation type.
+
+### Psionic identity and passive traffic
+The mind-link stack now shares a first-class concealment policy through `IMindContactConcealmentEffect`.
+
+`mindconceal` is the builder-creatable sustained power for this policy. While active it can:
+
+- replace the user's identity in `connectmind`, `mindsay`, `mindbroadcast`, `mindaudit`, and `mindexpel` output
+- add configured difficulty stages to audit-style detection
+- apply to the owning school and, optionally, child schools
+- use a character/observer prog to decide who is affected
+
+Passive psionic traffic continues to use the existing `telepathy` flow. Configure `telepathy` with `thinks`, `feels`, and `thinkemote` to represent powers such as Thoughtsense or Immersion. When the thinker is sustaining `mindconceal`, passive `think` and `feel` traffic uses the concealed identity instead of leaking the actor's short description or personal name.
+
+This is intentionally separate from true projection or possession. `mindconceal` hides identity across mind-contact and passive telepathy surfaces; it does not create a second acting body or remote command shell.
 
 ### Notable base or runtime-support types
 These matter to developers extending the subsystem, but they are not standalone builder-created types.

--- a/Design Documents/Magic_System_Spells.md
+++ b/Design Documents/Magic_System_Spells.md
@@ -359,6 +359,40 @@ The `transformform` builder effect currently supports:
 - `priorityband <merit|drug|spell|admin>`
 - `priorityoffset <number>`
 
+### Engine V2 dispels, portals, item enchantments, and recipes
+Engine V2 adds a deeper parity layer without introducing true simultaneous-body possession or projection.
+
+General dispels use `dispelmagic`. It can either remove matching spell-parent effects or shorten their scheduled duration. Matching can be restricted by:
+
+- specific spell
+- magic school, optionally including child schools
+- caster policy: own, any, or others
+- magic tag and optional tag value
+- approved effect key such as `magictag`, `itemenchant`, `portal`, `planarstate`, `roomward`, `personalward`, `exitbarrier`, `subjectivedesc`, `transformform`, `projectile`, `crafttool`, `powerfuel`, or `itemevent`
+
+The default policy is caster-owned cleanup. Hostile dispels must be explicitly configured with hostile matching and then travel through the ordinary spell targeting, ward, and resistance flow.
+
+Portals remain saved spell effects, not database exits or a gate table. The `portal` effect creates paired transient exits registered with `IExitManager`; active magical portals expose `IMagicPortalExit` metadata and can be inspected with `magic portals`. Anchor tags can be placed on rooms or items/objects with `magictag`; `portal` resolves caster-owned room anchors first, then caster-owned item anchors by using the item location. Builders can inspect active anchors with `magic anchors [tag]`.
+
+`itemenchant` now has first-class hooks beyond visible aura text, glow, weapon bonuses, and armour reduction:
+
+- projectile quality, damage, pain, and stun bonuses
+- craft tool fitness, phase speed, and tool usage multipliers
+- powered-item production, consumption, and fuel-use multipliers
+- optional item event type and callback prog
+
+Use `magictag` for metadata and lookup facts only. Runtime behaviours like projectile payloads, crafting bonuses, powered-item modifiers, and item event callbacks should use the first-class enchantment hooks.
+
+Current recipe guidance:
+
+- `Ethereal`: use `planarstate` or `planeshift` with a noncorporeal plane definition.
+- `Dispel Ethereal`: use `removeplanarstate`, or `dispelmagic` restricted to `effect planarstate` / the relevant school.
+- `Planeshift`: use `planeshift` when the target itself moves into the configured planar state.
+- Shadow or astral walking: use plane definitions plus `planeshift` when the caster becomes the walker.
+- Polymorph: use `transformform` with a stable `FormKey` and first-creation body-form defaults.
+
+Still-deferred boundary: possession, send-shadow projection, and body-left-behind disembodiment are not just spell effects. They require a simultaneous-body model for command routing, source-body vulnerability, inventory rules, death semantics, reconnect behavior, and admin observability.
+
 ### Material workflow
 Material requirements are authored through the spell's inventory plan:
 
@@ -496,6 +530,8 @@ Important implementation note:
 | `detectinvisible` | `DetectInvisibleEffect` | Grants magical vision that can pierce ordinary invisibility |
 | `detectmagick` | `DetectMagickEffect` | Grants magical sensing and visible aura readouts in ordinary descriptions |
 | `disease` | `DiseaseEffect` | Applies a configurable spell-owned systemic infection |
+| `dispelmagic` | `DispelMagicEffect` | Removes or shortens matching saved spell effects by caster policy, spell, school/subschool, magic tag, or approved effect key |
+| `destroyitem` | `DestroyItemEffect` | Deletes item targets with purge-warning safeguards |
 | `executeprog` | `ExecuteProgEffect` | Executes a supporting prog |
 | `exitbarrier` | `ExitBarrierEffect` | Applies a persistent magical barrier to a targeted exit |
 | `forcedexitmovement` | `ForcedExitMovementEffect` | Forces a targeted character through the trigger-supplied `exit` when movement is legal |
@@ -506,6 +542,9 @@ Important implementation note:
 | `healingrate` | `HealingRateSpellEffect` | Alters healing rate |
 | `infravision` | `InfravisionEffect` | Grants infrared vision and a darkness difficulty floor |
 | `invisibility` | `InvisibilityEffect` | Applies invisibility |
+| `itemdamage` | `ItemDamageEffect` | Damages an item with configured damage, pain, stun, and damage type |
+| `itemenchant` | `ItemEnchantEffect` | Adds aura/glow, weapon/armour bonuses, projectile payload bonuses, craft-tool bonuses, power/fuel modifiers, and optional item event progs |
+| `magictag` | `MagicTagEffect` | Adds spell-owned key/value metadata for marks, anchors, runes, signatures, and FutureProg queries |
 | `magicresourcedelta` | `MagicResourceDeltaEffect` | Adds or removes a configured magic resource from a character, item, or room |
 | `mend` | `MendEffect` | Mends damage or wear |
 | `needdelta` | `NeedDeltaEffect` | Changes a need immediately |
@@ -516,6 +555,7 @@ Important implementation note:
 | `planeshift` | `PlanarStateSpellEffect` | Moves the target into a configured corporeal or noncorporeal planar state |
 | `paralysis` | `ParalysisEffect` | Applies magical paralysis through the forced-paralysis hook |
 | `poison` | `PoisonEffect` | Applies a configurable spell-owned drug payload |
+| `portal` | `PortalSpellEffect` | Creates an effect-owned paired transient portal between the caster's room and a target room, room anchor, or item/object anchor |
 | `rage` | `RageSpellEffect` | Applies rage |
 | `relocate` | `RelocateEffect` | Relocates a target |
 | `removecomprehendlanguage` | `RemoveComprehendLanguageEffect` | Removes magical language-comprehension effects |
@@ -527,6 +567,7 @@ Important implementation note:
 | `removefear` | `RemoveFearEffect` | Removes magical fear effects |
 | `removeflying` | `RemoveFlyingEffect` | Removes magical flight-granting effects |
 | `removeinfravision` | `RemoveInfravisionEffect` | Removes magical infravision effects |
+| `removemagictag` | `RemoveMagicTagEffect` | Removes matching spell-owned magic tags by key and optional value |
 | `removeparalysis` | `RemoveParalysisEffect` | Removes magical paralysis effects |
 | `removeplanarstate` | `RemovePlanarStateSpellEffect` | Removes spell-owned and saved planar-state overlays |
 | `removepoison` | `RemovePoisonEffect` | Removes a matching spell-owned poison payload |
@@ -550,6 +591,9 @@ Important implementation note:
 | `telepathy` | `TelepathySpellEffect` | Applies telepathic linkage |
 | `teleport` | `TeleportEffect` | Teleports the caster to a room or cell target |
 | `teleporttarget` | `TeleportTargetEffect` | Teleports a target selected by the spell |
+| `subjectivedesc` | `SubjectiveDescriptionEffect` | Adds caster-scoped subjective full-description replacement |
+| `subjectivesdesc` | `SubjectiveSDescEffect` | Adds caster-scoped subjective short-description replacement |
+| `transformform` | `TransformFormEffect` | Ensures or reuses a keyed alternate body form and applies a priority-ranked forced transformation demand |
 | `waterbreathing` | `WaterBreathingEffect` | Grants additional breathable fluids |
 | `weatherchange` | `WeatherChangeEffect` | Changes weather |
 | `weatherchangefreeze` | `WeatherChangeFreezeEffect` | Changes and freezes weather state |

--- a/FutureMUDLibrary/Construction/Boundary/IExitManager.cs
+++ b/FutureMUDLibrary/Construction/Boundary/IExitManager.cs
@@ -60,6 +60,7 @@ namespace MudSharp.Construction.Boundary
         IEnumerable<ICellExit> GetAllExits(ICell cell);
 
         IExit GetExitByID(long id);
+        IEnumerable<IExit> TransientExits { get; }
         void RegisterTransientExit(IExit exit);
         void UnregisterTransientExit(IExit exit);
 

--- a/FutureMUDLibrary/Effects/Interfaces/IMagicCraftToolEnhancementEffect.cs
+++ b/FutureMUDLibrary/Effects/Interfaces/IMagicCraftToolEnhancementEffect.cs
@@ -1,0 +1,14 @@
+#nullable enable
+
+using MudSharp.Framework;
+using MudSharp.GameItems;
+
+namespace MudSharp.Effects.Interfaces;
+
+public interface IMagicCraftToolEnhancementEffect : IEffectSubtype
+{
+	double ToolFitnessBonus { get; }
+	double ToolSpeedMultiplier { get; }
+	double ToolUsageMultiplier { get; }
+	bool AppliesToCraftTool(IGameItem tool, ITag? toolTag);
+}

--- a/FutureMUDLibrary/Effects/Interfaces/IMagicItemEventEffect.cs
+++ b/FutureMUDLibrary/Effects/Interfaces/IMagicItemEventEffect.cs
@@ -1,0 +1,12 @@
+#nullable enable
+
+using MudSharp.Events;
+using MudSharp.FutureProg;
+
+namespace MudSharp.Effects.Interfaces;
+
+public interface IMagicItemEventEffect : IHandleEventsEffect
+{
+	EventType? ItemEventType { get; }
+	IFutureProg? ItemEventProg { get; }
+}

--- a/FutureMUDLibrary/Effects/Interfaces/IMagicPortalExit.cs
+++ b/FutureMUDLibrary/Effects/Interfaces/IMagicPortalExit.cs
@@ -1,0 +1,22 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Construction.Boundary;
+using MudSharp.Framework;
+using MudSharp.Magic;
+
+namespace MudSharp.Effects.Interfaces;
+
+public interface IMagicPortalExit
+{
+	IExit Exit { get; }
+	ICell Source { get; }
+	ICell Destination { get; }
+	ICharacter? Caster { get; }
+	IMagicSpell? Spell { get; }
+	IEffect? SourceEffect { get; }
+	string Verb { get; }
+	string OutboundKeyword { get; }
+	string InboundKeyword { get; }
+}

--- a/FutureMUDLibrary/Effects/Interfaces/IMagicPowerOrFuelEnhancementEffect.cs
+++ b/FutureMUDLibrary/Effects/Interfaces/IMagicPowerOrFuelEnhancementEffect.cs
@@ -1,0 +1,13 @@
+#nullable enable
+
+using MudSharp.GameItems;
+
+namespace MudSharp.Effects.Interfaces;
+
+public interface IMagicPowerOrFuelEnhancementEffect : IEffectSubtype
+{
+	double PowerProductionMultiplier { get; }
+	double PowerConsumptionMultiplier { get; }
+	double FuelUseMultiplier { get; }
+	bool AppliesToPoweredItem(IGameItem item);
+}

--- a/FutureMUDLibrary/Effects/Interfaces/IMagicProjectilePayloadEffect.cs
+++ b/FutureMUDLibrary/Effects/Interfaces/IMagicProjectilePayloadEffect.cs
@@ -1,0 +1,16 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Framework;
+using MudSharp.GameItems;
+
+namespace MudSharp.Effects.Interfaces;
+
+public interface IMagicProjectilePayloadEffect : IEffectSubtype
+{
+	double ProjectileQualityBonus { get; }
+	double ProjectileDamageBonus { get; }
+	double ProjectilePainBonus { get; }
+	double ProjectileStunBonus { get; }
+	bool AppliesToProjectileAttack(ICharacter attacker, IPerceiver target, IGameItem projectile);
+}

--- a/FutureMUDLibrary/Effects/Interfaces/IMindContactConcealmentEffect.cs
+++ b/FutureMUDLibrary/Effects/Interfaces/IMindContactConcealmentEffect.cs
@@ -1,0 +1,13 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Magic;
+
+namespace MudSharp.Effects.Interfaces;
+
+public interface IMindContactConcealmentEffect : IEffectSubtype
+{
+	string UnknownIdentityDescription { get; }
+	int AuditDifficultyStages { get; }
+	bool ConcealsIdentityFrom(ICharacter source, ICharacter observer, IMagicSchool school);
+}

--- a/MudSharpCore Unit Tests/MagicEngineV2Tests.cs
+++ b/MudSharpCore Unit Tests/MagicEngineV2Tests.cs
@@ -1,0 +1,482 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Character;
+using MudSharp.Character.Heritage;
+using MudSharp.Construction;
+using MudSharp.Construction.Boundary;
+using MudSharp.Effects;
+using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Concrete.SpellEffects;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Form.Shape;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.GameItems;
+using MudSharp.Magic;
+using MudSharp.Magic.Powers;
+using MudSharp.Magic.SpellEffects;
+using MudSharp.Magic.SpellTriggers;
+using MudSharp.Models;
+using MudSharp.Planes;
+using MudSharp.RPG.Checks;
+using MudSharp.Body.Traits;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class MagicEngineV2Tests
+{
+	[TestInitialize]
+	public void TestInitialize()
+	{
+		SpellTriggerFactory.SetupFactory();
+		SpellEffectFactory.SetupFactory();
+	}
+
+	[TestMethod]
+	public void SpellEffectFactory_RegistersEngineV2DispelMagic()
+	{
+		var spell = CreateSpellMock();
+
+		var (effect, error) = SpellEffectFactory.LoadEffectFromBuilderInput("dispelmagic",
+			new StringStack(string.Empty), spell.Object);
+
+		Assert.AreEqual(string.Empty, error);
+		Assert.IsNotNull(effect);
+		Assert.AreEqual("dispelmagic", effect!.SaveToXml().Attribute("type")?.Value);
+		Assert.IsTrue(SpellEffectFactory.BuilderInfoForType("dispelmagic").MatchingTriggers.Any());
+	}
+
+	[TestMethod]
+	public void DispelMagicEffect_ShortenModeShortensOwnedMatchingEffects()
+	{
+		var caster = CreateCharacter(10);
+		var target = CreatePerceivable(CreateGameworld().Object);
+		var existingSpell = CreateSpellMock(20);
+		var parent = new MagicSpellParent(target.Object, existingSpell.Object, caster.Object);
+		var dispelSpell = CreateSpellMock(30);
+		var effect = SpellEffectFactory.LoadEffect(new XElement("Effect",
+			new XAttribute("type", "dispelmagic"),
+			new XElement("Mode", (int)DispelMagicMode.Shorten),
+			new XElement("CasterPolicy", (int)DispelCasterPolicy.OwnOnly),
+			new XElement("AllowHostile", false),
+			new XElement("ShortenSeconds", 45.0),
+			new XElement("EffectKey", new XCData("any"))), dispelSpell.Object);
+
+		target.Setup(x => x.EffectsOfType<MagicSpellParent>(It.IsAny<Predicate<MagicSpellParent>>()))
+		      .Returns<Predicate<MagicSpellParent>>(predicate => new[] { parent }.Where(x => predicate(x)));
+
+		effect.GetOrApplyEffect(caster.Object, target.Object, OpposedOutcomeDegree.None, SpellPower.Insignificant,
+			CreateParent(dispelSpell.Object, caster.Object).Object, []);
+
+		target.Verify(x => x.RemoveDuration(parent, TimeSpan.FromSeconds(45.0), true), Times.Once);
+		target.Verify(x => x.RemoveEffect(parent, It.IsAny<bool>()), Times.Never);
+	}
+
+	[TestMethod]
+	public void DispelMagicEffect_DefaultCasterPolicyDoesNotRemoveHostileEffects()
+	{
+		var caster = CreateCharacter(10);
+		var otherCaster = CreateCharacter(11);
+		var target = CreatePerceivable(CreateGameworld().Object);
+		var existingSpell = CreateSpellMock(20);
+		var parent = new MagicSpellParent(target.Object, existingSpell.Object, otherCaster.Object);
+		var dispelSpell = CreateSpellMock(30);
+		var effect = SpellEffectFactory.LoadEffect(new XElement("Effect",
+			new XAttribute("type", "dispelmagic"),
+			new XElement("Mode", (int)DispelMagicMode.Remove),
+			new XElement("CasterPolicy", (int)DispelCasterPolicy.OwnOnly),
+			new XElement("AllowHostile", false),
+			new XElement("EffectKey", new XCData("any"))), dispelSpell.Object);
+
+		target.Setup(x => x.EffectsOfType<MagicSpellParent>(It.IsAny<Predicate<MagicSpellParent>>()))
+		      .Returns<Predicate<MagicSpellParent>>(predicate => new[] { parent }.Where(x => predicate(x)));
+
+		effect.GetOrApplyEffect(caster.Object, target.Object, OpposedOutcomeDegree.None, SpellPower.Insignificant,
+			CreateParent(dispelSpell.Object, caster.Object).Object, []);
+
+		target.Verify(x => x.RemoveEffect(It.IsAny<IEffect>(), It.IsAny<bool>()), Times.Never);
+		target.Verify(x => x.RemoveDuration(It.IsAny<IEffect>(), It.IsAny<TimeSpan>(), It.IsAny<bool>()), Times.Never);
+	}
+
+	[TestMethod]
+	public void TransientExitManager_ExposesPortalMetadataForInspection()
+	{
+		var gameworld = CreateGameworld();
+		var manager = new ExitManager(gameworld.Object);
+		var caster = CreateCharacter(10);
+		var spell = CreateSpellMock(20);
+		var sourceEffect = new Mock<IEffect>();
+		var origin = CreateCell(1, "Origin", gameworld.Object);
+		var destination = CreateCell(2, "Destination", gameworld.Object);
+
+		var exit = new TransientExit(gameworld.Object, origin.Object, destination.Object, "enter", "gate", "gate",
+			"a bright gate", "a bright gate", "through", "through", 1.0, caster.Object, spell.Object,
+			sourceEffect.Object);
+
+		manager.RegisterTransientExit(exit);
+
+		var portal = manager.TransientExits.OfType<IMagicPortalExit>().Single();
+		Assert.AreSame(exit, portal.Exit);
+		Assert.AreSame(origin.Object, portal.Source);
+		Assert.AreSame(destination.Object, portal.Destination);
+		Assert.AreSame(caster.Object, portal.Caster);
+		Assert.AreSame(spell.Object, portal.Spell);
+		Assert.AreSame(sourceEffect.Object, portal.SourceEffect);
+		Assert.AreEqual("enter", portal.Verb);
+	}
+
+	[TestMethod]
+	public void PortalSpellEffect_ResolvesCasterOwnedItemAnchors()
+	{
+		var plane = CreatePlane();
+		var zone = new Mock<IZone>();
+		var caster = CreateCharacter(10);
+		var source = CreateCell(1, "Source", null, zone.Object);
+		var destination = CreateCell(2, "Destination", null, zone.Object);
+		var anchorItem = new Mock<IGameItem>();
+		var tag = new Mock<IMagicTagEffect>();
+		var gameworld = CreateGameworld([source.Object, destination.Object], [anchorItem.Object], plane.Object);
+		var spell = CreateSpellMock(20, gameworld.Object);
+		source.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		destination.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		caster.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		caster.SetupGet(x => x.Location).Returns(source.Object);
+		tag.SetupGet(x => x.Caster).Returns(caster.Object);
+		tag.SetupGet(x => x.Tag).Returns("travel-gate");
+		tag.SetupGet(x => x.Value).Returns("south");
+		anchorItem.SetupGet(x => x.Location).Returns(destination.Object);
+		anchorItem.Setup(x => x.EffectsOfType<IMagicTagEffect>(It.IsAny<Predicate<IMagicTagEffect>>()))
+		          .Returns<Predicate<IMagicTagEffect>>(predicate => new[] { tag.Object }.Where(x => predicate(x)));
+
+		var effect = SpellEffectFactory.LoadEffect(new XElement("Effect",
+			new XAttribute("type", "portal"),
+			new XElement("Verb", new XCData("enter")),
+			new XElement("OutboundKeyword", new XCData("gate")),
+			new XElement("InboundKeyword", new XCData("gate")),
+			new XElement("OutboundTarget", new XCData("a gate")),
+			new XElement("InboundTarget", new XCData("a gate")),
+			new XElement("OutboundDescription", new XCData("through")),
+			new XElement("InboundDescription", new XCData("through")),
+			new XElement("TimeMultiplier", 1.0),
+			new XElement("AllowCrossZone", false),
+			new XElement("AnchorTag", new XCData("travel-gate")),
+			new XElement("AnchorValue", new XCData("south")),
+			new XElement("DestinationProg", 0L)), spell.Object);
+
+		var portal = (SpellPortalEffect?)effect.GetOrApplyEffect(caster.Object, null, OpposedOutcomeDegree.None,
+			SpellPower.Insignificant, CreateParent(spell.Object, caster.Object).Object, []);
+
+		Assert.IsNotNull(portal);
+		Assert.AreEqual(source.Object.Id, portal!.SourceCellId);
+		Assert.AreEqual(destination.Object.Id, portal.DestinationCellId);
+	}
+
+	[TestMethod]
+	public void ItemEnchantEffect_RoundTripsEngineV2HookFields()
+	{
+		var spell = CreateSpellMock();
+		var effect = SpellEffectFactory.LoadEffect(new XElement("Effect",
+			new XAttribute("type", "itemenchant"),
+			new XElement("SDescAddendum", new XCData("(storm-charged)")),
+			new XElement("DescAddendum", new XCData("It crackles with stored force.")),
+			new XElement("Colour", "bold magenta"),
+			new XElement("GlowLux", 2.0),
+			new XElement("AttackCheckBonus", 1.0),
+			new XElement("QualityBonus", 2.0),
+			new XElement("DamageBonus", 3.0),
+			new XElement("PainBonus", 4.0),
+			new XElement("StunBonus", 5.0),
+			new XElement("ArmourDamageReduction", 6.0),
+			new XElement("ProjectileQualityBonus", 7.0),
+			new XElement("ProjectileDamageBonus", 8.0),
+			new XElement("ProjectilePainBonus", 9.0),
+			new XElement("ProjectileStunBonus", 10.0),
+			new XElement("ToolFitnessBonus", 11.0),
+			new XElement("ToolSpeedMultiplier", 0.75),
+			new XElement("ToolUsageMultiplier", 0.5),
+			new XElement("PowerProductionMultiplier", 1.25),
+			new XElement("PowerConsumptionMultiplier", 0.8),
+			new XElement("FuelUseMultiplier", 0.6),
+			new XElement("ItemEventType", -1),
+			new XElement("ItemEventProg", 0L),
+			new XElement("ApplicabilityProg", 0L)), spell.Object);
+
+		var saved = effect.SaveToXml();
+
+		Assert.AreEqual("7", saved.Element("ProjectileQualityBonus")!.Value);
+		Assert.AreEqual("8", saved.Element("ProjectileDamageBonus")!.Value);
+		Assert.AreEqual("11", saved.Element("ToolFitnessBonus")!.Value);
+		Assert.AreEqual("0.75", saved.Element("ToolSpeedMultiplier")!.Value);
+		Assert.AreEqual("1.25", saved.Element("PowerProductionMultiplier")!.Value);
+		Assert.AreEqual("0.6", saved.Element("FuelUseMultiplier")!.Value);
+	}
+
+	[TestMethod]
+	public void MindConcealPower_LoadsAndConcealsMindContactIdentity()
+	{
+		var school = CreateSchool(1);
+		var childSchool = CreateSchool(2);
+		childSchool.Setup(x => x.IsChildSchool(school.Object)).Returns(true);
+		var trait = CreateTrait();
+		var prog = CreateProg(0, true);
+		var gameworld = CreateGameworld(magicSchools: [school.Object, childSchool.Object], traits: [trait.Object],
+			progs: [prog.Object]);
+		var power = (MindConcealPower)MagicPowerFactory.LoadPower(CreateMindConcealModel(), gameworld.Object);
+		var owner = CreateCharacter(10, gameworld.Object);
+		var observer = CreateCharacter(11, gameworld.Object);
+		var effect = new MindConcealmentEffect(owner.Object, power);
+
+		Assert.IsTrue(effect.ConcealsIdentityFrom(owner.Object, observer.Object, school.Object));
+		Assert.IsTrue(effect.ConcealsIdentityFrom(owner.Object, observer.Object, childSchool.Object));
+		Assert.AreEqual("a veiled mind", effect.UnknownIdentityDescription);
+		Assert.AreEqual(2, effect.AuditDifficultyStages);
+	}
+
+	[TestMethod]
+	public void PlaneAndFormRecipes_RemainBuilderLoadableForEngineV2()
+	{
+		var plane = CreatePlane();
+		var race = CreateRace();
+		var gameworld = CreateGameworld(planes: [plane.Object], races: [race.Object]);
+		var spell = CreateSpellMock(20, gameworld.Object);
+		var etherealDefinition = PlanarPresenceDefinition.NonCorporeal(plane.Object).SaveToXml();
+		var astralWalkingDefinition = PlanarPresenceDefinition.Manifested(plane.Object).SaveToXml();
+
+		var recipes = new[]
+		{
+			new XElement("Effect", new XAttribute("type", "planarstate"), etherealDefinition),
+			new XElement("Effect", new XAttribute("type", "removeplanarstate")),
+			new XElement("Effect", new XAttribute("type", "planeshift"), etherealDefinition),
+			new XElement("Effect", new XAttribute("type", "planarstate"), astralWalkingDefinition),
+			new XElement("Effect", new XAttribute("type", "transformform"),
+				new XElement("FormKey", "polymorph-wolf"),
+				new XElement("Race", race.Object.Id),
+				new XElement("Ethnicity", 0L),
+				new XElement("Gender", -1),
+				new XElement("Alias", "wolf form"),
+				new XElement("SortOrder", string.Empty),
+				new XElement("TraumaMode", (int)BodySwitchTraumaMode.Automatic),
+				new XElement("TransformationEcho", new XAttribute("mode", "none"), string.Empty),
+				new XElement("AllowVoluntarySwitch", false),
+				new XElement("CanVoluntarilySwitchProg", 0L),
+				new XElement("WhyCannotVoluntarilySwitchProg", 0L),
+				new XElement("CanSeeFormProg", 0L),
+				new XElement("ShortDescriptionPattern", 0L),
+				new XElement("FullDescriptionPattern", 0L),
+				new XElement("PriorityBand", (int)ForcedTransformationPriorityBand.SpellOrPower),
+				new XElement("PriorityOffset", 0))
+		};
+
+		foreach (var recipe in recipes)
+		{
+			var effect = SpellEffectFactory.LoadEffect(recipe, spell.Object);
+
+			Assert.AreEqual(recipe.Attribute("type")?.Value, effect.SaveToXml().Attribute("type")?.Value);
+		}
+	}
+
+	private static MagicPower CreateMindConcealModel()
+	{
+		return new MagicPower
+		{
+			Id = 99,
+			Name = "Veil Mind",
+			Blurb = "Conceal mental identity",
+			ShowHelp = "Conceal mental identity.",
+			MagicSchoolId = 1,
+			PowerModel = "mindconceal",
+			Definition = new XElement("Definition",
+				new XElement("CanInvokePowerProg", 0L),
+				new XElement("WhyCantInvokePowerProg", 0L),
+				new XElement("BeginVerb", "mindconceal"),
+				new XElement("EndVerb", "endmindconceal"),
+				new XElement("SkillCheckDifficulty", (int)Difficulty.Easy),
+				new XElement("SkillCheckTrait", 1L),
+				new XElement("MinimumSuccessThreshold", (int)Outcome.MinorFail),
+				new XElement("AppliesToCharacterProg", 0L),
+				new XElement("UnknownIdentityDescription", new XCData("a veiled mind")),
+				new XElement("AuditDifficultyStages", 2),
+				new XElement("IncludeSubschools", true),
+				new XElement("EmoteForBegin", new XCData(string.Empty)),
+				new XElement("EmoteForBeginSelf", new XCData("You veil your mind.")),
+				new XElement("EmoteForEnd", new XCData(string.Empty)),
+				new XElement("EmoteForEndSelf", new XCData("You lower your veil.")),
+				new XElement("BeginWhenAlreadySustainingError", new XCData("Already concealed.")),
+				new XElement("EndWhenNotSustainingError", new XCData("Not concealed.")),
+				new XElement("IsPsionic", true),
+				new XElement("ConcentrationPointsToSustain", 1.0),
+				new XElement("SustainPenalty", 0.0),
+				new XElement("DetectableWithDetectMagic", (int)Difficulty.Normal),
+				new XElement("SustainResourceCosts")
+			).ToString()
+		};
+	}
+
+	private static Mock<ICharacter> CreateCharacter(long id, IFuturemud? gameworld = null)
+	{
+		var character = new Mock<ICharacter>();
+		character.SetupGet(x => x.Id).Returns(id);
+		character.SetupGet(x => x.Name).Returns($"Character {id}");
+		character.SetupGet(x => x.FrameworkItemType).Returns("Character");
+		if (gameworld is not null)
+		{
+			character.SetupGet(x => x.Gameworld).Returns(gameworld);
+		}
+
+		return character;
+	}
+
+	private static Mock<IPerceivable> CreatePerceivable(IFuturemud gameworld)
+	{
+		var perceivable = new Mock<IPerceivable>();
+		perceivable.SetupGet(x => x.Id).Returns(100);
+		perceivable.SetupGet(x => x.Name).Returns("Target");
+		perceivable.SetupGet(x => x.FrameworkItemType).Returns("Perceivable");
+		perceivable.SetupGet(x => x.Gameworld).Returns(gameworld);
+		perceivable.SetupProperty(x => x.EffectsChanged);
+		perceivable.Setup(x => x.EffectsOfType<IPlanarOverlayEffect>(It.IsAny<Predicate<IPlanarOverlayEffect>>()))
+		           .Returns([]);
+		return perceivable;
+	}
+
+	private static Mock<ICell> CreateCell(long id, string name, IFuturemud? gameworld = null, IZone? zone = null)
+	{
+		var cell = new Mock<ICell>();
+		cell.SetupGet(x => x.Id).Returns(id);
+		cell.SetupGet(x => x.Name).Returns(name);
+		cell.SetupGet(x => x.FrameworkItemType).Returns("Cell");
+		if (gameworld is not null)
+		{
+			cell.SetupGet(x => x.Gameworld).Returns(gameworld);
+		}
+
+		if (zone is not null)
+		{
+			cell.SetupGet(x => x.Zone).Returns(zone);
+		}
+
+		cell.Setup(x => x.EffectsOfType<IMagicTagEffect>(It.IsAny<Predicate<IMagicTagEffect>>())).Returns([]);
+		cell.Setup(x => x.EffectsOfType<IPlanarOverlayEffect>(It.IsAny<Predicate<IPlanarOverlayEffect>>()))
+		    .Returns([]);
+		return cell;
+	}
+
+	private static Mock<IMagicSpellEffectParent> CreateParent(IMagicSpell? spell = null, ICharacter? caster = null)
+	{
+		var parent = new Mock<IMagicSpellEffectParent>();
+		parent.SetupGet(x => x.Spell).Returns(spell ?? CreateSpellMock().Object);
+		if (caster is not null)
+		{
+			parent.SetupGet(x => x.Caster).Returns(caster);
+		}
+
+		return parent;
+	}
+
+	private static Mock<IFuturemud> CreateGameworld(IEnumerable<ICell>? cells = null,
+		IEnumerable<IGameItem>? items = null,
+		IPlane? defaultPlane = null,
+		IEnumerable<IMagicSchool>? magicSchools = null,
+		IEnumerable<ITraitDefinition>? traits = null,
+		IEnumerable<IFutureProg>? progs = null,
+		IEnumerable<IPlane>? planes = null,
+		IEnumerable<IRace>? races = null)
+	{
+		var progList = (progs ?? [CreateProg(0, true).Object]).ToArray();
+		var planeList = (planes ?? (defaultPlane is null ? [CreatePlane().Object] : [defaultPlane])).ToArray();
+		var resolvedDefaultPlane = defaultPlane ?? planeList.First();
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.FutureProgs).Returns(CreateCollectionMock(progList).Object);
+		gameworld.SetupGet(x => x.MagicSchools).Returns(CreateCollectionMock((magicSchools ?? [CreateSchool().Object]).ToArray()).Object);
+		gameworld.SetupGet(x => x.Traits).Returns(CreateCollectionMock((traits ?? [CreateTrait().Object]).ToArray()).Object);
+		gameworld.SetupGet(x => x.Cells).Returns(CreateCollectionMock((cells ?? []).ToArray()).Object);
+		gameworld.SetupGet(x => x.Items).Returns(CreateCollectionMock((items ?? []).ToArray()).Object);
+		gameworld.SetupGet(x => x.Planes).Returns(CreateCollectionMock(planeList).Object);
+		gameworld.SetupGet(x => x.DefaultPlane).Returns(resolvedDefaultPlane);
+		gameworld.SetupGet(x => x.Races).Returns(CreateCollectionMock((races ?? [CreateRace().Object]).ToArray()).Object);
+		gameworld.SetupGet(x => x.Ethnicities).Returns(CreateCollectionMock<IEthnicity>().Object);
+		gameworld.SetupGet(x => x.EntityDescriptionPatterns).Returns(CreateCollectionMock<IEntityDescriptionPattern>().Object);
+		return gameworld;
+	}
+
+	private static Mock<IMagicSchool> CreateSchool(long id = 1)
+	{
+		var school = new Mock<IMagicSchool>();
+		school.SetupGet(x => x.Id).Returns(id);
+		school.SetupGet(x => x.Name).Returns($"School {id}");
+		school.SetupGet(x => x.PowerListColour).Returns(Telnet.Green);
+		school.Setup(x => x.IsChildSchool(It.IsAny<IMagicSchool>())).Returns(false);
+		return school;
+	}
+
+	private static Mock<IMagicSpell> CreateSpellMock(long id = 1, IFuturemud? gameworld = null)
+	{
+		var spell = new Mock<IMagicSpell>();
+		spell.SetupGet(x => x.Id).Returns(id);
+		spell.SetupGet(x => x.Name).Returns($"Spell {id}");
+		spell.SetupGet(x => x.Gameworld).Returns(gameworld ?? CreateGameworld().Object);
+		spell.SetupGet(x => x.School).Returns(CreateSchool().Object);
+		spell.SetupProperty(x => x.Changed);
+		return spell;
+	}
+
+	private static Mock<IFutureProg> CreateProg(long id, bool truth)
+	{
+		var prog = new Mock<IFutureProg>();
+		prog.SetupGet(x => x.Id).Returns(id);
+		prog.SetupGet(x => x.Name).Returns($"Prog {id}");
+		prog.SetupGet(x => x.FunctionName).Returns($"Prog{id}");
+		prog.SetupGet(x => x.ReturnType).Returns(ProgVariableTypes.Boolean);
+		prog.Setup(x => x.ExecuteBool(It.IsAny<object[]>())).Returns(truth);
+		prog.Setup(x => x.Execute<bool?>(It.IsAny<object[]>())).Returns(truth);
+		prog.Setup(x => x.Execute(It.IsAny<object[]>())).Returns(truth);
+		prog.Setup(x => x.MatchesParameters(It.IsAny<IEnumerable<ProgVariableTypes>>())).Returns(true);
+		prog.Setup(x => x.MXPClickableFunctionName()).Returns($"Prog{id}");
+		return prog;
+	}
+
+	private static Mock<ITraitDefinition> CreateTrait()
+	{
+		var trait = new Mock<ITraitDefinition>();
+		trait.SetupGet(x => x.Id).Returns(1);
+		trait.SetupGet(x => x.Name).Returns("Psionics");
+		return trait;
+	}
+
+	private static Mock<IPlane> CreatePlane(long id = 1)
+	{
+		var plane = new Mock<IPlane>();
+		plane.SetupGet(x => x.Id).Returns(id);
+		plane.SetupGet(x => x.Name).Returns($"Plane {id}");
+		return plane;
+	}
+
+	private static Mock<IRace> CreateRace()
+	{
+		var race = new Mock<IRace>();
+		race.SetupGet(x => x.Id).Returns(1);
+		race.SetupGet(x => x.Name).Returns("Human");
+		return race;
+	}
+
+	private static Mock<IUneditableAll<T>> CreateCollectionMock<T>(params T[] items) where T : class, IFrameworkItem
+	{
+		var byId = items.ToDictionary(x => x.Id, x => x);
+		var collection = new Mock<IUneditableAll<T>>();
+		collection.SetupGet(x => x.Count).Returns(items.Length);
+		collection.Setup(x => x.Get(It.IsAny<long>())).Returns<long>(id => byId.GetValueOrDefault(id));
+		collection.Setup(x => x.GetByName(It.IsAny<string>())).Returns<string>(name =>
+			items.FirstOrDefault(x => x.Name.EqualTo(name)));
+		collection.Setup(x => x.GetByIdOrName(It.IsAny<string>(), It.IsAny<bool>())).Returns<string, bool>((text, _) =>
+			long.TryParse(text, out var id) ? byId.GetValueOrDefault(id) : items.FirstOrDefault(x => x.Name.EqualTo(text)));
+		collection.Setup(x => x.GetEnumerator()).Returns(() => ((IEnumerable<T>)items).GetEnumerator());
+		return collection;
+	}
+}

--- a/MudSharpCore/Commands/Modules/CommunicationsModule.cs
+++ b/MudSharpCore/Commands/Modules/CommunicationsModule.cs
@@ -71,11 +71,17 @@ internal class CommunicationsModule : Module<ICharacter>
             List<ITelepathyEffect> effects =
                 character.EffectsOfType<ITelepathyEffect>().Where(x => x.Applies(actor) && x.ShowThinks).ToList();
             bool showDesc = effects.Any(x => x.ShowDescription(actor));
-            bool showName = effects.Any(x => x.ShowName(actor));
+            var concealment = actor.EffectsOfType<IMindContactConcealmentEffect>()
+                                  .FirstOrDefault(x => effects.OfType<IMagicEffect>()
+                                                             .Any(y => x.ConcealsIdentityFrom(actor, character,
+                                                                 y.School)));
+            bool showName = concealment is null && effects.Any(x => x.ShowName(actor));
             bool showEmote = effects.Any(x => x.ShowThinkEmote(actor));
+            var thinkerDescription = concealment?.UnknownIdentityDescription.ColourCharacter() ??
+                                     (showDesc ? actor.HowSeen(character, true) : "Someone");
 
             character.Send(
-                $"{(showDesc ? actor.HowSeen(character, true) : "Someone")} {(showName ? $"({actor.PersonalName.GetName(NameStyle.SimpleFull)}) " : "")}thinks{(showEmote && !string.IsNullOrWhiteSpace(emote.RawText) ? $", {emote.ParseFor(character)}, " : ",")}\n\t\"{thinkText}\"");
+                $"{thinkerDescription} {(showName ? $"({actor.PersonalName.GetName(NameStyle.SimpleFull)}) " : "")}thinks{(showEmote && !string.IsNullOrWhiteSpace(emote.RawText) ? $", {emote.ParseFor(character)}, " : ",")}\n\t\"{thinkText}\"");
         }
     }
 
@@ -120,11 +126,17 @@ internal class CommunicationsModule : Module<ICharacter>
             List<ITelepathyEffect> effects =
                 character.EffectsOfType<ITelepathyEffect>().Where(x => x.Applies(actor) && x.ShowFeels).ToList();
             bool showDesc = effects.Any(x => x.ShowDescription(actor));
-            bool showName = effects.Any(x => x.ShowName(actor));
+            var concealment = actor.EffectsOfType<IMindContactConcealmentEffect>()
+                                  .FirstOrDefault(x => effects.OfType<IMagicEffect>()
+                                                             .Any(y => x.ConcealsIdentityFrom(actor, character,
+                                                                 y.School)));
+            bool showName = concealment is null && effects.Any(x => x.ShowName(actor));
             bool showEmote = effects.Any(x => x.ShowThinkEmote(actor));
+            var thinkerDescription = concealment?.UnknownIdentityDescription.ColourCharacter() ??
+                                     (showDesc ? actor.HowSeen(character, true) : "Someone");
 
             character.OutputHandler.Send(
-                $"{(showDesc ? actor.HowSeen(character, true) : "Someone")} {(showName ? $"({actor.PersonalName.GetName(NameStyle.SimpleFull)}) " : "")}feels{(showEmote && !string.IsNullOrWhiteSpace(emote.RawText) ? $", {emote.ParseFor(character)}, " : " ")}{feelEmote.ParseFor(character)}");
+                $"{thinkerDescription} {(showName ? $"({actor.PersonalName.GetName(NameStyle.SimpleFull)}) " : "")}feels{(showEmote && !string.IsNullOrWhiteSpace(emote.RawText) ? $", {emote.ParseFor(character)}, " : " ")}{feelEmote.ParseFor(character)}");
         }
     }
 

--- a/MudSharpCore/Commands/Modules/MagicModule.cs
+++ b/MudSharpCore/Commands/Modules/MagicModule.cs
@@ -233,6 +233,12 @@ public class MagicModule : Module<ICharacter>
             case "power":
                 MagicPower(actor, ss);
                 return;
+            case "portals":
+                MagicPortals(actor, ss);
+                return;
+            case "anchors":
+                MagicAnchors(actor, ss);
+                return;
             case "resource":
                 MagicResource(actor, ss);
                 return;
@@ -248,6 +254,8 @@ public class MagicModule : Module<ICharacter>
 	#3magic regenerator#0 - magic regenerators produce magic resources based on rules
 	#3magic power#0 - magic powers are customisable hard-coded powers for a magic school
 	#3magic spell#0 - magic spells are completely flexible and editable templates for magical effects
+	#3magic portals#0 - inspects active transient magical portals
+	#3magic anchors [tag]#0 - inspects active magic-tag anchors on rooms and items
 
 #ENote - It's relatively easy to add new spell effect types. Reach out to Japheth on the FutureMUD discord if you want something added.#0".SubstituteANSIColour());
                 return;
@@ -277,6 +285,93 @@ public class MagicModule : Module<ICharacter>
     public static void MagicResource(ICharacter actor, StringStack command)
     {
         BuilderModule.GenericBuildingCommand(actor, command, EditableItemHelper.MagicResourceHelper);
+    }
+
+    public static void MagicPortals(ICharacter actor, StringStack command)
+    {
+        var portals = actor.Gameworld.ExitManager.TransientExits
+                           .OfType<IMagicPortalExit>()
+                           .OrderBy(x => x.Source.Id)
+                           .ThenBy(x => x.Destination.Id)
+                           .ToList();
+        if (!portals.Any())
+        {
+            actor.OutputHandler.Send("There are no active transient magical portals.");
+            return;
+        }
+
+        actor.OutputHandler.Send(StringUtilities.GetTextTable(
+            from portal in portals
+            let duration = portal.SourceEffect?.Owner.ScheduledDuration(portal.SourceEffect) ?? TimeSpan.Zero
+            select new List<string>
+            {
+                portal.Exit.Id.ToString("N0", actor),
+                $"#{portal.Source.Id.ToString("N0", actor)} {portal.Source.Name}",
+                $"#{portal.Destination.Id.ToString("N0", actor)} {portal.Destination.Name}",
+                $"{portal.Verb} {portal.OutboundKeyword}",
+                portal.Caster?.HowSeen(actor, flags: PerceiveIgnoreFlags.IgnoreCanSee) ?? "None",
+                portal.Spell?.Name ?? "Unknown",
+                duration > TimeSpan.Zero ? duration.Describe(actor) : "persistent"
+            },
+            new List<string>
+            {
+                "Id",
+                "Source",
+                "Destination",
+                "Command",
+                "Caster",
+                "Spell",
+                "Duration"
+            },
+            actor,
+            Telnet.Magenta));
+    }
+
+    public static void MagicAnchors(ICharacter actor, StringStack command)
+    {
+        var filter = command.SafeRemainingArgument;
+        var anchors = actor.Gameworld.Cells
+                           .SelectMany(x => x.EffectsOfType<IMagicTagEffect>(tag =>
+                               string.IsNullOrWhiteSpace(filter) || tag.Tag.EqualTo(filter)).Select(tag => (Owner: (IPerceivable)x, Tag: tag)))
+                           .Concat(actor.Gameworld.Items
+                                        .SelectMany(x => x.EffectsOfType<IMagicTagEffect>(tag =>
+                                            string.IsNullOrWhiteSpace(filter) || tag.Tag.EqualTo(filter)).Select(tag => (Owner: (IPerceivable)x, Tag: tag))))
+                           .OrderBy(x => x.Owner.FrameworkItemType)
+                           .ThenBy(x => x.Owner.Id)
+                           .ToList();
+        if (!anchors.Any())
+        {
+            actor.OutputHandler.Send(string.IsNullOrWhiteSpace(filter)
+                ? "There are no active magic-tag anchors on rooms or items."
+                : $"There are no active magic-tag anchors matching {filter.ColourCommand()}.");
+            return;
+        }
+
+        actor.OutputHandler.Send(StringUtilities.GetTextTable(
+            from anchor in anchors
+            let duration = anchor.Owner.ScheduledDuration(anchor.Tag)
+            select new List<string>
+            {
+                anchor.Owner.FrameworkItemType,
+                $"#{anchor.Owner.Id.ToString("N0", actor)} {anchor.Owner.Name}",
+                anchor.Tag.Tag,
+                anchor.Tag.Value,
+                anchor.Tag.Caster?.HowSeen(actor, flags: PerceiveIgnoreFlags.IgnoreCanSee) ?? "None",
+                anchor.Tag.Spell.Name,
+                duration > TimeSpan.Zero ? duration.Describe(actor) : "persistent"
+            },
+            new List<string>
+            {
+                "Type",
+                "Owner",
+                "Tag",
+                "Value",
+                "Caster",
+                "Spell",
+                "Duration"
+            },
+            actor,
+            Telnet.Magenta));
     }
 
     #region Magic Spells

--- a/MudSharpCore/Construction/Boundary/ExitManager.cs
+++ b/MudSharpCore/Construction/Boundary/ExitManager.cs
@@ -245,6 +245,11 @@ public class ExitManager : IExitManager, IHaveFuturemud
                TransientExitDictionary.SelectMany(x => x.Value).FirstOrDefault(x => x.Id == id);
     }
 
+    public IEnumerable<IExit> TransientExits => TransientExitDictionary
+        .SelectMany(x => x.Value)
+        .Distinct()
+        .ToList();
+
     public void RegisterTransientExit(IExit exit)
     {
         if (exit is null)

--- a/MudSharpCore/Construction/Boundary/TransientExit.cs
+++ b/MudSharpCore/Construction/Boundary/TransientExit.cs
@@ -2,8 +2,12 @@
 
 using MudSharp.Framework;
 using MudSharp.FutureProg;
+using MudSharp.Character;
+using MudSharp.Effects;
+using MudSharp.Effects.Interfaces;
 using MudSharp.GameItems;
 using MudSharp.GameItems.Interfaces;
+using MudSharp.Magic;
 using MudSharp.PerceptionEngine;
 using MudSharp.RPG.Checks;
 using System;
@@ -13,7 +17,7 @@ using System.Threading;
 
 namespace MudSharp.Construction.Boundary;
 
-public class TransientExit : PerceivedItem, IExit
+public class TransientExit : PerceivedItem, IExit, IMagicPortalExit
 {
 	private static long _nextId;
 	private readonly List<ICell> _cells = new();
@@ -22,7 +26,8 @@ public class TransientExit : PerceivedItem, IExit
 
 	public TransientExit(IFuturemud gameworld, ICell origin, ICell destination, string verb, string outboundKeyword,
 		string inboundKeyword, string outboundTarget, string inboundTarget, string outboundDescription,
-		string inboundDescription, double timeMultiplier)
+		string inboundDescription, double timeMultiplier, ICharacter? caster = null, IMagicSpell? spell = null,
+		IEffect? sourceEffect = null)
 	{
 		Gameworld = gameworld;
 		_id = Interlocked.Decrement(ref _nextId);
@@ -35,6 +40,14 @@ public class TransientExit : PerceivedItem, IExit
 		MaximumSizeToEnterUpright = SizeCategory.Titanic;
 		AcceptsDoor = false;
 		ClimbDifficulty = Difficulty.Normal;
+		Caster = caster;
+		Spell = spell;
+		SourceEffect = sourceEffect;
+		Verb = verb;
+		OutboundKeyword = outboundKeyword;
+		InboundKeyword = inboundKeyword;
+		Source = origin;
+		Destination = destination;
 
 		var outboundKeywords = KeywordsFor(outboundTarget, outboundKeyword);
 		var inboundKeywords = KeywordsFor(inboundTarget, inboundKeyword);
@@ -65,6 +78,15 @@ public class TransientExit : PerceivedItem, IExit
 	public SizeCategory MaximumSizeToEnterUpright { get; set; }
 	public SizeCategory MaximumSizeToEnter { get; set; }
 	public IEnumerable<ICell> Cells => _cells;
+	public IExit Exit => this;
+	public ICell Source { get; }
+	public ICell Destination { get; }
+	public ICharacter? Caster { get; }
+	public IMagicSpell? Spell { get; }
+	public IEffect? SourceEffect { get; }
+	public string Verb { get; }
+	public string OutboundKeyword { get; }
+	public string InboundKeyword { get; }
 	public ICell? FallCell { get; set; }
 	public bool IsClimbExit { get; set; }
 	public Difficulty ClimbDifficulty { get; set; }

--- a/MudSharpCore/Effects/Concrete/MindConcealmentEffect.cs
+++ b/MudSharpCore/Effects/Concrete/MindConcealmentEffect.cs
@@ -1,0 +1,130 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.Magic;
+using MudSharp.Magic.Powers;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Outputs;
+using MudSharp.PerceptionEngine.Parsers;
+using MudSharp.RPG.Checks;
+using System;
+using System.Xml.Linq;
+
+namespace MudSharp.Effects.Concrete;
+
+public class MindConcealmentEffect : ConcentrationConsumingEffect, IMagicEffect, ICheckBonusEffect,
+	IMindContactConcealmentEffect
+{
+	public static void InitialiseEffectType()
+	{
+		RegisterFactory("MindConcealment", (effect, owner) => new MindConcealmentEffect(effect, owner));
+	}
+
+	public MindConcealmentEffect(ICharacter owner, MindConcealPower power) : base(owner, power.School,
+		power.ConcentrationPointsToSustain)
+	{
+		MindPower = power;
+		Login();
+	}
+
+	protected MindConcealmentEffect(XElement effect, IPerceivable owner) : base(effect, owner)
+	{
+		var root = effect.Element("Effect");
+		var powerId = long.Parse(root!.Element("Power")!.Value);
+		MindPower = Gameworld.MagicPowers.Get(powerId) as MindConcealPower ??
+		            throw new ApplicationException(
+			            $"The MindConcealment effect for {owner.FrameworkItemType} #{owner.Id} referred to invalid mindconceal power #{powerId}.");
+	}
+
+	protected override XElement SaveDefinition()
+	{
+		return SaveToXml(new XElement("Power", PowerOrigin.Id));
+	}
+
+	public override bool SavingEffect => true;
+
+	protected override string SpecificEffectType => "MindConcealment";
+
+	protected override bool EffectCanPersistOnLogout => true;
+
+	public MindConcealPower MindPower { get; protected set; }
+	public IMagicPower PowerOrigin => MindPower;
+	public Difficulty DetectMagicDifficulty => MindPower.DetectableWithDetectMagic;
+	public string UnknownIdentityDescription => MindPower.UnknownIdentityDescription;
+	public int AuditDifficultyStages => MindPower.AuditDifficultyStages;
+
+	public override string Describe(IPerceiver voyeur)
+	{
+		return
+			$"Mind-contact identity is concealed as {UnknownIdentityDescription.ColourCharacter()} via {MindPower.Name.Colour(School.PowerListColour)}.";
+	}
+
+	public bool ConcealsIdentityFrom(ICharacter source, ICharacter observer, IMagicSchool school)
+	{
+		return source == CharacterOwner &&
+		       MindPower.AppliesToSchool(school) &&
+		       MindPower.AppliesToCharacterProg.Execute<bool?>(CharacterOwner, observer) != false;
+	}
+
+	protected override void RegisterEvents()
+	{
+		base.RegisterEvents();
+		CharacterOwner.OnStateChanged += CharacterOwner_OnStateChanged;
+		CharacterOwner.OnDeath += CharacterOwner_OnNoLongerValid;
+		if (Gameworld?.HeartbeatManager is not null)
+		{
+			Gameworld.HeartbeatManager.FuzzyMinuteHeartbeat += DoSustainCostsTick;
+		}
+	}
+
+	private void CharacterOwner_OnNoLongerValid(IPerceivable owner)
+	{
+		CharacterOwner.RemoveEffect(this, true);
+	}
+
+	private void CharacterOwner_OnStateChanged(IPerceivable owner)
+	{
+		if (!CharacterState.Conscious.HasFlag(CharacterOwner.State))
+		{
+			CharacterOwner.RemoveEffect(this, true);
+		}
+	}
+
+	public override void ReleaseEvents()
+	{
+		base.ReleaseEvents();
+		CharacterOwner.OnStateChanged -= CharacterOwner_OnStateChanged;
+		CharacterOwner.OnDeath -= CharacterOwner_OnNoLongerValid;
+		if (Gameworld?.HeartbeatManager is not null)
+		{
+			Gameworld.HeartbeatManager.FuzzyMinuteHeartbeat -= DoSustainCostsTick;
+		}
+	}
+
+	public override void RemovalEffect()
+	{
+		ReleaseEvents();
+		CharacterOwner.OutputHandler.Send(new EmoteOutput(new Emote(MindPower.EmoteForEndSelf, CharacterOwner,
+			CharacterOwner)));
+		if (!string.IsNullOrWhiteSpace(MindPower.EmoteForEnd))
+		{
+			CharacterOwner.OutputHandler.Handle(new EmoteOutput(new Emote(MindPower.EmoteForEnd, CharacterOwner,
+				CharacterOwner), flags: OutputFlags.SuppressSource), OutputRange.Local);
+		}
+	}
+
+	private void DoSustainCostsTick()
+	{
+		MindPower.DoSustainCostsTick(CharacterOwner);
+	}
+
+	public bool AppliesToCheck(CheckType type)
+	{
+		return type.IsDefensiveCombatAction() || type.IsOffensiveCombatAction() || type.IsGeneralActivityCheck() ||
+		       type.IsTargettedFriendlyCheck() || type.IsTargettedHostileCheck();
+	}
+
+	public double CheckBonus => MindPower.SustainPenalty;
+}

--- a/MudSharpCore/Effects/Concrete/SpellEffects/SpellItemEnchantmentEffect.cs
+++ b/MudSharpCore/Effects/Concrete/SpellEffects/SpellItemEnchantmentEffect.cs
@@ -2,18 +2,21 @@
 
 using MudSharp.Character;
 using MudSharp.Effects.Interfaces;
+using MudSharp.Events;
 using MudSharp.Framework;
 using MudSharp.FutureProg;
 using MudSharp.GameItems;
 using MudSharp.Health;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml.Linq;
 
 namespace MudSharp.Effects.Concrete.SpellEffects;
 
 public class SpellItemEnchantmentEffect : MagicSpellEffectBase, IDescriptionAdditionEffect, ISDescAdditionEffect,
-	IProduceIllumination, IMagicWeaponEnhancementEffect, IMagicArmourEnhancementEffect
+	IProduceIllumination, IMagicWeaponEnhancementEffect, IMagicArmourEnhancementEffect, IMagicProjectilePayloadEffect,
+	IMagicCraftToolEnhancementEffect, IMagicPowerOrFuelEnhancementEffect, IMagicItemEventEffect
 {
 	public static void InitialiseEffectType()
 	{
@@ -22,7 +25,12 @@ public class SpellItemEnchantmentEffect : MagicSpellEffectBase, IDescriptionAddi
 
 	public SpellItemEnchantmentEffect(IPerceivable owner, IMagicSpellEffectParent parent, string sdescAddendum,
 		string descAddendum, ANSIColour colour, double glowLux, double attackCheckBonus, double qualityBonus,
-		double damageBonus, double painBonus, double stunBonus, double armourDamageReduction, IFutureProg? prog = null)
+		double damageBonus, double painBonus, double stunBonus, double armourDamageReduction,
+		double projectileQualityBonus = 0.0, double projectileDamageBonus = 0.0, double projectilePainBonus = 0.0,
+		double projectileStunBonus = 0.0, double toolFitnessBonus = 0.0, double toolSpeedMultiplier = 1.0,
+		double toolUsageMultiplier = 1.0, double powerProductionMultiplier = 1.0,
+		double powerConsumptionMultiplier = 1.0, double fuelUseMultiplier = 1.0,
+		EventType? itemEventType = null, IFutureProg? itemEventProg = null, IFutureProg? prog = null)
 		: base(owner, parent, prog)
 	{
 		SDescAddendum = sdescAddendum;
@@ -35,6 +43,18 @@ public class SpellItemEnchantmentEffect : MagicSpellEffectBase, IDescriptionAddi
 		PainBonus = painBonus;
 		StunBonus = stunBonus;
 		ArmourDamageReduction = armourDamageReduction;
+		ProjectileQualityBonus = projectileQualityBonus;
+		ProjectileDamageBonus = projectileDamageBonus;
+		ProjectilePainBonus = projectilePainBonus;
+		ProjectileStunBonus = projectileStunBonus;
+		ToolFitnessBonus = toolFitnessBonus;
+		ToolSpeedMultiplier = toolSpeedMultiplier;
+		ToolUsageMultiplier = toolUsageMultiplier;
+		PowerProductionMultiplier = powerProductionMultiplier;
+		PowerConsumptionMultiplier = powerConsumptionMultiplier;
+		FuelUseMultiplier = fuelUseMultiplier;
+		ItemEventType = itemEventType;
+		ItemEventProg = itemEventProg;
 	}
 
 	private SpellItemEnchantmentEffect(XElement root, IPerceivable owner) : base(root, owner)
@@ -50,6 +70,19 @@ public class SpellItemEnchantmentEffect : MagicSpellEffectBase, IDescriptionAddi
 		PainBonus = double.Parse(trueRoot?.Element("PainBonus")?.Value ?? "0");
 		StunBonus = double.Parse(trueRoot?.Element("StunBonus")?.Value ?? "0");
 		ArmourDamageReduction = double.Parse(trueRoot?.Element("ArmourDamageReduction")?.Value ?? "0");
+		ProjectileQualityBonus = double.Parse(trueRoot?.Element("ProjectileQualityBonus")?.Value ?? "0");
+		ProjectileDamageBonus = double.Parse(trueRoot?.Element("ProjectileDamageBonus")?.Value ?? "0");
+		ProjectilePainBonus = double.Parse(trueRoot?.Element("ProjectilePainBonus")?.Value ?? "0");
+		ProjectileStunBonus = double.Parse(trueRoot?.Element("ProjectileStunBonus")?.Value ?? "0");
+		ToolFitnessBonus = double.Parse(trueRoot?.Element("ToolFitnessBonus")?.Value ?? "0");
+		ToolSpeedMultiplier = double.Parse(trueRoot?.Element("ToolSpeedMultiplier")?.Value ?? "1");
+		ToolUsageMultiplier = double.Parse(trueRoot?.Element("ToolUsageMultiplier")?.Value ?? "1");
+		PowerProductionMultiplier = double.Parse(trueRoot?.Element("PowerProductionMultiplier")?.Value ?? "1");
+		PowerConsumptionMultiplier = double.Parse(trueRoot?.Element("PowerConsumptionMultiplier")?.Value ?? "1");
+		FuelUseMultiplier = double.Parse(trueRoot?.Element("FuelUseMultiplier")?.Value ?? "1");
+		var eventValue = int.Parse(trueRoot?.Element("ItemEventType")?.Value ?? "-1");
+		ItemEventType = eventValue < 0 ? null : (EventType)eventValue;
+		ItemEventProg = Gameworld.FutureProgs.Get(long.Parse(trueRoot?.Element("ItemEventProg")?.Value ?? "0"));
 	}
 
 	public string SDescAddendum { get; }
@@ -62,6 +95,18 @@ public class SpellItemEnchantmentEffect : MagicSpellEffectBase, IDescriptionAddi
 	public double PainBonus { get; }
 	public double StunBonus { get; }
 	public double ArmourDamageReduction { get; }
+	public double ProjectileQualityBonus { get; }
+	public double ProjectileDamageBonus { get; }
+	public double ProjectilePainBonus { get; }
+	public double ProjectileStunBonus { get; }
+	public double ToolFitnessBonus { get; }
+	public double ToolSpeedMultiplier { get; }
+	public double ToolUsageMultiplier { get; }
+	public double PowerProductionMultiplier { get; }
+	public double PowerConsumptionMultiplier { get; }
+	public double FuelUseMultiplier { get; }
+	public EventType? ItemEventType { get; }
+	public IFutureProg? ItemEventProg { get; }
 
 	protected override XElement SaveDefinition()
 	{
@@ -76,7 +121,19 @@ public class SpellItemEnchantmentEffect : MagicSpellEffectBase, IDescriptionAddi
 			new XElement("DamageBonus", DamageBonus),
 			new XElement("PainBonus", PainBonus),
 			new XElement("StunBonus", StunBonus),
-			new XElement("ArmourDamageReduction", ArmourDamageReduction)
+			new XElement("ArmourDamageReduction", ArmourDamageReduction),
+			new XElement("ProjectileQualityBonus", ProjectileQualityBonus),
+			new XElement("ProjectileDamageBonus", ProjectileDamageBonus),
+			new XElement("ProjectilePainBonus", ProjectilePainBonus),
+			new XElement("ProjectileStunBonus", ProjectileStunBonus),
+			new XElement("ToolFitnessBonus", ToolFitnessBonus),
+			new XElement("ToolSpeedMultiplier", ToolSpeedMultiplier),
+			new XElement("ToolUsageMultiplier", ToolUsageMultiplier),
+			new XElement("PowerProductionMultiplier", PowerProductionMultiplier),
+			new XElement("PowerConsumptionMultiplier", PowerConsumptionMultiplier),
+			new XElement("FuelUseMultiplier", FuelUseMultiplier),
+			new XElement("ItemEventType", ItemEventType.HasValue ? (int)ItemEventType.Value : -1),
+			new XElement("ItemEventProg", ItemEventProg?.Id ?? 0L)
 		);
 	}
 
@@ -98,6 +155,24 @@ public class SpellItemEnchantmentEffect : MagicSpellEffectBase, IDescriptionAddi
 	{
 		return ReferenceEquals(Owner, weapon) &&
 		       (ApplicabilityProg?.ExecuteBool(weapon, attacker, target) ?? true);
+	}
+
+	public bool AppliesToProjectileAttack(ICharacter attacker, IPerceiver target, IGameItem projectile)
+	{
+		return ReferenceEquals(Owner, projectile) &&
+		       (ApplicabilityProg?.ExecuteBool(projectile, attacker, target) ?? true);
+	}
+
+	public bool AppliesToCraftTool(IGameItem tool, ITag? toolTag)
+	{
+		return ReferenceEquals(Owner, tool) &&
+		       (ApplicabilityProg?.ExecuteBool(tool) ?? true);
+	}
+
+	public bool AppliesToPoweredItem(IGameItem item)
+	{
+		return ReferenceEquals(Owner, item) &&
+		       (ApplicabilityProg?.ExecuteBool(item) ?? true);
 	}
 
 	public IDamage SufferDamage(IDamage damage, ref List<IWound> wounds)
@@ -145,6 +220,30 @@ public class SpellItemEnchantmentEffect : MagicSpellEffectBase, IDescriptionAddi
 	public override string Describe(IPerceiver voyeur)
 	{
 		return "Magically enchanted item.";
+	}
+
+	public bool HandleEvent(EventType type, params dynamic[] arguments)
+	{
+		if (ItemEventProg is null || (ItemEventType.HasValue && ItemEventType.Value != type) || Owner is not IGameItem item)
+		{
+			return false;
+		}
+
+		if (ItemEventProg.MatchesParameters([ProgVariableTypes.Item, ProgVariableTypes.Text]))
+		{
+			ItemEventProg.Execute(item, type.DescribeEnum());
+		}
+		else if (ItemEventProg.MatchesParameters([ProgVariableTypes.Item]))
+		{
+			ItemEventProg.Execute(item);
+		}
+
+		return false;
+	}
+
+	public bool HandlesEvent(params EventType[] types)
+	{
+		return ItemEventProg is not null && (!ItemEventType.HasValue || types.Contains(ItemEventType.Value));
 	}
 
 	protected override string SpecificEffectType => "SpellItemEnchantment";

--- a/MudSharpCore/Effects/Concrete/SpellEffects/SpellPortalEffect.cs
+++ b/MudSharpCore/Effects/Concrete/SpellEffects/SpellPortalEffect.cs
@@ -93,7 +93,8 @@ public class SpellPortalEffect : MagicSpellEffectBase
 		}
 
 		_registeredExit = new TransientExit(Gameworld, source, destination, Verb, OutboundKeyword, InboundKeyword,
-			OutboundTarget, InboundTarget, OutboundDescription, InboundDescription, TimeMultiplier);
+			OutboundTarget, InboundTarget, OutboundDescription, InboundDescription, TimeMultiplier,
+			ParentEffect?.Caster, Spell, this);
 		Gameworld.ExitManager.RegisterTransientExit(_registeredExit);
 	}
 

--- a/MudSharpCore/GameItems/Components/AmmunitionGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/AmmunitionGameItemComponent.cs
@@ -496,20 +496,23 @@ public class AmmunitionGameItemComponent : GameItemComponent, IAmmo
         return true;
     }
 
-    private Damage BuildDamage(ICharacter actor, IPerceiver target, IBodypart bodypart,
+	private Damage BuildDamage(ICharacter actor, IPerceiver target, IBodypart bodypart,
         IGameItem ammo, IRangedWeaponType weaponType, OpposedOutcome defenseOutcome)
     {
-        AmmoType.DamageProfile.DamageExpression.Formula.Parameters["quality"] = (int)ammo.Quality;
+        var payloadEffects = ammo.EffectsOfType<IMagicProjectilePayloadEffect>(x =>
+            x.AppliesToProjectileAttack(actor, target, ammo)).ToList();
+        var effectiveQuality = (int)ammo.Quality + (int)Math.Round(payloadEffects.Sum(x => x.ProjectileQualityBonus));
+        AmmoType.DamageProfile.DamageExpression.Formula.Parameters["quality"] = effectiveQuality;
         AmmoType.DamageProfile.DamageExpression.Formula.Parameters["degree"] = (int)defenseOutcome.Degree;
         AmmoType.DamageProfile.DamageExpression.Formula.Parameters["pointblank"] = actor == target ? 1 : 0;
         AmmoType.DamageProfile.DamageExpression.Formula.Parameters["inmelee"] = actor.MeleeRange ? 1 : 0;
         AmmoType.DamageProfile.DamageExpression.Formula.Parameters["range"] = target.DistanceBetween(actor, 10);
-        AmmoType.DamageProfile.PainExpression.Formula.Parameters["quality"] = (int)ammo.Quality;
+        AmmoType.DamageProfile.PainExpression.Formula.Parameters["quality"] = effectiveQuality;
         AmmoType.DamageProfile.PainExpression.Formula.Parameters["degree"] = (int)defenseOutcome.Degree;
         AmmoType.DamageProfile.PainExpression.Formula.Parameters["pointblank"] = actor == target ? 1 : 0;
         AmmoType.DamageProfile.PainExpression.Formula.Parameters["inmelee"] = actor.MeleeRange ? 1 : 0;
         AmmoType.DamageProfile.PainExpression.Formula.Parameters["range"] = target.DistanceBetween(actor, 10);
-        AmmoType.DamageProfile.StunExpression.Formula.Parameters["quality"] = (int)ammo.Quality;
+        AmmoType.DamageProfile.StunExpression.Formula.Parameters["quality"] = effectiveQuality;
         AmmoType.DamageProfile.StunExpression.Formula.Parameters["degree"] = (int)defenseOutcome.Degree;
         AmmoType.DamageProfile.StunExpression.Formula.Parameters["pointblank"] = actor == target ? 1 : 0;
         AmmoType.DamageProfile.StunExpression.Formula.Parameters["inmelee"] = actor.MeleeRange ? 1 : 0;
@@ -522,9 +525,12 @@ public class AmmunitionGameItemComponent : GameItemComponent, IAmmo
         weaponType.DamageBonusExpression.Formula.Parameters["inmelee"] = actor.MeleeRange ? 1 : 0;
 
         double finalDamage = AmmoType.DamageProfile.DamageExpression.Evaluate(actor) +
-                          weaponType.DamageBonusExpression.Evaluate(actor, weaponType.FireTrait);
-        double finalPain = AmmoType.DamageProfile.PainExpression.Evaluate(actor);
-        double finalStun = AmmoType.DamageProfile.StunExpression.Evaluate(actor);
+                          weaponType.DamageBonusExpression.Evaluate(actor, weaponType.FireTrait) +
+                          payloadEffects.Sum(x => x.ProjectileDamageBonus);
+        double finalPain = AmmoType.DamageProfile.PainExpression.Evaluate(actor) +
+                           payloadEffects.Sum(x => x.ProjectilePainBonus);
+        double finalStun = AmmoType.DamageProfile.StunExpression.Evaluate(actor) +
+                           payloadEffects.Sum(x => x.ProjectileStunBonus);
         return new Damage
         {
             ActorOrigin = actor,

--- a/MudSharpCore/GameItems/Components/FuelGeneratorGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/FuelGeneratorGameItemComponent.cs
@@ -270,7 +270,10 @@ public class FuelGeneratorGameItemComponent : GameItemComponent, IProducePower, 
 
     public bool ProducingPower => SwitchedOn && LiquidMixture?.CountsAs(_prototype.LiquidFuel).Truth == true;
 
-    public double MaximumPowerInWatts => ProducingPower ? _prototype.WattageProvided : 0.0;
+    public double MaximumPowerInWatts => ProducingPower
+        ? _prototype.WattageProvided * Parent.EffectsOfType<IMagicPowerOrFuelEnhancementEffect>(x =>
+            x.AppliesToPoweredItem(Parent)).Aggregate(1.0, (current, effect) => current * effect.PowerProductionMultiplier)
+        : 0.0;
 
     private double _spikeDrawdown;
 
@@ -278,14 +281,14 @@ public class FuelGeneratorGameItemComponent : GameItemComponent, IProducePower, 
     {
         return SwitchedOn && ProducingPower &&
                _powerUsers.Sum(x => x.PowerConsumptionInWatts) + wattage + _spikeDrawdown <
-               _prototype.WattageProvided;
+               MaximumPowerInWatts;
     }
 
     public bool CanDrawdownSpike(double wattage)
     {
         return SwitchedOn &&
                _powerUsers.Sum(x => x.PowerConsumptionInWatts) + wattage + _spikeDrawdown <
-               _prototype.WattageProvided && ProducingPower;
+               MaximumPowerInWatts && ProducingPower;
     }
 
     public bool DrawdownSpike(double wattage)
@@ -307,7 +310,7 @@ public class FuelGeneratorGameItemComponent : GameItemComponent, IProducePower, 
 
             if (SwitchedOn &&
                 _powerUsers.Sum(x => x.PowerConsumptionInWatts) + item.PowerConsumptionInWatts <=
-                _prototype.WattageProvided)
+                MaximumPowerInWatts)
             {
                 _powerUsers.Add(item);
                 item.OnPowerCutIn();
@@ -463,7 +466,7 @@ public class FuelGeneratorGameItemComponent : GameItemComponent, IProducePower, 
             double cumulativeDraw = 0.0;
             foreach (IConsumePower item in _connectedConsumers)
             {
-                if (_prototype.WattageProvided - cumulativeDraw >= item.PowerConsumptionInWatts)
+                if (MaximumPowerInWatts - cumulativeDraw >= item.PowerConsumptionInWatts)
                 {
                     _powerUsers.Add(item);
                     item.OnPowerCutIn();
@@ -478,7 +481,9 @@ public class FuelGeneratorGameItemComponent : GameItemComponent, IProducePower, 
 
     private void HeartbeatManager_SecondHeartbeat()
     {
-        LiquidMixture?.RemoveLiquidVolume(_prototype.FuelPerSecond);
+        var fuelMultiplier = Parent.EffectsOfType<IMagicPowerOrFuelEnhancementEffect>(x => x.AppliesToPoweredItem(Parent))
+                                   .Aggregate(1.0, (current, effect) => current * effect.FuelUseMultiplier);
+        LiquidMixture?.RemoveLiquidVolume(_prototype.FuelPerSecond * fuelMultiplier);
         _spikeDrawdown = 0.0;
         if ((LiquidMixture?.TotalWeight ?? 0.0) <= 0)
         {

--- a/MudSharpCore/GameItems/Components/GridPowerSupplyGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/GridPowerSupplyGameItemComponent.cs
@@ -1,6 +1,7 @@
 #nullable enable annotations
 
 using MudSharp.Construction.Grids;
+using MudSharp.Effects.Interfaces;
 using MudSharp.Framework;
 using MudSharp.GameItems.Interfaces;
 using MudSharp.GameItems.Prototypes;
@@ -140,22 +141,27 @@ public class GridPowerSupplyGameItemComponent : GameItemComponent, IProducePower
 
     public bool CanBeginDrawDown(double wattage)
     {
-        return RegisteredDrawdown + wattage <= _prototype.Wattage;
+        return RegisteredDrawdown + wattage <= MaximumPowerInWatts;
     }
 
     public bool CanDrawdownSpike(double wattage)
     {
-        return ProducingPower && CurrentDrawdown + wattage <= _prototype.Wattage;
+        return ProducingPower && CurrentDrawdown + wattage <= MaximumPowerInWatts;
     }
 
     public bool DrawdownSpike(double wattage)
     {
         return ProducingPower &&
-               CurrentDrawdown + wattage <= _prototype.Wattage &&
+               CurrentDrawdown + wattage <= MaximumPowerInWatts &&
                (ElectricalGrid?.DrawdownSpike(wattage) ?? false);
     }
 
-    public double MaximumPowerInWatts => _prototype.Wattage;
+    public double MaximumPowerInWatts => _prototype.Wattage *
+                                         Parent.EffectsOfType<IMagicPowerOrFuelEnhancementEffect>(x =>
+                                                   x.AppliesToPoweredItem(Parent))
+                                               .Aggregate(1.0,
+                                                   (current, effect) => current *
+                                                                        effect.PowerProductionMultiplier);
 
     public bool ProducingPower => ElectricalGrid != null && _powered;
 

--- a/MudSharpCore/GameItems/Components/PowerPackGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/PowerPackGameItemComponent.cs
@@ -117,11 +117,15 @@ public class PowerPackGameItemComponent : GameItemComponent, ILaserPowerPack
     private Damage BuildDamage(ICharacter actor, IPerceiver target, IBodypart bodypart,
             IRangedWeaponType weaponType, OpposedOutcome defenseOutcome, double painMultiplier, double stunMultiplier)
     {
+        var payloadEffects = Parent.EffectsOfType<IMagicProjectilePayloadEffect>(x =>
+            x.AppliesToProjectileAttack(actor, target, Parent)).ToList();
         weaponType.DamageBonusExpression.Formula.Parameters["range"] = target.DistanceBetween(actor, 10);
-        weaponType.DamageBonusExpression.Formula.Parameters["quality"] = (int)Parent.Quality;
+        weaponType.DamageBonusExpression.Formula.Parameters["quality"] =
+            (int)Parent.Quality + (int)Math.Round(payloadEffects.Sum(x => x.ProjectileQualityBonus));
         weaponType.DamageBonusExpression.Formula.Parameters["degrees"] = (int)defenseOutcome.Degree;
 
-        double finalDamage = weaponType.DamageBonusExpression.Evaluate(actor);
+        double finalDamage = weaponType.DamageBonusExpression.Evaluate(actor) +
+                             payloadEffects.Sum(x => x.ProjectileDamageBonus);
         return new Damage
         {
             ActorOrigin = actor,
@@ -129,8 +133,8 @@ public class PowerPackGameItemComponent : GameItemComponent, ILaserPowerPack
             Bodypart = bodypart,
             DamageAmount = finalDamage,
             DamageType = DamageType.Burning,
-            PainAmount = finalDamage * painMultiplier,
-            StunAmount = finalDamage * stunMultiplier
+            PainAmount = finalDamage * painMultiplier + payloadEffects.Sum(x => x.ProjectilePainBonus),
+            StunAmount = finalDamage * stunMultiplier + payloadEffects.Sum(x => x.ProjectileStunBonus)
         };
     }
 

--- a/MudSharpCore/GameItems/Components/PoweredMachineBaseGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/PoweredMachineBaseGameItemComponent.cs
@@ -1,4 +1,5 @@
 ﻿using MudSharp.Character;
+using MudSharp.Effects.Interfaces;
 using MudSharp.Framework;
 using MudSharp.GameItems.Interfaces;
 using MudSharp.GameItems.Prototypes;
@@ -167,7 +168,11 @@ public abstract class PoweredMachineBaseGameItemComponent : GameItemComponent, I
 	}
 
 	public double PowerConsumptionInWatts =>
-		SwitchedOn ? _prototype.Wattage - _prototype.WattageDiscountPerQuality * (int)Parent.Quality : 0.0;
+		SwitchedOn
+			? (_prototype.Wattage - _prototype.WattageDiscountPerQuality * (int)Parent.Quality) *
+			  Parent.EffectsOfType<IMagicPowerOrFuelEnhancementEffect>(x => x.AppliesToPoweredItem(Parent))
+		            .Aggregate(1.0, (current, effect) => current * effect.PowerConsumptionMultiplier)
+			: 0.0;
 
     #endregion
 

--- a/MudSharpCore/GameItems/Components/ThrownWeaponGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/ThrownWeaponGameItemComponent.cs
@@ -5,6 +5,7 @@ using MudSharp.Combat;
 using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
 using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
 using MudSharp.Form.Shape;
 using MudSharp.Framework;
 using MudSharp.GameItems.Interfaces;
@@ -190,7 +191,10 @@ public class ThrownWeaponGameItemComponent : GameItemComponent, IRangedWeapon, I
                     target, target, Parent), style: OutputStyle.CombatMessage, flags: OutputFlags.InnerWrap));
         }
 
-        _prototype.RangedWeaponType.DamageBonusExpression.Formula.Parameters["quality"] = (int)Parent.Quality;
+        var payloadEffects = Parent.EffectsOfType<IMagicProjectilePayloadEffect>(x =>
+            x.AppliesToProjectileAttack(actor, target, Parent)).ToList();
+        _prototype.RangedWeaponType.DamageBonusExpression.Formula.Parameters["quality"] =
+            (int)Parent.Quality + (int)Math.Round(payloadEffects.Sum(x => x.ProjectileQualityBonus));
         _prototype.RangedWeaponType.DamageBonusExpression.Formula.Parameters["degrees"] =
             (int)defenseOutcome.Degree;
         _prototype.RangedWeaponType.DamageBonusExpression.Formula.Parameters["range"] = actor.DistanceBetween(
@@ -202,8 +206,10 @@ public class ThrownWeaponGameItemComponent : GameItemComponent, IRangedWeapon, I
             Bodypart = bodypart,
             DamageAmount =
                 _prototype.RangedWeaponType.DamageBonusExpression.Evaluate(actor,
-                    _prototype.RangedWeaponType.FireTrait),
+                    _prototype.RangedWeaponType.FireTrait) + payloadEffects.Sum(x => x.ProjectileDamageBonus),
             DamageType = _prototype.MeleeWeaponType.Attacks.FirstMax(x => x.Weighting).Profile.DamageType,
+            PainAmount = payloadEffects.Sum(x => x.ProjectilePainBonus),
+            StunAmount = payloadEffects.Sum(x => x.ProjectileStunBonus),
             LodgableItem = Parent
         };
 

--- a/MudSharpCore/GameItems/Components/UnlimitedGeneratorGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/UnlimitedGeneratorGameItemComponent.cs
@@ -1,4 +1,5 @@
 ﻿using MudSharp.Character;
+using MudSharp.Effects.Interfaces;
 using MudSharp.Form.Shape;
 using MudSharp.Framework;
 using MudSharp.FutureProg;
@@ -162,7 +163,10 @@ public class UnlimitedGeneratorGameItemComponent : GameItemComponent, IProducePo
     public double FuelLevel => 1.0;
     public bool ProducingPower => SwitchedOn;
 
-    public double MaximumPowerInWatts => ProducingPower ? _prototype.WattageProvided : 0.0;
+    public double MaximumPowerInWatts => ProducingPower
+        ? _prototype.WattageProvided * Parent.EffectsOfType<IMagicPowerOrFuelEnhancementEffect>(x =>
+            x.AppliesToPoweredItem(Parent)).Aggregate(1.0, (current, effect) => current * effect.PowerProductionMultiplier)
+        : 0.0;
 
     private double _spikeDrawdown;
 
@@ -170,14 +174,14 @@ public class UnlimitedGeneratorGameItemComponent : GameItemComponent, IProducePo
     {
         return SwitchedOn && ProducingPower &&
                _powerUsers.Sum(x => x.PowerConsumptionInWatts) + wattage + _spikeDrawdown <
-               _prototype.WattageProvided;
+               MaximumPowerInWatts;
     }
 
     public bool CanDrawdownSpike(double wattage)
     {
         return SwitchedOn &&
                _powerUsers.Sum(x => x.PowerConsumptionInWatts) + wattage + _spikeDrawdown <
-               _prototype.WattageProvided && ProducingPower;
+               MaximumPowerInWatts && ProducingPower;
     }
 
     public bool DrawdownSpike(double wattage)
@@ -199,7 +203,7 @@ public class UnlimitedGeneratorGameItemComponent : GameItemComponent, IProducePo
 
             if (SwitchedOn &&
                 _powerUsers.Sum(x => x.PowerConsumptionInWatts) + item.PowerConsumptionInWatts <=
-                _prototype.WattageProvided)
+                MaximumPowerInWatts)
             {
                 _powerUsers.Add(item);
                 item.OnPowerCutIn();
@@ -275,7 +279,7 @@ public class UnlimitedGeneratorGameItemComponent : GameItemComponent, IProducePo
             double cumulativeDraw = 0.0;
             foreach (IConsumePower item in _connectedConsumers)
             {
-                if (_prototype.WattageProvided - cumulativeDraw >= item.PowerConsumptionInWatts)
+                if (MaximumPowerInWatts - cumulativeDraw >= item.PowerConsumptionInWatts)
                 {
                     _powerUsers.Add(item);
                     item.OnPowerCutIn();

--- a/MudSharpCore/Magic/Powers/ConnectMindPower.cs
+++ b/MudSharpCore/Magic/Powers/ConnectMindPower.cs
@@ -583,6 +583,12 @@ public class ConnectMindPower : SustainedMagicPower
 
     public string GetAppropriateConnectEmote(ICharacter connecter, ICharacter connectee)
     {
+        var concealment = GetMindConcealment(connecter, connectee, School);
+        if (concealment is not null)
+        {
+            return string.Format(EmoteForConnect, concealment.UnknownIdentityDescription.ColourCharacter());
+        }
+
         if (TargetCanSeeIdentityProg.ExecuteBool(connecter, connectee))
         {
             return string.Format(EmoteForConnect, "$0");
@@ -598,6 +604,12 @@ public class ConnectMindPower : SustainedMagicPower
             return null;
         }
 
+        var concealment = GetMindConcealment(connecter, connectee, School);
+        if (concealment is not null)
+        {
+            return string.Format(EmoteForDisconnect, concealment.UnknownIdentityDescription.ColourCharacter());
+        }
+
         if (TargetCanSeeIdentityProg.ExecuteBool(connecter, connectee))
         {
             return string.Format(EmoteForDisconnect, "$0");
@@ -608,6 +620,12 @@ public class ConnectMindPower : SustainedMagicPower
 
     public string GetAppropriateHowSeen(ICharacter connecter, ICharacter connectee)
     {
+        var concealment = GetMindConcealment(connecter, connectee, School);
+        if (concealment is not null)
+        {
+            return concealment.UnknownIdentityDescription.ColourCharacter();
+        }
+
         if (TargetCanSeeIdentityProg.ExecuteBool(connecter, connectee))
         {
             return connecter.HowSeen(connectee, flags: PerceiveIgnoreFlags.IgnoreConsciousness);

--- a/MudSharpCore/Magic/Powers/MagicPowerBase.cs
+++ b/MudSharpCore/Magic/Powers/MagicPowerBase.cs
@@ -1,6 +1,7 @@
 ﻿using MudSharp.Character;
 using MudSharp.Database;
 using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
 using MudSharp.Framework;
 using MudSharp.Framework.Save;
 using MudSharp.FutureProg;
@@ -284,10 +285,17 @@ public abstract class MagicPowerBase : SaveableItem, IMagicPower
 		return true;
 	}
 
-	protected virtual bool TargetIsValid(ICharacter owner, ICharacter target)
+    protected virtual bool TargetIsValid(ICharacter owner, ICharacter target)
 	{
 		return TargetFilterFunction(owner, target) &&
 		       MagicInterdictionHelper.GetInterdiction(owner, target, School, false) is null;
+	}
+
+	protected static IMindContactConcealmentEffect GetMindConcealment(ICharacter source, ICharacter observer,
+		IMagicSchool school)
+	{
+		return source.EffectsOfType<IMindContactConcealmentEffect>()
+		             .FirstOrDefault(x => x.ConcealsIdentityFrom(source, observer, school));
 	}
 
     public bool TargetIsInRange(ICharacter owner, ICharacter target, MagicPowerDistance distance)

--- a/MudSharpCore/Magic/Powers/MindAuditPower.cs
+++ b/MudSharpCore/Magic/Powers/MindAuditPower.cs
@@ -189,12 +189,21 @@ public class MindAuditPower : MagicPowerBase
                 difficulty = Difficulty.Normal;
             }
 
+            var concealment = GetMindConcealment(effect.OriginatorCharacter, actor, effect.School);
+            if (concealment is not null)
+            {
+                difficulty = difficulty.StageUp(concealment.AuditDifficultyStages);
+            }
+
             if (results[difficulty].Outcome < MinimumSuccessThreshold)
             {
                 continue;
             }
 
-            sb.AppendLine($"You detect the presence of {effect.OriginatorCharacter.HowSeen(actor, flags: PerceiveIgnoreFlags.IgnoreCanSee | PerceiveIgnoreFlags.IgnoreDisguises)} in your mind.");
+            var identity = concealment?.UnknownIdentityDescription.ColourCharacter() ??
+                           effect.OriginatorCharacter.HowSeen(actor,
+                               flags: PerceiveIgnoreFlags.IgnoreCanSee | PerceiveIgnoreFlags.IgnoreDisguises);
+            sb.AppendLine($"You detect the presence of {identity} in your mind.");
 
             if (!string.IsNullOrEmpty(EchoToDetectedTarget) && ShouldEchoDetectionProg.Execute<bool?>(effect.OriginatorCharacter, actor) == true)
             {

--- a/MudSharpCore/Magic/Powers/MindBroadcastPower.cs
+++ b/MudSharpCore/Magic/Powers/MindBroadcastPower.cs
@@ -321,6 +321,12 @@ public class MindBroadcastPower : MagicPowerBase
 
     public string GetAppropriateHowSeen(ICharacter connecter, ICharacter connectee)
     {
+        var concealment = GetMindConcealment(connecter, connectee, School);
+        if (concealment is not null)
+        {
+            return concealment.UnknownIdentityDescription.ColourCharacter();
+        }
+
         if (TargetCanSeeIdentityProg.ExecuteBool(connecter, connectee))
         {
             return connecter.HowSeen(connectee, flags: PerceiveIgnoreFlags.IgnoreConsciousness);
@@ -331,6 +337,12 @@ public class MindBroadcastPower : MagicPowerBase
 
     public string GetAppropriateTargetEmote(ICharacter connecter, ICharacter connectee)
     {
+        var concealment = GetMindConcealment(connecter, connectee, School);
+        if (concealment is not null)
+        {
+            return string.Format(TargetEmoteText, concealment.UnknownIdentityDescription.ColourCharacter(), "{0}");
+        }
+
         if (TargetCanSeeIdentityProg.ExecuteBool(connecter, connectee))
         {
             return string.Format(TargetEmoteText, "$0", "{0}");

--- a/MudSharpCore/Magic/Powers/MindConcealPower.cs
+++ b/MudSharpCore/Magic/Powers/MindConcealPower.cs
@@ -1,0 +1,483 @@
+#nullable enable
+
+using MudSharp.Body.Traits;
+using MudSharp.Character;
+using MudSharp.Effects.Concrete;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.Models;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Outputs;
+using MudSharp.PerceptionEngine.Parsers;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+namespace MudSharp.Magic.Powers;
+
+public class MindConcealPower : SustainedMagicPower
+{
+	public override string PowerType => "Mind Conceal";
+	public override string DatabaseType => "mindconceal";
+
+	public static void RegisterLoader()
+	{
+		MagicPowerFactory.RegisterLoader("mindconceal", (power, gameworld) => new MindConcealPower(power, gameworld));
+		MagicPowerFactory.RegisterBuilderLoader("mindconceal", (gameworld, school, name, actor, command) =>
+		{
+			if (command.IsFinished)
+			{
+				actor.OutputHandler.Send("Which skill do you want to use for the skill check?");
+				return null;
+			}
+
+			var skill = gameworld.Traits.GetByIdOrName(command.SafeRemainingArgument);
+			if (skill is null)
+			{
+				actor.OutputHandler.Send("There is no such skill or attribute.");
+				return null;
+			}
+
+			return new MindConcealPower(gameworld, school, name, skill);
+		});
+	}
+
+	private MindConcealPower(IFuturemud gameworld, IMagicSchool school, string name, ITraitDefinition trait) : base(
+		gameworld, school, name)
+	{
+		Blurb = "Conceal your identity from mental contacts";
+		_showHelpText =
+			$"You can use {school.SchoolVerb.ToUpperInvariant()} MINDCONCEAL to sustain a hidden mental identity, and {school.SchoolVerb.ToUpperInvariant()} ENDMINDCONCEAL to reveal yourself again.";
+		BeginVerb = "mindconceal";
+		EndVerb = "endmindconceal";
+		SkillCheckTrait = trait;
+		SkillCheckDifficulty = Difficulty.Easy;
+		MinimumSuccessThreshold = Outcome.MinorFail;
+		ConcentrationPointsToSustain = 1.0;
+		UnknownIdentityDescription = "an unknown presence";
+		AuditDifficultyStages = 1;
+		IncludeSubschools = true;
+		AppliesToCharacterProg = Gameworld.AlwaysTrueProg;
+		EmoteForBegin = "";
+		EmoteForBeginSelf = "You veil your mental signature.";
+		EmoteForEnd = "";
+		EmoteForEndSelf = "You let the veil fall away from your mental signature.";
+		BeginWhenAlreadySustainingError = "You are already concealing your mental identity.";
+		EndWhenNotSustainingError = "You are not currently concealing your mental identity.";
+		DoDatabaseInsert();
+	}
+
+	protected MindConcealPower(MagicPower power, IFuturemud gameworld) : base(power, gameworld)
+	{
+		var root = XElement.Parse(power.Definition);
+		BeginVerb = root.Element("BeginVerb")?.Value.ToLowerInvariant() ?? "mindconceal";
+		EndVerb = root.Element("EndVerb")?.Value.ToLowerInvariant() ?? "endmindconceal";
+		SkillCheckDifficulty = (Difficulty)int.Parse(root.Element("SkillCheckDifficulty")?.Value ??
+		                                              ((int)Difficulty.Easy).ToString());
+		var skillId = long.Parse(root.Element("SkillCheckTrait")!.Value);
+		SkillCheckTrait = Gameworld.Traits.Get(skillId) ??
+		                  throw new ApplicationException(
+			                  $"The MindConcealPower #{Id} ({Name}) had a SkillCheckTrait element that pointed to invalid trait #{skillId}.");
+		MinimumSuccessThreshold = (Outcome)int.Parse(root.Element("MinimumSuccessThreshold")?.Value ??
+		                                             ((int)Outcome.MinorFail).ToString());
+		UnknownIdentityDescription = root.Element("UnknownIdentityDescription")?.Value ?? "an unknown presence";
+		AuditDifficultyStages = int.Parse(root.Element("AuditDifficultyStages")?.Value ?? "1");
+		IncludeSubschools = bool.Parse(root.Element("IncludeSubschools")?.Value ?? "true");
+		var progText = root.Element("AppliesToCharacterProg")?.Value ?? Gameworld.AlwaysTrueProg.Id.ToString();
+		AppliesToCharacterProg = Gameworld.FutureProgs.GetByIdOrName(progText) ??
+		                         throw new ApplicationException(
+			                         $"The MindConcealPower #{Id} ({Name}) had an AppliesToCharacterProg element that pointed to invalid prog {progText}.");
+		EmoteForBegin = root.Element("EmoteForBegin")?.Value ?? "";
+		EmoteForBeginSelf = root.Element("EmoteForBeginSelf")?.Value ?? "You veil your mental signature.";
+		EmoteForEnd = root.Element("EmoteForEnd")?.Value ?? "";
+		EmoteForEndSelf = root.Element("EmoteForEndSelf")?.Value ??
+		                   "You let the veil fall away from your mental signature.";
+		BeginWhenAlreadySustainingError = root.Element("BeginWhenAlreadySustainingError")?.Value ??
+		                                  "You are already concealing your mental identity.";
+		EndWhenNotSustainingError = root.Element("EndWhenNotSustainingError")?.Value ??
+		                            "You are not currently concealing your mental identity.";
+	}
+
+	protected override XElement SaveDefinition()
+	{
+		var definition = new XElement("Definition",
+			new XElement("BeginVerb", BeginVerb),
+			new XElement("EndVerb", EndVerb),
+			new XElement("SkillCheckDifficulty", (int)SkillCheckDifficulty),
+			new XElement("SkillCheckTrait", SkillCheckTrait.Id),
+			new XElement("MinimumSuccessThreshold", (int)MinimumSuccessThreshold),
+			new XElement("AppliesToCharacterProg", AppliesToCharacterProg.Id),
+			new XElement("UnknownIdentityDescription", new XCData(UnknownIdentityDescription)),
+			new XElement("AuditDifficultyStages", AuditDifficultyStages),
+			new XElement("IncludeSubschools", IncludeSubschools),
+			new XElement("EmoteForBegin", new XCData(EmoteForBegin)),
+			new XElement("EmoteForBeginSelf", new XCData(EmoteForBeginSelf)),
+			new XElement("EmoteForEnd", new XCData(EmoteForEnd)),
+			new XElement("EmoteForEndSelf", new XCData(EmoteForEndSelf)),
+			new XElement("BeginWhenAlreadySustainingError", new XCData(BeginWhenAlreadySustainingError)),
+			new XElement("EndWhenNotSustainingError", new XCData(EndWhenNotSustainingError))
+		);
+		AddBaseDefinition(definition);
+		SaveSustainedDefinition(definition);
+		return definition;
+	}
+
+	public bool AppliesToSchool(IMagicSchool school)
+	{
+		return school == School || IncludeSubschools && school.IsChildSchool(School);
+	}
+
+	public override void UseCommand(ICharacter actor, string verb, StringStack command)
+	{
+		var (truth, missing) = CanAffordToInvokePower(actor, verb);
+		if (!truth)
+		{
+			actor.OutputHandler.Send(
+				$"You can't do that because you lack sufficient {missing.Name.Colour(Telnet.BoldMagenta)}.");
+			return;
+		}
+
+		if (verb.EqualTo(BeginVerb))
+		{
+			UseCommandBegin(actor);
+			return;
+		}
+
+		UseCommandEnd(actor);
+	}
+
+	private void UseCommandBegin(ICharacter actor)
+	{
+		if (actor.EffectsOfType<MindConcealmentEffect>().Any(x => x.PowerOrigin == this))
+		{
+			actor.OutputHandler.Send(BeginWhenAlreadySustainingError);
+			return;
+		}
+
+		if (CanInvokePowerProg.ExecuteBool(actor) == false)
+		{
+			actor.OutputHandler.Send(WhyCantInvokePowerProg.Execute(actor)?.ToString() ?? "You cannot use that power.");
+			return;
+		}
+
+		var check = Gameworld.GetCheck(CheckType.MagicTelepathyCheck);
+		var result = check.Check(actor, SkillCheckDifficulty, SkillCheckTrait);
+		if (result < MinimumSuccessThreshold)
+		{
+			actor.OutputHandler.Send("You fail to conceal your mental identity.");
+			ConsumePowerCosts(actor, BeginVerb);
+			return;
+		}
+
+		actor.OutputHandler.Send(EmoteForBeginSelf);
+		if (!string.IsNullOrWhiteSpace(EmoteForBegin))
+		{
+			actor.OutputHandler.Handle(new EmoteOutput(new Emote(EmoteForBegin, actor, actor),
+				flags: OutputFlags.SuppressSource), OutputRange.Local);
+		}
+
+		actor.AddEffect(new MindConcealmentEffect(actor, this), GetDuration(result.SuccessDegrees()));
+		ConsumePowerCosts(actor, BeginVerb);
+	}
+
+	private void UseCommandEnd(ICharacter actor)
+	{
+		var effects = actor.EffectsOfType<MindConcealmentEffect>().Where(x => x.PowerOrigin == this).ToList();
+		if (!effects.Any())
+		{
+			actor.OutputHandler.Send(EndWhenNotSustainingError);
+			return;
+		}
+
+		foreach (var effect in effects)
+		{
+			actor.RemoveEffect(effect, true);
+		}
+
+		ConsumePowerCosts(actor, EndVerb);
+	}
+
+	protected override void ExpireSustainedEffect(ICharacter actor)
+	{
+		foreach (var effect in actor.EffectsOfType<MindConcealmentEffect>().Where(x => x.PowerOrigin == this).ToList())
+		{
+			actor.RemoveEffect(effect, true);
+		}
+	}
+
+	public override IEnumerable<string> Verbs => new[] { BeginVerb, EndVerb };
+
+	public string BeginVerb { get; protected set; }
+	public string EndVerb { get; protected set; }
+	public Difficulty SkillCheckDifficulty { get; protected set; }
+	public ITraitDefinition SkillCheckTrait { get; protected set; }
+	public Outcome MinimumSuccessThreshold { get; protected set; }
+	public IFutureProg AppliesToCharacterProg { get; protected set; }
+	public string UnknownIdentityDescription { get; protected set; }
+	public int AuditDifficultyStages { get; protected set; }
+	public bool IncludeSubschools { get; protected set; }
+	public string EmoteForBegin { get; protected set; }
+	public string EmoteForBeginSelf { get; protected set; }
+	public string EmoteForEnd { get; protected set; }
+	public string EmoteForEndSelf { get; protected set; }
+	public string BeginWhenAlreadySustainingError { get; protected set; }
+	public string EndWhenNotSustainingError { get; protected set; }
+
+	protected override void ShowSubtype(ICharacter actor, StringBuilder sb)
+	{
+		sb.AppendLine($"Begin Verb: {BeginVerb.ColourCommand()}");
+		sb.AppendLine($"End Verb: {EndVerb.ColourCommand()}");
+		sb.AppendLine($"Skill Check Trait: {SkillCheckTrait.Name.ColourValue()}");
+		sb.AppendLine($"Skill Check Difficulty: {SkillCheckDifficulty.DescribeColoured()}");
+		sb.AppendLine($"Minimum Success Threshold: {MinimumSuccessThreshold.DescribeColour()}");
+		sb.AppendLine($"Unknown Identity Desc: {UnknownIdentityDescription.ColourCharacter()}");
+		sb.AppendLine($"Audit Difficulty Stages: {AuditDifficultyStages.ToString("N0", actor).ColourValue()}");
+		sb.AppendLine($"Includes Subschools: {IncludeSubschools.ToColouredString()}");
+		sb.AppendLine($"Applies Character Prog: {AppliesToCharacterProg.MXPClickableFunctionName()}");
+		sb.AppendLine();
+		sb.AppendLine("Emotes:");
+		sb.AppendLine();
+		sb.AppendLine($"Begin Emote: {EmoteForBegin.ColourCommand()}");
+		sb.AppendLine($"Begin Self Emote: {EmoteForBeginSelf.ColourCommand()}");
+		sb.AppendLine($"End Emote: {EmoteForEnd.ColourCommand()}");
+		sb.AppendLine($"End Self Emote: {EmoteForEndSelf.ColourCommand()}");
+	}
+
+	protected override string SubtypeHelpText => @"	#3begin <verb>#0 - sets the verb to activate this power
+	#3end <verb>#0 - sets the verb to end this power
+	#3skill <which>#0 - sets the skill used in the skill check
+	#3difficulty <difficulty>#0 - sets the difficulty of the skill check
+	#3threshold <outcome>#0 - sets the minimum outcome for skill success
+	#3unknown <desc>#0 - sets the replacement identity shown while concealed
+	#3audit <stages>#0 - sets extra difficulty stages for audit/trace attempts
+	#3subschools#0 - toggles whether the concealment covers child schools
+	#3applies <prog>#0 - sets a prog controlling which observers are affected
+	#3beginemote <emote>#0 - sets the emote for beginning this power
+	#3beginemoteself <emote>#0 - sets the self emote for beginning this power
+	#3endemote <emote>#0 - sets the emote for ending this power
+	#3endemoteself <emote>#0 - sets the self emote for ending this power";
+
+	public override bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "begin":
+			case "beginverb":
+			case "verb":
+				return BuildingCommandBegin(actor, command);
+			case "end":
+			case "endverb":
+				return BuildingCommandEnd(actor, command);
+			case "skill":
+			case "trait":
+				return BuildingCommandSkill(actor, command);
+			case "difficulty":
+				return BuildingCommandDifficulty(actor, command);
+			case "threshold":
+				return BuildingCommandThreshold(actor, command);
+			case "unknown":
+				return BuildingCommandUnknown(actor, command);
+			case "audit":
+				return BuildingCommandAudit(actor, command);
+			case "subschools":
+				return BuildingCommandSubschools(actor);
+			case "applies":
+			case "appliesprog":
+				return BuildingCommandApplies(actor, command);
+			case "beginemote":
+				return BuildingCommandBeginEmote(actor, command);
+			case "beginemoteself":
+				return BuildingCommandBeginEmoteSelf(actor, command);
+			case "endemote":
+				return BuildingCommandEndEmote(actor, command);
+			case "endemoteself":
+				return BuildingCommandEndEmoteSelf(actor, command);
+		}
+
+		return base.BuildingCommand(actor, command.GetUndo());
+	}
+
+	private bool BuildingCommandBegin(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("What verb should activate this power?");
+			return false;
+		}
+
+		BeginVerb = command.SafeRemainingArgument.ToLowerInvariant();
+		Changed = true;
+		actor.OutputHandler.Send($"This power is now activated with {BeginVerb.ColourCommand()}.");
+		return true;
+	}
+
+	private bool BuildingCommandEnd(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("What verb should end this power?");
+			return false;
+		}
+
+		EndVerb = command.SafeRemainingArgument.ToLowerInvariant();
+		Changed = true;
+		actor.OutputHandler.Send($"This power is now ended with {EndVerb.ColourCommand()}.");
+		return true;
+	}
+
+	private bool BuildingCommandSkill(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which skill or attribute should be used for this power?");
+			return false;
+		}
+
+		var skill = Gameworld.Traits.GetByIdOrName(command.SafeRemainingArgument);
+		if (skill is null)
+		{
+			actor.OutputHandler.Send("There is no such skill or attribute.");
+			return false;
+		}
+
+		SkillCheckTrait = skill;
+		Changed = true;
+		actor.OutputHandler.Send($"This power now uses {skill.Name.ColourValue()}.");
+		return true;
+	}
+
+	private bool BuildingCommandDifficulty(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !command.SafeRemainingArgument.TryParseEnum<Difficulty>(out var value))
+		{
+			actor.OutputHandler.Send("You must specify a valid difficulty.");
+			return false;
+		}
+
+		SkillCheckDifficulty = value;
+		Changed = true;
+		actor.OutputHandler.Send($"The activation check is now {value.DescribeColoured()}.");
+		return true;
+	}
+
+	private bool BuildingCommandThreshold(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !command.SafeRemainingArgument.TryParseEnum<Outcome>(out var value))
+		{
+			actor.OutputHandler.Send("You must specify a valid outcome.");
+			return false;
+		}
+
+		MinimumSuccessThreshold = value;
+		Changed = true;
+		actor.OutputHandler.Send($"The power user must now achieve {value.DescribeColour()}.");
+		return true;
+	}
+
+	private bool BuildingCommandUnknown(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("What unknown identity description should observers see?");
+			return false;
+		}
+
+		UnknownIdentityDescription = command.SafeRemainingArgument;
+		Changed = true;
+		actor.OutputHandler.Send($"Concealed observers now see {UnknownIdentityDescription.ColourCharacter()}.");
+		return true;
+	}
+
+	private bool BuildingCommandAudit(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !int.TryParse(command.SafeRemainingArgument, out var value))
+		{
+			actor.OutputHandler.Send("How many difficulty stages should this add to audit attempts?");
+			return false;
+		}
+
+		AuditDifficultyStages = value;
+		Changed = true;
+		actor.OutputHandler.Send($"Audit attempts are now shifted by {value.ToString("N0", actor).ColourValue()} stages.");
+		return true;
+	}
+
+	private bool BuildingCommandSubschools(ICharacter actor)
+	{
+		IncludeSubschools = !IncludeSubschools;
+		Changed = true;
+		actor.OutputHandler.Send($"This concealment will {IncludeSubschools.NowNoLonger()} apply to child schools.");
+		return true;
+	}
+
+	private bool BuildingCommandApplies(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which prog should control which observers are affected?");
+			return false;
+		}
+
+		var prog = new ProgLookupFromBuilderInput(Gameworld, actor, command.SafeRemainingArgument,
+			ProgVariableTypes.Boolean,
+			[
+				[ProgVariableTypes.Character, ProgVariableTypes.Character]
+			]).LookupProg();
+		if (prog is null)
+		{
+			return false;
+		}
+
+		AppliesToCharacterProg = prog;
+		Changed = true;
+		actor.OutputHandler.Send($"This concealment now uses {prog.MXPClickableFunctionName()} to decide observers.");
+		return true;
+	}
+
+	private bool BuildingCommandBeginEmote(ICharacter actor, StringStack command)
+	{
+		EmoteForBegin = command.SafeRemainingArgument;
+		Changed = true;
+		actor.OutputHandler.Send("The begin emote has been updated.");
+		return true;
+	}
+
+	private bool BuildingCommandBeginEmoteSelf(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("What should the caster see when beginning this power?");
+			return false;
+		}
+
+		EmoteForBeginSelf = command.SafeRemainingArgument;
+		Changed = true;
+		actor.OutputHandler.Send("The begin self emote has been updated.");
+		return true;
+	}
+
+	private bool BuildingCommandEndEmote(ICharacter actor, StringStack command)
+	{
+		EmoteForEnd = command.SafeRemainingArgument;
+		Changed = true;
+		actor.OutputHandler.Send("The end emote has been updated.");
+		return true;
+	}
+
+	private bool BuildingCommandEndEmoteSelf(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("What should the caster see when ending this power?");
+			return false;
+		}
+
+		EmoteForEndSelf = command.SafeRemainingArgument;
+		Changed = true;
+		actor.OutputHandler.Send("The end self emote has been updated.");
+		return true;
+	}
+}

--- a/MudSharpCore/Magic/Powers/MindExpelPower.cs
+++ b/MudSharpCore/Magic/Powers/MindExpelPower.cs
@@ -195,7 +195,11 @@ public class MindExpelPower : MagicPowerBase
                 continue;
             }
 
-            sb.AppendLine($"You successfully expel the presence of {effect.OriginatorCharacter.HowSeen(actor, flags: PerceiveIgnoreFlags.IgnoreCanSee | PerceiveIgnoreFlags.IgnoreDisguises)} from your mind.");
+            var concealment = GetMindConcealment(effect.OriginatorCharacter, actor, effect.School);
+            var identity = concealment?.UnknownIdentityDescription.ColourCharacter() ??
+                           effect.OriginatorCharacter.HowSeen(actor,
+                               flags: PerceiveIgnoreFlags.IgnoreCanSee | PerceiveIgnoreFlags.IgnoreDisguises);
+            sb.AppendLine($"You successfully expel the presence of {identity} from your mind.");
 
             if (!string.IsNullOrEmpty(EchoToExpelledTarget))
             {

--- a/MudSharpCore/Magic/Powers/MindSayPower.cs
+++ b/MudSharpCore/Magic/Powers/MindSayPower.cs
@@ -315,6 +315,12 @@ public class MindSayPower : MagicPowerBase
 
     public string GetAppropriateHowSeen(ICharacter connecter, ICharacter connectee)
     {
+        var concealment = GetMindConcealment(connecter, connectee, School);
+        if (concealment is not null)
+        {
+            return concealment.UnknownIdentityDescription.ColourCharacter();
+        }
+
         if (TargetCanSeeIdentityProg.ExecuteBool(connecter, connectee))
         {
             return connecter.HowSeen(connectee, flags: PerceiveIgnoreFlags.IgnoreConsciousness);
@@ -325,6 +331,12 @@ public class MindSayPower : MagicPowerBase
 
     public string GetAppropriateTargetEmote(ICharacter connecter, ICharacter connectee)
     {
+        var concealment = GetMindConcealment(connecter, connectee, School);
+        if (concealment is not null)
+        {
+            return string.Format(TargetEmoteText, concealment.UnknownIdentityDescription.ColourCharacter());
+        }
+
         if (TargetCanSeeIdentityProg.ExecuteBool(connecter, connectee))
         {
             return string.Format(TargetEmoteText, "$0");

--- a/MudSharpCore/Magic/SpellEffects/DispelMagicEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/DispelMagicEffect.cs
@@ -1,0 +1,425 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Effects;
+using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Concrete.SpellEffects;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace MudSharp.Magic.SpellEffects;
+
+public enum DispelMagicMode
+{
+	Remove = 0,
+	Shorten = 1
+}
+
+public enum DispelCasterPolicy
+{
+	OwnOnly = 0,
+	AnyCaster = 1,
+	OthersOnly = 2
+}
+
+public class DispelMagicEffect : IMagicSpellEffectTemplate
+{
+	private static readonly Dictionary<string, Func<IMagicSpellEffect, bool>> EffectKeyMatchers =
+		new(StringComparer.InvariantCultureIgnoreCase)
+		{
+			{ "any", _ => true },
+			{ "spell", _ => true },
+			{ "magictag", x => x is IMagicTagEffect },
+			{ "itemenchant", x => x is SpellItemEnchantmentEffect },
+			{ "portal", x => x is SpellPortalEffect },
+			{ "planarstate", x => x is SpellPlanarStateEffect },
+			{ "roomward", x => x is SpellRoomWardEffect },
+			{ "personalward", x => x is SpellPersonalWardEffect },
+			{ "exitbarrier", x => x is SpellExitBarrierEffect },
+			{ "subjectivedesc", x => x is SpellSubjectiveDescriptionEffect },
+			{ "transformform", x => x is SpellTransformFormEffect },
+			{ "projectile", x => x is IMagicProjectilePayloadEffect },
+			{ "crafttool", x => x is IMagicCraftToolEnhancementEffect },
+			{ "powerfuel", x => x is IMagicPowerOrFuelEnhancementEffect },
+			{ "itemevent", x => x is IMagicItemEventEffect }
+		};
+
+	public static void RegisterFactory()
+	{
+		SpellEffectFactory.RegisterLoadTimeFactory("dispelmagic", (root, spell) => new DispelMagicEffect(root, spell));
+		SpellEffectFactory.RegisterBuilderFactory("dispelmagic", BuilderFactory,
+			"Removes or shortens matching magical spell effects",
+			HelpText,
+			true,
+			true,
+			SpellTriggerFactory.MagicTriggerTypes
+				.Where(x => IsCompatibleWithTrigger(SpellTriggerFactory.BuilderInfoForType(x).TargetTypes))
+				.ToArray());
+	}
+
+	private static (IMagicSpellEffectTemplate Trigger, string Error) BuilderFactory(StringStack commands,
+		IMagicSpell spell)
+	{
+		return (new DispelMagicEffect(new XElement("Effect",
+			new XAttribute("type", "dispelmagic"),
+			new XElement("Mode", (int)DispelMagicMode.Remove),
+			new XElement("CasterPolicy", (int)DispelCasterPolicy.OwnOnly),
+			new XElement("AllowHostile", false),
+			new XElement("IncludeSubschools", true),
+			new XElement("ShortenSeconds", 60.0),
+			new XElement("SpellId", 0L),
+			new XElement("SchoolId", 0L),
+			new XElement("Tag", new XCData(string.Empty)),
+			new XElement("TagValue", new XCData(string.Empty)),
+			new XElement("MatchTagValue", false),
+			new XElement("EffectKey", new XCData("any"))
+		), spell), string.Empty);
+	}
+
+	private DispelMagicEffect(XElement root, IMagicSpell spell)
+	{
+		Spell = spell;
+		Mode = (DispelMagicMode)int.Parse(root.Element("Mode")?.Value ?? "0");
+		CasterPolicy = (DispelCasterPolicy)int.Parse(root.Element("CasterPolicy")?.Value ?? "0");
+		AllowHostile = bool.Parse(root.Element("AllowHostile")?.Value ?? "false");
+		IncludeSubschools = bool.Parse(root.Element("IncludeSubschools")?.Value ?? "true");
+		ShortenDuration = TimeSpan.FromSeconds(double.Parse(root.Element("ShortenSeconds")?.Value ?? "60"));
+		SpellId = long.Parse(root.Element("SpellId")?.Value ?? "0");
+		SchoolId = long.Parse(root.Element("SchoolId")?.Value ?? "0");
+		Tag = root.Element("Tag")?.Value ?? string.Empty;
+		TagValue = root.Element("TagValue")?.Value ?? string.Empty;
+		MatchTagValue = bool.Parse(root.Element("MatchTagValue")?.Value ?? "false");
+		EffectKey = root.Element("EffectKey")?.Value ?? "any";
+	}
+
+	public IMagicSpell Spell { get; }
+	public IFuturemud Gameworld => Spell.Gameworld;
+	public DispelMagicMode Mode { get; private set; }
+	public DispelCasterPolicy CasterPolicy { get; private set; }
+	public bool AllowHostile { get; private set; }
+	public bool IncludeSubschools { get; private set; }
+	public TimeSpan ShortenDuration { get; private set; }
+	public long SpellId { get; private set; }
+	public long SchoolId { get; private set; }
+	public string Tag { get; private set; }
+	public string TagValue { get; private set; }
+	public bool MatchTagValue { get; private set; }
+	public string EffectKey { get; private set; }
+	public bool IsInstantaneous => true;
+	public bool RequiresTarget => true;
+
+	public XElement SaveToXml()
+	{
+		return new XElement("Effect",
+			new XAttribute("type", "dispelmagic"),
+			new XElement("Mode", (int)Mode),
+			new XElement("CasterPolicy", (int)CasterPolicy),
+			new XElement("AllowHostile", AllowHostile),
+			new XElement("IncludeSubschools", IncludeSubschools),
+			new XElement("ShortenSeconds", ShortenDuration.TotalSeconds),
+			new XElement("SpellId", SpellId),
+			new XElement("SchoolId", SchoolId),
+			new XElement("Tag", new XCData(Tag)),
+			new XElement("TagValue", new XCData(TagValue)),
+			new XElement("MatchTagValue", MatchTagValue),
+			new XElement("EffectKey", new XCData(EffectKey))
+		);
+	}
+
+	public bool IsCompatibleWithTrigger(IMagicTrigger trigger)
+	{
+		return IsCompatibleWithTrigger(trigger.TargetTypes);
+	}
+
+	public static bool IsCompatibleWithTrigger(string targetTypes)
+	{
+		return targetTypes is "character" or "characters" or "item" or "items" or "room" or "rooms" or
+			"perceivable" or "perceivables" or "character&room";
+	}
+
+	public IMagicSpellEffect? GetOrApplyEffect(ICharacter caster, IPerceivable? target, OpposedOutcomeDegree outcome,
+		SpellPower power, IMagicSpellEffectParent parent, SpellAdditionalParameter[] additionalParameters)
+	{
+		if (target is null)
+		{
+			return null;
+		}
+
+		var parents = target.EffectsOfType<MagicSpellParent>(x => MatchesParent(caster, x)).ToList();
+		foreach (var effect in parents)
+		{
+			if (Mode == DispelMagicMode.Remove)
+			{
+				target.RemoveEffect(effect, true);
+				continue;
+			}
+
+			target.RemoveDuration(effect, ShortenDuration, true);
+		}
+
+		return null;
+	}
+
+	private bool MatchesParent(ICharacter caster, MagicSpellParent parent)
+	{
+		if (!MatchesCaster(caster, parent))
+		{
+			return false;
+		}
+
+		if (SpellId > 0L && parent.Spell.Id != SpellId)
+		{
+			return false;
+		}
+
+		if (SchoolId > 0L)
+		{
+			var school = Gameworld.MagicSchools.Get(SchoolId);
+			if (school is null)
+			{
+				return false;
+			}
+
+			if (parent.Spell.School != school && (!IncludeSubschools || !parent.Spell.School.IsChildSchool(school)))
+			{
+				return false;
+			}
+		}
+
+		if (!string.IsNullOrWhiteSpace(Tag) && !parent.SpellEffects.OfType<IMagicTagEffect>().Any(MatchesTag))
+		{
+			return false;
+		}
+
+		if (!string.IsNullOrWhiteSpace(EffectKey) && !EffectKey.EqualTo("any"))
+		{
+			if (!EffectKeyMatchers.TryGetValue(EffectKey, out var matcher))
+			{
+				return false;
+			}
+
+			if (!parent.SpellEffects.Any(matcher))
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private bool MatchesCaster(ICharacter caster, MagicSpellParent parent)
+	{
+		var sameCaster = parent.Caster?.Id == caster.Id;
+		if (!sameCaster && !AllowHostile)
+		{
+			return false;
+		}
+
+		return CasterPolicy switch
+		{
+			DispelCasterPolicy.OwnOnly => sameCaster,
+			DispelCasterPolicy.AnyCaster => true,
+			DispelCasterPolicy.OthersOnly => !sameCaster,
+			_ => false
+		};
+	}
+
+	private bool MatchesTag(IMagicTagEffect tag)
+	{
+		if (!tag.Tag.EqualTo(Tag))
+		{
+			return false;
+		}
+
+		return !MatchTagValue || tag.Value.EqualTo(TagValue);
+	}
+
+	public IMagicSpellEffectTemplate Clone()
+	{
+		return new DispelMagicEffect(SaveToXml(), Spell);
+	}
+
+	public const string HelpText = @"You can use the following options with this effect:
+
+	#3mode remove|shorten#0 - removes matching spells or shortens their duration
+	#3shorten <seconds>#0 - sets the duration removed by shorten mode
+	#3caster own|any|others#0 - sets caster matching policy
+	#3hostile#0 - toggles whether non-caster spells can be affected
+	#3subschools#0 - toggles whether school matching includes child schools
+	#3spell <id|none>#0 - restricts matching to a specific spell
+	#3school <id|name|none>#0 - restricts matching to a magic school
+	#3tag <tag> [value]#0 - restricts matching to a magic tag, optionally including value
+	#3tag none#0 - clears tag matching
+	#3effect <key>#0 - restricts matching to an approved key: any, magictag, itemenchant, portal, planarstate, roomward, personalward, exitbarrier, subjectivedesc, transformform, projectile, crafttool, powerfuel, itemevent";
+
+	public bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopSpeech().ToLowerInvariant())
+		{
+			case "mode":
+				return BuildingCommandMode(actor, command);
+			case "shorten":
+				return BuildingCommandShorten(actor, command);
+			case "caster":
+				return BuildingCommandCaster(actor, command);
+			case "hostile":
+				AllowHostile = !AllowHostile;
+				Spell.Changed = true;
+				actor.OutputHandler.Send($"This dispel will {AllowHostile.NowNoLonger()} affect spells from other casters.");
+				return true;
+			case "subschools":
+			case "subschool":
+				IncludeSubschools = !IncludeSubschools;
+				Spell.Changed = true;
+				actor.OutputHandler.Send($"This dispel will {IncludeSubschools.NowNoLonger()} include child schools.");
+				return true;
+			case "spell":
+				return BuildingCommandSpell(actor, command);
+			case "school":
+				return BuildingCommandSchool(actor, command);
+			case "tag":
+				return BuildingCommandTag(actor, command);
+			case "effect":
+			case "key":
+				return BuildingCommandEffect(actor, command);
+		}
+
+		actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
+		return false;
+	}
+
+	private bool BuildingCommandMode(ICharacter actor, StringStack command)
+	{
+		if (!command.SafeRemainingArgument.TryParseEnum(out DispelMagicMode value))
+		{
+			actor.OutputHandler.Send($"You must specify either {nameof(DispelMagicMode.Remove).ColourCommand()} or {nameof(DispelMagicMode.Shorten).ColourCommand()}.");
+			return false;
+		}
+
+		Mode = value;
+		Spell.Changed = true;
+		actor.OutputHandler.Send($"This dispel now uses {value.DescribeEnum().ColourValue()} mode.");
+		return true;
+	}
+
+	private bool BuildingCommandShorten(ICharacter actor, StringStack command)
+	{
+		if (!double.TryParse(command.SafeRemainingArgument, out var seconds) || seconds <= 0.0)
+		{
+			actor.OutputHandler.Send("You must enter a positive number of seconds.");
+			return false;
+		}
+
+		ShortenDuration = TimeSpan.FromSeconds(seconds);
+		Spell.Changed = true;
+		actor.OutputHandler.Send($"Shorten mode will remove {ShortenDuration.Describe(actor).ColourValue()} from matching spells.");
+		return true;
+	}
+
+	private bool BuildingCommandCaster(ICharacter actor, StringStack command)
+	{
+		if (!command.SafeRemainingArgument.TryParseEnum(out DispelCasterPolicy value))
+		{
+			actor.OutputHandler.Send($"Valid caster policies are {Enum.GetValues<DispelCasterPolicy>().Select(x => x.DescribeEnum().ColourValue()).ListToString()}.");
+			return false;
+		}
+
+		CasterPolicy = value;
+		Spell.Changed = true;
+		actor.OutputHandler.Send($"This dispel now uses the {value.DescribeEnum().ColourValue()} caster policy.");
+		return true;
+	}
+
+	private bool BuildingCommandSpell(ICharacter actor, StringStack command)
+	{
+		if (command.SafeRemainingArgument.EqualToAny("none", "clear", "0"))
+		{
+			SpellId = 0L;
+			Spell.Changed = true;
+			actor.OutputHandler.Send("This dispel no longer restricts by spell.");
+			return true;
+		}
+
+		var spell = Gameworld.MagicSpells.GetByIdOrName(command.SafeRemainingArgument);
+		if (spell is null)
+		{
+			actor.OutputHandler.Send("There is no such spell.");
+			return false;
+		}
+
+		SpellId = spell.Id;
+		Spell.Changed = true;
+		actor.OutputHandler.Send($"This dispel now only affects the {spell.Name.Colour(spell.School.PowerListColour)} spell.");
+		return true;
+	}
+
+	private bool BuildingCommandSchool(ICharacter actor, StringStack command)
+	{
+		if (command.SafeRemainingArgument.EqualToAny("none", "clear", "0"))
+		{
+			SchoolId = 0L;
+			Spell.Changed = true;
+			actor.OutputHandler.Send("This dispel no longer restricts by school.");
+			return true;
+		}
+
+		var school = Gameworld.MagicSchools.GetByIdOrName(command.SafeRemainingArgument);
+		if (school is null)
+		{
+			actor.OutputHandler.Send("There is no such magic school.");
+			return false;
+		}
+
+		SchoolId = school.Id;
+		Spell.Changed = true;
+		actor.OutputHandler.Send($"This dispel now only affects {school.Name.Colour(school.PowerListColour)} spells.");
+		return true;
+	}
+
+	private bool BuildingCommandTag(ICharacter actor, StringStack command)
+	{
+		if (command.SafeRemainingArgument.EqualToAny("none", "clear"))
+		{
+			Tag = string.Empty;
+			TagValue = string.Empty;
+			MatchTagValue = false;
+			Spell.Changed = true;
+			actor.OutputHandler.Send("This dispel no longer restricts by magic tag.");
+			return true;
+		}
+
+		Tag = command.PopSpeech();
+		TagValue = command.SafeRemainingArgument;
+		MatchTagValue = !string.IsNullOrWhiteSpace(TagValue);
+		Spell.Changed = true;
+		actor.OutputHandler.Send(MatchTagValue
+			? $"This dispel now matches magic tag {Tag.ColourName()} with value {TagValue.ColourValue()}."
+			: $"This dispel now matches any magic tag {Tag.ColourName()}.");
+		return true;
+	}
+
+	private bool BuildingCommandEffect(ICharacter actor, StringStack command)
+	{
+		var key = command.SafeRemainingArgument;
+		if (!EffectKeyMatchers.ContainsKey(key))
+		{
+			actor.OutputHandler.Send($"Valid effect keys are {EffectKeyMatchers.Keys.ListToColouredString()}.");
+			return false;
+		}
+
+		EffectKey = key.ToLowerInvariant();
+		Spell.Changed = true;
+		actor.OutputHandler.Send($"This dispel now matches effect key {EffectKey.ColourCommand()}.");
+		return true;
+	}
+
+	public string Show(ICharacter actor)
+	{
+		return $"DispelMagic - {Mode.DescribeEnum().ColourValue()} - Caster {CasterPolicy.DescribeEnum().ColourValue()} - Hostile {AllowHostile.ToColouredString()} - School #{SchoolId.ToString("N0", actor).ColourValue()} - Spell #{SpellId.ToString("N0", actor).ColourValue()} - Tag {(string.IsNullOrWhiteSpace(Tag) ? "any".ColourValue() : $"{Tag}={TagValue}".ColourName())} - Effect {EffectKey.ColourCommand()}";
+	}
+}

--- a/MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs
+++ b/MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs
@@ -552,6 +552,18 @@ public class ItemEnchantEffect : IMagicSpellEffectTemplate
 			new XElement("PainBonus", 0.0),
 			new XElement("StunBonus", 0.0),
 			new XElement("ArmourDamageReduction", 0.0),
+			new XElement("ProjectileQualityBonus", 0.0),
+			new XElement("ProjectileDamageBonus", 0.0),
+			new XElement("ProjectilePainBonus", 0.0),
+			new XElement("ProjectileStunBonus", 0.0),
+			new XElement("ToolFitnessBonus", 0.0),
+			new XElement("ToolSpeedMultiplier", 1.0),
+			new XElement("ToolUsageMultiplier", 1.0),
+			new XElement("PowerProductionMultiplier", 1.0),
+			new XElement("PowerConsumptionMultiplier", 1.0),
+			new XElement("FuelUseMultiplier", 1.0),
+			new XElement("ItemEventType", -1),
+			new XElement("ItemEventProg", 0L),
 			new XElement("ApplicabilityProg", 0)
 		), spell), string.Empty);
 	}
@@ -569,6 +581,19 @@ public class ItemEnchantEffect : IMagicSpellEffectTemplate
 		PainBonus = double.Parse(root.Element("PainBonus")?.Value ?? "0");
 		StunBonus = double.Parse(root.Element("StunBonus")?.Value ?? "0");
 		ArmourDamageReduction = double.Parse(root.Element("ArmourDamageReduction")?.Value ?? "0");
+		ProjectileQualityBonus = double.Parse(root.Element("ProjectileQualityBonus")?.Value ?? "0");
+		ProjectileDamageBonus = double.Parse(root.Element("ProjectileDamageBonus")?.Value ?? "0");
+		ProjectilePainBonus = double.Parse(root.Element("ProjectilePainBonus")?.Value ?? "0");
+		ProjectileStunBonus = double.Parse(root.Element("ProjectileStunBonus")?.Value ?? "0");
+		ToolFitnessBonus = double.Parse(root.Element("ToolFitnessBonus")?.Value ?? "0");
+		ToolSpeedMultiplier = double.Parse(root.Element("ToolSpeedMultiplier")?.Value ?? "1");
+		ToolUsageMultiplier = double.Parse(root.Element("ToolUsageMultiplier")?.Value ?? "1");
+		PowerProductionMultiplier = double.Parse(root.Element("PowerProductionMultiplier")?.Value ?? "1");
+		PowerConsumptionMultiplier = double.Parse(root.Element("PowerConsumptionMultiplier")?.Value ?? "1");
+		FuelUseMultiplier = double.Parse(root.Element("FuelUseMultiplier")?.Value ?? "1");
+		var eventValue = int.Parse(root.Element("ItemEventType")?.Value ?? "-1");
+		ItemEventType = eventValue < 0 ? null : (EventType)eventValue;
+		ItemEventProg = Gameworld.FutureProgs.Get(long.Parse(root.Element("ItemEventProg")?.Value ?? "0"));
 		ApplicabilityProg = Gameworld.FutureProgs.Get(long.Parse(root.Element("ApplicabilityProg")?.Value ?? "0"));
 	}
 
@@ -584,6 +609,18 @@ public class ItemEnchantEffect : IMagicSpellEffectTemplate
 	public double PainBonus { get; private set; }
 	public double StunBonus { get; private set; }
 	public double ArmourDamageReduction { get; private set; }
+	public double ProjectileQualityBonus { get; private set; }
+	public double ProjectileDamageBonus { get; private set; }
+	public double ProjectilePainBonus { get; private set; }
+	public double ProjectileStunBonus { get; private set; }
+	public double ToolFitnessBonus { get; private set; }
+	public double ToolSpeedMultiplier { get; private set; }
+	public double ToolUsageMultiplier { get; private set; }
+	public double PowerProductionMultiplier { get; private set; }
+	public double PowerConsumptionMultiplier { get; private set; }
+	public double FuelUseMultiplier { get; private set; }
+	public EventType? ItemEventType { get; private set; }
+	public IFutureProg? ItemEventProg { get; private set; }
 	public IFutureProg? ApplicabilityProg { get; private set; }
 
 	public XElement SaveToXml()
@@ -600,6 +637,18 @@ public class ItemEnchantEffect : IMagicSpellEffectTemplate
 			new XElement("PainBonus", PainBonus),
 			new XElement("StunBonus", StunBonus),
 			new XElement("ArmourDamageReduction", ArmourDamageReduction),
+			new XElement("ProjectileQualityBonus", ProjectileQualityBonus),
+			new XElement("ProjectileDamageBonus", ProjectileDamageBonus),
+			new XElement("ProjectilePainBonus", ProjectilePainBonus),
+			new XElement("ProjectileStunBonus", ProjectileStunBonus),
+			new XElement("ToolFitnessBonus", ToolFitnessBonus),
+			new XElement("ToolSpeedMultiplier", ToolSpeedMultiplier),
+			new XElement("ToolUsageMultiplier", ToolUsageMultiplier),
+			new XElement("PowerProductionMultiplier", PowerProductionMultiplier),
+			new XElement("PowerConsumptionMultiplier", PowerConsumptionMultiplier),
+			new XElement("FuelUseMultiplier", FuelUseMultiplier),
+			new XElement("ItemEventType", ItemEventType.HasValue ? (int)ItemEventType.Value : -1),
+			new XElement("ItemEventProg", ItemEventProg?.Id ?? 0L),
 			new XElement("ApplicabilityProg", ApplicabilityProg?.Id ?? 0)
 		);
 	}
@@ -618,7 +667,9 @@ public class ItemEnchantEffect : IMagicSpellEffectTemplate
 		return target is IGameItem
 			? new SpellItemEnchantmentEffect(target, parent, SDescAddendum, DescAddendum, Colour, GlowLux,
 				AttackCheckBonus, QualityBonus, DamageBonus, PainBonus, StunBonus, ArmourDamageReduction,
-				ApplicabilityProg)
+				ProjectileQualityBonus, ProjectileDamageBonus, ProjectilePainBonus, ProjectileStunBonus,
+				ToolFitnessBonus, ToolSpeedMultiplier, ToolUsageMultiplier, PowerProductionMultiplier,
+				PowerConsumptionMultiplier, FuelUseMultiplier, ItemEventType, ItemEventProg, ApplicabilityProg)
 			: null;
 	}
 
@@ -639,6 +690,18 @@ public class ItemEnchantEffect : IMagicSpellEffectTemplate
 	#3pain <bonus>#0 - sets weapon pain bonus
 	#3stun <bonus>#0 - sets weapon stun bonus
 	#3armour <amount>#0 - sets armour damage reduction
+	#3projectilequality <bonus>#0 - sets projectile quality bonus
+	#3projectiledamage <bonus>#0 - sets projectile damage bonus
+	#3projectilepain <bonus>#0 - sets projectile pain bonus
+	#3projectilestun <bonus>#0 - sets projectile stun bonus
+	#3toolfitness <bonus>#0 - sets craft tool fitness bonus
+	#3toolspeed <multiplier>#0 - sets craft phase speed multiplier
+	#3toolusage <multiplier>#0 - sets tool durability usage multiplier
+	#3powerproduction <multiplier>#0 - sets powered-item production multiplier
+	#3powerconsumption <multiplier>#0 - sets powered-item consumption multiplier
+	#3fuelusage <multiplier>#0 - sets powered-item fuel usage multiplier
+	#3event <event|none>#0 - sets the item event this enchantment listens for
+	#3eventprog <prog|none>#0 - sets the item event callback prog
 	#3prog <prog|none>#0 - gates whether the enchantment applies";
 
 	public bool BuildingCommand(ICharacter actor, StringStack command)
@@ -670,6 +733,16 @@ public class ItemEnchantEffect : IMagicSpellEffectTemplate
 			case "pain":
 			case "stun":
 			case "armour":
+			case "projectilequality":
+			case "projectiledamage":
+			case "projectilepain":
+			case "projectilestun":
+			case "toolfitness":
+			case "toolspeed":
+			case "toolusage":
+			case "powerproduction":
+			case "powerconsumption":
+			case "fuelusage":
 				if (!double.TryParse(command.SafeRemainingArgument, out var value))
 				{
 					actor.OutputHandler.Send("You must enter a valid number.");
@@ -678,6 +751,10 @@ public class ItemEnchantEffect : IMagicSpellEffectTemplate
 
 				SetNumeric(which, value);
 				break;
+			case "event":
+				return BuildingCommandEvent(actor, command);
+			case "eventprog":
+				return BuildingCommandEventProg(actor, command);
 			case "prog":
 				if (command.SafeRemainingArgument.EqualTo("none"))
 				{
@@ -733,12 +810,89 @@ public class ItemEnchantEffect : IMagicSpellEffectTemplate
 			case "armour":
 				ArmourDamageReduction = value;
 				return;
+			case "projectilequality":
+				ProjectileQualityBonus = value;
+				return;
+			case "projectiledamage":
+				ProjectileDamageBonus = value;
+				return;
+			case "projectilepain":
+				ProjectilePainBonus = value;
+				return;
+			case "projectilestun":
+				ProjectileStunBonus = value;
+				return;
+			case "toolfitness":
+				ToolFitnessBonus = value;
+				return;
+			case "toolspeed":
+				ToolSpeedMultiplier = Math.Max(0.01, value);
+				return;
+			case "toolusage":
+				ToolUsageMultiplier = Math.Max(0.0, value);
+				return;
+			case "powerproduction":
+				PowerProductionMultiplier = Math.Max(0.0, value);
+				return;
+			case "powerconsumption":
+				PowerConsumptionMultiplier = Math.Max(0.0, value);
+				return;
+			case "fuelusage":
+				FuelUseMultiplier = Math.Max(0.0, value);
+				return;
 		}
+	}
+
+	private bool BuildingCommandEvent(ICharacter actor, StringStack command)
+	{
+		if (command.SafeRemainingArgument.EqualToAny("none", "clear"))
+		{
+			ItemEventType = null;
+			Spell.Changed = true;
+			actor.OutputHandler.Send("This enchantment no longer listens for item events.");
+			return true;
+		}
+
+		if (!command.SafeRemainingArgument.TryParseEnum(out EventType value))
+		{
+			actor.OutputHandler.Send("That is not a valid event type.");
+			return false;
+		}
+
+		ItemEventType = value;
+		Spell.Changed = true;
+		actor.OutputHandler.Send($"This enchantment now listens for {value.DescribeEnum().ColourValue()}.");
+		return true;
+	}
+
+	private bool BuildingCommandEventProg(ICharacter actor, StringStack command)
+	{
+		if (command.SafeRemainingArgument.EqualToAny("none", "clear"))
+		{
+			ItemEventProg = null;
+			Spell.Changed = true;
+			actor.OutputHandler.Send("This enchantment no longer invokes an item event prog.");
+			return true;
+		}
+
+		ItemEventProg = new ProgLookupFromBuilderInput(actor, command.SafeRemainingArgument, ProgVariableTypes.Void,
+			[
+				[ProgVariableTypes.Item],
+				[ProgVariableTypes.Item, ProgVariableTypes.Text]
+			]).LookupProg();
+		if (ItemEventProg is null)
+		{
+			return false;
+		}
+
+		Spell.Changed = true;
+		actor.OutputHandler.Send($"This enchantment now invokes {ItemEventProg.MXPClickableFunctionName()} for matching item events.");
+		return true;
 	}
 
 	public string Show(ICharacter actor)
 	{
-		return $"ItemEnchant - {SDescAddendum.Colour(Colour)} - Glow {GlowLux.ToString("N2", actor).ColourValue()} - Attack {AttackCheckBonus.ToBonusString(actor)} - Armour {ArmourDamageReduction.ToString("N2", actor).ColourValue()}";
+		return $"ItemEnchant - {SDescAddendum.Colour(Colour)} - Glow {GlowLux.ToString("N2", actor).ColourValue()} - Attack {AttackCheckBonus.ToBonusString(actor)} - Armour {ArmourDamageReduction.ToString("N2", actor).ColourValue()} - Projectile {ProjectileDamageBonus.ToBonusString(actor)} - Tool {ToolFitnessBonus.ToBonusString(actor)} - Power x{PowerProductionMultiplier.ToString("N2", actor).ColourValue()}";
 	}
 }
 
@@ -1215,12 +1369,24 @@ public class PortalSpellEffect : IMagicSpellEffectTemplate
 
 	private ICell? AnchorDestination(ICharacter caster)
 	{
-		return Gameworld.Cells
+		var roomAnchor = Gameworld.Cells
 			.Where(x => x != caster.Location)
 			.SingleOrDefault(x => x.EffectsOfType<IMagicTagEffect>(tag =>
 				tag.Caster?.Id == caster.Id &&
 				tag.Tag.EqualTo(AnchorTag) &&
 				(string.IsNullOrEmpty(AnchorValue) || tag.Value.EqualTo(AnchorValue))).Any());
+		if (roomAnchor is not null)
+		{
+			return roomAnchor;
+		}
+
+		return Gameworld.Items
+			.Where(x => x.Location is not null && x.Location != caster.Location)
+			.SingleOrDefault(x => x.EffectsOfType<IMagicTagEffect>(tag =>
+				tag.Caster?.Id == caster.Id &&
+				tag.Tag.EqualTo(AnchorTag) &&
+				(string.IsNullOrEmpty(AnchorValue) || tag.Value.EqualTo(AnchorValue))).Any())
+			?.Location;
 	}
 
 	public IMagicSpellEffectTemplate Clone() => new PortalSpellEffect(SaveToXml(), Spell);

--- a/MudSharpCore/Work/Crafts/Tools/SimpleTool.cs
+++ b/MudSharpCore/Work/Crafts/Tools/SimpleTool.cs
@@ -1,6 +1,10 @@
 ﻿using MudSharp.Character;
+using MudSharp.Effects.Interfaces;
 using MudSharp.Framework;
 using MudSharp.GameItems;
+using MudSharp.GameItems.Interfaces;
+using System;
+using System.Linq;
 using System.Xml.Linq;
 
 namespace MudSharp.Work.Crafts.Tools;
@@ -34,7 +38,28 @@ public class SimpleTool : BaseTool
 
     public override double ToolFitness(IGameItem item)
     {
-        return 1.0;
+        return Math.Max(0.0, 1.0 + item.EffectsOfType<IMagicCraftToolEnhancementEffect>(x =>
+            x.AppliesToCraftTool(item, null)).Sum(x => x.ToolFitnessBonus));
+    }
+
+    public override double PhaseLengthMultiplier(IGameItem item)
+    {
+        return item.EffectsOfType<IMagicCraftToolEnhancementEffect>(x =>
+            x.AppliesToCraftTool(item, null))
+            .Aggregate(1.0, (current, effect) => current * effect.ToolSpeedMultiplier);
+    }
+
+    public override void UseTool(IGameItem item, TimeSpan phaseLength, bool hasFailed)
+    {
+        if (!UseToolDuration)
+        {
+            return;
+        }
+
+        var usageMultiplier = item.EffectsOfType<IMagicCraftToolEnhancementEffect>(x =>
+            x.AppliesToCraftTool(item, null))
+            .Aggregate(1.0, (current, effect) => current * effect.ToolUsageMultiplier);
+        item.GetItemType<IToolItem>()?.UseTool(null, TimeSpan.FromTicks((long)(phaseLength.Ticks * usageMultiplier)));
     }
 
     public override string ToolType => "SimpleTool";

--- a/MudSharpCore/Work/Crafts/Tools/TagTool.cs
+++ b/MudSharpCore/Work/Crafts/Tools/TagTool.cs
@@ -1,4 +1,5 @@
 ﻿using MudSharp.Character;
+using MudSharp.Effects.Interfaces;
 using MudSharp.Framework;
 using MudSharp.GameItems;
 using MudSharp.GameItems.Interfaces;
@@ -39,18 +40,22 @@ public class TagTool : BaseTool
 
     public override double ToolFitness(IGameItem item)
     {
+        var enhancements = item.EffectsOfType<IMagicCraftToolEnhancementEffect>(x =>
+            x.AppliesToCraftTool(item, TargetItemTag)).ToList();
         IToolItem tool = item.GetItemType<IToolItem>();
         if (tool == null)
         {
-            return 1.0;
+            return Math.Max(0.0, 1.0 + enhancements.Sum(x => x.ToolFitnessBonus));
         }
 
-        if (tool.ToolTimeMultiplier(TargetItemTag) <= 0.0)
+        var multiplier = tool.ToolTimeMultiplier(TargetItemTag) *
+                         enhancements.Aggregate(1.0, (current, effect) => current * effect.ToolSpeedMultiplier);
+        if (multiplier <= 0.0)
         {
             return 0.0;
         }
 
-        return 1.0 / tool.ToolTimeMultiplier(TargetItemTag);
+        return Math.Max(0.0, 1.0 / multiplier + enhancements.Sum(x => x.ToolFitnessBonus));
     }
 
     public override void UseTool(IGameItem item, TimeSpan phaseLength, bool hasFailed)
@@ -59,12 +64,18 @@ public class TagTool : BaseTool
         {
             return;
         }
-        item.GetItemType<IToolItem>()?.UseTool(TargetItemTag, phaseLength);
+        var usageMultiplier = item.EffectsOfType<IMagicCraftToolEnhancementEffect>(x =>
+            x.AppliesToCraftTool(item, TargetItemTag))
+            .Aggregate(1.0, (current, effect) => current * effect.ToolUsageMultiplier);
+        item.GetItemType<IToolItem>()?.UseTool(TargetItemTag, TimeSpan.FromTicks((long)(phaseLength.Ticks * usageMultiplier)));
     }
 
     public override double PhaseLengthMultiplier(IGameItem item)
     {
-        return item.GetItemType<IToolItem>()?.ToolTimeMultiplier(TargetItemTag) ?? 1.0;
+        var multiplier = item.EffectsOfType<IMagicCraftToolEnhancementEffect>(x =>
+            x.AppliesToCraftTool(item, TargetItemTag))
+            .Aggregate(1.0, (current, effect) => current * effect.ToolSpeedMultiplier);
+        return (item.GetItemType<IToolItem>()?.ToolTimeMultiplier(TargetItemTag) ?? 1.0) * multiplier;
     }
 
     public override string ToolType => "TagTool";


### PR DESCRIPTION
## Summary
- Adds `dispelmagic` with remove/shorten modes and caster-owned default cleanup.
- Extends portal handling to support saved-effect topology, room/item anchors, and admin inspection via `magic portals` and `magic anchors`.
- Expands `itemenchant` into first-class hooks for projectile payloads, crafting tools, power/fuel modifiers, and item event progs.
- Adds `mindconceal` plus psionic identity and passive traffic support for telepathy-based contact flows.
- Updates the magic design docs and gap report to reflect the shipped Engine V2 slice and the remaining possession/projection boundary.
- Splits the new Engine V2 contracts into one interface per file for clearer ownership and reuse.

## Testing
- `MagicEngineV2Tests` added for dispel criteria, duration shortening, portal/anchor inspection, item enchantment XML round-trips, and concealment/audit behavior.
- Verified with targeted `MagicEngineV2Tests`, `scripts/test-unit-core.ps1`, and `scripts/test-unit.ps1`.
- Full validation passed; remaining build warnings are pre-existing analyzer warnings unrelated to this slice.