### PR TITLE
Assign CellOverlayPackage IDs and wrap room import in a transaction

### DIFF
--- a/RPI Engine Worldfile Converter/FutureMudRoomImporter.cs
+++ b/RPI Engine Worldfile Converter/FutureMudRoomImporter.cs
@@ -265,6 +265,7 @@ public sealed class FutureMudRoomImporter
 	private readonly FutureMudRoomBaselineCatalog _catalog;
 	private readonly string? _zoneTemplateName;
 	private readonly DateTime _now = DateTime.UtcNow;
+	private long _nextCellOverlayPackageId;
 
 	public FutureMudRoomImporter(
 		FuturemudDatabaseContext context,
@@ -274,6 +275,9 @@ public sealed class FutureMudRoomImporter
 		_context = context;
 		_catalog = catalog;
 		_zoneTemplateName = zoneTemplateName;
+		_nextCellOverlayPackageId = context.CellOverlayPackages.Any()
+			? context.CellOverlayPackages.Max(x => x.Id) + 1
+			: 1;
 	}
 
 	public IReadOnlyList<FutureMudRoomValidationIssue> Validate(RoomConversionResult conversion)
@@ -314,6 +318,7 @@ public sealed class FutureMudRoomImporter
 		var skippedExistingZoneCount = 0;
 
 		Dictionary<int, RoomDbState> createdRoomStates = [];
+		using var transaction = execute ? _context.Database.BeginTransaction() : null;
 
 		foreach (var zone in conversion.Zones.OrderBy(x => x.ZoneName, StringComparer.OrdinalIgnoreCase))
 		{
@@ -378,6 +383,7 @@ public sealed class FutureMudRoomImporter
 			};
 			var package = new CellOverlayPackage
 			{
+				Id = _nextCellOverlayPackageId++,
 				Name = zone.OverlayPackageName,
 				RevisionNumber = 0,
 				EditableItem = editableItem,
@@ -582,6 +588,7 @@ public sealed class FutureMudRoomImporter
 		}
 
 		_context.SaveChanges();
+		transaction?.Commit();
 
 		return new FutureMudRoomImportResult(
 			insertedZoneCount,

--- a/RPI Engine Worldfile Converter/RpiRoomConversionMapping.md
+++ b/RPI Engine Worldfile Converter/RpiRoomConversionMapping.md
@@ -57,6 +57,14 @@ That merge is justified by base-room evidence in the preserved corpus:
 
 Other zones are not auto-merged from memory. When no clean base-room name can be derived, the converter falls back to `Zone NN` and records a warning.
 
+## Import Persistence
+
+Room import creates one FutureMUD `CellOverlayPackage` per converted zone group.
+
+`CellOverlayPackage.Id` is a revision-group identifier rather than a database-generated key, so the importer assigns new package ids from the current maximum package id plus one, matching the runtime builder workflow.
+
+Execute-mode imports run inside a database transaction. Intermediate `SaveChanges` calls are still used to obtain generated room, cell, overlay, and exit ids for dependent rows, but an exception rolls the whole execute import back rather than leaving a partial room import behind.
+
 ## Terrain Mapping
 
 Sector mapping defaults:


### PR DESCRIPTION
## Summary
- Fix room import so new `CellOverlayPackage` records get a unique revision-group `Id` instead of defaulting to `0`, which avoids EF tracking conflicts during multi-zone imports.
- Run execute-mode room imports inside a database transaction so a failure rolls back the whole import instead of leaving partial zones behind.
- Document the room import persistence model in the room conversion mapping notes.

## Testing
- Restored the converter test project dependencies.
- Ran `dotnet test "RPI Engine Worldfile Converter Tests\RPI Engine Worldfile Converter Tests.csproj" -c Debug --no-restore -m:1` and confirmed all tests passed.