### PR TITLE
Add AI description suggestions for item skins

### DIFF
--- a/Design Documents/Item Authoring Guidelines.md
+++ b/Design Documents/Item Authoring Guidelines.md
@@ -71,6 +71,8 @@ Skins are important whenever:
 - content should be customised without cloning behaviour-heavy item prototypes
 - Players themselves can write the variants with optional admin review and approval, rather than relying solely on an admin builder workflow
 
+Admins can use `itemskin set suggestdesc [<optional extra context>]` to generate AI-assisted full-description override suggestions for a skin. This is not available to ordinary player skin authors because it can incur external API cost.
+
 ### Writing Blocks
 
 Writing blocks let item descriptions include readable text that depends on language, script, and skill.

--- a/Design Documents/Item_System_Content_Workflows.md
+++ b/Design Documents/Item_System_Content_Workflows.md
@@ -114,6 +114,7 @@ Commonly relevant commands include:
 - `item set sdesc`
 - `item set ldesc`
 - `item set desc`
+- `item set suggestdesc`
 - `item set size`
 - `item set weight`
 - `item set material`
@@ -285,6 +286,8 @@ Skins are item-prototype-adjacent content that override presentation details suc
 From a workflow perspective, skins matter when:
 - the base item prototype is intentionally generic
 - builders need controlled presentation variants without duplicating item behaviour
+
+Skin authors edit these variants with `itemskin set ...`. Admins can also use `itemskin set suggestdesc [<optional extra context>]` to ask the configured description AI for full-description override suggestions. That prompt is deliberately framed as a variant of the base item: it includes the prototype's physical properties and tags, the effective short and long descriptions, the skin's overrides, and the item-description markup available to full descriptions. The AI call is admin-only so ordinary player skin authors cannot create unbounded API cost.
 
 ### Item groups
 Item groups are content-side presentation tools for rooms. They let many similar items collapse into grouped room descriptions instead of flooding room output.

--- a/Design Documents/Item_System_Presentation_and_Integration.md
+++ b/Design Documents/Item_System_Presentation_and_Integration.md
@@ -125,6 +125,8 @@ Skins are important whenever:
 
 When changing item presentation flows, remember that skins may override prototype text.
 
+Admins can request AI-assisted full-description override suggestions with `itemskin set suggestdesc [<optional extra context>]` while editing a skin. The generated prompt treats the skin as a variant rather than a new prototype: it passes the base item properties, effective short and long descriptions, skin-specific overrides, tags, existing full descriptions, and supported item-description markup to the configured description AI. The command is intentionally admin-only because it can incur external API cost.
+
 ## Health, Magic, and Other System Integrations
 ### Health integration
 Items participate in the health system more directly than many engines would expect:

--- a/MudSharpCore/Commands/Modules/ItemBuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/ItemBuilderModule.cs
@@ -1302,12 +1302,32 @@ The syntax to use this command is as follows:
 #3itemskin show <which>#0 - views information about an item skin
 #3itemskin show#0 - views information about your currently editing item skin
 #3itemskin set ...#0 - edits properties of an item skin
+
+{GenericReviewableSearchList}";
+
+        public const string ItemSkinAdminHelp =
+            @$"This command is used to make item skins, which can be applied to items to change their appearance. They can be manually added to items by admins, set to load that way through shops and created via crafts. Players with the correct permissions are allowed to create item skins of their own.
+
+When players are editing item skins they will only be able to edit skins that they originally created.
+
+The syntax to use this command is as follows:
+
+#3itemskin list#0 - lists all of the item skins
+#3itemskin protos#0 - lists all the items that players can create skins for
+#3itemskin edit <which>#0 - begins editing an item skin
+#3itemskin edit new <proto> <name>#0 - creates a new item skin
+#3itemskin clone <old> <new name>#0 - clones an existing item skin to a new one
+#3itemskin close#0 - stops editing an item skin
+#3itemskin show <which>#0 - views information about an item skin
+#3itemskin show#0 - views information about your currently editing item skin
+#3itemskin set ...#0 - edits properties of an item skin
+#3itemskin set suggestdesc [<optional extra context>]#0 - asks your configured AI model to suggest a full description override
 #3itemskin review all|mine|<builder name>|<id>#0 - opens the specified item skins for review and approval
 
 {GenericReviewableSearchList}";
 
         [PlayerCommand("ItemSkin", "itemskin", "is")]
-        [HelpInfo("itemskin", ItemSkinHelp, AutoHelp.HelpArgOrNoArg)]
+        [HelpInfo("itemskin", ItemSkinHelp, AutoHelp.HelpArgOrNoArg, ItemSkinAdminHelp)]
         protected static void ItemSkin(ICharacter actor, string input)
         {
             StringStack ss = new(input.RemoveFirstWord());

--- a/MudSharpCore/GameItems/GameItemSkin.cs
+++ b/MudSharpCore/GameItems/GameItemSkin.cs
@@ -3,9 +3,14 @@ using MudSharp.Character;
 using MudSharp.Commands.Trees;
 using MudSharp.Database;
 using MudSharp.Editor;
+using MudSharp.Effects.Concrete;
+using MudSharp.Form.Characteristics;
 using MudSharp.Framework;
 using MudSharp.Framework.Revision;
+using MudSharp.Framework.Units;
 using MudSharp.FutureProg;
+using MudSharp.GameItems.Prototypes;
+using MudSharp.OpenAI;
 using MudSharp.PerceptionEngine;
 using MudSharp.Work.Crafts;
 using System;
@@ -193,6 +198,21 @@ public class GameItemSkin : EditableItem, IGameItemSkin
     public const string BuildingHelp = @"You can use the following options with this command:
 
 	#3name <name>#0 - renames this skin
+	#3prog <prog>#0 - sets the prog that controls use of this skin
+	#3itemname <name>#0 - sets an override for the item's name
+	#3itemname#0 - clears an override for the item's name
+	#3sdesc <sdesc>#0 - sets an override for the item's short description
+	#3sdesc#0 - clears an override for the item's short description
+	#3ldesc <ldesc>#0 - sets an override for the item's long description
+	#3ldesc#0 - clears an override for the item's long description
+	#3desc#0 - drops you into an editor to enter an override description
+	#3desc clear#0 - clears an override for the item's full description
+	#3quality <quality>#0 - sets an overriding quality for the base item
+	#3quality#0 - clears an override for the item's quality";
+
+    public const string AdminBuildingHelp = @"You can use the following options with this command:
+
+	#3name <name>#0 - renames this skin
 	#3public#0 - toggles this skin being public (admin only)
 	#3prog <prog>#0 - sets the prog that controls use of this skin
 	#3itemname <name>#0 - sets an override for the item's name
@@ -203,6 +223,7 @@ public class GameItemSkin : EditableItem, IGameItemSkin
 	#3ldesc#0 - clears an override for the item's long description
 	#3desc#0 - drops you into an editor to enter an override description
 	#3desc clear#0 - clears an override for the item's full description
+	#3suggestdesc [<optional extra context>]#0 - asks your configured AI model to suggest a description (admin only)
 	#3quality <quality>#0 - sets an overriding quality for the base item
 	#3quality#0 - clears an override for the item's quality";
 
@@ -224,6 +245,9 @@ public class GameItemSkin : EditableItem, IGameItemSkin
             case "itemdesc":
             case "desc":
                 return BuildingCommandFDesc(actor, command);
+            case "suggestdesc":
+            case "suggestdescription":
+                return BuildingCommandSuggestDesc(actor, command);
             case "quality":
                 return BuildingCommandQuality(actor, command);
             case "prog":
@@ -231,7 +255,7 @@ public class GameItemSkin : EditableItem, IGameItemSkin
             case "public":
                 return BuildingCommandPublic(actor, command);
             default:
-                actor.OutputHandler.Send(BuildingHelp.SubstituteANSIColour());
+                actor.OutputHandler.Send((actor.IsAdministrator() ? AdminBuildingHelp : BuildingHelp).SubstituteANSIColour());
                 return false;
         }
     }
@@ -338,6 +362,206 @@ public class GameItemSkin : EditableItem, IGameItemSkin
         FullDescription = text.Fullstop().ProperSentences();
         Changed = true;
         handler.Send($"You update the full description override for this skin to:\n\n{FullDescription.Wrap(80, "\t")}");
+    }
+
+    private bool BuildingCommandSuggestDesc(ICharacter actor, StringStack command)
+    {
+        if (!actor.IsAdministrator())
+        {
+            actor.OutputHandler.Send("Only administrators can request AI description suggestions for item skins.");
+            return false;
+        }
+
+        var effectiveShortDescription = ShortDescription ?? ItemProto.ShortDescription;
+        var effectiveLongDescription = LongDescription ?? (ItemProto.OverridesLongDescription ? ItemProto.LongDescription : null);
+        var effectiveQuality = Quality ?? ItemProto.BaseItemQuality;
+        var differences = new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(ItemName))
+        {
+            differences.Add($"Item name override: \"{ItemName}\".");
+        }
+
+        if (!string.IsNullOrWhiteSpace(ShortDescription))
+        {
+            differences.Add($"Short description override: \"{ShortDescription}\".");
+        }
+
+        if (!string.IsNullOrWhiteSpace(LongDescription))
+        {
+            differences.Add($"Long description override: \"{LongDescription}\".");
+        }
+
+        if (!string.IsNullOrWhiteSpace(FullDescription))
+        {
+            differences.Add("Existing full description override is supplied below for possible refinement.");
+        }
+
+        if (Quality is not null)
+        {
+            differences.Add($"Quality override: {Quality.Value.DescribeEnum(true)}.");
+        }
+
+        StringBuilder sb = new();
+        sb.AppendLine(Futuremud.Games.First().GetStaticString("GPT_ItemSuggestionPrompt"));
+        sb.AppendLine();
+        sb.AppendLine($"You are suggesting full-description overrides for an item skin named \"{Name}\". An item skin is a presentation variant for an existing item prototype; it changes how the same underlying item appears without changing its mechanics. Keep the base item's purpose and physical constraints intact, but make the description fit the skin's variant details.");
+        sb.AppendLine();
+        sb.AppendLine($"Base item prototype: {ItemProto.EditHeader()}.");
+        sb.AppendLine($"Base short description: \"{ItemProto.ShortDescription}\".");
+        sb.AppendLine($"Variant short description to match: \"{effectiveShortDescription}\".");
+        sb.AppendLine($"Variant item name: \"{ItemName ?? ItemProto.Name}\".");
+        if (!string.IsNullOrWhiteSpace(effectiveLongDescription))
+        {
+            sb.AppendLine($"Variant long description: \"{effectiveLongDescription}\".");
+        }
+
+        sb.AppendLine($"The item is made mostly out of {ItemProto.Material?.Name ?? "an unknown material"}. Its effective quality for this skin is {effectiveQuality.DescribeEnum(true)}, and it weighs {Gameworld.UnitManager.Describe(ItemProto.Weight, UnitType.Mass, "metric")} (but don't refer to the specific number in the description, though you can describe the weight in other non-numeric terms). It's {ItemProto.Size.DescribeEnum(true)} relative to a person.");
+        sb.AppendLine();
+
+        if (differences.Any())
+        {
+            sb.AppendLine("The skin differs from the base prototype as follows:");
+            foreach (var difference in differences)
+            {
+                sb.AppendLine($"\t{difference}");
+            }
+        }
+        else
+        {
+            sb.AppendLine("This skin does not currently override any presentation fields other than its builder-facing skin name. Use any extra builder context below as the requested variant direction.");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("Base full description for context:");
+        sb.AppendLine(ItemProto.FullDescription);
+        if (!string.IsNullOrWhiteSpace(FullDescription))
+        {
+            sb.AppendLine();
+            sb.AppendLine("Existing skin full description override to replace or improve:");
+            sb.AppendLine(FullDescription);
+        }
+
+        if (ItemProto.Tags.Any())
+        {
+            sb.AppendLine();
+            sb.AppendLine("It has been tagged with the following prompts:");
+            foreach (var tag in ItemProto.Tags)
+            {
+                sb.AppendLine($"\t{tag.FullName}");
+            }
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("The full description you suggest may use these item-description markup options, but only where they genuinely help:");
+        sb.AppendLine("\t@material - replaced with the item's material");
+        sb.AppendLine("\t@matdesc - replaced with the item's material description");
+        sb.AppendLine("\twriting{language,script,style=...,colour=...,skill|minskill}{text if you can understand}{text if you cant}");
+        sb.AppendLine("\tcheck{trait,minvalue}{text if the trait is >= value}{text if not}");
+
+        var variableComponent = ItemProto.Components.OfType<VariableGameItemComponentProto>().FirstOrDefault();
+        if (variableComponent is not null)
+        {
+            sb.AppendLine();
+            sb.AppendLine("When the engine uses this item it will substitute values for a few variables. In the description that you write, you should use only the pattern of the variable rather than any of its actual values. For example, if there is a variable called $colour then you should use that variable to refer to the colour of the item rather than writing in an actual colour. If there are multiple similar variables you can decide what part of each item each of the variables refer to. Each variation has a plain, basic and fancy variety - they refer to the same underlying variable but present the text in a different format. The following variables (and some examples of what the engine may render them as, so you can match your grammar to their usage) are available:");
+            foreach (var variable in variableComponent.CharacteristicDefinitions)
+            {
+                var profile = variableComponent.ProfileFor(variable);
+                var random = new List<ICharacteristicValue>
+                {
+                    profile.GetRandomCharacteristic(),
+                    profile.GetRandomCharacteristic(),
+                    profile.GetRandomCharacteristic(),
+                    profile.GetRandomCharacteristic(),
+                    profile.GetRandomCharacteristic(),
+                    profile.GetRandomCharacteristic(),
+                    profile.GetRandomCharacteristic(),
+                    profile.GetRandomCharacteristic(),
+                    profile.GetRandomCharacteristic(),
+                    profile.GetRandomCharacteristic(),
+                    profile.GetRandomCharacteristic(),
+                    profile.GetRandomCharacteristic()
+                };
+                sb.AppendLine($"\t${variable.Pattern.TransformRegexIntoPattern()} - Examples: {random.Select(x => x.GetValue).ListToString()}");
+            }
+
+            sb.AppendLine("You should use each variable at least once in the description.");
+        }
+
+        sb.AppendLine("Your response should only use characters from the ISO-8859-1 page (i.e. Latin1).");
+
+        if (!command.IsFinished)
+        {
+            sb.AppendLine();
+            sb.AppendLine("Additional builder context:");
+            sb.AppendLine(command.SafeRemainingArgument);
+        }
+
+        void GPTCallback(string text)
+        {
+            var descriptions = text.Split('#', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            StringBuilder sb = new();
+            sb.AppendLine($"Your AI model has made the following suggestions for descriptions for item skin {Name.ColourName()} ({effectiveShortDescription.ColourObject()}):");
+            var i = 1;
+            foreach (var desc in descriptions)
+            {
+                sb.AppendLine();
+                sb.AppendLine($"Suggestion {i++.ToString("N0", actor)}".GetLineWithTitle(actor, Telnet.Cyan, Telnet.BoldWhite));
+                sb.AppendLine();
+                sb.AppendLine(desc.Wrap(actor.InnerLineFormatLength, "\t"));
+            }
+
+            sb.AppendLine();
+            sb.AppendLine($"You can apply one of these by using the syntax {"accept desc <n>".Colour(Telnet.Cyan)}, such as {"accept desc 1".Colour(Telnet.Cyan)}.");
+            actor.OutputHandler.Send(sb.ToString());
+            actor.AddEffect(new Accept(actor, new GenericProposal
+            {
+                DescriptionString = "Applying an AI description suggestion to an item skin",
+                AcceptAction = text =>
+                {
+                    if (!int.TryParse(text, out var value) || value < 1 || value > descriptions.Length)
+                    {
+                        actor.OutputHandler.Send("You did not specify a valid description. If you still want to use the descriptions, you'll have to copy them in manually.");
+                        return;
+                    }
+
+                    FullDescription = descriptions[value - 1];
+                    Changed = true;
+                    actor.OutputHandler.Send($"You set the full description override for this item skin based on the {value.ToOrdinal()} suggestion.");
+                },
+                RejectAction = text => { actor.OutputHandler.Send("You decide not to use any of the suggestions."); },
+                ExpireAction = () => { actor.OutputHandler.Send("You decide not to use any of the suggestions."); },
+                Keywords = new List<string> { "description", "suggestion", "skin" }
+            }), TimeSpan.FromSeconds(120));
+        }
+
+        switch (actor.Gameworld.GetStaticConfiguration("DescSuggestionAIModel").ToLowerInvariant())
+        {
+            case "openai":
+                var descModel = Futuremud.Games.First().GetStaticConfiguration("GPT_DescSuggestion_Model");
+                if (!OpenAIHandler.MakeGPTRequest(sb.ToString(), actor.Gameworld.GetStaticString("GPT_ItemSuggestionFinalWord"), GPTCallback, descModel))
+                {
+                    actor.OutputHandler.Send("Your GPT Model is not set up correctly, so you cannot get any suggestions.");
+                    return false;
+                }
+
+                break;
+            case "anthropic":
+                var anthropicModel = Futuremud.Games.First().GetStaticConfiguration("AnthropicDefaultModel");
+                if (!OpenAIHandler.MakeAnthropicRequest(sb.ToString(), actor.Gameworld.GetStaticString("GPT_ItemSuggestionFinalWord"), GPTCallback, anthropicModel))
+                {
+                    actor.OutputHandler.Send("Your Anthropic Model is not set up correctly, so you cannot get any suggestions.");
+                    return false;
+                }
+
+                break;
+            default:
+                actor.OutputHandler.Send($"The value of the #3DescSuggestionAIModel#0 static configuration must be either #3openai#0 or #3anthropic#0.");
+                return false;
+        }
+
+        actor.OutputHandler.Send("You send your request off to the AI model.");
+        return true;
     }
 
     private bool BuildingCommandQuality(ICharacter actor, StringStack command)


### PR DESCRIPTION
## Summary
- Add admin-only `itemskin set suggestdesc [<optional extra context>]` support for item skin full-description override suggestions.
- Build the prompt from the existing item description suggestion flow, with skin variant context, overrides, base item properties, tags, item markup, and variable component details.
- Split item-skin help so the AI option is only shown in admin help, and update item-system docs for the new workflow.

## Validation
- `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510` (736 passed)

Note: build still reports existing unrelated analyzer warnings for `FunctionStatement` and `GeneralActiveCheckBonus`.