### PR TITLE
Refine auction settlement, buyouts, and auction house validation

### DIFF
--- a/Design Documents/Economy_System_Runtime.md
+++ b/Design Documents/Economy_System_Runtime.md
@@ -297,8 +297,10 @@ Current verified runtime characteristics:
 - it is tied to a specific cell
 - it routes proceeds into a bank account
 - it is surfaced through economy commands rather than being embedded into shops
+- configured flat and percentage auction fees are retained by the auction house, with sellers receiving net proceeds
 - standard player auction commands now work for both item and property lots, including estate-liquidation property lots whose names are ordinary property names rather than inventory items
 - hotel lost-property bundles can be listed as item lots by the property when their retention period expires
+- buyout purchases immediately settle the lot rather than waiting for the normal auction end tick
 - player-listed property auctions now sell the listing seller's ownership share in the property, and lot descriptions explicitly call out that they are ownership-share sales rather than sole-control sales
 - winning property-share bids transfer the sold share directly at auction completion without requiring a fixed-price property sale order
 - persisted active and unclaimed lots now defer seller and payout-target resolution until the post-NPC boot finalisation pass, so auction loading no longer materialises characters before jobs are available

--- a/Design Documents/Economy_System_Workflows_and_Integration.md
+++ b/Design Documents/Economy_System_Workflows_and_Integration.md
@@ -232,6 +232,8 @@ Practical estate note:
 Current player-facing capability note:
 
 - auction houses can now host both item lots and property-share lots, and ordinary character-listed property auctions sell whatever ownership share the listing character currently owns in that property
+- auction-house settlement keeps the configured flat plus percentage fee and pays the seller the net proceeds
+- buyout purchases complete the auction immediately and move item lots into the normal claim workflow
 
 Contributor note:
 

--- a/FutureMUDLibrary/Community/IEstate.cs
+++ b/FutureMUDLibrary/Community/IEstate.cs
@@ -86,7 +86,7 @@ namespace MudSharp.Community
         bool CheckStatus();
         bool StartLiquidation();
         bool TryCreateAuctionListing(IAuctionHouse auctionHouse, IEstateAsset asset, decimal reservePrice, decimal? buyoutPrice);
-        void RecordAuctionCompletion(AuctionItem item, [CanBeNull] AuctionBid winningBid);
+        void RecordAuctionCompletion(AuctionItem item, [CanBeNull] AuctionBid winningBid, decimal sellerProceeds);
         bool HasPendingLiquidationLots { get; }
         void Finalise();
     }

--- a/FutureMUDLibrary/Economy/IAuctionHouse.cs
+++ b/FutureMUDLibrary/Economy/IAuctionHouse.cs
@@ -200,6 +200,7 @@ namespace MudSharp.Economy
         DecimalCounter<long> BidderRefundsOwed { get; }
         void AddAuctionItem(AuctionItem item);
         void AddBid(AuctionItem item, AuctionBid bid);
+        void BuyoutItem(AuctionItem item, AuctionBid bid);
         void ClaimItem(AuctionItem item);
         bool ClaimRefund(ICharacter actor);
         decimal CurrentBid(AuctionItem item);

--- a/MudSharpCore Unit Tests/AuctionHouseSettlementTests.cs
+++ b/MudSharpCore Unit Tests/AuctionHouseSettlementTests.cs
@@ -1,0 +1,159 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Economy;
+using MudSharp.Economy.Auctions;
+using MudSharp.Economy.Currency;
+using MudSharp.Economy.Property;
+using MudSharp.Form.Shape;
+using MudSharp.Framework;
+using MudSharp.Framework.Save;
+using MudSharp.Framework.Scheduling;
+using MudSharp.GameItems;
+using MudSharp.TimeAndDate;
+using MudSharp.TimeAndDate.Date;
+using System.Linq;
+using System.Xml.Linq;
+using DbAuctionHouse = MudSharp.Models.AuctionHouse;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class AuctionHouseSettlementTests
+{
+	private static AuctionHouse CreateAuctionHouse(
+		out Mock<IBankAccount> profitsAccount,
+		out Mock<IBankAccount> payoutAccount,
+		out Mock<ICurrency> currency)
+	{
+		currency = new Mock<ICurrency>();
+		currency.SetupGet(x => x.Id).Returns(1L);
+		currency.SetupGet(x => x.Name).Returns("dollars");
+		currency.Setup(x => x.Describe(It.IsAny<decimal>(), It.IsAny<CurrencyDescriptionPatternType>()))
+		        .Returns<decimal, CurrencyDescriptionPatternType>((value, _) => value.ToString("N2"));
+
+		Mock<IBank> profitsBank = new();
+		profitsBank.SetupGet(x => x.Id).Returns(11L);
+		profitsBank.SetupGet(x => x.Code).Returns("AHB");
+		profitsBank.SetupGet(x => x.CurrencyReserves).Returns(new DecimalCounter<ICurrency>());
+
+		Mock<IBank> payoutBank = new();
+		payoutBank.SetupGet(x => x.Id).Returns(12L);
+		payoutBank.SetupGet(x => x.Code).Returns("PAY");
+		payoutBank.SetupGet(x => x.CurrencyReserves).Returns(new DecimalCounter<ICurrency>());
+
+		profitsAccount = new Mock<IBankAccount>();
+		profitsAccount.SetupGet(x => x.Id).Returns(21L);
+		profitsAccount.SetupGet(x => x.Name).Returns("Auction Profits");
+		profitsAccount.SetupGet(x => x.FrameworkItemType).Returns("BankAccount");
+		profitsAccount.SetupGet(x => x.Bank).Returns(profitsBank.Object);
+		profitsAccount.SetupGet(x => x.Currency).Returns(currency.Object);
+		profitsAccount.SetupGet(x => x.AccountNumber).Returns(1001);
+		profitsAccount.Setup(x => x.CanWithdraw(It.IsAny<decimal>(), true)).Returns((true, string.Empty));
+
+		payoutAccount = new Mock<IBankAccount>();
+		payoutAccount.SetupGet(x => x.Id).Returns(22L);
+		payoutAccount.SetupGet(x => x.Name).Returns("Seller Account");
+		payoutAccount.SetupGet(x => x.FrameworkItemType).Returns("BankAccount");
+		payoutAccount.SetupGet(x => x.Bank).Returns(payoutBank.Object);
+		payoutAccount.SetupGet(x => x.Currency).Returns(currency.Object);
+		payoutAccount.SetupGet(x => x.AccountNumber).Returns(2002);
+
+		Mock<IEconomicZone> zone = new();
+		zone.SetupGet(x => x.Id).Returns(31L);
+		zone.SetupGet(x => x.Name).Returns("Central");
+		zone.SetupGet(x => x.Currency).Returns(currency.Object);
+
+		Mock<ICalendar> calendar = new();
+		calendar.SetupGet(x => x.CurrentDateTime).Returns(MudDateTime.Never);
+		zone.SetupGet(x => x.FinancialPeriodReferenceCalendar).Returns(calendar.Object);
+
+		Mock<ICell> cell = new();
+		cell.SetupGet(x => x.Id).Returns(41L);
+		cell.SetupGet(x => x.Name).Returns("Auction Floor");
+
+		Mock<IHeartbeatManager> heartbeatManager = new();
+		All<IEconomicZone> economicZones = new();
+		economicZones.Add(zone.Object);
+		All<ICell> cells = new();
+		cells.Add(cell.Object);
+		All<IBankAccount> bankAccounts = new();
+		bankAccounts.Add(profitsAccount.Object);
+		bankAccounts.Add(payoutAccount.Object);
+		All<IProperty> properties = new();
+
+		Mock<IFuturemud> gameworld = new();
+		gameworld.SetupGet(x => x.HeartbeatManager).Returns(heartbeatManager.Object);
+		gameworld.SetupGet(x => x.SaveManager).Returns(new Mock<ISaveManager>().Object);
+		gameworld.SetupGet(x => x.EconomicZones).Returns(economicZones);
+		gameworld.SetupGet(x => x.Cells).Returns(cells);
+		gameworld.SetupGet(x => x.BankAccounts).Returns(bankAccounts);
+		gameworld.SetupGet(x => x.Properties).Returns(properties);
+
+		DbAuctionHouse dbitem = new()
+		{
+			Id = 51L,
+			Name = "Central Auction House",
+			EconomicZoneId = zone.Object.Id,
+			AuctionHouseCellId = cell.Object.Id,
+			ProfitsBankAccountId = profitsAccount.Object.Id,
+			AuctionListingFeeFlat = 10.0M,
+			AuctionListingFeeRate = 0.10M,
+			DefaultListingTime = 3600.0,
+			Definition = new XElement("Definition").ToString()
+		};
+
+		return new AuctionHouse(dbitem, gameworld.Object);
+	}
+
+	[TestMethod]
+	public void BuyoutItem_ActiveItem_CompletesImmediatelyAndPaysNetSellerProceeds()
+	{
+		var house = CreateAuctionHouse(out var profitsAccount, out var payoutAccount, out _);
+		Mock<ICharacter> seller = new();
+		seller.SetupGet(x => x.Id).Returns(61L);
+		seller.SetupGet(x => x.Name).Returns("Seller");
+		seller.SetupGet(x => x.FrameworkItemType).Returns("Character");
+
+		Mock<ICharacter> bidder = new();
+		bidder.SetupGet(x => x.Id).Returns(62L);
+		bidder.SetupGet(x => x.Name).Returns("Bidder");
+		bidder.SetupGet(x => x.FrameworkItemType).Returns("Character");
+
+		Mock<IGameItem> asset = new();
+		asset.SetupGet(x => x.Id).Returns(71L);
+		asset.SetupGet(x => x.Name).Returns("sabre");
+		asset.SetupGet(x => x.FrameworkItemType).Returns("GameItem");
+		asset.Setup(x => x.HowSeen(It.IsAny<IPerceiver>(), It.IsAny<bool>(), It.IsAny<DescriptionType>(),
+				It.IsAny<bool>(), It.IsAny<PerceiveIgnoreFlags>()))
+		     .Returns("a sabre");
+
+		AuctionItem lot = new()
+		{
+			Asset = asset.Object,
+			Seller = seller.Object,
+			PayoutTarget = payoutAccount.Object,
+			MinimumPrice = 100.0M,
+			BuyoutPrice = 200.0M,
+			ListingDateTime = MudDateTime.Never,
+			FinishingDateTime = MudDateTime.Never
+		};
+
+		house.AddAuctionItem(lot);
+
+		house.BuyoutItem(lot, new AuctionBid
+		{
+			Bidder = bidder.Object,
+			Bid = 200.0M,
+			BidDateTime = MudDateTime.Never
+		});
+
+		Assert.AreEqual(0, house.ActiveAuctionItems.Count());
+		Assert.AreSame(lot, house.UnclaimedItems.Single().AuctionItem);
+		Assert.AreEqual(200.0M, house.UnclaimedItems.Single().WinningBid!.Bid);
+		profitsAccount.Verify(x => x.Deposit(200.0M), Times.Once);
+		profitsAccount.Verify(x => x.WithdrawFromTransfer(170.0M, "PAY", 2002, It.IsAny<string>()), Times.Once);
+		payoutAccount.Verify(x => x.DepositFromTransfer(170.0M, "AHB", 1001, It.IsAny<string>()), Times.Once);
+	}
+}

--- a/MudSharpCore/Commands/Helpers/EditableItemHelperEconomy.cs
+++ b/MudSharpCore/Commands/Helpers/EditableItemHelperEconomy.cs
@@ -198,10 +198,24 @@ public partial class EditableItemHelper
                 return;
             }
 
+            if (accountTarget.Currency != zone.Currency)
+            {
+                actor.OutputHandler.Send(
+                    $"That account uses {accountTarget.Currency.Name.ColourName()}, but auction houses in the {zone.Name.ColourName()} economic zone must use {zone.Currency.Name.ColourName()}.");
+                return;
+            }
+
             if (actor.Gameworld.AuctionHouses.Any(x => x.Name.EqualTo(name)))
             {
                 actor.OutputHandler.Send(
                     $"There is already an auction house with that name. Names must be unique.");
+                return;
+            }
+
+            if (actor.Gameworld.AuctionHouses.Any(x => x.AuctionHouseCell == actor.Location))
+            {
+                actor.OutputHandler.Send(
+                    "There is already an auction house in this location. Only one auction house may be in a room at any time.");
                 return;
             }
 

--- a/MudSharpCore/Commands/Modules/EconomyModule.cs
+++ b/MudSharpCore/Commands/Modules/EconomyModule.cs
@@ -5693,6 +5693,16 @@ The syntax for using this command is as follows:
 	#3auction refund#0 - claims all money owed for unsuccessful bids
 	#3auction cancel <lot>#0 - cancels an auction lot";
 
+    public const string AuctionsHelp =
+        @"The auctions command lists the active lots at the auction house in your current location.
+
+The syntax for using this command is as follows:
+
+	#3auctions#0 - lists all active lots at the auction house
+	#3auctions <keyword> [<keyword>...]#0 - filters active lots by one or more keywords
+
+The listing shows each lot, its number of bids, current bid, remaining time and buyout price. It also reminds you when that auction house owes you a refund or has items waiting for you to claim.";
+
     public const string AuctionHelpAdmins = @"This command is used to create and edit auction houses.
 
 The syntax for using this command is as follows:
@@ -6025,6 +6035,13 @@ Note: Admins can use the #3auction cancel#0 subcommand on other people's items";
             return;
         }
 
+        if (accountTarget.Currency != auctionHouse.EconomicZone.Currency)
+        {
+            actor.OutputHandler.Send(
+                $"That account uses {accountTarget.Currency.Name.ColourName()}, but this auction house uses {auctionHouse.EconomicZone.Currency.Name.ColourName()}.");
+            return;
+        }
+
         decimal buyout = 0.0M;
         if (!ss.IsFinished)
         {
@@ -6134,6 +6151,14 @@ Note: Admins can use the #3auction cancel#0 subcommand on other people's items";
         }
 
         decimal amount = item.BuyoutPrice.Value;
+        decimal currentBid = auctionHouse.CurrentBid(item);
+        if (currentBid >= amount)
+        {
+            actor.OutputHandler.Send(
+                $"The current bid for {DescribeAuctionLot(actor, item)} already meets or exceeds the buyout price.");
+            return;
+        }
+
         ICurrency currency = auctionHouse.EconomicZone.Currency;
         Dictionary<ICurrencyPile, Dictionary<ICoin, int>> targetCoins = currency.FindCurrency(actor.Body.HeldItems.SelectNotNull(x => x.GetItemType<ICurrencyPile>()),
             amount);
@@ -6166,7 +6191,7 @@ Note: Admins can use the #3auction cancel#0 subcommand on other people's items";
             }
         }
 
-        auctionHouse.AddBid(item, new AuctionBid
+        auctionHouse.BuyoutItem(item, new AuctionBid
         {
             Bidder = actor,
             Bid = amount,
@@ -6266,6 +6291,13 @@ Note: Admins can use the #3auction cancel#0 subcommand on other people's items";
         decimal currentPrice = auctionHouse.AuctionBids[item].Select(x => x.Bid).DefaultIfEmpty(item.MinimumPrice)
                                        .Max();
         decimal nextBidMinimum = !auctionHouse.AuctionBids[item].Any() ? item.MinimumPrice : currentPrice * 1.05M;
+        if (item.BuyoutPrice.HasValue && amount >= item.BuyoutPrice.Value)
+        {
+            actor.OutputHandler.Send(
+                $"Bids cannot meet or exceed the buyout price. Use {"AUCTION BUYOUT".ColourCommand()} if you want to buy the lot outright.");
+            return;
+        }
+
         if (amount <= nextBidMinimum)
         {
             actor.OutputHandler.Send(
@@ -6380,7 +6412,7 @@ Note: Admins can use the #3auction cancel#0 subcommand on other people's items";
     [RequiredCharacterState(CharacterState.Able)]
     [NoCombatCommand]
     [NoHideCommand]
-    [HelpInfo("auctions", @"", AutoHelp.HelpArg)]
+    [HelpInfo("auctions", AuctionsHelp, AutoHelp.HelpArgOrNoArg)]
     protected static void Auctions(ICharacter actor, string command)
     {
         IAuctionHouse auctionHouse = actor.Gameworld.AuctionHouses.FirstOrDefault(x => x.AuctionHouseCell == actor.Location);

--- a/MudSharpCore/Economy/Auctions/AuctionHouse.cs
+++ b/MudSharpCore/Economy/Auctions/AuctionHouse.cs
@@ -71,6 +71,7 @@ public class AuctionHouse : SaveableItem, IAuctionHouse, IPostCharacterLoadFinal
                 AuctionListingFeeFlat = AuctionListingFeeFlat,
                 AuctionListingFeeRate = AuctionListingFeeRate,
                 AuctionHouseCellId = cell.Id,
+                DefaultListingTime = DefaultListingTime.TotalSeconds,
                 Definition = SaveDefinition().ToString()
             };
             FMDB.Context.AuctionHouses.Add(dbitem);
@@ -252,7 +253,35 @@ public class AuctionHouse : SaveableItem, IAuctionHouse, IPostCharacterLoadFinal
             return true;
         }
 
-        return TryPaySellerTarget(item.PayoutTarget ?? item.Seller, amount, DescribeLotPlain(item));
+        decimal sellerProceeds = SellerProceedsFor(amount);
+        if (sellerProceeds <= 0.0M)
+        {
+            return true;
+        }
+
+        return TryPaySellerTarget(item.PayoutTarget ?? item.Seller, sellerProceeds, DescribeLotPlain(item));
+    }
+
+    private decimal AuctionFeeFor(decimal salePrice)
+    {
+        if (salePrice <= 0.0M)
+        {
+            return 0.0M;
+        }
+
+        decimal fee = Math.Max(0.0M, AuctionListingFeeFlat) + salePrice * Math.Max(0.0M, AuctionListingFeeRate);
+        return Math.Min(salePrice, fee);
+    }
+
+    private decimal SellerProceedsFor(decimal salePrice)
+    {
+        return Math.Max(0.0M, salePrice - AuctionFeeFor(salePrice));
+    }
+
+    private decimal CurrentSellerProceeds(AuctionItem item)
+    {
+        AuctionBid bid = CurrentAuctionBid(item);
+        return bid == null ? 0.0M : SellerProceedsFor(bid.Bid);
     }
 
     private bool TryPaySellerTarget(IFrameworkItem payoutTarget, decimal amount, string assetDescription)
@@ -320,7 +349,13 @@ public class AuctionHouse : SaveableItem, IAuctionHouse, IPostCharacterLoadFinal
             return;
         }
 
-        _sellerPaymentsOwed[(payoutTarget.Id, payoutTarget.FrameworkItemType)] += amount;
+        decimal sellerProceeds = SellerProceedsFor(amount);
+        if (sellerProceeds <= 0.0M)
+        {
+            return;
+        }
+
+        _sellerPaymentsOwed[(payoutTarget.Id, payoutTarget.FrameworkItemType)] += sellerProceeds;
         Changed = true;
     }
 
@@ -344,6 +379,88 @@ public class AuctionHouse : SaveableItem, IAuctionHouse, IPostCharacterLoadFinal
         }
     }
 
+    private void CompleteAuction(AuctionItem item, AuctionBid? winningBid, MudDateTime now)
+    {
+        bool propertyShareUnavailable = winningBid != null &&
+                                      item.Asset is IProperty &&
+                                      !CanTransferPropertyShare(item);
+        if (propertyShareUnavailable)
+        {
+            BidderRefundsOwed[winningBid.BidderId] += winningBid.Bid;
+            Changed = true;
+            AuctionHouseCell.Handle(
+                $"The auctioneers announce that the auction for {DescribeLotPlain(item)} cannot be completed because the listed ownership share is no longer available, and the winning bid has been refunded.");
+            winningBid = null;
+        }
+        else if (winningBid == null)
+        {
+            AuctionHouseCell.Handle(
+                $"The auctioneers announce that the auction for {DescribeLotPlain(item)} has ended without any bids.");
+        }
+        else
+        {
+            AuctionHouseCell.Handle(
+                $"The auctioneers announce that the auction for {DescribeLotPlain(item)} has ended with a winning bid of {EconomicZone.Currency.Describe(winningBid.Bid, CurrencyDescriptionPatternType.ShortDecimal).ColourValue()}.");
+        }
+
+        _activeAuctionItems.Remove(item);
+
+        bool paid = true;
+        decimal sellerProceeds = 0.0M;
+        if (winningBid != null)
+        {
+            sellerProceeds = SellerProceedsFor(winningBid.Bid);
+            paid = TryPaySeller(item, winningBid.Bid);
+            if (!paid)
+            {
+                QueueSellerPayment(item, winningBid.Bid);
+            }
+        }
+
+        if (item.Seller is IEstate estateSeller)
+        {
+            estateSeller.RecordAuctionCompletion(item, winningBid, sellerProceeds);
+        }
+
+        switch (item.Asset)
+        {
+            case IProperty when winningBid != null:
+                TransferPropertyShare(item, winningBid.Bidder, winningBid.Bid);
+                break;
+            case IGameItem when winningBid != null:
+                _unclaimedItems.Add(new UnclaimedAuctionItem
+                {
+                    AuctionItem = item,
+                    WinningBid = winningBid
+                });
+                break;
+            case IGameItem when winningBid == null && item.Seller is not IEstate:
+                _unclaimedItems.Add(new UnclaimedAuctionItem
+                {
+                    AuctionItem = item,
+                    WinningBid = null
+                });
+                break;
+        }
+
+        _auctionResults.Add(new AuctionResult
+        {
+            AssetId = item.Asset.Id,
+            AssetType = item.Asset.FrameworkItemType,
+            AssetDescription = DescribeLotPlain(item),
+            Sold = winningBid != null,
+            SalePrice = winningBid?.Bid ?? 0.0M,
+            ResultDateTime = now,
+            SellerId = item.Seller.Id,
+            SellerType = item.Seller.FrameworkItemType,
+            PayoutTargetId = item.PayoutTarget?.Id,
+            PayoutTargetType = item.PayoutTarget?.FrameworkItemType,
+            SoldToId = winningBid?.BidderId ?? 0L,
+            PaidOutAtTime = paid
+        });
+        Changed = true;
+    }
+
     private void AuctionTick()
     {
         RetrySellerPayments();
@@ -351,83 +468,7 @@ public class AuctionHouse : SaveableItem, IAuctionHouse, IPostCharacterLoadFinal
         List<AuctionItem> finished = ActiveAuctionItems.Where(x => x.FinishingDateTime <= now).ToList();
         foreach (AuctionItem item in finished)
         {
-            AuctionBid winningBid = CurrentAuctionBid(item);
-            bool propertyShareUnavailable = winningBid != null &&
-                                          item.Asset is IProperty &&
-                                          !CanTransferPropertyShare(item);
-            if (propertyShareUnavailable)
-            {
-                BidderRefundsOwed[winningBid.BidderId] += winningBid.Bid;
-                Changed = true;
-                AuctionHouseCell.Handle(
-                    $"The auctioneers announce that the auction for {DescribeLotPlain(item)} cannot be completed because the listed ownership share is no longer available, and the winning bid has been refunded.");
-                winningBid = null;
-            }
-            else if (winningBid == null)
-            {
-                AuctionHouseCell.Handle(
-                    $"The auctioneers announce that the auction for {DescribeLotPlain(item)} has ended without any bids.");
-            }
-            else
-            {
-                AuctionHouseCell.Handle(
-                    $"The auctioneers announce that the auction for {DescribeLotPlain(item)} has ended with a winning bid of {EconomicZone.Currency.Describe(CurrentBid(item), CurrencyDescriptionPatternType.ShortDecimal).ColourValue()}.");
-            }
-
-            _activeAuctionItems.Remove(item);
-
-            bool paid = true;
-            if (winningBid != null)
-            {
-                paid = TryPaySeller(item, winningBid.Bid);
-                if (!paid)
-                {
-                    QueueSellerPayment(item, winningBid.Bid);
-                }
-            }
-
-            if (item.Seller is IEstate estateSeller)
-            {
-                estateSeller.RecordAuctionCompletion(item, winningBid);
-            }
-
-            switch (item.Asset)
-            {
-                case IProperty when winningBid != null:
-                    TransferPropertyShare(item, winningBid.Bidder, winningBid.Bid);
-                    break;
-                case IGameItem when winningBid != null:
-                    _unclaimedItems.Add(new UnclaimedAuctionItem
-                    {
-                        AuctionItem = item,
-                        WinningBid = winningBid
-                    });
-                    break;
-                case IGameItem when winningBid == null && item.Seller is not IEstate:
-                    _unclaimedItems.Add(new UnclaimedAuctionItem
-                    {
-                        AuctionItem = item,
-                        WinningBid = null
-                    });
-                    break;
-            }
-
-            _auctionResults.Add(new AuctionResult
-            {
-                AssetId = item.Asset.Id,
-                AssetType = item.Asset.FrameworkItemType,
-                AssetDescription = DescribeLotPlain(item),
-                Sold = winningBid != null,
-                SalePrice = winningBid?.Bid ?? 0.0M,
-                ResultDateTime = now,
-                SellerId = item.Seller.Id,
-                SellerType = item.Seller.FrameworkItemType,
-                PayoutTargetId = item.PayoutTarget?.Id,
-                PayoutTargetType = item.PayoutTarget?.FrameworkItemType,
-                SoldToId = winningBid?.BidderId ?? 0L,
-                PaidOutAtTime = paid
-            });
-            Changed = true;
+            CompleteAuction(item, CurrentAuctionBid(item), now);
         }
     }
 
@@ -616,6 +657,12 @@ public class AuctionHouse : SaveableItem, IAuctionHouse, IPostCharacterLoadFinal
         Changed = true;
     }
 
+    public void BuyoutItem(AuctionItem item, AuctionBid bid)
+    {
+        AddBid(item, bid);
+        CompleteAuction(item, bid, EconomicZone.FinancialPeriodReferenceCalendar.CurrentDateTime);
+    }
+
     public void ClaimItem(AuctionItem item)
     {
         _unclaimedItems.RemoveAll(x => x.AuctionItem == item);
@@ -732,6 +779,13 @@ public class AuctionHouse : SaveableItem, IAuctionHouse, IPostCharacterLoadFinal
         if (bankAccount is null)
         {
             actor.OutputHandler.Send(error);
+            return false;
+        }
+
+        if (bankAccount.Currency != EconomicZone.Currency)
+        {
+            actor.OutputHandler.Send(
+                $"That account uses {bankAccount.Currency.Name.ColourName()}, but this auction house uses {EconomicZone.Currency.Name.ColourName()}.");
             return false;
         }
 
@@ -890,9 +944,9 @@ public class AuctionHouse : SaveableItem, IAuctionHouse, IPostCharacterLoadFinal
         sb.AppendLine(
             $"Seller Proceeds Owed: {EconomicZone.Currency.Describe(_sellerPaymentsOwed.Sum(x => x.Value), CurrencyDescriptionPatternType.ShortDecimal).ColourValue()}");
         sb.AppendLine(
-            $"Pending Payments: {EconomicZone.Currency.Describe(ActiveAuctionItems.SelectNotNull(CurrentAuctionBid).Sum(x => x.Bid), CurrencyDescriptionPatternType.ShortDecimal).ColourValue()}");
+            $"Pending Payments: {EconomicZone.Currency.Describe(ActiveAuctionItems.Sum(CurrentSellerProceeds), CurrencyDescriptionPatternType.ShortDecimal).ColourValue()}");
         sb.AppendLine(
-            $"Total Commitments: {EconomicZone.Currency.Describe(BidderRefundsOwed.Sum(x => x.Value) + _sellerPaymentsOwed.Sum(x => x.Value) + ActiveAuctionItems.SelectNotNull(CurrentAuctionBid).Sum(x => x.Bid), CurrencyDescriptionPatternType.ShortDecimal).ColourValue()}");
+            $"Total Commitments: {EconomicZone.Currency.Describe(BidderRefundsOwed.Sum(x => x.Value) + _sellerPaymentsOwed.Sum(x => x.Value) + ActiveAuctionItems.Sum(CurrentSellerProceeds), CurrencyDescriptionPatternType.ShortDecimal).ColourValue()}");
         sb.AppendLine($"Unclaimed Items: {UnclaimedItems.Count().ToString("N0", actor).ColourValue()}");
         return sb.ToString();
     }

--- a/MudSharpCore/Economy/Estates/Estate.cs
+++ b/MudSharpCore/Economy/Estates/Estate.cs
@@ -649,7 +649,7 @@ public class Estate : SaveableItem, IEstate, ILazyLoadDuringIdleTime
         return true;
     }
 
-    public void RecordAuctionCompletion(AuctionItem item, AuctionBid winningBid)
+    public void RecordAuctionCompletion(AuctionItem item, AuctionBid winningBid, decimal sellerProceeds)
     {
         IEstateAsset asset = FindAsset(item.Asset);
         if (asset == null)
@@ -660,7 +660,7 @@ public class Estate : SaveableItem, IEstate, ILazyLoadDuringIdleTime
         if (winningBid != null)
         {
             asset.IsLiquidated = true;
-            asset.LiquidatedValue = winningBid.Bid;
+            asset.LiquidatedValue = sellerProceeds;
             return;
         }
 


### PR DESCRIPTION
**Summary**
- Keep auction-house fees on the house and pay sellers net proceeds at settlement.
- Complete buyout purchases immediately instead of waiting for the normal auction tick.
- Tighten auction-house setup and bidding rules around currency matching, duplicate locations, and buyout limits.
- Update estate liquidation recording to store seller proceeds rather than gross sale price.
- Add coverage for buyout settlement and refresh economy design docs to match the new behavior.

**Testing**
- Added a unit test covering immediate buyout completion and net seller payout calculation.
- Not run (not requested).