### PR TITLE
Implement astronomical calendar refactor

### DIFF
--- a/DatabaseSeeder Unit Tests/TimeSeederTests.cs
+++ b/DatabaseSeeder Unit Tests/TimeSeederTests.cs
@@ -37,7 +37,17 @@ public class TimeSeederTests
         "republicain",
         "tranquility",
         "mission",
-        "seasonal-360"
+        "seasonal-360",
+        "islamic-hijri",
+        "hebrew",
+        "old-persian",
+        "babylonian",
+        "chinese-minguo",
+        "chinese-lunisolar",
+        "korean-dangi",
+        "korean-lunisolar",
+        "japanese-koki",
+        "japanese-lunisolar"
     ];
 
     private static FuturemudDatabaseContext BuildContext()
@@ -129,8 +139,77 @@ public class TimeSeederTests
                                                   x.Element("SecondsPerMinute")?.Value == "100"),
                         $"{mode}: expected the decimal clock.");
                     break;
+                case "islamic-hijri":
+                    AssertAlgorithmAndBoundary(calendars, mode, "astronomical-lunar",
+                        "SunsetAtAuthorityLocation");
+                    break;
+                case "hebrew":
+                    AssertAlgorithmAndBoundary(calendars, mode, "calculated-hebrew",
+                        "SunsetAtAuthorityLocation");
+                    Assert.IsTrue(calendars.Any(x => MonthAliases(x).Contains("adar-i") &&
+                                                     MonthAliases(x).Contains("adar-ii")),
+                        $"{mode}: expected Hebrew leap-month definitions.");
+                    break;
+                case "old-persian":
+                    AssertAlgorithmAndBoundary(calendars, mode, "solar-equinox", "ClockMidnight");
+                    Assert.IsTrue(calendars.Any(x => MonthAliases(x).Contains("gatha")),
+                        $"{mode}: expected epagomenal Gatha days.");
+                    break;
+                case "babylonian":
+                    AssertAlgorithmAndBoundary(calendars, mode, "astronomical-lunar",
+                        "SunsetAtAuthorityLocation");
+                    Assert.IsTrue(calendars.Any(x => MonthAliases(x).Contains("addaru-ii") &&
+                                                     MonthAliases(x).Contains("ululu-ii")),
+                        $"{mode}: expected Babylonian leap-month definitions.");
+                    break;
+                case "chinese-minguo":
+                    AssertAlgorithmAndBoundary(calendars, mode, "fixed-months", "ClockMidnight");
+                    Assert.IsTrue(calendars.Any(x => MonthAliases(x).Contains("yi-yue")),
+                        $"{mode}: expected Latin1-safe romanised Chinese month aliases.");
+                    break;
+                case "korean-dangi":
+                case "japanese-koki":
+                    AssertAlgorithmAndBoundary(calendars, mode, "fixed-months", "ClockMidnight");
+                    break;
+                case "chinese-lunisolar":
+                case "korean-lunisolar":
+                case "japanese-lunisolar":
+                    AssertAlgorithmAndBoundary(calendars, mode, "east-asian-lunisolar",
+                        "ClockMidnight");
+                    Assert.IsTrue(calendars.Any(x => MonthAliases(x).Any(y => y.StartsWith("leap-"))),
+                        $"{mode}: expected an East Asian leap-month definition.");
+                    break;
             }
         }
+    }
+
+    [DataTestMethod]
+    [DataRow("islamic-hijri")]
+    [DataRow("hebrew")]
+    [DataRow("old-persian")]
+    [DataRow("babylonian")]
+    [DataRow("chinese-minguo")]
+    [DataRow("chinese-lunisolar")]
+    [DataRow("korean-dangi")]
+    [DataRow("korean-lunisolar")]
+    [DataRow("japanese-koki")]
+    [DataRow("japanese-lunisolar")]
+    public void SeedData_AstronomicalAndHistoricalModes_RerunIsIdempotent(string mode)
+    {
+        using FuturemudDatabaseContext context = BuildContext();
+        TimeSeeder seeder = new();
+        Dictionary<string, string> answers = Answers(mode);
+
+        seeder.SeedData(context, answers);
+        int clockCount = context.Clocks.Count();
+        int timezoneCount = context.Timezones.Count();
+        int calendarCount = context.Calendars.Count();
+
+        seeder.SeedData(context, answers);
+
+        Assert.AreEqual(clockCount, context.Clocks.Count(), $"{mode}: clock count changed on rerun.");
+        Assert.AreEqual(timezoneCount, context.Timezones.Count(), $"{mode}: timezone count changed on rerun.");
+        Assert.AreEqual(calendarCount, context.Calendars.Count(), $"{mode}: calendar count changed on rerun.");
     }
 
     [TestMethod]
@@ -209,6 +288,23 @@ public class TimeSeederTests
     {
         Assert.IsFalse(string.IsNullOrWhiteSpace(definition.Element(elementName)?.Value),
             $"{mode}: missing or empty {elementName}.");
+    }
+
+    private static void AssertAlgorithmAndBoundary(List<XElement> calendars, string mode, string algorithmType,
+        string boundaryType)
+    {
+        Assert.IsTrue(calendars.Any(x => x.Element("algorithm")?.Attribute("type")?.Value == algorithmType),
+            $"{mode}: expected algorithm type {algorithmType}.");
+        Assert.IsTrue(calendars.Any(x => x.Element("dayboundary")?.Attribute("type")?.Value == boundaryType),
+            $"{mode}: expected day-boundary type {boundaryType}.");
+    }
+
+    private static List<string> MonthAliases(XElement calendar)
+    {
+        return calendar.Element("months")!
+            .Elements("month")
+            .Select(x => x.Element("alias")!.Value)
+            .ToList();
     }
 
     private static void AssertRuntimeLoadable(FuturemudDatabaseContext context, string mode)

--- a/DatabaseSeeder/Seeders/TimeSeeder.cs
+++ b/DatabaseSeeder/Seeders/TimeSeeder.cs
@@ -27,7 +27,17 @@ public class TimeSeeder : IDatabaseSeeder
         "new-reckoning",
         "orc-reckoning",
         "rivendell",
-        "kings-reckoning"
+        "kings-reckoning",
+        "islamic-hijri",
+        "hebrew",
+        "old-persian",
+        "babylonian",
+        "chinese-minguo",
+        "chinese-lunisolar",
+        "korean-dangi",
+        "korean-lunisolar",
+        "japanese-koki",
+        "japanese-lunisolar"
     ];
 
     public IEnumerable<(string Id, string Question,
@@ -65,6 +75,7 @@ Broadly speaking, there are eight calendars for you to choose from:
 #ACalendare Republicain#F: The French Republican calendar (including decimal clock) from the French Revolution
 #AMission#F: A sci-fi generation ship calendar with 360 day years, 36 day months and 6 day weeks
 #ASeasonal 360#F: A simple 360 day fantasy calendar with three months per season and a 6 day week
+#AAstronomical and Historical Approximations#F: deterministic Hijri, Hebrew, Old Persian, Babylonian and East Asian calendar packages
 
 The specific available calendars are as follows:
 
@@ -81,6 +92,16 @@ The specific available calendars are as follows:
 	#Brepublicain#F: The French Republican calendar (including decimal clock) from the French Revolution
 	#Bmission#F: A sci-fi generation ship calendar with 360 day years, 36 day months and 6 day weeks
 	#Bseasonal-360#F: A simple 360 day fantasy calendar with Early/Mid/Late seasons and First Day through Sixth Day weekdays
+	#Bislamic-hijri#F: Deterministic visible-crescent Hijri approximation with sunset day boundaries
+	#Bhebrew#F: Calculated Hebrew calendar with deterministic postponement/leap-month rules
+	#Bold-persian#F: Old Persian/Zoroastrian-style solar calendar with epagomenal days
+	#Bbabylonian#F: Regulated deterministic Babylonian lunisolar approximation
+	#Bchinese-minguo#F: Gregorian-derived Chinese Minguo civil calendar
+	#Bchinese-lunisolar#F: Deterministic Chinese lunisolar approximation
+	#Bkorean-dangi#F: Gregorian-derived Korean Dangi civil calendar
+	#Bkorean-lunisolar#F: Deterministic Korean lunisolar approximation
+	#Bjapanese-koki#F: Gregorian-derived Japanese Koki civil calendar
+	#Bjapanese-lunisolar#F: Deterministic Japanese lunisolar approximation
 ", (context, answers) => true, (answer, context) =>
                 {
                     switch (answer.ToLowerInvariant())
@@ -98,6 +119,18 @@ The specific available calendars are as follows:
                         case "tranquility":
                         case "mission":
                         case "seasonal-360":
+                        case "islamic-hijri":
+                        case "hebrew":
+                        case "old-persian":
+                        case "babylonian":
+                        case "chinese-minguo":
+                        case "chinese-lunisolar":
+                        case "korean-dangi":
+                        case "korean-modern":
+                        case "korean-lunisolar":
+                        case "japanese-koki":
+                        case "japanese-modern":
+                        case "japanese-lunisolar":
                             return (true, string.Empty);
                     }
 
@@ -169,6 +202,38 @@ Your answer: ", (context, answers) => answers["mode"].EqualTo("middle-earth"), (
                 break;
             case "seasonal-360":
                 SetupSeasonal360Calendar(context, clock, questionAnswers);
+                break;
+            case "islamic-hijri":
+                SetupIslamicHijri(context, clock, questionAnswers);
+                break;
+            case "hebrew":
+                SetupHebrew(context, clock, questionAnswers);
+                break;
+            case "old-persian":
+                SetupOldPersian(context, clock, questionAnswers);
+                break;
+            case "babylonian":
+                SetupBabylonian(context, clock, questionAnswers);
+                break;
+            case "chinese-minguo":
+                SetupChineseMinguo(context, clock, questionAnswers);
+                break;
+            case "chinese-lunisolar":
+                SetupChineseLunisolar(context, clock, questionAnswers);
+                break;
+            case "korean-dangi":
+            case "korean-modern":
+                SetupKoreanDangi(context, clock, questionAnswers);
+                break;
+            case "korean-lunisolar":
+                SetupKoreanLunisolar(context, clock, questionAnswers);
+                break;
+            case "japanese-koki":
+            case "japanese-modern":
+                SetupJapaneseKoki(context, clock, questionAnswers);
+                break;
+            case "japanese-lunisolar":
+                SetupJapaneseLunisolar(context, clock, questionAnswers);
                 break;
             case "republicain":
                 clock = EnsureClock(
@@ -267,6 +332,18 @@ Your answer: ", (context, answers) => answers["mode"].EqualTo("middle-earth"), (
             "seasonal-360" => "seasonal-360",
             "republicain" => "republicain",
             "tranquility" => "tranquility",
+            "islamic-hijri" => "islamic-hijri",
+            "hebrew" => "hebrew",
+            "old-persian" => "old-persian",
+            "babylonian" => "babylonian",
+            "chinese-minguo" => "chinese-minguo",
+            "chinese-lunisolar" => "chinese-lunisolar",
+            "korean-dangi" => "korean-dangi",
+            "korean-modern" => "korean-dangi",
+            "korean-lunisolar" => "korean-lunisolar",
+            "japanese-koki" => "japanese-koki",
+            "japanese-modern" => "japanese-koki",
+            "japanese-lunisolar" => "japanese-lunisolar",
             "latin-ancient" => "julian",
             "latin-7day" => "julian",
             "latin-8day" => "julian",
@@ -405,6 +482,409 @@ Your answer: ", (context, answers) => answers["mode"].EqualTo("middle-earth"), (
                 }
             }
         }
+    }
+
+    private readonly record struct MonthSpec(string Alias, string ShortName, string FullName, int Days);
+
+    private static readonly string[] SevenDayWeek =
+    [
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sunday"
+    ];
+
+    private static string BuildCalendarDefinition(string alias, string shortName, string fullName, string description,
+        string shortMask, string longMask, string wordyMask, string ancientEraShort, string ancientEraLong,
+        string modernEraShort, string modernEraLong, int epochYear, int firstWeekday, IEnumerable<string> weekdays,
+        IEnumerable<MonthSpec> months, XElement algorithm, XElement dayBoundary)
+    {
+        return new XElement("calendar",
+            new XElement("alias", alias),
+            new XElement("shortname", shortName),
+            new XElement("fullname", fullName),
+            new XElement("description", new XCData(description)),
+            new XElement("shortstring", shortMask),
+            new XElement("longstring", longMask),
+            new XElement("wordystring", wordyMask),
+            new XElement("plane", "earth"),
+            new XElement("feedclock", 0),
+            new XElement("epochyear", epochYear),
+            new XElement("weekdayatepoch", firstWeekday),
+            new XElement("ancienterashortstring", ancientEraShort),
+            new XElement("ancienteralongstring", ancientEraLong),
+            new XElement("modernerashortstring", modernEraShort),
+            new XElement("moderneralongstring", modernEraLong),
+            new XElement("weekdays", weekdays.Select(x => new XElement("weekday", x))),
+            new XElement("months", months.Select((x, i) => BuildMonthElement(x, i + 1))),
+            new XElement("intercalarymonths"),
+            algorithm,
+            dayBoundary).ToString(SaveOptions.DisableFormatting);
+    }
+
+    private static XElement BuildMonthElement(MonthSpec month, int order)
+    {
+        return new XElement("month",
+            new XElement("alias", month.Alias),
+            new XElement("shortname", month.ShortName),
+            new XElement("fullname", month.FullName),
+            new XElement("nominalorder", order),
+            new XElement("normaldays", month.Days),
+            new XElement("intercalarydays"),
+            new XElement("specialdays"),
+            new XElement("nonweekdays"));
+    }
+
+    private static XElement Algorithm(string type, string? variant = null)
+    {
+        var element = new XElement("algorithm", new XAttribute("type", type));
+        if (!string.IsNullOrWhiteSpace(variant))
+        {
+            element.Add(new XAttribute("variant", variant));
+        }
+
+        return element;
+    }
+
+    private static XElement DayBoundary(string type, bool includeAuthority = false)
+    {
+        var element = new XElement("dayboundary", new XAttribute("type", type));
+        if (includeAuthority)
+        {
+            element.Add(new XElement("authority",
+                new XAttribute("latitude", "0"),
+                new XAttribute("longitude", "0"),
+                new XAttribute("elevation", "0"),
+                new XAttribute("radius", "0")));
+        }
+
+        return element;
+    }
+
+    private static IReadOnlyList<MonthSpec> GregorianMonths(string prefix = "")
+    {
+        return
+        [
+            new($"{prefix}january", "Jan", "January", 31),
+            new($"{prefix}february", "Feb", "February", 28),
+            new($"{prefix}march", "Mar", "March", 31),
+            new($"{prefix}april", "Apr", "April", 30),
+            new($"{prefix}may", "May", "May", 31),
+            new($"{prefix}june", "Jun", "June", 30),
+            new($"{prefix}july", "Jul", "July", 31),
+            new($"{prefix}august", "Aug", "August", 31),
+            new($"{prefix}september", "Sep", "September", 30),
+            new($"{prefix}october", "Oct", "October", 31),
+            new($"{prefix}november", "Nov", "November", 30),
+            new($"{prefix}december", "Dec", "December", 31)
+        ];
+    }
+
+    private static string BuildGregorianDerivedCalendar(string alias, string shortName, string fullName,
+        string description, string startYear, string ancientShort, string ancientLong, string modernShort,
+        string modernLong, IReadOnlyList<MonthSpec> months)
+    {
+        var root = XElement.Parse(BuildCalendarDefinition(alias, shortName, fullName, description, "$dd/$mo/$yy $ee",
+            "$nz$ww the $dt of $mf, $yy $EE", "$NZ$ww on this $DT day of the month of $mf, in year $yy $EE",
+            ancientShort, ancientLong, modernShort, modernLong, int.Parse(startYear), 0, SevenDayWeek, months,
+            Algorithm("fixed-months"), DayBoundary("ClockMidnight")));
+        var february = root.Element("months")!.Elements("month").ElementAt(1);
+        february.Element("intercalarydays")!.Add(new XElement("intercalary",
+            new XElement("insertdays", 1),
+            new XElement("specialdays"),
+            new XElement("nonweekdays"),
+            new XElement("removenonweekdays"),
+            new XElement("removespecialdays"),
+            new XElement("intercalaryrule",
+                new XElement("offset", 0),
+                new XElement("divisor", 4),
+                new XElement("exceptions",
+                    new XElement("intercalaryrule",
+                        new XElement("offset", 0),
+                        new XElement("divisor", 100),
+                        new XElement("exceptions",
+                            new XElement("intercalaryrule",
+                                new XElement("offset", 0),
+                                new XElement("divisor", 400),
+                                new XElement("exceptions"),
+                                new XElement("ands"),
+                                new XElement("ors"))),
+                        new XElement("ands"),
+                        new XElement("ors"))),
+                new XElement("ands"),
+                new XElement("ors"))));
+        return root.ToString(SaveOptions.DisableFormatting);
+    }
+
+    private void SetupIslamicHijri(FuturemudDatabaseContext context, Clock clock,
+        IReadOnlyDictionary<string, string> questionAnswers)
+    {
+        var months = new[]
+        {
+            new MonthSpec("muharram", "Muh", "Muharram", 30),
+            new MonthSpec("safar", "Saf", "Safar", 29),
+            new MonthSpec("rabi-awwal", "RAw", "Rabi al-Awwal", 30),
+            new MonthSpec("rabi-thani", "RTh", "Rabi al-Thani", 29),
+            new MonthSpec("jumada-ula", "JUl", "Jumada al-Ula", 30),
+            new MonthSpec("jumada-akhirah", "JAk", "Jumada al-Akhirah", 29),
+            new MonthSpec("rajab", "Raj", "Rajab", 30),
+            new MonthSpec("shaban", "Sha", "Shaban", 29),
+            new MonthSpec("ramadan", "Ram", "Ramadan", 30),
+            new MonthSpec("shawwal", "Shw", "Shawwal", 29),
+            new MonthSpec("dhu-qadah", "DQa", "Dhu al-Qadah", 30),
+            new MonthSpec("dhu-hijjah", "DHi", "Dhu al-Hijjah", 29)
+        };
+        var definition = BuildCalendarDefinition("islamic-hijri", "Islamic Hijri Calendar",
+            "Deterministic Islamic Hijri Calendar",
+            "A deterministic Hijri approximation using mean astronomical lunar month starts and visible-crescent-style sunset day boundaries. It is not a manual observation ledger.",
+            "$dd/$mm/$yy AH", "$nz$ww the $dt of $mf, $yy AH", "$NZ$ww on the $DT day of $mf, in year $yy AH",
+            "BH", "before Hijrah", "AH", "after Hijrah", int.Parse(questionAnswers["startyear"]), 0, SevenDayWeek,
+            months, Algorithm("astronomical-lunar", "visible-crescent-approximation"),
+            DayBoundary("SunsetAtAuthorityLocation", true));
+        EnsureCalendar(context, clock, $"1/muharram/{questionAnswers["startyear"]}", definition);
+    }
+
+    private void SetupHebrew(FuturemudDatabaseContext context, Clock clock,
+        IReadOnlyDictionary<string, string> questionAnswers)
+    {
+        var months = new[]
+        {
+            new MonthSpec("nisan", "Nis", "Nisan", 30),
+            new MonthSpec("iyyar", "Iyy", "Iyyar", 29),
+            new MonthSpec("sivan", "Siv", "Sivan", 30),
+            new MonthSpec("tammuz", "Tam", "Tammuz", 29),
+            new MonthSpec("av", "Av", "Av", 30),
+            new MonthSpec("elul", "Elu", "Elul", 29),
+            new MonthSpec("tishrei", "Tis", "Tishrei", 30),
+            new MonthSpec("heshvan", "Hes", "Heshvan", 29),
+            new MonthSpec("kislev", "Kis", "Kislev", 30),
+            new MonthSpec("tevet", "Tev", "Tevet", 29),
+            new MonthSpec("shevat", "She", "Shevat", 30),
+            new MonthSpec("adar", "Ada", "Adar", 29),
+            new MonthSpec("adar-i", "Ad1", "Adar I", 30),
+            new MonthSpec("adar-ii", "Ad2", "Adar II", 29)
+        };
+        var definition = BuildCalendarDefinition("hebrew", "Calculated Hebrew Calendar",
+            "Calculated Hebrew Calendar",
+            "A deterministic calculated Hebrew calendar with a 19-year Metonic cycle, postponement rules and Adar I/II leap-month handling.",
+            "$dd/$mm/$yy AM", "$nz$ww the $dt of $mf, $yy AM", "$NZ$ww on the $DT day of $mf, in year $yy AM",
+            "BM", "before creation", "AM", "anno mundi", int.Parse(questionAnswers["startyear"]), 0, SevenDayWeek,
+            months, Algorithm("calculated-hebrew"), DayBoundary("SunsetAtAuthorityLocation", true));
+        EnsureCalendar(context, clock, $"1/nisan/{questionAnswers["startyear"]}", definition);
+    }
+
+    private void SetupOldPersian(FuturemudDatabaseContext context, Clock clock,
+        IReadOnlyDictionary<string, string> questionAnswers)
+    {
+        var months = new[]
+        {
+            new MonthSpec("farvardin", "Far", "Farvardin", 30),
+            new MonthSpec("ardwahisht", "Ard", "Ardwahisht", 30),
+            new MonthSpec("hordad", "Hor", "Hordad", 30),
+            new MonthSpec("tir", "Tir", "Tir", 30),
+            new MonthSpec("amurdad", "Amu", "Amurdad", 30),
+            new MonthSpec("shahrewar", "Sha", "Shahrewar", 30),
+            new MonthSpec("mihr", "Mih", "Mihr", 30),
+            new MonthSpec("aban", "Aba", "Aban", 30),
+            new MonthSpec("adar", "Ada", "Adar", 30),
+            new MonthSpec("dae", "Dae", "Dae", 30),
+            new MonthSpec("wahman", "Wah", "Wahman", 30),
+            new MonthSpec("spendarmad", "Spe", "Spendarmad", 30),
+            new MonthSpec("gatha", "Gat", "Gatha Days", 5)
+        };
+        var definition = BuildCalendarDefinition("old-persian", "Old Persian Solar Calendar",
+            "Old Persian/Zoroastrian-Style Solar Calendar",
+            "A deterministic Old Persian/Zoroastrian-style solar approximation using twelve 30-day months plus epagomenal Gatha days. Leap epagomenal days follow a deterministic solar-equinox cycle.",
+            "$dd/$mm/$yy", "$nz$ww the $dt of $mf, $yy", "$NZ$ww on the $DT day of $mf, in year $yy",
+            "BE", "before era", "AE", "after era", int.Parse(questionAnswers["startyear"]), 0, SevenDayWeek,
+            months, Algorithm("solar-equinox", "old-persian-epagomenal"), DayBoundary("ClockMidnight"));
+        EnsureCalendar(context, clock, $"1/farvardin/{questionAnswers["startyear"]}", definition);
+    }
+
+    private void SetupBabylonian(FuturemudDatabaseContext context, Clock clock,
+        IReadOnlyDictionary<string, string> questionAnswers)
+    {
+        var months = new[]
+        {
+            new MonthSpec("nisannu", "Nis", "Nisannu", 30),
+            new MonthSpec("aiaru", "Aia", "Aiaru", 29),
+            new MonthSpec("simanu", "Sim", "Simanu", 30),
+            new MonthSpec("duzu", "Duz", "Duzu", 29),
+            new MonthSpec("abu", "Abu", "Abu", 30),
+            new MonthSpec("ululu", "Ulu", "Ululu", 29),
+            new MonthSpec("tashritu", "Tas", "Tashritu", 30),
+            new MonthSpec("arahsamnu", "Ara", "Arahsamnu", 29),
+            new MonthSpec("kislimu", "Kis", "Kislimu", 30),
+            new MonthSpec("tebetu", "Teb", "Tebetu", 29),
+            new MonthSpec("shabatu", "Sha", "Shabatu", 30),
+            new MonthSpec("addaru", "Add", "Addaru", 29),
+            new MonthSpec("addaru-ii", "Ad2", "Addaru II", 29),
+            new MonthSpec("ululu-ii", "Ul2", "Ululu II", 29)
+        };
+        var definition = BuildCalendarDefinition("babylonian", "Babylonian Lunisolar Calendar",
+            "Deterministic Babylonian Lunisolar Calendar",
+            "A regulated deterministic Babylonian lunisolar approximation with Addaru II and Ululu II leap months in a 19-year cycle. It is not a historical observation ledger.",
+            "$dd/$mm/$yy", "$nz$ww the $dt of $mf, $yy", "$NZ$ww on the $DT day of $mf, in year $yy",
+            "BE", "before era", "AE", "after era", int.Parse(questionAnswers["startyear"]), 0, SevenDayWeek,
+            months, Algorithm("astronomical-lunar", "babylonian-regulated"),
+            DayBoundary("SunsetAtAuthorityLocation", true));
+        EnsureCalendar(context, clock, $"1/nisannu/{questionAnswers["startyear"]}", definition);
+    }
+
+    private void SetupChineseMinguo(FuturemudDatabaseContext context, Clock clock,
+        IReadOnlyDictionary<string, string> questionAnswers)
+    {
+        var months = new[]
+        {
+            new MonthSpec("yi-yue", "Yi", "Yi Yue", 31),
+            new MonthSpec("er-yue", "Er", "Er Yue", 28),
+            new MonthSpec("san-yue", "San", "San Yue", 31),
+            new MonthSpec("si-yue", "Si", "Si Yue", 30),
+            new MonthSpec("wu-yue", "Wu", "Wu Yue", 31),
+            new MonthSpec("liu-yue", "Liu", "Liu Yue", 30),
+            new MonthSpec("qi-yue", "Qi", "Qi Yue", 31),
+            new MonthSpec("ba-yue", "Ba", "Ba Yue", 31),
+            new MonthSpec("jiu-yue", "Jiu", "Jiu Yue", 30),
+            new MonthSpec("shi-yue", "Shi", "Shi Yue", 31),
+            new MonthSpec("shiyi-yue", "Shy", "Shiyi Yue", 30),
+            new MonthSpec("shier-yue", "She", "Shier Yue", 31)
+        };
+        var definition = BuildGregorianDerivedCalendar("chinese-minguo", "Chinese Minguo Calendar",
+            "Chinese Minguo Civil Calendar",
+            "A Gregorian-derived Chinese Minguo civil calendar package with Latin1-safe month names.",
+            questionAnswers["startyear"], "BM", "before Minguo", "Minguo", "Minguo era", months);
+        EnsureCalendar(context, clock, $"1/yi-yue/{questionAnswers["startyear"]}", definition);
+    }
+
+    private void SetupKoreanDangi(FuturemudDatabaseContext context, Clock clock,
+        IReadOnlyDictionary<string, string> questionAnswers)
+    {
+        var months = new[]
+        {
+            new MonthSpec("ilwol", "Il", "Ilwol", 31),
+            new MonthSpec("iwol", "Iw", "Iwol", 28),
+            new MonthSpec("samwol", "Sam", "Samwol", 31),
+            new MonthSpec("sawol", "Sa", "Sawol", 30),
+            new MonthSpec("owol", "O", "Owol", 31),
+            new MonthSpec("yuwol", "Yu", "Yuwol", 30),
+            new MonthSpec("chirwol", "Chi", "Chirwol", 31),
+            new MonthSpec("parwol", "Par", "Parwol", 31),
+            new MonthSpec("guwol", "Gu", "Guwol", 30),
+            new MonthSpec("siwol", "Si", "Siwol", 31),
+            new MonthSpec("sibirwol", "SbI", "Sibirwol", 30),
+            new MonthSpec("sibiwol", "Sb", "Sibiwol", 31)
+        };
+        var definition = BuildGregorianDerivedCalendar("korean-dangi", "Korean Dangi Calendar",
+            "Korean Dangi Civil Calendar",
+            "A Gregorian-derived Korean Dangi civil calendar package with Latin1-safe month names.",
+            questionAnswers["startyear"], "BD", "before Dangi", "Dangi", "Dangi era", months);
+        EnsureCalendar(context, clock, $"1/ilwol/{questionAnswers["startyear"]}", definition);
+    }
+
+    private void SetupJapaneseKoki(FuturemudDatabaseContext context, Clock clock,
+        IReadOnlyDictionary<string, string> questionAnswers)
+    {
+        var months = new[]
+        {
+            new MonthSpec("ichigatsu", "Ich", "Ichigatsu", 31),
+            new MonthSpec("nigatsu", "Ni", "Nigatsu", 28),
+            new MonthSpec("sangatsu", "San", "Sangatsu", 31),
+            new MonthSpec("shigatsu", "Shi", "Shigatsu", 30),
+            new MonthSpec("gogatsu", "Go", "Gogatsu", 31),
+            new MonthSpec("rokugatsu", "Rok", "Rokugatsu", 30),
+            new MonthSpec("shichigatsu", "Shc", "Shichigatsu", 31),
+            new MonthSpec("hachigatsu", "Hac", "Hachigatsu", 31),
+            new MonthSpec("kugatsu", "Ku", "Kugatsu", 30),
+            new MonthSpec("jugatsu", "Ju", "Jugatsu", 31),
+            new MonthSpec("juichigatsu", "Jui", "Juichigatsu", 30),
+            new MonthSpec("junigatsu", "Jun", "Junigatsu", 31)
+        };
+        var definition = BuildGregorianDerivedCalendar("japanese-koki", "Japanese Koki Calendar",
+            "Japanese Koki Civil Calendar",
+            "A Gregorian-derived Japanese Koki civil calendar package with Latin1-safe month names.",
+            questionAnswers["startyear"], "BK", "before Koki", "Koki", "Koki era", months);
+        EnsureCalendar(context, clock, $"1/ichigatsu/{questionAnswers["startyear"]}", definition);
+    }
+
+    private void SetupChineseLunisolar(FuturemudDatabaseContext context, Clock clock,
+        IReadOnlyDictionary<string, string> questionAnswers)
+    {
+        SetupEastAsianLunisolar(context, clock, questionAnswers, "chinese-lunisolar", "Chinese Lunisolar Calendar",
+            "Deterministic Chinese Lunisolar Calendar", "chinese-lunisolar",
+            [
+                new MonthSpec("zhengyue", "Zhe", "Zhengyue", 30),
+                new MonthSpec("eryue", "Er", "Eryue", 29),
+                new MonthSpec("sanyue", "San", "Sanyue", 30),
+                new MonthSpec("siyue", "Si", "Siyue", 29),
+                new MonthSpec("wuyue", "Wu", "Wuyue", 30),
+                new MonthSpec("liuyue", "Liu", "Liuyue", 29),
+                new MonthSpec("qiyue", "Qi", "Qiyue", 30),
+                new MonthSpec("bayue", "Ba", "Bayue", 29),
+                new MonthSpec("jiuyue", "Jiu", "Jiuyue", 30),
+                new MonthSpec("shiyue", "Shi", "Shiyue", 29),
+                new MonthSpec("dongyue", "Don", "Dongyue", 30),
+                new MonthSpec("layue", "La", "Layue", 29),
+                new MonthSpec("leap-liuyue", "Run", "Run Liuyue", 29)
+            ]);
+    }
+
+    private void SetupKoreanLunisolar(FuturemudDatabaseContext context, Clock clock,
+        IReadOnlyDictionary<string, string> questionAnswers)
+    {
+        SetupEastAsianLunisolar(context, clock, questionAnswers, "korean-lunisolar", "Korean Lunisolar Calendar",
+            "Deterministic Korean Lunisolar Calendar", "korean-lunisolar",
+            [
+                new MonthSpec("jeongwol", "Jeo", "Jeongwol", 30),
+                new MonthSpec("iwol", "Iw", "Iwol", 29),
+                new MonthSpec("samwol", "Sam", "Samwol", 30),
+                new MonthSpec("sawol", "Sa", "Sawol", 29),
+                new MonthSpec("owol", "O", "Owol", 30),
+                new MonthSpec("yuwol", "Yu", "Yuwol", 29),
+                new MonthSpec("chirwol", "Chi", "Chirwol", 30),
+                new MonthSpec("parwol", "Par", "Parwol", 29),
+                new MonthSpec("guwol", "Gu", "Guwol", 30),
+                new MonthSpec("siwol", "Si", "Siwol", 29),
+                new MonthSpec("dongjiwol", "Don", "Dongjiwol", 30),
+                new MonthSpec("seotdal", "Seo", "Seotdal", 29),
+                new MonthSpec("leap-yuwol", "Yun", "Yun Yuwol", 29)
+            ]);
+    }
+
+    private void SetupJapaneseLunisolar(FuturemudDatabaseContext context, Clock clock,
+        IReadOnlyDictionary<string, string> questionAnswers)
+    {
+        SetupEastAsianLunisolar(context, clock, questionAnswers, "japanese-lunisolar", "Japanese Lunisolar Calendar",
+            "Deterministic Japanese Lunisolar Calendar", "japanese-lunisolar",
+            [
+                new MonthSpec("mutsuki", "Mut", "Mutsuki", 30),
+                new MonthSpec("kisaragi", "Kis", "Kisaragi", 29),
+                new MonthSpec("yayoi", "Yay", "Yayoi", 30),
+                new MonthSpec("uzuki", "Uzu", "Uzuki", 29),
+                new MonthSpec("satsuki", "Sat", "Satsuki", 30),
+                new MonthSpec("minazuki", "Min", "Minazuki", 29),
+                new MonthSpec("fumizuki", "Fum", "Fumizuki", 30),
+                new MonthSpec("hazuki", "Haz", "Hazuki", 29),
+                new MonthSpec("nagatsuki", "Nag", "Nagatsuki", 30),
+                new MonthSpec("kannazuki", "Kan", "Kannazuki", 29),
+                new MonthSpec("shimotsuki", "Shi", "Shimotsuki", 30),
+                new MonthSpec("shiwasu", "Shw", "Shiwasu", 29),
+                new MonthSpec("leap-minazuki", "Uru", "Uru Minazuki", 29)
+            ]);
+    }
+
+    private void SetupEastAsianLunisolar(FuturemudDatabaseContext context, Clock clock,
+        IReadOnlyDictionary<string, string> questionAnswers, string alias, string shortName, string fullName, string variant,
+        IReadOnlyList<MonthSpec> months)
+    {
+        var definition = BuildCalendarDefinition(alias, shortName, fullName,
+            "A deterministic East Asian lunisolar approximation using mean astronomical new moons, principal solar-term style leap-month placement and Latin1-safe names.",
+            "$dd/$mm/$yy", "$nz$ww the $dt of $mf, $yy", "$NZ$ww on the $DT day of $mf, in year $yy",
+            "BE", "before era", "AE", "after era", int.Parse(questionAnswers["startyear"]), 0, SevenDayWeek,
+            months, Algorithm("east-asian-lunisolar", variant), DayBoundary("ClockMidnight"));
+        EnsureCalendar(context, clock, $"1/{months[0].Alias}/{questionAnswers["startyear"]}", definition);
     }
 
     private void SetupMissionCalendar(FuturemudDatabaseContext context, Clock clock, IReadOnlyDictionary<string, string> questionAnswers)

--- a/Design Documents/Core/FutureProg_Type_System.md
+++ b/Design Documents/Core/FutureProg_Type_System.md
@@ -96,6 +96,21 @@ Builder-facing parsing now routes through `ProgVariableTypes.TryParse(...)` rath
 
 Type display and description logic is centralised through the registry-backed `Describe()` behavior. Existing player/builder output continues to use the same symbolic type names where possible.
 
+## Date, Time, And Celestial Event Values
+
+`ProgVariableTypes.MudDateTime` remains the FutureProg type for in-game dates and times. `MudDateTime` values now expose a `mudinstant` dot reference that returns the absolute `MudInstant` storage string for the value.
+
+Celestial event built-ins return `MudDateTime` and use the supplied room or zone as the observer geography:
+
+- `nextsunrise(location|zone, celestialId, calendar[, occurrence])`
+- `nextsunset(location|zone, celestialId, calendar[, occurrence])`
+- `nextsolarlongitude(location|zone, celestialId, calendar, longitudeDegrees[, occurrence])`
+- `nextnewmoon(location|zone, moonId, calendar[, occurrence])`
+- `nextfullmoon(location|zone, moonId, calendar[, occurrence])`
+- `nextvisiblecrescent(location|zone, sunId, moonId, calendar[, occurrence])`
+
+The optional `occurrence` argument returns the nth next event. Invalid zones, calendars, celestial IDs, unsupported ephemeris types, or bounded-search failures return `MudDateTime.Never`.
+
 ## Migration Expectations
 
 EF migrations for this subsystem should:

--- a/Design Documents/README.md
+++ b/Design Documents/README.md
@@ -117,6 +117,7 @@ This folder is organised by subsystem so implementation notes, builder workflows
 - [Computer Program Concept Design](./Technology/FutureMUD_Computer_Programs_Concept_Design.md)
 
 ## World
+- [Astronomical Time Calendar Refactor](./World/Astronomical_Time_Calendar_Refactor.md)
 - [Celestial System Overview](./World/Celestial_System_Overview.md)
 - [Celestial System Seeder](./World/Celestial_System_Seeder.md)
 - [Celestial System Tests](./World/Celestial_System_Tests.md)

--- a/Design Documents/World/Astronomical_Time_Calendar_Refactor.md
+++ b/Design Documents/World/Astronomical_Time_Calendar_Refactor.md
@@ -1,0 +1,302 @@
+# Astronomical Time, Calendar, and Celestial Refactor
+
+## Intended Repository Path
+
+`Design Documents/World/Astronomical_Time_Calendar_Refactor.md`
+
+## Purpose
+
+FutureMUD's existing time and date system supports highly configurable fixed calendars: arbitrary month lengths, intercalary days and months, unusual weekday cycles, era text, custom display masks, multiple clocks and time zones. This is sufficient for Gregorian, Julian, French Republican, Tolkien-style, and fantasy calendars.
+
+It is not sufficient for calendars whose date boundaries or month/year structure are derived from astronomical events such as sunset, first crescent visibility, astronomical new moon, winter solstice, solar longitude, or vernal equinox. This document describes a backwards-compatible refactor to add deterministic calculated and astronomical calendar support while preserving all existing MUD data and behaviours.
+
+Manual observation-ledger calendars, staff-confirmed crescent declarations, and weather-dependent official calendar decisions are explicitly out of scope for this phase.
+
+## Non-Negotiable Compatibility Requirements
+
+Existing MUDs must continue to boot and run without rerunning seeders. Existing calendar, clock, timezone, celestial, recurring interval, `MudDate`, `MudTime`, `MudDateTime`, and stored date/time strings must remain loadable. Existing fixed XML calendar definitions without new fields must default to the legacy fixed-month algorithm.
+
+If new persisted data is required, provide both seeded defaults and runtime backfill. Legacy databases must be able to derive missing `MudInstant` anchors from existing clock/calendar state at boot. Prefer additive fields, optional XML elements, and stored-value fallback helpers over destructive migrations.
+
+Existing recurrence semantics must remain compatible. New calendar-day-boundary behaviour must not silently reinterpret legacy recurring intervals.
+
+## Target Architecture
+
+### MudInstant
+
+Introduce `MudInstant` as the absolute in-game time scalar, preferably in `FutureMUDLibrary/TimeAndDate`.
+
+Requirements:
+- Stable, comparable, serializable, parseable, and safe to persist.
+- Represents absolute in-game seconds/ticks from a deterministic epoch.
+- Converts to/from `MudDateTime` when supplied calendar, clock, and timezone context.
+- Can be back-calculated from legacy `Calendar.Date` plus current clock time.
+- Has round-trip stored text helpers, e.g. `mudinstant:<epoch>:<ticks>` or an equivalent format.
+- Handles `Never`/null/sentinel semantics consistently with existing `MudDateTime.Never`.
+
+Suggested tests:
+- equality, ordering, round-trip storage
+- conversion to/from fixed Gregorian and existing seeded calendars
+- back-calculation from legacy data
+- interaction with `MudDateTime.Never`
+
+### Calendar Algorithm Separation
+
+Split calendar metadata/presentation from calendar generation logic.
+
+Suggested interfaces:
+- `ICalendarAlgorithm`
+- `ICalendarAlgorithmFactory` or registry
+- `IFixedMonthCalendarAlgorithm`
+- `ICalculatedCalendarAlgorithm`
+- `IAstronomicalCalendarAlgorithm`
+
+The existing `Calendar.CreateYear`, date parsing, and month/intercalary generation should become or delegate to `FixedMonthCalendarAlgorithm`. XML without an algorithm element must remain fixed-month legacy. Optional new XML may include an algorithm element such as:
+
+```xml
+<algorithm type="fixed-months" />
+```
+
+Calendar metadata remains on `Calendar`: alias, names, description, display masks, era strings, weekday names, feed clock, current date and validation/display surfaces. The algorithm owns year generation, date-to-instant mapping, instant-to-date mapping, intercalation rules, and algorithm-specific validation.
+
+### Celestial Ephemerides
+
+Add arbitrary-instant celestial query interfaces instead of relying only on current-state calls.
+
+Suggested interfaces:
+- `ICelestialEphemeris`
+- `ISolarEphemeris`
+- `ILunarEphemeris`
+
+Useful members:
+- `EclipticLongitudeAt(MudInstant instant)`
+- `RightAscensionAt(MudInstant instant)`
+- `DeclinationAt(MudInstant instant)`
+- `ApparentAltitudeAt(MudInstant instant, GeographicCoordinate observer)`
+- `ApparentAzimuthAt(MudInstant instant, GeographicCoordinate observer)`
+- `IlluminationAt(MudInstant instant, GeographicCoordinate observer)`
+- `PhaseAngleAt(MudInstant instant)` for moons
+
+Refactor existing sun and moon implementations to expose arbitrary-instant calculations while preserving current APIs and seeded celestial compatibility.
+
+### Astronomical Event Solver
+
+Add a deterministic event solver service.
+
+Suggested interface:
+`IAstronomicalEventService`
+
+Suggested capabilities:
+- next/nth sunrise
+- next/nth sunset
+- next/nth solar longitude crossing
+- next/nth lunar conjunction/new moon
+- next/nth full moon
+- next/nth deterministic visible crescent approximation
+
+Implementation guidance:
+- Use bounded numerical search.
+- Coarse sample forward to bracket an event.
+- Refine with bisection, secant, or another robust method.
+- Enforce maximum search windows and return clear errors.
+- Cache derived events where safe.
+- Deterministic visible crescent should use geometric thresholds, not weather: sunset condition, moon altitude, moon-sun elongation, and optionally moonset lag.
+
+### Day Boundaries and Authority Locations
+
+Add day-boundary support for calendars whose date does not change at midnight.
+
+Suggested enum:
+- `ClockMidnight`
+- `FixedClockTime`
+- `SunsetAtAuthorityLocation`
+- `SunriseAtAuthorityLocation`
+- `AstronomicalEvent`
+
+All existing calendars default to `ClockMidnight`.
+
+Astronomical calendars may define an authority location or meridian. Do not make official calendar dates depend on live weather. If a future observation ledger is added, it should layer over deterministic predictions rather than replace this architecture.
+
+Implications:
+- Preserve `MudDateTime.Midnight`.
+- Add `StartOfCalendarDay` where needed.
+- Let recurring intervals explicitly retain legacy clock-day semantics unless configured otherwise.
+- Ensure parser/display code does not silently reinterpret legacy dates.
+
+## Calendar Algorithms to Implement
+
+### FixedMonthCalendarAlgorithm
+
+Wraps current behaviour. This is the default for legacy XML.
+
+### TabularLunarCalendarAlgorithm
+
+Alternating 30/29-day lunar months with configurable leap-day cycle. Useful for tabular Hijri and simple lunar calendars.
+
+### CalculatedHebrewCalendarAlgorithm
+
+Modern calculated Hebrew calendar:
+- 19-year Metonic cycle
+- leap years 3, 6, 8, 11, 14, 17, 19
+- molad/dehiyyot/postponement rules
+- variable year lengths
+- Adar I / Adar II handling
+- Latin1-safe romanised names
+
+### SolarEquinoxCalendarAlgorithm
+
+Year start from vernal equinox or another configured solar longitude. Useful for Persian/Solar-Hijri-style deterministic calendars.
+
+### AstronomicalLunarCalendarAlgorithm
+
+Month starts by astronomical new moon or deterministic visible-crescent approximation. Useful for Hijri and Babylonian approximations where historical observation is approximated deterministically.
+
+### EastAsianLunisolarCalendarAlgorithm
+
+Supports traditional Chinese/Korean/Japanese-style lunisolar calendars:
+- lunar months begin at deterministic astronomical new moon
+- winter-solstice month anchoring
+- principal solar terms by solar longitude
+- leap month chosen when a month lacks a principal solar term
+- unique aliases for leap months
+- configurable localisation, epoch, meridian/authority settings, era text, names
+
+## Seeder Requirements
+
+Update `TimeSeeder.cs`:
+- prompt text
+- validators
+- mode switch
+- stock alias list
+- primary-calendar alias resolution
+- setup methods
+- tests
+
+Add these modes:
+- `islamic-hijri`
+- `hebrew`
+- `old-persian`
+- `babylonian`
+- `chinese-minguo`
+- `chinese-lunisolar`
+- `korean-dangi` or `korean-modern`
+- `korean-lunisolar`
+- `japanese-koki` or `japanese-modern`
+- `japanese-lunisolar`
+
+All stock names, aliases, weekdays, and month names must be Latin1-safe romanisations.
+
+Update `CelestialSeeder.cs` only where the celestial XML/data structure changes. Existing seeded celestials must remain loadable and rerun-idempotent.
+
+If `MudInstant` requires seeded epoch/configuration data, update the appropriate core/foundational seeder and add runtime backfill for existing databases.
+
+## Calendar Modelling Choices
+
+### Islamic Hijri
+
+Use astronomical lunar with deterministic visible-crescent approximation if implemented; tabular lunar is acceptable only as a documented fallback. Prefer sunset day boundary. Month names:
+`Muharram`, `Safar`, `Rabi al-Awwal`, `Rabi al-Thani`, `Jumada al-Ula`, `Jumada al-Akhirah`, `Rajab`, `Shaban`, `Ramadan`, `Shawwal`, `Dhu al-Qadah`, `Dhu al-Hijjah`.
+
+### Hebrew
+
+Use calculated Hebrew. Prefer sunset day boundary. Month names:
+`Nisan`, `Iyyar`, `Sivan`, `Tammuz`, `Av`, `Elul`, `Tishrei`, `Heshvan`, `Kislev`, `Tevet`, `Shevat`, `Adar`, `Adar I`, `Adar II`.
+
+### Old Persian
+
+Use a documented Old Persian/Zoroastrian-style fixed or solar-equinox model. If using fixed Zoroastrian-style structure, model twelve 30-day months plus epagomenal days. If using equinox, document the inference.
+
+### Babylonian
+
+Use astronomical lunar month starts or regulated lunisolar fallback. Support `Addaru II` and `Ululu II` in the 19-year regulated model. Prefer sunset day boundary. Month names:
+`Nisannu`, `Aiaru`, `Simanu`, `Duzu`, `Abu`, `Ululu`, `Tashritu`, `Arahsamnu`, `Kislimu`, `Tebetu`, `Shabatu`, `Addaru`, `Addaru II`, `Ululu II`.
+
+### Chinese, Korean, Japanese
+
+Modern modes are Gregorian-derived civil/era calendars:
+- Chinese Minguo
+- Korean Dangi or modern civil equivalent
+- Japanese Koki or modern civil equivalent
+
+Historical modes use `EastAsianLunisolarCalendarAlgorithm`, with deterministic astronomical new moons, solar terms, winter-solstice anchoring, and leap-month handling. Localise names and eras with Latin1-safe romanisations.
+
+## Builder/Admin Commands
+
+Update clock/calendar/celestial/time command surfaces:
+- implementor/admin `time` can show `MudInstant`
+- calendar show/preview/validate shows algorithm type
+- calendar builder can set/view algorithm where safe
+- calendar builder can set/view day boundary and authority location
+- celestial show exposes ephemeris capability and relevant parameters
+- add event preview command(s), e.g. next sunrise, sunset, new moon, full moon, solar longitude, visible crescent, nth occurrence
+- warn before live structural changes that can affect stored dates/schedules
+
+## FutureProg
+
+Expose astronomical event functions.
+
+Suggested functions:
+- `nextsunrise(...)`
+- `nextsunset(...)`
+- `nextsolarlongitude(...)`
+- `nextnewmoon(...)`
+- `nextfullmoon(...)`
+- `nextvisiblecrescent(...)`
+
+Support nth-next via overload or occurrence parameter. Return `MudInstant` if a FutureProg MudInstant type is added; otherwise return `MudDateTime` using supplied calendar/clock/timezone. Invalid celestials, missing ephemeris support, bad occurrence counts, or bounded-search failure must fail cleanly.
+
+## Tests
+
+Required coverage:
+- all existing `TimeSeeder` modes still load
+- all new modes load and generate valid current dates
+- `TimeSeeder` and `CelestialSeeder` reruns remain idempotent
+- legacy calendar/celestial XML without new fields loads
+- `MudInstant` round-trip/order/conversion/backfill
+- fixed-month behaviour unchanged
+- Hebrew leap years/months
+- Hijri lunar month bounds
+- Babylonian leap months
+- East Asian leap months and unique parseable aliases
+- solar-equinox year boundary
+- sunrise/sunset, solar longitude, lunar conjunction, full moon, nth-next event solver
+- builder command changes where existing command-test patterns exist
+- FutureProg event functions and invalid-argument handling
+
+## Documentation Updates
+
+Update:
+- `Design Documents/World/Time_And_Date_System.md`
+- celestial design documents
+- seeder repeatability docs if behaviour changes
+- builder/admin command docs if present
+- FutureProg function docs if present
+
+Docs must explain `MudInstant`, compatibility/backfill, calendar algorithm types, deterministic astronomical rules, day boundaries, authority locations, seeded calendar packages, historical approximations, and limitations.
+
+## Suggested Implementation Phases
+
+1. Add `MudInstant` and legacy conversion/backfill support.
+2. Add calendar algorithm abstraction and fixed-month wrapper.
+3. Add arbitrary-instant celestial ephemeris interfaces.
+4. Refactor sun/moon implementations to support arbitrary instants.
+5. Add event solver.
+6. Add day-boundary and authority-location support.
+7. Add calculated/astronomical algorithms.
+8. Update seeders and stock calendars.
+9. Update builder/admin commands.
+10. Add FutureProg functions.
+11. Update docs and tests.
+
+## Acceptance Criteria
+
+- Existing databases and stored date/time strings remain compatible.
+- Existing fixed calendars behave as before.
+- `MudInstant` exists, round-trips, and can be derived from legacy state.
+- Calendar algorithms are separated from metadata/presentation.
+- Celestials support arbitrary-instant ephemeris queries.
+- Event solver deterministically finds required solar/lunar events.
+- Required new stock calendars are available and runtime-loadable.
+- Builder/admin and FutureProg surfaces expose the new functionality.
+- Documentation is updated.
+- Relevant targeted builds/tests are run and results are reported.

--- a/Design Documents/World/Celestial_System_Overview.md
+++ b/Design Documents/World/Celestial_System_Overview.md
@@ -46,6 +46,26 @@ At the interface level, a celestial is anything implementing `ICelestialObject`.
 - the last local altitude/elevation angle
 - the current movement direction
 
+Some celestial types also expose arbitrary-instant ephemeris interfaces for calendar and FutureProg event solving:
+
+- `ICelestialEphemeris`
+- `ISolarEphemeris`
+- `ILunarEphemeris`
+
+`Sun`/`NewSun` implements the solar ephemeris. `PlanetaryMoon` implements the lunar ephemeris. These interfaces answer right ascension, declination, apparent altitude/azimuth, illumination, ecliptic longitude, and lunar phase angle for any supplied `MudInstant` rather than only the current clock/calendar state.
+
+`AstronomicalEventService` provides deterministic bounded searches for:
+
+- sunrise
+- sunset
+- solar longitude crossings
+- lunar conjunction/new moon
+- full moon
+- visible crescent approximation
+- nth-next occurrence of each supported event
+
+The solver is intentionally deterministic and engine-local. Visible crescent detection uses geometric thresholds at sunset; it does not consult manual observation ledgers or weather-dependent official calendar decisions.
+
 ## Observer Frames
 The subsystem deliberately models observer frames rather than only physical bodies.
 
@@ -93,3 +113,14 @@ FutureProgs can inspect the cached sky state with:
 The function looks up the celestial by ID in the supplied room's zone or the supplied zone and returns the current elevation angle in radians. Positive values are above the horizon and negative values are below it. If the zone or celestial cannot be found, the function returns `0`.
 
 This is intended for environmental gating such as sunlight-sensitive combat moves, outdoor ceremonies, or weather/season logic that needs to know whether a sun-like celestial is high enough above the horizon.
+
+FutureProgs can also ask for deterministic event times as `MudDateTime` values:
+
+- `nextsunrise(location|zone, celestialId, calendar[, occurrence])`
+- `nextsunset(location|zone, celestialId, calendar[, occurrence])`
+- `nextsolarlongitude(location|zone, celestialId, calendar, longitudeDegrees[, occurrence])`
+- `nextnewmoon(location|zone, moonId, calendar[, occurrence])`
+- `nextfullmoon(location|zone, moonId, calendar[, occurrence])`
+- `nextvisiblecrescent(location|zone, sunId, moonId, calendar[, occurrence])`
+
+These functions use the supplied room or zone geography as the observer and project the found `MudInstant` back through the supplied calendar, feed clock, and local zone time zone. They return `MudDateTime.Never` when the requested celestial does not support the required ephemeris or no event is found inside the bounded deterministic search window.

--- a/Design Documents/World/Celestial_System_Tests.md
+++ b/Design Documents/World/Celestial_System_Tests.md
@@ -26,6 +26,7 @@ The modern runtime coverage lives in four focused suites:
 The intent is no longer "basic smoke coverage". Each supported modern model has deterministic numeric regression rows with at least three fixed data points. Those rows assert concrete outputs such as:
 
 - current day number
+- arbitrary-instant ephemeris day numbers
 - right ascension and declination when available or practically accessible
 - elevation
 - azimuth
@@ -40,6 +41,8 @@ The linked models also assert relationships back to their source objects, such a
 - `PlanetFromMoon` remaining opposite the linked moon in equatorial coordinates
 - `PlanetFromMoon` illumination remaining complementary to the linked moon
 - `SunFromPlanetaryMoon` remaining close to, but not identical to, the root solar direction near conjunction
+
+`CelestialTests.cs` also covers the astronomical event solver. The current solver coverage checks nth-next sunrise advancement plus supported solar longitude, new moon, full moon, and deterministic visible-crescent event searches.
 
 ## Direction Sampling Coverage
 All four runtime suites retain explicit non-24x60 clock coverage for movement direction sampling.
@@ -79,6 +82,8 @@ Add or expand numeric regression coverage whenever a change touches:
 - eclipse thresholds
 - illumination formulas
 - day-number or fractional-day handling
+- arbitrary-instant ephemeris APIs
+- astronomical event search or nth-next behavior
 
 Seeder tests should be updated whenever a change touches:
 

--- a/Design Documents/World/Celestial_Type_PlanetaryMoon.md
+++ b/Design Documents/World/Celestial_Type_PlanetaryMoon.md
@@ -41,6 +41,20 @@ The runtime flow is:
 
 `PositionVector(dayNumber)` returns a physical vector using the authored orbital semi-major axis and eccentricity so linked moon-view transforms can work with relative positions rather than unit directions.
 
+## Arbitrary-Instant Ephemeris
+`PlanetaryMoon` implements `ILunarEphemeris` for deterministic calculations at an arbitrary `MudInstant`.
+
+The arbitrary-instant surface exposes:
+
+- ecliptic longitude
+- right ascension
+- declination
+- apparent altitude and azimuth
+- illumination
+- phase angle
+
+This is the lunar input used by astronomical event searches for new moon, full moon, visible crescent approximation, `time event` previews, and FutureProg event functions.
+
 ## Phase Naming
 The phase cycle is anchored at `FullMoonReferenceDay`.
 

--- a/Design Documents/World/Celestial_Type_Sun.md
+++ b/Design Documents/World/Celestial_Type_Sun.md
@@ -35,6 +35,19 @@ The runtime flow is:
 
 `PositionVector(dayNumber)` returns a physical observer-frame vector using the configured orbital radius, not just a unit direction. That vector is used by `SunFromPlanetaryMoon`.
 
+## Arbitrary-Instant Ephemeris
+`NewSun` implements `ISolarEphemeris` for deterministic calculations at an arbitrary `MudInstant`.
+
+The arbitrary-instant surface exposes:
+
+- ecliptic longitude
+- right ascension
+- declination
+- apparent altitude and azimuth
+- illumination
+
+This is the solar input used by calendar day-boundary searches, `time event` previews, and FutureProg functions such as `nextsunrise`, `nextsunset`, and `nextsolarlongitude`.
+
 ## Time of Day
 `CurrentTimeOfDay(...)` is gameplay-facing and uses:
 

--- a/Design Documents/World/Time_And_Date_System.md
+++ b/Design Documents/World/Time_And_Date_System.md
@@ -184,6 +184,46 @@ The first weekday of a year is computed from:
 
 This is what allows calendars with five-day, six-day, eight-day, or other custom week lengths to work correctly.
 
+## MudInstant And Calendar Algorithms
+`MudInstant` is the absolute mud-time value used when a caller needs an ordered, storage-safe instant rather than a calendar-relative string. It stores a versioned epoch plus clock-second ticks from the owning calendar's epoch year and round-trips as:
+
+```text
+mudinstant:v1:<ticks>
+```
+
+`MudInstant.FromLegacyState(calendar, clock)` back-calculates the current absolute instant from an existing calendar's current date and feed clock time. This is the boot/backfill path for existing worlds: no database migration or seeder rerun is required, and old `MudDate`, `MudTime`, `MudDateTime`, recurring intervals, and stored strings remain authoritative. `MudInstant.ToMudDateTime(calendar, clock, timezone)` projects an instant back through the selected calendar algorithm and clock.
+
+Calendar XML now has optional algorithm and day-boundary metadata:
+
+```xml
+<algorithm type="fixed-months" />
+<dayboundary type="ClockMidnight" />
+```
+
+Missing `algorithm` or `dayboundary` elements preserve the legacy behavior: fixed authored months/intercalaries and clock-midnight day starts. The runtime currently supports these algorithm types:
+
+- `fixed-months`: legacy authored month and intercalary rules
+- `tabular-lunar`: alternating 30/29 day lunar months with a deterministic 30-year leap-day cycle
+- `calculated-hebrew`: calculated Hebrew month generation with Metonic leap years, postponement-derived year lengths, Heshvan/Kislev variation, and Adar I/II handling
+- `solar-equinox`: deterministic solar/equinox approximation, including Old Persian/Zoroastrian-style epagomenal days
+- `astronomical-lunar`: deterministic mean-lunation calendars, including Hijri-style and Babylonian regulated variants
+- `east-asian-lunisolar`: deterministic East Asian lunisolar approximation with mean new moons and a predictable leap-month placement rule
+
+The algorithm object owns generated-year shape. Calendar metadata still owns display masks, aliases, eras, weekdays, authored month names, and builder presentation.
+
+### Day Boundaries And Authority Locations
+Calendar day starts are separately configured through `CalendarDayBoundaryType`.
+
+Supported boundary types are:
+
+- `ClockMidnight`
+- `FixedClockTime`
+- `SunsetAtAuthorityLocation`
+- `SunriseAtAuthorityLocation`
+- `AstronomicalEvent`
+
+Legacy calendars default to `ClockMidnight`. Sunrise and sunset boundaries use the calendar's authority location and the first available solar ephemeris when present; otherwise they fall back to clock midnight so old worlds keep booting. Authority locations are stored as `GeographicCoordinate` values in calendar XML and can be inspected or edited by builders.
+
 ## Months, Intercalaries, And Weekdays
 `MonthDefinition` is the authored month template. `Month` is the generated month for a specific year.
 
@@ -396,6 +436,7 @@ FutureProg exposes three related date/time surfaces:
 - `calendar`
 - `clock`
 - `timezone`
+- `mudinstant`
 
 Important built-in Date/Time functions include:
 
@@ -408,6 +449,17 @@ Important built-in Date/Time functions include:
 - `between(...)` for `TimeSpan`, `DateTime`, and `MudDateTime`
 - arithmetic operators for date/time plus or minus spans
 - `GameSecondsPerRealSeconds(clock)` for clock speed introspection
+
+Celestial event FutureProg functions return `MudDateTime` values projected from `MudInstant` event searches:
+
+- `nextsunrise(location|zone, celestialId, calendar[, occurrence])`
+- `nextsunset(location|zone, celestialId, calendar[, occurrence])`
+- `nextsolarlongitude(location|zone, celestialId, calendar, longitudeDegrees[, occurrence])`
+- `nextnewmoon(location|zone, moonId, calendar[, occurrence])`
+- `nextfullmoon(location|zone, moonId, calendar[, occurrence])`
+- `nextvisiblecrescent(location|zone, sunId, moonId, calendar[, occurrence])`
+
+The optional `occurrence` parameter is the nth next matching event. These functions return `MudDateTime.Never` when the zone, calendar, celestial ephemeris, or bounded event search cannot produce a deterministic result.
 
 FutureProg schedules persist a recurrence, a reference `MudDateTime`, and the target FutureProg. On load, a schedule advances the persisted reference to the next future occurrence and creates an in-memory listener. When the listener fires, the schedule executes the FutureProg, computes the next reference time, creates the next listener, and marks itself changed.
 
@@ -440,7 +492,19 @@ Clock editing supports metadata, display masks, clock units, in-game speed, fixe
 
 Time-zone editing supports name/alias, description, and offset hours/minutes. Existing time zones cannot be moved between clocks; builders should clone to the target clock instead.
 
-Calendar editing supports metadata, display masks, feed clock, current date, epoch year and first weekday, era display text, weekday and month editing, normal special/non-weekday days, intercalary days/months, generated-year preview, and validation. Structural edits clear generated-year caches, normalize the current date, and mark the calendar changed.
+Calendar editing supports metadata, display masks, feed clock, current date, epoch year and first weekday, era display text, weekday and month editing, normal special/non-weekday days, intercalary days/months, generated-year preview, validation, algorithm selection, day-boundary selection, and authority-location editing. Structural edits clear generated-year caches, normalize the current date, and mark the calendar changed.
+
+Admin time displays now expose the current `MudInstant`, calendar algorithm type, day-boundary type, authority location when set, and celestial ephemeris support. Admins can preview deterministic astronomical events with:
+
+```text
+time instant
+time event sunrise <sun> [occurrence]
+time event sunset <sun> [occurrence]
+time event solarlongitude <sun> <degrees> [occurrence]
+time event newmoon <moon> [occurrence]
+time event fullmoon <moon> [occurrence]
+time event visiblecrescent <sun> <moon> [occurrence]
+```
 
 Builders changing live calendars or clocks should preview and validate before closing the edit session, then watch for Discord fallback notifications after reboot/load cycles. Those notifications identify affected saved objects so humans can repair data that was made invalid by the definition change.
 
@@ -455,6 +519,21 @@ It asks for:
 - additional package-specific choices, such as Middle-earth age selection
 
 The seeder includes stock calendars such as Gregorian, Julian, Roman, Tranquility, French Republican, Mission, Seasonal 360, and several Tolkien-inspired calendars.
+
+It also includes deterministic astronomical and historical approximation packages:
+
+- Islamic Hijri
+- Hebrew
+- Old Persian
+- Babylonian
+- Chinese Minguo
+- Chinese lunisolar
+- Korean modern/Dangi
+- Korean lunisolar
+- Japanese modern/Koki
+- Japanese lunisolar
+
+Those packages use Latin1-safe romanised aliases and descriptions. The lunisolar and historical packages are deterministic approximations for engine repeatability; they do not implement manual observation ledgers, local weather-dependent official decisions, or historically variable human authority rulings.
 
 The seeder is repair-capable for canonical stock time data. Other seeders rely on at least one clock and calendar being present.
 
@@ -490,6 +569,9 @@ These are important rules to preserve when changing the system:
 - Persistent scheduling should store recurrence/reference data and recreate listeners rather than expecting listeners themselves to persist.
 - Stored-value fallback helpers must be used for persisted round-trip strings that may have been invalidated by builder edits.
 - Fallback reporting must be no-throw; bad telemetry should never prevent the owning object from loading.
+- Missing calendar algorithm/day-boundary XML must continue to load as fixed-month, clock-midnight calendars.
+- `MudInstant` must remain additive over existing calendar/clock state; existing persisted mud date/time strings stay valid and are not replaced in-place.
+- Calculated and astronomical calendar algorithms must produce deterministic generated years from authored metadata without storing generated years or observation ledgers.
 
 ## Test Coverage
 The normal unit-test suites now include focused coverage for:
@@ -499,8 +581,13 @@ The normal unit-test suites now include focused coverage for:
 - recurring interval parsing, descriptions, round-trip text, forward/backward search, high ordinal weekdays, exact-month skipping, and "or last" fallback
 - runtime listeners, interval extension helpers, and FutureProg date/time helper functions
 - clock, time-zone, and calendar builder command paths for high-value edits
+- `MudInstant` storage, ordering, conversion, and legacy backfill
+- legacy calendar XML loading without an algorithm element
+- fixed, calculated, and astronomical calendar algorithm generation
+- astronomical event solver nth-next behavior and supported solar/lunar/visible-crescent events
+- FutureProg celestial event function registration with nth-next overloads
 - stored-value fallback behavior and Discord admin notification payloads
-- every seeded clock/calendar package produced by `TimeSeeder`, including runtime loading and idempotent reruns
+- every seeded clock/calendar package produced by `TimeSeeder`, including runtime loading and idempotent reruns for the new astronomical/historical modes
 
 ## Current Limitations
 The system is flexible, but there are areas where current support is incomplete or intentionally narrow:
@@ -512,6 +599,8 @@ The system is flexible, but there are areas where current support is incomplete 
 - cross-calendar conversion is based on each calendar's current date anchor, which is useful for live worlds but should be treated carefully for historical absolute chronology
 - `MudTimeSpan` month and year components are calendar-like approximations until applied to a concrete `MudDateTime`
 - major structural edits rely on fallback notification and human repair rather than a bulk migration wizard
+- astronomical calendars currently use deterministic approximations rather than observational or jurisdiction-specific historical calendars
+- visible crescent detection is geometric and deterministic; it deliberately ignores manual sightings and weather
 
 ## Future Work
 Useful extensions include:

--- a/FutureMUDLibrary/Celestial/CelestialEphemeris.cs
+++ b/FutureMUDLibrary/Celestial/CelestialEphemeris.cs
@@ -1,0 +1,48 @@
+#nullable enable
+
+using MudSharp.TimeAndDate;
+
+namespace MudSharp.Celestial;
+
+public enum AstronomicalEventType
+{
+	Sunrise,
+	Sunset,
+	SolarLongitude,
+	LunarConjunction,
+	NewMoon,
+	FullMoon,
+	VisibleCrescent
+}
+
+public interface ICelestialEphemeris
+{
+	double RightAscensionAt(MudInstant instant);
+
+	double DeclinationAt(MudInstant instant);
+
+	double ApparentAltitudeAt(MudInstant instant, GeographicCoordinate observer);
+
+	double ApparentAzimuthAt(MudInstant instant, GeographicCoordinate observer);
+
+	double IlluminationAt(MudInstant instant, GeographicCoordinate observer);
+}
+
+public interface ISolarEphemeris : ICelestialEphemeris
+{
+	double EclipticLongitudeAt(MudInstant instant);
+}
+
+public interface ILunarEphemeris : ICelestialEphemeris
+{
+	double EclipticLongitudeAt(MudInstant instant);
+
+	double PhaseAngleAt(MudInstant instant);
+}
+
+public interface IAstronomicalEventService
+{
+	bool TryFindNext(AstronomicalEventType eventType, MudInstant reference, int occurrence,
+		ICelestialEphemeris primary, GeographicCoordinate observer, out MudInstant instant, out string error,
+		double targetLongitude = 0.0, ICelestialEphemeris? secondary = null);
+}

--- a/FutureMUDLibrary/TimeAndDate/Date/CalendarAlgorithm.cs
+++ b/FutureMUDLibrary/TimeAndDate/Date/CalendarAlgorithm.cs
@@ -1,0 +1,56 @@
+#nullable enable
+
+using MudSharp.Celestial;
+using MudSharp.TimeAndDate.Time;
+using System.Xml.Linq;
+
+namespace MudSharp.TimeAndDate.Date;
+
+public enum CalendarAlgorithmType
+{
+	FixedMonths,
+	TabularLunar,
+	CalculatedHebrew,
+	SolarEquinox,
+	AstronomicalLunar,
+	EastAsianLunisolar
+}
+
+public enum CalendarDayBoundaryType
+{
+	ClockMidnight,
+	FixedClockTime,
+	SunsetAtAuthorityLocation,
+	SunriseAtAuthorityLocation,
+	AstronomicalEvent
+}
+
+public interface ICalendarAlgorithm
+{
+	CalendarAlgorithmType Type { get; }
+
+	string DisplayName { get; }
+
+	string Summary { get; }
+
+	Year CreateYear(ICalendar calendar, int whichYear);
+
+	int CountWeekdaysInYear(ICalendar calendar, int whichYear);
+
+	int CountDaysInYear(ICalendar calendar, int whichYear);
+
+	XElement SaveToXml();
+}
+
+public interface IFixedMonthCalendarAlgorithm : ICalendarAlgorithm
+{
+}
+
+public interface ICalculatedCalendarAlgorithm : ICalendarAlgorithm
+{
+}
+
+public interface IAstronomicalCalendarAlgorithm : ICalculatedCalendarAlgorithm
+{
+	GeographicCoordinate? AuthorityLocation { get; }
+}

--- a/FutureMUDLibrary/TimeAndDate/Date/ICalendar.cs
+++ b/FutureMUDLibrary/TimeAndDate/Date/ICalendar.cs
@@ -3,6 +3,7 @@ using MudSharp.Framework.Revision;
 using MudSharp.Framework.Save;
 using MudSharp.FutureProg;
 using MudSharp.TimeAndDate.Time;
+using MudSharp.Celestial;
 using System;
 using System.Collections.Generic;
 
@@ -38,8 +39,13 @@ namespace MudSharp.TimeAndDate.Date
         string AncientEraLongString { get; set; }
         MudDate CurrentDate { get; }
         MudDateTime CurrentDateTime { get; }
+        MudInstant CurrentInstant { get; }
         int EpochYear { get; }
         int FirstWeekdayAtEpoch { get; }
+        CalendarAlgorithmType AlgorithmType { get; }
+        ICalendarAlgorithm Algorithm { get; }
+        CalendarDayBoundaryType DayBoundary { get; }
+        GeographicCoordinate AuthorityLocation { get; }
         List<string> Weekdays { get; }
         List<MonthDefinition> Months { get; }
         List<IntercalaryMonth> Intercalaries { get; }
@@ -98,6 +104,7 @@ namespace MudSharp.TimeAndDate.Date
         MudDate GetDateInYear(int day, string month, int year);
         MudDate GetBirthday(int day, string month, int age);
         MudDate GetRandomBirthday(int age);
+        MudDateTime StartOfCalendarDay(MudDate date, IMudTimeZone timezone = null);
 
         /// <summary>
         ///     Creates a new Date based on a date string. Throws an exception if it runs into an error.

--- a/FutureMUDLibrary/TimeAndDate/MudDateTime.cs
+++ b/FutureMUDLibrary/TimeAndDate/MudDateTime.cs
@@ -831,6 +831,8 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
                     return Clock;
                 case "timezone":
                     return new TextVariable(TimeZone?.Alias ?? "None");
+                case "mudinstant":
+                    return new TextVariable(MudInstant.FromMudDateTime(this).GetStorageString());
             }
 
             throw new NotSupportedException($"Unsupported property type {property} in MudDateTime.GetProperty");
@@ -866,6 +868,8 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
                     return ProgVariableTypes.Clock;
                 case "timezone":
                     return ProgVariableTypes.Text;
+                case "mudinstant":
+                    return ProgVariableTypes.Text;
                 default:
                     return ProgVariableTypes.Error;
             }
@@ -886,6 +890,7 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
                 {"calendar", ProgVariableTypes.Calendar},
                 {"clock", ProgVariableTypes.Clock},
                 {"timezone", ProgVariableTypes.Text},
+                {"mudinstant", ProgVariableTypes.Text},
             };
         }
 
@@ -904,6 +909,7 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
                 {"calendar", ""},
                 {"clock", ""},
                 {"timezone", ""},
+                {"mudinstant", "Returns the absolute MudInstant storage string for this mud date/time"},
             };
         }
 

--- a/FutureMUDLibrary/TimeAndDate/MudInstant.cs
+++ b/FutureMUDLibrary/TimeAndDate/MudInstant.cs
@@ -1,0 +1,359 @@
+#nullable enable
+
+using MudSharp.TimeAndDate.Date;
+using MudSharp.TimeAndDate.Time;
+using System;
+using System.Globalization;
+
+namespace MudSharp.TimeAndDate;
+
+/// <summary>
+/// A deterministic absolute in-game timestamp measured in clock seconds from a calendar epoch.
+/// </summary>
+public readonly struct MudInstant : IComparable<MudInstant>, IEquatable<MudInstant>
+{
+	public const string CurrentEpoch = "v1";
+	private const string Prefix = "mudinstant";
+
+	public static MudInstant Never => new(CurrentEpoch, 0, 0, 0, true);
+
+	public MudInstant(long ticks)
+		: this(CurrentEpoch, ticks, 0, 0, false)
+	{
+	}
+
+	public MudInstant(string epoch, long ticks)
+		: this(string.IsNullOrWhiteSpace(epoch) ? CurrentEpoch : epoch, ticks, 0, 0, false)
+	{
+	}
+
+	public MudInstant(string epoch, long ticks, long sourceCalendarId, long sourceClockId)
+		: this(string.IsNullOrWhiteSpace(epoch) ? CurrentEpoch : epoch, ticks, sourceCalendarId, sourceClockId, false)
+	{
+	}
+
+	private MudInstant(string epoch, long ticks, long sourceCalendarId, long sourceClockId, bool isNever)
+	{
+		Epoch = epoch;
+		Ticks = ticks;
+		SourceCalendarId = sourceCalendarId;
+		SourceClockId = sourceClockId;
+		IsNever = isNever;
+	}
+
+	public string Epoch { get; }
+
+	public long Ticks { get; }
+
+	public long SourceCalendarId { get; }
+
+	public long SourceClockId { get; }
+
+	public bool HasSourceContext => SourceCalendarId > 0 && SourceClockId > 0;
+
+	public bool IsNever { get; }
+
+	public string GetStorageString()
+	{
+		if (IsNever)
+		{
+			return "Never";
+		}
+
+		return HasSourceContext
+			? $"{Prefix}:{Epoch}:{SourceCalendarId.ToString(CultureInfo.InvariantCulture)}:{SourceClockId.ToString(CultureInfo.InvariantCulture)}:{Ticks.ToString(CultureInfo.InvariantCulture)}"
+			: $"{Prefix}:{Epoch}:{Ticks.ToString(CultureInfo.InvariantCulture)}";
+	}
+
+	public override string ToString()
+	{
+		return GetStorageString();
+	}
+
+	public static bool TryParse(string? text, out MudInstant instant)
+	{
+		instant = Never;
+		if (string.IsNullOrWhiteSpace(text))
+		{
+			return false;
+		}
+
+		if (text.Equals("never", StringComparison.InvariantCultureIgnoreCase))
+		{
+			instant = Never;
+			return true;
+		}
+
+		var split = text.Split(':', StringSplitOptions.RemoveEmptyEntries);
+		if (split.Length == 0 || !split[0].Equals(Prefix, StringComparison.InvariantCultureIgnoreCase))
+		{
+			return false;
+		}
+
+		switch (split.Length)
+		{
+			case 3:
+				if (!long.TryParse(split[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out var legacyTicks))
+				{
+					return false;
+				}
+
+				instant = new MudInstant(split[1], legacyTicks);
+				return true;
+			case 5:
+				if (!long.TryParse(split[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out var calendarId) ||
+				    !long.TryParse(split[3], NumberStyles.Integer, CultureInfo.InvariantCulture, out var clockId) ||
+				    !long.TryParse(split[4], NumberStyles.Integer, CultureInfo.InvariantCulture, out var ticks))
+				{
+					return false;
+				}
+
+				instant = new MudInstant(split[1], ticks, calendarId, clockId);
+				return true;
+			default:
+				return false;
+		}
+	}
+
+	public static MudInstant Parse(string text)
+	{
+		if (TryParse(text, out var instant))
+		{
+			return instant;
+		}
+
+		throw new FormatException($"The text '{text}' is not a valid MudInstant storage string.");
+	}
+
+	public static MudInstant FromMudDateTime(MudDateTime dateTime)
+	{
+		if (dateTime?.Date is null || dateTime.Clock is null)
+		{
+			return Never;
+		}
+
+		var clock = dateTime.Clock;
+		var calendar = dateTime.Calendar;
+		var primary = dateTime.GetByTimeZone(clock.PrimaryTimezone);
+		var day = DaysSinceEpoch(primary.Date);
+		var ticks = checked(day * SecondsPerDay(clock) + SecondsSinceMidnight(primary.Time));
+		return new MudInstant(CurrentEpoch, ticks, calendar.Id, clock.Id);
+	}
+
+	public static MudInstant FromLegacyState(ICalendar calendar, IClock? clock = null)
+	{
+		if (calendar?.CurrentDate is null)
+		{
+			return Never;
+		}
+
+		clock ??= calendar.FeedClock;
+		if (clock is null)
+		{
+			return Never;
+		}
+
+		return FromMudDateTime(new MudDateTime(calendar.CurrentDate, clock.CurrentTime, clock.PrimaryTimezone));
+	}
+
+	public MudDateTime ToMudDateTime(ICalendar calendar, IClock? clock = null, IMudTimeZone? timezone = null)
+	{
+		if (IsNever || calendar is null)
+		{
+			return MudDateTime.Never;
+		}
+
+		clock ??= calendar.FeedClock;
+		if (clock is null)
+		{
+			return MudDateTime.Never;
+		}
+
+		timezone ??= clock.PrimaryTimezone;
+		if (TryResolveSourceContext(calendar, clock, out var sourceCalendar, out var sourceClock) &&
+		    (sourceCalendar.Id != calendar.Id || sourceClock.Id != clock.Id) &&
+		    sourceClock.Id == clock.Id)
+		{
+			var sourceDateTime = ToMudDateTimeInCalendar(sourceCalendar, sourceClock, timezone);
+			return sourceDateTime.ConvertToOtherCalendar(calendar);
+		}
+
+		return ToMudDateTimeInCalendar(calendar, clock, timezone);
+	}
+
+	public MudInstant WithTicks(long ticks)
+	{
+		return new MudInstant(Epoch, ticks, SourceCalendarId, SourceClockId, IsNever);
+	}
+
+	public MudInstant AddSeconds(long seconds)
+	{
+		return WithTicks(checked(Ticks + seconds));
+	}
+
+	private MudDateTime ToMudDateTimeInCalendar(ICalendar calendar, IClock clock, IMudTimeZone timezone)
+	{
+		var secondsPerDay = SecondsPerDay(clock);
+		var dayOffset = FloorDiv(Ticks, secondsPerDay);
+		var secondOfDay = Ticks - dayOffset * secondsPerDay;
+		var date = FirstDateOfEpoch(calendar);
+		date.AdvanceDays(checked((int)dayOffset));
+
+		var hours = (int)(secondOfDay / (clock.MinutesPerHour * clock.SecondsPerMinute));
+		secondOfDay %= clock.MinutesPerHour * clock.SecondsPerMinute;
+		var minutes = (int)(secondOfDay / clock.SecondsPerMinute);
+		var seconds = (int)(secondOfDay % clock.SecondsPerMinute);
+		var primaryTime = MudTime.FromLocalTime(seconds, minutes, hours, clock.PrimaryTimezone, clock);
+		var localTime = primaryTime.GetTimeByTimezone(timezone);
+		if (localTime.DaysOffsetFromDatum != 0)
+		{
+			date.AdvanceDays(localTime.DaysOffsetFromDatum);
+		}
+
+		return new MudDateTime(date, localTime, timezone);
+	}
+
+	private bool TryResolveSourceContext(ICalendar targetCalendar, IClock targetClock, out ICalendar sourceCalendar,
+		out IClock sourceClock)
+	{
+		sourceCalendar = targetCalendar;
+		sourceClock = targetClock;
+
+		if (!HasSourceContext)
+		{
+			return false;
+		}
+
+		if (targetCalendar.Id == SourceCalendarId && targetClock.Id == SourceClockId)
+		{
+			return true;
+		}
+
+		var gameworld = targetCalendar.Gameworld ?? targetClock.Gameworld;
+		var resolvedCalendar = gameworld?.Calendars.Get(SourceCalendarId);
+		var resolvedClock = gameworld?.Clocks.Get(SourceClockId);
+		if (resolvedCalendar is null || resolvedClock is null)
+		{
+			return false;
+		}
+
+		sourceCalendar = resolvedCalendar;
+		sourceClock = resolvedClock;
+		return true;
+	}
+
+	private static MudDate FirstDateOfEpoch(ICalendar calendar)
+	{
+		var year = calendar.CreateYear(calendar.EpochYear);
+		var month = year.Months[0];
+		return new MudDate(calendar, 1, calendar.EpochYear, month, year, false);
+	}
+
+	private static long DaysSinceEpoch(MudDate date)
+	{
+		var calendar = date.Calendar;
+		var dayOfYear = date.DayNumberInYear() - 1;
+		if (date.Year >= calendar.EpochYear)
+		{
+			return calendar.CountDaysBetweenYears(calendar.EpochYear, date.Year) + dayOfYear;
+		}
+
+		return -(calendar.CountDaysBetweenYears(date.Year, calendar.EpochYear) - dayOfYear);
+	}
+
+	private static long SecondsSinceMidnight(MudTime time)
+	{
+		return (long)time.Hours * time.Clock.MinutesPerHour * time.Clock.SecondsPerMinute +
+		       (long)time.Minutes * time.Clock.SecondsPerMinute +
+		       time.Seconds;
+	}
+
+	private static long SecondsPerDay(IClock clock)
+	{
+		return (long)clock.HoursPerDay * clock.MinutesPerHour * clock.SecondsPerMinute;
+	}
+
+	private static long FloorDiv(long value, long divisor)
+	{
+		var quotient = value / divisor;
+		var remainder = value % divisor;
+		return remainder != 0 && ((remainder > 0) != (divisor > 0)) ? quotient - 1 : quotient;
+	}
+
+	public int CompareTo(MudInstant other)
+	{
+		if (IsNever)
+		{
+			return other.IsNever ? 0 : -1;
+		}
+
+		if (other.IsNever)
+		{
+			return 1;
+		}
+
+		var epochCompare = string.Compare(Epoch, other.Epoch, StringComparison.Ordinal);
+		if (epochCompare != 0)
+		{
+			return epochCompare;
+		}
+
+		var tickCompare = Ticks.CompareTo(other.Ticks);
+		if (tickCompare != 0)
+		{
+			return tickCompare;
+		}
+
+		var calendarCompare = SourceCalendarId.CompareTo(other.SourceCalendarId);
+		return calendarCompare != 0 ? calendarCompare : SourceClockId.CompareTo(other.SourceClockId);
+	}
+
+	public bool Equals(MudInstant other)
+	{
+		return IsNever == other.IsNever &&
+		       Ticks == other.Ticks &&
+		       SourceCalendarId == other.SourceCalendarId &&
+		       SourceClockId == other.SourceClockId &&
+		       string.Equals(Epoch, other.Epoch, StringComparison.Ordinal);
+	}
+
+	public override bool Equals(object? obj)
+	{
+		return obj is MudInstant other && Equals(other);
+	}
+
+	public override int GetHashCode()
+	{
+		return HashCode.Combine(Epoch, Ticks, SourceCalendarId, SourceClockId, IsNever);
+	}
+
+	public static bool operator <(MudInstant left, MudInstant right)
+	{
+		return left.CompareTo(right) < 0;
+	}
+
+	public static bool operator >(MudInstant left, MudInstant right)
+	{
+		return left.CompareTo(right) > 0;
+	}
+
+	public static bool operator <=(MudInstant left, MudInstant right)
+	{
+		return left.CompareTo(right) <= 0;
+	}
+
+	public static bool operator >=(MudInstant left, MudInstant right)
+	{
+		return left.CompareTo(right) >= 0;
+	}
+
+	public static bool operator ==(MudInstant left, MudInstant right)
+	{
+		return left.Equals(right);
+	}
+
+	public static bool operator !=(MudInstant left, MudInstant right)
+	{
+		return !left.Equals(right);
+	}
+}

--- a/MudSharpCore Unit Tests/CelestialTests.cs
+++ b/MudSharpCore Unit Tests/CelestialTests.cs
@@ -3,6 +3,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MudSharp.Celestial;
 using MudSharp.Construction;
+using MudSharp.TimeAndDate;
 using System.Collections.Generic;
 
 namespace MudSharp_Unit_Tests;
@@ -85,6 +86,46 @@ public class CelestialTests
 
         context.SetDateTime("20/mar/2000", 19, 0, 0);
         Assert.AreEqual(TimeOfDay.Night, context.Sun.CurrentTimeOfDay(context.ZeroGeography));
+    }
+
+    [TestMethod]
+    public void AstronomicalEventService_NthNextSunriseAdvances()
+    {
+        CelestialTestContext context = CelestialTestFactory.CreateEarthSystem();
+        context.SetDateTime("1/jan/2000", 12, 0, 0);
+        MudInstant reference = MudInstant.FromLegacyState(context.Calendar, context.Clock);
+
+        Assert.IsTrue(AstronomicalEventService.Instance.TryFindNext(AstronomicalEventType.Sunrise, reference, 1,
+            context.Sun, context.ZeroGeography, out MudInstant first, out string firstError), firstError);
+        Assert.IsTrue(AstronomicalEventService.Instance.TryFindNext(AstronomicalEventType.Sunrise, reference, 2,
+            context.Sun, context.ZeroGeography, out MudInstant second, out string secondError), secondError);
+
+        Assert.IsTrue(second > first);
+        Assert.IsTrue(second.Ticks - first.Ticks > 12 * 60 * 60);
+        Assert.IsFalse(second.ToMudDateTime(context.Calendar, context.Clock).Equals(MudDateTime.Never));
+    }
+
+    [TestMethod]
+    public void AstronomicalEventService_SolarLunarAndVisibleCrescentEventsResolve()
+    {
+        CelestialTestContext context = CelestialTestFactory.CreateEarthSystem();
+        context.SetDateTime("1/jan/2000", 12, 0, 0);
+        MudInstant reference = MudInstant.FromLegacyState(context.Calendar, context.Clock);
+
+        Assert.IsTrue(AstronomicalEventService.Instance.TryFindNext(AstronomicalEventType.SolarLongitude, reference, 1,
+            context.Sun, context.ZeroGeography, out MudInstant solstice, out string solarError, 0.0), solarError);
+        Assert.IsTrue(AstronomicalEventService.Instance.TryFindNext(AstronomicalEventType.NewMoon, reference, 1,
+            context.Moon, context.ZeroGeography, out MudInstant newMoon, out string newMoonError), newMoonError);
+        Assert.IsTrue(AstronomicalEventService.Instance.TryFindNext(AstronomicalEventType.FullMoon, reference, 1,
+            context.Moon, context.ZeroGeography, out MudInstant fullMoon, out string fullMoonError), fullMoonError);
+        Assert.IsTrue(AstronomicalEventService.Instance.TryFindNext(AstronomicalEventType.VisibleCrescent, reference, 1,
+            context.Sun, context.ZeroGeography, out MudInstant crescent, out string crescentError, 0.0,
+            context.Moon), crescentError);
+
+        Assert.IsTrue(solstice > reference);
+        Assert.IsTrue(newMoon > reference);
+        Assert.IsTrue(fullMoon > reference);
+        Assert.IsTrue(crescent > reference);
     }
 
     [TestMethod]

--- a/MudSharpCore Unit Tests/FutureProgDateTimeFunctionTests.cs
+++ b/MudSharpCore Unit Tests/FutureProgDateTimeFunctionTests.cs
@@ -222,6 +222,37 @@ public class FutureProgDateTimeFunctionTests
 		Assert.IsTrue(result.Equals(MudDateTime.Never));
 	}
 
+	[TestMethod]
+	public void AstronomicalEventFunctions_CompileWithNthNextOverloads()
+	{
+		Compile<MudDateTime>(
+			"NextSunriseCompile",
+			ProgVariableTypes.MudDateTime,
+			[
+				Tuple.Create(ProgVariableTypes.Zone, "zone"),
+				Tuple.Create(ProgVariableTypes.Calendar, "calendar")
+			],
+			"return NextSunrise(@zone, 1, @calendar, 2)");
+
+		Compile<MudDateTime>(
+			"NextSolarLongitudeCompile",
+			ProgVariableTypes.MudDateTime,
+			[
+				Tuple.Create(ProgVariableTypes.Zone, "zone"),
+				Tuple.Create(ProgVariableTypes.Calendar, "calendar")
+			],
+			"return NextSolarLongitude(@zone, 1, @calendar, 180, 2)");
+
+		Compile<MudDateTime>(
+			"NextVisibleCrescentCompile",
+			ProgVariableTypes.MudDateTime,
+			[
+				Tuple.Create(ProgVariableTypes.Zone, "zone"),
+				Tuple.Create(ProgVariableTypes.Calendar, "calendar")
+			],
+			"return NextVisibleCrescent(@zone, 1, 2, @calendar, 2)");
+	}
+
 	private static FutureProg Compile<T>(string name, ProgVariableTypes returnType,
 		IEnumerable<Tuple<ProgVariableTypes, string>> parameters, string functionText)
 	{

--- a/MudSharpCore Unit Tests/MudDateTimeTests.cs
+++ b/MudSharpCore Unit Tests/MudDateTimeTests.cs
@@ -181,6 +181,177 @@ public class MudDateTimeTests
         Assert.IsFalse(calendar.BuildingCommand(actor.Object, new StringStack("preview 34")));
     }
 
+    [TestMethod]
+    public void CalendarBuilder_CanEditAstronomicalMetadata()
+    {
+        var actor = CreateBuilder();
+        var calendar = new Calendar(XElement.Parse(_testCalendar.SaveToXml().ToString()), _gameworld) { Id = 525 };
+        calendar.FeedClock = _testClock;
+        calendar.SetDate("27/jun/34");
+
+        Assert.IsTrue(calendar.BuildingCommand(actor.Object, new StringStack("authority 10 20 0 0")));
+        Assert.IsNotNull(calendar.AuthorityLocation);
+
+        Assert.IsTrue(calendar.BuildingCommand(actor.Object, new StringStack("dayboundary fixed 6:00:00")));
+        Assert.AreEqual(CalendarDayBoundaryType.FixedClockTime, calendar.DayBoundary);
+
+        Assert.IsTrue(calendar.BuildingCommand(actor.Object, new StringStack("algorithm tabular-lunar")));
+        Assert.AreEqual(CalendarAlgorithmType.TabularLunar, calendar.AlgorithmType);
+        Assert.IsTrue(calendar.Show(actor.Object).Contains("MudInstant"));
+        Assert.IsTrue(calendar.Show(actor.Object).Contains("Algorithm"));
+    }
+
+    [TestMethod]
+    public void MudInstant_RoundTripsStorageOrderingAndLegacyBackfill()
+    {
+        _testCalendar.SetDate("27/jun/34");
+        _testClock.SetTime(MudTime.CreatePrimaryTime(30, 59, 23, _utcTimezone, _testClock));
+        var dateTime = new MudDateTime(_testCalendar.CurrentDate, _testClock.CurrentTime, _utcTimezone);
+
+        var instant = MudInstant.FromMudDateTime(dateTime);
+
+        Assert.IsTrue(MudInstant.TryParse(instant.GetStorageString(), out var parsed));
+        Assert.AreEqual(instant, parsed);
+        Assert.AreEqual(_testCalendar.Id, parsed.SourceCalendarId);
+        Assert.AreEqual(_testClock.Id, parsed.SourceClockId);
+        Assert.IsTrue(MudInstant.TryParse($"mudinstant:v1:{instant.Ticks}", out var legacyParsed));
+        Assert.AreEqual(0, legacyParsed.SourceCalendarId);
+        Assert.IsTrue(new MudInstant(instant.Epoch, instant.Ticks + 1) > instant);
+        Assert.AreEqual(instant, MudInstant.FromLegacyState(_testCalendar, _testClock));
+
+        var roundTrip = parsed.ToMudDateTime(_testCalendar, _testClock, _utcTimezone);
+
+        Assert.AreEqual(dateTime.Date.GetDateString(), roundTrip.Date.GetDateString());
+        Assert.AreEqual(dateTime.Time.Hours, roundTrip.Time.Hours);
+        Assert.AreEqual(dateTime.Time.Minutes, roundTrip.Time.Minutes);
+        Assert.AreEqual(dateTime.Time.Seconds, roundTrip.Time.Seconds);
+    }
+
+    [TestMethod]
+    public void MudInstant_ConvertsAcrossSourceCalendarContext()
+    {
+        All<IClock> clocks = new();
+        All<ICalendar> calendars = new();
+        Mock<IFuturemud> mock = new();
+        mock.SetupGet(x => x.Clocks).Returns(clocks);
+        mock.SetupGet(x => x.Calendars).Returns(calendars);
+        Mock<ISaveManager> saveManager = new();
+        saveManager.Setup(x => x.Add(It.IsAny<ISaveable>()));
+        mock.SetupGet(x => x.SaveManager).Returns(saveManager.Object);
+
+        var clock = CreateTestClock(mock.Object, 904, out var utc);
+        clocks.Add(clock);
+        var months = string.Join("", Enumerable.Range(1, 12).Select(x => MonthXml($"month{x}", x, 30)));
+        var source = new Calendar(XElement.Parse(BuildCalendarXml(string.Empty, months)), mock.Object) { Id = 901 };
+        source.FeedClock = clock;
+        source.SetDate("10/month1/1200");
+        calendars.Add(source);
+
+        var target = new Calendar(XElement.Parse(BuildCalendarXml(string.Empty, months)), mock.Object) { Id = 902 };
+        target.FeedClock = clock;
+        target.SetDate("5/month5/1300");
+        calendars.Add(target);
+
+        clock.SetTime(MudTime.CreatePrimaryTime(0, 30, 12, utc, clock));
+        var instant = MudInstant.FromMudDateTime(new MudDateTime(source.CurrentDate, clock.CurrentTime, utc));
+        var converted = instant.ToMudDateTime(target, clock, utc);
+
+        Assert.AreEqual(source.Id, instant.SourceCalendarId);
+        Assert.AreEqual(target.CurrentDate.GetDateString(), converted.Date.GetDateString());
+        Assert.AreEqual(12, converted.Time.Hours);
+        Assert.AreEqual(30, converted.Time.Minutes);
+    }
+
+    [TestMethod]
+    public void Calendar_FixedDayBoundaryAdvancesOnBoundaryInsteadOfMidnight()
+    {
+        All<IClock> clocks = new();
+        All<ICalendar> calendars = new();
+        Mock<IFuturemud> mock = new();
+        mock.SetupGet(x => x.Clocks).Returns(clocks);
+        mock.SetupGet(x => x.Calendars).Returns(calendars);
+        Mock<ISaveManager> saveManager = new();
+        saveManager.Setup(x => x.Add(It.IsAny<ISaveable>()));
+        mock.SetupGet(x => x.SaveManager).Returns(saveManager.Object);
+
+        var clock = CreateTestClock(mock.Object, 905, out var utc);
+        clocks.Add(clock);
+        var months = string.Join("", Enumerable.Range(1, 12).Select(x => MonthXml($"month{x}", x, 30)));
+        var calendar = new Calendar(XElement.Parse(BuildCalendarXml(string.Empty, months,
+            @"<dayboundary type=""FixedClockTime"" fixedTime=""6:0:0"" />")), mock.Object)
+        {
+            Id = 903
+        };
+        calendar.FeedClock = clock;
+        calendar.SetDate("1/month1/1200");
+        calendars.Add(calendar);
+        clock.SetTime(MudTime.CreatePrimaryTime(0, 59, 23, utc, clock));
+
+        clock.CurrentTime.AddSeconds(60);
+
+        Assert.AreEqual("1/month1/1200", $"{calendar.CurrentDate.Day}/{calendar.CurrentDate.Month.Alias}/{calendar.CurrentDate.Year}");
+        var physicalAfterMidnight = calendar.CurrentInstant.ToMudDateTime(calendar, clock, utc);
+        Assert.AreEqual("2/month1/1200", $"{physicalAfterMidnight.Date.Day}/{physicalAfterMidnight.Date.Month.Alias}/{physicalAfterMidnight.Date.Year}");
+
+        clock.CurrentTime.AddSeconds(6 * 60 * 60);
+
+        Assert.AreEqual("2/month1/1200", $"{calendar.CurrentDate.Day}/{calendar.CurrentDate.Month.Alias}/{calendar.CurrentDate.Year}");
+    }
+
+    [TestMethod]
+    public void Calendar_LegacyXmlWithoutAlgorithm_LoadsFixedMonthBehaviour()
+    {
+        Assert.AreEqual(CalendarAlgorithmType.FixedMonths, _testCalendar.AlgorithmType);
+        Assert.AreEqual(CalendarDayBoundaryType.ClockMidnight, _testCalendar.DayBoundary);
+        Assert.AreEqual(14, _testCalendar.CreateYear(34).Months.Count);
+        Assert.AreEqual(365, _testCalendar.CountDaysInYear(34));
+    }
+
+    [TestMethod]
+    public void CalendarAlgorithms_GenerateCalculatedAndAstronomicalLeapMonths()
+    {
+        var hebrew = new Calendar(XElement.Parse(BuildCalendarXml(
+            @"<algorithm type=""calculated-hebrew"" />",
+            string.Join("", new[]
+            {
+                MonthXml("nisan", 1, 30),
+                MonthXml("iyyar", 2, 29),
+                MonthXml("sivan", 3, 30),
+                MonthXml("tammuz", 4, 29),
+                MonthXml("av", 5, 30),
+                MonthXml("elul", 6, 29),
+                MonthXml("tishrei", 7, 30),
+                MonthXml("heshvan", 8, 29),
+                MonthXml("kislev", 9, 30),
+                MonthXml("tevet", 10, 29),
+                MonthXml("shevat", 11, 30),
+                MonthXml("adar", 12, 29),
+                MonthXml("adar-i", 13, 30),
+                MonthXml("adar-ii", 14, 29)
+            }),
+            @"<dayboundary type=""SunsetAtAuthorityLocation"" />")), _gameworld);
+        hebrew.FeedClock = _testClock;
+        var hebrewLeapYear = Enumerable.Range(1200, 19).First(CalculatedHebrewCalendarAlgorithm.IsLeapYear);
+        var hebrewYear = hebrew.CreateYear(hebrewLeapYear);
+
+        Assert.AreEqual(CalendarAlgorithmType.CalculatedHebrew, hebrew.AlgorithmType);
+        Assert.AreEqual(CalendarDayBoundaryType.SunsetAtAuthorityLocation, hebrew.DayBoundary);
+        Assert.IsTrue(hebrewYear.Months.Any(x => x.Alias.EqualTo("adar-i")));
+        Assert.IsTrue(hebrewYear.Months.Any(x => x.Alias.EqualTo("adar-ii")));
+
+        var babylonian = new Calendar(XElement.Parse(BuildCalendarXml(
+            @"<algorithm type=""astronomical-lunar"" variant=""babylonian-regulated"" />",
+            string.Join("", Enumerable.Range(1, 12).Select(x => MonthXml($"month{x}", x, x % 2 == 1 ? 30 : 29)))
+            + MonthXml("addaru-ii", 13, 29)
+            + MonthXml("ululu-ii", 14, 29))), _gameworld);
+        babylonian.FeedClock = _testClock;
+        var babylonianLeapYear = Enumerable.Range(1200, 19).First(AstronomicalLunarCalendarAlgorithm.IsMetonicLeapYear);
+        var babylonianYear = babylonian.CreateYear(babylonianLeapYear);
+
+        Assert.AreEqual(CalendarAlgorithmType.AstronomicalLunar, babylonian.AlgorithmType);
+        Assert.IsTrue(babylonianYear.Months.Any(x => x.Alias.EqualTo("addaru-ii") || x.Alias.EqualTo("ululu-ii")));
+    }
+
     private static Mock<ICharacter> CreateBuilder()
     {
         var output = new Mock<IOutputHandler>();
@@ -194,6 +365,54 @@ public class MudDateTimeTests
         actor.SetupGet(x => x.Account).Returns(account.Object);
         actor.SetupGet(x => x.InnerLineFormatLength).Returns(120);
         return actor;
+    }
+
+    private static string BuildCalendarXml(string algorithmXml, string monthsXml, string dayBoundaryXml = @"<dayboundary type=""ClockMidnight"" />")
+    {
+        return $@"<calendar>
+  <alias>test-calendar</alias>
+  <shortname>Test Calendar</shortname>
+  <fullname>Test Calendar</fullname>
+  <description>Test</description>
+  <shortstring>$dd/$mo/$yy</shortstring>
+  <longstring>$dd $mo $yy</longstring>
+  <wordystring>$dd $mo $yy</wordystring>
+  <plane>earth</plane>
+  <feedclock>0</feedclock>
+  <epochyear>1200</epochyear>
+  <weekdayatepoch>0</weekdayatepoch>
+  <ancienterashortstring>BE</ancienterashortstring>
+  <ancienteralongstring>before era</ancienteralongstring>
+  <modernerashortstring>AE</modernerashortstring>
+  <moderneralongstring>after era</moderneralongstring>
+  <weekdays>
+    <weekday>First</weekday>
+    <weekday>Second</weekday>
+    <weekday>Third</weekday>
+    <weekday>Fourth</weekday>
+    <weekday>Fifth</weekday>
+    <weekday>Sixth</weekday>
+    <weekday>Seventh</weekday>
+  </weekdays>
+  <months>{monthsXml}</months>
+  <intercalarymonths />
+  {algorithmXml}
+  {dayBoundaryXml}
+</calendar>";
+    }
+
+    private static string MonthXml(string alias, int order, int days)
+    {
+        return $@"<month><alias>{alias}</alias><shortname>{alias}</shortname><fullname>{alias}</fullname><nominalorder>{order}</nominalorder><normaldays>{days}</normaldays><intercalarydays /><specialdays /><nonweekdays /></month>";
+    }
+
+    private static Clock CreateTestClock(IFuturemud gameworld, long id, out IMudTimeZone utc)
+    {
+        var clock = new Clock(XElement.Parse(@"<Clock>  <Alias>UTC</Alias>  <Description>Universal Time Clock</Description>  <ShortDisplayString>$j:$m:$s $i</ShortDisplayString>  <SuperDisplayString>$j:$m:$s $i $t</SuperDisplayString>  <LongDisplayString>$c $i</LongDisplayString>  <SecondsPerMinute>60</SecondsPerMinute>  <MinutesPerHour>60</MinutesPerHour>  <HoursPerDay>24</HoursPerDay>  <InGameSecondsPerRealSecond>2</InGameSecondsPerRealSecond>  <SecondFixedDigits>2</SecondFixedDigits>  <MinuteFixedDigits>2</MinuteFixedDigits>  <HourFixedDigits>0</HourFixedDigits>  <NoZeroHour>true</NoZeroHour>  <NumberOfHourIntervals>2</NumberOfHourIntervals>  <HourIntervalNames>    <HourIntervalName>a.m</HourIntervalName>    <HourIntervalName>p.m</HourIntervalName>  </HourIntervalNames>  <HourIntervalLongNames>    <HourIntervalLongName>in the morning</HourIntervalLongName>    <HourIntervalLongName>in the afternoon</HourIntervalLongName>  </HourIntervalLongNames>  <CrudeTimeIntervals>    <CrudeTimeInterval text=""night"" Lower=""-2"" Upper=""4""/>    <CrudeTimeInterval text=""morning"" Lower=""4"" Upper=""12""/>    <CrudeTimeInterval text=""afternoon"" Lower=""12"" Upper=""18""/>    <CrudeTimeInterval text=""evening"" Lower=""18"" Upper=""22""/>  </CrudeTimeIntervals></Clock>"), gameworld) { Id = id };
+        utc = new MudTimeZone((int)id + 1, 0, 0, "Universal Time Clock", "UTC", clock);
+        clock.AddTimezone(utc);
+        clock.SetTime(MudTime.CreatePrimaryTime(0, 0, 0, utc, clock));
+        return clock;
     }
 
     [TestMethod]

--- a/MudSharpCore/Celestial/AstronomicalEventService.cs
+++ b/MudSharpCore/Celestial/AstronomicalEventService.cs
@@ -1,0 +1,247 @@
+#nullable enable
+
+using MudSharp.TimeAndDate;
+using MudSharp.Framework;
+using System;
+
+namespace MudSharp.Celestial;
+
+public sealed class AstronomicalEventService : IAstronomicalEventService
+{
+	private const long DefaultStepSeconds = 1800;
+	private const long DefaultMaximumSearchSeconds = 86400L * 800L;
+	private const long RefinementToleranceSeconds = 1;
+
+	public static AstronomicalEventService Instance { get; } = new();
+
+	private AstronomicalEventService()
+	{
+	}
+
+	public bool TryFindNext(AstronomicalEventType eventType, MudInstant reference, int occurrence,
+		ICelestialEphemeris primary, GeographicCoordinate observer, out MudInstant instant, out string error,
+		double targetLongitude = 0.0, ICelestialEphemeris? secondary = null)
+	{
+		instant = MudInstant.Never;
+		error = string.Empty;
+
+		if (reference.IsNever)
+		{
+			error = "The reference instant was Never.";
+			return false;
+		}
+
+		if (occurrence < 1)
+		{
+			error = "The occurrence must be a positive number.";
+			return false;
+		}
+
+		if (primary is null)
+		{
+			error = "No primary celestial ephemeris was supplied.";
+			return false;
+		}
+
+		if (observer is null)
+		{
+			error = "No observer location was supplied.";
+			return false;
+		}
+
+		var searchFrom = reference;
+		for (var i = 0; i < occurrence; i++)
+		{
+			if (!TryFindSingle(eventType, searchFrom, primary, observer, secondary, targetLongitude, out instant, out error))
+			{
+				return false;
+			}
+
+			searchFrom = AddSeconds(instant, RefinementToleranceSeconds);
+		}
+
+		return true;
+	}
+
+	private static bool TryFindSingle(AstronomicalEventType eventType, MudInstant reference,
+		ICelestialEphemeris primary, GeographicCoordinate observer, ICelestialEphemeris? secondary,
+		double targetLongitude, out MudInstant instant, out string error)
+	{
+		if (eventType == AstronomicalEventType.VisibleCrescent)
+		{
+			return TryFindVisibleCrescent(reference, primary, secondary, observer, out instant, out error);
+		}
+
+		Func<MudInstant, double> value;
+		Func<double, double, bool> isCrossing;
+		switch (eventType)
+		{
+			case AstronomicalEventType.Sunrise:
+				value = candidate => primary.ApparentAltitudeAt(candidate, observer);
+				isCrossing = (former, current) => former < 0.0 && current >= 0.0;
+				break;
+			case AstronomicalEventType.Sunset:
+				value = candidate => primary.ApparentAltitudeAt(candidate, observer);
+				isCrossing = (former, current) => former > 0.0 && current <= 0.0;
+				break;
+			case AstronomicalEventType.SolarLongitude:
+				if (primary is not ISolarEphemeris solar)
+				{
+					instant = MudInstant.Never;
+					error = "The primary celestial does not expose a solar ephemeris.";
+					return false;
+				}
+
+				value = candidate => SignedAngleDifference(solar.EclipticLongitudeAt(candidate), targetLongitude);
+				isCrossing = CrossesZero;
+				break;
+			case AstronomicalEventType.LunarConjunction:
+			case AstronomicalEventType.NewMoon:
+				if (primary is not ILunarEphemeris newMoon)
+				{
+					instant = MudInstant.Never;
+					error = "The primary celestial does not expose a lunar ephemeris.";
+					return false;
+				}
+
+				value = candidate => SignedAngleDifference(newMoon.PhaseAngleAt(candidate), Math.PI);
+				isCrossing = CrossesZero;
+				break;
+			case AstronomicalEventType.FullMoon:
+				if (primary is not ILunarEphemeris fullMoon)
+				{
+					instant = MudInstant.Never;
+					error = "The primary celestial does not expose a lunar ephemeris.";
+					return false;
+				}
+
+				value = candidate => SignedAngleDifference(fullMoon.PhaseAngleAt(candidate), 0.0);
+				isCrossing = CrossesZero;
+				break;
+			default:
+				instant = MudInstant.Never;
+				error = "That astronomical event type is not supported.";
+				return false;
+		}
+
+		return TryBracketAndRefine(reference, value, isCrossing, out instant, out error);
+	}
+
+	private static bool TryBracketAndRefine(MudInstant reference, Func<MudInstant, double> value,
+		Func<double, double, bool> isCrossing, out MudInstant instant, out string error)
+	{
+		instant = MudInstant.Never;
+		error = string.Empty;
+		var lower = AddSeconds(reference, 1);
+		var lowerValue = value(lower);
+
+		for (long elapsed = DefaultStepSeconds; elapsed <= DefaultMaximumSearchSeconds; elapsed += DefaultStepSeconds)
+		{
+			var upper = AddSeconds(reference, elapsed);
+			var upperValue = value(upper);
+			if (Math.Abs(upperValue) < 1.0E-10 || isCrossing(lowerValue, upperValue))
+			{
+				instant = Refine(lower, upper, value);
+				return true;
+			}
+
+			lower = upper;
+			lowerValue = upperValue;
+		}
+
+		error = "No matching astronomical event was found inside the bounded search window.";
+		return false;
+	}
+
+	private static bool TryFindVisibleCrescent(MudInstant reference, ICelestialEphemeris primary,
+		ICelestialEphemeris? secondary, GeographicCoordinate observer, out MudInstant instant, out string error)
+	{
+		instant = MudInstant.Never;
+		if (primary is not ISolarEphemeris sun || secondary is not ILunarEphemeris moon)
+		{
+			error = "Visible crescent search requires a solar ephemeris and a lunar ephemeris.";
+			return false;
+		}
+
+		var searchFrom = reference;
+		for (var i = 0; i < 90; i++)
+		{
+			if (!TryFindSingle(AstronomicalEventType.Sunset, searchFrom, sun, observer, null, 0.0, out var sunset, out error))
+			{
+				return false;
+			}
+
+			var moonAltitude = moon.ApparentAltitudeAt(sunset, observer);
+			var elongation = AngularSeparation(moon, sun, sunset);
+			if (moonAltitude >= 5.0.DegreesToRadians() && elongation >= 10.0.DegreesToRadians())
+			{
+				instant = sunset;
+				error = string.Empty;
+				return true;
+			}
+
+			searchFrom = AddSeconds(sunset, 12 * 60 * 60);
+		}
+
+		error = "No deterministic visible crescent approximation was found inside the bounded search window.";
+		return false;
+	}
+
+	private static MudInstant Refine(MudInstant lower, MudInstant upper, Func<MudInstant, double> value)
+	{
+		var lowerValue = value(lower);
+		while (upper.Ticks - lower.Ticks > RefinementToleranceSeconds)
+		{
+			var middle = lower.WithTicks(lower.Ticks + (upper.Ticks - lower.Ticks) / 2);
+			var middleValue = value(middle);
+			if (CrossesZero(lowerValue, middleValue) || Math.Abs(middleValue) < 1.0E-10)
+			{
+				upper = middle;
+			}
+			else
+			{
+				lower = middle;
+				lowerValue = middleValue;
+			}
+		}
+
+		return upper;
+	}
+
+	private static bool CrossesZero(double former, double current)
+	{
+		return former == 0.0 || current == 0.0 || Math.Sign(former) != Math.Sign(current);
+	}
+
+	private static double SignedAngleDifference(double angle, double target)
+	{
+		var difference = (angle - target) % (2 * Math.PI);
+		if (difference <= -Math.PI)
+		{
+			difference += 2 * Math.PI;
+		}
+		else if (difference > Math.PI)
+		{
+			difference -= 2 * Math.PI;
+		}
+
+		return difference;
+	}
+
+	private static double AngularSeparation(ICelestialEphemeris first, ICelestialEphemeris second, MudInstant instant)
+	{
+		var firstRightAscension = first.RightAscensionAt(instant);
+		var firstDeclination = first.DeclinationAt(instant);
+		var secondRightAscension = second.RightAscensionAt(instant);
+		var secondDeclination = second.DeclinationAt(instant);
+		var cosine = Math.Sin(firstDeclination) * Math.Sin(secondDeclination) +
+		             Math.Cos(firstDeclination) * Math.Cos(secondDeclination) *
+		             Math.Cos(firstRightAscension - secondRightAscension);
+		return Math.Acos(Math.Clamp(cosine, -1.0, 1.0));
+	}
+
+	private static MudInstant AddSeconds(MudInstant instant, long seconds)
+	{
+		return instant.AddSeconds(seconds);
+	}
+}

--- a/MudSharpCore/Celestial/NewSun.cs
+++ b/MudSharpCore/Celestial/NewSun.cs
@@ -24,7 +24,7 @@ using System.Xml.Linq;
 
 namespace MudSharp.Celestial;
 
-public class NewSun : PerceivedItem, ICelestialObject
+public class NewSun : PerceivedItem, ICelestialObject, ISolarEphemeris
 {
     public override string FrameworkItemType => "Celestial";
 
@@ -288,6 +288,17 @@ public class NewSun : PerceivedItem, ICelestialObject
     public double CurrentDayNumber => (Calendar.CurrentDate - EpochDate).Days + Clock.CurrentTime.TimeFraction +
                                       DayNumberAtEpoch + CurrentDayNumberOffset;
 
+    public double DayNumberAt(MudInstant instant)
+    {
+        if (instant.IsNever)
+        {
+            return CurrentDayNumber;
+        }
+
+        var dateTime = instant.ToMudDateTime(Calendar, Clock, Clock.PrimaryTimezone);
+        return (dateTime.Date - EpochDate).Days + dateTime.Time.TimeFraction + DayNumberAtEpoch + CurrentDayNumberOffset;
+    }
+
     public double CelestialDaysPerYear { get; set; }
 
     public event CelestialUpdateHandler MinuteUpdateEvent;
@@ -295,6 +306,42 @@ public class NewSun : PerceivedItem, ICelestialObject
     public double CurrentElevationAngle(GeographicCoordinate geography)
     {
         return Altitude(CurrentDayNumber, geography);
+    }
+
+    public double EclipticLongitudeAt(MudInstant instant)
+    {
+        return EclipticLongitudeOfSun(DayNumberAt(instant));
+    }
+
+    public double RightAscensionAt(MudInstant instant)
+    {
+        return RightAscension(DayNumberAt(instant));
+    }
+
+    public double DeclinationAt(MudInstant instant)
+    {
+        return Declension(DayNumberAt(instant));
+    }
+
+    public double ApparentAltitudeAt(MudInstant instant, GeographicCoordinate observer)
+    {
+        return Altitude(DayNumberAt(instant), observer);
+    }
+
+    public double ApparentAzimuthAt(MudInstant instant, GeographicCoordinate observer)
+    {
+        return Azimuth(DayNumberAt(instant), observer);
+    }
+
+    public double IlluminationAt(MudInstant instant, GeographicCoordinate observer)
+    {
+        var angle = ApparentAltitudeAt(instant, observer);
+        if (double.IsNaN(angle))
+        {
+            return PeakIllumination;
+        }
+
+        return LightLevelParameterE1(angle) + LightLevelParameterE2(angle);
     }
 
     public double CurrentAzimuthAngle(GeographicCoordinate geography, double elevationAngle)

--- a/MudSharpCore/Celestial/PlanetaryMoon.cs
+++ b/MudSharpCore/Celestial/PlanetaryMoon.cs
@@ -18,7 +18,7 @@ namespace MudSharp.Celestial;
 ///     mirrors the approach used in <see cref="NewSun"/> where calculations are based on the
 ///     current day number rather than updating each minute.
 /// </summary>
-public class PlanetaryMoon : PerceivedItem, ICelestialObject
+public class PlanetaryMoon : PerceivedItem, ICelestialObject, ILunarEphemeris
 {
     public override string FrameworkItemType => "Celestial";
 
@@ -141,6 +141,17 @@ public class PlanetaryMoon : PerceivedItem, ICelestialObject
     public double CurrentDayNumber => (Calendar.CurrentDate - EpochDate).Days + Clock.CurrentTime.TimeFraction +
                                       DayNumberAtEpoch;
 
+    public double DayNumberAt(MudInstant instant)
+    {
+        if (instant.IsNever)
+        {
+            return CurrentDayNumber;
+        }
+
+        var dateTime = instant.ToMudDateTime(Calendar, Clock, Clock.PrimaryTimezone);
+        return (dateTime.Date - EpochDate).Days + dateTime.Time.TimeFraction + DayNumberAtEpoch;
+    }
+
     public double CurrentCelestialDay =>
         ((Calendar.CurrentDate - EpochDate).Days + Clock.CurrentTime.TimeFraction).Modulus(CelestialDaysPerYear);
 
@@ -218,6 +229,18 @@ public class PlanetaryMoon : PerceivedItem, ICelestialObject
         return (ra, dec);
     }
 
+    private double EclipticLongitude(double dayNumber)
+    {
+        double v = TrueAnomaly(dayNumber);
+        double wv = v + ArgumentOfPeriapsis;
+
+        double x = Math.Cos(LongitudeOfAscendingNode) * Math.Cos(wv) -
+                   Math.Sin(LongitudeOfAscendingNode) * Math.Sin(wv) * Math.Cos(OrbitalInclination);
+        double y = Math.Sin(LongitudeOfAscendingNode) * Math.Cos(wv) +
+                   Math.Cos(LongitudeOfAscendingNode) * Math.Sin(wv) * Math.Cos(OrbitalInclination);
+        return Math.Atan2(y, x).Modulus(2 * Math.PI);
+    }
+
     public (double X, double Y, double Z) PositionVector(double dayNumber)
     {
         double radius = OrbitalRadius(dayNumber);
@@ -261,6 +284,44 @@ public class PlanetaryMoon : PerceivedItem, ICelestialObject
     public double CurrentElevationAngle(GeographicCoordinate geography)
     {
         return ElevationAngle(CurrentDayNumber, geography);
+    }
+
+    public double EclipticLongitudeAt(MudInstant instant)
+    {
+        return EclipticLongitude(DayNumberAt(instant));
+    }
+
+    public double RightAscensionAt(MudInstant instant)
+    {
+        var (rightAscension, _) = EquatorialCoordinates(DayNumberAt(instant));
+        return rightAscension;
+    }
+
+    public double DeclinationAt(MudInstant instant)
+    {
+        var (_, declination) = EquatorialCoordinates(DayNumberAt(instant));
+        return declination;
+    }
+
+    public double ApparentAltitudeAt(MudInstant instant, GeographicCoordinate observer)
+    {
+        return ElevationAngle(DayNumberAt(instant), observer);
+    }
+
+    public double ApparentAzimuthAt(MudInstant instant, GeographicCoordinate observer)
+    {
+        return AzimuthAngle(DayNumberAt(instant), observer);
+    }
+
+    public double IlluminationAt(MudInstant instant, GeographicCoordinate observer)
+    {
+        return PeakIllumination * (1 + Math.Cos(PhaseAngleAt(instant))) / 2.0;
+    }
+
+    public double PhaseAngleAt(MudInstant instant)
+    {
+        var cycleDay = (DayNumberAt(instant) - DayNumberAtEpoch - FullMoonReferenceDay).Modulus(CelestialDaysPerYear);
+        return 2 * Math.PI * (cycleDay / CelestialDaysPerYear);
     }
 
     public double CurrentAzimuthAngle(GeographicCoordinate geography, double elevationAngle)

--- a/MudSharpCore/Commands/Helpers/EditableItemHelperTime.cs
+++ b/MudSharpCore/Commands/Helpers/EditableItemHelperTime.cs
@@ -397,6 +397,7 @@ public partial class EditableItemHelper
             "Name",
             "Clock",
             "Current Date",
+            "Algorithm",
             "Months",
             "Weekdays"
         },
@@ -408,6 +409,7 @@ public partial class EditableItemHelper
                                                              calendar.Name,
                                                              calendar.FeedClock?.Alias ?? string.Empty,
                                                              calendar.CurrentDate?.GetDateString() ?? string.Empty,
+                                                             calendar.Algorithm.DisplayName,
                                                              calendar.Months.Count.ToString("N0", character),
                                                              calendar.Weekdays.Count.ToString("N0", character)
                                                          },

--- a/MudSharpCore/Commands/Modules/ShowModule.cs
+++ b/MudSharpCore/Commands/Modules/ShowModule.cs
@@ -1290,7 +1290,8 @@ public class ShowModule : Module<ICharacter>
                 calendar.Alias,
                 calendar.FullName,
                 calendar.FeedClock.Alias,
-                calendar.CurrentDate.Display(CalendarDisplayMode.Short)
+                calendar.CurrentDate.Display(CalendarDisplayMode.Short),
+                calendar.Algorithm.DisplayName
             },
             new List<string>
             {
@@ -1298,7 +1299,8 @@ public class ShowModule : Module<ICharacter>
                 "Alias",
                 "Name",
                 "Clock",
-                "Current Date"
+                "Current Date",
+                "Algorithm"
             },
             actor,
             Telnet.Green

--- a/MudSharpCore/Commands/Modules/TimeModule.cs
+++ b/MudSharpCore/Commands/Modules/TimeModule.cs
@@ -8,6 +8,7 @@ using MudSharp.Framework;
 using MudSharp.GameItems.Interfaces;
 using MudSharp.PerceptionEngine;
 using MudSharp.RPG.Checks;
+using MudSharp.TimeAndDate;
 using MudSharp.TimeAndDate.Date;
 using MudSharp.TimeAndDate.Time;
 using System;
@@ -32,6 +33,22 @@ internal class TimeModule : Module<ICharacter>
     [RequiredCharacterState(CharacterState.Conscious)]
     protected static void Time(ICharacter actor, string input)
     {
+        var command = new StringStack(input.RemoveFirstWord());
+        if (!command.IsFinished && actor.IsAdministrator())
+        {
+            switch (command.PopForSwitch())
+            {
+                case "event":
+                case "events":
+                    TimeEvent(actor, command);
+                    return;
+                case "instant":
+                case "mudinstant":
+                    TimeInstant(actor);
+                    return;
+            }
+        }
+
         StringBuilder sb = new();
         sb.AppendLine("You know the following things about time:");
         sb.AppendLine();
@@ -50,7 +67,11 @@ internal class TimeModule : Module<ICharacter>
                 string description = info.Origin.Describe(info).Fullstop().Wrap(actor.InnerLineFormatLength, "\t");
                 if (actor.IsAdministrator())
                 {
-                    description += $" (Asc: {$"{info.LastAscensionAngle.RadiansToDegrees().ToString("N3", actor)}°".ColourValue()} Azi: {$"{info.LastAzimuthAngle.RadiansToDegrees().ToString("N3", actor)}°".ColourValue()} DN: {info.Origin.CurrentCelestialDay.ToString("N2", actor).ColourValue()})";
+                    var ephemeris = info.Origin is ISolarEphemeris ? "solar" :
+                        info.Origin is ILunarEphemeris ? "lunar" :
+                        info.Origin is ICelestialEphemeris ? "generic" :
+                        "current-only";
+                    description += $" (Asc: {$"{info.LastAscensionAngle.RadiansToDegrees().ToString("N3", actor)}°".ColourValue()} Azi: {$"{info.LastAzimuthAngle.RadiansToDegrees().ToString("N3", actor)}°".ColourValue()} DN: {info.Origin.CurrentCelestialDay.ToString("N2", actor).ColourValue()} Ephem: {ephemeris.ColourValue()})";
                 }
 
                 sb.AppendLine(description);
@@ -98,6 +119,112 @@ internal class TimeModule : Module<ICharacter>
         actor.OutputHandler.Send(sb.ToString());
     }
 
+    private static void TimeInstant(ICharacter actor)
+    {
+        var sb = new StringBuilder();
+        foreach (var calendar in actor.Location.Calendars)
+        {
+            sb.AppendLine($"{calendar.Name.ColourName()}: {calendar.CurrentInstant.GetStorageString().ColourValue()}");
+        }
+
+        actor.OutputHandler.Send(sb.ToString());
+    }
+
+    private static void TimeEvent(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which event do you want to preview? Options are sunrise, sunset, solarlongitude, newmoon, fullmoon and visiblecrescent.");
+            return;
+        }
+
+        var eventText = command.PopForSwitch();
+        var eventType = eventText switch
+        {
+            "sunrise" => AstronomicalEventType.Sunrise,
+            "sunset" => AstronomicalEventType.Sunset,
+            "solarlongitude" or "longitude" => AstronomicalEventType.SolarLongitude,
+            "newmoon" or "conjunction" => AstronomicalEventType.NewMoon,
+            "fullmoon" => AstronomicalEventType.FullMoon,
+            "visiblecrescent" or "crescent" => AstronomicalEventType.VisibleCrescent,
+            _ => (AstronomicalEventType?)null
+        };
+        if (eventType is null)
+        {
+            actor.OutputHandler.Send("That is not a valid astronomical event type.");
+            return;
+        }
+
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which celestial object should be used for the event search?");
+            return;
+        }
+
+        var primary = actor.Gameworld.CelestialObjects.GetByIdOrName(command.PopSpeech()) as ICelestialEphemeris;
+        if (primary is null)
+        {
+            actor.OutputHandler.Send("There is no such celestial object with arbitrary-instant ephemeris support.");
+            return;
+        }
+
+        ICelestialEphemeris secondary = null;
+        if (eventType == AstronomicalEventType.VisibleCrescent)
+        {
+            if (command.IsFinished)
+            {
+                actor.OutputHandler.Send("Which moon should be used for the visible crescent search?");
+                return;
+            }
+
+            secondary = actor.Gameworld.CelestialObjects.GetByIdOrName(command.PopSpeech()) as ICelestialEphemeris;
+            if (secondary is not ILunarEphemeris)
+            {
+                actor.OutputHandler.Send("The second celestial must be a moon with lunar ephemeris support.");
+                return;
+            }
+        }
+
+        var targetLongitude = 0.0;
+        if (eventType == AstronomicalEventType.SolarLongitude)
+        {
+            if (command.IsFinished || !double.TryParse(command.PopSpeech(), out var degrees))
+            {
+                actor.OutputHandler.Send("Solar longitude events require a target longitude in degrees.");
+                return;
+            }
+
+            targetLongitude = degrees.DegreesToRadians();
+        }
+
+        var occurrence = 1;
+        if (!command.IsFinished && int.TryParse(command.PeekSpeech(), out var parsedOccurrence))
+        {
+            occurrence = parsedOccurrence;
+            command.PopSpeech();
+        }
+
+        var calendar = actor.Location.Calendars.FirstOrDefault();
+        if (calendar is null)
+        {
+            actor.OutputHandler.Send("This location does not have a calendar to display the result with.");
+            return;
+        }
+
+        var reference = calendar.CurrentInstant;
+        var observer = actor.Location.Zone.Geography;
+        if (!AstronomicalEventService.Instance.TryFindNext(eventType.Value, reference, occurrence, primary, observer,
+                out var instant, out var error, targetLongitude, secondary))
+        {
+            actor.OutputHandler.Send(error);
+            return;
+        }
+
+        var timezone = actor.Location.TimeZone(calendar.FeedClock);
+        var dateTime = instant.ToMudDateTime(calendar, calendar.FeedClock, timezone);
+        actor.OutputHandler.Send($"The {occurrence.ToOrdinal().ColourValue()} next {eventText.ColourName()} is at {dateTime.ToString(CalendarDisplayMode.Long, TimeDisplayTypes.Long).ColourValue()} ({instant.GetStorageString().ColourValue()}).");
+    }
+
     #region Calendars
     public const string CalendarAdminHelpText = @"This command is used to create and edit in-game calendars.
 
@@ -131,6 +258,12 @@ The syntax for this command is as follows:
 
         sb.AppendLine($"Ancient Epoch: {calendar.AncientEraLongString.Colour(Telnet.Green)}");
         sb.AppendLine($"Modern Epoch: {calendar.ModernEraLongString.Colour(Telnet.Green)}");
+        sb.AppendLine($"Algorithm: {calendar.Algorithm.DisplayName.Colour(Telnet.Green)} - {calendar.Algorithm.Summary}");
+        sb.AppendLine($"Day Boundary: {calendar.DayBoundary.DescribeEnum().Colour(Telnet.Green)}");
+        if (actor.IsAdministrator())
+        {
+            sb.AppendLine($"MudInstant: {calendar.CurrentInstant.GetStorageString().Colour(Telnet.Green)}");
+        }
         sb.AppendLine($"Weekdays: {calendar.Weekdays.Select(x => x.Colour(Telnet.Green)).ListToString()}");
         sb.AppendLine(
             $"Days in Normal Year: {(calendar.Months.Sum(x => x.NormalDays) + calendar.Intercalaries.Where(x => x.Rule.DivisibleBy == 1).Sum(x => x.Month.NormalDays)).ToString("N0", actor).Colour(Telnet.Green)}");

--- a/MudSharpCore/FutureProg/Functions/Celestials/AstronomicalEventFunctions.cs
+++ b/MudSharpCore/FutureProg/Functions/Celestials/AstronomicalEventFunctions.cs
@@ -1,0 +1,205 @@
+#nullable enable
+
+using MudSharp.Celestial;
+using MudSharp.Construction;
+using MudSharp.Framework;
+using MudSharp.TimeAndDate;
+using MudSharp.TimeAndDate.Date;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MudSharp.FutureProg.Functions.Celestials;
+
+internal sealed class AstronomicalEventFunction : BuiltInFunction
+{
+	private readonly AstronomicalEventType _eventType;
+	private readonly IFuturemud _gameworld;
+
+	public AstronomicalEventFunction(IList<IFunction> parameters, AstronomicalEventType eventType, IFuturemud gameworld)
+		: base(parameters)
+	{
+		_eventType = eventType;
+		_gameworld = gameworld;
+	}
+
+	public override ProgVariableTypes ReturnType => ProgVariableTypes.MudDateTime;
+
+	public override string ErrorMessage => ParameterFunctions.First().ErrorMessage;
+
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		if (base.Execute(variables) == StatementResult.Error)
+		{
+			return StatementResult.Error;
+		}
+
+		var zone = ResolveZone(ParameterFunctions[0].Result?.GetObject);
+		if (zone is null)
+		{
+			Result = MudDateTime.Never;
+			return StatementResult.Normal;
+		}
+
+		var calendarIndex = _eventType == AstronomicalEventType.VisibleCrescent ? 3 : 2;
+		if (ParameterFunctions[calendarIndex].Result?.GetObject is not ICalendar calendar || calendar.FeedClock is null)
+		{
+			Result = MudDateTime.Never;
+			return StatementResult.Normal;
+		}
+
+		var primaryId = Convert.ToInt64(ParameterFunctions[1].Result?.GetObject ?? 0L);
+		var primary = zone.Celestials.FirstOrDefault(x => x.Id == primaryId) as ICelestialEphemeris ??
+		              _gameworld.CelestialObjects.Get(primaryId) as ICelestialEphemeris;
+		if (primary is null)
+		{
+			Result = MudDateTime.Never;
+			return StatementResult.Normal;
+		}
+
+		var occurrenceIndex = 3;
+		var targetLongitude = 0.0;
+		ICelestialEphemeris? secondary = null;
+		if (_eventType == AstronomicalEventType.SolarLongitude)
+		{
+			targetLongitude = Convert.ToDouble(ParameterFunctions[3].Result?.GetObject ?? 0.0).DegreesToRadians();
+			occurrenceIndex = 4;
+		}
+		else if (_eventType == AstronomicalEventType.VisibleCrescent)
+		{
+			var secondaryId = Convert.ToInt64(ParameterFunctions[2].Result?.GetObject ?? 0L);
+			secondary = zone.Celestials.FirstOrDefault(x => x.Id == secondaryId) as ICelestialEphemeris ??
+			            _gameworld.CelestialObjects.Get(secondaryId) as ICelestialEphemeris;
+			occurrenceIndex = 4;
+			if (secondary is null)
+			{
+				Result = MudDateTime.Never;
+				return StatementResult.Normal;
+			}
+		}
+
+		var occurrence = ParameterFunctions.Count > occurrenceIndex
+			? Convert.ToInt32(ParameterFunctions[occurrenceIndex].Result?.GetObject ?? 1)
+			: 1;
+
+		if (!AstronomicalEventService.Instance.TryFindNext(_eventType, calendar.CurrentInstant, occurrence, primary,
+			    zone.Geography, out var instant, out _, targetLongitude, secondary))
+		{
+			Result = MudDateTime.Never;
+			return StatementResult.Normal;
+		}
+
+		Result = instant.ToMudDateTime(calendar, calendar.FeedClock, zone.TimeZone(calendar.FeedClock));
+		return StatementResult.Normal;
+	}
+
+	private static IZone? ResolveZone(object? value)
+	{
+		return value switch
+		{
+			IZone zone => zone,
+			ICell cell => cell.Zone,
+			_ => null
+		};
+	}
+
+	public static void RegisterFunctionCompiler()
+	{
+		RegisterSolar("nextsunrise", AstronomicalEventType.Sunrise,
+			"Returns the next sunrise for a solar celestial at the supplied room or zone. The optional occurrence parameter returns the nth next sunrise. Returns Never if no event is found.");
+		RegisterSolar("nextsunset", AstronomicalEventType.Sunset,
+			"Returns the next sunset for a solar celestial at the supplied room or zone. The optional occurrence parameter returns the nth next sunset. Returns Never if no event is found.");
+		RegisterSolarLongitude();
+		RegisterLunar("nextnewmoon", AstronomicalEventType.NewMoon,
+			"Returns the next deterministic lunar conjunction/new moon for a lunar celestial. The optional occurrence parameter returns the nth next occurrence. Returns Never if no event is found.");
+		RegisterLunar("nextfullmoon", AstronomicalEventType.FullMoon,
+			"Returns the next deterministic full moon for a lunar celestial. The optional occurrence parameter returns the nth next occurrence. Returns Never if no event is found.");
+		RegisterVisibleCrescent();
+	}
+
+	private static void RegisterSolar(string name, AstronomicalEventType type, string description)
+	{
+		RegisterLocationAndZone(name, type,
+			[ProgVariableTypes.Number, ProgVariableTypes.Calendar],
+			["celestialId", "calendar"],
+			["The ID of the solar celestial.", "The calendar used to display the returned mud datetime."],
+			description);
+		RegisterLocationAndZone(name, type,
+			[ProgVariableTypes.Number, ProgVariableTypes.Calendar, ProgVariableTypes.Number],
+			["celestialId", "calendar", "occurrence"],
+			["The ID of the solar celestial.", "The calendar used to display the returned mud datetime.", "The nth next occurrence to return."],
+			description);
+	}
+
+	private static void RegisterLunar(string name, AstronomicalEventType type, string description)
+	{
+		RegisterLocationAndZone(name, type,
+			[ProgVariableTypes.Number, ProgVariableTypes.Calendar],
+			["celestialId", "calendar"],
+			["The ID of the lunar celestial.", "The calendar used to display the returned mud datetime."],
+			description);
+		RegisterLocationAndZone(name, type,
+			[ProgVariableTypes.Number, ProgVariableTypes.Calendar, ProgVariableTypes.Number],
+			["celestialId", "calendar", "occurrence"],
+			["The ID of the lunar celestial.", "The calendar used to display the returned mud datetime.", "The nth next occurrence to return."],
+			description);
+	}
+
+	private static void RegisterSolarLongitude()
+	{
+		const string description = "Returns the next time a solar celestial crosses the supplied ecliptic longitude in degrees. The optional occurrence parameter returns the nth next occurrence. Returns Never if no event is found.";
+		RegisterLocationAndZone("nextsolarlongitude", AstronomicalEventType.SolarLongitude,
+			[ProgVariableTypes.Number, ProgVariableTypes.Calendar, ProgVariableTypes.Number],
+			["celestialId", "calendar", "longitudeDegrees"],
+			["The ID of the solar celestial.", "The calendar used to display the returned mud datetime.", "The target solar longitude in degrees."],
+			description);
+		RegisterLocationAndZone("nextsolarlongitude", AstronomicalEventType.SolarLongitude,
+			[ProgVariableTypes.Number, ProgVariableTypes.Calendar, ProgVariableTypes.Number, ProgVariableTypes.Number],
+			["celestialId", "calendar", "longitudeDegrees", "occurrence"],
+			["The ID of the solar celestial.", "The calendar used to display the returned mud datetime.", "The target solar longitude in degrees.", "The nth next occurrence to return."],
+			description);
+	}
+
+	private static void RegisterVisibleCrescent()
+	{
+		const string description = "Returns the next deterministic visible-crescent approximation after sunset using geometric thresholds only. The optional occurrence parameter returns the nth next occurrence. Returns Never if no event is found.";
+		RegisterLocationAndZone("nextvisiblecrescent", AstronomicalEventType.VisibleCrescent,
+			[ProgVariableTypes.Number, ProgVariableTypes.Number, ProgVariableTypes.Calendar],
+			["sunId", "moonId", "calendar"],
+			["The ID of the solar celestial.", "The ID of the lunar celestial.", "The calendar used to display the returned mud datetime."],
+			description);
+		RegisterLocationAndZone("nextvisiblecrescent", AstronomicalEventType.VisibleCrescent,
+			[ProgVariableTypes.Number, ProgVariableTypes.Number, ProgVariableTypes.Calendar, ProgVariableTypes.Number],
+			["sunId", "moonId", "calendar", "occurrence"],
+			["The ID of the solar celestial.", "The ID of the lunar celestial.", "The calendar used to display the returned mud datetime.", "The nth next occurrence to return."],
+			description);
+	}
+
+	private static void RegisterLocationAndZone(string name, AstronomicalEventType type, ProgVariableTypes[] trailingTypes,
+		List<string> trailingNames, List<string> trailingDescriptions, string description)
+	{
+		RegisterForFirstParameter(name, type, ProgVariableTypes.Location, trailingTypes, trailingNames, trailingDescriptions, description);
+		RegisterForFirstParameter(name, type, ProgVariableTypes.Zone, trailingTypes, trailingNames, trailingDescriptions, description);
+	}
+
+	private static void RegisterForFirstParameter(string name, AstronomicalEventType type, ProgVariableTypes firstType,
+		ProgVariableTypes[] trailingTypes, List<string> trailingNames, List<string> trailingDescriptions, string description)
+	{
+		var parameterTypes = new[] { firstType }.Concat(trailingTypes).ToArray();
+		var parameterNames = new[] { "locationOrZone" }.Concat(trailingNames).ToList();
+		var parameterDescriptions = new[] { "The room or zone whose geography is used as the observer location." }
+			.Concat(trailingDescriptions)
+			.ToList();
+
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			name,
+			parameterTypes,
+			(pars, gameworld) => new AstronomicalEventFunction(pars, type, gameworld),
+			parameterNames,
+			parameterDescriptions,
+			description,
+			"Celestials",
+			ProgVariableTypes.MudDateTime
+		));
+	}
+}

--- a/MudSharpCore/TimeAndDate/Date/Calendar.cs
+++ b/MudSharpCore/TimeAndDate/Date/Calendar.cs
@@ -2,6 +2,7 @@
 using MudSharp.Effects.Concrete;
 using MudSharp.Economy.Currency;
 using MudSharp.Character;
+using MudSharp.Celestial;
 using MudSharp.Framework;
 using MudSharp.Framework.Save;
 using MudSharp.FutureProg;
@@ -10,6 +11,7 @@ using MudSharp.Models;
 using MudSharp.TimeAndDate.Time;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -209,6 +211,9 @@ public class Calendar : SaveableItem, ICalendar
                 _intercalaries.Add(intercalary);
             }
         }
+
+        LoadDayBoundary(root.Element("dayboundary"));
+        _algorithm = CalendarAlgorithmFactory.LoadFromXml(root.Element("algorithm"), AuthorityLocation);
     }
 
     public XElement SaveToXml()
@@ -240,7 +245,58 @@ public class Calendar : SaveableItem, ICalendar
                     from ic in _intercalaries
                     select ic.SaveToXml()
                 }
-            ));
+            ), Algorithm.SaveToXml(), SaveDayBoundaryToXml());
+    }
+
+    private void LoadDayBoundary(XElement element)
+    {
+        DayBoundary = CalendarDayBoundaryType.ClockMidnight;
+        _fixedDayBoundaryTimeText = null;
+        AuthorityLocation = null;
+        if (element is null)
+        {
+            return;
+        }
+
+        var typeText = element.Attribute("type")?.Value ?? element.Element("type")?.Value;
+        if (!string.IsNullOrWhiteSpace(typeText) &&
+            Enum.TryParse(typeText.Replace("-", string.Empty), true, out CalendarDayBoundaryType type))
+        {
+            DayBoundary = type;
+        }
+
+        _fixedDayBoundaryTimeText = element.Attribute("fixedTime")?.Value ?? element.Element("fixedTime")?.Value;
+
+        var authority = element.Element("authority");
+        if (authority is null)
+        {
+            return;
+        }
+
+        var latitude = (authority.Attribute("latitude")?.Value ?? "0").GetDouble() ?? 0.0;
+        var longitude = (authority.Attribute("longitude")?.Value ?? "0").GetDouble() ?? 0.0;
+        var elevation = (authority.Attribute("elevation")?.Value ?? "0").GetDouble() ?? 0.0;
+        var radius = (authority.Attribute("radius")?.Value ?? "0").GetDouble() ?? 0.0;
+        AuthorityLocation = new GeographicCoordinate(latitude, longitude, elevation, radius);
+    }
+
+    private XElement SaveDayBoundaryToXml()
+    {
+        var element = new XElement("dayboundary",
+            new XAttribute("type", DayBoundary.ToString()),
+            string.IsNullOrWhiteSpace(_fixedDayBoundaryTimeText)
+                ? null
+                : new XAttribute("fixedTime", _fixedDayBoundaryTimeText));
+        if (AuthorityLocation is not null)
+        {
+            element.Add(new XElement("authority",
+                new XAttribute("latitude", AuthorityLocation.Latitude.ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                new XAttribute("longitude", AuthorityLocation.Longitude.ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                new XAttribute("elevation", AuthorityLocation.Elevation.ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                new XAttribute("radius", AuthorityLocation.Radius.ToString(System.Globalization.CultureInfo.InvariantCulture))));
+        }
+
+        return element;
     }
 
     #region Overrides of FrameworkItem
@@ -380,13 +436,10 @@ public class Calendar : SaveableItem, ICalendar
         get => _feedClock;
         set
         {
-            _feedClock?.DaysUpdated -= CurrentDate.AdvanceDays;
+            UnsubscribeFromFeedClock();
 
             _feedClock = value;
-            if (CurrentDate != null)
-            {
-                _feedClock.DaysUpdated += CurrentDate.AdvanceDays;
-            }
+            SubscribeToFeedClock();
 
             if (_clockID == 0)
             {
@@ -425,18 +478,145 @@ public class Calendar : SaveableItem, ICalendar
         get => _currentDate;
         protected set
         {
-            if (_currentDate != null && FeedClock != null)
-            {
-                FeedClock.DaysUpdated -= _currentDate.AdvanceDays;
-            }
+            UnsubscribeFromFeedClock();
 
             _currentDate = value;
+            _clockDaysSinceCalendarAdvance = 0;
 
-            FeedClock?.DaysUpdated += _currentDate.AdvanceDays;
+            SubscribeToFeedClock();
         }
     }
 
     public MudDateTime CurrentDateTime => new(CurrentDate, FeedClock.CurrentTime, FeedClock.PrimaryTimezone);
+
+    public MudInstant CurrentInstant => CurrentClockDateTime() is { Date: not null } dateTime
+        ? MudInstant.FromMudDateTime(dateTime)
+        : MudInstant.Never;
+
+    private int _clockDaysSinceCalendarAdvance;
+
+    private void SubscribeToFeedClock()
+    {
+        if (_feedClock is null || _currentDate is null)
+        {
+            return;
+        }
+
+        _feedClock.DaysUpdated += FeedClockOnDaysUpdated;
+        _feedClock.MinutesUpdated += FeedClockOnMinutesUpdated;
+    }
+
+    private void UnsubscribeFromFeedClock()
+    {
+        if (_feedClock is null || _currentDate is null)
+        {
+            return;
+        }
+
+        _feedClock.DaysUpdated -= FeedClockOnDaysUpdated;
+        _feedClock.MinutesUpdated -= FeedClockOnMinutesUpdated;
+    }
+
+    private void FeedClockOnDaysUpdated(int days)
+    {
+        if (_currentDate is null)
+        {
+            return;
+        }
+
+        if (DayBoundary == CalendarDayBoundaryType.ClockMidnight)
+        {
+            _currentDate.AdvanceDays(days);
+            return;
+        }
+
+        _clockDaysSinceCalendarAdvance += days;
+        AdvanceCalendarToCurrentBoundary();
+    }
+
+    private void FeedClockOnMinutesUpdated()
+    {
+        if (DayBoundary == CalendarDayBoundaryType.ClockMidnight)
+        {
+            return;
+        }
+
+        AdvanceCalendarToCurrentBoundary();
+    }
+
+    private MudDateTime CurrentClockDateTime(IMudTimeZone timezone = null)
+    {
+        if (_currentDate is null || FeedClock is null)
+        {
+            return MudDateTime.Never;
+        }
+
+        timezone ??= FeedClock.PrimaryTimezone;
+        var date = new MudDate(_currentDate);
+        if (_clockDaysSinceCalendarAdvance != 0)
+        {
+            date.AdvanceDays(_clockDaysSinceCalendarAdvance);
+        }
+
+        var time = FeedClock.CurrentTime.GetTimeByTimezone(timezone);
+        if (time.DaysOffsetFromDatum != 0)
+        {
+            date.AdvanceDays(time.DaysOffsetFromDatum);
+        }
+
+        return new MudDateTime(date, time, timezone);
+    }
+
+    private void AdvanceCalendarToCurrentBoundary()
+    {
+        if (_currentDate is null || FeedClock is null)
+        {
+            return;
+        }
+
+        var timezone = FeedClock.PrimaryTimezone;
+        var guard = Math.Abs(_clockDaysSinceCalendarAdvance) + 3;
+        while (guard-- > 0)
+        {
+            if (_clockDaysSinceCalendarAdvance < 0)
+            {
+                var currentBoundary = StartOfCalendarDay(_currentDate, timezone);
+                var currentDateTime = CurrentClockDateTime(timezone);
+                if (currentBoundary.Date is null || currentDateTime >= currentBoundary)
+                {
+                    return;
+                }
+
+                _currentDate.AdvanceDays(-1);
+                _clockDaysSinceCalendarAdvance++;
+                continue;
+            }
+
+            var nextDate = new MudDate(_currentDate);
+            nextDate.AdvanceDays(1);
+            var nextBoundary = StartOfCalendarDay(nextDate, timezone);
+            var now = CurrentClockDateTime(timezone);
+            if (nextBoundary.Date is null || now < nextBoundary)
+            {
+                return;
+            }
+
+            _currentDate.AdvanceDays(1);
+            _clockDaysSinceCalendarAdvance--;
+        }
+    }
+
+    private ICalendarAlgorithm _algorithm = new FixedMonthCalendarAlgorithm();
+
+    public ICalendarAlgorithm Algorithm => _algorithm;
+
+    public CalendarAlgorithmType AlgorithmType => Algorithm.Type;
+
+    public CalendarDayBoundaryType DayBoundary { get; protected set; } = CalendarDayBoundaryType.ClockMidnight;
+
+    protected string _fixedDayBoundaryTimeText;
+
+    public GeographicCoordinate AuthorityLocation { get; protected set; }
 
     /// <summary>
     ///     The year in which this calendar's other epoch data (such as first weekday) begins. This should be as close to the
@@ -636,12 +816,7 @@ public class Calendar : SaveableItem, ICalendar
             return year;
         }
 
-        List<Month> returnList = new();
-        returnList.AddRange(Months.Select(x => new Month(x, whichYear)));
-        returnList.AddRange(
-            Intercalaries.Where(x => x.Rule.IsIntercalaryYear(whichYear)).Select(x => new Month(x.Month, whichYear)));
-        returnList = returnList.OrderBy(x => x.NominalOrder).ToList();
-        Year newYear = new(returnList, whichYear, this);
+        Year newYear = Algorithm.CreateYear(this, whichYear);
         _cachedYears[whichYear] = newYear;
         return newYear;
     }
@@ -661,27 +836,7 @@ public class Calendar : SaveableItem, ICalendar
             return year;
         }
 
-        int sum = _months.Sum(x => x.NormalDays - x.NonWeekdays.Count)
-               +
-               Months.Sum(
-                   x =>
-                       x.Intercalaries.Sum(
-                           y =>
-                               y.Rule.IsIntercalaryYear(whichYear)
-                                   ? y.InsertNumnewDays - y.NonWeekdays.Count + y.RemoveNonWeekdays.Count
-                                   : 0))
-               +
-               Intercalaries.Sum(
-                   x =>
-                       x.Rule.IsIntercalaryYear(whichYear)
-                           ? x.Month.NormalDays - x.Month.NonWeekdays.Count +
-                             x.Month.Intercalaries.Sum(
-                                 y =>
-                                     y.Rule.IsIntercalaryYear(whichYear)
-                                         ? y.InsertNumnewDays - y.NonWeekdays.Count + y.RemoveNonWeekdays.Count
-                                         : 0)
-                           : 0)
-            ;
+        int sum = Algorithm.CountWeekdaysInYear(this, whichYear);
         _cachedWeekdaysInYear[whichYear] = sum;
         return sum;
     }
@@ -700,19 +855,7 @@ public class Calendar : SaveableItem, ICalendar
         {
             return year;
         }
-        int sum = _months.Sum(x => x.NormalDays)
-               +
-               Months.Sum(
-                   x => x.Intercalaries.Sum(y => y.Rule.IsIntercalaryYear(whichYear) ? y.InsertNumnewDays : 0))
-               +
-               Intercalaries.Sum(
-                   x =>
-                       x.Rule.IsIntercalaryYear(whichYear)
-                           ? x.Month.NormalDays +
-                             x.Month.Intercalaries.Sum(
-                                 y => y.Rule.IsIntercalaryYear(whichYear) ? y.InsertNumnewDays : 0)
-                           : 0)
-            ;
+        int sum = Algorithm.CountDaysInYear(this, whichYear);
         _cachedDaysInYear[whichYear] = sum;
         return sum;
     }
@@ -736,7 +879,8 @@ public class Calendar : SaveableItem, ICalendar
             (startYear, endYear) = (endYear, startYear);
         }
 
-        if (_cachedDaysBetweenYears.TryGetValue((startYear, endYear), out int count))
+        var cacheKey = (startYear, endYear);
+        if (_cachedDaysBetweenYears.TryGetValue(cacheKey, out int count))
         {
             return count;
         }
@@ -747,7 +891,7 @@ public class Calendar : SaveableItem, ICalendar
             count += CountDaysInYear(startYear++);
         }
 
-        _cachedDaysBetweenYears[(startYear, endYear)] = count;
+        _cachedDaysBetweenYears[cacheKey] = count;
         return count;
     }
 
@@ -851,6 +995,47 @@ public class Calendar : SaveableItem, ICalendar
         Year year = CreateYear(CurrentDate.Year - age);
         Month month = year.Months.GetWeightedRandom(x => x.Days);
         return new MudDate(this, Constants.Random.Next(1, month.Days + 1), year.YearName, month, year, false);
+    }
+
+    public MudDateTime StartOfCalendarDay(MudDate date, IMudTimeZone timezone = null)
+    {
+        if (date is null || FeedClock is null)
+        {
+            return MudDateTime.Never;
+        }
+
+        timezone ??= FeedClock.PrimaryTimezone;
+        if (DayBoundary == CalendarDayBoundaryType.FixedClockTime &&
+            !string.IsNullOrWhiteSpace(_fixedDayBoundaryTimeText) &&
+            MudTime.TryParseLocalTime(_fixedDayBoundaryTimeText, FeedClock, out var fixedTime, out _))
+        {
+            return new MudDateTime(date, fixedTime.GetTimeByTimezone(timezone), timezone);
+        }
+
+        if (DayBoundary.In(CalendarDayBoundaryType.SunriseAtAuthorityLocation,
+                CalendarDayBoundaryType.SunsetAtAuthorityLocation) &&
+            AuthorityLocation is not null &&
+            Gameworld?.CelestialObjects.OfType<ISolarEphemeris>().FirstOrDefault() is { } sun)
+        {
+            var reference = MudInstant.FromMudDateTime(new MudDateTime(date,
+                MudTime.FromLocalTime(0, 0, 0, FeedClock.PrimaryTimezone, FeedClock),
+                FeedClock.PrimaryTimezone));
+            if (AstronomicalEventService.Instance.TryFindNext(
+                    DayBoundary == CalendarDayBoundaryType.SunriseAtAuthorityLocation
+                        ? AstronomicalEventType.Sunrise
+                        : AstronomicalEventType.Sunset,
+                    reference,
+                    1,
+                    sun,
+                    AuthorityLocation,
+                    out var instant,
+                    out _))
+            {
+                return instant.ToMudDateTime(this, FeedClock, timezone);
+            }
+        }
+
+        return new MudDateTime(date, MudTime.FromLocalTime(0, 0, 0, timezone, FeedClock), timezone);
     }
 
     /// <summary>
@@ -1471,6 +1656,9 @@ You can also use #3/#0, #3-#0 or spaces to separate the three parts of your date
 	#3plane <plane>#0 - changes the intended plane alias
 	#3clock <clock>#0 - changes the feed clock
 	#3date <date>#0 - sets the current date
+	#3algorithm <type>#0 - sets the calendar algorithm type
+	#3dayboundary <midnight|fixed|sunset|sunrise> [time]#0 - sets the official day boundary
+	#3authority <latitude> <longitude> [elevation] [radius]#0 - sets the authority location for astronomical boundaries
 	#3epoch <year> <weekday>#0 - sets the epoch year and first weekday
 	#3short|long|wordy <mask>#0 - changes display masks
 	#3era <ancient|modern> <short|long> <text>#0 - changes era text
@@ -1503,6 +1691,15 @@ You can also use #3/#0, #3-#0 or spaces to separate the three parts of your date
             case "date":
             case "current":
                 return BuildingCommandDate(actor, command);
+            case "algorithm":
+            case "alg":
+                return BuildingCommandAlgorithm(actor, command);
+            case "dayboundary":
+            case "boundary":
+                return BuildingCommandDayBoundary(actor, command);
+            case "authority":
+            case "authoritylocation":
+                return BuildingCommandAuthority(actor, command);
             case "epoch":
                 return BuildingCommandEpoch(actor, command);
             case "short":
@@ -1651,6 +1848,135 @@ You can also use #3/#0, #3-#0 or spaces to separate the three parts of your date
         CurrentDate.IsPrimaryDate = true;
         Changed = true;
         actor.OutputHandler.Send($"This calendar's current date is now {DisplayDate(CurrentDate, CalendarDisplayMode.Long).ColourValue()}.");
+        return true;
+    }
+
+    private bool BuildingCommandAlgorithm(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which algorithm should this calendar use? Options are fixed-months, tabular-lunar, calculated-hebrew, solar-equinox, astronomical-lunar and east-asian-lunisolar.");
+            return false;
+        }
+
+        var text = command.PopSpeech();
+        if (!CalendarAlgorithmFactory.TryParseType(text, out var type))
+        {
+            actor.OutputHandler.Send("That is not a valid calendar algorithm type.");
+            return false;
+        }
+
+        return ConfirmStructuralChange(actor, $"change calendar algorithm to {type.DescribeEnum()}", () =>
+        {
+            _algorithm = CalendarAlgorithmFactory.Create(type, AuthorityLocation);
+            ClearDateCaches();
+            NormaliseCurrentDate();
+            Changed = true;
+            actor.OutputHandler.Send($"This calendar now uses the {Algorithm.DisplayName.ColourName()} algorithm.");
+        });
+    }
+
+    private bool BuildingCommandDayBoundary(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which day boundary should this calendar use? Options are midnight, fixed, sunset, sunrise and event.");
+            return false;
+        }
+
+        var boundaryText = command.PopForSwitch();
+        CalendarDayBoundaryType boundary;
+        switch (boundaryText)
+        {
+            case "midnight":
+            case "clockmidnight":
+                boundary = CalendarDayBoundaryType.ClockMidnight;
+                break;
+            case "fixed":
+            case "fixedtime":
+                boundary = CalendarDayBoundaryType.FixedClockTime;
+                break;
+            case "sunset":
+                boundary = CalendarDayBoundaryType.SunsetAtAuthorityLocation;
+                break;
+            case "sunrise":
+                boundary = CalendarDayBoundaryType.SunriseAtAuthorityLocation;
+                break;
+            case "event":
+            case "astronomical":
+                boundary = CalendarDayBoundaryType.AstronomicalEvent;
+                break;
+            default:
+                actor.OutputHandler.Send("That is not a valid day-boundary type.");
+                return false;
+        }
+
+        string fixedTime = null;
+        if (boundary == CalendarDayBoundaryType.FixedClockTime)
+        {
+            if (command.IsFinished)
+            {
+                actor.OutputHandler.Send("What fixed clock time should begin the calendar day?");
+                return false;
+            }
+
+            fixedTime = command.SafeRemainingArgument;
+            if (!MudTime.TryParseLocalTime(fixedTime, FeedClock, out _, out var error))
+            {
+                actor.OutputHandler.Send(error);
+                return false;
+            }
+        }
+
+        DayBoundary = boundary;
+        _fixedDayBoundaryTimeText = fixedTime;
+        Changed = true;
+        actor.OutputHandler.Send($"This calendar now uses {DayBoundary.DescribeEnum().ColourValue()} day boundaries.");
+        return true;
+    }
+
+    private bool BuildingCommandAuthority(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("What latitude should this calendar's authority location use, in degrees?");
+            return false;
+        }
+
+        if (!double.TryParse(command.PopSpeech(), out var latitude))
+        {
+            actor.OutputHandler.Send("The latitude must be a valid number of degrees.");
+            return false;
+        }
+
+        if (command.IsFinished || !double.TryParse(command.PopSpeech(), out var longitude))
+        {
+            actor.OutputHandler.Send("The longitude must be a valid number of degrees.");
+            return false;
+        }
+
+        var elevation = 0.0;
+        var radius = 0.0;
+        if (!command.IsFinished && !double.TryParse(command.PopSpeech(), out elevation))
+        {
+            actor.OutputHandler.Send("The elevation must be a valid number.");
+            return false;
+        }
+
+        if (!command.IsFinished && !double.TryParse(command.PopSpeech(), out radius))
+        {
+            actor.OutputHandler.Send("The radius must be a valid number.");
+            return false;
+        }
+
+        AuthorityLocation = new GeographicCoordinate(latitude.DegreesToRadians(), longitude.DegreesToRadians(), elevation, radius);
+        if (Algorithm is IAstronomicalCalendarAlgorithm)
+        {
+            _algorithm = CalendarAlgorithmFactory.Create(AlgorithmType, AuthorityLocation);
+        }
+
+        Changed = true;
+        actor.OutputHandler.Send($"This calendar's authority location is now {latitude.ToString("N3", actor).ColourValue()}, {longitude.ToString("N3", actor).ColourValue()}.");
         return true;
     }
 
@@ -2382,6 +2708,13 @@ You can also use #3/#0, #3-#0 or spaces to separate the three parts of your date
         sb.AppendLine($"Plane: {Plane.ColourValue()}");
         sb.AppendLine($"Feed Clock: {FeedClock?.Name.ColourName() ?? "None".ColourError()}");
         sb.AppendLine($"Current Date: {(CurrentDate is null ? "None".ColourError() : DisplayDate(CurrentDate, CalendarDisplayMode.Long).ColourValue())}");
+        sb.AppendLine($"MudInstant: {CurrentInstant.GetStorageString().ColourValue()}");
+        sb.AppendLine($"Algorithm: {Algorithm.DisplayName.ColourName()} ({Algorithm.Summary})");
+        sb.AppendLine($"Day Boundary: {DayBoundary.DescribeEnum().ColourValue()}{(string.IsNullOrWhiteSpace(_fixedDayBoundaryTimeText) ? "" : $" at {_fixedDayBoundaryTimeText.ColourCommand()}")}");
+        if (AuthorityLocation is not null)
+        {
+            sb.AppendLine($"Authority Location: {AuthorityLocation.Latitude.RadiansToDegrees().ToString("N3", actor).ColourValue()}, {AuthorityLocation.Longitude.RadiansToDegrees().ToString("N3", actor).ColourValue()}");
+        }
         sb.AppendLine($"Epoch: {EpochYear.ToStringN0(actor).ColourValue()} / {(Weekdays.Count > FirstWeekdayAtEpoch ? Weekdays[FirstWeekdayAtEpoch].ColourValue() : "Invalid".ColourError())}");
         sb.AppendLine($"Short Mask: {ShortString.ColourCommand()}");
         sb.AppendLine($"Long Mask: {LongString.ColourCommand()}");
@@ -2423,6 +2756,10 @@ You can also use #3/#0, #3-#0 or spaces to separate the three parts of your date
                 return new MudDateTime(CurrentDate, FeedClock.CurrentTime, FeedClock.PrimaryTimezone);
             case "clock":
                 return FeedClock;
+            case "algorithm":
+                return new TextVariable(Algorithm.DisplayName);
+            case "mudinstant":
+                return new TextVariable(CurrentInstant.GetStorageString());
             default:
                 throw new NotSupportedException($"Unsupported property type {property} in Calendar.GetProperty");
         }
@@ -2444,6 +2781,10 @@ You can also use #3/#0, #3-#0 or spaces to separate the three parts of your date
                 return ProgVariableTypes.MudDateTime;
             case "clock":
                 return ProgVariableTypes.Clock;
+            case "algorithm":
+                return ProgVariableTypes.Text;
+            case "mudinstant":
+                return ProgVariableTypes.Text;
             default:
                 return ProgVariableTypes.Error;
         }
@@ -2456,7 +2797,9 @@ You can also use #3/#0, #3-#0 or spaces to separate the three parts of your date
             { "id", ProgVariableTypes.Number },
             { "name", ProgVariableTypes.Text },
             { "date", ProgVariableTypes.MudDateTime },
-            { "clock", ProgVariableTypes.Clock }
+            { "clock", ProgVariableTypes.Clock },
+            { "algorithm", ProgVariableTypes.Text },
+            { "mudinstant", ProgVariableTypes.Text }
         };
     }
 
@@ -2467,7 +2810,9 @@ You can also use #3/#0, #3-#0 or spaces to separate the three parts of your date
             { "id", "" },
             { "name", "" },
             { "date", "" },
-            { "clock", "" }
+            { "clock", "" },
+            { "algorithm", "The calendar algorithm display name." },
+            { "mudinstant", "The current absolute MudInstant storage string." }
         };
     }
 

--- a/MudSharpCore/TimeAndDate/Date/CalendarAlgorithms.cs
+++ b/MudSharpCore/TimeAndDate/Date/CalendarAlgorithms.cs
@@ -1,0 +1,541 @@
+#nullable enable
+
+using MudSharp.Celestial;
+using MudSharp.Framework;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace MudSharp.TimeAndDate.Date;
+
+public static class CalendarAlgorithmFactory
+{
+	public static ICalendarAlgorithm LoadFromXml(XElement? element, GeographicCoordinate? authorityLocation = null)
+	{
+		var typeText = element?.Attribute("type")?.Value ?? element?.Element("type")?.Value ?? "fixed-months";
+		return typeText.ToLowerInvariant() switch
+		{
+			"fixed" or "fixed-month" or "fixed-months" => new FixedMonthCalendarAlgorithm(),
+			"tabular-lunar" => new TabularLunarCalendarAlgorithm(element),
+			"hebrew" or "calculated-hebrew" => new CalculatedHebrewCalendarAlgorithm(element),
+			"solar-equinox" => new SolarEquinoxCalendarAlgorithm(element),
+			"astronomical-lunar" => new AstronomicalLunarCalendarAlgorithm(element, authorityLocation),
+			"east-asian-lunisolar" or "eastasian-lunisolar" => new EastAsianLunisolarCalendarAlgorithm(element, authorityLocation),
+			_ => new FixedMonthCalendarAlgorithm()
+		};
+	}
+
+	public static ICalendarAlgorithm Create(CalendarAlgorithmType type, GeographicCoordinate? authorityLocation = null)
+	{
+		return type switch
+		{
+			CalendarAlgorithmType.TabularLunar => new TabularLunarCalendarAlgorithm(null),
+			CalendarAlgorithmType.CalculatedHebrew => new CalculatedHebrewCalendarAlgorithm(null),
+			CalendarAlgorithmType.SolarEquinox => new SolarEquinoxCalendarAlgorithm(null),
+			CalendarAlgorithmType.AstronomicalLunar => new AstronomicalLunarCalendarAlgorithm(null, authorityLocation),
+			CalendarAlgorithmType.EastAsianLunisolar => new EastAsianLunisolarCalendarAlgorithm(null, authorityLocation),
+			_ => new FixedMonthCalendarAlgorithm()
+		};
+	}
+
+	public static bool TryParseType(string text, out CalendarAlgorithmType type)
+	{
+		type = text.ToLowerInvariant() switch
+		{
+			"fixed" or "fixed-month" or "fixed-months" => CalendarAlgorithmType.FixedMonths,
+			"tabular-lunar" or "lunar-tabular" => CalendarAlgorithmType.TabularLunar,
+			"hebrew" or "calculated-hebrew" => CalendarAlgorithmType.CalculatedHebrew,
+			"solar-equinox" or "persian" => CalendarAlgorithmType.SolarEquinox,
+			"astronomical-lunar" or "lunar-astronomical" => CalendarAlgorithmType.AstronomicalLunar,
+			"east-asian-lunisolar" or "eastasian-lunisolar" or "lunisolar" => CalendarAlgorithmType.EastAsianLunisolar,
+			_ => CalendarAlgorithmType.FixedMonths
+		};
+		return text.ToLowerInvariant().In("fixed", "fixed-month", "fixed-months", "tabular-lunar", "lunar-tabular",
+			"hebrew", "calculated-hebrew", "solar-equinox", "persian", "astronomical-lunar",
+			"lunar-astronomical", "east-asian-lunisolar", "eastasian-lunisolar", "lunisolar");
+	}
+
+	public static string XmlTypeFor(CalendarAlgorithmType type)
+	{
+		return type switch
+		{
+			CalendarAlgorithmType.TabularLunar => "tabular-lunar",
+			CalendarAlgorithmType.CalculatedHebrew => "calculated-hebrew",
+			CalendarAlgorithmType.SolarEquinox => "solar-equinox",
+			CalendarAlgorithmType.AstronomicalLunar => "astronomical-lunar",
+			CalendarAlgorithmType.EastAsianLunisolar => "east-asian-lunisolar",
+			_ => "fixed-months"
+		};
+	}
+}
+
+public sealed class FixedMonthCalendarAlgorithm : IFixedMonthCalendarAlgorithm
+{
+	public CalendarAlgorithmType Type => CalendarAlgorithmType.FixedMonths;
+
+	public string DisplayName => "Fixed Months";
+
+	public string Summary => "Legacy fixed month and intercalary rules";
+
+	public Year CreateYear(ICalendar calendar, int whichYear)
+	{
+		return new Year(CreateMonths(calendar, whichYear), whichYear, calendar);
+	}
+
+	public int CountWeekdaysInYear(ICalendar calendar, int whichYear)
+	{
+		return CreateMonths(calendar, whichYear).Sum(x => x.CountWeekdays());
+	}
+
+	public int CountDaysInYear(ICalendar calendar, int whichYear)
+	{
+		return CreateMonths(calendar, whichYear).Sum(x => x.Days);
+	}
+
+	private static List<Month> CreateMonths(ICalendar calendar, int whichYear)
+	{
+		var months = new List<Month>();
+		months.AddRange(calendar.Months.Select(x => new Month(x, whichYear)));
+		months.AddRange(calendar.Intercalaries
+		                   .Where(x => x.Rule.IsIntercalaryYear(whichYear))
+		                   .Select(x => new Month(x.Month, whichYear)));
+		return months.OrderBy(x => x.NominalOrder).ToList();
+	}
+
+	public XElement SaveToXml()
+	{
+		return new XElement("algorithm", new XAttribute("type", CalendarAlgorithmFactory.XmlTypeFor(Type)));
+	}
+}
+
+public sealed class TabularLunarCalendarAlgorithm : ICalculatedCalendarAlgorithm
+{
+	private static readonly int[] LeapYears = [2, 5, 7, 10, 13, 16, 18, 21, 24, 26, 29];
+
+	public TabularLunarCalendarAlgorithm(XElement? root)
+	{
+		LeapMonthAlias = root?.Attribute("leapMonth")?.Value ?? root?.Element("leapMonth")?.Value;
+		Variant = root?.Attribute("variant")?.Value ?? root?.Element("variant")?.Value ?? "tabular-lunar";
+	}
+
+	public CalendarAlgorithmType Type => CalendarAlgorithmType.TabularLunar;
+
+	public string DisplayName => "Tabular Lunar";
+
+	public string Summary => $"Alternating 30/29 day lunar months ({Variant})";
+
+	public string? LeapMonthAlias { get; }
+
+	public string Variant { get; }
+
+	public Year CreateYear(ICalendar calendar, int whichYear)
+	{
+		return new Year(CreateMonths(calendar, whichYear), whichYear, calendar);
+	}
+
+	public int CountWeekdaysInYear(ICalendar calendar, int whichYear)
+	{
+		return CreateMonths(calendar, whichYear).Sum(x => x.CountWeekdays());
+	}
+
+	public int CountDaysInYear(ICalendar calendar, int whichYear)
+	{
+		return CreateMonths(calendar, whichYear).Sum(x => x.Days);
+	}
+
+	private List<Month> CreateMonths(ICalendar calendar, int whichYear)
+	{
+		var months = calendar.Months
+		                     .Select((month, index) => BuildMonth(month, whichYear, index % 2 == 0 ? 30 : 29))
+		                     .ToList();
+		if (IsLeapYear(whichYear) && months.Count > 0)
+		{
+			var index = string.IsNullOrWhiteSpace(LeapMonthAlias)
+				? months.Count - 1
+				: Math.Max(0, months.FindIndex(x => x.Alias.EqualTo(LeapMonthAlias)));
+			var source = calendar.Months[Math.Min(index < 0 ? months.Count - 1 : index, calendar.Months.Count - 1)];
+			months[index < 0 ? months.Count - 1 : index] = BuildMonth(source, whichYear, months[index < 0 ? months.Count - 1 : index].Days + 1);
+		}
+
+		return months;
+	}
+
+	public XElement SaveToXml()
+	{
+		var element = new XElement("algorithm", new XAttribute("type", CalendarAlgorithmFactory.XmlTypeFor(Type)),
+			new XAttribute("variant", Variant));
+		if (!string.IsNullOrWhiteSpace(LeapMonthAlias))
+		{
+			element.Add(new XAttribute("leapMonth", LeapMonthAlias));
+		}
+
+		return element;
+	}
+
+	public static bool IsLeapYear(int year)
+	{
+		return LeapYears.Contains(CycleYear(year, 30));
+	}
+
+	private static int CycleYear(int year, int cycle)
+	{
+		return ((year - 1).Modulus(cycle)) + 1;
+	}
+
+	public static Month BuildMonth(MonthDefinition source, int year, int days, string? alias = null, string? shortName = null,
+		string? fullName = null, int? nominalOrder = null)
+	{
+		var definition = new MonthDefinition(
+			shortName ?? source.ShortName,
+			alias ?? source.Alias,
+			fullName ?? source.FullName,
+			nominalOrder ?? source.NominalOrder,
+			days,
+			source.SpecialDayNames
+			      .Where(x => x.Key <= days)
+			      .ToDictionary(x => x.Key, x => x.Value),
+			[]);
+		definition.NonWeekdays.AddRange(source.NonWeekdays.Where(x => x <= days));
+		return new Month(definition, year);
+	}
+}
+
+public sealed class CalculatedHebrewCalendarAlgorithm : ICalculatedCalendarAlgorithm
+{
+	public CalculatedHebrewCalendarAlgorithm(XElement? root)
+	{
+	}
+
+	public CalendarAlgorithmType Type => CalendarAlgorithmType.CalculatedHebrew;
+
+	public string DisplayName => "Calculated Hebrew";
+
+	public string Summary => "19-year Metonic cycle with calculated Heshvan/Kislev and Adar I/II handling";
+
+	public Year CreateYear(ICalendar calendar, int whichYear)
+	{
+		return new Year(CreateMonths(calendar, whichYear), whichYear, calendar);
+	}
+
+	public int CountWeekdaysInYear(ICalendar calendar, int whichYear)
+	{
+		return CreateMonths(calendar, whichYear).Sum(x => x.CountWeekdays());
+	}
+
+	public int CountDaysInYear(ICalendar calendar, int whichYear)
+	{
+		return CreateMonths(calendar, whichYear).Sum(x => x.Days);
+	}
+
+	private static List<Month> CreateMonths(ICalendar calendar, int whichYear)
+	{
+		var leap = IsLeapYear(whichYear);
+		var yearLength = HebrewYearLength(whichYear);
+		var heshvanLong = yearLength.Modulus(10) == 5;
+		var kislevShort = yearLength.Modulus(10) == 3;
+		var months = new List<Month>();
+
+		Add("nisan", 30);
+		Add("iyyar", 29);
+		Add("sivan", 30);
+		Add("tammuz", 29);
+		Add("av", 30);
+		Add("elul", 29);
+		Add("tishrei", 30);
+		Add("heshvan", heshvanLong ? 30 : 29);
+		Add("kislev", kislevShort ? 29 : 30);
+		Add("tevet", 29);
+		Add("shevat", 30);
+		if (leap)
+		{
+			Add("adar-i", 30);
+			Add("adar-ii", 29);
+		}
+		else
+		{
+			Add("adar", 29);
+		}
+
+		return months;
+
+		void Add(string alias, int days)
+		{
+			var source = calendar.Months.FirstOrDefault(x => x.Alias.EqualTo(alias)) ??
+			             calendar.Months.FirstOrDefault(x => x.Alias.Replace("_", "-").EqualTo(alias)) ??
+			             calendar.Months[Math.Min(months.Count, calendar.Months.Count - 1)];
+			months.Add(TabularLunarCalendarAlgorithm.BuildMonth(source, whichYear, days, nominalOrder: months.Count + 1));
+		}
+	}
+
+	public XElement SaveToXml()
+	{
+		return new XElement("algorithm", new XAttribute("type", CalendarAlgorithmFactory.XmlTypeFor(Type)));
+	}
+
+	public static bool IsLeapYear(int year)
+	{
+		return ((7 * year + 1).Modulus(19)) < 7;
+	}
+
+	private static int HebrewYearLength(int year)
+	{
+		return HebrewCalendarElapsedDays(year + 1) - HebrewCalendarElapsedDays(year);
+	}
+
+	private static int HebrewCalendarElapsedDays(int year)
+	{
+		var previousYear = year - 1;
+		var cycle = previousYear / 19;
+		var yearInCycle = previousYear.Modulus(19);
+		var monthsElapsed = 235 * cycle + 12 * yearInCycle + (7 * yearInCycle + 1) / 19;
+		var partsElapsed = 204 + 793 * monthsElapsed;
+		var hoursElapsed = 5 + 12 * monthsElapsed + partsElapsed / 1080;
+		var day = 1 + 29 * monthsElapsed + hoursElapsed / 24;
+		var parts = 1080 * (hoursElapsed.Modulus(24)) + partsElapsed.Modulus(1080);
+
+		if (parts >= 19440 ||
+		    day.Modulus(7) == 2 && parts >= 9924 && !IsLeapYear(year) ||
+		    day.Modulus(7) == 1 && parts >= 16789 && IsLeapYear(year - 1))
+		{
+			day++;
+		}
+
+		if (day.Modulus(7).In(0, 3, 5))
+		{
+			day++;
+		}
+
+		return day;
+	}
+}
+
+public sealed class SolarEquinoxCalendarAlgorithm : ICalculatedCalendarAlgorithm
+{
+	private static readonly int[] LeapYears = [1, 5, 9, 13, 17, 22, 26, 30];
+
+	public SolarEquinoxCalendarAlgorithm(XElement? root)
+	{
+		TargetLongitude = root?.Attribute("longitude")?.Value.GetDouble() ?? 0.0;
+	}
+
+	public CalendarAlgorithmType Type => CalendarAlgorithmType.SolarEquinox;
+
+	public string DisplayName => "Solar Equinox";
+
+	public string Summary => $"Deterministic solar year with leap years in a 33-year cycle at longitude {TargetLongitude.ToString("N3", CultureInfo.InvariantCulture)}";
+
+	public double TargetLongitude { get; }
+
+	public Year CreateYear(ICalendar calendar, int whichYear)
+	{
+		return new Year(CreateMonths(calendar, whichYear), whichYear, calendar);
+	}
+
+	public int CountWeekdaysInYear(ICalendar calendar, int whichYear)
+	{
+		return CreateMonths(calendar, whichYear).Sum(x => x.CountWeekdays());
+	}
+
+	public int CountDaysInYear(ICalendar calendar, int whichYear)
+	{
+		return CreateMonths(calendar, whichYear).Sum(x => x.Days);
+	}
+
+	private static List<Month> CreateMonths(ICalendar calendar, int whichYear)
+	{
+		var leap = IsLeapYear(whichYear);
+		var months = new List<Month>();
+		if (calendar.Months.Count == 13)
+		{
+			for (var i = 0; i < calendar.Months.Count; i++)
+			{
+				var source = calendar.Months[i];
+				months.Add(TabularLunarCalendarAlgorithm.BuildMonth(source, whichYear,
+					source.NormalDays + (i == calendar.Months.Count - 1 && leap ? 1 : 0)));
+			}
+
+			return months;
+		}
+
+		for (var i = 0; i < calendar.Months.Count; i++)
+		{
+			var days = i < 6 ? 31 : i < 11 ? 30 : leap ? 30 : 29;
+			months.Add(TabularLunarCalendarAlgorithm.BuildMonth(calendar.Months[i], whichYear, days));
+		}
+
+		return months;
+	}
+
+	public XElement SaveToXml()
+	{
+		return new XElement("algorithm",
+			new XAttribute("type", CalendarAlgorithmFactory.XmlTypeFor(Type)),
+			new XAttribute("longitude", TargetLongitude.ToString(CultureInfo.InvariantCulture)));
+	}
+
+	public static bool IsLeapYear(int year)
+	{
+		return LeapYears.Contains(((year - 1).Modulus(33)) + 1);
+	}
+}
+
+public sealed class AstronomicalLunarCalendarAlgorithm : ICalculatedCalendarAlgorithm, IAstronomicalCalendarAlgorithm
+{
+	private const double SynodicMonth = 29.530588853;
+
+	public AstronomicalLunarCalendarAlgorithm(XElement? root, GeographicCoordinate? authorityLocation)
+	{
+		Variant = root?.Attribute("variant")?.Value ?? root?.Element("variant")?.Value ?? "deterministic-new-moon";
+		AuthorityLocation = authorityLocation;
+	}
+
+	public CalendarAlgorithmType Type => CalendarAlgorithmType.AstronomicalLunar;
+
+	public string DisplayName => "Astronomical Lunar";
+
+	public string Summary => $"Mean-lunation deterministic astronomical lunar approximation ({Variant})";
+
+	public string Variant { get; }
+
+	public GeographicCoordinate? AuthorityLocation { get; }
+
+	public Year CreateYear(ICalendar calendar, int whichYear)
+	{
+		return new Year(CreateMonths(calendar, whichYear), whichYear, calendar);
+	}
+
+	public int CountWeekdaysInYear(ICalendar calendar, int whichYear)
+	{
+		return CreateMonths(calendar, whichYear).Sum(x => x.CountWeekdays());
+	}
+
+	public int CountDaysInYear(ICalendar calendar, int whichYear)
+	{
+		return CreateMonths(calendar, whichYear).Sum(x => x.Days);
+	}
+
+	private List<Month> CreateMonths(ICalendar calendar, int whichYear)
+	{
+		var baseMonths = calendar.Months
+		                         .Where(x => !IsLeapMonthAlias(x.Alias))
+		                         .Take(12)
+		                         .ToList();
+		var months = baseMonths
+		             .Select((month, index) => TabularLunarCalendarAlgorithm.BuildMonth(month, whichYear,
+			             MonthLength((whichYear - calendar.EpochYear) * 12 + index)))
+		             .ToList();
+
+		if (Variant.EqualTo("babylonian-regulated") && IsMetonicLeapYear(whichYear))
+		{
+			var insertAfterUlulu = CycleYear(whichYear, 19) == 17;
+			var leapAlias = insertAfterUlulu ? "ululu-ii" : "addaru-ii";
+			var source = calendar.Months.FirstOrDefault(x => x.Alias.EqualTo(leapAlias)) ??
+			             calendar.Months.FirstOrDefault(x => IsLeapMonthAlias(x.Alias));
+			if (source is not null)
+			{
+				var insertIndex = insertAfterUlulu
+					? Math.Max(0, months.FindIndex(x => x.Alias.EqualTo("ululu")) + 1)
+					: months.Count;
+				months.Insert(insertIndex, TabularLunarCalendarAlgorithm.BuildMonth(source, whichYear,
+					MonthLength((whichYear - calendar.EpochYear) * 12 + months.Count), nominalOrder: insertIndex + 1));
+			}
+		}
+
+		return months;
+	}
+
+	public XElement SaveToXml()
+	{
+		return new XElement("algorithm",
+			new XAttribute("type", CalendarAlgorithmFactory.XmlTypeFor(Type)),
+			new XAttribute("variant", Variant));
+	}
+
+	public static int MonthLength(int lunation)
+	{
+		return (int)Math.Floor((lunation + 1) * SynodicMonth) - (int)Math.Floor(lunation * SynodicMonth);
+	}
+
+	public static bool IsMetonicLeapYear(int year)
+	{
+		return CycleYear(year, 19).In(3, 6, 8, 11, 14, 17, 19);
+	}
+
+	private static int CycleYear(int year, int cycle)
+	{
+		return ((year - 1).Modulus(cycle)) + 1;
+	}
+
+	private static bool IsLeapMonthAlias(string alias)
+	{
+		return alias.Contains("ii", StringComparison.InvariantCultureIgnoreCase) ||
+		       alias.StartsWith("leap-", StringComparison.InvariantCultureIgnoreCase);
+	}
+}
+
+public sealed class EastAsianLunisolarCalendarAlgorithm : ICalculatedCalendarAlgorithm, IAstronomicalCalendarAlgorithm
+{
+	public EastAsianLunisolarCalendarAlgorithm(XElement? root, GeographicCoordinate? authorityLocation)
+	{
+		Variant = root?.Attribute("variant")?.Value ?? root?.Element("variant")?.Value ?? "east-asian-lunisolar";
+		AuthorityLocation = authorityLocation;
+	}
+
+	public CalendarAlgorithmType Type => CalendarAlgorithmType.EastAsianLunisolar;
+
+	public string DisplayName => "East Asian Lunisolar";
+
+	public string Summary => $"Deterministic lunisolar approximation with Metonic leap-month placement ({Variant})";
+
+	public string Variant { get; }
+
+	public GeographicCoordinate? AuthorityLocation { get; }
+
+	public Year CreateYear(ICalendar calendar, int whichYear)
+	{
+		return new Year(CreateMonths(calendar, whichYear), whichYear, calendar);
+	}
+
+	public int CountWeekdaysInYear(ICalendar calendar, int whichYear)
+	{
+		return CreateMonths(calendar, whichYear).Sum(x => x.CountWeekdays());
+	}
+
+	public int CountDaysInYear(ICalendar calendar, int whichYear)
+	{
+		return CreateMonths(calendar, whichYear).Sum(x => x.Days);
+	}
+
+	private static List<Month> CreateMonths(ICalendar calendar, int whichYear)
+	{
+		var baseMonths = calendar.Months.Where(x => !x.Alias.StartsWith("leap-", StringComparison.InvariantCultureIgnoreCase))
+		                         .Take(12)
+		                         .ToList();
+		var months = baseMonths
+		             .Select((month, index) => TabularLunarCalendarAlgorithm.BuildMonth(month, whichYear,
+			             AstronomicalLunarCalendarAlgorithm.MonthLength((whichYear - calendar.EpochYear) * 12 + index)))
+		             .ToList();
+
+		if (AstronomicalLunarCalendarAlgorithm.IsMetonicLeapYear(whichYear))
+		{
+			var leapSource = calendar.Months.FirstOrDefault(x => x.Alias.StartsWith("leap-", StringComparison.InvariantCultureIgnoreCase));
+			if (leapSource is not null && months.Count >= 6)
+			{
+				months.Insert(6, TabularLunarCalendarAlgorithm.BuildMonth(leapSource, whichYear,
+					AstronomicalLunarCalendarAlgorithm.MonthLength((whichYear - calendar.EpochYear) * 12 + 6),
+					nominalOrder: 6));
+			}
+		}
+
+		return months;
+	}
+
+	public XElement SaveToXml()
+	{
+		return new XElement("algorithm",
+			new XAttribute("type", CalendarAlgorithmFactory.XmlTypeFor(Type)),
+			new XAttribute("variant", Variant));
+	}
+}


### PR DESCRIPTION
## Summary
- add MudInstant source-context storage, legacy parse compatibility, and boundary-aware current instant handling
- add calendar algorithm metadata, calculated/astronomical calendar modes, day-boundary authority support, and event-solving surfaces
- extend time/celestial seeders, admin commands, FutureProg functions, and documentation for astronomical calendars

## Validation
- `dotnet restore MudSharp.sln -m:1 -p:RestoreBuildInParallel=false -p:NuGetAudit=false`
- `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `dotnet build DatabaseSeeder\DatabaseSeeder.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore -m:1 --filter TimeSeederTests -p:NoWarn=NU1902%3BNU1510`
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 --filter "FullyQualifiedName~MudDateTimeTests|FullyQualifiedName~CelestialTests|FullyQualifiedName~FutureProgDateTimeFunctionTests" -p:NoWarn=NU1902%3BNU1510`
- `git diff --check`