### PR TITLE
Add antiquity repair kit seeding

### DIFF
--- a/DatabaseSeeder Unit Tests/ItemSeederAntiquityLeatherCraftingTests.cs
+++ b/DatabaseSeeder Unit Tests/ItemSeederAntiquityLeatherCraftingTests.cs
@@ -147,7 +147,9 @@ public class ItemSeederAntiquityLeatherCraftingTests
 	[TestMethod]
 	public void LeatherCrafts_CoverEveryAntiquityLeatherMaterialItem()
 	{
-		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Antiquity.cs");
+		var craftSource =
+			ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.Antiquity.cs") +
+			ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.AntiquityRepairKits.cs");
 		var itemSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.Antiquity.cs");
 		var leatherItemStableReferences = FindAntiquityLeatherMaterialItemStableReferences(itemSource)
 			.ToArray();

--- a/DatabaseSeeder Unit Tests/ItemSeederAntiquityRemainingCraftingTests.cs
+++ b/DatabaseSeeder Unit Tests/ItemSeederAntiquityRemainingCraftingTests.cs
@@ -19,6 +19,7 @@ public class ItemSeederAntiquityRemainingCraftingTests
 		"SeedAntiquityArmour",
 		"SeedAntiquityContainers",
 		"SeedAntiquityDoorsAndLocks",
+		"SeedAntiquityRepairKits",
 		"SeedAntiquityHouseholdFurniture",
 		"SeedAntiquityWeaponsShieldsAccessories"
 	];
@@ -58,7 +59,7 @@ public class ItemSeederAntiquityRemainingCraftingTests
 			.SelectMany(method => ParseItemsInMethod(itemSource, method))
 			.ToList();
 
-		Assert.AreEqual(1034, items.Count, "The audit should track the current antiquity item catalogue.");
+		Assert.AreEqual(1042, items.Count, "The audit should track the current antiquity item catalogue.");
 		Assert.AreEqual(29, items.Count(IsAntiquityCraftToolTarget));
 		Assert.AreEqual(18, items.Count(x => equipmentCraftSource.Contains($"\"{x.StableReference}\"", StringComparison.Ordinal) &&
 		                                     x.MethodName.Equals("SeedAntiquityClothing", StringComparison.Ordinal) &&
@@ -98,6 +99,68 @@ public class ItemSeederAntiquityRemainingCraftingTests
 
 		Assert.AreEqual(0, uncoveredPartialReferences.Count,
 			$"Expected every explicitly named item in antiquity partial seeders to be craft-covered, dynamically craftable, or a documented morph target. Missing: {string.Join(", ", uncoveredPartialReferences)}");
+	}
+
+	[TestMethod]
+	public void AntiquityRepairKitCrafts_RegisterGeneralMaterialCoverage()
+	{
+		var reworkRoot = ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.cs");
+		var craftRoot = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.cs");
+		var itemSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Rework.Antiquity.cs");
+		var craftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.AntiquityRepairKits.cs");
+		var equipmentCraftSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeederCrafting.AntiquityEquipment.cs");
+		var componentSource = ReadSource("DatabaseSeeder", "Seeders", "UsefulSeeder.ItemComponents.cs");
+		var componentCatalogue = ReadSource("Design Documents", "Data", "Seeded_Item_Components.json");
+		var equipmentDoc = ReadSource("Design Documents", "Crafting", "Antiquity_Equipment_Crafting_Suite.md");
+
+		AssertContains(reworkRoot, "SeedAntiquityRepairKits();");
+		AssertContains(craftRoot, "SeedAntiquityRepairKitCrafts();");
+		AssertContains(itemSource, "private void SeedAntiquityRepairKits()");
+		AssertContains(craftSource, "private void SeedAntiquityRepairKitCrafts()");
+		AssertContains(craftSource, "AncientToolmakingKnowledge");
+		AssertContains(craftSource, "Repair Kits");
+		AssertContains(equipmentCraftSource, "!AntiquityRepairKitStableReferences.Contains");
+
+		var repairItems = ParseItemsInMethod(itemSource, "SeedAntiquityRepairKits");
+		Assert.AreEqual(8, repairItems.Count, "The antiquity repair-kit stock surface should stay intentionally compact.");
+
+		foreach (var expected in new[]
+		{
+			(Stable: "antiquity_textile_repair_kit", Component: "Repair_Cloth", Material: "linen", Skill: "Tailoring"),
+			(Stable: "antiquity_leather_repair_kit", Component: "Repair_Leather", Material: "deer leather", Skill: "Leathermaking"),
+			(Stable: "antiquity_wood_repair_kit", Component: "Repair_Wood", Material: "oak", Skill: "Carpentry"),
+			(Stable: "antiquity_metal_repair_kit", Component: "Repair_Metal", Material: "bronze", Skill: "Blacksmithing"),
+			(Stable: "antiquity_stone_repair_kit", Component: "Repair_Stone", Material: "limestone", Skill: "Masonry"),
+			(Stable: "antiquity_ceramic_repair_kit", Component: "Repair_Ceramic", Material: "earthenware", Skill: "Pottery"),
+			(Stable: "antiquity_hard_organic_repair_kit", Component: "Repair_Hard_Organic", Material: "bone", Skill: "Scrimshawing"),
+			(Stable: "antiquity_field_repair_bundle", Component: "Repair_Universal", Material: "leather", Skill: "Salvaging")
+		})
+		{
+			var block = ExtractCallBlockContaining(itemSource, expected.Stable);
+			AssertContains(block, expected.Component);
+			AssertContains(block, expected.Material);
+			AssertContains(block, "Market / Professional Tools / Standard Tools");
+			AssertContains(block, "Functions / Repairing");
+			AssertContains(craftSource, $"\"{expected.Stable}\"");
+			AssertContains(craftSource, $"\"{expected.Skill}\"");
+			AssertContains(equipmentDoc, $"`{expected.Stable}`");
+			AssertContains(componentCatalogue, expected.Component);
+		}
+
+		foreach (var expectedComponent in new[]
+		{
+			"Repair_Wood",
+			"Repair_Metal",
+			"Repair_Stone",
+			"Repair_Ceramic",
+			"Repair_Hard_Organic"
+		})
+		{
+			AssertContains(componentSource, $"AddRepairKitType(\"{expectedComponent["Repair_".Length..]}\"");
+			AssertContains(componentCatalogue, expectedComponent);
+			AssertContains(componentCatalogue, $"{expectedComponent}_Good");
+			AssertContains(componentCatalogue, $"{expectedComponent}_Poor");
+		}
 	}
 
 	[TestMethod]

--- a/DatabaseSeeder Unit Tests/UsefulSeederItemPackageTests.cs
+++ b/DatabaseSeeder Unit Tests/UsefulSeederItemPackageTests.cs
@@ -6,10 +6,12 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MudSharp.Database;
+using MudSharp.Health;
 using MudSharp.Models;
 using System;
 using System.Linq;
 using System.Xml.Linq;
+using MaterialBehaviourType = MudSharp.Form.Material.MaterialBehaviourType;
 using TraitOwnerScope = MudSharp.Body.Traits.TraitOwnerScope;
 using TraitType = MudSharp.Body.Traits.TraitType;
 using SizeCategory = MudSharp.GameItems.SizeCategory;
@@ -151,6 +153,68 @@ public class UsefulSeederItemPackageTests
 		};
 	}
 
+	private static Tag CreateTag(long id, string name)
+	{
+		return new Tag
+		{
+			Id = id,
+			Name = name
+		};
+	}
+
+	private static Material CreateMaterial(long id, string name, MaterialBehaviourType behaviourType)
+	{
+		return new Material
+		{
+			Id = id,
+			Name = name,
+			MaterialDescription = name,
+			BehaviourType = (int)behaviourType,
+			ResidueSdesc = string.Empty,
+			ResidueDesc = string.Empty,
+			ResidueColour = string.Empty
+		};
+	}
+
+	private static void SeedRepairKitPrerequisites(FuturemudDatabaseContext context)
+	{
+		context.Tags.AddRange(
+			CreateTag(1, "Armour"),
+			CreateTag(2, "Weapons"),
+			CreateTag(3, "Tools"));
+
+		context.TraitDefinitions.AddRange(
+			CreateSkill(101, "Tailoring"),
+			CreateSkill(102, "Armourcrafting"),
+			CreateSkill(103, "Weaponcrafting"),
+			CreateSkill(104, "Blacksmithing"),
+			CreateSkill(105, "Carpentry"),
+			CreateSkill(106, "Masonry"),
+			CreateSkill(107, "Pottery"),
+			CreateSkill(108, "Scrimshawing"),
+			CreateSkill(109, "Salvaging"));
+
+		context.Materials.AddRange(
+			CreateMaterial(201, "linen", MaterialBehaviourType.Fabric),
+			CreateMaterial(202, "hair", MaterialBehaviourType.Hair),
+			CreateMaterial(203, "feather", MaterialBehaviourType.Feather),
+			CreateMaterial(204, "leather", MaterialBehaviourType.Leather),
+			CreateMaterial(205, "skin", MaterialBehaviourType.Skin),
+			CreateMaterial(206, "flesh", MaterialBehaviourType.Flesh),
+			CreateMaterial(207, "bronze", MaterialBehaviourType.Metal),
+			CreateMaterial(208, "oak", MaterialBehaviourType.Wood),
+			CreateMaterial(209, "limestone", MaterialBehaviourType.Stone),
+			CreateMaterial(210, "earthenware", MaterialBehaviourType.Ceramic),
+			CreateMaterial(211, "bone", MaterialBehaviourType.Bone),
+			CreateMaterial(212, "shell", MaterialBehaviourType.Shell),
+			CreateMaterial(213, "horn", MaterialBehaviourType.Horn),
+			CreateMaterial(214, "tooth", MaterialBehaviourType.Tooth),
+			CreateMaterial(215, "scale", MaterialBehaviourType.Scale),
+			CreateMaterial(216, "claw", MaterialBehaviourType.Claw),
+			CreateMaterial(217, "beak", MaterialBehaviourType.Beak));
+		context.SaveChanges();
+	}
+
 	private static void AssertContainerDefinition(GameItemComponentProto component, double weight, SizeCategory maxSize, string preposition, bool closable, bool transparent)
 	{
 		XElement definition = XElement.Parse(component.Definition);
@@ -287,6 +351,64 @@ public class UsefulSeederItemPackageTests
 	}
 
 	[TestMethod]
+	public void SeedRepairKitsForTesting_RerunDoesNotDuplicateAndAddsGeneralMaterialFamilies()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedGeneralPrerequisites(context);
+		SeedRepairKitPrerequisites(context);
+		UsefulSeeder seeder = new();
+
+		seeder.SeedRepairKitsForTesting(context);
+		seeder.SeedRepairKitsForTesting(context);
+
+		foreach (var name in new[]
+		{
+			"Repair_Wood",
+			"Repair_Wood_Good",
+			"Repair_Wood_Poor",
+			"Repair_Metal",
+			"Repair_Metal_Good",
+			"Repair_Metal_Poor",
+			"Repair_Stone",
+			"Repair_Stone_Good",
+			"Repair_Stone_Poor",
+			"Repair_Ceramic",
+			"Repair_Ceramic_Good",
+			"Repair_Ceramic_Poor",
+			"Repair_Hard_Organic",
+			"Repair_Hard_Organic_Good",
+			"Repair_Hard_Organic_Poor"
+		})
+		{
+			Assert.AreEqual(1, context.GameItemComponentProtos.Count(x => x.Name == name), $"Expected one component named {name}.");
+			Assert.AreEqual("RepairKit", context.GameItemComponentProtos.Single(x => x.Name == name).Type);
+		}
+
+		AssertRepairKitDefinition(context, "Repair_Wood", "Carpentry", WoundSeverity.Grievous, 1000.0, 0.0, "oak");
+		AssertRepairKitDefinition(context, "Repair_Wood_Good", "Carpentry", WoundSeverity.Horrifying, 1500.0, 1.0, "oak");
+		AssertRepairKitDefinition(context, "Repair_Wood_Poor", "Carpentry", WoundSeverity.Severe, 600.0, -1.0, "oak");
+
+		AssertRepairKitDefinition(context, "Repair_Metal", "Blacksmithing", WoundSeverity.Grievous, 1000.0, 0.0, "bronze");
+		AssertRepairKitDefinition(context, "Repair_Metal_Good", "Blacksmithing", WoundSeverity.Horrifying, 1500.0, 1.0, "bronze");
+		AssertRepairKitDefinition(context, "Repair_Metal_Poor", "Blacksmithing", WoundSeverity.Severe, 600.0, -1.0, "bronze");
+
+		AssertRepairKitDefinition(context, "Repair_Stone", "Masonry", WoundSeverity.Grievous, 1000.0, 0.0, "limestone");
+		AssertRepairKitDefinition(context, "Repair_Stone_Good", "Masonry", WoundSeverity.Horrifying, 1500.0, 1.0, "limestone");
+		AssertRepairKitDefinition(context, "Repair_Stone_Poor", "Masonry", WoundSeverity.Severe, 600.0, -1.0, "limestone");
+
+		AssertRepairKitDefinition(context, "Repair_Ceramic", "Pottery", WoundSeverity.Grievous, 1000.0, 0.0, "earthenware");
+		AssertRepairKitDefinition(context, "Repair_Ceramic_Good", "Pottery", WoundSeverity.Horrifying, 1500.0, 1.0, "earthenware");
+		AssertRepairKitDefinition(context, "Repair_Ceramic_Poor", "Pottery", WoundSeverity.Severe, 600.0, -1.0, "earthenware");
+
+		AssertRepairKitDefinition(context, "Repair_Hard_Organic", "Scrimshawing", WoundSeverity.Grievous, 1000.0, 0.0,
+			"beak", "bone", "claw", "horn", "scale", "shell", "tooth");
+		AssertRepairKitDefinition(context, "Repair_Hard_Organic_Good", "Scrimshawing", WoundSeverity.Horrifying, 1500.0, 1.0,
+			"beak", "bone", "claw", "horn", "scale", "shell", "tooth");
+		AssertRepairKitDefinition(context, "Repair_Hard_Organic_Poor", "Scrimshawing", WoundSeverity.Severe, 600.0, -1.0,
+			"beak", "bone", "claw", "horn", "scale", "shell", "tooth");
+	}
+
+	[TestMethod]
 	public void SeedWornTraitChangersForTesting_NoExpectedSkillPackageTraits_SkipsFamily()
 	{
 		using FuturemudDatabaseContext context = BuildContext();
@@ -348,6 +470,30 @@ public class UsefulSeederItemPackageTests
 		Assert.AreEqual(5.0, ModifierFor(Component("WornTraitChanger_StealthMobilityBonus_Moderate"), 106));
 
 		GameItemComponentProto Component(string name) => context.GameItemComponentProtos.Single(x => x.Name == name);
+	}
+
+	private static void AssertRepairKitDefinition(FuturemudDatabaseContext context, string componentName, string traitName,
+		WoundSeverity maximumSeverity, double repairPoints, double checkBonus, params string[] expectedMaterials)
+	{
+		var component = context.GameItemComponentProtos.Single(x => x.Name == componentName);
+		XElement definition = XElement.Parse(component.Definition);
+		Assert.AreEqual((int)maximumSeverity, (int)definition.Element("MaximumSeverity")!);
+		Assert.AreEqual(repairPoints, (double)definition.Element("RepairPoints")!);
+		Assert.AreEqual(context.TraitDefinitions.Single(x => x.Name == traitName).Id, (long)definition.Element("CheckTrait")!);
+		Assert.AreEqual(checkBonus, (double)definition.Element("CheckBonus")!);
+		Assert.AreEqual(0, definition.Element("Tags")!.Elements("Tag").Count(), $"{componentName} should not require category tags.");
+
+		var materialIds = definition.Element("Materials")!
+		                            .Elements("Material")
+		                            .Select(x => (long)x)
+		                            .ToHashSet();
+		var materialNames = context.Materials
+		                           .AsEnumerable()
+		                           .Where(x => materialIds.Contains(x.Id))
+		                           .Select(x => x.Name)
+		                           .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+		                           .ToArray();
+		CollectionAssert.AreEqual(expectedMaterials.OrderBy(x => x, StringComparer.OrdinalIgnoreCase).ToArray(), materialNames);
 	}
 
 	private static double ModifierFor(GameItemComponentProto component, long traitId)

--- a/DatabaseSeeder/Seeders/ItemSeeder.Rework.Antiquity.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Rework.Antiquity.cs
@@ -16425,6 +16425,177 @@ namespace DatabaseSeeder.Seeders
 
         }
 
+        private void SeedAntiquityRepairKits()
+        {
+            CreateItem(
+                "antiquity_textile_repair_kit",
+                "kit",
+                "a linen textile repair kit",
+                null,
+                "This compact repair kit is wrapped in a roll of sturdy linen and tied with braided cord. Inside are packets of thread, folded patches, spare ties, small needles, and a few smooth tools for setting cloth back into shape. It is arranged for quick repairs to garments, padding, coverings, and other fabric goods.",
+                SizeCategory.Normal,
+                ItemQuality.Standard,
+                450.0,
+                35.0m,
+                true,
+                false,
+                "linen",
+                ["Market / Professional Tools / Standard Tools", "Functions / Repairing"],
+                ["Holdable", "Destroyable_Misc", "Repair_Cloth"],
+                null,
+                null,
+                null,
+                null
+            );
+
+            CreateItem(
+                "antiquity_leather_repair_kit",
+                "kit",
+                "a leather repair kit",
+                null,
+                "This leather repair kit is packed into a soft deer-leather pouch with rows of narrow pockets stitched inside. It holds waxed thread, thongs, small patches, awls, burnishers, and scraps suitable for binding split seams or replacing worn straps. The contents are practical and field-ready rather than ornamental.",
+                SizeCategory.Normal,
+                ItemQuality.Standard,
+                700.0,
+                45.0m,
+                true,
+                false,
+                "deer leather",
+                ["Market / Professional Tools / Standard Tools", "Functions / Repairing"],
+                ["Holdable", "Destroyable_Misc", "Repair_Leather"],
+                null,
+                null,
+                null,
+                null
+            );
+
+            CreateItem(
+                "antiquity_wood_repair_kit",
+                "kit",
+                "a woodwork repair kit",
+                null,
+                "This oak repair kit keeps wedges, pegs, binding cord, small clamps, and dressed slips of wood bundled inside a shallow tool tray. Its contents are suited to splinting cracks, tightening joints, and replacing small worn fittings on doors, furniture, tools, and wooden weapons. The kit smells faintly of resin and scraped hardwood.",
+                SizeCategory.Normal,
+                ItemQuality.Standard,
+                1200.0,
+                38.0m,
+                true,
+                false,
+                "oak",
+                ["Market / Professional Tools / Standard Tools", "Functions / Repairing"],
+                ["Holdable", "Destroyable_Misc", "Repair_Wood"],
+                null,
+                null,
+                null,
+                null
+            );
+
+            CreateItem(
+                "antiquity_metal_repair_kit",
+                "kit",
+                "a bronze metal repair kit",
+                null,
+                "This bronze repair kit carries small rivets, binding strips, soft wire, polishing grit, and compact shaping tools in a compartmented leather-lined case. It is meant for mending ordinary metal fittings, tool heads, hinges, studs, trim, and battered household hardware. The pieces inside are scuffed from repeated use around forge and workshop benches.",
+                SizeCategory.Normal,
+                ItemQuality.Standard,
+                1600.0,
+                80.0m,
+                true,
+                false,
+                "bronze",
+                ["Market / Professional Tools / Standard Tools", "Functions / Repairing"],
+                ["Holdable", "Destroyable_Misc", "Repair_Metal"],
+                null,
+                null,
+                null,
+                null
+            );
+
+            CreateItem(
+                "antiquity_stone_repair_kit",
+                "kit",
+                "a stone repair kit",
+                null,
+                "This limestone repair kit is a heavy bundle of fitted chips, fine abrasive, wedges, binding cord, and small smoothing tools. The pieces are chosen for patching chipped stoneware, heavy fittings, work surfaces, and shaped tool parts without needing a full quarrying setup. Its wrapping is dusted pale from the stone grit inside.",
+                SizeCategory.Normal,
+                ItemQuality.Standard,
+                1800.0,
+                50.0m,
+                true,
+                false,
+                "limestone",
+                ["Market / Professional Tools / Standard Tools", "Functions / Repairing"],
+                ["Holdable", "Destroyable_Misc", "Repair_Stone"],
+                null,
+                null,
+                null,
+                null
+            );
+
+            CreateItem(
+                "antiquity_ceramic_repair_kit",
+                "kit",
+                "a ceramic repair kit",
+                null,
+                "This earthenware repair kit keeps powdered clay, slip, burnishing stones, small smoothing ribs, and wrapped sherd patches together in a padded basket. It is suited to stabilising cracked vessels, tablets, lamps, and fired-clay fittings before more complete workshop repair. The contents are dry, powdery, and carefully cushioned.",
+                SizeCategory.Normal,
+                ItemQuality.Standard,
+                1000.0,
+                36.0m,
+                true,
+                false,
+                "earthenware",
+                ["Market / Professional Tools / Standard Tools", "Functions / Repairing"],
+                ["Holdable", "Destroyable_Misc", "Repair_Ceramic"],
+                null,
+                null,
+                null,
+                null
+            );
+
+            CreateItem(
+                "antiquity_hard_organic_repair_kit",
+                "kit",
+                "a bone and horn repair kit",
+                null,
+                "This bone repair kit holds smooth pegs, small slivers of horn and shell, binding sinew, abrasive grit, and a few fine scraping tools. It is built for mending hard organic pieces such as handles, fittings, pins, gaming pieces, tools, and light decorative parts. The kit is neat, pale, and faintly polished from handling.",
+                SizeCategory.Normal,
+                ItemQuality.Standard,
+                900.0,
+                55.0m,
+                true,
+                false,
+                "bone",
+                ["Market / Professional Tools / Standard Tools", "Functions / Repairing"],
+                ["Holdable", "Destroyable_Misc", "Repair_Hard_Organic"],
+                null,
+                null,
+                null,
+                null
+            );
+
+            CreateItem(
+                "antiquity_field_repair_bundle",
+                "bundle",
+                "a mixed field repair bundle",
+                null,
+                "This leather bundle is tied around a mixed assortment of patches, cord, wedges, pins, scraps, grit, glue, and small hand tools. Nothing inside is specialised, but the bundle gives a traveller or quartermaster a way to make temporary repairs to almost any damaged object. It is bulky, useful, and plainly meant for hard use.",
+                SizeCategory.Normal,
+                ItemQuality.Standard,
+                1400.0,
+                60.0m,
+                true,
+                false,
+                "leather",
+                ["Market / Professional Tools / Standard Tools", "Functions / Repairing"],
+                ["Holdable", "Destroyable_Misc", "Repair_Universal"],
+                null,
+                null,
+                null,
+                null
+            );
+        }
+
         private void SeedAntiquityHouseholdFurniture()
         {
             CreateItem(

--- a/DatabaseSeeder/Seeders/ItemSeeder.Rework.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Rework.cs
@@ -180,6 +180,7 @@ namespace DatabaseSeeder.Seeders
                 SeedAntiquityArmour();
                 SeedAntiquityContainers();
                 SeedAntiquityDoorsAndLocks();
+                SeedAntiquityRepairKits();
                 SeedAntiquityHouseholdFurniture();
                 SeedAntiquityWeaponsShieldsAccessories();
                 SeedAntiquityApiaryItems();

--- a/DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityEquipment.cs
+++ b/DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityEquipment.cs
@@ -629,6 +629,7 @@ public partial class ItemSeeder
 				.Where(x => !AntiquityWritingStableReferences.Contains(x.Key, StringComparer.OrdinalIgnoreCase))
 				.Where(x => !AntiquityMedicalStableReferences.Contains(x.Key, StringComparer.OrdinalIgnoreCase))
 				.Where(x => !AntiquityLitWorkshopApparatusStableReferences.Contains(x.Key, StringComparer.OrdinalIgnoreCase))
+				.Where(x => !AntiquityRepairKitStableReferences.Contains(x.Key, StringComparer.OrdinalIgnoreCase))
 				.Where(x => x.Value.GameItemProtosTags.Any(y => professionalToolTagIds.Contains(y.TagId)))
 				.Select(x => x.Key))
 			.Concat(AntiquityUnlitWorkshopApparatusStableReferences)

--- a/DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityRepairKits.cs
+++ b/DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityRepairKits.cs
@@ -1,0 +1,238 @@
+using MudSharp.RPG.Checks;
+using System.Collections.Generic;
+
+namespace DatabaseSeeder.Seeders;
+
+public partial class ItemSeeder
+{
+	private static readonly string[] AntiquityRepairKitStableReferences =
+	[
+		"antiquity_textile_repair_kit",
+		"antiquity_leather_repair_kit",
+		"antiquity_wood_repair_kit",
+		"antiquity_metal_repair_kit",
+		"antiquity_stone_repair_kit",
+		"antiquity_ceramic_repair_kit",
+		"antiquity_hard_organic_repair_kit",
+		"antiquity_field_repair_bundle"
+	];
+
+	private sealed record AntiquityRepairKitCraftSpec(
+		string StableReference,
+		string Name,
+		string Category,
+		string TraitName,
+		string Blurb,
+		string Action,
+		int MinimumTraitValue,
+		Difficulty Difficulty,
+		IReadOnlyList<string> Inputs,
+		IReadOnlyList<string> Tools);
+
+	private void SeedAntiquityRepairKitCrafts()
+	{
+		if (!ShouldSeedAntiquityCrafts())
+		{
+			return;
+		}
+
+		foreach (var kit in AntiquityRepairKitCrafts())
+		{
+			if (!TryLookupReworkItem(kit.StableReference, out _))
+			{
+				continue;
+			}
+
+			AddAntiquityCraft(
+				kit.Name,
+				kit.Category,
+				kit.Blurb,
+				kit.Action,
+				"a repair kit assembly",
+				AncientToolmakingKnowledge,
+				kit.TraitName,
+				kit.MinimumTraitValue,
+				kit.Difficulty,
+				AntiquityRepairKitAssemblyPhases(),
+				kit.Inputs,
+				kit.Tools,
+				[StableSimpleProduct(kit.StableReference)],
+				knowledgeSubtype: "Repair Kits",
+				knowledgeDescription: "Ancient Toolmaking covers assembling portable repair kits from prepared workshop stock.",
+				knowledgeLongDescription: "Ancient Toolmaking covers assembling portable repair kits from prepared workshop stock for textile, leather, wood, metal, stone, ceramic, hard organic, and mixed field repairs.");
+		}
+	}
+
+	private static IReadOnlyList<AntiquityRepairKitCraftSpec> AntiquityRepairKitCrafts()
+	{
+		return
+		[
+			new(
+				"antiquity_textile_repair_kit",
+				"assemble textile repair kit",
+				"Tailoring",
+				"Tailoring",
+				"assemble a textile repair kit",
+				"assembling a textile repair kit",
+				12,
+				Difficulty.Easy,
+				[
+					CommodityInput(450.0, "linen", "Garment Cloth", colour: true, fineColour: true),
+					CommodityInput(60.0, "linen", "Spun Yarn", colour: true),
+					CommodityInput(40.0, "beeswax")
+				],
+				[
+					"TagTool - Held - an item with the Sewing Needle tag",
+					"TagTool - Held - an item with the Shears tag"
+				]),
+
+			new(
+				"antiquity_leather_repair_kit",
+				"assemble leather repair kit",
+				"Leathermaking",
+				"Leathermaking",
+				"assemble a leather repair kit",
+				"assembling a leather repair kit",
+				14,
+				Difficulty.Easy,
+				[
+					CommodityInput(500.0, "deer leather", "Prepared Leather Panel", colour: true, fineColour: true),
+					CommodityInput(100.0, "leather", "Military Cord Stock", colour: true),
+					CommodityInput(50.0, "beeswax")
+				],
+				[
+					"TagTool - Held - an item with the Awl Punch tag",
+					"TagTool - Held - an item with the Sewing Needle tag"
+				]),
+
+			new(
+				"antiquity_wood_repair_kit",
+				"assemble woodwork repair kit",
+				"Carpentry",
+				"Carpentry",
+				"assemble a woodwork repair kit",
+				"assembling a woodwork repair kit",
+				16,
+				Difficulty.Easy,
+				[
+					CommodityInput(600.0, "oak", "Tool Blank Stock"),
+					CommodityInput(300.0, "oak", "Furniture Timber Stock"),
+					CommodityInput(60.0, "beeswax")
+				],
+				[
+					"TagTool - Held - an item with the Hand Saw tag",
+					"TagTool - Held - an item with the Wood Chisel tag",
+					"TagTool - Held - an item with the Rasp tag"
+				]),
+
+			new(
+				"antiquity_metal_repair_kit",
+				"assemble metal repair kit",
+				"Blacksmithing",
+				"Blacksmithing",
+				"assemble a metal repair kit",
+				"assembling a metal repair kit",
+				18,
+				Difficulty.Normal,
+				[
+					CommodityInput(800.0, "bronze", "Tool Blank Stock"),
+					CommodityInput(250.0, "bronze", "Door Hardware Stock"),
+					CommodityInput(60.0, "beeswax")
+				],
+				[
+					"TagTool - Held - an item with the Hammer tag",
+					"TagTool - InRoom - an item with the Anvil tag",
+					"TagTool - Held - an item with the Forge Tongs tag"
+				]),
+
+			new(
+				"antiquity_stone_repair_kit",
+				"assemble stone repair kit",
+				"Masonry",
+				"Masonry",
+				"assemble a stone repair kit",
+				"assembling a stone repair kit",
+				16,
+				Difficulty.Easy,
+				[
+					CommodityInput(900.0, "limestone", "Tool Blank Stock"),
+					CommodityInput(120.0, "leather", "Prepared Leather Panel", colour: true)
+				],
+				[
+					"TagTool - Held - an item with the Stone Chisel tag",
+					"TagTool - Held - an item with the Stone Mallet tag",
+					"TagTool - Held - an item with the Polishing Stone tag"
+				]),
+
+			new(
+				"antiquity_ceramic_repair_kit",
+				"assemble ceramic repair kit",
+				"Pottery",
+				"Pottery",
+				"assemble a ceramic repair kit",
+				"assembling a ceramic repair kit",
+				16,
+				Difficulty.Easy,
+				[
+					CommodityInput(700.0, "earthenware", "Bisque Vessel Blank", colour: true, fineColour: true),
+					CommodityInput(120.0, "clay", "Pottery Clay Body")
+				],
+				[
+					"TagTool - Held - an item with the Potter's Rib tag",
+					"TagTool - InRoom - an item with the Potter's Wheel tag",
+					"TagTool - InRoom - an item with the Lit Kiln tag"
+				]),
+
+			new(
+				"antiquity_hard_organic_repair_kit",
+				"assemble bone and horn repair kit",
+				"Scrimshawing",
+				"Scrimshawing",
+				"assemble a bone and horn repair kit",
+				"assembling a bone and horn repair kit",
+				16,
+				Difficulty.Easy,
+				[
+					CommodityInput(650.0, "bone", "Tool Blank Stock"),
+					CommodityInput(120.0, "leather", "Prepared Leather Panel", colour: true)
+				],
+				[
+					"TagTool - Held - an item with the Stone Chisel tag",
+					"TagTool - Held - an item with the Polishing Stone tag"
+				]),
+
+			new(
+				"antiquity_field_repair_bundle",
+				"assemble mixed field repair bundle",
+				"Salvaging",
+				"Salvaging",
+				"assemble a mixed field repair bundle",
+				"assembling a mixed field repair bundle",
+				12,
+				Difficulty.Normal,
+				[
+					CommodityInput(250.0, "leather", "Prepared Leather Panel", colour: true),
+					CommodityInput(250.0, "linen", "Garment Cloth", colour: true, fineColour: true),
+					CommodityInput(200.0, "oak", "Tool Blank Stock"),
+					CommodityInput(150.0, "bronze", "Tool Blank Stock"),
+					CommodityInput(60.0, "beeswax")
+				],
+				[
+					"TagTool - Held - an item with the Awl Punch tag",
+					"TagTool - Held - an item with the Hammer tag",
+					"TagTool - Held - an item with the Sewing Needle tag"
+				])
+		];
+	}
+
+	private static (int Seconds, string Echo, string FailEcho)[] AntiquityRepairKitAssemblyPhases()
+	{
+		return
+		[
+			(25, "$0 lay|lays out the prepared repair stock and sort|sorts it into usable packets.", "$0 lay|lays out the prepared stock, but miss|misses damaged or unsuitable pieces."),
+			(35, "$0 trim|trims patches, fasteners, and small fittings with $t1.", "$0 trim|trims the repair stock poorly, spoiling some of the useful pieces."),
+			(35, "$0 bind|binds the packets and tools into a compact repair kit.", "$0 bind|binds the packets poorly, leaving the kit loose and confused."),
+			(25, "$0 close|closes $p1 and check|checks that the supplies are secure.", "$0 close|closes the kit, but the contents are too disordered to keep.")
+		];
+	}
+}

--- a/DatabaseSeeder/Seeders/ItemSeederCrafting.cs
+++ b/DatabaseSeeder/Seeders/ItemSeederCrafting.cs
@@ -2221,6 +2221,7 @@ return ""You need at least {minimumTraitValue.Value.ToString(System.Globalizatio
 		SeedAntiquityWritingCrafts();
 		SeedAntiquityMedicalCrafts();
 		SeedAntiquityFurnitureAndContainerCrafts();
+		SeedAntiquityRepairKitCrafts();
 		SeedAntiquityLeatherPreparationCrafts();
 		SeedAntiquityLeatherClothingCrafts();
 		SeedAntiquityLeatherArmourCrafts();

--- a/DatabaseSeeder/Seeders/UsefulSeeder.ItemComponents.cs
+++ b/DatabaseSeeder/Seeders/UsefulSeeder.ItemComponents.cs
@@ -198,6 +198,18 @@ public partial class UsefulSeeder
         context.SaveChanges();
     }
 
+    internal void SeedRepairKitsForTesting(FuturemudDatabaseContext context)
+    {
+        _context = context;
+        PrepareItemProtoCache(context);
+        _tags = context.Tags.ToDictionaryWithDefault(x => x.Name, x => x, StringComparer.OrdinalIgnoreCase);
+        DateTime now = DateTime.UtcNow;
+        Account dbaccount = context.Accounts.First();
+        long nextId = context.GameItemComponentProtos.Any() ? context.GameItemComponentProtos.Max(x => x.Id) + 1 : 1;
+        SeedRepairKits(context, now, dbaccount, ref nextId);
+        context.SaveChanges();
+    }
+
     internal void SeedContainersForTesting(FuturemudDatabaseContext context)
     {
         _context = context;
@@ -6635,6 +6647,26 @@ public partial class UsefulSeeder
         AddRepairKitType("Metal_Tool", "a repair kit that repairs metal tools", WoundSeverity.Grievous, 1000, (skills["Blacksmithing"] ?? skills["Blacksmith"])?.Id, 0.0, ["Metal"], ["Tools"]);
         AddRepairKitType("Metal_Tool_Good", "a good-quality repair kit that repairs metal tools", WoundSeverity.Horrifying, 1500, (skills["Blacksmithing"] ?? skills["Blacksmith"])?.Id, 1.0, ["Metal"], ["Tools"]);
         AddRepairKitType("Metal_Tool_Poor", "a poor-quality repair kit that repairs metal tools", WoundSeverity.Severe, 600, (skills["Blacksmithing"] ?? skills["Blacksmith"])?.Id, -1.0, ["Metal"], ["Tools"]);
+
+        AddRepairKitType("Wood", "a repair kit that repairs wooden items", WoundSeverity.Grievous, 1000, (skills["Carpentry"] ?? skills["Woodcraft"] ?? skills["Constructing"] ?? skills["Construction"])?.Id, 0.0, ["Wood"], []);
+        AddRepairKitType("Wood_Good", "a good-quality repair kit that repairs wooden items", WoundSeverity.Horrifying, 1500, (skills["Carpentry"] ?? skills["Woodcraft"] ?? skills["Constructing"] ?? skills["Construction"])?.Id, 1.0, ["Wood"], []);
+        AddRepairKitType("Wood_Poor", "a poor-quality repair kit that repairs wooden items", WoundSeverity.Severe, 600, (skills["Carpentry"] ?? skills["Woodcraft"] ?? skills["Constructing"] ?? skills["Construction"])?.Id, -1.0, ["Wood"], []);
+
+        AddRepairKitType("Metal", "a repair kit that repairs metal items", WoundSeverity.Grievous, 1000, (skills["Blacksmithing"] ?? skills["Metalcraft"] ?? skills["Blacksmith"])?.Id, 0.0, ["Metal"], []);
+        AddRepairKitType("Metal_Good", "a good-quality repair kit that repairs metal items", WoundSeverity.Horrifying, 1500, (skills["Blacksmithing"] ?? skills["Metalcraft"] ?? skills["Blacksmith"])?.Id, 1.0, ["Metal"], []);
+        AddRepairKitType("Metal_Poor", "a poor-quality repair kit that repairs metal items", WoundSeverity.Severe, 600, (skills["Blacksmithing"] ?? skills["Metalcraft"] ?? skills["Blacksmith"])?.Id, -1.0, ["Metal"], []);
+
+        AddRepairKitType("Stone", "a repair kit that repairs stone items", WoundSeverity.Grievous, 1000, (skills["Masonry"] ?? skills["Stonecraft"] ?? skills["Constructing"] ?? skills["Construction"])?.Id, 0.0, ["Stone"], []);
+        AddRepairKitType("Stone_Good", "a good-quality repair kit that repairs stone items", WoundSeverity.Horrifying, 1500, (skills["Masonry"] ?? skills["Stonecraft"] ?? skills["Constructing"] ?? skills["Construction"])?.Id, 1.0, ["Stone"], []);
+        AddRepairKitType("Stone_Poor", "a poor-quality repair kit that repairs stone items", WoundSeverity.Severe, 600, (skills["Masonry"] ?? skills["Stonecraft"] ?? skills["Constructing"] ?? skills["Construction"])?.Id, -1.0, ["Stone"], []);
+
+        AddRepairKitType("Ceramic", "a repair kit that repairs ceramic items", WoundSeverity.Grievous, 1000, (skills["Pottery"] ?? skills["Potter"] ?? skills["Masonry"] ?? skills["Stonecraft"])?.Id, 0.0, ["Ceramic"], []);
+        AddRepairKitType("Ceramic_Good", "a good-quality repair kit that repairs ceramic items", WoundSeverity.Horrifying, 1500, (skills["Pottery"] ?? skills["Potter"] ?? skills["Masonry"] ?? skills["Stonecraft"])?.Id, 1.0, ["Ceramic"], []);
+        AddRepairKitType("Ceramic_Poor", "a poor-quality repair kit that repairs ceramic items", WoundSeverity.Severe, 600, (skills["Pottery"] ?? skills["Potter"] ?? skills["Masonry"] ?? skills["Stonecraft"])?.Id, -1.0, ["Ceramic"], []);
+
+        AddRepairKitType("Hard_Organic", "a repair kit that repairs hard organic items", WoundSeverity.Grievous, 1000, (skills["Scrimshawing"] ?? skills["Scrimshaw"] ?? skills["Carpentry"] ?? skills["Woodcraft"])?.Id, 0.0, ["Bone", "Shell", "Horn", "Tooth", "Scale", "Claw", "Beak"], []);
+        AddRepairKitType("Hard_Organic_Good", "a good-quality repair kit that repairs hard organic items", WoundSeverity.Horrifying, 1500, (skills["Scrimshawing"] ?? skills["Scrimshaw"] ?? skills["Carpentry"] ?? skills["Woodcraft"])?.Id, 1.0, ["Bone", "Shell", "Horn", "Tooth", "Scale", "Claw", "Beak"], []);
+        AddRepairKitType("Hard_Organic_Poor", "a poor-quality repair kit that repairs hard organic items", WoundSeverity.Severe, 600, (skills["Scrimshawing"] ?? skills["Scrimshaw"] ?? skills["Carpentry"] ?? skills["Woodcraft"])?.Id, -1.0, ["Bone", "Shell", "Horn", "Tooth", "Scale", "Claw", "Beak"], []);
 
         AddRepairKitType("Universal", "a repair kit that repairs anything", WoundSeverity.Severe, 250, (skills["Salvaging"] ?? skills["Salvage"])?.Id, -1.0, [], []);
         AddRepairKitType("Universal_Good", "a good-quality repair kit that repairs anything", WoundSeverity.VerySevere, 350, (skills["Salvaging"] ?? skills["Salvage"])?.Id, 0.0, [], []);

--- a/Design Documents/Crafting/Antiquity_Equipment_Crafting_Suite.md
+++ b/Design Documents/Crafting/Antiquity_Equipment_Crafting_Suite.md
@@ -11,12 +11,13 @@ This document records the craft suite that closes the remaining non-household an
 - 76 non-leather armour prototypes from `SeedAntiquityArmour`.
 - 117 weapon, shield, ammunition, sling, and military-accessory prototypes from `SeedAntiquityWeaponsShieldsAccessories`.
 - Shared `Door Hardware Stock` used by the expanded household/door suite.
+- Eight portable repair-kit prototypes from `SeedAntiquityRepairKits`.
 
 Existing jewellery, culture-specific textile clothing, leather clothing, leather armour, leather containers, leather furnishings, medical goods, writing goods, and household goods stay on their existing suites. The equipment suite discovers military goods dynamically from `Market / Military Goods` tags, discovers support tools dynamically from `Market / Professional Tools / Standard Tools`, and excludes stable references already handled by the culture/leather/writing/medical suites.
 
 ## Implementation
 
-The implementation lives in `DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityEquipment.cs` and is registered from `SeedCrafts()` through `SeedAntiquityEquipmentCrafts()`.
+The implementation lives primarily in `DatabaseSeeder/Seeders/ItemSeederCrafting.AntiquityEquipment.cs` and is registered from `SeedCrafts()` through `SeedAntiquityEquipmentCrafts()`. Portable repair kits live in `ItemSeederCrafting.AntiquityRepairKits.cs` and are registered through `SeedAntiquityRepairKitCrafts()`.
 
 The suite follows the same stock pattern as the textile, leather, jewellery, and household work:
 
@@ -58,6 +59,21 @@ Reusable intermediate outputs that are intentionally allowed to sit at a stock b
 | `Ancient Armourcrafting` | Helmet bowls, armour plates, rings, scales, lamellae, textile padding, shields, and final armour assembly. |
 | `Ancient Toolmaking` | Metal, wooden, textile, leather, stone, bone, shell, glass, support-tool, and unlit apparatus prototypes. |
 | `Ancient Common Clothing Crafting` | Culture-neutral common clothing and accessories left outside the culture garment suites. |
+
+## Repair Kits
+
+Repair kits use general material-family `RepairKit` components instead of era-specific components. The stock antiquity items are standard-quality kits; good and poor component grades are also seeded for future item variants.
+
+| Stable Reference | Component | Primary Coverage |
+| --- | --- | --- |
+| `antiquity_textile_repair_kit` | `Repair_Cloth` | fabric armour padding, clothing, soft furnishings, and textile tools |
+| `antiquity_leather_repair_kit` | `Repair_Leather` | leather armour, containers, straps, furnishings, and tools |
+| `antiquity_wood_repair_kit` | `Repair_Wood` | wooden weapons, shields, furniture, doors, tool handles, and fixtures |
+| `antiquity_metal_repair_kit` | `Repair_Metal` | metal furniture, doors, fittings, tools, and general hardware |
+| `antiquity_stone_repair_kit` | `Repair_Stone` | stone tools, work surfaces, furniture, and fittings |
+| `antiquity_ceramic_repair_kit` | `Repair_Ceramic` | ceramic vessels, lamps, tablets, containers, and fired-clay fittings |
+| `antiquity_hard_organic_repair_kit` | `Repair_Hard_Organic` | bone, horn, shell, tooth, scale, claw, and beak fittings or tools |
+| `antiquity_field_repair_bundle` | `Repair_Universal` | low-grade mixed emergency repair across odd or composite items |
 
 ## Commodity Tags
 

--- a/Design Documents/Data/Seeded_Item_Components.json
+++ b/Design Documents/Data/Seeded_Item_Components.json
@@ -4130,6 +4130,171 @@
         "Component Type":  "Relay Switch"
     },
     {
+        "Component Name":  "Repair_Ceramic",
+        "Component Description":  "Turns an item into a repair kit that repairs ceramic items",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Ceramic_Good",
+        "Component Description":  "Turns an item into a good-quality repair kit that repairs ceramic items",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Ceramic_Poor",
+        "Component Description":  "Turns an item into a poor-quality repair kit that repairs ceramic items",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Cloth",
+        "Component Description":  "Turns an item into a repair kit that repairs cloth items",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Cloth_Good",
+        "Component Description":  "Turns an item into a good-quality repair kit that repairs cloth items",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Cloth_Poor",
+        "Component Description":  "Turns an item into a poor-quality repair kit that repairs cloth items",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Hard_Organic",
+        "Component Description":  "Turns an item into a repair kit that repairs hard organic items",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Hard_Organic_Good",
+        "Component Description":  "Turns an item into a good-quality repair kit that repairs hard organic items",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Hard_Organic_Poor",
+        "Component Description":  "Turns an item into a poor-quality repair kit that repairs hard organic items",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Leather",
+        "Component Description":  "Turns an item into a repair kit that repairs leather items",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Leather_Good",
+        "Component Description":  "Turns an item into a good-quality repair kit that repairs leather items",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Leather_Poor",
+        "Component Description":  "Turns an item into a poor-quality repair kit that repairs leather items",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Metal",
+        "Component Description":  "Turns an item into a repair kit that repairs metal items",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Metal_Armour",
+        "Component Description":  "Turns an item into a repair kit that repairs metal armour",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Metal_Armour_Good",
+        "Component Description":  "Turns an item into a good-quality repair kit that repairs metal armour",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Metal_Armour_Poor",
+        "Component Description":  "Turns an item into a poor-quality repair kit that repairs metal armour",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Metal_Good",
+        "Component Description":  "Turns an item into a good-quality repair kit that repairs metal items",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Metal_Poor",
+        "Component Description":  "Turns an item into a poor-quality repair kit that repairs metal items",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Metal_Tool",
+        "Component Description":  "Turns an item into a repair kit that repairs metal tools",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Metal_Tool_Good",
+        "Component Description":  "Turns an item into a good-quality repair kit that repairs metal tools",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Metal_Tool_Poor",
+        "Component Description":  "Turns an item into a poor-quality repair kit that repairs metal tools",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Metal_Weapon",
+        "Component Description":  "Turns an item into a repair kit that repairs metal weapons",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Metal_Weapon_Good",
+        "Component Description":  "Turns an item into a good-quality repair kit that repairs metal weapons",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Metal_Weapon_Poor",
+        "Component Description":  "Turns an item into a poor-quality repair kit that repairs metal weapons",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Stone",
+        "Component Description":  "Turns an item into a repair kit that repairs stone items",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Stone_Good",
+        "Component Description":  "Turns an item into a good-quality repair kit that repairs stone items",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Stone_Poor",
+        "Component Description":  "Turns an item into a poor-quality repair kit that repairs stone items",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Universal",
+        "Component Description":  "Turns an item into a repair kit that repairs anything",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Universal_Good",
+        "Component Description":  "Turns an item into a good-quality repair kit that repairs anything",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Universal_Poor",
+        "Component Description":  "Turns an item into a poor-quality repair kit that repairs anything",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Wood",
+        "Component Description":  "Turns an item into a repair kit that repairs wooden items",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Wood_Good",
+        "Component Description":  "Turns an item into a good-quality repair kit that repairs wooden items",
+        "Component Type":  "RepairKit"
+    },
+    {
+        "Component Name":  "Repair_Wood_Poor",
+        "Component Description":  "Turns an item into a poor-quality repair kit that repairs wooden items",
+        "Component Type":  "RepairKit"
+    },
+    {
         "Component Name":  "Restraint",
         "Component Description":  "Turns an item into a restraint when combined with the wearables that are named \"Bound \u003cX\u003e\"",
         "Component Type":  "Restraint"


### PR DESCRIPTION
## Summary
- Add general repair-kit component families for wood, metal, stone, ceramic, and hard-organic materials
- Seed 8 antiquity repair-kit item prototypes and make them craftable through a dedicated repair-kit craft suite
- Refresh repair-kit component catalogue/docs and add source-backed DatabaseSeeder tests

## Validation
- `dotnet build DatabaseSeeder\DatabaseSeeder.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 --filter "ItemSeeder|UsefulSeederItemPackageTests"` (102 passed)
- `git diff --check`

gh auth note: local `gh auth status` reports the default token is invalid, so PR creation/merge is using the GitHub connector.