### PR TITLE
Add magic FutureProg functions

### DIFF
--- a/Design Documents/Magic_System_Capabilities_Resources_and_Generators.md
+++ b/Design Documents/Magic_System_Capabilities_Resources_and_Generators.md
@@ -286,6 +286,18 @@ Practical builder guidance:
 - if a resource should exist only for characters, set the item and room predicates to false
 - use the short name for compact cost displays and prompts
 
+### FutureProg Resource Helpers
+FutureProg can inspect and alter live resource levels on any `IHaveMagicResource` holder, which means characters, items, and rooms/cells.
+
+Current helpers are:
+
+- `magicresourcelevel(thing, resource)`
+- `setmagicresource(thing, resource, amount)` / `setmagicresourcelevel(thing, resource, amount)`
+- `addmagicresource(thing, resource, amount)` / `addmagicresourcelevel(thing, resource, amount)`
+- `subtractmagicresource(thing, resource, amount)` / `subtractmagicresourcelevel(thing, resource, amount)`
+
+The `resource` argument can be the resource name/id as text or the numeric id. Mutations route through the holder's normal `AddResource` behavior, so the resulting level is clamped to the resource cap and never below zero. All mutation helpers return the resulting resource level.
+
 ### Seeder and Data Author Workflow
 There is no dedicated magic resource seeder in `DatabaseSeeder`.
 

--- a/Design Documents/Magic_System_Implemented_Types.md
+++ b/Design Documents/Magic_System_Implemented_Types.md
@@ -34,6 +34,22 @@ It is intended for:
 | `linear` | `LinearTimeBasedGenerator` | Regenerator | Switch dispatch in `MudSharpCore/Magic/Generators/BaseMagicResourceGenerator.cs` | Yes | Adds a fixed amount of one resource per minute |
 | `state` | `StateGenerator` | Regenerator | Switch dispatch in `MudSharpCore/Magic/Generators/BaseMagicResourceGenerator.cs` | Yes | Adds one or more resources per minute based on boolean state progs |
 
+## FutureProg Magic Helpers
+
+| Function or property | Subsystem | Purpose |
+| --- | --- | --- |
+| `magicresourcelevel` | Resources | Reads a character, item, or room magic resource level by resource name/id or numeric id |
+| `setmagicresource`, `setmagicresourcelevel` | Resources | Sets a character, item, or room magic resource level and returns the clamped result |
+| `addmagicresource`, `addmagicresourcelevel` | Resources | Adds to a character, item, or room magic resource level and returns the clamped result |
+| `subtractmagicresource`, `subtractmagicresourcelevel` | Resources | Subtracts from a character, item, or room magic resource level and returns the clamped result |
+| `magiccapabilities(character)`, `character.magiccapabilities` | Capabilities | Returns the character's currently applicable magic capabilities |
+| `knownspells(character)`, `character.knownspells` | Spells | Returns spells whose known-spell prog says the character knows them |
+| `castablespells(character)`, `character.castablespells` | Spells | Returns ready, known spells that use a cast trigger |
+| `castablespellsnow(character)`, `character.castablespellsnow` | Spells | Returns ready, known cast-trigger spells currently castable against the character at some permitted power |
+| `cancastspell`, `cancastspellnow` | Spells | Checks general spell availability or current lockout/resource/material preconditions without performing the cast |
+| `activespells`, `activespelleffects` | Spell effects | Reads retained `MagicSpellParent` state on a character |
+| `spellremainingduration`, `spellduration`, `setspellduration`, `addspellduration`, `subtractspellduration`, `removespell` | Spell effects | Reads, changes, or removes active spell-parent effects for a specific spell on a character |
+
 ## Power Types
 Current count: 32 power tokens, including 31 builder-creatable tokens and the non-builder `armor` runtime alias. V4 added 9 builder-creatable psionic powers, and the Old SOI parity slice added 7 more psionic power tokens in per-power files under `MudSharpCore/Magic/Powers/`.
 

--- a/Design Documents/Magic_System_Spells.md
+++ b/Design Documents/Magic_System_Spells.md
@@ -174,14 +174,48 @@ Some effects now also rely on trigger-supplied additional parameters:
 - `exit` from the `exit` and `characterexit` triggers
 - `room` from the `progcharacterroom` and `progitemroom` triggers
 
-### 13. Exclusivity and lockouts
+### 13. FutureProg inspection and control
+FutureProg can inspect and manipulate the live spell state without going through player command parsing.
+
+Character dot-properties expose:
+
+- `magiccapabilities`
+- `knownspells`
+- `castablespells`
+- `castablespellsnow`
+
+The matching built-in functions are useful when the source character is not already the object being dereferenced:
+
+- `magiccapabilities(character)`
+- `knownspells(character)`
+- `castablespells(character)`
+- `castablespellsnow(character)`
+- `cancastspell(character, spell)`
+- `cancastspellnow(character, spell[, target][, power])`
+
+`cancastspell` checks the general command surface: capability school access, known-spell prog, spell readiness, and cast-trigger availability. `cancastspellnow` also checks current lockouts, available magic resources, material requirements, target-null rules, and the requested or any permitted spell power. It does not perform the random casting check, consume resources, execute material plans, run crimes, or consult target wards.
+
+Active spell parent effects on a character are exposed through:
+
+- `activespells(character)`
+- `activespelleffects(character)`
+- `activespelleffects(character, spell)`
+- `spellremainingduration(character, spell)` / `spellduration(character, spell)`
+- `setspellduration(character, spell, duration)`
+- `addspellduration(character, spell, duration)`
+- `subtractspellduration(character, spell, duration)`
+- `removespell(character, spell)`
+
+Duration helpers operate on retained `MagicSpellParent` effects. The retrieval helper returns the longest remaining scheduled duration, or zero when no matching effect is scheduled. Set can turn an unscheduled spell-parent effect into a scheduled one; add and subtract only alter already scheduled spell-parent effects. Remove clears the parent and its owned child effects.
+
+### 14. Exclusivity and lockouts
 Spells can enforce:
 
 - an `ExclusiveDelay`, which blocks all spell casting for a time
 - a `NonExclusiveDelay`, which blocks same-school spells for a time
 - exclusive applied effects, which replace prior parent effects from the same spell instead of stacking
 
-### 14. Ready-for-game validation
+### 15. Ready-for-game validation
 `MagicSpell.ReadyForGame` verifies that the spell has enough data to function safely.
 
 Current readiness checks include:

--- a/FutureMUDLibrary/Magic/IMagicSpell.cs
+++ b/FutureMUDLibrary/Magic/IMagicSpell.cs
@@ -25,6 +25,9 @@ namespace MudSharp.Magic
 
         string Blurb { get; }
         string Description { get; }
+        bool CharacterKnowsSpell(ICharacter magician);
+        bool CharacterCanCast(ICharacter magician, IPerceivable target);
+        bool CharacterCanCast(ICharacter magician, IPerceivable target, SpellPower power);
         void CastSpell(ICharacter magician, IPerceivable target, SpellPower power, params SpellAdditionalParameter[] additionalParameters);
         bool ReadyForGame { get; }
         string WhyNotReadyForGame(ICharacter builder);

--- a/MudSharpCore Unit Tests/MagicFutureProgFunctionTests.cs
+++ b/MudSharpCore Unit Tests/MagicFutureProgFunctionTests.cs
@@ -1,0 +1,253 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Character;
+using MudSharp.Effects.Concrete;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.FutureProg.Functions;
+using MudSharp.FutureProg.Variables;
+using MudSharp.Magic;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class MagicFutureProgFunctionTests
+{
+	[TestMethod]
+	public void MagicFutureProgFunctions_RegisterExpectedSurface()
+	{
+		FutureProgTestBootstrap.EnsureInitialised();
+
+		var names = FutureProg.GetFunctionCompilerInformations()
+		                      .Where(x => x.Category.EqualTo("Magic"))
+		                      .Select(x => x.FunctionName.ToLowerInvariant())
+		                      .ToHashSet();
+
+		foreach (var expected in new[]
+		         {
+			         "magicresourcelevel",
+			         "setmagicresource",
+			         "addmagicresource",
+			         "subtractmagicresource",
+			         "magiccapabilities",
+			         "knownspells",
+			         "castablespells",
+			         "castablespellsnow",
+			         "cancastspell",
+			         "cancastspellnow",
+			         "activespells",
+			         "activespelleffects",
+			         "spellremainingduration",
+			         "spellduration",
+			         "setspellduration",
+			         "addspellduration",
+			         "subtractspellduration",
+			         "removespell"
+		         })
+		{
+			Assert.IsTrue(names.Contains(expected), $"Missing FutureProg magic function {expected}.");
+		}
+	}
+
+	[TestMethod]
+	public void MagicResourceFunctions_SetAddSubtractClampAndReturnCurrentLevel()
+	{
+		var resource = CreateFrameworkItemMock<IMagicResource>(1, "Essence");
+		resource.Setup(x => x.ResourceCap(It.IsAny<IHaveMagicResource>())).Returns(100.0);
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.MagicResources).Returns(CreateCollectionMock(resource.Object).Object);
+		var haver = new TestMagicResourceHaver();
+		var variables = new Mock<IVariableSpace>().Object;
+
+		var set = Compile("setmagicresourcelevel", gameworld.Object,
+			Constant(haver, ProgVariableTypes.MagicResourceHaver),
+			Constant("Essence", ProgVariableTypes.Text),
+			Constant(150.0M, ProgVariableTypes.Number));
+
+		Assert.AreEqual(StatementResult.Normal, set.Execute(variables));
+		Assert.AreEqual(100.0M, set.Result.GetObject);
+
+		var subtract = Compile("subtractmagicresource", gameworld.Object,
+			Constant(haver, ProgVariableTypes.MagicResourceHaver),
+			Constant(1.0M, ProgVariableTypes.Number),
+			Constant(25.0M, ProgVariableTypes.Number));
+
+		Assert.AreEqual(StatementResult.Normal, subtract.Execute(variables));
+		Assert.AreEqual(75.0M, subtract.Result.GetObject);
+		Assert.AreEqual(75.0, haver.MagicResourceAmounts[resource.Object]);
+	}
+
+	[TestMethod]
+	public void CanCastSpellFunctions_UseGeneralAndCurrentSpellChecks()
+	{
+		var character = new Mock<ICharacter>();
+		var spell = new Mock<IMagicSpell>();
+		var trigger = new Mock<ICastMagicTrigger>();
+		var variables = new Mock<IVariableSpace>().Object;
+
+		spell.Setup(x => x.CharacterKnowsSpell(character.Object)).Returns(true);
+		spell.SetupGet(x => x.ReadyForGame).Returns(true);
+		spell.SetupGet(x => x.Trigger).Returns(trigger.Object);
+		spell.Setup(x => x.CharacterCanCast(character.Object, character.Object)).Returns(true);
+
+		var general = Compile("cancastspell", FutureProgTestBootstrap.Gameworld,
+			Constant(character.Object, ProgVariableTypes.Character),
+			Constant(spell.Object, ProgVariableTypes.MagicSpell));
+		var now = Compile("cancastspellnow", FutureProgTestBootstrap.Gameworld,
+			Constant(character.Object, ProgVariableTypes.Character),
+			Constant(spell.Object, ProgVariableTypes.MagicSpell));
+
+		Assert.AreEqual(StatementResult.Normal, general.Execute(variables));
+		Assert.AreEqual(true, general.Result.GetObject);
+		Assert.AreEqual(StatementResult.Normal, now.Execute(variables));
+		Assert.AreEqual(true, now.Result.GetObject);
+	}
+
+	[TestMethod]
+	public void SpellDurationFunctions_QueryRescheduleAndRemoveMatchingParents()
+	{
+		var gameworld = new Mock<IFuturemud>();
+		var character = new Mock<ICharacter>();
+		var spell = CreateFrameworkItemMock<IMagicSpell>(10, "Ward");
+		var caster = new Mock<ICharacter>();
+		caster.SetupGet(x => x.Id).Returns(25);
+		character.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		character.SetupGet(x => x.Id).Returns(26);
+		character.SetupGet(x => x.FrameworkItemType).Returns("Character");
+		spell.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		var parent = new MagicSpellParent(character.Object, spell.Object, caster.Object);
+		character.Setup(x => x.EffectsOfType<MagicSpellParent>(It.IsAny<Predicate<MagicSpellParent>>()))
+		         .Returns<Predicate<MagicSpellParent>>(predicate => new[] { parent }.Where(x => predicate(x)));
+		character.Setup(x => x.ScheduledDuration(parent)).Returns(TimeSpan.FromSeconds(12));
+		var variables = new Mock<IVariableSpace>().Object;
+
+		var duration = Compile("spellremainingduration", gameworld.Object,
+			Constant(character.Object, ProgVariableTypes.Character),
+			Constant(spell.Object, ProgVariableTypes.MagicSpell));
+		var set = Compile("setspellduration", gameworld.Object,
+			Constant(character.Object, ProgVariableTypes.Character),
+			Constant(spell.Object, ProgVariableTypes.MagicSpell),
+			Constant(TimeSpan.FromSeconds(30), ProgVariableTypes.TimeSpan));
+		var remove = Compile("removespell", gameworld.Object,
+			Constant(character.Object, ProgVariableTypes.Character),
+			Constant(spell.Object, ProgVariableTypes.MagicSpell));
+
+		Assert.AreEqual(StatementResult.Normal, duration.Execute(variables));
+		Assert.AreEqual(TimeSpan.FromSeconds(12), duration.Result.GetObject);
+		Assert.AreEqual(StatementResult.Normal, set.Execute(variables));
+		Assert.AreEqual(1.0M, set.Result.GetObject);
+		character.Verify(x => x.Reschedule(parent, TimeSpan.FromSeconds(30)), Times.Once);
+		Assert.AreEqual(StatementResult.Normal, remove.Execute(variables));
+		Assert.AreEqual(1.0M, remove.Result.GetObject);
+		character.Verify(x => x.RemoveEffect(parent, true), Times.Once);
+	}
+
+	private static IFunction Compile(string name, IFuturemud gameworld, params IFunction[] parameters)
+	{
+		FutureProgTestBootstrap.EnsureInitialised();
+		var types = parameters.Select(x => x.ReturnType).ToList();
+		var compiler = FutureProg.GetFunctionCompilerInformations()
+		                         .Single(x => x.FunctionName.EqualTo(name) &&
+		                                      x.Parameters.SequenceEqual(types, FutureProgVariableComparer.Instance));
+
+		return compiler.CompilerFunction(parameters.ToList(), gameworld);
+	}
+
+	private static IFunction Constant(object value, ProgVariableTypes type)
+	{
+		return new ConstantFunctionStub(new ObjectVariable(value, type));
+	}
+
+	private static Mock<IUneditableAll<T>> CreateCollectionMock<T>(params T[] items) where T : class, IFrameworkItem
+	{
+		var list = items.ToList();
+		var collection = new Mock<IUneditableAll<T>>();
+		collection.SetupGet(x => x.Count).Returns(() => list.Count);
+		collection.As<IEnumerable<T>>().Setup(x => x.GetEnumerator()).Returns(() => list.GetEnumerator());
+		collection.Setup(x => x.Get(It.IsAny<long>())).Returns<long>(id => list.FirstOrDefault(x => x.Id == id));
+		collection.Setup(x => x.GetByName(It.IsAny<string>())).Returns<string>(name =>
+			list.FirstOrDefault(x => x.Name.EqualTo(name)));
+		collection.Setup(x => x.GetByIdOrName(It.IsAny<string>(), It.IsAny<bool>())).Returns<string, bool>((value, _) =>
+			long.TryParse(value, out var id)
+				? list.FirstOrDefault(x => x.Id == id)
+				: list.FirstOrDefault(x => x.Name.EqualTo(value)));
+		return collection;
+	}
+
+	private static Mock<T> CreateFrameworkItemMock<T>(long id, string name) where T : class, IFrameworkItem
+	{
+		var mock = new Mock<T>();
+		mock.SetupGet(x => x.Id).Returns(id);
+		mock.SetupGet(x => x.Name).Returns(name);
+		mock.SetupGet(x => x.FrameworkItemType).Returns(typeof(T).Name);
+		return mock;
+	}
+
+	private sealed class ConstantFunctionStub : IFunction
+	{
+		public ConstantFunctionStub(IProgVariable result)
+		{
+			Result = result;
+			ReturnType = result.Type;
+		}
+
+		public IProgVariable Result { get; private set; }
+		public ProgVariableTypes ReturnType { get; }
+		public string ErrorMessage => string.Empty;
+		public StatementResult ExpectedResult => StatementResult.Normal;
+		public StatementResult Execute(IVariableSpace variables) => StatementResult.Normal;
+		public bool IsReturnOrContainsReturnOnAllBranches() => false;
+	}
+
+	private sealed class ObjectVariable : IProgVariable
+	{
+		public ObjectVariable(object value, ProgVariableTypes type)
+		{
+			GetObject = value;
+			Type = type;
+		}
+
+		public ProgVariableTypes Type { get; }
+		public object GetObject { get; }
+		public IProgVariable GetProperty(string property) => throw new NotSupportedException();
+	}
+
+	private sealed class TestMagicResourceHaver : IHaveMagicResource
+	{
+		private readonly DoubleCounter<IMagicResource> _resources = new();
+
+		public IEnumerable<IMagicResource> MagicResources => _resources.Keys;
+		public IReadOnlyDictionary<IMagicResource, double> MagicResourceAmounts => _resources;
+		public IEnumerable<IMagicResourceRegenerator> MagicResourceGenerators => Enumerable.Empty<IMagicResourceRegenerator>();
+		public bool CanUseResource(IMagicResource resource, double amount) => _resources[resource] >= amount;
+		public bool UseResource(IMagicResource resource, double amount)
+		{
+			if (!CanUseResource(resource, amount))
+			{
+				_resources[resource] = 0;
+				return false;
+			}
+
+			_resources[resource] -= amount;
+			return true;
+		}
+
+		public void AddResource(IMagicResource resource, double amount)
+		{
+			_resources[resource] = Math.Max(0.0, Math.Min(resource.ResourceCap(this), _resources[resource] + amount));
+		}
+
+		public void AddMagicResourceGenerator(IMagicResourceRegenerator generator)
+		{
+		}
+
+		public void RemoveMagicResourceGenerator(IMagicResourceRegenerator generator)
+		{
+		}
+	}
+}

--- a/MudSharpCore/Character/CharacterFutureprogs.cs
+++ b/MudSharpCore/Character/CharacterFutureprogs.cs
@@ -7,6 +7,7 @@ using MudSharp.Effects.Concrete;
 using MudSharp.Framework;
 using MudSharp.FutureProg;
 using MudSharp.FutureProg.Variables;
+using MudSharp.Magic;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -227,6 +228,20 @@ public partial class Character
                 return RidingMount;
             case "riders":
                 return new CollectionVariable(Riders.ToList(), ProgVariableTypes.Character);
+            case "magiccapabilities":
+                return new CollectionVariable(Capabilities.ToList(), ProgVariableTypes.MagicCapability);
+            case "knownspells":
+                return new CollectionVariable(
+                    Gameworld.MagicSpells.Where(x => x.CharacterKnowsSpell(this)).ToList(),
+                    ProgVariableTypes.MagicSpell);
+            case "castablespells":
+                return new CollectionVariable(
+                    Gameworld.MagicSpells.Where(x => x.CharacterKnowsSpell(this) && x.ReadyForGame && x.Trigger is ICastMagicTrigger).ToList(),
+                    ProgVariableTypes.MagicSpell);
+            case "castablespellsnow":
+                return new CollectionVariable(
+                    Gameworld.MagicSpells.Where(x => x.CharacterCanCast(this, this)).ToList(),
+                    ProgVariableTypes.MagicSpell);
             default:
                 return base.GetProperty(property);
         }
@@ -307,6 +322,10 @@ public partial class Character
             { "writings", ProgVariableTypes.Writing | ProgVariableTypes.Collection },
             { "mount", ProgVariableTypes.Character },
             { "riders", ProgVariableTypes.Character | ProgVariableTypes.Collection },
+            { "magiccapabilities", ProgVariableTypes.MagicCapability | ProgVariableTypes.Collection },
+            { "knownspells", ProgVariableTypes.MagicSpell | ProgVariableTypes.Collection },
+            { "castablespells", ProgVariableTypes.MagicSpell | ProgVariableTypes.Collection },
+            { "castablespellsnow", ProgVariableTypes.MagicSpell | ProgVariableTypes.Collection },
         };
     }
 
@@ -380,6 +399,10 @@ public partial class Character
             { "possessednpc", "Returns true if this character is an NPC and has an admin possessing / switched into them"},
             { "mount", "returns the mount this character is riding, if any (can be null)" },
             { "riders", "returns a collection of all characters currently riding this character" },
+            { "magiccapabilities", "A collection of all magic capabilities currently applying to the character" },
+            { "knownspells", "A collection of all ready or unready magic spells whose known-spell prog says the character knows them" },
+            { "castablespells", "A collection of all ready, known magic spells that use a cast trigger" },
+            { "castablespellsnow", "A collection of all ready, known cast-trigger spells the character can cast right now against themself at any permitted power" },
         };
     }
 

--- a/MudSharpCore/FutureProg/Functions/Magic/MagicResourceAndSpellFunctions.cs
+++ b/MudSharpCore/FutureProg/Functions/Magic/MagicResourceAndSpellFunctions.cs
@@ -1,0 +1,692 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Effects;
+using MudSharp.Effects.Concrete;
+using MudSharp.Framework;
+using MudSharp.FutureProg.Variables;
+using MudSharp.Magic;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MudSharp.FutureProg.Functions.Magic;
+
+internal abstract class MagicBuiltInFunctionBase : BuiltInFunction
+{
+	protected MagicBuiltInFunctionBase(IList<IFunction> parameterFunctions, IFuturemud gameworld) : base(parameterFunctions)
+	{
+		Gameworld = gameworld;
+	}
+
+	protected IFuturemud Gameworld { get; }
+
+	protected bool TryGetCharacter(int index, out ICharacter? character)
+	{
+		character = ParameterFunctions[index].Result?.GetObject as ICharacter;
+		if (character is not null)
+		{
+			return true;
+		}
+
+		ErrorMessage = "The character argument cannot be null.";
+		return false;
+	}
+
+	protected bool TryGetSpell(int index, out IMagicSpell? spell)
+	{
+		spell = ParameterFunctions[index].Result?.GetObject as IMagicSpell;
+		if (spell is not null)
+		{
+			return true;
+		}
+
+		ErrorMessage = "The magic spell argument cannot be null.";
+		return false;
+	}
+
+	protected bool TryGetMagicResource(int index, bool useId, out IMagicResource? resource)
+	{
+		resource = null;
+		var reference = ParameterFunctions[index].Result?.GetObject;
+		if (reference is null)
+		{
+			ErrorMessage = "The magic resource argument cannot be null.";
+			return false;
+		}
+
+		resource = useId
+			? Gameworld.MagicResources.Get((long)(decimal)reference)
+			: Gameworld.MagicResources.GetByIdOrName(reference.ToString() ?? string.Empty);
+
+		if (resource is not null)
+		{
+			return true;
+		}
+
+		ErrorMessage = $"There was no magic resource found with reference {reference}.";
+		return false;
+	}
+
+	protected bool TryGetSpellPower(int index, out SpellPower power)
+	{
+		var reference = ParameterFunctions[index].Result?.GetObject?.ToString() ?? string.Empty;
+		if (reference.TryParseEnum<SpellPower>(out power))
+		{
+			return true;
+		}
+
+		foreach (var value in Enum.GetValues<SpellPower>())
+		{
+			if (value.DescribeEnum().EqualTo(reference))
+			{
+				power = value;
+				return true;
+			}
+		}
+
+		ErrorMessage =
+			$"The text {reference} is not a valid spell power. Valid values are {Enum.GetValues<SpellPower>().Select(x => x.DescribeEnum()).ListToString()}.";
+		return false;
+	}
+
+	protected static IEnumerable<MagicSpellParent> ActiveSpellParents(ICharacter character, IMagicSpell? spell = null)
+	{
+		return character.EffectsOfType<MagicSpellParent>(x => x.Applies() && (spell is null || x.Spell == spell));
+	}
+}
+
+internal class MagicResourceLevelFunction : MagicBuiltInFunctionBase
+{
+	private readonly bool _useId;
+
+	private MagicResourceLevelFunction(IList<IFunction> parameterFunctions, IFuturemud gameworld, bool useId) :
+		base(parameterFunctions, gameworld)
+	{
+		_useId = useId;
+	}
+
+	public override ProgVariableTypes ReturnType { get => ProgVariableTypes.Number; protected set { } }
+
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		if (base.Execute(variables) == StatementResult.Error)
+		{
+			return StatementResult.Error;
+		}
+
+		if (ParameterFunctions[0].Result?.GetObject is not IHaveMagicResource haver)
+		{
+			ErrorMessage = "The magic resource holder argument cannot be null.";
+			return StatementResult.Error;
+		}
+
+		if (!TryGetMagicResource(1, _useId, out var resource))
+		{
+			return StatementResult.Error;
+		}
+
+		Result = new NumberVariable(haver.MagicResourceAmounts.TryGetValue(resource!, out var amount) ? amount : 0.0);
+		return StatementResult.Normal;
+	}
+
+	public static void RegisterFunctionCompiler()
+	{
+		Register(false, ProgVariableTypes.Text, "resource", "The name or id of the magic resource to inspect");
+		Register(true, ProgVariableTypes.Number, "resourceId", "The id of the magic resource to inspect");
+	}
+
+	private static void Register(bool useId, ProgVariableTypes resourceType, string resourceName, string resourceHelp)
+	{
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			"magicresourcelevel",
+			new[] { ProgVariableTypes.MagicResourceHaver, resourceType },
+			(pars, gameworld) => new MagicResourceLevelFunction(pars, gameworld, useId),
+			new[] { "thing", resourceName },
+			new[] { "The character, item, or room whose magic resource level should be inspected", resourceHelp },
+			"Returns the current amount of the specified magic resource on a character, item, or room.",
+			"Magic",
+			ProgVariableTypes.Number));
+	}
+}
+
+internal class MagicResourceMutationFunction : MagicBuiltInFunctionBase
+{
+	private enum MutationMode
+	{
+		Set,
+		Add,
+		Subtract
+	}
+
+	private readonly MutationMode _mode;
+	private readonly bool _useId;
+
+	private MagicResourceMutationFunction(IList<IFunction> parameterFunctions, IFuturemud gameworld,
+		MutationMode mode, bool useId) : base(parameterFunctions, gameworld)
+	{
+		_mode = mode;
+		_useId = useId;
+	}
+
+	public override ProgVariableTypes ReturnType { get => ProgVariableTypes.Number; protected set { } }
+
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		if (base.Execute(variables) == StatementResult.Error)
+		{
+			return StatementResult.Error;
+		}
+
+		if (ParameterFunctions[0].Result?.GetObject is not IHaveMagicResource haver)
+		{
+			ErrorMessage = "The magic resource holder argument cannot be null.";
+			return StatementResult.Error;
+		}
+
+		if (!TryGetMagicResource(1, _useId, out var resource))
+		{
+			return StatementResult.Error;
+		}
+
+		var amount = Convert.ToDouble(ParameterFunctions[2].Result?.GetObject ?? 0.0M);
+		var current = haver.MagicResourceAmounts.TryGetValue(resource!, out var value) ? value : 0.0;
+		var delta = _mode switch
+		{
+			MutationMode.Set => amount - current,
+			MutationMode.Add => amount,
+			MutationMode.Subtract => -amount,
+			_ => throw new ApplicationException("Unknown magic resource mutation mode.")
+		};
+
+		haver.AddResource(resource!, delta);
+		Result = new NumberVariable(haver.MagicResourceAmounts.TryGetValue(resource!, out var result) ? result : 0.0);
+		return StatementResult.Normal;
+	}
+
+	public static void RegisterFunctionCompiler()
+	{
+		Register("setmagicresource", MutationMode.Set);
+		Register("setmagicresourcelevel", MutationMode.Set);
+		Register("addmagicresource", MutationMode.Add);
+		Register("addmagicresourcelevel", MutationMode.Add);
+		Register("subtractmagicresource", MutationMode.Subtract);
+		Register("subtractmagicresourcelevel", MutationMode.Subtract);
+	}
+
+	private static void Register(string name, MutationMode mode)
+	{
+		Register(name, mode, false, ProgVariableTypes.Text, "resource", "The name or id of the magic resource to alter");
+		Register(name, mode, true, ProgVariableTypes.Number, "resourceId", "The id of the magic resource to alter");
+	}
+
+	private static void Register(string name, MutationMode mode, bool useId, ProgVariableTypes resourceType,
+		string resourceName, string resourceHelp)
+	{
+		var verb = mode switch
+		{
+			MutationMode.Set => "Sets",
+			MutationMode.Add => "Adds to",
+			MutationMode.Subtract => "Subtracts from",
+			_ => throw new ApplicationException("Unknown magic resource mutation mode.")
+		};
+
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			name,
+			new[] { ProgVariableTypes.MagicResourceHaver, resourceType, ProgVariableTypes.Number },
+			(pars, gameworld) => new MagicResourceMutationFunction(pars, gameworld, mode, useId),
+			new[] { "thing", resourceName, "amount" },
+			new[]
+			{
+				"The character, item, or room whose magic resource level should be altered",
+				resourceHelp,
+				"The amount to set, add, or subtract"
+			},
+			$"{verb} the specified magic resource on a character, item, or room and returns the resulting clamped amount.",
+			"Magic",
+			ProgVariableTypes.Number));
+	}
+}
+
+internal class MagicCharacterCollectionFunction : MagicBuiltInFunctionBase
+{
+	private enum CollectionMode
+	{
+		Capabilities,
+		KnownSpells,
+		CastableSpells,
+		CastableSpellsNow
+	}
+
+	private readonly CollectionMode _mode;
+	private readonly ProgVariableTypes _returnType;
+
+	private MagicCharacterCollectionFunction(IList<IFunction> parameterFunctions, IFuturemud gameworld,
+		CollectionMode mode, ProgVariableTypes returnType) : base(parameterFunctions, gameworld)
+	{
+		_mode = mode;
+		_returnType = returnType;
+	}
+
+	public override ProgVariableTypes ReturnType { get => _returnType; protected set { } }
+
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		if (base.Execute(variables) == StatementResult.Error)
+		{
+			return StatementResult.Error;
+		}
+
+		if (!TryGetCharacter(0, out var character))
+		{
+			return StatementResult.Error;
+		}
+
+		Result = _mode switch
+		{
+			CollectionMode.Capabilities => new CollectionVariable(character!.Capabilities.ToList(),
+				ProgVariableTypes.MagicCapability),
+			CollectionMode.KnownSpells => new CollectionVariable(
+				character!.Gameworld.MagicSpells.Where(x => x.CharacterKnowsSpell(character)).ToList(),
+				ProgVariableTypes.MagicSpell),
+			CollectionMode.CastableSpells => new CollectionVariable(
+				character!.Gameworld.MagicSpells
+				          .Where(x => x.CharacterKnowsSpell(character) && x.ReadyForGame && x.Trigger is ICastMagicTrigger)
+				          .ToList(),
+				ProgVariableTypes.MagicSpell),
+			CollectionMode.CastableSpellsNow => new CollectionVariable(
+				character!.Gameworld.MagicSpells.Where(x => x.CharacterCanCast(character, character)).ToList(),
+				ProgVariableTypes.MagicSpell),
+			_ => throw new ApplicationException("Unknown magic character collection mode.")
+		};
+		return StatementResult.Normal;
+	}
+
+	public static void RegisterFunctionCompiler()
+	{
+		Register("magiccapabilities", CollectionMode.Capabilities, ProgVariableTypes.MagicCapability | ProgVariableTypes.Collection,
+			"Returns the magic capabilities currently applying to the character.");
+		Register("knownspells", CollectionMode.KnownSpells, ProgVariableTypes.MagicSpell | ProgVariableTypes.Collection,
+			"Returns all spells whose known-spell prog says the character knows them.");
+		Register("castablespells", CollectionMode.CastableSpells, ProgVariableTypes.MagicSpell | ProgVariableTypes.Collection,
+			"Returns all ready, known spells that can be invoked through a cast trigger.");
+		Register("castablespellsnow", CollectionMode.CastableSpellsNow, ProgVariableTypes.MagicSpell | ProgVariableTypes.Collection,
+			"Returns all ready, known cast-trigger spells the character can cast right now against themself at any permitted power.");
+	}
+
+	private static void Register(string name, CollectionMode mode, ProgVariableTypes returnType, string help)
+	{
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			name,
+			new[] { ProgVariableTypes.Character },
+			(pars, gameworld) => new MagicCharacterCollectionFunction(pars, gameworld, mode, returnType),
+			new[] { "character" },
+			new[] { "The character whose magic state should be inspected" },
+			help,
+			"Magic",
+			returnType));
+	}
+}
+
+internal class CanCastSpellFunction : MagicBuiltInFunctionBase
+{
+	private readonly bool _now;
+	private readonly bool _hasTarget;
+	private readonly bool _hasPower;
+
+	private CanCastSpellFunction(IList<IFunction> parameterFunctions, IFuturemud gameworld, bool now, bool hasTarget,
+		bool hasPower) : base(parameterFunctions, gameworld)
+	{
+		_now = now;
+		_hasTarget = hasTarget;
+		_hasPower = hasPower;
+	}
+
+	public override ProgVariableTypes ReturnType { get => ProgVariableTypes.Boolean; protected set { } }
+
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		if (base.Execute(variables) == StatementResult.Error)
+		{
+			return StatementResult.Error;
+		}
+
+		if (!TryGetCharacter(0, out var character) || !TryGetSpell(1, out var spell))
+		{
+			return StatementResult.Error;
+		}
+
+		if (!_now)
+		{
+			Result = new BooleanVariable(spell!.CharacterKnowsSpell(character!) &&
+			                             spell.ReadyForGame &&
+			                             spell.Trigger is ICastMagicTrigger);
+			return StatementResult.Normal;
+		}
+
+		IPerceivable target = character!;
+		var powerIndex = 2;
+		if (_hasTarget)
+		{
+			if (ParameterFunctions[2].Result?.GetObject is not IPerceivable perceivable)
+			{
+				ErrorMessage = "The spell target argument cannot be null.";
+				return StatementResult.Error;
+			}
+
+			target = perceivable;
+			powerIndex = 3;
+		}
+
+		if (_hasPower)
+		{
+			if (!TryGetSpellPower(powerIndex, out var power))
+			{
+				return StatementResult.Error;
+			}
+
+			Result = new BooleanVariable(spell!.CharacterCanCast(character!, target, power));
+			return StatementResult.Normal;
+		}
+
+		Result = new BooleanVariable(spell!.CharacterCanCast(character!, target));
+		return StatementResult.Normal;
+	}
+
+	public static void RegisterFunctionCompiler()
+	{
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			"cancastspell",
+			new[] { ProgVariableTypes.Character, ProgVariableTypes.MagicSpell },
+			(pars, gameworld) => new CanCastSpellFunction(pars, gameworld, false, false, false),
+			new[] { "character", "spell" },
+			new[] { "The character to check", "The spell to check" },
+			"Returns true if the character knows the spell, the spell is ready, and it uses a cast trigger.",
+			"Magic",
+			ProgVariableTypes.Boolean));
+
+		RegisterNow(new[] { ProgVariableTypes.Character, ProgVariableTypes.MagicSpell },
+			new[] { "character", "spell" },
+			new[] { "The character to check", "The spell to check" },
+			false,
+			false,
+			"Returns true if the character can currently cast the spell against themself at any permitted power.");
+		RegisterNow(new[] { ProgVariableTypes.Character, ProgVariableTypes.MagicSpell, ProgVariableTypes.Perceivable },
+			new[] { "character", "spell", "target" },
+			new[] { "The character to check", "The spell to check", "The target to use for target-aware cost and readiness checks" },
+			true,
+			false,
+			"Returns true if the character can currently cast the spell against the target at any permitted power.");
+		RegisterNow(new[] { ProgVariableTypes.Character, ProgVariableTypes.MagicSpell, ProgVariableTypes.Text },
+			new[] { "character", "spell", "power" },
+			new[] { "The character to check", "The spell to check", "The spell power name to test" },
+			false,
+			true,
+			"Returns true if the character can currently cast the spell against themself at the specified power.");
+		RegisterNow(new[] { ProgVariableTypes.Character, ProgVariableTypes.MagicSpell, ProgVariableTypes.Perceivable, ProgVariableTypes.Text },
+			new[] { "character", "spell", "target", "power" },
+			new[] { "The character to check", "The spell to check", "The target to use for target-aware cost and readiness checks", "The spell power name to test" },
+			true,
+			true,
+			"Returns true if the character can currently cast the spell against the target at the specified power.");
+	}
+
+	private static void RegisterNow(IEnumerable<ProgVariableTypes> parameters, IEnumerable<string> parameterNames,
+		IEnumerable<string> parameterHelp, bool hasTarget, bool hasPower, string help)
+	{
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			"cancastspellnow",
+			parameters,
+			(pars, gameworld) => new CanCastSpellFunction(pars, gameworld, true, hasTarget, hasPower),
+			parameterNames,
+			parameterHelp,
+			help,
+			"Magic",
+			ProgVariableTypes.Boolean));
+	}
+}
+
+internal class ActiveSpellFunction : MagicBuiltInFunctionBase
+{
+	private enum ActiveSpellMode
+	{
+		Spells,
+		Effects
+	}
+
+	private readonly ActiveSpellMode _mode;
+	private readonly bool _hasSpell;
+	private readonly ProgVariableTypes _returnType;
+
+	private ActiveSpellFunction(IList<IFunction> parameterFunctions, IFuturemud gameworld, ActiveSpellMode mode,
+		bool hasSpell, ProgVariableTypes returnType) : base(parameterFunctions, gameworld)
+	{
+		_mode = mode;
+		_hasSpell = hasSpell;
+		_returnType = returnType;
+	}
+
+	public override ProgVariableTypes ReturnType { get => _returnType; protected set { } }
+
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		if (base.Execute(variables) == StatementResult.Error)
+		{
+			return StatementResult.Error;
+		}
+
+		if (!TryGetCharacter(0, out var character))
+		{
+			return StatementResult.Error;
+		}
+
+		IMagicSpell? spell = null;
+		if (_hasSpell && !TryGetSpell(1, out spell))
+		{
+			return StatementResult.Error;
+		}
+
+		var parents = ActiveSpellParents(character!, spell).ToList();
+		Result = _mode switch
+		{
+			ActiveSpellMode.Spells => new CollectionVariable(parents.Select(x => x.Spell).Distinct().ToList(),
+				ProgVariableTypes.MagicSpell),
+			ActiveSpellMode.Effects => new CollectionVariable(parents.Cast<IEffect>().ToList(), ProgVariableTypes.Effect),
+			_ => throw new ApplicationException("Unknown active spell mode.")
+		};
+		return StatementResult.Normal;
+	}
+
+	public static void RegisterFunctionCompiler()
+	{
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			"activespells",
+			new[] { ProgVariableTypes.Character },
+			(pars, gameworld) => new ActiveSpellFunction(pars, gameworld, ActiveSpellMode.Spells, false,
+				ProgVariableTypes.MagicSpell | ProgVariableTypes.Collection),
+			new[] { "character" },
+			new[] { "The character whose active spell effects should be inspected" },
+			"Returns the distinct spells currently represented by active spell-parent effects on the character.",
+			"Magic",
+			ProgVariableTypes.MagicSpell | ProgVariableTypes.Collection));
+
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			"activespelleffects",
+			new[] { ProgVariableTypes.Character },
+			(pars, gameworld) => new ActiveSpellFunction(pars, gameworld, ActiveSpellMode.Effects, false,
+				ProgVariableTypes.Effect | ProgVariableTypes.Collection),
+			new[] { "character" },
+			new[] { "The character whose active spell effects should be inspected" },
+			"Returns the active spell-parent effects on the character.",
+			"Magic",
+			ProgVariableTypes.Effect | ProgVariableTypes.Collection));
+
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			"activespelleffects",
+			new[] { ProgVariableTypes.Character, ProgVariableTypes.MagicSpell },
+			(pars, gameworld) => new ActiveSpellFunction(pars, gameworld, ActiveSpellMode.Effects, true,
+				ProgVariableTypes.Effect | ProgVariableTypes.Collection),
+			new[] { "character", "spell" },
+			new[] { "The character whose active spell effects should be inspected", "The spell to match" },
+			"Returns the active spell-parent effects on the character that belong to the specified spell.",
+			"Magic",
+			ProgVariableTypes.Effect | ProgVariableTypes.Collection));
+	}
+}
+
+internal class SpellDurationFunction : MagicBuiltInFunctionBase
+{
+	private enum DurationMode
+	{
+		Get,
+		Set,
+		Add,
+		Subtract,
+		Remove
+	}
+
+	private readonly DurationMode _mode;
+
+	private SpellDurationFunction(IList<IFunction> parameterFunctions, IFuturemud gameworld, DurationMode mode) :
+		base(parameterFunctions, gameworld)
+	{
+		_mode = mode;
+	}
+
+	public override ProgVariableTypes ReturnType
+	{
+		get => _mode == DurationMode.Get ? ProgVariableTypes.TimeSpan : ProgVariableTypes.Number;
+		protected set { }
+	}
+
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		if (base.Execute(variables) == StatementResult.Error)
+		{
+			return StatementResult.Error;
+		}
+
+		if (!TryGetCharacter(0, out var character) || !TryGetSpell(1, out var spell))
+		{
+			return StatementResult.Error;
+		}
+
+		var parents = ActiveSpellParents(character!, spell).ToList();
+		if (_mode == DurationMode.Get)
+		{
+			Result = new TimeSpanVariable(parents.Select(character!.ScheduledDuration).DefaultIfEmpty(TimeSpan.Zero).Max());
+			return StatementResult.Normal;
+		}
+
+		if (_mode == DurationMode.Remove)
+		{
+			foreach (var parent in parents)
+			{
+				character!.RemoveEffect(parent, true);
+			}
+
+			Result = new NumberVariable(parents.Count);
+			return StatementResult.Normal;
+		}
+
+		var duration = (TimeSpan)(ParameterFunctions[2].Result?.GetObject ?? TimeSpan.Zero);
+		var count = 0;
+		foreach (var parent in parents)
+		{
+			switch (_mode)
+			{
+				case DurationMode.Set:
+					if (duration <= TimeSpan.Zero)
+					{
+						character!.RemoveEffect(parent, true);
+					}
+					else
+					{
+						character!.Reschedule(parent, duration);
+					}
+					count++;
+					break;
+				case DurationMode.Add:
+					if (duration < TimeSpan.Zero)
+					{
+						character!.RemoveDuration(parent, duration.Duration(), true);
+						count++;
+						break;
+					}
+
+					if (character!.ScheduledDuration(parent) > TimeSpan.Zero)
+					{
+						character.AddDuration(parent, duration);
+						count++;
+					}
+					break;
+				case DurationMode.Subtract:
+					if (duration < TimeSpan.Zero)
+					{
+						character!.AddDuration(parent, duration.Duration());
+						count++;
+						break;
+					}
+
+					if (character!.ScheduledDuration(parent) > TimeSpan.Zero)
+					{
+						character.RemoveDuration(parent, duration, true);
+						count++;
+					}
+					break;
+			}
+		}
+
+		Result = new NumberVariable(count);
+		return StatementResult.Normal;
+	}
+
+	public static void RegisterFunctionCompiler()
+	{
+		RegisterGet("spellremainingduration");
+		RegisterGet("spellduration");
+		RegisterMutation("setspellduration", DurationMode.Set, "Sets the remaining duration of active effects from the specified spell and returns the number of spell-parent effects altered.");
+		RegisterMutation("addspellduration", DurationMode.Add, "Adds to the remaining duration of scheduled active effects from the specified spell and returns the number altered.");
+		RegisterMutation("subtractspellduration", DurationMode.Subtract, "Subtracts from the remaining duration of scheduled active effects from the specified spell and returns the number altered. Effects reduced below zero are removed.");
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			"removespell",
+			new[] { ProgVariableTypes.Character, ProgVariableTypes.MagicSpell },
+			(pars, gameworld) => new SpellDurationFunction(pars, gameworld, DurationMode.Remove),
+			new[] { "character", "spell" },
+			new[] { "The character whose active spell effects should be removed", "The spell to remove" },
+			"Removes active spell-parent effects from the character for the specified spell and returns the number removed.",
+			"Magic",
+			ProgVariableTypes.Number));
+	}
+
+	private static void RegisterGet(string name)
+	{
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			name,
+			new[] { ProgVariableTypes.Character, ProgVariableTypes.MagicSpell },
+			(pars, gameworld) => new SpellDurationFunction(pars, gameworld, DurationMode.Get),
+			new[] { "character", "spell" },
+			new[] { "The character whose active spell effects should be inspected", "The spell to inspect" },
+			"Returns the longest remaining scheduled duration of active spell-parent effects from the specified spell, or zero if none are scheduled.",
+			"Magic",
+			ProgVariableTypes.TimeSpan));
+	}
+
+	private static void RegisterMutation(string name, DurationMode mode, string help)
+	{
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			name,
+			new[] { ProgVariableTypes.Character, ProgVariableTypes.MagicSpell, ProgVariableTypes.TimeSpan },
+			(pars, gameworld) => new SpellDurationFunction(pars, gameworld, mode),
+			new[] { "character", "spell", "duration" },
+			new[]
+			{
+				"The character whose active spell effects should be altered",
+				"The spell to alter",
+				"The duration to set, add, or subtract"
+			},
+			help,
+			"Magic",
+			ProgVariableTypes.Number));
+	}
+}

--- a/MudSharpCore/Magic/MagicSpell.cs
+++ b/MudSharpCore/Magic/MagicSpell.cs
@@ -1348,6 +1348,77 @@ public class MagicSpell : SaveableItem, IMagicSpell
     public OutputFlags CastingEmoteFlags { get; set; }
     public OutputFlags TargetEmoteFlags { get; set; }
 
+    public bool CharacterKnowsSpell(ICharacter magician)
+    {
+        if (magician is null || SpellKnownProg is null)
+        {
+            return false;
+        }
+
+        if (magician.Capabilities.Select(x => x.School).Distinct().All(x => x != School))
+        {
+            return false;
+        }
+
+        return SpellKnownProg.Execute<bool?>(magician, this) == true;
+    }
+
+    public bool CharacterCanCast(ICharacter magician, IPerceivable target)
+    {
+        if (Trigger is not ICastMagicTrigger castTrigger)
+        {
+            return false;
+        }
+
+        return Enum.GetValues<SpellPower>()
+                   .Where(x => x >= castTrigger.MinimumPower && x <= castTrigger.MaximumPower)
+                   .Any(x => CharacterCanCast(magician, target, x));
+    }
+
+    public bool CharacterCanCast(ICharacter magician, IPerceivable target, SpellPower power)
+    {
+        if (magician is null || !ReadyForGame || !CharacterKnowsSpell(magician))
+        {
+            return false;
+        }
+
+        if (Trigger is not ICastMagicTrigger castTrigger ||
+            power < castTrigger.MinimumPower ||
+            power > castTrigger.MaximumPower)
+        {
+            return false;
+        }
+
+        if (magician.CombinedEffectsOfType<MagicSpellLockout>().Any(x => x.Applies(School)))
+        {
+            return false;
+        }
+
+        foreach ((IMagicResource resource, ITraitExpression expression) in _castingCosts)
+        {
+            expression.Formula.Parameters["power"] = (int)power;
+            expression.Formula.Parameters["self"] = magician == target ? 1 : 0;
+            double cost = expression.Evaluate(magician, CastingTrait, TraitBonusContext.SpellCost);
+            if (!magician.CanUseResource(resource, cost))
+            {
+                return false;
+            }
+        }
+
+        if (InventoryPlanTemplate is null ||
+            InventoryPlanTemplate.CreatePlan(magician).PlanIsFeasible() != InventoryPlanFeasibility.Feasible)
+        {
+            return false;
+        }
+
+        if (target is null && SpellEffects.Any(x => x.RequiresTarget))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
     public void CastSpell(ICharacter magician, IPerceivable target, SpellPower power,
         params SpellAdditionalParameter[] additionalParameters)
     {


### PR DESCRIPTION
## Summary
- Add Magic FutureProg built-ins for magic resource level query/mutation, spell capability/castability checks, active spell queries, and spell duration/removal controls.
- Add character FutureProg dot-properties for magic capabilities, known spells, generally castable spells, and spells castable now.
- Add reusable spell knowledge/castability checks on `IMagicSpell` / `MagicSpell` and sync the magic design docs.

## Verification
- `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 --filter MagicFutureProgFunctionTests`
- `git diff --check`