### PR TITLE
Add commodity outputs for foraging

### DIFF
--- a/DatabaseSeeder/BlankDatabaseSnapshot.sql
+++ b/DatabaseSeeder/BlankDatabaseSnapshot.sql
@@ -886,6 +886,9 @@ CREATE TABLE `Foragables` (
     `MaximumOutcome` int(11) NOT NULL,
     `QuantityDiceExpression` varchar(200) CHARACTER SET utf8mb4 NOT NULL,
     `ItemProtoId` bigint(20) NOT NULL,
+    `CommodityMaterialId` bigint(20) NULL,
+    `CommodityTagId` bigint(20) NULL,
+    `CommodityWeightExpression` varchar(200) CHARACTER SET utf8mb4 NULL,
     `OnForageProgId` bigint(20) NULL,
     `CanForageProgId` bigint(20) NULL,
     `EditableItemId` bigint(20) NOT NULL,
@@ -5479,6 +5482,8 @@ ALTER TABLE `FutureProgs` MODIFY COLUMN `FunctionComment` text CHARACTER SET utf
 ALTER TABLE `FutureProgs` MODIFY COLUMN `Category` varchar(255) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL;
 
 ALTER TABLE `Foragables` MODIFY COLUMN `QuantityDiceExpression` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+ALTER TABLE `Foragables` MODIFY COLUMN `CommodityWeightExpression` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL;
 
 ALTER TABLE `Foragables` MODIFY COLUMN `Name` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
 

--- a/Design Documents/Crafting/Food_and_Cooking_System.md
+++ b/Design Documents/Crafting/Food_and_Cooking_System.md
@@ -1,4 +1,4 @@
-# FutureMUD Food And Cooking System
+﻿# FutureMUD Food And Cooking System
 
 ## Scope
 This document describes the current new-style food system centred on `PreparedFood`, recipe-initialised prepared foods, and the `cook` command facade over crafts.
@@ -78,7 +78,7 @@ Builders can use:
 The `cook` command only filters and dispatches cooking crafts. Tools, phases, echoes, checks, availability progs, and interruption behaviour remain ordinary craft behaviour.
 
 ## Foraging And Direct Creation
-Forageable item yields do not need a new forage process. Point the `Foragable` at a prepared-food item prototype, and the normal forage item-loading path produces usable food.
+Forageable item yields do not need a new forage process. Point the `Foragable` at a prepared-food item prototype, and the normal forage item-loading path produces usable food. Foragables can also produce commodity piles by specifying a material, optional commodity tag, and weight expression; this is useful for raw harvested foodstuffs that should enter craft and spoilage chains as commodities instead of full item prototypes.
 
 Likewise, FutureProg `loaditem`, spell `createitem`, shop prototype loading, and direct builder load all work with prepared food because the item prototype itself owns a complete food profile.
 

--- a/FutureMUDLibrary/Work/Foraging/IForagable.cs
+++ b/FutureMUDLibrary/Work/Foraging/IForagable.cs
@@ -1,4 +1,6 @@
 ﻿using MudSharp.Character;
+using MudSharp.Form.Material;
+using MudSharp.Framework;
 using MudSharp.Framework.Revision;
 using MudSharp.FutureProg;
 using MudSharp.GameItems;
@@ -49,8 +51,23 @@ namespace MudSharp.Work.Foraging
         IGameItemProto ItemProto { get; }
 
         /// <summary>
+        ///     The commodity material to load when this foragable produces a commodity instead of an item prototype
+        /// </summary>
+        ISolid CommodityMaterial { get; }
+
+        /// <summary>
+        ///     The optional commodity tag to apply when this foragable produces a commodity
+        /// </summary>
+        ITag CommodityTag { get; }
+
+        /// <summary>
+        ///     A string containing a dice expression for how much commodity weight to load
+        /// </summary>
+        string CommodityWeightExpression { get; }
+
+        /// <summary>
         ///     An optional prog to execute whenever this item is foraged
-        ///     The parameters to the prog are Character, Foragable ID, Item and Quantity
+        ///     The parameters to the prog are Character, Foragable ID, Item and Quantity or Weight
         /// </summary>
         IFutureProg OnForageProg { get; }
 

--- a/MudSharpCore Unit Tests/ForagingRuntimeTests.cs
+++ b/MudSharpCore Unit Tests/ForagingRuntimeTests.cs
@@ -1,7 +1,8 @@
-#nullable enable
+﻿#nullable enable
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using MudSharp.Form.Material;
 using MudSharp.Framework;
 using MudSharp.Framework.Revision;
 using MudSharp.FutureProg;
@@ -70,6 +71,52 @@ public class ForagingRuntimeTests
 	}
 
 	[TestMethod]
+	public void Foragable_LoadFromDb_CommodityOutputCanSubmit()
+	{
+		var material = new Mock<ISolid>();
+		material.SetupGet(x => x.Id).Returns(22);
+		material.SetupGet(x => x.Name).Returns("Oak");
+		var gameworld = CreateGameworld(material: material.Object);
+		var foragable = new Foragable(new DbForagable
+		{
+			Id = 1,
+			RevisionNumber = 0,
+			Name = "Fallen Branches",
+			ForagableTypes = "wood",
+			ForageDifficulty = (int)Difficulty.Normal,
+			RelativeChance = 100,
+			MinimumOutcome = (int)Outcome.MajorFail,
+			MaximumOutcome = (int)Outcome.MajorPass,
+			QuantityDiceExpression = "1",
+			ItemProtoId = 0,
+			CommodityMaterialId = 22,
+			CommodityWeightExpression = "500",
+			EditableItem = CreateEditableItem()
+		}, gameworld.Object);
+
+		Assert.IsNull(foragable.ItemProto);
+		Assert.AreSame(material.Object, foragable.CommodityMaterial);
+		Assert.AreEqual("500", foragable.CommodityWeightExpression);
+		Assert.IsTrue(foragable.CanSubmit());
+	}
+
+	[TestMethod]
+	public void ForagableProfile_GetForageResult_ReturnsCommodityMatch()
+	{
+		var actor = Mock.Of<MudSharp.Character.ICharacter>();
+		var foragable = CreateForagable(1, "Fallen Branches", "wood", Difficulty.Normal, commodity: true);
+		foragable.Setup(x => x.CanForage(actor, Outcome.Pass)).Returns(true);
+		var gameworld = CreateGameworld(foragable: foragable.Object);
+		var profile = CreateProfile(gameworld.Object, "wood", 1);
+		var outcomes = new Dictionary<Difficulty, CheckOutcome>
+		{
+			[Difficulty.Normal] = CheckOutcome.SimpleOutcome(CheckType.ForageCheck, Outcome.Pass)
+		};
+
+		Assert.AreSame(foragable.Object, profile.GetForageResult(actor, outcomes, "wood"));
+	}
+
+	[TestMethod]
 	public void ForagableProfile_GetForageResult_RequiresMatchingProfileYield()
 	{
 		var foragable = CreateForagable(1, "Loose Stones", "stone", Difficulty.Normal);
@@ -114,7 +161,8 @@ public class ForagingRuntimeTests
 		Assert.AreSame(foragable.Object, profile.GetForageResult(actor, outcomes, "food"));
 	}
 
-	private static Mock<IForagable> CreateForagable(long id, string name, string forageType, Difficulty difficulty)
+	private static Mock<IForagable> CreateForagable(long id, string name, string forageType, Difficulty difficulty,
+		bool commodity = false)
 	{
 		var proto = new Mock<IGameItemProto>();
 		proto.SetupGet(x => x.Id).Returns(id + 100);
@@ -124,7 +172,23 @@ public class ForagingRuntimeTests
 		var foragable = new Mock<IForagable>();
 		foragable.SetupGet(x => x.Id).Returns(id);
 		foragable.SetupGet(x => x.Name).Returns(name);
-		foragable.SetupGet(x => x.ItemProto).Returns(proto.Object);
+		if (commodity)
+		{
+			foragable.SetupGet(x => x.ItemProto).Returns((IGameItemProto)null!);
+		}
+		else
+		{
+			foragable.SetupGet(x => x.ItemProto).Returns(proto.Object);
+		}
+
+		if (commodity)
+		{
+			var material = new Mock<ISolid>();
+			material.SetupGet(x => x.Id).Returns(id + 200);
+			material.SetupGet(x => x.Name).Returns(name);
+			foragable.SetupGet(x => x.CommodityMaterial).Returns(material.Object);
+			foragable.SetupGet(x => x.CommodityWeightExpression).Returns("500");
+		}
 		foragable.SetupGet(x => x.ForagableTypes).Returns(new[] { forageType });
 		foragable.SetupGet(x => x.ForageDifficulty).Returns(difficulty);
 		foragable.SetupGet(x => x.RelativeChance).Returns(100);
@@ -152,7 +216,8 @@ public class ForagingRuntimeTests
 		return new ForagableProfile(profile, gameworld);
 	}
 
-	private static Mock<IFuturemud> CreateGameworld(IGameItemProto? itemProto = null, IForagable? foragable = null)
+	private static Mock<IFuturemud> CreateGameworld(IGameItemProto? itemProto = null, IForagable? foragable = null,
+		ISolid? material = null, ITag? tag = null)
 	{
 		var progRepo = new Mock<IUneditableAll<IFutureProg>>();
 		progRepo.Setup(x => x.Get(It.IsAny<long>())).Returns((IFutureProg)null!);
@@ -160,12 +225,20 @@ public class ForagingRuntimeTests
 		var itemRepo = new Mock<IUneditableRevisableAll<IGameItemProto>>();
 		itemRepo.Setup(x => x.Get(It.IsAny<long>())).Returns(itemProto!);
 
+		var materialRepo = new Mock<IUneditableAll<ISolid>>();
+		materialRepo.Setup(x => x.Get(It.IsAny<long>())).Returns(material!);
+
+		var tagRepo = new Mock<IUneditableAll<ITag>>();
+		tagRepo.Setup(x => x.Get(It.IsAny<long>())).Returns(tag!);
+
 		var foragableRepo = new Mock<IUneditableRevisableAll<IForagable>>();
 		foragableRepo.Setup(x => x.Get(It.IsAny<long>())).Returns(foragable!);
 
 		var gameworld = new Mock<IFuturemud>();
 		gameworld.SetupGet(x => x.FutureProgs).Returns(progRepo.Object);
 		gameworld.SetupGet(x => x.ItemProtos).Returns(itemRepo.Object);
+		gameworld.SetupGet(x => x.Materials).Returns(materialRepo.Object);
+		gameworld.SetupGet(x => x.Tags).Returns(tagRepo.Object);
 		gameworld.SetupGet(x => x.Foragables).Returns(foragableRepo.Object);
 		return gameworld;
 	}

--- a/MudSharpCore/Commands/Helpers/EditableRevisableItemHelper.cs
+++ b/MudSharpCore/Commands/Helpers/EditableRevisableItemHelper.cs
@@ -341,14 +341,16 @@ internal class EditableRevisableItemHelper
                                        ? string.Format(actor, "{0} {1:N0}r{2:N0}", proto.ItemProto.Name,
                                            proto.ItemProto.Id,
                                            proto.ItemProto.RevisionNumber)
-                                       : "None",
-                                   proto.QuantityDiceExpression,
+                                       : proto.CommodityMaterial != null
+                                           ? $"Commodity: {proto.CommodityMaterial.Name}{(proto.CommodityTag != null ? $" [{proto.CommodityTag.FullName}]" : "")}"
+                                           : "None",
+                                   proto.ItemProto != null ? proto.QuantityDiceExpression : proto.CommodityWeightExpression,
                                    FMDB.Context.Accounts.Find(proto.BuilderAccountID).Name, proto.BuilderComment ?? ""
                                };
                 }
             },
             GetReviewTableHeaderFunc =
-                character => new[] { "ID#", "Rev#", "Name", "Proto", "Quantity", "Builder", "Comment" },
+                character => new[] { "ID#", "Rev#", "Name", "Output", "Amount", "Builder", "Comment" },
             GetListTableContentsFunc = (character, protos) => from proto in protos.OfType<IForagable>()
                                                               select
                                                                   new[]
@@ -361,11 +363,13 @@ internal class EditableRevisableItemHelper
                                                                               "{0} {1:N0}r{2:N0}", proto.ItemProto.Name,
                                                                               proto.ItemProto.Id,
                                                                               proto.ItemProto.RevisionNumber)
-                                                                          : "None",
-                                                                      proto.QuantityDiceExpression,
+                                                                          : proto.CommodityMaterial != null
+                                                                              ? $"Commodity: {proto.CommodityMaterial.Name}{(proto.CommodityTag != null ? $" [{proto.CommodityTag.FullName}]" : "")}"
+                                                                              : "None",
+                                                                      proto.ItemProto != null ? proto.QuantityDiceExpression : proto.CommodityWeightExpression,
                                                                       proto.Status.Describe()
                                                                   },
-            GetListTableHeaderFunc = character => new[] { "ID#", "Rev#", "Name", "Proto", "Quantity", "Status" },
+            GetListTableHeaderFunc = character => new[] { "ID#", "Rev#", "Name", "Output", "Amount", "Status" },
             GetReviewProposalEffectFunc =
                 (protos, character) =>
                     new Accept(character,

--- a/MudSharpCore/Commands/Modules/ActivityBuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/ActivityBuilderModule.cs
@@ -933,7 +933,7 @@ The syntax for this command is as follows:
     #region Foragables
 
     private const string ForagableHelpText =
-        @$"This command is used to view and edit foragables. Foragables are records of item results that can be loaded by the #3forage#0 command. The item prototype must be built first, and the foragable must be linked to a foragable profile before players can find it. A single foragable can be shared between multiple profiles.
+        @$"This command is used to view and edit foragables. Foragables are records of item or commodity results that can be loaded by the #3forage#0 command. Item outputs need an item prototype; commodity outputs need a material, optional tag, and weight expression. The foragable must be linked to a foragable profile before players can find it. A single foragable can be shared between multiple profiles.
 
 The #3types#0 on a foragable must match the #3yield#0 names on the profile where you link it. For example, a foragable with type #6wood#0 can be found by #3forage wood#0 anywhere that profile has a #6wood#0 yield.
 
@@ -952,10 +952,17 @@ You can use the following options with this command:
 	#3foragable review list#0 - shows all the foragables due to review
 	#3foragable review history <which>#0 - shows the history of a foragable
 	#3foragable set name <name>#0 - renames this foragable
-	#3foragable set proto <which>#0 - sets the proto for this foragable to load
+	#3foragable set proto <which>#0 - sets the proto for this foragable to load and clears commodity output
+	#3foragable set commodity material <material> [tag <tag>|notag] weight <weight>#0 - switches this foragable to commodity output
+	#3foragable set commodity clear#0 - clears commodity output
+	#3foragable set material <which>#0 - sets the commodity material and clears item prototype output
+	#3foragable set tag <which>#0 - sets the commodity tag
+	#3foragable set tag none#0 - clears the commodity tag
+	#3foragable set weight <weight>#0 - sets a fixed commodity weight
+	#3foragable set weight variable <expression>#0 - sets a variable commodity weight expression with #6outcome#0 available
 	#3foragable set chance <#>#0 - the relative weight of this option being found
-	#3foragable set quantity <# or dice>#0 - a number or dice expression for the quantity found
-	#3foragable set difficulty <difficulty>#0 - the difficulty that the result is evaluated against for this item
+	#3foragable set quantity <# or dice>#0 - a number or dice expression for the item quantity found
+	#3foragable set difficulty <difficulty>#0 - the difficulty that the result is evaluated against for this output
 	#3foragable set outcome <min> <max>#0 - the minimum and maximum check outcome that this item can appear on
 	#3foragable set types <type1> [<type2>] ... [<typen>]#0 - sets the yield types that this foragable appears against
 	#3foragable set canforage <prog>#0 - sets a prog that controls whether this foragable can be found
@@ -1001,9 +1008,9 @@ You can use the following options with this command:
     private const string ForagableProfileHelpText =
         @$"This command is used to view and edit foragable profiles. 
 
-Foragable profiles are attached to terrain types, zones or individual cells, and control both what yield types exist in that location and what item results can be foraged by players. Cells inherit from their zone, and zones usually inherit from terrain defaults unless a builder sets a more specific override.
+Foragable profiles are attached to terrain types, zones or individual cells, and control both what yield types exist in that location and what item or commodity results can be foraged by players. Cells inherit from their zone, and zones usually inherit from terrain defaults unless a builder sets a more specific override.
 
-The individual foraged items are built using the #Bforagable#0 command. These foragables can be shared between multiple foragable profiles. A profile yield without matching linked foragables can still support grazing/eating systems, but players will not gather items from it with #3forage#0 until you link matching foragables.
+The individual foraged outputs are built using the #Bforagable#0 command. These foragables can be shared between multiple foragable profiles. A profile yield without matching linked foragables can still support grazing/eating systems, but players will not gather items from it with #3forage#0 until you link matching foragables.
 
 See #6terrain set forage <id|name>#0 to set a default foragable profile for a terrain type
 See #6zone set <which> forage <id|name>#0 to set a foragable profile for a zone

--- a/MudSharpCore/Commands/Modules/GameModule.cs
+++ b/MudSharpCore/Commands/Modules/GameModule.cs
@@ -1236,7 +1236,7 @@ The syntax is #3tagsearch <tag>#0.", AutoHelp.HelpArgOrNoArg)]
     [NoCombatCommand]
     [NoMovementCommand]
     [HelpInfo("forage",
-        @"The forage command is used to look for useful items in your location. You must always forage against a 'yield type', for example you might be foraging for 'food', or for 'wood'. As you forage items from these categories there is less of it to find in the current location, and it may or may not regenerate over time.
+        @"The forage command is used to look for useful items or commodities in your location. You must always forage against a 'yield type', for example you might be foraging for 'food', or for 'wood'. As you forage items from these categories there is less of it to find in the current location, and it may or may not regenerate over time.
 
 The syntax to use with this command is as follows:
 
@@ -1254,7 +1254,8 @@ You can also type 'forage' on its own to see what kinds of yields you can search
         }
 
         List<string> forageTypes =
-            profile.Foragables.SelectMany(x => x.ForagableTypes)
+            profile.Foragables.Where(ForagableCanProduceOutput)
+                    .SelectMany(x => x.ForagableTypes)
                     .Select(x => x.ToLowerInvariant())
                     .Where(x => !string.IsNullOrWhiteSpace(x) && profile.MaximumYieldPoints.ContainsKey(x))
                     .Distinct()
@@ -1265,7 +1266,7 @@ You can also type 'forage' on its own to see what kinds of yields you can search
         {
             if (!forageTypes.Any())
             {
-                actor.Send("There do not seem to be any useful items that can be foraged in this location.");
+                actor.Send("There do not seem to be any useful outputs that can be foraged in this location.");
                 return;
             }
 
@@ -1338,11 +1339,67 @@ You can also type 'forage' on its own to see what kinds of yields you can search
                 }
 
                 List<IGameItem> newItems = new();
-                int quantity =
-                    (int)Math.Floor(new TraitExpression(foragable.QuantityDiceExpression, actor.Gameworld).EvaluateWith(
+                if (foragable.ItemProto != null)
+                {
+                    int quantity =
+                        (int)Math.Floor(new TraitExpression(foragable.QuantityDiceExpression, actor.Gameworld).EvaluateWith(
+                            actor,
+                            values: ("outcome", forageOutcome[foragable.ForageDifficulty])));
+                    if (quantity <= 0)
+                    {
+                        actor.OutputHandler.Handle(
+                            new EmoteOutput(
+                                new Emote(
+                                    "@ finish|finishes foraging, but are|is not successful in finding what #0 were|was looking for.",
+                                    actor, actor)));
+                        return;
+                    }
+
+                    actor.Location.ConsumeYield(type, 1.0);
+                    if (foragable.ItemProto.IsItemType<StackableGameItemComponentProto>())
+                    {
+                        IGameItem newItem = foragable.ItemProto.CreateNew(actor);
+                        newItem.GetItemType<IStackable>().Quantity = quantity;
+                        newItems.Add(newItem);
+                        actor.Gameworld.Add(newItem);
+                    }
+                    else
+                    {
+                        for (int i = 0; i < quantity; i++)
+                        {
+                            IGameItem newItem = foragable.ItemProto.CreateNew(actor);
+                            newItems.Add(newItem);
+                            actor.Gameworld.Add(newItem);
+                        }
+                    }
+                }
+                else if (foragable.CommodityMaterial != null)
+                {
+                    var weight = new TraitExpression(foragable.CommodityWeightExpression, actor.Gameworld).EvaluateWith(
                         actor,
-                        values: ("outcome", forageOutcome[foragable.ForageDifficulty])));
-                if (quantity <= 0)
+                        values: ("outcome", forageOutcome[foragable.ForageDifficulty]));
+                    if (weight <= 0.0)
+                    {
+                        actor.OutputHandler.Handle(
+                            new EmoteOutput(
+                                new Emote(
+                                    "@ finish|finishes foraging, but are|is not successful in finding what #0 were|was looking for.",
+                                    actor, actor)));
+                        return;
+                    }
+
+                    actor.Location.ConsumeYield(type, 1.0);
+                    if (CommodityGameItemComponentProto.ItemPrototype == null)
+                    {
+                        CommodityGameItemComponentProto.InitialiseItemType(actor.Gameworld);
+                    }
+
+                    IGameItem newItem = CommodityGameItemComponentProto.CreateNewCommodity(foragable.CommodityMaterial,
+                        weight, foragable.CommodityTag);
+                    newItems.Add(newItem);
+                    actor.Gameworld.Add(newItem);
+                }
+                else
                 {
                     actor.OutputHandler.Handle(
                         new EmoteOutput(
@@ -1352,29 +1409,11 @@ You can also type 'forage' on its own to see what kinds of yields you can search
                     return;
                 }
 
-                actor.Location.ConsumeYield(type, 1.0);
-                if (foragable.ItemProto.IsItemType<StackableGameItemComponentProto>())
-                {
-                    IGameItem newItem = foragable.ItemProto.CreateNew(actor);
-                    newItem.GetItemType<IStackable>().Quantity = quantity;
-                    newItems.Add(newItem);
-                    actor.Gameworld.Add(newItem);
-                }
-                else
-                {
-                    for (int i = 0; i < quantity; i++)
-                    {
-                        IGameItem newItem = foragable.ItemProto.CreateNew(actor);
-                        newItems.Add(newItem);
-                        actor.Gameworld.Add(newItem);
-                    }
-                }
-
                 if (foragable.OnForageProg != null)
                 {
                     foreach (IGameItem item in newItems)
                     {
-                        var progQuantity = item.IsItemType<IStackable>() ? item.GetItemType<IStackable>().Quantity : 1;
+                        var progQuantity = GetForageProgQuantity(item);
                         foragable.OnForageProg.Execute(actor, foragable.Id, item, progQuantity);
                     }
                 }
@@ -1474,6 +1513,22 @@ You can also type 'forage' on its own to see what kinds of yields you can search
         actor.OutputHandler.Handle(new EmoteOutput(new Emote($"@ begin|begins foraging for {type}.", actor)));
     }
 
+    private static bool ForagableCanProduceOutput(IForagable foragable)
+    {
+        return foragable.ItemProto != null ||
+               foragable.CommodityMaterial != null && !string.IsNullOrWhiteSpace(foragable.CommodityWeightExpression);
+    }
+
+    private static double GetForageProgQuantity(IGameItem item)
+    {
+        if (item.GetItemType<ICommodity>() is { } commodity)
+        {
+            return commodity.Weight;
+        }
+
+        return item.IsItemType<IStackable>() ? item.GetItemType<IStackable>().Quantity : 1;
+    }
+
     private static bool TryParseForageOptions(ICharacter actor, StringStack command, IForagableProfile profile,
         string forageType, out IForagable specificForagable, out IGameItem targetContainer)
     {
@@ -1551,7 +1606,7 @@ You can also type 'forage' on its own to see what kinds of yields you can search
         string targetText)
     {
         var candidates = profile.Foragables
-                                .Where(x => x.ItemProto != null)
+                                .Where(ForagableCanProduceOutput)
                                 .Where(x => x.ForageDifficulty != Difficulty.Impossible)
                                 .Where(x => x.ForagableTypes.Any(y => y.EqualTo(forageType)))
                                 .ToList();
@@ -1568,7 +1623,13 @@ You can also type 'forage' on its own to see what kinds of yields you can search
                                   (x.ItemProto?.Name.EqualTo(targetText) ?? false) ||
                                   (x.ItemProto?.Name.StartsWith(targetText, StringComparison.InvariantCultureIgnoreCase) ?? false) ||
                                   (x.ItemProto?.ShortDescription.EqualTo(targetText) ?? false) ||
-                                  (x.ItemProto?.ShortDescription.StartsWith(targetText, StringComparison.InvariantCultureIgnoreCase) ?? false))
+                                  (x.ItemProto?.ShortDescription.StartsWith(targetText, StringComparison.InvariantCultureIgnoreCase) ?? false) ||
+                                  (x.CommodityMaterial?.Name.EqualTo(targetText) ?? false) ||
+                                  (x.CommodityMaterial?.Name.StartsWith(targetText, StringComparison.InvariantCultureIgnoreCase) ?? false) ||
+                                  (x.CommodityTag?.Name.EqualTo(targetText) ?? false) ||
+                                  (x.CommodityTag?.Name.StartsWith(targetText, StringComparison.InvariantCultureIgnoreCase) ?? false) ||
+                                  (x.CommodityTag?.FullName.EqualTo(targetText) ?? false) ||
+                                  (x.CommodityTag?.FullName.StartsWith(targetText, StringComparison.InvariantCultureIgnoreCase) ?? false))
                               .Distinct()
                               .ToList();
         }

--- a/MudSharpCore/Work/Foraging/Foragable.cs
+++ b/MudSharpCore/Work/Foraging/Foragable.cs
@@ -1,4 +1,6 @@
 ﻿using ExpressionEngine;
+using MudSharp.Form.Material;
+using MudSharp.Framework.Units;
 using MudSharp.Accounts;
 using MudSharp.Body.Traits;
 using MudSharp.Character;
@@ -11,6 +13,7 @@ using MudSharp.PerceptionEngine;
 using MudSharp.RPG.Checks;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 
@@ -24,6 +27,39 @@ public class Foragable : EditableItem, IForagable
         => Futuremud.Games.First().GetStaticConfiguration("BaseForageTimeExpression");
 
     #endregion
+
+    private string DescribeOutput(ICharacter actor)
+    {
+        if (ItemProto != null)
+        {
+            return string.Format(actor, "item #{0:N0}r{1:N0} - {2} ({3})", ItemProto.Id, ItemProto.RevisionNumber,
+                ItemProto.ShortDescription, QuantityDiceExpression.ColourCommand());
+        }
+
+        if (CommodityMaterial != null)
+        {
+            return $"{DescribeCommodityWeightExpression(actor)} of {CommodityMaterial.Name.Colour(CommodityMaterial.ResidueColour)}{(CommodityTag != null ? $" tagged {CommodityTag.FullName.ColourName()}" : "")}";
+        }
+
+        return "Not Selected".ColourError();
+    }
+
+    private string DescribeCommodityWeightExpression(ICharacter actor)
+    {
+        if (string.IsNullOrWhiteSpace(CommodityWeightExpression))
+        {
+            return "Not Selected".ColourError();
+        }
+
+        return double.TryParse(CommodityWeightExpression, NumberStyles.Float, CultureInfo.InvariantCulture, out var weight)
+            ? Gameworld.UnitManager.DescribeExact(weight, UnitType.Mass, actor).ColourValue()
+            : CommodityWeightExpression.ColourCommand();
+    }
+
+    private bool HasItemOutput => ItemProto != null;
+    private bool HasCommodityMaterial => CommodityMaterial != null;
+    private bool HasCommodityOutput => HasCommodityMaterial && !string.IsNullOrWhiteSpace(CommodityWeightExpression);
+    private bool HasExactlyOneOutput => HasItemOutput && !HasCommodityMaterial || !HasItemOutput && HasCommodityOutput;
 
     public override string Show(ICharacter actor)
     {
@@ -41,12 +77,7 @@ public class Foragable : EditableItem, IForagable
             $"Forage Difficulty: {ForageDifficulty.Describe().Colour(Telnet.Green)}",
             $"Relative Chance: {RelativeChance.ToString("N0", actor).ColourValue()}"
         }.ArrangeStringsOntoLines(2, (uint)actor.LineFormatLength));
-        sb.AppendLineFormat("Item Proto: {0}",
-            ItemProto != null
-                ? string.Format(actor, "{0:N0}r{1:N0} - {2}", ItemProto.Id, ItemProto.RevisionNumber,
-                    ItemProto.ShortDescription)
-                : "Not Selected".Colour(Telnet.Red));
-        sb.AppendLineFormat("Quantity Expression: {0}", QuantityDiceExpression.Colour(Telnet.Yellow));
+        sb.AppendLineFormat("Output: {0}", DescribeOutput(actor));
         sb.AppendLineFormat("Foragable Types: {0}",
             ForagableTypes.Any()
                 ? ForagableTypes.Select(x => x.Colour(Telnet.Green)).ListToString()
@@ -79,6 +110,9 @@ public class Foragable : EditableItem, IForagable
                 MinimumOutcome = (int)MinimumOutcome,
                 MaximumOutcome = (int)MaximumOutcome,
                 QuantityDiceExpression = QuantityDiceExpression,
+                CommodityMaterialId = CommodityMaterial?.Id,
+                CommodityTagId = HasCommodityMaterial ? CommodityTag?.Id : null,
+                CommodityWeightExpression = HasCommodityMaterial ? CommodityWeightExpression : null,
                 RelativeChance = RelativeChance,
                 EditableItem = new Models.EditableItem()
             };
@@ -103,7 +137,7 @@ public class Foragable : EditableItem, IForagable
 
     public override bool CanSubmit()
     {
-        return ForagableTypes.Any() && ItemProto != null;
+        return ForagableTypes.Any() && HasExactlyOneOutput;
     }
 
     public override string WhyCannotSubmit()
@@ -113,7 +147,19 @@ public class Foragable : EditableItem, IForagable
             return "You must set at least one foragable type.";
         }
 
-        return ItemProto == null ? "You must set an item prototype." : "I don't know why you can't submit.";
+        if (HasItemOutput && HasCommodityMaterial)
+        {
+            return "You must set either an item prototype or a commodity output, not both.";
+        }
+
+        if (HasCommodityMaterial && string.IsNullOrWhiteSpace(CommodityWeightExpression))
+        {
+            return "You must set a commodity weight expression.";
+        }
+
+        return !HasItemOutput && !HasCommodityMaterial
+            ? "You must set either an item prototype or a commodity output."
+            : "I don't know why you can't submit.";
     }
 
     public override string FrameworkItemType => "Foragable";
@@ -134,6 +180,9 @@ public class Foragable : EditableItem, IForagable
             dbitem.ForagableTypes = SerialisedForagableTypes;
             dbitem.ForageDifficulty = (int)ForageDifficulty;
             dbitem.ItemProtoId = ItemProto?.Id ?? 0;
+            dbitem.CommodityMaterialId = CommodityMaterial?.Id;
+            dbitem.CommodityTagId = HasCommodityMaterial ? CommodityTag?.Id : null;
+            dbitem.CommodityWeightExpression = HasCommodityMaterial ? CommodityWeightExpression : null;
             dbitem.MinimumOutcome = (int)MinimumOutcome;
             dbitem.MaximumOutcome = (int)MaximumOutcome;
             dbitem.QuantityDiceExpression = QuantityDiceExpression ?? "1";
@@ -171,6 +220,7 @@ public class Foragable : EditableItem, IForagable
             _minimumOutcome = Outcome.MajorFail;
             _maximumOutcome = Outcome.MajorPass;
             _quantityDiceExpression = "1";
+            _commodityWeightExpression = null;
 
             dbitem.Name = _name;
             dbitem.RelativeChance = RelativeChance;
@@ -204,6 +254,9 @@ public class Foragable : EditableItem, IForagable
         _canForageProg = Gameworld.FutureProgs.Get(foragable.CanForageProgId ?? 0);
         _quantityDiceExpression = foragable.QuantityDiceExpression;
         _itemProtoId = foragable.ItemProtoId;
+        _commodityMaterialId = foragable.CommodityMaterialId ?? 0;
+        _commodityTagId = foragable.CommodityTagId ?? 0;
+        _commodityWeightExpression = foragable.CommodityWeightExpression;
     }
 
     protected override IEnumerable<IEditableRevisableItem> GetAllSameId()
@@ -218,10 +271,17 @@ public class Foragable : EditableItem, IForagable
     private const string BuildingCommandHelp = @"You can use the following options with this command:
 
 	#3name <name>#0 - renames this foragable
-	#3proto <which>#0 - sets the item prototype for this foragable to load
+	#3proto <which>#0 - sets the item prototype for this foragable to load and clears commodity output
+	#3commodity material <material> [tag <tag>|notag] weight <weight>#0 - switches this foragable to commodity output
+	#3commodity clear#0 - clears commodity output
+	#3material <which>#0 - sets the commodity material and clears item prototype output
+	#3tag <which>#0 - sets the commodity tag
+	#3tag none#0 - clears the commodity tag
+	#3weight <weight>#0 - sets a fixed commodity weight
+	#3weight variable <expression>#0 - sets a variable commodity weight expression, in base mass units, with #6outcome#0 available
 	#3chance <#>#0 - the relative weight of this option being found
-	#3quantity <# or dice>#0 - a number or dice expression for the quantity found
-	#3difficulty <difficulty>#0 - the difficulty that the result is evaluated against for this item
+	#3quantity <# or dice>#0 - a number or dice expression for the item quantity found
+	#3difficulty <difficulty>#0 - the difficulty that the result is evaluated against for this output
 	#3outcome <min> <max>#0 - the minimum and maximum check outcome that this item can appear on
 	#3types <type1> [<type2>] ... [<typen>]#0 - sets the yield types that this foragable appears against
 	#3canforage <prog>#0 - sets a boolean prog that controls whether this foragable can be found
@@ -249,12 +309,276 @@ public class Foragable : EditableItem, IForagable
                 return BuildingCommandCanForage(actor, command);
             case "proto":
                 return BuildingCommandProto(actor, command);
+            case "commodity":
+                return BuildingCommandCommodity(actor, command);
+            case "material":
+                return BuildingCommandMaterial(actor, command);
+            case "tag":
+                return BuildingCommandTag(actor, command);
+            case "weight":
+                return BuildingCommandWeight(actor, command);
             case "quantity":
                 return BuildingCommandQuantity(actor, command);
             default:
                 actor.OutputHandler.Send(BuildingCommandHelp.SubstituteANSIColour());
                 return false;
         }
+    }
+
+    private bool BuildingCommandCommodity(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.Send("Use {0} to set commodity output.", "commodity material <material> [tag <tag>|notag] weight <weight>".ColourCommand());
+            return false;
+        }
+
+        if (command.SafeRemainingArgument.EqualTo("clear"))
+        {
+            if (CommodityMaterial == null && CommodityTag == null)
+            {
+                actor.Send("This foragable does not have any commodity output to clear.");
+                return false;
+            }
+
+            ClearCommodityOutput();
+            actor.Send("You clear the commodity output from this foragable.");
+            return true;
+        }
+
+        ISolid material = null;
+        ITag tag = null;
+        string weightExpression = null;
+        string weightDescription = null;
+        while (!command.IsFinished)
+        {
+            var token = command.PopSpeech();
+            if (token.EqualTo("material"))
+            {
+                var materialText = ConsumeUntilKeyword(command, "tag", "notag", "none", "weight");
+                if (string.IsNullOrWhiteSpace(materialText))
+                {
+                    actor.Send("Which commodity material do you want this foragable to produce?");
+                    return false;
+                }
+
+                material = Gameworld.Materials.GetByIdOrName(materialText);
+                if (material == null)
+                {
+                    actor.Send("There is no material identified by {0}.", materialText.ColourCommand());
+                    return false;
+                }
+
+                continue;
+            }
+
+            if (token.EqualTo("tag"))
+            {
+                var tagText = ConsumeUntilKeyword(command, "weight", "material");
+                if (string.IsNullOrWhiteSpace(tagText))
+                {
+                    actor.Send("Which commodity tag do you want this foragable to use?");
+                    return false;
+                }
+
+                tag = Gameworld.Tags.GetByIdOrName(tagText);
+                if (tag == null)
+                {
+                    actor.Send("There is no tag identified by {0}.", tagText.ColourCommand());
+                    return false;
+                }
+
+                continue;
+            }
+
+            if (token.EqualToAny("notag", "none"))
+            {
+                tag = null;
+                continue;
+            }
+
+            if (token.EqualTo("weight"))
+            {
+                if (!TryParseCommodityWeightExpression(actor, command.SafeRemainingArgument, out weightExpression, out weightDescription))
+                {
+                    return false;
+                }
+
+                break;
+            }
+
+            actor.Send("The option {0} is not valid for commodity output. Use {1}.", token.ColourCommand(), "commodity material <material> [tag <tag>|notag] weight <weight>".ColourCommand());
+            return false;
+        }
+
+        if (material == null)
+        {
+            actor.Send("You must specify a commodity material.");
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(weightExpression))
+        {
+            actor.Send("You must specify a commodity weight.");
+            return false;
+        }
+
+        SetCommodityOutput(material, tag, weightExpression);
+        actor.Send("This foragable will now produce {0} of {1}{2} when foraged.", weightDescription,
+            material.Name.Colour(material.ResidueColour), tag != null ? $" tagged {tag.FullName.ColourName()}" : "");
+        return true;
+    }
+
+    private bool BuildingCommandMaterial(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.Send("Which commodity material do you want this foragable to produce?");
+            return false;
+        }
+
+        var materialText = command.SafeRemainingArgument;
+        var material = Gameworld.Materials.GetByIdOrName(materialText);
+        if (material == null)
+        {
+            actor.Send("There is no material identified by {0}.", materialText.ColourCommand());
+            return false;
+        }
+
+        _itemProtoId = 0;
+        CommodityMaterial = material;
+        actor.Send("This foragable will now produce commodity piles of {0} instead of item prototypes.", material.Name.Colour(material.ResidueColour));
+        if (string.IsNullOrWhiteSpace(CommodityWeightExpression))
+        {
+            actor.Send("Warning: you still need to set a commodity weight before this foragable can be submitted.".Colour(Telnet.Yellow));
+        }
+
+        return true;
+    }
+
+    private bool BuildingCommandTag(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.Send("Which commodity tag do you want this foragable to use? Use {0} to clear it.", "none".ColourCommand());
+            return false;
+        }
+
+        if (command.SafeRemainingArgument.EqualToAny("clear", "none", "notag"))
+        {
+            _itemProtoId = 0;
+            CommodityTag = null;
+            actor.Send("This foragable will now produce an untagged commodity pile.");
+            return true;
+        }
+
+        var tagText = command.SafeRemainingArgument;
+        var tag = Gameworld.Tags.GetByIdOrName(tagText);
+        if (tag == null)
+        {
+            actor.Send("There is no tag identified by {0}.", tagText.ColourCommand());
+            return false;
+        }
+
+        _itemProtoId = 0;
+        CommodityTag = tag;
+        actor.Send("This foragable will now apply the {0} tag to its commodity output.", tag.FullName.ColourName());
+        return true;
+    }
+
+    private bool BuildingCommandWeight(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.Send("What weight of commodity should this foragable produce?");
+            return false;
+        }
+
+        if (!TryParseCommodityWeightExpression(actor, command.SafeRemainingArgument, out var expression, out var description))
+        {
+            return false;
+        }
+
+        _itemProtoId = 0;
+        CommodityWeightExpression = expression;
+        actor.Send("This foragable will now produce {0} of commodity when foraged.", description);
+        if (CommodityMaterial == null)
+        {
+            actor.Send("Warning: you still need to set a commodity material before this foragable can be submitted.".Colour(Telnet.Yellow));
+        }
+
+        return true;
+    }
+
+    private bool TryParseCommodityWeightExpression(ICharacter actor, string text, out string expression, out string description)
+    {
+        expression = null;
+        description = null;
+        var command = new StringStack(text);
+        var isFormula = command.PeekSpeech().EqualToAny("variable", "formula", "expression");
+        if (isFormula)
+        {
+            command.PopSpeech();
+            text = command.SafeRemainingArgument;
+        }
+
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            actor.Send("What weight expression do you want to use for this commodity output?");
+            return false;
+        }
+
+        if (!isFormula && Gameworld.UnitManager.TryGetBaseUnits(text, UnitType.Mass, actor, out var weight))
+        {
+            if (weight <= 0.0)
+            {
+                actor.Send("Commodity weight must be greater than zero.");
+                return false;
+            }
+
+            expression = weight.ToString("R", CultureInfo.InvariantCulture);
+            description = Gameworld.UnitManager.DescribeExact(weight, UnitType.Mass, actor).ColourValue();
+            return true;
+        }
+
+        TraitExpression testExpression = new(text, Gameworld);
+        if (testExpression.HasErrors())
+        {
+            actor.OutputHandler.Send($"Your formula had the following error: {testExpression.Error.ColourCommand()}");
+            return false;
+        }
+
+        expression = text;
+        description = text.ColourCommand();
+        return true;
+    }
+
+    private static string ConsumeUntilKeyword(StringStack command, params string[] keywords)
+    {
+        List<string> parts = new();
+        while (!command.IsFinished && !command.PeekSpeech().EqualToAny(keywords))
+        {
+            parts.Add(command.PopSpeech());
+        }
+
+        return string.Join(" ", parts);
+    }
+
+    private void SetCommodityOutput(ISolid material, ITag tag, string weightExpression)
+    {
+        _itemProtoId = 0;
+        _commodityMaterialId = material?.Id ?? 0;
+        _commodityTagId = tag?.Id ?? 0;
+        _commodityWeightExpression = weightExpression;
+        Changed = true;
+    }
+
+    private void ClearCommodityOutput()
+    {
+        _commodityMaterialId = 0;
+        _commodityTagId = 0;
+        _commodityWeightExpression = null;
+        Changed = true;
     }
 
     private bool BuildingCommandQuantity(ICharacter actor, StringStack command)
@@ -309,6 +633,7 @@ public class Foragable : EditableItem, IForagable
         }
 
         ItemProto = proto;
+        ClearCommodityOutput();
         actor.OutputHandler.Send(
             $"This foragable will now load item prototype {proto.Name} (#{proto.Id}) when foraged.");
         return true;
@@ -411,7 +736,7 @@ public class Foragable : EditableItem, IForagable
             }))
         {
             actor.Send(
-                "The OnForage prog must accept a Character, Number, Item and Number parameter. {0} does not match that pattern.",
+                "The OnForage prog must accept a Character, Number, Item and Number parameter. The final number is item quantity or commodity weight. {0} does not match that pattern.",
                 prog.FunctionName);
             return false;
         }
@@ -651,6 +976,42 @@ public class Foragable : EditableItem, IForagable
         set
         {
             _quantityDiceExpression = value;
+            Changed = true;
+        }
+    }
+
+    private long _commodityMaterialId;
+
+    public ISolid CommodityMaterial
+    {
+        get => Gameworld.Materials.Get(_commodityMaterialId);
+        set
+        {
+            _commodityMaterialId = value?.Id ?? 0;
+            Changed = true;
+        }
+    }
+
+    private long _commodityTagId;
+
+    public ITag CommodityTag
+    {
+        get => Gameworld.Tags.Get(_commodityTagId);
+        set
+        {
+            _commodityTagId = value?.Id ?? 0;
+            Changed = true;
+        }
+    }
+
+    private string _commodityWeightExpression;
+
+    public string CommodityWeightExpression
+    {
+        get => _commodityWeightExpression;
+        set
+        {
+            _commodityWeightExpression = value;
             Changed = true;
         }
     }

--- a/MudSharpCore/Work/Foraging/ForagableProfile.cs
+++ b/MudSharpCore/Work/Foraging/ForagableProfile.cs
@@ -3,11 +3,13 @@ using MudSharp.Character;
 using MudSharp.Database;
 using MudSharp.Framework;
 using MudSharp.Framework.Revision;
+using MudSharp.Framework.Units;
 using MudSharp.Models;
 using MudSharp.PerceptionEngine;
 using MudSharp.RPG.Checks;
 using System;
 using System.Collections.Generic;
+using CultureInfo = System.Globalization.CultureInfo;
 using System.Linq;
 using System.Text;
 using EditableItem = MudSharp.Framework.Revision.EditableItem;
@@ -50,15 +52,11 @@ public class ForagableProfile : EditableItem, IForagableProfile
         {
             sb.Append(StringUtilities.GetTextTable(
                 from item in foragables
-                let proto = item.ItemProto
                 select new[]
                 {
                     item.Id.ToString("N0", actor),
                     item.Name,
-                    proto != null
-                        ? $"{proto.Name} {proto.Id.ToString("N0", actor)}r{proto.RevisionNumber.ToString("N0", actor)}"
-                        : "Missing".ColourError(),
-                    item.QuantityDiceExpression,
+                    DescribeForagableOutput(item, actor),
                     item.MinimumOutcome.Describe(),
                     item.MaximumOutcome.Describe(),
                     item.RelativeChance.ToString("N0", actor),
@@ -68,8 +66,7 @@ public class ForagableProfile : EditableItem, IForagableProfile
                 {
                     "ID",
                     "Name",
-                    "Item Proto",
-                    "Quantity",
+                    "Output",
                     "Min Outcome",
                     "Max Outcome",
                     "Chance",
@@ -143,6 +140,42 @@ public class ForagableProfile : EditableItem, IForagableProfile
     }
 
     public override string FrameworkItemType => "ForagableProfile";
+
+    private static bool CanProduceOutput(IForagable item)
+    {
+        return item.ItemProto != null ||
+               item.CommodityMaterial != null && !string.IsNullOrWhiteSpace(item.CommodityWeightExpression);
+    }
+
+    private string DescribeForagableOutput(IForagable item, ICharacter actor)
+    {
+        var proto = item.ItemProto;
+        if (proto != null)
+        {
+            return $"{proto.Name} {proto.Id.ToString("N0", actor)}r{proto.RevisionNumber.ToString("N0", actor)} x {item.QuantityDiceExpression.ColourCommand()}";
+        }
+
+        var material = item.CommodityMaterial;
+        if (material != null)
+        {
+            var weight = DescribeCommodityWeight(item, actor);
+            return $"{weight} {material.Name.Colour(material.ResidueColour)}{(item.CommodityTag != null ? $" [{item.CommodityTag.FullName.ColourName()}]" : string.Empty)}";
+        }
+
+        return "Missing".ColourError();
+    }
+
+    private string DescribeCommodityWeight(IForagable item, ICharacter actor)
+    {
+        if (string.IsNullOrWhiteSpace(item.CommodityWeightExpression))
+        {
+            return "missing weight".ColourError();
+        }
+
+        return double.TryParse(item.CommodityWeightExpression, System.Globalization.NumberStyles.Float, CultureInfo.InvariantCulture, out var weight)
+            ? Gameworld.UnitManager.DescribeExact(weight, UnitType.Mass, actor).ColourValue()
+            : item.CommodityWeightExpression.ColourCommand();
+    }
 
     public override void Save()
     {
@@ -259,7 +292,7 @@ public class ForagableProfile : EditableItem, IForagableProfile
 	#3yield <which> clear#0 - removes a yield from this profile
 	#3foragable <which>#0 - toggles a foragable belonging to this profile
 
-Yield types are the resource pools in a location. Foragables are the item results that can appear when a player uses #3forage <yield>#0. A foragable linked to this profile will only appear if at least one of its types has a matching yield here.";
+Yield types are the resource pools in a location. Foragables are the item or commodity results that can appear when a player uses #3forage <yield>#0. A foragable linked to this profile will only appear if at least one of its types has a matching yield here.";
 
     public override bool BuildingCommand(ICharacter actor, StringStack command)
     {
@@ -455,7 +488,7 @@ Yield types are the resource pools in a location. Foragables are the item result
         return
             Foragables.Where(
                           x =>
-                              x.ItemProto != null &&
+                              CanProduceOutput(x) &&
                               x.ForagableTypes.Any(y =>
                                   y.Equals(foragableType, StringComparison.InvariantCultureIgnoreCase)) &&
                               forageOutcome.TryGetValue(x.ForageDifficulty, out var outcome) &&

--- a/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextConfiguring2.cs
+++ b/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextConfiguring2.cs
@@ -2869,6 +2869,15 @@ namespace MudSharp.Database
 
                 entity.Property(e => e.CanForageProgId).HasColumnType("bigint(20)");
 
+                entity.Property(e => e.CommodityMaterialId).HasColumnType("bigint(20)");
+
+                entity.Property(e => e.CommodityTagId).HasColumnType("bigint(20)");
+
+                entity.Property(e => e.CommodityWeightExpression)
+                    .HasColumnType("varchar(200)")
+                    .HasCharSet("utf8mb4")
+                    .UseCollation("utf8mb4_unicode_ci");
+
                 entity.Property(e => e.EditableItemId).HasColumnType("bigint(20)");
 
                 entity.Property(e => e.ForagableTypes)

--- a/MudsharpDatabaseLibrary/Migrations/20260523205847_ForagableCommodityOutput.Designer.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260523205847_ForagableCommodityOutput.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MudSharp.Database;
 
@@ -11,9 +12,11 @@ using MudSharp.Database;
 namespace MudSharp.Migrations
 {
     [DbContext(typeof(FuturemudDatabaseContext))]
-    partial class FutureMUDContextModelSnapshot : ModelSnapshot
+    [Migration("20260523205847_ForagableCommodityOutput")]
+    partial class ForagableCommodityOutput
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MudsharpDatabaseLibrary/Migrations/20260523205847_ForagableCommodityOutput.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260523205847_ForagableCommodityOutput.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MudSharp.Migrations
+{
+    /// <inheritdoc />
+    public partial class ForagableCommodityOutput : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "CommodityMaterialId",
+                table: "Foragables",
+                type: "bigint(20)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "CommodityTagId",
+                table: "Foragables",
+                type: "bigint(20)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CommodityWeightExpression",
+                table: "Foragables",
+                type: "varchar(200)",
+                nullable: true,
+                collation: "utf8mb4_unicode_ci")
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CommodityMaterialId",
+                table: "Foragables");
+
+            migrationBuilder.DropColumn(
+                name: "CommodityTagId",
+                table: "Foragables");
+
+            migrationBuilder.DropColumn(
+                name: "CommodityWeightExpression",
+                table: "Foragables");
+        }
+    }
+}

--- a/MudsharpDatabaseLibrary/Models/Foragable.cs
+++ b/MudsharpDatabaseLibrary/Models/Foragable.cs
@@ -14,6 +14,9 @@ namespace MudSharp.Models
         public int MaximumOutcome { get; set; }
         public string QuantityDiceExpression { get; set; }
         public long ItemProtoId { get; set; }
+        public long? CommodityMaterialId { get; set; }
+        public long? CommodityTagId { get; set; }
+        public string CommodityWeightExpression { get; set; }
         public long? OnForageProgId { get; set; }
         public long? CanForageProgId { get; set; }
         public long EditableItemId { get; set; }


### PR DESCRIPTION
## Summary
- Adds commodity output support to foragables alongside legacy item prototype outputs, with builder commands for material, tag, and weight expressions.
- Updates forage runtime, display/list surfaces, persistence, migration/snapshot data, and documentation for commodity-producing foragables.
- Tightens submit validation so a foragable cannot be both item-backed and commodity-backed, including incomplete commodity rows.

## Validation
- `git diff --check`
- `git diff --cached --check`
- `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 --filter ForagingRuntimeTests -p:NoWarn=NU1902%3BNU1510`