### PR TITLE
Improve foraging player and builder experience

### DIFF
--- a/FutureMUDLibrary/Work/Foraging/IForagable.cs
+++ b/FutureMUDLibrary/Work/Foraging/IForagable.cs
@@ -50,7 +50,7 @@ namespace MudSharp.Work.Foraging
 
         /// <summary>
         ///     An optional prog to execute whenever this item is foraged
-        ///     The parameters to the prog are Character, Quantity
+        ///     The parameters to the prog are Character, Foragable ID, Item and Quantity
         /// </summary>
         IFutureProg OnForageProg { get; }
 

--- a/MudSharpCore Unit Tests/ForagingRuntimeTests.cs
+++ b/MudSharpCore Unit Tests/ForagingRuntimeTests.cs
@@ -1,0 +1,183 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Framework;
+using MudSharp.Framework.Revision;
+using MudSharp.FutureProg;
+using MudSharp.GameItems;
+using MudSharp.RPG.Checks;
+using MudSharp.Work.Foraging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DbEditableItem = MudSharp.Models.EditableItem;
+using DbForagable = MudSharp.Models.Foragable;
+using DbForagableProfile = MudSharp.Models.ForagableProfile;
+using DbForagableProfilesForagables = MudSharp.Models.ForagableProfilesForagables;
+using DbForagableProfilesMaximumYields = MudSharp.Models.ForagableProfilesMaximumYields;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class ForagingRuntimeTests
+{
+	[TestMethod]
+	public void Foragable_LoadFromDb_IgnoresBlankAndDuplicateTypes()
+	{
+		var proto = new Mock<IGameItemProto>();
+		var gameworld = CreateGameworld(itemProto: proto.Object);
+		var foragable = new Foragable(new DbForagable
+		{
+			Id = 1,
+			RevisionNumber = 0,
+			Name = "Wild Berries",
+			ForagableTypes = "food,, Food, wood ",
+			ForageDifficulty = (int)Difficulty.Normal,
+			RelativeChance = 100,
+			MinimumOutcome = (int)Outcome.MajorFail,
+			MaximumOutcome = (int)Outcome.MajorPass,
+			QuantityDiceExpression = "1",
+			ItemProtoId = 1,
+			EditableItem = CreateEditableItem()
+		}, gameworld.Object);
+
+		CollectionAssert.AreEqual(new[] { "food", "wood" }, foragable.ForagableTypes.ToArray());
+	}
+
+	[TestMethod]
+	public void Foragable_LoadFromDb_BlankTypesCannotSubmit()
+	{
+		var proto = new Mock<IGameItemProto>();
+		var gameworld = CreateGameworld(itemProto: proto.Object);
+		var foragable = new Foragable(new DbForagable
+		{
+			Id = 1,
+			RevisionNumber = 0,
+			Name = "Wild Berries",
+			ForagableTypes = "",
+			ForageDifficulty = (int)Difficulty.Normal,
+			RelativeChance = 100,
+			MinimumOutcome = (int)Outcome.MajorFail,
+			MaximumOutcome = (int)Outcome.MajorPass,
+			QuantityDiceExpression = "1",
+			ItemProtoId = 1,
+			EditableItem = CreateEditableItem()
+		}, gameworld.Object);
+
+		Assert.IsFalse(foragable.ForagableTypes.Any());
+		Assert.IsFalse(foragable.CanSubmit());
+	}
+
+	[TestMethod]
+	public void ForagableProfile_GetForageResult_RequiresMatchingProfileYield()
+	{
+		var foragable = CreateForagable(1, "Loose Stones", "stone", Difficulty.Normal);
+		var gameworld = CreateGameworld(foragable: foragable.Object);
+		var profile = CreateProfile(gameworld.Object, "wood", 1);
+		var outcomes = new Dictionary<Difficulty, CheckOutcome>
+		{
+			[Difficulty.Normal] = CheckOutcome.SimpleOutcome(CheckType.ForageCheck, Outcome.Pass)
+		};
+
+		Assert.IsNull(profile.GetForageResult(Mock.Of<MudSharp.Character.ICharacter>(), outcomes, "stone"));
+	}
+
+	[TestMethod]
+	public void ForagableProfile_GetForageResult_SkipsForagablesWithoutDifficultyOutcome()
+	{
+		var foragable = CreateForagable(1, "Wild Berries", "food", Difficulty.Impossible);
+		var gameworld = CreateGameworld(foragable: foragable.Object);
+		var profile = CreateProfile(gameworld.Object, "food", 1);
+		var outcomes = new Dictionary<Difficulty, CheckOutcome>
+		{
+			[Difficulty.Normal] = CheckOutcome.SimpleOutcome(CheckType.ForageCheck, Outcome.Pass)
+		};
+
+		Assert.IsNull(profile.GetForageResult(Mock.Of<MudSharp.Character.ICharacter>(), outcomes, "food"));
+		foragable.Verify(x => x.CanForage(It.IsAny<MudSharp.Character.ICharacter>(), It.IsAny<Outcome>()), Times.Never);
+	}
+
+	[TestMethod]
+	public void ForagableProfile_GetForageResult_ReturnsWeightedMatch()
+	{
+		var actor = Mock.Of<MudSharp.Character.ICharacter>();
+		var foragable = CreateForagable(1, "Wild Berries", "food", Difficulty.Normal);
+		foragable.Setup(x => x.CanForage(actor, Outcome.Pass)).Returns(true);
+		var gameworld = CreateGameworld(foragable: foragable.Object);
+		var profile = CreateProfile(gameworld.Object, "food", 1);
+		var outcomes = new Dictionary<Difficulty, CheckOutcome>
+		{
+			[Difficulty.Normal] = CheckOutcome.SimpleOutcome(CheckType.ForageCheck, Outcome.Pass)
+		};
+
+		Assert.AreSame(foragable.Object, profile.GetForageResult(actor, outcomes, "food"));
+	}
+
+	private static Mock<IForagable> CreateForagable(long id, string name, string forageType, Difficulty difficulty)
+	{
+		var proto = new Mock<IGameItemProto>();
+		proto.SetupGet(x => x.Id).Returns(id + 100);
+		proto.SetupGet(x => x.RevisionNumber).Returns(0);
+		proto.SetupGet(x => x.Name).Returns(name);
+
+		var foragable = new Mock<IForagable>();
+		foragable.SetupGet(x => x.Id).Returns(id);
+		foragable.SetupGet(x => x.Name).Returns(name);
+		foragable.SetupGet(x => x.ItemProto).Returns(proto.Object);
+		foragable.SetupGet(x => x.ForagableTypes).Returns(new[] { forageType });
+		foragable.SetupGet(x => x.ForageDifficulty).Returns(difficulty);
+		foragable.SetupGet(x => x.RelativeChance).Returns(100);
+		return foragable;
+	}
+
+	private static ForagableProfile CreateProfile(IFuturemud gameworld, string yieldType, long foragableId)
+	{
+		var profile = new DbForagableProfile
+		{
+			Id = 10,
+			RevisionNumber = 0,
+			Name = "Test Profile",
+			EditableItem = CreateEditableItem()
+		};
+		profile.ForagableProfilesForagables.Add(new DbForagableProfilesForagables
+		{
+			ForagableId = foragableId
+		});
+		profile.ForagableProfilesMaximumYields.Add(new DbForagableProfilesMaximumYields
+		{
+			ForageType = yieldType,
+			Yield = 10.0
+		});
+		return new ForagableProfile(profile, gameworld);
+	}
+
+	private static Mock<IFuturemud> CreateGameworld(IGameItemProto? itemProto = null, IForagable? foragable = null)
+	{
+		var progRepo = new Mock<IUneditableAll<IFutureProg>>();
+		progRepo.Setup(x => x.Get(It.IsAny<long>())).Returns((IFutureProg)null!);
+
+		var itemRepo = new Mock<IUneditableRevisableAll<IGameItemProto>>();
+		itemRepo.Setup(x => x.Get(It.IsAny<long>())).Returns(itemProto!);
+
+		var foragableRepo = new Mock<IUneditableRevisableAll<IForagable>>();
+		foragableRepo.Setup(x => x.Get(It.IsAny<long>())).Returns(foragable!);
+
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.FutureProgs).Returns(progRepo.Object);
+		gameworld.SetupGet(x => x.ItemProtos).Returns(itemRepo.Object);
+		gameworld.SetupGet(x => x.Foragables).Returns(foragableRepo.Object);
+		return gameworld;
+	}
+
+	private static DbEditableItem CreateEditableItem()
+	{
+		return new DbEditableItem
+		{
+			RevisionNumber = 0,
+			RevisionStatus = (int)RevisionStatus.Current,
+			BuilderAccountId = 1,
+			BuilderDate = DateTime.UtcNow
+		};
+	}
+}

--- a/MudSharpCore/Commands/Modules/ActivityBuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/ActivityBuilderModule.cs
@@ -933,7 +933,9 @@ The syntax for this command is as follows:
     #region Foragables
 
     private const string ForagableHelpText =
-        @$"This command is used to view and edit foragables. Foragables are records of items that can be loaded by the foraging system. The items need to be first built using the item system, and you also need to add the foragable record to a foragable profile before it will show up in the world. A single foragable record can be shared between multiple foragable profiles.
+        @$"This command is used to view and edit foragables. Foragables are records of item results that can be loaded by the #3forage#0 command. The item prototype must be built first, and the foragable must be linked to a foragable profile before players can find it. A single foragable can be shared between multiple profiles.
+
+The #3types#0 on a foragable must match the #3yield#0 names on the profile where you link it. For example, a foragable with type #6wood#0 can be found by #3forage wood#0 anywhere that profile has a #6wood#0 yield.
 
 You can use the following options with this command:
 
@@ -952,7 +954,7 @@ You can use the following options with this command:
 	#3foragable set name <name>#0 - renames this foragable
 	#3foragable set proto <which>#0 - sets the proto for this foragable to load
 	#3foragable set chance <#>#0 - the relative weight of this option being found
-	#3foragable set quanity <# or dice>#0 - a number or dice expression for the quantity found
+	#3foragable set quantity <# or dice>#0 - a number or dice expression for the quantity found
 	#3foragable set difficulty <difficulty>#0 - the difficulty that the result is evaluated against for this item
 	#3foragable set outcome <min> <max>#0 - the minimum and maximum check outcome that this item can appear on
 	#3foragable set types <type1> [<type2>] ... [<typen>]#0 - sets the yield types that this foragable appears against
@@ -999,13 +1001,13 @@ You can use the following options with this command:
     private const string ForagableProfileHelpText =
         @$"This command is used to view and edit foragable profiles. 
 
-Foragable profiles are attached typically to zones or terrain types, and control both what yield types appear in that location and what items can be foraged by players. Each zone or terrain type has a maximum of one foragable profile. The foragable profile controls what things can be found in that area with foraging and how fast the resources regenerate.
+Foragable profiles are attached to terrain types, zones or individual cells, and control both what yield types exist in that location and what item results can be foraged by players. Cells inherit from their zone, and zones usually inherit from terrain defaults unless a builder sets a more specific override.
 
-The individual foraged items are built using the #Bforagable#0 command. These foragables can be shared between multiple foragable profiles. 
+The individual foraged items are built using the #Bforagable#0 command. These foragables can be shared between multiple foragable profiles. A profile yield without matching linked foragables can still support grazing/eating systems, but players will not gather items from it with #3forage#0 until you link matching foragables.
 
 See #6terrain set forage <id|name>#0 to set a default foragable profile for a terrain type
-See #6zone set <which> forage <id|name>#0 to set a default foragable profile for a zone
-See #6cell set forage <id|name>#0 to set a foragable profile at a room level.
+See #6zone set <which> forage <id|name>#0 to set a foragable profile for a zone
+See #6cell set forage <id|name>#0 to set a foragable profile at a cell level.
 
 You can use the following options with this command:
 
@@ -1019,11 +1021,12 @@ You can use the following options with this command:
 	#3fp edit delete#0 - deletes a non-approved revision
 	#3fp edit obsolete#0 - marks a foragable profile as obsolete
 	#3fp review all|mine|<which>#0 - opens a foragable profile for review
-	#3fp review list#0 - shows all the foragable profile due to review
+	#3fp review list#0 - shows all the foragable profiles due to review
 	#3fp review history <which>#0 - shows the history of a foragable profile
 	#3fp set name <name>#0 - renames this foragable profile
-	#3fp set yield <which> <max> <hourly regain>#0 - sets up a yield for this profile
+	#3fp set yield <which> <max> <hourly regain>#0 - sets or updates a yield for this profile
 	#3fp set yield <which> 0#0 - removes a yield from this profile
+	#3fp set yield <which> clear#0 - removes a yield from this profile
 	#3fp set foragable <which>#0 - toggles a foragable belonging to this profile
 
 {GenericReviewableSearchList}";

--- a/MudSharpCore/Commands/Modules/GameModule.cs
+++ b/MudSharpCore/Commands/Modules/GameModule.cs
@@ -1230,7 +1230,7 @@ The syntax is #3tagsearch <tag>#0.", AutoHelp.HelpArgOrNoArg)]
     }
 
     [PlayerCommand("Forage", "forage")]
-    [DelayBlock("general", "You must first stop {0} before you can quit.")]
+    [DelayBlock("general", "You must first stop {0} before you can forage.")]
     [RequiredCharacterState(CharacterState.Conscious)]
     [NoHideCommand]
     [NoCombatCommand]
@@ -1241,6 +1241,7 @@ The syntax is #3tagsearch <tag>#0.", AutoHelp.HelpArgOrNoArg)]
 The syntax to use with this command is as follows:
 
 	forage <yield> [into <container>]
+	forage <yield> for <specific result> [into <container>]
 
 You can also type 'forage' on its own to see what kinds of yields you can search for in the area.", AutoHelp.HelpArg)]
     protected static void Forage(ICharacter actor, string input)
@@ -1254,66 +1255,61 @@ You can also type 'forage' on its own to see what kinds of yields you can search
 
         List<string> forageTypes =
             profile.Foragables.SelectMany(x => x.ForagableTypes)
-                   .Select(x => x.ToLowerInvariant())
-                   .Where(x => !string.IsNullOrEmpty(x))
-                   .Distinct()
-                   .ToList();
+                    .Select(x => x.ToLowerInvariant())
+                    .Where(x => !string.IsNullOrWhiteSpace(x) && profile.MaximumYieldPoints.ContainsKey(x))
+                    .Distinct()
+                    .OrderBy(x => x)
+                    .ToList();
         StringStack ss = new(input.RemoveFirstWord());
         if (ss.IsFinished)
         {
+            if (!forageTypes.Any())
+            {
+                actor.Send("There do not seem to be any useful items that can be foraged in this location.");
+                return;
+            }
+
             actor.Send("You must specify whether you want to forage for {0} in this location.",
                 forageTypes.Select(x => x.Colour(Telnet.Green)).ListToString());
             return;
         }
 
-        string type = ss.PopSpeech();
-        IGameItem targetContainer = null;
-        if (!ss.IsFinished)
+        string type = ss.PopSpeech().ToLowerInvariant();
+        if (!forageTypes.Contains(type, StringComparer.InvariantCultureIgnoreCase))
         {
-            if (ss.Peek().Equals("into", StringComparison.InvariantCultureIgnoreCase))
-            {
-                ss.PopSpeech();
-                if (ss.IsFinished)
-                {
-                    actor.Send("Into what container do you want to forage for items?");
-                    return;
-                }
+            actor.Send("You cannot forage for {0} here. You can forage for {1}.", type.ColourCommand(),
+                forageTypes.Select(x => x.Colour(Telnet.Green)).ListToString());
+            return;
+        }
 
-                targetContainer = actor.TargetItem(ss.PopSpeech());
-                if (targetContainer == null)
-                {
-                    actor.Send("There is no such container into which you can forage.");
-                    return;
-                }
-
-                if (!targetContainer.IsItemType<IContainer>())
-                {
-                    actor.Send("{0} is not a container.", targetContainer.HowSeen(actor, true));
-                    return;
-                }
-
-                (bool truth, string error) = actor.CanManipulateItem(targetContainer);
-                if (!truth)
-                {
-                    actor.OutputHandler.Send(error);
-                    return;
-                }
-            }
-            else
-            {
-                actor.Send("Foraging for specific items is coming soon.");
-                return;
-            }
+        IGameItem targetContainer = null;
+        IForagable specificForagable = null;
+        if (!TryParseForageOptions(actor, ss, profile, type, out specificForagable, out targetContainer))
+        {
+            return;
         }
 
         int time = Dice.Roll(Foragable.BaseForageTimeExpression);
         actor.AddEffect(new SimpleCharacterAction(actor, perceivable =>
             {
-                ICheck forageCheck = actor.Gameworld.GetCheck(CheckType.ForageCheck);
+                ICheck forageCheck = actor.Gameworld.GetCheck(specificForagable == null ? CheckType.ForageCheck : CheckType.ForageSpecificCheck);
                 Dictionary<Difficulty, CheckOutcome> forageOutcome =
                     forageCheck.CheckAgainstAllDifficulties(actor, Difficulty.Normal, null,
                         customParameters: ("yield", type));
-                IForagable foragable = profile.GetForageResult(actor, forageOutcome, type);
+                IForagable foragable = specificForagable;
+                if (foragable != null)
+                {
+                    if (!forageOutcome.TryGetValue(foragable.ForageDifficulty, out var specificOutcome) ||
+                        !foragable.CanForage(actor, specificOutcome))
+                    {
+                        foragable = null;
+                    }
+                }
+                else
+                {
+                    foragable = profile.GetForageResult(actor, forageOutcome, type);
+                }
+
                 if (foragable == null)
                 {
                     actor.OutputHandler.Handle(
@@ -1324,7 +1320,7 @@ You can also type 'forage' on its own to see what kinds of yields you can search
                     return;
                 }
 
-                if (foragable.ForagableTypes.All(x => actor.Location.GetForagableYield(x) <= 0.0))
+                if (actor.Location.GetForagableYield(type) <= 0.0)
                 {
                     actor.OutputHandler.Handle(
                         new EmoteOutput(
@@ -1341,12 +1337,22 @@ You can also type 'forage' on its own to see what kinds of yields you can search
                     return;
                 }
 
-                actor.Location.ConsumeYieldFor(foragable);
                 List<IGameItem> newItems = new();
                 int quantity =
                     (int)Math.Floor(new TraitExpression(foragable.QuantityDiceExpression, actor.Gameworld).EvaluateWith(
                         actor,
                         values: ("outcome", forageOutcome[foragable.ForageDifficulty])));
+                if (quantity <= 0)
+                {
+                    actor.OutputHandler.Handle(
+                        new EmoteOutput(
+                            new Emote(
+                                "@ finish|finishes foraging, but are|is not successful in finding what #0 were|was looking for.",
+                                actor, actor)));
+                    return;
+                }
+
+                actor.Location.ConsumeYield(type, 1.0);
                 if (foragable.ItemProto.IsItemType<StackableGameItemComponentProto>())
                 {
                     IGameItem newItem = foragable.ItemProto.CreateNew(actor);
@@ -1368,9 +1374,8 @@ You can also type 'forage' on its own to see what kinds of yields you can search
                 {
                     foreach (IGameItem item in newItems)
                     {
-                        foragable.OnForageProg.Execute(actor, foragable.Id, item, 1);
-                        item.HandleEvent(EventType.ItemFinishedLoading, item);
-                        item.Login();
+                        var progQuantity = item.IsItemType<IStackable>() ? item.GetItemType<IStackable>().Quantity : 1;
+                        foragable.OnForageProg.Execute(actor, foragable.Id, item, progQuantity);
                     }
                 }
 
@@ -1432,6 +1437,12 @@ You can also type 'forage' on its own to see what kinds of yields you can search
                             targetContainer.HowSeen(actor));
                     }
 
+                    foreach (IGameItem item in newItems)
+                    {
+                        item.HandleEvent(Events.EventType.ItemFinishedLoading, item);
+                        item.Login();
+                    }
+
                     return;
                 }
 
@@ -1460,7 +1471,122 @@ You can also type 'forage' on its own to see what kinds of yields you can search
             }, "foraging for " + type, new[] { "general", "movement" }, "foraging about the area"),
             TimeSpan.FromSeconds(time));
 
-        actor.OutputHandler.Handle(new EmoteOutput(new Emote("@ begin|begins foraging about the area.", actor)));
+        actor.OutputHandler.Handle(new EmoteOutput(new Emote($"@ begin|begins foraging for {type}.", actor)));
+    }
+
+    private static bool TryParseForageOptions(ICharacter actor, StringStack command, IForagableProfile profile,
+        string forageType, out IForagable specificForagable, out IGameItem targetContainer)
+    {
+        specificForagable = null;
+        targetContainer = null;
+        if (command.IsFinished)
+        {
+            return true;
+        }
+
+        var specificWords = new List<string>();
+        while (!command.IsFinished)
+        {
+            var token = command.PopSpeech();
+            if (token.EqualTo("into"))
+            {
+                if (command.IsFinished)
+                {
+                    actor.Send("Into what container do you want to forage for items?");
+                    return false;
+                }
+
+                targetContainer = ResolveForageContainer(actor, command.SafeRemainingArgument);
+                if (targetContainer == null)
+                {
+                    return false;
+                }
+
+                break;
+            }
+
+            if (token.EqualTo("for") && !specificWords.Any())
+            {
+                continue;
+            }
+
+            specificWords.Add(token);
+        }
+
+        if (!specificWords.Any())
+        {
+            return true;
+        }
+
+        specificForagable = ResolveSpecificForagable(actor, profile, forageType, string.Join(" ", specificWords));
+        return specificForagable != null;
+    }
+
+    private static IGameItem ResolveForageContainer(ICharacter actor, string targetText)
+    {
+        IGameItem targetContainer = actor.TargetItem(targetText);
+        if (targetContainer == null)
+        {
+            actor.Send("There is no such container into which you can forage.");
+            return null;
+        }
+
+        if (!targetContainer.IsItemType<IContainer>())
+        {
+            actor.Send("{0} is not a container.", targetContainer.HowSeen(actor, true));
+            return null;
+        }
+
+        (bool truth, string error) = actor.CanManipulateItem(targetContainer);
+        if (!truth)
+        {
+            actor.OutputHandler.Send(error);
+            return null;
+        }
+
+        return targetContainer;
+    }
+
+    private static IForagable ResolveSpecificForagable(ICharacter actor, IForagableProfile profile, string forageType,
+        string targetText)
+    {
+        var candidates = profile.Foragables
+                                .Where(x => x.ItemProto != null)
+                                .Where(x => x.ForageDifficulty != Difficulty.Impossible)
+                                .Where(x => x.ForagableTypes.Any(y => y.EqualTo(forageType)))
+                                .ToList();
+        List<IForagable> matches;
+        if (long.TryParse(targetText, out var id))
+        {
+            matches = candidates.Where(x => x.Id == id).ToList();
+        }
+        else
+        {
+            matches = candidates.Where(x =>
+                                  x.Name.EqualTo(targetText) ||
+                                  x.Name.StartsWith(targetText, StringComparison.InvariantCultureIgnoreCase) ||
+                                  (x.ItemProto?.Name.EqualTo(targetText) ?? false) ||
+                                  (x.ItemProto?.Name.StartsWith(targetText, StringComparison.InvariantCultureIgnoreCase) ?? false) ||
+                                  (x.ItemProto?.ShortDescription.EqualTo(targetText) ?? false) ||
+                                  (x.ItemProto?.ShortDescription.StartsWith(targetText, StringComparison.InvariantCultureIgnoreCase) ?? false))
+                              .Distinct()
+                              .ToList();
+        }
+
+        if (!matches.Any())
+        {
+            actor.Send("You cannot specifically forage for {0} here.", targetText.ColourCommand());
+            return null;
+        }
+
+        if (matches.Count > 1)
+        {
+            actor.Send("That matched more than one foragable result: {0}.",
+                matches.Select(x => $"{x.Name.ColourName()} (#{x.Id.ToString("N0", actor)})").ListToString());
+            return null;
+        }
+
+        return matches.Single();
     }
 
     [PlayerCommand("Implant", "implant")]

--- a/MudSharpCore/Commands/Modules/RoomBuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/RoomBuilderModule.cs
@@ -1436,7 +1436,9 @@ See the #3CELL#0 command for more information about #3CELL PACKAGES#0.";
             return;
         }
 
-        if (command.Peek().Equals("clear", StringComparison.InvariantCultureIgnoreCase))
+        if (command.SafeRemainingArgument.EqualTo("clear") ||
+            command.SafeRemainingArgument.EqualTo("none") ||
+            command.SafeRemainingArgument.EqualTo("remove"))
         {
             if (zone.ForagableProfile == null)
             {
@@ -1449,9 +1451,7 @@ See the #3CELL#0 command for more information about #3CELL PACKAGES#0.";
             return;
         }
 
-        IForagableProfile profile = long.TryParse(command.PopSpeech(), out long value)
-            ? actor.Gameworld.ForagableProfiles.Get(value)
-            : actor.Gameworld.ForagableProfiles.GetByName(command.Last, true);
+        IForagableProfile profile = actor.Gameworld.ForagableProfiles.GetByIdOrName(command.SafeRemainingArgument);
 
         if (profile == null)
         {
@@ -2009,16 +2009,20 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
             return;
         }
 
-        if (input.Peek().Equals("clear", StringComparison.InvariantCultureIgnoreCase))
+        if (input.SafeRemainingArgument.EqualTo("clear") ||
+            input.SafeRemainingArgument.EqualTo("none") ||
+            input.SafeRemainingArgument.EqualTo("remove"))
         {
+            actor.Location.ForagableProfile = null;
             if (actor.Location.ForagableProfile == null)
             {
-                actor.Send("Your location does not have a foragable profile to clear.");
-                return;
+                actor.Send("You clear the foragable profile from this cell.");
             }
-
-            actor.Location.ForagableProfile = null;
-            actor.Send("You clear the foragable profile from this cell.");
+            else
+            {
+                actor.Send("You clear the cell-level foragable profile override. This cell will now inherit {0} ({1:N0}).",
+                    actor.Location.ForagableProfile.Name.ColourName(), actor.Location.ForagableProfile.Id);
+            }
             return;
         }
 

--- a/MudSharpCore/Construction/Cell.cs
+++ b/MudSharpCore/Construction/Cell.cs
@@ -905,7 +905,7 @@ public partial class Cell : Location, IDisposable, ICell
         Models.Cell dbcell = FMDB.Context.Cells.Find(Id);
         dbcell.CurrentOverlayId = CurrentOverlay.Id;
         dbcell.RoomId = Room.Id;
-        dbcell.ForagableProfileId = ForagableProfile?.Id;
+        dbcell.ForagableProfileId = ExplicitForagableProfileId;
         SaveEffects();
         if (ContentsChanged)
         {
@@ -1759,30 +1759,44 @@ public partial class Cell : Location, IDisposable, ICell
 
     private long _foragableProfileId;
     private IForagableProfile _foragableProfile;
+    private long _foragableYieldProfileId;
+    private int _foragableYieldProfileRevision;
 
     public IForagableProfile ForagableProfile
     {
         get
         {
-            if (_foragableProfileId != 0)
-            {
-                _foragableProfile = Gameworld.ForagableProfiles.Get(_foragableProfileId);
-                _foragableProfileId = 0;
-            }
-
-            return _foragableProfile ?? Room.Zone.ForagableProfile ?? CurrentOverlay.Terrain.ForagableProfile;
+            var profile = ResolveForagableProfile();
+            SynchroniseForagableYields(profile);
+            return profile;
         }
         set
         {
             _foragableProfile = value;
+            _foragableProfileId = 0;
+            SynchroniseForagableYields(ResolveForagableProfile());
             Changed = true;
         }
+    }
+
+    private long? ExplicitForagableProfileId => _foragableProfile?.Id ?? (_foragableProfileId == 0 ? null : _foragableProfileId);
+
+    private IForagableProfile ResolveForagableProfile()
+    {
+        if (_foragableProfileId != 0)
+        {
+            _foragableProfile = Gameworld.ForagableProfiles.Get(_foragableProfileId);
+            _foragableProfileId = 0;
+        }
+
+        return _foragableProfile ?? Room?.Zone?.ForagableProfile ?? CurrentOverlay?.Terrain?.ForagableProfile;
     }
 
     private readonly Dictionary<string, double> _foragableYields = new(StringComparer.InvariantCultureIgnoreCase);
 
     public double GetForagableYield(string foragableType)
     {
+        SynchroniseForagableYields(ResolveForagableProfile());
         return _foragableYields.ContainsKey(foragableType) ? _foragableYields[foragableType] : 0.0;
     }
 
@@ -1790,7 +1804,7 @@ public partial class Cell : Location, IDisposable, ICell
     {
         foreach (string type in foragable.ForagableTypes.Where(type => _foragableYields.ContainsKey(type)))
         {
-            _foragableYields[type] -= 1.0;
+            _foragableYields[type] = Math.Max(0.0, _foragableYields[type] - 1.0);
         }
 
         YieldsChanged = true;
@@ -1800,7 +1814,7 @@ public partial class Cell : Location, IDisposable, ICell
 
     public void ConsumeYield(string foragableType, double yield)
     {
-        _foragableYields[foragableType] -= yield;
+        _foragableYields[foragableType] = Math.Max(0.0, GetForagableYield(foragableType) - yield);
         YieldsChanged = true;
         Gameworld.HeartbeatManager.HourHeartbeat -= YieldTick;
         Gameworld.HeartbeatManager.HourHeartbeat += YieldTick;
@@ -1808,22 +1822,24 @@ public partial class Cell : Location, IDisposable, ICell
 
     private double GetMaxYield(string type)
     {
-        if (!(ForagableProfile?.MaximumYieldPoints.ContainsKey(type) ?? false))
+        var profile = ResolveForagableProfile();
+        if (!(profile?.MaximumYieldPoints.ContainsKey(type) ?? false))
         {
             return 0.0;
         }
 
-        return ForagableProfile.MaximumYieldPoints[type];
+        return profile.MaximumYieldPoints[type];
     }
 
     private double GetHourlyYield(string type)
     {
-        if (!ForagableProfile?.HourlyYieldPoints.ContainsKey(type) ?? false)
+        var profile = ResolveForagableProfile();
+        if (!(profile?.HourlyYieldPoints.ContainsKey(type) ?? false))
         {
             return 0.0;
         }
 
-        return ForagableProfile.HourlyYieldPoints[type];
+        return profile.HourlyYieldPoints[type];
     }
 
     private void YieldTick()
@@ -1848,11 +1864,19 @@ public partial class Cell : Location, IDisposable, ICell
         }
     }
 
-    public IEnumerable<string> ForagableTypes => _foragableYields.Select(x => x.Key);
+    public IEnumerable<string> ForagableTypes
+    {
+        get
+        {
+            SynchroniseForagableYields(ResolveForagableProfile());
+            return _foragableYields.Select(x => x.Key);
+        }
+    }
 
     public void PostLoadTasks(MudSharp.Models.Cell cell)
     {
-        if (ForagableProfile == null)
+        var profile = ResolveForagableProfile();
+        if (profile == null)
         {
             return;
         }
@@ -1862,16 +1886,60 @@ public partial class Cell : Location, IDisposable, ICell
             _foragableYields[foragable.ForagableType] = foragable.Yield;
         }
 
-        foreach (
-            KeyValuePair<string, double> yield in
-            ForagableProfile.MaximumYieldPoints.Where(x => !_foragableYields.ContainsKey(x.Key)).ToList())
+        SynchroniseForagableYields(profile, markChanged: false);
+    }
+
+    private void SynchroniseForagableYields(IForagableProfile profile, bool markChanged = true)
+    {
+        var profileId = profile?.Id ?? 0;
+        var profileRevision = profile?.RevisionNumber ?? 0;
+        if (_foragableYieldProfileId == profileId && _foragableYieldProfileRevision == profileRevision)
         {
-            _foragableYields[yield.Key] = yield.Value;
+            return;
         }
 
-        if (!_foragableYields.All(x => GetMaxYield(x.Key) <= x.Value))
+        var changed = false;
+        if (profile == null)
         {
-            Gameworld.HeartbeatManager.HourHeartbeat += YieldTick;
+            if (_foragableYields.Any())
+            {
+                _foragableYields.Clear();
+                changed = true;
+            }
+
+            Gameworld.HeartbeatManager.HourHeartbeat -= YieldTick;
+        }
+        else
+        {
+            var validTypes = profile.MaximumYieldPoints.Keys.ToHashSet(StringComparer.InvariantCultureIgnoreCase);
+            foreach (var type in _foragableYields.Keys.Where(x => !validTypes.Contains(x)).ToList())
+            {
+                _foragableYields.Remove(type);
+                changed = true;
+            }
+
+            foreach (var yield in profile.MaximumYieldPoints.Where(x => !_foragableYields.ContainsKey(x.Key)))
+            {
+                _foragableYields[yield.Key] = yield.Value;
+                changed = true;
+            }
+
+            if (_foragableYields.Any(x => GetMaxYield(x.Key) > x.Value))
+            {
+                Gameworld.HeartbeatManager.HourHeartbeat -= YieldTick;
+                Gameworld.HeartbeatManager.HourHeartbeat += YieldTick;
+            }
+            else
+            {
+                Gameworld.HeartbeatManager.HourHeartbeat -= YieldTick;
+            }
+        }
+
+        _foragableYieldProfileId = profileId;
+        _foragableYieldProfileRevision = profileRevision;
+        if (changed && markChanged)
+        {
+            YieldsChanged = true;
         }
     }
 

--- a/MudSharpCore/Construction/Terrain.cs
+++ b/MudSharpCore/Construction/Terrain.cs
@@ -1361,11 +1361,13 @@ The following additional models require you to specify a liquid to go with them:
         if (command.IsFinished)
         {
             actor.OutputHandler.Send(
-                "You must either specify a foragable profile to use for this terrain, or 'none' to remove an existing foreable profile.");
+                "You must either specify a foragable profile to use for this terrain, or 'none' to remove an existing foragable profile.");
             return false;
         }
 
-        if (command.Peek().EqualTo("none"))
+        if (command.SafeRemainingArgument.EqualTo("none") ||
+            command.SafeRemainingArgument.EqualTo("clear") ||
+            command.SafeRemainingArgument.EqualTo("remove"))
         {
             _foragableProfile = null;
             _foragableProfileId = 0;
@@ -1374,9 +1376,7 @@ The following additional models require you to specify a liquid to go with them:
             return true;
         }
 
-        IForagableProfile profile = long.TryParse(command.PopSpeech(), out long value)
-            ? Gameworld.ForagableProfiles.Get(value)
-            : Gameworld.ForagableProfiles.GetByName(command.Last);
+        IForagableProfile profile = Gameworld.ForagableProfiles.GetByIdOrName(command.SafeRemainingArgument);
         if (profile == null)
         {
             actor.OutputHandler.Send("There is no such foragable profile.");

--- a/MudSharpCore/Work/Foraging/Foragable.cs
+++ b/MudSharpCore/Work/Foraging/Foragable.cs
@@ -48,7 +48,9 @@ public class Foragable : EditableItem, IForagable
                 : "Not Selected".Colour(Telnet.Red));
         sb.AppendLineFormat("Quantity Expression: {0}", QuantityDiceExpression.Colour(Telnet.Yellow));
         sb.AppendLineFormat("Foragable Types: {0}",
-            ForagableTypes.Select(x => x.Colour(Telnet.Green)).ListToString());
+            ForagableTypes.Any()
+                ? ForagableTypes.Select(x => x.Colour(Telnet.Green)).ListToString()
+                : "None".Colour(Telnet.Red));
         sb.Append(new List<string>
         {
             $"Can Forage Prog: {CanForageProg?.MXPClickableFunctionNameWithId() ?? "None".Colour(Telnet.Yellow)}",
@@ -71,7 +73,7 @@ public class Foragable : EditableItem, IForagable
                 Name = Name,
                 CanForageProgId = CanForageProg?.Id,
                 OnForageProgId = OnForageProg?.Id,
-                ForagableTypes = ForagableTypes.ListToString(separator: ",", conjunction: "", twoItemJoiner: ","),
+                ForagableTypes = SerialisedForagableTypes,
                 ForageDifficulty = (int)ForageDifficulty,
                 ItemProtoId = ItemProto?.Id ?? 0,
                 MinimumOutcome = (int)MinimumOutcome,
@@ -111,7 +113,7 @@ public class Foragable : EditableItem, IForagable
             return "You must set at least one foragable type.";
         }
 
-        return ItemProto == null ? "You must set a item prototype." : "I don't know why you can't submit.";
+        return ItemProto == null ? "You must set an item prototype." : "I don't know why you can't submit.";
     }
 
     public override string FrameworkItemType => "Foragable";
@@ -129,7 +131,7 @@ public class Foragable : EditableItem, IForagable
             dbitem.Name = Name;
             dbitem.CanForageProgId = CanForageProg?.Id;
             dbitem.OnForageProgId = OnForageProg?.Id;
-            dbitem.ForagableTypes = ForagableTypes.ListToString(separator: ",", conjunction: "", twoItemJoiner: ",");
+            dbitem.ForagableTypes = SerialisedForagableTypes;
             dbitem.ForageDifficulty = (int)ForageDifficulty;
             dbitem.ItemProtoId = ItemProto?.Id ?? 0;
             dbitem.MinimumOutcome = (int)MinimumOutcome;
@@ -193,7 +195,7 @@ public class Foragable : EditableItem, IForagable
     {
         _id = foragable.Id;
         _name = foragable.Name;
-        _foragabaleTypes = foragable.ForagableTypes.Split(',').ToList();
+        _foragableTypes = ParseForagableTypes(foragable.ForagableTypes);
         _forageDifficulty = (Difficulty)foragable.ForageDifficulty;
         _relativeChance = foragable.RelativeChance;
         _minimumOutcome = (Outcome)foragable.MinimumOutcome;
@@ -216,13 +218,13 @@ public class Foragable : EditableItem, IForagable
     private const string BuildingCommandHelp = @"You can use the following options with this command:
 
 	#3name <name>#0 - renames this foragable
-	#3proto <which>#0 - sets the proto for this foragable to load
+	#3proto <which>#0 - sets the item prototype for this foragable to load
 	#3chance <#>#0 - the relative weight of this option being found
-	#3quanity <# or dice>#0 - a number or dice expression for the quantity found
+	#3quantity <# or dice>#0 - a number or dice expression for the quantity found
 	#3difficulty <difficulty>#0 - the difficulty that the result is evaluated against for this item
 	#3outcome <min> <max>#0 - the minimum and maximum check outcome that this item can appear on
 	#3types <type1> [<type2>] ... [<typen>]#0 - sets the yield types that this foragable appears against
-	#3canforage <prog>#0 - sets a prog that controls whether this foragable can be found
+	#3canforage <prog>#0 - sets a boolean prog that controls whether this foragable can be found
 	#3canforage clear#0 - clears the can-forage prog
 	#3onforage <prog>#0 - sets a prog that will run when this item is foraged
 	#3onforage clear#0 - clears the on-forage prog";
@@ -285,9 +287,8 @@ public class Foragable : EditableItem, IForagable
             return false;
         }
 
-        IGameItemProto proto = long.TryParse(command.PopSpeech(), out long value)
-            ? Gameworld.ItemProtos.Get(value)
-            : Gameworld.ItemProtos.GetByName(command.Last, true);
+        string targetText = command.SafeRemainingArgument;
+        IGameItemProto proto = Gameworld.ItemProtos.GetByIdOrName(targetText);
 
         if (proto == null)
         {
@@ -322,7 +323,7 @@ public class Foragable : EditableItem, IForagable
             return false;
         }
 
-        if (command.Peek().Equals("clear", StringComparison.InvariantCultureIgnoreCase))
+        if (command.SafeRemainingArgument.EqualTo("clear"))
         {
             if (CanForageProg == null)
             {
@@ -335,9 +336,8 @@ public class Foragable : EditableItem, IForagable
             return true;
         }
 
-        IFutureProg prog = long.TryParse(command.PopSpeech(), out long value)
-            ? Gameworld.FutureProgs.Get(value)
-            : Gameworld.FutureProgs.GetByName(command.Last);
+        string targetText = command.SafeRemainingArgument;
+        IFutureProg prog = Gameworld.FutureProgs.GetByIdOrName(targetText);
 
         if (prog == null)
         {
@@ -360,7 +360,7 @@ public class Foragable : EditableItem, IForagable
             }))
         {
             actor.Send(
-                "The CanForage prog must accept a single Character parameter and a Number. {0} does not match that pattern.",
+                "The CanForage prog must accept a Character and a Number parameter. {0} does not match that pattern.",
                 prog.FunctionName);
             return false;
         }
@@ -379,7 +379,7 @@ public class Foragable : EditableItem, IForagable
             return false;
         }
 
-        if (command.Peek().Equals("clear", StringComparison.InvariantCultureIgnoreCase))
+        if (command.SafeRemainingArgument.EqualTo("clear"))
         {
             if (OnForageProg == null)
             {
@@ -392,9 +392,8 @@ public class Foragable : EditableItem, IForagable
             return true;
         }
 
-        IFutureProg prog = long.TryParse(command.PopSpeech(), out long value)
-            ? Gameworld.FutureProgs.Get(value)
-            : Gameworld.FutureProgs.GetByName(command.Last);
+        string targetText = command.SafeRemainingArgument;
+        IFutureProg prog = Gameworld.FutureProgs.GetByIdOrName(targetText);
 
         if (prog == null)
         {
@@ -526,7 +525,17 @@ public class Foragable : EditableItem, IForagable
 
         command = new StringStack(command.RemainingArgument);
         command.PopSpeechAll();
-        List<string> choices = command.Memory.Select(x => x.ToLowerInvariant()).ToList();
+        List<string> choices = command.Memory
+                                       .Select(x => x.Trim().ToLowerInvariant())
+                                       .Where(x => !string.IsNullOrWhiteSpace(x))
+                                       .Distinct(StringComparer.InvariantCultureIgnoreCase)
+                                       .ToList();
+        if (!choices.Any())
+        {
+            actor.Send("You must enter at least one non-blank forage type.");
+            return false;
+        }
+
         actor.Send("This foragable can now be found using the keywords {0}",
             choices.Select(x => x.Colour(Telnet.Green)).ListToString(conjunction: "or "));
         List<string> existing =
@@ -536,7 +545,7 @@ public class Foragable : EditableItem, IForagable
                      .Distinct()
                      .ToList();
         List<string> newChoices =
-            choices.Where(x => existing.Any(y => y.Equals(x, StringComparison.InvariantCultureIgnoreCase))).ToList();
+            choices.Where(x => !existing.Any(y => y.Equals(x, StringComparison.InvariantCultureIgnoreCase))).ToList();
         if (newChoices.Any())
         {
             actor.Send(
@@ -544,8 +553,8 @@ public class Foragable : EditableItem, IForagable
                 newChoices.ListToString());
         }
 
-        _foragabaleTypes.Clear();
-        _foragabaleTypes.AddRange(choices);
+        _foragableTypes.Clear();
+        _foragableTypes.AddRange(choices);
         Changed = true;
         return true;
     }
@@ -554,7 +563,7 @@ public class Foragable : EditableItem, IForagable
     {
         if (command.IsFinished)
         {
-            actor.Send("You must specify a name to set for this foragabale.");
+            actor.Send("You must specify a name to set for this foragable.");
             return false;
         }
 
@@ -568,8 +577,23 @@ public class Foragable : EditableItem, IForagable
 
     #region IForagable Members
 
-    private List<string> _foragabaleTypes = new();
-    public IEnumerable<string> ForagableTypes => _foragabaleTypes;
+    private List<string> _foragableTypes = new();
+    public IEnumerable<string> ForagableTypes => _foragableTypes;
+
+    private string SerialisedForagableTypes =>
+        ForagableTypes.Where(x => !string.IsNullOrWhiteSpace(x))
+                      .Select(x => x.Trim().ToLowerInvariant())
+                      .Distinct(StringComparer.InvariantCultureIgnoreCase)
+                      .ListToString(separator: ",", conjunction: "", twoItemJoiner: ",");
+
+    private static List<string> ParseForagableTypes(string types)
+    {
+        return (types ?? string.Empty).Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                                      .Where(x => !string.IsNullOrWhiteSpace(x))
+                                      .Select(x => x.ToLowerInvariant())
+                                      .Distinct(StringComparer.InvariantCultureIgnoreCase)
+                                      .ToList();
+    }
 
     private Difficulty _forageDifficulty;
 

--- a/MudSharpCore/Work/Foraging/ForagableProfile.cs
+++ b/MudSharpCore/Work/Foraging/ForagableProfile.cs
@@ -18,7 +18,7 @@ public class ForagableProfile : EditableItem, IForagableProfile
 {
     public override bool CanSubmit()
     {
-        return MaximumYieldPoints.Any();
+        return MaximumYieldPoints.Any(x => x.Value > 0.0 && HourlyYieldPoints.ContainsKey(x.Key));
     }
 
     public override string WhyCannotSubmit()
@@ -33,38 +33,50 @@ public class ForagableProfile : EditableItem, IForagableProfile
             $"Foragable Profile #{Id.ToString("N0", actor)}r{RevisionNumber.ToString("N0", actor)} - {Name.ColourName()} - {Status.DescribeColour()}");
         sb.AppendLine();
         sb.AppendLine("Yield types:");
-        foreach (string type in MaximumYieldPoints.Keys)
+        foreach (string type in MaximumYieldPoints.Keys.OrderBy(x => x))
         {
+            HourlyYieldPoints.TryGetValue(type, out var hourlyYield);
             sb.AppendLine(
-                $"\t{type.ColourName()} - maximum {MaximumYieldPoints[type].ToString("N2", actor).ColourValue()}, recover {HourlyYieldPoints[type].ToString("N2", actor).ColourValue()} per hour");
+                $"\t{type.ColourName()} - maximum {MaximumYieldPoints[type].ToString("N2", actor).ColourValue()}, recover {hourlyYield.ToString("N2", actor).ColourValue()} per hour");
         }
 
         sb.AppendLine();
-        sb.Append(StringUtilities.GetTextTable(
-            from item in Foragables
-            select new[]
-            {
-                item.Id.ToString("N0", actor),
-                item.Name,
-                $"{item.ItemProto.Name} {item.ItemProto.Id:N0}r{item.ItemProto.RevisionNumber:N0}",
-                item.QuantityDiceExpression,
-                item.MinimumOutcome.Describe(),
-                item.MaximumOutcome.Describe(),
-                item.RelativeChance.ToString("N0", actor),
-                item.ForagableTypes.Any(x => _maximumYieldPoints.ContainsKey(x)) ? "Y" : "N"
-            },
-            new[]
-            {
-                "ID",
-                "Name",
-                "Item Proto",
-                "Quantity",
-                "Min Outcome",
-                "Max Outcome",
-                "Chances",
-                "Has Yield?"
-            },
-            actor.LineFormatLength, colour: Telnet.Green, unicodeTable: actor.Account.UseUnicode));
+        var foragables = Foragables.ToList();
+        if (!foragables.Any())
+        {
+            sb.AppendLine("No foragables are linked to this profile.".Colour(Telnet.Yellow));
+        }
+        else
+        {
+            sb.Append(StringUtilities.GetTextTable(
+                from item in foragables
+                let proto = item.ItemProto
+                select new[]
+                {
+                    item.Id.ToString("N0", actor),
+                    item.Name,
+                    proto != null
+                        ? $"{proto.Name} {proto.Id.ToString("N0", actor)}r{proto.RevisionNumber.ToString("N0", actor)}"
+                        : "Missing".ColourError(),
+                    item.QuantityDiceExpression,
+                    item.MinimumOutcome.Describe(),
+                    item.MaximumOutcome.Describe(),
+                    item.RelativeChance.ToString("N0", actor),
+                    item.ForagableTypes.Any(x => _maximumYieldPoints.ContainsKey(x)).ToColouredString()
+                },
+                new[]
+                {
+                    "ID",
+                    "Name",
+                    "Item Proto",
+                    "Quantity",
+                    "Min Outcome",
+                    "Max Outcome",
+                    "Chance",
+                    "Has Yield?"
+                },
+                actor.LineFormatLength, colour: Telnet.Green, unicodeTable: actor.Account.UseUnicode));
+        }
 
         return sb.ToString();
     }
@@ -198,10 +210,8 @@ public class ForagableProfile : EditableItem, IForagableProfile
             _foragableIds.Add(item.ForagableId);
         }
 
-        _maximumYieldPoints = profile.ForagableProfilesMaximumYields.ToDictionary(item => item.ForageType.ToLowerInvariant(),
-            item => item.Yield, StringComparer.InvariantCultureIgnoreCase);
-        _hourlyYieldPoints = profile.ForagableProfilesHourlyYieldGains.ToDictionary(item => item.ForageType.ToLowerInvariant(),
-            item => item.Yield, StringComparer.InvariantCultureIgnoreCase);
+        _maximumYieldPoints = BuildYieldDictionary(profile.ForagableProfilesMaximumYields.Select(x => (x.ForageType, x.Yield)));
+        _hourlyYieldPoints = BuildYieldDictionary(profile.ForagableProfilesHourlyYieldGains.Select(x => (x.ForageType, x.Yield)));
     }
 
     public ForagableProfile(IAccount originator) : base(originator)
@@ -244,9 +254,12 @@ public class ForagableProfile : EditableItem, IForagableProfile
     private const string BuildingHelpText = @"You can use the following options with this command:
 
 	#3name <name>#0 - renames this foragable profile
-	#3yield <which> <max> <hourly regain>#0 - sets up a yield for this profile
+	#3yield <which> <max> <hourly regain>#0 - sets or updates a yield for this profile
 	#3yield <which> 0#0 - removes a yield from this profile
-	#3foragable <which>#0 - toggles a foragable belonging to this profile";
+	#3yield <which> clear#0 - removes a yield from this profile
+	#3foragable <which>#0 - toggles a foragable belonging to this profile
+
+Yield types are the resource pools in a location. Foragables are the item results that can appear when a player uses #3forage <yield>#0. A foragable linked to this profile will only appear if at least one of its types has a matching yield here.";
 
     public override bool BuildingCommand(ICharacter actor, StringStack command)
     {
@@ -276,9 +289,8 @@ public class ForagableProfile : EditableItem, IForagableProfile
             return false;
         }
 
-        IForagable foragable = long.TryParse(command.PopSpeech(), out long value)
-            ? actor.Gameworld.Foragables.Get(value)
-            : actor.Gameworld.Foragables.GetByName(command.Last, true);
+        string targetText = command.SafeRemainingArgument;
+        IForagable foragable = actor.Gameworld.Foragables.GetByIdOrName(targetText);
 
         if (foragable == null)
         {
@@ -290,7 +302,7 @@ public class ForagableProfile : EditableItem, IForagableProfile
         {
             _foragableIds.RemoveAll(x => x == foragable.Id);
             Changed = true;
-            actor.Send("You remove foragable {0} {1:N0} from the foragable profile.", foragable.Name, foragable.Id);
+            actor.Send("You remove foragable {0} {1:N0} from the foragable profile.", foragable.Name.ColourName(), foragable.Id);
             return true;
         }
 
@@ -304,7 +316,14 @@ public class ForagableProfile : EditableItem, IForagableProfile
 
         _foragableIds.Add(foragable.Id);
         Changed = true;
-        actor.Send("You add foragable {0} {1:N0} from the foragable profile.", foragable.Name, foragable.Id);
+        actor.Send("You add foragable {0} {1:N0} to the foragable profile.", foragable.Name.ColourName(), foragable.Id);
+        if (!foragable.ForagableTypes.Any(x => MaximumYieldPoints.ContainsKey(x)))
+        {
+            actor.Send(
+                "Warning: this foragable does not currently share any yield types with this profile, so players will not find it here until you add a matching yield."
+                     .Colour(Telnet.Yellow));
+        }
+
         return true;
     }
 
@@ -316,14 +335,26 @@ public class ForagableProfile : EditableItem, IForagableProfile
             return false;
         }
 
-        string forageType = command.PopSpeech().ToLowerInvariant();
+        string forageType = command.PopSpeech().Trim().ToLowerInvariant();
+        if (string.IsNullOrWhiteSpace(forageType))
+        {
+            actor.Send("Which forage type do you want to set the yield for?");
+            return false;
+        }
+
         if (command.IsFinished)
         {
             actor.Send("You must specify both a maximum yield and yield recovery per hour.");
             return false;
         }
 
-        if (!double.TryParse(command.PopSpeech(), out double maximumYield))
+        string maximumText = command.PopSpeech();
+        if (maximumText.EqualTo("clear") || maximumText.EqualTo("remove") || maximumText.EqualTo("none"))
+        {
+            return RemoveYield(actor, forageType);
+        }
+
+        if (!double.TryParse(maximumText, out double maximumYield))
         {
             actor.Send("The maximum yield must be a number.");
             return false;
@@ -331,19 +362,7 @@ public class ForagableProfile : EditableItem, IForagableProfile
 
         if (maximumYield <= 0.0)
         {
-            if (!_maximumYieldPoints.ContainsKey(forageType))
-            {
-                actor.OutputHandler.Send(
-                    "There is no such yield to remove. If you're trying to add a new yield, it must have a maximum of greater than zero.");
-                return false;
-            }
-
-            _maximumYieldPoints.Remove(forageType);
-            _hourlyYieldPoints.Remove(forageType);
-            Changed = true;
-            actor.OutputHandler.Send(
-                $"This foragable profile will no longer contain the {forageType.ColourName()} yield type.");
-            return true;
+            return RemoveYield(actor, forageType);
         }
 
         if (command.IsFinished)
@@ -358,11 +377,34 @@ public class ForagableProfile : EditableItem, IForagableProfile
             return false;
         }
 
+        if (hourlyGain < 0.0)
+        {
+            actor.Send("The hourly yield recovery cannot be negative.");
+            return false;
+        }
+
         _maximumYieldPoints[forageType] = maximumYield;
         _hourlyYieldPoints[forageType] = hourlyGain;
         actor.OutputHandler.Send(
             $"You set the maximum yield for the {forageType.ColourName()} forage type to {maximumYield.ToString("N2", actor).ColourValue()} and the hourly yield recovery to {hourlyGain.ToString("N2", actor).ColourValue()}.");
         Changed = true;
+        return true;
+    }
+
+    private bool RemoveYield(ICharacter actor, string forageType)
+    {
+        if (!_maximumYieldPoints.ContainsKey(forageType))
+        {
+            actor.OutputHandler.Send(
+                "There is no such yield to remove. If you're trying to add a new yield, it must have a maximum of greater than zero.");
+            return false;
+        }
+
+        _maximumYieldPoints.Remove(forageType);
+        _hourlyYieldPoints.Remove(forageType);
+        Changed = true;
+        actor.OutputHandler.Send(
+            $"This foragable profile will no longer contain the {forageType.ColourName()} yield type.");
         return true;
     }
 
@@ -395,15 +437,29 @@ public class ForagableProfile : EditableItem, IForagableProfile
     private readonly List<long> _foragableIds = new();
     public IEnumerable<IForagable> Foragables => _foragableIds.SelectNotNull(x => Gameworld.Foragables.Get(x));
 
+    private static Dictionary<string, double> BuildYieldDictionary(IEnumerable<(string ForageType, double Yield)> yields)
+    {
+        return yields.Where(x => !string.IsNullOrWhiteSpace(x.ForageType))
+                     .GroupBy(x => x.ForageType.Trim().ToLowerInvariant(), StringComparer.InvariantCultureIgnoreCase)
+                     .ToDictionary(x => x.Key, x => x.Last().Yield, StringComparer.InvariantCultureIgnoreCase);
+    }
+
     public IForagable GetForageResult(ICharacter character, IReadOnlyDictionary<Difficulty, CheckOutcome> forageOutcome,
         string foragableType)
     {
+        if (!MaximumYieldPoints.ContainsKey(foragableType))
+        {
+            return null;
+        }
+
         return
             Foragables.Where(
                           x =>
+                              x.ItemProto != null &&
                               x.ForagableTypes.Any(y =>
                                   y.Equals(foragableType, StringComparison.InvariantCultureIgnoreCase)) &&
-                              x.CanForage(character, forageOutcome[x.ForageDifficulty]))
+                              forageOutcome.TryGetValue(x.ForageDifficulty, out var outcome) &&
+                              x.CanForage(character, outcome))
                       .GetWeightedRandom(x => x.RelativeChance);
     }
 


### PR DESCRIPTION
## Summary
- Improve the player-facing `forage` command with clearer yield feedback, specific-result foraging, safer container handling, and missing-data guards.
- Harden foragable/profile builder workflows around blank types, multi-word lookups, profile yield editing, and stale linked data.
- Preserve inherited forage profile behavior on cells and synchronize runtime forage yield pools when profile assignments change.
- Expand foragable/profile help text and update the OnForage prog contract comment.

## Validation
- `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510` passed with the existing analyzer warnings for `FunctionStatement` and `GeneralActiveCheckBonus`.
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 --filter FullyQualifiedName~ForagingRuntimeTests` passed, 5 tests.
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1` passed, 749 tests.
- `git diff --check` passed.