### PR TITLE
Warn and truncate overlong room descriptions during room import

### DIFF
--- a/RPI Engine Worldfile Converter Tests/RpiRoomConversionTests.cs
+++ b/RPI Engine Worldfile Converter Tests/RpiRoomConversionTests.cs
@@ -114,6 +114,36 @@ public class RpiRoomConversionTests
 		Assert.IsTrue(rooms[1004].Warnings.Any(x => x.Code == "layout-conflict"));
 	}
 
+	[TestMethod]
+	public void RoomTransformer_WarnsForLongDescriptions_AndImporterTruncatesForPersistence()
+	{
+		var longDescription = new string('a', FutureMudRoomImportLimits.CellDescriptionMaxLength + 1);
+		var room = new RpiRoomRecord
+		{
+			Vnum = 99000,
+			SourceFile = "rooms.99",
+			Zone = 99,
+			Name = "Long Description Test",
+			Description = longDescription,
+			RawFlags = 0,
+			RoomFlags = RpiRoomFlags.None,
+			RawSectorType = (int)RpiRoomSectorType.Inside,
+			SectorType = RpiRoomSectorType.Inside,
+			Deity = 0,
+		};
+
+		var transformer = new FutureMudRoomTransformer();
+		var converted = transformer.Convert([room]).Rooms.Single();
+
+		Assert.AreEqual(longDescription.Length, converted.EffectiveDescription.Length);
+		Assert.IsTrue(converted.Warnings.Any(x => x.Code == "cell-description-truncated"));
+
+		var truncated = FutureMudRoomImportLimits.TruncateCellDescription(converted.EffectiveDescription);
+
+		Assert.AreEqual(FutureMudRoomImportLimits.CellDescriptionMaxLength, truncated.Length);
+		Assert.AreEqual(longDescription[..FutureMudRoomImportLimits.CellDescriptionMaxLength], truncated);
+	}
+
 	private static string GetRoomFixtureDirectory()
 	{
 		var candidates = new[]

--- a/RPI Engine Worldfile Converter/FutureMudRoomImporter.cs
+++ b/RPI Engine Worldfile Converter/FutureMudRoomImporter.cs
@@ -75,6 +75,18 @@ public sealed record FutureMudRoomImportResult(
 	IReadOnlyList<FutureMudRoomValidationIssue> Issues,
 	RoomApplyAuditReport Audit);
 
+public static class FutureMudRoomImportLimits
+{
+	public const int CellDescriptionMaxLength = 4000;
+
+	public static string TruncateCellDescription(string description)
+	{
+		return description.Length <= CellDescriptionMaxLength
+			? description
+			: description[..CellDescriptionMaxLength];
+	}
+}
+
 public sealed class FutureMudRoomBaselineCatalog
 {
 	public required long BuilderAccountId { get; init; }
@@ -435,7 +447,7 @@ public sealed class FutureMudRoomImporter
 				{
 					Name = package.Name,
 					CellName = room.Name,
-					CellDescription = room.EffectiveDescription,
+					CellDescription = FutureMudRoomImportLimits.TruncateCellDescription(room.EffectiveDescription),
 					CellOverlayPackageId = package.Id,
 					CellOverlayPackageRevisionNumber = package.RevisionNumber,
 					CellId = dbCell.Id,

--- a/RPI Engine Worldfile Converter/FutureMudRoomTransformer.cs
+++ b/RPI Engine Worldfile Converter/FutureMudRoomTransformer.cs
@@ -97,6 +97,7 @@ public sealed class FutureMudRoomTransformer
 		var zones = BuildZones(orderedRooms);
 		var roomStates = BuildRoomStates(zones, roomByVnum);
 		ResolveXerox(roomStates, roomByVnum);
+		AppendFieldLimitWarnings(roomStates);
 		MapTerrainAndOutdoors(roomStates, roomByVnum);
 		AssignCoordinates(zones, roomByVnum);
 		var exits = BuildExits(roomStates, roomByVnum);
@@ -225,6 +226,21 @@ public sealed class FutureMudRoomTransformer
 			state.EffectiveDescription = xeroxRoom.Description;
 			state.EffectiveWeather = xeroxRoom.Weather;
 			state.XeroxResolved = true;
+		}
+	}
+
+	private static void AppendFieldLimitWarnings(IReadOnlyList<RoomState> roomStates)
+	{
+		foreach (var state in roomStates)
+		{
+			if (state.EffectiveDescription.Length <= FutureMudRoomImportLimits.CellDescriptionMaxLength)
+			{
+				continue;
+			}
+
+			state.Warnings.Add(new RoomConversionWarning(
+				"cell-description-truncated",
+				$"Room #{state.Source.Vnum} has an effective description of {state.EffectiveDescription.Length.ToString("N0", CultureInfo.InvariantCulture)} characters; FutureMUD CellDescription is limited to {FutureMudRoomImportLimits.CellDescriptionMaxLength.ToString("N0", CultureInfo.InvariantCulture)}, so apply-rooms will truncate it."));
 		}
 	}
 

--- a/RPI Engine Worldfile Converter/RpiRoomConversionMapping.md
+++ b/RPI Engine Worldfile Converter/RpiRoomConversionMapping.md
@@ -65,6 +65,8 @@ Room import creates one FutureMUD `CellOverlayPackage` per converted zone group.
 
 Execute-mode imports run inside a database transaction. Intermediate `SaveChanges` calls are still used to obtain generated room, cell, overlay, and exit ids for dependent rows, but an exception rolls the whole execute import back rather than leaving a partial room import behind.
 
+FutureMUD currently stores `CellOverlay.CellDescription` in a `varchar(4000)` column. Converted rooms keep the full effective description for export and audit, but descriptions longer than that limit produce a `cell-description-truncated` warning and are truncated to 4,000 characters only when `apply-rooms --execute` writes the overlay row.
+
 ## Terrain Mapping
 
 Sector mapping defaults:


### PR DESCRIPTION
## Summary
- Added a room conversion warning when an effective room description exceeds FutureMUD's `CellOverlay.CellDescription` limit.
- Truncate descriptions to 4,000 characters only at `apply-rooms --execute` persistence time.
- Added regression coverage for the warning and truncation path.
- Updated the room conversion mapping notes to document the database limit and runtime behavior.

## Testing
- Ran the RPI room converter test project; all tests passed.
- Verified the new long-description regression test alongside the existing room conversion coverage.