### PR TITLE
Fix animal fluid material name collisions

### DIFF
--- a/DatabaseSeeder Unit Tests/AnimalSeederTemplateTests.cs
+++ b/DatabaseSeeder Unit Tests/AnimalSeederTemplateTests.cs
@@ -48,6 +48,43 @@ public class AnimalSeederTemplateTests
         };
     }
 
+	private static Material Material(long id, string name, string description)
+	{
+		return new Material
+		{
+			Id = id,
+			Name = name,
+			MaterialDescription = description,
+			ResidueDesc = string.Empty,
+			ResidueColour = string.Empty
+		};
+	}
+
+	private static Liquid Liquid(long id, string name, string description, Material driedResidue)
+	{
+		return new Liquid
+		{
+			Id = id,
+			Name = name,
+			Description = description,
+			LongDescription = description,
+			TasteText = string.Empty,
+			VagueTasteText = string.Empty,
+			SmellText = string.Empty,
+			VagueSmellText = string.Empty,
+			DisplayColour = string.Empty,
+			DampDescription = string.Empty,
+			WetDescription = string.Empty,
+			DrenchedDescription = string.Empty,
+			DampShortDescription = string.Empty,
+			WetShortDescription = string.Empty,
+			DrenchedShortDescription = string.Empty,
+			SurfaceReactionInfo = string.Empty,
+			DriedResidue = driedResidue,
+			DriedResidueId = driedResidue.Id
+		};
+	}
+
     private static void SeedAnimalAiPrerequisiteProgs(FuturemudDatabaseContext context)
     {
         context.FutureProgs.AddRange(
@@ -285,12 +322,115 @@ public class AnimalSeederTemplateTests
             "Drink satiation maxima should preserve the intended cadence before becoming parched.");
     }
 
+	private static void AssertNoDuplicateNames(IEnumerable<string> names, string label)
+	{
+		var duplicates = names
+			.GroupBy(x => x, StringComparer.OrdinalIgnoreCase)
+			.Where(x => x.Count() > 1)
+			.Select(x => x.Key)
+			.OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+			.ToList();
+
+		Assert.AreEqual(0, duplicates.Count,
+			$"Generated animal {label} names should be unique. Duplicates: {string.Join(", ", duplicates)}");
+	}
+
     [TestMethod]
     public void ValidateTemplateCatalogForTesting_CurrentCatalog_HasNoIssues()
     {
         IReadOnlyList<string> issues = AnimalSeeder.ValidateTemplateCatalogForTesting();
         Assert.AreEqual(0, issues.Count, string.Join("\n", issues));
     }
+
+	[TestMethod]
+	public void RaceTemplatesForTesting_SharedAdjectives_GenerateUniqueFluidNames()
+	{
+		var sharedAdjectives = AnimalSeeder.RaceTemplatesForTesting.Values
+			.GroupBy(x => x.Adjective, StringComparer.OrdinalIgnoreCase)
+			.Where(x => x.Count() > 1)
+			.ToDictionary(x => x.Key, x => x.Select(y => y.Name).ToList(), StringComparer.OrdinalIgnoreCase);
+
+		Assert.IsTrue(sharedAdjectives.ContainsKey("Macropod"),
+			"Macropod remains a shared adjective and should be covered by the generated-name invariant.");
+		Assert.IsTrue(sharedAdjectives.ContainsKey("Canine"),
+			"Canine remains a shared adjective and should be covered by the generated-name invariant.");
+
+		AssertNoDuplicateNames(
+			AnimalSeeder.RaceTemplatesForTesting.Keys.Select(AnimalSeeder.RaceBloodMaterialNameForTesting),
+			"blood residue material");
+		AssertNoDuplicateNames(
+			AnimalSeeder.RaceTemplatesForTesting.Keys.Select(AnimalSeeder.RaceBloodLiquidNameForTesting),
+			"blood liquid");
+		AssertNoDuplicateNames(
+			AnimalSeeder.RaceTemplatesForTesting.Values
+				.Where(x => x.Sweats)
+				.Select(x => AnimalSeeder.RaceSweatMaterialNameForTesting(x.Name)),
+			"sweat residue material");
+		AssertNoDuplicateNames(
+			AnimalSeeder.RaceTemplatesForTesting.Values
+				.Where(x => x.Sweats)
+				.Select(x => AnimalSeeder.RaceSweatLiquidNameForTesting(x.Name)),
+			"sweat liquid");
+	}
+
+	[TestMethod]
+	public void RepairLegacyAnimalFluidNames_RenamesSharedAdjectiveRowsForExistingCatalogues()
+	{
+		using FuturemudDatabaseContext context = BuildExpandedAnimalCatalogueContext();
+		long nextMaterialId = 1;
+		long nextLiquidId = 1;
+
+		foreach ((string RaceName, string Adjective) in new[]
+		         {
+			         ("Kangaroo", "Macropod"),
+			         ("Wallaby", "Macropod"),
+			         ("Dog", "Canine"),
+			         ("Dingo", "Canine")
+		         })
+		{
+			var bloodResidue = Material(nextMaterialId++, $"dried {Adjective.ToLowerInvariant()} blood", "dried blood");
+			var sweatResidue = Material(nextMaterialId++, $"dried {Adjective.ToLowerInvariant()} sweat", "dried sweat");
+			var blood = Liquid(nextLiquidId++, $"{Adjective} Blood", "blood", bloodResidue);
+			var sweat = Liquid(nextLiquidId++, $"{Adjective} Sweat", "sweat", sweatResidue);
+			context.Materials.AddRange(bloodResidue, sweatResidue);
+			context.Liquids.AddRange(blood, sweat);
+
+			Race race = context.Races.Single(x => x.Name == RaceName);
+			race.BloodLiquid = blood;
+			race.BloodLiquidId = blood.Id;
+			race.SweatLiquid = sweat;
+			race.SweatLiquidId = sweat.Id;
+		}
+
+		context.SaveChanges();
+
+		Assert.IsTrue(AnimalSeeder.HasLegacyAnimalFluidNamesForTesting(context),
+			"The legacy adjective-keyed rows should be detected as stock catalogue drift.");
+
+		AnimalSeeder.RepairLegacyAnimalFluidNamesForTesting(context);
+
+		Assert.IsFalse(AnimalSeeder.HasLegacyAnimalFluidNamesForTesting(context),
+			"The repair should leave the stock animal fluid keys in their current race-specific form.");
+		foreach (string raceName in new[] { "Kangaroo", "Wallaby", "Dog", "Dingo" })
+		{
+			string bloodLiquidName = AnimalSeeder.RaceBloodLiquidNameForTesting(raceName);
+			string sweatLiquidName = AnimalSeeder.RaceSweatLiquidNameForTesting(raceName);
+			string bloodMaterialName = AnimalSeeder.RaceBloodMaterialNameForTesting(raceName);
+			string sweatMaterialName = AnimalSeeder.RaceSweatMaterialNameForTesting(raceName);
+
+			Assert.IsTrue(context.Liquids.Any(x => x.Name == bloodLiquidName));
+			Assert.IsTrue(context.Liquids.Any(x => x.Name == sweatLiquidName));
+			Assert.IsTrue(context.Materials.Any(x =>
+				x.Name == bloodMaterialName &&
+				x.MaterialDescription == "dried blood"));
+			Assert.IsTrue(context.Materials.Any(x =>
+				x.Name == sweatMaterialName &&
+				x.MaterialDescription == "dried sweat"));
+		}
+
+		AssertNoDuplicateNames(context.Materials.Select(x => x.Name), "material");
+		AssertNoDuplicateNames(context.Liquids.Select(x => x.Name), "liquid");
+	}
 
     [TestMethod]
     public void AnimalAIRecommendations_CoverEverySeededAnimalRace()

--- a/DatabaseSeeder/Seeders/AnimalSeeder.Backfill.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.Backfill.cs
@@ -43,6 +43,11 @@ public partial class AnimalSeeder
 			return true;
 		}
 
+		if (HasLegacyAnimalFluidNames(context))
+		{
+			return true;
+		}
+
 		Race? beetleRace = context.Races.FirstOrDefault(x => x.Name == "Beetle");
 		if (beetleRace is not null && context.BodyProtos.FirstOrDefault(x => x.Id == beetleRace.BaseBodyId)?.Name != "Beetle")
 		{
@@ -57,6 +62,7 @@ public partial class AnimalSeeder
 		SetupHeightWeightModels();
 		SetupAttacks(false);
 		RefreshExistingAnimalBaseBodies();
+		RepairLegacyAnimalFluidNames(_context);
 
 		Dictionary<string, BodyProto> bodyLookup = EnsureBackfillAnimalBodies();
 		MigrateBeetleRace(bodyLookup["Beetle"]);

--- a/DatabaseSeeder/Seeders/AnimalSeeder.FluidNames.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.FluidNames.cs
@@ -1,0 +1,171 @@
+#nullable enable
+
+using MudSharp.Database;
+using MudSharp.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DatabaseSeeder.Seeders;
+
+public partial class AnimalSeeder
+{
+	internal static string RaceBloodMaterialNameForTesting(string raceName) => GetRaceBloodMaterialName(raceName);
+	internal static string RaceSweatMaterialNameForTesting(string raceName) => GetRaceSweatMaterialName(raceName);
+	internal static string RaceBloodLiquidNameForTesting(string raceName) => GetRaceBloodLiquidName(raceName);
+	internal static string RaceSweatLiquidNameForTesting(string raceName) => GetRaceSweatLiquidName(raceName);
+	internal static bool HasLegacyAnimalFluidNamesForTesting(FuturemudDatabaseContext context) =>
+		HasLegacyAnimalFluidNames(context);
+	internal static void RepairLegacyAnimalFluidNamesForTesting(FuturemudDatabaseContext context) =>
+		RepairLegacyAnimalFluidNames(context);
+
+	private static string GetRaceBloodMaterialName(string raceName) => $"dried {raceName.ToLowerInvariant()} blood";
+	private static string GetRaceSweatMaterialName(string raceName) => $"dried {raceName.ToLowerInvariant()} sweat";
+	private static string GetRaceBloodLiquidName(string raceName) => $"{raceName} Blood";
+	private static string GetRaceSweatLiquidName(string raceName) => $"{raceName} Sweat";
+
+	private static string GetLegacyRaceBloodMaterialName(AnimalRaceTemplate template) =>
+		$"dried {template.Adjective.ToLowerInvariant()} blood";
+
+	private static string GetLegacyRaceSweatMaterialName(AnimalRaceTemplate template) =>
+		$"dried {template.Adjective.ToLowerInvariant()} sweat";
+
+	private static string GetLegacyRaceBloodLiquidName(AnimalRaceTemplate template) => $"{template.Adjective} Blood";
+	private static string GetLegacyRaceSweatLiquidName(AnimalRaceTemplate template) => $"{template.Adjective} Sweat";
+
+	private static bool HasLegacyAnimalFluidNames(FuturemudDatabaseContext context)
+	{
+		var racesByName = context.Races
+			.ToDictionary(x => x.Name, x => x, StringComparer.OrdinalIgnoreCase);
+		var liquidsById = context.Liquids
+			.ToDictionary(x => x.Id);
+		var materialsById = context.Materials
+			.ToDictionary(x => x.Id);
+
+		return RaceTemplates.Values.Any(template =>
+			racesByName.TryGetValue(template.Name, out var race) &&
+			(HasLegacyLiquidName(
+					race.BloodLiquidId,
+					GetRaceBloodLiquidName(template.Name),
+					GetLegacyRaceBloodLiquidName(template),
+					GetRaceBloodMaterialName(template.Name),
+					GetLegacyRaceBloodMaterialName(template)) ||
+			 (template.Sweats &&
+			  HasLegacyLiquidName(
+				  race.SweatLiquidId,
+				  GetRaceSweatLiquidName(template.Name),
+				  GetLegacyRaceSweatLiquidName(template),
+				  GetRaceSweatMaterialName(template.Name),
+				  GetLegacyRaceSweatMaterialName(template)))));
+
+		bool HasLegacyLiquidName(
+			long? liquidId,
+			string expectedLiquidName,
+			string legacyLiquidName,
+			string expectedResidueName,
+			string legacyResidueName)
+		{
+			if (legacyLiquidName.Equals(expectedLiquidName, StringComparison.OrdinalIgnoreCase) &&
+			    legacyResidueName.Equals(expectedResidueName, StringComparison.OrdinalIgnoreCase))
+			{
+				return false;
+			}
+
+			if (liquidId is null || !liquidsById.TryGetValue(liquidId.Value, out var liquid))
+			{
+				return false;
+			}
+
+			if (!legacyLiquidName.Equals(expectedLiquidName, StringComparison.OrdinalIgnoreCase) &&
+			    liquid.Name.Equals(legacyLiquidName, StringComparison.OrdinalIgnoreCase))
+			{
+				return true;
+			}
+
+			return !legacyResidueName.Equals(expectedResidueName, StringComparison.OrdinalIgnoreCase) &&
+			       liquid.DriedResidueId is not null &&
+			       materialsById.TryGetValue(liquid.DriedResidueId.Value, out var residue) &&
+			       residue.Name.Equals(legacyResidueName, StringComparison.OrdinalIgnoreCase);
+		}
+	}
+
+	private static void RepairLegacyAnimalFluidNames(FuturemudDatabaseContext context)
+	{
+		var racesByName = context.Races
+			.ToDictionary(x => x.Name, x => x, StringComparer.OrdinalIgnoreCase);
+		var liquids = context.Liquids.ToList();
+		var liquidsById = liquids
+			.ToDictionary(x => x.Id);
+		var materials = context.Materials.ToList();
+		var materialsById = materials
+			.ToDictionary(x => x.Id);
+		var dirty = false;
+
+		foreach (var template in RaceTemplates.Values)
+		{
+			if (!racesByName.TryGetValue(template.Name, out var race))
+			{
+				continue;
+			}
+
+			RepairLiquidName(
+				race.BloodLiquidId,
+				GetRaceBloodLiquidName(template.Name),
+				GetLegacyRaceBloodLiquidName(template),
+				GetRaceBloodMaterialName(template.Name),
+				GetLegacyRaceBloodMaterialName(template));
+
+			if (template.Sweats)
+			{
+				RepairLiquidName(
+					race.SweatLiquidId,
+					GetRaceSweatLiquidName(template.Name),
+					GetLegacyRaceSweatLiquidName(template),
+					GetRaceSweatMaterialName(template.Name),
+					GetLegacyRaceSweatMaterialName(template));
+			}
+		}
+
+		if (dirty)
+		{
+			context.SaveChanges();
+		}
+
+		void RepairLiquidName(
+			long? liquidId,
+			string expectedLiquidName,
+			string legacyLiquidName,
+			string expectedResidueName,
+			string legacyResidueName)
+		{
+			if (liquidId is null || !liquidsById.TryGetValue(liquidId.Value, out var liquid))
+			{
+				return;
+			}
+
+			if (!legacyLiquidName.Equals(expectedLiquidName, StringComparison.OrdinalIgnoreCase) &&
+			    liquid.Name.Equals(legacyLiquidName, StringComparison.OrdinalIgnoreCase) &&
+			    liquids.All(x => x.Id == liquid.Id ||
+			                     !x.Name.Equals(expectedLiquidName, StringComparison.OrdinalIgnoreCase)))
+			{
+				liquid.Name = expectedLiquidName;
+				dirty = true;
+			}
+
+			if (liquid.DriedResidueId is null ||
+			    !materialsById.TryGetValue(liquid.DriedResidueId.Value, out var residue))
+			{
+				return;
+			}
+
+			if (!legacyResidueName.Equals(expectedResidueName, StringComparison.OrdinalIgnoreCase) &&
+			    residue.Name.Equals(legacyResidueName, StringComparison.OrdinalIgnoreCase) &&
+			    materials.All(x => x.Id == residue.Id ||
+			                       !x.Name.Equals(expectedResidueName, StringComparison.OrdinalIgnoreCase)))
+			{
+				residue.Name = expectedResidueName;
+				dirty = true;
+			}
+		}
+	}
+}

--- a/DatabaseSeeder/Seeders/AnimalSeeder.TemplateUtilities.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.TemplateUtilities.cs
@@ -481,6 +481,27 @@ public partial class AnimalSeeder
             "treehaul"
         };
 
+		AddDuplicateGeneratedFluidKeyIssues(
+			RaceTemplates.Values.Select(x => (x.Name, Key: GetRaceBloodMaterialName(x.Name))),
+			"blood residue material",
+			issues);
+		AddDuplicateGeneratedFluidKeyIssues(
+			RaceTemplates.Values.Select(x => (x.Name, Key: GetRaceBloodLiquidName(x.Name))),
+			"blood liquid",
+			issues);
+		AddDuplicateGeneratedFluidKeyIssues(
+			RaceTemplates.Values
+				.Where(x => x.Sweats)
+				.Select(x => (x.Name, Key: GetRaceSweatMaterialName(x.Name))),
+			"sweat residue material",
+			issues);
+		AddDuplicateGeneratedFluidKeyIssues(
+			RaceTemplates.Values
+				.Where(x => x.Sweats)
+				.Select(x => (x.Name, Key: GetRaceSweatLiquidName(x.Name))),
+			"sweat liquid",
+			issues);
+
         foreach ((string? raceName, AnimalRaceTemplate? template) in RaceTemplates)
         {
             if (string.IsNullOrWhiteSpace(template.CombatStrategyKey))
@@ -705,6 +726,18 @@ public partial class AnimalSeeder
                 issues.Add($"Race {raceName} has a blank short or full description variant.");
             }
         }
+
+		static void AddDuplicateGeneratedFluidKeyIssues(
+			IEnumerable<(string RaceName, string Key)> generatedKeys,
+			string keyType,
+			List<string> issues)
+		{
+			foreach (var group in generatedKeys.GroupBy(x => x.Key, StringComparer.OrdinalIgnoreCase).Where(x => x.Count() > 1))
+			{
+				issues.Add(
+					$"Generated animal {keyType} name {group.Key} is reused by {string.Join(", ", group.Select(x => x.RaceName))}.");
+			}
+		}
     }
 
     private void SeedAnimalRaces(IEnumerable<AnimalRaceTemplate> templates, params (string Key, BodyProto Body)[] bodies)

--- a/DatabaseSeeder/Seeders/AnimalSeeder.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.cs
@@ -4013,7 +4013,7 @@ Warning: There is an enormous amount of data contained in this seeder, and it ma
 
         Material driedBlood = new()
         {
-            Name = $"dried {adjective.ToLowerInvariant()} blood",
+            Name = GetRaceBloodMaterialName(name),
             MaterialDescription = "dried blood",
             Density = 1520,
             Organic = true,
@@ -4040,7 +4040,7 @@ Warning: There is an enormous amount of data contained in this seeder, and it ma
         _context.Materials.Add(driedBlood);
         Liquid bloodLiquid = new()
         {
-            Name = $"{adjective} Blood",
+            Name = GetRaceBloodLiquidName(name),
             Description = "blood",
             LongDescription = "a virtually opaque dark red fluid",
             TasteText = "It has a sharply metallic, umami taste",
@@ -4083,7 +4083,7 @@ Warning: There is an enormous amount of data contained in this seeder, and it ma
         {
             Material driedSweat = new()
             {
-                Name = $"dried {adjective.ToLowerInvariant()} sweat",
+                Name = GetRaceSweatMaterialName(name),
                 MaterialDescription = "dried sweat",
                 Density = 1520,
                 Organic = true,
@@ -4110,7 +4110,7 @@ Warning: There is an enormous amount of data contained in this seeder, and it ma
             _context.Materials.Add(driedSweat);
             sweat = new Liquid
             {
-                Name = $"{adjective} Sweat",
+                Name = GetRaceSweatLiquidName(name),
                 Description = "sweat",
                 LongDescription = "a relatively clear, translucent fluid that smells strongly of wild animal odor",
                 TasteText = "It tastes like a pungent, salty lick of someone's underarms",


### PR DESCRIPTION
## Summary
- Generate animal blood and sweat material/liquid storage names from the race name instead of the shared adjective.
- Detect and repair legacy adjective-keyed animal fluid rows on rerun.
- Add broad animal catalogue tests covering generated blood/sweat material and liquid name uniqueness, including Macropod and Canine shared-adjective cases.

## Validation
- dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510
- git diff --check -- DatabaseSeeder\Seeders\AnimalSeeder.cs DatabaseSeeder\Seeders\AnimalSeeder.Backfill.cs DatabaseSeeder\Seeders\AnimalSeeder.TemplateUtilities.cs DatabaseSeeder\Seeders\AnimalSeeder.FluidNames.cs " DatabaseSeeder Unit Tests\AnimalSeederTemplateTests.cs\