### PR TITLE
Add NPC template unique names and builder notes

### DIFF
--- a/Design Documents/AI/NPC_AI_and_Group_AI_Runtime.md
+++ b/Design Documents/AI/NPC_AI_and_Group_AI_Runtime.md
@@ -133,6 +133,13 @@ Each AI row stores:
 `Type` is the runtime loader discriminator. `Definition` is XML owned by the concrete AI class.
 
 #### NPC Attachments
+NPC templates persist through `NPCTemplates` rows. In addition to the template `Name`, `Type`, revision state, and XML `Definition`, templates may carry two builder-only metadata fields:
+
+- `UniqueName`: optional stable lookup key for builder commands and `loadnpc(text)`
+- `BuilderNotes`: optional free-form builder comment for design intent and maintenance notes
+
+Blank unique names are treated as unset. Nonblank unique names are trimmed, cannot be entirely numeric, and must be unique case-insensitively among active template revisions: `Current`, `PendingRevision`, and `UnderDesign`. Historical `Rejected`, `Revised`, and `Obsolete` revisions may duplicate them.
+
 NPC-template and live-NPC attachment are separate:
 
 - template linkage: `NpcTemplatesArtificalIntelligences`
@@ -209,6 +216,8 @@ Group AI instances subscribe themselves directly on creation/load:
 
 - `npc set ai add <which>`
 - `npc set ai remove <which>`
+
+NPC-template lookup resolves numeric ids first, exact `UniqueName` second, then legacy name matching. This applies to normal builder surfaces such as `npc show`, `npc edit`, `npc clone`, `npc load`, spawners, magic effects, agriculture herd templates, and craft NPC products.
 
 When a new `NPC` is created from a template, the template's AI list is copied into the NPC's `_AIs` collection. The references still point at shared AI definitions.
 
@@ -330,6 +339,17 @@ NPC templates attach and remove reusable AI definitions with:
 - `npc set ai remove <which>`
 
 This is the normal way to make future spawns of a template inherit a behavior package.
+
+NPC templates also support builder-facing metadata:
+
+- `npc set unique <name>`
+- `npc set unique clear`
+- `npc set comment <text>`
+- `npc set comment append <text>`
+- `npc set comment edit`
+- `npc set comment clear`
+
+`npc show` displays the unique name and builder comment. `npc list` includes the unique-name column; `+<text>` and `-<text>` search names, unique names, and builder comments, while `comment:<text>` searches builder comments directly.
 
 ### `ai add` / `ai remove`
 Live NPC instances can be modified directly:

--- a/Design Documents/Agriculture/Agriculture_Builder_Workflows.md
+++ b/Design Documents/Agriculture/Agriculture_Builder_Workflows.md
@@ -146,7 +146,7 @@ field herd absorb <npc> <herd>
 field herd drive <herd> <direction> [count]
 ```
 
-Drawdown requires the herd definition to have an NPC template. Absorb is for turning live livestock back into abstract field stock after validation.
+Drawdown requires the herd definition to have an NPC template. Builders may select that template by numeric id or by its unique template name. Absorb is for turning live livestock back into abstract field stock after validation.
 
 Driving a herd moves abstract animals from the current field into an adjacent field through the named exit. Omit the count, or use `all`, to move the whole herd. The destination field must already exist, support pasture use, and be fallow or pasture. Herders can drive animals into unowned fields or fields they are authorised to use, which allows wild grazing grounds and semi-nomadic pastoral movement without making owned fields freely available.
 

--- a/Design Documents/Crafting/Crafting_System_Runtime_and_Extensibility.md
+++ b/Design Documents/Crafting/Crafting_System_Runtime_and_Extensibility.md
@@ -341,7 +341,7 @@ All tool types inherit shared builder options from `BaseTool`:
 | `inputvariable` | `InputVariableProduct` | Load items whose variable values depend on which item proto was used for an input | `item`, `skin`, `quantity`, `variable ...` | Supports per-input-index and per-item-to-value mappings |
 | `commodity` | `CommodityProduct` | Produce a commodity pile of a material, mass, optional tag, and optional characteristics | `commodity`, `weight`, `tag`, `material`, `characteristic` | Characteristic outputs can be fixed values or copied from a variable-capable input |
 | `money` | `MoneyProduct` | Produce money in a chosen currency | `currency`, `amount` | Valid only with currency plus positive amount |
-| `npc` | `NPCProduct` | Spawn one or more NPCs from an approved NPC template | `template`, `quantity`, optional `prog` | Optional on-load prog must be `void(Character)` |
+| `npc` | `NPCProduct` | Spawn one or more NPCs from an approved NPC template | `template`, `quantity`, optional `prog` | Template accepts an id or unique name. Optional on-load prog must be `void(Character)` |
 | `prog` | `ProgProduct` | Let a FutureProg decide which item or items are produced | `prog` | Prog must return item or collection of items and accept item/liquid input collections |
 | `progvariable` | `ProgVariableProduct` | Load an item and fill characteristics through per-definition progs | `item`, `quantity`, `variable <definition> <prog>` | Uses progs instead of input indexes for characteristic resolution |
 | `unusedinput` | `UnusedInputProduct` | Return copies of an unused portion of a consumed item input | `input`, `percentage` | Target input must consume items or item groups |

--- a/FutureMUDLibrary Unit Tests/NPCTemplateLookupExtensionsTests.cs
+++ b/FutureMUDLibrary Unit Tests/NPCTemplateLookupExtensionsTests.cs
@@ -1,0 +1,91 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Framework;
+using MudSharp.Framework.Revision;
+using MudSharp.NPC.Templates;
+
+#nullable enable
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class NPCTemplateLookupExtensionsTests
+{
+	[TestMethod]
+	public void UniqueNameLookupPrefersExactUniqueNameBeforeLegacyName()
+	{
+		var unique = Template(1, 0, RevisionStatus.Current, "wanderer", "guard");
+		var legacy = Template(2, 0, RevisionStatus.Current, "guard", null);
+
+		var result = new[] { legacy, unique }.GetByIdOrUniqueNameOrName("guard");
+
+		Assert.AreSame(unique, result);
+	}
+
+	[TestMethod]
+	public void UniqueNameLookupIsCaseInsensitiveAndActiveOnly()
+	{
+		var historical = Template(1, 0, RevisionStatus.Obsolete, "old", "template-key");
+		var current = Template(2, 0, RevisionStatus.Current, "new", "Template-Key");
+
+		var result = new[] { historical, current }.FindByUniqueName("template-key");
+
+		Assert.AreSame(current, result);
+	}
+
+	[TestMethod]
+	public void UniqueNameValidationRejectsAllNumericNames()
+	{
+		Assert.IsFalse(NPCTemplateLookupExtensions.IsValidUniqueName("12345"));
+		Assert.IsTrue(NPCTemplateLookupExtensions.IsValidUniqueName("template-12345"));
+		Assert.IsTrue(NPCTemplateLookupExtensions.IsValidUniqueName("  "));
+	}
+
+	[TestMethod]
+	public void ActiveConflictIgnoresSameIdAndHistoricalRows()
+	{
+		var sameId = Template(1, 1, RevisionStatus.UnderDesign, "same", "shared-key");
+		var obsolete = Template(2, 0, RevisionStatus.Obsolete, "old", "shared-key");
+		var current = Template(3, 0, RevisionStatus.Current, "current", "shared-key");
+
+		var templates = new[] { sameId, obsolete, current };
+
+		Assert.IsNull(new[] { sameId, obsolete }.GetActiveUniqueNameConflict("shared-key", 1));
+		Assert.IsNull(new[] { obsolete }.GetActiveUniqueNameConflict("shared-key", 99));
+		Assert.AreSame(current, templates.GetActiveUniqueNameConflict("shared-key", 1));
+	}
+
+	[TestMethod]
+	public void RevisableLookupUsesDifferentPriorityForEditing()
+	{
+		var current = Template(1, 0, RevisionStatus.Current, "guard", "guard-key");
+		var underDesign = Template(1, 1, RevisionStatus.UnderDesign, "guard", "guard-key");
+
+		var templates = new[] { current, underDesign };
+
+		Assert.AreSame(current, templates.GetByIdOrNameRevisable("guard-key"));
+		Assert.AreSame(underDesign, templates.GetByIdOrNameRevisableForEditing("guard-key"));
+	}
+
+	[TestMethod]
+	public void BuilderSearchTextMatchesUniqueNameAndBuilderNotes()
+	{
+		var template = Template(1, 0, RevisionStatus.Current, "guard", "clockwork-key", "Used by the clockwork quest.");
+
+		Assert.IsTrue(template.HasBuilderSearchText("clockwork"));
+		Assert.IsTrue(template.HasBuilderSearchText("quest"));
+		Assert.IsFalse(template.HasBuilderSearchText("alchemy"));
+	}
+
+	private static INPCTemplate Template(long id, int revision, RevisionStatus status, string name, string? uniqueName, string? builderNotes = null)
+	{
+		var template = new Mock<INPCTemplate>();
+		template.SetupGet(x => x.Id).Returns(id);
+		template.SetupGet(x => x.RevisionNumber).Returns(revision);
+		template.SetupGet(x => x.Status).Returns(status);
+		template.SetupGet(x => x.Name).Returns(name);
+		template.SetupGet(x => x.UniqueName).Returns(uniqueName);
+		template.SetupGet(x => x.BuilderNotes).Returns(builderNotes);
+		return template.Object;
+	}
+}

--- a/FutureMUDLibrary/Framework/CollectionExtensions.cs
+++ b/FutureMUDLibrary/Framework/CollectionExtensions.cs
@@ -2,6 +2,7 @@
 using MudSharp.Construction;
 using MudSharp.Framework.Revision;
 using MudSharp.GameItems;
+using MudSharp.NPC.Templates;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -1147,6 +1148,14 @@ namespace MudSharp.Framework
                 return match is null ? default : (T)(object)match;
             }
 
+            if (typeof(INPCTemplate).IsAssignableFrom(typeof(T)))
+            {
+                var match = items
+                            .Cast<INPCTemplate>()
+                            .GetByIdOrUniqueNameOrNameForEditing(text);
+                return match is null ? default : (T)(object)match;
+            }
+
             List<T> filteredItems;
             if (long.TryParse(text, out long id))
             {
@@ -1192,6 +1201,14 @@ namespace MudSharp.Framework
             {
                 var match = items
                             .Cast<IGameItemProto>()
+                            .GetByIdOrUniqueNameOrNameRevisable(text);
+                return match is null ? default : (T)(object)match;
+            }
+
+            if (typeof(INPCTemplate).IsAssignableFrom(typeof(T)))
+            {
+                var match = items
+                            .Cast<INPCTemplate>()
                             .GetByIdOrUniqueNameOrNameRevisable(text);
                 return match is null ? default : (T)(object)match;
             }

--- a/FutureMUDLibrary/NPC/Templates/INPCTemplate.cs
+++ b/FutureMUDLibrary/NPC/Templates/INPCTemplate.cs
@@ -15,6 +15,8 @@ namespace MudSharp.NPC.Templates
     public interface INPCTemplate : IEditableRevisableItem
     {
         string NPCTemplateType { get; }
+        string? UniqueName { get; }
+        string? BuilderNotes { get; }
         IFutureProg? OnLoadProg { get; }
         IHealthStrategy? HealthStrategy { get; }
         ICharacterCombatSettings? DefaultCombatSetting { get; }

--- a/FutureMUDLibrary/NPC/Templates/NPCTemplateLookupExtensions.cs
+++ b/FutureMUDLibrary/NPC/Templates/NPCTemplateLookupExtensions.cs
@@ -1,0 +1,152 @@
+using MudSharp.Framework.Revision;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+#nullable enable
+
+namespace MudSharp.NPC.Templates;
+
+public static class NPCTemplateLookupExtensions
+{
+	public static string? NormaliseUniqueName(string? value)
+	{
+		return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+	}
+
+	public static bool IsValidUniqueName(string? value)
+	{
+		var normalised = NormaliseUniqueName(value);
+		return normalised is null || !long.TryParse(normalised, out _);
+	}
+
+	public static bool IsActiveForUniqueName(this RevisionStatus status)
+	{
+		return status == RevisionStatus.Current ||
+		       status == RevisionStatus.PendingRevision ||
+		       status == RevisionStatus.UnderDesign;
+	}
+
+	public static INPCTemplate? FindByUniqueName(this IEnumerable<INPCTemplate> templates, string? uniqueName, bool activeOnly = true)
+	{
+		var normalised = NormaliseUniqueName(uniqueName);
+		if (normalised is null)
+		{
+			return null;
+		}
+
+		var matches = templates
+		              .Where(x => x.UniqueName?.Equals(normalised, StringComparison.InvariantCultureIgnoreCase) == true);
+		if (activeOnly)
+		{
+			matches = matches.Where(x => x.Status.IsActiveForUniqueName());
+		}
+
+		var list = matches.ToList();
+		return list.FirstOrDefault(x => x.Status == RevisionStatus.Current) ??
+		       list.FirstOrDefault(x => x.Status == RevisionStatus.PendingRevision || x.Status == RevisionStatus.UnderDesign) ??
+		       (list.Count > 0 ? list.OrderByDescending(x => x.RevisionNumber).First() : null);
+	}
+
+	public static INPCTemplate? GetByIdOrUniqueNameOrName(this IEnumerable<INPCTemplate> templates, string value, bool permitAbbreviations = true)
+	{
+		var list = templates.ToList();
+		if (long.TryParse(value, out var id))
+		{
+			return BestCurrentMatch(list.Where(x => x.Id == id));
+		}
+
+		return list.FindByUniqueName(value) ?? GetByLegacyName(list, value, permitAbbreviations, preferEditing: false);
+	}
+
+	public static INPCTemplate? GetByIdOrUniqueNameOrNameForEditing(this IEnumerable<INPCTemplate> templates, string value)
+	{
+		var list = templates.ToList();
+		if (long.TryParse(value, out var id))
+		{
+			return BestEditingMatch(list.Where(x => x.Id == id));
+		}
+
+		return FindByUniqueNameForEditing(list, value) ?? GetByLegacyName(list, value, permitAbbreviations: true, preferEditing: true);
+	}
+
+	public static INPCTemplate? GetByIdOrUniqueNameOrNameRevisable(this IEnumerable<INPCTemplate> templates, string value)
+	{
+		return templates.GetByIdOrUniqueNameOrName(value);
+	}
+
+	public static INPCTemplate? GetActiveUniqueNameConflict(this IEnumerable<INPCTemplate> templates, string? uniqueName, long ownId)
+	{
+		var normalised = NormaliseUniqueName(uniqueName);
+		if (normalised is null)
+		{
+			return null;
+		}
+
+		return templates
+		       .Where(x => x.Id != ownId)
+		       .Where(x => x.Status.IsActiveForUniqueName())
+		       .FirstOrDefault(x => x.UniqueName?.Equals(normalised, StringComparison.InvariantCultureIgnoreCase) == true);
+	}
+
+	public static IEnumerable<INPCTemplate> WithBuilderText(this IEnumerable<INPCTemplate> templates, string text)
+	{
+		return templates.Where(x => x.HasBuilderSearchText(text));
+	}
+
+	public static bool HasBuilderSearchText(this INPCTemplate template, string text)
+	{
+		return template.UniqueName?.Contains(text, StringComparison.InvariantCultureIgnoreCase) == true ||
+		       template.BuilderNotes?.Contains(text, StringComparison.InvariantCultureIgnoreCase) == true;
+	}
+
+	private static INPCTemplate? FindByUniqueNameForEditing(IEnumerable<INPCTemplate> templates, string value)
+	{
+		var normalised = NormaliseUniqueName(value);
+		if (normalised is null)
+		{
+			return null;
+		}
+
+		var matches = templates
+		              .Where(x => x.Status.IsActiveForUniqueName())
+		              .Where(x => x.UniqueName?.Equals(normalised, StringComparison.InvariantCultureIgnoreCase) == true)
+		              .ToList();
+		return matches.FirstOrDefault(x => x.Status == RevisionStatus.UnderDesign) ??
+		       matches.FirstOrDefault(x => x.Status == RevisionStatus.PendingRevision) ??
+		       matches.FirstOrDefault(x => x.Status == RevisionStatus.Current) ??
+		       (matches.Count > 0 ? matches.OrderByDescending(x => x.RevisionNumber).First() : null);
+	}
+
+	private static INPCTemplate? GetByLegacyName(IEnumerable<INPCTemplate> templates, string value, bool permitAbbreviations, bool preferEditing)
+	{
+		var list = templates
+		           .Where(x => x.Name.Equals(value, StringComparison.InvariantCultureIgnoreCase))
+		           .ToList();
+		if (permitAbbreviations && list.Count == 0)
+		{
+			list = templates
+			       .Where(x => x.Name.StartsWith(value, StringComparison.InvariantCultureIgnoreCase))
+			       .ToList();
+		}
+
+		return preferEditing ? BestEditingMatch(list) : BestCurrentMatch(list);
+	}
+
+	private static INPCTemplate? BestCurrentMatch(IEnumerable<INPCTemplate> templates)
+	{
+		var list = templates.ToList();
+		return list.FirstOrDefault(x => x.Status == RevisionStatus.Current) ??
+		       list.FirstOrDefault(x => x.Status == RevisionStatus.PendingRevision || x.Status == RevisionStatus.UnderDesign) ??
+		       (list.Count > 0 ? list.OrderByDescending(x => x.RevisionNumber).First() : null);
+	}
+
+	private static INPCTemplate? BestEditingMatch(IEnumerable<INPCTemplate> templates)
+	{
+		var list = templates.ToList();
+		return list.FirstOrDefault(x => x.Status == RevisionStatus.UnderDesign) ??
+		       list.FirstOrDefault(x => x.Status == RevisionStatus.PendingRevision) ??
+		       list.FirstOrDefault(x => x.Status == RevisionStatus.Current) ??
+		       (list.Count > 0 ? list.OrderByDescending(x => x.RevisionNumber).First() : null);
+	}
+}

--- a/MudSharpCore Unit Tests/EditableItemReviewProposalTests.cs
+++ b/MudSharpCore Unit Tests/EditableItemReviewProposalTests.cs
@@ -5,6 +5,7 @@ using MudSharp.Character;
 using MudSharp.Framework;
 using MudSharp.Framework.Revision;
 using MudSharp.GameItems;
+using MudSharp.NPC.Templates;
 using MudSharp.PerceptionEngine;
 
 namespace MudSharp_Unit_Tests;
@@ -45,6 +46,39 @@ public class EditableItemReviewProposalTests
 			Times.Once);
 	}
 
+	[TestMethod]
+	public void Accept_SubmittedNpcTemplateCannotSubmit_DoesNotObsoleteCurrentRevision()
+	{
+		var current = CreateNpcTemplate(10, 0, RevisionStatus.Current, canSubmit: true, "current NPC template", "");
+		var pending = CreateNpcTemplate(10, 1, RevisionStatus.PendingRevision, canSubmit: false, "pending NPC template",
+			"duplicate unique name");
+		var templates = new RevisableAll<INPCTemplate>();
+		templates.Add(current.Object);
+		templates.Add(pending.Object);
+
+		var output = new Mock<IOutputHandler>();
+		var actor = new Mock<ICharacter>();
+		var account = new Mock<IAccount>();
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.NpcTemplates).Returns(templates);
+		actor.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		actor.SetupGet(x => x.OutputHandler).Returns(output.Object);
+		actor.SetupGet(x => x.Account).Returns(account.Object);
+
+		var proposal = new EditableItemReviewProposal<INPCTemplate>(actor.Object, [pending.Object]);
+
+		proposal.Accept("approval");
+
+		pending.Verify(x => x.CanSubmit(), Times.Once);
+		pending.Verify(x => x.WhyCannotSubmit(), Times.Once);
+		current.Verify(x => x.ChangeStatus(It.IsAny<RevisionStatus>(), It.IsAny<string>(), It.IsAny<IAccount>()),
+			Times.Never);
+		pending.Verify(x => x.ChangeStatus(It.IsAny<RevisionStatus>(), It.IsAny<string>(), It.IsAny<IAccount>()),
+			Times.Never);
+		output.Verify(x => x.Send(It.Is<string>(text => text.Contains("duplicate unique name")), true, false),
+			Times.Once);
+	}
+
 	private static Mock<IGameItemProto> CreateProto(long id, int revision, RevisionStatus status, bool canSubmit,
 		string editHeader, string whyCannotSubmit)
 	{
@@ -57,5 +91,19 @@ public class EditableItemReviewProposalTests
 		proto.Setup(x => x.WhyCannotSubmit()).Returns(whyCannotSubmit);
 		proto.Setup(x => x.EditHeader()).Returns(editHeader);
 		return proto;
+	}
+
+	private static Mock<INPCTemplate> CreateNpcTemplate(long id, int revision, RevisionStatus status, bool canSubmit,
+		string editHeader, string whyCannotSubmit)
+	{
+		var template = new Mock<INPCTemplate>();
+		template.SetupGet(x => x.Id).Returns(id);
+		template.SetupGet(x => x.RevisionNumber).Returns(revision);
+		template.SetupGet(x => x.Status).Returns(status);
+		template.SetupGet(x => x.Name).Returns(editHeader);
+		template.Setup(x => x.CanSubmit()).Returns(canSubmit);
+		template.Setup(x => x.WhyCannotSubmit()).Returns(whyCannotSubmit);
+		template.Setup(x => x.EditHeader()).Returns(editHeader);
+		return template;
 	}
 }

--- a/MudSharpCore Unit Tests/GameItemHelperTests.cs
+++ b/MudSharpCore Unit Tests/GameItemHelperTests.cs
@@ -4,6 +4,7 @@ using MudSharp.Commands.Helpers;
 using MudSharp.Framework;
 using MudSharp.Framework.Revision;
 using MudSharp.GameItems;
+using MudSharp.NPC.Templates;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -36,10 +37,41 @@ public class GameItemHelperTests
 		CollectionAssert.Contains(header, "Unique Name");
 	}
 
+	[TestMethod]
+	public void CustomSearch_NpcTemplateCommentFilter_FiltersByBuilderNotes()
+	{
+		var matching = NpcTemplate("Clockwork calibration notes.");
+		var other = NpcTemplate("Alchemy preparation notes.");
+		List<IEditableRevisableItem> protos = [matching.Object, other.Object];
+
+		var result = EditableRevisableItemHelper.NpcTemplateHelper.CustomSearch(
+			protos,
+			"comment:calibration",
+			new Mock<IFuturemud>().Object);
+
+		CollectionAssert.AreEqual(new[] { matching.Object }, result.Cast<INPCTemplate>().ToArray());
+	}
+
+	[TestMethod]
+	public void GetListTableHeaderFunc_NpcTemplate_IncludesUniqueName()
+	{
+		var header = EditableRevisableItemHelper.NpcTemplateHelper.GetListTableHeaderFunc(new Mock<MudSharp.Character.ICharacter>().Object)
+		                                         .ToArray();
+
+		CollectionAssert.Contains(header, "Unique Name");
+	}
+
 	private static Mock<IGameItemProto> Proto(string builderNotes)
 	{
 		var proto = new Mock<IGameItemProto>();
 		proto.SetupGet(x => x.BuilderNotes).Returns(builderNotes);
 		return proto;
+	}
+
+	private static Mock<INPCTemplate> NpcTemplate(string builderNotes)
+	{
+		var template = new Mock<INPCTemplate>();
+		template.SetupGet(x => x.BuilderNotes).Returns(builderNotes);
+		return template;
 	}
 }

--- a/MudSharpCore/Commands/Helpers/EditableRevisableItemHelper.cs
+++ b/MudSharpCore/Commands/Helpers/EditableRevisableItemHelper.cs
@@ -105,6 +105,7 @@ internal class EditableRevisableItemHelper
                                new[]
                                {
                                    item.Id.ToString(character), item.RevisionNumber.ToString(character),
+                                   item.UniqueName ?? "",
                                    item.Name.Proper(),
                                    item.Keywords.ListToString(separator: ", ", conjunction: "", twoItemJoiner: ""),
                                    item.NPCTemplateType,
@@ -114,13 +115,14 @@ internal class EditableRevisableItemHelper
                 }
             },
             GetReviewTableHeaderFunc =
-                character => new[] { "ID#", "Rev#", "Name", "Keywords", "Type", "Builder", "Comment" },
+                character => new[] { "ID#", "Rev#", "Unique Name", "Name", "Keywords", "Type", "Builder", "Comment" },
             GetListTableContentsFunc = (character, items) => from item in items.OfType<INPCTemplate>()
                                                              select
                                                                  new[]
                                                                  {
                                                                      item.Id.ToString(character),
                                                                      item.RevisionNumber.ToString(character),
+                                                                     item.UniqueName ?? "",
                                                                      item.Name.Proper(),
                                                                      item.NPCTemplateType,
                                                                      item.Status.Describe(),
@@ -128,7 +130,7 @@ internal class EditableRevisableItemHelper
                                                                               .Count(x => x.Template == item)
                                                                               .ToString(character).MXPSend($"npc instances {item.Id}", "View the instances")
                                                                  },
-            GetListTableHeaderFunc = character => new[] { "ID#", "Rev#", "Name", "Type", "Status", "Instances" },
+            GetListTableHeaderFunc = character => new[] { "ID#", "Rev#", "Unique Name", "Name", "Type", "Status", "Instances" },
             GetReviewProposalEffectFunc =
                 (protos, character) =>
                     new Accept(character,
@@ -146,6 +148,14 @@ internal class EditableRevisableItemHelper
                     }
                     return protos.OfType<INPCTemplate>()
                                  .Where(x => x.ArtificialIntelligences.Contains(ai))
+                                 .ToList<IEditableRevisableItem>();
+                }
+
+                if (keyword.StartsWith("comment:", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    keyword = keyword["comment:".Length..];
+                    return protos.OfType<INPCTemplate>()
+                                 .Where(x => x.BuilderNotes?.Contains(keyword, StringComparison.InvariantCultureIgnoreCase) == true)
                                  .ToList<IEditableRevisableItem>();
                 }
 

--- a/MudSharpCore/Commands/Modules/BaseBuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/BaseBuilderModule.cs
@@ -10,6 +10,7 @@ using MudSharp.Framework.Revision;
 using MudSharp.GameItems;
 using MudSharp.GameItems.Interfaces;
 using MudSharp.GameItems.Prototypes;
+using MudSharp.NPC.Templates;
 using MudSharp.PerceptionEngine;
 using MudSharp.PerceptionEngine.Lists;
 using MudSharp.PerceptionEngine.Outputs;
@@ -567,7 +568,8 @@ If you do not wish to approve or decline, you may type {"abort edit".Colour(Teln
                         protos = protos.Where(x =>
                             x.HasKeyword(subcmd, character.Body, true) ||
                             x.Name.Contains(subcmd, StringComparison.InvariantCultureIgnoreCase) ||
-                            x is IGameItemProto itemProto && itemProto.HasBuilderSearchText(subcmd)).ToList();
+                            (x is IGameItemProto itemProto && itemProto.HasBuilderSearchText(subcmd)) ||
+                            (x is INPCTemplate npcTemplate && npcTemplate.HasBuilderSearchText(subcmd))).ToList();
                         break;
                     }
 
@@ -583,7 +585,8 @@ If you do not wish to approve or decline, you may type {"abort edit".Colour(Teln
                         protos = protos.Where(x =>
                             !x.HasKeyword(subcmd, character.Body, true) &&
                             !x.Name.Contains(subcmd, StringComparison.InvariantCultureIgnoreCase) &&
-                            (x is not IGameItemProto itemProto || !itemProto.HasBuilderSearchText(subcmd))).ToList();
+                            (x is not IGameItemProto itemProto || !itemProto.HasBuilderSearchText(subcmd)) &&
+                            (x is not INPCTemplate npcTemplate || !npcTemplate.HasBuilderSearchText(subcmd))).ToList();
                         break;
                     }
 

--- a/MudSharpCore/Commands/Modules/ImplementorModule.cs
+++ b/MudSharpCore/Commands/Modules/ImplementorModule.cs
@@ -1944,9 +1944,7 @@ div.function-generalhelp {
             return;
         }
 
-        INPCTemplate template = long.TryParse(ss.PopSpeech(), out long value)
-            ? actor.Gameworld.NpcTemplates.Get(value)
-            : actor.Gameworld.NpcTemplates.GetByName(ss.Last, true);
+        INPCTemplate template = actor.Gameworld.NpcTemplates.GetByIdOrUniqueNameOrName(ss.SafeRemainingArgument);
 
         if (template == null)
         {

--- a/MudSharpCore/Commands/Modules/NPCBuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/NPCBuilderModule.cs
@@ -36,9 +36,13 @@ namespace MudSharp.Commands.Modules
 
         private static void NPCLoad(ICharacter character, StringStack command)
         {
-            INPCTemplate template = long.TryParse(command.PopSpeech(), out long value)
-                ? character.Gameworld.NpcTemplates.Get(value)
-                : character.Gameworld.NpcTemplates.GetByName(command.Last, true);
+            if (command.IsFinished)
+            {
+                character.OutputHandler.Send("Which NPC Template would you like to load?");
+                return;
+            }
+
+            INPCTemplate template = character.Gameworld.NpcTemplates.GetByIdOrUniqueNameOrName(command.SafeRemainingArgument);
             if (template == null)
             {
                 character.OutputHandler.Send("There is no such NPC Template to load.");
@@ -154,18 +158,18 @@ namespace MudSharp.Commands.Modules
 The core syntax to use this command is as follows:
 
 	#3npc edit new simple|variable#0 - creates a new NPC prototype
-	#3npc edit <id>#0 - opens prototype with ID for editing
+	#3npc edit <id|unique name>#0 - opens prototype for editing
 	#3npc edit#0 - shows the currently open NPC. Equivalent to doing NPC SHOW <ID> on it.
 	#3npc edit submit#0 - submits the open NPC for review
 	#3npc edit close#0 - closes the open NPC
 	#3npc edit delete#0 - deletes the open NPC prototype (only if not yet approved)
 	#3npc edit obsolete#0 - marks the NPC as obsolete, and no longer loadable
-	#3npc show <ID>#0 - shows info about prototype with ID
+	#3npc show <id|unique name>#0 - shows info about prototype
 	#3npc review all|mine|<admin name>|<id>#0 - opens the specified NPC prototypes for review and approval
-	#3npc clone <id>#0 - clones an existing prototype to a new one (also opens for editing)
+	#3npc clone <id|unique name>#0 - clones an existing prototype to a new one (also opens for editing)
 	#3npc set <parameters>#0 - makes a specific edit to an NPC. See NPC SET HELP for more info
 	#3npc make <id>|<target>#0 - clones a PC into a simple NPC Template (also opens for editing)
-	#3npc load <which>#0 - creates a new NPC character from the specified template
+	#3npc load <id|unique name>#0 - creates a new NPC character from the specified template
 	#3npc instances <template>#0 - lists all NPCs that have the specified template
 	#3npc list [<filters>]#0 - lists all NPC prototypes. See below for filters:
 
@@ -173,8 +177,9 @@ The core syntax to use this command is as follows:
 		#6mine#0 - only shows NPCs you personally created
 		#6by <account>#0 - only shows NPCs the nominated account created
 		#6reviewed <account>#0 - only shows NPCs the nominated account has approved
-		#6+<keyword>#0 - only shows NPCs with that keyword in their name or description
-		#6-<keyword>#0 - only shows NPCs without that keyword in their name or description
+		#6+<keyword>#0 - only shows NPCs with that keyword in their name, unique name or builder comment
+		#6-<keyword>#0 - only shows NPCs without that keyword in their name, unique name or builder comment
+		#6comment:<text>#0 - only shows NPCs with that text in their builder comment
 		#6&<ai>#0 - only shows NPCs with that AI attached";
 
         [PlayerCommand("NPC", "npc")]

--- a/MudSharpCore/Commands/Modules/ShowModule.cs
+++ b/MudSharpCore/Commands/Modules/ShowModule.cs
@@ -2432,13 +2432,7 @@ public class ShowModule : Module<ICharacter>
                     return;
                 }
 
-                if (!long.TryParse(ss.PopSpeech(), out value))
-                {
-                    actor.Send("That is not a valid ID number for an NPC template.");
-                    return;
-                }
-
-                INPCTemplate template = actor.Gameworld.NpcTemplates.Get(value);
+                INPCTemplate template = actor.Gameworld.NpcTemplates.GetByIdOrUniqueNameOrName(ss.SafeRemainingArgument);
                 if (template == null)
                 {
                     actor.Send("There is no such NPC Template.");
@@ -2560,13 +2554,7 @@ public class ShowModule : Module<ICharacter>
                     return;
                 }
 
-                if (!long.TryParse(ss.PopSpeech(), out value))
-                {
-                    actor.Send("That is not a valid ID number for an NPC template.");
-                    return;
-                }
-
-                INPCTemplate template = actor.Gameworld.NpcTemplates.Get(value);
+                INPCTemplate template = actor.Gameworld.NpcTemplates.GetByIdOrUniqueNameOrName(ss.SafeRemainingArgument);
                 if (template == null)
                 {
                     actor.Send("There is no such NPC Template.");

--- a/MudSharpCore/Framework/RevisableAll.cs
+++ b/MudSharpCore/Framework/RevisableAll.cs
@@ -1,5 +1,6 @@
 ﻿using MudSharp.Framework.Revision;
 using MudSharp.GameItems;
+using MudSharp.NPC.Templates;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -139,6 +140,13 @@ public class RevisableAll<T> : IRevisableAll<T>, IUneditableRevisableAll<T> wher
                    .GetByIdOrUniqueNameOrName(value, permitAbbreviations) as T;
         }
 
+        if (typeof(INPCTemplate).IsAssignableFrom(typeof(T)))
+        {
+            return _iterlist
+                   .Cast<INPCTemplate>()
+                   .GetByIdOrUniqueNameOrName(value, permitAbbreviations) as T;
+        }
+
         if (long.TryParse(value, out long id))
         {
             return Get(id);
@@ -170,6 +178,14 @@ public class RevisableAll<T> : IRevisableAll<T>, IUneditableRevisableAll<T> wher
         {
             var match = _iterlist
                         .Cast<IGameItemProto>()
+                        .GetByIdOrUniqueNameOrName(value, permitAbbreviations);
+            return match is null ? [] : GetAll(match.Id);
+        }
+
+        if (typeof(INPCTemplate).IsAssignableFrom(typeof(T)))
+        {
+            var match = _iterlist
+                        .Cast<INPCTemplate>()
                         .GetByIdOrUniqueNameOrName(value, permitAbbreviations);
             return match is null ? [] : GetAll(match.Id);
         }

--- a/MudSharpCore/FutureProg/Functions/BuiltIn/LoadNpcFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/BuiltIn/LoadNpcFunction.cs
@@ -30,17 +30,33 @@ internal class LoadNpcFunction : BuiltInFunction
             return StatementResult.Error;
         }
 
-        long vnum = (long)(decimal)(ParameterFunctions[0].Result?.GetObject ?? 0);
-        INPCTemplate proto = _gameworld.NpcTemplates.Get(vnum);
-        if (proto == null)
+        var templateParameter = ParameterFunctions[0].Result?.GetObject;
+        var templateLabel = templateParameter?.ToString() ?? "<null>";
+        INPCTemplate proto;
+        if (templateParameter is decimal number)
         {
-            ErrorMessage = "There was no prototype " + vnum;
-            return StatementResult.Error;
+            var vnum = (long)number;
+            proto = _gameworld.NpcTemplates.Get(vnum);
+            if (proto == null)
+            {
+                ErrorMessage = "There was no prototype " + vnum;
+                return StatementResult.Error;
+            }
+        }
+        else
+        {
+            var uniqueName = templateParameter?.ToString();
+            proto = _gameworld.NpcTemplates.FindByUniqueName(uniqueName);
+            if (proto == null)
+            {
+                ErrorMessage = "There was no prototype with the unique name " + (uniqueName ?? "<null>");
+                return StatementResult.Error;
+            }
         }
 
         if (proto.Status != RevisionStatus.Current)
         {
-            ErrorMessage = "Prototype " + vnum + " is not approved for use.";
+            ErrorMessage = "Prototype " + templateLabel + " is not approved for use.";
             return StatementResult.Error;
         }
 
@@ -91,12 +107,38 @@ internal class LoadNpcFunction : BuiltInFunction
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "loadnpc",
+            new[] { ProgVariableTypes.Text, ProgVariableTypes.Location },
+            (pars, gameworld) => new LoadNpcFunction(pars, gameworld),
+            new List<string> { "UniqueName", "Location" },
+            new List<string> { "The unique name of the NPC template to load", "The location into which they will be loaded" },
+            "This function loads an NPC from a specified template into a location.",
+            "NPCs",
+            ProgVariableTypes.Character
+        ));
+
+        FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+            "loadnpc",
             new[] { ProgVariableTypes.Number, ProgVariableTypes.Location, ProgVariableTypes.Text },
             (pars, gameworld) => new LoadNpcFunction(pars, gameworld),
             new List<string> { "Id", "Location", "Layer" },
             new List<string>
             {
                 "The Id of the NPC template to load", "The location into which they will be loaded",
+                "The layer into which to load the NPC"
+            },
+            "This function loads an NPC from a specified template into a location.",
+            "NPCs",
+            ProgVariableTypes.Character
+        ));
+
+        FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+            "loadnpc",
+            new[] { ProgVariableTypes.Text, ProgVariableTypes.Location, ProgVariableTypes.Text },
+            (pars, gameworld) => new LoadNpcFunction(pars, gameworld),
+            new List<string> { "UniqueName", "Location", "Layer" },
+            new List<string>
+            {
+                "The unique name of the NPC template to load", "The location into which they will be loaded",
                 "The layer into which to load the NPC"
             },
             "This function loads an NPC from a specified template into a location.",

--- a/MudSharpCore/NPC/Templates/NPCTemplateBase.cs
+++ b/MudSharpCore/NPC/Templates/NPCTemplateBase.cs
@@ -32,6 +32,8 @@ public abstract class NPCTemplateBase : EditableItem, INPCTemplate
         Gameworld = gameworld;
         _id = template.Id;
         _name = template.Name;
+        UniqueName = NPCTemplateLookupExtensions.NormaliseUniqueName(template.UniqueName);
+        BuilderNotes = string.IsNullOrWhiteSpace(template.BuilderNotes) ? null : template.BuilderNotes;
         RevisionNumber = template.RevisionNumber;
         XElement definition = XElement.Parse(template.Definition);
         XElement element = definition.Element("OnLoadProg");
@@ -69,7 +71,9 @@ public abstract class NPCTemplateBase : EditableItem, INPCTemplate
                 Id = Gameworld.NpcTemplates.NextID(),
                 Name = _name,
                 Type = type,
-                Definition = "<Definition/>"
+                Definition = "<Definition/>",
+                UniqueName = null,
+                BuilderNotes = null
             };
             FMDB.Context.NpcTemplates.Add(dbnew);
             dbnew.EditableItem = new Models.EditableItem();
@@ -107,8 +111,23 @@ public abstract class NPCTemplateBase : EditableItem, INPCTemplate
             case "combatsetting":
             case "combat":
                 return BuildingCommandCombatSetting(actor, command);
+            case "unique":
+            case "uniquename":
+            case "key":
+                return BuildingCommandUniqueName(actor, command);
+            case "comment":
+            case "notes":
+            case "buildercomment":
+            case "buildernotes":
+                return BuildingCommandBuilderNotes(actor, command);
             default:
                 actor.OutputHandler.Send($@"{HelpText}
+	#3unique <name>#0 - sets a unique lookup name for this NPC template
+	#3unique clear#0 - clears the unique lookup name
+	#3comment <text>#0 - overwrites the builder comment
+	#3comment append <text>#0 - appends to the builder comment
+	#3comment edit#0 - edits the builder comment in the editor
+	#3comment clear#0 - clears the builder comment
 	#3onload <prog>#0 - adds an onload prog to this NPC
 	#3onload clear#0 - clears an onload prog
 	#3combatsetting <setting>#0 - sets the default combat setting for this NPC
@@ -161,6 +180,122 @@ public abstract class NPCTemplateBase : EditableItem, INPCTemplate
             default:
                 throw new NotSupportedException();
         }
+    }
+
+    private bool BuildingCommandUniqueName(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("What unique name do you want to set for this NPC template?");
+            return false;
+        }
+
+        var uniqueName = NPCTemplateLookupExtensions.NormaliseUniqueName(command.SafeRemainingArgument);
+        if (uniqueName is null || uniqueName.EqualToAny("none", "clear", "delete", "remove"))
+        {
+            UniqueName = null;
+            Changed = true;
+            actor.OutputHandler.Send("This NPC template no longer has a unique lookup name.");
+            return true;
+        }
+
+        if (!NPCTemplateLookupExtensions.IsValidUniqueName(uniqueName))
+        {
+            actor.OutputHandler.Send("Unique names cannot be entirely numeric, because numeric NPC template input is reserved for IDs.");
+            return false;
+        }
+
+        var conflict = Gameworld.NpcTemplates.GetActiveUniqueNameConflict(uniqueName, Id);
+        if (conflict is not null)
+        {
+            actor.OutputHandler.Send(
+                $"The unique name {uniqueName.ColourCommand()} is already used by {conflict.EditHeader().ColourName()}.");
+            return false;
+        }
+
+        UniqueName = uniqueName;
+        Changed = true;
+        actor.OutputHandler.Send($"This NPC template can now be looked up by the unique name {UniqueName.ColourCommand()}.");
+        return true;
+    }
+
+    private bool BuildingCommandBuilderNotes(ICharacter actor, StringStack command)
+    {
+        var subCommand = command.PopSpeech();
+        if (subCommand.Length == 0)
+        {
+            actor.OutputHandler.Send("Do you want to set, append, edit or clear the builder comment?");
+            return false;
+        }
+
+        switch (subCommand.ToLowerInvariant())
+        {
+            case "clear":
+            case "none":
+            case "delete":
+            case "remove":
+                BuilderNotes = null;
+                Changed = true;
+                actor.OutputHandler.Send("You clear the builder comment for this NPC template.");
+                return true;
+            case "edit":
+                actor.OutputHandler.Send("Enter the builder comment in the editor below.");
+                actor.EditorMode(BuildingCommandBuilderNotesPost, BuildingCommandBuilderNotesCancel, 1.0,
+                    BuilderNotes, suppliedArguments: [false]);
+                return true;
+            case "append":
+                if (command.IsFinished)
+                {
+                    actor.OutputHandler.Send("Enter the text to append to the builder comment in the editor below.");
+                    actor.EditorMode(BuildingCommandBuilderNotesPost, BuildingCommandBuilderNotesCancel, 1.0,
+                        null, suppliedArguments: [true]);
+                    return true;
+                }
+
+                AppendBuilderNotes(command.SafeRemainingArgument);
+                actor.OutputHandler.Send("You append to the builder comment for this NPC template.");
+                return true;
+        }
+
+        var text = command.IsFinished ? subCommand : $"{subCommand} {command.SafeRemainingArgument}";
+        BuilderNotes = string.IsNullOrWhiteSpace(text) ? null : text.Trim();
+        Changed = true;
+        actor.OutputHandler.Send("You set the builder comment for this NPC template.");
+        return true;
+    }
+
+    private void BuildingCommandBuilderNotesPost(string text, IOutputHandler handler, object[] arguments)
+    {
+        var append = (bool)arguments[0];
+        if (append)
+        {
+            AppendBuilderNotes(text);
+            handler.Send("You append to the builder comment for this NPC template.");
+            return;
+        }
+
+        BuilderNotes = string.IsNullOrWhiteSpace(text) ? null : text.Trim();
+        Changed = true;
+        handler.Send("You set the builder comment for this NPC template.");
+    }
+
+    private void BuildingCommandBuilderNotesCancel(IOutputHandler handler, object[] arguments)
+    {
+        handler.Send("You decide not to change the builder comment.");
+    }
+
+    private void AppendBuilderNotes(string text)
+    {
+        var trimmed = text.Trim();
+        if (trimmed.Length == 0)
+        {
+            return;
+        }
+
+        BuilderNotes = string.IsNullOrWhiteSpace(BuilderNotes)
+            ? trimmed
+            : $"{BuilderNotes.TrimEnd()}\n{trimmed}";
+        Changed = true;
     }
 
     private bool BuildingCommandCombatSetting(ICharacter actor, StringStack command)
@@ -365,6 +500,10 @@ public abstract class NPCTemplateBase : EditableItem, INPCTemplate
 
     #region INPCTemplate Members
 
+    public string? UniqueName { get; protected set; }
+
+    public string? BuilderNotes { get; protected set; }
+
     public ICharacterTemplate GetCharacterTemplate(ICell cell = null)
     {
         return CharacterTemplate(cell);
@@ -386,4 +525,27 @@ public abstract class NPCTemplateBase : EditableItem, INPCTemplate
     public abstract INPCTemplate Clone(ICharacter builder);
 
     #endregion
+
+    public override bool CanSubmit()
+    {
+        return NPCTemplateLookupExtensions.IsValidUniqueName(UniqueName) &&
+               Gameworld.NpcTemplates.GetActiveUniqueNameConflict(UniqueName, Id) is null;
+    }
+
+    public override string WhyCannotSubmit()
+    {
+        if (!NPCTemplateLookupExtensions.IsValidUniqueName(UniqueName))
+        {
+            return "The unique name cannot be entirely numeric, because numeric NPC template input is reserved for IDs.";
+        }
+
+        var uniqueNameConflict = Gameworld.NpcTemplates.GetActiveUniqueNameConflict(UniqueName, Id);
+        if (uniqueNameConflict is not null)
+        {
+            return
+                $"The unique name {UniqueName!.ColourCommand()} is already used by {uniqueNameConflict.EditHeader().ColourName()}.";
+        }
+
+        return base.WhyCannotSubmit();
+    }
 }

--- a/MudSharpCore/NPC/Templates/SimpleNPCTemplate.cs
+++ b/MudSharpCore/NPC/Templates/SimpleNPCTemplate.cs
@@ -58,12 +58,13 @@ public class SimpleNPCTemplate : NPCTemplateBase
         }
     }
 
-    public SimpleNPCTemplate(IFuturemud gameworld, IAccount originator, ICharacterTemplate template, string name) :
+    public SimpleNPCTemplate(IFuturemud gameworld, IAccount originator, ICharacterTemplate template, string name, string builderNotes = null) :
         base(
             gameworld, originator, "Simple")
     {
         Initialise();
         _name = string.IsNullOrEmpty(name) ? template.SelectedName.GetName(NameStyle.FullName) : name;
+        BuilderNotes = string.IsNullOrWhiteSpace(builderNotes) ? null : builderNotes;
         SelectedGender = template.SelectedGender;
         SelectedAccents = template.SelectedAccents.ToList();
         SelectedBirthday = template.SelectedBirthday;
@@ -89,6 +90,7 @@ public class SimpleNPCTemplate : NPCTemplateBase
             dbitem.EditableItem.RevisionStatus = (int)RevisionStatus.Current;
             dbitem.EditableItem.ReviewerAccountId = originator.Id;
             dbitem.EditableItem.ReviewerDate = date;
+            dbitem.BuilderNotes = BuilderNotes;
             dbitem.Definition = SaveDefinition();
             FMDB.Context.SaveChanges();
         }
@@ -100,7 +102,7 @@ public class SimpleNPCTemplate : NPCTemplateBase
 
     public override INPCTemplate Clone(ICharacter builder)
     {
-        return new SimpleNPCTemplate(Gameworld, builder.Account, GetCharacterTemplate(null), Name);
+        return new SimpleNPCTemplate(Gameworld, builder.Account, GetCharacterTemplate(null), Name, BuilderNotes);
     }
 
     public override string FrameworkItemType => "SimpleNPCTemplate";
@@ -267,7 +269,8 @@ public class SimpleNPCTemplate : NPCTemplateBase
             {
                 $"Created By: {FMDB.Context.Accounts.Find(BuilderAccountID).Name.Proper().Colour(Telnet.Green)}",
                 $"Reviewed By: {(ReviewerAccountID.HasValue ? FMDB.Context.Accounts.Find(ReviewerAccountID.Value).Name.Proper().Colour(Telnet.Green) : "N/A")}",
-                $"Status: {Status.Describe().Colour(Telnet.Green)}"
+                $"Status: {Status.Describe().Colour(Telnet.Green)}",
+                $"Unique Name: {(string.IsNullOrEmpty(UniqueName) ? "None".ColourCommand() : UniqueName.ColourValue())}"
             }.ArrangeStringsOntoLines(3, (uint)actor.LineFormatLength));
 
             sb.Append(new[]
@@ -331,6 +334,12 @@ public class SimpleNPCTemplate : NPCTemplateBase
                     $"Birthday: {SelectedBirthday.Display(CalendarDisplayMode.Long).ColourValue()} ({SelectedBirthday.Calendar.CurrentDate.YearsDifference(SelectedBirthday).ToString("N0", actor).ColourValue()} years old)");
             }
 
+            sb.AppendLine();
+            sb.AppendLine("Builder Comment:");
+            sb.AppendLine();
+            sb.AppendLine(string.IsNullOrWhiteSpace(BuilderNotes)
+                ? "\tNone".ColourName()
+                : BuilderNotes.Wrap(actor.InnerLineFormatLength, "  "));
             sb.AppendLine();
             sb.AppendLine("Attributes:");
             foreach (ITrait item in SelectedAttributes.OrderBy(x => ((IAttributeDefinition)x.Definition).DisplayOrder))
@@ -442,6 +451,8 @@ public class SimpleNPCTemplate : NPCTemplateBase
                                      .DefaultIfEmpty(0)
                                      .Max() + 1,
                 Name = Name,
+                UniqueName = UniqueName,
+                BuilderNotes = BuilderNotes,
                 Definition = SaveDefinition()
             };
             foreach (IArtificialIntelligence item in ArtificialIntelligences)
@@ -477,6 +488,8 @@ public class SimpleNPCTemplate : NPCTemplateBase
             dbItem.Name = SelectedName != null
                 ? SelectedName.GetName(NameStyle.FullWithNickname)
                 : "Unnamed NPC Template #" + Id;
+            dbItem.UniqueName = UniqueName;
+            dbItem.BuilderNotes = BuilderNotes;
             dbItem.Definition = SaveDefinition();
             FMDB.Context.NpctemplatesArtificalIntelligences.RemoveRange(dbItem.NpctemplatesArtificalIntelligences);
             foreach (IArtificialIntelligence item in ArtificialIntelligences)
@@ -799,7 +812,8 @@ public class SimpleNPCTemplate : NPCTemplateBase
                              .All(x => SelectedAccents.Any(y => y.Language.LinkedTrait == x)) &&
                !string.IsNullOrEmpty(SelectedSdesc) &&
                SelectedRace.HandednessOptions.Contains(Handedness) &&
-               !string.IsNullOrEmpty(SelectedFullDesc);
+               !string.IsNullOrEmpty(SelectedFullDesc) &&
+               base.CanSubmit();
     }
 
     public override string WhyCannotSubmit()

--- a/MudSharpCore/NPC/Templates/VariableNPCTemplate.cs
+++ b/MudSharpCore/NPC/Templates/VariableNPCTemplate.cs
@@ -86,6 +86,8 @@ public class VariableNPCTemplate : NPCTemplateBase
                 Id = Gameworld.NpcTemplates.NextID(),
                 RevisionNumber = 0,
                 Name = Name,
+                UniqueName = null,
+                BuilderNotes = BuilderNotes,
                 Type = "Variable",
                 Definition = SaveDefinition()
             };
@@ -359,7 +361,8 @@ public class VariableNPCTemplate : NPCTemplateBase
                         _nameProfiles.Any(y => y.Key == x.Value)) &&
                _race != null &&
                _culture != null &&
-               Gameworld.Ethnicities.Any(x => _race.SameRace(x.ParentRace));
+               Gameworld.Ethnicities.Any(x => _race.SameRace(x.ParentRace)) &&
+               base.CanSubmit();
     }
 
     public override string WhyCannotSubmit()
@@ -402,6 +405,11 @@ public class VariableNPCTemplate : NPCTemplateBase
                 errors.Add(
                     $"You are missing name profiles for the following genders: {genders.Select(x => x.DescribeEnum()).ListToString()}");
             }
+        }
+
+        if (!base.CanSubmit())
+        {
+            errors.Add(base.WhyCannotSubmit());
         }
 
         return errors.Select(x => x.ColourIncludingReset(Telnet.Red)).ListToLines(true);
@@ -563,7 +571,8 @@ public class VariableNPCTemplate : NPCTemplateBase
                         : "N/A",
                     "Reviewed By"),
                 string.Format("{1}: {0}", Status.Describe().Colour(Telnet.Green),
-                    "Status")
+                    "Status"),
+                $"Unique Name: {(string.IsNullOrEmpty(UniqueName) ? "None".ColourCommand() : UniqueName.ColourValue())}"
             }.ArrangeStringsOntoLines(3, Math.Min(120u, (uint)actor.Account.LineFormatLength)));
         }
 
@@ -587,6 +596,14 @@ public class VariableNPCTemplate : NPCTemplateBase
 
         sb.AppendLine($"Sdesc Pattern: {(_sdescPattern != null ? $"{_sdescPattern.Pattern.ColourCharacter()} (#{_sdescPattern.Id.ToStringN0Colour(actor)})" : "Random".Colour(Telnet.Red))}");
         sb.AppendLine($"Fdesc Pattern: {(_fdescPattern != null ? _fdescPattern.Id.ToStringN0Colour(actor) : "Random".Colour(Telnet.Red))}");
+
+        sb.AppendLine();
+        sb.AppendLine("Builder Comment:");
+        sb.AppendLine();
+        sb.AppendLine(string.IsNullOrWhiteSpace(BuilderNotes)
+            ? "\tNone".ColourName()
+            : BuilderNotes.Wrap(actor.InnerLineFormatLength, "  "));
+        sb.AppendLine();
 
         sb.AppendLine();
         sb.AppendLine("Gender Chances:");
@@ -729,6 +746,8 @@ public class VariableNPCTemplate : NPCTemplateBase
                                      .DefaultIfEmpty(0)
                                      .Max() + 1,
                 Name = Name,
+                UniqueName = UniqueName,
+                BuilderNotes = BuilderNotes,
                 Type = "Variable",
                 Definition = SaveDefinition()
             };
@@ -763,6 +782,8 @@ public class VariableNPCTemplate : NPCTemplateBase
             NpcTemplate dbItem = FMDB.Context.NpcTemplates.Find(Id, RevisionNumber);
             dbItem.Definition = SaveDefinition();
             dbItem.Name = _name;
+            dbItem.UniqueName = UniqueName;
+            dbItem.BuilderNotes = BuilderNotes;
             FMDB.Context.NpctemplatesArtificalIntelligences.RemoveRange(dbItem.NpctemplatesArtificalIntelligences);
             foreach (IArtificialIntelligence item in ArtificialIntelligences)
             {

--- a/MudSharpCore/Work/Crafts/Products/NPCProduct.cs
+++ b/MudSharpCore/Work/Crafts/Products/NPCProduct.cs
@@ -242,7 +242,7 @@ internal class NPCProduct : BaseProduct
             return false;
         }
 
-        INPCTemplate template = Gameworld.NpcTemplates.GetByRevisableId(command.SafeRemainingArgument);
+        INPCTemplate template = Gameworld.NpcTemplates.GetByIdOrUniqueNameOrName(command.SafeRemainingArgument);
         if (template is null)
         {
             actor.OutputHandler.Send("There is no such NPC Template.");

--- a/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextConfiguring3.cs
+++ b/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextConfiguring3.cs
@@ -714,6 +714,9 @@ namespace MudSharp.Database
                 entity.HasIndex(e => e.EditableItemId)
                     .HasDatabaseName("FK_NPCTemplates_EditableItems");
 
+                entity.HasIndex(e => e.UniqueName)
+                    .HasDatabaseName("IX_NPCTemplates_UniqueName");
+
                 entity.Property(e => e.Id).HasColumnType("bigint(20)");
 
                 entity.Property(e => e.RevisionNumber).HasColumnType("int(11)");
@@ -729,6 +732,16 @@ namespace MudSharp.Database
                 entity.Property(e => e.Name)
                     .IsRequired()
                     .HasColumnType("varchar(255)")
+                    .HasCharSet("utf8")
+                    .UseCollation("utf8_general_ci");
+
+                entity.Property(e => e.UniqueName)
+                    .HasColumnType("varchar(255)")
+                    .HasCharSet("utf8")
+                    .UseCollation("utf8_general_ci");
+
+                entity.Property(e => e.BuilderNotes)
+                    .HasColumnType("text")
                     .HasCharSet("utf8")
                     .UseCollation("utf8_general_ci");
 

--- a/MudsharpDatabaseLibrary/Migrations/20260523134149_NpcTemplateUniqueNameBuilderNotes.Designer.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260523134149_NpcTemplateUniqueNameBuilderNotes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MudSharp.Database;
 
@@ -11,9 +12,11 @@ using MudSharp.Database;
 namespace MudSharp.Migrations
 {
     [DbContext(typeof(FuturemudDatabaseContext))]
-    partial class FutureMUDContextModelSnapshot : ModelSnapshot
+    [Migration("20260523134149_NpcTemplateUniqueNameBuilderNotes")]
+    partial class NpcTemplateUniqueNameBuilderNotes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MudsharpDatabaseLibrary/Migrations/20260523134149_NpcTemplateUniqueNameBuilderNotes.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260523134149_NpcTemplateUniqueNameBuilderNotes.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MudSharp.Migrations
+{
+    /// <inheritdoc />
+    public partial class NpcTemplateUniqueNameBuilderNotes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "BuilderNotes",
+                table: "NPCTemplates",
+                type: "text",
+                nullable: true,
+                collation: "utf8_general_ci")
+                .Annotation("MySql:CharSet", "utf8");
+
+            migrationBuilder.AddColumn<string>(
+                name: "UniqueName",
+                table: "NPCTemplates",
+                type: "varchar(255)",
+                nullable: true,
+                collation: "utf8_general_ci")
+                .Annotation("MySql:CharSet", "utf8");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NPCTemplates_UniqueName",
+                table: "NPCTemplates",
+                column: "UniqueName");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_NPCTemplates_UniqueName",
+                table: "NPCTemplates");
+
+            migrationBuilder.DropColumn(
+                name: "BuilderNotes",
+                table: "NPCTemplates");
+
+            migrationBuilder.DropColumn(
+                name: "UniqueName",
+                table: "NPCTemplates");
+        }
+    }
+}

--- a/MudsharpDatabaseLibrary/Models/NpcTemplate.cs
+++ b/MudsharpDatabaseLibrary/Models/NpcTemplate.cs
@@ -14,6 +14,8 @@ namespace MudSharp.Models
         public long Id { get; set; }
         public string Type { get; set; }
         public string Name { get; set; }
+        public string UniqueName { get; set; }
+        public string BuilderNotes { get; set; }
         public string Definition { get; set; }
         public long EditableItemId { get; set; }
         public int RevisionNumber { get; set; }


### PR DESCRIPTION
## Summary
- Adds optional `UniqueName` and `BuilderNotes` metadata to NPC templates, including EF model/configuration and migration artifacts.
- Adds NPC-template lookup helpers and wires unique-name lookup into generic revisable lookup, builder commands, NPC load/clone/show flows, craft/agriculture/magic/spawner selector paths, and `loadnpc(text)` FutureProg overloads.
- Adds NPC builder command support, show/list/review table display, builder-comment filtering, and documentation updates.

## Validation
- `dotnet restore MudSharp.sln -m:1 -p:RestoreBuildInParallel=false -p:NuGetAudit=false`
- `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1`
- `dotnet test 'FutureMUDLibrary Unit Tests\FutureMUDLibrary Unit Tests.csproj' -c Debug --no-restore -m:1`
- `git diff --check`
- `git diff --cached --check`