### PR TITLE
Implement V4 psionic and perception policy layer

### DIFF
--- a/Design Documents/Armageddon_Magic_Psionics_Gap_Report.md
+++ b/Design Documents/Armageddon_Magic_Psionics_Gap_Report.md
@@ -24,7 +24,7 @@ and the current runtime implementations under `MudSharpCore/Magic`.
 - Existing powers count as valid coverage even when Armageddon exposed the original ability as a spell. If you want strict `cast`-spell parity rather than "same subsystem can do it", several defensive entries would slide from `Native now` to `Needs engine primitive`.
 - A handful of Armageddon entries are under-specified in the dump (`Daylight`, `Empower`, `Drown`, `Cause Disease`, `Acid Spray`, some passive psionics). The first pass counted those conservatively unless the name clearly mapped to an existing FutureMUD primitive.
 - The original first-pass counts used a single `Needs engine work` bucket. This revision keeps those historical lists in the appendix, but current planning uses the two-way split above.
-- Status reviewed on 2026-05-02 against `Magic_System_Implemented_Types.md`, `Magic_System_Spells.md`, `Magic_System_Powers.md`, and the registered runtime types under `MudSharpCore/Magic`. Exact family-by-family counts were not recomputed in this pass; the stale top-line counts have therefore been removed from the planning sections.
+- Status reviewed on 2026-05-03 against `Magic_System_Implemented_Types.md`, `Magic_System_Spells.md`, `Magic_System_Powers.md`, and the registered runtime types under `MudSharpCore/Magic`. Exact family-by-family counts were not recomputed in this pass; the stale top-line counts have therefore been removed from the planning sections. V4 added 9 builder-registered psionic power tokens and 2 builder-registered tag-aware ward effect tokens.
 
 ## Executive Summary
 
@@ -43,7 +43,7 @@ Key takeaways:
 - Previous phases closed three medium-difficulty primitive gaps: local exit targeting, prog-resolved summon-style remote targeting, and reusable room or personal wards with shared spell and power interception.
 - The plane and body-form work moves several old blockers into the buildable bucket: `Ethereal`, `Detect Ethereal`, `Dispel Ethereal`, simple `Planeshift`, ghostly manifestation, and polymorph-style transformations can now use first-class effects rather than bespoke tags.
 - The biggest remaining architecture blockers are durable portal topology beyond saved effects, objective or group-scoped illusion policy, world-specific metaphysics, and true "dual body" mechanics like possession or shadow projection.
-- Psionics are now better covered than the first pass suggested. The current mind-link stack handles contact, barriers, mind-looking, audits, expulsion, sense, messaging, direct mental attacks, passive thought/feeling traffic, and identity concealment. Advanced coercion policy, trace consequences, animal/wild mind variants, and projection-style powers still need work.
+- Psionics are now better covered than the first pass suggested. The current mind-link stack handles contact, barriers, mind-looking, audits, expulsion, sense, messaging, direct mental attacks, passive thought/feeling traffic, identity concealment, trace inspection, psionic hearing, clairaudience, language comprehension, babbling, magical sensing, emotion/thought injection, and non-command coerce modes. Durable trace consequences and projection-style powers still need supporting-system work.
 
 ## Current Family Themes
 
@@ -57,7 +57,7 @@ Key takeaways:
 | Lightning | direct attacks, stamina effects, paralysis | `insomnia`, footprint tracking such as `Fluorescent Footsteps` | none obvious from the current report |
 | Void | wards, portals, marks/runes, corpse preservation/consumption/spawn, resource drains, item enchantments | strength-contested dispel math, exact `Identify`/`Dead Speak`/`Recite` surfaces if they need first-class UX | durable portal/rune topology, possession, disembodiment, setting-specific `Solace` / `Dragon Bane` / `Cathexis` |
 | Unspecified / incomplete magic | `Puddle`; `Cause Disease` if the dump only requires disease application | `Acid Spray`, exact `Drown` if not covered by existing damage/need/breathing primitives | source clarification may be needed before classification |
-| Psionics | contact, barriers, locate/probe/expel/sense, mindblast, rejuvenate, dome, telepathy, passive traffic, identity concealment | `Trace`, advanced coercion/compulsion, `Allspeak`, `Hear`, `Clairaudience`, `Babble`, `Magicksense`, animal/wild contact variants | projection/remote-presence semantics and any durable psionic trace/consequence model |
+| Psionics | contact, barriers, locate/probe/expel/sense, mindblast, rejuvenate, dome, telepathy, passive traffic, identity concealment, `Trace`, `Hear`, `Clairaudience`, `Allspeak`, `Babble`, `Magicksense`, `Project Emotion`, `Suggest`, `Coerce`, and animal/wild contact variants via `connectmind` eligibility progs | content-specific `Cathexis`, `Mindwipe`, or beast/wild wrappers if they require unique UX beyond existing links and policy hooks | projection/remote-presence semantics, durable psionic trace/consequence models, and objective multi-viewer illusion state |
 
 ## Where FutureMUD Is Already Strong
 
@@ -82,6 +82,7 @@ The current system already has good coverage for:
 - Wind movement and fall-control effects through `levitate`, `featherfall`, `forcedpathmovement` / `handsofwind`, `transference`, and `removeinvisibility` / `dispelinvisibility`
 - V3 edge statuses through `detectpoison`, `insomnia`, `removeinsomnia`, `removeblindness` / `cureblindness`, and optional strength-contested `dispelmagic`
 - Coercion V1 through `forcecommand`, `subjectivedesc`, and `subjectivesdesc`
+- V4 psionic and perception policy through `trace`, `hear`, `clairaudience`, `allspeak`, `babble`, `magicksense`, `projectemotion`, `suggest`, and `coerce`, plus shared traffic/audit delivery, `connectmind` eligibility progs, subjective-description priority/key handling, and tag-aware `roomtagward` / `personaltagward`
 
 ## Previous Work
 
@@ -121,7 +122,9 @@ Completed on 2026-05-01.
 
 Deferred from V1 but later resolved in V2: general dispel/shorten support, portal inspection and item anchors, richer item-enchantment hooks, and psionic identity/passive-traffic policy.
 
-Deferred from V1 and still relevant: durable portal/rune topology, objective or group-scoped illusions, advanced coercion policy, trace consequences, and true possession/projection.
+Deferred from V1 but later resolved in V4: advanced non-command coercion policy and subjective illusion priority/dispel keys.
+
+Deferred from V1 and still relevant: durable portal/rune topology, objective or group-scoped illusions, durable trace consequences, and true possession/projection.
 
 ### Engine V2: dispels, richer enchantments, portal inspection, and psionic identity
 
@@ -133,7 +136,22 @@ Completed on 2026-05-02.
 - Added builder-loadable plane/form recipe coverage for `Ethereal`, `Dispel Ethereal`, `Planeshift`, shadow/astral walking, and polymorph-style configurations.
 - Added `mindconceal` and wired shared concealment policy into mind contact, mind speech/broadcast, mind audit/expel, and passive `think`/`feel` telepathy.
 
-Deferred from V2 and still relevant: persistent gate/rune topology if saved effects are not enough, strength-contested dispel formulas, richer illusion stacking and perception policy, advanced coercion and trace consequences, and the simultaneous-body possession/projection model.
+Deferred from V2 but later resolved in V3 or V4: strength-contested dispel formulas, richer subjective-illusion priority and dispel policy, advanced non-command coercion primitives, and tag-aware ward matching.
+
+Deferred from V2 and still relevant: persistent gate/rune topology if saved effects are not enough, durable trace consequences, objective or group-scoped illusion state, and the simultaneous-body possession/projection model.
+
+### Engine V4: psionic and perception policy layer
+
+Completed on 2026-05-03.
+
+- Added builder-registered psionic powers `trace`, `hear`, `clairaudience`, `allspeak`, `babble`, `magicksense`, `projectemotion`, `suggest`, and `coerce`.
+- Added shared psionic traffic and coercion policy for involuntary thought/feeling delivery, listener forwarding, opt-out checks, blocked command roots, source/target messaging, and wiz-audit output.
+- Added a builder-visible `psionic` toggle to `MagicPowerBase`, persisting through the existing `IsPsionic` XML field and using the psionics crime type.
+- Added contextual interdiction metadata and tag-aware `roomtagward` / `personaltagward` effects that match configured `magictag` key/value metadata.
+- Added subjective-description priority and illusion-key support, including `dispelmagic illusion <key>` matching for keyed subjective illusions.
+- Added a target-eligibility prog to `connectmind`, so animal, wild, or setting-specific contact variants can be expressed without new hard-coded link powers.
+
+V4 count deltas: +9 builder power tokens, +2 builder spell-effect tokens, +7 shared policy/support types. The V4 psionic/perception engine-primitive backlog is complete; the remaining psionic/perception blockers are supporting-system problems rather than ordinary power/effect registration work.
 
 ## Current Reclassification From Planes And Body Forms
 
@@ -270,9 +288,9 @@ This now unlocks:
 - `Elemental Fog`
 - `Dome`
 
-Remaining limitation:
+V4 extension:
 
-- wards are school-based rather than freeform tag- or item-keyed, so future rune-specific anti-magic wants a tag-aware ward primitive rather than more metadata
+- `roomtagward` and `personaltagward` add tag-aware interdiction that matches `magictag` key/value metadata while reusing the same fail/reflect and coverage model.
 
 ### 6. Item and corpse enchantment, magic tags, and anchors
 
@@ -346,7 +364,7 @@ Remaining work:
 
 ### 8. Subjective perception, coercive psionics, and passive mind traffic
 
-Status: Coercion V1, psionic identity concealment, and passive thought/feeling traffic are implemented. The older report text that listed identity hiding and passive traffic as open blockers is stale.
+Status: Coercion V1, psionic identity concealment, passive thought/feeling traffic, and the V4 psionic/perception policy layer are implemented. The older report text that listed identity hiding, passive traffic, basic trace/hear/clairaudience powers, and non-command coercion primitives as open blockers is stale.
 
 FutureMUD already has good mind-link primitives and now has:
 
@@ -356,24 +374,34 @@ FutureMUD already has good mind-link primitives and now has:
 - caster-scoped subjective-description support through fixed-viewer handling.
 - `mindconceal`, which supplies sustained identity concealment and an audit difficulty modifier.
 - passive `think` / `feel` / `thinkemote` traffic through `telepathy`, with concealment consulted before identities are exposed.
+- `trace`, which inspects active mind links around a target mind and respects `mindconceal` audit difficulty and unknown-identity output.
+- `hear`, which sustains psionic thought/feeling listening over configured scope without becoming ordinary room audio.
+- `clairaudience`, which sustains contact-based remote hearing through another mind's location and forwards audible output only.
+- `allspeak`, which grants sustained spoken-language comprehension through `IComprehendLanguageEffect` without permanent language skill or literacy bypass.
+- `babble`, which applies hostile timed speech obfuscation before language comprehension can decode the speech.
+- `magicksense`, which grants sustained `SenseMagical` perception through the existing magical aura display.
+- `projectemotion`, `suggest`, and `coerce`, which share traffic/coercion policy for involuntary emotion/thought delivery, listener forwarding, opt-out checks, and audit output.
+- subjective-description priority and illusion keys for predictable stacking and keyed `dispelmagic`.
+- `roomtagward` and `personaltagward`, which interdict by `magictag` key/value metadata rather than only school/subschool.
+- `connectmind` target eligibility progs, so animal, wild, or setting-specific contact variants can be configured directly.
 
 This now covers:
 
 - `Conceal`, when the desired behaviour is hidden mental identity.
 - `Thoughtsense` and `Immersion`, when the desired behaviour is passive thought/feeling eavesdropping.
-- the safest command-forcing cases for `Control`, `Compel`, `Suggest`, and `Coerce`, so long as content stays within non-staff, non-account-destructive command roots.
+- the safest command-forcing cases for `Control` and `Compel`, so long as content stays within non-staff, non-account-destructive command roots.
+- non-command `Suggest`, `Project Emotion`, and common `Coerce` modes that should alter thought, feeling, stamina, hunger, or thirst rather than run a victim command.
 - single-viewer description changes for parts of `Masquerade`, `Imitate`, and `Vanish`.
 
 It does not yet cover:
 
-- injecting emotions or compulsions as first-class non-command mental states.
-- robust refusal/consent policy beyond the hard safety block list.
-- trace consequences beyond `mindconceal` making audits harder.
-- objective room-state illusions, multi-viewer/group-scoped illusions, or explicit illusion stacking and priority rules beyond the current override-description ordering.
+- robust refusal/consent policy beyond opt-out effects, ordinary targeting checks, and hard safety block lists.
+- durable trace consequences beyond live link inspection and `mindconceal` making audits harder.
+- objective room-state illusions or multi-viewer/group-scoped illusions that need a general perception-overlay model.
 
 That means the remaining work splits cleanly:
 
-- Needs engine primitive: emotion/compulsion effects, trace/trail powers, explicit illusion priority rules, clairaudience/hearing powers, `Allspeak`, `Babble`, `Magicksense`, and animal/wild mind-contact variants.
+- Needs engine primitive: none from the V4 psionic/perception policy slice. Content-specific `Cathexis`, `Mindwipe`, or beast/wild wrappers may still need dedicated UX if progs and existing link effects are not enough.
 - Needs supporting system: projection-style psionics, durable trace consequence models if traces must persist as world facts, and objective multi-viewer illusions if they need a general perception-overlay framework.
 
 ## Future Work
@@ -387,9 +415,8 @@ These tasks should be ordinary implementation work inside the existing magic, pe
 - Add exit state mutation beyond barriers, such as opening, closing, sealing, or unlocking a targeted exit when `exitbarrier` is not the right model.
 - Add burn-over-time, footprint-tracking, and similar persistent sensory/combat effects for spells such as `Immolate` and `Fluorescent Footsteps`.
 - Add swap or long-range movement effects if `Transference` and `Hands Of Wind` require more than `teleporttarget`, `relocate`, `prog...room`, or `forcedexitmovement`.
-- Add specific information powers/effects for `Identify`, `Dead Speak`, `Recite`, `Magicksense`, `Hear`, `Clairaudience`, `Allspeak`, `Babble`, and animal/wild mind-contact variants where existing progs or telepathy are not sufficient.
-- Add emotion/compulsion effects and trace/trail powers for psionics that need more than `forcecommand`, `mindconceal`, or passive `telepathy`.
-- Add a tag-aware ward primitive if rune- or item-specific anti-magic needs to match magic tags rather than school/subschool.
+- Add specific information powers/effects for `Identify`, `Dead Speak`, and `Recite` where existing progs or metadata are not sufficient.
+- Add dedicated `Beast Affinity`, `Wild Contact`, or `Wild Barrier` wrappers only if `connectmind` eligibility progs, existing barriers, and ordinary content naming are not expressive enough.
 
 ### Needs supporting system or rework
 
@@ -399,7 +426,7 @@ These are the remaining true blockers. They should not be represented as one-off
 - Durable portal/rune topology: standing gates, persistent rune networks, portal objects, and topology edits that must survive beyond saved spell effects need a deliberate persistence and lifecycle model.
 - Objective or group-scoped illusions: if illusions must alter room state for multiple observers, stack with other illusions, and expose consistent dispel/priority rules, they need a general perception-overlay policy rather than only `subjectivedesc` / `subjectivesdesc`.
 - World-specific metaphysics: `Determine Relationship`, `Solace`, `Dragon Bane`, `Cathexis`, and richer `Planeshift` interpretations need a model for land/elemental relationships, plane travel graphs, and any clan/tribe/identity consequences.
-- Durable psionic trace consequences: a simple `Trace` power can be an engine primitive, but traces that persist as world facts or feed staff/audit consequences need a shared psionic trail model.
+- Durable psionic trace consequences: the live `trace` power inspects active links, but traces that persist as world facts or feed staff/audit consequences need a shared psionic trail model.
 
 ## Next Logical Steps
 
@@ -415,33 +442,25 @@ The next slice should finish the small, unglamorous primitives that no longer ne
 
 ### V4: psionic and perception policy layer
 
-After the remaining easy primitives, the best next value is the policy-heavy middle ground that still fits inside existing systems:
+Status: completed on 2026-05-03.
 
-- Add explicit `Trace`, `Hear`/`Clairaudience`, `Allspeak`, `Babble`, `Magicksense`, and animal/wild mind-contact powers where telepathy/progs are only approximate.
-- Add emotion/compulsion effects for non-command coercion, plus clearer refusal, consent, and audit policy around coercive powers.
-- Extend subjective descriptions into a coherent illusion stack with priority/dispel rules before attempting full objective room-state illusions.
-- Add tag-aware wards if rune/item anti-magic is a real content target.
+- `trace`, `hear`, `clairaudience`, `allspeak`, `babble`, `magicksense`, `projectemotion`, `suggest`, and `coerce` are builder-registered powers.
+- `connectmind` now has an eligibility prog for animal, wild, or setting-specific mind-contact variants.
+- Psionic traffic now has a shared delivery/refusal/listener/audit helper rather than each effect hand-rolling policy.
+- Subjective descriptions now have priority and illusion-key handling, and `dispelmagic` can target keyed illusions.
+- `roomtagward` and `personaltagward` are available for tag-aware anti-magic.
 
 ### V5: supporting-system buildout
 
 V5 should tackle the remaining architecture blockers after V3/V4 make the easy and medium gaps boring:
 
-- injecting emotions or compulsions
-- hiding a psionic identity from trace/contact flows
-- passive thought-traffic/eavesdropping powers
-- robust refusal/consent policy beyond the hard safety block list
-- illusion stacking policy beyond ordinary override-description precedence
+- simultaneous-body possession and projection
+- objective or group-scoped illusion state that changes room facts for multiple observers
+- durable psionic trace/trail consequences that survive beyond live link inspection
+- persistent rune/gate/portal topology if saved effects and transient exits are not enough
+- world-specific metaphysics such as land relationships, elemental patronage, or clan-keyed psionic consequences
 
-This still blocks or complicates:
-
-- `Conceal`
-- `Masquerade`
-- `Imitate`
-- `Vanish`
-- `Thoughtsense`
-- `Immersion`
-
-`Control`, `Compel`, `Suggest`, and `Coerce` are now buildable for non-staff, non-account-destructive command roots, but content authors should still treat them as policy-sensitive spells and pair them with clear messaging or setting rules.
+`Control` and `Compel` remain policy-sensitive when authored as command-forcing effects. `Suggest`, `Project Emotion`, and most `Coerce` variants now have non-command delivery paths, but content authors should still pair them with clear IC/OOC policy and staff-facing audit expectations.
 
 ## Prioritised Implementation Plan
 
@@ -491,8 +510,9 @@ These are the next-best return once the basic statuses exist.
 
 5. Add a command-safe psionic coercion framework.
    - Completed for Coercion V1 with `forcecommand`.
-   - The current implementation executes through the target's own `ExecuteCommand`, respects `IIgnoreForceEffect`, blocks staff/editor/account-destructive roots, and emits wiz-only audit output.
-   - Deeper consent/refusal semantics, emotion injection, trace consequences, and non-command coercion remain future work.
+   - Extended in V4 with `projectemotion`, `suggest`, and mode-based `coerce`.
+   - The command-forcing implementation executes through the target's own `ExecuteCommand`, respects `IIgnoreForceEffect`, blocks staff/editor/account-destructive roots, and emits wiz-only audit output.
+   - The V4 non-command path shares opt-out checks, listener delivery, and audit output. Durable trace consequences and broader consent-policy models remain future work.
 
 ### Phase 3: Tricky Design Work
 
@@ -529,12 +549,10 @@ These are the parity items with the most engine-level uncertainty.
    - `Delusion`
    - `Shadowplay`
    - `Illuminant`
-   - Status: caster-scoped subjective short/full description overrides are live through `subjectivesdesc` and `subjectivedesc`.
+   - Status: caster-scoped subjective short/full description overrides are live through `subjectivesdesc` and `subjectivedesc`, now with priority and illusion-key handling.
    - Remaining work:
      - objective room-state illusions
      - multi-viewer or group-scoped illusions
-     - identity masking in psionic contact/trace flows
-     - explicit stacking and priority rules beyond the existing override-description effect ordering
 
 4. World-model-specific metaphysics.
    - `Determine Relationship`
@@ -639,6 +657,6 @@ This appendix is the historical family-by-family classification from the first p
 
 ### Psionics
 
-- Native now: `Contact`, `Barrier`, `Locate`, `Probe`, `Expel`, `Sense Presence`, `Mindblast`, `Mesmerize`, `Rejuvenate`, `Dome`
-- Builder+Prog now: `Empathy`, `Masquerade`, `Illusion`, `Disorient`, `Clairvoyance`, `Imitate`, `Project`, `Vanish`
-- Historical needs engine work: `Trace`, `Cathexis`, `Allspeak`, `Mindwipe`, `Shadowwalk`, `Hear`, `Control`, `Compel`, `Conceal`, `Clairaudience`, `Suggest`, `Babble`, `Coerce`, `Magicksense`, `Thoughtsense`, `Beast Affinity`, `Wild Contact`, `Wild Barrier`, `Immersion`
+- Native now: `Contact`, `Barrier`, `Locate`, `Probe`, `Expel`, `Sense Presence`, `Mindblast`, `Mesmerize`, `Rejuvenate`, `Dome`, `Trace`, `Allspeak`, `Hear`, `Clairaudience`, `Suggest`, `Babble`, `Coerce`, `Magicksense`, `Thoughtsense`, and `Immersion`
+- Builder+Prog now: `Empathy`, `Masquerade`, `Illusion`, `Disorient`, `Clairvoyance`, `Imitate`, `Project`, `Vanish`, `Beast Affinity`, `Wild Contact`, and `Wild Barrier`
+- Historical needs engine work still requiring content-specific decision or broader systems: `Cathexis`, `Mindwipe`, `Shadowwalk`, and true projection/possession interpretations

--- a/Design Documents/Magic_System_Implemented_Types.md
+++ b/Design Documents/Magic_System_Implemented_Types.md
@@ -35,16 +35,23 @@ It is intended for:
 | `state` | `StateGenerator` | Regenerator | Switch dispatch in `MudSharpCore/Magic/Generators/BaseMagicResourceGenerator.cs` | Yes | Adds one or more resources per minute based on boolean state progs |
 
 ## Power Types
+Current count: 25 power tokens, including 24 builder-creatable tokens and the non-builder `armor` runtime alias. V4 added 9 builder-creatable psionic powers in per-power files under `MudSharpCore/Magic/Powers/`.
 
 | Builder/runtime token | Class | Subsystem | Where registered or dispatched | Builder-creatable | Purpose |
 | --- | --- | --- | --- | --- | --- |
 | `armour` | `MagicArmourPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/MagicArmourPower.cs` via `MagicPowerFactory` | Yes | Applies magical armour behavior |
 | `armor` | `MagicArmourPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/MagicArmourPower.cs` via `MagicPowerFactory` | No | Runtime compatibility alias for the armour power model |
 | `anesthesia` | `MindAnesthesiaPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/MindAnesthesiaPower.cs` via `MagicPowerFactory` | Yes | Applies mental anesthesia behavior |
+| `allspeak` | `AllspeakPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/AllspeakPower.cs` via `MagicPowerFactory` | Yes | Sustains spoken-language comprehension without adding permanent language knowledge or literacy |
+| `babble` | `BabblePower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/BabblePower.cs` via `MagicPowerFactory` | Yes | Applies hostile timed speech obfuscation before language comprehension can decode speech |
 | `choke` | `ChokePower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/ChokePower.cs` via `MagicPowerFactory` | Yes | Applies choking or constriction behavior |
+| `clairaudience` | `ClairaudiencePower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/ClairaudiencePower.cs` via `MagicPowerFactory` | Yes | Sustains contact-based remote hearing through another mind's location |
+| `coerce` | `CoercePower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/CoercePower.cs` via `MagicPowerFactory` | Yes | Applies mode-based psionic influence for stamina, hunger, thirst, or thought injection |
 | `connectmind` | `ConnectMindPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/ConnectMindPower.cs` via `MagicPowerFactory` | Yes | Creates or manages a mind connection |
+| `hear` | `HearPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/HearPower.cs` via `MagicPowerFactory` | Yes | Sustains a listener for psionic thought and feeling traffic |
 | `invisibility` | `InvisibilityPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/InvisibilityPower.cs` via `MagicPowerFactory` | Yes | Applies invisibility behavior |
 | `magicattack` | `MagicAttackPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/MagicAttackPower.cs` via `MagicPowerFactory` | Yes | Executes a direct magical attack |
+| `magicksense` | `MagicksensePower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/MagicksensePower.cs` via `MagicPowerFactory` | Yes | Sustains `SenseMagical` perception and uses the existing magical aura display |
 | `mindaudit` | `MindAuditPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/MindAuditPower.cs` via `MagicPowerFactory` | Yes | Audits or inspects a mind |
 | `mindbarrier` | `MindBarrierPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/MindBarrierPower.cs` via `MagicPowerFactory` | Yes | Creates a mental barrier |
 | `mindbroadcast` | `MindBroadcastPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/MindBroadcastPower.cs` via `MagicPowerFactory` | Yes | Broadcasts mind-to-mind communication |
@@ -52,8 +59,11 @@ It is intended for:
 | `mindexpel` | `MindExpelPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/MindExpelPower.cs` via `MagicPowerFactory` | Yes | Expels a connection or presence |
 | `mindlook` | `MindLookPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/MindLookPower.cs` via `MagicPowerFactory` | Yes | Observes through mind mechanics |
 | `mindsay` | `MindSayPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/MindSayPower.cs` via `MagicPowerFactory` | Yes | Sends directed mind speech |
+| `projectemotion` | `ProjectEmotionPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/ProjectEmotionPower.cs` via `MagicPowerFactory` | Yes | Injects an involuntary feeling into a target mind and eligible psionic listeners |
 | `sense` | `SensePower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/SensePower.cs` via `MagicPowerFactory` | Yes | Senses characters or items across a configured range |
+| `suggest` | `SuggestPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/SuggestPower.cs` via `MagicPowerFactory` | Yes | Injects an involuntary thought, optionally wrapped with an emotional delivery |
 | `telepathy` | `TelepathyPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/TelepathyPower.cs` via `MagicPowerFactory` | Yes | Telepathic communication or related perception |
+| `trace` | `TracePower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/TracePower.cs` via `MagicPowerFactory` | Yes | Inspects active mind links around a target mind while respecting concealment difficulty |
 | n/a | `MagicPowerBase` | Power support | Shared base in `MudSharpCore/Magic/Powers/MagicPowerBase.cs` | No | Shared costs, progs, help text, crime handling, and builder support |
 | n/a | `SustainedMagicPower` | Power support | Shared base in `MudSharpCore/Magic/Powers/SustainedMagicPower.cs` | No | Shared support for sustained powers |
 | n/a | `MagicalMeleeAttackPower` | Power support | Shared base in `MudSharpCore/Magic/Powers/MagicalMeleeAttackPower.cs` | No | Shared support base for melee-style magical attacks |
@@ -81,6 +91,7 @@ It is intended for:
 | `vicinity` | `CastingTriggerVicinity` | Spell trigger | Static `RegisterFactory` in `MudSharpCore/Magic/SpellTriggers/CastingTriggerVicinity.cs` via `SpellTriggerFactory` | Yes | Casts across a vicinity target set |
 
 ## Spell Effect Types
+V4 added 2 builder-creatable tag-aware ward effect tokens: `roomtagward` and `personaltagward`.
 
 | Builder/runtime token | Class | Subsystem | Where registered or dispatched | Builder-creatable | Purpose |
 | --- | --- | --- | --- | --- | --- |
@@ -101,7 +112,7 @@ It is intended for:
 | `detectpoison` | `DetectPoisonEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/DetectPoisonEffect.cs` via `SpellEffectFactory` | Yes | Reports active and latent drug dosages on a character |
 | `disease` | `DiseaseEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/StandaloneStatusSpellEffects.Configured.cs` via `SpellEffectFactory` | Yes | Applies a configurable spell-owned systemic infection payload |
 | `dispelinvisibility` | `RemoveInvisibilityEffect` | Spell effect alias | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/WindSpellEffects.cs` via `SpellEffectFactory` | Yes | Builder/load alias for `removeinvisibility` |
-| `dispelmagic` | `DispelMagicEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/DispelMagicEffect.cs` via `SpellEffectFactory` | Yes | Removes or shortens matching spell-parent effects by caster policy, spell, school/subschool, tag, approved effect key, and optional strength contest |
+| `dispelmagic` | `DispelMagicEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/DispelMagicEffect.cs` via `SpellEffectFactory` | Yes | Removes or shortens matching spell-parent effects by caster policy, spell, school/subschool, tag, illusion key, approved effect key, and optional strength contest |
 | `destroyitem` | `DestroyItemEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs` via `SpellEffectFactory` | Yes | Deletes item targets with purge-warning safeguards |
 | `executeprog` | `ExecuteProgEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/ExecuteProgEffect.cs` via `SpellEffectFactory` | Yes | Executes a supporting prog |
 | `exitbarrier` | `ExitBarrierEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/ExitBarrierEffect.cs` via `SpellEffectFactory` | Yes | Applies a persistent magical barrier to a targeted shared `IExit` so crossing that exit can be blocked |
@@ -120,13 +131,14 @@ It is intended for:
 | `itemdamage` | `ItemDamageEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs` via `SpellEffectFactory` | Yes | Applies ordinary item damage using configured damage, pain, stun, and damage-type formulas |
 | `itemenchant` | `ItemEnchantEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs` via `SpellEffectFactory` | Yes | Adds item aura text, glow, weapon/armour hooks, projectile bonuses, craft-tool bonuses, power/fuel modifiers, and optional item event progs |
 | `levitate` | `LevitationEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/WindSpellEffects.cs` via `SpellEffectFactory` | Yes | Suspends a character or item, optionally moves it to a configured room layer, and prevents falling while active |
-| `magictag` | `MagicTagEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs` via `SpellEffectFactory` | Yes | Adds spell-owned key/value metadata for marks, anchors, runes, signatures, and FutureProg queries |
+| `magictag` | `MagicTagEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs` via `SpellEffectFactory` | Yes | Adds spell-owned key/value metadata for marks, anchors, runes, signatures, FutureProg queries, and tag-aware interdiction |
 | `magicresourcedelta` | `MagicResourceDeltaEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/MagicResourceDeltaEffect.cs` via `SpellEffectFactory` | Yes | Adds or removes a configured magic resource from a character, item, or room |
 | `mend` | `MendEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/MendEffect.cs` via `SpellEffectFactory` | Yes | Mends damage or wear |
 | `needdelta` | `NeedDeltaEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/NeedDeltaEffect.cs` via `SpellEffectFactory` | Yes | Changes a need immediately |
 | `needrate` | `NeedRateSpellEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/NeedRateSpellEffect.cs` via `SpellEffectFactory` | Yes | Alters need rate |
 | `pacifism` | `PacifismSpellEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/PacifismSpellEffect.cs` via `SpellEffectFactory` | Yes | Applies pacifism |
 | `personalward` | `PersonalWardEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/PersonalWardEffect.cs` via `SpellEffectFactory` | Yes | Applies a school-based personal ward that can fail or reflect matching incoming or outgoing magic |
+| `personaltagward` | `PersonalTagWardEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/TagWardSpellEffects.cs` via `SpellEffectFactory` | Yes | Applies a personal ward that fails or reflects matching incoming or outgoing magic by `magictag` key/value |
 | `paralysis` | `ParalysisEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/StandaloneStatusSpellEffects.cs` via `SpellEffectFactory` | Yes | Applies forced paralysis through the health effect system |
 | `poison` | `PoisonEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/StandaloneStatusSpellEffects.Configured.cs` via `SpellEffectFactory` | Yes | Applies a configurable spell-owned drug payload |
 | `portal` | `PortalSpellEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs` via `SpellEffectFactory` | Yes | Creates effect-owned paired transient exits between the caster's room and a target room, room anchor, or item/object anchor |
@@ -156,6 +168,7 @@ It is intended for:
 | `roomatmosphere` | `RoomAtmosphereEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/RoomAtmosphereEffect.cs` via `SpellEffectFactory` | Yes | Alters room atmosphere |
 | `roomlight` | `RoomLightEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/RoomLightEffect.cs` via `SpellEffectFactory` | Yes | Alters room light |
 | `roomward` | `RoomWardEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/RoomWardEffect.cs` via `SpellEffectFactory` | Yes | Applies a school-based room ward that can fail or reflect matching incoming or outgoing magic |
+| `roomtagward` | `RoomTagWardEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/TagWardSpellEffects.cs` via `SpellEffectFactory` | Yes | Applies a room ward that fails or reflects matching incoming or outgoing magic by `magictag` key/value |
 | `roomtemperature` | `RoomTemperatureEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/RoomTemperatureEffect.cs` via `SpellEffectFactory` | Yes | Alters room temperature |
 | `selfdamage` | `SelfDamageEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/SelfDamageEffect.cs` via `SpellEffectFactory` | Yes | Damages the caster |
 | `silence` | `SilenceEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/StandaloneStatusSpellEffects.cs` via `SpellEffectFactory` | Yes | Applies vocal silence without blocking telepathy |
@@ -167,8 +180,8 @@ It is intended for:
 | `telepathy` | `TelepathySpellEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/TelepathySpellEffect.cs` via `SpellEffectFactory` | Yes | Applies telepathic linkage |
 | `teleport` | `TeleportEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/TeleportEffect.cs` via `SpellEffectFactory` | Yes | Teleports the caster to a room or cell target |
 | `teleporttarget` | `TeleportTargetEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/TeleportTargetEffect.cs` via `SpellEffectFactory` | Yes | Teleports a target selected by the spell |
-| `subjectivedesc` | `SubjectiveDescriptionEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs` via `SpellEffectFactory` | Yes | Adds caster-scoped subjective full-description replacement |
-| `subjectivesdesc` | `SubjectiveSDescEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs` via `SpellEffectFactory` | Yes | Adds caster-scoped subjective short-description replacement |
+| `subjectivedesc` | `SubjectiveDescriptionEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs` via `SpellEffectFactory` | Yes | Adds caster-scoped subjective full-description replacement with priority and optional illusion key |
+| `subjectivesdesc` | `SubjectiveSDescEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs` via `SpellEffectFactory` | Yes | Adds caster-scoped subjective short-description replacement with priority and optional illusion key |
 | `transference` | `TransferenceEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/WindSpellEffects.cs` via `SpellEffectFactory` | Yes | Swaps caster and target character locations, optionally including followers and room layers |
 | `transformform` | `TransformFormEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/TransformFormEffect.cs` via `SpellEffectFactory` | Yes | Ensures or reuses a keyed alternate body form, applies first-creation defaults such as description patterns and transformation echo, contributes a priority-ranked forced transformation demand, and reuses the shared baseline-form revert path when the demand ends |
 | `waterbreathing` | `WaterBreathingEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/StandaloneStatusSpellEffects.cs` via `SpellEffectFactory` | Yes | Grants additional breathable fluids for the target |
@@ -184,6 +197,10 @@ It is intended for:
 | `incoming`, `outgoing`, `both` | `MagicInterdictionCoverage` | Ward coverage enum that decides whether an interdiction catches incoming magic, outgoing magic, or both |
 | `fail`, `reflect` | `MagicInterdictionMode` | Ward mode enum that decides whether a matching invocation fizzles or reflects where the runtime supports reflection |
 | n/a | `IMagicInterdictionEffect` | Shared runtime contract used by room and personal wards so spells and powers can consult the same interception rules |
+| n/a | `IMagicContextualInterdictionEffect` | Optional contextual interdiction contract that can inspect source, target, school, direction, and invocation tags |
+| n/a | `MagicInterdictionContext` | Shared context object passed to contextual interdiction effects |
+| n/a | `MagicInterdictionTag` | Key/value metadata pair used by tag-aware wards |
+| n/a | `IMagicInterdictionTagProvider` | Template-side contract for spell effects that contribute contextual interdiction tags |
 | n/a | `IExitBarrierEffect` | Shared runtime contract used by movement logic so magical exit barriers can block `Character.CanCross` |
 
 ## Engine V2 Support Types
@@ -201,6 +218,21 @@ It is intended for:
 | n/a | `ILevitationEffect` | Spell-owned levitation marker for target-specific suspension |
 | n/a | `IFallDamageMitigationEffect` | Shared fall mitigation contract exposing fall-distance and fall-damage multipliers |
 
+## Engine V4 Support Types
+
+| Token or API | Class or interface | Role |
+| --- | --- | --- |
+| n/a | `PsionicTrafficHelper` | Shared helper for involuntary psionic thought/feeling delivery, eligible listener forwarding, opt-out checks, blocked command roots, source/target messaging, and wiz-audit output |
+| n/a | `IPrioritisedOverrideDescEffect` | Subjective-description priority and illusion-key contract used by body/item description override resolution and `dispelmagic illusion <key>` |
+| n/a | `IBabbleSpeechEffect` | Speech-obfuscation contract used by communication strategies before language comprehension |
+| n/a | `PsionicSustainedPowerEffectBase<TPower>` | Shared base for V4 sustained psionic effects |
+| n/a | `MagicAllspeakEffect` | Sustained `IComprehendLanguageEffect` used by `allspeak` |
+| n/a | `MagicMagicksenseEffect` | Sustained `SenseMagical` perception grant used by `magicksense` |
+| n/a | `PsionicHearEffect` | Sustained `ITelepathyEffect` listener used by `hear` |
+| n/a | `PsionicBabbleEffect` | Timed `IBabbleSpeechEffect` used by `babble` |
+| n/a | `MagicClairaudienceConcentrationEffect` | Caster-side concentration marker for `clairaudience` |
+| n/a | `PsionicClairaudienceEffect` | Remote-observation effect that forwards audible output only |
+
 ## Notes
 - Schools are first-class records rather than subtype-driven types, so they are documented in the overview and backbone docs rather than listed here as a type family.
 - Powers, triggers, and spell effects are all current-state inventories of registered runtime implementations.
@@ -209,3 +241,4 @@ It is intended for:
 - Phase 1 spell support also introduced additive `IEffect.PerceptionGranting`, spell-runtime query interfaces such as `ISilencedEffect`, `ISleepEffect`, `IFearEffect`, `IFlightEffect`, `IAdditionalBreathableFluidEffect`, `IDarksightEffect`, `IComprehendLanguageEffect`, and `ICurseEffect`, plus shared `MagicArmourConfiguration` for power and spell armour parity.
 - `transformform` is the current builder-creatable spell effect for cached alternate-form provisioning and scripted transformation, including optional transformation emotes, first-creation description-pattern defaults, and configurable forced-transformation priority metadata.
 - Wind spell support extends the runtime movement layer with `IFly.CanContinueFlying`, target-specific fall prevention, fall-damage mitigation, exit-path forced movement, precise invisibility removal, and caster/target transference.
+- V4 psionic and perception support adds 9 power tokens, tag-aware wards, contextual interdiction tags, illusion priority/key matching, speech babbling, remote audible observation, and non-command psionic traffic/coercion delivery.

--- a/Design Documents/Magic_System_Powers.md
+++ b/Design Documents/Magic_System_Powers.md
@@ -90,8 +90,9 @@ In current runtime behavior:
 - `MagicPowerBase` target acquisition filters out targets blocked by matching room or personal wards
 - custom target-gathering powers such as `SensePower` and `ConnectMindPower` also consult the shared interdiction helper
 - this means school-based room and personal wards can block magical and psionic powers as well as spells
+- contextual interdiction effects can inspect invocation metadata; tag-aware spell wards use this for `magictag` key/value matching
 
-Unlike spells, powers do not currently use ward reflection retargeting. Their target acquisition path simply treats interdicted targets as invalid.
+Unlike spells, powers do not currently use ward reflection retargeting. Their target acquisition path simply treats interdicted targets as invalid. Powers currently enter this shared helper without spell-effect tags, so tag-aware wards are primarily a spell-interdiction tool unless a future power type supplies explicit tags.
 
 ### How power types are loaded
 `MagicPowerFactory` uses reflection to find `IMagicPower` implementers in the executing assembly and call their static `RegisterLoader` method.
@@ -131,6 +132,7 @@ All ordinary power types get these common commands:
 - `why <prog>`
 - `help`
 - `cost <verb> <which> <number>`
+- `psionic` / `psi`, which toggles the psionics crime category
 
 Each concrete power type then adds its own subtype commands in its overridden `BuildingCommand`.
 
@@ -196,16 +198,22 @@ Add a new power type when the behavior does not fit the spell system well and de
 
 ## Current Implemented Power Types
 ### Builder-registered power types
-These are the currently builder-creatable power tokens registered through `MagicPowerFactory`:
+These are the currently builder-creatable power tokens registered through `MagicPowerFactory`. There are 24 builder-created tokens in this table; the implemented-types inventory also lists the non-builder `armor` runtime alias.
 
 | Builder token | Class | Summary |
 | --- | --- | --- |
 | `armour` | `MagicArmourPower` | Sustained defensive protection effect |
 | `anesthesia` | `MindAnesthesiaPower` | Mental anesthesia style effect |
+| `allspeak` | `AllspeakPower` | Sustained spoken-language comprehension without permanent language gain |
+| `babble` | `BabblePower` | Timed hostile speech obfuscation |
 | `choke` | `ChokePower` | Choking or constriction style offensive power |
+| `clairaudience` | `ClairaudiencePower` | Sustained contact-based remote hearing through another mind's location |
+| `coerce` | `CoercePower` | Mode-based psionic influence for stamina, hunger, thirst, or thought injection |
 | `connectmind` | `ConnectMindPower` | Creates or manages mind links |
+| `hear` | `HearPower` | Sustained listener for psionic thought and feeling traffic |
 | `invisibility` | `InvisibilityPower` | Applies invisibility behavior |
 | `magicattack` | `MagicAttackPower` | Direct magical attack action |
+| `magicksense` | `MagicksensePower` | Sustained magical-aura perception grant |
 | `mindaudit` | `MindAuditPower` | Mind-reading or auditing style power |
 | `mindbarrier` | `MindBarrierPower` | Mental barrier or protection effect |
 | `mindbroadcast` | `MindBroadcastPower` | Broadcast-style mind communication |
@@ -213,8 +221,11 @@ These are the currently builder-creatable power tokens registered through `Magic
 | `mindexpel` | `MindExpelPower` | Expels connected minds or effects |
 | `mindlook` | `MindLookPower` | Observe or inspect through mind-link mechanics |
 | `mindsay` | `MindSayPower` | Directed mind-to-mind speech |
+| `projectemotion` | `ProjectEmotionPower` | Injects an involuntary feeling into the target's mind and eligible listeners |
 | `sense` | `SensePower` | Sense targets across a configurable distance |
+| `suggest` | `SuggestPower` | Injects an involuntary thought, optionally with an emotional wrapper |
 | `telepathy` | `TelepathyPower` | Telepathic communication or related perception |
+| `trace` | `TracePower` | Inspects active mind links around a target mind while respecting concealment |
 
 Important current-state note:
 
@@ -230,9 +241,11 @@ The mind-link stack now shares a first-class concealment policy through `IMindCo
 - apply to the owning school and, optionally, child schools
 - use a character/observer prog to decide who is affected
 
-Passive psionic traffic continues to use the existing `telepathy` flow. Configure `telepathy` with `thinks`, `feels`, and `thinkemote` to represent powers such as Thoughtsense or Immersion. When the thinker is sustaining `mindconceal`, passive `think` and `feel` traffic uses the concealed identity instead of leaking the actor's short description or personal name.
+Passive psionic traffic can use either the existing `telepathy` flow or the dedicated V4 `hear` power, depending on whether the content wants ordinary telepathic communication or a sustained listener. Configure `telepathy` with `thinks`, `feels`, and `thinkemote` to represent broad passive links such as Thoughtsense or Immersion. When the thinker is sustaining `mindconceal`, passive `think` and `feel` traffic uses the concealed identity instead of leaking the actor's short description or personal name.
 
-This is intentionally separate from true projection or possession. `mindconceal` hides identity across mind-contact and passive telepathy surfaces; it does not create a second acting body or remote command shell.
+V4 adds a shared psionic traffic/coercion helper used by `projectemotion`, `suggest`, and `coerce`. It handles involuntary mental delivery, eligible listener forwarding, opt-out/refusal checks, consistent source/target messaging, and wiz-audit output. `coerce` supports stamina, hunger, thirst, and thought modes; it does not run the victim's command parser.
+
+This is intentionally separate from true projection or possession. `mindconceal` hides identity across mind-contact and passive telepathy surfaces; `clairaudience` forwards remote audible output through another mind's location; neither creates a second acting body or remote command shell.
 
 ### Notable base or runtime-support types
 These matter to developers extending the subsystem, but they are not standalone builder-created types.
@@ -242,6 +255,13 @@ These matter to developers extending the subsystem, but they are not standalone 
 | `MagicPowerBase` | Main shared base for most powers |
 | `SustainedMagicPower` | Shared support for powers that persist and consume concentration over time |
 | `MagicalMeleeAttackPower` | Abstract base for melee-style magic attacks; not a standalone builder type |
+| `PsionicTrafficHelper` | Shared policy helper for involuntary thought/feeling delivery, eligible listener forwarding, opt-out checks, blocked command roots, and audit output |
+| `PsionicSustainedPowerEffectBase<TPower>` | Shared runtime base for the V4 sustained psionic effects |
+| `MagicAllspeakEffect` | Sustained `IComprehendLanguageEffect` used by `allspeak` |
+| `PsionicBabbleEffect` | Timed `IBabbleSpeechEffect` used by `babble` |
+| `MagicMagicksenseEffect` | Sustained magical perception grant used by `magicksense` |
+| `PsionicHearEffect` | Sustained `ITelepathyEffect` listener used by `hear` |
+| `PsionicClairaudienceEffect` | Remote audible-observation effect used by `clairaudience` |
 
 ## Important Current-State Notes
 - School verbs are the player namespace for powers. There is no separate general player command that bypasses the school.
@@ -249,6 +269,7 @@ These matter to developers extending the subsystem, but they are not standalone 
 - Power definitions are polymorphic and XML-backed, so database seeding must match the runtime class exactly.
 - If a power type grows mostly into editable composition rather than unique runtime logic, it may be a better fit as a spell instead of as a new power class.
 - Room and personal wards are authored as spell effects, but targeted powers and psionic sensing flows still respect them through the shared interdiction helper.
+- `connectmind` has a target-eligibility prog in addition to its target-list prog. Use that for animal, wild, or setting-specific contact variants before adding a new hard-coded link power.
 
 ## Related Reading
 - [Magic System Overview](./Magic_System_Overview.md)

--- a/Design Documents/Magic_System_Spells.md
+++ b/Design Documents/Magic_System_Spells.md
@@ -123,8 +123,10 @@ Current interdiction sources are:
 
 - room wards
 - personal wards
+- room tag wards
+- personal tag wards
 
-These wards match by school, optionally include child schools, and can be further gated by a custom prog.
+School wards match by school, optionally include child schools, and can be further gated by a custom prog. Tag wards match configured `magictag` key/value metadata exposed by spell effects that implement the contextual interdiction tag provider.
 
 Current behavior is:
 
@@ -390,6 +392,7 @@ General dispels use `dispelmagic`. It can either remove matching spell-parent ef
 - caster policy: own, any, or others
 - magic tag and optional tag value
 - approved effect key such as `spell`, `invisibility`, `flight`, `levitation`, `featherfall`, `magictag`, `itemenchant`, `portal`, `planarstate`, `roomward`, `personalward`, `exitbarrier`, `subjectivedesc`, `transformform`, `projectile`, `crafttool`, `powerfuel`, or `itemevent`
+- keyed subjective illusions through `illusion <key>`
 - optional strength contest
 
 The default policy is caster-owned cleanup. Hostile dispels must be explicitly configured with hostile matching and then travel through the ordinary spell targeting, ward, and resistance flow.
@@ -401,6 +404,13 @@ The Engine V3 edge-status slice adds:
 - `detectpoison`: instantly reports a character's active and latent drug dosages, including drug IDs, localized mass, and latent delivery vector.
 - `insomnia` / `removeinsomnia`: prevents voluntary sleep and blocks magical sleep while active.
 - `removeblindness` / `cureblindness`: removes spell-owned blindness; `cureblindness` saves as `removeblindness`.
+
+The Engine V4 psionic/perception slice adds:
+
+- contextual interdiction tags from `magictag`, so tag-aware wards can inspect spell metadata rather than only school/subschool.
+- `roomtagward` / `personaltagward`, which reuse ward coverage and fail/reflect modes but match `magictag` key/value metadata.
+- subjective-description priority and illusion keys on `subjectivedesc` / `subjectivesdesc`.
+- `dispelmagic illusion <key>`, which targets keyed subjective-description effects through the general dispel flow.
 
 Portals remain saved spell effects, not database exits or a gate table. The `portal` effect creates paired transient exits registered with `IExitManager`; active magical portals expose `IMagicPortalExit` metadata and can be inspected with `magic portals`. Anchor tags can be placed on rooms or items/objects with `magictag`; `portal` resolves caster-owned room anchors first, then caster-owned item anchors by using the item location. Builders can inspect active anchors with `magic anchors [tag]`.
 
@@ -544,6 +554,8 @@ Important implementation note:
 | `vicinity` | `CastingTriggerVicinity` | Casts across a vicinity target set |
 
 ## Current Implemented Spell Effect Types
+The V4 spell-side catalogue adds 2 tag-aware ward tokens: `roomtagward` and `personaltagward`.
+
 | Token | Class | Summary |
 | --- | --- | --- |
 | `blindness` | `BlindnessEffect` | Applies blindness |
@@ -563,7 +575,7 @@ Important implementation note:
 | `detectpoison` | `DetectPoisonEffect` | Reports active and latent drug dosages on a character |
 | `disease` | `DiseaseEffect` | Applies a configurable spell-owned systemic infection |
 | `dispelinvisibility` | `RemoveInvisibilityEffect` | Builder/load alias for `removeinvisibility` |
-| `dispelmagic` | `DispelMagicEffect` | Removes or shortens matching saved spell effects by caster policy, spell, school/subschool, magic tag, approved effect key, or optional strength contest |
+| `dispelmagic` | `DispelMagicEffect` | Removes or shortens matching saved spell effects by caster policy, spell, school/subschool, magic tag, illusion key, approved effect key, or optional strength contest |
 | `destroyitem` | `DestroyItemEffect` | Deletes item targets with purge-warning safeguards |
 | `executeprog` | `ExecuteProgEffect` | Executes a supporting prog |
 | `exitbarrier` | `ExitBarrierEffect` | Applies a persistent magical barrier to a targeted exit |
@@ -582,13 +594,14 @@ Important implementation note:
 | `itemdamage` | `ItemDamageEffect` | Damages an item with configured damage, pain, stun, and damage type |
 | `itemenchant` | `ItemEnchantEffect` | Adds aura/glow, weapon/armour bonuses, projectile payload bonuses, craft-tool bonuses, power/fuel modifiers, and optional item event progs |
 | `levitate` | `LevitationEffect` | Suspends a character or item, optionally moves it to a configured room layer, and prevents falling while active |
-| `magictag` | `MagicTagEffect` | Adds spell-owned key/value metadata for marks, anchors, runes, signatures, and FutureProg queries |
+| `magictag` | `MagicTagEffect` | Adds spell-owned key/value metadata for marks, anchors, runes, signatures, FutureProg queries, and tag-aware interdiction |
 | `magicresourcedelta` | `MagicResourceDeltaEffect` | Adds or removes a configured magic resource from a character, item, or room |
 | `mend` | `MendEffect` | Mends damage or wear |
 | `needdelta` | `NeedDeltaEffect` | Changes a need immediately |
 | `needrate` | `NeedRateSpellEffect` | Alters need rate |
 | `pacifism` | `PacifismSpellEffect` | Applies pacifism |
 | `personalward` | `PersonalWardEffect` | Applies a school-based personal ward that can fail or reflect matching incoming or outgoing magic |
+| `personaltagward` | `PersonalTagWardEffect` | Applies a personal ward that fails or reflects matching incoming or outgoing magic by `magictag` key/value |
 | `planarstate` | `PlanarStateSpellEffect` | Applies a corporeal or noncorporeal planar overlay to the target |
 | `planeshift` | `PlanarStateSpellEffect` | Moves the target into a configured corporeal or noncorporeal planar state |
 | `paralysis` | `ParalysisEffect` | Applies magical paralysis through the forced-paralysis hook |
@@ -621,6 +634,7 @@ Important implementation note:
 | `roomatmosphere` | `RoomAtmosphereEffect` | Alters room atmosphere |
 | `roomlight` | `RoomLightEffect` | Alters room light |
 | `roomward` | `RoomWardEffect` | Applies a school-based room ward that can fail or reflect matching incoming or outgoing magic |
+| `roomtagward` | `RoomTagWardEffect` | Applies a room ward that fails or reflects matching incoming or outgoing magic by `magictag` key/value |
 | `roomtemperature` | `RoomTemperatureEffect` | Alters room temperature |
 | `selfdamage` | `SelfDamageEffect` | Damages the caster |
 | `silence` | `SilenceEffect` | Applies vocal silence without blocking telepathy |
@@ -633,8 +647,8 @@ Important implementation note:
 | `teleport` | `TeleportEffect` | Teleports the caster to a room or cell target |
 | `teleporttarget` | `TeleportTargetEffect` | Teleports a target selected by the spell |
 | `transference` | `TransferenceEffect` | Swaps the caster and target character locations, optionally including followers and room layers |
-| `subjectivedesc` | `SubjectiveDescriptionEffect` | Adds caster-scoped subjective full-description replacement |
-| `subjectivesdesc` | `SubjectiveSDescEffect` | Adds caster-scoped subjective short-description replacement |
+| `subjectivedesc` | `SubjectiveDescriptionEffect` | Adds caster-scoped subjective full-description replacement with priority and optional illusion key |
+| `subjectivesdesc` | `SubjectiveSDescEffect` | Adds caster-scoped subjective short-description replacement with priority and optional illusion key |
 | `transformform` | `TransformFormEffect` | Ensures or reuses a keyed alternate body form and applies a priority-ranked forced transformation demand |
 | `waterbreathing` | `WaterBreathingEffect` | Grants additional breathable fluids |
 | `weatherchange` | `WeatherChangeEffect` | Changes weather |
@@ -643,9 +657,9 @@ Important implementation note:
 | `weight` | `WeightSpellEffect` | Alters weight |
 
 ## Ward Effects
-`roomward` and `personalward` are the reusable spell-authored interdiction primitives.
+`roomward` and `personalward` are the reusable school-based spell-authored interdiction primitives. `roomtagward` and `personaltagward` are the tag-aware variants for magic that carries `magictag` metadata.
 
-Both support these builder commands:
+School wards support these builder commands:
 
 - `school <school>`
 - `mode fail|reflect`
@@ -653,10 +667,23 @@ Both support these builder commands:
 - `subschools`
 - `prog <prog>|none`
 
-The optional custom prog can use either of these signatures:
+Their optional custom prog can use either of these signatures:
 
 - `(character source, perceivable owner) -> bool`
 - `(character source, perceivable owner, magicschool school) -> bool`
+
+Tag wards support these builder commands:
+
+- `tag <tag> [value]`
+- `value <value|none>`
+- `mode fail|reflect`
+- `coverage incoming|outgoing|both`
+- `prog <prog>|none`
+
+Their optional custom prog can use either of these signatures:
+
+- `(character source, perceivable owner) -> bool`
+- `(character source, perceivable owner, text tag, text value) -> bool`
 
 Reflection is intentionally narrow:
 
@@ -668,7 +695,7 @@ Reflection is intentionally narrow:
 - The trigger/effect registries are the extension point; there is no fully script-defined spell-effect system.
 - Readiness validation is a major part of spell authoring. If a spell is incomplete, it will show a builder error rather than quietly misbehaving.
 - Caster effects are separate from ordinary effects and apply to the caster after the target-side application path.
-- Target-side spell application now checks room and personal wards after the casting emote and before any target-side effect is applied.
+- Target-side spell application now checks room, personal, room-tag, and personal-tag wards after the casting emote and before any target-side effect is applied.
 - Status-style spell effects are not currently modelled as one generic "status enum" template. The builder-visible Phase 1 statuses are intentionally separate effect types so XML shape, help text, and runtime semantics can differ cleanly per effect.
 
 ## Related Reading

--- a/FutureMUDLibrary/Effects/Interfaces/IBabbleSpeechEffect.cs
+++ b/FutureMUDLibrary/Effects/Interfaces/IBabbleSpeechEffect.cs
@@ -1,0 +1,5 @@
+namespace MudSharp.Effects.Interfaces;
+
+public interface IBabbleSpeechEffect : IEffectSubtype
+{
+}

--- a/FutureMUDLibrary/Effects/Interfaces/IMagicContextualInterdictionEffect.cs
+++ b/FutureMUDLibrary/Effects/Interfaces/IMagicContextualInterdictionEffect.cs
@@ -1,0 +1,8 @@
+using MudSharp.Magic;
+
+namespace MudSharp.Effects.Interfaces;
+
+public interface IMagicContextualInterdictionEffect : IEffectSubtype
+{
+	bool ShouldInterdict(MagicInterdictionContext context);
+}

--- a/FutureMUDLibrary/Effects/Interfaces/IPrioritisedOverrideDescEffect.cs
+++ b/FutureMUDLibrary/Effects/Interfaces/IPrioritisedOverrideDescEffect.cs
@@ -1,0 +1,7 @@
+namespace MudSharp.Effects.Interfaces;
+
+public interface IPrioritisedOverrideDescEffect : IEffectSubtype
+{
+	int OverridePriority { get; }
+	string OverrideKey { get; }
+}

--- a/FutureMUDLibrary/Magic/MagicInterdictionContext.cs
+++ b/FutureMUDLibrary/Magic/MagicInterdictionContext.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using MudSharp.Character;
+using MudSharp.Framework;
+
+namespace MudSharp.Magic;
+
+#nullable enable
+
+public sealed record MagicInterdictionTag(string Tag, string Value);
+
+public sealed class MagicInterdictionContext
+{
+	public MagicInterdictionContext(ICharacter source, IPerceivable? target, IMagicSchool school,
+		IReadOnlyCollection<MagicInterdictionTag> tags, IReadOnlyCollection<SpellAdditionalParameter> additionalParameters)
+	{
+		Source = source;
+		Target = target;
+		School = school;
+		Tags = tags;
+		AdditionalParameters = additionalParameters;
+	}
+
+	public ICharacter Source { get; }
+	public IPerceivable? Target { get; }
+	public IMagicSchool School { get; }
+	public IReadOnlyCollection<MagicInterdictionTag> Tags { get; }
+	public IReadOnlyCollection<SpellAdditionalParameter> AdditionalParameters { get; }
+}
+
+public interface IMagicInterdictionTagProvider
+{
+	IEnumerable<MagicInterdictionTag> MagicInterdictionTags { get; }
+}

--- a/FutureMUDLibrary/PerceptionEngine/IEmote.cs
+++ b/FutureMUDLibrary/PerceptionEngine/IEmote.cs
@@ -14,7 +14,8 @@ namespace MudSharp.PerceptionEngine
         LanguageIsChoking,
         LanguageIsClicking,
         LanguageIsError,
-        LanguageIsBuzzing
+        LanguageIsBuzzing,
+        LanguageIsBabbling
     }
 
 

--- a/MudSharpCore Unit Tests/MagicEngineV4Tests.cs
+++ b/MudSharpCore Unit Tests/MagicEngineV4Tests.cs
@@ -1,0 +1,416 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Body.Traits;
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Effects.Concrete.SpellEffects;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.Magic;
+using MudSharp.Magic.Powers;
+using MudSharp.Magic.SpellEffects;
+using MudSharp.Magic.SpellTriggers;
+using MudSharp.Models;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Xml.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class MagicEngineV4Tests
+{
+	private static readonly string[] V4PowerTypes =
+	[
+		"trace",
+		"hear",
+		"clairaudience",
+		"allspeak",
+		"babble",
+		"magicksense",
+		"projectemotion",
+		"suggest",
+		"coerce"
+	];
+
+	[TestInitialize]
+	public void TestInitialize()
+	{
+		SpellTriggerFactory.SetupFactory();
+		SpellEffectFactory.SetupFactory();
+	}
+
+	[TestMethod]
+	public void MagicPowerFactory_RegistersAndLoadsV4PsionicPowerTypes()
+	{
+		var gameworld = CreateGameworld();
+
+		foreach (var type in V4PowerTypes)
+		{
+			var power = MagicPowerFactory.LoadPower(CreatePowerModel(type), gameworld.Object);
+
+			Assert.AreEqual(type, ((MagicPowerBase)power).DatabaseType, $"DatabaseType mismatch for {type}.");
+			Assert.IsTrue(power.IsPsionic, $"{type} should load as psionic.");
+			CollectionAssert.Contains(power.Verbs.ToArray(), PrimaryVerb(type));
+		}
+	}
+
+	[TestMethod]
+	public void V4PowerXml_RoundTripsPsionicAndBasePolicyFields()
+	{
+		var gameworld = CreateGameworld();
+		var power = MagicPowerFactory.LoadPower(CreatePowerModel("suggest"), gameworld.Object);
+
+		var saved = InvokeSaveDefinition(power);
+
+		Assert.IsTrue(bool.Parse(saved.Element("IsPsionic")!.Value));
+		Assert.AreEqual("0", saved.Element("CanInvokePowerProg")!.Value);
+		Assert.AreEqual("0", saved.Element("WhyCantInvokePowerProg")!.Value);
+		Assert.IsNotNull(saved.Element("InvocationCosts"));
+		Assert.AreEqual("suggest", saved.Element("Verb")!.Value);
+	}
+
+	[TestMethod]
+	public void ConnectMindPower_LoadsAndAppliesTargetEligibilityProg()
+	{
+		var trueProg = CreateProg(0, true);
+		var falseProg = CreateProg(2, false);
+		var gameworld = CreateGameworld(progs: [trueProg.Object, falseProg.Object]);
+		var power = (ConnectMindPower)MagicPowerFactory.LoadPower(CreateConnectMindModel(2), gameworld.Object);
+		var owner = CreateCharacter(10, gameworld.Object);
+		var target = CreateCharacter(11, gameworld.Object);
+		var method = typeof(ConnectMindPower).GetMethod("TargetFilterFunction",
+			BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+		Assert.AreSame(falseProg.Object, power.TargetEligibilityProg);
+		Assert.AreEqual(false, method.Invoke(power, [owner.Object, target.Object]));
+	}
+
+	[TestMethod]
+	public void SpellEffectFactory_RegistersV4TagWardTypes()
+	{
+		var spell = CreateSpellMock();
+
+		foreach (var type in new[] { "roomtagward", "personaltagward" })
+		{
+			var (effect, error) = SpellEffectFactory.LoadEffectFromBuilderInput(type, new StringStack(string.Empty),
+				spell.Object);
+
+			Assert.AreEqual(string.Empty, error);
+			Assert.IsNotNull(effect);
+			Assert.AreEqual(type, effect!.SaveToXml().Attribute("type")?.Value);
+			Assert.IsTrue(SpellEffectFactory.BuilderInfoForType(type).MatchingTriggers.Any());
+		}
+	}
+
+	[TestMethod]
+	public void MagicTagEffect_ExposesInterdictionMetadata()
+	{
+		var spell = CreateSpellMock();
+		var effect = SpellEffectFactory.LoadEffect(new XElement("Effect",
+			new XAttribute("type", "magictag"),
+			new XElement("Tag", new XCData("discipline")),
+			new XElement("Value", new XCData("mind")),
+			new XElement("ReplaceExisting", true)), spell.Object);
+
+		var tag = ((IMagicInterdictionTagProvider)effect).MagicInterdictionTags.Single();
+
+		Assert.AreEqual("discipline", tag.Tag);
+		Assert.AreEqual("mind", tag.Value);
+	}
+
+	[TestMethod]
+	public void SubjectiveDescriptionEffect_RoundTripsPriorityAndIllusionKey()
+	{
+		var spell = CreateSpellMock();
+		var effect = SpellEffectFactory.LoadEffect(new XElement("Effect",
+			new XAttribute("type", "subjectivedesc"),
+			new XElement("Description", new XCData("A false face.")),
+			new XElement("FixedViewer", true),
+			new XElement("Priority", 5),
+			new XElement("OverrideKey", new XCData("false-face")),
+			new XElement("ApplicabilityProg", 0)), spell.Object);
+
+		var saved = effect.SaveToXml();
+
+		Assert.AreEqual("5", saved.Element("Priority")!.Value);
+		Assert.AreEqual("false-face", saved.Element("OverrideKey")!.Value);
+	}
+
+	[TestMethod]
+	public void RuntimeSubjectiveDescriptionEffect_ExposesPriorityAndKey()
+	{
+		var gameworld = CreateGameworld();
+		var owner = CreatePerceivable(gameworld.Object);
+		var parent = CreateParent();
+		var effect = new SpellSubjectiveDescriptionEffect(owner.Object, parent.Object,
+			MudSharp.Form.Shape.DescriptionType.Full, "A false face.", 0, priority: 7, overrideKey: "mask");
+
+		Assert.AreEqual(7, effect.OverridePriority);
+		Assert.AreEqual("mask", effect.OverrideKey);
+	}
+
+	[TestMethod]
+	public void PsionicTrafficHelper_RespectsIgnoreForceOptOut()
+	{
+		var target = new Mock<ICharacter>();
+		target.Setup(x => x.AffectedBy<IIgnoreForceEffect>()).Returns(true);
+
+		Assert.IsFalse(PsionicTrafficHelper.CanReceiveInvoluntaryMentalTraffic(target.Object));
+	}
+
+	private static XElement InvokeSaveDefinition(IMagicPower power)
+	{
+		return (XElement)power.GetType()
+		                      .GetMethod("SaveDefinition", BindingFlags.Instance | BindingFlags.NonPublic)!
+		                      .Invoke(power, [])!;
+	}
+
+	private static MagicPower CreatePowerModel(string type)
+	{
+		return new MagicPower
+		{
+			Id = Array.IndexOf(V4PowerTypes, type) + 1,
+			Name = type,
+			Blurb = type,
+			ShowHelp = type,
+			MagicSchoolId = 1,
+			PowerModel = type,
+			Definition = type switch
+			{
+				"hear" => SustainedDefinition("hear", "endhear",
+					new XElement("PowerDistance", MagicPowerDistance.AnyConnectedMindOrConnectedTo),
+					new XElement("ShowThinks", true),
+					new XElement("ShowFeels", true),
+					new XElement("ShowName", false),
+					new XElement("ShowEmotes", true),
+					new XElement("ShowDescriptionProg", 0L)).ToString(),
+				"clairaudience" => ClairaudienceDefinition().ToString(),
+				"allspeak" => SustainedDefinition("allspeak", "endallspeak").ToString(),
+				"magicksense" => SustainedDefinition("magicksense", "endmagicksense").ToString(),
+				"babble" => TargetedDefinition("babble", new XElement("DurationSeconds", 120.0)).ToString(),
+				"coerce" => TargetedDefinition("coerce",
+					new XElement("StaminaFractionPerDegree", 0.05),
+					new XElement("NeedHoursPerDegree", 2.0)).ToString(),
+				_ => TargetedDefinition(type).ToString()
+			}
+		};
+	}
+
+	private static XElement TargetedDefinition(string verb, params object[] additional)
+	{
+		var definition = new XElement("Definition",
+			BaseElements(),
+			new XElement("Verb", verb),
+			new XElement("PowerDistance", MagicPowerDistance.AnyConnectedMindOrConnectedTo),
+			new XElement("SkillCheckDifficulty", (int)Difficulty.Normal),
+			new XElement("SkillCheckTrait", 1L),
+			new XElement("MinimumSuccessThreshold", (int)Outcome.MinorPass),
+			new XElement("DetectableWithDetectMagic", (int)Difficulty.Normal),
+			new XElement("FailEcho", new XCData("Fail.")),
+			new XElement("SuccessEcho", new XCData(string.Empty))
+		);
+		foreach (var item in additional)
+		{
+			definition.Add(item);
+		}
+
+		return definition;
+	}
+
+	private static XElement SustainedDefinition(string begin, string end, params object[] additional)
+	{
+		var definition = new XElement("Definition",
+			BaseElements(),
+			new XElement("BeginVerb", begin),
+			new XElement("EndVerb", end),
+			new XElement("SkillCheckDifficulty", (int)Difficulty.Normal),
+			new XElement("SkillCheckTrait", 1L),
+			new XElement("MinimumSuccessThreshold", (int)Outcome.MinorPass),
+			new XElement("BeginEmote", new XCData("Begin.")),
+			new XElement("EndEmote", new XCData("End.")),
+			new XElement("FailEmote", new XCData("Fail.")),
+			new XElement("ConcentrationPointsToSustain", 1.0),
+			new XElement("SustainPenalty", 0.0),
+			new XElement("DetectableWithDetectMagic", (int)Difficulty.Normal),
+			new XElement("SustainResourceCosts")
+		);
+		foreach (var item in additional)
+		{
+			definition.Add(item);
+		}
+
+		return definition;
+	}
+
+	private static XElement ClairaudienceDefinition()
+	{
+		var definition = SustainedDefinition("clairaudience", "endclairaudience");
+		definition.Add(new XElement("PowerDistance", MagicPowerDistance.AnyConnectedMindOrConnectedTo));
+		return definition;
+	}
+
+	private static object[] BaseElements()
+	{
+		return
+		[
+			new XElement("CanInvokePowerProg", 0L),
+			new XElement("WhyCantInvokePowerProg", 0L),
+			new XElement("IsPsionic", true),
+			new XElement("InvocationCosts")
+		];
+	}
+
+	private static string PrimaryVerb(string type)
+	{
+		return type switch
+		{
+			"hear" => "hear",
+			"clairaudience" => "clairaudience",
+			"allspeak" => "allspeak",
+			"magicksense" => "magicksense",
+			_ => type
+		};
+	}
+
+	private static MagicPower CreateConnectMindModel(long eligibilityProg)
+	{
+		return new MagicPower
+		{
+			Id = 99,
+			Name = "Connect Mind",
+			Blurb = "Connect mind",
+			ShowHelp = "Connect mind.",
+			MagicSchoolId = 1,
+			PowerModel = "connectmind",
+			Definition = new XElement("Definition",
+				BaseElements(),
+				new XElement("ConnectVerb", "connect"),
+				new XElement("DisconnectVerb", "disconnect"),
+				new XElement("PowerDistance", (int)MagicPowerDistance.AnyConnectedMindOrConnectedTo),
+				new XElement("SkillCheckDifficulty", (int)Difficulty.Normal),
+				new XElement("SkillCheckTrait", 1L),
+				new XElement("MinimumSuccessThreshold", (int)Outcome.MinorPass),
+				new XElement("TargetCanSeeIdentityProg", 0L),
+				new XElement("TargetEligibilityProg", eligibilityProg),
+				new XElement("ExclusiveConnection", true),
+				new XElement("EmoteForConnect", new XCData("Connect.")),
+				new XElement("SelfEmoteForConnect", new XCData("Connect self.")),
+				new XElement("EmoteForDisconnect", new XCData("Disconnect.")),
+				new XElement("SelfEmoteForDisconnect", new XCData("Disconnect self.")),
+				new XElement("UnknownIdentityDescription", new XCData("unknown")),
+				new XElement("EmoteForFailConnect", new XCData("Fail.")),
+				new XElement("SelfEmoteForFailConnect", new XCData("Fail self.")),
+				new XElement("OutcomeEchoes"),
+				new XElement("ConcentrationPointsToSustain", 1.0),
+				new XElement("SustainPenalty", 0.0),
+				new XElement("DetectableWithDetectMagic", (int)Difficulty.Normal),
+				new XElement("SustainResourceCosts")
+			).ToString()
+		};
+	}
+
+	private static Mock<IFuturemud> CreateGameworld(IEnumerable<IFutureProg>? progs = null)
+	{
+		var progList = (progs ?? [CreateProg(0, true).Object]).ToArray();
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.FutureProgs).Returns(CreateCollectionMock(progList).Object);
+		gameworld.SetupGet(x => x.MagicSchools).Returns(CreateCollectionMock(CreateSchool().Object).Object);
+		gameworld.SetupGet(x => x.Traits).Returns(CreateCollectionMock(CreateTrait().Object).Object);
+		gameworld.SetupGet(x => x.AlwaysTrueProg).Returns(progList.FirstOrDefault(x => x.Id == 0) ?? CreateProg(0, true).Object);
+		gameworld.SetupGet(x => x.AlwaysFalseProg).Returns(CreateProg(3, false).Object);
+		gameworld.SetupGet(x => x.UniversalErrorTextProg).Returns(progList.FirstOrDefault(x => x.Id == 0) ?? CreateProg(0, true).Object);
+		return gameworld;
+	}
+
+	private static Mock<IMagicSchool> CreateSchool()
+	{
+		var school = new Mock<IMagicSchool>();
+		school.SetupGet(x => x.Id).Returns(1);
+		school.SetupGet(x => x.Name).Returns("Psionics");
+		school.SetupGet(x => x.PowerListColour).Returns(Telnet.BoldMagenta);
+		school.SetupGet(x => x.SchoolVerb).Returns("psi");
+		return school;
+	}
+
+	private static Mock<ITraitDefinition> CreateTrait()
+	{
+		var trait = new Mock<ITraitDefinition>();
+		trait.SetupGet(x => x.Id).Returns(1);
+		trait.SetupGet(x => x.Name).Returns("Psionics");
+		return trait;
+	}
+
+	private static Mock<IFutureProg> CreateProg(long id, bool truth)
+	{
+		var prog = new Mock<IFutureProg>();
+		prog.SetupGet(x => x.Id).Returns(id);
+		prog.SetupGet(x => x.Name).Returns($"Prog {id}");
+		prog.SetupGet(x => x.FunctionName).Returns($"Prog{id}");
+		prog.SetupGet(x => x.ReturnType).Returns(ProgVariableTypes.Boolean);
+		prog.Setup(x => x.ExecuteBool(It.IsAny<object[]>())).Returns(truth);
+		prog.Setup(x => x.Execute<bool?>(It.IsAny<object[]>())).Returns(truth);
+		prog.Setup(x => x.Execute(It.IsAny<object[]>())).Returns(truth);
+		prog.Setup(x => x.MatchesParameters(It.IsAny<IEnumerable<ProgVariableTypes>>())).Returns(true);
+		prog.Setup(x => x.MXPClickableFunctionName()).Returns($"Prog{id}");
+		return prog;
+	}
+
+	private static Mock<ICharacter> CreateCharacter(long id, IFuturemud gameworld)
+	{
+		var character = new Mock<ICharacter>();
+		character.SetupGet(x => x.Id).Returns(id);
+		character.SetupGet(x => x.Name).Returns($"Character {id}");
+		character.SetupGet(x => x.FrameworkItemType).Returns("Character");
+		character.SetupGet(x => x.Gameworld).Returns(gameworld);
+		return character;
+	}
+
+	private static Mock<IPerceivable> CreatePerceivable(IFuturemud gameworld)
+	{
+		var perceivable = new Mock<IPerceivable>();
+		perceivable.SetupGet(x => x.Id).Returns(100);
+		perceivable.SetupGet(x => x.Name).Returns("Perceivable");
+		perceivable.SetupGet(x => x.FrameworkItemType).Returns("Perceivable");
+		perceivable.SetupGet(x => x.Gameworld).Returns(gameworld);
+		return perceivable;
+	}
+
+	private static Mock<IMagicSpellEffectParent> CreateParent()
+	{
+		var parent = new Mock<IMagicSpellEffectParent>();
+		parent.SetupGet(x => x.Spell).Returns(CreateSpellMock().Object);
+		return parent;
+	}
+
+	private static Mock<IMagicSpell> CreateSpellMock()
+	{
+		var spell = new Mock<IMagicSpell>();
+		spell.SetupGet(x => x.Id).Returns(1);
+		spell.SetupGet(x => x.Name).Returns("V4 Spell");
+		spell.SetupGet(x => x.Gameworld).Returns(CreateGameworld().Object);
+		spell.SetupGet(x => x.School).Returns(CreateSchool().Object);
+		spell.SetupProperty(x => x.Changed);
+		return spell;
+	}
+
+	private static Mock<IUneditableAll<T>> CreateCollectionMock<T>(params T[] items) where T : class, IFrameworkItem
+	{
+		var byId = items.ToDictionary(x => x.Id, x => x);
+		var collection = new Mock<IUneditableAll<T>>();
+		collection.SetupGet(x => x.Count).Returns(items.Length);
+		collection.Setup(x => x.Get(It.IsAny<long>())).Returns<long>(id => byId.GetValueOrDefault(id));
+		collection.Setup(x => x.GetByName(It.IsAny<string>())).Returns<string>(name =>
+			items.FirstOrDefault(x => x.Name.EqualTo(name)));
+		collection.Setup(x => x.GetByIdOrName(It.IsAny<string>(), It.IsAny<bool>())).Returns<string, bool>((text, _) =>
+			long.TryParse(text, out var id) ? byId.GetValueOrDefault(id) : items.FirstOrDefault(x => x.Name.EqualTo(text)));
+		collection.Setup(x => x.GetEnumerator()).Returns(() => ((IEnumerable<T>)items).GetEnumerator());
+		return collection;
+	}
+}

--- a/MudSharpCore/Body/CommunicationStrategies/HumanoidCommunicationStrategy.cs
+++ b/MudSharpCore/Body/CommunicationStrategies/HumanoidCommunicationStrategy.cs
@@ -32,6 +32,11 @@ public class HumanoidCommunicationStrategy : IBodyCommunicationStrategy
         return body.CombinedEffectsOfType<ISilencedEffect>().Any(x => x.Applies());
     }
 
+    protected static bool IsBabbled(IBody body)
+    {
+        return body.Actor.CombinedEffectsOfType<IBabbleSpeechEffect>().Any(x => x.Applies());
+    }
+
     protected static string SilenceReason => "A magical silence prevents you from speaking.";
 
     protected HumanoidCommunicationStrategy()
@@ -219,6 +224,11 @@ public class HumanoidCommunicationStrategy : IBodyCommunicationStrategy
         if (body.Actor.Merits.OfType<IMuteMerit>().Any(x => x.Applies(body.Actor)))
         {
             return body.Actor.Merits.OfType<IMuteMerit>().First(x => x.Applies(body.Actor)).LanguageOptions;
+        }
+
+        if (IsBabbled(body))
+        {
+            return PermitLanguageOptions.LanguageIsBabbling;
         }
 
         if (IsSilenced(body))

--- a/MudSharpCore/Body/CommunicationStrategies/MouthOnlyCommunicationStrategy.cs
+++ b/MudSharpCore/Body/CommunicationStrategies/MouthOnlyCommunicationStrategy.cs
@@ -54,6 +54,11 @@ public class MouthOnlyCommunicationStrategy : HumanoidCommunicationStrategy, IBo
             return PermitLanguageOptions.LanguageIsMuffling;
         }
 
+        if (IsBabbled(body))
+        {
+            return PermitLanguageOptions.LanguageIsBabbling;
+        }
+
         if (IsSilenced(body))
         {
             return PermitLanguageOptions.LanguageIsMuffling;

--- a/MudSharpCore/Body/CommunicationStrategies/RobotCommunicationStrategy.cs
+++ b/MudSharpCore/Body/CommunicationStrategies/RobotCommunicationStrategy.cs
@@ -83,6 +83,11 @@ public class RobotCommunicationStrategy : HumanoidCommunicationStrategy, IBodyCo
             return body.Actor.Merits.OfType<IMuteMerit>().First(x => x.Applies(body.Actor)).LanguageOptions;
         }
 
+        if (IsBabbled(body))
+        {
+            return PermitLanguageOptions.LanguageIsBabbling;
+        }
+
         if (IsSilenced(body))
         {
             return PermitLanguageOptions.LanguageIsBuzzing;

--- a/MudSharpCore/Body/Implementations/BodyPerception.cs
+++ b/MudSharpCore/Body/Implementations/BodyPerception.cs
@@ -430,12 +430,14 @@ public partial class Body
             flags = flags | PerceiveIgnoreFlags.IgnoreSelf;
         }
 
-        if (CombinedEffectsOfType<IOverrideDescEffect>().Any(x => x.OverrideApplies(voyeur, type)) &&
+        var overrideEffect = CombinedEffectsOfType<IOverrideDescEffect>()
+                             .Where(x => x.OverrideApplies(voyeur, type))
+                             .OrderByDescending(x => (x as IPrioritisedOverrideDescEffect)?.OverridePriority ?? 0)
+                             .FirstOrDefault();
+        if (overrideEffect is not null &&
             (voyeur.CanSee(this) || flags.HasFlag(PerceiveIgnoreFlags.IgnoreCanSee)))
         {
-            return CombinedEffectsOfType<IOverrideDescEffect>()
-                   .First(x => x.OverrideApplies(voyeur, type))
-                   .Description(type, colour);
+            return overrideEffect.Description(type, colour);
         }
 
         // TODO - add in obscuring effects like cloaks

--- a/MudSharpCore/Effects/Concrete/MagicAllspeakEffect.cs
+++ b/MudSharpCore/Effects/Concrete/MagicAllspeakEffect.cs
@@ -1,0 +1,40 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.Magic;
+using MudSharp.Magic.Powers;
+using MudSharp.PerceptionEngine;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace MudSharp.Effects.Concrete;
+
+public sealed class MagicAllspeakEffect : PsionicSustainedPowerEffectBase<AllspeakPower>, IComprehendLanguageEffect
+{
+	public static void InitialiseEffectType()
+	{
+		RegisterFactory("MagicAllspeak", (effect, owner) => new MagicAllspeakEffect(effect, owner));
+	}
+
+	public MagicAllspeakEffect(ICharacter owner, AllspeakPower power) : base(owner, power)
+	{
+	}
+
+	private MagicAllspeakEffect(XElement effect, IPerceivable owner) : base(effect, owner)
+	{
+	}
+
+	protected override string SpecificEffectType => "MagicAllspeak";
+
+	public override string Describe(IPerceiver voyeur)
+	{
+		return $"Comprehending languages via the {Power.Name.Colour(Power.School.PowerListColour)} power.";
+	}
+}
+

--- a/MudSharpCore/Effects/Concrete/MagicClairaudienceConcentrationEffect.cs
+++ b/MudSharpCore/Effects/Concrete/MagicClairaudienceConcentrationEffect.cs
@@ -1,0 +1,96 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.Magic;
+using MudSharp.Magic.Powers;
+using MudSharp.PerceptionEngine;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace MudSharp.Effects.Concrete;
+
+public sealed class MagicClairaudienceConcentrationEffect : PsionicSustainedPowerEffectBase<ClairaudiencePower>
+{
+	public static void InitialiseEffectType()
+	{
+		RegisterFactory("MagicClairaudienceConcentration",
+			(effect, owner) => new MagicClairaudienceConcentrationEffect(effect, owner));
+	}
+
+	public MagicClairaudienceConcentrationEffect(ICharacter owner, ClairaudiencePower power, ICharacter target)
+		: base(owner, power)
+	{
+		TargetCharacter = target;
+		EnsureChildEffect();
+	}
+
+	private MagicClairaudienceConcentrationEffect(XElement effect, IPerceivable owner) : base(effect, owner)
+	{
+		var root = effect.Element("Effect");
+		TargetCharacter = Gameworld.TryGetCharacter(long.Parse(root!.Element("Target")!.Value), true);
+	}
+
+	public ICharacter? TargetCharacter { get; private set; }
+
+	protected override XElement SaveDefinition()
+	{
+		return SaveToXml(
+			new XElement("Power", PowerOrigin.Id),
+			new XElement("Target", TargetCharacter?.Id ?? 0L)
+		);
+	}
+
+	protected override string SpecificEffectType => "MagicClairaudienceConcentration";
+
+	public override void Login()
+	{
+		base.Login();
+		EnsureChildEffect();
+	}
+
+	public override void RemovalEffect()
+	{
+		base.RemovalEffect();
+		if (TargetCharacter is null)
+		{
+			return;
+		}
+
+		foreach (var effect in TargetCharacter.EffectsOfType<PsionicClairaudienceEffect>()
+		                                      .Where(x => x.Observer == CharacterOwner && x.Power == Power)
+		                                      .ToList())
+		{
+			TargetCharacter.RemoveEffect(effect, true);
+		}
+	}
+
+	public override string Describe(IPerceiver voyeur)
+	{
+		return TargetCharacter is null
+			? $"Clairaudience from the {Power.Name.Colour(Power.School.PowerListColour)} power."
+			: $"Clairaudience through {TargetCharacter.HowSeen(voyeur)} via the {Power.Name.Colour(Power.School.PowerListColour)} power.";
+	}
+
+	private void EnsureChildEffect()
+	{
+		if (TargetCharacter is null)
+		{
+			return;
+		}
+
+		if (TargetCharacter.EffectsOfType<PsionicClairaudienceEffect>()
+		                   .Any(x => x.Observer == CharacterOwner && x.Power == Power))
+		{
+			return;
+		}
+
+		TargetCharacter.AddEffect(new PsionicClairaudienceEffect(TargetCharacter, CharacterOwner, Power));
+	}
+}
+

--- a/MudSharpCore/Effects/Concrete/MagicMagicksenseEffect.cs
+++ b/MudSharpCore/Effects/Concrete/MagicMagicksenseEffect.cs
@@ -1,0 +1,42 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.Magic;
+using MudSharp.Magic.Powers;
+using MudSharp.PerceptionEngine;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace MudSharp.Effects.Concrete;
+
+public sealed class MagicMagicksenseEffect : PsionicSustainedPowerEffectBase<MagicksensePower>
+{
+	public static void InitialiseEffectType()
+	{
+		RegisterFactory("MagicMagicksense", (effect, owner) => new MagicMagicksenseEffect(effect, owner));
+	}
+
+	public MagicMagicksenseEffect(ICharacter owner, MagicksensePower power) : base(owner, power)
+	{
+	}
+
+	private MagicMagicksenseEffect(XElement effect, IPerceivable owner) : base(effect, owner)
+	{
+	}
+
+	protected override string SpecificEffectType => "MagicMagicksense";
+
+	public override PerceptionTypes PerceptionGranting => PerceptionTypes.SenseMagical;
+
+	public override string Describe(IPerceiver voyeur)
+	{
+		return $"Sensing magical auras via the {Power.Name.Colour(Power.School.PowerListColour)} power.";
+	}
+}
+

--- a/MudSharpCore/Effects/Concrete/PsionicBabbleEffect.cs
+++ b/MudSharpCore/Effects/Concrete/PsionicBabbleEffect.cs
@@ -1,0 +1,62 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.Magic;
+using MudSharp.Magic.Powers;
+using MudSharp.PerceptionEngine;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace MudSharp.Effects.Concrete;
+
+public sealed class PsionicBabbleEffect : Effect, IMagicEffect, IBabbleSpeechEffect
+{
+	public static void InitialiseEffectType()
+	{
+		RegisterFactory("PsionicBabble", (effect, owner) => new PsionicBabbleEffect(effect, owner));
+	}
+
+	public PsionicBabbleEffect(ICharacter owner, BabblePower power) : base(owner)
+	{
+		CharacterOwner = owner;
+		Power = power;
+	}
+
+	private PsionicBabbleEffect(XElement effect, IPerceivable owner) : base(effect, owner)
+	{
+		CharacterOwner = (ICharacter)owner;
+		var root = effect.Element("Effect");
+		Power = Gameworld.MagicPowers.Get(long.Parse(root!.Element("Power")!.Value)) as BabblePower ??
+		        throw new ApplicationException(
+			        $"The PsionicBabble effect for {owner.FrameworkItemType} #{owner.Id} referred to an invalid babble power.");
+	}
+
+	public ICharacter CharacterOwner { get; }
+	public BabblePower Power { get; }
+	public IMagicPower PowerOrigin => Power;
+	public Difficulty DetectMagicDifficulty => Power.DetectableWithDetectMagic;
+	public IMagicSchool School => Power.School;
+	public override bool SavingEffect => true;
+
+	protected override XElement SaveDefinition()
+	{
+		return new XElement("Effect",
+			new XElement("ApplicabilityProg", ApplicabilityProg?.Id ?? 0L),
+			new XElement("Power", PowerOrigin.Id)
+		);
+	}
+
+	protected override string SpecificEffectType => "PsionicBabble";
+
+	public override string Describe(IPerceiver voyeur)
+	{
+		return $"Speech is psionically scrambled by the {Power.Name.Colour(Power.School.PowerListColour)} power.";
+	}
+}
+

--- a/MudSharpCore/Effects/Concrete/PsionicClairaudienceEffect.cs
+++ b/MudSharpCore/Effects/Concrete/PsionicClairaudienceEffect.cs
@@ -1,0 +1,77 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.Magic;
+using MudSharp.Magic.Powers;
+using MudSharp.PerceptionEngine;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace MudSharp.Effects.Concrete;
+
+public sealed class PsionicClairaudienceEffect : Effect, IMagicEffect, IRemoteObservationEffect
+{
+	public PsionicClairaudienceEffect(ICharacter owner, ICharacter observer, ClairaudiencePower power) : base(owner)
+	{
+		TargetCharacter = owner;
+		Observer = observer;
+		Power = power;
+	}
+
+	public ICharacter TargetCharacter { get; }
+	public ICharacter Observer { get; }
+	public ClairaudiencePower Power { get; }
+	public IMagicPower PowerOrigin => Power;
+	public Difficulty DetectMagicDifficulty => Power.DetectableWithDetectMagic;
+	public IMagicSchool School => Power.School;
+
+	protected override string SpecificEffectType => "PsionicClairaudience";
+
+	protected override XElement SaveDefinition()
+	{
+		return new XElement("Effect");
+	}
+
+	public override string Describe(IPerceiver voyeur)
+	{
+		return $"{Observer.HowSeen(voyeur)} is hearing through this mind via the {Power.Name.Colour(Power.School.PowerListColour)} power.";
+	}
+
+	public void HandleOutput(IOutput output, ILocation location)
+	{
+		if (!output.Flags.HasFlag(OutputFlags.PurelyAudible))
+		{
+			return;
+		}
+
+		if (location != TargetCharacter.Location || !output.ShouldSee(TargetCharacter))
+		{
+			return;
+		}
+
+		if (!CharacterState.Conscious.HasFlag(Observer.State))
+		{
+			return;
+		}
+
+		var text = output.ParseFor(TargetCharacter);
+		if (string.IsNullOrWhiteSpace(text))
+		{
+			return;
+		}
+
+		Observer.OutputHandler.Send(
+			$"[{TargetCharacter.HowSeen(Observer, flags: PerceiveIgnoreFlags.IgnoreConsciousness)}] {text}");
+	}
+
+	public void HandleOutput(string text, ILocation location)
+	{
+		// String-only room output has no channel flags, so clairaudience refuses it by policy.
+	}
+}

--- a/MudSharpCore/Effects/Concrete/PsionicHearEffect.cs
+++ b/MudSharpCore/Effects/Concrete/PsionicHearEffect.cs
@@ -1,0 +1,70 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.Magic;
+using MudSharp.Magic.Powers;
+using MudSharp.PerceptionEngine;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace MudSharp.Effects.Concrete;
+
+public sealed class PsionicHearEffect : PsionicSustainedPowerEffectBase<HearPower>, ITelepathyEffect
+{
+	public static void InitialiseEffectType()
+	{
+		RegisterFactory("PsionicHear", (effect, owner) => new PsionicHearEffect(effect, owner));
+	}
+
+	public PsionicHearEffect(ICharacter owner, HearPower power) : base(owner, power)
+	{
+	}
+
+	private PsionicHearEffect(XElement effect, IPerceivable owner) : base(effect, owner)
+	{
+	}
+
+	protected override string SpecificEffectType => "PsionicHear";
+
+	public override string Describe(IPerceiver voyeur)
+	{
+		return $"Listening to psionic thought and emotion via the {Power.Name.Colour(Power.School.PowerListColour)} power.";
+	}
+
+	public override bool Applies(object target)
+	{
+		if (target is not ICharacter thinker)
+		{
+			return false;
+		}
+
+		return Power.TargetIsInRange(CharacterOwner, thinker, Power.PowerDistance) &&
+		       Power.TargetFilter(CharacterOwner, thinker) &&
+		       Power.CheckCanHear(CharacterOwner, thinker);
+	}
+
+	public bool ShowThinks => Power.ShowThinks;
+	public bool ShowFeels => Power.ShowFeels;
+
+	public bool ShowDescription(ICharacter thinker)
+	{
+		return Power.ShowDescriptionProg.ExecuteBool(CharacterOwner, thinker) != false;
+	}
+
+	public bool ShowName(ICharacter thinker)
+	{
+		return Power.ShowName;
+	}
+
+	public bool ShowThinkEmote(ICharacter thinker)
+	{
+		return Power.ShowEmotes;
+	}
+}
+

--- a/MudSharpCore/Effects/Concrete/PsionicSustainedPowerEffectBase.cs
+++ b/MudSharpCore/Effects/Concrete/PsionicSustainedPowerEffectBase.cs
@@ -1,0 +1,77 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.Magic;
+using MudSharp.Magic.Powers;
+using MudSharp.PerceptionEngine;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace MudSharp.Effects.Concrete;
+
+public abstract class PsionicSustainedPowerEffectBase<TPower> : ConcentrationConsumingEffect, IMagicEffect, ICheckBonusEffect
+	where TPower : SustainedMagicPower
+{
+	protected PsionicSustainedPowerEffectBase(ICharacter owner, TPower power)
+		: base(owner, power.School, power.ConcentrationPointsToSustain)
+	{
+		Power = power;
+		Login();
+	}
+
+	protected PsionicSustainedPowerEffectBase(XElement effect, IPerceivable owner)
+		: base(effect, owner)
+	{
+		var root = effect.Element("Effect");
+		Power = Gameworld.MagicPowers.Get(long.Parse(root!.Element("Power")!.Value)) as TPower ??
+		        throw new ApplicationException(
+			        $"The {GetType().Name} effect for {owner.FrameworkItemType} #{owner.Id} referred to an invalid power.");
+	}
+
+	public TPower Power { get; protected set; }
+	public IMagicPower PowerOrigin => Power;
+	public Difficulty DetectMagicDifficulty => Power.DetectableWithDetectMagic;
+	public override bool SavingEffect => true;
+
+	protected override XElement SaveDefinition()
+	{
+		return SaveToXml(new XElement("Power", PowerOrigin.Id));
+	}
+
+	protected override void RegisterEvents()
+	{
+		base.RegisterEvents();
+		Gameworld.HeartbeatManager.FuzzyMinuteHeartbeat += DoSustainCostsTick;
+	}
+
+	public override void ReleaseEvents()
+	{
+		base.ReleaseEvents();
+		Gameworld.HeartbeatManager.FuzzyMinuteHeartbeat -= DoSustainCostsTick;
+	}
+
+	public override void RemovalEffect()
+	{
+		ReleaseEvents();
+	}
+
+	private void DoSustainCostsTick()
+	{
+		Power.DoSustainCostsTick(CharacterOwner);
+	}
+
+	public bool AppliesToCheck(CheckType type)
+	{
+		return type.IsDefensiveCombatAction() || type.IsOffensiveCombatAction() || type.IsGeneralActivityCheck() ||
+		       type.IsTargettedFriendlyCheck() || type.IsTargettedHostileCheck();
+	}
+
+	public double CheckBonus => Power.SustainPenalty;
+}
+

--- a/MudSharpCore/Effects/Concrete/SpellEffects/SpellSubjectiveDescriptionEffect.cs
+++ b/MudSharpCore/Effects/Concrete/SpellEffects/SpellSubjectiveDescriptionEffect.cs
@@ -8,7 +8,7 @@ using System.Xml.Linq;
 
 namespace MudSharp.Effects.Concrete.SpellEffects;
 
-public class SpellSubjectiveDescriptionEffect : MagicSpellEffectBase, IOverrideDescEffect
+public class SpellSubjectiveDescriptionEffect : MagicSpellEffectBase, IOverrideDescEffect, IPrioritisedOverrideDescEffect
 {
 	public static void InitialiseEffectType()
 	{
@@ -17,12 +17,15 @@ public class SpellSubjectiveDescriptionEffect : MagicSpellEffectBase, IOverrideD
 	}
 
 	public SpellSubjectiveDescriptionEffect(IPerceivable owner, IMagicSpellEffectParent parent,
-		DescriptionType descriptionType, string description, long fixedPerceiverId, IFutureProg? prog = null)
+		DescriptionType descriptionType, string description, long fixedPerceiverId, IFutureProg? prog = null,
+		int priority = 0, string overrideKey = "")
 		: base(owner, parent, prog)
 	{
 		DescriptionType = descriptionType;
 		DescriptionText = description;
 		FixedPerceiverId = fixedPerceiverId;
+		OverridePriority = priority;
+		OverrideKey = overrideKey;
 	}
 
 	private SpellSubjectiveDescriptionEffect(XElement root, IPerceivable owner) : base(root, owner)
@@ -31,11 +34,15 @@ public class SpellSubjectiveDescriptionEffect : MagicSpellEffectBase, IOverrideD
 		DescriptionType = (DescriptionType)int.Parse(trueRoot?.Element("DescriptionType")?.Value ?? "0");
 		DescriptionText = trueRoot?.Element("Description")?.Value ?? string.Empty;
 		FixedPerceiverId = long.Parse(trueRoot?.Element("FixedPerceiver")?.Value ?? "0");
+		OverridePriority = int.Parse(trueRoot?.Element("Priority")?.Value ?? "0");
+		OverrideKey = trueRoot?.Element("OverrideKey")?.Value ?? string.Empty;
 	}
 
 	public DescriptionType DescriptionType { get; }
 	public string DescriptionText { get; }
 	public long FixedPerceiverId { get; }
+	public int OverridePriority { get; }
+	public string OverrideKey { get; }
 
 	protected override XElement SaveDefinition()
 	{
@@ -43,7 +50,9 @@ public class SpellSubjectiveDescriptionEffect : MagicSpellEffectBase, IOverrideD
 			new XElement("ApplicabilityProg", ApplicabilityProg?.Id ?? 0),
 			new XElement("DescriptionType", (int)DescriptionType),
 			new XElement("Description", new XCData(DescriptionText)),
-			new XElement("FixedPerceiver", FixedPerceiverId)
+			new XElement("FixedPerceiver", FixedPerceiverId),
+			new XElement("Priority", OverridePriority),
+			new XElement("OverrideKey", new XCData(OverrideKey))
 		);
 	}
 

--- a/MudSharpCore/Effects/Concrete/SpellEffects/SpellTagWardEffects.cs
+++ b/MudSharpCore/Effects/Concrete/SpellEffects/SpellTagWardEffects.cs
@@ -1,0 +1,164 @@
+#nullable enable
+
+using System.Linq;
+using System.Xml.Linq;
+using MudSharp.Character;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.Magic;
+
+namespace MudSharp.Effects.Concrete.SpellEffects;
+
+public abstract class TagMagicInterdictionSpellEffectBase : MagicSpellEffectBase, IMagicInterdictionEffect, IMagicContextualInterdictionEffect
+{
+	protected TagMagicInterdictionSpellEffectBase(IPerceivable owner, IMagicSpellEffectParent parent, string tag,
+		string value, bool matchValue, MagicInterdictionMode mode, MagicInterdictionCoverage coverage, IFutureProg? prog)
+		: base(owner, parent, prog)
+	{
+		Tag = tag;
+		Value = value;
+		MatchValue = matchValue;
+		Mode = mode;
+		Coverage = coverage;
+	}
+
+	protected TagMagicInterdictionSpellEffectBase(XElement root, IPerceivable owner)
+		: base(root, owner)
+	{
+		var trueRoot = root.Element("Effect");
+		Tag = trueRoot?.Element("Tag")?.Value ?? string.Empty;
+		Value = trueRoot?.Element("Value")?.Value ?? string.Empty;
+		MatchValue = bool.Parse(trueRoot?.Element("MatchValue")?.Value ?? "false");
+		Mode = System.Enum.Parse<MagicInterdictionMode>(trueRoot?.Element("Mode")?.Value ?? nameof(MagicInterdictionMode.Fail), true);
+		Coverage = System.Enum.Parse<MagicInterdictionCoverage>(trueRoot?.Element("Coverage")?.Value ?? nameof(MagicInterdictionCoverage.Both), true);
+	}
+
+	public string Tag { get; }
+	public string Value { get; }
+	public bool MatchValue { get; }
+	public MagicInterdictionCoverage Coverage { get; }
+	public MagicInterdictionMode Mode { get; }
+	public IMagicSchool School => Spell.School;
+	public bool IncludesSubschools => true;
+
+	public bool ShouldInterdict(ICharacter source, IMagicSchool school)
+	{
+		return false;
+	}
+
+	public bool ShouldInterdict(MagicInterdictionContext context)
+	{
+		if (string.IsNullOrWhiteSpace(Tag))
+		{
+			return false;
+		}
+
+		if (!context.Tags.Any(x => x.Tag.EqualTo(Tag) && (!MatchValue || x.Value.EqualTo(Value))))
+		{
+			return false;
+		}
+
+		if (ApplicabilityProg is null)
+		{
+			return true;
+		}
+
+		if (ApplicabilityProg.MatchesParameters([ProgVariableTypes.Character, ProgVariableTypes.Perceivable, ProgVariableTypes.Text, ProgVariableTypes.Text]))
+		{
+			return ApplicabilityProg.ExecuteBool(context.Source, Owner, Tag, Value);
+		}
+
+		if (ApplicabilityProg.MatchesParameters([ProgVariableTypes.Character, ProgVariableTypes.Perceivable]))
+		{
+			return ApplicabilityProg.ExecuteBool(context.Source, Owner);
+		}
+
+		return false;
+	}
+
+	public override bool Applies()
+	{
+		return true;
+	}
+
+	protected XElement SaveTagInterdictionDefinition()
+	{
+		return new XElement("Effect",
+			new XElement("ApplicabilityProg", ApplicabilityProg?.Id ?? 0L),
+			new XElement("Tag", new XCData(Tag)),
+			new XElement("Value", new XCData(Value)),
+			new XElement("MatchValue", MatchValue),
+			new XElement("Mode", Mode),
+			new XElement("Coverage", Coverage)
+		);
+	}
+
+	protected string TagInterdictionDescription(IPerceiver voyeur, string kind)
+	{
+		return
+			$"{kind} Tag Ward - {Tag.ColourValue()}{(MatchValue ? $"={Value.ColourValue()}" : "")} - {Coverage.DescribeEnum().ColourValue()} - {Mode.DescribeEnum().ColourValue()}";
+	}
+}
+
+public sealed class SpellRoomTagWardEffect : TagMagicInterdictionSpellEffectBase
+{
+	public static void InitialiseEffectType()
+	{
+		RegisterFactory("SpellRoomTagWard", (effect, owner) => new SpellRoomTagWardEffect(effect, owner));
+	}
+
+	public SpellRoomTagWardEffect(IPerceivable owner, IMagicSpellEffectParent parent, string tag, string value,
+		bool matchValue, MagicInterdictionMode mode, MagicInterdictionCoverage coverage, IFutureProg? prog)
+		: base(owner, parent, tag, value, matchValue, mode, coverage, prog)
+	{
+	}
+
+	private SpellRoomTagWardEffect(XElement root, IPerceivable owner)
+		: base(root, owner)
+	{
+	}
+
+	public override string Describe(IPerceiver voyeur)
+	{
+		return TagInterdictionDescription(voyeur, "Room");
+	}
+
+	protected override string SpecificEffectType => "SpellRoomTagWard";
+
+	protected override XElement SaveDefinition()
+	{
+		return SaveTagInterdictionDefinition();
+	}
+}
+
+public sealed class SpellPersonalTagWardEffect : TagMagicInterdictionSpellEffectBase
+{
+	public static void InitialiseEffectType()
+	{
+		RegisterFactory("SpellPersonalTagWard", (effect, owner) => new SpellPersonalTagWardEffect(effect, owner));
+	}
+
+	public SpellPersonalTagWardEffect(IPerceivable owner, IMagicSpellEffectParent parent, string tag, string value,
+		bool matchValue, MagicInterdictionMode mode, MagicInterdictionCoverage coverage, IFutureProg? prog)
+		: base(owner, parent, tag, value, matchValue, mode, coverage, prog)
+	{
+	}
+
+	private SpellPersonalTagWardEffect(XElement root, IPerceivable owner)
+		: base(root, owner)
+	{
+	}
+
+	public override string Describe(IPerceiver voyeur)
+	{
+		return TagInterdictionDescription(voyeur, "Personal");
+	}
+
+	protected override string SpecificEffectType => "SpellPersonalTagWard";
+
+	protected override XElement SaveDefinition()
+	{
+		return SaveTagInterdictionDefinition();
+	}
+}

--- a/MudSharpCore/GameItems/GameItem.cs
+++ b/MudSharpCore/GameItems/GameItem.cs
@@ -449,10 +449,13 @@ public partial class GameItem : PerceiverItem, IGameItem, IDisposable
             voyeur = this;
         }
 
-        if (EffectsOfType<IOverrideDescEffect>().Any(x => x.OverrideApplies(voyeur, type)) && voyeur.CanSee(this))
+        var overrideEffect = EffectsOfType<IOverrideDescEffect>()
+                             .Where(x => x.OverrideApplies(voyeur, type))
+                             .OrderByDescending(x => (x as IPrioritisedOverrideDescEffect)?.OverridePriority ?? 0)
+                             .FirstOrDefault();
+        if (overrideEffect is not null && voyeur.CanSee(this))
         {
-            return EffectsOfType<IOverrideDescEffect>().First(x => x.OverrideApplies(voyeur, type))
-                                                       .Description(type, colour);
+            return overrideEffect.Description(type, colour);
         }
 
         switch (type)

--- a/MudSharpCore/Magic/MagicInterdictionHelper.cs
+++ b/MudSharpCore/Magic/MagicInterdictionHelper.cs
@@ -20,9 +20,21 @@ internal static class MagicInterdictionHelper
 	public static MagicInterdictionResult? GetInterdiction(ICharacter source, IPerceivable? target, IMagicSchool school,
 		bool allowReflection, params SpellAdditionalParameter[] additionalParameters)
 	{
+		return GetInterdiction(source, target, school, allowReflection, [], additionalParameters);
+	}
+
+	public static MagicInterdictionResult? GetInterdiction(ICharacter source, IPerceivable? target, IMagicSchool school,
+		bool allowReflection, IEnumerable<MagicInterdictionTag> tags, params SpellAdditionalParameter[] additionalParameters)
+	{
+		var context = new MagicInterdictionContext(source, target, school, tags.ToList(), additionalParameters.ToList());
 		foreach ((IMagicInterdictionEffect effect, IPerceivable owner) in GetRelevantEffects(source, target, additionalParameters))
 		{
-			if (!effect.ShouldInterdict(source, school))
+			var shouldInterdict =
+				effect is IMagicContextualInterdictionEffect contextual
+					? contextual.ShouldInterdict(context)
+					: effect.ShouldInterdict(source, school);
+
+			if (!shouldInterdict)
 			{
 				continue;
 			}

--- a/MudSharpCore/Magic/MagicSpell.cs
+++ b/MudSharpCore/Magic/MagicSpell.cs
@@ -1524,7 +1524,9 @@ public class MagicSpell : SaveableItem, IMagicSpell
 		bool ProcessSpellTarget(IPerceivable originalTarget, bool mayReflect)
 		{
 			MagicInterdictionResult? interdiction =
-				MagicInterdictionHelper.GetInterdiction(magician, originalTarget, School, mayReflect, additionalParameters);
+				MagicInterdictionHelper.GetInterdiction(magician, originalTarget, School, mayReflect,
+					_spellEffects.OfType<IMagicInterdictionTagProvider>().SelectMany(x => x.MagicInterdictionTags),
+					additionalParameters);
 			bool reflected = interdiction?.Mode == MagicInterdictionMode.Reflect && originalTarget is ICharacter &&
 			                 originalTarget != magician;
 			IPerceivable actualTarget = reflected ? magician : originalTarget;

--- a/MudSharpCore/Magic/Powers/AllspeakPower.cs
+++ b/MudSharpCore/Magic/Powers/AllspeakPower.cs
@@ -1,0 +1,70 @@
+#nullable enable
+
+using MudSharp.Body.Needs;
+using MudSharp.Body.Traits;
+using MudSharp.Character;
+using MudSharp.Effects;
+using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.Models;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Outputs;
+using MudSharp.PerceptionEngine.Parsers;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+namespace MudSharp.Magic.Powers;
+
+public sealed class AllspeakPower : PsionicSustainedSelfPowerBase
+{
+	public override string PowerType => "Allspeak";
+	public override string DatabaseType => "allspeak";
+	protected override string DefaultBeginVerb => "allspeak";
+	protected override string DefaultEndVerb => "endallspeak";
+
+	public static void RegisterLoader()
+	{
+		MagicPowerFactory.RegisterLoader("allspeak", (power, gameworld) => new AllspeakPower(power, gameworld));
+		MagicPowerFactory.RegisterBuilderLoader("allspeak", BuilderLoader);
+	}
+
+	private static IMagicPower? BuilderLoader(IFuturemud gameworld, IMagicSchool school, string name, ICharacter actor,
+		StringStack command)
+	{
+		return PsionicV4PowerBuilderHelpers.BuildWithSkill(gameworld, school, name, actor, command,
+			trait => new AllspeakPower(gameworld, school, name, trait));
+	}
+
+	private AllspeakPower(IFuturemud gameworld, IMagicSchool school, string name, ITraitDefinition trait) : base(gameworld, school, name, trait)
+	{
+		Blurb = "Comprehend spoken and written language while sustained";
+		_showHelpText = $"Use {school.SchoolVerb.ToUpperInvariant()} ALLSPEAK to comprehend languages without learning them.";
+		DoDatabaseInsert();
+	}
+
+	private AllspeakPower(MagicPower power, IFuturemud gameworld) : base(power, gameworld)
+	{
+	}
+
+	protected override XElement SaveDefinition()
+	{
+		return SaveSustainedSelfDefinition();
+	}
+
+	protected override IEffect CreateEffect(ICharacter actor)
+	{
+		return new MagicAllspeakEffect(actor, this);
+	}
+
+	protected override IEnumerable<IEffect> ActiveEffects(ICharacter actor)
+	{
+		return actor.EffectsOfType<MagicAllspeakEffect>().Where(x => x.Power == this);
+	}
+}
+

--- a/MudSharpCore/Magic/Powers/BabblePower.cs
+++ b/MudSharpCore/Magic/Powers/BabblePower.cs
@@ -1,0 +1,94 @@
+#nullable enable
+
+using MudSharp.Body.Needs;
+using MudSharp.Body.Traits;
+using MudSharp.Character;
+using MudSharp.Effects;
+using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.Models;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Outputs;
+using MudSharp.PerceptionEngine.Parsers;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+namespace MudSharp.Magic.Powers;
+
+public sealed class BabblePower : PsionicTargetedPowerBase
+{
+	public override string PowerType => "Babble";
+	public override string DatabaseType => "babble";
+	protected override string DefaultVerb => "babble";
+
+	public static void RegisterLoader()
+	{
+		MagicPowerFactory.RegisterLoader("babble", (power, gameworld) => new BabblePower(power, gameworld));
+		MagicPowerFactory.RegisterBuilderLoader("babble", BuilderLoader);
+	}
+
+	private static IMagicPower? BuilderLoader(IFuturemud gameworld, IMagicSchool school, string name, ICharacter actor,
+		StringStack command)
+	{
+		return PsionicV4PowerBuilderHelpers.BuildWithSkill(gameworld, school, name, actor, command,
+			trait => new BabblePower(gameworld, school, name, trait));
+	}
+
+	private BabblePower(IFuturemud gameworld, IMagicSchool school, string name, ITraitDefinition trait) : base(gameworld, school, name, trait)
+	{
+		Blurb = "Scramble a target's outgoing speech";
+		_showHelpText = $"Use {school.SchoolVerb.ToUpperInvariant()} BABBLE <target> to make their speech come out as incomprehensible babble.";
+		DurationSeconds = 120.0;
+		FailEcho = "You brush against $1's speech centres, but cannot tangle them.";
+		SuccessEcho = "You tangle $1's speech centres.";
+		DoDatabaseInsert();
+	}
+
+	private BabblePower(MagicPower power, IFuturemud gameworld) : base(power, gameworld)
+	{
+		var root = XElement.Parse(power.Definition);
+		DurationSeconds = double.Parse(root.Element("DurationSeconds")?.Value ?? "120");
+	}
+
+	public double DurationSeconds { get; private set; }
+
+	protected override XElement SaveDefinition()
+	{
+		return SaveTargetedDefinition(new XElement("DurationSeconds", DurationSeconds));
+	}
+
+	public override void UseCommand(ICharacter actor, string verb, StringStack command)
+	{
+		if (!TryPrepareTarget(actor, command, "Whose speech do you want to scramble?", out var target) || target is null)
+		{
+			return;
+		}
+
+		var outcome = CheckPower(actor, target, CheckType.ConnectMindPower);
+		if (outcome < MinimumSuccessThreshold)
+		{
+			SendFailure(actor, target);
+			return;
+		}
+
+		target.AddEffect(new PsionicBabbleEffect(target, this), TimeSpan.FromSeconds(DurationSeconds));
+		if (!string.IsNullOrWhiteSpace(SuccessEcho))
+		{
+			actor.OutputHandler.Send(new EmoteOutput(new Emote(SuccessEcho, actor, actor, target)));
+		}
+
+		ConsumePowerCosts(actor, Verb);
+	}
+
+	protected override void ShowSubtypeDetails(ICharacter actor, StringBuilder sb)
+	{
+		sb.AppendLine($"Duration: {TimeSpan.FromSeconds(DurationSeconds).Describe(actor).ColourValue()}");
+	}
+}
+

--- a/MudSharpCore/Magic/Powers/ClairaudiencePower.cs
+++ b/MudSharpCore/Magic/Powers/ClairaudiencePower.cs
@@ -1,0 +1,219 @@
+#nullable enable
+
+using MudSharp.Body.Needs;
+using MudSharp.Body.Traits;
+using MudSharp.Character;
+using MudSharp.Effects;
+using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.Models;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Outputs;
+using MudSharp.PerceptionEngine.Parsers;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+namespace MudSharp.Magic.Powers;
+
+public sealed class ClairaudiencePower : SustainedMagicPower
+{
+	public override string PowerType => "Clairaudience";
+	public override string DatabaseType => "clairaudience";
+
+	public static void RegisterLoader()
+	{
+		MagicPowerFactory.RegisterLoader("clairaudience", (power, gameworld) => new ClairaudiencePower(power, gameworld));
+		MagicPowerFactory.RegisterBuilderLoader("clairaudience", BuilderLoader);
+	}
+
+	private static IMagicPower? BuilderLoader(IFuturemud gameworld, IMagicSchool school, string name, ICharacter actor,
+		StringStack command)
+	{
+		return PsionicV4PowerBuilderHelpers.BuildWithSkill(gameworld, school, name, actor, command,
+			trait => new ClairaudiencePower(gameworld, school, name, trait));
+	}
+
+	private ClairaudiencePower(IFuturemud gameworld, IMagicSchool school, string name, ITraitDefinition trait) : base(gameworld, school, name)
+	{
+		IsPsionic = true;
+		Blurb = "Hear audible output through a contacted mind";
+		_showHelpText = $"Use {school.SchoolVerb.ToUpperInvariant()} CLAIRAUDIENCE <target> to hear audible output at that mind's location.";
+		BeginVerb = "clairaudience";
+		EndVerb = "endclairaudience";
+		PowerDistance = MagicPowerDistance.AnyConnectedMindOrConnectedTo;
+		SkillCheckTrait = trait;
+		SkillCheckDifficulty = Difficulty.Normal;
+		MinimumSuccessThreshold = Outcome.MinorPass;
+		ConcentrationPointsToSustain = 1.0;
+		SustainPenalty = Gameworld.GetStaticDouble("CheckBonusPerDifficultyLevel") * -1.0;
+		DetectableWithDetectMagic = Difficulty.Normal;
+		BeginEmote = "You open your hearing through $1's mind.";
+		EndEmote = "You close your remote hearing.";
+		FailEmote = "You reach for $1's senses, but cannot tune them.";
+		DoDatabaseInsert();
+	}
+
+	private ClairaudiencePower(MagicPower power, IFuturemud gameworld) : base(power, gameworld)
+	{
+		var root = XElement.Parse(power.Definition);
+		BeginVerb = root.Element("BeginVerb")?.Value ?? "clairaudience";
+		EndVerb = root.Element("EndVerb")?.Value ?? "endclairaudience";
+		PowerDistance = Enum.Parse<MagicPowerDistance>(root.Element("PowerDistance")?.Value ?? nameof(MagicPowerDistance.AnyConnectedMindOrConnectedTo), true);
+		SkillCheckDifficulty = (Difficulty)int.Parse(root.Element("SkillCheckDifficulty")?.Value ?? ((int)Difficulty.Normal).ToString());
+		MinimumSuccessThreshold = (Outcome)int.Parse(root.Element("MinimumSuccessThreshold")?.Value ?? ((int)Outcome.MinorPass).ToString());
+		SkillCheckTrait = Gameworld.Traits.Get(long.Parse(root.Element("SkillCheckTrait")?.Value ?? "0")) ??
+		                  throw new ApplicationException($"Invalid SkillCheckTrait in power {Id} ({Name}).");
+		BeginEmote = root.Element("BeginEmote")?.Value ?? "You open your hearing through $1's mind.";
+		EndEmote = root.Element("EndEmote")?.Value ?? "You close your remote hearing.";
+		FailEmote = root.Element("FailEmote")?.Value ?? "You reach for $1's senses, but cannot tune them.";
+	}
+
+	public string BeginVerb { get; private set; }
+	public string EndVerb { get; private set; }
+	public MagicPowerDistance PowerDistance { get; private set; }
+	public Difficulty SkillCheckDifficulty { get; private set; }
+	public ITraitDefinition SkillCheckTrait { get; private set; }
+	public Outcome MinimumSuccessThreshold { get; private set; }
+	public string BeginEmote { get; private set; }
+	public string EndEmote { get; private set; }
+	public string FailEmote { get; private set; }
+	public override IEnumerable<string> Verbs => [BeginVerb, EndVerb];
+
+	protected override XElement SaveDefinition()
+	{
+		var definition = new XElement("Definition",
+			new XElement("BeginVerb", BeginVerb),
+			new XElement("EndVerb", EndVerb),
+			new XElement("PowerDistance", PowerDistance),
+			new XElement("SkillCheckDifficulty", (int)SkillCheckDifficulty),
+			new XElement("SkillCheckTrait", SkillCheckTrait.Id),
+			new XElement("MinimumSuccessThreshold", (int)MinimumSuccessThreshold),
+			new XElement("BeginEmote", new XCData(BeginEmote)),
+			new XElement("EndEmote", new XCData(EndEmote)),
+			new XElement("FailEmote", new XCData(FailEmote))
+		);
+		AddBaseDefinition(definition);
+		SaveSustainedDefinition(definition);
+		return definition;
+	}
+
+	public override void UseCommand(ICharacter actor, string verb, StringStack command)
+	{
+		if (verb.EqualTo(EndVerb))
+		{
+			UseEnd(actor, command);
+			return;
+		}
+
+		UseBegin(actor, command);
+	}
+
+	private void UseBegin(ICharacter actor, StringStack command)
+	{
+		var (truth, missing) = CanAffordToInvokePower(actor, BeginVerb);
+		if (!truth)
+		{
+			actor.OutputHandler.Send($"You can't do that because you lack sufficient {missing.Name.Colour(Telnet.BoldMagenta)}.");
+			return;
+		}
+
+		if (!HandleGeneralUseRestrictions(actor))
+		{
+			return;
+		}
+
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Whose mind do you want to hear through?");
+			return;
+		}
+
+		var target = AcquireTarget(actor, command.PopSpeech(), PowerDistance);
+		if (target is null)
+		{
+			actor.OutputHandler.Send("You cannot find any eligible mind by that description.");
+			return;
+		}
+
+		if (actor.EffectsOfType<MagicClairaudienceConcentrationEffect>().Any(x => x.Power == this && x.TargetCharacter == target))
+		{
+			actor.OutputHandler.Send("You are already hearing through that mind.");
+			return;
+		}
+
+		if (CanInvokePowerProg.ExecuteBool(actor, target) == false)
+		{
+			actor.OutputHandler.Send(WhyCantInvokePowerProg.Execute(actor, target)?.ToString() ??
+			                         $"You cannot use that power on {target.HowSeen(actor)}.");
+			return;
+		}
+
+		var outcome = Gameworld.GetCheck(CheckType.MagicTelepathyCheck).Check(actor, SkillCheckDifficulty, SkillCheckTrait, target);
+		if (outcome < MinimumSuccessThreshold)
+		{
+			actor.OutputHandler.Send(new EmoteOutput(new Emote(FailEmote, actor, actor, target)));
+			return;
+		}
+
+		actor.AddEffect(new MagicClairaudienceConcentrationEffect(actor, this, target), GetDuration(outcome.SuccessDegrees()));
+		actor.OutputHandler.Send(new EmoteOutput(new Emote(BeginEmote, actor, actor, target)));
+		ConsumePowerCosts(actor, BeginVerb);
+	}
+
+	private void UseEnd(ICharacter actor, StringStack command)
+	{
+		var effects = actor.EffectsOfType<MagicClairaudienceConcentrationEffect>().Where(x => x.Power == this).ToList();
+		if (!effects.Any())
+		{
+			actor.OutputHandler.Send("You are not currently hearing through any mind with that power.");
+			return;
+		}
+
+		var effect = effects.First();
+		if (!command.IsFinished)
+		{
+			var targetText = command.PopSpeech();
+			var target = effects.Select(x => x.TargetCharacter)
+			                    .OfType<ICharacter>()
+			                    .GetFromItemListByKeyword(targetText, actor);
+			effect = effects.FirstOrDefault(x => x.TargetCharacter == target);
+		}
+		if (effect is null)
+		{
+			actor.OutputHandler.Send("You are not hearing through any mind like that.");
+			return;
+		}
+
+		actor.RemoveEffect(effect, true);
+		actor.OutputHandler.Send(new EmoteOutput(new Emote(EndEmote, actor, actor, effect.TargetCharacter ?? actor)));
+		ConsumePowerCosts(actor, EndVerb);
+	}
+
+	protected override void ExpireSustainedEffect(ICharacter actor)
+	{
+		foreach (var effect in actor.EffectsOfType<MagicClairaudienceConcentrationEffect>().Where(x => x.Power == this).ToList())
+		{
+			actor.RemoveEffect(effect, true);
+		}
+	}
+
+	protected override void ShowSubtype(ICharacter actor, StringBuilder sb)
+	{
+		sb.AppendLine($"Begin Verb: {BeginVerb.ColourCommand()}");
+		sb.AppendLine($"End Verb: {EndVerb.ColourCommand()}");
+		sb.AppendLine($"Power Distance: {PowerDistance.DescribeEnum().ColourValue()}");
+		sb.AppendLine($"Skill Check Trait: {SkillCheckTrait.Name.ColourValue()}");
+		sb.AppendLine($"Skill Check Difficulty: {SkillCheckDifficulty.DescribeColoured()}");
+		sb.AppendLine($"Minimum Success Threshold: {MinimumSuccessThreshold.DescribeColour()}");
+		sb.AppendLine($"Begin Emote: {BeginEmote.ColourCommand()}");
+		sb.AppendLine($"End Emote: {EndEmote.ColourCommand()}");
+		sb.AppendLine($"Fail Emote: {FailEmote.ColourCommand()}");
+	}
+}
+

--- a/MudSharpCore/Magic/Powers/CoercePower.cs
+++ b/MudSharpCore/Magic/Powers/CoercePower.cs
@@ -1,0 +1,173 @@
+#nullable enable
+
+using MudSharp.Body.Needs;
+using MudSharp.Body.Traits;
+using MudSharp.Character;
+using MudSharp.Effects;
+using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.Models;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Outputs;
+using MudSharp.PerceptionEngine.Parsers;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+namespace MudSharp.Magic.Powers;
+
+public sealed class CoercePower : PsionicTargetedPowerBase
+{
+	public override string PowerType => "Coerce";
+	public override string DatabaseType => "coerce";
+	protected override string DefaultVerb => "coerce";
+
+	public static void RegisterLoader()
+	{
+		MagicPowerFactory.RegisterLoader("coerce", (power, gameworld) => new CoercePower(power, gameworld));
+		MagicPowerFactory.RegisterBuilderLoader("coerce", BuilderLoader);
+	}
+
+	private static IMagicPower? BuilderLoader(IFuturemud gameworld, IMagicSchool school, string name, ICharacter actor,
+		StringStack command)
+	{
+		return PsionicV4PowerBuilderHelpers.BuildWithSkill(gameworld, school, name, actor, command,
+			trait => new CoercePower(gameworld, school, name, trait));
+	}
+
+	private CoercePower(IFuturemud gameworld, IMagicSchool school, string name, ITraitDefinition trait) : base(gameworld, school, name, trait)
+	{
+		Blurb = "Influence stamina, hunger, thirst, or thoughts";
+		_showHelpText = $"Use {school.SchoolVerb.ToUpperInvariant()} COERCE <target> <fatigue|refresh|thirst|quench|hunger|full|thought> [thought] to influence a body or mind.";
+		StaminaFractionPerDegree = 0.05;
+		NeedHoursPerDegree = 2.0;
+		FailEcho = "You press against $1's body and mind, but cannot make it answer.";
+		DoDatabaseInsert();
+	}
+
+	private CoercePower(MagicPower power, IFuturemud gameworld) : base(power, gameworld)
+	{
+		var root = XElement.Parse(power.Definition);
+		StaminaFractionPerDegree = double.Parse(root.Element("StaminaFractionPerDegree")?.Value ?? "0.05");
+		NeedHoursPerDegree = double.Parse(root.Element("NeedHoursPerDegree")?.Value ?? "2.0");
+	}
+
+	public double StaminaFractionPerDegree { get; private set; }
+	public double NeedHoursPerDegree { get; private set; }
+
+	protected override XElement SaveDefinition()
+	{
+		return SaveTargetedDefinition(
+			new XElement("StaminaFractionPerDegree", StaminaFractionPerDegree),
+			new XElement("NeedHoursPerDegree", NeedHoursPerDegree)
+		);
+	}
+
+	public override void UseCommand(ICharacter actor, string verb, StringStack command)
+	{
+		if (!TryPrepareTarget(actor, command, "Whose body or mind do you want to coerce?", out var target) || target is null)
+		{
+			return;
+		}
+
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which mode do you want to use: fatigue, refresh, thirst, quench, hunger, full, or thought?");
+			return;
+		}
+
+		if (!command.PopSpeech().TryParseEnum(out PsionicCoerceMode mode))
+		{
+			actor.OutputHandler.Send("That is not a valid coerce mode. Use fatigue, refresh, thirst, quench, hunger, full, or thought.");
+			return;
+		}
+
+		if (!PsionicTrafficHelper.CanReceiveInvoluntaryMentalTraffic(target))
+		{
+			actor.OutputHandler.Send($"{target.HowSeen(actor, true)} refuses involuntary mental traffic.");
+			return;
+		}
+
+		if (mode == PsionicCoerceMode.Thought && command.IsFinished)
+		{
+			actor.OutputHandler.Send("What thought do you want to coerce?");
+			return;
+		}
+
+		var outcome = CheckPower(actor, target, CheckType.MindSayPower);
+		if (outcome < MinimumSuccessThreshold)
+		{
+			SendFailure(actor, target);
+			return;
+		}
+
+		var degrees = Math.Max(1, outcome.SuccessDegrees());
+		switch (mode)
+		{
+			case PsionicCoerceMode.Fatigue:
+				ApplyStamina(actor, target, -target.MaximumStamina * StaminaFractionPerDegree * degrees, "fatigue");
+				break;
+			case PsionicCoerceMode.Refresh:
+				ApplyStamina(actor, target, target.MaximumStamina * StaminaFractionPerDegree * degrees, "refresh");
+				break;
+			case PsionicCoerceMode.Thirst:
+				ApplyNeeds(actor, target, 0.0, -NeedHoursPerDegree * degrees, "thirst");
+				break;
+			case PsionicCoerceMode.Quench:
+				ApplyNeeds(actor, target, 0.0, NeedHoursPerDegree * degrees, "quench");
+				break;
+			case PsionicCoerceMode.Hunger:
+				ApplyNeeds(actor, target, -NeedHoursPerDegree * degrees, 0.0, "hunger");
+				break;
+			case PsionicCoerceMode.Full:
+				ApplyNeeds(actor, target, NeedHoursPerDegree * degrees, 0.0, "fullness");
+				break;
+			case PsionicCoerceMode.Thought:
+				PsionicTrafficHelper.DeliverThought(actor, target, School, command.SafeRemainingArgument);
+				break;
+		}
+
+		ConsumePowerCosts(actor, Verb);
+	}
+
+	private static void ApplyStamina(ICharacter actor, ICharacter target, double amount, string label)
+	{
+		if (amount < 0)
+		{
+			target.SpendStamina(Math.Abs(amount));
+		}
+		else
+		{
+			target.GainStamina(amount);
+		}
+
+		actor.OutputHandler.Send($"You coerce {label} through {target.HowSeen(actor, true)}.");
+		target.OutputHandler.Send($"A psionic pressure forces {label} through your body.");
+		PsionicTrafficHelper.Audit(actor, target, $"coerced {label} in", amount.ToString("N2", actor));
+	}
+
+	private static void ApplyNeeds(ICharacter actor, ICharacter target, double hunger, double thirst, string label)
+	{
+		target.FulfilNeeds(new NeedFulfiller
+		{
+			SatiationPoints = hunger,
+			ThirstPoints = thirst
+		}, true);
+
+		actor.OutputHandler.Send($"You coerce {label} through {target.HowSeen(actor, true)}.");
+		target.OutputHandler.Send($"A psionic pressure forces {label} through your body.");
+		PsionicTrafficHelper.Audit(actor, target, $"coerced {label} in", $"hunger {hunger:N2}, thirst {thirst:N2}");
+	}
+
+	protected override void ShowSubtypeDetails(ICharacter actor, StringBuilder sb)
+	{
+		sb.AppendLine($"Stamina Fraction Per Degree: {StaminaFractionPerDegree.ToString("P2", actor).ColourValue()}");
+		sb.AppendLine($"Need Hours Per Degree: {NeedHoursPerDegree.ToString("N2", actor).ColourValue()}");
+	}
+}
+

--- a/MudSharpCore/Magic/Powers/ConnectMindPower.cs
+++ b/MudSharpCore/Magic/Powers/ConnectMindPower.cs
@@ -58,6 +58,7 @@ public class ConnectMindPower : SustainedMagicPower
     new XElement("SkillCheckTrait", SkillCheckTrait.Id),
     new XElement("MinimumSuccessThreshold", (int)MinimumSuccessThreshold),
     new XElement("TargetCanSeeIdentityProg", TargetCanSeeIdentityProg.Id),
+    new XElement("TargetEligibilityProg", TargetEligibilityProg.Id),
     new XElement("ExclusiveConnection", ExclusiveConnection),
     new XElement("EmoteForConnect", new XCData(EmoteForConnect)),
     new XElement("SelfEmoteForConnect", new XCData(SelfEmoteForConnect)),
@@ -193,6 +194,13 @@ public class ConnectMindPower : SustainedMagicPower
             ? Gameworld.FutureProgs.Get(value)
             : Gameworld.FutureProgs.GetByName(element.Value);
 
+        element = root.Element("TargetEligibilityProg");
+        TargetEligibilityProg = element is null
+            ? Gameworld.AlwaysTrueProg
+            : long.TryParse(element.Value, out value)
+                ? Gameworld.FutureProgs.Get(value)
+                : Gameworld.FutureProgs.GetByName(element.Value);
+
         element = root.Element("ExclusiveConnection");
         if (element == null)
         {
@@ -275,6 +283,7 @@ public class ConnectMindPower : SustainedMagicPower
         MinimumSuccessThreshold = Outcome.Fail;
         ConcentrationPointsToSustain = 1.0;
         TargetCanSeeIdentityProg = Gameworld.AlwaysFalseProg;
+        TargetEligibilityProg = Gameworld.AlwaysTrueProg;
         ExclusiveConnection = true;
         UnknownIdentityDescription = "an unknown entity";
         _outcomeEchoDictionary[Outcome.MajorFail] = false;
@@ -335,6 +344,7 @@ public class ConnectMindPower : SustainedMagicPower
 				actor.EffectsOfType<ConnectMindEffect>().All(y => y.TargetCharacter != x.CharacterOwner)).ToList();
 			List<MindConnectedToEffect> eligable = potentialTargets
 			               .Where(x => CanInvokePowerProg?.ExecuteBool(actor, x.OriginatorCharacter) != false &&
+			                           TargetFilterFunction(actor, x.OriginatorCharacter) &&
 			                           TargetIsInRange(actor, x.OriginatorCharacter, PowerDistance) &&
 			                           MagicInterdictionHelper.GetInterdiction(actor, x.OriginatorCharacter, School, false) is null).ToList();
             if (eligable.Any())
@@ -408,7 +418,7 @@ public class ConnectMindPower : SustainedMagicPower
 			return;
 		}
 
-		if (CanInvokePowerProg.ExecuteBool(actor, target))
+		if (!TargetFilterFunction(actor, target) || CanInvokePowerProg.ExecuteBool(actor, target) == false)
 		{
             actor.OutputHandler.Send(string.Format(
                 WhyCantInvokePowerProg.Execute(actor, target)?.ToString() ??
@@ -432,7 +442,7 @@ public class ConnectMindPower : SustainedMagicPower
             return;
         }
 
-        if (barrier.MindPower.FailIfOvercome && results.Item1.IsPass())
+        if (barrier is not null && barrier.MindPower.FailIfOvercome && results.Item1.IsPass())
         {
             barrier.Shatter(actor);
         }
@@ -550,6 +560,7 @@ public class ConnectMindPower : SustainedMagicPower
     public string SelfEmoteForDisconnect { get; protected set; }
 
     public IFutureProg TargetCanSeeIdentityProg { get; protected set; }
+    public IFutureProg TargetEligibilityProg { get; protected set; }
     public string UnknownIdentityDescription { get; protected set; }
 
     public bool ExclusiveConnection { get; protected set; }
@@ -564,6 +575,7 @@ public class ConnectMindPower : SustainedMagicPower
         sb.AppendLine($"Unknown Identity Desc: {UnknownIdentityDescription.ColourCharacter()}");
         sb.AppendLine($"Exclusive: {ExclusiveConnection.ToColouredString()}");
         sb.AppendLine($"Target Knows Identity Prog: {TargetCanSeeIdentityProg.MXPClickableFunctionName()}");
+        sb.AppendLine($"Target Eligibility Prog: {TargetEligibilityProg.MXPClickableFunctionName()}");
         sb.AppendLine();
         sb.AppendLine("Emotes:");
         sb.AppendLine();
@@ -649,6 +661,7 @@ public class ConnectMindPower : SustainedMagicPower
 	#3failconnect <emote>#0 - sets the emote for failed connecting. $0 is the power user, $1 is the target
 	#3faiilselfconnect <emote>#0 - sets the self emote for failed connecting. $0 is the power user, $1 is the target
 	#3targetprog <prog>#0 - sets the prog that controls if the target can see the sdesc
+	#3eligibility <prog>|none#0 - sets the prog that controls valid mind-contact targets
 	#3unknown <desc>#0 - sets the unknown description if the target prog fails
 	#3exclusive#0 - toggles whether this connection is exclusive or not
 
@@ -698,6 +711,11 @@ public class ConnectMindPower : SustainedMagicPower
                 return BuildingCommandSelfFailConnectEmote(actor, command);
             case "targetprog":
                 return BuildingCommandTargetProg(actor, command);
+            case "eligibility":
+            case "eligible":
+            case "filter":
+            case "filterprog":
+                return BuildingCommandEligibilityProg(actor, command);
             case "unknown":
                 return BuildingCommandUnknown(actor, command);
             case "exclusive":
@@ -727,6 +745,43 @@ public class ConnectMindPower : SustainedMagicPower
         UnknownIdentityDescription = command.SafeRemainingArgument;
         Changed = true;
         actor.OutputHandler.Send($"The unknown description will now be {UnknownIdentityDescription.ColourCharacter()}.");
+        return true;
+    }
+
+    protected override bool TargetFilterFunction(ICharacter owner, ICharacter target)
+    {
+        return TargetEligibilityProg?.ExecuteBool(owner, target) != false;
+    }
+
+    private bool BuildingCommandEligibilityProg(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("What prog should be used to control whether a target can be contacted? Use none to clear it.");
+            return false;
+        }
+
+        if (command.SafeRemainingArgument.EqualToAny("none", "clear", "delete"))
+        {
+            TargetEligibilityProg = Gameworld.AlwaysTrueProg;
+            Changed = true;
+            actor.OutputHandler.Send("This power no longer uses a target eligibility prog.");
+            return true;
+        }
+
+        IFutureProg prog = new ProgLookupFromBuilderInput(actor, command.SafeRemainingArgument, ProgVariableTypes.Boolean,
+            [
+                [ProgVariableTypes.Character, ProgVariableTypes.Character]
+            ]
+        ).LookupProg();
+        if (prog is null)
+        {
+            return false;
+        }
+
+        TargetEligibilityProg = prog;
+        Changed = true;
+        actor.OutputHandler.Send($"The {prog.MXPClickableFunctionName()} prog now controls which minds this power can target.");
         return true;
     }
 

--- a/MudSharpCore/Magic/Powers/HearPower.cs
+++ b/MudSharpCore/Magic/Powers/HearPower.cs
@@ -1,0 +1,185 @@
+#nullable enable
+
+using MudSharp.Body.Needs;
+using MudSharp.Body.Traits;
+using MudSharp.Character;
+using MudSharp.Effects;
+using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.Models;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Outputs;
+using MudSharp.PerceptionEngine.Parsers;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+namespace MudSharp.Magic.Powers;
+
+public sealed class HearPower : PsionicSustainedSelfPowerBase
+{
+	public override string PowerType => "Hear";
+	public override string DatabaseType => "hear";
+	protected override string DefaultBeginVerb => "hear";
+	protected override string DefaultEndVerb => "endhear";
+
+	public static void RegisterLoader()
+	{
+		MagicPowerFactory.RegisterLoader("hear", (power, gameworld) => new HearPower(power, gameworld));
+		MagicPowerFactory.RegisterBuilderLoader("hear", BuilderLoader);
+	}
+
+	private static IMagicPower? BuilderLoader(IFuturemud gameworld, IMagicSchool school, string name, ICharacter actor,
+		StringStack command)
+	{
+		return PsionicV4PowerBuilderHelpers.BuildWithSkill(gameworld, school, name, actor, command,
+			trait => new HearPower(gameworld, school, name, trait));
+	}
+
+	private HearPower(IFuturemud gameworld, IMagicSchool school, string name, ITraitDefinition trait) : base(gameworld, school, name, trait)
+	{
+		Blurb = "Listen to psionic thought and emotion traffic";
+		_showHelpText = $"Use {school.SchoolVerb.ToUpperInvariant()} HEAR to listen for thought and feeling traffic. This does not hear ordinary room audio.";
+		PowerDistance = MagicPowerDistance.AnyConnectedMindOrConnectedTo;
+		ShowThinks = true;
+		ShowFeels = true;
+		ShowName = false;
+		ShowEmotes = true;
+		ShowDescriptionProg = Gameworld.AlwaysTrueProg;
+		DoDatabaseInsert();
+	}
+
+	private HearPower(MagicPower power, IFuturemud gameworld) : base(power, gameworld)
+	{
+		var root = XElement.Parse(power.Definition);
+		PowerDistance = Enum.Parse<MagicPowerDistance>(root.Element("PowerDistance")?.Value ?? nameof(MagicPowerDistance.AnyConnectedMindOrConnectedTo), true);
+		ShowThinks = bool.Parse(root.Element("ShowThinks")?.Value ?? "true");
+		ShowFeels = bool.Parse(root.Element("ShowFeels")?.Value ?? "true");
+		ShowName = bool.Parse(root.Element("ShowName")?.Value ?? "false");
+		ShowEmotes = bool.Parse(root.Element("ShowEmotes")?.Value ?? "true");
+		ShowDescriptionProg = Gameworld.FutureProgs.Get(long.Parse(root.Element("ShowDescriptionProg")?.Value ?? "0")) ?? Gameworld.AlwaysTrueProg;
+	}
+
+	protected override XElement SaveDefinition()
+	{
+		return SaveSustainedSelfDefinition(
+			new XElement("PowerDistance", PowerDistance),
+			new XElement("ShowThinks", ShowThinks),
+			new XElement("ShowFeels", ShowFeels),
+			new XElement("ShowName", ShowName),
+			new XElement("ShowEmotes", ShowEmotes),
+			new XElement("ShowDescriptionProg", ShowDescriptionProg.Id)
+		);
+	}
+
+	public MagicPowerDistance PowerDistance { get; private set; }
+	public bool ShowThinks { get; private set; }
+	public bool ShowFeels { get; private set; }
+	public bool ShowName { get; private set; }
+	public bool ShowEmotes { get; private set; }
+	public IFutureProg ShowDescriptionProg { get; private set; }
+
+	public bool TargetFilter(ICharacter listener, ICharacter thinker)
+	{
+		return TargetIsValid(listener, thinker);
+	}
+
+	public bool CheckCanHear(ICharacter listener, ICharacter thinker)
+	{
+		return Gameworld.GetCheck(CheckType.MagicTelepathyCheck)
+		                .Check(listener, SkillCheckDifficulty, SkillCheckTrait, thinker) >= MinimumSuccessThreshold;
+	}
+
+	protected override IEffect CreateEffect(ICharacter actor)
+	{
+		return new PsionicHearEffect(actor, this);
+	}
+
+	protected override IEnumerable<IEffect> ActiveEffects(ICharacter actor)
+	{
+		return actor.EffectsOfType<PsionicHearEffect>().Where(x => x.Power == this);
+	}
+
+	protected override void ShowSubtypeDetails(ICharacter actor, StringBuilder sb)
+	{
+		sb.AppendLine($"Power Distance: {PowerDistance.DescribeEnum().ColourValue()}");
+		sb.AppendLine($"Show Thinks: {ShowThinks.ToColouredString()}");
+		sb.AppendLine($"Show Feels: {ShowFeels.ToColouredString()}");
+		sb.AppendLine($"Show Name: {ShowName.ToColouredString()}");
+		sb.AppendLine($"Show Emotes: {ShowEmotes.ToColouredString()}");
+		sb.AppendLine($"Show Description Prog: {ShowDescriptionProg.MXPClickableFunctionName()}");
+	}
+
+	public override bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "distance":
+				if (!command.SafeRemainingArgument.TryParseEnum(out MagicPowerDistance value))
+				{
+					actor.OutputHandler.Send($"Valid distances are {Enum.GetValues<MagicPowerDistance>().Select(x => x.DescribeEnum().ColourValue()).ListToString()}.");
+					return false;
+				}
+
+				PowerDistance = value;
+				Changed = true;
+				actor.OutputHandler.Send($"This power now listens across {value.LongDescription().ColourValue()}.");
+				return true;
+			case "thinks":
+				ShowThinks = !ShowThinks;
+				Changed = true;
+				actor.OutputHandler.Send($"This power will {ShowThinks.NowNoLonger()} show thoughts.");
+				return true;
+			case "feels":
+				ShowFeels = !ShowFeels;
+				Changed = true;
+				actor.OutputHandler.Send($"This power will {ShowFeels.NowNoLonger()} show feelings.");
+				return true;
+			case "name":
+				ShowName = !ShowName;
+				Changed = true;
+				actor.OutputHandler.Send($"This power will {ShowName.NowNoLonger()} show real names.");
+				return true;
+			case "emotes":
+				ShowEmotes = !ShowEmotes;
+				Changed = true;
+				actor.OutputHandler.Send($"This power will {ShowEmotes.NowNoLonger()} show think/feel emotes.");
+				return true;
+			case "descprog":
+				return BuildingCommandDescriptionProg(actor, command);
+		}
+
+		return base.BuildingCommand(actor, command.GetUndo());
+	}
+
+	private bool BuildingCommandDescriptionProg(ICharacter actor, StringStack command)
+	{
+		if (command.SafeRemainingArgument.EqualToAny("none", "clear", "delete"))
+		{
+			ShowDescriptionProg = Gameworld.AlwaysTrueProg;
+			Changed = true;
+			actor.OutputHandler.Send("This power will always show descriptions for heard minds.");
+			return true;
+		}
+
+		var prog = new ProgLookupFromBuilderInput(actor, command.SafeRemainingArgument, ProgVariableTypes.Boolean,
+			[
+				[ProgVariableTypes.Character, ProgVariableTypes.Character]
+			]).LookupProg();
+		if (prog is null)
+		{
+			return false;
+		}
+
+		ShowDescriptionProg = prog;
+		Changed = true;
+		actor.OutputHandler.Send($"This power now uses {prog.MXPClickableFunctionName()} to decide whether descriptions are shown.");
+		return true;
+	}
+}
+

--- a/MudSharpCore/Magic/Powers/MagicPowerBase.cs
+++ b/MudSharpCore/Magic/Powers/MagicPowerBase.cs
@@ -450,6 +450,7 @@ public abstract class MagicPowerBase : SaveableItem, IMagicPower
 	#3why <prog>#0 - sets a prog that controls an error message if prog can't be used
 	#3help#0 - drops you into an editor to write the player help file
 	#3cost <verb> <which> <number>#0 - sets the cost of using a particular verb
+	#3psionic#0 - toggles whether this power is psionic for crime and policy purposes
 {SubtypeHelpText}";
 
     public virtual bool BuildingCommand(ICharacter actor, StringStack command)
@@ -476,10 +477,21 @@ public abstract class MagicPowerBase : SaveableItem, IMagicPower
                 return BuildingCommandCost(actor, command);
             case "school":
                 return BuildingCommandSchool(actor, command);
+            case "psionic":
+            case "psi":
+                return BuildingCommandPsionic(actor);
         }
 
         actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
         return false;
+    }
+
+    private bool BuildingCommandPsionic(ICharacter actor)
+    {
+        IsPsionic = !IsPsionic;
+        Changed = true;
+        actor.OutputHandler.Send($"This power is {IsPsionic.NowNoLonger()} considered psionic.");
+        return true;
     }
 
     private bool BuildingCommandSchool(ICharacter actor, StringStack command)
@@ -680,6 +692,7 @@ public abstract class MagicPowerBase : SaveableItem, IMagicPower
         sb.AppendLine($"Magic Power #{Id.ToString("N0", actor)} - {Name}".GetLineWithTitle(actor, School.PowerListColour, Telnet.BoldWhite));
         sb.AppendLine($"Type: {PowerType.ColourValue()}");
         sb.AppendLine($"School: {School.Name.Colour(School.PowerListColour)}");
+        sb.AppendLine($"Psionic: {IsPsionic.ToColouredString()}");
         sb.AppendLine($"Blurb: {Blurb.ColourCommand()}");
         sb.AppendLine($"Can Invoke Prog: {CanInvokePowerProg?.MXPClickableFunctionName() ?? "None".ColourError()}");
         sb.AppendLine($"Why Can't Invoke Prog: {WhyCantInvokePowerProg?.MXPClickableFunctionName() ?? "None".ColourError()}");
@@ -712,6 +725,21 @@ public abstract class MagicPowerBase : SaveableItem, IMagicPower
     protected void AddBaseDefinition(XElement root)
     {
         root.Add(new XElement("IsPsionic", IsPsionic));
+        root.Add(new XElement("CanInvokePowerProg", CanInvokePowerProg.Id));
+        root.Add(new XElement("WhyCantInvokePowerProg", WhyCantInvokePowerProg.Id));
+        root.Add(new XElement("InvocationCosts",
+            new XElement("Verbs",
+                from verb in InvocationCosts
+                select new XElement("Verb",
+                    new XAttribute("verb", verb.Key),
+                    from cost in verb.Value
+                    select new XElement("Cost",
+                        new XAttribute("resource", cost.Resource.Id),
+                        cost.Cost
+                    )
+                )
+            )
+        ));
     }
 
     protected abstract XElement SaveDefinition();

--- a/MudSharpCore/Magic/Powers/MagicksensePower.cs
+++ b/MudSharpCore/Magic/Powers/MagicksensePower.cs
@@ -1,0 +1,70 @@
+#nullable enable
+
+using MudSharp.Body.Needs;
+using MudSharp.Body.Traits;
+using MudSharp.Character;
+using MudSharp.Effects;
+using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.Models;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Outputs;
+using MudSharp.PerceptionEngine.Parsers;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+namespace MudSharp.Magic.Powers;
+
+public sealed class MagicksensePower : PsionicSustainedSelfPowerBase
+{
+	public override string PowerType => "Magicksense";
+	public override string DatabaseType => "magicksense";
+	protected override string DefaultBeginVerb => "magicksense";
+	protected override string DefaultEndVerb => "endmagicksense";
+
+	public static void RegisterLoader()
+	{
+		MagicPowerFactory.RegisterLoader("magicksense", (power, gameworld) => new MagicksensePower(power, gameworld));
+		MagicPowerFactory.RegisterBuilderLoader("magicksense", BuilderLoader);
+	}
+
+	private static IMagicPower? BuilderLoader(IFuturemud gameworld, IMagicSchool school, string name, ICharacter actor,
+		StringStack command)
+	{
+		return PsionicV4PowerBuilderHelpers.BuildWithSkill(gameworld, school, name, actor, command,
+			trait => new MagicksensePower(gameworld, school, name, trait));
+	}
+
+	private MagicksensePower(IFuturemud gameworld, IMagicSchool school, string name, ITraitDefinition trait) : base(gameworld, school, name, trait)
+	{
+		Blurb = "Sense magical auras while sustained";
+		_showHelpText = $"Use {school.SchoolVerb.ToUpperInvariant()} MAGICKSENSE to gain the normal magical aura sense.";
+		DoDatabaseInsert();
+	}
+
+	private MagicksensePower(MagicPower power, IFuturemud gameworld) : base(power, gameworld)
+	{
+	}
+
+	protected override XElement SaveDefinition()
+	{
+		return SaveSustainedSelfDefinition();
+	}
+
+	protected override IEffect CreateEffect(ICharacter actor)
+	{
+		return new MagicMagicksenseEffect(actor, this);
+	}
+
+	protected override IEnumerable<IEffect> ActiveEffects(ICharacter actor)
+	{
+		return actor.EffectsOfType<MagicMagicksenseEffect>().Where(x => x.Power == this);
+	}
+}
+

--- a/MudSharpCore/Magic/Powers/ProjectEmotionPower.cs
+++ b/MudSharpCore/Magic/Powers/ProjectEmotionPower.cs
@@ -1,0 +1,90 @@
+#nullable enable
+
+using MudSharp.Body.Needs;
+using MudSharp.Body.Traits;
+using MudSharp.Character;
+using MudSharp.Effects;
+using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.Models;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Outputs;
+using MudSharp.PerceptionEngine.Parsers;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+namespace MudSharp.Magic.Powers;
+
+public sealed class ProjectEmotionPower : PsionicTargetedPowerBase
+{
+	public override string PowerType => "Project Emotion";
+	public override string DatabaseType => "projectemotion";
+	protected override string DefaultVerb => "projectemotion";
+
+	public static void RegisterLoader()
+	{
+		MagicPowerFactory.RegisterLoader("projectemotion", (power, gameworld) => new ProjectEmotionPower(power, gameworld));
+		MagicPowerFactory.RegisterBuilderLoader("projectemotion", BuilderLoader);
+	}
+
+	private static IMagicPower? BuilderLoader(IFuturemud gameworld, IMagicSchool school, string name, ICharacter actor,
+		StringStack command)
+	{
+		return PsionicV4PowerBuilderHelpers.BuildWithSkill(gameworld, school, name, actor, command,
+			trait => new ProjectEmotionPower(gameworld, school, name, trait));
+	}
+
+	private ProjectEmotionPower(IFuturemud gameworld, IMagicSchool school, string name, ITraitDefinition trait) : base(gameworld, school, name, trait)
+	{
+		Blurb = "Inject an involuntary feeling into a target mind";
+		_showHelpText = $"Use {school.SchoolVerb.ToUpperInvariant()} PROJECTEMOTION <target> <feeling> to put a feeling into a mind.";
+		FailEcho = "You reach for $1's feelings, but cannot touch them.";
+		DoDatabaseInsert();
+	}
+
+	private ProjectEmotionPower(MagicPower power, IFuturemud gameworld) : base(power, gameworld)
+	{
+	}
+
+	protected override XElement SaveDefinition()
+	{
+		return SaveTargetedDefinition();
+	}
+
+	public override void UseCommand(ICharacter actor, string verb, StringStack command)
+	{
+		if (!TryPrepareTarget(actor, command, "Whose mind do you want to project emotion into?", out var target) || target is null)
+		{
+			return;
+		}
+
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("What feeling do you want to project?");
+			return;
+		}
+
+		if (!PsionicTrafficHelper.CanReceiveInvoluntaryMentalTraffic(target))
+		{
+			actor.OutputHandler.Send($"{target.HowSeen(actor, true)} refuses involuntary mental traffic.");
+			return;
+		}
+
+		var outcome = CheckPower(actor, target, CheckType.MindSayPower);
+		if (outcome < MinimumSuccessThreshold)
+		{
+			SendFailure(actor, target);
+			return;
+		}
+
+		PsionicTrafficHelper.DeliverEmotion(actor, target, School, command.SafeRemainingArgument);
+		ConsumePowerCosts(actor, Verb);
+	}
+}
+

--- a/MudSharpCore/Magic/Powers/PsionicCoerceMode.cs
+++ b/MudSharpCore/Magic/Powers/PsionicCoerceMode.cs
@@ -1,0 +1,34 @@
+#nullable enable
+
+using MudSharp.Body.Needs;
+using MudSharp.Body.Traits;
+using MudSharp.Character;
+using MudSharp.Effects;
+using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.Models;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Outputs;
+using MudSharp.PerceptionEngine.Parsers;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+namespace MudSharp.Magic.Powers;
+
+public enum PsionicCoerceMode
+{
+	Fatigue,
+	Refresh,
+	Thirst,
+	Quench,
+	Hunger,
+	Full,
+	Thought
+}
+

--- a/MudSharpCore/Magic/Powers/PsionicSustainedSelfPowerBase.cs
+++ b/MudSharpCore/Magic/Powers/PsionicSustainedSelfPowerBase.cs
@@ -1,0 +1,349 @@
+#nullable enable
+
+using MudSharp.Body.Needs;
+using MudSharp.Body.Traits;
+using MudSharp.Character;
+using MudSharp.Effects;
+using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.Models;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Outputs;
+using MudSharp.PerceptionEngine.Parsers;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+namespace MudSharp.Magic.Powers;
+
+public abstract class PsionicSustainedSelfPowerBase : SustainedMagicPower
+{
+	protected PsionicSustainedSelfPowerBase(MagicPower power, IFuturemud gameworld) : base(power, gameworld)
+	{
+		var root = XElement.Parse(power.Definition);
+		BeginVerb = root.Element("BeginVerb")?.Value ?? throw new ApplicationException($"Missing BeginVerb in power {Id} ({Name}).");
+		EndVerb = root.Element("EndVerb")?.Value ?? throw new ApplicationException($"Missing EndVerb in power {Id} ({Name}).");
+		SkillCheckDifficulty = (Difficulty)int.Parse(root.Element("SkillCheckDifficulty")?.Value ?? ((int)Difficulty.Normal).ToString());
+		MinimumSuccessThreshold = (Outcome)int.Parse(root.Element("MinimumSuccessThreshold")?.Value ?? ((int)Outcome.MinorPass).ToString());
+		SkillCheckTrait = Gameworld.Traits.Get(long.Parse(root.Element("SkillCheckTrait")?.Value ?? "0")) ??
+		                  throw new ApplicationException($"Invalid SkillCheckTrait in power {Id} ({Name}).");
+		BeginEmote = root.Element("BeginEmote")?.Value ?? "You gather your psionic focus.";
+		EndEmote = root.Element("EndEmote")?.Value ?? "You release your psionic focus.";
+		FailEmote = root.Element("FailEmote")?.Value ?? "Your focus slips away from you.";
+	}
+
+	protected PsionicSustainedSelfPowerBase(IFuturemud gameworld, IMagicSchool school, string name, ITraitDefinition trait)
+		: base(gameworld, school, name)
+	{
+		IsPsionic = true;
+		BeginVerb = DefaultBeginVerb;
+		EndVerb = DefaultEndVerb;
+		SkillCheckTrait = trait;
+		SkillCheckDifficulty = Difficulty.Normal;
+		MinimumSuccessThreshold = Outcome.MinorPass;
+		ConcentrationPointsToSustain = 1.0;
+		SustainPenalty = Gameworld.GetStaticDouble("CheckBonusPerDifficultyLevel") * -1.0;
+		DetectableWithDetectMagic = Difficulty.Normal;
+		BeginEmote = "You gather your psionic focus.";
+		EndEmote = "You release your psionic focus.";
+		FailEmote = "Your focus slips away from you.";
+	}
+
+	protected abstract string DefaultBeginVerb { get; }
+	protected abstract string DefaultEndVerb { get; }
+	public string BeginVerb { get; protected set; }
+	public string EndVerb { get; protected set; }
+	public Difficulty SkillCheckDifficulty { get; protected set; }
+	public ITraitDefinition SkillCheckTrait { get; protected set; }
+	public Outcome MinimumSuccessThreshold { get; protected set; }
+	public string BeginEmote { get; protected set; }
+	public string EndEmote { get; protected set; }
+	public string FailEmote { get; protected set; }
+	public override IEnumerable<string> Verbs => [BeginVerb, EndVerb];
+
+	protected XElement SaveSustainedSelfDefinition(params object[] additional)
+	{
+		var definition = new XElement("Definition",
+			new XElement("BeginVerb", BeginVerb),
+			new XElement("EndVerb", EndVerb),
+			new XElement("SkillCheckDifficulty", (int)SkillCheckDifficulty),
+			new XElement("SkillCheckTrait", SkillCheckTrait.Id),
+			new XElement("MinimumSuccessThreshold", (int)MinimumSuccessThreshold),
+			new XElement("BeginEmote", new XCData(BeginEmote)),
+			new XElement("EndEmote", new XCData(EndEmote)),
+			new XElement("FailEmote", new XCData(FailEmote))
+		);
+		foreach (var item in additional)
+		{
+			definition.Add(item);
+		}
+
+		AddBaseDefinition(definition);
+		SaveSustainedDefinition(definition);
+		return definition;
+	}
+
+	public override void UseCommand(ICharacter actor, string verb, StringStack command)
+	{
+		if (verb.EqualTo(BeginVerb))
+		{
+			UseBegin(actor);
+			return;
+		}
+
+		UseEnd(actor);
+	}
+
+	private void UseBegin(ICharacter actor)
+	{
+		if (ActiveEffects(actor).Any())
+		{
+			actor.OutputHandler.Send("You are already sustaining that power.");
+			return;
+		}
+
+		var (truth, missing) = CanAffordToInvokePower(actor, BeginVerb);
+		if (!truth)
+		{
+			actor.OutputHandler.Send($"You can't do that because you lack sufficient {missing.Name.Colour(Telnet.BoldMagenta)}.");
+			return;
+		}
+
+		if (CanInvokePowerProg.ExecuteBool(actor) == false)
+		{
+			actor.OutputHandler.Send(WhyCantInvokePowerProg.Execute(actor)?.ToString() ?? "You cannot use that power right now.");
+			return;
+		}
+
+		if (!HandleGeneralUseRestrictions(actor))
+		{
+			return;
+		}
+
+		var outcome = Gameworld.GetCheck(CheckType.MagicTelepathyCheck).Check(actor, SkillCheckDifficulty, SkillCheckTrait);
+		if (outcome < MinimumSuccessThreshold)
+		{
+			actor.OutputHandler.Send(new EmoteOutput(new Emote(FailEmote, actor, actor)));
+			return;
+		}
+
+		actor.AddEffect(CreateEffect(actor), GetDuration(outcome.SuccessDegrees()));
+		actor.OutputHandler.Send(new EmoteOutput(new Emote(BeginEmote, actor, actor)));
+		ConsumePowerCosts(actor, BeginVerb);
+	}
+
+	private void UseEnd(ICharacter actor)
+	{
+		var effect = ActiveEffects(actor).FirstOrDefault();
+		if (effect is null)
+		{
+			actor.OutputHandler.Send("You are not currently sustaining that power.");
+			return;
+		}
+
+		actor.RemoveEffect(effect, true);
+		actor.OutputHandler.Send(new EmoteOutput(new Emote(EndEmote, actor, actor)));
+		ConsumePowerCosts(actor, EndVerb);
+	}
+
+	protected override void ExpireSustainedEffect(ICharacter actor)
+	{
+		foreach (var effect in ActiveEffects(actor).ToList())
+		{
+			actor.RemoveEffect(effect, true);
+		}
+	}
+
+	protected abstract IEffect CreateEffect(ICharacter actor);
+	protected abstract IEnumerable<IEffect> ActiveEffects(ICharacter actor);
+
+	protected override void ShowSubtype(ICharacter actor, StringBuilder sb)
+	{
+		sb.AppendLine($"Begin Verb: {BeginVerb.ColourCommand()}");
+		sb.AppendLine($"End Verb: {EndVerb.ColourCommand()}");
+		sb.AppendLine($"Skill Check Trait: {SkillCheckTrait.Name.ColourValue()}");
+		sb.AppendLine($"Skill Check Difficulty: {SkillCheckDifficulty.DescribeColoured()}");
+		sb.AppendLine($"Minimum Success Threshold: {MinimumSuccessThreshold.DescribeColour()}");
+		sb.AppendLine($"Begin Emote: {BeginEmote.ColourCommand()}");
+		sb.AppendLine($"End Emote: {EndEmote.ColourCommand()}");
+		sb.AppendLine($"Fail Emote: {FailEmote.ColourCommand()}");
+		ShowSubtypeDetails(actor, sb);
+	}
+
+	protected virtual void ShowSubtypeDetails(ICharacter actor, StringBuilder sb)
+	{
+	}
+
+	protected override string SubtypeHelpText => @"	#3begin <verb>#0 - sets the activation verb
+	#3end <verb>#0 - sets the ending verb
+	#3skill <which>#0 - sets the skill used in the skill check
+	#3difficulty <difficulty>#0 - sets the skill check difficulty
+	#3threshold <outcome>#0 - sets the minimum success threshold
+	#3beginemote <emote>#0 - sets the activation emote
+	#3endemote <emote>#0 - sets the ending emote
+	#3failemote <emote>#0 - sets the failure emote";
+
+	public override bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "begin":
+			case "beginverb":
+				return BuildingCommandBegin(actor, command);
+			case "end":
+			case "endverb":
+				return BuildingCommandEnd(actor, command);
+			case "skill":
+			case "trait":
+				return BuildingCommandSkill(actor, command);
+			case "difficulty":
+				return BuildingCommandDifficulty(actor, command);
+			case "threshold":
+				return BuildingCommandThreshold(actor, command);
+			case "beginemote":
+				return BuildingCommandEmote(actor, command, "begin");
+			case "endemote":
+				return BuildingCommandEmote(actor, command, "end");
+			case "failemote":
+				return BuildingCommandEmote(actor, command, "fail");
+		}
+
+		return base.BuildingCommand(actor, command.GetUndo());
+	}
+
+	private bool BuildingCommandBegin(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which verb should activate this power?");
+			return false;
+		}
+
+		var verb = command.SafeRemainingArgument.ToLowerInvariant();
+		if (verb.EqualTo(EndVerb))
+		{
+			actor.OutputHandler.Send("The begin and end verbs cannot match.");
+			return false;
+		}
+
+		var costs = InvocationCosts[BeginVerb].ToList();
+		InvocationCosts[verb] = costs;
+		InvocationCosts.Remove(BeginVerb);
+		BeginVerb = verb;
+		Changed = true;
+		actor.OutputHandler.Send($"This power now begins with {BeginVerb.ColourCommand()}.");
+		return true;
+	}
+
+	private bool BuildingCommandEnd(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which verb should end this power?");
+			return false;
+		}
+
+		var verb = command.SafeRemainingArgument.ToLowerInvariant();
+		if (verb.EqualTo(BeginVerb))
+		{
+			actor.OutputHandler.Send("The begin and end verbs cannot match.");
+			return false;
+		}
+
+		var costs = InvocationCosts[EndVerb].ToList();
+		InvocationCosts[verb] = costs;
+		InvocationCosts.Remove(EndVerb);
+		EndVerb = verb;
+		Changed = true;
+		actor.OutputHandler.Send($"This power now ends with {EndVerb.ColourCommand()}.");
+		return true;
+	}
+
+	private bool BuildingCommandSkill(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which skill or trait should be used?");
+			return false;
+		}
+
+		var trait = Gameworld.Traits.GetByIdOrName(command.SafeRemainingArgument);
+		if (trait is null)
+		{
+			actor.OutputHandler.Send("That is not a valid skill or trait.");
+			return false;
+		}
+
+		SkillCheckTrait = trait;
+		Changed = true;
+		actor.OutputHandler.Send($"This power now checks {trait.Name.ColourName()}.");
+		return true;
+	}
+
+	private bool BuildingCommandDifficulty(ICharacter actor, StringStack command)
+	{
+		if (!command.SafeRemainingArgument.TryParseEnum(out Difficulty value))
+		{
+			actor.OutputHandler.Send($"Valid difficulties are {Enum.GetValues<Difficulty>().Select(x => x.DescribeColoured()).ListToString()}.");
+			return false;
+		}
+
+		SkillCheckDifficulty = value;
+		Changed = true;
+		actor.OutputHandler.Send($"This power now checks at {value.DescribeColoured()}.");
+		return true;
+	}
+
+	private bool BuildingCommandThreshold(ICharacter actor, StringStack command)
+	{
+		if (!command.SafeRemainingArgument.TryParseEnum(out Outcome value))
+		{
+			actor.OutputHandler.Send($"That is not a valid outcome. See {"show outcomes".MXPSend("show outcomes")}.");
+			return false;
+		}
+
+		MinimumSuccessThreshold = value;
+		Changed = true;
+		actor.OutputHandler.Send($"This power now requires at least {value.DescribeColour()}.");
+		return true;
+	}
+
+	private bool BuildingCommandEmote(ICharacter actor, StringStack command, string which)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("What emote should be used?");
+			return false;
+		}
+
+		var emote = new Emote(command.SafeRemainingArgument, new DummyPerceiver(), new DummyPerceivable());
+		if (!emote.Valid)
+		{
+			actor.OutputHandler.Send(emote.ErrorMessage);
+			return false;
+		}
+
+		switch (which)
+		{
+			case "begin":
+				BeginEmote = command.SafeRemainingArgument;
+				break;
+			case "end":
+				EndEmote = command.SafeRemainingArgument;
+				break;
+			case "fail":
+				FailEmote = command.SafeRemainingArgument;
+				break;
+		}
+
+		Changed = true;
+		actor.OutputHandler.Send($"The {which} emote is now {command.SafeRemainingArgument.ColourCommand()}.");
+		return true;
+	}
+}
+

--- a/MudSharpCore/Magic/Powers/PsionicTargetedPowerBase.cs
+++ b/MudSharpCore/Magic/Powers/PsionicTargetedPowerBase.cs
@@ -1,0 +1,334 @@
+#nullable enable
+
+using MudSharp.Body.Needs;
+using MudSharp.Body.Traits;
+using MudSharp.Character;
+using MudSharp.Effects;
+using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.Models;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Outputs;
+using MudSharp.PerceptionEngine.Parsers;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+namespace MudSharp.Magic.Powers;
+
+public abstract class PsionicTargetedPowerBase : MagicPowerBase
+{
+	protected PsionicTargetedPowerBase(MagicPower power, IFuturemud gameworld) : base(power, gameworld)
+	{
+		var root = XElement.Parse(power.Definition);
+		Verb = root.Element("Verb")?.Value ?? throw new ApplicationException($"Missing Verb in power {Id} ({Name}).");
+		PowerDistance = Enum.Parse<MagicPowerDistance>(root.Element("PowerDistance")?.Value ?? nameof(MagicPowerDistance.AnyConnectedMindOrConnectedTo), true);
+		SkillCheckDifficulty = (Difficulty)int.Parse(root.Element("SkillCheckDifficulty")?.Value ?? ((int)Difficulty.Normal).ToString());
+		MinimumSuccessThreshold = (Outcome)int.Parse(root.Element("MinimumSuccessThreshold")?.Value ?? ((int)Outcome.MinorPass).ToString());
+		SkillCheckTrait = Gameworld.Traits.Get(long.Parse(root.Element("SkillCheckTrait")?.Value ?? "0")) ??
+		                  throw new ApplicationException($"Invalid SkillCheckTrait in power {Id} ({Name}).");
+		FailEcho = root.Element("FailEcho")?.Value ?? "You cannot quite force the thought into shape.";
+		SuccessEcho = root.Element("SuccessEcho")?.Value ?? string.Empty;
+		DetectableWithDetectMagic = (Difficulty)int.Parse(root.Element("DetectableWithDetectMagic")?.Value ?? ((int)Difficulty.Normal).ToString());
+	}
+
+	protected PsionicTargetedPowerBase(IFuturemud gameworld, IMagicSchool school, string name, ITraitDefinition trait) :
+		base(gameworld, school, name)
+	{
+		IsPsionic = true;
+		Verb = DefaultVerb;
+		PowerDistance = MagicPowerDistance.AnyConnectedMindOrConnectedTo;
+		SkillCheckTrait = trait;
+		SkillCheckDifficulty = Difficulty.Normal;
+		MinimumSuccessThreshold = Outcome.MinorPass;
+		FailEcho = "You cannot quite force the thought into shape.";
+		SuccessEcho = string.Empty;
+		DetectableWithDetectMagic = Difficulty.Normal;
+	}
+
+	protected abstract string DefaultVerb { get; }
+	public string Verb { get; protected set; }
+	public MagicPowerDistance PowerDistance { get; protected set; }
+	public Difficulty SkillCheckDifficulty { get; protected set; }
+	public ITraitDefinition SkillCheckTrait { get; protected set; }
+	public Outcome MinimumSuccessThreshold { get; protected set; }
+	public string FailEcho { get; protected set; }
+	public string SuccessEcho { get; protected set; }
+	public Difficulty DetectableWithDetectMagic { get; protected set; }
+	public override IEnumerable<string> Verbs => [Verb];
+
+	protected XElement SaveTargetedDefinition(params object[] additional)
+	{
+		var definition = new XElement("Definition",
+			new XElement("Verb", Verb),
+			new XElement("PowerDistance", PowerDistance),
+			new XElement("SkillCheckDifficulty", (int)SkillCheckDifficulty),
+			new XElement("SkillCheckTrait", SkillCheckTrait.Id),
+			new XElement("MinimumSuccessThreshold", (int)MinimumSuccessThreshold),
+			new XElement("DetectableWithDetectMagic", (int)DetectableWithDetectMagic),
+			new XElement("FailEcho", new XCData(FailEcho)),
+			new XElement("SuccessEcho", new XCData(SuccessEcho))
+		);
+		foreach (var item in additional)
+		{
+			definition.Add(item);
+		}
+
+		AddBaseDefinition(definition);
+		return definition;
+	}
+
+	protected bool TryPrepareTarget(ICharacter actor, StringStack command, string missingTargetEcho,
+		out ICharacter? target)
+	{
+		target = null;
+		var (truth, missing) = CanAffordToInvokePower(actor, Verb);
+		if (!truth)
+		{
+			actor.OutputHandler.Send($"You can't do that because you lack sufficient {missing.Name.Colour(Telnet.BoldMagenta)}.");
+			return false;
+		}
+
+		if (!HandleGeneralUseRestrictions(actor))
+		{
+			return false;
+		}
+
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send(missingTargetEcho);
+			return false;
+		}
+
+		var targetText = command.PopSpeech();
+		target = targetText.EqualToAny("me", "self")
+			? actor
+			: AcquireTarget(actor, targetText, PowerDistance);
+		if (target is null)
+		{
+			actor.OutputHandler.Send("You cannot find any eligible mind by that description.");
+			return false;
+		}
+
+		if (CanInvokePowerProg.ExecuteBool(actor, target) == false)
+		{
+			actor.OutputHandler.Send(WhyCantInvokePowerProg.Execute(actor, target)?.ToString() ??
+			                         $"You cannot use that power on {target.HowSeen(actor)}.");
+			return false;
+		}
+
+		return true;
+	}
+
+	protected CheckOutcome CheckPower(ICharacter actor, ICharacter target, CheckType type)
+	{
+		return Gameworld.GetCheck(type).Check(actor, SkillCheckDifficulty, SkillCheckTrait, target);
+	}
+
+	protected void SendFailure(ICharacter actor, ICharacter target)
+	{
+		actor.OutputHandler.Send(new EmoteOutput(new Emote(FailEcho, actor, actor, target)));
+	}
+
+	public bool TargetFilter(ICharacter owner, ICharacter target)
+	{
+		return TargetIsValid(owner, target);
+	}
+
+	protected override void ShowSubtype(ICharacter actor, StringBuilder sb)
+	{
+		sb.AppendLine($"Verb: {Verb.ColourCommand()}");
+		sb.AppendLine($"Skill Check Trait: {SkillCheckTrait.Name.ColourValue()}");
+		sb.AppendLine($"Skill Check Difficulty: {SkillCheckDifficulty.DescribeColoured()}");
+		sb.AppendLine($"Minimum Success Threshold: {MinimumSuccessThreshold.DescribeColour()}");
+		sb.AppendLine($"Power Distance: {PowerDistance.DescribeEnum().ColourValue()}");
+		sb.AppendLine($"Detect Difficulty: {DetectableWithDetectMagic.Describe().ColourValue()}");
+		sb.AppendLine($"Fail Echo: {FailEcho.ColourCommand()}");
+		sb.AppendLine($"Success Echo: {(string.IsNullOrWhiteSpace(SuccessEcho) ? "None".ColourError() : SuccessEcho.ColourCommand())}");
+		ShowSubtypeDetails(actor, sb);
+	}
+
+	protected virtual void ShowSubtypeDetails(ICharacter actor, StringBuilder sb)
+	{
+	}
+
+	protected override string SubtypeHelpText => @"	#3verb <verb>#0 - sets the command verb
+	#3skill <which>#0 - sets the skill used in the skill check
+	#3difficulty <difficulty>#0 - sets the skill check difficulty
+	#3threshold <outcome>#0 - sets the minimum success threshold
+	#3distance <distance>#0 - sets the target distance policy
+	#3detect <difficulty>#0 - sets how hard this power's effects are to detect
+	#3failecho <emote>#0 - sets the failure echo
+	#3successecho <emote|none>#0 - sets an optional success echo";
+
+	public override bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "verb":
+				return BuildingCommandVerb(actor, command);
+			case "skill":
+			case "trait":
+				return BuildingCommandSkill(actor, command);
+			case "difficulty":
+				return BuildingCommandDifficulty(actor, command);
+			case "threshold":
+				return BuildingCommandThreshold(actor, command);
+			case "distance":
+				return BuildingCommandDistance(actor, command);
+			case "detect":
+				return BuildingCommandDetect(actor, command);
+			case "failecho":
+				return BuildingCommandFailEcho(actor, command);
+			case "successecho":
+				return BuildingCommandSuccessEcho(actor, command);
+		}
+
+		return base.BuildingCommand(actor, command.GetUndo());
+	}
+
+	private bool BuildingCommandVerb(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which verb should activate this power?");
+			return false;
+		}
+
+		var verb = command.SafeRemainingArgument.ToLowerInvariant();
+		var costs = InvocationCosts[Verb].ToList();
+		InvocationCosts[verb] = costs;
+		InvocationCosts.Remove(Verb);
+		Verb = verb;
+		Changed = true;
+		actor.OutputHandler.Send($"This power now uses the verb {Verb.ColourCommand()}.");
+		return true;
+	}
+
+	private bool BuildingCommandSkill(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which skill or trait should be used?");
+			return false;
+		}
+
+		var trait = Gameworld.Traits.GetByIdOrName(command.SafeRemainingArgument);
+		if (trait is null)
+		{
+			actor.OutputHandler.Send("That is not a valid skill or trait.");
+			return false;
+		}
+
+		SkillCheckTrait = trait;
+		Changed = true;
+		actor.OutputHandler.Send($"This power now checks {trait.Name.ColourName()}.");
+		return true;
+	}
+
+	private bool BuildingCommandDifficulty(ICharacter actor, StringStack command)
+	{
+		if (!command.SafeRemainingArgument.TryParseEnum(out Difficulty value))
+		{
+			actor.OutputHandler.Send($"Valid difficulties are {Enum.GetValues<Difficulty>().Select(x => x.DescribeColoured()).ListToString()}.");
+			return false;
+		}
+
+		SkillCheckDifficulty = value;
+		Changed = true;
+		actor.OutputHandler.Send($"This power now checks at {value.DescribeColoured()}.");
+		return true;
+	}
+
+	private bool BuildingCommandThreshold(ICharacter actor, StringStack command)
+	{
+		if (!command.SafeRemainingArgument.TryParseEnum(out Outcome value))
+		{
+			actor.OutputHandler.Send($"That is not a valid outcome. See {"show outcomes".MXPSend("show outcomes")}.");
+			return false;
+		}
+
+		MinimumSuccessThreshold = value;
+		Changed = true;
+		actor.OutputHandler.Send($"This power now requires at least {value.DescribeColour()}.");
+		return true;
+	}
+
+	private bool BuildingCommandDistance(ICharacter actor, StringStack command)
+	{
+		if (!command.SafeRemainingArgument.TryParseEnum(out MagicPowerDistance value))
+		{
+			actor.OutputHandler.Send($"Valid distances are {Enum.GetValues<MagicPowerDistance>().Select(x => x.DescribeEnum().ColourValue()).ListToString()}.");
+			return false;
+		}
+
+		PowerDistance = value;
+		Changed = true;
+		actor.OutputHandler.Send($"This power can now target {value.LongDescription().ColourValue()}.");
+		return true;
+	}
+
+	private bool BuildingCommandDetect(ICharacter actor, StringStack command)
+	{
+		if (!command.SafeRemainingArgument.TryParseEnum(out Difficulty value))
+		{
+			actor.OutputHandler.Send($"Valid difficulties are {Enum.GetValues<Difficulty>().Select(x => x.DescribeColoured()).ListToString()}.");
+			return false;
+		}
+
+		DetectableWithDetectMagic = value;
+		Changed = true;
+		actor.OutputHandler.Send($"Effects from this power are now detected at {value.DescribeColoured()}.");
+		return true;
+	}
+
+	private bool BuildingCommandFailEcho(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("What emote should be shown on failure?");
+			return false;
+		}
+
+		var emote = new Emote(command.SafeRemainingArgument, new DummyPerceiver(), new DummyPerceivable(), new DummyPerceivable());
+		if (!emote.Valid)
+		{
+			actor.OutputHandler.Send(emote.ErrorMessage);
+			return false;
+		}
+
+		FailEcho = command.SafeRemainingArgument;
+		Changed = true;
+		actor.OutputHandler.Send($"The failure echo is now {FailEcho.ColourCommand()}.");
+		return true;
+	}
+
+	private bool BuildingCommandSuccessEcho(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || command.SafeRemainingArgument.EqualToAny("none", "clear", "delete"))
+		{
+			SuccessEcho = string.Empty;
+			Changed = true;
+			actor.OutputHandler.Send("This power no longer has a success echo.");
+			return true;
+		}
+
+		var emote = new Emote(command.SafeRemainingArgument, new DummyPerceiver(), new DummyPerceivable(), new DummyPerceivable());
+		if (!emote.Valid)
+		{
+			actor.OutputHandler.Send(emote.ErrorMessage);
+			return false;
+		}
+
+		SuccessEcho = command.SafeRemainingArgument;
+		Changed = true;
+		actor.OutputHandler.Send($"The success echo is now {SuccessEcho.ColourCommand()}.");
+		return true;
+	}
+}
+

--- a/MudSharpCore/Magic/Powers/PsionicV4PowerBuilderHelpers.cs
+++ b/MudSharpCore/Magic/Powers/PsionicV4PowerBuilderHelpers.cs
@@ -1,0 +1,44 @@
+#nullable enable
+
+using MudSharp.Body.Needs;
+using MudSharp.Body.Traits;
+using MudSharp.Character;
+using MudSharp.Effects;
+using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.Models;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Outputs;
+using MudSharp.PerceptionEngine.Parsers;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+namespace MudSharp.Magic.Powers;
+
+internal static class PsionicV4PowerBuilderHelpers
+{
+	public static IMagicPower? BuildWithSkill(IFuturemud gameworld, IMagicSchool school, string name, ICharacter actor,
+		StringStack command, Func<ITraitDefinition, IMagicPower> builder)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which skill do you want to use for the skill check?");
+			return null;
+		}
+
+		var skill = gameworld.Traits.GetByIdOrName(command.SafeRemainingArgument);
+		if (skill is null)
+		{
+			actor.OutputHandler.Send("There is no such skill or attribute.");
+			return null;
+		}
+
+		return builder(skill);
+	}
+}

--- a/MudSharpCore/Magic/Powers/SuggestPower.cs
+++ b/MudSharpCore/Magic/Powers/SuggestPower.cs
@@ -1,0 +1,134 @@
+#nullable enable
+
+using MudSharp.Body.Needs;
+using MudSharp.Body.Traits;
+using MudSharp.Character;
+using MudSharp.Effects;
+using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.Models;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Outputs;
+using MudSharp.PerceptionEngine.Parsers;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+namespace MudSharp.Magic.Powers;
+
+public sealed class SuggestPower : PsionicTargetedPowerBase
+{
+	public override string PowerType => "Suggest";
+	public override string DatabaseType => "suggest";
+	protected override string DefaultVerb => "suggest";
+
+	public static void RegisterLoader()
+	{
+		MagicPowerFactory.RegisterLoader("suggest", (power, gameworld) => new SuggestPower(power, gameworld));
+		MagicPowerFactory.RegisterBuilderLoader("suggest", BuilderLoader);
+	}
+
+	private static IMagicPower? BuilderLoader(IFuturemud gameworld, IMagicSchool school, string name, ICharacter actor,
+		StringStack command)
+	{
+		return PsionicV4PowerBuilderHelpers.BuildWithSkill(gameworld, school, name, actor, command,
+			trait => new SuggestPower(gameworld, school, name, trait));
+	}
+
+	private SuggestPower(IFuturemud gameworld, IMagicSchool school, string name, ITraitDefinition trait) : base(gameworld, school, name, trait)
+	{
+		Blurb = "Inject an involuntary thought into a target mind";
+		_showHelpText = $"Use {school.SchoolVerb.ToUpperInvariant()} SUGGEST <target> [<emotion wrapper>] <thought> to put a thought into a mind.";
+		FailEcho = "You reach for $1's thoughts, but cannot plant your suggestion.";
+		DoDatabaseInsert();
+	}
+
+	private SuggestPower(MagicPower power, IFuturemud gameworld) : base(power, gameworld)
+	{
+	}
+
+	protected override XElement SaveDefinition()
+	{
+		return SaveTargetedDefinition();
+	}
+
+	public override void UseCommand(ICharacter actor, string verb, StringStack command)
+	{
+		if (!TryPrepareTarget(actor, command, "Whose mind do you want to suggest a thought to?", out var target) || target is null)
+		{
+			return;
+		}
+
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("What thought do you want to suggest?");
+			return;
+		}
+
+		if (!PsionicTrafficHelper.CanReceiveInvoluntaryMentalTraffic(target))
+		{
+			actor.OutputHandler.Send($"{target.HowSeen(actor, true)} refuses involuntary mental traffic.");
+			return;
+		}
+
+		var (emotion, thought) = ParseEmotionWrapper(command.SafeRemainingArgument);
+		if (string.IsNullOrWhiteSpace(thought))
+		{
+			actor.OutputHandler.Send("What thought do you want to suggest?");
+			return;
+		}
+
+		var outcome = CheckPower(actor, target, CheckType.MindSayPower);
+		if (outcome < MinimumSuccessThreshold)
+		{
+			SendFailure(actor, target);
+			return;
+		}
+
+		if (!string.IsNullOrWhiteSpace(emotion))
+		{
+			var emotionOutcome = CheckPower(actor, target, CheckType.MindSayPower);
+			if (emotionOutcome >= MinimumSuccessThreshold)
+			{
+				PsionicTrafficHelper.DeliverEmotion(actor, target, School, emotion, notifySource: false);
+			}
+		}
+
+		PsionicTrafficHelper.DeliverThought(actor, target, School, thought);
+		ConsumePowerCosts(actor, Verb);
+	}
+
+	private static (string? Emotion, string Thought) ParseEmotionWrapper(string text)
+	{
+		var trimmed = text.Trim();
+		if (trimmed.Length < 3)
+		{
+			return (null, trimmed);
+		}
+
+		var pairs = new[] { ('(', ')'), ('[', ']'), ('*', '*'), ('-', '-') };
+		foreach (var (open, close) in pairs)
+		{
+			if (trimmed[0] != open)
+			{
+				continue;
+			}
+
+			var index = trimmed.IndexOf(close, 1);
+			if (index <= 1)
+			{
+				continue;
+			}
+
+			return (trimmed[1..index].Trim(), trimmed[(index + 1)..].Trim());
+		}
+
+		return (null, trimmed);
+	}
+}
+

--- a/MudSharpCore/Magic/Powers/SustainedMagicPower.cs
+++ b/MudSharpCore/Magic/Powers/SustainedMagicPower.cs
@@ -190,6 +190,7 @@ public abstract class SustainedMagicPower : MagicPowerBase
 	#3why <prog>#0 - sets a prog that controls an error message if prog can't be used
 	#3help#0 - drops you into an editor to write the player help file
 	#3cost <verb> <which> <number>#0 - sets the cost of using a particular verb
+	#3psionic#0 - toggles whether this power is psionic for crime and policy purposes
 	#3sustaincost <which> <number>#0 - sets the sustain cost per minute of the power
 	#3duration <expression>#0 - sets the duration the power will last
 	#3concentration <points>#0 - sets the number of concentration points this power occupies

--- a/MudSharpCore/Magic/Powers/TracePower.cs
+++ b/MudSharpCore/Magic/Powers/TracePower.cs
@@ -1,0 +1,117 @@
+#nullable enable
+
+using MudSharp.Body.Needs;
+using MudSharp.Body.Traits;
+using MudSharp.Character;
+using MudSharp.Effects;
+using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.Models;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Outputs;
+using MudSharp.PerceptionEngine.Parsers;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+namespace MudSharp.Magic.Powers;
+
+public sealed class TracePower : PsionicTargetedPowerBase
+{
+	public override string PowerType => "Trace";
+	public override string DatabaseType => "trace";
+	protected override string DefaultVerb => "trace";
+
+	public static void RegisterLoader()
+	{
+		MagicPowerFactory.RegisterLoader("trace", (power, gameworld) => new TracePower(power, gameworld));
+		MagicPowerFactory.RegisterBuilderLoader("trace", BuilderLoader);
+	}
+
+	private static IMagicPower? BuilderLoader(IFuturemud gameworld, IMagicSchool school, string name, ICharacter actor,
+		StringStack command)
+	{
+		return PsionicV4PowerBuilderHelpers.BuildWithSkill(gameworld, school, name, actor, command,
+			trait => new TracePower(gameworld, school, name, trait));
+	}
+
+	private TracePower(IFuturemud gameworld, IMagicSchool school, string name, ITraitDefinition trait) : base(gameworld, school, name, trait)
+	{
+		Blurb = "Inspect active mind links around a target";
+		_showHelpText = $"Use {school.SchoolVerb.ToUpperInvariant()} TRACE <target> to inspect active mental links around a mind.";
+		FailEcho = "You trace the surface of $1's mind, but the connections elude you.";
+		DoDatabaseInsert();
+	}
+
+	private TracePower(MagicPower power, IFuturemud gameworld) : base(power, gameworld)
+	{
+	}
+
+	protected override XElement SaveDefinition()
+	{
+		return SaveTargetedDefinition();
+	}
+
+	public override void UseCommand(ICharacter actor, string verb, StringStack command)
+	{
+		if (!TryPrepareTarget(actor, command, "Whose mind do you want to trace?", out var target) || target is null)
+		{
+			return;
+		}
+
+		var outcome = CheckPower(actor, target, CheckType.MagicTelepathyCheck);
+		if (outcome < MinimumSuccessThreshold)
+		{
+			SendFailure(actor, target);
+			return;
+		}
+
+		var results = Gameworld.GetCheck(CheckType.MagicTelepathyCheck)
+		                       .CheckAgainstAllDifficulties(actor, SkillCheckDifficulty, SkillCheckTrait, target);
+		var links = TraceLinks(target).DistinctBy(x => x.Character).ToList();
+		if (!links.Any())
+		{
+			actor.OutputHandler.Send($"{target.HowSeen(actor, true)} has no active mind links that you can detect.");
+			ConsumePowerCosts(actor, Verb);
+			return;
+		}
+
+		var sb = new StringBuilder();
+		sb.AppendLine($"You trace the active mind links around {target.HowSeen(actor, true)}:");
+		foreach (var link in links)
+		{
+			var concealment = link.Character.EffectsOfType<IMindContactConcealmentEffect>()
+			                      .FirstOrDefault(x => x.ConcealsIdentityFrom(link.Character, actor, School));
+			var difficulty = concealment is null
+				? SkillCheckDifficulty
+				: SkillCheckDifficulty.StageUp(concealment.AuditDifficultyStages);
+			var visible = results[difficulty] >= MinimumSuccessThreshold;
+			var description = visible
+				? link.Character.HowSeen(actor, flags: PerceiveIgnoreFlags.IgnoreConsciousness)
+				: concealment?.UnknownIdentityDescription.ColourCharacter() ?? "an unknown mind".ColourCharacter();
+			sb.AppendLine($"\t{link.Direction}: {description} [{link.School.Name.Colour(link.School.PowerListColour)}]");
+		}
+
+		actor.OutputHandler.Send(sb.ToString());
+		ConsumePowerCosts(actor, Verb);
+	}
+
+	private static IEnumerable<(ICharacter Character, string Direction, IMagicSchool School)> TraceLinks(ICharacter target)
+	{
+		foreach (var effect in target.EffectsOfType<ConnectMindEffect>())
+		{
+			yield return (effect.TargetCharacter, "outbound", effect.School);
+		}
+
+		foreach (var effect in target.EffectsOfType<MindConnectedToEffect>())
+		{
+			yield return (effect.OriginatorCharacter, "inbound", effect.School);
+		}
+	}
+}
+

--- a/MudSharpCore/Magic/PsionicTrafficHelper.cs
+++ b/MudSharpCore/Magic/PsionicTrafficHelper.cs
@@ -1,0 +1,125 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.PerceptionEngine;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MudSharp.Magic;
+
+public static class PsionicTrafficHelper
+{
+	private static readonly string[] BlockedCommandRoots =
+	[
+		"quit",
+		"suicide",
+		"password",
+		"passwd",
+		"account",
+		"delete",
+		"@",
+		"admin",
+		"staff",
+		"force",
+		"shutdown",
+		"reboot"
+	];
+
+	public static bool IsBlockedCommandRoot(string text)
+	{
+		var stack = new StringStack(text);
+		var root = stack.PopSpeech();
+		return !string.IsNullOrWhiteSpace(root) && BlockedCommandRoots.Any(x => x.EqualTo(root));
+	}
+
+	public static bool CanReceiveInvoluntaryMentalTraffic(ICharacter target)
+	{
+		return !target.AffectedBy<IIgnoreForceEffect>();
+	}
+
+	public static string SourceDescription(ICharacter source, ICharacter observer, IMagicSchool school)
+	{
+		var concealment = source.EffectsOfType<IMindContactConcealmentEffect>()
+		                        .FirstOrDefault(x => x.ConcealsIdentityFrom(source, observer, school));
+		return concealment?.UnknownIdentityDescription.ColourCharacter() ??
+		       source.HowSeen(observer, flags: PerceiveIgnoreFlags.IgnoreConsciousness);
+	}
+
+	public static void Audit(ICharacter source, ICharacter target, string action, string payload)
+	{
+		source.Gameworld.SystemMessage(
+			$"{source.PersonalName.GetName(MudSharp.Character.Name.NameStyle.SimpleFull)} psionically {action} {target.PersonalName.GetName(MudSharp.Character.Name.NameStyle.SimpleFull)}: {payload}",
+			true
+		);
+	}
+
+	public static void DeliverEmotion(ICharacter source, ICharacter target, IMagicSchool school, string emotion,
+		bool notifySource = true)
+	{
+		var cleanEmotion = emotion.Sanitise().NormaliseSpacing().Fullstop();
+		if (notifySource)
+		{
+			source.OutputHandler.Send(
+				$"You push a feeling into {target.HowSeen(source, flags: PerceiveIgnoreFlags.IgnoreConsciousness)}'s mind: {cleanEmotion.ColourCommand()}");
+		}
+
+		target.OutputHandler.Send(
+			$"A feeling that is not your own settles into your mind: {cleanEmotion.ColourCommand()}");
+		Audit(source, target, "projected emotion into", cleanEmotion.RawText());
+
+		foreach (var listener in GetMentalListeners(source, target, showFeels: true))
+		{
+			var thinkerDescription = ListenerDescription(target, listener, school, showFeels: true);
+			listener.OutputHandler.Send($"{thinkerDescription} feels {cleanEmotion}");
+		}
+	}
+
+	public static void DeliverThought(ICharacter source, ICharacter target, IMagicSchool school, string thought)
+	{
+		var cleanThought = thought.Sanitise().NormaliseSpacing().ProperSentences().Fullstop();
+		source.OutputHandler.Send(
+			$"You press a thought into {target.HowSeen(source, flags: PerceiveIgnoreFlags.IgnoreConsciousness)}'s mind:\n\t\"{cleanThought}\"");
+		target.OutputHandler.Send(
+			$"A thought that is not your own surfaces in your mind:\n\t\"{cleanThought}\"");
+		Audit(source, target, "suggested thought to", cleanThought.RawText());
+
+		foreach (var listener in GetMentalListeners(source, target, showThinks: true))
+		{
+			var thinkerDescription = ListenerDescription(target, listener, school, showThinks: true);
+			listener.OutputHandler.Send($"{thinkerDescription} thinks,\n\t\"{cleanThought}\"");
+		}
+	}
+
+	private static IEnumerable<ICharacter> GetMentalListeners(ICharacter source, ICharacter target, bool showThinks = false,
+		bool showFeels = false)
+	{
+		return source.Gameworld.Characters
+		             .Where(x => x != source && x != target)
+		             .Where(x => x.EffectsOfType<ITelepathyEffect>()
+		                          .Any(y => y.Applies(target) &&
+		                                    ((!showThinks || y.ShowThinks) && (!showFeels || y.ShowFeels))));
+	}
+
+	private static string ListenerDescription(ICharacter thinker, ICharacter listener, IMagicSchool school,
+		bool showThinks = false, bool showFeels = false)
+	{
+		var effects = listener.EffectsOfType<ITelepathyEffect>()
+		                      .Where(x => x.Applies(thinker) &&
+		                                  ((!showThinks || x.ShowThinks) && (!showFeels || x.ShowFeels)))
+		                      .ToList();
+		var concealment = thinker.EffectsOfType<IMindContactConcealmentEffect>()
+		                         .FirstOrDefault(x => effects.OfType<IMagicEffect>()
+		                                                    .Any(y => x.ConcealsIdentityFrom(thinker, listener, y.School)));
+		if (concealment is not null)
+		{
+			return concealment.UnknownIdentityDescription.ColourCharacter();
+		}
+
+		return effects.Any(x => x.ShowDescription(thinker))
+			? thinker.HowSeen(listener, true)
+			: "Someone";
+	}
+}

--- a/MudSharpCore/Magic/SpellEffects/DispelMagicEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/DispelMagicEffect.cs
@@ -44,6 +44,7 @@ public class DispelMagicEffect : IMagicSpellEffectTemplate
 			{ "planarstate", x => x is SpellPlanarStateEffect },
 			{ "roomward", x => x is SpellRoomWardEffect },
 			{ "personalward", x => x is SpellPersonalWardEffect },
+			{ "tagward", x => x is SpellRoomTagWardEffect or SpellPersonalTagWardEffect },
 			{ "exitbarrier", x => x is SpellExitBarrierEffect },
 			{ "subjectivedesc", x => x is SpellSubjectiveDescriptionEffect },
 			{ "transformform", x => x is SpellTransformFormEffect },
@@ -82,6 +83,7 @@ public class DispelMagicEffect : IMagicSpellEffectTemplate
 			new XElement("TagValue", new XCData(string.Empty)),
 			new XElement("MatchTagValue", false),
 			new XElement("EffectKey", new XCData("any")),
+			new XElement("IllusionKey", new XCData(string.Empty)),
 			new XElement("Contest", false),
 			new XElement("ContestBonus", 0)
 		), spell), string.Empty);
@@ -101,6 +103,7 @@ public class DispelMagicEffect : IMagicSpellEffectTemplate
 		TagValue = root.Element("TagValue")?.Value ?? string.Empty;
 		MatchTagValue = bool.Parse(root.Element("MatchTagValue")?.Value ?? "false");
 		EffectKey = root.Element("EffectKey")?.Value ?? "any";
+		IllusionKey = root.Element("IllusionKey")?.Value ?? string.Empty;
 		Contest = bool.Parse(root.Element("Contest")?.Value ?? "false");
 		ContestBonus = int.Parse(root.Element("ContestBonus")?.Value ?? "0");
 	}
@@ -118,6 +121,7 @@ public class DispelMagicEffect : IMagicSpellEffectTemplate
 	public string TagValue { get; private set; }
 	public bool MatchTagValue { get; private set; }
 	public string EffectKey { get; private set; }
+	public string IllusionKey { get; private set; }
 	public bool Contest { get; private set; }
 	public int ContestBonus { get; private set; }
 	public bool IsInstantaneous => true;
@@ -138,6 +142,7 @@ public class DispelMagicEffect : IMagicSpellEffectTemplate
 			new XElement("TagValue", new XCData(TagValue)),
 			new XElement("MatchTagValue", MatchTagValue),
 			new XElement("EffectKey", new XCData(EffectKey)),
+			new XElement("IllusionKey", new XCData(IllusionKey)),
 			new XElement("Contest", Contest),
 			new XElement("ContestBonus", ContestBonus)
 		);
@@ -223,6 +228,13 @@ public class DispelMagicEffect : IMagicSpellEffectTemplate
 			}
 		}
 
+		if (!string.IsNullOrWhiteSpace(IllusionKey) &&
+		    !parent.SpellEffects.OfType<IPrioritisedOverrideDescEffect>()
+		           .Any(x => x.OverrideKey.EqualTo(IllusionKey)))
+		{
+			return false;
+		}
+
 		return true;
 	}
 
@@ -281,7 +293,8 @@ public class DispelMagicEffect : IMagicSpellEffectTemplate
 	#3school <id|name|none>#0 - restricts matching to a magic school
 	#3tag <tag> [value]#0 - restricts matching to a magic tag, optionally including value
 	#3tag none#0 - clears tag matching
-	#3effect <key>#0 - restricts matching to an approved key: any, spell, invisibility, flight, levitation, featherfall, magictag, itemenchant, portal, planarstate, roomward, personalward, exitbarrier, subjectivedesc, transformform, projectile, crafttool, powerfuel, itemevent
+	#3effect <key>#0 - restricts matching to an approved key: any, spell, invisibility, flight, levitation, featherfall, magictag, itemenchant, portal, planarstate, roomward, personalward, tagward, exitbarrier, subjectivedesc, transformform, projectile, crafttool, powerfuel, itemevent
+	#3illusion <key|none>#0 - restricts matching to a subjective illusion key
 	#3contest#0 - toggles strength-contested dispel matching
 	#3bonus <amount>#0 - sets the flat strength bonus or penalty for contested dispels";
 
@@ -315,6 +328,9 @@ public class DispelMagicEffect : IMagicSpellEffectTemplate
 			case "effect":
 			case "key":
 				return BuildingCommandEffect(actor, command);
+			case "illusion":
+			case "illusionkey":
+				return BuildingCommandIllusionKey(actor, command);
 			case "contest":
 				Contest = !Contest;
 				Spell.Changed = true;
@@ -339,6 +355,22 @@ public class DispelMagicEffect : IMagicSpellEffectTemplate
 		Mode = value;
 		Spell.Changed = true;
 		actor.OutputHandler.Send($"This dispel now uses {value.DescribeEnum().ColourValue()} mode.");
+		return true;
+	}
+
+	private bool BuildingCommandIllusionKey(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which subjective illusion key should this dispel match? Use none to clear it.");
+			return false;
+		}
+
+		IllusionKey = command.SafeRemainingArgument.EqualTo("none") ? string.Empty : command.SafeRemainingArgument;
+		Spell.Changed = true;
+		actor.OutputHandler.Send(string.IsNullOrWhiteSpace(IllusionKey)
+			? "This dispel no longer restricts by subjective illusion key."
+			: $"This dispel will only match subjective illusions keyed {IllusionKey.ColourValue()}.");
 		return true;
 	}
 

--- a/MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs
+++ b/MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs
@@ -28,7 +28,7 @@ using System.Xml.Linq;
 
 namespace MudSharp.Magic.SpellEffects;
 
-public class MagicTagEffect : IMagicSpellEffectTemplate
+public class MagicTagEffect : IMagicSpellEffectTemplate, IMagicInterdictionTagProvider
 {
 	public static void RegisterFactory()
 	{
@@ -67,6 +67,13 @@ public class MagicTagEffect : IMagicSpellEffectTemplate
 	public string Tag { get; private set; }
 	public string Value { get; private set; }
 	public bool ReplaceExisting { get; private set; }
+	public IEnumerable<MagicInterdictionTag> MagicInterdictionTags
+	{
+		get
+		{
+			yield return new MagicInterdictionTag(Tag, Value);
+		}
+	}
 
 	public virtual XElement SaveToXml()
 	{
@@ -1627,7 +1634,9 @@ public class SubjectiveDescriptionEffect : IMagicSpellEffectTemplate
 			new XAttribute("type", effectType),
 			new XElement("Description", new XCData(type == DescriptionType.Short ? "someone altered by magic" : "They appear different through magic.")),
 			new XElement("FixedViewer", true),
-			new XElement("ApplicabilityProg", 0)
+			new XElement("ApplicabilityProg", 0),
+			new XElement("Priority", 0),
+			new XElement("OverrideKey", new XCData(string.Empty))
 		), spell, type), string.Empty);
 	}
 
@@ -1639,6 +1648,8 @@ public class SubjectiveDescriptionEffect : IMagicSpellEffectTemplate
 		Description = root.Element("Description")?.Value ?? string.Empty;
 		FixedViewer = bool.Parse(root.Element("FixedViewer")?.Value ?? "true");
 		ApplicabilityProg = Gameworld.FutureProgs.Get(long.Parse(root.Element("ApplicabilityProg")?.Value ?? "0"));
+		Priority = int.Parse(root.Element("Priority")?.Value ?? "0");
+		OverrideKey = root.Element("OverrideKey")?.Value ?? string.Empty;
 	}
 
 	public IMagicSpell Spell { get; }
@@ -1648,6 +1659,8 @@ public class SubjectiveDescriptionEffect : IMagicSpellEffectTemplate
 	public string Description { get; private set; }
 	public bool FixedViewer { get; private set; }
 	public IFutureProg? ApplicabilityProg { get; private set; }
+	public int Priority { get; private set; }
+	public string OverrideKey { get; private set; }
 
 	public XElement SaveToXml()
 	{
@@ -1655,7 +1668,9 @@ public class SubjectiveDescriptionEffect : IMagicSpellEffectTemplate
 			new XAttribute("type", EffectType),
 			new XElement("Description", new XCData(Description)),
 			new XElement("FixedViewer", FixedViewer),
-			new XElement("ApplicabilityProg", ApplicabilityProg?.Id ?? 0)
+			new XElement("ApplicabilityProg", ApplicabilityProg?.Id ?? 0),
+			new XElement("Priority", Priority),
+			new XElement("OverrideKey", new XCData(OverrideKey))
 		);
 	}
 
@@ -1668,7 +1683,7 @@ public class SubjectiveDescriptionEffect : IMagicSpellEffectTemplate
 	{
 		return target is not null
 			? new SpellSubjectiveDescriptionEffect(target, parent, DescriptionType, Description,
-				FixedViewer ? caster.Id : 0, ApplicabilityProg)
+				FixedViewer ? caster.Id : 0, ApplicabilityProg, Priority, OverrideKey)
 			: null;
 	}
 
@@ -1678,7 +1693,9 @@ public class SubjectiveDescriptionEffect : IMagicSpellEffectTemplate
 
 	#3description <text>#0 - sets the replacement description
 	#3fixedviewer#0 - toggles whether only the caster sees it
-	#3prog <prog|none>#0 - gates whether the override applies";
+	#3prog <prog|none>#0 - gates whether the override applies
+	#3priority <number>#0 - sets override priority; higher priorities win
+	#3key <text|none>#0 - sets an optional illusion/dispel key";
 
 	public bool BuildingCommand(ICharacter actor, StringStack command)
 	{
@@ -1691,6 +1708,21 @@ public class SubjectiveDescriptionEffect : IMagicSpellEffectTemplate
 				break;
 			case "fixedviewer":
 				FixedViewer = !FixedViewer;
+				break;
+			case "priority":
+				if (!int.TryParse(command.SafeRemainingArgument, out var value))
+				{
+					actor.OutputHandler.Send("You must enter a valid whole number priority.");
+					return false;
+				}
+
+				Priority = value;
+				break;
+			case "key":
+			case "illusionkey":
+				OverrideKey = command.SafeRemainingArgument.EqualTo("none")
+					? string.Empty
+					: command.SafeRemainingArgument;
 				break;
 			case "prog":
 				if (command.SafeRemainingArgument.EqualTo("none"))
@@ -1723,6 +1755,6 @@ public class SubjectiveDescriptionEffect : IMagicSpellEffectTemplate
 
 	public string Show(ICharacter actor)
 	{
-		return $"{EffectType} - Fixed Viewer: {FixedViewer.ToColouredString()} - {Description.ColourValue()}";
+		return $"{EffectType} - Fixed Viewer: {FixedViewer.ToColouredString()} - Priority: {Priority.ToString("N0", actor).ColourValue()} - Key: {(string.IsNullOrWhiteSpace(OverrideKey) ? "none".ColourError() : OverrideKey.ColourValue())} - {Description.ColourValue()}";
 	}
 }

--- a/MudSharpCore/Magic/SpellEffects/TagWardSpellEffects.cs
+++ b/MudSharpCore/Magic/SpellEffects/TagWardSpellEffects.cs
@@ -1,0 +1,279 @@
+#nullable enable
+
+using System;
+using System.Linq;
+using System.Xml.Linq;
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Effects.Concrete.SpellEffects;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.RPG.Checks;
+
+namespace MudSharp.Magic.SpellEffects;
+
+public abstract class TagWardSpellEffectBase : IMagicSpellEffectTemplate
+{
+	protected TagWardSpellEffectBase(XElement root, IMagicSpell spell)
+	{
+		Spell = spell;
+		Tag = root.Element("Tag")?.Value ?? "magic";
+		Value = root.Element("Value")?.Value ?? string.Empty;
+		MatchValue = bool.Parse(root.Element("MatchValue")?.Value ?? "false");
+		Mode = Enum.Parse<MagicInterdictionMode>(root.Element("Mode")?.Value ?? nameof(MagicInterdictionMode.Fail), true);
+		Coverage = Enum.Parse<MagicInterdictionCoverage>(root.Element("Coverage")?.Value ?? nameof(MagicInterdictionCoverage.Both), true);
+		Prog = Gameworld.FutureProgs.Get(long.Parse(root.Element("Prog")?.Value ?? "0"));
+	}
+
+	public IMagicSpell Spell { get; }
+	public IFuturemud Gameworld => Spell.Gameworld;
+	public string Tag { get; private set; }
+	public string Value { get; private set; }
+	public bool MatchValue { get; private set; }
+	public MagicInterdictionMode Mode { get; private set; }
+	public MagicInterdictionCoverage Coverage { get; private set; }
+	public IFutureProg? Prog { get; private set; }
+	protected abstract string EffectType { get; }
+	protected abstract string EffectName { get; }
+	protected abstract string[] CompatibleTargetTypes { get; }
+
+	public XElement SaveToXml()
+	{
+		return new XElement("Effect",
+			new XAttribute("type", EffectType),
+			new XElement("Tag", new XCData(Tag)),
+			new XElement("Value", new XCData(Value)),
+			new XElement("MatchValue", MatchValue),
+			new XElement("Mode", Mode),
+			new XElement("Coverage", Coverage),
+			new XElement("Prog", Prog?.Id ?? 0L)
+		);
+	}
+
+	public bool IsInstantaneous => false;
+	public bool RequiresTarget => true;
+	public bool IsCompatibleWithTrigger(IMagicTrigger trigger) => CompatibleTargetTypes.Contains(trigger.TargetTypes);
+
+	public IMagicSpellEffect? GetOrApplyEffect(ICharacter caster, IPerceivable? target, OpposedOutcomeDegree outcome,
+		SpellPower power, IMagicSpellEffectParent parent, SpellAdditionalParameter[] additionalParameters)
+	{
+		return target is null ? null : CreateWardEffect(target, parent);
+	}
+
+	protected abstract IMagicSpellEffect? CreateWardEffect(IPerceivable target, IMagicSpellEffectParent parent);
+	protected abstract IMagicSpellEffectTemplate CloneEffect(XElement root, IMagicSpell spell);
+
+	public IMagicSpellEffectTemplate Clone() => CloneEffect(SaveToXml(), Spell);
+
+	public string Show(ICharacter actor)
+	{
+		return
+			$"{EffectName.ColourName()} - {Tag.ColourValue()}{(MatchValue ? $"={Value.ColourValue()}" : "")} - {Coverage.DescribeEnum().ColourValue()} - {Mode.DescribeEnum().ColourValue()} - Prog: {Prog?.MXPClickableFunctionName() ?? "None".ColourError()}";
+	}
+
+	public bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopSpeech().ToLowerInvariant())
+		{
+			case "tag":
+			case "key":
+				if (command.IsFinished)
+				{
+					actor.OutputHandler.Send("Which magic tag should this ward interdict?");
+					return false;
+				}
+
+				Tag = command.PopSpeech();
+				if (!command.IsFinished)
+				{
+					Value = command.SafeRemainingArgument;
+					MatchValue = true;
+				}
+				Spell.Changed = true;
+				actor.OutputHandler.Send($"This ward now catches tag {Tag.ColourValue()}{(MatchValue ? $" with value {Value.ColourValue()}" : "")}.");
+				return true;
+			case "value":
+				if (command.IsFinished || command.SafeRemainingArgument.EqualTo("none"))
+				{
+					Value = string.Empty;
+					MatchValue = false;
+				}
+				else
+				{
+					Value = command.SafeRemainingArgument;
+					MatchValue = true;
+				}
+				Spell.Changed = true;
+				actor.OutputHandler.Send(MatchValue
+					? $"This ward now requires tag value {Value.ColourValue()}."
+					: "This ward now matches any value for its tag.");
+				return true;
+			case "mode":
+				if (!command.SafeRemainingArgument.TryParseEnum(out MagicInterdictionMode mode))
+				{
+					actor.OutputHandler.Send($"Valid modes are {Enum.GetValues<MagicInterdictionMode>().Select(x => x.DescribeEnum().ColourValue()).ListToString()}.");
+					return false;
+				}
+
+				Mode = mode;
+				Spell.Changed = true;
+				actor.OutputHandler.Send($"This ward will now {mode.DescribeEnum().ToLowerInvariant().ColourValue()} matching invocations.");
+				return true;
+			case "coverage":
+				if (!command.SafeRemainingArgument.TryParseEnum(out MagicInterdictionCoverage coverage))
+				{
+					actor.OutputHandler.Send($"Valid coverage values are {Enum.GetValues<MagicInterdictionCoverage>().Select(x => x.DescribeEnum().ColourValue()).ListToString()}.");
+					return false;
+				}
+
+				Coverage = coverage;
+				Spell.Changed = true;
+				actor.OutputHandler.Send($"This ward now applies to {coverage.DescribeEnum().ToLowerInvariant().ColourValue()} magic.");
+				return true;
+			case "prog":
+				return BuildingCommandProg(actor, command);
+		}
+
+		actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
+		return false;
+	}
+
+	private bool BuildingCommandProg(ICharacter actor, StringStack command)
+	{
+		if (command.SafeRemainingArgument.EqualToAny("none", "clear", "delete"))
+		{
+			Prog = null;
+			Spell.Changed = true;
+			actor.OutputHandler.Send("This ward no longer uses a custom prog.");
+			return true;
+		}
+
+		var prog = new ProgLookupFromBuilderInput(Gameworld, actor, command.SafeRemainingArgument,
+			ProgVariableTypes.Boolean,
+			[
+				[ProgVariableTypes.Character, ProgVariableTypes.Perceivable],
+				[ProgVariableTypes.Character, ProgVariableTypes.Perceivable, ProgVariableTypes.Text, ProgVariableTypes.Text]
+			]).LookupProg();
+		if (prog is null)
+		{
+			return false;
+		}
+
+		Prog = prog;
+		Spell.Changed = true;
+		actor.OutputHandler.Send($"This ward will now use {prog.MXPClickableFunctionName()} when deciding whether to interdict.");
+		return true;
+	}
+
+	public const string HelpText = @"You can use the following options with this effect:
+
+	#3tag <tag> [value]#0 - sets the magic tag and optional value to catch
+	#3value <value|none>#0 - sets or clears value matching
+	#3mode fail|reflect#0 - sets whether matching invocations fail or reflect
+	#3coverage incoming|outgoing|both#0 - sets whether the ward catches incoming, outgoing, or both
+	#3prog <prog>|none#0 - sets or clears an optional custom prog";
+}
+
+public sealed class RoomTagWardEffect : TagWardSpellEffectBase
+{
+	private static readonly string[] CompatibleTypes = ["room"];
+
+	public static void RegisterFactory()
+	{
+		SpellEffectFactory.RegisterLoadTimeFactory("roomtagward", (root, spell) => new RoomTagWardEffect(root, spell));
+		SpellEffectFactory.RegisterBuilderFactory("roomtagward", BuilderFactory,
+			"Applies a room ward that catches magic by magic tag",
+			HelpText,
+			false,
+			true,
+			SpellTriggerFactory.MagicTriggerTypes
+			                   .Where(x => CompatibleTypes.Contains(SpellTriggerFactory.BuilderInfoForType(x).TargetTypes))
+			                   .ToArray());
+	}
+
+	private static (IMagicSpellEffectTemplate Trigger, string Error) BuilderFactory(StringStack commands, IMagicSpell spell)
+	{
+		return (new RoomTagWardEffect(DefaultRoot("roomtagward"), spell), string.Empty);
+	}
+
+	private static XElement DefaultRoot(string type)
+	{
+		return new XElement("Effect",
+			new XAttribute("type", type),
+			new XElement("Tag", new XCData("magic")),
+			new XElement("Value", new XCData(string.Empty)),
+			new XElement("MatchValue", false),
+			new XElement("Mode", MagicInterdictionMode.Fail),
+			new XElement("Coverage", MagicInterdictionCoverage.Both),
+			new XElement("Prog", 0L)
+		);
+	}
+
+	private RoomTagWardEffect(XElement root, IMagicSpell spell) : base(root, spell)
+	{
+	}
+
+	protected override string EffectType => "roomtagward";
+	protected override string EffectName => "Room Tag Ward";
+	protected override string[] CompatibleTargetTypes => CompatibleTypes;
+
+	protected override IMagicSpellEffect? CreateWardEffect(IPerceivable target, IMagicSpellEffectParent parent)
+	{
+		return target is ICell ? new SpellRoomTagWardEffect(target, parent, Tag, Value, MatchValue, Mode, Coverage, Prog) : null;
+	}
+
+	protected override IMagicSpellEffectTemplate CloneEffect(XElement root, IMagicSpell spell)
+	{
+		return new RoomTagWardEffect(root, spell);
+	}
+}
+
+public sealed class PersonalTagWardEffect : TagWardSpellEffectBase
+{
+	private static readonly string[] CompatibleTypes = ["character", "characters", "character&room", "character&exit"];
+
+	public static void RegisterFactory()
+	{
+		SpellEffectFactory.RegisterLoadTimeFactory("personaltagward", (root, spell) => new PersonalTagWardEffect(root, spell));
+		SpellEffectFactory.RegisterBuilderFactory("personaltagward", BuilderFactory,
+			"Applies a personal ward that catches magic by magic tag",
+			HelpText,
+			false,
+			true,
+			SpellTriggerFactory.MagicTriggerTypes
+			                   .Where(x => CompatibleTypes.Contains(SpellTriggerFactory.BuilderInfoForType(x).TargetTypes))
+			                   .ToArray());
+	}
+
+	private static (IMagicSpellEffectTemplate Trigger, string Error) BuilderFactory(StringStack commands, IMagicSpell spell)
+	{
+		return (new PersonalTagWardEffect(new XElement("Effect",
+			new XAttribute("type", "personaltagward"),
+			new XElement("Tag", new XCData("magic")),
+			new XElement("Value", new XCData(string.Empty)),
+			new XElement("MatchValue", false),
+			new XElement("Mode", MagicInterdictionMode.Fail),
+			new XElement("Coverage", MagicInterdictionCoverage.Both),
+			new XElement("Prog", 0L)
+		), spell), string.Empty);
+	}
+
+	private PersonalTagWardEffect(XElement root, IMagicSpell spell) : base(root, spell)
+	{
+	}
+
+	protected override string EffectType => "personaltagward";
+	protected override string EffectName => "Personal Tag Ward";
+	protected override string[] CompatibleTargetTypes => CompatibleTypes;
+
+	protected override IMagicSpellEffect? CreateWardEffect(IPerceivable target, IMagicSpellEffectParent parent)
+	{
+		return target is ICharacter ? new SpellPersonalTagWardEffect(target, parent, Tag, Value, MatchValue, Mode, Coverage, Prog) : null;
+	}
+
+	protected override IMagicSpellEffectTemplate CloneEffect(XElement root, IMagicSpell spell)
+	{
+		return new PersonalTagWardEffect(root, spell);
+	}
+}

--- a/MudSharpCore/PerceptionEngine/OutputExtensions.cs
+++ b/MudSharpCore/PerceptionEngine/OutputExtensions.cs
@@ -22,6 +22,20 @@ public static partial class OutputHandlerExtensions
 
 public static class OutputExtensions
 {
+    private static IEnumerable<IRemoteObservationEffect> RemoteObservationEffectsFor(ILocation location)
+    {
+        if (location is null)
+        {
+            return Enumerable.Empty<IRemoteObservationEffect>();
+        }
+
+        return location.Cells
+                       .SelectMany(x => x.EffectsOfType<IRemoteObservationEffect>())
+                       .Concat(location.Characters.SelectMany(x => x.EffectsOfType<IRemoteObservationEffect>()))
+                       .Distinct()
+                       .ToList();
+    }
+
     public static void Send<T>(this T target, string text, params object[] parameters) where T : IHandleOutput
     {
         if (!text.IsValidFormatString(parameters?.Length ?? 0))
@@ -119,8 +133,7 @@ public static class OutputExtensions
             ch.OutputHandler?.Send(text);
         }
 
-        foreach (IRemoteObservationEffect effect in location?.Cells.SelectMany(x => x.EffectsOfType<IRemoteObservationEffect>()).ToList() ??
-                                   Enumerable.Empty<IRemoteObservationEffect>())
+        foreach (IRemoteObservationEffect effect in RemoteObservationEffectsFor(location))
         {
             effect.HandleOutput(text, location);
         }
@@ -149,8 +162,7 @@ public static class OutputExtensions
 
         if (!output.Flags.HasFlag(OutputFlags.IgnoreWatchers))
         {
-            foreach (IRemoteObservationEffect effect in location?.Cells.SelectMany(x => x.EffectsOfType<IRemoteObservationEffect>()).ToList() ??
-                                   Enumerable.Empty<IRemoteObservationEffect>())
+            foreach (IRemoteObservationEffect effect in RemoteObservationEffectsFor(location))
             {
                 effect.HandleOutput(output, location);
             }
@@ -173,8 +185,7 @@ public static class OutputExtensions
             ch.OutputHandler?.Send(text);
         }
 
-        foreach (IRemoteObservationEffect effect in location?.Cells.SelectMany(x => x.EffectsOfType<IRemoteObservationEffect>()).ToList() ??
-                                   Enumerable.Empty<IRemoteObservationEffect>())
+        foreach (IRemoteObservationEffect effect in RemoteObservationEffectsFor(location))
         {
             effect.HandleOutput(text, location);
         }
@@ -203,8 +214,7 @@ public static class OutputExtensions
 
         if (!output.Flags.HasFlag(OutputFlags.IgnoreWatchers))
         {
-            foreach (IRemoteObservationEffect effect in location?.EffectsOfType<IRemoteObservationEffect>().ToList() ??
-                                   Enumerable.Empty<IRemoteObservationEffect>())
+            foreach (IRemoteObservationEffect effect in RemoteObservationEffectsFor(location))
             // TODO - layer awareness for watching?
             {
                 effect.HandleOutput(output, location);

--- a/MudSharpCore/PerceptionEngine/Parsers/EmoteTokens.cs
+++ b/MudSharpCore/PerceptionEngine/Parsers/EmoteTokens.cs
@@ -1227,6 +1227,8 @@ public partial class Emote
                     return "*** odd clicking sounds ***".ColourBold(Telnet.Cyan);
                 case PermitLanguageOptions.LanguageIsBuzzing:
                     return "*** muted buzzing sounds ***".ColourBold(Telnet.Cyan);
+                case PermitLanguageOptions.LanguageIsBabbling:
+                    return "*** jumbled, incomprehensible babbling ***".ColourBold(Telnet.Cyan);
                 default:
                     throw new ArgumentOutOfRangeException(nameof(perceiver));
             }


### PR DESCRIPTION
## Summary
- Added the V4 psionic power set: `trace`, `hear`, `clairaudience`, `allspeak`, `babble`, `magicksense`, `projectemotion`, `suggest`, and `coerce`.
- Added shared psionic traffic, coercion, ward, and perception-policy hooks for opt-out handling, listener delivery, tag-aware interdiction, babble speech masking, and subjective-description priority/key resolution.
- Updated `connectmind` eligibility handling and split the V4 power/effect implementations into one file per class/interface.
- Refreshed the magic subsystem docs and the Armageddon gap report to reflect the implemented V4 scope.

## Testing
- Targeted `MudSharpCore` build passed.
- `MudSharpCore Unit Tests` passed with 677 tests green.
- Diff whitespace check passed.