### PR TITLE
Guard room exit text against 255-character column overflows

### DIFF
--- a/RPI Engine Worldfile Converter Tests/RpiRoomConversionTests.cs
+++ b/RPI Engine Worldfile Converter Tests/RpiRoomConversionTests.cs
@@ -144,6 +144,72 @@ public class RpiRoomConversionTests
 		Assert.AreEqual(longDescription[..FutureMudRoomImportLimits.CellDescriptionMaxLength], truncated);
 	}
 
+	[TestMethod]
+	public void RoomTransformer_WarnsForLongExitText_AndImporterTruncatesEveryExitTextField()
+	{
+		var longExitDescription = new string('d', FutureMudRoomImportLimits.ExitTextMaxLength + 1);
+		var longKeyword = new string('k', FutureMudRoomImportLimits.ExitTextMaxLength + 1);
+		var sourceRoom = new RpiRoomRecord
+		{
+			Vnum = 99000,
+			SourceFile = "rooms.99",
+			Zone = 99,
+			Name = "Long Exit Source",
+			Description = "A room with a suspiciously long exit.",
+			RawFlags = 0,
+			RoomFlags = RpiRoomFlags.None,
+			RawSectorType = (int)RpiRoomSectorType.Inside,
+			SectorType = RpiRoomSectorType.Inside,
+			Deity = 0,
+			Exits =
+			[
+				new RpiRoomExitRecord(
+					RpiRoomDirection.North,
+					RpiRoomExitSectionType.Normal,
+					longExitDescription,
+					longKeyword,
+					RpiRoomDoorType.None,
+					-1,
+					0,
+					99001)
+			],
+		};
+		var destinationRoom = new RpiRoomRecord
+		{
+			Vnum = 99001,
+			SourceFile = "rooms.99",
+			Zone = 99,
+			Name = "Long Exit Destination",
+			Description = "A destination room.",
+			RawFlags = 0,
+			RoomFlags = RpiRoomFlags.None,
+			RawSectorType = (int)RpiRoomSectorType.Inside,
+			SectorType = RpiRoomSectorType.Inside,
+			Deity = 0,
+		};
+
+		var transformer = new FutureMudRoomTransformer();
+		var convertedExit = transformer.Convert([sourceRoom, destinationRoom]).Exits.Single();
+
+		Assert.AreEqual(longExitDescription.Length, convertedExit.Side1.Description.Length);
+		Assert.AreEqual(longKeyword.Length, convertedExit.Side1.Keywords.Length);
+		Assert.AreEqual(longKeyword.Length, convertedExit.Side1.PrimaryKeyword!.Length);
+		Assert.IsTrue(convertedExit.Warnings.Any(x => x.Code == "exit-description-truncated"));
+		Assert.IsTrue(convertedExit.Warnings.Any(x => x.Code == "exit-keywords-truncated"));
+		Assert.IsTrue(convertedExit.Warnings.Any(x => x.Code == "exit-primary-keyword-truncated"));
+
+		var truncatedDescription = FutureMudRoomImportLimits.TruncateExitText(convertedExit.Side1.Description);
+		var truncatedKeywords = FutureMudRoomImportLimits.TruncateExitText(convertedExit.Side1.Keywords);
+		var truncatedPrimaryKeyword = FutureMudRoomImportLimits.TruncateExitText(convertedExit.Side1.PrimaryKeyword);
+
+		Assert.AreEqual(FutureMudRoomImportLimits.ExitTextMaxLength, truncatedDescription.Length);
+		Assert.AreEqual(FutureMudRoomImportLimits.ExitTextMaxLength, truncatedKeywords.Length);
+		Assert.AreEqual(FutureMudRoomImportLimits.ExitTextMaxLength, truncatedPrimaryKeyword.Length);
+		Assert.AreEqual(longExitDescription[..FutureMudRoomImportLimits.ExitTextMaxLength], truncatedDescription);
+		Assert.AreEqual(longKeyword[..FutureMudRoomImportLimits.ExitTextMaxLength], truncatedKeywords);
+		Assert.AreEqual(longKeyword[..FutureMudRoomImportLimits.ExitTextMaxLength], truncatedPrimaryKeyword);
+	}
+
 	private static string GetRoomFixtureDirectory()
 	{
 		var candidates = new[]

--- a/RPI Engine Worldfile Converter/FutureMudRoomImporter.cs
+++ b/RPI Engine Worldfile Converter/FutureMudRoomImporter.cs
@@ -78,12 +78,23 @@ public sealed record FutureMudRoomImportResult(
 public static class FutureMudRoomImportLimits
 {
 	public const int CellDescriptionMaxLength = 4000;
+	public const int ExitTextMaxLength = 255;
 
 	public static string TruncateCellDescription(string description)
 	{
-		return description.Length <= CellDescriptionMaxLength
-			? description
-			: description[..CellDescriptionMaxLength];
+		return TruncateText(description, CellDescriptionMaxLength);
+	}
+
+	public static string TruncateExitText(string? text)
+	{
+		return TruncateText(text ?? string.Empty, ExitTextMaxLength);
+	}
+
+	private static string TruncateText(string text, int maxLength)
+	{
+		return text.Length <= maxLength
+			? text
+			: text[..maxLength];
 	}
 }
 
@@ -525,18 +536,18 @@ public sealed class FutureMudRoomImporter
 				CellId2 = room2.DbCell.Id,
 				Direction1 = (int)exit.Side1.Direction,
 				Direction2 = (int)exit.Side2.Direction,
-				Keywords1 = exit.Side1.Keywords,
-				Keywords2 = exit.Side2.Keywords,
-				PrimaryKeyword1 = exit.Side1.PrimaryKeyword ?? string.Empty,
-				PrimaryKeyword2 = exit.Side2.PrimaryKeyword ?? string.Empty,
-				InboundDescription1 = exit.Side1.Description,
-				InboundDescription2 = exit.Side2.Description,
-				OutboundDescription1 = exit.Side1.Description,
-				OutboundDescription2 = exit.Side2.Description,
-				InboundTarget1 = exit.Side1.Description,
-				InboundTarget2 = exit.Side2.Description,
-				OutboundTarget1 = exit.Side1.Description,
-				OutboundTarget2 = exit.Side2.Description,
+				Keywords1 = FutureMudRoomImportLimits.TruncateExitText(exit.Side1.Keywords),
+				Keywords2 = FutureMudRoomImportLimits.TruncateExitText(exit.Side2.Keywords),
+				PrimaryKeyword1 = FutureMudRoomImportLimits.TruncateExitText(exit.Side1.PrimaryKeyword),
+				PrimaryKeyword2 = FutureMudRoomImportLimits.TruncateExitText(exit.Side2.PrimaryKeyword),
+				InboundDescription1 = FutureMudRoomImportLimits.TruncateExitText(exit.Side1.Description),
+				InboundDescription2 = FutureMudRoomImportLimits.TruncateExitText(exit.Side2.Description),
+				OutboundDescription1 = FutureMudRoomImportLimits.TruncateExitText(exit.Side1.Description),
+				OutboundDescription2 = FutureMudRoomImportLimits.TruncateExitText(exit.Side2.Description),
+				InboundTarget1 = FutureMudRoomImportLimits.TruncateExitText(exit.Side1.Description),
+				InboundTarget2 = FutureMudRoomImportLimits.TruncateExitText(exit.Side2.Description),
+				OutboundTarget1 = FutureMudRoomImportLimits.TruncateExitText(exit.Side1.Description),
+				OutboundTarget2 = FutureMudRoomImportLimits.TruncateExitText(exit.Side2.Description),
 				Verb1 = string.Empty,
 				Verb2 = string.Empty,
 				DoorId = null,

--- a/RPI Engine Worldfile Converter/FutureMudRoomTransformer.cs
+++ b/RPI Engine Worldfile Converter/FutureMudRoomTransformer.cs
@@ -338,6 +338,9 @@ public sealed class FutureMudRoomTransformer
 						$"Room #{room.Vnum} has a one-sided {side1.Direction.Describe()} exit to #{destinationRoom.Vnum}."));
 				}
 
+				AppendExitFieldLimitWarnings(warnings, side1);
+				AppendExitFieldLimitWarnings(warnings, side2);
+
 				exits.Add(new ConvertedRoomExitDefinition(
 					BuildExitKey(room.Vnum, destinationRoom.Vnum, side1.Direction, side2.Direction),
 					room.Vnum,
@@ -363,6 +366,32 @@ public sealed class FutureMudRoomTransformer
 			.ThenBy(x => x.RoomVnum2)
 			.ThenBy(x => x.Side1.Direction.SortOrder())
 			.ToList();
+	}
+
+	private static void AppendExitFieldLimitWarnings(
+		ICollection<RoomConversionWarning> warnings,
+		ConvertedRoomExitSideDefinition side)
+	{
+		if (side.Description.Length > FutureMudRoomImportLimits.ExitTextMaxLength)
+		{
+			warnings.Add(new RoomConversionWarning(
+				"exit-description-truncated",
+				$"Room #{side.RoomVnum} has a {side.Direction.Describe()} exit description of {side.Description.Length.ToString("N0", CultureInfo.InvariantCulture)} characters; FutureMUD inbound/outbound description and target fields are limited to {FutureMudRoomImportLimits.ExitTextMaxLength.ToString("N0", CultureInfo.InvariantCulture)}, so apply-rooms will truncate those fields."));
+		}
+
+		if (side.Keywords.Length > FutureMudRoomImportLimits.ExitTextMaxLength)
+		{
+			warnings.Add(new RoomConversionWarning(
+				"exit-keywords-truncated",
+				$"Room #{side.RoomVnum} has {side.Direction.Describe()} exit keywords of {side.Keywords.Length.ToString("N0", CultureInfo.InvariantCulture)} characters; FutureMUD exit keyword fields are limited to {FutureMudRoomImportLimits.ExitTextMaxLength.ToString("N0", CultureInfo.InvariantCulture)}, so apply-rooms will truncate them."));
+		}
+
+		if (side.PrimaryKeyword is { Length: > FutureMudRoomImportLimits.ExitTextMaxLength } primaryKeyword)
+		{
+			warnings.Add(new RoomConversionWarning(
+				"exit-primary-keyword-truncated",
+				$"Room #{side.RoomVnum} has a {side.Direction.Describe()} primary exit keyword of {primaryKeyword.Length.ToString("N0", CultureInfo.InvariantCulture)} characters; FutureMUD primary keyword fields are limited to {FutureMudRoomImportLimits.ExitTextMaxLength.ToString("N0", CultureInfo.InvariantCulture)}, so apply-rooms will truncate it."));
+		}
 	}
 
 	private static void AppendUnresolvedSecretWarnings(IReadOnlyList<RoomState> roomStates)

--- a/RPI Engine Worldfile Converter/RpiRoomConversionMapping.md
+++ b/RPI Engine Worldfile Converter/RpiRoomConversionMapping.md
@@ -67,6 +67,8 @@ Execute-mode imports run inside a database transaction. Intermediate `SaveChange
 
 FutureMUD currently stores `CellOverlay.CellDescription` in a `varchar(4000)` column. Converted rooms keep the full effective description for export and audit, but descriptions longer than that limit produce a `cell-description-truncated` warning and are truncated to 4,000 characters only when `apply-rooms --execute` writes the overlay row.
 
+FutureMUD stores exit keywords, primary keywords, verbs, inbound/outbound descriptions, and inbound/outbound targets in `varchar(255)` columns. Converted exit-side text is preserved at full length for export and audit, but overlong values produce `exit-description-truncated`, `exit-keywords-truncated`, or `exit-primary-keyword-truncated` warnings and are truncated only when the importer writes the `Exit` row. Long exit descriptions are especially suspicious because the current pass maps the legacy exit description into all four FutureMUD inbound/outbound description and target fields for that side.
+
 ## Terrain Mapping
 
 Sector mapping defaults:


### PR DESCRIPTION
## Summary
- Truncate imported exit-side text to FutureMUD’s 255-character column limit at write time for keywords, primary keywords, inbound/outbound descriptions, and inbound/outbound targets.
- Add conversion warnings for overlong exit descriptions, keywords, and primary keywords so malformed legacy data is visible before import.
- Add regression coverage for long exit text and update the room conversion mapping notes to document the persistence limits.

## Testing
- `dotnet test "RPI Engine Worldfile Converter Tests\RPI Engine Worldfile Converter Tests.csproj" -c Debug --no-restore -m:1`
- Result: passed, including the new truncation/warning regression test.