### PR TITLE
Add clan budgets, balance sheets, and payroll history

### DIFF
--- a/Design Documents/Clan_Command_Surface_and_Permissions.md
+++ b/Design Documents/Clan_Command_Surface_and_Permissions.md
@@ -23,6 +23,8 @@ The clan runtime now follows a thinner command-module pattern:
   - exposes the clan-owned runtime command surface.
 - `MudSharpCore/Community/Clan.CommandHandling.cs`
   - contains the concrete clan-owned implementations.
+- `MudSharpCore/Community/Clan.Finance.cs`
+  - contains clan-owned finance commands for appointment budgets, balance sheets, and payroll history.
 - `MudSharpCore/Community/ClanCommandUtilities.cs`
   - contains shared helper logic for appointment-chain authority, election helper selection, term-limit checks, and appointment-capacity calculations.
 
@@ -47,6 +49,9 @@ The following runtime actions are now owned by `IClan` / `Clan`:
 - `SetControllingAppointment`
 - `AppointExternal`
 - `DismissExternal`
+- `BudgetCommand`
+- `ShowBalanceSheet`
+- `ShowPayrollHistory`
 
 This is intentionally focused on operational clan behaviour. Builder-oriented commands that mutate multiple related entities or templates still live in `ClanModule` for now.
 
@@ -87,12 +92,15 @@ The command surface distinguishes between:
 - `CanViewClanStructure`
 - `CanViewClanStructureEqualRankOrLower`
 - `CanViewTreasury`
+- `CanCreateBudgets`
 
 The view logic now consistently uses those distinctions so that:
 
 - member rosters do not automatically imply full structure visibility;
 - office-holder visibility does not automatically imply financial visibility; and
 - lower-trust members can be limited to equal-or-lower-rank visibility when configured.
+
+Budget creation and closure use `CanCreateBudgets`. Reviewing budgets, budget audit rows, balance sheets, and payroll history uses `CanViewTreasury`, which is the clan-level financial-information privilege. Budget drawdown also allows the holder of the budgeted appointment, or a superior appointment in that appointment chain, to draw from that appointment's active budget without granting broad treasury visibility.
 
 ### Appointment-chain authority
 
@@ -109,6 +117,48 @@ That rule is used in places such as:
 - direct appointment to subordinate positions;
 - direct dismissal from subordinate positions; and
 - appointment creation/edit flows that are restricted to “under own” authority.
+
+Appointment budget drawdowns also use the appointment-chain helper, so a character who holds or controls the budgeted office can draw from that budget without needing broad budget-creation authority.
+
+## Runtime Finance Commands
+
+### Appointment budgets
+
+`clan budget <clan> list`
+
+`clan budget <clan> view <budget>`
+
+`clan budget <clan> audit [<budget>]`
+
+`clan budget <clan> create <appointment> <amount> "<interval>" <name>`
+
+`clan budget <clan> draw <budget> <amount> <reason>`
+
+`clan budget <clan> close <budget>`
+
+Appointment budgets are recurring-period allowances backed by the clan's default bank account. Each budget stores its recurring interval, current period window, period drawdown, and drawdown audit rows. Period windows roll forward lazily when the budget is reviewed or used; a new period resets the tracked drawdown while preserving historical transactions.
+
+Creating or closing a budget requires `CanCreateBudgets`. Drawing from a budget requires administrator authority, `CanCreateBudgets`, or appointment-chain authority over the assigned appointment. A successful drawdown withdraws from the clan bank account, issues a currency pile to the actor, and records the actor, amount, period window, bank balance after withdrawal, and audit reason.
+
+### Balance sheet
+
+`clan balance <clan>`
+
+`clan balance sheet <clan>`
+
+The balance sheet is gated by `CanViewTreasury`. It summarises clan-owned bank accounts, property value and lease revenue, leased-property commitments, shop current-period gross and net results, shop cash and bank balances, controlled economic-zone revenues, payroll commitments, budget commitments, budget remaining, and backpay liability.
+
+### Payroll history
+
+`clan payroll <clan>`
+
+`clan payroll <clan> member <who>`
+
+`clan payroll <clan> rank <rank>`
+
+`clan payroll <clan> appointment <appointment>`
+
+Payroll history is gated by `CanViewTreasury`. It records payroll accruals from normal payday processing, manual backpay adjustments, and pay collection events. Review commands can filter by individual member, rank, or appointment, and show both summary totals and recent audit rows.
 
 ## External Control Permissions
 

--- a/Design Documents/Economy_System_Runtime.md
+++ b/Design Documents/Economy_System_Runtime.md
@@ -326,6 +326,24 @@ Job listings currently include:
 
 The system is integrated with job-finding cells on economic zones and with command workflows in `EconomyModule`.
 
+### Clan Finance, Budgets, and Payroll History
+Clan finance is implemented across the clan and economy layers. Clans can nominate a default bank account, use that account for payroll float, and now use it as the funding source for appointment budgets.
+
+Appointment budgets are persisted as `ClanBudget` rows with:
+
+- a clan
+- an assigned appointment
+- a backing bank account and currency
+- an amount per recurring period
+- the current period start, end, and drawdown
+- an active flag
+
+Budget drawdowns are persisted as `ClanBudgetTransaction` rows. Each transaction records the budget, actor, backing bank account, currency, amount, MUD time, period window, bank balance after withdrawal, and audit reason. The runtime rolls the current period forward lazily when a budget is reviewed or used; historical drawdown rows remain available for audit.
+
+Clan balance-sheet review is a reporting surface rather than a separate ledger. It aggregates currently loaded economy state from clan-owned bank accounts, owned and leased properties, property lease revenue and commitments, shops tied to clan property or clan bank accounts, controlled economic-zone revenues, payroll commitments, budget commitments, and outstanding backpay.
+
+Clan payroll history is persisted separately from the employment/job subsystem. `ClanPayrollHistory` rows are written when clan payday processing accrues pay, when a character collects owed clan pay, and when authorised users make manual backpay adjustments. This gives clans an audit trail for their rank, appointment, and individual payroll activity without changing the broader `JobListingBase` / `OngoingJobListing` employment model.
+
 ### Estates
 Estates are now a live persisted subsystem.
 

--- a/Design Documents/Economy_System_Workflows_and_Integration.md
+++ b/Design Documents/Economy_System_Workflows_and_Integration.md
@@ -18,6 +18,7 @@ The current economy implementation is rich and only partially seed-driven. In pr
 | --- | --- |
 | `EconomyModule` | currencies, coins, banks, shops, auctions, jobs, markets, market influences, market categories, market populations, shoppers, player-facing buy and sell operations |
 | `PropertyModule` | property sale, lease, ownership, keys, short-term hotel room rental, and conveyancing-facing workflows |
+| `ClanModule` | clan bank-account assignment, appointment budgets, clan balance-sheet review, and clan payroll history |
 | `EditableItemHelperEconomy` | standardized admin creation and editing flows for property, auction houses, banks, coins, and shoppers |
 
 ### Practical implication
@@ -47,20 +48,22 @@ The current runtime supports a lot of optional depth, but the minimum viable pat
 5. Add any initial sales or profit taxes to each live economic zone.
 6. Create a bank if the world needs account-backed payments, property ownership, shop floats, or auction settlement.
 7. Add bank account types before expecting players, clans, or shops to use accounts meaningfully.
-8. Create at least one shop or other money sink/source if the world needs day-to-day commerce.
-9. Create stables in cells where players should be able to lodge mounts, if the game uses mounted travel.
-10. Point relevant shops at a market if pricing should reflect macroeconomic pressure rather than fixed local pricing only.
-11. Add job-finding cells, jobs, and employers if the world will use the employment system.
-12. Add conveyancing cells and property data if the world will use formal property ownership, sale, or leasing.
-13. For hotel-style short stays, configure property-backed hotel rooms after banks and properties exist, then add hotel taxes to the economic zone if rentals should be taxed.
-14. Decide whether estates are enabled for each zone, then add probate offices if players should interact with estates in the zone.
-15. Add morgue office and morgue storage cells if the world will use corpse recovery and morgue claim workflows.
+8. Assign clan bank accounts before using clan payroll float or appointment budgets.
+9. Create at least one shop or other money sink/source if the world needs day-to-day commerce.
+10. Create stables in cells where players should be able to lodge mounts, if the game uses mounted travel.
+11. Point relevant shops at a market if pricing should reflect macroeconomic pressure rather than fixed local pricing only.
+12. Add job-finding cells, jobs, and employers if the world will use the employment system.
+13. Add conveyancing cells and property data if the world will use formal property ownership, sale, or leasing.
+14. For hotel-style short stays, configure property-backed hotel rooms after banks and properties exist, then add hotel taxes to the economic zone if rentals should be taxed.
+15. Decide whether estates are enabled for each zone, then add probate offices if players should interact with estates in the zone.
+16. Add morgue office and morgue storage cells if the world will use corpse recovery and morgue claim workflows.
 
 ### Why this order fits the current implementation
 - currencies are prerequisites for almost every downstream object
 - economic zones are the tax and time hub
 - the stock economy package depends on `UsefulSeeder` market tags plus the earlier time and currency layers
 - banks unlock multiple other systems, including payment instruments and property administration
+- clan budgets and payroll float depend on a clan bank account that already exists
 - markets, shoppers, and jobs all assume earlier layers already exist
 - property and auctions depend heavily on cells, banks, and world-specific content
 - stables depend on mount-supporting cells, stable fee policy, and a stable bank account
@@ -144,6 +147,24 @@ Current builder-facing bank work includes:
 - creating account types
 - attaching open and close permission progs
 - tuning fees, interest, and payment-item limits
+
+### Clan Finance
+Clan finance depends on the clan system plus the bank/property/economic-zone layers. Builders should first create or select a clan-owned bank account with `clan set bankaccount <account>`, because appointment budgets and payroll float draw from that default account.
+
+Current player/admin-facing clan finance workflows include:
+
+- `clan budget <clan> list|view|audit|create|draw|close` for appointment budgets
+- `clan balance <clan>` or `clan balance sheet <clan>` for a cross-system balance sheet
+- `clan payroll <clan> [member|rank|appointment <which>]` for payroll audit history
+
+Budget creation and closure require the clan `CanCreateBudgets` privilege. Budget, balance-sheet, and payroll-history review require `CanViewTreasury`. Budget drawdown can also be performed by someone who holds or controls the budgeted appointment, so builders can give an office practical spending authority without exposing the whole treasury.
+
+Practical note:
+
+- appointment budgets are recurring-period allowances, not separate bank accounts
+- a drawdown withdraws from the clan bank account and issues cash to the actor
+- every drawdown stores an audit reason, actor, period window, amount, and bank balance after withdrawal
+- payroll history is clan payroll audit data, while the broader employment/job subsystem remains separate
 
 ### Markets, Categories, Influences, Populations, and Shoppers
 The market system becomes useful when the world wants more than fixed shop pricing.

--- a/FutureMUDLibrary/Community/IClan.cs
+++ b/FutureMUDLibrary/Community/IClan.cs
@@ -38,6 +38,7 @@ namespace MudSharp.Community
         List<IAppointment> Appointments { get; }
         List<IClanMembership> Memberships { get; }
         List<IPaygrade> Paygrades { get; }
+        List<IClanBudget> Budgets { get; }
         List<IExternalClanControl> ExternalControls { get; }
 
         RecurringInterval PayInterval { get; set; }
@@ -81,6 +82,9 @@ namespace MudSharp.Community
         void SetControllingAppointment(ICharacter actor, StringStack command);
         void AppointExternal(ICharacter actor, StringStack command);
         void DismissExternal(ICharacter actor, StringStack command);
+        void BudgetCommand(ICharacter actor, StringStack command);
+        void ShowBalanceSheet(ICharacter actor);
+        void ShowPayrollHistory(ICharacter actor, StringStack command);
 
         bool FreePosition(IAppointment appointment);
         bool FreePosition(IAppointment appointment, IClan liegeClan);

--- a/FutureMUDLibrary/Community/IClanBudget.cs
+++ b/FutureMUDLibrary/Community/IClanBudget.cs
@@ -1,0 +1,28 @@
+using MudSharp.Economy;
+using MudSharp.Economy.Currency;
+using MudSharp.Framework;
+using MudSharp.Framework.Save;
+using MudSharp.TimeAndDate;
+using MudSharp.TimeAndDate.Intervals;
+using System.Collections.Generic;
+
+namespace MudSharp.Community;
+
+public interface IClanBudget : IFrameworkItem, ISaveable
+{
+	IClan Clan { get; }
+	IAppointment Appointment { get; set; }
+	IBankAccount BankAccount { get; set; }
+	ICurrency Currency { get; }
+	decimal AmountPerPeriod { get; set; }
+	decimal CurrentPeriodDrawdown { get; }
+	decimal RemainingBudget { get; }
+	RecurringInterval PeriodInterval { get; set; }
+	MudDateTime CurrentPeriodStart { get; }
+	MudDateTime CurrentPeriodEnd { get; }
+	bool IsActive { get; set; }
+	IEnumerable<IClanBudgetTransaction> Transactions { get; }
+	void RollToCurrentPeriod();
+	void AddDrawdown(IClanBudgetTransaction transaction);
+	void Delete();
+}

--- a/FutureMUDLibrary/Community/IClanBudgetTransaction.cs
+++ b/FutureMUDLibrary/Community/IClanBudgetTransaction.cs
@@ -1,0 +1,21 @@
+using MudSharp.Character;
+using MudSharp.Economy;
+using MudSharp.Economy.Currency;
+using MudSharp.Framework;
+using MudSharp.TimeAndDate;
+
+namespace MudSharp.Community;
+
+public interface IClanBudgetTransaction : IFrameworkItem
+{
+	IClanBudget Budget { get; }
+	ICharacter Actor { get; }
+	IBankAccount BankAccount { get; }
+	ICurrency Currency { get; }
+	decimal Amount { get; }
+	MudDateTime TransactionTime { get; }
+	MudDateTime PeriodStart { get; }
+	MudDateTime PeriodEnd { get; }
+	decimal BankBalanceAfter { get; }
+	string Reason { get; }
+}

--- a/FutureMUDLibrary/Community/IClanPayrollHistoryEntry.cs
+++ b/FutureMUDLibrary/Community/IClanPayrollHistoryEntry.cs
@@ -1,0 +1,28 @@
+using MudSharp.Character;
+using MudSharp.Economy.Currency;
+using MudSharp.Framework;
+using MudSharp.TimeAndDate;
+
+namespace MudSharp.Community;
+
+public enum ClanPayrollHistoryType
+{
+	PayAccrued = 0,
+	ManualAdjustment = 1,
+	PayCollected = 2
+}
+
+public interface IClanPayrollHistoryEntry : IFrameworkItem
+{
+	IClan Clan { get; }
+	ICharacter Character { get; }
+	IRank Rank { get; }
+	IPaygrade Paygrade { get; }
+	IAppointment Appointment { get; }
+	ICharacter Actor { get; }
+	ICurrency Currency { get; }
+	decimal Amount { get; }
+	ClanPayrollHistoryType EntryType { get; }
+	MudDateTime DateTime { get; }
+	string Description { get; }
+}

--- a/FutureMUDLibrary/TimeAndDate/Intervals/RecurringInterval.cs
+++ b/FutureMUDLibrary/TimeAndDate/Intervals/RecurringInterval.cs
@@ -426,6 +426,19 @@ namespace MudSharp.TimeAndDate.Intervals
             return newDate;
         }
 
+        public MudDateTime GetNextDateTimeAfter(MudDateTime referenceDateTime)
+        {
+            MudDateTime newDate = IsOrdinalMonthly
+                ? AlignOrdinalDateTime(referenceDateTime, 1)
+                : new MudDateTime(referenceDateTime);
+            if (newDate <= referenceDateTime)
+            {
+                newDate = MoveDateTimeByInterval(newDate, 1);
+            }
+
+            return newDate;
+        }
+
         public MudDate GetNextDateExclusive(ICalendar whichCalendar, MudDate referenceDate)
         {
             MudDate newDate = IsOrdinalMonthly

--- a/MudSharpCore/Commands/Modules/ClanModule.cs
+++ b/MudSharpCore/Commands/Modules/ClanModule.cs
@@ -155,6 +155,9 @@ The following clan sub-commands are used to interact with clans:
 	#3clan dismiss <person> <clan> <appointment>#0 - dismisses a person from a clan appointment
 	#3clan reportdead <clan> <person>#0 - reports a person as dead or long-term missing
 	#3clan pay <person> <clan> <how much>#0 - manually adds backpay owing to a person
+	#3clan budget <clan> <...>#0 - manages appointment budgets for a clan
+	#3clan balance <clan>#0 - reviews a clan balance sheet
+	#3clan payroll <clan> [member|rank|appointment <which>]#0 - reviews payroll history
 	#3clan maxpay <clan> <max multiple backpay>#0 - sets the maximum backpay permissable for a clan
 	#3clan payinterval <clan> ""<every x days|weeks|months|years>""#0 - sets the pay interval
 	#3clan payinterval <clan> ""<every x days|weeks|months|years>"" [<date time>]#0 - sets the pay interval and the reference date time
@@ -231,6 +234,16 @@ All of the following commands must happen with an edited clan selected:
         {
             case "pay":
                 ClanPay(actor, ss);
+                return;
+            case "budget":
+                ClanBudget(actor, ss);
+                return;
+            case "balance":
+            case "balancesheet":
+                ClanBalanceSheet(actor, ss);
+                return;
+            case "payroll":
+                ClanPayroll(actor, ss);
                 return;
             case "invite":
                 ClanInvite(actor, ss);
@@ -368,6 +381,72 @@ All of the following commands must happen with an edited clan selected:
                 return;
         }
     }
+
+    private static void ClanBudget(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which clan do you want to manage budgets for?");
+            return;
+        }
+
+        IClan clan = GetTargetClan(actor, command.PopSpeech());
+        if (clan == null)
+        {
+            actor.OutputHandler.Send(actor.IsAdministrator(PermissionLevel.Admin)
+                ? "There is no such clan."
+                : "You are not a member of any such clan.");
+            return;
+        }
+
+        clan.BudgetCommand(actor, command);
+    }
+
+    private static void ClanBalanceSheet(ICharacter actor, StringStack command)
+    {
+        if (!command.IsFinished && command.PeekSpeech().EqualTo("sheet"))
+        {
+            command.PopSpeech();
+        }
+
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which clan do you want to review the balance sheet for?");
+            return;
+        }
+
+        IClan clan = GetTargetClan(actor, command.PopSpeech());
+        if (clan == null)
+        {
+            actor.OutputHandler.Send(actor.IsAdministrator(PermissionLevel.Admin)
+                ? "There is no such clan."
+                : "You are not a member of any such clan.");
+            return;
+        }
+
+        clan.ShowBalanceSheet(actor);
+    }
+
+    private static void ClanPayroll(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which clan do you want to review payroll history for?");
+            return;
+        }
+
+        IClan clan = GetTargetClan(actor, command.PopSpeech());
+        if (clan == null)
+        {
+            actor.OutputHandler.Send(actor.IsAdministrator(PermissionLevel.Admin)
+                ? "There is no such clan."
+                : "You are not a member of any such clan.");
+            return;
+        }
+
+        clan.ShowPayrollHistory(actor, command);
+    }
+
     private static void ClanRemove(ICharacter actor, StringStack ss)
     {
         IClan clan = actor.CombinedEffectsOfType<BuilderEditingEffect<IClan>>().FirstOrDefault()?.EditingItem;
@@ -2053,13 +2132,16 @@ Your next payday is {3}.
 
             foreach (KeyValuePair<ICurrency, Dictionary<ICoin, int>> currency in coinsToLoad)
             {
+                IEnumerable<Tuple<ICoin, int>> payAmount = currency.Value.Select(x => Tuple.Create(x.Key, x.Value)).ToList();
+                decimal paidAmount = payAmount.Sum(x => x.Item1.Value * x.Item2);
                 membership.BackPayDiciontary[currency.Key] = 0;
                 membership.Changed = true;
-                IEnumerable<Tuple<ICoin, int>> payAmount = currency.Value.Select(x => Tuple.Create(x.Key, x.Value));
+                ClanPayrollHistoryEntry.Create(membership, currency.Key, -paidAmount,
+                    ClanPayrollHistoryType.PayCollected, "Payroll collected", actor: actor);
                 IGameItem newItem = CurrencyGameItemComponentProto.CreateNewCurrencyPile(currency.Key, payAmount);
                 actor.Gameworld.Add(newItem);
                 actor.OutputHandler.Send(
-                    $"You are paid {newItem.HowSeen(actor)} ({currency.Key.Describe(payAmount.Sum(x => x.Item1.Value * x.Item2), CurrencyDescriptionPatternType.ShortDecimal).ColourValue()}).");
+                    $"You are paid {newItem.HowSeen(actor)} ({currency.Key.Describe(paidAmount, CurrencyDescriptionPatternType.ShortDecimal).ColourValue()}).");
                 if (actor.Body.CanGet(newItem, 0))
                 {
                     actor.Body.Get(newItem, silent: true);
@@ -2165,6 +2247,9 @@ Your next payday is {3}.
 
         targetMembership.BackPayDiciontary[actor.Currency] += amount;
         targetMembership.Changed = true;
+        ClanPayrollHistoryEntry.Create(targetMembership, actor.Currency, amount,
+            ClanPayrollHistoryType.ManualAdjustment,
+            $"Manual backpay adjustment by {actor.PersonalName.GetName(NameStyle.FullName)}", actor: actor);
         actor.OutputHandler.Send(
             $"You change the backpay owing to {targetMembership.PersonalName.GetName(NameStyle.FullName)} by {actor.Currency.Describe(amount, CurrencyDescriptionPatternType.Short).Colour(Telnet.Green)}, with their current backpay sitting at {actor.Currency.Describe(targetMembership.BackPayDiciontary[actor.Currency], CurrencyDescriptionPatternType.Short).Colour(Telnet.Green)}.");
     }
@@ -6995,6 +7080,9 @@ return 0",
         }
 
         targetMembership.AwardPay(actor.Currency, amount);
+        ClanPayrollHistoryEntry.Create(targetMembership, actor.Currency, amount,
+            ClanPayrollHistoryType.ManualAdjustment,
+            $"Manual backpay adjustment by {actor.PersonalName.GetName(NameStyle.FullName)}", actor: actor);
         actor.Send(
             $"You give {actor.Currency.Describe(amount, CurrencyDescriptionPatternType.Long)} in backpay to {targetMembership.PersonalName.GetName(NameStyle.FullName).Colour(Telnet.Green)} in the {clan.FullName.Colour(Telnet.Green)} clan.");
     }

--- a/MudSharpCore/Community/Clan.Finance.cs
+++ b/MudSharpCore/Community/Clan.Finance.cs
@@ -1,0 +1,759 @@
+using MoreLinq.Extensions;
+using MudSharp.Accounts;
+using MudSharp.Character;
+using MudSharp.Character.Name;
+using MudSharp.Database;
+using MudSharp.Economy;
+using MudSharp.Economy.Currency;
+using MudSharp.Economy.Property;
+using MudSharp.Framework;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Prototypes;
+using MudSharp.TimeAndDate.Date;
+using MudSharp.TimeAndDate.Intervals;
+using MudSharp.TimeAndDate.Time;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+#nullable enable
+
+namespace MudSharp.Community;
+
+public partial class Clan
+{
+	private const string ClanBudgetHelp = @"You can use the clan budget command in the following ways:
+
+	#3clan budget <clan> list#0 - lists appointment budgets
+	#3clan budget <clan> view <budget>#0 - reviews a budget and recent drawdowns
+	#3clan budget <clan> audit [<budget>]#0 - reviews drawdown audit history
+	#3clan budget <clan> create <appointment> <amount> ""<interval>"" <name>#0 - creates an appointment budget
+	#3clan budget <clan> draw <budget> <amount> <reason>#0 - draws money from a budget
+	#3clan budget <clan> close <budget>#0 - closes an active budget";
+
+	public void BudgetCommand(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send(ClanBudgetHelp.SubstituteANSIColour());
+			return;
+		}
+
+		switch (command.PopForSwitch())
+		{
+			case "list":
+			case "show":
+				BudgetList(actor);
+				return;
+			case "view":
+				BudgetView(actor, command);
+				return;
+			case "audit":
+			case "history":
+				BudgetAudit(actor, command);
+				return;
+			case "create":
+			case "new":
+			case "add":
+				BudgetCreate(actor, command);
+				return;
+			case "draw":
+			case "drawdown":
+			case "withdraw":
+				BudgetDraw(actor, command);
+				return;
+			case "close":
+			case "delete":
+			case "remove":
+				BudgetClose(actor, command);
+				return;
+			default:
+				actor.OutputHandler.Send(ClanBudgetHelp.SubstituteANSIColour());
+				return;
+		}
+	}
+
+	private bool CanReviewFinance(ICharacter actor, out IClanMembership? membership)
+	{
+		membership = ActorMembership(actor);
+		return CanViewFinances(actor, membership);
+	}
+
+	private bool CanCreateBudget(ICharacter actor, out IClanMembership? membership)
+	{
+		return HasPrivilege(actor, ClanPrivilegeType.CanCreateBudgets, out membership);
+	}
+
+	private static string DescribeAmount(ICurrency currency, decimal amount)
+	{
+		return currency.Describe(amount, CurrencyDescriptionPatternType.ShortDecimal).ColourValue();
+	}
+
+	private static string DescribeTotals(IEnumerable<(ICurrency Currency, decimal Amount)> totals)
+	{
+		var list = totals
+			.GroupBy(x => x.Currency)
+			.Select(x => DescribeAmount(x.Key, x.Sum(y => y.Amount)))
+			.ToList();
+		return list.Any() ? list.ListToString() : "None".ColourError();
+	}
+
+	private void BudgetList(ICharacter actor)
+	{
+		if (!CanReviewFinance(actor, out _))
+		{
+			actor.OutputHandler.Send($"You are not allowed to review the finances of {FullName.ColourName()}.");
+			return;
+		}
+
+		foreach (var budget in Budgets)
+		{
+			budget.RollToCurrentPeriod();
+		}
+
+		if (!Budgets.Any())
+		{
+			actor.OutputHandler.Send($"{FullName.ColourName()} has no appointment budgets.");
+			return;
+		}
+
+		actor.OutputHandler.Send(StringUtilities.GetTextTable(
+			from budget in Budgets.OrderBy(x => x.Appointment.Name).ThenBy(x => x.Name)
+			select new[]
+			{
+				budget.Id.ToString("N0", actor),
+				budget.Name.TitleCase(),
+				budget.Appointment.Name.TitleCase(),
+				DescribeAmount(budget.Currency, budget.AmountPerPeriod),
+				DescribeAmount(budget.Currency, budget.CurrentPeriodDrawdown),
+				DescribeAmount(budget.Currency, budget.RemainingBudget),
+				budget.PeriodInterval.Describe(Calendar),
+				budget.IsActive.ToColouredString()
+			},
+			new[] { "Id", "Budget", "Appointment", "Per Period", "Drawn", "Remaining", "Period", "Active?" },
+			actor.Account.LineFormatLength,
+			colour: Telnet.Green,
+			truncatableColumnIndex: 1,
+			unicodeTable: actor.Account.UseUnicode));
+	}
+
+	private void BudgetView(ICharacter actor, StringStack command)
+	{
+		if (!CanReviewFinance(actor, out _))
+		{
+			actor.OutputHandler.Send($"You are not allowed to review the finances of {FullName.ColourName()}.");
+			return;
+		}
+
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which budget do you want to view?");
+			return;
+		}
+
+		var budget = Budgets.GetByIdOrName(command.SafeRemainingArgument);
+		if (budget is null)
+		{
+			actor.OutputHandler.Send($"{FullName.ColourName()} has no such budget.");
+			return;
+		}
+
+		budget.RollToCurrentPeriod();
+		var sb = new StringBuilder();
+		sb.AppendLine($"Budget #{budget.Id.ToString("N0", actor)} - {budget.Name.TitleCase().ColourName()}");
+		sb.AppendLine();
+		sb.AppendLine($"Appointment: {budget.Appointment.Name.TitleCase().ColourName()}");
+		sb.AppendLine($"Account: {budget.BankAccount.AccountReference.ColourName()}");
+		sb.AppendLine($"Status: {budget.IsActive.ToColouredString()}");
+		sb.AppendLine($"Period: {budget.PeriodInterval.Describe(Calendar).ColourValue()}");
+		sb.AppendLine($"Current Window: {budget.CurrentPeriodStart.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()} to {budget.CurrentPeriodEnd.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}");
+		sb.AppendLine($"Per Period: {DescribeAmount(budget.Currency, budget.AmountPerPeriod)}");
+		sb.AppendLine($"Drawn This Period: {DescribeAmount(budget.Currency, budget.CurrentPeriodDrawdown)}");
+		sb.AppendLine($"Remaining This Period: {DescribeAmount(budget.Currency, budget.RemainingBudget)}");
+		sb.AppendLine();
+		AppendBudgetTransactions(actor, sb, budget.Transactions.OrderByDescending(x => x.TransactionTime).Take(10));
+		actor.OutputHandler.Send(sb.ToString());
+	}
+
+	private void BudgetAudit(ICharacter actor, StringStack command)
+	{
+		if (!CanReviewFinance(actor, out _))
+		{
+			actor.OutputHandler.Send($"You are not allowed to review the finances of {FullName.ColourName()}.");
+			return;
+		}
+
+		IEnumerable<IClanBudgetTransaction> transactions;
+		if (command.IsFinished)
+		{
+			transactions = Budgets.SelectMany(x => x.Transactions);
+		}
+		else
+		{
+			var budget = Budgets.GetByIdOrName(command.SafeRemainingArgument);
+			if (budget is null)
+			{
+				actor.OutputHandler.Send($"{FullName.ColourName()} has no such budget.");
+				return;
+			}
+
+			transactions = budget.Transactions;
+		}
+
+		var sb = new StringBuilder();
+		sb.AppendLine($"Budget Audit for {FullName.ColourName()}");
+		sb.AppendLine();
+		AppendBudgetTransactions(actor, sb, transactions.OrderByDescending(x => x.TransactionTime).Take(50));
+		actor.OutputHandler.Send(sb.ToString());
+	}
+
+	private static void AppendBudgetTransactions(ICharacter actor, StringBuilder sb,
+		IEnumerable<IClanBudgetTransaction> transactions)
+	{
+		var rows = transactions.ToList();
+		if (!rows.Any())
+		{
+			sb.AppendLine("No drawdowns have been recorded.");
+			return;
+		}
+
+		sb.AppendLine(StringUtilities.GetTextTable(
+			from transaction in rows
+			select new[]
+			{
+				transaction.TransactionTime.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short),
+				transaction.Budget.Name.TitleCase(),
+				transaction.Actor?.PersonalName.GetName(NameStyle.FullName) ?? "Unknown",
+				DescribeAmount(transaction.Currency, transaction.Amount),
+				DescribeAmount(transaction.Currency, transaction.BankBalanceAfter),
+				transaction.Reason
+			},
+			new[] { "Date", "Budget", "Actor", "Amount", "Bank After", "Reason" },
+			actor.Account.LineFormatLength,
+			colour: Telnet.Green,
+			truncatableColumnIndex: 5,
+			unicodeTable: actor.Account.UseUnicode));
+	}
+
+	private void BudgetCreate(ICharacter actor, StringStack command)
+	{
+		if (!CanCreateBudget(actor, out _))
+		{
+			actor.OutputHandler.Send($"You are not allowed to create budgets for {FullName.ColourName()}.");
+			return;
+		}
+
+		if (ClanBankAccount is null)
+		{
+			actor.OutputHandler.Send($"{FullName.ColourName()} does not have a default bank account configured.");
+			return;
+		}
+
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which appointment should this budget belong to?");
+			return;
+		}
+
+		var appointment = Appointments.GetByIdOrName(command.PopSpeech());
+		if (appointment is null)
+		{
+			actor.OutputHandler.Send($"{FullName.ColourName()} has no such appointment.");
+			return;
+		}
+
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("How much should this budget allow per period?");
+			return;
+		}
+
+		if (!ClanBankAccount.Currency.TryGetBaseCurrency(command.PopSpeech(), out var amount) || amount <= 0.0M)
+		{
+			actor.OutputHandler.Send($"That is not a valid positive amount of {ClanBankAccount.Currency.Name.ColourName()}.");
+			return;
+		}
+
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("What recurring interval should this budget cover?");
+			return;
+		}
+
+		var intervalText = command.PopSpeech();
+		if (!RecurringInterval.TryParse(intervalText, Calendar, out var interval, out var error))
+		{
+			actor.OutputHandler.Send($"That is not a valid recurring interval: {error}");
+			return;
+		}
+
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("What should this budget be called?");
+			return;
+		}
+
+		var name = command.SafeRemainingArgument;
+		if (Budgets.Any(x => x.Name.EqualTo(name)))
+		{
+			actor.OutputHandler.Send($"{FullName.ColourName()} already has a budget called {name.ColourName()}.");
+			return;
+		}
+
+		var budget = new ClanBudget(this, appointment, ClanBankAccount, name, amount, interval);
+		Budgets.Add(budget);
+		actor.OutputHandler.Send(
+			$"You create the {budget.Name.ColourName()} budget for {appointment.Name.ColourName()}, allowing {DescribeAmount(budget.Currency, amount)} {interval.Describe(Calendar).ColourValue()} from {ClanBankAccount.AccountReference.ColourName()}.");
+	}
+
+	private void BudgetClose(ICharacter actor, StringStack command)
+	{
+		if (!CanCreateBudget(actor, out _))
+		{
+			actor.OutputHandler.Send($"You are not allowed to close budgets for {FullName.ColourName()}.");
+			return;
+		}
+
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which budget do you want to close?");
+			return;
+		}
+
+		var budget = Budgets.GetByIdOrName(command.SafeRemainingArgument);
+		if (budget is null)
+		{
+			actor.OutputHandler.Send($"{FullName.ColourName()} has no such budget.");
+			return;
+		}
+
+		budget.IsActive = false;
+		budget.Changed = true;
+		actor.OutputHandler.Send($"The {budget.Name.ColourName()} budget is now closed.");
+	}
+
+	private void BudgetDraw(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which budget do you want to draw from?");
+			return;
+		}
+
+		var budget = Budgets.GetByIdOrName(command.PopSpeech());
+		if (budget is null)
+		{
+			actor.OutputHandler.Send($"{FullName.ColourName()} has no such budget.");
+			return;
+		}
+
+		var actorMembership = ActorMembership(actor);
+		var canDraw = actor.IsAdministrator(PermissionLevel.Admin) ||
+		              actorMembership?.NetPrivileges.HasFlag(ClanPrivilegeType.CanCreateBudgets) == true ||
+		              ClanCommandUtilities.HoldsOrControlsAppointment(actorMembership, budget.Appointment);
+		if (!canDraw)
+		{
+			actor.OutputHandler.Send($"You are not allowed to draw down the {budget.Name.ColourName()} budget.");
+			return;
+		}
+
+		if (!budget.IsActive)
+		{
+			actor.OutputHandler.Send($"The {budget.Name.ColourName()} budget is not active.");
+			return;
+		}
+
+		if (budget.BankAccount is null)
+		{
+			actor.OutputHandler.Send($"The {budget.Name.ColourName()} budget does not have a bank account configured.");
+			return;
+		}
+
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("How much do you want to draw from that budget?");
+			return;
+		}
+
+		if (!budget.Currency.TryGetBaseCurrency(command.PopSpeech(), out var amount) || amount <= 0.0M)
+		{
+			actor.OutputHandler.Send($"That is not a valid positive amount of {budget.Currency.Name.ColourName()}.");
+			return;
+		}
+
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("What is the audit reason for this drawdown?");
+			return;
+		}
+
+		budget.RollToCurrentPeriod();
+		if (amount > budget.RemainingBudget)
+		{
+			actor.OutputHandler.Send(
+				$"That would exceed the remaining budget for this period. Remaining: {DescribeAmount(budget.Currency, budget.RemainingBudget)}.");
+			return;
+		}
+
+		var canWithdraw = budget.BankAccount.CanWithdraw(amount, false);
+		if (!canWithdraw.Truth)
+		{
+			actor.OutputHandler.Send(canWithdraw.Error);
+			return;
+		}
+
+		var reason = command.SafeRemainingArgument;
+		budget.BankAccount.WithdrawFromTransaction(amount, $"Clan budget {budget.Name}: {reason}");
+		var transaction = new ClanBudgetTransaction(budget, actor, amount, reason);
+		budget.AddDrawdown(transaction);
+
+		var payAmount = budget.Currency.FindCoinsForAmount(amount, out _);
+		IGameItem newItem = CurrencyGameItemComponentProto.CreateNewCurrencyPile(budget.Currency, payAmount);
+		actor.Gameworld.Add(newItem);
+		if (actor.Body.CanGet(newItem, 0))
+		{
+			actor.Body.Get(newItem, silent: true);
+		}
+		else
+		{
+			newItem.RoomLayer = actor.RoomLayer;
+			actor.Location.Insert(newItem, true);
+		}
+
+		actor.OutputHandler.Send(
+			$"You draw {DescribeAmount(budget.Currency, amount)} from the {budget.Name.ColourName()} budget. {newItem.HowSeen(actor).ColourName()} has been issued to you.");
+	}
+
+	public void ShowBalanceSheet(ICharacter actor)
+	{
+		if (!CanReviewFinance(actor, out _))
+		{
+			actor.OutputHandler.Send($"You are not allowed to review the finances of {FullName.ColourName()}.");
+			return;
+		}
+
+		foreach (var budget in Budgets)
+		{
+			budget.RollToCurrentPeriod();
+		}
+
+		var accounts = Gameworld.Banks
+			.SelectMany(x => x.BankAccounts)
+			.Where(x => x.IsAccountOwner(this))
+			.ToList();
+		var ownedProperties = Gameworld.Properties
+			.Where(x => x.PropertyOwners.Any(y => y.Owner == this))
+			.ToList();
+		var leasedProperties = Gameworld.Properties
+			.Where(x => x.Lease?.Leaseholder == this)
+			.ToList();
+		var propertyShops = ownedProperties.Concat(leasedProperties)
+			.SelectMany(x => x.PropertyLocations.Select(y => y.Shop).Where(y => y is not null))
+			.Distinct()
+			.ToList();
+		var bankOwnedShops = Gameworld.Shops
+			.Where(x => x.BankAccount?.IsAccountOwner(this) == true)
+			.ToList();
+		var shops = propertyShops
+			.Concat(bankOwnedShops)
+			.Distinct()
+			.ToList();
+		var controlledZones = Gameworld.EconomicZones
+			.Where(x => x.ControllingClan == this)
+			.ToList();
+
+		var sb = new StringBuilder();
+		sb.AppendLine($"Balance Sheet for {FullName.ColourName()}");
+		sb.AppendLine();
+		sb.AppendLine("Bank Assets:");
+		if (accounts.Any())
+		{
+			sb.AppendLine(StringUtilities.GetTextTable(
+				from account in accounts.OrderBy(x => x.Bank.Name).ThenBy(x => x.AccountNumber)
+				select new[]
+				{
+					account.AccountReference,
+					account.Name,
+					account.Bank.Name,
+					account.Currency.Name.TitleCase(),
+					DescribeAmount(account.Currency, account.CurrentBalance),
+					DescribeAmount(account.Currency, account.MaximumWithdrawal())
+				},
+				new[] { "Account", "Name", "Bank", "Currency", "Balance", "Available" },
+				actor.Account.LineFormatLength,
+				colour: Telnet.Green,
+				truncatableColumnIndex: 1,
+				unicodeTable: actor.Account.UseUnicode));
+		}
+		else
+		{
+			sb.AppendLine("\tNo clan-owned bank accounts.");
+		}
+
+		sb.AppendLine();
+		sb.AppendLine("Property Position:");
+		sb.AppendLine($"Owned Value: {DescribeTotals(ownedProperties.SelectMany(PropertyValueTotals))}");
+		sb.AppendLine($"Owned Lease Revenue: {DescribeTotals(ownedProperties.SelectMany(PropertyRevenueTotals))}");
+		sb.AppendLine($"Leased Commitments: {DescribeTotals(leasedProperties.Select(x => (x.EconomicZone.Currency, x.Lease?.PricePerInterval ?? 0.0M)))}");
+		if (ownedProperties.Any() || leasedProperties.Any())
+		{
+			sb.AppendLine(StringUtilities.GetTextTable(
+				from property in ownedProperties.Concat(leasedProperties).Distinct().OrderBy(x => x.Name)
+				select new[]
+				{
+					property.Name,
+					ownedProperties.Contains(property) ? "Owner" : "Leaseholder",
+					property.EconomicZone.Currency.Describe(property.LastSaleValue, CurrencyDescriptionPatternType.ShortDecimal),
+					property.Lease is null ? "None" : property.EconomicZone.Currency.Describe(property.Lease.PricePerInterval, CurrencyDescriptionPatternType.ShortDecimal),
+					property.Lease is null ? "None" : property.EconomicZone.Currency.Describe(property.Lease.PaymentBalance, CurrencyDescriptionPatternType.ShortDecimal)
+				},
+				new[] { "Property", "Role", "Last Value", "Lease Rate", "Lease Balance" },
+				actor.Account.LineFormatLength,
+				colour: Telnet.Green,
+				truncatableColumnIndex: 0,
+				unicodeTable: actor.Account.UseUnicode));
+		}
+
+		sb.AppendLine();
+		sb.AppendLine("Shop Position:");
+		if (shops.Any())
+		{
+			sb.AppendLine(StringUtilities.GetTextTable(
+				from shop in shops.OrderBy(x => x.Name)
+				let periodStart = shop.EconomicZone.CurrentFinancialPeriod.FinancialPeriodStart
+				let transactions = shop.TransactionRecords.Where(x => x.RealDateTime >= periodStart).ToList()
+				select new[]
+				{
+					shop.Name,
+					shop.EconomicZone.Name,
+					DescribeAmount(shop.Currency, transactions.Where(x => x.TransactionType == ShopTransactionType.Sale).Sum(x => x.PretaxValue)),
+					DescribeAmount(shop.Currency, transactions.Sum(x => x.NetValue)),
+					DescribeAmount(shop.Currency, shop.CashBalance),
+					shop.BankAccount is null ? "None" : DescribeAmount(shop.BankAccount.Currency, shop.BankAccount.CurrentBalance),
+					DescribeAmount(shop.Currency, shop.EconomicZone.OutstandingTaxesForShop(shop))
+				},
+				new[] { "Shop", "Zone", "Gross CFP", "Net CFP", "Cash", "Bank", "Taxes" },
+				actor.Account.LineFormatLength,
+				colour: Telnet.Green,
+				truncatableColumnIndex: 0,
+				unicodeTable: actor.Account.UseUnicode));
+		}
+		else
+		{
+			sb.AppendLine("\tNo shops are tied to clan accounts or clan-owned/leased properties.");
+		}
+
+		sb.AppendLine();
+		sb.AppendLine("Economic Zone Revenues:");
+		if (controlledZones.Any())
+		{
+			sb.AppendLine(StringUtilities.GetTextTable(
+				from zone in controlledZones.OrderBy(x => x.Name)
+				select new[]
+				{
+					zone.Name,
+					DescribeAmount(zone.Currency, zone.TotalRevenueHeld),
+					DescribeAmount(zone.Currency, zone.HistoricalRevenues.Where(x => x.Period == zone.CurrentFinancialPeriod).Select(x => x.TotalTaxRevenue).DefaultIfEmpty(0.0M).First()),
+					DescribeAmount(zone.Currency, zone.OutstandingTaxesForShop(null))
+				},
+				new[] { "Zone", "Held Revenue", "Current Revenue", "Shop Taxes" },
+				actor.Account.LineFormatLength,
+				colour: Telnet.Green,
+				truncatableColumnIndex: 0,
+				unicodeTable: actor.Account.UseUnicode));
+		}
+		else
+		{
+			sb.AppendLine("\tNo economic zones are controlled by this clan.");
+		}
+
+		sb.AppendLine();
+		sb.AppendLine($"Payroll Commitment Per Payday: {DescribeTotals(PayrollCommitments())}");
+		sb.AppendLine($"Budget Commitment Per Period: {DescribeTotals(Budgets.Where(x => x.IsActive).Select(x => (x.Currency, x.AmountPerPeriod)))}");
+		sb.AppendLine($"Budget Remaining This Period: {DescribeTotals(Budgets.Where(x => x.IsActive).Select(x => (x.Currency, x.RemainingBudget)))}");
+		sb.AppendLine($"Backpay Liability: {DescribeTotals(Memberships.SelectMany(x => x.BackPayDiciontary.Select(y => (y.Key, y.Value))))}");
+		actor.OutputHandler.Send(sb.ToString());
+	}
+
+	private IEnumerable<(ICurrency Currency, decimal Amount)> PropertyValueTotals(IProperty property)
+	{
+		return property.PropertyOwners
+			.Where(x => x.Owner == this)
+			.Select(x => (property.EconomicZone.Currency, property.LastSaleValue * x.ShareOfOwnership));
+	}
+
+	private IEnumerable<(ICurrency Currency, decimal Amount)> PropertyRevenueTotals(IProperty property)
+	{
+		if (property.Lease is null)
+		{
+			return Enumerable.Empty<(ICurrency Currency, decimal Amount)>();
+		}
+
+		return property.PropertyOwners
+			.Where(x => x.Owner == this)
+			.Select(x => (property.EconomicZone.Currency, property.Lease.PricePerInterval * x.ShareOfOwnership));
+	}
+
+	private IEnumerable<(ICurrency Currency, decimal Amount)> PayrollCommitments()
+	{
+		foreach (var membership in Memberships.Where(x => !x.IsArchivedMembership))
+		{
+			if (membership.Paygrade is not null)
+			{
+				yield return (membership.Paygrade.PayCurrency, membership.Paygrade.PayAmount);
+			}
+
+			foreach (var appointment in membership.Appointments.Where(x => x.Paygrade is not null))
+			{
+				yield return (appointment.Paygrade.PayCurrency, appointment.Paygrade.PayAmount);
+			}
+		}
+	}
+
+	public void ShowPayrollHistory(ICharacter actor, StringStack command)
+	{
+		if (!CanReviewFinance(actor, out _))
+		{
+			actor.OutputHandler.Send($"You are not allowed to review payroll history for {FullName.ColourName()}.");
+			return;
+		}
+
+		long? characterId = null;
+		long? rankId = null;
+		long? appointmentId = null;
+		string filterDescription = "all members";
+
+		if (!command.IsFinished)
+		{
+			switch (command.PopForSwitch())
+			{
+				case "member":
+				case "person":
+				case "individual":
+					if (command.IsFinished)
+					{
+						actor.OutputHandler.Send("Which member do you want to review?");
+						return;
+					}
+
+					var membership = GetMembershipByName(command.SafeRemainingArgument);
+					if (membership is null)
+					{
+						var target = actor.TargetActor(command.SafeRemainingArgument);
+						membership = target?.ClanMemberships.FirstOrDefault(x => x.Clan == this);
+					}
+
+					if (membership is null)
+					{
+						actor.OutputHandler.Send($"{FullName.ColourName()} has no such member.");
+						return;
+					}
+
+					characterId = membership.MemberId;
+					filterDescription = membership.PersonalName.GetName(NameStyle.FullName);
+					break;
+				case "rank":
+					if (command.IsFinished)
+					{
+						actor.OutputHandler.Send("Which rank do you want to review?");
+						return;
+					}
+
+					var rank = Ranks.GetByIdOrName(command.SafeRemainingArgument);
+					if (rank is null)
+					{
+						actor.OutputHandler.Send($"{FullName.ColourName()} has no such rank.");
+						return;
+					}
+
+					rankId = rank.Id;
+					filterDescription = $"rank {rank.Name.TitleCase()}";
+					break;
+				case "appointment":
+				case "position":
+					if (command.IsFinished)
+					{
+						actor.OutputHandler.Send("Which appointment do you want to review?");
+						return;
+					}
+
+					var appointment = Appointments.GetByIdOrName(command.SafeRemainingArgument);
+					if (appointment is null)
+					{
+						actor.OutputHandler.Send($"{FullName.ColourName()} has no such appointment.");
+						return;
+					}
+
+					appointmentId = appointment.Id;
+					filterDescription = $"appointment {appointment.Name.TitleCase()}";
+					break;
+				case "all":
+				case "summary":
+					break;
+				default:
+					actor.OutputHandler.Send(
+						"Use #3clan payroll <clan>#0, #3clan payroll <clan> member <who>#0, #3clan payroll <clan> rank <rank>#0, or #3clan payroll <clan> appointment <appointment>#0.".SubstituteANSIColour());
+					return;
+			}
+		}
+
+		List<MudSharp.Models.ClanPayrollHistory> rows;
+		using (new FMDB())
+		{
+			var query = FMDB.Context.ClanPayrollHistories.Where(x => x.ClanId == Id);
+			if (characterId.HasValue)
+			{
+				query = query.Where(x => x.CharacterId == characterId.Value);
+			}
+
+			if (rankId.HasValue)
+			{
+				query = query.Where(x => x.RankId == rankId.Value);
+			}
+
+			if (appointmentId.HasValue)
+			{
+				query = query.Where(x => x.AppointmentId == appointmentId.Value);
+			}
+
+			rows = query.OrderByDescending(x => x.Id).ToList();
+		}
+
+		if (!rows.Any())
+		{
+			actor.OutputHandler.Send($"There is no payroll history for {filterDescription.ColourName()} in {FullName.ColourName()}.");
+			return;
+		}
+
+		var entries = rows.Select(x => new ClanPayrollHistoryEntry(x, this)).ToList();
+		var sb = new StringBuilder();
+		sb.AppendLine($"Payroll History for {FullName.ColourName()} ({filterDescription})");
+		sb.AppendLine();
+		sb.AppendLine($"Total Accrued: {DescribeTotals(entries.Where(x => x.EntryType != ClanPayrollHistoryType.PayCollected).Select(x => (x.Currency, x.Amount)))}");
+		sb.AppendLine($"Total Collected: {DescribeTotals(entries.Where(x => x.EntryType == ClanPayrollHistoryType.PayCollected).Select(x => (x.Currency, -x.Amount)))}");
+		if (entries.Count > 50)
+		{
+			sb.AppendLine($"Showing Latest: {50.ToString("N0", actor)} of {entries.Count.ToString("N0", actor)} entries");
+		}
+		sb.AppendLine();
+		sb.AppendLine(StringUtilities.GetTextTable(
+			from entry in entries.Take(50)
+			select new[]
+			{
+				entry.DateTime.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short),
+				entry.EntryType.DescribeEnum(),
+				entry.Character?.PersonalName.GetName(NameStyle.FullName) ?? "Unknown",
+				entry.Rank?.Name.TitleCase() ?? "Unknown",
+				entry.Appointment?.Name.TitleCase() ?? "None",
+				DescribeAmount(entry.Currency, entry.Amount),
+				entry.Description
+			},
+			new[] { "Date", "Type", "Member", "Rank", "Appointment", "Amount", "Detail" },
+			actor.Account.LineFormatLength,
+			colour: Telnet.Green,
+			truncatableColumnIndex: 6,
+			unicodeTable: actor.Account.UseUnicode));
+		actor.OutputHandler.Send(sb.ToString());
+	}
+}

--- a/MudSharpCore/Community/Clan.cs
+++ b/MudSharpCore/Community/Clan.cs
@@ -217,11 +217,17 @@ public partial class Clan : SaveableItem, IClan
             if (member.Paygrade != null)
             {
                 member.AwardPay(member.Paygrade.PayCurrency, member.Paygrade.PayAmount);
+                ClanPayrollHistoryEntry.Create(member, member.Paygrade.PayCurrency, member.Paygrade.PayAmount,
+                    ClanPayrollHistoryType.PayAccrued,
+                    $"Paygrade {member.Paygrade.Name} payroll accrual", member.Paygrade);
             }
 
             foreach (IAppointment appointment in member.Appointments.Where(x => x.Paygrade != null))
             {
                 member.AwardPay(appointment.Paygrade.PayCurrency, appointment.Paygrade.PayAmount);
+                ClanPayrollHistoryEntry.Create(member, appointment.Paygrade.PayCurrency, appointment.Paygrade.PayAmount,
+                    ClanPayrollHistoryType.PayAccrued,
+                    $"Appointment {appointment.Name} payroll accrual", appointment.Paygrade, appointment);
             }
         }
 
@@ -316,6 +322,9 @@ public partial class Clan : SaveableItem, IClan
 
     private readonly List<IPaygrade> _paygrades = new();
     public virtual List<IPaygrade> Paygrades => _paygrades;
+
+    private readonly List<IClanBudget> _budgets = new();
+    public virtual List<IClanBudget> Budgets => _budgets;
 
     public virtual List<IExternalClanControl> ExternalControls { get; } = new();
 
@@ -481,6 +490,14 @@ public partial class Clan : SaveableItem, IClan
         }
 
 #if DEBUG
+        ConsoleUtilities.WriteLine($"...Clan #6{FullName}#0...Loading budgets [#2{sw.ElapsedMilliseconds}ms#0]");
+#endif
+        foreach (Models.ClanBudget item in clan.ClanBudgets)
+        {
+            _budgets.Add(new ClanBudget(item, this));
+        }
+
+#if DEBUG
         ConsoleUtilities.WriteLine($"...Clan #6{FullName}#0...Loading memberships [#2{sw.ElapsedMilliseconds}ms#0]");
 #endif
         foreach (Models.ClanMembership item in memberships.Where(x => x.ClanId == Id))
@@ -611,6 +628,12 @@ public partial class Clan : SaveableItem, IClan
                 item.Delete();
                 ExternalControls.Remove(item);
             }
+        }
+
+        foreach (var budget in Budgets.Where(x => x.Appointment == appointment).ToList())
+        {
+            budget.Delete();
+            Budgets.Remove(budget);
         }
     }
 

--- a/MudSharpCore/Community/ClanBudget.cs
+++ b/MudSharpCore/Community/ClanBudget.cs
@@ -1,0 +1,189 @@
+using MudSharp.Database;
+using MudSharp.Economy;
+using MudSharp.Economy.Currency;
+using MudSharp.Framework;
+using MudSharp.Framework.Save;
+using MudSharp.TimeAndDate;
+using MudSharp.TimeAndDate.Intervals;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MudSharp.Community;
+
+public class ClanBudget : SaveableItem, IClanBudget
+{
+	private MudDateTime _currentPeriodStart;
+	private MudDateTime _currentPeriodEnd;
+	private decimal _currentPeriodDrawdown;
+	private long _bankAccountId;
+	private IBankAccount _bankAccount;
+	private readonly List<IClanBudgetTransaction> _transactions = new();
+
+	public ClanBudget(MudSharp.Models.ClanBudget budget, IClan clan)
+	{
+		Gameworld = ((Clan)clan).Gameworld;
+		_id = budget.Id;
+		_name = budget.Name;
+		Clan = clan;
+		Appointment = clan.Appointments.First(x => x.Id == budget.AppointmentId);
+		_bankAccountId = budget.BankAccountId;
+		Currency = Gameworld.Currencies.Get(budget.CurrencyId);
+		AmountPerPeriod = budget.AmountPerPeriod;
+		PeriodInterval = new RecurringInterval
+		{
+			Type = (IntervalType)budget.PeriodIntervalType,
+			IntervalAmount = budget.PeriodIntervalModifier,
+			Modifier = budget.PeriodIntervalOther,
+			SecondaryModifier = budget.PeriodIntervalOtherSecondary,
+			OrdinalFallbackMode = (OrdinalFallbackMode)budget.PeriodIntervalFallback
+		};
+		_currentPeriodStart = MudDateTime.FromStoredStringOrFallback(budget.CurrentPeriodStart, Gameworld,
+			StoredMudDateTimeFallback.CurrentDateTime, "ClanBudget", budget.Id, budget.Name, "CurrentPeriodStart");
+		_currentPeriodEnd = MudDateTime.FromStoredStringOrFallback(budget.CurrentPeriodEnd, Gameworld,
+			StoredMudDateTimeFallback.CurrentDateTime, "ClanBudget", budget.Id, budget.Name, "CurrentPeriodEnd");
+		_currentPeriodDrawdown = budget.CurrentPeriodDrawdown;
+		IsActive = budget.IsActive;
+
+		foreach (var transaction in budget.ClanBudgetTransactions)
+		{
+			_transactions.Add(new ClanBudgetTransaction(transaction, this));
+		}
+	}
+
+	public ClanBudget(Clan clan, IAppointment appointment, IBankAccount bankAccount, string name, decimal amount,
+		RecurringInterval interval)
+	{
+		Gameworld = clan.Gameworld;
+		Clan = clan;
+		Appointment = appointment;
+		_bankAccount = bankAccount;
+		_bankAccountId = bankAccount.Id;
+		Currency = bankAccount.Currency;
+		_name = name;
+		AmountPerPeriod = amount;
+		PeriodInterval = interval;
+		_currentPeriodStart = clan.Calendar.CurrentDateTime;
+		_currentPeriodEnd = interval.GetNextDateTimeAfter(_currentPeriodStart);
+		_currentPeriodDrawdown = 0.0M;
+		IsActive = true;
+
+		using (new FMDB())
+		{
+			var dbitem = new MudSharp.Models.ClanBudget
+			{
+				ClanId = clan.Id,
+				AppointmentId = appointment.Id,
+				BankAccountId = bankAccount.Id,
+				CurrencyId = Currency.Id,
+				Name = name,
+				AmountPerPeriod = amount,
+				PeriodIntervalType = (int)interval.Type,
+				PeriodIntervalModifier = interval.IntervalAmount,
+				PeriodIntervalOther = interval.Modifier,
+				PeriodIntervalOtherSecondary = interval.SecondaryModifier,
+				PeriodIntervalFallback = (int)interval.OrdinalFallbackMode,
+				CurrentPeriodStart = _currentPeriodStart.GetDateTimeString(),
+				CurrentPeriodEnd = _currentPeriodEnd.GetDateTimeString(),
+				CurrentPeriodDrawdown = _currentPeriodDrawdown,
+				IsActive = IsActive
+			};
+			FMDB.Context.ClanBudgets.Add(dbitem);
+			FMDB.Context.SaveChanges();
+			_id = dbitem.Id;
+		}
+	}
+
+	public override string FrameworkItemType => "ClanBudget";
+
+	public IClan Clan { get; }
+	public IAppointment Appointment { get; set; }
+	public IBankAccount BankAccount
+	{
+		get => _bankAccount ??= Gameworld.BankAccounts.Get(_bankAccountId);
+		set
+		{
+			_bankAccount = value;
+			_bankAccountId = value.Id;
+			Changed = true;
+		}
+	}
+	public ICurrency Currency { get; }
+	public decimal AmountPerPeriod { get; set; }
+	public decimal CurrentPeriodDrawdown => _currentPeriodDrawdown;
+	public decimal RemainingBudget => AmountPerPeriod - CurrentPeriodDrawdown;
+	public RecurringInterval PeriodInterval { get; set; }
+	public MudDateTime CurrentPeriodStart => _currentPeriodStart;
+	public MudDateTime CurrentPeriodEnd => _currentPeriodEnd;
+	public bool IsActive { get; set; }
+	public IEnumerable<IClanBudgetTransaction> Transactions => _transactions;
+
+	public void RollToCurrentPeriod()
+	{
+		var now = Clan.Calendar.CurrentDateTime;
+		var rolled = false;
+		while (_currentPeriodEnd <= now)
+		{
+			_currentPeriodStart = _currentPeriodEnd;
+			_currentPeriodEnd = PeriodInterval.GetNextDateTimeAfter(_currentPeriodStart);
+			_currentPeriodDrawdown = 0.0M;
+			rolled = true;
+		}
+
+		if (rolled)
+		{
+			Changed = true;
+		}
+	}
+
+	public void AddDrawdown(IClanBudgetTransaction transaction)
+	{
+		_transactions.Add(transaction);
+		_currentPeriodDrawdown += transaction.Amount;
+		Changed = true;
+	}
+
+	public void Delete()
+	{
+		Gameworld.SaveManager.Abort(this);
+		if (_id == 0)
+		{
+			return;
+		}
+
+		using (new FMDB())
+		{
+			Gameworld.SaveManager.Flush();
+			var dbitem = FMDB.Context.ClanBudgets.Find(Id);
+			if (dbitem is not null)
+			{
+				FMDB.Context.ClanBudgets.Remove(dbitem);
+				FMDB.Context.SaveChanges();
+			}
+		}
+	}
+
+	public override void Save()
+	{
+		using (new FMDB())
+		{
+			var dbitem = FMDB.Context.ClanBudgets.Find(Id);
+			dbitem.Name = Name;
+			dbitem.AppointmentId = Appointment.Id;
+			dbitem.BankAccountId = BankAccount.Id;
+			dbitem.CurrencyId = Currency.Id;
+			dbitem.AmountPerPeriod = AmountPerPeriod;
+			dbitem.PeriodIntervalType = (int)PeriodInterval.Type;
+			dbitem.PeriodIntervalModifier = PeriodInterval.IntervalAmount;
+			dbitem.PeriodIntervalOther = PeriodInterval.Modifier;
+			dbitem.PeriodIntervalOtherSecondary = PeriodInterval.SecondaryModifier;
+			dbitem.PeriodIntervalFallback = (int)PeriodInterval.OrdinalFallbackMode;
+			dbitem.CurrentPeriodStart = CurrentPeriodStart.GetDateTimeString();
+			dbitem.CurrentPeriodEnd = CurrentPeriodEnd.GetDateTimeString();
+			dbitem.CurrentPeriodDrawdown = CurrentPeriodDrawdown;
+			dbitem.IsActive = IsActive;
+			FMDB.Context.SaveChanges();
+		}
+
+		Changed = false;
+	}
+}

--- a/MudSharpCore/Community/ClanBudgetTransaction.cs
+++ b/MudSharpCore/Community/ClanBudgetTransaction.cs
@@ -1,0 +1,89 @@
+using MudSharp.Character;
+using MudSharp.Database;
+using MudSharp.Economy;
+using MudSharp.Economy.Currency;
+using MudSharp.Framework;
+using MudSharp.TimeAndDate;
+
+namespace MudSharp.Community;
+
+public class ClanBudgetTransaction : IClanBudgetTransaction
+{
+	private readonly long _actorId;
+	private readonly long _bankAccountId;
+	private ICharacter _actor;
+	private IBankAccount _bankAccount;
+	private IFuturemud Gameworld => ((ClanBudget)Budget).Gameworld;
+
+	public ClanBudgetTransaction(MudSharp.Models.ClanBudgetTransaction transaction, IClanBudget budget)
+	{
+		Budget = budget;
+		_id = transaction.Id;
+		_actorId = transaction.ActorId;
+		_bankAccountId = transaction.BankAccountId;
+		Currency = Gameworld.Currencies.Get(transaction.CurrencyId);
+		Amount = transaction.Amount;
+		TransactionTime = MudDateTime.FromStoredStringOrFallback(transaction.TransactionTime, Gameworld,
+			StoredMudDateTimeFallback.CurrentDateTime, "ClanBudgetTransaction", transaction.Id, budget.Name,
+			"TransactionTime");
+		PeriodStart = MudDateTime.FromStoredStringOrFallback(transaction.PeriodStart, Gameworld,
+			StoredMudDateTimeFallback.CurrentDateTime, "ClanBudgetTransaction", transaction.Id, budget.Name,
+			"PeriodStart");
+		PeriodEnd = MudDateTime.FromStoredStringOrFallback(transaction.PeriodEnd, Gameworld,
+			StoredMudDateTimeFallback.CurrentDateTime, "ClanBudgetTransaction", transaction.Id, budget.Name,
+			"PeriodEnd");
+		BankBalanceAfter = transaction.BankBalanceAfter;
+		Reason = transaction.Reason;
+	}
+
+	public ClanBudgetTransaction(IClanBudget budget, ICharacter actor, decimal amount, string reason)
+	{
+		Budget = budget;
+		_actor = actor;
+		_actorId = actor.Id;
+		_bankAccount = budget.BankAccount;
+		_bankAccountId = budget.BankAccount.Id;
+		Currency = budget.Currency;
+		Amount = amount;
+		TransactionTime = budget.Clan.Calendar.CurrentDateTime;
+		PeriodStart = budget.CurrentPeriodStart;
+		PeriodEnd = budget.CurrentPeriodEnd;
+		BankBalanceAfter = budget.BankAccount.CurrentBalance;
+		Reason = reason;
+
+		using (new FMDB())
+		{
+			var dbitem = new MudSharp.Models.ClanBudgetTransaction
+			{
+				ClanBudgetId = budget.Id,
+				ActorId = actor.Id,
+				BankAccountId = budget.BankAccount.Id,
+				CurrencyId = budget.Currency.Id,
+				Amount = amount,
+				TransactionTime = TransactionTime.GetDateTimeString(),
+				PeriodStart = PeriodStart.GetDateTimeString(),
+				PeriodEnd = PeriodEnd.GetDateTimeString(),
+				BankBalanceAfter = BankBalanceAfter,
+				Reason = reason
+			};
+			FMDB.Context.ClanBudgetTransactions.Add(dbitem);
+			FMDB.Context.SaveChanges();
+			_id = dbitem.Id;
+		}
+	}
+
+	private readonly long _id;
+	public long Id => _id;
+	public string Name => $"Budget Drawdown #{Id:N0}";
+	public string FrameworkItemType => "ClanBudgetTransaction";
+	public IClanBudget Budget { get; }
+	public ICharacter Actor => _actor ??= Gameworld.TryGetCharacter(_actorId, true);
+	public IBankAccount BankAccount => _bankAccount ??= Gameworld.BankAccounts.Get(_bankAccountId);
+	public ICurrency Currency { get; }
+	public decimal Amount { get; }
+	public MudDateTime TransactionTime { get; }
+	public MudDateTime PeriodStart { get; }
+	public MudDateTime PeriodEnd { get; }
+	public decimal BankBalanceAfter { get; }
+	public string Reason { get; }
+}

--- a/MudSharpCore/Community/ClanPayrollHistoryEntry.cs
+++ b/MudSharpCore/Community/ClanPayrollHistoryEntry.cs
@@ -1,0 +1,99 @@
+using MudSharp.Character;
+using MudSharp.Database;
+using MudSharp.Economy.Currency;
+using MudSharp.Framework;
+using MudSharp.TimeAndDate;
+using System.Linq;
+
+namespace MudSharp.Community;
+
+public class ClanPayrollHistoryEntry : IClanPayrollHistoryEntry
+{
+	private readonly IFuturemud _gameworld;
+	private readonly long _characterId;
+	private readonly long? _actorId;
+	private ICharacter _character;
+	private ICharacter _actor;
+
+	public ClanPayrollHistoryEntry(MudSharp.Models.ClanPayrollHistory history, IClan clan)
+	{
+		_gameworld = ((Clan)clan).Gameworld;
+		_id = history.Id;
+		Clan = clan;
+		_characterId = history.CharacterId;
+		Rank = clan.Ranks.FirstOrDefault(x => x.Id == history.RankId);
+		Paygrade = history.PaygradeId.HasValue ? clan.Paygrades.FirstOrDefault(x => x.Id == history.PaygradeId.Value) : null;
+		Appointment = history.AppointmentId.HasValue ? clan.Appointments.FirstOrDefault(x => x.Id == history.AppointmentId.Value) : null;
+		_actorId = history.ActorId;
+		Currency = _gameworld.Currencies.Get(history.CurrencyId);
+		Amount = history.Amount;
+		EntryType = (ClanPayrollHistoryType)history.EntryType;
+		DateTime = MudDateTime.FromStoredStringOrFallback(history.DateTime, _gameworld,
+			StoredMudDateTimeFallback.CurrentDateTime, "ClanPayrollHistory", history.Id, clan.Name, "DateTime");
+		Description = history.Description;
+	}
+
+	private ClanPayrollHistoryEntry(IClanMembership membership, ICurrency currency, decimal amount,
+		ClanPayrollHistoryType entryType, string description, IPaygrade paygrade, IAppointment appointment,
+		ICharacter actor)
+	{
+		_gameworld = ((Clan)membership.Clan).Gameworld;
+		Clan = membership.Clan;
+		_characterId = membership.MemberId;
+		Rank = membership.Rank;
+		Paygrade = paygrade;
+		Appointment = appointment;
+		_actor = actor;
+		_actorId = actor?.Id;
+		Currency = currency;
+		Amount = amount;
+		EntryType = entryType;
+		DateTime = membership.Clan.Calendar.CurrentDateTime;
+		Description = description;
+
+		using (new FMDB())
+		{
+			var dbitem = new MudSharp.Models.ClanPayrollHistory
+			{
+				ClanId = Clan.Id,
+				CharacterId = membership.MemberId,
+				RankId = membership.Rank.Id,
+				PaygradeId = paygrade?.Id,
+				AppointmentId = appointment?.Id,
+				ActorId = actor?.Id,
+				CurrencyId = currency.Id,
+				Amount = amount,
+				EntryType = (int)entryType,
+				DateTime = DateTime.GetDateTimeString(),
+				Description = description
+			};
+			FMDB.Context.ClanPayrollHistories.Add(dbitem);
+			FMDB.Context.SaveChanges();
+			_id = dbitem.Id;
+		}
+	}
+
+	private readonly long _id;
+	public long Id => _id;
+	public string Name => $"Payroll Entry #{Id:N0}";
+	public string FrameworkItemType => "ClanPayrollHistory";
+	public IClan Clan { get; }
+	public ICharacter Character => _character ??= _gameworld.TryGetCharacter(_characterId, true);
+	public IRank Rank { get; }
+	public IPaygrade Paygrade { get; }
+	public IAppointment Appointment { get; }
+	public ICharacter Actor => _actor ??= _actorId.HasValue ? _gameworld.TryGetCharacter(_actorId.Value, true) : null;
+	public ICurrency Currency { get; }
+	public decimal Amount { get; }
+	public ClanPayrollHistoryType EntryType { get; }
+	public MudDateTime DateTime { get; }
+	public string Description { get; }
+
+	public static IClanPayrollHistoryEntry Create(IClanMembership membership, ICurrency currency, decimal amount,
+		ClanPayrollHistoryType entryType, string description, IPaygrade paygrade = null, IAppointment appointment = null,
+		ICharacter actor = null)
+	{
+		return new ClanPayrollHistoryEntry(membership, currency, amount, entryType, description, paygrade, appointment,
+			actor);
+	}
+}

--- a/MudSharpCore/Framework/FuturemudLoaders.cs
+++ b/MudSharpCore/Framework/FuturemudLoaders.cs
@@ -3666,6 +3666,8 @@ For information on the syntax to use in emotes (such as those included in bracke
                                       .ThenInclude(x => x.AppointmentsAbbreviations)
                                       .Include(x => x.Appointments)
                                       .ThenInclude(x => x.AppointmentsTitles)
+                                      .Include(x => x.ClanBudgets)
+                                      .ThenInclude(x => x.ClanBudgetTransactions)
                                       .Include(x => x.ExternalClanControlsLiegeClan)
                                       .AsSplitQuery()
                                       .AsNoTracking()

--- a/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContext.cs
+++ b/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContext.cs
@@ -171,6 +171,9 @@ namespace MudSharp.Database
         public virtual DbSet<ClanMembership> ClanMemberships { get; set; }
         public virtual DbSet<ClanMembershipsAppointments> ClanMembershipsAppointments { get; set; }
         public virtual DbSet<ClanMembershipBackpay> ClanMembershipsBackpay { get; set; }
+        public virtual DbSet<ClanBudget> ClanBudgets { get; set; }
+        public virtual DbSet<ClanBudgetTransaction> ClanBudgetTransactions { get; set; }
+        public virtual DbSet<ClanPayrollHistory> ClanPayrollHistories { get; set; }
         public virtual DbSet<Clan> Clans { get; set; }
         public virtual DbSet<ClanAdministrationCell> ClansAdministrationCells { get; set; }
         public virtual DbSet<ClanTreasuryCell> ClansTreasuryCells { get; set; }

--- a/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextShopDeals.cs
+++ b/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextShopDeals.cs
@@ -10,6 +10,7 @@ namespace MudSharp.Database
             ConfigureCharacterComputerWorkspace(modelBuilder);
             ConfigureComputerMail(modelBuilder);
             ConfigureStables(modelBuilder);
+            ConfigureClanFinance(modelBuilder);
 
             modelBuilder.Entity<ShopDeal>(entity =>
             {
@@ -87,6 +88,218 @@ namespace MudSharp.Database
 
                 entity.Property(e => e.StressFlickerThreshold)
                       .HasDefaultValue(0.01m);
+            });
+        }
+
+        private static void ConfigureClanFinance(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<ClanBudget>(entity =>
+            {
+                entity.ToTable("ClanBudgets");
+                entity.HasKey(e => e.Id).HasName("PRIMARY");
+
+                entity.HasIndex(e => e.ClanId)
+                      .HasDatabaseName("FK_ClanBudgets_Clans_idx");
+                entity.HasIndex(e => e.AppointmentId)
+                      .HasDatabaseName("FK_ClanBudgets_Appointments_idx");
+                entity.HasIndex(e => e.BankAccountId)
+                      .HasDatabaseName("FK_ClanBudgets_BankAccounts_idx");
+                entity.HasIndex(e => e.CurrencyId)
+                      .HasDatabaseName("FK_ClanBudgets_Currencies_idx");
+
+                entity.Property(e => e.Id).HasColumnType("bigint(20)");
+                entity.Property(e => e.ClanId).HasColumnType("bigint(20)");
+                entity.Property(e => e.AppointmentId).HasColumnType("bigint(20)");
+                entity.Property(e => e.BankAccountId).HasColumnType("bigint(20)");
+                entity.Property(e => e.CurrencyId).HasColumnType("bigint(20)");
+                entity.Property(e => e.Name)
+                      .IsRequired()
+                      .HasColumnType("varchar(200)")
+                      .HasCharSet("utf8")
+                      .UseCollation("utf8_general_ci");
+                entity.Property(e => e.AmountPerPeriod).HasColumnType("decimal(58,29)");
+                entity.Property(e => e.CurrentPeriodDrawdown).HasColumnType("decimal(58,29)");
+                entity.Property(e => e.PeriodIntervalType).HasColumnType("int(11)");
+                entity.Property(e => e.PeriodIntervalModifier).HasColumnType("int(11)");
+                entity.Property(e => e.PeriodIntervalOther).HasColumnType("int(11)");
+                entity.Property(e => e.PeriodIntervalOtherSecondary).HasColumnType("int(11)");
+                entity.Property(e => e.PeriodIntervalFallback).HasColumnType("int(11)");
+                entity.Property(e => e.CurrentPeriodStart)
+                      .IsRequired()
+                      .HasColumnType("varchar(255)")
+                      .HasCharSet("utf8")
+                      .UseCollation("utf8_general_ci");
+                entity.Property(e => e.CurrentPeriodEnd)
+                      .IsRequired()
+                      .HasColumnType("varchar(255)")
+                      .HasCharSet("utf8")
+                      .UseCollation("utf8_general_ci");
+                entity.Property(e => e.IsActive)
+                      .HasColumnType("bit(1)")
+                      .HasDefaultValue(true);
+
+                entity.HasOne(e => e.Clan)
+                      .WithMany(e => e.ClanBudgets)
+                      .HasForeignKey(e => e.ClanId)
+                      .OnDelete(DeleteBehavior.Cascade)
+                      .HasConstraintName("FK_ClanBudgets_Clans");
+                entity.HasOne(e => e.Appointment)
+                      .WithMany(e => e.ClanBudgets)
+                      .HasForeignKey(e => e.AppointmentId)
+                      .OnDelete(DeleteBehavior.Cascade)
+                      .HasConstraintName("FK_ClanBudgets_Appointments");
+                entity.HasOne(e => e.BankAccount)
+                      .WithMany(e => e.ClanBudgets)
+                      .HasForeignKey(e => e.BankAccountId)
+                      .OnDelete(DeleteBehavior.Cascade)
+                      .HasConstraintName("FK_ClanBudgets_BankAccounts");
+                entity.HasOne(e => e.Currency)
+                      .WithMany(e => e.ClanBudgets)
+                      .HasForeignKey(e => e.CurrencyId)
+                      .OnDelete(DeleteBehavior.Cascade)
+                      .HasConstraintName("FK_ClanBudgets_Currencies");
+            });
+
+            modelBuilder.Entity<ClanBudgetTransaction>(entity =>
+            {
+                entity.ToTable("ClanBudgetTransactions");
+                entity.HasKey(e => e.Id).HasName("PRIMARY");
+
+                entity.HasIndex(e => e.ClanBudgetId)
+                      .HasDatabaseName("FK_ClanBudgetTransactions_Budgets_idx");
+                entity.HasIndex(e => e.ActorId)
+                      .HasDatabaseName("FK_ClanBudgetTransactions_Actors_idx");
+                entity.HasIndex(e => e.BankAccountId)
+                      .HasDatabaseName("FK_ClanBudgetTransactions_BankAccounts_idx");
+                entity.HasIndex(e => e.CurrencyId)
+                      .HasDatabaseName("FK_ClanBudgetTransactions_Currencies_idx");
+
+                entity.Property(e => e.Id).HasColumnType("bigint(20)");
+                entity.Property(e => e.ClanBudgetId).HasColumnType("bigint(20)");
+                entity.Property(e => e.ActorId).HasColumnType("bigint(20)");
+                entity.Property(e => e.BankAccountId).HasColumnType("bigint(20)");
+                entity.Property(e => e.CurrencyId).HasColumnType("bigint(20)");
+                entity.Property(e => e.Amount).HasColumnType("decimal(58,29)");
+                entity.Property(e => e.BankBalanceAfter).HasColumnType("decimal(58,29)");
+                entity.Property(e => e.TransactionTime)
+                      .IsRequired()
+                      .HasColumnType("varchar(255)")
+                      .HasCharSet("utf8")
+                      .UseCollation("utf8_general_ci");
+                entity.Property(e => e.PeriodStart)
+                      .IsRequired()
+                      .HasColumnType("varchar(255)")
+                      .HasCharSet("utf8")
+                      .UseCollation("utf8_general_ci");
+                entity.Property(e => e.PeriodEnd)
+                      .IsRequired()
+                      .HasColumnType("varchar(255)")
+                      .HasCharSet("utf8")
+                      .UseCollation("utf8_general_ci");
+                entity.Property(e => e.Reason)
+                      .IsRequired()
+                      .HasColumnType("varchar(1000)")
+                      .HasCharSet("utf8")
+                      .UseCollation("utf8_general_ci");
+
+                entity.HasOne(e => e.ClanBudget)
+                      .WithMany(e => e.ClanBudgetTransactions)
+                      .HasForeignKey(e => e.ClanBudgetId)
+                      .OnDelete(DeleteBehavior.Cascade)
+                      .HasConstraintName("FK_ClanBudgetTransactions_Budgets");
+                entity.HasOne(e => e.Actor)
+                      .WithMany()
+                      .HasForeignKey(e => e.ActorId)
+                      .OnDelete(DeleteBehavior.Cascade)
+                      .HasConstraintName("FK_ClanBudgetTransactions_Characters");
+                entity.HasOne(e => e.BankAccount)
+                      .WithMany(e => e.ClanBudgetTransactions)
+                      .HasForeignKey(e => e.BankAccountId)
+                      .OnDelete(DeleteBehavior.Cascade)
+                      .HasConstraintName("FK_ClanBudgetTransactions_BankAccounts");
+                entity.HasOne(e => e.Currency)
+                      .WithMany(e => e.ClanBudgetTransactions)
+                      .HasForeignKey(e => e.CurrencyId)
+                      .OnDelete(DeleteBehavior.Cascade)
+                      .HasConstraintName("FK_ClanBudgetTransactions_Currencies");
+            });
+
+            modelBuilder.Entity<ClanPayrollHistory>(entity =>
+            {
+                entity.ToTable("ClanPayrollHistories");
+                entity.HasKey(e => e.Id).HasName("PRIMARY");
+
+                entity.HasIndex(e => e.ClanId)
+                      .HasDatabaseName("FK_ClanPayrollHistories_Clans_idx");
+                entity.HasIndex(e => e.CharacterId)
+                      .HasDatabaseName("FK_ClanPayrollHistories_Characters_idx");
+                entity.HasIndex(e => e.RankId)
+                      .HasDatabaseName("FK_ClanPayrollHistories_Ranks_idx");
+                entity.HasIndex(e => e.PaygradeId)
+                      .HasDatabaseName("FK_ClanPayrollHistories_Paygrades_idx");
+                entity.HasIndex(e => e.AppointmentId)
+                      .HasDatabaseName("FK_ClanPayrollHistories_Appointments_idx");
+                entity.HasIndex(e => e.ActorId)
+                      .HasDatabaseName("FK_ClanPayrollHistories_Actors_idx");
+                entity.HasIndex(e => e.CurrencyId)
+                      .HasDatabaseName("FK_ClanPayrollHistories_Currencies_idx");
+
+                entity.Property(e => e.Id).HasColumnType("bigint(20)");
+                entity.Property(e => e.ClanId).HasColumnType("bigint(20)");
+                entity.Property(e => e.CharacterId).HasColumnType("bigint(20)");
+                entity.Property(e => e.RankId).HasColumnType("bigint(20)");
+                entity.Property(e => e.PaygradeId).HasColumnType("bigint(20)");
+                entity.Property(e => e.AppointmentId).HasColumnType("bigint(20)");
+                entity.Property(e => e.ActorId).HasColumnType("bigint(20)");
+                entity.Property(e => e.CurrencyId).HasColumnType("bigint(20)");
+                entity.Property(e => e.Amount).HasColumnType("decimal(58,29)");
+                entity.Property(e => e.EntryType).HasColumnType("int(11)");
+                entity.Property(e => e.DateTime)
+                      .IsRequired()
+                      .HasColumnType("varchar(255)")
+                      .HasCharSet("utf8")
+                      .UseCollation("utf8_general_ci");
+                entity.Property(e => e.Description)
+                      .IsRequired()
+                      .HasColumnType("varchar(1000)")
+                      .HasCharSet("utf8")
+                      .UseCollation("utf8_general_ci");
+
+                entity.HasOne(e => e.Clan)
+                      .WithMany(e => e.ClanPayrollHistories)
+                      .HasForeignKey(e => e.ClanId)
+                      .OnDelete(DeleteBehavior.Cascade)
+                      .HasConstraintName("FK_ClanPayrollHistories_Clans");
+                entity.HasOne(e => e.Character)
+                      .WithMany()
+                      .HasForeignKey(e => e.CharacterId)
+                      .OnDelete(DeleteBehavior.Cascade)
+                      .HasConstraintName("FK_ClanPayrollHistories_Characters");
+                entity.HasOne(e => e.Rank)
+                      .WithMany()
+                      .HasForeignKey(e => e.RankId)
+                      .OnDelete(DeleteBehavior.Cascade)
+                      .HasConstraintName("FK_ClanPayrollHistories_Ranks");
+                entity.HasOne(e => e.Paygrade)
+                      .WithMany()
+                      .HasForeignKey(e => e.PaygradeId)
+                      .OnDelete(DeleteBehavior.SetNull)
+                      .HasConstraintName("FK_ClanPayrollHistories_Paygrades");
+                entity.HasOne(e => e.Appointment)
+                      .WithMany()
+                      .HasForeignKey(e => e.AppointmentId)
+                      .OnDelete(DeleteBehavior.SetNull)
+                      .HasConstraintName("FK_ClanPayrollHistories_Appointments");
+                entity.HasOne(e => e.Actor)
+                      .WithMany()
+                      .HasForeignKey(e => e.ActorId)
+                      .OnDelete(DeleteBehavior.SetNull)
+                      .HasConstraintName("FK_ClanPayrollHistories_Actors");
+                entity.HasOne(e => e.Currency)
+                      .WithMany(e => e.ClanPayrollHistories)
+                      .HasForeignKey(e => e.CurrencyId)
+                      .OnDelete(DeleteBehavior.Cascade)
+                      .HasConstraintName("FK_ClanPayrollHistories_Currencies");
             });
         }
     }

--- a/MudsharpDatabaseLibrary/Migrations/20260506103358_ClanBudgetsAndPayrollHistory.Designer.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260506103358_ClanBudgetsAndPayrollHistory.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MudSharp.Database;
 
@@ -11,9 +12,11 @@ using MudSharp.Database;
 namespace MudSharp.Migrations
 {
     [DbContext(typeof(FuturemudDatabaseContext))]
-    partial class FutureMUDContextModelSnapshot : ModelSnapshot
+    [Migration("20260506103358_ClanBudgetsAndPayrollHistory")]
+    partial class ClanBudgetsAndPayrollHistory
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MudsharpDatabaseLibrary/Migrations/20260506103358_ClanBudgetsAndPayrollHistory.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260506103358_ClanBudgetsAndPayrollHistory.cs
@@ -1,0 +1,277 @@
+﻿using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MudSharp.Migrations
+{
+    /// <inheritdoc />
+    public partial class ClanBudgetsAndPayrollHistory : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ClanBudgets",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint(20)", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    ClanId = table.Column<long>(type: "bigint(20)", nullable: false),
+                    AppointmentId = table.Column<long>(type: "bigint(20)", nullable: false),
+                    BankAccountId = table.Column<long>(type: "bigint(20)", nullable: false),
+                    CurrencyId = table.Column<long>(type: "bigint(20)", nullable: false),
+                    Name = table.Column<string>(type: "varchar(200)", nullable: false, collation: "utf8_general_ci")
+                        .Annotation("MySql:CharSet", "utf8"),
+                    AmountPerPeriod = table.Column<decimal>(type: "decimal(58,29)", nullable: false),
+                    PeriodIntervalType = table.Column<int>(type: "int(11)", nullable: false),
+                    PeriodIntervalModifier = table.Column<int>(type: "int(11)", nullable: false),
+                    PeriodIntervalOther = table.Column<int>(type: "int(11)", nullable: false),
+                    PeriodIntervalOtherSecondary = table.Column<int>(type: "int(11)", nullable: false),
+                    PeriodIntervalFallback = table.Column<int>(type: "int(11)", nullable: false),
+                    CurrentPeriodStart = table.Column<string>(type: "varchar(255)", nullable: false, collation: "utf8_general_ci")
+                        .Annotation("MySql:CharSet", "utf8"),
+                    CurrentPeriodEnd = table.Column<string>(type: "varchar(255)", nullable: false, collation: "utf8_general_ci")
+                        .Annotation("MySql:CharSet", "utf8"),
+                    CurrentPeriodDrawdown = table.Column<decimal>(type: "decimal(58,29)", nullable: false),
+                    IsActive = table.Column<ulong>(type: "bit(1)", nullable: false, defaultValue: 1ul)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PRIMARY", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ClanBudgets_Appointments",
+                        column: x => x.AppointmentId,
+                        principalTable: "Appointments",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ClanBudgets_BankAccounts",
+                        column: x => x.BankAccountId,
+                        principalTable: "BankAccounts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ClanBudgets_Clans",
+                        column: x => x.ClanId,
+                        principalTable: "Clans",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ClanBudgets_Currencies",
+                        column: x => x.CurrencyId,
+                        principalTable: "Currencies",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "ClanPayrollHistories",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint(20)", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    ClanId = table.Column<long>(type: "bigint(20)", nullable: false),
+                    CharacterId = table.Column<long>(type: "bigint(20)", nullable: false),
+                    RankId = table.Column<long>(type: "bigint(20)", nullable: false),
+                    PaygradeId = table.Column<long>(type: "bigint(20)", nullable: true),
+                    AppointmentId = table.Column<long>(type: "bigint(20)", nullable: true),
+                    ActorId = table.Column<long>(type: "bigint(20)", nullable: true),
+                    CurrencyId = table.Column<long>(type: "bigint(20)", nullable: false),
+                    Amount = table.Column<decimal>(type: "decimal(58,29)", nullable: false),
+                    EntryType = table.Column<int>(type: "int(11)", nullable: false),
+                    DateTime = table.Column<string>(type: "varchar(255)", nullable: false, collation: "utf8_general_ci")
+                        .Annotation("MySql:CharSet", "utf8"),
+                    Description = table.Column<string>(type: "varchar(1000)", nullable: false, collation: "utf8_general_ci")
+                        .Annotation("MySql:CharSet", "utf8")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PRIMARY", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ClanPayrollHistories_Actors",
+                        column: x => x.ActorId,
+                        principalTable: "Characters",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_ClanPayrollHistories_Appointments",
+                        column: x => x.AppointmentId,
+                        principalTable: "Appointments",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_ClanPayrollHistories_Characters",
+                        column: x => x.CharacterId,
+                        principalTable: "Characters",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ClanPayrollHistories_Clans",
+                        column: x => x.ClanId,
+                        principalTable: "Clans",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ClanPayrollHistories_Currencies",
+                        column: x => x.CurrencyId,
+                        principalTable: "Currencies",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ClanPayrollHistories_Paygrades",
+                        column: x => x.PaygradeId,
+                        principalTable: "Paygrades",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_ClanPayrollHistories_Ranks",
+                        column: x => x.RankId,
+                        principalTable: "Ranks",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "ClanBudgetTransactions",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint(20)", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    ClanBudgetId = table.Column<long>(type: "bigint(20)", nullable: false),
+                    ActorId = table.Column<long>(type: "bigint(20)", nullable: false),
+                    BankAccountId = table.Column<long>(type: "bigint(20)", nullable: false),
+                    CurrencyId = table.Column<long>(type: "bigint(20)", nullable: false),
+                    Amount = table.Column<decimal>(type: "decimal(58,29)", nullable: false),
+                    TransactionTime = table.Column<string>(type: "varchar(255)", nullable: false, collation: "utf8_general_ci")
+                        .Annotation("MySql:CharSet", "utf8"),
+                    PeriodStart = table.Column<string>(type: "varchar(255)", nullable: false, collation: "utf8_general_ci")
+                        .Annotation("MySql:CharSet", "utf8"),
+                    PeriodEnd = table.Column<string>(type: "varchar(255)", nullable: false, collation: "utf8_general_ci")
+                        .Annotation("MySql:CharSet", "utf8"),
+                    BankBalanceAfter = table.Column<decimal>(type: "decimal(58,29)", nullable: false),
+                    Reason = table.Column<string>(type: "varchar(1000)", nullable: false, collation: "utf8_general_ci")
+                        .Annotation("MySql:CharSet", "utf8")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PRIMARY", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ClanBudgetTransactions_BankAccounts",
+                        column: x => x.BankAccountId,
+                        principalTable: "BankAccounts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ClanBudgetTransactions_Budgets",
+                        column: x => x.ClanBudgetId,
+                        principalTable: "ClanBudgets",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ClanBudgetTransactions_Characters",
+                        column: x => x.ActorId,
+                        principalTable: "Characters",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ClanBudgetTransactions_Currencies",
+                        column: x => x.CurrencyId,
+                        principalTable: "Currencies",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_ClanBudgets_Appointments_idx",
+                table: "ClanBudgets",
+                column: "AppointmentId");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_ClanBudgets_BankAccounts_idx",
+                table: "ClanBudgets",
+                column: "BankAccountId");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_ClanBudgets_Clans_idx",
+                table: "ClanBudgets",
+                column: "ClanId");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_ClanBudgets_Currencies_idx",
+                table: "ClanBudgets",
+                column: "CurrencyId");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_ClanBudgetTransactions_Actors_idx",
+                table: "ClanBudgetTransactions",
+                column: "ActorId");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_ClanBudgetTransactions_BankAccounts_idx",
+                table: "ClanBudgetTransactions",
+                column: "BankAccountId");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_ClanBudgetTransactions_Budgets_idx",
+                table: "ClanBudgetTransactions",
+                column: "ClanBudgetId");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_ClanBudgetTransactions_Currencies_idx",
+                table: "ClanBudgetTransactions",
+                column: "CurrencyId");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_ClanPayrollHistories_Actors_idx",
+                table: "ClanPayrollHistories",
+                column: "ActorId");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_ClanPayrollHistories_Appointments_idx",
+                table: "ClanPayrollHistories",
+                column: "AppointmentId");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_ClanPayrollHistories_Characters_idx",
+                table: "ClanPayrollHistories",
+                column: "CharacterId");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_ClanPayrollHistories_Clans_idx",
+                table: "ClanPayrollHistories",
+                column: "ClanId");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_ClanPayrollHistories_Currencies_idx",
+                table: "ClanPayrollHistories",
+                column: "CurrencyId");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_ClanPayrollHistories_Paygrades_idx",
+                table: "ClanPayrollHistories",
+                column: "PaygradeId");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_ClanPayrollHistories_Ranks_idx",
+                table: "ClanPayrollHistories",
+                column: "RankId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ClanBudgetTransactions");
+
+            migrationBuilder.DropTable(
+                name: "ClanPayrollHistories");
+
+            migrationBuilder.DropTable(
+                name: "ClanBudgets");
+        }
+    }
+}

--- a/MudsharpDatabaseLibrary/Models/Appointment.cs
+++ b/MudsharpDatabaseLibrary/Models/Appointment.cs
@@ -9,6 +9,7 @@ namespace MudSharp.Models
         {
             AppointmentsAbbreviations = new HashSet<AppointmentsAbbreviations>();
             AppointmentsTitles = new HashSet<AppointmentsTitles>();
+            ClanBudgets = new HashSet<ClanBudget>();
             ClanMembershipsAppointments = new HashSet<ClanMembershipsAppointments>();
             ExternalClanControlsControlledAppointment = new HashSet<ExternalClanControl>();
             ExternalClanControlsControllingAppointment = new HashSet<ExternalClanControl>();
@@ -52,6 +53,7 @@ namespace MudSharp.Models
         public virtual FutureProg WhyCantNominateProg { get; set; }
         public virtual ICollection<AppointmentsAbbreviations> AppointmentsAbbreviations { get; set; }
         public virtual ICollection<AppointmentsTitles> AppointmentsTitles { get; set; }
+        public virtual ICollection<ClanBudget> ClanBudgets { get; set; }
         public virtual ICollection<ClanMembershipsAppointments> ClanMembershipsAppointments { get; set; }
         public virtual ICollection<ExternalClanControl> ExternalClanControlsControlledAppointment { get; set; }
         public virtual ICollection<ExternalClanControl> ExternalClanControlsControllingAppointment { get; set; }

--- a/MudsharpDatabaseLibrary/Models/BankAccount.cs
+++ b/MudsharpDatabaseLibrary/Models/BankAccount.cs
@@ -11,6 +11,8 @@ namespace MudSharp.Models
         public BankAccount()
         {
             BankAccountTransactions = new HashSet<BankAccountTransaction>();
+            ClanBudgets = new HashSet<ClanBudget>();
+            ClanBudgetTransactions = new HashSet<ClanBudgetTransaction>();
         }
 
         public long Id { get; set; }
@@ -39,5 +41,7 @@ namespace MudSharp.Models
         public virtual BankAccount NominatedBenefactorAccount { get; set; }
 
         public virtual ICollection<BankAccountTransaction> BankAccountTransactions { get; set; }
+        public virtual ICollection<ClanBudget> ClanBudgets { get; set; }
+        public virtual ICollection<ClanBudgetTransaction> ClanBudgetTransactions { get; set; }
     }
 }

--- a/MudsharpDatabaseLibrary/Models/Clan.cs
+++ b/MudsharpDatabaseLibrary/Models/Clan.cs
@@ -10,6 +10,8 @@ namespace MudSharp.Models
             Appointments = new HashSet<Appointment>();
             ChargenRolesClanMemberships = new HashSet<ChargenRolesClanMemberships>();
             ClanMemberships = new HashSet<ClanMembership>();
+            ClanBudgets = new HashSet<ClanBudget>();
+            ClanPayrollHistories = new HashSet<ClanPayrollHistory>();
             ClansAdministrationCells = new HashSet<ClanAdministrationCell>();
             ClansTreasuryCells = new HashSet<ClanTreasuryCell>();
             ExternalClanControlsLiegeClan = new HashSet<ExternalClanControl>();
@@ -49,6 +51,8 @@ namespace MudSharp.Models
         public virtual Character Paymaster { get; set; }
         public virtual BankAccount BankAccount { get; set; }
         public virtual ICollection<Appointment> Appointments { get; set; }
+        public virtual ICollection<ClanBudget> ClanBudgets { get; set; }
+        public virtual ICollection<ClanPayrollHistory> ClanPayrollHistories { get; set; }
         public virtual ICollection<ChargenRolesClanMemberships> ChargenRolesClanMemberships { get; set; }
         public virtual ICollection<ClanMembership> ClanMemberships { get; set; }
         public virtual ICollection<ClanAdministrationCell> ClansAdministrationCells { get; set; }

--- a/MudsharpDatabaseLibrary/Models/ClanBudget.cs
+++ b/MudsharpDatabaseLibrary/Models/ClanBudget.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+
+namespace MudSharp.Models;
+
+public partial class ClanBudget
+{
+	public ClanBudget()
+	{
+		ClanBudgetTransactions = new HashSet<ClanBudgetTransaction>();
+	}
+
+	public long Id { get; set; }
+	public long ClanId { get; set; }
+	public long AppointmentId { get; set; }
+	public long BankAccountId { get; set; }
+	public long CurrencyId { get; set; }
+	public string Name { get; set; }
+	public decimal AmountPerPeriod { get; set; }
+	public int PeriodIntervalType { get; set; }
+	public int PeriodIntervalModifier { get; set; }
+	public int PeriodIntervalOther { get; set; }
+	public int PeriodIntervalOtherSecondary { get; set; }
+	public int PeriodIntervalFallback { get; set; }
+	public string CurrentPeriodStart { get; set; }
+	public string CurrentPeriodEnd { get; set; }
+	public decimal CurrentPeriodDrawdown { get; set; }
+	public bool IsActive { get; set; }
+
+	public virtual Clan Clan { get; set; }
+	public virtual Appointment Appointment { get; set; }
+	public virtual BankAccount BankAccount { get; set; }
+	public virtual Currency Currency { get; set; }
+	public virtual ICollection<ClanBudgetTransaction> ClanBudgetTransactions { get; set; }
+}

--- a/MudsharpDatabaseLibrary/Models/ClanBudgetTransaction.cs
+++ b/MudsharpDatabaseLibrary/Models/ClanBudgetTransaction.cs
@@ -1,0 +1,21 @@
+namespace MudSharp.Models;
+
+public partial class ClanBudgetTransaction
+{
+	public long Id { get; set; }
+	public long ClanBudgetId { get; set; }
+	public long ActorId { get; set; }
+	public long BankAccountId { get; set; }
+	public long CurrencyId { get; set; }
+	public decimal Amount { get; set; }
+	public string TransactionTime { get; set; }
+	public string PeriodStart { get; set; }
+	public string PeriodEnd { get; set; }
+	public decimal BankBalanceAfter { get; set; }
+	public string Reason { get; set; }
+
+	public virtual ClanBudget ClanBudget { get; set; }
+	public virtual Character Actor { get; set; }
+	public virtual BankAccount BankAccount { get; set; }
+	public virtual Currency Currency { get; set; }
+}

--- a/MudsharpDatabaseLibrary/Models/ClanPayrollHistory.cs
+++ b/MudsharpDatabaseLibrary/Models/ClanPayrollHistory.cs
@@ -1,0 +1,25 @@
+namespace MudSharp.Models;
+
+public partial class ClanPayrollHistory
+{
+	public long Id { get; set; }
+	public long ClanId { get; set; }
+	public long CharacterId { get; set; }
+	public long RankId { get; set; }
+	public long? PaygradeId { get; set; }
+	public long? AppointmentId { get; set; }
+	public long? ActorId { get; set; }
+	public long CurrencyId { get; set; }
+	public decimal Amount { get; set; }
+	public int EntryType { get; set; }
+	public string DateTime { get; set; }
+	public string Description { get; set; }
+
+	public virtual Clan Clan { get; set; }
+	public virtual Character Character { get; set; }
+	public virtual Rank Rank { get; set; }
+	public virtual Paygrade Paygrade { get; set; }
+	public virtual Appointment Appointment { get; set; }
+	public virtual Character Actor { get; set; }
+	public virtual Currency Currency { get; set; }
+}

--- a/MudsharpDatabaseLibrary/Models/Currency.cs
+++ b/MudsharpDatabaseLibrary/Models/Currency.cs
@@ -10,6 +10,9 @@ namespace MudSharp.Models
             Characters = new HashSet<Character>();
             ChargenRolesCurrencies = new HashSet<ChargenRolesCurrency>();
             ClanMembershipsBackpay = new HashSet<ClanMembershipBackpay>();
+            ClanBudgets = new HashSet<ClanBudget>();
+            ClanBudgetTransactions = new HashSet<ClanBudgetTransaction>();
+            ClanPayrollHistories = new HashSet<ClanPayrollHistory>();
             Coins = new HashSet<Coin>();
             CurrencyDescriptionPatterns = new HashSet<CurrencyDescriptionPattern>();
             CurrencyDivisions = new HashSet<CurrencyDivision>();
@@ -27,6 +30,9 @@ namespace MudSharp.Models
         public virtual ICollection<Character> Characters { get; set; }
         public virtual ICollection<ChargenRolesCurrency> ChargenRolesCurrencies { get; set; }
         public virtual ICollection<ClanMembershipBackpay> ClanMembershipsBackpay { get; set; }
+        public virtual ICollection<ClanBudget> ClanBudgets { get; set; }
+        public virtual ICollection<ClanBudgetTransaction> ClanBudgetTransactions { get; set; }
+        public virtual ICollection<ClanPayrollHistory> ClanPayrollHistories { get; set; }
         public virtual ICollection<Coin> Coins { get; set; }
         public virtual ICollection<CurrencyDescriptionPattern> CurrencyDescriptionPatterns { get; set; }
         public virtual ICollection<CurrencyDivision> CurrencyDivisions { get; set; }


### PR DESCRIPTION
## Summary
- Added appointment-assigned clan budgets with recurring periods, drawdown tracking, audit history, and clan-bank funding
- Added clan finance commands for budget management, balance sheet review, and payroll history review
- Persisted new clan finance entities and updated the EF model, snapshot, and migration
- Updated clan and economy design docs to reflect the new financial workflows and permissions

## Testing
- `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `dotnet build MudsharpDatabaseLibrary\MudsharpDatabaseLibrary.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `scripts\test-unit-core.ps1`