### PR TITLE
Respect cash payout targets before bank fallback in auction settlement

### DIFF
--- a/MudSharpCore Unit Tests/AuctionHouseSettlementTests.cs
+++ b/MudSharpCore Unit Tests/AuctionHouseSettlementTests.cs
@@ -221,4 +221,51 @@ public class AuctionHouseSettlementTests
 		profitsAccount.Verify(x => x.WithdrawFromTransaction(It.IsAny<decimal>(), It.IsAny<string>()), Times.Never);
 		payoutAccount.Verify(x => x.DepositFromTransaction(170.0M, It.IsAny<string>()), Times.Once);
 	}
+
+	[TestMethod]
+	public void BuyoutItem_CashPayoutTargetWithOwnedBank_QueuesCashCollection()
+	{
+		var house = CreateAuctionHouse(out _, out var payoutAccount, out _);
+		Mock<ICharacter> seller = new();
+		seller.SetupGet(x => x.Id).Returns(65L);
+		seller.SetupGet(x => x.Name).Returns("Seller");
+		seller.SetupGet(x => x.FrameworkItemType).Returns("Character");
+		payoutAccount.Setup(x => x.IsAccountOwner(seller.Object)).Returns(true);
+
+		Mock<ICharacter> bidder = new();
+		bidder.SetupGet(x => x.Id).Returns(66L);
+		bidder.SetupGet(x => x.Name).Returns("Bidder");
+		bidder.SetupGet(x => x.FrameworkItemType).Returns("Character");
+
+		Mock<IGameItem> asset = new();
+		asset.SetupGet(x => x.Id).Returns(73L);
+		asset.SetupGet(x => x.Name).Returns("ring");
+		asset.SetupGet(x => x.FrameworkItemType).Returns("GameItem");
+		asset.Setup(x => x.HowSeen(It.IsAny<IPerceiver>(), It.IsAny<bool>(), It.IsAny<DescriptionType>(),
+				It.IsAny<bool>(), It.IsAny<PerceiveIgnoreFlags>()))
+		     .Returns("a ring");
+
+		AuctionItem lot = new()
+		{
+			Asset = asset.Object,
+			Seller = seller.Object,
+			PayoutTarget = seller.Object,
+			MinimumPrice = 100.0M,
+			BuyoutPrice = 200.0M,
+			ListingDateTime = MudDateTime.Never,
+			FinishingDateTime = MudDateTime.Never
+		};
+
+		house.AddAuctionItem(lot);
+		house.BuyoutItem(lot, new AuctionBid
+		{
+			Bidder = bidder.Object,
+			Bid = 200.0M,
+			BidDateTime = MudDateTime.Never
+		});
+
+		Assert.AreEqual(200.0M, house.CashBalance);
+		Assert.AreEqual(170.0M, house.BidderRefundsOwed[seller.Object.Id]);
+		payoutAccount.Verify(x => x.DepositFromTransaction(It.IsAny<decimal>(), It.IsAny<string>()), Times.Never);
+	}
 }

--- a/MudSharpCore/Economy/Auctions/AuctionHouse.cs
+++ b/MudSharpCore/Economy/Auctions/AuctionHouse.cs
@@ -335,6 +335,12 @@ public class AuctionHouse : SaveableItem, IAuctionHouse, IPostCharacterLoadFinal
             return true;
         }
 
+        if (payoutTarget is ICharacter character)
+        {
+            BidderRefundsOwed[character.Id] += amount;
+            return true;
+        }
+
         IBankAccount payoutAccount = Gameworld.BankAccounts.FirstOrDefault(x =>
             x.AccountStatus == BankAccountStatus.Active &&
             x.Currency == EconomicZone.Currency &&
@@ -351,12 +357,6 @@ public class AuctionHouse : SaveableItem, IAuctionHouse, IPostCharacterLoadFinal
             payoutAccount.DepositFromTransaction(amount, $"Proceeds from a successful auction of {assetDescription} with {Name}");
             payoutAccount.Bank.CurrencyReserves[EconomicZone.Currency] += amount;
             payoutAccount.Bank.Changed = true;
-            return true;
-        }
-
-        if (payoutTarget is ICharacter character)
-        {
-            BidderRefundsOwed[character.Id] += amount;
             return true;
         }
 


### PR DESCRIPTION
## Summary
- Fixed auction settlement so seller payouts explicitly marked as `cash` stay on the auction house’s virtual balance even if the seller also owns an active bank account.
- Added a regression test covering the cash-payout path for a seller who has an owned bank account.

## Testing
- Added unit coverage in `MudSharpCore Unit Tests/AuctionHouseSettlementTests.cs`.
- Not run (not requested).