### PR TITLE
Close antiquity item seeder supply gaps

### DIFF
--- a/DatabaseSeeder Unit Tests/AgricultureSeederTests.cs
+++ b/DatabaseSeeder Unit Tests/AgricultureSeederTests.cs
@@ -85,7 +85,12 @@ public class AgricultureSeederTests
 		context.Tags.AddRange(
 			new Tag { Id = 1, Name = "Seeds" },
 			new Tag { Id = 2, Name = "Seeded Yield" },
-			new Tag { Id = 3, Name = "Agriculture Seedable" });
+			new Tag { Id = 3, Name = "Agriculture Seedable" },
+			new Tag { Id = 4, Name = "Bee Hive" },
+			new Tag { Id = 5, Name = "Hive Stand" },
+			new Tag { Id = 6, Name = "Raw Honeycomb" },
+			new Tag { Id = 7, Name = "Pressed Honey" },
+			new Tag { Id = 8, Name = "Rendered Beeswax" });
 		context.TraitDefinitions.Add(new TraitDefinition
 		{
 			Id = 10,
@@ -141,11 +146,11 @@ public class AgricultureSeederTests
 		seeder.SeedData(context, new Dictionary<string, string>());
 		seeder.SeedData(context, new Dictionary<string, string>());
 
-		Assert.AreEqual(45, context.AgricultureFieldProfiles.Count());
+		Assert.AreEqual(46, context.AgricultureFieldProfiles.Count());
 		Assert.AreEqual(136, context.AgricultureCropDefinitions.Count());
 		Assert.AreEqual(4, context.AgricultureHerdDefinitions.Count());
 		Assert.AreEqual(8, context.AgricultureWoodlandDefinitions.Count());
-		Assert.AreEqual(18, context.AgricultureOperations.Count());
+		Assert.AreEqual(22, context.AgricultureOperations.Count());
 		foreach (var cropName in new[]
 		         {
 			         "Wheat", "Barley", "Rye", "Oats", "Quinoa", "Field Beans", "Peas", "Lentils", "Potatoes",
@@ -243,6 +248,9 @@ public class AgricultureSeederTests
 		Assert.AreEqual("Fallow,Crop", paddyDefinition.Attribute("uses")!.Value);
 		Assert.AreEqual("90", paddyDefinition.Elements("Score").Single(x => x.Attribute("type")!.Value == "Moisture").Attribute("value")!.Value);
 
+		var apiaryYardDefinition = XElement.Parse(context.AgricultureFieldProfiles.Single(x => x.Name == "Apiary Yard").Definition);
+		Assert.AreEqual("Fallow,Crop,Orchard,Pasture,Woodland", apiaryYardDefinition.Attribute("uses")!.Value);
+
 		var wheatDefinition = XElement.Parse(context.AgricultureCropDefinitions.Single(x => x.Name == "Wheat").Definition);
 		Assert.AreEqual("110", wheatDefinition.Attribute("growthDays")!.Value);
 		Assert.AreEqual("18", wheatDefinition.Attribute("harvestWindowDays")!.Value);
@@ -254,6 +262,7 @@ public class AgricultureSeederTests
 			x.Attribute("material")!.Value == "wheat" &&
 			x.Attribute("weight")!.Value == "2500000" &&
 			x.Attribute("tag")!.Value == "Seeded Yield"));
+		Assert.AreEqual("None", wheatDefinition.Element("Pollination")!.Attribute("dependency")!.Value);
 
 		var applesDefinition = XElement.Parse(context.AgricultureCropDefinitions.Single(x => x.Name == "Apples").Definition);
 		Assert.AreEqual("true", applesDefinition.Attribute("perennial")!.Value);
@@ -262,6 +271,12 @@ public class AgricultureSeederTests
 		Assert.IsTrue(applesDefinition.Element("Outputs")!.Elements("Commodity").Any(x =>
 			x.Attribute("material")!.Value == "apple" &&
 			x.Attribute("tag")!.Value == "Seeded Yield"));
+		Assert.AreEqual("Strong", applesDefinition.Element("Pollination")!.Attribute("dependency")!.Value);
+		Assert.AreEqual("1", applesDefinition.Element("Pollination")!.Attribute("healthBonus")!.Value);
+		Assert.AreEqual("2", applesDefinition.Element("Pollination")!.Attribute("yieldBonus")!.Value);
+
+		var cucumberDefinition = XElement.Parse(context.AgricultureCropDefinitions.Single(x => x.Name == "Cucumbers").Definition);
+		Assert.AreEqual("Required", cucumberDefinition.Element("Pollination")!.Attribute("dependency")!.Value);
 
 		var walnutsDefinition = XElement.Parse(context.AgricultureCropDefinitions.Single(x => x.Name == "Walnuts").Definition);
 		Assert.IsTrue(walnutsDefinition.Element("Outputs")!.Elements("Commodity").Any(x =>
@@ -296,11 +311,25 @@ public class AgricultureSeederTests
 		Assert.AreEqual("0.45", coppiceDefinition.Attribute("woodlandYieldMultiplier")!.Value);
 		Assert.AreEqual("45", coppiceDefinition.Attribute("woodlandYieldCost")!.Value);
 
+		var installApiary = context.AgricultureOperations.Single(x => x.Name == "Install Apiary");
+		Assert.AreEqual((int)AgricultureOperationType.InstallApiary, installApiary.OperationType);
+		var installApiaryDefinition = XElement.Parse(installApiary.Definition);
+		Assert.AreEqual("Fallow,Crop,Orchard,Pasture,Woodland", installApiaryDefinition.Element("AllowedUses")!.Attribute("uses")!.Value);
+		Assert.AreEqual("2", installApiaryDefinition.Element("Apiary")!.Attribute("installHives")!.Value);
+		Assert.AreEqual("2", installApiaryDefinition.Element("Apiary")!.Attribute("pollinationRadius")!.Value);
+
+		var harvestApiary = context.AgricultureOperations.Single(x => x.Name == "Harvest Apiary");
+		Assert.AreEqual((int)AgricultureOperationType.HarvestApiary, harvestApiary.OperationType);
+		var apiaryOutputs = XElement.Parse(harvestApiary.Definition).Element("Apiary")!.Element("Outputs")!.Elements("Commodity").ToArray();
+		Assert.IsTrue(apiaryOutputs.Any(x => x.Attribute("material")!.Value == "honeycomb" && x.Attribute("tag")!.Value == "Raw Honeycomb"));
+		Assert.IsTrue(apiaryOutputs.Any(x => x.Attribute("material")!.Value == "honey" && x.Attribute("tag")!.Value == "Pressed Honey"));
+		Assert.IsTrue(apiaryOutputs.Any(x => x.Attribute("material")!.Value == "beeswax" && x.Attribute("tag")!.Value == "Rendered Beeswax"));
+
 		var projectIds = context.Projects
 			.Where(x => x.Name.StartsWith("Stock Agriculture:"))
 			.Select(x => x.Id)
 			.ToHashSet();
-		Assert.AreEqual(18, projectIds.Count);
+		Assert.AreEqual(22, projectIds.Count);
 		Assert.IsTrue(projectIds.Contains(sow.ProjectId));
 
 		var phaseIds = context.ProjectPhases
@@ -342,6 +371,17 @@ public class AgricultureSeederTests
 			x.ProjectRevisionNumber == orchardProject.RevisionNumber);
 		var orchardSeedRequirement = context.ProjectMaterialRequirements.Single(x => x.ProjectPhaseId == orchardPhase.Id && x.Name == "Seed Stock");
 		Assert.AreEqual("250000", XElement.Parse(orchardSeedRequirement.Definition).Element("Amount")!.Value);
+
+		var apiaryPhase = context.ProjectPhases.Single(x =>
+			x.ProjectId == installApiary.ProjectId &&
+			x.ProjectRevisionNumber == installApiary.ProjectRevisionNumber);
+		var beeHives = context.ProjectMaterialRequirements.Single(x => x.ProjectPhaseId == apiaryPhase.Id && x.Name == "Bee Hives");
+		Assert.AreEqual("simple", beeHives.Type);
+		Assert.AreEqual("4", XElement.Parse(beeHives.Definition).Element("Tag")!.Value);
+		Assert.AreEqual("2", XElement.Parse(beeHives.Definition).Element("Amount")!.Value);
+		var hiveStand = context.ProjectMaterialRequirements.Single(x => x.ProjectPhaseId == apiaryPhase.Id && x.Name == "Hive Stand");
+		Assert.AreEqual("5", XElement.Parse(hiveStand.Definition).Element("Tag")!.Value);
+		Assert.AreEqual("1", XElement.Parse(hiveStand.Definition).Element("Amount")!.Value);
 
 		Assert.AreEqual(ShouldSeedResult.MayAlreadyBeInstalled, seeder.ShouldSeedData(context));
 	}
@@ -399,6 +439,15 @@ public class AgricultureSeederTests
 			new Tag { Id = 1, Name = "Seeds" },
 			new Tag { Id = 2, Name = "Seeded Yield" },
 			new Tag { Id = 3, Name = "Agriculture Seedable" });
+		context.SaveChanges();
+		Assert.AreEqual(ShouldSeedResult.PrerequisitesNotMet, seeder.ShouldSeedData(context));
+
+		context.Tags.AddRange(
+			new Tag { Id = 4, Name = "Bee Hive" },
+			new Tag { Id = 5, Name = "Hive Stand" },
+			new Tag { Id = 6, Name = "Raw Honeycomb" },
+			new Tag { Id = 7, Name = "Pressed Honey" },
+			new Tag { Id = 8, Name = "Rendered Beeswax" });
 		context.SaveChanges();
 		Assert.AreEqual(ShouldSeedResult.PrerequisitesNotMet, seeder.ShouldSeedData(context));
 

--- a/DatabaseSeeder Unit Tests/AgricultureSeederTests.cs
+++ b/DatabaseSeeder Unit Tests/AgricultureSeederTests.cs
@@ -90,7 +90,11 @@ public class AgricultureSeederTests
 			new Tag { Id = 5, Name = "Hive Stand" },
 			new Tag { Id = 6, Name = "Raw Honeycomb" },
 			new Tag { Id = 7, Name = "Pressed Honey" },
-			new Tag { Id = 8, Name = "Rendered Beeswax" });
+			new Tag { Id = 8, Name = "Rendered Beeswax" },
+			new Tag { Id = 9, Name = "Raw Milk" },
+			new Tag { Id = 10, Name = "Raw Textile Fibre" },
+			new Tag { Id = 11, Name = "Egg Product" },
+			new Tag { Id = 12, Name = "Manure Commodity" });
 		context.TraitDefinitions.Add(new TraitDefinition
 		{
 			Id = 10,
@@ -147,10 +151,10 @@ public class AgricultureSeederTests
 		seeder.SeedData(context, new Dictionary<string, string>());
 
 		Assert.AreEqual(46, context.AgricultureFieldProfiles.Count());
-		Assert.AreEqual(136, context.AgricultureCropDefinitions.Count());
-		Assert.AreEqual(4, context.AgricultureHerdDefinitions.Count());
-		Assert.AreEqual(8, context.AgricultureWoodlandDefinitions.Count());
-		Assert.AreEqual(22, context.AgricultureOperations.Count());
+		Assert.AreEqual(144, context.AgricultureCropDefinitions.Count());
+		Assert.AreEqual(5, context.AgricultureHerdDefinitions.Count());
+		Assert.AreEqual(11, context.AgricultureWoodlandDefinitions.Count());
+		Assert.AreEqual(23, context.AgricultureOperations.Count());
 		foreach (var cropName in new[]
 		         {
 			         "Wheat", "Barley", "Rye", "Oats", "Quinoa", "Field Beans", "Peas", "Lentils", "Potatoes",
@@ -165,7 +169,8 @@ public class AgricultureSeederTests
 		         {
 			         "Emmer Wheat", "Einkorn Wheat", "Spelt Wheat", "Naked Barley", "New Glume Wheat", "Bitter Vetch",
 			         "Grass Peas", "Lupins", "Canihua", "Pitseed Goosefoot", "Maygrass", "Little Barley", "Erect Knotweed",
-			         "Oca", "Ulluco", "Mashua", "Jerusalem Artichokes", "Mustard", "Woad"
+			         "Oca", "Ulluco", "Mashua", "Jerusalem Artichokes", "Mustard", "Madder", "Weld", "Alkanet",
+			         "Woad", "Coriander", "Saffron Crocus"
 		         })
 		{
 			AssertPlantingGroups(context, cropName, "Autumn", "Spring");
@@ -186,7 +191,7 @@ public class AgricultureSeederTests
 		         {
 			         "Cowpeas", "Mung Beans", "Bambara Groundnuts", "Adzuki Beans", "Teff", "Fonio", "Finger Millet",
 			         "Pearl Millet", "Foxtail Millet", "Proso Millet", "Amaranth", "Chia", "Marshelder", "African Rice",
-			         "Eggplants", "Okra", "Bottle Gourds", "Safflower", "Niger Seed"
+			         "Eggplants", "Okra", "Bottle Gourds", "Safflower", "Niger Seed", "Cumin"
 		         })
 		{
 			AssertPlantingGroups(context, cropName, "Spring", "Summer");
@@ -230,8 +235,8 @@ public class AgricultureSeederTests
 		foreach (var cropName in new[]
 		         {
 			         "Mangoes", "Coconuts", "Plantains", "Breadfruit", "Avocados", "Cacao", "Coffee", "Tea", "Cashews",
-			         "Macadamias", "Guavas", "Lychees", "Jackfruit", "Papayas", "Passionfruit", "Cinnamon", "Cloves",
-			         "Nutmeg", "Kola Nuts", "Tamarinds"
+			         "Macadamias", "Guavas", "Lychees", "Jackfruit", "Papayas", "Passionfruit", "Cinnamon", "Black Pepper", "Cloves",
+			         "Nutmeg", "Henna", "Kola Nuts", "Tamarinds"
 		         })
 		{
 			AssertPlantingGroups(context, cropName, "Spring", "Summer", "Autumn");
@@ -283,10 +288,67 @@ public class AgricultureSeederTests
 			x.Attribute("material")!.Value == "walnut nut" &&
 			x.Attribute("tag")!.Value == "Seeded Yield"));
 
+		var corianderDefinition = XElement.Parse(context.AgricultureCropDefinitions.Single(x => x.Name == "Coriander").Definition);
+		Assert.IsTrue(corianderDefinition.Element("Outputs")!.Elements("Commodity").Any(x =>
+			x.Attribute("material")!.Value == "coriander" &&
+			x.Attribute("tag")!.Value == "Seeded Yield"));
+		var saffronDefinition = XElement.Parse(context.AgricultureCropDefinitions.Single(x => x.Name == "Saffron Crocus").Definition);
+		Assert.IsTrue(saffronDefinition.Element("Outputs")!.Elements("Commodity").Any(x =>
+			x.Attribute("material")!.Value == "saffron crocus" &&
+			x.Attribute("tag")!.Value == "Seeded Yield"));
+		var blackPepperDefinition = XElement.Parse(context.AgricultureCropDefinitions.Single(x => x.Name == "Black Pepper").Definition);
+		Assert.IsTrue(blackPepperDefinition.Element("Outputs")!.Elements("Commodity").Any(x =>
+			x.Attribute("material")!.Value == "black pepper" &&
+			x.Attribute("tag")!.Value == "Seeded Yield"));
+		foreach (var (cropName, materialName) in new[]
+		         {
+			         ("Madder", "madder root"),
+			         ("Weld", "weld"),
+			         ("Alkanet", "alkanet root"),
+			         ("Henna", "henna leaf")
+		         })
+		{
+			var dyeCropDefinition = XElement.Parse(context.AgricultureCropDefinitions.Single(x => x.Name == cropName).Definition);
+			Assert.IsTrue(dyeCropDefinition.Element("Outputs")!.Elements("Commodity").Any(x =>
+				x.Attribute("material")!.Value == materialName &&
+				x.Attribute("tag")!.Value == "Seeded Yield"));
+		}
+
+		var cattleDefinition = XElement.Parse(context.AgricultureHerdDefinitions.Single(x => x.Name == "Cattle Herd").Definition);
+		var cattleOutputs = cattleDefinition.Element("SecondaryOutputs")!.Elements("Commodity").ToArray();
+		Assert.IsTrue(cattleOutputs.Any(x => x.Attribute("material")!.Value == "milk" && x.Attribute("tag")!.Value == "Raw Milk"));
+		Assert.IsTrue(cattleOutputs.Any(x => x.Attribute("material")!.Value == "feces" && x.Attribute("tag")!.Value == "Manure Commodity"));
+		var flockOutputs = XElement.Parse(context.AgricultureHerdDefinitions.Single(x => x.Name == "Sheep or Goat Flock").Definition)
+		                           .Element("SecondaryOutputs")!
+		                           .Elements("Commodity")
+		                           .ToArray();
+		Assert.IsTrue(flockOutputs.Any(x => x.Attribute("material")!.Value == "wool" && x.Attribute("tag")!.Value == "Raw Textile Fibre"));
+		var horseOutputs = XElement.Parse(context.AgricultureHerdDefinitions.Single(x => x.Name == "Horse Herd").Definition)
+		                           .Element("SecondaryOutputs")!
+		                           .Elements("Commodity")
+		                           .ToArray();
+		Assert.IsTrue(horseOutputs.Any(x => x.Attribute("material")!.Value == "milk" && x.Attribute("tag")!.Value == "Raw Milk"));
+		var poultryOutputs = XElement.Parse(context.AgricultureHerdDefinitions.Single(x => x.Name == "Poultry Flock").Definition)
+		                             .Element("SecondaryOutputs")!
+		                             .Elements("Commodity")
+		                             .ToArray();
+		Assert.IsTrue(poultryOutputs.Any(x => x.Attribute("material")!.Value == "egg" && x.Attribute("tag")!.Value == "Egg Product"));
+
 		var hazelDefinition = XElement.Parse(context.AgricultureWoodlandDefinitions.Single(x => x.Name == "Hazel Coppice").Definition);
 		Assert.AreEqual("180", hazelDefinition.Attribute("establishmentDays")!.Value);
 		Assert.IsTrue(hazelDefinition.Element("Outputs")!.Elements("Commodity").Any(x =>
 			x.Attribute("material")!.Value == "hazel"));
+		foreach (var (woodlandName, materialName) in new[]
+		         {
+			         ("Kermes Oak Scrub", "kermes grain"),
+			         ("Dye Lichen Grove", "orchil lichen"),
+			         ("Lac Host Grove", "lac dye cake")
+		         })
+		{
+			var dyeWoodlandDefinition = XElement.Parse(context.AgricultureWoodlandDefinitions.Single(x => x.Name == woodlandName).Definition);
+			Assert.IsTrue(dyeWoodlandDefinition.Element("Outputs")!.Elements("Commodity").Any(x =>
+				x.Attribute("material")!.Value == materialName));
+		}
 
 		var sow = context.AgricultureOperations.Single(x => x.Name == "Sow Crop");
 		Assert.AreEqual((int)AgricultureOperationType.Sow, sow.OperationType);
@@ -305,6 +367,13 @@ public class AgricultureSeederTests
 		Assert.AreEqual((int)AgricultureOperationType.Harvest, harvestOrchard.OperationType);
 		Assert.AreEqual((int)AgricultureFieldUse.Orchard, harvestOrchard.RequiredUse);
 		Assert.AreEqual((int)AgricultureFieldUse.Orchard, harvestOrchard.ResultUse);
+
+		var collectHerdProducts = context.AgricultureOperations.Single(x => x.Name == "Collect Herd Products");
+		Assert.AreEqual((int)AgricultureOperationType.HarvestHerdProducts, collectHerdProducts.OperationType);
+		Assert.AreEqual((int)AgricultureTargetType.Herd, collectHerdProducts.TargetType);
+		var collectHerdDefinition = XElement.Parse(collectHerdProducts.Definition);
+		Assert.AreEqual("1", collectHerdDefinition.Attribute("herdYieldMultiplier")!.Value);
+		Assert.AreEqual("55", collectHerdDefinition.Attribute("herdYieldCost")!.Value);
 
 		var coppice = context.AgricultureOperations.Single(x => x.Name == "Coppice Woodland");
 		var coppiceDefinition = XElement.Parse(coppice.Definition);
@@ -329,7 +398,7 @@ public class AgricultureSeederTests
 			.Where(x => x.Name.StartsWith("Stock Agriculture:"))
 			.Select(x => x.Id)
 			.ToHashSet();
-		Assert.AreEqual(22, projectIds.Count);
+		Assert.AreEqual(23, projectIds.Count);
 		Assert.IsTrue(projectIds.Contains(sow.ProjectId));
 
 		var phaseIds = context.ProjectPhases
@@ -448,6 +517,14 @@ public class AgricultureSeederTests
 			new Tag { Id = 6, Name = "Raw Honeycomb" },
 			new Tag { Id = 7, Name = "Pressed Honey" },
 			new Tag { Id = 8, Name = "Rendered Beeswax" });
+		context.SaveChanges();
+		Assert.AreEqual(ShouldSeedResult.PrerequisitesNotMet, seeder.ShouldSeedData(context));
+
+		context.Tags.AddRange(
+			new Tag { Id = 9, Name = "Raw Milk" },
+			new Tag { Id = 10, Name = "Raw Textile Fibre" },
+			new Tag { Id = 11, Name = "Egg Product" },
+			new Tag { Id = 12, Name = "Manure Commodity" });
 		context.SaveChanges();
 		Assert.AreEqual(ShouldSeedResult.PrerequisitesNotMet, seeder.ShouldSeedData(context));
 

--- a/DatabaseSeeder Unit Tests/CoreDataSeederMaterialTests.cs
+++ b/DatabaseSeeder Unit Tests/CoreDataSeederMaterialTests.cs
@@ -168,6 +168,26 @@ public class CoreDataSeederMaterialTests
             .Include(x => x.MaterialsTags)
             .ThenInclude(x => x.Tag)
             .Single(x => x.Name == "beeswax");
+        MudSharp.Models.Material milk = context.Materials
+            .Include(x => x.MaterialsTags)
+            .ThenInclude(x => x.Tag)
+            .Single(x => x.Name == "milk");
+        MudSharp.Models.Material egg = context.Materials
+            .Include(x => x.MaterialsTags)
+            .ThenInclude(x => x.Tag)
+            .Single(x => x.Name == "egg");
+        MudSharp.Models.Material wool = context.Materials
+            .Include(x => x.MaterialsTags)
+            .ThenInclude(x => x.Tag)
+            .Single(x => x.Name == "wool");
+        MudSharp.Models.Material feces = context.Materials
+            .Include(x => x.MaterialsTags)
+            .ThenInclude(x => x.Tag)
+            .Single(x => x.Name == "feces");
+        MudSharp.Models.Material compost = context.Materials
+            .Include(x => x.MaterialsTags)
+            .ThenInclude(x => x.Tag)
+            .Single(x => x.Name == "compost");
         MudSharp.Models.Material salt = context.Materials.Single(x => x.Name == "salt");
         MudSharp.Models.Material guano = context.Materials.Single(x => x.Name == "guano");
         MudSharp.Models.Material cream = context.Materials.Single(x => x.Name == "cream");
@@ -195,6 +215,16 @@ public class CoreDataSeederMaterialTests
         Assert.IsTrue(honey.MaterialsTags.Any(x => x.Tag.Name == "Apiary Product"));
         Assert.IsTrue(honeycomb.MaterialsTags.Any(x => x.Tag.Name == "Apiary Product"));
         Assert.IsTrue(beeswax.MaterialsTags.Any(x => x.Tag.Name == "Apiary Product"));
+        Assert.IsTrue(context.Tags.Any(x => x.Name == "Pastoral Product"));
+        Assert.IsTrue(context.Tags.Any(x => x.Name == "Raw Milk"));
+        Assert.IsTrue(context.Tags.Any(x => x.Name == "Egg Product"));
+        Assert.IsTrue(context.Tags.Any(x => x.Name == "Manure Product"));
+        Assert.IsTrue(milk.MaterialsTags.Any(x => x.Tag.Name == "Raw Milk"));
+        Assert.IsTrue(egg.MaterialsTags.Any(x => x.Tag.Name == "Egg Product"));
+        Assert.IsTrue(wool.MaterialsTags.Any(x => x.Tag.Name == "Raw Wool"));
+        Assert.IsTrue(feces.MaterialsTags.Any(x => x.Tag.Name == "Manure Product"));
+        Assert.IsTrue(compost.MaterialsTags.Any(x => x.Tag.Name == "Manure Product"));
+        Assert.IsTrue(context.Materials.Any(x => x.Name == "saffron crocus"));
     }
 
     [TestMethod]

--- a/DatabaseSeeder Unit Tests/CoreDataSeederMaterialTests.cs
+++ b/DatabaseSeeder Unit Tests/CoreDataSeederMaterialTests.cs
@@ -156,6 +156,18 @@ public class CoreDataSeederMaterialTests
             .Include(x => x.MaterialsTags)
             .ThenInclude(x => x.Tag)
             .Single(x => x.Name == "paraffin wax");
+        MudSharp.Models.Material honey = context.Materials
+            .Include(x => x.MaterialsTags)
+            .ThenInclude(x => x.Tag)
+            .Single(x => x.Name == "honey");
+        MudSharp.Models.Material honeycomb = context.Materials
+            .Include(x => x.MaterialsTags)
+            .ThenInclude(x => x.Tag)
+            .Single(x => x.Name == "honeycomb");
+        MudSharp.Models.Material beeswax = context.Materials
+            .Include(x => x.MaterialsTags)
+            .ThenInclude(x => x.Tag)
+            .Single(x => x.Name == "beeswax");
         MudSharp.Models.Material salt = context.Materials.Single(x => x.Name == "salt");
         MudSharp.Models.Material guano = context.Materials.Single(x => x.Name == "guano");
         MudSharp.Models.Material cream = context.Materials.Single(x => x.Name == "cream");
@@ -177,6 +189,12 @@ public class CoreDataSeederMaterialTests
         Assert.IsTrue(context.Materials.Any(x => x.Name == "bone"));
         Assert.IsTrue(context.Materials.Any(x => x.Name == "blood"));
         Assert.IsTrue(context.Materials.Any(x => x.Name == "rosewood"));
+        Assert.IsTrue(context.Tags.Any(x => x.Name == "Apiary Product"));
+        Assert.IsTrue(context.Tags.Any(x => x.Name == "Raw Honeycomb"));
+        Assert.AreEqual((int)MaterialBehaviourType.Food, honeycomb.BehaviourType);
+        Assert.IsTrue(honey.MaterialsTags.Any(x => x.Tag.Name == "Apiary Product"));
+        Assert.IsTrue(honeycomb.MaterialsTags.Any(x => x.Tag.Name == "Apiary Product"));
+        Assert.IsTrue(beeswax.MaterialsTags.Any(x => x.Tag.Name == "Apiary Product"));
     }
 
     [TestMethod]

--- a/DatabaseSeeder Unit Tests/ItemSeederAntiquityFoodCraftingTests.cs
+++ b/DatabaseSeeder Unit Tests/ItemSeederAntiquityFoodCraftingTests.cs
@@ -344,9 +344,68 @@ public class ItemSeederAntiquityFoodCraftingTests
 			AssertContains(craftSource, expected);
 		}
 
-		AssertContains(itemSource, "beerFinished is null ? null : \"antiquity_food_finished_beer_amphora\"");
+		AssertContains(itemSource, "CreateAntiquityFermentingFoodVessel(\"antiquity_food_fermenting_beer_amphora\"");
 		Assert.IsFalse(craftSource.Contains("StableSimpleProduct(\"antiquity_food_finished_beer_amphora\")", StringComparison.Ordinal),
 			"The finished beer amphora should remain a morph target, not a direct craft output.");
+	}
+
+	[TestMethod]
+	public void AntiquityFoodCrafting_UsesFermentingMorphVesselsForFermentedBeverages()
+	{
+		var itemSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.AntiquityFood.cs");
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.AntiquityFood.cs");
+
+		foreach (var active in new[]
+		         {
+			         "antiquity_food_fermenting_beer_amphora",
+			         "antiquity_food_fermenting_date_beer_amphora",
+			         "antiquity_food_fermenting_red_wine_amphora",
+			         "antiquity_food_fermenting_white_wine_amphora",
+			         "antiquity_food_fermenting_kumis_amphora",
+			         "antiquity_food_fermenting_garum_amphora",
+			         "antiquity_food_aging_spiced_wine_amphora",
+			         "antiquity_food_aging_spiced_beer_amphora",
+			         "antiquity_food_aging_spiced_kumis_amphora"
+		         })
+		{
+			AssertContains(itemSource, active);
+			AssertContains(craftSource, active);
+		}
+
+		foreach (var finished in new[]
+		         {
+			         "antiquity_food_finished_beer_amphora",
+			         "antiquity_food_finished_date_beer_amphora",
+			         "antiquity_food_finished_red_wine_amphora",
+			         "antiquity_food_finished_white_wine_amphora",
+			         "antiquity_food_finished_kumis_amphora",
+			         "antiquity_food_finished_garum_amphora",
+			         "antiquity_food_finished_spiced_wine_amphora",
+			         "antiquity_food_finished_spiced_beer_amphora",
+			         "antiquity_food_finished_spiced_kumis_amphora"
+		         })
+		{
+			AssertContains(itemSource, finished);
+			Assert.IsFalse(craftSource.Contains($"StableSimpleProduct(\"{finished}\")", StringComparison.Ordinal),
+				$"{finished} should be a morph target, not a direct craft output.");
+		}
+
+		AssertContains(itemSource, "finished is null ? null : finishedStableReference");
+		AssertContains(craftSource, "StableSimpleProduct(CultureBeverageFermentingStableReference(culture))");
+		AssertContains(craftSource, "StableSimpleProduct(CultureLuxuryBeverageAgingStableReference(culture))");
+		AssertContains(craftSource, "TagTool - Held - an item with the Fermentation Amphora tag");
+		foreach (var directLiquid in new[]
+		         {
+			         "filled with 3 litres of barley beer",
+			         "filled with 3 litres of date beer",
+			         "filled with 3 litres of garum sauce",
+			         "filled with 3 litres of {culture.BeverageLiquid}",
+			         "filled with 3 litres of {CultureLuxuryBeverageLiquid(culture)}"
+		         })
+		{
+			Assert.IsFalse(craftSource.Contains(directLiquid, StringComparison.Ordinal),
+				$"Fermented beverage craft should use morphing amphorae instead of direct LiquidProduct output: {directLiquid}");
+		}
 	}
 
 	[TestMethod]

--- a/DatabaseSeeder Unit Tests/ItemSeederAntiquityFoodCraftingTests.cs
+++ b/DatabaseSeeder Unit Tests/ItemSeederAntiquityFoodCraftingTests.cs
@@ -149,6 +149,101 @@ public class ItemSeederAntiquityFoodCraftingTests
 	}
 
 	[TestMethod]
+	public void AntiquityFoodCrafting_MakesFoodToolsAndEmptyVesselsCraftable()
+	{
+		var itemSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.AntiquityFood.cs");
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.AntiquityFood.cs");
+
+		AssertContains(itemSource, "[toolTag, \"Market / Professional Tools / Standard Tools\"]");
+		foreach (var expected in new[]
+		         {
+			         "antiquity_food_butchers_knife",
+			         "antiquity_food_cooking_knife",
+			         "antiquity_food_threshing_flail",
+			         "antiquity_food_winnowing_basket",
+			         "antiquity_food_quern",
+			         "antiquity_food_mortar",
+			         "antiquity_food_grain_sieve",
+			         "antiquity_food_fruit_press",
+			         "antiquity_food_oil_press",
+			         "antiquity_food_mash_tun",
+			         "antiquity_food_drying_rack",
+			         "antiquity_food_smoking_rack",
+			         "antiquity_food_salting_trough"
+		         })
+		{
+			AssertContains(itemSource, expected);
+		}
+
+		foreach (var expected in new[]
+		         {
+			         "Functions / Tools / Butcher Tools / Meat Cutting Tools / Butcher's Knife",
+			         "Functions / Tools / Cooking / Cooking Utensils / Cooking Knife",
+			         "Functions / Tools / Foodmaking Tools / Threshing Flail",
+			         "Functions / Tools / Agricultural Tools / Winnowing Basket",
+			         "Functions / Tools / Foodmaking Tools / Hand Quern",
+			         "Functions / Tools / Cooking / Cooking Utensils / Mortar and Pestle",
+			         "Functions / Tools / Milling Tools / Grain Sieve",
+			         "Functions / Tools / Foodmaking Tools / Fruit Press",
+			         "Functions / Tools / Foodmaking Tools / Oil Press",
+			         "Functions / Tools / Brewing Tools / Mash Tun",
+			         "Functions / Tools / Cooking / Cooking Utensils / Drying Rack",
+			         "Functions / Tools / Foodmaking Tools / Smoking Rack",
+			         "Functions / Tools / Foodmaking Tools / Salting Trough"
+		         })
+		{
+			AssertContains(itemSource, expected);
+		}
+
+		foreach (var expected in new[]
+		         {
+			         "SeedAntiquityFoodVesselCrafts();",
+			         "private void SeedAntiquityFoodVesselCrafts()",
+			         "finish clay serving amphora",
+			         "line pitch fermenting amphora",
+			         "AncientCeramicVesselmakingKnowledge",
+			         "CommodityInput(900.0, \"fired clay\", \"Bisque Vessel Blank\")",
+			         "CommodityInput(80.0, \"pitch\", \"Prepared Pitch\")",
+			         "CommodityInput(240.0, \"pitch\", \"Prepared Pitch\")",
+			         "TagTool - InRoom - an item with the Potter's Wheel tag",
+			         "TagTool - Held - an item with the Potter's Rib tag",
+			         "TagTool - InRoom - an item with the Lit Kiln tag",
+			         "StableSimpleProduct(\"antiquity_food_serving_amphora\")",
+			         "StableSimpleProduct(\"antiquity_food_fermenting_amphora\")"
+		         })
+		{
+			AssertContains(craftSource, expected);
+		}
+
+		AssertContains(itemSource, "beerFinished is null ? null : \"antiquity_food_finished_beer_amphora\"");
+		Assert.IsFalse(craftSource.Contains("StableSimpleProduct(\"antiquity_food_finished_beer_amphora\")", StringComparison.Ordinal),
+			"The finished beer amphora should remain a morph target, not a direct craft output.");
+	}
+
+	[TestMethod]
+	public void AntiquityFoodCrafting_UsesMilkForKumisAndKeepsCoreWineLiquidsInCoreData()
+	{
+		var itemSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.AntiquityFood.cs");
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.AntiquityFood.cs");
+		var materialSource = ReadSource("DatabaseSeeder", "Seeders", "CoreDataSeeder.Materials.cs");
+
+		var beverageStockBody = ExtractMethodBody(craftSource, "CultureBeverageStockInput");
+		AssertContains(beverageStockBody, "culture.BeverageLiquid.Contains(\"kumis\", StringComparison.OrdinalIgnoreCase)");
+		AssertContains(beverageStockBody, "return \"LiquidUse - 3 litres of milk\";");
+		Assert.IsTrue(beverageStockBody.IndexOf("\"kumis\"", StringComparison.Ordinal) <
+		              beverageStockBody.IndexOf("Wort Commodity", StringComparison.Ordinal),
+			"Kumis should be handled before the fallback grain-wort branch.");
+
+		var foodLiquidsBody = ExtractMethodBody(itemSource, "EnsureAntiquityFoodLiquids");
+		AssertContains(materialSource, "AddLiquid(\"red wine\"");
+		AssertContains(materialSource, "AddLiquid(\"white wine\"");
+		Assert.IsFalse(foodLiquidsBody.Contains("EnsureAntiquityLiquid(\"red wine\"", StringComparison.Ordinal),
+			"Red wine is a core liquid and should not be duplicated by the food seeder.");
+		Assert.IsFalse(foodLiquidsBody.Contains("EnsureAntiquityLiquid(\"white wine\"", StringComparison.Ordinal),
+			"White wine is a core liquid and should not be duplicated by the food seeder.");
+	}
+
+	[TestMethod]
 	public void AntiquityFoodCrafting_AddsOilAndFruitCommodityPaths()
 	{
 		var itemSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.AntiquityFood.cs");
@@ -263,6 +358,55 @@ public class ItemSeederAntiquityFoodCraftingTests
 	private static void AssertRegexContains(string source, string expected)
 	{
 		Assert.IsTrue(Regex.IsMatch(source, expected), $"Expected source to match: {expected}");
+	}
+
+	private static string ExtractMethodBody(string source, string methodName)
+	{
+		var start = FindMethodDeclarationStart(source, methodName);
+		var openBrace = source.IndexOf('{', start);
+		Assert.IsTrue(openBrace >= 0, $"Could not find body for method {methodName}.");
+
+		var depth = 0;
+		for (var i = openBrace; i < source.Length; i++)
+		{
+			switch (source[i])
+			{
+				case '{':
+					depth++;
+					break;
+				case '}':
+					depth--;
+					if (depth == 0)
+					{
+						return source[(openBrace + 1)..i];
+					}
+					break;
+			}
+		}
+
+		Assert.Fail($"Could not extract body for method {methodName}.");
+		return string.Empty;
+	}
+
+	private static int FindMethodDeclarationStart(string source, string methodName)
+	{
+		var search = $"{methodName}(";
+		var index = source.IndexOf(search, StringComparison.Ordinal);
+		while (index >= 0)
+		{
+			var lineStart = source.LastIndexOf('\n', index);
+			lineStart = lineStart < 0 ? 0 : lineStart + 1;
+			var declarationPrefix = source[lineStart..index];
+			if (declarationPrefix.Contains("private ", StringComparison.Ordinal))
+			{
+				return lineStart;
+			}
+
+			index = source.IndexOf(search, index + search.Length, StringComparison.Ordinal);
+		}
+
+		Assert.Fail($"Could not find declaration for method {methodName}.");
+		return 0;
 	}
 
 	private static string ReadSource(params string[] parts)

--- a/DatabaseSeeder Unit Tests/ItemSeederAntiquityFoodCraftingTests.cs
+++ b/DatabaseSeeder Unit Tests/ItemSeederAntiquityFoodCraftingTests.cs
@@ -106,6 +106,81 @@ public class ItemSeederAntiquityFoodCraftingTests
 	}
 
 	[TestMethod]
+	public void AntiquityAgricultureCrafting_BackfillsSeedPastoralAndDerivativeProcessing()
+	{
+		var craftRootSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.cs");
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.AntiquityAgriculture.cs");
+		var agricultureSource = ReadSource("DatabaseSeeder", "Seeders", "AgricultureSeeder.cs");
+		var tagSource = ReadSource("DatabaseSeeder", "Seeders", "UsefulSeeder.Tags.cs");
+		var materialSource = ReadSource("DatabaseSeeder", "Seeders", "CoreDataSeeder.Materials.cs");
+
+		AssertContains(craftRootSource, "SeedAntiquityAgriculturalProcessingCrafts();");
+		AssertContains(craftSource, "select antiquity seed stock");
+		AssertContains(craftSource, "CommodityTag - 5 kilograms of a material tagged as Agriculture Seedable; tag Seeded Yield");
+		AssertContains(craftSource, "ScrapInput - 25.00% by weight of 5 kilograms of a material tagged as Agriculture Seedable ($i1); tag Seeds");
+		AssertContains(craftSource, "strain fresh milk into amphora");
+		AssertContains(craftSource, "Commodity - 3 kilograms of milk; piletag Raw Milk");
+		AssertContains(craftSource, "filled with 3 litres of milk");
+		AssertContains(craftSource, "heap herd manure compost");
+		AssertContains(craftSource, "Commodity - 3 kilograms of feces; piletag Manure Commodity");
+		AssertContains(craftSource, "CommodityProduct - 3 kilograms 500 grams of compost commodity; tag Manure Commodity");
+
+		foreach (var expected in new[]
+		         {
+			         "ferment indigo dye cakes",
+			         "strip pomegranate rind dye stock",
+			         "separate walnut hull dye stock",
+			         "dry saffron threads",
+			         "CommodityProduct - 500 grams of indigo dye cake commodity; tag Textile Dye Stock",
+			         "CommodityProduct - 350 grams of pomegranate rind commodity; tag Textile Dye Stock",
+			         "CommodityProduct - 300 grams of walnut hull commodity; tag Textile Dye Stock",
+			         "CommodityProduct - 45 grams of saffron commodity; tag Textile Dye Stock"
+		         })
+		{
+			AssertContains(craftSource, expected);
+		}
+
+		foreach (var expected in new[]
+		         {
+			         "Raw Milk",
+			         "Raw Wool",
+			         "Egg Product",
+			         "Manure Commodity"
+		         })
+		{
+			AssertContains(tagSource, expected);
+		}
+
+		foreach (var expected in new[]
+		         {
+			         "Yield(\"milk\", 3500, RawMilkTagName)",
+			         "Yield(\"wool\", 450, RawTextileFibreTagName)",
+			         "new(\"Horse Herd\"",
+			         "Yield(\"egg\", 60, EggProductTagName)",
+			         "Yield(\"feces\", 2500, ManureCommodityTagName)",
+			         "AgricultureOperationType.HarvestHerdProducts",
+			         "new(\"Madder\"",
+			         "new(\"Weld\"",
+			         "new(\"Alkanet\"",
+			         "new(\"Henna\"",
+			         "new(\"Coriander\"",
+			         "new(\"Cumin\"",
+			         "new(\"Saffron Crocus\"",
+			         "new(\"Black Pepper\"",
+			         "new(\"Kermes Oak Scrub\"",
+			         "new(\"Dye Lichen Grove\"",
+			         "new(\"Lac Host Grove\""
+		         })
+		{
+			AssertContains(agricultureSource, expected);
+		}
+
+		AssertContains(materialSource, "AddMaterial(\"milk\"");
+		AssertContains(materialSource, "AddMaterial(\"egg\"");
+		AssertContains(materialSource, "AddMaterial(\"saffron crocus\"");
+	}
+
+	[TestMethod]
 	public void AntiquityFoodCrafting_RunsThroughItemSeederReworkPath()
 	{
 		var shimPath = SourcePath("DatabaseSeeder", "Seeders", "AntiquityFoodBeverageSeeder.cs");
@@ -213,6 +288,7 @@ public class ItemSeederAntiquityFoodCraftingTests
 			         "antiquity_food_cooking_knife",
 			         "antiquity_food_threshing_flail",
 			         "antiquity_food_winnowing_basket",
+			         "antiquity_food_pitchfork",
 			         "antiquity_food_quern",
 			         "antiquity_food_mortar",
 			         "antiquity_food_grain_sieve",
@@ -233,6 +309,7 @@ public class ItemSeederAntiquityFoodCraftingTests
 			         "Functions / Tools / Cooking / Cooking Utensils / Cooking Knife",
 			         "Functions / Tools / Foodmaking Tools / Threshing Flail",
 			         "Functions / Tools / Agricultural Tools / Winnowing Basket",
+			         "Functions / Tools / Agricultural Tools / Pitchfork",
 			         "Functions / Tools / Foodmaking Tools / Hand Quern",
 			         "Functions / Tools / Cooking / Cooking Utensils / Mortar and Pestle",
 			         "Functions / Tools / Milling Tools / Grain Sieve",

--- a/DatabaseSeeder Unit Tests/ItemSeederAntiquityFoodCraftingTests.cs
+++ b/DatabaseSeeder Unit Tests/ItemSeederAntiquityFoodCraftingTests.cs
@@ -54,6 +54,58 @@ public class ItemSeederAntiquityFoodCraftingTests
 	];
 
 	[TestMethod]
+	public void AntiquityApiaryCrafting_BackfillsApicultureItemsAndProcessing()
+	{
+		var reworkSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.cs");
+		var itemSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.AntiquityApiary.cs");
+		var craftRootSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.cs");
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.AntiquityApiary.cs");
+		var tagSource = ReadSource("DatabaseSeeder", "Seeders", "UsefulSeeder.Tags.cs");
+		var materialSource = ReadSource("DatabaseSeeder", "Seeders", "CoreDataSeeder.Materials.cs");
+
+		AssertContains(reworkSource, "SeedAntiquityApiaryItems();");
+		AssertContains(craftRootSource, "SeedAntiquityApiaryCrafts();");
+		foreach (var expected in new[]
+		         {
+			         "antiquity_wicker_beehive",
+			         "antiquity_clay_tube_hive",
+			         "antiquity_wooden_hive_stand",
+			         "antiquity_bee_smoke_pot",
+			         "antiquity_honey_knife",
+			         "antiquity_honey_press",
+			         "antiquity_honey_strainer"
+		         })
+		{
+			AssertContains(itemSource, expected);
+			AssertContains(craftSource, expected);
+		}
+
+		foreach (var expected in new[]
+		         {
+			         "Beekeeping Tools",
+			         "Bee Hive",
+			         "Hive Stand",
+			         "Bee Smoke Pot",
+			         "Honey Knife",
+			         "Honey Press",
+			         "Honey Strainer",
+			         "Raw Honeycomb",
+			         "Pressed Honey",
+			         "Rendered Beeswax"
+		         })
+		{
+			AssertContains(tagSource, expected);
+		}
+
+		AssertContains(materialSource, "AddMaterial(\"honeycomb\"");
+		AssertContains(materialSource, "\"Animal Product\", \"Apiary Product\"");
+		AssertContains(craftSource, "press raw honeycomb");
+		AssertContains(craftSource, "Commodity - 2 kilograms of honeycomb; piletag Raw Honeycomb");
+		AssertContains(craftSource, "CommodityProduct - 1 kilogram 200 grams of honey commodity; tag Pressed Honey");
+		AssertContains(craftSource, "CommodityProduct - 350 grams of beeswax commodity; tag Rendered Beeswax");
+	}
+
+	[TestMethod]
 	public void AntiquityFoodCrafting_RunsThroughItemSeederReworkPath()
 	{
 		var shimPath = SourcePath("DatabaseSeeder", "Seeders", "AntiquityFoodBeverageSeeder.cs");

--- a/DatabaseSeeder Unit Tests/ItemSeederAntiquityLeatherCraftingTests.cs
+++ b/DatabaseSeeder Unit Tests/ItemSeederAntiquityLeatherCraftingTests.cs
@@ -175,6 +175,9 @@ public class ItemSeederAntiquityLeatherCraftingTests
 			"private const string AntiquityLeatherKnowledge = \"Ancient Hide and Leatherworking\"",
 			"\"Leatherworking\"",
 			"\"Leathermaking\"",
+			"break down raw hides into tanning stock",
+			"Tag - 1x an item with the Raw Hide tag",
+			"CommodityProduct - 1 kilogram 600 grams of animal skin commodity",
 			"CommodityTag - 1 kilogram 600 grams of a material tagged as Animal Skin",
 			"LiquidUse - 2 litres of Water",
 			"LiquidUse - 3 litres of Water",
@@ -204,6 +207,35 @@ public class ItemSeederAntiquityLeatherCraftingTests
 		{
 			AssertContains(craftSource, expected);
 		}
+	}
+
+	[TestMethod]
+	public void LeatherCrafts_BridgeAnimalButcheryRawHidesIntoCommodityPipeline()
+	{
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Antiquity.cs");
+		var butcherySource = ReadSource("DatabaseSeeder", "Seeders", "AnimalButcherySeeder.cs");
+
+		AssertContains(butcherySource, "private const string RawHideTag = \"Raw Hide\";");
+
+		foreach (var expected in new[]
+		         {
+			         "break down raw hides into tanning stock",
+			         "break raw hide items into animal skin commodity stock",
+			         "Tag - 1x an item with the Raw Hide tag",
+			         "TagTool - InRoom - an item with the Tanning Beam tag",
+			         "TagTool - Held - an item with the Hide Scraper tag",
+			         "CommodityProduct - 1 kilogram 600 grams of animal skin commodity",
+			         "CommodityProduct - 400 grams of animal skin commodity",
+			         "scrape and dehair animal hides",
+			         "CommodityTag - 1 kilogram 600 grams of a material tagged as Animal Skin"
+		         })
+		{
+			AssertContains(craftSource, expected);
+		}
+
+		var bridgeBlock = ExtractCallBlockContaining(craftSource, "break down raw hides into tanning stock");
+		Assert.IsFalse(bridgeBlock.Contains("tag Prepared Hide", StringComparison.Ordinal),
+			"The raw-hide bridge should produce raw animal-skin commodity stock; the existing scrape craft creates Prepared Hide.");
 	}
 
 	[TestMethod]
@@ -406,6 +438,15 @@ public class ItemSeederAntiquityLeatherCraftingTests
 	private static void AssertContains(string source, string expected)
 	{
 		Assert.IsTrue(source.Contains(expected, StringComparison.Ordinal), $"Expected source to contain: {expected}");
+	}
+
+	private static string ExtractCallBlockContaining(string source, string marker)
+	{
+		var start = source.IndexOf(marker, StringComparison.Ordinal);
+		Assert.IsTrue(start >= 0, $"Could not find source block for {marker}.");
+		var end = source.IndexOf(");", start, StringComparison.Ordinal);
+		Assert.IsTrue(end >= 0, $"Could not find end of source block for {marker}.");
+		return source[start..end];
 	}
 
 	private static string ReadSource(params string[] parts)

--- a/DatabaseSeeder Unit Tests/ItemSeederAntiquityRemainingCraftingTests.cs
+++ b/DatabaseSeeder Unit Tests/ItemSeederAntiquityRemainingCraftingTests.cs
@@ -39,6 +39,7 @@ public class ItemSeederAntiquityRemainingCraftingTests
 	{
 		var itemSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.Antiquity.cs");
 		var partialItemSource =
+			ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.AntiquityApiary.cs") +
 			ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.AntiquityFood.cs") +
 			ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.AntiquityHouseholdTools.cs") +
 			ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.AntiquityMedical.cs") +
@@ -79,10 +80,13 @@ public class ItemSeederAntiquityRemainingCraftingTests
 			.ToList();
 
 		AssertContains(partialItemSource, "CreateAntiquityFoodTool");
+		AssertContains(partialItemSource, "SeedAntiquityApiaryItems");
 		AssertContains(partialItemSource, "CreateAntiquityHouseholdCraftTool");
 		AssertContains(partialItemSource, "SeedAntiquityMedicalItems");
 		AssertContains(partialItemSource, "SeedAntiquityWritingImplementsAndDocuments");
 		AssertContains(partialStableReferences, "antiquity_food_butchers_knife");
+		AssertContains(partialStableReferences, "antiquity_wicker_beehive");
+		AssertContains(partialStableReferences, "antiquity_honey_press");
 		AssertContains(partialStableReferences, "antiquity_food_serving_amphora");
 		AssertContains(partialStableReferences, "antiquity_food_finished_beer_amphora");
 

--- a/DatabaseSeeder Unit Tests/ItemSeederAntiquityRemainingCraftingTests.cs
+++ b/DatabaseSeeder Unit Tests/ItemSeederAntiquityRemainingCraftingTests.cs
@@ -38,13 +38,20 @@ public class ItemSeederAntiquityRemainingCraftingTests
 	public void AntiquityRemainingCrafts_SourceAuditCoversAllCurrentTargets()
 	{
 		var itemSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.Antiquity.cs");
+		var partialItemSource =
+			ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.AntiquityFood.cs") +
+			ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.AntiquityHouseholdTools.cs") +
+			ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.AntiquityMedical.cs") +
+			ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.AntiquityWriting.cs");
 		var existingCraftSource =
 			ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.cs") +
 			ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Antiquity.cs") +
 			ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.AntiquityHousehold.cs");
 		var equipmentCraftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.AntiquityEquipment.cs");
 		var jewelleryCraftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.AntiquityJewellery.cs");
-		var allCraftSource = existingCraftSource + equipmentCraftSource + jewelleryCraftSource;
+		var allCraftSource =
+			ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.cs") +
+			ReadSeederSources("ItemSeederCrafting.Antiquity*.cs");
 
 		var items = AntiquityReworkMethods
 			.SelectMany(method => ParseItemsInMethod(itemSource, method))
@@ -66,6 +73,26 @@ public class ItemSeederAntiquityRemainingCraftingTests
 
 		Assert.AreEqual(0, uncovered.Count,
 			$"Expected every antiquity prototype to be covered by an existing or new craft suite. Missing: {string.Join(", ", uncovered)}");
+
+		var partialStableReferences = ExtractExplicitStringStableReferences(partialItemSource)
+			.OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+			.ToList();
+
+		AssertContains(partialItemSource, "CreateAntiquityFoodTool");
+		AssertContains(partialItemSource, "CreateAntiquityHouseholdCraftTool");
+		AssertContains(partialItemSource, "SeedAntiquityMedicalItems");
+		AssertContains(partialItemSource, "SeedAntiquityWritingImplementsAndDocuments");
+		AssertContains(partialStableReferences, "antiquity_food_butchers_knife");
+		AssertContains(partialStableReferences, "antiquity_food_serving_amphora");
+		AssertContains(partialStableReferences, "antiquity_food_finished_beer_amphora");
+
+		var uncoveredPartialReferences = partialStableReferences
+			.Where(stableReference => !IsCoveredPartialStableReference(stableReference, partialItemSource,
+				allCraftSource, equipmentCraftSource))
+			.ToList();
+
+		Assert.AreEqual(0, uncoveredPartialReferences.Count,
+			$"Expected every explicitly named item in antiquity partial seeders to be craft-covered, dynamically craftable, or a documented morph target. Missing: {string.Join(", ", uncoveredPartialReferences)}");
 	}
 
 	[TestMethod]
@@ -467,6 +494,52 @@ public class ItemSeederAntiquityRemainingCraftingTests
 		       HasRoot(item.Tags, "Market / Professional Tools / Standard Tools");
 	}
 
+	private static bool IsCoveredPartialStableReference(string stableReference, string partialItemSource,
+		string allCraftSource, string equipmentCraftSource)
+	{
+		return allCraftSource.Contains($"\"{stableReference}\"", StringComparison.Ordinal) ||
+		       IsDynamicStandardToolHelperReference(stableReference, partialItemSource, equipmentCraftSource) ||
+		       IsFoodFinishedBeerMorphTarget(stableReference, partialItemSource);
+	}
+
+	private static bool IsDynamicStandardToolHelperReference(string stableReference, string partialItemSource,
+		string equipmentCraftSource)
+	{
+		if (!equipmentCraftSource.Contains("professionalToolTagIds", StringComparison.Ordinal))
+		{
+			return false;
+		}
+
+		var escapedStableReference = Regex.Escape(stableReference);
+		if (Regex.IsMatch(partialItemSource, $@"CreateAntiquityHouseholdCraftTool\(\s*""{escapedStableReference}""") &&
+		    partialItemSource.Contains("var tags = new List<string> { \"Market / Professional Tools / Standard Tools\" };", StringComparison.Ordinal))
+		{
+			return true;
+		}
+
+		if (Regex.IsMatch(partialItemSource, $@"CreateAntiquityFoodTool\(\s*""{escapedStableReference}""") &&
+		    partialItemSource.Contains("[toolTag, \"Market / Professional Tools / Standard Tools\"]", StringComparison.Ordinal))
+		{
+			return true;
+		}
+
+		if (Regex.IsMatch(partialItemSource, $@"AddWritingCraftTool\(\s*""{escapedStableReference}""") &&
+		    partialItemSource.Contains("[\"Market / Professional Tools / Standard Tools\", .. functionalTags]", StringComparison.Ordinal))
+		{
+			return true;
+		}
+
+		var itemBlock = TryExtractCallBlockContaining(partialItemSource, $"\"{stableReference}\"");
+		return itemBlock?.Contains("Market / Professional Tools / Standard Tools", StringComparison.Ordinal) == true;
+	}
+
+	private static bool IsFoodFinishedBeerMorphTarget(string stableReference, string partialItemSource)
+	{
+		return stableReference.Equals("antiquity_food_finished_beer_amphora", StringComparison.OrdinalIgnoreCase) &&
+		       partialItemSource.Contains("beerFinished is null ? null : \"antiquity_food_finished_beer_amphora\"",
+			       StringComparison.Ordinal);
+	}
+
 	private static IEnumerable<string> ExpectedEquipmentStockTags()
 	{
 		return
@@ -584,6 +657,12 @@ public class ItemSeederAntiquityRemainingCraftingTests
 		Assert.IsTrue(source.Contains(expected, StringComparison.Ordinal), $"Expected source to contain: {expected}");
 	}
 
+	private static void AssertContains(IReadOnlyCollection<string> source, string expected)
+	{
+		Assert.IsTrue(source.Contains(expected, StringComparer.OrdinalIgnoreCase),
+			$"Expected source collection to contain: {expected}");
+	}
+
 	private static string ExtractCallBlockContaining(string source, string marker)
 	{
 		var start = source.IndexOf(marker, StringComparison.Ordinal);
@@ -591,6 +670,18 @@ public class ItemSeederAntiquityRemainingCraftingTests
 		var end = source.IndexOf(");", start, StringComparison.Ordinal);
 		Assert.IsTrue(end >= 0, $"Could not find end of source block for {marker}.");
 		return source[start..end];
+	}
+
+	private static string? TryExtractCallBlockContaining(string source, string marker)
+	{
+		var start = source.IndexOf(marker, StringComparison.Ordinal);
+		if (start < 0)
+		{
+			return null;
+		}
+
+		var end = source.IndexOf(");", start, StringComparison.Ordinal);
+		return end < 0 ? null : source[start..end];
 	}
 
 	private static HashSet<string> ExtractLiteralCommodityProductTags(string source)
@@ -625,6 +716,14 @@ public class ItemSeederAntiquityRemainingCraftingTests
 	{
 		return Regex.Matches(source, @"\b(?:antiquity|adjacent_antiquity|jewellery)_[a-z0-9_]+\b")
 			.Select(x => x.Value)
+			.ToHashSet(StringComparer.OrdinalIgnoreCase);
+	}
+
+	private static HashSet<string> ExtractExplicitStringStableReferences(string source)
+	{
+		return Regex.Matches(source,
+				@"""(?<stable>(?:antiquity|adjacent_antiquity|jewellery)_[a-z0-9]+(?:_[a-z0-9]+)+)""")
+			.Select(x => x.Groups["stable"].Value)
 			.ToHashSet(StringComparer.OrdinalIgnoreCase);
 	}
 

--- a/DatabaseSeeder Unit Tests/ItemSeederAntiquityRemainingCraftingTests.cs
+++ b/DatabaseSeeder Unit Tests/ItemSeederAntiquityRemainingCraftingTests.cs
@@ -89,6 +89,7 @@ public class ItemSeederAntiquityRemainingCraftingTests
 		AssertContains(partialStableReferences, "antiquity_honey_press");
 		AssertContains(partialStableReferences, "antiquity_food_serving_amphora");
 		AssertContains(partialStableReferences, "antiquity_food_finished_beer_amphora");
+		AssertContains(partialStableReferences, "antiquity_food_finished_spiced_kumis_amphora");
 
 		var uncoveredPartialReferences = partialStableReferences
 			.Where(stableReference => !IsCoveredPartialStableReference(stableReference, partialItemSource,
@@ -503,7 +504,7 @@ public class ItemSeederAntiquityRemainingCraftingTests
 	{
 		return allCraftSource.Contains($"\"{stableReference}\"", StringComparison.Ordinal) ||
 		       IsDynamicStandardToolHelperReference(stableReference, partialItemSource, equipmentCraftSource) ||
-		       IsFoodFinishedBeerMorphTarget(stableReference, partialItemSource);
+		       IsFoodFinishedBeverageMorphTarget(stableReference, partialItemSource);
 	}
 
 	private static bool IsDynamicStandardToolHelperReference(string stableReference, string partialItemSource,
@@ -537,11 +538,12 @@ public class ItemSeederAntiquityRemainingCraftingTests
 		return itemBlock?.Contains("Market / Professional Tools / Standard Tools", StringComparison.Ordinal) == true;
 	}
 
-	private static bool IsFoodFinishedBeerMorphTarget(string stableReference, string partialItemSource)
+	private static bool IsFoodFinishedBeverageMorphTarget(string stableReference, string partialItemSource)
 	{
-		return stableReference.Equals("antiquity_food_finished_beer_amphora", StringComparison.OrdinalIgnoreCase) &&
-		       partialItemSource.Contains("beerFinished is null ? null : \"antiquity_food_finished_beer_amphora\"",
-			       StringComparison.Ordinal);
+		return stableReference.StartsWith("antiquity_food_finished_", StringComparison.OrdinalIgnoreCase) &&
+		       stableReference.EndsWith("_amphora", StringComparison.OrdinalIgnoreCase) &&
+		       partialItemSource.Contains($"\"{stableReference}\"", StringComparison.Ordinal) &&
+		       partialItemSource.Contains("finished is null ? null : finishedStableReference", StringComparison.Ordinal);
 	}
 
 	private static IEnumerable<string> ExpectedEquipmentStockTags()

--- a/DatabaseSeeder/Seeders/AgricultureSeeder.cs
+++ b/DatabaseSeeder/Seeders/AgricultureSeeder.cs
@@ -18,6 +18,11 @@ public sealed class AgricultureSeeder : IDatabaseSeeder
 	private const string SeedTagName = "Seeds";
 	private const string SeededYieldTagName = "Seeded Yield";
 	private const string SeedableMaterialTagName = "Agriculture Seedable";
+	private const string BeeHiveTagName = "Bee Hive";
+	private const string HiveStandTagName = "Hive Stand";
+	private const string RawHoneycombTagName = "Raw Honeycomb";
+	private const string PressedHoneyTagName = "Pressed Honey";
+	private const string RenderedBeeswaxTagName = "Rendered Beeswax";
 	private const string FarmingTraitName = "Farming";
 
 	private sealed record CropSeed(string Name, string Description, string Category, int Growth, int Window,
@@ -30,7 +35,10 @@ public sealed class AgricultureSeeder : IDatabaseSeeder
 	private sealed record OperationSeed(string Name, string Description, AgricultureOperationType Type,
 		AgricultureTargetType Target, AgricultureFieldUse Required, AgricultureFieldUse Result, double Hours,
 		(AgricultureScoreType Score, int Delta)[] Deltas, double WoodlandYieldMultiplier = 0.0,
-		int WoodlandYieldCost = 0);
+		int WoodlandYieldCost = 0, AgricultureFieldUse[]? AllowedUses = null, int ApiaryInstallHiveCount = 0,
+		int ApiaryPollinationRadius = 0, int ApiaryTendHealthDelta = 0, int ApiaryTendStoresDelta = 0,
+		int ApiaryTendYieldDelta = 0, double ApiaryYieldMultiplier = 0.0, int ApiaryYieldCost = 0,
+		AgricultureCommodityYield[]? ApiaryOutputs = null);
 
 	private static AgricultureCommodityYield Yield(string materialName, double baseWeight, string tagName = "") => new(materialName, baseWeight, tagName);
 
@@ -100,6 +108,24 @@ public sealed class AgricultureSeeder : IDatabaseSeeder
 		};
 	}
 
+	private static (AgriculturePollinationDependency Dependency, int HealthBonus, int YieldBonus) PollinationFor(CropSeed definition)
+	{
+		return definition.Name switch
+		{
+			"Cucumbers" or "Pumpkins" or "Squash" or "Bottle Gourds" or "Melons" or "Watermelons" or
+				"Kiwifruit" or "Passionfruit" => (AgriculturePollinationDependency.Required, 1, 2),
+			"Apples" or "Pears" or "Peaches" or "Plums" or "Cherries" or "Almonds" or "Apricots" or
+				"Blueberries" or "Raspberries" or "Blackberries" or "Strawberries" or "Cacao" =>
+				(AgriculturePollinationDependency.Strong, 1, 2),
+			"Figs" or "Oranges" or "Lemons" or "Limes" or "Grapefruits" or "Mandarins" or "Mangoes" or
+				"Avocados" or "Pomegranates" or "Quinces" or "Persimmons" or "Mulberries" or "Chestnuts" or
+				"Pecans" or "Macadamias" or "Guavas" or "Lychees" or "Papayas" or "Coffee" or "Tea" or
+				"Sunflower" or "Safflower" or "Sesame" or "Cotton" =>
+				(AgriculturePollinationDependency.Beneficial, 0, 1),
+			_ => (AgriculturePollinationDependency.None, 0, 0)
+		};
+	}
+
 	private static readonly (string Name, string Description, AgricultureFieldUse[] Uses, (AgricultureScoreType Score, int Value)[] Scores)[] Profiles =
 	[
 		("Arable Field", "A general-purpose field suited to broadacre cropping and periodic improvement.", [AgricultureFieldUse.Fallow, AgricultureFieldUse.Crop], [(AgricultureScoreType.Moisture, 55), (AgricultureScoreType.Drainage, 60), (AgricultureScoreType.Nutrients, 55), (AgricultureScoreType.Salinity, 10), (AgricultureScoreType.Topsoil, 65), (AgricultureScoreType.Tilth, 50), (AgricultureScoreType.Rockiness, 20), (AgricultureScoreType.Weeds, 35), (AgricultureScoreType.Pests, 25), (AgricultureScoreType.Fence, 35), (AgricultureScoreType.Pasture, 35), (AgricultureScoreType.Condition, 60)]),
@@ -146,7 +172,8 @@ public sealed class AgricultureSeeder : IDatabaseSeeder
 		("Heavy Clay Flat", "A compact heavy-clay flat with decent fertility but poor drainage and weak tilth.", [AgricultureFieldUse.Fallow, AgricultureFieldUse.Crop, AgricultureFieldUse.Pasture], [(AgricultureScoreType.Moisture, 70), (AgricultureScoreType.Drainage, 20), (AgricultureScoreType.Nutrients, 55), (AgricultureScoreType.Salinity, 10), (AgricultureScoreType.Topsoil, 55), (AgricultureScoreType.Tilth, 15), (AgricultureScoreType.Rockiness, 10), (AgricultureScoreType.Weeds, 55), (AgricultureScoreType.Pests, 30), (AgricultureScoreType.Fence, 10), (AgricultureScoreType.Pasture, 40), (AgricultureScoreType.Condition, 30)]),
 		("Stony Alluvial Fan", "A coarse alluvial fan or wash with sharp drainage, gravel, and low fine topsoil.", [AgricultureFieldUse.Fallow, AgricultureFieldUse.Crop, AgricultureFieldUse.Pasture], [(AgricultureScoreType.Moisture, 25), (AgricultureScoreType.Drainage, 85), (AgricultureScoreType.Nutrients, 25), (AgricultureScoreType.Salinity, 10), (AgricultureScoreType.Topsoil, 30), (AgricultureScoreType.Tilth, 20), (AgricultureScoreType.Rockiness, 70), (AgricultureScoreType.Weeds, 35), (AgricultureScoreType.Pests, 15), (AgricultureScoreType.Fence, 5), (AgricultureScoreType.Pasture, 20), (AgricultureScoreType.Condition, 20)]),
 		("Eroded Hillslope", "A depleted slope with lost topsoil, exposed stone, and continuing erosion risk.", [AgricultureFieldUse.Fallow, AgricultureFieldUse.Pasture, AgricultureFieldUse.Orchard], [(AgricultureScoreType.Moisture, 35), (AgricultureScoreType.Drainage, 70), (AgricultureScoreType.Nutrients, 20), (AgricultureScoreType.Salinity, 5), (AgricultureScoreType.Topsoil, 20), (AgricultureScoreType.Tilth, 15), (AgricultureScoreType.Rockiness, 65), (AgricultureScoreType.Weeds, 45), (AgricultureScoreType.Pests, 15), (AgricultureScoreType.Fence, 5), (AgricultureScoreType.Pasture, 25), (AgricultureScoreType.Condition, 15)]),
-		("Lateritic Scrubland", "A tropical lateritic scrub profile with weathered low-fertility soil and hard seasonal limits.", [AgricultureFieldUse.Fallow, AgricultureFieldUse.Pasture, AgricultureFieldUse.Orchard, AgricultureFieldUse.Woodland], [(AgricultureScoreType.Moisture, 55), (AgricultureScoreType.Drainage, 60), (AgricultureScoreType.Nutrients, 20), (AgricultureScoreType.Salinity, 5), (AgricultureScoreType.Topsoil, 35), (AgricultureScoreType.Tilth, 20), (AgricultureScoreType.Rockiness, 35), (AgricultureScoreType.Weeds, 65), (AgricultureScoreType.Pests, 45), (AgricultureScoreType.Fence, 5), (AgricultureScoreType.Pasture, 30), (AgricultureScoreType.Condition, 25)])
+		("Lateritic Scrubland", "A tropical lateritic scrub profile with weathered low-fertility soil and hard seasonal limits.", [AgricultureFieldUse.Fallow, AgricultureFieldUse.Pasture, AgricultureFieldUse.Orchard, AgricultureFieldUse.Woodland], [(AgricultureScoreType.Moisture, 55), (AgricultureScoreType.Drainage, 60), (AgricultureScoreType.Nutrients, 20), (AgricultureScoreType.Salinity, 5), (AgricultureScoreType.Topsoil, 35), (AgricultureScoreType.Tilth, 20), (AgricultureScoreType.Rockiness, 35), (AgricultureScoreType.Weeds, 65), (AgricultureScoreType.Pests, 45), (AgricultureScoreType.Fence, 5), (AgricultureScoreType.Pasture, 30), (AgricultureScoreType.Condition, 25)]),
+		("Apiary Yard", "A managed beeyard profile for placing hives alongside fallow ground, crops, orchards, pasture, or woodland.", [AgricultureFieldUse.Fallow, AgricultureFieldUse.Crop, AgricultureFieldUse.Orchard, AgricultureFieldUse.Pasture, AgricultureFieldUse.Woodland], [(AgricultureScoreType.Moisture, 50), (AgricultureScoreType.Drainage, 55), (AgricultureScoreType.Nutrients, 50), (AgricultureScoreType.Salinity, 5), (AgricultureScoreType.Topsoil, 55), (AgricultureScoreType.Tilth, 35), (AgricultureScoreType.Rockiness, 20), (AgricultureScoreType.Weeds, 45), (AgricultureScoreType.Pests, 25), (AgricultureScoreType.Fence, 40), (AgricultureScoreType.Pasture, 45), (AgricultureScoreType.Condition, 60)])
 	];
 
 	private static readonly CropSeed[] Crops =
@@ -313,6 +340,15 @@ public sealed class AgricultureSeeder : IDatabaseSeeder
 		new("Fruitwood Pollard Grove", "A pollarded mixed fruitwood grove that yields prunings, light timber, and modest fruitwood.", "pollard", 300, 900, [Yield("applewood", 1500000), Yield("pearwood", 1000000), Yield("firewood", 1000000)])
 	];
 
+	private static readonly AgricultureFieldUse[] ApiaryAllowedUses =
+	[
+		AgricultureFieldUse.Fallow,
+		AgricultureFieldUse.Crop,
+		AgricultureFieldUse.Orchard,
+		AgricultureFieldUse.Pasture,
+		AgricultureFieldUse.Woodland
+	];
+
 	private static readonly OperationSeed[] Operations =
 	[
 		new("Plough Field", "Break and turn the soil to gradually improve tilth and suppress weeds.", AgricultureOperationType.Improve, AgricultureTargetType.None, AgricultureFieldUse.Fallow, AgricultureFieldUse.Fallow, 80.0, [(AgricultureScoreType.Tilth, 8), (AgricultureScoreType.Weeds, -4), (AgricultureScoreType.Moisture, -3), (AgricultureScoreType.Condition, 1)]),
@@ -332,13 +368,18 @@ public sealed class AgricultureSeeder : IDatabaseSeeder
 		new("Coppice Woodland", "Cut a coppice stand back on cycle to produce poles, rods, or firewood while preserving the stand.", AgricultureOperationType.Improve, AgricultureTargetType.None, AgricultureFieldUse.Woodland, AgricultureFieldUse.Woodland, 160.0, [(AgricultureScoreType.Nutrients, -2), (AgricultureScoreType.Condition, 1)], 0.45, 45),
 		new("Thin Woodland", "Thin a woodland stand to produce small timber and improve remaining growth.", AgricultureOperationType.Improve, AgricultureTargetType.None, AgricultureFieldUse.Woodland, AgricultureFieldUse.Woodland, 240.0, [(AgricultureScoreType.Pests, -4), (AgricultureScoreType.Condition, 2)], 0.25, 25),
 		new("Fell Woodland", "Fell a managed woodland stand and return the field to fallow use.", AgricultureOperationType.Clear, AgricultureTargetType.None, AgricultureFieldUse.Woodland, AgricultureFieldUse.Fallow, 360.0, [(AgricultureScoreType.Topsoil, -4), (AgricultureScoreType.Weeds, 4), (AgricultureScoreType.Condition, -4)], 1.0, 100),
-		new("Clear Land", "Clear brush, stumps, scrub, or unmanaged growth for future field use.", AgricultureOperationType.Clear, AgricultureTargetType.None, AgricultureFieldUse.Woodland, AgricultureFieldUse.Fallow, 480.0, [(AgricultureScoreType.Weeds, -6), (AgricultureScoreType.Topsoil, -3), (AgricultureScoreType.Condition, -3)], 0.15, 20)
+		new("Clear Land", "Clear brush, stumps, scrub, or unmanaged growth for future field use.", AgricultureOperationType.Clear, AgricultureTargetType.None, AgricultureFieldUse.Woodland, AgricultureFieldUse.Fallow, 480.0, [(AgricultureScoreType.Weeds, -6), (AgricultureScoreType.Topsoil, -3), (AgricultureScoreType.Condition, -3)], 0.15, 20),
+		new("Install Apiary", "Place hives and a stand so bees can establish alongside the field's existing use.", AgricultureOperationType.InstallApiary, AgricultureTargetType.None, AgricultureFieldUse.Fallow, AgricultureFieldUse.Fallow, 48.0, [(AgricultureScoreType.Condition, 1)], AllowedUses: ApiaryAllowedUses, ApiaryInstallHiveCount: 2, ApiaryPollinationRadius: 2),
+		new("Tend Apiary", "Inspect and tend the hives, calming the colony and reducing pest pressure near the field.", AgricultureOperationType.TendApiary, AgricultureTargetType.None, AgricultureFieldUse.Fallow, AgricultureFieldUse.Fallow, 16.0, [(AgricultureScoreType.Pests, -2), (AgricultureScoreType.Condition, 1)], AllowedUses: ApiaryAllowedUses, ApiaryTendHealthDelta: 8, ApiaryTendStoresDelta: 4, ApiaryTendYieldDelta: 8),
+		new("Harvest Apiary", "Harvest honeycomb, honey, and wax from a healthy apiary without changing the field's use.", AgricultureOperationType.HarvestApiary, AgricultureTargetType.None, AgricultureFieldUse.Fallow, AgricultureFieldUse.Fallow, 24.0, [(AgricultureScoreType.Pests, 1)], AllowedUses: ApiaryAllowedUses, ApiaryYieldMultiplier: 1.0, ApiaryYieldCost: 45, ApiaryOutputs: [Yield("honeycomb", 60000, RawHoneycombTagName), Yield("honey", 30000, PressedHoneyTagName), Yield("beeswax", 6000, RenderedBeeswaxTagName)]),
+		new("Remove Apiary", "Remove the hives and stand from the field while leaving the primary field use alone.", AgricultureOperationType.RemoveApiary, AgricultureTargetType.None, AgricultureFieldUse.Fallow, AgricultureFieldUse.Fallow, 16.0, [], AllowedUses: ApiaryAllowedUses)
 	];
 
 	public static IReadOnlyCollection<string> StockCommodityOutputMaterialsForTesting =>
 		Crops.SelectMany(x => x.Outputs)
 		     .Concat(Orchards.SelectMany(x => x.Outputs))
 		     .Concat(Woodlands.SelectMany(x => x.Outputs))
+		     .Concat(Operations.SelectMany(x => x.ApiaryOutputs ?? []))
 		     .Select(x => x.MaterialName)
 		     .Distinct(StringComparer.InvariantCultureIgnoreCase)
 		     .OrderBy(x => x, StringComparer.InvariantCultureIgnoreCase)
@@ -365,6 +406,11 @@ public sealed class AgricultureSeeder : IDatabaseSeeder
 		    !context.Tags.Any(x => x.Name == SeedTagName) ||
 		    !context.Tags.Any(x => x.Name == SeededYieldTagName) ||
 		    !context.Tags.Any(x => x.Name == SeedableMaterialTagName) ||
+		    !context.Tags.Any(x => x.Name == BeeHiveTagName) ||
+		    !context.Tags.Any(x => x.Name == HiveStandTagName) ||
+		    !context.Tags.Any(x => x.Name == RawHoneycombTagName) ||
+		    !context.Tags.Any(x => x.Name == PressedHoneyTagName) ||
+		    !context.Tags.Any(x => x.Name == RenderedBeeswaxTagName) ||
 		    !context.TraitDefinitions.Any(x => x.Name == FarmingTraitName))
 		{
 			return ShouldSeedResult.PrerequisitesNotMet;
@@ -477,6 +523,7 @@ public sealed class AgricultureSeeder : IDatabaseSeeder
 
 		crop.Description = definition.Description;
 		crop.Category = definition.Category;
+		var pollination = PollinationFor(definition);
 		crop.Definition = new XElement("Crop",
 			new XAttribute("growthDays", definition.Growth),
 			new XAttribute("harvestWindowDays", definition.Window),
@@ -486,6 +533,10 @@ public sealed class AgricultureSeeder : IDatabaseSeeder
 			new XAttribute("maxMoisture", definition.MaxMoisture),
 			new XAttribute("minTemperature", definition.MinTemp),
 			new XAttribute("maxTemperature", definition.MaxTemp),
+			new XElement("Pollination",
+				new XAttribute("dependency", pollination.Dependency.ToString()),
+				new XAttribute("healthBonus", pollination.HealthBonus),
+				new XAttribute("yieldBonus", pollination.YieldBonus)),
 			new XElement("PlantingWindows",
 				PlantingGroupsFor(definition).Select(x => new XElement("Window",
 					new XAttribute("type", "group"),
@@ -663,6 +714,7 @@ public sealed class AgricultureSeeder : IDatabaseSeeder
 		action.Description = "Apply the agriculture operation when the project completes.";
 		action.Definition = "<Action />";
 		EnsureSeedRequirement(context, phase, operation);
+		EnsureApiaryInstallRequirements(context, phase, operation);
 		context.SaveChanges();
 		return project;
 	}
@@ -714,6 +766,54 @@ public sealed class AgricultureSeeder : IDatabaseSeeder
 			new XElement("Characteristics")).ToString();
 	}
 
+	private static void EnsureApiaryInstallRequirements(FuturemudDatabaseContext context, ProjectPhase phase, OperationSeed operation)
+	{
+		if (operation.Type != AgricultureOperationType.InstallApiary)
+		{
+			RemoveMaterialRequirement(context, phase, "Bee Hives");
+			RemoveMaterialRequirement(context, phase, "Hive Stand");
+			return;
+		}
+
+		EnsureTaggedItemRequirement(context, phase, "Bee Hives", "Two reusable bee hives for the apiary installation.",
+			BeeHiveTagName, 2);
+		EnsureTaggedItemRequirement(context, phase, "Hive Stand", "A stand or rack to keep the installed hives off the ground.",
+			HiveStandTagName, 1);
+	}
+
+	private static void RemoveMaterialRequirement(FuturemudDatabaseContext context, ProjectPhase phase, string name)
+	{
+		var existing = context.ProjectMaterialRequirements.FirstOrDefault(x => x.ProjectPhaseId == phase.Id && x.Name == name);
+		if (existing != null)
+		{
+			context.ProjectMaterialRequirements.Remove(existing);
+		}
+	}
+
+	private static void EnsureTaggedItemRequirement(FuturemudDatabaseContext context, ProjectPhase phase, string name,
+		string description, string tagName, int amount)
+	{
+		var tag = context.Tags.First(x => x.Name == tagName);
+		var existing = context.ProjectMaterialRequirements.FirstOrDefault(x => x.ProjectPhaseId == phase.Id && x.Name == name);
+		if (existing == null)
+		{
+			existing = new ProjectMaterialRequirement
+			{
+				ProjectPhaseId = phase.Id,
+				Name = name
+			};
+			context.ProjectMaterialRequirements.Add(existing);
+		}
+
+		existing.Type = "simple";
+		existing.Description = description;
+		existing.IsMandatoryForProjectCompletion = true;
+		existing.Definition = new XElement("Material",
+			new XElement("Tag", tag.Id),
+			new XElement("Amount", amount),
+			new XElement("Quality", (int)ItemQuality.Terrible)).ToString();
+	}
+
 	private static void EnsureOperation(FuturemudDatabaseContext context, OperationSeed definition, Project project)
 	{
 		var operation = context.AgricultureOperations.FirstOrDefault(x => x.Name == definition.Name);
@@ -734,6 +834,21 @@ public sealed class AgricultureSeeder : IDatabaseSeeder
 		operation.Definition = new XElement("Operation",
 			new XAttribute("woodlandYieldMultiplier", definition.WoodlandYieldMultiplier),
 			new XAttribute("woodlandYieldCost", definition.WoodlandYieldCost),
+			new XElement("AllowedUses",
+				new XAttribute("uses", string.Join(",", (definition.AllowedUses ?? [definition.Required]).Select(x => x.ToString())))),
+			new XElement("Apiary",
+				new XAttribute("installHives", definition.ApiaryInstallHiveCount),
+				new XAttribute("pollinationRadius", definition.ApiaryPollinationRadius),
+				new XAttribute("tendHealthDelta", definition.ApiaryTendHealthDelta),
+				new XAttribute("tendStoresDelta", definition.ApiaryTendStoresDelta),
+				new XAttribute("tendYieldDelta", definition.ApiaryTendYieldDelta),
+				new XAttribute("yieldMultiplier", definition.ApiaryYieldMultiplier),
+				new XAttribute("yieldCost", definition.ApiaryYieldCost),
+				new XElement("Outputs",
+					(definition.ApiaryOutputs ?? []).Select(x => new XElement("Commodity",
+						new XAttribute("material", x.MaterialName),
+						new XAttribute("weight", x.BaseWeight),
+						string.IsNullOrWhiteSpace(x.TagName) ? null : new XAttribute("tag", x.TagName))))),
 			definition.Deltas.Select(x => new XElement("Score",
 				new XAttribute("type", x.Score.ToString()),
 				new XAttribute("value", x.Delta)))).ToString();

--- a/DatabaseSeeder/Seeders/AgricultureSeeder.cs
+++ b/DatabaseSeeder/Seeders/AgricultureSeeder.cs
@@ -23,6 +23,10 @@ public sealed class AgricultureSeeder : IDatabaseSeeder
 	private const string RawHoneycombTagName = "Raw Honeycomb";
 	private const string PressedHoneyTagName = "Pressed Honey";
 	private const string RenderedBeeswaxTagName = "Rendered Beeswax";
+	private const string RawMilkTagName = "Raw Milk";
+	private const string RawTextileFibreTagName = "Raw Textile Fibre";
+	private const string EggProductTagName = "Egg Product";
+	private const string ManureCommodityTagName = "Manure Commodity";
 	private const string FarmingTraitName = "Farming";
 
 	private sealed record CropSeed(string Name, string Description, string Category, int Growth, int Window,
@@ -32,10 +36,14 @@ public sealed class AgricultureSeeder : IDatabaseSeeder
 	private sealed record WoodlandSeed(string Name, string Description, string Type, int Establishment, int Cycle,
 		AgricultureCommodityYield[] Outputs);
 
+	private sealed record HerdSeed(string Name, string Description, double AnimalUnits, double DailyGraze,
+		int MaximumCondition, AgricultureCommodityYield[] SecondaryOutputs);
+
 	private sealed record OperationSeed(string Name, string Description, AgricultureOperationType Type,
 		AgricultureTargetType Target, AgricultureFieldUse Required, AgricultureFieldUse Result, double Hours,
 		(AgricultureScoreType Score, int Delta)[] Deltas, double WoodlandYieldMultiplier = 0.0,
-		int WoodlandYieldCost = 0, AgricultureFieldUse[]? AllowedUses = null, int ApiaryInstallHiveCount = 0,
+		int WoodlandYieldCost = 0, double HerdYieldMultiplier = 0.0, int HerdYieldCost = 0,
+		AgricultureFieldUse[]? AllowedUses = null, int ApiaryInstallHiveCount = 0,
 		int ApiaryPollinationRadius = 0, int ApiaryTendHealthDelta = 0, int ApiaryTendStoresDelta = 0,
 		int ApiaryTendYieldDelta = 0, double ApiaryYieldMultiplier = 0.0, int ApiaryYieldCost = 0,
 		AgricultureCommodityYield[]? ApiaryOutputs = null);
@@ -84,14 +92,15 @@ public sealed class AgricultureSeeder : IDatabaseSeeder
 				"Bitter Vetch" or "Grass Peas" or "Lupins" or "Canihua" or "Pitseed Goosefoot" or "Maygrass" or
 				"Little Barley" or "Erect Knotweed" or "Potatoes" or "Oca" or "Ulluco" or "Mashua" or
 				"Jerusalem Artichokes" or "Carrots" or "Beetroot" or "Turnips" or "Onions" or "Cabbage" or
-				"Lettuce" or "Sugar Beet" or "Canola" or "Mustard" or "Flax" or "Woad" => CoolSeasonPlanting,
+				"Lettuce" or "Sugar Beet" or "Canola" or "Mustard" or "Flax" or "Madder" or "Weld" or
+				"Alkanet" or "Woad" or "Coriander" or "Saffron Crocus" => CoolSeasonPlanting,
 			"Garlic" => OverwinteringPlanting,
 			"Rice" or "Maize" or "Sorghum" or "Millet" or "Buckwheat" or "Chickpeas" or "Soybeans" or
 				"Peanuts" or "Cowpeas" or "Mung Beans" or "Bambara Groundnuts" or "Adzuki Beans" or "Teff" or
 				"Fonio" or "Finger Millet" or "Pearl Millet" or "Foxtail Millet" or "Proso Millet" or
 				"Amaranth" or "Chia" or "Marshelder" or "African Rice" or "Sweet Potatoes" or "Tomatoes" or
 				"Eggplants" or "Cucumbers" or "Pumpkins" or "Squash" or "Okra" or "Bottle Gourds" or
-				"Peppers" or "Sunflower" or "Safflower" or "Niger Seed" or "Hemp" => WarmSeasonPlanting,
+				"Peppers" or "Sunflower" or "Safflower" or "Niger Seed" or "Hemp" or "Cumin" => WarmSeasonPlanting,
 			"Cassava" or "Taro" or "Yams" or "Sugarcane" or "Sesame" or "Cotton" or "Jute" or "Ramie" or
 				"Sisal" or "Pigeon Peas" or "Arrowroot" or "Lotus Root" or "Water Chestnuts" or "Kenaf" or
 				"Indigo" => HotLongSeasonPlanting,
@@ -103,7 +112,7 @@ public sealed class AgricultureSeeder : IDatabaseSeeder
 			"Dates" or "Bananas" or "Mangoes" or "Coconuts" or "Plantains" or "Breadfruit" or "Avocados" or
 				"Cacao" or "Coffee" or "Tea" or "Cashews" or "Macadamias" or "Guavas" or "Lychees" or
 				"Jackfruit" or "Papayas" or "Passionfruit" or "Cinnamon" or "Cloves" or "Nutmeg" or
-				"Kola Nuts" or "Tamarinds" => TropicalPerennialPlanting,
+				"Kola Nuts" or "Tamarinds" or "Black Pepper" or "Henna" => TropicalPerennialPlanting,
 			_ => Array.Empty<string>()
 		};
 	}
@@ -257,6 +266,9 @@ public sealed class AgricultureSeeder : IDatabaseSeeder
 		new("Safflower", "A dryland oilseed and dye crop with thistle-like flower heads.", "oilseed", 120, 18, 15, 60, 8, 38, [Yield("safflower", 900000), Yield("straw", 300000)]),
 		new("Niger Seed", "A warm oilseed crop important in parts of Ethiopia and India.", "oilseed", 100, 14, 25, 70, 12, 36, [Yield("niger seed", 700000), Yield("straw", 250000)]),
 		new("Mustard", "A brassica seed crop for spice, greens, and oil.", "oilseed", 90, 14, 30, 80, 2, 30, [Yield("mustard seed", 900000), Yield("straw", 300000)]),
+		new("Coriander", "A seed-spice and herb crop suited to irrigated gardens and cool-season fields.", "spice", 90, 14, 30, 75, 5, 32, [Yield("coriander", 450000), Yield("vegetation", 200000)]),
+		new("Cumin", "A warm dryland seed-spice crop for aromatic cumin seed.", "spice", 110, 16, 20, 65, 10, 38, [Yield("cumin", 350000), Yield("straw", 150000)]),
+		new("Saffron Crocus", "A cool-season crocus grown for labour-intensive saffron stigmas.", "spice", 150, 18, 20, 65, -2, 30, [Yield("saffron crocus", 80000), Yield("vegetation", 100000)]),
 		new("Cotton", "A warm-season fibre crop producing cotton bolls.", "fibre", 160, 24, 35, 75, 15, 40, [Yield("cotton crop", 1800000), Yield("straw", 700000)]),
 		new("Flax", "A cool-season fibre and seed crop.", "fibre", 110, 18, 35, 75, 2, 30, [Yield("flax", 1400000), Yield("straw", 800000)]),
 		new("Hemp", "A tall bast-fibre crop for fibre, seed, or biomass.", "fibre", 120, 18, 35, 80, 8, 35, [Yield("hemp crop", 2500000), Yield("straw", 1200000)]),
@@ -264,6 +276,9 @@ public sealed class AgricultureSeeder : IDatabaseSeeder
 		new("Ramie", "A perennial nettle-family fibre crop.", "fibre", 130, 20, 45, 90, 12, 38, [Yield("ramie", 1800000), Yield("straw", 800000)]),
 		new("Sisal", "A dryland leaf-fibre crop.", "fibre", 240, 35, 15, 55, 12, 42, [Yield("sisal", 2000000)]),
 		new("Kenaf", "A hot-season bast-fibre crop related to hibiscus.", "fibre", 140, 20, 45, 90, 16, 40, [Yield("kenaf", 1800000), Yield("straw", 800000)]),
+		new("Madder", "A deep-rooted dye crop grown for red dye roots.", "industrial", 730, 45, 25, 70, 0, 35, [Yield("madder root", 900000), Yield("vegetation", 300000)]),
+		new("Weld", "A cool-season yellow dye crop grown for flowering stems and leaves.", "industrial", 120, 18, 25, 70, 0, 32, [Yield("weld", 900000), Yield("vegetation", 250000)]),
+		new("Alkanet", "A dryland dye herb grown for purple-red roots.", "industrial", 240, 28, 20, 60, 2, 36, [Yield("alkanet root", 650000), Yield("vegetation", 200000)]),
 		new("Indigo", "A hot-climate dye crop grown for leaves used in blue dye production.", "industrial", 130, 20, 35, 85, 16, 40, [Yield("indigo crop", 1200000), Yield("vegetation", 400000)]),
 		new("Woad", "A cool-season dye crop grown for blue-dye leaves in temperate fields.", "industrial", 110, 18, 35, 80, 0, 30, [Yield("woad leaves", 1000000), Yield("vegetation", 300000)])
 	];
@@ -314,18 +329,41 @@ public sealed class AgricultureSeeder : IDatabaseSeeder
 		new("Kiwifruit", "A temperate climbing-vine orchard crop for fuzzy fruit.", "orchard", 730, 24, 45, 85, -5, 32, [Yield("kiwi fruit", 6000000)], true, 210),
 		new("Passionfruit", "A warm-climate climbing-vine orchard crop for aromatic fruit.", "orchard", 450, 24, 45, 90, 8, 36, [Yield("passionfruit", 5000000)], true, 180),
 		new("Cinnamon", "A tropical spice-tree plantation crop harvested for aromatic bark.", "orchard", 1095, 28, 60, 95, 18, 38, [Yield("cinnamon bark", 1200000)], true, 365),
+		new("Black Pepper", "A tropical climbing pepper vine grown for dried peppercorns.", "orchard", 1095, 28, 60, 95, 18, 40, [Yield("black pepper", 700000)], true, 300),
 		new("Cloves", "A humid tropical spice-tree crop for aromatic flower buds.", "orchard", 1460, 30, 65, 100, 18, 38, [Yield("cloves", 800000)], true, 300),
 		new("Nutmeg", "A tropical spice-tree crop for nutmeg seed and mace.", "orchard", 1460, 30, 65, 100, 18, 38, [Yield("nutmeg", 900000)], true, 300),
+		new("Henna", "A hot dry-climate dye shrub grown for orange-red leaves.", "orchard", 730, 24, 15, 60, 14, 42, [Yield("henna leaf", 900000), Yield("vegetation", 200000)], true, 220),
 		new("Kola Nuts", "A humid tropical kola tree crop for stimulant nuts.", "orchard", 1460, 30, 60, 95, 18, 38, [Yield("kola nut", 1200000)], true, 300),
 		new("Tamarinds", "A drought-tolerant tropical tamarind tree crop for sour-sweet pods.", "orchard", 1095, 28, 20, 70, 12, 42, [Yield("tamarind", 5000000)], true, 260)
 	];
 
-	private static readonly (string Name, string Description, double AnimalUnits, double DailyGraze, int MaximumCondition)[] Herds =
+	private static readonly HerdSeed[] Herds =
 	[
-		("Cattle Herd", "A generic cattle, aurochs, buffalo, or large grazing herd.", 1.0, 1.0, 100),
-		("Sheep or Goat Flock", "A generic flock of sheep, goats, or other small browsers.", 0.2, 0.3, 100),
-		("Pig Herd", "A generic pig, boar, or omnivorous rooting herd.", 0.4, 0.45, 100),
-		("Poultry Flock", "A generic flock of chickens, ducks, geese, or similar fowl.", 0.03, 0.05, 100)
+		new("Cattle Herd", "A generic cattle, aurochs, buffalo, or large grazing herd.", 1.0, 1.0, 100,
+		[
+			Yield("milk", 3500, RawMilkTagName),
+			Yield("feces", 2500, ManureCommodityTagName)
+		]),
+		new("Sheep or Goat Flock", "A generic flock of sheep, goats, or other small browsers.", 0.2, 0.3, 100,
+		[
+			Yield("milk", 900, RawMilkTagName),
+			Yield("wool", 450, RawTextileFibreTagName),
+			Yield("feces", 700, ManureCommodityTagName)
+		]),
+		new("Pig Herd", "A generic pig, boar, or omnivorous rooting herd.", 0.4, 0.45, 100,
+		[
+			Yield("feces", 1800, ManureCommodityTagName)
+		]),
+		new("Horse Herd", "A generic horse, pony, ass, onager, or other equine herd for mobile pastoral cultures.", 0.8, 0.8, 100,
+		[
+			Yield("milk", 1200, RawMilkTagName),
+			Yield("feces", 1600, ManureCommodityTagName)
+		]),
+		new("Poultry Flock", "A generic flock of chickens, ducks, geese, or similar fowl.", 0.03, 0.05, 100,
+		[
+			Yield("egg", 60, EggProductTagName),
+			Yield("feces", 45, ManureCommodityTagName)
+		])
 	];
 
 	private static readonly WoodlandSeed[] Woodlands =
@@ -334,6 +372,9 @@ public sealed class AgricultureSeeder : IDatabaseSeeder
 		new("Willow Coppice", "A damp-ground willow coppice for withies, rods, basketry material, and firewood.", "coppice", 150, 240, [Yield("willow", 2200000), Yield("firewood", 700000)]),
 		new("Bamboo Grove", "A fast-growing bamboo grove for canes, poles, shoots, and light structural material.", "coppice", 120, 180, [Yield("bamboo", 3500000), Yield("vegetation", 500000)]),
 		new("Oak Timber Stand", "A long-cycle hardwood timber stand managed for heavy oak logs and firewood.", "timber", 730, 3650, [Yield("oak", 9000000), Yield("firewood", 2500000), Yield("oak gall", 100000)]),
+		new("Kermes Oak Scrub", "A Mediterranean scrub woodland managed for small oak wood, fuel, galls, and kermes dye insects.", "coppice", 420, 900, [Yield("oak", 2000000), Yield("firewood", 900000), Yield("oak gall", 80000), Yield("kermes grain", 45000)]),
+		new("Dye Lichen Grove", "A damp stone-and-tree woodland managed for dye-bearing orchil lichens.", "coppice", 365, 730, [Yield("orchil lichen", 120000), Yield("moss", 200000), Yield("firewood", 400000)]),
+		new("Lac Host Grove", "A warm host-tree grove managed for lac dye encrustations and light fuel wood.", "coppice", 365, 730, [Yield("lac dye cake", 70000), Yield("firewood", 450000)]),
 		new("Pine Timber Stand", "A softwood timber stand grown for pine logs, poles, and fuel.", "timber", 540, 2555, [Yield("pine", 8500000), Yield("firewood", 2000000)]),
 		new("Cedar Timber Stand", "A managed cedar stand for aromatic softwood timber.", "timber", 650, 3285, [Yield("cedar", 7000000), Yield("firewood", 1600000)]),
 		new("Pollarded Willow Grove", "A pollarded willow grove cut above browsing height for poles and fuel.", "pollard", 240, 730, [Yield("willow", 3200000), Yield("firewood", 1000000)]),
@@ -364,6 +405,7 @@ public sealed class AgricultureSeeder : IDatabaseSeeder
 		new("Harvest Crop", "Harvest a crop that is ready to be gathered.", AgricultureOperationType.Harvest, AgricultureTargetType.None, AgricultureFieldUse.Crop, AgricultureFieldUse.Fallow, 96.0, [(AgricultureScoreType.Nutrients, -4), (AgricultureScoreType.Weeds, 4)]),
 		new("Harvest Orchard", "Harvest a ready perennial crop while leaving the orchard or vineyard in place.", AgricultureOperationType.Harvest, AgricultureTargetType.None, AgricultureFieldUse.Orchard, AgricultureFieldUse.Orchard, 128.0, [(AgricultureScoreType.Nutrients, -3), (AgricultureScoreType.Weeds, 3)]),
 		new("Rotate Grazing", "Move or settle an abstract herd onto pasture.", AgricultureOperationType.Herd, AgricultureTargetType.Herd, AgricultureFieldUse.Fallow, AgricultureFieldUse.Pasture, 32.0, [(AgricultureScoreType.Fence, -2), (AgricultureScoreType.Pasture, -4)]),
+		new("Collect Herd Products", "Collect milk, fleece, eggs, manure, or other configured secondary products from an established herd.", AgricultureOperationType.HarvestHerdProducts, AgricultureTargetType.Herd, AgricultureFieldUse.Pasture, AgricultureFieldUse.Pasture, 24.0, [(AgricultureScoreType.Pasture, -1)], HerdYieldMultiplier: 1.0, HerdYieldCost: 55),
 		new("Plant Woodland", "Plant or establish a managed woodland, coppice, pollard, or timber stand.", AgricultureOperationType.Woodland, AgricultureTargetType.Woodland, AgricultureFieldUse.Fallow, AgricultureFieldUse.Woodland, 480.0, [(AgricultureScoreType.Topsoil, -2), (AgricultureScoreType.Weeds, -4), (AgricultureScoreType.Condition, 2)]),
 		new("Coppice Woodland", "Cut a coppice stand back on cycle to produce poles, rods, or firewood while preserving the stand.", AgricultureOperationType.Improve, AgricultureTargetType.None, AgricultureFieldUse.Woodland, AgricultureFieldUse.Woodland, 160.0, [(AgricultureScoreType.Nutrients, -2), (AgricultureScoreType.Condition, 1)], 0.45, 45),
 		new("Thin Woodland", "Thin a woodland stand to produce small timber and improve remaining growth.", AgricultureOperationType.Improve, AgricultureTargetType.None, AgricultureFieldUse.Woodland, AgricultureFieldUse.Woodland, 240.0, [(AgricultureScoreType.Pests, -4), (AgricultureScoreType.Condition, 2)], 0.25, 25),
@@ -378,6 +420,7 @@ public sealed class AgricultureSeeder : IDatabaseSeeder
 	public static IReadOnlyCollection<string> StockCommodityOutputMaterialsForTesting =>
 		Crops.SelectMany(x => x.Outputs)
 		     .Concat(Orchards.SelectMany(x => x.Outputs))
+		     .Concat(Herds.SelectMany(x => x.SecondaryOutputs))
 		     .Concat(Woodlands.SelectMany(x => x.Outputs))
 		     .Concat(Operations.SelectMany(x => x.ApiaryOutputs ?? []))
 		     .Select(x => x.MaterialName)
@@ -411,6 +454,10 @@ public sealed class AgricultureSeeder : IDatabaseSeeder
 		    !context.Tags.Any(x => x.Name == RawHoneycombTagName) ||
 		    !context.Tags.Any(x => x.Name == PressedHoneyTagName) ||
 		    !context.Tags.Any(x => x.Name == RenderedBeeswaxTagName) ||
+		    !context.Tags.Any(x => x.Name == RawMilkTagName) ||
+		    !context.Tags.Any(x => x.Name == RawTextileFibreTagName) ||
+		    !context.Tags.Any(x => x.Name == EggProductTagName) ||
+		    !context.Tags.Any(x => x.Name == ManureCommodityTagName) ||
 		    !context.TraitDefinitions.Any(x => x.Name == FarmingTraitName))
 		{
 			return ShouldSeedResult.PrerequisitesNotMet;
@@ -553,7 +600,7 @@ public sealed class AgricultureSeeder : IDatabaseSeeder
 					string.IsNullOrWhiteSpace(x.TagName) ? null : new XAttribute("tag", x.TagName))))).ToString();
 	}
 
-	private static void EnsureHerd(FuturemudDatabaseContext context, (string Name, string Description, double AnimalUnits, double DailyGraze, int MaximumCondition) definition)
+	private static void EnsureHerd(FuturemudDatabaseContext context, HerdSeed definition)
 	{
 		var herd = context.AgricultureHerdDefinitions.FirstOrDefault(x => x.Name == definition.Name);
 		if (herd == null)
@@ -568,7 +615,12 @@ public sealed class AgricultureSeeder : IDatabaseSeeder
 		herd.Definition = new XElement("Herd",
 			new XAttribute("animalUnits", definition.AnimalUnits),
 			new XAttribute("dailyGraze", definition.DailyGraze),
-			new XAttribute("maximumCondition", definition.MaximumCondition)).ToString();
+			new XAttribute("maximumCondition", definition.MaximumCondition),
+			new XElement("SecondaryOutputs",
+				definition.SecondaryOutputs.Select(x => new XElement("Commodity",
+					new XAttribute("material", x.MaterialName),
+					new XAttribute("weight", x.BaseWeight),
+					string.IsNullOrWhiteSpace(x.TagName) ? null : new XAttribute("tag", x.TagName))))).ToString();
 	}
 
 	private static void EnsureWoodland(FuturemudDatabaseContext context, WoodlandSeed definition)
@@ -834,6 +886,8 @@ public sealed class AgricultureSeeder : IDatabaseSeeder
 		operation.Definition = new XElement("Operation",
 			new XAttribute("woodlandYieldMultiplier", definition.WoodlandYieldMultiplier),
 			new XAttribute("woodlandYieldCost", definition.WoodlandYieldCost),
+			new XAttribute("herdYieldMultiplier", definition.HerdYieldMultiplier),
+			new XAttribute("herdYieldCost", definition.HerdYieldCost),
 			new XElement("AllowedUses",
 				new XAttribute("uses", string.Join(",", (definition.AllowedUses ?? [definition.Required]).Select(x => x.ToString())))),
 			new XElement("Apiary",

--- a/DatabaseSeeder/Seeders/CoreDataSeeder.Materials.cs
+++ b/DatabaseSeeder/Seeders/CoreDataSeeder.Materials.cs
@@ -556,6 +556,10 @@ public partial class CoreDataSeeder
         AddTag("Materials", null);
         AddTag("Simplified", "Materials");
         AddTag("Animal Product", "Materials");
+        AddTag("Apiary Product", "Animal Product");
+        AddTag("Raw Honeycomb", "Apiary Product");
+        AddTag("Pressed Honey", "Apiary Product");
+        AddTag("Rendered Beeswax", "Apiary Product");
         AddTag("Natural Materials", "Materials");
         AddTag("Manufactured Materials", "Materials");
         AddTag("Stone", "Natural Materials");
@@ -1562,7 +1566,9 @@ public partial class CoreDataSeeder
         AddMaterial("cheese", MaterialBehaviourType.Food, 1.0, true, 1000, 1000, 0.0, 0.14, 0.0001, 500, null, "Food",
             "Animal Product");
         AddMaterial("honey", MaterialBehaviourType.Food, 1.0, true, 1000, 1000, 0.0, 0.14, 0.0001, 500, null, "Food",
-            "Animal Product");
+            "Animal Product", "Apiary Product");
+        AddMaterial("honeycomb", MaterialBehaviourType.Food, 0.95, true, 1000, 1000, 0.0, 0.14, 0.0001, 500, null, "Food",
+            "Animal Product", "Apiary Product");
         AddMaterial("yoghurt", MaterialBehaviourType.Food, 1.0, true, 1000, 1000, 0.0, 0.14, 0.0001, 500, null, "Food",
             "Animal Product");
 
@@ -1870,7 +1876,7 @@ public partial class CoreDataSeeder
         AddMaterial("soap", MaterialBehaviourType.Soap, 0.2, true, 1000, 1000, 0.05, 0.14, 0.0001, 500, null,
             "Natural Materials", "Animal Product");
         AddMaterial("beeswax", MaterialBehaviourType.Wax, 0.2, true, 1000, 1000, 0.0, 0.14, 0.0001, 500, null,
-            "Natural Materials", "Animal Product");
+            "Natural Materials", "Animal Product", "Apiary Product");
         AddMaterial("guano", MaterialBehaviourType.Wax, 0.2, true, 1000, 1000, 0.0, 0.14, 0.0001, 500, null,
             "Natural Materials", "Animal Product");
         AddMaterial("paraffin wax", MaterialBehaviourType.Wax, 0.2, false, 1000, 1000, 0.0, 0.14, 0.0001, 500, null,

--- a/DatabaseSeeder/Seeders/CoreDataSeeder.Materials.cs
+++ b/DatabaseSeeder/Seeders/CoreDataSeeder.Materials.cs
@@ -35,7 +35,7 @@ public partial class CoreDataSeeder
 		void EnsureTag(Material material, string tagName)
 		{
 			var tag = tags[tagName];
-			if (material.MaterialsTags.Any(x => x.TagId == tag.Id))
+			if (material.MaterialsTags.Any(x => x.TagId == tag.Id || x.Tag?.Id == tag.Id))
 			{
 				return;
 			}
@@ -283,6 +283,27 @@ public partial class CoreDataSeeder
 			AddMaterial(name, MaterialBehaviourType.Food, 1.0, true, 1000, 1000, 0.0, 0.14, 0.0001, 500, "Food",
 				"Animal Product");
 		}
+
+		AddMaterial("milk", MaterialBehaviourType.Food, 1.0, true, 1000, 1000, 0.0, 0.14, 0.0001, 500, "Food",
+			"Animal Product", "Pastoral Product", "Raw Milk");
+		AddMaterial("egg", MaterialBehaviourType.Food, 1.0, true, 1000, 1000, 0.0, 0.14, 0.0001, 500, "Food",
+			"Animal Product", "Pastoral Product", "Egg Product");
+		AddMaterial("saffron crocus", MaterialBehaviourType.Plant, 1.0, true, 1000, 1000, 0.0, 0.14, 0.0001, 500,
+			"Herb", "Textile Dye");
+		EnsureTag(materials["milk"], "Pastoral Product");
+		EnsureTag(materials["milk"], "Raw Milk");
+		EnsureTag(materials["egg"], "Pastoral Product");
+		EnsureTag(materials["egg"], "Egg Product");
+		EnsureTag(materials["wool"], "Animal Product");
+		EnsureTag(materials["wool"], "Pastoral Product");
+		EnsureTag(materials["wool"], "Raw Wool");
+		EnsureTag(materials["feces"], "Pastoral Product");
+		EnsureTag(materials["feces"], "Manure Product");
+		EnsureTag(materials["compost"], "Animal Product");
+		EnsureTag(materials["compost"], "Pastoral Product");
+		EnsureTag(materials["compost"], "Manure Product");
+		EnsureAlias(materials["egg"], "eggs");
+		EnsureAlias(materials["saffron crocus"], "crocus flower", "saffron flower");
 
 		foreach (var name in new[]
 		{
@@ -560,6 +581,11 @@ public partial class CoreDataSeeder
         AddTag("Raw Honeycomb", "Apiary Product");
         AddTag("Pressed Honey", "Apiary Product");
         AddTag("Rendered Beeswax", "Apiary Product");
+        AddTag("Pastoral Product", "Animal Product");
+        AddTag("Raw Milk", "Pastoral Product");
+        AddTag("Raw Wool", "Pastoral Product");
+        AddTag("Egg Product", "Pastoral Product");
+        AddTag("Manure Product", "Pastoral Product");
         AddTag("Natural Materials", "Materials");
         AddTag("Manufactured Materials", "Materials");
         AddTag("Stone", "Natural Materials");

--- a/DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityApiary.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityApiary.cs
@@ -1,0 +1,75 @@
+using MudSharp.GameItems;
+using System;
+using System.Collections.Generic;
+
+namespace DatabaseSeeder.Seeders;
+
+public partial class ItemSeeder
+{
+	private const string AntiquityBeekeepingToolsTagPath = "Functions / Tools / Agricultural Tools / Beekeeping Tools";
+
+	private void SeedAntiquityApiaryItems()
+	{
+		EnsureAntiquityTagPath(AntiquityBeekeepingToolsTagPath);
+		foreach (var tag in new[]
+		         {
+			         "Bee Hive",
+			         "Hive Stand",
+			         "Bee Smoke Pot",
+			         "Honey Knife",
+			         "Honey Press",
+			         "Honey Strainer"
+		         })
+		{
+			EnsureAntiquityTagPath($"{AntiquityBeekeepingToolsTagPath} / {tag}");
+		}
+
+		CreateAntiquityApiaryEquipment("antiquity_wicker_beehive", "hive", "a woven wicker beehive",
+			"A domed wicker hive daubed and sealed for keeping a small bee colony.", SizeCategory.Normal, 2800.0,
+			12.0m, "willow", "Functions / Tools / Agricultural Tools / Beekeeping Tools / Bee Hive");
+		CreateAntiquityApiaryEquipment("antiquity_clay_tube_hive", "hive", "a clay tube beehive",
+			"A fired clay tube hive with capped ends and a small working mouth for an apiary colony.", SizeCategory.Large,
+			12000.0, 16.0m, "fired clay", "Functions / Tools / Agricultural Tools / Beekeeping Tools / Bee Hive");
+		CreateAntiquityApiaryEquipment("antiquity_wooden_hive_stand", "stand", "a wooden hive stand",
+			"A sturdy wooden stand that keeps hives raised, level, and away from damp ground.", SizeCategory.Large,
+			9000.0, 18.0m, "oak", "Functions / Tools / Agricultural Tools / Beekeeping Tools / Hive Stand");
+		CreateAntiquityApiaryEquipment("antiquity_honey_press", "press", "a wooden honey press",
+			"A compact screw-and-basket press for squeezing honey from broken comb.", SizeCategory.VeryLarge, 22000.0,
+			30.0m, "oak", "Functions / Tools / Agricultural Tools / Beekeeping Tools / Honey Press");
+
+		CreateAntiquityApiaryTool("antiquity_bee_smoke_pot", "pot", "a clay bee smoke pot",
+			"A lidded clay pot with a small spout for directing cool smoke around opened hives.", SizeCategory.Small,
+			1200.0, 7.0m, "fired clay", "Functions / Tools / Agricultural Tools / Beekeeping Tools / Bee Smoke Pot");
+		CreateAntiquityApiaryTool("antiquity_honey_knife", "knife", "a bronze honey knife",
+			"A broad bronze knife used to loosen and cut honeycomb from hive bodies.", SizeCategory.Small, 220.0, 8.0m,
+			"bronze", "Functions / Tools / Agricultural Tools / Beekeeping Tools / Honey Knife");
+		CreateAntiquityApiaryTool("antiquity_honey_strainer", "strainer", "a linen honey strainer",
+			"A tight linen strainer stretched on a small hoop for cleaning pressed honey.", SizeCategory.Small, 180.0,
+			5.0m, "linen", "Functions / Tools / Agricultural Tools / Beekeeping Tools / Honey Strainer");
+	}
+
+	private void CreateAntiquityApiaryTool(string stableReference, string noun, string shortDescription,
+		string fullDescription, SizeCategory size, double weightInGrams, decimal cost, string material, string toolTagPath)
+	{
+		CreateItem(stableReference, noun, shortDescription, null, fullDescription, size, ItemQuality.Standard,
+			weightInGrams, cost, false, false, material,
+			[
+				toolTagPath,
+				"Market / Professional Tools / Standard Tools"
+			],
+			["Holdable", "Destroyable_Misc"], null, null, null, null);
+	}
+
+	private void CreateAntiquityApiaryEquipment(string stableReference, string noun, string shortDescription,
+		string fullDescription, SizeCategory size, double weightInGrams, decimal cost, string material, string toolTagPath)
+	{
+		CreateItem(stableReference, noun, shortDescription, null, fullDescription, size, ItemQuality.Standard,
+			weightInGrams, cost, false, false, material,
+			[
+				toolTagPath,
+				"Market / Professional Tools / Standard Tools"
+			],
+			["Holdable", (int)size >= (int)SizeCategory.Large ? "Destroyable_Furniture" : "Destroyable_Misc"],
+			null, null, null, null);
+	}
+}

--- a/DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityFood.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityFood.cs
@@ -276,6 +276,9 @@ public partial class ItemSeeder
 		CreateAntiquityFoodTool("antiquity_food_winnowing_basket", "basket", "a broad woven winnowing basket",
 			"A broad, shallow basket for tossing grain and chaff into a breeze.", SizeCategory.Normal, 900, "willow",
 			"Functions / Tools / Agricultural Tools / Winnowing Basket");
+		CreateAntiquityFoodTool("antiquity_food_pitchfork", "fork", "a long wooden pitchfork",
+			"A long-handled wooden fork used to turn straw, fodder and compost heaps.", SizeCategory.Normal, 2200,
+			"oak", "Functions / Tools / Agricultural Tools / Pitchfork");
 		CreateAntiquityFoodTool("antiquity_food_quern", "quern", "a heavy rotary hand quern",
 			"A paired stone quern for grinding cleaned grain into flour or meal.", SizeCategory.Large, 18000, "basalt",
 			"Functions / Tools / Foodmaking Tools / Hand Quern");

--- a/DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityFood.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityFood.cs
@@ -389,7 +389,8 @@ public partial class ItemSeeder
 		SizeCategory size, double weight, string material, string toolTag)
 	{
 		return CreateItem(stableReference, noun, sdesc, null, fdesc, size, ItemQuality.Standard, weight, 6M, false,
-			false, material, [toolTag], ["Holdable", "Destroyable_Misc"], null, null, null, null);
+			false, material, [toolTag, "Market / Professional Tools / Standard Tools"],
+			["Holdable", "Destroyable_Misc"], null, null, null, null);
 	}
 
 	private GameItemProto? CreateAntiquityFoodVessel(string stableReference, string noun, string sdesc, string fdesc,

--- a/DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityFood.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityFood.cs
@@ -324,16 +324,51 @@ public partial class ItemSeeder
 			"Bitter fruit has been cured in brine until it is ready to eat.", "olive",
 			"PreparedFood_Antiquity_BrinedFruit");
 
-		var beerFinished = CreateAntiquityFoodVessel("antiquity_food_finished_beer_amphora", "amphora", "an amphora of finished barley beer",
-			"A sealed amphora marked as containing finished barley beer.", "fired clay", "LContainer_Amphora_Congius",
-			$"{AntiquityFoodVesselTagPath} / Beverage Serving Vessel");
-		CreateItem("antiquity_food_fermenting_beer_amphora", "amphora", "a sealed beer-fermenting amphora", null,
-			"A sealed amphora with a fermenting grain mash inside it.", SizeCategory.Large, ItemQuality.Standard, 5200, 12M,
-			false, false, "fired clay",
-			[$"{AntiquityFoodRootTagPath} / Fermenting Foods", $"{AntiquityFoodVesselTagPath} / Fermenting Vessel"],
-			["Holdable", "Destroyable_Misc", "LContainer_Amphora_Congius"],
-			beerFinished is null ? null : "antiquity_food_finished_beer_amphora",
-			"$0 finishes fermenting into $1.", TimeSpan.FromDays(3), null);
+		CreateAntiquityFermentingFoodVessel("antiquity_food_fermenting_beer_amphora",
+			"antiquity_food_finished_beer_amphora", "a sealed beer-fermenting amphora",
+			"A sealed amphora with a fermenting grain mash inside it.",
+			"an amphora of finished barley beer", "A sealed amphora marked as containing finished barley beer.",
+			"$0 finishes fermenting into $1.", TimeSpan.FromDays(3));
+		CreateAntiquityFermentingFoodVessel("antiquity_food_fermenting_date_beer_amphora",
+			"antiquity_food_finished_date_beer_amphora", "a sealed date-beer-fermenting amphora",
+			"A sealed amphora with date-sweetened grain wort fermenting inside it.",
+			"an amphora of finished date beer", "A sealed amphora marked as containing finished date beer.",
+			"$0 finishes fermenting into $1.", TimeSpan.FromDays(3));
+		CreateAntiquityFermentingFoodVessel("antiquity_food_fermenting_red_wine_amphora",
+			"antiquity_food_finished_red_wine_amphora", "a sealed red-wine-fermenting amphora",
+			"A sealed amphora with pressed red fruit must fermenting inside it.",
+			"an amphora of finished red wine", "A sealed amphora marked as containing finished red wine.",
+			"$0 finishes fermenting into $1.", TimeSpan.FromDays(14));
+		CreateAntiquityFermentingFoodVessel("antiquity_food_fermenting_white_wine_amphora",
+			"antiquity_food_finished_white_wine_amphora", "a sealed white-wine-fermenting amphora",
+			"A sealed amphora with pale fruit must fermenting inside it.",
+			"an amphora of finished white wine", "A sealed amphora marked as containing finished white wine.",
+			"$0 finishes fermenting into $1.", TimeSpan.FromDays(14));
+		CreateAntiquityFermentingFoodVessel("antiquity_food_fermenting_kumis_amphora",
+			"antiquity_food_finished_kumis_amphora", "a sealed kumis-fermenting amphora",
+			"A sealed amphora with milk fermenting into tart kumis inside it.",
+			"an amphora of finished kumis", "A sealed amphora marked as containing finished kumis.",
+			"$0 finishes fermenting into $1.", TimeSpan.FromDays(2));
+		CreateAntiquityFermentingFoodVessel("antiquity_food_fermenting_garum_amphora",
+			"antiquity_food_finished_garum_amphora", "a sealed fish-sauce-fermenting amphora",
+			"A sealed amphora packed with salted fish fermenting into sauce.",
+			"an amphora of finished garum sauce", "A sealed amphora marked as containing finished garum sauce.",
+			"$0 finishes fermenting into $1.", TimeSpan.FromDays(10));
+		CreateAntiquityFermentingFoodVessel("antiquity_food_aging_spiced_wine_amphora",
+			"antiquity_food_finished_spiced_wine_amphora", "a sealed spiced-wine-aging amphora",
+			"A sealed amphora where wine, honey and spice are settling together.",
+			"an amphora of aged spiced wine", "A sealed amphora marked as containing aged spiced wine.",
+			"$0 finishes steeping into $1.", TimeSpan.FromDays(2));
+		CreateAntiquityFermentingFoodVessel("antiquity_food_aging_spiced_beer_amphora",
+			"antiquity_food_finished_spiced_beer_amphora", "a sealed spiced-beer-aging amphora",
+			"A sealed amphora where beer, honey and spice are settling together.",
+			"an amphora of aged spiced beer", "A sealed amphora marked as containing aged spiced beer.",
+			"$0 finishes steeping into $1.", TimeSpan.FromDays(2));
+		CreateAntiquityFermentingFoodVessel("antiquity_food_aging_spiced_kumis_amphora",
+			"antiquity_food_finished_spiced_kumis_amphora", "a sealed spiced-kumis-aging amphora",
+			"A sealed amphora where kumis, honey and spice are settling together.",
+			"an amphora of aged spiced kumis", "A sealed amphora marked as containing aged spiced kumis.",
+			"$0 finishes steeping into $1.", TimeSpan.FromDays(2));
 
 		foreach (var culture in AntiquityFoodCultures)
 		{
@@ -401,6 +436,19 @@ public partial class ItemSeeder
 	{
 		return CreateItem(stableReference, noun, sdesc, null, fdesc, SizeCategory.Large, ItemQuality.Standard, 5000, 10M,
 			false, false, material, vesselTags, ["Holdable", "Destroyable_Misc", liquidComponent], null, null, null, null);
+	}
+
+	private GameItemProto? CreateAntiquityFermentingFoodVessel(string activeStableReference,
+		string finishedStableReference, string activeSdesc, string activeFdesc, string finishedSdesc, string finishedFdesc,
+		string morphEmote, TimeSpan morphTimer)
+	{
+		var finished = CreateAntiquityFoodVessel(finishedStableReference, "amphora", finishedSdesc, finishedFdesc,
+			"fired clay", "LContainer_Amphora_Congius", $"{AntiquityFoodVesselTagPath} / Beverage Serving Vessel");
+		return CreateItem(activeStableReference, "amphora", activeSdesc, null, activeFdesc, SizeCategory.Large,
+			ItemQuality.Standard, 5200, 12M, false, false, "fired clay",
+			[$"{AntiquityFoodRootTagPath} / Fermenting Foods", $"{AntiquityFoodVesselTagPath} / Fermenting Vessel"],
+			["Holdable", "Destroyable_Misc", "LContainer_Amphora_Congius"],
+			finished is null ? null : finishedStableReference, morphEmote, morphTimer, null);
 	}
 
 	private GameItemProto? CreateAntiquityPreparedFoodItem(string stableSuffix, string noun, string sdesc, string fdesc,

--- a/DatabaseSeeder/Seeders/ItemSeeder.Rework.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Rework.cs
@@ -182,6 +182,7 @@ namespace DatabaseSeeder.Seeders
                 SeedAntiquityDoorsAndLocks();
                 SeedAntiquityHouseholdFurniture();
                 SeedAntiquityWeaponsShieldsAccessories();
+                SeedAntiquityApiaryItems();
                 SeedAntiquityFoodAndBeverageItems();
             }
 

--- a/DatabaseSeeder/Seeders/ItemSeederCrafting.Antiquity.cs
+++ b/DatabaseSeeder/Seeders/ItemSeederCrafting.Antiquity.cs
@@ -582,6 +582,26 @@ public partial class ItemSeeder
         }
 
         AddAntiquityLeatherCraft(
+            "break down raw hides into tanning stock",
+            "break raw hide items into animal skin commodity stock",
+            "breaking down raw hides",
+            "raw hides being cut into tanning stock",
+            1,
+            Difficulty.Easy,
+            [
+                (25, "$0 spread|spreads $i1 across $t1 and inspect|inspects the hide edges.", "$0 spread|spreads $i1 across $t1, but miss|misses torn and fouled edges."),
+                (35, "$0 scrape|scrapes loose flesh and fat away with $t2.", "$0 scrape|scrapes with $t2, but leave|leaves ragged patches in the hide."),
+                (25, "$0 cut|cuts the hide into workable animal-skin stock.", "$0 cut|cuts unevenly and salvage|salvages only $f1.")
+            ],
+            ["Tag - 1x an item with the Raw Hide tag"],
+            [
+                "TagTool - InRoom - an item with the Tanning Beam tag",
+                "TagTool - Held - an item with the Hide Scraper tag"
+            ],
+            ["CommodityProduct - 1 kilogram 600 grams of animal skin commodity"],
+            ["CommodityProduct - 400 grams of animal skin commodity"]);
+
+        AddAntiquityLeatherCraft(
             "scrape and dehair animal hides",
             "scrape and dehair raw animal hides into prepared hide stock",
             "scraping and dehairing animal hides",

--- a/DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityAgriculture.cs
+++ b/DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityAgriculture.cs
@@ -1,0 +1,152 @@
+#nullable enable
+
+using MudSharp.RPG.Checks;
+
+namespace DatabaseSeeder.Seeders;
+
+public partial class ItemSeeder
+{
+	private const string AncientAgriculturalProcessingKnowledge = "Ancient Agricultural Processing";
+
+	private void SeedAntiquityAgriculturalProcessingCrafts()
+	{
+		if (!ShouldSeedAntiquityCrafts())
+		{
+			return;
+		}
+
+		AddAntiquityCraft(
+			"select antiquity seed stock",
+			"Farming",
+			"select viable seed or planting stock from harvested crop commodity",
+			"selecting seed stock",
+			"a seed selection task",
+			AncientAgriculturalProcessingKnowledge,
+			"Farming",
+			10,
+			Difficulty.Easy,
+			SimpleFoodPhases("$0 sort|sorts through $i1, discarding damaged material and setting aside viable seed stock.",
+				"$0 finish|finishes selecting $p1 from the harvested crop."),
+			["CommodityTag - 5 kilograms of a material tagged as Agriculture Seedable; tag Seeded Yield"],
+			["TagTool - Held - an item with the Winnowing Basket tag"],
+			["ScrapInput - 25.00% by weight of 5 kilograms of a material tagged as Agriculture Seedable ($i1); tag Seeds"],
+			["ScrapInput - 5.00% by weight of 5 kilograms of a material tagged as Agriculture Seedable ($i1); tag Seeds"],
+			knowledgeSubtype: "Farming",
+			knowledgeDescription: "Ancient crop selection, seed saving, and farm-stock processing.",
+			knowledgeLongDescription: "This knowledge covers selecting viable seed stock and processing common ancient agricultural outputs into reusable craft commodities.");
+
+		AddAntiquityCraft(
+			"strain fresh milk into amphora",
+			"Food Processing",
+			"strain fresh herd milk into a serving amphora",
+			"straining fresh milk",
+			"a fresh milk straining task",
+			AncientAgriculturalProcessingKnowledge,
+			"Cooking",
+			10,
+			Difficulty.Easy,
+			SimpleFoodPhases("$0 strain|strains $i1 through $t1, keeping curd and hair out of the milk.",
+				"$0 pour|pours the strained milk into $p1."),
+			["Commodity - 3 kilograms of milk; piletag Raw Milk"],
+			["TagTool - Held - an item with the Honey Strainer tag"],
+			[$"LiquidProduct - 1x {_items["antiquity_food_serving_amphora"].ShortDescription} (#{_items["antiquity_food_serving_amphora"].Id}) filled with 3 litres of milk"],
+			[],
+			knowledgeSubtype: "Food Processing");
+
+		AddAntiquityCraft(
+			"heap herd manure compost",
+			"Farming",
+			"turn raw herd manure and crop refuse into compost",
+			"heaping herd manure compost",
+			"a manure composting task",
+			AncientAgriculturalProcessingKnowledge,
+			"Farming",
+			10,
+			Difficulty.Easy,
+			SimpleFoodPhases("$0 fork|forks $i1 and $i2 together into a hot compost heap.",
+				"$0 turn|turns the heap and sets aside usable compost."),
+			[
+				"Commodity - 3 kilograms of feces; piletag Manure Commodity",
+				"Commodity - 2 kilograms of vegetation; piletag Seeded Yield"
+			],
+			["TagTool - Held - an item with the Pitchfork tag"],
+			["CommodityProduct - 3 kilograms 500 grams of compost commodity; tag Manure Commodity"],
+			["CommodityProduct - 1 kilogram of compost commodity; tag Manure Commodity"],
+			knowledgeSubtype: "Farming");
+
+		AddAntiquityCraft(
+			"ferment indigo dye cakes",
+			"Dyeing",
+			"ferment and dry indigo leaves into dye cakes",
+			"fermenting indigo dye cakes",
+			"an indigo dye fermentation task",
+			AncientAgriculturalProcessingKnowledge,
+			"Dyeing",
+			20,
+			Difficulty.Normal,
+			SimpleFoodPhases("$0 steep|steeps $i1 in $t1 and work|works the vat until the blue settles.",
+				"$0 dry|dries the residue into compact dye cakes."),
+			["Commodity - 2 kilograms of indigo crop; piletag Seeded Yield"],
+			[
+				"TagTool - InRoom - an item with the Fermentation Amphora tag",
+				"TagTool - Held - an item with the Honey Strainer tag"
+			],
+			["CommodityProduct - 500 grams of indigo dye cake commodity; tag Textile Dye Stock"],
+			["CommodityProduct - 100 grams of indigo dye cake commodity; tag Textile Dye Stock"],
+			knowledgeSubtype: "Dyeing");
+
+		AddAntiquityCraft(
+			"strip pomegranate rind dye stock",
+			"Dyeing",
+			"strip pomegranate rind for dye stock",
+			"stripping pomegranate rind",
+			"a pomegranate rind stripping task",
+			AncientAgriculturalProcessingKnowledge,
+			"Dyeing",
+			10,
+			Difficulty.Easy,
+			SimpleFoodPhases("$0 score|scores and peel|peels $i1 with $t1.",
+				"$0 dry|dries and bundles the rind for dyeing."),
+			["Commodity - 2 kilograms of pomegranate; piletag Seeded Yield"],
+			["TagTool - Held - an item with the Cooking Knife tag"],
+			["CommodityProduct - 350 grams of pomegranate rind commodity; tag Textile Dye Stock"],
+			["CommodityProduct - 80 grams of pomegranate rind commodity; tag Textile Dye Stock"],
+			knowledgeSubtype: "Dyeing");
+
+		AddAntiquityCraft(
+			"separate walnut hull dye stock",
+			"Dyeing",
+			"separate walnut hulls for brown dye stock",
+			"separating walnut hulls",
+			"a walnut hull preparation task",
+			AncientAgriculturalProcessingKnowledge,
+			"Dyeing",
+			10,
+			Difficulty.Easy,
+			SimpleFoodPhases("$0 crack|cracks and bruise|bruises $i1 with $t1.",
+				"$0 pick|picks out the staining hulls and sets them aside."),
+			["Commodity - 2 kilograms of walnut nut; piletag Seeded Yield"],
+			["TagTool - Held - an item with the Mortar and Pestle tag"],
+			["CommodityProduct - 300 grams of walnut hull commodity; tag Textile Dye Stock"],
+			["CommodityProduct - 70 grams of walnut hull commodity; tag Textile Dye Stock"],
+			knowledgeSubtype: "Dyeing");
+
+		AddAntiquityCraft(
+			"dry saffron threads",
+			"Food Processing",
+			"dry saffron crocus stigmas into saffron",
+			"drying saffron threads",
+			"a saffron drying task",
+			AncientAgriculturalProcessingKnowledge,
+			"Cooking",
+			20,
+			Difficulty.Hard,
+			SimpleFoodPhases("$0 pluck|plucks the tiny stigmas from $i1.",
+				"$0 dry|dries the threads slowly into saffron."),
+			["Commodity - 500 grams of saffron crocus; piletag Seeded Yield"],
+			["TagTool - InRoom - an item with the Drying Rack tag"],
+			["CommodityProduct - 45 grams of saffron commodity; tag Textile Dye Stock"],
+			["CommodityProduct - 8 grams of saffron commodity; tag Textile Dye Stock"],
+			knowledgeSubtype: "Food Processing");
+	}
+}

--- a/DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityApiary.cs
+++ b/DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityApiary.cs
@@ -1,0 +1,243 @@
+using MudSharp.RPG.Checks;
+using System.Linq;
+
+namespace DatabaseSeeder.Seeders;
+
+public partial class ItemSeeder
+{
+	private const string AncientApicultureKnowledge = "Ancient Apiculture";
+
+	private static readonly string[] AntiquityApiaryStableReferences =
+	[
+		"antiquity_wicker_beehive",
+		"antiquity_clay_tube_hive",
+		"antiquity_wooden_hive_stand",
+		"antiquity_bee_smoke_pot",
+		"antiquity_honey_knife",
+		"antiquity_honey_press",
+		"antiquity_honey_strainer"
+	];
+
+	private void SeedAntiquityApiaryCrafts()
+	{
+		if (!ShouldSeedAntiquityCrafts() ||
+		    AntiquityApiaryStableReferences.Any(x => !TryLookupReworkItem(x, out _)))
+		{
+			return;
+		}
+
+		AddAntiquityCraft(
+			"weave wicker beehive",
+			"Basketry",
+			"weave and seal a wicker beehive",
+			"weaving a wicker beehive",
+			"a wicker hive under construction",
+			AncientApicultureKnowledge,
+			"Basketry",
+			15,
+			Difficulty.Normal,
+			[
+				(35, "$0 soak|soaks and flex|flexes the splints from $i1, sorting them by thickness.", "$0 kink|kinks too many splints while preparing them."),
+				(45, "$0 weave|weaves the hive body upward in a tight coil, packing each course with $t2.", "$0 weave|weaves the hive body unevenly and leaves gaps in the coil."),
+				(35, "$0 bind|binds the lip with $i2 and smear|smears $i3 into the seams.", "$0 bind|binds the lip poorly and the hive will not hold its shape."),
+				(25, "$0 set|sets aside $p1 after checking the entrance and sealed crown.", "$0 set|sets aside only $f1 after the hive body collapses.")
+			],
+			[
+				CommodityInput(1800.0, "willow", "Basketry Splint"),
+				CommodityInput(150.0, "linen", "Spun Yarn"),
+				CommodityInput(120.0, "pitch", "Prepared Pitch")
+			],
+			[
+				"TagTool - Held - an item with the Basket Knife tag",
+				"TagTool - Held - an item with the Packing Bone tag"
+			],
+			[StableSimpleProduct("antiquity_wicker_beehive")]);
+
+		AddAntiquityCraft(
+			"finish clay tube beehive",
+			"Pottery",
+			"line and finish a clay tube hive",
+			"finishing a clay tube hive",
+			"a clay tube hive being finished",
+			AncientApicultureKnowledge,
+			"Pottery",
+			20,
+			Difficulty.Normal,
+			[
+				(30, "$0 checks $i1 for cracks and true|trues its mouth with $t2.", "$0 find|finds the fired body warped and hard to true."),
+				(40, "$0 turn|turns $i1 on $t1, smoothing the inner mouth and capping surfaces.", "$0 scrape|scrapes unevenly and chips the hive mouth."),
+				(35, "$0 warm|warms and smear|smears $i2 along the seams and plug line.", "$0 smear|smears the pitch too thinly to seal the hive."),
+				(25, "$0 set|sets aside $p1 as a sealed clay hive.", "$0 set|sets aside only $f1 after the hive cracks.")
+			],
+			[
+				CommodityInput(4500.0, "fired clay", "Bisque Vessel Blank"),
+				CommodityInput(180.0, "pitch", "Prepared Pitch")
+			],
+			[
+				"TagTool - InRoom - an item with the Potter's Wheel tag",
+				"TagTool - Held - an item with the Potter's Rib tag",
+				"TagTool - InRoom - an item with the Lit Kiln tag"
+			],
+			[StableSimpleProduct("antiquity_clay_tube_hive")]);
+
+		AddAntiquityCraft(
+			"build wooden hive stand",
+			"Carpentry",
+			"build a raised wooden hive stand",
+			"building a hive stand",
+			"a wooden hive stand under construction",
+			AncientApicultureKnowledge,
+			"Carpentry",
+			15,
+			Difficulty.Easy,
+			[
+				(35, "$0 mark|marks and saw|saws the stand parts from $i1.", "$0 saw|saws the stand parts unevenly."),
+				(40, "$0 chisel|chisels notches and test|tests the fit with $t2.", "$0 chisel|chisels the notches too loose."),
+				(35, "$0 bind|binds the frame with $i2 and clamp|clamps it square.", "$0 bind|binds the frame out of square."),
+				(25, "$0 set|sets aside $p1 after checking that it sits level.", "$0 set|sets aside only $f1 after the stand twists apart.")
+			],
+			[
+				CommodityInput(8000.0, "oak", "Furniture Timber Stock"),
+				CommodityInput(350.0, "bronze", "Hoop Stock")
+			],
+			[
+				"TagTool - Held - an item with the Hand Saw tag",
+				"TagTool - Held - an item with the Wood Chisel tag",
+				"TagTool - InRoom - an item with the Wood Clamp tag"
+			],
+			[StableSimpleProduct("antiquity_wooden_hive_stand")]);
+
+		AddAntiquityCraft(
+			"make bee smoke pot",
+			"Pottery",
+			"make a clay smoke pot for tending hives",
+			"making a bee smoke pot",
+			"a clay smoke pot under construction",
+			AncientApicultureKnowledge,
+			"Pottery",
+			15,
+			Difficulty.Easy,
+			[
+				(30, "$0 shape|shapes a small lidded pot from $i1.", "$0 shape|shapes the pot too thinly."),
+				(35, "$0 draw|draws out a narrow spout and smooth|smooths it with $t2.", "$0 pinch|pinches the spout closed by mistake."),
+				(45, "$0 fire|fires the smoke pot in $t3.", "$0 fire|fires the pot too quickly and it cracks."),
+				(20, "$0 set|sets aside $p1.", "$0 set|sets aside only $f1.")
+			],
+			[CommodityInput(850.0, "fired clay", "Pottery Clay Body")],
+			[
+				"TagTool - InRoom - an item with the Potter's Wheel tag",
+				"TagTool - Held - an item with the Potter's Rib tag",
+				"TagTool - InRoom - an item with the Lit Kiln tag"
+			],
+			[StableSimpleProduct("antiquity_bee_smoke_pot")]);
+
+		AddAntiquityCraft(
+			"forge honey knife",
+			"Blacksmithing",
+			"forge a broad honey knife",
+			"forging a honey knife",
+			"a honey knife being forged",
+			AncientApicultureKnowledge,
+			"Blacksmithing",
+			20,
+			Difficulty.Normal,
+			[
+				(35, "$0 heat|heats $i1 in $t3 and grip|grips it with $t4.", "$0 heat|heats $i1 unevenly."),
+				(45, "$0 hammer|hammers the blank wide and thin on $t2.", "$0 hammer|hammers a ragged, warped blade."),
+				(35, "$0 fit|fits the handle stock from $i2 and bind|binds it tight.", "$0 fit|fits the handle poorly."),
+				(25, "$0 set|sets aside $p1 after checking the edge.", "$0 set|sets aside only $f1 after the knife fails.")
+			],
+			[
+				CommodityInput(250.0, "bronze", "Tool Blank Stock"),
+				CommodityInput(90.0, "oak", "Tool Blank Stock")
+			],
+			[
+				"TagTool - Held - an item with the Hammer tag",
+				"TagTool - InRoom - an item with the Anvil tag",
+				"TagTool - InRoom - an item with the Hot Fire tag",
+				"TagTool - Held - an item with the Forge Tongs tag"
+			],
+			[StableSimpleProduct("antiquity_honey_knife")]);
+
+		AddAntiquityCraft(
+			"build honey press",
+			"Carpentry",
+			"build a small wooden honey press",
+			"building a honey press",
+			"a honey press under construction",
+			AncientApicultureKnowledge,
+			"Carpentry",
+			25,
+			Difficulty.Normal,
+			[
+				(45, "$0 saw|saws frame parts from $i1 and basket slats from $i2.", "$0 saw|saws the press parts unevenly."),
+				(45, "$0 chisel|chisels the screw channel and pressure plate.", "$0 chisel|chisels the screw channel off centre."),
+				(40, "$0 hoop|hoops the basket with $i3 and clamp|clamps the frame square.", "$0 hoop|hoops the basket too loosely."),
+				(30, "$0 turn|turns the screw and set|sets aside $p1.", "$0 turn|turns the screw, but the press binds and fails.")
+			],
+			[
+				CommodityInput(12000.0, "oak", "Furniture Timber Stock"),
+				CommodityInput(2500.0, "willow", "Basketry Splint"),
+				CommodityInput(700.0, "bronze", "Hoop Stock")
+			],
+			[
+				"TagTool - Held - an item with the Hand Saw tag",
+				"TagTool - Held - an item with the Wood Chisel tag",
+				"TagTool - InRoom - an item with the Wood Clamp tag"
+			],
+			[StableSimpleProduct("antiquity_honey_press")]);
+
+		AddAntiquityCraft(
+			"stitch honey strainer",
+			"Tailoring",
+			"stitch a linen strainer for honey",
+			"stitching a honey strainer",
+			"a honey strainer being stitched",
+			AncientApicultureKnowledge,
+			"Tailoring",
+			10,
+			Difficulty.Easy,
+			[
+				(25, "$0 cut|cuts a clean square from $i1.", "$0 cut|cuts the cloth too small."),
+				(30, "$0 stitch|stitches the cloth around the hoop stock from $i2.", "$0 stitch|stitches the cloth unevenly."),
+				(20, "$0 pull|pulls the strainer taut and set|sets aside $p1.", "$0 pull|pulls the strainer out of shape.")
+			],
+			[
+				CommodityInput(120.0, "linen", "Garment Cloth", colour: true, fineColour: true),
+				CommodityInput(80.0, "willow", "Hoop Stock")
+			],
+			[
+				"TagTool - Held - an item with the Sewing Needle tag",
+				"TagTool - Held - an item with the Shears tag"
+			],
+			[StableSimpleProduct("antiquity_honey_strainer")]);
+
+		AddAntiquityCraft(
+			"press raw honeycomb",
+			"Farming",
+			"press raw honeycomb into honey and beeswax",
+			"pressing raw honeycomb",
+			"a batch of honeycomb being pressed",
+			AncientApicultureKnowledge,
+			"Farming",
+			15,
+			Difficulty.Easy,
+			[
+				(30, "$0 cut|cuts the raw comb with $t1 and load|loads it into $t2.", "$0 cut|cuts the comb raggedly and spills much of it."),
+				(45, "$0 press|presses the comb, letting honey run through $t3.", "$0 press|presses too hard and fouls the strainer."),
+				(35, "$0 scrape|scrapes waxy comb residue aside from the pressed honey.", "$0 scrape|scrapes wax and honey into a messy slurry."),
+				(25, "$0 set|sets aside $p1 and $p2.", "$0 set|sets aside only $f1 after the batch is spoiled.")
+			],
+			["Commodity - 2 kilograms of honeycomb; piletag Raw Honeycomb"],
+			[
+				"TagTool - Held - an item with the Honey Knife tag",
+				"TagTool - InRoom - an item with the Honey Press tag",
+				"TagTool - Held - an item with the Honey Strainer tag"
+			],
+			[
+				"CommodityProduct - 1 kilogram 200 grams of honey commodity; tag Pressed Honey",
+				"CommodityProduct - 350 grams of beeswax commodity; tag Rendered Beeswax"
+			],
+			["CommodityProduct - 200 grams of honeycomb commodity; tag Raw Honeycomb"]);
+	}
+}

--- a/DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityFood.cs
+++ b/DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityFood.cs
@@ -367,43 +367,33 @@ public partial class ItemSeeder
 				"$0 set|sets aside $p1 to ferment."),
 			["CommodityTag - 2 kilograms of a material tagged as Grain Crop; piletag Wort Commodity"],
 			["TagTool - Held - an item with the Fermentation Amphora tag"],
-			[$"SimpleProduct - 1x {_items["antiquity_food_fermenting_beer_amphora"].ShortDescription} (#{_items["antiquity_food_fermenting_beer_amphora"].Id})"],
+			[StableSimpleProduct("antiquity_food_fermenting_beer_amphora")],
 			[]);
 
-		AddCraft("fill amphora with barley beer", "Brewing", "fill a serving amphora with barley beer",
-			"filling an amphora with barley beer", "a beer filling task", "HasBrewing", null, null, null, brewing,
-			Difficulty.Easy, Outcome.MinorFail, 5, 1, false,
-			SimpleFoodPhases("$0 strain|strains beer into $p1.",
-				"$0 seal|seals the beer amphora."),
-			["CommodityTag - 2 kilograms of a material tagged as Grain Crop; piletag Wort Commodity"],
-			[],
-			[$"LiquidProduct - 1x {_items["antiquity_food_serving_amphora"].ShortDescription} (#{_items["antiquity_food_serving_amphora"].Id}) filled with 3 litres of barley beer"],
-			[]);
-
-		AddCraft("fill amphora with date beer", "Brewing", "fill a serving amphora with date beer",
-			"filling an amphora with date beer", "a date beer filling task", "HasBrewing", null, null, null, brewing,
-			Difficulty.Easy, Outcome.MinorFail, 5, 1, false,
-			SimpleFoodPhases("$0 strain|strains date beer into $p1.",
-				"$0 seal|seals the date beer amphora."),
+		AddCraft("fill date beer fermenting amphora", "Brewing", "fill a date beer fermenting amphora",
+			"filling a date beer fermenting amphora", "a date beer fermentation task", "HasBrewing", null, null, null,
+			brewing, Difficulty.Normal, Outcome.MinorFail, 5, 2, false,
+			SimpleFoodPhases("$0 pour|pours $i1 and $i2 into $t1 and seal|seals it.",
+				"$0 set|sets aside $p1 to ferment."),
 			[
 				"CommodityTag - 1 kilogram of a material tagged as Grain Crop; piletag Wort Commodity",
 				"Commodity - 500 grams of date"
 			],
-			[],
-			[$"LiquidProduct - 1x {_items["antiquity_food_serving_amphora"].ShortDescription} (#{_items["antiquity_food_serving_amphora"].Id}) filled with 3 litres of date beer"],
+			["TagTool - Held - an item with the Fermentation Amphora tag"],
+			[StableSimpleProduct("antiquity_food_fermenting_date_beer_amphora")],
 			[]);
 
 		AddCraft("fill amphora with fish sauce", "Food Processing", "fill an amphora with fermented fish sauce",
 			"filling an amphora with fish sauce", "a fish sauce filling task", "HasCooking", null, null, null, cooking,
 			Difficulty.Normal, Outcome.MinorFail, 5, 2, false,
 			SimpleFoodPhases("$0 pack|packs fish and salt down for fermentation.",
-				"$0 strain|strains the sauce into $p1."),
+				"$0 seal|seals the fish sauce in $p1 to ferment."),
 			[
 				"CommodityTag - 1 kilogram of a material tagged as Meat; piletag Raw Meat Commodity",
 				"Commodity - 300 grams of salt"
 			],
-			[],
-			[$"LiquidProduct - 1x {_items["antiquity_food_serving_amphora"].ShortDescription} (#{_items["antiquity_food_serving_amphora"].Id}) filled with 3 litres of garum sauce"],
+			["TagTool - Held - an item with the Fermentation Amphora tag"],
+			[StableSimpleProduct("antiquity_food_fermenting_garum_amphora")],
 			[]);
 	}
 
@@ -583,28 +573,33 @@ public partial class ItemSeeder
 			difficulty: Difficulty.Hard);
 
 		AddCultureFoodCraft(culture, $"fill {culture.Display.ToLowerInvariant()} beverage amphora", "fill a staple beverage amphora",
-			"filling a beverage amphora", "a beverage filling task",
+			"filling a beverage amphora", "a beverage fermentation task",
 			[
 				CultureBeverageStockInput(culture, 1200.0, 1000.0)
 			],
-			[],
-			$"LiquidProduct - 1x {_items["antiquity_food_serving_amphora"].ShortDescription} (#{_items["antiquity_food_serving_amphora"].Id}) filled with 3 litres of {culture.BeverageLiquid}",
-			brewing);
+			["TagTool - Held - an item with the Fermentation Amphora tag"],
+			StableSimpleProduct(CultureBeverageFermentingStableReference(culture)),
+			brewing,
+			phases: SimpleFoodPhases("$0 pour|pours the beverage stock into $t1 and seal|seals it.",
+				"$0 set|sets aside $p1 to ferment."));
 
 		AddCultureFoodCraft(culture, $"fill {culture.Display.ToLowerInvariant()} spiced beverage amphora",
 			"fill a luxury spiced beverage amphora", "filling a spiced beverage amphora",
-			"a spiced beverage filling task",
+			"a spiced beverage aging task",
 			[
 				CultureBeverageStockInput(culture, 1200.0, 1000.0),
 				"Commodity - 250 grams of honey",
 				"Commodity - 15 grams of coriander"
 			],
-			["TagTool - Held - an item with the Mortar and Pestle tag"],
-			$"LiquidProduct - 1x {_items["antiquity_food_serving_amphora"].ShortDescription} (#{_items["antiquity_food_serving_amphora"].Id}) filled with 3 litres of {CultureLuxuryBeverageLiquid(culture)}",
+			[
+				"TagTool - Held - an item with the Mortar and Pestle tag",
+				"TagTool - Held - an item with the Fermentation Amphora tag"
+			],
+			StableSimpleProduct(CultureLuxuryBeverageAgingStableReference(culture)),
 			brewing,
 			phases: LuxuryFoodPhases("$0 bruise|bruises $i3 in $t1 and stir|stirs it with honey.",
 				"$0 blend|blends the sweet spice into the beverage stock.",
-				"$0 strain|strains the luxury drink into $p1 and seal|seals it."),
+				"$0 strain|strains the luxury drink into $t2 and set|sets aside $p1 to age."),
 			difficulty: Difficulty.Hard);
 	}
 
@@ -655,6 +650,41 @@ public partial class ItemSeeder
 		}
 
 		return "spiced beer";
+	}
+
+	private static string CultureBeverageFermentingStableReference(AntiquityFoodCultureSpec culture)
+	{
+		if (culture.BeverageLiquid.Equals("red wine", StringComparison.OrdinalIgnoreCase))
+		{
+			return "antiquity_food_fermenting_red_wine_amphora";
+		}
+
+		if (culture.BeverageLiquid.Equals("white wine", StringComparison.OrdinalIgnoreCase))
+		{
+			return "antiquity_food_fermenting_white_wine_amphora";
+		}
+
+		if (culture.BeverageLiquid.Contains("date beer", StringComparison.OrdinalIgnoreCase))
+		{
+			return "antiquity_food_fermenting_date_beer_amphora";
+		}
+
+		if (culture.BeverageLiquid.Contains("kumis", StringComparison.OrdinalIgnoreCase))
+		{
+			return "antiquity_food_fermenting_kumis_amphora";
+		}
+
+		return "antiquity_food_fermenting_beer_amphora";
+	}
+
+	private static string CultureLuxuryBeverageAgingStableReference(AntiquityFoodCultureSpec culture)
+	{
+		return CultureLuxuryBeverageLiquid(culture) switch
+		{
+			"spiced wine" => "antiquity_food_aging_spiced_wine_amphora",
+			"spiced kumis" => "antiquity_food_aging_spiced_kumis_amphora",
+			_ => "antiquity_food_aging_spiced_beer_amphora"
+		};
 	}
 
 	private string CookedProduct(string stableReference, string ingredientOptions)

--- a/DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityFood.cs
+++ b/DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityFood.cs
@@ -16,10 +16,66 @@ public partial class ItemSeeder
 			return;
 		}
 
+		SeedAntiquityFoodVesselCrafts();
 		SeedAntiquityFoodProcessingCrafts();
 		SeedAntiquityButcheryFoodCrafts();
 		SeedAntiquityBeverageCrafts();
 		SeedAntiquityCultureFoodCrafts();
+	}
+
+	private void SeedAntiquityFoodVesselCrafts()
+	{
+		AddAntiquityCraft(
+			"finish clay serving amphora",
+			"Pottery",
+			"finish a sealed clay serving amphora",
+			"finishing a clay serving amphora",
+			"a clay serving amphora being finished",
+			AncientCeramicVesselmakingKnowledge,
+			"Ceramics",
+			20,
+			Difficulty.Normal,
+			SimpleFoodPhases("$0 turn|turns $i1 on $t1 and smooth|smooths the shoulders with $t2.",
+				"$0 fire|fires and seal|seals $p1 in $t3 with prepared pitch."),
+			[
+				CommodityInput(900.0, "fired clay", "Bisque Vessel Blank"),
+				CommodityInput(80.0, "pitch", "Prepared Pitch")
+			],
+			[
+				"TagTool - InRoom - an item with the Potter's Wheel tag",
+				"TagTool - Held - an item with the Potter's Rib tag",
+				"TagTool - InRoom - an item with the Lit Kiln tag"
+			],
+			[StableSimpleProduct("antiquity_food_serving_amphora")],
+			knowledgeSubtype: "Ceramics",
+			knowledgeDescription: "Ancient ceramic vesselmaking for domestic and food-storage vessels.",
+			knowledgeLongDescription: "This knowledge covers shaping, firing, lining, and finishing ancient ceramic vessels used for household and food-production workflows.");
+
+		AddAntiquityCraft(
+			"line pitch fermenting amphora",
+			"Pottery",
+			"finish a pitch-lined fermenting amphora",
+			"lining a fermenting amphora",
+			"a fermenting amphora being lined with pitch",
+			AncientCeramicVesselmakingKnowledge,
+			"Ceramics",
+			25,
+			Difficulty.Normal,
+			SimpleFoodPhases("$0 shape|shapes the mouth and belly of $i1 on $t1, smoothing it with $t2.",
+				"$0 warm|warms prepared pitch and line|lines $p1 before setting it in $t3."),
+			[
+				CommodityInput(900.0, "fired clay", "Bisque Vessel Blank"),
+				CommodityInput(240.0, "pitch", "Prepared Pitch")
+			],
+			[
+				"TagTool - InRoom - an item with the Potter's Wheel tag",
+				"TagTool - Held - an item with the Potter's Rib tag",
+				"TagTool - InRoom - an item with the Lit Kiln tag"
+			],
+			[StableSimpleProduct("antiquity_food_fermenting_amphora")],
+			knowledgeSubtype: "Ceramics",
+			knowledgeDescription: "Ancient ceramic vesselmaking for domestic and food-storage vessels.",
+			knowledgeLongDescription: "This knowledge covers shaping, firing, lining, and finishing ancient ceramic vessels used for household and food-production workflows.");
 	}
 
 	private void SeedAntiquityFoodProcessingCrafts()
@@ -576,6 +632,11 @@ public partial class ItemSeeder
 
 	private string CultureBeverageStockInput(AntiquityFoodCultureSpec culture, double wineFruitGrams, double wortGrams)
 	{
+		if (culture.BeverageLiquid.Contains("kumis", StringComparison.OrdinalIgnoreCase))
+		{
+			return "LiquidUse - 3 litres of milk";
+		}
+
 		return culture.BeverageLiquid.Contains("wine", StringComparison.OrdinalIgnoreCase)
 			? $"Commodity - {FormatCommodityAmount(wineFruitGrams)} of {culture.SweetMaterial}; piletag Fruit Must Commodity"
 			: $"CommodityTag - {FormatCommodityAmount(wortGrams)} of a material tagged as Grain Crop; piletag Wort Commodity";

--- a/DatabaseSeeder/Seeders/ItemSeederCrafting.cs
+++ b/DatabaseSeeder/Seeders/ItemSeederCrafting.cs
@@ -2225,6 +2225,7 @@ return ""You need at least {minimumTraitValue.Value.ToString(System.Globalizatio
 		SeedAntiquityLeatherContainerCrafts();
 		SeedAntiquityLeatherFurnishingCrafts();
 		SeedAntiquityApiaryCrafts();
+		SeedAntiquityAgriculturalProcessingCrafts();
 		SeedAntiquityFoodCrafts();
 	}
 

--- a/DatabaseSeeder/Seeders/ItemSeederCrafting.cs
+++ b/DatabaseSeeder/Seeders/ItemSeederCrafting.cs
@@ -2224,8 +2224,9 @@ return ""You need at least {minimumTraitValue.Value.ToString(System.Globalizatio
 		SeedAntiquityLeatherArmourCrafts();
 		SeedAntiquityLeatherContainerCrafts();
 		SeedAntiquityLeatherFurnishingCrafts();
+		SeedAntiquityApiaryCrafts();
 		SeedAntiquityFoodCrafts();
-    }
+	}
 
 	private void SeedCraftsLegacy()
 	{

--- a/DatabaseSeeder/Seeders/UsefulSeeder.Tags.cs
+++ b/DatabaseSeeder/Seeders/UsefulSeeder.Tags.cs
@@ -83,6 +83,11 @@ namespace DatabaseSeeder.Seeders
             AddTag(context, "Raw Honeycomb", "Apiary Product");
             AddTag(context, "Pressed Honey", "Apiary Product");
             AddTag(context, "Rendered Beeswax", "Apiary Product");
+            AddTag(context, "Pastoral Product", "Agriculture");
+            AddTag(context, "Raw Milk", "Pastoral Product");
+            AddTag(context, "Raw Wool", "Pastoral Product");
+            AddTag(context, "Egg Product", "Pastoral Product");
+            AddTag(context, "Manure Commodity", "Pastoral Product");
             AddTag(context, "Leather Commodity", "Material Functions");
             AddTag(context, "Prepared Hide", "Leather Commodity");
             AddTag(context, "Tanned Leather", "Leather Commodity");

--- a/DatabaseSeeder/Seeders/UsefulSeeder.Tags.cs
+++ b/DatabaseSeeder/Seeders/UsefulSeeder.Tags.cs
@@ -79,6 +79,10 @@ namespace DatabaseSeeder.Seeders
             AddTag(context, "Agriculture", "Material Functions");
             AddTag(context, "Seeds", "Agriculture");
             AddTag(context, "Seeded Yield", "Agriculture");
+            AddTag(context, "Apiary Product", "Agriculture");
+            AddTag(context, "Raw Honeycomb", "Apiary Product");
+            AddTag(context, "Pressed Honey", "Apiary Product");
+            AddTag(context, "Rendered Beeswax", "Apiary Product");
             AddTag(context, "Leather Commodity", "Material Functions");
             AddTag(context, "Prepared Hide", "Leather Commodity");
             AddTag(context, "Tanned Leather", "Leather Commodity");
@@ -795,6 +799,13 @@ namespace DatabaseSeeder.Seeders
             AddTag(context, "Yoke", "Agricultural Tools");
             AddTag(context, "Drover's Goad", "Agricultural Tools");
             AddTag(context, "Pruning Hook", "Agricultural Tools");
+            AddTag(context, "Beekeeping Tools", "Agricultural Tools");
+            AddTag(context, "Bee Hive", "Beekeeping Tools");
+            AddTag(context, "Hive Stand", "Beekeeping Tools");
+            AddTag(context, "Bee Smoke Pot", "Beekeeping Tools");
+            AddTag(context, "Honey Knife", "Beekeeping Tools");
+            AddTag(context, "Honey Press", "Beekeeping Tools");
+            AddTag(context, "Honey Strainer", "Beekeeping Tools");
 
             // Masonry
             AddTag(context, "Masonry Tools", "Construction Tools");

--- a/Design Documents/Agriculture/Agriculture_Builder_Workflows.md
+++ b/Design Documents/Agriculture/Agriculture_Builder_Workflows.md
@@ -6,9 +6,9 @@ Run `AgricultureSeeder` after core utility progs exist. It installs:
 - stock field profiles for arable fields, garden beds, orchards/groves, pasture, wet fields, rocky fields, saline coastal fields, and managed woodland
 - additional cultivated, marginal, natural, and unimproved field profiles for paddies, dryland fields, terraces, floodplains, old fallows, scrub, woodland clearings, marshes, saline edges, heavy clay, eroded slopes, and similar land-expansion starting points
 - specific annual crop and perennial orchard/vineyard/plantation definitions with seed requirements, commodity outputs, and concrete pollination metadata, including broad temperate, tropical, dryland, wetland, archaic, and regional crop examples
-- generic herd definitions
-- specific managed woodland definitions with commodity outputs
-- stock operations, including woodland yield multipliers, yield costs, and apiary install, tend, harvest, and removal operations
+- generic herd definitions with secondary product outputs for milk, wool, eggs, and manure, including horse herds for pastoral milk
+- specific managed woodland definitions with commodity outputs, including dye woodland products
+- stock operations, including woodland and herd yield multipliers, yield costs, and apiary install, tend, harvest, and removal operations
 - local project templates with agriculture completion actions, seed stock material requirements, apiary installation requirements, deliberately substantial labour requirements, and Farming-based supervision labour
 
 The stock package is idempotent. Reruns refresh stock-owned rows by stable names instead of duplicating them.
@@ -65,10 +65,12 @@ field crop set "Apples" pollination Strong 1 2
 field crop set "Apples" perennial true
 field crop set "Apples" cycle 220
 field herds set "Cattle Herd" npc cattle
+field herds set "Cattle Herd" output add 3500 milk tag Raw Milk
 field woodland set "Hazel Coppice" cycle 365
 field operation set "Sow Crop" delta Moisture -3
 field operation set "Sow Crop" project "Stock Agriculture: Sow Crop"
 field operation set "Coppice Woodland" woodlandyield 0.45 45
+field operation set "Collect Herd Products" herdyield 1.0 55
 field operation set "Install Apiary" allowed Crop on
 ```
 
@@ -169,11 +171,14 @@ Use herd operations to put abstract livestock onto a field. Once a field has abs
 field herd draw <herd> [count]
 field herd absorb <npc> <herd>
 field herd drive <herd> <direction> [count]
+field start "Collect Herd Products" <herd>
 ```
 
 Drawdown requires the herd definition to have an NPC template. Absorb is for turning live livestock back into abstract field stock after validation.
 
 Driving a herd moves abstract animals from the current field into an adjacent field through the named exit. Omit the count, or use `all`, to move the whole herd. The destination field must already exist, support pasture use, and be fallow or pasture. Herders can drive animals into unowned fields or fields they are authorised to use, which allows wild grazing grounds and semi-nomadic pastoral movement without making owned fields freely available.
+
+Herd definitions can also define per-head secondary commodity outputs. Stock herds use this to provide raw milk, wool, eggs, and manure; the horse herd is the stock pastoral milk source for kumis-facing cultures. Fed herds build secondary yield potential on the daily tick, and `Collect Herd Products` releases the configured commodities without changing the pasture use.
 
 ## Managed Woodland
 Managed woodland is a field use rather than a separate subsystem. Builders can represent:
@@ -187,14 +192,14 @@ Orchards, vineyards, nut groves, and plantation crops use the separate `Orchard`
 
 Use woodland definitions for growth cadence and operations for planting, coppicing, thinning, felling, and clearing.
 
-Stock woodland definitions also define commodity outputs. Woodland operations can release a fraction of the stand's products and consume part of the stand's current yield, so coppicing, thinning, felling, and clearing can all be tuned separately.
+Stock woodland definitions also define commodity outputs. Woodland operations can release a fraction of the stand's products and consume part of the stand's current yield, so coppicing, thinning, felling, and clearing can all be tuned separately. The stock dye woodland examples cover kermes grain, orchil lichen, and lac dye cake as managed woodland products.
 
 Crafts can use the `field` craft input when a craft should require a local field state rather than a loose commodity pile. This is useful for actions such as collecting firewood, cutting poles, tapping or gathering from a managed grove, or any craft that should require a particular crop, orchard, or woodland, minimum health, minimum yield, and optionally consume some of that yield.
 
 ## Seeds and Planting Stock
 Seed stock is modelled as commodity piles with the secondary `Seeds` tag. Seedable crop materials are tagged `Agriculture Seedable`, and stock sowing/planting projects require `commoditytag` material requirements that accept any commodity whose material has that tag and whose pile tag is `Seeds`.
 
-Stock harvests also produce a small seed-tagged commodity output, and they tag the main yield as `Seeded Yield`. The generic `select seed stock` craft takes `Seeded Yield` agricultural commodity and returns a smaller `Seeds` commodity pile of the same material.
+Stock harvests also produce a small seed-tagged commodity output, and they tag the main yield as `Seeded Yield`. The active antiquity `select antiquity seed stock` craft takes `Seeded Yield` agricultural commodity and returns a smaller `Seeds` commodity pile of the same material, which lets harvested grain, pulses, roots, orchard crops, spice crops, and dye crops bootstrap future sowing projects. The companion compost craft turns raw herd manure and crop refuse into reusable compost stock for games that want a visible manure-to-fertiliser economy.
 
 ## Project Authoring Notes
 Agriculture operations should use local projects. Put labour, tools, seeds, fencing, fertiliser, drainage materials, and other inputs on the project template. The operation only stores the field-side effects and dynamic target context.

--- a/Design Documents/Agriculture/Agriculture_Builder_Workflows.md
+++ b/Design Documents/Agriculture/Agriculture_Builder_Workflows.md
@@ -5,15 +5,15 @@ Run `AgricultureSeeder` after core utility progs exist. It installs:
 
 - stock field profiles for arable fields, garden beds, orchards/groves, pasture, wet fields, rocky fields, saline coastal fields, and managed woodland
 - additional cultivated, marginal, natural, and unimproved field profiles for paddies, dryland fields, terraces, floodplains, old fallows, scrub, woodland clearings, marshes, saline edges, heavy clay, eroded slopes, and similar land-expansion starting points
-- specific annual crop and perennial orchard/vineyard/plantation definitions with seed requirements and commodity outputs, including broad temperate, tropical, dryland, wetland, archaic, and regional crop examples
+- specific annual crop and perennial orchard/vineyard/plantation definitions with seed requirements, commodity outputs, and concrete pollination metadata, including broad temperate, tropical, dryland, wetland, archaic, and regional crop examples
 - generic herd definitions
 - specific managed woodland definitions with commodity outputs
-- stock operations, including woodland yield multipliers and yield costs
-- local project templates with agriculture completion actions, seed stock material requirements, deliberately substantial labour requirements, and Farming-based supervision labour
+- stock operations, including woodland yield multipliers, yield costs, and apiary install, tend, harvest, and removal operations
+- local project templates with agriculture completion actions, seed stock material requirements, apiary installation requirements, deliberately substantial labour requirements, and Farming-based supervision labour
 
 The stock package is idempotent. Reruns refresh stock-owned rows by stable names instead of duplicating them.
 
-The stock agriculture catalogue is intentionally broad rather than setting-specific. Builders can use the installed profiles as starter land conditions and then tune or delete examples that do not fit their world.
+The stock agriculture catalogue is intentionally broad rather than setting-specific. Builders can use the installed profiles as starter land conditions and then tune or delete examples that do not fit their world. It includes an `Apiary Yard` profile for dedicated beeyards, but apiaries can also be installed on suitable crop, orchard, pasture, woodland, or fallow fields.
 
 ## Terrain Defaults
 Use terrain defaults to make field creation fast:
@@ -61,6 +61,7 @@ field crop set "Wheat" moisture 35 80
 field crop set "Wheat" planting group Autumn Spring
 field crop set "Moonwheat" planting season "Early Thaw"
 field crop set "Moonwheat" planting none
+field crop set "Apples" pollination Strong 1 2
 field crop set "Apples" perennial true
 field crop set "Apples" cycle 220
 field herds set "Cattle Herd" npc cattle
@@ -68,6 +69,7 @@ field woodland set "Hazel Coppice" cycle 365
 field operation set "Sow Crop" delta Moisture -3
 field operation set "Sow Crop" project "Stock Agriculture: Sow Crop"
 field operation set "Coppice Woodland" woodlandyield 0.45 45
+field operation set "Install Apiary" allowed Crop on
 ```
 
 Deleting a definition is blocked while live fields or active agriculture contexts still reference it.
@@ -108,6 +110,29 @@ Group windows are broad labels such as Winter, Spring, Summer, and Autumn. They 
 Season windows are exact local season names or display names. Use these when a game has detailed local seasons and a crop should only be planted during specific named seasons.
 
 Planting windows are hard gates for `Sow Crop` and `Plant Orchard`. They are checked when the field project starts and again when the project completion action applies the operation.
+
+## Apiaries and Pollination
+Apiaries are installed on fields as adjunct state instead of changing the field's primary use. This lets hives support nearby crops, orchards, pasture edges, woodland clearings, or a dedicated `Apiary Yard` without making bees compete with the land use they support.
+
+Crop definitions can declare how much they care about pollination:
+
+```text
+field crop set "Wheat" pollination None
+field crop set "Apples" pollination Strong 1 2
+field crop set "Cucumbers" pollination Required 1 2
+```
+
+The optional numbers are capped daily health and yield bonuses while the crop is `Growing` or `Setting`. Required crops take a stress penalty during `Setting` when no happy apiary is in range.
+
+Apiary operations use `AllowedUses`, so a single operation can run on fallow, crop, orchard, pasture, or woodland fields:
+
+```text
+field operation set "Install Apiary" allowed Crop on
+field operation set "Install Apiary" allowed Orchard on
+field operation set "Harvest Apiary" allowed Woodland on
+```
+
+The stock install project consumes two bee hives and one hive stand. Tend, harvest, and remove apiary operations are labour and skill operations; their reusable tools are represented through ordinary item and craft paths rather than consumed project materials.
 
 ## Starting Field Work
 Players and admins start work with:

--- a/Design Documents/Agriculture/Agriculture_Runtime_Model.md
+++ b/Design Documents/Agriculture/Agriculture_Runtime_Model.md
@@ -36,6 +36,8 @@ Player-facing output shows qualitative bands. Administrators see exact values th
 
 The enum also reserves `Custom1` through `Custom12`. These slots are disabled by default through the `AgricultureCustomScoreTypes` static configuration. When a slot is enabled, the configuration supplies its display name and whether higher values are beneficial or harmful. Built-in scores remain stored in their existing `AgricultureFields` columns; custom live field values are stored in the field definition XML under `<CustomScores>`.
 
+Apiary adjunct state is also stored in the field definition XML, under `<Apiary>`. This keeps hive count, colony health, stores, yield potential, pollination radius, and derived pollination strength beside the field state without adding another EF table.
+
 Profiles, operations, and crop definitions persist score references by stable enum slot name. This means a builder can rename `Custom1` from one local term to another without rewriting existing field profile, operation, crop, or field XML.
 
 ## Daily Tick
@@ -52,6 +54,7 @@ The tick applies coarse pressure:
 - crops gain growth days when conditions are reasonable.
 - crop stress reduces health and yield potential.
 - crop definitions can include additional score ranges, including custom score ranges, and out-of-range values count as stress.
+- happy apiaries build stores and yield potential, and crop or orchard fields can receive capped pollination support from the best happy apiary within range.
 - unmanaged weeds and pests increase slowly.
 - herds consume pasture biomass and can damage fences, topsoil, compaction, and condition when overstocked.
 - managed woodlands gain growth and yield potential slowly, with pest and condition pressure.
@@ -85,6 +88,8 @@ Stock crop outputs use the ordinary seeded material catalogue. Where a crop name
 
 Optional crop score ranges are saved under `<ScoreRanges>`. They are independent of moisture and temperature, so a non-terrestrial crop can require a configured field score such as magical saturation, radiation, nutrient medium quality, or other setting-specific resources.
 
+Crop definitions can also save pollination metadata. `None` crops ignore apiaries, `Beneficial` and `Strong` crops can receive capped daily health and yield bonuses during `Growing` and `Setting`, and `Required` crops take a stress penalty while setting fruit if no happy apiary support is in range. The stock crop catalogue uses concrete crop rules instead of assigning pollination to whole crop families.
+
 ## Orchard State
 Orchards, vineyards, nut groves, and similar perennial crops use the `Orchard` field use and the same `AgricultureFieldCrop` persistence row as annual crops. Their crop definitions set `perennial=true`, use `growthDays` for establishment time, and use `harvestCycleDays` for recurring harvest cadence after the first successful harvest.
 
@@ -116,6 +121,20 @@ The same field model supports coppice, pollards, timber stands, and clearing. Or
 
 Woodland definitions can include commodity outputs such as poles, rods, timber, fruitwood, bamboo, and firewood. Woodland operations can define a yield multiplier and a yield cost. When such an operation completes, the field releases commodities scaled by woodland health, current yield potential, and the operation multiplier, then consumes the configured amount of woodland yield.
 
+## Apiary State
+Apiaries are field adjuncts rather than a primary `AgricultureFieldUse`. A field can remain fallow, crop, orchard, pasture, or woodland while also carrying hive state:
+
+- hive count
+- colony health
+- stores
+- yield potential
+- pollination radius
+- pollination strength
+
+A happy apiary requires colony health of at least 50, stores of at least 25, field condition of at least 40, pests no higher than 70, and an acceptable field temperature. Happy apiaries supply pollination support out to their configured radius, defaulting to two cell hops in seeded operations.
+
+Install, tend, harvest, and remove apiary operations use `AllowedUses` so they can run across suitable primary uses without changing the field's current use. Harvesting can release raw honeycomb, pressed honey, and rendered beeswax commodity piles, scaled by colony state and the operation's harvest settings.
+
 ## Operations and Projects
 Agriculture operations are definition rows backed by normal project templates. Starting an operation creates an `ActiveLocalProject` and writes an `AgricultureProjectContext` row with:
 
@@ -135,6 +154,7 @@ During each project tick, agriculture projects record a Farming-weighted labour 
 - crop, orchard, and woodland outputs adjust commodity weight
 - seed-tagged outputs receive their own seed recovery multiplier
 - released commodities receive an output quality based on the Farming outcome
+- apiary operations can install hives, improve or weaken colony state, harvest commodity outputs, or remove hive state
 
 This means hired labour still supplies scale, but skilled farmers and supervisors influence the result that comes out of the project.
 
@@ -162,4 +182,4 @@ Agriculture registers the `field` FutureProg variable type and exposes `location
 
 These are intended for land expansion, scripted estates, controlled wilderness development, seasonal events, and builder automation.
 
-Field dot properties include crop and woodland state such as health, yield, growth days, crop stage, and whether the current crop is harvest-ready.
+Field dot properties include crop, woodland, and apiary state such as health, yield, growth days, crop stage, harvest readiness, hive count, apiary happiness, apiary stores, and pollination strength.

--- a/Design Documents/Agriculture/Agriculture_Runtime_Model.md
+++ b/Design Documents/Agriculture/Agriculture_Runtime_Model.md
@@ -36,7 +36,7 @@ Player-facing output shows qualitative bands. Administrators see exact values th
 
 The enum also reserves `Custom1` through `Custom12`. These slots are disabled by default through the `AgricultureCustomScoreTypes` static configuration. When a slot is enabled, the configuration supplies its display name and whether higher values are beneficial or harmful. Built-in scores remain stored in their existing `AgricultureFields` columns; custom live field values are stored in the field definition XML under `<CustomScores>`.
 
-Apiary adjunct state is also stored in the field definition XML, under `<Apiary>`. This keeps hive count, colony health, stores, yield potential, pollination radius, and derived pollination strength beside the field state without adding another EF table.
+Apiary adjunct state is also stored in the field definition XML, under `<Apiary>`. This keeps hive count, colony health, stores, yield potential, pollination radius, and derived pollination strength beside the field state without adding another EF table. Herd rows continue to use the existing `AgricultureFieldHerds` table and store secondary product yield potential in their definition XML.
 
 Profiles, operations, and crop definitions persist score references by stable enum slot name. This means a builder can rename `Custom1` from one local term to another without rewriting existing field profile, operation, crop, or field XML.
 
@@ -56,7 +56,8 @@ The tick applies coarse pressure:
 - crop definitions can include additional score ranges, including custom score ranges, and out-of-range values count as stress.
 - happy apiaries build stores and yield potential, and crop or orchard fields can receive capped pollination support from the best happy apiary within range.
 - unmanaged weeds and pests increase slowly.
-- herds consume pasture biomass and can damage fences, topsoil, compaction, and condition when overstocked.
+- fed herds consume pasture biomass, improve condition, and build secondary product yield potential when their definition has outputs.
+- overstocked herds can damage fences, topsoil, compaction, condition, and secondary product yield potential.
 - managed woodlands gain growth and yield potential slowly, with pest and condition pressure.
 
 The point is to create agricultural consequences and timing, not a detailed soil simulator.
@@ -101,8 +102,11 @@ Pasture fields can hold one or more `AgricultureFieldHerd` rows. Herds are abstr
 - herd definition
 - head count
 - condition
+- secondary product yield potential
 
-Animal-unit and daily-graze settings translate head count into pressure. Moderate grazing can be beneficial through nutrient cycling, while overstocking damages pasture biomass, topsoil, tilth, condition, and fencing.
+Animal-unit and daily-graze settings translate head count into pressure. Moderate grazing can be beneficial through nutrient cycling, while overstocking damages pasture biomass, topsoil, tilth, condition, fencing, and any pending secondary product yield.
+
+Herd definitions can define per-head secondary commodity outputs, such as raw milk, wool, eggs, and manure. Stock cattle, sheep/goat, horse, pig, and poultry definitions use this for culture-neutral pastoral products, including a horse-herd milk path for kumis-facing foodways. Fed herds build a 0-100 secondary yield potential over daily ticks. The `HarvestHerdProducts` operation releases the configured outputs scaled by head count, herd condition, yield potential, and operation multiplier, then consumes the operation's herd yield cost.
 
 When builders attach an NPC template to a herd definition, `field herd draw` can materialise live NPC livestock and decrement the abstract count. `field herd absorb` validates an eligible NPC, removes it from the active world, and increments the abstract herd.
 
@@ -119,7 +123,7 @@ Woodland fields hold one `AgricultureFieldWoodland` row:
 
 The same field model supports coppice, pollards, timber stands, and clearing. Orchards and vineyards are represented by the `Orchard` field use instead of woodland because they behave like perennial crop systems with harvest windows.
 
-Woodland definitions can include commodity outputs such as poles, rods, timber, fruitwood, bamboo, and firewood. Woodland operations can define a yield multiplier and a yield cost. When such an operation completes, the field releases commodities scaled by woodland health, current yield potential, and the operation multiplier, then consumes the configured amount of woodland yield.
+Woodland definitions can include commodity outputs such as poles, rods, timber, fruitwood, bamboo, firewood, galls, dye insects, lichens, and lac stock. Woodland operations can define a yield multiplier and a yield cost. When such an operation completes, the field releases commodities scaled by woodland health, current yield potential, and the operation multiplier, then consumes the configured amount of woodland yield.
 
 ## Apiary State
 Apiaries are field adjuncts rather than a primary `AgricultureFieldUse`. A field can remain fallow, crop, orchard, pasture, or woodland while also carrying hive state:
@@ -155,6 +159,7 @@ During each project tick, agriculture projects record a Farming-weighted labour 
 - seed-tagged outputs receive their own seed recovery multiplier
 - released commodities receive an output quality based on the Farming outcome
 - apiary operations can install hives, improve or weaken colony state, harvest commodity outputs, or remove hive state
+- herd product operations can release configured secondary herd commodities and consume herd yield potential
 
 This means hired labour still supplies scale, but skilled farmers and supervisors influence the result that comes out of the project.
 
@@ -162,7 +167,7 @@ The completion FutureProg receives the field and the best available character co
 
 This keeps project labour/material requirements generic while preserving dynamic agriculture state outside the project template.
 
-Crafts can also depend on agriculture state through the `field` / `AgricultureField` craft input. It resolves the current cell's agriculture field, can require a particular field use, crop, orchard, woodland, minimum field condition, minimum crop or woodland health, and minimum crop or woodland yield, and can consume a configured amount of crop or woodland yield during reservation. Use this for forestry, orchard, or gathering crafts that should operate on a live field rather than consuming a pre-existing commodity pile.
+Crafts can also depend on agriculture state through the `field` / `AgricultureField` craft input. It resolves the current cell's agriculture field, can require a particular field use, crop, orchard, woodland, minimum field condition, minimum crop or woodland health, and minimum crop or woodland yield, and can consume a configured amount of crop or woodland yield during reservation. Use this for forestry, orchard, or gathering crafts that should operate on a live field rather than consuming a pre-existing commodity pile. Herd secondary products are currently exposed through field operations that create commodity piles, after which ordinary craft inputs consume those piles.
 
 ## Permission Model
 When a field's cell belongs to a property, field work is allowed for administrators, authorised owners, and authorised leaseholders. Fields outside property are currently open to ordinary field commands unless the operation or project template applies its own FutureProg gates.

--- a/Design Documents/Agriculture/Agriculture_System_Overview.md
+++ b/Design Documents/Agriculture/Agriculture_System_Overview.md
@@ -3,7 +3,7 @@
 ## Purpose
 Agriculture is a first-class subsystem for fields, crops, pastures, herds, and managed woodlands. It deliberately sits beside crafting, projects, weather, property, terrain, and NPC systems rather than replacing any of them.
 
-The core abstraction is `IAgricultureField`: zero or one field can exist in a cell, and multiple fields are represented by multiple cells. A field holds visible 0-100 scores, an active use, and optional crop, perennial crop, herd, or woodland state.
+The core abstraction is `IAgricultureField`: zero or one field can exist in a cell, and multiple fields are represented by multiple cells. A field holds visible 0-100 scores, an active use, optional crop, perennial crop, herd, or woodland state, and optional apiary adjunct state.
 
 ## Design Goals
 - Give farmers meaningful choices without requiring soil-science simulation.
@@ -18,6 +18,7 @@ The core abstraction is `IAgricultureField`: zero or one field can exist in a ce
 | Field profile | Default score package and allowed uses for new fields. |
 | Field | Persisted cell-bound state, one per cell at most. |
 | Crop definition | Builder-editable crop parameters for annual crops and perennial orchard/vineyard crops, including planting windows, seed requirements, and commodity outputs. |
+| Apiary state | Optional hive installation on a field, independent of the primary field use, producing honeycomb, honey, beeswax, and pollination support. |
 | Herd definition | Abstract livestock definition with animal-unit pressure and optional NPC template for drawdown. |
 | Woodland definition | Managed tree stand or coppice definition with establishment timings, harvest cycle timings, and commodity outputs. |
 | Operation | Project-backed field operation such as sowing, drainage, weeding, harvesting, grazing, coppicing, felling, or clearing land. Woodland operations can release and consume yield. |
@@ -32,6 +33,8 @@ The core abstraction is `IAgricultureField`: zero or one field can exist in a ce
 - `Woodland`: coppice, pollard, timber stands, managed groves, and land clearing.
 
 A field has one primary use at a time. Temporary transitions, such as grazing fallow land or stubble, are modelled through operations that change the field's use.
+
+Apiaries are not a primary field use. They are nullable field state so hives can coexist with fallow ground, crops, orchards, pasture, or managed woodland. Apiary operations use `AllowedUses` to run across those primary uses without making bees compete with the land use they support.
 
 ## Player Surface
 The player-facing command is `field`.
@@ -65,6 +68,7 @@ Terrain defaults do not create fields automatically. They are a builder convenie
 - Weather supplies coarse daily moisture, stress, and growth pressure.
 - Crop planting windows use the local weather season when one exists, with static celestial-year group windows as a fallback for games without regional climate setup.
 - Commodity piles carry harvested crop, seed stock, and woodland products into the item economy.
+- Apiaries can release raw honeycomb, pressed honey, and rendered beeswax commodities, and happy colonies can improve pollination-sensitive crop and orchard yield.
 - Crafts can require and consume live crop or woodland yield through the `field` input type.
 - Generic commodity crafts can convert tagged agricultural yield into seed-tagged commodity piles.
 - Terrain supplies a default field profile.
@@ -75,6 +79,6 @@ Terrain defaults do not create fields automatically. They are a builder convenie
 Custom agriculture score slots are reserved in the `AgricultureScoreType` enum as `Custom1` through `Custom12`. They are disabled by default and named per game through static configuration, which lets fantasy or science-fiction games model unusual growing pressures without schema changes or stock crop assumptions.
 
 ## Seed Content
-`AgricultureSeeder` installs stock profiles, specific crop definitions, herd definitions, specific managed woodland definitions, operation definitions, and project templates. The stock project templates include general field labour and an optional Farming-based supervision role so skilled farmers can improve the final result without being the only source of labour. The stock package is still builder-editable, but it now covers many common crop and woodland products so new games can start from concrete commodities instead of broad placeholder categories.
+`AgricultureSeeder` installs stock profiles, specific crop definitions, herd definitions, specific managed woodland definitions, operation definitions, and project templates. The stock project templates include general field labour and an optional Farming-based supervision role so skilled farmers can improve the final result without being the only source of labour. The stock package is still builder-editable, but it now covers many common crop, woodland, and apiary products so new games can start from concrete commodities instead of broad placeholder categories.
 
-The stock profile set includes both ready-use cultivated land and rougher land-expansion starting points such as old fallows, scrub, wetland margins, heavy clay flats, eroded slopes, salt marsh edges, and woodland clearings. The crop catalogue likewise spans common temperate staples, tropical and wetland crops, dryland cereals and pulses, archaic crops, orchard fruit, nuts, vines, and plantation spices.
+The stock profile set includes both ready-use cultivated land and rougher land-expansion starting points such as old fallows, scrub, wetland margins, heavy clay flats, eroded slopes, salt marsh edges, woodland clearings, and an `Apiary Yard` profile for dedicated beeyards. The crop catalogue likewise spans common temperate staples, tropical and wetland crops, dryland cereals and pulses, archaic crops, orchard fruit, nuts, vines, and plantation spices, with concrete pollination metadata on crops that benefit from or require bee support.

--- a/Design Documents/Agriculture/Agriculture_System_Overview.md
+++ b/Design Documents/Agriculture/Agriculture_System_Overview.md
@@ -19,7 +19,7 @@ The core abstraction is `IAgricultureField`: zero or one field can exist in a ce
 | Field | Persisted cell-bound state, one per cell at most. |
 | Crop definition | Builder-editable crop parameters for annual crops and perennial orchard/vineyard crops, including planting windows, seed requirements, and commodity outputs. |
 | Apiary state | Optional hive installation on a field, independent of the primary field use, producing honeycomb, honey, beeswax, and pollination support. |
-| Herd definition | Abstract livestock definition with animal-unit pressure and optional NPC template for drawdown. |
+| Herd definition | Abstract livestock definition with animal-unit pressure, secondary commodity outputs, and optional NPC template for drawdown. |
 | Woodland definition | Managed tree stand or coppice definition with establishment timings, harvest cycle timings, and commodity outputs. |
 | Operation | Project-backed field operation such as sowing, drainage, weeding, harvesting, grazing, coppicing, felling, or clearing land. Woodland operations can release and consume yield. |
 
@@ -67,8 +67,9 @@ Terrain defaults do not create fields automatically. They are a builder convenie
 - Agriculture project completion records Farming-weighted worker contribution, including skilled supervision, and uses it to adjust field effects, crop yield, seed recovery, and commodity quality.
 - Weather supplies coarse daily moisture, stress, and growth pressure.
 - Crop planting windows use the local weather season when one exists, with static celestial-year group windows as a fallback for games without regional climate setup.
-- Commodity piles carry harvested crop, seed stock, and woodland products into the item economy.
+- Commodity piles carry harvested crop, seed stock, secondary herd products, and woodland products into the item economy.
 - Apiaries can release raw honeycomb, pressed honey, and rendered beeswax commodities, and happy colonies can improve pollination-sensitive crop and orchard yield.
+- Herd product operations can release milk, wool, eggs, and manure from established pasture herds, including horse-herd milk for kumis-facing pastoral play.
 - Crafts can require and consume live crop or woodland yield through the `field` input type.
 - Generic commodity crafts can convert tagged agricultural yield into seed-tagged commodity piles.
 - Terrain supplies a default field profile.
@@ -79,6 +80,6 @@ Terrain defaults do not create fields automatically. They are a builder convenie
 Custom agriculture score slots are reserved in the `AgricultureScoreType` enum as `Custom1` through `Custom12`. They are disabled by default and named per game through static configuration, which lets fantasy or science-fiction games model unusual growing pressures without schema changes or stock crop assumptions.
 
 ## Seed Content
-`AgricultureSeeder` installs stock profiles, specific crop definitions, herd definitions, specific managed woodland definitions, operation definitions, and project templates. The stock project templates include general field labour and an optional Farming-based supervision role so skilled farmers can improve the final result without being the only source of labour. The stock package is still builder-editable, but it now covers many common crop, woodland, and apiary products so new games can start from concrete commodities instead of broad placeholder categories.
+`AgricultureSeeder` installs stock profiles, specific crop definitions, herd definitions, specific managed woodland definitions, operation definitions, and project templates. The stock project templates include general field labour and an optional Farming-based supervision role so skilled farmers can improve the final result without being the only source of labour. The stock package is still builder-editable, but it now covers many common crop, herd, woodland, and apiary products so new games can start from concrete commodities instead of broad placeholder categories.
 
-The stock profile set includes both ready-use cultivated land and rougher land-expansion starting points such as old fallows, scrub, wetland margins, heavy clay flats, eroded slopes, salt marsh edges, woodland clearings, and an `Apiary Yard` profile for dedicated beeyards. The crop catalogue likewise spans common temperate staples, tropical and wetland crops, dryland cereals and pulses, archaic crops, orchard fruit, nuts, vines, and plantation spices, with concrete pollination metadata on crops that benefit from or require bee support.
+The stock profile set includes both ready-use cultivated land and rougher land-expansion starting points such as old fallows, scrub, wetland margins, heavy clay flats, eroded slopes, salt marsh edges, woodland clearings, and an `Apiary Yard` profile for dedicated beeyards. The crop catalogue likewise spans common temperate staples, tropical and wetland crops, dryland cereals and pulses, archaic crops, orchard fruit, nuts, vines, and plantation spices, with concrete pollination metadata on crops that benefit from or require bee support. Stock herds provide milk, wool, eggs, and manure outputs, and stock crops and woodlands include coriander, cumin, saffron crocus, black pepper, indigo, pomegranate, walnut, madder, weld, alkanet, henna, kermes, orchil, and lac paths used by antiquity processing crafts.

--- a/Design Documents/Crafting/Antiquity_Crafting_Audit.md
+++ b/Design Documents/Crafting/Antiquity_Crafting_Audit.md
@@ -9,11 +9,11 @@ Current item definitions are seeded from:
 | Source | Current Item Definitions |
 | --- | ---: |
 | `DatabaseSeeder/Seeders/ItemSeeder.Rework.Antiquity.cs` | 1034 |
-| `DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityFood.cs` | 151 |
+| `DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityFood.cs` | 167 |
 | `DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityHouseholdTools.cs` | 65 |
 | `DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityMedical.cs` | 41 |
 | `DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityWriting.cs` | 33 |
-| Total | 1324 |
+| Total | 1340 |
 
 Current craft definitions are seeded from:
 
@@ -34,7 +34,7 @@ The suite-specific docs now catalogue every stable reference explicitly named by
 - 398 household/container/door/furniture targets discovered from household, writing, religious, lighting, heating, construction, and writing-product tag roots.
 - 162 jewellery targets discovered from jewellery tags and catalogued in the dedicated jewellery suite.
 - 193 military equipment targets discovered from `Market / Military Goods`, split into 76 armour prototypes and 117 weapon, shield, ammunition, sling, and accessory prototypes.
-- the food and beverage suite documents the explicit `antiquity_food_` stable-reference prefix plus the shared amphora references used by `LiquidProduct` and fermentation crafts.
+- the food and beverage suite documents the explicit `antiquity_food_` stable-reference prefix plus the shared amphora references used by liquid filling, fermentation, and aging crafts.
 - 395 stable references explicitly named in the pre-food non-jewellery antiquity craft source files, plus the dynamically discovered jewellery catalogue, the food prefix catalogue, and source-audited partial seeder coverage for food, household tools, medical items, and writing items.
 
 ## Verified Invariants
@@ -50,7 +50,7 @@ The suite-specific docs now catalogue every stable reference explicitly named by
 - Glassworking now uses a lit glory-hole furnace for hot working and a lit annealing lehr for cooling finished glass.
 - Food and beverage crafts now add commodity-first grain, pulse, meat, preservation, broth, fermented drink, condiment, luxury beverage, and culture-gated prepared-food chains in the `ItemSeeder` rework path, assuming the butchery package has seeded its raw animal outputs.
 - Food tools now carry `Market / Professional Tools / Standard Tools` in addition to their functional tags, so the dynamic equipment toolmaking suite covers them.
-- Empty food serving and fermenting amphorae are craftable through pottery recipes that consume fired-clay `Bisque Vessel Blank` and `Prepared Pitch`; the finished beer amphora remains a fermentation morph target.
+- Empty food serving and fermenting amphorae are craftable through pottery recipes that consume fired-clay `Bisque Vessel Blank` and `Prepared Pitch`; finished beer, date beer, wine, kumis, garum, and spiced beverage amphorae remain fermentation or aging morph targets.
 - Kumis beverage stock consumes milk instead of grain wort. Red and white wine remain core liquids supplied by `CoreDataSeeder.Materials.cs`, not duplicate food-seeder liquids.
 - Raw hides from `AnimalButcherySeeder` now have a bridge craft into raw `animal skin` commodity stock before the existing prepared-hide and tanning chain.
 - Agriculture herd definitions now define secondary outputs and the stock `Collect Herd Products` operation can release milk, wool, eggs, and manure commodity piles from established pasture herds, including a horse-herd milk path for kumis-facing cultures.
@@ -64,7 +64,7 @@ The next-pass implementation resolves the earlier follow-up gaps as follows:
 - The expanded equipment craft pass discovers stock support tools from `Market / Professional Tools / Standard Tools` and explicitly includes unlit workshop apparatus. Support tools and unlit workshop apparatus are now craftable instead of remaining stock-only prerequisites.
 - Glassworking now has a glassworking glory-hole furnace pair, `antiquity_glory_hole_furnace` and `antiquity_lit_glory_hole_furnace`. Hot glassworking crafts require the lit glory-hole furnace, while annealing still requires the lit annealing lehr.
 - The food pass is kept wholly in `ItemSeeder` partials: item, liquid, prepared-food and spoilage-rule setup runs with rework items, and the matching crafts run with the normal ItemSeeder craft pass.
-- The food gap closure keeps this pattern: food tools use the standard tool market root, empty amphorae use the household pottery stock chain, `antiquity_food_finished_beer_amphora` stays a morph target, and culture beverage inputs now branch kumis to milk before the grain-wort fallback.
+- The food gap closure keeps this pattern: food tools use the standard tool market root, empty amphorae use the household pottery stock chain, fermented beverages and garum finish through morphing amphorae, and culture beverage inputs now branch kumis to milk before the grain-wort fallback.
 - The pastoral and derivative closure keeps the same commodity-first style: AgricultureSeeder owns crop, herd, and managed woodland production, while ItemSeeder owns reusable processing crafts that turn field outputs into seed stock, liquid milk, compost, textile dye stock, or saffron.
 - The external-catalogue risk is handled with source-backed regression tests rather than a generated file pipeline: tests parse the live seeder source, compare counts, inspect the partial seeder files, and verify that dynamic catalogues are represented in the dedicated design documents.
 

--- a/Design Documents/Crafting/Antiquity_Crafting_Audit.md
+++ b/Design Documents/Crafting/Antiquity_Crafting_Audit.md
@@ -65,4 +65,6 @@ The next-pass implementation resolves the earlier follow-up gaps as follows:
 
 ## Deferred Upstream Systems
 
-The current closure is an ItemSeeder craftability pass. It deliberately does not add full primary-production systems for pastoral secondary products, apiculture, mining and quarrying, dye and spice derivative supply, or other broad source chains. Those remain future subsystem expansions. The current antiquity recipes are closed against existing source truth: AgricultureSeeder commodities, AnimalButcherySeeder raw animal outputs, core liquids and materials, household pottery stock, and the dynamic equipment toolmaking surface.
+The current closure is an ItemSeeder craftability pass plus a first apiary source slice. Apiculture now has seeded upstream support through agriculture apiary operations, raw honeycomb, pressed honey, rendered beeswax, and antiquity hives, stands, smoke pots, honey knives, presses, and strainers. Those paths close the honey and beeswax source gap for existing food, medical, writing, leather, and household crafts.
+
+The pass deliberately does not add full primary-production systems for pastoral secondary products, mining and quarrying, dye and spice derivative supply, or other broad source chains. Those remain future subsystem expansions. The current antiquity recipes are closed against existing source truth: AgricultureSeeder commodities, apiary outputs, AnimalButcherySeeder raw animal outputs, core liquids and materials, household pottery stock, and the dynamic equipment toolmaking surface.

--- a/Design Documents/Crafting/Antiquity_Crafting_Audit.md
+++ b/Design Documents/Crafting/Antiquity_Crafting_Audit.md
@@ -20,6 +20,8 @@ Current craft definitions are seeded from:
 | Source | Craft Surface |
 | --- | --- |
 | `ItemSeederCrafting.Antiquity.cs` | Textile, leather, and older shared antiquity craft chains. |
+| `ItemSeederCrafting.AntiquityAgriculture.cs` | Seed-stock selection, raw milk straining, and crop derivative stock for dyes and saffron. |
+| `ItemSeederCrafting.AntiquityApiary.cs` | Apiary tools, hive equipment, and honeycomb processing. |
 | `ItemSeederCrafting.AntiquityEquipment.cs` | Common clothing/accessories, equipment stock, military goods, and heat-source lighting crafts. |
 | `ItemSeederCrafting.AntiquityFood.cs` | Grain, pulse, meat, preservation, beverage, and culture-gated foodway crafts. |
 | `ItemSeederCrafting.AntiquityHousehold.cs` | Household, container, vessel, door, gate, and furnishing craft discovery. |
@@ -51,6 +53,8 @@ The suite-specific docs now catalogue every stable reference explicitly named by
 - Empty food serving and fermenting amphorae are craftable through pottery recipes that consume fired-clay `Bisque Vessel Blank` and `Prepared Pitch`; the finished beer amphora remains a fermentation morph target.
 - Kumis beverage stock consumes milk instead of grain wort. Red and white wine remain core liquids supplied by `CoreDataSeeder.Materials.cs`, not duplicate food-seeder liquids.
 - Raw hides from `AnimalButcherySeeder` now have a bridge craft into raw `animal skin` commodity stock before the existing prepared-hide and tanning chain.
+- Agriculture herd definitions now define secondary outputs and the stock `Collect Herd Products` operation can release milk, wool, eggs, and manure commodity piles from established pasture herds, including a horse-herd milk path for kumis-facing cultures.
+- Active antiquity craft paths now convert `Seeded Yield` agricultural commodity back into `Seeds`, strain raw milk into liquid milk amphorae, compost raw manure with crop refuse, and process indigo crop, pomegranate, walnut, and saffron crocus into derivative dye or spice stock.
 
 ## Second-Pass Resolution
 
@@ -61,10 +65,11 @@ The next-pass implementation resolves the earlier follow-up gaps as follows:
 - Glassworking now has a glassworking glory-hole furnace pair, `antiquity_glory_hole_furnace` and `antiquity_lit_glory_hole_furnace`. Hot glassworking crafts require the lit glory-hole furnace, while annealing still requires the lit annealing lehr.
 - The food pass is kept wholly in `ItemSeeder` partials: item, liquid, prepared-food and spoilage-rule setup runs with rework items, and the matching crafts run with the normal ItemSeeder craft pass.
 - The food gap closure keeps this pattern: food tools use the standard tool market root, empty amphorae use the household pottery stock chain, `antiquity_food_finished_beer_amphora` stays a morph target, and culture beverage inputs now branch kumis to milk before the grain-wort fallback.
+- The pastoral and derivative closure keeps the same commodity-first style: AgricultureSeeder owns crop, herd, and managed woodland production, while ItemSeeder owns reusable processing crafts that turn field outputs into seed stock, liquid milk, compost, textile dye stock, or saffron.
 - The external-catalogue risk is handled with source-backed regression tests rather than a generated file pipeline: tests parse the live seeder source, compare counts, inspect the partial seeder files, and verify that dynamic catalogues are represented in the dedicated design documents.
 
 ## Deferred Upstream Systems
 
-The current closure is an ItemSeeder craftability pass plus a first apiary source slice. Apiculture now has seeded upstream support through agriculture apiary operations, raw honeycomb, pressed honey, rendered beeswax, and antiquity hives, stands, smoke pots, honey knives, presses, and strainers. Those paths close the honey and beeswax source gap for existing food, medical, writing, leather, and household crafts.
+The current closure is an ItemSeeder craftability pass plus agriculture source slices for apiaries, secondary herd outputs, seed stock, and common agricultural derivatives. Apiculture now has seeded upstream support through agriculture apiary operations, raw honeycomb, pressed honey, rendered beeswax, and antiquity hives, stands, smoke pots, honey knives, presses, and strainers. Herd operations now provide milk, wool, eggs, and manure; crop, woodland, and antiquity processing paths now cover seed selection, compost, indigo dye cake, pomegranate rind, walnut hull, saffron, madder root, weld, alkanet root, henna leaf, kermes grain, orchil lichen, and lac dye cake.
 
-The pass deliberately does not add full primary-production systems for pastoral secondary products, mining and quarrying, dye and spice derivative supply, or other broad source chains. Those remain future subsystem expansions. The current antiquity recipes are closed against existing source truth: AgricultureSeeder commodities, apiary outputs, AnimalButcherySeeder raw animal outputs, core liquids and materials, household pottery stock, and the dynamic equipment toolmaking surface.
+The pass deliberately does not add full primary-production systems for mining and quarrying, marine shellfish harvesting for murex purple, regional livestock breeds, queen breeding, or every local dye/spice crop. Those remain future subsystem expansions. The current antiquity recipes are closed against existing source truth: AgricultureSeeder crop, herd, woodland, and apiary commodities; AnimalButcherySeeder raw animal outputs; core liquids and materials; household pottery stock; and the dynamic equipment toolmaking surface.

--- a/Design Documents/Crafting/Antiquity_Crafting_Audit.md
+++ b/Design Documents/Crafting/Antiquity_Crafting_Audit.md
@@ -9,10 +9,11 @@ Current item definitions are seeded from:
 | Source | Current Item Definitions |
 | --- | ---: |
 | `DatabaseSeeder/Seeders/ItemSeeder.Rework.Antiquity.cs` | 1034 |
+| `DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityFood.cs` | 151 |
 | `DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityHouseholdTools.cs` | 65 |
 | `DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityMedical.cs` | 41 |
 | `DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityWriting.cs` | 33 |
-| Total | 1173 |
+| Total | 1324 |
 
 Current craft definitions are seeded from:
 
@@ -32,7 +33,7 @@ The suite-specific docs now catalogue every stable reference explicitly named by
 - 162 jewellery targets discovered from jewellery tags and catalogued in the dedicated jewellery suite.
 - 193 military equipment targets discovered from `Market / Military Goods`, split into 76 armour prototypes and 117 weapon, shield, ammunition, sling, and accessory prototypes.
 - the food and beverage suite documents the explicit `antiquity_food_` stable-reference prefix plus the shared amphora references used by `LiquidProduct` and fermentation crafts.
-- 395 stable references explicitly named in the pre-food non-jewellery antiquity craft source files, plus the dynamically discovered jewellery catalogue and the food prefix catalogue.
+- 395 stable references explicitly named in the pre-food non-jewellery antiquity craft source files, plus the dynamically discovered jewellery catalogue, the food prefix catalogue, and source-audited partial seeder coverage for food, household tools, medical items, and writing items.
 
 ## Verified Invariants
 
@@ -46,6 +47,10 @@ The suite-specific docs now catalogue every stable reference explicitly named by
 - Support tools and unlit workshop apparatus are now craftable through the expanded equipment toolmaking pass.
 - Glassworking now uses a lit glory-hole furnace for hot working and a lit annealing lehr for cooling finished glass.
 - Food and beverage crafts now add commodity-first grain, pulse, meat, preservation, broth, fermented drink, condiment, luxury beverage, and culture-gated prepared-food chains in the `ItemSeeder` rework path, assuming the butchery package has seeded its raw animal outputs.
+- Food tools now carry `Market / Professional Tools / Standard Tools` in addition to their functional tags, so the dynamic equipment toolmaking suite covers them.
+- Empty food serving and fermenting amphorae are craftable through pottery recipes that consume fired-clay `Bisque Vessel Blank` and `Prepared Pitch`; the finished beer amphora remains a fermentation morph target.
+- Kumis beverage stock consumes milk instead of grain wort. Red and white wine remain core liquids supplied by `CoreDataSeeder.Materials.cs`, not duplicate food-seeder liquids.
+- Raw hides from `AnimalButcherySeeder` now have a bridge craft into raw `animal skin` commodity stock before the existing prepared-hide and tanning chain.
 
 ## Second-Pass Resolution
 
@@ -55,4 +60,9 @@ The next-pass implementation resolves the earlier follow-up gaps as follows:
 - The expanded equipment craft pass discovers stock support tools from `Market / Professional Tools / Standard Tools` and explicitly includes unlit workshop apparatus. Support tools and unlit workshop apparatus are now craftable instead of remaining stock-only prerequisites.
 - Glassworking now has a glassworking glory-hole furnace pair, `antiquity_glory_hole_furnace` and `antiquity_lit_glory_hole_furnace`. Hot glassworking crafts require the lit glory-hole furnace, while annealing still requires the lit annealing lehr.
 - The food pass is kept wholly in `ItemSeeder` partials: item, liquid, prepared-food and spoilage-rule setup runs with rework items, and the matching crafts run with the normal ItemSeeder craft pass.
-- The external-catalogue risk is handled with source-backed regression tests rather than a generated file pipeline: tests parse the live seeder source, compare counts, and verify that dynamic catalogues are represented in the dedicated design documents.
+- The food gap closure keeps this pattern: food tools use the standard tool market root, empty amphorae use the household pottery stock chain, `antiquity_food_finished_beer_amphora` stays a morph target, and culture beverage inputs now branch kumis to milk before the grain-wort fallback.
+- The external-catalogue risk is handled with source-backed regression tests rather than a generated file pipeline: tests parse the live seeder source, compare counts, inspect the partial seeder files, and verify that dynamic catalogues are represented in the dedicated design documents.
+
+## Deferred Upstream Systems
+
+The current closure is an ItemSeeder craftability pass. It deliberately does not add full primary-production systems for pastoral secondary products, apiculture, mining and quarrying, dye and spice derivative supply, or other broad source chains. Those remain future subsystem expansions. The current antiquity recipes are closed against existing source truth: AgricultureSeeder commodities, AnimalButcherySeeder raw animal outputs, core liquids and materials, household pottery stock, and the dynamic equipment toolmaking surface.

--- a/Design Documents/Crafting/Antiquity_Food_Beverage_Crafting_Suite.md
+++ b/Design Documents/Crafting/Antiquity_Food_Beverage_Crafting_Suite.md
@@ -20,10 +20,21 @@ The shared chains are intentionally broad and tag-driven:
 - raw meat and offal breakdown from `AnimalButcherySeeder` outputs
 - raw meat cooking, salting, drying, smoking, rendering, and broth boiling
 - beer, date beer, wine-style fruit beverages, kumis, spiced luxury beverages, broth, and garum-style sauce filling
+- ceramic serving and fermenting amphora finishing from the household pottery blank pipeline
 
 The skill split is deliberately narrower than Farming: threshing and winnowing use `Threshing`, flour/meal/pulse/oil milling uses `Milling`, and wort or beer work uses `Brewing`. Fruit must pressing uses `Brewing`, while chopped vegetables, fruit serving, brining, cooked meat, broth, preserved foods, and most finished dishes remain cooking-led. Flatbread uses `Baking`.
 
 Crafts prefer commodity inputs such as `Raw Meat Commodity`, `Prepared Meat Commodity`, `Flour Commodity`, and `Pulse Meal Commodity` so one tagged chain can serve beef, lamb, goat, fish, or other seeded meat families without creating species-specific recipe explosions.
+
+## Tool And Vessel Closure
+
+Food tools are tagged with their exact functional tool tags and `Market / Professional Tools / Standard Tools`, so the shared antiquity equipment toolmaking suite discovers and crafts them without duplicating one-off recipes in the food file. This covers the butcher's knife, cooking knife, threshing flail, winnowing basket, hand quern, mortar and pestle, grain sieve, fruit press, oil press, mash tun, drying rack, smoking rack, and salting trough.
+
+Empty food vessels are explicit pottery crafts:
+
+- `antiquity_food_serving_amphora` is finished from fired-clay `Bisque Vessel Blank` stock and sealed with `Prepared Pitch`.
+- `antiquity_food_fermenting_amphora` is finished from fired-clay `Bisque Vessel Blank` stock with heavier `Prepared Pitch` lining and carries the fermentation amphora tool tag.
+- `antiquity_food_finished_beer_amphora` is intentionally a morph target for `antiquity_food_fermenting_beer_amphora`, not a direct craft output.
 
 ## Culture Coverage
 
@@ -45,6 +56,8 @@ The culture-gated final craft suites use `Foodways` knowledge gates:
 
 Each culture gets fourteen foodway crafts: the original flatbread, porridge, pulse stew, meat-grain dish, preserved meat ration, fruit sweet, and beverage amphora plus fresh fruit platter, oilseed cakes, spiced meat stew, honeyed pastry, fish sauce relish, stuffed flatbread, and spiced beverage amphora. Five of the seven new entries are high-end preparations distinguished by imported spices, honey, oil, fermented sauce, broth, brined fruit, or multi-stage cooking. Visible craft names are plain food actions; culture-specific access is enforced by the knowledge gate.
 
+Wine cultures consume `Fruit Must Commodity` and rely on the core liquids `red wine` and `white wine` from `CoreDataSeeder.Materials.cs`; the food seeder does not duplicate those base liquids. The Scythian-Sarmatian kumis path consumes `LiquidUse - 3 litres of milk` for the beverage stock rather than the grain-wort fallback. A future pastoral pass can split out mare's milk as a more specific stock source without changing the current foodway craft surface.
+
 ## Reusable Stock Outputs
 
 Most intermediate products are consumed downstream by other food crafts. The following are deliberately reusable stock outputs for later cuisine, economy, or preservation passes:
@@ -63,7 +76,25 @@ These remain commodity stock because they are useful in multiple future recipe f
 The craft source explicitly names the shared vessel references:
 
 - `antiquity_food_serving_amphora`
+- `antiquity_food_fermenting_amphora`
 - `antiquity_food_fermenting_beer_amphora`
+- `antiquity_food_finished_beer_amphora`
+
+The food tool stable references are:
+
+- `antiquity_food_butchers_knife`
+- `antiquity_food_cooking_knife`
+- `antiquity_food_threshing_flail`
+- `antiquity_food_winnowing_basket`
+- `antiquity_food_quern`
+- `antiquity_food_mortar`
+- `antiquity_food_grain_sieve`
+- `antiquity_food_fruit_press`
+- `antiquity_food_oil_press`
+- `antiquity_food_mash_tun`
+- `antiquity_food_drying_rack`
+- `antiquity_food_smoking_rack`
+- `antiquity_food_salting_trough`
 
 Culture-specific prepared-food prototypes are generated with the `antiquity_food_` stable-reference prefix. The current suffix set is:
 
@@ -89,3 +120,7 @@ where `<culture>` is one of `hellenic`, `egyptian`, `roman`, `celtic`, `germanic
 The food pass also seeds builder-owned `CommoditySpoilageRule` rows for raw meat, prepared meat, salted meat, dried meat, smoked meat, and broth-base commodities. These rules turn matching commodity piles into rotten food commodities on heartbeat instead of relying on item morphs or static JSON.
 
 `LiquidProduct` is the craft-product type used where a craft should create a concrete liquid container already filled with a named liquid, such as barley beer, date beer, meat broth, garum sauce, spiced wine, spiced beer, or spiced kumis.
+
+## Deferred Source Systems
+
+This pass closes current ItemSeeder craftability gaps, but it does not add new primary-production systems. Pastoral secondary products, apiculture, mining and quarrying, dye and spice derivative supply, and similar upstream source systems remain future expansion work. Current recipes use existing core liquids, materials, agricultural commodities, butchery outputs, and household pottery stock.

--- a/Design Documents/Crafting/Antiquity_Food_Beverage_Crafting_Suite.md
+++ b/Design Documents/Crafting/Antiquity_Food_Beverage_Crafting_Suite.md
@@ -7,7 +7,9 @@ The antiquity food and beverage pass lives in `ItemSeeder` partials and runs in 
 The implementation files are:
 
 - `DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityFood.cs`
+- `DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityApiary.cs`
 - `DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityFood.cs`
+- `DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityApiary.cs`
 
 ## Processing Chains
 
@@ -21,6 +23,7 @@ The shared chains are intentionally broad and tag-driven:
 - raw meat cooking, salting, drying, smoking, rendering, and broth boiling
 - beer, date beer, wine-style fruit beverages, kumis, spiced luxury beverages, broth, and garum-style sauce filling
 - ceramic serving and fermenting amphora finishing from the household pottery blank pipeline
+- apiary equipment and raw honeycomb processing into reusable honey and beeswax stock
 
 The skill split is deliberately narrower than Farming: threshing and winnowing use `Threshing`, flour/meal/pulse/oil milling uses `Milling`, and wort or beer work uses `Brewing`. Fruit must pressing uses `Brewing`, while chopped vegetables, fruit serving, brining, cooked meat, broth, preserved foods, and most finished dishes remain cooking-led. Flatbread uses `Baking`.
 
@@ -66,6 +69,8 @@ Most intermediate products are consumed downstream by other food crafts. The fol
 - `Smoked Meat Commodity`
 - `Oilseed Mash Commodity`
 - `Brined Fruit Commodity`
+- `Pressed Honey`
+- `Rendered Beeswax`
 
 These remain commodity stock because they are useful in multiple future recipe families and should not require one-off item prototypes.
 
@@ -96,6 +101,16 @@ The food tool stable references are:
 - `antiquity_food_smoking_rack`
 - `antiquity_food_salting_trough`
 
+The apiary stable references are:
+
+- `antiquity_wicker_beehive`
+- `antiquity_clay_tube_hive`
+- `antiquity_wooden_hive_stand`
+- `antiquity_bee_smoke_pot`
+- `antiquity_honey_knife`
+- `antiquity_honey_press`
+- `antiquity_honey_strainer`
+
 Culture-specific prepared-food prototypes are generated with the `antiquity_food_` stable-reference prefix. The current suffix set is:
 
 - `<culture>_flatbread`
@@ -123,4 +138,6 @@ The food pass also seeds builder-owned `CommoditySpoilageRule` rows for raw meat
 
 ## Deferred Source Systems
 
-This pass closes current ItemSeeder craftability gaps, but it does not add new primary-production systems. Pastoral secondary products, apiculture, mining and quarrying, dye and spice derivative supply, and similar upstream source systems remain future expansion work. Current recipes use existing core liquids, materials, agricultural commodities, butchery outputs, and household pottery stock.
+This pass closes current ItemSeeder craftability gaps and now has a seeded apiculture source path. Agriculture apiary operations can produce raw honeycomb, pressed honey, and rendered beeswax, and antiquity crafts can build the hives, stands, smoke pots, honey knives, presses, and strainers that support that chain. Existing honeyed food, medical, writing, leather, and household crafts can therefore trace honey and beeswax back to seeded field work.
+
+It still does not add new primary-production systems for pastoral secondary products, mining and quarrying, dye and spice derivative supply, and similar upstream source systems. Current recipes use existing core liquids, materials, agricultural commodities, apiary commodities, butchery outputs, and household pottery stock.

--- a/Design Documents/Crafting/Antiquity_Food_Beverage_Crafting_Suite.md
+++ b/Design Documents/Crafting/Antiquity_Food_Beverage_Crafting_Suite.md
@@ -22,7 +22,7 @@ The shared chains are intentionally broad and tag-driven:
 - oilseed crushing, vegetable/olive oil pressing, oilseed cake, and rendered-fat stock preparation
 - raw meat and offal breakdown from `AnimalButcherySeeder` outputs
 - raw meat cooking, salting, drying, smoking, rendering, and broth boiling
-- beer, date beer, wine-style fruit beverages, kumis, spiced luxury beverages, broth, and garum-style sauce filling
+- beer, date beer, wine-style fruit beverages, kumis, spiced luxury beverages, and garum-style sauce fermenting or aging amphora workflows, plus broth filling
 - ceramic serving and fermenting amphora finishing from the household pottery blank pipeline
 - apiary equipment and raw honeycomb processing into reusable honey and beeswax stock
 - agricultural seed-stock selection from `Seeded Yield` commodity into `Seeds` commodity
@@ -42,7 +42,7 @@ Empty food vessels are explicit pottery crafts:
 
 - `antiquity_food_serving_amphora` is finished from fired-clay `Bisque Vessel Blank` stock and sealed with `Prepared Pitch`.
 - `antiquity_food_fermenting_amphora` is finished from fired-clay `Bisque Vessel Blank` stock with heavier `Prepared Pitch` lining and carries the fermentation amphora tool tag.
-- `antiquity_food_finished_beer_amphora` is intentionally a morph target for `antiquity_food_fermenting_beer_amphora`, not a direct craft output.
+- Finished beverage and sauce amphorae are intentionally morph targets, not direct craft outputs. Active fermenting or aging amphorae cover barley beer, date beer, red wine, white wine, kumis, garum sauce, spiced wine, spiced beer, and spiced kumis.
 
 ## Culture Coverage
 
@@ -64,7 +64,7 @@ The culture-gated final craft suites use `Foodways` knowledge gates:
 
 Each culture gets fourteen foodway crafts: the original flatbread, porridge, pulse stew, meat-grain dish, preserved meat ration, fruit sweet, and beverage amphora plus fresh fruit platter, oilseed cakes, spiced meat stew, honeyed pastry, fish sauce relish, stuffed flatbread, and spiced beverage amphora. Five of the seven new entries are high-end preparations distinguished by imported spices, honey, oil, fermented sauce, broth, brined fruit, or multi-stage cooking. Visible craft names are plain food actions; culture-specific access is enforced by the knowledge gate.
 
-Wine cultures consume `Fruit Must Commodity` and rely on the core liquids `red wine` and `white wine` from `CoreDataSeeder.Materials.cs`; the food seeder does not duplicate those base liquids. The Scythian-Sarmatian kumis path consumes `LiquidUse - 3 litres of milk` for the beverage stock rather than the grain-wort fallback. A future species-specific livestock pass can split out mare's milk as a more specific stock source without changing the current foodway craft surface.
+Wine cultures consume `Fruit Must Commodity` and rely on the core liquids `red wine` and `white wine` from `CoreDataSeeder.Materials.cs`; the food seeder does not duplicate those base liquids. The Scythian-Sarmatian kumis path consumes `LiquidUse - 3 litres of milk` for the beverage stock rather than the grain-wort fallback. Beverage foodway crafts now produce sealed fermenting or aging amphorae that morph into finished serving amphorae, so wine, beer, date beer, kumis, garum, and spiced luxury beverages all use the same delayed production pattern. A future species-specific livestock pass can split out mare's milk as a more specific stock source without changing the current foodway craft surface.
 
 The agriculture pass now supplies the broader antiquity luxury inputs used by all cultures: coriander, cumin, saffron crocus, and black pepper are stock crops, and saffron crocus is processed into saffron. Pomegranate and walnut orchard outputs can be stripped into dye stock, indigo crop can be fermented into indigo dye cake, madder, weld, alkanet, and henna are stock dye crops, and managed woodland definitions cover kermes grain, orchil lichen, and lac dye cake. These are culture-neutral upstream crafts and field definitions so Hellenic, Egyptian, Roman, Celtic, Germanic, Kushite, Punic, Persian, Etruscan, Anatolian, and Scythian-Sarmatian recipes can share the same source paths.
 
@@ -97,6 +97,22 @@ The craft source explicitly names the shared vessel references:
 - `antiquity_food_fermenting_amphora`
 - `antiquity_food_fermenting_beer_amphora`
 - `antiquity_food_finished_beer_amphora`
+- `antiquity_food_fermenting_date_beer_amphora`
+- `antiquity_food_finished_date_beer_amphora`
+- `antiquity_food_fermenting_red_wine_amphora`
+- `antiquity_food_finished_red_wine_amphora`
+- `antiquity_food_fermenting_white_wine_amphora`
+- `antiquity_food_finished_white_wine_amphora`
+- `antiquity_food_fermenting_kumis_amphora`
+- `antiquity_food_finished_kumis_amphora`
+- `antiquity_food_fermenting_garum_amphora`
+- `antiquity_food_finished_garum_amphora`
+- `antiquity_food_aging_spiced_wine_amphora`
+- `antiquity_food_finished_spiced_wine_amphora`
+- `antiquity_food_aging_spiced_beer_amphora`
+- `antiquity_food_finished_spiced_beer_amphora`
+- `antiquity_food_aging_spiced_kumis_amphora`
+- `antiquity_food_finished_spiced_kumis_amphora`
 
 The food tool stable references are:
 
@@ -148,7 +164,7 @@ where `<culture>` is one of `hellenic`, `egyptian`, `roman`, `celtic`, `germanic
 
 The food pass also seeds builder-owned `CommoditySpoilageRule` rows for raw meat, prepared meat, salted meat, dried meat, smoked meat, and broth-base commodities. These rules turn matching commodity piles into rotten food commodities on heartbeat instead of relying on item morphs or static JSON.
 
-`LiquidProduct` is the craft-product type used where a craft should create a concrete liquid container already filled with a named liquid, such as barley beer, date beer, meat broth, garum sauce, spiced wine, spiced beer, or spiced kumis.
+`LiquidProduct` remains the craft-product type for non-fermenting filled liquid containers such as oils, meat broth, and strained milk. Fermented beverages, garum sauce, and aged spiced beverages instead produce sealed fermenting or aging amphora item prototypes; those prototypes morph into finished filled amphorae after their configured fermentation or steeping timer.
 
 ## Deferred Source Systems
 

--- a/Design Documents/Crafting/Antiquity_Food_Beverage_Crafting_Suite.md
+++ b/Design Documents/Crafting/Antiquity_Food_Beverage_Crafting_Suite.md
@@ -10,6 +10,7 @@ The implementation files are:
 - `DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityApiary.cs`
 - `DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityFood.cs`
 - `DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityApiary.cs`
+- `DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityAgriculture.cs`
 
 ## Processing Chains
 
@@ -24,14 +25,18 @@ The shared chains are intentionally broad and tag-driven:
 - beer, date beer, wine-style fruit beverages, kumis, spiced luxury beverages, broth, and garum-style sauce filling
 - ceramic serving and fermenting amphora finishing from the household pottery blank pipeline
 - apiary equipment and raw honeycomb processing into reusable honey and beeswax stock
+- agricultural seed-stock selection from `Seeded Yield` commodity into `Seeds` commodity
+- pastoral milk straining from raw herd milk commodity into liquid milk amphorae
+- pastoral manure composting from raw herd manure and crop refuse
+- agricultural derivative processing for indigo dye cake, pomegranate rind, walnut hull, and saffron stock, with crop or woodland sources for the common antiquity dye plants
 
-The skill split is deliberately narrower than Farming: threshing and winnowing use `Threshing`, flour/meal/pulse/oil milling uses `Milling`, and wort or beer work uses `Brewing`. Fruit must pressing uses `Brewing`, while chopped vegetables, fruit serving, brining, cooked meat, broth, preserved foods, and most finished dishes remain cooking-led. Flatbread uses `Baking`.
+The skill split is deliberately narrower than Farming: threshing and winnowing use `Threshing`, flour/meal/pulse/oil milling uses `Milling`, and wort or beer work uses `Brewing`. Fruit must pressing uses `Brewing`, dye derivatives use `Dyeing`, seed selection uses `Farming`, while chopped vegetables, fruit serving, milk straining, brining, cooked meat, broth, preserved foods, and most finished dishes remain cooking-led. Flatbread uses `Baking`.
 
 Crafts prefer commodity inputs such as `Raw Meat Commodity`, `Prepared Meat Commodity`, `Flour Commodity`, and `Pulse Meal Commodity` so one tagged chain can serve beef, lamb, goat, fish, or other seeded meat families without creating species-specific recipe explosions.
 
 ## Tool And Vessel Closure
 
-Food tools are tagged with their exact functional tool tags and `Market / Professional Tools / Standard Tools`, so the shared antiquity equipment toolmaking suite discovers and crafts them without duplicating one-off recipes in the food file. This covers the butcher's knife, cooking knife, threshing flail, winnowing basket, hand quern, mortar and pestle, grain sieve, fruit press, oil press, mash tun, drying rack, smoking rack, and salting trough.
+Food tools are tagged with their exact functional tool tags and `Market / Professional Tools / Standard Tools`, so the shared antiquity equipment toolmaking suite discovers and crafts them without duplicating one-off recipes in the food file. This covers the butcher's knife, cooking knife, threshing flail, winnowing basket, pitchfork, hand quern, mortar and pestle, grain sieve, fruit press, oil press, mash tun, drying rack, smoking rack, and salting trough.
 
 Empty food vessels are explicit pottery crafts:
 
@@ -59,7 +64,9 @@ The culture-gated final craft suites use `Foodways` knowledge gates:
 
 Each culture gets fourteen foodway crafts: the original flatbread, porridge, pulse stew, meat-grain dish, preserved meat ration, fruit sweet, and beverage amphora plus fresh fruit platter, oilseed cakes, spiced meat stew, honeyed pastry, fish sauce relish, stuffed flatbread, and spiced beverage amphora. Five of the seven new entries are high-end preparations distinguished by imported spices, honey, oil, fermented sauce, broth, brined fruit, or multi-stage cooking. Visible craft names are plain food actions; culture-specific access is enforced by the knowledge gate.
 
-Wine cultures consume `Fruit Must Commodity` and rely on the core liquids `red wine` and `white wine` from `CoreDataSeeder.Materials.cs`; the food seeder does not duplicate those base liquids. The Scythian-Sarmatian kumis path consumes `LiquidUse - 3 litres of milk` for the beverage stock rather than the grain-wort fallback. A future pastoral pass can split out mare's milk as a more specific stock source without changing the current foodway craft surface.
+Wine cultures consume `Fruit Must Commodity` and rely on the core liquids `red wine` and `white wine` from `CoreDataSeeder.Materials.cs`; the food seeder does not duplicate those base liquids. The Scythian-Sarmatian kumis path consumes `LiquidUse - 3 litres of milk` for the beverage stock rather than the grain-wort fallback. A future species-specific livestock pass can split out mare's milk as a more specific stock source without changing the current foodway craft surface.
+
+The agriculture pass now supplies the broader antiquity luxury inputs used by all cultures: coriander, cumin, saffron crocus, and black pepper are stock crops, and saffron crocus is processed into saffron. Pomegranate and walnut orchard outputs can be stripped into dye stock, indigo crop can be fermented into indigo dye cake, madder, weld, alkanet, and henna are stock dye crops, and managed woodland definitions cover kermes grain, orchil lichen, and lac dye cake. These are culture-neutral upstream crafts and field definitions so Hellenic, Egyptian, Roman, Celtic, Germanic, Kushite, Punic, Persian, Etruscan, Anatolian, and Scythian-Sarmatian recipes can share the same source paths.
 
 ## Reusable Stock Outputs
 
@@ -71,6 +78,12 @@ Most intermediate products are consumed downstream by other food crafts. The fol
 - `Brined Fruit Commodity`
 - `Pressed Honey`
 - `Rendered Beeswax`
+- `Raw Milk`
+- `Egg Product`
+- `Manure Commodity`
+- `compost` tagged as manure commodity stock
+- `Textile Dye Stock`
+- `Seeds`
 
 These remain commodity stock because they are useful in multiple future recipe families and should not require one-off item prototypes.
 
@@ -91,6 +104,7 @@ The food tool stable references are:
 - `antiquity_food_cooking_knife`
 - `antiquity_food_threshing_flail`
 - `antiquity_food_winnowing_basket`
+- `antiquity_food_pitchfork`
 - `antiquity_food_quern`
 - `antiquity_food_mortar`
 - `antiquity_food_grain_sieve`
@@ -138,6 +152,6 @@ The food pass also seeds builder-owned `CommoditySpoilageRule` rows for raw meat
 
 ## Deferred Source Systems
 
-This pass closes current ItemSeeder craftability gaps and now has a seeded apiculture source path. Agriculture apiary operations can produce raw honeycomb, pressed honey, and rendered beeswax, and antiquity crafts can build the hives, stands, smoke pots, honey knives, presses, and strainers that support that chain. Existing honeyed food, medical, writing, leather, and household crafts can therefore trace honey and beeswax back to seeded field work.
+This pass closes current ItemSeeder craftability gaps and now has seeded source paths for apiculture, seed stock, pastoral secondary products, and common agricultural derivatives. Agriculture apiary operations can produce raw honeycomb, pressed honey, and rendered beeswax, while herd operations can produce milk, wool, eggs, and manure from cattle, sheep/goat, horse, pig, and poultry herd definitions. Antiquity crafts build the hives, stands, smoke pots, honey knives, presses, strainers, and agricultural processing steps that support those chains.
 
-It still does not add new primary-production systems for pastoral secondary products, mining and quarrying, dye and spice derivative supply, and similar upstream source systems. Current recipes use existing core liquids, materials, agricultural commodities, apiary commodities, butchery outputs, and household pottery stock.
+It still does not add new primary-production systems for mining and quarrying, marine shellfish harvesting for murex, or every possible regional crop specialization. Current recipes use existing core liquids, materials, agricultural commodities, herd secondary outputs, apiary commodities, butchery outputs, and household pottery stock.

--- a/Design Documents/Data/SeededTagHierarchy.csv
+++ b/Design Documents/Data/SeededTagHierarchy.csv
@@ -1295,6 +1295,12 @@ Apiary Product	Animal Product	Materials / Animal Product / Apiary Product
 Pressed Honey	Apiary Product	Materials / Animal Product / Apiary Product / Pressed Honey
 Raw Honeycomb	Apiary Product	Materials / Animal Product / Apiary Product / Raw Honeycomb
 Rendered Beeswax	Apiary Product	Materials / Animal Product / Apiary Product / Rendered Beeswax
+Pastoral Product	Animal Product	Materials / Animal Product / Pastoral Product
+Egg Product	Pastoral Product	Materials / Animal Product / Pastoral Product / Egg Product
+Manure Commodity	Pastoral Product	Materials / Animal Product / Pastoral Product / Manure Commodity
+Manure Product	Pastoral Product	Materials / Animal Product / Pastoral Product / Manure Product
+Raw Milk	Pastoral Product	Materials / Animal Product / Pastoral Product / Raw Milk
+Raw Wool	Pastoral Product	Materials / Animal Product / Pastoral Product / Raw Wool
 Elastomer	Materials	Materials / Elastomer
 Elemental Materials	Materials	Materials / Elemental Materials
 Gases	Materials	Materials / Gases

--- a/Design Documents/Data/SeededTagHierarchy.csv
+++ b/Design Documents/Data/SeededTagHierarchy.csv
@@ -239,10 +239,17 @@ Extension Ladder	Ladder	Functions / Tools / Access Equipment / Ladder / Extensio
 Stepladder	Ladder	Functions / Tools / Access Equipment / Ladder / Stepladder
 Agricultural Tools	Tools	Functions / Tools / Agricultural Tools
 Ard	Agricultural Tools	Functions / Tools / Agricultural Tools / Ard
+Beekeeping Tools	Agricultural Tools	Functions / Tools / Agricultural Tools / Beekeeping Tools
+Bee Hive	Beekeeping Tools	Functions / Tools / Agricultural Tools / Beekeeping Tools / Bee Hive
+Bee Smoke Pot	Beekeeping Tools	Functions / Tools / Agricultural Tools / Beekeeping Tools / Bee Smoke Pot
 Digging Fork	Agricultural Tools	Functions / Tools / Agricultural Tools / Digging Fork
 Drover's Goad	Agricultural Tools	Functions / Tools / Agricultural Tools / Drover's Goad
 Grain Flail	Agricultural Tools	Functions / Tools / Agricultural Tools / Grain Flail
 Hay Rake	Agricultural Tools	Functions / Tools / Agricultural Tools / Hay Rake
+Hive Stand	Beekeeping Tools	Functions / Tools / Agricultural Tools / Beekeeping Tools / Hive Stand
+Honey Knife	Beekeeping Tools	Functions / Tools / Agricultural Tools / Beekeeping Tools / Honey Knife
+Honey Press	Beekeeping Tools	Functions / Tools / Agricultural Tools / Beekeeping Tools / Honey Press
+Honey Strainer	Beekeeping Tools	Functions / Tools / Agricultural Tools / Beekeeping Tools / Honey Strainer
 Pitchfork	Agricultural Tools	Functions / Tools / Agricultural Tools / Pitchfork
 Plough	Agricultural Tools	Functions / Tools / Agricultural Tools / Plough
 Ploughshare	Agricultural Tools	Functions / Tools / Agricultural Tools / Ploughshare
@@ -1284,6 +1291,10 @@ Beverage Serving Vessel	Vessels	Food and Drink / Vessels / Beverage Serving Vess
 Fermenting Vessel	Vessels	Food and Drink / Vessels / Fermenting Vessel
 Materials		Materials
 Animal Product	Materials	Materials / Animal Product
+Apiary Product	Animal Product	Materials / Animal Product / Apiary Product
+Pressed Honey	Apiary Product	Materials / Animal Product / Apiary Product / Pressed Honey
+Raw Honeycomb	Apiary Product	Materials / Animal Product / Apiary Product / Raw Honeycomb
+Rendered Beeswax	Apiary Product	Materials / Animal Product / Apiary Product / Rendered Beeswax
 Elastomer	Materials	Materials / Elastomer
 Elemental Materials	Materials	Materials / Elemental Materials
 Gases	Materials	Materials / Gases

--- a/Design Documents/Data/Seeded_Materials.json
+++ b/Design Documents/Data/Seeded_Materials.json
@@ -431,6 +431,7 @@
         "Material Name":  "beeswax",
         "Tags":  [
                      "Materials / Animal Product",
+                     "Materials / Animal Product / Apiary Product",
                      "Materials / Natural Materials"
                  ]
     },
@@ -2276,6 +2277,15 @@
         "Material Name":  "honey",
         "Tags":  [
                      "Materials / Animal Product",
+                     "Materials / Animal Product / Apiary Product",
+                     "Materials / Natural Materials / Food"
+                 ]
+    },
+    {
+        "Material Name":  "honeycomb",
+        "Tags":  [
+                     "Materials / Animal Product",
+                     "Materials / Animal Product / Apiary Product",
                      "Materials / Natural Materials / Food"
                  ]
     },

--- a/Design Documents/Data/Seeded_Materials.json
+++ b/Design Documents/Data/Seeded_Materials.json
@@ -1263,6 +1263,7 @@
     {
         "Material Name":  "compost",
         "Tags":  [
+                     "Materials / Animal Product / Pastoral Product / Manure Product",
                      "Materials / Natural Materials"
                  ]
     },
@@ -1774,6 +1775,15 @@
                  ]
     },
     {
+        "Material Name":  "egg",
+        "Tags":  [
+                     "Materials / Animal Product",
+                     "Materials / Animal Product / Pastoral Product",
+                     "Materials / Animal Product / Pastoral Product / Egg Product",
+                     "Materials / Natural Materials / Food"
+                 ]
+    },
+    {
         "Material Name":  "fatty flesh",
         "Tags":  [
 
@@ -1790,6 +1800,8 @@
         "Material Name":  "feces",
         "Tags":  [
                      "Materials / Animal Product",
+                     "Materials / Animal Product / Pastoral Product",
+                     "Materials / Animal Product / Pastoral Product / Manure Product",
                      "Materials / Natural Materials"
                  ]
     },
@@ -2926,6 +2938,15 @@
         "Material Name":  "mild steel",
         "Tags":  [
                      "Materials / Manufactured Materials / Manufactured Metal / Modern Age"
+                 ]
+    },
+    {
+        "Material Name":  "milk",
+        "Tags":  [
+                     "Materials / Animal Product",
+                     "Materials / Animal Product / Pastoral Product",
+                     "Materials / Animal Product / Pastoral Product / Raw Milk",
+                     "Materials / Natural Materials / Food"
                  ]
     },
     {
@@ -4100,6 +4121,13 @@
                  ]
     },
     {
+        "Material Name":  "saffron crocus",
+        "Tags":  [
+                     "Materials / Natural Materials / Food / Herb",
+                     "Materials / Textile Dye"
+                 ]
+    },
+    {
         "Material Name":  "sage",
         "Tags":  [
                      "Materials / Natural Materials / Food / Herb"
@@ -5222,6 +5250,9 @@
     {
         "Material Name":  "wool",
         "Tags":  [
+                     "Materials / Animal Product",
+                     "Materials / Animal Product / Pastoral Product",
+                     "Materials / Animal Product / Pastoral Product / Raw Wool",
                      "Materials / Manufactured Materials / Fabric / Animal Fiber Fabric"
                  ]
     },

--- a/FutureMUDLibrary/Work/Agriculture/AgricultureEnums.cs
+++ b/FutureMUDLibrary/Work/Agriculture/AgricultureEnums.cs
@@ -32,7 +32,11 @@ public enum AgricultureOperationType
 	Herd = 4,
 	Woodland = 5,
 	Clear = 6,
-	PlantOrchard = 7
+	PlantOrchard = 7,
+	InstallApiary = 8,
+	TendApiary = 9,
+	HarvestApiary = 10,
+	RemoveApiary = 11
 }
 
 public enum AgricultureTargetType
@@ -41,6 +45,14 @@ public enum AgricultureTargetType
 	Crop = 1,
 	Herd = 2,
 	Woodland = 3
+}
+
+public enum AgriculturePollinationDependency
+{
+	None = 0,
+	Beneficial = 1,
+	Strong = 2,
+	Required = 3
 }
 
 public enum AgricultureScoreType

--- a/FutureMUDLibrary/Work/Agriculture/AgricultureEnums.cs
+++ b/FutureMUDLibrary/Work/Agriculture/AgricultureEnums.cs
@@ -36,7 +36,8 @@ public enum AgricultureOperationType
 	InstallApiary = 8,
 	TendApiary = 9,
 	HarvestApiary = 10,
-	RemoveApiary = 11
+	RemoveApiary = 11,
+	HarvestHerdProducts = 12
 }
 
 public enum AgricultureTargetType

--- a/FutureMUDLibrary/Work/Agriculture/IAgricultureCropDefinition.cs
+++ b/FutureMUDLibrary/Work/Agriculture/IAgricultureCropDefinition.cs
@@ -13,6 +13,9 @@ public interface IAgricultureCropDefinition : IFrameworkItem, IHaveFuturemud
 	int MaximumMoisture { get; }
 	int MinimumTemperature { get; }
 	int MaximumTemperature { get; }
+	AgriculturePollinationDependency PollinationDependency { get; }
+	int PollinationHealthBonus { get; }
+	int PollinationYieldBonus { get; }
 	bool IsPerennial { get; }
 	int HarvestCycleDays { get; }
 	IReadOnlyCollection<AgriculturePlantingWindow> PlantingWindows { get; }

--- a/FutureMUDLibrary/Work/Agriculture/IAgricultureField.cs
+++ b/FutureMUDLibrary/Work/Agriculture/IAgricultureField.cs
@@ -22,6 +22,10 @@ public interface IAgricultureField : IFrameworkItem, ISaveable, IHaveFuturemud, 
 	int WoodlandGrowthDays { get; }
 	int WoodlandHealth { get; }
 	int WoodlandYieldPotential { get; }
+	IAgricultureFieldApiary Apiary { get; }
+	bool HasActiveApiary { get; }
+	bool IsApiaryHappy { get; }
+	int PollinationStrength { get; }
 	IEnumerable<IAgricultureFieldHerd> Herds { get; }
 	int Moisture { get; set; }
 	int Drainage { get; set; }
@@ -57,4 +61,14 @@ public interface IAgricultureFieldHerd : IFrameworkItem
 	IAgricultureHerdDefinition Definition { get; }
 	int HeadCount { get; }
 	double Condition { get; }
+}
+
+public interface IAgricultureFieldApiary
+{
+	int HiveCount { get; }
+	int ColonyHealth { get; }
+	int Stores { get; }
+	int YieldPotential { get; }
+	int PollinationRadius { get; }
+	int PollinationStrength { get; }
 }

--- a/FutureMUDLibrary/Work/Agriculture/IAgricultureField.cs
+++ b/FutureMUDLibrary/Work/Agriculture/IAgricultureField.cs
@@ -61,6 +61,7 @@ public interface IAgricultureFieldHerd : IFrameworkItem
 	IAgricultureHerdDefinition Definition { get; }
 	int HeadCount { get; }
 	double Condition { get; }
+	int SecondaryYieldPotential { get; }
 }
 
 public interface IAgricultureFieldApiary

--- a/FutureMUDLibrary/Work/Agriculture/IAgricultureHerdDefinition.cs
+++ b/FutureMUDLibrary/Work/Agriculture/IAgricultureHerdDefinition.cs
@@ -1,5 +1,6 @@
 using MudSharp.Framework;
 using MudSharp.NPC.Templates;
+using System.Collections.Generic;
 
 namespace MudSharp.Work.Agriculture;
 
@@ -9,6 +10,7 @@ public interface IAgricultureHerdDefinition : IFrameworkItem, IHaveFuturemud
 	double AnimalUnits { get; }
 	double DailyGraze { get; }
 	int MaximumCondition { get; }
+	IReadOnlyCollection<AgricultureCommodityYield> SecondaryOutputs { get; }
 	INPCTemplate NpcTemplate { get; }
 	bool CanMaterialise { get; }
 }

--- a/FutureMUDLibrary/Work/Agriculture/IAgricultureOperation.cs
+++ b/FutureMUDLibrary/Work/Agriculture/IAgricultureOperation.cs
@@ -18,6 +18,8 @@ public interface IAgricultureOperation : IFrameworkItem, IHaveFuturemud
 	IReadOnlyDictionary<AgricultureScoreType, int> ScoreDeltas { get; }
 	double WoodlandYieldMultiplier { get; }
 	int WoodlandYieldCost { get; }
+	double HerdYieldMultiplier { get; }
+	int HerdYieldCost { get; }
 	int ApiaryInstallHiveCount { get; }
 	int ApiaryPollinationRadius { get; }
 	int ApiaryTendHealthDelta { get; }

--- a/FutureMUDLibrary/Work/Agriculture/IAgricultureOperation.cs
+++ b/FutureMUDLibrary/Work/Agriculture/IAgricultureOperation.cs
@@ -12,11 +12,20 @@ public interface IAgricultureOperation : IFrameworkItem, IHaveFuturemud
 	AgricultureTargetType TargetType { get; }
 	AgricultureFieldUse RequiredUse { get; }
 	AgricultureFieldUse ResultUse { get; }
+	IReadOnlyCollection<AgricultureFieldUse> AllowedUses { get; }
 	IProject Project { get; }
 	IFutureProg CompletionProg { get; }
 	IReadOnlyDictionary<AgricultureScoreType, int> ScoreDeltas { get; }
 	double WoodlandYieldMultiplier { get; }
 	int WoodlandYieldCost { get; }
+	int ApiaryInstallHiveCount { get; }
+	int ApiaryPollinationRadius { get; }
+	int ApiaryTendHealthDelta { get; }
+	int ApiaryTendStoresDelta { get; }
+	int ApiaryTendYieldDelta { get; }
+	double ApiaryYieldMultiplier { get; }
+	int ApiaryYieldCost { get; }
+	IReadOnlyCollection<AgricultureCommodityYield> ApiaryYieldOutputs { get; }
 	bool CanApply(IAgricultureField field, IFrameworkItem target);
 	string WhyCannotApply(IAgricultureField field, IFrameworkItem target);
 }

--- a/MudSharpCore Unit Tests/AgricultureOperationTests.cs
+++ b/MudSharpCore Unit Tests/AgricultureOperationTests.cs
@@ -3,6 +3,7 @@ using Moq;
 using MudSharp.Celestial;
 using MudSharp.Climate;
 using MudSharp.Construction;
+using MudSharp.Construction.Boundary;
 using MudSharp.Framework;
 using MudSharp.Framework.Save;
 using MudSharp.Work.Agriculture;
@@ -101,6 +102,30 @@ public class AgricultureOperationTests
 		Assert.AreEqual(2, windows.Count);
 		Assert.IsTrue(windows.Any(x => x.Attribute("type")!.Value == "group" && x.Attribute("value")!.Value == "Spring"));
 		Assert.IsTrue(windows.Any(x => x.Attribute("type")!.Value == "season" && x.Attribute("value")!.Value == "Early Spring"));
+	}
+
+	[TestMethod]
+	public void CropDefinition_LoadsAndSavesPollinationMetadata()
+	{
+		var crop = new AgricultureCropDefinition(new MudSharp.Models.AgricultureCropDefinition
+		{
+			Id = 1,
+			Name = "Moonmelon",
+			Description = "A test crop.",
+			Category = "test",
+			Definition = @"<Crop growthDays=""30"" harvestWindowDays=""5"" minMoisture=""10"" maxMoisture=""90"" minTemperature=""0"" maxTemperature=""40""><Pollination dependency=""Required"" healthBonus=""1"" yieldBonus=""2"" /></Crop>"
+		}, BuildGameworldWithCustomScore(enabled: true).Object);
+
+		Assert.AreEqual(AgriculturePollinationDependency.Required, crop.PollinationDependency);
+		Assert.AreEqual(1, crop.PollinationHealthBonus);
+		Assert.AreEqual(2, crop.PollinationYieldBonus);
+
+		var saveMethod = typeof(AgricultureCropDefinition).GetMethod("SaveDefinition",
+			BindingFlags.Instance | BindingFlags.NonPublic);
+		var saved = (XElement)saveMethod!.Invoke(crop, null)!;
+		Assert.AreEqual("Required", saved.Element("Pollination")!.Attribute("dependency")!.Value);
+		Assert.AreEqual("1", saved.Element("Pollination")!.Attribute("healthBonus")!.Value);
+		Assert.AreEqual("2", saved.Element("Pollination")!.Attribute("yieldBonus")!.Value);
 	}
 
 	[TestMethod]
@@ -215,6 +240,88 @@ public class AgricultureOperationTests
 	}
 
 	[TestMethod]
+	public void CropTick_HappyApiarySupportsPollinationCrop()
+	{
+		var gameworld = BuildFieldGameworld(enabled: false,
+			cropPollination: AgriculturePollinationDependency.Strong,
+			pollinationHealthBonus: 1,
+			pollinationYieldBonus: 2,
+			includeNeighbourCell: true,
+			connectNeighbour: true);
+		var cropField = BuildFieldWithCustomScore(gameworld.Object, 50, AgricultureFieldUse.Crop, withCrop: true);
+		var apiaryField = BuildFieldWithCustomScore(gameworld.Object, 50, AgricultureFieldUse.Fallow,
+			apiary: new TestApiaryState(2, 70, 40, 60, 2), fieldId: 2, cellId: 2);
+		var fields = new All<IAgricultureField>();
+		fields.Add(cropField);
+		fields.Add(apiaryField);
+		gameworld.SetupGet(x => x.AgricultureFields).Returns(fields);
+
+		cropField.DailyTick();
+
+		Assert.AreEqual(52, cropField.CropHealth);
+		Assert.AreEqual(52, cropField.CropYieldPotential);
+	}
+
+	[TestMethod]
+	public void CropTick_OutOfRangeApiaryDoesNotSupportPollinationCrop()
+	{
+		var gameworld = BuildFieldGameworld(enabled: false,
+			cropPollination: AgriculturePollinationDependency.Strong,
+			pollinationHealthBonus: 1,
+			pollinationYieldBonus: 2,
+			includeNeighbourCell: true,
+			connectNeighbour: false);
+		var cropField = BuildFieldWithCustomScore(gameworld.Object, 50, AgricultureFieldUse.Crop, withCrop: true);
+		var apiaryField = BuildFieldWithCustomScore(gameworld.Object, 50, AgricultureFieldUse.Fallow,
+			apiary: new TestApiaryState(2, 70, 40, 60, 2), fieldId: 2, cellId: 2);
+		var fields = new All<IAgricultureField>();
+		fields.Add(cropField);
+		fields.Add(apiaryField);
+		gameworld.SetupGet(x => x.AgricultureFields).Returns(fields);
+
+		cropField.DailyTick();
+
+		Assert.AreEqual(51, cropField.CropHealth);
+		Assert.AreEqual(50, cropField.CropYieldPotential);
+	}
+
+	[TestMethod]
+	public void CropTick_HappyApiaryDoesNotAffectNonPollinationCrop()
+	{
+		var gameworld = BuildFieldGameworld(enabled: false,
+			cropPollination: AgriculturePollinationDependency.None,
+			pollinationHealthBonus: 1,
+			pollinationYieldBonus: 2);
+		var field = BuildFieldWithCustomScore(gameworld.Object, 50, AgricultureFieldUse.Crop,
+			withCrop: true, apiary: new TestApiaryState(2, 70, 40, 60, 2));
+		var fields = new All<IAgricultureField>();
+		fields.Add(field);
+		gameworld.SetupGet(x => x.AgricultureFields).Returns(fields);
+
+		field.DailyTick();
+
+		Assert.AreEqual(51, field.CropHealth);
+		Assert.AreEqual(50, field.CropYieldPotential);
+	}
+
+	[TestMethod]
+	public void CropTick_RequiredPollinationPenaltyAppliesDuringSettingWithoutHappyApiary()
+	{
+		var gameworld = BuildFieldGameworld(enabled: false,
+			cropPollination: AgriculturePollinationDependency.Required,
+			pollinationHealthBonus: 1,
+			pollinationYieldBonus: 2);
+		var cropField = BuildFieldWithCustomScore(gameworld.Object, 50, AgricultureFieldUse.Crop,
+			withCrop: true, cropStage: AgricultureCropStage.Setting);
+		gameworld.SetupGet(x => x.AgricultureFields).Returns(new All<IAgricultureField>());
+
+		cropField.DailyTick();
+
+		Assert.AreEqual(46, cropField.CropHealth);
+		Assert.AreEqual(47, cropField.CropYieldPotential);
+	}
+
+	[TestMethod]
 	public void AgricultureWorkOutcome_HighFarmingSkillImprovesYieldAndQuality()
 	{
 		var outcome = AgricultureWorkOutcome.FromSkill(800.0, 10.0, 0.0, 0.0);
@@ -321,6 +428,60 @@ public class AgricultureOperationTests
 	}
 
 	[TestMethod]
+	public void WhyCannotApply_AllowedUsesPermitApiaryOperationsWithoutChangingPrimaryUse()
+	{
+		var operation = BuildOperation(AgricultureOperationType.InstallApiary, AgricultureFieldUse.Fallow,
+			AgricultureFieldUse.Fallow, allowedUses:
+			[
+				AgricultureFieldUse.Fallow,
+				AgricultureFieldUse.Crop,
+				AgricultureFieldUse.Orchard,
+				AgricultureFieldUse.Pasture,
+				AgricultureFieldUse.Woodland
+			], apiaryInstallHives: 2, apiaryRadius: 2);
+		var field = new Mock<IAgricultureField>();
+		field.SetupGet(x => x.CurrentUse).Returns(AgricultureFieldUse.Crop);
+		field.SetupGet(x => x.HasActiveApiary).Returns(false);
+
+		var reason = operation.WhyCannotApply(field.Object, null);
+
+		Assert.AreEqual(string.Empty, reason);
+		CollectionAssert.Contains(operation.AllowedUses.ToList(), AgricultureFieldUse.Crop);
+	}
+
+	[TestMethod]
+	public void ApplyOperation_InstallsTendsHarvestsAndRemovesApiaryState()
+	{
+		var gameworld = BuildFieldGameworld(enabled: false);
+		var field = BuildFieldWithCustomScore(gameworld.Object, 50, AgricultureFieldUse.Fallow);
+		gameworld.SetupGet(x => x.AgricultureFields).Returns(new All<IAgricultureField>());
+		var install = BuildOperation(AgricultureOperationType.InstallApiary, AgricultureFieldUse.Fallow,
+			AgricultureFieldUse.Fallow, apiaryInstallHives: 2, apiaryRadius: 2, gameworldOverride: gameworld.Object);
+		var tend = BuildOperation(AgricultureOperationType.TendApiary, AgricultureFieldUse.Fallow,
+			AgricultureFieldUse.Fallow, apiaryTendHealth: 5, apiaryTendStores: 4, apiaryTendYield: 3,
+			gameworldOverride: gameworld.Object);
+		var remove = BuildOperation(AgricultureOperationType.RemoveApiary, AgricultureFieldUse.Fallow,
+			AgricultureFieldUse.Fallow, gameworldOverride: gameworld.Object);
+
+		Assert.IsTrue(field.ApplyOperation(install, null, null!, false, out _));
+		Assert.AreEqual(AgricultureFieldUse.Fallow, field.CurrentUse);
+		Assert.IsTrue(field.HasActiveApiary);
+		Assert.AreEqual(2, field.Apiary.HiveCount);
+
+		Assert.IsTrue(field.ApplyOperation(tend, null, null!, false, out _));
+		Assert.IsTrue(field.Apiary.ColonyHealth > 50);
+		Assert.IsTrue(field.Apiary.Stores > 35);
+
+		var saveMethod = typeof(AgricultureField).GetMethod("SaveFieldDefinition",
+			BindingFlags.Instance | BindingFlags.NonPublic);
+		var saved = (XElement)saveMethod!.Invoke(field, null)!;
+		Assert.AreEqual("2", saved.Element("Apiary")!.Attribute("hives")!.Value);
+
+		Assert.IsTrue(field.ApplyOperation(remove, null, null!, false, out _));
+		Assert.IsFalse(field.HasActiveApiary);
+	}
+
+	[TestMethod]
 	public void WhyCannotApply_SowRejectsPerennialCropTarget()
 	{
 		var operation = BuildOperation(AgricultureOperationType.Sow, AgricultureFieldUse.Fallow, AgricultureFieldUse.Crop, AgricultureTargetType.Crop);
@@ -375,8 +536,30 @@ public class AgricultureOperationTests
 	private static AgricultureOperation BuildOperation(AgricultureOperationType type, AgricultureFieldUse requiredUse,
 		AgricultureFieldUse resultUse, AgricultureTargetType targetType = AgricultureTargetType.None,
 		IEnumerable<(AgricultureScoreType Score, int Delta)>? scoreDeltas = null,
-		IFuturemud? gameworldOverride = null)
+		IFuturemud? gameworldOverride = null,
+		IEnumerable<AgricultureFieldUse>? allowedUses = null,
+		int apiaryInstallHives = 0,
+		int apiaryRadius = 0,
+		int apiaryTendHealth = 0,
+		int apiaryTendStores = 0,
+		int apiaryTendYield = 0)
 	{
+		var root = new XElement("Operation",
+			scoreDeltas?.Select(x => new XElement("Score",
+				new XAttribute("type", x.Score.ToString()),
+				new XAttribute("value", x.Delta))) ?? Enumerable.Empty<XElement>());
+		if (allowedUses != null)
+		{
+			root.Add(new XElement("AllowedUses",
+				new XAttribute("uses", string.Join(",", allowedUses.Select(x => x.ToString())))));
+		}
+
+		root.Add(new XElement("Apiary",
+			new XAttribute("installHives", apiaryInstallHives),
+			new XAttribute("pollinationRadius", apiaryRadius),
+			new XAttribute("tendHealthDelta", apiaryTendHealth),
+			new XAttribute("tendStoresDelta", apiaryTendStores),
+			new XAttribute("tendYieldDelta", apiaryTendYield)));
 		var model = new MudSharp.Models.AgricultureOperation
 		{
 			Id = 1,
@@ -386,10 +569,7 @@ public class AgricultureOperationTests
 			TargetType = (int)targetType,
 			RequiredUse = (int)requiredUse,
 			ResultUse = (int)resultUse,
-			Definition = new XElement("Operation",
-				scoreDeltas?.Select(x => new XElement("Score",
-					new XAttribute("type", x.Score.ToString()),
-					new XAttribute("value", x.Delta))) ?? Enumerable.Empty<XElement>()).ToString()
+			Definition = root.ToString()
 		};
 		var gameworld = gameworldOverride ?? new Mock<IFuturemud>().Object;
 		return new AgricultureOperation(model, gameworld);
@@ -413,7 +593,12 @@ public class AgricultureOperationTests
 	}
 
 	private static Mock<IFuturemud> BuildFieldGameworld(bool enabled, bool higherIsGood = true,
-		ISeason? season = null, double? celestialDay = null)
+		ISeason? season = null, double? celestialDay = null,
+		AgriculturePollinationDependency cropPollination = AgriculturePollinationDependency.None,
+		int pollinationHealthBonus = 0,
+		int pollinationYieldBonus = 0,
+		bool includeNeighbourCell = false,
+		bool connectNeighbour = false)
 	{
 		var gameworld = BuildGameworldWithCustomScore(enabled, higherIsGood);
 		var saveManager = new Mock<ISaveManager>();
@@ -430,7 +615,34 @@ public class AgricultureOperationTests
 		cell.Setup(x => x.CurrentTemperature(It.IsAny<IPerceiver>())).Returns(20.0);
 		cell.Setup(x => x.CurrentWeather(It.IsAny<IPerceiver>())).Returns(default(IWeatherEvent)!);
 		cell.Setup(x => x.CurrentSeason(It.IsAny<IPerceiver>())).Returns(season!);
+		cell.Setup(x => x.ExitsFor(It.IsAny<IPerceiver>(), It.IsAny<bool>())).Returns(Array.Empty<ICellExit>());
 		cells.Add(cell.Object);
+		if (includeNeighbourCell)
+		{
+			var neighbour = new Mock<ICell>();
+			neighbour.SetupGet(x => x.Id).Returns(2);
+			neighbour.SetupGet(x => x.Name).Returns("Neighbour Cell");
+			neighbour.SetupGet(x => x.FrameworkItemType).Returns("Cell");
+			neighbour.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+			neighbour.Setup(x => x.CurrentTemperature(It.IsAny<IPerceiver>())).Returns(20.0);
+			neighbour.Setup(x => x.CurrentWeather(It.IsAny<IPerceiver>())).Returns(default(IWeatherEvent)!);
+			neighbour.Setup(x => x.CurrentSeason(It.IsAny<IPerceiver>())).Returns(season!);
+			neighbour.Setup(x => x.ExitsFor(It.IsAny<IPerceiver>(), It.IsAny<bool>())).Returns(Array.Empty<ICellExit>());
+			if (connectNeighbour)
+			{
+				var outbound = new Mock<ICellExit>();
+				outbound.SetupGet(x => x.Destination).Returns(neighbour.Object);
+				var inbound = new Mock<ICellExit>();
+				inbound.SetupGet(x => x.Destination).Returns(cell.Object);
+				cell.Setup(x => x.ExitsFor(It.IsAny<IPerceiver>(), It.IsAny<bool>()))
+				    .Returns([outbound.Object]);
+				neighbour.Setup(x => x.ExitsFor(It.IsAny<IPerceiver>(), It.IsAny<bool>()))
+				         .Returns([inbound.Object]);
+			}
+
+			cells.Add(neighbour.Object);
+		}
+
 		gameworld.SetupGet(x => x.Cells).Returns(cells);
 		var celestials = new All<ICelestialObject>();
 		if (celestialDay.HasValue)
@@ -470,6 +682,9 @@ public class AgricultureOperationTests
 		crop.SetupGet(x => x.MaximumMoisture).Returns(100);
 		crop.SetupGet(x => x.MinimumTemperature).Returns(0);
 		crop.SetupGet(x => x.MaximumTemperature).Returns(40);
+		crop.SetupGet(x => x.PollinationDependency).Returns(cropPollination);
+		crop.SetupGet(x => x.PollinationHealthBonus).Returns(pollinationHealthBonus);
+		crop.SetupGet(x => x.PollinationYieldBonus).Returns(pollinationYieldBonus);
 		crop.SetupGet(x => x.HarvestCycleDays).Returns(30);
 		crop.SetupGet(x => x.PlantingWindows).Returns(Array.Empty<AgriculturePlantingWindow>());
 		crop.SetupGet(x => x.ScoreRanges).Returns(
@@ -480,6 +695,7 @@ public class AgricultureOperationTests
 		gameworld.SetupGet(x => x.AgricultureCropDefinitions).Returns(crops);
 
 		gameworld.SetupGet(x => x.Properties).Returns(new All<IProperty>());
+		gameworld.SetupGet(x => x.AgricultureFields).Returns(new All<IAgricultureField>());
 		return gameworld;
 	}
 
@@ -581,12 +797,13 @@ public class AgricultureOperationTests
 	}
 
 	private static AgricultureField BuildFieldWithCustomScore(IFuturemud gameworld, int customScore,
-		AgricultureFieldUse use, bool withCrop = false)
+		AgricultureFieldUse use, bool withCrop = false, AgricultureCropStage cropStage = AgricultureCropStage.Growing,
+		TestApiaryState? apiary = null, long fieldId = 1, long cellId = 1)
 	{
 		var model = new MudSharp.Models.AgricultureField
 		{
-			Id = 1,
-			CellId = 1,
+			Id = fieldId,
+			CellId = cellId,
 			ProfileId = 1,
 			CurrentUse = (int)use,
 			Moisture = 50,
@@ -602,6 +819,14 @@ public class AgricultureOperationTests
 			Pasture = 50,
 			Condition = 50,
 			Definition = new XElement("Field",
+				apiary == null
+					? null
+					: new XElement("Apiary",
+						new XAttribute("hives", apiary.HiveCount),
+						new XAttribute("health", apiary.ColonyHealth),
+						new XAttribute("stores", apiary.Stores),
+						new XAttribute("yield", apiary.YieldPotential),
+						new XAttribute("radius", apiary.PollinationRadius)),
 				new XElement("CustomScores",
 					new XElement("Score",
 						new XAttribute("type", AgricultureScoreType.Custom1.ToString()),
@@ -612,10 +837,10 @@ public class AgricultureOperationTests
 		{
 			model.AgricultureFieldCrop = new MudSharp.Models.AgricultureFieldCrop
 			{
-				AgricultureFieldId = 1,
+				AgricultureFieldId = fieldId,
 				CropDefinitionId = 1,
-				Stage = (int)AgricultureCropStage.Growing,
-				GrowthDays = 10,
+				Stage = (int)cropStage,
+				GrowthDays = cropStage == AgricultureCropStage.Setting ? 20 : 10,
 				Health = 50,
 				YieldPotential = 50,
 				Definition = "<Crop />"
@@ -624,4 +849,7 @@ public class AgricultureOperationTests
 
 		return new AgricultureField(model, gameworld);
 	}
+
+	private sealed record TestApiaryState(int HiveCount, int ColonyHealth, int Stores, int YieldPotential,
+		int PollinationRadius);
 }

--- a/MudSharpCore Unit Tests/AgricultureOperationTests.cs
+++ b/MudSharpCore Unit Tests/AgricultureOperationTests.cs
@@ -129,6 +129,35 @@ public class AgricultureOperationTests
 	}
 
 	[TestMethod]
+	public void HerdDefinition_LoadsAndSavesSecondaryOutputs()
+	{
+		var herd = new AgricultureHerdDefinition(new MudSharp.Models.AgricultureHerdDefinition
+		{
+			Id = 1,
+			Name = "Test Herd",
+			Description = "A test herd.",
+			Definition = @"<Herd animalUnits=""1"" dailyGraze=""1"" maximumCondition=""100""><SecondaryOutputs><Commodity material=""milk"" weight=""3500"" tag=""Raw Milk"" /><Commodity material=""feces"" weight=""2500"" tag=""Manure Commodity"" /></SecondaryOutputs></Herd>"
+		}, BuildGameworldWithCustomScore(enabled: true).Object);
+
+		Assert.AreEqual(2, herd.SecondaryOutputs.Count);
+		Assert.IsTrue(herd.SecondaryOutputs.Any(x =>
+			x.MaterialName == "milk" &&
+			x.BaseWeight == 3500 &&
+			x.TagName == "Raw Milk"));
+
+		var saveMethod = typeof(AgricultureHerdDefinition).GetMethod("SaveDefinition",
+			BindingFlags.Instance | BindingFlags.NonPublic);
+		var saved = (XElement)saveMethod!.Invoke(herd, null)!;
+		var outputs = saved.Element("SecondaryOutputs")!.Elements("Commodity").ToArray();
+		Assert.IsTrue(outputs.Any(x =>
+			x.Attribute("material")!.Value == "milk" &&
+			x.Attribute("tag")!.Value == "Raw Milk"));
+		Assert.IsTrue(outputs.Any(x =>
+			x.Attribute("material")!.Value == "feces" &&
+			x.Attribute("tag")!.Value == "Manure Commodity"));
+	}
+
+	[TestMethod]
 	public void WhyCannotApply_SowWithoutPlantingWindowsIsUnrestricted()
 	{
 		var gameworld = BuildFieldGameworld(enabled: false);
@@ -404,6 +433,46 @@ public class AgricultureOperationTests
 	}
 
 	[TestMethod]
+	public void HerdTick_FedHerdBuildsSecondaryYieldPotential()
+	{
+		var (gameworld, herd) = BuildTwoFieldGameworld();
+		var field = BuildFieldWithHerd(gameworld.Object, 1, 1, AgricultureFieldUse.Pasture, herd, 10, 60.0,
+			secondaryYield: 10);
+
+		field.DailyTick();
+
+		Assert.IsTrue(field.Herds.Single().SecondaryYieldPotential > 10);
+	}
+
+	[TestMethod]
+	public void WhyCannotApply_HarvestHerdProductsRequiresReadySecondaryYield()
+	{
+		var herd = new Mock<IAgricultureHerdDefinition>();
+		herd.SetupGet(x => x.Id).Returns(1);
+		herd.SetupGet(x => x.Name).Returns("Cattle Herd");
+		herd.SetupGet(x => x.SecondaryOutputs).Returns([
+			new AgricultureCommodityYield("milk", 3500, "Raw Milk")
+		]);
+		var field = new Mock<IAgricultureField>();
+		field.SetupGet(x => x.CurrentUse).Returns(AgricultureFieldUse.Pasture);
+		field.SetupGet(x => x.Herds).Returns([
+			new AgricultureFieldHerd(1, herd.Object, 4, 60.0, 0)
+		]);
+		var operation = BuildOperation(AgricultureOperationType.HarvestHerdProducts, AgricultureFieldUse.Pasture,
+			AgricultureFieldUse.Pasture, AgricultureTargetType.Herd, herdYieldMultiplier: 1.0, herdYieldCost: 55);
+
+		var reason = operation.WhyCannotApply(field.Object, herd.Object);
+
+		Assert.AreEqual("That herd does not have any secondary products ready to collect.", reason);
+
+		field.SetupGet(x => x.Herds).Returns([
+			new AgricultureFieldHerd(1, herd.Object, 4, 60.0, 40)
+		]);
+
+		Assert.AreEqual(string.Empty, operation.WhyCannotApply(field.Object, herd.Object));
+	}
+
+	[TestMethod]
 	public void WhyCannotApply_ImproveOperationRequiresConfiguredFieldUse()
 	{
 		var operation = BuildOperation(AgricultureOperationType.Improve, AgricultureFieldUse.Woodland, AgricultureFieldUse.Woodland);
@@ -542,9 +611,13 @@ public class AgricultureOperationTests
 		int apiaryRadius = 0,
 		int apiaryTendHealth = 0,
 		int apiaryTendStores = 0,
-		int apiaryTendYield = 0)
+		int apiaryTendYield = 0,
+		double herdYieldMultiplier = 0.0,
+		int herdYieldCost = 0)
 	{
 		var root = new XElement("Operation",
+			new XAttribute("herdYieldMultiplier", herdYieldMultiplier),
+			new XAttribute("herdYieldCost", herdYieldCost),
 			scoreDeltas?.Select(x => new XElement("Score",
 				new XAttribute("type", x.Score.ToString()),
 				new XAttribute("value", x.Delta))) ?? Enumerable.Empty<XElement>());
@@ -728,6 +801,11 @@ public class AgricultureOperationTests
 		herd.SetupGet(x => x.Name).Returns("Cattle Herd");
 		herd.SetupGet(x => x.FrameworkItemType).Returns("AgricultureHerdDefinition");
 		herd.SetupGet(x => x.MaximumCondition).Returns(100);
+		herd.SetupGet(x => x.AnimalUnits).Returns(1.0);
+		herd.SetupGet(x => x.DailyGraze).Returns(1.0);
+		herd.SetupGet(x => x.SecondaryOutputs).Returns([
+			new AgricultureCommodityYield("milk", 3500, "Raw Milk")
+		]);
 		var herds = new All<IAgricultureHerdDefinition>();
 		herds.Add(herd.Object);
 		gameworld.SetupGet(x => x.AgricultureHerdDefinitions).Returns(herds);
@@ -758,7 +836,8 @@ public class AgricultureOperationTests
 	}
 
 	private static AgricultureField BuildFieldWithHerd(IFuturemud gameworld, long id, long cellId,
-		AgricultureFieldUse use, IAgricultureHerdDefinition herd, int count, double herdCondition)
+		AgricultureFieldUse use, IAgricultureHerdDefinition herd, int count, double herdCondition,
+		int secondaryYield = 0)
 	{
 		var model = new MudSharp.Models.AgricultureField
 		{
@@ -789,7 +868,8 @@ public class AgricultureOperationTests
 				HerdDefinitionId = herd.Id,
 				HeadCount = count,
 				Condition = herdCondition,
-				Definition = "<Herd />"
+				Definition = new XElement("Herd",
+					new XAttribute("secondaryYield", secondaryYield)).ToString()
 			});
 		}
 

--- a/MudSharpCore/Commands/Modules/AgricultureModule.cs
+++ b/MudSharpCore/Commands/Modules/AgricultureModule.cs
@@ -309,7 +309,8 @@ Admin Syntax:
 		}
 
 		var operation = actor.Gameworld.AgricultureOperations
-		                     .Where(x => x.OperationType == AgricultureOperationType.Harvest)
+		                     .Where(x => x.OperationType is AgricultureOperationType.Harvest or AgricultureOperationType.HarvestApiary)
+		                     .OrderBy(x => x.OperationType == AgricultureOperationType.Harvest ? 0 : 1)
 		                     .FirstOrDefault(x => field.CanBeginOperation(actor, x, null, out _));
 		if (operation == null)
 		{
@@ -1007,9 +1008,20 @@ Harvest Window: {crop.HarvestWindowDays.ToString("N0", actor).ColourValue()}
 Planting: {DescribePlantingWindows(crop.PlantingWindows, actor)}
 Moisture: {crop.MinimumMoisture.ToString("N0", actor).ColourValue()} to {crop.MaximumMoisture.ToString("N0", actor).ColourValue()}
 Temperature: {crop.MinimumTemperature.ToString("N0", actor).ColourValue()} to {crop.MaximumTemperature.ToString("N0", actor).ColourValue()} C
+Pollination: {DescribePollination(crop, actor)}
 Score Ranges: {DescribeScoreRanges(crop.ScoreRanges, actor)}
 Seeds: {DescribeCommodityOutputs(crop.SeedRequirements, actor)}
 Outputs: {DescribeCommodityOutputs(crop.YieldOutputs, actor)}");
+	}
+
+	private static string DescribePollination(IAgricultureCropDefinition crop, ICharacter actor)
+	{
+		if (crop.PollinationDependency == AgriculturePollinationDependency.None)
+		{
+			return "None".ColourError();
+		}
+
+		return $"{crop.PollinationDependency.DescribeEnum().ColourName()} (+{crop.PollinationHealthBonus.ToString("N0", actor).ColourValue()} health, +{crop.PollinationYieldBonus.ToString("N0", actor).ColourValue()} yield)";
 	}
 
 	private static string DescribePlantingWindows(IReadOnlyCollection<AgriculturePlantingWindow> windows, ICharacter actor)
@@ -1073,7 +1085,7 @@ Outputs: {DescribeCommodityOutputs(crop.YieldOutputs, actor)}");
 
 		if (ss.IsFinished)
 		{
-			actor.OutputHandler.Send("Do you want to set name, description, category, growth, perennial, cycle, window, planting, moisture, temperature, or score?");
+			actor.OutputHandler.Send("Do you want to set name, description, category, growth, perennial, cycle, window, planting, moisture, temperature, pollination, or score?");
 			return;
 		}
 
@@ -1163,6 +1175,31 @@ Outputs: {DescribeCommodityOutputs(crop.YieldOutputs, actor)}");
 				concrete.BuildingSetTemperatureRange(minTemperature, maxTemperature);
 				actor.OutputHandler.Send("You update the crop temperature range.");
 				return;
+			case "pollination":
+			case "pollinate":
+				if (ss.IsFinished || !Enum.TryParse<AgriculturePollinationDependency>(ss.PopSpeech(), true, out var dependency))
+				{
+					actor.OutputHandler.Send($"Valid pollination dependencies are {Enum.GetValues(typeof(AgriculturePollinationDependency)).OfType<AgriculturePollinationDependency>().Select(x => x.DescribeEnum().ColourName()).ListToString()}.");
+					return;
+				}
+
+				var healthBonus = dependency == AgriculturePollinationDependency.Beneficial ? 0 : 1;
+				var yieldBonus = dependency == AgriculturePollinationDependency.Beneficial ? 1 : 2;
+				if (!ss.IsFinished && (!int.TryParse(ss.PopSpeech(), out healthBonus) || healthBonus < 0 || healthBonus > 1))
+				{
+					actor.OutputHandler.Send("The pollination health bonus must be 0 or 1.");
+					return;
+				}
+
+				if (!ss.IsFinished && (!int.TryParse(ss.PopSpeech(), out yieldBonus) || yieldBonus < 0 || yieldBonus > 2))
+				{
+					actor.OutputHandler.Send("The pollination yield bonus must be 0, 1, or 2.");
+					return;
+				}
+
+				concrete.BuildingSetPollination(dependency, healthBonus, yieldBonus);
+				actor.OutputHandler.Send($"You set crop pollination to {DescribePollination(concrete, actor)}.");
+				return;
 			case "score":
 			case "scorerange":
 			case "range":
@@ -1210,7 +1247,7 @@ Outputs: {DescribeCommodityOutputs(crop.YieldOutputs, actor)}");
 				return;
 		}
 
-		actor.OutputHandler.Send("Do you want to set name, description, category, growth, perennial, cycle, window, planting, moisture, temperature, or score?");
+		actor.OutputHandler.Send("Do you want to set name, description, category, growth, perennial, cycle, window, planting, moisture, temperature, pollination, or score?");
 	}
 
 	private static void SetCropPlanting(ICharacter actor, AgricultureCropDefinition crop, StringStack ss)
@@ -1713,10 +1750,12 @@ Outputs: {DescribeCommodityOutputs(woodland.YieldOutputs, actor)}");
 Type: {operation.OperationType.DescribeEnum().ColourName()}
 Target: {operation.TargetType.DescribeEnum().ColourName()}
 Required Use: {operation.RequiredUse.DescribeEnum().ColourName()}
+Allowed Uses: {operation.AllowedUses.OrderBy(x => (int)x).Select(x => x.DescribeEnum().ColourName()).ListToString()}
 Result Use: {operation.ResultUse.DescribeEnum().ColourName()}
 Project: {(operation.Project?.Name ?? "None").ColourName()}
 Completion Prog: {(operation.CompletionProg?.FunctionName ?? "None").ColourName()}
 Woodland Yield: x{operation.WoodlandYieldMultiplier.ToString("N2", actor).ColourValue()}, consumes {operation.WoodlandYieldCost.ToString("N0", actor).ColourValue()} yield
+Apiary: install {operation.ApiaryInstallHiveCount.ToString("N0", actor).ColourValue()} hives, radius {operation.ApiaryPollinationRadius.ToString("N0", actor).ColourValue()}, tend {operation.ApiaryTendHealthDelta.ToString("N0", actor).ColourValue()}/{operation.ApiaryTendStoresDelta.ToString("N0", actor).ColourValue()}/{operation.ApiaryTendYieldDelta.ToString("N0", actor).ColourValue()}, harvest x{operation.ApiaryYieldMultiplier.ToString("N2", actor).ColourValue()} cost {operation.ApiaryYieldCost.ToString("N0", actor).ColourValue()} [{DescribeCommodityOutputs(operation.ApiaryYieldOutputs, actor)}]
 Deltas: {operation.ScoreDeltas.Where(x => x.Key.IsEnabledScore(actor.Gameworld)).OrderBy(x => x.Key).Select(x => $"{x.Key.DescribeFor(actor.Gameworld)} {x.Value.ToString("N0", actor)}").ListToString()}");
 	}
 
@@ -1770,7 +1809,7 @@ Deltas: {operation.ScoreDeltas.Where(x => x.Key.IsEnabledScore(actor.Gameworld))
 
 		if (ss.IsFinished)
 		{
-			actor.OutputHandler.Send("Do you want to set name, description, type, target, required, result, project, prog, delta, or woodlandyield?");
+			actor.OutputHandler.Send("Do you want to set name, description, type, target, required, allowed, result, project, prog, delta, or woodlandyield?");
 			return;
 		}
 
@@ -1815,6 +1854,25 @@ Deltas: {operation.ScoreDeltas.Where(x => x.Key.IsEnabledScore(actor.Gameworld))
 
 				concrete.BuildingSetRequiredUse(requiredUse);
 				actor.OutputHandler.Send($"You set the required field use to {requiredUse.DescribeEnum().ColourName()}.");
+				return;
+			case "allowed":
+			case "allowuse":
+			case "alloweduse":
+				if (ss.IsFinished || !Enum.TryParse<AgricultureFieldUse>(ss.PopSpeech(), true, out var allowedUse))
+				{
+					actor.OutputHandler.Send($"Valid field uses are {Enum.GetValues(typeof(AgricultureFieldUse)).OfType<AgricultureFieldUse>().Select(x => x.DescribeEnum().ColourName()).ListToString()}.");
+					return;
+				}
+
+				var allowed = true;
+				if (!ss.IsFinished && !TryParseOnOff(ss.PopSpeech(), out allowed))
+				{
+					actor.OutputHandler.Send("Do you want to allow or disallow that field use?");
+					return;
+				}
+
+				concrete.BuildingSetAllowedUse(allowedUse, allowed);
+				actor.OutputHandler.Send($"You {(allowed ? "allow" : "disallow")} this operation on {allowedUse.DescribeEnum().ColourName()} fields.");
 				return;
 			case "result":
 			case "resultuse":
@@ -1899,7 +1957,7 @@ Deltas: {operation.ScoreDeltas.Where(x => x.Key.IsEnabledScore(actor.Gameworld))
 				return;
 		}
 
-		actor.OutputHandler.Send("Do you want to set name, description, type, target, required, result, project, prog, delta, or woodlandyield?");
+		actor.OutputHandler.Send("Do you want to set name, description, type, target, required, allowed, result, project, prog, delta, or woodlandyield?");
 	}
 
 	private static void DeleteOperation(ICharacter actor, StringStack ss)

--- a/MudSharpCore/Commands/Modules/AgricultureModule.cs
+++ b/MudSharpCore/Commands/Modules/AgricultureModule.cs
@@ -1380,6 +1380,7 @@ Outputs: {DescribeCommodityOutputs(crop.YieldOutputs, actor)}");
 Animal Units: {herd.AnimalUnits.ToString("N2", actor).ColourValue()}
 Daily Graze: {herd.DailyGraze.ToString("N2", actor).ColourValue()}
 Maximum Condition: {herd.MaximumCondition.ToString("N0", actor).ColourValue()}
+Secondary Outputs: {DescribeCommodityOutputs(herd.SecondaryOutputs, actor)}
 NPC Template: {(herd.NpcTemplate?.Name ?? "None").ColourName()}");
 	}
 
@@ -1417,7 +1418,7 @@ NPC Template: {(herd.NpcTemplate?.Name ?? "None").ColourName()}");
 
 		if (ss.IsFinished)
 		{
-			actor.OutputHandler.Send("Do you want to set name, description, animalunits, graze, condition, or npc?");
+			actor.OutputHandler.Send("Do you want to set name, description, animalunits, graze, condition, output, or npc?");
 			return;
 		}
 
@@ -1464,6 +1465,11 @@ NPC Template: {(herd.NpcTemplate?.Name ?? "None").ColourName()}");
 				concrete.BuildingSetMaximumCondition(condition);
 				actor.OutputHandler.Send($"You set maximum condition to {concrete.MaximumCondition.ToStringN0Colour(actor)}.");
 				return;
+			case "output":
+			case "outputs":
+			case "secondary":
+				SetHerdDefinitionOutput(actor, concrete, ss);
+				return;
 			case "npc":
 			case "template":
 				if (ss.IsFinished)
@@ -1491,7 +1497,66 @@ NPC Template: {(herd.NpcTemplate?.Name ?? "None").ColourName()}");
 				return;
 		}
 
-		actor.OutputHandler.Send("Do you want to set name, description, animalunits, graze, condition, or npc?");
+		actor.OutputHandler.Send("Do you want to set name, description, animalunits, graze, condition, output, or npc?");
+	}
+
+	private static void SetHerdDefinitionOutput(ICharacter actor, AgricultureHerdDefinition herd, StringStack ss)
+	{
+		if (ss.IsFinished)
+		{
+			actor.OutputHandler.Send("Syntax: field herds set <herd> output clear|add <weight grams> <material> [tag <tag>]");
+			return;
+		}
+
+		switch (ss.PopSpeech().ToLowerInvariant())
+		{
+			case "clear":
+				herd.BuildingSetSecondaryOutputs(Array.Empty<AgricultureCommodityYield>());
+				actor.OutputHandler.Send("You clear the secondary product outputs for this herd definition.");
+				return;
+			case "add":
+				if (ss.IsFinished || !double.TryParse(ss.PopSpeech(), out var weight) || weight <= 0.0)
+				{
+					actor.OutputHandler.Send("What positive output weight in grams should each head produce at full condition?");
+					return;
+				}
+
+				var tagName = string.Empty;
+				var remaining = ss.SafeRemainingArgument;
+				var tagIndex = remaining.LastIndexOf(" tag ", StringComparison.InvariantCultureIgnoreCase);
+				if (tagIndex >= 0)
+				{
+					tagName = remaining[(tagIndex + 5)..].Trim().Trim('"');
+					remaining = remaining[..tagIndex].Trim();
+				}
+
+				if (string.IsNullOrWhiteSpace(remaining))
+				{
+					actor.OutputHandler.Send("Which material should this secondary output use?");
+					return;
+				}
+
+				if (actor.Gameworld.Materials.GetByName(remaining) == null)
+				{
+					actor.OutputHandler.Send("There is no such material.");
+					return;
+				}
+
+				if (!string.IsNullOrWhiteSpace(tagName) && actor.Gameworld.Tags.GetByName(tagName) == null)
+				{
+					actor.OutputHandler.Send("There is no such tag.");
+					return;
+				}
+
+				herd.BuildingSetSecondaryOutputs(herd.SecondaryOutputs.Concat(new[]
+				{
+					new AgricultureCommodityYield(remaining, weight, tagName)
+				}));
+				actor.OutputHandler.Send($"You add {actor.Gameworld.UnitManager.DescribeMostSignificantExact(weight, MudSharp.Framework.Units.UnitType.Mass, actor).ColourValue()} of {remaining.ColourName()} per head to this herd's secondary outputs.");
+				return;
+		}
+
+		actor.OutputHandler.Send("Syntax: field herds set <herd> output clear|add <weight grams> <material> [tag <tag>]");
 	}
 
 	private static void DeleteHerdDefinition(ICharacter actor, StringStack ss)
@@ -1755,6 +1820,7 @@ Result Use: {operation.ResultUse.DescribeEnum().ColourName()}
 Project: {(operation.Project?.Name ?? "None").ColourName()}
 Completion Prog: {(operation.CompletionProg?.FunctionName ?? "None").ColourName()}
 Woodland Yield: x{operation.WoodlandYieldMultiplier.ToString("N2", actor).ColourValue()}, consumes {operation.WoodlandYieldCost.ToString("N0", actor).ColourValue()} yield
+Herd Yield: x{operation.HerdYieldMultiplier.ToString("N2", actor).ColourValue()}, consumes {operation.HerdYieldCost.ToString("N0", actor).ColourValue()} yield
 Apiary: install {operation.ApiaryInstallHiveCount.ToString("N0", actor).ColourValue()} hives, radius {operation.ApiaryPollinationRadius.ToString("N0", actor).ColourValue()}, tend {operation.ApiaryTendHealthDelta.ToString("N0", actor).ColourValue()}/{operation.ApiaryTendStoresDelta.ToString("N0", actor).ColourValue()}/{operation.ApiaryTendYieldDelta.ToString("N0", actor).ColourValue()}, harvest x{operation.ApiaryYieldMultiplier.ToString("N2", actor).ColourValue()} cost {operation.ApiaryYieldCost.ToString("N0", actor).ColourValue()} [{DescribeCommodityOutputs(operation.ApiaryYieldOutputs, actor)}]
 Deltas: {operation.ScoreDeltas.Where(x => x.Key.IsEnabledScore(actor.Gameworld)).OrderBy(x => x.Key).Select(x => $"{x.Key.DescribeFor(actor.Gameworld)} {x.Value.ToString("N0", actor)}").ListToString()}");
 	}
@@ -1809,7 +1875,7 @@ Deltas: {operation.ScoreDeltas.Where(x => x.Key.IsEnabledScore(actor.Gameworld))
 
 		if (ss.IsFinished)
 		{
-			actor.OutputHandler.Send("Do you want to set name, description, type, target, required, allowed, result, project, prog, delta, or woodlandyield?");
+			actor.OutputHandler.Send("Do you want to set name, description, type, target, required, allowed, result, project, prog, delta, woodlandyield, or herdyield?");
 			return;
 		}
 
@@ -1955,9 +2021,19 @@ Deltas: {operation.ScoreDeltas.Where(x => x.Key.IsEnabledScore(actor.Gameworld))
 				concrete.BuildingSetWoodlandYield(multiplier, cost);
 				actor.OutputHandler.Send($"You set woodland product output to x{concrete.WoodlandYieldMultiplier.ToString("N2", actor).ColourValue()} and yield cost to {concrete.WoodlandYieldCost.ToString("N0", actor).ColourValue()}.");
 				return;
+			case "herdyield":
+				if (ss.IsFinished || !double.TryParse(ss.PopSpeech(), out var herdMultiplier) || ss.IsFinished || !int.TryParse(ss.PopSpeech(), out var herdCost))
+				{
+					actor.OutputHandler.Send("You must specify a commodity multiplier and a 0-100 herd yield cost.");
+					return;
+				}
+
+				concrete.BuildingSetHerdYield(herdMultiplier, herdCost);
+				actor.OutputHandler.Send($"You set herd product output to x{concrete.HerdYieldMultiplier.ToString("N2", actor).ColourValue()} and yield cost to {concrete.HerdYieldCost.ToString("N0", actor).ColourValue()}.");
+				return;
 		}
 
-		actor.OutputHandler.Send("Do you want to set name, description, type, target, required, allowed, result, project, prog, delta, or woodlandyield?");
+		actor.OutputHandler.Send("Do you want to set name, description, type, target, required, allowed, result, project, prog, delta, woodlandyield, or herdyield?");
 	}
 
 	private static void DeleteOperation(ICharacter actor, StringStack ss)

--- a/MudSharpCore/Work/Agriculture/AgricultureCropDefinition.cs
+++ b/MudSharpCore/Work/Agriculture/AgricultureCropDefinition.cs
@@ -29,7 +29,9 @@ public class AgricultureCropDefinition : SaveableItem, IAgricultureCropDefinitio
 		int maximumTemperature, IEnumerable<AgricultureCommodityYield> yieldOutputs = null,
 		IEnumerable<AgricultureCommodityYield> seedRequirements = null, bool isPerennial = false,
 		int harvestCycleDays = 0, IEnumerable<AgricultureScoreRange> scoreRanges = null,
-		IEnumerable<AgriculturePlantingWindow> plantingWindows = null)
+		IEnumerable<AgriculturePlantingWindow> plantingWindows = null,
+		AgriculturePollinationDependency pollinationDependency = AgriculturePollinationDependency.None,
+		int pollinationHealthBonus = 0, int pollinationYieldBonus = 0)
 	{
 		Gameworld = gameworld;
 		_name = name;
@@ -41,6 +43,9 @@ public class AgricultureCropDefinition : SaveableItem, IAgricultureCropDefinitio
 		MaximumMoisture = maximumMoisture;
 		MinimumTemperature = minimumTemperature;
 		MaximumTemperature = maximumTemperature;
+		PollinationDependency = pollinationDependency;
+		PollinationHealthBonus = System.Math.Clamp(pollinationHealthBonus, 0, 1);
+		PollinationYieldBonus = System.Math.Clamp(pollinationYieldBonus, 0, 2);
 		IsPerennial = isPerennial;
 		HarvestCycleDays = System.Math.Clamp(harvestCycleDays <= 0 ? baseGrowthDays : harvestCycleDays, 1, 10000);
 		_yieldOutputs.AddRange(yieldOutputs ?? Enumerable.Empty<AgricultureCommodityYield>());
@@ -75,6 +80,9 @@ public class AgricultureCropDefinition : SaveableItem, IAgricultureCropDefinitio
 	public int MaximumMoisture { get; private set; }
 	public int MinimumTemperature { get; private set; }
 	public int MaximumTemperature { get; private set; }
+	public AgriculturePollinationDependency PollinationDependency { get; private set; }
+	public int PollinationHealthBonus { get; private set; }
+	public int PollinationYieldBonus { get; private set; }
 	public bool IsPerennial { get; private set; }
 	public int HarvestCycleDays { get; private set; }
 	public IReadOnlyCollection<AgriculturePlantingWindow> PlantingWindows => _plantingWindows;
@@ -148,6 +156,14 @@ public class AgricultureCropDefinition : SaveableItem, IAgricultureCropDefinitio
 		Changed = true;
 	}
 
+	public void BuildingSetPollination(AgriculturePollinationDependency dependency, int healthBonus, int yieldBonus)
+	{
+		PollinationDependency = dependency;
+		PollinationHealthBonus = dependency == AgriculturePollinationDependency.None ? 0 : System.Math.Clamp(healthBonus, 0, 1);
+		PollinationYieldBonus = dependency == AgriculturePollinationDependency.None ? 0 : System.Math.Clamp(yieldBonus, 0, 2);
+		Changed = true;
+	}
+
 	public void BuildingSetScoreRange(AgricultureScoreType score, int minimum, int maximum)
 	{
 		_scoreRanges[score] = new AgricultureScoreRange(score, minimum, maximum);
@@ -193,6 +209,19 @@ public class AgricultureCropDefinition : SaveableItem, IAgricultureCropDefinitio
 		MaximumMoisture = ((int?)root.Attribute("maxMoisture") ?? 85).ClampScore();
 		MinimumTemperature = (int?)root.Attribute("minTemperature") ?? 0;
 		MaximumTemperature = (int?)root.Attribute("maxTemperature") ?? 45;
+		var pollination = root.Element("Pollination");
+		PollinationDependency = System.Enum.TryParse<AgriculturePollinationDependency>(
+			(string)pollination?.Attribute("dependency") ?? nameof(AgriculturePollinationDependency.None),
+			true,
+			out var dependency)
+			? dependency
+			: AgriculturePollinationDependency.None;
+		PollinationHealthBonus = PollinationDependency == AgriculturePollinationDependency.None
+			? 0
+			: System.Math.Clamp((int?)pollination?.Attribute("healthBonus") ?? 0, 0, 1);
+		PollinationYieldBonus = PollinationDependency == AgriculturePollinationDependency.None
+			? 0
+			: System.Math.Clamp((int?)pollination?.Attribute("yieldBonus") ?? 0, 0, 2);
 		_plantingWindows.Clear();
 		foreach (var element in root.Element("PlantingWindows")?.Elements("Window") ?? Enumerable.Empty<XElement>())
 		{
@@ -246,6 +275,10 @@ public class AgricultureCropDefinition : SaveableItem, IAgricultureCropDefinitio
 			new XAttribute("maxMoisture", MaximumMoisture),
 			new XAttribute("minTemperature", MinimumTemperature),
 			new XAttribute("maxTemperature", MaximumTemperature),
+			new XElement("Pollination",
+				new XAttribute("dependency", PollinationDependency.ToString()),
+				new XAttribute("healthBonus", PollinationHealthBonus),
+				new XAttribute("yieldBonus", PollinationYieldBonus)),
 			new XElement("PlantingWindows",
 				_plantingWindows.Select(x => x.SaveToXml())),
 			new XElement("ScoreRanges",

--- a/MudSharpCore/Work/Agriculture/AgricultureField.cs
+++ b/MudSharpCore/Work/Agriculture/AgricultureField.cs
@@ -39,6 +39,7 @@ public class AgricultureField : SaveableItem, IAgricultureField
 	private int _woodlandGrowthDays;
 	private int _woodlandHealth;
 	private int _woodlandYieldPotential;
+	private AgricultureFieldApiary _apiary;
 
 	public AgricultureField(Models.AgricultureField field, IFuturemud gameworld)
 	{
@@ -116,6 +117,10 @@ public class AgricultureField : SaveableItem, IAgricultureField
 	public int WoodlandGrowthDays => _woodlandGrowthDays;
 	public int WoodlandHealth => _woodlandHealth;
 	public int WoodlandYieldPotential => _woodlandYieldPotential;
+	public IAgricultureFieldApiary Apiary => _apiary;
+	public bool HasActiveApiary => _apiary?.HiveCount > 0;
+	public bool IsApiaryHappy => IsApiaryHappyForPollination();
+	public int PollinationStrength => IsApiaryHappy ? _apiary.PollinationStrength : 0;
 
 	public IAgricultureCropDefinition CurrentCrop
 	{
@@ -184,6 +189,12 @@ public class AgricultureField : SaveableItem, IAgricultureField
 			{
 				_customScores[score.Key] = score.Value;
 			}
+		}
+
+		var apiaryRoot = fieldRoot.Element("Apiary");
+		if (apiaryRoot != null)
+		{
+			_apiary = AgricultureFieldApiary.LoadFromXml(apiaryRoot);
 		}
 
 		if (field.AgricultureFieldCrop != null)
@@ -325,6 +336,11 @@ public class AgricultureField : SaveableItem, IAgricultureField
 			}
 		}
 
+		if (_apiary != null)
+		{
+			sb.AppendLine($"Apiary: {_apiary.HiveCount.ToString("N0", voyeur).ColourValue()} hives, colony health {_apiary.ColonyHealth.ToStringN0Colour(voyeur)}, stores {_apiary.Stores.ToStringN0Colour(voyeur)}, yield {_apiary.YieldPotential.ToStringN0Colour(voyeur)}, pollination radius {_apiary.PollinationRadius.ToStringN0Colour(voyeur)}");
+		}
+
 		sb.AppendLine();
 		sb.AppendLine("Field State:");
 		foreach (var score in AgricultureScoreTypeExtensions.ActiveScoreTypes(Gameworld))
@@ -376,9 +392,29 @@ public class AgricultureField : SaveableItem, IAgricultureField
 			AdjustScore(AgricultureScoreType.Condition, -1);
 		}
 
+		TickApiary();
 		TickCrop();
 		TickHerds();
 		TickWoodland();
+	}
+
+	private void TickApiary()
+	{
+		if (_apiary == null)
+		{
+			return;
+		}
+
+		var temperature = Cell.CurrentTemperature(null);
+		var temperate = temperature >= 5.0 && temperature <= 40.0;
+		var wellSituated = Condition >= 40 && Pests <= 70 && temperate;
+		var healthDelta = wellSituated ? 1 : -3;
+		var storesDelta = temperate && _apiary.ColonyHealth >= 40
+			? Math.Max(1, _apiary.HiveCount * 2)
+			: -2;
+		var yieldDelta = IsApiaryHappyForPollination() ? 2 : (_apiary.ColonyHealth < 40 ? -1 : 0);
+		_apiary.Adjust(healthDelta, storesDelta, yieldDelta);
+		Changed = true;
 	}
 
 	private void TickCrop()
@@ -390,10 +426,15 @@ public class AgricultureField : SaveableItem, IAgricultureField
 		}
 
 		var temperature = Cell.CurrentTemperature(null);
+		var pollinationSupport = CurrentPollinationSupport(crop);
+		var lacksRequiredPollination = crop.PollinationDependency == AgriculturePollinationDependency.Required &&
+		                                CropStage == AgricultureCropStage.Setting &&
+		                                pollinationSupport <= 0;
 		var stressed = Moisture < crop.MinimumMoisture || Moisture > crop.MaximumMoisture ||
 		               temperature < crop.MinimumTemperature || temperature > crop.MaximumTemperature ||
 		               Weeds > 75 || Pests > 75 || Salinity > 80 ||
-		               crop.ScoreRanges.Any(x => x.Score.IsEnabledScore(Gameworld) && !x.Contains(Score(x.Score)));
+		               crop.ScoreRanges.Any(x => x.Score.IsEnabledScore(Gameworld) && !x.Contains(Score(x.Score))) ||
+		               lacksRequiredPollination;
 		if (stressed)
 		{
 			_cropHealth = (_cropHealth - 4).ClampScore();
@@ -403,6 +444,12 @@ public class AgricultureField : SaveableItem, IAgricultureField
 		{
 			_cropHealth = (_cropHealth + 1).ClampScore();
 			_cropYieldPotential = (_cropYieldPotential + Math.Sign(Nutrients - 50)).ClampScore();
+			if (pollinationSupport > 0)
+			{
+				_cropHealth = (_cropHealth + crop.PollinationHealthBonus).ClampScore();
+				_cropYieldPotential = (_cropYieldPotential + crop.PollinationYieldBonus).ClampScore();
+			}
+
 			_cropGrowthDays++;
 		}
 
@@ -439,6 +486,99 @@ public class AgricultureField : SaveableItem, IAgricultureField
 		}
 
 		Changed = true;
+	}
+
+	private int CurrentPollinationSupport(IAgricultureCropDefinition crop)
+	{
+		if (crop.PollinationDependency == AgriculturePollinationDependency.None ||
+		    CropStage is not (AgricultureCropStage.Growing or AgricultureCropStage.Setting))
+		{
+			return 0;
+		}
+
+		var best = 0;
+		foreach (var field in Gameworld.AgricultureFields)
+		{
+			if (field?.HasActiveApiary != true || !field.IsApiaryHappy || field.Apiary == null)
+			{
+				continue;
+			}
+
+			var distance = DistanceBetweenCells(Cell, field.Cell, field.Apiary.PollinationRadius);
+			if (distance < 0)
+			{
+				continue;
+			}
+
+			best = Math.Max(best, Math.Max(1, field.Apiary.PollinationStrength - distance * 15));
+		}
+
+		return best;
+	}
+
+	private static int DistanceBetweenCells(ICell origin, ICell destination, int maximumDistance)
+	{
+		if (origin == null || destination == null)
+		{
+			return -1;
+		}
+
+		if (origin.Id == destination.Id)
+		{
+			return 0;
+		}
+
+		if (maximumDistance <= 0)
+		{
+			return -1;
+		}
+
+		var seen = new HashSet<long> { origin.Id };
+		var queue = new Queue<(ICell Cell, int Distance)>();
+		queue.Enqueue((origin, 0));
+		while (queue.Count > 0)
+		{
+			var current = queue.Dequeue();
+			if (current.Distance >= maximumDistance)
+			{
+				continue;
+			}
+
+			foreach (var exit in current.Cell.ExitsFor(null, true))
+			{
+				var next = exit.Destination;
+				if (next == null || !seen.Add(next.Id))
+				{
+					continue;
+				}
+
+				var distance = current.Distance + 1;
+				if (next.Id == destination.Id)
+				{
+					return distance;
+				}
+
+				queue.Enqueue((next, distance));
+			}
+		}
+
+		return -1;
+	}
+
+	private bool IsApiaryHappyForPollination()
+	{
+		if (_apiary == null || _apiary.HiveCount <= 0)
+		{
+			return false;
+		}
+
+		var temperature = Cell.CurrentTemperature(null);
+		return _apiary.ColonyHealth >= 50 &&
+		       _apiary.Stores >= 25 &&
+		       Condition >= 40 &&
+		       Pests <= 70 &&
+		       temperature >= 5.0 &&
+		       temperature <= 40.0;
 	}
 
 	private void TickHerds()
@@ -625,6 +765,31 @@ public class AgricultureField : SaveableItem, IAgricultureField
 					CurrentUse = AgricultureFieldUse.Fallow;
 				}
 				break;
+			case AgricultureOperationType.InstallApiary:
+				_apiary = new AgricultureFieldApiary(
+					Math.Max(1, operation.ApiaryInstallHiveCount),
+					(Condition + outcome.CropHealthDelta).ClampScore(),
+					(35 + outcome.CropYieldDelta).ClampScore(),
+					(40 + outcome.CropYieldDelta).ClampScore(),
+					operation.ApiaryPollinationRadius <= 0 ? 2 : operation.ApiaryPollinationRadius);
+				result = $"The field has been fitted with an apiary installation of {_apiary.HiveCount.ToString("N0", actor)} hives.{outcome.DescribeEffect()}";
+				break;
+			case AgricultureOperationType.TendApiary:
+				_apiary.Adjust(operation.ApiaryTendHealthDelta + outcome.CropHealthDelta,
+					operation.ApiaryTendStoresDelta,
+					operation.ApiaryTendYieldDelta + outcome.CropYieldDelta);
+				result = $"The apiary has been tended. Colony health is now {_apiary.ColonyHealth.DescribeBand()}, stores are {_apiary.Stores.DescribeBand()}, and yield potential is {_apiary.YieldPotential.DescribeBand()}.{outcome.DescribeEffect()}";
+				break;
+			case AgricultureOperationType.HarvestApiary:
+				var apiaryOutputs = ReleaseCommodityOutputs(operation.ApiaryYieldOutputs, _apiary.ColonyHealth,
+					Math.Min(_apiary.Stores, _apiary.YieldPotential), operation.ApiaryYieldMultiplier, outcome);
+				_apiary.Adjust(0, -operation.ApiaryYieldCost, -operation.ApiaryYieldCost);
+				result = $"The apiary is harvested with an estimated stores quality of {_apiary.Stores.DescribeBand()}.{outcome.DescribeEffect()}{DescribeOutputResult(apiaryOutputs)}";
+				break;
+			case AgricultureOperationType.RemoveApiary:
+				_apiary = null;
+				result = $"The apiary installation has been removed from the field.{outcome.DescribeEffect()}";
+				break;
 			case AgricultureOperationType.Graze:
 			case AgricultureOperationType.Herd:
 				CurrentUse = AgricultureFieldUse.Pasture;
@@ -695,6 +860,12 @@ public class AgricultureField : SaveableItem, IAgricultureField
 		     CropStage is not (AgricultureCropStage.Harvestable or AgricultureCropStage.Overripe)))
 		{
 			return "There is no harvest-ready crop in this field.";
+		}
+
+		if (operation.OperationType == AgricultureOperationType.HarvestApiary &&
+		    (_apiary == null || _apiary.Stores <= 0 || _apiary.YieldPotential <= 0))
+		{
+			return "The apiary does not have harvestable stores.";
 		}
 
 		return string.Empty;
@@ -1112,6 +1283,7 @@ public class AgricultureField : SaveableItem, IAgricultureField
 	private XElement SaveFieldDefinition()
 	{
 		return new XElement("Field",
+			_apiary?.SaveToXml(),
 			new XElement("CustomScores",
 				_customScores
 					.Where(x => x.Key.IsCustomScore())
@@ -1142,6 +1314,13 @@ public class AgricultureField : SaveableItem, IAgricultureField
 			"woodland" => new TextVariable(CurrentWoodland?.Name ?? string.Empty),
 			"woodlandhealth" => new NumberVariable(_woodlandHealth),
 			"woodlandyield" => new NumberVariable(_woodlandYieldPotential),
+			"hasapiary" => new BooleanVariable(HasActiveApiary),
+			"apiaryhappy" => new BooleanVariable(IsApiaryHappy),
+			"apiaryhives" => new NumberVariable(_apiary?.HiveCount ?? 0),
+			"apiaryhealth" => new NumberVariable(_apiary?.ColonyHealth ?? 0),
+			"apiarystores" => new NumberVariable(_apiary?.Stores ?? 0),
+			"apiaryyield" => new NumberVariable(_apiary?.YieldPotential ?? 0),
+			"pollinationstrength" => new NumberVariable(PollinationStrength),
 			"moisture" => new NumberVariable(Moisture),
 			"drainage" => new NumberVariable(Drainage),
 			"nutrients" => new NumberVariable(Nutrients),
@@ -1175,6 +1354,13 @@ public class AgricultureField : SaveableItem, IAgricultureField
 			{ "woodland", ProgVariableTypes.Text },
 			{ "woodlandhealth", ProgVariableTypes.Number },
 			{ "woodlandyield", ProgVariableTypes.Number },
+			{ "hasapiary", ProgVariableTypes.Boolean },
+			{ "apiaryhappy", ProgVariableTypes.Boolean },
+			{ "apiaryhives", ProgVariableTypes.Number },
+			{ "apiaryhealth", ProgVariableTypes.Number },
+			{ "apiarystores", ProgVariableTypes.Number },
+			{ "apiaryyield", ProgVariableTypes.Number },
+			{ "pollinationstrength", ProgVariableTypes.Number },
 			{ "moisture", ProgVariableTypes.Number },
 			{ "drainage", ProgVariableTypes.Number },
 			{ "nutrients", ProgVariableTypes.Number },

--- a/MudSharpCore/Work/Agriculture/AgricultureField.cs
+++ b/MudSharpCore/Work/Agriculture/AgricultureField.cs
@@ -221,7 +221,10 @@ public class AgricultureField : SaveableItem, IAgricultureField
 			var definition = Gameworld.AgricultureHerdDefinitions.Get(herd.HerdDefinitionId);
 			if (definition != null)
 			{
-				_herds.Add(new AgricultureFieldHerd(herd.Id, definition, herd.HeadCount, herd.Condition));
+				var herdRoot = AgricultureXmlExtensions.RootOrDefault(herd.Definition, "Herd");
+				var secondaryYieldPotential = ((int?)herdRoot.Attribute("secondaryYield") ?? 0).ClampScore();
+				_herds.Add(new AgricultureFieldHerd(herd.Id, definition, herd.HeadCount, herd.Condition,
+					secondaryYieldPotential));
 			}
 		}
 	}
@@ -332,7 +335,7 @@ public class AgricultureField : SaveableItem, IAgricultureField
 			sb.AppendLine("Herds:");
 			foreach (var herd in _herds)
 			{
-				sb.AppendLine($"\t{herd.Definition.Name.ColourName()} - {herd.HeadCount.ToString("N0", voyeur).ColourValue()} head, condition {herd.Condition.ToString("N0", voyeur).ColourValue()}");
+				sb.AppendLine($"\t{herd.Definition.Name.ColourName()} - {herd.HeadCount.ToString("N0", voyeur).ColourValue()} head, condition {herd.Condition.ToString("N0", voyeur).ColourValue()}, secondary yield {herd.SecondaryYieldPotential.ToStringN0Colour(voyeur)}");
 			}
 		}
 
@@ -601,6 +604,11 @@ public class AgricultureField : SaveableItem, IAgricultureField
 			foreach (var herd in _herds)
 			{
 				herd.Condition = Math.Min(herd.Definition.MaximumCondition, herd.Condition + 1.0);
+				if (herd.HeadCount > 0 && herd.Definition.SecondaryOutputs.Count > 0 && herd.Condition >= 35.0)
+				{
+					var yieldDelta = Math.Max(1, (int)Math.Ceiling(herd.Condition / 25.0));
+					herd.SecondaryYieldPotential = (herd.SecondaryYieldPotential + yieldDelta).ClampScore();
+				}
 			}
 		}
 		else
@@ -613,6 +621,7 @@ public class AgricultureField : SaveableItem, IAgricultureField
 			foreach (var herd in _herds)
 			{
 				herd.Condition = Math.Max(0.0, herd.Condition - 3.0);
+				herd.SecondaryYieldPotential = (herd.SecondaryYieldPotential - 8).ClampScore();
 			}
 		}
 
@@ -790,6 +799,12 @@ public class AgricultureField : SaveableItem, IAgricultureField
 				_apiary = null;
 				result = $"The apiary installation has been removed from the field.{outcome.DescribeEffect()}";
 				break;
+			case AgricultureOperationType.HarvestHerdProducts:
+				var herdTarget = (IAgricultureHerdDefinition)target;
+				var herdOutputs = ReleaseHerdOutputs(operation, herdTarget, outcome);
+				var harvestedHerd = _herds.First(x => x.Definition.Id == herdTarget.Id);
+				result = $"The {harvestedHerd.Definition.Name} herd products are collected with an estimated condition of {((int)Math.Round(harvestedHerd.Condition)).DescribeBand()}.{outcome.DescribeEffect()}{DescribeOutputResult(herdOutputs)}";
+				break;
 			case AgricultureOperationType.Graze:
 			case AgricultureOperationType.Herd:
 				CurrentUse = AgricultureFieldUse.Pasture;
@@ -868,6 +883,16 @@ public class AgricultureField : SaveableItem, IAgricultureField
 			return "The apiary does not have harvestable stores.";
 		}
 
+		if (operation.OperationType == AgricultureOperationType.HarvestHerdProducts &&
+		    target is IAgricultureHerdDefinition herdDefinition)
+		{
+			var herd = _herds.FirstOrDefault(x => x.Definition.Id == herdDefinition.Id);
+			if (herd == null || herd.SecondaryYieldPotential <= 0)
+			{
+				return "That herd does not have any secondary products ready to collect.";
+			}
+		}
+
 		return string.Empty;
 	}
 
@@ -892,6 +917,35 @@ public class AgricultureField : SaveableItem, IAgricultureField
 		if (operation.WoodlandYieldCost > 0)
 		{
 			_woodlandYieldPotential = (_woodlandYieldPotential - Math.Min(_woodlandYieldPotential, operation.WoodlandYieldCost)).ClampScore();
+		}
+
+		return outputs;
+	}
+
+	private IReadOnlyList<IGameItem> ReleaseHerdOutputs(IAgricultureOperation operation,
+		IAgricultureHerdDefinition definition, AgricultureWorkOutcome outcome)
+	{
+		if (operation.HerdYieldMultiplier <= 0.0 || definition == null)
+		{
+			return Array.Empty<IGameItem>();
+		}
+
+		var herd = _herds.FirstOrDefault(x => x.Definition.Id == definition.Id);
+		if (herd == null || herd.HeadCount <= 0 || herd.SecondaryYieldPotential <= 0)
+		{
+			return Array.Empty<IGameItem>();
+		}
+
+		var perHerdOutputs = herd.Definition.SecondaryOutputs
+		                         .Select(x => new AgricultureCommodityYield(x.MaterialName,
+			                         x.BaseWeight * herd.HeadCount, x.TagName))
+		                         .ToList();
+		var outputs = ReleaseCommodityOutputs(perHerdOutputs, (int)Math.Round(herd.Condition),
+			herd.SecondaryYieldPotential, operation.HerdYieldMultiplier, outcome);
+		if (operation.HerdYieldCost > 0)
+		{
+			herd.SecondaryYieldPotential = (herd.SecondaryYieldPotential -
+			                                Math.Min(herd.SecondaryYieldPotential, operation.HerdYieldCost)).ClampScore();
 		}
 
 		return outputs;
@@ -1259,7 +1313,8 @@ public class AgricultureField : SaveableItem, IAgricultureField
 				HerdDefinitionId = herd.Definition.Id,
 				HeadCount = herd.HeadCount,
 				Condition = herd.Condition,
-				Definition = "<Herd />"
+				Definition = new XElement("Herd",
+					new XAttribute("secondaryYield", herd.SecondaryYieldPotential)).ToString()
 			});
 		}
 

--- a/MudSharpCore/Work/Agriculture/AgricultureFieldApiary.cs
+++ b/MudSharpCore/Work/Agriculture/AgricultureFieldApiary.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Xml.Linq;
+
+namespace MudSharp.Work.Agriculture;
+
+internal sealed class AgricultureFieldApiary : IAgricultureFieldApiary
+{
+	public AgricultureFieldApiary(int hiveCount, int colonyHealth, int stores, int yieldPotential, int pollinationRadius)
+	{
+		HiveCount = Math.Max(0, hiveCount);
+		ColonyHealth = colonyHealth.ClampScore();
+		Stores = stores.ClampScore();
+		YieldPotential = yieldPotential.ClampScore();
+		PollinationRadius = Math.Max(0, pollinationRadius);
+	}
+
+	public int HiveCount { get; private set; }
+	public int ColonyHealth { get; private set; }
+	public int Stores { get; private set; }
+	public int YieldPotential { get; private set; }
+	public int PollinationRadius { get; private set; }
+	public int PollinationStrength => HiveCount <= 0
+		? 0
+		: Math.Clamp((ColonyHealth + Stores + YieldPotential) / 3 + Math.Max(0, HiveCount - 1) * 5, 0, 100);
+
+	public void Adjust(int healthDelta, int storesDelta, int yieldDelta)
+	{
+		ColonyHealth = (ColonyHealth + healthDelta).ClampScore();
+		Stores = (Stores + storesDelta).ClampScore();
+		YieldPotential = (YieldPotential + yieldDelta).ClampScore();
+	}
+
+	public XElement SaveToXml()
+	{
+		return new XElement("Apiary",
+			new XAttribute("hives", HiveCount),
+			new XAttribute("health", ColonyHealth),
+			new XAttribute("stores", Stores),
+			new XAttribute("yield", YieldPotential),
+			new XAttribute("radius", PollinationRadius));
+	}
+
+	public static AgricultureFieldApiary LoadFromXml(XElement root)
+	{
+		return new AgricultureFieldApiary(
+			(int?)root.Attribute("hives") ?? 0,
+			(int?)root.Attribute("health") ?? 50,
+			(int?)root.Attribute("stores") ?? 0,
+			(int?)root.Attribute("yield") ?? 0,
+			(int?)root.Attribute("radius") ?? 2);
+	}
+}

--- a/MudSharpCore/Work/Agriculture/AgricultureFieldHerd.cs
+++ b/MudSharpCore/Work/Agriculture/AgricultureFieldHerd.cs
@@ -4,17 +4,20 @@ namespace MudSharp.Work.Agriculture;
 
 public class AgricultureFieldHerd : FrameworkItem, IAgricultureFieldHerd
 {
-	public AgricultureFieldHerd(long id, IAgricultureHerdDefinition definition, int headCount, double condition)
+	public AgricultureFieldHerd(long id, IAgricultureHerdDefinition definition, int headCount, double condition,
+		int secondaryYieldPotential = 0)
 	{
 		_id = id;
 		_name = definition?.Name ?? "Unknown Herd";
 		Definition = definition;
 		HeadCount = headCount;
 		Condition = condition;
+		SecondaryYieldPotential = secondaryYieldPotential.ClampScore();
 	}
 
 	public override string FrameworkItemType => "AgricultureFieldHerd";
 	public IAgricultureHerdDefinition Definition { get; }
 	public int HeadCount { get; internal set; }
 	public double Condition { get; internal set; }
+	public int SecondaryYieldPotential { get; internal set; }
 }

--- a/MudSharpCore/Work/Agriculture/AgricultureHerdDefinition.cs
+++ b/MudSharpCore/Work/Agriculture/AgricultureHerdDefinition.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Xml.Linq;
 using MudSharp.Database;
 using MudSharp.Framework;
@@ -8,6 +10,7 @@ namespace MudSharp.Work.Agriculture;
 
 public class AgricultureHerdDefinition : SaveableItem, IAgricultureHerdDefinition
 {
+	private readonly List<AgricultureCommodityYield> _secondaryOutputs = new();
 	private long _npcTemplateId;
 	private int _npcTemplateRevisionNumber;
 	private INPCTemplate _npcTemplate;
@@ -24,7 +27,8 @@ public class AgricultureHerdDefinition : SaveableItem, IAgricultureHerdDefinitio
 	}
 
 	public AgricultureHerdDefinition(IFuturemud gameworld, string name, string description, INPCTemplate npcTemplate,
-		double animalUnits, double dailyGraze, int maximumCondition)
+		double animalUnits, double dailyGraze, int maximumCondition,
+		IEnumerable<AgricultureCommodityYield> secondaryOutputs = null)
 	{
 		Gameworld = gameworld;
 		_name = name;
@@ -35,6 +39,7 @@ public class AgricultureHerdDefinition : SaveableItem, IAgricultureHerdDefinitio
 		AnimalUnits = animalUnits;
 		DailyGraze = dailyGraze;
 		MaximumCondition = maximumCondition;
+		_secondaryOutputs.AddRange(secondaryOutputs ?? Enumerable.Empty<AgricultureCommodityYield>());
 		using (new FMDB())
 		{
 			var dbitem = new Models.AgricultureHerdDefinition
@@ -56,6 +61,7 @@ public class AgricultureHerdDefinition : SaveableItem, IAgricultureHerdDefinitio
 	public double AnimalUnits { get; private set; }
 	public double DailyGraze { get; private set; }
 	public int MaximumCondition { get; private set; }
+	public IReadOnlyCollection<AgricultureCommodityYield> SecondaryOutputs => _secondaryOutputs;
 
 	public void BuildingSetName(string name)
 	{
@@ -84,6 +90,13 @@ public class AgricultureHerdDefinition : SaveableItem, IAgricultureHerdDefinitio
 	public void BuildingSetMaximumCondition(int value)
 	{
 		MaximumCondition = value.ClampScore();
+		Changed = true;
+	}
+
+	public void BuildingSetSecondaryOutputs(IEnumerable<AgricultureCommodityYield> outputs)
+	{
+		_secondaryOutputs.Clear();
+		_secondaryOutputs.AddRange(outputs ?? Enumerable.Empty<AgricultureCommodityYield>());
 		Changed = true;
 	}
 
@@ -118,6 +131,19 @@ public class AgricultureHerdDefinition : SaveableItem, IAgricultureHerdDefinitio
 		AnimalUnits = (double?)root.Attribute("animalUnits") ?? 1.0;
 		DailyGraze = (double?)root.Attribute("dailyGraze") ?? 1.0;
 		MaximumCondition = ((int?)root.Attribute("maximumCondition") ?? 100).ClampScore();
+		_secondaryOutputs.Clear();
+		foreach (var element in root.Element("SecondaryOutputs")?.Elements("Commodity") ?? Enumerable.Empty<XElement>())
+		{
+			var material = (string)element.Attribute("material");
+			var weight = (double?)element.Attribute("weight") ?? 0.0;
+			if (string.IsNullOrWhiteSpace(material) || weight <= 0.0)
+			{
+				continue;
+			}
+
+			_secondaryOutputs.Add(new AgricultureCommodityYield(material, weight,
+				(string)element.Attribute("tag") ?? string.Empty));
+		}
 	}
 
 	private XElement SaveDefinition()
@@ -125,7 +151,12 @@ public class AgricultureHerdDefinition : SaveableItem, IAgricultureHerdDefinitio
 		return new XElement("Herd",
 			new XAttribute("animalUnits", AnimalUnits),
 			new XAttribute("dailyGraze", DailyGraze),
-			new XAttribute("maximumCondition", MaximumCondition));
+			new XAttribute("maximumCondition", MaximumCondition),
+			new XElement("SecondaryOutputs",
+				_secondaryOutputs.Select(x => new XElement("Commodity",
+					new XAttribute("material", x.MaterialName),
+					new XAttribute("weight", x.BaseWeight),
+					string.IsNullOrWhiteSpace(x.TagName) ? null : new XAttribute("tag", x.TagName)))));
 	}
 
 	public override void Save()

--- a/MudSharpCore/Work/Agriculture/AgricultureOperation.cs
+++ b/MudSharpCore/Work/Agriculture/AgricultureOperation.cs
@@ -41,6 +41,7 @@ public class AgricultureOperation : SaveableItem, IAgricultureOperation
 		AgricultureOperationType operationType, AgricultureTargetType targetType, AgricultureFieldUse requiredUse,
 		AgricultureFieldUse resultUse, IProject project, IReadOnlyDictionary<AgricultureScoreType, int> deltas,
 		double woodlandYieldMultiplier = 0.0, int woodlandYieldCost = 0,
+		double herdYieldMultiplier = 0.0, int herdYieldCost = 0,
 		IEnumerable<AgricultureFieldUse> allowedUses = null, int apiaryInstallHiveCount = 0,
 		int apiaryPollinationRadius = 0, int apiaryTendHealthDelta = 0, int apiaryTendStoresDelta = 0,
 		int apiaryTendYieldDelta = 0, double apiaryYieldMultiplier = 0.0, int apiaryYieldCost = 0,
@@ -63,6 +64,8 @@ public class AgricultureOperation : SaveableItem, IAgricultureOperation
 		_projectRevisionNumber = project?.RevisionNumber ?? 0;
 		WoodlandYieldMultiplier = Math.Max(0.0, woodlandYieldMultiplier);
 		WoodlandYieldCost = System.Math.Clamp(woodlandYieldCost, 0, 100);
+		HerdYieldMultiplier = Math.Max(0.0, herdYieldMultiplier);
+		HerdYieldCost = System.Math.Clamp(herdYieldCost, 0, 100);
 		ApiaryInstallHiveCount = Math.Max(0, apiaryInstallHiveCount);
 		ApiaryPollinationRadius = Math.Max(0, apiaryPollinationRadius);
 		ApiaryTendHealthDelta = apiaryTendHealthDelta;
@@ -107,6 +110,8 @@ public class AgricultureOperation : SaveableItem, IAgricultureOperation
 	public IReadOnlyDictionary<AgricultureScoreType, int> ScoreDeltas => _scoreDeltas;
 	public double WoodlandYieldMultiplier { get; private set; }
 	public int WoodlandYieldCost { get; private set; }
+	public double HerdYieldMultiplier { get; private set; }
+	public int HerdYieldCost { get; private set; }
 	public int ApiaryInstallHiveCount { get; private set; }
 	public int ApiaryPollinationRadius { get; private set; }
 	public int ApiaryTendHealthDelta { get; private set; }
@@ -179,6 +184,13 @@ public class AgricultureOperation : SaveableItem, IAgricultureOperation
 	{
 		WoodlandYieldMultiplier = Math.Max(0.0, multiplier);
 		WoodlandYieldCost = System.Math.Clamp(cost, 0, 100);
+		Changed = true;
+	}
+
+	public void BuildingSetHerdYield(double multiplier, int cost)
+	{
+		HerdYieldMultiplier = Math.Max(0.0, multiplier);
+		HerdYieldCost = System.Math.Clamp(cost, 0, 100);
 		Changed = true;
 	}
 
@@ -310,6 +322,29 @@ public class AgricultureOperation : SaveableItem, IAgricultureOperation
 				}
 
 				break;
+			case AgricultureOperationType.HarvestHerdProducts:
+				if (target is not IAgricultureHerdDefinition herdDefinition)
+				{
+					return "This operation needs a herd target.";
+				}
+
+				if (herdDefinition.SecondaryOutputs.Count == 0)
+				{
+					return "That herd definition does not have any secondary products configured.";
+				}
+
+				var herd = field.Herds.FirstOrDefault(x => x.Definition.Id == herdDefinition.Id);
+				if (herd == null || herd.HeadCount <= 0)
+				{
+					return "There are no animals of that herd in this field.";
+				}
+
+				if (herd.SecondaryYieldPotential <= 0)
+				{
+					return "That herd does not have any secondary products ready to collect.";
+				}
+
+				break;
 		}
 
 		if (TargetType == AgricultureTargetType.None)
@@ -356,6 +391,8 @@ public class AgricultureOperation : SaveableItem, IAgricultureOperation
 		var root = AgricultureXmlExtensions.RootOrDefault(definition, "Operation");
 		WoodlandYieldMultiplier = Math.Max(0.0, (double?)root.Attribute("woodlandYieldMultiplier") ?? 0.0);
 		WoodlandYieldCost = System.Math.Clamp((int?)root.Attribute("woodlandYieldCost") ?? 0, 0, 100);
+		HerdYieldMultiplier = Math.Max(0.0, (double?)root.Attribute("herdYieldMultiplier") ?? 0.0);
+		HerdYieldCost = System.Math.Clamp((int?)root.Attribute("herdYieldCost") ?? 0, 0, 100);
 		_allowedUses.Clear();
 		var allowedRoot = root.Element("AllowedUses");
 		foreach (var use in allowedRoot?.LoadUses(defaultAll: false) ?? Enumerable.Empty<AgricultureFieldUse>())
@@ -405,6 +442,8 @@ public class AgricultureOperation : SaveableItem, IAgricultureOperation
 		return new XElement("Operation",
 			new XAttribute("woodlandYieldMultiplier", WoodlandYieldMultiplier),
 			new XAttribute("woodlandYieldCost", WoodlandYieldCost),
+			new XAttribute("herdYieldMultiplier", HerdYieldMultiplier),
+			new XAttribute("herdYieldCost", HerdYieldCost),
 			new XElement("AllowedUses",
 				new XAttribute("uses", _allowedUses.OrderBy(x => (int)x).Select(x => x.ToString()).ListToCommaSeparatedValues())),
 			new XElement("Apiary",

--- a/MudSharpCore/Work/Agriculture/AgricultureOperation.cs
+++ b/MudSharpCore/Work/Agriculture/AgricultureOperation.cs
@@ -13,6 +13,8 @@ namespace MudSharp.Work.Agriculture;
 public class AgricultureOperation : SaveableItem, IAgricultureOperation
 {
 	private readonly Dictionary<AgricultureScoreType, int> _scoreDeltas = new();
+	private readonly HashSet<AgricultureFieldUse> _allowedUses = new();
+	private readonly List<AgricultureCommodityYield> _apiaryYieldOutputs = new();
 	private long _projectId;
 	private int _projectRevisionNumber;
 	private IProject _project;
@@ -38,7 +40,11 @@ public class AgricultureOperation : SaveableItem, IAgricultureOperation
 	public AgricultureOperation(IFuturemud gameworld, string name, string description,
 		AgricultureOperationType operationType, AgricultureTargetType targetType, AgricultureFieldUse requiredUse,
 		AgricultureFieldUse resultUse, IProject project, IReadOnlyDictionary<AgricultureScoreType, int> deltas,
-		double woodlandYieldMultiplier = 0.0, int woodlandYieldCost = 0)
+		double woodlandYieldMultiplier = 0.0, int woodlandYieldCost = 0,
+		IEnumerable<AgricultureFieldUse> allowedUses = null, int apiaryInstallHiveCount = 0,
+		int apiaryPollinationRadius = 0, int apiaryTendHealthDelta = 0, int apiaryTendStoresDelta = 0,
+		int apiaryTendYieldDelta = 0, double apiaryYieldMultiplier = 0.0, int apiaryYieldCost = 0,
+		IEnumerable<AgricultureCommodityYield> apiaryYieldOutputs = null)
 	{
 		Gameworld = gameworld;
 		_name = name;
@@ -47,11 +53,24 @@ public class AgricultureOperation : SaveableItem, IAgricultureOperation
 		TargetType = targetType;
 		RequiredUse = requiredUse;
 		ResultUse = resultUse;
+		foreach (var use in allowedUses ?? new[] { requiredUse })
+		{
+			_allowedUses.Add(use);
+		}
+
 		_project = project;
 		_projectId = project?.Id ?? 0;
 		_projectRevisionNumber = project?.RevisionNumber ?? 0;
 		WoodlandYieldMultiplier = Math.Max(0.0, woodlandYieldMultiplier);
 		WoodlandYieldCost = System.Math.Clamp(woodlandYieldCost, 0, 100);
+		ApiaryInstallHiveCount = Math.Max(0, apiaryInstallHiveCount);
+		ApiaryPollinationRadius = Math.Max(0, apiaryPollinationRadius);
+		ApiaryTendHealthDelta = apiaryTendHealthDelta;
+		ApiaryTendStoresDelta = apiaryTendStoresDelta;
+		ApiaryTendYieldDelta = apiaryTendYieldDelta;
+		ApiaryYieldMultiplier = Math.Max(0.0, apiaryYieldMultiplier);
+		ApiaryYieldCost = System.Math.Clamp(apiaryYieldCost, 0, 100);
+		_apiaryYieldOutputs.AddRange(apiaryYieldOutputs ?? Enumerable.Empty<AgricultureCommodityYield>());
 		foreach (var delta in deltas)
 		{
 			_scoreDeltas[delta.Key] = delta.Value;
@@ -84,9 +103,18 @@ public class AgricultureOperation : SaveableItem, IAgricultureOperation
 	public AgricultureTargetType TargetType { get; private set; }
 	public AgricultureFieldUse RequiredUse { get; private set; }
 	public AgricultureFieldUse ResultUse { get; private set; }
+	public IReadOnlyCollection<AgricultureFieldUse> AllowedUses => _allowedUses;
 	public IReadOnlyDictionary<AgricultureScoreType, int> ScoreDeltas => _scoreDeltas;
 	public double WoodlandYieldMultiplier { get; private set; }
 	public int WoodlandYieldCost { get; private set; }
+	public int ApiaryInstallHiveCount { get; private set; }
+	public int ApiaryPollinationRadius { get; private set; }
+	public int ApiaryTendHealthDelta { get; private set; }
+	public int ApiaryTendStoresDelta { get; private set; }
+	public int ApiaryTendYieldDelta { get; private set; }
+	public double ApiaryYieldMultiplier { get; private set; }
+	public int ApiaryYieldCost { get; private set; }
+	public IReadOnlyCollection<AgricultureCommodityYield> ApiaryYieldOutputs => _apiaryYieldOutputs;
 
 	public void BuildingSetName(string name)
 	{
@@ -115,6 +143,8 @@ public class AgricultureOperation : SaveableItem, IAgricultureOperation
 	public void BuildingSetRequiredUse(AgricultureFieldUse use)
 	{
 		RequiredUse = use;
+		_allowedUses.Clear();
+		_allowedUses.Add(use);
 		Changed = true;
 	}
 
@@ -149,6 +179,49 @@ public class AgricultureOperation : SaveableItem, IAgricultureOperation
 	{
 		WoodlandYieldMultiplier = Math.Max(0.0, multiplier);
 		WoodlandYieldCost = System.Math.Clamp(cost, 0, 100);
+		Changed = true;
+	}
+
+	public void BuildingSetAllowedUse(AgricultureFieldUse use, bool allowed)
+	{
+		if (allowed)
+		{
+			_allowedUses.Add(use);
+		}
+		else
+		{
+			_allowedUses.Remove(use);
+		}
+
+		if (!_allowedUses.Any())
+		{
+			_allowedUses.Add(RequiredUse);
+		}
+
+		Changed = true;
+	}
+
+	public void BuildingSetApiaryInstallation(int hiveCount, int pollinationRadius)
+	{
+		ApiaryInstallHiveCount = Math.Max(0, hiveCount);
+		ApiaryPollinationRadius = Math.Max(0, pollinationRadius);
+		Changed = true;
+	}
+
+	public void BuildingSetApiaryTending(int healthDelta, int storesDelta, int yieldDelta)
+	{
+		ApiaryTendHealthDelta = healthDelta;
+		ApiaryTendStoresDelta = storesDelta;
+		ApiaryTendYieldDelta = yieldDelta;
+		Changed = true;
+	}
+
+	public void BuildingSetApiaryYield(double multiplier, int cost, IEnumerable<AgricultureCommodityYield> outputs)
+	{
+		ApiaryYieldMultiplier = Math.Max(0.0, multiplier);
+		ApiaryYieldCost = System.Math.Clamp(cost, 0, 100);
+		_apiaryYieldOutputs.Clear();
+		_apiaryYieldOutputs.AddRange(outputs ?? Enumerable.Empty<AgricultureCommodityYield>());
 		Changed = true;
 	}
 
@@ -192,9 +265,13 @@ public class AgricultureOperation : SaveableItem, IAgricultureOperation
 			return "There is no field to apply this operation to.";
 		}
 
-		if (RequiredUse != field.CurrentUse)
+		if (!(_allowedUses.Any() ? _allowedUses : new HashSet<AgricultureFieldUse> { RequiredUse }).Contains(field.CurrentUse))
 		{
-			return $"This operation can only be used on {RequiredUse.DescribeEnum().ToLowerInvariant()} fields.";
+			var uses = (_allowedUses.Any() ? _allowedUses : new HashSet<AgricultureFieldUse> { RequiredUse })
+			           .OrderBy(x => (int)x)
+			           .Select(x => x.DescribeEnum().ToLowerInvariant())
+			           .ListToString();
+			return $"This operation can only be used on {uses} fields.";
 		}
 
 		if (OperationType == AgricultureOperationType.Harvest &&
@@ -202,6 +279,37 @@ public class AgricultureOperation : SaveableItem, IAgricultureOperation
 		     field.CropStage is not (AgricultureCropStage.Harvestable or AgricultureCropStage.Overripe)))
 		{
 			return "There is no harvest-ready crop in this field.";
+		}
+
+		switch (OperationType)
+		{
+			case AgricultureOperationType.InstallApiary:
+				if (field.HasActiveApiary)
+				{
+					return "This field already has an apiary installation.";
+				}
+
+				break;
+			case AgricultureOperationType.TendApiary:
+			case AgricultureOperationType.RemoveApiary:
+				if (!field.HasActiveApiary)
+				{
+					return "This field does not have an apiary installation.";
+				}
+
+				break;
+			case AgricultureOperationType.HarvestApiary:
+				if (!field.HasActiveApiary)
+				{
+					return "This field does not have an apiary installation.";
+				}
+
+				if (field.Apiary.Stores <= 0 || field.Apiary.YieldPotential <= 0)
+				{
+					return "The apiary does not have harvestable stores.";
+				}
+
+				break;
 		}
 
 		if (TargetType == AgricultureTargetType.None)
@@ -248,6 +356,39 @@ public class AgricultureOperation : SaveableItem, IAgricultureOperation
 		var root = AgricultureXmlExtensions.RootOrDefault(definition, "Operation");
 		WoodlandYieldMultiplier = Math.Max(0.0, (double?)root.Attribute("woodlandYieldMultiplier") ?? 0.0);
 		WoodlandYieldCost = System.Math.Clamp((int?)root.Attribute("woodlandYieldCost") ?? 0, 0, 100);
+		_allowedUses.Clear();
+		var allowedRoot = root.Element("AllowedUses");
+		foreach (var use in allowedRoot?.LoadUses(defaultAll: false) ?? Enumerable.Empty<AgricultureFieldUse>())
+		{
+			_allowedUses.Add(use);
+		}
+
+		if (!_allowedUses.Any())
+		{
+			_allowedUses.Add(RequiredUse);
+		}
+
+		var apiaryRoot = root.Element("Apiary");
+		ApiaryInstallHiveCount = Math.Max(0, (int?)apiaryRoot?.Attribute("installHives") ?? 0);
+		ApiaryPollinationRadius = Math.Max(0, (int?)apiaryRoot?.Attribute("pollinationRadius") ?? 0);
+		ApiaryTendHealthDelta = (int?)apiaryRoot?.Attribute("tendHealthDelta") ?? 0;
+		ApiaryTendStoresDelta = (int?)apiaryRoot?.Attribute("tendStoresDelta") ?? 0;
+		ApiaryTendYieldDelta = (int?)apiaryRoot?.Attribute("tendYieldDelta") ?? 0;
+		ApiaryYieldMultiplier = Math.Max(0.0, (double?)apiaryRoot?.Attribute("yieldMultiplier") ?? 0.0);
+		ApiaryYieldCost = System.Math.Clamp((int?)apiaryRoot?.Attribute("yieldCost") ?? 0, 0, 100);
+		_apiaryYieldOutputs.Clear();
+		foreach (var element in apiaryRoot?.Element("Outputs")?.Elements("Commodity") ?? Enumerable.Empty<XElement>())
+		{
+			var material = (string)element.Attribute("material");
+			var weight = (double?)element.Attribute("weight") ?? 0.0;
+			if (string.IsNullOrWhiteSpace(material) || weight <= 0.0)
+			{
+				continue;
+			}
+
+			_apiaryYieldOutputs.Add(new AgricultureCommodityYield(material, weight, (string)element.Attribute("tag") ?? string.Empty));
+		}
+
 		foreach (var element in root.Elements("Score"))
 		{
 			if (!AgricultureScoreTypeExtensions.TryParseScoreType((string)element.Attribute("type"), Gameworld, out var type, true))
@@ -264,6 +405,21 @@ public class AgricultureOperation : SaveableItem, IAgricultureOperation
 		return new XElement("Operation",
 			new XAttribute("woodlandYieldMultiplier", WoodlandYieldMultiplier),
 			new XAttribute("woodlandYieldCost", WoodlandYieldCost),
+			new XElement("AllowedUses",
+				new XAttribute("uses", _allowedUses.OrderBy(x => (int)x).Select(x => x.ToString()).ListToCommaSeparatedValues())),
+			new XElement("Apiary",
+				new XAttribute("installHives", ApiaryInstallHiveCount),
+				new XAttribute("pollinationRadius", ApiaryPollinationRadius),
+				new XAttribute("tendHealthDelta", ApiaryTendHealthDelta),
+				new XAttribute("tendStoresDelta", ApiaryTendStoresDelta),
+				new XAttribute("tendYieldDelta", ApiaryTendYieldDelta),
+				new XAttribute("yieldMultiplier", ApiaryYieldMultiplier),
+				new XAttribute("yieldCost", ApiaryYieldCost),
+				new XElement("Outputs",
+					_apiaryYieldOutputs.Select(x => new XElement("Commodity",
+						new XAttribute("material", x.MaterialName),
+						new XAttribute("weight", x.BaseWeight),
+						string.IsNullOrWhiteSpace(x.TagName) ? null : new XAttribute("tag", x.TagName))))),
 			_scoreDeltas.Select(x => new XElement("Score",
 				new XAttribute("type", x.Key.ToString()),
 				new XAttribute("value", x.Value))));

--- a/MudSharpCore/Work/Agriculture/AgricultureXmlExtensions.cs
+++ b/MudSharpCore/Work/Agriculture/AgricultureXmlExtensions.cs
@@ -51,7 +51,7 @@ internal static class AgricultureXmlExtensions
 				new XAttribute("value", Math.Clamp(x.Value, 0, 100)))));
 	}
 
-	public static HashSet<AgricultureFieldUse> LoadUses(this XElement root)
+	public static HashSet<AgricultureFieldUse> LoadUses(this XElement root, bool defaultAll = true)
 	{
 		var text = (string)root.Attribute("uses") ?? string.Empty;
 		var result = new HashSet<AgricultureFieldUse>();
@@ -63,7 +63,7 @@ internal static class AgricultureXmlExtensions
 			}
 		}
 
-		if (!result.Any())
+		if (!result.Any() && defaultAll)
 		{
 			result.Add(AgricultureFieldUse.Fallow);
 			result.Add(AgricultureFieldUse.Crop);


### PR DESCRIPTION
## Summary
- closes the antiquity ItemSeeder review gaps across food tools/vessels, kumis, wine source boundaries, raw-hide leather prep, apiary supply, secondary herd outputs, seed-stock bootstrapping, agricultural derivatives, and fermentation consistency
- adds apiary/pollinator cultivation runtime support and matching agriculture/item/craft seed paths for honeycomb, honey, and beeswax
- routes fermented/aged antiquity beverages and garum through morphing amphora workflows instead of direct filled-liquid outputs
- updates the antiquity crafting docs and source-audit tests to pin the new boundaries

## Validation
- `dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore -m:1 -p:UseSharedCompilation=false -p:NoWarn=NU1902%3BNU1510 --filter 'ClassName~ItemSeederAntiquity|ClassName~AgricultureSeeder|ClassName~CoreDataSeederMaterial'` passed: 59 tests
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 -p:UseSharedCompilation=false -p:NoWarn=NU1902%3BNU1510 --filter 'ClassName~AgricultureOperationTests'` passed: 33 tests
- `dotnet build DatabaseSeeder\DatabaseSeeder.csproj -c Debug --no-restore -m:1 -p:UseSharedCompilation=false -p:NoWarn=NU1902%3BNU1510` passed
- `git diff --check` passed