### PR TITLE
Fix position state comparison and item positioning, add subsystem design doc

### DIFF
--- a/Design Documents/Position_State_System.md
+++ b/Design Documents/Position_State_System.md
@@ -1,0 +1,180 @@
+# Position State System
+
+## Purpose
+
+The position state system describes how a perceivable thing is physically arranged in a cell: standing, sitting, swimming, flying, floating, hanging, riding, and similar states. It affects:
+
+- long descriptions and movement echoes;
+- whether a character can move immediately or must first change posture;
+- which movement speed entry is used;
+- contextual height for combat, cover, sleep, infection recovery, and size checks;
+- fall safety, swimming, climbing, flying, and zero-gravity behavior;
+- relative placement of characters and items against other perceivables.
+
+Position states are posture and movement-mode abstractions. They are not meant to encode every locomotor anatomy. For example, a wheeled or tracked robot can still use an upright/mobile position state, while its body prototype and move speed rows provide "roll", "trundle", or similar verbs. Add a new position state only when the state has distinct engine-wide posture, height, movement, or targeting rules.
+
+## Core Types
+
+`IPositionState` lives in `FutureMUDLibrary/Body/Position/IPositionState.cs`. Concrete runtime implementations live under `MudSharpCore/Body/Position/PositionStates`.
+
+The main contract members are:
+
+- `Upright`: whether the position counts as upright for effects such as exit size checks, standing combat assumptions, and falling decisions.
+- `MoveRestrictions`: one of `Free`, `FreeIfNotInOn`, `Restricted`, `Climbing`, `Swimming`, `Flying`, or `ZeroGravity`.
+- `TransitionOnMovement`: the state a character should use when movement begins from this state, usually standing for free upright variants.
+- `DescribePositionMovement`: the intralocal transition verb pair such as `step|steps` or `crawl|crawls`.
+- `DescribeLocationMovementParticiple`: the label used by move speed builders and position lookup.
+- `SafeFromFalling`: whether the state protects against fall exits or fall layer transitions.
+- `Describe(...)`: produces the long-description suffix for an `IPositionable`.
+- `DescribeTransition(...)`: produces the emote used when a character changes position.
+- `CompareTo(dynamic state)`: reports relative height for sleep, combat, cover, infection recovery, and contextual size logic.
+
+`IPositionable` is implemented by characters, bodies, items, perceived items, and temporary perceivables. It stores the current `PositionState`, `PositionTarget`, `PositionModifier`, optional `PositionEmote`, and reverse `TargetedBy` references.
+
+`PositionModifier` represents target relationship: `In`, `On`, `Under`, `Before`, `Behind`, `None`, or `Around`. `None` means "by" for the base position description, but some states override it. For example, leaning and slumped states describe `None` against a target as "against", and hanging describes `None` as "from".
+
+## Registry and Persistence
+
+`PositionState.SetupPositions()` registers singleton state instances by numeric ID. Those IDs are persisted directly in database rows and should not be renumbered.
+
+Current registered IDs:
+
+| ID | Class | Label | Movement restriction | Height model |
+| --- | --- | --- | --- | --- |
+| 0 | `PositionUndefined` | existing | restricted by default | undefined |
+| 1 | `PositionStanding` | standing | free | standing tier |
+| 2 | `PositionSitting` | sitting | restricted by default | sitting tier |
+| 3 | `PositionKneeling` | kneeling | restricted by default | kneeling tier |
+| 4 | `PositionLounging` | lounging | restricted by default | sitting/low tier |
+| 5 | `PositionLyingDown` | lying down | restricted by default | low tier |
+| 6 | `PositionProne` | prone | free | low/crawling tier |
+| 7 | `PositionProstrate` | prostrate | free if not in/on a target | low/crawling tier |
+| 8 | `PositionSprawled` | sprawled | restricted by default | lowest tier |
+| 9 | `PositionStandingAttention` | standing at attention | free | standing tier |
+| 10 | `PositionStandingEasy` | standing at ease | free | standing tier |
+| 11 | `PositionLeaning` | leaning | free | standing tier |
+| 12 | `PositionSlumped` | slumped | restricted by default | sitting tier |
+| 13 | `PositionHanging` | hanging | restricted by default | undefined |
+| 14 | `PositionSquatting` | squatting | free | standing/kneeling boundary |
+| 15 | `PositionClimbing` | climbing | climbing | climbing tier |
+| 16 | `PositionSwimming` | swimming | swimming | standing/swimming tier |
+| 17 | `PositionFloatingInWater` | floating | restricted by default | swimming tier |
+| 18 | `PositionFlying` | flying | flying | standing/flying tier |
+| 19 | `PositionRiding` | riding | restricted | sitting tier for height comparisons |
+| 20 | `PositionFloatingInZeroGravity` | floating | zero gravity | standing/floating tier |
+
+`BodyPrototype` loads valid positions from `BodyProtosPositions`. If an older prototype has no position rows, it falls back to a broad default set. Move speeds load from `MoveSpeeds` and point to a position ID. `Body.CurrentSpeeds` is then keyed by `IPositionState`, so a body can only move in positions for which it has speed rows.
+
+The zero-gravity bootstrap path ensures every body prototype has a zero-gravity floating move speed, copying flying, standing, or any available speed as a template.
+
+## Command Flow
+
+`PositionModule` owns player-facing posture commands:
+
+- `stand`, `stand easy`, `stand attention`;
+- `sit`, `rest`, `lounge`, `sprawl`, `prone`, `kneel`, `prostrate`, `squat`;
+- `lean` and `slump` for characters, or for items when the next argument resolves to a local item;
+- `position`, `hang`, `lean`, and `slump` for item positioning;
+- `fly`, `land`, `swim`, `climb`, `dive`, and `ascend` for movement-mode positions;
+- `pmote` and `omote` for long-description position emotes.
+
+For character positions, `_positionRegex` parses the desired state, optional modifier, optional target, optional pmote in square brackets, and optional transition emote in parentheses. `Position_General` then:
+
+1. chooses the desired `PositionState`;
+2. validates emote and pmote text;
+3. maps textual modifiers onto `PositionModifier`;
+4. resolves the target, including table and chair special handling;
+5. calls `MovePosition(...)` or `ResetPositionTarget(...)`.
+
+For item positions, `_positionItemRegex` parses command, item, optional modifier, optional target, optional omote, and optional actor emote. `position <item> <target>` uses the default `by` modifier. `hang`, `lean`, and `slump` set the item's position state as well as its target relationship. Reset clears the target, modifier, state, and omote through `SetPosition(PositionUndefined.Instance, PositionModifier.None, null, imote)`.
+
+## Movement Flow
+
+`CharacterMovement.GetRequiredMovementPosition` chooses mandatory movement states from exits and terrain:
+
+- climb exits require `PositionClimbing`;
+- fly exits require `PositionFlying`;
+- swim transitions require `PositionSwimming`;
+- zero-gravity cells require `PositionFloatingInZeroGravity` unless the transition is swim-only, swim-to-land, or fly-only.
+
+`CanMoveInternal` rejects `Restricted` positions and `FreeIfNotInOn` positions that are currently in or on a target. It then chooses a moving position:
+
+- swimming, climbing, flying, and zero-gravity floating keep their own state;
+- other states use `TransitionOnMovement` if present, otherwise the current state;
+- zero gravity can replace that with `PositionFloatingInZeroGravity`.
+
+`CouldMove` follows similar rules and finds an available `IMoveSpeed` for the moving position. The ordinary fallback path only tries standing, prostrate, prone, and zero-gravity floating. This is why non-legged actors should generally be modeled with appropriate standing/upright move speeds rather than a new "wheeled" or "tracked" posture state.
+
+Movement display text comes primarily from `IMoveSpeed` (`FirstPersonVerb`, `ThirdPersonVerb`, `PresentParticiple`), not from `IPositionState.DescribeLocationMovement3rd`.
+
+## Runtime Consumers
+
+Position states are consumed outside the position module in several important places:
+
+- `CharacterPosition` validates whether a target can accept a position and whether a character can change state, including body ability checks such as sitting up.
+- `BodyMovement` exposes current and available speeds.
+- `BodyBiology.CurrentContextualSize` changes effective size for swimming, prone-like states, exits, explosive damage, and mounted contexts.
+- `CharacterMovement` uses `SafeFromFalling`, `MoveRestrictions`, `TransitionOnMovement`, and move speed availability.
+- `ZeroGravityMovementHelper` enforces floating state for characters and items in zero gravity.
+- `Cell` changes items and characters to floating-in-water or zero-gravity floating when room layers demand it.
+- combat strategies and combat moves use `CompareTo` for cover height, firing posture, ranged bonuses, melee assumptions, and forced movement decisions.
+- sleep commands and animal AI compare the current state to a race's `MinimumSleepingPosition`.
+- infection recovery checks posture height against lounging.
+- mount code sets rider and mount states through riding or mounted movement calls.
+- builder combat actions and ranged cover builders use `PositionState.GetState(string)` for position lookup.
+
+## Description Rules
+
+Base `PositionState.Describe` uses:
+
+- no target: `<default description> here`;
+- target with `Before`, `Behind`, `In`, `On`, `Under`, or `Around`: explicit preposition plus target;
+- target with `None`: `by <target>`.
+
+State overrides handle special English:
+
+- leaning/slumped plus `None` target: "against";
+- hanging plus `None` target: "from";
+- undefined omits a posture word;
+- floating-in-water and hanging do not inject "here" before a target phrase.
+
+`DescribeTransition` is only valid for states that characters can directly move into through normal posture commands. Runtime-set states such as undefined, hanging, floating-in-water, and riding deliberately throw if a caller asks them for a transition emote.
+
+## Height Comparison
+
+Height comparison is not a strict numeric ordering. It is a posture relationship used by game rules. Standing-like states are higher than sitting and prone-like states; sprawled is effectively lowest; flying, swimming, climbing, and zero-gravity floating map into existing comparison tiers.
+
+The dynamic fallback must never recursively call itself. When adding a new `PositionState` class, add an explicit comparison overload or choose a base-state mapping in `PositionState.CompareTo(dynamic state)`.
+
+Current base mappings:
+
+- flying and zero-gravity floating compare as standing;
+- climbing compares as sitting;
+- swimming and floating-in-water compare as swimming/standing tier;
+- slumped and lounging compare as sitting tier;
+- leaning, standing attention, standing easy, and squatting compare through standing;
+- riding compares as sitting tier;
+- hanging and undefined return `Undefined`.
+
+## Physiology Guidance
+
+Valid positions and movement verbs belong on body prototypes and move speed data. This is the right extension point for most animals and robots:
+
+- legged humanoids and many quadrupeds use standing/prostrate/prone plus race-appropriate movement verbs;
+- swimming bodies need swimming speeds and valid swimming positions;
+- flying bodies need flying speeds and enough wings to satisfy flight checks;
+- climbing-capable bodies need climbing speeds and usable limbs that make sense for the body plan;
+- wheeled or tracked robots should usually keep an upright/mobile posture state and use move speeds such as "roll", "drive", "trundle", or "crawl";
+- robots that cannot crouch, kneel, sit, or go prone should omit those valid positions from their body prototype;
+- robots that can brace, dock, fold, or park in a way that has distinct height/combat/movement consequences may justify a future generic state, but that should be modeled as posture rather than locomotion media.
+
+Avoid adding separate states such as "wheeled", "tracked", or "legged" unless engine rules genuinely need to distinguish them after move speeds, limbs, and body prototype positions have been considered.
+
+## Known Gaps and Future Work
+
+- `PositionFloatingInWater` and `PositionFloatingInZeroGravity` both use the lookup text `floating`. `PositionState.GetState("floating")` returns the first registered match, which is water floating. If builders need to select zero-gravity floating by text, introduce unique aliases or a stricter lookup flow before changing persisted IDs.
+- `DescribeLocationMovement3rd` is effectively unused and only zero-gravity floating overrides it. Either remove it from the contract in a breaking cleanup or give every state a meaningful value.
+- `CheckClimbingStillValid` is still a placeholder. Climbing validity should eventually re-check room layer, climb exits, limb usability, and whether the character still has a legal climbing target.
+- `MostUprightMobilePosition` only considers standing, prostrate, and prone outside the current fall-safety state. That is suitable for current movement rules, but any future generic "braced/mobile" state would need to participate there and in `CouldMove`.
+- Body prototype tooling should make it easier to audit valid positions and move speeds together, especially for non-humanoid animals and robots.
+- Combat builder position lookup should be revisited when duplicate or alias-heavy state labels are introduced.

--- a/MudSharpCore Unit Tests/PositionStateTests.cs
+++ b/MudSharpCore Unit Tests/PositionStateTests.cs
@@ -1,0 +1,63 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Body.Position;
+using MudSharp.Body.Position.PositionStates;
+using MudSharp.Form.Shape;
+using MudSharp.Framework;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class PositionStateTests
+{
+	[TestMethod]
+	public void CompareTo_DynamicFallbackStates_DoNotRecurse()
+	{
+		dynamic floatingInWater = PositionFloatingInWater.Instance;
+		dynamic riding = PositionRiding.Instance;
+		dynamic hanging = PositionHanging.Instance;
+		dynamic undefined = PositionUndefined.Instance;
+
+		Assert.AreEqual(PositionHeightComparison.Equivalent, PositionStanding.Instance.CompareTo(floatingInWater));
+		Assert.AreEqual(PositionHeightComparison.Higher, PositionStanding.Instance.CompareTo(riding));
+		Assert.AreEqual(PositionHeightComparison.Undefined, PositionStanding.Instance.CompareTo(hanging));
+		Assert.AreEqual(PositionHeightComparison.Undefined, PositionStanding.Instance.CompareTo(undefined));
+	}
+
+	[TestMethod]
+	public void HangingDescribe_BeforeTarget_UsesSpatialPreposition()
+	{
+		var voyeur = new Mock<IPerceiver>();
+		var target = GetTarget("a ceiling hook");
+
+		Assert.AreEqual(
+			"hanging before a ceiling hook",
+			PositionHanging.Instance.Describe(voyeur.Object, target.Object, PositionModifier.Before, null));
+	}
+
+	[TestMethod]
+	public void FloatingInWaterDescribe_NoHere_DoesNotLeaveTrailingSpace()
+	{
+		var voyeur = new Mock<IPerceiver>();
+
+		Assert.AreEqual(
+			"floating",
+			PositionFloatingInWater.Instance.Describe(voyeur.Object, null, PositionModifier.None, null, false));
+	}
+
+	private static Mock<IPerceivable> GetTarget(string description)
+	{
+		var target = new Mock<IPerceivable>();
+		target
+			.Setup(x => x.HowSeen(
+				It.IsAny<IPerceiver>(),
+				It.IsAny<bool>(),
+				It.IsAny<DescriptionType>(),
+				It.IsAny<bool>(),
+				It.IsAny<PerceiveIgnoreFlags>()))
+			.Returns(description);
+		return target;
+	}
+}

--- a/MudSharpCore/Body/Position/PositionState.cs
+++ b/MudSharpCore/Body/Position/PositionState.cs
@@ -282,7 +282,32 @@ public abstract class PositionState : FrameworkItem, IPositionState
     /// <returns>An enum representing the result of the comparison</returns>
     public virtual PositionHeightComparison CompareTo(dynamic state)
     {
-        return CompareTo(state);
+        return state switch
+        {
+            PositionFlying position => CompareTo(position),
+            PositionFloatingInZeroGravity position => CompareTo(position),
+            PositionClimbing position => CompareTo(position),
+            PositionSwimming position => CompareTo(position),
+            PositionFloatingInWater position => CompareTo(position),
+            PositionSitting position => CompareTo(position),
+            PositionStanding position => CompareTo(position),
+            PositionKneeling position => CompareTo(position),
+            PositionSlumped position => CompareTo(position),
+            PositionProne position => CompareTo(position),
+            PositionLyingDown position => CompareTo(position),
+            PositionSprawled position => CompareTo(position),
+            PositionProstrate position => CompareTo(position),
+            PositionLeaning position => CompareTo(position),
+            PositionStandingAttention position => CompareTo(position),
+            PositionSquatting position => CompareTo(position),
+            PositionStandingEasy position => CompareTo(position),
+            PositionLounging position => CompareTo(position),
+            PositionHanging position => CompareTo(position),
+            PositionRiding position => CompareTo(position),
+            PositionUndefined position => CompareTo(position),
+            null => PositionHeightComparison.Undefined,
+            _ => PositionHeightComparison.Undefined
+        };
     }
 
     public virtual PositionHeightComparison CompareTo(PositionFlying state)
@@ -303,6 +328,26 @@ public abstract class PositionState : FrameworkItem, IPositionState
     public virtual PositionHeightComparison CompareTo(PositionSwimming state)
     {
         return CompareTo(PositionStanding.Instance);
+    }
+
+    public virtual PositionHeightComparison CompareTo(PositionFloatingInWater state)
+    {
+        return CompareTo(PositionSwimming.Instance);
+    }
+
+    public virtual PositionHeightComparison CompareTo(PositionHanging state)
+    {
+        return PositionHeightComparison.Undefined;
+    }
+
+    public virtual PositionHeightComparison CompareTo(PositionRiding state)
+    {
+        return CompareTo(PositionSitting.Instance);
+    }
+
+    public virtual PositionHeightComparison CompareTo(PositionUndefined state)
+    {
+        return PositionHeightComparison.Undefined;
     }
 
     public virtual PositionHeightComparison CompareTo(PositionSitting state)

--- a/MudSharpCore/Body/Position/PositionStates/PositionFloatingInWater.cs
+++ b/MudSharpCore/Body/Position/PositionStates/PositionFloatingInWater.cs
@@ -26,25 +26,25 @@ public class PositionFloatingInWater : PositionState
         string emoteText = emote != null ? $", {emote.ParseFor(voyeur)}" : "";
         if (target == null)
         {
-            return $"floating {(useHere ? "here" : "")}{emoteText}";
+            return $"floating{(useHere ? " here" : "")}{emoteText}";
         }
 
         switch (modifier)
         {
             case PositionModifier.Before:
-                return $"floating {(useHere ? "here" : "")} before {target.HowSeen(voyeur)}{emoteText}";
+                return $"floating before {target.HowSeen(voyeur)}{emoteText}";
             case PositionModifier.Behind:
-                return $"floating {(useHere ? "here" : "")} behind {target.HowSeen(voyeur)}{emoteText}";
+                return $"floating behind {target.HowSeen(voyeur)}{emoteText}";
             case PositionModifier.In:
-                return $"floating {(useHere ? "here" : "")} in {target.HowSeen(voyeur)}{emoteText}";
+                return $"floating in {target.HowSeen(voyeur)}{emoteText}";
             case PositionModifier.On:
-                return $"floating {(useHere ? "here" : "")} on {target.HowSeen(voyeur)}{emoteText}";
+                return $"floating on {target.HowSeen(voyeur)}{emoteText}";
             case PositionModifier.Under:
-                return $"floating {(useHere ? "here" : "")} under {target.HowSeen(voyeur)}{emoteText}";
+                return $"floating under {target.HowSeen(voyeur)}{emoteText}";
             case PositionModifier.Around:
-                return $"floating {(useHere ? "here" : "")} around {target.HowSeen(voyeur)}{emoteText}";
+                return $"floating around {target.HowSeen(voyeur)}{emoteText}";
             default:
-                return $"floating {(useHere ? "here" : "")} by {target.HowSeen(voyeur)}{emoteText}";
+                return $"floating by {target.HowSeen(voyeur)}{emoteText}";
         }
     }
 

--- a/MudSharpCore/Body/Position/PositionStates/PositionHanging.cs
+++ b/MudSharpCore/Body/Position/PositionStates/PositionHanging.cs
@@ -32,17 +32,17 @@ public class PositionHanging : PositionState
         switch (modifier)
         {
             case PositionModifier.Before:
-                return $"hanging{(useHere ? " here" : "")}{target.HowSeen(voyeur)}{emoteText}";
+                return $"hanging before {target.HowSeen(voyeur)}{emoteText}";
             case PositionModifier.Behind:
-                return $"hanging{(useHere ? " here" : "")}behind {target.HowSeen(voyeur)}{emoteText}";
+                return $"hanging behind {target.HowSeen(voyeur)}{emoteText}";
             case PositionModifier.In:
-                return $"hanging{(useHere ? " here" : "")} in {target.HowSeen(voyeur)}{emoteText}";
+                return $"hanging in {target.HowSeen(voyeur)}{emoteText}";
             case PositionModifier.On:
-                return $"hanging{(useHere ? " here" : "")} on {target.HowSeen(voyeur)}{emoteText}";
+                return $"hanging on {target.HowSeen(voyeur)}{emoteText}";
             case PositionModifier.Under:
-                return $"hanging{(useHere ? " here" : "")} under {target.HowSeen(voyeur)}{emoteText}";
+                return $"hanging under {target.HowSeen(voyeur)}{emoteText}";
             case PositionModifier.Around:
-                return $"hanging{(useHere ? " here" : "")} around {target.HowSeen(voyeur)}{emoteText}";
+                return $"hanging around {target.HowSeen(voyeur)}{emoteText}";
             default:
                 return $"hanging from {target.HowSeen(voyeur)}{emoteText}";
         }

--- a/MudSharpCore/Commands/Modules/PositionModule.cs
+++ b/MudSharpCore/Commands/Modules/PositionModule.cs
@@ -37,12 +37,12 @@ internal class PositionModule : Module<ICharacter>
 
     private static readonly Regex _positionRegex =
         new(
-            @"^(stand|lean|squat|slump|sit|rest|lounge|sprawl|prone|kneel|prostrate) {0,1}(attention|easy){0,1} {0,1}(reset|normal|revert|on|in|by|under|underneath|below|beneath|before|behind){0,1} {0,1}([\w]{0,}[a-zA-Z.-]{0,}) {0,1}(?:\[(.*)\]){0,1} {0,1}(?:\((.*)\)){0,1}$",
+            @"^(stand|lean|squat|slump|sit|rest|lounge|sprawl|prone|kneel|prostrate) {0,1}(attention|easy){0,1} {0,1}(reset|normal|revert|on|in|inside|by|against|under|underneath|below|beneath|before|behind|around){0,1} {0,1}([\w]{0,}[a-zA-Z.-]{0,}) {0,1}(?:\[(.*)\]){0,1} {0,1}(?:\((.*)\)){0,1}$",
             RegexOptions.IgnoreCase);
 
     private static readonly Regex _positionItemRegex =
         new(
-            @"^(position|lean|slump|hang) ([\w]{0,}[a-zA-Z.-]{1,}) (reset|normal|revert|by|on|in|under|before|behind|against|from){1} {0,1}([\w]{0,}[a-zA-Z.-]{0,}) {0,1}(?:\[(.*)\]){0,1} {0,1}(?:\((.*)\)){0,1}$",
+            @"^(?<command>position|lean|slump|hang) (?<item>[\w]{0,}[a-zA-Z.-]{1,})(?: (?:(?<modifier>reset|normal|revert|by|on|in|inside|under|underneath|below|beneath|before|behind|around|against|from){1}(?: {0,1}(?<target>[\w]{0,}[a-zA-Z.-]{1,})){0,1}|(?<target>[\w]{0,}[a-zA-Z.-]{1,}))){0,1} {0,1}(?:\[(?<omote>.*)\]){0,1} {0,1}(?:\((?<emote>.*)\)){0,1}$",
             RegexOptions.IgnoreCase);
 
     private PositionModule()
@@ -809,6 +809,9 @@ The syntax can be either of the following:
                 case "before":
                     desiredModifier = PositionModifier.Before;
                     break;
+                case "around":
+                    desiredModifier = PositionModifier.Around;
+                    break;
                 case "by":
                 case "against":
                     desiredModifier = PositionModifier.None;
@@ -923,10 +926,17 @@ The syntax can be either of the following:
             return;
         }
 
+        var commandText = match.Groups["command"].Value.ToLowerInvariant();
+        var itemText = match.Groups["item"].Value;
+        var modifierText = match.Groups["modifier"].Value.ToLowerInvariant();
+        var targetText = match.Groups["target"].Value;
+        var omoteText = match.Groups["omote"].Value;
+        var emoteText = match.Groups["emote"].Value;
+
         PlayerEmote emote = null;
-        if (match.Groups[5].Value.Length > 0)
+        if (emoteText.Length > 0)
         {
-            emote = new PlayerEmote(match.Groups[5].Value, actor.Body);
+            emote = new PlayerEmote(emoteText, actor.Body);
             if (!emote.Valid)
             {
                 actor.OutputHandler.Send(emote.ErrorMessage);
@@ -934,7 +944,7 @@ The syntax can be either of the following:
             }
         }
 
-        IGameItem item = actor.Body.TargetLocalItem(match.Groups[2].Value);
+        IGameItem item = actor.Body.TargetLocalItem(itemText);
         if (item == null)
         {
             actor.OutputHandler.Send("You do not see that here to position.");
@@ -948,9 +958,9 @@ The syntax can be either of the following:
         }
 
         PlayerEmote imote = null;
-        if (match.Groups[4].Value.Length > 0)
+        if (omoteText.Length > 0)
         {
-            imote = new PlayerEmote(match.Groups[4].Value, actor.Body);
+            imote = new PlayerEmote(omoteText, actor.Body);
             if (!imote.Valid)
             {
                 actor.OutputHandler.Send(imote.ErrorMessage);
@@ -958,49 +968,82 @@ The syntax can be either of the following:
             }
         }
 
-        MixedEmoteOutput output = null;
-        if (match.Groups[2].Value == "reset" || match.Groups[2].Value == "normal" ||
-            match.Groups[2].Value == "revert")
+        var desiredState = commandText switch
         {
-            if (item.PositionTarget == null)
+            "hang" => PositionHanging.Instance,
+            "lean" => PositionLeaning.Instance,
+            "slump" => PositionSlumped.Instance,
+            _ => item.PositionState
+        };
+
+        MixedEmoteOutput output;
+        if (modifierText == "reset" || modifierText == "normal" || modifierText == "revert")
+        {
+            if (item.PositionTarget == null && item.PositionModifier == PositionModifier.None &&
+                item.PositionState == PositionUndefined.Instance)
             {
                 actor.OutputHandler.Send(item.HowSeen(actor.Body, true) + " is already in a normal position.");
                 return;
             }
 
-            string text;
-            switch (item.PositionModifier)
+            if (item.PositionTarget == null)
             {
-                case PositionModifier.On:
-                    text = " down off of ";
-                    break;
-                case PositionModifier.Under:
-                    text = " out from under ";
-                    break;
-                case PositionModifier.In:
-                    text = " out of ";
-                    break;
-                case PositionModifier.Behind:
-                    text = " out from behind ";
-                    break;
-                default:
-                    text = " away from ";
-                    break;
+                output =
+                    new MixedEmoteOutput(
+                        new Emote("@ reset|resets the position of $0", actor.Body, item),
+                        flags: OutputFlags.SuppressObscured);
+            }
+            else
+            {
+                var text = item.PositionModifier switch
+                {
+                    PositionModifier.On => " down off of ",
+                    PositionModifier.Under => " out from under ",
+                    PositionModifier.In => " out of ",
+                    PositionModifier.Behind => " out from behind ",
+                    PositionModifier.Before => " away from before ",
+                    PositionModifier.Around => " away from around ",
+                    PositionModifier.None when item.PositionState == PositionHanging.Instance => " down from ",
+                    _ => " away from "
+                };
+
+                output =
+                    new MixedEmoteOutput(
+                        new Emote("@ move|moves $0" + text + "$1", actor.Body, item, item.PositionTarget),
+                        flags: OutputFlags.SuppressObscured);
             }
 
-            output =
-                new MixedEmoteOutput(
-                    new Emote("@ move|moves $0" + text + "$1", actor.Body, item, item.PositionTarget),
-                    flags: OutputFlags.SuppressObscured);
             output.Append(emote);
             actor.OutputHandler.Handle(output);
-            item.SetTarget(null);
-            item.SetModifier(PositionModifier.None);
-            item.SetEmote(imote);
+            item.SetPosition(PositionUndefined.Instance, PositionModifier.None, null, imote);
             return;
         }
 
-        IPerceivable target = actor.Body.TargetLocal(match.Groups[3].Value);
+        if (modifierText.Length == 0 && targetText.Length == 0)
+        {
+            if (commandText == "position")
+            {
+                actor.OutputHandler.Send("What do you want to position " + item.HowSeen(actor.Body) + " against?");
+                return;
+            }
+
+            item.SetPosition(desiredState, PositionModifier.None, null, imote);
+            output =
+                new MixedEmoteOutput(
+                    new Emote($"@ {commandText}|{commandText}s $0", actor.Body, item),
+                    flags: OutputFlags.SuppressObscured);
+            output.Append(emote);
+            actor.OutputHandler.Handle(output);
+            return;
+        }
+
+        if (targetText.Length == 0)
+        {
+            actor.OutputHandler.Send("What do you want to position " + item.HowSeen(actor.Body) + " against?");
+            return;
+        }
+
+        IPerceivable target = actor.Body.TargetLocal(targetText);
         if (target == null)
         {
             actor.OutputHandler.Send("You do not see that here to position " + item.HowSeen(actor.Body) +
@@ -1009,11 +1052,21 @@ The syntax can be either of the following:
         }
 
         PositionModifier desiredModifier;
-        switch (match.Groups[2].Value.ToLowerInvariant())
+        switch (modifierText)
         {
+            case "":
+                desiredModifier = PositionModifier.None;
+                break;
             case "on":
                 desiredModifier = PositionModifier.On;
                 break;
+            case "inside":
+            case "in":
+                desiredModifier = PositionModifier.In;
+                break;
+            case "underneath":
+            case "below":
+            case "beneath":
             case "under":
                 desiredModifier = PositionModifier.Under;
                 break;
@@ -1023,8 +1076,8 @@ The syntax can be either of the following:
             case "behind":
                 desiredModifier = PositionModifier.Behind;
                 break;
-            case "in":
-                desiredModifier = PositionModifier.In;
+            case "around":
+                desiredModifier = PositionModifier.Around;
                 break;
             case "by":
             case "against":
@@ -1034,18 +1087,34 @@ The syntax can be either of the following:
                 break;
         }
 
-        if (!target.CanBePositionedAgainst(item.PositionState, desiredModifier))
+        if (!target.CanBePositionedAgainst(desiredState, desiredModifier))
         {
             actor.OutputHandler.Send(target.HowSeen(actor.Body, true) + " cannot be positioned against in that way.");
             return;
         }
 
-        item.SetTarget(target);
-        item.SetModifier(desiredModifier);
-        item.SetEmote(imote);
+        item.SetPosition(desiredState, desiredModifier, target, imote);
+        var displayModifier = modifierText switch
+        {
+            "" when commandText == "lean" || commandText == "slump" => "against",
+            "" when commandText == "hang" => "from",
+            "" => "by",
+            "inside" => "in",
+            "underneath" or "below" or "beneath" => "under",
+            "against" when commandText == "lean" || commandText == "slump" => "against",
+            "from" when commandText == "hang" => "from",
+            _ => modifierText
+        };
+        var verb = commandText switch
+        {
+            "hang" => "hang|hangs",
+            "lean" => "lean|leans",
+            "slump" => "slump|slumps",
+            _ => "position|positions"
+        };
         output =
             new MixedEmoteOutput(
-                new Emote("@ position|positions $0 " + match.Groups[2].Value + " $1", actor.Body, item,
+                new Emote("@ " + verb + " $0 " + displayModifier + " $1", actor.Body, item,
                     item.PositionTarget), flags: OutputFlags.SuppressObscured);
         output.Append(emote);
         actor.OutputHandler.Handle(output);
@@ -1118,6 +1187,7 @@ The syntax of this is as follows:
 
 	#3position <item> [<modifier>] <target>#0 - positions an item relative to another target
 	#3position <item> reset#0 - resets an item to just generally in the room
+	#3hang|lean|slump <item> [<modifier> <target>]#0 - sets an item's visible state, optionally relative to another target
 
 Like with the player version you can have an optional omote set within square brackets #3[]#0, an an optional emote addendum after that with round brackets #3()#0.
 
@@ -1128,10 +1198,16 @@ For example:
 	#3slump shirt [in an unceremonious heap] (discarding it without a second thought)#0", AutoHelp.HelpArg)]
     protected static void Position(ICharacter actor, string input)
     {
-        if (_positionItemRegex.IsMatch(input))
+        var itemMatch = _positionItemRegex.Match(input);
+        if (itemMatch.Success)
         {
-            Item_Position(actor, input);
-            return;
+            var commandText = itemMatch.Groups["command"].Value.ToLowerInvariant();
+            if (commandText == "position" || commandText == "hang" ||
+                actor.Body.TargetLocalItem(itemMatch.Groups["item"].Value) != null)
+            {
+                Item_Position(actor, input);
+                return;
+            }
         }
 
         Match match = _positionRegex.Match(input);


### PR DESCRIPTION
## Summary
- Fixed the `PositionState.CompareTo(dynamic)` recursion bug and added explicit handling for floating-in-water, hanging, riding, and undefined states.
- Corrected item-position parsing in `PositionModule` so reset, target lookup, omote/emote capture, and `hang`/`lean`/`slump` item states work as intended.
- Cleaned up bad hanging and floating descriptions so location echoes read correctly.
- Added a dedicated design doc for the position-state system, including runtime consumers, movement flow, and physiology guidance for robots/animals.
- Added regression coverage for the comparison fallback and description edge cases.

## Testing
- `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510` passed.
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510` passed.