### PR TITLE
Add preloaded printed content support for books

### DIFF
--- a/Design Documents/Item_System_Component_Authoring.md
+++ b/Design Documents/Item_System_Component_Authoring.md
@@ -132,6 +132,21 @@ Do not create bespoke ammunition components for ordinary projectile variants. Sl
 
 `IRangedWeapon.CanFireWhileHidden` is deliberately narrow. Leave the default false for normal ranged weapons. Only components that should preserve hiding through `fire -> Engage/JoinCombat`, such as `BlowgunGameItemComponent`, should return true and use obscured output for ready/load/fire emotes.
 
+### Readable book components
+Books remain one component family rather than splitting blank books and published books into separate component types. `BookGameItemComponentProto` owns reusable authored defaults, while `BookGameItemComponent` owns live page state, torn pages, current page, title, and the actual readable rows attached to each loaded item.
+
+Builder-authored book defaults include:
+- `title <text>` for the default fresh-item title
+- `content list` for the printed starting contents
+- `content add <page> <language> <script> <provenance>` followed by editor text entry
+- `content copy <index> <page>` for duplicating an existing prototype page entry
+- `content edit <index>` for changing an authored entry's text
+- `content remove <index>` and `content clear`
+
+Prototype contents are stored as page-scoped readable templates, not as live `Writing` ids. Freshly loaded books instantiate their own `PrintedWriting` rows from those templates, so two copies of the same manual or novel do not share mutable writing records. The builder path validates page range and page capacity, and the runtime constructor repeats those checks defensively when loading prototype XML.
+
+Printed book content uses the `PrintedWriting` writing type with `WritingImplementType.Printed`. Printed writing has no character author; use its provenance text for publisher, source, anonymous, or generated-document attribution. V1 printed books remain writable: player handwriting can still be added to any non-torn page if the printed content leaves enough page capacity.
+
 ### Example: Container proto
 `ContainerGameItemComponentProto` is a good reference because it shows the common editable-proto pattern:
 - several builder-editable properties

--- a/Design Documents/Item_System_Content_Workflows.md
+++ b/Design Documents/Item_System_Content_Workflows.md
@@ -212,6 +212,16 @@ For the current signal-automation slice, also validate:
 - whether switched-on mounted powered machines recover host-derived power after reboot or late topology initialisation without requiring a manual off/on cycle
 - whether motion sensors ignore administrator movement when the mover is using `IImmwalkEffect`
 
+For readable book content, also validate:
+- whether `comp set title <text>` gives fresh books the expected default title
+- whether `comp set content add <page> <language> <script> <provenance>` creates printed prototype content that appears on newly loaded books
+- whether `content list`, `content copy`, `content edit`, `content remove`, and `content clear` round-trip cleanly through component save/load
+- whether prototype content rejects invalid pages and text that exceeds the page capacity supplied by the selected paper prototype
+- whether two loaded copies of the same book have independent printed writing rows rather than shared mutable records
+- whether player handwriting can still be added after printed content when the page has spare capacity
+- whether tearing a page preserves the normal book behaviour and does not create dangling readable rows in the remaining pages
+- whether on-load FutureProgs can use `addprintedwriting`, `copywritingto`, and `setbooktitle` for generated manuals, certificates, letters, or personalised documents
+
 For the current modern breathing and emergency-medicine slice, also validate:
 - whether `gascontainer` and `rebreather` connector genders and socket types match the intended gas-line ecosystem
 - whether `externalinhaler` and `inhalergascanister` agree on canister type, and whether gas-bearing presets only exist when the required stock gas was seeded

--- a/Design Documents/Item_System_Presentation_and_Integration.md
+++ b/Design Documents/Item_System_Presentation_and_Integration.md
@@ -161,6 +161,10 @@ Deep ownership mutation follows the practical containment graph that builders an
 
 Telecommunications items also expose scripting hooks through item and endpoint queries such as current phone number and shared-number policy, which allows crafting or project systems to assign, clear, or reconfigure telephone numbers at runtime. The same runtime scripting surface applies to cellular handsets and implant telephones, even though implant telephones present their user interaction through neural-interface status and command flows instead of direct room manipulation.
 
+Readable book items expose a small scripting surface for dynamic document generation. `addprintedwriting(item, page, text, language, script, provenance)` adds provenance-aware printed text to a book page, with an overload accepting colour and style text. `copywritingto(item, page, writing)` copies an existing writing into a book without sharing the original row. `setbooktitle(item, title)` changes the live book title. These functions return false instead of mutating internals when the item is not a book, the page is invalid or torn, a language/script/colour/style cannot be resolved, or the page lacks capacity.
+
+Printed writing has nullable authorship. Player-facing and admin displays should treat missing author as printed or anonymous provenance rather than assuming every writing row belongs to a character.
+
 Telephone presentation is not only textual state. For room-facing telephones and cellular phones, ringing is an audible output with an effective ring volume. Players adjust that through the ordinary `switch` command rather than a staff-only builder path: wired phones expose `quiet`, `normal`, and `loud`, while cellular phones also expose `silent`. Nearby rooms may hear ringing through ordinary audio-echo rules, but a silent cellular phone can still vibrate for the wearer if it is sitting inside a worn container. Implant telephones do not emit room audio and instead report ringing and connection progress through implant messaging.
 
 The current signal-automation slice has its own presentation and integration rules:

--- a/Design Documents/Item_System_Runtime_Model.md
+++ b/Design Documents/Item_System_Runtime_Model.md
@@ -122,6 +122,10 @@ Some subsystems also need reusable runtime data that is not owned by one concret
 - each segment snapshots the language id, accent id, raw text, volume, speech outcome, and immutable speaker identity metadata needed to recreate later playback without consulting the speaker's current state
 - the shared model owns XML round-tripping so stage-1 item implementations can persist recordings in ordinary component XML rather than new database tables
 
+Readable documents follow the same copy-on-load principle. `IReadableContentTemplate` describes a reusable authored readable payload that can create a live `ICanBeRead` instance, while page-aware templates identify their target page and order. Book prototypes store printed content templates in component XML. Book runtime components store the resulting live readable ids in their own component XML after item creation.
+
+This distinction is important for persistence. A prototype-authored book page is reusable content; a loaded book page is mutable instance state. Fresh books create independent `PrintedWriting` rows, copied books copy readable rows rather than sharing them, and ordinary handwritten writing can still be added later through the existing `IWriteable` contract if the page has spare capacity. Printed writing rows allow `Writings.AuthorId` to be null, with provenance carried in the writing definition and exposed to FutureProg as `.provenance`.
+
 ### Computers and signal automation pattern
 The planned computer-programs subsystem follows the same composition rules:
 - shared contracts live in `FutureMUDLibrary/Computers`

--- a/FutureMUDLibrary/Communication/IReadable.cs
+++ b/FutureMUDLibrary/Communication/IReadable.cs
@@ -1,6 +1,7 @@
 ﻿using MudSharp.Character;
 using MudSharp.Framework;
 using MudSharp.Framework.Save;
+using MudSharp.Communication.Language;
 using MudSharp.GameItems.Interfaces;
 using System;
 using System.Collections.Generic;
@@ -17,5 +18,37 @@ namespace MudSharp.Communication
         WritingImplementType ImplementType { get; }
         string ParseFor(ICharacter voyeur);
         string DescribeInLook(ICharacter voyeur);
+    }
+
+    public interface IReadableContentTemplate
+    {
+        int DocumentLength { get; }
+        ICanBeRead CreateReadable(IFuturemud gameworld);
+    }
+
+    public interface IPageReadableContentTemplate : IReadableContentTemplate
+    {
+        int Page { get; }
+        int Order { get; }
+    }
+
+    public interface IPageReadable
+    {
+        int Page { get; }
+        int Order { get; }
+        ICanBeRead Readable { get; }
+    }
+
+    public static class ReadableExtensions
+    {
+        public static ICanBeRead CopyReadable(this ICanBeRead readable)
+        {
+            return readable switch
+            {
+                IWriting writing => writing.Copy(),
+                IDrawing drawing => drawing.Copy(),
+                _ => throw new NotSupportedException($"Cannot copy readable type {readable.GetType().FullName}.")
+            };
+        }
     }
 }

--- a/FutureMUDLibrary/GameItems/Interfaces/IWritingImplement.cs
+++ b/FutureMUDLibrary/GameItems/Interfaces/IWritingImplement.cs
@@ -13,7 +13,8 @@ namespace MudSharp.GameItems.Interfaces
         ComputerStylus,
         Brush,
         Chisel,
-        Crayon
+        Crayon,
+        Printed
     }
 
     public static class WritingImplementTypeExtensions
@@ -38,6 +39,8 @@ namespace MudSharp.GameItems.Interfaces
                     return "Chisel";
                 case WritingImplementType.Crayon:
                     return "Crayon";
+                case WritingImplementType.Printed:
+                    return "Printed";
                 default:
                     throw new ApplicationException($"Unknown WritingImplementType {type} in WritingImplementTypeExtensions.Describe");
             }
@@ -63,6 +66,8 @@ namespace MudSharp.GameItems.Interfaces
                     return "stylus";
                 case WritingImplementType.Chisel:
                     return "chisel";
+                case WritingImplementType.Printed:
+                    return "printed text";
                 default:
                     throw new ApplicationException($"Unknown WritingImplementType {type} in WritingImplementTypeExtensions.Describe");
             }

--- a/MudSharpCore Unit Tests/PreloadedBookContentTests.cs
+++ b/MudSharpCore Unit Tests/PreloadedBookContentTests.cs
@@ -1,0 +1,438 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Xml.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Character;
+using MudSharp.Communication;
+using MudSharp.Communication.Language;
+using MudSharp.Form.Colour;
+using MudSharp.Framework;
+using MudSharp.Framework.Revision;
+using MudSharp.Framework.Save;
+using MudSharp.FutureProg;
+using MudSharp.FutureProg.Functions;
+using MudSharp.FutureProg.Variables;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Components;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.GameItems.Prototypes;
+using DbEditableItem = MudSharp.Models.EditableItem;
+using DbGameItemComponentProto = MudSharp.Models.GameItemComponentProto;
+using DbWriting = MudSharp.Models.Writing;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class PreloadedBookContentTests
+{
+	private const long LanguageId = 1L;
+	private const long ScriptId = 2L;
+	private const long ColourId = 3L;
+	private const long PaperProtoId = 4L;
+
+	[TestMethod]
+	public void PrintedWriting_LoadsThroughFactoryWithNullableAuthorAndProvenance()
+	{
+		var language = CreateLanguage(LanguageId, "Common");
+		var script = CreateScript(ScriptId, "Latin", 1.5);
+		var colour = CreateColour(ColourId, "black");
+		var gameworld = CreateGameworld(language, script, colour, 200).Object;
+		var dbWriting = new DbWriting
+		{
+			Id = 10,
+			AuthorId = null,
+			TrueAuthorId = null,
+			LanguageId = LanguageId,
+			ScriptId = ScriptId,
+			WritingColour = ColourId,
+			WritingType = "printed",
+			ImplementType = (int)WritingImplementType.Printed,
+			Style = (int)WritingStyleDescriptors.MachinePrinted,
+			Definition = new XElement("Definition",
+				new XElement("Text", "Follow the marked trail."),
+				new XElement("Provenance", "Guild Trail Manual")
+			).ToString(),
+			LiteracySkill = 42.0,
+			LanguageSkill = 43.0,
+			HandwritingSkill = 44.0,
+			ForgerySkill = 5.0
+		};
+
+		var writing = WritingFactory.LoadWriting(dbWriting, gameworld);
+
+		Assert.IsInstanceOfType(writing, typeof(PrintedWriting));
+		Assert.IsNull(writing.Author);
+		Assert.IsNull(writing.TrueAuthor);
+		Assert.AreEqual(WritingImplementType.Printed, writing.ImplementType);
+		Assert.AreEqual((int)("Follow the marked trail.".RawTextLength() * 1.5), writing.DocumentLength);
+		Assert.AreEqual(42.0, writing.LiteracySkill);
+		Assert.AreEqual(43.0, writing.LanguageSkill);
+		Assert.AreEqual(44.0, writing.HandwritingSkill);
+		Assert.AreEqual(5.0, writing.ForgerySkill);
+		Assert.AreEqual(true, writing.GetProperty("printed").GetObject);
+		Assert.AreEqual("Guild Trail Manual", writing.GetProperty("provenance").GetObject);
+		Assert.IsInstanceOfType(writing.GetProperty("author"), typeof(NullVariable));
+	}
+
+	[TestMethod]
+	public void BookPrototypeXml_CreatesDefaultTitleAndIndependentPrintedContent()
+	{
+		var language = CreateLanguage(LanguageId, "Common");
+		var script = CreateScript(ScriptId, "Latin", 1.0);
+		var colour = CreateColour(ColourId, "black");
+		var gameworld = CreateGameworld(language, script, colour, 200);
+		var proto = CreateBookProto(gameworld.Object, BookDefinition(
+			3,
+			"Apprentice Manual",
+			WritingElement(1, 1, "Read this first.", "Training Press"),
+			WritingElement(2, 1, "Then read this.", "Training Press")
+		));
+		var savedXml = InvokeSaveToXml(proto);
+		var loadedProto = CreateBookProto(gameworld.Object, savedXml);
+		var firstBook = (BookGameItemComponent)loadedProto.CreateNew(CreateParent(gameworld.Object, 20));
+		var secondBook = (BookGameItemComponent)loadedProto.CreateNew(CreateParent(gameworld.Object, 21));
+
+		Assert.AreEqual("Apprentice Manual", firstBook.Title);
+		Assert.AreEqual(2, firstBook.PagesAndReadables.Count);
+		Assert.AreEqual(2, secondBook.PagesAndReadables.Count);
+		Assert.AreNotSame(firstBook.PagesAndReadables[0].Writing, secondBook.PagesAndReadables[0].Writing);
+		Assert.AreEqual("Read this first.", firstBook.PagesAndReadables[0].Writing.ParseFor(null));
+		Assert.AreEqual("Training Press", ((IWriting)firstBook.PagesAndReadables[0].Writing).GetProperty("provenance").GetObject);
+	}
+
+	[TestMethod]
+	public void BookPrototypeContent_InvalidPagesAndOversizedTextAreSkippedOnFreshItems()
+	{
+		var language = CreateLanguage(LanguageId, "Common");
+		var script = CreateScript(ScriptId, "Latin", 1.0);
+		var colour = CreateColour(ColourId, "black");
+		var gameworld = CreateGameworld(language, script, colour, 12);
+		var proto = CreateBookProto(gameworld.Object, BookDefinition(
+			1,
+			"Small Book",
+			WritingElement(1, 1, "Fits.", "Small Press"),
+			WritingElement(2, 1, "Wrong page.", "Small Press"),
+			WritingElement(1, 2, "This line is much too long for the configured page capacity.", "Small Press")
+		));
+
+		var book = (BookGameItemComponent)proto.CreateNew(CreateParent(gameworld.Object, 30));
+
+		Assert.AreEqual(1, book.PagesAndReadables.Count);
+		Assert.AreEqual("Fits.", book.PagesAndReadables[0].Writing.ParseFor(null));
+	}
+
+	[TestMethod]
+	public void BookWithPreloadedContent_AllowsPlayerWritingWhenCapacityRemains()
+	{
+		var language = CreateLanguage(LanguageId, "Common");
+		var script = CreateScript(ScriptId, "Latin", 1.0);
+		var colour = CreateColour(ColourId, "black");
+		var gameworld = CreateGameworld(language, script, colour, 50);
+		var proto = CreateBookProto(gameworld.Object, BookDefinition(
+			2,
+			"Mixed Notebook",
+			WritingElement(1, 1, "Printed.", "Press")
+		));
+		var book = (BookGameItemComponent)proto.CreateNew(CreateParent(gameworld.Object, 40));
+		var handwritten = new Mock<IWriting>();
+		handwritten.SetupGet(x => x.DocumentLength).Returns(10);
+
+		var result = book.AddWriting(handwritten.Object, 1);
+
+		Assert.IsTrue(result);
+		Assert.AreEqual(2, book.PagesAndReadables.Count(x => x.Page == 1));
+	}
+
+	[TestMethod]
+	public void FutureProgBookHelpers_CompileAndExecuteAgainstBookComponents()
+	{
+		FutureProgTestBootstrap.EnsureInitialised();
+		var language = CreateLanguage(LanguageId, "Common");
+		var script = CreateScript(ScriptId, "Latin", 1.0);
+		var colour = CreateColour(ColourId, "black");
+		var gameworld = CreateGameworld(language, script, colour, 200);
+		var proto = CreateBookProto(gameworld.Object, BookDefinition(3, string.Empty));
+		var item = CreateBookItem(gameworld.Object, proto, out var book);
+
+		AssertFunctionRegistered("addprintedwriting", ProgVariableTypes.Item, ProgVariableTypes.Number,
+			ProgVariableTypes.Text, ProgVariableTypes.Language, ProgVariableTypes.Script, ProgVariableTypes.Text);
+		AssertFunctionRegistered("addprintedwriting", ProgVariableTypes.Item, ProgVariableTypes.Number,
+			ProgVariableTypes.Text, ProgVariableTypes.Language, ProgVariableTypes.Script, ProgVariableTypes.Text,
+			ProgVariableTypes.Text, ProgVariableTypes.Text);
+		var setTitle = CompileFunction("setbooktitle", gameworld.Object,
+			(ProgVariableTypes.Item, item),
+			(ProgVariableTypes.Text, "Field Manual")
+		);
+		Assert.AreEqual(StatementResult.Normal, setTitle.Execute(null));
+		Assert.AreEqual(true, setTitle.Result.GetObject);
+		Assert.AreEqual("Field Manual", book.Title);
+
+		var addPrinted = CompileFunction("addprintedwriting", gameworld.Object,
+			(ProgVariableTypes.Item, item),
+			(ProgVariableTypes.Number, 1.0M),
+			(ProgVariableTypes.Text, "Keep dry."),
+			(ProgVariableTypes.Language, language),
+			(ProgVariableTypes.Script, script),
+			(ProgVariableTypes.Text, "Quartermaster")
+		);
+		Assert.AreEqual(StatementResult.Normal, addPrinted.Execute(null));
+		Assert.AreEqual(true, addPrinted.Result.GetObject);
+		var printed = (IWriting)book.PagesAndReadables.Single(x => x.Page == 1).Writing;
+		Assert.AreEqual("Quartermaster", printed.GetProperty("provenance").GetObject);
+
+		var copyWriting = CompileFunction("copywritingto", gameworld.Object,
+			(ProgVariableTypes.Item, item),
+			(ProgVariableTypes.Number, 2.0M),
+			(ProgVariableTypes.Writing, printed)
+		);
+		Assert.AreEqual(StatementResult.Normal, copyWriting.Execute(null));
+		Assert.AreEqual(true, copyWriting.Result.GetObject);
+		var copied = (IWriting)book.PagesAndReadables.Single(x => x.Page == 2).Writing;
+		Assert.AreNotSame(printed, copied);
+		Assert.AreEqual("Keep dry.", copied.ParseFor(null));
+	}
+
+	private static IFunction CompileFunction(string name, IFuturemud gameworld, params (ProgVariableTypes Type, object Value)[] parameters)
+	{
+		var compiler = FutureProg.GetFunctionCompilerInformations()
+		                         .Single(x => x.FunctionName.EqualTo(name) &&
+		                                      x.Parameters.SequenceEqual(parameters.Select(y => y.Type)));
+		var functions = parameters
+		                .Select(x => new ConstantTestFunction(x.Type, x.Value))
+		                .Cast<IFunction>()
+		                .ToList();
+		return compiler.CompilerFunction(functions, gameworld);
+	}
+
+	private static void AssertFunctionRegistered(string name, params ProgVariableTypes[] parameters)
+	{
+		Assert.IsTrue(
+			FutureProg.GetFunctionCompilerInformations()
+			          .Any(x => x.FunctionName.EqualTo(name) && x.Parameters.SequenceEqual(parameters)),
+			$"Expected FutureProg function {name}({string.Join(", ", parameters.Select(x => x.Describe()))}) to be registered."
+		);
+	}
+
+	private static BookGameItemComponentProto CreateBookProto(IFuturemud gameworld, string definition)
+	{
+		return (BookGameItemComponentProto)Activator.CreateInstance(
+			typeof(BookGameItemComponentProto),
+			BindingFlags.Instance | BindingFlags.NonPublic,
+			null,
+			new object[] { ComponentProtoModel(100, "Book", definition), gameworld },
+			CultureInfo.InvariantCulture
+		)!;
+	}
+
+	private static PaperSheetGameItemComponentProto CreatePaperProto(IFuturemud gameworld, int maximumLength)
+	{
+		return (PaperSheetGameItemComponentProto)Activator.CreateInstance(
+			typeof(PaperSheetGameItemComponentProto),
+			BindingFlags.Instance | BindingFlags.NonPublic,
+			null,
+			new object[]
+			{
+				ComponentProtoModel(101, "PaperSheet", new XElement("Definition",
+					new XElement("MaximumCharacterLengthOfText", maximumLength)
+				).ToString()),
+				gameworld
+			},
+			CultureInfo.InvariantCulture
+		)!;
+	}
+
+	private static DbGameItemComponentProto ComponentProtoModel(long id, string type, string definition)
+	{
+		return new DbGameItemComponentProto
+		{
+			Id = id,
+			Type = type,
+			Name = type,
+			Description = $"{type} component",
+			Definition = definition,
+			RevisionNumber = 1,
+			EditableItem = new DbEditableItem
+			{
+				Id = id,
+				BuilderAccountId = 1,
+				BuilderDate = DateTime.UtcNow,
+				RevisionNumber = 1,
+				RevisionStatus = (int)RevisionStatus.Current
+			}
+		};
+	}
+
+	private static string InvokeSaveToXml(BookGameItemComponentProto proto)
+	{
+		return (string)typeof(BookGameItemComponentProto)
+		                .GetMethod("SaveToXml", BindingFlags.Instance | BindingFlags.NonPublic)!
+		                .Invoke(proto, Array.Empty<object>())!;
+	}
+
+	private static string BookDefinition(int pageCount, string title, params XElement[] writings)
+	{
+		return new XElement("Definition",
+			new XElement("PaperProto", PaperProtoId),
+			new XElement("PageCount", pageCount),
+			new XElement("DefaultTitle", new XCData(title)),
+			new XElement("InitialReadables", writings)
+		).ToString();
+	}
+
+	private static XElement WritingElement(int page, int order, string text, string provenance)
+	{
+		return new XElement("Writing",
+			new XAttribute("Type", "printed"),
+			new XAttribute("Page", page),
+			new XAttribute("Order", order),
+			new XElement("Language", LanguageId),
+			new XElement("Script", ScriptId),
+			new XElement("Colour", ColourId),
+			new XElement("Style", (int)WritingStyleDescriptors.MachinePrinted),
+			new XElement("Provenance", new XCData(provenance)),
+			new XElement("Text", new XCData(text)),
+			new XElement("LiteracySkill", 100.0),
+			new XElement("LanguageSkill", 100.0),
+			new XElement("HandwritingSkill", 100.0),
+			new XElement("ForgerySkill", 0.0)
+		);
+	}
+
+	private static Mock<IFuturemud> CreateGameworld(ILanguage language, IScript script, IColour colour, int pageCapacity)
+	{
+		var saveManager = new Mock<ISaveManager>();
+		var gameworld = new Mock<IFuturemud>();
+		var paperProto = CreatePaperProto(gameworld.Object, pageCapacity);
+		var paperItemProto = new Mock<IGameItemProto>();
+		paperItemProto.SetupGet(x => x.Id).Returns(PaperProtoId);
+		paperItemProto.Setup(x => x.GetItemType<PaperSheetGameItemComponentProto>()).Returns(paperProto);
+
+		gameworld.SetupGet(x => x.SaveManager).Returns(saveManager.Object);
+		gameworld.SetupGet(x => x.Languages).Returns(Repository(language));
+		gameworld.SetupGet(x => x.Scripts).Returns(Repository(script));
+		gameworld.SetupGet(x => x.Colours).Returns(Repository(colour));
+		gameworld.SetupGet(x => x.ItemProtos).Returns(RevisableRepository(paperItemProto.Object));
+		gameworld.Setup(x => x.GetStaticLong("DefaultWritingColourInText")).Returns(ColourId);
+		return gameworld;
+	}
+
+	private static IGameItem CreateParent(IFuturemud gameworld, long id)
+	{
+		var parent = new Mock<IGameItem>();
+		parent.SetupGet(x => x.Id).Returns(id);
+		parent.SetupGet(x => x.Gameworld).Returns(gameworld);
+		return parent.Object;
+	}
+
+	private static IGameItem CreateBookItem(IFuturemud gameworld, BookGameItemComponentProto proto, out BookGameItemComponent book)
+	{
+		var item = new Mock<IGameItem>();
+		item.SetupGet(x => x.Id).Returns(500);
+		item.SetupGet(x => x.Gameworld).Returns(gameworld);
+		book = (BookGameItemComponent)proto.CreateNew(item.Object);
+		item.Setup(x => x.GetItemType<BookGameItemComponent>()).Returns(book);
+		return item.Object;
+	}
+
+	private static ILanguage CreateLanguage(long id, string name)
+	{
+		var language = new Mock<ILanguage>();
+		language.SetupGet(x => x.Id).Returns(id);
+		language.SetupGet(x => x.Name).Returns(name);
+		return language.Object;
+	}
+
+	private static IScript CreateScript(long id, string name, double modifier)
+	{
+		var script = new Mock<IScript>();
+		script.SetupGet(x => x.Id).Returns(id);
+		script.SetupGet(x => x.Name).Returns(name);
+		script.SetupGet(x => x.DocumentLengthModifier).Returns(modifier);
+		return script.Object;
+	}
+
+	private static IColour CreateColour(long id, string name)
+	{
+		var colour = new Mock<IColour>();
+		colour.SetupGet(x => x.Id).Returns(id);
+		colour.SetupGet(x => x.Name).Returns(name);
+		return colour.Object;
+	}
+
+	private static IUneditableAll<T> Repository<T>(params T[] items) where T : class, IFrameworkItem
+	{
+		var repository = new Mock<IUneditableAll<T>>();
+		repository.Setup(x => x.Get(It.IsAny<long>()))
+		          .Returns<long>(id => items.FirstOrDefault(x => x.Id == id));
+		repository.Setup(x => x.GetByName(It.IsAny<string>()))
+		          .Returns<string>(name => items.FirstOrDefault(x => x.Name.EqualTo(name)));
+		repository.Setup(x => x.Get(It.IsAny<string>()))
+		          .Returns<string>(name => items.Where(x => x.Name.EqualTo(name)).ToList());
+		repository.Setup(x => x.GetEnumerator())
+		          .Returns(() => ((IEnumerable<T>)items).GetEnumerator());
+		repository.SetupGet(x => x.Count).Returns(items.Length);
+		return repository.Object;
+	}
+
+	private static IUneditableRevisableAll<T> RevisableRepository<T>(params T[] items) where T : class, IRevisableItem
+	{
+		var repository = new Mock<IUneditableRevisableAll<T>>();
+		repository.Setup(x => x.Get(It.IsAny<long>()))
+		          .Returns<long>(id => items.FirstOrDefault(x => x.Id == id));
+		repository.Setup(x => x.GetByName(It.IsAny<string>(), It.IsAny<bool>()))
+		          .Returns<string, bool>((name, ignoreCase) => items.FirstOrDefault(x =>
+			          ignoreCase ? x.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase) : x.Name.EqualTo(name)));
+		repository.Setup(x => x.Get(It.IsAny<string>()))
+		          .Returns<string>(name => items.Where(x => x.Name.EqualTo(name)).ToList());
+		repository.Setup(x => x.GetEnumerator())
+		          .Returns(() => ((IEnumerable<T>)items).GetEnumerator());
+		return repository.Object;
+	}
+
+	private sealed class ConstantTestFunction : IFunction
+	{
+		public ConstantTestFunction(ProgVariableTypes type, object value)
+		{
+			Result = new ObjectTestVariable(type, value);
+			ReturnType = type;
+		}
+
+		public IProgVariable Result { get; }
+		public ProgVariableTypes ReturnType { get; }
+		public StatementResult ExpectedResult => StatementResult.Normal;
+		public string ErrorMessage => string.Empty;
+
+		public StatementResult Execute(IVariableSpace variables)
+		{
+			return StatementResult.Normal;
+		}
+
+		public bool IsReturnOrContainsReturnOnAllBranches()
+		{
+			return false;
+		}
+	}
+
+	private sealed class ObjectTestVariable : ProgVariable
+	{
+		private readonly object _value;
+
+		public ObjectTestVariable(ProgVariableTypes type, object value)
+		{
+			Type = type;
+			_value = value;
+		}
+
+		public override ProgVariableTypes Type { get; }
+		public override object GetObject => _value;
+
+		public override IProgVariable GetProperty(string property)
+		{
+			throw new NotSupportedException();
+		}
+	}
+}

--- a/MudSharpCore/Character/CharacterCommunication.cs
+++ b/MudSharpCore/Character/CharacterCommunication.cs
@@ -353,8 +353,11 @@ public partial class Character
 
     public string GetWritingHeader(IWriting writing)
     {
+        var provenance = writing.Author is null
+            ? $" Source: {(writing.GetProperty("provenance")?.GetObject as string).IfNullOrWhiteSpace("unspecified").Colour(Telnet.Cyan)}"
+            : string.Empty;
         return
-            $"Language: {writing.Language.Name.Colour(Telnet.Green)} {writing.Language.LinkedTrait.Decorator.Decorate(writing.LanguageSkill).Colour(Telnet.Cyan)}, Script: {writing.Script.Name.Colour(Telnet.Green)} {$"({writing.Style.Describe().TitleCase()})".Colour(Telnet.Cyan)}\nWritten in {writing.ImplementType.Describe(writing.WritingColour, Telnet.Green)}."
+            $"Language: {writing.Language.Name.Colour(Telnet.Green)} {writing.Language.LinkedTrait.Decorator.Decorate(writing.LanguageSkill).Colour(Telnet.Cyan)}, Script: {writing.Script.Name.Colour(Telnet.Green)} {$"({writing.Style.Describe().TitleCase()})".Colour(Telnet.Cyan)}\nWritten in {writing.ImplementType.Describe(writing.WritingColour, Telnet.Green)}.{provenance}"
                 .ColourIncludingReset(Telnet.Yellow);
     }
 

--- a/MudSharpCore/Commands/Modules/StorytellerModule.cs
+++ b/MudSharpCore/Commands/Modules/StorytellerModule.cs
@@ -3190,15 +3190,15 @@ The syntax is as follows:
 
                 if (long.TryParse(text, out long value))
                 {
-                    writings = writings.Where(x => x.Author.Id == value);
+                    writings = writings.Where(x => x.Author?.Id == value);
                 }
                 else if (text[0] == '*' && text.Length > 1)
                 {
-                    writings = writings.Where(x => x.Author.Account.Name.EqualTo(text[1..]));
+                    writings = writings.Where(x => x.Author?.Account.Name.EqualTo(text[1..]) == true);
                 }
                 else
                 {
-                    writings = writings.Where(x => x.Author.PersonalName.GetName(NameStyle.FullName).EqualTo(text));
+                    writings = writings.Where(x => x.Author?.PersonalName.GetName(NameStyle.FullName).EqualTo(text) == true);
                 }
 
                 continue;
@@ -3237,7 +3237,7 @@ The syntax is as follows:
                 select new string[]
                 {
                     writing.Id.ToString("N0", actor),
-                    writing.Author.PersonalName.GetName(NameStyle.FullName),
+                    writing.Author?.PersonalName.GetName(NameStyle.FullName) ?? "Printed/Anonymous",
                     writing.Language.Name,
                     writing.Script.Name,
                     writing.ImplementType.Describe(),
@@ -3361,9 +3361,17 @@ The syntax is as follows:
         sb.AppendLine(
             $"Written in the {writing.Language.Name.ColourValue()} language and the {writing.Script.Name.ColourValue()} script.");
         sb.AppendLine(
-            $"Written in {writing.Style.DescribeEnum().A_An().Colour(Telnet.Yellow)} style with {writing.WritingColour.Name.ColourValue()} {writing.ImplementType.Describe(writing.WritingColour).ColourValue()}.");
-        sb.AppendLine(
-            $"Written by {writing.Author.PersonalName.GetName(NameStyle.FullWithNickname).ColourName()} (ID #{writing.Author.Id.ToString("N0", actor)} - Account {writing.Author.Account.Name.ColourName()}).");
+            $"Written in {writing.Style.DescribeEnum().A_An().Colour(Telnet.Yellow)} style with {(writing.WritingColour?.Name ?? "default").ColourValue()} {writing.ImplementType.Describe(writing.WritingColour).ColourValue()}.");
+        if (writing.Author is null)
+        {
+            var provenance = writing.GetProperty("provenance")?.GetObject as string;
+            sb.AppendLine($"Printed source: {provenance.IfNullOrWhiteSpace("unspecified").ColourName()}.");
+        }
+        else
+        {
+            sb.AppendLine(
+                $"Written by {writing.Author.PersonalName.GetName(NameStyle.FullWithNickname).ColourName()} (ID #{writing.Author.Id.ToString("N0", actor)} - Account {writing.Author.Account.Name.ColourName()}).");
+        }
         sb.AppendLine();
         sb.AppendLine(writing.ParseFor(actor));
         actor.OutputHandler.Send(sb.ToString());

--- a/MudSharpCore/Communication/Language/CompositeWriting.cs
+++ b/MudSharpCore/Communication/Language/CompositeWriting.cs
@@ -132,16 +132,16 @@ public class CompositeWriting : LateInitialisingItem, IGraffitiWriting, ILazyLoa
     public WritingImplementType ImplementType { get; init; }
     public IColour WritingColour { get; init; }
 
-    private long _authorId;
+    private long? _authorId;
     private ICharacter _author;
 
     public ICharacter Author
     {
         get
         {
-            if (_author == null && _authorId != 0)
+            if (_author == null && (_authorId ?? 0L) != 0)
             {
-                _author = Gameworld.TryGetCharacter(_authorId, true);
+                _author = Gameworld.TryGetCharacter(_authorId ?? 0L, true);
             }
 
             return _author;
@@ -149,7 +149,7 @@ public class CompositeWriting : LateInitialisingItem, IGraffitiWriting, ILazyLoa
         init
         {
             _author = value;
-            _authorId = value?.Id ?? 0;
+            _authorId = value?.Id;
             Changed = true;
         }
     }
@@ -291,9 +291,9 @@ public class CompositeWriting : LateInitialisingItem, IGraffitiWriting, ILazyLoa
 
     void ILazyLoadDuringIdleTime.DoLoad()
     {
-        if (_author == null && _authorId != 0)
+        if (_author == null && (_authorId ?? 0L) != 0)
         {
-            _author = Gameworld.TryGetCharacter(_authorId, true);
+            _author = Gameworld.TryGetCharacter(_authorId ?? 0L, true);
         }
 
         if (_trueAuthor == null && (_trueAuthorId ?? 0) != 0)
@@ -336,6 +336,10 @@ public class CompositeWriting : LateInitialisingItem, IGraffitiWriting, ILazyLoa
                 return new TextVariable(ParseFor(null));
             case "simple":
                 return new BooleanVariable(false);
+            case "printed":
+                return new BooleanVariable(false);
+            case "provenance":
+                return new TextVariable(string.Empty);
             default:
                 throw new NotSupportedException();
         }

--- a/MudSharpCore/Communication/Language/PrintedWriting.cs
+++ b/MudSharpCore/Communication/Language/PrintedWriting.cs
@@ -1,0 +1,229 @@
+using MudSharp.Character;
+using MudSharp.Database;
+using MudSharp.Form.Colour;
+using MudSharp.Framework;
+using MudSharp.Framework.Save;
+using MudSharp.FutureProg;
+using MudSharp.FutureProg.Variables;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace MudSharp.Communication.Language;
+
+public class PrintedWriting : LateInitialisingItem, IWriting
+{
+	public PrintedWriting(
+		IFuturemud gameworld,
+		string text,
+		ILanguage language,
+		IScript script,
+		string provenance,
+		WritingStyleDescriptors style,
+		IColour writingColour,
+		double literacySkill = 100.0,
+		double languageSkill = 100.0,
+		double handwritingSkill = 100.0,
+		double forgerySkill = 0.0)
+	{
+		Gameworld = gameworld;
+		Text = text;
+		Language = language;
+		Script = script;
+		Provenance = provenance;
+		Style = style == WritingStyleDescriptors.None ? WritingStyleDescriptors.MachinePrinted : style;
+		WritingColour = writingColour;
+		LiteracySkill = literacySkill;
+		LanguageSkill = languageSkill;
+		HandwritingSkill = handwritingSkill;
+		ForgerySkill = forgerySkill;
+		DocumentLength = (int)(Text.RawTextLength() * Script.DocumentLengthModifier);
+		Gameworld.SaveManager.AddInitialisation(this);
+	}
+
+	public PrintedWriting(Writing writing, IFuturemud gameworld)
+	{
+		_id = writing.Id;
+		Gameworld = gameworld;
+		var definition = XElement.Parse(writing.Definition);
+		Text = definition.Element("Text")?.Value ?? string.Empty;
+		Provenance = definition.Element("Provenance")?.Value ?? string.Empty;
+		ForgerySkill = writing.ForgerySkill;
+		HandwritingSkill = writing.HandwritingSkill;
+		LiteracySkill = writing.LiteracySkill;
+		LanguageSkill = writing.LanguageSkill;
+		Language = gameworld.Languages.Get(writing.LanguageId);
+		Script = gameworld.Scripts.Get(writing.ScriptId);
+		Style = (WritingStyleDescriptors)writing.Style;
+		DocumentLength = (int)(Text.RawTextLength() * Script.DocumentLengthModifier);
+		WritingColour = gameworld.Colours.Get(writing.WritingColour);
+		IdInitialised = true;
+	}
+
+	public PrintedWriting(PrintedWriting rhs)
+	{
+		Gameworld = rhs.Gameworld;
+		Text = rhs.Text;
+		Provenance = rhs.Provenance;
+		DocumentLength = rhs.DocumentLength;
+		ForgerySkill = rhs.ForgerySkill;
+		HandwritingSkill = rhs.HandwritingSkill;
+		LiteracySkill = rhs.LiteracySkill;
+		LanguageSkill = rhs.LanguageSkill;
+		Script = rhs.Script;
+		Language = rhs.Language;
+		Style = rhs.Style;
+		WritingColour = rhs.WritingColour;
+		Gameworld.SaveManager.AddInitialisation(this);
+	}
+
+	public string Text { get; set; }
+	public string Provenance { get; set; }
+	public WritingImplementType ImplementType => WritingImplementType.Printed;
+	public IColour WritingColour { get; init; }
+	public ICharacter Author => null;
+	public ICharacter TrueAuthor => null;
+	public int DocumentLength { get; set; }
+	public double ForgerySkill { get; set; }
+	public double HandwritingSkill { get; set; }
+	public double LanguageSkill { get; set; }
+	public override string FrameworkItemType => "Writing";
+	public WritingStyleDescriptors Style { get; set; }
+	public ILanguage Language { get; set; }
+	public double LiteracySkill { get; set; }
+	public IScript Script { get; set; }
+
+	public IWriting Copy()
+	{
+		return new PrintedWriting(this);
+	}
+
+	public override object DatabaseInsert()
+	{
+		var dbitem = new Writing
+		{
+			ScriptId = Script.Id,
+			LanguageId = Language.Id,
+			AuthorId = null,
+			TrueAuthorId = null,
+			ForgerySkill = ForgerySkill,
+			HandwritingSkill = HandwritingSkill,
+			LanguageSkill = LanguageSkill,
+			LiteracySkill = LiteracySkill,
+			Style = (int)Style,
+			WritingType = "printed",
+			Definition = SaveDefinition(),
+			WritingColour = WritingColour?.Id ?? 0,
+			ImplementType = (int)ImplementType
+		};
+		FMDB.Context.Writings.Add(dbitem);
+		return dbitem;
+	}
+
+	public string ParseFor(ICharacter voyeur)
+	{
+		return Text;
+	}
+
+	public override void Save()
+	{
+		var dbitem = FMDB.Context.Writings.Find(Id);
+		dbitem.ScriptId = Script.Id;
+		dbitem.LanguageId = Language.Id;
+		dbitem.TrueAuthorId = null;
+		dbitem.AuthorId = null;
+		dbitem.ForgerySkill = ForgerySkill;
+		dbitem.HandwritingSkill = HandwritingSkill;
+		dbitem.LanguageSkill = LanguageSkill;
+		dbitem.LiteracySkill = LiteracySkill;
+		dbitem.Style = (int)Style;
+		dbitem.Definition = SaveDefinition();
+		dbitem.WritingColour = WritingColour?.Id ?? 0;
+		dbitem.ImplementType = (int)ImplementType;
+		Changed = false;
+	}
+
+	private string SaveDefinition()
+	{
+		return new XElement("Definition",
+			new XElement("Text", new XCData(Text ?? string.Empty)),
+			new XElement("Provenance", new XCData(Provenance ?? string.Empty))
+		).ToString();
+	}
+
+	public override void SetIDFromDatabase(object dbitem)
+	{
+		_id = ((Writing)dbitem)?.Id ?? 0;
+	}
+
+	public string DescribeInLook(ICharacter voyeur)
+	{
+		var provenance = string.IsNullOrWhiteSpace(Provenance)
+			? string.Empty
+			: $" from {Provenance}";
+
+		if (voyeur is null)
+		{
+			return $"{DocumentLength:N0} characters of {Language.Name} printed in {Style.Describe()} {Script.KnownScriptDescription.Strip_A_An()}{provenance}.".Colour(Telnet.BoldCyan);
+		}
+
+		if (!voyeur.IsLiterate)
+		{
+			return "A bunch of printed symbols that you cannot read.".Colour(Telnet.BoldCyan);
+		}
+
+		if (!voyeur.Knowledges.Contains(Script.ScriptKnowledge))
+		{
+			return $"{DocumentLength.ToString("N0", voyeur)} printed characters in {Script.UnknownScriptDescription.Strip_A_An()}{provenance}.".Colour(Telnet.BoldCyan);
+		}
+
+		return voyeur.HasTrait(Language.LinkedTrait)
+			? $"{DocumentLength.ToString("N0", voyeur)} characters of {Language.Name} printed in {Style.Describe()} {Script.KnownScriptDescription.Strip_A_An()}{provenance}.".Colour(Telnet.BoldCyan)
+			: $"{DocumentLength.ToString("N0", voyeur)} characters of an unknown language printed in {Style.Describe()} {Script.KnownScriptDescription.Strip_A_An()}{provenance}.".Colour(Telnet.BoldCyan);
+	}
+
+	#region Implementation of IProgVariable
+	public IProgVariable GetProperty(string property)
+	{
+		switch (property.ToLowerInvariant())
+		{
+			case "id":
+				return new NumberVariable(Id);
+			case "name":
+				return new TextVariable(Name);
+			case "author":
+			case "trueauthor":
+				return new NullVariable(ProgVariableTypes.Character);
+			case "script":
+				return Script;
+			case "language":
+				return Language;
+			case "handwriting":
+				return new NumberVariable(HandwritingSkill);
+			case "literacy":
+				return new NumberVariable(LiteracySkill);
+			case "forgery":
+				return new NumberVariable(ForgerySkill);
+			case "languageskill":
+				return new NumberVariable(LanguageSkill);
+			case "text":
+				return new TextVariable(ParseFor(null));
+			case "simple":
+				return new BooleanVariable(false);
+			case "printed":
+				return new BooleanVariable(true);
+			case "provenance":
+				return new TextVariable(Provenance ?? string.Empty);
+			default:
+				throw new NotSupportedException();
+		}
+	}
+
+	public ProgVariableTypes Type => ProgVariableTypes.Writing;
+
+	public object GetObject => this;
+	#endregion
+}

--- a/MudSharpCore/Communication/Language/SimpleWriting.cs
+++ b/MudSharpCore/Communication/Language/SimpleWriting.cs
@@ -79,16 +79,16 @@ public class SimpleWriting : LateInitialisingItem, IWriting, ILazyLoadDuringIdle
     public WritingImplementType ImplementType { get; init; }
     public IColour WritingColour { get; init; }
 
-    private long _authorId;
+    private long? _authorId;
     private ICharacter _author;
 
     public ICharacter Author
     {
         get
         {
-            if (_author == null && _authorId != 0)
+            if (_author == null && (_authorId ?? 0L) != 0)
             {
-                _author = Gameworld.TryGetCharacter(_authorId, true);
+                _author = Gameworld.TryGetCharacter(_authorId ?? 0L, true);
             }
 
             return _author;
@@ -96,7 +96,7 @@ public class SimpleWriting : LateInitialisingItem, IWriting, ILazyLoadDuringIdle
         init
         {
             _author = value;
-            _authorId = value?.Id ?? 0;
+            _authorId = value?.Id;
             Changed = true;
         }
     }
@@ -200,9 +200,9 @@ public class SimpleWriting : LateInitialisingItem, IWriting, ILazyLoadDuringIdle
 
     void ILazyLoadDuringIdleTime.DoLoad()
     {
-        if (_author == null && _authorId != 0)
+        if (_author == null && (_authorId ?? 0L) != 0)
         {
-            _author = Gameworld.TryGetCharacter(_authorId, true);
+            _author = Gameworld.TryGetCharacter(_authorId ?? 0L, true);
         }
 
         if (_trueAuthor == null && (_trueAuthorId ?? 0) != 0)
@@ -263,6 +263,10 @@ public class SimpleWriting : LateInitialisingItem, IWriting, ILazyLoadDuringIdle
                 return new TextVariable(ParseFor(null));
             case "simple":
                 return new BooleanVariable(true);
+            case "printed":
+                return new BooleanVariable(false);
+            case "provenance":
+                return new TextVariable(string.Empty);
             default:
                 throw new NotSupportedException();
         }
@@ -287,7 +291,9 @@ public class SimpleWriting : LateInitialisingItem, IWriting, ILazyLoadDuringIdle
             { "forgery", ProgVariableTypes.Number },
             { "languageskill", ProgVariableTypes.Number },
             { "text", ProgVariableTypes.Text },
-            { "simple", ProgVariableTypes.Boolean}
+            { "simple", ProgVariableTypes.Boolean},
+            { "printed", ProgVariableTypes.Boolean},
+            { "provenance", ProgVariableTypes.Text}
         };
     }
 
@@ -306,7 +312,9 @@ public class SimpleWriting : LateInitialisingItem, IWriting, ILazyLoadDuringIdle
             { "forgery", "The forgery skill of the author" },
             { "languageskill", "The language skill of the author" },
             { "text", "The parsed text of the writing" },
-            { "simple", "True if simple writing, false is composite (drawing+writing)"}
+            { "simple", "True if simple writing, false is composite (drawing+writing) or printed" },
+            { "printed", "True if this is printed writing without a character author" },
+            { "provenance", "The publisher, source, or other provenance text for printed writing" }
         };
     }
 

--- a/MudSharpCore/Communication/Language/WritingFactory.cs
+++ b/MudSharpCore/Communication/Language/WritingFactory.cs
@@ -14,6 +14,8 @@ public static class WritingFactory
                 return new SimpleWriting(writing, gameworld);
             case "composite":
                 return new CompositeWriting(writing, gameworld);
+            case "printed":
+                return new PrintedWriting(writing, gameworld);
             default:
                 throw new ApplicationException(
                     $"Unknown writing type in WritingFactory.LoadWriting: {writing.WritingType}");

--- a/MudSharpCore/FutureProg/Functions/GameItem/BookWritingFunctions.cs
+++ b/MudSharpCore/FutureProg/Functions/GameItem/BookWritingFunctions.cs
@@ -1,0 +1,301 @@
+using MudSharp.Communication.Language;
+using MudSharp.Form.Colour;
+using MudSharp.Framework;
+using MudSharp.FutureProg.Variables;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Components;
+using MudSharp.GameItems.Interfaces;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MudSharp.FutureProg.Functions.GameItem;
+
+internal class AddPrintedWritingFunction : BuiltInFunction
+{
+	private readonly IFuturemud _gameworld;
+	private readonly bool _useAdvancedOptions;
+
+	public AddPrintedWritingFunction(IList<IFunction> parameters, IFuturemud gameworld, bool useAdvancedOptions)
+		: base(parameters)
+	{
+		_gameworld = gameworld;
+		_useAdvancedOptions = useAdvancedOptions;
+	}
+
+	public override ProgVariableTypes ReturnType
+	{
+		get => ProgVariableTypes.Boolean;
+		protected set { }
+	}
+
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		if (base.Execute(variables) == StatementResult.Error)
+		{
+			return StatementResult.Error;
+		}
+
+		var item = ParameterFunctions[0].Result.GetObject as IGameItem;
+		var book = item?.GetItemType<BookGameItemComponent>();
+		if (book is null)
+		{
+			Result = new BooleanVariable(false);
+			return StatementResult.Normal;
+		}
+
+		var page = (int)(decimal)ParameterFunctions[1].Result.GetObject;
+		var text = (string)ParameterFunctions[2].Result.GetObject;
+		var language = ParameterFunctions[3].Result.GetObject as ILanguage;
+		var script = ParameterFunctions[4].Result.GetObject as IScript;
+		var provenance = (string)ParameterFunctions[5].Result.GetObject;
+		if (language is null || script is null)
+		{
+			Result = new BooleanVariable(false);
+			return StatementResult.Normal;
+		}
+
+		var colour = _gameworld.Colours.Get(_gameworld.GetStaticLong("DefaultWritingColourInText"));
+		if (colour is null)
+		{
+			Result = new BooleanVariable(false);
+			return StatementResult.Normal;
+		}
+
+		var style = WritingStyleDescriptors.MachinePrinted;
+		if (_useAdvancedOptions)
+		{
+			if (!TryGetColour((string)ParameterFunctions[6].Result.GetObject, out colour) ||
+			    !TryGetStyle((string)ParameterFunctions[7].Result.GetObject, out style))
+			{
+				Result = new BooleanVariable(false);
+				return StatementResult.Normal;
+			}
+		}
+
+		var writing = new PrintedWriting(_gameworld, text, language, script, provenance, style, colour);
+		if (!book.CanAddWriting(writing, page))
+		{
+			_gameworld.SaveManager.Abort(writing);
+			Result = new BooleanVariable(false);
+			return StatementResult.Normal;
+		}
+
+		Result = new BooleanVariable(book.AddWriting(writing, page));
+		return StatementResult.Normal;
+	}
+
+	private bool TryGetColour(string text, out IColour colour)
+	{
+		colour = _gameworld.Colours.Get(_gameworld.GetStaticLong("DefaultWritingColourInText"));
+		if (string.IsNullOrWhiteSpace(text))
+		{
+			return colour is not null;
+		}
+
+		colour = long.TryParse(text, out var value)
+			? _gameworld.Colours.Get(value)
+			: _gameworld.Colours.GetByName(text);
+		return colour is not null;
+	}
+
+	private static bool TryGetStyle(string text, out WritingStyleDescriptors style)
+	{
+		style = WritingStyleDescriptors.MachinePrinted;
+		if (string.IsNullOrWhiteSpace(text))
+		{
+			return true;
+		}
+
+		var parsed = WritingStyleDescriptors.None.Parse(text);
+		if (parsed != WritingStyleDescriptors.None)
+		{
+			style = parsed;
+			return true;
+		}
+
+		var result = WritingStyleDescriptors.None;
+		foreach (var item in text.Split(',', '|', '+').Select(x => x.Trim()).Where(x => x.Length > 0))
+		{
+			parsed = WritingStyleDescriptors.None.Parse(item);
+			if (parsed == WritingStyleDescriptors.None)
+			{
+				return false;
+			}
+
+			result |= parsed;
+		}
+
+		if (result == WritingStyleDescriptors.None)
+		{
+			return false;
+		}
+
+		style = result;
+		return true;
+	}
+
+	public static void RegisterFunctionCompiler()
+	{
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			"addprintedwriting",
+			new[]
+			{
+				ProgVariableTypes.Item, ProgVariableTypes.Number, ProgVariableTypes.Text, ProgVariableTypes.Language,
+				ProgVariableTypes.Script, ProgVariableTypes.Text
+			},
+			(pars, gameworld) => new AddPrintedWritingFunction(pars, gameworld, false),
+			new List<string> { "item", "page", "text", "language", "script", "provenance" },
+			new List<string>
+			{
+				"The book item to receive the printed writing",
+				"The page number to write to",
+				"The printed text to add",
+				"The language of the printed text",
+				"The script of the printed text",
+				"The publisher, source, or provenance text to display for this writing"
+			},
+			"Adds a new piece of provenance-aware printed writing to a specific page of a book, returning false if the target is not a book, the page is invalid, or the text will not fit.",
+			"Items",
+			ProgVariableTypes.Boolean
+		));
+
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			"addprintedwriting",
+			new[]
+			{
+				ProgVariableTypes.Item, ProgVariableTypes.Number, ProgVariableTypes.Text, ProgVariableTypes.Language,
+				ProgVariableTypes.Script, ProgVariableTypes.Text, ProgVariableTypes.Text, ProgVariableTypes.Text
+			},
+			(pars, gameworld) => new AddPrintedWritingFunction(pars, gameworld, true),
+			new List<string> { "item", "page", "text", "language", "script", "provenance", "colour", "style" },
+			new List<string>
+			{
+				"The book item to receive the printed writing",
+				"The page number to write to",
+				"The printed text to add",
+				"The language of the printed text",
+				"The script of the printed text",
+				"The publisher, source, or provenance text to display for this writing",
+				"The colour name or ID for the printed text",
+				"The writing style descriptor, or multiple descriptors separated by commas, pipes, or plus signs"
+			},
+			"Adds a new piece of provenance-aware printed writing with explicit colour and style to a specific page of a book, returning false if validation fails.",
+			"Items",
+			ProgVariableTypes.Boolean
+		));
+	}
+}
+
+internal class CopyWritingToFunction : BuiltInFunction
+{
+	public CopyWritingToFunction(IList<IFunction> parameters)
+		: base(parameters)
+	{
+	}
+
+	public override ProgVariableTypes ReturnType
+	{
+		get => ProgVariableTypes.Boolean;
+		protected set { }
+	}
+
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		if (base.Execute(variables) == StatementResult.Error)
+		{
+			return StatementResult.Error;
+		}
+
+		var item = ParameterFunctions[0].Result.GetObject as IGameItem;
+		var book = item?.GetItemType<BookGameItemComponent>();
+		var page = (int)(decimal)ParameterFunctions[1].Result.GetObject;
+		var writing = ParameterFunctions[2].Result.GetObject as IWriting;
+		if (book is null || writing is null || !book.CanAddWriting(writing, page))
+		{
+			Result = new BooleanVariable(false);
+			return StatementResult.Normal;
+		}
+
+		var copy = writing.Copy();
+		var result = book.AddWriting(copy, page);
+		if (!result)
+		{
+			copy.Gameworld.SaveManager.Abort(copy);
+		}
+
+		Result = new BooleanVariable(result);
+		return StatementResult.Normal;
+	}
+
+	public static void RegisterFunctionCompiler()
+	{
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			"copywritingto",
+			new[] { ProgVariableTypes.Item, ProgVariableTypes.Number, ProgVariableTypes.Writing },
+			(pars, _) => new CopyWritingToFunction(pars),
+			new List<string> { "item", "page", "writing" },
+			new List<string>
+			{
+				"The book item to receive the writing copy",
+				"The page number to copy to",
+				"The existing writing to copy"
+			},
+			"Copies an existing writing onto a specific page of a book, returning false if the target is not a book, the page is invalid, or the writing will not fit.",
+			"Items",
+			ProgVariableTypes.Boolean
+		));
+	}
+}
+
+internal class SetBookTitleFunction : BuiltInFunction
+{
+	public SetBookTitleFunction(IList<IFunction> parameters)
+		: base(parameters)
+	{
+	}
+
+	public override ProgVariableTypes ReturnType
+	{
+		get => ProgVariableTypes.Boolean;
+		protected set { }
+	}
+
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		if (base.Execute(variables) == StatementResult.Error)
+		{
+			return StatementResult.Error;
+		}
+
+		var item = ParameterFunctions[0].Result.GetObject as IGameItem;
+		var book = item?.GetItemType<BookGameItemComponent>();
+		if (book is null)
+		{
+			Result = new BooleanVariable(false);
+			return StatementResult.Normal;
+		}
+
+		book.Title = (string)ParameterFunctions[1].Result.GetObject;
+		book.Changed = true;
+		Result = new BooleanVariable(true);
+		return StatementResult.Normal;
+	}
+
+	public static void RegisterFunctionCompiler()
+	{
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			"setbooktitle",
+			new[] { ProgVariableTypes.Item, ProgVariableTypes.Text },
+			(pars, _) => new SetBookTitleFunction(pars),
+			new List<string> { "item", "title" },
+			new List<string>
+			{
+				"The book item whose title should be changed",
+				"The new title to apply"
+			},
+			"Sets the title on a book item and returns false if the supplied item is not a book.",
+			"Items",
+			ProgVariableTypes.Boolean
+		));
+	}
+}

--- a/MudSharpCore/GameItems/Components/BookGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/BookGameItemComponent.cs
@@ -37,6 +37,21 @@ public class BookGameItemComponent : GameItemComponent, IWriteable, IReadable, I
     {
         _prototype = proto;
         CurrentPage = 1;
+        Title = proto.DefaultTitle;
+        if (!temporary)
+        {
+            foreach (var item in proto.InitialReadables)
+            {
+                if (!CanAddTemplate(item))
+                {
+                    continue;
+                }
+
+                var readable = item.CreateReadable(Gameworld);
+                PagesAndReadables.Add((item.Page, item.Order, readable));
+                RegisterReadable(readable);
+            }
+        }
         CalculateWritings();
     }
 
@@ -55,7 +70,12 @@ public class BookGameItemComponent : GameItemComponent, IWriteable, IReadable, I
         _prototype = rhs._prototype;
         foreach ((int Page, int Order, ICanBeRead Writing) item in rhs.PagesAndReadables)
         {
-            PagesAndReadables.Add((item.Page, item.Order, item.Writing));
+            var readable = temporary ? item.Writing : item.Writing.CopyReadable();
+            PagesAndReadables.Add((item.Page, item.Order, readable));
+            if (!temporary)
+            {
+                RegisterReadable(readable);
+            }
         }
 
         TornPages = rhs.TornPages.ToHashSet();
@@ -93,6 +113,40 @@ public class BookGameItemComponent : GameItemComponent, IWriteable, IReadable, I
     }
 
     #endregion
+
+    private bool CanAddTemplate(IPageReadableContentTemplate template)
+    {
+        if (template is BookPageContentTemplate bookTemplate &&
+            (bookTemplate.Language is null || bookTemplate.Script is null || bookTemplate.Colour is null))
+        {
+            return false;
+        }
+
+        if (template.Page < 1 || template.Page > _prototype.PageCount)
+        {
+            return false;
+        }
+
+        if (template.DocumentLength > _prototype.MaximumCharacterLengthOfText - DocumentLengthUsedForPage(template.Page))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private void RegisterReadable(ICanBeRead readable)
+    {
+        switch (readable)
+        {
+            case IWriting writing:
+                Gameworld.Add(writing);
+                break;
+            case IDrawing drawing:
+                Gameworld.Add(drawing);
+                break;
+        }
+    }
 
     #region Saving
 
@@ -139,9 +193,29 @@ public class BookGameItemComponent : GameItemComponent, IWriteable, IReadable, I
 
     public int DocumentLengthUsed => Readables.Sum(x => x.DocumentLength);
 
+    public int DocumentLengthUsedForPage(int page)
+    {
+        return PagesAndReadables.Where(x => x.Page == page).Sum(x => x.Writing.DocumentLength);
+    }
+
     public bool CanAddWriting(IWriting writing)
     {
-        if (writing.DocumentLength > _prototype.MaximumCharacterLengthOfText - DocumentLengthUsed)
+        return CanAddWriting(writing, CurrentPage);
+    }
+
+    public bool CanAddWriting(IWriting writing, int page)
+    {
+        if (page < 1 || page > _prototype.PageCount)
+        {
+            return false;
+        }
+
+        if (TornPages.Contains(page))
+        {
+            return false;
+        }
+
+        if (writing.DocumentLength > _prototype.MaximumCharacterLengthOfText - DocumentLengthUsedForPage(page))
         {
             return false;
         }
@@ -149,14 +223,39 @@ public class BookGameItemComponent : GameItemComponent, IWriteable, IReadable, I
         return true;
     }
 
+    public string WhyCannotAddWriting(IWriting writing, int page)
+    {
+        if (page < 1 || page > _prototype.PageCount)
+        {
+            return $"You can only add writing to a page between 1 and {_prototype.PageCount:N0}.";
+        }
+
+        if (TornPages.Contains(page))
+        {
+            return $"The {page.ToOrdinal()} page has been torn out of {Parent.HowSeen(null)}.";
+        }
+
+        if (writing.DocumentLength > _prototype.MaximumCharacterLengthOfText - DocumentLengthUsedForPage(page))
+        {
+            return $"There is not enough space left on page {page:N0} of {Parent.HowSeen(null)} to add that writing.";
+        }
+
+        return "That writing cannot be added to the book.";
+    }
+
     public bool AddWriting(IWriting newWriting)
     {
-        if (!CanAddWriting(newWriting))
+        return AddWriting(newWriting, CurrentPage);
+    }
+
+    public bool AddWriting(IWriting newWriting, int page)
+    {
+        if (!CanAddWriting(newWriting, page))
         {
             return false;
         }
 
-        PagesAndReadables.Add((CurrentPage, Readables.Count() + 1, newWriting));
+        PagesAndReadables.Add((page, PagesAndReadables.Count(x => x.Page == page) + 1, newWriting));
         CalculateWritings();
         Gameworld.Add(newWriting);
         Changed = true;

--- a/MudSharpCore/GameItems/Components/PaperSheetGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/PaperSheetGameItemComponent.cs
@@ -49,8 +49,29 @@ public class PaperSheetGameItemComponent : GameItemComponent, IWriteable, IReada
         base(rhs, newParent, temporary)
     {
         _prototype = rhs._prototype;
-        Readables.AddRange(rhs.Readables);
+        foreach (var readable in rhs.Readables)
+        {
+            var newReadable = temporary ? readable : readable.CopyReadable();
+            Readables.Add(newReadable);
+            if (!temporary)
+            {
+                RegisterReadable(newReadable);
+            }
+        }
         Title = rhs.Title;
+    }
+
+    private void RegisterReadable(ICanBeRead readable)
+    {
+        switch (readable)
+        {
+            case IWriting writing:
+                Gameworld.Add(writing);
+                break;
+            case IDrawing drawing:
+                Gameworld.Add(drawing);
+                break;
+        }
     }
 
     protected void LoadFromXml(XElement root)

--- a/MudSharpCore/GameItems/Prototypes/BookGameItemComponentProto.cs
+++ b/MudSharpCore/GameItems/Prototypes/BookGameItemComponentProto.cs
@@ -1,8 +1,10 @@
 using MudSharp.Accounts;
 using MudSharp.Character;
+using MudSharp.Communication.Language;
 using MudSharp.Framework;
 using MudSharp.Framework.Revision;
 using MudSharp.GameItems.Components;
+using MudSharp.GameItems.Interfaces;
 using MudSharp.PerceptionEngine;
 using MudSharp.PerceptionEngine.Outputs;
 using MudSharp.PerceptionEngine.Parsers;
@@ -25,6 +27,11 @@ public class BookGameItemComponentProto : GameItemComponentProto, IWriteableProt
     public IGameItemProto PaperProto => Gameworld.ItemProtos.Get(_paperProtoId);
 
     public int PageCount { get; protected set; }
+
+    public string DefaultTitle { get; protected set; } = string.Empty;
+
+    private readonly List<BookPageContentTemplate> _initialReadables = new();
+    internal IEnumerable<BookPageContentTemplate> InitialReadables => _initialReadables.OrderBy(x => x.Page).ThenBy(x => x.Order);
 
     public int MaximumCharacterLengthOfText =>
         PaperProto?.GetItemType<PaperSheetGameItemComponentProto>()?.MaximumCharacterLengthOfText ?? 0;
@@ -49,6 +56,12 @@ public class BookGameItemComponentProto : GameItemComponentProto, IWriteableProt
     {
         _paperProtoId = long.Parse(root.Element("PaperProto")?.Value ?? "0");
         PageCount = int.Parse(root.Element("PageCount")?.Value ?? "0");
+        DefaultTitle = root.Element("DefaultTitle")?.Value ?? string.Empty;
+        _initialReadables.Clear();
+        foreach (var item in root.Element("InitialReadables")?.Elements("Writing") ?? Enumerable.Empty<XElement>())
+        {
+            _initialReadables.Add(new BookPageContentTemplate(Gameworld, item));
+        }
     }
 
     #endregion
@@ -60,7 +73,11 @@ public class BookGameItemComponentProto : GameItemComponentProto, IWriteableProt
         return new XElement("Definition", new[]
         {
             new XElement("PaperProto", PaperProto?.Id ?? 0),
-            new XElement("PageCount", PageCount)
+            new XElement("PageCount", PageCount),
+            new XElement("DefaultTitle", new XCData(DefaultTitle ?? string.Empty)),
+            new XElement("InitialReadables",
+                from item in InitialReadables
+                select item.SaveToXml())
         }).ToString();
     }
 
@@ -105,7 +122,7 @@ public class BookGameItemComponentProto : GameItemComponentProto, IWriteableProt
     #region Building Commands
 
     private const string BuildingHelpText =
-        "You can use the following options with this component:\n\tname <name> - sets the name of the component\n\tdesc <desc> - sets the description of the component\n\tpaper <id|name> - sets the item prototype for pages in this book\n\tpages <number> - sets the number of pages in a fresh copy of this book";
+        "You can use the following options with this component:\n\tname <name> - sets the name of the component\n\tdesc <desc> - sets the description of the component\n\tpaper <id|name> - sets the item prototype for pages in this book\n\tpages <number> - sets the number of pages in a fresh copy of this book\n\ttitle <title|clear> - sets the default title of fresh books\n\tcontent list - lists preloaded printed content\n\tcontent add <page> <language> <script> [provenance] - adds printed content via the editor\n\tcontent copy <page> <writing id> - copies an existing writing into the printed content template\n\tcontent edit <#> - edits the text of a preloaded content entry\n\tcontent remove <#> - removes a preloaded content entry\n\tcontent clear - removes all preloaded content";
 
     public override string ShowBuildingHelp => BuildingHelpText;
 
@@ -126,9 +143,353 @@ public class BookGameItemComponentProto : GameItemComponentProto, IWriteableProt
             case "pagecount":
             case "page_count":
                 return BuildingCommandPageCount(actor, command);
+            case "title":
+                return BuildingCommandDefaultTitle(actor, command);
+            case "content":
+            case "contents":
+                return BuildingCommandContent(actor, command);
             default:
                 return base.BuildingCommand(actor, command);
         }
+    }
+
+    private bool BuildingCommandDefaultTitle(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.Send("What default title should fresh copies of this book use? Use CLEAR to remove the default title.");
+            return false;
+        }
+
+        if (command.PeekSpeech().EqualToAny("clear", "none", "reset", "delete"))
+        {
+            DefaultTitle = string.Empty;
+            Changed = true;
+            actor.Send("Fresh copies of this book will no longer start with a title.");
+            return true;
+        }
+
+        DefaultTitle = command.SafeRemainingArgument;
+        Changed = true;
+        actor.Send($"Fresh copies of this book will start titled \"{DefaultTitle.Colour(Telnet.BoldWhite)}\".");
+        return true;
+    }
+
+    private bool BuildingCommandContent(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.Send(BuildingHelpText.SubstituteANSIColour());
+            return false;
+        }
+
+        switch (command.PopSpeech().ToLowerInvariant())
+        {
+            case "list":
+            case "show":
+                return BuildingCommandContentList(actor);
+            case "add":
+                return BuildingCommandContentAdd(actor, command);
+            case "copy":
+                return BuildingCommandContentCopy(actor, command);
+            case "edit":
+                return BuildingCommandContentEdit(actor, command);
+            case "remove":
+            case "delete":
+                return BuildingCommandContentRemove(actor, command);
+            case "clear":
+                _initialReadables.Clear();
+                Changed = true;
+                actor.Send("You remove all preloaded printed content from this book.");
+                return true;
+            default:
+                actor.Send(BuildingHelpText.SubstituteANSIColour());
+                return false;
+        }
+    }
+
+    private bool BuildingCommandContentList(ICharacter actor)
+    {
+        if (!_initialReadables.Any())
+        {
+            actor.Send("This book does not have any preloaded printed content.");
+            return true;
+        }
+
+        actor.Send(StringUtilities.GetTextTable(
+            from item in InitialReadables.Select((x, i) => (Content: x, Index: i + 1))
+            select new[]
+            {
+                item.Index.ToString("N0", actor),
+                item.Content.Page.ToString("N0", actor),
+                item.Content.Order.ToString("N0", actor),
+                item.Content.Language?.Name ?? "Unknown",
+                item.Content.Script?.Name ?? "Unknown",
+                item.Content.DocumentLength.ToString("N0", actor),
+                item.Content.Provenance.IfNullOrWhiteSpace(""),
+                item.Content.Text.Length <= actor.LineFormatLength / 3
+                    ? item.Content.Text
+                    : $"{item.Content.Text[..Math.Max(0, actor.LineFormatLength / 3 - 3)]}..."
+            },
+            new[] { "#", "Page", "Order", "Language", "Script", "Length", "Source", "Text" },
+            actor.LineFormatLength,
+            colour: Telnet.Cyan,
+            unicodeTable: actor.Account.UseUnicode));
+        return true;
+    }
+
+    private bool BuildingCommandContentAdd(ICharacter actor, StringStack command)
+    {
+        if (!TryParseContentHeader(actor, command, out var page, out var language, out var script, out var provenance))
+        {
+            return false;
+        }
+
+        var colour = Gameworld.Colours.Get(Gameworld.GetStaticLong("DefaultWritingColourInText"));
+        if (colour is null)
+        {
+            actor.Send("There is no valid default writing colour configured for printed book content.");
+            return false;
+        }
+
+        actor.EditorMode((text, handler, _) =>
+        {
+            var template = new BookPageContentTemplate(Gameworld, page, NextContentOrder(page), text, language, script,
+                provenance, colour, WritingStyleDescriptors.MachinePrinted);
+            if (!CanAddTemplate(template, out var error))
+            {
+                handler.Send(error);
+                return;
+            }
+
+            _initialReadables.Add(template);
+            Changed = true;
+            handler.Send($"You add preloaded printed content to page {page.ToString("N0", actor)} of this book.");
+        }, (handler, _) => handler.Send("You decide not to add any preloaded content."), 1.0);
+        return true;
+    }
+
+    private bool BuildingCommandContentCopy(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.Send("Which page should the copied writing be preloaded onto?");
+            return false;
+        }
+
+        if (!int.TryParse(command.PopSpeech(), out var page) || page < 1)
+        {
+            actor.Send("You must enter a valid page number.");
+            return false;
+        }
+
+        if (command.IsFinished)
+        {
+            actor.Send("Which existing writing ID do you want to copy into the book template?");
+            return false;
+        }
+
+        if (!long.TryParse(command.PopSpeech(), out var writingId))
+        {
+            actor.Send("You must enter a valid writing ID.");
+            return false;
+        }
+
+        var writing = Gameworld.Writings.Get(writingId);
+        if (writing is null)
+        {
+            actor.Send("There is no such writing.");
+            return false;
+        }
+
+        var template = BookPageContentTemplate.FromWriting(Gameworld, page, NextContentOrder(page), writing);
+        if (!CanAddTemplate(template, out var error))
+        {
+            actor.Send(error);
+            return false;
+        }
+
+        _initialReadables.Add(template);
+        Changed = true;
+        actor.Send($"You copy writing #{writing.Id.ToString("N0", actor)} into the preloaded content for page {page.ToString("N0", actor)}.");
+        return true;
+    }
+
+    private bool BuildingCommandContentEdit(ICharacter actor, StringStack command)
+    {
+        if (!TryGetContentByIndex(actor, command, out var template))
+        {
+            return false;
+        }
+
+        actor.EditorMode((text, handler, _) =>
+        {
+            var oldText = template.Text;
+            template.Text = text;
+            if (!CanFitPage(template.Page, out var error))
+            {
+                template.Text = oldText;
+                handler.Send(error);
+                return;
+            }
+
+            Changed = true;
+            handler.Send($"You edit preloaded content #{InitialReadables.ToList().IndexOf(template) + 1:N0}.");
+        }, (handler, _) => handler.Send("You decide not to edit the preloaded content."), 1.0, template.Text);
+        return true;
+    }
+
+    private bool BuildingCommandContentRemove(ICharacter actor, StringStack command)
+    {
+        if (!TryGetContentByIndex(actor, command, out var template))
+        {
+            return false;
+        }
+
+        _initialReadables.Remove(template);
+        ReorderContent(template.Page);
+        Changed = true;
+        actor.Send("You remove that preloaded content from this book.");
+        return true;
+    }
+
+    private bool TryParseContentHeader(ICharacter actor, StringStack command, out int page, out ILanguage language,
+        out IScript script, out string provenance)
+    {
+        page = 0;
+        language = null;
+        script = null;
+        provenance = string.Empty;
+
+        if (command.IsFinished)
+        {
+            actor.Send("Which page should this preloaded content appear on?");
+            return false;
+        }
+
+        if (!int.TryParse(command.PopSpeech(), out page) || page < 1 || page > PageCount)
+        {
+            actor.Send($"You must enter a page number between 1 and {PageCount.ToString("N0", actor)}.");
+            return false;
+        }
+
+        if (command.IsFinished)
+        {
+            actor.Send("Which language should this printed text be written in?");
+            return false;
+        }
+
+        var text = command.PopSpeech();
+        language = long.TryParse(text, out var value)
+            ? Gameworld.Languages.Get(value)
+            : Gameworld.Languages.GetByName(text);
+        if (language is null)
+        {
+            actor.Send("There is no such language.");
+            return false;
+        }
+
+        if (command.IsFinished)
+        {
+            actor.Send("Which script should this printed text use?");
+            return false;
+        }
+
+        text = command.PopSpeech();
+        script = long.TryParse(text, out value)
+            ? Gameworld.Scripts.Get(value)
+            : Gameworld.Scripts.GetByName(text);
+        if (script is null)
+        {
+            actor.Send("There is no such script.");
+            return false;
+        }
+
+        provenance = command.SafeRemainingArgument;
+        return true;
+    }
+
+    private bool TryGetContentByIndex(ICharacter actor, StringStack command, out BookPageContentTemplate template)
+    {
+        template = null;
+        if (command.IsFinished)
+        {
+            actor.Send("Which preloaded content number do you want to target?");
+            return false;
+        }
+
+        if (!int.TryParse(command.PopSpeech(), out var value) || value < 1 || value > _initialReadables.Count)
+        {
+            actor.Send($"You must enter a number between 1 and {_initialReadables.Count.ToString("N0", actor)}.");
+            return false;
+        }
+
+        template = InitialReadables.ElementAt(value - 1);
+        return true;
+    }
+
+    private int NextContentOrder(int page)
+    {
+        return _initialReadables.Where(x => x.Page == page).Select(x => x.Order).DefaultIfEmpty(0).Max() + 1;
+    }
+
+    private void ReorderContent(int page)
+    {
+        var order = 1;
+        foreach (var item in _initialReadables.Where(x => x.Page == page).OrderBy(x => x.Order))
+        {
+            item.Order = order++;
+        }
+    }
+
+    private bool CanAddTemplate(BookPageContentTemplate template, out string error)
+    {
+        if (template.Page < 1 || template.Page > PageCount)
+        {
+            error = $"Preloaded content can only target pages between 1 and {PageCount:N0}.";
+            return false;
+        }
+
+        if (template.Language is null)
+        {
+            error = "The preloaded content must use a valid language.";
+            return false;
+        }
+
+        if (template.Script is null)
+        {
+            error = "The preloaded content must use a valid script.";
+            return false;
+        }
+
+        if (template.Colour is null)
+        {
+            error = "The preloaded content must use a valid text colour.";
+            return false;
+        }
+
+        var used = _initialReadables.Where(x => x.Page == template.Page).Sum(x => x.DocumentLength);
+        if (used + template.DocumentLength > MaximumCharacterLengthOfText)
+        {
+            error = $"The preloaded content for page {template.Page:N0} would be {(used + template.DocumentLength):N0} characters, which exceeds the page capacity of {MaximumCharacterLengthOfText:N0}.";
+            return false;
+        }
+
+        error = string.Empty;
+        return true;
+    }
+
+    private bool CanFitPage(int page, out string error)
+    {
+        var used = _initialReadables.Where(x => x.Page == page).Sum(x => x.DocumentLength);
+        if (used > MaximumCharacterLengthOfText)
+        {
+            error = $"The preloaded content for page {page:N0} is {used:N0} characters, which exceeds the page capacity of {MaximumCharacterLengthOfText:N0}.";
+            return false;
+        }
+
+        error = string.Empty;
+        return true;
     }
 
     private bool BuildingCommandPageCount(ICharacter actor, StringStack command)
@@ -142,6 +503,12 @@ public class BookGameItemComponentProto : GameItemComponentProto, IWriteableProt
         if (!int.TryParse(command.SafeRemainingArgument, out int value) || value <= 0)
         {
             actor.Send("You must enter a valid number of pages greater than zero for this book.");
+            return false;
+        }
+
+        if (_initialReadables.Any(x => x.Page > value))
+        {
+            actor.Send("You cannot reduce the page count below the highest page that already has preloaded content.");
             return false;
         }
 
@@ -195,7 +562,7 @@ public class BookGameItemComponentProto : GameItemComponentProto, IWriteableProt
     public override string ComponentDescriptionOLC(ICharacter actor)
     {
         return string.Format(actor,
-            "{0} (#{1:N0}r{2:N0}, {3})\r\n\r\nThis item is a book with {4} pages, that references the {5} prototype for its paper.",
+            "{0} (#{1:N0}r{2:N0}, {3})\r\n\r\nThis item is a book with {4} pages, that references the {5} prototype for its paper.\nFresh copies start {6} and contain {7:N0} pieces of preloaded printed content.",
             "Book Game Item Component".Colour(Telnet.Cyan),
             Id,
             RevisionNumber,
@@ -203,7 +570,9 @@ public class BookGameItemComponentProto : GameItemComponentProto, IWriteableProt
             PageCount,
             PaperProto != null
                 ? $"{PaperProto.Name.Colour(Telnet.Cyan)} (#{PaperProto.Id})"
-                : "Not Set".Colour(Telnet.Red)
+                : "Not Set".Colour(Telnet.Red),
+            string.IsNullOrWhiteSpace(DefaultTitle) ? "untitled" : $"titled \"{DefaultTitle.Colour(Telnet.BoldWhite)}\"",
+            _initialReadables.Count
         );
     }
 }

--- a/MudSharpCore/GameItems/Prototypes/BookPageContentTemplate.cs
+++ b/MudSharpCore/GameItems/Prototypes/BookPageContentTemplate.cs
@@ -1,0 +1,120 @@
+using MudSharp.Communication;
+using MudSharp.Communication.Language;
+using MudSharp.Form.Colour;
+using MudSharp.Framework;
+using MudSharp.GameItems.Interfaces;
+using System;
+using System.Xml.Linq;
+
+namespace MudSharp.GameItems.Prototypes;
+
+internal sealed class BookPageContentTemplate : IPageReadableContentTemplate
+{
+	private readonly IFuturemud _gameworld;
+	private long _languageId;
+	private long _scriptId;
+	private long _colourId;
+
+	public BookPageContentTemplate(IFuturemud gameworld, int page, int order, string text, ILanguage language,
+		IScript script, string provenance, IColour colour, WritingStyleDescriptors style)
+	{
+		_gameworld = gameworld;
+		Page = page;
+		Order = order;
+		Text = text ?? string.Empty;
+		_languageId = language?.Id ?? 0;
+		_scriptId = script?.Id ?? 0;
+		Provenance = provenance ?? string.Empty;
+		_colourId = colour?.Id ?? 0;
+		Style = style == WritingStyleDescriptors.None ? WritingStyleDescriptors.MachinePrinted : style;
+	}
+
+	public BookPageContentTemplate(IFuturemud gameworld, XElement root)
+	{
+		_gameworld = gameworld;
+		Page = int.Parse(root.Attribute("Page")?.Value ?? "1");
+		Order = int.Parse(root.Attribute("Order")?.Value ?? "1");
+		_languageId = long.Parse(root.Element("Language")?.Value ?? "0");
+		_scriptId = long.Parse(root.Element("Script")?.Value ?? "0");
+		_colourId = long.Parse(root.Element("Colour")?.Value ?? "0");
+		Style = (WritingStyleDescriptors)int.Parse(root.Element("Style")?.Value ?? ((int)WritingStyleDescriptors.MachinePrinted).ToString());
+		Text = root.Element("Text")?.Value ?? string.Empty;
+		Provenance = root.Element("Provenance")?.Value ?? string.Empty;
+		LiteracySkill = double.Parse(root.Element("LiteracySkill")?.Value ?? "100.0");
+		LanguageSkill = double.Parse(root.Element("LanguageSkill")?.Value ?? "100.0");
+		HandwritingSkill = double.Parse(root.Element("HandwritingSkill")?.Value ?? "100.0");
+		ForgerySkill = double.Parse(root.Element("ForgerySkill")?.Value ?? "0.0");
+	}
+
+	public int Page { get; set; }
+	public int Order { get; set; }
+	public string Text { get; set; }
+	public string Provenance { get; set; }
+	public WritingStyleDescriptors Style { get; set; }
+	public double LiteracySkill { get; set; } = 100.0;
+	public double LanguageSkill { get; set; } = 100.0;
+	public double HandwritingSkill { get; set; } = 100.0;
+	public double ForgerySkill { get; set; }
+	public ILanguage Language => _gameworld.Languages.Get(_languageId);
+	public IScript Script => _gameworld.Scripts.Get(_scriptId);
+	public IColour Colour => _gameworld.Colours.Get(_colourId);
+
+	public int DocumentLength => Script is null ? Text.RawTextLength() : (int)(Text.RawTextLength() * Script.DocumentLengthModifier);
+
+	public ICanBeRead CreateReadable(IFuturemud gameworld)
+	{
+		var language = gameworld.Languages.Get(_languageId);
+		var script = gameworld.Scripts.Get(_scriptId);
+		var colour = gameworld.Colours.Get(_colourId);
+		if (language is null || script is null || colour is null)
+		{
+			throw new InvalidOperationException("Cannot create printed book content with missing language, script, or colour.");
+		}
+
+		return new PrintedWriting(gameworld, Text, language, script, Provenance, Style, colour, LiteracySkill,
+			LanguageSkill, HandwritingSkill, ForgerySkill);
+	}
+
+	public XElement SaveToXml()
+	{
+		return new XElement("Writing",
+			new XAttribute("Type", "printed"),
+			new XAttribute("Page", Page),
+			new XAttribute("Order", Order),
+			new XElement("Language", _languageId),
+			new XElement("Script", _scriptId),
+			new XElement("Colour", _colourId),
+			new XElement("Style", (int)Style),
+			new XElement("Provenance", new XCData(Provenance ?? string.Empty)),
+			new XElement("Text", new XCData(Text ?? string.Empty)),
+			new XElement("LiteracySkill", LiteracySkill),
+			new XElement("LanguageSkill", LanguageSkill),
+			new XElement("HandwritingSkill", HandwritingSkill),
+			new XElement("ForgerySkill", ForgerySkill)
+		);
+	}
+
+	public BookPageContentTemplate CloneForPage(int page, int order)
+	{
+		return new BookPageContentTemplate(_gameworld, page, order, Text, Language, Script, Provenance, Colour, Style)
+		{
+			LiteracySkill = LiteracySkill,
+			LanguageSkill = LanguageSkill,
+			HandwritingSkill = HandwritingSkill,
+			ForgerySkill = ForgerySkill
+		};
+	}
+
+	public static BookPageContentTemplate FromWriting(IFuturemud gameworld, int page, int order, IWriting writing)
+	{
+		var provenance = writing.Author?.Name ?? (writing.GetProperty("provenance")?.GetObject as string) ?? string.Empty;
+		return new BookPageContentTemplate(gameworld, page, order, writing.ParseFor(null), writing.Language, writing.Script,
+			provenance, writing.WritingColour, writing.Style)
+		{
+			LiteracySkill = writing.LiteracySkill,
+			LanguageSkill = writing.LanguageSkill,
+			HandwritingSkill = writing.HandwritingSkill,
+			ForgerySkill = writing.ForgerySkill
+		};
+	}
+}

--- a/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextConfiguring4.cs
+++ b/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextConfiguring4.cs
@@ -2252,7 +2252,7 @@ namespace MudSharp.Database
                 entity.HasOne(d => d.Author)
                     .WithMany(p => p.WritingsAuthor)
                     .HasForeignKey(d => d.AuthorId)
-                    .OnDelete(DeleteBehavior.ClientSetNull)
+                    .OnDelete(DeleteBehavior.SetNull)
                     .HasConstraintName("FK_Writings_Characters_Author");
 
                 entity.HasOne(d => d.Language)

--- a/MudsharpDatabaseLibrary/Migrations/20260506102652_PrintedWritingAuthorNullable.Designer.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260506102652_PrintedWritingAuthorNullable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MudSharp.Database;
 
@@ -11,9 +12,11 @@ using MudSharp.Database;
 namespace MudSharp.Migrations
 {
     [DbContext(typeof(FuturemudDatabaseContext))]
-    partial class FutureMUDContextModelSnapshot : ModelSnapshot
+    [Migration("20260506102652_PrintedWritingAuthorNullable")]
+    partial class PrintedWritingAuthorNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MudsharpDatabaseLibrary/Migrations/20260506102652_PrintedWritingAuthorNullable.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260506102652_PrintedWritingAuthorNullable.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MudSharp.Migrations
+{
+    /// <inheritdoc />
+    public partial class PrintedWritingAuthorNullable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Writings_Characters_Author",
+                table: "Writings");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "AuthorId",
+                table: "Writings",
+                type: "bigint(20)",
+                nullable: true,
+                oldClrType: typeof(long),
+                oldType: "bigint(20)");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Writings_Characters_Author",
+                table: "Writings",
+                column: "AuthorId",
+                principalTable: "Characters",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Writings_Characters_Author",
+                table: "Writings");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "AuthorId",
+                table: "Writings",
+                type: "bigint(20)",
+                nullable: false,
+                defaultValue: 0L,
+                oldClrType: typeof(long),
+                oldType: "bigint(20)",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Writings_Characters_Author",
+                table: "Writings",
+                column: "AuthorId",
+                principalTable: "Characters",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/MudsharpDatabaseLibrary/Models/Writing.cs
+++ b/MudsharpDatabaseLibrary/Models/Writing.cs
@@ -10,7 +10,7 @@ namespace MudSharp.Models
         public int Style { get; set; }
         public long LanguageId { get; set; }
         public long ScriptId { get; set; }
-        public long AuthorId { get; set; }
+        public long? AuthorId { get; set; }
         public long? TrueAuthorId { get; set; }
         public double HandwritingSkill { get; set; }
         public double LiteracySkill { get; set; }


### PR DESCRIPTION
## Summary
- Add printed writing as a first-class writing type with nullable author support and provenance-aware display
- Extend book components to support default titles and preloaded page content templates that instantiate independent live writings on load
- Add FutureProg helpers for adding printed writing, copying writing into books, and setting book titles
- Update item system docs to cover the new authoring and runtime model

## Testing
- Added focused unit coverage for printed writing loading, book prototype XML round-tripping, independent loaded copies, capacity validation, and FutureProg execution paths
- Built the database library and core runtime projects successfully
- Ran the targeted `PreloadedBookContentTests` and `FutureProgFunctionDocumentationTests` suites successfully