### PR TITLE
Seed item metadata and functional craft tags

### DIFF
--- a/DatabaseSeeder Unit Tests/ItemSeederAntiquityHouseholdCraftingTests.cs
+++ b/DatabaseSeeder Unit Tests/ItemSeederAntiquityHouseholdCraftingTests.cs
@@ -20,22 +20,19 @@ public class ItemSeederAntiquityHouseholdCraftingTests
 	}
 
 	[TestMethod]
-	public void AntiquityHouseholdCrafts_DiscoverAllHouseholdGoodsByMarketTags()
+	public void AntiquityHouseholdCrafts_DiscoverAllHouseholdGoodsByFunctionalTags()
 	{
 		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.AntiquityHousehold.cs");
 		var craftRoot = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.cs");
 
 		AssertContains(craftRoot, "SeedAntiquityFurnitureAndContainerCrafts();");
-		AssertContains(craftSource, "Market / Household Goods");
-		AssertContains(craftSource, "Market / Writing Materials");
-		AssertContains(craftSource, "Market / Religious Goods");
-		AssertContains(craftSource, "Market / Lighting");
-		AssertContains(craftSource, "Market / Domestic Heating");
-		AssertContains(craftSource, "Market / Construction Materials");
-		AssertContains(craftSource, "Materials / Writing Product");
+		AssertContains(craftSource, "Functions / Household Items");
+		AssertContains(craftSource, "Functions / Writing Goods");
 		AssertContains(craftSource, "GameItemProtosTags.Any");
 		AssertContains(craftSource, "SeedAntiquityHouseholdIntermediateCommodityCrafts();");
 		AssertContains(craftSource, "targetItems");
+		Assert.IsFalse(craftSource.Contains("Market /", StringComparison.Ordinal),
+			"Household crafts should discover products through functional tags rather than market tags.");
 	}
 
 	[TestMethod]

--- a/DatabaseSeeder Unit Tests/ItemSeederAntiquityRemainingCraftingTests.cs
+++ b/DatabaseSeeder Unit Tests/ItemSeederAntiquityRemainingCraftingTests.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using DatabaseSeeder.Seeders;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
@@ -23,15 +24,18 @@ public class ItemSeederAntiquityRemainingCraftingTests
 		"SeedAntiquityWeaponsShieldsAccessories"
 	];
 
-	private static readonly string[] HouseholdCraftRoots =
+	private static readonly string[] HouseholdCraftFunctionalRoots =
 	[
-		"Market / Household Goods",
-		"Market / Writing Materials",
-		"Market / Religious Goods",
-		"Market / Lighting",
-		"Market / Domestic Heating",
-		"Market / Construction Materials",
-		"Materials / Writing Product"
+		"Functions / Household Items",
+		"Functions / Writing Goods"
+	];
+
+	private static readonly string[] CraftToolFunctionalRoots =
+	[
+		"Functions / Tools",
+		"Functions / Separation",
+		"Functions / Joining",
+		"Functions / Sharpening"
 	];
 
 	[TestMethod]
@@ -191,7 +195,7 @@ public class ItemSeederAntiquityRemainingCraftingTests
 			"AddAntiquityCraft(",
 			"knowledgeSubtype:",
 			"knowledgeDescription:",
-			"Market / Military Goods"
+			"Functions / Military Equipment"
 		})
 		{
 			AssertContains(equipmentCraftSource, expected);
@@ -244,8 +248,10 @@ public class ItemSeederAntiquityRemainingCraftingTests
 
 		foreach (var expected in new[]
 		{
-			"professionalToolTagIds",
-			"Market / Professional Tools / Standard Tools",
+			"craftToolTagIds",
+			"AntiquityCraftToolFunctionalRoots",
+			"Functions / Tools",
+			"Functions / Sharpening",
 			"AntiquityUnlitWorkshopApparatusStableReferences",
 			"AntiquityLitWorkshopApparatusStableReferences",
 			"antiquity_workshop_hearth",
@@ -484,19 +490,19 @@ public class ItemSeederAntiquityRemainingCraftingTests
 	private static bool IsHouseholdDynamicTarget(SeededAntiquityItem item)
 	{
 		return item.MethodName is "SeedAntiquityContainers" or "SeedAntiquityDoorsAndLocks" or "SeedAntiquityHouseholdFurniture" &&
-		       HasAnyRoot(item.Tags, HouseholdCraftRoots);
+		       HasAnyRoot(item.Tags, HouseholdCraftFunctionalRoots);
 	}
 
 	private static bool IsMilitaryEquipmentTarget(SeededAntiquityItem item, string existingCraftSource)
 	{
-		return HasRoot(item.Tags, "Market / Military Goods") &&
+		return HasRoot(item.Tags, "Functions / Military Equipment") &&
 		       !existingCraftSource.Contains($"\"{item.StableReference}\"", StringComparison.Ordinal);
 	}
 
 	private static bool IsAntiquityCraftToolTarget(SeededAntiquityItem item)
 	{
 		return item.MethodName.Equals("SeedAntiquityClothing", StringComparison.Ordinal) &&
-		       HasRoot(item.Tags, "Market / Professional Tools / Standard Tools");
+		       HasAnyRoot(item.Tags, CraftToolFunctionalRoots);
 	}
 
 	private static bool IsCoveredPartialStableReference(string stableReference, string partialItemSource,
@@ -510,14 +516,14 @@ public class ItemSeederAntiquityRemainingCraftingTests
 	private static bool IsDynamicStandardToolHelperReference(string stableReference, string partialItemSource,
 		string equipmentCraftSource)
 	{
-		if (!equipmentCraftSource.Contains("professionalToolTagIds", StringComparison.Ordinal))
+		if (!equipmentCraftSource.Contains("AntiquityCraftToolFunctionalRoots", StringComparison.Ordinal))
 		{
 			return false;
 		}
 
 		var escapedStableReference = Regex.Escape(stableReference);
 		if (Regex.IsMatch(partialItemSource, $@"CreateAntiquityHouseholdCraftTool\(\s*""{escapedStableReference}""") &&
-		    partialItemSource.Contains("var tags = new List<string> { \"Market / Professional Tools / Standard Tools\" };", StringComparison.Ordinal))
+		    partialItemSource.Contains("tags.AddRange(functionalTags);", StringComparison.Ordinal))
 		{
 			return true;
 		}
@@ -529,13 +535,14 @@ public class ItemSeederAntiquityRemainingCraftingTests
 		}
 
 		if (Regex.IsMatch(partialItemSource, $@"AddWritingCraftTool\(\s*""{escapedStableReference}""") &&
-		    partialItemSource.Contains("[\"Market / Professional Tools / Standard Tools\", .. functionalTags]", StringComparison.Ordinal))
+		    partialItemSource.Contains(".. functionalTags", StringComparison.Ordinal))
 		{
 			return true;
 		}
 
 		var itemBlock = TryExtractCallBlockContaining(partialItemSource, $"\"{stableReference}\"");
-		return itemBlock?.Contains("Market / Professional Tools / Standard Tools", StringComparison.Ordinal) == true;
+		return itemBlock is not null &&
+		       CraftToolFunctionalRoots.Any(root => itemBlock.Contains(root, StringComparison.Ordinal));
 	}
 
 	private static bool IsFoodFinishedBeverageMorphTarget(string stableReference, string partialItemSource)
@@ -582,10 +589,18 @@ public class ItemSeederAntiquityRemainingCraftingTests
 				match.Groups["ref"].Value,
 				match.Groups["short"].Value,
 				match.Groups["material"].Value,
-				Regex.Matches(match.Groups["tags"].Value, @"""(?<tag>[^""]+)""")
-					.Select(tagMatch => tagMatch.Groups["tag"].Value)
+				ExpandInferredFunctionalTags(Regex.Matches(match.Groups["tags"].Value, @"""(?<tag>[^""]+)""")
+					.Select(tagMatch => tagMatch.Groups["tag"].Value))
 					.ToList()))
 			.ToList();
+	}
+
+	private static IEnumerable<string> ExpandInferredFunctionalTags(IEnumerable<string> tags)
+	{
+		var tagList = tags.ToList();
+		return tagList
+			.Concat(ItemSeeder.InferReworkFunctionalTagsForTesting(tagList))
+			.Distinct(StringComparer.OrdinalIgnoreCase);
 	}
 
 	private static bool HasAnyRoot(IEnumerable<string> tags, IEnumerable<string> roots)

--- a/DatabaseSeeder Unit Tests/ItemSeederReworkMetadataTests.cs
+++ b/DatabaseSeeder Unit Tests/ItemSeederReworkMetadataTests.cs
@@ -1,0 +1,301 @@
+#nullable enable
+
+using DatabaseSeeder.Seeders;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Database;
+using MudSharp.Models;
+using System;
+using System.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class ItemSeederReworkMetadataTests
+{
+	private static FuturemudDatabaseContext BuildContext()
+	{
+		var options = new DbContextOptionsBuilder<FuturemudDatabaseContext>()
+			.UseInMemoryDatabase(Guid.NewGuid().ToString())
+			.ConfigureWarnings(x => x.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+			.Options;
+		return new FuturemudDatabaseContext(options);
+	}
+
+	[TestMethod]
+	public void BuildReworkItemBuilderNotes_RecordsStableReferenceCultureAndCategory()
+	{
+		var notes = ItemSeeder.BuildReworkItemBuilderNotesForTesting(
+			"antiquity_food_hellenic_flatbread",
+			["Food and Drink / Antiquity Food / Prepared Foods"],
+			"Crafted through Hellenic Foodways.");
+
+		StringAssert.Contains(notes, "Stock unique reference: antiquity_food_hellenic_flatbread.");
+		StringAssert.Contains(notes, "Cultures: Hellenic.");
+		StringAssert.Contains(notes, "Seeder category: antiquity food and beverage stock.");
+		StringAssert.Contains(notes, "Crafted through Hellenic Foodways.");
+	}
+
+	[TestMethod]
+	public void BuildReworkItemBuilderNotes_RecordsSharedCultureMembership()
+	{
+		var notes = ItemSeeder.BuildReworkItemBuilderNotesForTesting(
+			"adjacent_antiquity_narrow_linen_kilt",
+			[]);
+
+		StringAssert.Contains(notes, "Cultures: Egyptian, Kushite.");
+	}
+
+	[TestMethod]
+	public void InferReworkFunctionalTags_MirrorsMarketTagsWithoutRemovingThem()
+	{
+		var inferredTags = ItemSeeder.InferReworkFunctionalTagsForTesting(
+			[
+				"Market / Professional Tools / Standard Tools",
+				"Market / Military Goods / Armour / Shields",
+				"Market / Household Goods / Luxury Furniture",
+				"Market / Writing Materials / Scrolls",
+				"Materials / Writing Product"
+			]).ToList();
+
+		CollectionAssert.Contains(inferredTags, "Functions / Tools");
+		CollectionAssert.Contains(inferredTags, "Functions / Military Equipment");
+		CollectionAssert.Contains(inferredTags, "Functions / Military Equipment / Military Armour");
+		CollectionAssert.Contains(inferredTags, "Functions / Military Equipment / Military Armour / Military Shields");
+		CollectionAssert.Contains(inferredTags, "Functions / Household Items");
+		CollectionAssert.Contains(inferredTags, "Functions / Household Items / Household Furniture");
+		CollectionAssert.Contains(inferredTags, "Functions / Writing Goods");
+	}
+
+	[TestMethod]
+	public void CreateReworkItem_AssignsStableReferenceAsUniqueName()
+	{
+		using var context = BuildContext();
+		SeedPrerequisites(context);
+
+		var item = new ItemSeeder().CreateReworkItemForTesting(
+			context,
+			"antiquity_short_wool_chiton",
+			"chiton",
+			"a test wool chiton",
+			"wool");
+
+		Assert.IsNotNull(item);
+		Assert.AreEqual("antiquity_short_wool_chiton", item!.UniqueName);
+		StringAssert.Contains(item.BuilderNotes, "Stock unique reference: antiquity_short_wool_chiton.");
+		StringAssert.Contains(item.BuilderNotes, "Cultures: Hellenic.");
+	}
+
+	[TestMethod]
+	public void CreateReworkItem_BackfillsExistingItemMetadataWithoutReplacingBuilderNotes()
+	{
+		using var context = BuildContext();
+		SeedPrerequisites(context);
+		context.GameItemProtos.Add(Item(
+			10,
+			"chiton",
+			"a reused wool chiton",
+			"wool",
+			null,
+			"Existing builder-maintained note."));
+		context.SaveChanges();
+
+		var item = new ItemSeeder().CreateReworkItemForTesting(
+			context,
+			"antiquity_short_wool_chiton",
+			"chiton",
+			"a reused wool chiton",
+			"wool");
+
+		Assert.IsNotNull(item);
+		Assert.AreEqual(10, item!.Id);
+		Assert.AreEqual("antiquity_short_wool_chiton", item.UniqueName);
+		StringAssert.Contains(item.BuilderNotes, "Existing builder-maintained note.");
+		StringAssert.Contains(item.BuilderNotes, "Stock unique reference: antiquity_short_wool_chiton.");
+		StringAssert.Contains(item.BuilderNotes, "Cultures: Hellenic.");
+	}
+
+	[TestMethod]
+	public void CreateReworkItem_BackfillsInferredFunctionalTagsOntoExistingItems()
+	{
+		using var context = BuildContext();
+		SeedPrerequisites(context);
+		context.GameItemProtos.Add(Item(
+			11,
+			"hammer",
+			"a reused workshop hammer",
+			"wool",
+			null,
+			null));
+		context.SaveChanges();
+
+		var item = new ItemSeeder().CreateReworkItemForTesting(
+			context,
+			"antiquity_reused_workshop_hammer",
+			"hammer",
+			"a reused workshop hammer",
+			"wool",
+			tags: ["Market / Professional Tools / Standard Tools"]);
+
+		Assert.IsNotNull(item);
+		var tagNames = item!.GameItemProtosTags
+			.Select(x => context.Tags.Single(tag => tag.Id == x.TagId).Name)
+			.ToList();
+		CollectionAssert.Contains(tagNames, "Standard Tools");
+		CollectionAssert.Contains(tagNames, "Tools");
+	}
+
+	[TestMethod]
+	public void CreateReworkItem_DoesNotCollapseDistinctStableReferencesWithSameShortDescription()
+	{
+		using var context = BuildContext();
+		SeedPrerequisites(context);
+		var seeder = new ItemSeeder();
+
+		var roman = seeder.CreateReworkItemForTesting(
+			context,
+			"antiquity_roman_bronze_greaves",
+			"greaves",
+			"a pair of bronze greaves",
+			"wool");
+		var hellenic = seeder.CreateReworkItemForTesting(
+			context,
+			"antiquity_hellenic_bronze_greaves",
+			"greaves",
+			"a pair of bronze greaves",
+			"wool");
+
+		Assert.IsNotNull(roman);
+		Assert.IsNotNull(hellenic);
+		Assert.AreNotEqual(roman!.Id, hellenic!.Id);
+		Assert.AreEqual("antiquity_roman_bronze_greaves", roman.UniqueName);
+		Assert.AreEqual("antiquity_hellenic_bronze_greaves", hellenic.UniqueName);
+		StringAssert.Contains(roman.BuilderNotes, "Cultures: Roman.");
+		StringAssert.Contains(hellenic.BuilderNotes, "Cultures: Hellenic.");
+	}
+
+	private static void SeedPrerequisites(FuturemudDatabaseContext context)
+	{
+		context.Accounts.Add(new Account
+		{
+			Id = 1,
+			Name = "SeederTest",
+			Password = "password",
+			Salt = 1,
+			AccessStatus = 0,
+			Email = "seeder@example.com",
+			LastLoginIp = "127.0.0.1",
+			FormatLength = 80,
+			InnerFormatLength = 78,
+			UseMxp = false,
+			UseMsp = false,
+			UseMccp = false,
+			ActiveCharactersAllowed = 1,
+			UseUnicode = true,
+			TimeZoneId = "UTC",
+			CultureName = "en-AU",
+			RegistrationCode = string.Empty,
+			IsRegistered = true,
+			RecoveryCode = string.Empty,
+			UnitPreference = "metric",
+			CreationDate = DateTime.UtcNow,
+			PageLength = 22,
+			PromptType = 0,
+			TabRoomDescriptions = false,
+			CodedRoomDescriptionAdditionsOnNewLine = false,
+			CharacterNameOverlaySetting = 0,
+			AppendNewlinesBetweenMultipleEchoesPerPrompt = false,
+			ActLawfully = false,
+			HasBeenActiveInWeek = true,
+			HintsEnabled = true,
+			AutoReacquireTargets = false
+		});
+		context.Materials.Add(Material(1, "wool"));
+		var functions = Tag(1, "Functions");
+		var tools = Tag(2, "Tools", functions);
+		var market = Tag(3, "Market");
+		var professionalTools = Tag(4, "Professional Tools", market);
+		var standardTools = Tag(5, "Standard Tools", professionalTools);
+		context.Tags.AddRange(functions, tools, market, professionalTools, standardTools);
+		context.GameItemProtos.Add(Item(1, "dummy", "a dummy item", "wool", null, null));
+		context.SaveChanges();
+	}
+
+	private static Material Material(long id, string name)
+	{
+		return new Material
+		{
+			Id = id,
+			Name = name,
+			MaterialDescription = name,
+			Type = 0,
+			BehaviourType = 0,
+			Density = 1.0,
+			Organic = true,
+			ResidueSdesc = string.Empty,
+			ResidueDesc = string.Empty,
+			ResidueColour = "grey"
+		};
+	}
+
+	private static Tag Tag(long id, string name, Tag? parent = null)
+	{
+		return new Tag
+		{
+			Id = id,
+			Name = name,
+			Parent = parent
+		};
+	}
+
+	private static GameItemProto Item(
+		long id,
+		string name,
+		string shortDescription,
+		string material,
+		string? uniqueName,
+		string? builderNotes)
+	{
+		return new GameItemProto
+		{
+			Id = id,
+			Name = name,
+			UniqueName = uniqueName,
+			BuilderNotes = builderNotes,
+			Keywords = name,
+			MaterialId = material == "wool" ? 1 : 0,
+			EditableItem = Editable(),
+			RevisionNumber = 0,
+			Size = 0,
+			Weight = 1.0,
+			ReadOnly = false,
+			LongDescription = string.Empty,
+			BaseItemQuality = 0,
+			CustomColour = string.Empty,
+			MorphTimeSeconds = 0,
+			MorphEmote = string.Empty,
+			ShortDescription = shortDescription,
+			FullDescription = string.Empty,
+			PermitPlayerSkins = false,
+			CostInBaseCurrency = 0.0M,
+			IsHiddenFromPlayers = false,
+			PlanarData = string.Empty
+		};
+	}
+
+	private static EditableItem Editable()
+	{
+		return new EditableItem
+		{
+			RevisionNumber = 0,
+			RevisionStatus = 4,
+			BuilderAccountId = 1,
+			BuilderDate = DateTime.UtcNow,
+			BuilderComment = "test",
+			ReviewerAccountId = 1,
+			ReviewerComment = "test",
+			ReviewerDate = DateTime.UtcNow
+		};
+	}
+}

--- a/DatabaseSeeder/Seeders/ItemSeeder.Rework.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Rework.cs
@@ -1,4 +1,5 @@
-﻿using MudSharp.Framework;
+﻿using MudSharp.Database;
+using MudSharp.Framework;
 using MudSharp.GameItems;
 using MudSharp.Models;
 using System;
@@ -27,23 +28,32 @@ namespace DatabaseSeeder.Seeders
                                                   string? morphToUniqueReference,
                                                   string? morphEmote,
                                                   TimeSpan? morphTimer,
-                                                  string? destroyedItemUniqueReference)
+                                                  string? destroyedItemUniqueReference,
+                                                  string? builderNotes = null)
         {
+            var tagList = BuildReworkItemTagList(tags);
+            var componentList = components as IReadOnlyCollection<string> ?? components.ToArray();
+
             if (_items.TryGetValue(stableReference, out var existing))
             {
+                ApplyReworkItemMetadata(existing, stableReference, tagList, builderNotes);
                 ApplyItemLifecycleSettings(existing, morphToUniqueReference, morphEmote, morphTimer, destroyedItemUniqueReference);
                 return existing;
             }
 
             existing = _context!.GameItemProtos.Local
                 .AsEnumerable()
-                .FirstOrDefault(x => x.ShortDescription.Equals(sdesc, StringComparison.OrdinalIgnoreCase)) ??
+                .FirstOrDefault(x => x.UniqueName?.Equals(stableReference, StringComparison.OrdinalIgnoreCase) == true) ??
                        _context.GameItemProtos.AsEnumerable()
-                           .FirstOrDefault(x => x.ShortDescription.Equals(sdesc, StringComparison.OrdinalIgnoreCase));
+                           .FirstOrDefault(x => x.UniqueName?.Equals(stableReference, StringComparison.OrdinalIgnoreCase) == true) ??
+                       _context.GameItemProtos.AsEnumerable()
+                           .FirstOrDefault(x =>
+                               string.IsNullOrWhiteSpace(x.UniqueName) &&
+                               x.ShortDescription.Equals(sdesc, StringComparison.OrdinalIgnoreCase));
             if (existing is not null)
             {
-                _items[stableReference] = existing;
-                _items[existing.ShortDescription] = existing;
+                ApplyReworkItemMetadata(existing, stableReference, tagList, builderNotes);
+                CacheReworkItem(stableReference, existing);
                 ApplyItemLifecycleSettings(existing, morphToUniqueReference, morphEmote, morphTimer, destroyedItemUniqueReference);
                 return existing;
             }
@@ -52,6 +62,8 @@ namespace DatabaseSeeder.Seeders
             {
                 Id = _nextId++,
                 Name = noun.ToLowerInvariant(),
+                UniqueName = GameItemProtoLookupExtensions.NormaliseUniqueName(stableReference),
+                BuilderNotes = BuildReworkItemBuilderNotes(stableReference, tagList, builderNotes),
                 Keywords = new ExplodedString(sdesc.Strip_A_An()).Words.Distinct().ListToCommaSeparatedValues(" "),
                 MaterialId = _materials[material].Id,
                 EditableItem = new EditableItem
@@ -79,7 +91,7 @@ namespace DatabaseSeeder.Seeders
                 MorphTimeSeconds = 0,
                 MorphEmote = "$0 $?1|morphs into $1|decays into nothing$.",
             };
-            foreach (string item in tags)
+            foreach (string item in tagList)
             {
                 if (string.IsNullOrEmpty(item))
                 {
@@ -98,7 +110,7 @@ namespace DatabaseSeeder.Seeders
                 });
             }
 
-            foreach (string item in components)
+            foreach (string item in componentList)
             {
                 if (string.IsNullOrEmpty(item))
                 {
@@ -118,10 +130,354 @@ namespace DatabaseSeeder.Seeders
             }
 
             _context!.GameItemProtos.Add(dbitem);
-            _items[stableReference] = dbitem;
-            _items[dbitem.ShortDescription] = dbitem;
+            CacheReworkItem(stableReference, dbitem);
             ApplyItemLifecycleSettings(dbitem, morphToUniqueReference, morphEmote, morphTimer, destroyedItemUniqueReference);
             return dbitem;
+        }
+
+        private void CacheReworkItem(string stableReference, GameItemProto item)
+        {
+            _items[stableReference] = item;
+            _items[item.ShortDescription] = item;
+            if (!string.IsNullOrWhiteSpace(item.UniqueName))
+            {
+                _items[item.UniqueName] = item;
+            }
+        }
+
+        private static readonly (string Token, string Culture)[] ReworkStableReferenceCultureTokens =
+        [
+            ("_hellenic_", "Hellenic"),
+            ("_roman_", "Roman"),
+            ("_italic_", "Italic/Roman"),
+            ("_celtic_", "Celtic"),
+            ("_germanic_", "Germanic"),
+            ("_punic_", "Punic"),
+            ("_phoenician_", "Punic/Phoenician"),
+            ("_persian_", "Persian"),
+            ("_median_", "Persian/Median"),
+            ("_egyptian_", "Egyptian"),
+            ("_kushite_", "Kushite"),
+            ("_nubian_", "Kushite/Nubian"),
+            ("_etruscan_", "Etruscan"),
+            ("_anatolian_", "Anatolian"),
+            ("_scythian_", "Scythian-Sarmatian"),
+            ("_sarmatian_", "Scythian-Sarmatian"),
+            ("_steppe_", "Scythian-Sarmatian")
+        ];
+
+        private static readonly (string SourceRoot, string FunctionalTag)[] ReworkFunctionalTagMappings =
+        [
+            ("Market / Professional Tools", "Functions / Tools"),
+            ("Market / Military Goods", "Functions / Military Equipment"),
+            ("Market / Military Goods / Weapons", "Functions / Military Equipment / Military Weapons"),
+            ("Market / Military Goods / Ammunition", "Functions / Military Equipment / Military Ammunition"),
+            ("Market / Military Goods / Armour", "Functions / Military Equipment / Military Armour"),
+            ("Market / Military Goods / Armour / Shields", "Functions / Military Equipment / Military Armour / Military Shields"),
+            ("Market / Household Goods", "Functions / Household Items"),
+            ("Market / Household Goods / Simple Furniture", "Functions / Household Items / Household Furniture"),
+            ("Market / Household Goods / Standard Furniture", "Functions / Household Items / Household Furniture"),
+            ("Market / Household Goods / Luxury Furniture", "Functions / Household Items / Household Furniture"),
+            ("Market / Household Goods / Simple Decorations", "Functions / Household Items / Household Decorations"),
+            ("Market / Household Goods / Standard Decorations", "Functions / Household Items / Household Decorations"),
+            ("Market / Household Goods / Luxury Decorations", "Functions / Household Items / Household Decorations"),
+            ("Market / Household Goods / Simple Wares", "Functions / Household Items / Household Wares"),
+            ("Market / Household Goods / Standard Wares", "Functions / Household Items / Household Wares"),
+            ("Market / Household Goods / Luxury Wares", "Functions / Household Items / Household Wares"),
+            ("Market / Religious Goods", "Functions / Household Items / Household Religious Items"),
+            ("Market / Lighting", "Functions / Household Items / Household Lighting"),
+            ("Market / Domestic Heating", "Functions / Household Items / Household Heating"),
+            ("Market / Construction Materials", "Functions / Household Items / Household Construction Materials"),
+            ("Market / Writing Materials", "Functions / Writing Goods"),
+            ("Materials / Writing Product", "Functions / Writing Goods")
+        ];
+
+        private IReadOnlyCollection<string> BuildReworkItemTagList(IEnumerable<string> tags)
+        {
+            var tagList = new List<string>();
+
+            void AddTag(string tag, bool requireKnownTag)
+            {
+                if (string.IsNullOrWhiteSpace(tag))
+                {
+                    return;
+                }
+
+                var trimmedTag = tag.Trim();
+                if (requireKnownTag && !_tagsByFullPath.ContainsKey(trimmedTag))
+                {
+                    return;
+                }
+
+                if (tagList.Any(x => x.Equals(trimmedTag, StringComparison.InvariantCultureIgnoreCase)))
+                {
+                    return;
+                }
+
+                tagList.Add(trimmedTag);
+            }
+
+            foreach (var tag in tags)
+            {
+                AddTag(tag, false);
+                foreach (var functionalTag in InferReworkFunctionalTags(tag))
+                {
+                    AddTag(functionalTag, true);
+                }
+            }
+
+            return tagList;
+        }
+
+        private static IEnumerable<string> InferReworkFunctionalTags(string tag)
+        {
+            foreach (var (sourceRoot, functionalTag) in ReworkFunctionalTagMappings)
+            {
+                if (ReworkTagPathMatchesRoot(tag, sourceRoot))
+                {
+                    yield return functionalTag;
+                }
+            }
+        }
+
+        private static bool ReworkTagPathMatchesRoot(string tagPath, string root)
+        {
+            return tagPath.Equals(root, StringComparison.OrdinalIgnoreCase) ||
+                   tagPath.StartsWith($"{root} /", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private void ApplyReworkItemMetadata(GameItemProto item,
+                                             string stableReference,
+                                             IEnumerable<string> tags,
+                                             string? builderNotes)
+        {
+            item.UniqueName = string.IsNullOrWhiteSpace(item.UniqueName)
+                ? GameItemProtoLookupExtensions.NormaliseUniqueName(stableReference)
+                : item.UniqueName;
+            item.BuilderNotes = MergeBuilderNotes(
+                item.BuilderNotes,
+                BuildReworkItemBuilderNotes(stableReference, tags, builderNotes));
+            ApplyReworkItemTags(item, tags);
+        }
+
+        private void ApplyReworkItemTags(GameItemProto item, IEnumerable<string> tags)
+        {
+            var existingTagIds = item.GameItemProtosTags
+                .Select(x => x.TagId)
+                .ToHashSet();
+
+            foreach (var tag in tags)
+            {
+                if (string.IsNullOrWhiteSpace(tag) ||
+                    !_tagsByFullPath.TryGetValue(tag, out var dbtag) ||
+                    !existingTagIds.Add(dbtag.Id))
+                {
+                    continue;
+                }
+
+                item.GameItemProtosTags.Add(new GameItemProtosTags
+                {
+                    GameItemProto = item,
+                    TagId = dbtag.Id
+                });
+            }
+        }
+
+        private static string BuildReworkItemBuilderNotes(string stableReference, IEnumerable<string> tags, string? builderNotes)
+        {
+            var notes = new List<string>
+            {
+                $"Stock unique reference: {stableReference}."
+            };
+
+            var cultures = GetReworkItemCultureContexts(stableReference);
+            if (cultures.Count > 0)
+            {
+                notes.Add($"Cultures: {string.Join(", ", cultures)}.");
+            }
+
+            var category = GetReworkItemBuilderCategory(stableReference, tags);
+            if (!string.IsNullOrWhiteSpace(category))
+            {
+                notes.Add($"Seeder category: {category}.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(builderNotes))
+            {
+                notes.Add(builderNotes.Trim());
+            }
+
+            return string.Join("\n", notes);
+        }
+
+        private static string? MergeBuilderNotes(string? existingNotes, string? additionalNotes)
+        {
+            if (string.IsNullOrWhiteSpace(additionalNotes))
+            {
+                return string.IsNullOrWhiteSpace(existingNotes) ? null : existingNotes.Trim();
+            }
+
+            var trimmedAdditional = additionalNotes.Trim();
+            if (string.IsNullOrWhiteSpace(existingNotes))
+            {
+                return trimmedAdditional;
+            }
+
+            var trimmedExisting = existingNotes.Trim();
+            var newLines = trimmedAdditional
+                .Split(["\r\n", "\n"], StringSplitOptions.RemoveEmptyEntries)
+                .Select(x => x.Trim())
+                .Where(x => !string.IsNullOrWhiteSpace(x))
+                .Where(x => !trimmedExisting.Contains(x, StringComparison.InvariantCultureIgnoreCase))
+                .ToList();
+
+            return newLines.Count == 0
+                ? trimmedExisting
+                : $"{trimmedExisting}\n{string.Join("\n", newLines)}";
+        }
+
+        private static IReadOnlyList<string> GetReworkItemCultureContexts(string stableReference)
+        {
+            var cultures = new List<string>();
+
+            void AddCulture(string culture)
+            {
+                if (!cultures.Any(x => x.Equals(culture, StringComparison.InvariantCultureIgnoreCase)))
+                {
+                    cultures.Add(culture);
+                }
+            }
+
+            void AddIfStableReferenceIn(IReadOnlyDictionary<string, string> stableReferences, string culture)
+            {
+                if (stableReferences.ContainsKey(stableReference))
+                {
+                    AddCulture(culture);
+                }
+            }
+
+            AddIfStableReferenceIn(HellenicAntiquityClothingStableReferences, "Hellenic");
+            AddIfStableReferenceIn(EgyptianAntiquityClothingStableReferences, "Egyptian");
+            AddIfStableReferenceIn(RomanAntiquityClothingStableReferences, "Roman");
+            AddIfStableReferenceIn(CelticAntiquityClothingStableReferences, "Celtic");
+            AddIfStableReferenceIn(GermanicAntiquityClothingStableReferences, "Germanic");
+            AddIfStableReferenceIn(KushiteAntiquityClothingStableReferences, "Kushite");
+            AddIfStableReferenceIn(PunicAntiquityClothingStableReferences, "Punic");
+            AddIfStableReferenceIn(PersianAntiquityClothingStableReferences, "Persian");
+            AddIfStableReferenceIn(EtruscanAntiquityClothingStableReferences, "Etruscan");
+            AddIfStableReferenceIn(AnatolianAntiquityClothingStableReferences, "Anatolian");
+            AddIfStableReferenceIn(ScythianSarmatianAntiquityClothingStableReferences, "Scythian-Sarmatian");
+
+            foreach (var culture in AntiquityFoodCultures)
+            {
+                if (stableReference.StartsWith($"antiquity_food_{culture.Key}_", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    AddCulture(culture.Display);
+                }
+            }
+
+            foreach (var (token, culture) in ReworkStableReferenceCultureTokens)
+            {
+                if (stableReference.Contains(token, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    AddCulture(culture);
+                }
+            }
+
+            return cultures;
+        }
+
+        private static string? GetReworkItemBuilderCategory(string stableReference, IEnumerable<string> tags)
+        {
+            var tagList = tags.ToList();
+            bool HasTagText(string text)
+            {
+                return tagList.Any(x => x.Contains(text, StringComparison.InvariantCultureIgnoreCase));
+            }
+
+            if (stableReference.StartsWith("antiquity_food_", StringComparison.InvariantCultureIgnoreCase))
+            {
+                return "antiquity food and beverage stock";
+            }
+
+            if (stableReference.StartsWith("jewellery_", StringComparison.InvariantCultureIgnoreCase) ||
+                HasTagText("Jewellery"))
+            {
+                return "antiquity jewellery stock";
+            }
+
+            if (HasTagText("Professional Tools"))
+            {
+                return "antiquity tool or workshop support stock";
+            }
+
+            if (HasTagText("Military Goods"))
+            {
+                return "antiquity military stock";
+            }
+
+            if (HasTagText("Furniture"))
+            {
+                return "antiquity furniture stock";
+            }
+
+            if (HasTagText("Food and Drink"))
+            {
+                return "antiquity food and drink stock";
+            }
+
+            return null;
+        }
+
+        internal static string BuildReworkItemBuilderNotesForTesting(string stableReference,
+                                                                     IEnumerable<string> tags,
+                                                                     string? builderNotes = null)
+        {
+            return BuildReworkItemBuilderNotes(stableReference, tags, builderNotes);
+        }
+
+        internal static IReadOnlyList<string> InferReworkFunctionalTagsForTesting(IEnumerable<string> tags)
+        {
+            return tags
+                .SelectMany(InferReworkFunctionalTags)
+                .Distinct(StringComparer.InvariantCultureIgnoreCase)
+                .ToList();
+        }
+
+        internal MudSharp.Models.GameItemProto? CreateReworkItemForTesting(FuturemudDatabaseContext context,
+                                                                           string stableReference,
+                                                                           string noun,
+                                                                           string shortDescription,
+                                                                           string material,
+                                                                           string? builderNotes = null,
+                                                                           IEnumerable<string>? tags = null)
+        {
+            if (!ReferenceEquals(_context, context))
+            {
+                _context = context;
+                InitialiseDependencies();
+            }
+
+            return CreateItem(
+                stableReference,
+                noun,
+                shortDescription,
+                null,
+                "A test item.",
+                SizeCategory.Small,
+                ItemQuality.Standard,
+                1.0,
+                1.0M,
+                false,
+                false,
+                material,
+                tags ?? [],
+                [],
+                null,
+                null,
+                null,
+                null,
+                builderNotes);
         }
 
         private void ApplyItemLifecycleSettings(GameItemProto item,

--- a/DatabaseSeeder/Seeders/ItemSeeder.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.cs
@@ -128,7 +128,9 @@ The items and crafts are fairly universal and of approximately medieval to renei
         _tagsByFullPath = tagList.ToDictionary(BuildTagFullPath, x => x, StringComparer.OrdinalIgnoreCase);
         _materials = _context.Materials.ToDictionary(x => x.Name, x => x, StringComparer.OrdinalIgnoreCase);
         _liquids = _context.Liquids.ToDictionary(x => x.Name, x => x, StringComparer.OrdinalIgnoreCase);
-        _nextId = _context.GameItemProtos.Max(x => x.Id) + 1;
+        _nextId = _context.GameItemProtos.Any()
+            ? _context.GameItemProtos.Max(x => x.Id) + 1
+            : 1;
         _dbAccount = _context.Accounts.First();
 
         foreach (TraitDefinition trait in _context.TraitDefinitions)
@@ -139,6 +141,10 @@ The items and crafts are fairly universal and of approximately medieval to renei
         foreach (GameItemProto item in _context.GameItemProtos)
         {
             _items[item.ShortDescription] = item;
+            if (!string.IsNullOrWhiteSpace(item.UniqueName))
+            {
+                _items[item.UniqueName] = item;
+            }
         }
     }
 

--- a/DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityEquipment.cs
+++ b/DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityEquipment.cs
@@ -14,9 +14,17 @@ public partial class ItemSeeder
 	private const string AncientToolmakingKnowledge = "Ancient Toolmaking";
 	private const string AncientCommonClothingKnowledge = "Ancient Common Clothing Crafting";
 
-	private static readonly string[] AntiquityMilitaryCraftMarketRoots =
+	private static readonly string[] AntiquityMilitaryCraftFunctionalRoots =
 	[
-		"Market / Military Goods"
+		"Functions / Military Equipment"
+	];
+
+	private static readonly string[] AntiquityCraftToolFunctionalRoots =
+	[
+		"Functions / Tools",
+		"Functions / Separation",
+		"Functions / Joining",
+		"Functions / Sharpening"
 	];
 
 	private static readonly string[] AntiquityCommonClothingStableReferences =
@@ -622,14 +630,14 @@ public partial class ItemSeeder
 
 	private void SeedAntiquityCraftToolCrafts(IDictionary<string, int> usedCraftNames)
 	{
-		var professionalToolTagIds = GetTagIdsUnderRoots(["Market / Professional Tools / Standard Tools"]);
+		var craftToolTagIds = GetTagIdsUnderRoots(AntiquityCraftToolFunctionalRoots);
 		var stableReferences = AntiquityCraftToolStableReferences
 			.Concat(_items
 				.Where(x => x.Key.StartsWith("antiquity_", StringComparison.OrdinalIgnoreCase))
 				.Where(x => !AntiquityWritingStableReferences.Contains(x.Key, StringComparer.OrdinalIgnoreCase))
 				.Where(x => !AntiquityMedicalStableReferences.Contains(x.Key, StringComparer.OrdinalIgnoreCase))
 				.Where(x => !AntiquityLitWorkshopApparatusStableReferences.Contains(x.Key, StringComparer.OrdinalIgnoreCase))
-				.Where(x => x.Value.GameItemProtosTags.Any(y => professionalToolTagIds.Contains(y.TagId)))
+				.Where(x => x.Value.GameItemProtosTags.Any(y => craftToolTagIds.Contains(y.TagId)))
 				.Select(x => x.Key))
 			.Concat(AntiquityUnlitWorkshopApparatusStableReferences)
 			.Distinct(StringComparer.OrdinalIgnoreCase)
@@ -650,7 +658,7 @@ public partial class ItemSeeder
 
 	private void SeedAntiquityMilitaryEquipmentCrafts(IDictionary<string, int> usedCraftNames)
 	{
-		var militaryTagIds = GetTagIdsUnderRoots(AntiquityMilitaryCraftMarketRoots);
+		var militaryTagIds = GetTagIdsUnderRoots(AntiquityMilitaryCraftFunctionalRoots);
 		var targetItems = _items
 			.Where(x => x.Key.StartsWith("antiquity_", StringComparison.OrdinalIgnoreCase))
 			.Where(x => x.Value.GameItemProtosTags.Any(y => militaryTagIds.Contains(y.TagId)))

--- a/DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityHousehold.cs
+++ b/DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityHousehold.cs
@@ -19,15 +19,10 @@ public partial class ItemSeeder
 	private const string AncientStoneCarvingKnowledge = "Ancient Stone Bone and Horn Carving";
 	private const string AncientLightingKnowledge = "Ancient Lighting and Heating";
 
-	private static readonly string[] AntiquityHouseholdCraftMarketRoots =
+	private static readonly string[] AntiquityHouseholdCraftFunctionalRoots =
 	[
-		"Market / Household Goods",
-		"Market / Writing Materials",
-		"Market / Religious Goods",
-		"Market / Lighting",
-		"Market / Domestic Heating",
-		"Market / Construction Materials",
-		"Materials / Writing Product"
+		"Functions / Household Items",
+		"Functions / Writing Goods"
 	];
 
 	private sealed record AntiquityHouseholdCraftPath(
@@ -122,7 +117,7 @@ public partial class ItemSeeder
 
 		SeedAntiquityHouseholdIntermediateCommodityCrafts();
 
-		var householdTagIds = GetTagIdsUnderRoots(AntiquityHouseholdCraftMarketRoots);
+		var householdTagIds = GetTagIdsUnderRoots(AntiquityHouseholdCraftFunctionalRoots);
 
 		var targetItems = _items
 			.Where(x => x.Key.StartsWith("antiquity_", StringComparison.OrdinalIgnoreCase))

--- a/DatabaseSeeder/Seeders/UsefulSeeder.Tags.cs
+++ b/DatabaseSeeder/Seeders/UsefulSeeder.Tags.cs
@@ -178,6 +178,23 @@ namespace DatabaseSeeder.Seeders
             AddTag(context, "Mobility Aid", "Medical Treatment");
             AddTag(context, "Herbal Remedy", "Medical Treatment");
 
+            // Functional catalogue roles distinct from market/pricing categories
+            AddTag(context, "Military Equipment", "Functions");
+            AddTag(context, "Military Weapons", "Military Equipment");
+            AddTag(context, "Military Ammunition", "Military Equipment");
+            AddTag(context, "Military Armour", "Military Equipment");
+            AddTag(context, "Military Shields", "Military Armour");
+
+            AddTag(context, "Household Items", "Functions");
+            AddTag(context, "Household Furniture", "Household Items");
+            AddTag(context, "Household Decorations", "Household Items");
+            AddTag(context, "Household Wares", "Household Items");
+            AddTag(context, "Household Religious Items", "Household Items");
+            AddTag(context, "Household Lighting", "Household Items");
+            AddTag(context, "Household Heating", "Household Items");
+            AddTag(context, "Household Construction Materials", "Household Items");
+            AddTag(context, "Writing Goods", "Functions");
+
             // Clothing
             AddTag(context, "Worn Items", "Functions");
             AddTag(context, "Footwear", "Worn Items");

--- a/Design Documents/Crafting/Antiquity_Crafting_Audit.md
+++ b/Design Documents/Crafting/Antiquity_Crafting_Audit.md
@@ -31,9 +31,9 @@ Current craft definitions are seeded from:
 
 The suite-specific docs now catalogue every stable reference explicitly named by those craft source files. Dynamic discovery surfaces are documented by their source counts and inventory lists:
 
-- 398 household/container/door/furniture targets discovered from household, writing, religious, lighting, heating, construction, and writing-product tag roots.
+- 398 household/container/door/furniture targets discovered from functional household and writing tag roots.
 - 162 jewellery targets discovered from jewellery tags and catalogued in the dedicated jewellery suite.
-- 193 military equipment targets discovered from `Market / Military Goods`, split into 76 armour prototypes and 117 weapon, shield, ammunition, sling, and accessory prototypes.
+- 193 military equipment targets discovered from `Functions / Military Equipment`, split into 76 armour prototypes and 117 weapon, shield, ammunition, sling, and accessory prototypes.
 - the food and beverage suite documents the explicit `antiquity_food_` stable-reference prefix plus the shared amphora references used by liquid filling, fermentation, and aging crafts.
 - 395 stable references explicitly named in the pre-food non-jewellery antiquity craft source files, plus the dynamically discovered jewellery catalogue, the food prefix catalogue, and source-audited partial seeder coverage for food, household tools, medical items, and writing items.
 
@@ -49,7 +49,7 @@ The suite-specific docs now catalogue every stable reference explicitly named by
 - Support tools and unlit workshop apparatus are now craftable through the expanded equipment toolmaking pass.
 - Glassworking now uses a lit glory-hole furnace for hot working and a lit annealing lehr for cooling finished glass.
 - Food and beverage crafts now add commodity-first grain, pulse, meat, preservation, broth, fermented drink, condiment, luxury beverage, and culture-gated prepared-food chains in the `ItemSeeder` rework path, assuming the butchery package has seeded its raw animal outputs.
-- Food tools now carry `Market / Professional Tools / Standard Tools` in addition to their functional tags, so the dynamic equipment toolmaking suite covers them.
+- Food tools now carry exact functional tool tags and retain `Market / Professional Tools / Standard Tools` for economy use; the dynamic equipment toolmaking suite discovers them through functional tool roots.
 - Empty food serving and fermenting amphorae are craftable through pottery recipes that consume fired-clay `Bisque Vessel Blank` and `Prepared Pitch`; finished beer, date beer, wine, kumis, garum, and spiced beverage amphorae remain fermentation or aging morph targets.
 - Kumis beverage stock consumes milk instead of grain wort. Red and white wine remain core liquids supplied by `CoreDataSeeder.Materials.cs`, not duplicate food-seeder liquids.
 - Raw hides from `AnimalButcherySeeder` now have a bridge craft into raw `animal skin` commodity stock before the existing prepared-hide and tanning chain.
@@ -61,10 +61,10 @@ The suite-specific docs now catalogue every stable reference explicitly named by
 The next-pass implementation resolves the earlier follow-up gaps as follows:
 
 - `SeedAntiquityJewelleryCrafts()` now discovers all 162 `SeedAntiquityJewellery` prototypes and `Antiquity_Jewellery_Crafting_Suite.md` catalogues every stable reference.
-- The expanded equipment craft pass discovers stock support tools from `Market / Professional Tools / Standard Tools` and explicitly includes unlit workshop apparatus. Support tools and unlit workshop apparatus are now craftable instead of remaining stock-only prerequisites.
+- The expanded equipment craft pass discovers stock support tools from functional tool roots and explicitly includes unlit workshop apparatus. Support tools and unlit workshop apparatus are now craftable instead of remaining stock-only prerequisites.
 - Glassworking now has a glassworking glory-hole furnace pair, `antiquity_glory_hole_furnace` and `antiquity_lit_glory_hole_furnace`. Hot glassworking crafts require the lit glory-hole furnace, while annealing still requires the lit annealing lehr.
 - The food pass is kept wholly in `ItemSeeder` partials: item, liquid, prepared-food and spoilage-rule setup runs with rework items, and the matching crafts run with the normal ItemSeeder craft pass.
-- The food gap closure keeps this pattern: food tools use the standard tool market root, empty amphorae use the household pottery stock chain, fermented beverages and garum finish through morphing amphorae, and culture beverage inputs now branch kumis to milk before the grain-wort fallback.
+- The food gap closure keeps this pattern: food tools use functional tool tags while retaining the standard tool market root for pricing, empty amphorae use the household pottery stock chain, fermented beverages and garum finish through morphing amphorae, and culture beverage inputs now branch kumis to milk before the grain-wort fallback.
 - The pastoral and derivative closure keeps the same commodity-first style: AgricultureSeeder owns crop, herd, and managed woodland production, while ItemSeeder owns reusable processing crafts that turn field outputs into seed stock, liquid milk, compost, textile dye stock, or saffron.
 - The external-catalogue risk is handled with source-backed regression tests rather than a generated file pipeline: tests parse the live seeder source, compare counts, inspect the partial seeder files, and verify that dynamic catalogues are represented in the dedicated design documents.
 

--- a/Design Documents/Crafting/Antiquity_Equipment_Crafting_Suite.md
+++ b/Design Documents/Crafting/Antiquity_Equipment_Crafting_Suite.md
@@ -5,14 +5,14 @@ This document records the craft suite that closes the remaining non-household an
 ## Target Surface
 
 - 29 antiquity craft-tool prototypes from `SeedAntiquityClothing`.
-- Support tool prototypes discovered from `Market / Professional Tools / Standard Tools`, excluding writing and medical products already owned by their dedicated suites.
+- Support tool prototypes discovered from functional tool roots (`Functions / Tools`, `Functions / Separation`, `Functions / Joining`, and `Functions / Sharpening`), excluding writing and medical products already owned by their dedicated suites.
 - Unlit workshop apparatus prototypes for the hearth, kiln, glory-hole furnace, annealing lehr, and smelting furnace.
 - 18 common culture-neutral clothing/accessory prototypes from `SeedAntiquityClothing`.
 - 76 non-leather armour prototypes from `SeedAntiquityArmour`.
 - 117 weapon, shield, ammunition, sling, and military-accessory prototypes from `SeedAntiquityWeaponsShieldsAccessories`.
 - Shared `Door Hardware Stock` used by the expanded household/door suite.
 
-Existing jewellery, culture-specific textile clothing, leather clothing, leather armour, leather containers, leather furnishings, medical goods, writing goods, and household goods stay on their existing suites. The equipment suite discovers military goods dynamically from `Market / Military Goods` tags, discovers support tools dynamically from `Market / Professional Tools / Standard Tools`, and excludes stable references already handled by the culture/leather/writing/medical suites.
+Existing jewellery, culture-specific textile clothing, leather clothing, leather armour, leather containers, leather furnishings, medical goods, writing goods, and household goods stay on their existing suites. The equipment suite discovers military goods dynamically from `Functions / Military Equipment` tags, discovers support tools dynamically from functional tool roots, and excludes stable references already handled by the culture/leather/writing/medical suites. Market tags remain on items for economy and pricing use, but craft discovery is functional-tag based.
 
 ## Implementation
 
@@ -84,7 +84,7 @@ All equipment stock tags are seeded under `Functions / Material Functions / Anti
 
 ## Source-Audited Product Catalogue
 
-The equipment suite has two product surfaces. The military surface is discovered dynamically from `Market / Military Goods` tags, while common clothing and craft-tool products are explicitly named in `ItemSeederCrafting.AntiquityEquipment.cs`.
+The equipment suite has two product surfaces. The military surface is discovered dynamically from `Functions / Military Equipment` tags, while common clothing and craft-tool products are explicitly named or discovered from functional tool tags in `ItemSeederCrafting.AntiquityEquipment.cs`.
 
 ### Armour
 

--- a/Design Documents/Crafting/Antiquity_Food_Beverage_Crafting_Suite.md
+++ b/Design Documents/Crafting/Antiquity_Food_Beverage_Crafting_Suite.md
@@ -36,7 +36,7 @@ Crafts prefer commodity inputs such as `Raw Meat Commodity`, `Prepared Meat Comm
 
 ## Tool And Vessel Closure
 
-Food tools are tagged with their exact functional tool tags and `Market / Professional Tools / Standard Tools`, so the shared antiquity equipment toolmaking suite discovers and crafts them without duplicating one-off recipes in the food file. This covers the butcher's knife, cooking knife, threshing flail, winnowing basket, pitchfork, hand quern, mortar and pestle, grain sieve, fruit press, oil press, mash tun, drying rack, smoking rack, and salting trough.
+Food tools are tagged with their exact functional tool tags and retain `Market / Professional Tools / Standard Tools` for economy use. The shared antiquity equipment toolmaking suite discovers and crafts them through functional tool roots without duplicating one-off recipes in the food file. This covers the butcher's knife, cooking knife, threshing flail, winnowing basket, pitchfork, hand quern, mortar and pestle, grain sieve, fruit press, oil press, mash tun, drying rack, smoking rack, and salting trough.
 
 Empty food vessels are explicit pottery crafts:
 

--- a/Design Documents/Crafting/Antiquity_Furniture_Container_Crafting_Suite.md
+++ b/Design Documents/Crafting/Antiquity_Furniture_Container_Crafting_Suite.md
@@ -13,7 +13,7 @@ The implementation lives in `DatabaseSeeder/Seeders/ItemSeederCrafting.Antiquity
 
 ## Design Goals
 
-1. Every item currently seeded by `SeedAntiquityContainers`, `SeedAntiquityDoorsAndLocks`, and `SeedAntiquityHouseholdFurniture` should have a stock craft path when it is tagged as household, writing, religious, lighting, heating, construction, or writing-product stock.
+1. Every item currently seeded by `SeedAntiquityContainers`, `SeedAntiquityDoorsAndLocks`, and `SeedAntiquityHouseholdFurniture` should have a stock craft path when it is tagged with the functional household or writing roots generated from the item catalogue.
 2. Commodity inputs should be preferred over full-item inputs wherever the input is a mass of material, fittings, fasteners, panels, cloth, clay, wax, glass, metal, reed, leather, or stone stock.
 3. Full items should be used for tools and final products. Full item intermediates should only be used where the object is worth exposing as its own gameplay item.
 4. Final crafts should be knowledge-gated so builders can control which shared techniques and which cultural household suites appear in a game.
@@ -22,8 +22,8 @@ The implementation lives in `DatabaseSeeder/Seeders/ItemSeederCrafting.Antiquity
 ## Implementation Plan
 
 1. Discover the target item groups dynamically.
-   - Rather than maintaining a 398-row stable-reference dictionary, the implemented craft suite discovers antiquity rework items whose seeded tags sit under `Market / Household Goods`, `Market / Writing Materials`, `Market / Religious Goods`, `Market / Lighting`, `Market / Domestic Heating`, `Market / Construction Materials`, or `Materials / Writing Product`.
-   - This keeps the coverage tied to the furniture/container/door catalogue itself and means future household additions are craftable as long as they are tagged consistently.
+   - Rather than maintaining a 398-row stable-reference dictionary, the implemented craft suite discovers antiquity rework items whose seeded tags sit under `Functions / Household Items` or `Functions / Writing Goods`.
+   - This keeps the coverage tied to the furniture/container/door catalogue itself and means future household additions are craftable as long as they carry functional tags. Market tags may still be present for price and commodity-category tuning, but they are not craft selectors.
    - Focused tests assert the current target methods still contain 243 container, 66 door/lock, and 89 household-furniture prototypes, and that the craft suite uses the expanded tag-root discovery.
 
 2. Seed missing tool prototypes.
@@ -395,7 +395,7 @@ Add focused DatabaseSeeder tests:
 | Test | Purpose |
 | --- | --- |
 | `AntiquityHouseholdSeeder_CurrentCatalogueHasFurnitureAndContainerTargets` | Extracts the two target seeder methods and asserts the current 243 container plus 89 household-furniture prototype counts. |
-| `AntiquityHouseholdCrafts_DiscoverAllHouseholdGoodsByMarketTags` | Asserts the craft suite discovers target products through `Market / Household Goods / ...` tags rather than a stale hand-maintained reference list. |
+| `AntiquityHouseholdCrafts_DiscoverAllHouseholdGoodsByFunctionalTags` | Asserts the craft suite discovers target products through functional household/writing tags rather than a stale hand-maintained reference list or market roots. |
 | `ItemSeeder_AntiquityFurnitureAndContainers_KnowledgeGatesAreSeeded` | Asserts shared and culture-specific knowledge names are created and used by at least one craft. |
 | `ItemSeeder_AntiquityFurnitureAndContainers_ToolTagsResolve` | Asserts every `TagTool` referenced by the craft suite has a seeded tag and at least one seeded tool prototype where appropriate. |
 | `ItemSeeder_AntiquityFurnitureAndContainers_NewSkillsResolve` | Asserts `Basketry`, `Coopering`, `Ropemaking`, and `Lacquerwork` exist when the stock skill package is installed. |

--- a/Design Documents/Data/SeededTagHierarchy.csv
+++ b/Design Documents/Data/SeededTagHierarchy.csv
@@ -93,6 +93,20 @@ Suture Kit	Medical Treatment	Functions / Medical Treatment / Suture Kit
 Prosthetic	Medical Treatment	Functions / Medical Treatment / Prosthetic
 Mobility Aid	Medical Treatment	Functions / Medical Treatment / Mobility Aid
 Herbal Remedy	Medical Treatment	Functions / Medical Treatment / Herbal Remedy
+Military Equipment	Functions	Functions / Military Equipment
+Military Weapons	Military Equipment	Functions / Military Equipment / Military Weapons
+Military Ammunition	Military Equipment	Functions / Military Equipment / Military Ammunition
+Military Armour	Military Equipment	Functions / Military Equipment / Military Armour
+Military Shields	Military Armour	Functions / Military Equipment / Military Armour / Military Shields
+Household Items	Functions	Functions / Household Items
+Household Furniture	Household Items	Functions / Household Items / Household Furniture
+Household Decorations	Household Items	Functions / Household Items / Household Decorations
+Household Wares	Household Items	Functions / Household Items / Household Wares
+Household Religious Items	Household Items	Functions / Household Items / Household Religious Items
+Household Lighting	Household Items	Functions / Household Items / Household Lighting
+Household Heating	Household Items	Functions / Household Items / Household Heating
+Household Construction Materials	Household Items	Functions / Household Items / Household Construction Materials
+Writing Goods	Functions	Functions / Writing Goods
 Joining	Functions	Functions / Joining
 Adhesion	Joining	Functions / Joining / Adhesion
 Cement	Adhesion	Functions / Joining / Adhesion / Cement

--- a/Design Documents/Items/Item_System_Content_Workflows.md
+++ b/Design Documents/Items/Item_System_Content_Workflows.md
@@ -101,6 +101,8 @@ Use:
 
 Item prototype lookup prefers numeric ids, then exact `UniqueName`, then the legacy noun/name matching that older builder commands expect. Unique names are optional, case-insensitively unique among active revisions, and cannot be entirely numeric.
 
+Stock rework items seeded by `ItemSeeder` use their stable seeder reference as `UniqueName`. Their builder comments also carry stock-only metadata such as the stable reference, culture context when the catalogue item belongs to a culture-specific slice, and broad seeder package notes.
+
 ### Attach or detach components
 Use:
 - `item set add <id|name>`


### PR DESCRIPTION
## Summary
- add canonical unique names and builder notes to rework item prototypes, including rerun backfill
- infer functional catalogue tags from retained market tags so items keep economy categories without making crafts depend on them
- switch antiquity equipment and household craft discovery to functional tag roots and update docs/tests/tag hierarchy

## Validation
- `dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 --filter ItemSeeder` passed 95/95
- `dotnet build DatabaseSeeder\DatabaseSeeder.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510` passed
- `git diff --check` passed
- Full DatabaseSeeder unit run had one unrelated existing-looking failure: `BlankDatabaseSnapshotTests.CommittedBlankSnapshotManifest_TracksLatestMigration` expected `20260523205847_ForagableCommodityOutput` but manifest has `20260523000000_CommoditySpoilageRules`