### PR TITLE
[codex] Backfill combat rebalance fauna coverage

### DIFF
--- a/DatabaseSeeder Unit Tests/AnimalSeederTemplateTests.cs
+++ b/DatabaseSeeder Unit Tests/AnimalSeederTemplateTests.cs
@@ -639,6 +639,45 @@ public class AnimalSeederTemplateTests
     }
 
     [TestMethod]
+    public void AnimalCombatRebalanceBodyNamesForTesting_CoversEveryStockAnimalBodyFamily()
+    {
+        HashSet<string> coveredBodies = AnimalSeeder.AnimalCombatRebalanceBodyNamesForTesting
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        string[] missingBodyKeys = AnimalSeeder.RaceTemplatesForTesting.Values
+            .Select(x => x.BodyKey)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Where(x => !coveredBodies.Contains(x))
+            .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        Assert.AreEqual(0, missingBodyKeys.Length,
+            $"Every stock animal body key should be refreshed by combat-rebalance reruns. Missing: {string.Join(", ", missingBodyKeys)}");
+
+        foreach (string raceName in new[]
+                 {
+                     "Donkey",
+                     "Mule",
+                     "Spider",
+                     "Scorpion",
+                     "Small Crab",
+                     "Lobster",
+                     "Komodo Dragon",
+                     "Caiman",
+                     "Frog"
+                 })
+        {
+            string bodyKey = AnimalSeeder.RaceTemplatesForTesting[raceName].BodyKey;
+            Assert.IsTrue(coveredBodies.Contains(bodyKey),
+                $"{raceName} uses {bodyKey}, so the rebalance rerun body list should refresh that body family.");
+        }
+
+        CollectionAssert.Contains(AnimalSeeder.AnimalCombatRebalanceBodyNamesForTesting.ToArray(), "Quadruped Base",
+            "The shared quadruped base still needs direct rerun refreshes because multiple derived bodies clone from it.");
+        CollectionAssert.Contains(AnimalSeeder.AnimalCombatRebalanceBodyNamesForTesting.ToArray(), "Vermiform",
+            "Mythic worm-beasts reuse the stock vermiform body even though ordinary animal templates primarily use serpentine bodies.");
+    }
+
+    [TestMethod]
     public void RaceTemplatesForTesting_RegionalCoverageAddsIconicNonEuropeanAnimals()
     {
         string[] expectedMammals =

--- a/DatabaseSeeder Unit Tests/MythicalAnimalSeederTemplateTests.cs
+++ b/DatabaseSeeder Unit Tests/MythicalAnimalSeederTemplateTests.cs
@@ -738,6 +738,43 @@ public class MythicalAnimalSeederTemplateTests
     }
 
     [TestMethod]
+    public void MythicalCombatRebalanceReferenceBodyNamesForTesting_CoversEveryStockMythicBodyFamily()
+    {
+        HashSet<string> mappedBodyKeys = MythicalAnimalSeeder.MythicalCombatRebalanceBodyKeysForTesting
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        string[] missingBodyKeys = MythicalAnimalSeeder.TemplatesForTesting.Values
+            .Select(x => x.BodyKey)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Where(x => !mappedBodyKeys.Contains(x))
+            .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        Assert.AreEqual(0, missingBodyKeys.Length,
+            $"Every stock mythical body key should have an explicit combat-rebalance reference map. Missing: {string.Join(", ", missingBodyKeys)}");
+
+        Assert.IsTrue(
+            MythicalAnimalSeeder.MythicalCombatRebalanceReferenceBodyNamesForTesting["Arachnid"]
+                .Contains("Arachnid", StringComparer.OrdinalIgnoreCase),
+            "Giant spiders should refresh from the stock arachnid body under the rebalance profile.");
+        Assert.IsTrue(
+            MythicalAnimalSeeder.MythicalCombatRebalanceReferenceBodyNamesForTesting["Scorpion"]
+                .Contains("Scorpion", StringComparer.OrdinalIgnoreCase),
+            "Giant scorpions should refresh from the stock scorpion body under the rebalance profile.");
+        Assert.IsTrue(
+            MythicalAnimalSeeder.MythicalCombatRebalanceReferenceBodyNamesForTesting["Avian"]
+                .Contains("Avian", StringComparer.OrdinalIgnoreCase),
+            "Garuda and giant eagles should refresh from the stock avian body under the rebalance profile.");
+        Assert.IsTrue(
+            MythicalAnimalSeeder.MythicalCombatRebalanceReferenceBodyNamesForTesting["Ungulate"]
+                .Contains("Ungulate", StringComparer.OrdinalIgnoreCase),
+            "Qilin and equine mythics should refresh from the stock ungulate body under the rebalance profile.");
+        Assert.IsTrue(
+            MythicalAnimalSeeder.MythicalCombatRebalanceReferenceBodyNamesForTesting["Toed Quadruped"]
+                .Contains("Toed Quadruped", StringComparer.OrdinalIgnoreCase),
+            "Wargs, dire beasts, and bunyips should refresh from the stock toed quadruped body under the rebalance profile.");
+    }
+
+    [TestMethod]
     public void TemplatesForTesting_CombatStrategyKeys_MapRepresentativeMythicRacesToExpectedStyles()
     {
         Assert.AreEqual("Beast Artillery", MythicalAnimalSeeder.TemplatesForTesting["Dragon"].CombatStrategyKey);

--- a/DatabaseSeeder/Seeders/AnimalSeeder.CombatRebalance.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.CombatRebalance.cs
@@ -17,6 +17,33 @@ public partial class AnimalSeeder
 
 	private bool UsesCombatRebalance => _combatBalanceProfile == CombatBalanceProfile.CombatRebalance;
 
+	private static readonly string[] AnimalCombatRebalanceBodyNames =
+	[
+		"Quadruped Base",
+		"Ungulate",
+		"Toed Quadruped",
+		"Pinniped",
+		"Avian",
+		"Vermiform",
+		"Serpentine",
+		"Piscine",
+		"Decapod",
+		"Malacostracan",
+		"Cetacean",
+		"Cephalopod",
+		"Jellyfish",
+		"Insectoid",
+		"Winged Insectoid",
+		"Beetle",
+		"Centipede",
+		"Arachnid",
+		"Scorpion",
+		"Reptilian",
+		"Anuran"
+	];
+
+	internal static IReadOnlyList<string> AnimalCombatRebalanceBodyNamesForTesting => AnimalCombatRebalanceBodyNames;
+
 	private IReadOnlyDictionary<string, string> BuildAnimalDamageExpressions()
 	{
 		if (UsesCombatRebalance)
@@ -235,7 +262,9 @@ public partial class AnimalSeeder
 	private int ResolveAnimalRelativeHitChance(BodyProto body, string alias, BodypartTypeEnum type, SizeCategory size,
 		int fallback)
 	{
-		int baseChance = GetAnimalRelativeHitChance(body, alias, fallback);
+		int baseChance = UsesCombatRebalance
+			? GetAnimalCombatRebalanceRelativeHitChance(body, alias, fallback)
+			: GetAnimalRelativeHitChance(body, alias, fallback);
 		if (!UsesCombatRebalance)
 		{
 			return baseChance;
@@ -262,6 +291,60 @@ public partial class AnimalSeeder
 		};
 
 		return Math.Max(1, (int)Math.Round(baseChance * modifier, MidpointRounding.AwayFromZero));
+	}
+
+	private static int GetAnimalCombatRebalanceRelativeHitChance(BodyProto body, string alias, int fallback)
+	{
+		return body.Name switch
+		{
+			"Decapod" or "Malacostracan" => GetCrustaceanRelativeHitChance(alias, fallback),
+			"Arachnid" or "Scorpion" => GetArachnidRelativeHitChance(alias, fallback),
+			"Reptilian" or "Anuran" => GetToedQuadrupedRelativeHitChance(alias, fallback),
+			_ => GetAnimalRelativeHitChance(body, alias, fallback)
+		};
+	}
+
+	private static int GetCrustaceanRelativeHitChance(string alias, int fallback)
+	{
+		if (alias.StartsWith("rleg", StringComparison.OrdinalIgnoreCase) ||
+		    alias.StartsWith("lleg", StringComparison.OrdinalIgnoreCase))
+		{
+			return 10;
+		}
+
+		return alias switch
+		{
+			"carapace" => 65,
+			"underbelly" => 40,
+			"mouth" => 8,
+			"reye" or "leye" => 2,
+			"rantenna" or "lantenna" => 2,
+			"rclaw" or "lclaw" => 16,
+			"gillcluster" => 8,
+			"tail" => 18,
+			_ => fallback
+		};
+	}
+
+	private static int GetArachnidRelativeHitChance(string alias, int fallback)
+	{
+		if (alias.StartsWith("rleg", StringComparison.OrdinalIgnoreCase) ||
+		    alias.StartsWith("lleg", StringComparison.OrdinalIgnoreCase))
+		{
+			return 12;
+		}
+
+		return alias switch
+		{
+			"cephalothorax" => 55,
+			"abdomen" => 45,
+			"reye" or "leye" => 2,
+			"rfang" or "lfang" => 3,
+			"rclaw" or "lclaw" => 12,
+			"tail" => 18,
+			"stinger" => 3,
+			_ => fallback
+		};
 	}
 
 	private string? ResolveAnimalSeverFormula(string alias, SizeCategory size)
@@ -298,24 +381,7 @@ public partial class AnimalSeeder
 
 		RefreshDragonfireBreathDamageExpression(expressions);
 
-		foreach (string bodyName in new[]
-		         {
-			         "Quadruped Base",
-			         "Ungulate",
-			         "Toed Quadruped",
-			         "Pinniped",
-			         "Avian",
-			         "Vermiform",
-			         "Serpentine",
-			         "Piscine",
-			         "Cetacean",
-			         "Cephalopod",
-			         "Jellyfish",
-			         "Insectoid",
-			         "Winged Insectoid",
-			         "Beetle",
-			         "Centipede"
-		         })
+		foreach (string bodyName in AnimalCombatRebalanceBodyNames)
 		{
 			BodyProto? body = _context.BodyProtos.FirstOrDefault(x => x.Name == bodyName);
 			if (body is null)

--- a/DatabaseSeeder/Seeders/MythicalAnimalSeeder.CombatRebalance.cs
+++ b/DatabaseSeeder/Seeders/MythicalAnimalSeeder.CombatRebalance.cs
@@ -15,6 +15,77 @@ public partial class MythicalAnimalSeeder
 
 	private bool UsesCombatRebalance => _combatBalanceProfile == CombatBalanceProfile.CombatRebalance;
 
+	private const string DefaultMythicalCombatRebalanceReferenceKey = "*";
+
+	private static readonly IReadOnlyDictionary<string, string[]> MythicalCombatRebalanceReferenceBodyNames =
+		new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+		{
+			["Organic Humanoid"] =
+			[
+				"Organic Humanoid", "Quadruped Base", "Ungulate", "Toed Quadruped", "Avian", "Vermiform",
+				"Serpentine", "Piscine"
+			],
+			["Horned Humanoid"] =
+			[
+				"Organic Humanoid", "Quadruped Base", "Ungulate", "Toed Quadruped", "Avian", "Vermiform",
+				"Serpentine", "Piscine"
+			],
+			["Winged Humanoid"] =
+			[
+				"Organic Humanoid", "Quadruped Base", "Ungulate", "Toed Quadruped", "Avian", "Vermiform",
+				"Serpentine", "Piscine"
+			],
+			["Naga"] =
+			[
+				"Organic Humanoid", "Quadruped Base", "Ungulate", "Toed Quadruped", "Avian", "Vermiform",
+				"Serpentine", "Piscine"
+			],
+			["Mermaid"] =
+			[
+				"Organic Humanoid", "Quadruped Base", "Ungulate", "Toed Quadruped", "Avian", "Vermiform",
+				"Serpentine", "Piscine"
+			],
+			["Centaur"] =
+			[
+				"Organic Humanoid", "Quadruped Base", "Ungulate", "Toed Quadruped", "Avian", "Vermiform",
+				"Serpentine", "Piscine"
+			],
+			["Toed Quadruped"] = ["Toed Quadruped", "Quadruped Base", "Ungulate", "Avian", "Serpentine"],
+			["Ungulate"] = ["Ungulate", "Quadruped Base", "Toed Quadruped", "Avian"],
+			["Avian"] = ["Avian", "Toed Quadruped", "Quadruped Base", "Ungulate"],
+			["Serpentine"] = ["Serpentine", "Vermiform"],
+			["Vermiform"] = ["Vermiform", "Serpentine"],
+			["Insectoid"] = ["Insectoid", "Arachnid", "Scorpion", "Beetle", "Centipede"],
+			["Arachnid"] = ["Arachnid", "Scorpion", "Insectoid", "Centipede"],
+			["Beetle"] = ["Beetle", "Insectoid", "Centipede"],
+			["Centipede"] = ["Centipede", "Insectoid", "Beetle"],
+			["Scorpion"] = ["Scorpion", "Arachnid", "Insectoid", "Centipede"],
+			["Eastern Dragon"] =
+				["Quadruped Base", "Toed Quadruped", "Ungulate", "Avian", "Piscine", "Scorpion"],
+			["Griffin"] =
+				["Quadruped Base", "Toed Quadruped", "Ungulate", "Avian", "Piscine", "Scorpion"],
+			["Hippogriff"] =
+				["Quadruped Base", "Toed Quadruped", "Ungulate", "Avian", "Piscine", "Scorpion"],
+			["Manticore"] =
+				["Quadruped Base", "Toed Quadruped", "Ungulate", "Avian", "Piscine", "Scorpion"],
+			["Hippocamp"] =
+				["Quadruped Base", "Toed Quadruped", "Ungulate", "Avian", "Piscine", "Scorpion"],
+			["Wyvern"] = ["Avian", "Quadruped Base", "Toed Quadruped", "Ungulate"],
+			[DefaultMythicalCombatRebalanceReferenceKey] =
+			[
+				"Organic Humanoid", "Quadruped Base", "Toed Quadruped", "Ungulate", "Avian", "Insectoid",
+				"Arachnid", "Beetle", "Centipede", "Vermiform", "Serpentine", "Piscine", "Scorpion"
+			]
+		};
+
+	internal static IReadOnlyDictionary<string, string[]> MythicalCombatRebalanceReferenceBodyNamesForTesting =>
+		MythicalCombatRebalanceReferenceBodyNames;
+
+	internal static IReadOnlyCollection<string> MythicalCombatRebalanceBodyKeysForTesting =>
+		MythicalCombatRebalanceReferenceBodyNames.Keys
+			.Where(x => !x.Equals(DefaultMythicalCombatRebalanceReferenceKey, StringComparison.OrdinalIgnoreCase))
+			.ToArray();
+
 	private double ResolveMythicalHealthMultiplier(MythicalRaceTemplate template)
 	{
 		if (!UsesCombatRebalance)
@@ -105,89 +176,39 @@ public partial class MythicalAnimalSeeder
 			yield return countsAsBody;
 		}
 
-		switch (template.BodyKey)
+		if (!MythicalCombatRebalanceReferenceBodyNames.TryGetValue(template.BodyKey, out string[]? referenceBodyNames))
 		{
-			case "Organic Humanoid":
-			case "Horned Humanoid":
-			case "Winged Humanoid":
-			case "Naga":
-			case "Mermaid":
-			case "Centaur":
-				yield return _organicHumanoidBody;
-				yield return _quadrupedBody;
-				yield return _ungulateBody;
-				yield return _toedQuadrupedBody;
-				yield return _avianBody;
-				yield return _vermiformBody;
-				yield return _serpentineBody;
-				yield return _piscineBody;
-				break;
-			case "Insectoid":
-				yield return _insectoidBody;
-				yield return _arachnidBody;
-				yield return _scorpionBody;
-				yield return _beetleBody;
-				yield return _centipedeBody;
-				break;
-			case "Arachnid":
-				yield return _arachnidBody;
-				yield return _scorpionBody;
-				yield return _insectoidBody;
-				yield return _centipedeBody;
-				break;
-			case "Vermiform":
-				yield return _vermiformBody;
-				yield return _serpentineBody;
-				break;
-			case "Beetle":
-				yield return _beetleBody;
-				yield return _insectoidBody;
-				yield return _centipedeBody;
-				break;
-			case "Centipede":
-				yield return _centipedeBody;
-				yield return _insectoidBody;
-				yield return _beetleBody;
-				break;
-			case "Scorpion":
-				yield return _scorpionBody;
-				yield return _arachnidBody;
-				yield return _insectoidBody;
-				yield return _centipedeBody;
-				break;
-			case "Eastern Dragon":
-			case "Griffin":
-			case "Hippogriff":
-			case "Manticore":
-			case "Hippocamp":
-				yield return _quadrupedBody;
-				yield return _toedQuadrupedBody;
-				yield return _ungulateBody;
-				yield return _avianBody;
-				yield return _piscineBody;
-				yield return _scorpionBody;
-				break;
-			case "Wyvern":
-				yield return _avianBody;
-				yield return _quadrupedBody;
-				yield return _toedQuadrupedBody;
-				yield return _ungulateBody;
-				break;
-			default:
-				yield return _organicHumanoidBody;
-				yield return _quadrupedBody;
-				yield return _toedQuadrupedBody;
-				yield return _ungulateBody;
-				yield return _avianBody;
-				yield return _insectoidBody;
-				yield return _arachnidBody;
-				yield return _beetleBody;
-				yield return _centipedeBody;
-				yield return _vermiformBody;
-				yield return _serpentineBody;
-				yield return _piscineBody;
-				yield return _scorpionBody;
-				break;
+			referenceBodyNames = MythicalCombatRebalanceReferenceBodyNames[DefaultMythicalCombatRebalanceReferenceKey];
 		}
+
+		foreach (string referenceBodyName in referenceBodyNames)
+		{
+			BodyProto? referenceBody = ResolveMythicalReferenceBody(referenceBodyName);
+			if (referenceBody is not null)
+			{
+				yield return referenceBody;
+			}
+		}
+	}
+
+	private BodyProto? ResolveMythicalReferenceBody(string bodyName)
+	{
+		return bodyName switch
+		{
+			"Organic Humanoid" => _organicHumanoidBody,
+			"Quadruped Base" => _quadrupedBody,
+			"Ungulate" => _ungulateBody,
+			"Toed Quadruped" => _toedQuadrupedBody,
+			"Avian" => _avianBody,
+			"Insectoid" => _insectoidBody,
+			"Arachnid" => _arachnidBody,
+			"Beetle" => _beetleBody,
+			"Centipede" => _centipedeBody,
+			"Vermiform" => _vermiformBody,
+			"Serpentine" => _serpentineBody,
+			"Piscine" => _piscineBody,
+			"Scorpion" => _scorpionBody,
+			_ => null
+		};
 	}
 }

--- a/Design Documents/Damage_System_Design.md
+++ b/Design Documents/Damage_System_Design.md
@@ -320,6 +320,7 @@ Animal severing is now profile-aware:
 - `stock` continues to use legacy numeric thresholds
 - `combat-rebalance` leaves many major parts on thresholds but adds probabilistic sever formulas to minor appendages, tails, and wings where the seeded body family calls for it
 - size and bodypart role now also feed the seeded bodypart HP and hit-chance values for stock animal bodies
+- rebalance reruns refresh every stock animal body family used by the current catalogue, including later additions such as `Decapod`, `Malacostracan`, `Arachnid`, `Scorpion`, `Reptilian`, and `Anuran`; shared-body races such as donkeys and mules are covered through the `Ungulate` body
 
 ## Mythical Race Armour Inheritance
 Seeded mythical races now follow the stock model they are actually built from:
@@ -335,6 +336,8 @@ That removes the old accidental double-layering on animal-default mythics, where
 Humanoid-default mythics still inherit the human racial/bodypart/cranial split through their cloned humanoid body parts plus human-style racial tissue.
 
 Under `combat-rebalance`, reruns also refresh mythic bodyparts in place from their reference humanoid or animal bodies so the profile's HP, hit-chance, armour, and sever-formula tuning propagates without seeding duplicate races.
+
+The mythical refresh map is explicit for every stock mythical body key. Direct animal-body mythics such as `Giant Spider`, `Giant Scorpion`, `Giant Eagle`, `Qilin`, `Bunyip`, and `Yacumama` now resolve to their matching stock animal reference body first, while hybrid bodies keep their `CountsAs` parent plus a small fallback list of nearby humanoid or animal bodies for inherited aliases.
 
 ## Mythical Offensive and Durability Scaling
 Seeded mythical races now use row-backed racial attribute bonuses rather than the old shared all-zero prog.

--- a/Design Documents/Health_System_Design.md
+++ b/Design Documents/Health_System_Design.md
@@ -120,6 +120,7 @@ Current balance-profile behavior:
 - `stock` keeps the older FutureMUD combat formulas and still asks the legacy damage-randomness question where relevant
 - `combat-rebalance` suppresses that randomness question and rewrites stock-owned bodypart HP, hit chances, natural armour formulas, and shared damage expressions in place while keeping the same named attack and combat-message catalogues
 - reruns refresh stock-owned rows for the selected profile instead of seeding duplicate races, bodies, or attack suites
+- the non-human rerun coverage now tracks every stock animal body family used by the template catalogue, so later additions such as donkey and mule through `Ungulate`, crustaceans, arachnids, scorpions, reptiles, anurans, and animal-body mythics such as giant spiders stay aligned with the selected profile
 
 ## Tuning Surfaces
 The current runtime exposes health tuning in two different ways, depending on where the behavior lives.


### PR DESCRIPTION
## Summary
- Add explicit animal combat-rebalance body coverage for newer stock families including crustaceans, arachnids, scorpions, reptiles, and anurans.
- Make mythical combat-rebalance reference-body mapping explicit for every stock mythic body key so direct animal-body mythics refresh from their tuned stock body first.
- Add focused seeder coverage tests and update the health and damage design docs.

## Validation
- Passed: `dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore --filter "FullyQualifiedName~AnimalSeederTemplateTests|FullyQualifiedName~MythicalAnimalSeederTemplateTests"` (61/61).
- Full DatabaseSeeder suite currently has one unrelated failure in `BlankDatabaseSnapshotTests.CommittedBlankSnapshotManifest_TracksLatestMigration`: the blank snapshot manifest records `20260501132243_RaceAgeColumnsNoDatabaseDefaults`, while the latest migration source is `20260507092824_ClanBudgetVirtualTreasuryFallback`.