### PR TITLE
Fix stock terrain atmosphere seeding order

### DIFF
--- a/DatabaseSeeder Unit Tests/CoreDataSeederTerrainTests.cs
+++ b/DatabaseSeeder Unit Tests/CoreDataSeederTerrainTests.cs
@@ -188,6 +188,31 @@ public class CoreDataSeederTerrainTests
     }
 
     [TestMethod]
+    public void SeedTerrainFoundationsForTesting_SeedsBreathableAtmosphereForStockTerrains()
+    {
+        using FuturemudDatabaseContext context = BuildContext();
+
+        SeedTerrainFoundations(context);
+
+        Gas breathableAtmosphere = context.Gases.Single(x => x.Name == "Breathable Atmosphere");
+        foreach (string terrainName in new[]
+                 { "Void", "Residence", "Grasslands", "Ocean", "Zero-G Spaceship Compartment" })
+        {
+            Terrain terrain = context.Terrains.Single(x => x.Name == terrainName);
+            Assert.AreEqual(breathableAtmosphere.Id, terrain.AtmosphereId,
+                $"Expected terrain {terrainName} to use the stock breathable atmosphere.");
+            Assert.AreEqual("Gas", terrain.AtmosphereType);
+        }
+
+        foreach (string terrainName in new[]
+                 { "Deep Ocean", "Moon Surface", "Lunar Mare", "Asteroid Surface", "Orbital Space", "Interstellar Space" })
+        {
+            Assert.IsNull(context.Terrains.Single(x => x.Name == terrainName).AtmosphereId,
+                $"Expected terrain {terrainName} to remain without a breathable atmosphere.");
+        }
+    }
+
+    [TestMethod]
     public void SeedTerrainFoundationsForTesting_RerunDoesNotDuplicateTagsOrTerrains()
     {
         using FuturemudDatabaseContext context = BuildContext();
@@ -405,9 +430,32 @@ public class CoreDataSeederTerrainTests
         Terrain ocean = context.Terrains.Single(x => x.Name == "Ocean");
         Terrain orbitalSpace = context.Terrains.Single(x => x.Name == "Orbital Space");
         Terrain moonSurface = context.Terrains.Single(x => x.Name == "Moon Surface");
+        Gas breathableAtmosphere = context.Gases.Single(x => x.Name == "Breathable Atmosphere");
+        Gas customAtmosphere = new()
+        {
+            Id = 2,
+            Name = "Builder Custom Atmosphere",
+            Description = "A builder-custom atmosphere",
+            Density = 0.002,
+            ThermalConductivity = 0.02,
+            ElectricalConductivity = 0.000001,
+            Organic = false,
+            SpecificHeatCapacity = 1.0,
+            BoilingPoint = -150,
+            DisplayColour = "green",
+            Viscosity = 10,
+            SmellIntensity = 0,
+            SmellText = "It has no smell",
+            VagueSmellText = "It has no smell"
+        };
+        context.Gases.Add(customAtmosphere);
 
         grasslands.ForagableProfileId = customProfile.Id;
+        grasslands.AtmosphereId = null;
+        grasslands.AtmosphereType = "Gas";
         ocean.ForagableProfileId = 999999L;
+        ocean.AtmosphereId = customAtmosphere.Id;
+        ocean.AtmosphereType = "Gas";
         orbitalSpace.GravityModel = (int)GravityModel.Normal;
         moonSurface.GravityModel = (int)GravityModel.ZeroGravity;
         context.SaveChanges();
@@ -416,11 +464,17 @@ public class CoreDataSeederTerrainTests
 
         Assert.AreEqual(customProfile.Id, context.Terrains.Single(x => x.Name == "Grasslands").ForagableProfileId,
             "Expected rerun to preserve terrain assignments to a valid custom forage profile.");
+        Assert.AreEqual(breathableAtmosphere.Id, context.Terrains.Single(x => x.Name == "Grasslands").AtmosphereId,
+            "Expected rerun to repair stock terrains that were seeded before the breathable atmosphere existed.");
+        Assert.IsNull(context.Terrains.Single(x => x.Name == "Moon Surface").AtmosphereId,
+            "Expected rerun to leave vacuum stock terrains without a breathable atmosphere.");
 
         Terrain repairedOcean = context.Terrains.Single(x => x.Name == "Ocean");
         ForagableProfile oceanStockProfile = context.ForagableProfiles.Single(x => x.Name == "Ocean Stock Forage");
         Assert.AreEqual(oceanStockProfile.Id, repairedOcean.ForagableProfileId,
             "Expected rerun to repair terrain assignments that point at no current forage profile.");
+        Assert.AreEqual(customAtmosphere.Id, repairedOcean.AtmosphereId,
+            "Expected rerun to preserve builder-customized stock terrain atmospheres.");
         Assert.AreEqual((int)GravityModel.ZeroGravity, context.Terrains.Single(x => x.Name == "Orbital Space").GravityModel,
             "Expected rerun to repair orbital space to zero gravity.");
         Assert.AreEqual((int)GravityModel.Normal, context.Terrains.Single(x => x.Name == "Moon Surface").GravityModel,

--- a/DatabaseSeeder/Seeders/CoreDataSeeder.Terrain.cs
+++ b/DatabaseSeeder/Seeders/CoreDataSeeder.Terrain.cs
@@ -865,6 +865,83 @@ public partial class CoreDataSeeder
 		return profile;
 	}
 
+	internal static Gas EnsureBreathableAtmosphere(FuturemudDatabaseContext context)
+	{
+		var atmosphere = context.Gases
+			.AsEnumerable()
+			.FirstOrDefault(x => x.Name.Equals("Breathable Atmosphere", StringComparison.OrdinalIgnoreCase));
+		if (atmosphere is not null)
+		{
+			return atmosphere;
+		}
+
+		var nextGasId = context.Gases.Any(x => x.Id == 1L)
+			? context.Gases.Select(x => x.Id).AsEnumerable().DefaultIfEmpty(0L).Max() + 1L
+			: 1L;
+		atmosphere = new Gas
+		{
+			Id = nextGasId,
+			Name = "Breathable Atmosphere",
+			Description = "Breathable Air",
+			Density = 0.001205,
+			ThermalConductivity = 0.0257,
+			ElectricalConductivity = 0.000005,
+			Organic = false,
+			SpecificHeatCapacity = 1.005,
+			BoilingPoint = -200,
+			DisplayColour = "blue",
+			Viscosity = 15,
+			SmellIntensity = 0,
+			SmellText = "It has no smell",
+			VagueSmellText = "It has no smell"
+		};
+		context.Gases.Add(atmosphere);
+		context.SaveChanges();
+
+		return atmosphere;
+	}
+
+	private static void BackfillStockTerrainAtmospheres(FuturemudDatabaseContext context,
+		IReadOnlyDictionary<string, string?> stockTerrainAtmospheres)
+	{
+		var atmosphereIds = stockTerrainAtmospheres
+			.Values
+			.Where(x => !string.IsNullOrWhiteSpace(x))
+			.Select(x => x!)
+			.Distinct(StringComparer.OrdinalIgnoreCase)
+			.ToDictionary(
+				x => x,
+				x => context.Gases
+					.AsEnumerable()
+					.FirstOrDefault(y => y.Name.Equals(x, StringComparison.OrdinalIgnoreCase))?.Id,
+				StringComparer.OrdinalIgnoreCase);
+
+		foreach (var terrain in context.Terrains.AsEnumerable())
+		{
+			if (terrain.AtmosphereId is not null)
+			{
+				continue;
+			}
+
+			if (!stockTerrainAtmospheres.TryGetValue(terrain.Name, out var atmosphereName) ||
+			    string.IsNullOrWhiteSpace(atmosphereName))
+			{
+				continue;
+			}
+
+			if (!atmosphereIds.TryGetValue(atmosphereName, out var atmosphereId) ||
+			    atmosphereId is null)
+			{
+				continue;
+			}
+
+			terrain.AtmosphereId = atmosphereId.Value;
+			terrain.AtmosphereType = "Gas";
+		}
+
+		context.SaveChanges();
+	}
+
 	private static void BackfillStockTerrainGravity(FuturemudDatabaseContext context)
 	{
 		var zeroGravityTerrains = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
@@ -892,21 +969,33 @@ public partial class CoreDataSeeder
     internal static void SeedStockTerrainCatalogue(FuturemudDatabaseContext context, DictionaryWithDefault<string, Tag> tagLookup,
         ICollection<string>? errors = null)
     {
-        if (context.Terrains.Count() > 1)
-        {
-			SeedStockTerrainForageProfiles(context);
-			BackfillStockTerrainGravity(context);
-			errors?.Add("Terrains were already installed, so did not add any new terrain data. Missing stock forage profiles and stock gravity models were repaired or backfilled where safe.");
-            return;
-        }
+	    var breathableAtmosphere = EnsureBreathableAtmosphere(context);
+	    var terrainsAlreadyInstalled = context.Terrains.Count() > 1;
 
-        context.Terrains.Find(1L)!.DefaultTerrain = false;
+	    if (!terrainsAlreadyInstalled)
+	    {
+		    var voidTerrain = context.Terrains.Find(1L)!;
+		    voidTerrain.DefaultTerrain = false;
+		    voidTerrain.AtmosphereId = breathableAtmosphere.Id;
+		    voidTerrain.AtmosphereType = "Gas";
+	    }
+
+	    var stockTerrainAtmospheres = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+	    {
+		    ["Void"] = "Breathable Atmosphere"
+	    };
 
         void AddTerrain(string name, string behaviour, double movementRate, double staminaCost,
             Difficulty hideDifficulty, Difficulty spotDifficulty, string? atmosphere, CellOutdoorsType outdoorsType,
             Color editorColour, string? editorText = null, bool isdefault = false, IEnumerable<string>? tags = null,
             GravityModel gravityModel = GravityModel.Normal)
         {
+	        stockTerrainAtmospheres[name] = atmosphere;
+	        if (terrainsAlreadyInstalled)
+	        {
+		        return;
+	        }
+
             context.Terrains.Add(new Terrain
             {
                 Name = name,
@@ -1353,6 +1442,15 @@ public partial class CoreDataSeeder
             gravityModel: GravityModel.ZeroGravity);
 
         #endregion
+
+		if (terrainsAlreadyInstalled)
+		{
+			BackfillStockTerrainAtmospheres(context, stockTerrainAtmospheres);
+			SeedStockTerrainForageProfiles(context);
+			BackfillStockTerrainGravity(context);
+			errors?.Add("Terrains were already installed, so did not add any new terrain data. Missing stock atmospheres, stock forage profiles, and stock gravity models were repaired or backfilled where safe.");
+			return;
+		}
 
 		SeedStockTerrainForageProfiles(context);
 

--- a/DatabaseSeeder/Seeders/CoreDataSeeder.cs
+++ b/DatabaseSeeder/Seeders/CoreDataSeeder.cs
@@ -1198,6 +1198,7 @@ public partial class CoreDataSeeder : IDatabaseSeeder
         };
         context.Rooms.Add(room);
 
+        Gas breathableAtmosphere = EnsureBreathableAtmosphere(context);
         Terrain terrain = new()
         {
             Id = 1,
@@ -1211,6 +1212,8 @@ public partial class CoreDataSeeder : IDatabaseSeeder
             TerrainEditorColour = "#FFFFFFFF",
             TerrainBehaviourMode = "outdoors",
             DefaultTerrain = true,
+            AtmosphereId = breathableAtmosphere.Id,
+            AtmosphereType = "Gas"
         };
         context.Terrains.Add(terrain);
         SeedTerrainFoundations(context);
@@ -1238,6 +1241,8 @@ public partial class CoreDataSeeder : IDatabaseSeeder
             HearingProfile = seededHearingProfiles["Universal"],
             OutdoorsType = 0,
             AmbientLightFactor = 1.0,
+            AtmosphereId = breathableAtmosphere.Id,
+            AtmosphereType = "Gas",
             CellId = cell.Id
         };
         context.CellOverlays.Add(overlay);

--- a/DatabaseSeeder/Seeders/HumanSeeder.cs
+++ b/DatabaseSeeder/Seeders/HumanSeeder.cs
@@ -1888,25 +1888,7 @@ $?hairstyle[&he has &?a_an[$haircolour $hairstyle]][&he is completely bald].$?fa
 
         #region Breathable Air
 
-        Gas air = new()
-        {
-            Id = 1,
-            Name = "Breathable Atmosphere",
-            Description = "Breathable Air",
-            Density = 0.001205,
-            ThermalConductivity = 0.0257,
-            ElectricalConductivity = 0.000005,
-            Organic = false,
-            SpecificHeatCapacity = 1.005,
-            BoilingPoint = -200,
-            DisplayColour = "blue",
-            Viscosity = 15,
-            SmellIntensity = 0,
-            SmellText = "It has no smell",
-            VagueSmellText = "It has no smell"
-        };
-        _context.Gases.Add(air);
-        _context.SaveChanges();
+        Gas air = CoreDataSeeder.EnsureBreathableAtmosphere(_context);
 
         _context.Terrains.First().AtmosphereId = air.Id;
         _context.Terrains.First().AtmosphereType = "Gas";


### PR DESCRIPTION
## Summary
- Move the stock `Breathable Atmosphere` gas into `CoreDataSeeder` so terrain seeding can resolve it during initial install.
- Reuse the same helper from `HumanSeeder` to avoid duplicate gas creation.
- Add rerun repair logic for stock terrains that were seeded without an atmosphere, while preserving builder-custom atmosphere assignments.
- Add regression tests covering fresh install and rerun behavior.

## Testing
- `dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore --filter CoreDataSeederTerrainTests -m:1 -p:NoWarn=NU1902%3BNU1510`
- `dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`