### PR TITLE
Improve item seeder craft guide and repeatability coverage

### DIFF
--- a/DatabaseSeeder Unit Tests/ItemSeederAddCraftTests.cs
+++ b/DatabaseSeeder Unit Tests/ItemSeederAddCraftTests.cs
@@ -1,0 +1,522 @@
+#nullable enable
+
+using DatabaseSeeder.Seeders;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Body;
+using MudSharp.Database;
+using MudSharp.FutureProg;
+using MudSharp.Models;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class ItemSeederAddCraftTests
+{
+	private static FuturemudDatabaseContext BuildContext()
+	{
+		DbContextOptions<FuturemudDatabaseContext> options = new DbContextOptionsBuilder<FuturemudDatabaseContext>()
+			.UseInMemoryDatabase(Guid.NewGuid().ToString())
+			.ConfigureWarnings(x => x.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+			.Options;
+		return new FuturemudDatabaseContext(options);
+	}
+
+	private static void SeedPrerequisites(FuturemudDatabaseContext context)
+	{
+		context.Accounts.Add(new Account
+		{
+			Id = 1,
+			Name = "SeederTest",
+			Password = "password",
+			Salt = 1,
+			AccessStatus = 0,
+			Email = "seeder@example.com",
+			LastLoginIp = "127.0.0.1",
+			FormatLength = 80,
+			InnerFormatLength = 78,
+			UseMxp = false,
+			UseMsp = false,
+			UseMccp = false,
+			ActiveCharactersAllowed = 1,
+			UseUnicode = true,
+			TimeZoneId = "UTC",
+			CultureName = "en-AU",
+			RegistrationCode = string.Empty,
+			IsRegistered = true,
+			RecoveryCode = string.Empty,
+			UnitPreference = "metric",
+			CreationDate = DateTime.UtcNow,
+			PageLength = 22,
+			PromptType = 0,
+			TabRoomDescriptions = false,
+			CodedRoomDescriptionAdditionsOnNewLine = false,
+			CharacterNameOverlaySetting = 0,
+			AppendNewlinesBetweenMultipleEchoesPerPrompt = false,
+			ActLawfully = false,
+			HasBeenActiveInWeek = true,
+			HintsEnabled = true,
+			AutoReacquireTargets = false
+		});
+
+		context.TraitDefinitions.Add(new TraitDefinition
+		{
+			Id = 1,
+			Name = "Crafting",
+			Type = 0,
+			OwnerScope = 0,
+			TraitGroup = "Crafting",
+			ChargenBlurb = string.Empty,
+			ValueExpression = string.Empty
+		});
+
+		context.Tags.AddRange(
+			Tag(1, "Ingredient"),
+			Tag(2, "Variable Ingredient"),
+			Tag(3, "Repairable"),
+			Tag(4, "Flexible Material"),
+			Tag(5, "Fabric"),
+			Tag(6, "Metal Pile"),
+			Tag(7, "Water Source"),
+			Tag(8, "Tool Tag"),
+			Tag(9, "Scrap Metal")
+		);
+
+		context.Materials.AddRange(
+			Material(1, "iron"),
+			Material(2, "clay"),
+			Material(3, "oak")
+		);
+
+		context.Liquids.Add(Liquid(1, "Water"));
+		context.Currencies.Add(new Currency { Id = 1, Name = "test coins", BaseCurrencyToGlobalBaseCurrencyConversion = 1.0M });
+		context.NpcTemplates.Add(new NpcTemplate
+		{
+			Id = 1,
+			Name = "test assistant",
+			Type = "Test",
+			Definition = "<Definition />",
+			RevisionNumber = 0,
+			EditableItem = Editable()
+		});
+		context.BloodModels.Add(new BloodModel { Id = 1, Name = "ABO" });
+
+		context.CharacteristicDefinitions.AddRange(
+			CharacteristicDefinition(1, "Colour"),
+			CharacteristicDefinition(2, "Origin")
+		);
+		context.CharacteristicValues.AddRange(
+			CharacteristicValue(1, 1, "red"),
+			CharacteristicValue(2, 1, "blue"),
+			CharacteristicValue(3, 2, "mine")
+		);
+
+		context.FutureProgs.AddRange(
+			Prog(1, "AlwaysTrue", ProgVariableTypes.Boolean, "return true"),
+			Prog(2, "AlwaysText", ProgVariableTypes.Text, @"return ""No."""),
+			Prog(3, "OnFinish", ProgVariableTypes.Void, string.Empty),
+			Prog(4, "OnStart", ProgVariableTypes.Void, string.Empty),
+			Prog(5, "OnCancel", ProgVariableTypes.Void, string.Empty),
+			Prog(6, "SelectColour", ProgVariableTypes.Text, @"return ""red"""),
+			Prog(7, "SetupNpc", ProgVariableTypes.Void, string.Empty),
+			Prog(8, "LoadCraftProducts", ProgVariableTypes.Void, string.Empty)
+		);
+
+		context.GameItemProtos.AddRange(
+			Item(100, "plain input item", "a plain input item", "iron"),
+			Item(101, "simple product", "a simple test product", "iron"),
+			Item(102, "cooked product", "a cooked test product", "iron"),
+			Item(103, "variable product", "a variable test product", "iron"),
+			Item(104, "input variable product", "an input-variable test product", "iron"),
+			Item(105, "prog variable product", "a prog-variable test product", "iron"),
+			Item(106, "failed product", "a failed test product", "clay"),
+			Item(107, "test hammer", "a test hammer", "iron")
+		);
+
+		context.SaveChanges();
+	}
+
+	private static Tag Tag(long id, string name)
+	{
+		return new Tag { Id = id, Name = name };
+	}
+
+	private static Material Material(long id, string name)
+	{
+		return new Material
+		{
+			Id = id,
+			Name = name,
+			MaterialDescription = name,
+			Type = 0,
+			BehaviourType = 0,
+			Density = 1.0,
+			Organic = true,
+			ResidueSdesc = string.Empty,
+			ResidueDesc = string.Empty,
+			ResidueColour = "grey"
+		};
+	}
+
+	private static Liquid Liquid(long id, string name)
+	{
+		return new Liquid
+		{
+			Id = id,
+			Name = name,
+			Description = name,
+			LongDescription = name,
+			TasteText = string.Empty,
+			VagueTasteText = string.Empty,
+			SmellText = string.Empty,
+			VagueSmellText = string.Empty,
+			Density = 1.0,
+			Organic = false,
+			DisplayColour = "blue",
+			DampDescription = string.Empty,
+			WetDescription = string.Empty,
+			DrenchedDescription = string.Empty,
+			DampShortDescription = string.Empty,
+			WetShortDescription = string.Empty,
+			DrenchedShortDescription = string.Empty,
+			SurfaceReactionInfo = string.Empty
+		};
+	}
+
+	private static CharacteristicDefinition CharacteristicDefinition(long id, string name)
+	{
+		return new CharacteristicDefinition
+		{
+			Id = id,
+			Name = name,
+			Type = 0,
+			Pattern = string.Empty,
+			Description = name,
+			Model = string.Empty,
+			Definition = string.Empty
+		};
+	}
+
+	private static CharacteristicValue CharacteristicValue(long id, long definitionId, string name)
+	{
+		return new CharacteristicValue
+		{
+			Id = id,
+			Name = name,
+			DefinitionId = definitionId,
+			Value = name,
+			AdditionalValue = string.Empty,
+			Pluralisation = 0
+		};
+	}
+
+	private static MudSharp.Models.FutureProg Prog(long id, string name, ProgVariableTypes returnType, string text)
+	{
+		return new MudSharp.Models.FutureProg
+		{
+			Id = id,
+			FunctionName = name,
+			Category = "Test",
+			Subcategory = "Test",
+			FunctionComment = string.Empty,
+			FunctionText = text,
+			ReturnType = (long)returnType,
+			StaticType = (int)FutureProgStaticType.NotStatic,
+			AcceptsAnyParameters = false,
+			Public = true
+		};
+	}
+
+	private static MudSharp.Models.GameItemProto Item(long id, string name, string shortDescription, string material)
+	{
+		return new GameItemProto
+		{
+			Id = id,
+			Name = name,
+			Keywords = name,
+			MaterialId = material == "clay" ? 2 : 1,
+			EditableItem = Editable(),
+			RevisionNumber = 0,
+			Size = 0,
+			Weight = 1.0,
+			ReadOnly = false,
+			LongDescription = string.Empty,
+			BaseItemQuality = 0,
+			CustomColour = string.Empty,
+			MorphTimeSeconds = 0,
+			MorphEmote = string.Empty,
+			ShortDescription = shortDescription,
+			FullDescription = string.Empty,
+			PermitPlayerSkins = false,
+			CostInBaseCurrency = 0.0M,
+			IsHiddenFromPlayers = false,
+			PlanarData = string.Empty
+		};
+	}
+
+	private static EditableItem Editable()
+	{
+		return new EditableItem
+		{
+			RevisionNumber = 0,
+			RevisionStatus = 4,
+			BuilderAccountId = 1,
+			BuilderDate = DateTime.UtcNow,
+			BuilderComment = "test",
+			ReviewerAccountId = 1,
+			ReviewerComment = "test",
+			ReviewerDate = DateTime.UtcNow
+		};
+	}
+
+	private static (int Seconds, string Echo, string FailEcho)[] BasicPhases()
+	{
+		return [(5, "$0 work|works.", "$0 fail|fails.")];
+	}
+
+	private static string[] BasicInputs()
+	{
+		return ["Tag - 1x an item with the Ingredient tag"];
+	}
+
+	private static string[] BasicTools()
+	{
+		return ["TagTool - Held - an item with the Tool Tag tag"];
+	}
+
+	private static string[] BasicProducts()
+	{
+		return ["SimpleProduct - 1x a simple test product (#101)"];
+	}
+
+	[TestMethod]
+	public void ItemSeeder_AddCraft_ParsesInputToolAndProductImportGrammar()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedPrerequisites(context);
+
+		var craft = new ItemSeeder().AddCraftFromImportsForTesting(
+			context,
+			"test comprehensive craft",
+			"Testing",
+			BasicPhases(),
+			[
+				"Tag - 2x an item with the Ingredient tag; quality 2.5",
+				"TagVariable - 1x an item with the Variable Ingredient tag with variable Colour",
+				"ConditionRepair - 25% repair of an item with the Repairable tag",
+				"SimpleItem - 1x a plain input item (#100)",
+				"SimpleMaterial - 1x an item made of iron",
+				"SimpleMaterial - 1x an item with material tagged as Flexible Material",
+				"Commodity - 1 kilogram 250 grams of iron; piletag Metal Pile; characteristic Colour red; characteristic Origin any",
+				"CommodityTag - 500 grams of a material tagged as Fabric; characteristic none",
+				"LiquidUse - 1 litre 250 millilitres of Water",
+				"LiquidTagUse - 500 millilitres of a liquid tagged Water Source"
+			],
+			[
+				"TagTool - Held - an item with the Tool Tag tag; quality 3.25; usetool off",
+				"SimpleTool - InRoom - a test hammer (#107); quality 0.75; usetool on"
+			],
+			[
+				"SimpleProduct - 1x a simple test product (#101)",
+				"CookedFoodProduct - 1x a cooked test product (#102); ingredient $i1=vegetable; purify off",
+				"SimpleVariableProduct - 1x a variable test product (#103); variable Colour=$i2",
+				"InputVariableProduct - 1x an input-variable test product (#104); variable Colour=$i2; specific Colour: a plain input item (#100)=red",
+				"ProgVariableProduct - 1x a prog-variable test product (#105); variable Colour=SelectColour",
+				"CommodityProduct - 250 grams of iron commodity; tag Scrap Metal; characteristic Colour=red; characteristic Origin from $i7",
+				"MoneyProduct - 12.50 of test coins",
+				"NPCProduct - 1x test assistant (#1); prog SetupNpc",
+				"Prog - LoadCraftProducts",
+				"DNATest - compare $i9 and $i10",
+				"BloodTyping - test $i9 against ABO blood model",
+				"ScrapInput - 35% by weight of 1x a plain input item (#100) ($i4); tag Scrap Metal",
+				"UnusedInput - 45% of 2x an item with the Ingredient tag ($i1)"
+			],
+			["SimpleProduct - 1x a failed test product (#106)"],
+			failProductMaterialInputIndexes: [(1, 5)]
+		);
+
+		Assert.AreEqual(10, craft.CraftInputs.Count);
+		Assert.AreEqual(2, craft.CraftTools.Count);
+		Assert.AreEqual(14, craft.CraftProducts.Count);
+		Assert.AreEqual(2.5, craft.CraftInputs.OrderBy(x => x.OriginalAdditionTime).First().InputQualityWeight);
+
+		var exactMaterial = XElement.Parse(craft.CraftInputs.Single(x =>
+			x.InputType == "SimpleMaterial" && XElement.Parse(x.Definition).Element("TargetMaterial")!.Value == "1").Definition);
+		Assert.AreEqual("0", exactMaterial.Element("TargetMaterialTag")!.Value);
+
+		var taggedMaterial = XElement.Parse(craft.CraftInputs.Single(x =>
+			x.InputType == "SimpleMaterial" && XElement.Parse(x.Definition).Element("TargetMaterialTag")!.Value == "4").Definition);
+		Assert.AreEqual("0", taggedMaterial.Element("TargetMaterial")!.Value);
+
+		var commodity = XElement.Parse(craft.CraftInputs.Single(x => x.InputType == "Commodity").Definition);
+		Assert.AreEqual("6", commodity.Element("CommodityPileTag")!.Value);
+		Assert.AreEqual("specific", commodity.Element("Characteristics")!.Attribute("mode")!.Value);
+		Assert.AreEqual(2, commodity.Element("Characteristics")!.Elements("Characteristic").Count());
+
+		var commodityTag = XElement.Parse(craft.CraftInputs.Single(x => x.InputType == "CommodityTag").Definition);
+		Assert.AreEqual("none", commodityTag.Element("Characteristics")!.Attribute("mode")!.Value);
+
+		var tagTool = craft.CraftTools.Single(x => x.ToolType == "TagTool");
+		Assert.AreEqual(3.25, tagTool.ToolQualityWeight);
+		Assert.IsFalse(tagTool.UseToolDuration);
+		var simpleTool = craft.CraftTools.Single(x => x.ToolType == "SimpleTool");
+		Assert.AreEqual(0.75, simpleTool.ToolQualityWeight);
+		Assert.IsTrue(simpleTool.UseToolDuration);
+
+		CollectionAssert.IsSubsetOf(
+			new[]
+			{
+				"SimpleProduct", "CookedFoodProduct", "SimpleVariableProduct", "InputVariable", "ProgVariableProduct",
+				"CommodityProduct", "MoneyProduct", "NPCProduct", "Prog", "DNATest", "BloodTyping", "ScrapInput",
+				"UnusedInput"
+			},
+			craft.CraftProducts.Select(x => x.ProductType).Distinct().ToArray()
+		);
+
+		var commodityProduct = XElement.Parse(craft.CraftProducts.Single(x => x.ProductType == "CommodityProduct").Definition);
+		Assert.AreEqual("9", commodityProduct.Element("Tag")!.Value);
+		Assert.AreEqual("6", commodityProduct.Element("Characteristics")!.Elements("Characteristic").Single(x => x.Attribute("definition")!.Value == "2").Attribute("input")!.Value);
+		Assert.AreEqual(4, craft.CraftProducts.Single(x => x.IsFailProduct).MaterialDefiningInputIndex);
+	}
+
+	[TestMethod]
+	public void ItemSeeder_AddCraft_TypedSpecPersistsPhaseMetadataAndLifecycleProgs()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedPrerequisites(context);
+
+		var appear = context.FutureProgs.Single(x => x.FunctionName == "AlwaysTrue");
+		var start = context.FutureProgs.Single(x => x.FunctionName == "OnStart");
+		var finish = context.FutureProgs.Single(x => x.FunctionName == "OnFinish");
+		var cancel = context.FutureProgs.Single(x => x.FunctionName == "OnCancel");
+		var trait = context.TraitDefinitions.Single(x => x.Name == "Crafting");
+
+		var craft = new ItemSeeder().AddCraftForTesting(context, new ItemSeeder.CraftDefinitionSpec
+		{
+			Name = "test typed craft",
+			Category = "Testing",
+			Blurb = "typed test",
+			Action = "testing typed",
+			ActiveCraftItemSdesc = "a typed craft event",
+			AppearProg = appear,
+			OnStartProg = start,
+			OnFinishProg = finish,
+			OnCancelProg = cancel,
+			Trait = trait,
+			FailPhase = 1,
+			Phases =
+			[
+				new ItemSeeder.CraftPhaseSpec
+				{
+					Seconds = 12,
+					Echo = "$0 carefully work|works.",
+					FailEcho = "$0 botch|botches it.",
+					Exertion = ExertionLevel.Heavy,
+					Stamina = 4.5
+				}
+			],
+			Inputs = [new ItemSeeder.CraftInputSpec("Tag - 1x an item with the Ingredient tag", "Tag", "1x an item with the Ingredient tag", [], 1.0)],
+			Tools = [new ItemSeeder.CraftToolSpec("TagTool - Held - an item with the Tool Tag tag", "TagTool", "Held - an item with the Tool Tag tag", [], 1.0, true)],
+			Products = [new ItemSeeder.CraftProductSpec("SimpleProduct - 1x a simple test product (#101)", "SimpleProduct", "1x a simple test product (#101)", [], false, null)]
+		});
+
+		Assert.AreEqual(start.Id, craft.OnUseProgStartId);
+		Assert.AreEqual(finish.Id, craft.OnUseProgCompleteId);
+		Assert.AreEqual(cancel.Id, craft.OnUseProgCancelId);
+		var phase = craft.CraftPhases.Single();
+		Assert.AreEqual((int)ExertionLevel.Heavy, phase.ExertionLevel);
+		Assert.AreEqual(4.5, phase.StaminaUsage);
+	}
+
+	[TestMethod]
+	public void ItemSeeder_AddCraft_TraitGateCreatesDeterministicProgsAndUsesThem()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedPrerequisites(context);
+
+		var craft = new ItemSeeder().AddTraitGatedCraftFromImportsForTesting(
+			context,
+			"test trait gated craft",
+			"Testing",
+			"Crafting",
+			40,
+			BasicPhases(),
+			BasicInputs(),
+			BasicTools(),
+			BasicProducts(),
+			[]
+		);
+
+		var appear = context.FutureProgs.Single(x => x.FunctionName == "ItemSeederAppearCrafting40");
+		var canUse = context.FutureProgs.Single(x => x.FunctionName == "ItemSeederCanUseCrafting40");
+		var whyCannot = context.FutureProgs.Single(x => x.FunctionName == "ItemSeederWhyCannotUseCrafting40");
+		Assert.AreEqual(appear.Id, craft.AppearInCraftsListProgId);
+		Assert.AreEqual(canUse.Id, craft.CanUseProgId);
+		Assert.AreEqual(whyCannot.Id, craft.WhyCannotUseProgId);
+		Assert.IsTrue(appear.FunctionText.Contains(">= 40"));
+		Assert.IsTrue(whyCannot.FunctionText.Contains("You need at least 40"));
+	}
+
+	[TestMethod]
+	public void ItemSeeder_AddCraft_RerunSameNameAndCategorySkipsExistingCraft()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedPrerequisites(context);
+		ItemSeeder seeder = new();
+
+		var first = seeder.AddCraftFromImportsForTesting(
+			context,
+			"test idempotent craft",
+			"Testing",
+			BasicPhases(),
+			BasicInputs(),
+			BasicTools(),
+			BasicProducts(),
+			[]
+		);
+		var second = seeder.AddCraftFromImportsForTesting(
+			context,
+			"test idempotent craft",
+			"Testing",
+			BasicPhases(),
+			["Tag - 2x an item with the Ingredient tag"],
+			BasicTools(),
+			["SimpleProduct - 1x a failed test product (#106)"],
+			[]
+		);
+
+		Assert.AreEqual(first.Id, second.Id);
+		Assert.AreEqual(1, context.Crafts.Count(x => x.Name == "test idempotent craft" && x.Category == "Testing"));
+		Assert.AreEqual(1, first.CraftInputs.Count);
+		Assert.AreEqual(1, first.CraftProducts.Count);
+	}
+
+	[TestMethod]
+	public void ItemSeeder_AddCraft_InvalidImportsThrowAggregateValidationErrors()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedPrerequisites(context);
+
+		var exception = Assert.ThrowsException<ApplicationException>(() => new ItemSeeder().AddCraftFromImportsForTesting(
+			context,
+			"test invalid craft",
+			"Testing",
+			BasicPhases(),
+			["Tag - 1x an item with the Missing tag"],
+			["TagTool - Nowhere - an item with the Tool Tag tag"],
+			["SimpleProduct - 1x a missing product (#999)"],
+			[]
+		));
+
+		StringAssert.Contains(exception.Message, "Craft 'test invalid craft' has 3 validation error");
+		StringAssert.Contains(exception.Message, "input 'Tag - 1x an item with the Missing tag'");
+		StringAssert.Contains(exception.Message, "tool 'TagTool - Nowhere - an item with the Tool Tag tag'");
+		StringAssert.Contains(exception.Message, "product 'SimpleProduct - 1x a missing product (#999)'");
+	}
+}

--- a/DatabaseSeeder/Seeders/ItemSeederCrafting.cs
+++ b/DatabaseSeeder/Seeders/ItemSeederCrafting.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using MudSharp.Database;
+using MudSharp.Body;
 using MudSharp.Framework;
 using MudSharp.FutureProg;
 using MudSharp.GameItems;
@@ -24,6 +25,117 @@ namespace DatabaseSeeder.Seeders;
 
 public partial class ItemSeeder
 {
+	internal sealed record CraftPhaseSpec
+	{
+		public int Seconds { get; init; }
+		public string Echo { get; init; } = string.Empty;
+		public string FailEcho { get; init; } = string.Empty;
+		public ExertionLevel Exertion { get; init; } = ExertionLevel.Stasis;
+		public double Stamina { get; init; }
+	}
+
+	internal sealed record CraftInputSpec(
+		string ImportText,
+		string InputType,
+		string Details,
+		IReadOnlyList<string> Options,
+		double QualityWeight);
+
+	internal sealed record CraftToolSpec(
+		string ImportText,
+		string ToolType,
+		string Details,
+		IReadOnlyList<string> Options,
+		double QualityWeight,
+		bool UseToolDuration);
+
+	internal sealed record CraftProductSpec(
+		string ImportText,
+		string ProductType,
+		string Details,
+		IReadOnlyList<string> Options,
+		bool IsFailProduct,
+		int? MaterialDefiningInputIndex);
+
+	internal sealed record CraftDefinitionSpec
+	{
+		public string Name { get; init; } = string.Empty;
+		public string Category { get; init; } = string.Empty;
+		public string Blurb { get; init; } = string.Empty;
+		public string Action { get; init; } = string.Empty;
+		public string ActiveCraftItemSdesc { get; init; } = string.Empty;
+		public FutureProg? AppearProg { get; init; }
+		public FutureProg? CanUseProg { get; init; }
+		public FutureProg? WhyCannotUseProg { get; init; }
+		public FutureProg? OnStartProg { get; init; }
+		public FutureProg? OnFinishProg { get; init; }
+		public FutureProg? OnCancelProg { get; init; }
+		public TraitDefinition? Trait { get; init; }
+		public Difficulty Difficulty { get; init; } = Difficulty.Normal;
+		public Outcome Threshold { get; init; } = Outcome.MinorFail;
+		public int FreeChecks { get; init; } = 5;
+		public int FailPhase { get; init; } = 1;
+		public bool Interruptable { get; init; }
+		public IReadOnlyList<CraftPhaseSpec> Phases { get; init; } = [];
+		public IReadOnlyList<CraftInputSpec> Inputs { get; init; } = [];
+		public IReadOnlyList<CraftToolSpec> Tools { get; init; } = [];
+		public IReadOnlyList<CraftProductSpec> Products { get; init; } = [];
+		public IReadOnlyList<CraftProductSpec> FailProducts { get; init; } = [];
+	}
+
+	private sealed record CraftValidationError(string CraftName, string Kind, string ImportText, string Message)
+	{
+		public override string ToString()
+		{
+			return $"Craft '{CraftName}' {Kind} '{ImportText}': {Message}";
+		}
+	}
+
+	private FutureProg EnsureFutureProg(string name, string category, string subcategory, ProgVariableTypes returnType,
+		string comment, IEnumerable<(ProgVariableTypes Type, string Name)> parameters, string text)
+	{
+		if (_progs.TryGetValue(name, out var existing))
+		{
+			return existing;
+		}
+
+		var contextProg = _context!.FutureProgs.Local.FirstOrDefault(x =>
+			x.FunctionName.Equals(name, StringComparison.OrdinalIgnoreCase)) ??
+			_context.FutureProgs.FirstOrDefault(x => x.FunctionName.Equals(name, StringComparison.OrdinalIgnoreCase));
+		if (contextProg is not null)
+		{
+			_progs[name] = contextProg;
+			return contextProg;
+		}
+
+		FutureProg prog = new()
+		{
+			FunctionName = name,
+			Category = category,
+			Subcategory = subcategory,
+			ReturnType = (long)returnType,
+			FunctionComment = comment,
+			FunctionText = text,
+			StaticType = (int)FutureProgStaticType.NotStatic,
+			AcceptsAnyParameters = false
+		};
+		_context.FutureProgs.Add(prog);
+		int index = 0;
+		foreach ((ProgVariableTypes type, string? varname) in parameters)
+		{
+			prog.FutureProgsParameters.Add(new FutureProgsParameter
+			{
+				FutureProg = prog,
+				ParameterIndex = index++,
+				ParameterType = (long)type,
+				ParameterName = varname
+			});
+		}
+
+		_progs[name] = prog;
+		return prog;
+	}
+
     private void CreateProgs()
     {
 		foreach (FutureProg prog in _context!.FutureProgs)
@@ -33,36 +145,7 @@ public partial class ItemSeeder
 
         void AddProg(string name, string category, string subcategory, ProgVariableTypes returnType, string comment, IEnumerable<(ProgVariableTypes Type, string Name)> parameters, string text)
         {
-            if (_progs.ContainsKey(name))
-            {
-                return;
-            }
-
-            FutureProg prog = new()
-            {
-                FunctionName = name,
-                Category = category,
-                Subcategory = subcategory,
-                ReturnType = (long)returnType,
-                FunctionComment = comment,
-                FunctionText = text,
-                StaticType = (int)FutureProgStaticType.NotStatic,
-                AcceptsAnyParameters = false
-            };
-            _context.FutureProgs.Add(prog);
-            int index = 0;
-            foreach ((ProgVariableTypes type, string? varname) in parameters)
-            {
-                prog.FutureProgsParameters.Add(new FutureProgsParameter
-                {
-                    FutureProg = prog,
-                    ParameterIndex = index++,
-                    ParameterType = (long)type,
-                    ParameterName = varname
-                });
-            }
-
-            _progs[name] = prog;
+			EnsureFutureProg(name, category, subcategory, returnType, comment, parameters, text);
         }
 
         if (_context.VariableDefinitions.All(x => x.Property != "constructioncooldown"))
@@ -148,6 +231,8 @@ return ""There is no useful clay that is accessible in the biome you're in.""");
     private Regex SimpleItemInputRegex = new(@"^(?<quantity>\d+)x (?<sdesc>.+) \(#(?<craftid>\d+)\)$", RegexOptions.IgnoreCase);
 
     private Regex SimpleMaterialInputRegex = new(@"^(?<quantity>\d+)x an item with material tagged as (?<tag>.+)$", RegexOptions.IgnoreCase);
+
+    private Regex SimpleMaterialExactInputRegex = new(@"^(?<quantity>\d+)x an item (?:made of|with material) (?<material>.+)$", RegexOptions.IgnoreCase);
 
     private Regex CommodityInputRegex = new(@"^(?:(?<kgs>\d+(?:\.\d+)?) kilograms?)*\s*(?:(?<grams>\d+(?:\.\d+)?) grams?)* of (?<material>.+)\s*$", RegexOptions.IgnoreCase);
 
@@ -241,6 +326,94 @@ return ""There is no useful clay that is accessible in the biome you're in.""");
         return (parts.FirstOrDefault() ?? string.Empty, parts.Skip(1).ToList());
     }
 
+	private (string Type, string Details, List<string> Options) ParseConversionImport(string text, string error)
+	{
+		Match match = RequireMatch(ConversionRegex, text, error);
+		(string details, List<string> options) = SplitDetails(match.Groups["details"].Value);
+		return (match.Groups["type"].Value.Trim(), details, options);
+	}
+
+	private static bool StartsWithOption(string option, string keyword)
+	{
+		return option.StartsWith(keyword, StringComparison.OrdinalIgnoreCase) &&
+		       (option.Length == keyword.Length || char.IsWhiteSpace(option[keyword.Length]));
+	}
+
+	private static string GetOptionRemainder(string option, string keyword)
+	{
+		return option.Length == keyword.Length ? string.Empty : option[keyword.Length..].Trim();
+	}
+
+	private static bool TryParseImportBoolean(string value, out bool result)
+	{
+		if (value.EqualToAny("on", "true", "yes", "1"))
+		{
+			result = true;
+			return true;
+		}
+
+		if (value.EqualToAny("off", "false", "no", "0"))
+		{
+			result = false;
+			return true;
+		}
+
+		result = false;
+		return false;
+	}
+
+	private static double ParseQualityWeight(IEnumerable<string> options, string importText)
+	{
+		double quality = 1.0;
+		foreach (string option in options.Where(x => StartsWithOption(x, "quality") || StartsWithOption(x, "qualityweight")))
+		{
+			string keyword = StartsWithOption(option, "qualityweight") ? "qualityweight" : "quality";
+			string valueText = GetOptionRemainder(option, keyword);
+			if (string.IsNullOrWhiteSpace(valueText) ||
+			    !double.TryParse(valueText.Replace(",", ""), NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out quality) ||
+			    quality < 0.0)
+			{
+				throw new ApplicationException($"Invalid quality weight in import '{importText}'");
+			}
+		}
+
+		return quality;
+	}
+
+	private static bool ParseUseToolDuration(IEnumerable<string> options, string importText)
+	{
+		bool useToolDuration = true;
+		foreach (string option in options.Where(x => StartsWithOption(x, "usetool")))
+		{
+			string valueText = GetOptionRemainder(option, "usetool");
+			if (string.IsNullOrWhiteSpace(valueText) || !TryParseImportBoolean(valueText, out useToolDuration))
+			{
+				throw new ApplicationException($"Invalid usetool option in import '{importText}'");
+			}
+		}
+
+		return useToolDuration;
+	}
+
+	private CraftInputSpec ParseInputSpec(string text)
+	{
+		(string type, string details, List<string> options) = ParseConversionImport(text, "Invalid input definition");
+		return new CraftInputSpec(text, type, details, options, ParseQualityWeight(options, text));
+	}
+
+	private CraftToolSpec ParseToolSpec(string text)
+	{
+		(string type, string details, List<string> options) = ParseConversionImport(text, "Invalid tool definition");
+		return new CraftToolSpec(text, type, details, options, ParseQualityWeight(options, text),
+			ParseUseToolDuration(options, text));
+	}
+
+	private CraftProductSpec ParseProductSpec(string text, bool isFailProduct, int? materialDefiningInputIndex = null)
+	{
+		(string type, string details, List<string> options) = ParseConversionImport(text, "Invalid product definition");
+		return new CraftProductSpec(text, type, details, options, isFailProduct, materialDefiningInputIndex);
+	}
+
     private MudSharp.Models.Tag LookupTag(string text)
     {
         if (_tags.TryGetValue(text.Trim(), out MudSharp.Models.Tag? tag))
@@ -318,6 +491,94 @@ return ""There is no useful clay that is accessible in the biome you're in.""");
             : _context!.CharacteristicValues.FirstOrDefault(x => x.DefinitionId == definition.Id && x.Name.Equals(trimmed, StringComparison.OrdinalIgnoreCase));
         return value ?? throw new ApplicationException($"Unknown value {text} for characteristic {definition.Name}");
     }
+
+	private long LookupCommodityPileTagId(IEnumerable<string> options)
+	{
+		long tagId = 0;
+		foreach (string option in options.Where(x => StartsWithOption(x, "piletag") || StartsWithOption(x, "pile tag")))
+		{
+			string keyword = StartsWithOption(option, "piletag") ? "piletag" : "pile tag";
+			string tagText = GetOptionRemainder(option, keyword);
+			if (tagText.EqualToAny("none", "clear", "0"))
+			{
+				tagId = 0;
+				continue;
+			}
+
+			tagId = LookupTag(tagText).Id;
+		}
+
+		return tagId;
+	}
+
+	private (CharacteristicDefinition Definition, string ValueText) ParseCommodityInputCharacteristicRequirement(string text)
+	{
+		int equalsIndex = text.IndexOf('=');
+		if (equalsIndex > 0)
+		{
+			return (LookupCharacteristicDefinition(text[..equalsIndex]), text[(equalsIndex + 1)..].Trim());
+		}
+
+		Match idMatch = Regex.Match(text, @"^(?<definition>#?\d+)\s+(?<value>.+)$", RegexOptions.IgnoreCase);
+		if (idMatch.Success)
+		{
+			return (LookupCharacteristicDefinition(idMatch.Groups["definition"].Value), idMatch.Groups["value"].Value.Trim());
+		}
+
+		foreach (CharacteristicDefinition definition in _context!.CharacteristicDefinitions.AsEnumerable()
+		                                            .OrderByDescending(x => x.Name.Length))
+		{
+			if (!text.StartsWith(definition.Name, StringComparison.OrdinalIgnoreCase))
+			{
+				continue;
+			}
+
+			if (text.Length <= definition.Name.Length || !char.IsWhiteSpace(text[definition.Name.Length]))
+			{
+				continue;
+			}
+
+			return (definition, text[definition.Name.Length..].Trim());
+		}
+
+		Match match = RequireMatch(ProgVariableMappingRegex, text, "Invalid commodity characteristic requirement");
+		return (LookupCharacteristicDefinition(match.Groups["definition"].Value), match.Groups["prog"].Value.Trim());
+	}
+
+	private XElement BuildCommodityInputCharacteristics(IEnumerable<string> options)
+	{
+		string mode = "any";
+		List<XElement> requirements = [];
+		foreach (string option in options.Where(x => StartsWithOption(x, "characteristic")))
+		{
+			string text = GetOptionRemainder(option, "characteristic");
+			if (text.EqualTo("any"))
+			{
+				mode = "any";
+				requirements.Clear();
+				continue;
+			}
+
+			if (text.EqualTo("none"))
+			{
+				mode = "none";
+				requirements.Clear();
+				continue;
+			}
+
+			(CharacteristicDefinition definition, string valueText) = ParseCommodityInputCharacteristicRequirement(text);
+			mode = "specific";
+			requirements.Add(new XElement("Characteristic",
+				new XAttribute("definition", definition.Id),
+				new XAttribute("value", valueText.EqualTo("any") ? 0 : LookupCharacteristicValue(definition, valueText).Id)
+			));
+		}
+
+		return new XElement("Characteristics",
+			new XAttribute("mode", mode),
+			mode.EqualTo("specific") ? requirements : Enumerable.Empty<XElement>()
+		);
+	}
 
     private GameItemSkin? LookupSkin(GameItemProto item, string text)
     {
@@ -419,11 +680,15 @@ return ""There is no useful clay that is accessible in the biome you're in.""");
     }
 
     private (string TypeName, string Definition) BuildInputDefinition(string text)
+	{
+		return BuildInputDefinition(ParseInputSpec(text));
+	}
+
+    private (string TypeName, string Definition) BuildInputDefinition(CraftInputSpec spec)
     {
-        Match match = RequireMatch(ConversionRegex, text, "Invalid input definition");
-        string details = match.Groups["details"].Value;
+        string details = spec.Details;
         Match innerMatch;
-        switch (match.Groups["type"].Value.ToLowerInvariant())
+        switch (spec.InputType.ToLowerInvariant())
         {
             case "tag":
                 innerMatch = RequireMatch(TagInputRegex, details, "Invalid tag input definition");
@@ -456,8 +721,8 @@ return ""There is no useful clay that is accessible in the biome you're in.""");
                 return ("Commodity", new XElement("Definition",
                     new XElement("Material", LookupMaterial(innerMatch.Groups["material"].Value).Id),
                     new XElement("Weight", ParseMass(innerMatch)),
-                    new XElement("CommodityPileTag", 0),
-                    new XElement("Characteristics")
+                    new XElement("CommodityPileTag", LookupCommodityPileTagId(spec.Options)),
+                    BuildCommodityInputCharacteristics(spec.Options)
                 ).ToString());
             case "liquidtaguse":
             case "tagliquid":
@@ -478,8 +743,8 @@ return ""There is no useful clay that is accessible in the biome you're in.""");
                 return ("CommodityTag", new XElement("Definition",
                     new XElement("MaterialTag", LookupTag(innerMatch.Groups["material"].Value).Id),
                     new XElement("Weight", ParseMass(innerMatch)),
-                    new XElement("CommodityPileTag", 0),
-                    new XElement("Characteristics")
+                    new XElement("CommodityPileTag", LookupCommodityPileTagId(spec.Options)),
+                    BuildCommodityInputCharacteristics(spec.Options)
                 ).ToString());
             case "simpleitem":
             case "simple":
@@ -495,10 +760,20 @@ return ""There is no useful clay that is accessible in the biome you're in.""");
                     new XElement("Quantity", ParseIntValue(innerMatch.Groups["quantity"].Value))
                 ).ToString());
             case "simplematerial":
-                innerMatch = RequireMatch(SimpleMaterialInputRegex, details, "Invalid simple material input definition");
+                innerMatch = SimpleMaterialInputRegex.Match(details);
+				if (innerMatch.Success)
+				{
+					return ("SimpleMaterial", new XElement("Definition",
+						new XElement("TargetMaterialTag", LookupTag(innerMatch.Groups["tag"].Value).Id),
+						new XElement("TargetMaterial", 0),
+						new XElement("Quantity", ParseIntValue(innerMatch.Groups["quantity"].Value))
+					).ToString());
+				}
+
+                innerMatch = RequireMatch(SimpleMaterialExactInputRegex, details, "Invalid simple material input definition");
                 return ("SimpleMaterial", new XElement("Definition",
-                    new XElement("TargetMaterialTag", LookupTag(innerMatch.Groups["tag"].Value).Id),
-                    new XElement("TargetMaterial", 0),
+                    new XElement("TargetMaterialTag", 0),
+                    new XElement("TargetMaterial", LookupMaterial(innerMatch.Groups["material"].Value).Id),
                     new XElement("Quantity", ParseIntValue(innerMatch.Groups["quantity"].Value))
                 ).ToString());
             default:
@@ -519,13 +794,13 @@ return ""There is no useful clay that is accessible in the biome you're in.""");
         }
     }
 
-    private CraftInput ConvertToInput(Craft craft, string text)
+    private CraftInput ConvertToInput(Craft craft, CraftInputSpec spec)
     {
-        (string typename, string definition) = BuildInputDefinition(text);
+        (string typename, string definition) = BuildInputDefinition(spec);
         CraftInput input = new()
         {
             Craft = craft,
-            InputQualityWeight = 1.0,
+            InputQualityWeight = spec.QualityWeight,
             OriginalAdditionTime = DateTime.UtcNow,
             Definition = definition,
             InputType = typename
@@ -535,15 +810,19 @@ return ""There is no useful clay that is accessible in the biome you're in.""");
     }
 
     private (string TypeName, DesiredItemState State, string Definition) BuildToolDefinition(string text)
+	{
+		return BuildToolDefinition(ParseToolSpec(text));
+	}
+
+    private (string TypeName, DesiredItemState State, string Definition) BuildToolDefinition(CraftToolSpec spec)
     {
-        Match match = RequireMatch(ConversionRegex, text, "Invalid tool definition");
-        Match toolMatch = RequireMatch(ToolRegex, match.Groups["details"].Value, "Invalid tool state definition");
+        Match toolMatch = RequireMatch(ToolRegex, spec.Details, "Invalid tool state definition");
         if (!toolMatch.Groups["state"].Value.TryParseEnum(out DesiredItemState state))
         {
             throw new ApplicationException("Unknown State");
         }
 
-        switch (match.Groups["type"].Value.ToLowerInvariant())
+        switch (spec.ToolType.ToLowerInvariant())
         {
             case "tagtool":
             case "tag":
@@ -562,16 +841,16 @@ return ""There is no useful clay that is accessible in the biome you're in.""");
         }
     }
 
-    private CraftTool ConvertToTool(Craft craft, string text)
+    private CraftTool ConvertToTool(Craft craft, CraftToolSpec spec)
     {
-        (string typename, DesiredItemState state, string definition) = BuildToolDefinition(text);
+        (string typename, DesiredItemState state, string definition) = BuildToolDefinition(spec);
         CraftTool tool = new()
         {
             Craft = craft,
             OriginalAdditionTime = DateTime.UtcNow,
             ToolType = typename,
-            ToolQualityWeight = 1.0,
-            UseToolDuration = true,
+            ToolQualityWeight = spec.QualityWeight,
+            UseToolDuration = spec.UseToolDuration,
             DesiredState = (int)state,
             Definition = definition
         };
@@ -792,12 +1071,17 @@ return ""There is no useful clay that is accessible in the biome you're in.""");
     }
 
     private (string TypeName, string Definition) BuildProductDefinition(Craft craft, string text)
+	{
+		return BuildProductDefinition(craft, ParseProductSpec(text, false));
+	}
+
+    private (string TypeName, string Definition) BuildProductDefinition(Craft craft, CraftProductSpec spec)
     {
-        Match match = RequireMatch(ConversionRegex, text, "Invalid product definition");
-        (string details, List<string> options) = SplitDetails(match.Groups["details"].Value);
+        string details = spec.Details;
+		List<string> options = spec.Options.ToList();
         Match innerMatch;
         CraftInput input;
-        switch (match.Groups["type"].Value.ToLowerInvariant())
+        switch (spec.ProductType.ToLowerInvariant())
         {
             case "simpleproduct":
             case "simple":
@@ -903,30 +1187,161 @@ return ""There is no useful clay that is accessible in the biome you're in.""");
         }
     }
 
-    private CraftProduct? ConvertToProduct(Craft craft, string text, bool isFailProduct, int? materialDefiningInputIndex = null)
+    private CraftProduct ConvertToProduct(Craft craft, CraftProductSpec spec)
     {
-        (string typename, string definition) = BuildProductDefinition(craft, text);
+        (string typename, string definition) = BuildProductDefinition(craft, spec);
         return new CraftProduct()
         {
             Craft = craft,
-            IsFailProduct = isFailProduct,
+            IsFailProduct = spec.IsFailProduct,
             OriginalAdditionTime = DateTime.UtcNow,
             ProductType = typename,
             Definition = definition,
-            MaterialDefiningInputIndex = materialDefiningInputIndex
+            MaterialDefiningInputIndex = spec.MaterialDefiningInputIndex
         };
     }
 
-    private MudSharp.Models.Craft? AddCraft(string name, string category, string blurb, string action, string itemsdesc, string appearProg, string? canUseProg, string? whyCantProg, string? onFinishProg, MudSharp.Models.TraitDefinition trait, Difficulty difficulty, Outcome threshold, int freeChecks, int failPhase, bool interrupatable, IEnumerable<(int Seconds, string Echo, string FailEcho)> phases, IEnumerable<string> inputs, IEnumerable<string> tools, IEnumerable<string> products, IEnumerable<string> failProducts, List<(int Product, int Input)>? productMaterialInputIndexes = null, List<(int Product, int Input)>? failProductMaterialInputIndexes = null)
+    private MudSharp.Models.Craft? AddCraft(string name, string category, string blurb, string action, string itemsdesc, string appearProg, string? canUseProg, string? whyCantProg, string? onFinishProg, MudSharp.Models.TraitDefinition trait, Difficulty difficulty, Outcome threshold, int freeChecks, int failPhase, bool interrupatable, IEnumerable<(int Seconds, string Echo, string FailEcho)> phases, IEnumerable<string> inputs, IEnumerable<string> tools, IEnumerable<string> products, IEnumerable<string> failProducts, List<(int Product, int Input)>? productMaterialInputIndexes = null, List<(int Product, int Input)>? failProductMaterialInputIndexes = null, string? onStartProg = null, string? onCancelProg = null)
     {
-        List<string> inputList = inputs.ToList();
-        List<string> toolList = tools.ToList();
-        List<string> productList = products.ToList();
-        List<string> failProductList = failProducts.ToList();
-        if (!InputsAreValid(inputList, toolList, productList, failProductList))
-        {
-            return null;
-        }
+		Craft? existing = FindExistingCraft(name, category);
+		if (existing is not null)
+		{
+			return existing;
+		}
+
+        List<CraftValidationError> importErrors = [];
+		var inputSpecs = ParseImportSpecs(inputs, name, "input", ParseInputSpec, importErrors);
+		var toolSpecs = ParseImportSpecs(tools, name, "tool", ParseToolSpec, importErrors);
+		var productSpecs = ParseProductSpecs(products, name, false, productMaterialInputIndexes, importErrors);
+		var failProductSpecs = ParseProductSpecs(failProducts, name, true, failProductMaterialInputIndexes, importErrors);
+
+		var spec = new CraftDefinitionSpec
+		{
+			Name = name,
+			Category = category,
+			Blurb = blurb,
+			Action = action,
+			ActiveCraftItemSdesc = itemsdesc,
+			AppearProg = LookupProg(appearProg),
+			CanUseProg = canUseProg is not null ? LookupProg(canUseProg) : null,
+			WhyCannotUseProg = whyCantProg is not null ? LookupProg(whyCantProg) : null,
+			OnStartProg = onStartProg is not null ? LookupProg(onStartProg) : null,
+			OnFinishProg = onFinishProg is not null ? LookupProg(onFinishProg) : null,
+			OnCancelProg = onCancelProg is not null ? LookupProg(onCancelProg) : null,
+			Trait = trait,
+			Difficulty = difficulty,
+			Threshold = threshold,
+			FreeChecks = freeChecks,
+			FailPhase = failPhase,
+			Interruptable = interrupatable,
+			Phases = phases.Select(x => new CraftPhaseSpec
+			{
+				Seconds = x.Seconds,
+				Echo = x.Echo,
+				FailEcho = x.FailEcho
+			}).ToList(),
+			Inputs = inputSpecs,
+			Tools = toolSpecs,
+			Products = productSpecs,
+			FailProducts = failProductSpecs
+		};
+
+		return AddCraft(spec, importErrors);
+    }
+
+	private MudSharp.Models.Craft? AddCraft(string name, string category, string blurb, string action, string itemsdesc, string traitName, int? minimumTraitValue, Difficulty difficulty, Outcome threshold, int freeChecks, int failPhase, bool interrupatable, IEnumerable<(int Seconds, string Echo, string FailEcho)> phases, IEnumerable<string> inputs, IEnumerable<string> tools, IEnumerable<string> products, IEnumerable<string> failProducts, List<(int Product, int Input)>? productMaterialInputIndexes = null, List<(int Product, int Input)>? failProductMaterialInputIndexes = null, string? onFinishProg = null, string? onStartProg = null, string? onCancelProg = null)
+	{
+		Craft? existing = FindExistingCraft(name, category);
+		if (existing is not null)
+		{
+			return existing;
+		}
+
+		(FutureProg appearProg, FutureProg canUseProg, FutureProg whyCannotUseProg, TraitDefinition trait) =
+			EnsureTraitGateProgs(traitName, minimumTraitValue);
+		return AddCraft(
+			name,
+			category,
+			blurb,
+			action,
+			itemsdesc,
+			appearProg.FunctionName,
+			canUseProg.FunctionName,
+			whyCannotUseProg.FunctionName,
+			onFinishProg,
+			trait,
+			difficulty,
+			threshold,
+			freeChecks,
+			failPhase,
+			interrupatable,
+			phases,
+			inputs,
+			tools,
+			products,
+			failProducts,
+			productMaterialInputIndexes,
+			failProductMaterialInputIndexes,
+			onStartProg,
+			onCancelProg
+		);
+	}
+
+	private List<TSpec> ParseImportSpecs<TSpec>(IEnumerable<string> imports, string craftName, string kind,
+		Func<string, TSpec> parser, List<CraftValidationError> errors)
+	{
+		List<TSpec> specs = [];
+		foreach (string import in imports)
+		{
+			try
+			{
+				specs.Add(parser(import));
+			}
+			catch (ApplicationException ex)
+			{
+				errors.Add(new CraftValidationError(craftName, kind, import, ex.Message));
+			}
+		}
+
+		return specs;
+	}
+
+	private List<CraftProductSpec> ParseProductSpecs(IEnumerable<string> imports, string craftName, bool isFailProduct,
+		List<(int Product, int Input)>? materialInputIndexes, List<CraftValidationError> errors)
+	{
+		List<CraftProductSpec> specs = [];
+		int index = 0;
+		foreach (string import in imports)
+		{
+			index++;
+			try
+			{
+				specs.Add(ParseProductSpec(import, isFailProduct, GetMaterialDefiningInputIndex(materialInputIndexes, index)));
+			}
+			catch (ApplicationException ex)
+			{
+				errors.Add(new CraftValidationError(craftName, isFailProduct ? "fail product" : "product", import, ex.Message));
+			}
+		}
+
+		return specs;
+	}
+
+	private MudSharp.Models.Craft AddCraft(CraftDefinitionSpec spec, IEnumerable<CraftValidationError>? importErrors = null)
+	{
+		Craft? existing = FindExistingCraft(spec.Name, spec.Category);
+		if (existing is not null)
+		{
+			return existing;
+		}
+
+		List<CraftValidationError> errors = importErrors?.ToList() ?? [];
+		errors.AddRange(ValidateCraftSpec(spec));
+		if (errors.Count > 0)
+		{
+			throw new ApplicationException(
+				$"Craft '{spec.Name}' has {errors.Count.ToString(System.Globalization.CultureInfo.InvariantCulture)} validation error(s):\n - {string.Join("\n - ", errors.Select(x => x.ToString()))}");
+		}
 
         Craft dbitem = new()
         {
@@ -943,21 +1358,24 @@ return ""There is no useful clay that is accessible in the biome you're in.""");
                 ReviewerComment = "Auto-generated by the system",
                 ReviewerDate = _now
             },
-            Name = name,
-            Category = category,
-            Blurb = blurb,
-            ActionDescription = action,
-            ActiveCraftItemSdesc = itemsdesc,
-            AppearInCraftsListProgId = _progs[appearProg].Id,
-            CanUseProgId = canUseProg is not null ? _progs[canUseProg].Id : null,
-            WhyCannotUseProgId = whyCantProg is not null ? _progs[whyCantProg].Id : null,
-            OnUseProgCompleteId = onFinishProg is not null ? _progs[onFinishProg].Id : null,
-            CheckTrait = trait,
-            CheckDifficulty = (int)difficulty,
-            FailThreshold = (int)threshold,
-            FreeSkillChecks = freeChecks,
-            FailPhase = failPhase,
-            Interruptable = interrupatable,
+            Name = spec.Name,
+            Category = spec.Category,
+            Blurb = spec.Blurb,
+            ActionDescription = spec.Action,
+            ActiveCraftItemSdesc = spec.ActiveCraftItemSdesc,
+            AppearInCraftsListProgId = spec.AppearProg!.Id,
+            CanUseProgId = spec.CanUseProg?.Id,
+            WhyCannotUseProgId = spec.WhyCannotUseProg?.Id,
+			OnUseProgStartId = spec.OnStartProg?.Id,
+            OnUseProgCompleteId = spec.OnFinishProg?.Id,
+			OnUseProgCancelId = spec.OnCancelProg?.Id,
+            CheckTrait = spec.Trait!,
+			CheckTraitId = spec.Trait!.Id,
+            CheckDifficulty = (int)spec.Difficulty,
+            FailThreshold = (int)spec.Threshold,
+            FreeSkillChecks = spec.FreeChecks,
+            FailPhase = spec.FailPhase,
+            Interruptable = spec.Interruptable,
             QualityFormula = "5 + (outcome/3) + (variable/20)",
             CheckQualityWeighting = 1.0,
             InputQualityWeighting = 1.0,
@@ -966,7 +1384,7 @@ return ""There is no useful clay that is accessible in the biome you're in.""");
         };
 		_context!.Crafts.Add(dbitem);
         int i = 1;
-        foreach ((int Seconds, string Echo, string FailEcho) phase in phases)
+        foreach (CraftPhaseSpec phase in spec.Phases)
         {
             dbitem.CraftPhases.Add(new CraftPhase
             {
@@ -974,58 +1392,40 @@ return ""There is no useful clay that is accessible in the biome you're in.""");
                 Echo = phase.Echo,
                 FailEcho = phase.FailEcho,
                 PhaseLengthInSeconds = phase.Seconds,
-                PhaseNumber = i++
+                PhaseNumber = i++,
+				ExertionLevel = (int)phase.Exertion,
+				StaminaUsage = phase.Stamina
             });
         }
 
-        foreach (string input in inputList)
+        foreach (CraftInputSpec input in spec.Inputs)
         {
-            CraftInput? dbinput = ConvertToInput(dbitem, input);
-            if (dbinput is null)
-            {
-                return null;
-            }
+            CraftInput dbinput = ConvertToInput(dbitem, input);
             dbitem.CraftInputs.Add(dbinput);
         }
 
-        foreach (string tool in toolList)
+        foreach (CraftToolSpec tool in spec.Tools)
         {
-            CraftTool? dbtool = ConvertToTool(dbitem, tool);
-            if (dbtool is null)
-            {
-                return null;
-            }
+            CraftTool dbtool = ConvertToTool(dbitem, tool);
             dbitem.CraftTools.Add(dbtool);
         }
 
         // We have to save before products because some of the product types depend on input IDs
         _context.SaveChanges();
 
-        i = 0;
-        foreach (string product in productList)
+        foreach (CraftProductSpec product in spec.Products)
         {
-            i++;
-            CraftProduct? dbproduct = ConvertToProduct(dbitem, product, false, GetMaterialDefiningInputIndex(productMaterialInputIndexes, i));
-            if (dbproduct is null)
-            {
-                return null;
-            }
-            dbitem.CraftProducts.Add(dbproduct);
+            dbitem.CraftProducts.Add(ConvertToProduct(dbitem, product));
         }
 
-        i = 0;
-        foreach (string product in failProductList)
+        foreach (CraftProductSpec product in spec.FailProducts)
         {
-            i++;
-            CraftProduct? dbproduct = ConvertToProduct(dbitem, product, true, GetMaterialDefiningInputIndex(failProductMaterialInputIndexes, i));
-            if (dbproduct is null)
-            {
-                return null;
-            }
-            dbitem.CraftProducts.Add(dbproduct);
+            dbitem.CraftProducts.Add(ConvertToProduct(dbitem, product));
         }
+
+		_context.SaveChanges();
         return dbitem;
-    }
+	}
 
     private static int? GetMaterialDefiningInputIndex(List<(int Product, int Input)>? indexes, int productNumber)
     {
@@ -1033,45 +1433,210 @@ return ""There is no useful clay that is accessible in the biome you're in.""");
         return match.Product == 0 ? null : Math.Max(0, match.Input - 1);
     }
 
-    bool InputsAreValid(IEnumerable<string> inputs, IEnumerable<string> tools, IEnumerable<string> products, IEnumerable<string> failproducts)
-    {
-        try
-        {
-            Craft validationCraft = new();
-            var index = 1;
-            foreach (string item in inputs)
-            {
-                BuildInputDefinition(item);
-                validationCraft.CraftInputs.Add(new CraftInput
-                {
-                    Id = index,
-                    OriginalAdditionTime = _now.AddTicks(index)
-                });
-                index++;
-            }
+	private Craft? FindExistingCraft(string name, string category)
+	{
+		return _context!.Crafts.Local.FirstOrDefault(x =>
+			       x.Name.Equals(name, StringComparison.OrdinalIgnoreCase) &&
+			       x.Category.Equals(category, StringComparison.OrdinalIgnoreCase)) ??
+		       _context.Crafts.AsEnumerable().FirstOrDefault(x =>
+			       x.Name.Equals(name, StringComparison.OrdinalIgnoreCase) &&
+			       x.Category.Equals(category, StringComparison.OrdinalIgnoreCase));
+	}
 
-            foreach (string item in tools)
-            {
-                BuildToolDefinition(item);
-            }
+	private IReadOnlyList<CraftValidationError> ValidateCraftSpec(CraftDefinitionSpec spec)
+	{
+		List<CraftValidationError> errors = [];
+		if (string.IsNullOrWhiteSpace(spec.Name))
+		{
+			errors.Add(new CraftValidationError(spec.Name, "craft", spec.Name, "Craft name cannot be blank"));
+		}
 
-            foreach (string item in products)
-            {
-                BuildProductDefinition(validationCraft, item);
-            }
+		if (string.IsNullOrWhiteSpace(spec.Category))
+		{
+			errors.Add(new CraftValidationError(spec.Name, "craft", spec.Category, "Craft category cannot be blank"));
+		}
 
-            foreach (string item in failproducts)
-            {
-                BuildProductDefinition(validationCraft, item);
-            }
+		if (spec.AppearProg is null)
+		{
+			errors.Add(new CraftValidationError(spec.Name, "craft", "appear prog", "Craft must have an appear prog"));
+		}
 
-            return true;
-        }
-        catch (ApplicationException)
-        {
-            return false;
-        }
-    }
+		if (spec.Trait is null)
+		{
+			errors.Add(new CraftValidationError(spec.Name, "craft", "trait", "Craft must have a check trait"));
+		}
+
+		if (spec.Phases.Count == 0)
+		{
+			errors.Add(new CraftValidationError(spec.Name, "phase", "phases", "Craft must have at least one phase"));
+		}
+
+		if (spec.FailPhase < 1 || spec.FailPhase > Math.Max(1, spec.Phases.Count))
+		{
+			errors.Add(new CraftValidationError(spec.Name, "phase", spec.FailPhase.ToString(System.Globalization.CultureInfo.InvariantCulture), "Fail phase must be a one-based phase number"));
+		}
+
+		for (int i = 0; i < spec.Phases.Count; i++)
+		{
+			CraftPhaseSpec phase = spec.Phases[i];
+			if (phase.Seconds <= 0)
+			{
+				errors.Add(new CraftValidationError(spec.Name, "phase", (i + 1).ToString(System.Globalization.CultureInfo.InvariantCulture), "Phase seconds must be positive"));
+			}
+
+			if (phase.Stamina < 0.0)
+			{
+				errors.Add(new CraftValidationError(spec.Name, "phase", (i + 1).ToString(System.Globalization.CultureInfo.InvariantCulture), "Phase stamina cannot be negative"));
+			}
+		}
+
+		Craft validationCraft = new();
+		for (int i = 0; i < spec.Inputs.Count; i++)
+		{
+			CraftInputSpec input = spec.Inputs[i];
+			try
+			{
+				BuildInputDefinition(input);
+			}
+			catch (ApplicationException ex)
+			{
+				errors.Add(new CraftValidationError(spec.Name, "input", input.ImportText, ex.Message));
+			}
+
+			validationCraft.CraftInputs.Add(new CraftInput
+			{
+				Id = i + 1,
+				InputType = input.InputType,
+				Definition = "<Definition />",
+				OriginalAdditionTime = _now.AddTicks(i + 1)
+			});
+		}
+
+		foreach (CraftToolSpec tool in spec.Tools)
+		{
+			try
+			{
+				BuildToolDefinition(tool);
+			}
+			catch (ApplicationException ex)
+			{
+				errors.Add(new CraftValidationError(spec.Name, "tool", tool.ImportText, ex.Message));
+			}
+		}
+
+		ValidateProductSpecs(spec, validationCraft, spec.Products, "product", errors);
+		ValidateProductSpecs(spec, validationCraft, spec.FailProducts, "fail product", errors);
+		return errors;
+	}
+
+	private void ValidateProductSpecs(CraftDefinitionSpec spec, Craft validationCraft, IEnumerable<CraftProductSpec> products,
+		string kind, List<CraftValidationError> errors)
+	{
+		foreach (CraftProductSpec product in products)
+		{
+			if (product.MaterialDefiningInputIndex is < 0 || product.MaterialDefiningInputIndex >= spec.Inputs.Count)
+			{
+				errors.Add(new CraftValidationError(spec.Name, kind, product.ImportText, "Material-defining input index is outside the craft input list"));
+			}
+
+			try
+			{
+				BuildProductDefinition(validationCraft, product);
+			}
+			catch (ApplicationException ex)
+			{
+				errors.Add(new CraftValidationError(spec.Name, kind, product.ImportText, ex.Message));
+			}
+		}
+	}
+
+	private TraitDefinition LookupTraitDefinition(string traitName)
+	{
+		return _traits.TryGetValue(traitName, out TraitDefinition? trait) && trait is not null
+			? trait
+			: throw new ApplicationException($"Unknown trait {traitName}");
+	}
+
+	private static string SanitiseFutureProgNamePart(string text)
+	{
+		string value = new(text.Where(char.IsLetterOrDigit).ToArray());
+		return string.IsNullOrWhiteSpace(value) ? "Trait" : value;
+	}
+
+	private static string EscapeFutureProgText(string text)
+	{
+		return text.Replace(@"\", @"\\").Replace("\"", "\\\"");
+	}
+
+	private (FutureProg AppearProg, FutureProg CanUseProg, FutureProg WhyCannotUseProg, TraitDefinition Trait) EnsureTraitGateProgs(string traitName, int? minimumTraitValue)
+	{
+		TraitDefinition trait = LookupTraitDefinition(traitName);
+		string suffix = $"{SanitiseFutureProgNamePart(trait.Name)}{(minimumTraitValue is null ? "" : minimumTraitValue.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))}";
+		string booleanText = minimumTraitValue is null
+			? $@"return @ch.Skills.Any(x, @x.Id == {trait.Id.ToString(System.Globalization.CultureInfo.InvariantCulture)})"
+			: $@"return GetTrait(@ch, ToTrait(""{trait.Id.ToString(System.Globalization.CultureInfo.InvariantCulture)}"")) >= {minimumTraitValue.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)}";
+		string traitText = EscapeFutureProgText(trait.Name);
+		string whyText = minimumTraitValue is null
+			? $@"return ""You do not have the {traitText} skill."""
+			: $@"return ""You need at least {minimumTraitValue.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)} in {traitText} to do that craft.""";
+
+		FutureProg appearProg = EnsureFutureProg($"ItemSeederAppear{suffix}", "Crafting", "Access", ProgVariableTypes.Boolean, "",
+			[(ProgVariableTypes.Character, "ch")], booleanText);
+		FutureProg canUseProg = EnsureFutureProg($"ItemSeederCanUse{suffix}", "Crafting", "Access", ProgVariableTypes.Boolean, "",
+			[(ProgVariableTypes.Character, "ch")], booleanText);
+		FutureProg whyCannotUseProg = EnsureFutureProg($"ItemSeederWhyCannotUse{suffix}", "Crafting", "Access", ProgVariableTypes.Text, "",
+			[(ProgVariableTypes.Character, "ch")], whyText);
+		_context!.SaveChanges();
+		return (appearProg, canUseProg, whyCannotUseProg, trait);
+	}
+
+	private void InitialiseCraftAuthoringForTesting(FuturemudDatabaseContext context)
+	{
+		_context = context;
+		_questionAnswers = new Dictionary<string, string>();
+		_missingTags.Clear();
+		_progs = new Dictionary<string, FutureProg>(StringComparer.InvariantCultureIgnoreCase);
+		_traits = new DictionaryWithDefault<string, TraitDefinition>(StringComparer.OrdinalIgnoreCase);
+		InitialiseDependencies();
+		foreach (FutureProg prog in context.FutureProgs)
+		{
+			_progs[prog.FunctionName] = prog;
+		}
+		_nextId = context.Crafts.Select(x => x.Id).ToList().DefaultIfEmpty(0).Max(x => x) + 1;
+	}
+
+	internal MudSharp.Models.Craft AddCraftForTesting(FuturemudDatabaseContext context, CraftDefinitionSpec spec)
+	{
+		InitialiseCraftAuthoringForTesting(context);
+		return AddCraft(spec);
+	}
+
+	internal MudSharp.Models.Craft AddCraftFromImportsForTesting(FuturemudDatabaseContext context, string name, string category,
+		IEnumerable<(int Seconds, string Echo, string FailEcho)> phases, IEnumerable<string> inputs, IEnumerable<string> tools,
+		IEnumerable<string> products, IEnumerable<string> failProducts, List<(int Product, int Input)>? productMaterialInputIndexes = null,
+		List<(int Product, int Input)>? failProductMaterialInputIndexes = null, string traitName = "Crafting",
+		string appearProg = "AlwaysTrue", string? canUseProg = null, string? whyCantProg = null, string? onFinishProg = null,
+		string? onStartProg = null, string? onCancelProg = null, Difficulty difficulty = Difficulty.Normal,
+		Outcome threshold = Outcome.MinorFail, int freeChecks = 5, int failPhase = 1, bool interruptable = false,
+		string blurb = "test craft", string action = "testing", string itemSdesc = "a test craft event")
+	{
+		InitialiseCraftAuthoringForTesting(context);
+		return AddCraft(name, category, blurb, action, itemSdesc, appearProg, canUseProg, whyCantProg, onFinishProg,
+			       LookupTraitDefinition(traitName), difficulty, threshold, freeChecks, failPhase, interruptable, phases,
+			       inputs, tools, products, failProducts, productMaterialInputIndexes, failProductMaterialInputIndexes,
+			       onStartProg, onCancelProg) ??
+		       throw new ApplicationException($"Craft '{name}' was not created.");
+	}
+
+	internal MudSharp.Models.Craft AddTraitGatedCraftFromImportsForTesting(FuturemudDatabaseContext context, string name,
+		string category, string traitName, int? minimumTraitValue, IEnumerable<(int Seconds, string Echo, string FailEcho)> phases,
+		IEnumerable<string> inputs, IEnumerable<string> tools, IEnumerable<string> products, IEnumerable<string> failProducts)
+	{
+		InitialiseCraftAuthoringForTesting(context);
+		return AddCraft(name, category, "test craft", "testing", "a test craft event", traitName, minimumTraitValue,
+			       Difficulty.Normal, Outcome.MinorFail, 5, 1, false, phases, inputs, tools, products, failProducts) ??
+		       throw new ApplicationException($"Craft '{name}' was not created.");
+	}
 
     private void SeedCrafts()
     {

--- a/Design Documents/DatabaseSeeder_Repeatability_Strategy.md
+++ b/Design Documents/DatabaseSeeder_Repeatability_Strategy.md
@@ -43,6 +43,7 @@ This document is based on verified code behavior in the current stock repo, not 
 - `UsefulSeeder` now exposes its AI examples as one repeatable stock package question instead of the older `ai` / `ai2` split, and that package installs or refreshes stock-owned AI examples by stable names, including the `BasicMount` stock `MountAI` definition used by mount-capable NPC imports.
 - `CoreDataSeeder` now owns the stock terrain catalogue, terrain-tag taxonomy, and stock terrain forage-profile backfill so terrain-aware packages and animal grazing systems can rely on default terrain yield capacities without an extra prompt.
 - `StockMeritsSeeder` now provides a repair-capable stock merits and flaws package built around stable merit names and tag-driven helper FutureProgs.
+- `ItemSeeder` craft authoring now inserts missing stock craft rows by `Name + Category` and skips matching existing craft rows without adding duplicate phases, inputs, tools, or products. This is a narrow stock-craft install-missing behavior, not full `ItemSeeder` repeatability.
 - Shared answer reuse is no longer combat-only. The live shared-answer wave covers combat message style, damage randomness, human health model, and non-human health model.
 - Many legacy seeders still rely on coarse installed-state checks such as `Accounts.Any()`, `WeaponAttacks.Any()`, `ClimateModels.Any()`, `ChargenScreenStoryboards.Any()`, or `SurgicalProcedures.Any()`. Phase 2 is the wave intended to replace those with deterministic stock-key detection.
 - Duplicate `SortOrder` values were previously unstable in the menu flow; the structured assessment/menu work now gives that ordering deterministic tie-breaking.
@@ -72,7 +73,7 @@ This document is based on verified code behavior in the current stock repo, not 
 | `WeatherSeeder` | 300 | Requires account and at least one celestial | Deterministic stock-key check on seeded climate/weather markers | None | Upserts stock weather events, seasons, climate models, regional climates, and rain settings by stable names | Repairs seeded package in place | `Idempotent` / `RepairExisting` | Medium | Keep controller assignment builder-owned and expand regression coverage only where needed |
 | `MythicalAnimalSeeder` | 302 | Requires human and animal body frameworks, corpse models, characteristic profiles, and non-human strategies | `MayAlreadyBeInstalled` only when all stock mythic races exist | Non-human health model, damage randomness, and combat message style are now shareable | Installs incrementally and skips existing stock mythic races | Install-missing only | `Idempotent` / `InstallMissing` | Medium | Document exact skip behavior and preserve as repeatable package |
 | `RobotSeeder` | 305 | Requires humanoid and animal body frameworks, characteristic profiles, corpse models, tool tags, progs, and prerequisite attacks | `MayAlreadyBeInstalled` only when all tracked robot content exists | None | Installs incrementally and skips existing stock robot records | Install-missing only | `Idempotent` / `InstallMissing` | Medium | Document exact skip behavior and preserve as repeatable package |
-| `ItemSeeder` | 400 | Requires Useful item component prerequisites | Always `ReadyToInstall` once prerequisites exist | None | No installed-state guard despite large stock content surface | None | `OneShot` / `None` until dedicated plan | High | Create explicit stock package ownership model before declaring rerun support |
+| `ItemSeeder` | 400 | Requires Useful item component prerequisites | Always `ReadyToInstall` once prerequisites exist | None | Large item content remains broadly one-shot; `AddCraft` now installs missing stock craft rows by `Name + Category` and skips matching existing rows without duplicating children | Stock craft rows only: install missing / skip existing. No item-prototype repair or full craft refresh | Overall `OneShot`; craft rows have limited `InstallMissing` behavior | High | Keep the craft-row skip behavior narrow and create explicit stock package ownership before declaring broader ItemSeeder repeatability |
 | `LawSeeder` | 5000 | Requires account and currency | Deterministic stock-key check within legal authorities | None | Upserts named authorities, legal classes, witness profiles, enforcement groups, and stock laws by stable names | Repairs seeded package in place | `Idempotent` / `RepairExisting` | Medium | Add same-authority rerun tests and confirm live runtime references stay intact |
 
 ## Current Buckets
@@ -104,7 +105,7 @@ This document is based on verified code behavior in the current stock repo, not 
 - `CoreDataSeeder`
 - `HumanSeeder`
 - `CombatSeeder`
-- `ItemSeeder`
+- `ItemSeeder` overall, except the narrow stock-craft install-missing/skip-existing behavior in `AddCraft`
 - `AnimalSeeder`
 
 ## System-Level Findings

--- a/Design Documents/ItemSeeder_AddCraft_Guide.md
+++ b/Design Documents/ItemSeeder_AddCraft_Guide.md
@@ -1,8 +1,8 @@
 # ItemSeeder AddCraft Authoring Guide
 
-This guide documents the private `AddCraft` helper in `DatabaseSeeder/Seeders/ItemSeederCrafting.cs`.
+This guide documents the craft-authoring slice in `DatabaseSeeder/Seeders/ItemSeederCrafting.cs`.
 
-`AddCraft` is a spreadsheet-friendly bridge into the craft tables. It creates a `Craft`, its phases, inputs, tools, success products, and fail products from compact strings that are converted into the XML definitions used by the runtime craft factories.
+`AddCraft` now uses a typed seeder API internally. The compact spreadsheet-style strings are still supported, but they are treated as an import layer: strings are parsed into typed phase, input, tool, and product specs, validated as a group, and then inserted through one implementation path.
 
 For the broader runtime and builder model, see:
 
@@ -10,124 +10,146 @@ For the broader runtime and builder model, see:
 - `Design Documents/Crafting_System_Runtime_and_Extensibility.md`
 - `Design Documents/Crafting_System_Builder_Workflows.md`
 
-## Function Shape
+## Typed Shape
 
-```csharp
-private MudSharp.Models.Craft? AddCraft(
-	string name,
-	string category,
-	string blurb,
-	string action,
-	string itemsdesc,
-	string appearProg,
-	string? canUseProg,
-	string? whyCantProg,
-	string? onFinishProg,
-	MudSharp.Models.TraitDefinition trait,
-	Difficulty difficulty,
-	Outcome threshold,
-	int freeChecks,
-	int failPhase,
-	bool interrupatable,
-	IEnumerable<(int Seconds, string Echo, string FailEcho)> phases,
-	IEnumerable<string> inputs,
-	IEnumerable<string> tools,
-	IEnumerable<string> products,
-	IEnumerable<string> failProducts,
-	List<(int Product, int Input)>? productMaterialInputIndexes = null,
-	List<(int Product, int Input)>? failProductMaterialInputIndexes = null)
+The core typed specs are:
+
+| Spec | Purpose |
+| --- | --- |
+| `CraftDefinitionSpec` | Craft metadata, access progs, lifecycle progs, trait check, phases, inputs, tools, products, and fail products. |
+| `CraftPhaseSpec` | Phase seconds, success echo, fail echo, exertion level, and stamina use. |
+| `CraftInputSpec` | Original import text, input type, main details, import options, and input quality weight. |
+| `CraftToolSpec` | Original import text, tool type, main details, import options, tool quality weight, and `UseToolDuration`. |
+| `CraftProductSpec` | Original import text, product type, main details, import options, success/fail status, and material-defining input index. |
+
+The old string-heavy `AddCraft` overload remains for stock spreadsheet imports. It builds these specs and calls the typed implementation.
+
+## Rerun Behavior
+
+Craft creation is insert-or-skip by stable `Name + Category`.
+
+If a matching craft already exists, `AddCraft` returns that existing row unchanged. It does not refresh the craft and does not add duplicate phases, inputs, tools, products, or fail products.
+
+This is deliberate narrow repeatability for stock craft rows only. It is not a claim that all `ItemSeeder` item/component content is fully repeatable or repair-capable.
+
+## Validation
+
+New craft specs are validated before insertion. Validation accumulates all input, tool, product, fail-product, phase, trait, and prog errors it can find, then throws one `ApplicationException`.
+
+Error lines include:
+
+- craft name
+- spec kind, such as `input`, `tool`, `product`, or `fail product`
+- original import text where the error came from
+- the specific lookup or grammar failure
+
+Existing `Name + Category` rows skip before validation because the chosen rerun policy is "do not touch existing stock craft rows".
+
+## Lifecycle And Trait Progs
+
+Typed specs support all craft lifecycle hooks:
+
+- `OnStartProg`
+- `OnFinishProg`
+- `OnCancelProg`
+
+The legacy string overload still exposes completion directly and also accepts optional start/cancel prog names.
+
+Trait-gated overloads accept a `traitName` and optional `minimumTraitValue`. They create deterministic FutureProgs:
+
+```text
+ItemSeederAppear<Trait><Minimum?>
+ItemSeederCanUse<Trait><Minimum?>
+ItemSeederWhyCannotUse<Trait><Minimum?>
 ```
 
-The helper returns the created craft or `null` if any input, tool, or product string cannot be resolved against the seeded lookup data.
-
-## Parameters
-
-| Parameter | Meaning |
-| --- | --- |
-| `name` | Unique craft name, for example `forge sword blade`. |
-| `category` | Craft category shown in craft lists, for example `Weaponcrafting`. |
-| `blurb` | Short command-style description, for example `forge a sword blade`. |
-| `action` | Active action description, for example `forging a sword blade`. |
-| `itemsdesc` | Short description for the active craft progress item. |
-| `appearProg` | FutureProg function name for list visibility. Must exist in `_progs`. |
-| `canUseProg` | Optional FutureProg function name that gates craft use. |
-| `whyCantProg` | Optional FutureProg function name explaining a failed `canUseProg`. |
-| `onFinishProg` | Optional FutureProg function name run on successful completion. |
-| `trait` | Trait checked by the craft outcome roll. |
-| `difficulty` | `Difficulty` enum value for the craft check. |
-| `threshold` | `Outcome` enum value at or below which the craft fails. |
-| `freeChecks` | Number of practical/free skill checks granted by the craft. |
-| `failPhase` | Phase number where the success/failure result is decided. |
-| `interrupatable` | Whether the active craft can pause and resume. The parameter name is misspelled in the current helper. |
-| `phases` | Ordered phase tuples: seconds, success echo, fail echo. |
-| `inputs` | Ordered input conversion strings. Referenced in echoes as `$i1`, `$i2`, etc. |
-| `tools` | Ordered tool conversion strings. Referenced in echoes as `$t1`, `$t2`, etc. |
-| `products` | Ordered success product conversion strings. Referenced in success echoes as `$p1`, `$p2`, etc. |
-| `failProducts` | Ordered failure product conversion strings. Referenced in fail echoes as `$f1`, `$f2`, etc. |
-| `productMaterialInputIndexes` | Optional one-based `(Product, Input)` pairs. Product `1` with input `1` means `$p1` inherits material from `$i1`. |
-| `failProductMaterialInputIndexes` | Same as above, but for fail products. |
-
-## Phase Echoes
-
-Phases are not just text. The runtime scans success and fail echoes for tokens and uses them to infer when inputs, tools, and products participate.
-
-| Token | Meaning |
-| --- | --- |
-| `$iN` | Input N. The first success-echo reference sets the phase where the input is consumed. |
-| `$tN` | Tool N. The tool is required in each success phase where it appears. |
-| `$pN` | Success product N. The first success-echo reference sets the phase where the product appears. |
-| `$fN` | Fail product N. Only valid in fail echoes; the first reference sets the fail-product phase. |
-
-If an input is never referenced, it is consumed at phase 1. If a tool is never referenced, it is required in every normal phase. Unreferenced success and fail products default to `failPhase`.
+Without a minimum, the generated boolean progs check whether the character has the skill. With a minimum, they check `GetTrait(@ch, ToTrait("<id>")) >= minimum`. The generated why prog returns a short builder-safe explanation.
 
 ## Conversion String Basics
 
-All input, tool, and product strings use this basic shape:
+Inputs, tools, and products still use this shape:
 
 ```text
-TypeName - details
+TypeName - details; option; option
 ```
 
-Tools include a desired state between the type and details:
+Tools include desired item state:
 
 ```text
-TypeName - Held - details
-TypeName - InRoom - details
+TagTool - Held - an item with the Sewing Needle tag
+SimpleTool - InRoom - a cast-iron stove (#456)
 ```
 
-Product strings may add semicolon-separated options after the main detail:
+Type names and options are case-insensitive.
+
+## Shared Import Options
+
+Inputs and tools support:
 
 ```text
-SimpleProduct - 1x a cloak (#100); skin blue cloak skin
-CookedFoodProduct - 1x a stew (#200); purify off; ingredient $i1=meat, $i2=vegetable
+quality <number>
 ```
 
-Type names are matched case-insensitively, but the seeder writes the canonical runtime type names into the database.
+Examples:
+
+```text
+Tag - 2x an item with the Thread tag; quality 2.5
+TagTool - Held - an item with the Sewing Needle tag; quality 1.75
+```
+
+Tools also support:
+
+```text
+usetool on
+usetool off
+```
+
+This controls the persisted `CraftTool.UseToolDuration` flag. The default is `on`.
+
+Products do not currently have a runtime quality-weight contract. Per-product quality weights are intentionally deferred until the craft runtime has a field and behavior for them.
 
 ## Input Types
 
 | Type | Syntax | Notes |
 | --- | --- | --- |
 | `Tag` | `Tag - 2x an item with the Thread tag` | Consumes items with the tag. |
-| `TagVariable` | `TagVariable - 1x an item with the Dyed Cloth tag with variables Colour, Pattern` | Like `Tag`, but also declares characteristic definitions available to variable products. |
-| `SimpleItem` | `SimpleItem - 1x a short shaft (#123)` | Consumes exact item prototype. The `#id` is preferred if present. |
-| `SimpleMaterial` | `SimpleMaterial - 1x an item with material tagged as Wood` | Consumes item prototypes whose material has the tag. |
+| `TagVariable` | `TagVariable - 1x an item with the Dyed Cloth tag with variable Colour, Pattern` | Declares characteristic definitions available to variable products. |
+| `SimpleItem` | `SimpleItem - 1x a short shaft (#123)` | Consumes an exact item prototype. The `#id` is preferred. |
+| `SimpleMaterial` | `SimpleMaterial - 1x an item with material tagged as Wood` | Consumes an item whose material has the tag. |
+| `SimpleMaterial` | `SimpleMaterial - 1x an item made of iron` | Consumes an item whose material is exactly `iron`. |
 | `Commodity` | `Commodity - 1 kilogram 500 grams of iron` | Consumes exact material commodity by mass. |
 | `CommodityTag` | `CommodityTag - 500 grams of a material tagged as Fabric` | Consumes commodity whose material has the tag. |
 | `LiquidUse` | `LiquidUse - 1 litre of Water` | Consumes a specific liquid. Alias: `Liquid`. |
 | `LiquidTagUse` | `LiquidTagUse - 250 millilitres of a liquid tagged Cooking Oil` | Consumes a liquid from a tagged source. Alias: `TagLiquid`. |
-| `ConditionRepair` | `ConditionRepair - 15.00% repair of an item with the Damaged Tool tag` | Targets a damaged tagged item and repairs condition rather than deleting the input. Alias: `Repair`. |
+| `ConditionRepair` | `ConditionRepair - 15.00% repair of an item with the Damaged Tool tag` | Repairs condition rather than deleting the input. Alias: `Repair`. |
+
+Commodity inputs additionally support:
+
+```text
+piletag <tag name>
+characteristic any
+characteristic none
+characteristic <definition> any
+characteristic <definition> <value>
+characteristic <definition>=<value>
+```
+
+These write the runtime `CommodityCharacteristicRequirement` XML shape:
+
+```xml
+<Characteristics mode="specific">
+  <Characteristic definition="1" value="2" />
+</Characteristics>
+```
 
 ## Tool Types
 
-Valid tool states are the `DesiredItemState` enum names. In seeded craft examples, the useful ones are usually `Held`, `Wielded`, `Worn`, and `InRoom`.
+Valid tool states are the `DesiredItemState` enum names. Seeded examples usually use `Held`, `Wielded`, `Worn`, and `InRoom`.
 
 | Type | Syntax | Notes |
 | --- | --- | --- |
 | `TagTool` | `TagTool - Held - an item with the Sewing Needle tag` | Requires any item with the tag in the desired state. Alias: `Tag`. |
 | `SimpleTool` | `SimpleTool - InRoom - a cast-iron stove (#456)` | Requires one exact item prototype in the desired state. Alias: `Simple`. |
-
-Tools currently default to quality weight `1.0` and `UseToolDuration = true`.
 
 ## Product Types
 
@@ -138,14 +160,14 @@ Products and fail products use the same grammar.
 | `SimpleProduct` | `SimpleProduct - 1x a padded @material gambeson (#274)` | Loads item prototypes. Option: `skin <id|name>`. |
 | `CookedFoodProduct` | `CookedFoodProduct - 1x a baked apple (#999); purify off; ingredient $i1=fruit` | Loads prepared food and transfers consumed inputs into the food ledger. Aliases: `CookedFood`, `Cooked`. |
 | `SimpleVariableProduct` | `SimpleVariableProduct - 1x a dyed cloak (#1001); variable Colour=$i1` | Copies characteristic values from `IVariableInput` sources. Alias: `Variable`. |
-| `InputVariable` | `InputVariable - 1x a filled vial (#1002); variable Colour=$i1; specific Colour: red dye (#501)=red, blue dye (#502)=blue` | Chooses output characteristic values based on which input item prototype was used. |
-| `ProgVariableProduct` | `ProgVariableProduct - 1x a patterned cloth (#1003); variable Pattern=SelectPatternFromInputs` | Uses numeric FutureProgs to choose characteristic value IDs. Alias: `ProgVariable`. |
-| `CommodityProduct` | `CommodityProduct - 500 grams of beeswax commodity; tag Candle Wax; characteristic Colour=yellow; characteristic Origin from $i1` | Produces commodity piles. Alias: `Commodity`. |
-| `MoneyProduct` | `MoneyProduct - 10.00 of Gondorian Penny` | Produces a currency pile. The amount is the currency base amount. Alias: `Money`. |
+| `InputVariable` | `InputVariable - 1x a filled vial (#1002); variable Colour=$i1; specific Colour: red dye (#501)=red` | Chooses output characteristic values based on which input item prototype was used. |
+| `ProgVariableProduct` | `ProgVariableProduct - 1x a patterned cloth (#1003); variable Pattern=SelectPatternFromInputs` | Uses a FutureProg to choose characteristic output values. Alias: `ProgVariable`. |
+| `CommodityProduct` | `CommodityProduct - 500 grams of beeswax commodity; tag Candle Wax; characteristic Colour=yellow; characteristic Origin from $i1` | Produces commodity piles with optional tag and fixed/copied characteristics. Alias: `Commodity`. |
+| `MoneyProduct` | `MoneyProduct - 10.00 of Gondorian Penny` | Produces a currency pile. Alias: `Money`. |
 | `NPCProduct` | `NPCProduct - 1x common rat (#42); prog SetupSpawnedRat` | Spawns NPCs from a template. Optional `prog` runs after load. Alias: `NPC`. |
 | `Prog` | `Prog - LoadCraftProductsFromInputs` | Lets a FutureProg produce item or item collection products. Alias: `ProgProduct`. |
 | `DNATest` | `DNATest - compare $i1 and $i2` | Compares two liquid-consuming inputs. |
-| `BloodTyping` | `BloodTyping - test $i1 against the ABO blood model` | Tests one liquid-consuming input against a blood model. The older verbose syntax with liquid amount also works. |
+| `BloodTyping` | `BloodTyping - test $i1 against the ABO blood model` | Tests one liquid-consuming input against a blood model. |
 | `ScrapInput` | `ScrapInput - 40.00% by weight of 1x an item with the Sheet Metal tag ($i1); tag Scrap Metal` | Converts part of an item input's weight into commodity salvage. Alias: `Scrap`. |
 | `UnusedInput` | `UnusedInput - 50.00% of 20x an item with the Padding tag ($i3)` | Returns copies of a portion of a consumed input. |
 
@@ -159,101 +181,15 @@ Use `productMaterialInputIndexes` and `failProductMaterialInputIndexes` when an 
 
 That means product 1 inherits material from input 1. The values are one-based to match `$p1` and `$i1` echo notation. The helper converts them to the zero-based index expected by the runtime.
 
-## Examples
+## Phase Echoes
 
-### Simple Assembly
+The runtime scans success and fail echoes for tokens and uses them to infer when inputs, tools, and products participate.
 
-```csharp
-AddCraft(
-	"assemble simple spear",
-	"Weaponcrafting",
-	"assemble a simple spear",
-	"assembling a simple spear",
-	"an unfinished spear assembly",
-	"HasWeaponcrafting",
-	null,
-	null,
-	null,
-	_traits["Weaponcrafting"] ?? _traits["Weaponsmith"] ?? _traits.First().Value,
-	Difficulty.Normal,
-	Outcome.MinorFail,
-	5,
-	3,
-	false,
-	[
-		(30, "$0 fit|fits $i2 onto $i1.", "$0 fumble|fumbles the fitting of $i2 onto $i1."),
-		(30, "$0 secure|secures the head with $i3 and $t1.", "$0 ruin|ruins the binding but saves $f1."),
-		(20, "$0 set|sets aside $p1.", "$0 set|sets aside $f1.")
-	],
-	[
-		"Tag - 1x an item with the Pole tag",
-		"Tag - 1x an item with the Spearhead tag",
-		"Tag - 1x an item with the Tie tag"
-	],
-	[
-		"TagTool - Held - an item with the Pliers tag"
-	],
-	[
-		"SimpleProduct - 1x a long, reinforced pike with &a_an[@material] spearhead (#13)"
-	],
-	[
-		"SimpleProduct - 1x &a_an[@material] spearhead (#214)"
-	],
-	[(1, 2)],
-	[(1, 2)]);
-```
+| Token | Meaning |
+| --- | --- |
+| `$iN` | Input N. The first success-echo reference sets the phase where the input is consumed. |
+| `$tN` | Tool N. The tool is required in each success phase where it appears. |
+| `$pN` | Success product N. The first success-echo reference sets the phase where the product appears. |
+| `$fN` | Fail product N. Only valid in fail echoes; the first reference sets the fail-product phase. |
 
-### Prepared Food With Ingredient Roles
-
-```csharp
-AddCraft(
-	"bake spiced apple",
-	"Cooking",
-	"bake a spiced apple",
-	"baking a spiced apple",
-	"an apple-baking process",
-	"HasCooking",
-	null,
-	null,
-	null,
-	_traits["Cooking"] ?? _traits["Cook"] ?? _traits.First().Value,
-	Difficulty.Easy,
-	Outcome.MinorFail,
-	3,
-	2,
-	true,
-	[
-		(30, "$0 score|scores $i1 and dust|dusts it with $i2.", "$0 spill|spills too much $i2 over $i1."),
-		(60, "$0 bake|bakes $i1 into $p1.", "$0 scorch|scorches the apple and ends up with $f1.")
-	],
-	[
-		"Tag - 1x an item with the Apple tag",
-		"Tag - 1x an item with the Spice tag"
-	],
-	[
-		"TagTool - InRoom - an item with the Oven tag"
-	],
-	[
-		"CookedFoodProduct - 1x a baked apple (#999); ingredient $i1=fruit, $i2=seasoning"
-	],
-	[
-		"SimpleProduct - 1x some burnt food (#998)"
-	]);
-```
-
-## Recommended Upgrades
-
-The helper is useful, but it is still a spreadsheet import shim. The next version would be easier to maintain if it moved toward a typed seeder API while keeping this compact syntax as an optional import layer.
-
-Recommended upgrades:
-
-- Add a trait-gating overload such as `AddCraft(..., string traitName, int? minimumTraitValue)` that creates deterministic `Appear`, `CanUse`, and `WhyCannotUse` progs internally.
-- Make crafts upsert by stable name/category instead of always appending rows. The seeder rework will be safer if reruns can update stock craft suites deterministically.
-- Replace raw strings with typed records like `CraftInputSpec`, `CraftToolSpec`, and `CraftProductSpec`, plus parser helpers for spreadsheet import. That keeps bulk authoring easy while making tests and refactors less brittle.
-- Add per-input, per-tool, and per-product quality weights. The current helper always uses `1.0`.
-- Add tool options for `UseToolDuration` and quality weighting, especially for power tools, consumable hand tools, and high-quality apparatus.
-- Add phase metadata for exertion and stamina usage. The current tuple only captures seconds and echoes, but runtime phases can carry more behaviour.
-- Add craft-wide start and cancel progs. The helper exposes completion only, even though runtime crafts also support start and cancel hooks.
-- Add first-class support for commodity input characteristic requirements, commodity pile tags, exact-material `SimpleMaterial` inputs, and fixed or copied commodity output characteristics through typed specs.
-- Make validation report all unresolved references with craft name and string text instead of returning `null` silently. That would make large content-suite imports much easier to debug.
-- Add focused tests for every conversion grammar. A simple parser test suite would catch broken regexes before a large stock-content import silently skips crafts.
+If an input is never referenced, it is consumed at phase 1. If a tool is never referenced, it is required in every normal phase. Unreferenced success and fail products default to `failPhase`.


### PR DESCRIPTION
**Summary**
- Expanded the item seeder craft flow with guide-oriented upgrades.
- Added and updated repeatability coverage for item seeder craft additions.
- Updated the related seeder strategy and add-craft guide documentation to match current behavior.

**Testing**
- Not run (not requested)