### PR TITLE
Expand seeded gas catalogue and assign terrain-specific atmospheres

### DIFF
--- a/DatabaseSeeder Unit Tests/CoreDataSeederGasTests.cs
+++ b/DatabaseSeeder Unit Tests/CoreDataSeederGasTests.cs
@@ -1,0 +1,114 @@
+#nullable enable
+
+using DatabaseSeeder.Seeders;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Database;
+using MudSharp.GameItems;
+using MudSharp.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class CoreDataSeederGasTests
+{
+	private static FuturemudDatabaseContext BuildContext()
+	{
+		DbContextOptions<FuturemudDatabaseContext> options = new DbContextOptionsBuilder<FuturemudDatabaseContext>()
+			.UseInMemoryDatabase(Guid.NewGuid().ToString())
+			.ConfigureWarnings(x => x.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+			.Options;
+		return new FuturemudDatabaseContext(options);
+	}
+
+	[TestMethod]
+	public void EnsureStockGases_SeedsBreathableVariantsAndEconomicCatalogue()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+
+		CoreDataSeeder.EnsureStockGases(context);
+
+		Assert.IsTrue(CoreDataSeeder.StockBreathableAtmosphereGasNamesForTesting.Count >= 10,
+			"Expected several stock breathable atmosphere variants.");
+		Assert.IsTrue(CoreDataSeeder.StockEconomicGasNamesForTesting.Count >= 30,
+			"Expected at least 30 non-atmosphere stock gases.");
+		Assert.IsTrue(CoreDataSeeder.StockEconomicGasNamesForTesting.Count <= 50,
+			"Expected no more than 50 non-atmosphere stock gases in this first pass.");
+		Assert.AreEqual(CoreDataSeeder.StockGasNamesForTesting.Count, context.Gases.Count());
+
+		foreach (string gasName in CoreDataSeeder.StockGasNamesForTesting)
+		{
+			Assert.AreEqual(1, context.Gases.Count(x => x.Name == gasName),
+				$"Expected a single stock gas named {gasName}.");
+		}
+
+		Dictionary<string, Gas> gases = context.Gases.ToDictionary(x => x.Name, StringComparer.OrdinalIgnoreCase);
+		Gas breathableAtmosphere = gases["Breathable Atmosphere"];
+		Assert.AreEqual(1L, breathableAtmosphere.Id);
+		Assert.IsNull(breathableAtmosphere.CountAsId);
+		Assert.IsNull(breathableAtmosphere.CountsAsQuality);
+
+		foreach (string gasName in CoreDataSeeder.StockBreathableAtmosphereGasNamesForTesting
+			         .Where(x => !x.Equals("Breathable Atmosphere", StringComparison.OrdinalIgnoreCase)))
+		{
+			Assert.AreEqual(breathableAtmosphere.Id, gases[gasName].CountAsId,
+				$"Expected {gasName} to count as the canonical breathable atmosphere.");
+			Assert.IsNotNull(gases[gasName].CountsAsQuality,
+				$"Expected {gasName} to declare a breathable quality multiplier.");
+		}
+
+		Assert.AreEqual((int)ItemQuality.Great, gases["High Altitude Breathable Atmosphere"].CountsAsQuality);
+		Assert.AreEqual((int)ItemQuality.Standard, gases["Very Thin Breathable Atmosphere"].CountsAsQuality);
+		Assert.AreEqual((int)ItemQuality.Legendary, gases["Oxygen-Enriched Breathable Atmosphere"].CountsAsQuality);
+		Assert.IsTrue(gases["High-Oxygen Breathable Atmosphere"].OxidationFactor > breathableAtmosphere.OxidationFactor);
+
+		foreach (string gasName in new[]
+		         {
+			         "Hydrogen", "Chlorine", "Nitrogen", "Natural Gas", "Acetylene", "Carbon Dioxide", "Propane",
+			         "Butane", "Neon", "Argon", "Ethylene", "Nitrous Oxide"
+		         })
+		{
+			Assert.IsTrue(gases.ContainsKey(gasName), $"Expected stock economic gas {gasName} to be seeded.");
+		}
+
+		Assert.AreEqual(gases["Methane"].Id, gases["Natural Gas"].CountAsId);
+		Assert.AreEqual((int)ItemQuality.Good, gases["Natural Gas"].CountsAsQuality);
+		Assert.AreEqual(gases["Propane"].Id, gases["Liquefied Petroleum Gas"].CountAsId);
+		Assert.AreEqual(gases["Butane"].Id, gases["Isobutane"].CountAsId);
+
+		foreach (string tagName in new[]
+		         {
+			         "Gases", "Breathable Atmospheres", "Industrial Gases", "Elemental Gases", "Fuel Gases",
+			         "Medical Gases", "Noble Gases", "Refrigerant Gases"
+		         })
+		{
+			Assert.AreEqual(1, context.Tags.Count(x => x.Name == tagName),
+				$"Expected a single stock gas tag named {tagName}.");
+		}
+	}
+
+	[TestMethod]
+	public void EnsureStockGases_RerunPreservesIdsAndDoesNotDuplicateTags()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+
+		CoreDataSeeder.EnsureStockGases(context);
+		Dictionary<string, long> originalIds = context.Gases.ToDictionary(x => x.Name, x => x.Id);
+		CoreDataSeeder.EnsureStockGases(context);
+
+		Assert.AreEqual(CoreDataSeeder.StockGasNamesForTesting.Count, context.Gases.Count());
+		foreach ((string gasName, long gasId) in originalIds)
+		{
+			Assert.AreEqual(gasId, context.Gases.Single(x => x.Name == gasName).Id,
+				$"Expected rerun to preserve the ID for {gasName}.");
+		}
+
+		Assert.IsFalse(context.GasesTags
+			.GroupBy(x => new { x.GasId, x.TagId })
+			.Any(x => x.Count() > 1), "Expected rerun not to duplicate gas tag links.");
+	}
+}

--- a/DatabaseSeeder Unit Tests/CoreDataSeederTerrainTests.cs
+++ b/DatabaseSeeder Unit Tests/CoreDataSeederTerrainTests.cs
@@ -194,21 +194,36 @@ public class CoreDataSeederTerrainTests
 
         SeedTerrainFoundations(context);
 
-        Gas breathableAtmosphere = context.Gases.Single(x => x.Name == "Breathable Atmosphere");
-        foreach (string terrainName in new[]
-                 { "Void", "Residence", "Grasslands", "Ocean", "Zero-G Spaceship Compartment" })
+        Dictionary<string, Gas> gases = context.Gases.ToDictionary(x => x.Name, StringComparer.OrdinalIgnoreCase);
+
+        void AssertGasAtmosphere(string terrainName, string gasName)
         {
             Terrain terrain = context.Terrains.Single(x => x.Name == terrainName);
-            Assert.AreEqual(breathableAtmosphere.Id, terrain.AtmosphereId,
-                $"Expected terrain {terrainName} to use the stock breathable atmosphere.");
+            Assert.AreEqual(gases[gasName].Id, terrain.AtmosphereId,
+                $"Expected terrain {terrainName} to use {gasName}.");
             Assert.AreEqual("Gas", terrain.AtmosphereType);
         }
 
+        AssertGasAtmosphere("Void", "Breathable Atmosphere");
+        AssertGasAtmosphere("Residence", "Breathable Atmosphere");
+        AssertGasAtmosphere("Grasslands", "Breathable Atmosphere");
+        AssertGasAtmosphere("Cave", "Stale Breathable Atmosphere");
+        AssertGasAtmosphere("Ocean", "Humid Breathable Atmosphere");
+        AssertGasAtmosphere("Plateau", "High Altitude Breathable Atmosphere");
+        AssertGasAtmosphere("Mountain Ridge", "Thin Breathable Atmosphere");
+        AssertGasAtmosphere("Volcanic Plain", "Sulfurous Breathable Atmosphere");
+        AssertGasAtmosphere("Zero-G Spaceship Compartment", "Pressurized Breathable Atmosphere");
+
+        Terrain deepOcean = context.Terrains.Single(x => x.Name == "Deep Ocean");
+        Assert.AreEqual(context.Liquids.Single(x => x.Name == "salt water").Id, deepOcean.AtmosphereId,
+            "Expected Deep Ocean to use salt water as its liquid atmosphere.");
+        Assert.AreEqual("Liquid", deepOcean.AtmosphereType);
+
         foreach (string terrainName in new[]
-                 { "Deep Ocean", "Moon Surface", "Lunar Mare", "Asteroid Surface", "Orbital Space", "Interstellar Space" })
+                 { "Moon Surface", "Lunar Mare", "Asteroid Surface", "Orbital Space", "Interstellar Space" })
         {
             Assert.IsNull(context.Terrains.Single(x => x.Name == terrainName).AtmosphereId,
-                $"Expected terrain {terrainName} to remain without a breathable atmosphere.");
+                $"Expected terrain {terrainName} to remain without an atmosphere.");
         }
     }
 
@@ -431,9 +446,10 @@ public class CoreDataSeederTerrainTests
         Terrain orbitalSpace = context.Terrains.Single(x => x.Name == "Orbital Space");
         Terrain moonSurface = context.Terrains.Single(x => x.Name == "Moon Surface");
         Gas breathableAtmosphere = context.Gases.Single(x => x.Name == "Breathable Atmosphere");
+        long customAtmosphereId = context.Gases.Select(x => x.Id).AsEnumerable().DefaultIfEmpty(0L).Max() + 1L;
         Gas customAtmosphere = new()
         {
-            Id = 2,
+            Id = customAtmosphereId,
             Name = "Builder Custom Atmosphere",
             Description = "A builder-custom atmosphere",
             Density = 0.002,

--- a/DatabaseSeeder/Seeders/CoreDataSeeder.Gases.cs
+++ b/DatabaseSeeder/Seeders/CoreDataSeeder.Gases.cs
@@ -1,0 +1,336 @@
+#nullable enable
+
+using MudSharp.Database;
+using MudSharp.GameItems;
+using MudSharp.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DatabaseSeeder.Seeders;
+
+public partial class CoreDataSeeder
+{
+	private sealed record StockGasDefinition(
+		string Name,
+		string Description,
+		double Density,
+		double BoilingPoint,
+		string DisplayColour,
+		string SmellText,
+		string VagueSmellText,
+		double SmellIntensity,
+		double OxidationFactor,
+		string? CountAsName,
+		ItemQuality? CountAsQuality,
+		bool Organic,
+		IReadOnlyCollection<string> Tags)
+	{
+		public double ThermalConductivity { get; init; } = 0.0257;
+		public double ElectricalConductivity { get; init; } = 0.000005;
+		public double SpecificHeatCapacity { get; init; } = 1.005;
+		public double Viscosity { get; init; } = 15.0;
+	}
+
+	private static readonly (string Name, string? Parent)[] StockGasTagDefinitions =
+	[
+		("Gases", "Materials"),
+		("Breathable Atmospheres", "Gases"),
+		("Industrial Gases", "Gases"),
+		("Elemental Gases", "Gases"),
+		("Fuel Gases", "Industrial Gases"),
+		("Medical Gases", "Industrial Gases"),
+		("Noble Gases", "Elemental Gases"),
+		("Refrigerant Gases", "Industrial Gases")
+	];
+
+	private static readonly IReadOnlyCollection<StockGasDefinition> StockGasDefinitions = BuildStockGasDefinitions();
+
+	internal static IReadOnlyCollection<string> StockGasNamesForTesting =>
+		StockGasDefinitions
+			.Select(x => x.Name)
+			.ToArray();
+
+	internal static IReadOnlyCollection<string> StockBreathableAtmosphereGasNamesForTesting =>
+		StockGasDefinitions
+			.Where(x => x.Tags.Contains("Breathable Atmospheres", StringComparer.OrdinalIgnoreCase))
+			.Select(x => x.Name)
+			.ToArray();
+
+	internal static IReadOnlyCollection<string> StockEconomicGasNamesForTesting =>
+		StockGasDefinitions
+			.Where(x => !x.Tags.Contains("Breathable Atmospheres", StringComparer.OrdinalIgnoreCase))
+			.Select(x => x.Name)
+			.ToArray();
+
+	private static IReadOnlyCollection<StockGasDefinition> BuildStockGasDefinitions()
+	{
+		static StockGasDefinition Gas(
+			string name,
+			string description,
+			double density,
+			double boilingPoint,
+			string colour = "cyan",
+			string smell = "It has no smell",
+			string? vagueSmell = null,
+			double smellIntensity = 0.0,
+			double oxidationFactor = 0.0,
+			string? countAs = null,
+			ItemQuality? countAsQuality = null,
+			bool organic = false,
+			params string[] tags)
+		{
+			return new StockGasDefinition(
+				name,
+				description,
+				density,
+				boilingPoint,
+				colour,
+				smell,
+				vagueSmell ?? smell,
+				smellIntensity,
+				oxidationFactor,
+				countAs,
+				countAsQuality,
+				organic,
+				tags);
+		}
+
+		static StockGasDefinition Breathable(
+			string name,
+			string description,
+			ItemQuality? countAsQuality,
+			double density = 0.001205,
+			double oxidationFactor = 1.0,
+			string smell = "It has no smell",
+			string? vagueSmell = null,
+			double smellIntensity = 0.0)
+		{
+			return Gas(
+				name,
+				description,
+				density,
+				-200.0,
+				"blue",
+				smell,
+				vagueSmell,
+				smellIntensity,
+				oxidationFactor,
+				name.Equals("Breathable Atmosphere", StringComparison.OrdinalIgnoreCase) ? null : "Breathable Atmosphere",
+				countAsQuality,
+				tags: ["Breathable Atmospheres"]);
+		}
+
+		return
+		[
+			Breathable("Breathable Atmosphere", "Breathable Air", null),
+			Breathable("Fresh Breathable Atmosphere", "clean, fresh breathable air", ItemQuality.Legendary,
+				smell: "It smells clean and fresh", vagueSmell: "It smells fresh", smellIntensity: 0.5),
+			Breathable("Filtered Breathable Atmosphere", "filtered breathable air", ItemQuality.Legendary),
+			Breathable("Pressurized Breathable Atmosphere", "pressurized breathable air", ItemQuality.Legendary,
+				density: 0.0015),
+			Breathable("Humid Breathable Atmosphere", "humid breathable air", ItemQuality.Heroic,
+				density: 0.00124, smell: "It smells faintly damp", vagueSmell: "It smells damp", smellIntensity: 0.5),
+			Breathable("Hot Humid Breathable Atmosphere", "hot, humid breathable air", ItemQuality.Excellent,
+				density: 0.00112, smell: "It smells warm and damp", vagueSmell: "It smells damp", smellIntensity: 0.7),
+			Breathable("Cold Dry Breathable Atmosphere", "cold, dry breathable air", ItemQuality.Excellent,
+				density: 0.00135),
+			Breathable("Stale Breathable Atmosphere", "stale breathable air", ItemQuality.Great,
+				smell: "It smells stale", vagueSmell: "It smells stale", smellIntensity: 1.5),
+			Breathable("Polluted Breathable Atmosphere", "polluted but breathable air", ItemQuality.Good,
+				smell: "It smells dirty and chemical", vagueSmell: "It smells polluted", smellIntensity: 2.5),
+			Breathable("Smoke-Tainted Breathable Atmosphere", "smoke-tainted breathable air", ItemQuality.Substandard,
+				smell: "It smells of smoke", vagueSmell: "It smells smoky", smellIntensity: 3.0),
+			Breathable("Sulfurous Breathable Atmosphere", "sulfurous but breathable air", ItemQuality.Poor,
+				smell: "It has a sharp sulfurous tang", vagueSmell: "It smells sulfurous", smellIntensity: 3.5),
+			Breathable("High Altitude Breathable Atmosphere", "thin high-altitude breathable air", ItemQuality.Great,
+				density: 0.0009),
+			Breathable("Thin Breathable Atmosphere", "thin breathable air", ItemQuality.Good,
+				density: 0.00065),
+			Breathable("Very Thin Breathable Atmosphere", "very thin breathable air", ItemQuality.Standard,
+				density: 0.0004),
+			Breathable("Oxygen-Enriched Breathable Atmosphere", "oxygen-enriched breathable air", ItemQuality.Legendary,
+				density: 0.00132, oxidationFactor: 1.4),
+			Breathable("High-Oxygen Breathable Atmosphere", "high-oxygen breathable air", ItemQuality.Legendary,
+				density: 0.00145, oxidationFactor: 2.0),
+
+			Gas("Hydrogen", "hydrogen gas", 0.0000899, -252.9, "white", tags: ["Industrial Gases", "Elemental Gases", "Fuel Gases"]),
+			Gas("Helium", "helium gas", 0.0001785, -268.9, "cyan", tags: ["Industrial Gases", "Elemental Gases", "Noble Gases"]),
+			Gas("Nitrogen", "nitrogen gas", 0.001251, -195.8, "cyan", tags: ["Industrial Gases", "Elemental Gases"]),
+			Gas("Oxygen", "oxygen gas", 0.001429, -183.0, "blue", oxidationFactor: 4.76, tags: ["Industrial Gases", "Elemental Gases", "Medical Gases"]),
+			Gas("Fluorine", "fluorine gas", 0.001696, -188.1, "yellow", smell: "It has a sharp chemical smell", vagueSmell: "It smells sharply chemical", smellIntensity: 4.0, oxidationFactor: 3.0, tags: ["Industrial Gases", "Elemental Gases"]),
+			Gas("Chlorine", "chlorine gas", 0.003214, -34.0, "green", smell: "It has a sharp bleach-like smell", vagueSmell: "It smells like bleach", smellIntensity: 5.0, oxidationFactor: 0.8, tags: ["Industrial Gases", "Elemental Gases"]),
+			Gas("Neon", "neon gas", 0.000900, -246.1, "magenta", tags: ["Industrial Gases", "Elemental Gases", "Noble Gases"]),
+			Gas("Argon", "argon gas", 0.001784, -185.8, "cyan", tags: ["Industrial Gases", "Elemental Gases", "Noble Gases"]),
+			Gas("Krypton", "krypton gas", 0.003749, -153.4, "cyan", tags: ["Industrial Gases", "Elemental Gases", "Noble Gases"]),
+			Gas("Xenon", "xenon gas", 0.005894, -108.1, "cyan", tags: ["Industrial Gases", "Elemental Gases", "Noble Gases"]),
+			Gas("Ozone", "ozone gas", 0.002144, -112.0, "blue", smell: "It has a sharp clean smell", vagueSmell: "It smells sharp and clean", smellIntensity: 2.0, oxidationFactor: 2.0, tags: ["Industrial Gases"]),
+
+			Gas("Carbon Dioxide", "carbon dioxide gas", 0.001977, -78.5, "white", tags: ["Industrial Gases"]),
+			Gas("Carbon Monoxide", "carbon monoxide gas", 0.001145, -191.5, "white", tags: ["Industrial Gases", "Fuel Gases"]),
+			Gas("Methane", "methane gas", 0.000657, -161.5, "yellow", organic: true, tags: ["Industrial Gases", "Fuel Gases"]),
+			Gas("Natural Gas", "natural gas", 0.00075, -161.5, "yellow", smell: "It has a faint sulfurous odorant smell", vagueSmell: "It smells faintly sulfurous", smellIntensity: 2.0, countAs: "Methane", countAsQuality: ItemQuality.Good, organic: true, tags: ["Industrial Gases", "Fuel Gases"]),
+			Gas("Ethane", "ethane gas", 0.001356, -88.6, "yellow", organic: true, tags: ["Industrial Gases", "Fuel Gases"]),
+			Gas("Propane", "propane gas", 0.001882, -42.1, "yellow", smell: "It has a faint fuel odorant smell", vagueSmell: "It smells faintly of fuel", smellIntensity: 2.0, organic: true, tags: ["Industrial Gases", "Fuel Gases"]),
+			Gas("Butane", "butane gas", 0.002489, -0.5, "yellow", smell: "It has a faint fuel odorant smell", vagueSmell: "It smells faintly of fuel", smellIntensity: 2.0, organic: true, tags: ["Industrial Gases", "Fuel Gases"]),
+			Gas("Isobutane", "isobutane gas", 0.00251, -11.7, "yellow", countAs: "Butane", countAsQuality: ItemQuality.Great, organic: true, tags: ["Industrial Gases", "Fuel Gases", "Refrigerant Gases"]),
+			Gas("Liquefied Petroleum Gas", "liquefied petroleum gas vapour", 0.0021, -42.0, "yellow", smell: "It has a fuel odorant smell", vagueSmell: "It smells of fuel", smellIntensity: 2.5, countAs: "Propane", countAsQuality: ItemQuality.Good, organic: true, tags: ["Industrial Gases", "Fuel Gases"]),
+			Gas("Acetylene", "acetylene gas", 0.001097, -84.0, "yellow", smell: "It has a faint garlic-like smell", vagueSmell: "It smells faintly garlicky", smellIntensity: 2.0, organic: true, tags: ["Industrial Gases", "Fuel Gases"]),
+			Gas("Ethylene", "ethylene gas", 0.001178, -103.7, "yellow", organic: true, tags: ["Industrial Gases", "Fuel Gases"]),
+			Gas("Propylene", "propylene gas", 0.00181, -47.6, "yellow", organic: true, tags: ["Industrial Gases", "Fuel Gases"]),
+			Gas("Dimethyl Ether", "dimethyl ether gas", 0.001918, -24.8, "yellow", smell: "It has a faint ether-like smell", vagueSmell: "It smells faintly ether-like", smellIntensity: 1.5, organic: true, tags: ["Industrial Gases", "Fuel Gases", "Refrigerant Gases"]),
+
+			Gas("Ammonia", "ammonia gas", 0.000769, -33.3, "green", smell: "It has a sharp ammonia smell", vagueSmell: "It smells sharply alkaline", smellIntensity: 5.0, tags: ["Industrial Gases"]),
+			Gas("Nitrous Oxide", "nitrous oxide gas", 0.001978, -88.5, "blue", oxidationFactor: 1.4, tags: ["Industrial Gases", "Medical Gases"]),
+			Gas("Nitric Oxide", "nitric oxide gas", 0.00134, -151.8, "green", oxidationFactor: 0.5, tags: ["Industrial Gases"]),
+			Gas("Nitrogen Dioxide", "nitrogen dioxide gas", 0.00205, 21.2, "red", smell: "It has a sharp acrid smell", vagueSmell: "It smells acrid", smellIntensity: 4.0, oxidationFactor: 0.7, tags: ["Industrial Gases"]),
+			Gas("Sulfur Dioxide", "sulfur dioxide gas", 0.002927, -10.0, "green", smell: "It smells like burnt matches", vagueSmell: "It smells sharply sulfurous", smellIntensity: 4.0, tags: ["Industrial Gases"]),
+			Gas("Hydrogen Sulfide", "hydrogen sulfide gas", 0.001539, -60.3, "green", smell: "It smells like rotten eggs", vagueSmell: "It smells rotten", smellIntensity: 8.0, tags: ["Industrial Gases"]),
+			Gas("Hydrogen Chloride", "hydrogen chloride gas", 0.00149, -85.1, "green", smell: "It has a sharp acidic smell", vagueSmell: "It smells acidic", smellIntensity: 4.0, tags: ["Industrial Gases"]),
+			Gas("Hydrogen Fluoride", "hydrogen fluoride gas", 0.000922, 19.5, "green", smell: "It has a sharp acidic smell", vagueSmell: "It smells acidic", smellIntensity: 4.0, tags: ["Industrial Gases"]),
+			Gas("Hydrogen Cyanide", "hydrogen cyanide gas", 0.000687, 25.6, "green", smell: "It has a faint bitter almond smell", vagueSmell: "It smells faintly bitter", smellIntensity: 1.5, organic: true, tags: ["Industrial Gases"]),
+			Gas("Sulfur Hexafluoride", "sulfur hexafluoride gas", 0.00617, -63.8, "cyan", tags: ["Industrial Gases"]),
+			Gas("Silane", "silane gas", 0.00144, -112.0, "yellow", organic: false, tags: ["Industrial Gases"]),
+			Gas("Phosphine", "phosphine gas", 0.00153, -87.7, "green", smell: "It has a garlic-like smell", vagueSmell: "It smells garlicky", smellIntensity: 3.0, tags: ["Industrial Gases"]),
+			Gas("Chlorine Dioxide", "chlorine dioxide gas", 0.00309, 11.0, "green", smell: "It has a sharp chlorine smell", vagueSmell: "It smells like chlorine", smellIntensity: 5.0, oxidationFactor: 1.0, tags: ["Industrial Gases"]),
+			Gas("Phosgene", "phosgene gas", 0.00425, 8.2, "green", smell: "It smells faintly of musty hay", vagueSmell: "It smells musty", smellIntensity: 2.0, organic: true, tags: ["Industrial Gases"]),
+
+			Gas("Steam", "water vapour", 0.000598, 100.0, "white", tags: ["Industrial Gases"]),
+			Gas("Methyl Chloride", "methyl chloride gas", 0.00222, -24.2, "green", smell: "It has a faint sweet smell", vagueSmell: "It smells faintly sweet", smellIntensity: 1.5, organic: true, tags: ["Industrial Gases", "Refrigerant Gases"]),
+			Gas("Methyl Bromide", "methyl bromide gas", 0.00397, 3.6, "green", smell: "It has a faint sweet smell", vagueSmell: "It smells faintly sweet", smellIntensity: 1.5, organic: true, tags: ["Industrial Gases"]),
+			Gas("Refrigerant R-134a", "R-134a refrigerant gas", 0.00425, -26.3, "cyan", organic: true, tags: ["Industrial Gases", "Refrigerant Gases"]),
+			Gas("Difluoromethane", "difluoromethane gas", 0.00228, -51.7, "cyan", organic: true, tags: ["Industrial Gases", "Refrigerant Gases"]),
+			Gas("Chlorodifluoromethane", "chlorodifluoromethane gas", 0.00366, -40.8, "cyan", organic: true, tags: ["Industrial Gases", "Refrigerant Gases"]),
+			Gas("Tetrafluoromethane", "tetrafluoromethane gas", 0.00372, -128.0, "cyan", organic: true, tags: ["Industrial Gases", "Refrigerant Gases"]),
+			Gas("Vinyl Chloride", "vinyl chloride gas", 0.00267, -13.4, "yellow", smell: "It has a faint sweet smell", vagueSmell: "It smells faintly sweet", smellIntensity: 1.5, organic: true, tags: ["Industrial Gases", "Fuel Gases"]),
+			Gas("Formaldehyde", "formaldehyde gas", 0.000815, -19.0, "green", smell: "It has a sharp resinous smell", vagueSmell: "It smells sharply resinous", smellIntensity: 4.0, organic: true, tags: ["Industrial Gases"]),
+			Gas("Landfill Gas", "landfill gas", 0.0010, -160.0, "yellow", smell: "It smells rotten and sulfurous", vagueSmell: "It smells rotten", smellIntensity: 5.0, countAs: "Methane", countAsQuality: ItemQuality.Substandard, organic: true, tags: ["Industrial Gases", "Fuel Gases"]),
+			Gas("Biogas", "biogas", 0.0011, -160.0, "yellow", smell: "It smells earthy and sulfurous", vagueSmell: "It smells earthy", smellIntensity: 3.0, countAs: "Methane", countAsQuality: ItemQuality.Standard, organic: true, tags: ["Industrial Gases", "Fuel Gases"]),
+			Gas("Synthesis Gas", "synthesis gas", 0.0010, -190.0, "yellow", countAs: "Hydrogen", countAsQuality: ItemQuality.Substandard, tags: ["Industrial Gases", "Fuel Gases"])
+		];
+	}
+
+	internal static IReadOnlyDictionary<string, Gas> EnsureStockGases(FuturemudDatabaseContext context)
+	{
+		var tags = EnsureStockGasTags(context);
+		var gases = context.Gases
+			.AsEnumerable()
+			.ToDictionary(x => x.Name, x => x, StringComparer.OrdinalIgnoreCase);
+		var nextGasId = context.Gases
+			.Select(x => x.Id)
+			.AsEnumerable()
+			.DefaultIfEmpty(0L)
+			.Max() + 1L;
+
+		foreach (var definition in StockGasDefinitions)
+		{
+			if (!gases.TryGetValue(definition.Name, out var gas))
+			{
+				gas = new Gas
+				{
+					Id = definition.Name.Equals("Breathable Atmosphere", StringComparison.OrdinalIgnoreCase) &&
+					     !context.Gases.Any(x => x.Id == 1L)
+						? 1L
+						: nextGasId++
+				};
+				if (gas.Id >= nextGasId)
+				{
+					nextGasId = gas.Id + 1L;
+				}
+
+				context.Gases.Add(gas);
+				gases[definition.Name] = gas;
+			}
+
+			gas.Name = definition.Name;
+			gas.Description = definition.Description;
+			gas.Density = definition.Density;
+			gas.ThermalConductivity = definition.ThermalConductivity;
+			gas.ElectricalConductivity = definition.ElectricalConductivity;
+			gas.Organic = definition.Organic;
+			gas.SpecificHeatCapacity = definition.SpecificHeatCapacity;
+			gas.BoilingPoint = definition.BoilingPoint;
+			gas.DisplayColour = definition.DisplayColour;
+			gas.Viscosity = definition.Viscosity;
+			gas.SmellIntensity = definition.SmellIntensity;
+			gas.SmellText = definition.SmellText;
+			gas.VagueSmellText = definition.VagueSmellText;
+			gas.OxidationFactor = definition.OxidationFactor;
+			gas.DrugId = null;
+			gas.DrugGramsPerUnitVolume = 0.0;
+			gas.PrecipitateId = null;
+			gas.CountsAsQuality = definition.CountAsQuality is null ? null : (int)definition.CountAsQuality.Value;
+		}
+
+		foreach (var definition in StockGasDefinitions.Where(x => !string.IsNullOrWhiteSpace(x.CountAsName)))
+		{
+			gases[definition.Name].CountAsId = gases[definition.CountAsName!].Id;
+		}
+
+		foreach (var definition in StockGasDefinitions.Where(x => string.IsNullOrWhiteSpace(x.CountAsName)))
+		{
+			gases[definition.Name].CountAsId = null;
+		}
+
+		context.SaveChanges();
+
+		foreach (var definition in StockGasDefinitions)
+		{
+			var gas = gases[definition.Name];
+			var existingTagIds = context.GasesTags
+				.Where(x => x.GasId == gas.Id)
+				.Select(x => x.TagId)
+				.ToHashSet();
+
+			foreach (var tag in definition.Tags.Select(x => tags[x]).Where(x => x is not null))
+			{
+				if (existingTagIds.Contains(tag!.Id))
+				{
+					continue;
+				}
+
+				context.GasesTags.Add(new GasesTags
+				{
+					Gas = gas,
+					GasId = gas.Id,
+					Tag = tag,
+					TagId = tag.Id
+				});
+			}
+		}
+
+		context.SaveChanges();
+		return gases;
+	}
+
+	internal static Gas EnsureBreathableAtmosphere(FuturemudDatabaseContext context)
+	{
+		return EnsureStockGases(context)["Breathable Atmosphere"];
+	}
+
+	private static Dictionary<string, Tag?> EnsureStockGasTags(FuturemudDatabaseContext context)
+	{
+		var tags = context.Tags
+			.AsEnumerable()
+			.ToDictionary(x => x.Name, x => (Tag?)x, StringComparer.OrdinalIgnoreCase);
+
+		foreach (var (name, parentName) in StockGasTagDefinitions)
+		{
+			if (tags.ContainsKey(name))
+			{
+				continue;
+			}
+
+			var tag = new Tag
+			{
+				Name = name,
+				Parent = parentName is null || !tags.TryGetValue(parentName, out var parent) ? null : parent
+			};
+			context.Tags.Add(tag);
+			tags[name] = tag;
+		}
+
+		context.SaveChanges();
+		return tags;
+	}
+}

--- a/DatabaseSeeder/Seeders/CoreDataSeeder.Terrain.cs
+++ b/DatabaseSeeder/Seeders/CoreDataSeeder.Terrain.cs
@@ -25,6 +25,8 @@ public partial class CoreDataSeeder
 		public string ProfileName => $"{TerrainName} Stock Forage";
 	}
 
+	private sealed record StockTerrainAtmosphere(string? Name, string Type);
+
     private static readonly (string Name, string Parent)[] StockTerrainTagDefinitions =
     [
         ("Terrain", ""),
@@ -865,81 +867,86 @@ public partial class CoreDataSeeder
 		return profile;
 	}
 
-	internal static Gas EnsureBreathableAtmosphere(FuturemudDatabaseContext context)
-	{
-		var atmosphere = context.Gases
-			.AsEnumerable()
-			.FirstOrDefault(x => x.Name.Equals("Breathable Atmosphere", StringComparison.OrdinalIgnoreCase));
-		if (atmosphere is not null)
-		{
-			return atmosphere;
-		}
-
-		var nextGasId = context.Gases.Any(x => x.Id == 1L)
-			? context.Gases.Select(x => x.Id).AsEnumerable().DefaultIfEmpty(0L).Max() + 1L
-			: 1L;
-		atmosphere = new Gas
-		{
-			Id = nextGasId,
-			Name = "Breathable Atmosphere",
-			Description = "Breathable Air",
-			Density = 0.001205,
-			ThermalConductivity = 0.0257,
-			ElectricalConductivity = 0.000005,
-			Organic = false,
-			SpecificHeatCapacity = 1.005,
-			BoilingPoint = -200,
-			DisplayColour = "blue",
-			Viscosity = 15,
-			SmellIntensity = 0,
-			SmellText = "It has no smell",
-			VagueSmellText = "It has no smell"
-		};
-		context.Gases.Add(atmosphere);
-		context.SaveChanges();
-
-		return atmosphere;
-	}
-
 	private static void BackfillStockTerrainAtmospheres(FuturemudDatabaseContext context,
-		IReadOnlyDictionary<string, string?> stockTerrainAtmospheres)
+		IReadOnlyDictionary<string, StockTerrainAtmosphere> stockTerrainAtmospheres)
 	{
-		var atmosphereIds = stockTerrainAtmospheres
+		var stockGasIds = context.Gases
+			.AsEnumerable()
+			.Where(x => StockGasNamesForTesting.Contains(x.Name, StringComparer.OrdinalIgnoreCase))
+			.Select(x => x.Id)
+			.ToHashSet();
+		var stockLiquidNames = stockTerrainAtmospheres
 			.Values
-			.Where(x => !string.IsNullOrWhiteSpace(x))
-			.Select(x => x!)
-			.Distinct(StringComparer.OrdinalIgnoreCase)
-			.ToDictionary(
-				x => x,
-				x => context.Gases
-					.AsEnumerable()
-					.FirstOrDefault(y => y.Name.Equals(x, StringComparison.OrdinalIgnoreCase))?.Id,
-				StringComparer.OrdinalIgnoreCase);
+			.Where(x => x.Type.Equals("Liquid", StringComparison.OrdinalIgnoreCase) &&
+			            !string.IsNullOrWhiteSpace(x.Name))
+			.Select(x => x.Name!)
+			.ToHashSet(StringComparer.OrdinalIgnoreCase);
+		var stockLiquidIds = context.Liquids
+			.AsEnumerable()
+			.Where(x => stockLiquidNames.Contains(x.Name))
+			.Select(x => x.Id)
+			.ToHashSet();
 
 		foreach (var terrain in context.Terrains.AsEnumerable())
 		{
-			if (terrain.AtmosphereId is not null)
+			if (!stockTerrainAtmospheres.TryGetValue(terrain.Name, out var atmosphere))
 			{
 				continue;
 			}
 
-			if (!stockTerrainAtmospheres.TryGetValue(terrain.Name, out var atmosphereName) ||
-			    string.IsNullOrWhiteSpace(atmosphereName))
+			if (!TerrainAtmosphereIsStock(terrain, stockGasIds, stockLiquidIds))
 			{
 				continue;
 			}
 
-			if (!atmosphereIds.TryGetValue(atmosphereName, out var atmosphereId) ||
-			    atmosphereId is null)
-			{
-				continue;
-			}
-
-			terrain.AtmosphereId = atmosphereId.Value;
-			terrain.AtmosphereType = "Gas";
+			terrain.AtmosphereId = ResolveStockTerrainAtmosphereId(context, atmosphere);
+			terrain.AtmosphereType = atmosphere.Type;
 		}
 
 		context.SaveChanges();
+	}
+
+	private static long? ResolveStockTerrainAtmosphereId(FuturemudDatabaseContext context,
+		StockTerrainAtmosphere atmosphere)
+	{
+		if (string.IsNullOrWhiteSpace(atmosphere.Name))
+		{
+			return null;
+		}
+
+		if (atmosphere.Type.Equals("Liquid", StringComparison.OrdinalIgnoreCase))
+		{
+			return context.Liquids
+				.AsEnumerable()
+				.FirstOrDefault(x => x.Name.Equals(atmosphere.Name, StringComparison.OrdinalIgnoreCase))
+				?.Id;
+		}
+
+		return context.Gases
+			.AsEnumerable()
+			.FirstOrDefault(x => x.Name.Equals(atmosphere.Name, StringComparison.OrdinalIgnoreCase))
+			?.Id;
+	}
+
+	private static bool TerrainAtmosphereIsStock(Terrain terrain,
+		IReadOnlySet<long> stockGasIds, IReadOnlySet<long> stockLiquidIds)
+	{
+		if (terrain.AtmosphereId is null)
+		{
+			return true;
+		}
+
+		if (terrain.AtmosphereType?.Equals("Gas", StringComparison.OrdinalIgnoreCase) == true)
+		{
+			return stockGasIds.Contains(terrain.AtmosphereId.Value);
+		}
+
+		if (terrain.AtmosphereType?.Equals("Liquid", StringComparison.OrdinalIgnoreCase) == true)
+		{
+			return stockLiquidIds.Contains(terrain.AtmosphereId.Value);
+		}
+
+		return false;
 	}
 
 	private static void BackfillStockTerrainGravity(FuturemudDatabaseContext context)
@@ -969,7 +976,8 @@ public partial class CoreDataSeeder
     internal static void SeedStockTerrainCatalogue(FuturemudDatabaseContext context, DictionaryWithDefault<string, Tag> tagLookup,
         ICollection<string>? errors = null)
     {
-	    var breathableAtmosphere = EnsureBreathableAtmosphere(context);
+	    var stockGases = EnsureStockGases(context);
+	    var breathableAtmosphere = stockGases["Breathable Atmosphere"];
 	    var terrainsAlreadyInstalled = context.Terrains.Count() > 1;
 
 	    if (!terrainsAlreadyInstalled)
@@ -980,17 +988,18 @@ public partial class CoreDataSeeder
 		    voidTerrain.AtmosphereType = "Gas";
 	    }
 
-	    var stockTerrainAtmospheres = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+	    var stockTerrainAtmospheres = new Dictionary<string, StockTerrainAtmosphere>(StringComparer.OrdinalIgnoreCase)
 	    {
-		    ["Void"] = "Breathable Atmosphere"
+		    ["Void"] = new("Breathable Atmosphere", "Gas")
 	    };
 
         void AddTerrain(string name, string behaviour, double movementRate, double staminaCost,
             Difficulty hideDifficulty, Difficulty spotDifficulty, string? atmosphere, CellOutdoorsType outdoorsType,
             Color editorColour, string? editorText = null, bool isdefault = false, IEnumerable<string>? tags = null,
-            GravityModel gravityModel = GravityModel.Normal)
+            GravityModel gravityModel = GravityModel.Normal, string atmosphereType = "Gas")
         {
-	        stockTerrainAtmospheres[name] = atmosphere;
+	        var stockAtmosphere = new StockTerrainAtmosphere(atmosphere, atmosphereType);
+	        stockTerrainAtmospheres[name] = stockAtmosphere;
 	        if (terrainsAlreadyInstalled)
 	        {
 		        return;
@@ -1004,8 +1013,8 @@ public partial class CoreDataSeeder
                 StaminaCost = staminaCost,
                 HideDifficulty = (int)hideDifficulty,
                 SpotDifficulty = (int)spotDifficulty,
-                AtmosphereId = context.Gases.FirstOrDefault(x => x.Name == atmosphere)?.Id,
-                AtmosphereType = "Gas",
+                AtmosphereId = ResolveStockTerrainAtmosphereId(context, stockAtmosphere),
+                AtmosphereType = atmosphereType,
                 InfectionMultiplier = 1.0,
                 InfectionType = (int)InfectionType.Simple,
                 InfectionVirulence = (int)Difficulty.Normal,
@@ -1060,54 +1069,54 @@ public partial class CoreDataSeeder
         AddTerrain("Shopfront", "indoors", 0.5, 3.0, Difficulty.Easy, Difficulty.Automatic, "Breathable Atmosphere",
                 CellOutdoorsType.IndoorsWithWindows, Color.SandyBrown, "Sf",
                 tags: ["Urban", "Commercial", "Public"]);
-        AddTerrain("Workshop", "indoors", 0.5, 3.0, Difficulty.Easy, Difficulty.Automatic, "Breathable Atmosphere",
+        AddTerrain("Workshop", "indoors", 0.5, 3.0, Difficulty.Easy, Difficulty.Automatic, "Polluted Breathable Atmosphere",
                 CellOutdoorsType.IndoorsWithWindows, Color.SaddleBrown, "Ws",
                 tags: ["Urban", "Industrial", "Private"]);
         AddTerrain("Office", "indoors", 0.5, 3.0, Difficulty.Easy, Difficulty.Automatic, "Breathable Atmosphere",
                 CellOutdoorsType.IndoorsWithWindows, Color.LightSteelBlue, "Of",
                 tags: ["Urban", "Administrative", "Private"]);
-        AddTerrain("Factory", "indoors", 0.5, 3.0, Difficulty.Easy, Difficulty.Automatic, "Breathable Atmosphere",
+        AddTerrain("Factory", "indoors", 0.5, 3.0, Difficulty.Easy, Difficulty.Automatic, "Polluted Breathable Atmosphere",
                 CellOutdoorsType.IndoorsWithWindows, Color.Silver, "Fa",
                 tags: ["Urban", "Industrial", "Private"]);
-        AddTerrain("Warehouse", "indoors", 0.5, 3.0, Difficulty.Easy, Difficulty.Automatic, "Breathable Atmosphere",
+        AddTerrain("Warehouse", "indoors", 0.5, 3.0, Difficulty.Easy, Difficulty.Automatic, "Stale Breathable Atmosphere",
                 CellOutdoorsType.IndoorsWithWindows, Color.DarkGray, "Wh",
                 tags: ["Urban", "Industrial", "Private"]);
         AddTerrain("Indoor Market", "indoors", 0.5, 3.0, Difficulty.ExtremelyEasy, Difficulty.Easy,
                 "Breathable Atmosphere", CellOutdoorsType.IndoorsWithWindows, Color.Plum, "Im",
                 tags: ["Urban", "Commercial", "Public"]);
         AddTerrain("Underground Market", "indoors", 0.5, 3.0, Difficulty.ExtremelyEasy, Difficulty.Easy,
-                "Breathable Atmosphere", CellOutdoorsType.IndoorsWithWindows, Color.DarkOrchid, "Um",
+                "Stale Breathable Atmosphere", CellOutdoorsType.IndoorsWithWindows, Color.DarkOrchid, "Um",
                 tags: ["Urban", "Commercial", "Public"]);
-        AddTerrain("Garage", "indoors", 0.5, 3.0, Difficulty.ExtremelyEasy, Difficulty.Easy, "Breathable Atmosphere",
+        AddTerrain("Garage", "indoors", 0.5, 3.0, Difficulty.ExtremelyEasy, Difficulty.Easy, "Polluted Breathable Atmosphere",
                 CellOutdoorsType.IndoorsWithWindows, Color.DimGray, "Ga",
                 tags: ["Urban", "Industrial", "Private"]);
         AddTerrain("Underground Garage", "indoors", 0.5, 3.0, Difficulty.ExtremelyEasy, Difficulty.Easy,
-                "Breathable Atmosphere", CellOutdoorsType.IndoorsNoLight, Color.DarkSlateGray, "Ug",
+                "Polluted Breathable Atmosphere", CellOutdoorsType.IndoorsNoLight, Color.DarkSlateGray, "Ug",
                 tags: ["Urban", "Industrial", "Private"]);
         AddTerrain("Barn", "indoors", 0.5, 3.0, Difficulty.Easy, Difficulty.Automatic, "Breathable Atmosphere",
                 CellOutdoorsType.Indoors, Color.Brown, "Bn", tags: ["Rural"]);
-        AddTerrain("Cell", "indoors", 0.5, 3.0, Difficulty.Insane, Difficulty.Automatic, "Breathable Atmosphere",
+        AddTerrain("Cell", "indoors", 0.5, 3.0, Difficulty.Insane, Difficulty.Automatic, "Stale Breathable Atmosphere",
                 CellOutdoorsType.IndoorsNoLight, Color.LightSlateGray, "Ce",
                 tags: ["Urban", "Administrative", "Private"]);
-        AddTerrain("Dank Cell", "indoors", 0.5, 3.0, Difficulty.Insane, Difficulty.Automatic, "Breathable Atmosphere",
+        AddTerrain("Dank Cell", "indoors", 0.5, 3.0, Difficulty.Insane, Difficulty.Automatic, "Humid Breathable Atmosphere",
                 CellOutdoorsType.IndoorsNoLight, Color.Gray, "Dc",
                 tags: ["Urban", "Administrative", "Private"]);
-        AddTerrain("Dungeon", "indoors", 0.5, 3.0, Difficulty.Insane, Difficulty.Automatic, "Breathable Atmosphere",
+        AddTerrain("Dungeon", "indoors", 0.5, 3.0, Difficulty.Insane, Difficulty.Automatic, "Stale Breathable Atmosphere",
                 CellOutdoorsType.IndoorsNoLight, Color.Indigo, "Du",
                 tags: ["Urban", "Administrative", "Private"]);
-        AddTerrain("Grotto", "cave", 0.5, 3.0, Difficulty.Insane, Difficulty.Automatic, "Breathable Atmosphere",
+        AddTerrain("Grotto", "cave", 0.5, 3.0, Difficulty.Insane, Difficulty.Automatic, "Humid Breathable Atmosphere",
                 CellOutdoorsType.IndoorsNoLight, Color.DarkSlateBlue, "Gr", tags: ["Rural"]);
-        AddTerrain("Cellar", "indoors", 0.5, 3.0, Difficulty.Insane, Difficulty.Automatic, "Breathable Atmosphere",
+        AddTerrain("Cellar", "indoors", 0.5, 3.0, Difficulty.Insane, Difficulty.Automatic, "Stale Breathable Atmosphere",
                  CellOutdoorsType.IndoorsNoLight, Color.BurlyWood, "Cl",
                  tags: ["Urban", "Residential", "Private"]);
         AddTerrain("Baths", "indoors", 0.5, 3.0, Difficulty.ExtremelyHard, Difficulty.ExtremelyEasy,
-                 "Breathable Atmosphere", CellOutdoorsType.Indoors, Color.LightBlue, "Bt",
+                 "Humid Breathable Atmosphere", CellOutdoorsType.Indoors, Color.LightBlue, "Bt",
                  tags: ["Urban", "Aquatic", "Commercial", "Public"]);
         AddTerrain("Indoor Pool", $"shallowwater {poolwater.Id}", 0.5, 5.0, Difficulty.ExtremelyHard,
-                 Difficulty.ExtremelyEasy, "Breathable Atmosphere", CellOutdoorsType.Indoors, Color.DeepSkyBlue, "IP",
+                 Difficulty.ExtremelyEasy, "Humid Breathable Atmosphere", CellOutdoorsType.Indoors, Color.DeepSkyBlue, "IP",
                  tags: ["Urban", "Aquatic", "Private"]);
         AddTerrain("Indoor Spring", $"shallowwater {springwater.Id}", 0.5, 5.0, Difficulty.ExtremelyHard,
-                 Difficulty.ExtremelyEasy, "Breathable Atmosphere", CellOutdoorsType.Indoors, Color.MediumAquamarine, "IS", tags: ["Rural", "Aquatic"]);
+                 Difficulty.ExtremelyEasy, "Humid Breathable Atmosphere", CellOutdoorsType.Indoors, Color.MediumAquamarine, "IS", tags: ["Rural", "Aquatic"]);
 
         AddTerrain("Rooftop", "outdoors", 0.75, 7.0, Difficulty.Easy, Difficulty.Automatic, "Breathable Atmosphere",
                 CellOutdoorsType.Outdoors, Color.DarkSlateGray, tags: ["Urban", "Private"]);
@@ -1132,11 +1141,11 @@ public partial class CoreDataSeeder
                 CellOutdoorsType.Outdoors, Color.SlateGray, tags: ["Urban", "Commercial", "Public"]);
         AddTerrain("Courtyard", "outdoors", 1.0, 7.0, Difficulty.Easy, Difficulty.Automatic, "Breathable Atmosphere",
                 CellOutdoorsType.Outdoors, Color.SlateGray, tags: ["Urban", "Private"]);
-        AddTerrain("Park", "trees", 1.0, 7.0, Difficulty.VeryEasy, Difficulty.Automatic, "Breathable Atmosphere",
+        AddTerrain("Park", "trees", 1.0, 7.0, Difficulty.VeryEasy, Difficulty.Automatic, "Fresh Breathable Atmosphere",
                 CellOutdoorsType.Outdoors, Color.LightGreen, tags: ["Urban", "Natural", "Public", "Diggable Soil"]);
-        AddTerrain("Garden", "trees", 1.0, 7.0, Difficulty.VeryEasy, Difficulty.Automatic, "Breathable Atmosphere",
+        AddTerrain("Garden", "trees", 1.0, 7.0, Difficulty.VeryEasy, Difficulty.Automatic, "Fresh Breathable Atmosphere",
                 CellOutdoorsType.Outdoors, Color.LightGreen, tags: ["Urban", "Natural", "Private", "Diggable Soil"]);
-        AddTerrain("Lawn", "outdoors", 1.0, 7.0, Difficulty.VeryEasy, Difficulty.Automatic, "Breathable Atmosphere",
+        AddTerrain("Lawn", "outdoors", 1.0, 7.0, Difficulty.VeryEasy, Difficulty.Automatic, "Fresh Breathable Atmosphere",
                 CellOutdoorsType.Outdoors, Color.LightGreen, tags: ["Urban", "Natural", "Private", "Diggable Soil"]);
         AddTerrain("Showground", "outdoors", 1.0, 7.0, Difficulty.VeryHard, Difficulty.Automatic,
                 "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.LightGreen,
@@ -1144,10 +1153,10 @@ public partial class CoreDataSeeder
         AddTerrain("Forum", "outdoors", 1.0, 7.0, Difficulty.VeryEasy, Difficulty.VeryEasy, "Breathable Atmosphere",
                 CellOutdoorsType.Outdoors, Color.SlateGray, tags: ["Urban", "Administrative", "Public"]);
         AddTerrain("Public Square", "outdoors", 1.0, 7.0, Difficulty.VeryEasy, Difficulty.VeryEasy,
-                "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.SlateGray,
+                "Polluted Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.SlateGray,
                 tags: ["Urban", "Administrative", "Public"]);
         AddTerrain("Outdoor Mall", "outdoors", 1.0, 7.0, Difficulty.VeryEasy, Difficulty.VeryEasy,
-                "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.SlateGray,
+                "Polluted Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.SlateGray,
                 tags: ["Urban", "Commercial", "Public"]);
         AddTerrain("Alleyway", "outdoors", 1.0, 7.0, Difficulty.Easy, Difficulty.Automatic, "Breathable Atmosphere",
                 CellOutdoorsType.Outdoors, Color.SlateGray, tags: ["Urban", "Public"]);
@@ -1206,7 +1215,7 @@ public partial class CoreDataSeeder
             CellOutdoorsType.Outdoors, Color.LightGreen, tags: ["Terrestrial", "Diggable Soil"]);
         AddTerrain("Field", "outdoors", 2.0, 15.0, Difficulty.Normal, Difficulty.Automatic, "Breathable Atmosphere",
             CellOutdoorsType.Outdoors, Color.LightGreen, tags: ["Rural", "Diggable Soil"]);
-        AddTerrain("Tundra", "outdoors", 2.0, 15.0, Difficulty.Normal, Difficulty.Automatic, "Breathable Atmosphere",
+        AddTerrain("Tundra", "outdoors", 2.0, 15.0, Difficulty.Normal, Difficulty.Automatic, "Cold Dry Breathable Atmosphere",
             CellOutdoorsType.Outdoors, Color.LightGreen, tags: ["Terrestrial", "Diggable Soil"]);
         AddTerrain("Flood Plain", "outdoors", 2.0, 15.0, Difficulty.Normal, Difficulty.Automatic,
             "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.LightGreen, tags: ["Terrestrial", "Riparian", "Diggable Soil", "Foragable Clay"]);
@@ -1242,24 +1251,24 @@ public partial class CoreDataSeeder
         AddTerrain("Dunes", "outdoors", 3.0, 15.0, Difficulty.Easy, Difficulty.Automatic, "Breathable Atmosphere",
             CellOutdoorsType.Outdoors, Color.OrangeRed, tags: ["Terrestrial", "Diggable Soil", "Foragable Sand"]);
         AddTerrain("Plateau", "outdoors", 3.0, 15.0, Difficulty.Easy, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Peru, tags: ["Terrestrial", "Diggable Soil"]);
+            "High Altitude Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Peru, tags: ["Terrestrial", "Diggable Soil"]);
         AddTerrain("Escarpment", "cliff", 4.5, 22.0, Difficulty.VeryHard, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.IndianRed, tags: ["Terrestrial"]);
+            "High Altitude Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.IndianRed, tags: ["Terrestrial"]);
         AddTerrain("Scree Slope", "outdoors", 4.0, 25.0, Difficulty.Hard, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkKhaki, tags: ["Terrestrial"]);
+            "High Altitude Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkKhaki, tags: ["Terrestrial"]);
         AddTerrain("Talus Field", "outdoors", 4.0, 25.0, Difficulty.Hard, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkGoldenrod, tags: ["Terrestrial"]);
+            "High Altitude Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkGoldenrod, tags: ["Terrestrial"]);
 
         AddTerrain("Mountainside", "outdoors", 4.0, 20.0, Difficulty.ExtremelyEasy, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Red, tags: ["Terrestrial", "Diggable Soil"]);
+            "High Altitude Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Red, tags: ["Terrestrial", "Diggable Soil"]);
         AddTerrain("Mountain Pass", "outdoors", 4.0, 20.0, Difficulty.ExtremelyEasy, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Red, tags: ["Terrestrial", "Diggable Soil"]);
+            "High Altitude Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Red, tags: ["Terrestrial", "Diggable Soil"]);
         AddTerrain("Mountain Ridge", "outdoors", 4.0, 20.0, Difficulty.ExtremelyEasy, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Red, tags: ["Terrestrial"]);
-        AddTerrain("Cliff Face", "cliff", 5.0, 20.0, Difficulty.Insane, Difficulty.Automatic, "Breathable Atmosphere",
+            "Thin Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Red, tags: ["Terrestrial"]);
+        AddTerrain("Cliff Face", "cliff", 5.0, 20.0, Difficulty.Insane, Difficulty.Automatic, "High Altitude Breathable Atmosphere",
             CellOutdoorsType.Outdoors, Color.Red, tags: ["Terrestrial"]);
         AddTerrain("Cliff Edge", "outdoors", 5.0, 20.0, Difficulty.ExtremelyEasy, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Red, tags: ["Terrestrial"]);
+            "High Altitude Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Red, tags: ["Terrestrial"]);
 
         AddTerrain("Valley", "outdoors", 3.0, 10.0, Difficulty.Normal, Difficulty.Automatic, "Breathable Atmosphere",
             CellOutdoorsType.Outdoors, Color.Beige, tags: ["Terrestrial", "Diggable Soil"]);
@@ -1281,44 +1290,44 @@ public partial class CoreDataSeeder
             CellOutdoorsType.Outdoors, Color.Beige, tags: ["Terrestrial", "Diggable Soil"]);
 
         AddTerrain("Boreal Forest", "talltrees", 3.5, 20.0, Difficulty.VeryEasy, Difficulty.ExtremelyEasy,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkGreen, tags: ["Terrestrial", "Diggable Soil"]);
+            "Fresh Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkGreen, tags: ["Terrestrial", "Diggable Soil"]);
         AddTerrain("Broadleaf Forest", "talltrees", 3.5, 20.0, Difficulty.VeryEasy, Difficulty.ExtremelyEasy,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkGreen, tags: ["Terrestrial", "Diggable Soil"]);
+            "Fresh Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkGreen, tags: ["Terrestrial", "Diggable Soil"]);
         AddTerrain("Temperate Coniferous Forest", "talltrees", 3.5, 20.0, Difficulty.VeryEasy, Difficulty.ExtremelyEasy,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkGreen, tags: ["Terrestrial", "Diggable Soil"]);
+            "Fresh Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkGreen, tags: ["Terrestrial", "Diggable Soil"]);
         AddTerrain("Temperate Rainforest", "talltrees", 3.5, 20.0, Difficulty.VeryEasy, Difficulty.ExtremelyEasy,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkGreen, tags: ["Terrestrial", "Diggable Soil"]);
+            "Fresh Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkGreen, tags: ["Terrestrial", "Diggable Soil"]);
         AddTerrain("Tropical Rainforest", "talltrees", 3.5, 20.0, Difficulty.VeryEasy, Difficulty.ExtremelyEasy,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkGreen, tags: ["Terrestrial", "Diggable Soil"]);
+            "Hot Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkGreen, tags: ["Terrestrial", "Diggable Soil"]);
         AddTerrain("Bramble", "talltrees", 3.0, 20.0, Difficulty.VeryEasy, Difficulty.ExtremelyEasy,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkGreen, tags: ["Terrestrial", "Diggable Soil"]);
+            "Fresh Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkGreen, tags: ["Terrestrial", "Diggable Soil"]);
         AddTerrain("Plantation Forest", "talltrees", 3.0, 10.0, Difficulty.VeryEasy, Difficulty.ExtremelyEasy,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkGreen, tags: ["Rural", "Diggable Soil"]);
+            "Fresh Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkGreen, tags: ["Rural", "Diggable Soil"]);
         AddTerrain("Orchard", "talltrees", 3.0, 10.0, Difficulty.VeryEasy, Difficulty.ExtremelyEasy,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkGreen, tags: ["Rural", "Diggable Soil"]);
+            "Fresh Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkGreen, tags: ["Rural", "Diggable Soil"]);
         AddTerrain("Grove", "talltrees", 3.0, 10.0, Difficulty.VeryEasy, Difficulty.ExtremelyEasy,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkGreen, tags: ["Rural", "Diggable Soil"]);
+            "Fresh Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkGreen, tags: ["Rural", "Diggable Soil"]);
         AddTerrain("Woodland", "talltrees", 3.0, 10.0, Difficulty.VeryEasy, Difficulty.ExtremelyEasy,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkGreen, tags: ["Rural", "Diggable Soil"]);
+            "Fresh Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkGreen, tags: ["Rural", "Diggable Soil"]);
 
         AddTerrain("Bog", $"shallowwatertrees {swampwater.Id}", 4.0, 30.0, Difficulty.VeryEasy,
-            Difficulty.ExtremelyEasy, "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Purple, tags: ["Terrestrial", "Wetland", "Diggable Soil", "Foragable Clay"]);
+            Difficulty.ExtremelyEasy, "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Purple, tags: ["Terrestrial", "Wetland", "Diggable Soil", "Foragable Clay"]);
         AddTerrain("Fen", $"shallowwater {swampwater.Id}", 4.0, 30.0, Difficulty.VeryEasy,
-            Difficulty.ExtremelyEasy, "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.MediumPurple, tags: ["Terrestrial", "Wetland", "Riparian", "Diggable Soil", "Foragable Clay"]);
+            Difficulty.ExtremelyEasy, "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.MediumPurple, tags: ["Terrestrial", "Wetland", "Riparian", "Diggable Soil", "Foragable Clay"]);
         AddTerrain("Marsh", $"shallowwater {swampwater.Id}", 4.0, 30.0, Difficulty.VeryEasy,
-            Difficulty.ExtremelyEasy, "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkMagenta, tags: ["Terrestrial", "Wetland", "Riparian", "Diggable Soil", "Foragable Clay"]);
+            Difficulty.ExtremelyEasy, "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkMagenta, tags: ["Terrestrial", "Wetland", "Riparian", "Diggable Soil", "Foragable Clay"]);
         AddTerrain("Salt Marsh", $"shallowwater {brackishwater.Id}", 4.0, 30.0, Difficulty.VeryEasy,
-            Difficulty.ExtremelyEasy, "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Purple, tags: ["Terrestrial", "Littoral", "Wetland", "Diggable Soil", "Foragable Clay", "Foragable Sand"]);
+            Difficulty.ExtremelyEasy, "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Purple, tags: ["Terrestrial", "Littoral", "Wetland", "Diggable Soil", "Foragable Clay", "Foragable Sand"]);
         AddTerrain("Mangrove Swamp", $"shallowwatertrees {brackishwater.Id}", 4.0, 30.0, Difficulty.VeryEasy,
-            Difficulty.ExtremelyEasy, "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Purple, tags: ["Terrestrial", "Littoral", "Wetland", "Diggable Soil", "Foragable Sand"]);
+            Difficulty.ExtremelyEasy, "Hot Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Purple, tags: ["Terrestrial", "Littoral", "Wetland", "Diggable Soil", "Foragable Sand"]);
         AddTerrain("Wetland", $"shallowwater {swampwater.Id}", 4.0, 30.0, Difficulty.VeryEasy, Difficulty.ExtremelyEasy,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Purple, tags: ["Terrestrial", "Wetland", "Diggable Soil", "Foragable Clay"]);
+            "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Purple, tags: ["Terrestrial", "Wetland", "Diggable Soil", "Foragable Clay"]);
         AddTerrain("Swamp Forest", $"shallowwatertrees {swampwater.Id}", 4.0, 30.0, Difficulty.VeryEasy,
-            Difficulty.ExtremelyEasy, "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Purple, tags: ["Terrestrial", "Wetland", "Diggable Soil", "Foragable Clay"]);
+            Difficulty.ExtremelyEasy, "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Purple, tags: ["Terrestrial", "Wetland", "Diggable Soil", "Foragable Clay"]);
         AddTerrain("Tropical Freshwater Swamp", $"shallowwatertrees {swampwater.Id}", 4.0, 30.0, Difficulty.VeryEasy,
-            Difficulty.ExtremelyEasy, "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Purple, tags: ["Terrestrial", "Wetland", "Diggable Soil", "Foragable Clay"]);
+            Difficulty.ExtremelyEasy, "Hot Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Purple, tags: ["Terrestrial", "Wetland", "Diggable Soil", "Foragable Clay"]);
         AddTerrain("Temperate Freshwater Swamp", $"shallowwatertrees {swampwater.Id}", 4.0, 30.0, Difficulty.VeryEasy,
-            Difficulty.ExtremelyEasy, "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Purple, tags: ["Terrestrial", "Wetland", "Diggable Soil", "Foragable Clay"]);
+            Difficulty.ExtremelyEasy, "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Purple, tags: ["Terrestrial", "Wetland", "Diggable Soil", "Foragable Clay"]);
 
         AddTerrain("Sandy Desert", "outdoors", 4.0, 20.0, Difficulty.VeryHard, Difficulty.Automatic,
             "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Yellow, tags: ["Terrestrial", "Arid", "Diggable Soil", "Foragable Sand"]);
@@ -1329,86 +1338,86 @@ public partial class CoreDataSeeder
         AddTerrain("Oasis", "trees", 2.0, 12.0, Difficulty.Easy, Difficulty.Automatic, "Breathable Atmosphere",
             CellOutdoorsType.Outdoors, Color.MediumSeaGreen, tags: ["Terrestrial", "Arid", "Diggable Soil"]);
         AddTerrain("Volcanic Plain", "outdoors", 3.5, 20.0, Difficulty.Hard, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Firebrick, tags: ["Terrestrial", "Volcanic"]);
+            "Sulfurous Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Firebrick, tags: ["Terrestrial", "Volcanic"]);
         AddTerrain("Lava Field", "outdoors", 4.0, 25.0, Difficulty.Hard, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkRed, tags: ["Terrestrial", "Volcanic"]);
+            "Sulfurous Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkRed, tags: ["Terrestrial", "Volcanic"]);
         AddTerrain("Caldera", "outdoors", 3.5, 20.0, Difficulty.Normal, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.IndianRed, tags: ["Terrestrial", "Volcanic"]);
+            "Sulfurous Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.IndianRed, tags: ["Terrestrial", "Volcanic"]);
         AddTerrain("Crater", "outdoors", 3.5, 20.0, Difficulty.Normal, Difficulty.Automatic,
             "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.BurlyWood, tags: ["Terrestrial"]);
         AddTerrain("Glacier", "outdoors", 4.0, 22.0, Difficulty.Hard, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.LightCyan, tags: ["Terrestrial", "Glacial"]);
+            "Cold Dry Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.LightCyan, tags: ["Terrestrial", "Glacial"]);
         AddTerrain("Ice Field", "outdoors", 3.0, 18.0, Difficulty.Hard, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.AliceBlue, tags: ["Terrestrial", "Glacial"]);
+            "Cold Dry Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.AliceBlue, tags: ["Terrestrial", "Glacial"]);
         AddTerrain("Snowfield", "outdoors", 3.0, 18.0, Difficulty.Normal, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.WhiteSmoke, tags: ["Terrestrial", "Glacial"]);
+            "Cold Dry Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.WhiteSmoke, tags: ["Terrestrial", "Glacial"]);
 
         AddTerrain("Cave Entrance", "indoors", 3.0, 20.0, Difficulty.Normal, Difficulty.Automatic,
             "Breathable Atmosphere", CellOutdoorsType.IndoorsClimateExposed, Color.LightGreen, tags: ["Terrestrial"]);
-        AddTerrain("Cave", "cave", 3.0, 20.0, Difficulty.Normal, Difficulty.Automatic, "Breathable Atmosphere",
+        AddTerrain("Cave", "cave", 3.0, 20.0, Difficulty.Normal, Difficulty.Automatic, "Stale Breathable Atmosphere",
             CellOutdoorsType.IndoorsNoLight, Color.LightGreen, tags: ["Terrestrial"]);
-        AddTerrain("Cavern", "cave", 3.0, 20.0, Difficulty.Normal, Difficulty.Automatic, "Breathable Atmosphere",
+        AddTerrain("Cavern", "cave", 3.0, 20.0, Difficulty.Normal, Difficulty.Automatic, "Stale Breathable Atmosphere",
             CellOutdoorsType.IndoorsNoLight, Color.DarkSeaGreen, tags: ["Terrestrial"]);
         AddTerrain("Cave Pool", $"shallowwatercave {springwater.Id}", 3.0, 10.0, Difficulty.Normal,
-            Difficulty.Automatic, "Breathable Atmosphere", CellOutdoorsType.IndoorsNoLight, Color.LightGreen, tags: ["Terrestrial", "Aquatic"]);
+            Difficulty.Automatic, "Humid Breathable Atmosphere", CellOutdoorsType.IndoorsNoLight, Color.LightGreen, tags: ["Terrestrial", "Aquatic"]);
         AddTerrain("Underground Water", $"deepwatercave {springwater.Id}", 3.0, 10.0, Difficulty.Normal,
-            Difficulty.Automatic, "Breathable Atmosphere", CellOutdoorsType.IndoorsNoLight, Color.LightGreen, tags: ["Terrestrial", "Aquatic"]);
+            Difficulty.Automatic, "Humid Breathable Atmosphere", CellOutdoorsType.IndoorsNoLight, Color.LightGreen, tags: ["Terrestrial", "Aquatic"]);
 
         #endregion
 
         #region Water
 
         AddTerrain("Sandy Beach", "outdoors", 4.0, 20.0, Difficulty.Insane, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Yellow, tags: ["Littoral", "Diggable Soil", "Foragable Sand"]);
+            "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Yellow, tags: ["Littoral", "Diggable Soil", "Foragable Sand"]);
         AddTerrain("Rocky Beach", "outdoors", 4.0, 20.0, Difficulty.Insane, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Yellow, tags: ["Littoral"]);
-        AddTerrain("Beachrock", "outdoors", 4.0, 20.0, Difficulty.Insane, Difficulty.Automatic, "Breathable Atmosphere",
+            "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Yellow, tags: ["Littoral"]);
+        AddTerrain("Beachrock", "outdoors", 4.0, 20.0, Difficulty.Insane, Difficulty.Automatic, "Humid Breathable Atmosphere",
             CellOutdoorsType.Outdoors, Color.Yellow, tags: ["Littoral"]);
-        AddTerrain("Riverbank", "outdoors", 3.0, 20.0, Difficulty.Normal, Difficulty.Automatic, "Breathable Atmosphere",
+        AddTerrain("Riverbank", "outdoors", 3.0, 20.0, Difficulty.Normal, Difficulty.Automatic, "Humid Breathable Atmosphere",
             CellOutdoorsType.Outdoors, Color.Yellow, tags: ["Riparian", "Diggable Soil", "Foragable Clay", "Foragable Sand"]);
         AddTerrain("Lake Shore", "outdoors", 3.0, 20.0, Difficulty.Normal, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Yellow, tags: ["Littoral", "Diggable Soil", "Foragable Clay", "Foragable Sand"]);
+            "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.Yellow, tags: ["Littoral", "Diggable Soil", "Foragable Clay", "Foragable Sand"]);
 
         AddTerrain("Ocean Shallows", $"shallowwater {saltwater.Id}", 3.0, 10.0, Difficulty.Insane, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Littoral", "Foragable Sand"]);
+            "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Littoral", "Foragable Sand"]);
         AddTerrain("Ocean Surf", $"water {saltwater.Id}", 3.0, 10.0, Difficulty.Insane, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Littoral", "Foragable Sand"]);
+            "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Littoral", "Foragable Sand"]);
         AddTerrain("Ocean", $"deepwater {saltwater.Id}", 3.0, 10.0, Difficulty.Insane, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Sand"]);
+            "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Sand"]);
         AddTerrain("Mudflat", "outdoors", 4.0, 30.0, Difficulty.VeryHard, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.SaddleBrown, tags: ["Littoral", "Wetland", "Diggable Soil", "Foragable Clay", "Foragable Sand"]);
+            "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.SaddleBrown, tags: ["Littoral", "Wetland", "Diggable Soil", "Foragable Clay", "Foragable Sand"]);
         AddTerrain("Bay", $"water {saltwater.Id}", 3.0, 10.0, Difficulty.Insane, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Sand"]);
+            "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Sand"]);
         AddTerrain("Lagoon", $"water {brackishwater.Id}", 3.0, 10.0, Difficulty.Insane, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Sand"]);
+            "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Sand"]);
         AddTerrain("Cove", $"shallowwater {saltwater.Id}", 3.0, 10.0, Difficulty.Insane, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Sand"]);
+            "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Sand"]);
         AddTerrain("Tide Pool", $"shallowwater {saltwater.Id}", 3.0, 10.0, Difficulty.Insane, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Sand"]);
+            "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Sand"]);
         AddTerrain("Shoal", $"shallowwater {saltwater.Id}", 3.0, 10.0, Difficulty.Insane, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Sand"]);
+            "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Sand"]);
         AddTerrain("Coral Reef", $"deepwater {saltwater.Id}", 3.0, 10.0, Difficulty.Insane, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Sand"]);
+            "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Sand"]);
         AddTerrain("Reef", $"deepwater {saltwater.Id}", 3.0, 10.0, Difficulty.Insane, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Sand"]);
+            "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Sand"]);
         AddTerrain("Sound", $"deepwater {saltwater.Id}", 3.0, 10.0, Difficulty.Insane, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Sand"]);
+            "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Sand"]);
         AddTerrain("Estuary", $"shallowwater {brackishwater.Id}", 3.0, 10.0, Difficulty.Insane, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Clay", "Foragable Sand"]);
+            "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Clay", "Foragable Sand"]);
         AddTerrain("Shallow River", $"shallowwater {riverwater.Id}", 3.0, 10.0, Difficulty.Insane, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Clay", "Foragable Sand"]);
+            "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Clay", "Foragable Sand"]);
         AddTerrain("River", $"water {riverwater.Id}", 3.0, 10.0, Difficulty.Insane, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Clay", "Foragable Sand"]);
+            "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Clay", "Foragable Sand"]);
         AddTerrain("Deep River", $"deepwater {riverwater.Id}", 3.0, 10.0, Difficulty.Insane, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Clay", "Foragable Sand"]);
+            "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Clay", "Foragable Sand"]);
         AddTerrain("Shallow Lake", $"shallowwater {lakewater.Id}", 3.0, 10.0, Difficulty.Insane, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Clay", "Foragable Sand"]);
+            "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Clay", "Foragable Sand"]);
         AddTerrain("Lake", $"water {lakewater.Id}", 3.0, 10.0, Difficulty.Insane, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Clay", "Foragable Sand"]);
+            "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Clay", "Foragable Sand"]);
         AddTerrain("Deep Lake", $"deepwater {lakewater.Id}", 3.0, 10.0, Difficulty.Insane, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Clay", "Foragable Sand"]);
+            "Humid Breathable Atmosphere", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Clay", "Foragable Sand"]);
         AddTerrain("Deep Ocean", $"verydeepunderwater {saltwater.Id}", 3.0, 10.0, Difficulty.Insane,
-            Difficulty.Automatic, null, CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Sand"]);
+            Difficulty.Automatic, "salt water", CellOutdoorsType.Outdoors, Color.DarkBlue, tags: ["Aquatic", "Foragable Sand"], atmosphereType: "Liquid");
 
         #endregion
 
@@ -1437,7 +1446,7 @@ public partial class CoreDataSeeder
             CellOutdoorsType.Outdoors, Color.Black, tags: ["Extraterrestrial", "Space", "Vacuum"],
             gravityModel: GravityModel.ZeroGravity);
         AddTerrain("Zero-G Spaceship Compartment", "indoors", 0.5, 2.0, Difficulty.Normal, Difficulty.Automatic,
-            "Breathable Atmosphere", CellOutdoorsType.Indoors, Color.MidnightBlue, "ZG",
+            "Pressurized Breathable Atmosphere", CellOutdoorsType.Indoors, Color.MidnightBlue, "ZG",
             tags: ["Human Influenced", "Industrial", "Space"],
             gravityModel: GravityModel.ZeroGravity);
 

--- a/DatabaseSeeder/Seeders/MythicalAnimalSeeder.cs
+++ b/DatabaseSeeder/Seeders/MythicalAnimalSeeder.cs
@@ -291,7 +291,7 @@ public partial class MythicalAnimalSeeder : IDatabaseSeeder
         _saltWater = _context.Liquids.First(x => x.Name == "salt water");
         _brackishWater = _context.Liquids.First(x => x.Name == "brackish water");
         _sweat = _context.Liquids.FirstOrDefault(x => x.Name == "sweat");
-        _breathableAir = _context.Gases.AsEnumerable().First(x => x.Name.Contains("Breathable Atmosphere", StringComparison.OrdinalIgnoreCase));
+        _breathableAir = CoreDataSeeder.EnsureBreathableAtmosphere(_context);
         _defaultPopulationBloodModel = _humanRace.Ethnicities.FirstOrDefault()?.PopulationBloodModel ??
                                        _context.PopulationBloodModels.FirstOrDefault();
         _personWordDefinition = _context.CharacteristicDefinitions.First(x => x.Name == "Person Word");

--- a/DatabaseSeeder/Seeders/SupernaturalSeeder.cs
+++ b/DatabaseSeeder/Seeders/SupernaturalSeeder.cs
@@ -173,8 +173,7 @@ public partial class SupernaturalSeeder : IDatabaseSeeder
 		       context.CorpseModels.Any(x => x.Name == "Organic Human Corpse") &&
 		       context.CorpseModels.Any(x => x.Name == "Organic Animal Corpse") &&
 		       context.Liquids.Any(x => x.Name == "blood") &&
-		       context.Gases.AsEnumerable().Any(x =>
-			       x.Name.Contains("Breathable Atmosphere", StringComparison.OrdinalIgnoreCase)) &&
+		       context.Gases.Any(x => x.Name == "Breathable Atmosphere") &&
 		       context.TraitDefinitions
 			       .Where(x => x.Type == (int)TraitType.Attribute)
 			       .AsEnumerable()
@@ -219,9 +218,7 @@ public partial class SupernaturalSeeder : IDatabaseSeeder
 		_animalCorpse = _context.CorpseModels.First(x => x.Name == "Organic Animal Corpse");
 		_blood = _context.Liquids.First(x => x.Name == "blood");
 		_sweat = _context.Liquids.FirstOrDefault(x => x.Name == "sweat");
-		_breathableAir = _context.Gases
-			.AsEnumerable()
-			.First(x => x.Name.Contains("Breathable Atmosphere", StringComparison.OrdinalIgnoreCase));
+		_breathableAir = CoreDataSeeder.EnsureBreathableAtmosphere(_context);
 		_defaultPopulationBloodModel = _humanRace.Ethnicities.FirstOrDefault()?.PopulationBloodModel ??
 		                               _context.PopulationBloodModels.FirstOrDefault();
 		_personWordDefinition = _context.CharacteristicDefinitions.First(x => x.Name == "Person Word");


### PR DESCRIPTION
**Summary**
- Add a broader stock gas catalogue in `CoreDataSeeder`, including multiple breathable atmosphere variants and 50 economically useful gases.
- Update stock terrain seeding to use more appropriate breathable, polluted, humid, high-altitude, sulfurous, and pressurized atmospheres.
- Treat Deep Ocean as a liquid-atmosphere terrain and keep vacuum/extraterrestrial terrains atmosphere-free.
- Tighten breathable-atmosphere lookups in the mythology and supernatural seeders so they target the canonical stock gas.
- Add focused seeder tests covering gas catalogue contents, rerun stability, and terrain atmosphere assignments.

**Testing**
- `dotnet build DatabaseSeeder\DatabaseSeeder.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `dotnet test "DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj" -c Debug --no-restore -m:1 --filter CoreDataSeeder -p:NoWarn=NU1902%3BNU1510`
- `dotnet test "DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj" -c Debug --no-restore -m:1 --filter "FullyQualifiedName~MythicalAnimalSeederTemplateTests|FullyQualifiedName~SupernaturalSeederTemplateTests" -p:NoWarn=NU1902%3BNU1510`