### PR TITLE
[codex] Harden RPI room import edge cases

### DIFF
--- a/RPI Engine Worldfile Converter Tests/RpiRoomConversionTests.cs
+++ b/RPI Engine Worldfile Converter Tests/RpiRoomConversionTests.cs
@@ -210,6 +210,53 @@ public class RpiRoomConversionTests
 		Assert.AreEqual(longKeyword[..FutureMudRoomImportLimits.ExitTextMaxLength], truncatedPrimaryKeyword);
 	}
 
+	[TestMethod]
+	public void RoomTransformer_WarnsForSelfLoopExits()
+	{
+		var room = new RpiRoomRecord
+		{
+			Vnum = 99000,
+			SourceFile = "rooms.99",
+			Zone = 99,
+			Name = "Self Loop Room",
+			Description = "A room whose exits point back into itself.",
+			RawFlags = 0,
+			RoomFlags = RpiRoomFlags.None,
+			RawSectorType = (int)RpiRoomSectorType.Inside,
+			SectorType = RpiRoomSectorType.Inside,
+			Deity = 0,
+			Exits =
+			[
+				new RpiRoomExitRecord(
+					RpiRoomDirection.North,
+					RpiRoomExitSectionType.Normal,
+					"around",
+					"loop",
+					RpiRoomDoorType.None,
+					-1,
+					0,
+					99000),
+				new RpiRoomExitRecord(
+					RpiRoomDirection.South,
+					RpiRoomExitSectionType.Normal,
+					"around",
+					"loop",
+					RpiRoomDoorType.None,
+					-1,
+					0,
+					99000)
+			],
+		};
+
+		var transformer = new FutureMudRoomTransformer();
+		var convertedExit = transformer.Convert([room]).Exits.Single();
+
+		Assert.AreEqual(99000, convertedExit.RoomVnum1);
+		Assert.AreEqual(99000, convertedExit.RoomVnum2);
+		Assert.IsTrue(convertedExit.Side2.Visible);
+		Assert.IsTrue(convertedExit.Warnings.Any(x => x.Code == "self-loop-exit"));
+	}
+
 	private static string GetRoomFixtureDirectory()
 	{
 		var candidates = new[]

--- a/RPI Engine Worldfile Converter/FutureMudRoomImporter.cs
+++ b/RPI Engine Worldfile Converter/FutureMudRoomImporter.cs
@@ -521,6 +521,7 @@ public sealed class FutureMudRoomImporter
 
 		var hiddenExitIdsByCell = new Dictionary<long, List<long>>();
 		var exitModels = new List<(ConvertedRoomExitDefinition definition, Exit dbExit)>();
+		var linkedOverlayExits = new HashSet<(long CellOverlayId, long ExitId)>();
 		foreach (var exit in conversion.Exits.OrderBy(x => x.ExitKey, StringComparer.OrdinalIgnoreCase))
 		{
 			if (!createdRoomStates.TryGetValue(exit.RoomVnum1, out var room1) ||
@@ -574,19 +575,11 @@ public sealed class FutureMudRoomImporter
 			var room1 = createdRoomStates[definition.RoomVnum1];
 			var room2 = createdRoomStates[definition.RoomVnum2];
 
-			_context.CellOverlaysExits.Add(new CellOverlayExit
-			{
-				CellOverlayId = room1.DbOverlay.Id,
-				ExitId = dbExit.Id,
-			});
+			AddCellOverlayExitLink(linkedOverlayExits, room1.DbOverlay.Id, dbExit.Id);
 
 			if (definition.Side2.Visible)
 			{
-				_context.CellOverlaysExits.Add(new CellOverlayExit
-				{
-					CellOverlayId = room2.DbOverlay.Id,
-					ExitId = dbExit.Id,
-				});
+				AddCellOverlayExitLink(linkedOverlayExits, room2.DbOverlay.Id, dbExit.Id);
 			}
 
 			if (definition.Side1.Hidden)
@@ -620,6 +613,23 @@ public sealed class FutureMudRoomImporter
 			skippedExistingZoneCount,
 			issues,
 			new RoomApplyAuditReport(DateTime.UtcNow, true, defaults!.Description, zoneAudit, roomAudit, exitAudit));
+	}
+
+	private void AddCellOverlayExitLink(
+		ISet<(long CellOverlayId, long ExitId)> linkedOverlayExits,
+		long cellOverlayId,
+		long exitId)
+	{
+		if (!linkedOverlayExits.Add((cellOverlayId, exitId)))
+		{
+			return;
+		}
+
+		_context.CellOverlaysExits.Add(new CellOverlayExit
+		{
+			CellOverlayId = cellOverlayId,
+			ExitId = exitId,
+		});
 	}
 
 	private static string? GetSkipReason(

--- a/RPI Engine Worldfile Converter/FutureMudRoomTransformer.cs
+++ b/RPI Engine Worldfile Converter/FutureMudRoomTransformer.cs
@@ -338,6 +338,13 @@ public sealed class FutureMudRoomTransformer
 						$"Room #{room.Vnum} has a one-sided {side1.Direction.Describe()} exit to #{destinationRoom.Vnum}."));
 				}
 
+				if (room.Vnum == destinationRoom.Vnum)
+				{
+					warnings.Add(new RoomConversionWarning(
+						"self-loop-exit",
+						$"Room #{room.Vnum} has a {side1.Direction.Describe()} exit that points back to itself."));
+				}
+
 				AppendExitFieldLimitWarnings(warnings, side1);
 				AppendExitFieldLimitWarnings(warnings, side2);
 

--- a/RPI Engine Worldfile Converter/RpiRoomConversionMapping.md
+++ b/RPI Engine Worldfile Converter/RpiRoomConversionMapping.md
@@ -140,6 +140,8 @@ Side-specific data is preserved per direction:
 
 One-sided exits are allowed. The shared `Exit` is created, and only the visible overlay side is linked.
 
+Self-loop exits are allowed and produce a `self-loop-exit` warning. FutureMUD stores overlay-to-exit links in a join table keyed by overlay id and exit id, so the importer de-duplicates those join rows when both visible sides of a self-loop belong to the same overlay.
+
 ## Doors And Gates
 
 RPI Engine doors and gates were not standalone items. In this pass:


### PR DESCRIPTION
## Summary

Hardens the RPI room importer against several legacy room-data edge cases found while running `apply-rooms`:

- assigns explicit revision-group IDs for imported `CellOverlayPackage` rows so EF does not track multiple `{Id: 0, RevisionNumber: 0}` packages
- wraps execute-mode room import in a transaction to avoid partial imports after later failures
- warns on and truncates overlong room descriptions at the `CellOverlay.CellDescription` database boundary
- warns on and truncates overlong exit-side text for FutureMUD's 255-character exit text columns
- detects self-loop exits and de-duplicates `CellOverlayExit` join rows so self-loops do not crash import
- documents the persistence limits and self-loop handling in the room conversion mapping notes

## Validation

- `dotnet test "RPI Engine Worldfile Converter Tests\RPI Engine Worldfile Converter Tests.csproj" -c Debug --no-restore -m:1`
- Result: Passed, 30 tests

Note: the dependency build still emits two existing `MudSharpCore` analyzer warnings unrelated to this importer change.