### PR TITLE
Expand event surface metadata and item interaction hooks

### DIFF
--- a/Design Documents/Event_System_for_AI_and_Hooks.md
+++ b/Design Documents/Event_System_for_AI_and_Hooks.md
@@ -38,7 +38,7 @@ For AI authors, the important point is that event names are only half of the con
 - the FutureProg compatibility signature
 
 ### `EventInfoAttribute`
-Most event entries carry `EventInfoAttribute`, which stores:
+Every event entry carries `EventInfoAttribute`, which stores:
 
 - a human-readable description
 - parameter type names for display
@@ -364,6 +364,48 @@ Frequently used movement events include:
 - `CharacterCannotMove`
 
 These drive wanderers, trackers, herds, doorguards, and greeting/farewell logic.
+
+### Item Interaction
+Useful item interaction events include:
+
+- `CharacterOpenedItem`
+- `ItemOpened`
+- `CharacterOpenedItemWitness`
+- `CharacterClosedItem`
+- `ItemClosed`
+- `CharacterClosedItemWitness`
+- `ItemLocked`
+- `ItemLockedWitness`
+- `ItemUnlocked`
+- `ItemUnlockedWitness`
+
+These provide hook/prog surfaces for doors, containers, lockable props, alarms, security scripts, and NPC reactions to people manipulating objects in a room. Lock events fire on the lock item and on witnesses; the actor and key parameters may be null when a lock changes state without a keyed actor action.
+
+### Equipment
+Useful equipment events include:
+
+- `ItemWielded`
+- `ItemWieldedWitness`
+- `ItemUnwielded`
+- `CharacterUnwieldedItem`
+- `CharacterUnwieldedItemWitness`
+- `ItemWorn`
+- `ItemWornWitness`
+- `CharacterWornItemRemoved`
+- `ItemRemovedFromWear`
+- `CharacterWornItemRemovedWitness`
+
+These are useful for weapon alarms, cursed or reactive equipment, guards responding to armed characters, and content that cares about people putting on or removing visible gear.
+
+### Mounts
+Mounting events include:
+
+- `CharacterMounted`
+- `CharacterMountedWitness`
+- `CharacterDismounted`
+- `CharacterDismountedWitness`
+
+These let mount AI, stable areas, guards, and scenario hooks react to riders mounting or dismounting character mounts.
 
 ### Combat
 Common combat events include:

--- a/Design Documents/Item_System_Runtime_Model.md
+++ b/Design Documents/Item_System_Runtime_Model.md
@@ -24,6 +24,17 @@ In practice, `GameItem` is the orchestration layer. Components provide most spec
 
 Planar presence is resolved at the item level before component-specific physical interaction. A visible but non-interactable item can still appear in descriptions or be speech/observation targeted where commands allow it, while inventory and manipulation checks can reject it through `CanInteractPlanar`.
 
+### Runtime Event Surface
+Items participate in the shared event system through `HandleEvent(...)`, installed hooks, and component-level event forwarding.
+
+Item-facing event surfaces include:
+- load and creation activation through `ItemFinishedLoading`
+- item manipulation such as being opened, closed, locked, unlocked, wielded, unwielded, worn, or removed from wear
+- item health changes through `ItemDamaged` and `ItemDamagedWitness`
+- local witness variants that let rooms, characters, room items, and carried external items react through hooks or AI
+
+When adding a new item event, keep the `EventInfoAttribute` metadata in `FutureMUDLibrary/Events/EventTypeEnum.cs` aligned with the actual dispatch arguments. The event metadata is the builder-facing contract used by `show event`, hook validation, and FutureProg compatibility checks.
+
 ### `IGameItemProto`
 `IGameItemProto` is the revisioned prototype for creating items.
 

--- a/FutureMUDLibrary Unit Tests/EventTypeMetadataTests.cs
+++ b/FutureMUDLibrary Unit Tests/EventTypeMetadataTests.cs
@@ -1,0 +1,42 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Events;
+using MudSharp.Framework;
+using System;
+using System.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class EventTypeMetadataTests
+{
+    [TestMethod]
+    public void EventTypes_AllHaveEventInfoMetadata()
+    {
+        EventType[] missingMetadata = Enum.GetValues<EventType>()
+                                          .Where(x => x.GetAttribute<EventInfoAttribute>() is null)
+                                          .ToArray();
+
+        Assert.IsFalse(missingMetadata.Any(), $"Missing EventInfoAttribute: {string.Join(", ", missingMetadata)}");
+    }
+
+    [TestMethod]
+    public void EventInfoMetadata_ParameterNamesAndProgTypesStayAligned()
+    {
+        foreach (EventType eventType in Enum.GetValues<EventType>())
+        {
+            EventInfoAttribute info = eventType.GetAttribute<EventInfoAttribute>();
+            Assert.IsFalse(string.IsNullOrWhiteSpace(info.Description), $"{eventType} has a blank description.");
+
+            var parameters = info.Parameters.ToArray();
+            var progTypes = info.ProgTypes.ToArray();
+
+            Assert.AreEqual(parameters.Length, progTypes.Length,
+                $"{eventType} has {parameters.Length} display parameters but {progTypes.Length} FutureProg types.");
+
+            Assert.IsFalse(parameters.Any(x => string.IsNullOrWhiteSpace(x.type)),
+                $"{eventType} has a blank parameter type.");
+            Assert.IsFalse(parameters.Any(x => string.IsNullOrWhiteSpace(x.name)),
+                $"{eventType} has a blank parameter name.");
+        }
+    }
+}

--- a/FutureMUDLibrary/Events/EventTypeEnum.cs
+++ b/FutureMUDLibrary/Events/EventTypeEnum.cs
@@ -18,7 +18,7 @@ namespace MudSharp.Events
         /// <summary>
         ///     Hooks any IHookable that witnessed an item being dropped. Parameteres are character, item, witness
         /// </summary>
-        [EventInfo("Hooks a perceiver witnessing an item being dropped.", new[] { "character", "item", "perceiver" }, new[] { "dropper", "dropped", "witness" }, new[] { ProgVariableTypeCode.Character, ProgVariableTypeCode.Item, ProgVariableTypeCode.Perceiver, })]
+        [EventInfo("Hooks a perceivable witnessing an item being dropped.", new[] { "character", "item", "perceivable" }, new[] { "dropper", "dropped", "witness" }, new[] { ProgVariableTypeCode.Character, ProgVariableTypeCode.Item, ProgVariableTypeCode.Perceivable, })]
         CharacterDroppedItemWitness = 1,
 
         /// <summary>
@@ -36,7 +36,7 @@ namespace MudSharp.Events
         /// <summary>
         ///     Hooks any IHookable that witnesed an item being gotten from the ground. Parameters are character, item, witness
         /// </summary>
-        [EventInfo("Hooks a witnessing an item being gotten from the ground.", new[] { "character", "item", "perceiver" }, new[] { "getter", "gotten", "witness" }, new[] { ProgVariableTypeCode.Character, ProgVariableTypeCode.Item, ProgVariableTypeCode.Perceiver })]
+        [EventInfo("Hooks a perceivable witnessing an item being gotten from the ground.", new[] { "character", "item", "perceivable" }, new[] { "getter", "gotten", "witness" }, new[] { ProgVariableTypeCode.Character, ProgVariableTypeCode.Item, ProgVariableTypeCode.Perceivable })]
         CharacterGotItemWitness = 4,
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace MudSharp.Events
         ///     Hooks any IHookable that witnesed an item being gotten from a container. Parameters are character, item, container,
         ///     witness
         /// </summary>
-        [EventInfo("Hooks witnessing an item being gotten from a container.", new[] { "character", "item", "item", "perceiver" }, new[] { "getter", "gotten", "container", "witness" }, new[] { ProgVariableTypeCode.Character, ProgVariableTypeCode.Item, ProgVariableTypeCode.Item, ProgVariableTypeCode.Perceiver, })]
+        [EventInfo("Hooks a perceivable witnessing an item being gotten from a container.", new[] { "character", "item", "item", "perceivable" }, new[] { "getter", "gotten", "container", "witness" }, new[] { ProgVariableTypeCode.Character, ProgVariableTypeCode.Item, ProgVariableTypeCode.Item, ProgVariableTypeCode.Perceivable, })]
         CharacterGotItemContainerWitness = 7,
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace MudSharp.Events
         ///     Hooks any IHookable that witnesed an item being put in a container. Parameters are character, item, container,
         ///     witness
         /// </summary>
-        [EventInfo("Hooks witnessing an item being put in a container.", new[] { "character", "item", "item", "perceiver" }, new[] { "putter", "put", "container", "witness" }, new[] { ProgVariableTypeCode.Character, ProgVariableTypeCode.Item, ProgVariableTypeCode.Item, ProgVariableTypeCode.Perceiver, })]
+        [EventInfo("Hooks a perceivable witnessing an item being put in a container.", new[] { "character", "item", "item", "perceivable" }, new[] { "putter", "put", "container", "witness" }, new[] { ProgVariableTypeCode.Character, ProgVariableTypeCode.Item, ProgVariableTypeCode.Item, ProgVariableTypeCode.Perceivable, })]
         CharacterPutItemContainerWitness = 10,
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace MudSharp.Events
         /// <summary>
         ///     Hooks the character who is witnessing an item being given. Parameters are giver, receiver, item, witness
         /// </summary>
-        [EventInfo("Hooks witnessing an item being given to someone.", new[] { "character", "character", "item", "perceiver" }, new[] { "giver", "receiver", "given", "witness" }, new[] { ProgVariableTypeCode.Character, ProgVariableTypeCode.Character, ProgVariableTypeCode.Item, ProgVariableTypeCode.Perceiver, })]
+        [EventInfo("Hooks a perceivable witnessing an item being given to someone.", new[] { "character", "character", "item", "perceivable" }, new[] { "giver", "receiver", "given", "witness" }, new[] { ProgVariableTypeCode.Character, ProgVariableTypeCode.Character, ProgVariableTypeCode.Item, ProgVariableTypeCode.Perceivable, })]
         CharacterGiveItemWitness = 14,
 
         /// <summary>
@@ -247,7 +247,7 @@ namespace MudSharp.Events
         ///     Hooks to any character who is targeted by a social. Parameters are Parameters are socialite, social, target,
         ///     (cellexit)direction
         /// </summary>
-        [EventInfo("Hooks to a perceivable being targeted by a social", new[] { "character", "text", "perceivable", "exit" }, new[] { "socialite", "social", "target", "exit" }, new[] { ProgVariableTypeCode.Character, ProgVariableTypeCode.Text, ProgVariableTypeCode.Collection, ProgVariableTypeCode.Exit })]
+        [EventInfo("Hooks to a perceivable being targeted by a social", new[] { "character", "text", "perceivable", "exit" }, new[] { "socialite", "social", "target", "exit" }, new[] { ProgVariableTypeCode.Character, ProgVariableTypeCode.Text, ProgVariableTypeCode.Perceivable, ProgVariableTypeCode.Exit })]
         CharacterSocialTarget = 30,
 
         /// <summary>
@@ -411,7 +411,7 @@ namespace MudSharp.Events
         /// <summary>
         ///     Hooks to someone who has witnessed another bleed. Parameters are character, bleeding, witness
         /// </summary>
-        [EventInfo("Fires when something witnesses a character bleeding.", new[] { "character", "number", "perceiver" }, new[] { "person", "litres", "witness" }, new[] { ProgVariableTypeCode.Character, ProgVariableTypeCode.Number, ProgVariableTypeCode.Perceiver, })]
+        [EventInfo("Fires when a perceivable witnesses a character bleeding.", new[] { "character", "number", "perceivable" }, new[] { "person", "litres", "witness" }, new[] { ProgVariableTypeCode.Character, ProgVariableTypeCode.Number, ProgVariableTypeCode.Perceivable, })]
         WitnessBleedTick = 56,
 
 
@@ -490,7 +490,7 @@ namespace MudSharp.Events
         /// <summary>
         /// Fires whenever weather changes for all perceivers and locations. Parameters are perceiver, oldweather, newweather
         /// </summary>
-        [EventInfo("Fires on all perceivers and locations when weather changes.", new[] { "perceiver", "weatherevent", "weatherevent" }, new[] { "witness", "oldweather", "newweather" }, new[] { ProgVariableTypeCode.Perceiver, ProgVariableTypeCode.WeatherEvent, ProgVariableTypeCode.WeatherEvent })]
+        [EventInfo("Fires on all perceivers and locations when weather changes.", new[] { "perceivable", "weatherevent", "weatherevent" }, new[] { "witness", "oldweather", "newweather" }, new[] { ProgVariableTypeCode.Perceivable, ProgVariableTypeCode.WeatherEvent, ProgVariableTypeCode.WeatherEvent })]
         WeatherChanged = 76,
 
         /// <summary>
@@ -532,6 +532,7 @@ namespace MudSharp.Events
         /// <summary>
         /// Fires on all clocked-in employees of a shop when an item requires restocking. Parameters are employee, shop, merchandise, amount
         /// </summary>
+        [EventInfo("Fires on clocked-in employees of a shop when merchandise requires restocking.", new[] { "character", "shop", "merchandise", "number" }, new[] { "employee", "shop", "merchandise", "quantity" }, new[] { ProgVariableTypeCode.Character, ProgVariableTypeCode.Shop, ProgVariableTypeCode.Merchandise, ProgVariableTypeCode.Number })]
         ItemRequiresRestocking = 83,
 
         /// <summary>
@@ -552,9 +553,13 @@ namespace MudSharp.Events
         /// <summary>
         /// Fires when the character witnesses a crime committed at their location. (criminal, victim, witness, crime id)
         /// </summary>
-        [EventInfo("Fires when the character witnesses a crime committed at their location", new[] { "character", "character", "character", "number" }, new[] { "criminal", "victim", "witness", "crime" }, new[] { ProgVariableTypeCode.Character, ProgVariableTypeCode.Character, ProgVariableTypeCode.Character, ProgVariableTypeCode.Number })]
+        [EventInfo("Fires when the character witnesses a crime committed at their location", new[] { "character", "character", "character", "crime" }, new[] { "criminal", "victim", "witness", "crime" }, new[] { ProgVariableTypeCode.Character, ProgVariableTypeCode.Character, ProgVariableTypeCode.Character, ProgVariableTypeCode.Crime })]
         WitnessedCrime = 87,
 
+        /// <summary>
+        /// Fires on the victim of a crime. Parameters are criminal, victim, crime.
+        /// </summary>
+        [EventInfo("Fires on the victim of a crime.", new[] { "character", "character", "crime" }, new[] { "criminal", "victim", "crime" }, new[] { ProgVariableTypeCode.Character, ProgVariableTypeCode.Character, ProgVariableTypeCode.Crime })]
         VictimOfCrime = 88,
 
         /// <summary>
@@ -591,25 +596,25 @@ namespace MudSharp.Events
         [EventInfo("Fired on an item when the item takes damage. Weapon and Aggressor may be null.", ["item", "item", "character"], ["item", "weapon", "aggressor"], [ProgVariableTypeCode.Item, ProgVariableTypeCode.Item, ProgVariableTypeCode.Character])]
         ItemDamaged = 94,
 
-        [EventInfo("Fired on all perceivers in the location when the item takes damage. Weapon and Aggressor may be null.", ["item", "item", "character", "perceiver"], ["item", "weapon", "aggressor", "witness"], [ProgVariableTypeCode.Item, ProgVariableTypeCode.Item, ProgVariableTypeCode.Character, ProgVariableTypeCode.Perceiver])]
+        [EventInfo("Fired on all perceivables in the location when the item takes damage. Weapon and Aggressor may be null.", ["item", "item", "character", "perceivable"], ["item", "weapon", "aggressor", "witness"], [ProgVariableTypeCode.Item, ProgVariableTypeCode.Item, ProgVariableTypeCode.Character, ProgVariableTypeCode.Perceivable])]
         ItemDamagedWitness = 95,
 
         [EventInfo("Fired on a character when they take damage. Weapon and Aggressor may be null.", ["character", "item", "character"], ["character", "weapon", "aggressor"], [ProgVariableTypeCode.Character, ProgVariableTypeCode.Item, ProgVariableTypeCode.Character])]
         CharacterDamaged = 96,
 
-        [EventInfo("Fired on all perceivers in the location when a character takes damage.  Weapon and Aggressor may be null.", ["character", "item", "character", "perceiver"], ["character", "weapon", "aggressor", "witness"], [ProgVariableTypeCode.Character, ProgVariableTypeCode.Item, ProgVariableTypeCode.Character, ProgVariableTypeCode.Perceiver])]
+        [EventInfo("Fired on all perceivables in the location when a character takes damage.  Weapon and Aggressor may be null.", ["character", "item", "character", "perceivable"], ["character", "weapon", "aggressor", "witness"], [ProgVariableTypeCode.Character, ProgVariableTypeCode.Item, ProgVariableTypeCode.Character, ProgVariableTypeCode.Perceivable])]
         CharacterDamagedWitness = 97,
 
         [EventInfo("Fired on an item when it is wielded", ["item", "character"], ["item", "wielder"], [ProgVariableTypeCode.Item, ProgVariableTypeCode.Character])]
         ItemWielded = 98,
 
-        [EventInfo("Fired on all perceivers in the location when an item is wielded", ["item", "character", "perceiver"], ["item", "wielder", "witness"], [ProgVariableTypeCode.Item, ProgVariableTypeCode.Character, ProgVariableTypeCode.Perceiver])]
+        [EventInfo("Fired on all perceivables in the location when an item is wielded", ["item", "character", "perceivable"], ["item", "wielder", "witness"], [ProgVariableTypeCode.Item, ProgVariableTypeCode.Character, ProgVariableTypeCode.Perceivable])]
         ItemWieldedWitness = 99,
 
         [EventInfo("Fired on an item when it is worn", ["item", "character"], ["item", "wearer"], [ProgVariableTypeCode.Item, ProgVariableTypeCode.Character])]
         ItemWorn = 100,
 
-        [EventInfo("Fired on all perceivers in the location when an item is worn", ["item", "character", "perceiver"], ["item", "wearer", "witness"], [ProgVariableTypeCode.Item, ProgVariableTypeCode.Character, ProgVariableTypeCode.Perceiver])]
+        [EventInfo("Fired on all perceivables in the location when an item is worn", ["item", "character", "perceivable"], ["item", "wearer", "witness"], [ProgVariableTypeCode.Item, ProgVariableTypeCode.Character, ProgVariableTypeCode.Perceivable])]
         ItemWornWitness = 101,
 
         [EventInfo("Fired on a character when they become hidden", ["character"], ["character"], [ProgVariableTypeCode.Character])]
@@ -622,6 +627,66 @@ namespace MudSharp.Events
         /// Fires on an item receiving in-call keypad digits from a telephone source. Parameters are source item, digits.
         /// </summary>
         [EventInfo("Fires on an item receiving in-call keypad digits from a telephone source", ["item", "text"], ["source", "digits"], [ProgVariableTypeCode.Item, ProgVariableTypeCode.Text])]
-        TelephoneDigitsReceived = 104
+        TelephoneDigitsReceived = 104,
+
+        [EventInfo("Fires on a character when they open an item.", ["character", "item"], ["opener", "item"], [ProgVariableTypeCode.Character, ProgVariableTypeCode.Item])]
+        CharacterOpenedItem = 105,
+
+        [EventInfo("Fires on an item when it is opened by a character.", ["character", "item"], ["opener", "item"], [ProgVariableTypeCode.Character, ProgVariableTypeCode.Item])]
+        ItemOpened = 106,
+
+        [EventInfo("Fires on perceivables witnessing a character opening an item.", ["character", "item", "perceivable"], ["opener", "item", "witness"], [ProgVariableTypeCode.Character, ProgVariableTypeCode.Item, ProgVariableTypeCode.Perceivable])]
+        CharacterOpenedItemWitness = 107,
+
+        [EventInfo("Fires on a character when they close an item.", ["character", "item"], ["closer", "item"], [ProgVariableTypeCode.Character, ProgVariableTypeCode.Item])]
+        CharacterClosedItem = 108,
+
+        [EventInfo("Fires on an item when it is closed by a character.", ["character", "item"], ["closer", "item"], [ProgVariableTypeCode.Character, ProgVariableTypeCode.Item])]
+        ItemClosed = 109,
+
+        [EventInfo("Fires on perceivables witnessing a character closing an item.", ["character", "item", "perceivable"], ["closer", "item", "witness"], [ProgVariableTypeCode.Character, ProgVariableTypeCode.Item, ProgVariableTypeCode.Perceivable])]
+        CharacterClosedItemWitness = 110,
+
+        [EventInfo("Fires on a character when they unwield an item.", ["character", "item"], ["unwielder", "item"], [ProgVariableTypeCode.Character, ProgVariableTypeCode.Item])]
+        CharacterUnwieldedItem = 111,
+
+        [EventInfo("Fires on an item when it is unwielded.", ["character", "item"], ["unwielder", "item"], [ProgVariableTypeCode.Character, ProgVariableTypeCode.Item])]
+        ItemUnwielded = 112,
+
+        [EventInfo("Fires on perceivables witnessing a character unwielding an item.", ["character", "item", "perceivable"], ["unwielder", "item", "witness"], [ProgVariableTypeCode.Character, ProgVariableTypeCode.Item, ProgVariableTypeCode.Perceivable])]
+        CharacterUnwieldedItemWitness = 113,
+
+        [EventInfo("Fires on a character when one of their worn items is removed.", ["character", "character", "item"], ["wearer", "remover", "item"], [ProgVariableTypeCode.Character, ProgVariableTypeCode.Character, ProgVariableTypeCode.Item])]
+        CharacterWornItemRemoved = 114,
+
+        [EventInfo("Fires on an item when it is removed from being worn.", ["character", "character", "item"], ["wearer", "remover", "item"], [ProgVariableTypeCode.Character, ProgVariableTypeCode.Character, ProgVariableTypeCode.Item])]
+        ItemRemovedFromWear = 115,
+
+        [EventInfo("Fires on perceivables witnessing a worn item being removed.", ["character", "character", "item", "perceivable"], ["wearer", "remover", "item", "witness"], [ProgVariableTypeCode.Character, ProgVariableTypeCode.Character, ProgVariableTypeCode.Item, ProgVariableTypeCode.Perceivable])]
+        CharacterWornItemRemovedWitness = 116,
+
+        [EventInfo("Fires on a character when they mount another character.", ["character", "character"], ["rider", "mount"], [ProgVariableTypeCode.Character, ProgVariableTypeCode.Character])]
+        CharacterMounted = 117,
+
+        [EventInfo("Fires on perceivables witnessing a character mounting another character.", ["character", "character", "perceivable"], ["rider", "mount", "witness"], [ProgVariableTypeCode.Character, ProgVariableTypeCode.Character, ProgVariableTypeCode.Perceivable])]
+        CharacterMountedWitness = 118,
+
+        [EventInfo("Fires on a character when they dismount another character.", ["character", "character"], ["rider", "mount"], [ProgVariableTypeCode.Character, ProgVariableTypeCode.Character])]
+        CharacterDismounted = 119,
+
+        [EventInfo("Fires on perceivables witnessing a character dismounting another character.", ["character", "character", "perceivable"], ["rider", "mount", "witness"], [ProgVariableTypeCode.Character, ProgVariableTypeCode.Character, ProgVariableTypeCode.Perceivable])]
+        CharacterDismountedWitness = 120,
+
+        [EventInfo("Fires on a lock item when it is locked. Actor and key may be null.", ["item", "character", "item", "perceivable"], ["lock", "actor", "key", "target"], [ProgVariableTypeCode.Item, ProgVariableTypeCode.Character, ProgVariableTypeCode.Item, ProgVariableTypeCode.Perceivable])]
+        ItemLocked = 121,
+
+        [EventInfo("Fires on perceivables witnessing a lock item being locked. Actor and key may be null.", ["item", "character", "item", "perceivable", "perceivable"], ["lock", "actor", "key", "target", "witness"], [ProgVariableTypeCode.Item, ProgVariableTypeCode.Character, ProgVariableTypeCode.Item, ProgVariableTypeCode.Perceivable, ProgVariableTypeCode.Perceivable])]
+        ItemLockedWitness = 122,
+
+        [EventInfo("Fires on a lock item when it is unlocked. Actor and key may be null.", ["item", "character", "item", "perceivable"], ["lock", "actor", "key", "target"], [ProgVariableTypeCode.Item, ProgVariableTypeCode.Character, ProgVariableTypeCode.Item, ProgVariableTypeCode.Perceivable])]
+        ItemUnlocked = 123,
+
+        [EventInfo("Fires on perceivables witnessing a lock item being unlocked. Actor and key may be null.", ["item", "character", "item", "perceivable", "perceivable"], ["lock", "actor", "key", "target", "witness"], [ProgVariableTypeCode.Item, ProgVariableTypeCode.Character, ProgVariableTypeCode.Item, ProgVariableTypeCode.Perceivable, ProgVariableTypeCode.Perceivable])]
+        ItemUnlockedWitness = 124
     }
 }

--- a/MudSharpCore/Body/Implementations/BodyBehaviours.cs
+++ b/MudSharpCore/Body/Implementations/BodyBehaviours.cs
@@ -1,6 +1,7 @@
 using MudSharp.Character;
 using MudSharp.Communication.Language;
 using MudSharp.Construction.Boundary;
+using MudSharp.Events;
 using MudSharp.Form.Shape;
 using MudSharp.Framework;
 using MudSharp.GameItems;
@@ -190,6 +191,17 @@ public partial class Body
         return false;
     }
 
+    private void HandleCharacterItemEvent(EventType characterEvent, EventType itemEvent, EventType witnessEvent,
+        IGameItem item)
+    {
+        Actor.HandleEvent(characterEvent, Actor, item);
+        item.HandleEvent(itemEvent, Actor, item);
+        foreach (IHandleEvents witness in Location.EventHandlers)
+        {
+            witness.HandleEvent(witnessEvent, Actor, item, witness);
+        }
+    }
+
     public void Open(IOpenable openable, ICharacter openableOwner, IEmote playerEmote, bool useCouldLogic = false)
     {
         if (useCouldLogic)
@@ -262,6 +274,8 @@ public partial class Body
         }
 
         openable.Open();
+        HandleCharacterItemEvent(EventType.CharacterOpenedItem, EventType.ItemOpened,
+            EventType.CharacterOpenedItemWitness, openable.Parent);
     }
 
     public bool CouldOpen(IOpenable openable)
@@ -361,6 +375,8 @@ public partial class Body
         }
 
         openable.Close();
+        HandleCharacterItemEvent(EventType.CharacterClosedItem, EventType.ItemClosed,
+            EventType.CharacterClosedItemWitness, openable.Parent);
     }
 
     public string WhyCannotClose { get; protected set; }

--- a/MudSharpCore/Body/Implementations/BodyBiology.cs
+++ b/MudSharpCore/Body/Implementations/BodyBiology.cs
@@ -1295,7 +1295,7 @@ public partial class Body
         HandleEvent(EventType.CharacterDamaged, Actor, wound.ToolOrigin, wound.ActorOrigin);
         foreach (IHandleEvents witness in Location.EventHandlers)
         {
-            HandleEvent(EventType.CharacterDamagedWitness, Actor, wound.ToolOrigin, wound.ActorOrigin, witness);
+            witness.HandleEvent(EventType.CharacterDamagedWitness, Actor, wound.ToolOrigin, wound.ActorOrigin, witness);
         }
     }
 

--- a/MudSharpCore/Body/Implementations/BodyInventory.cs
+++ b/MudSharpCore/Body/Implementations/BodyInventory.cs
@@ -534,7 +534,7 @@ public partial class Body
         item.HandleEvent(EventType.ItemWielded, item, Actor);
         foreach (IHandleEvents witness in Location.EventHandlers)
         {
-            HandleEvent(EventType.ItemWieldedWitness, item, Actor, witness);
+            witness.HandleEvent(EventType.ItemWieldedWitness, item, Actor, witness);
         }
         return true;
     }
@@ -630,7 +630,7 @@ public partial class Body
         item.HandleEvent(EventType.ItemWielded, item, Actor);
         foreach (IHandleEvents witness in Location.EventHandlers)
         {
-            HandleEvent(EventType.ItemWieldedWitness, item, Actor, witness);
+            witness.HandleEvent(EventType.ItemWieldedWitness, item, Actor, witness);
         }
         return true;
     }
@@ -661,6 +661,8 @@ public partial class Body
         OnInventoryChange?.Invoke(InventoryState.Wielded, InventoryState.Held, item);
         item.InvokeInventoryChange(InventoryState.Wielded, InventoryState.Held);
         CheckConsequences();
+        HandleCharacterItemEvent(EventType.CharacterUnwieldedItem, EventType.ItemUnwielded,
+            EventType.CharacterUnwieldedItemWitness, item);
         return true;
     }
 
@@ -2578,6 +2580,17 @@ public partial class Body
         output.Append(playerEmote);
         OutputHandler.Handle(output);
         RemoveItem(item);
+        HandleWornItemRemovedEvent(item, remover);
+    }
+
+    private void HandleWornItemRemovedEvent(IGameItem item, ICharacter remover)
+    {
+        Actor.HandleEvent(EventType.CharacterWornItemRemoved, Actor, remover, item);
+        item.HandleEvent(EventType.ItemRemovedFromWear, Actor, remover, item);
+        foreach (IHandleEvents witness in Location.EventHandlers)
+        {
+            witness.HandleEvent(EventType.CharacterWornItemRemovedWitness, Actor, remover, item, witness);
+        }
     }
 
     public void RemoveItem(IGameItem item, IEmote playerEmote, bool silent = false,
@@ -2618,6 +2631,7 @@ public partial class Body
             Get(item, silent: true, ignoreFlags: ignoreFlags);
         }
 
+        HandleWornItemRemovedEvent(item, Actor);
         InventoryChanged = true;
     }
 
@@ -2843,7 +2857,7 @@ public partial class Body
         item.HandleEvent(EventType.ItemWorn, item, Actor);
         foreach (IHandleEvents witness in Location.EventHandlers)
         {
-            HandleEvent(EventType.ItemWornWitness, item, Actor, witness);
+            witness.HandleEvent(EventType.ItemWornWitness, item, Actor, witness);
         }
     }
 

--- a/MudSharpCore/Character/CharacterEvents.cs
+++ b/MudSharpCore/Character/CharacterEvents.cs
@@ -33,6 +33,10 @@ public partial class Character
         switch (type)
         {
             case EventType.CharacterBeginMovementWitness:
+            case EventType.CharacterClosedItemWitness:
+            case EventType.CharacterDamagedWitness:
+            case EventType.CharacterDiesWitness:
+            case EventType.CharacterDismountedWitness:
             case EventType.CharacterDoorKnockedOtherSide:
             case EventType.CharacterDoorKnockedSameSide:
             case EventType.CharacterDroppedItemWitness:
@@ -42,7 +46,11 @@ public partial class Character
             case EventType.CharacterGiveItemWitness:
             case EventType.CharacterGotItemContainerWitness:
             case EventType.CharacterGotItemWitness:
+            case EventType.CharacterHidesWitness:
+            case EventType.CharacterIncapacitatedWitness:
             case EventType.CharacterLeaveCellWitness:
+            case EventType.CharacterMountedWitness:
+            case EventType.CharacterOpenedItemWitness:
             case EventType.CharacterPutItemContainerWitness:
             case EventType.CharacterSheatheItemWitness:
             case EventType.CharacterSocialWitness:
@@ -52,7 +60,14 @@ public partial class Character
             case EventType.CharacterStopMovementClosedDoorWitness:
             case EventType.CharacterStopMovementWitness:
             case EventType.CharacterSwallowWitness:
+            case EventType.CharacterUnwieldedItemWitness:
+            case EventType.CharacterWornItemRemovedWitness:
             case EventType.EngagedInCombatWitness:
+            case EventType.ItemDamagedWitness:
+            case EventType.ItemLockedWitness:
+            case EventType.ItemUnlockedWitness:
+            case EventType.ItemWieldedWitness:
+            case EventType.ItemWornWitness:
             case EventType.WitnessBleedTick:
                 foreach (IGameItem item in Body.ExternalItems)
                 {

--- a/MudSharpCore/Character/CharacterMountable.cs
+++ b/MudSharpCore/Character/CharacterMountable.cs
@@ -1,6 +1,7 @@
 using MudSharp.Body.Position;
 using MudSharp.Character.Heritage;
 using MudSharp.Construction.Boundary;
+using MudSharp.Events;
 using MudSharp.Framework;
 using MudSharp.NPC;
 using MudSharp.NPC.AI;
@@ -121,6 +122,15 @@ public partial class Character
 
     public IEnumerable<ICharacter> Riders => _riders;
 
+    private void HandleMountEvent(EventType characterEvent, EventType witnessEvent, ICharacter rider)
+    {
+        rider.HandleEvent(characterEvent, rider, this);
+        foreach (IHandleEvents witness in Location.EventHandlers.Where(x => x != rider))
+        {
+            witness.HandleEvent(witnessEvent, rider, this, witness);
+        }
+    }
+
     public bool Mount(ICharacter rider)
     {
         if (!CanBeMountedBy(rider))
@@ -139,6 +149,7 @@ public partial class Character
         _riders.Add(rider);
         rider.RidingMount = this;
         rider.OutputHandler.Handle(new EmoteOutput(new Emote(ai.MountEmote(this, rider), this, this, rider)));
+        HandleMountEvent(EventType.CharacterMounted, EventType.CharacterMountedWitness, rider);
         return false;
     }
 
@@ -152,6 +163,7 @@ public partial class Character
         }
 
         rider.OutputHandler.Handle(new EmoteOutput(new Emote(ai.DismountEmote(this, rider), this, this, rider)));
+        HandleMountEvent(EventType.CharacterDismounted, EventType.CharacterDismountedWitness, rider);
         rider.RidingMount = null;
         _riders.Remove(rider);
     }

--- a/MudSharpCore/Construction/Cell.cs
+++ b/MudSharpCore/Construction/Cell.cs
@@ -1069,7 +1069,7 @@ public partial class Cell : Location, IDisposable, ICell
                 continue;
             }
 
-            HandleEvent(EventType.WeatherChanged, handler, oldWeather, newWeather);
+            handler.HandleEvent(EventType.WeatherChanged, handler, oldWeather, newWeather);
         }
     }
 
@@ -1107,7 +1107,7 @@ public partial class Cell : Location, IDisposable, ICell
                 continue;
             }
 
-            HandleEvent(EventType.WeatherChanged, handler, oldWeather, newWeather);
+            handler.HandleEvent(EventType.WeatherChanged, handler, oldWeather, newWeather);
         }
     }
 

--- a/MudSharpCore/GameItems/Components/LatchGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/LatchGameItemComponent.cs
@@ -1,6 +1,7 @@
 ﻿using MudSharp.Character;
 using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
+using MudSharp.Events;
 using MudSharp.Form.Shape;
 using MudSharp.Framework;
 using MudSharp.GameItems.Interfaces;
@@ -157,6 +158,7 @@ public class LatchGameItemComponent : GameItemComponent, ILock
                      .Handle(
                          new EmoteOutput(new Emote(_prototype.UnlockEmoteOtherSide, actor, actor, Parent,
                              containingPerceivable)));
+        HandleItemLockEvent(EventType.ItemUnlocked, EventType.ItemUnlockedWitness, actor, key?.Parent, containingPerceivable);
         return true;
     }
 
@@ -191,6 +193,7 @@ public class LatchGameItemComponent : GameItemComponent, ILock
                      .Handle(
                          new EmoteOutput(new Emote(_prototype.LockEmoteOtherSide, actor, actor, Parent,
                              containingPerceivable)));
+        HandleItemLockEvent(EventType.ItemLocked, EventType.ItemLockedWitness, actor, key?.Parent, containingPerceivable);
         return true;
     }
 
@@ -223,6 +226,8 @@ public class LatchGameItemComponent : GameItemComponent, ILock
                     flags: OutputFlags.SuppressObscured));
         }
 
+        HandleItemLockEvent(locked ? EventType.ItemLocked : EventType.ItemUnlocked,
+            locked ? EventType.ItemLockedWitness : EventType.ItemUnlockedWitness, null, null, Parent);
         return true;
     }
 

--- a/MudSharpCore/GameItems/Components/LockingContainerGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/LockingContainerGameItemComponent.cs
@@ -435,6 +435,8 @@ namespace MudSharp.GameItems.Components
                         flags: OutputFlags.SuppressObscured));
             }
 
+            HandleItemLockEvent(locked ? EventType.ItemLocked : EventType.ItemUnlocked,
+                locked ? EventType.ItemLockedWitness : EventType.ItemUnlockedWitness, null, null, Parent);
             return true;
         }
 
@@ -476,6 +478,7 @@ namespace MudSharp.GameItems.Components
                 }
             }
 
+            HandleItemLockEvent(EventType.ItemUnlocked, EventType.ItemUnlockedWitness, actor, key?.Parent, containingPerceivable);
             return true;
         }
 
@@ -512,6 +515,7 @@ namespace MudSharp.GameItems.Components
                 }
             }
 
+            HandleItemLockEvent(EventType.ItemLocked, EventType.ItemLockedWitness, actor, key?.Parent, containingPerceivable);
             return true;
         }
 

--- a/MudSharpCore/GameItems/Components/LockingDoorGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/LockingDoorGameItemComponent.cs
@@ -3,6 +3,7 @@ using MudSharp.Character;
 using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
 using MudSharp.Effects.Interfaces;
+using MudSharp.Events;
 using MudSharp.Framework;
 using MudSharp.GameItems.Interfaces;
 using MudSharp.GameItems.Prototypes;
@@ -121,6 +122,8 @@ public class LockingDoorGameItemComponent : DoorGameItemComponentBase, ILock
 					flags: OutputFlags.SuppressObscured));
 		}
 
+		HandleItemLockEvent(locked ? EventType.ItemLocked : EventType.ItemUnlocked,
+			locked ? EventType.ItemLockedWitness : EventType.ItemUnlockedWitness, null, null, Parent);
 		return true;
 	}
 
@@ -165,6 +168,7 @@ public class LockingDoorGameItemComponent : DoorGameItemComponentBase, ILock
 			}
 		}
 
+		HandleItemLockEvent(EventType.ItemUnlocked, EventType.ItemUnlockedWitness, actor, key?.Parent, containingPerceivable);
 		return true;
 	}
 
@@ -199,6 +203,7 @@ public class LockingDoorGameItemComponent : DoorGameItemComponentBase, ILock
 			}
 		}
 
+		HandleItemLockEvent(EventType.ItemLocked, EventType.ItemLockedWitness, actor, key?.Parent, containingPerceivable);
 		return true;
 	}
 

--- a/MudSharpCore/GameItems/Components/ProgLockGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/ProgLockGameItemComponent.cs
@@ -1,6 +1,7 @@
 ﻿using MudSharp.Character;
 using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
+using MudSharp.Events;
 using MudSharp.Form.Shape;
 using MudSharp.Framework;
 using MudSharp.GameItems.Interfaces;
@@ -151,6 +152,8 @@ public class ProgLockGameItemComponent : GameItemComponent, ILock
                     flags: OutputFlags.SuppressObscured));
         }
 
+        HandleItemLockEvent(locked ? EventType.ItemLocked : EventType.ItemUnlocked,
+            locked ? EventType.ItemLockedWitness : EventType.ItemUnlockedWitness, null, null, Parent);
         return true;
     }
 
@@ -187,6 +190,7 @@ public class ProgLockGameItemComponent : GameItemComponent, ILock
             }
         }
 
+        HandleItemLockEvent(EventType.ItemUnlocked, EventType.ItemUnlockedWitness, actor, key?.Parent, containingPerceivable);
         return true;
     }
 
@@ -223,6 +227,7 @@ public class ProgLockGameItemComponent : GameItemComponent, ILock
             }
         }
 
+        HandleItemLockEvent(EventType.ItemLocked, EventType.ItemLockedWitness, actor, key?.Parent, containingPerceivable);
         return true;
     }
 

--- a/MudSharpCore/GameItems/Components/ShopStallGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/ShopStallGameItemComponent.cs
@@ -768,6 +768,8 @@ namespace MudSharp.GameItems.Components
                         flags: OutputFlags.SuppressObscured));
             }
 
+            HandleItemLockEvent(locked ? EventType.ItemLocked : EventType.ItemUnlocked,
+                locked ? EventType.ItemLockedWitness : EventType.ItemUnlockedWitness, null, null, Parent);
             return true;
         }
 
@@ -809,6 +811,7 @@ namespace MudSharp.GameItems.Components
                 }
             }
 
+            HandleItemLockEvent(EventType.ItemUnlocked, EventType.ItemUnlockedWitness, actor, key?.Parent, containingPerceivable);
             return true;
         }
 
@@ -845,6 +848,7 @@ namespace MudSharp.GameItems.Components
                 }
             }
 
+            HandleItemLockEvent(EventType.ItemLocked, EventType.ItemLockedWitness, actor, key?.Parent, containingPerceivable);
             return true;
         }
 

--- a/MudSharpCore/GameItems/Components/SimpleLockGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/SimpleLockGameItemComponent.cs
@@ -2,6 +2,7 @@
 using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
 using MudSharp.Effects.Interfaces;
+using MudSharp.Events;
 using MudSharp.Form.Shape;
 using MudSharp.Framework;
 using MudSharp.GameItems.Interfaces;
@@ -156,6 +157,8 @@ public class SimpleLockGameItemComponent : GameItemComponent, ILock
                     flags: OutputFlags.SuppressObscured));
         }
 
+        HandleItemLockEvent(locked ? EventType.ItemLocked : EventType.ItemUnlocked,
+            locked ? EventType.ItemLockedWitness : EventType.ItemUnlockedWitness, null, null, Parent);
         return true;
     }
 
@@ -203,6 +206,7 @@ public class SimpleLockGameItemComponent : GameItemComponent, ILock
             }
         }
 
+        HandleItemLockEvent(EventType.ItemUnlocked, EventType.ItemUnlockedWitness, actor, key?.Parent, containingPerceivable);
         return true;
     }
 
@@ -245,6 +249,7 @@ public class SimpleLockGameItemComponent : GameItemComponent, ILock
             }
         }
 
+        HandleItemLockEvent(EventType.ItemLocked, EventType.ItemLockedWitness, actor, key?.Parent, containingPerceivable);
         return true;
     }
 

--- a/MudSharpCore/GameItems/GameItemComponent.cs
+++ b/MudSharpCore/GameItems/GameItemComponent.cs
@@ -301,6 +301,16 @@ public abstract class GameItemComponent : LateInitialisingItem, IGameItemCompone
         DescriptionUpdate?.Invoke(this, new EventArgs());
     }
 
+    protected void HandleItemLockEvent(EventType itemEvent, EventType witnessEvent, ICharacter actor, IGameItem key,
+        IPerceivable containingPerceivable)
+    {
+        Parent.HandleEvent(itemEvent, Parent, actor, key, containingPerceivable);
+        foreach (IHandleEvents witness in Parent.TrueLocations.SelectMany(x => x.EventHandlers))
+        {
+            witness.HandleEvent(witnessEvent, Parent, actor, key, containingPerceivable, witness);
+        }
+    }
+
     #endregion
 
     #region IHandleEvents Members

--- a/MudSharpCore/GameItems/GameItemHealth.cs
+++ b/MudSharpCore/GameItems/GameItemHealth.cs
@@ -65,7 +65,7 @@ public partial class GameItem : IHaveWounds
         HandleEvent(EventType.ItemDamaged, this, wound.ToolOrigin, wound.ActorOrigin);
         foreach (IHandleEvents witness in TrueLocations.SelectMany(x => x.EventHandlers))
         {
-            HandleEvent(EventType.ItemDamagedWitness, this, wound.ToolOrigin, wound.ActorOrigin, witness);
+            witness.HandleEvent(EventType.ItemDamagedWitness, this, wound.ToolOrigin, wound.ActorOrigin, witness);
         }
 
         PileGameItemComponent pile = GetItemType<PileGameItemComponent>();

--- a/MudSharpCore/Movement/Movement.cs
+++ b/MudSharpCore/Movement/Movement.cs
@@ -777,7 +777,7 @@ public class Movement : IMovement
                     person.OutputHandler.Handle(output, OutputRange.Personal);
 					if (!MovementEventUtilities.ShouldSuppressMovementEvents(person))
 					{
-						person.HandleEvent(EventType.CharacterStopMovement);
+						person.HandleEvent(EventType.CharacterStopMovement, person, Exit.Origin, Exit);
 						foreach (IHandleEvents witness in person.Location.EventHandlers.Except(person))
 						{
 							witness.HandleEvent(EventType.CharacterStopMovementWitness, person, Exit.Origin, Exit, witness);
@@ -831,7 +831,7 @@ public class Movement : IMovement
                     person.OutputHandler.Handle(output, OutputRange.Personal);
 					if (!MovementEventUtilities.ShouldSuppressMovementEvents(person))
 					{
-						person.HandleEvent(EventType.CharacterStopMovement);
+						person.HandleEvent(EventType.CharacterStopMovement, person, Exit.Origin, Exit);
 						foreach (IHandleEvents witness in person.Location.EventHandlers.Except(person))
 						{
 							witness.HandleEvent(EventType.CharacterStopMovementWitness, person, Exit.Origin, Exit, witness);


### PR DESCRIPTION
## Summary
- Expanded the event catalog docs to cover item interaction, equipment, and mount-related surfaces.
- Added missing `EventInfoAttribute` coverage and corrected several event metadata entries to align with actual dispatch types.
- Wired new body-level events for opening, closing, unwielding, removing worn items, mounting, dismounting, and lock/unlock handling.
- Added metadata regression tests to ensure every `EventType` carries aligned event descriptors and FutureProg types.

## Testing
- Not run (not requested)