### PR TITLE
Fix body remains prototype marker

### DIFF
--- a/Design Documents/Items/Item_System_Component_Authoring.md
+++ b/Design Documents/Items/Item_System_Component_Authoring.md
@@ -99,6 +99,7 @@ For example:
 - a runtime component that implements `IContainer` should have a proto that implements `IContainerPrototype`
 - a runtime component that implements `IWearable` should have a proto that implements `IWearablePrototype`
 - a runtime component that implements `ILiquidContainer` should have a proto that implements `ILiquidContainerPrototype`, which also implies the relevant parent capability markers
+- inherited public component capabilities need markers too; for example `ICorpsePrototype` also advertises `IBodyRemainsPrototype` and `IButcherablePrototype`
 
 These markers let item prototypes catch invalid component combinations before review. Most capability markers are exclusive, because runtime code usually calls `GetItemType<T>()` or `IsItemType<T>()` and expects one authoritative component. Aggregate service markers such as `IConnectablePrototype`, `IConsumePowerPrototype`, `IProducePowerPrototype`, `ISignalSourceComponentPrototype`, `IChangeTraitsInInventoryPrototype`, and grid-connection markers remain composable.
 

--- a/FutureMUDLibrary/GameItems/Prototypes/GameItemComponentPrototypeInterfaces.cs
+++ b/FutureMUDLibrary/GameItems/Prototypes/GameItemComponentPrototypeInterfaces.cs
@@ -89,6 +89,10 @@ public interface IBoardItemPrototype : IExclusiveGameItemComponentPrototype<IBoa
 {
 }
 
+public interface IBodyRemainsPrototype : IExclusiveGameItemComponentPrototype<IBodyRemains>, IButcherablePrototype
+{
+}
+
 public interface IButcherablePrototype : IExclusiveGameItemComponentPrototype<IButcherable>
 {
 }
@@ -145,7 +149,7 @@ public interface IContainerPrototype : IExclusiveGameItemComponentPrototype<ICon
 {
 }
 
-public interface ICorpsePrototype : IExclusiveGameItemComponentPrototype<ICorpse>, IButcherablePrototype
+public interface ICorpsePrototype : IExclusiveGameItemComponentPrototype<ICorpse>, IBodyRemainsPrototype
 {
 }
 


### PR DESCRIPTION
## Summary
- Add the missing `IBodyRemainsPrototype` marker as an exclusive item-component prototype capability.
- Make `ICorpsePrototype` advertise `IBodyRemainsPrototype`, preserving the inherited `IButcherablePrototype` capability.
- Document that inherited public component capabilities need matching prototype markers.

## Validation
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 --filter FullyQualifiedName~GameItemComponentPrototypeExclusivityTests --verbosity normal`
- `git diff --check`