### PR TITLE
Add antiquity leather craft suite coverage

### DIFF
--- a/DatabaseSeeder Unit Tests/ItemSeederAntiquityLeatherCraftingTests.cs
+++ b/DatabaseSeeder Unit Tests/ItemSeederAntiquityLeatherCraftingTests.cs
@@ -1,0 +1,421 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class ItemSeederAntiquityLeatherCraftingTests
+{
+	private static readonly string[] LeatherClothingStableReferences =
+	[
+		"antiquity_plain_leather_belt",
+		"antiquity_bronze_buckled_leather_belt",
+		"antiquity_plain_leather_sandals",
+		"antiquity_fine_leather_sandals",
+		"antiquity_soft_leather_shoes",
+		"antiquity_ankle_leather_boots",
+		"antiquity_low_strapped_leather_shoes",
+		"antiquity_soft_leather_riding_boots",
+		"adjacent_antiquity_pointed_leather_shoes",
+		"adjacent_antiquity_fine_pointed_leather_shoes",
+		"adjacent_antiquity_soft_riding_boots",
+		"adjacent_antiquity_fine_linen_sandals"
+	];
+
+	private static readonly string[] LeatherArmourStableReferences =
+	[
+		"antiquity_celtic_dyed_leather_scale_vest",
+		"antiquity_celtic_bronze_studded_leather_belt",
+		"antiquity_celtic_leather_war_bracers",
+		"antiquity_celtic_fur_lined_war_boots",
+		"antiquity_germanic_broad_leather_war_belt",
+		"antiquity_germanic_hide_war_bracers",
+		"antiquity_germanic_fur_cuffed_high_boots",
+		"antiquity_etruscan_pteruges_leather_girdle",
+		"antiquity_etruscan_bronze_studded_sandals",
+		"antiquity_roman_plated_military_belt",
+		"antiquity_roman_aproned_military_belt",
+		"antiquity_roman_reinforced_caligae",
+		"antiquity_roman_leather_field_boots",
+		"antiquity_hellenic_leather_pteruges_girdle",
+		"antiquity_hellenic_bronze_studded_sandals",
+		"antiquity_punic_bronze_studded_girdle",
+		"antiquity_persian_scale_anaxyrides",
+		"antiquity_persian_soft_riding_boots",
+		"antiquity_egyptian_leather_scale_cuirass",
+		"antiquity_egyptian_scale_kilt_guard",
+		"antiquity_egyptian_leather_archer_bracer",
+		"antiquity_anatolian_leather_cavalry_boots",
+		"antiquity_scythian_leather_scale_corselet",
+		"antiquity_scythian_conical_scale_cap",
+		"antiquity_scythian_scale_trousers",
+		"antiquity_scythian_high_riding_boots",
+		"antiquity_kushite_leather_scale_breastguard",
+		"antiquity_kushite_leather_archer_bracer",
+		"antiquity_kushite_leather_kilt_guard",
+		"antiquity_kushite_sand_armoured_sandals"
+	];
+
+	private static readonly string[] LeatherContainerStableReferences =
+	[
+		"antiquity_smoked_hide_meat_bag",
+		"antiquity_leather_document_case",
+		"antiquity_leather_mirror_case",
+		"antiquity_plain_leather_belt_pouch",
+		"antiquity_double_strap_travel_pack",
+		"antiquity_fur_lined_forager_bag",
+		"antiquity_deer_leather_game_bag",
+		"antiquity_folded_tablet_wallet",
+		"antiquity_round_coin_purse",
+		"antiquity_leather_dispatch_satchel",
+		"antiquity_wide_belt_document_pouch",
+		"antiquity_steppe_saddlebag_pack",
+		"antiquity_steppe_gorytos_case",
+		"antiquity_fur_provision_pouch",
+		"antiquity_liquid_steppe_milk_skin",
+		"antiquity_liquid_plain_leather_waterskin",
+		"antiquity_liquid_wide_mouth_waterskin",
+		"antiquity_liquid_leather_belt_oil_flask",
+		"antiquity_liquid_hide_ale_skin",
+		"antiquity_liquid_birch_stoppered_mead_skin",
+		"antiquity_liquid_soldier_shoulder_canteen",
+		"antiquity_liquid_sailor_water_skin",
+		"antiquity_liquid_caravan_waterskin",
+		"antiquity_liquid_silver_tipped_belt_flask",
+		"antiquity_liquid_felt_covered_riding_canteen",
+		"antiquity_liquid_saddle_waterskin",
+		"antiquity_liquid_steppe_kumis_skin",
+		"antiquity_liquid_tooled_leather_flask",
+		"antiquity_tableware_scythian_leather_travel_cup"
+	];
+
+	private static readonly string[] LeatherFurnishingStableReferences =
+	[
+		"antiquity_fur_door_hanging",
+		"antiquity_leather_tent_door_flap"
+	];
+
+	private static readonly string[] LeatherCraftStableReferences =
+		LeatherClothingStableReferences
+			.Concat(LeatherArmourStableReferences)
+			.Concat(LeatherContainerStableReferences)
+			.Concat(LeatherFurnishingStableReferences)
+			.ToArray();
+
+	[TestMethod]
+	public void LeatherCrafts_HaveStableReferencesInItemAndCraftSources()
+	{
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Antiquity.cs");
+		var itemCraftingSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.cs");
+		var itemSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.Antiquity.cs");
+
+		foreach (var expected in new[]
+		{
+			"AntiquityLeatherClothingStableReferences",
+			"AntiquityLeatherArmourStableReferences",
+			"AntiquityLeatherContainerStableReferences",
+			"AntiquityLeatherFurnishingStableReferences",
+			"SeedAntiquityLeatherPreparationCrafts();",
+			"SeedAntiquityLeatherClothingCrafts();",
+			"SeedAntiquityLeatherArmourCrafts();",
+			"SeedAntiquityLeatherContainerCrafts();",
+			"SeedAntiquityLeatherFurnishingCrafts();",
+			"private void SeedAntiquityLeatherPreparationCrafts()",
+			"private void SeedAntiquityLeatherClothingCrafts()",
+			"private void SeedAntiquityLeatherArmourCrafts()",
+			"private void SeedAntiquityLeatherContainerCrafts()",
+			"private void SeedAntiquityLeatherFurnishingCrafts()"
+		})
+		{
+			AssertContains(itemCraftingSource + craftSource, expected);
+		}
+
+		foreach (var stableReference in LeatherCraftStableReferences)
+		{
+			AssertContains(itemSource, $"\"{stableReference}\"");
+			AssertContains(craftSource, $"\"{stableReference}\"");
+			AssertContains(itemCraftingSource, $"[\"{stableReference}\"]");
+		}
+	}
+
+	[TestMethod]
+	public void LeatherCrafts_CoverEveryAntiquityLeatherMaterialItem()
+	{
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Antiquity.cs");
+		var itemSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.Antiquity.cs");
+		var leatherItemStableReferences = FindAntiquityLeatherMaterialItemStableReferences(itemSource)
+			.ToArray();
+
+		Assert.IsTrue(leatherItemStableReferences.Length >= 70, "Expected the material audit to find the full antiquity leather, hide, and fur item surface.");
+
+		var missingCrafts = leatherItemStableReferences
+			.Where(x => !craftSource.Contains($"\"{x}\"", StringComparison.Ordinal))
+			.ToArray();
+
+		Assert.AreEqual(
+			0,
+			missingCrafts.Length,
+			"Every antiquity item whose base material is leather, hide, or fur should have a craft. Missing: " +
+			string.Join(", ", missingCrafts));
+	}
+
+	[TestMethod]
+	public void LeatherCrafts_UseLeatherworkingKnowledgeTraitAndCommodityPipeline()
+	{
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Antiquity.cs");
+
+		foreach (var expected in new[]
+		{
+			"private const string AntiquityLeatherKnowledge = \"Ancient Hide and Leatherworking\"",
+			"\"Leatherworking\"",
+			"\"Leathermaking\"",
+			"CommodityTag - 1 kilogram 600 grams of a material tagged as Animal Skin",
+			"LiquidUse - 2 litres of Water",
+			"LiquidUse - 3 litres of Water",
+			"LiquidTagUse - 2 litres of a liquid tagged Tanning Agent",
+			"tag Prepared Hide",
+			"tag Tanned Leather",
+			"tag Leather Sole",
+			"tag Leather Strap",
+			"tag Leather Thong",
+			"tag Leather Panel",
+			"tag Hardened Leather Panel",
+			"tag Leather Scale",
+			"tag Sealed Leather Panel",
+			"piletag Tanned Leather",
+			"piletag Leather Sole",
+			"piletag Leather Strap",
+			"piletag Leather Thong",
+			"piletag Leather Panel",
+			"piletag Hardened Leather Panel",
+			"AddLeatherCommodityInput(inputs, armourCraft.Scales, \"Leather Scale\")",
+			"AddLeatherCommodityInput(inputs, containerCraft.SealedPanels, \"Sealed Leather Panel\")",
+			"Commodity - 120 grams of beeswax",
+			"Commodity - 90 grams of beeswax",
+			"StableSimpleProduct(",
+			"StableVariableProduct("
+		})
+		{
+			AssertContains(craftSource, expected);
+		}
+	}
+
+	[TestMethod]
+	public void LeatherCrafts_HaveSupportingTagsAndPeriodTools()
+	{
+		var tagSource = ReadSource("DatabaseSeeder", "Seeders", "UsefulSeeder.Tags.cs");
+		var hierarchySource = ReadSource("Design Documents", "SeededTagHierarchy.csv");
+		var itemSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.Antiquity.cs");
+
+		foreach (var expected in new[]
+		{
+			"AddTag(context, \"Leather Commodity\", \"Material Functions\")",
+			"AddTag(context, \"Prepared Hide\", \"Leather Commodity\")",
+			"AddTag(context, \"Tanned Leather\", \"Leather Commodity\")",
+			"AddTag(context, \"Leather Sole\", \"Leather Commodity\")",
+			"AddTag(context, \"Leather Strap\", \"Leather Commodity\")",
+			"AddTag(context, \"Leather Thong\", \"Leather Commodity\")",
+			"AddTag(context, \"Leather Panel\", \"Leather Commodity\")",
+			"AddTag(context, \"Hardened Leather Panel\", \"Leather Commodity\")",
+			"AddTag(context, \"Leather Scale\", \"Leather Commodity\")",
+			"AddTag(context, \"Sealed Leather Panel\", \"Leather Commodity\")",
+			"AddTag(context, \"Shoe Last\", \"Leatherworking Tools\")",
+			"AddTag(context, \"Leather Wax Pot\", \"Leatherworking Tools\")"
+		})
+		{
+			AssertContains(tagSource, expected);
+		}
+
+		foreach (var expected in new[]
+		{
+			"Functions / Material Functions / Leather Commodity / Prepared Hide",
+			"Functions / Material Functions / Leather Commodity / Tanned Leather",
+			"Functions / Material Functions / Leather Commodity / Leather Sole",
+			"Functions / Material Functions / Leather Commodity / Leather Strap",
+			"Functions / Material Functions / Leather Commodity / Leather Thong",
+			"Functions / Material Functions / Leather Commodity / Leather Panel",
+			"Functions / Material Functions / Leather Commodity / Hardened Leather Panel",
+			"Functions / Material Functions / Leather Commodity / Leather Scale",
+			"Functions / Material Functions / Leather Commodity / Sealed Leather Panel",
+			"Functions / Tools / Leatherworking Tools / Shoe Last",
+			"Functions / Tools / Leatherworking Tools / Leather Wax Pot"
+		})
+		{
+			AssertContains(hierarchySource, expected);
+		}
+
+		foreach (var expected in new[]
+		{
+			"antiquity_bronze_awl_punch",
+			"antiquity_oak_stitching_pony",
+			"antiquity_bronze_edge_beveller",
+			"antiquity_bronze_leather_gouge",
+			"antiquity_bronze_leather_creaser",
+			"antiquity_oak_shoe_last",
+			"antiquity_bronze_leather_wax_pot",
+			"antiquity_bronze_hide_scraper",
+			"antiquity_oak_tanning_beam",
+			"antiquity_oak_tanning_rack",
+			"antiquity_oak_tanning_paddle",
+			"antiquity_bronze_dehairing_knife",
+			"antiquity_oak_brain_tanning_bucket"
+		})
+		{
+			AssertContains(itemSource, expected);
+		}
+	}
+
+	[TestMethod]
+	public void AntiquityCraftVisibleStrings_DoNotUseCultureNamesOrRepairLayer()
+	{
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Antiquity.cs");
+		var bannedTerms = new[]
+		{
+			"Hellenic",
+			"Egyptian",
+			"Kushite",
+			"Nubian",
+			"Roman",
+			"Celtic",
+			"Germanic",
+			"Punic",
+			"Phoenician",
+			"Persian",
+			"Median",
+			"Etruscan",
+			"Anatolian",
+			"Phrygian",
+			"Scythian",
+			"Sarmatian"
+		};
+
+		var offendingLines = craftSource
+			.Split(["\r\n", "\n"], StringSplitOptions.None)
+			.Select((Line, Index) => (Line, LineNumber: Index + 1))
+			.Where(x => x.Line.Contains('"'))
+			.Where(x => bannedTerms.Any(term => x.Line.Contains(term, StringComparison.Ordinal)))
+			.Where(x => !IsAllowedCultureMetadataLine(x.Line))
+			.ToList();
+
+		Assert.AreEqual(
+			0,
+			offendingLines.Count,
+			"Culture-name terms should only appear in knowledge metadata. Offending lines: " +
+			string.Join("; ", offendingLines.Select(x => $"{x.LineNumber}: {x.Line.Trim()}")));
+
+		foreach (var banned in new[]
+		{
+			"RepairAntiquityCraftVisibleText",
+			"AddAntiquityCraftWithVisibleTextRepair",
+			"LegacyName",
+			"legacyNames"
+		})
+		{
+			Assert.IsFalse(craftSource.Contains(banned, StringComparison.Ordinal), $"Base data should be corrected directly, without {banned}.");
+		}
+	}
+
+	[TestMethod]
+	public void AntiquityDesignDocument_DocumentsFullLeatherSlice()
+	{
+		var designSource = ReadSource("Design Documents", "Antiquity_Hellenic_Clothing_Crafting_Suite.md");
+
+		foreach (var expected in new[]
+		{
+			"## Full Leather Item Suite",
+			"Ancient Hide and Leatherworking",
+			"`Leathermaking`",
+			"`Leatherworking`",
+			"`Leather Commodity`",
+			"`Prepared Hide`",
+			"`Tanned Leather`",
+			"`Leather Sole`",
+			"`Leather Strap`",
+			"`Leather Thong`",
+			"`Leather Panel`",
+			"`Hardened Leather Panel`",
+			"`Leather Scale`",
+			"`Sealed Leather Panel`",
+			"`Leather Wax Pot`",
+			"armour, containers, liquid vessels, tableware, and doorway fittings"
+		})
+		{
+			AssertContains(designSource, expected);
+		}
+
+		foreach (var stableReference in LeatherCraftStableReferences)
+		{
+			AssertContains(designSource, $"`{stableReference}`");
+		}
+	}
+
+	private static IEnumerable<string> FindAntiquityLeatherMaterialItemStableReferences(string itemSource)
+	{
+		foreach (Match match in Regex.Matches(itemSource, "CreateItem\\(\\s*\"(?<stable>[^\"]+)\"(?<body>.*?)\\n\\s*\\);", RegexOptions.Singleline))
+		{
+			var material = FindMaterialArgument(match.Value);
+			if (material is not null &&
+			    (material.Contains("leather", StringComparison.OrdinalIgnoreCase) ||
+			     material.Contains("hide", StringComparison.OrdinalIgnoreCase) ||
+			     material.Contains("fur", StringComparison.OrdinalIgnoreCase)))
+			{
+				yield return match.Groups["stable"].Value;
+			}
+		}
+	}
+
+	private static string? FindMaterialArgument(string createItemBlock)
+	{
+		var lines = createItemBlock.Split(["\r\n", "\n"], StringSplitOptions.None);
+		for (var i = 0; i < lines.Length; i++)
+		{
+			if (!lines[i].Trim().Equals("false,", StringComparison.Ordinal))
+			{
+				continue;
+			}
+
+			for (var j = i + 1; j < Math.Min(i + 5, lines.Length); j++)
+			{
+				var match = Regex.Match(lines[j], "^\\s*\"(?<material>[^\"]+)\",\\s*$");
+				if (match.Success)
+				{
+					return match.Groups["material"].Value;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	private static bool IsAllowedCultureMetadataLine(string line)
+	{
+		var trimmed = line.Trim();
+		return line.Contains("Knowledge", StringComparison.Ordinal) ||
+		       line.Contains("knowledge", StringComparison.Ordinal) ||
+		       trimmed is "\"Hellenic\"," or "\"Egyptian\"," or "\"Kushite\"," or "\"Roman\"," or "\"Celtic\","
+			       or "\"Germanic\"," or "\"Punic\"," or "\"Persian\"," or "\"Etruscan\"," or "\"Anatolian\","
+			       or "\"Scythian-Sarmatian\",";
+	}
+
+	private static void AssertContains(string source, string expected)
+	{
+		Assert.IsTrue(source.Contains(expected, StringComparison.Ordinal), $"Expected source to contain: {expected}");
+	}
+
+	private static string ReadSource(params string[] parts)
+	{
+		return File.ReadAllText(Path.GetFullPath(Path.Combine(
+			AppContext.BaseDirectory,
+			"..",
+			"..",
+			"..",
+			"..",
+			Path.Combine(parts))));
+	}
+}

--- a/DatabaseSeeder Unit Tests/ItemSeederEgyptianClothingCraftingTests.cs
+++ b/DatabaseSeeder Unit Tests/ItemSeederEgyptianClothingCraftingTests.cs
@@ -24,7 +24,7 @@ public class ItemSeederEgyptianClothingCraftingTests
 	[TestMethod]
 	public void EgyptianClothingCrafts_ProduceEveryCurrentEgyptianClothingPrototype()
 	{
-		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Egyptian.cs");
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Antiquity.cs");
 		var itemSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.Antiquity.cs");
 
 		foreach (var stableReference in EgyptianClothingStableReferences)
@@ -39,7 +39,7 @@ public class ItemSeederEgyptianClothingCraftingTests
 	[TestMethod]
 	public void EgyptianFinishedGarmentCrafts_UseEgyptianKnowledgeGate()
 	{
-		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Egyptian.cs");
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Antiquity.cs");
 		var itemCraftingSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.cs");
 
 		AssertContains(craftSource, "const string egyptianKnowledge = \"Egyptian Textilecraft\"");
@@ -52,7 +52,7 @@ public class ItemSeederEgyptianClothingCraftingTests
 	[TestMethod]
 	public void EgyptianBeadedGarments_UseCommodityBeadStockAndPeriodNeedle()
 	{
-		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Egyptian.cs");
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Antiquity.cs");
 		var tagSource = ReadSource("DatabaseSeeder", "Seeders", "UsefulSeeder.Tags.cs");
 		var itemSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.Antiquity.cs");
 
@@ -67,7 +67,7 @@ public class ItemSeederEgyptianClothingCraftingTests
 	[TestMethod]
 	public void EgyptianGarmentCrafts_UseSharedTextileCommoditiesAndCopyColours()
 	{
-		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Egyptian.cs");
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Antiquity.cs");
 
 		foreach (var expected in new[]
 		{

--- a/DatabaseSeeder Unit Tests/ItemSeederHellenicClothingCraftingTests.cs
+++ b/DatabaseSeeder Unit Tests/ItemSeederHellenicClothingCraftingTests.cs
@@ -27,7 +27,7 @@ public class ItemSeederHellenicClothingCraftingTests
 	[TestMethod]
 	public void HellenicClothingCrafts_ProduceEveryCurrentHellenicClothingPrototype()
 	{
-		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Hellenic.cs");
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Antiquity.cs");
 		var itemSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.Antiquity.cs");
 
 		foreach (var stableReference in HellenicClothingStableReferences)
@@ -43,7 +43,7 @@ public class ItemSeederHellenicClothingCraftingTests
 	[TestMethod]
 	public void HellenicFinishedGarmentCrafts_UseHellenicKnowledgeGate()
 	{
-		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Hellenic.cs");
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Antiquity.cs");
 
 		AssertContains(craftSource, "const string hellenicKnowledge = \"Hellenic Textilecraft\"");
 		AssertContains(craftSource, "knowledgeSubtype: \"Hellenic\"");
@@ -54,7 +54,7 @@ public class ItemSeederHellenicClothingCraftingTests
 	[TestMethod]
 	public void UpstreamTextileCrafts_UseCommodityStateTagsAndPreserveColours()
 	{
-		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Hellenic.cs");
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Antiquity.cs");
 
 		foreach (var expected in new[]
 		{

--- a/DatabaseSeeder Unit Tests/ItemSeederNorthernAndKushiteClothingCraftingTests.cs
+++ b/DatabaseSeeder Unit Tests/ItemSeederNorthernAndKushiteClothingCraftingTests.cs
@@ -60,7 +60,7 @@ public class ItemSeederNorthernAndKushiteClothingCraftingTests
 	[TestMethod]
 	public void NorthernAndKushiteClothingCrafts_ProduceEveryCurrentGarmentPrototype()
 	{
-		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.CelticGermanicKushite.cs");
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Antiquity.cs");
 		var itemSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.Antiquity.cs");
 		var itemCraftingSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.cs");
 
@@ -90,7 +90,7 @@ public class ItemSeederNorthernAndKushiteClothingCraftingTests
 	[TestMethod]
 	public void FinishedGarmentCrafts_UseCultureKnowledgeGates()
 	{
-		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.CelticGermanicKushite.cs");
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Antiquity.cs");
 
 		foreach (var expected in new[]
 		{
@@ -109,7 +109,7 @@ public class ItemSeederNorthernAndKushiteClothingCraftingTests
 	[TestMethod]
 	public void SharedUpstreamTextileCrafts_AddCottonCommodityPath()
 	{
-		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Hellenic.cs");
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Antiquity.cs");
 		var materialSource = ReadSource("DatabaseSeeder", "Seeders", "CoreDataSeeder.Materials.cs");
 
 		foreach (var expected in new[]
@@ -136,8 +136,8 @@ public class ItemSeederNorthernAndKushiteClothingCraftingTests
 	[TestMethod]
 	public void SpecialNorthernGarments_UseCommodityInputsAndStableSimpleProducts()
 	{
-		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.CelticGermanicKushite.cs");
-		var helperSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Hellenic.cs");
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Antiquity.cs");
+		var helperSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Antiquity.cs");
 
 		AssertContains(helperSource, "private string StableSimpleProduct(string stableReference)");
 		AssertContains(craftSource, "StableSimpleProduct(garment.StableReference)");

--- a/DatabaseSeeder Unit Tests/ItemSeederRemainingAntiquityClothingCraftingTests.cs
+++ b/DatabaseSeeder Unit Tests/ItemSeederRemainingAntiquityClothingCraftingTests.cs
@@ -80,7 +80,7 @@ public class ItemSeederRemainingAntiquityClothingCraftingTests
 	[TestMethod]
 	public void RemainingAntiquityClothingCrafts_ProduceEveryCurrentCultureGarmentPrototype()
 	{
-		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.RemainingAntiquity.cs");
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Antiquity.cs");
 		var itemSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.Antiquity.cs");
 		var itemCraftingSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.cs");
 
@@ -106,7 +106,7 @@ public class ItemSeederRemainingAntiquityClothingCraftingTests
 	[TestMethod]
 	public void RemainingAntiquityFinishedGarmentCrafts_UseCultureKnowledgeGates()
 	{
-		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.RemainingAntiquity.cs");
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Antiquity.cs");
 
 		foreach (var expected in new[]
 		{
@@ -129,7 +129,7 @@ public class ItemSeederRemainingAntiquityClothingCraftingTests
 	[TestMethod]
 	public void SharedUpstreamTextileCrafts_AddFeltCommodityPath()
 	{
-		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Hellenic.cs");
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Antiquity.cs");
 		var materialSource = ReadSource("DatabaseSeeder", "Seeders", "CoreDataSeeder.Materials.cs");
 
 		foreach (var expected in new[]
@@ -149,7 +149,7 @@ public class ItemSeederRemainingAntiquityClothingCraftingTests
 	[TestMethod]
 	public void RemainingAntiquitySpecialGarments_UseCommodityInputsAndGeneratedProducts()
 	{
-		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.RemainingAntiquity.cs");
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Antiquity.cs");
 
 		foreach (var expected in new[]
 		{
@@ -184,7 +184,7 @@ public class ItemSeederRemainingAntiquityClothingCraftingTests
 			"## Anatolian Garment Matrix",
 			"## Scythian-Sarmatian Garment Matrix",
 			"Felt prepared wool fibre into garment felt",
-			"Leather footwear remains out of this clothing pass"
+			"## Full Leather Item Suite"
 		})
 		{
 			AssertContains(designSource, expected);

--- a/DatabaseSeeder Unit Tests/ItemSeederRomanClothingCraftingTests.cs
+++ b/DatabaseSeeder Unit Tests/ItemSeederRomanClothingCraftingTests.cs
@@ -25,7 +25,7 @@ public class ItemSeederRomanClothingCraftingTests
 	[TestMethod]
 	public void RomanClothingCrafts_ProduceEveryCurrentRomanClothingPrototype()
 	{
-		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Roman.cs");
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Antiquity.cs");
 		var itemSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.Antiquity.cs");
 
 		foreach (var stableReference in RomanClothingStableReferences)
@@ -40,7 +40,7 @@ public class ItemSeederRomanClothingCraftingTests
 	[TestMethod]
 	public void RomanFinishedGarmentCrafts_UseRomanKnowledgeGate()
 	{
-		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Roman.cs");
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Antiquity.cs");
 		var itemCraftingSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.cs");
 
 		AssertContains(craftSource, "const string romanKnowledge = \"Roman Textilecraft\"");
@@ -53,7 +53,7 @@ public class ItemSeederRomanClothingCraftingTests
 	[TestMethod]
 	public void RomanGarmentCrafts_UseSharedTextileCommoditiesAndCopyColours()
 	{
-		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Roman.cs");
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Antiquity.cs");
 
 		foreach (var expected in new[]
 		{

--- a/DatabaseSeeder/AGENTS.md
+++ b/DatabaseSeeder/AGENTS.md
@@ -18,6 +18,7 @@ Interactive installer that seeds initial database data and configuration for a n
 
 ## Seeder Policy
 - Treat repeatability as a first-class design concern. New or modified seeders should declare honest repeatability and update semantics through the seeder metadata, not only through prose or warning colors.
+- Treat stock seed definitions as the base install truth. Fix bad stock content at the source definition; use repair/update paths only for existing databases or explicitly documented stock-owned rerun reconciliation.
 - Prefer additive installs and deterministic lookup-and-upsert behavior over one-shot seeders whenever the stock data has stable ownership boundaries.
 - Ask as few questions as practical. If multiple stock options can coexist safely, prefer installing multiple options over forcing an early fork in the setup flow.
 - Reuse prior answers through shared answer keys and the generic `SeederChoice` answer-memory flow instead of ad hoc per-seeder lookup code.

--- a/DatabaseSeeder/Seeders/ItemSeeder.Rework.Antiquity.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Rework.Antiquity.cs
@@ -348,6 +348,282 @@ namespace DatabaseSeeder.Seeders
 
             #endregion
 
+            #region Antiquity Leatherworking Tools
+            CreateItem(
+                "antiquity_bronze_awl_punch",
+                "awl",
+                "a bronze awl punch",
+                null,
+                "This bronze awl punch has a narrow tapered point set into a plain wooden grip. It is made for opening stitch holes in leather straps, soles, belts, and soft footwear without tearing the hide.",
+                SizeCategory.VerySmall,
+                ItemQuality.Standard,
+                90.0,
+                12.0m,
+                false,
+                false,
+                "bronze",
+                ["Market / Professional Tools / Standard Tools", "Functions / Tools / Leatherworking Tools / Awl Punch"],
+                ["Holdable", "Destroyable_Misc"],
+                null,
+                null,
+                null,
+                null
+            );
+
+            CreateItem(
+                "antiquity_oak_stitching_pony",
+                "clamp",
+                "an oak leather stitching clamp",
+                null,
+                "This oak stitching clamp has two smooth jaws and a wedge for holding leather while it is sewn. It frees both hands for awl work, thonging, and close stitching along soles or belt edges.",
+                SizeCategory.Normal,
+                ItemQuality.Standard,
+                3200.0,
+                24.0m,
+                false,
+                false,
+                "oak",
+                ["Market / Professional Tools / Standard Tools", "Functions / Tools / Leatherworking Tools / Leather Stitching Pony"],
+                ["Holdable", "Destroyable_Misc"],
+                null,
+                null,
+                null,
+                null
+            );
+
+            CreateItem(
+                "antiquity_bronze_edge_beveller",
+                "beveller",
+                "a bronze leather edge beveller",
+                null,
+                "This small bronze edge beveller has a hooked cutting lip for shaving the harsh corners from leather soles and straps. Its wooden handle is darkened from oily hands and tanning work.",
+                SizeCategory.VerySmall,
+                ItemQuality.Standard,
+                85.0,
+                14.0m,
+                false,
+                false,
+                "bronze",
+                ["Market / Professional Tools / Standard Tools", "Functions / Tools / Leatherworking Tools / Edge Beveller"],
+                ["Holdable", "Destroyable_Misc"],
+                null,
+                null,
+                null,
+                null
+            );
+
+            CreateItem(
+                "antiquity_bronze_leather_gouge",
+                "gouge",
+                "a bronze leather gouge",
+                null,
+                "This bronze leather gouge is narrow and slightly curved, suited to drawing straight cuts for straps and thinning channels where leather will fold or stitch.",
+                SizeCategory.VerySmall,
+                ItemQuality.Standard,
+                95.0,
+                16.0m,
+                false,
+                false,
+                "bronze",
+                ["Market / Professional Tools / Standard Tools", "Functions / Tools / Leatherworking Tools / Leather Gouge"],
+                ["Holdable", "Destroyable_Misc"],
+                null,
+                null,
+                null,
+                null
+            );
+
+            CreateItem(
+                "antiquity_bronze_leather_creaser",
+                "creaser",
+                "a bronze leather creaser",
+                null,
+                "This blunt bronze creaser presses guide lines and fold marks into damp leather. Its working end is rounded rather than sharp so it can set a line without cutting the grain.",
+                SizeCategory.VerySmall,
+                ItemQuality.Standard,
+                80.0,
+                12.0m,
+                false,
+                false,
+                "bronze",
+                ["Market / Professional Tools / Standard Tools", "Functions / Tools / Leatherworking Tools / Leather Creaser"],
+                ["Holdable", "Destroyable_Misc"],
+                null,
+                null,
+                null,
+                null
+            );
+
+            CreateItem(
+                "antiquity_oak_shoe_last",
+                "last",
+                "an oak shoe last",
+                null,
+                "This simple oak shoe last is shaped like a low foot form with a rounded toe and narrow heel. It gives soft shoes, sandals, and ankle boots a steady shape while straps and uppers are stitched.",
+                SizeCategory.Small,
+                ItemQuality.Standard,
+                850.0,
+                18.0m,
+                false,
+                false,
+                "oak",
+                ["Market / Professional Tools / Standard Tools", "Functions / Tools / Leatherworking Tools / Shoe Last"],
+                ["Holdable", "Destroyable_Misc"],
+                null,
+                null,
+                null,
+                null
+            );
+
+            CreateItem(
+                "antiquity_bronze_leather_wax_pot",
+                "pot",
+                "a bronze leather wax pot",
+                null,
+                "This small bronze pot has a rounded base, soot-darkened sides, and a short pouring lip for warming beeswax and oils used in leather hardening and vessel sealing. Its handle is wrapped in worn leather so it can be shifted near a hot fire.",
+                SizeCategory.Small,
+                ItemQuality.Standard,
+                650.0,
+                28.0m,
+                false,
+                false,
+                "bronze",
+                ["Market / Professional Tools / Standard Tools", "Functions / Tools / Leatherworking Tools / Leather Wax Pot"],
+                ["Holdable", "Destroyable_Misc"],
+                null,
+                null,
+                null,
+                null
+            );
+
+            CreateItem(
+                "antiquity_bronze_hide_scraper",
+                "scraper",
+                "a bronze hide scraper",
+                null,
+                "This bronze hide scraper has a broad dull edge for pushing fat, flesh, and membrane away from raw skin. Its back is heavy enough to lean into the work without cutting through the hide.",
+                SizeCategory.Small,
+                ItemQuality.Standard,
+                420.0,
+                18.0m,
+                false,
+                false,
+                "bronze",
+                ["Market / Professional Tools / Standard Tools", "Functions / Tools / Tanning Tools / Hide Scraper"],
+                ["Holdable", "Destroyable_Misc"],
+                null,
+                null,
+                null,
+                null
+            );
+
+            CreateItem(
+                "antiquity_oak_tanning_beam",
+                "beam",
+                "an oak tanning beam",
+                null,
+                "This rounded oak beam is braced low for scraping hides. Its surface is slick and dark from water, fat, bark liquor, and years of hard pressure from scrapers.",
+                SizeCategory.Large,
+                ItemQuality.Standard,
+                18000.0,
+                32.0m,
+                false,
+                false,
+                "oak",
+                ["Market / Professional Tools / Standard Tools", "Functions / Tools / Tanning Tools / Tanning Beam"],
+                ["Holdable", "Destroyable_Furniture"],
+                null,
+                null,
+                null,
+                null
+            );
+
+            CreateItem(
+                "antiquity_oak_tanning_rack",
+                "rack",
+                "an oak tanning rack",
+                null,
+                "This oak rack has pegged rails and tie points for stretching wet hides as they dry. It keeps leather broad and even while scraping, oiling, and curing finish the work.",
+                SizeCategory.VeryLarge,
+                ItemQuality.Standard,
+                26000.0,
+                45.0m,
+                false,
+                false,
+                "oak",
+                ["Market / Professional Tools / Standard Tools", "Functions / Tools / Tanning Tools / Tanning Rack"],
+                ["Holdable", "Destroyable_Furniture"],
+                null,
+                null,
+                null,
+                null
+            );
+
+            CreateItem(
+                "antiquity_oak_tanning_paddle",
+                "paddle",
+                "an oak tanning paddle",
+                null,
+                "This flat oak paddle is used to turn hides through water and tanning liquor. Its blade is broad and smooth so it can move soaked leather without tearing it.",
+                SizeCategory.Normal,
+                ItemQuality.Standard,
+                900.0,
+                10.0m,
+                false,
+                false,
+                "oak",
+                ["Market / Professional Tools / Standard Tools", "Functions / Tools / Tanning Tools / Tanning Paddle"],
+                ["Holdable", "Destroyable_Misc"],
+                null,
+                null,
+                null,
+                null
+            );
+
+            CreateItem(
+                "antiquity_bronze_dehairing_knife",
+                "knife",
+                "a bronze dehairing knife",
+                null,
+                "This bronze dehairing knife has a long dull blade made for pushing hair from soaked skins. It is safer against the hide than a sharp cutting knife, but still firm enough to strip stubborn patches.",
+                SizeCategory.Small,
+                ItemQuality.Standard,
+                260.0,
+                16.0m,
+                false,
+                false,
+                "bronze",
+                ["Market / Professional Tools / Standard Tools", "Functions / Tools / Tanning Tools / Leather Dehairing Knife"],
+                ["Holdable", "Destroyable_Misc"],
+                null,
+                null,
+                null,
+                null
+            );
+
+            CreateItem(
+                "antiquity_oak_brain_tanning_bucket",
+                "bucket",
+                "an oak brain-tanning bucket",
+                null,
+                "This tight oak bucket is made for mixing oily tanning liquor before it is worked into prepared hide. Its staves are stained by bark, fat, smoke, and repeated hide dressing.",
+                SizeCategory.Normal,
+                ItemQuality.Standard,
+                2800.0,
+                18.0m,
+                false,
+                false,
+                "oak",
+                ["Market / Professional Tools / Standard Tools", "Functions / Tools / Tanning Tools / Brain Tanning Bucket"],
+                ["Holdable", "Destroyable_Misc"],
+                null,
+                null,
+                null,
+                null
+            );
+
+            #endregion
+
             #region Common Antiquity
             CreateItem(
                 "antiquity_linen_loincloth",

--- a/DatabaseSeeder/Seeders/ItemSeederCrafting.Antiquity.cs
+++ b/DatabaseSeeder/Seeders/ItemSeederCrafting.Antiquity.cs
@@ -31,7 +31,11 @@ public partial class ItemSeeder
             !PersianAntiquityClothingStableReferences.TryGetValue(stableReference, out shortDescription) &&
             !EtruscanAntiquityClothingStableReferences.TryGetValue(stableReference, out shortDescription) &&
             !AnatolianAntiquityClothingStableReferences.TryGetValue(stableReference, out shortDescription) &&
-            !ScythianSarmatianAntiquityClothingStableReferences.TryGetValue(stableReference, out shortDescription))
+            !ScythianSarmatianAntiquityClothingStableReferences.TryGetValue(stableReference, out shortDescription) &&
+            !AntiquityLeatherClothingStableReferences.TryGetValue(stableReference, out shortDescription) &&
+            !AntiquityLeatherArmourStableReferences.TryGetValue(stableReference, out shortDescription) &&
+            !AntiquityLeatherContainerStableReferences.TryGetValue(stableReference, out shortDescription) &&
+            !AntiquityLeatherFurnishingStableReferences.TryGetValue(stableReference, out shortDescription))
         {
             item = null!;
             return false;
@@ -76,6 +80,50 @@ public partial class ItemSeeder
         var item = LookupReworkItem(stableReference);
         return $"SimpleProduct - 1x {item.ShortDescription} (#{item.Id})";
     }
+
+    private MudSharp.Models.Craft? AddAntiquityCraft(
+        string name,
+        string category,
+        string blurb,
+        string action,
+        string itemDescription,
+        string knowledgeName,
+        string traitName,
+        int? minimumTraitValue,
+        Difficulty difficulty,
+        IEnumerable<(int Seconds, string Echo, string FailEcho)> phases,
+        IEnumerable<string> inputs,
+        IEnumerable<string> tools,
+        IEnumerable<string> products,
+        IEnumerable<string>? failProducts = null,
+        string knowledgeSubtype = "General",
+        string? knowledgeDescription = null,
+        string? knowledgeLongDescription = null)
+    {
+        return AddCraft(
+            name,
+            category,
+            blurb,
+            action,
+            itemDescription,
+            knowledgeName,
+            traitName,
+            minimumTraitValue,
+            difficulty,
+            Outcome.MinorFail,
+            5,
+            3,
+            false,
+            phases,
+            inputs,
+            tools,
+            products,
+            failProducts ?? [],
+            knowledgeSubtype: knowledgeSubtype,
+            knowledgeDescription: knowledgeDescription,
+            knowledgeLongDescription: knowledgeLongDescription);
+    }
+
     private sealed record AntiquityCultureGarmentCraftSpec(
         string StableReference,
         string Name,
@@ -110,7 +158,7 @@ public partial class ItemSeeder
             IEnumerable<(int Seconds, string Echo, string FailEcho)> phases, IEnumerable<string> inputs,
             IEnumerable<string> tools, IEnumerable<string> products)
         {
-            AddCraft(
+            AddAntiquityCraft(
                 name,
                 "Tailoring",
                 blurb,
@@ -120,15 +168,10 @@ public partial class ItemSeeder
                 "Tailoring",
                 minimumTraitValue,
                 difficulty,
-                Outcome.MinorFail,
-                5,
-                3,
-                false,
                 phases,
                 inputs,
                 tools,
                 products,
-                [],
                 knowledgeSubtype: knowledgeSubtype,
                 knowledgeDescription: knowledgeDescription,
                 knowledgeLongDescription: knowledgeDescription);
@@ -186,7 +229,7 @@ public partial class ItemSeeder
                 garment.Name,
                 $"assemble {garment.DisplayName} from {garment.Material} garment cloth",
                 garment.Name,
-                $"{garment.Material} cloth being assembled into {knowledgeSubtype} clothing",
+                $"{garment.Material} cloth being assembled into clothing",
                 garment.Minimum,
                 garment.Difficulty,
                 garment.Hair > 0 ? furTrimmedAssemblyPhases : garment.GeneratedProduct ? patternedAssemblyPhases : assemblyPhases,
@@ -220,7 +263,7 @@ public partial class ItemSeeder
             IEnumerable<(int Seconds, string Echo, string FailEcho)> phases, IEnumerable<string> inputs,
             IEnumerable<string> tools, IEnumerable<string> products)
         {
-            AddCraft(
+            AddAntiquityCraft(
                 name,
                 "Tailoring",
                 blurb,
@@ -230,15 +273,10 @@ public partial class ItemSeeder
                 "Tailoring",
                 minimumTraitValue,
                 difficulty,
-                Outcome.MinorFail,
-                5,
-                3,
-                false,
                 phases,
                 inputs,
                 tools,
                 products,
-                [],
                 knowledgeSubtype: "Roman",
                 knowledgeDescription: romanKnowledgeDescription,
                 knowledgeLongDescription: romanKnowledgeDescription);
@@ -246,7 +284,7 @@ public partial class ItemSeeder
 
         var romanAssemblyPhases = new (int Seconds, string Echo, string FailEcho)[]
         {
-            (35, "$0 lay|lays out $i1 and mark|marks the Roman garment dimensions and drape lines.", "$0 lay|lays out $i1, but mark|marks the garment dimensions unevenly."),
+            (35, "$0 lay|lays out $i1 and mark|marks the garment dimensions and drape lines.", "$0 lay|lays out $i1, but mark|marks the garment dimensions unevenly."),
             (35, "$0 cut|cuts the cloth with $t2 and shape|shapes the edges, openings, or rounded fall required by the garment.", "$0 cut|cuts with $t2, but the edges and openings sit awkwardly."),
             (40, "$0 thread|threads $t1 and finish|finishes hems, straps, joins, or weighted fold points as needed.", "$0 thread|threads $t1, but the hems and joins pull out of line."),
             (30, "$0 arrange|arranges $p1, checking the weight and drape.", "$0 arrange|arranges only $f1 after the cloth is spoiled.")
@@ -259,15 +297,15 @@ public partial class ItemSeeder
 
         foreach (var garment in new[]
         {
-            (StableReference: "antiquity_knee_length_wool_tunica", Name: "assemble a Roman knee-length wool tunica", DisplayName: "a Roman knee-length wool tunica", Material: "wool", Cloth: 540, Yarn: 25, Fine: false, Minimum: 15, Difficulty: Difficulty.Easy),
-            (StableReference: "antiquity_wool_travel_mantle", Name: "assemble a Roman wool travel mantle", DisplayName: "a Roman wool travel mantle", Material: "wool", Cloth: 920, Yarn: 35, Fine: false, Minimum: 15, Difficulty: Difficulty.Normal),
-            (StableReference: "antiquity_fine_linen_tunica", Name: "assemble a Roman fine linen tunica", DisplayName: "a Roman fine linen tunica", Material: "linen", Cloth: 360, Yarn: 25, Fine: true, Minimum: 35, Difficulty: Difficulty.Normal),
-            (StableReference: "antiquity_wool_toga", Name: "assemble a Roman wool toga", DisplayName: "a Roman wool toga", Material: "wool", Cloth: 2800, Yarn: 90, Fine: true, Minimum: 40, Difficulty: Difficulty.Hard),
-            (StableReference: "antiquity_long_wool_tunica", Name: "assemble a Roman long wool tunica", DisplayName: "a Roman long wool tunica", Material: "wool", Cloth: 650, Yarn: 30, Fine: false, Minimum: 20, Difficulty: Difficulty.Normal),
-            (StableReference: "antiquity_wool_palla", Name: "assemble a Roman wool palla", DisplayName: "a Roman wool palla", Material: "wool", Cloth: 870, Yarn: 35, Fine: false, Minimum: 20, Difficulty: Difficulty.Normal),
-            (StableReference: "antiquity_fine_long_linen_tunica", Name: "assemble a Roman fine long linen tunica", DisplayName: "a Roman fine long linen tunica", Material: "linen", Cloth: 400, Yarn: 30, Fine: true, Minimum: 40, Difficulty: Difficulty.Hard),
-            (StableReference: "antiquity_wool_stola", Name: "assemble a Roman wool stola", DisplayName: "a Roman wool stola", Material: "wool", Cloth: 860, Yarn: 40, Fine: true, Minimum: 40, Difficulty: Difficulty.Hard),
-            (StableReference: "antiquity_fine_wool_palla", Name: "assemble a Roman fine wool palla", DisplayName: "a Roman fine wool palla", Material: "wool", Cloth: 820, Yarn: 35, Fine: true, Minimum: 40, Difficulty: Difficulty.Hard)
+            (StableReference: "antiquity_knee_length_wool_tunica", Name: "assemble a knee-length wool tunica", DisplayName: "a knee-length wool tunica", Material: "wool", Cloth: 540, Yarn: 25, Fine: false, Minimum: 15, Difficulty: Difficulty.Easy),
+            (StableReference: "antiquity_wool_travel_mantle", Name: "assemble a wool travel mantle", DisplayName: "a wool travel mantle", Material: "wool", Cloth: 920, Yarn: 35, Fine: false, Minimum: 15, Difficulty: Difficulty.Normal),
+            (StableReference: "antiquity_fine_linen_tunica", Name: "assemble a fine linen tunica", DisplayName: "a fine linen tunica", Material: "linen", Cloth: 360, Yarn: 25, Fine: true, Minimum: 35, Difficulty: Difficulty.Normal),
+            (StableReference: "antiquity_wool_toga", Name: "assemble a wool toga", DisplayName: "a wool toga", Material: "wool", Cloth: 2800, Yarn: 90, Fine: true, Minimum: 40, Difficulty: Difficulty.Hard),
+            (StableReference: "antiquity_long_wool_tunica", Name: "assemble a long wool tunica", DisplayName: "a long wool tunica", Material: "wool", Cloth: 650, Yarn: 30, Fine: false, Minimum: 20, Difficulty: Difficulty.Normal),
+            (StableReference: "antiquity_wool_palla", Name: "assemble a wool palla", DisplayName: "a wool palla", Material: "wool", Cloth: 870, Yarn: 35, Fine: false, Minimum: 20, Difficulty: Difficulty.Normal),
+            (StableReference: "antiquity_fine_long_linen_tunica", Name: "assemble a fine long linen tunica", DisplayName: "a fine long linen tunica", Material: "linen", Cloth: 400, Yarn: 30, Fine: true, Minimum: 40, Difficulty: Difficulty.Hard),
+            (StableReference: "antiquity_wool_stola", Name: "assemble a wool stola", DisplayName: "a wool stola", Material: "wool", Cloth: 860, Yarn: 40, Fine: true, Minimum: 40, Difficulty: Difficulty.Hard),
+            (StableReference: "antiquity_fine_wool_palla", Name: "assemble a fine wool palla", DisplayName: "a fine wool palla", Material: "wool", Cloth: 820, Yarn: 35, Fine: true, Minimum: 40, Difficulty: Difficulty.Hard)
         })
         {
             var characteristicRequirements = garment.Fine
@@ -277,7 +315,7 @@ public partial class ItemSeeder
                 garment.Name,
                 $"assemble {garment.DisplayName} from {garment.Material} garment cloth",
                 garment.Name,
-                $"{garment.Material} cloth being assembled into Roman clothing",
+                $"{garment.Material} cloth being assembled into clothing",
                 garment.Minimum,
                 garment.Difficulty,
                 romanAssemblyPhases,
@@ -307,16 +345,16 @@ public partial class ItemSeeder
             "Punic",
             punicKnowledgeDescription,
             [
-                new("antiquity_short_fitted_linen_tunic", "assemble a Punic short fitted linen tunic", "a Punic short fitted linen tunic", "linen", 340, 20, false, 15, Difficulty.Normal),
-                new("antiquity_patterned_linen_waistcloth", "assemble a Punic patterned linen waistcloth", "a Punic patterned linen waistcloth", "linen", 220, 15, true, 30, Difficulty.Normal),
-                new("antiquity_short_sleeved_linen_overblouse", "assemble a Punic short sleeved linen overblouse", "a Punic short sleeved linen overblouse", "linen", 300, 20, true, 35, Difficulty.Normal),
-                new("antiquity_long_linen_inner_robe", "assemble a Punic long linen inner robe", "a Punic long linen inner robe", "linen", 670, 30, false, 20, Difficulty.Normal),
-                new("antiquity_one_shoulder_wool_mantle", "assemble a Punic one shoulder wool mantle", "a Punic one shoulder wool mantle", "wool", 940, 35, false, 20, Difficulty.Normal),
-                new("antiquity_long_folded_linen_robe", "assemble a Punic long folded linen robe", "a Punic long folded linen robe", "linen", 745, 35, false, 25, Difficulty.Normal),
-                new("antiquity_loose_linen_hood", "assemble a Punic loose linen hood", "a Punic loose linen hood", "linen", 125, 10, false, 15, Difficulty.Easy),
-                new("antiquity_fine_full_linen_gown", "assemble a Punic fine full linen gown", "a Punic fine full linen gown", "linen", 820, 40, true, 40, Difficulty.Hard),
-                new("antiquity_left_shoulder_overdrape", "assemble a Punic left shoulder overdrape", "a Punic left shoulder overdrape", "linen", 280, 20, true, 35, Difficulty.Normal),
-                new("antiquity_star_bordered_linen_robe", "assemble a Punic star bordered linen robe", "a Punic star bordered linen robe", "linen", 780, 40, true, 40, Difficulty.Hard)
+                new("antiquity_short_fitted_linen_tunic", "assemble a short fitted linen tunic", "a short fitted linen tunic", "linen", 340, 20, false, 15, Difficulty.Normal),
+                new("antiquity_patterned_linen_waistcloth", "assemble a patterned linen waistcloth", "a patterned linen waistcloth", "linen", 220, 15, true, 30, Difficulty.Normal),
+                new("antiquity_short_sleeved_linen_overblouse", "assemble a short sleeved linen overblouse", "a short sleeved linen overblouse", "linen", 300, 20, true, 35, Difficulty.Normal),
+                new("antiquity_long_linen_inner_robe", "assemble a long linen inner robe", "a long linen inner robe", "linen", 670, 30, false, 20, Difficulty.Normal),
+                new("antiquity_one_shoulder_wool_mantle", "assemble a one shoulder wool mantle", "a one shoulder wool mantle", "wool", 940, 35, false, 20, Difficulty.Normal),
+                new("antiquity_long_folded_linen_robe", "assemble a long folded linen robe", "a long folded linen robe", "linen", 745, 35, false, 25, Difficulty.Normal),
+                new("antiquity_loose_linen_hood", "assemble a loose linen hood", "a loose linen hood", "linen", 125, 10, false, 15, Difficulty.Easy),
+                new("antiquity_fine_full_linen_gown", "assemble a fine full linen gown", "a fine full linen gown", "linen", 820, 40, true, 40, Difficulty.Hard),
+                new("antiquity_left_shoulder_overdrape", "assemble a left shoulder overdrape", "a left shoulder overdrape", "linen", 280, 20, true, 35, Difficulty.Normal),
+                new("antiquity_star_bordered_linen_robe", "assemble a star bordered linen robe", "a star bordered linen robe", "linen", 780, 40, true, 40, Difficulty.Hard)
             ]);
     }
 
@@ -337,17 +375,17 @@ public partial class ItemSeeder
             "Persian",
             persianKnowledgeDescription,
             [
-                new("antiquity_sarapis_wool_tunic", "assemble a Persian wool sarapis", "a Persian wool sarapis", "wool", 690, 35, false, 20, Difficulty.Normal),
-                new("antiquity_fine_sarapis_linen_tunic", "assemble a Persian fine linen sarapis", "a Persian fine linen sarapis", "linen", 495, 30, true, 35, Difficulty.Normal),
-                new("antiquity_anaxyrides_wool_trousers", "assemble Persian wool anaxyrides", "Persian wool anaxyrides", "wool", 590, 30, false, 20, Difficulty.Normal),
-                new("antiquity_fine_patterned_anaxyrides", "assemble Persian fine patterned anaxyrides", "Persian fine patterned anaxyrides", "wool", 440, 35, true, 40, Difficulty.Hard, true, 120),
-                new("antiquity_wool_kandys", "assemble a Persian wool kandys", "a Persian wool kandys", "wool", 1290, 50, false, 25, Difficulty.Hard),
-                new("antiquity_fine_wool_kandys", "assemble a Persian fine wool kandys", "a Persian fine wool kandys", "wool", 1190, 50, true, 45, Difficulty.Hard),
-                new("antiquity_pleated_court_robe", "assemble a Persian pleated court robe", "a Persian pleated court robe", "linen", 930, 50, true, 45, Difficulty.Hard),
-                new("antiquity_fine_pleated_court_gown", "assemble a Persian fine pleated court gown", "a Persian fine pleated court gown", "linen", 835, 45, true, 45, Difficulty.Hard),
-                new("antiquity_wide_cloth_belt", "assemble a Persian wide cloth belt", "a Persian wide cloth belt", "linen", 150, 10, false, 15, Difficulty.Easy),
-                new("antiquity_fine_wide_cloth_belt", "assemble a Persian fine wide cloth belt", "a Persian fine wide cloth belt", "linen", 135, 10, true, 30, Difficulty.Normal),
-                new("antiquity_full_head_and_neck_veil", "assemble a Persian full head and neck veil", "a Persian full head and neck veil", "linen", 175, 15, true, 35, Difficulty.Normal)
+                new("antiquity_sarapis_wool_tunic", "assemble a wool sarapis", "a wool sarapis", "wool", 690, 35, false, 20, Difficulty.Normal),
+                new("antiquity_fine_sarapis_linen_tunic", "assemble a fine linen sarapis", "a fine linen sarapis", "linen", 495, 30, true, 35, Difficulty.Normal),
+                new("antiquity_anaxyrides_wool_trousers", "assemble wool anaxyrides", "wool anaxyrides", "wool", 590, 30, false, 20, Difficulty.Normal),
+                new("antiquity_fine_patterned_anaxyrides", "assemble fine patterned anaxyrides", "fine patterned anaxyrides", "wool", 440, 35, true, 40, Difficulty.Hard, true, 120),
+                new("antiquity_wool_kandys", "assemble a wool kandys", "a wool kandys", "wool", 1290, 50, false, 25, Difficulty.Hard),
+                new("antiquity_fine_wool_kandys", "assemble a fine wool kandys", "a fine wool kandys", "wool", 1190, 50, true, 45, Difficulty.Hard),
+                new("antiquity_pleated_court_robe", "assemble a pleated court robe", "a pleated court robe", "linen", 930, 50, true, 45, Difficulty.Hard),
+                new("antiquity_fine_pleated_court_gown", "assemble a fine pleated court gown", "a fine pleated court gown", "linen", 835, 45, true, 45, Difficulty.Hard),
+                new("antiquity_wide_cloth_belt", "assemble a wide cloth belt", "a wide cloth belt", "linen", 150, 10, false, 15, Difficulty.Easy),
+                new("antiquity_fine_wide_cloth_belt", "assemble a fine wide cloth belt", "a fine wide cloth belt", "linen", 135, 10, true, 30, Difficulty.Normal),
+                new("antiquity_full_head_and_neck_veil", "assemble a full head and neck veil", "a full head and neck veil", "linen", 175, 15, true, 35, Difficulty.Normal)
             ]);
     }
 
@@ -368,14 +406,14 @@ public partial class ItemSeeder
             "Etruscan",
             etruscanKnowledgeDescription,
             [
-                new("adjacent_antiquity_short_sleeved_linen_tunic", "assemble an Etruscan short sleeved linen tunic", "an Etruscan short sleeved linen tunic", "linen", 395, 25, false, 15, Difficulty.Normal),
-                new("adjacent_antiquity_bordered_wool_tunic", "assemble an Etruscan bordered wool tunic", "an Etruscan bordered wool tunic", "wool", 530, 30, true, 35, Difficulty.Normal),
-                new("adjacent_antiquity_curved_tebenna", "assemble an Etruscan curved wool tebenna", "an Etruscan curved wool tebenna", "wool", 860, 35, false, 25, Difficulty.Normal),
-                new("adjacent_antiquity_fine_curved_tebenna", "assemble an Etruscan fine curved wool tebenna", "an Etruscan fine curved wool tebenna", "wool", 780, 35, true, 40, Difficulty.Hard),
-                new("adjacent_antiquity_wrapped_linen_skirt", "assemble an Etruscan wrapped linen skirt", "an Etruscan wrapped linen skirt", "linen", 340, 20, false, 15, Difficulty.Normal),
-                new("adjacent_antiquity_rectangular_shoulder_cloak", "assemble an Etruscan rectangular shoulder cloak", "an Etruscan rectangular shoulder cloak", "wool", 740, 35, false, 20, Difficulty.Normal),
-                new("adjacent_antiquity_fitted_linen_gown", "assemble an Etruscan fitted linen gown", "an Etruscan fitted linen gown", "linen", 590, 35, true, 40, Difficulty.Hard),
-                new("adjacent_antiquity_linen_head_mantle", "assemble an Etruscan linen head mantle", "an Etruscan linen head mantle", "linen", 165, 15, true, 30, Difficulty.Normal)
+                new("adjacent_antiquity_short_sleeved_linen_tunic", "assemble a short sleeved linen tunic", "a short sleeved linen tunic", "linen", 395, 25, false, 15, Difficulty.Normal),
+                new("adjacent_antiquity_bordered_wool_tunic", "assemble a bordered wool tunic", "a bordered wool tunic", "wool", 530, 30, true, 35, Difficulty.Normal),
+                new("adjacent_antiquity_curved_tebenna", "assemble a curved wool tebenna", "a curved wool tebenna", "wool", 860, 35, false, 25, Difficulty.Normal),
+                new("adjacent_antiquity_fine_curved_tebenna", "assemble a fine curved wool tebenna", "a fine curved wool tebenna", "wool", 780, 35, true, 40, Difficulty.Hard),
+                new("adjacent_antiquity_wrapped_linen_skirt", "assemble a wrapped linen skirt", "a wrapped linen skirt", "linen", 340, 20, false, 15, Difficulty.Normal),
+                new("adjacent_antiquity_rectangular_shoulder_cloak", "assemble a rectangular shoulder cloak", "a rectangular shoulder cloak", "wool", 740, 35, false, 20, Difficulty.Normal),
+                new("adjacent_antiquity_fitted_linen_gown", "assemble a fitted linen gown", "a fitted linen gown", "linen", 590, 35, true, 40, Difficulty.Hard),
+                new("adjacent_antiquity_linen_head_mantle", "assemble a linen head mantle", "a linen head mantle", "linen", 165, 15, true, 30, Difficulty.Normal)
             ]);
     }
 
@@ -396,16 +434,16 @@ public partial class ItemSeeder
             "Anatolian",
             anatolianKnowledgeDescription,
             [
-                new("adjacent_antiquity_belted_wool_tunic", "assemble an Anatolian belted wool tunic", "an Anatolian belted wool tunic", "wool", 590, 30, false, 20, Difficulty.Normal),
-                new("adjacent_antiquity_fine_banded_tunic", "assemble an Anatolian fine banded wool tunic", "an Anatolian fine banded wool tunic", "wool", 450, 35, true, 40, Difficulty.Hard, true, 130),
-                new("adjacent_antiquity_banded_leg_wraps", "assemble Anatolian banded wool leg wraps", "Anatolian banded wool leg wraps", "wool", 160, 10, false, 15, Difficulty.Easy),
-                new("adjacent_antiquity_hooded_wool_cloak", "assemble an Anatolian hooded wool cloak", "an Anatolian hooded wool cloak", "wool", 1000, 45, false, 25, Difficulty.Hard),
-                new("adjacent_antiquity_forward_pointing_felt_cap", "assemble an Anatolian forward pointing felt cap", "an Anatolian forward pointing felt cap", "felt", 105, 8, false, 20, Difficulty.Normal),
-                new("adjacent_antiquity_short_wool_cape", "assemble an Anatolian short wool cape", "an Anatolian short wool cape", "wool", 495, 25, false, 20, Difficulty.Normal),
-                new("adjacent_antiquity_fine_patterned_wool_robe", "assemble an Anatolian fine patterned wool robe", "an Anatolian fine patterned wool robe", "wool", 855, 45, true, 45, Difficulty.Hard),
-                new("adjacent_antiquity_fringed_wool_mantle", "assemble an Anatolian fringed wool mantle", "an Anatolian fringed wool mantle", "wool", 720, 40, true, 40, Difficulty.Hard),
-                new("adjacent_antiquity_wool_wrapped_skirt", "assemble an Anatolian wrapped wool skirt", "an Anatolian wrapped wool skirt", "wool", 515, 25, false, 20, Difficulty.Normal),
-                new("adjacent_antiquity_fine_rectangular_veil", "assemble an Anatolian fine rectangular linen veil", "an Anatolian fine rectangular linen veil", "linen", 110, 10, true, 30, Difficulty.Normal)
+                new("adjacent_antiquity_belted_wool_tunic", "assemble a belted wool tunic", "a belted wool tunic", "wool", 590, 30, false, 20, Difficulty.Normal),
+                new("adjacent_antiquity_fine_banded_tunic", "assemble a highland fine banded wool tunic", "a highland fine banded wool tunic", "wool", 450, 35, true, 40, Difficulty.Hard, true, 130),
+                new("adjacent_antiquity_banded_leg_wraps", "assemble banded wool leg wraps", "banded wool leg wraps", "wool", 160, 10, false, 15, Difficulty.Easy),
+                new("adjacent_antiquity_hooded_wool_cloak", "assemble a hooded wool cloak", "a hooded wool cloak", "wool", 1000, 45, false, 25, Difficulty.Hard),
+                new("adjacent_antiquity_forward_pointing_felt_cap", "assemble a forward pointing felt cap", "a forward pointing felt cap", "felt", 105, 8, false, 20, Difficulty.Normal),
+                new("adjacent_antiquity_short_wool_cape", "assemble a short wool cape", "a short wool cape", "wool", 495, 25, false, 20, Difficulty.Normal),
+                new("adjacent_antiquity_fine_patterned_wool_robe", "assemble a fine patterned wool robe", "a fine patterned wool robe", "wool", 855, 45, true, 45, Difficulty.Hard),
+                new("adjacent_antiquity_fringed_wool_mantle", "assemble a fringed wool mantle", "a fringed wool mantle", "wool", 720, 40, true, 40, Difficulty.Hard),
+                new("adjacent_antiquity_wool_wrapped_skirt", "assemble a wrapped wool skirt", "a wrapped wool skirt", "wool", 515, 25, false, 20, Difficulty.Normal),
+                new("adjacent_antiquity_fine_rectangular_veil", "assemble a fine rectangular linen veil", "a fine rectangular linen veil", "linen", 110, 10, true, 30, Difficulty.Normal)
             ]);
     }
 
@@ -426,16 +464,714 @@ public partial class ItemSeeder
             "Scythian-Sarmatian",
             scythianKnowledgeDescription,
             [
-                new("adjacent_antiquity_felt_riding_cap", "assemble a Scythian felt riding cap", "a Scythian felt riding cap", "felt", 90, 8, false, 20, Difficulty.Normal),
-                new("adjacent_antiquity_tall_felt_cap", "assemble a Scythian tall felt cap", "a Scythian tall felt cap", "felt", 130, 10, true, 35, Difficulty.Hard),
-                new("adjacent_antiquity_riding_tunic", "assemble a Scythian riding tunic", "a Scythian riding tunic", "wool", 645, 35, false, 20, Difficulty.Normal),
-                new("adjacent_antiquity_wool_riding_trousers", "assemble Scythian wool riding trousers", "Scythian wool riding trousers", "wool", 495, 25, false, 20, Difficulty.Normal),
-                new("adjacent_antiquity_patterned_riding_trousers", "assemble Scythian patterned riding trousers", "Scythian patterned riding trousers", "wool", 470, 30, true, 35, Difficulty.Hard),
-                new("adjacent_antiquity_open_riding_caftan", "assemble a Scythian open riding caftan", "a Scythian open riding caftan", "wool", 820, 40, false, 25, Difficulty.Hard),
-                new("adjacent_antiquity_fur_trimmed_caftan", "assemble a Scythian fur trimmed caftan", "a Scythian fur trimmed caftan", "wool", 1060, 45, true, 45, Difficulty.Hard, Hair: 140),
-                new("adjacent_antiquity_split_riding_skirt", "assemble a Scythian split riding skirt", "a Scythian split riding skirt", "wool", 590, 30, false, 20, Difficulty.Normal),
-                new("adjacent_antiquity_long_felt_coat", "assemble a Scythian long felt coat", "a Scythian long felt coat", "felt", 1270, 50, true, 45, Difficulty.Hard)
+                new("adjacent_antiquity_felt_riding_cap", "assemble a felt riding cap", "a felt riding cap", "felt", 90, 8, false, 20, Difficulty.Normal),
+                new("adjacent_antiquity_tall_felt_cap", "assemble a tall felt cap", "a tall felt cap", "felt", 130, 10, true, 35, Difficulty.Hard),
+                new("adjacent_antiquity_riding_tunic", "assemble a riding tunic", "a riding tunic", "wool", 645, 35, false, 20, Difficulty.Normal),
+                new("adjacent_antiquity_wool_riding_trousers", "assemble wool riding trousers", "wool riding trousers", "wool", 495, 25, false, 20, Difficulty.Normal),
+                new("adjacent_antiquity_patterned_riding_trousers", "assemble patterned riding trousers", "patterned riding trousers", "wool", 470, 30, true, 35, Difficulty.Hard),
+                new("adjacent_antiquity_open_riding_caftan", "assemble an open riding caftan", "an open riding caftan", "wool", 820, 40, false, 25, Difficulty.Hard),
+                new("adjacent_antiquity_fur_trimmed_caftan", "assemble a fur trimmed caftan", "a fur trimmed caftan", "wool", 1060, 45, true, 45, Difficulty.Hard, Hair: 140),
+                new("adjacent_antiquity_split_riding_skirt", "assemble a split riding skirt", "a split riding skirt", "wool", 590, 30, false, 20, Difficulty.Normal),
+                new("adjacent_antiquity_long_felt_coat", "assemble a long felt coat", "a long felt coat", "felt", 1270, 50, true, 45, Difficulty.Hard)
             ]);
+    }
+
+    private const string AntiquityLeatherKnowledge = "Ancient Hide and Leatherworking";
+
+    private const string AntiquityLeatherKnowledgeDescription =
+        "Shared ancient hideworking knowledge for scraping, dehairing, tanning, cutting leather stock, and assembling leather clothing, armour, containers, and camp fittings.";
+
+    private void AddAntiquityLeatherCraft(
+        string name,
+        string blurb,
+        string action,
+        string itemDescription,
+        int minimumTraitValue,
+        Difficulty difficulty,
+        IEnumerable<(int Seconds, string Echo, string FailEcho)> phases,
+        IEnumerable<string> inputs,
+        IEnumerable<string> tools,
+        IEnumerable<string> products,
+        IEnumerable<string>? failProducts = null)
+    {
+        AddAntiquityCraft(
+            name,
+            "Leatherworking",
+            blurb,
+            action,
+            itemDescription,
+            AntiquityLeatherKnowledge,
+            "Leathermaking",
+            minimumTraitValue,
+            difficulty,
+            phases,
+            inputs,
+            tools,
+            products,
+            failProducts,
+            knowledgeSubtype: "Leatherworking",
+            knowledgeDescription: AntiquityLeatherKnowledgeDescription,
+            knowledgeLongDescription: AntiquityLeatherKnowledgeDescription);
+    }
+
+    private static void AddLeatherCommodityInput(ICollection<string> inputs, int grams, string pileTag)
+    {
+        if (grams <= 0)
+        {
+            return;
+        }
+
+        inputs.Add($"Commodity - {grams} grams of leather; piletag {pileTag}; characteristic Colour any; characteristic Fine Colour any");
+    }
+
+    private sealed record AntiquityLeatherClothingCraftSpec(
+        string StableReference,
+        string Name,
+        string DisplayName,
+        int Leather,
+        int Soles,
+        int Straps,
+        int Thongs,
+        int LinenYarn,
+        bool VariableProduct,
+        int Minimum,
+        Difficulty Difficulty,
+        bool Footwear = true);
+
+    private void SeedAntiquityLeatherPreparationCrafts()
+    {
+        if (!ShouldSeedAntiquityCrafts())
+        {
+            return;
+        }
+
+        AddAntiquityLeatherCraft(
+            "scrape and dehair animal hides",
+            "scrape and dehair raw animal hides into prepared hide stock",
+            "scraping and dehairing animal hides",
+            "animal hides being scraped into prepared hide stock",
+            1,
+            Difficulty.Easy,
+            [
+                (30, "$0 spread|spreads $i1 over $t1 and rinse|rinses it with clean water.", "$0 spread|spreads $i1 over $t1, but leave|leaves dirt and blood through the hide."),
+                (40, "$0 scrape|scrapes flesh and fat away with $t2.", "$0 scrape|scrapes with $t2, but gouge|gouges and weakens the hide."),
+                (40, "$0 work|works $t3 along the hair side until the loose hair is stripped away.", "$0 work|works $t3 unevenly and leave|leaves stubborn patches behind."),
+                (25, "$0 fold|folds $p1 into a clean prepared hide bundle.", "$0 salvage|salvages only $f1 from the damaged hide.")
+            ],
+            [
+                "CommodityTag - 1 kilogram 600 grams of a material tagged as Animal Skin",
+                "LiquidUse - 2 litres of Water"
+            ],
+            [
+                "TagTool - InRoom - an item with the Tanning Beam tag",
+                "TagTool - Held - an item with the Hide Scraper tag",
+                "TagTool - Held - an item with the Leather Dehairing Knife tag"
+            ],
+            ["CommodityProduct - 1 kilogram 200 grams of animal skin commodity; tag Prepared Hide; characteristic Colour=brown; characteristic Fine Colour=light brown"],
+            ["CommodityProduct - 400 grams of animal skin commodity; tag Prepared Hide; characteristic Colour=brown; characteristic Fine Colour=light brown"]);
+
+        AddAntiquityLeatherCraft(
+            "tan prepared hides into leather",
+            "tan prepared hides into supple leather stock",
+            "tanning prepared hides",
+            "prepared hides being tanned into leather",
+            10,
+            Difficulty.Normal,
+            [
+                (35, "$0 soak|soaks $i1 in clean water and work|works the hide open.", "$0 soak|soaks $i1 unevenly, leaving stiff dry patches."),
+                (50, "$0 steep|steeps the hide with $i3, turning it with $t2 and keeping the tanning liquor even.", "$0 steep|steeps the hide poorly and leave|leaves the tanning liquor uneven."),
+                (45, "$0 stretch|stretches the treated hide over $t1 and scrape|scrapes it smooth.", "$0 stretch|stretches the hide poorly over $t1, warping the grain."),
+                (30, "$0 oil|oils and fold|folds $p1 into usable leather stock.", "$0 salvage|salvages only $f1 from the uneven tanning.")
+            ],
+            [
+                "Commodity - 1 kilogram 200 grams of animal skin; piletag Prepared Hide; characteristic Colour any; characteristic Fine Colour any",
+                "LiquidUse - 3 litres of Water",
+                "LiquidTagUse - 2 litres of a liquid tagged Tanning Agent"
+            ],
+            [
+                "TagTool - InRoom - an item with the Tanning Rack tag",
+                "TagTool - Held - an item with the Tanning Paddle tag",
+                "TagTool - InRoom - an item with the Brain Tanning Bucket tag"
+            ],
+            ["CommodityProduct - 1 kilogram of leather commodity; tag Tanned Leather; characteristic Colour from $i1; characteristic Fine Colour from $i1"],
+            ["CommodityProduct - 300 grams of leather commodity; tag Tanned Leather; characteristic Colour from $i1; characteristic Fine Colour from $i1"]);
+
+        AddAntiquityLeatherCraft(
+            "cut leather soles",
+            "cut tanned leather into matched sole blanks",
+            "cutting leather soles",
+            "tanned leather being cut into sole blanks",
+            10,
+            Difficulty.Normal,
+            [
+                (25, "$0 flatten|flattens $i1 and mark|marks matched sole outlines.", "$0 flatten|flattens $i1 poorly and mark|marks mismatched soles."),
+                (35, "$0 cut|cuts the sole blanks free with $t1.", "$0 cut|cuts with $t1, but the sole edges pull ragged."),
+                (30, "$0 trim|trims and bevel|bevels the edges with $t2.", "$0 trim|trims with $t2, but the edges remain uneven."),
+                (20, "$0 stack|stacks $p1 for footwear assembly.", "$0 salvage|salvages only $f1 from the miscut leather.")
+            ],
+            ["Commodity - 700 grams of leather; piletag Tanned Leather; characteristic Colour any; characteristic Fine Colour any"],
+            [
+                "TagTool - Held - an item with the Leather Gouge tag",
+                "TagTool - Held - an item with the Edge Beveller tag"
+            ],
+            ["CommodityProduct - 560 grams of leather commodity; tag Leather Sole; characteristic Colour from $i1; characteristic Fine Colour from $i1"],
+            ["CommodityProduct - 120 grams of leather commodity; tag Tanned Leather; characteristic Colour from $i1; characteristic Fine Colour from $i1"]);
+
+        AddAntiquityLeatherCraft(
+            "cut leather straps and thongs",
+            "cut tanned leather into straps and narrow thongs",
+            "cutting leather straps and thongs",
+            "tanned leather being cut into straps and thongs",
+            10,
+            Difficulty.Normal,
+            [
+                (25, "$0 measure|measures strap widths along $i1.", "$0 measure|measures $i1 unevenly."),
+                (35, "$0 draw|draws $t1 along the leather, cutting long straps.", "$0 draw|draws $t1 poorly and split|splits the straps."),
+                (35, "$0 cut|cuts narrower tying thongs and crease|creases the wider straps with $t3.", "$0 cut|cuts the thongs ragged and overwork|overworks the straps."),
+                (20, "$0 coil|coils $p1 with the matching thongs for assembly work.", "$0 salvage|salvages only $f1 from the ruined offcuts.")
+            ],
+            ["Commodity - 500 grams of leather; piletag Tanned Leather; characteristic Colour any; characteristic Fine Colour any"],
+            [
+                "TagTool - Held - an item with the Leather Gouge tag",
+                "TagTool - Held - an item with the Edge Beveller tag",
+                "TagTool - Held - an item with the Leather Creaser tag"
+            ],
+            [
+                "CommodityProduct - 320 grams of leather commodity; tag Leather Strap; characteristic Colour from $i1; characteristic Fine Colour from $i1",
+                "CommodityProduct - 120 grams of leather commodity; tag Leather Thong; characteristic Colour from $i1; characteristic Fine Colour from $i1"
+            ],
+            ["CommodityProduct - 80 grams of leather commodity; tag Leather Thong; characteristic Colour from $i1; characteristic Fine Colour from $i1"]);
+
+        AddAntiquityLeatherCraft(
+            "cut leather panels",
+            "cut tanned leather into broad panels for armour and containers",
+            "cutting leather panels",
+            "tanned leather being cut into broad panels",
+            15,
+            Difficulty.Normal,
+            [
+                (30, "$0 square|squares $i1 and mark|marks broad panel lines across the grain.", "$0 square|squares $i1 poorly, leaving the panel marks crooked."),
+                (40, "$0 draw|draws $t1 along the marks, cutting panel blanks free.", "$0 draw|draws $t1 unevenly and split|splits the panel edges."),
+                (30, "$0 bevel|bevels and crease|creases the panel edges with $t2 and $t3.", "$0 bevel|bevels the panels poorly, leaving thick and ragged edges."),
+                (20, "$0 stack|stacks $p1 for armour and container work.", "$0 salvage|salvages only $f1 from the miscut panels.")
+            ],
+            ["Commodity - 1 kilogram 100 grams of leather; piletag Tanned Leather; characteristic Colour any; characteristic Fine Colour any"],
+            [
+                "TagTool - Held - an item with the Leather Gouge tag",
+                "TagTool - Held - an item with the Edge Beveller tag",
+                "TagTool - Held - an item with the Leather Creaser tag"
+            ],
+            ["CommodityProduct - 920 grams of leather commodity; tag Leather Panel; characteristic Colour from $i1; characteristic Fine Colour from $i1"],
+            ["CommodityProduct - 160 grams of leather commodity; tag Tanned Leather; characteristic Colour from $i1; characteristic Fine Colour from $i1"]);
+
+        AddAntiquityLeatherCraft(
+            "harden leather panels",
+            "wax-harden leather panels for armour plates",
+            "hardening leather panels",
+            "leather panels being wax-hardened",
+            25,
+            Difficulty.Hard,
+            [
+                (35, "$0 soak|soaks $i1 in clean water and warm|warms beeswax in $t1.", "$0 soak|soaks $i1 unevenly and overheat|overheats patches of wax."),
+                (45, "$0 soften|softens the panels near $t2 and work|works wax into the grain.", "$0 soften|softens the panels poorly, leaving brittle and limp patches together."),
+                (45, "$0 shape|shapes the panels over $t3 as they cool and stiffen.", "$0 shape|shapes the panels carelessly, warping the hardened faces."),
+                (25, "$0 set|sets aside $p1 for armour assembly.", "$0 salvage|salvages only $f1 from the spoiled hardening.")
+            ],
+            [
+                "Commodity - 800 grams of leather; piletag Leather Panel; characteristic Colour any; characteristic Fine Colour any",
+                "Commodity - 120 grams of beeswax",
+                "LiquidUse - 1 litre of Water"
+            ],
+            [
+                "TagTool - InRoom - an item with the Leather Wax Pot tag",
+                "TagTool - InRoom - an item with the Hot Fire tag",
+                "TagTool - InRoom - an item with the Tanning Rack tag"
+            ],
+            ["CommodityProduct - 760 grams of leather commodity; tag Hardened Leather Panel; characteristic Colour from $i1; characteristic Fine Colour from $i1"],
+            ["CommodityProduct - 250 grams of leather commodity; tag Leather Panel; characteristic Colour from $i1; characteristic Fine Colour from $i1"]);
+
+        AddAntiquityLeatherCraft(
+            "cut hardened leather scales",
+            "cut hardened panels into lacing-ready leather scales",
+            "cutting hardened leather scales",
+            "hardened leather panels being cut into scales",
+            30,
+            Difficulty.Hard,
+            [
+                (30, "$0 mark|marks even scale rows across $i1.", "$0 mark|marks $i1 unevenly, leaving mismatched scale sizes."),
+                (45, "$0 cut|cuts the scales free with $t1 and smooth|smooths their lower edges with $t2.", "$0 cut|cuts with $t1, but the scales chip and split."),
+                (40, "$0 punch|punches lacing holes with $t3, keeping each scale aligned.", "$0 punch|punches the holes unevenly so the scales will not lace flat."),
+                (25, "$0 gather|gathers $p1 into measured scale stock.", "$0 salvage|salvages only $f1 from the broken scale stock.")
+            ],
+            ["Commodity - 650 grams of leather; piletag Hardened Leather Panel; characteristic Colour any; characteristic Fine Colour any"],
+            [
+                "TagTool - Held - an item with the Leather Gouge tag",
+                "TagTool - Held - an item with the Edge Beveller tag",
+                "TagTool - Held - an item with the Awl Punch tag"
+            ],
+            ["CommodityProduct - 520 grams of leather commodity; tag Leather Scale; characteristic Colour from $i1; characteristic Fine Colour from $i1"],
+            ["CommodityProduct - 120 grams of leather commodity; tag Hardened Leather Panel; characteristic Colour from $i1; characteristic Fine Colour from $i1"]);
+
+        AddAntiquityLeatherCraft(
+            "seal leather panels for vessels",
+            "wax-seal leather panels for waterskins, flasks, and travel cups",
+            "sealing leather panels for vessels",
+            "leather panels being sealed for liquid containers",
+            20,
+            Difficulty.Normal,
+            [
+                (30, "$0 warm|warms beeswax in $t1 and wipe|wipes $i1 clean.", "$0 warm|warms the wax unevenly and leave|leaves grit on the leather."),
+                (40, "$0 work|works wax across the grain and seams of each panel.", "$0 work|works wax into the panels poorly, leaving dry streaks."),
+                (35, "$0 flex|flexes the panels while the wax sets, checking for cracks.", "$0 flex|flexes the panels too sharply and crack|cracks the sealed surface."),
+                (20, "$0 stack|stacks $p1 for vessel assembly.", "$0 salvage|salvages only $f1 from the failed sealing.")
+            ],
+            [
+                "Commodity - 650 grams of leather; piletag Leather Panel; characteristic Colour any; characteristic Fine Colour any",
+                "Commodity - 90 grams of beeswax"
+            ],
+            [
+                "TagTool - InRoom - an item with the Leather Wax Pot tag",
+                "TagTool - InRoom - an item with the Hot Fire tag",
+                "TagTool - Held - an item with the Leather Creaser tag"
+            ],
+            ["CommodityProduct - 600 grams of leather commodity; tag Sealed Leather Panel; characteristic Colour from $i1; characteristic Fine Colour from $i1"],
+            ["CommodityProduct - 180 grams of leather commodity; tag Leather Panel; characteristic Colour from $i1; characteristic Fine Colour from $i1"]);
+    }
+
+    private void SeedAntiquityLeatherClothingCrafts()
+    {
+        if (!ShouldSeedAntiquityCrafts())
+        {
+            return;
+        }
+
+        var missingGarments = AntiquityLeatherClothingStableReferences.Keys
+            .Where(x => !TryLookupReworkItem(x, out _))
+            .ToList();
+        if (missingGarments.Count > 0)
+        {
+            return;
+        }
+
+        var beltTools = new[]
+        {
+            "TagTool - Held - an item with the Awl Punch tag",
+            "TagTool - Held - an item with the Leather Stitching Pony tag",
+            "TagTool - Held - an item with the Edge Beveller tag"
+        };
+        var footwearTools = new[]
+        {
+            "TagTool - Held - an item with the Awl Punch tag",
+            "TagTool - Held - an item with the Leather Stitching Pony tag",
+            "TagTool - Held - an item with the Edge Beveller tag",
+            "TagTool - Held - an item with the Shoe Last tag"
+        };
+        var assemblyPhases = new (int Seconds, string Echo, string FailEcho)[]
+        {
+            (35, "$0 mark|marks the leather pieces, straps, and stitching lines.", "$0 mark|marks the leather unevenly."),
+            (40, "$0 punch|punches stitch holes with $t1 and smooth|smooths exposed edges with $t3.", "$0 punch|punches with $t1, but the holes wander out of line."),
+            (50, "$0 stitch|stitches the pieces together on $t2, drawing the thongs tight.", "$0 stitch|stitches on $t2, but the joins sit weakly."),
+            (30, "$0 flex|flexes $p1 and check|checks the fit and finish.", "$0 salvage|salvages only $f1 from the failed leatherwork.")
+        };
+
+        foreach (var leatherCraft in new[]
+        {
+            new AntiquityLeatherClothingCraftSpec("antiquity_plain_leather_belt", "assemble a plain leather belt", "a plain leather belt", 140, 0, 80, 20, 0, false, 10, Difficulty.Easy, false),
+            new AntiquityLeatherClothingCraftSpec("antiquity_bronze_buckled_leather_belt", "assemble a bronze-buckled leather belt", "a bronze-buckled leather belt", 170, 0, 95, 25, 0, true, 25, Difficulty.Normal, false),
+            new AntiquityLeatherClothingCraftSpec("antiquity_plain_leather_sandals", "assemble plain leather sandals", "plain leather sandals", 120, 210, 120, 30, 0, false, 10, Difficulty.Easy),
+            new AntiquityLeatherClothingCraftSpec("antiquity_fine_leather_sandals", "assemble fine leather sandals", "fine leather sandals", 110, 190, 130, 35, 0, true, 30, Difficulty.Normal),
+            new AntiquityLeatherClothingCraftSpec("antiquity_soft_leather_shoes", "assemble soft leather shoes", "soft leather shoes", 260, 220, 90, 40, 0, false, 20, Difficulty.Normal),
+            new AntiquityLeatherClothingCraftSpec("antiquity_ankle_leather_boots", "assemble ankle leather boots", "ankle leather boots", 420, 300, 130, 55, 0, false, 25, Difficulty.Hard),
+            new AntiquityLeatherClothingCraftSpec("antiquity_low_strapped_leather_shoes", "assemble strapped leather shoes", "strapped leather shoes", 230, 210, 150, 40, 0, false, 20, Difficulty.Normal),
+            new AntiquityLeatherClothingCraftSpec("antiquity_soft_leather_riding_boots", "assemble soft leather riding boots", "soft leather riding boots", 520, 320, 160, 65, 0, false, 30, Difficulty.Hard),
+            new AntiquityLeatherClothingCraftSpec("adjacent_antiquity_pointed_leather_shoes", "assemble pointed leather shoes", "pointed leather shoes", 250, 200, 80, 35, 0, false, 20, Difficulty.Normal),
+            new AntiquityLeatherClothingCraftSpec("adjacent_antiquity_fine_pointed_leather_shoes", "assemble fine pointed leather shoes", "fine pointed leather shoes", 240, 190, 90, 40, 0, true, 35, Difficulty.Hard),
+            new AntiquityLeatherClothingCraftSpec("adjacent_antiquity_soft_riding_boots", "assemble soft riding boots", "soft riding boots", 440, 280, 140, 55, 0, false, 25, Difficulty.Hard),
+            new AntiquityLeatherClothingCraftSpec("adjacent_antiquity_fine_linen_sandals", "assemble fine linen-strapped sandals", "fine linen-strapped sandals", 80, 180, 40, 25, 45, false, 25, Difficulty.Normal)
+        })
+        {
+            var inputs = new List<string>();
+            if (leatherCraft.Leather > 0)
+            {
+                inputs.Add($"Commodity - {leatherCraft.Leather} grams of leather; piletag Tanned Leather; characteristic Colour any; characteristic Fine Colour any");
+            }
+
+            if (leatherCraft.Soles > 0)
+            {
+                inputs.Add($"Commodity - {leatherCraft.Soles} grams of leather; piletag Leather Sole; characteristic Colour any; characteristic Fine Colour any");
+            }
+
+            if (leatherCraft.Straps > 0)
+            {
+                inputs.Add($"Commodity - {leatherCraft.Straps} grams of leather; piletag Leather Strap; characteristic Colour any; characteristic Fine Colour any");
+            }
+
+            if (leatherCraft.Thongs > 0)
+            {
+                inputs.Add($"Commodity - {leatherCraft.Thongs} grams of leather; piletag Leather Thong; characteristic Colour any; characteristic Fine Colour any");
+            }
+
+            if (leatherCraft.LinenYarn > 0)
+            {
+                inputs.Add($"Commodity - {leatherCraft.LinenYarn} grams of linen; piletag Spun Yarn; characteristic Colour any; characteristic Fine Colour any");
+            }
+
+            AddAntiquityLeatherCraft(
+                leatherCraft.Name,
+                $"assemble {leatherCraft.DisplayName} from prepared leather pieces",
+                leatherCraft.Name,
+                $"leather pieces being assembled into {leatherCraft.DisplayName}",
+                leatherCraft.Minimum,
+                leatherCraft.Difficulty,
+                assemblyPhases,
+                inputs,
+                leatherCraft.Footwear ? footwearTools : beltTools,
+                [
+                    leatherCraft.VariableProduct
+                        ? StableVariableProduct(leatherCraft.StableReference, true)
+                        : StableSimpleProduct(leatherCraft.StableReference)
+                ]);
+        }
+    }
+
+    private sealed record AntiquityLeatherArmourCraftSpec(
+        string StableReference,
+        string Name,
+        string DisplayName,
+        int Panels,
+        int HardenedPanels,
+        int Scales,
+        int Soles,
+        int Straps,
+        int Thongs,
+        int LinenYarn,
+        int Hair,
+        int Metal,
+        string MetalMaterial,
+        bool VariableProduct,
+        int Minimum,
+        Difficulty Difficulty,
+        bool Footwear = false,
+        bool FineProduct = false);
+
+    private void SeedAntiquityLeatherArmourCrafts()
+    {
+        if (!ShouldSeedAntiquityCrafts())
+        {
+            return;
+        }
+
+        var missingArmour = AntiquityLeatherArmourStableReferences.Keys
+            .Where(x => !TryLookupReworkItem(x, out _))
+            .ToList();
+        if (missingArmour.Count > 0)
+        {
+            return;
+        }
+
+        var armourTools = new[]
+        {
+            "TagTool - Held - an item with the Awl Punch tag",
+            "TagTool - Held - an item with the Leather Stitching Pony tag",
+            "TagTool - Held - an item with the Edge Beveller tag",
+            "TagTool - Held - an item with the Mallet tag"
+        };
+        var footwearTools = new[]
+        {
+            "TagTool - Held - an item with the Awl Punch tag",
+            "TagTool - Held - an item with the Leather Stitching Pony tag",
+            "TagTool - Held - an item with the Edge Beveller tag",
+            "TagTool - Held - an item with the Shoe Last tag",
+            "TagTool - Held - an item with the Mallet tag"
+        };
+        var armourPhases = new (int Seconds, string Echo, string FailEcho)[]
+        {
+            (40, "$0 lay|lays out the leather panels, scales, straps, and lacing in fitted order.", "$0 lay|lays out the leather pieces poorly, leaving the fit confused."),
+            (45, "$0 punch|punches holes with $t1 and smooth|smooths exposed edges with $t3.", "$0 punch|punches with $t1, but the holes wander and the edges stay ragged."),
+            (55, "$0 lace|laces and stitch|stitches the armour on $t2, drawing each thong tight.", "$0 lace|laces on $t2, but the rows sit loose and uneven."),
+            (35, "$0 set|sets fittings with $t4 and check|checks the finished balance of $p1.", "$0 salvage|salvages only $f1 from the failed armour work.")
+        };
+        var footwearPhases = new (int Seconds, string Echo, string FailEcho)[]
+        {
+            (35, "$0 fit|fits the leather uppers, soles, straps, and guards around $t4.", "$0 fit|fits the leather around $t4 poorly, throwing the pair out of shape."),
+            (40, "$0 punch|punches stitch holes with $t1 and smooth|smooths the exposed edges with $t3.", "$0 punch|punches with $t1, but the holes wander and the straps pull unevenly."),
+            (50, "$0 stitch|stitches the pair on $t2, setting studs or reinforcements with $t5 where needed.", "$0 stitch|stitches on $t2, but the joins sit weakly."),
+            (30, "$0 flex|flexes $p1 and check|checks the sole, strap, and armour fit.", "$0 salvage|salvages only $f1 from the failed armoured footwear.")
+        };
+
+        foreach (var armourCraft in new[]
+        {
+            new AntiquityLeatherArmourCraftSpec("antiquity_celtic_dyed_leather_scale_vest", "assemble a dyed leather scale vest", "a dyed leather scale vest", 450, 0, 1100, 0, 180, 180, 70, 0, 0, "bronze", true, 35, Difficulty.Hard),
+            new AntiquityLeatherArmourCraftSpec("antiquity_celtic_bronze_studded_leather_belt", "assemble a bronze-studded war belt", "a bronze-studded war belt", 0, 260, 0, 0, 240, 60, 0, 0, 90, "bronze", false, 25, Difficulty.Normal),
+            new AntiquityLeatherArmourCraftSpec("antiquity_celtic_leather_war_bracers", "assemble leather war bracers", "leather war bracers", 0, 360, 0, 0, 120, 50, 0, 0, 40, "bronze", false, 25, Difficulty.Normal),
+            new AntiquityLeatherArmourCraftSpec("antiquity_celtic_fur_lined_war_boots", "assemble fur-lined war boots", "fur-lined war boots", 520, 240, 0, 320, 160, 70, 0, 150, 60, "bronze", false, 30, Difficulty.Hard, true),
+            new AntiquityLeatherArmourCraftSpec("antiquity_germanic_broad_leather_war_belt", "assemble a broad leather war belt", "a broad leather war belt", 0, 360, 0, 0, 260, 60, 0, 0, 80, "wrought iron", false, 25, Difficulty.Normal),
+            new AntiquityLeatherArmourCraftSpec("antiquity_germanic_hide_war_bracers", "assemble hide war bracers", "hide war bracers", 180, 420, 0, 0, 0, 70, 0, 0, 0, "bronze", false, 25, Difficulty.Normal),
+            new AntiquityLeatherArmourCraftSpec("antiquity_germanic_fur_cuffed_high_boots", "assemble fur-cuffed high boots", "fur-cuffed high boots", 650, 300, 0, 360, 180, 80, 0, 200, 0, "bronze", false, 35, Difficulty.Hard, true),
+            new AntiquityLeatherArmourCraftSpec("antiquity_hellenic_leather_pteruges_girdle", "assemble a leather pteruges girdle", "a leather pteruges girdle", 300, 420, 0, 0, 240, 120, 0, 0, 90, "bronze", false, 30, Difficulty.Hard),
+            new AntiquityLeatherArmourCraftSpec("antiquity_hellenic_bronze_studded_sandals", "assemble bronze-studded leather sandals", "bronze-studded leather sandals", 0, 120, 0, 260, 220, 60, 0, 0, 60, "bronze", false, 25, Difficulty.Normal, true),
+            new AntiquityLeatherArmourCraftSpec("antiquity_etruscan_pteruges_leather_girdle", "assemble a studded pteruges girdle", "a studded pteruges girdle", 300, 430, 0, 0, 240, 120, 0, 0, 110, "bronze", false, 30, Difficulty.Hard),
+            new AntiquityLeatherArmourCraftSpec("antiquity_etruscan_bronze_studded_sandals", "assemble fitted bronze-studded sandals", "fitted bronze-studded sandals", 0, 140, 0, 270, 220, 60, 0, 0, 65, "bronze", false, 25, Difficulty.Normal, true),
+            new AntiquityLeatherArmourCraftSpec("antiquity_roman_plated_military_belt", "assemble a plated military belt", "a plated military belt", 0, 480, 0, 0, 300, 100, 0, 0, 180, "bronze", false, 35, Difficulty.Hard),
+            new AntiquityLeatherArmourCraftSpec("antiquity_roman_aproned_military_belt", "assemble an apron-fronted military belt", "an apron-fronted military belt", 250, 520, 0, 0, 320, 130, 0, 0, 240, "bronze", false, 40, Difficulty.Hard),
+            new AntiquityLeatherArmourCraftSpec("antiquity_roman_reinforced_caligae", "assemble reinforced leather caligae", "reinforced leather caligae", 0, 120, 0, 300, 260, 60, 0, 0, 80, "bronze", false, 25, Difficulty.Normal, true),
+            new AntiquityLeatherArmourCraftSpec("antiquity_roman_leather_field_boots", "assemble leather field boots", "leather field boots", 600, 360, 0, 360, 180, 80, 0, 0, 60, "bronze", false, 30, Difficulty.Hard, true),
+            new AntiquityLeatherArmourCraftSpec("antiquity_punic_bronze_studded_girdle", "assemble a bronze-studded leather girdle", "a bronze-studded leather girdle", 260, 420, 0, 0, 260, 100, 0, 0, 120, "bronze", false, 30, Difficulty.Hard),
+            new AntiquityLeatherArmourCraftSpec("antiquity_persian_scale_anaxyrides", "assemble scale anaxyrides", "scale anaxyrides", 550, 0, 1200, 0, 160, 180, 80, 0, 0, "bronze", false, 40, Difficulty.Hard),
+            new AntiquityLeatherArmourCraftSpec("antiquity_persian_soft_riding_boots", "assemble armoured riding boots", "armoured riding boots", 650, 420, 0, 340, 170, 80, 0, 0, 0, "bronze", false, 35, Difficulty.Hard, true),
+            new AntiquityLeatherArmourCraftSpec("antiquity_egyptian_leather_scale_cuirass", "assemble a leather scale cuirass", "a leather scale cuirass", 650, 0, 1500, 0, 260, 220, 100, 0, 0, "bronze", false, 40, Difficulty.Hard),
+            new AntiquityLeatherArmourCraftSpec("antiquity_egyptian_scale_kilt_guard", "assemble a scale kilt guard", "a scale kilt guard", 300, 0, 600, 0, 240, 140, 70, 0, 0, "bronze", false, 35, Difficulty.Hard),
+            new AntiquityLeatherArmourCraftSpec("antiquity_egyptian_leather_archer_bracer", "assemble a leather archer bracer", "a leather archer bracer", 70, 180, 0, 0, 80, 30, 0, 0, 0, "bronze", false, 20, Difficulty.Normal),
+            new AntiquityLeatherArmourCraftSpec("antiquity_anatolian_leather_cavalry_boots", "assemble leather cavalry boots", "leather cavalry boots", 620, 360, 0, 320, 200, 80, 0, 0, 0, "bronze", false, 35, Difficulty.Hard, true),
+            new AntiquityLeatherArmourCraftSpec("antiquity_scythian_leather_scale_corselet", "assemble a leather scale corselet", "a leather scale corselet", 550, 0, 1300, 0, 220, 220, 90, 0, 0, "bronze", false, 40, Difficulty.Hard),
+            new AntiquityLeatherArmourCraftSpec("antiquity_scythian_conical_scale_cap", "assemble a conical scale war cap", "a conical scale war cap", 220, 0, 420, 0, 0, 100, 60, 0, 0, "bronze", false, 35, Difficulty.Hard),
+            new AntiquityLeatherArmourCraftSpec("antiquity_scythian_scale_trousers", "assemble leather scale trousers", "leather scale trousers", 700, 0, 1450, 0, 220, 220, 110, 0, 0, "bronze", false, 45, Difficulty.Hard),
+            new AntiquityLeatherArmourCraftSpec("antiquity_scythian_high_riding_boots", "assemble high riding boots", "high riding boots", 780, 520, 0, 420, 220, 90, 0, 0, 0, "bronze", false, 40, Difficulty.Hard, true),
+            new AntiquityLeatherArmourCraftSpec("antiquity_kushite_leather_scale_breastguard", "assemble a leather scale breastguard", "a leather scale breastguard", 250, 0, 650, 0, 200, 120, 50, 0, 0, "bronze", false, 35, Difficulty.Hard),
+            new AntiquityLeatherArmourCraftSpec("antiquity_kushite_leather_archer_bracer", "assemble a river-valley leather archer bracer", "a river-valley leather archer bracer", 70, 180, 0, 0, 80, 30, 0, 0, 0, "bronze", false, 20, Difficulty.Normal),
+            new AntiquityLeatherArmourCraftSpec("antiquity_kushite_leather_kilt_guard", "assemble a leather kilt guard", "a leather kilt guard", 300, 520, 0, 0, 240, 120, 60, 0, 0, "bronze", false, 35, Difficulty.Hard),
+            new AntiquityLeatherArmourCraftSpec("antiquity_kushite_sand_armoured_sandals", "assemble armoured leather sandals", "armoured leather sandals", 0, 160, 0, 260, 220, 60, 0, 0, 0, "bronze", false, 25, Difficulty.Normal, true)
+        })
+        {
+            var inputs = new List<string>();
+            AddLeatherCommodityInput(inputs, armourCraft.Panels, "Leather Panel");
+            AddLeatherCommodityInput(inputs, armourCraft.HardenedPanels, "Hardened Leather Panel");
+            AddLeatherCommodityInput(inputs, armourCraft.Scales, "Leather Scale");
+            AddLeatherCommodityInput(inputs, armourCraft.Soles, "Leather Sole");
+            AddLeatherCommodityInput(inputs, armourCraft.Straps, "Leather Strap");
+            AddLeatherCommodityInput(inputs, armourCraft.Thongs, "Leather Thong");
+            if (armourCraft.LinenYarn > 0)
+            {
+                inputs.Add($"Commodity - {armourCraft.LinenYarn} grams of linen; piletag Spun Yarn; characteristic Colour any");
+            }
+
+            if (armourCraft.Hair > 0)
+            {
+                inputs.Add($"CommodityTag - {armourCraft.Hair} grams of a material tagged as Hair");
+            }
+
+            if (armourCraft.Metal > 0)
+            {
+                inputs.Add($"Commodity - {armourCraft.Metal} grams of {armourCraft.MetalMaterial}");
+            }
+
+            AddAntiquityLeatherCraft(
+                armourCraft.Name,
+                $"assemble {armourCraft.DisplayName} from prepared leather armour pieces",
+                armourCraft.Name,
+                $"leather armour pieces being assembled into {armourCraft.DisplayName}",
+                armourCraft.Minimum,
+                armourCraft.Difficulty,
+                armourCraft.Footwear ? footwearPhases : armourPhases,
+                inputs,
+                armourCraft.Footwear ? footwearTools : armourTools,
+                [
+                    armourCraft.VariableProduct
+                        ? StableVariableProduct(armourCraft.StableReference, armourCraft.FineProduct)
+                        : StableSimpleProduct(armourCraft.StableReference)
+                ]);
+        }
+    }
+
+    private sealed record AntiquityLeatherContainerCraftSpec(
+        string StableReference,
+        string Name,
+        string DisplayName,
+        int Panels,
+        int SealedPanels,
+        int Straps,
+        int Thongs,
+        int LinenYarn,
+        int Hair,
+        int Beeswax,
+        int Metal,
+        string MetalMaterial,
+        bool Liquid,
+        int Minimum,
+        Difficulty Difficulty);
+
+    private void SeedAntiquityLeatherContainerCrafts()
+    {
+        if (!ShouldSeedAntiquityCrafts())
+        {
+            return;
+        }
+
+        var missingContainers = AntiquityLeatherContainerStableReferences.Keys
+            .Where(x => !TryLookupReworkItem(x, out _))
+            .ToList();
+        if (missingContainers.Count > 0)
+        {
+            return;
+        }
+
+        var dryTools = new[]
+        {
+            "TagTool - Held - an item with the Awl Punch tag",
+            "TagTool - Held - an item with the Leather Stitching Pony tag",
+            "TagTool - Held - an item with the Edge Beveller tag",
+            "TagTool - Held - an item with the Leather Creaser tag"
+        };
+        var liquidTools = new[]
+        {
+            "TagTool - Held - an item with the Awl Punch tag",
+            "TagTool - Held - an item with the Leather Stitching Pony tag",
+            "TagTool - InRoom - an item with the Leather Wax Pot tag",
+            "TagTool - Held - an item with the Edge Beveller tag"
+        };
+        var dryPhases = new (int Seconds, string Echo, string FailEcho)[]
+        {
+            (30, "$0 mark|marks the leather panels, straps, flap, and closure lines.", "$0 mark|marks the leather unevenly."),
+            (40, "$0 punch|punches stitch holes with $t1 and finish|finishes the edges with $t3 and $t4.", "$0 punch|punches with $t1, but the holes and edges wander."),
+            (50, "$0 stitch|stitches the container on $t2, drawing the thongs snug.", "$0 stitch|stitches on $t2, but the container twists out of shape."),
+            (25, "$0 test|tests the closure and set|sets aside $p1.", "$0 salvage|salvages only $f1 from the failed container work.")
+        };
+        var liquidPhases = new (int Seconds, string Echo, string FailEcho)[]
+        {
+            (30, "$0 match|matches sealed panels for a tight liquid-holding body.", "$0 match|matches the sealed panels poorly, leaving gaps at the neck and seams."),
+            (45, "$0 punch|punches close stitch holes with $t1 and sew|sews the vessel on $t2.", "$0 punch|punches with $t1, but the seam line wanders."),
+            (40, "$0 warm|warms wax in $t3 and work|works it into the seams and mouth.", "$0 warm|warms the wax poorly and leave|leaves dry leaking seams."),
+            (30, "$0 flex|flexes $p1 and check|checks the sealed shape.", "$0 salvage|salvages only $f1 from the leaking vessel.")
+        };
+
+        foreach (var containerCraft in new[]
+        {
+            new AntiquityLeatherContainerCraftSpec("antiquity_smoked_hide_meat_bag", "assemble a smoked hide provision bag", "a smoked hide provision bag", 480, 0, 120, 60, 40, 80, 0, 0, "bronze", false, 20, Difficulty.Normal),
+            new AntiquityLeatherContainerCraftSpec("antiquity_leather_document_case", "assemble a folded leather document case", "a folded leather document case", 260, 0, 40, 30, 25, 0, 0, 0, "bronze", false, 20, Difficulty.Normal),
+            new AntiquityLeatherContainerCraftSpec("antiquity_leather_mirror_case", "assemble a tooled leather mirror case", "a tooled leather mirror case", 220, 0, 0, 30, 20, 0, 20, 0, "bronze", false, 25, Difficulty.Normal),
+            new AntiquityLeatherContainerCraftSpec("antiquity_plain_leather_belt_pouch", "assemble a plain leather belt pouch", "a plain leather belt pouch", 140, 0, 50, 25, 20, 0, 0, 0, "bronze", false, 10, Difficulty.Easy),
+            new AntiquityLeatherContainerCraftSpec("antiquity_double_strap_travel_pack", "assemble a double-strapped leather pack", "a double-strapped leather pack", 950, 0, 420, 100, 80, 0, 0, 60, "bronze", false, 30, Difficulty.Hard),
+            new AntiquityLeatherContainerCraftSpec("antiquity_fur_lined_forager_bag", "assemble a fur-lined forager bag", "a fur-lined forager bag", 480, 0, 200, 70, 50, 180, 0, 0, "bronze", false, 25, Difficulty.Normal),
+            new AntiquityLeatherContainerCraftSpec("antiquity_deer_leather_game_bag", "assemble a deer-leather game bag", "a deer-leather game bag", 480, 0, 220, 70, 50, 0, 0, 0, "bronze", false, 25, Difficulty.Normal),
+            new AntiquityLeatherContainerCraftSpec("antiquity_folded_tablet_wallet", "assemble a folded leather tablet wallet", "a folded leather tablet wallet", 160, 0, 0, 35, 20, 0, 0, 0, "bronze", false, 15, Difficulty.Normal),
+            new AntiquityLeatherContainerCraftSpec("antiquity_round_coin_purse", "assemble a round leather coin purse", "a round leather coin purse", 80, 0, 0, 35, 10, 0, 0, 0, "bronze", false, 10, Difficulty.Easy),
+            new AntiquityLeatherContainerCraftSpec("antiquity_leather_dispatch_satchel", "assemble a leather dispatch satchel", "a leather dispatch satchel", 520, 0, 220, 70, 55, 0, 0, 0, "bronze", false, 30, Difficulty.Hard),
+            new AntiquityLeatherContainerCraftSpec("antiquity_wide_belt_document_pouch", "assemble a wide leather document pouch", "a wide leather document pouch", 320, 0, 120, 45, 35, 0, 0, 0, "bronze", false, 20, Difficulty.Normal),
+            new AntiquityLeatherContainerCraftSpec("antiquity_steppe_saddlebag_pack", "assemble a saddlebag leather pack", "a saddlebag leather pack", 1000, 0, 320, 140, 80, 0, 0, 0, "bronze", false, 35, Difficulty.Hard),
+            new AntiquityLeatherContainerCraftSpec("antiquity_steppe_gorytos_case", "assemble a tooled gorytos case", "a tooled gorytos case", 650, 0, 220, 100, 60, 0, 25, 0, "bronze", false, 35, Difficulty.Hard),
+            new AntiquityLeatherContainerCraftSpec("antiquity_fur_provision_pouch", "assemble a fur provision pouch", "a fur provision pouch", 180, 0, 60, 35, 20, 120, 0, 0, "bronze", false, 20, Difficulty.Normal),
+            new AntiquityLeatherContainerCraftSpec("antiquity_liquid_steppe_milk_skin", "assemble a leather milk skin", "a leather milk skin", 0, 430, 100, 60, 0, 0, 40, 0, "bronze", true, 20, Difficulty.Normal),
+            new AntiquityLeatherContainerCraftSpec("antiquity_liquid_plain_leather_waterskin", "assemble a plain leather waterskin", "a plain leather waterskin", 0, 360, 100, 50, 0, 0, 35, 0, "bronze", true, 15, Difficulty.Normal),
+            new AntiquityLeatherContainerCraftSpec("antiquity_liquid_wide_mouth_waterskin", "assemble a wide-mouthed waterskin", "a wide-mouthed waterskin", 0, 450, 140, 60, 0, 0, 45, 0, "bronze", true, 20, Difficulty.Normal),
+            new AntiquityLeatherContainerCraftSpec("antiquity_liquid_leather_belt_oil_flask", "assemble a leather belt oil flask", "a leather belt oil flask", 0, 160, 45, 25, 0, 0, 30, 0, "bronze", true, 20, Difficulty.Normal),
+            new AntiquityLeatherContainerCraftSpec("antiquity_liquid_hide_ale_skin", "assemble a hide ale skin", "a hide ale skin", 0, 480, 120, 70, 0, 0, 45, 0, "bronze", true, 25, Difficulty.Normal),
+            new AntiquityLeatherContainerCraftSpec("antiquity_liquid_birch_stoppered_mead_skin", "assemble a birch-stoppered mead skin", "a birch-stoppered mead skin", 0, 420, 120, 60, 0, 0, 40, 0, "bronze", true, 25, Difficulty.Normal),
+            new AntiquityLeatherContainerCraftSpec("antiquity_liquid_soldier_shoulder_canteen", "assemble a leather-covered shoulder canteen", "a leather-covered shoulder canteen", 0, 520, 180, 70, 0, 0, 45, 0, "bronze", true, 25, Difficulty.Hard),
+            new AntiquityLeatherContainerCraftSpec("antiquity_liquid_sailor_water_skin", "assemble a tar-dark waterskin", "a tar-dark waterskin", 0, 520, 120, 70, 0, 0, 60, 0, "bronze", true, 25, Difficulty.Normal),
+            new AntiquityLeatherContainerCraftSpec("antiquity_liquid_caravan_waterskin", "assemble a large caravan waterskin", "a large caravan waterskin", 0, 750, 220, 100, 0, 0, 70, 0, "bronze", true, 30, Difficulty.Hard),
+            new AntiquityLeatherContainerCraftSpec("antiquity_liquid_silver_tipped_belt_flask", "assemble a silver-tipped belt flask", "a silver-tipped belt flask", 0, 180, 60, 30, 0, 0, 40, 30, "silver", true, 35, Difficulty.Hard),
+            new AntiquityLeatherContainerCraftSpec("antiquity_liquid_felt_covered_riding_canteen", "assemble a felt-covered riding canteen", "a felt-covered riding canteen", 0, 520, 200, 80, 0, 80, 45, 0, "bronze", true, 30, Difficulty.Hard),
+            new AntiquityLeatherContainerCraftSpec("antiquity_liquid_saddle_waterskin", "assemble a saddle-hung waterskin", "a saddle-hung waterskin", 0, 850, 300, 120, 0, 0, 75, 0, "bronze", true, 35, Difficulty.Hard),
+            new AntiquityLeatherContainerCraftSpec("antiquity_liquid_steppe_kumis_skin", "assemble a patched fermented-milk skin", "a patched fermented-milk skin", 0, 500, 120, 80, 0, 0, 40, 0, "bronze", true, 25, Difficulty.Normal),
+            new AntiquityLeatherContainerCraftSpec("antiquity_liquid_tooled_leather_flask", "assemble a tooled leather flask", "a tooled leather flask", 0, 180, 50, 30, 0, 0, 35, 0, "bronze", true, 25, Difficulty.Normal),
+            new AntiquityLeatherContainerCraftSpec("antiquity_tableware_scythian_leather_travel_cup", "assemble a folded leather travel cup", "a folded leather travel cup", 0, 160, 0, 20, 15, 0, 30, 0, "bronze", true, 20, Difficulty.Normal)
+        })
+        {
+            var inputs = new List<string>();
+            AddLeatherCommodityInput(inputs, containerCraft.Panels, "Leather Panel");
+            AddLeatherCommodityInput(inputs, containerCraft.SealedPanels, "Sealed Leather Panel");
+            AddLeatherCommodityInput(inputs, containerCraft.Straps, "Leather Strap");
+            AddLeatherCommodityInput(inputs, containerCraft.Thongs, "Leather Thong");
+            if (containerCraft.LinenYarn > 0)
+            {
+                inputs.Add($"Commodity - {containerCraft.LinenYarn} grams of linen; piletag Spun Yarn; characteristic Colour any");
+            }
+
+            if (containerCraft.Hair > 0)
+            {
+                inputs.Add($"CommodityTag - {containerCraft.Hair} grams of a material tagged as Hair");
+            }
+
+            if (containerCraft.Beeswax > 0)
+            {
+                inputs.Add($"Commodity - {containerCraft.Beeswax} grams of beeswax");
+            }
+
+            if (containerCraft.Metal > 0)
+            {
+                inputs.Add($"Commodity - {containerCraft.Metal} grams of {containerCraft.MetalMaterial}");
+            }
+
+            AddAntiquityLeatherCraft(
+                containerCraft.Name,
+                $"assemble {containerCraft.DisplayName} from prepared leather container pieces",
+                containerCraft.Name,
+                $"leather container pieces being assembled into {containerCraft.DisplayName}",
+                containerCraft.Minimum,
+                containerCraft.Difficulty,
+                containerCraft.Liquid ? liquidPhases : dryPhases,
+                inputs,
+                containerCraft.Liquid ? liquidTools : dryTools,
+                [StableSimpleProduct(containerCraft.StableReference)]);
+        }
+    }
+
+    private void SeedAntiquityLeatherFurnishingCrafts()
+    {
+        if (!ShouldSeedAntiquityCrafts())
+        {
+            return;
+        }
+
+        var missingFurnishings = AntiquityLeatherFurnishingStableReferences.Keys
+            .Where(x => !TryLookupReworkItem(x, out _))
+            .ToList();
+        if (missingFurnishings.Count > 0)
+        {
+            return;
+        }
+
+        var hangingTools = new[]
+        {
+            "TagTool - Held - an item with the Awl Punch tag",
+            "TagTool - Held - an item with the Leather Stitching Pony tag",
+            "TagTool - Held - an item with the Edge Beveller tag",
+            "TagTool - Held - an item with the Leather Creaser tag"
+        };
+
+        AddAntiquityLeatherCraft(
+            "assemble a fur doorway hanging",
+            "assemble a fur doorway hanging from hair-on skins and leather header stock",
+            "assemble a fur doorway hanging",
+            "hair-on skins being assembled into a doorway hanging",
+            25,
+            Difficulty.Normal,
+            [
+                (35, "$0 sort|sorts the hair-on skins and mark|marks a leather header strip.", "$0 sort|sorts the skins poorly, leaving mismatched panels."),
+                (45, "$0 punch|punches hanging and stitching holes with $t1, smoothing the header with $t3 and $t4.", "$0 punch|punches with $t1, but the hanging holes sit unevenly."),
+                (55, "$0 stitch|stitches the skins onto the header on $t2 and draw|draws the thongs tight.", "$0 stitch|stitches on $t2, but the skins sag and pull loose."),
+                (30, "$0 lift|lifts $p1 to check its fall and overlap.", "$0 salvage|salvages only $f1 from the failed hanging.")
+            ],
+            [
+                "CommodityTag - 1 kilogram 800 grams of a material tagged as Animal Skin",
+                "CommodityTag - 600 grams of a material tagged as Hair",
+                "Commodity - 220 grams of leather; piletag Leather Strap; characteristic Colour any; characteristic Fine Colour any",
+                "Commodity - 120 grams of leather; piletag Leather Thong; characteristic Colour any; characteristic Fine Colour any"
+            ],
+            hangingTools,
+            [StableSimpleProduct("antiquity_fur_door_hanging")]);
+
+        AddAntiquityLeatherCraft(
+            "assemble a leather tent door flap",
+            "assemble a leather tent door flap from broad panels and tie stock",
+            "assemble a leather tent door flap",
+            "leather panels being assembled into a tent door flap",
+            30,
+            Difficulty.Hard,
+            [
+                (40, "$0 lay|lays out broad leather panels and mark|marks the top strip and overlap.", "$0 lay|lays out the panels poorly, leaving the flap out of square."),
+                (45, "$0 punch|punches tie and seam holes with $t1, smoothing panel edges with $t3 and $t4.", "$0 punch|punches with $t1, but the holes wander through the flap."),
+                (60, "$0 stitch|stitches the panels and top strip together on $t2.", "$0 stitch|stitches on $t2, but the panels buckle and pull apart."),
+                (35, "$0 fold|folds $p1 and check|checks that the tie points sit evenly.", "$0 salvage|salvages only $f1 from the failed door flap.")
+            ],
+            [
+                "Commodity - 1 kilogram 800 grams of leather; piletag Leather Panel; characteristic Colour any; characteristic Fine Colour any",
+                "Commodity - 360 grams of leather; piletag Leather Strap; characteristic Colour any; characteristic Fine Colour any",
+                "Commodity - 180 grams of leather; piletag Leather Thong; characteristic Colour any; characteristic Fine Colour any",
+                "Commodity - 80 grams of beeswax"
+            ],
+            hangingTools,
+            [StableSimpleProduct("antiquity_leather_tent_door_flap")]);
     }
     
     private void SeedAntiquityHellenicClothingCrafts()
@@ -486,7 +1222,7 @@ public partial class ItemSeeder
             IEnumerable<(int Seconds, string Echo, string FailEcho)> phases, IEnumerable<string> inputs,
             IEnumerable<string> tools, IEnumerable<string> products)
         {
-            AddCraft(
+            AddAntiquityCraft(
                 name,
                 "Tailoring",
                 blurb,
@@ -496,15 +1232,10 @@ public partial class ItemSeeder
                 "Tailoring",
                 minimumTraitValue,
                 difficulty,
-                Outcome.MinorFail,
-                5,
-                3,
-                false,
                 phases,
                 inputs,
                 tools,
                 products,
-                [],
                 knowledgeSubtype: "Hellenic",
                 knowledgeDescription: hellenicKnowledgeDescription,
                 knowledgeLongDescription: hellenicKnowledgeDescription);
@@ -931,7 +1662,7 @@ public partial class ItemSeeder
                 garment.Name,
                 $"assemble {garment.Name["assemble a ".Length..]} from rectangular {garment.Material} cloth",
                 garment.Name,
-                $"{garment.Material} cloth being assembled into Hellenic clothing",
+                $"{garment.Material} cloth being assembled into clothing",
                 garment.Minimum,
                 garment.Difficulty,
                 assemblyPhases,
@@ -968,7 +1699,7 @@ public partial class ItemSeeder
 			IEnumerable<(int Seconds, string Echo, string FailEcho)> phases, IEnumerable<string> inputs,
 			IEnumerable<string> tools, IEnumerable<string> products)
 		{
-			AddCraft(
+			AddAntiquityCraft(
 				name,
 				"Tailoring",
 				blurb,
@@ -978,23 +1709,18 @@ public partial class ItemSeeder
 				"Tailoring",
 				minimumTraitValue,
 				difficulty,
-				Outcome.MinorFail,
-				5,
-				3,
-				false,
 				phases,
 				inputs,
 				tools,
 				products,
-				[],
-				knowledgeSubtype: "Celtic",
+                knowledgeSubtype: "Celtic",
 				knowledgeDescription: celticKnowledgeDescription,
 				knowledgeLongDescription: celticKnowledgeDescription);
 		}
 
 		var celticAssemblyPhases = new (int Seconds, string Echo, string FailEcho)[]
 		{
-			(35, "$0 lay|lays out $i1 and mark|marks a rectangular Celtic garment pattern.", "$0 lay|lays out $i1, but mark|marks the garment unevenly."),
+			(35, "$0 lay|lays out $i1 and mark|marks a rectangular garment pattern.", "$0 lay|lays out $i1, but mark|marks the garment unevenly."),
 			(35, "$0 cut|cuts the cloth with $t2 and turn|turns the main edges into hems.", "$0 cut|cuts with $t2, but the edges wander out of line."),
 			(45, "$0 stitch|stitches seams, folds, and fastening points with $t1, using $i2 for the strongest joins.", "$0 stitch|stitches with $t1, but the joins sit awkwardly and weakly."),
 			(30, "$0 shake|shakes out $p1, checking the drape and fit over a belted layer.", "$0 shake|shakes out only $f1 after spoiling the cloth.")
@@ -1014,18 +1740,18 @@ public partial class ItemSeeder
 
 		foreach (var garment in new[]
 		{
-			(StableReference: "antiquity_sleeved_common_wool_tunic", Name: "assemble a Celtic sleeved wool tunic", DisplayName: "a Celtic sleeved wool tunic", Material: "wool", Cloth: 590, SecondaryCloth: 0, Yarn: 30, Fine: false, GeneratedProduct: false, Minimum: 15, Difficulty: Difficulty.Easy),
-			(StableReference: "antiquity_wool_braccae", Name: "assemble Celtic wool braccae", DisplayName: "Celtic wool braccae", Material: "wool", Cloth: 500, SecondaryCloth: 0, Yarn: 25, Fine: false, GeneratedProduct: false, Minimum: 15, Difficulty: Difficulty.Normal),
-			(StableReference: "antiquity_rectangular_wool_cloak", Name: "assemble a Celtic rectangular wool cloak", DisplayName: "a Celtic rectangular wool cloak", Material: "wool", Cloth: 1160, SecondaryCloth: 0, Yarn: 40, Fine: false, GeneratedProduct: false, Minimum: 15, Difficulty: Difficulty.Normal),
-			(StableReference: "antiquity_fine_bordered_wool_tunic", Name: "assemble a Celtic fine bordered wool tunic", DisplayName: "a Celtic fine bordered wool tunic", Material: "wool", Cloth: 530, SecondaryCloth: 0, Yarn: 30, Fine: true, GeneratedProduct: false, Minimum: 35, Difficulty: Difficulty.Normal),
-			(StableReference: "antiquity_fine_wool_braccae", Name: "assemble Celtic fine wool braccae", DisplayName: "Celtic fine wool braccae", Material: "wool", Cloth: 470, SecondaryCloth: 0, Yarn: 30, Fine: true, GeneratedProduct: false, Minimum: 35, Difficulty: Difficulty.Hard),
-			(StableReference: "antiquity_fine_checked_wool_cloak", Name: "assemble a Celtic fine checked wool cloak", DisplayName: "a Celtic fine checked wool cloak", Material: "wool", Cloth: 900, SecondaryCloth: 250, Yarn: 45, Fine: true, GeneratedProduct: true, Minimum: 40, Difficulty: Difficulty.Hard),
-			(StableReference: "antiquity_long_sleeved_wool_tunic", Name: "assemble a Celtic long sleeved wool tunic", DisplayName: "a Celtic long sleeved wool tunic", Material: "wool", Cloth: 650, SecondaryCloth: 0, Yarn: 30, Fine: false, GeneratedProduct: false, Minimum: 20, Difficulty: Difficulty.Normal),
-			(StableReference: "antiquity_wool_wrap_skirt", Name: "assemble a Celtic wool wrap skirt", DisplayName: "a Celtic wool wrap skirt", Material: "wool", Cloth: 535, SecondaryCloth: 0, Yarn: 25, Fine: false, GeneratedProduct: false, Minimum: 15, Difficulty: Difficulty.Normal),
-			(StableReference: "antiquity_broad_wool_mantle", Name: "assemble a Celtic broad wool mantle", DisplayName: "a Celtic broad wool mantle", Material: "wool", Cloth: 960, SecondaryCloth: 0, Yarn: 35, Fine: false, GeneratedProduct: false, Minimum: 20, Difficulty: Difficulty.Normal),
-			(StableReference: "antiquity_fine_sleeved_wool_gown", Name: "assemble a Celtic fine sleeved wool gown", DisplayName: "a Celtic fine sleeved wool gown", Material: "wool", Cloth: 740, SecondaryCloth: 0, Yarn: 40, Fine: true, GeneratedProduct: false, Minimum: 40, Difficulty: Difficulty.Hard),
-			(StableReference: "antiquity_fine_bordered_wool_mantle", Name: "assemble a Celtic fine bordered wool mantle", DisplayName: "a Celtic fine bordered wool mantle", Material: "wool", Cloth: 910, SecondaryCloth: 0, Yarn: 40, Fine: true, GeneratedProduct: false, Minimum: 40, Difficulty: Difficulty.Hard),
-			(StableReference: "antiquity_linen_shoulder_veil", Name: "assemble a Celtic linen shoulder veil", DisplayName: "a Celtic linen shoulder veil", Material: "linen", Cloth: 110, SecondaryCloth: 0, Yarn: 10, Fine: true, GeneratedProduct: false, Minimum: 30, Difficulty: Difficulty.Normal)
+			(StableReference: "antiquity_sleeved_common_wool_tunic", Name: "assemble a sleeved wool tunic", DisplayName: "a sleeved wool tunic", Material: "wool", Cloth: 590, SecondaryCloth: 0, Yarn: 30, Fine: false, GeneratedProduct: false, Minimum: 15, Difficulty: Difficulty.Easy),
+			(StableReference: "antiquity_wool_braccae", Name: "assemble wool braccae", DisplayName: "wool braccae", Material: "wool", Cloth: 500, SecondaryCloth: 0, Yarn: 25, Fine: false, GeneratedProduct: false, Minimum: 15, Difficulty: Difficulty.Normal),
+			(StableReference: "antiquity_rectangular_wool_cloak", Name: "assemble a rectangular wool cloak", DisplayName: "a rectangular wool cloak", Material: "wool", Cloth: 1160, SecondaryCloth: 0, Yarn: 40, Fine: false, GeneratedProduct: false, Minimum: 15, Difficulty: Difficulty.Normal),
+			(StableReference: "antiquity_fine_bordered_wool_tunic", Name: "assemble a fine bordered wool tunic", DisplayName: "a fine bordered wool tunic", Material: "wool", Cloth: 530, SecondaryCloth: 0, Yarn: 30, Fine: true, GeneratedProduct: false, Minimum: 35, Difficulty: Difficulty.Normal),
+			(StableReference: "antiquity_fine_wool_braccae", Name: "assemble fine wool braccae", DisplayName: "fine wool braccae", Material: "wool", Cloth: 470, SecondaryCloth: 0, Yarn: 30, Fine: true, GeneratedProduct: false, Minimum: 35, Difficulty: Difficulty.Hard),
+			(StableReference: "antiquity_fine_checked_wool_cloak", Name: "assemble a fine checked wool cloak", DisplayName: "a fine checked wool cloak", Material: "wool", Cloth: 900, SecondaryCloth: 250, Yarn: 45, Fine: true, GeneratedProduct: true, Minimum: 40, Difficulty: Difficulty.Hard),
+			(StableReference: "antiquity_long_sleeved_wool_tunic", Name: "assemble a long sleeved wool tunic", DisplayName: "a long sleeved wool tunic", Material: "wool", Cloth: 650, SecondaryCloth: 0, Yarn: 30, Fine: false, GeneratedProduct: false, Minimum: 20, Difficulty: Difficulty.Normal),
+			(StableReference: "antiquity_wool_wrap_skirt", Name: "assemble a wool wrap skirt", DisplayName: "a wool wrap skirt", Material: "wool", Cloth: 535, SecondaryCloth: 0, Yarn: 25, Fine: false, GeneratedProduct: false, Minimum: 15, Difficulty: Difficulty.Normal),
+			(StableReference: "antiquity_broad_wool_mantle", Name: "assemble a broad wool mantle", DisplayName: "a broad wool mantle", Material: "wool", Cloth: 960, SecondaryCloth: 0, Yarn: 35, Fine: false, GeneratedProduct: false, Minimum: 20, Difficulty: Difficulty.Normal),
+			(StableReference: "antiquity_fine_sleeved_wool_gown", Name: "assemble a fine sleeved wool gown", DisplayName: "a fine sleeved wool gown", Material: "wool", Cloth: 740, SecondaryCloth: 0, Yarn: 40, Fine: true, GeneratedProduct: false, Minimum: 40, Difficulty: Difficulty.Hard),
+			(StableReference: "antiquity_fine_bordered_wool_mantle", Name: "assemble a fine bordered wool mantle", DisplayName: "a fine bordered wool mantle", Material: "wool", Cloth: 910, SecondaryCloth: 0, Yarn: 40, Fine: true, GeneratedProduct: false, Minimum: 40, Difficulty: Difficulty.Hard),
+			(StableReference: "antiquity_linen_shoulder_veil", Name: "assemble a linen shoulder veil", DisplayName: "a linen shoulder veil", Material: "linen", Cloth: 110, SecondaryCloth: 0, Yarn: 10, Fine: true, GeneratedProduct: false, Minimum: 30, Difficulty: Difficulty.Normal)
 		})
 		{
 			var characteristicRequirements = garment.Fine
@@ -1045,7 +1771,7 @@ public partial class ItemSeeder
 				garment.Name,
 				$"assemble {garment.DisplayName} from {garment.Material} garment cloth",
 				garment.Name,
-				$"{garment.Material} cloth being assembled into Celtic clothing",
+				$"{garment.Material} cloth being assembled into clothing",
 				garment.Minimum,
 				garment.Difficulty,
 				garment.GeneratedProduct ? checkedAssemblyPhases : celticAssemblyPhases,
@@ -1079,7 +1805,7 @@ public partial class ItemSeeder
 			IEnumerable<(int Seconds, string Echo, string FailEcho)> phases, IEnumerable<string> inputs,
 			IEnumerable<string> tools, IEnumerable<string> products)
 		{
-			AddCraft(
+			AddAntiquityCraft(
 				name,
 				"Tailoring",
 				blurb,
@@ -1089,16 +1815,11 @@ public partial class ItemSeeder
 				"Tailoring",
 				minimumTraitValue,
 				difficulty,
-				Outcome.MinorFail,
-				5,
-				3,
-				false,
 				phases,
 				inputs,
 				tools,
 				products,
-				[],
-				knowledgeSubtype: "Germanic",
+                knowledgeSubtype: "Germanic",
 				knowledgeDescription: germanicKnowledgeDescription,
 				knowledgeLongDescription: germanicKnowledgeDescription);
 		}
@@ -1139,17 +1860,17 @@ public partial class ItemSeeder
 
 		foreach (var garment in new[]
 		{
-			(StableReference: "antiquity_straight_wool_tunic", Name: "assemble a Germanic straight wool tunic", DisplayName: "a Germanic straight wool tunic", Material: "wool", Cloth: 620, SecondaryCloth: 0, Yarn: 30, Fine: false, GeneratedProduct: false, Minimum: 15, Difficulty: Difficulty.Easy),
-			(StableReference: "antiquity_narrow_wool_trousers", Name: "assemble Germanic narrow wool trousers", DisplayName: "Germanic narrow wool trousers", Material: "wool", Cloth: 515, SecondaryCloth: 0, Yarn: 25, Fine: false, GeneratedProduct: false, Minimum: 15, Difficulty: Difficulty.Normal),
-			(StableReference: "antiquity_heavy_wool_cloak", Name: "assemble a Germanic heavy wool cloak", DisplayName: "a Germanic heavy wool cloak", Material: "wool", Cloth: 1210, SecondaryCloth: 0, Yarn: 45, Fine: false, GeneratedProduct: false, Minimum: 20, Difficulty: Difficulty.Normal),
-			(StableReference: "antiquity_fine_banded_wool_tunic", Name: "assemble a Germanic fine banded wool tunic", DisplayName: "a Germanic fine banded wool tunic", Material: "wool", Cloth: 570, SecondaryCloth: 0, Yarn: 35, Fine: true, GeneratedProduct: false, Minimum: 35, Difficulty: Difficulty.Normal),
-			(StableReference: "antiquity_fine_tapered_wool_trousers", Name: "assemble Germanic fine tapered wool trousers", DisplayName: "Germanic fine tapered wool trousers", Material: "wool", Cloth: 495, SecondaryCloth: 0, Yarn: 30, Fine: true, GeneratedProduct: false, Minimum: 35, Difficulty: Difficulty.Hard),
-			(StableReference: "antiquity_long_straight_wool_tunic", Name: "assemble a Germanic long straight wool tunic", DisplayName: "a Germanic long straight wool tunic", Material: "wool", Cloth: 670, SecondaryCloth: 0, Yarn: 30, Fine: false, GeneratedProduct: false, Minimum: 20, Difficulty: Difficulty.Normal),
-			(StableReference: "antiquity_overlapping_wool_skirt", Name: "assemble a Germanic overlapping wool skirt", DisplayName: "a Germanic overlapping wool skirt", Material: "wool", Cloth: 570, SecondaryCloth: 0, Yarn: 25, Fine: false, GeneratedProduct: false, Minimum: 15, Difficulty: Difficulty.Normal),
-			(StableReference: "antiquity_checked_wool_scarf", Name: "assemble a Germanic checked wool scarf", DisplayName: "a Germanic checked wool scarf", Material: "wool", Cloth: 210, SecondaryCloth: 40, Yarn: 12, Fine: false, GeneratedProduct: true, Minimum: 20, Difficulty: Difficulty.Normal),
-			(StableReference: "antiquity_fine_long_wool_gown", Name: "assemble a Germanic fine long wool gown", DisplayName: "a Germanic fine long wool gown", Material: "wool", Cloth: 780, SecondaryCloth: 0, Yarn: 40, Fine: true, GeneratedProduct: false, Minimum: 40, Difficulty: Difficulty.Hard),
-			(StableReference: "antiquity_fine_heavy_wool_mantle", Name: "assemble a Germanic fine heavy wool mantle", DisplayName: "a Germanic fine heavy wool mantle", Material: "wool", Cloth: 1010, SecondaryCloth: 0, Yarn: 40, Fine: true, GeneratedProduct: false, Minimum: 40, Difficulty: Difficulty.Hard),
-			(StableReference: "antiquity_linen_head_veil", Name: "assemble a Germanic linen head veil", DisplayName: "a Germanic linen head veil", Material: "linen", Cloth: 120, SecondaryCloth: 0, Yarn: 10, Fine: true, GeneratedProduct: false, Minimum: 30, Difficulty: Difficulty.Normal)
+			(StableReference: "antiquity_straight_wool_tunic", Name: "assemble a straight wool tunic", DisplayName: "a straight wool tunic", Material: "wool", Cloth: 620, SecondaryCloth: 0, Yarn: 30, Fine: false, GeneratedProduct: false, Minimum: 15, Difficulty: Difficulty.Easy),
+			(StableReference: "antiquity_narrow_wool_trousers", Name: "assemble narrow wool trousers", DisplayName: "narrow wool trousers", Material: "wool", Cloth: 515, SecondaryCloth: 0, Yarn: 25, Fine: false, GeneratedProduct: false, Minimum: 15, Difficulty: Difficulty.Normal),
+			(StableReference: "antiquity_heavy_wool_cloak", Name: "assemble a heavy wool cloak", DisplayName: "a heavy wool cloak", Material: "wool", Cloth: 1210, SecondaryCloth: 0, Yarn: 45, Fine: false, GeneratedProduct: false, Minimum: 20, Difficulty: Difficulty.Normal),
+			(StableReference: "antiquity_fine_banded_wool_tunic", Name: "assemble a fine banded wool tunic", DisplayName: "a fine banded wool tunic", Material: "wool", Cloth: 570, SecondaryCloth: 0, Yarn: 35, Fine: true, GeneratedProduct: false, Minimum: 35, Difficulty: Difficulty.Normal),
+			(StableReference: "antiquity_fine_tapered_wool_trousers", Name: "assemble fine tapered wool trousers", DisplayName: "fine tapered wool trousers", Material: "wool", Cloth: 495, SecondaryCloth: 0, Yarn: 30, Fine: true, GeneratedProduct: false, Minimum: 35, Difficulty: Difficulty.Hard),
+			(StableReference: "antiquity_long_straight_wool_tunic", Name: "assemble a long straight wool tunic", DisplayName: "a long straight wool tunic", Material: "wool", Cloth: 670, SecondaryCloth: 0, Yarn: 30, Fine: false, GeneratedProduct: false, Minimum: 20, Difficulty: Difficulty.Normal),
+			(StableReference: "antiquity_overlapping_wool_skirt", Name: "assemble an overlapping wool skirt", DisplayName: "an overlapping wool skirt", Material: "wool", Cloth: 570, SecondaryCloth: 0, Yarn: 25, Fine: false, GeneratedProduct: false, Minimum: 15, Difficulty: Difficulty.Normal),
+			(StableReference: "antiquity_checked_wool_scarf", Name: "assemble a checked wool scarf", DisplayName: "a checked wool scarf", Material: "wool", Cloth: 210, SecondaryCloth: 40, Yarn: 12, Fine: false, GeneratedProduct: true, Minimum: 20, Difficulty: Difficulty.Normal),
+			(StableReference: "antiquity_fine_long_wool_gown", Name: "assemble a fine long wool gown", DisplayName: "a fine long wool gown", Material: "wool", Cloth: 780, SecondaryCloth: 0, Yarn: 40, Fine: true, GeneratedProduct: false, Minimum: 40, Difficulty: Difficulty.Hard),
+			(StableReference: "antiquity_fine_heavy_wool_mantle", Name: "assemble a fine heavy wool mantle", DisplayName: "a fine heavy wool mantle", Material: "wool", Cloth: 1010, SecondaryCloth: 0, Yarn: 40, Fine: true, GeneratedProduct: false, Minimum: 40, Difficulty: Difficulty.Hard),
+			(StableReference: "antiquity_linen_head_veil", Name: "assemble a linen head veil", DisplayName: "a linen head veil", Material: "linen", Cloth: 120, SecondaryCloth: 0, Yarn: 10, Fine: true, GeneratedProduct: false, Minimum: 30, Difficulty: Difficulty.Normal)
 		})
 		{
 			var characteristicRequirements = garment.Fine
@@ -1169,7 +1890,7 @@ public partial class ItemSeeder
 				garment.Name,
 				$"assemble {garment.DisplayName} from {garment.Material} garment cloth",
 				garment.Name,
-				$"{garment.Material} cloth being assembled into Germanic clothing",
+				$"{garment.Material} cloth being assembled into clothing",
 				garment.Minimum,
 				garment.Difficulty,
 				garment.GeneratedProduct ? patternedAssemblyPhases : germanicAssemblyPhases,
@@ -1179,10 +1900,10 @@ public partial class ItemSeeder
 		}
 
 		AddGermanicGarmentCraft(
-			"assemble a Germanic fur-lined wool cloak",
-			"assemble a Germanic fur-lined wool cloak from fine wool cloth and fur lining stock",
-			"assemble a Germanic fur-lined wool cloak",
-			"fine wool and fur being assembled into Germanic winter clothing",
+			"assemble a fur-lined wool cloak",
+			"assemble a fur-lined wool cloak from fine wool cloth and fur lining stock",
+			"assemble a fur-lined wool cloak",
+			"fine wool and fur being assembled into winter clothing",
 			40,
 			Difficulty.Hard,
 			furLinedAssemblyPhases,
@@ -1195,10 +1916,10 @@ public partial class ItemSeeder
 			[StableVariableProduct("antiquity_fur_lined_wool_cloak", true)]);
 
 		AddGermanicGarmentCraft(
-			"assemble a Germanic woolly skin cape",
-			"assemble a Germanic woolly skin cape from processed hair-on skin",
-			"assemble a Germanic woolly skin cape",
-			"hair-on animal skin being assembled into Germanic winter clothing",
+			"assemble a woolly skin cape",
+			"assemble a woolly skin cape from processed hair-on skin",
+			"assemble a woolly skin cape",
+			"hair-on animal skin being assembled into winter clothing",
 			25,
 			Difficulty.Normal,
 			skinCapePhases,
@@ -1235,7 +1956,7 @@ public partial class ItemSeeder
 			IEnumerable<(int Seconds, string Echo, string FailEcho)> phases, IEnumerable<string> inputs,
 			IEnumerable<string> tools, IEnumerable<string> products)
 		{
-			AddCraft(
+			AddAntiquityCraft(
 				name,
 				"Tailoring",
 				blurb,
@@ -1245,16 +1966,11 @@ public partial class ItemSeeder
 				"Tailoring",
 				minimumTraitValue,
 				difficulty,
-				Outcome.MinorFail,
-				5,
-				3,
-				false,
 				phases,
 				inputs,
 				tools,
 				products,
-				[],
-				knowledgeSubtype: "Kushite",
+                knowledgeSubtype: "Kushite",
 				knowledgeDescription: kushiteKnowledgeDescription,
 				knowledgeLongDescription: kushiteKnowledgeDescription);
 		}
@@ -1286,17 +2002,17 @@ public partial class ItemSeeder
 
 		foreach (var garment in new[]
 		{
-			(StableReference: "adjacent_antiquity_narrow_linen_kilt", Name: "assemble a Kushite narrow linen kilt", DisplayName: "a Kushite narrow linen kilt", Material: "linen", Cloth: 210, Yarn: 15, BeadStock: 0, Fine: false, Minimum: 10, Difficulty: Difficulty.Easy),
-			(StableReference: "adjacent_antiquity_linen_shoulder_cloth", Name: "assemble a Kushite linen shoulder cloth", DisplayName: "a Kushite linen shoulder cloth", Material: "linen", Cloth: 170, Yarn: 10, BeadStock: 0, Fine: false, Minimum: 10, Difficulty: Difficulty.Easy),
-			(StableReference: "adjacent_antiquity_cotton_wrap_skirt", Name: "assemble a Kushite cotton wrap skirt", DisplayName: "a Kushite cotton wrap skirt", Material: "cotton", Cloth: 310, Yarn: 20, BeadStock: 0, Fine: false, Minimum: 15, Difficulty: Difficulty.Normal),
-			(StableReference: "adjacent_antiquity_sleeveless_linen_tunic", Name: "assemble a Kushite sleeveless linen tunic", DisplayName: "a Kushite sleeveless linen tunic", Material: "linen", Cloth: 285, Yarn: 25, BeadStock: 0, Fine: false, Minimum: 15, Difficulty: Difficulty.Normal),
-			(StableReference: "adjacent_antiquity_fringed_linen_robe", Name: "assemble a Kushite fringed linen robe", DisplayName: "a Kushite fringed linen robe", Material: "linen", Cloth: 500, Yarn: 40, BeadStock: 0, Fine: true, Minimum: 35, Difficulty: Difficulty.Hard),
-			(StableReference: "adjacent_antiquity_tasseled_linen_shawl", Name: "assemble a Kushite tasseled linen shawl", DisplayName: "a Kushite tasseled linen shawl", Material: "linen", Cloth: 190, Yarn: 30, BeadStock: 0, Fine: true, Minimum: 30, Difficulty: Difficulty.Normal),
-			(StableReference: "adjacent_antiquity_tall_linen_headdress", Name: "assemble a Kushite tall linen headdress", DisplayName: "a Kushite tall linen headdress", Material: "linen", Cloth: 235, Yarn: 25, BeadStock: 0, Fine: true, Minimum: 35, Difficulty: Difficulty.Hard),
-			(StableReference: "adjacent_antiquity_beaded_linen_girdle", Name: "assemble a Kushite beaded linen girdle", DisplayName: "a Kushite beaded linen girdle", Material: "linen", Cloth: 210, Yarn: 25, BeadStock: 40, Fine: true, Minimum: 40, Difficulty: Difficulty.Hard),
-			(StableReference: "adjacent_antiquity_cotton_draped_dress", Name: "assemble a Kushite cotton draped dress", DisplayName: "a Kushite cotton draped dress", Material: "cotton", Cloth: 430, Yarn: 30, BeadStock: 0, Fine: true, Minimum: 35, Difficulty: Difficulty.Hard),
-			(StableReference: "adjacent_antiquity_linen_bead_apron", Name: "assemble a Kushite linen bead apron", DisplayName: "a Kushite linen bead apron", Material: "linen", Cloth: 150, Yarn: 20, BeadStock: 50, Fine: true, Minimum: 35, Difficulty: Difficulty.Normal),
-			(StableReference: "adjacent_antiquity_plain_cotton_headcloth", Name: "assemble a Kushite plain cotton headcloth", DisplayName: "a Kushite plain cotton headcloth", Material: "cotton", Cloth: 80, Yarn: 8, BeadStock: 0, Fine: false, Minimum: 10, Difficulty: Difficulty.Easy)
+			(StableReference: "adjacent_antiquity_narrow_linen_kilt", Name: "assemble a river-valley narrow linen kilt", DisplayName: "a river-valley narrow linen kilt", Material: "linen", Cloth: 210, Yarn: 15, BeadStock: 0, Fine: false, Minimum: 10, Difficulty: Difficulty.Easy),
+			(StableReference: "adjacent_antiquity_linen_shoulder_cloth", Name: "assemble a river-valley linen shoulder cloth", DisplayName: "a river-valley linen shoulder cloth", Material: "linen", Cloth: 170, Yarn: 10, BeadStock: 0, Fine: false, Minimum: 10, Difficulty: Difficulty.Easy),
+			(StableReference: "adjacent_antiquity_cotton_wrap_skirt", Name: "assemble a river-valley cotton wrap skirt", DisplayName: "a river-valley cotton wrap skirt", Material: "cotton", Cloth: 310, Yarn: 20, BeadStock: 0, Fine: false, Minimum: 15, Difficulty: Difficulty.Normal),
+			(StableReference: "adjacent_antiquity_sleeveless_linen_tunic", Name: "assemble a river-valley sleeveless linen tunic", DisplayName: "a river-valley sleeveless linen tunic", Material: "linen", Cloth: 285, Yarn: 25, BeadStock: 0, Fine: false, Minimum: 15, Difficulty: Difficulty.Normal),
+			(StableReference: "adjacent_antiquity_fringed_linen_robe", Name: "assemble a river-valley fringed linen robe", DisplayName: "a river-valley fringed linen robe", Material: "linen", Cloth: 500, Yarn: 40, BeadStock: 0, Fine: true, Minimum: 35, Difficulty: Difficulty.Hard),
+			(StableReference: "adjacent_antiquity_tasseled_linen_shawl", Name: "assemble a river-valley tasseled linen shawl", DisplayName: "a river-valley tasseled linen shawl", Material: "linen", Cloth: 190, Yarn: 30, BeadStock: 0, Fine: true, Minimum: 30, Difficulty: Difficulty.Normal),
+			(StableReference: "adjacent_antiquity_tall_linen_headdress", Name: "assemble a river-valley tall linen headdress", DisplayName: "a river-valley tall linen headdress", Material: "linen", Cloth: 235, Yarn: 25, BeadStock: 0, Fine: true, Minimum: 35, Difficulty: Difficulty.Hard),
+			(StableReference: "adjacent_antiquity_beaded_linen_girdle", Name: "assemble a river-valley beaded linen girdle", DisplayName: "a river-valley beaded linen girdle", Material: "linen", Cloth: 210, Yarn: 25, BeadStock: 40, Fine: true, Minimum: 40, Difficulty: Difficulty.Hard),
+			(StableReference: "adjacent_antiquity_cotton_draped_dress", Name: "assemble a river-valley cotton draped dress", DisplayName: "a river-valley cotton draped dress", Material: "cotton", Cloth: 430, Yarn: 30, BeadStock: 0, Fine: true, Minimum: 35, Difficulty: Difficulty.Hard),
+			(StableReference: "adjacent_antiquity_linen_bead_apron", Name: "assemble a river-valley linen bead apron", DisplayName: "a river-valley linen bead apron", Material: "linen", Cloth: 150, Yarn: 20, BeadStock: 50, Fine: true, Minimum: 35, Difficulty: Difficulty.Normal),
+			(StableReference: "adjacent_antiquity_plain_cotton_headcloth", Name: "assemble a river-valley plain cotton headcloth", DisplayName: "a river-valley plain cotton headcloth", Material: "cotton", Cloth: 80, Yarn: 8, BeadStock: 0, Fine: false, Minimum: 10, Difficulty: Difficulty.Easy)
 		})
 		{
 			var characteristicRequirements = garment.Fine
@@ -1317,7 +2033,7 @@ public partial class ItemSeeder
 				garment.Name,
 				$"assemble {garment.DisplayName} from {garment.Material} garment cloth",
 				garment.Name,
-				$"{garment.Material} cloth being assembled into Kushite clothing",
+				$"{garment.Material} cloth being assembled into clothing",
 				garment.Minimum,
 				garment.Difficulty,
 				garment.BeadStock > 0 ? kushiteBeadedPhases : kushiteAssemblyPhases,
@@ -1381,7 +2097,7 @@ public partial class ItemSeeder
             IEnumerable<(int Seconds, string Echo, string FailEcho)> phases, IEnumerable<string> inputs,
             IEnumerable<string> tools, IEnumerable<string> products)
         {
-            AddCraft(
+            AddAntiquityCraft(
                 name,
                 "Tailoring",
                 blurb,
@@ -1391,15 +2107,10 @@ public partial class ItemSeeder
                 "Tailoring",
                 minimumTraitValue,
                 difficulty,
-                Outcome.MinorFail,
-                5,
-                3,
-                false,
                 phases,
                 inputs,
                 tools,
                 products,
-                [],
                 knowledgeSubtype: "Egyptian",
                 knowledgeDescription: egyptianKnowledgeDescription,
                 knowledgeLongDescription: egyptianKnowledgeDescription);
@@ -1432,14 +2143,14 @@ public partial class ItemSeeder
 
         foreach (var garment in new[]
         {
-            (StableReference: "adjacent_antiquity_narrow_linen_kilt", Name: "assemble an Egyptian narrow linen kilt", DisplayName: "an Egyptian narrow linen kilt", Cloth: 210, Yarn: 15, BeadStock: 0, Fine: false, Minimum: 10, Difficulty: Difficulty.Easy),
-            (StableReference: "adjacent_antiquity_linen_shoulder_cloth", Name: "assemble an Egyptian linen shoulder cloth", DisplayName: "an Egyptian linen shoulder cloth", Cloth: 170, Yarn: 10, BeadStock: 0, Fine: false, Minimum: 10, Difficulty: Difficulty.Easy),
-            (StableReference: "adjacent_antiquity_sleeveless_linen_tunic", Name: "assemble an Egyptian sleeveless linen tunic", DisplayName: "an Egyptian sleeveless linen tunic", Cloth: 285, Yarn: 25, BeadStock: 0, Fine: false, Minimum: 15, Difficulty: Difficulty.Normal),
-            (StableReference: "adjacent_antiquity_fringed_linen_robe", Name: "assemble an Egyptian fringed linen robe", DisplayName: "an Egyptian fringed linen robe", Cloth: 500, Yarn: 40, BeadStock: 0, Fine: true, Minimum: 35, Difficulty: Difficulty.Hard),
-            (StableReference: "adjacent_antiquity_tasseled_linen_shawl", Name: "assemble an Egyptian tasseled linen shawl", DisplayName: "an Egyptian tasseled linen shawl", Cloth: 190, Yarn: 30, BeadStock: 0, Fine: true, Minimum: 30, Difficulty: Difficulty.Normal),
-            (StableReference: "adjacent_antiquity_tall_linen_headdress", Name: "assemble an Egyptian tall linen headdress", DisplayName: "an Egyptian tall linen headdress", Cloth: 235, Yarn: 25, BeadStock: 0, Fine: true, Minimum: 35, Difficulty: Difficulty.Hard),
-            (StableReference: "adjacent_antiquity_beaded_linen_girdle", Name: "assemble an Egyptian beaded linen girdle", DisplayName: "an Egyptian beaded linen girdle", Cloth: 210, Yarn: 25, BeadStock: 40, Fine: true, Minimum: 40, Difficulty: Difficulty.Hard),
-            (StableReference: "adjacent_antiquity_linen_bead_apron", Name: "assemble an Egyptian linen bead apron", DisplayName: "an Egyptian linen bead apron", Cloth: 150, Yarn: 20, BeadStock: 50, Fine: true, Minimum: 35, Difficulty: Difficulty.Normal)
+            (StableReference: "adjacent_antiquity_narrow_linen_kilt", Name: "assemble a narrow linen kilt", DisplayName: "a narrow linen kilt", Cloth: 210, Yarn: 15, BeadStock: 0, Fine: false, Minimum: 10, Difficulty: Difficulty.Easy),
+            (StableReference: "adjacent_antiquity_linen_shoulder_cloth", Name: "assemble a linen shoulder cloth", DisplayName: "a linen shoulder cloth", Cloth: 170, Yarn: 10, BeadStock: 0, Fine: false, Minimum: 10, Difficulty: Difficulty.Easy),
+            (StableReference: "adjacent_antiquity_sleeveless_linen_tunic", Name: "assemble a sleeveless linen tunic", DisplayName: "a sleeveless linen tunic", Cloth: 285, Yarn: 25, BeadStock: 0, Fine: false, Minimum: 15, Difficulty: Difficulty.Normal),
+            (StableReference: "adjacent_antiquity_fringed_linen_robe", Name: "assemble a fringed linen robe", DisplayName: "a fringed linen robe", Cloth: 500, Yarn: 40, BeadStock: 0, Fine: true, Minimum: 35, Difficulty: Difficulty.Hard),
+            (StableReference: "adjacent_antiquity_tasseled_linen_shawl", Name: "assemble a tasseled linen shawl", DisplayName: "a tasseled linen shawl", Cloth: 190, Yarn: 30, BeadStock: 0, Fine: true, Minimum: 30, Difficulty: Difficulty.Normal),
+            (StableReference: "adjacent_antiquity_tall_linen_headdress", Name: "assemble a tall linen headdress", DisplayName: "a tall linen headdress", Cloth: 235, Yarn: 25, BeadStock: 0, Fine: true, Minimum: 35, Difficulty: Difficulty.Hard),
+            (StableReference: "adjacent_antiquity_beaded_linen_girdle", Name: "assemble a beaded linen girdle", DisplayName: "a beaded linen girdle", Cloth: 210, Yarn: 25, BeadStock: 40, Fine: true, Minimum: 40, Difficulty: Difficulty.Hard),
+            (StableReference: "adjacent_antiquity_linen_bead_apron", Name: "assemble a linen bead apron", DisplayName: "a linen bead apron", Cloth: 150, Yarn: 20, BeadStock: 50, Fine: true, Minimum: 35, Difficulty: Difficulty.Normal)
         })
         {
             var characteristicRequirements = garment.Fine
@@ -1460,7 +2171,7 @@ public partial class ItemSeeder
                 garment.Name,
                 $"assemble {garment.DisplayName} from linen garment cloth",
                 garment.Name,
-                "linen cloth being assembled into Egyptian clothing",
+                "linen cloth being assembled into clothing",
                 garment.Minimum,
                 garment.Difficulty,
                 garment.BeadStock > 0 ? beadedAssemblyPhases : linenAssemblyPhases,

--- a/DatabaseSeeder/Seeders/ItemSeederCrafting.cs
+++ b/DatabaseSeeder/Seeders/ItemSeederCrafting.cs
@@ -250,6 +250,99 @@ public partial class ItemSeeder
 			["adjacent_antiquity_long_felt_coat"] = "a long $colour felt coat"
 		};
 
+	private static readonly IReadOnlyDictionary<string, string> AntiquityLeatherClothingStableReferences =
+		new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+		{
+			["antiquity_plain_leather_belt"] = "a plain brown leather belt",
+			["antiquity_bronze_buckled_leather_belt"] = "a $colour bronze-buckled belt",
+			["antiquity_plain_leather_sandals"] = "a pair of plain leather sandals",
+			["antiquity_fine_leather_sandals"] = "a pair of fine $colour sandals",
+			["antiquity_soft_leather_shoes"] = "a pair of soft leather shoes",
+			["antiquity_ankle_leather_boots"] = "a pair of ankle leather boots",
+			["antiquity_low_strapped_leather_shoes"] = "a pair of strapped leather shoes",
+			["antiquity_soft_leather_riding_boots"] = "a pair of soft leather riding boots",
+			["adjacent_antiquity_pointed_leather_shoes"] = "a pair of pointed leather shoes",
+			["adjacent_antiquity_fine_pointed_leather_shoes"] = "a pair of fine $colour pointed shoes",
+			["adjacent_antiquity_soft_riding_boots"] = "a pair of soft riding boots",
+			["adjacent_antiquity_fine_linen_sandals"] = "a pair of fine linen-strapped sandals"
+		};
+
+	private static readonly IReadOnlyDictionary<string, string> AntiquityLeatherArmourStableReferences =
+		new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+		{
+			["antiquity_celtic_dyed_leather_scale_vest"] = "a $colour leather scale vest",
+			["antiquity_celtic_bronze_studded_leather_belt"] = "a bronze-studded leather war belt",
+			["antiquity_celtic_leather_war_bracers"] = "a pair of leather war bracers",
+			["antiquity_celtic_fur_lined_war_boots"] = "a pair of fur-lined war boots",
+			["antiquity_germanic_broad_leather_war_belt"] = "a broad leather war belt",
+			["antiquity_germanic_hide_war_bracers"] = "a pair of hide war bracers",
+			["antiquity_germanic_fur_cuffed_high_boots"] = "a pair of fur-cuffed high boots",
+			["antiquity_etruscan_pteruges_leather_girdle"] = "a leather pteruges girdle",
+			["antiquity_etruscan_bronze_studded_sandals"] = "a pair of bronze-studded sandals",
+			["antiquity_roman_plated_military_belt"] = "a plated leather military belt",
+			["antiquity_roman_aproned_military_belt"] = "an apron-fronted military belt",
+			["antiquity_roman_reinforced_caligae"] = "a pair of reinforced leather caligae",
+			["antiquity_roman_leather_field_boots"] = "a pair of leather field boots",
+			["antiquity_hellenic_leather_pteruges_girdle"] = "a leather pteruges girdle",
+			["antiquity_hellenic_bronze_studded_sandals"] = "a pair of bronze-studded sandals",
+			["antiquity_punic_bronze_studded_girdle"] = "a bronze-studded leather girdle",
+			["antiquity_persian_scale_anaxyrides"] = "a pair of scale anaxyrides",
+			["antiquity_persian_soft_riding_boots"] = "a pair of armoured riding boots",
+			["antiquity_egyptian_leather_scale_cuirass"] = "a leather scale cuirass",
+			["antiquity_egyptian_scale_kilt_guard"] = "a leather scale kilt guard",
+			["antiquity_egyptian_leather_archer_bracer"] = "a leather archer bracer",
+			["antiquity_anatolian_leather_cavalry_boots"] = "a pair of leather cavalry boots",
+			["antiquity_scythian_leather_scale_corselet"] = "a leather scale corselet",
+			["antiquity_scythian_conical_scale_cap"] = "a conical scale war cap",
+			["antiquity_scythian_scale_trousers"] = "a pair of leather scale trousers",
+			["antiquity_scythian_high_riding_boots"] = "a pair of high riding boots",
+			["antiquity_kushite_leather_scale_breastguard"] = "a leather scale breastguard",
+			["antiquity_kushite_leather_archer_bracer"] = "a leather archer bracer",
+			["antiquity_kushite_leather_kilt_guard"] = "a leather kilt guard",
+			["antiquity_kushite_sand_armoured_sandals"] = "a pair of armoured leather sandals"
+		};
+
+	private static readonly IReadOnlyDictionary<string, string> AntiquityLeatherContainerStableReferences =
+		new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+		{
+			["antiquity_smoked_hide_meat_bag"] = "a smoked hide provision bag",
+			["antiquity_leather_document_case"] = "a folded leather document case",
+			["antiquity_leather_mirror_case"] = "a tooled leather mirror case",
+			["antiquity_plain_leather_belt_pouch"] = "a plain leather belt pouch",
+			["antiquity_double_strap_travel_pack"] = "a double-strapped leather pack",
+			["antiquity_fur_lined_forager_bag"] = "a fur-lined forager's bag",
+			["antiquity_deer_leather_game_bag"] = "a deer-leather game bag",
+			["antiquity_folded_tablet_wallet"] = "a folded leather tablet wallet",
+			["antiquity_round_coin_purse"] = "a round leather coin purse",
+			["antiquity_leather_dispatch_satchel"] = "a leather dispatch satchel",
+			["antiquity_wide_belt_document_pouch"] = "a wide leather document pouch",
+			["antiquity_steppe_saddlebag_pack"] = "a steppe leather saddlebag pack",
+			["antiquity_steppe_gorytos_case"] = "a tooled leather gorytos case",
+			["antiquity_fur_provision_pouch"] = "a fur provision pouch",
+			["antiquity_liquid_steppe_milk_skin"] = "a dark leather milk skin",
+			["antiquity_liquid_plain_leather_waterskin"] = "a plain leather waterskin",
+			["antiquity_liquid_wide_mouth_waterskin"] = "a wide-mouthed waterskin",
+			["antiquity_liquid_leather_belt_oil_flask"] = "a leather belt oil flask",
+			["antiquity_liquid_hide_ale_skin"] = "a hide ale skin",
+			["antiquity_liquid_birch_stoppered_mead_skin"] = "a birch-stoppered mead skin",
+			["antiquity_liquid_soldier_shoulder_canteen"] = "a leather-covered shoulder canteen",
+			["antiquity_liquid_sailor_water_skin"] = "a tar-dark sailor waterskin",
+			["antiquity_liquid_caravan_waterskin"] = "a large caravan waterskin",
+			["antiquity_liquid_silver_tipped_belt_flask"] = "a silver-tipped belt flask",
+			["antiquity_liquid_felt_covered_riding_canteen"] = "a felt-covered riding canteen",
+			["antiquity_liquid_saddle_waterskin"] = "a saddle-hung waterskin",
+			["antiquity_liquid_steppe_kumis_skin"] = "a patched fermented-milk skin",
+			["antiquity_liquid_tooled_leather_flask"] = "a tooled leather flask",
+			["antiquity_tableware_scythian_leather_travel_cup"] = "a folded leather travel cup"
+		};
+
+	private static readonly IReadOnlyDictionary<string, string> AntiquityLeatherFurnishingStableReferences =
+		new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+		{
+			["antiquity_fur_door_hanging"] = "a fur doorway hanging",
+			["antiquity_leather_tent_door_flap"] = "a leather tent door flap"
+		};
+
 	private sealed record CraftValidationError(string CraftName, string Kind, string ImportText, string Message)
 	{
 		public override string ToString()
@@ -1994,6 +2087,11 @@ return ""You need at least {minimumTraitValue.Value.ToString(System.Globalizatio
 		SeedAntiquityEtruscanClothingCrafts();
 		SeedAntiquityAnatolianClothingCrafts();
 		SeedAntiquityScythianSarmatianClothingCrafts();
+		SeedAntiquityLeatherPreparationCrafts();
+		SeedAntiquityLeatherClothingCrafts();
+		SeedAntiquityLeatherArmourCrafts();
+		SeedAntiquityLeatherContainerCrafts();
+		SeedAntiquityLeatherFurnishingCrafts();
 
         AddCraft("sew padded vest", "Armorcrafting", "sew a padded cloth vest", "sewing a padded vest", "a padded vest armormaking event", "HasTailoring", null, null, null, _traits["Tailoring"] ?? _traits["Tailor"] ?? _traits.First().Value, Difficulty.Normal, Outcome.MinorFail, 5, 6, false, [(35, "$0 lay|lays out $i1 and begin|begins to divide it into three pieces - one large, and two smaller sheets, cutting away with $t2. Additionally, when that is done, $0 pick|picks up $t1 and thread|threads $i2 through the needle eye.", "$0 lay|lays out $i1 and begin|begins to divide it into three pieces - one large, and two smaller sheets, cutting away with $t2. Additionally, when that is done, $0 pick|picks up $t1 and thread|threads $i2 through the needle eye."), (30, "$0 set|sets aside the smaller pieces of cloth for the moment, focusing on the larger sheet. $0 further cut|cuts that larger piece into two more pieces, and then sew|sews those pieces together to form a rough sort of case.", "$0 set|sets aside the smaller pieces of cloth for the moment, focusing on the larger sheet. $0 further cut|cuts that larger piece into two more pieces, and then sew|sews those pieces together to form a rough sort of case."), (35, "$0 liberally stuff|stuffs that cloth case with $i3 until it is almost stiff and inflexible, then sew|sews it shut with $t1 to create a padded tube with a hole for someone's head, and two smaller holes for someone's arms.", "$0 liberally stuff|stuffs that cloth case with $i3 until it is almost stiff and inflexible, then sew|sews it shut with $t1 to create a padded tube with a hole for someone's head, and two smaller holes for someone's arms."), (40, "$0 turn|turns to the smaller sheets of cloth, cutting, sewing and padding these sheets until they are amply padded cloth tubes.", "$0 turn|turns to the smaller sheets of cloth, cutting, sewing and padding these sheets until they are amply padded cloth tubes."), (40, "$0 finally begin|begins to sew the padded sleeves to the shoulder arm-holes of the vest, using $i2 to tightly fix them in place.", "$0 finally begin|begins to sew the padded sleeves to the shoulder arm-holes of the vest, using $i2 to tightly fix them in place."), (40, "$0 hold|holds up $p1, checking the piece over critically before setting it aside.", "Unfortunately, shoddy craftsmanship means that $0 end|ends up shredding the terrible vest for $f1.")], ["CommodityTag - 1 kilogram 500 grams of a material tagged as Fabric", "Tag - 1x an item with the Thread tag", "Tag - 50x an item with the Padding tag"], ["TagTool - Held - an item with the Sewing Needle tag", "TagTool - Held - an item with the Scissors tag"], ["SimpleProduct - 1x a padded @material gambeson with long sleeves (#274)"], ["UnusedInput - 45.00% of 50x an item with the Padding tag ($i3)"], [(1, 1)]);
         AddCraft("sew padded cap", "Armorcrafting", "sew a padded cloth cap", "sewing a padded cap", "a padded cap armormaking event", "HasTailoring", null, null, null, _traits["Tailoring"] ?? _traits["Tailor"] ?? _traits.First().Value, Difficulty.Normal, Outcome.MinorFail, 5, 5, false, [(35, "$0 lay|lays out $i1 and begin|begins to divide it into two smaller pieces, cutting with $t2.", "$0 lay|lays out $i1 and begin|begins to divide it into two smaller pieces, cutting with $t2."), (30, "$0 set|sets aside the pattern-shaped pieces of cloth for a moment and instead reach|reaches for $t1 and $i2, threading the end of the thread through the needle.", "$0 set|sets aside the pattern-shaped pieces of cloth for a moment and instead reach|reaches for $t1 and $i2, threading the end of the thread through the needle."), (35, "$0 begin|begins to stitch the two smaller pieces of cloth together, leaving the bowl-shaped case open at one end.", "$0 begin|begins to stitch the two smaller pieces of cloth together, leaving the bowl-shaped case open at one end."), (40, "$0 begin|begins to stuff the case full of $i3 until it is stiff and firmly padded, then stitch|stitches the opening shut.", "$0 begin|begins to stuff the case full of $i3 until it is stiff and firmly padded, then stitch|stitches the opening shut."), (40, "$0 hold|holds up $p1, checking the piece over critically before setting it aside.", "Unfortunately, shoddy craftsmanship means that $0 end|ends up shredding the terrible cap for $f1.")], ["CommodityTag - 500 grams of a material tagged as Fabric", "Tag - 1x an item with the Thread tag", "Tag - 20x an item with the Padding tag"], ["TagTool - Held - an item with the Sewing Needle tag", "TagTool - Held - an item with the Scissors tag"], ["SimpleProduct - 1x a padded @material arming cap (#275)"], ["UnusedInput - 45.00% of 50x an item with the Padding tag ($i3)"], [(1, 1)]);

--- a/DatabaseSeeder/Seeders/UsefulSeeder.Tags.cs
+++ b/DatabaseSeeder/Seeders/UsefulSeeder.Tags.cs
@@ -75,6 +75,16 @@ namespace DatabaseSeeder.Seeders
             AddTag(context, "Woven Cloth", "Garment Cloth");
             AddTag(context, "Dyed Cloth", "Garment Cloth");
             AddTag(context, "Fulled Cloth", "Garment Cloth");
+            AddTag(context, "Leather Commodity", "Material Functions");
+            AddTag(context, "Prepared Hide", "Leather Commodity");
+            AddTag(context, "Tanned Leather", "Leather Commodity");
+            AddTag(context, "Leather Sole", "Leather Commodity");
+            AddTag(context, "Leather Strap", "Leather Commodity");
+            AddTag(context, "Leather Thong", "Leather Commodity");
+            AddTag(context, "Leather Panel", "Leather Commodity");
+            AddTag(context, "Hardened Leather Panel", "Leather Commodity");
+            AddTag(context, "Leather Scale", "Leather Commodity");
+            AddTag(context, "Sealed Leather Panel", "Leather Commodity");
             AddTag(context, "Bead Stock", "Material Functions");
 
             AddTag(context, "Repairing", "Functions");
@@ -446,6 +456,8 @@ namespace DatabaseSeeder.Seeders
             AddTag(context, "Edge Beveller", "Leatherworking Tools");
             AddTag(context, "Leather Gouge", "Leatherworking Tools");
             AddTag(context, "Leather Creaser", "Leatherworking Tools");
+            AddTag(context, "Shoe Last", "Leatherworking Tools");
+            AddTag(context, "Leather Wax Pot", "Leatherworking Tools");
 
             // Stoneworking
             AddTag(context, "Stoneworking Tools", "Tools");

--- a/Design Documents/Antiquity_Hellenic_Clothing_Crafting_Suite.md
+++ b/Design Documents/Antiquity_Hellenic_Clothing_Crafting_Suite.md
@@ -1,6 +1,6 @@
 # Antiquity Clothing Crafting Suite
 
-This document records the antiquity clothing craft suite as it grows through culture-specific garment slices. The shared upstream chain takes agricultural or animal-fibre commodities through prepared fibre, yarn, cloth, dyeing, fulling, and final assembly. Finished garments are split by culture knowledge so builders can decide which cultural clothing sets appear in their game.
+This document records the antiquity clothing craft suite as it grows through culture-specific garment slices. The shared upstream textile chain takes agricultural or animal-fibre commodities through prepared fibre, yarn, cloth, dyeing, fulling, and final assembly. The leather suite takes raw animal skin through prepared hide, tanned leather, cut soles, straps, thongs, panels, hardened panels, leather scales, and sealed panels before assembling leather clothing, armour, containers, liquid vessels, tableware, and doorway fittings. Finished textile garments remain split by culture knowledge so builders can decide which cultural clothing sets appear in their game.
 
 Historical anchors:
 
@@ -39,7 +39,7 @@ Historical anchors:
 
 `Celtic Textilecraft` covers culturally specific finished garments for the Celtic antiquity slice: sleeved wool tunics, braccae, rectangular cloaks, checked cloaks, mantles, gowns, skirts, and linen veils. The source anchor here is the broad archaeological and iconographic pattern of tunic-trouser-cloak dress, with checked and bordered cloth represented as textile finish rather than as full intermediate item panels.
 
-`Germanic Textilecraft` covers culturally specific finished garments for the northern Germanic antiquity slice: straight wool tunics, narrow trousers, heavy cloaks, checked scarves, gowns, mantles, linen veils, fur-lined cloaks, and woolly skin capes. Hair-on skins and fur lining use existing `Animal Skin` and `Hair` material tags as commodity inputs in this slice; a full tanning/fur-processing chain belongs to a later leather and hide pass.
+`Germanic Textilecraft` covers culturally specific finished garments for the northern Germanic antiquity slice: straight wool tunics, narrow trousers, heavy cloaks, checked scarves, gowns, mantles, linen veils, fur-lined cloaks, and woolly skin capes. Hair-on skins and fur lining use existing `Animal Skin` and `Hair` material tags as commodity inputs in this textile slice; the separate leather chain now handles hide scraping, tanning, and cut leather stock.
 
 `Kushite Textilecraft` covers culturally specific finished garments for the Kushite/Nubian Nile Valley slice: linen kilts, shoulder cloths, tunics, robes, shawls, headdresses, beaded girdles and aprons, cotton wrap skirts, cotton draped dresses, and cotton headcloths. Shared linen production remains culture-neutral, while cotton is added to the shared textile commodity chain so Kushite cotton garments can be craftable from agricultural stock.
 
@@ -51,7 +51,9 @@ Historical anchors:
 
 `Anatolian Textilecraft` covers culturally specific finished garments for Anatolian and Phrygian-adjacent dress: belted wool tunics, banded tunics, leg wraps, hooded cloaks, forward-pointing felt caps, wool capes, patterned robes, fringed mantles, wrapped skirts, and rectangular veils.
 
-`Scythian-Sarmatian Textilecraft` covers culturally specific finished garments for steppe riding dress: felt riding caps, tall felt caps, riding tunics and trousers, open caftans, fur-trimmed caftans, split riding skirts, and long felt coats. The leather riding boots remain out of this pass because hide footwear belongs with the later hide and footwear craft suite.
+`Scythian-Sarmatian Textilecraft` covers culturally specific finished garments for steppe riding dress: felt riding caps, tall felt caps, riding tunics and trousers, open caftans, fur-trimmed caftans, split riding skirts, and long felt coats.
+
+`Ancient Hide and Leatherworking` covers the shared leather path: scraping and dehairing raw animal skin, tanning prepared hides, cutting leather soles, straps, thongs, panels, hardened armour plates, leather scales, and sealed vessel panels, and assembling leather clothing, armour, containers, liquid vessels, tableware, and doorway fittings. It is culture-neutral so the same stock leather economy can support multiple antiquity item sets without duplicating hide preparation.
 
 ## Commodity Tags
 
@@ -69,6 +71,21 @@ The textile commodity hierarchy is seeded under `Material Functions`:
 `Woven Cloth`, `Dyed Cloth`, and `Fulled Cloth` are children of `Garment Cloth`. Finished garment crafts therefore ask for the broad `Garment Cloth` pile tag and can accept undyed woven cloth, dyed cloth, or fulled cloth through tag ancestry.
 
 `Bead Stock` is also seeded under `Material Functions` for lightweight commodity handling of garment beadwork. It is intentionally separate from the textile hierarchy because the stock can be glass or another bead material, but the craft input can still require the commodity pile tag rather than a full item.
+
+The leather commodity hierarchy is also seeded under `Material Functions`:
+
+- `Leather Commodity`
+- `Prepared Hide`
+- `Tanned Leather`
+- `Leather Sole`
+- `Leather Strap`
+- `Leather Thong`
+- `Leather Panel`
+- `Hardened Leather Panel`
+- `Leather Scale`
+- `Sealed Leather Panel`
+
+`Prepared Hide` is produced from commodities tagged `Animal Skin`. `Tanned Leather` carries the colour characteristics from the prepared hide, and the cut sole, strap, thong, panel, hardened-panel, scale, and sealed-panel commodities copy those characteristics forward so variable leather items can inherit their colour from the leather stock.
 
 ## Tool Prototypes
 
@@ -90,6 +107,19 @@ The antiquity rework item seeder adds period-appropriate full item tools where c
 - Oak fuller's trough
 - Oak fuller's mallet
 - Oak cloth tenter frame
+- Bronze awl punch
+- Oak leather stitching clamp
+- Bronze leather edge beveller
+- Bronze leather gouge
+- Bronze leather creaser
+- Oak shoe last
+- Bronze leather wax pot (`Leather Wax Pot`)
+- Bronze hide scraper
+- Oak tanning beam
+- Oak tanning rack
+- Oak tanning paddle
+- Bronze dehairing knife
+- Oak brain-tanning bucket
 
 The missing supporting tool tags are seeded under `Textilecraft Tools / Flax Processing Tools`: `Retting Trough`, `Flax Break`, `Flax Beater`, `Hackle`, and `Fibre Comb`.
 
@@ -263,7 +293,7 @@ All final garments use `Tailoring` plus `Persian Textilecraft`. One-colour texti
 
 ## Etruscan Garment Matrix
 
-All final garments use `Tailoring` plus `Etruscan Textilecraft`. The slice focuses on linen tunics and gowns, wool tebennas and shoulder cloaks, and head mantles. Pointed leather shoes from the same item block remain out of this clothing pass.
+All final garments use `Tailoring` plus `Etruscan Textilecraft`. The slice focuses on linen tunics and gowns, wool tebennas and shoulder cloaks, and head mantles. Pointed leather shoes from the same item block are handled by the shared leather clothing suite.
 
 | Stable Reference | Garment | Material | Cloth Input | Yarn Input | Product Variable Copy |
 | --- | --- | --- | --- | --- | --- |
@@ -295,7 +325,7 @@ All final garments use `Tailoring` plus `Anatolian Textilecraft`. Felt caps cons
 
 ## Scythian-Sarmatian Garment Matrix
 
-All final garments use `Tailoring` plus `Scythian-Sarmatian Textilecraft`. Felt caps and felt coats rely on the shared felt commodity path. The fur-trimmed caftan uses a commodity input tagged `Hair` rather than a full fur trim item. Leather footwear remains out of this clothing pass and belongs in the hide/footwear suite.
+All final garments use `Tailoring` plus `Scythian-Sarmatian Textilecraft`. Felt caps and felt coats rely on the shared felt commodity path. The fur-trimmed caftan uses a commodity input tagged `Hair` rather than a full fur trim item. Leather riding boots from the same catalogue are handled by the shared leather clothing suite.
 
 | Stable Reference | Garment | Material | Cloth Input | Yarn Input | Other Input | Product Variable Copy |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -309,12 +339,120 @@ All final garments use `Tailoring` plus `Scythian-Sarmatian Textilecraft`. Felt 
 | `adjacent_antiquity_split_riding_skirt` | Split riding skirt | Wool | 590g `Garment Cloth` | 30g `Spun Yarn` | None | `Colour` |
 | `adjacent_antiquity_long_felt_coat` | Long felt coat | Felt | 1270g `Garment Cloth` | 50g `Spun Yarn` | None | `Colour`, `Fine Colour` |
 
+## Full Leather Item Suite
+
+The leather item suite uses `Leathermaking`, the `Leatherworking` craft category, and the `Ancient Hide and Leatherworking` knowledge gate. It now covers the full antiquity leather item surface: clothing leather, armour, containers, liquid vessels, tableware, and doorway fittings. The only fur or hide item in the clothing tables outside this shared method is `antiquity_woolly_skin_cape`, which remains with the Germanic textile slice because it is assembled as a hair-on skin garment rather than tanned leatherwork.
+
+Upstream crafts:
+
+| Craft | Inputs | Tools | Products |
+| --- | --- | --- | --- |
+| Scrape and dehair animal hides | 1.6kg material tagged `Animal Skin`, 2L `Water` | Tanning beam, hide scraper, dehairing knife | 1.2kg `Prepared Hide` |
+| Tan prepared hides into leather | 1.2kg `Prepared Hide`, 3L `Water`, 2L liquid tagged `Tanning Agent` | Tanning rack, tanning paddle, brain-tanning bucket | 1kg `Tanned Leather` |
+| Cut leather soles | 700g `Tanned Leather` | Leather gouge, edge beveller | 560g `Leather Sole` |
+| Cut leather straps and thongs | 500g `Tanned Leather` | Leather gouge, edge beveller, leather creaser | 320g `Leather Strap`, 120g `Leather Thong` |
+| Cut leather panels | 1.1kg `Tanned Leather` | Leather gouge, edge beveller, leather creaser | 920g `Leather Panel` |
+| Harden leather panels | 800g `Leather Panel`, 120g beeswax, 1L `Water` | Leather wax pot, hot fire, tanning rack | 760g `Hardened Leather Panel` |
+| Cut hardened leather scales | 650g `Hardened Leather Panel` | Leather gouge, edge beveller, awl punch | 520g `Leather Scale` |
+| Seal leather panels for vessels | 650g `Leather Panel`, 90g beeswax | Leather wax pot, hot fire, leather creaser | 600g `Sealed Leather Panel` |
+
+Final leather clothing crafts:
+
+| Stable Reference | Item | Leather Input | Sole Input | Strap Input | Thong Input | Other Input | Product Helper |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `antiquity_plain_leather_belt` | Plain leather belt | 140g `Tanned Leather` | None | 80g `Leather Strap` | 20g `Leather Thong` | None | `StableSimpleProduct` |
+| `antiquity_bronze_buckled_leather_belt` | Bronze-buckled leather belt | 170g `Tanned Leather` | None | 95g `Leather Strap` | 25g `Leather Thong` | None | `StableVariableProduct` |
+| `antiquity_plain_leather_sandals` | Plain leather sandals | 120g `Tanned Leather` | 210g `Leather Sole` | 120g `Leather Strap` | 30g `Leather Thong` | None | `StableSimpleProduct` |
+| `antiquity_fine_leather_sandals` | Fine leather sandals | 110g `Tanned Leather` | 190g `Leather Sole` | 130g `Leather Strap` | 35g `Leather Thong` | None | `StableVariableProduct` |
+| `antiquity_soft_leather_shoes` | Soft leather shoes | 260g `Tanned Leather` | 220g `Leather Sole` | 90g `Leather Strap` | 40g `Leather Thong` | None | `StableSimpleProduct` |
+| `antiquity_ankle_leather_boots` | Ankle leather boots | 420g `Tanned Leather` | 300g `Leather Sole` | 130g `Leather Strap` | 55g `Leather Thong` | None | `StableSimpleProduct` |
+| `antiquity_low_strapped_leather_shoes` | Strapped leather shoes | 230g `Tanned Leather` | 210g `Leather Sole` | 150g `Leather Strap` | 40g `Leather Thong` | None | `StableSimpleProduct` |
+| `antiquity_soft_leather_riding_boots` | Soft leather riding boots | 520g `Tanned Leather` | 320g `Leather Sole` | 160g `Leather Strap` | 65g `Leather Thong` | None | `StableSimpleProduct` |
+| `adjacent_antiquity_pointed_leather_shoes` | Pointed leather shoes | 250g `Tanned Leather` | 200g `Leather Sole` | 80g `Leather Strap` | 35g `Leather Thong` | None | `StableSimpleProduct` |
+| `adjacent_antiquity_fine_pointed_leather_shoes` | Fine pointed leather shoes | 240g `Tanned Leather` | 190g `Leather Sole` | 90g `Leather Strap` | 40g `Leather Thong` | None | `StableVariableProduct` |
+| `adjacent_antiquity_soft_riding_boots` | Soft riding boots | 440g `Tanned Leather` | 280g `Leather Sole` | 140g `Leather Strap` | 55g `Leather Thong` | None | `StableSimpleProduct` |
+| `adjacent_antiquity_fine_linen_sandals` | Fine linen-strapped sandals | 80g `Tanned Leather` | 180g `Leather Sole` | 40g `Leather Strap` | 25g `Leather Thong` | 45g linen `Spun Yarn` | `StableSimpleProduct` |
+
+Final leather armour crafts:
+
+| Stable Reference | Item |
+| --- | --- |
+| `antiquity_celtic_dyed_leather_scale_vest` | Dyed leather scale vest |
+| `antiquity_celtic_bronze_studded_leather_belt` | Bronze-studded war belt |
+| `antiquity_celtic_leather_war_bracers` | Leather war bracers |
+| `antiquity_celtic_fur_lined_war_boots` | Fur-lined war boots |
+| `antiquity_germanic_broad_leather_war_belt` | Broad leather war belt |
+| `antiquity_germanic_hide_war_bracers` | Hide war bracers |
+| `antiquity_germanic_fur_cuffed_high_boots` | Fur-cuffed high boots |
+| `antiquity_hellenic_leather_pteruges_girdle` | Leather pteruges girdle |
+| `antiquity_hellenic_bronze_studded_sandals` | Bronze-studded leather sandals |
+| `antiquity_etruscan_pteruges_leather_girdle` | Studded pteruges girdle |
+| `antiquity_etruscan_bronze_studded_sandals` | Fitted bronze-studded sandals |
+| `antiquity_roman_plated_military_belt` | Plated military belt |
+| `antiquity_roman_aproned_military_belt` | Apron-fronted military belt |
+| `antiquity_roman_reinforced_caligae` | Reinforced leather caligae |
+| `antiquity_roman_leather_field_boots` | Leather field boots |
+| `antiquity_punic_bronze_studded_girdle` | Bronze-studded leather girdle |
+| `antiquity_persian_scale_anaxyrides` | Scale anaxyrides |
+| `antiquity_persian_soft_riding_boots` | Armoured riding boots |
+| `antiquity_egyptian_leather_scale_cuirass` | Leather scale cuirass |
+| `antiquity_egyptian_scale_kilt_guard` | Scale kilt guard |
+| `antiquity_egyptian_leather_archer_bracer` | Leather archer bracer |
+| `antiquity_anatolian_leather_cavalry_boots` | Leather cavalry boots |
+| `antiquity_scythian_leather_scale_corselet` | Leather scale corselet |
+| `antiquity_scythian_conical_scale_cap` | Conical scale war cap |
+| `antiquity_scythian_scale_trousers` | Leather scale trousers |
+| `antiquity_scythian_high_riding_boots` | High riding boots |
+| `antiquity_kushite_leather_scale_breastguard` | Leather scale breastguard |
+| `antiquity_kushite_leather_archer_bracer` | River-valley leather archer bracer |
+| `antiquity_kushite_leather_kilt_guard` | Leather kilt guard |
+| `antiquity_kushite_sand_armoured_sandals` | Armoured leather sandals |
+
+Final leather container and vessel crafts:
+
+| Stable Reference | Item |
+| --- | --- |
+| `antiquity_smoked_hide_meat_bag` | Smoked hide provision bag |
+| `antiquity_leather_document_case` | Folded leather document case |
+| `antiquity_leather_mirror_case` | Tooled leather mirror case |
+| `antiquity_plain_leather_belt_pouch` | Plain leather belt pouch |
+| `antiquity_double_strap_travel_pack` | Double-strapped leather pack |
+| `antiquity_fur_lined_forager_bag` | Fur-lined forager bag |
+| `antiquity_deer_leather_game_bag` | Deer-leather game bag |
+| `antiquity_folded_tablet_wallet` | Folded leather tablet wallet |
+| `antiquity_round_coin_purse` | Round leather coin purse |
+| `antiquity_leather_dispatch_satchel` | Leather dispatch satchel |
+| `antiquity_wide_belt_document_pouch` | Wide leather document pouch |
+| `antiquity_steppe_saddlebag_pack` | Saddlebag leather pack |
+| `antiquity_steppe_gorytos_case` | Tooled gorytos case |
+| `antiquity_fur_provision_pouch` | Fur provision pouch |
+| `antiquity_liquid_steppe_milk_skin` | Leather milk skin |
+| `antiquity_liquid_plain_leather_waterskin` | Plain leather waterskin |
+| `antiquity_liquid_wide_mouth_waterskin` | Wide-mouthed waterskin |
+| `antiquity_liquid_leather_belt_oil_flask` | Leather belt oil flask |
+| `antiquity_liquid_hide_ale_skin` | Hide ale skin |
+| `antiquity_liquid_birch_stoppered_mead_skin` | Birch-stoppered mead skin |
+| `antiquity_liquid_soldier_shoulder_canteen` | Leather-covered shoulder canteen |
+| `antiquity_liquid_sailor_water_skin` | Tar-dark waterskin |
+| `antiquity_liquid_caravan_waterskin` | Large caravan waterskin |
+| `antiquity_liquid_silver_tipped_belt_flask` | Silver-tipped belt flask |
+| `antiquity_liquid_felt_covered_riding_canteen` | Felt-covered riding canteen |
+| `antiquity_liquid_saddle_waterskin` | Saddle-hung waterskin |
+| `antiquity_liquid_steppe_kumis_skin` | Patched fermented-milk skin |
+| `antiquity_liquid_tooled_leather_flask` | Tooled leather flask |
+| `antiquity_tableware_scythian_leather_travel_cup` | Folded leather travel cup |
+
+Final leather doorway fitting crafts:
+
+| Stable Reference | Item |
+| --- | --- |
+| `antiquity_fur_door_hanging` | Fur doorway hanging |
+| `antiquity_leather_tent_door_flap` | Leather tent door flap |
+
 ## Implementation Notes
 
 The craft suite keeps cloth bolts, yarn spools, and garment panels as commodities in this slice. Full item prototypes are only used for finished garments and durable tools.
 
-The item craft helper resolves rework stable references to generated prototype IDs when constructing `SimpleVariableProduct` and `SimpleProduct` import strings. If an existing database has the garment prototype by short description but not in the in-memory stable-reference dictionary, the helper can still resolve it by short description. The helper currently knows the Hellenic, Egyptian, Roman, Celtic, Germanic, Kushite, Punic, Persian, Etruscan, Anatolian, and Scythian-Sarmatian antiquity clothing stable-reference maps.
+The item craft helper resolves rework stable references to generated prototype IDs when constructing `SimpleVariableProduct` and `SimpleProduct` import strings. If an existing database has the item prototype by short description but not in the in-memory stable-reference dictionary, the helper can still resolve it by short description. The helper currently knows the Hellenic, Egyptian, Roman, Celtic, Germanic, Kushite, Punic, Persian, Etruscan, Anatolian, Scythian-Sarmatian, leather clothing, leather armour, leather container, and leather furnishing stable-reference maps.
 
-Leather footwear remains out of this clothing pass. It needs its own hide and footwear suite so sandal, shoe, boot, sole, strap, thong, awl, last, and leather-preparation inputs can be handled coherently rather than bolted onto textilecraft.
-
-The craft row repeatability rule remains the existing `Name + Category` skip. This slice does not attempt full repair of already-seeded item prototypes in older databases.
+The craft row repeatability rule remains the existing `Name + Category` skip described in `ItemSeeder_AddCraft_Guide.md`. This suite follows the general base-install-truth rule in `DatabaseSeeder_Repeatability_Strategy.md`: culture-neutral names, blurbs, actions, active craft item descriptions, phase echoes, and fail echoes are written directly in the seed data rather than normalized by a follow-up correction layer.

--- a/Design Documents/DatabaseSeeder_Repeatability_Strategy.md
+++ b/Design Documents/DatabaseSeeder_Repeatability_Strategy.md
@@ -14,11 +14,26 @@ This document is based on verified code behavior in the current stock repo, not 
 
 ## Target Principles
 - Minimize questions. If multiple stock options can coexist safely, prefer shipping more stock content over asking the builder to choose only one path.
+- Treat stock seed definitions as the base install truth. Clean installs should receive corrected content directly from the source definitions, not from follow-up repair passes.
 - Reuse previous answers wherever practical. Shared setup answers should come from the generic `SeederChoice` answer-memory flow rather than bespoke helper logic.
 - Present honest rerun semantics. If a seeder is additive, idempotent, or one-shot, the menu and package details should say so clearly.
 - Prefer deterministic lookup-and-upsert behavior for stock-owned records. The default rule for repeatable seeders is: install missing stock records, update stock-owned canonical records when safe, and leave clearly user-customized records alone unless the seeder explicitly documents a different rule.
 - Keep prerequisites explicit. A blocked seeder should explain what is missing instead of relying only on broad boolean probes.
 - Treat the seeder framework as shared infrastructure. Foundational seeders should not solve repeatability in isolation.
+
+## Base Install Truth
+Stock seed definitions are the canonical output of a clean install. When stock content is wrong, incomplete, poorly named, or inconsistent with the authoring rules, fix the definition that creates it so a new database receives the corrected data immediately.
+
+Do not seed known-bad stock data and then rely on a follow-up correction method to make the install usable. Compatibility update paths are acceptable only when they serve existing databases that may already have old stock rows, or when a seeder has an explicitly documented `RepairExisting` or `FullReconcile` ownership model.
+
+Any repair-capable or compatibility update path must be:
+
+- narrow to stock-owned rows with stable lookup keys
+- documented in this strategy and in the affected seeder or subsystem design note
+- safe for builder-customized data
+- unnecessary for a clean install to be correct
+
+For source-only catalogue fixes, prefer invariant tests that scan the seed definitions or generated specs so regressions fail before they become seeded data.
 
 ## Taxonomy
 ### Repeatability mode
@@ -163,7 +178,9 @@ These five seeders need separate design work before repeatability claims are exp
 
 ## Contributor Checklist
 - When adding or changing a seeder, update both its metadata and any shared-answer mapping that applies.
+- Fix incorrect stock content at the seed definition first. Do not add a correction layer that is required for a clean install to be correct.
 - If a seeder becomes safely rerunnable, document whether it is additive, install-missing, repair-capable, or full-reconcile.
+- Add compatibility repair/update code only for existing databases or explicitly owned rerun reconciliation, and keep it narrow and documented.
 - Do not rely on `ExtraPackagesAvailable` alone to communicate rerun safety.
 - Do not pass `StringComparison`-based predicates directly into EF-translated seeder queries. Use `AsEnumerable()` explicitly or shape the query so EF only handles the safe prefilter.
 - Prefer deterministic, stock-owned lookup keys over “anything exists” installed-state checks.

--- a/Design Documents/ItemSeeder_AddCraft_Guide.md
+++ b/Design Documents/ItemSeeder_AddCraft_Guide.md
@@ -568,7 +568,9 @@ Craft creation is insert-or-skip by stable `Name + Category`.
 
 If a matching craft already exists, `AddCraft` returns that existing row unchanged. It does not refresh the craft and does not add duplicate phases, inputs, tools, products, or fail products.
 
-The skip happens before parsing imports or generating/upserting trait and knowledge helper progs. If you need to repair an existing craft's access progs or knowledge metadata, do that as a deliberate separate migration rather than by rerunning the same craft call.
+The seed craft call is still the base install truth. If a craft has incorrect visible text, inputs, tools, products, or metadata, fix the `AddCraft` call or typed spec so a clean install creates the correct craft directly. Do not seed a wrong craft and then rely on a second correction pass for new databases.
+
+The skip happens before parsing imports or generating/upserting trait and knowledge helper progs. This protects already-installed craft rows from accidental duplicate child records. If an existing database needs a stock-craft compatibility update, implement that as explicit, narrow migration or compatibility work with documented stock ownership rather than by rerunning the same craft call.
 
 This is deliberate narrow repeatability for stock craft rows only. It is not a claim that all `ItemSeeder` item/component content is fully repeatable or repair-capable.
 

--- a/Design Documents/SeededTagHierarchy.csv
+++ b/Design Documents/SeededTagHierarchy.csv
@@ -141,6 +141,16 @@ Padding	Material Functions	Functions / Material Functions / Padding
 Salvagable Fabric	Material Functions	Functions / Material Functions / Salvagable Fabric
 String	Material Functions	Functions / Material Functions / String
 Tanning Agent	Material Functions	Functions / Material Functions / Tanning Agent
+Leather Commodity	Material Functions	Functions / Material Functions / Leather Commodity
+Prepared Hide	Leather Commodity	Functions / Material Functions / Leather Commodity / Prepared Hide
+Tanned Leather	Leather Commodity	Functions / Material Functions / Leather Commodity / Tanned Leather
+Leather Sole	Leather Commodity	Functions / Material Functions / Leather Commodity / Leather Sole
+Leather Strap	Leather Commodity	Functions / Material Functions / Leather Commodity / Leather Strap
+Leather Thong	Leather Commodity	Functions / Material Functions / Leather Commodity / Leather Thong
+Leather Panel	Leather Commodity	Functions / Material Functions / Leather Commodity / Leather Panel
+Hardened Leather Panel	Leather Commodity	Functions / Material Functions / Leather Commodity / Hardened Leather Panel
+Leather Scale	Leather Commodity	Functions / Material Functions / Leather Commodity / Leather Scale
+Sealed Leather Panel	Leather Commodity	Functions / Material Functions / Leather Commodity / Sealed Leather Panel
 Reflective	Functions	Functions / Reflective
 Repairing	Functions	Functions / Repairing
 Separation	Functions	Functions / Separation
@@ -545,6 +555,8 @@ Edge Beveller	Leatherworking Tools	Functions / Tools / Leatherworking Tools / Ed
 Leather Creaser	Leatherworking Tools	Functions / Tools / Leatherworking Tools / Leather Creaser
 Leather Gouge	Leatherworking Tools	Functions / Tools / Leatherworking Tools / Leather Gouge
 Leather Stitching Pony	Leatherworking Tools	Functions / Tools / Leatherworking Tools / Leather Stitching Pony
+Shoe Last	Leatherworking Tools	Functions / Tools / Leatherworking Tools / Shoe Last
+Leather Wax Pot	Leatherworking Tools	Functions / Tools / Leatherworking Tools / Leather Wax Pot
 Locksmithing Tools	Tools	Functions / Tools / Locksmithing Tools
 Impressioning File	Locksmithing Tools	Functions / Tools / Locksmithing Tools / Impressioning File
 Key Gauge	Locksmithing Tools	Functions / Tools / Locksmithing Tools / Key Gauge


### PR DESCRIPTION
## Summary
- Removes culture names from antiquity craft visible text and keeps the source craft definitions as the base install truth.
- Adds full antiquity leather item craft coverage across clothing, armour, containers, liquid vessels, tableware, and doorway fittings.
- Adds supporting leather tools/tags, focused seeder tests, seeded tag documentation, and DatabaseSeeder authoring-rule guidance.

## Validation
- dotnet build DatabaseSeeder\\DatabaseSeeder.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510
- dotnet test 'DatabaseSeeder Unit Tests\\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 --filter ItemSeeder
- git diff --check