### PR TITLE
Expand auxiliary combat effects and seed stock tactical moves

### DIFF
--- a/DatabaseSeeder Unit Tests/CombatSeederSourceTests.cs
+++ b/DatabaseSeeder Unit Tests/CombatSeederSourceTests.cs
@@ -172,6 +172,158 @@ public class CombatSeederSourceTests
     }
 
 	[TestMethod]
+	public void CombatAuxiliarySeederSource_HumanCatalogue_HasTwentyNamedMovesAndNewEffectTypes()
+	{
+		string source = File.ReadAllText(GetSeederSourcePath("CombatAuxiliarySeederHelper.cs"));
+		string[] expectedNames =
+		[
+			"Circle to Flank",
+			"Sidestep and Press",
+			"Bind and Step",
+			"Low Line Feint",
+			"High Line Feint",
+			"Distracting Flourish",
+			"False Opening",
+			"Retreating Guard",
+			"Guarded Shuffle",
+			"Shield Jostle",
+			"Shield Glint",
+			"Shoulder Check",
+			"Foot Sweep",
+			"Shove Off Balance",
+			"Pommel Beat",
+			"Wrist Check",
+			"Beat the Weapon",
+			"Hook and Pull",
+			"Sand in the Eyes",
+			"Dirt Kick"
+		];
+
+		Match catalogue = Regex.Match(source,
+			@"private static readonly string\[\] HumanAuxiliaryMoveNames\s*=\s*\[(?<body>.*?)\];",
+			RegexOptions.Singleline | RegexOptions.CultureInvariant);
+		Assert.IsTrue(catalogue.Success, "Could not find the human auxiliary catalogue.");
+		List<string> names = Regex.Matches(catalogue.Groups["body"].Value, @"""(?<name>[^""]+)""")
+		                          .Select(x => x.Groups["name"].Value)
+		                          .ToList();
+
+		Assert.IsTrue(names.Count >= 20, $"Expected at least 20 human auxiliary moves, found {names.Count}.");
+		CollectionAssert.IsSubsetOf(expectedNames, names);
+
+		foreach (string effectType in new[] { "targetdelay", "facing", "targetstamina", "positionchange", "disarm" })
+		{
+			StringAssert.Contains(source, $"Common(\"{effectType}\"");
+		}
+
+		StringAssert.Contains(source, "new XAttribute(\"position\", PositionSprawledId)");
+		StringAssert.Contains(source, "new XAttribute(\"selection\", \"Best\")");
+		StringAssert.Contains(source, "new XAttribute(\"subject\", \"Attacker\")");
+		StringAssert.Contains(source, "new XAttribute(\"direction\", \"Improve\")");
+	}
+
+	[TestMethod]
+	public void CombatAuxiliarySeederSource_GatedProgsTagsMessagesAndRerunHooks_ArePresent()
+	{
+		string helper = File.ReadAllText(GetSeederSourcePath("CombatAuxiliarySeederHelper.cs"));
+		string combatSeeder = File.ReadAllText(GetCombatSeederSourcePath());
+
+		StringAssert.Contains(combatSeeder, "EnsureStockAuxiliaryContent(context)");
+		StringAssert.Contains(combatSeeder, "auxiliaryResult");
+		StringAssert.Contains(helper, "EnsureTag(context, \"Shiny\", functions)");
+		StringAssert.Contains(helper, "EnsureTag(context, \"Reflective\", functions)");
+		StringAssert.Contains(helper, "\"Auxiliary_CanThrowSandOrDirt\"");
+		StringAssert.Contains(helper, "\"Auxiliary_CanShieldGlint\"");
+		StringAssert.Contains(helper, "\"Diggable Soil\"");
+		StringAssert.Contains(helper, "\"Foragable Sand\"");
+		StringAssert.Contains(helper, "\"Vacuum\"");
+		StringAssert.Contains(helper, "\"Space\"");
+		StringAssert.Contains(helper, "isunderwater(@ch.Location, @ch.Layer)");
+		StringAssert.Contains(helper, "istagged(@item, \"\"Shiny\"\") or istagged(@item, \"\"Reflective\"\")");
+		StringAssert.Contains(helper, "celestialelevation(@ch.Location");
+		StringAssert.Contains(helper, "> 0.26");
+		StringAssert.Contains(helper, "CombatMessagesCombatActions");
+		StringAssert.Contains(helper, "RacesCombatActions");
+		StringAssert.Contains(helper, "RequiredPositionStateIds");
+		StringAssert.Contains(helper, "progs.TryGetValue(definition.UsabilityProgName");
+		StringAssert.Contains(helper, "ApplyStockAuxiliaryPercentages(context)");
+	}
+
+	[TestMethod]
+	public void CombatAuxiliarySeederSource_NonHumanSeeders_LinkRaceAppropriateAuxiliaryMoves()
+	{
+		string helper = File.ReadAllText(GetSeederSourcePath("CombatAuxiliarySeederHelper.cs"));
+		Dictionary<string, string> expectedActions = new(StringComparer.OrdinalIgnoreCase)
+		{
+			["Canid Harry"] = "Dog",
+			["Feline Pounce Feint"] = "Cat",
+			["Equine Shoulder Barge"] = "Horse",
+			["Avian Wing Buffet"] = "Eagle",
+			["Serpent Coil Feint"] = "Snake",
+			["Ursine Maul-Feint"] = "Bear",
+			["Dragon Wing Shadow"] = "Dragon",
+			["Gryphon Buffet"] = "Gryphon",
+			["Unicorn Dazzling Feint"] = "Unicorn",
+			["Hydra Many-Head Feint"] = "Hydra",
+			["Basilisk Glare Feint"] = "Basilisk",
+			["Myconid Spore Cloud"] = "Myconid",
+			["Servo Jostle"] = "Robot",
+			["Hydraulic Shove"] = "Robot",
+			["Sensor Flash"] = "Robot",
+			["Magnetic Wrench"] = "Robot",
+			["Ghostly Misdirection"] = "Ghost",
+			["Infernal Glare"] = "Demon",
+			["Angelic Dazzle"] = "Angel",
+			["Werewolf Lunge Feint"] = "Werewolf",
+			["Undead Bone-Rattle"] = "Skeleton",
+			["Fiend Tail Hook"] = "Fiend"
+		};
+
+		foreach ((string action, string raceHint) in expectedActions)
+		{
+			StringAssert.Contains(helper, $"[\"{action}\"]");
+			StringAssert.Contains(helper, $"\"{raceHint}\"");
+			StringAssert.Contains(helper, $"Def(\"{action}\"");
+		}
+
+		Dictionary<string, string> seederHooks = new(StringComparer.OrdinalIgnoreCase)
+		{
+			["AnimalSeeder.cs"] = "EnsureAnimalAuxiliaryLinks",
+			["MythicalAnimalSeeder.cs"] = "EnsureMythicalAuxiliaryLinks",
+			["RobotSeeder.cs"] = "EnsureRobotAuxiliaryLinks",
+			["SupernaturalSeeder.cs"] = "EnsureSupernaturalAuxiliaryLinks"
+		};
+
+		foreach ((string fileName, string hook) in seederHooks)
+		{
+			string source = File.ReadAllText(GetSeederSourcePath(fileName));
+			Assert.IsTrue(source.Contains(hook, StringComparison.Ordinal),
+				$"{fileName} should call {hook}.");
+		}
+	}
+
+	[TestMethod]
+	public void CombatAuxiliarySeederSource_StockStrategies_ReceiveAuxiliaryPercentagesWithoutOverfilling()
+	{
+		string helper = File.ReadAllText(GetSeederSourcePath("CombatAuxiliarySeederHelper.cs"));
+		string strategyHelper = File.ReadAllText(GetSeederSourcePath("CombatStrategySeederHelper.cs"));
+
+		foreach (string strategyName in new[]
+		         {
+			         "Melee", "Shielder", "Skirmisher", "Brawler", "Pitfighter", "Beast Brawler",
+			         "Beast Swooper", "Construct Brawler", "Construct Artillery"
+		         })
+		{
+			StringAssert.Contains(helper, $"[\"{strategyName}\"]");
+		}
+
+		StringAssert.Contains(helper, "setting.AuxiliaryPercentage = desired");
+		StringAssert.Contains(helper, "if (total > 1.0)");
+		StringAssert.Contains(helper, "setting.WeaponUsePercentage -= reduction");
+		StringAssert.Contains(helper, "setting.NaturalWeaponPercentage -= reduction");
+		StringAssert.Contains(strategyHelper, "CombatAuxiliarySeederHelper.ApplyStockAuxiliaryPercentage");
+	}
+
+	[TestMethod]
 	public void CombatSeederSource_PrimitiveRangedWeapons_SeedAndRepairSlingAndBlowgunStock()
 	{
 		string source = File.ReadAllText(GetCombatSeederSourcePath());
@@ -303,6 +455,11 @@ public class CombatSeederSourceTests
 
     private static string GetCombatSeederSourcePath()
     {
+		return GetSeederSourcePath("CombatSeeder.cs");
+    }
+
+	private static string GetSeederSourcePath(string fileName)
+	{
         return Path.GetFullPath(Path.Combine(
             AppContext.BaseDirectory,
             "..",
@@ -311,6 +468,6 @@ public class CombatSeederSourceTests
             "..",
             "DatabaseSeeder",
             "Seeders",
-            "CombatSeeder.cs"));
+            fileName));
     }
 }

--- a/DatabaseSeeder/Seeders/AnimalSeeder.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.cs
@@ -288,6 +288,7 @@ public partial class AnimalSeeder : IDatabaseSeeder
             }
 
             RefreshExistingAnimalDietSettings();
+            CombatAuxiliarySeedResult auxiliaryResult = CombatAuxiliarySeederHelper.EnsureAnimalAuxiliaryLinks(context);
             context.Database.CommitTransaction();
             List<string> updates = ["Updated the animal combat balance profile"];
             if (hasMissingCatalogue)
@@ -308,6 +309,11 @@ public partial class AnimalSeeder : IDatabaseSeeder
             if (hasMissingDietSettings)
             {
                 updates.Add("refreshed stock animal diet settings");
+            }
+
+            if (auxiliaryResult.HasChanges)
+            {
+                updates.Add($"refreshed animal auxiliary combat links ({auxiliaryResult.RaceLinks} links)");
             }
 
             return $"{string.Join(", ", updates)}.";
@@ -848,10 +854,13 @@ public partial class AnimalSeeder : IDatabaseSeeder
         CloneBodyPositionsAndSpeeds(toedQuadruped, anuranBody);
         ApplyDefaultCombatSettingsToSeededRaces();
         SeedAnimalAIStockTemplates();
+        CombatAuxiliarySeedResult freshAuxiliaryResult = CombatAuxiliarySeederHelper.EnsureAnimalAuxiliaryLinks(context);
 
         context.Database.CommitTransaction();
 
-        return "Successfully installed animal prototypes and stock animal AI templates.";
+        return freshAuxiliaryResult.HasChanges
+            ? $"Successfully installed animal prototypes, stock animal AI templates, and {freshAuxiliaryResult.RaceLinks} animal auxiliary combat links."
+            : "Successfully installed animal prototypes and stock animal AI templates.";
     }
 
     public ShouldSeedResult ShouldSeedData(FuturemudDatabaseContext context)

--- a/DatabaseSeeder/Seeders/CombatAuxiliarySeederHelper.cs
+++ b/DatabaseSeeder/Seeders/CombatAuxiliarySeederHelper.cs
@@ -1,0 +1,600 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.EntityFrameworkCore;
+using MudSharp.Body;
+using MudSharp.Body.Traits;
+using MudSharp.Combat;
+using MudSharp.Database;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.Models;
+using MudSharp.RPG.Checks;
+
+namespace DatabaseSeeder.Seeders;
+
+internal sealed record CombatAuxiliarySeedResult(int Actions, int Messages, int RaceLinks, int Tags, int Progs, int Strategies)
+{
+	public static CombatAuxiliarySeedResult Empty => new(0, 0, 0, 0, 0, 0);
+
+	public CombatAuxiliarySeedResult Add(CombatAuxiliarySeedResult rhs)
+	{
+		return new CombatAuxiliarySeedResult(
+			Actions + rhs.Actions,
+			Messages + rhs.Messages,
+			RaceLinks + rhs.RaceLinks,
+			Tags + rhs.Tags,
+			Progs + rhs.Progs,
+			Strategies + rhs.Strategies);
+	}
+
+	public bool HasChanges => Actions + Messages + RaceLinks + Tags + Progs + Strategies > 0;
+}
+
+internal static class CombatAuxiliarySeederHelper
+{
+	private const long PositionStandingId = 1;
+	private const long PositionSprawledId = 8;
+	private const long PositionSwimmingId = 16;
+	private const long PositionFloatingInWaterId = 17;
+	private const long PositionFlyingId = 18;
+
+	private sealed record ActionDefinition(
+		string Name,
+		CombatMoveIntentions Intentions,
+		Func<TraitDefinition, IEnumerable<XElement>> Effects,
+		string SuccessMessage,
+		string FailureMessage,
+		string? UsabilityProgName = null,
+		double StaminaCost = 1.0,
+		double BaseDelay = 1.0,
+		double Weighting = 100.0,
+		Difficulty MoveDifficulty = Difficulty.Normal);
+
+	private static readonly string[] HumanAuxiliaryMoveNames =
+	[
+		"Circle to Flank",
+		"Sidestep and Press",
+		"Bind and Step",
+		"Low Line Feint",
+		"High Line Feint",
+		"Distracting Flourish",
+		"False Opening",
+		"Retreating Guard",
+		"Guarded Shuffle",
+		"Shield Jostle",
+		"Shield Glint",
+		"Shoulder Check",
+		"Foot Sweep",
+		"Shove Off Balance",
+		"Pommel Beat",
+		"Wrist Check",
+		"Beat the Weapon",
+		"Hook and Pull",
+		"Sand in the Eyes",
+		"Dirt Kick"
+	];
+
+	private static readonly IReadOnlyDictionary<string, string[]> NonHumanActionRaceHints =
+		new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+		{
+			["Canid Harry"] = ["Dog", "Wolf", "Coyote", "Dingo", "Jackal", "Hyena", "Fox"],
+			["Feline Pounce Feint"] = ["Cat", "Lion", "Tiger", "Leopard", "Jaguar", "Cheetah", "Panther", "Sabretooth"],
+			["Equine Shoulder Barge"] = ["Horse", "Pony", "Donkey", "Mule", "Zebra", "Camel", "Bull", "Cow", "Bison", "Buffalo", "Ox"],
+			["Avian Wing Buffet"] = ["Eagle", "Falcon", "Hawk", "Owl", "Crow", "Raven", "Vulture", "Condor", "Swan", "Goose"],
+			["Serpent Coil Feint"] = ["Snake", "Adder", "Anaconda", "Boa", "Cobra", "Mamba", "Python", "Rattlesnake", "Viper"],
+			["Ursine Maul-Feint"] = ["Bear", "Ursine"],
+			["Dragon Wing Shadow"] = ["Dragon", "Drake", "Wyvern"],
+			["Gryphon Buffet"] = ["Gryphon", "Griffin"],
+			["Unicorn Dazzling Feint"] = ["Unicorn", "Qilin", "Kirin"],
+			["Hydra Many-Head Feint"] = ["Hydra"],
+			["Basilisk Glare Feint"] = ["Basilisk", "Cockatrice"],
+			["Myconid Spore Cloud"] = ["Myconid", "Mushroom", "Fungus"],
+			["Servo Jostle"] = ["Robot", "Android", "Drone", "Automaton", "Construct", "Cyborg"],
+			["Hydraulic Shove"] = ["Robot", "Android", "Drone", "Automaton", "Construct", "Cyborg"],
+			["Sensor Flash"] = ["Robot", "Android", "Drone", "Automaton", "Construct", "Cyborg"],
+			["Magnetic Wrench"] = ["Robot", "Android", "Drone", "Automaton", "Construct", "Cyborg"],
+			["Ghostly Misdirection"] = ["Ghost", "Spirit", "Wraith", "Spectre", "Specter", "Shade", "Phantom"],
+			["Infernal Glare"] = ["Demon", "Devil", "Fiend", "Infernal", "Balrog", "Imp"],
+			["Angelic Dazzle"] = ["Angel", "Seraph", "Cherub", "Celestial"],
+			["Werewolf Lunge Feint"] = ["Werewolf", "Lycanthrope"],
+			["Undead Bone-Rattle"] = ["Skeleton", "Zombie", "Ghoul", "Mummy", "Lich", "Undead"],
+			["Fiend Tail Hook"] = ["Fiend", "Demon", "Devil", "Imp", "Succubus", "Incubus", "Balrog"]
+		};
+
+	private static readonly IReadOnlyDictionary<string, double> StockAuxiliaryStrategyPercentages =
+		new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase)
+		{
+			["Melee"] = 0.10,
+			["Melee (Auto)"] = 0.10,
+			["Cautious Melee"] = 0.12,
+			["Cautious Melee (Auto)"] = 0.12,
+			["Shielder"] = 0.15,
+			["Shielder (Auto)"] = 0.15,
+			["Skirmisher"] = 0.15,
+			["Skirmisher (Auto)"] = 0.15,
+			["Brawler"] = 0.18,
+			["Brawler (Auto)"] = 0.18,
+			["Pitfighter"] = 0.18,
+			["Pitfighter (Auto)"] = 0.18,
+			["Swarmer"] = 0.18,
+			["Swarmer (Auto)"] = 0.18,
+			["Outboxer"] = 0.15,
+			["Outboxer (Auto)"] = 0.15,
+			["Grappler"] = 0.18,
+			["Grappler (Auto)"] = 0.18,
+			["Bonebreaker"] = 0.18,
+			["Bonebreaker (Auto)"] = 0.18,
+			["Strangler"] = 0.18,
+			["Strangler (Auto)"] = 0.18,
+			["Beast Brawler"] = 0.18,
+			["Beast Clincher"] = 0.18,
+			["Beast Behemoth"] = 0.20,
+			["Beast Skirmisher"] = 0.15,
+			["Beast Swooper"] = 0.15,
+			["Beast Drowner"] = 0.18,
+			["Beast Dropper"] = 0.18,
+			["Beast Physical Avoider"] = 0.20,
+			["Construct Brawler"] = 0.18,
+			["Construct Skirmisher"] = 0.15,
+			["Construct Artillery"] = 0.20
+		};
+
+	internal static IReadOnlyCollection<string> HumanAuxiliaryMoveNamesForTesting => HumanAuxiliaryMoveNames;
+	internal static IReadOnlyDictionary<string, string[]> NonHumanActionRaceHintsForTesting => NonHumanActionRaceHints;
+	internal static IReadOnlyCollection<string> StockAuxiliaryProgNamesForTesting =>
+		["Auxiliary_CanThrowSandOrDirt", "Auxiliary_CanShieldGlint"];
+
+	public static CombatAuxiliarySeedResult EnsureStockAuxiliaryContent(FuturemudDatabaseContext context)
+	{
+		var tags = EnsureAuxiliaryTags(context);
+		var progs = EnsureAuxiliaryProgs(context);
+		var trait = GetAuxiliaryTrait(context);
+		var actionCount = EnsureActions(context, BuildAllDefinitions(progs), progs, trait);
+		context.SaveChanges();
+		var messageCount = EnsureCombatMessages(context, BuildAllDefinitions(progs));
+		var raceLinks = EnsureHumanoidAuxiliaryLinks(context);
+		var strategies = ApplyStockAuxiliaryPercentages(context);
+		context.SaveChanges();
+		return new CombatAuxiliarySeedResult(actionCount, messageCount, raceLinks, tags, progs.Count, strategies);
+	}
+
+	public static CombatAuxiliarySeedResult EnsureAnimalAuxiliaryLinks(FuturemudDatabaseContext context)
+	{
+		var stock = EnsureStockAuxiliaryContent(context);
+		var links = EnsureRaceLinks(context, NonHumanActionRaceHints.Keys.Take(6));
+		context.SaveChanges();
+		return stock.Add(new CombatAuxiliarySeedResult(0, 0, links, 0, 0, 0));
+	}
+
+	public static CombatAuxiliarySeedResult EnsureMythicalAuxiliaryLinks(FuturemudDatabaseContext context)
+	{
+		var stock = EnsureStockAuxiliaryContent(context);
+		var links = EnsureRaceLinks(context, NonHumanActionRaceHints.Keys.Skip(6).Take(6));
+		context.SaveChanges();
+		return stock.Add(new CombatAuxiliarySeedResult(0, 0, links, 0, 0, 0));
+	}
+
+	public static CombatAuxiliarySeedResult EnsureRobotAuxiliaryLinks(FuturemudDatabaseContext context)
+	{
+		var stock = EnsureStockAuxiliaryContent(context);
+		var links = EnsureRaceLinks(context, NonHumanActionRaceHints.Keys.Skip(12).Take(4));
+		context.SaveChanges();
+		return stock.Add(new CombatAuxiliarySeedResult(0, 0, links, 0, 0, 0));
+	}
+
+	public static CombatAuxiliarySeedResult EnsureSupernaturalAuxiliaryLinks(FuturemudDatabaseContext context)
+	{
+		var stock = EnsureStockAuxiliaryContent(context);
+		var links = EnsureRaceLinks(context, NonHumanActionRaceHints.Keys.Skip(16));
+		context.SaveChanges();
+		return stock.Add(new CombatAuxiliarySeedResult(0, 0, links, 0, 0, 0));
+	}
+
+	public static int ApplyStockAuxiliaryPercentages(FuturemudDatabaseContext context)
+	{
+		var count = 0;
+		foreach (var setting in context.CharacterCombatSettings.AsEnumerable()
+		                       .Where(x => StockAuxiliaryStrategyPercentages.ContainsKey(x.Name)))
+		{
+			if (ApplyStockAuxiliaryPercentage(setting))
+			{
+				count++;
+			}
+		}
+
+		return count;
+	}
+
+	public static bool ApplyStockAuxiliaryPercentage(CharacterCombatSetting setting)
+	{
+		if (!StockAuxiliaryStrategyPercentages.TryGetValue(setting.Name, out var desired))
+		{
+			return false;
+		}
+
+		var changed = Math.Abs(setting.AuxiliaryPercentage - desired) > 0.0001;
+		var oldAuxiliary = setting.AuxiliaryPercentage;
+		setting.AuxiliaryPercentage = desired;
+		var total = setting.WeaponUsePercentage + setting.NaturalWeaponPercentage + setting.MagicUsePercentage +
+		            setting.PsychicUsePercentage + setting.AuxiliaryPercentage;
+		if (total > 1.0)
+		{
+			var excess = total - 1.0;
+			if (setting.WeaponUsePercentage > 0.0)
+			{
+				var reduction = Math.Min(setting.WeaponUsePercentage, excess);
+				setting.WeaponUsePercentage -= reduction;
+				excess -= reduction;
+			}
+
+			if (excess > 0.0 && setting.NaturalWeaponPercentage > 0.0)
+			{
+				var reduction = Math.Min(setting.NaturalWeaponPercentage, excess);
+				setting.NaturalWeaponPercentage -= reduction;
+				excess -= reduction;
+			}
+
+			changed = true;
+		}
+
+		return changed || Math.Abs(oldAuxiliary - setting.AuxiliaryPercentage) > 0.0001;
+	}
+
+	private static int EnsureAuxiliaryTags(FuturemudDatabaseContext context)
+	{
+		var before = context.Tags.Local.Count + context.Tags.Count();
+		var functions = EnsureTag(context, "Functions", null);
+		EnsureTag(context, "Shiny", functions);
+		EnsureTag(context, "Reflective", functions);
+		context.SaveChanges();
+		var after = context.Tags.Local.Count + context.Tags.Count();
+		return Math.Max(0, after - before);
+	}
+
+	private static Tag EnsureTag(FuturemudDatabaseContext context, string name, Tag? parent)
+	{
+		var tag = context.Tags.Local.FirstOrDefault(x => x.Name.Equals(name, StringComparison.OrdinalIgnoreCase)) ??
+		          context.Tags.AsEnumerable().FirstOrDefault(x => x.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+		if (tag is not null)
+		{
+			if (parent is not null && tag.ParentId is null && tag.Parent is null)
+			{
+				tag.Parent = parent;
+			}
+
+			return tag;
+		}
+
+		tag = new Tag
+		{
+			Name = name,
+			Parent = parent
+		};
+		context.Tags.Add(tag);
+		return tag;
+	}
+
+	private static Dictionary<string, FutureProg> EnsureAuxiliaryProgs(FuturemudDatabaseContext context)
+	{
+		var sunId = context.Celestials
+		                   .AsEnumerable()
+		                   .Where(x => x.CelestialType?.Contains("Sun", StringComparison.OrdinalIgnoreCase) == true)
+		                   .Select(x => x.Id)
+		                   .FirstOrDefault();
+		var result = new Dictionary<string, FutureProg>(StringComparer.OrdinalIgnoreCase)
+		{
+			["Auxiliary_CanThrowSandOrDirt"] = SeederRepeatabilityHelper.EnsureProg(
+				context,
+				"Auxiliary_CanThrowSandOrDirt",
+				"Combat",
+				"Auxiliary",
+				ProgVariableTypes.Boolean,
+				"Allows dirty sand and dirt auxiliary moves only in loose soil or sandy terrain, and blocks vacuum, space and underwater use.",
+				@"return (istagged(@ch.Location.Terrain, ""Diggable Soil"") or istagged(@ch.Location.Terrain, ""Foragable Sand"")) and not istagged(@ch.Location.Terrain, ""Vacuum"") and not istagged(@ch.Location.Terrain, ""Space"") and not isunderwater(@ch.Location, @ch.Layer);",
+				true,
+				false,
+				FutureProgStaticType.NotStatic,
+				(ProgVariableTypes.Character, "ch"),
+				(ProgVariableTypes.Item, "item"),
+				(ProgVariableTypes.Character, "target")),
+			["Auxiliary_CanShieldGlint"] = SeederRepeatabilityHelper.EnsureProg(
+				context,
+				"Auxiliary_CanShieldGlint",
+				"Combat",
+				"Auxiliary",
+				ProgVariableTypes.Boolean,
+				"Allows shield glint auxiliary moves only with a shiny or reflective wielded item, outdoors in light, with a sun-like celestial above about 15 degrees.",
+				$@"return @ch.Location.Outdoors >= 2 and @ch.Location.Light > 100 and @ch.WieldedItems.any(item, istagged(@item, ""Shiny"") or istagged(@item, ""Reflective"")) and celestialelevation(@ch.Location, {sunId.ToString(System.Globalization.CultureInfo.InvariantCulture)}) > 0.26;",
+				true,
+				false,
+				FutureProgStaticType.NotStatic,
+				(ProgVariableTypes.Character, "ch"),
+				(ProgVariableTypes.Item, "item"),
+				(ProgVariableTypes.Character, "target"))
+		};
+		return result;
+	}
+
+	private static TraitDefinition GetAuxiliaryTrait(FuturemudDatabaseContext context)
+	{
+		var configured = context.StaticConfigurations
+		                        .FirstOrDefault(x => x.SettingName == "DefaultAuxiliaryMoveTraitId");
+		if (configured is not null && long.TryParse(configured.Definition, out var id))
+		{
+			var trait = context.TraitDefinitions.FirstOrDefault(x => x.Id == id);
+			if (trait is not null)
+			{
+				return trait;
+			}
+		}
+
+		var traits = context.TraitDefinitions.AsEnumerable().ToList();
+		return traits.FirstOrDefault(x => x.Name.In("Brawling", "Dodge", "Agility", "Dexterity", "Speed")) ??
+		       traits.First(x => x.Type == (int)TraitType.Skill || x.Type == (int)TraitType.Attribute);
+	}
+
+	private static IEnumerable<ActionDefinition> BuildAllDefinitions(IReadOnlyDictionary<string, FutureProg> progs)
+	{
+		foreach (var definition in BuildHumanDefinitions(progs))
+		{
+			yield return definition;
+		}
+
+		foreach (var definition in BuildNonHumanDefinitions())
+		{
+			yield return definition;
+		}
+	}
+
+	private static IEnumerable<ActionDefinition> BuildHumanDefinitions(IReadOnlyDictionary<string, FutureProg> progs)
+	{
+		yield return Def("Circle to Flank", CombatMoveIntentions.Advantage | CombatMoveIntentions.Flank, t => [Facing(t)], "@ circle|circles warily around $1, looking for a flank.", "@ try|tries to circle $1, but cannot find a better angle.");
+		yield return Def("Sidestep and Press", CombatMoveIntentions.Advantage | CombatMoveIntentions.Flank, t => [Facing(t), AttackerAdvantage(t, 0.2, 0.1)], "@ sidestep|sidesteps and press|presses $1 from an awkward angle.", "@ sidestep|sidesteps, but $1 turns with the pressure.");
+		yield return Def("Bind and Step", CombatMoveIntentions.Advantage | CombatMoveIntentions.Hinder, t => [Delay(t, 1.0, 0.4, 4.0), Facing(t)], "@ bind|binds $1 up for a heartbeat and step|steps aside.", "@ try|tries to bind $1 up, but cannot make it stick.");
+		yield return Def("Low Line Feint", CombatMoveIntentions.Advantage | CombatMoveIntentions.Distraction, t => [AttackerAdvantage(t, 0.25, 0.0)], "@ dip|dips into a low-line feint against $1.", "@ feint|feints low, but $1 does not bite.");
+		yield return Def("High Line Feint", CombatMoveIntentions.Advantage | CombatMoveIntentions.Distraction, t => [AttackerAdvantage(t, 0.25, 0.0)], "@ threaten|threatens high, drawing $1's guard upward.", "@ threaten|threatens high, but $1 keeps a disciplined guard.");
+		yield return Def("Distracting Flourish", CombatMoveIntentions.Advantage | CombatMoveIntentions.Distraction | CombatMoveIntentions.Flashy, t => [AttackerAdvantage(t, 0.15, 0.25)], "@ flourish|flourishes with distracting movement at $1.", "@ flourish|flourishes, but $1 keeps focus.");
+		yield return Def("False Opening", CombatMoveIntentions.Advantage | CombatMoveIntentions.Distraction | CombatMoveIntentions.Risky, t => [AttackerAdvantage(t, 0.35, 0.0)], "@ offer|offers $1 a false opening.", "@ offer|offers a false opening, but $1 refuses it.");
+		yield return Def("Retreating Guard", CombatMoveIntentions.Advantage | CombatMoveIntentions.Defensive, t => [AttackerAdvantage(t, 0.0, 0.35)], "@ retreat|retreats behind a guarded posture against $1.", "@ retreat|retreats, but $1 keeps the pressure on.");
+		yield return Def("Guarded Shuffle", CombatMoveIntentions.Advantage | CombatMoveIntentions.Defensive | CombatMoveIntentions.Cautious, t => [AttackerAdvantage(t, 0.0, 0.25), Facing(t)], "@ shuffle|shuffles guardedly around $1.", "@ shuffle|shuffles, but $1 denies the angle.");
+		yield return Def("Shield Jostle", CombatMoveIntentions.Disadvantage | CombatMoveIntentions.Shield | CombatMoveIntentions.Hinder, t => [Delay(t, 1.0, 0.5, 4.0), Stamina(t, 2.0, 1.0, 8.0)], "@ jostle|jostles $1 with a shield-side shove.", "@ try|tries to jostle $1, but cannot break their rhythm.");
+		yield return Def("Shield Glint", CombatMoveIntentions.Disadvantage | CombatMoveIntentions.Shield | CombatMoveIntentions.Distraction | CombatMoveIntentions.Flashy, t => [Delay(t, 1.5, 0.5, 5.0)], "@ flash|flashes reflected light toward $1's eyes.", "@ angle|angles for a flash of light, but $1 is not caught by it.", "Auxiliary_CanShieldGlint");
+		yield return Def("Shoulder Check", CombatMoveIntentions.Disadvantage | CombatMoveIntentions.Hinder, t => [Stamina(t, 3.0, 1.0, 10.0), Delay(t, 0.5, 0.3, 3.0)], "@ check|checks $1 hard with a shoulder.", "@ try|tries to check $1, but cannot shift them.");
+		yield return Def("Foot Sweep", CombatMoveIntentions.Trip | CombatMoveIntentions.Disadvantage, t => [PositionChange(t, 1.0, 0.4, 4.0)], "@ sweep|sweeps at $1's feet.", "@ sweep|sweeps low, but $1 stays upright.");
+		yield return Def("Shove Off Balance", CombatMoveIntentions.Trip | CombatMoveIntentions.Hinder, t => [PositionChange(t, 1.5, 0.5, 5.0)], "@ shove|shoves $1 off balance.", "@ shove|shoves at $1, but cannot topple them.");
+		yield return Def("Pommel Beat", CombatMoveIntentions.Disarm | CombatMoveIntentions.Disadvantage, t => [Disarm(t), Delay(t, 0.5, 0.2, 2.5)], "@ beat|beats at $1's weapon hand.", "@ beat|beats at $1's weapon hand, but $1 keeps hold.");
+		yield return Def("Wrist Check", CombatMoveIntentions.Disarm | CombatMoveIntentions.Hinder, t => [Disarm(t), Stamina(t, 2.0, 1.0, 6.0)], "@ check|checks $1's wrist and weapon line.", "@ check|checks $1's wrist, but cannot open the grip.");
+		yield return Def("Beat the Weapon", CombatMoveIntentions.Disarm | CombatMoveIntentions.Disadvantage, t => [Disarm(t)], "@ beat|beats $1's weapon aside.", "@ beat|beats at $1's weapon, but it stays in line.");
+		yield return Def("Hook and Pull", CombatMoveIntentions.Disadvantage | CombatMoveIntentions.Hinder | CombatMoveIntentions.Flank, t => [Delay(t, 1.0, 0.5, 4.0), Facing(t)], "@ hook|hooks and pull|pulls $1 out of line.", "@ hook|hooks at $1, but cannot drag them out of line.");
+		yield return Def("Sand in the Eyes", CombatMoveIntentions.Disadvantage | CombatMoveIntentions.Distraction | CombatMoveIntentions.Dirty, t => [Delay(t, 2.0, 0.5, 6.0)], "@ fling|flings grit toward $1's eyes.", "@ fling|flings grit, but $1 avoids the worst of it.", "Auxiliary_CanThrowSandOrDirt");
+		yield return Def("Dirt Kick", CombatMoveIntentions.Disadvantage | CombatMoveIntentions.Dirty | CombatMoveIntentions.Hinder, t => [Delay(t, 1.5, 0.5, 5.0), Stamina(t, 2.0, 1.0, 6.0)], "@ kick|kicks dirt and grit toward $1.", "@ kick|kicks dirt, but $1 stays clear.", "Auxiliary_CanThrowSandOrDirt");
+	}
+
+	private static IEnumerable<ActionDefinition> BuildNonHumanDefinitions()
+	{
+		yield return Def("Canid Harry", CombatMoveIntentions.Disadvantage | CombatMoveIntentions.Hinder, t => [Delay(t), Stamina(t)], "@ harry|harries $1 with darting snaps.", "@ snap|snaps and harry|harries, but $1 keeps pace.");
+		yield return Def("Feline Pounce Feint", CombatMoveIntentions.Advantage | CombatMoveIntentions.Flank, t => [Facing(t), AttackerAdvantage(t, 0.2, 0.0)], "@ bunch|bunches and feint|feints a sudden pounce at $1.", "@ feint|feints a pounce, but $1 does not give ground.");
+		yield return Def("Equine Shoulder Barge", CombatMoveIntentions.Disadvantage | CombatMoveIntentions.Hinder, t => [PositionChange(t), Stamina(t, 4.0, 1.0, 12.0)], "@ barge|barges shoulder-first into $1.", "@ barge|barges at $1, but cannot knock them aside.");
+		yield return Def("Avian Wing Buffet", CombatMoveIntentions.Disadvantage | CombatMoveIntentions.Distraction, t => [Delay(t), Facing(t)], "@ buffet|buffets $1 with beating wings.", "@ beat|beats wings at $1, but $1 weathers it.");
+		yield return Def("Serpent Coil Feint", CombatMoveIntentions.Advantage | CombatMoveIntentions.Distraction, t => [AttackerAdvantage(t, 0.3, 0.0), Delay(t, 0.5, 0.3, 3.0)], "@ coil|coils and feint|feints at $1.", "@ coil|coils in a feint, but $1 reads it.");
+		yield return Def("Ursine Maul-Feint", CombatMoveIntentions.Advantage | CombatMoveIntentions.Savage, t => [Stamina(t, 4.0, 1.0, 12.0), AttackerAdvantage(t, 0.2, 0.0)], "@ rear|rears and feint|feints a mauling rush at $1.", "@ feint|feints a mauling rush, but $1 stands firm.");
+		yield return Def("Dragon Wing Shadow", CombatMoveIntentions.Disadvantage | CombatMoveIntentions.Flashy | CombatMoveIntentions.Distraction, t => [Delay(t, 2.0, 0.5, 7.0), Facing(t)], "@ cast|casts a sudden wing-shadow over $1.", "@ spread|spreads wings dramatically, but $1 is not wrong-footed.");
+		yield return Def("Gryphon Buffet", CombatMoveIntentions.Disadvantage | CombatMoveIntentions.Hinder, t => [Delay(t), PositionChange(t, 1.0, 0.4, 4.0)], "@ buffet|buffets $1 with a hard wing and shoulder rush.", "@ buffet|buffets at $1, but $1 keeps balance.");
+		yield return Def("Unicorn Dazzling Feint", CombatMoveIntentions.Advantage | CombatMoveIntentions.Flashy | CombatMoveIntentions.Distraction, t => [AttackerAdvantage(t, 0.3, 0.1), Delay(t)], "@ toss|tosses a dazzling horn-feint toward $1.", "@ toss|tosses a glittering feint, but $1 sees through it.");
+		yield return Def("Hydra Many-Head Feint", CombatMoveIntentions.Disadvantage | CombatMoveIntentions.Distraction, t => [Delay(t, 2.0, 0.5, 8.0), Stamina(t)], "@ feint|feints with a confusion of snapping heads around $1.", "@ feint|feints with many heads, but $1 tracks the danger.");
+		yield return Def("Basilisk Glare Feint", CombatMoveIntentions.Disadvantage | CombatMoveIntentions.Distraction, t => [Delay(t, 2.0, 0.5, 6.0)], "@ fix|fixes $1 with a terrible glare.", "@ glare|glares at $1, but $1 refuses the stare.");
+		yield return Def("Myconid Spore Cloud", CombatMoveIntentions.Disadvantage | CombatMoveIntentions.Hinder, t => [Delay(t, 2.0, 0.5, 7.0), Stamina(t, 3.0, 1.0, 9.0)], "@ puff|puffs a distracting spore cloud toward $1.", "@ release|releases spores, but $1 avoids the cloud.");
+		yield return Def("Servo Jostle", CombatMoveIntentions.Disadvantage | CombatMoveIntentions.Hinder, t => [Stamina(t), Delay(t)], "@ jostle|jostles $1 with precise servo pressure.", "@ jostle|jostles at $1, but cannot disrupt them.");
+		yield return Def("Hydraulic Shove", CombatMoveIntentions.Trip | CombatMoveIntentions.Hinder, t => [PositionChange(t, 1.5, 0.5, 5.0)], "@ shove|shoves $1 with hydraulic force.", "@ shove|shoves hydraulically at $1, but $1 holds position.");
+		yield return Def("Sensor Flash", CombatMoveIntentions.Disadvantage | CombatMoveIntentions.Distraction, t => [Delay(t, 1.5, 0.5, 5.0)], "@ pulse|pulses a sensor flash at $1.", "@ pulse|pulses a sensor flash, but $1 is not caught.");
+		yield return Def("Magnetic Wrench", CombatMoveIntentions.Disarm | CombatMoveIntentions.Disadvantage, t => [Disarm(t)], "@ wrench|wrenches magnetically at $1's weapon.", "@ wrench|wrenches magnetically, but $1 keeps hold.");
+		yield return Def("Ghostly Misdirection", CombatMoveIntentions.Advantage | CombatMoveIntentions.Distraction, t => [Facing(t), AttackerAdvantage(t, 0.25, 0.0)], "@ blur|blurs with ghostly misdirection around $1.", "@ blur|blurs aside, but $1 follows the motion.");
+		yield return Def("Infernal Glare", CombatMoveIntentions.Disadvantage | CombatMoveIntentions.Distraction, t => [Delay(t, 2.0, 0.5, 6.0)], "@ level|levels an infernal glare at $1.", "@ glare|glares infernally, but $1 does not falter.");
+		yield return Def("Angelic Dazzle", CombatMoveIntentions.Advantage | CombatMoveIntentions.Flashy | CombatMoveIntentions.Distraction, t => [AttackerAdvantage(t, 0.25, 0.25), Delay(t)], "@ dazzle|dazzles $1 with a sudden radiant feint.", "@ flare|flares radiantly, but $1 keeps focus.");
+		yield return Def("Werewolf Lunge Feint", CombatMoveIntentions.Advantage | CombatMoveIntentions.Savage, t => [AttackerAdvantage(t, 0.3, 0.0), Facing(t)], "@ lunge|lunges in a savage feint at $1.", "@ lunge|lunges, but $1 reads the feint.");
+		yield return Def("Undead Bone-Rattle", CombatMoveIntentions.Disadvantage | CombatMoveIntentions.Distraction, t => [Delay(t), Stamina(t, 2.0, 1.0, 6.0)], "@ rattle|rattles with unnerving dead motion before $1.", "@ rattle|rattles unnervingly, but $1 is not distracted.");
+		yield return Def("Fiend Tail Hook", CombatMoveIntentions.Disadvantage | CombatMoveIntentions.Hinder | CombatMoveIntentions.Flank, t => [Facing(t), PositionChange(t, 1.0, 0.4, 4.0)], "@ hook|hooks at $1 with a fiendish tail.", "@ hook|hooks with a tail, but $1 slips clear.");
+	}
+
+	private static ActionDefinition Def(string name, CombatMoveIntentions intentions, Func<TraitDefinition, IEnumerable<XElement>> effects,
+		string success, string failure, string? prog = null)
+	{
+		return new ActionDefinition(name, intentions, effects, success, failure, prog);
+	}
+
+	private static XElement Common(string type, TraitDefinition trait, Difficulty difficulty, double flat, double perDegree,
+		double maximum, OpposedOutcomeDegree minimum = OpposedOutcomeDegree.Marginal)
+	{
+		return new XElement("Effect",
+			new XAttribute("type", type),
+			new XAttribute("defensetrait", trait.Id),
+			new XAttribute("defensedifficulty", (int)difficulty),
+			new XAttribute("minimumdegree", (int)minimum),
+			new XAttribute("flatamount", flat.ToString(System.Globalization.CultureInfo.InvariantCulture)),
+			new XAttribute("perdegreeamount", perDegree.ToString(System.Globalization.CultureInfo.InvariantCulture)),
+			new XAttribute("maximumamount", maximum.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+	}
+
+	private static XElement Delay(TraitDefinition trait, double flat = 1.5, double perDegree = 0.5, double maximum = 6.0) =>
+		Common("targetdelay", trait, Difficulty.Normal, flat, perDegree, maximum);
+
+	private static XElement Stamina(TraitDefinition trait, double flat = 3.0, double perDegree = 1.0, double maximum = 10.0) =>
+		Common("targetstamina", trait, Difficulty.Normal, flat, perDegree, maximum);
+
+	private static XElement Facing(TraitDefinition trait)
+	{
+		var root = Common("facing", trait, Difficulty.Normal, 1.0, 0.0, 1.0);
+		root.Add(new XAttribute("subject", "Attacker"), new XAttribute("direction", "Improve"));
+		return root;
+	}
+
+	private static XElement PositionChange(TraitDefinition trait, double flat = 1.5, double perDegree = 0.5, double maximum = 5.0)
+	{
+		var root = Common("positionchange", trait, Difficulty.Normal, flat, perDegree, maximum);
+		root.Add(new XAttribute("position", PositionSprawledId), new XAttribute("knockdown", true));
+		return root;
+	}
+
+	private static XElement Disarm(TraitDefinition trait)
+	{
+		var root = Common("disarm", trait, Difficulty.Normal, 90.0, 0.0, 90.0);
+		root.Add(new XAttribute("selection", "Best"));
+		return root;
+	}
+
+	private static XElement AttackerAdvantage(TraitDefinition trait, double offense, double defense)
+	{
+		return new XElement("Effect",
+			new XAttribute("type", "attackeradvantage"),
+			new XAttribute("defensebonusperdegree", defense.ToString(System.Globalization.CultureInfo.InvariantCulture)),
+			new XAttribute("offensebonusperdegree", offense.ToString(System.Globalization.CultureInfo.InvariantCulture)),
+			new XAttribute("defensetrait", trait.Id),
+			new XAttribute("defensedifficulty", (int)Difficulty.Normal),
+			new XAttribute("allownegatives", true),
+			new XAttribute("allowpositives", true));
+	}
+
+	private static int EnsureActions(FuturemudDatabaseContext context, IEnumerable<ActionDefinition> definitions,
+		IReadOnlyDictionary<string, FutureProg> progs, TraitDefinition trait)
+	{
+		var count = 0;
+		var alwaysTrue = context.FutureProgs.First(x => x.FunctionName == "AlwaysTrue");
+		var definitionsList = definitions.ToList();
+		foreach (var definition in definitionsList)
+		{
+			var action = context.CombatActions
+			                    .Include(x => x.CombatMessagesCombatActions)
+			                    .FirstOrDefault(x => x.Name == definition.Name &&
+			                                         x.MoveType == (int)BuiltInCombatMoveType.AuxiliaryMove);
+			if (action is null)
+			{
+				action = new CombatAction();
+				context.CombatActions.Add(action);
+				count++;
+			}
+
+			var prog = definition.UsabilityProgName is null || !progs.TryGetValue(definition.UsabilityProgName, out var definedProg)
+				? alwaysTrue
+				: definedProg;
+			action.Name = definition.Name;
+			action.BaseDelay = definition.BaseDelay;
+			action.ExertionLevel = (int)ExertionLevel.Heavy;
+			action.UsabilityProg = prog;
+			action.UsabilityProgId = prog.Id == 0 ? null : prog.Id;
+			action.Intentions = (long)definition.Intentions;
+			action.MoveType = (int)BuiltInCombatMoveType.AuxiliaryMove;
+			action.RecoveryDifficultyFailure = (int)Difficulty.Normal;
+			action.RecoveryDifficultySuccess = (int)Difficulty.Easy;
+			action.StaminaCost = definition.StaminaCost;
+			action.Weighting = definition.Weighting;
+			action.MoveDifficulty = (int)definition.MoveDifficulty;
+			action.RequiredPositionStateIds =
+				$"{PositionStandingId} {PositionFlyingId} {PositionFloatingInWaterId} {PositionSwimmingId}";
+			action.TraitDefinition = trait;
+			action.TraitDefinitionId = trait.Id;
+			action.AdditionalInfo = new XElement("Root", definition.Effects(trait)).ToString(SaveOptions.DisableFormatting);
+		}
+
+		return count;
+	}
+
+	private static int EnsureCombatMessages(FuturemudDatabaseContext context, IEnumerable<ActionDefinition> definitions)
+	{
+		var count = 0;
+		foreach (var definition in definitions)
+		{
+			var action = context.CombatActions.First(x => x.Name == definition.Name &&
+			                                             x.MoveType == (int)BuiltInCombatMoveType.AuxiliaryMove);
+			var existing = context.CombatMessages
+			                      .Include(x => x.CombatMessagesCombatActions)
+			                      .AsEnumerable()
+			                      .FirstOrDefault(x => x.Type == (int)BuiltInCombatMoveType.AuxiliaryMove &&
+			                                           x.CombatMessagesCombatActions.Any(y => y.CombatActionId == action.Id));
+			if (existing is null)
+			{
+				existing = new CombatMessage
+				{
+					CombatMessagesCombatActions =
+					[
+						new CombatMessagesCombatActions
+						{
+							CombatAction = action,
+							CombatActionId = action.Id
+						}
+					]
+				};
+				context.CombatMessages.Add(existing);
+				count++;
+			}
+
+			existing.Type = (int)BuiltInCombatMoveType.AuxiliaryMove;
+			existing.Outcome = null;
+			existing.Message = definition.SuccessMessage;
+			existing.FailureMessage = definition.FailureMessage;
+			existing.Priority = 50;
+			existing.Chance = 1.0;
+			existing.Verb = null;
+		}
+
+		return count;
+	}
+
+	private static int EnsureHumanoidAuxiliaryLinks(FuturemudDatabaseContext context)
+	{
+		var raceHints = new[]
+		{
+			"Human", "Elf", "Dwarf", "Gnome", "Goblin", "Orc", "Hobbit", "Halfling", "Troll", "Ogre", "Half-Elf", "Half-Orc"
+		};
+		return EnsureRaceLinks(context, HumanAuxiliaryMoveNames, raceHints);
+	}
+
+	private static int EnsureRaceLinks(FuturemudDatabaseContext context, IEnumerable<string> actionNames)
+	{
+		var actionList = actionNames.ToList();
+		var raceHints = actionList.SelectMany(x => NonHumanActionRaceHints[x]).Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+		return EnsureRaceLinks(context, actionList, raceHints);
+	}
+
+	private static int EnsureRaceLinks(FuturemudDatabaseContext context, IEnumerable<string> actionNames, IReadOnlyCollection<string> raceHints)
+	{
+		var count = 0;
+		var actions = context.CombatActions
+		                     .AsEnumerable()
+		                     .Where(x => actionNames.Contains(x.Name, StringComparer.OrdinalIgnoreCase) &&
+		                                 x.MoveType == (int)BuiltInCombatMoveType.AuxiliaryMove)
+		                     .ToList();
+		var races = context.Races
+		                   .AsEnumerable()
+		                   .Where(x => raceHints.Any(y =>
+			                   x.Name.Equals(y, StringComparison.OrdinalIgnoreCase) ||
+			                   x.Name.Contains(y, StringComparison.OrdinalIgnoreCase)))
+		                   .ToList();
+		foreach (var race in races)
+		{
+			foreach (var action in actions)
+			{
+				if (context.RacesCombatActions.Local.Any(x => x.RaceId == race.Id && x.CombatActionId == action.Id) ||
+				    context.RacesCombatActions.Any(x => x.RaceId == race.Id && x.CombatActionId == action.Id))
+				{
+					continue;
+				}
+
+				context.RacesCombatActions.Add(new RacesCombatActions
+				{
+					Race = race,
+					RaceId = race.Id,
+					CombatAction = action,
+					CombatActionId = action.Id
+				});
+				count++;
+			}
+		}
+
+		return count;
+	}
+}

--- a/DatabaseSeeder/Seeders/CombatSeeder.cs
+++ b/DatabaseSeeder/Seeders/CombatSeeder.cs
@@ -179,6 +179,7 @@ You can choose #3Compact#f, #3Sentences#f or #3Sparse#f",
         }
 
         SeedArmourTypes(context, effectiveAnswers);
+        CombatAuxiliarySeederHelper.EnsureStockAuxiliaryContent(context);
 
         context.Database.CommitTransaction();
 
@@ -225,6 +226,13 @@ You can choose #3Compact#f, #3Sentences#f or #3Sparse#f",
         if (primitiveRangedCount > 0)
         {
             updates.Add($"added {primitiveRangedCount} missing sling/blowgun stock entries");
+        }
+
+        CombatAuxiliarySeedResult auxiliaryResult = CombatAuxiliarySeederHelper.EnsureStockAuxiliaryContent(context);
+        if (auxiliaryResult.HasChanges)
+        {
+            updates.Add(
+                $"refreshed auxiliary combat stock ({auxiliaryResult.Actions} actions, {auxiliaryResult.Messages} messages, {auxiliaryResult.RaceLinks} race links, {auxiliaryResult.Strategies} strategies)");
         }
 
         return updates.Count > 0

--- a/DatabaseSeeder/Seeders/CombatStrategySeederHelper.cs
+++ b/DatabaseSeeder/Seeders/CombatStrategySeederHelper.cs
@@ -37,6 +37,11 @@ internal static class CombatStrategySeederHelper
         CharacterCombatSetting? existing = context.CharacterCombatSettings.FirstOrDefault(x => x.Name == strategyName);
         if (existing is not null)
         {
+            if (CombatAuxiliarySeederHelper.ApplyStockAuxiliaryPercentage(existing))
+            {
+                context.SaveChanges();
+            }
+
             return existing;
         }
 
@@ -225,6 +230,7 @@ internal static class CombatStrategySeederHelper
         };
 
         context.CharacterCombatSettings.Add(strategy);
+        CombatAuxiliarySeederHelper.ApplyStockAuxiliaryPercentage(strategy);
         context.SaveChanges();
         return strategy;
     }

--- a/DatabaseSeeder/Seeders/MythicalAnimalSeeder.cs
+++ b/DatabaseSeeder/Seeders/MythicalAnimalSeeder.cs
@@ -129,8 +129,11 @@ public partial class MythicalAnimalSeeder : IDatabaseSeeder
             !hasMissingDietSettings)
         {
             RefreshExistingMythicalCombatBalance();
+            CombatAuxiliarySeedResult auxiliaryResult = CombatAuxiliarySeederHelper.EnsureMythicalAuxiliaryLinks(_context);
             _context.Database.CommitTransaction();
-            return "Mythical races are already installed and their breathing, mobility, diet, and combat balance profiles have been refreshed.";
+            return auxiliaryResult.HasChanges
+                ? $"Mythical races are already installed and their breathing, mobility, diet, combat balance profiles, and {auxiliaryResult.RaceLinks} auxiliary combat links have been refreshed."
+                : "Mythical races are already installed and their breathing, mobility, diet, and combat balance profiles have been refreshed.";
         }
 
         foreach (MythicalRaceTemplate template in templatesToSeed)
@@ -150,6 +153,7 @@ public partial class MythicalAnimalSeeder : IDatabaseSeeder
             SeedMythicalAnimalAIStockTemplates();
         }
 
+        CombatAuxiliarySeedResult freshAuxiliaryResult = CombatAuxiliarySeederHelper.EnsureMythicalAuxiliaryLinks(_context);
         _context.SaveChanges();
         _context.Database.CommitTransaction();
         int skippedCount = Templates.Count - templatesToSeed.Count;
@@ -171,6 +175,11 @@ public partial class MythicalAnimalSeeder : IDatabaseSeeder
         if (hasMissingDietSettings)
         {
             updates.Add("refreshed stock mythical diet settings");
+        }
+
+        if (freshAuxiliaryResult.HasChanges)
+        {
+            updates.Add($"refreshed mythical auxiliary combat links ({freshAuxiliaryResult.RaceLinks} links)");
         }
 
         if (templatesToSeed.Count > 0 && skippedCount > 0)

--- a/DatabaseSeeder/Seeders/RobotSeeder.cs
+++ b/DatabaseSeeder/Seeders/RobotSeeder.cs
@@ -122,12 +122,13 @@ public partial class RobotSeeder : IDatabaseSeeder
         SeedRobotCulture();
         SeedRaces(bodyCatalogue, summary);
         SeedRobotProcedures(bodyCatalogue, summary);
+        CombatAuxiliarySeedResult auxiliaryResult = CombatAuxiliarySeederHelper.EnsureRobotAuxiliaryLinks(_context);
 
         _context.SaveChanges();
         _context.Database.CommitTransaction();
 
         return
-            $"Successfully installed or updated robot content. Added {summary.BodiesAdded} bodies, {summary.RacesAdded} races, and {summary.ProceduresAdded} procedures.";
+            $"Successfully installed or updated robot content. Added {summary.BodiesAdded} bodies, {summary.RacesAdded} races, {summary.ProceduresAdded} procedures, and {auxiliaryResult.RaceLinks} robot auxiliary combat links.";
     }
 
     public ShouldSeedResult ShouldSeedData(FuturemudDatabaseContext context)

--- a/DatabaseSeeder/Seeders/SupernaturalSeeder.cs
+++ b/DatabaseSeeder/Seeders/SupernaturalSeeder.cs
@@ -83,10 +83,11 @@ public partial class SupernaturalSeeder : IDatabaseSeeder
 		}
 
 		SeedFormMerits(summary);
+		CombatAuxiliarySeedResult auxiliaryResult = CombatAuxiliarySeederHelper.EnsureSupernaturalAuxiliaryLinks(_context);
 
 		_context.SaveChanges();
 		_context.Database.CommitTransaction();
-		return summary.ToMessage(Templates.Count);
+		return $"{summary.ToMessage(Templates.Count)} Refreshed {auxiliaryResult.RaceLinks} supernatural auxiliary combat links.";
 	}
 
 	public ShouldSeedResult ShouldSeedData(FuturemudDatabaseContext context)

--- a/Design Documents/Celestial_System_Overview.md
+++ b/Design Documents/Celestial_System_Overview.md
@@ -82,3 +82,14 @@ Zones then provide the local context that makes the celestial meaningful:
 - ambient light and weather
 
 Weather controllers and seasons bind to the celestial that defines their astronomy frame. For ordinary planetary worlds this is usually a root `Sun`. Moon-local climates or analysis contexts can instead bind to the linked moon-frame representation.
+
+## FutureProg Integration
+
+FutureProgs can inspect the cached sky state with:
+
+- `celestialelevation(location, celestialId) -> number`
+- `celestialelevation(zone, celestialId) -> number`
+
+The function looks up the celestial by ID in the supplied room's zone or the supplied zone and returns the current elevation angle in radians. Positive values are above the horizon and negative values are below it. If the zone or celestial cannot be found, the function returns `0`.
+
+This is intended for environmental gating such as sunlight-sensitive combat moves, outdoor ceremonies, or weather/season logic that needs to know whether a sun-like celestial is high enough above the horizon.

--- a/Design Documents/Combat_Strategy_Runtime.md
+++ b/Design Documents/Combat_Strategy_Runtime.md
@@ -47,6 +47,10 @@ Melee-family strategies select active attacks through this order:
 3. Weighted attack-mode roll: weapon, natural weapon, magic, psychic, then auxiliary.
 4. Weapon/natural/magic attack selection constrained by combat settings, allowed classifications, preferred/forbidden intentions, stamina, target type, and current melee or clinch state.
 
+Auxiliary moves are selected by shared strategy code through `AttemptUseAuxilliaryAction`. The move list comes from the attacker's race combat actions and is filtered by position, intention requirements, forbidden intentions, usability prog, target, and stamina. If the selected channel has authored moves but the actor is too exhausted to pay for any of them, the strategy returns `TooExhaustedMove`.
+
+`StandardMeleeStrategy` now includes `AuxiliaryPercentage` in the normal weighted roll while keeping the old melee fallback: if no weighted channel produces a move, it may still try an auxiliary move before idling. This preserves older custom combat settings that left auxiliary probability at zero but relied on auxiliary moves as a last resort. Ranged-family strategies also include `AuxiliaryPercentage` in their weighted roll, but they retain the ranged no-move fallback when no ranged, natural, magic, psychic, or auxiliary channel is selected.
+
 Ranged-family strategies select active attacks through:
 
 1. Weighted attack-mode roll.
@@ -60,7 +64,7 @@ Ranged firing normally reveals a hidden firer when out-of-combat fire engages th
 
 ### StandardMelee
 
-The general melee strategy. It handles automatic weapon and shield loadout, normal melee attacks, natural attacks, auxiliary attacks, fixed attacks, coup de grace, and fallback between normal melee and clinch when only one range has viable attacks.
+The general melee strategy. It handles automatic weapon and shield loadout, normal melee attacks, natural attacks, weighted auxiliary attacks, fixed attacks, coup de grace, legacy auxiliary fallback, and fallback between normal melee and clinch when only one range has viable attacks.
 
 Expected active no-move cases: no target, combat policy refuses the target, stamina below minimum, fully manual inventory or movement, no viable attack and no fallback.
 
@@ -185,6 +189,24 @@ Shove moves only the victim. It breaks melee, clinch, and grapple contact and th
 Forced exit movement still enforces hard movement rules: the target-side exit must exist in the target's current location and layer, fall exits are rejected, zero-gravity movement must be possible, size limits apply, fly/climb-only exits require matching capabilities, and `CanCross` must approve the transition. Victim safe-movement warnings are ignored so hostile forced movement can pass through destinations a voluntary mover would sensibly avoid; hard impossibility is not ignored.
 
 Forced layer movement requires the destination layer to exist in the current terrain. Pulling requires the attacker to be able to transition to that layer. Shoving can place the victim in layers such as water, trees, or air even if they could not voluntarily transition there, but the existing floating and fall checks run immediately afterwards.
+
+## Auxiliary Move Effects
+
+Auxiliary combat actions are non-attack combat moves stored as `CombatAction` records with `MoveType = AuxiliaryMove`. Their effect configuration remains in `CombatActions.AdditionalInfo` XML, so adding or changing effect types does not require a database migration.
+
+The current effect types are:
+
+- `attackeradvantage`: applies offensive and defensive advantage or penalties to the attacker from an opposed defense check.
+- `defenderadvantage`: applies offensive and defensive advantage or penalties to the defender from an opposed defense check.
+- `targetdelay`: delays the target's next combat action. The stock default is 1.5 seconds plus 0.5 seconds per opposed success degree, capped at 6 seconds.
+- `facing`: improves or worsens combat facing for the attacker or target. The stock default improves the attacker's position one step toward flank or rear.
+- `targetstamina`: drains target stamina. The stock default is 3 stamina plus 1 per opposed success degree, capped at 10.
+- `positionchange`: changes combat position. The stock default uses the existing combat knockdown flow and delays the target by 1.5 seconds plus 0.5 seconds per opposed success degree, capped at 5 seconds.
+- `disarm`: knocks a wielded item from the target's hands. The stock default chooses the best disarmable wielded weapon and applies the existing `CombatNoGetEffect` / `CombatGetItemEffect` recovery flow for 90 seconds.
+
+The new state-changing effect types share an opposed-resolution configuration: defense trait, defense difficulty, minimum opposed outcome degree, flat amount, per-degree amount, maximum cap, and optional success/failure echoes. Builders can inspect effect syntax with `auxiliary set typehelp <effect>` and edit individual effects from the auxiliary action builder with commands such as `trait`, `difficulty`, `minimum`, `amount`, `perdegree`, `max`, `successecho`, `failureecho`, and `clearecho`. Effect-specific commands add the remaining knobs, for example `facing subject`, `facing direction`, `positionchange knockdown`, `positionchange position`, and `disarm selection`.
+
+State-changing auxiliary effects apply only when the move has a character target. Item or other perceivable targets are safely ignored by these effects rather than trying to mutate character-only combat state.
 
 ## Audit Notes
 

--- a/MudSharpCore Unit Tests/CombatStrategyRuntimeTests.cs
+++ b/MudSharpCore Unit Tests/CombatStrategyRuntimeTests.cs
@@ -22,6 +22,8 @@ using MudSharp.Magic.Powers;
 using MudSharp.RPG.Checks;
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Reflection;
 using TraitExpression = MudSharp.Body.Traits.TraitExpression;
 
@@ -273,5 +275,130 @@ public class CombatStrategyRuntimeTests
 
 		StringAssert.StartsWith(shove.Description, "Shoving");
 		StringAssert.StartsWith(pull.Description, "Pulling");
+	}
+
+	[TestMethod]
+	public void AuxiliaryCombatActionSource_LoadsAndDocumentsExpandedEffectTypes()
+	{
+		string actionSource = File.ReadAllText(GetCoreSourcePath("Combat", "AuxiliaryCombatAction.cs"));
+		string baseEffectSource = File.ReadAllText(GetCoreSourcePath("Combat", "AuxiliaryEffects", "OpposedAuxiliaryEffectBase.cs"));
+
+		foreach (string effectType in new[] { "targetdelay", "facing", "targetstamina", "positionchange", "disarm" })
+		{
+			StringAssert.Contains(actionSource, $"case \"{effectType}\"");
+		}
+
+		Dictionary<string, string> effectFiles = new(StringComparer.OrdinalIgnoreCase)
+		{
+			["targetdelay"] = "TargetDelay.cs",
+			["facing"] = "FacingChange.cs",
+			["targetstamina"] = "TargetStamina.cs",
+			["positionchange"] = "PositionChange.cs",
+			["disarm"] = "Disarm.cs"
+		};
+		foreach ((string effectType, string fileName) in effectFiles)
+		{
+			StringAssert.Contains(
+				File.ReadAllText(GetCoreSourcePath("Combat", "AuxiliaryEffects", fileName)),
+				$"RegisterBuilderParser(\"{effectType}\"");
+		}
+
+		foreach (string sharedCommand in new[]
+		         {
+			         "trait", "difficulty", "minimum", "amount", "perdegree", "max", "successecho",
+			         "failureecho", "clearecho"
+		         })
+		{
+			StringAssert.Contains(baseEffectSource, $"case \"{sharedCommand}\"");
+		}
+
+		foreach (string attributeName in new[]
+		         {
+			         "defensetrait", "defensedifficulty", "minimumdegree", "flatamount",
+			         "perdegreeamount", "maximumamount", "successecho", "failureecho"
+		         })
+		{
+			StringAssert.Contains(baseEffectSource, $"\"{attributeName}\"");
+		}
+	}
+
+	[TestMethod]
+	public void AuxiliaryEffectSources_DefaultsAndStateChangingFlows_ArePresent()
+	{
+		string delay = File.ReadAllText(GetCoreSourcePath("Combat", "AuxiliaryEffects", "TargetDelay.cs"));
+		string stamina = File.ReadAllText(GetCoreSourcePath("Combat", "AuxiliaryEffects", "TargetStamina.cs"));
+		string facing = File.ReadAllText(GetCoreSourcePath("Combat", "AuxiliaryEffects", "FacingChange.cs"));
+		string position = File.ReadAllText(GetCoreSourcePath("Combat", "AuxiliaryEffects", "PositionChange.cs"));
+		string disarm = File.ReadAllText(GetCoreSourcePath("Combat", "AuxiliaryEffects", "Disarm.cs"));
+
+		StringAssert.Contains(delay, "1.5, 0.5, 6.0");
+		StringAssert.Contains(delay, "DelayScheduleType(tch, ScheduleType.Combat");
+		StringAssert.Contains(stamina, "3.0, 1.0, 10.0");
+		StringAssert.Contains(stamina, "tch.SpendStamina(amount)");
+		StringAssert.Contains(facing, "1.0, 0.0, 1.0");
+		StringAssert.Contains(facing, "CombatPositioningUtilities.ImproveCombatPosition");
+		StringAssert.Contains(facing, "CombatPositioningUtilities.WorsenCombatPosition");
+		StringAssert.Contains(position, "1.5, 0.5, 5.0");
+		StringAssert.Contains(position, "tch.DoCombatKnockdown()");
+		StringAssert.Contains(position, "tch.SetPosition(Position, PositionModifier.None, null, null)");
+		StringAssert.Contains(disarm, "90.0, 0.0, 90.0");
+		StringAssert.Contains(disarm, "DisarmSelection.Best");
+		StringAssert.Contains(disarm, "target.Body.WieldedItems");
+		StringAssert.Contains(disarm, "new CombatNoGetEffect(item, tch.Combat)");
+		StringAssert.Contains(disarm, "new CombatGetItemEffect(tch, item)");
+	}
+
+	[TestMethod]
+	public void AuxiliaryAdvantageSources_DefenderTypeAndNumericParsingBugsStayFixed()
+	{
+		string attacker = File.ReadAllText(GetCoreSourcePath("Combat", "AuxiliaryEffects", "AttackerAdvantage.cs"));
+		string defender = File.ReadAllText(GetCoreSourcePath("Combat", "AuxiliaryEffects", "DefenderAdvantage.cs"));
+
+		StringAssert.Contains(defender, "RegisterBuilderParser(\"defenderadvantage\"");
+		StringAssert.Contains(defender, "return new DefenderAdvantage(");
+		StringAssert.Contains(defender, "new XAttribute(\"defensedifficulty\", (int)DefenseDifficulty)");
+		StringAssert.Contains(defender, "Defender Advantage Effect");
+		Assert.IsFalse(attacker.Contains("if (double.TryParse"), "Attacker advantage builder should reject only invalid numeric bonuses.");
+		Assert.IsFalse(defender.Contains("if (double.TryParse"), "Defender advantage builder should reject only invalid numeric bonuses.");
+	}
+
+	[TestMethod]
+	public void CombatStrategySources_AuxiliaryPercentageFeedsSharedMeleeAndRangedSelection()
+	{
+		string strategyBase = File.ReadAllText(GetCoreSourcePath("Combat", "Strategies", "StrategyBase.cs"));
+		string melee = File.ReadAllText(GetCoreSourcePath("Combat", "Strategies", "StandardMeleeStrategy.cs"));
+		string ranged = File.ReadAllText(GetCoreSourcePath("Combat", "Strategies", "RangeBaseStrategy.cs"));
+
+		StringAssert.Contains(strategyBase, "protected virtual ICombatMove AttemptUseAuxilliaryAction");
+		StringAssert.Contains(strategyBase, "UsableAuxiliaryMoves(combatant, tch, false)");
+		StringAssert.Contains(strategyBase, "return new AuxiliaryMove(combatant, tch, move)");
+		StringAssert.Contains(melee, "combatant.CombatSettings.AuxiliaryPercentage > 0.0");
+		StringAssert.Contains(melee, "roll <= combatant.CombatSettings.AuxiliaryPercentage");
+		StringAssert.Contains(melee, "return AttemptUseAuxilliaryAction(combatant);");
+		StringAssert.Contains(ranged, "combatant.CombatSettings.AuxiliaryPercentage > 0.0");
+		StringAssert.Contains(ranged, "roll <= combatant.CombatSettings.AuxiliaryPercentage");
+		StringAssert.Contains(ranged, "return AttemptUseAuxilliaryAction(combatant);");
+		Assert.IsTrue(
+			melee.LastIndexOf("return AttemptUseAuxilliaryAction(combatant);", StringComparison.Ordinal) >
+			melee.LastIndexOf("roll <= combatant.CombatSettings.AuxiliaryPercentage", StringComparison.Ordinal),
+			"Standard melee should retain its legacy auxiliary fallback after the weighted roll.");
+		Assert.IsTrue(
+			ranged.LastIndexOf("return null;", StringComparison.Ordinal) >
+			ranged.LastIndexOf("roll <= combatant.CombatSettings.AuxiliaryPercentage", StringComparison.Ordinal),
+			"Ranged strategies should keep their no-move fallback if no weighted auxiliary roll is selected.");
+	}
+
+	private static string GetCoreSourcePath(params string[] segments)
+	{
+		return Path.GetFullPath(Path.Combine(
+			new[]
+			{
+				AppContext.BaseDirectory,
+				"..",
+				"..",
+				"..",
+				"..",
+				"MudSharpCore"
+			}.Concat(segments).ToArray()));
 	}
 }

--- a/MudSharpCore Unit Tests/FutureProgFunctionDocumentationTests.cs
+++ b/MudSharpCore Unit Tests/FutureProgFunctionDocumentationTests.cs
@@ -63,6 +63,25 @@ public class FutureProgFunctionDocumentationTests
 		);
 	}
 
+	[TestMethod]
+	public void CelestialElevationFunction_Metadata_HasLocationAndZoneNumberOverloads()
+	{
+		FutureProgTestBootstrap.EnsureInitialised();
+
+		var overloads = FutureProg.GetFunctionCompilerInformations()
+		                          .Where(x => x.FunctionName.EqualTo("celestialelevation"))
+		                          .ToList();
+
+		Assert.AreEqual(2, overloads.Count);
+		Assert.IsTrue(overloads.Any(x =>
+			x.Parameters.SequenceEqual(new[] { ProgVariableTypes.Location, ProgVariableTypes.Number })));
+		Assert.IsTrue(overloads.Any(x =>
+			x.Parameters.SequenceEqual(new[] { ProgVariableTypes.Zone, ProgVariableTypes.Number })));
+		Assert.IsTrue(overloads.All(x => x.ReturnType == ProgVariableTypes.Number));
+		Assert.IsTrue(overloads.All(x => x.Category.EqualTo("Celestials")));
+		Assert.IsTrue(overloads.All(x => x.FunctionHelp.Contains("radians", StringComparison.OrdinalIgnoreCase)));
+	}
+
 	private static IEnumerable<string> ValidateFunction(FunctionCompilerInformation function)
 	{
 		var signature = $"{function.FunctionName}({string.Join(", ", function.Parameters.Select(x => x.Describe()))})";

--- a/MudSharpCore/Combat/AuxiliaryCombatAction.cs
+++ b/MudSharpCore/Combat/AuxiliaryCombatAction.cs
@@ -156,6 +156,16 @@ internal class AuxiliaryCombatAction : CombatAction, IAuxiliaryCombatAction
                 return new AttackerAdvantage(definition, gameworld);
             case "defenderadvantage":
                 return new DefenderAdvantage(definition, gameworld);
+            case "targetdelay":
+                return new TargetDelay(definition, gameworld);
+            case "facing":
+                return new FacingChange(definition, gameworld);
+            case "targetstamina":
+                return new TargetStamina(definition, gameworld);
+            case "positionchange":
+                return new PositionChange(definition, gameworld);
+            case "disarm":
+                return new Disarm(definition, gameworld);
             default:
                 throw new NotImplementedException();
         }

--- a/MudSharpCore/Combat/AuxiliaryEffects/AttackerAdvantage.cs
+++ b/MudSharpCore/Combat/AuxiliaryEffects/AttackerAdvantage.cs
@@ -247,7 +247,7 @@ Use negative values for offense/defense bonus to indicate penalties.
             return false;
         }
 
-        if (double.TryParse(command.SafeRemainingArgument, out double value))
+        if (!double.TryParse(command.SafeRemainingArgument, out double value))
         {
             actor.OutputHandler.Send("That is not a valid number.");
             return false;
@@ -279,7 +279,7 @@ Use negative values for offense/defense bonus to indicate penalties.
             return false;
         }
 
-        if (double.TryParse(command.SafeRemainingArgument, out double value))
+        if (!double.TryParse(command.SafeRemainingArgument, out double value))
         {
             actor.OutputHandler.Send("That is not a valid number.");
             return false;

--- a/MudSharpCore/Combat/AuxiliaryEffects/DefenderAdvantage.cs
+++ b/MudSharpCore/Combat/AuxiliaryEffects/DefenderAdvantage.cs
@@ -28,7 +28,7 @@ internal class DefenderAdvantage : IAuxiliaryEffect
         OffenseBonusPerDegree = double.Parse(root.Attribute("offensebonusperdegree")!.Value);
         AllowNegatives = bool.Parse(root.Attribute("allownegatives")!.Value);
         AllowPositives = bool.Parse(root.Attribute("allowpositives")!.Value);
-        DefenseTrait = gameworld.Traits.Get(long.Parse(root.Attribute("defensetrait")!.Value)) ?? throw new ApplicationException($"Missing DefenseTrait for AttackerAdvantage: {root.Attribute("defensetrait")!.Value}");
+        DefenseTrait = gameworld.Traits.Get(long.Parse(root.Attribute("defensetrait")!.Value)) ?? throw new ApplicationException($"Missing DefenseTrait for DefenderAdvantage: {root.Attribute("defensetrait")!.Value}");
         DefenseDifficulty = (Difficulty)(int.Parse(root.Attribute("defensedifficulty")!.Value));
     }
 
@@ -39,7 +39,7 @@ internal class DefenderAdvantage : IAuxiliaryEffect
             new XAttribute("defensebonusperdegree", DefenseBonusPerDegree),
             new XAttribute("offensebonusperdegree", OffenseBonusPerDegree),
             new XAttribute("defensetrait", DefenseTrait.Id),
-            new XAttribute("defensedifficulty", DefenseDifficulty),
+            new XAttribute("defensedifficulty", (int)DefenseDifficulty),
             new XAttribute("allownegatives", AllowNegatives),
             new XAttribute("allowpositives", AllowPositives)
         );
@@ -103,7 +103,7 @@ internal class DefenderAdvantage : IAuxiliaryEffect
                 return null;
             }
 
-            return new AttackerAdvantage(
+            return new DefenderAdvantage(
                 new XElement("Effect",
                     new XAttribute("type", "defenderadvantage"),
                     new XAttribute("defensebonusperdegree", defense.Abs()),
@@ -245,7 +245,7 @@ Use negative values for offense/defense bonus to indicate penalties.
             return false;
         }
 
-        if (double.TryParse(command.SafeRemainingArgument, out double value))
+        if (!double.TryParse(command.SafeRemainingArgument, out double value))
         {
             actor.OutputHandler.Send("That is not a valid number.");
             return false;
@@ -277,7 +277,7 @@ Use negative values for offense/defense bonus to indicate penalties.
             return false;
         }
 
-        if (double.TryParse(command.SafeRemainingArgument, out double value))
+        if (!double.TryParse(command.SafeRemainingArgument, out double value))
         {
             actor.OutputHandler.Send("That is not a valid number.");
             return false;
@@ -304,7 +304,7 @@ Use negative values for offense/defense bonus to indicate penalties.
     public string Show(ICharacter actor)
     {
         StringBuilder sb = new();
-        sb.AppendLine($"Attacker Advantage Effect".GetLineWithTitle(actor, Telnet.Cyan, Telnet.BoldWhite));
+        sb.AppendLine($"Defender Advantage Effect".GetLineWithTitle(actor, Telnet.Cyan, Telnet.BoldWhite));
         sb.AppendLine($"Allow Positives: {AllowPositives.ToColouredString()}");
         sb.AppendLine($"Allow Negatives: {AllowNegatives.ToColouredString()}");
         sb.AppendLine($"Defense Trait: {DefenseTrait.Name.ColourValue()} @ {DefenseDifficulty.DescribeColoured()}");

--- a/MudSharpCore/Combat/AuxiliaryEffects/Disarm.cs
+++ b/MudSharpCore/Combat/AuxiliaryEffects/Disarm.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+using MudSharp.Character;
+using MudSharp.Effects.Concrete;
+using MudSharp.Framework;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.RPG.Checks;
+
+namespace MudSharp.Combat.AuxiliaryEffects;
+
+#nullable enable
+
+internal sealed class Disarm : OpposedAuxiliaryEffectBase
+{
+	private enum DisarmSelection
+	{
+		Best,
+		Primary,
+		Random
+	}
+
+	private DisarmSelection Selection { get; set; }
+
+	public Disarm(XElement root, IFuturemud gameworld) : base(root, gameworld)
+	{
+		Selection = root.Attribute("selection")?.Value.TryParseEnum(out DisarmSelection selection) == true
+			? selection
+			: DisarmSelection.Best;
+	}
+
+	private Disarm(IFuturemud gameworld, MudSharp.Body.Traits.ITraitDefinition defenseTrait,
+		Difficulty defenseDifficulty) : base(gameworld, defenseTrait, defenseDifficulty, 90.0, 0.0, 90.0)
+	{
+		Selection = DisarmSelection.Best;
+		SuccessEcho = "$0 knock|knocks $2 from $1's grip!";
+	}
+
+	protected override string TypeName => "disarm";
+	protected override string EffectName => "Disarm";
+	protected override string AmountName => "No-Get Duration";
+	protected override string AmountUnit => "s";
+	protected override double DefaultFlatAmount => 90.0;
+	protected override double DefaultPerDegreeAmount => 0.0;
+	protected override double DefaultMaximumAmount => 90.0;
+
+	public static void RegisterTypeHelp()
+	{
+		AuxiliaryCombatAction.RegisterBuilderParser("disarm", (action, actor, command) =>
+		{
+			return !TryParseDefenseArguments(action, actor, command, out var trait, out var difficulty)
+				? null
+				: new Disarm(actor.Gameworld, trait, difficulty);
+		},
+			@"The Disarm effect knocks a wielded weapon out of the target's hands on a successful opposed auxiliary move.
+
+The syntax to create this type is as follows:
+
+	#3auxiliary set add disarm [defense trait] [difficulty]#0
+
+If omitted, the defense trait defaults to the auxiliary action's check trait and difficulty defaults to Normal. The default targets the best wielded weapon and marks it with the normal combat no-get/get-item effects for 90 seconds.",
+			true);
+	}
+
+	public override XElement Save()
+	{
+		var root = new XElement("Effect",
+			new XAttribute("selection", Selection));
+		SaveCommonAttributes(root);
+		return root;
+	}
+
+	public override string DescribeForShow(ICharacter actor)
+	{
+		return $"{EffectName} | {Selection.DescribeEnum()} | {DescribeCommon(actor)}";
+	}
+
+	public override bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "selection":
+			case "select":
+			case "target":
+				return BuildingCommandSelection(actor, command);
+			default:
+				return base.BuildingCommand(actor, command.GetUndo());
+		}
+	}
+
+	private bool BuildingCommandSelection(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !command.SafeRemainingArgument.TryParseEnum(out DisarmSelection selection))
+		{
+			actor.OutputHandler.Send($"How should this effect select a weapon? The valid options are {Enum.GetValues<DisarmSelection>().Select(x => x.DescribeEnum().ColourValue()).ListToString()}.");
+			return false;
+		}
+
+		Selection = selection;
+		actor.OutputHandler.Send($"This effect will now select the {Selection.DescribeEnum().ColourValue()} wielded item.");
+		return true;
+	}
+
+	protected override void AppendSpecificShow(ICharacter actor, StringBuilder sb)
+	{
+		sb.AppendLine($"Selection: {Selection.DescribeEnum().ColourValue()}");
+	}
+
+	private IGameItem? SelectItem(ICharacter attacker, ICharacter target)
+	{
+		var items = target.Body.WieldedItems
+		                  .Where(x => target.Body.CanBeDisarmed(x, attacker))
+		                  .ToList();
+		return Selection switch
+		{
+			DisarmSelection.Random => items.GetRandomElement(),
+			DisarmSelection.Primary => items.FirstOrDefault(),
+			_ => items
+				.OrderByDescending(x => x.IsItemType<IMeleeWeapon>() || x.IsItemType<IRangedWeapon>())
+				.ThenByDescending(x => x.Weight)
+				.FirstOrDefault()
+		};
+	}
+
+	public override void ApplyEffect(ICharacter attacker, IPerceiver target, CheckOutcome outcome)
+	{
+		if (target is not ICharacter tch)
+		{
+			return;
+		}
+
+		if (!TryGetOpposedSuccess(attacker, target, outcome, out var opposed))
+		{
+			SendEcho(FailureEcho, attacker, tch);
+			return;
+		}
+
+		var item = SelectItem(attacker, tch);
+		if (item is null)
+		{
+			return;
+		}
+
+		tch.Body.Take(item);
+		item.RoomLayer = tch.RoomLayer;
+		tch.Location.Insert(item);
+		var duration = CalculateAmount(opposed);
+		if (duration > 0.0)
+		{
+			item.AddEffect(new CombatNoGetEffect(item, tch.Combat), TimeSpan.FromSeconds(duration));
+		}
+
+		tch.AddEffect(new CombatGetItemEffect(tch, item));
+		SendEcho(SuccessEcho, attacker, tch, item);
+	}
+}

--- a/MudSharpCore/Combat/AuxiliaryEffects/FacingChange.cs
+++ b/MudSharpCore/Combat/AuxiliaryEffects/FacingChange.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Text;
+using System.Xml.Linq;
+using MudSharp.Character;
+using MudSharp.Combat.Moves;
+using MudSharp.Framework;
+using MudSharp.RPG.Checks;
+
+namespace MudSharp.Combat.AuxiliaryEffects;
+
+#nullable enable
+
+internal sealed class FacingChange : OpposedAuxiliaryEffectBase
+{
+	private enum FacingSubject
+	{
+		Attacker,
+		Target
+	}
+
+	private enum FacingDirection
+	{
+		Improve,
+		Worsen
+	}
+
+	private FacingSubject Subject { get; set; }
+	private FacingDirection Direction { get; set; }
+
+	public FacingChange(XElement root, IFuturemud gameworld) : base(root, gameworld)
+	{
+		Subject = root.Attribute("subject")?.Value.TryParseEnum(out FacingSubject subject) == true
+			? subject
+			: FacingSubject.Attacker;
+		Direction = root.Attribute("direction")?.Value.TryParseEnum(out FacingDirection direction) == true
+			? direction
+			: FacingDirection.Improve;
+	}
+
+	private FacingChange(IFuturemud gameworld, MudSharp.Body.Traits.ITraitDefinition defenseTrait,
+		Difficulty defenseDifficulty) : base(gameworld, defenseTrait, defenseDifficulty, 1.0, 0.0, 1.0)
+	{
+		Subject = FacingSubject.Attacker;
+		Direction = FacingDirection.Improve;
+	}
+
+	protected override string TypeName => "facing";
+	protected override string EffectName => "Facing Change";
+	protected override string AmountName => "Facing Steps";
+	protected override double DefaultFlatAmount => 1.0;
+	protected override double DefaultPerDegreeAmount => 0.0;
+	protected override double DefaultMaximumAmount => 1.0;
+
+	public static void RegisterTypeHelp()
+	{
+		AuxiliaryCombatAction.RegisterBuilderParser("facing", (action, actor, command) =>
+		{
+			return !TryParseDefenseArguments(action, actor, command, out var trait, out var difficulty)
+				? null
+				: new FacingChange(actor.Gameworld, trait, difficulty);
+		},
+			@"The Facing effect changes combat facing on a successful opposed auxiliary move.
+
+The syntax to create this type is as follows:
+
+	#3auxiliary set add facing [defense trait] [difficulty]#0
+
+If omitted, the defense trait defaults to the auxiliary action's check trait and difficulty defaults to Normal. The default improves the attacker's facing by one step, usually from front to flank.",
+			true);
+	}
+
+	public override XElement Save()
+	{
+		var root = new XElement("Effect",
+			new XAttribute("subject", Subject),
+			new XAttribute("direction", Direction));
+		SaveCommonAttributes(root);
+		return root;
+	}
+
+	public override string DescribeForShow(ICharacter actor)
+	{
+		return $"{EffectName} | {Subject.DescribeEnum()} {Direction.DescribeEnum()} | {DescribeCommon(actor)}";
+	}
+
+	public override bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "subject":
+			case "target":
+			case "who":
+				return BuildingCommandSubject(actor, command);
+			case "direction":
+			case "mode":
+				return BuildingCommandDirection(actor, command);
+			default:
+				return base.BuildingCommand(actor, command.GetUndo());
+		}
+	}
+
+	private bool BuildingCommandSubject(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !command.SafeRemainingArgument.TryParseEnum(out FacingSubject subject))
+		{
+			actor.OutputHandler.Send("Do you want this facing change to affect the attacker or the target?");
+			return false;
+		}
+
+		Subject = subject;
+		actor.OutputHandler.Send($"This effect will now affect the {Subject.DescribeEnum().ColourValue()}.");
+		return true;
+	}
+
+	private bool BuildingCommandDirection(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !command.SafeRemainingArgument.TryParseEnum(out FacingDirection direction))
+		{
+			actor.OutputHandler.Send("Do you want this effect to improve or worsen facing?");
+			return false;
+		}
+
+		Direction = direction;
+		actor.OutputHandler.Send($"This effect will now {Direction.DescribeEnum().ToLowerInvariant().ColourValue()} facing.");
+		return true;
+	}
+
+	protected override void AppendSpecificShow(ICharacter actor, StringBuilder sb)
+	{
+		sb.AppendLine($"Subject: {Subject.DescribeEnum().ColourValue()}");
+		sb.AppendLine($"Direction: {Direction.DescribeEnum().ColourValue()}");
+	}
+
+	public override void ApplyEffect(ICharacter attacker, IPerceiver target, CheckOutcome outcome)
+	{
+		if (target is not ICharacter tch)
+		{
+			return;
+		}
+
+		if (!TryGetOpposedSuccess(attacker, target, outcome, out var opposed))
+		{
+			SendEcho(FailureEcho, attacker, tch);
+			return;
+		}
+
+		var steps = Math.Max(1, (int)Math.Round(CalculateAmount(opposed), MidpointRounding.AwayFromZero));
+		var actor = Subject == FacingSubject.Attacker ? attacker : tch;
+		var defender = Subject == FacingSubject.Attacker ? tch : attacker;
+		for (var i = 0; i < steps; i++)
+		{
+			if (Direction == FacingDirection.Improve)
+			{
+				CombatPositioningUtilities.ImproveCombatPosition(actor, defender);
+				continue;
+			}
+
+			CombatPositioningUtilities.WorsenCombatPosition(actor, defender);
+		}
+
+		SendEcho(SuccessEcho, attacker, tch);
+	}
+}

--- a/MudSharpCore/Combat/AuxiliaryEffects/OpposedAuxiliaryEffectBase.cs
+++ b/MudSharpCore/Combat/AuxiliaryEffects/OpposedAuxiliaryEffectBase.cs
@@ -1,0 +1,409 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+using MudSharp.Body.Traits;
+using MudSharp.Character;
+using MudSharp.Framework;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Outputs;
+using MudSharp.PerceptionEngine.Parsers;
+using MudSharp.RPG.Checks;
+
+namespace MudSharp.Combat.AuxiliaryEffects;
+
+#nullable enable
+
+internal abstract class OpposedAuxiliaryEffectBase : IAuxiliaryEffect
+{
+	protected OpposedAuxiliaryEffectBase(XElement root, IFuturemud gameworld)
+	{
+		Gameworld = gameworld;
+		DefenseTrait = gameworld.Traits.Get(long.Parse(root.Attribute("defensetrait")!.Value, CultureInfo.InvariantCulture)) ??
+			throw new ApplicationException($"Missing DefenseTrait for {EffectName}: {root.Attribute("defensetrait")!.Value}");
+		DefenseDifficulty = (Difficulty)int.Parse(root.Attribute("defensedifficulty")!.Value, CultureInfo.InvariantCulture);
+		MinimumDegree = root.Attribute("minimumdegree") is XAttribute minimum
+			? (OpposedOutcomeDegree)int.Parse(minimum.Value, CultureInfo.InvariantCulture)
+			: OpposedOutcomeDegree.Marginal;
+		FlatAmount = ReadDouble(root, "flatamount", DefaultFlatAmount);
+		PerDegreeAmount = ReadDouble(root, "perdegreeamount", DefaultPerDegreeAmount);
+		MaximumAmount = ReadDouble(root, "maximumamount", DefaultMaximumAmount);
+		SuccessEcho = root.Attribute("successecho")?.Value;
+		FailureEcho = root.Attribute("failureecho")?.Value;
+	}
+
+	protected OpposedAuxiliaryEffectBase(IFuturemud gameworld, ITraitDefinition defenseTrait, Difficulty defenseDifficulty,
+		double flatAmount, double perDegreeAmount, double maximumAmount)
+	{
+		Gameworld = gameworld;
+		DefenseTrait = defenseTrait;
+		DefenseDifficulty = defenseDifficulty;
+		MinimumDegree = OpposedOutcomeDegree.Marginal;
+		FlatAmount = flatAmount;
+		PerDegreeAmount = perDegreeAmount;
+		MaximumAmount = maximumAmount;
+	}
+
+	public IFuturemud Gameworld { get; }
+	public ITraitDefinition DefenseTrait { get; set; }
+	public Difficulty DefenseDifficulty { get; set; }
+	public OpposedOutcomeDegree MinimumDegree { get; set; }
+	public double FlatAmount { get; set; }
+	public double PerDegreeAmount { get; set; }
+	public double MaximumAmount { get; set; }
+	public string? SuccessEcho { get; set; }
+	public string? FailureEcho { get; set; }
+
+	protected abstract string TypeName { get; }
+	protected abstract string EffectName { get; }
+	protected abstract string AmountName { get; }
+	protected virtual string AmountUnit => string.Empty;
+	protected abstract double DefaultFlatAmount { get; }
+	protected abstract double DefaultPerDegreeAmount { get; }
+	protected abstract double DefaultMaximumAmount { get; }
+
+	private static double ReadDouble(XElement root, string attribute, double defaultValue)
+	{
+		return root.Attribute(attribute) is XAttribute value
+			? double.Parse(value.Value, CultureInfo.InvariantCulture)
+			: defaultValue;
+	}
+
+	protected static bool TryParseDefenseArguments(
+		AuxiliaryCombatAction action,
+		ICharacter actor,
+		StringStack command,
+		out ITraitDefinition trait,
+		out Difficulty difficulty)
+	{
+		trait = action.CheckTrait;
+		difficulty = Difficulty.Normal;
+		if (command.IsFinished)
+		{
+			return true;
+		}
+
+		var traitText = command.PopSpeech();
+		var foundTrait = actor.Gameworld.Traits.GetByIdOrName(traitText);
+		if (foundTrait is null)
+		{
+			actor.OutputHandler.Send("There is no such trait.");
+			return false;
+		}
+		trait = foundTrait;
+
+		if (command.IsFinished)
+		{
+			return true;
+		}
+
+		if (!command.PopSpeech().TryParseEnum(out difficulty))
+		{
+			actor.OutputHandler.Send($"That is not a valid difficulty. The valid difficulties are {Enum.GetValues<Difficulty>().Select(x => x.DescribeColoured()).ListToString()}.");
+			return false;
+		}
+
+		return true;
+	}
+
+	protected void SaveCommonAttributes(XElement root)
+	{
+		root.Add(
+			new XAttribute("type", TypeName),
+			new XAttribute("defensetrait", DefenseTrait.Id.ToString(CultureInfo.InvariantCulture)),
+			new XAttribute("defensedifficulty", ((int)DefenseDifficulty).ToString(CultureInfo.InvariantCulture)),
+			new XAttribute("minimumdegree", ((int)MinimumDegree).ToString(CultureInfo.InvariantCulture)),
+			new XAttribute("flatamount", FlatAmount.ToString(CultureInfo.InvariantCulture)),
+			new XAttribute("perdegreeamount", PerDegreeAmount.ToString(CultureInfo.InvariantCulture)),
+			new XAttribute("maximumamount", MaximumAmount.ToString(CultureInfo.InvariantCulture))
+		);
+
+		if (!string.IsNullOrWhiteSpace(SuccessEcho))
+		{
+			root.Add(new XAttribute("successecho", SuccessEcho));
+		}
+
+		if (!string.IsNullOrWhiteSpace(FailureEcho))
+		{
+			root.Add(new XAttribute("failureecho", FailureEcho));
+		}
+	}
+
+	protected bool TryGetOpposedSuccess(ICharacter attacker, IPerceiver target, CheckOutcome outcome, out OpposedOutcome opposed)
+	{
+		opposed = new OpposedOutcome(OpposedOutcomeDirection.Stalemate, OpposedOutcomeDegree.None);
+		if (target is not ICharacter tch)
+		{
+			return false;
+		}
+
+		var defenderOutcome = Gameworld.GetCheck(CheckType.CombatMoveCheck)
+		                               .Check(tch, DefenseDifficulty, DefenseTrait, attacker);
+		opposed = new OpposedOutcome(outcome, defenderOutcome);
+		return opposed.Outcome == OpposedOutcomeDirection.Proponent && opposed.Degree >= MinimumDegree;
+	}
+
+	protected double CalculateAmount(OpposedOutcome opposed)
+	{
+		var amount = FlatAmount + PerDegreeAmount * (int)opposed.Degree;
+		if (MaximumAmount > 0.0)
+		{
+			amount = Math.Min(amount, MaximumAmount);
+		}
+
+		return Math.Max(0.0, amount);
+	}
+
+	protected string DescribeCommon(ICharacter actor)
+	{
+		return $"vs {DefenseTrait.Name.ColourValue()}@{DefenseDifficulty.DescribeColoured()} | min {MinimumDegree.DescribeColour()} | {AmountName}: {FlatAmount.ToString("N2", actor).ColourValue()}{AmountUnit}+{PerDegreeAmount.ToString("N2", actor).ColourValue()}{AmountUnit}/degree capped {MaximumAmount.ToString("N2", actor).ColourValue()}{AmountUnit}";
+	}
+
+	public virtual bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "trait":
+			case "skill":
+			case "defensetrait":
+				return BuildingCommandTrait(actor, command);
+			case "difficulty":
+			case "diff":
+			case "defensedifficulty":
+				return BuildingCommandDifficulty(actor, command);
+			case "minimum":
+			case "minimumdegree":
+			case "mindegree":
+			case "min":
+				return BuildingCommandMinimum(actor, command);
+			case "amount":
+			case "base":
+			case "flat":
+			case "flatamount":
+				return BuildingCommandFlatAmount(actor, command);
+			case "perdegree":
+			case "scale":
+			case "scaling":
+				return BuildingCommandPerDegree(actor, command);
+			case "maximum":
+			case "max":
+			case "cap":
+				return BuildingCommandMaximum(actor, command);
+			case "successecho":
+			case "success":
+				return BuildingCommandSuccessEcho(actor, command);
+			case "failureecho":
+			case "fail":
+			case "failure":
+				return BuildingCommandFailureEcho(actor, command);
+			case "clearecho":
+			case "clear":
+				return BuildingCommandClearEcho(actor, command);
+			default:
+				actor.OutputHandler.Send(BuildingHelpText.SubstituteANSIColour());
+				return false;
+		}
+	}
+
+	protected virtual string BuildingHelpText => $@"You can use the following syntax to edit this effect:
+
+	#3trait <which>#0 - sets the trait used to defend against this move
+	#3difficulty <diff>#0 - sets the difficulty of defending
+	#3minimum <degree>#0 - sets the minimum opposed success degree required
+	#3amount <value>#0 - sets the flat {AmountName.ToLowerInvariant()} amount
+	#3perdegree <value>#0 - sets the {AmountName.ToLowerInvariant()} amount per success degree
+	#3max <value>#0 - sets the maximum {AmountName.ToLowerInvariant()} amount, or 0 for no cap
+	#3successecho <emote>#0 - sets an optional success echo
+	#3failureecho <emote>#0 - sets an optional failed defense echo
+	#3clearecho success|failure|all#0 - clears optional echoes";
+
+	private bool BuildingCommandTrait(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which trait should be used for the defense test against this effect?");
+			return false;
+		}
+
+		var trait = Gameworld.Traits.GetByIdOrName(command.SafeRemainingArgument);
+		if (trait is null)
+		{
+			actor.OutputHandler.Send("There is no such trait.");
+			return false;
+		}
+
+		DefenseTrait = trait;
+		actor.OutputHandler.Send($"The defense test against this effect will now use the {trait.Name.ColourValue()} trait.");
+		return true;
+	}
+
+	private bool BuildingCommandDifficulty(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send($"What difficulty should the defense test against this effect be? The valid values are {Enum.GetValues<Difficulty>().Select(x => x.DescribeColoured()).ListToString()}.");
+			return false;
+		}
+
+		if (!command.SafeRemainingArgument.TryParseEnum(out Difficulty difficulty))
+		{
+			actor.OutputHandler.Send($"That is not a valid difficulty. The valid values are {Enum.GetValues<Difficulty>().Select(x => x.DescribeColoured()).ListToString()}.");
+			return false;
+		}
+
+		DefenseDifficulty = difficulty;
+		actor.OutputHandler.Send($"The defense test against this effect will now be at {difficulty.DescribeColoured()} difficulty.");
+		return true;
+	}
+
+	private bool BuildingCommandMinimum(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send($"What minimum opposed outcome degree should this effect require? The valid values are {Enum.GetValues<OpposedOutcomeDegree>().Select(x => x.DescribeColour()).ListToString()}.");
+			return false;
+		}
+
+		if (!command.SafeRemainingArgument.TryParseEnum(out OpposedOutcomeDegree degree))
+		{
+			actor.OutputHandler.Send($"That is not a valid opposed outcome degree. The valid values are {Enum.GetValues<OpposedOutcomeDegree>().Select(x => x.DescribeColour()).ListToString()}.");
+			return false;
+		}
+
+		MinimumDegree = degree;
+		actor.OutputHandler.Send($"This effect will now require at least a {degree.DescribeColour()} opposed success.");
+		return true;
+	}
+
+	private bool BuildingCommandFlatAmount(ICharacter actor, StringStack command)
+	{
+		return BuildingCommandDouble(actor, command, AmountName, value =>
+		{
+			FlatAmount = value;
+			actor.OutputHandler.Send($"The flat {AmountName.ToLowerInvariant()} amount is now {value.ToString("N2", actor).ColourValue()}{AmountUnit}.");
+		});
+	}
+
+	private bool BuildingCommandPerDegree(ICharacter actor, StringStack command)
+	{
+		return BuildingCommandDouble(actor, command, $"{AmountName} per degree", value =>
+		{
+			PerDegreeAmount = value;
+			actor.OutputHandler.Send($"The {AmountName.ToLowerInvariant()} amount per degree is now {value.ToString("N2", actor).ColourValue()}{AmountUnit}.");
+		});
+	}
+
+	private bool BuildingCommandMaximum(ICharacter actor, StringStack command)
+	{
+		return BuildingCommandDouble(actor, command, $"maximum {AmountName}", value =>
+		{
+			MaximumAmount = value;
+			actor.OutputHandler.Send($"The maximum {AmountName.ToLowerInvariant()} amount is now {value.ToString("N2", actor).ColourValue()}{AmountUnit}.");
+		});
+	}
+
+	private static bool BuildingCommandDouble(ICharacter actor, StringStack command, string amountName, Action<double> action)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send($"What should the {amountName.ToLowerInvariant()} value be?");
+			return false;
+		}
+
+		if (!double.TryParse(command.SafeRemainingArgument, out var value))
+		{
+			actor.OutputHandler.Send("That is not a valid number.");
+			return false;
+		}
+
+		action(value);
+		return true;
+	}
+
+	private bool BuildingCommandSuccessEcho(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("What emote should be shown when this effect succeeds?");
+			return false;
+		}
+
+		SuccessEcho = command.SafeRemainingArgument;
+		actor.OutputHandler.Send($"This effect will now show the following success echo: {SuccessEcho.ColourCommand()}");
+		return true;
+	}
+
+	private bool BuildingCommandFailureEcho(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("What emote should be shown when the defender resists this effect?");
+			return false;
+		}
+
+		FailureEcho = command.SafeRemainingArgument;
+		actor.OutputHandler.Send($"This effect will now show the following resisted echo: {FailureEcho.ColourCommand()}");
+		return true;
+	}
+
+	private bool BuildingCommandClearEcho(ICharacter actor, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "success":
+				SuccessEcho = null;
+				actor.OutputHandler.Send("The success echo has been cleared.");
+				return true;
+			case "failure":
+			case "fail":
+				FailureEcho = null;
+				actor.OutputHandler.Send("The failure echo has been cleared.");
+				return true;
+			case "all":
+			case "":
+				SuccessEcho = null;
+				FailureEcho = null;
+				actor.OutputHandler.Send("All optional echoes have been cleared.");
+				return true;
+			default:
+				actor.OutputHandler.Send("Do you want to clear the success echo, failure echo, or all echoes?");
+				return false;
+		}
+	}
+
+	protected void SendEcho(string? echo, ICharacter attacker, IPerceivable target, params IPerceivable[] additionalTargets)
+	{
+		if (string.IsNullOrWhiteSpace(echo))
+		{
+			return;
+		}
+
+		var targets = new[] { attacker, target }.Concat(additionalTargets).ToArray();
+		attacker.OutputHandler.Handle(new EmoteOutput(new Emote(echo, attacker, targets),
+			style: OutputStyle.CombatMessage, flags: OutputFlags.InnerWrap));
+	}
+
+	public virtual string Show(ICharacter actor)
+	{
+		var sb = new StringBuilder();
+		sb.AppendLine($"{EffectName} Effect".GetLineWithTitle(actor, Telnet.Cyan, Telnet.BoldWhite));
+		sb.AppendLine($"Defense Trait: {DefenseTrait.Name.ColourValue()} @ {DefenseDifficulty.DescribeColoured()}");
+		sb.AppendLine($"Minimum Degree: {MinimumDegree.DescribeColour()}");
+		sb.AppendLine($"Flat {AmountName}: {FlatAmount.ToString("N2", actor).ColourValue()}{AmountUnit}");
+		sb.AppendLine($"{AmountName} Per Degree: {PerDegreeAmount.ToString("N2", actor).ColourValue()}{AmountUnit}");
+		sb.AppendLine($"Maximum {AmountName}: {MaximumAmount.ToString("N2", actor).ColourValue()}{AmountUnit}");
+		sb.AppendLine($"Success Echo: {(SuccessEcho?.ColourCommand() ?? "None".Colour(Telnet.Red))}");
+		sb.AppendLine($"Failure Echo: {(FailureEcho?.ColourCommand() ?? "None".Colour(Telnet.Red))}");
+		AppendSpecificShow(actor, sb);
+		return sb.ToString();
+	}
+
+	protected virtual void AppendSpecificShow(ICharacter actor, StringBuilder sb)
+	{
+	}
+
+	public abstract XElement Save();
+	public abstract string DescribeForShow(ICharacter actor);
+	public abstract void ApplyEffect(ICharacter attacker, IPerceiver target, CheckOutcome outcome);
+}

--- a/MudSharpCore/Combat/AuxiliaryEffects/PositionChange.cs
+++ b/MudSharpCore/Combat/AuxiliaryEffects/PositionChange.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Text;
+using System.Xml.Linq;
+using MudSharp.Body.Position;
+using MudSharp.Body.Position.PositionStates;
+using MudSharp.Character;
+using MudSharp.Framework;
+using MudSharp.Framework.Scheduling;
+using MudSharp.PerceptionEngine.Parsers;
+using MudSharp.RPG.Checks;
+
+namespace MudSharp.Combat.AuxiliaryEffects;
+
+#nullable enable
+
+internal sealed class PositionChange : OpposedAuxiliaryEffectBase
+{
+	private IPositionState Position { get; set; }
+	private bool UseKnockdown { get; set; }
+
+	public PositionChange(XElement root, IFuturemud gameworld) : base(root, gameworld)
+	{
+		Position = PositionState.GetState(root.Attribute("position")?.Value ?? PositionSprawled.Instance.Id.ToString()) ??
+			PositionSprawled.Instance;
+		UseKnockdown = root.Attribute("knockdown")?.Value.Equals("true", StringComparison.OrdinalIgnoreCase) != false;
+	}
+
+	private PositionChange(IFuturemud gameworld, MudSharp.Body.Traits.ITraitDefinition defenseTrait,
+		Difficulty defenseDifficulty) : base(gameworld, defenseTrait, defenseDifficulty, 1.5, 0.5, 5.0)
+	{
+		Position = PositionSprawled.Instance;
+		UseKnockdown = true;
+		SuccessEcho = "$0 send|sends $1 sprawling off balance.";
+	}
+
+	protected override string TypeName => "positionchange";
+	protected override string EffectName => "Position Change";
+	protected override string AmountName => "Delay";
+	protected override string AmountUnit => "s";
+	protected override double DefaultFlatAmount => 1.5;
+	protected override double DefaultPerDegreeAmount => 0.5;
+	protected override double DefaultMaximumAmount => 5.0;
+
+	public static void RegisterTypeHelp()
+	{
+		AuxiliaryCombatAction.RegisterBuilderParser("positionchange", (action, actor, command) =>
+		{
+			return !TryParseDefenseArguments(action, actor, command, out var trait, out var difficulty)
+				? null
+				: new PositionChange(actor.Gameworld, trait, difficulty);
+		},
+			@"The Position Change effect changes the target's combat position on a successful opposed auxiliary move.
+
+The syntax to create this type is as follows:
+
+	#3auxiliary set add positionchange [defense trait] [difficulty]#0
+
+If omitted, the defense trait defaults to the auxiliary action's check trait and difficulty defaults to Normal. The default performs the existing combat knockdown and delays the target for 1.5 seconds plus 0.5 seconds per opposed success degree, capped at 5 seconds.",
+			true);
+	}
+
+	public override XElement Save()
+	{
+		var root = new XElement("Effect",
+			new XAttribute("position", Position.Id),
+			new XAttribute("knockdown", UseKnockdown));
+		SaveCommonAttributes(root);
+		return root;
+	}
+
+	public override string DescribeForShow(ICharacter actor)
+	{
+		return $"{EffectName} | {(UseKnockdown ? "Knockdown".ColourValue() : Position.DescribeLocationMovementParticiple.ColourValue())} | {DescribeCommon(actor)}";
+	}
+
+	public override bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "knockdown":
+			case "trip":
+				UseKnockdown = !UseKnockdown;
+				actor.OutputHandler.Send($"This effect will {UseKnockdown.NowNoLonger()} use the stock combat knockdown.");
+				return true;
+			case "position":
+			case "state":
+				return BuildingCommandPosition(actor, command);
+			default:
+				return base.BuildingCommand(actor, command.GetUndo());
+		}
+	}
+
+	private bool BuildingCommandPosition(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which position state should this effect force the target into?");
+			return false;
+		}
+
+		var state = PositionState.GetState(command.SafeRemainingArgument);
+		if (state is null)
+		{
+			actor.OutputHandler.Send("There is no such position state.");
+			return false;
+		}
+
+		Position = state;
+		UseKnockdown = false;
+		actor.OutputHandler.Send($"This effect will now force the target to be {state.DefaultDescription().ColourValue()}.");
+		return true;
+	}
+
+	protected override void AppendSpecificShow(ICharacter actor, StringBuilder sb)
+	{
+		sb.AppendLine($"Use Combat Knockdown: {UseKnockdown.ToColouredString()}");
+		sb.AppendLine($"Fallback Position: {Position.DescribeLocationMovementParticiple.ColourValue()}");
+	}
+
+	public override void ApplyEffect(ICharacter attacker, IPerceiver target, CheckOutcome outcome)
+	{
+		if (target is not ICharacter tch)
+		{
+			return;
+		}
+
+		if (!TryGetOpposedSuccess(attacker, target, outcome, out var opposed))
+		{
+			SendEcho(FailureEcho, attacker, tch);
+			return;
+		}
+
+		if (UseKnockdown)
+		{
+			tch.DoCombatKnockdown();
+		}
+		else if (tch.CanMovePosition(Position, true))
+		{
+			tch.SetPosition(Position, PositionModifier.None, null, null);
+		}
+
+		var delay = CalculateAmount(opposed);
+		if (delay > 0.0)
+		{
+			Gameworld.Scheduler.DelayScheduleType(tch, ScheduleType.Combat,
+				TimeSpan.FromSeconds(delay * CombatBase.CombatSpeedMultiplier));
+		}
+
+		SendEcho(SuccessEcho, attacker, tch);
+	}
+}

--- a/MudSharpCore/Combat/AuxiliaryEffects/TargetDelay.cs
+++ b/MudSharpCore/Combat/AuxiliaryEffects/TargetDelay.cs
@@ -1,0 +1,83 @@
+using System.Xml.Linq;
+using MudSharp.Character;
+using MudSharp.Framework;
+using MudSharp.Framework.Scheduling;
+using MudSharp.RPG.Checks;
+
+namespace MudSharp.Combat.AuxiliaryEffects;
+
+#nullable enable
+
+internal sealed class TargetDelay : OpposedAuxiliaryEffectBase
+{
+	public TargetDelay(XElement root, IFuturemud gameworld) : base(root, gameworld)
+	{
+	}
+
+	private TargetDelay(IFuturemud gameworld, MudSharp.Body.Traits.ITraitDefinition defenseTrait,
+		Difficulty defenseDifficulty) : base(gameworld, defenseTrait, defenseDifficulty, 1.5, 0.5, 6.0)
+	{
+	}
+
+	protected override string TypeName => "targetdelay";
+	protected override string EffectName => "Target Delay";
+	protected override string AmountName => "Delay";
+	protected override string AmountUnit => "s";
+	protected override double DefaultFlatAmount => 1.5;
+	protected override double DefaultPerDegreeAmount => 0.5;
+	protected override double DefaultMaximumAmount => 6.0;
+
+	public static void RegisterTypeHelp()
+	{
+		AuxiliaryCombatAction.RegisterBuilderParser("targetdelay", (action, actor, command) =>
+		{
+			return !TryParseDefenseArguments(action, actor, command, out var trait, out var difficulty)
+				? null
+				: new TargetDelay(actor.Gameworld, trait, difficulty);
+		},
+			@"The Target Delay effect makes a successful auxiliary move delay the target's next combat action.
+
+The syntax to create this type is as follows:
+
+	#3auxiliary set add targetdelay [defense trait] [difficulty]#0
+
+If omitted, the defense trait defaults to the auxiliary action's check trait and difficulty defaults to Normal. The default delay is 1.5 seconds plus 0.5 seconds per opposed success degree, capped at 6 seconds.",
+			true);
+	}
+
+	public override XElement Save()
+	{
+		var root = new XElement("Effect");
+		SaveCommonAttributes(root);
+		return root;
+	}
+
+	public override string DescribeForShow(ICharacter actor)
+	{
+		return $"{EffectName} | {DescribeCommon(actor)}";
+	}
+
+	public override void ApplyEffect(ICharacter attacker, IPerceiver target, CheckOutcome outcome)
+	{
+		if (target is not ICharacter tch)
+		{
+			return;
+		}
+
+		if (!TryGetOpposedSuccess(attacker, target, outcome, out var opposed))
+		{
+			SendEcho(FailureEcho, attacker, tch);
+			return;
+		}
+
+		var delay = CalculateAmount(opposed);
+		if (delay <= 0.0)
+		{
+			return;
+		}
+
+		Gameworld.Scheduler.DelayScheduleType(tch, ScheduleType.Combat,
+			System.TimeSpan.FromSeconds(delay * CombatBase.CombatSpeedMultiplier));
+		SendEcho(SuccessEcho, attacker, tch);
+	}
+}

--- a/MudSharpCore/Combat/AuxiliaryEffects/TargetStamina.cs
+++ b/MudSharpCore/Combat/AuxiliaryEffects/TargetStamina.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Xml.Linq;
+using MudSharp.Character;
+using MudSharp.Framework;
+using MudSharp.RPG.Checks;
+
+namespace MudSharp.Combat.AuxiliaryEffects;
+
+#nullable enable
+
+internal sealed class TargetStamina : OpposedAuxiliaryEffectBase
+{
+	public TargetStamina(XElement root, IFuturemud gameworld) : base(root, gameworld)
+	{
+	}
+
+	private TargetStamina(IFuturemud gameworld, MudSharp.Body.Traits.ITraitDefinition defenseTrait,
+		Difficulty defenseDifficulty) : base(gameworld, defenseTrait, defenseDifficulty, 3.0, 1.0, 10.0)
+	{
+	}
+
+	protected override string TypeName => "targetstamina";
+	protected override string EffectName => "Target Stamina Drain";
+	protected override string AmountName => "Stamina";
+	protected override double DefaultFlatAmount => 3.0;
+	protected override double DefaultPerDegreeAmount => 1.0;
+	protected override double DefaultMaximumAmount => 10.0;
+
+	public static void RegisterTypeHelp()
+	{
+		AuxiliaryCombatAction.RegisterBuilderParser("targetstamina", (action, actor, command) =>
+		{
+			return !TryParseDefenseArguments(action, actor, command, out var trait, out var difficulty)
+				? null
+				: new TargetStamina(actor.Gameworld, trait, difficulty);
+		},
+			@"The Target Stamina effect drains stamina from the target on a successful opposed auxiliary move.
+
+The syntax to create this type is as follows:
+
+	#3auxiliary set add targetstamina [defense trait] [difficulty]#0
+
+If omitted, the defense trait defaults to the auxiliary action's check trait and difficulty defaults to Normal. The default drain is 3 stamina plus 1 stamina per opposed success degree, capped at 10.",
+			true);
+	}
+
+	public override XElement Save()
+	{
+		var root = new XElement("Effect");
+		SaveCommonAttributes(root);
+		return root;
+	}
+
+	public override string DescribeForShow(ICharacter actor)
+	{
+		return $"{EffectName} | {DescribeCommon(actor)}";
+	}
+
+	public override void ApplyEffect(ICharacter attacker, IPerceiver target, CheckOutcome outcome)
+	{
+		if (target is not ICharacter tch)
+		{
+			return;
+		}
+
+		if (!TryGetOpposedSuccess(attacker, target, outcome, out var opposed))
+		{
+			SendEcho(FailureEcho, attacker, tch);
+			return;
+		}
+
+		var amount = Math.Min(tch.CurrentStamina, CalculateAmount(opposed));
+		if (amount <= 0.0)
+		{
+			return;
+		}
+
+		tch.SpendStamina(amount);
+		SendEcho(SuccessEcho, attacker, tch);
+	}
+}

--- a/MudSharpCore/Combat/Moves/CombatMoveBase.cs
+++ b/MudSharpCore/Combat/Moves/CombatMoveBase.cs
@@ -94,45 +94,12 @@ public abstract class CombatMoveBase : ICombatMove
 
     protected void WorsenCombatPosition(ICharacter assailant, ICharacter defender)
     {
-        IFixedFacingEffect effect = assailant.EffectsOfType<IFixedFacingEffect>().FirstOrDefault(x => x.AppliesTo(defender));
-        if (effect != null)
-        {
-            switch (effect.Facing)
-            {
-                case Facing.Front:
-                    return;
-                case Facing.Rear:
-                    assailant.RemoveEffect(effect);
-                    assailant.AddEffect(new FixedCombatFacing(assailant, defender,
-                        RandomUtilities.Random(1, 2) == 1 ? Facing.LeftFlank : Facing.RightFlank));
-                    return;
-                case Facing.LeftFlank:
-                case Facing.RightFlank:
-                    assailant.RemoveEffect(effect);
-                    return;
-            }
-        }
+        CombatPositioningUtilities.WorsenCombatPosition(assailant, defender);
     }
 
     protected void ImproveCombatPosition(ICharacter assailant, ICharacter defender)
     {
-        IFixedFacingEffect effect = assailant.EffectsOfType<IFixedFacingEffect>().FirstOrDefault(x => x.AppliesTo(defender));
-        if (effect != null)
-        {
-            switch (effect.Facing)
-            {
-                case Facing.Rear:
-                    return;
-                case Facing.LeftFlank:
-                case Facing.RightFlank:
-                    assailant.AddEffect(new FixedCombatFacing(assailant, defender, Facing.Rear));
-                    assailant.RemoveEffect(effect);
-                    return;
-            }
-        }
-
-        assailant.AddEffect(new FixedCombatFacing(assailant, defender,
-            RandomUtilities.Random(1, 2) == 1 ? Facing.LeftFlank : Facing.RightFlank));
+        CombatPositioningUtilities.ImproveCombatPosition(assailant, defender);
     }
 
     public virtual bool UsesStaminaWithResult(CombatMoveResult result)

--- a/MudSharpCore/Combat/Moves/CombatPositioningUtilities.cs
+++ b/MudSharpCore/Combat/Moves/CombatPositioningUtilities.cs
@@ -1,0 +1,54 @@
+using System.Linq;
+using MudSharp.Body;
+using MudSharp.Character;
+using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+
+namespace MudSharp.Combat.Moves;
+
+public static class CombatPositioningUtilities
+{
+	public static void WorsenCombatPosition(ICharacter assailant, ICharacter defender)
+	{
+		var effect = assailant.EffectsOfType<IFixedFacingEffect>().FirstOrDefault(x => x.AppliesTo(defender));
+		if (effect is not null)
+		{
+			switch (effect.Facing)
+			{
+				case Facing.Front:
+					return;
+				case Facing.Rear:
+					assailant.RemoveEffect(effect);
+					assailant.AddEffect(new FixedCombatFacing(assailant, defender,
+						RandomUtilities.Random(1, 2) == 1 ? Facing.LeftFlank : Facing.RightFlank));
+					return;
+				case Facing.LeftFlank:
+				case Facing.RightFlank:
+					assailant.RemoveEffect(effect);
+					return;
+			}
+		}
+	}
+
+	public static void ImproveCombatPosition(ICharacter assailant, ICharacter defender)
+	{
+		var effect = assailant.EffectsOfType<IFixedFacingEffect>().FirstOrDefault(x => x.AppliesTo(defender));
+		if (effect is not null)
+		{
+			switch (effect.Facing)
+			{
+				case Facing.Rear:
+					return;
+				case Facing.LeftFlank:
+				case Facing.RightFlank:
+					assailant.AddEffect(new FixedCombatFacing(assailant, defender, Facing.Rear));
+					assailant.RemoveEffect(effect);
+					return;
+			}
+		}
+
+		assailant.AddEffect(new FixedCombatFacing(assailant, defender,
+			RandomUtilities.Random(1, 2) == 1 ? Facing.LeftFlank : Facing.RightFlank));
+	}
+}

--- a/MudSharpCore/Combat/Strategies/RangeBaseStrategy.cs
+++ b/MudSharpCore/Combat/Strategies/RangeBaseStrategy.cs
@@ -300,6 +300,13 @@ public abstract class RangeBaseStrategy : StrategyBase
             return AttemptUsePsychicAbility(combatant);
         }
 
+        roll -= combatant.CombatSettings.PsychicUsePercentage;
+        if (combatant.CombatSettings.AuxiliaryPercentage > 0.0 &&
+            roll <= combatant.CombatSettings.AuxiliaryPercentage)
+        {
+            return AttemptUseAuxilliaryAction(combatant);
+        }
+
         return null;
     }
 

--- a/MudSharpCore/Combat/Strategies/StandardMeleeStrategy.cs
+++ b/MudSharpCore/Combat/Strategies/StandardMeleeStrategy.cs
@@ -1047,36 +1047,6 @@ public class StandardMeleeStrategy : StrategyBase
             combatant.CombatTarget.GetType().FullName);
     }
 
-    protected virtual ICombatMove AttemptUseAuxilliaryAction(ICharacter combatant)
-    {
-        if (combatant.CombatTarget is not ICharacter tch)
-        {
-            return null;
-        }
-
-        List<IAuxiliaryCombatAction> moves = combatant.Race.UsableAuxiliaryMoves(combatant, tch, false).ToList();
-        List<IAuxiliaryCombatAction> usableMoves = moves.Where(x => combatant.CanSpendStamina(x.StaminaCost)).ToList();
-        if (!usableMoves.Any())
-        {
-            return moves.Any() ? new TooExhaustedMove { Assailant = combatant } : null;
-        }
-
-        List<IAuxiliaryCombatAction> preferredMoves = usableMoves.Where(x => x.Intentions.HasFlag(combatant.CombatSettings.PreferredIntentions))
-                                        .ToList();
-        if (preferredMoves.Any() && Dice.Roll(1, 2) == 1)
-        {
-            usableMoves = preferredMoves;
-        }
-
-        IAuxiliaryCombatAction move = usableMoves.GetWeightedRandom(x => x.Weighting);
-        if (move is null)
-        {
-            return null;
-        }
-
-        return new AuxiliaryMove(combatant, tch, move);
-    }
-
     protected virtual ICombatMove HandleWeaponAttackRolled(ICharacter combatant)
     {
         ICombatMove move = AttemptUseWeapon(combatant);
@@ -1179,6 +1149,13 @@ public class StandardMeleeStrategy : StrategyBase
         if (combatant.CombatSettings.PsychicUsePercentage > 0 && roll <= combatant.CombatSettings.PsychicUsePercentage)
         {
             return AttemptUsePsychicAbility(combatant);
+        }
+
+        roll -= combatant.CombatSettings.PsychicUsePercentage;
+        if (combatant.CombatSettings.AuxiliaryPercentage > 0.0 &&
+            roll <= combatant.CombatSettings.AuxiliaryPercentage)
+        {
+            return AttemptUseAuxilliaryAction(combatant);
         }
 
         return AttemptUseAuxilliaryAction(combatant);

--- a/MudSharpCore/Combat/Strategies/StrategyBase.cs
+++ b/MudSharpCore/Combat/Strategies/StrategyBase.cs
@@ -842,6 +842,36 @@ public abstract class StrategyBase : ICombatStrategy
         return null;
     }
 
+    protected virtual ICombatMove AttemptUseAuxilliaryAction(ICharacter combatant)
+    {
+        if (combatant.CombatTarget is not ICharacter tch)
+        {
+            return null;
+        }
+
+        List<IAuxiliaryCombatAction> moves = combatant.Race.UsableAuxiliaryMoves(combatant, tch, false).ToList();
+        List<IAuxiliaryCombatAction> usableMoves = moves.Where(x => combatant.CanSpendStamina(x.StaminaCost)).ToList();
+        if (!usableMoves.Any())
+        {
+            return moves.Any() ? new TooExhaustedMove { Assailant = combatant } : null;
+        }
+
+        List<IAuxiliaryCombatAction> preferredMoves =
+            usableMoves.Where(x => x.Intentions.HasFlag(combatant.CombatSettings.PreferredIntentions)).ToList();
+        if (preferredMoves.Any() && Dice.Roll(1, 2) == 1)
+        {
+            usableMoves = preferredMoves;
+        }
+
+        IAuxiliaryCombatAction move = usableMoves.GetWeightedRandom(x => x.Weighting);
+        if (move is null)
+        {
+            return null;
+        }
+
+        return new AuxiliaryMove(combatant, tch, move);
+    }
+
     protected virtual ICombatMove CheckWeaponryLoadout(ICharacter ch)
     {
         // The default strategy checks that they have a weapon if they use a weapon, and a shield if they use a shield.

--- a/MudSharpCore/FutureProg/Functions/Celestials/CelestialElevationFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Celestials/CelestialElevationFunction.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MudSharp.Celestial;
+using MudSharp.Construction;
+using MudSharp.FutureProg.Variables;
+
+namespace MudSharp.FutureProg.Functions.Celestials;
+
+#nullable enable
+
+internal class CelestialElevationFunction : BuiltInFunction
+{
+	public CelestialElevationFunction(IList<IFunction> parameters) : base(parameters)
+	{
+	}
+
+	public override ProgVariableTypes ReturnType => ProgVariableTypes.Number;
+	public override string ErrorMessage => ParameterFunctions.First().ErrorMessage;
+
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		if (base.Execute(variables) == StatementResult.Error)
+		{
+			return StatementResult.Error;
+		}
+
+		var obj = ParameterFunctions[0].Result?.GetObject;
+		var zone = obj as IZone;
+		if (zone is null && obj is ICell cell)
+		{
+			zone = cell.Zone;
+		}
+
+		if (zone is null)
+		{
+			Result = new NumberVariable(0.0);
+			return StatementResult.Normal;
+		}
+
+		var id = Convert.ToInt64(ParameterFunctions[1].Result?.GetObject ?? 0L);
+		var celestial = zone.Celestials.FirstOrDefault(x => x.Id == id);
+		if (celestial is null)
+		{
+			Result = new NumberVariable(0.0);
+			return StatementResult.Normal;
+		}
+
+		CelestialInformation info = zone.GetInfo(celestial);
+		Result = new NumberVariable(info.LastAscensionAngle);
+		return StatementResult.Normal;
+	}
+
+	public static void RegisterFunctionCompiler()
+	{
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			"celestialelevation",
+			new[] { ProgVariableTypes.Location, ProgVariableTypes.Number },
+			(pars, gameworld) => new CelestialElevationFunction(pars),
+			new List<string> { "locationOrZone", "celestialId" },
+			new List<string> { "The room or zone whose celestial collection is searched.", "The ID of the celestial object to inspect." },
+			"Looks up a celestial object by ID in the supplied room or zone and returns its current elevation above or below the horizon in radians. Positive values are above the horizon. Returns 0 if the zone or celestial object cannot be found.",
+			"Celestials",
+			ProgVariableTypes.Number
+		));
+
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			"celestialelevation",
+			new[] { ProgVariableTypes.Zone, ProgVariableTypes.Number },
+			(pars, gameworld) => new CelestialElevationFunction(pars),
+			new List<string> { "locationOrZone", "celestialId" },
+			new List<string> { "The room or zone whose celestial collection is searched.", "The ID of the celestial object to inspect." },
+			"Looks up a celestial object by ID in the supplied room or zone and returns its current elevation above or below the horizon in radians. Positive values are above the horizon. Returns 0 if the zone or celestial object cannot be found.",
+			"Celestials",
+			ProgVariableTypes.Number
+		));
+	}
+}


### PR DESCRIPTION
## Summary
- Expanded auxiliary combat from advantage-only into configurable tactical effects, including target delay, facing changes, stamina drain, position changes, and disarm.
- Added shared opposed-resolution handling, builder syntax, and stock defaults for each new effect.
- Wired `AuxiliaryPercentage` into shared strategy selection and kept the melee fallback behavior for legacy configs.
- Seeded a broad stock catalogue of human, animal, mythic, robot, and supernatural auxiliary moves, plus the gated progs and tags they need.
- Added `celestialelevation(location|zone, celestialId)` for sky-state checks and updated combat/celestial strategy docs.
- Added focused runtime and seeder regression tests for effect loading, builder parsing, strategy selection, seeded content, and the new FutureProg metadata.

## Testing
- `dotnet build MudSharpCore/MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `dotnet build DatabaseSeeder/DatabaseSeeder.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- Focused `MudSharpCore Unit Tests` for combat strategy and FutureProg documentation passed.
- Focused `DatabaseSeeder Unit Tests` for combat seeder source invariants passed.
- `git diff --check` passed.