### PR TITLE
[codex] Fix tollkeeper review regressions

### DIFF
--- a/MudSharpCore/Commands/Modules/NPCOnlyModule.cs
+++ b/MudSharpCore/Commands/Modules/NPCOnlyModule.cs
@@ -80,18 +80,18 @@ The syntax is:
 			return;
 		}
 
-		if (tollkeeperAis.All(x => !x.IsReadyToBeUsed))
-		{
-			actor.OutputHandler.Send("Your tollkeeper AI is not ready to be used yet.");
-			return;
-		}
-
 		var ss = new StringStack(command.RemoveFirstWord());
 		if (ss.IsFinished)
 		{
 			if (actor.RemoveAllEffects<ITollkeeperModeEffect>(fireRemovalAction: true))
 			{
 				actor.OutputHandler.Handle(new EmoteOutput(new Emote("@ are|is no longer imposing a toll.", actor)));
+				return;
+			}
+
+			if (tollkeeperAis.All(x => !x.IsReadyToBeUsed))
+			{
+				actor.OutputHandler.Send("Your tollkeeper AI is not ready to be used yet.");
 				return;
 			}
 
@@ -108,6 +108,12 @@ The syntax is:
 			}
 
 			actor.OutputHandler.Send("You are not currently imposing a toll.");
+			return;
+		}
+
+		if (tollkeeperAis.All(x => !x.IsReadyToBeUsed))
+		{
+			actor.OutputHandler.Send("Your tollkeeper AI is not ready to be used yet.");
 			return;
 		}
 

--- a/MudSharpCore/NPC/AI/TollkeeperAI.cs
+++ b/MudSharpCore/NPC/AI/TollkeeperAI.cs
@@ -942,15 +942,23 @@ public class TollkeeperAI : PathingAIBase
 			return;
 		}
 
+		var depositedAny = false;
 		foreach (var item in items.Where(x => !x.Deleted && x.InInventoryOf == tollkeeper.Body).ToList())
 		{
 			if (tollkeeper.Body.CanPut(item, containerItem, null, 0, true))
 			{
 				tollkeeper.Body.Put(item, containerItem, null, silent: true);
+				depositedAny = true;
 			}
 		}
 
 		SecureContainerAfterDeposit(tollkeeper, containerItem);
+		if (!depositedAny)
+		{
+			EmitEmote(tollkeeper, DepositFailedEmote, 0.0M, exit, tollkeeper, containerItem);
+			return;
+		}
+
 		EmitEmote(tollkeeper, DepositCompleteEmote, 0.0M, exit, tollkeeper, containerItem);
 	}
 


### PR DESCRIPTION
## Summary
- Allow NPCs to clear toll mode even when their tollkeeper AI is currently unready.
- Treat toll deposits as failed when no carried toll money can be stored in the configured container.

## Validation
- dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510
- scripts\test-unit-core.ps1