### PR TITLE
Preserve legacy room vnums in RPI room imports

### DIFF
--- a/RPI Engine Worldfile Converter Tests/RpiRoomConversionTests.cs
+++ b/RPI Engine Worldfile Converter Tests/RpiRoomConversionTests.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -112,6 +113,132 @@ public class RpiRoomConversionTests
 		Assert.AreEqual(new RoomCoordinate(1, 2, 1), rooms[1005].Coordinates);
 
 		Assert.IsTrue(rooms[1004].Warnings.Any(x => x.Code == "layout-conflict"));
+	}
+
+	[TestMethod]
+	public void RpiRoomDirections_MapLegacyDirectionValues_ToFutureMudCardinalValues()
+	{
+		Assert.AreEqual(CardinalDirection.North, RpiRoomDirection.North.ToFutureMudDirection());
+		Assert.AreEqual(CardinalDirection.East, RpiRoomDirection.East.ToFutureMudDirection());
+		Assert.AreEqual(CardinalDirection.South, RpiRoomDirection.South.ToFutureMudDirection());
+		Assert.AreEqual(CardinalDirection.West, RpiRoomDirection.West.ToFutureMudDirection());
+		Assert.AreEqual(CardinalDirection.Up, RpiRoomDirection.Up.ToFutureMudDirection());
+		Assert.AreEqual(CardinalDirection.Down, RpiRoomDirection.Down.ToFutureMudDirection());
+		Assert.AreEqual(CardinalDirection.NorthEast, RpiRoomDirection.NorthEast.ToFutureMudDirection());
+		Assert.AreEqual(CardinalDirection.NorthWest, RpiRoomDirection.NorthWest.ToFutureMudDirection());
+		Assert.AreEqual(CardinalDirection.SouthEast, RpiRoomDirection.SouthEast.ToFutureMudDirection());
+		Assert.AreEqual(CardinalDirection.SouthWest, RpiRoomDirection.SouthWest.ToFutureMudDirection());
+		Assert.AreEqual(CardinalDirection.Unknown, RpiRoomDirection.Outside.ToFutureMudDirection());
+		Assert.AreEqual(CardinalDirection.Unknown, RpiRoomDirection.Inside.ToFutureMudDirection());
+
+		Assert.IsTrue(RpiRoomDirections.TryParse("10", out var southEast));
+		Assert.AreEqual(RpiRoomDirection.SouthEast, southEast);
+	}
+
+	[TestMethod]
+	public void RoomTransformer_DoesNotShrinkNormalDoorBecauseRoomDescriptionMentionsTrapdoor()
+	{
+		var tavern = new RpiRoomRecord
+		{
+			Vnum = 99010,
+			SourceFile = "rooms.99",
+			Zone = 99,
+			Name = "The Strange Brew Tavern",
+			Description = "A broad tavern with a normal wooden door to the north.",
+			RawFlags = 0,
+			RoomFlags = RpiRoomFlags.None,
+			RawSectorType = (int)RpiRoomSectorType.Inside,
+			SectorType = RpiRoomSectorType.Inside,
+			Deity = 0,
+			Exits =
+			[
+				new RpiRoomExitRecord(
+					RpiRoomDirection.North,
+					RpiRoomExitSectionType.Normal,
+					string.Empty,
+					"door",
+					RpiRoomDoorType.Door,
+					-1,
+					0,
+					99011)
+			],
+		};
+		var kitchen = new RpiRoomRecord
+		{
+			Vnum = 99011,
+			SourceFile = "rooms.99",
+			Zone = 99,
+			Name = "A Cluttered Brewery and Kitchen",
+			Description = "A carpet in one corner covers a trapdoor, while a normal door leads south.",
+			RawFlags = 0,
+			RoomFlags = RpiRoomFlags.None,
+			RawSectorType = (int)RpiRoomSectorType.Inside,
+			SectorType = RpiRoomSectorType.Inside,
+			Deity = 0,
+			Exits =
+			[
+				new RpiRoomExitRecord(
+					RpiRoomDirection.South,
+					RpiRoomExitSectionType.Normal,
+					string.Empty,
+					"door",
+					RpiRoomDoorType.Door,
+					-1,
+					0,
+					99010)
+			],
+		};
+
+		var transformer = new FutureMudRoomTransformer();
+		var convertedExit = transformer.Convert([tavern, kitchen]).Exits.Single();
+
+		Assert.AreEqual((int)SizeCategory.Large, convertedExit.DoorSize);
+		Assert.AreEqual((int)SizeCategory.Large, convertedExit.MaximumSizeToEnter);
+		Assert.AreEqual((int)SizeCategory.Large, convertedExit.MaximumSizeToEnterUpright);
+	}
+
+	[TestMethod]
+	public void RoomIdPlanner_PreservesPositiveLegacyVnums_ForRoomAndCellIds()
+	{
+		var rooms = new[]
+		{
+			CreateConvertedRoom(66896),
+			CreateConvertedRoom(66897),
+		};
+
+		var plan = FutureMudRoomIdPlanner.Plan(rooms, new HashSet<long>(), new HashSet<long>());
+
+		Assert.AreEqual(0, plan.Issues.Count);
+		Assert.AreEqual(66896L, plan.Reservations[66896].RoomId);
+		Assert.AreEqual(66896L, plan.Reservations[66896].CellId);
+		Assert.AreEqual(66897L, plan.Reservations[66897].RoomId);
+		Assert.AreEqual(66897L, plan.Reservations[66897].CellId);
+	}
+
+	[TestMethod]
+	public void RoomIdPlanner_AssignsHighFallbackIds_ForZeroVnumsAndCollisions()
+	{
+		var rooms = new[]
+		{
+			CreateConvertedRoom(0),
+			CreateConvertedRoom(1000),
+			CreateConvertedRoom(1001),
+		};
+
+		var plan = FutureMudRoomIdPlanner.Plan(
+			rooms,
+			new HashSet<long> { 1000 },
+			new HashSet<long> { 1001 });
+
+		Assert.AreEqual(1002L, plan.Reservations[0].RoomId);
+		Assert.AreEqual(1002L, plan.Reservations[0].CellId);
+		Assert.AreEqual(1003L, plan.Reservations[1000].RoomId);
+		Assert.AreEqual(1000L, plan.Reservations[1000].CellId);
+		Assert.AreEqual(1001L, plan.Reservations[1001].RoomId);
+		Assert.AreEqual(1003L, plan.Reservations[1001].CellId);
+		Assert.IsTrue(plan.Issues.Any(x => x.SourceKey == "rooms.0#0" && x.Message.Contains("cannot be used")));
+		Assert.IsTrue(plan.Issues.Any(x => x.SourceKey == "rooms.1000#1000" && x.Message.Contains("already exists")));
+		Assert.IsTrue(plan.Issues.Any(x => x.SourceKey == "rooms.1001#1001" && x.Message.Contains("already exists")));
 	}
 
 	[TestMethod]
@@ -255,6 +382,32 @@ public class RpiRoomConversionTests
 		Assert.AreEqual(99000, convertedExit.RoomVnum2);
 		Assert.IsTrue(convertedExit.Side2.Visible);
 		Assert.IsTrue(convertedExit.Warnings.Any(x => x.Code == "self-loop-exit"));
+	}
+
+	private static ConvertedRoomDefinition CreateConvertedRoom(int vnum)
+	{
+		return new ConvertedRoomDefinition
+		{
+			Vnum = vnum,
+			SourceFile = $"rooms.{vnum}",
+			SourceZone = vnum / 1000,
+			SourceKey = $"rooms.{vnum}#{vnum}",
+			ZoneGroupKey = "test-zone",
+			ZoneName = "Test Zone",
+			OverlayPackageName = "RPI Import Rooms - Test Zone (#1r0)",
+			Name = $"Room {vnum}",
+			RawDescription = "A test room.",
+			EffectiveDescription = "A test room.",
+			TerrainName = "Hall",
+			OutdoorsTypeName = "Indoors",
+			OutdoorsTypeValue = (int)CellOutdoorsType.Indoors,
+			SafeQuit = false,
+			Coordinates = new RoomCoordinate(vnum, 0, 0),
+			RawFlags = 0,
+			RoomFlagNames = Array.Empty<string>(),
+			SectorType = RpiRoomSectorType.Inside,
+			Deity = 0,
+		};
 	}
 
 	private static string GetRoomFixtureDirectory()

--- a/RPI Engine Worldfile Converter/FutureMudRoomImporter.cs
+++ b/RPI Engine Worldfile Converter/FutureMudRoomImporter.cs
@@ -75,6 +75,12 @@ public sealed record FutureMudRoomImportResult(
 	IReadOnlyList<FutureMudRoomValidationIssue> Issues,
 	RoomApplyAuditReport Audit);
 
+public sealed record FutureMudRoomIdReservation(int Vnum, long RoomId, long CellId);
+
+public sealed record FutureMudRoomIdReservationPlan(
+	IReadOnlyDictionary<int, FutureMudRoomIdReservation> Reservations,
+	IReadOnlyList<FutureMudRoomValidationIssue> Issues);
+
 public static class FutureMudRoomImportLimits
 {
 	public const int CellDescriptionMaxLength = 4000;
@@ -95,6 +101,112 @@ public static class FutureMudRoomImportLimits
 		return text.Length <= maxLength
 			? text
 			: text[..maxLength];
+	}
+}
+
+public static class FutureMudRoomIdPlanner
+{
+	public static FutureMudRoomIdReservationPlan Plan(
+		IEnumerable<ConvertedRoomDefinition> rooms,
+		IReadOnlySet<long> existingRoomIds,
+		IReadOnlySet<long> existingCellIds)
+	{
+		var roomList = rooms
+			.OrderBy(x => x.Vnum)
+			.ToList();
+		Dictionary<int, FutureMudRoomIdReservation> reservations = [];
+		List<FutureMudRoomValidationIssue> issues = [];
+		HashSet<long> reservedRoomIds = [];
+		HashSet<long> reservedCellIds = [];
+		var nextRoomFallbackId = DetermineFirstFallbackId(roomList, existingRoomIds);
+		var nextCellFallbackId = DetermineFirstFallbackId(roomList, existingCellIds);
+
+		foreach (var room in roomList)
+		{
+			var roomId = ReserveId(
+				room,
+				"Room",
+				existingRoomIds,
+				reservedRoomIds,
+				ref nextRoomFallbackId,
+				issues);
+			var cellId = ReserveId(
+				room,
+				"Cell",
+				existingCellIds,
+				reservedCellIds,
+				ref nextCellFallbackId,
+				issues);
+
+			reservations[room.Vnum] = new FutureMudRoomIdReservation(room.Vnum, roomId, cellId);
+		}
+
+		return new FutureMudRoomIdReservationPlan(reservations, issues);
+	}
+
+	private static long DetermineFirstFallbackId(
+		IReadOnlyList<ConvertedRoomDefinition> rooms,
+		IReadOnlySet<long> existingIds)
+	{
+		var highestExistingId = existingIds.Count == 0
+			? 0L
+			: existingIds.Max();
+		var highestLegacyId = rooms
+			.Select(x => x.LegacyPersistenceId ?? 0L)
+			.DefaultIfEmpty(0L)
+			.Max();
+
+		return Math.Max(highestExistingId, highestLegacyId) + 1;
+	}
+
+	private static long ReserveId(
+		ConvertedRoomDefinition room,
+		string entityName,
+		IReadOnlySet<long> existingIds,
+		ISet<long> reservedIds,
+		ref long nextFallbackId,
+		ICollection<FutureMudRoomValidationIssue> issues)
+	{
+		if (room.LegacyPersistenceId is { } legacyId)
+		{
+			if (!existingIds.Contains(legacyId) && reservedIds.Add(legacyId))
+			{
+				return legacyId;
+			}
+
+			var fallbackId = ReserveFallbackId(existingIds, reservedIds, ref nextFallbackId);
+			var reason = existingIds.Contains(legacyId)
+				? "already exists in the target database"
+				: "was already reserved by another converted room";
+			issues.Add(new FutureMudRoomValidationIssue(
+				room.SourceKey,
+				"warning",
+				$"Legacy vnum {room.Vnum} could not be used as the FutureMUD {entityName} id because id {legacyId} {reason}; assigned fallback id {fallbackId}."));
+			return fallbackId;
+		}
+
+		var generatedFallbackId = ReserveFallbackId(existingIds, reservedIds, ref nextFallbackId);
+		issues.Add(new FutureMudRoomValidationIssue(
+			room.SourceKey,
+			"warning",
+			$"Legacy vnum {room.Vnum} cannot be used as the FutureMUD {entityName} id; assigned fallback id {generatedFallbackId}."));
+		return generatedFallbackId;
+	}
+
+	private static long ReserveFallbackId(
+		IReadOnlySet<long> existingIds,
+		ISet<long> reservedIds,
+		ref long nextFallbackId)
+	{
+		while (existingIds.Contains(nextFallbackId) || reservedIds.Contains(nextFallbackId))
+		{
+			nextFallbackId++;
+		}
+
+		var fallbackId = nextFallbackId;
+		reservedIds.Add(fallbackId);
+		nextFallbackId++;
+		return fallbackId;
 	}
 }
 
@@ -330,6 +442,19 @@ public sealed class FutureMudRoomImporter
 		var existingZoneNames = _context.Zones
 			.Select(x => x.Name)
 			.ToHashSet(StringComparer.OrdinalIgnoreCase);
+		var skipReasons = conversion.Zones.ToDictionary(
+			x => x.GroupKey,
+			x => GetSkipReason(x, CreatePackageMarker(x), packageMarkers, existingPackageNames, existingZoneNames),
+			StringComparer.OrdinalIgnoreCase);
+		var roomsToCreate = conversion.Zones
+			.Where(x => skipReasons[x.GroupKey] is null)
+			.SelectMany(x => x.Rooms)
+			.ToList();
+		var idPlan = FutureMudRoomIdPlanner.Plan(
+			roomsToCreate,
+			_context.Rooms.Select(x => x.Id).ToHashSet(),
+			_context.Cells.Select(x => x.Id).ToHashSet());
+		issues.AddRange(idPlan.Issues);
 
 		List<RoomApplyAuditZoneEntry> zoneAudit = [];
 		List<RoomApplyAuditRoomEntry> roomAudit = [];
@@ -346,7 +471,7 @@ public sealed class FutureMudRoomImporter
 		foreach (var zone in conversion.Zones.OrderBy(x => x.ZoneName, StringComparer.OrdinalIgnoreCase))
 		{
 			var marker = CreatePackageMarker(zone);
-			var skipReason = GetSkipReason(zone, marker, packageMarkers, existingPackageNames, existingZoneNames);
+			var skipReason = skipReasons[zone.GroupKey];
 			if (skipReason is not null)
 			{
 				issues.Add(new FutureMudRoomValidationIssue(zone.GroupKey, "warning", skipReason));
@@ -365,7 +490,16 @@ public sealed class FutureMudRoomImporter
 				zoneAudit.Add(new RoomApplyAuditZoneEntry(zone.GroupKey, zone.ZoneName, zone.OverlayPackageName, "would-create", null, null));
 				foreach (var room in zone.Rooms)
 				{
-					roomAudit.Add(new RoomApplyAuditRoomEntry(room.SourceKey, room.Vnum, room.ZoneGroupKey, "would-create", null, null, null, null));
+					var reservation = idPlan.Reservations[room.Vnum];
+					roomAudit.Add(new RoomApplyAuditRoomEntry(
+						room.SourceKey,
+						room.Vnum,
+						room.ZoneGroupKey,
+						"would-create",
+						null,
+						reservation.RoomId,
+						reservation.CellId,
+						null));
 				}
 
 				continue;
@@ -417,27 +551,30 @@ public sealed class FutureMudRoomImporter
 			zoneAudit.Add(new RoomApplyAuditZoneEntry(zone.GroupKey, zone.ZoneName, zone.OverlayPackageName, "created", dbZone.Id, package.Id));
 			insertedZoneCount++;
 
-			var zoneRooms = new List<(ConvertedRoomDefinition room, MudSharp.Models.Room dbRoom)>();
+			var zoneRooms = new List<(ConvertedRoomDefinition room, MudSharp.Models.Room dbRoom, FutureMudRoomIdReservation reservation)>();
 			foreach (var room in zone.Rooms.OrderBy(x => x.Vnum))
 			{
+				var reservation = idPlan.Reservations[room.Vnum];
 				var dbRoom = new MudSharp.Models.Room
 				{
+					Id = reservation.RoomId,
 					ZoneId = dbZone.Id,
 					X = room.Coordinates.X,
 					Y = room.Coordinates.Y,
 					Z = room.Coordinates.Z,
 				};
 				_context.Rooms.Add(dbRoom);
-				zoneRooms.Add((room, dbRoom));
+				zoneRooms.Add((room, dbRoom, reservation));
 			}
 
 			_context.SaveChanges();
 
 			var zoneCells = new List<(ConvertedRoomDefinition room, MudSharp.Models.Room dbRoom, MudSharp.Models.Cell dbCell)>();
-			foreach (var (room, dbRoom) in zoneRooms)
+			foreach (var (room, dbRoom, reservation) in zoneRooms)
 			{
 				var dbCell = new MudSharp.Models.Cell
 				{
+					Id = reservation.CellId,
 					RoomId = dbRoom.Id,
 					Temporary = room.RoomFlagNames.Contains(nameof(RpiRoomFlags.Temporary), StringComparer.OrdinalIgnoreCase),
 					EffectData = "<Effects/>",
@@ -535,8 +672,8 @@ public sealed class FutureMudRoomImporter
 			{
 				CellId1 = room1.DbCell.Id,
 				CellId2 = room2.DbCell.Id,
-				Direction1 = (int)exit.Side1.Direction,
-				Direction2 = (int)exit.Side2.Direction,
+				Direction1 = (int)exit.Side1.Direction.ToFutureMudDirection(),
+				Direction2 = (int)exit.Side2.Direction.ToFutureMudDirection(),
 				Keywords1 = FutureMudRoomImportLimits.TruncateExitText(exit.Side1.Keywords),
 				Keywords2 = FutureMudRoomImportLimits.TruncateExitText(exit.Side2.Keywords),
 				PrimaryKeyword1 = FutureMudRoomImportLimits.TruncateExitText(exit.Side1.PrimaryKeyword),

--- a/RPI Engine Worldfile Converter/FutureMudRoomTransformer.cs
+++ b/RPI Engine Worldfile Converter/FutureMudRoomTransformer.cs
@@ -805,36 +805,26 @@ public sealed class FutureMudRoomTransformer
 		ConvertedRoomExitSideDefinition side1,
 		ConvertedRoomExitSideDefinition side2)
 	{
-		var text = string.Join(
-			' ',
-			new[]
-			{
-				sourceRoom.Name,
-				sourceRoom.Description,
-				destinationRoom.Name,
-				destinationRoom.Description,
-				side1.Keywords,
-				side1.Description,
-				side2.Keywords,
-				side2.Description,
-			});
+		var exitText = BuildExitSpecificEvidence(side1, side2);
 
-		if (ContainsAny(text, "great gate", "massive gate", "fortress gate"))
+		if (ContainsAny(exitText, "great gate", "massive gate", "fortress gate"))
 		{
 			return (int)SizeCategory.Enormous;
 		}
 
-		if (ContainsAny(text, "double doors", "carriage doors"))
+		if (ContainsAny(exitText, "double doors", "carriage doors"))
 		{
 			return (int)SizeCategory.VeryLarge;
 		}
 
-		if (ContainsAny(text, "trapdoor", "hatch"))
+		if (ContainsAny(exitText, "trapdoor", "hatch"))
 		{
 			return (int)SizeCategory.Small;
 		}
 
-		if (ContainsAny(text, "gate", "portcullis"))
+		if (side1.DoorType == RpiRoomDoorType.Gate ||
+		    side2.DoorType == RpiRoomDoorType.Gate ||
+		    ContainsAny(exitText, "gate", "portcullis"))
 		{
 			return (int)SizeCategory.Huge;
 		}
@@ -849,31 +839,36 @@ public sealed class FutureMudRoomTransformer
 		ConvertedRoomExitSideDefinition side1,
 		ConvertedRoomExitSideDefinition side2)
 	{
-		var text = string.Join(
-			' ',
-			new[]
-			{
-				sourceRoom.Name,
-				sourceRoom.Description,
-				destinationRoom.Name,
-				destinationRoom.Description,
-				side1.Keywords,
-				side1.Description,
-				side2.Keywords,
-				side2.Description,
-			});
+		var exitText = BuildExitSpecificEvidence(side1, side2);
 
-		if (ContainsAny(text, "trapdoor", "hatch"))
+		if (ContainsAny(exitText, "trapdoor", "hatch"))
 		{
 			return (int)SizeCategory.Small;
 		}
 
-		if (ContainsAny(text, "crawl", "crouch", "low", "tight", "narrow", "squeeze"))
+		if (ContainsAny(exitText, "crawl", "crouch", "low", "tight", "narrow", "squeeze"))
 		{
 			return Math.Min(doorSize, (int)SizeCategory.Normal);
 		}
 
 		return doorSize;
+	}
+
+	private static string BuildExitSpecificEvidence(
+		ConvertedRoomExitSideDefinition side1,
+		ConvertedRoomExitSideDefinition side2)
+	{
+		return string.Join(
+			' ',
+			new[]
+			{
+				side1.Keywords,
+				side1.PrimaryKeyword ?? string.Empty,
+				side1.Description,
+				side2.Keywords,
+				side2.PrimaryKeyword ?? string.Empty,
+				side2.Description,
+			});
 	}
 
 	private static string BuildExitKey(

--- a/RPI Engine Worldfile Converter/RPIRoom.cs
+++ b/RPI Engine Worldfile Converter/RPIRoom.cs
@@ -2,6 +2,7 @@
 
 using System.Globalization;
 using System.IO;
+using MudSharp.Construction;
 
 namespace RPI_Engine_Worldfile_Converter;
 
@@ -57,6 +58,12 @@ public enum RpiRoomDirection
 	West = 3,
 	Up = 4,
 	Down = 5,
+	Outside = 6,
+	Inside = 7,
+	NorthEast = 8,
+	NorthWest = 9,
+	SouthEast = 10,
+	SouthWest = 11,
 }
 
 public enum RpiRoomExitSectionType
@@ -190,6 +197,7 @@ public sealed record ConvertedRoomExitDefinition(
 public sealed record ConvertedRoomDefinition
 {
 	public required int Vnum { get; init; }
+	public long? LegacyPersistenceId => Vnum > 0 ? Vnum : null;
 	public required string SourceFile { get; init; }
 	public required int SourceZone { get; init; }
 	public required string SourceKey { get; init; }
@@ -286,6 +294,12 @@ public static class RpiRoomDirections
 			[RpiRoomDirection.West] = new(-1, 0, 0),
 			[RpiRoomDirection.Up] = new(0, 0, 1),
 			[RpiRoomDirection.Down] = new(0, 0, -1),
+			[RpiRoomDirection.Outside] = new(0, 0, 0),
+			[RpiRoomDirection.Inside] = new(0, 0, 0),
+			[RpiRoomDirection.NorthEast] = new(1, 1, 0),
+			[RpiRoomDirection.NorthWest] = new(-1, 1, 0),
+			[RpiRoomDirection.SouthEast] = new(1, -1, 0),
+			[RpiRoomDirection.SouthWest] = new(-1, -1, 0),
 		};
 
 	private static readonly IReadOnlyList<RpiRoomDirection> OrderedDirections =
@@ -296,6 +310,12 @@ public static class RpiRoomDirections
 		RpiRoomDirection.West,
 		RpiRoomDirection.Up,
 		RpiRoomDirection.Down,
+		RpiRoomDirection.Outside,
+		RpiRoomDirection.Inside,
+		RpiRoomDirection.NorthEast,
+		RpiRoomDirection.NorthWest,
+		RpiRoomDirection.SouthEast,
+		RpiRoomDirection.SouthWest,
 	];
 
 	public static RoomCoordinate Delta(this RpiRoomDirection direction)
@@ -313,7 +333,31 @@ public static class RpiRoomDirections
 			RpiRoomDirection.West => RpiRoomDirection.East,
 			RpiRoomDirection.Up => RpiRoomDirection.Down,
 			RpiRoomDirection.Down => RpiRoomDirection.Up,
+			RpiRoomDirection.Outside => RpiRoomDirection.Inside,
+			RpiRoomDirection.Inside => RpiRoomDirection.Outside,
+			RpiRoomDirection.NorthEast => RpiRoomDirection.SouthWest,
+			RpiRoomDirection.NorthWest => RpiRoomDirection.SouthEast,
+			RpiRoomDirection.SouthEast => RpiRoomDirection.NorthWest,
+			RpiRoomDirection.SouthWest => RpiRoomDirection.NorthEast,
 			_ => throw new ArgumentOutOfRangeException(nameof(direction), direction, null),
+		};
+	}
+
+	public static CardinalDirection ToFutureMudDirection(this RpiRoomDirection direction)
+	{
+		return direction switch
+		{
+			RpiRoomDirection.North => CardinalDirection.North,
+			RpiRoomDirection.East => CardinalDirection.East,
+			RpiRoomDirection.South => CardinalDirection.South,
+			RpiRoomDirection.West => CardinalDirection.West,
+			RpiRoomDirection.Up => CardinalDirection.Up,
+			RpiRoomDirection.Down => CardinalDirection.Down,
+			RpiRoomDirection.NorthEast => CardinalDirection.NorthEast,
+			RpiRoomDirection.NorthWest => CardinalDirection.NorthWest,
+			RpiRoomDirection.SouthEast => CardinalDirection.SouthEast,
+			RpiRoomDirection.SouthWest => CardinalDirection.SouthWest,
+			_ => CardinalDirection.Unknown,
 		};
 	}
 

--- a/RPI Engine Worldfile Converter/RpiRoomConversionMapping.md
+++ b/RPI Engine Worldfile Converter/RpiRoomConversionMapping.md
@@ -63,7 +63,11 @@ Room import creates one FutureMUD `CellOverlayPackage` per converted zone group.
 
 `CellOverlayPackage.Id` is a revision-group identifier rather than a database-generated key, so the importer assigns new package ids from the current maximum package id plus one, matching the runtime builder workflow.
 
-Execute-mode imports run inside a database transaction. Intermediate `SaveChanges` calls are still used to obtain generated room, cell, overlay, and exit ids for dependent rows, but an exception rolls the whole execute import back rather than leaving a partial room import behind.
+RPI room vnums are used as explicit FutureMUD `Room.Id` and `Cell.Id` values when they are positive and not already occupied in the target database. The visible in-game `ID[...]` display is the `Cell.Id`, so this preserves legacy room-number grouping for imported rooms wherever the target baseline permits it.
+
+Legacy vnum `0` and any vnum that collides with an existing FutureMUD room or cell id are not inserted directly. The importer assigns a deterministic fallback id above the highest existing or legacy id for that table and emits an apply warning naming the affected source room. Dry-run audit rows include the ids that would be used.
+
+Execute-mode imports run inside a database transaction. Intermediate `SaveChanges` calls are still used to obtain generated overlay and exit ids for dependent rows, but an exception rolls the whole execute import back rather than leaving a partial room import behind.
 
 FutureMUD currently stores `CellOverlay.CellDescription` in a `varchar(4000)` column. Converted rooms keep the full effective description for export and audit, but descriptions longer than that limit produce a `cell-description-truncated` warning and are truncated to 4,000 characters only when `apply-rooms --execute` writes the overlay row.
 
@@ -132,6 +136,13 @@ If the xerox target is missing, the room keeps its original description and reco
 
 Each converted RPI exit becomes one shared FutureMUD `Exit`.
 
+RPI Engine stores direction ids in its own legacy order:
+
+- `0=NORTH`, `1=EAST`, `2=SOUTH`, `3=WEST`, `4=UP`, `5=DOWN`
+- `8=NORTHEAST`, `9=NORTHWEST`, `10=SOUTHEAST`, `11=SOUTHWEST`
+
+FutureMUD's `CardinalDirection` enum uses a different integer order because it interleaves diagonal directions between cardinal directions. The importer therefore translates directions by name instead of persisting raw legacy direction integers.
+
 Side-specific data is preserved per direction:
 
 - keyword text -> `PrimaryKeyword` and `Keywords`
@@ -159,7 +170,9 @@ Door-size heuristics:
 - `gate` / `portcullis` -> `Huge`
 - `great gate`, `massive gate`, `fortress gate` -> `Enormous`
 
-Unless crawl / low-opening cues exist, both `MaximumSizeToEnter` and `MaximumSizeToEnterUpright` follow the inferred door size.
+Door-size and upright-size cues are taken from the two exit sides' keywords and exit descriptions, not from the full source and destination room descriptions. This avoids shrinking a normal door because the room happens to mention a separate trapdoor, hatch, crawlspace, or low opening elsewhere in its prose.
+
+Unless exit-side crawl / low-opening cues exist, both `MaximumSizeToEnter` and `MaximumSizeToEnterUpright` follow the inferred door size.
 
 ## Hidden, Trapped, Climb, And Fall Exits
 

--- a/RPI Engine Worldfile Converter/RpiRoomWorldfileParser.cs
+++ b/RPI Engine Worldfile Converter/RpiRoomWorldfileParser.cs
@@ -331,12 +331,12 @@ public sealed class RpiRoomWorldfileParser
 	{
 		sectionType = RpiRoomExitSectionType.Normal;
 		direction = RpiRoomDirection.North;
-		if (marker.Length != 2)
+		if (marker.Length < 2)
 		{
 			return false;
 		}
 
-		if (!RpiRoomDirections.TryParse(marker[1].ToString(), out direction))
+		if (!RpiRoomDirections.TryParse(marker[1..], out direction))
 		{
 			return false;
 		}
@@ -363,9 +363,9 @@ public sealed class RpiRoomWorldfileParser
 	private static bool TryParseSecretMarker(string marker, out RpiRoomDirection direction)
 	{
 		direction = RpiRoomDirection.North;
-		return marker.Length == 2 &&
+		return marker.Length >= 2 &&
 		       marker[0] == 'Q' &&
-		       RpiRoomDirections.TryParse(marker[1].ToString(), out direction);
+		       RpiRoomDirections.TryParse(marker[1..], out direction);
 	}
 
 	private static string ReadTildeString(


### PR DESCRIPTION
## Summary
- Preserve positive RPI room vnums as explicit FutureMUD `Room.Id` and `Cell.Id` values during `apply-rooms`
- Use deterministic fallback ids, with warnings, when `vnum 0` or an id collision prevents exact parity
- Keep the earlier room-import fixes for exit direction mapping, multi-digit direction markers, and door-size heuristics
- Add room-import tests covering legacy direction mapping, door-size inference, and id reservation planning
- Update the room-conversion mapping doc to describe legacy id preservation and fallback behavior

## Testing
- `RPI Engine Worldfile Converter Tests`: focused room conversion tests passed
- `RPI Engine Worldfile Converter`: build passed
- `analyze-rooms` over `soiregions-main` completed with 25,318/25,318 room blocks parsed and 0 parse failures
- Full converter test suite still has 2 unrelated failing clan tests already present in the suite