### PR TITLE
[codex] Implement palm and steal commands

### DIFF
--- a/DatabaseSeeder/Seeders/SkillPackageSeeder.cs
+++ b/DatabaseSeeder/Seeders/SkillPackageSeeder.cs
@@ -558,6 +558,7 @@ Please choose either #6simple#0 or #6complex#0: ", (context, answers) => true,
         TraitDefinition hideTrait = GetSkill("Hide", "Stealth");
         TraitDefinition sneakTrait = GetSkill("Sneak", "Stealth");
         TraitDefinition palmTrait = GetSkill("Palm", "Stealth");
+        TraitDefinition stealTrait = GetSkill("Steal", "Stealing", "Stealth");
         TraitDefinition lockpickTrait = GetSkill("Pick Locks", "Picklock", "Security");
         TraitDefinition swimTrait = GetSkill("Swim", "Swimming", "Athletics");
         TraitDefinition runTrait = GetSkill("Run", "Running", "Athletics");
@@ -739,6 +740,10 @@ Please choose either #6simple#0 or #6complex#0: ", (context, answers) => true,
                     continue;
                 case CheckType.PalmCheck:
                     AddCheck(check, new TraitExpression { Expression = $"palm:{palmTrait.Id}" },
+                        templates["Skill Check"].Id, Difficulty.Impossible);
+                    continue;
+                case CheckType.StealCheck:
+                    AddCheck(check, new TraitExpression { Expression = $"steal:{stealTrait.Id}" },
                         templates["Skill Check"].Id, Difficulty.Impossible);
                     continue;
                 case CheckType.HideItemCheck:

--- a/DatabaseSeeder/Seeders/SkillSeeder.cs
+++ b/DatabaseSeeder/Seeders/SkillSeeder.cs
@@ -277,6 +277,7 @@ Again, the choices you make here can be fixed later so don't stress it too great
                 case CheckType.HideCheck:
                 case CheckType.SneakCheck:
                 case CheckType.PalmCheck:
+                case CheckType.StealCheck:
                 case CheckType.HideItemCheck:
                 case CheckType.UninstallDoorCheck:
                 case CheckType.SkillTeachCheck:

--- a/Design Documents/Economy_System_Workflows_and_Integration.md
+++ b/Design Documents/Economy_System_Workflows_and_Integration.md
@@ -116,6 +116,10 @@ Practical note:
 - description patterns determine how values are surfaced all across the engine
 - the stock Pounds package now seeds historical compact `£sd` notation, using `d` forms below one shilling, slash forms from one shilling to less than one pound, full `£/s/d` forms above one pound, quarter-penny glyphs (`¼`, `½`, `¾`), and `–` for zero slots in slash notation
 
+Stealth command integration:
+
+- `palm` and `steal` use the same currency parsing and physical `CurrencyGameItemComponent` piles as ordinary get/put flows, so exact or inexact loose money can move through character inventory and container state without adding a separate economy ledger path
+
 ### Economic Zones and Taxes
 Builders use economic zones to define:
 

--- a/Design Documents/Item_System_Runtime_Model.md
+++ b/Design Documents/Item_System_Runtime_Model.md
@@ -33,6 +33,8 @@ Item-facing event surfaces include:
 - item health changes through `ItemDamaged` and `ItemDamagedWitness`
 - local witness variants that let rooms, characters, room items, and carried external items react through hooks or AI
 
+Inventory transfers can also be dispatched to an explicit witness set. This is used by stealth commands such as `palm` and `steal`: the underlying `Get` and `Put` mutations still raise the normal character/item inventory events, but witness variants are limited to characters who passed the stealth notice checks instead of automatically echoing to every event handler in the cell.
+
 When adding a new item event, keep the `EventInfoAttribute` metadata in `FutureMUDLibrary/Events/EventTypeEnum.cs` aligned with the actual dispatch arguments. The event metadata is the builder-facing contract used by `show event`, hook validation, and FutureProg compatibility checks.
 
 ### `IGameItemProto`

--- a/FutureMUDLibrary/Body/IInventory.cs
+++ b/FutureMUDLibrary/Body/IInventory.cs
@@ -1,6 +1,7 @@
 using MudSharp.Character;
 using MudSharp.Combat;
 using MudSharp.Economy.Currency;
+using MudSharp.Events;
 using MudSharp.Form.Material;
 using MudSharp.Framework;
 using MudSharp.GameItems;
@@ -396,12 +397,24 @@ namespace MudSharp.Body
         /// <returns>True if the grab succeeded</returns>
         void Get(IGameItem item, int quantity = 0, IEmote? playerEmote = null, bool silent = false, ItemCanGetIgnore ignoreFlags = ItemCanGetIgnore.None);
 
+        IGameItem? Get(IGameItem item, int quantity, IEmote? playerEmote, bool silent, ItemCanGetIgnore ignoreFlags,
+            IEnumerable<IHandleEvents> witnessHandlers);
+
         void Get(IGameItem item, IGameItem containerItem, int quantity = 0, IEmote? playerEmote = null, bool silent = false, ItemCanGetIgnore ignoreFlags = ItemCanGetIgnore.None);
+
+        IGameItem? Get(IGameItem item, IGameItem containerItem, int quantity, IEmote? playerEmote, bool silent,
+            ItemCanGetIgnore ignoreFlags, IEnumerable<IHandleEvents> witnessHandlers);
 
         void Get(ICurrency currency, IGameItem containerItem, decimal amount, bool exact, IEmote? playerEmote = null,
             bool silent = false);
 
+        IGameItem? Get(ICurrency currency, IGameItem containerItem, decimal amount, bool exact, IEmote? playerEmote,
+            bool silent, IEnumerable<IHandleEvents> witnessHandlers);
+
         void Get(ICurrency currency, decimal amount, bool exact, IEmote? playerEmote = null, bool silent = false);
+
+        IGameItem? Get(ICurrency currency, decimal amount, bool exact, IEmote? playerEmote, bool silent,
+            IEnumerable<IHandleEvents> witnessHandlers);
 
         void GetByWeight(IGameItem item, double weight, IEmote? playerEmote = null, bool silent = false, ItemCanGetIgnore ignoreFlags = ItemCanGetIgnore.None);
 
@@ -418,8 +431,14 @@ namespace MudSharp.Body
 
         void Put(IGameItem item, IGameItem container, ICharacter? containerOwner, int quantity = 0, IEmote? playerEmote = null, bool silent = false, bool allowLesserAmounts = true);
 
+        IGameItem? Put(IGameItem item, IGameItem container, ICharacter? containerOwner, int quantity,
+            IEmote? playerEmote, bool silent, bool allowLesserAmounts, IEnumerable<IHandleEvents> witnessHandlers);
+
         void Put(ICurrency currency, IGameItem container, ICharacter? containerOwner, decimal amount, bool exact, IEmote? playerEmote = null,
             bool silent = false);
+
+        IGameItem? Put(ICurrency currency, IGameItem container, ICharacter? containerOwner, decimal amount, bool exact,
+            IEmote? playerEmote, bool silent, IEnumerable<IHandleEvents> witnessHandlers);
 
         bool CanDrop(IGameItem item, int quantity);
 

--- a/FutureMUDLibrary/Framework/DefaultStaticSettings.cs
+++ b/FutureMUDLibrary/Framework/DefaultStaticSettings.cs
@@ -240,6 +240,7 @@ public static class DefaultStaticSettings
             { "ElectricalConfigureTraitName", "Electronics" },
             { "ProgrammingToolTagName", "Standard Tools" },
             { "ElectricalToolTagName", "Standard Tools" },
+            { "CutPurseToolTagName", "Knife" },
             { "ProgrammingActionDurationSeconds", "30" },
             { "ElectricalInstallActionDurationSeconds", "20" },
             { "ElectricalConfigureActionDurationSeconds", "15" },

--- a/FutureMUDLibrary/RPG/Checks/CheckEnum.cs
+++ b/FutureMUDLibrary/RPG/Checks/CheckEnum.cs
@@ -206,6 +206,7 @@ namespace MudSharp.RPG.Checks
         SensitivityPower = 197,
         SensitivityCapabilityRead = 198,
         PsychicBoltPower = 199,
+        StealCheck = 200, // Called when someone uses the steal command or palms into someone else's belongings
     }
 
     public enum FailIfTraitMissingType
@@ -241,6 +242,7 @@ namespace MudSharp.RPG.Checks
                 case CheckType.HideCheck:
                 case CheckType.SneakCheck:
                 case CheckType.PalmCheck:
+                case CheckType.StealCheck:
                 case CheckType.HideItemCheck:
                 case CheckType.UninstallDoorCheck:
                 case CheckType.ForageCheck:

--- a/FutureMUDLibrary/RPG/Law/CrimeExtensions.cs
+++ b/FutureMUDLibrary/RPG/Law/CrimeExtensions.cs
@@ -123,6 +123,15 @@ namespace MudSharp.RPG.Law
             }
         }
 
+        public static void CheckPossibleCrimeAllAuthorities(ICharacter criminal, CrimeTypes crime, ICharacter victim,
+            IGameItem item, string additionalInformation, IEnumerable<ICharacter> witnesses, bool notifyVictim)
+        {
+            foreach (ILegalAuthority authority in criminal.Gameworld.LegalAuthorities)
+            {
+                authority.CheckPossibleCrime(criminal, crime, victim, item, additionalInformation, witnesses, notifyVictim);
+            }
+        }
+
         public static bool ShowMercyToIncapacitatedTarget(this EnforcementStrategy strategy)
         {
             switch (strategy)

--- a/FutureMUDLibrary/RPG/Law/ILegalAuthority.cs
+++ b/FutureMUDLibrary/RPG/Law/ILegalAuthority.cs
@@ -51,6 +51,8 @@ namespace MudSharp.RPG.Law
         IEnumerable<ICrime> ResolvedCrimesForIndividual(ICharacter individual);
 
         IEnumerable<ICrime> CheckPossibleCrime(ICharacter criminal, CrimeTypes crime, ICharacter victim, IGameItem item, string additionalInformation);
+        IEnumerable<ICrime> CheckPossibleCrime(ICharacter criminal, CrimeTypes crime, ICharacter victim, IGameItem item,
+            string additionalInformation, IEnumerable<ICharacter> witnesses, bool notifyVictim);
         bool WouldBeACrime(ICharacter criminal, CrimeTypes crime, ICharacter victim, IGameItem item,
             string additionalInformation);
         ILegalClass GetLegalClass(ICharacter character);

--- a/MudSharpCore/Body/Implementations/BodyInventory.cs
+++ b/MudSharpCore/Body/Implementations/BodyInventory.cs
@@ -1536,8 +1536,30 @@ public partial class Body
         return true;
     }
 
+    private IEnumerable<IHandleEvents> FilterWitnessHandlers(IEnumerable<IHandleEvents> explicitWitnessHandlers,
+        params IHandleEvents[] excluded)
+    {
+        return explicitWitnessHandlers is null
+            ? Location.EventHandlers.Except(excluded)
+            : explicitWitnessHandlers.Except(excluded);
+    }
+
+    private IEnumerable<IGameItem> FilterExternalItemWitnesses(IEnumerable<IHandleEvents> explicitWitnessHandlers,
+        params IGameItem[] excluded)
+    {
+        return explicitWitnessHandlers is null
+            ? ExternalItems.Except(excluded)
+            : explicitWitnessHandlers.OfType<IGameItem>().Except(excluded);
+    }
+
     public void Get(IGameItem item, int quantity = 0, IEmote? playerEmote = null, bool silent = false,
         ItemCanGetIgnore ignoreFlags = ItemCanGetIgnore.None)
+    {
+        Get(item, quantity, playerEmote, silent, ignoreFlags, null);
+    }
+
+    public IGameItem? Get(IGameItem item, int quantity, IEmote? playerEmote, bool silent,
+        ItemCanGetIgnore ignoreFlags, IEnumerable<IHandleEvents> witnessHandlers)
     {
         if (!CanGet(item, quantity, ignoreFlags))
         {
@@ -1546,7 +1568,7 @@ public partial class Body
                 OutputHandler.Send(WhyCannotGet(item, quantity, ignoreFlags));
             }
 
-            return;
+            return null;
         }
 
         MixedEmoteOutput output;
@@ -1626,21 +1648,28 @@ public partial class Body
         // Handle events
         HandleEvent(EventType.CharacterGotItem, Actor, gottenItem);
         gottenItem.HandleEvent(EventType.ItemGotten, Actor, gottenItem);
-        foreach (IHandleEvents witness in Location.EventHandlers.Except(Actor))
+        foreach (IHandleEvents witness in FilterWitnessHandlers(witnessHandlers, Actor))
         {
             witness.HandleEvent(EventType.CharacterGotItemWitness, Actor, gottenItem, witness);
         }
 
-        foreach (IGameItem witness in ExternalItems.Except(gottenItem))
+        foreach (IGameItem witness in FilterExternalItemWitnesses(witnessHandlers, gottenItem))
         {
             witness.HandleEvent(EventType.CharacterGotItemWitness, Actor, gottenItem, witness);
         }
 
         CheckConsequences();
+        return gottenItem;
     }
 
     public void Get(IGameItem item, IGameItem containerItem, int quantity = 0, IEmote? playerEmote = null,
         bool silent = false, ItemCanGetIgnore ignoreFlags = ItemCanGetIgnore.None)
+    {
+        Get(item, containerItem, quantity, playerEmote, silent, ignoreFlags, null);
+    }
+
+    public IGameItem? Get(IGameItem item, IGameItem containerItem, int quantity, IEmote? playerEmote, bool silent,
+        ItemCanGetIgnore ignoreFlags, IEnumerable<IHandleEvents> witnessHandlers)
     {
         if (!CanGet(item, containerItem, quantity, ignoreFlags))
         {
@@ -1649,7 +1678,7 @@ public partial class Body
                 OutputHandler.Send(WhyCannotGet(item, containerItem, quantity, ignoreFlags));
             }
 
-            return;
+            return null;
         }
 
         IContainer containerComp = containerItem.GetItemType<IContainer>();
@@ -1694,17 +1723,18 @@ public partial class Body
         // Handle events
         HandleEvent(EventType.CharacterGotItemContainer, Actor, takenItem, containerItem);
         takenItem.HandleEvent(EventType.ItemGottenContainer, Actor, takenItem, containerItem);
-        foreach (IHandleEvents witness in Location.EventHandlers.Except(Actor))
+        foreach (IHandleEvents witness in FilterWitnessHandlers(witnessHandlers, Actor))
         {
             witness.HandleEvent(EventType.CharacterGotItemContainerWitness, Actor, takenItem, containerItem, witness);
         }
 
-        foreach (IGameItem witness in ExternalItems.Except(new[] { takenItem, containerItem }))
+        foreach (IGameItem witness in FilterExternalItemWitnesses(witnessHandlers, takenItem, containerItem))
         {
             witness.HandleEvent(EventType.CharacterGotItemContainerWitness, Actor, takenItem, containerItem, witness);
         }
 
         CheckConsequences();
+        return takenItem;
     }
 
     public void UpdateDescriptionHeld(IGameItem item)
@@ -1798,10 +1828,16 @@ public partial class Body
         IEmote? playerEmote = null,
         bool silent = false, bool allowLesserAmounts = true)
     {
+        Put(item, container, containerOwner, quantity, playerEmote, silent, allowLesserAmounts, null);
+    }
+
+    public IGameItem? Put(IGameItem item, IGameItem container, ICharacter? containerOwner, int quantity,
+        IEmote? playerEmote, bool silent, bool allowLesserAmounts, IEnumerable<IHandleEvents> witnessHandlers)
+    {
         if (container.IsItemType<ICorpse>())
         {
             Put(item, container, "", playerEmote);
-            return;
+            return null;
         }
 
         if (!CanPut(item, container, containerOwner, quantity, allowLesserAmounts))
@@ -1811,7 +1847,7 @@ public partial class Body
                 OutputHandler.Send(WhyCannotPut(item, container, containerOwner, quantity, allowLesserAmounts));
             }
 
-            return;
+            return null;
         }
 
         IContainer containerComp = container.GetItemType<IContainer>();
@@ -1876,17 +1912,18 @@ public partial class Body
         // Handle events
         HandleEvent(EventType.CharacterPutItemContainer, Actor, putItem, container);
         putItem.HandleEvent(EventType.ItemPutContainer, Actor, putItem, container);
-        foreach (IHandleEvents witness in Location.EventHandlers.Except(Actor))
+        foreach (IHandleEvents witness in FilterWitnessHandlers(witnessHandlers, Actor))
         {
             witness.HandleEvent(EventType.CharacterPutItemContainerWitness, Actor, putItem, container, witness);
         }
 
-        foreach (IGameItem witness in ExternalItems.Except(new[] { putItem, container }))
+        foreach (IGameItem witness in FilterExternalItemWitnesses(witnessHandlers, putItem, container))
         {
             witness.HandleEvent(EventType.CharacterPutItemContainerWitness, Actor, putItem, container, witness);
         }
 
         CheckConsequences();
+        return putItem;
     }
 
     #region Corpse-Related Versions of Put
@@ -3665,10 +3702,16 @@ public partial class Body
     public void Get(ICurrency currency, IGameItem containerItem, decimal amount, bool exact, IEmote? playerEmote = null,
         bool silent = false)
     {
+        Get(currency, containerItem, amount, exact, playerEmote, silent, null);
+    }
+
+    public IGameItem? Get(ICurrency currency, IGameItem containerItem, decimal amount, bool exact,
+        IEmote? playerEmote, bool silent, IEnumerable<IHandleEvents> witnessHandlers)
+    {
         if (!CanGet(currency, containerItem, amount, exact))
         {
             OutputHandler.Send(WhyCannotGet(currency, containerItem, amount, exact));
-            return;
+            return null;
         }
 
         IContainer container = containerItem.GetItemType<IContainer>();
@@ -3693,15 +3736,21 @@ public partial class Body
             }
         }
 
-        Get(newItem, containerItem, playerEmote: playerEmote, silent: silent);
+        return Get(newItem, containerItem, 0, playerEmote, silent, ItemCanGetIgnore.None, witnessHandlers);
     }
 
     public void Get(ICurrency currency, decimal amount, bool exact, IEmote? playerEmote = null, bool silent = false)
     {
+        Get(currency, amount, exact, playerEmote, silent, null);
+    }
+
+    public IGameItem? Get(ICurrency currency, decimal amount, bool exact, IEmote? playerEmote, bool silent,
+        IEnumerable<IHandleEvents> witnessHandlers)
+    {
         if (!CanGet(currency, amount, exact))
         {
             OutputHandler.Send(WhyCannotGet(currency, amount, exact));
-            return;
+            return null;
         }
 
         Dictionary<ICurrencyPile, Dictionary<ICoin, int>> targetCoins =
@@ -3721,7 +3770,7 @@ public partial class Body
             }
         }
 
-        Get(newItem, playerEmote: playerEmote, silent: silent);
+        return Get(newItem, 0, playerEmote, silent, ItemCanGetIgnore.None, witnessHandlers);
     }
 
     public bool CanPut(ICurrency currency, IGameItem container, ICharacter? containerOwner, decimal amount, bool exact)
@@ -3779,10 +3828,16 @@ public partial class Body
         IEmote? playerEmote = null,
         bool silent = false)
     {
+        Put(currency, container, containerOwner, amount, exact, playerEmote, silent, null);
+    }
+
+    public IGameItem? Put(ICurrency currency, IGameItem container, ICharacter? containerOwner, decimal amount, bool exact,
+        IEmote? playerEmote, bool silent, IEnumerable<IHandleEvents> witnessHandlers)
+    {
         if (!CanPut(currency, container, containerOwner, amount, exact))
         {
             OutputHandler.Send(WhyCannotPut(currency, container, containerOwner, amount, exact));
-            return;
+            return null;
         }
 
         Dictionary<ICurrencyPile, Dictionary<ICoin, int>> targetCoins = currency.FindCurrency(HeldItems.SelectNotNull(x => x.GetItemType<ICurrencyPile>()),
@@ -3802,7 +3857,7 @@ public partial class Body
             }
         }
 
-        Put(newItem, container, containerOwner, playerEmote: playerEmote, silent: silent);
+        return Put(newItem, container, containerOwner, 0, playerEmote, silent, true, witnessHandlers);
     }
 
     public bool CanDrop(ICurrency currency, decimal amount, bool exact)

--- a/MudSharpCore/Commands/Modules/StealthModule.cs
+++ b/MudSharpCore/Commands/Modules/StealthModule.cs
@@ -1,6 +1,7 @@
 ﻿using MoreLinq.Extensions;
 using MudSharp.Accounts;
 using MudSharp.Character;
+using MudSharp.Economy.Currency;
 using MudSharp.Effects.Concrete;
 using MudSharp.Effects.Interfaces;
 using MudSharp.Events;
@@ -12,8 +13,10 @@ using MudSharp.PerceptionEngine;
 using MudSharp.PerceptionEngine.Outputs;
 using MudSharp.PerceptionEngine.Parsers;
 using MudSharp.RPG.Checks;
+using MudSharp.RPG.Law;
 using Org.BouncyCastle.Asn1.X509;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace MudSharp.Commands.Modules;
@@ -304,6 +307,20 @@ The syntax is as follows:
     [DelayBlock("general", "You must first stop {0} before you can palm anything.")]
     [CommandPermission(PermissionLevel.NPC)]
     [RequiredCharacterState(CharacterState.Able)]
+    [HelpInfo("palm", @"The #3palm#0 command is used to secretly move items or money without a public echo unless someone notices what you are doing.
+
+The syntax is as follows:
+
+	#3palm [<quantity>] <item>#0 - secretly get an item from the room
+	#3palm [exactly] <currency>#0 - secretly get money from the room
+	#3palm [<quantity>] <item> from <container>#0 - secretly get an item from a container
+	#3palm [exactly] <currency> from <container>#0 - secretly get money from a container
+	#3palm [<quantity>] <item> from <person> <container>#0 - secretly get an item from someone's container
+	#3palm [exactly] <currency> from <person> <container>#0 - secretly get money from someone's container
+	#3palm [<quantity>] <item> into <container>#0 - secretly put an item into a container
+	#3palm [exactly] <currency> into <container>#0 - secretly put money into a container
+	#3palm [<quantity>] <item> into <person> <container>#0 - secretly put an item into someone's container
+	#3palm [exactly] <currency> into <person> <container>#0 - secretly put money into someone's container", AutoHelp.HelpArg)]
     protected static void Palm(ICharacter actor, string command)
     {
         if (actor.Combat != null)
@@ -312,7 +329,1063 @@ The syntax is as follows:
             return;
         }
 
-        actor.Send("Coming soon.");
+        var ss = new StringStack(command.RemoveFirstWord());
+        if (ss.IsFinished)
+        {
+            actor.OutputHandler.Send(
+                $"What do you want to palm?\nThe syntax is {"palm [<quantity>] <item>".ColourCommand()}, {"palm [<quantity>] <item> from <container>".ColourCommand()} or {"palm [<quantity>] <item> into [<person>] <container>".ColourCommand()}.");
+            return;
+        }
+
+        var text = ss.SafeRemainingArgument;
+        if (TrySplitOnKeyword(text, "into", out var targetText, out var destinationText))
+        {
+            PalmInto(actor, targetText, destinationText);
+            return;
+        }
+
+        if (TrySplitOnKeyword(text, "from", out targetText, out var sourceText))
+        {
+            PalmFrom(actor, targetText, sourceText);
+            return;
+        }
+
+        PalmFromRoom(actor, text);
+    }
+
+    [PlayerCommand("Steal", "steal")]
+    [DelayBlock("general", "You must first stop {0} before you can steal anything.")]
+    [CommandPermission(PermissionLevel.NPC)]
+    [RequiredCharacterState(CharacterState.Able)]
+    [HelpInfo("steal", @"The #3steal#0 command is used to secretly steal from another character's open worn or held containers, or cut a belted item free from one of their belts. Belt-cutting requires a held or wielded item tagged by the #6CutPurseToolTagName#0 static configuration.
+
+The syntax is as follows:
+
+	#3steal <person>#0 - steal a random item from an open container or belt
+	#3steal <person> <container|belt>#0 - steal a random item from a specific open container or belt
+	#3steal <person> from <container|belt>#0 - steal a random item from a specific open container or belt
+	#3steal <person> [<quantity>] <item>#0 - steal an item from any open container
+	#3steal <person> [<quantity>] <item> from <container>#0 - steal an item from a specific open container
+	#3steal <person> [exactly] <currency>#0 - steal money from any open container
+	#3steal <person> [exactly] <currency> from <container>#0 - steal money from a specific open container
+	#3steal <person> <belted item> from <belt>#0 - cut a belted item free", AutoHelp.HelpArg)]
+    protected static void Steal(ICharacter actor, string command)
+    {
+        if (actor.Combat != null)
+        {
+            actor.Send("You are too busy fighting to worry about that!");
+            return;
+        }
+
+        var ss = new StringStack(command.RemoveFirstWord());
+        if (ss.IsFinished)
+        {
+            actor.OutputHandler.Send(
+                $"Who do you want to steal from?\nThe syntax is {"steal <person> [[<quantity>] <item>|[exactly] <currency>|<container>]".ColourCommand()}.");
+            return;
+        }
+
+        var target = actor.TargetActor(ss.PopSpeech(), PerceiveIgnoreFlags.IgnoreSelf);
+        if (target is null)
+        {
+            actor.OutputHandler.Send("You don't see anyone like that to steal from.");
+            return;
+        }
+
+        if (target == actor)
+        {
+            actor.OutputHandler.Send("You cannot steal from yourself.");
+            return;
+        }
+
+        if (!actor.ColocatedWith(target))
+        {
+            actor.OutputHandler.Send($"{target.HowSeen(actor, true)} is not close enough for you to steal from.");
+            return;
+        }
+
+        var remaining = ss.SafeRemainingArgument;
+        if (string.IsNullOrWhiteSpace(remaining))
+        {
+            StealRandom(actor, target);
+            return;
+        }
+
+        if (TrySplitOnKeyword(remaining, "from", out var itemText, out var sourceText))
+        {
+            if (string.IsNullOrWhiteSpace(sourceText))
+            {
+                actor.OutputHandler.Send("Which container or belt do you want to steal from?");
+                return;
+            }
+
+            StealFromSource(actor, target, itemText, sourceText);
+            return;
+        }
+
+        if (TryResolveStealSource(actor, target, remaining, out var source))
+        {
+            StealFromSource(actor, target, string.Empty, remaining);
+            return;
+        }
+
+        StealSpecificFromAnyContainer(actor, target, remaining);
+    }
+
+    private enum StealthTransferKind
+    {
+        Item,
+        Currency
+    }
+
+    private enum StealSourceKind
+    {
+        Container,
+        Belt
+    }
+
+    private sealed class StealthTransferSpec
+    {
+        public StealthTransferKind Kind { get; set; }
+        public IGameItem Item { get; set; }
+        public int Quantity { get; set; }
+        public ICurrency Currency { get; set; }
+        public decimal Amount { get; set; }
+        public bool Exact { get; set; }
+        public string OriginalText { get; set; }
+
+        public string Describe(ICharacter actor)
+        {
+            return Kind == StealthTransferKind.Currency
+                ? Currency.Describe(Amount, CurrencyDescriptionPatternType.ShortDecimal)
+                : Quantity > 0
+                    ? $"{Quantity.ToString("N0", actor)} of {Item.HowSeen(actor)}"
+                    : Item.HowSeen(actor);
+        }
+    }
+
+    private sealed class StealthDetectionResult
+    {
+        public CheckOutcome ActorOutcome { get; set; } = CheckOutcome.NotTested(CheckType.None);
+        public List<ICharacter> Noticers { get; } = new();
+        public bool VictimStopped { get; set; }
+        public bool ActorSucceeded => ActorOutcome.IsPass();
+    }
+
+    private sealed class StealSource
+    {
+        public StealSourceKind Kind { get; set; }
+        public IGameItem Item { get; set; }
+    }
+
+    private sealed class StealCandidate
+    {
+        public StealSourceKind Kind { get; set; }
+        public IGameItem Source { get; set; }
+        public IGameItem Item { get; set; }
+    }
+
+    private static bool TrySplitOnKeyword(string text, string keyword, out string before, out string after)
+    {
+        text = text.Trim();
+        var start = $"{keyword} ";
+        if (text.StartsWith(start, StringComparison.InvariantCultureIgnoreCase))
+        {
+            before = string.Empty;
+            after = text[start.Length..].Trim();
+            return true;
+        }
+
+        var marker = $" {keyword} ";
+        var index = text.IndexOf(marker, StringComparison.InvariantCultureIgnoreCase);
+        if (index < 0)
+        {
+            before = text;
+            after = string.Empty;
+            return false;
+        }
+
+        before = text[..index].Trim();
+        after = text[(index + marker.Length)..].Trim();
+        return true;
+    }
+
+    private static bool TryParseCurrencyAmount(ICharacter actor, string text, out decimal amount, out bool exact)
+    {
+        amount = 0.0M;
+        exact = false;
+        text = text.Trim();
+        if (text.StartsWith("exactly ", StringComparison.InvariantCultureIgnoreCase))
+        {
+            exact = true;
+            text = text["exactly ".Length..].Trim();
+        }
+
+        text = text.Strip(x => x == '"');
+        if (string.IsNullOrWhiteSpace(text) || actor.Currency is null)
+        {
+            return false;
+        }
+
+        amount = actor.Currency.GetBaseCurrency(text, out var success);
+        return success && amount > 0.0M;
+    }
+
+    private static bool TryParseTransferSpec(ICharacter actor, string text, IEnumerable<IGameItem> items,
+        string locationDescription, out StealthTransferSpec spec, out string error)
+    {
+        spec = null;
+        error = string.Empty;
+        text = text.Trim();
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            error = "You must specify what you want to move.";
+            return false;
+        }
+
+        if (!text.StartsWith("exactly ", StringComparison.InvariantCultureIgnoreCase))
+        {
+            var quantity = 0;
+            var itemText = text;
+            var ss = new StringStack(text);
+            var first = ss.PopSpeech();
+            if (int.TryParse(first, out var parsedQuantity))
+            {
+                if (parsedQuantity <= 0)
+                {
+                    error = "You must specify a positive quantity.";
+                    return false;
+                }
+
+                if (ss.IsFinished)
+                {
+                    error = "You must specify an item after the quantity.";
+                    return false;
+                }
+
+                quantity = parsedQuantity;
+                itemText = ss.SafeRemainingArgument;
+            }
+
+            var item = items
+                       .Where(x => actor.CanSee(x))
+                       .GetFromItemListByKeyword(itemText, actor);
+            if (item is not null)
+            {
+                spec = new StealthTransferSpec
+                {
+                    Kind = StealthTransferKind.Item,
+                    Item = item,
+                    Quantity = quantity,
+                    OriginalText = text
+                };
+                return true;
+            }
+        }
+
+        if (TryParseCurrencyAmount(actor, text, out var amount, out var exact))
+        {
+            spec = new StealthTransferSpec
+            {
+                Kind = StealthTransferKind.Currency,
+                Currency = actor.Currency,
+                Amount = amount,
+                Exact = exact,
+                OriginalText = text
+            };
+            return true;
+        }
+
+        error =
+            $"You don't see anything like {text.ColourCommand()} {locationDescription}, and that is not a valid amount of money.";
+        return false;
+    }
+
+    private static bool TryResolvePalmDestination(ICharacter actor, string text, out IGameItem containerItem,
+        out ICharacter containerOwner, out string error)
+    {
+        containerItem = null;
+        containerOwner = null;
+        error = string.Empty;
+        text = text.Trim();
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            error = "Which container do you want to palm it into?";
+            return false;
+        }
+
+        var ss = new StringStack(text);
+        var first = ss.PopSpeech();
+        if (!ss.IsFinished)
+        {
+            var possibleOwner = actor.TargetActor(first);
+            if (possibleOwner is not null)
+            {
+                if (!actor.ColocatedWith(possibleOwner))
+                {
+                    error = $"{possibleOwner.HowSeen(actor, true)} is not close enough for you to palm anything into their belongings.";
+                    return false;
+                }
+
+                containerOwner = possibleOwner;
+                containerItem = possibleOwner.Body.ExternalItemsForOtherActors
+                                             .Where(x => actor.CanSee(x))
+                                             .GetFromItemListByKeyword(ss.SafeRemainingArgument, actor);
+                if (containerItem is null)
+                {
+                    error = $"{possibleOwner.HowSeen(actor, true)} does not seem to have any container like that.";
+                    return false;
+                }
+
+                if (!containerItem.IsItemType<IContainer>())
+                {
+                    error = $"{containerItem.HowSeen(actor, true)} is not a container.";
+                    return false;
+                }
+
+                return true;
+            }
+        }
+
+        containerItem = actor.TargetItem(text);
+        if (containerItem is null)
+        {
+            error = "You don't see any such container.";
+            return false;
+        }
+
+        if (!containerItem.IsItemType<IContainer>())
+        {
+            error = $"{containerItem.HowSeen(actor, true)} is not a container.";
+            return false;
+        }
+
+        containerOwner = containerItem.InInventoryOf?.Actor;
+        return true;
+    }
+
+    private static bool TryResolvePalmSource(ICharacter actor, string text, out IGameItem containerItem,
+        out ICharacter containerOwner, out string error)
+    {
+        containerItem = null;
+        containerOwner = null;
+        error = string.Empty;
+        text = text.Trim();
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            error = "Which container do you want to palm something from?";
+            return false;
+        }
+
+        var ss = new StringStack(text);
+        var first = ss.PopSpeech();
+        if (!ss.IsFinished)
+        {
+            var possibleOwner = actor.TargetActor(first);
+            if (possibleOwner is not null)
+            {
+                if (!actor.ColocatedWith(possibleOwner))
+                {
+                    error = $"{possibleOwner.HowSeen(actor, true)} is not close enough for you to palm anything from their belongings.";
+                    return false;
+                }
+
+                containerOwner = possibleOwner;
+                containerItem = possibleOwner.Body.ExternalItemsForOtherActors
+                                             .Where(x => actor.CanSee(x))
+                                             .GetFromItemListByKeyword(ss.SafeRemainingArgument, actor);
+                if (containerItem is null)
+                {
+                    error = $"{possibleOwner.HowSeen(actor, true)} does not seem to have any container like that.";
+                    return false;
+                }
+
+                if (!containerItem.IsItemType<IContainer>())
+                {
+                    error = $"{containerItem.HowSeen(actor, true)} is not a container.";
+                    return false;
+                }
+
+                return true;
+            }
+        }
+
+        containerItem = actor.TargetItem(text);
+        if (containerItem is null)
+        {
+            error = "You don't see any such container.";
+            return false;
+        }
+
+        if (!containerItem.IsItemType<IContainer>())
+        {
+            error = $"{containerItem.HowSeen(actor, true)} is not a container.";
+            return false;
+        }
+
+        containerOwner = containerItem.InInventoryOf?.Actor;
+        return true;
+    }
+
+    private static void PalmFromRoom(ICharacter actor, string targetText)
+    {
+        var items = actor.Location.LayerGameItems(actor.RoomLayer);
+        if (!TryParseTransferSpec(actor, targetText, items, "here", out var spec, out var error))
+        {
+            actor.OutputHandler.Send(error);
+            return;
+        }
+
+        IGameItem previewItem;
+        if (spec.Kind == StealthTransferKind.Item)
+        {
+            previewItem = spec.Item;
+            if (!actor.Body.CanGet(spec.Item, spec.Quantity))
+            {
+                actor.OutputHandler.Send(actor.Body.WhyCannotGet(spec.Item, spec.Quantity));
+                return;
+            }
+        }
+        else
+        {
+            previewItem = null;
+            if (!actor.Body.CanGet(spec.Currency, spec.Amount, spec.Exact))
+            {
+                actor.OutputHandler.Send(actor.Body.WhyCannotGet(spec.Currency, spec.Amount, spec.Exact));
+                return;
+            }
+        }
+
+        if (!TryResolveStealth(actor, null, previewItem, CheckType.PalmCheck, null,
+                $"palm {spec.Describe(actor)}", out var detection))
+        {
+            return;
+        }
+
+        var moved = spec.Kind == StealthTransferKind.Item
+            ? actor.Body.Get(spec.Item, spec.Quantity, null, true, ItemCanGetIgnore.None,
+                detection.Noticers.Cast<IHandleEvents>())
+            : actor.Body.Get(spec.Currency, spec.Amount, spec.Exact, null, true,
+                detection.Noticers.Cast<IHandleEvents>());
+
+        if (moved is null)
+        {
+            return;
+        }
+
+        actor.OutputHandler.Send(
+            $"You palm {moved.HowSeen(actor)} without drawing attention.{NoticedSuffix(detection)}");
+        NotifyNoticers(actor, detection, witness =>
+            $"You notice {actor.HowSeen(witness, true)} palm {moved.HowSeen(witness)}.");
+    }
+
+    private static void PalmFrom(ICharacter actor, string targetText, string sourceText)
+    {
+        if (!TryResolvePalmSource(actor, sourceText, out var sourceItem, out var owner, out var error))
+        {
+            actor.OutputHandler.Send(error);
+            return;
+        }
+
+        var container = sourceItem.GetItemType<IContainer>();
+        if (!TryParseTransferSpec(actor, targetText, container.Contents, $"in {sourceItem.HowSeen(actor)}",
+                out var spec, out error))
+        {
+            actor.OutputHandler.Send(error);
+            return;
+        }
+
+        var crime = owner is not null && owner != actor ? CrimeTypes.Theft : (CrimeTypes?)null;
+        var previewItem = spec.Kind == StealthTransferKind.Item ? spec.Item : sourceItem;
+        if (WouldStopLawfulAction(actor, crime, owner, previewItem))
+        {
+            return;
+        }
+
+        if (spec.Kind == StealthTransferKind.Item)
+        {
+            if (!actor.Body.CanGet(spec.Item, sourceItem, spec.Quantity))
+            {
+                actor.OutputHandler.Send(actor.Body.WhyCannotGet(spec.Item, sourceItem, spec.Quantity));
+                return;
+            }
+        }
+        else if (!actor.Body.CanGet(spec.Currency, sourceItem, spec.Amount, spec.Exact))
+        {
+            actor.OutputHandler.Send(actor.Body.WhyCannotGet(spec.Currency, sourceItem, spec.Amount, spec.Exact));
+            return;
+        }
+
+        if (!TryResolveStealth(actor, owner == actor ? null : owner, previewItem, CheckType.PalmCheck, crime,
+                $"palm {spec.Describe(actor)} from {sourceItem.HowSeen(actor)}", out var detection))
+        {
+            return;
+        }
+
+        var moved = spec.Kind == StealthTransferKind.Item
+            ? actor.Body.Get(spec.Item, sourceItem, spec.Quantity, null, true, ItemCanGetIgnore.None,
+                detection.Noticers.Cast<IHandleEvents>())
+            : actor.Body.Get(spec.Currency, sourceItem, spec.Amount, spec.Exact, null, true,
+                detection.Noticers.Cast<IHandleEvents>());
+
+        if (moved is null)
+        {
+            return;
+        }
+
+        actor.OutputHandler.Send(
+            $"You palm {moved.HowSeen(actor)} from {sourceItem.HowSeen(actor)} without drawing attention.{NoticedSuffix(detection)}");
+        NotifyNoticers(actor, detection, witness =>
+            $"You notice {actor.HowSeen(witness, true)} palm {moved.HowSeen(witness)} from {sourceItem.HowSeen(witness)}.");
+        RecordStealthCrime(actor, crime, owner, moved, detection);
+    }
+
+    private static void PalmInto(ICharacter actor, string targetText, string destinationText)
+    {
+        if (!TryResolvePalmDestination(actor, destinationText, out var containerItem, out var containerOwner,
+                out var error))
+        {
+            actor.OutputHandler.Send(error);
+            return;
+        }
+
+        if (!TryParseTransferSpec(actor, targetText, actor.Body.ItemsInHands,
+                "in your hands", out var spec, out error))
+        {
+            actor.OutputHandler.Send(error);
+            return;
+        }
+
+        var victim = containerOwner == actor ? null : containerOwner;
+        var check = victim is null ? CheckType.PalmCheck : CheckType.StealCheck;
+        var crime = victim is null ? (CrimeTypes?)null : CrimeTypes.UnauthorisedDealing;
+        var previewItem = spec.Kind == StealthTransferKind.Item ? spec.Item : containerItem;
+        if (WouldStopLawfulAction(actor, crime, victim, previewItem))
+        {
+            return;
+        }
+
+        if (spec.Kind == StealthTransferKind.Item)
+        {
+            if (!actor.Body.CanPut(spec.Item, containerItem, containerOwner, spec.Quantity, true))
+            {
+                actor.OutputHandler.Send(actor.Body.WhyCannotPut(spec.Item, containerItem, containerOwner,
+                    spec.Quantity, true));
+                return;
+            }
+        }
+        else if (!actor.Body.CanPut(spec.Currency, containerItem, containerOwner, spec.Amount, spec.Exact))
+        {
+            actor.OutputHandler.Send(actor.Body.WhyCannotPut(spec.Currency, containerItem, containerOwner,
+                spec.Amount, spec.Exact));
+            return;
+        }
+
+        if (!TryResolveStealth(actor, victim, previewItem, check, crime,
+                $"palm {spec.Describe(actor)} into {containerItem.HowSeen(actor)}", out var detection))
+        {
+            return;
+        }
+
+        var moved = spec.Kind == StealthTransferKind.Item
+            ? actor.Body.Put(spec.Item, containerItem, containerOwner, spec.Quantity, null, true, true,
+                detection.Noticers.Cast<IHandleEvents>())
+            : actor.Body.Put(spec.Currency, containerItem, containerOwner, spec.Amount, spec.Exact, null, true,
+                detection.Noticers.Cast<IHandleEvents>());
+
+        if (moved is null)
+        {
+            return;
+        }
+
+        actor.OutputHandler.Send(
+            $"You palm {moved.HowSeen(actor)} into {containerItem.HowSeen(actor)} without drawing attention.{NoticedSuffix(detection)}");
+        NotifyNoticers(actor, detection, witness =>
+            $"You notice {actor.HowSeen(witness, true)} palm {moved.HowSeen(witness)} into {containerItem.HowSeen(witness)}.");
+        RecordStealthCrime(actor, crime, victim, moved, detection);
+    }
+
+    private static void StealRandom(ICharacter actor, ICharacter target)
+    {
+        var candidates = GetStealCandidates(actor, target, true).ToList();
+        if (!candidates.Any())
+        {
+            actor.OutputHandler.Send(
+                $"{target.HowSeen(actor, true)} does not have anything visible and accessible in an open container or on a belt for you to steal.");
+            return;
+        }
+
+        ExecuteStealCandidate(actor, target, candidates.GetRandomElement());
+    }
+
+    private static void StealFromSource(ICharacter actor, ICharacter target, string itemText, string sourceText)
+    {
+        if (!TryResolveStealSource(actor, target, sourceText, out var source))
+        {
+            actor.OutputHandler.Send(
+                $"{target.HowSeen(actor, true)} does not have any open container or belt like {sourceText.ColourCommand()}.");
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(itemText))
+        {
+            var candidates = GetStealCandidates(actor, target)
+                             .Where(x => x.Source == source.Item && x.Kind == source.Kind)
+                             .ToList();
+            if (!candidates.Any())
+            {
+                actor.OutputHandler.Send(
+                    $"{source.Item.HowSeen(actor, true)} does not have anything visible and accessible for you to steal.");
+                return;
+            }
+
+            ExecuteStealCandidate(actor, target, candidates.GetRandomElement());
+            return;
+        }
+
+        if (source.Kind == StealSourceKind.Belt)
+        {
+            var item = source.Item.GetItemType<IBelt>().ConnectedItems
+                             .Select(x => x.Parent)
+                             .Where(x => actor.CanSee(x))
+                             .GetFromItemListByKeyword(itemText, actor);
+            if (item is null)
+            {
+                actor.OutputHandler.Send($"{source.Item.HowSeen(actor, true)} does not have anything like that attached to it.");
+                return;
+            }
+
+            StealBeltedItem(actor, target, source.Item, item);
+            return;
+        }
+
+        StealSpecificFromContainer(actor, target, itemText, source.Item);
+    }
+
+    private static void StealSpecificFromAnyContainer(ICharacter actor, ICharacter target, string itemText)
+    {
+        var containers = GetOpenStealableContainers(actor, target).ToList();
+        if (!containers.Any())
+        {
+            actor.OutputHandler.Send($"{target.HowSeen(actor, true)} does not have any visible open containers you can steal from.");
+            return;
+        }
+
+        if (TryParseCurrencyAmount(actor, itemText, out var amount, out var exact))
+        {
+            var container = containers.FirstOrDefault(x => actor.Body.CanGet(actor.Currency, x, amount, exact));
+            if (container is null)
+            {
+                actor.OutputHandler.Send(
+                    $"{target.HowSeen(actor, true)} does not have that much accessible money in any visible open container.");
+                return;
+            }
+
+            StealCurrencyFromContainer(actor, target, actor.Currency, amount, exact, container);
+            return;
+        }
+
+        var allItems = containers.SelectMany(x => x.GetItemType<IContainer>().Contents).ToList();
+        if (!TryParseTransferSpec(actor, itemText, allItems, $"in {target.HowSeen(actor)}'s open containers",
+                out var spec, out var error) || spec.Kind != StealthTransferKind.Item)
+        {
+            actor.OutputHandler.Send(error);
+            return;
+        }
+
+        var source = containers.FirstOrDefault(x => x.GetItemType<IContainer>().Contents.Contains(spec.Item));
+        if (source is null)
+        {
+            actor.OutputHandler.Send("You cannot work out which container that item is in.");
+            return;
+        }
+
+        StealItemFromContainer(actor, target, spec.Item, spec.Quantity, source);
+    }
+
+    private static void StealSpecificFromContainer(ICharacter actor, ICharacter target, string itemText,
+        IGameItem containerItem)
+    {
+        var container = containerItem.GetItemType<IContainer>();
+        if (TryParseCurrencyAmount(actor, itemText, out var amount, out var exact))
+        {
+            StealCurrencyFromContainer(actor, target, actor.Currency, amount, exact, containerItem);
+            return;
+        }
+
+        if (!TryParseTransferSpec(actor, itemText, container.Contents, $"in {containerItem.HowSeen(actor)}",
+                out var spec, out var error))
+        {
+            actor.OutputHandler.Send(error);
+            return;
+        }
+
+        if (spec.Kind == StealthTransferKind.Currency)
+        {
+            StealCurrencyFromContainer(actor, target, spec.Currency, spec.Amount, spec.Exact, containerItem);
+            return;
+        }
+
+        StealItemFromContainer(actor, target, spec.Item, spec.Quantity, containerItem);
+    }
+
+    private static void ExecuteStealCandidate(ICharacter actor, ICharacter target, StealCandidate candidate)
+    {
+        if (candidate.Kind == StealSourceKind.Belt)
+        {
+            StealBeltedItem(actor, target, candidate.Source, candidate.Item);
+            return;
+        }
+
+        StealItemFromContainer(actor, target, candidate.Item, 0, candidate.Source);
+    }
+
+    private static void StealItemFromContainer(ICharacter actor, ICharacter target, IGameItem item, int quantity,
+        IGameItem containerItem)
+    {
+        if (!actor.Body.CanGet(item, containerItem, quantity))
+        {
+            actor.OutputHandler.Send(actor.Body.WhyCannotGet(item, containerItem, quantity));
+            return;
+        }
+
+        if (WouldStopLawfulAction(actor, CrimeTypes.Theft, target, item))
+        {
+            return;
+        }
+
+        if (!TryResolveStealth(actor, target, item, CheckType.StealCheck, CrimeTypes.Theft,
+                $"steal {DescribeItemQuantity(actor, item, quantity)} from {target.HowSeen(actor)}", out var detection))
+        {
+            return;
+        }
+
+        var moved = actor.Body.Get(item, containerItem, quantity, null, true, ItemCanGetIgnore.None,
+            detection.Noticers.Cast<IHandleEvents>());
+        if (moved is null)
+        {
+            return;
+        }
+
+        actor.OutputHandler.Send(
+            $"You steal {moved.HowSeen(actor)} from {containerItem.HowSeen(actor)}.{NoticedSuffix(detection)}");
+        NotifyNoticers(actor, detection, witness =>
+            $"You notice {actor.HowSeen(witness, true)} steal {moved.HowSeen(witness)} from {containerItem.HowSeen(witness)}.");
+        RecordStealthCrime(actor, CrimeTypes.Theft, target, moved, detection);
+    }
+
+    private static void StealCurrencyFromContainer(ICharacter actor, ICharacter target, ICurrency currency,
+        decimal amount, bool exact, IGameItem containerItem)
+    {
+        if (!actor.Body.CanGet(currency, containerItem, amount, exact))
+        {
+            actor.OutputHandler.Send(actor.Body.WhyCannotGet(currency, containerItem, amount, exact));
+            return;
+        }
+
+        if (WouldStopLawfulAction(actor, CrimeTypes.Theft, target, containerItem))
+        {
+            return;
+        }
+
+        var description = currency.Describe(amount, CurrencyDescriptionPatternType.ShortDecimal);
+        if (!TryResolveStealth(actor, target, containerItem, CheckType.StealCheck, CrimeTypes.Theft,
+                $"steal {description} from {target.HowSeen(actor)}", out var detection))
+        {
+            return;
+        }
+
+        var moved = actor.Body.Get(currency, containerItem, amount, exact, null, true,
+            detection.Noticers.Cast<IHandleEvents>());
+        if (moved is null)
+        {
+            return;
+        }
+
+        actor.OutputHandler.Send(
+            $"You steal {moved.HowSeen(actor)} from {containerItem.HowSeen(actor)}.{NoticedSuffix(detection)}");
+        NotifyNoticers(actor, detection, witness =>
+            $"You notice {actor.HowSeen(witness, true)} steal {moved.HowSeen(witness)} from {containerItem.HowSeen(witness)}.");
+        RecordStealthCrime(actor, CrimeTypes.Theft, target, moved, detection);
+    }
+
+    private static void StealBeltedItem(ICharacter actor, ICharacter target, IGameItem beltItem, IGameItem item)
+    {
+        if (!HasCutPurseTool(actor, out var error))
+        {
+            actor.OutputHandler.Send(error);
+            return;
+        }
+
+        var belt = beltItem.GetItemType<IBelt>();
+        var beltable = item.GetItemType<IBeltable>();
+        if (belt is null || beltable is null || beltable.ConnectedTo != belt)
+        {
+            actor.OutputHandler.Send($"{item.HowSeen(actor, true)} is not attached to {beltItem.HowSeen(actor)}.");
+            return;
+        }
+
+        if (!actor.Body.CanGet(item, 0))
+        {
+            actor.OutputHandler.Send(actor.Body.WhyCannotGet(item, 0));
+            return;
+        }
+
+        if (WouldStopLawfulAction(actor, CrimeTypes.Theft, target, item))
+        {
+            return;
+        }
+
+        if (!TryResolveStealth(actor, target, item, CheckType.StealCheck, CrimeTypes.Theft,
+                $"cut {item.HowSeen(actor)} free from {target.HowSeen(actor)}", out var detection))
+        {
+            return;
+        }
+
+        belt.RemoveConnectedItem(beltable);
+        var moved = actor.Body.Get(item, 0, null, true, ItemCanGetIgnore.None,
+            detection.Noticers.Cast<IHandleEvents>());
+        beltItem.InInventoryOf?.RecalculateItemHelpers();
+
+        if (moved is null)
+        {
+            return;
+        }
+
+        actor.OutputHandler.Send(
+            $"You cut {moved.HowSeen(actor)} free from {beltItem.HowSeen(actor)} and steal it.{NoticedSuffix(detection)}");
+        NotifyNoticers(actor, detection, witness =>
+            $"You notice {actor.HowSeen(witness, true)} cut {moved.HowSeen(witness)} free from {beltItem.HowSeen(witness)}.");
+        RecordStealthCrime(actor, CrimeTypes.Theft, target, moved, detection);
+    }
+
+    private static IEnumerable<IGameItem> GetOpenStealableContainers(ICharacter actor, ICharacter target)
+    {
+        return target.Body.ExternalItemsForOtherActors
+                     .Where(x => actor.CanSee(x))
+                     .Where(x => x.IsItemType<IContainer>())
+                     .Where(IsOpenContainer);
+    }
+
+    private static IEnumerable<IGameItem> GetStealableBelts(ICharacter actor, ICharacter target)
+    {
+        return target.Body.ExternalItemsForOtherActors
+                     .Where(x => actor.CanSee(x))
+                     .Where(x => x.IsItemType<IBelt>());
+    }
+
+    private static bool TryResolveStealSource(ICharacter actor, ICharacter target, string sourceText,
+        out StealSource source)
+    {
+        source = null;
+        var sourceItems = GetOpenStealableContainers(actor, target)
+                          .Concat(GetStealableBelts(actor, target))
+                          .Distinct()
+                          .ToList();
+        var item = sourceItems.GetFromItemListByKeyword(sourceText, actor);
+        if (item is null)
+        {
+            return false;
+        }
+
+        source = new StealSource
+        {
+            Item = item,
+            Kind = item.IsItemType<IContainer>() && IsOpenContainer(item)
+                ? StealSourceKind.Container
+                : StealSourceKind.Belt
+        };
+        return true;
+    }
+
+    private static IEnumerable<StealCandidate> GetStealCandidates(ICharacter actor, ICharacter target,
+        bool requireCutPurseToolForBelts = false)
+    {
+        foreach (var containerItem in GetOpenStealableContainers(actor, target))
+        {
+            foreach (var item in containerItem.GetItemType<IContainer>().Contents
+                                              .Where(x => actor.CanSee(x))
+                                              .Where(x => actor.Body.CanGet(x, containerItem, 0)))
+            {
+                yield return new StealCandidate
+                {
+                    Kind = StealSourceKind.Container,
+                    Source = containerItem,
+                    Item = item
+                };
+            }
+        }
+
+        if (requireCutPurseToolForBelts && !HasCutPurseTool(actor, out _))
+        {
+            yield break;
+        }
+
+        foreach (var beltItem in GetStealableBelts(actor, target))
+        {
+            foreach (var item in beltItem.GetItemType<IBelt>().ConnectedItems
+                                         .Select(x => x.Parent)
+                                         .Where(x => actor.CanSee(x))
+                                         .Where(x => actor.Body.CanGet(x, 0)))
+            {
+                yield return new StealCandidate
+                {
+                    Kind = StealSourceKind.Belt,
+                    Source = beltItem,
+                    Item = item
+                };
+            }
+        }
+    }
+
+    private static bool IsOpenContainer(IGameItem item)
+    {
+        return item.GetItemType<IOpenable>()?.IsOpen != false;
+    }
+
+    private static bool HasCutPurseTool(ICharacter actor, out string error)
+    {
+        error = string.Empty;
+        var tagText = actor.Gameworld.GetStaticConfiguration("CutPurseToolTagName");
+        if (string.IsNullOrWhiteSpace(tagText))
+        {
+            error = "No cut-purse tool tag is configured in the CutPurseToolTagName static configuration.";
+            return false;
+        }
+
+        var tag = long.TryParse(tagText, out var tagId)
+            ? actor.Gameworld.Tags.Get(tagId)
+            : actor.Gameworld.Tags.GetByName(tagText);
+        if (tag is null)
+        {
+            error =
+                $"The configured cut-purse tag {tagText.ColourCommand()} does not match any known tag.";
+            return false;
+        }
+
+        if (actor.Body.HeldOrWieldedItems.Any(x => x.IsA(tag)))
+        {
+            return true;
+        }
+
+        error =
+            $"You need to be holding or wielding something tagged {tag.FullName.ColourName()} to cut something loose.";
+        return false;
+    }
+
+    private static string DescribeItemQuantity(ICharacter actor, IGameItem item, int quantity)
+    {
+        return quantity > 0 ? $"{quantity.ToString("N0", actor)} of {item.HowSeen(actor)}" : item.HowSeen(actor);
+    }
+
+    private static bool WouldStopLawfulAction(ICharacter actor, CrimeTypes? crime, ICharacter victim, IGameItem item)
+    {
+        if (crime is null || actor.IsAdministrator())
+        {
+            return false;
+        }
+
+        if (!crime.Value.CheckWouldBeACrime(actor, victim, item, string.Empty) || !actor.Account.ActLawfully)
+        {
+            return false;
+        }
+
+        actor.OutputHandler.Send($"That action would be a crime.\n{CrimeExtensions.StandardDisableIllegalFlagText}");
+        return true;
+    }
+
+    private static bool TryResolveStealth(ICharacter actor, ICharacter victim, IGameItem focusItem, CheckType check,
+        CrimeTypes? crime, string actionDescription, out StealthDetectionResult detection)
+    {
+        detection = ResolveStealthDetection(actor, victim, focusItem, check);
+        if (!detection.ActorSucceeded)
+        {
+            actor.OutputHandler.Send($"You fumble your attempt to {actionDescription}.");
+            NotifyNoticers(actor, detection, witness =>
+                $"You notice {actor.HowSeen(witness, true)} trying to {actionDescription}.");
+            RecordStealthCrime(actor, crime, victim, focusItem, detection);
+            return false;
+        }
+
+        if (detection.VictimStopped)
+        {
+            actor.OutputHandler.Send($"{victim.HowSeen(actor, true)} notices what you are doing before you can finish.");
+            NotifyNoticers(actor, detection, witness =>
+                $"You notice {actor.HowSeen(witness, true)} trying to {actionDescription}.");
+            RecordStealthCrime(actor, crime, victim, focusItem, detection);
+            return false;
+        }
+
+        return true;
+    }
+
+    private static StealthDetectionResult ResolveStealthDetection(ICharacter actor, ICharacter victim,
+        IGameItem focusItem, CheckType check)
+    {
+        IPerceivable checkTarget = victim is not null ? victim : focusItem;
+        var result = new StealthDetectionResult
+        {
+            ActorOutcome = actor.Gameworld.GetCheck(check).Check(actor, Difficulty.Normal, checkTarget)
+        };
+
+        var observers = actor.Location.LayerCharacters(actor.RoomLayer)
+                            .Where(x => x != actor)
+                            .Where(x => x.CanSee(actor))
+                            .Distinct()
+                            .ToList();
+        if (victim is not null && victim != actor && !observers.Contains(victim) && victim.CanSee(actor))
+        {
+            observers.Add(victim);
+        }
+
+        foreach (var observer in observers)
+        {
+            var observerOutcome = actor.Gameworld.GetCheck(CheckType.SpotStealthCheck)
+                                       .Check(observer, observer.Location.SpotDifficulty(observer), actor);
+            var opposed = new OpposedOutcome(result.ActorOutcome.Outcome, observerOutcome.Outcome);
+            var notices = opposed.Outcome != OpposedOutcomeDirection.Proponent &&
+                          (observerOutcome.IsPass() || result.ActorOutcome.IsFail());
+            if (!notices)
+            {
+                continue;
+            }
+
+            result.Noticers.Add(observer);
+            if (observer == victim && result.ActorOutcome.IsPass() &&
+                opposed.Outcome == OpposedOutcomeDirection.Opponent &&
+                opposed.Degree >= OpposedOutcomeDegree.Major)
+            {
+                result.VictimStopped = true;
+            }
+        }
+
+        return result;
+    }
+
+    private static void NotifyNoticers(ICharacter actor, StealthDetectionResult detection,
+        Func<ICharacter, string> message)
+    {
+        foreach (var witness in detection.Noticers.Where(x => x != actor))
+        {
+            witness.OutputHandler.Send(message(witness));
+        }
+    }
+
+    private static string NoticedSuffix(StealthDetectionResult detection)
+    {
+        return detection.Noticers.Any() ? " You think someone may have noticed." : string.Empty;
+    }
+
+    private static void RecordStealthCrime(ICharacter actor, CrimeTypes? crime, ICharacter victim, IGameItem item,
+        StealthDetectionResult detection)
+    {
+        if (crime is null || !detection.Noticers.Any())
+        {
+            return;
+        }
+
+        CrimeExtensions.CheckPossibleCrimeAllAuthorities(actor, crime.Value, victim, item, string.Empty,
+            detection.Noticers, victim is not null && detection.Noticers.Contains(victim));
     }
 
     [PlayerCommand("Search", "search")]

--- a/MudSharpCore/RPG/Law/LegalAuthority.cs
+++ b/MudSharpCore/RPG/Law/LegalAuthority.cs
@@ -705,6 +705,12 @@ public partial class LegalAuthority : SaveableItem, ILegalAuthority
     public IEnumerable<ICrime> CheckPossibleCrime(ICharacter criminal, CrimeTypes crime, ICharacter victim,
         IGameItem item, string additionalInformation)
     {
+        return CheckPossibleCrime(criminal, crime, victim, item, additionalInformation, null, true);
+    }
+
+    public IEnumerable<ICrime> CheckPossibleCrime(ICharacter criminal, CrimeTypes crime, ICharacter victim,
+        IGameItem item, string additionalInformation, IEnumerable<ICharacter> explicitWitnesses, bool notifyVictim)
+    {
         if (criminal.IsAdministrator())
         {
             return Enumerable.Empty<ICrime>();
@@ -740,8 +746,10 @@ public partial class LegalAuthority : SaveableItem, ILegalAuthority
                 continue;
             }
 
-            List<ICharacter> witnesses = criminal.Location.LayerCharacters(criminal.RoomLayer).Except(criminal)
-                                    .Where(x => x.CanSee(criminal)).ToList();
+            List<ICharacter> witnesses = explicitWitnesses is null
+                ? criminal.Location.LayerCharacters(criminal.RoomLayer).Except(criminal)
+                          .Where(x => x.CanSee(criminal)).ToList()
+                : explicitWitnesses.Except(criminal).Distinct().ToList();
             Crime newCrime = new(criminal, victim, witnesses, law, item);
             _unknownCrimes.Add(newCrime);
             _unknownCrimesLookup.Add(criminal.Id, newCrime);
@@ -752,7 +760,10 @@ public partial class LegalAuthority : SaveableItem, ILegalAuthority
                 witness.HandleEvent(Events.EventType.WitnessedCrime, criminal, victim, witness, newCrime);
             }
 
-            victim?.HandleEvent(Events.EventType.VictimOfCrime, criminal, victim, newCrime);
+            if (notifyVictim)
+            {
+                victim?.HandleEvent(Events.EventType.VictimOfCrime, criminal, victim, newCrime);
+            }
             Changed = true;
             crimes.Add(newCrime);
         }


### PR DESCRIPTION
## Summary
- Add the Palm and Steal stealth commands with item, quantity, currency, container, carried-container, and belt-cutting flows.
- Add explicit-witness inventory event overloads and stealth-aware crime reporting so only noticers receive witness/crime events.
- Seed the Steal check/static cut-purse configuration and update the relevant item/economy docs.

## Validation
- `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `git diff --check`