### PR TITLE
Fix vehicle mount wagon test path

### DIFF
--- a/Design Documents/Vehicle_System_Fresh_MUD_Test_Runbook.md
+++ b/Design Documents/Vehicle_System_Fresh_MUD_Test_Runbook.md
@@ -355,14 +355,16 @@ vehicleproto show <vehicle proto id>
 vehicleproto set slot add <cart-compartment-id> driver 1 cart handle
 vehicleproto set station add <cart-driver-slot-id> handles
 vehicleproto set movement cell
-vehicleproto set tow add none hand towed 300 pull 4 shafts
-vehicleproto set tow add none yoke towed 600 pull 6 yoke
+vehicleproto set tow add none hand towed 300000 pull 4 shafts
+vehicleproto set tow add none yoke towed 600000 pull 6 yoke
 vehicleproto set damage add 50 1 30 50 false frame
 vehicleproto submit fresh vehicle runbook mount cart
 vehicleproto approve <vehicle proto id> fresh vehicle runbook mount cart
 vehicleproto create <vehicle proto id>
 vehicle show <cart vehicle id>
 ```
+
+The tow point maximum weight argument is currently entered in the engine's base mass units. For the suggested `120 kg` cart item, use `300000` and `600000` rather than `300` and `600`.
 
 Direct hand/shaft hitch test:
 

--- a/MudSharpCore/Body/Implementations/BodyPerception.cs
+++ b/MudSharpCore/Body/Implementations/BodyPerception.cs
@@ -605,18 +605,18 @@ public partial class Body
                               .SelectMany(x => x.Targets)
                               .OfType<IGameItem>()
                               .ToHashSet();
-        var vehiclesDescribedByVisibleOccupants = Gameworld.Vehicles
-                                                           .Where(x => x.ExteriorItem is not null &&
-                                                                       x.ExteriorItem.Location == Location &&
-                                                                       x.ExteriorItem.RoomLayer == RoomLayer &&
-                                                                       CanSee(x.ExteriorItem) &&
-                                                                       visibleCharacters.Any(x.IsOccupant))
-                                                           .Select(x => x.ExteriorItem)
-                                                           .ToHashSet();
+        var vehiclesDescribedByOccupants = Gameworld.Vehicles
+                                                    .Where(x => x.ExteriorItem is not null &&
+                                                                x.ExteriorItem.Location == Location &&
+                                                                x.ExteriorItem.RoomLayer == RoomLayer &&
+                                                                CanSee(x.ExteriorItem) &&
+                                                                (x.IsOccupant(Actor) || visibleCharacters.Any(x.IsOccupant)))
+                                                    .Select(x => x.ExteriorItem)
+                                                    .ToHashSet();
         List<IGameItem> items = Location.LayerGameItems(RoomLayer)
                                         .Where(x => CanSee(x))
                                         .Where(x => !movementTargets.Contains(x))
-                                        .Where(x => !vehiclesDescribedByVisibleOccupants.Contains(x))
+                                        .Where(x => !vehiclesDescribedByOccupants.Contains(x))
                                         .ToList();
         if (items.GroupBy(x => x.ItemGroup?.Forms.Any() == true ? x.ItemGroup : null).Sum(x => x.Key != null ? 1 : x.Count()) > 25 &&
             GameItemProto.TooManyItemsGroup != null)

--- a/MudSharpCore/Vehicles/VehiclePrototype.cs
+++ b/MudSharpCore/Vehicles/VehiclePrototype.cs
@@ -1779,14 +1779,19 @@ public class VehiclePrototype : EditableItem, IVehiclePrototype
 	{
 		using (new FMDB())
 		{
+			var newRevisionNumber = FMDB.Context.VehicleProtos.Where(x => x.Id == Id).Select(x => x.RevisionNumber)
+			                                  .AsEnumerable()
+			                                  .DefaultIfEmpty(0)
+			                                  .Max() + 1;
 			var dbnew = new DB.VehicleProto
 			{
 				Id = Id,
-				RevisionNumber = FMDB.Context.VehicleProtos.Where(x => x.Id == Id).Select(x => x.RevisionNumber).AsEnumerable().DefaultIfEmpty(0).Max() + 1,
+				RevisionNumber = newRevisionNumber,
 				EditableItem = new DB.EditableItem
 				{
 					BuilderAccountId = initiator.Account.Id,
 					BuilderDate = DateTime.UtcNow,
+					RevisionNumber = newRevisionNumber,
 					RevisionStatus = (int)RevisionStatus.UnderDesign
 				},
 				Name = Name,


### PR DESCRIPTION
## Summary
- Suppress a rider's own occupied vehicle exterior from their room look output while preserving visible occupant vehicle lines.
- Keep vehicle prototype revision rows aligned with their editable item revision numbers when creating a new revision.
- Update the fresh MUD mount-cart runbook tow limits to use the engine's base mass units.

## Validation
- `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- Live MUD tester runs for bicycle rider perspective and hand/yoke cart hitch movement.