### PR TITLE
Show door-capable exits in room look output

### DIFF
--- a/Design Documents/Room_Building_Builder_Guide.md
+++ b/Design Documents/Room_Building_Builder_Guide.md
@@ -401,6 +401,7 @@ cell set door <exit> clear
 ```
 
 `cell set door` controls whether an exit accepts a door and, if so, what size. It does not by itself install a specific door item.
+Player `look` and `exits` output shows door-capable exits without an installed door in bold white; installed doors still show their door state and description directly on the exit.
 
 Climb and fall:
 

--- a/MudSharpCore Unit Tests/CellExitDescriptionTests.cs
+++ b/MudSharpCore Unit Tests/CellExitDescriptionTests.cs
@@ -1,0 +1,123 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Construction;
+using MudSharp.Construction.Boundary;
+using MudSharp.Framework;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.RPG.Checks;
+using System.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class CellExitDescriptionTests
+{
+	[TestMethod]
+	public void DescribeFor_DoorCapableCardinalExitWithoutDoor_UsesBoldWhite()
+	{
+		var origin = CreateGroundCell();
+		var destination = CreateGroundCell();
+		var parent = CreateExit(acceptsDoor: true, door: null);
+		var perceiver = CreatePerceiver(origin.Object);
+		var exit = new CellExit(parent.Object, origin.Object, destination.Object, CardinalDirection.North,
+			CardinalDirection.South);
+
+		var description = exit.DescribeFor(perceiver.Object, colour: true);
+
+		Assert.IsTrue(description.StartsWith(Telnet.BoldWhite.ToString()),
+			"Door-capable exits with no installed door should begin with the door-capable colour.");
+		Assert.IsTrue(description.Contains("North"));
+		Assert.IsTrue(description.EndsWith(Telnet.RESET + Telnet.Green));
+	}
+
+	[TestMethod]
+	public void DescribeFor_DoorCapableNonCardinalExitWithoutDoor_UsesBoldWhite()
+	{
+		var origin = CreateGroundCell();
+		var destination = CreateGroundCell();
+		var parent = CreateExit(acceptsDoor: true, door: null);
+		var perceiver = CreatePerceiver(origin.Object);
+		var exit = new NonCardinalCellExit(parent.Object, origin.Object, destination.Object, "enter", "gate",
+			new[] { "gate" }, "towards", "the gate", "from", "the gate");
+
+		var description = exit.DescribeFor(perceiver.Object, colour: true);
+
+		Assert.IsTrue(description.StartsWith(Telnet.BoldWhite.ToString()),
+			"Door-capable non-cardinal exits with no installed door should begin with the door-capable colour.");
+		Assert.IsTrue(description.Contains("'Enter Gate'"));
+		Assert.IsTrue(description.EndsWith(Telnet.RESET + Telnet.Green));
+	}
+
+	[TestMethod]
+	public void DescribeFor_ColourFalse_DoesNotApplyDoorCapableColour()
+	{
+		var origin = CreateGroundCell();
+		var destination = CreateGroundCell();
+		var parent = CreateExit(acceptsDoor: true, door: null);
+		var perceiver = CreatePerceiver(origin.Object);
+		var exit = new CellExit(parent.Object, origin.Object, destination.Object, CardinalDirection.North,
+			CardinalDirection.South);
+
+		var description = exit.DescribeFor(perceiver.Object, colour: false);
+
+		Assert.AreEqual("North", description);
+		Assert.IsFalse(description.Contains("\x1B["));
+	}
+
+	[TestMethod]
+	public void DescribeFor_DoorCapableClimbExit_UsesClimbColour()
+	{
+		var origin = CreateGroundCell();
+		var destination = CreateGroundCell();
+		var parent = CreateExit(acceptsDoor: true, door: null, isClimbExit: true);
+		var perceiver = CreatePerceiver(origin.Object);
+		var exit = new CellExit(parent.Object, origin.Object, destination.Object, CardinalDirection.Down,
+			CardinalDirection.Up);
+
+		var description = exit.DescribeFor(perceiver.Object, colour: true);
+
+		Assert.IsTrue(description.StartsWith(Telnet.Yellow.ToString()),
+			"Movement warning colours should take priority over the door-capable colour.");
+		Assert.IsFalse(description.StartsWith(Telnet.BoldWhite.ToString()));
+	}
+
+	private static Mock<ITerrain> CreateGroundTerrain()
+	{
+		var terrain = new Mock<ITerrain>();
+		terrain.SetupGet(x => x.TerrainLayers).Returns(new[] { RoomLayer.GroundLevel });
+		return terrain;
+	}
+
+	private static Mock<ICell> CreateGroundCell()
+	{
+		var terrain = CreateGroundTerrain();
+		var cell = new Mock<ICell>();
+		cell.SetupGet(x => x.Location).Returns(cell.Object);
+		cell.Setup(x => x.Terrain(It.IsAny<IPerceiver>())).Returns(terrain.Object);
+		cell.Setup(x => x.IsSwimmingLayer(It.IsAny<RoomLayer>())).Returns(false);
+		cell.Setup(x => x.IsUnderwaterLayer(It.IsAny<RoomLayer>())).Returns(false);
+		cell.Setup(x => x.ExitsFor(It.IsAny<IPerceiver>(), true)).Returns(Enumerable.Empty<ICellExit>());
+		return cell;
+	}
+
+	private static Mock<IExit> CreateExit(bool acceptsDoor, IDoor? door, bool isClimbExit = false)
+	{
+		var exit = new Mock<IExit>();
+		exit.SetupGet(x => x.AcceptsDoor).Returns(acceptsDoor);
+		exit.SetupGet(x => x.Door).Returns(door!);
+		exit.SetupGet(x => x.BlockedLayers).Returns(Enumerable.Empty<RoomLayer>());
+		exit.SetupGet(x => x.IsClimbExit).Returns(isClimbExit);
+		exit.SetupGet(x => x.ClimbDifficulty).Returns(Difficulty.Normal);
+		return exit;
+	}
+
+	private static Mock<IPerceiver> CreatePerceiver(ICell location)
+	{
+		var perceiver = new Mock<IPerceiver>();
+		perceiver.SetupGet(x => x.Location).Returns(location);
+		perceiver.SetupProperty(x => x.RoomLayer, RoomLayer.GroundLevel);
+		return perceiver;
+	}
+}

--- a/MudSharpCore/Construction/Boundary/CellExit.cs
+++ b/MudSharpCore/Construction/Boundary/CellExit.cs
@@ -117,35 +117,43 @@ public class CellExit : ICellExit
     {
         string startColourString = "";
         string endColourString = "";
-        (CellMovementTransition transition, RoomLayer _) = MovementTransition(voyeur);
-        switch (transition)
+        if (colour)
         {
-            case CellMovementTransition.SwimOnly:
-                startColourString = Telnet.BoldBlue.ToString();
-                endColourString = Telnet.RESET + Telnet.Green.ToString();
-                break;
-            case CellMovementTransition.FallExit:
-                if (IsClimbExit)
-                {
-                    startColourString = Telnet.Yellow.ToString();
+            (CellMovementTransition transition, RoomLayer _) = MovementTransition(voyeur);
+            switch (transition)
+            {
+                case CellMovementTransition.SwimOnly:
+                    startColourString = Telnet.BoldBlue.ToString();
+                    endColourString = Telnet.RESET + Telnet.Green.ToString();
+                    break;
+                case CellMovementTransition.FallExit:
+                    if (IsClimbExit)
+                    {
+                        startColourString = Telnet.Yellow.ToString();
+                        endColourString = Telnet.Green.ToString();
+                        break;
+                    }
+
+                    startColourString = Telnet.Red.ToString();
                     endColourString = Telnet.Green.ToString();
                     break;
-                }
+                case CellMovementTransition.FlyOnly:
+                    if (IsClimbExit)
+                    {
+                        startColourString = Telnet.Yellow.ToString();
+                        endColourString = Telnet.Green.ToString();
+                        break;
+                    }
 
-                startColourString = Telnet.Red.ToString();
-                endColourString = Telnet.Green.ToString();
-                break;
-            case CellMovementTransition.FlyOnly:
-                if (IsClimbExit)
-                {
-                    startColourString = Telnet.Yellow.ToString();
-                    endColourString = Telnet.Green.ToString();
+                    startColourString = Telnet.BoldCyan.ToString();
+                    endColourString = Telnet.RESET + Telnet.Green.ToString();
                     break;
-                }
+            }
 
-                startColourString = Telnet.BoldCyan.ToString();
-                endColourString = Telnet.RESET + Telnet.Green.ToString();
-                break;
+            if (string.IsNullOrEmpty(startColourString))
+            {
+                (startColourString, endColourString) = DoorCapableExitDescriptionColour();
+            }
         }
 
         string dirString = OutboundDirection.Describe();
@@ -153,6 +161,13 @@ public class CellExit : ICellExit
             ? $" ({Exit.Door.State.Describe().ToLowerInvariant()} {Exit.Door.InstalledExitDescription(voyeur)})"
             : "";
         return $"{startColourString}{dirString}{doorString}{endColourString}";
+    }
+
+    protected (string StartColourString, string EndColourString) DoorCapableExitDescriptionColour()
+    {
+        return Exit.AcceptsDoor && Exit.Door is null
+            ? (Telnet.BoldWhite.ToString(), Telnet.RESET + Telnet.Green.ToString())
+            : ("", "");
     }
 
     public virtual string BuilderInformationString(IPerceiver voyeur)

--- a/MudSharpCore/Construction/Boundary/NonCardinalCellExit.cs
+++ b/MudSharpCore/Construction/Boundary/NonCardinalCellExit.cs
@@ -92,15 +92,22 @@ public class NonCardinalCellExit : CellExit, INonCardinalCellExit
     {
         string startColourString = "";
         string endColourString = "";
-        if (IsFallExit)
+        if (colour)
         {
-            startColourString = Telnet.Red.ToString();
-            endColourString = Telnet.Green.ToString();
-        }
-        else if (IsClimbExit)
-        {
-            startColourString = Telnet.Yellow.ToString();
-            endColourString = Telnet.Green.ToString();
+            if (IsFallExit)
+            {
+                startColourString = Telnet.Red.ToString();
+                endColourString = Telnet.Green.ToString();
+            }
+            else if (IsClimbExit)
+            {
+                startColourString = Telnet.Yellow.ToString();
+                endColourString = Telnet.Green.ToString();
+            }
+            else
+            {
+                (startColourString, endColourString) = DoorCapableExitDescriptionColour();
+            }
         }
 
         return


### PR DESCRIPTION
## Summary
- Added a visual indicator for exits that accept a door but do not currently have one installed, using `Telnet.BoldWhite` in exit descriptions.
- Kept existing swim/fall/fly/climb colouring as the higher-priority signal, so movement warnings still win.
- Updated the room-building guide to mention the new player-facing cue.
- Added unit coverage for cardinal and non-cardinal exits, `colour: false`, and warning-colour precedence.

## Testing
- Passed `MudSharpCore Unit Tests` with the new exit-description tests included.
- Full core test pass completed successfully: `681/681` tests passed.