### PR TITLE
Add item prototype unique names and builder notes

### DIFF
--- a/Design Documents/Items/Item_System_Content_Workflows.md
+++ b/Design Documents/Items/Item_System_Content_Workflows.md
@@ -96,8 +96,10 @@ Because component prototypes are revisioned content, do not think of them as raw
 ### Create or edit an item prototype
 Use:
 - `item edit new`
-- `item edit <id>`
-- `item clone <id>`
+- `item edit <id|unique name>`
+- `item clone <id|unique name>`
+
+Item prototype lookup prefers numeric ids, then exact `UniqueName`, then the legacy noun/name matching that older builder commands expect. Unique names are optional, case-insensitively unique among active revisions, and cannot be entirely numeric.
 
 ### Attach or detach components
 Use:
@@ -115,6 +117,12 @@ Commonly relevant commands include:
 - `item set ldesc`
 - `item set desc`
 - `item set suggestdesc`
+- `item set unique <name>`
+- `item set unique clear`
+- `item set comment <text>`
+- `item set comment append [<text>]`
+- `item set comment edit`
+- `item set comment clear`
 - `item set size`
 - `item set weight`
 - `item set material`
@@ -135,11 +143,16 @@ These matter because many component features only make sense in combination with
 - morph and destroyed settings affect component replacement behaviour
 - registers and on-load progs can feed variable-style components
 - skinnability affects how content can be customised by players
+- unique names give builders, scripts, and content references a stable lookup key that is not the item noun
+- builder comments preserve design intent, associations, and maintenance notes without changing runtime behaviour
+
+### Listing and searching item prototypes
+`item list` includes the unique name column. The `+<text>` and `-<text>` filters match ordinary keywords and noun/name text, and also search unique names and builder comments. Use `comment:<text>` to search builder comments directly.
 
 ## Loading and Testing Live Items
 ### Manual load workflow
 Use:
-- `item load [<quantity>] <id> [<extra args>]`
+- `item load [<quantity>] <id|unique name> [<extra args>]`
 
 This is the normal developer validation path for checking whether a prototype, its components, and its runtime behaviour work together.
 

--- a/Design Documents/Items/Item_System_Presentation_and_Integration.md
+++ b/Design Documents/Items/Item_System_Presentation_and_Integration.md
@@ -12,13 +12,17 @@ The focus is on:
 ## Description Model
 ### Item-level descriptions
 Item prototypes provide the base descriptive layer:
+- builder-visible unique lookup name
 - noun
 - short description
 - full description
 - optional long description override
 - extra descriptions gated by progs
+- builder comment metadata
 
 Skins can override several of these presentation values without replacing the underlying item behaviour.
+
+`item show` displays the prototype's unique name and builder comment alongside the runtime-facing description fields. `item list` and item review tables include the unique name to make active templates easier to distinguish when nouns are intentionally generic. Builder comments are intentionally visible only in builder/admin workflows and are searchable with `comment:<text>` or the normal item-list text filters.
 
 ### Component-driven description decoration
 Components can decorate item descriptions by overriding:

--- a/Design Documents/Items/Item_System_Runtime_Model.md
+++ b/Design Documents/Items/Item_System_Runtime_Model.md
@@ -42,6 +42,7 @@ When adding a new item event, keep the `EventInfoAttribute` metadata in `FutureM
 
 It owns the reusable definition of:
 - name and descriptive text
+- optional builder-facing unique lookup name and builder comment
 - base quality, weight, material, and size
 - health strategy
 - default registers
@@ -53,6 +54,10 @@ It owns the reusable definition of:
 - default `PlanarData` for corporeality and metaphysical visibility
 
 Prototype methods like `CreateNew(...)` instantiate a `GameItem`, create one runtime component per attached component prototype, apply variable initialisation, and execute on-load progs.
+
+`UniqueName` is a nullable, builder-facing identifier for the item template. It exists because the inherited `Name` property is the item noun in most builder workflows. Nonblank unique names are trimmed, must not be entirely numeric, and must be unique case-insensitively among active builder-visible revisions: `Current`, `PendingRevision`, and `UnderDesign`. Historical `Rejected`, `Revised`, and `Obsolete` revisions may duplicate active or historical unique names. Lookup code resolves item prototypes by numeric id first, exact unique name second, and legacy noun/name matching last.
+
+`BuilderNotes` is nullable free-form metadata for builders. It is displayed in `item show`, copied through revisions and clones, and searchable through item list filters, but it does not affect live item behaviour.
 
 If `PlanarData` is null or invalid, the item prototype resolves as ordinary Prime Material corporeal matter. Builders can use the item prototype `planar` command to make special items present on another plane, visible-only to another plane, or fully noncorporeal.
 

--- a/FutureMUDLibrary Unit Tests/GameItemProtoLookupExtensionsTests.cs
+++ b/FutureMUDLibrary Unit Tests/GameItemProtoLookupExtensionsTests.cs
@@ -1,0 +1,93 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Framework;
+using MudSharp.Framework.Revision;
+using MudSharp.GameItems;
+using System.Collections.Generic;
+using System.Linq;
+
+#nullable enable
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class GameItemProtoLookupExtensionsTests
+{
+	[TestMethod]
+	public void UniqueNameLookupPrefersExactUniqueNameBeforeLegacyName()
+	{
+		var unique = Proto(1, 0, RevisionStatus.Current, "widget", "alpha");
+		var legacy = Proto(2, 0, RevisionStatus.Current, "alpha", null);
+
+		var result = new[] { legacy, unique }.GetByIdOrUniqueNameOrName("alpha");
+
+		Assert.AreSame(unique, result);
+	}
+
+	[TestMethod]
+	public void UniqueNameLookupIsCaseInsensitiveAndActiveOnly()
+	{
+		var historical = Proto(1, 0, RevisionStatus.Obsolete, "old", "template-key");
+		var current = Proto(2, 0, RevisionStatus.Current, "new", "Template-Key");
+
+		var result = new[] { historical, current }.FindByUniqueName("template-key");
+
+		Assert.AreSame(current, result);
+	}
+
+	[TestMethod]
+	public void UniqueNameValidationRejectsAllNumericNames()
+	{
+		Assert.IsFalse(GameItemProtoLookupExtensions.IsValidUniqueName("12345"));
+		Assert.IsTrue(GameItemProtoLookupExtensions.IsValidUniqueName("template-12345"));
+		Assert.IsTrue(GameItemProtoLookupExtensions.IsValidUniqueName("  "));
+	}
+
+	[TestMethod]
+	public void ActiveConflictIgnoresSameIdAndHistoricalRows()
+	{
+		var sameId = Proto(1, 1, RevisionStatus.UnderDesign, "same", "shared-key");
+		var obsolete = Proto(2, 0, RevisionStatus.Obsolete, "old", "shared-key");
+		var current = Proto(3, 0, RevisionStatus.Current, "current", "shared-key");
+
+		var protos = new[] { sameId, obsolete, current };
+
+		Assert.IsNull(new[] { sameId, obsolete }.GetActiveUniqueNameConflict("shared-key", 1));
+		Assert.IsNull(new[] { obsolete }.GetActiveUniqueNameConflict("shared-key", 99));
+		Assert.AreSame(current, protos.GetActiveUniqueNameConflict("shared-key", 1));
+	}
+
+	[TestMethod]
+	public void RevisableLookupUsesDifferentPriorityForEditing()
+	{
+		var current = Proto(1, 0, RevisionStatus.Current, "tool", "tool-key");
+		var underDesign = Proto(1, 1, RevisionStatus.UnderDesign, "tool", "tool-key");
+
+		var protos = new[] { current, underDesign };
+
+		Assert.AreSame(current, protos.GetByIdOrNameRevisable("tool-key"));
+		Assert.AreSame(underDesign, protos.GetByIdOrNameRevisableForEditing("tool-key"));
+	}
+
+	[TestMethod]
+	public void BuilderSearchTextMatchesUniqueNameAndBuilderNotes()
+	{
+		var proto = Proto(1, 0, RevisionStatus.Current, "tool", "clockwork-key", "Used by the clockwork quest.");
+
+		Assert.IsTrue(proto.HasBuilderSearchText("clockwork"));
+		Assert.IsTrue(proto.HasBuilderSearchText("quest"));
+		Assert.IsFalse(proto.HasBuilderSearchText("alchemy"));
+	}
+
+	private static IGameItemProto Proto(long id, int revision, RevisionStatus status, string name, string? uniqueName, string? builderNotes = null)
+	{
+		var proto = new Mock<IGameItemProto>();
+		proto.SetupGet(x => x.Id).Returns(id);
+		proto.SetupGet(x => x.RevisionNumber).Returns(revision);
+		proto.SetupGet(x => x.Status).Returns(status);
+		proto.SetupGet(x => x.Name).Returns(name);
+		proto.SetupGet(x => x.UniqueName).Returns(uniqueName);
+		proto.SetupGet(x => x.BuilderNotes).Returns(builderNotes);
+		return proto.Object;
+	}
+}

--- a/FutureMUDLibrary/Framework/CollectionExtensions.cs
+++ b/FutureMUDLibrary/Framework/CollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using JetBrains.Annotations;
 using MudSharp.Construction;
 using MudSharp.Framework.Revision;
+using MudSharp.GameItems;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -1138,6 +1139,14 @@ namespace MudSharp.Framework
         /// </returns>
         public static T? GetByIdOrNameRevisableForEditing<T>(this IEnumerable<T> items, string text) where T : IRevisableItem
         {
+            if (typeof(IGameItemProto).IsAssignableFrom(typeof(T)))
+            {
+                var match = items
+                            .Cast<IGameItemProto>()
+                            .GetByIdOrUniqueNameOrNameForEditing(text);
+                return match is null ? default : (T)(object)match;
+            }
+
             List<T> filteredItems;
             if (long.TryParse(text, out long id))
             {
@@ -1179,6 +1188,14 @@ namespace MudSharp.Framework
         /// </returns>
         public static T? GetByIdOrNameRevisable<T>(this IEnumerable<T> items, string text) where T : IRevisableItem
         {
+            if (typeof(IGameItemProto).IsAssignableFrom(typeof(T)))
+            {
+                var match = items
+                            .Cast<IGameItemProto>()
+                            .GetByIdOrUniqueNameOrNameRevisable(text);
+                return match is null ? default : (T)(object)match;
+            }
+
             List<T> filteredItems;
             if (long.TryParse(text, out long id))
             {

--- a/FutureMUDLibrary/GameItems/GameItemProtoLookupExtensions.cs
+++ b/FutureMUDLibrary/GameItems/GameItemProtoLookupExtensions.cs
@@ -1,0 +1,152 @@
+using MudSharp.Framework.Revision;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+#nullable enable
+
+namespace MudSharp.GameItems;
+
+public static class GameItemProtoLookupExtensions
+{
+	public static string? NormaliseUniqueName(string? value)
+	{
+		return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+	}
+
+	public static bool IsValidUniqueName(string? value)
+	{
+		var normalised = NormaliseUniqueName(value);
+		return normalised is null || !long.TryParse(normalised, out _);
+	}
+
+	public static bool IsActiveForUniqueName(this RevisionStatus status)
+	{
+		return status == RevisionStatus.Current ||
+		       status == RevisionStatus.PendingRevision ||
+		       status == RevisionStatus.UnderDesign;
+	}
+
+	public static IGameItemProto? FindByUniqueName(this IEnumerable<IGameItemProto> protos, string? uniqueName, bool activeOnly = true)
+	{
+		var normalised = NormaliseUniqueName(uniqueName);
+		if (normalised is null)
+		{
+			return null;
+		}
+
+		var matches = protos
+		              .Where(x => x.UniqueName?.Equals(normalised, StringComparison.InvariantCultureIgnoreCase) == true);
+		if (activeOnly)
+		{
+			matches = matches.Where(x => x.Status.IsActiveForUniqueName());
+		}
+
+		var list = matches.ToList();
+		return list.FirstOrDefault(x => x.Status == RevisionStatus.Current) ??
+		       list.FirstOrDefault(x => x.Status == RevisionStatus.PendingRevision || x.Status == RevisionStatus.UnderDesign) ??
+		       (list.Count > 0 ? list.OrderByDescending(x => x.RevisionNumber).First() : null);
+	}
+
+	public static IGameItemProto? GetByIdOrUniqueNameOrName(this IEnumerable<IGameItemProto> protos, string value, bool permitAbbreviations = true)
+	{
+		var list = protos.ToList();
+		if (long.TryParse(value, out var id))
+		{
+			return BestCurrentMatch(list.Where(x => x.Id == id));
+		}
+
+		return list.FindByUniqueName(value) ?? GetByLegacyName(list, value, permitAbbreviations, preferEditing: false);
+	}
+
+	public static IGameItemProto? GetByIdOrUniqueNameOrNameForEditing(this IEnumerable<IGameItemProto> protos, string value)
+	{
+		var list = protos.ToList();
+		if (long.TryParse(value, out var id))
+		{
+			return BestEditingMatch(list.Where(x => x.Id == id));
+		}
+
+		return FindByUniqueNameForEditing(list, value) ?? GetByLegacyName(list, value, permitAbbreviations: true, preferEditing: true);
+	}
+
+	public static IGameItemProto? GetByIdOrUniqueNameOrNameRevisable(this IEnumerable<IGameItemProto> protos, string value)
+	{
+		return protos.GetByIdOrUniqueNameOrName(value);
+	}
+
+	public static IGameItemProto? GetActiveUniqueNameConflict(this IEnumerable<IGameItemProto> protos, string? uniqueName, long ownId)
+	{
+		var normalised = NormaliseUniqueName(uniqueName);
+		if (normalised is null)
+		{
+			return null;
+		}
+
+		return protos
+		       .Where(x => x.Id != ownId)
+		       .Where(x => x.Status.IsActiveForUniqueName())
+		       .FirstOrDefault(x => x.UniqueName?.Equals(normalised, StringComparison.InvariantCultureIgnoreCase) == true);
+	}
+
+	public static IEnumerable<IGameItemProto> WithBuilderText(this IEnumerable<IGameItemProto> protos, string text)
+	{
+		return protos.Where(x => x.HasBuilderSearchText(text));
+	}
+
+	public static bool HasBuilderSearchText(this IGameItemProto proto, string text)
+	{
+		return proto.UniqueName?.Contains(text, StringComparison.InvariantCultureIgnoreCase) == true ||
+		       proto.BuilderNotes?.Contains(text, StringComparison.InvariantCultureIgnoreCase) == true;
+	}
+
+	private static IGameItemProto? FindByUniqueNameForEditing(IEnumerable<IGameItemProto> protos, string value)
+	{
+		var normalised = NormaliseUniqueName(value);
+		if (normalised is null)
+		{
+			return null;
+		}
+
+		var matches = protos
+		              .Where(x => x.Status.IsActiveForUniqueName())
+		              .Where(x => x.UniqueName?.Equals(normalised, StringComparison.InvariantCultureIgnoreCase) == true)
+		              .ToList();
+		return matches.FirstOrDefault(x => x.Status == RevisionStatus.UnderDesign) ??
+		       matches.FirstOrDefault(x => x.Status == RevisionStatus.PendingRevision) ??
+		       matches.FirstOrDefault(x => x.Status == RevisionStatus.Current) ??
+		       (matches.Count > 0 ? matches.OrderByDescending(x => x.RevisionNumber).First() : null);
+	}
+
+	private static IGameItemProto? GetByLegacyName(IEnumerable<IGameItemProto> protos, string value, bool permitAbbreviations, bool preferEditing)
+	{
+		var list = protos
+		           .Where(x => x.Name.Equals(value, StringComparison.InvariantCultureIgnoreCase))
+		           .ToList();
+		if (permitAbbreviations && list.Count == 0)
+		{
+			list = protos
+			       .Where(x => x.Name.StartsWith(value, StringComparison.InvariantCultureIgnoreCase))
+			       .ToList();
+		}
+
+		return preferEditing ? BestEditingMatch(list) : BestCurrentMatch(list);
+	}
+
+	private static IGameItemProto? BestCurrentMatch(IEnumerable<IGameItemProto> protos)
+	{
+		var list = protos.ToList();
+		return list.FirstOrDefault(x => x.Status == RevisionStatus.Current) ??
+		       list.FirstOrDefault(x => x.Status == RevisionStatus.PendingRevision || x.Status == RevisionStatus.UnderDesign) ??
+		       (list.Count > 0 ? list.OrderByDescending(x => x.RevisionNumber).First() : null);
+	}
+
+	private static IGameItemProto? BestEditingMatch(IEnumerable<IGameItemProto> protos)
+	{
+		var list = protos.ToList();
+		return list.FirstOrDefault(x => x.Status == RevisionStatus.UnderDesign) ??
+		       list.FirstOrDefault(x => x.Status == RevisionStatus.PendingRevision) ??
+		       list.FirstOrDefault(x => x.Status == RevisionStatus.Current) ??
+		       (list.Count > 0 ? list.OrderByDescending(x => x.RevisionNumber).First() : null);
+	}
+}

--- a/FutureMUDLibrary/GameItems/IGameItemProto.cs
+++ b/FutureMUDLibrary/GameItems/IGameItemProto.cs
@@ -17,6 +17,8 @@ namespace MudSharp.GameItems
     public interface IGameItemProto : IEditableRevisableItem, IHaveTags, IHavePlanarPresence
     {
         IHealthStrategy HealthStrategy { get; }
+        string? UniqueName { get; }
+        string? BuilderNotes { get; }
         string ShortDescription { get; }
         string FullDescription { get; }
         SizeCategory Size { get; }

--- a/MudSharpCore Unit Tests/EditableItemReviewProposalTests.cs
+++ b/MudSharpCore Unit Tests/EditableItemReviewProposalTests.cs
@@ -1,0 +1,61 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Accounts;
+using MudSharp.Character;
+using MudSharp.Framework;
+using MudSharp.Framework.Revision;
+using MudSharp.GameItems;
+using MudSharp.PerceptionEngine;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class EditableItemReviewProposalTests
+{
+	[TestMethod]
+	public void Accept_SubmittedItemCannotSubmit_DoesNotObsoleteCurrentRevision()
+	{
+		var current = CreateProto(10, 0, RevisionStatus.Current, canSubmit: true, "current item", "");
+		var pending = CreateProto(10, 1, RevisionStatus.PendingRevision, canSubmit: false, "pending item",
+			"duplicate unique name");
+		var itemProtos = new RevisableAll<IGameItemProto>();
+		itemProtos.Add(current.Object);
+		itemProtos.Add(pending.Object);
+
+		var output = new Mock<IOutputHandler>();
+		var actor = new Mock<ICharacter>();
+		var account = new Mock<IAccount>();
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.ItemProtos).Returns(itemProtos);
+		actor.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		actor.SetupGet(x => x.OutputHandler).Returns(output.Object);
+		actor.SetupGet(x => x.Account).Returns(account.Object);
+
+		var proposal = new EditableItemReviewProposal<IGameItemProto>(actor.Object, [pending.Object]);
+
+		proposal.Accept("approval");
+
+		pending.Verify(x => x.CanSubmit(), Times.Once);
+		pending.Verify(x => x.WhyCannotSubmit(), Times.Once);
+		current.Verify(x => x.ChangeStatus(It.IsAny<RevisionStatus>(), It.IsAny<string>(), It.IsAny<IAccount>()),
+			Times.Never);
+		pending.Verify(x => x.ChangeStatus(It.IsAny<RevisionStatus>(), It.IsAny<string>(), It.IsAny<IAccount>()),
+			Times.Never);
+		output.Verify(x => x.Send(It.Is<string>(text => text.Contains("duplicate unique name")), true, false),
+			Times.Once);
+	}
+
+	private static Mock<IGameItemProto> CreateProto(long id, int revision, RevisionStatus status, bool canSubmit,
+		string editHeader, string whyCannotSubmit)
+	{
+		var proto = new Mock<IGameItemProto>();
+		proto.SetupGet(x => x.Id).Returns(id);
+		proto.SetupGet(x => x.RevisionNumber).Returns(revision);
+		proto.SetupGet(x => x.Status).Returns(status);
+		proto.SetupGet(x => x.Name).Returns(editHeader);
+		proto.Setup(x => x.CanSubmit()).Returns(canSubmit);
+		proto.Setup(x => x.WhyCannotSubmit()).Returns(whyCannotSubmit);
+		proto.Setup(x => x.EditHeader()).Returns(editHeader);
+		return proto;
+	}
+}

--- a/MudSharpCore Unit Tests/GameItemHelperTests.cs
+++ b/MudSharpCore Unit Tests/GameItemHelperTests.cs
@@ -1,0 +1,45 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Commands.Helpers;
+using MudSharp.Framework;
+using MudSharp.Framework.Revision;
+using MudSharp.GameItems;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class GameItemHelperTests
+{
+	[TestMethod]
+	public void CustomSearch_CommentFilter_FiltersByBuilderNotes()
+	{
+		var matching = Proto("Clockwork calibration notes.");
+		var other = Proto("Alchemy preparation notes.");
+		List<IEditableRevisableItem> protos = [matching.Object, other.Object];
+
+		var result = EditableRevisableItemHelper.GameItemHelper.CustomSearch(
+			protos,
+			"comment:calibration",
+			new Mock<IFuturemud>().Object);
+
+		CollectionAssert.AreEqual(new[] { matching.Object }, result.Cast<IGameItemProto>().ToArray());
+	}
+
+	[TestMethod]
+	public void GetListTableHeaderFunc_ItemPrototype_IncludesUniqueName()
+	{
+		var header = EditableRevisableItemHelper.GameItemHelper.GetListTableHeaderFunc(new Mock<MudSharp.Character.ICharacter>().Object)
+		                                      .ToArray();
+
+		CollectionAssert.Contains(header, "Unique Name");
+	}
+
+	private static Mock<IGameItemProto> Proto(string builderNotes)
+	{
+		var proto = new Mock<IGameItemProto>();
+		proto.SetupGet(x => x.BuilderNotes).Returns(builderNotes);
+		return proto;
+	}
+}

--- a/MudSharpCore/Commands/Helpers/EditableRevisableItemHelper.cs
+++ b/MudSharpCore/Commands/Helpers/EditableRevisableItemHelper.cs
@@ -222,7 +222,8 @@ internal class EditableRevisableItemHelper
                            select
                                new[]
                                {
-                                   proto.Id.ToString(), proto.RevisionNumber.ToString(), proto.Name.Proper(),
+                                   proto.Id.ToString(), proto.RevisionNumber.ToString(), proto.UniqueName ?? "",
+                                   proto.Name.Proper(),
                                    proto.ShortDescription,
                                    proto.Keywords.ListToString(separator: " ", conjunction: "", twoItemJoiner: ""),
                                    FMDB.Context.Accounts.Find(proto.BuilderAccountID).Name, proto.BuilderComment ?? ""
@@ -230,18 +231,19 @@ internal class EditableRevisableItemHelper
                 }
             },
             GetReviewTableHeaderFunc =
-                character => new[] { "ID#", "Rev#", "Name", "Short Description", "Keywords", "Builder", "Comment" },
+                character => new[] { "ID#", "Rev#", "Unique Name", "Name", "Short Description", "Keywords", "Builder", "Comment" },
             GetListTableContentsFunc = (character, protos) => from proto in protos.OfType<IGameItemProto>()
                                                               select
                                                                   new[]
                                                                   {
                                                                       proto.Id.ToString(),
                                                                       proto.RevisionNumber.ToString(),
+                                                                      proto.UniqueName ?? "",
                                                                       proto.Name.Proper(),
                                                                       proto.ShortDescription,
                                                                       proto.Status.Describe()
                                                                   },
-            GetListTableHeaderFunc = character => new[] { "ID#", "Rev#", "Name", "Short Description", "Status" },
+            GetListTableHeaderFunc = character => new[] { "ID#", "Rev#", "Unique Name", "Name", "Short Description", "Status" },
             GetReviewProposalEffectFunc =
                 (protos, character) =>
                     new Accept(character,
@@ -256,6 +258,14 @@ internal class EditableRevisableItemHelper
                     List<ITag> tags = gameworld.Tags.FindMatchingTags(keyword);
                     return protos.OfType<IGameItemProto>()
                                  .Where(x => x.Tags.Any(y => tags.Any(z => y.IsA(z))))
+                                 .ToList<IEditableRevisableItem>();
+                }
+
+                if (keyword.StartsWith("comment:", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    keyword = keyword["comment:".Length..];
+                    return protos.OfType<IGameItemProto>()
+                                 .Where(x => x.BuilderNotes?.Contains(keyword, StringComparison.InvariantCultureIgnoreCase) == true)
                                  .ToList<IEditableRevisableItem>();
                 }
 
@@ -879,13 +889,8 @@ internal class EditableRevisableItemHelper
                     return;
                 }
 
-                if (!long.TryParse(input.PopSpeech(), out long protoid))
-                {
-                    actor.OutputHandler.Send("You must enter a valid id number for the item prototype.");
-                    return;
-                }
-
-                IGameItemProto proto = actor.Gameworld.ItemProtos.Get(protoid);
+                var protoText = input.PopSpeech();
+                IGameItemProto proto = actor.Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(protoText);
                 if (proto is null || (!actor.IsAdministrator() && !proto.PermitPlayerSkins))
                 {
                     actor.OutputHandler.Send(

--- a/MudSharpCore/Commands/Modules/BaseBuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/BaseBuilderModule.cs
@@ -566,7 +566,8 @@ If you do not wish to approve or decline, you may type {"abort edit".Colour(Teln
 
                         protos = protos.Where(x =>
                             x.HasKeyword(subcmd, character.Body, true) ||
-                            x.Name.Contains(subcmd, StringComparison.InvariantCultureIgnoreCase)).ToList();
+                            x.Name.Contains(subcmd, StringComparison.InvariantCultureIgnoreCase) ||
+                            x is IGameItemProto itemProto && itemProto.HasBuilderSearchText(subcmd)).ToList();
                         break;
                     }
 
@@ -581,7 +582,8 @@ If you do not wish to approve or decline, you may type {"abort edit".Colour(Teln
 
                         protos = protos.Where(x =>
                             !x.HasKeyword(subcmd, character.Body, true) &&
-                            !x.Name.Contains(subcmd, StringComparison.InvariantCultureIgnoreCase)).ToList();
+                            !x.Name.Contains(subcmd, StringComparison.InvariantCultureIgnoreCase) &&
+                            (x is not IGameItemProto itemProto || !itemProto.HasBuilderSearchText(subcmd))).ToList();
                         break;
                     }
 
@@ -930,30 +932,28 @@ If you do not wish to approve or decline, you may type {"abort edit".Colour(Teln
     protected static void Item_Load(ICharacter actor, StringStack input)
     {
         IGameItemProto proto;
-        int quantity;
-        if (!long.TryParse(input.PopSpeech(), out long value))
+        var quantity = 1;
+        var first = input.PopSpeech();
+        if (first.Length == 0)
         {
-            actor.OutputHandler.Send("What is the ID of the item you wish to load?");
+            actor.OutputHandler.Send("What is the ID or unique name of the item you wish to load?");
             return;
         }
 
-        if (!input.IsFinished && long.TryParse(input.Peek(), out long value2))
+        var targetText = first;
+        if (!input.IsFinished && int.TryParse(first, out var possibleQuantity) && possibleQuantity > 0)
         {
-            if (value <= 0)
+            var possibleTarget = input.PeekSpeech();
+            if (!possibleTarget.StartsWith("*") &&
+                !possibleTarget.Contains('=') &&
+                actor.Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(possibleTarget) is not null)
             {
-                actor.OutputHandler.Send("The quantity of items to load must be greater than 0.");
-                return;
+                quantity = possibleQuantity;
+                targetText = input.PopSpeech();
             }
+        }
 
-            proto = actor.Gameworld.ItemProtos.Get(value2);
-            quantity = (int)value;
-            input.PopSpeech();
-        }
-        else
-        {
-            proto = actor.Gameworld.ItemProtos.Get(value);
-            quantity = 1;
-        }
+        proto = actor.Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(targetText);
 
         if (proto == null)
         {

--- a/MudSharpCore/Commands/Modules/EconomyModule.cs
+++ b/MudSharpCore/Commands/Modules/EconomyModule.cs
@@ -4249,14 +4249,9 @@ Additionally, you can use the following shop admin subcommands:
 
         string text = ss.PopSpeech();
         IGameItemProto proto;
-        if (actor.IsAdministrator() && long.TryParse(text, out long value))
+        if (actor.IsAdministrator() && actor.Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(text) is { } itemProto)
         {
-            proto = actor.Gameworld.ItemProtos.Get(value);
-            if (proto == null)
-            {
-                actor.OutputHandler.Send("There is no such item prototype.");
-                return;
-            }
+            proto = itemProto;
         }
         else
         {

--- a/MudSharpCore/Commands/Modules/ItemBuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/ItemBuilderModule.cs
@@ -43,19 +43,20 @@ The valid sub-commands and their syntaxes are as follows:
 		#6mine#0 - only shows items you personally created
 		#6by <account>#0 - only shows items the nominated account created
 		#6reviewed <account>#0 - only shows items the nominated account has approved
-		#6+<keyword>#0 - only shows items with the nominated keyword
-		#6-<keyword>#0 - excludes items with the nominated keyword
+		#6+<keyword>#0 - only shows items with the nominated keyword, unique name or builder comment text
+		#6-<keyword>#0 - excludes items with the nominated keyword, unique name or builder comment text
+		#6comment:<text>#0 - shows only items whose builder comment contains the text
 		#6<type>#0 - shows only items that have a component of the specified type
 		#6*<tag>#0 - shows only items that 'are' the specified tag
 
-	#3item load [<quantity>] <id> [<extra args>]#0 - loads an item into the game. See below for extra args:
+	#3item load [<quantity>] <id|unique name> [<extra args>]#0 - loads an item into the game. See below for extra args:
 
 		#6variable=value|id#0 - sets a specific variable
 		#6variable=""value""#0 - same as above, for variable values with spaces
 		#6*<skin name|id>#0 - sets a skin for the item. Must be the first extra argument
 
 	#3item edit new#0 - creates a new item prototype
-	#3item edit <id>#0 - opens prototype with ID for editing
+	#3item edit <id|unique name>#0 - opens a prototype for editing
 	#3item edit#0 - shows the currently open item. Equivalent to doing ITEM SHOW <ID> on it.
 	#3item edit submit#0 - submits the open item for review
 	#3item edit close#0 - closes the open item
@@ -63,9 +64,15 @@ The valid sub-commands and their syntaxes are as follows:
 	#3item edit obsolete#0 - marks the item as obsolete, and no longer loadable
 	#3item show <ID>#0 - shows info about prototype with ID
 	#3item review all|mine|<admin name>|<id>#0 - opens the specified item prototypes for review and approval
-	#3item clone <id>#0 - clones an existing prototype to a new one (also opens for editing)
+	#3item clone <id|unique name>#0 - clones an existing prototype to a new one (also opens for editing)
 	#3item set add <id|name>#0 - adds the specified component to this item
 	#3item set remove <id|name>#0 - removes the specified component from this item
+	#3item set unique <name>#0 - sets an optional unique lookup name for this item template
+	#3item set unique clear#0 - clears the unique lookup name
+	#3item set comment <text>#0 - overwrites the builder comment for this item template
+	#3item set comment append [<text>]#0 - appends to the builder comment, using an editor if no text is supplied
+	#3item set comment edit#0 - edits the builder comment in an editor
+	#3item set comment clear#0 - clears the builder comment
 	#3item set noun <noun>#0 - sets the primary noun for this item. Single word only.
 	#3item set sdesc <sdesc>#0 - sets the short description (e.g. a solid iron sword)
 	#3item set ldesc <ldesc>#0 - sets an overrided long description (in room) for this item
@@ -86,7 +93,7 @@ The valid sub-commands and their syntaxes are as follows:
 	#3item set canskin#0 - toggles whether players can make skins for this item
 	#3item set register <variable name> <default value>#0 - sets a default value for a register variable for this item
 	#3item set register delete <variable name>#0 - deletes a default value for a register variable
-	#3item set morph <item##|none> <seconds> [<emote>]#0 - sets item morph information. The 'none' value makes the item disappear.
+	#3item set morph <item##|unique name|none> <seconds> [<emote>]#0 - sets item morph information. The 'none' value makes the item disappear.
 	#3item set morph clear#0 - clears any morph info for this item
 	#3item set group <id|name>#0 - sets this item's item group (for in-room grouping)
 	#3item set group none#0 - clears this item's item group
@@ -147,9 +154,7 @@ The valid sub-commands and their syntaxes are as follows:
                 return;
             }
 
-            IGameItemProto proto = long.TryParse(ss.SafeRemainingArgument, out long value)
-                ? actor.Gameworld.ItemProtos.Get(value)
-                : actor.Gameworld.ItemProtos.GetByName(ss.SafeRemainingArgument, true);
+            IGameItemProto proto = actor.Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(ss.SafeRemainingArgument);
             if (proto == null)
             {
                 actor.Send("There is no such item prototype for you to clone.");

--- a/MudSharpCore/Economy/Banking/BankAccountType.cs
+++ b/MudSharpCore/Economy/Banking/BankAccountType.cs
@@ -662,13 +662,7 @@ public class BankAccountType : SaveableItem, IBankAccountType
             return true;
         }
 
-        if (!long.TryParse(command.SafeRemainingArgument, out long value))
-        {
-            actor.OutputHandler.Send("You must enter the id number of the item prototype.");
-            return false;
-        }
-
-        IGameItemProto item = Gameworld.ItemProtos.Get(value);
+        IGameItemProto item = Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(command.SafeRemainingArgument);
         if (item is null)
         {
             actor.OutputHandler.Send("There is no such item prototype.");
@@ -684,7 +678,7 @@ public class BankAccountType : SaveableItem, IBankAccountType
         PaymentItemPrototype = item.Id;
         Changed = true;
         actor.OutputHandler.Send(
-            $"This bank account type will now use item #{value.ToString("N0", actor)} ({item.ShortDescription.Colour(item.CustomColour ?? Telnet.Green)}) as its payment item.");
+            $"This bank account type will now use item #{item.Id.ToString("N0", actor)} ({item.ShortDescription.Colour(item.CustomColour ?? Telnet.Green)}) as its payment item.");
         return true;
     }
 

--- a/MudSharpCore/Economy/Shops/Merchandise.cs
+++ b/MudSharpCore/Economy/Shops/Merchandise.cs
@@ -345,14 +345,9 @@ public class Merchandise : LateInitialisingItem, IMerchandise
 
         IGameItemProto proto;
         string text = command.PopSpeech();
-        if (actor.IsAdministrator() && long.TryParse(text, out long value))
+        if (actor.IsAdministrator() && Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(text) is { } itemProto)
         {
-            proto = Gameworld.ItemProtos.Get(value);
-            if (proto == null)
-            {
-                actor.OutputHandler.Send("There is no such item prototype.");
-                return false;
-            }
+            proto = itemProto;
         }
         else
         {

--- a/MudSharpCore/Framework/RevisableAll.cs
+++ b/MudSharpCore/Framework/RevisableAll.cs
@@ -1,4 +1,5 @@
 ﻿using MudSharp.Framework.Revision;
+using MudSharp.GameItems;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -131,6 +132,13 @@ public class RevisableAll<T> : IRevisableAll<T>, IUneditableRevisableAll<T> wher
 
     public T? GetByIdOrName(string value, bool permitAbbreviations = true)
     {
+        if (typeof(IGameItemProto).IsAssignableFrom(typeof(T)))
+        {
+            return _iterlist
+                   .Cast<IGameItemProto>()
+                   .GetByIdOrUniqueNameOrName(value, permitAbbreviations) as T;
+        }
+
         if (long.TryParse(value, out long id))
         {
             return Get(id);
@@ -158,6 +166,14 @@ public class RevisableAll<T> : IRevisableAll<T>, IUneditableRevisableAll<T> wher
 
     public List<T> GetAllByIdOrName(string value, bool permitAbbreviations = true)
     {
+        if (typeof(IGameItemProto).IsAssignableFrom(typeof(T)))
+        {
+            var match = _iterlist
+                        .Cast<IGameItemProto>()
+                        .GetByIdOrUniqueNameOrName(value, permitAbbreviations);
+            return match is null ? [] : GetAll(match.Id);
+        }
+
         if (long.TryParse(value, out long id))
         {
             return GetAll(id);

--- a/MudSharpCore/Framework/Revision/EditableItemReviewProposal.cs
+++ b/MudSharpCore/Framework/Revision/EditableItemReviewProposal.cs
@@ -82,6 +82,12 @@ public class EditableItemReviewProposal<T> : Proposal, IProposal where T : IEdit
 
     public override void Accept(string message = "")
     {
+        foreach (T item in _reviewItems.Where(x => !x.CanSubmit()))
+        {
+            _proponent.OutputHandler.Send($"{item.EditHeader().ColourName()} cannot be approved: {item.WhyCannotSubmit()}");
+            return;
+        }
+
         foreach (T item in _reviewItems)
         {
             foreach (

--- a/MudSharpCore/FutureProg/Functions/GameItem/LoadItemFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/GameItem/LoadItemFunction.cs
@@ -14,16 +14,18 @@ internal class LoadItemFunction : BuiltInFunction
 {
     private readonly IFuturemud _gameworld;
 
-    public LoadItemFunction(IList<IFunction> parameters, IFuturemud gameworld, bool usequantity, bool useparamstring)
+    public LoadItemFunction(IList<IFunction> parameters, IFuturemud gameworld, bool usequantity, bool useparamstring, bool useUniqueName)
         : base(parameters)
     {
         _gameworld = gameworld;
         UseQuantity = usequantity;
         UseParamsString = useparamstring;
+        UseUniqueName = useUniqueName;
     }
 
     public bool UseQuantity { get; set; }
     public bool UseParamsString { get; set; }
+    public bool UseUniqueName { get; set; }
 
     public override ProgVariableTypes ReturnType
     {
@@ -38,23 +40,27 @@ internal class LoadItemFunction : BuiltInFunction
             return StatementResult.Error;
         }
 
-        long vnum = (long)(decimal)ParameterFunctions[0].Result.GetObject;
-        IGameItemProto proto = _gameworld.ItemProtos.Get(vnum);
+        var inputText = UseUniqueName
+            ? (string)ParameterFunctions[0].Result.GetObject
+            : ((long)(decimal)ParameterFunctions[0].Result.GetObject).ToString();
+        IGameItemProto proto = UseUniqueName
+            ? _gameworld.ItemProtos.FindByUniqueName(inputText)
+            : _gameworld.ItemProtos.Get(long.Parse(inputText));
         if (proto == null)
         {
-            ErrorMessage = "There was no prototype " + vnum;
+            ErrorMessage = "There was no prototype " + inputText;
             return StatementResult.Error;
         }
 
         if (proto.Status != RevisionStatus.Current)
         {
-            ErrorMessage = "Prototype " + vnum + " is not approved for use.";
+            ErrorMessage = "Prototype " + inputText + " is not approved for use.";
             return StatementResult.Error;
         }
 
         if (proto.Components.Any(x => x.PreventManualLoad))
         {
-            ErrorMessage = $"Prototype {vnum} contains components that prevent manual loading.";
+            ErrorMessage = $"Prototype {inputText} contains components that prevent manual loading.";
             return StatementResult.Error;
         }
 
@@ -92,7 +98,7 @@ internal class LoadItemFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "loaditem",
             new[] { ProgVariableTypes.Number },
-            (pars, gameworld) => new LoadItemFunction(pars, gameworld, false, false),
+            (pars, gameworld) => new LoadItemFunction(pars, gameworld, false, false, false),
             new List<string> { "id" },
             new List<string> { "The ID of the item prototype that you want to load" },
             "This function loads a new item into the game based on the ID that you supply. It does not put the item anywhere, so you must then insert it somewhere like in a room or a character's inventory.",
@@ -103,7 +109,7 @@ internal class LoadItemFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "loaditem",
             new[] { ProgVariableTypes.Number, ProgVariableTypes.Number },
-            (pars, gameworld) => new LoadItemFunction(pars, gameworld, true, false),
+            (pars, gameworld) => new LoadItemFunction(pars, gameworld, true, false, false),
             new List<string> { "id", "quantity" },
             new List<string>
             {
@@ -118,7 +124,7 @@ internal class LoadItemFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "loaditem",
             new[] { ProgVariableTypes.Number, ProgVariableTypes.Text },
-            (pars, gameworld) => new LoadItemFunction(pars, gameworld, false, true),
+            (pars, gameworld) => new LoadItemFunction(pars, gameworld, false, true, false),
             new List<string> { "id", "variables" },
             new List<string>
             {
@@ -133,7 +139,7 @@ internal class LoadItemFunction : BuiltInFunction
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "loaditem",
             new[] { ProgVariableTypes.Number, ProgVariableTypes.Number, ProgVariableTypes.Text },
-            (pars, gameworld) => new LoadItemFunction(pars, gameworld, true, true),
+            (pars, gameworld) => new LoadItemFunction(pars, gameworld, true, true, false),
             new List<string> { "id", "quantity", "variables" },
             new List<string>
             {
@@ -142,6 +148,63 @@ internal class LoadItemFunction : BuiltInFunction
                 "The default values for any variables on this item. This syntax is as per using the ITEM LOAD command in game, which means the general syntax is varname=value or varname=\"longer value\", with multiple variables separated by spaces"
             },
             "This function loads a new item into the game based on the ID that you supply. It does not put the item anywhere, so you must then insert it somewhere like in a room or a character's inventory.",
+            "Items",
+            ProgVariableTypes.Item
+        ));
+
+        FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+            "loaditem",
+            new[] { ProgVariableTypes.Text },
+            (pars, gameworld) => new LoadItemFunction(pars, gameworld, false, false, true),
+            new List<string> { "uniqueName" },
+            new List<string> { "The unique name of the item prototype that you want to load" },
+            "This function loads a new item into the game based on the unique name that you supply. It does not put the item anywhere, so you must then insert it somewhere like in a room or a character's inventory.",
+            "Items",
+            ProgVariableTypes.Item
+        ));
+
+        FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+            "loaditem",
+            new[] { ProgVariableTypes.Text, ProgVariableTypes.Number },
+            (pars, gameworld) => new LoadItemFunction(pars, gameworld, true, false, true),
+            new List<string> { "uniqueName", "quantity" },
+            new List<string>
+            {
+                "The unique name of the item prototype that you want to load",
+                "The quantity of the item you want to load. If this item is not stackable, this input is ignored."
+            },
+            "This function loads a new item into the game based on the unique name that you supply. It does not put the item anywhere, so you must then insert it somewhere like in a room or a character's inventory.",
+            "Items",
+            ProgVariableTypes.Item
+        ));
+
+        FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+            "loaditem",
+            new[] { ProgVariableTypes.Text, ProgVariableTypes.Text },
+            (pars, gameworld) => new LoadItemFunction(pars, gameworld, false, true, true),
+            new List<string> { "uniqueName", "variables" },
+            new List<string>
+            {
+                "The unique name of the item prototype that you want to load",
+                "The default values for any variables on this item. This syntax is as per using the ITEM LOAD command in game, which means the general syntax is varname=value or varname=\"longer value\", with multiple variables separated by spaces"
+            },
+            "This function loads a new item into the game based on the unique name that you supply. It does not put the item anywhere, so you must then insert it somewhere like in a room or a character's inventory.",
+            "Items",
+            ProgVariableTypes.Item
+        ));
+
+        FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+            "loaditem",
+            new[] { ProgVariableTypes.Text, ProgVariableTypes.Number, ProgVariableTypes.Text },
+            (pars, gameworld) => new LoadItemFunction(pars, gameworld, true, true, true),
+            new List<string> { "uniqueName", "quantity", "variables" },
+            new List<string>
+            {
+                "The unique name of the item prototype that you want to load",
+                "The quantity of the item you want to load. If this item is not stackable, this input is ignored",
+                "The default values for any variables on this item. This syntax is as per using the ITEM LOAD command in game, which means the general syntax is varname=value or varname=\"longer value\", with multiple variables separated by spaces"
+            },
+            "This function loads a new item into the game based on the unique name that you supply. It does not put the item anywhere, so you must then insert it somewhere like in a room or a character's inventory.",
             "Items",
             ProgVariableTypes.Item
         ));

--- a/MudSharpCore/GameItems/Components/VendingMachineGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/VendingMachineGameItemComponent.cs
@@ -213,9 +213,7 @@ public class VendingMachineGameItemComponent : GameItemComponent, IContainer, IV
             return;
         }
 
-        IGameItemProto proto = long.TryParse(command.PopSpeech(), out long value)
-            ? Gameworld.ItemProtos.Get(value)
-            : Gameworld.ItemProtos.GetByName(command.Last, true);
+        IGameItemProto proto = Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(command.PopSpeech());
         if (proto == null)
         {
             character.Send(StringUtilities.HMark + "That is not a valid prototype to load in the vending machine.");
@@ -282,9 +280,10 @@ public class VendingMachineGameItemComponent : GameItemComponent, IContainer, IV
             extraText = command.PopSpeech();
             if (!command.IsFinished)
             {
-                onloadProg = long.TryParse(command.PopSpeech(), out value)
-                    ? Gameworld.FutureProgs.Get(value)
-                    : Gameworld.FutureProgs.GetByName(command.Last);
+                var onloadText = command.PopSpeech();
+                onloadProg = long.TryParse(onloadText, out var onloadProgId)
+                    ? Gameworld.FutureProgs.Get(onloadProgId)
+                    : Gameworld.FutureProgs.GetByName(onloadText);
                 if (onloadProg == null)
                 {
                     character.Send(StringUtilities.HMark + "There is no such prog for you to use as an OnLoadProg.");

--- a/MudSharpCore/GameItems/GameItemProto.cs
+++ b/MudSharpCore/GameItems/GameItemProto.cs
@@ -52,6 +52,8 @@ public class GameItemProto : EditableItem, IGameItemProto
                 MaterialId = 0, // TODO
                 Keywords = "new object",
                 Name = name,
+                UniqueName = null,
+                BuilderNotes = null,
                 Size = (int)SizeCategory.Normal,
                 Weight = 1.0,
                 IsHiddenFromPlayers = false,
@@ -99,6 +101,8 @@ public class GameItemProto : EditableItem, IGameItemProto
     public static IGameItemGroup TooManyItemsGroup { get; set; }
     public static IHealthStrategy DefaultItemHealthStrategy { get; set; }
     public string ShortDescription { get; private set; }
+    public string? UniqueName { get; private set; }
+    public string? BuilderNotes { get; private set; }
     public string FullDescription { get; private set; }
     public decimal CostInBaseCurrency { get; private set; }
     public bool IsHiddenFromPlayers { get; private set; }
@@ -137,6 +141,7 @@ public class GameItemProto : EditableItem, IGameItemProto
         int maxRevision = Gameworld.ItemProtos.GetAll(Id).Max(x => x.RevisionNumber);
         sb.AppendLine($"Item Prototype #{Id.ToString("N0", actor)} - Revision {RevisionNumber.ToString("N0", actor)} / {maxRevision.ToString("N0", actor)}".GetLineWithTitle(actor, Telnet.Cyan, Telnet.BoldWhite));
         sb.AppendLine($"Status: {Status.DescribeColour()}");
+        sb.AppendLine($"Unique Name: {(string.IsNullOrEmpty(UniqueName) ? "None".ColourCommand() : UniqueName.ColourValue())}");
         sb.AppendLine($"Noun: {Name.Proper().ColourValue()}");
         sb.AppendLine($"Short Description: {ShortDescription.ColourObject()}");
         if (OverridesLongDescription)
@@ -188,6 +193,12 @@ public class GameItemProto : EditableItem, IGameItemProto
         sb.AppendLine("Full Description:");
         sb.AppendLine();
         sb.AppendLine(FullDescription.Wrap(actor.InnerLineFormatLength, "  "));
+        sb.AppendLine();
+        sb.AppendLine("Builder Comment:");
+        sb.AppendLine();
+        sb.AppendLine(string.IsNullOrWhiteSpace(BuilderNotes)
+            ? "\tNone".ColourName()
+            : BuilderNotes.Wrap(actor.InnerLineFormatLength, "  "));
         sb.AppendLine();
         sb.AppendLine("Tags:");
         if (Tags.Any())
@@ -413,6 +424,8 @@ public class GameItemProto : EditableItem, IGameItemProto
                 MaterialId = Material?.Id ?? 0,
                 EditableItemId = 0,
                 Name = Name.Proper(),
+                UniqueName = UniqueName,
+                BuilderNotes = BuilderNotes,
                 Size = (int)Size,
                 Weight = Weight,
                 ReadOnly = false,
@@ -521,6 +534,8 @@ public class GameItemProto : EditableItem, IGameItemProto
                     conjunction: ""),
                 MaterialId = Material?.Id ?? 0,
                 Name = Name.Proper(),
+                UniqueName = null,
+                BuilderNotes = BuilderNotes,
                 Size = (int)Size,
                 Weight = Weight,
                 ReadOnly = ReadOnly,
@@ -625,6 +640,8 @@ public class GameItemProto : EditableItem, IGameItemProto
     public override bool CanSubmit()
     {
         return Material != null &&
+               GameItemProtoLookupExtensions.IsValidUniqueName(UniqueName) &&
+               Gameworld.ItemProtos.GetActiveUniqueNameConflict(UniqueName, Id) is null &&
                !GameItemComponentPrototypeExclusivity.FindConflicts(_components).Any();
     }
 
@@ -633,6 +650,18 @@ public class GameItemProto : EditableItem, IGameItemProto
         if (Material == null)
         {
             return "You must first set a material.";
+        }
+
+        if (!GameItemProtoLookupExtensions.IsValidUniqueName(UniqueName))
+        {
+            return "The unique name cannot be entirely numeric, because numeric item prototype input is reserved for IDs.";
+        }
+
+        var uniqueNameConflict = Gameworld.ItemProtos.GetActiveUniqueNameConflict(UniqueName, Id);
+        if (uniqueNameConflict is not null)
+        {
+            return
+                $"The unique name {UniqueName!.ColourCommand()} is already used by {uniqueNameConflict.EditHeaderColour(null)}.";
         }
 
         var conflict = GameItemComponentPrototypeExclusivity.FindConflicts(_components).FirstOrDefault();
@@ -649,6 +678,8 @@ public class GameItemProto : EditableItem, IGameItemProto
         Gameworld = gameworld;
         _id = proto.Id;
         _name = proto.Name;
+        UniqueName = GameItemProtoLookupExtensions.NormaliseUniqueName(proto.UniqueName);
+        BuilderNotes = string.IsNullOrWhiteSpace(proto.BuilderNotes) ? null : proto.BuilderNotes;
         _keywords = new Lazy<List<string>>(() => (from keyword in proto.Keywords.Split(' ') select keyword).ToList());
         foreach (GameItemProtosGameItemComponentProtos component in proto.GameItemProtosGameItemComponentProtos)
         {
@@ -722,6 +753,8 @@ public class GameItemProto : EditableItem, IGameItemProto
             Models.GameItemProto dbproto = FMDB.Context.GameItemProtos.Find(Id, RevisionNumber);
             dbproto.Keywords = Keywords.ListToString(separator: " ", conjunction: "");
             dbproto.Name = Name.Proper();
+            dbproto.UniqueName = UniqueName;
+            dbproto.BuilderNotes = BuilderNotes;
             dbproto.Weight = Weight;
             dbproto.ShortDescription = ShortDescription;
             dbproto.FullDescription = FullDescription;
@@ -1042,6 +1075,15 @@ public class GameItemProto : EditableItem, IGameItemProto
                 return BuildingCommandSubmit(actor, command);
             case "sdesc":
                 return BuildingCommandSDesc(actor, command);
+            case "unique":
+            case "uniquename":
+            case "key":
+                return BuildingCommandUniqueName(actor, command);
+            case "comment":
+            case "notes":
+            case "buildercomment":
+            case "buildernotes":
+                return BuildingCommandBuilderNotes(actor, command);
             case "ldesc":
                 return BuildingCommandLDesc(actor, command);
             case "name":
@@ -1102,6 +1144,12 @@ public class GameItemProto : EditableItem, IGameItemProto
 
 	#3add <id|name>#0 - adds the specified component to this item
 	#3remove <id|name>#0 - removes the specified component from this item
+	#3unique <name>#0 - sets a unique lookup name for this item template
+	#3unique clear#0 - clears the unique lookup name
+	#3comment <text>#0 - overwrites the builder comment for this item template
+	#3comment append [<text>]#0 - appends to the builder comment, using an editor if no text is supplied
+	#3comment edit#0 - edits the builder comment in an editor
+	#3comment clear#0 - clears the builder comment
 	#3noun <noun>#0 - sets the primary noun for this item. Single word only.
 	#3sdesc <sdesc>#0 - sets the short description (e.g. a solid iron sword)
 	#3ldesc <ldesc>#0 - sets an overrided long description (in room) for this item
@@ -1124,7 +1172,7 @@ public class GameItemProto : EditableItem, IGameItemProto
 	#3planar default|corporeal|noncorporeal|xml ...#0 - sets the item prototype's planar defaults
 	#3register <variable name> <default value>#0 - sets a default value for a register variable for this item
 	#3register delete <variable name>#0 - deletes a default value for a register variable
-	#3morph <item##|none> <seconds> [<emote>]#0 - sets item morph information. The 'none' value makes the item disappear.
+	#3morph <item##|unique name|none> <seconds> [<emote>]#0 - sets item morph information. The 'none' value makes the item disappear.
 	#3morph clear#0 - clears any morph info for this item
 	#3hidden#0 - toggles this item being hidden from players in information/searching commands
 	#3group <id|name>#0 - sets this item's item group (for in-room grouping)
@@ -1948,9 +1996,7 @@ public class GameItemProto : EditableItem, IGameItemProto
             return true;
         }
 
-        IGameItemProto item = long.TryParse(command.Last, out long value)
-            ? Gameworld.ItemProtos.Get(value)
-            : Gameworld.ItemProtos.GetByName(command.Last);
+        IGameItemProto item = Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(command.Last);
         if (item == null)
         {
             actor.Send("There is no item proto like that which you can set as a destroyed item for another item.");
@@ -2115,6 +2161,122 @@ public class GameItemProto : EditableItem, IGameItemProto
         Changed = true;
         actor.OutputHandler.Send("You set the noun for " + EditHeader() + " to " + cmd);
         return true;
+    }
+
+    private bool BuildingCommandUniqueName(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("What unique name do you want to set for this item prototype?");
+            return false;
+        }
+
+        var uniqueName = GameItemProtoLookupExtensions.NormaliseUniqueName(command.SafeRemainingArgument);
+        if (uniqueName is null || uniqueName.EqualToAny("none", "clear", "delete", "remove"))
+        {
+            UniqueName = null;
+            Changed = true;
+            actor.OutputHandler.Send("This item prototype no longer has a unique lookup name.");
+            return true;
+        }
+
+        if (!GameItemProtoLookupExtensions.IsValidUniqueName(uniqueName))
+        {
+            actor.OutputHandler.Send("Unique names cannot be entirely numeric, because numeric item prototype input is reserved for IDs.");
+            return false;
+        }
+
+        var conflict = Gameworld.ItemProtos.GetActiveUniqueNameConflict(uniqueName, Id);
+        if (conflict is not null)
+        {
+            actor.OutputHandler.Send(
+                $"The unique name {uniqueName.ColourCommand()} is already used by {conflict.EditHeaderColour(actor)}.");
+            return false;
+        }
+
+        UniqueName = uniqueName;
+        Changed = true;
+        actor.OutputHandler.Send($"This item prototype can now be looked up by the unique name {UniqueName.ColourCommand()}.");
+        return true;
+    }
+
+    private bool BuildingCommandBuilderNotes(ICharacter actor, StringStack command)
+    {
+        var subCommand = command.PopSpeech();
+        if (subCommand.Length == 0)
+        {
+            actor.OutputHandler.Send("Do you want to set, append, edit or clear the builder comment?");
+            return false;
+        }
+
+        switch (subCommand.ToLowerInvariant())
+        {
+            case "clear":
+            case "none":
+            case "delete":
+            case "remove":
+                BuilderNotes = null;
+                Changed = true;
+                actor.OutputHandler.Send("You clear the builder comment for this item prototype.");
+                return true;
+            case "edit":
+                actor.OutputHandler.Send("Enter the builder comment in the editor below.");
+                actor.EditorMode(BuildingCommandBuilderNotesPost, BuildingCommandBuilderNotesCancel, 1.0,
+                    BuilderNotes, suppliedArguments: [false]);
+                return true;
+            case "append":
+                if (command.IsFinished)
+                {
+                    actor.OutputHandler.Send("Enter the text to append to the builder comment in the editor below.");
+                    actor.EditorMode(BuildingCommandBuilderNotesPost, BuildingCommandBuilderNotesCancel, 1.0,
+                        null, suppliedArguments: [true]);
+                    return true;
+                }
+
+                AppendBuilderNotes(command.SafeRemainingArgument);
+                actor.OutputHandler.Send("You append to the builder comment for this item prototype.");
+                return true;
+        }
+
+        var text = command.IsFinished ? subCommand : $"{subCommand} {command.SafeRemainingArgument}";
+        BuilderNotes = string.IsNullOrWhiteSpace(text) ? null : text.Trim();
+        Changed = true;
+        actor.OutputHandler.Send("You set the builder comment for this item prototype.");
+        return true;
+    }
+
+    private void BuildingCommandBuilderNotesPost(string text, IOutputHandler handler, object[] arguments)
+    {
+        var append = (bool)arguments[0];
+        if (append)
+        {
+            AppendBuilderNotes(text);
+            handler.Send("You append to the builder comment for this item prototype.");
+            return;
+        }
+
+        BuilderNotes = string.IsNullOrWhiteSpace(text) ? null : text.Trim();
+        Changed = true;
+        handler.Send("You set the builder comment for this item prototype.");
+    }
+
+    private void BuildingCommandBuilderNotesCancel(IOutputHandler handler, object[] arguments)
+    {
+        handler.Send("You decide not to change the builder comment.");
+    }
+
+    private void AppendBuilderNotes(string text)
+    {
+        var trimmed = text.Trim();
+        if (trimmed.Length == 0)
+        {
+            return;
+        }
+
+        BuilderNotes = string.IsNullOrWhiteSpace(BuilderNotes)
+            ? trimmed
+            : $"{BuilderNotes.TrimEnd()}\n{trimmed}";
+        Changed = true;
     }
 
     private bool BuildingCommandKeywords(ICharacter actor, StringStack command)
@@ -2386,7 +2548,7 @@ public class GameItemProto : EditableItem, IGameItemProto
         if (command.IsFinished)
         {
             actor.Send(
-                $"Correct syntax is {"item set morph clear".Colour(Telnet.Yellow)} or {"item set morph <item#/none> <seconds> [<emote>]".Colour(Telnet.Yellow)}.");
+                    $"Correct syntax is {"item set morph clear".Colour(Telnet.Yellow)} or {"item set morph <item#/unique name/none> <seconds> [<emote>]".Colour(Telnet.Yellow)}.");
             return false;
         }
 
@@ -2416,18 +2578,15 @@ public class GameItemProto : EditableItem, IGameItemProto
         }
         else
         {
-            if (!long.TryParse(command.PopSpeech(), out value))
-            {
-                actor.Send(
-                    $"Correct syntax is {"item set morph clear".Colour(Telnet.Yellow)} or {"item set morph <item#/none> <seconds> [<emote>]".Colour(Telnet.Yellow)}.");
-                return false;
-            }
-
-            if (Gameworld.ItemProtos.Get(value) == null)
+            var morphText = command.PopSpeech();
+            var morphProto = Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(morphText);
+            if (morphProto is null)
             {
                 actor.Send("There is no such item prototype for this item to morph into.");
                 return false;
             }
+
+            value = morphProto.Id;
         }
 
         if (command.IsFinished)

--- a/MudSharpCore/GameItems/Prototypes/AmmunitionGameItemComponentProto.cs
+++ b/MudSharpCore/GameItems/Prototypes/AmmunitionGameItemComponentProto.cs
@@ -160,9 +160,7 @@ public class AmmunitionGameItemComponentProto : GameItemComponentProto, IAmmoPro
             return false;
         }
 
-        IGameItemProto proto = long.TryParse(command.SafeRemainingArgument, out long value)
-            ? Gameworld.ItemProtos.Get(value)
-            : Gameworld.ItemProtos.GetByName(command.SafeRemainingArgument);
+        IGameItemProto proto = Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(command.SafeRemainingArgument);
         if (proto == null)
         {
             actor.Send("There is no such proto.");
@@ -191,9 +189,7 @@ public class AmmunitionGameItemComponentProto : GameItemComponentProto, IAmmoPro
             return false;
         }
 
-        IGameItemProto proto = long.TryParse(command.SafeRemainingArgument, out long value)
-            ? Gameworld.ItemProtos.Get(value)
-            : Gameworld.ItemProtos.GetByName(command.SafeRemainingArgument);
+        IGameItemProto proto = Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(command.SafeRemainingArgument);
         if (proto == null)
         {
             actor.Send("There is no such proto.");

--- a/MudSharpCore/GameItems/Prototypes/BenchGameItemComponentProto.cs
+++ b/MudSharpCore/GameItems/Prototypes/BenchGameItemComponentProto.cs
@@ -301,9 +301,7 @@ public class BenchGameItemComponentProto : GameItemComponentProto, ITablePrototy
             return false;
         }
 
-        IGameItemProto proto = long.TryParse(command.PopSpeech(), out long value)
-            ? Gameworld.ItemProtos.Get(value)
-            : Gameworld.ItemProtos.GetByName(command.Last);
+        IGameItemProto proto = Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(command.PopSpeech());
         if (proto == null)
         {
             actor.Send("There is no such component prototype.");

--- a/MudSharpCore/GameItems/Prototypes/BookGameItemComponentProto.cs
+++ b/MudSharpCore/GameItems/Prototypes/BookGameItemComponentProto.cs
@@ -527,9 +527,7 @@ public class BookGameItemComponentProto : GameItemComponentProto, IWriteableProt
             return false;
         }
 
-        IGameItemProto proto = long.TryParse(command.PopSpeech(), out long value)
-            ? Gameworld.ItemProtos.Get(value)
-            : Gameworld.ItemProtos.GetByName(command.Last);
+        IGameItemProto proto = Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(command.PopSpeech());
         if (proto == null)
         {
             actor.Send("There is no such prototype.");

--- a/MudSharpCore/GameItems/Prototypes/BreathingFilterGameItemComponentProto.cs
+++ b/MudSharpCore/GameItems/Prototypes/BreathingFilterGameItemComponentProto.cs
@@ -234,16 +234,10 @@ public class BreathingFilterGameItemComponentProto : GameItemComponentProto, IPr
             return false;
         }
 
-        if (!long.TryParse(command.PopSpeech(), out long value))
-        {
-            actor.OutputHandler.Send("You must enter a valid item prototype ID.");
-            return false;
-        }
-
-        IGameItemProto proto = Gameworld.ItemProtos.Get(value);
+        IGameItemProto proto = Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(command.PopSpeech());
         if (proto == null)
         {
-            actor.OutputHandler.Send("That is not a valid item prototype ID.");
+            actor.OutputHandler.Send("That is not a valid item prototype.");
             return false;
         }
 

--- a/MudSharpCore/GameItems/Prototypes/ConsumableHeaterCoolerGameItemComponentProto.cs
+++ b/MudSharpCore/GameItems/Prototypes/ConsumableHeaterCoolerGameItemComponentProto.cs
@@ -148,9 +148,7 @@ public class ConsumableHeaterCoolerGameItemComponentProto : ThermalSourceGameIte
             return true;
         }
 
-        IGameItemProto? proto = long.TryParse(command.SafeRemainingArgument, out long value)
-            ? Gameworld.ItemProtos.Get(value)
-            : Gameworld.ItemProtos.GetByName(command.SafeRemainingArgument);
+        IGameItemProto? proto = Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(command.SafeRemainingArgument);
         if (proto is null)
         {
             actor.OutputHandler.Send("There is no such item prototype.");

--- a/MudSharpCore/GameItems/Prototypes/DwellingGameItemComponentProto.cs
+++ b/MudSharpCore/GameItems/Prototypes/DwellingGameItemComponentProto.cs
@@ -254,9 +254,7 @@ public class DwellingGameItemComponentProto : GameItemComponentProto
             return true;
         }
 
-        IGameItemProto proto = long.TryParse(command.PopSpeech(), out long value)
-            ? Gameworld.ItemProtos.Get(value)
-            : Gameworld.ItemProtos.GetByName(command.Last);
+        IGameItemProto proto = Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(command.PopSpeech());
         if (proto == null)
         {
             actor.Send("There is no such game item template to use for the door.");

--- a/MudSharpCore/GameItems/Prototypes/FaxMachineGameItemComponentProto.cs
+++ b/MudSharpCore/GameItems/Prototypes/FaxMachineGameItemComponentProto.cs
@@ -138,13 +138,7 @@ public class FaxMachineGameItemComponentProto : TelephoneGameItemComponentProto,
             return false;
         }
 
-        if (!long.TryParse(command.PopSpeech(), out long value))
-        {
-            actor.OutputHandler.Send("You must enter a valid ID number.");
-            return false;
-        }
-
-        IGameItemProto proto = Gameworld.ItemProtos.Get(value);
+        IGameItemProto? proto = Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(command.PopSpeech());
         if (proto == null)
         {
             actor.OutputHandler.Send("There is no such item prototype.");
@@ -174,13 +168,7 @@ public class FaxMachineGameItemComponentProto : TelephoneGameItemComponentProto,
             return false;
         }
 
-        if (!long.TryParse(command.PopSpeech(), out long value))
-        {
-            actor.OutputHandler.Send("You must enter a valid ID number.");
-            return false;
-        }
-
-        IGameItemProto proto = Gameworld.ItemProtos.Get(value);
+        IGameItemProto? proto = Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(command.PopSpeech());
         if (proto == null)
         {
             actor.OutputHandler.Send("There is no such item prototype.");

--- a/MudSharpCore/GameItems/Prototypes/PhotocopierGameItemComponentProto.cs
+++ b/MudSharpCore/GameItems/Prototypes/PhotocopierGameItemComponentProto.cs
@@ -146,13 +146,7 @@ public class PhotocopierGameItemComponentProto : PoweredMachineBaseGameItemCompo
             return false;
         }
 
-        if (!long.TryParse(command.PopSpeech(), out long value))
-        {
-            actor.OutputHandler.Send("You must enter a valid ID number.");
-            return false;
-        }
-
-        IGameItemProto proto = Gameworld.ItemProtos.Get(value);
+        IGameItemProto proto = Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(command.PopSpeech());
         if (proto == null)
         {
             actor.OutputHandler.Send("There is no such item prototype.");
@@ -226,13 +220,7 @@ public class PhotocopierGameItemComponentProto : PoweredMachineBaseGameItemCompo
             return false;
         }
 
-        if (!long.TryParse(command.PopSpeech(), out long value))
-        {
-            actor.OutputHandler.Send("You must enter a valid ID number.");
-            return false;
-        }
-
-        IGameItemProto proto = Gameworld.ItemProtos.Get(value);
+        IGameItemProto proto = Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(command.PopSpeech());
         if (proto == null)
         {
             actor.OutputHandler.Send("There is no such item prototype.");

--- a/MudSharpCore/Work/Crafts/Inputs/SimpleItemInput.cs
+++ b/MudSharpCore/Work/Crafts/Inputs/SimpleItemInput.cs
@@ -125,9 +125,7 @@ public class SimpleItemInput : BaseInput, ICraftInputConsumesGameItemGroup
             return false;
         }
 
-        IGameItemProto proto = long.TryParse(command.SafeRemainingArgument, out long value)
-            ? Gameworld.ItemProtos.Get(value)
-            : Gameworld.ItemProtos.GetByName(command.SafeRemainingArgument);
+        IGameItemProto proto = Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(command.SafeRemainingArgument);
         if (proto == null)
         {
             actor.OutputHandler.Send("There is no such item prototype.");

--- a/MudSharpCore/Work/Crafts/Products/CookedFoodProduct.cs
+++ b/MudSharpCore/Work/Crafts/Products/CookedFoodProduct.cs
@@ -334,9 +334,7 @@ public class CookedFoodProduct : BaseProduct
 			return false;
 		}
 
-		var proto = long.TryParse(command.SafeRemainingArgument, out var value)
-			? Gameworld.ItemProtos.Get(value)
-			: Gameworld.ItemProtos.GetByName(command.SafeRemainingArgument);
+		var proto = Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(command.SafeRemainingArgument);
 		if (proto is null)
 		{
 			actor.OutputHandler.Send("There is no such item prototype.");

--- a/MudSharpCore/Work/Crafts/Products/InputVariableProduct.cs
+++ b/MudSharpCore/Work/Crafts/Products/InputVariableProduct.cs
@@ -553,9 +553,7 @@ internal class InputVariableProduct : BaseProduct
             return false;
         }
 
-        IGameItemProto proto = long.TryParse(command.SafeRemainingArgument, out long value)
-            ? Gameworld.ItemProtos.Get(value)
-            : Gameworld.ItemProtos.GetByName(command.SafeRemainingArgument);
+        IGameItemProto proto = Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(command.SafeRemainingArgument);
         if (proto == null)
         {
             actor.OutputHandler.Send("There is no such item prototype.");

--- a/MudSharpCore/Work/Crafts/Products/LiquidProduct.cs
+++ b/MudSharpCore/Work/Crafts/Products/LiquidProduct.cs
@@ -228,9 +228,7 @@ public class LiquidProduct : BaseProduct
 			return false;
 		}
 
-		var proto = long.TryParse(command.SafeRemainingArgument, out var value)
-			? Gameworld.ItemProtos.Get(value)
-			: Gameworld.ItemProtos.GetByName(command.SafeRemainingArgument);
+		var proto = Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(command.SafeRemainingArgument);
 		if (proto is null)
 		{
 			actor.OutputHandler.Send("There is no such item prototype.");

--- a/MudSharpCore/Work/Crafts/Products/SimpleProduct.cs
+++ b/MudSharpCore/Work/Crafts/Products/SimpleProduct.cs
@@ -246,9 +246,7 @@ public class SimpleProduct : BaseProduct
             return false;
         }
 
-        IGameItemProto proto = long.TryParse(command.SafeRemainingArgument, out long value)
-            ? Gameworld.ItemProtos.Get(value)
-            : Gameworld.ItemProtos.GetByName(command.SafeRemainingArgument);
+        IGameItemProto proto = Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(command.SafeRemainingArgument);
         if (proto == null)
         {
             actor.OutputHandler.Send("There is no such item prototype.");

--- a/MudSharpCore/Work/Crafts/Tools/SimpleTool.cs
+++ b/MudSharpCore/Work/Crafts/Tools/SimpleTool.cs
@@ -93,9 +93,7 @@ public class SimpleTool : BaseTool
             return false;
         }
 
-        IGameItemProto item = long.TryParse(command.SafeRemainingArgument, out long value)
-            ? Gameworld.ItemProtos.Get(value)
-            : Gameworld.ItemProtos.GetByName(command.SafeRemainingArgument);
+        IGameItemProto item = Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(command.SafeRemainingArgument);
         if (item == null)
         {
             actor.OutputHandler.Send("There is no such item prototype.");

--- a/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextConfiguring2.cs
+++ b/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextConfiguring2.cs
@@ -3068,6 +3068,9 @@ namespace MudSharp.Database
                 entity.HasIndex(e => e.ItemGroupId)
                     .HasDatabaseName("FK_GameItemProtos_ItemGroups_idx");
 
+                entity.HasIndex(e => e.UniqueName)
+                    .HasDatabaseName("IX_GameItemProtos_UniqueName");
+
                 entity.Property(e => e.Id).HasColumnType("bigint(20)");
 
                 entity.Property(e => e.RevisionNumber).HasColumnType("int(11)");
@@ -3131,6 +3134,16 @@ namespace MudSharp.Database
                 entity.Property(e => e.Name)
                     .IsRequired()
                     .HasColumnType("varchar(255)")
+                    .HasCharSet("utf8")
+                    .UseCollation("utf8_general_ci");
+
+                entity.Property(e => e.UniqueName)
+                    .HasColumnType("varchar(255)")
+                    .HasCharSet("utf8")
+                    .UseCollation("utf8_general_ci");
+
+                entity.Property(e => e.BuilderNotes)
+                    .HasColumnType("text")
                     .HasCharSet("utf8")
                     .UseCollation("utf8_general_ci");
 

--- a/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextConfiguring3.cs
+++ b/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextConfiguring3.cs
@@ -135,6 +135,9 @@ namespace MudSharp.Database
 
             modelBuilder.Entity<CommoditySpoilageRule>(entity =>
             {
+                entity.HasKey(e => e.Id)
+                    .HasName("PRIMARY");
+
                 entity.HasIndex(e => e.Name)
                     .HasDatabaseName("IX_CommoditySpoilageRules_Name")
                     .IsUnique();

--- a/MudsharpDatabaseLibrary/Migrations/20260523125349_ItemProtoUniqueNameBuilderNotes.Designer.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260523125349_ItemProtoUniqueNameBuilderNotes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MudSharp.Database;
 
@@ -11,9 +12,11 @@ using MudSharp.Database;
 namespace MudSharp.Migrations
 {
     [DbContext(typeof(FuturemudDatabaseContext))]
-    partial class FutureMUDContextModelSnapshot : ModelSnapshot
+    [Migration("20260523125349_ItemProtoUniqueNameBuilderNotes")]
+    partial class ItemProtoUniqueNameBuilderNotes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MudsharpDatabaseLibrary/Migrations/20260523125349_ItemProtoUniqueNameBuilderNotes.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260523125349_ItemProtoUniqueNameBuilderNotes.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MudSharp.Migrations
+{
+    /// <inheritdoc />
+    public partial class ItemProtoUniqueNameBuilderNotes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "BuilderNotes",
+                table: "GameItemProtos",
+                type: "text",
+                nullable: true,
+                collation: "utf8_general_ci")
+                .Annotation("MySql:CharSet", "utf8");
+
+            migrationBuilder.AddColumn<string>(
+                name: "UniqueName",
+                table: "GameItemProtos",
+                type: "varchar(255)",
+                nullable: true,
+                collation: "utf8_general_ci")
+                .Annotation("MySql:CharSet", "utf8");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GameItemProtos_UniqueName",
+                table: "GameItemProtos",
+                column: "UniqueName");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_GameItemProtos_UniqueName",
+                table: "GameItemProtos");
+
+            migrationBuilder.DropColumn(
+                name: "BuilderNotes",
+                table: "GameItemProtos");
+
+            migrationBuilder.DropColumn(
+                name: "UniqueName",
+                table: "GameItemProtos");
+        }
+    }
+}

--- a/MudsharpDatabaseLibrary/Models/GameItemProto.cs
+++ b/MudsharpDatabaseLibrary/Models/GameItemProto.cs
@@ -18,6 +18,8 @@ namespace MudSharp.Models
 
         public long Id { get; set; }
         public string Name { get; set; }
+        public string UniqueName { get; set; }
+        public string BuilderNotes { get; set; }
         public string Keywords { get; set; }
         public long MaterialId { get; set; }
         public long EditableItemId { get; set; }


### PR DESCRIPTION
## Summary
- Add optional `UniqueName` and `BuilderNotes` metadata to item prototypes, including EF migration columns and lookup helpers.
- Add builder commands, item show/list/review display, list/comment searching, unique-name-aware lookup surfaces, and FutureProg `loaditem(text)` overloads.
- Preserve metadata through revision/clone flows as designed, with cloned prototypes clearing `UniqueName`, and document the new behavior in the item-system docs.

## Validation
- `dotnet restore MudSharp.sln -m:1 -p:RestoreBuildInParallel=false -p:NuGetAudit=false`
- `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1`
- `dotnet test 'FutureMUDLibrary Unit Tests\FutureMUDLibrary Unit Tests.csproj' -c Debug --no-restore -m:1`
- `git diff --check`

Notes: local verification only reported expected sandbox/package-audit `NU1900` warnings and Git CRLF conversion notices.