### PR TITLE
[codex] Add worn trait changer seed components

### DIFF
--- a/DatabaseSeeder Unit Tests/UsefulSeederItemPackageTests.cs
+++ b/DatabaseSeeder Unit Tests/UsefulSeederItemPackageTests.cs
@@ -10,6 +10,8 @@ using MudSharp.Models;
 using System;
 using System.Linq;
 using System.Xml.Linq;
+using TraitOwnerScope = MudSharp.Body.Traits.TraitOwnerScope;
+using TraitType = MudSharp.Body.Traits.TraitType;
 using SizeCategory = MudSharp.GameItems.SizeCategory;
 
 namespace MudSharp_Unit_Tests;
@@ -131,6 +133,21 @@ public class UsefulSeederItemPackageTests
 				ReviewerComment = "test",
 				ReviewerDate = DateTime.UtcNow
 			}
+		};
+	}
+
+	private static TraitDefinition CreateSkill(long id, string name)
+	{
+		return new TraitDefinition
+		{
+			Id = id,
+			Name = name,
+			Alias = name.Replace(" ", string.Empty).ToLowerInvariant(),
+			Type = (int)TraitType.Skill,
+			OwnerScope = (int)TraitOwnerScope.Character,
+			TraitGroup = "Test",
+			ChargenBlurb = string.Empty,
+			ValueExpression = string.Empty
 		};
 	}
 
@@ -267,5 +284,77 @@ public class UsefulSeederItemPackageTests
 		Assert.AreEqual(1, context.VariableDefinitions.Count(x => x.Property == "nicotineuntil"));
 		Assert.AreEqual(1, context.VariableDefaults.Count(x => x.Property == "nicotineuntil"));
 		Assert.AreEqual(0, context.GameItemComponentProtos.Count(x => x.Name.StartsWith("Food_")));
+	}
+
+	[TestMethod]
+	public void SeedWornTraitChangersForTesting_NoExpectedSkillPackageTraits_SkipsFamily()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedGeneralPrerequisites(context);
+		UsefulSeeder seeder = new();
+
+		seeder.SeedWornTraitChangersForTesting(context);
+
+		Assert.AreEqual(0,
+			context.GameItemComponentProtos.Count(x => x.Name.StartsWith("WornTraitChanger_") && x.Type == "WornTraitChanger"));
+	}
+
+	[TestMethod]
+	public void SeedWornTraitChangersForTesting_WithSkillPackageTraits_UpsertsGradedFamilies()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedGeneralPrerequisites(context);
+		context.TraitDefinitions.AddRange(
+			CreateSkill(101, "Hiding"),
+			CreateSkill(102, "Sneaking"),
+			CreateSkill(103, "Swimming"),
+			CreateSkill(104, "Climbing"),
+			CreateSkill(105, "Flying"),
+			CreateSkill(106, "Running"),
+			CreateSkill(107, "Palming"),
+			CreateSkill(108, "Lockpicking"),
+			CreateSkill(109, "Stealing"),
+			CreateSkill(110, "Surgery"),
+			CreateSkill(111, "First Aid"),
+			CreateSkill(112, "Spotting"),
+			CreateSkill(113, "Searching"),
+			CreateSkill(114, "Tracking"),
+			CreateSkill(115, "Listening"),
+			CreateSkill(116, "Handwriting"));
+		context.GameItemComponentProtos.Add(CreateComponentMarker(200,
+			"WornTraitChanger_StealthPenalty_Moderate", "OldType"));
+		context.SaveChanges();
+		UsefulSeeder seeder = new();
+
+		seeder.SeedWornTraitChangersForTesting(context);
+		seeder.SeedWornTraitChangersForTesting(context);
+
+		GameItemComponentProto stealthPenalty = context.GameItemComponentProtos.Single(x =>
+			x.Name == "WornTraitChanger_StealthPenalty_Moderate");
+		Assert.AreEqual("WornTraitChanger", stealthPenalty.Type);
+		Assert.AreEqual(1, context.GameItemComponentProtos.Count(x => x.Name == "WornTraitChanger_StealthPenalty_Moderate"));
+		Assert.AreEqual(-5.0, ModifierFor(stealthPenalty, 101));
+		Assert.AreEqual(-5.0, ModifierFor(stealthPenalty, 102));
+
+		Assert.AreEqual(-2.5, ModifierFor(Component("WornTraitChanger_SwimPenalty_Minor"), 103));
+		Assert.AreEqual(-10.0, ModifierFor(Component("WornTraitChanger_ClimbPenalty_Severe"), 104));
+		Assert.AreEqual(-7.5, ModifierFor(Component("WornTraitChanger_FlyPenalty_Major"), 105));
+		Assert.AreEqual(7.5, ModifierFor(Component("WornTraitChanger_RunningBonus_Major"), 106));
+		Assert.AreEqual(-5.0, ModifierFor(Component("WornTraitChanger_ManualDexterityPenalty_Moderate"), 107));
+		Assert.AreEqual(-5.0, ModifierFor(Component("WornTraitChanger_ManualDexterityPenalty_Moderate"), 108));
+		Assert.AreEqual(-10.0, ModifierFor(Component("WornTraitChanger_VisualPerceptionPenalty_Severe"), 112));
+		Assert.AreEqual(-2.5, ModifierFor(Component("WornTraitChanger_ListeningPenalty_Minor"), 115));
+		Assert.AreEqual(-7.5, ModifierFor(Component("WornTraitChanger_AwarenessPenalty_Major"), 115));
+		Assert.AreEqual(5.0, ModifierFor(Component("WornTraitChanger_StealthMobilityBonus_Moderate"), 106));
+
+		GameItemComponentProto Component(string name) => context.GameItemComponentProtos.Single(x => x.Name == name);
+	}
+
+	private static double ModifierFor(GameItemComponentProto component, long traitId)
+	{
+		XElement modifier = XElement.Parse(component.Definition)
+		                            .Elements("Modifier")
+		                            .Single(x => (long)x.Attribute("trait")! == traitId);
+		return (double)modifier.Attribute("bonus")!;
 	}
 }

--- a/DatabaseSeeder/Seeders/UsefulSeeder.ItemComponents.cs
+++ b/DatabaseSeeder/Seeders/UsefulSeeder.ItemComponents.cs
@@ -76,6 +76,28 @@ public partial class UsefulSeeder
         return AddGameItemComponent(context, component);
     }
 
+    private GameItemComponentProto UpsertComponent(FuturemudDatabaseContext context,
+        ref long nextId, Account account, DateTime now, string type, string name,
+        string description, string definition)
+    {
+        if (!_itemProtos.TryGetValue(name, out GameItemComponentProto? existing))
+        {
+            existing = context.GameItemComponentProtos
+                .FirstOrDefault(x => x.Name == name && x.EditableItem.RevisionStatus == 4);
+        }
+
+        if (existing is not null)
+        {
+            existing.Type = type;
+            existing.Description = description;
+            existing.Definition = definition;
+            _itemProtos[existing.Name] = existing;
+            return existing;
+        }
+
+        return CreateComponent(context, ref nextId, account, now, type, name, description, definition);
+    }
+
     private GameItemComponentProto CreateTorchComponent(FuturemudDatabaseContext context,
     ref long nextId, Account account, DateTime now, string name, string description,
     int illuminationProvided, int secondsOfFuel, bool requiresIgnitionSource,
@@ -162,6 +184,17 @@ public partial class UsefulSeeder
         long nextId = context.GameItemComponentProtos.Any() ? context.GameItemComponentProtos.Max(x => x.Id) + 1 : 1;
         SeedAdditionalBuilderExamples(context, now, dbaccount, ref nextId);
         SeedSmokeables(context, now, dbaccount, ref nextId);
+        context.SaveChanges();
+    }
+
+    internal void SeedWornTraitChangersForTesting(FuturemudDatabaseContext context)
+    {
+        _context = context;
+        PrepareItemProtoCache(context);
+        DateTime now = DateTime.UtcNow;
+        Account dbaccount = context.Accounts.First();
+        long nextId = context.GameItemComponentProtos.Any() ? context.GameItemComponentProtos.Max(x => x.Id) + 1 : 1;
+        SeedWornTraitChangers(context, now, dbaccount, ref nextId, new List<string>());
         context.SaveChanges();
     }
 
@@ -2522,6 +2555,7 @@ public partial class UsefulSeeder
         SeedRangedCoverItemComponents(context, now, ref nextId);
         SeedTables(context, now, dbaccount, ref nextId);
         SeedWornExpansion(context, now, dbaccount, ref nextId);
+        SeedWornTraitChangers(context, now, dbaccount, ref nextId, errors);
         SeedHealthRelatedItems(context, now, dbaccount, ref nextId);
         SeedProsthetics(context, now, dbaccount, ref nextId);
         SeedDice(context, now, dbaccount, ref nextId);
@@ -4136,6 +4170,218 @@ public partial class UsefulSeeder
             Definition = @"<Definition StealthDrawDifficulty=""8"" MaximumSize=""7""/>"
         };
         AddGameItemComponent(context, component);
+        context.SaveChanges();
+
+        #endregion
+    }
+
+    private void SeedWornTraitChangers(FuturemudDatabaseContext context, DateTime now, Account dbaccount,
+        ref long nextId, ICollection<string> errors)
+    {
+        #region Worn Trait Changers
+
+        var allTraits = context.TraitDefinitions.AsEnumerable().ToList();
+        var skippedFamilies = new List<string>();
+        long currentId = nextId;
+        var grades = new[]
+        {
+            ("Minor", 2.5),
+            ("Moderate", 5.0),
+            ("Major", 7.5),
+            ("Severe", 10.0)
+        };
+
+        TraitDefinition? FindTrait(params string[] names)
+        {
+            foreach (string name in names)
+            {
+                TraitDefinition? trait = allTraits.FirstOrDefault(x =>
+                    string.Equals(x.Name, name, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(x.Alias, name, StringComparison.OrdinalIgnoreCase));
+                if (trait is not null)
+                {
+                    return trait;
+                }
+            }
+
+            return null;
+        }
+
+        List<TraitDefinition> UniqueTraits(params TraitDefinition?[] traits)
+        {
+            var seen = new HashSet<long>();
+            var results = new List<TraitDefinition>();
+            foreach (TraitDefinition? trait in traits)
+            {
+                if (trait is null || !seen.Add(trait.Id))
+                {
+                    continue;
+                }
+
+                results.Add(trait);
+            }
+
+            return results;
+        }
+
+        XElement BuildDefinition(IEnumerable<TraitDefinition> traits, double modifier)
+        {
+            return new XElement("Definition",
+                from trait in traits
+                select new XElement("Modifier",
+                    new XAttribute("trait", trait.Id),
+                    new XAttribute("bonus", modifier),
+                    new XAttribute("context", (int)TraitBonusContext.None)));
+        }
+
+        void CreateGradedFamily(string key, string description, IReadOnlyCollection<TraitDefinition> traits,
+            double sign)
+        {
+            if (!traits.Any())
+            {
+                skippedFamilies.Add(key);
+                return;
+            }
+
+            foreach ((string grade, double magnitude) in grades)
+            {
+                double modifier = sign * magnitude;
+                UpsertComponent(context, ref currentId, dbaccount, now, "WornTraitChanger",
+                    $"WornTraitChanger_{key}_{grade}",
+                    $"{description} This is the {grade.ToLowerInvariant()} grade at {modifier:N1} per affected trait.",
+                    BuildDefinition(traits, modifier).ToString());
+            }
+        }
+
+        TraitDefinition? hideTrait = FindTrait("Hide", "Hiding", "Stealth");
+        TraitDefinition? sneakTrait = FindTrait("Sneak", "Sneaking", "Stealth");
+        List<TraitDefinition> stealthTraits = UniqueTraits(hideTrait, sneakTrait);
+        if (stealthTraits.Any())
+        {
+            if (hideTrait is not null && hideTrait.Id != sneakTrait?.Id)
+            {
+                CreateGradedFamily("HidePenalty", "Makes worn items harder to hide in.", [hideTrait], -1.0);
+            }
+
+            if (sneakTrait is not null && sneakTrait.Id != hideTrait?.Id)
+            {
+                CreateGradedFamily("SneakPenalty", "Makes worn items noisier or more awkward for sneaking.", [sneakTrait],
+                    -1.0);
+            }
+
+            CreateGradedFamily("StealthPenalty", "Makes worn items harder to hide and sneak in.", stealthTraits, -1.0);
+            CreateGradedFamily("StealthBonus", "Helps worn camouflage, soft soles, or fitted clothing support stealth.",
+                stealthTraits, 1.0);
+        }
+        else
+        {
+            skippedFamilies.Add("StealthPenalty");
+            skippedFamilies.Add("StealthBonus");
+        }
+
+        TraitDefinition? swimTrait = FindTrait("Swim", "Swimming", "Athletics");
+        TraitDefinition? climbTrait = FindTrait("Climb", "Climbing", "Athletics");
+        TraitDefinition? flyTrait = FindTrait("Fly", "Flying", "Athletics");
+        TraitDefinition? runTrait = FindTrait("Run", "Running", "Athletics");
+        List<TraitDefinition> movementPenaltyTraits = UniqueTraits(swimTrait, climbTrait, flyTrait);
+        if (movementPenaltyTraits.Any())
+        {
+            if (swimTrait is not null && swimTrait.Id != climbTrait?.Id && swimTrait.Id != flyTrait?.Id)
+            {
+                CreateGradedFamily("SwimPenalty", "Makes worn items harder to swim in.", [swimTrait], -1.0);
+            }
+
+            if (climbTrait is not null && climbTrait.Id != swimTrait?.Id && climbTrait.Id != flyTrait?.Id)
+            {
+                CreateGradedFamily("ClimbPenalty", "Makes worn items harder to climb in.", [climbTrait], -1.0);
+            }
+
+            if (flyTrait is not null && flyTrait.Id != swimTrait?.Id && flyTrait.Id != climbTrait?.Id)
+            {
+                CreateGradedFamily("FlyPenalty", "Makes worn items harder to fly in.", [flyTrait], -1.0);
+            }
+
+            CreateGradedFamily("MovementPenalty", "Makes worn items harder to swim, climb, or fly in.",
+                movementPenaltyTraits, -1.0);
+        }
+        else
+        {
+            skippedFamilies.Add("MovementPenalty");
+        }
+
+        List<TraitDefinition> movementBonusTraits = UniqueTraits(swimTrait, climbTrait, flyTrait, runTrait);
+        if (movementBonusTraits.Any())
+        {
+            CreateGradedFamily("MovementBonus", "Helps fitted athletic gear support swimming, climbing, flying, or running.",
+                movementBonusTraits, 1.0);
+        }
+        else
+        {
+            skippedFamilies.Add("MovementBonus");
+        }
+
+        if (runTrait is not null)
+        {
+            CreateGradedFamily("RunningBonus", "Helps good footwear or legwear support running.", [runTrait], 1.0);
+        }
+        else
+        {
+            skippedFamilies.Add("RunningBonus");
+        }
+
+        List<TraitDefinition> stealthMobilityBonusTraits = UniqueTraits(hideTrait, sneakTrait, swimTrait, climbTrait,
+            flyTrait, runTrait);
+        if (stealthMobilityBonusTraits.Any())
+        {
+            CreateGradedFamily("StealthMobilityBonus",
+                "Helps specialised worn gear support stealth, swimming, climbing, flying, and running.",
+                stealthMobilityBonusTraits, 1.0);
+        }
+        else
+        {
+            skippedFamilies.Add("StealthMobilityBonus");
+        }
+
+        List<TraitDefinition> manualDexterityTraits = UniqueTraits(
+            FindTrait("Palm", "Palming", "Sleight", "Security"),
+            FindTrait("Picklock", "Pick Locks", "Lockpicking", "Security"),
+            FindTrait("Steal", "Stealing", "Sleight", "Security"),
+            FindTrait("Surgery", "Medicine"),
+            FindTrait("First Aid", "Healing", "Medicine"),
+            FindTrait("Patient Care", "Medicine"),
+            FindTrait("Skin", "Skinning", "Survival"),
+            FindTrait("Tattoo", "Tattooing"),
+            FindTrait("Handwriting"));
+        CreateGradedFamily("ManualDexterityPenalty",
+            "Makes worn gloves, gauntlets, or similar gear interfere with manual dexterity work.",
+            manualDexterityTraits, -1.0);
+
+        TraitDefinition? spotTrait = FindTrait("Spot", "Spotting", "Scan", "Perception");
+        TraitDefinition? searchTrait = FindTrait("Search", "Searching", "Perception");
+        TraitDefinition? trackTrait = FindTrait("Track", "Tracking", "Perception");
+        List<TraitDefinition> visualPerceptionTraits = UniqueTraits(spotTrait, searchTrait, trackTrait);
+        CreateGradedFamily("VisualPerceptionPenalty",
+            "Makes worn masks, visors, or closed helmets interfere with visual perception.",
+            visualPerceptionTraits, -1.0);
+
+        TraitDefinition? listenTrait = FindTrait("Listen", "Listening", "Perception");
+        List<TraitDefinition> listeningTraits = UniqueTraits(listenTrait);
+        CreateGradedFamily("ListeningPenalty",
+            "Makes worn earplugs, heavy helmets, or muffling gear interfere with listening.",
+            listeningTraits, -1.0);
+
+        List<TraitDefinition> awarenessTraits = UniqueTraits(spotTrait, searchTrait, trackTrait, listenTrait);
+        CreateGradedFamily("AwarenessPenalty",
+            "Makes worn hoods, enclosed helmets, or heavy masks interfere with both seeing and hearing.",
+            awarenessTraits, -1.0);
+
+        if (skippedFamilies.Any())
+        {
+            errors.Add(
+                $"Skipped worn trait changer component families because the expected Skill Package traits were not found: {string.Join(", ", skippedFamilies.Distinct())}.");
+        }
+
+        nextId = currentId;
         context.SaveChanges();
 
         #endregion

--- a/Design Documents/Item_System_Component_Authoring.md
+++ b/Design Documents/Item_System_Component_Authoring.md
@@ -100,7 +100,7 @@ For example:
 - a runtime component that implements `IWearable` should have a proto that implements `IWearablePrototype`
 - a runtime component that implements `ILiquidContainer` should have a proto that implements `ILiquidContainerPrototype`, which also implies the relevant parent capability markers
 
-These markers let item prototypes catch invalid component combinations before review. Most capability markers are exclusive, because runtime code usually calls `GetItemType<T>()` or `IsItemType<T>()` and expects one authoritative component. Aggregate service markers such as `IConnectablePrototype`, `IConsumePowerPrototype`, `IProducePowerPrototype`, `ISignalSourceComponentPrototype`, and grid-connection markers remain composable.
+These markers let item prototypes catch invalid component combinations before review. Most capability markers are exclusive, because runtime code usually calls `GetItemType<T>()` or `IsItemType<T>()` and expects one authoritative component. Aggregate service markers such as `IConnectablePrototype`, `IConsumePowerPrototype`, `IProducePowerPrototype`, `ISignalSourceComponentPrototype`, `IChangeTraitsInInventoryPrototype`, and grid-connection markers remain composable.
 
 If you add a new public `IGameItemComponent` interface, add its matching `I...Prototype` marker at the same time and classify it as exclusive unless the runtime deliberately aggregates multiple sibling components of that interface.
 

--- a/Design Documents/Item_System_Content_Workflows.md
+++ b/Design Documents/Item_System_Content_Workflows.md
@@ -67,7 +67,7 @@ Power, telecom, and modern medical examples also include:
 - `comp edit new defibrillator`
 - `comp edit new externalorgan`
 
-`UsefulSeeder` now ships stock component examples across those modern families, including lithium batteries, cellular devices, answering-machine tapes, computer/network gear, signal automation, gas containers, rebreathers, inhalers, defibrillators, and external-organ support machines. Its general item package also includes a broad furniture-container catalogue for tables, shelves, bookcases, racks, stands, cabinets, wardrobes, trunks, drawers, counters, bins, beds and display cases, plus size-labelled door, gate, glass-door, and locking-door component presets for door items intended to match exit `DoorSize` values from `Tiny` through `Gigantic`; the item prototype size itself must still be set on the item. Food presets now live in the dedicated `CookingSeeder` package, which installs `PreparedFood` examples for direct load, forageable stock, stackable servings, and cooking recipe products. Fax-machine examples and breathing-filter cartridge ecosystems remain later dedicated content passes.
+`UsefulSeeder` now ships stock component examples across those modern families, including lithium batteries, cellular devices, answering-machine tapes, computer/network gear, signal automation, gas containers, rebreathers, inhalers, defibrillators, and external-organ support machines. Its general item package also includes a broad furniture-container catalogue for tables, shelves, bookcases, racks, stands, cabinets, wardrobes, trunks, drawers, counters, bins, beds and display cases, size-labelled door, gate, glass-door, and locking-door component presets for door items intended to match exit `DoorSize` values from `Tiny` through `Gigantic`, and Skill-Package-aware `WornTraitChanger` presets for worn stealth, movement, dexterity, sight, hearing, and athletic bonuses or penalties; the item prototype size itself must still be set on the item. Food presets now live in the dedicated `CookingSeeder` package, which installs `PreparedFood` examples for direct load, forageable stock, stackable servings, and cooking recipe products. Fax-machine examples and breathing-filter cartridge ecosystems remain later dedicated content passes.
 
 Prepared-food examples include:
 - `comp edit new preparedfood`
@@ -106,7 +106,7 @@ Use:
 
 This is the key step that turns a generic item prototype into something functional.
 
-The attach and submit workflow enforces prototype-side capability exclusivity. If two attached component protos both advertise the same exclusive marker, such as `IContainerPrototype` or `IWearablePrototype`, the item prototype cannot be submitted until the duplicate role is removed. Aggregate markers such as connection, power, and signal-source roles can still appear more than once where the runtime intentionally aggregates them.
+The attach and submit workflow enforces prototype-side capability exclusivity. If two attached component protos both advertise the same exclusive marker, such as `IContainerPrototype` or `IWearablePrototype`, the item prototype cannot be submitted until the duplicate role is removed. Aggregate markers such as connection, power, signal-source, and worn trait-change roles can still appear more than once where the runtime intentionally aggregates them.
 
 ### Important item settings for developers
 Commonly relevant commands include:

--- a/Design Documents/Item_System_Runtime_Model.md
+++ b/Design Documents/Item_System_Runtime_Model.md
@@ -83,7 +83,7 @@ It owns:
 - type help and builder help text
 - flags such as `WarnBeforePurge` and `PreventManualLoad`
 
-Component protos also advertise their runtime capability contracts through marker interfaces such as `IContainerPrototype`, `IWearablePrototype`, or `ILiquidContainerPrototype`. Item prototypes use these markers to reject duplicate exclusive capabilities when builders attach components or submit an item prototype for review.
+Component protos also advertise their runtime capability contracts through marker interfaces such as `IContainerPrototype`, `IWearablePrototype`, or `ILiquidContainerPrototype`. Item prototypes use these markers to reject duplicate exclusive capabilities when builders attach components or submit an item prototype for review. Aggregate markers remain intentionally stackable; for example, multiple worn trait-change components on the same item all contribute their bonuses or penalties while the item is worn.
 
 ## Composition Model
 ### Components define capabilities

--- a/Design Documents/Seeded_Item_Components.json
+++ b/Design Documents/Seeded_Item_Components.json
@@ -5545,6 +5545,306 @@
         "Component Type":  "Wireless Modem"
     },
     {
+        "Component Name":  "WornTraitChanger_AwarenessPenalty_Minor",
+        "Component Description":  "Makes worn hoods, enclosed helmets, or heavy masks interfere with both seeing and hearing. This is the minor grade at -2.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_AwarenessPenalty_Moderate",
+        "Component Description":  "Makes worn hoods, enclosed helmets, or heavy masks interfere with both seeing and hearing. This is the moderate grade at -5.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_AwarenessPenalty_Major",
+        "Component Description":  "Makes worn hoods, enclosed helmets, or heavy masks interfere with both seeing and hearing. This is the major grade at -7.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_AwarenessPenalty_Severe",
+        "Component Description":  "Makes worn hoods, enclosed helmets, or heavy masks interfere with both seeing and hearing. This is the severe grade at -10.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_ClimbPenalty_Minor",
+        "Component Description":  "Makes worn items harder to climb in. This is the minor grade at -2.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_ClimbPenalty_Moderate",
+        "Component Description":  "Makes worn items harder to climb in. This is the moderate grade at -5.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_ClimbPenalty_Major",
+        "Component Description":  "Makes worn items harder to climb in. This is the major grade at -7.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_ClimbPenalty_Severe",
+        "Component Description":  "Makes worn items harder to climb in. This is the severe grade at -10.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_FlyPenalty_Minor",
+        "Component Description":  "Makes worn items harder to fly in. This is the minor grade at -2.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_FlyPenalty_Moderate",
+        "Component Description":  "Makes worn items harder to fly in. This is the moderate grade at -5.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_FlyPenalty_Major",
+        "Component Description":  "Makes worn items harder to fly in. This is the major grade at -7.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_FlyPenalty_Severe",
+        "Component Description":  "Makes worn items harder to fly in. This is the severe grade at -10.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_HidePenalty_Minor",
+        "Component Description":  "Makes worn items harder to hide in. This is the minor grade at -2.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_HidePenalty_Moderate",
+        "Component Description":  "Makes worn items harder to hide in. This is the moderate grade at -5.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_HidePenalty_Major",
+        "Component Description":  "Makes worn items harder to hide in. This is the major grade at -7.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_HidePenalty_Severe",
+        "Component Description":  "Makes worn items harder to hide in. This is the severe grade at -10.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_ListeningPenalty_Minor",
+        "Component Description":  "Makes worn earplugs, heavy helmets, or muffling gear interfere with listening. This is the minor grade at -2.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_ListeningPenalty_Moderate",
+        "Component Description":  "Makes worn earplugs, heavy helmets, or muffling gear interfere with listening. This is the moderate grade at -5.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_ListeningPenalty_Major",
+        "Component Description":  "Makes worn earplugs, heavy helmets, or muffling gear interfere with listening. This is the major grade at -7.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_ListeningPenalty_Severe",
+        "Component Description":  "Makes worn earplugs, heavy helmets, or muffling gear interfere with listening. This is the severe grade at -10.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_ManualDexterityPenalty_Minor",
+        "Component Description":  "Makes worn gloves, gauntlets, or similar gear interfere with manual dexterity work. This is the minor grade at -2.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_ManualDexterityPenalty_Moderate",
+        "Component Description":  "Makes worn gloves, gauntlets, or similar gear interfere with manual dexterity work. This is the moderate grade at -5.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_ManualDexterityPenalty_Major",
+        "Component Description":  "Makes worn gloves, gauntlets, or similar gear interfere with manual dexterity work. This is the major grade at -7.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_ManualDexterityPenalty_Severe",
+        "Component Description":  "Makes worn gloves, gauntlets, or similar gear interfere with manual dexterity work. This is the severe grade at -10.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_MovementBonus_Minor",
+        "Component Description":  "Helps fitted athletic gear support swimming, climbing, flying, or running. This is the minor grade at 2.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_MovementBonus_Moderate",
+        "Component Description":  "Helps fitted athletic gear support swimming, climbing, flying, or running. This is the moderate grade at 5.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_MovementBonus_Major",
+        "Component Description":  "Helps fitted athletic gear support swimming, climbing, flying, or running. This is the major grade at 7.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_MovementBonus_Severe",
+        "Component Description":  "Helps fitted athletic gear support swimming, climbing, flying, or running. This is the severe grade at 10.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_MovementPenalty_Minor",
+        "Component Description":  "Makes worn items harder to swim, climb, or fly in. This is the minor grade at -2.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_MovementPenalty_Moderate",
+        "Component Description":  "Makes worn items harder to swim, climb, or fly in. This is the moderate grade at -5.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_MovementPenalty_Major",
+        "Component Description":  "Makes worn items harder to swim, climb, or fly in. This is the major grade at -7.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_MovementPenalty_Severe",
+        "Component Description":  "Makes worn items harder to swim, climb, or fly in. This is the severe grade at -10.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_RunningBonus_Minor",
+        "Component Description":  "Helps good footwear or legwear support running. This is the minor grade at 2.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_RunningBonus_Moderate",
+        "Component Description":  "Helps good footwear or legwear support running. This is the moderate grade at 5.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_RunningBonus_Major",
+        "Component Description":  "Helps good footwear or legwear support running. This is the major grade at 7.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_RunningBonus_Severe",
+        "Component Description":  "Helps good footwear or legwear support running. This is the severe grade at 10.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_SneakPenalty_Minor",
+        "Component Description":  "Makes worn items noisier or more awkward for sneaking. This is the minor grade at -2.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_SneakPenalty_Moderate",
+        "Component Description":  "Makes worn items noisier or more awkward for sneaking. This is the moderate grade at -5.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_SneakPenalty_Major",
+        "Component Description":  "Makes worn items noisier or more awkward for sneaking. This is the major grade at -7.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_SneakPenalty_Severe",
+        "Component Description":  "Makes worn items noisier or more awkward for sneaking. This is the severe grade at -10.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_StealthBonus_Minor",
+        "Component Description":  "Helps worn camouflage, soft soles, or fitted clothing support stealth. This is the minor grade at 2.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_StealthBonus_Moderate",
+        "Component Description":  "Helps worn camouflage, soft soles, or fitted clothing support stealth. This is the moderate grade at 5.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_StealthBonus_Major",
+        "Component Description":  "Helps worn camouflage, soft soles, or fitted clothing support stealth. This is the major grade at 7.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_StealthBonus_Severe",
+        "Component Description":  "Helps worn camouflage, soft soles, or fitted clothing support stealth. This is the severe grade at 10.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_StealthMobilityBonus_Minor",
+        "Component Description":  "Helps specialised worn gear support stealth, swimming, climbing, flying, and running. This is the minor grade at 2.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_StealthMobilityBonus_Moderate",
+        "Component Description":  "Helps specialised worn gear support stealth, swimming, climbing, flying, and running. This is the moderate grade at 5.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_StealthMobilityBonus_Major",
+        "Component Description":  "Helps specialised worn gear support stealth, swimming, climbing, flying, and running. This is the major grade at 7.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_StealthMobilityBonus_Severe",
+        "Component Description":  "Helps specialised worn gear support stealth, swimming, climbing, flying, and running. This is the severe grade at 10.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_StealthPenalty_Minor",
+        "Component Description":  "Makes worn items harder to hide and sneak in. This is the minor grade at -2.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_StealthPenalty_Moderate",
+        "Component Description":  "Makes worn items harder to hide and sneak in. This is the moderate grade at -5.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_StealthPenalty_Major",
+        "Component Description":  "Makes worn items harder to hide and sneak in. This is the major grade at -7.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_StealthPenalty_Severe",
+        "Component Description":  "Makes worn items harder to hide and sneak in. This is the severe grade at -10.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_SwimPenalty_Minor",
+        "Component Description":  "Makes worn items harder to swim in. This is the minor grade at -2.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_SwimPenalty_Moderate",
+        "Component Description":  "Makes worn items harder to swim in. This is the moderate grade at -5.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_SwimPenalty_Major",
+        "Component Description":  "Makes worn items harder to swim in. This is the major grade at -7.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_SwimPenalty_Severe",
+        "Component Description":  "Makes worn items harder to swim in. This is the severe grade at -10.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_VisualPerceptionPenalty_Minor",
+        "Component Description":  "Makes worn masks, visors, or closed helmets interfere with visual perception. This is the minor grade at -2.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_VisualPerceptionPenalty_Moderate",
+        "Component Description":  "Makes worn masks, visors, or closed helmets interfere with visual perception. This is the moderate grade at -5.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_VisualPerceptionPenalty_Major",
+        "Component Description":  "Makes worn masks, visors, or closed helmets interfere with visual perception. This is the major grade at -7.5 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
+        "Component Name":  "WornTraitChanger_VisualPerceptionPenalty_Severe",
+        "Component Description":  "Makes worn masks, visors, or closed helmets interfere with visual perception. This is the severe grade at -10.0 per affected trait.",
+        "Component Type":  "WornTraitChanger"
+    },
+    {
         "Component Name":  "WornTraitChanger_Bonus",
         "Component Description":  "Provides a small bonus to a common trait while worn.",
         "Component Type":  "WornTraitChanger"

--- a/FutureMUDLibrary/GameItems/Prototypes/GameItemComponentPrototypeInterfaces.cs
+++ b/FutureMUDLibrary/GameItems/Prototypes/GameItemComponentPrototypeInterfaces.cs
@@ -125,7 +125,7 @@ public interface IChangeCharacteristicsPrototype : IExclusiveGameItemComponentPr
 {
 }
 
-public interface IChangeTraitsInInventoryPrototype : IExclusiveGameItemComponentPrototype<IChangeTraitsInInventory>
+public interface IChangeTraitsInInventoryPrototype : IAggregateGameItemComponentPrototype<IChangeTraitsInInventory>
 {
 }
 

--- a/MudSharpCore Unit Tests/GameItemComponentPrototypeExclusivityTests.cs
+++ b/MudSharpCore Unit Tests/GameItemComponentPrototypeExclusivityTests.cs
@@ -21,6 +21,7 @@ public class GameItemComponentPrototypeExclusivityTests
 		typeof(ICanConnectToGrid),
 		typeof(ICanConnectToLiquidGrid),
 		typeof(ICanConnectToTelecommunicationsGrid),
+		typeof(IChangeTraitsInInventory),
 		typeof(IConnectable),
 		typeof(IConsumePower),
 		typeof(IOnOff),
@@ -73,6 +74,15 @@ public class GameItemComponentPrototypeExclusivityTests
 	{
 		var first = CreatePrototype<IConnectablePrototype>(1, "left connector");
 		var second = CreatePrototype<IConnectablePrototype>(2, "right connector");
+
+		Assert.IsFalse(GameItemComponentPrototypeExclusivity.FindConflicts([first.Object, second.Object]).Any());
+	}
+
+	[TestMethod]
+	public void FindConflicts_DuplicateAggregateWornTraitChanger_DoesNotConflict()
+	{
+		var first = CreatePrototype<IChangeTraitsInInventoryPrototype>(1, "heavy gloves");
+		var second = CreatePrototype<IChangeTraitsInInventoryPrototype>(2, "muffling boots");
 
 		Assert.IsFalse(GameItemComponentPrototypeExclusivity.FindConflicts([first.Object, second.Object]).Any());
 	}

--- a/MudSharpCore/Body/Implementations/BodyTraits.cs
+++ b/MudSharpCore/Body/Implementations/BodyTraits.cs
@@ -53,7 +53,7 @@ public partial class Body
                 .Where(x => x.AppliesToTrait(trait))
                 .Sum(x => x.GetBonus(trait));
         baseValue += Implants.OfType<IImplantTraitChange>().Sum(x => x.BonusForTrait(trait, context));
-        baseValue += ExternalItems.SelectNotNull(x => x.GetItemType<IChangeTraitsInInventory>())
+        baseValue += ExternalItems.SelectMany(x => x.GetItemTypes<IChangeTraitsInInventory>())
                                   .Sum(x => x.BonusForTrait(definition, context));
         baseValue += Actor.CurrentProject.Labour?.LabourImpacts.Where(x => x.Applies(Actor))
                           .OfType<ILabourImpactTraits>().Sum(x => x.EffectOnTrait(trait, context)) ?? 0.0;

--- a/MudSharpCore/Character/CharacterTraits.cs
+++ b/MudSharpCore/Character/CharacterTraits.cs
@@ -324,7 +324,7 @@ public partial class Character
                 .Where(x => x.Applies(this))
                 .Where(x => x.AppliesToTrait(characterTrait))
                 .Sum(x => x.GetBonus(characterTrait));
-        baseValue += Body.ExternalItems.SelectNotNull(x => x.GetItemType<IChangeTraitsInInventory>())
+        baseValue += Body.ExternalItems.SelectMany(x => x.GetItemTypes<IChangeTraitsInInventory>())
                               .Sum(x => x.BonusForTrait(trait, context));
         baseValue += CurrentProject.Labour?.LabourImpacts.Where(x => x.Applies(this))
                          .OfType<ILabourImpactTraits>().Sum(x => x.EffectOnTrait(characterTrait, context)) ?? 0.0;


### PR DESCRIPTION
## Summary
- Add seeded WornTraitChanger component families for stealth, mobility, perception, listening, manual dexterity, and movement bonuses.
- Allow multiple worn trait changers to contribute by aggregating all matching worn item components instead of treating the prototype as exclusive.
- Update item-system docs, seeded component inventory, and focused seeder/runtime tests.

## Validation
- `dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 --filter 'ClassName=MudSharp_Unit_Tests.UsefulSeederItemPackageTests'`
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 --filter 'ClassName=MudSharp_Unit_Tests.GameItemComponentPrototypeExclusivityTests'`
- JSON parse check for `Design Documents/Seeded_Item_Components.json`
- `git diff --check`