### PR TITLE
Add antiquity jewellery and support tool crafts

### DIFF
--- a/DatabaseSeeder Unit Tests/ItemSeederAntiquityRemainingCraftingTests.cs
+++ b/DatabaseSeeder Unit Tests/ItemSeederAntiquityRemainingCraftingTests.cs
@@ -43,7 +43,8 @@ public class ItemSeederAntiquityRemainingCraftingTests
 			ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Antiquity.cs") +
 			ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.AntiquityHousehold.cs");
 		var equipmentCraftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.AntiquityEquipment.cs");
-		var allCraftSource = existingCraftSource + equipmentCraftSource;
+		var jewelleryCraftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.AntiquityJewellery.cs");
+		var allCraftSource = existingCraftSource + equipmentCraftSource + jewelleryCraftSource;
 
 		var items = AntiquityReworkMethods
 			.SelectMany(method => ParseItemsInMethod(itemSource, method))
@@ -58,12 +59,80 @@ public class ItemSeederAntiquityRemainingCraftingTests
 		Assert.AreEqual(398, items.Count(IsHouseholdDynamicTarget));
 
 		var uncovered = items
-			.Where(item => !IsCoveredByCraftSuites(item, existingCraftSource, equipmentCraftSource, allCraftSource))
+			.Where(item => !IsCoveredByCraftSuites(item, existingCraftSource, equipmentCraftSource, jewelleryCraftSource,
+				allCraftSource))
 			.Select(item => $"{item.MethodName}:{item.StableReference}")
 			.ToList();
 
 		Assert.AreEqual(0, uncovered.Count,
 			$"Expected every antiquity prototype to be covered by an existing or new craft suite. Missing: {string.Join(", ", uncovered)}");
+	}
+
+	[TestMethod]
+	public void AntiquityJewelleryCrafts_RegisterDynamicKnowledgeGatedSuiteAndCatalogue()
+	{
+		var itemSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.Antiquity.cs");
+		var craftRoot = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.cs");
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.AntiquityJewellery.cs");
+		var tagSource = ReadSource("DatabaseSeeder", "Seeders", "UsefulSeeder.Tags.cs");
+		var tagHierarchy = ReadSource("Design Documents", "Data", "SeededTagHierarchy.csv");
+		var jewelleryDoc = ReadSource("Design Documents", "Crafting", "Antiquity_Jewellery_Crafting_Suite.md");
+
+		var jewelleryItems = ParseItemsInMethod(itemSource, "SeedAntiquityJewellery");
+		Assert.AreEqual(162, jewelleryItems.Count, "The jewellery craft catalogue should track the current stock jewellery set.");
+		var usekhBlock = ExtractCallBlockContaining(itemSource, "jewellery_gold_usekh_collar");
+		AssertContains(usekhBlock, "carnelian, turquoise and lapis-coloured beads");
+
+		foreach (var expected in new[]
+		{
+			"SeedAntiquityJewelleryCrafts();",
+			"private void SeedAntiquityJewelleryCrafts()",
+			"SeedAntiquityJewelleryIntermediateCommodityCrafts();",
+			"Ancient Jewellery Crafting",
+			"Jewellery Metal Stock",
+			"Jewellery Wire Stock",
+			"Jewellery Bead Stock",
+			"Jewellery Setting Stock",
+			"Wooden Bead Jewellery",
+			"Functions / Worn Items / Jewellery",
+			"var materialScanText = $\"{stableReference} {item.ShortDescription} {item.FullDescription}\".ToLowerInvariant();",
+			"GetAntiquityJewelleryCraftPath(material, materialScanText)",
+			"BuildAntiquityJewelleryFinalInputs(item, material, materialScanText, path)",
+			"(\"lapis\", \"lapis lazuli\")",
+			"AddAntiquityCraft(",
+			"knowledgeSubtype:",
+			"SanitiseAntiquityJewelleryVisibleName(item.ShortDescription)",
+			"BuildUniqueAntiquityEquipmentCraftName"
+		})
+		{
+			Assert.IsTrue(craftRoot.Contains(expected, StringComparison.Ordinal) ||
+			              craftSource.Contains(expected, StringComparison.Ordinal),
+				$"Expected source to contain: {expected}");
+		}
+
+		foreach (var expected in new[]
+		{
+			"Jewellery Craft Stock",
+			"Jewellery Metal Stock",
+			"Jewellery Wire Stock",
+			"Jewellery Bead Stock",
+			"Jewellery Setting Stock"
+		})
+		{
+			AssertContains(tagSource, $"AddTag(context, \"{expected}\",");
+			AssertContains(tagHierarchy, expected.Equals("Jewellery Craft Stock", StringComparison.Ordinal)
+				? $"Material Functions / {expected}"
+				: $"Jewellery Craft Stock / {expected}");
+			if (!expected.Equals("Jewellery Craft Stock", StringComparison.Ordinal))
+			{
+				AssertContains(craftSource, expected);
+			}
+		}
+
+		foreach (var item in jewelleryItems)
+		{
+			AssertContains(jewelleryDoc, $"`{item.StableReference}`");
+		}
 	}
 
 	[TestMethod]
@@ -136,6 +205,57 @@ public class ItemSeederAntiquityRemainingCraftingTests
 	}
 
 	[TestMethod]
+	public void AntiquityEquipmentCrafts_MakeSupportToolsAndUnlitApparatusCraftable()
+	{
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.AntiquityEquipment.cs");
+		var householdToolSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.AntiquityHouseholdTools.cs");
+
+		foreach (var expected in new[]
+		{
+			"professionalToolTagIds",
+			"Market / Professional Tools / Standard Tools",
+			"AntiquityUnlitWorkshopApparatusStableReferences",
+			"AntiquityLitWorkshopApparatusStableReferences",
+			"antiquity_workshop_hearth",
+			"antiquity_updraft_kiln",
+			"antiquity_glory_hole_furnace",
+			"antiquity_annealing_lehr",
+			"antiquity_clay_smelting_furnace",
+			"Pottery Clay Body",
+			"Tool Blank Stock",
+			"AntiquityEquipmentToolBlankMaterials",
+			"GetToolBlankSkill(material)",
+			"ToolBlankShapingTools(material)",
+			"\"glass\"",
+			"\"shell\"",
+			"\"stone\""
+		})
+		{
+			AssertContains(craftSource, expected);
+		}
+
+		foreach (var litOnly in new[]
+		{
+			"antiquity_lit_workshop_hearth",
+			"antiquity_lit_updraft_kiln",
+			"antiquity_lit_glory_hole_furnace",
+			"antiquity_lit_annealing_lehr",
+			"antiquity_lit_clay_smelting_furnace"
+		})
+		{
+			AssertContains(householdToolSource, litOnly);
+			AssertContains(craftSource, litOnly);
+		}
+
+		var stoneBlankToolBranch = ExtractBlockContaining(craftSource,
+			"if (material.Equals(\"stone\", StringComparison.OrdinalIgnoreCase))");
+		AssertContains(stoneBlankToolBranch, "TagTool - Held - an item with the Stone Chisel tag");
+		AssertContains(stoneBlankToolBranch, "TagTool - Held - an item with the Stone Mallet tag");
+		Assert.IsFalse(stoneBlankToolBranch.Contains("Polishing Stone", StringComparison.Ordinal),
+			"Stone tool blank stock must not require an existing polishing stone because it bootstraps the polishing stone tool itself.");
+	}
+
+	[TestMethod]
 	public void AntiquityEquipmentCrafts_KeepVisibleCraftStringsCultureNeutral()
 	{
 		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.AntiquityEquipment.cs");
@@ -204,6 +324,7 @@ public class ItemSeederAntiquityRemainingCraftingTests
 			(Lit: "antiquity_lit_workshop_hearth", Unlit: "antiquity_workshop_hearth", ToolTag: "Functions / Material Functions / Fire"),
 			(Lit: "antiquity_lit_clay_smelting_furnace", Unlit: "antiquity_clay_smelting_furnace", ToolTag: "Functions / Tools / Smelting Tools / Smelting Furnace / Lit Smelting Furnace"),
 			(Lit: "antiquity_lit_updraft_kiln", Unlit: "antiquity_updraft_kiln", ToolTag: "Functions / Tools / Pottery Tools / Kiln / Lit Kiln"),
+			(Lit: "antiquity_lit_glory_hole_furnace", Unlit: "antiquity_glory_hole_furnace", ToolTag: "Functions / Tools / Glassblowing Tools / Glory Hole / Lit Glory Hole"),
 			(Lit: "antiquity_lit_annealing_lehr", Unlit: "antiquity_annealing_lehr", ToolTag: "Functions / Tools / Glassblowing Tools / Annealing Lehr / Lit Annealing Lehr")
 		})
 		{
@@ -219,6 +340,7 @@ public class ItemSeederAntiquityRemainingCraftingTests
 			"light a workshop hearth",
 			"stoke an updraft pottery kiln",
 			"stoke a clay smelting furnace",
+			"stoke a glassworking glory hole",
 			"stoke an annealing lehr",
 			"CommodityInput(charcoalGrams, \"charcoal\")",
 			"lay|lays $i2 into the fire bed",
@@ -236,6 +358,7 @@ public class ItemSeederAntiquityRemainingCraftingTests
 		var docsSource =
 			ReadSource("Design Documents", "Crafting", "Antiquity_Equipment_Crafting_Suite.md") +
 			ReadSource("Design Documents", "Crafting", "Antiquity_Furniture_Container_Crafting_Suite.md") +
+			ReadSource("Design Documents", "Crafting", "Antiquity_Jewellery_Crafting_Suite.md") +
 			ReadSource("Design Documents", "Crafting", "Antiquity_Writing_Implements_Crafting_Suite.md") +
 			ReadSource("Design Documents", "Crafting", "Antiquity_Medical_Crafting_Suite.md");
 
@@ -290,16 +413,17 @@ public class ItemSeederAntiquityRemainingCraftingTests
 	}
 
 	[TestMethod]
-	public void AntiquityCrafting_CatalogueAuditDocumentsRemainingLogicalGaps()
+	public void AntiquityCrafting_CatalogueAuditDocumentsSecondPassResolution()
 	{
 		var auditDoc = ReadSource("Design Documents", "Crafting", "Antiquity_Crafting_Audit.md");
 
 		foreach (var expected in new[]
 		{
-			"SeedAntiquityJewellery",
-			"support tools and unlit workshop apparatus",
-			"glass furnace",
-			"maintained rather than generated"
+			"Second-Pass Resolution",
+			"SeedAntiquityJewelleryCrafts",
+			"Support tools and unlit workshop apparatus are now craftable",
+			"glassworking glory-hole furnace",
+			"source-backed regression tests"
 		})
 		{
 			AssertContains(auditDoc, expected);
@@ -307,14 +431,21 @@ public class ItemSeederAntiquityRemainingCraftingTests
 	}
 
 	private static bool IsCoveredByCraftSuites(SeededAntiquityItem item, string existingCraftSource,
-		string equipmentCraftSource, string allCraftSource)
+		string equipmentCraftSource, string jewelleryCraftSource, string allCraftSource)
 	{
-		return item.MethodName.Equals("SeedAntiquityJewellery", StringComparison.Ordinal) ||
+		return IsJewelleryDynamicTarget(item, jewelleryCraftSource) ||
 		       existingCraftSource.Contains($"\"{item.StableReference}\"", StringComparison.Ordinal) ||
 		       IsHouseholdDynamicTarget(item) ||
 		       equipmentCraftSource.Contains($"\"{item.StableReference}\"", StringComparison.Ordinal) ||
 		       IsMilitaryEquipmentTarget(item, existingCraftSource) ||
 		       allCraftSource.Contains($"\"{item.StableReference}\"", StringComparison.Ordinal);
+	}
+
+	private static bool IsJewelleryDynamicTarget(SeededAntiquityItem item, string jewelleryCraftSource)
+	{
+		return item.MethodName.Equals("SeedAntiquityJewellery", StringComparison.Ordinal) &&
+		       HasRoot(item.Tags, "Functions / Worn Items / Jewellery") &&
+		       jewelleryCraftSource.Contains("SeedAntiquityJewelleryCrafts()", StringComparison.Ordinal);
 	}
 
 	private static bool IsHouseholdDynamicTarget(SeededAntiquityItem item)
@@ -415,6 +546,35 @@ public class ItemSeederAntiquityRemainingCraftingTests
 		}
 
 		Assert.Fail($"Could not extract body for method {methodName}.");
+		return string.Empty;
+	}
+
+	private static string ExtractBlockContaining(string source, string marker)
+	{
+		var start = source.IndexOf(marker, StringComparison.Ordinal);
+		Assert.IsTrue(start >= 0, $"Could not find source block for {marker}.");
+		var openBrace = source.IndexOf('{', start);
+		Assert.IsTrue(openBrace >= 0, $"Could not find body for {marker}.");
+
+		var depth = 0;
+		for (var i = openBrace; i < source.Length; i++)
+		{
+			switch (source[i])
+			{
+				case '{':
+					depth++;
+					break;
+				case '}':
+					depth--;
+					if (depth == 0)
+					{
+						return source[(openBrace + 1)..i];
+					}
+					break;
+			}
+		}
+
+		Assert.Fail($"Could not extract block for {marker}.");
 		return string.Empty;
 	}
 

--- a/DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityHouseholdTools.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityHouseholdTools.cs
@@ -190,6 +190,17 @@ public partial class ItemSeeder
 			"Heavy bronze shears with long handles, made to cut hot glass threads and trim vessel mouths before annealing.",
 			SizeCategory.Small, 820.0, 24.0m, "bronze",
 			["Functions / Tools / Glassblowing Tools / Glass Shears"]);
+		CreateAntiquityHouseholdCraftTool("antiquity_glory_hole_furnace", "furnace", "an unlit glassworking glory-hole furnace",
+			"A compact clay glory-hole furnace with a round working mouth, charcoal chamber, and blackened side vents for reheating glass gathers during shaping.",
+			SizeCategory.Huge, 68000.0, 130.0m, "earthenware",
+			["Functions / Tools / Glassblowing Tools / Glory Hole"]);
+		CreateAntiquityHouseholdCraftTool("antiquity_lit_glory_hole_furnace", "furnace", "a lit glassworking glory-hole furnace",
+			"This compact clay glory-hole furnace burns with a deep charcoal heat at its round working mouth, ready to keep glass gathers soft while they are shaped.",
+			SizeCategory.Huge, 68200.0, 140.0m, "earthenware",
+			["Functions / Tools / Glassblowing Tools / Glory Hole", "Functions / Tools / Glassblowing Tools / Glory Hole / Lit Glory Hole", "Functions / Material Functions / Hot Fire"],
+			"antiquity_glory_hole_furnace",
+			"$0 cools and dies back into $1.",
+			TimeSpan.FromHours(3));
 		CreateAntiquityHouseholdCraftTool("antiquity_annealing_lehr", "lehr", "a small annealing lehr",
 			"A long earthenware annealing lehr that holds finished glass at a gentler heat so vessels can cool without cracking.",
 			SizeCategory.Huge, 52000.0, 110.0m, "earthenware",

--- a/DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityEquipment.cs
+++ b/DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityEquipment.cs
@@ -122,7 +122,36 @@ public partial class ItemSeeder
 	[
 		"earthenware",
 		"fired clay",
+		"glazed ceramic",
 		"terracotta"
+	];
+
+	private static readonly string[] AntiquityEquipmentToolBlankMaterials =
+	[
+		"bone",
+		"glass",
+		"horn",
+		"ivory",
+		"shell",
+		"stone"
+	];
+
+	private static readonly string[] AntiquityUnlitWorkshopApparatusStableReferences =
+	[
+		"antiquity_workshop_hearth",
+		"antiquity_updraft_kiln",
+		"antiquity_glory_hole_furnace",
+		"antiquity_annealing_lehr",
+		"antiquity_clay_smelting_furnace"
+	];
+
+	private static readonly string[] AntiquityLitWorkshopApparatusStableReferences =
+	[
+		"antiquity_lit_workshop_hearth",
+		"antiquity_lit_updraft_kiln",
+		"antiquity_lit_glory_hole_furnace",
+		"antiquity_lit_annealing_lehr",
+		"antiquity_lit_clay_smelting_furnace"
 	];
 
 	private static readonly string[] AntiquityEquipmentCultureTerms =
@@ -238,6 +267,19 @@ public partial class ItemSeeder
 			"antiquity_clay_smelting_furnace",
 			"antiquity_lit_clay_smelting_furnace",
 			2600.0,
+			20,
+			Difficulty.Normal);
+
+		AddAntiquityHeatSourceCraft(
+			"stoke a glassworking glory hole",
+			"Glassworking",
+			"Glassworking",
+			AncientGlassworkingKnowledge,
+			"Glassworking",
+			"stoke a glassworking glory hole",
+			"antiquity_glory_hole_furnace",
+			"antiquity_lit_glory_hole_furnace",
+			2400.0,
 			20,
 			Difficulty.Normal);
 
@@ -532,6 +574,20 @@ public partial class ItemSeeder
 				[$"CommodityProduct - {FormatCommodityAmount(760.0)} of {material} commodity; tag Weapon Head Stock"]);
 		}
 
+		foreach (var material in AntiquityEquipmentToolBlankMaterials)
+		{
+			AddAntiquityEquipmentCommodityCraft(
+				$"shape {material} tool blank stock",
+				GetToolBlankSkill(material),
+				GetToolBlankSkill(material),
+				AncientToolmakingKnowledge,
+				"Toolmaking Stock",
+				$"shape {material} into tool blank stock",
+				[CommodityInput(1000.0, material)],
+				ToolBlankShapingTools(material),
+				[$"CommodityProduct - {FormatCommodityAmount(780.0)} of {material} commodity; tag Tool Blank Stock"]);
+		}
+
 		foreach (var material in AntiquityEquipmentCeramicMaterials)
 		{
 			AddAntiquityEquipmentCommodityCraft(
@@ -566,7 +622,21 @@ public partial class ItemSeeder
 
 	private void SeedAntiquityCraftToolCrafts(IDictionary<string, int> usedCraftNames)
 	{
-		foreach (var stableReference in AntiquityCraftToolStableReferences)
+		var professionalToolTagIds = GetTagIdsUnderRoots(["Market / Professional Tools / Standard Tools"]);
+		var stableReferences = AntiquityCraftToolStableReferences
+			.Concat(_items
+				.Where(x => x.Key.StartsWith("antiquity_", StringComparison.OrdinalIgnoreCase))
+				.Where(x => !AntiquityWritingStableReferences.Contains(x.Key, StringComparer.OrdinalIgnoreCase))
+				.Where(x => !AntiquityMedicalStableReferences.Contains(x.Key, StringComparer.OrdinalIgnoreCase))
+				.Where(x => !AntiquityLitWorkshopApparatusStableReferences.Contains(x.Key, StringComparer.OrdinalIgnoreCase))
+				.Where(x => x.Value.GameItemProtosTags.Any(y => professionalToolTagIds.Contains(y.TagId)))
+				.Select(x => x.Key))
+			.Concat(AntiquityUnlitWorkshopApparatusStableReferences)
+			.Distinct(StringComparer.OrdinalIgnoreCase)
+			.OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+			.ToList();
+
+		foreach (var stableReference in stableReferences)
 		{
 			if (!TryLookupReworkItem(stableReference, out var item))
 			{
@@ -655,7 +725,7 @@ public partial class ItemSeeder
 				BuildCommonClothingInputs(inputs, AddInput, material, lowerText, primaryAmount, needsColour);
 				break;
 			case AntiquityEquipmentCraftFamily.CraftTool:
-				BuildCraftToolInputs(inputs, AddInput, material, lowerText, primaryAmount);
+				BuildCraftToolInputs(inputs, AddInput, material, lowerText, primaryAmount, path.PrimaryStockTag);
 				break;
 			case AntiquityEquipmentCraftFamily.Shield:
 				AddInput(CommodityInput(primaryAmount * 0.65, GetEquipmentWoodMaterial(material, lowerText), "Shield Board Stock"));
@@ -740,8 +810,20 @@ public partial class ItemSeeder
 	}
 
 	private static void BuildCraftToolInputs(List<string> inputs, Action<string, bool> addInput,
-		string material, string lowerText, double primaryAmount)
+		string material, string lowerText, double primaryAmount, string primaryStockTag)
 	{
+		if (!primaryStockTag.Equals("Tool Blank Stock", StringComparison.OrdinalIgnoreCase))
+		{
+			addInput(CommodityInput(primaryAmount, material, primaryStockTag), false);
+			if (ContainsAny(lowerText, "hearth", "kiln", "furnace", "lehr"))
+			{
+				addInput(CommodityInput(Math.Max(500.0, primaryAmount * 0.15), "clay"), false);
+				addInput(CommodityInput(Math.Max(250.0, primaryAmount * 0.05), "charcoal"), false);
+			}
+
+			return;
+		}
+
 		if (IsWoodEquipmentMaterial(material))
 		{
 			addInput(CommodityInput(primaryAmount, material, "Tool Blank Stock"), false);
@@ -878,6 +960,27 @@ public partial class ItemSeeder
 	private AntiquityEquipmentCraftPath GetCraftToolPath(string stableReference, GameItemProto item)
 	{
 		var material = GetMaterialName(item);
+		var text = $"{stableReference} {item.ShortDescription}".ToLowerInvariant();
+		if (AntiquityUnlitWorkshopApparatusStableReferences.Contains(stableReference, StringComparer.OrdinalIgnoreCase))
+		{
+			return new AntiquityEquipmentCraftPath(
+				AntiquityEquipmentCraftFamily.CraftTool,
+				stableReference.Contains("glory", StringComparison.OrdinalIgnoreCase) ? "Glassworking" : "Pottery",
+				stableReference.Contains("glory", StringComparison.OrdinalIgnoreCase) ? "Glassworking" : "Pottery",
+				AncientToolmakingKnowledge,
+				"Workshop Apparatus",
+				"Pottery Clay Body",
+				"build",
+				"building",
+				25,
+				stableReference.Contains("hearth", StringComparison.OrdinalIgnoreCase) ? Difficulty.Normal : Difficulty.Hard,
+				[
+					"TagTool - Held - an item with the Clay Knife tag",
+					"TagTool - Held - an item with the Stone Mallet tag",
+					"TagTool - Held - an item with the Trowel tag"
+				]);
+		}
+
 		if (IsMetalEquipmentMaterial(material))
 		{
 			return new AntiquityEquipmentCraftPath(
@@ -904,6 +1007,17 @@ public partial class ItemSeeder
 					"TagTool - InRoom - an item with the Potter's Wheel tag",
 					"TagTool - InRoom - an item with the Lit Kiln tag"
 				]);
+		}
+
+		if (AntiquityEquipmentToolBlankMaterials.Contains(material, StringComparer.OrdinalIgnoreCase))
+		{
+			return new AntiquityEquipmentCraftPath(
+				AntiquityEquipmentCraftFamily.CraftTool,
+				GetToolBlankSkill(material), GetToolBlankSkill(material), AncientToolmakingKnowledge, "Craft Tools",
+				"Tool Blank Stock",
+				ContainsAny(text, "muller", "stone", "shell", "bone", "ivory") ? "polish" : "shape",
+				ContainsAny(text, "muller", "stone", "shell", "bone", "ivory") ? "polishing" : "shaping",
+				15, Difficulty.Normal, ToolBlankShapingTools(material));
 		}
 
 		return new AntiquityEquipmentCraftPath(
@@ -1335,6 +1449,65 @@ public partial class ItemSeeder
 			"TagTool - Held - an item with the Awl Punch tag",
 			"TagTool - InRoom - an item with the Leather Stitching Pony tag",
 			"TagTool - Held - an item with the Edge Beveller tag"
+		];
+	}
+
+	private static string GetToolBlankSkill(string material)
+	{
+		if (material.Equals("glass", StringComparison.OrdinalIgnoreCase))
+		{
+			return "Glassworking";
+		}
+
+		if (material.Equals("bone", StringComparison.OrdinalIgnoreCase) ||
+		    material.Equals("horn", StringComparison.OrdinalIgnoreCase) ||
+		    material.Equals("ivory", StringComparison.OrdinalIgnoreCase) ||
+		    material.Equals("shell", StringComparison.OrdinalIgnoreCase))
+		{
+			return "Bonecarving";
+		}
+
+		return "Masonry";
+	}
+
+	private static string[] ToolBlankShapingTools(string material)
+	{
+		if (material.Equals("glass", StringComparison.OrdinalIgnoreCase))
+		{
+			return
+			[
+				"TagTool - Held - an item with the Glass Shears tag",
+				"TagTool - Held - an item with the Polishing Stone tag",
+				"TagTool - InRoom - an item with the Lit Glory Hole tag"
+			];
+		}
+
+		if (material.Equals("bone", StringComparison.OrdinalIgnoreCase) ||
+		    material.Equals("horn", StringComparison.OrdinalIgnoreCase) ||
+		    material.Equals("ivory", StringComparison.OrdinalIgnoreCase) ||
+		    material.Equals("shell", StringComparison.OrdinalIgnoreCase))
+		{
+			return
+			[
+				"TagTool - Held - an item with the Bow Drill tag",
+				"TagTool - Held - an item with the Polishing Stone tag"
+			];
+		}
+
+		if (material.Equals("stone", StringComparison.OrdinalIgnoreCase))
+		{
+			return
+			[
+				"TagTool - Held - an item with the Stone Chisel tag",
+				"TagTool - Held - an item with the Stone Mallet tag"
+			];
+		}
+
+		return
+		[
+			"TagTool - Held - an item with the Stone Chisel tag",
+			"TagTool - Held - an item with the Stone Mallet tag",
+			"TagTool - Held - an item with the Polishing Stone tag"
 		];
 	}
 }

--- a/DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityHousehold.cs
+++ b/DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityHousehold.cs
@@ -402,6 +402,7 @@ public partial class ItemSeeder
 				[
 					"TagTool - Held - an item with the Blowpipe tag",
 					"TagTool - Held - an item with the Pontil Rod tag",
+					"TagTool - InRoom - an item with the Lit Glory Hole tag",
 					"TagTool - InRoom - an item with the Lit Annealing Lehr tag"
 				],
 				[
@@ -896,6 +897,7 @@ public partial class ItemSeeder
 		[
 			"TagTool - Held - an item with the Blowpipe tag",
 			"TagTool - Held - an item with the Pontil Rod tag",
+			"TagTool - InRoom - an item with the Lit Glory Hole tag",
 			"TagTool - InRoom - an item with the Lit Annealing Lehr tag"
 		]);
 

--- a/DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityJewellery.cs
+++ b/DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityJewellery.cs
@@ -1,0 +1,486 @@
+using MudSharp.Models;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DatabaseSeeder.Seeders;
+
+public partial class ItemSeeder
+{
+	private const string AncientJewelleryCraftingKnowledge = "Ancient Jewellery Crafting";
+
+	private static readonly string[] AntiquityJewelleryTagRoots =
+	[
+		"Functions / Worn Items / Jewellery"
+	];
+
+	private static readonly string[] AntiquityJewelleryMetals =
+	[
+		"bronze",
+		"copper",
+		"electrum",
+		"gold",
+		"silver",
+		"wrought iron"
+	];
+
+	private static readonly string[] AntiquityJewelleryBeadMaterials =
+	[
+		"agate",
+		"amber",
+		"bone",
+		"carnelian",
+		"emerald",
+		"garnet",
+		"glass",
+		"glazed ceramic",
+		"ivory",
+		"jasper",
+		"lapis lazuli",
+		"pearl",
+		"quartz",
+		"shell",
+		"turquoise",
+		"wood"
+	];
+
+	private static readonly (string Alias, string Material)[] AntiquityJewelleryMaterialAliases =
+	[
+		("lapis", "lapis lazuli")
+	];
+
+	private static readonly string[] AntiquityJewelleryCultureTerms =
+	[
+		"achaemenid",
+		"anatolian",
+		"athenian",
+		"campanian",
+		"carthaginian",
+		"celtic",
+		"corinthian",
+		"egyptian",
+		"etruscan",
+		"gallic",
+		"germanic",
+		"greek",
+		"hellenic",
+		"kushite",
+		"lydian",
+		"meroitic",
+		"nubian",
+		"parthian",
+		"persian",
+		"phrygian",
+		"punic",
+		"roman",
+		"sarmatian",
+		"scythian",
+		"spartan",
+		"urartian"
+	];
+
+	private sealed record AntiquityJewelleryCraftPath(
+		string Category,
+		string Skill,
+		string KnowledgeSubtype,
+		string PrimaryStockTag,
+		string Verb,
+		string Gerund,
+		int MinimumTraitValue,
+		Difficulty Difficulty,
+		IReadOnlyList<string> Tools);
+
+	private void SeedAntiquityJewelleryCrafts()
+	{
+		if (!ShouldSeedAntiquityCrafts())
+		{
+			return;
+		}
+
+		SeedAntiquityJewelleryIntermediateCommodityCrafts();
+
+		var jewelleryTagIds = GetTagIdsUnderRoots(AntiquityJewelleryTagRoots);
+		var targetItems = _items
+			.Where(x => x.Key.StartsWith("jewellery_", StringComparison.OrdinalIgnoreCase))
+			.Where(x => x.Value.GameItemProtosTags.Any(y => jewelleryTagIds.Contains(y.TagId)))
+			.OrderBy(x => x.Key, StringComparer.OrdinalIgnoreCase)
+			.ToList();
+
+		var usedCraftNames = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+		foreach (var target in targetItems)
+		{
+			SeedAntiquityJewelleryFinishedCraft(target.Key, target.Value, usedCraftNames);
+		}
+	}
+
+	private void SeedAntiquityJewelleryIntermediateCommodityCrafts()
+	{
+		foreach (var material in AntiquityJewelleryMetals)
+		{
+			AddAntiquityJewelleryCommodityCraft(
+				$"prepare {material} jewellery metal stock",
+				IsPreciousJewelleryMetal(material) ? "Silversmithing" : "Blacksmithing",
+				IsPreciousJewelleryMetal(material) ? "Silversmithing" : "Blacksmithing",
+				"Metal Jewellery",
+				$"prepare {material} for jewellery work",
+				[CommodityInput(500.0, material)],
+				MetalJewelleryStockTools(material),
+				[$"CommodityProduct - {FormatCommodityAmount(420.0)} of {material} commodity; tag Jewellery Metal Stock"]);
+
+			AddAntiquityJewelleryCommodityCraft(
+				$"draw {material} jewellery wire stock",
+				IsPreciousJewelleryMetal(material) ? "Silversmithing" : "Blacksmithing",
+				IsPreciousJewelleryMetal(material) ? "Silversmithing" : "Blacksmithing",
+				"Metal Jewellery",
+				$"draw {material} into jewellery wire",
+				[CommodityInput(420.0, material, "Jewellery Metal Stock")],
+				[
+					"TagTool - Held - an item with the Pliers tag",
+					"TagTool - Held - an item with the Hammer tag",
+					"TagTool - InRoom - an item with the Anvil tag"
+				],
+				[$"CommodityProduct - {FormatCommodityAmount(320.0)} of {material} commodity; tag Jewellery Wire Stock"]);
+		}
+
+		foreach (var material in AntiquityJewelleryBeadMaterials)
+		{
+			AddAntiquityJewelleryCommodityCraft(
+				$"drill {material} jewellery bead stock",
+				GetJewelleryBeadSkill(material),
+				GetJewelleryBeadSkill(material),
+				"Beads and Settings",
+				$"drill and polish {material} into jewellery beads",
+				[CommodityInput(260.0, material, colour: true, fineColour: true)],
+				JewelleryBeadTools(material),
+				[
+					$"CommodityProduct - {FormatCommodityAmount(190.0)} of {material} commodity; tag Jewellery Bead Stock; characteristic Colour from $i1; characteristic Fine Colour from $i1"
+				]);
+
+			AddAntiquityJewelleryCommodityCraft(
+				$"cut {material} jewellery setting stock",
+				GetJewelleryBeadSkill(material),
+				GetJewelleryBeadSkill(material),
+				"Beads and Settings",
+				$"cut and polish {material} into jewellery settings",
+				[CommodityInput(240.0, material, colour: true, fineColour: true)],
+				JewelleryBeadTools(material),
+				[
+					$"CommodityProduct - {FormatCommodityAmount(170.0)} of {material} commodity; tag Jewellery Setting Stock; characteristic Colour from $i1; characteristic Fine Colour from $i1"
+				]);
+		}
+	}
+
+	private void AddAntiquityJewelleryCommodityCraft(string name, string category, string traitName, string knowledgeSubtype,
+		string blurb, IEnumerable<string> inputs, IEnumerable<string> tools, IEnumerable<string> products)
+	{
+		AddAntiquityCraft(
+			name,
+			category,
+			blurb,
+			name,
+			$"{blurb} in progress",
+			AncientJewelleryCraftingKnowledge,
+			traitName,
+			15,
+			Difficulty.Easy,
+			AntiquityJewelleryIntermediatePhases(),
+			inputs,
+			tools,
+			products,
+			knowledgeSubtype: knowledgeSubtype,
+			knowledgeDescription: $"{AncientJewelleryCraftingKnowledge} covers reusable stock preparation for antiquity jewellery.",
+			knowledgeLongDescription: $"{AncientJewelleryCraftingKnowledge} covers reusable stock preparation for antiquity jewellery.");
+	}
+
+	private void SeedAntiquityJewelleryFinishedCraft(string stableReference, GameItemProto item,
+		IDictionary<string, int> usedCraftNames)
+	{
+		var material = GetMaterialName(item);
+		var materialScanText = $"{stableReference} {item.ShortDescription} {item.FullDescription}".ToLowerInvariant();
+		var path = GetAntiquityJewelleryCraftPath(material, materialScanText);
+		var inputs = BuildAntiquityJewelleryFinalInputs(item, material, materialScanText, path);
+		var displayName = SanitiseAntiquityJewelleryVisibleName(item.ShortDescription);
+		var craftName = BuildUniqueAntiquityEquipmentCraftName(usedCraftNames, "make", StripLeadingArticle(displayName));
+
+		AddAntiquityCraft(
+			craftName,
+			path.Category,
+			$"{path.Verb} {displayName}",
+			$"{path.Gerund} {displayName}",
+			$"{displayName} being made",
+			AncientJewelleryCraftingKnowledge,
+			path.Skill,
+			path.MinimumTraitValue,
+			path.Difficulty,
+			AntiquityJewelleryFinalPhases(),
+			inputs,
+			path.Tools,
+			[$"SimpleProduct - 1x {item.ShortDescription} (#{item.Id})"],
+			knowledgeSubtype: path.KnowledgeSubtype,
+			knowledgeDescription: $"{AncientJewelleryCraftingKnowledge} covers culture-neutral antiquity jewellery making from prepared metal, bead, and setting stock.",
+			knowledgeLongDescription: $"{AncientJewelleryCraftingKnowledge} covers culture-neutral antiquity jewellery making from prepared metal, bead, and setting stock.");
+	}
+
+	private static List<string> BuildAntiquityJewelleryFinalInputs(GameItemProto item, string material,
+		string lowerText, AntiquityJewelleryCraftPath path)
+	{
+		var primaryAmount = Math.Max(8.0, item.Weight * 0.7);
+		var inputs = new List<string>
+		{
+			CommodityInput(primaryAmount, material, path.PrimaryStockTag,
+				colour: path.PrimaryStockTag.Equals("Jewellery Bead Stock", StringComparison.OrdinalIgnoreCase),
+				fineColour: path.PrimaryStockTag.Equals("Jewellery Bead Stock", StringComparison.OrdinalIgnoreCase))
+		};
+
+		if (ContainsAny(lowerText, "necklace", "collar", "headband", "brow band", "diadem", "circlet"))
+		{
+			inputs.Add(CommodityInput(45.0, "linen", "Military Cord Stock", colour: true, fineColour: true));
+		}
+
+		if (ContainsAny(lowerText, "bracelet", "armlet", "anklet", "earring", "ring", "torc", "fibula", "brooch") &&
+		    !path.PrimaryStockTag.Equals("Jewellery Wire Stock", StringComparison.OrdinalIgnoreCase))
+		{
+			inputs.Add(CommodityInput(35.0, GetJewelleryMetalMaterial(material, lowerText), "Jewellery Wire Stock"));
+		}
+
+		var accentMaterial = GetJewelleryAccentMaterial(material, lowerText);
+		if (accentMaterial is not null && !accentMaterial.Equals(material, StringComparison.OrdinalIgnoreCase))
+		{
+			inputs.Add(CommodityInput(30.0, accentMaterial, "Jewellery Setting Stock", colour: true, fineColour: true));
+		}
+
+		if (ContainsAny(lowerText, "bead", "pearl", "amber", "glass", "lapis", "turquoise", "agate") &&
+		    !path.PrimaryStockTag.Equals("Jewellery Bead Stock", StringComparison.OrdinalIgnoreCase))
+		{
+			inputs.Add(CommodityInput(40.0, accentMaterial ?? GetJewelleryBeadMaterial(material, lowerText),
+				"Jewellery Bead Stock", colour: true, fineColour: true));
+		}
+
+		return inputs;
+	}
+
+	private static AntiquityJewelleryCraftPath GetAntiquityJewelleryCraftPath(string material, string lowerText)
+	{
+		if (IsJewelleryMetal(material))
+		{
+			var stockTag = ContainsAny(lowerText, "wire", "chain", "coil", "spiral", "hoop", "torc", "ankle ring")
+				? "Jewellery Wire Stock"
+				: "Jewellery Metal Stock";
+			var category = IsPreciousJewelleryMetal(material) ? "Silversmithing" : "Blacksmithing";
+			var minimum = IsPreciousJewelleryMetal(material) ? 35 : 20;
+			var difficulty = IsPreciousJewelleryMetal(material) || GetJewelleryAccentMaterial(material, lowerText) is not null
+				? Difficulty.Hard
+				: Difficulty.Normal;
+			return new AntiquityJewelleryCraftPath(category, category, "Metal Jewellery", stockTag, "shape", "shaping",
+				minimum, difficulty, MetalJewelleryFinalTools(material, lowerText));
+		}
+
+		if (material.Equals("glass", StringComparison.OrdinalIgnoreCase) ||
+		    material.Equals("glazed ceramic", StringComparison.OrdinalIgnoreCase))
+		{
+			return new AntiquityJewelleryCraftPath("Glassworking", "Glassworking", "Glass Beads",
+				"Jewellery Bead Stock", "string", "stringing", 25, Difficulty.Normal,
+				[
+					"TagTool - Held - an item with the Beading Needle tag",
+					"TagTool - InRoom - an item with the Lit Glory Hole tag",
+					"TagTool - Held - an item with the Polishing Stone tag"
+				]);
+		}
+
+		if (material.Equals("bone", StringComparison.OrdinalIgnoreCase) ||
+		    material.Equals("ivory", StringComparison.OrdinalIgnoreCase))
+		{
+			return new AntiquityJewelleryCraftPath("Bonecarving", "Bonecarving", "Bone and Ivory Jewellery",
+				"Jewellery Bead Stock", "carve", "carving", 20, Difficulty.Normal,
+				[
+					"TagTool - Held - an item with the Bow Drill tag",
+					"TagTool - Held - an item with the Polishing Stone tag"
+				]);
+		}
+
+		if (material.Equals("wood", StringComparison.OrdinalIgnoreCase))
+		{
+			return new AntiquityJewelleryCraftPath("Carpentry", "Carpentry", "Wooden Bead Jewellery",
+				"Jewellery Bead Stock", "string", "stringing", 15, Difficulty.Easy, JewelleryBeadTools(material));
+		}
+
+		return new AntiquityJewelleryCraftPath("Gemcraft", "Gemcraft", "Beads and Settings",
+			"Jewellery Bead Stock", "polish", "polishing", 25, Difficulty.Normal, JewelleryBeadTools(material));
+	}
+
+	private static (int Seconds, string Echo, string FailEcho)[] AntiquityJewelleryIntermediatePhases()
+	{
+		return
+		[
+			(25, "$0 inspect|inspects $i1 and select|selects pieces fit for jewellery work.", "$0 inspect|inspects $i1, but miss|misses flaws in the material."),
+			(35, "$0 work|works the material into small, regular stock.", "$0 work|works the material unevenly."),
+			(25, "$0 finish|finishes the jewellery stock and set|sets aside $p1.", "$0 finish|finishes the stock, but the result is not worth keeping.")
+		];
+	}
+
+	private static (int Seconds, string Echo, string FailEcho)[] AntiquityJewelleryFinalPhases()
+	{
+		return
+		[
+			(30, "$0 lay|lays out $i1 and check|checks the prepared jewellery stock.", "$0 lay|lays out $i1, but overlook|overlooks a flaw in the stock."),
+			(40, "$0 shape|shapes, pierce|pierces, and fit|fits the main form with $t1.", "$0 shape|shapes the piece poorly with $t1."),
+			(35, "$0 polish|polishes and secure|secures the finer details.", "$0 polish|polishes the piece, but the fitting slips out of true."),
+			(25, "$0 set|sets aside $p1 after a final inspection.", "$0 set|sets aside the work, but it is not worth keeping.")
+		];
+	}
+
+	private static string[] MetalJewelleryStockTools(string material)
+	{
+		return IsPreciousJewelleryMetal(material)
+			?
+			[
+				"TagTool - Held - an item with the Crucible tag",
+				"TagTool - Held - an item with the Crucible Tongs tag",
+				"TagTool - InRoom - an item with the Lit Smelting Furnace tag"
+			]
+			:
+			[
+				"TagTool - InRoom - an item with the Lit Smelting Furnace tag",
+				"TagTool - Held - an item with the Forge Tongs tag",
+				"TagTool - InRoom - an item with the Anvil tag",
+				"TagTool - Held - an item with the Hammer tag"
+			];
+	}
+
+	private static string[] MetalJewelleryFinalTools(string material, string lowerText)
+	{
+		if (IsPreciousJewelleryMetal(material) || ContainsAny(lowerText, "gilt", "inlaid", "garnet", "emerald", "pearl"))
+		{
+			return
+			[
+				"TagTool - Held - an item with the Pliers tag",
+				"TagTool - Held - an item with the Bronze Burnisher tag",
+				"TagTool - Held - an item with the Polishing Stone tag"
+			];
+		}
+
+		return
+		[
+			"TagTool - Held - an item with the Pliers tag",
+			"TagTool - Held - an item with the Hammer tag",
+			"TagTool - InRoom - an item with the Anvil tag"
+		];
+	}
+
+	private static string[] JewelleryBeadTools(string material)
+	{
+		if (material.Equals("glass", StringComparison.OrdinalIgnoreCase) ||
+		    material.Equals("glazed ceramic", StringComparison.OrdinalIgnoreCase))
+		{
+			return
+			[
+				"TagTool - Held - an item with the Bow Drill tag",
+				"TagTool - Held - an item with the Polishing Stone tag",
+				"TagTool - InRoom - an item with the Lit Glory Hole tag"
+			];
+		}
+
+		return
+		[
+			"TagTool - Held - an item with the Bow Drill tag",
+			"TagTool - Held - an item with the Polishing Stone tag"
+		];
+	}
+
+	private static bool IsJewelleryMetal(string material)
+	{
+		return AntiquityJewelleryMetals.Contains(material, StringComparer.OrdinalIgnoreCase);
+	}
+
+	private static bool IsPreciousJewelleryMetal(string material)
+	{
+		return material.Equals("gold", StringComparison.OrdinalIgnoreCase) ||
+		       material.Equals("silver", StringComparison.OrdinalIgnoreCase) ||
+		       material.Equals("electrum", StringComparison.OrdinalIgnoreCase);
+	}
+
+	private static string GetJewelleryBeadSkill(string material)
+	{
+		if (material.Equals("glass", StringComparison.OrdinalIgnoreCase) ||
+		    material.Equals("glazed ceramic", StringComparison.OrdinalIgnoreCase))
+		{
+			return "Glassworking";
+		}
+
+		if (material.Equals("bone", StringComparison.OrdinalIgnoreCase) ||
+		    material.Equals("ivory", StringComparison.OrdinalIgnoreCase))
+		{
+			return "Bonecarving";
+		}
+
+		if (material.Equals("wood", StringComparison.OrdinalIgnoreCase))
+		{
+			return "Carpentry";
+		}
+
+		return "Gemcraft";
+	}
+
+	private static string GetJewelleryMetalMaterial(string material, string lowerText)
+	{
+		foreach (var metal in AntiquityJewelleryMetals)
+		{
+			if (lowerText.Contains(metal, StringComparison.OrdinalIgnoreCase))
+			{
+				return metal;
+			}
+		}
+
+		return IsJewelleryMetal(material) ? material : "bronze";
+	}
+
+	private static string GetJewelleryBeadMaterial(string material, string lowerText)
+	{
+		return GetJewelleryAccentMaterial(material, lowerText) ?? (AntiquityJewelleryBeadMaterials.Contains(material,
+			StringComparer.OrdinalIgnoreCase)
+			? material
+			: "glass");
+	}
+
+	private static string? GetJewelleryAccentMaterial(string material, string lowerText)
+	{
+		foreach (var accent in AntiquityJewelleryBeadMaterials)
+		{
+			if (!accent.Equals(material, StringComparison.OrdinalIgnoreCase) &&
+			    lowerText.Contains(accent, StringComparison.OrdinalIgnoreCase))
+			{
+				return accent;
+			}
+		}
+
+		foreach (var alias in AntiquityJewelleryMaterialAliases)
+		{
+			if (!alias.Material.Equals(material, StringComparison.OrdinalIgnoreCase) &&
+			    lowerText.Contains(alias.Alias, StringComparison.OrdinalIgnoreCase))
+			{
+				return alias.Material;
+			}
+		}
+
+		return null;
+	}
+
+	private static string SanitiseAntiquityJewelleryVisibleName(string shortDescription)
+	{
+		var text = SanitiseHouseholdCraftDisplayName(shortDescription);
+		foreach (var cultureTerm in AntiquityJewelleryCultureTerms)
+		{
+			text = text.Replace(cultureTerm, "", StringComparison.OrdinalIgnoreCase);
+		}
+
+		while (text.Contains("  ", StringComparison.Ordinal))
+		{
+			text = text.Replace("  ", " ", StringComparison.Ordinal);
+		}
+
+		return text.Replace(" ,", ",", StringComparison.Ordinal)
+			.Replace(" -", "-", StringComparison.Ordinal)
+			.Trim();
+	}
+}

--- a/DatabaseSeeder/Seeders/ItemSeederCrafting.cs
+++ b/DatabaseSeeder/Seeders/ItemSeederCrafting.cs
@@ -2141,6 +2141,7 @@ return ""You need at least {minimumTraitValue.Value.ToString(System.Globalizatio
 		SeedAntiquityAnatolianClothingCrafts();
 		SeedAntiquityScythianSarmatianClothingCrafts();
 		SeedAntiquityEquipmentCrafts();
+		SeedAntiquityJewelleryCrafts();
 		SeedAntiquityWritingCrafts();
 		SeedAntiquityMedicalCrafts();
 		SeedAntiquityFurnitureAndContainerCrafts();

--- a/DatabaseSeeder/Seeders/UsefulSeeder.Tags.cs
+++ b/DatabaseSeeder/Seeders/UsefulSeeder.Tags.cs
@@ -146,6 +146,11 @@ namespace DatabaseSeeder.Seeders
             AddTag(context, "Prosthetic Stock", "Medical Craft Stock");
             AddTag(context, "Surgical Tool Blank", "Medical Craft Stock");
             AddTag(context, "Herbal Remedy Stock", "Medical Craft Stock");
+            AddTag(context, "Jewellery Craft Stock", "Material Functions");
+            AddTag(context, "Jewellery Metal Stock", "Jewellery Craft Stock");
+            AddTag(context, "Jewellery Wire Stock", "Jewellery Craft Stock");
+            AddTag(context, "Jewellery Bead Stock", "Jewellery Craft Stock");
+            AddTag(context, "Jewellery Setting Stock", "Jewellery Craft Stock");
 
             AddTag(context, "Repairing", "Functions");
             AddTag(context, "Sharpening", "Functions");
@@ -615,6 +620,7 @@ namespace DatabaseSeeder.Seeders
             AddTag(context, "Snap Tool", "Glassblowing Tools");
             AddTag(context, "Punty Paddle", "Glassblowing Tools");
             AddTag(context, "Glory Hole", "Glassblowing Tools");
+            AddTag(context, "Lit Glory Hole", "Glory Hole");
             AddTag(context, "Annealing Lehr", "Glassblowing Tools");
             AddTag(context, "Lit Annealing Lehr", "Annealing Lehr");
 

--- a/Design Documents/Crafting/Antiquity_Crafting_Audit.md
+++ b/Design Documents/Crafting/Antiquity_Crafting_Audit.md
@@ -9,10 +9,10 @@ Current item definitions are seeded from:
 | Source | Current Item Definitions |
 | --- | ---: |
 | `DatabaseSeeder/Seeders/ItemSeeder.Rework.Antiquity.cs` | 995 |
-| `DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityHouseholdTools.cs` | 63 |
+| `DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityHouseholdTools.cs` | 65 |
 | `DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityMedical.cs` | 41 |
 | `DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityWriting.cs` | 33 |
-| Total | 1132 |
+| Total | 1134 |
 
 Current craft definitions are seeded from:
 
@@ -21,14 +21,16 @@ Current craft definitions are seeded from:
 | `ItemSeederCrafting.Antiquity.cs` | Textile, leather, and older shared antiquity craft chains. |
 | `ItemSeederCrafting.AntiquityEquipment.cs` | Common clothing/accessories, equipment stock, military goods, and heat-source lighting crafts. |
 | `ItemSeederCrafting.AntiquityHousehold.cs` | Household, container, vessel, door, gate, and furnishing craft discovery. |
+| `ItemSeederCrafting.AntiquityJewellery.cs` | Jewellery stock, beads, settings, wire, and final jewellery craft discovery. |
 | `ItemSeederCrafting.AntiquityMedical.cs` | Medical supplies, remedies, surgical tools, mobility aids, and prosthetics. |
 | `ItemSeederCrafting.AntiquityWriting.cs` | Writing surfaces, implements, inks, scrolls, codices, and document containers. |
 
 The suite-specific docs now catalogue every stable reference explicitly named by those craft source files. Dynamic discovery surfaces are documented by their source counts and inventory lists:
 
 - 398 household/container/door/furniture targets discovered from household, writing, religious, lighting, heating, construction, and writing-product tag roots.
+- 162 jewellery targets discovered from jewellery tags and catalogued in the dedicated jewellery suite.
 - 193 military equipment targets discovered from `Market / Military Goods`, split into 76 armour prototypes and 117 weapon, shield, ammunition, sling, and accessory prototypes.
-- 356 stable references explicitly named in the current antiquity craft source files.
+- 356 stable references explicitly named in the current non-jewellery antiquity craft source files, plus the dynamically discovered jewellery catalogue.
 
 ## Verified Invariants
 
@@ -38,12 +40,15 @@ The suite-specific docs now catalogue every stable reference explicitly named by
 - Heat-source lighting crafts consume `charcoal`, produce the lit apparatus, and return the unlit apparatus on failure.
 - Literal commodity product tags are either consumed downstream or documented as reusable stock outputs.
 - Low-heat medical recipes that boil, warm, or steep in a cooking pot now also require an in-room `Fire` tool, so they use the lit workshop hearth convention.
+- Jewellery uses a dedicated `Ancient Jewellery Crafting` knowledge gate with metal, wire, bead, and setting stock.
+- Support tools and unlit workshop apparatus are now craftable through the expanded equipment toolmaking pass.
+- Glassworking now uses a lit glory-hole furnace for hot working and a lit annealing lehr for cooling finished glass.
 
-## Remaining Logical Gaps
+## Second-Pass Resolution
 
-The current audit leaves these as deliberate follow-up gaps rather than hidden assumptions:
+The next-pass implementation resolves the earlier follow-up gaps as follows:
 
-- `SeedAntiquityJewellery` currently contains 162 item prototypes in the main antiquity item source, but there is no dedicated jewellery craft file or per-reference jewellery crafting catalogue. Existing tests treat jewellery as an older covered surface; the next audit should either add jewellery crafts or explicitly mark jewellery as stock-only.
-- Newly introduced support tools and unlit workshop apparatus are seeded prerequisites. Crafts to manufacture those tools and apparatus remain the second-pass boundary unless they already belong to an existing product suite.
-- Glassworking currently uses `Glass Batch`, blowing tools, and the lit annealing lehr as the current craftable glass chain. A dedicated glass furnace or glory-hole style apparatus would be a better simulation if glasswork needs to move beyond this abstraction.
-- The craft system still relies on commodity tags and item stable references rather than a generated external catalogue. The tests now protect the docs from drifting away from the current source, but the docs are maintained rather than generated.
+- `SeedAntiquityJewelleryCrafts()` now discovers all 162 `SeedAntiquityJewellery` prototypes and `Antiquity_Jewellery_Crafting_Suite.md` catalogues every stable reference.
+- The expanded equipment craft pass discovers stock support tools from `Market / Professional Tools / Standard Tools` and explicitly includes unlit workshop apparatus. Support tools and unlit workshop apparatus are now craftable instead of remaining stock-only prerequisites.
+- Glassworking now has a glassworking glory-hole furnace pair, `antiquity_glory_hole_furnace` and `antiquity_lit_glory_hole_furnace`. Hot glassworking crafts require the lit glory-hole furnace, while annealing still requires the lit annealing lehr.
+- The external-catalogue risk is handled with source-backed regression tests rather than a generated file pipeline: tests parse the live seeder source, compare counts, and verify that dynamic catalogues are represented in the dedicated design documents.

--- a/Design Documents/Crafting/Antiquity_Equipment_Crafting_Suite.md
+++ b/Design Documents/Crafting/Antiquity_Equipment_Crafting_Suite.md
@@ -1,16 +1,18 @@
 # Antiquity Equipment Crafting Suite
 
-This document records the craft suite that closes the remaining non-household antiquity gaps from `ItemSeeder.Rework.Antiquity.cs`: common clothing/accessories, textile and leather craft tools, non-leather armour, weapons, shields, ammunition, slings, and the construction hardware used by doors and gates.
+This document records the craft suite that closes the remaining non-household antiquity gaps from `ItemSeeder.Rework.Antiquity.cs`: common clothing/accessories, textile and leather craft tools, support tools, unlit workshop apparatus, non-leather armour, weapons, shields, ammunition, slings, and the construction hardware used by doors and gates.
 
 ## Target Surface
 
 - 29 antiquity craft-tool prototypes from `SeedAntiquityClothing`.
+- Support tool prototypes discovered from `Market / Professional Tools / Standard Tools`, excluding writing and medical products already owned by their dedicated suites.
+- Unlit workshop apparatus prototypes for the hearth, kiln, glory-hole furnace, annealing lehr, and smelting furnace.
 - 18 common culture-neutral clothing/accessory prototypes from `SeedAntiquityClothing`.
 - 76 non-leather armour prototypes from `SeedAntiquityArmour`.
 - 117 weapon, shield, ammunition, sling, and military-accessory prototypes from `SeedAntiquityWeaponsShieldsAccessories`.
 - Shared `Door Hardware Stock` used by the expanded household/door suite.
 
-Existing jewellery, culture-specific textile clothing, leather clothing, leather armour, leather containers, leather furnishings, and household goods stay on their existing suites. The equipment suite discovers military goods dynamically from `Market / Military Goods` tags and excludes stable references already handled by the culture/leather suites.
+Existing jewellery, culture-specific textile clothing, leather clothing, leather armour, leather containers, leather furnishings, medical goods, writing goods, and household goods stay on their existing suites. The equipment suite discovers military goods dynamically from `Market / Military Goods` tags, discovers support tools dynamically from `Market / Professional Tools / Standard Tools`, and excludes stable references already handled by the culture/leather/writing/medical suites.
 
 ## Implementation
 
@@ -33,7 +35,7 @@ The May 2026 one-step-back pass audits the full `ItemSeederCrafting.Antiquity*.c
 - every literal commodity product tag produced by an antiquity craft
 - every literal commodity input pile tag that should be produced upstream or intentionally remain a reusable stock output
 
-The seeded tool closure now includes the previously missing heat and metal tools (`Fire`, `Bellows`, `Forge Tongs`, `Anvil`, `Hammer`, `Pliers`, `Cooking Pot`, `Sharpening`, and lit high-heat apparatus), dye/textile/leather tools (`Dye Strainer`, `Indigo Beating Paddle`, `Leather Paring Knife`, `Rope Hook`, `Twine Shuttle`), writing/book/pigment tools, and medical preparation tools. These are seeded as stock prerequisites; crafts to manufacture newly introduced support tools are the explicit second-pass boundary unless a support item already belongs to a current craft-product suite.
+The seeded tool closure now includes the previously missing heat and metal tools (`Fire`, `Bellows`, `Forge Tongs`, `Anvil`, `Hammer`, `Pliers`, `Cooking Pot`, `Sharpening`, and lit high-heat apparatus), dye/textile/leather tools (`Dye Strainer`, `Indigo Beating Paddle`, `Leather Paring Knife`, `Rope Hook`, `Twine Shuttle`), writing/book/pigment tools, and medical preparation tools. The second-pass implementation now makes the equipment-owned support tools and unlit workshop apparatus craftable; writing and medical support items remain owned by their dedicated craft files.
 
 Lit workshop objects are craft-tool state markers, not runtime heat/light components. Current stock pairs are:
 
@@ -42,9 +44,10 @@ Lit workshop objects are craft-tool state markers, not runtime heat/light compon
 | `antiquity_workshop_hearth` | `antiquity_lit_workshop_hearth` | `Fire` |
 | `antiquity_clay_smelting_furnace` | `antiquity_lit_clay_smelting_furnace` | `Lit Smelting Furnace`, `Hot Fire` |
 | `antiquity_updraft_kiln` | `antiquity_lit_updraft_kiln` | `Lit Kiln`, `Hot Fire` |
+| `antiquity_glory_hole_furnace` | `antiquity_lit_glory_hole_furnace` | `Lit Glory Hole`, `Hot Fire` |
 | `antiquity_annealing_lehr` | `antiquity_lit_annealing_lehr` | `Lit Annealing Lehr`, `Hot Fire` |
 
-Reusable intermediate outputs that are intentionally allowed to sit at a stock boundary are: `Armour Lamella Stock`, `Armour Plate Stock`, `Armour Ring Stock`, `Armour Scale Stock`, `Bisque Vessel Blank`, `Bookbinding Stock`, `Bow Stave`, `Carved Wood Stock`, `Coopered Staves`, `Decoction Stock`, `Door Hardware Stock`, `Dyed Cloth`, `Fulled Cloth`, `Glass Batch`, `Glass Vessel Blank`, `Helmet Bowl Stock`, `Herbal Remedy Stock`, `Ink Stock`, `Lake Pigment`, `Leather Scale`, `Paint Pigment`, `Papyrus Sheet Stock`, `Pen Blank`, `Prosthetic Stock`, `Sealed Leather Panel`, `Shield Board Stock`, `Shield Facing Stock`, `Splint Stock`, `Stone Vessel Blank`, `Surgical Tool Blank`, `Suture Stock`, `Tablet Blank`, `Waxed Tablet Board`, `Weapon Blade Stock`, `Weapon Head Stock`, `Weapon Shaft Stock`, `Wet Vessel Blank`, and `Woven Cloth`.
+Reusable intermediate outputs that are intentionally allowed to sit at a stock boundary are: `Armour Lamella Stock`, `Armour Plate Stock`, `Armour Ring Stock`, `Armour Scale Stock`, `Bisque Vessel Blank`, `Bookbinding Stock`, `Bow Stave`, `Carved Wood Stock`, `Coopered Staves`, `Decoction Stock`, `Door Hardware Stock`, `Dyed Cloth`, `Fulled Cloth`, `Glass Batch`, `Glass Vessel Blank`, `Helmet Bowl Stock`, `Herbal Remedy Stock`, `Ink Stock`, `Jewellery Bead Stock`, `Jewellery Metal Stock`, `Jewellery Setting Stock`, `Jewellery Wire Stock`, `Lake Pigment`, `Leather Scale`, `Paint Pigment`, `Papyrus Sheet Stock`, `Pen Blank`, `Prosthetic Stock`, `Sealed Leather Panel`, `Shield Board Stock`, `Shield Facing Stock`, `Splint Stock`, `Stone Vessel Blank`, `Surgical Tool Blank`, `Suture Stock`, `Tablet Blank`, `Tool Blank Stock`, `Waxed Tablet Board`, `Weapon Blade Stock`, `Weapon Head Stock`, `Weapon Shaft Stock`, `Wet Vessel Blank`, and `Woven Cloth`.
 
 ## Knowledge Gates
 
@@ -53,7 +56,7 @@ Reusable intermediate outputs that are intentionally allowed to sit at a stock b
 | `Ancient Equipment Crafting` | Shared construction and equipment stock, especially door and gate hardware. |
 | `Ancient Weaponcrafting` | Weapon blade/head stock, shafts, bow staves, fletching stock, cord stock, ammunition, bows, slings, spears, blades, hafted weapons, and wooden weapons. |
 | `Ancient Armourcrafting` | Helmet bowls, armour plates, rings, scales, lamellae, textile padding, shields, and final armour assembly. |
-| `Ancient Toolmaking` | Metal, wooden, textile, and leather tool blanks plus final craft-tool prototypes. |
+| `Ancient Toolmaking` | Metal, wooden, textile, leather, stone, bone, shell, glass, support-tool, and unlit apparatus prototypes. |
 | `Ancient Common Clothing Crafting` | Culture-neutral common clothing and accessories left outside the culture garment suites. |
 
 ## Commodity Tags
@@ -76,7 +79,7 @@ All equipment stock tags are seeded under `Functions / Material Functions / Anti
 | `Armour Scale Stock` | Scale armour stock. |
 | `Armour Lamella Stock` | Lamellar armour stock. |
 | `Armour Textile Padding` | Layered textile padding for armour and armour linings. |
-| `Tool Blank Stock` | Reusable metal, wooden, textile, or leather stock for craft tools. |
+| `Tool Blank Stock` | Reusable metal, wooden, textile, leather, ceramic, stone, bone, shell, and glass stock for craft tools. |
 | `Door Hardware Stock` | Hinges, straps, latch plates, bars, and fittings for doors and gates. |
 
 ## Source-Audited Product Catalogue

--- a/Design Documents/Crafting/Antiquity_Furniture_Container_Crafting_Suite.md
+++ b/Design Documents/Crafting/Antiquity_Furniture_Container_Crafting_Suite.md
@@ -204,6 +204,8 @@ The household-tool source now owns the shared antiquity workshop tool catalogue 
 | `antiquity_marver_slab` | `Marver Table` | a stone marver slab |
 | `antiquity_glassworking_jacks` | `Jacks` | a pair of bronze glassworking jacks |
 | `antiquity_glass_shears` | `Glass Shears` | a pair of bronze glass shears |
+| `antiquity_glory_hole_furnace` | `Glory Hole` | an unlit glassworking glory-hole furnace |
+| `antiquity_lit_glory_hole_furnace` | `Glory Hole`, `Lit Glory Hole`, `Hot Fire` | a lit glassworking glory-hole furnace |
 | `antiquity_annealing_lehr` | `Annealing Lehr` | a small annealing lehr |
 | `antiquity_lit_annealing_lehr` | `Annealing Lehr`, `Lit Annealing Lehr`, `Hot Fire` | a lit annealing lehr |
 | `antiquity_casting_crucible` | `Crucible` | a bronze casting crucible |
@@ -244,8 +246,8 @@ These are the upstream craft families to implement before final products. The ex
 | Prepare pottery clay body | Pottery | Ancient Ceramic Vesselmaking | Clay or earthenware commodity, water | Pug mill or hand tools | Commodity tagged `Pottery Clay Body`. |
 | Form wet vessel blanks | Pottery | Ancient Ceramic Vesselmaking | `Pottery Clay Body` | Potter's wheel, rib, clay knife | Commodity tagged `Wet Vessel Blank`. |
 | Fire bisque vessel blanks | Pottery | Ancient Ceramic Vesselmaking | `Wet Vessel Blank`, fuel | Lit kiln | Commodity tagged `Bisque Vessel Blank`. |
-| Prepare glass batch | Glassworking | Ancient Glassworking | Soda-lime glass inputs or glass commodity | Crucible, kiln/glory heat | Commodity tagged `Glass Batch`. |
-| Blow glass vessel blanks | Glassworking | Ancient Glassworking | `Glass Batch` | Blowpipe, pontil, marver, jacks, lit annealing lehr | Commodity tagged `Glass Vessel Blank`. |
+| Prepare glass batch | Glassworking | Ancient Glassworking | Soda-lime glass inputs or glass commodity | Crucible and cold batch tools | Commodity tagged `Glass Batch`. |
+| Blow glass vessel blanks | Glassworking | Ancient Glassworking | `Glass Batch` | Blowpipe, pontil, marver, jacks, lit glory-hole furnace, lit annealing lehr | Commodity tagged `Glass Vessel Blank`. |
 | Cast vessel blanks | Blacksmithing or Silversmithing | Ancient Metal Vesselmaking | Bronze, iron, silver, or gold commodity | Crucible, tongs, mould, lit smelting furnace | Commodity tagged `Cast Vessel Blank`. |
 | Carve stone vessel blanks | Masonry or Scrimshawing | Ancient Stone Bone and Horn Carving | Alabaster, calcite, horn, or ivory commodity | Chisel, mallet, bow drill, polishing stone | Commodity tagged `Stone Vessel Blank`. |
 | Prepare inlay stock | Scrimshawing, Glassworking, or Silversmithing | Ancient Household Crafting | Ivory, glass, shell, metal, or coloured stone commodity | Saw, chisel, polishing stone | Commodity tagged `Inlay Stock`. |
@@ -262,7 +264,7 @@ Each final craft should use one row from this family table and one stable produc
 | Textile and Leather Goods | 57 | Tailoring or Leathermaking | Ancient Leather Containers, Ancient Household Crafting, or culture-specific household knowledge | `Garment Cloth`, `Spun Yarn`, `Prepared Leather Panel`, hide/fur commodity, optional `Lamp Wick`, optional `Bead Stock`. | Sewing needle, shears, leather awl, stitching pony, edge beveller. | Stable simple/variable product. |
 | Coopering | 7 | Coopering | Ancient Coopering | `Coopered Staves`, `Hoop Stock`, optional pitch or wax seal. | Cooper's adze, croze, hoop driver, bung borer, mallet. | Dry or liquid container stable product. |
 | Pottery and Fired Clay | 85 | Pottery | Ancient Ceramic Vesselmaking or culture-specific household knowledge | `Pottery Clay Body`, `Wet Vessel Blank`, `Bisque Vessel Blank`, optional slip/glaze/pigment, optional wick for lamps. | Potter's wheel, rib, clay knife, loop tool, stamp, lit kiln. | Stable product; variable colour products when painted/glazed descriptors require it. |
-| Glassworking | 10 | Glassworking | Ancient Glassworking or culture-specific household knowledge | `Glass Batch`, `Glass Vessel Blank`, optional `Glass Panes`, optional pigment/colour stock. | Blowpipe, pontil, marver, jacks, shears, lit annealing lehr. | Stable product. |
+| Glassworking | 10 | Glassworking | Ancient Glassworking or culture-specific household knowledge | `Glass Batch`, `Glass Vessel Blank`, optional `Glass Panes`, optional pigment/colour stock. | Blowpipe, pontil, marver, jacks, shears, lit glory-hole furnace, lit annealing lehr. | Stable product. |
 | Metal Vesselmaking and Casting | 49 | Blacksmithing or Silversmithing | Ancient Metal Vesselmaking or culture-specific household knowledge | Bronze/iron/silver/gold `Cast Vessel Blank`, optional `Rivet`, `Hoop Stock`, `Inlay Stock`, lamp wick. | Crucible, tongs, lit smelting furnace, hammer, anvil, burnisher. | Stable product. |
 | Stone Bone and Horn Carving | 12 | Masonry or Scrimshawing | Ancient Stone Bone and Horn Carving or culture-specific household knowledge | `Stone Vessel Blank`, exact alabaster/calcite/horn/ivory commodity, optional polish/inlay. | Stone chisel, stone mallet, bow drill, polishing stone. | Stable product. |
 | Candlemaking and Wicks | 2 | Candlemaking | Ancient Lighting and Heating | Beeswax commodity, `Lamp Wick`, optional dye/pigment. | Candle mould, knife. | Stable product. |

--- a/Design Documents/Crafting/Antiquity_Jewellery_Crafting_Suite.md
+++ b/Design Documents/Crafting/Antiquity_Jewellery_Crafting_Suite.md
@@ -1,0 +1,80 @@
+# Antiquity Jewellery Crafting Suite
+
+This document records the dedicated craft suite for the `SeedAntiquityJewellery` catalogue in `DatabaseSeeder/Seeders/ItemSeeder.Rework.Antiquity.cs`. Jewellery was previously treated as an older covered surface by the broad antiquity audit; the next-pass implementation now gives it a real craft source, upstream commodity chain, knowledge gate, and per-reference catalogue.
+
+## Target Surface
+
+- 162 jewellery prototypes from `SeedAntiquityJewellery`.
+- Dynamic product discovery through `Functions / Worn Items / Jewellery` tags and stable references beginning with `jewellery_`.
+- Metal, wire, bead, and setting stock for the materials present in the current catalogue.
+- Culture-neutral craft names and visible echoes generated from item short descriptions rather than stable reference names.
+
+## Implementation
+
+The implementation lives in `DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityJewellery.cs` and is registered from `SeedCrafts()` through `SeedAntiquityJewelleryCrafts()`.
+
+The suite follows the same stock pattern as the other antiquity craft suites:
+
+- `SeedAntiquityJewelleryIntermediateCommodityCrafts()` creates reusable stock commodities first.
+- Final crafts discover current jewellery prototypes from seeded item tags and scan the stable reference, short description, and full description for material requirements.
+- Final crafts produce the exact seeded prototype by ID and short description.
+- Knowledge-gated `AddAntiquityCraft` calls use `Ancient Jewellery Crafting`.
+- Visible craft text is sanitised through `SanitiseAntiquityJewelleryVisibleName(item.ShortDescription)`.
+
+## Knowledge And Skills
+
+| Knowledge | Used For |
+| --- | --- |
+| `Ancient Jewellery Crafting` | Metal jewellery, wire jewellery, bead strings, gem settings, bone/ivory ornaments, shell ornaments, and glass beads. |
+
+| Material or Form | Main Skill | Notes |
+| --- | --- | --- |
+| Bronze, copper, and wrought iron jewellery | `Blacksmithing` | Uses prepared metal or wire stock with pliers, hammer/anvil, or burnishing tools. |
+| Gold, silver, and electrum jewellery | `Silversmithing` | Uses precious-metal stock and finer finishing tools. |
+| Glass and glazed ceramic beads | `Glassworking` | Uses the lit glory-hole furnace and polishing tools. |
+| Bone and ivory jewellery | `Bonecarving` | Uses drilling and polishing tools. |
+| Gem, shell, amber, pearl, agate, carnelian, jasper, quartz, lapis, turquoise, and similar bead stock | `Gemcraft` | Uses drilling, polishing, and setting stock. |
+| Wooden bead jewellery | `Carpentry` | Uses drilling and polishing tools for simple wooden ornaments. |
+
+## Commodity Tags
+
+All jewellery stock tags are seeded under `Functions / Material Functions / Jewellery Craft Stock` and exported to `Design Documents/Data/SeededTagHierarchy.csv`.
+
+| Tag | Purpose |
+| --- | --- |
+| `Jewellery Metal Stock` | Small prepared billets, sheet, strips, plaques, and mounts for non-wire jewellery. |
+| `Jewellery Wire Stock` | Drawn wire and coiled wire for torcs, bracelets, rings, anklets, earrings, chains, and fine links. |
+| `Jewellery Bead Stock` | Drilled and polished beads or bead-like ornaments made from glass, ceramic, shell, bone, ivory, wood, amber, pearl, and gemstones. |
+| `Jewellery Setting Stock` | Cabochons, inlays, plaques, and small polished settings used as accent material in metal jewellery. |
+
+## Source-Audited Product Catalogue
+
+The code discovers this catalogue dynamically, but every current stable reference is listed here so the source-backed tests catch accidental drift.
+
+### Anklets (22)
+
+`jewellery_bronze_ankle_hoops`, `jewellery_bronze_chain_anklets`, `jewellery_bronze_heavy_anklets`, `jewellery_bronze_link_anklets`, `jewellery_bronze_tapered_anklets`, `jewellery_copper_ankle_rings`, `jewellery_copper_ankle_rings_valley`, `jewellery_copper_bell_anklets`, `jewellery_electrum_ankle_rings`, `jewellery_gold_carnelian_anklets`, `jewellery_gold_carnelian_bead_anklets`, `jewellery_gold_inlaid_turquoise_anklets`, `jewellery_gold_pearl_anklets`, `jewellery_gold_rosette_anklets`, `jewellery_gold_rosette_sea_anklets`, `jewellery_gold_spiral_anklets`, `jewellery_gold_turquoise_anklets`, `jewellery_granulated_gold_anklets`, `jewellery_shell_bead_anklets`, `jewellery_shell_copper_anklets`, `jewellery_shell_laced_anklets`, `jewellery_silver_bell_anklets`
+
+### Bracelets (22)
+
+`jewellery_blue_glazed_ceramic_bracelets`, `jewellery_bronze_disc_bracelet`, `jewellery_bronze_open_armlet`, `jewellery_bronze_open_bracelet`, `jewellery_bronze_pair_bracelets`, `jewellery_bronze_rounded_armlet`, `jewellery_bronze_spiral_bracelet`, `jewellery_carved_ivory_bangle`, `jewellery_copper_ram_bracelet`, `jewellery_electrum_spiral_bracelets`, `jewellery_glass_bead_bracelet`, `jewellery_gold_carnelian_bracelet`, `jewellery_gold_carnelian_bracelets`, `jewellery_gold_falcon_bracelets`, `jewellery_gold_griffin_armlet`, `jewellery_gold_griffin_armlets`, `jewellery_gold_lapis_bracelets`, `jewellery_gold_openwork_bracelets`, `jewellery_gold_ribbon_bracelet`, `jewellery_gold_serpent_bracelets`, `jewellery_gold_snake_head_armlet`, `jewellery_iron_wire_bracelet`
+
+### Earrings (23)
+
+`jewellery_bronze_ball_earrings`, `jewellery_bronze_disc_earrings`, `jewellery_bronze_drop_loop_earrings`, `jewellery_bronze_hollow_earrings`, `jewellery_bronze_hoop_earrings`, `jewellery_bronze_lobed_earrings`, `jewellery_bronze_loop_earrings`, `jewellery_bronze_wire_drop_earrings`, `jewellery_copper_hoop_earrings`, `jewellery_copper_wire_earrings`, `jewellery_gold_amber_drop_earrings`, `jewellery_gold_amber_earrings`, `jewellery_gold_bird_drop_earrings`, `jewellery_gold_boat_pendant_earrings`, `jewellery_gold_cage_ball_earrings`, `jewellery_gold_carnelian_earrings`, `jewellery_gold_crescent_earrings`, `jewellery_gold_glass_head_earrings`, `jewellery_gold_pearl_earrings`, `jewellery_gold_quartz_disc_earrings`, `jewellery_gold_ram_head_earrings`, `jewellery_gold_turquoise_drop_earrings`, `jewellery_small_bronze_wire_earrings`
+
+### Necklaces (28)
+
+`jewellery_agate_bead_necklace`, `jewellery_amber_disc_necklace`, `jewellery_blue_glass_eye_bead_necklace`, `jewellery_blue_glass_head_amulet`, `jewellery_blue_glass_ram_amulet`, `jewellery_blue_melon_bead_necklace`, `jewellery_bone_and_amber_necklace`, `jewellery_bone_tooth_necklace`, `jewellery_electrum_winged_pectoral`, `jewellery_glass_pendant_necklace`, `jewellery_glass_tube_necklace`, `jewellery_gold_agate_necklace`, `jewellery_gold_carnelian_broad_collar`, `jewellery_gold_filigrane_glass_necklace`, `jewellery_gold_foil_amber_necklace`, `jewellery_gold_glass_pendant_necklace`, `jewellery_gold_lapis_necklace`, `jewellery_gold_pearl_necklace`, `jewellery_gold_ram_head_pectoral`, `jewellery_gold_strap_necklace`, `jewellery_gold_turquoise_pendant_necklace`, `jewellery_gold_usekh_collar`, `jewellery_heavy_gold_torc`, `jewellery_red_inlaid_silver_torc`, `jewellery_shell_and_bone_necklace`, `jewellery_shell_carnelian_necklace`, `jewellery_simple_bronze_torc`, `jewellery_wooden_bead_necklace`
+
+### Other Jewellery (44)
+
+`jewellery_angular_marked_silver_fibula`, `jewellery_blue_glazed_ceramic_headband`, `jewellery_bone_belt_plaque`, `jewellery_bone_dress_pin`, `jewellery_bone_hair_pin`, `jewellery_bronze_animal_belt_plaques`, `jewellery_bronze_animal_cloak_pin`, `jewellery_bronze_animal_headband`, `jewellery_bronze_bead_headband`, `jewellery_bronze_cloak_pin`, `jewellery_bronze_crossbar_fibula`, `jewellery_bronze_disc_browband`, `jewellery_bronze_dress_fibula`, `jewellery_bronze_granule_headband`, `jewellery_bronze_rosette_headband`, `jewellery_bronze_studded_fibula`, `jewellery_bronze_winged_fibula`, `jewellery_copper_lion_brooch`, `jewellery_cowrie_shell_girdle`, `jewellery_electrum_rosette_diadem`, `jewellery_gold_animal_belt_plaques`, `jewellery_gold_animal_cloak_pin`, `jewellery_gold_animal_plaque_headband`, `jewellery_gold_bossed_circlet`, `jewellery_gold_cobra_frontlet`, `jewellery_gold_floral_brooch`, `jewellery_gold_garnet_diadem`, `jewellery_gold_ivory_belt_plaque`, `jewellery_gold_lapis_hair_pin`, `jewellery_gold_leaf_diadem`, `jewellery_gold_lion_girdle`, `jewellery_gold_palmette_diadem`, `jewellery_gold_ram_head_diadem`, `jewellery_gold_rosette_plate_diadem`, `jewellery_gold_rosette_sea_diadem`, `jewellery_gold_scarab_dress_pin`, `jewellery_gold_sphinx_fibula`, `jewellery_gold_studded_fibula`, `jewellery_penannular_bronze_brooch`, `jewellery_plain_bronze_brow_band`, `jewellery_shell_and_bone_browband`, `jewellery_shell_disc_headband`, `jewellery_silver_gilt_brow_band`, `jewellery_turquoise_bead_headband`
+
+### Rings (23)
+
+`jewellery_bone_scarab_ring`, `jewellery_bronze_animal_ring`, `jewellery_bronze_carnelian_ring`, `jewellery_bronze_coil_ring`, `jewellery_bronze_seal_ring`, `jewellery_bronze_square_seal_ring`, `jewellery_bronze_wire_ring`, `jewellery_copper_ram_ring`, `jewellery_copper_scarab_ring`, `jewellery_copper_seal_ring`, `jewellery_gold_carnelian_seal_ring`, `jewellery_gold_carnelian_signet_ring`, `jewellery_gold_emerald_ring`, `jewellery_gold_garnet_ring`, `jewellery_gold_jasper_ring`, `jewellery_gold_lapis_scarab_ring`, `jewellery_gold_lion_seal_ring`, `jewellery_gold_scarab_ring`, `jewellery_gold_scarab_signet_ring`, `jewellery_gold_serpent_ring`, `jewellery_gold_snake_head_ring`, `jewellery_gold_stag_ring`, `jewellery_iron_signet_ring`
+
+## Verification
+
+`ItemSeederAntiquityRemainingCraftingTests` asserts that the jewellery source count stays at 162 until the source catalogue changes, that `SeedAntiquityJewelleryCrafts()` is registered, that the jewellery stock tags exist in both the seeder and exported tag hierarchy, and that every current jewellery stable reference appears in this document.

--- a/Design Documents/Data/SeededTagHierarchy.csv
+++ b/Design Documents/Data/SeededTagHierarchy.csv
@@ -196,6 +196,11 @@ Splint Stock	Medical Craft Stock	Functions / Material Functions / Medical Craft 
 Prosthetic Stock	Medical Craft Stock	Functions / Material Functions / Medical Craft Stock / Prosthetic Stock
 Surgical Tool Blank	Medical Craft Stock	Functions / Material Functions / Medical Craft Stock / Surgical Tool Blank
 Herbal Remedy Stock	Medical Craft Stock	Functions / Material Functions / Medical Craft Stock / Herbal Remedy Stock
+Jewellery Craft Stock	Material Functions	Functions / Material Functions / Jewellery Craft Stock
+Jewellery Metal Stock	Jewellery Craft Stock	Functions / Material Functions / Jewellery Craft Stock / Jewellery Metal Stock
+Jewellery Wire Stock	Jewellery Craft Stock	Functions / Material Functions / Jewellery Craft Stock / Jewellery Wire Stock
+Jewellery Bead Stock	Jewellery Craft Stock	Functions / Material Functions / Jewellery Craft Stock / Jewellery Bead Stock
+Jewellery Setting Stock	Jewellery Craft Stock	Functions / Material Functions / Jewellery Craft Stock / Jewellery Setting Stock
 Leather Commodity	Material Functions	Functions / Material Functions / Leather Commodity
 Prepared Hide	Leather Commodity	Functions / Material Functions / Leather Commodity / Prepared Hide
 Tanned Leather	Leather Commodity	Functions / Material Functions / Leather Commodity / Tanned Leather
@@ -540,6 +545,7 @@ Blowpipe	Glassblowing Tools	Functions / Tools / Glassblowing Tools / Blowpipe
 Glass Shears	Glassblowing Tools	Functions / Tools / Glassblowing Tools / Glass Shears
 Glassblower's Bench	Glassblowing Tools	Functions / Tools / Glassblowing Tools / Glassblower's Bench
 Glory Hole	Glassblowing Tools	Functions / Tools / Glassblowing Tools / Glory Hole
+Lit Glory Hole	Glory Hole	Functions / Tools / Glassblowing Tools / Glory Hole / Lit Glory Hole
 Jacks	Glassblowing Tools	Functions / Tools / Glassblowing Tools / Jacks
 Marver Table	Glassblowing Tools	Functions / Tools / Glassblowing Tools / Marver Table
 Optic Mold	Glassblowing Tools	Functions / Tools / Glassblowing Tools / Optic Mold

--- a/Design Documents/README.md
+++ b/Design Documents/README.md
@@ -38,6 +38,7 @@ This folder is organised by subsystem so implementation notes, builder workflows
 - [Antiquity Clothing Crafting Suite](./Crafting/Antiquity_Hellenic_Clothing_Crafting_Suite.md)
 - [Antiquity Equipment Crafting Suite](./Crafting/Antiquity_Equipment_Crafting_Suite.md)
 - [Antiquity Furniture and Container Crafting Suite](./Crafting/Antiquity_Furniture_Container_Crafting_Suite.md)
+- [Antiquity Jewellery Crafting Suite](./Crafting/Antiquity_Jewellery_Crafting_Suite.md)
 - [Antiquity Medical Crafting Suite](./Crafting/Antiquity_Medical_Crafting_Suite.md)
 - [Antiquity Writing Implements and Documents Crafting Suite](./Crafting/Antiquity_Writing_Implements_Crafting_Suite.md)
 - [Butchering System](./Crafting/Butchering_System.md)


### PR DESCRIPTION
## Summary
- Add a dedicated antiquity jewellery crafting suite with dynamic seeded coverage for metal, bead, wire, setting, and ornament workflows.
- Make support tools and intermediate apparatus craftable, including the workshop tool blank chain and lit/unlit glass furnace support.
- Update antiquity crafting design docs, seeded tag hierarchy docs, and regression tests for the review fixes.

## Validation
- dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 --filter ItemSeederAntiquityRemainingCraftingTests --verbosity minimal
- dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 --verbosity minimal
- dotnet build DatabaseSeeder\DatabaseSeeder.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 --verbosity minimal
- git diff --check