### PR TITLE
Audit antiquity crafting coverage

### DIFF
--- a/DatabaseSeeder Unit Tests/ItemSeederAntiquityRemainingCraftingTests.cs
+++ b/DatabaseSeeder Unit Tests/ItemSeederAntiquityRemainingCraftingTests.cs
@@ -153,6 +153,159 @@ public class ItemSeederAntiquityRemainingCraftingTests
 		}
 	}
 
+	[TestMethod]
+	public void AntiquityCrafting_AllCurrentTagToolsHaveSeededItemCoverage()
+	{
+		var craftSource = ReadSeederSources("ItemSeederCrafting.Antiquity*.cs");
+		var itemSource = ReadSeederSources("ItemSeeder.Rework.Antiquity*.cs");
+
+		var toolTags = Regex.Matches(craftSource,
+				@"TagTool\s*-\s*(?:Held|InRoom|In Room|Wielded)\s*-\s*an item with the (?<tag>.+?) tag",
+				RegexOptions.IgnoreCase)
+			.Select(x => x.Groups["tag"].Value.Trim())
+			.Where(x => !string.IsNullOrWhiteSpace(x))
+			.Distinct(StringComparer.OrdinalIgnoreCase)
+			.OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+			.ToList();
+
+		var seededToolTagLeafs = Regex.Matches(itemSource, @"""(?<tag>Functions / [^""]+)""")
+			.Select(x => x.Groups["tag"].Value.Split(" / ").Last().Trim())
+			.Where(x => !string.IsNullOrWhiteSpace(x))
+			.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+		var missing = toolTags
+			.Where(x => !seededToolTagLeafs.Contains(x))
+			.ToList();
+
+		Assert.AreEqual(0, missing.Count,
+			$"Every current antiquity TagTool should have at least one seeded rework item carrying the exact tool tag. Missing: {string.Join(", ", missing)}");
+	}
+
+	[TestMethod]
+	public void AntiquityCrafting_LitWorkshopItemsHaveMorphTargetsTimersAndToolTags()
+	{
+		var createItemSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.cs");
+		var householdToolSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.AntiquityHouseholdTools.cs");
+		var equipmentCraftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.AntiquityEquipment.cs");
+
+		foreach (var expected in new[]
+		{
+			"item.MorphGameItemProtoId = morphItem.Id;",
+			"item.MorphTimeSeconds = (int)morphTimer.Value.TotalSeconds;",
+			"item.MorphEmote = morphEmote;",
+			"item.OnDestroyedGameItemProtoId = destroyedItem.Id;"
+		})
+		{
+			AssertContains(createItemSource, expected);
+		}
+
+		foreach (var spec in new[]
+		{
+			(Lit: "antiquity_lit_workshop_hearth", Unlit: "antiquity_workshop_hearth", ToolTag: "Functions / Material Functions / Fire"),
+			(Lit: "antiquity_lit_clay_smelting_furnace", Unlit: "antiquity_clay_smelting_furnace", ToolTag: "Functions / Tools / Smelting Tools / Smelting Furnace / Lit Smelting Furnace"),
+			(Lit: "antiquity_lit_updraft_kiln", Unlit: "antiquity_updraft_kiln", ToolTag: "Functions / Tools / Pottery Tools / Kiln / Lit Kiln"),
+			(Lit: "antiquity_lit_annealing_lehr", Unlit: "antiquity_annealing_lehr", ToolTag: "Functions / Tools / Glassblowing Tools / Annealing Lehr / Lit Annealing Lehr")
+		})
+		{
+			var block = ExtractCallBlockContaining(householdToolSource, spec.Lit);
+			AssertContains(block, spec.Unlit);
+			AssertContains(block, spec.ToolTag);
+			AssertContains(block, "TimeSpan.FromHours(");
+		}
+
+		foreach (var expected in new[]
+		{
+			"SeedAntiquityWorkshopHeatSourceCrafts();",
+			"light a workshop hearth",
+			"stoke an updraft pottery kiln",
+			"stoke a clay smelting furnace",
+			"stoke an annealing lehr",
+			"CommodityInput(charcoalGrams, \"charcoal\")",
+			"lay|lays $i2 into the fire bed",
+			"StableUnusedInputProduct(unlitStableReference, 1)"
+		})
+		{
+			AssertContains(equipmentCraftSource, expected);
+		}
+	}
+
+	[TestMethod]
+	public void AntiquityCrafting_ProducedIntermediateTagsAreConsumedOrDocumentedReusableStock()
+	{
+		var craftSource = ReadSeederSources("ItemSeederCrafting.Antiquity*.cs");
+		var docsSource =
+			ReadSource("Design Documents", "Crafting", "Antiquity_Equipment_Crafting_Suite.md") +
+			ReadSource("Design Documents", "Crafting", "Antiquity_Furniture_Container_Crafting_Suite.md") +
+			ReadSource("Design Documents", "Crafting", "Antiquity_Writing_Implements_Crafting_Suite.md") +
+			ReadSource("Design Documents", "Crafting", "Antiquity_Medical_Crafting_Suite.md");
+
+		var producedTags = ExtractLiteralCommodityProductTags(craftSource);
+		var consumedTags = ExtractLiteralCommodityInputTags(craftSource);
+
+		var undocumentedReusableOutputs = producedTags
+			.Where(x => !consumedTags.Contains(x))
+			.Where(x => !docsSource.Contains($"`{x}`", StringComparison.Ordinal))
+			.OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+			.ToList();
+
+		Assert.AreEqual(0, undocumentedReusableOutputs.Count,
+			$"Produced intermediate tags should be consumed downstream or documented as reusable stock outputs. Missing docs: {string.Join(", ", undocumentedReusableOutputs)}");
+	}
+
+	[TestMethod]
+	public void AntiquityCrafting_DocumentationMentionsEveryCraftSourceStableReference()
+	{
+		var craftSource = ReadSeederSources("ItemSeederCrafting.Antiquity*.cs");
+		var docsSource = ReadDesignDocumentSources("Antiquity_*.md");
+
+		var craftStableReferences = ExtractStableReferences(craftSource)
+			.OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+			.ToList();
+		var documentedStableReferences = ExtractStableReferences(docsSource);
+
+		var missing = craftStableReferences
+			.Where(x => !documentedStableReferences.Contains(x))
+			.ToList();
+
+		Assert.AreEqual(0, missing.Count,
+			$"Every stable reference explicitly named by current antiquity craft source should be catalogued in the antiquity docs. Missing: {string.Join(", ", missing)}");
+	}
+
+	[TestMethod]
+	public void AntiquityMedicalCookingPotCrafts_RequireLitFireState()
+	{
+		var medicalCraftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.AntiquityMedical.cs");
+
+		foreach (var craftName in new[]
+		{
+			"prepare clean dressing stock",
+			"render herbal salve stock",
+			"steep medicinal decoction stock"
+		})
+		{
+			var block = ExtractCallBlockContaining(medicalCraftSource, craftName);
+			AssertContains(block, "TagTool - InRoom - an item with the Cooking Pot tag");
+			AssertContains(block, "TagTool - InRoom - an item with the Fire tag");
+		}
+	}
+
+	[TestMethod]
+	public void AntiquityCrafting_CatalogueAuditDocumentsRemainingLogicalGaps()
+	{
+		var auditDoc = ReadSource("Design Documents", "Crafting", "Antiquity_Crafting_Audit.md");
+
+		foreach (var expected in new[]
+		{
+			"SeedAntiquityJewellery",
+			"support tools and unlit workshop apparatus",
+			"glass furnace",
+			"maintained rather than generated"
+		})
+		{
+			AssertContains(auditDoc, expected);
+		}
+	}
+
 	private static bool IsCoveredByCraftSuites(SeededAntiquityItem item, string existingCraftSource,
 		string equipmentCraftSource, string allCraftSource)
 	{
@@ -268,6 +421,68 @@ public class ItemSeederAntiquityRemainingCraftingTests
 	private static void AssertContains(string source, string expected)
 	{
 		Assert.IsTrue(source.Contains(expected, StringComparison.Ordinal), $"Expected source to contain: {expected}");
+	}
+
+	private static string ExtractCallBlockContaining(string source, string marker)
+	{
+		var start = source.IndexOf(marker, StringComparison.Ordinal);
+		Assert.IsTrue(start >= 0, $"Could not find source block for {marker}.");
+		var end = source.IndexOf(");", start, StringComparison.Ordinal);
+		Assert.IsTrue(end >= 0, $"Could not find end of source block for {marker}.");
+		return source[start..end];
+	}
+
+	private static HashSet<string> ExtractLiteralCommodityProductTags(string source)
+	{
+		return Regex.Matches(source, @"CommodityProduct\s*-\s*[^""\]]*?;\s*tag\s+(?<tag>[^;""\]\}]+)")
+			.Select(x => x.Groups["tag"].Value.Trim())
+			.Where(IsLiteralTagReference)
+			.ToHashSet(StringComparer.OrdinalIgnoreCase);
+	}
+
+	private static HashSet<string> ExtractLiteralCommodityInputTags(string source)
+	{
+		var pileTags = Regex.Matches(source, @"piletag\s+(?<tag>[^;""\]\)]+)")
+			.Select(x => x.Groups["tag"].Value.Trim());
+		var helperTags = Regex.Matches(source, @"CommodityInput\([^,\)]*,\s*""[^""]+""\s*,\s*""(?<tag>[^""]+)""")
+			.Select(x => x.Groups["tag"].Value.Trim());
+
+		return pileTags
+			.Concat(helperTags)
+			.Where(IsLiteralTagReference)
+			.ToHashSet(StringComparer.OrdinalIgnoreCase);
+	}
+
+	private static bool IsLiteralTagReference(string tag)
+	{
+		return !string.IsNullOrWhiteSpace(tag) &&
+		       !tag.Contains('{', StringComparison.Ordinal) &&
+		       !tag.Contains('$', StringComparison.Ordinal);
+	}
+
+	private static HashSet<string> ExtractStableReferences(string source)
+	{
+		return Regex.Matches(source, @"\b(?:antiquity|adjacent_antiquity|jewellery)_[a-z0-9_]+\b")
+			.Select(x => x.Value)
+			.ToHashSet(StringComparer.OrdinalIgnoreCase);
+	}
+
+	private static string ReadSeederSources(string pattern)
+	{
+		var sourceRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+		return string.Concat(Directory
+			.EnumerateFiles(Path.Combine(sourceRoot, "DatabaseSeeder", "Seeders"), pattern)
+			.OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+			.Select(File.ReadAllText));
+	}
+
+	private static string ReadDesignDocumentSources(string pattern)
+	{
+		var sourceRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+		return string.Concat(Directory
+			.EnumerateFiles(Path.Combine(sourceRoot, "Design Documents", "Crafting"), pattern)
+			.OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+			.Select(File.ReadAllText));
 	}
 
 	private static string ReadSource(params string[] parts)

--- a/DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityHouseholdTools.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityHouseholdTools.cs
@@ -1,4 +1,5 @@
 using MudSharp.GameItems;
+using System;
 using System.Collections.Generic;
 
 namespace DatabaseSeeder.Seeders;
@@ -19,6 +20,26 @@ public partial class ItemSeeder
 			"A narrow bronze chisel with a faceted wooden handle, kept sharp for cutting mortises, trimming pegs, and carving small household fittings.",
 			SizeCategory.Small, 280.0, 18.0m, "bronze",
 			["Functions / Tools / Woodcrafting Tools / Wood Chisel"]);
+		CreateAntiquityHouseholdCraftTool("antiquity_bronze_workshop_chisel", "chisel", "a bronze workshop chisel",
+			"A general bronze chisel with a plain wooden handle, useful for rough shaping, small notches, and tool finishing where a specialist edge is not needed.",
+			SizeCategory.Small, 320.0, 16.0m, "bronze",
+			["Functions / Tools / Cutting and Shaping Tools / Chisel"]);
+		CreateAntiquityHouseholdCraftTool("antiquity_bronze_workshop_hammer", "hammer", "a bronze workshop hammer",
+			"A compact bronze hammer with a square face and a smooth wooden haft, heavy enough for peening, riveting, and general workshop striking.",
+			SizeCategory.Small, 760.0, 20.0m, "bronze",
+			["Functions / Tools / Striking Tools / Hammer", "Functions / Tools / Metalworking Tools / Forge Hammer"]);
+		CreateAntiquityHouseholdCraftTool("antiquity_bronze_workshop_pliers", "pliers", "a pair of bronze workshop pliers",
+			"A pair of bronze pliers with short jaws and a wrapped grip, made for bending wire, holding hot fittings briefly, and closing small rings.",
+			SizeCategory.Small, 360.0, 14.0m, "bronze",
+			["Functions / Tools / Gripping Tools / Pliers"]);
+		CreateAntiquityHouseholdCraftTool("antiquity_bronze_plaster_trowel", "trowel", "a bronze finishing trowel",
+			"A flat bronze trowel with a stubby wooden handle, used to smooth plaster, clay slips, pigments, and other spread workshop mixtures.",
+			SizeCategory.Small, 310.0, 11.0m, "bronze",
+			["Functions / Tools / Finishing Tools / Trowel"]);
+		CreateAntiquityHouseholdCraftTool("antiquity_sharpening_whetstone", "whetstone", "a grooved sharpening whetstone",
+			"A palm-sized stone worn into shallow grooves by knives, chisels, and needles. It is kept damp when used to freshen working edges.",
+			SizeCategory.Tiny, 220.0, 4.0m, "stone",
+			["Functions / Sharpening"]);
 		CreateAntiquityHouseholdCraftTool("antiquity_bronze_wood_auger", "auger", "a bronze wood auger",
 			"A bronze auger with a simple cross-grip, used to bore peg holes, hinge sockets, bung holes, and narrow openings in wooden vessels.",
 			SizeCategory.Small, 470.0, 26.0m, "bronze",
@@ -71,6 +92,22 @@ public partial class ItemSeeder
 			"A polished bone tool for pressing weavers close, creasing folds, and settling splints without cutting their fibres.",
 			SizeCategory.Small, 90.0, 5.0m, "horn",
 			["Functions / Tools / Textilecraft Tools / Basketry Tools / Packing Bone"]);
+		CreateAntiquityHouseholdCraftTool("antiquity_linen_dye_strainer", "strainer", "a linen dye strainer",
+			"A tight linen strainer stretched over a light willow hoop, used to separate dregs, lake pigment, and plant matter from prepared dye liquor.",
+			SizeCategory.Small, 95.0, 5.0m, "linen",
+			["Functions / Tools / Textilecraft Tools / Dyeing Tools / Dye Strainer"]);
+		CreateAntiquityHouseholdCraftTool("antiquity_indigo_beating_paddle", "paddle", "an indigo beating paddle",
+			"A flat wooden paddle with a dark-stained face, made for beating indigo vats and lifting oxygen through the liquor until the colour takes.",
+			SizeCategory.Normal, 540.0, 7.0m, "oak",
+			["Functions / Tools / Textilecraft Tools / Dyeing Tools / Indigo Beating Paddle"]);
+		CreateAntiquityHouseholdCraftTool("antiquity_rope_hook_bar", "hook", "a bronze rope hook",
+			"A stout bronze hook mounted on a short wooden bar, useful for twisting cordage, holding tension, and starting small rope lays.",
+			SizeCategory.Small, 410.0, 10.0m, "bronze",
+			["Functions / Tools / Textilecraft Tools / Ropemaking Tools / Rope Hook"]);
+		CreateAntiquityHouseholdCraftTool("antiquity_twine_shuttle", "shuttle", "a wooden twine shuttle",
+			"A flat wooden twine shuttle notched at both ends, sized for carrying cord through tight turns and binding lamp wicks, nets, or small ropes.",
+			SizeCategory.Tiny, 70.0, 3.0m, "wood",
+			["Functions / Tools / Textilecraft Tools / Ropemaking Tools / Twine Shuttle"]);
 		CreateAntiquityHouseholdCraftTool("antiquity_leather_awl_punch", "awl", "a bronze leather awl punch",
 			"A tapered bronze awl punch with a sturdy wooden grip, used to open stitch holes in leather panels, straps, and fitted covers.",
 			SizeCategory.Small, 140.0, 9.0m, "bronze",
@@ -83,10 +120,25 @@ public partial class ItemSeeder
 			"A small bronze edge beveller for shaving hard corners from straps, pouches, buckets, and leather-covered boxes.",
 			SizeCategory.VerySmall, 90.0, 8.0m, "bronze",
 			["Functions / Tools / Leatherworking Tools / Edge Beveller"]);
+		CreateAntiquityHouseholdCraftTool("antiquity_bronze_leather_paring_knife", "knife", "a bronze leather paring knife",
+			"A thin bronze paring knife with a slanted edge, used to shave leather edges thin for covers, cases, straps, and joined panels.",
+			SizeCategory.VerySmall, 120.0, 9.0m, "bronze",
+			["Functions / Tools / Bookbinding Tools / Leather Paring Knife"]);
 		CreateAntiquityHouseholdCraftTool("antiquity_slow_potters_wheel", "wheel", "a slow wooden potter's wheel",
 			"A heavy wooden turntable set on a low pivot, spun by hand for shaping small bowls, jars, lamps, and household vessels.",
 			SizeCategory.Large, 18000.0, 42.0m, "oak",
 			["Functions / Tools / Pottery Tools / Potter's Wheel"]);
+		CreateAntiquityHouseholdCraftTool("antiquity_workshop_hearth", "hearth", "an unlit clay workshop hearth",
+			"A low fired-clay hearth with a shallow bed for charcoal and a battered lip for resting small pots, wax vessels, or light workshop work.",
+			SizeCategory.Large, 28000.0, 42.0m, "fired clay",
+			[]);
+		CreateAntiquityHouseholdCraftTool("antiquity_lit_workshop_hearth", "hearth", "a lit clay workshop hearth",
+			"This low fired-clay hearth holds a bed of glowing charcoal. It gives steady workshop heat for wax, pitch, glue, small pots, and other gentle heating jobs.",
+			SizeCategory.Large, 28200.0, 46.0m, "fired clay",
+			["Functions / Material Functions / Fire"],
+			"antiquity_workshop_hearth",
+			"$0 burns low and settles back into $1.",
+			TimeSpan.FromHours(2));
 		CreateAntiquityHouseholdCraftTool("antiquity_clay_knife", "knife", "a bronze clay knife",
 			"A blunt-edged bronze clay knife for cutting wet clay, trimming vessel mouths, and cleaning the foot of a pot before firing.",
 			SizeCategory.Small, 160.0, 8.0m, "bronze",
@@ -111,6 +163,13 @@ public partial class ItemSeeder
 			"A squat earthenware updraft kiln with a low firebox and a pierced setting floor for firing small batches of vessels, lamps, and tiles.",
 			SizeCategory.Huge, 65000.0, 120.0m, "earthenware",
 			["Functions / Tools / Pottery Tools / Kiln"]);
+		CreateAntiquityHouseholdCraftTool("antiquity_lit_updraft_kiln", "kiln", "a lit updraft pottery kiln",
+			"This squat earthenware updraft kiln is stoked with charcoal heat, drawing fire up through a pierced setting floor for vessel and tile firing.",
+			SizeCategory.Huge, 65200.0, 128.0m, "earthenware",
+			["Functions / Tools / Pottery Tools / Kiln", "Functions / Tools / Pottery Tools / Kiln / Lit Kiln", "Functions / Material Functions / Hot Fire"],
+			"antiquity_updraft_kiln",
+			"$0 cools and dies back into $1.",
+			TimeSpan.FromHours(4));
 		CreateAntiquityHouseholdCraftTool("antiquity_glass_blowpipe", "blowpipe", "a bronze glass blowpipe",
 			"A long bronze blowpipe with a flared mouthpiece and a heat-darkened working end for gathering and inflating molten glass.",
 			SizeCategory.Normal, 1800.0, 38.0m, "bronze",
@@ -135,6 +194,13 @@ public partial class ItemSeeder
 			"A long earthenware annealing lehr that holds finished glass at a gentler heat so vessels can cool without cracking.",
 			SizeCategory.Huge, 52000.0, 110.0m, "earthenware",
 			["Functions / Tools / Glassblowing Tools / Annealing Lehr"]);
+		CreateAntiquityHouseholdCraftTool("antiquity_lit_annealing_lehr", "lehr", "a lit annealing lehr",
+			"This long earthenware annealing lehr is held at a steady charcoal heat, ready to take hot glass vessels and let them cool without cracking.",
+			SizeCategory.Huge, 52200.0, 116.0m, "earthenware",
+			["Functions / Tools / Glassblowing Tools / Annealing Lehr", "Functions / Tools / Glassblowing Tools / Annealing Lehr / Lit Annealing Lehr", "Functions / Material Functions / Hot Fire"],
+			"antiquity_annealing_lehr",
+			"$0 cools and dies back into $1.",
+			TimeSpan.FromHours(4));
 		CreateAntiquityHouseholdCraftTool("antiquity_casting_crucible", "crucible", "a bronze casting crucible",
 			"A thick-walled bronze crucible with a darkened lip for melting small charges of metal for vessels, fittings, and decorative mounts.",
 			SizeCategory.Small, 1600.0, 36.0m, "bronze",
@@ -143,6 +209,33 @@ public partial class ItemSeeder
 			"Long bronze tongs with hooked jaws, shaped to grip hot crucibles and carry them clear of the furnace mouth.",
 			SizeCategory.Normal, 1450.0, 28.0m, "bronze",
 			["Functions / Tools / Smelting Tools / Crucible Tongs"]);
+		CreateAntiquityHouseholdCraftTool("antiquity_clay_smelting_furnace", "furnace", "an unlit clay smelting furnace",
+			"A squat clay smelting furnace with a charcoal chamber, tuyere opening, and a blackened working mouth for small charges of metal or high-heat tool work.",
+			SizeCategory.Huge, 74000.0, 135.0m, "earthenware",
+			["Functions / Tools / Smelting Tools / Smelting Furnace"]);
+		CreateAntiquityHouseholdCraftTool("antiquity_lit_clay_smelting_furnace", "furnace", "a lit clay smelting furnace",
+			"This squat clay smelting furnace roars with charcoal heat through its tuyere opening, hot enough for metal blank work, casting, and other demanding furnace tasks.",
+			SizeCategory.Huge, 74200.0, 146.0m, "earthenware",
+			["Functions / Tools / Smelting Tools / Smelting Furnace", "Functions / Tools / Smelting Tools / Smelting Furnace / Lit Smelting Furnace", "Functions / Material Functions / Hot Fire"],
+			"antiquity_clay_smelting_furnace",
+			"$0 cools and dies back into $1.",
+			TimeSpan.FromHours(3));
+		CreateAntiquityHouseholdCraftTool("antiquity_bronze_forge_tongs", "tongs", "a pair of bronze forge tongs",
+			"Long bronze forge tongs with squared jaws and wrapped grips, shaped for shifting heated blanks between furnace mouth and anvil.",
+			SizeCategory.Normal, 1280.0, 24.0m, "bronze",
+			["Functions / Tools / Metalworking Tools / Forge Tongs"]);
+		CreateAntiquityHouseholdCraftTool("antiquity_goatskin_bellows", "bellows", "a goatskin workshop bellows",
+			"A goatskin bellows fixed between wooden boards with a narrow bronze nozzle, used to drive air into hearths and small furnaces.",
+			SizeCategory.Normal, 1600.0, 18.0m, "leather",
+			["Functions / Tools / Metalworking Tools / Bellows", "Functions / Tools / Smelting Tools / Furnace Bellows"]);
+		CreateAntiquityHouseholdCraftTool("antiquity_bronze_anvil", "anvil", "a low bronze workshop anvil",
+			"A low bronze anvil with a broad working face and a simple stake foot, suited to small blades, fittings, rings, and sheet work.",
+			SizeCategory.Large, 34000.0, 55.0m, "bronze",
+			["Functions / Tools / Metalworking Tools / Anvil"]);
+		CreateAntiquityHouseholdCraftTool("antiquity_bronze_cooking_pot", "pot", "a bronze cooking pot",
+			"A rounded bronze cooking pot with two small loop handles and a smoke-darkened base, large enough for wax, pitch, herbs, or kitchen stewing.",
+			SizeCategory.Normal, 1800.0, 28.0m, "bronze",
+			["Functions / Tools / Cooking / Cookware / Cooking Pot"]);
 		CreateAntiquityHouseholdCraftTool("antiquity_vessel_casting_mould", "mould", "a clay vessel casting mould",
 			"A two-part fired-clay mould for rough-casting simple cups, bowls, trays, and lamp bodies before hammering and burnishing.",
 			SizeCategory.Normal, 4200.0, 32.0m, "fired clay",
@@ -183,7 +276,10 @@ public partial class ItemSeeder
 
 	private void CreateAntiquityHouseholdCraftTool(string stableReference, string noun, string shortDescription,
 		string fullDescription, SizeCategory size, double weightInGrams, decimal cost, string material,
-		IEnumerable<string> functionalTags)
+		IEnumerable<string> functionalTags,
+		string? morphToUniqueReference = null,
+		string? morphEmote = null,
+		TimeSpan? morphTimer = null)
 	{
 		var tags = new List<string> { "Market / Professional Tools / Standard Tools" };
 		tags.AddRange(functionalTags);
@@ -202,9 +298,9 @@ public partial class ItemSeeder
 			material,
 			tags,
 			["Holdable", (int)size >= (int)SizeCategory.Large ? "Destroyable_Furniture" : "Destroyable_Misc"],
-			null,
-			null,
-			null,
+			morphToUniqueReference,
+			morphEmote,
+			morphTimer,
 			null
 		);
 	}

--- a/DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityMedical.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityMedical.cs
@@ -61,6 +61,32 @@ public partial class ItemSeeder
 		];
 
 		AddMedicalItem(
+			"antiquity_medicine_strainer",
+			"strainer",
+			"a linen medicine strainer",
+			"This tight linen strainer is stretched over a small willow hoop for separating steeped herbs, resin flecks, and grit from draughts and salves.",
+			SizeCategory.VerySmall,
+			ItemQuality.Standard,
+			80.0,
+			5.0m,
+			"linen",
+			["Functions / Tools / Medical Tools / Medicine Strainer", "Market / Professional Tools / Standard Tools", "Market / Medicine / Herbal Medicine"],
+			["Holdable", "Destroyable_Misc"]);
+
+		AddMedicalItem(
+			"antiquity_stone_mortar_and_pestle",
+			"mortar",
+			"a stone mortar and pestle",
+			"This compact stone mortar is paired with a blunt pestle worn smooth from crushing herbs, minerals, resins, and dried medicine stock.",
+			SizeCategory.Small,
+			ItemQuality.Standard,
+			1450.0,
+			10.0m,
+			"stone",
+			["Functions / Tools / Cooking / Cooking Utensils / Mortar and Pestle", "Market / Professional Tools / Standard Tools", "Market / Medicine / Herbal Medicine"],
+			["Holdable", "Destroyable_Misc"]);
+
+		AddMedicalItem(
 			"antiquity_linen_bandage_roll",
 			"roll",
 			"a roll of clean linen bandage",

--- a/DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityWriting.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityWriting.cs
@@ -53,6 +53,186 @@ public partial class ItemSeeder
 		var reedStylus = EnsureAntiquityScribingImplementComponent("Antiquity_Reed_Stylus",
 			"Turns an item into a non-consuming reed stylus", WritingImplementType.Stylus, "black", 0);
 
+		void AddWritingCraftTool(string stableReference, string noun, string shortDescription,
+			string fullDescription, SizeCategory size, double weightInGrams, decimal cost, string material,
+			string[] functionalTags)
+		{
+			CreateItem(
+				stableReference,
+				noun,
+				shortDescription,
+				null,
+				fullDescription,
+				size,
+				ItemQuality.Standard,
+				weightInGrams,
+				cost,
+				false,
+				false,
+				material,
+				["Market / Professional Tools / Standard Tools", .. functionalTags],
+				["Holdable", (int)size >= (int)SizeCategory.Large ? "Destroyable_Furniture" : "Destroyable_Misc"],
+				null,
+				null,
+				null,
+				null
+			);
+		}
+
+		AddWritingCraftTool(
+			"antiquity_papyrus_strip_knife",
+			"knife",
+			"a bronze papyrus strip knife",
+			"A narrow bronze knife with a straight edge, kept for slicing soaked papyrus pith into long even strips before pressing.",
+			SizeCategory.VerySmall,
+			85.0,
+			7.0m,
+			"bronze",
+			["Functions / Tools / Papyrusmaking Tools / Papyrus Strip Knife"]);
+
+		AddWritingCraftTool(
+			"antiquity_papyrus_pressing_board",
+			"board",
+			"a papyrus pressing board",
+			"A flat cedar board darkened by damp papyrus sheets, used with weights or clamps to press crossed pith strips into a firm writing sheet.",
+			SizeCategory.Normal,
+			1800.0,
+			10.0m,
+			"cedar",
+			["Functions / Tools / Papyrusmaking Tools / Papyrus Pressing Board"]);
+
+		AddWritingCraftTool(
+			"antiquity_papyrus_burnishing_shell",
+			"shell",
+			"a smooth papyrus burnishing shell",
+			"A polished shell worn satin-smooth along one edge, used to burnish dried papyrus sheets until ink will sit cleanly on the surface.",
+			SizeCategory.Tiny,
+			35.0,
+			4.0m,
+			"shell",
+			["Functions / Tools / Papyrusmaking Tools / Papyrus Burnishing Shell"]);
+
+		AddWritingCraftTool(
+			"antiquity_parchment_scraping_knife",
+			"knife",
+			"a curved parchment scraping knife",
+			"A curved bronze scraping knife with a dulled back and keen working edge, made for thinning stretched parchment without cutting through it.",
+			SizeCategory.VerySmall,
+			120.0,
+			9.0m,
+			"bronze",
+			["Functions / Tools / Parchmentmaking Tools / Parchment Scraping Knife"]);
+
+		AddWritingCraftTool(
+			"antiquity_parchment_stretching_frame",
+			"frame",
+			"a wooden parchment stretching frame",
+			"A rectangular wooden frame pierced around the edges for cords, used to stretch wet hide taut while it is scraped into parchment.",
+			SizeCategory.Large,
+			6200.0,
+			22.0m,
+			"wood",
+			["Functions / Tools / Parchmentmaking Tools / Parchment Stretching Frame"]);
+
+		AddWritingCraftTool(
+			"antiquity_parchment_pumice",
+			"pumice",
+			"a piece of parchment pumice",
+			"A light abrasive stone used to smooth parchment, remove grease, and prepare a surface to take ink evenly.",
+			SizeCategory.Tiny,
+			55.0,
+			3.0m,
+			"stone",
+			["Functions / Tools / Parchmentmaking Tools / Parchment Pumice"]);
+
+		AddWritingCraftTool(
+			"antiquity_bookbinders_needle",
+			"needle",
+			"a bronze bookbinder's needle",
+			"A stout bronze needle with a broad eye, sized for sewing parchment quires, scroll ties, and leather document cases.",
+			SizeCategory.Tiny,
+			18.0,
+			5.0m,
+			"bronze",
+			["Functions / Tools / Bookbinding Tools / Bookbinder's Needle"]);
+
+		AddWritingCraftTool(
+			"antiquity_bookbinders_punch",
+			"punch",
+			"a bronze bookbinder's punch",
+			"A short bronze punch with a wooden grip, made for opening clean sewing holes through quires, boards, and leather covers.",
+			SizeCategory.VerySmall,
+			110.0,
+			7.0m,
+			"bronze",
+			["Functions / Tools / Bookbinding Tools / Bookbinder's Punch"]);
+
+		AddWritingCraftTool(
+			"antiquity_scroll_roller_rod",
+			"rod",
+			"a cedar scroll roller rod",
+			"A slender cedar rod smoothed for winding sheets into a scroll, with enough stiffness to keep the document from creasing.",
+			SizeCategory.Small,
+			90.0,
+			4.0m,
+			"cedar",
+			["Functions / Tools / Scrollmaking Tools / Scroll Roller Rod"]);
+
+		AddWritingCraftTool(
+			"antiquity_scroll_smoothing_stone",
+			"stone",
+			"a scroll smoothing stone",
+			"A flat, rounded stone used to ease joins, press glued sheets, and smooth scroll surfaces without tearing the fibres.",
+			SizeCategory.Tiny,
+			180.0,
+			3.0m,
+			"stone",
+			["Functions / Tools / Scrollmaking Tools / Scroll Smoothing Stone"]);
+
+		AddWritingCraftTool(
+			"antiquity_quill_curing_sand",
+			"sand",
+			"a tray of quill curing sand",
+			"A shallow fired-clay tray filled with clean hot-work sand, used to dry and harden quills before trimming them into pens.",
+			SizeCategory.Small,
+			950.0,
+			5.0m,
+			"fired clay",
+			["Functions / Tools / Calligraphy Tools / Quill Curing Sand"]);
+
+		AddWritingCraftTool(
+			"antiquity_wax_spatula",
+			"spatula",
+			"a bronze wax spatula",
+			"A small bronze spatula with a flattened blade, used for spreading warm wax into tablet recesses and scraping it level again.",
+			SizeCategory.Tiny,
+			55.0,
+			5.0m,
+			"bronze",
+			["Functions / Tools / Scribing Tools / Wax Spatula"]);
+
+		AddWritingCraftTool(
+			"antiquity_pigment_muller",
+			"muller",
+			"a stone pigment muller",
+			"A rounded stone muller with a worn flat underside, used to grind soot, minerals, and lake pigments into fine ink and paint stock.",
+			SizeCategory.Small,
+			620.0,
+			6.0m,
+			"stone",
+			["Functions / Tools / Illumination Tools / Pigment Muller"]);
+
+		AddWritingCraftTool(
+			"antiquity_pigment_shell",
+			"shell",
+			"a pigment mixing shell",
+			"A shallow shell with a polished hollow, used as a tiny palette for wet pigment, ink binder, and writing colour.",
+			SizeCategory.Tiny,
+			28.0,
+			3.0m,
+			"shell",
+			["Functions / Tools / Illumination Tools / Pigment Shell"]);
+
 		CreateItem(
 			"antiquity_loose_papyrus_sheet",
 			"sheet",

--- a/DatabaseSeeder/Seeders/ItemSeeder.Rework.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Rework.cs
@@ -31,6 +31,7 @@ namespace DatabaseSeeder.Seeders
         {
             if (_items.TryGetValue(stableReference, out var existing))
             {
+                ApplyItemLifecycleSettings(existing, morphToUniqueReference, morphEmote, morphTimer, destroyedItemUniqueReference);
                 return existing;
             }
 
@@ -42,6 +43,7 @@ namespace DatabaseSeeder.Seeders
             {
                 _items[stableReference] = existing;
                 _items[existing.ShortDescription] = existing;
+                ApplyItemLifecycleSettings(existing, morphToUniqueReference, morphEmote, morphTimer, destroyedItemUniqueReference);
                 return existing;
             }
 
@@ -73,6 +75,8 @@ namespace DatabaseSeeder.Seeders
                 PermitPlayerSkins = skinnable,
                 CostInBaseCurrency = inherentCost,
                 IsHiddenFromPlayers = hideFromPlayers,
+                MorphTimeSeconds = 0,
+                MorphEmote = "$0 $?1|morphs into $1|decays into nothing$.",
             };
             foreach (string item in tags)
             {
@@ -115,7 +119,45 @@ namespace DatabaseSeeder.Seeders
             _context!.GameItemProtos.Add(dbitem);
             _items[stableReference] = dbitem;
             _items[dbitem.ShortDescription] = dbitem;
+            ApplyItemLifecycleSettings(dbitem, morphToUniqueReference, morphEmote, morphTimer, destroyedItemUniqueReference);
             return dbitem;
+        }
+
+        private void ApplyItemLifecycleSettings(GameItemProto item,
+                                                string? morphToUniqueReference,
+                                                string? morphEmote,
+                                                TimeSpan? morphTimer,
+                                                string? destroyedItemUniqueReference)
+        {
+            if (string.IsNullOrWhiteSpace(morphToUniqueReference) &&
+                string.IsNullOrWhiteSpace(morphEmote) &&
+                morphTimer is null &&
+                string.IsNullOrWhiteSpace(destroyedItemUniqueReference))
+            {
+                return;
+            }
+
+            if (!string.IsNullOrWhiteSpace(morphToUniqueReference) &&
+                _items.TryGetValue(morphToUniqueReference, out var morphItem))
+            {
+                item.MorphGameItemProtoId = morphItem.Id;
+            }
+
+            if (morphTimer is not null)
+            {
+                item.MorphTimeSeconds = (int)morphTimer.Value.TotalSeconds;
+            }
+
+            if (!string.IsNullOrWhiteSpace(morphEmote))
+            {
+                item.MorphEmote = morphEmote;
+            }
+
+            if (!string.IsNullOrWhiteSpace(destroyedItemUniqueReference) &&
+                _items.TryGetValue(destroyedItemUniqueReference, out var destroyedItem))
+            {
+                item.OnDestroyedGameItemProtoId = destroyedItem.Id;
+            }
         }
 
         

--- a/DatabaseSeeder/Seeders/ItemSeederCrafting.Antiquity.cs
+++ b/DatabaseSeeder/Seeders/ItemSeederCrafting.Antiquity.cs
@@ -81,6 +81,22 @@ public partial class ItemSeeder
         return $"SimpleProduct - 1x {item.ShortDescription} (#{item.Id})";
     }
 
+    private string StableSimpleItemDescription(string stableReference)
+    {
+        var item = LookupReworkItem(stableReference);
+        return $"1x {item.ShortDescription} (#{item.Id})";
+    }
+
+    private string StableSimpleItemInput(string stableReference)
+    {
+        return $"SimpleItem - {StableSimpleItemDescription(stableReference)}";
+    }
+
+    private string StableUnusedInputProduct(string stableReference, int inputIndex)
+    {
+        return $"UnusedInput - 100.00% of {StableSimpleItemDescription(stableReference)} ($i{inputIndex})";
+    }
+
     private MudSharp.Models.Craft? AddAntiquityCraft(
         string name,
         string category,
@@ -684,7 +700,7 @@ public partial class ItemSeeder
             ],
             [
                 "TagTool - InRoom - an item with the Leather Wax Pot tag",
-                "TagTool - InRoom - an item with the Hot Fire tag",
+                "TagTool - InRoom - an item with the Fire tag",
                 "TagTool - InRoom - an item with the Tanning Rack tag"
             ],
             ["CommodityProduct - 760 grams of leather commodity; tag Hardened Leather Panel; characteristic Colour from $i1; characteristic Fine Colour from $i1"],
@@ -731,7 +747,7 @@ public partial class ItemSeeder
             ],
             [
                 "TagTool - InRoom - an item with the Leather Wax Pot tag",
-                "TagTool - InRoom - an item with the Hot Fire tag",
+                "TagTool - InRoom - an item with the Fire tag",
                 "TagTool - Held - an item with the Leather Creaser tag"
             ],
             ["CommodityProduct - 600 grams of leather commodity; tag Sealed Leather Panel; characteristic Colour from $i1; characteristic Fine Colour from $i1"],

--- a/DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityEquipment.cs
+++ b/DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityEquipment.cs
@@ -191,12 +191,105 @@ public partial class ItemSeeder
 			return;
 		}
 
+		SeedAntiquityWorkshopHeatSourceCrafts();
 		SeedAntiquityEquipmentIntermediateCommodityCrafts();
 
 		var usedCraftNames = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 		SeedAntiquityCommonClothingCrafts(usedCraftNames);
 		SeedAntiquityCraftToolCrafts(usedCraftNames);
 		SeedAntiquityMilitaryEquipmentCrafts(usedCraftNames);
+	}
+
+	private void SeedAntiquityWorkshopHeatSourceCrafts()
+	{
+		AddAntiquityHeatSourceCraft(
+			"light a workshop hearth",
+			"Survival",
+			"Surviving",
+			AncientLightingKnowledge,
+			"Workshop Heat",
+			"light a clay workshop hearth",
+			"antiquity_workshop_hearth",
+			"antiquity_lit_workshop_hearth",
+			500.0,
+			5,
+			Difficulty.Easy);
+
+		AddAntiquityHeatSourceCraft(
+			"stoke an updraft pottery kiln",
+			"Pottery",
+			"Pottery",
+			AncientCeramicVesselmakingKnowledge,
+			"Ceramics",
+			"stoke an updraft pottery kiln",
+			"antiquity_updraft_kiln",
+			"antiquity_lit_updraft_kiln",
+			2400.0,
+			15,
+			Difficulty.Normal);
+
+		AddAntiquityHeatSourceCraft(
+			"stoke a clay smelting furnace",
+			"Blacksmithing",
+			"Blacksmithing",
+			AncientToolmakingKnowledge,
+			"Metal Heat",
+			"stoke a clay smelting furnace",
+			"antiquity_clay_smelting_furnace",
+			"antiquity_lit_clay_smelting_furnace",
+			2600.0,
+			20,
+			Difficulty.Normal);
+
+		AddAntiquityHeatSourceCraft(
+			"stoke an annealing lehr",
+			"Glassworking",
+			"Glassworking",
+			AncientGlassworkingKnowledge,
+			"Glassworking",
+			"stoke an annealing lehr",
+			"antiquity_annealing_lehr",
+			"antiquity_lit_annealing_lehr",
+			1800.0,
+			20,
+			Difficulty.Normal);
+	}
+
+	private void AddAntiquityHeatSourceCraft(string name, string category, string traitName, string knowledgeName,
+		string knowledgeSubtype, string blurb, string unlitStableReference, string litStableReference, double charcoalGrams,
+		int minimumTraitValue, Difficulty difficulty)
+	{
+		AddAntiquityCraft(
+			name,
+			category,
+			blurb,
+			name,
+			$"{blurb} in progress",
+			knowledgeName,
+			traitName,
+			minimumTraitValue,
+			difficulty,
+			AntiquityHeatSourcePhases(),
+			[
+				StableSimpleItemInput(unlitStableReference),
+				CommodityInput(charcoalGrams, "charcoal")
+			],
+			[],
+			[StableSimpleProduct(litStableReference)],
+			[StableUnusedInputProduct(unlitStableReference, 1)],
+			knowledgeSubtype: knowledgeSubtype,
+			knowledgeDescription: $"{knowledgeName} covers lighting, stoking, and maintaining reusable antiquity workshop heat sources.",
+			knowledgeLongDescription: $"{knowledgeName} covers lighting, stoking, and maintaining reusable antiquity workshop heat sources.");
+	}
+
+	private static (int Seconds, string Echo, string FailEcho)[] AntiquityHeatSourcePhases()
+	{
+		return
+		[
+			(20, "$0 clear|clears ash from $i1 and lay|lays $i2 into the fire bed.", "$0 clear|clears ash from $i1, but pack|packs the charcoal poorly."),
+			(35, "$0 coax|coaxes the charcoal into a steady working heat.", "$0 coax|coaxes the charcoal, but the heat gutters and chokes."),
+			(25, "$0 settle|settles $p1 into a usable heat.", "$0 lose|loses the heat before the work is ready, leaving only $f1 usable.")
+		];
 	}
 
 	private void SeedAntiquityEquipmentIntermediateCommodityCrafts()
@@ -451,7 +544,7 @@ public partial class ItemSeeder
 				[CommodityInput(1000.0, material)],
 				[
 					"TagTool - InRoom - an item with the Potter's Wheel tag",
-					"TagTool - InRoom - an item with the Kiln tag"
+					"TagTool - InRoom - an item with the Lit Kiln tag"
 				],
 				[$"CommodityProduct - {FormatCommodityAmount(820.0)} of {material} commodity; tag Tool Blank Stock"]);
 		}
@@ -809,7 +902,7 @@ public partial class ItemSeeder
 				"form", "forming", 15, Difficulty.Normal,
 				[
 					"TagTool - InRoom - an item with the Potter's Wheel tag",
-					"TagTool - InRoom - an item with the Kiln tag"
+					"TagTool - InRoom - an item with the Lit Kiln tag"
 				]);
 		}
 
@@ -1198,7 +1291,7 @@ public partial class ItemSeeder
 	{
 		return
 		[
-			"TagTool - InRoom - an item with the Hot Fire tag",
+			"TagTool - InRoom - an item with the Lit Smelting Furnace tag",
 			"TagTool - InRoom - an item with the Bellows tag",
 			"TagTool - Held - an item with the Forge Tongs tag",
 			"TagTool - InRoom - an item with the Anvil tag",

--- a/DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityHousehold.cs
+++ b/DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityHousehold.cs
@@ -370,7 +370,7 @@ public partial class ItemSeeder
 				"Ceramics",
 				$"bisque fire a {material} vessel blank",
 				[CommodityInput(1000.0, material, "Wet Vessel Blank", colour: true, fineColour: true)],
-				["TagTool - InRoom - an item with the Kiln tag"],
+				["TagTool - InRoom - an item with the Lit Kiln tag"],
 				[
 					$"CommodityProduct - {FormatCommodityAmount(900.0)} of {material} commodity; tag Bisque Vessel Blank; characteristic Colour from $i1; characteristic Fine Colour from $i1"
 				]);
@@ -402,7 +402,7 @@ public partial class ItemSeeder
 				[
 					"TagTool - Held - an item with the Blowpipe tag",
 					"TagTool - Held - an item with the Pontil Rod tag",
-					"TagTool - InRoom - an item with the Annealing Lehr tag"
+					"TagTool - InRoom - an item with the Lit Annealing Lehr tag"
 				],
 				[
 					$"CommodityProduct - {FormatCommodityAmount(850.0)} of {material} commodity; tag Glass Vessel Blank; characteristic Colour from $i1; characteristic Fine Colour from $i1"
@@ -422,6 +422,7 @@ public partial class ItemSeeder
 				[
 					"TagTool - Held - an item with the Crucible tag",
 					"TagTool - Held - an item with the Crucible Tongs tag",
+					"TagTool - InRoom - an item with the Lit Smelting Furnace tag",
 					"TagTool - InRoom - an item with the Vessel Casting Mould tag"
 				],
 				[$"CommodityProduct - {FormatCommodityAmount(1000.0)} of {material} commodity; tag Cast Vessel Blank"]);
@@ -886,7 +887,7 @@ public partial class ItemSeeder
 		[
 			"TagTool - InRoom - an item with the Potter's Wheel tag",
 			"TagTool - Held - an item with the Potter's Rib tag",
-			"TagTool - InRoom - an item with the Kiln tag"
+			"TagTool - InRoom - an item with the Lit Kiln tag"
 		]);
 
 	private static AntiquityHouseholdCraftPath GlassPath() => new(
@@ -895,7 +896,7 @@ public partial class ItemSeeder
 		[
 			"TagTool - Held - an item with the Blowpipe tag",
 			"TagTool - Held - an item with the Pontil Rod tag",
-			"TagTool - InRoom - an item with the Annealing Lehr tag"
+			"TagTool - InRoom - an item with the Lit Annealing Lehr tag"
 		]);
 
 	private static AntiquityHouseholdCraftPath MetalPath(string material) => new(
@@ -911,6 +912,7 @@ public partial class ItemSeeder
 		[
 			"TagTool - Held - an item with the Crucible tag",
 			"TagTool - Held - an item with the Crucible Tongs tag",
+			"TagTool - InRoom - an item with the Lit Smelting Furnace tag",
 			"TagTool - Held - an item with the Bronze Burnisher tag"
 		]);
 

--- a/DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityMedical.cs
+++ b/DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityMedical.cs
@@ -104,7 +104,8 @@ public partial class ItemSeeder
 			],
 			[
 				"TagTool - Held - an item with the Shears tag",
-				"TagTool - InRoom - an item with the Cooking Pot tag"
+				"TagTool - InRoom - an item with the Cooking Pot tag",
+				"TagTool - InRoom - an item with the Fire tag"
 			],
 			[$"CommodityProduct - {FormatCommodityAmount(720.0)} of linen commodity; tag Dressing Stock; characteristic Colour from $i1; characteristic Fine Colour from $i1"]);
 
@@ -140,6 +141,7 @@ public partial class ItemSeeder
 			],
 			[
 				"TagTool - InRoom - an item with the Cooking Pot tag",
+				"TagTool - InRoom - an item with the Fire tag",
 				"TagTool - Held - an item with the Ointment Spatula tag"
 			],
 			[$"CommodityProduct - {FormatCommodityAmount(430.0)} of resin commodity; tag Salve Stock"]);
@@ -159,6 +161,7 @@ public partial class ItemSeeder
 			],
 			[
 				"TagTool - InRoom - an item with the Cooking Pot tag",
+				"TagTool - InRoom - an item with the Fire tag",
 				"TagTool - Held - an item with the Medicine Strainer tag"
 			],
 			[$"CommodityProduct - {FormatCommodityAmount(320.0)} of herb commodity; tag Decoction Stock"]);
@@ -520,7 +523,7 @@ public partial class ItemSeeder
 	{
 		return
 		[
-			"TagTool - InRoom - an item with the Hot Fire tag",
+			"TagTool - InRoom - an item with the Lit Smelting Furnace tag",
 			"TagTool - InRoom - an item with the Anvil tag",
 			"TagTool - Held - an item with the Hammer tag",
 			"TagTool - Held - an item with the Forge Tongs tag"

--- a/DatabaseSeeder/Seeders/UsefulSeeder.Tags.cs
+++ b/DatabaseSeeder/Seeders/UsefulSeeder.Tags.cs
@@ -616,6 +616,7 @@ namespace DatabaseSeeder.Seeders
             AddTag(context, "Punty Paddle", "Glassblowing Tools");
             AddTag(context, "Glory Hole", "Glassblowing Tools");
             AddTag(context, "Annealing Lehr", "Glassblowing Tools");
+            AddTag(context, "Lit Annealing Lehr", "Annealing Lehr");
 
             // Locksmithing
             AddTag(context, "Locksmithing Tools", "Tools");
@@ -750,10 +751,12 @@ namespace DatabaseSeeder.Seeders
             AddTag(context, "Extruder", "Pottery Tools");
             AddTag(context, "Slab Roller", "Pottery Tools");
             AddTag(context, "Kiln", "Pottery Tools");
+            AddTag(context, "Lit Kiln", "Kiln");
 
             // Smelting
             AddTag(context, "Smelting Tools", "Tools");
             AddTag(context, "Smelting Furnace", "Smelting Tools");
+            AddTag(context, "Lit Smelting Furnace", "Smelting Furnace");
             AddTag(context, "Crucible Tongs", "Smelting Tools");
             AddTag(context, "Slag Skimmer", "Smelting Tools");
             AddTag(context, "Furnace Bellows", "Smelting Tools");

--- a/Design Documents/Crafting/Antiquity_Crafting_Audit.md
+++ b/Design Documents/Crafting/Antiquity_Crafting_Audit.md
@@ -1,0 +1,49 @@
+# Antiquity Crafting Catalogue Audit
+
+This document records the source-backed audit boundary for the current antiquity item and craft suite. It is a catalogue guide, not a replacement for the suite-specific implementation documents.
+
+## Source Boundary
+
+Current item definitions are seeded from:
+
+| Source | Current Item Definitions |
+| --- | ---: |
+| `DatabaseSeeder/Seeders/ItemSeeder.Rework.Antiquity.cs` | 995 |
+| `DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityHouseholdTools.cs` | 63 |
+| `DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityMedical.cs` | 41 |
+| `DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityWriting.cs` | 33 |
+| Total | 1132 |
+
+Current craft definitions are seeded from:
+
+| Source | Craft Surface |
+| --- | --- |
+| `ItemSeederCrafting.Antiquity.cs` | Textile, leather, and older shared antiquity craft chains. |
+| `ItemSeederCrafting.AntiquityEquipment.cs` | Common clothing/accessories, equipment stock, military goods, and heat-source lighting crafts. |
+| `ItemSeederCrafting.AntiquityHousehold.cs` | Household, container, vessel, door, gate, and furnishing craft discovery. |
+| `ItemSeederCrafting.AntiquityMedical.cs` | Medical supplies, remedies, surgical tools, mobility aids, and prosthetics. |
+| `ItemSeederCrafting.AntiquityWriting.cs` | Writing surfaces, implements, inks, scrolls, codices, and document containers. |
+
+The suite-specific docs now catalogue every stable reference explicitly named by those craft source files. Dynamic discovery surfaces are documented by their source counts and inventory lists:
+
+- 398 household/container/door/furniture targets discovered from household, writing, religious, lighting, heating, construction, and writing-product tag roots.
+- 193 military equipment targets discovered from `Market / Military Goods`, split into 76 armour prototypes and 117 weapon, shield, ammunition, sling, and accessory prototypes.
+- 356 stable references explicitly named in the current antiquity craft source files.
+
+## Verified Invariants
+
+- Every current antiquity `TagTool` requirement has at least one seeded item prototype carrying the exact leaf tool tag.
+- Every explicit stable reference in `ItemSeederCrafting.Antiquity*.cs` is listed in the antiquity crafting docs.
+- Lit workshop items have morph targets, morph timers, and their expected lit-state tags.
+- Heat-source lighting crafts consume `charcoal`, produce the lit apparatus, and return the unlit apparatus on failure.
+- Literal commodity product tags are either consumed downstream or documented as reusable stock outputs.
+- Low-heat medical recipes that boil, warm, or steep in a cooking pot now also require an in-room `Fire` tool, so they use the lit workshop hearth convention.
+
+## Remaining Logical Gaps
+
+The current audit leaves these as deliberate follow-up gaps rather than hidden assumptions:
+
+- `SeedAntiquityJewellery` currently contains 162 item prototypes in the main antiquity item source, but there is no dedicated jewellery craft file or per-reference jewellery crafting catalogue. Existing tests treat jewellery as an older covered surface; the next audit should either add jewellery crafts or explicitly mark jewellery as stock-only.
+- Newly introduced support tools and unlit workshop apparatus are seeded prerequisites. Crafts to manufacture those tools and apparatus remain the second-pass boundary unless they already belong to an existing product suite.
+- Glassworking currently uses `Glass Batch`, blowing tools, and the lit annealing lehr as the current craftable glass chain. A dedicated glass furnace or glory-hole style apparatus would be a better simulation if glasswork needs to move beyond this abstraction.
+- The craft system still relies on commodity tags and item stable references rather than a generated external catalogue. The tests now protect the docs from drifting away from the current source, but the docs are maintained rather than generated.

--- a/Design Documents/Crafting/Antiquity_Equipment_Crafting_Suite.md
+++ b/Design Documents/Crafting/Antiquity_Equipment_Crafting_Suite.md
@@ -19,10 +19,32 @@ The implementation lives in `DatabaseSeeder/Seeders/ItemSeederCrafting.Antiquity
 The suite follows the same stock pattern as the textile, leather, jewellery, and household work:
 
 - Shared upstream commodity crafts run first.
+- Reusable workshop heat-source crafts run before stock crafts. They consume an unlit apparatus and `charcoal`, produce the lit apparatus, and rely on the lit item's morph timer to cool back to the unlit prototype.
 - Final crafts produce the exact seeded prototype by ID and short description.
 - Variable products copy colour characteristics from commodity inputs where the item has variable colour components.
 - Craft names and visible echoes are generated from sanitised short descriptions, not stable references, so visible craft text remains culture-neutral.
 - Knowledge-gated `AddCraft` overloads are used for both upstream and final crafts.
+
+## One-Step-Back Heat And Tool Audit
+
+The May 2026 one-step-back pass audits the full `ItemSeederCrafting.Antiquity*.cs` source set, not only the clothing/equipment anchor file. The audit boundary is:
+
+- every current `TagTool` requirement in the antiquity craft suite
+- every literal commodity product tag produced by an antiquity craft
+- every literal commodity input pile tag that should be produced upstream or intentionally remain a reusable stock output
+
+The seeded tool closure now includes the previously missing heat and metal tools (`Fire`, `Bellows`, `Forge Tongs`, `Anvil`, `Hammer`, `Pliers`, `Cooking Pot`, `Sharpening`, and lit high-heat apparatus), dye/textile/leather tools (`Dye Strainer`, `Indigo Beating Paddle`, `Leather Paring Knife`, `Rope Hook`, `Twine Shuttle`), writing/book/pigment tools, and medical preparation tools. These are seeded as stock prerequisites; crafts to manufacture newly introduced support tools are the explicit second-pass boundary unless a support item already belongs to a current craft-product suite.
+
+Lit workshop objects are craft-tool state markers, not runtime heat/light components. Current stock pairs are:
+
+| Unlit item | Lit item | Lit tool tags |
+| --- | --- | --- |
+| `antiquity_workshop_hearth` | `antiquity_lit_workshop_hearth` | `Fire` |
+| `antiquity_clay_smelting_furnace` | `antiquity_lit_clay_smelting_furnace` | `Lit Smelting Furnace`, `Hot Fire` |
+| `antiquity_updraft_kiln` | `antiquity_lit_updraft_kiln` | `Lit Kiln`, `Hot Fire` |
+| `antiquity_annealing_lehr` | `antiquity_lit_annealing_lehr` | `Lit Annealing Lehr`, `Hot Fire` |
+
+Reusable intermediate outputs that are intentionally allowed to sit at a stock boundary are: `Armour Lamella Stock`, `Armour Plate Stock`, `Armour Ring Stock`, `Armour Scale Stock`, `Bisque Vessel Blank`, `Bookbinding Stock`, `Bow Stave`, `Carved Wood Stock`, `Coopered Staves`, `Decoction Stock`, `Door Hardware Stock`, `Dyed Cloth`, `Fulled Cloth`, `Glass Batch`, `Glass Vessel Blank`, `Helmet Bowl Stock`, `Herbal Remedy Stock`, `Ink Stock`, `Lake Pigment`, `Leather Scale`, `Paint Pigment`, `Papyrus Sheet Stock`, `Pen Blank`, `Prosthetic Stock`, `Sealed Leather Panel`, `Shield Board Stock`, `Shield Facing Stock`, `Splint Stock`, `Stone Vessel Blank`, `Surgical Tool Blank`, `Suture Stock`, `Tablet Blank`, `Waxed Tablet Board`, `Weapon Blade Stock`, `Weapon Head Stock`, `Weapon Shaft Stock`, `Wet Vessel Blank`, and `Woven Cloth`.
 
 ## Knowledge Gates
 
@@ -57,6 +79,84 @@ All equipment stock tags are seeded under `Functions / Material Functions / Anti
 | `Tool Blank Stock` | Reusable metal, wooden, textile, or leather stock for craft tools. |
 | `Door Hardware Stock` | Hinges, straps, latch plates, bars, and fittings for doors and gates. |
 
+## Source-Audited Product Catalogue
+
+The equipment suite has two product surfaces. The military surface is discovered dynamically from `Market / Military Goods` tags, while common clothing and craft-tool products are explicitly named in `ItemSeederCrafting.AntiquityEquipment.cs`.
+
+### Armour
+
+`antiquity_celtic_peaked_bronze_helmet`, `antiquity_celtic_crested_bronze_helmet`, `antiquity_celtic_riveted_iron_mail_shirt`, `antiquity_celtic_fine_riveted_mail_shirt`, `antiquity_germanic_iron_banded_helmet`, `antiquity_germanic_decorated_spangenhelm`, `antiquity_germanic_iron_mail_coat`, `antiquity_germanic_padded_wool_undercoat`, `antiquity_etruscan_cheek_guarded_bronze_helmet`, `antiquity_etruscan_anatomical_bronze_cuirass`, `antiquity_etruscan_bronze_left_greave`, `antiquity_etruscan_pair_bronze_greaves`, `antiquity_etruscan_round_bronze_pectoral`, `antiquity_etruscan_silver_inlaid_bronze_cuirass`, `antiquity_roman_montefortino_bronze_helmet`, `antiquity_roman_crested_montefortino_helmet`, `antiquity_roman_coolus_bronze_helmet`, `antiquity_roman_imperial_gallic_iron_helmet`, `antiquity_roman_plumed_iron_officer_helmet`, `antiquity_roman_intercisa_iron_ridge_helmet`, `antiquity_roman_bronze_pectoral_plate`, `antiquity_roman_triple_disc_bronze_cuirass`, `antiquity_roman_lorica_hamata_mail_shirt`, `antiquity_roman_lorica_hamata_fine_mail_shirt`, `antiquity_roman_lorica_squamata_scale_cuirass`, `antiquity_roman_lorica_squamata_gilded_cuirass`, `antiquity_roman_lorica_segmentata_banded_cuirass`, `antiquity_roman_padded_subarmalis`, `antiquity_roman_fine_padded_subarmalis`, `antiquity_roman_bronze_greaves`, `antiquity_roman_segmented_iron_armguard`, `antiquity_roman_late_mail_coat`, `antiquity_roman_late_scale_coat`, `antiquity_roman_bronze_muscle_cuirass`, `antiquity_hellenic_corinthian_bronze_helmet`, `antiquity_hellenic_crested_bronze_helmet`, `antiquity_hellenic_bronze_bell_cuirass`, `antiquity_hellenic_bronze_muscle_cuirass`, `antiquity_hellenic_linen_linothorax`, `antiquity_hellenic_fine_painted_linothorax`, `antiquity_hellenic_bronze_greaves`, `antiquity_hellenic_bronze_vambraces`, `antiquity_punic_conical_bronze_helmet`, `antiquity_punic_crested_bronze_helmet`, `antiquity_punic_linen_tube_cuirass`, `antiquity_punic_fine_painted_cuirass`, `antiquity_punic_iron_mail_cuirass`, `antiquity_punic_gilded_scale_cuirass`, `antiquity_punic_bronze_greaves`, `antiquity_persian_iron_scale_corselet`, `antiquity_persian_bronze_scale_corselet`, `antiquity_persian_padded_riding_coat`, `antiquity_persian_iron_helmet_with_aventail`, `antiquity_persian_felt_armoured_kyrbasia`, `antiquity_persian_lamellar_vambraces`, `antiquity_persian_lamellar_greaves`, `antiquity_egyptian_padded_linen_war_cap`, `antiquity_egyptian_blue_war_crown_cap`, `antiquity_egyptian_linen_corselet`, `antiquity_egyptian_bronze_scale_cuirass`, `antiquity_anatolian_forward_curved_bronze_helmet`, `antiquity_anatolian_ionian_bronze_helmet`, `antiquity_anatolian_bronze_chest_cuirass`, `antiquity_anatolian_linen_arrow_cuirass`, `antiquity_anatolian_bronze_greaves`, `antiquity_anatolian_fine_winged_bronze_helmet`, `antiquity_anatolian_fine_painted_linen_cuirass`, `antiquity_scythian_felt_padded_cap`, `antiquity_sarmatian_iron_scale_cuirass`, `antiquity_sarmatian_lamellar_cuirass`, `antiquity_sarmatian_iron_laminar_armguards`, `antiquity_sarmatian_lamellar_greaves`, `antiquity_sarmatian_mail_aventail_helmet`, `antiquity_kushite_padded_linen_archer_cap`, `antiquity_kushite_reinforced_linen_corselet`, `antiquity_kushite_bronze_scale_royal_cuirass`
+
+### Weapons, Shields, and Ammunition
+
+Arrows: `antiquity_ammo_common_field_point_arrow`, `antiquity_ammo_common_broadhead_arrow`, `antiquity_ammo_common_target_arrow`, `antiquity_ammo_persian_reed_arrow`, `antiquity_ammo_egyptian_reed_arrow`, `antiquity_ammo_scythian_barbed_arrow`, `antiquity_ammo_kushite_cane_arrow`, `antiquity_ammo_kushite_barbed_arrow`
+
+Axes: `antiquity_weapon_celtic_iron_war_axe`, `antiquity_weapon_germanic_throwing_axe`, `antiquity_weapon_roman_dolabra`, `antiquity_weapon_persian_sagaris_axe`, `antiquity_weapon_egyptian_bronze_war_axe`, `antiquity_weapon_anatolian_crescent_axe`, `antiquity_weapon_scythian_sagaris`, `antiquity_weapon_kushite_hand_axe`
+
+Bolts and bullets: `antiquity_ammo_common_field_point_bolt`, `antiquity_ammo_common_broadhead_bolt`, `antiquity_ammo_common_stone_sling_bullet`, `antiquity_ammo_common_lead_sling_bullet`
+
+Bows and crossbows: `antiquity_weapon_common_short_self_bow`, `antiquity_weapon_roman_composite_bow`, `antiquity_weapon_hellenic_short_war_bow`, `antiquity_weapon_punic_composite_bow`, `antiquity_weapon_persian_composite_bow`, `antiquity_weapon_egyptian_simple_self_bow`, `antiquity_weapon_egyptian_composite_bow`, `antiquity_weapon_anatolian_composite_bow`, `antiquity_weapon_scythian_composite_bow`, `antiquity_weapon_kushite_long_self_bow`, `antiquity_weapon_kushite_compact_bow`, `antiquity_weapon_hellenic_belly_drawn_bow`
+
+Daggers, swords, and knives: `antiquity_weapon_common_bronze_utility_knife`, `antiquity_weapon_common_iron_utility_knife`, `antiquity_weapon_common_bronze_dagger`, `antiquity_weapon_common_iron_dagger`, `antiquity_weapon_roman_pugio_dagger`, `antiquity_weapon_etruscan_bronze_dagger`, `antiquity_weapon_anatolian_long_dagger`, `antiquity_weapon_kushite_iron_dagger`, `antiquity_weapon_celtic_long_iron_slashing_sword`, `antiquity_weapon_celtic_fine_long_iron_sword`, `antiquity_weapon_germanic_broad_seax`, `antiquity_weapon_germanic_long_war_sword`, `antiquity_weapon_roman_republican_gladius`, `antiquity_weapon_roman_mainz_gladius`, `antiquity_weapon_roman_pompeii_gladius`, `antiquity_weapon_roman_late_spatha`, `antiquity_weapon_hellenic_xiphos`, `antiquity_weapon_hellenic_kopis`, `antiquity_weapon_punic_short_straight_sword`, `antiquity_weapon_punic_curved_mercenary_sword`, `antiquity_weapon_persian_akinakes`, `antiquity_weapon_egyptian_khopesh`, `antiquity_weapon_etruscan_short_sword`, `antiquity_weapon_etruscan_curved_sword`, `antiquity_weapon_anatolian_curved_short_sword`, `antiquity_weapon_scythian_akinakes`, `antiquity_weapon_kushite_short_sword`
+
+Maces, clubs, slings, and polearms: `antiquity_weapon_egyptian_stone_mace`, `antiquity_weapon_egyptian_bronze_mace`, `antiquity_weapon_common_hardwood_club`, `antiquity_weapon_common_hardwood_quarterstaff`, `antiquity_weapon_common_simple_sling`, `antiquity_weapon_common_staff_sling`, `antiquity_weapon_roman_weighted_plumbata`, `antiquity_weapon_punic_balearic_sling`, `antiquity_weapon_hellenic_sarissa_pike`
+
+Shields: `antiquity_shield_common_round_wooden_shield`, `antiquity_shield_common_wicker_shield`, `antiquity_shield_common_small_bossed_shield`, `antiquity_shield_celtic_long_oval_painted_shield`, `antiquity_shield_celtic_round_bossed_shield`, `antiquity_shield_germanic_round_linden_shield`, `antiquity_shield_germanic_painted_round_shield`, `antiquity_shield_roman_round_clipeus`, `antiquity_shield_roman_republican_oval_scutum`, `antiquity_shield_roman_curved_rectangular_scutum`, `antiquity_shield_roman_auxiliary_oval_shield`, `antiquity_shield_roman_parma`, `antiquity_shield_roman_late_oval_shield`, `antiquity_shield_hellenic_aspis`, `antiquity_shield_hellenic_pelta`, `antiquity_shield_hellenic_thureos`, `antiquity_shield_punic_oval_infantry_shield`, `antiquity_shield_punic_wicker_light_shield`, `antiquity_shield_persian_wicker_spara`, `antiquity_shield_egyptian_papyrus_shield`, `antiquity_shield_etruscan_round_bronze_shield`, `antiquity_shield_etruscan_large_aspis`, `antiquity_shield_anatolian_wicker_pelta`, `antiquity_shield_kushite_wicker_hide_shield`
+
+Spears and javelins: `antiquity_weapon_celtic_leaf_bladed_spear`, `antiquity_weapon_celtic_light_throwing_javelin`, `antiquity_weapon_germanic_framea_spear`, `antiquity_weapon_germanic_barbed_angon_javelin`, `antiquity_weapon_roman_early_hasta_spear`, `antiquity_weapon_roman_verutum_javelin`, `antiquity_weapon_roman_heavy_pilum`, `antiquity_weapon_roman_contus_lance`, `antiquity_weapon_hellenic_dory_spear`, `antiquity_weapon_hellenic_light_javelin`, `antiquity_weapon_punic_socketed_infantry_spear`, `antiquity_weapon_punic_light_javelin`, `antiquity_weapon_punic_heavy_iron_javelin`, `antiquity_weapon_persian_long_spear`, `antiquity_weapon_persian_light_javelin`, `antiquity_weapon_egyptian_short_spear`, `antiquity_weapon_egyptian_light_javelin`, `antiquity_weapon_etruscan_bronze_tipped_spear`, `antiquity_weapon_etruscan_light_javelin`, `antiquity_weapon_anatolian_bronze_spear`, `antiquity_weapon_anatolian_light_javelin`, `antiquity_weapon_sarmatian_kontos_lance`, `antiquity_weapon_scythian_light_javelin`, `antiquity_weapon_kushite_iron_spear`, `antiquity_weapon_kushite_light_javelin`
+
+### Explicit Common Clothing and Tool Products
+
+| Stable Reference | Source Catalogue Name |
+| --- | --- |
+| `antiquity_bronze_awl_punch` | a bronze awl punch |
+| `antiquity_bronze_dehairing_knife` | a bronze dehairing knife |
+| `antiquity_bronze_edge_beveller` | a bronze leather edge beveller |
+| `antiquity_bronze_hide_scraper` | a bronze hide scraper |
+| `antiquity_bronze_leather_creaser` | a bronze leather creaser |
+| `antiquity_bronze_leather_gouge` | a bronze leather gouge |
+| `antiquity_bronze_leather_wax_pot` | a bronze leather wax pot |
+| `antiquity_bronze_sewing_needle` | a bronze sewing needle |
+| `antiquity_bronze_textile_shears` | a pair of bronze textile shears |
+| `antiquity_clay_loom_weight` | a clay loom weight |
+| `antiquity_conical_felt_cap` | a conical felt cap |
+| `antiquity_distaff` | an oak distaff |
+| `antiquity_drop_spindle` | a wooden drop spindle with a clay whorl |
+| `antiquity_dye_vat` | an earthenware dye vat |
+| `antiquity_fibre_hackle` | a bronze-toothed fibre hackle |
+| `antiquity_fine_conical_felt_cap` | a fine conical cap |
+| `antiquity_fine_front_knotted_girdle` | a fine knotted girdle |
+| `antiquity_fine_linen_headcloth` | a fine headcloth |
+| `antiquity_fine_linen_shoulder_shawl` | a fine linen shawl |
+| `antiquity_fine_papyrus_sandals` | a pair of fine papyrus sandals |
+| `antiquity_fine_woven_sash` | a fine sash |
+| `antiquity_flax_break` | an oak flax break |
+| `antiquity_fluted_felt_hat` | a fluted felt hat |
+| `antiquity_front_knotted_girdle` | a front-knotted girdle |
+| `antiquity_fullers_mallet` | an oak fuller's mallet |
+| `antiquity_fullers_trough` | an oak fuller's trough |
+| `antiquity_glass_usekh_collar` | a glass usekh collar |
+| `antiquity_linen_breastband` | a linen breastband |
+| `antiquity_linen_loincloth` | a linen loincloth |
+| `antiquity_linen_shoulder_shawl` | a linen shawl |
+| `antiquity_mordant_cauldron` | a bronze mordant cauldron |
+| `antiquity_oak_brain_tanning_bucket` | an oak brain-tanning bucket |
+| `antiquity_oak_shoe_last` | an oak shoe last |
+| `antiquity_oak_stitching_pony` | an oak leather stitching clamp |
+| `antiquity_oak_tanning_beam` | an oak tanning beam |
+| `antiquity_oak_tanning_paddle` | an oak tanning paddle |
+| `antiquity_oak_tanning_rack` | an oak tanning rack |
+| `antiquity_papyrus_sandals` | a pair of papyrus sandals |
+| `antiquity_retting_trough` | an oak retting trough |
+| `antiquity_rounded_felt_cap` | a rounded felt cap |
+| `antiquity_simple_woven_sash` | a woven sash |
+| `antiquity_tall_kyrbasia` | a tall kyrbasia |
+| `antiquity_tenter_frame` | an oak cloth tenter frame |
+| `antiquity_warp_weighted_loom` | an oak warp-weighted loom |
+| `antiquity_weavers_sword` | an oak weaver's sword |
+| `antiquity_weaving_shuttle` | an oak weaving shuttle |
+| `antiquity_wrapped_linen_headcloth` | a linen headcloth |
+
 ## Verification
 
-`ItemSeederAntiquityRemainingCraftingTests` parses `ItemSeeder.Rework.Antiquity.cs`, applies the same coverage rules as the seeder, and fails if a current prototype is not covered by either an existing suite or the new equipment/expanded household pass. It also asserts upstream commodity tags, knowledge-gated registration, culture-neutral visible string construction, and the corrected fresh-install `HasWeaponcrafting` / `HasArmourcrafting` source definitions.
+`ItemSeederAntiquityRemainingCraftingTests` parses `ItemSeeder.Rework.Antiquity.cs`, applies the same coverage rules as the seeder, and fails if a current prototype is not covered by either an existing suite or the new equipment/expanded household pass. It also asserts upstream commodity tags, full antiquity `TagTool` item coverage, lit workshop morph metadata, reusable intermediate documentation, knowledge-gated registration, culture-neutral visible string construction, and the corrected fresh-install `HasWeaponcrafting` / `HasArmourcrafting` source definitions.

--- a/Design Documents/Crafting/Antiquity_Furniture_Container_Crafting_Suite.md
+++ b/Design Documents/Crafting/Antiquity_Furniture_Container_Crafting_Suite.md
@@ -156,53 +156,73 @@ Add the following tool tags if they do not already exist:
 
 ## Tool Prototypes
 
-The following full item tool prototypes should be seeded before the craft suite. Names are suggested stable references; exact descriptions can follow the style already used for textile tools.
+The household-tool source now owns the shared antiquity workshop tool catalogue for household, equipment, textile, leather, heat, and metal-adjacent crafts. The table below lists the exact leaf tool tags seeded on each prototype; parent tags are implied by the seeded tag hierarchy rather than repeated here.
 
-| Stable Reference | Tags | Used By |
+| Stable Reference | Exact Seeded Tool Tags | Source Catalogue Name |
 | --- | --- | --- |
-| `antiquity_bronze_hand_saw` | `Hand Saw`, `Saws`, `Woodcrafting Tools` | Plank cutting, furniture, shelving, boxes. |
-| `antiquity_bronze_adze` | `Adze`, `Woodcrafting Tools` | Shaping boards, bowls, planks, furniture frames. |
-| `antiquity_bronze_wood_chisel` | `Wood Chisel`, `Chisel`, `Woodcrafting Tools` | Joinery, carving, inlay recesses. |
-| `antiquity_bronze_wood_auger` | `Wood Auger`, `Woodcrafting Tools` | Peg holes, dowel holes, coopering bungs. |
-| `antiquity_wooden_smoothing_plane` | `Planer`, `Woodcrafting Tools` | Dressed timber and finished furniture surfaces. |
-| `antiquity_wooden_joinery_clamp` | `Wood Clamp`, `Clamp`, `Woodcrafting Tools` | Panel glue-ups, cases, doors, furniture frames. |
-| `antiquity_bow_drill` | `Bow Drill`, `Woodcrafting Tools`, `Stoneworking Tools` | Fine boring in wood, bone, horn, stone, and inlay. |
-| `antiquity_wood_rasp` | `Rasp`, `Wood File`, `Woodcrafting Tools` | Carving, shaping, smoothing. |
-| `antiquity_coopers_adze` | `Cooper's Adze`, `Coopering Tools` | Staves and casks. |
-| `antiquity_coopers_croze` | `Croze`, `Coopering Tools` | Barrel head grooves. |
-| `antiquity_hoop_driver` | `Hoop Driver`, `Coopering Tools` | Driving hoops onto casks/barrels. |
-| `antiquity_bung_borer` | `Bung Borer`, `Coopering Tools` | Wet casks and liquid barrels. |
-| `antiquity_basket_knife` | `Basket Knife`, `Basketry Tools` | Basketry splints and plaiting. |
-| `antiquity_reed_splitter` | `Reed Splitter`, `Basketry Tools` | Reed/papyrus/willow stock preparation. |
-| `antiquity_weaving_bodkin` | `Weaving Bodkin`, `Basketry Tools` | Tight basket and reed mat weaving. |
-| `antiquity_packing_bone` | `Packing Bone`, `Basketry Tools` | Packing woven rows tight. |
-| `antiquity_leather_awl_punch` | `Awl Punch`, `Leatherworking Tools` | Pouches, skins, cases, strap holes. |
-| `antiquity_leather_stitching_pony` | `Leather Stitching Pony`, `Leatherworking Tools` | Sewn leather goods. |
-| `antiquity_leather_edge_beveller` | `Edge Beveller`, `Leatherworking Tools` | Finished leather edges. |
-| `antiquity_slow_potters_wheel` | `Potter's Wheel`, `Pottery Tools` | Cups, bowls, jars, amphorae. |
-| `antiquity_clay_knife` | `Clay Knife`, `Pottery Tools` | Cutting clay bodies and vessels. |
-| `antiquity_potters_rib` | `Potter's Rib`, `Pottery Tools` | Smoothing vessel walls. |
-| `antiquity_loop_tool` | `Loop Tool`, `Pottery Tools` | Trimming feet, rims, and reliefs. |
-| `antiquity_wire_cutter` | `Wire Cutter`, `Pottery Tools` | Cutting vessels from wheel and clay blocks. |
-| `antiquity_clay_stamp` | `Clay Stamp`, `Pottery Tools` | Moulded or stamped decoration. |
-| `antiquity_updraft_kiln` | `Kiln`, `Pottery Tools`, `Hot Fire` | Firing clay, terracotta, ceramic, and glass-adjacent work. |
-| `antiquity_glass_blowpipe` | `Blowpipe`, `Glassblowing Tools` | Blown glass vessels. |
-| `antiquity_pontil_rod` | `Pontil Rod`, `Glassblowing Tools` | Glass finishing. |
-| `antiquity_marver_slab` | `Marver Table`, `Glassblowing Tools` | Shaping hot glass. |
-| `antiquity_glassworking_jacks` | `Jacks`, `Glassblowing Tools` | Glass mouths, necks, and feet. |
-| `antiquity_glass_shears` | `Glass Shears`, `Glassblowing Tools` | Cutting hot glass. |
-| `antiquity_annealing_lehr` | `Annealing Lehr`, `Glassblowing Tools` | Cooling glass vessels and panes. |
-| `antiquity_casting_crucible` | `Crucible`, `Metalworking Tools`, `Smelting Tools` | Bronze/silver/gold casting. |
-| `antiquity_crucible_tongs` | `Crucible Tongs`, `Smelting Tools` | Handling hot crucibles. |
-| `antiquity_vessel_casting_mould` | `Casting Mould`, `Metalworking Tools` | Cast vessel and lamp blanks. |
-| `antiquity_bronze_burnisher` | `Burnisher`, `Engraving Tools` | Polishing metal and stone surfaces. |
-| `antiquity_stone_chisel` | `Stone Chisel`, `Stoneworking Tools` | Alabaster, calcite, stone bowl shaping. |
-| `antiquity_stone_mallet` | `Stone Mallet`, `Stoneworking Tools` | Stone carving. |
-| `antiquity_polishing_stone` | `Lacquer Polishing Stone`, `Stoneworking Tools` | Lacquer, stone, and fine finish polishing. |
-| `antiquity_candle_mould` | `Candle Mould`, `Candlemaking Tools` | Moulded beeswax candles. |
-| `antiquity_lamp_mould` | `Press Mold`, `Pottery Tools` | Moulded clay lamps. |
-| `antiquity_lacquer_brush` | `Lacquerer's Brush`, `Lacquerwork Tools` | Painted/lacquered boxes and furniture. |
-| `antiquity_lacquer_spatula` | `Lacquer Spatula`, `Lacquerwork Tools` | Lacquer application. |
+| `antiquity_bronze_hand_saw` | `Hand Saw` | a bronze hand saw |
+| `antiquity_bronze_adze` | `Adze` | a bronze woodworking adze |
+| `antiquity_bronze_wood_chisel` | `Wood Chisel` | a bronze wood chisel |
+| `antiquity_bronze_workshop_chisel` | `Chisel` | a bronze workshop chisel |
+| `antiquity_bronze_workshop_hammer` | `Hammer`, `Forge Hammer` | a bronze workshop hammer |
+| `antiquity_bronze_workshop_pliers` | `Pliers` | a pair of bronze workshop pliers |
+| `antiquity_bronze_plaster_trowel` | `Trowel` | a bronze finishing trowel |
+| `antiquity_sharpening_whetstone` | `Sharpening` | a grooved sharpening whetstone |
+| `antiquity_bronze_wood_auger` | `Wood Auger` | a bronze wood auger |
+| `antiquity_wooden_smoothing_plane` | `Planer` | a wooden smoothing plane with a bronze iron |
+| `antiquity_wooden_joinery_clamp` | `Wood Clamp` | a wooden joinery clamp |
+| `antiquity_bow_drill` | `Bow Drill` | a bow drill with a bronze bit |
+| `antiquity_wood_rasp` | `Rasp` | a bronze-toothed wood rasp |
+| `antiquity_coopers_adze` | `Cooper's Adze` | a cooper's bronze adze |
+| `antiquity_coopers_croze` | `Croze` | a cooper's croze |
+| `antiquity_hoop_driver` | `Hoop Driver` | a wooden hoop driver |
+| `antiquity_bung_borer` | `Bung Borer` | a bronze bung borer |
+| `antiquity_basket_knife` | `Basket Knife` | a bronze basket knife |
+| `antiquity_reed_splitter` | `Reed Splitter` | a bronze reed splitter |
+| `antiquity_weaving_bodkin` | `Weaving Bodkin` | a bronze weaving bodkin |
+| `antiquity_packing_bone` | `Packing Bone` | a polished packing bone |
+| `antiquity_linen_dye_strainer` | `Dye Strainer` | a linen dye strainer |
+| `antiquity_indigo_beating_paddle` | `Indigo Beating Paddle` | an indigo beating paddle |
+| `antiquity_rope_hook_bar` | `Rope Hook` | a bronze rope hook |
+| `antiquity_twine_shuttle` | `Twine Shuttle` | a wooden twine shuttle |
+| `antiquity_leather_awl_punch` | `Awl Punch` | a bronze leather awl punch |
+| `antiquity_leather_stitching_pony` | `Leather Stitching Pony` | a wooden leather stitching pony |
+| `antiquity_leather_edge_beveller` | `Edge Beveller` | a bronze leather edge beveller |
+| `antiquity_bronze_leather_paring_knife` | `Leather Paring Knife` | a bronze leather paring knife |
+| `antiquity_slow_potters_wheel` | `Potter's Wheel` | a slow wooden potter's wheel |
+| `antiquity_workshop_hearth` | None; unlit apparatus only | an unlit clay workshop hearth |
+| `antiquity_lit_workshop_hearth` | `Fire` | a lit clay workshop hearth |
+| `antiquity_clay_knife` | `Clay Knife` | a bronze clay knife |
+| `antiquity_potters_rib` | `Potter's Rib` | a wooden potter's rib |
+| `antiquity_loop_tool` | `Loop Tool` | a bronze loop tool |
+| `antiquity_wire_cutter` | `Wire Cutter` | a linen-cord clay wire cutter |
+| `antiquity_clay_stamp` | `Clay Stamp` | a carved clay stamp |
+| `antiquity_updraft_kiln` | `Kiln` | an updraft pottery kiln |
+| `antiquity_lit_updraft_kiln` | `Kiln`, `Lit Kiln`, `Hot Fire` | a lit updraft pottery kiln |
+| `antiquity_glass_blowpipe` | `Blowpipe` | a bronze glass blowpipe |
+| `antiquity_pontil_rod` | `Pontil Rod` | a bronze pontil rod |
+| `antiquity_marver_slab` | `Marver Table` | a stone marver slab |
+| `antiquity_glassworking_jacks` | `Jacks` | a pair of bronze glassworking jacks |
+| `antiquity_glass_shears` | `Glass Shears` | a pair of bronze glass shears |
+| `antiquity_annealing_lehr` | `Annealing Lehr` | a small annealing lehr |
+| `antiquity_lit_annealing_lehr` | `Annealing Lehr`, `Lit Annealing Lehr`, `Hot Fire` | a lit annealing lehr |
+| `antiquity_casting_crucible` | `Crucible` | a bronze casting crucible |
+| `antiquity_crucible_tongs` | `Crucible Tongs` | a pair of bronze crucible tongs |
+| `antiquity_clay_smelting_furnace` | `Smelting Furnace` | an unlit clay smelting furnace |
+| `antiquity_lit_clay_smelting_furnace` | `Smelting Furnace`, `Lit Smelting Furnace`, `Hot Fire` | a lit clay smelting furnace |
+| `antiquity_bronze_forge_tongs` | `Forge Tongs` | a pair of bronze forge tongs |
+| `antiquity_goatskin_bellows` | `Bellows`, `Furnace Bellows` | a goatskin workshop bellows |
+| `antiquity_bronze_anvil` | `Anvil` | a low bronze workshop anvil |
+| `antiquity_bronze_cooking_pot` | `Cooking Pot` | a bronze cooking pot |
+| `antiquity_vessel_casting_mould` | `Vessel Casting Mould` | a clay vessel casting mould |
+| `antiquity_bronze_burnisher` | `Bronze Burnisher` | a polished bronze burnisher |
+| `antiquity_stone_chisel` | `Stone Chisel` | a bronze stone chisel |
+| `antiquity_stone_mallet` | `Stone Mallet`, `Mallet` | a wooden stoneworking mallet |
+| `antiquity_polishing_stone` | `Polishing Stone` | a smooth polishing stone |
+| `antiquity_candle_mould` | `Candle Mould` | a clay candle mould |
+| `antiquity_lamp_mould` | `Lamp Mould` | a clay lamp mould |
+| `antiquity_lacquer_brush` | `Lacquerer's Brush` | a fine lacquerer's brush |
+| `antiquity_lacquer_spatula` | `Lacquer Spatula` | a wooden lacquer spatula |
 
 ## Shared Upstream Crafts
 
@@ -223,10 +243,10 @@ These are the upstream craft families to implement before final products. The ex
 | Prepare pitch stock | Ropemaking | Ancient Lighting and Heating | Resin/pitch commodity | Heating vessel, stirring tool | Commodity tagged `Prepared Pitch`. |
 | Prepare pottery clay body | Pottery | Ancient Ceramic Vesselmaking | Clay or earthenware commodity, water | Pug mill or hand tools | Commodity tagged `Pottery Clay Body`. |
 | Form wet vessel blanks | Pottery | Ancient Ceramic Vesselmaking | `Pottery Clay Body` | Potter's wheel, rib, clay knife | Commodity tagged `Wet Vessel Blank`. |
-| Fire bisque vessel blanks | Pottery | Ancient Ceramic Vesselmaking | `Wet Vessel Blank`, fuel | Kiln | Commodity tagged `Bisque Vessel Blank`. |
+| Fire bisque vessel blanks | Pottery | Ancient Ceramic Vesselmaking | `Wet Vessel Blank`, fuel | Lit kiln | Commodity tagged `Bisque Vessel Blank`. |
 | Prepare glass batch | Glassworking | Ancient Glassworking | Soda-lime glass inputs or glass commodity | Crucible, kiln/glory heat | Commodity tagged `Glass Batch`. |
-| Blow glass vessel blanks | Glassworking | Ancient Glassworking | `Glass Batch` | Blowpipe, pontil, marver, jacks, annealing lehr | Commodity tagged `Glass Vessel Blank`. |
-| Cast vessel blanks | Blacksmithing or Silversmithing | Ancient Metal Vesselmaking | Bronze, iron, silver, or gold commodity | Crucible, tongs, mould, hot fire | Commodity tagged `Cast Vessel Blank`. |
+| Blow glass vessel blanks | Glassworking | Ancient Glassworking | `Glass Batch` | Blowpipe, pontil, marver, jacks, lit annealing lehr | Commodity tagged `Glass Vessel Blank`. |
+| Cast vessel blanks | Blacksmithing or Silversmithing | Ancient Metal Vesselmaking | Bronze, iron, silver, or gold commodity | Crucible, tongs, mould, lit smelting furnace | Commodity tagged `Cast Vessel Blank`. |
 | Carve stone vessel blanks | Masonry or Scrimshawing | Ancient Stone Bone and Horn Carving | Alabaster, calcite, horn, or ivory commodity | Chisel, mallet, bow drill, polishing stone | Commodity tagged `Stone Vessel Blank`. |
 | Prepare inlay stock | Scrimshawing, Glassworking, or Silversmithing | Ancient Household Crafting | Ivory, glass, shell, metal, or coloured stone commodity | Saw, chisel, polishing stone | Commodity tagged `Inlay Stock`. |
 | Prepare painted or lacquered finish | Dyeing or Lacquerwork | Ancient Household Crafting | Pigment/lacquer commodity | Brush, spatula, polishing stone | Commodity tagged `Paint Pigment` or `Lacquer Finish`. |
@@ -241,9 +261,9 @@ Each final craft should use one row from this family table and one stable produc
 | Basketry and Reedwork | 9 | Basketry | Ancient Basketry or culture-specific household knowledge | Willow/papyrus/reed `Basketry Splint`, `Reed Matting`, optional yarn/tie. | Basket knife, reed splitter, bodkin, packing bone, basket clamp. | Stable product. |
 | Textile and Leather Goods | 57 | Tailoring or Leathermaking | Ancient Leather Containers, Ancient Household Crafting, or culture-specific household knowledge | `Garment Cloth`, `Spun Yarn`, `Prepared Leather Panel`, hide/fur commodity, optional `Lamp Wick`, optional `Bead Stock`. | Sewing needle, shears, leather awl, stitching pony, edge beveller. | Stable simple/variable product. |
 | Coopering | 7 | Coopering | Ancient Coopering | `Coopered Staves`, `Hoop Stock`, optional pitch or wax seal. | Cooper's adze, croze, hoop driver, bung borer, mallet. | Dry or liquid container stable product. |
-| Pottery and Fired Clay | 85 | Pottery | Ancient Ceramic Vesselmaking or culture-specific household knowledge | `Pottery Clay Body`, `Wet Vessel Blank`, `Bisque Vessel Blank`, optional slip/glaze/pigment, optional wick for lamps. | Potter's wheel, rib, clay knife, loop tool, stamp, kiln. | Stable product; variable colour products when painted/glazed descriptors require it. |
-| Glassworking | 10 | Glassworking | Ancient Glassworking or culture-specific household knowledge | `Glass Batch`, `Glass Vessel Blank`, optional `Glass Panes`, optional pigment/colour stock. | Blowpipe, pontil, marver, jacks, shears, annealing lehr. | Stable product. |
-| Metal Vesselmaking and Casting | 49 | Blacksmithing or Silversmithing | Ancient Metal Vesselmaking or culture-specific household knowledge | Bronze/iron/silver/gold `Cast Vessel Blank`, optional `Rivet`, `Hoop Stock`, `Inlay Stock`, lamp wick. | Crucible, tongs, mould, hammer, anvil, burnisher. | Stable product. |
+| Pottery and Fired Clay | 85 | Pottery | Ancient Ceramic Vesselmaking or culture-specific household knowledge | `Pottery Clay Body`, `Wet Vessel Blank`, `Bisque Vessel Blank`, optional slip/glaze/pigment, optional wick for lamps. | Potter's wheel, rib, clay knife, loop tool, stamp, lit kiln. | Stable product; variable colour products when painted/glazed descriptors require it. |
+| Glassworking | 10 | Glassworking | Ancient Glassworking or culture-specific household knowledge | `Glass Batch`, `Glass Vessel Blank`, optional `Glass Panes`, optional pigment/colour stock. | Blowpipe, pontil, marver, jacks, shears, lit annealing lehr. | Stable product. |
+| Metal Vesselmaking and Casting | 49 | Blacksmithing or Silversmithing | Ancient Metal Vesselmaking or culture-specific household knowledge | Bronze/iron/silver/gold `Cast Vessel Blank`, optional `Rivet`, `Hoop Stock`, `Inlay Stock`, lamp wick. | Crucible, tongs, lit smelting furnace, hammer, anvil, burnisher. | Stable product. |
 | Stone Bone and Horn Carving | 12 | Masonry or Scrimshawing | Ancient Stone Bone and Horn Carving or culture-specific household knowledge | `Stone Vessel Blank`, exact alabaster/calcite/horn/ivory commodity, optional polish/inlay. | Stone chisel, stone mallet, bow drill, polishing stone. | Stable product. |
 | Candlemaking and Wicks | 2 | Candlemaking | Ancient Lighting and Heating | Beeswax commodity, `Lamp Wick`, optional dye/pigment. | Candle mould, knife. | Stable product. |
 | Torchmaking and Pitchwork | 2 | Ropemaking or Carpentry | Ancient Lighting and Heating | Pine/wood shaft commodity, cloth/fibre, `Prepared Pitch`, `Lamp Wick`. | Knife, binding tool, heating vessel. | Stable product. |
@@ -286,6 +306,20 @@ The following stable references are the design-audit coverage list from the impl
 ### Coopering
 
 `antiquity_liquid_ash_ale_cask`, `antiquity_liquid_hooped_trade_barrel`, `antiquity_liquid_oak_hogshead`, `antiquity_liquid_oak_wet_cask`, `antiquity_liquid_small_coopered_rundlet`, `antiquity_oak_stave_dry_cask`, `antiquity_tall_hooped_trade_barrel`
+
+### Doors, Gates, Locks, and Keys
+
+`antiquity_oak_house_door`, `antiquity_lockable_oak_house_door`, `antiquity_cedar_panel_door`, `antiquity_lockable_cedar_panel_door`, `antiquity_acacia_courtyard_door`, `antiquity_lockable_acacia_courtyard_door`, `antiquity_studded_plank_door`, `antiquity_lockable_studded_plank_door`, `antiquity_cypress_shrine_door`, `antiquity_lockable_cypress_shrine_door`, `antiquity_bronze_clad_civic_door`, `antiquity_lockable_bronze_clad_civic_door`
+
+`antiquity_planked_courtyard_gate`, `antiquity_lockable_planked_courtyard_gate`, `antiquity_palisade_camp_gate`, `antiquity_lockable_palisade_camp_gate`, `antiquity_fortified_compound_gate`, `antiquity_lockable_fortified_compound_gate`, `antiquity_city_gate_leaf`, `antiquity_lockable_city_gate_leaf`, `antiquity_fur_door_hanging`, `antiquity_woven_wool_door_curtain`, `antiquity_heavy_linen_door_cloth`, `antiquity_patterned_carpet_door_hanging`
+
+`antiquity_bead_door_hanging`, `antiquity_reed_door_screen`, `antiquity_felt_tent_door_flap`, `antiquity_leather_tent_door_flap`, `antiquity_papyrus_lashed_light_door`, `antiquity_wooden_barred_wicket`, `antiquity_lockable_wooden_barred_wicket`, `antiquity_bronze_latticed_gate`, `antiquity_lockable_bronze_latticed_gate`, `antiquity_wrought_iron_barred_gate`, `antiquity_lockable_wrought_iron_barred_gate`, `antiquity_bronze_shrine_grille`
+
+`antiquity_lockable_bronze_shrine_grille`, `antiquity_city_sally_port_grate`, `antiquity_lockable_city_sally_port_grate`, `antiquity_massive_barred_gateway`, `antiquity_lockable_massive_barred_gateway`, `antiquity_wooden_pin_lock`, `antiquity_wooden_pin_lock_key`, `antiquity_bronze_warded_door_lock`, `antiquity_bronze_warded_key`, `antiquity_wrought_iron_warded_door_lock`, `antiquity_wrought_iron_warded_key`, `antiquity_small_casket_tumbler_lock`
+
+`antiquity_small_casket_lift_key`, `antiquity_large_gate_bar_lock`, `antiquity_large_gate_key`, `antiquity_poor_iron_slide_lock`, `antiquity_plain_slide_key`, `antiquity_fine_bronze_tumbler_lock`, `antiquity_fine_bronze_lift_key`, `antiquity_bronze_lever_door_lock`, `antiquity_two_toothed_bronze_lever_key`, `antiquity_wrought_iron_gate_lever_lock`, `antiquity_long_iron_gate_key`, `antiquity_temple_bar_lever_lock`
+
+`antiquity_ceremonial_temple_key`, `antiquity_wooden_crossbar_latch`, `antiquity_wrought_iron_draw_latch`, `antiquity_bronze_shrine_latch`, `antiquity_small_bronze_keyring`, `antiquity_large_iron_keyring`
 
 ### Glassworking
 

--- a/Design Documents/Crafting/Antiquity_Medical_Crafting_Suite.md
+++ b/Design Documents/Crafting/Antiquity_Medical_Crafting_Suite.md
@@ -16,6 +16,11 @@ Surgical tools:
 
 - Bone suture needles, bronze probes, scalpels, forceps, arterial clamps, cautery irons, and bone saws
 
+Preparation tools:
+
+- Linen medicine strainers
+- Stone mortar and pestle sets
+
 Herbal remedies:
 
 - Willow bark tea packets, poppy latex draughts, mandrake draughts, ephedra brew packets, foxglove tinctures, mint infusions, honey poultices, garlic salves, aloe burn salves, henbane fumigation cones, and mandrake smoke cones
@@ -23,6 +28,50 @@ Herbal remedies:
 Mobility and prosthetics:
 
 - Padded willow crutches, walking canes, peg legs, prosthetic feet, carved hands, bronze hook hands, and painted clay eyes
+
+Source-audited final product catalogue:
+
+| Stable Reference | Source Catalogue Name |
+| --- | --- |
+| `antiquity_aloe_burn_salve_pot` | an aloe burn salve pot |
+| `antiquity_bone_suture_needle` | a polished bone suture needle |
+| `antiquity_bronze_arterial_clamp` | a bronze arterial clamp |
+| `antiquity_bronze_bone_saw` | a bronze surgical bone saw |
+| `antiquity_bronze_cautery_iron` | a bronze cautery iron |
+| `antiquity_bronze_forceps` | a pair of bronze forceps |
+| `antiquity_bronze_hook_hand` | a bronze hook hand |
+| `antiquity_bronze_scalpel` | a bronze surgical scalpel |
+| `antiquity_bronze_surgical_probe` | a bronze surgical probe |
+| `antiquity_carved_prosthetic_foot` | a carved wooden prosthetic foot |
+| `antiquity_carved_prosthetic_hand` | a carved wooden prosthetic hand |
+| `antiquity_ephedra_brew_packets` | some ephedra brew packets |
+| `antiquity_foxglove_tincture_vial` | a foxglove tincture vial |
+| `antiquity_garlic_salve_pot` | a garlic salve pot |
+| `antiquity_gut_suture_spool` | a spool of plain gut suture |
+| `antiquity_henbane_fumigation_cone` | a henbane fumigation cone |
+| `antiquity_herbalist_pouch` | a labelled herbalist's pouch |
+| `antiquity_honey_antiseptic_kit` | a honey and vinegar antiseptic kit |
+| `antiquity_honey_poultice_pot` | a small honey poultice pot |
+| `antiquity_honeyed_linen_dressing` | a honeyed linen wound dressing |
+| `antiquity_linen_arm_sling` | a linen arm sling |
+| `antiquity_linen_bandage_roll` | a roll of clean linen bandage |
+| `antiquity_linen_tending_kit` | a linen-wrapped tending kit |
+| `antiquity_mandrake_draught_vial` | a mandrake draught vial |
+| `antiquity_mandrake_smoke_cone` | a mandrake smoke cone |
+| `antiquity_mint_infusion_bundle` | a mint infusion bundle |
+| `antiquity_padded_wooden_peg_leg` | a padded wooden peg leg |
+| `antiquity_painted_clay_eye` | a painted clay prosthetic eye |
+| `antiquity_poppy_latex_draught` | a stoppered poppy latex draught |
+| `antiquity_simple_walking_cane` | a simple walking cane |
+| `antiquity_surgical_tool_roll` | a leather surgical tool roll |
+| `antiquity_suturing_kit` | a compact suturing kit |
+| `antiquity_vinegar_wound_cloth` | a vinegar-soaked wound cloth |
+| `antiquity_willow_bark_packets` | some willow bark tea packets |
+| `antiquity_willow_crutch` | a padded willow crutch |
+| `antiquity_wooden_splint_pair` | a pair of padded wooden splints |
+| `antiquity_wool_compress` | a packed wool wound compress |
+| `antiquity_wound_cleaning_kit` | a wound cleaning kit |
+| `antiquity_yarrow_styptic_pad` | a yarrow styptic pad |
 
 ## Crafting Chains
 
@@ -40,6 +89,8 @@ Commodity crafts create upstream medical stock before final item crafts:
 - `Herbal Remedy Stock`
 
 Final crafts are registered from `SeedAntiquityMedicalCrafts()` and target the actual antiquity item prototypes by stable reference. The suite uses the current knowledge-gated `AddCraft` overload so the deterministic appear/can-use/why-cannot-use progs are upserted through the shared craft helper.
+
+Surgical-tool stock now requires the lit smelting-furnace tool state rather than a generic hot-fire tag. The medical stock recipes that boil, warm, or steep ingredients require both a cooking pot and an in-room `Fire` tool, so they use the same lit-hearth convention as the rest of the low-heat craft suite. Herbal remedy stock uses seeded medicine strainers and mortar-and-pestle tools as current prerequisites. Crafts to make those newly introduced preparation tools are the explicit second-pass boundary unless they become current product targets.
 
 ## Health Seeder Tie-Ins
 

--- a/Design Documents/Crafting/Antiquity_Writing_Implements_Crafting_Suite.md
+++ b/Design Documents/Crafting/Antiquity_Writing_Implements_Crafting_Suite.md
@@ -30,8 +30,51 @@ Implements and support goods:
 - Reed pens, quills, ink brushes, charcoal sticks
 - Bone, bronze, and reed styluses
 - Bronze pen knives and scraper knives
+- Papyrus strip knives, pressing boards, burnishing shells
+- Parchment scraping knives, stretching frames, and pumice
+- Bookbinder's needles and punches
+- Scroll roller rods and smoothing stones
+- Quill curing sand, wax spatulas, pigment mullers, and pigment shells
 - Soot ink cakes, small inkwells, and prepared black ink pots
 - Scroll cases, document pouches, tablet wraps, and scroll ties
+
+Source-audited final product catalogue:
+
+| Stable Reference | Source Catalogue Name |
+| --- | --- |
+| `antiquity_bone_stylus` | a polished bone stylus |
+| `antiquity_bronze_pen_knife` | a small bronze pen knife |
+| `antiquity_bronze_scraper_knife` | a bronze parchment scraper |
+| `antiquity_bronze_stylus` | a bronze stylus |
+| `antiquity_cedar_scroll_case` | a cedar scroll case |
+| `antiquity_charcoal_writing_stick` | a charcoal writing stick |
+| `antiquity_clay_tablet_envelope` | a clay tablet envelope |
+| `antiquity_fired_clay_tablet` | a fired clay writing tablet |
+| `antiquity_hinged_wax_diptych` | a hinged wax tablet diptych |
+| `antiquity_ink_brush` | a fine ink brush |
+| `antiquity_leather_codex_pouch` | a leather document pouch |
+| `antiquity_linen_tablet_wrap` | a linen tablet wrap |
+| `antiquity_liquid_black_ink_pot` | a small inkwell of black ink |
+| `antiquity_loose_papyrus_sheet` | a loose papyrus sheet |
+| `antiquity_loose_parchment_sheet` | a loose parchment sheet |
+| `antiquity_papyrus_scroll_tie` | a narrow linen scroll tie |
+| `antiquity_papyrus_sheet_bundle` | a bundle of loose papyrus sheets |
+| `antiquity_parchment_bifolium` | a folded parchment bifolium |
+| `antiquity_parchment_codex` | a small parchment codex |
+| `antiquity_parchment_quire` | a nested parchment quire |
+| `antiquity_parchment_scroll` | a parchment scroll |
+| `antiquity_potsherd_ostracon` | a smoothed potsherd ostracon |
+| `antiquity_quill_pen` | a trimmed quill pen |
+| `antiquity_reed_pen` | a cut reed pen |
+| `antiquity_reed_stylus` | a sharpened reed stylus |
+| `antiquity_sealed_papyrus_scroll` | a tied and sealed papyrus scroll |
+| `antiquity_simple_papyrus_scroll` | a simple papyrus scroll |
+| `antiquity_small_inkwell` | a small clay inkwell |
+| `antiquity_smoothed_wooden_writing_block` | a smoothed wooden writing block |
+| `antiquity_soot_ink_cake` | a soot-black ink cake |
+| `antiquity_unfired_clay_tablet` | an unfired clay writing tablet |
+| `antiquity_wax_triptych` | a three-leaf wax tablet triptych |
+| `antiquity_wax_writing_tablet` | a waxed wooden writing tablet |
 
 ## Crafting Chains
 
@@ -51,3 +94,7 @@ Final crafts are knowledge-gated through the shared `AddCraft` overload used by 
 ## Discovery Boundary
 
 The household craft suite still covers older document furniture and generic household containers. New writing-surface and writing-implement stable references are excluded from household dynamic discovery so final crafts are not duplicated.
+
+## One-Step-Back Boundary
+
+The May 2026 one-step-back pass seeds every writing/book/pigment tool currently named by `ItemSeederCrafting.AntiquityWriting.cs` as a `TagTool` prerequisite. Those tool prototypes are stock prerequisites for the current suite. Crafts to make the newly introduced tool prototypes themselves remain a second-pass task unless they are already part of a current finished-product craft family.

--- a/Design Documents/Data/SeededTagHierarchy.csv
+++ b/Design Documents/Data/SeededTagHierarchy.csv
@@ -534,6 +534,7 @@ Net Gauge	Fishing Tools	Functions / Tools / Fishing Tools / Net Gauge
 Net Needle	Fishing Tools	Functions / Tools / Fishing Tools / Net Needle
 Glassblowing Tools	Tools	Functions / Tools / Glassblowing Tools
 Annealing Lehr	Glassblowing Tools	Functions / Tools / Glassblowing Tools / Annealing Lehr
+Lit Annealing Lehr	Annealing Lehr	Functions / Tools / Glassblowing Tools / Annealing Lehr / Lit Annealing Lehr
 Blocks	Glassblowing Tools	Functions / Tools / Glassblowing Tools / Blocks
 Blowpipe	Glassblowing Tools	Functions / Tools / Glassblowing Tools / Blowpipe
 Glass Shears	Glassblowing Tools	Functions / Tools / Glassblowing Tools / Glass Shears
@@ -706,6 +707,7 @@ Clay Stamp	Pottery Tools	Functions / Tools / Pottery Tools / Clay Stamp
 Extruder	Pottery Tools	Functions / Tools / Pottery Tools / Extruder
 Hump Mold	Pottery Tools	Functions / Tools / Pottery Tools / Hump Mold
 Kiln	Pottery Tools	Functions / Tools / Pottery Tools / Kiln
+Lit Kiln	Kiln	Functions / Tools / Pottery Tools / Kiln / Lit Kiln
 Loop Tool	Pottery Tools	Functions / Tools / Pottery Tools / Loop Tool
 Needle Tool	Pottery Tools	Functions / Tools / Pottery Tools / Needle Tool
 Potter's Rib	Pottery Tools	Functions / Tools / Pottery Tools / Potter's Rib
@@ -871,6 +873,7 @@ Ore Roaster	Smelting Tools	Functions / Tools / Smelting Tools / Ore Roaster
 Slag Hammer	Smelting Tools	Functions / Tools / Smelting Tools / Slag Hammer
 Slag Skimmer	Smelting Tools	Functions / Tools / Smelting Tools / Slag Skimmer
 Smelting Furnace	Smelting Tools	Functions / Tools / Smelting Tools / Smelting Furnace
+Lit Smelting Furnace	Smelting Furnace	Functions / Tools / Smelting Tools / Smelting Furnace / Lit Smelting Furnace
 Tap Rod	Smelting Tools	Functions / Tools / Smelting Tools / Tap Rod
 Stoneworking Tools	Tools	Functions / Tools / Stoneworking Tools
 Bush Hammer	Stoneworking Tools	Functions / Tools / Stoneworking Tools / Bush Hammer

--- a/Design Documents/README.md
+++ b/Design Documents/README.md
@@ -34,6 +34,7 @@ This folder is organised by subsystem so implementation notes, builder workflows
 - [Patch Notes Authoring Guide](./Core/Patch_Notes_Authoring_Guide.md)
 
 ## Crafting
+- [Antiquity Crafting Catalogue Audit](./Crafting/Antiquity_Crafting_Audit.md)
 - [Antiquity Clothing Crafting Suite](./Crafting/Antiquity_Hellenic_Clothing_Crafting_Suite.md)
 - [Antiquity Equipment Crafting Suite](./Crafting/Antiquity_Equipment_Crafting_Suite.md)
 - [Antiquity Furniture and Container Crafting Suite](./Crafting/Antiquity_Furniture_Container_Crafting_Suite.md)


### PR DESCRIPTION
## Summary
- add a source-backed antiquity crafting catalogue audit document and link it from the design-doc index
- expand equipment, furniture/container, writing, and medical docs so current craft-source stable refs are catalogued
- require a lit Fire tool for low-heat medical cooking-pot stock crafts and add regression coverage for doc drift and remaining gap documentation

## Validation
- dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 --filter ItemSeederAntiquity
- dotnet build DatabaseSeeder\DatabaseSeeder.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510
- git diff --check