### PR TITLE
Add seal, measurement, and antiquity component-gap seeding

### DIFF
--- a/DatabaseSeeder Unit Tests/UsefulSeederItemPackageTests.cs
+++ b/DatabaseSeeder Unit Tests/UsefulSeederItemPackageTests.cs
@@ -214,6 +214,37 @@ public class UsefulSeederItemPackageTests
 		context.SaveChanges();
 	}
 
+	private static void EnsureComponentMarkers(FuturemudDatabaseContext context, params string[] names)
+	{
+		var nextId = context.GameItemComponentProtos.Any() ? context.GameItemComponentProtos.Max(x => x.Id) + 1 : 1;
+		foreach (var name in names)
+		{
+			if (context.GameItemComponentProtos.Any(x => x.Name == name))
+			{
+				continue;
+			}
+
+			context.GameItemComponentProtos.Add(CreateComponentMarker(nextId++, name));
+		}
+
+		context.SaveChanges();
+	}
+
+	private static GameItemProto LoadItem(FuturemudDatabaseContext context, string uniqueName)
+	{
+		return context.GameItemProtos
+		              .Include(x => x.GameItemProtosGameItemComponentProtos)
+		              .ThenInclude(x => x.GameItemComponent)
+		              .Single(x => x.UniqueName == uniqueName);
+	}
+
+	private static string[] ComponentNames(GameItemProto item)
+	{
+		return item.GameItemProtosGameItemComponentProtos
+		           .Select(x => x.GameItemComponent.Name)
+		           .ToArray();
+	}
+
 	private static void SeedRepairKitPrerequisites(FuturemudDatabaseContext context)
 	{
 		context.Tags.AddRange(
@@ -507,6 +538,66 @@ public class UsefulSeederItemPackageTests
 				"Sealable_Scroll"
 			},
 			scroll.GameItemProtosGameItemComponentProtos.Select(x => x.GameItemComponent.Name).ToArray());
+	}
+
+	[TestMethod]
+	public void ItemSeeder_AntiquityComponentGapItems_RerunDoesNotDuplicateAndUsesReportComponents()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedGeneralPrerequisites(context);
+		SeedMarketCategories(context);
+		UsefulSeeder usefulSeeder = new();
+		usefulSeeder.SeedAntiquityComponentGapCoverageForTesting(context);
+		EnsureComponentMarkers(context,
+			"Destroyable_Misc",
+			"Destroyable_Furniture",
+			"Destroyable_WoodenHeavy",
+			"Destroyable_HeavyMetal",
+			"Container_Tray",
+			"Container_Pouch",
+			"Container_Small_Drum",
+			"LContainer_DrinkingGlass",
+			"LContainer_WineGlass",
+			"LContainer_Amphora_Urna",
+			"Wear_Ring",
+			"Wear_Waist",
+			"Keyring_Large",
+			"LockingContainer_Lockbox",
+			"Dice_d6");
+		ItemSeeder itemSeeder = new();
+
+		itemSeeder.SeedAntiquityComponentGapItemsForTesting(context);
+		itemSeeder.SeedAntiquityComponentGapItemsForTesting(context);
+
+		var expectedStableReferences = ItemSeeder.AntiquityComponentGapItemStableReferencesForTesting;
+		foreach (var stableReference in expectedStableReferences)
+		{
+			Assert.AreEqual(1, context.GameItemProtos.Count(x => x.UniqueName == stableReference),
+				$"Expected one item prototype named {stableReference}.");
+		}
+
+		GameItemProto bronzeSignet = LoadItem(context, "antiquity_bronze_signet_ring");
+		CollectionAssert.Contains(ComponentNames(bronzeSignet), "SealStamp_Antiquity_BronzeSignet");
+		CollectionAssert.Contains(ComponentNames(bronzeSignet), "Wear_Ring");
+
+		GameItemProto papyrusScroll = LoadItem(context, "antiquity_sealed_papyrus_scroll");
+		CollectionAssert.Contains(ComponentNames(papyrusScroll), "Antiquity_Papyrus_Scroll_Surface");
+		CollectionAssert.Contains(ComponentNames(papyrusScroll), "Sealable_Scroll");
+
+		GameItemProto sealBox = LoadItem(context, "antiquity_tax_office_seal_box");
+		CollectionAssert.Contains(ComponentNames(sealBox), "LockingContainer_Lockbox");
+		CollectionAssert.Contains(ComponentNames(sealBox), "Sealable_Container_Wax");
+
+		GameItemProto oilCup = LoadItem(context, "antiquity_oil_measure_cup");
+		CollectionAssert.Contains(ComponentNames(oilCup), "LContainer_DrinkingGlass");
+		CollectionAssert.Contains(ComponentNames(oilCup), "MeasuringInstrument_Antiquity_OilCup");
+
+		GameItemProto publicWell = LoadItem(context, "antiquity_stone_public_well");
+		CollectionAssert.Contains(ComponentNames(publicWell), "WaterSource_Antiquity_PublicWell");
+
+		GameItemProto measuringRod = LoadItem(context, "antiquity_wooden_measuring_rod");
+		CollectionAssert.DoesNotContain(ComponentNames(measuringRod), "MeasuringInstrument_Antiquity_BalanceScale",
+			"Length measurement is deferred, so the rod should remain a non-measuring prop.");
 	}
 
 	[TestMethod]

--- a/DatabaseSeeder Unit Tests/UsefulSeederItemPackageTests.cs
+++ b/DatabaseSeeder Unit Tests/UsefulSeederItemPackageTests.cs
@@ -287,6 +287,9 @@ public class UsefulSeederItemPackageTests
 		Assert.AreEqual(ShouldSeedResult.ExtraPackagesAvailable, UsefulSeeder.ClassifyItemPackagePresence(context));
 		Assert.IsTrue(UsefulSeeder.StockItemMarkersForTesting.Contains("Container_Bookcase_Shelves"));
 		Assert.IsTrue(UsefulSeeder.StockItemMarkersForTesting.Contains("TimePiece_Antiquity_Sundial"));
+		Assert.IsTrue(UsefulSeeder.StockItemMarkersForTesting.Contains("SealStamp_Antiquity_BronzeSignet"));
+		Assert.IsTrue(UsefulSeeder.StockItemMarkersForTesting.Contains("Sealable_Envelope"));
+		Assert.IsTrue(UsefulSeeder.StockItemMarkersForTesting.Contains("MeasuringInstrument_Antiquity_BalanceScale"));
 
 		context.GameItemComponentProtos.Add(CreateComponentMarker(id++, "Container_Bookcase_Shelves"));
 		context.SaveChanges();
@@ -431,7 +434,24 @@ public class UsefulSeederItemPackageTests
 			"Locksmithing_Antiquity_BronzeStandard",
 			"Locksmithing_Antiquity_FineSteel",
 			"Locksmithing_Antiquity_Installation",
-			"Locksmithing_Antiquity_Fabrication"
+			"Locksmithing_Antiquity_Fabrication",
+			"SealStamp_Antiquity_BronzeSignet",
+			"SealStamp_Antiquity_CylinderSeal",
+			"Sealable_Document_Wax",
+			"Sealable_Document_Clay",
+			"Sealable_Envelope",
+			"Sealable_Scroll",
+			"Sealable_Container_Wax",
+			"MeasuringInstrument_Antiquity_BalanceScale",
+			"MeasuringInstrument_Antiquity_StandardWeights",
+			"MeasuringInstrument_Antiquity_FalseWeights",
+			"MeasuringInstrument_Antiquity_GrainMeasure",
+			"MeasuringInstrument_Antiquity_OilCup",
+			"MeasuringInstrument_Antiquity_WineCup",
+			"MeasuringInstrument_Antiquity_TaxAssessorKit",
+			"Container_Envelope",
+			"PaperSheet_Envelope",
+			"PaperSheet_Scroll"
 		];
 
 		foreach (string name in expectedNames)
@@ -447,6 +467,12 @@ public class UsefulSeederItemPackageTests
 		Assert.AreEqual(6, (int)Definition("DragAid_Antiquity_CorpseBier").Element("MaximumUsers")!);
 		Assert.AreEqual(-2, (int)Definition("Locksmithing_Antiquity_BronzePoor").Element("DifficultyAdjustment")!);
 		Assert.AreEqual("on", (string)Definition("ShopStall_Antiquity_OpenCounter").Attribute("Preposition")!);
+		Assert.AreEqual("a bronze signet showing a lion beneath a civic star",
+			(string)Definition("SealStamp_Antiquity_BronzeSignet").Element("SealDesign")!);
+		Assert.IsTrue(Definition("Sealable_Envelope").Element("AllowedMedia")!.Elements("Medium")
+		                                      .Any(x => (string)x == "wax"));
+		Assert.AreEqual("Weight", (string)Definition("MeasuringInstrument_Antiquity_BalanceScale").Element("Mode")!);
+		Assert.AreEqual("FluidVolume", (string)Definition("MeasuringInstrument_Antiquity_OilCup").Element("Mode")!);
 
 		XElement loadedDie = Definition("Dice_Antiquity_LoadedD6");
 		Assert.AreEqual(6, loadedDie.Element("Faces")!.Elements("Face").Count());
@@ -456,6 +482,31 @@ public class UsefulSeederItemPackageTests
 		long weaponsCategoryId = context.MarketCategories.Single(x => x.Name == "Weapons").Id;
 		Assert.IsTrue(militaryWeight.Element("Multipliers")!.Elements("Multiplier")
 			.Any(x => (long)x.Attribute("category")! == weaponsCategoryId && (decimal)x.Attribute("value")! == 1.25m));
+
+		GameItemProto envelope = context.GameItemProtos
+		                                .Include(x => x.GameItemProtosGameItemComponentProtos)
+		                                .ThenInclude(x => x.GameItemComponent)
+		                                .Single(x => x.ShortDescription == "a sealable envelope");
+		CollectionAssert.IsSubsetOf(new[]
+			{
+				"Holdable",
+				"Container_Envelope",
+				"PaperSheet_Envelope",
+				"Sealable_Envelope"
+			},
+			envelope.GameItemProtosGameItemComponentProtos.Select(x => x.GameItemComponent.Name).ToArray());
+
+		GameItemProto scroll = context.GameItemProtos
+		                            .Include(x => x.GameItemProtosGameItemComponentProtos)
+		                            .ThenInclude(x => x.GameItemComponent)
+		                            .Single(x => x.ShortDescription == "a sealable scroll");
+		CollectionAssert.IsSubsetOf(new[]
+			{
+				"Holdable",
+				"PaperSheet_Scroll",
+				"Sealable_Scroll"
+			},
+			scroll.GameItemProtosGameItemComponentProtos.Select(x => x.GameItemComponent.Name).ToArray());
 	}
 
 	[TestMethod]

--- a/DatabaseSeeder Unit Tests/UsefulSeederItemPackageTests.cs
+++ b/DatabaseSeeder Unit Tests/UsefulSeederItemPackageTests.cs
@@ -176,6 +176,44 @@ public class UsefulSeederItemPackageTests
 		};
 	}
 
+	private static MarketCategory CreateMarketCategory(long id, string name)
+	{
+		return new MarketCategory
+		{
+			Id = id,
+			Name = name,
+			Description = $"{name} test category",
+			ElasticityFactorAbove = 0.5,
+			ElasticityFactorBelow = 0.5,
+			MarketCategoryType = 0,
+			Tags = "<Tags />",
+			CombinationCategories = "<Components />"
+		};
+	}
+
+	private static void SeedMarketCategories(FuturemudDatabaseContext context)
+	{
+		string[] names =
+		[
+			"Staple Food",
+			"Standard Food",
+			"Beer",
+			"Wine",
+			"Luxury Wares",
+			"Luxury Clothing",
+			"Luxury Furniture",
+			"Luxury Decorations",
+			"Military Goods",
+			"Weapons",
+			"Armour",
+			"Ammunition",
+			"Shields"
+		];
+
+		context.MarketCategories.AddRange(names.Select((name, index) => CreateMarketCategory(index + 1, name)));
+		context.SaveChanges();
+	}
+
 	private static void SeedRepairKitPrerequisites(FuturemudDatabaseContext context)
 	{
 		context.Tags.AddRange(
@@ -248,6 +286,7 @@ public class UsefulSeederItemPackageTests
 
 		Assert.AreEqual(ShouldSeedResult.ExtraPackagesAvailable, UsefulSeeder.ClassifyItemPackagePresence(context));
 		Assert.IsTrue(UsefulSeeder.StockItemMarkersForTesting.Contains("Container_Bookcase_Shelves"));
+		Assert.IsTrue(UsefulSeeder.StockItemMarkersForTesting.Contains("TimePiece_Antiquity_Sundial"));
 
 		context.GameItemComponentProtos.Add(CreateComponentMarker(id++, "Container_Bookcase_Shelves"));
 		context.SaveChanges();
@@ -348,6 +387,75 @@ public class UsefulSeederItemPackageTests
 		Assert.AreEqual(1, context.VariableDefinitions.Count(x => x.Property == "nicotineuntil"));
 		Assert.AreEqual(1, context.VariableDefaults.Count(x => x.Property == "nicotineuntil"));
 		Assert.AreEqual(0, context.GameItemComponentProtos.Count(x => x.Name.StartsWith("Food_")));
+	}
+
+	[TestMethod]
+	public void SeedAntiquityComponentGapCoverageForTesting_RerunDoesNotDuplicateAndSeedsReportComponents()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedGeneralPrerequisites(context);
+		SeedMarketCategories(context);
+		UsefulSeeder seeder = new();
+
+		seeder.SeedAntiquityComponentGapCoverageForTesting(context);
+		seeder.SeedAntiquityComponentGapCoverageForTesting(context);
+
+		string[] expectedNames =
+		[
+			"TimePiece_Antiquity_Sundial",
+			"TimePiece_Antiquity_WaterClock",
+			"TimePiece_Antiquity_MarkedCandle",
+			"TimePiece_Antiquity_WatchBoard",
+			"WaterSource_Antiquity_PublicWell",
+			"WaterSource_Antiquity_Cistern",
+			"WaterSource_Antiquity_Fountain",
+			"WaterSource_Antiquity_BathPool",
+			"WaterSource_Antiquity_RitualBasin",
+			"WaterSource_Antiquity_IrrigationOutlet",
+			"ShopStall_Antiquity_OpenCounter",
+			"ShopStall_Antiquity_LockableCounter",
+			"ShopStall_Antiquity_PortableBooth",
+			"MarketGoodWeight_Antiquity_StapleFood",
+			"MarketGoodWeight_Antiquity_LuxuryCraft",
+			"MarketGoodWeight_Antiquity_MilitarySupply",
+			"Dice_Antiquity_Knucklebones",
+			"Dice_Antiquity_CastingSticks",
+			"Dice_Antiquity_LoadedD6",
+			"Dice_Antiquity_DivinationLots",
+			"DragAid_Antiquity_FieldStretcher",
+			"DragAid_Antiquity_CorpseBier",
+			"DragAid_Antiquity_CargoSled",
+			"DragAid_Antiquity_PackTravois",
+			"DragAid_Antiquity_CarryingSling",
+			"Locksmithing_Antiquity_BronzePoor",
+			"Locksmithing_Antiquity_BronzeStandard",
+			"Locksmithing_Antiquity_FineSteel",
+			"Locksmithing_Antiquity_Installation",
+			"Locksmithing_Antiquity_Fabrication"
+		];
+
+		foreach (string name in expectedNames)
+		{
+			Assert.AreEqual(1, context.GameItemComponentProtos.Count(x => x.Name == name), $"Expected one component named {name}.");
+		}
+
+		XElement Definition(string name) => XElement.Parse(context.GameItemComponentProtos.Single(x => x.Name == name).Definition);
+
+		Assert.AreEqual("$c", (string)Definition("TimePiece_Antiquity_Sundial").Element("TimeDisplayString")!);
+		Assert.AreEqual(100.0, (double)Definition("WaterSource_Antiquity_RitualBasin").Attribute("LiquidCapacity")!);
+		Assert.AreEqual(0.0, (double)Definition("WaterSource_Antiquity_RitualBasin").Attribute("RefillRate")!);
+		Assert.AreEqual(6, (int)Definition("DragAid_Antiquity_CorpseBier").Element("MaximumUsers")!);
+		Assert.AreEqual(-2, (int)Definition("Locksmithing_Antiquity_BronzePoor").Element("DifficultyAdjustment")!);
+		Assert.AreEqual("on", (string)Definition("ShopStall_Antiquity_OpenCounter").Attribute("Preposition")!);
+
+		XElement loadedDie = Definition("Dice_Antiquity_LoadedD6");
+		Assert.AreEqual(6, loadedDie.Element("Faces")!.Elements("Face").Count());
+		Assert.AreEqual(2.5, (double)loadedDie.Element("Weights")!.Elements("Weight").Last().Element("Probability")!);
+
+		XElement militaryWeight = Definition("MarketGoodWeight_Antiquity_MilitarySupply");
+		long weaponsCategoryId = context.MarketCategories.Single(x => x.Name == "Weapons").Id;
+		Assert.IsTrue(militaryWeight.Element("Multipliers")!.Elements("Multiplier")
+			.Any(x => (long)x.Attribute("category")! == weaponsCategoryId && (decimal)x.Attribute("value")! == 1.25m));
 	}
 
 	[TestMethod]

--- a/DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityComponentGaps.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityComponentGaps.cs
@@ -1,0 +1,394 @@
+using MudSharp.Database;
+using MudSharp.Form.Material;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DatabaseSeeder.Seeders;
+
+public partial class ItemSeeder
+{
+	private sealed record AntiquityComponentGapItemSpec(
+		string StableReference,
+		string Noun,
+		string ShortDescription,
+		string FullDescription,
+		SizeCategory Size,
+		ItemQuality Quality,
+		double WeightInGrams,
+		decimal Cost,
+		string Material,
+		MaterialBehaviourType MaterialType,
+		string[] Tags,
+		string[] Components,
+		string? BuilderNotes = null);
+
+	private void SeedAntiquityComponentGapItems()
+	{
+		EnsureAntiquityComponentGapWritingComponents();
+
+		foreach (var spec in AntiquityComponentGapItemSpecs())
+		{
+			EnsureAntiquityComponentGapMaterial(spec.Material, spec.MaterialType);
+			foreach (var tag in spec.Tags)
+			{
+				EnsureAntiquityTagPath(tag);
+			}
+
+			CreateItem(
+				spec.StableReference,
+				spec.Noun,
+				spec.ShortDescription,
+				null,
+				spec.FullDescription,
+				spec.Size,
+				spec.Quality,
+				spec.WeightInGrams,
+				spec.Cost,
+				false,
+				false,
+				spec.Material,
+				spec.Tags,
+				spec.Components,
+				null,
+				null,
+				null,
+				null,
+				spec.BuilderNotes ?? "Seeded from the antiquity item component gap report.");
+		}
+	}
+
+	internal void SeedAntiquityComponentGapItemsForTesting(FuturemudDatabaseContext context)
+	{
+		if (!ReferenceEquals(_context, context))
+		{
+			_context = context;
+			InitialiseDependencies();
+		}
+
+		SeedAntiquityComponentGapItems();
+		_context!.SaveChanges();
+	}
+
+	internal static IReadOnlyCollection<string> AntiquityComponentGapItemStableReferencesForTesting =>
+		AntiquityComponentGapItemSpecs().Select(x => x.StableReference).ToArray();
+
+	private void EnsureAntiquityComponentGapWritingComponents()
+	{
+		EnsureAntiquityPaperSheetComponent("Antiquity_Papyrus_Scroll_Surface",
+			"Allows an antiquity papyrus scroll to be written on as a long sheet", 12000);
+		EnsureAntiquityPaperSheetComponent("Antiquity_Papyrus_Sheet_Surface",
+			"Allows an antiquity papyrus sheet to be written on", 2400);
+		EnsureAntiquityInscribableSurfaceComponent("Antiquity_Clay_Tablet_Surface",
+			"Allows clay tablets to take stylus writing", 1600, WritingImplementType.Stylus);
+		EnsureAntiquityInscribableSurfaceComponent("Antiquity_Wooden_Block_Surface",
+			"Allows wooden boards and blocks to take incised or charcoal writing", 2200,
+			WritingImplementType.Stylus, WritingImplementType.Chisel, WritingImplementType.Charcoal);
+	}
+
+	private Material EnsureAntiquityComponentGapMaterial(string name, MaterialBehaviourType behaviourType)
+	{
+		if (_materials.TryGetValue(name, out var existing))
+		{
+			return existing;
+		}
+
+		existing = _context!.Materials.Local
+			.FirstOrDefault(x => x.Name.Equals(name, StringComparison.OrdinalIgnoreCase)) ??
+			_context.Materials.AsEnumerable()
+			        .FirstOrDefault(x => x.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+		if (existing is not null)
+		{
+			_materials[name] = existing;
+			return existing;
+		}
+
+		var material = new Material
+		{
+			Id = NextMaterialId(),
+			Name = name,
+			MaterialDescription = name.ToLowerInvariant(),
+			BehaviourType = (int)behaviourType,
+			ResidueSdesc = string.Empty,
+			ResidueDesc = string.Empty,
+			ResidueColour = string.Empty
+		};
+		_context.Materials.Add(material);
+		_materials[name] = material;
+		return material;
+	}
+
+	private long NextMaterialId()
+	{
+		var existing = _context!.Materials.Any() ? _context.Materials.Max(x => x.Id) : 0L;
+		var local = _context.Materials.Local.Any() ? _context.Materials.Local.Max(x => x.Id) : 0L;
+		return Math.Max(existing, local) + 1L;
+	}
+
+	private static IReadOnlyList<AntiquityComponentGapItemSpec> AntiquityComponentGapItemSpecs()
+	{
+		const string ToolTag = "Market / Professional Tools / Standard Tools";
+		const string MeasureTag = "Functions / Tools / Measurement Tools";
+		const string TimeTag = "Functions / Tools / Timekeeping Tools";
+		const string WritingTag = "Market / Writing Materials";
+		const string CivicTag = "Functions / Civic Fixtures";
+		const string MarketTag = "Market / Household Goods / Standard Wares";
+		const string FurnitureTag = "Market / Household Goods / Standard Furniture";
+		const string ReligiousTag = "Market / Religious Goods";
+		const string SecurityTag = "Functions / Security Tools";
+		const string LeisureTag = "Functions / Household Items / Leisure Goods";
+		const string MedicalTag = "Functions / Medical Items";
+
+		return
+		[
+			new("antiquity_stone_courtyard_sundial", "sundial", "a carved stone courtyard sundial",
+				"This heavy courtyard sundial is carved from pale stone, with a fixed gnomon and hour marks cut deeply enough to remain legible in hard public weather.",
+				SizeCategory.VeryLarge, ItemQuality.Standard, 120000.0, 65.0m, "stone", MaterialBehaviourType.Stone,
+				[ToolTag, TimeTag, CivicTag], ["TimePiece_Antiquity_Sundial", "Destroyable_Misc"]),
+			new("antiquity_bronze_portable_gnomon", "gnomon", "a bronze portable gnomon",
+				"This small bronze gnomon folds into a simple travelling frame. Priests, surveyors, officers, and merchants can set it upright to judge the hour by sun shadow.",
+				SizeCategory.Small, ItemQuality.Standard, 450.0, 24.0m, "bronze", MaterialBehaviourType.Metal,
+				[ToolTag, TimeTag], ["Holdable", "TimePiece_Antiquity_Sundial", "Destroyable_HeavyMetal"]),
+			new("antiquity_marked_watch_candle", "candle", "a marked wax watch candle",
+				"This thick wax candle is scored with dark watch marks. Even unlit, its careful divisions make it a useful temple, guard, or household time marker.",
+				SizeCategory.Small, ItemQuality.Standard, 320.0, 6.0m, "wax", MaterialBehaviourType.Wax,
+				[ToolTag, TimeTag], ["Holdable", "TimePiece_Antiquity_MarkedCandle", "Destroyable_Misc"]),
+			new("antiquity_temple_water_clock", "clock", "a clay temple water clock",
+				"This clay water clock has a marked inner wall and a narrow drain hole. Its weathered basin is suited to temple, court, or watch-house timekeeping.",
+				SizeCategory.Large, ItemQuality.Standard, 18500.0, 48.0m, "clay", MaterialBehaviourType.Ceramic,
+				[ToolTag, TimeTag, ReligiousTag], ["TimePiece_Antiquity_WaterClock", "Destroyable_Misc"]),
+			new("antiquity_watchman_hour_board", "board", "a painted watchman's hour board",
+				"This wooden board lists the night watches in painted bands, with room for fresh marks or duty notes beside each hour.",
+				SizeCategory.Large, ItemQuality.Standard, 6200.0, 18.0m, "oak", MaterialBehaviourType.Wood,
+				[ToolTag, TimeTag, CivicTag], ["TimePiece_Antiquity_WatchBoard", "Antiquity_Wooden_Block_Surface", "Destroyable_WoodenHeavy"]),
+
+			new("antiquity_stone_public_well", "well", "a stone public well",
+				"This public well is built from fitted stone blocks around a dark shaft, with worn lip marks from ropes, buckets, and daily civic use.",
+				SizeCategory.Huge, ItemQuality.Standard, 450000.0, 150.0m, "stone", MaterialBehaviourType.Stone,
+				[FurnitureTag, CivicTag], ["WaterSource_Antiquity_PublicWell", "Destroyable_Furniture"]),
+			new("antiquity_lined_cistern", "cistern", "a lined stone cistern",
+				"This lined stone cistern has a plastered interior and a heavy rim, built to store household, fortress, or courtyard water through dry weather.",
+				SizeCategory.Huge, ItemQuality.Standard, 600000.0, 180.0m, "stone", MaterialBehaviourType.Stone,
+				[FurnitureTag, CivicTag], ["WaterSource_Antiquity_Cistern", "Destroyable_Furniture"]),
+			new("antiquity_bronze_fountain_spout", "spout", "a bronze fountain spout",
+				"This bronze fountain spout is shaped for a wall or basin, its mouth polished bright where water would sheet into a public fountain.",
+				SizeCategory.Normal, ItemQuality.Good, 2400.0, 55.0m, "bronze", MaterialBehaviourType.Metal,
+				[FurnitureTag, CivicTag], ["WaterSource_Antiquity_Fountain", "Destroyable_HeavyMetal"]),
+			new("antiquity_bathhouse_plunge_pool", "pool", "a tiled bathhouse plunge pool",
+				"This tiled plunge pool is broad, cold, and public-facing, with a low rim and stained water line from repeated bathhouse use.",
+				SizeCategory.Huge, ItemQuality.Good, 900000.0, 260.0m, "tile", MaterialBehaviourType.Ceramic,
+				[FurnitureTag, CivicTag], ["WaterSource_Antiquity_BathPool", "Destroyable_Furniture"]),
+			new("antiquity_temple_purification_basin", "basin", "a temple purification basin",
+				"This temple basin is shallow and carefully cleaned, with a smooth stone lip suited to ritual washing before prayer, sacrifice, or official entry.",
+				SizeCategory.Large, ItemQuality.Good, 42000.0, 70.0m, "stone", MaterialBehaviourType.Stone,
+				[ReligiousTag, CivicTag], ["WaterSource_Antiquity_RitualBasin", "Destroyable_Misc"]),
+			new("antiquity_irrigation_channel_outlet", "outlet", "an irrigation channel outlet",
+				"This shaped stone outlet guides water from a channel into fields or garden beds, with silt marks and tool-cut edges around its mouth.",
+				SizeCategory.VeryLarge, ItemQuality.Standard, 160000.0, 85.0m, "stone", MaterialBehaviourType.Stone,
+				[FurnitureTag, CivicTag], ["WaterSource_Antiquity_IrrigationOutlet", "Destroyable_Furniture"]),
+
+			new("antiquity_canvas_field_stretcher", "stretcher", "a canvas field stretcher",
+				"This field stretcher is a pair of wooden poles laced through stout canvas, built for carrying wounded people across streets, camps, or battlefields.",
+				SizeCategory.Large, ItemQuality.Standard, 5200.0, 28.0m, "linen", MaterialBehaviourType.Fabric,
+				[ToolTag, MedicalTag], ["Holdable", "DragAid_Antiquity_FieldStretcher", "Destroyable_Misc"]),
+			new("antiquity_wooden_corpse_bier", "bier", "a wooden corpse bier",
+				"This wooden bier has carrying rails and a flat slatted bed, suitable for funerary procession, temple preparation, or moving the dead with dignity.",
+				SizeCategory.VeryLarge, ItemQuality.Standard, 18000.0, 42.0m, "oak", MaterialBehaviourType.Wood,
+				[ReligiousTag, MedicalTag], ["DragAid_Antiquity_CorpseBier", "Destroyable_WoodenHeavy"]),
+			new("antiquity_rope_carrying_sling", "sling", "a rope carrying sling",
+				"This rope sling knots into a broad carrying cradle for awkward bundles, injured limbs, jars, or field loads that need an extra hand.",
+				SizeCategory.Small, ItemQuality.Standard, 680.0, 8.0m, "hemp", MaterialBehaviourType.Plant,
+				[ToolTag], ["Holdable", "DragAid_Antiquity_CarryingSling", "Destroyable_Misc"]),
+			new("antiquity_pack_travois", "travois", "a rawhide pack travois",
+				"This rawhide travois binds two long poles with cross-bracing and hide webbing, ready to drag baggage behind a person or pack animal.",
+				SizeCategory.Large, ItemQuality.Standard, 9800.0, 30.0m, "leather", MaterialBehaviourType.Leather,
+				[ToolTag], ["DragAid_Antiquity_PackTravois", "Destroyable_WoodenHeavy"]),
+			new("antiquity_cargo_sled", "sled", "a low wooden cargo sled",
+				"This low cargo sled has scuffed runners and rope lashing points, built for warehouses, quarries, docks, and military stores.",
+				SizeCategory.Large, ItemQuality.Standard, 15000.0, 36.0m, "oak", MaterialBehaviourType.Wood,
+				[ToolTag], ["DragAid_Antiquity_CargoSled", "Destroyable_WoodenHeavy"]),
+
+			new("antiquity_bone_knucklebones", "knucklebones", "a set of bone knucklebones",
+				"This small set of polished knucklebones has four uneven faces on each piece, good for gambling, idle play, or informal divination.",
+				SizeCategory.Tiny, ItemQuality.Standard, 90.0, 5.0m, "bone", MaterialBehaviourType.Bone,
+				[MarketTag, LeisureTag], ["Holdable", "Dice_Antiquity_Knucklebones", "Destroyable_Misc"]),
+			new("antiquity_ivory_six_sided_die", "die", "an ivory six-sided die",
+				"This tiny ivory die is drilled with dark pips and worn smooth on its corners from cups, tavern tables, and travel pouches.",
+				SizeCategory.Tiny, ItemQuality.Good, 12.0, 16.0m, "ivory", MaterialBehaviourType.Bone,
+				[MarketTag, LeisureTag], ["Holdable", "Dice_d6", "Destroyable_Misc"]),
+			new("antiquity_casting_sticks", "sticks", "a bundle of marked casting sticks",
+				"This bundle of slender casting sticks is marked on one side and plain on the other, tied together with a narrow cord.",
+				SizeCategory.Tiny, ItemQuality.Standard, 80.0, 6.0m, "reed", MaterialBehaviourType.Plant,
+				[MarketTag, LeisureTag], ["Holdable", "Dice_Antiquity_CastingSticks", "Destroyable_Misc"]),
+			new("antiquity_senet_game_board", "board", "a painted senet game board",
+				"This painted wooden senet board is divided into neat squares and has a shallow lip for keeping counters and casting sticks together.",
+				SizeCategory.Normal, ItemQuality.Good, 1600.0, 34.0m, "oak", MaterialBehaviourType.Wood,
+				[MarketTag, LeisureTag], ["Holdable", "Container_Tray", "Destroyable_WoodenHeavy"]),
+			new("antiquity_latrunculi_board", "board", "a gridded latrunculi board",
+				"This gridded game board is scratched and inked into dark wood, with enough shallow grooves to keep counters aligned during play.",
+				SizeCategory.Normal, ItemQuality.Standard, 1400.0, 24.0m, "oak", MaterialBehaviourType.Wood,
+				[MarketTag, LeisureTag], ["Holdable", "Container_Tray", "Destroyable_WoodenHeavy"]),
+			new("antiquity_tavern_gambling_cup", "cup", "a leather dice cup",
+				"This stiff leather cup has a darkened rim and weighted base, made for rattling dice or knucklebones before a throw.",
+				SizeCategory.Small, ItemQuality.Standard, 160.0, 8.0m, "leather", MaterialBehaviourType.Leather,
+				[MarketTag, LeisureTag], ["Holdable", "Container_Pouch", "Destroyable_Misc"]),
+			new("antiquity_ivory_loaded_die", "die", "an ivory loaded die",
+				"This ivory die looks well made at a glance, but its polish, edge wear, and balance are just suspicious enough to reward a careful eye.",
+				SizeCategory.Tiny, ItemQuality.Good, 14.0, 24.0m, "ivory", MaterialBehaviourType.Bone,
+				[MarketTag, LeisureTag], ["Holdable", "Dice_Antiquity_LoadedD6", "Destroyable_Misc"]),
+			new("antiquity_divination_lots", "lots", "a set of marked divination lots",
+				"This set of marked lots carries tiny symbols for favour, warning, delay, journey, conflict, and sacrifice, kept together in a simple cord tie.",
+				SizeCategory.Tiny, ItemQuality.Standard, 65.0, 9.0m, "bone", MaterialBehaviourType.Bone,
+				[ReligiousTag, LeisureTag], ["Holdable", "Dice_Antiquity_DivinationLots", "Destroyable_Misc"]),
+			new("antiquity_tavern_gambling_set", "set", "a tavern gambling set",
+				"This compact gambling set bundles a leather cup, a cloth wrap, and a few spare counters for a quick game at camp or tavern.",
+				SizeCategory.Small, ItemQuality.Standard, 420.0, 16.0m, "leather", MaterialBehaviourType.Leather,
+				[MarketTag, LeisureTag], ["Holdable", "Container_Pouch", "Destroyable_Misc"]),
+
+			new("antiquity_market_canvas_stall", "stall", "a canvas-covered market stall",
+				"This portable market stall combines a light counter frame with a weathered canvas awning and tie-down cords for a temporary pitch.",
+				SizeCategory.VeryLarge, ItemQuality.Standard, 36000.0, 85.0m, "oak", MaterialBehaviourType.Wood,
+				[MarketTag, CivicTag], ["ShopStall_Antiquity_PortableBooth", "Destroyable_Furniture"]),
+			new("antiquity_market_counter_chest", "chest", "a lockable merchant counter chest",
+				"This merchant counter chest has a broad trading top and a secured compartment beneath, built for unattended market goods and coin-ready trade.",
+				SizeCategory.Large, ItemQuality.Standard, 28000.0, 70.0m, "oak", MaterialBehaviourType.Wood,
+				[MarketTag, CivicTag], ["ShopStall_Antiquity_LockableCounter", "Destroyable_WoodenHeavy"]),
+			new("antiquity_bronze_standard_weight_set", "weights", "a bronze standard weight set",
+				"This bronze weight set nests several marked weights in a small case, each piece worn shiny where merchants have handled it.",
+				SizeCategory.Small, ItemQuality.Good, 2600.0, 55.0m, "bronze", MaterialBehaviourType.Metal,
+				[ToolTag, MeasureTag], ["Holdable", "Container_Pouch", "MarketGoodWeight_Antiquity_StapleFood", "MeasuringInstrument_Antiquity_StandardWeights", "Destroyable_HeavyMetal"]),
+			new("antiquity_stone_grain_measure", "measure", "a stone grain measure",
+				"This squat stone measure has a level rim and worn interior, sized for fair grain portions in storehouses, mills, and tax courts.",
+				SizeCategory.Normal, ItemQuality.Standard, 4200.0, 22.0m, "stone", MaterialBehaviourType.Stone,
+				[ToolTag, MeasureTag], ["Holdable", "MarketGoodWeight_Antiquity_StapleFood", "MeasuringInstrument_Antiquity_GrainMeasure", "Destroyable_Misc"]),
+			new("antiquity_wooden_measuring_rod", "rod", "a marked wooden measuring rod",
+				"This wooden measuring rod is marked in repeated hand and cubit divisions. It remains a reference prop until physical length measurement is supported.",
+				SizeCategory.Normal, ItemQuality.Standard, 520.0, 9.0m, "oak", MaterialBehaviourType.Wood,
+				[ToolTag, MeasureTag], ["Holdable", "Destroyable_Misc"],
+				"Length measurement is intentionally deferred until item dimensions exist."),
+			new("antiquity_balance_scale", "scale", "a portable balance scale",
+				"This compact balance scale has a bronze beam, cord hangers, and shallow pans for comparing small trade goods against known weights.",
+				SizeCategory.Small, ItemQuality.Standard, 1800.0, 38.0m, "bronze", MaterialBehaviourType.Metal,
+				[ToolTag, MeasureTag], ["Holdable", "MeasuringInstrument_Antiquity_BalanceScale", "Destroyable_HeavyMetal"]),
+			new("antiquity_merchant_tax_tablet", "tablet", "a merchant tax tablet",
+				"This clay tablet is ruled for taxable goods and standard portions, with room for fresh stylus marks beside common market categories.",
+				SizeCategory.Small, ItemQuality.Standard, 650.0, 10.0m, "clay", MaterialBehaviourType.Ceramic,
+				[WritingTag, ToolTag, MeasureTag], ["Holdable", "Antiquity_Clay_Tablet_Surface", "MarketGoodWeight_Antiquity_StapleFood", "Destroyable_Misc"]),
+			new("antiquity_armoury_supply_counter", "counter", "an armoury supply counter",
+				"This rugged armoury counter has a secured trade surface for issuing weapons, shields, arrows, and repair gear under official oversight.",
+				SizeCategory.VeryLarge, ItemQuality.Standard, 42000.0, 95.0m, "oak", MaterialBehaviourType.Wood,
+				[MarketTag, "Market / Military Goods", CivicTag], ["ShopStall_Antiquity_LockableCounter", "MarketGoodWeight_Antiquity_MilitarySupply", "Destroyable_WoodenHeavy"]),
+
+			new("antiquity_bronze_lockpick_set", "lockpicks", "a bronze lockpick set",
+				"This small bronze lockpick set holds flat picks, hooked probes, and a simple tension tool in a battered wrap.",
+				SizeCategory.Tiny, ItemQuality.Standard, 120.0, 22.0m, "bronze", MaterialBehaviourType.Metal,
+				[ToolTag, SecurityTag], ["Holdable", "Locksmithing_Antiquity_BronzeStandard", "Destroyable_Misc"]),
+			new("antiquity_locksmith_probe_roll", "roll", "a roll of lock probes",
+				"This leather roll carries bronze probes, shims, and narrow feelers for inspecting low-tech locks without immediately forcing them.",
+				SizeCategory.Small, ItemQuality.Standard, 260.0, 26.0m, "leather", MaterialBehaviourType.Leather,
+				[ToolTag, SecurityTag], ["Holdable", "Locksmithing_Antiquity_BronzeStandard", "Destroyable_Misc"]),
+			new("antiquity_lock_installation_kit", "kit", "a locksmith's installation kit",
+				"This installation kit gathers punches, pins, wedges, and small files for seating locks, latches, hasps, and fittings into chests or doors.",
+				SizeCategory.Small, ItemQuality.Standard, 1600.0, 42.0m, "bronze", MaterialBehaviourType.Metal,
+				[ToolTag, SecurityTag], ["Holdable", "Container_Pouch", "Locksmithing_Antiquity_Installation", "Destroyable_Misc"]),
+			new("antiquity_key_filing_kit", "kit", "a key filing kit",
+				"This key filing kit keeps narrow files, blanks, and rubbing wax ready for shaping or adjusting keys at a locksmith's bench.",
+				SizeCategory.Small, ItemQuality.Standard, 900.0, 32.0m, "bronze", MaterialBehaviourType.Metal,
+				[ToolTag, SecurityTag], ["Holdable", "Locksmithing_Antiquity_Fabrication", "Destroyable_Misc"]),
+			new("antiquity_guard_key_cord", "cord", "a cord of guard keys",
+				"This heavy cord strings together several official-looking keys and tags for a watchman, jailer, warehouse guard, or gate officer.",
+				SizeCategory.Small, ItemQuality.Standard, 540.0, 18.0m, "bronze", MaterialBehaviourType.Metal,
+				[ToolTag, SecurityTag], ["Holdable", "Keyring_Large", "Wear_Waist", "Destroyable_HeavyMetal"]),
+			new("antiquity_fine_steel_lockpick_case", "case", "a fine steel lockpick case",
+				"This slim case holds unusually fine steel picks and probes, carefully oiled and wrapped for delicate locks or expert dishonest work.",
+				SizeCategory.Tiny, ItemQuality.Great, 180.0, 70.0m, "steel", MaterialBehaviourType.Metal,
+				[ToolTag, SecurityTag], ["Holdable", "Container_Pouch", "Locksmithing_Antiquity_FineSteel", "Destroyable_Misc"]),
+
+			new("antiquity_forum_notice_board", "board", "a whitewashed forum notice board",
+				"This whitewashed public board is broad enough for notices, decrees, sales, and accusations, its surface scraped and repainted many times.",
+				SizeCategory.Large, ItemQuality.Standard, 11000.0, 30.0m, "oak", MaterialBehaviourType.Wood,
+				[FurnitureTag, CivicTag], ["Antiquity_Wooden_Block_Surface", "Destroyable_WoodenHeavy"]),
+			new("antiquity_temple_decree_board", "board", "a temple decree board",
+				"This temple board is painted in sober colours and framed for formal notices, rosters, vows, and religious decrees.",
+				SizeCategory.Large, ItemQuality.Good, 9500.0, 38.0m, "cedar", MaterialBehaviourType.Wood,
+				[ReligiousTag, CivicTag], ["Antiquity_Wooden_Block_Surface", "Destroyable_WoodenHeavy"]),
+			new("antiquity_barracks_roster_board", "board", "a barracks roster board",
+				"This barracks roster board is cut with neat rows for names, watches, duties, penalties, and temporary chalk or charcoal notes.",
+				SizeCategory.Large, ItemQuality.Standard, 8200.0, 24.0m, "oak", MaterialBehaviourType.Wood,
+				["Market / Military Goods", CivicTag], ["Antiquity_Wooden_Block_Surface", "Destroyable_WoodenHeavy"]),
+
+			new("antiquity_bronze_signet_ring", "ring", "a bronze signet ring",
+				"This bronze signet ring has a raised face cut with an official seal design, suitable for wax, clay, and careful comparison.",
+				SizeCategory.Tiny, ItemQuality.Good, 28.0, 45.0m, "bronze", MaterialBehaviourType.Metal,
+				[ToolTag, SecurityTag], ["Holdable", "Wear_Ring", "SealStamp_Antiquity_BronzeSignet", "Destroyable_HeavyMetal"]),
+			new("antiquity_cylinder_seal", "seal", "a carved cylinder seal",
+				"This small cylinder seal is pierced for a cord and carved around its body so it can roll a continuous authority mark through clay.",
+				SizeCategory.Tiny, ItemQuality.Good, 95.0, 55.0m, "stone", MaterialBehaviourType.Stone,
+				[ToolTag, SecurityTag], ["Holdable", "SealStamp_Antiquity_CylinderSeal", "Destroyable_Misc"]),
+			new("antiquity_clay_bulla", "bulla", "a clay document bulla",
+				"This small clay bulla is shaped for cord impressions and a sealing mark, ready to authenticate a tied document or packet.",
+				SizeCategory.Tiny, ItemQuality.Standard, 85.0, 3.0m, "clay", MaterialBehaviourType.Ceramic,
+				[WritingTag, SecurityTag], ["Holdable", "Antiquity_Clay_Tablet_Surface", "Sealable_Document_Clay", "Destroyable_Misc"]),
+			new("antiquity_wax_seal_cake", "cake", "a wax seal cake",
+				"This cake of dark wax is wrapped in a scrap of cloth and kept ready for melting into a document, scroll, or container seal.",
+				SizeCategory.Tiny, ItemQuality.Standard, 55.0, 4.0m, "wax", MaterialBehaviourType.Wax,
+				[WritingTag, SecurityTag], ["Holdable", "Destroyable_Misc"]),
+			new("antiquity_sealed_papyrus_scroll", "scroll", "a sealable papyrus scroll",
+				"This papyrus scroll is rolled with enough overlap for wax or clay to secure the tie and leave tamper evidence when broken.",
+				SizeCategory.Small, ItemQuality.Standard, 95.0, 12.0m, "papyrus", MaterialBehaviourType.Plant,
+				[WritingTag, SecurityTag], ["Holdable", "Antiquity_Papyrus_Scroll_Surface", "Sealable_Scroll", "Destroyable_Paper"]),
+			new("antiquity_sealed_clay_tablet", "tablet", "a sealable clay tablet",
+				"This clay tablet has a smoothed writing face and an edge left ready to take a bulla, clay seal, or official impression.",
+				SizeCategory.Small, ItemQuality.Standard, 750.0, 8.0m, "clay", MaterialBehaviourType.Ceramic,
+				[WritingTag, SecurityTag], ["Holdable", "Antiquity_Clay_Tablet_Surface", "Sealable_Document_Clay", "Destroyable_Misc"]),
+			new("antiquity_tax_office_seal_box", "box", "a tax office seal box",
+				"This compact tax office box has a built-in lock and sealing points for wax or clay, meant to carry tokens, receipts, and official tablets.",
+				SizeCategory.Small, ItemQuality.Standard, 2200.0, 42.0m, "cedar", MaterialBehaviourType.Wood,
+				[ToolTag, SecurityTag, CivicTag], ["Holdable", "LockingContainer_Lockbox", "Sealable_Container_Wax", "Destroyable_WoodenHeavy"]),
+			new("antiquity_merchant_contract_bundle", "bundle", "a merchant contract bundle",
+				"This bundled contract is made from tied papyrus sheets and a scroll wrapper, ready for a wax seal once the bargain is witnessed.",
+				SizeCategory.Small, ItemQuality.Standard, 160.0, 16.0m, "papyrus", MaterialBehaviourType.Plant,
+				[WritingTag, SecurityTag, MarketTag], ["Holdable", "Antiquity_Papyrus_Scroll_Surface", "Sealable_Document_Wax", "Destroyable_Paper"]),
+			new("antiquity_grain_amphora_seal", "amphora", "a sealable grain amphora",
+				"This earthenware grain amphora has a tied cover and prepared sealing points so stores can show whether the vessel has been opened.",
+				SizeCategory.Large, ItemQuality.Standard, 12000.0, 20.0m, "earthenware", MaterialBehaviourType.Ceramic,
+				[MarketTag, SecurityTag], ["Holdable", "LContainer_Amphora_Urna", "Sealable_Container_Wax", "Destroyable_Misc"]),
+			new("antiquity_sealable_envelope", "envelope", "a papyrus sealable envelope",
+				"This folded papyrus envelope has a small writable face, a closable flap, and a spot prepared for wax, clay, or paste.",
+				SizeCategory.Tiny, ItemQuality.Standard, 18.0, 5.0m, "papyrus", MaterialBehaviourType.Plant,
+				[WritingTag, SecurityTag], ["Holdable", "Container_Envelope", "PaperSheet_Envelope", "Sealable_Envelope", "Destroyable_Paper"]),
+			new("antiquity_sealable_scroll", "scroll", "a blank sealable papyrus scroll",
+				"This blank papyrus scroll is long enough for a formal letter or contract and can be sealed after writing.",
+				SizeCategory.Small, ItemQuality.Standard, 85.0, 10.0m, "papyrus", MaterialBehaviourType.Plant,
+				[WritingTag, SecurityTag], ["Holdable", "Antiquity_Papyrus_Scroll_Surface", "Sealable_Scroll", "Destroyable_Paper"]),
+
+			new("antiquity_bronze_balance_scale", "scale", "a bronze balance scale",
+				"This bronze balance scale has a central beam, matched pans, and a small suspension loop for market or tax-table use.",
+				SizeCategory.Small, ItemQuality.Good, 2100.0, 48.0m, "bronze", MaterialBehaviourType.Metal,
+				[ToolTag, MeasureTag], ["Holdable", "MeasuringInstrument_Antiquity_BalanceScale", "Destroyable_HeavyMetal"]),
+			new("antiquity_standard_weight_set", "weights", "an official standard weight set",
+				"This official standard weight set is stamped and nested in a small pouch for checking measures at market, warehouse, or tax gate.",
+				SizeCategory.Small, ItemQuality.Good, 3000.0, 65.0m, "bronze", MaterialBehaviourType.Metal,
+				[ToolTag, MeasureTag, CivicTag], ["Holdable", "Container_Pouch", "MarketGoodWeight_Antiquity_StapleFood", "MeasuringInstrument_Antiquity_StandardWeights", "Destroyable_HeavyMetal"]),
+			new("antiquity_false_weight_set", "weights", "a false weight set",
+				"This false weight set looks respectable, but the marked pieces are subtly biased for dishonest market measures.",
+				SizeCategory.Small, ItemQuality.Standard, 2900.0, 45.0m, "bronze", MaterialBehaviourType.Metal,
+				[ToolTag, MeasureTag], ["Holdable", "Container_Pouch", "MarketGoodWeight_Antiquity_StapleFood", "MeasuringInstrument_Antiquity_FalseWeights", "Destroyable_HeavyMetal"]),
+			new("antiquity_oil_measure_cup", "cup", "an oil measure cup",
+				"This small measure cup has a clean pouring lip and a marked inside line for oil, perfume, and other valuable fluids.",
+				SizeCategory.Small, ItemQuality.Standard, 260.0, 14.0m, "bronze", MaterialBehaviourType.Metal,
+				[ToolTag, MeasureTag], ["Holdable", "LContainer_DrinkingGlass", "MeasuringInstrument_Antiquity_OilCup", "Destroyable_HeavyMetal"]),
+			new("antiquity_wine_measure_cup", "cup", "a wine measure cup",
+				"This wine measure cup is larger than an oil cup, with dark lines around the interior and a steady base for public pours.",
+				SizeCategory.Small, ItemQuality.Standard, 420.0, 16.0m, "bronze", MaterialBehaviourType.Metal,
+				[ToolTag, MeasureTag], ["Holdable", "LContainer_WineGlass", "MeasuringInstrument_Antiquity_WineCup", "Destroyable_HeavyMetal"]),
+			new("antiquity_tax_assessor_measure_kit", "kit", "a tax assessor's measure kit",
+				"This official measure kit combines a folding scale beam, reference weights, tally tablets, cord, and a small seal-ready pouch.",
+				SizeCategory.Normal, ItemQuality.Good, 5200.0, 95.0m, "bronze", MaterialBehaviourType.Metal,
+				[ToolTag, MeasureTag, CivicTag], ["Holdable", "Container_Pouch", "MeasuringInstrument_Antiquity_TaxAssessorKit", "Destroyable_HeavyMetal"])
+		];
+	}
+}

--- a/DatabaseSeeder/Seeders/ItemSeeder.Rework.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Rework.cs
@@ -541,6 +541,7 @@ namespace DatabaseSeeder.Seeders
                 SeedAntiquityWeaponsShieldsAccessories();
                 SeedAntiquityApiaryItems();
                 SeedAntiquityFoodAndBeverageItems();
+                SeedAntiquityComponentGapItems();
             }
 
             if (eras.Contains("medieval", StringComparison.InvariantCultureIgnoreCase))

--- a/DatabaseSeeder/Seeders/ItemSeeder.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.cs
@@ -1108,6 +1108,16 @@ The items and crafts are fairly universal and of approximately medieval to renei
             context.GameItemComponentProtos.All(x => x.Name != "Container_Wide_Shelves") ||
             context.GameItemComponentProtos.All(x => x.Name != "Container_Open_Bin") ||
             context.GameItemComponentProtos.All(x => x.Name != "Container_Trunk") ||
+            context.GameItemComponentProtos.All(x => x.Name != "TimePiece_Antiquity_Sundial") ||
+            context.GameItemComponentProtos.All(x => x.Name != "WaterSource_Antiquity_PublicWell") ||
+            context.GameItemComponentProtos.All(x => x.Name != "Dice_Antiquity_Knucklebones") ||
+            context.GameItemComponentProtos.All(x => x.Name != "DragAid_Antiquity_FieldStretcher") ||
+            context.GameItemComponentProtos.All(x => x.Name != "Locksmithing_Antiquity_BronzePoor") ||
+            context.GameItemComponentProtos.All(x => x.Name != "ShopStall_Antiquity_OpenCounter") ||
+            context.GameItemComponentProtos.All(x => x.Name != "MarketGoodWeight_Antiquity_StapleFood") ||
+            context.GameItemComponentProtos.All(x => x.Name != "SealStamp_Antiquity_BronzeSignet") ||
+            context.GameItemComponentProtos.All(x => x.Name != "Sealable_Envelope") ||
+            context.GameItemComponentProtos.All(x => x.Name != "MeasuringInstrument_Antiquity_BalanceScale") ||
             context.GameItemComponentProtos.All(x => x.Name != "Insulation_Minor") ||
             context.GameItemComponentProtos.All(x => x.Name != "Destroyable_Misc") ||
             context.GameItemComponentProtos.All(x => x.Name != "Torch_Infinite") ||

--- a/DatabaseSeeder/Seeders/UsefulSeeder.ItemComponents.cs
+++ b/DatabaseSeeder/Seeders/UsefulSeeder.ItemComponents.cs
@@ -220,6 +220,7 @@ public partial class UsefulSeeder
         SeedWaterSources(context, now, dbaccount, ref nextId);
         SeedDice(context, now, dbaccount, ref nextId);
         SeedAdditionalBuilderExamples(context, now, dbaccount, ref nextId);
+        SeedSealAndMeasurementComponents(context, now, dbaccount, ref nextId);
         context.SaveChanges();
     }
 
@@ -6474,6 +6475,7 @@ public partial class UsefulSeeder
         SeedWaterSources(context, now, dbaccount, ref nextId);
         SeedRepairKits(context, now, dbaccount, ref nextId);
         SeedAdditionalBuilderExamples(context, now, dbaccount, ref nextId);
+        SeedSealAndMeasurementComponents(context, now, dbaccount, ref nextId);
         SeedSmokeables(context, now, dbaccount, ref nextId);
     }
 
@@ -7391,6 +7393,273 @@ public partial class UsefulSeeder
 
         nextId = currentId;
         context.SaveChanges();
+        #endregion
+    }
+
+    private void SeedSealAndMeasurementComponents(FuturemudDatabaseContext context, DateTime now, Account dbaccount,
+        ref long nextId)
+    {
+        #region Seals and Measurement
+
+        long currentId = nextId;
+
+        GameItemComponentProto UpsertStockComponent(string type, string name, string description, XElement definition)
+        {
+            return UpsertComponent(context, ref currentId, dbaccount, now, type, name, description, definition.ToString());
+        }
+
+        GameItemComponentProto EnsureComponent(string type, string name, string description, XElement definition)
+        {
+            GameItemComponentProto? existing = context.GameItemComponentProtos.Local
+                                         .FirstOrDefault(x => x.Name == name && x.EditableItem.RevisionStatus == 4) ??
+                                     context.GameItemComponentProtos
+                                         .FirstOrDefault(x => x.Name == name && x.EditableItem.RevisionStatus == 4);
+            return existing ?? UpsertStockComponent(type, name, description, definition);
+        }
+
+        XElement SealStampDefinition(string design, string issuer, string owner, string clan, string office,
+            string material, Difficulty forgeryDifficulty)
+        {
+            return new XElement("Definition",
+                new XElement("SealDesign", new XCData(design)),
+                new XElement("IssuerText", new XCData(issuer)),
+                new XElement("OwnerText", new XCData(owner)),
+                new XElement("ClanText", new XCData(clan)),
+                new XElement("OfficeText", new XCData(office)),
+                new XElement("StampMaterial", new XCData(material)),
+                new XElement("ForgeryDifficulty", (int)forgeryDifficulty),
+                new XElement("AuthorityProg", 0));
+        }
+
+        XElement SealableDefinition(Difficulty inspectionDifficulty, bool brokenSealLeavesResidue,
+            params string[] allowedMedia)
+        {
+            return new XElement("Definition",
+                new XElement("AllowedMedia",
+                    from medium in allowedMedia
+                    select new XElement("Medium", new XCData(medium))),
+                new XElement("InspectionDifficulty", (int)inspectionDifficulty),
+                new XElement("BrokenSealLeavesResidue", brokenSealLeavesResidue));
+        }
+
+        XElement MeasuringDefinition(string mode, double precision, double capacity, double baseDriftPerUse,
+            double maximumDrift, double maximumWrongCalibration, Difficulty inspectionDifficulty)
+        {
+            return new XElement("Definition",
+                new XElement("Mode", mode),
+                new XElement("Precision", precision),
+                new XElement("Capacity", capacity),
+                new XElement("BaseDriftPerUse", baseDriftPerUse),
+                new XElement("MaximumDrift", maximumDrift),
+                new XElement("MaximumWrongCalibration", maximumWrongCalibration),
+                new XElement("CalibrationInspectionDifficulty", (int)inspectionDifficulty));
+        }
+
+        Material EnsureMaterial(string name, MaterialBehaviourType behaviourType)
+        {
+            Material? material = context.Materials.Local.FirstOrDefault(x => x.Name.EqualTo(name)) ??
+                                 context.Materials.FirstOrDefault(x => x.Name == name);
+            if (material is not null)
+            {
+                return material;
+            }
+
+            material = new Material
+            {
+                Id = context.Materials.Any() ? context.Materials.Max(x => x.Id) + 1 : 1,
+                Name = name,
+                MaterialDescription = name.ToLowerInvariant(),
+                BehaviourType = (int)behaviourType,
+                ResidueSdesc = string.Empty,
+                ResidueDesc = string.Empty,
+                ResidueColour = string.Empty
+            };
+            context.Materials.Add(material);
+            return material;
+        }
+
+        long nextItemProtoId = context.GameItemProtos.Any() ? context.GameItemProtos.Max(x => x.Id) + 1 : 1;
+
+        void EnsureComponentLink(GameItemProto item, GameItemComponentProto component)
+        {
+            if (item.GameItemProtosGameItemComponentProtos.Any(x =>
+                    x.GameItemComponentProtoId == component.Id || x.GameItemComponent == component))
+            {
+                return;
+            }
+
+            item.GameItemProtosGameItemComponentProtos.Add(new GameItemProtosGameItemComponentProtos
+            {
+                GameItemProto = item,
+                GameItemProtoId = item.Id,
+                GameItemProtoRevision = item.RevisionNumber,
+                GameItemComponent = component,
+                GameItemComponentProtoId = component.Id,
+                GameItemComponentRevision = component.RevisionNumber
+            });
+        }
+
+        void EnsureItemPrototype(string name, string keywords, Material material, SizeCategory size, double weight,
+            string shortDescription, string fullDescription, params GameItemComponentProto[] components)
+        {
+            GameItemProto? item = context.GameItemProtos.Local
+                                      .FirstOrDefault(x => x.ShortDescription == shortDescription) ??
+                                  context.GameItemProtos
+                                      .Include(x => x.GameItemProtosGameItemComponentProtos)
+                                      .FirstOrDefault(x => x.ShortDescription == shortDescription);
+            if (item is null)
+            {
+                item = new GameItemProto
+                {
+                    Id = nextItemProtoId++,
+                    RevisionNumber = 0,
+                    Name = name,
+                    UniqueName = shortDescription,
+                    BuilderNotes = "Auto-generated by the system",
+                    Keywords = keywords,
+                    MaterialId = material.Id,
+                    EditableItem = new EditableItem
+                    {
+                        RevisionNumber = 0,
+                        RevisionStatus = 4,
+                        BuilderAccountId = dbaccount.Id,
+                        BuilderDate = now,
+                        BuilderComment = "Auto-generated by the system",
+                        ReviewerAccountId = dbaccount.Id,
+                        ReviewerComment = "Auto-generated by the system",
+                        ReviewerDate = now
+                    },
+                    Size = (int)size,
+                    Weight = weight,
+                    ReadOnly = false,
+                    LongDescription = string.Empty,
+                    BaseItemQuality = (int)ItemQuality.Standard,
+                    CustomColour = string.Empty,
+                    HighPriority = false,
+                    MorphTimeSeconds = 0,
+                    MorphEmote = string.Empty,
+                    ShortDescription = shortDescription,
+                    FullDescription = fullDescription,
+                    PermitPlayerSkins = false,
+                    CostInBaseCurrency = 0.0M,
+                    IsHiddenFromPlayers = false,
+                    PreserveRegisterVariables = false,
+                    PlanarData = string.Empty
+                };
+                context.GameItemProtos.Add(item);
+            }
+            else
+            {
+                item.Name = name;
+                item.UniqueName = shortDescription;
+                item.Keywords = keywords;
+                item.MaterialId = material.Id;
+                item.Size = (int)size;
+                item.Weight = weight;
+                item.ShortDescription = shortDescription;
+                item.FullDescription = fullDescription;
+            }
+
+            foreach (GameItemComponentProto component in components)
+            {
+                EnsureComponentLink(item, component);
+            }
+        }
+
+        GameItemComponentProto bronzeSignet = UpsertStockComponent("SealStamp", "SealStamp_Antiquity_BronzeSignet",
+            "Turns an item into a bronze signet ring style seal stamp.",
+            SealStampDefinition("a bronze signet showing a lion beneath a civic star", "Civic Magistracy",
+                string.Empty, string.Empty, "Seal-Bearer", "bronze", Difficulty.VeryHard));
+        GameItemComponentProto cylinderSeal = UpsertStockComponent("SealStamp", "SealStamp_Antiquity_CylinderSeal",
+            "Turns an item into a cylinder seal for rolling an authority impression through clay or wax.",
+            SealStampDefinition("a rolled procession of officials, reeds and account marks", "Temple Archive",
+                string.Empty, "Temple Household", "Archive Steward", "stone", Difficulty.ExtremelyHard));
+
+        GameItemComponentProto sealableWaxDocument = UpsertStockComponent("Sealable", "Sealable_Document_Wax",
+            "Lets a document be sealed with wax and leave broken-seal residue.",
+            SealableDefinition(Difficulty.Normal, true, "wax"));
+        GameItemComponentProto sealableClayDocument = UpsertStockComponent("Sealable", "Sealable_Document_Clay",
+            "Lets a document be sealed with clay and leave broken-seal residue.",
+            SealableDefinition(Difficulty.Hard, true, "clay"));
+        GameItemComponentProto sealableEnvelope = UpsertStockComponent("Sealable", "Sealable_Envelope",
+            "Lets an envelope be sealed with wax, clay or paste.",
+            SealableDefinition(Difficulty.Normal, true, "wax", "clay", "paste"));
+        GameItemComponentProto sealableScroll = UpsertStockComponent("Sealable", "Sealable_Scroll",
+            "Lets a scroll be sealed with wax, clay or paste.",
+            SealableDefinition(Difficulty.Normal, true, "wax", "clay", "paste"));
+        GameItemComponentProto sealableContainer = UpsertStockComponent("Sealable", "Sealable_Container_Wax",
+            "Lets a closable container be sealed with wax or clay as tamper evidence.",
+            SealableDefinition(Difficulty.Hard, true, "wax", "clay"));
+
+        UpsertStockComponent("MeasuringInstrument", "MeasuringInstrument_Antiquity_BalanceScale",
+            "Turns an item into a weight-mode balance scale with modest use-based drift.",
+            MeasuringDefinition("Weight", 1.0, 50000.0, 0.00025, 0.03, 0.25, Difficulty.Normal));
+        UpsertStockComponent("MeasuringInstrument", "MeasuringInstrument_Antiquity_StandardWeights",
+            "Turns an item into a standard weight set for comparing trade goods.",
+            MeasuringDefinition("Weight", 0.5, 20000.0, 0.0001, 0.015, 0.20, Difficulty.Hard));
+        UpsertStockComponent("MeasuringInstrument", "MeasuringInstrument_Antiquity_FalseWeights",
+            "Turns an item into a weight set intended for biased trade measures.",
+            MeasuringDefinition("Weight", 0.5, 20000.0, 0.0001, 0.015, 0.35, Difficulty.VeryHard));
+        UpsertStockComponent("MeasuringInstrument", "MeasuringInstrument_Antiquity_GrainMeasure",
+            "Turns an item into a grain measure interpreted as a weight-mode trade measure.",
+            MeasuringDefinition("Weight", 10.0, 100000.0, 0.00075, 0.05, 0.30, Difficulty.Normal));
+        UpsertStockComponent("MeasuringInstrument", "MeasuringInstrument_Antiquity_OilCup",
+            "Turns an item into a fluid-volume measure cup for oil.",
+            MeasuringDefinition("FluidVolume", 0.005, 1.0, 0.0005, 0.04, 0.25, Difficulty.Normal));
+        UpsertStockComponent("MeasuringInstrument", "MeasuringInstrument_Antiquity_WineCup",
+            "Turns an item into a fluid-volume measure cup for wine.",
+            MeasuringDefinition("FluidVolume", 0.01, 2.0, 0.0005, 0.04, 0.25, Difficulty.Normal));
+        UpsertStockComponent("MeasuringInstrument", "MeasuringInstrument_Antiquity_TaxAssessorKit",
+            "Turns an item into a tax assessor's kit for weighing taxable goods.",
+            MeasuringDefinition("Weight", 5.0, 250000.0, 0.0002, 0.025, 0.20, Difficulty.Hard));
+
+        Material paperMaterial = EnsureMaterial("Paper", MaterialBehaviourType.Plant);
+        GameItemComponentProto holdable = EnsureComponent("Holdable", "Holdable",
+            "Allows an item to be picked up and manipulated.",
+            new XElement("Definition"));
+        GameItemComponentProto envelopeContainer = EnsureComponent("Container", "Container_Envelope",
+            "Allows an envelope to hold small flat contents.",
+            new XElement("Definition",
+                new XAttribute("Weight", 50.0),
+                new XAttribute("MaxSize", (int)SizeCategory.Tiny),
+                new XAttribute("Preposition", "in"),
+                new XAttribute("Closable", true),
+                new XAttribute("Transparent", false),
+                new XAttribute("OnceOnly", false)));
+        GameItemComponentProto envelopeWriteable = EnsureComponent("PaperSheet", "PaperSheet_Envelope",
+            "Turns an envelope into a small writable paper surface.",
+            new XElement("Definition",
+                new XElement("MaximumCharacterLengthOfText", 1000)));
+        GameItemComponentProto scrollWriteable = EnsureComponent("PaperSheet", "PaperSheet_Scroll",
+            "Turns a scroll into a long writable paper or parchment surface.",
+            new XElement("Definition",
+                new XElement("MaximumCharacterLengthOfText", 8000)));
+        GameItemComponentProto destroyablePaper = EnsureComponent("Destroyable", "Destroyable_Paper",
+            "Turns an item into a fragile paper or parchment object.",
+            new XElement("Definition",
+                new XElement("HpExpression", new XCData("2 * quality")),
+                new XElement("DamageMultipliers",
+                    new XElement("DamageMultiplier", new XAttribute("type", (int)DamageType.Burning), new XAttribute("multiplier", 2.5)),
+                    new XElement("DamageMultiplier", new XAttribute("type", (int)DamageType.Piercing), new XAttribute("multiplier", 1.1)))));
+
+        EnsureItemPrototype("envelope", "envelope paper sealable writable", paperMaterial, SizeCategory.Tiny, 10.0,
+            "a sealable envelope",
+            "This is a folded paper envelope with a closable flap suitable for writing, contents and sealing.",
+            holdable, envelopeContainer, envelopeWriteable, sealableEnvelope, destroyablePaper);
+        EnsureItemPrototype("scroll", "scroll paper parchment sealable writable", paperMaterial, SizeCategory.Small,
+            25.0, "a sealable scroll",
+            "This is a rolled writing scroll with a blank surface and enough overlap to bear a tamper-evident seal.",
+            holdable, scrollWriteable, sealableScroll, destroyablePaper);
+
+        _ = bronzeSignet;
+        _ = cylinderSeal;
+        _ = sealableWaxDocument;
+        _ = sealableClayDocument;
+        _ = sealableContainer;
+
+        nextId = currentId;
+        context.SaveChanges();
+
         #endregion
     }
 

--- a/DatabaseSeeder/Seeders/UsefulSeeder.ItemComponents.cs
+++ b/DatabaseSeeder/Seeders/UsefulSeeder.ItemComponents.cs
@@ -210,6 +210,19 @@ public partial class UsefulSeeder
         context.SaveChanges();
     }
 
+    internal void SeedAntiquityComponentGapCoverageForTesting(FuturemudDatabaseContext context)
+    {
+        _context = context;
+        PrepareItemProtoCache(context);
+        DateTime now = DateTime.UtcNow;
+        Account dbaccount = context.Accounts.First();
+        long nextId = context.GameItemComponentProtos.Any() ? context.GameItemComponentProtos.Max(x => x.Id) + 1 : 1;
+        SeedWaterSources(context, now, dbaccount, ref nextId);
+        SeedDice(context, now, dbaccount, ref nextId);
+        SeedAdditionalBuilderExamples(context, now, dbaccount, ref nextId);
+        context.SaveChanges();
+    }
+
     internal void SeedContainersForTesting(FuturemudDatabaseContext context)
     {
         _context = context;
@@ -5788,6 +5801,21 @@ public partial class UsefulSeeder
 
         GameItemComponentProto component;
 
+        GameItemComponentProto CreateDice(ref long id, string name, string description, IReadOnlyList<(string Face, double Probability)> faces)
+        {
+            return CreateComponent(context, ref id, dbaccount, now, "Dice", name, description,
+                new XElement("Definition",
+                    new XElement("Faces",
+                        from face in faces
+                        select new XElement("Face", new XCData(face.Face))),
+                    new XElement("Weights",
+                        from face in faces.Select((face, index) => (Probability: face.Probability, Index: index))
+                        select new XElement("Weight",
+                            new XElement("Face", face.Index),
+                            new XElement("Probability", face.Probability)))
+                ).ToString());
+        }
+
         component = new GameItemComponentProto
         {
             Id = nextId++,
@@ -6395,6 +6423,41 @@ public partial class UsefulSeeder
  </Definition>"
         };
         AddGameItemComponent(context, component);
+
+        CreateDice(ref nextId, "Dice_Antiquity_Knucklebones",
+            "Turns an item into a four-faced knucklebone die with named astragaloi-style faces.",
+            [
+                ("Dog", 1.0),
+                ("Vulture", 1.0),
+                ("King", 1.0),
+                ("Venus", 1.0)
+            ]);
+        CreateDice(ref nextId, "Dice_Antiquity_CastingSticks",
+            "Turns an item into a marked-or-unmarked casting stick die for lots, games or divination.",
+            [
+                ("Marked", 1.0),
+                ("Unmarked", 1.0)
+            ]);
+        CreateDice(ref nextId, "Dice_Antiquity_LoadedD6",
+            "Turns an item into a six-sided die subtly weighted toward high rolls.",
+            [
+                ("1", 0.6),
+                ("2", 0.8),
+                ("3", 0.8),
+                ("4", 1.0),
+                ("5", 1.2),
+                ("6", 2.5)
+            ]);
+        CreateDice(ref nextId, "Dice_Antiquity_DivinationLots",
+            "Turns an item into a symbolic divination lot die for temple, oracle or folk-divination use.",
+            [
+                ("Favour", 1.0),
+                ("Warning", 1.0),
+                ("Delay", 1.0),
+                ("Sacrifice", 1.0),
+                ("Journey", 1.0),
+                ("Conflict", 1.0)
+            ]);
         context.SaveChanges();
 
         #endregion
@@ -6528,6 +6591,25 @@ public partial class UsefulSeeder
         CreateWaterSourceComponent(context, ref nextId, dbaccount, now, "Infinite_SaltWaterSource",
             "Turns an item into a self-refilling source of salt water.",
             100000000, liquid.Id, 1000, false);
+
+        CreateWaterSourceComponent(context, ref nextId, dbaccount, now, "WaterSource_Antiquity_PublicWell",
+            "Turns an item into a stone public well or similar fixed potable water source.",
+            1000000, waterLiquid.Id, 0.8333333333333334, false);
+        CreateWaterSourceComponent(context, ref nextId, dbaccount, now, "WaterSource_Antiquity_Cistern",
+            "Turns an item into a lined stone cistern with a large stored water supply.",
+            50000, waterLiquid.Id, 0.0, false);
+        CreateWaterSourceComponent(context, ref nextId, dbaccount, now, "WaterSource_Antiquity_Fountain",
+            "Turns an item into a public fountain or flowing spout.",
+            1000000, springLiquid.Id, 1000, false);
+        CreateWaterSourceComponent(context, ref nextId, dbaccount, now, "WaterSource_Antiquity_BathPool",
+            "Turns an item into a large bathhouse plunge pool.",
+            5000, waterLiquid.Id, 10.0, false);
+        CreateWaterSourceComponent(context, ref nextId, dbaccount, now, "WaterSource_Antiquity_RitualBasin",
+            "Turns an item into a temple purification basin or other ritual water source.",
+            100, waterLiquid.Id, 0.0, false);
+        CreateWaterSourceComponent(context, ref nextId, dbaccount, now, "WaterSource_Antiquity_IrrigationOutlet",
+            "Turns an item into an irrigation-channel outlet or agricultural water fixture.",
+            100000000, riverLiquid.Id, 1000, false);
 
         Liquid tapWaterLiquid = context.Liquids.FirstOrDefault(x => x.Name == "tap water") ??
             context.Liquids.First(x => x.Name == "water");
@@ -6688,6 +6770,53 @@ public partial class UsefulSeeder
             return CreateComponent(context, ref currentId, dbaccount, now, type, name, description, definition.ToString());
         }
 
+        XElement LocksmithingDefinition(int difficultyAdjustment, bool usableForInstallation,
+            bool usableForConfiguration, bool usableForFabrication, bool breakable)
+        {
+            return new XElement("Definition",
+                new XElement("DifficultyAdjustment", difficultyAdjustment),
+                new XElement("UsableForInstallation", usableForInstallation),
+                new XElement("UsableForConfiguration", usableForConfiguration),
+                new XElement("UsableForFabrication", usableForFabrication),
+                new XElement("Breakable", breakable));
+        }
+
+        XElement ShopStallDefinition(double weight, SizeCategory maximumSize, bool transparent, Difficulty forceDifficulty,
+            Difficulty pickDifficulty, string lockType)
+        {
+            return new XElement("Definition",
+                new XAttribute("Weight", weight),
+                new XAttribute("MaxSize", (int)maximumSize),
+                new XAttribute("Preposition", "on"),
+                new XAttribute("Transparent", transparent),
+                new XElement("ForceDifficulty", (int)forceDifficulty),
+                new XElement("PickDifficulty", (int)pickDifficulty),
+                new XElement("LockEmote", new XCData("@ secure|secures $1$?2| with $2||$.")),
+                new XElement("UnlockEmote", new XCData("@ unfasten|unfastens $1$?2| with $2||$.")),
+                new XElement("LockEmoteNoActor", new XCData("@ settle|settles into a secured state.")),
+                new XElement("UnlockEmoteNoActor", new XCData("@ release|releases its fastening.")),
+                new XElement("LockType", lockType));
+        }
+
+        XElement MarketGoodWeightDefinition(params (string CategoryName, decimal Multiplier)[] multipliers)
+        {
+            XElement multiplierElement = new("Multipliers");
+            foreach ((string categoryName, decimal multiplier) in multipliers)
+            {
+                MarketCategory? category = context.MarketCategories.FirstOrDefault(x => x.Name == categoryName);
+                if (category is null)
+                {
+                    continue;
+                }
+
+                multiplierElement.Add(new XElement("Multiplier",
+                    new XAttribute("category", category.Id),
+                    new XAttribute("value", multiplier)));
+            }
+
+            return new XElement("Definition", multiplierElement);
+        }
+
         AddExtraComponent("LockingContainer", "LockingContainer_Lockbox",
             "Turns an item into a small lockbox with a built-in lever lock.",
             new XElement("Definition",
@@ -6778,6 +6907,21 @@ public partial class UsefulSeeder
                 new XElement("UsableForConfiguration", false),
                 new XElement("UsableForFabrication", true),
                 new XElement("Breakable", false)));
+        AddExtraComponent("Locksmithing Tool", "Locksmithing_Antiquity_BronzePoor",
+            "Turns an item into a penalty-bearing, breakable set of low-tech bronze lockpicks.",
+            LocksmithingDefinition(-2, false, false, false, true));
+        AddExtraComponent("Locksmithing Tool", "Locksmithing_Antiquity_BronzeStandard",
+            "Turns an item into a standard antiquity lockpick and probe roll.",
+            LocksmithingDefinition(0, false, true, false, true));
+        AddExtraComponent("Locksmithing Tool", "Locksmithing_Antiquity_FineSteel",
+            "Turns an item into a rare fine steel lockpick set for elite low-tech locksmithing.",
+            LocksmithingDefinition(2, false, true, false, false));
+        AddExtraComponent("Locksmithing Tool", "Locksmithing_Antiquity_Installation",
+            "Turns an item into an antiquity lock installation and configuration kit.",
+            LocksmithingDefinition(1, true, true, false, false));
+        AddExtraComponent("Locksmithing Tool", "Locksmithing_Antiquity_Fabrication",
+            "Turns an item into an antiquity key filing and lock fabrication kit.",
+            LocksmithingDefinition(1, false, false, true, false));
 
         AddExtraComponent("PencilSharpener", "PencilSharpener",
             "Turns an item into a pencil sharpener.",
@@ -6972,6 +7116,31 @@ public partial class UsefulSeeder
             new XElement("Definition",
                 new XElement("MaximumUsers", 2),
                 new XElement("EffortMultiplier", 2.25)));
+        AddExtraComponent("DragAid", "DragAid_Antiquity_FieldStretcher",
+            "Turns an item into an antiquity field stretcher for casualty movement.",
+            new XElement("Definition",
+                new XElement("MaximumUsers", 4),
+                new XElement("EffortMultiplier", 3.25)));
+        AddExtraComponent("DragAid", "DragAid_Antiquity_CorpseBier",
+            "Turns an item into a funerary bier or corpse litter for team movement.",
+            new XElement("Definition",
+                new XElement("MaximumUsers", 6),
+                new XElement("EffortMultiplier", 3.0)));
+        AddExtraComponent("DragAid", "DragAid_Antiquity_CargoSled",
+            "Turns an item into a low cargo sled for heavy antiquity hauling.",
+            new XElement("Definition",
+                new XElement("MaximumUsers", 4),
+                new XElement("EffortMultiplier", 2.75)));
+        AddExtraComponent("DragAid", "DragAid_Antiquity_PackTravois",
+            "Turns an item into a pack travois for pastoral or frontier cargo support.",
+            new XElement("Definition",
+                new XElement("MaximumUsers", 2),
+                new XElement("EffortMultiplier", 2.4)));
+        AddExtraComponent("DragAid", "DragAid_Antiquity_CarryingSling",
+            "Turns an item into a one-person carrying sling for smaller loads.",
+            new XElement("Definition",
+                new XElement("MaximumUsers", 1),
+                new XElement("EffortMultiplier", 1.6)));
 
         AddExtraComponent("WaterSource", "WaterSource_Canteen",
             "Turns an item into a transparent closable refill-on-toggle canteen.",
@@ -7157,7 +7326,68 @@ public partial class UsefulSeeder
                     new XElement("TimeZone", defaultTimeZone.Id),
                     new XElement("PlayersCanSetTime", false),
                     new XElement("TimeDisplayString", "$h:$m")));
+            AddExtraComponent("TimePiece", "TimePiece_Antiquity_Sundial",
+                "Turns an item into a non-settable sundial-style timepiece with crude daylight time display.",
+                new XElement("Definition",
+                    new XElement("Clock", primaryClock.Id),
+                    new XElement("TimeZone", defaultTimeZone.Id),
+                    new XElement("PlayersCanSetTime", false),
+                    new XElement("TimeDisplayString", "$c")));
+            AddExtraComponent("TimePiece", "TimePiece_Antiquity_WaterClock",
+                "Turns an item into a non-settable water-clock style timepiece for temples, courts or watch posts.",
+                new XElement("Definition",
+                    new XElement("Clock", primaryClock.Id),
+                    new XElement("TimeZone", defaultTimeZone.Id),
+                    new XElement("PlayersCanSetTime", false),
+                    new XElement("TimeDisplayString", "$j:$m $i")));
+            AddExtraComponent("TimePiece", "TimePiece_Antiquity_MarkedCandle",
+                "Turns an item into a coarse marked-candle timepiece.",
+                new XElement("Definition",
+                    new XElement("Clock", primaryClock.Id),
+                    new XElement("TimeZone", defaultTimeZone.Id),
+                    new XElement("PlayersCanSetTime", false),
+                    new XElement("TimeDisplayString", "$c")));
+            AddExtraComponent("TimePiece", "TimePiece_Antiquity_WatchBoard",
+                "Turns an item into a public watch-board timepiece tied to the default clock and timezone.",
+                new XElement("Definition",
+                    new XElement("Clock", primaryClock.Id),
+                    new XElement("TimeZone", defaultTimeZone.Id),
+                    new XElement("PlayersCanSetTime", false),
+                    new XElement("TimeDisplayString", "$j $i")));
         }
+
+        AddExtraComponent("ShopStall", "ShopStall_Antiquity_OpenCounter",
+            "Turns an item into an open antiquity market counter or stall surface.",
+            ShopStallDefinition(200000, SizeCategory.Large, true, Difficulty.Normal, Difficulty.Normal, "Warded Lock"));
+        AddExtraComponent("ShopStall", "ShopStall_Antiquity_LockableCounter",
+            "Turns an item into a lockable antiquity market counter for unattended goods.",
+            ShopStallDefinition(250000, SizeCategory.Large, false, Difficulty.VeryHard, Difficulty.Hard, "Warded Lock"));
+        AddExtraComponent("ShopStall", "ShopStall_Antiquity_PortableBooth",
+            "Turns an item into a lighter portable stall for fairs, camps and travelling merchants.",
+            ShopStallDefinition(100000, SizeCategory.Normal, true, Difficulty.Hard, Difficulty.Normal, "Warded Lock"));
+
+        AddExtraComponent("MarketGoodWeight", "MarketGoodWeight_Antiquity_StapleFood",
+            "Turns an item into an antiquity market-good weight for staples such as grain, beer and wine.",
+            MarketGoodWeightDefinition(
+                ("Staple Food", 1.25m),
+                ("Standard Food", 1.05m),
+                ("Beer", 1.10m),
+                ("Wine", 1.10m)));
+        AddExtraComponent("MarketGoodWeight", "MarketGoodWeight_Antiquity_LuxuryCraft",
+            "Turns an item into an antiquity market-good weight for luxury crafts and elite household wares.",
+            MarketGoodWeightDefinition(
+                ("Luxury Wares", 1.35m),
+                ("Luxury Clothing", 1.25m),
+                ("Luxury Furniture", 1.20m),
+                ("Luxury Decorations", 1.25m)));
+        AddExtraComponent("MarketGoodWeight", "MarketGoodWeight_Antiquity_MilitarySupply",
+            "Turns an item into an antiquity market-good weight for military supply goods.",
+            MarketGoodWeightDefinition(
+                ("Military Goods", 1.20m),
+                ("Weapons", 1.25m),
+                ("Armour", 1.25m),
+                ("Ammunition", 1.15m),
+                ("Shields", 1.15m)));
 
         nextId = currentId;
         context.SaveChanges();

--- a/DatabaseSeeder/Seeders/UsefulSeeder.cs
+++ b/DatabaseSeeder/Seeders/UsefulSeeder.cs
@@ -63,7 +63,10 @@ public partial class UsefulSeeder : IDatabaseSeeder
         "DragAid_Antiquity_FieldStretcher",
         "Locksmithing_Antiquity_BronzePoor",
         "ShopStall_Antiquity_OpenCounter",
-        "MarketGoodWeight_Antiquity_StapleFood"
+        "MarketGoodWeight_Antiquity_StapleFood",
+        "SealStamp_Antiquity_BronzeSignet",
+        "Sealable_Envelope",
+        "MeasuringInstrument_Antiquity_BalanceScale"
     ];
 
     private static readonly string[] StockModernItemMarkers =

--- a/DatabaseSeeder/Seeders/UsefulSeeder.cs
+++ b/DatabaseSeeder/Seeders/UsefulSeeder.cs
@@ -56,7 +56,14 @@ public partial class UsefulSeeder : IDatabaseSeeder
         "Smokeable_Cigar",
         "DragAid_Stretcher",
         "Treatment_AntiInflammatory_Single",
-        "TimePiece_PocketWatch"
+        "TimePiece_PocketWatch",
+        "TimePiece_Antiquity_Sundial",
+        "WaterSource_Antiquity_PublicWell",
+        "Dice_Antiquity_Knucklebones",
+        "DragAid_Antiquity_FieldStretcher",
+        "Locksmithing_Antiquity_BronzePoor",
+        "ShopStall_Antiquity_OpenCounter",
+        "MarketGoodWeight_Antiquity_StapleFood"
     ];
 
     private static readonly string[] StockModernItemMarkers =
@@ -128,7 +135,7 @@ public partial class UsefulSeeder : IDatabaseSeeder
                         if (answer.EqualToAny("yes", "y", "no", "n")) { return (true, string.Empty); } return (false, "Invalid answer");
                 }),
             ("items",
-                "#DItem Package 1#F\n\nDo you want to include a package of standard item definitions, which includes some commonly used item component types, including a wide selection of containers, liquid containers, doors, locks, keys, basic writing implements, insulation for clothing, components that let worn clothing hide or change characteristics (wigs, coloured contacts, etc), components that correct for myopia flaws, as well as identity obscurers (hoods, full helmets, niqabs, cloaks, etc.), destroyables, colour variables, further writing implements, tables and chairs, ranged covers, medical items, prosthetic limbs, dice, torches and lanterns, repair kits, water sources, smokeable tobacco, drag aids and timepieces.\n\nShall we install this package? Please answer #3yes#f or #3no#f: ",
+                "#DItem Package 1#F\n\nDo you want to include a package of standard item definitions, which includes some commonly used item component types, including a wide selection of containers, liquid containers, doors, locks, keys, basic writing implements, insulation for clothing, components that let worn clothing hide or change characteristics (wigs, coloured contacts, etc), components that correct for myopia flaws, as well as identity obscurers (hoods, full helmets, niqabs, cloaks, etc.), destroyables, colour variables, further writing implements, tables and chairs, ranged covers, medical items, prosthetic limbs, dice, torches and lanterns, repair kits, water sources, smokeable tobacco, drag aids, timepieces, market stalls, market good weights and pre-modern builder variants.\n\nShall we install this package? Please answer #3yes#f or #3no#f: ",
                 (context, questions) => true,
                 (answer, context) =>
                 {

--- a/Design Documents/Crafting/Antiquity_Item_Component_Gap_Report.md
+++ b/Design Documents/Crafting/Antiquity_Item_Component_Gap_Report.md
@@ -104,15 +104,15 @@ Current gap: `Board` exists as a message-board component, but there is no antiqu
 | `antiquity_temple_decree_board` | a temple decree board | Use `Board`, `Destroyable_WoodenHeavy`, and restricted post permissions for priests or officials. |
 | `antiquity_barracks_roster_board` | a barracks roster board | Use `Board` or `InscribableSurface`; `Board` is best if postings need persistence and access rules. |
 
-## Missing Seeded Component Prototypes Within Existing Component Types
+## Seeded Component Prototypes Within Existing Component Types
 
-These gaps do not require brand-new engine functionality. They need new component prototypes, seeded by `UsefulSeeder` or by the antiquity package before items reference them. The item additions listed here become cleaner and less misleading once these prototypes exist.
+These gaps did not require brand-new engine functionality. They are now seeded by `UsefulSeeder.ItemComponents.cs` as stock component prototypes so antiquity items can reference setting-appropriate variants instead of borrowing misleading generic or modern examples.
 
 ### Antiquity TimePiece Variants
 
-Missing: setting-specific `TimePiece` component prototypes with antiquity display strings and settable/non-settable behaviour.
+Seeder status: setting-specific `TimePiece` component prototypes with antiquity display strings and settable/non-settable behaviour are now present.
 
-Needed prototypes:
+Seeded prototypes:
 
 - `TimePiece_Antiquity_Sundial`: non-settable, crude daylight-style display string.
 - `TimePiece_Antiquity_WaterClock`: non-settable or priest/setter-only, suited to temple/court clocks.
@@ -129,9 +129,9 @@ Items enabled or improved:
 
 ### Antiquity WaterSource Variants
 
-Missing: fixed ancient water-source component prototypes with names, capacities, switches, and liquid defaults that do not read like modern sinks, bottles, or bathtubs.
+Seeder status: fixed ancient water-source component prototypes with names, capacities, switches, and liquid defaults that do not read like modern sinks, bottles, or bathtubs are now present.
 
-Needed prototypes:
+Seeded prototypes:
 
 - `WaterSource_Antiquity_PublicWell`: infinite or large-capacity potable water source.
 - `WaterSource_Antiquity_Cistern`: potable or brackish stored source, optionally switchable/lockable for city control.
@@ -151,9 +151,9 @@ Items enabled or improved:
 
 ### Antiquity ShopStall and MarketGoodWeight Variants
 
-Missing: seeded stock component prototypes for market stalls and market-good weights that game owners can attach without hand-authoring each example.
+Seeder status: seeded stock component prototypes for market stalls and market-good weights are now present for game owners to attach without hand-authoring each example.
 
-Needed prototypes:
+Seeded prototypes:
 
 - `ShopStall_Antiquity_OpenCounter`: open stall surface with generous weight capacity and no transparent-container weirdness.
 - `ShopStall_Antiquity_LockableCounter`: lockable market counter for unattended goods.
@@ -173,9 +173,9 @@ Items enabled or improved:
 
 ### Custom Dice and Casting Components
 
-Missing: antiquity-specific dice prototypes with non-modern face labels and loaded/fair variants.
+Seeder status: antiquity-specific dice prototypes with non-modern face labels and loaded/fair variants are now present.
 
-Needed prototypes:
+Seeded prototypes:
 
 - `Dice_Antiquity_Knucklebones`: four named faces or weighted values suitable for astragaloi.
 - `Dice_Antiquity_CastingSticks`: marked/unmarked stick faces.
@@ -192,9 +192,9 @@ Items enabled or improved:
 
 ### DragAid Tuning Variants
 
-Missing: setting-specific drag-aid components with tuned user limits and effort multipliers for medical, funerary, pastoral, and cargo contexts.
+Seeder status: setting-specific drag-aid components with tuned user limits and effort multipliers for medical, funerary, pastoral, and cargo contexts are now present.
 
-Needed prototypes:
+Seeded prototypes:
 
 - `DragAid_Antiquity_FieldStretcher`: two to four users, high wounded-person movement multiplier.
 - `DragAid_Antiquity_CorpseBier`: two to six users, funerary/corpse-focused naming.
@@ -212,9 +212,9 @@ Items enabled or improved:
 
 ### Antiquity Locksmithing Variants
 
-Missing: tuned antiquity locksmithing tool components, especially low-tech, breakable, or installation/fabrication-specialised versions.
+Seeder status: tuned antiquity locksmithing tool components, especially low-tech, breakable, or installation/fabrication-specialised versions, are now present.
 
-Needed prototypes:
+Seeded prototypes:
 
 - `Locksmithing_Antiquity_BronzePoor`: breakable, penalty-bearing improvised pick set.
 - `Locksmithing_Antiquity_BronzeStandard`: standard lockpick and probe roll.
@@ -401,7 +401,7 @@ Items enabled:
 ## Suggested Implementation Order
 
 1. Add data-only items that use existing components cleanly: dice, lockpicks, drag aids, notice boards, and a first water-source set.
-2. Add antiquity-specific component prototypes for `TimePiece`, `WaterSource`, `DragAid`, `Dice`, `Locksmithing Tool`, `ShopStall`, and `MarketGoodWeight`.
+2. Completed in `UsefulSeeder`: antiquity-specific component prototypes for `TimePiece`, `WaterSource`, `DragAid`, `Dice`, `Locksmithing Tool`, `ShopStall`, and `MarketGoodWeight`.
 3. Add matching item prototypes that use those new component prototypes and update this document with the shipped names.
 4. Choose one new runtime component family for a first deeper gameplay pass. `Instrument` is the best first candidate because it is socially important, highly visible in roleplay, and relatively self-contained.
 5. Treat `SealStamp`/`Sealable`, `MeasuringInstrument`, and `OfferingReceiver` as the next most setting-defining component families because they support administration, trade, religion, law, and trust.

--- a/Design Documents/Crafting/Antiquity_Item_Component_Gap_Report.md
+++ b/Design Documents/Crafting/Antiquity_Item_Component_Gap_Report.md
@@ -230,6 +230,78 @@ Items enabled or improved:
 - `antiquity_lock_installation_kit`
 - `antiquity_key_filing_kit`
 
+## Implemented New Component Families
+
+These gaps originally needed new runtime component families. They are now first-class component types with seeded examples in `UsefulSeeder.ItemComponents.cs`.
+
+### SealStamp and Sealable Components
+
+Runtime status: `SealStamp` and `Sealable` are implemented as separate component families. A stamp carries the authoritative design metadata, while `Sealable` is an attachable tamper-evidence component that can coexist with containers, writeable surfaces, openables, scrolls, envelopes, jars, or bundles.
+
+Implemented behaviour:
+
+- `seal <target> with <stamp> [using <medium>]` records the seal design, issuer, owner/clan/office metadata, stamp material, medium descriptor, sealing actor, and sealing time.
+- `break seal <target>`, opening, reading, writing, drawing, or retitling a sealed item break the seal and leave configured residue evidence while allowing the access action to continue.
+- `inspect seal <target>` and `compare seal <sealed item> with <stamp|sealed item>` use the existing appraisal-style inspection path rather than a new check type.
+- Item FutureProg dot references expose whether an item is sealable, sealed, broken, or residue-marked, plus seal design, issuer, owner, clan, office, material, medium, and sealing actor metadata.
+
+Seeded prototypes:
+
+- `SealStamp_Antiquity_BronzeSignet`: bronze signet or ring seal for household, office, or personal authority.
+- `SealStamp_Antiquity_CylinderSeal`: cylinder seal for clay impressions and administrative records.
+- `Sealable_Document_Wax`: wax-sealable document surface.
+- `Sealable_Document_Clay`: clay-sealable document or tablet surface.
+- `Sealable_Envelope`: envelope seal support.
+- `Sealable_Scroll`: scroll seal support.
+- `Sealable_Container_Wax`: wax-sealed container, jar, chest, or package support.
+
+Items enabled or improved:
+
+- `antiquity_bronze_signet_ring`
+- `antiquity_cylinder_seal`
+- `antiquity_clay_bulla`
+- `antiquity_wax_seal_cake`
+- `antiquity_sealed_papyrus_scroll`
+- `antiquity_sealed_clay_tablet`
+- `antiquity_tax_office_seal_box`
+- `antiquity_merchant_contract_bundle`
+- `antiquity_grain_amphora_seal`
+- `Envelope` as a holdable, closable container, writeable surface, and sealable item.
+- `Scroll` as a holdable, writeable, and sealable item.
+
+### MeasuringInstrument Component
+
+Runtime status: `MeasuringInstrument` is implemented for `Weight` and `FluidVolume` modes. Length, cubit, and surveying rod measurement remains deferred until item dimensions exist, so those objects should remain props for now.
+
+Implemented behaviour:
+
+- `weigh <item> on <instrument>` measures item weight with instrument precision, capacity, stable drift, and calibration bias.
+- `measure <target> with <instrument>` measures supported fluid-volume targets with the same drift and calibration model.
+- `calibrate <instrument>` clears deliberate bias and resets drift state.
+- `calibrate <instrument> wrong <+/-amount|+/-percent>` deliberately records a bad calibration for false measures.
+- `inspect calibration <instrument>` uses existing appraisal-style inspection and reports mode, precision, drift, use count, and deliberate bias according to the viewer's appraisal outcome.
+- Item quality scales calibration drift per use, with better-quality instruments drifting less.
+
+Seeded prototypes:
+
+- `MeasuringInstrument_Antiquity_BalanceScale`: weight-mode balance scale.
+- `MeasuringInstrument_Antiquity_StandardWeights`: weight-mode official or merchant weight set.
+- `MeasuringInstrument_Antiquity_FalseWeights`: weight-mode biased weight set for dishonest trade.
+- `MeasuringInstrument_Antiquity_GrainMeasure`: weight-mode grain measure.
+- `MeasuringInstrument_Antiquity_OilCup`: fluid-volume oil measure.
+- `MeasuringInstrument_Antiquity_WineCup`: fluid-volume wine measure.
+- `MeasuringInstrument_Antiquity_TaxAssessorKit`: weight-mode official inspection kit.
+
+Items enabled or improved:
+
+- `antiquity_bronze_balance_scale`
+- `antiquity_standard_weight_set`
+- `antiquity_false_weight_set`
+- `antiquity_stone_grain_measure`
+- `antiquity_oil_measure_cup`
+- `antiquity_wine_measure_cup`
+- `antiquity_tax_assessor_measure_kit`
+
 ## Missing Engine Functionality That Could Become New Component Types
 
 These gaps are not merely missing stock data. They describe gameplay that does not appear to be represented by a suitable current item component type, or where existing components would only produce a static prop.
@@ -262,63 +334,6 @@ Items enabled:
 - `antiquity_bronze_war_horn`
 - `antiquity_ship_signal_trumpet`
 - `antiquity_temple_ritual_rattle`
-
-### SealStamp and SealedDocument Components
-
-Missing functionality:
-
-- authenticating documents, containers, orders, and tablets with a seal.
-- preserving identity of the seal owner, clan, office, or issuer.
-- visible seal impressions that can be inspected, forged, broken, or compared.
-- tamper evidence for scrolls, tablets, storage jars, chests, doors, and official packages.
-
-Rough component guidance:
-
-- Component type names: `SealStamp` and `Sealable`.
-- `SealStamp` settings: seal design text, owner/clan/office metadata, material, forgery difficulty, optional authority prog.
-- `Sealable` settings: allowed seal media, current seal state, whether opening breaks the seal, inspection difficulty, whether a broken seal leaves residue.
-- Runtime commands: `seal <target> with <stamp> [using <wax/clay>]`, `break seal <target>`, `inspect seal <target>`, possibly `compare seal`.
-- FutureProg hooks should be able to read issuer, broken/unbroken state, and design metadata.
-
-Items enabled:
-
-- `antiquity_bronze_signet_ring`
-- `antiquity_cylinder_seal`
-- `antiquity_clay_bulla`
-- `antiquity_wax_seal_cake`
-- `antiquity_sealed_papyrus_scroll`
-- `antiquity_sealed_clay_tablet`
-- `antiquity_tax_office_seal_box`
-- `antiquity_merchant_contract_bundle`
-- `antiquity_grain_amphora_seal`
-
-### Scale and Measuring Instrument Component
-
-Missing functionality:
-
-- weighing loose commodities and ordinary items.
-- measuring volume or length with a physical in-world tool.
-- producing trusted or falsifiable measures for trade, taxation, and legal disputes.
-- modelling honest and dishonest weights or calibration errors.
-
-Rough component guidance:
-
-- Component type name: `MeasuringInstrument`, with optional subtypes or modes for weight, volume, and length.
-- Prototype settings: measurement mode, precision, capacity, units displayed, calibration error, required counterweight/container, check difficulty to detect cheating.
-- Runtime commands: `weigh <item> on <scale>`, `measure <liquid/commodity/item> with <instrument>`, `calibrate <instrument>`, `inspect calibration`.
-- Market and economy code should be able to use measured quantity where appropriate, but the first pass can simply report measures to players.
-
-Items enabled:
-
-- `antiquity_bronze_balance_scale`
-- `antiquity_standard_weight_set`
-- `antiquity_false_weight_set`
-- `antiquity_stone_grain_measure`
-- `antiquity_oil_measure_cup`
-- `antiquity_wine_measure_cup`
-- `antiquity_surveying_rod`
-- `antiquity_cubit_rod`
-- `antiquity_tax_assessor_measure_kit`
 
 ### GameSet Component
 
@@ -401,7 +416,7 @@ Items enabled:
 ## Suggested Implementation Order
 
 1. Add data-only items that use existing components cleanly: dice, lockpicks, drag aids, notice boards, and a first water-source set.
-2. Completed in `UsefulSeeder`: antiquity-specific component prototypes for `TimePiece`, `WaterSource`, `DragAid`, `Dice`, `Locksmithing Tool`, `ShopStall`, and `MarketGoodWeight`.
+2. Completed in `UsefulSeeder`: antiquity-specific component prototypes for `TimePiece`, `WaterSource`, `DragAid`, `Dice`, `Locksmithing Tool`, `ShopStall`, `MarketGoodWeight`, `SealStamp`, `Sealable`, and `MeasuringInstrument`.
 3. Add matching item prototypes that use those new component prototypes and update this document with the shipped names.
 4. Choose one new runtime component family for a first deeper gameplay pass. `Instrument` is the best first candidate because it is socially important, highly visible in roleplay, and relatively self-contained.
-5. Treat `SealStamp`/`Sealable`, `MeasuringInstrument`, and `OfferingReceiver` as the next most setting-defining component families because they support administration, trade, religion, law, and trust.
+5. Treat `OfferingReceiver` as the next most setting-defining component family. `SealStamp`/`Sealable` and the weight/fluid-volume portion of `MeasuringInstrument` are now implemented; length measurement remains a future item-dimension pass.

--- a/Design Documents/Crafting/Antiquity_Item_Component_Gap_Report.md
+++ b/Design Documents/Crafting/Antiquity_Item_Component_Gap_Report.md
@@ -19,9 +19,11 @@ The current antiquity item suite already has broad coverage for:
 
 These items can be added to the antiquity seeder without new runtime component types. Some use stock generic components exactly as seeded; others would be better if the component prototype names were later made more setting-specific, but they are still implementable today.
 
+Seeder status: the item prototypes listed in this section are now seeded by `ItemSeeder.Rework.AntiquityComponentGaps.cs`. Items whose richer behaviour depends on still-deferred systems, such as physical length measurement or rules-aware board games, are seeded as ordinary props.
+
 ### Timekeeping Items
 
-Current gap: `TimePiece` exists in the stock component catalogue, but antiquity does not currently have visible sundials, water clocks, watch clocks, or temple timekeepers.
+Original gap: `TimePiece` exists in the stock component catalogue, but antiquity did not have visible sundials, water clocks, watch clocks, or temple timekeepers.
 
 | Unique Name | Short Description | Build Pointers |
 | --- | --- | --- |
@@ -33,7 +35,7 @@ Current gap: `TimePiece` exists in the stock component catalogue, but antiquity 
 
 ### Public Water and Bathing Infrastructure
 
-Current gap: `WaterSource` exists in the generic stock set and the legacy item seeder has wells and cisterns, but the antiquity rework does not yet make public water infrastructure part of its own setting package.
+Original gap: `WaterSource` exists in the generic stock set and the legacy item seeder has wells and cisterns, but the antiquity rework did not make public water infrastructure part of its own setting package.
 
 | Unique Name | Short Description | Build Pointers |
 | --- | --- | --- |
@@ -46,7 +48,7 @@ Current gap: `WaterSource` exists in the generic stock set and the legacy item s
 
 ### Drag Aids, Litters, and Heavy-Carry Tools
 
-Current gap: `DragAid` exists in the general stock component package, while antiquity medical currently covers crutches and prosthetics but not group movement aids.
+Original gap: `DragAid` exists in the general stock component package, while antiquity medical covered crutches and prosthetics but not group movement aids.
 
 | Unique Name | Short Description | Build Pointers |
 | --- | --- | --- |
@@ -58,7 +60,7 @@ Current gap: `DragAid` exists in the general stock component package, while anti
 
 ### Games, Gambling, and Leisure
 
-Current gap: `Dice` components are seeded, including fair and custom-face dice support, but antiquity does not currently seed gambling or leisure objects as a visible social package.
+Original gap: `Dice` components are seeded, including fair and custom-face dice support, but antiquity did not seed gambling or leisure objects as a visible social package.
 
 | Unique Name | Short Description | Build Pointers |
 | --- | --- | --- |
@@ -71,7 +73,7 @@ Current gap: `Dice` components are seeded, including fair and custom-face dice s
 
 ### Markets, Stalls, Weights, and Measures
 
-Current gap: the runtime has `ShopStall` and `MarketGoodWeight`, but the antiquity package mostly models merchant furniture and containers rather than functional market instruments.
+Original gap: the runtime has `ShopStall` and `MarketGoodWeight`, but the antiquity package mostly modelled merchant furniture and containers rather than functional market instruments.
 
 | Unique Name | Short Description | Build Pointers |
 | --- | --- | --- |
@@ -84,7 +86,7 @@ Current gap: the runtime has `ShopStall` and `MarketGoodWeight`, but the antiqui
 
 ### Locksmithing and Security Tools
 
-Current gap: antiquity has locks, keys, latches, and keyrings, while generic stock already has `Locksmithing Tool` components. The setting can support a small security-tool package.
+Original gap: antiquity has locks, keys, latches, and keyrings, while generic stock already has `Locksmithing Tool` components. The setting can support a small security-tool package.
 
 | Unique Name | Short Description | Build Pointers |
 | --- | --- | --- |
@@ -96,7 +98,7 @@ Current gap: antiquity has locks, keys, latches, and keyrings, while generic sto
 
 ### Civic Notice and Administrative Boards
 
-Current gap: `Board` exists as a message-board component, but there is no antiquity-specific public posting surface.
+Original gap: `Board` exists as a message-board component, but there was no antiquity-specific public posting surface. The seeded board items are currently writable/inscribable props rather than live message-board bindings because board-backed component prototypes need world-specific board records and permissions.
 
 | Unique Name | Short Description | Build Pointers |
 | --- | --- | --- |
@@ -107,6 +109,8 @@ Current gap: `Board` exists as a message-board component, but there is no antiqu
 ## Seeded Component Prototypes Within Existing Component Types
 
 These gaps did not require brand-new engine functionality. They are now seeded by `UsefulSeeder.ItemComponents.cs` as stock component prototypes so antiquity items can reference setting-appropriate variants instead of borrowing misleading generic or modern examples.
+
+ItemSeeder status: the item prototypes named in the "Items enabled or improved" lists below are now seeded by `ItemSeeder.Rework.AntiquityComponentGaps.cs`.
 
 ### Antiquity TimePiece Variants
 
@@ -233,6 +237,8 @@ Items enabled or improved:
 ## Implemented New Component Families
 
 These gaps originally needed new runtime component families. They are now first-class component types with seeded examples in `UsefulSeeder.ItemComponents.cs`.
+
+ItemSeeder status: the `SealStamp`, `Sealable`, and `MeasuringInstrument` item examples listed below are now seeded by `ItemSeeder.Rework.AntiquityComponentGaps.cs`. Length/cubit/survey rod examples remain prop-only until item dimensions exist.
 
 ### SealStamp and Sealable Components
 

--- a/Design Documents/Items/Item_System_Component_Authoring.md
+++ b/Design Documents/Items/Item_System_Component_Authoring.md
@@ -141,6 +141,14 @@ Use `InscribableSurface` for wax, clay, wood, ostraca, or other non-paper surfac
 
 `IRangedWeapon.CanFireWhileHidden` is deliberately narrow. Leave the default false for normal ranged weapons. Only components that should preserve hiding through `fire -> Engage/JoinCombat`, such as `BlowgunGameItemComponent`, should return true and use obscured output for ready/load/fire emotes.
 
+### Seal and measuring components
+
+Use `SealStamp` for signets, cylinder seals, office stamps, or similar authority-bearing tools. The prototype stores the design text, issuer, owner/clan/office metadata, material text, forgery difficulty, and optional authority prog. The matching runtime component is stateless; it exposes the stamped metadata through `ISealStamp`.
+
+Use `Sealable` as a separate attachable component rather than folding seal state into containers, books, scrolls, or writing surfaces. This lets the same tamper-evidence behaviour compose with `IContainer`, `IWriteable`, `IReadable`, openable items, and other ordinary item capabilities. The prototype stores allowed media, inspection difficulty, and broken-residue behaviour. The live component stores the active seal snapshot, sealing actor/time evidence where available, medium descriptor, broken state, and residue state.
+
+Use `MeasuringInstrument` for physical measurement tools that should produce falsifiable reported quantities. The current implementation supports `Weight` and `FluidVolume` modes. Length, cubit, and surveying tools should remain prop-only until item dimensions exist. The prototype stores mode, precision, capacity, base drift per use, display unit text, and wrong-calibration limits. The live component stores stable drift direction, use count since calibration, calibration state, and any deliberate base-unit or percentage bias.
+
 ### Readable book components
 Books remain one component family rather than splitting blank books and published books into separate component types. `BookGameItemComponentProto` owns reusable authored defaults, while `BookGameItemComponent` owns live page state, torn pages, current page, title, and the actual readable rows attached to each loaded item.
 

--- a/Design Documents/Items/Item_System_Presentation_and_Integration.md
+++ b/Design Documents/Items/Item_System_Presentation_and_Integration.md
@@ -174,6 +174,10 @@ Readable book items expose a small scripting surface for dynamic document genera
 
 Printed writing has nullable authorship. Player-facing and admin displays should treat missing author as printed or anonymous provenance rather than assuming every writing row belongs to a character.
 
+Seals and measuring tools add a small player-facing command surface. `seal <target> with <stamp> [using <medium>]`, `break seal <target>`, `inspect seal <target>`, and `compare seal <sealed item> with <stamp|sealed item>` operate on `ISealStamp` and `ISealable`; ordinary read, write, draw, retitle, and open interactions break an intact seal before continuing. `weigh <item> on <instrument>`, `measure <target> with <instrument>`, `calibrate <instrument>`, `calibrate <instrument> wrong <+/-amount|+/-percent>`, and `inspect calibration <instrument>` operate on `IMeasuringInstrument`.
+
+Seal and calibration inspection uses existing appraisal-style skill evaluation rather than new check types. FutureProg item dots expose seal capability and state (`issealstamp`, `issealable`, `issealed`, `sealbroken`, `sealresidue`), seal metadata (`sealdesign`, `sealissuer`, `sealowner`, `sealclan`, `sealoffice`, `sealmaterial`, `sealmedium`, `sealingcharacterid`), and measurement state (`ismeasuringinstrument`, `measuringmode`, `calibrationbias`, `calibrationbiasispercent`, `calibrationdeliberate`, `usessincecalibration`).
+
 Telephone presentation is not only textual state. For room-facing telephones and cellular phones, ringing is an audible output with an effective ring volume. Players adjust that through the ordinary `switch` command rather than a staff-only builder path: wired phones expose `quiet`, `normal`, and `loud`, while cellular phones also expose `silent`. Nearby rooms may hear ringing through ordinary audio-echo rules, but a silent cellular phone can still vibrate for the wearer if it is sitting inside a worn container. Implant telephones do not emit room audio and instead report ringing and connection progress through implant messaging.
 
 The current signal-automation slice has its own presentation and integration rules:

--- a/Design Documents/Items/Item_System_Runtime_Model.md
+++ b/Design Documents/Items/Item_System_Runtime_Model.md
@@ -147,6 +147,10 @@ This distinction is important for persistence. A prototype-authored book page is
 
 Ancient and non-paper writing surfaces use the same readable/writeable runtime contract. `ScribingImplement` is a configurable `IWritingImplement` for reed pens, quills, brushes, charcoal sticks, styluses, and similar tools. `InscribableSurface` is a writable/readable component for wax, clay, wood, and ostraca; it stores readable ids in component XML, enforces a configured capacity, and only accepts the configured writing implement types. Non-consuming tools such as styluses use a total-use value of `0`, while ink or charcoal implements can consume use as writing is added.
 
+Seals and measuring tools follow the same interface-first composition model. A `SealStamp` item implements `ISealStamp` and exposes design, issuer, owner, office/clan, material, forgery difficulty, and authority-prog metadata. A `Sealable` item implements `ISealable` separately from any container or writing component; it stores the active seal snapshot in live XML so a sealed envelope, scroll, tablet, jar, or chest can retain tamper evidence without duplicating state in each of those component families. Opening, reading, writing, drawing, or retitling a sealed item breaks the seal and then continues the requested action.
+
+`MeasuringInstrument` implements `IMeasuringInstrument` for physical weight and fluid-volume tools. The live component stores use-based calibration drift, stable drift direction, quality-scaled drift accumulation, honest calibration state, and optional deliberate wrong-calibration bias. Length measurement is intentionally deferred until item dimensions exist, so rod-like tools should not be authored as functional measuring instruments yet.
+
 ### Computers and signal automation pattern
 The planned computer-programs subsystem follows the same composition rules:
 - shared contracts live in `FutureMUDLibrary/Computers`

--- a/FutureMUDLibrary/GameItems/Interfaces/IMeasuringInstrument.cs
+++ b/FutureMUDLibrary/GameItems/Interfaces/IMeasuringInstrument.cs
@@ -1,0 +1,38 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Framework.Units;
+
+namespace MudSharp.GameItems.Interfaces;
+
+public enum MeasuringInstrumentMode
+{
+	Weight = 0,
+	FluidVolume = 1
+}
+
+public sealed record MeasurementResult(
+	MeasuringInstrumentMode Mode,
+	UnitType UnitType,
+	double TrueValue,
+	double ReportedValue,
+	double Drift,
+	double CalibrationBias,
+	int UsesSinceCalibration);
+
+public interface IMeasuringInstrument : IGameItemComponent
+{
+	MeasuringInstrumentMode Mode { get; }
+	UnitType UnitType { get; }
+	double Precision { get; }
+	double Capacity { get; }
+	double CalibrationBias { get; }
+	bool CalibrationBiasIsPercentage { get; }
+	bool HasDeliberateBias { get; }
+	int UsesSinceCalibration { get; }
+	bool CanMeasure(IGameItem target, out string error);
+	MeasurementResult Measure(ICharacter actor, IGameItem target);
+	void Calibrate(ICharacter actor);
+	bool CalibrateWrong(ICharacter actor, double bias, bool percentageBias, out string error);
+	string InspectCalibration(ICharacter actor);
+}

--- a/FutureMUDLibrary/GameItems/Interfaces/ISealStamp.cs
+++ b/FutureMUDLibrary/GameItems/Interfaces/ISealStamp.cs
@@ -1,0 +1,33 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.RPG.Checks;
+using System;
+
+namespace MudSharp.GameItems.Interfaces;
+
+public sealed record SealImpression(
+	string SealDesign,
+	string IssuerText,
+	string OwnerText,
+	string ClanText,
+	string OfficeText,
+	string StampMaterial,
+	Difficulty ForgeryDifficulty,
+	long SealingCharacterId,
+	string SealingCharacterName,
+	DateTime SealedAt,
+	string SealMedium);
+
+public interface ISealStamp : IGameItemComponent
+{
+	string SealDesign { get; }
+	string IssuerText { get; }
+	string OwnerText { get; }
+	string ClanText { get; }
+	string OfficeText { get; }
+	string StampMaterial { get; }
+	Difficulty ForgeryDifficulty { get; }
+	bool CanSeal(ICharacter actor, IGameItem target, IGameItem? medium, out string error);
+	SealImpression CreateImpression(ICharacter actor, IGameItem target, IGameItem? medium);
+}

--- a/FutureMUDLibrary/GameItems/Interfaces/ISealable.cs
+++ b/FutureMUDLibrary/GameItems/Interfaces/ISealable.cs
@@ -1,0 +1,21 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.RPG.Checks;
+
+namespace MudSharp.GameItems.Interfaces;
+
+public interface ISealable : IGameItemComponent
+{
+	bool IsSealed { get; }
+	bool SealBroken { get; }
+	bool HasSealResidue { get; }
+	SealImpression? CurrentSeal { get; }
+	Difficulty InspectionDifficulty { get; }
+	bool CanSeal(ICharacter actor, ISealStamp stamp, IGameItem? medium, out string error);
+	void Seal(ICharacter actor, ISealStamp stamp, IGameItem? medium);
+	bool BreakSeal(ICharacter? actor, string reason);
+	string InspectSeal(ICharacter actor);
+	bool SealMatches(ISealStamp stamp);
+	bool SealMatches(ISealable sealable);
+}

--- a/FutureMUDLibrary/GameItems/Prototypes/GameItemComponentPrototypeInterfaces.cs
+++ b/FutureMUDLibrary/GameItems/Prototypes/GameItemComponentPrototypeInterfaces.cs
@@ -333,6 +333,10 @@ public interface IMarketGoodWeightItemPrototype : IExclusiveGameItemComponentPro
 {
 }
 
+public interface IMeasuringInstrumentPrototype : IExclusiveGameItemComponentPrototype<IMeasuringInstrument>
+{
+}
+
 public interface IMeleeWeaponPrototype : IExclusiveGameItemComponentPrototype<IMeleeWeapon>, IWieldablePrototype
 {
 }
@@ -434,6 +438,14 @@ public interface IRespondToSignalPrototype : IExclusiveGameItemComponentPrototyp
 }
 
 public interface IRestraintPrototype : IExclusiveGameItemComponentPrototype<IRestraint>
+{
+}
+
+public interface ISealStampPrototype : IExclusiveGameItemComponentPrototype<ISealStamp>
+{
+}
+
+public interface ISealablePrototype : IExclusiveGameItemComponentPrototype<ISealable>
 {
 }
 

--- a/MudSharpCore Unit Tests/SealAndMeasurementComponentTests.cs
+++ b/MudSharpCore Unit Tests/SealAndMeasurementComponentTests.cs
@@ -1,0 +1,323 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Accounts;
+using MudSharp.Character;
+using MudSharp.Commands.Modules;
+using MudSharp.Form.Material;
+using MudSharp.Form.Shape;
+using MudSharp.Framework;
+using MudSharp.Framework.Revision;
+using MudSharp.Framework.Save;
+using MudSharp.Framework.Units;
+using MudSharp.FutureProg;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Components;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.GameItems.Prototypes;
+using MudSharp.PerceptionEngine;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Xml.Linq;
+using DbEditableItem = MudSharp.Models.EditableItem;
+using DbGameItemComponent = MudSharp.Models.GameItemComponent;
+using DbGameItemComponentProto = MudSharp.Models.GameItemComponentProto;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class SealAndMeasurementComponentTests
+{
+	[TestMethod]
+	public void GameItemComponentManager_RegistersSealAndMeasuringTypes()
+	{
+		var manager = new GameItemComponentManager();
+		var primaryTypes = manager.PrimaryTypes.ToList();
+		var helpTypes = manager.TypeHelpInfo.Select(x => x.Name).ToList();
+
+		CollectionAssert.Contains(primaryTypes, "sealstamp");
+		CollectionAssert.Contains(primaryTypes, "sealable");
+		CollectionAssert.Contains(primaryTypes, "measuringinstrument");
+		CollectionAssert.Contains(helpTypes, "SealStamp");
+		CollectionAssert.Contains(helpTypes, "Sealable");
+		CollectionAssert.Contains(helpTypes, "MeasuringInstrument");
+	}
+
+	[TestMethod]
+	public void ManipulationModule_ExposesSealAndMeasurementCommands()
+	{
+		var commands = typeof(ManipulationModule)
+		               .GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
+		               .Select(x => x.GetCustomAttribute<PlayerCommand>())
+		               .OfType<PlayerCommand>()
+		               .ToDictionary(x => x.Name, StringComparer.OrdinalIgnoreCase);
+
+		foreach (var name in new[] { "Seal", "Break", "Inspect", "Compare", "Weigh", "Measure", "Calibrate" })
+		{
+			Assert.IsTrue(commands.ContainsKey(name), $"Expected {name} command to be registered.");
+		}
+	}
+
+	[TestMethod]
+	public void Sealable_SealsBreaksSavesCopiesAndCompares()
+	{
+		var gameworld = CreateGameworld();
+		var targetParent = CreateParent(gameworld.Object, 10L, "sealed tablet");
+		var stampParent = CreateStampParent(gameworld.Object, 11L, "bronze");
+		var actor = CreateActor(gameworld.Object, 20L);
+		var stampProto = CreateSealStampProto(gameworld.Object, "a lion seal", "Temple", "bronze");
+		var sealableProto = CreateSealableProto(gameworld.Object);
+		var stamp = (SealStampGameItemComponent)stampProto.CreateNew(stampParent.Object, temporary: true);
+		var sealable = (SealableGameItemComponent)sealableProto.CreateNew(targetParent.Object, temporary: true);
+
+		Assert.IsTrue(sealable.CanSeal(actor.Object, stamp, null, out var error), error);
+
+		sealable.Seal(actor.Object, stamp, null);
+
+		Assert.IsTrue(sealable.IsSealed);
+		Assert.AreEqual("a lion seal", sealable.CurrentSeal?.SealDesign);
+		Assert.IsTrue(sealable.SealMatches(stamp));
+		StringAssert.Contains(sealable.InspectSeal(actor.Object), "a lion seal");
+
+		sealable.HandleEvent(MudSharp.Events.EventType.ItemOpened);
+
+		Assert.IsFalse(sealable.IsSealed);
+		Assert.IsTrue(sealable.SealBroken);
+		Assert.IsTrue(sealable.HasSealResidue);
+		StringAssert.Contains(InvokeSaveToXml(sealable), "<SealBroken>true</SealBroken>");
+
+		var copy = (SealableGameItemComponent)sealable.Copy(CreateParent(gameworld.Object, 12L, "copy").Object, true);
+		Assert.IsTrue(copy.SealBroken);
+		Assert.AreEqual("a lion seal", copy.CurrentSeal?.SealDesign);
+	}
+
+	[TestMethod]
+	public void MeasuringInstrument_DriftCalibrationAndWrongCalibrationPersist()
+	{
+		var gameworld = CreateGameworld();
+		var actor = CreateActor(gameworld.Object, 30L);
+		var proto = CreateMeasuringProto(gameworld.Object, "Weight", 0.001, 10000.0, 0.001);
+		var poor = (MeasuringInstrumentGameItemComponent)proto.CreateNew(
+			CreateParent(gameworld.Object, 20L, "poor scale", quality: ItemQuality.Terrible).Object, temporary: true);
+		var excellent = (MeasuringInstrumentGameItemComponent)proto.CreateNew(
+			CreateParent(gameworld.Object, 22L, "excellent scale", quality: ItemQuality.Legendary).Object, temporary: true);
+		var target = CreateParent(gameworld.Object, 40L, "weight", weight: 1000.0);
+
+		var poorResult = poor.Measure(actor.Object, target.Object);
+		var excellentResult = excellent.Measure(actor.Object, target.Object);
+
+		Assert.AreEqual(1, poor.UsesSinceCalibration);
+		Assert.IsTrue(Math.Abs(poorResult.Drift) > Math.Abs(excellentResult.Drift));
+
+		Assert.IsTrue(poor.CalibrateWrong(actor.Object, 0.10, true, out var error), error);
+		Assert.IsTrue(poor.HasDeliberateBias);
+		Assert.IsTrue(poor.CalibrationBiasIsPercentage);
+		Assert.AreEqual(0.10, poor.CalibrationBias, 0.000001);
+
+		var biasedResult = poor.Measure(actor.Object, target.Object);
+		Assert.IsTrue(Math.Abs(biasedResult.CalibrationBias) > 0.0);
+		StringAssert.Contains(poor.InspectCalibration(actor.Object), "Deliberate Bias");
+
+		poor.Calibrate(actor.Object);
+
+		Assert.IsFalse(poor.HasDeliberateBias);
+		Assert.AreEqual(0, poor.UsesSinceCalibration);
+		StringAssert.Contains(InvokeSaveToXml(poor), "<HasDeliberateBias>false</HasDeliberateBias>");
+	}
+
+	[TestMethod]
+	public void MeasuringInstrument_LoadsSavesAndCopiesCalibrationState()
+	{
+		var gameworld = CreateGameworld();
+		var proto = CreateMeasuringProto(gameworld.Object, "FluidVolume", 0.01, 2.0, 0.0005);
+		var component = (MeasuringInstrumentGameItemComponent)proto.LoadComponent(
+			new DbGameItemComponent
+			{
+				Definition = new XElement("Definition",
+					new XElement("CalibrationBias", -0.05),
+					new XElement("CalibrationBiasIsPercentage", true),
+					new XElement("HasDeliberateBias", true),
+					new XElement("UsesSinceCalibration", 7),
+					new XElement("DriftDirection", -1)).ToString()
+			},
+			CreateParent(gameworld.Object, 50L, "cup").Object);
+
+		Assert.AreEqual(MeasuringInstrumentMode.FluidVolume, component.Mode);
+		Assert.AreEqual(-0.05, component.CalibrationBias, 0.000001);
+		Assert.IsTrue(component.CalibrationBiasIsPercentage);
+		Assert.IsTrue(component.HasDeliberateBias);
+		Assert.AreEqual(7, component.UsesSinceCalibration);
+
+		var copy = (MeasuringInstrumentGameItemComponent)component.Copy(
+			CreateParent(gameworld.Object, 51L, "copy").Object, true);
+
+		Assert.AreEqual(component.CalibrationBias, copy.CalibrationBias, 0.000001);
+		Assert.AreEqual(component.UsesSinceCalibration, copy.UsesSinceCalibration);
+		StringAssert.Contains(InvokeSaveToXml(component), "<UsesSinceCalibration>7</UsesSinceCalibration>");
+	}
+
+	private static SealStampGameItemComponentProto CreateSealStampProto(IFuturemud gameworld, string design,
+		string issuer, string material)
+	{
+		return (SealStampGameItemComponentProto)Activator.CreateInstance(
+			typeof(SealStampGameItemComponentProto),
+			BindingFlags.Instance | BindingFlags.NonPublic,
+			null,
+			new object[]
+			{
+				ComponentProtoModel(100, "SealStamp", new XElement("Definition",
+					new XElement("SealDesign", new XCData(design)),
+					new XElement("IssuerText", new XCData(issuer)),
+					new XElement("OwnerText", new XCData(string.Empty)),
+					new XElement("ClanText", new XCData(string.Empty)),
+					new XElement("OfficeText", new XCData("scribe")),
+					new XElement("StampMaterial", new XCData(material)),
+					new XElement("ForgeryDifficulty", (int)Difficulty.Hard),
+					new XElement("AuthorityProg", 0)).ToString()),
+				gameworld
+			},
+			CultureInfo.InvariantCulture)!;
+	}
+
+	private static SealableGameItemComponentProto CreateSealableProto(IFuturemud gameworld)
+	{
+		return (SealableGameItemComponentProto)Activator.CreateInstance(
+			typeof(SealableGameItemComponentProto),
+			BindingFlags.Instance | BindingFlags.NonPublic,
+			null,
+			new object[]
+			{
+				ComponentProtoModel(101, "Sealable", new XElement("Definition",
+					new XElement("AllowedMedia", new XElement("Medium", new XCData("wax"))),
+					new XElement("InspectionDifficulty", (int)Difficulty.Normal),
+					new XElement("BrokenSealLeavesResidue", true)).ToString()),
+				gameworld
+			},
+			CultureInfo.InvariantCulture)!;
+	}
+
+	private static MeasuringInstrumentGameItemComponentProto CreateMeasuringProto(IFuturemud gameworld, string mode,
+		double precision, double capacity, double baseDrift)
+	{
+		return (MeasuringInstrumentGameItemComponentProto)Activator.CreateInstance(
+			typeof(MeasuringInstrumentGameItemComponentProto),
+			BindingFlags.Instance | BindingFlags.NonPublic,
+			null,
+			new object[]
+			{
+				ComponentProtoModel(102, "MeasuringInstrument", new XElement("Definition",
+					new XElement("Mode", mode),
+					new XElement("Precision", precision),
+					new XElement("Capacity", capacity),
+					new XElement("BaseDriftPerUse", baseDrift),
+					new XElement("MaximumDrift", 0.10),
+					new XElement("MaximumWrongCalibration", 0.50),
+					new XElement("CalibrationInspectionDifficulty", (int)Difficulty.Normal)).ToString()),
+				gameworld
+			},
+			CultureInfo.InvariantCulture)!;
+	}
+
+	private static DbGameItemComponentProto ComponentProtoModel(long id, string type, string definition)
+	{
+		return new DbGameItemComponentProto
+		{
+			Id = id,
+			Type = type,
+			Name = type,
+			Description = $"{type} component",
+			Definition = definition,
+			RevisionNumber = 1,
+			EditableItem = new DbEditableItem
+			{
+				Id = id,
+				BuilderAccountId = 1,
+				BuilderDate = DateTime.UtcNow,
+				RevisionNumber = 1,
+				RevisionStatus = (int)RevisionStatus.Current
+			}
+		};
+	}
+
+	private static string InvokeSaveToXml(GameItemComponent component)
+	{
+		return (string)component.GetType()
+		                .GetMethod("SaveToXml", BindingFlags.Instance | BindingFlags.NonPublic)!
+		                .Invoke(component, Array.Empty<object>())!;
+	}
+
+	private static Mock<IGameItem> CreateParent(IFuturemud gameworld, long id, string seen, double weight = 0.0,
+		ItemQuality quality = ItemQuality.Standard)
+	{
+		var proto = new Mock<IGameItemProto>();
+		proto.SetupGet(x => x.Id).Returns(id + 1000);
+		var parent = new Mock<IGameItem>();
+		parent.SetupGet(x => x.Id).Returns(id);
+		parent.SetupGet(x => x.Gameworld).Returns(gameworld);
+		parent.SetupGet(x => x.Prototype).Returns(proto.Object);
+		parent.SetupGet(x => x.Quality).Returns(quality);
+		parent.SetupGet(x => x.Weight).Returns(weight);
+		parent.Setup(x => x.GetItemType<ILiquidContainer>()).Returns((ILiquidContainer)null!);
+		parent.Setup(x => x.HowSeen(It.IsAny<IPerceiver>(), It.IsAny<bool>(), It.IsAny<DescriptionType>(),
+				It.IsAny<bool>(), It.IsAny<PerceiveIgnoreFlags>()))
+		      .Returns(seen);
+		return parent;
+	}
+
+	private static Mock<IGameItem> CreateStampParent(IFuturemud gameworld, long id, string materialName)
+	{
+		var solid = new Mock<ISolid>();
+		solid.SetupGet(x => x.Name).Returns(materialName);
+		var parent = CreateParent(gameworld, id, "stamp");
+		parent.SetupGet(x => x.Material).Returns(solid.Object);
+		return parent;
+	}
+
+	private static Mock<ICharacter> CreateActor(IFuturemud gameworld, long id)
+	{
+		var actor = new Mock<ICharacter>();
+		actor.SetupGet(x => x.Id).Returns(id);
+		actor.SetupGet(x => x.Gameworld).Returns(gameworld);
+		actor.Setup(x => x.IsAdministrator(It.IsAny<PermissionLevel>())).Returns(true);
+		actor.Setup(x => x.HowSeen(It.IsAny<IPerceiver>(), It.IsAny<bool>(), It.IsAny<DescriptionType>(),
+				It.IsAny<bool>(), It.IsAny<PerceiveIgnoreFlags>()))
+		     .Returns("Tester");
+		return actor;
+	}
+
+	private static Mock<IFuturemud> CreateGameworld()
+	{
+		var saveManager = new Mock<ISaveManager>();
+		var unitManager = new Mock<IUnitManager>();
+		unitManager.Setup(x => x.DescribeExact(It.IsAny<double>(), It.IsAny<UnitType>(), It.IsAny<IPerceiver>()))
+		           .Returns<double, UnitType, IPerceiver>((value, type, _) => $"{value:N3} {type}");
+		unitManager.Setup(x => x.DescribeExact(It.IsAny<double>(), It.IsAny<UnitType>(), It.IsAny<string>(),
+				It.IsAny<IFormatProvider>()))
+		           .Returns<double, UnitType, string, IFormatProvider>((value, type, _, _) => $"{value:N3} {type}");
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.SaveManager).Returns(saveManager.Object);
+		gameworld.SetupGet(x => x.UnitManager).Returns(unitManager.Object);
+		gameworld.SetupGet(x => x.FutureProgs).Returns(Repository<IFutureProg>());
+		return gameworld;
+	}
+
+	private static IUneditableAll<T> Repository<T>(params T[] items) where T : class, IFrameworkItem
+	{
+		var repository = new Mock<IUneditableAll<T>>();
+		repository.Setup(x => x.Get(It.IsAny<long>()))
+		          .Returns<long>(id => items.FirstOrDefault(x => x.Id == id));
+		repository.Setup(x => x.GetByName(It.IsAny<string>()))
+		          .Returns<string>(name => items.FirstOrDefault(x => x.Name.EqualTo(name)));
+		repository.Setup(x => x.Get(It.IsAny<string>()))
+		          .Returns<string>(name => items.Where(x => x.Name.EqualTo(name)).ToList());
+		repository.Setup(x => x.GetEnumerator())
+		          .Returns(() => ((IEnumerable<T>)items).GetEnumerator());
+		repository.SetupGet(x => x.Count).Returns(items.Length);
+		return repository.Object;
+	}
+}

--- a/MudSharpCore/Commands/Modules/LiteracyModule.cs
+++ b/MudSharpCore/Commands/Modules/LiteracyModule.cs
@@ -27,6 +27,11 @@ public class LiteracyModule : Module<ICharacter>
 
     public static LiteracyModule Instance { get; } = new();
 
+	private static void BreakSealForAccess(ICharacter actor, GameItems.IGameItem target, string reason)
+	{
+		target.GetItemType<ISealable>()?.BreakSeal(actor, reason);
+	}
+
     [PlayerCommand("Scripts", "scripts")]
     [HelpInfo("Scripts", @"The #3scripts#0 command is used to show all of the scripts (systems of writing) that you know, and which one you are currently using when you write.
 
@@ -85,6 +90,8 @@ For graffiti, see the #3look#0 command instead.", AutoHelp.HelpArgOrNoArg)]
             actor.Send($"{target.HowSeen(actor, true)} must first be opened before it can be read.");
             return;
         }
+
+		BreakSealForAccess(actor, target, "read");
 
         StringBuilder sb = new();
         if (ss.IsFinished)
@@ -271,6 +278,7 @@ The syntax is as follows:
                     return;
                 }
 
+				BreakSealForAccess(actor, target, "written on");
                 targetAsWritable.Write(actor, implement, writing);
                 handler.Handle(new EmoteOutput(new Emote("@ write|writes on $0 with $1.", actor, target,
                     implement.Parent)));
@@ -391,6 +399,7 @@ Style: {actor.WritingStyle.Describe().ColourValue()}
 
             CompositeWriting graffiti = new(actor.Gameworld, actor, implement, text, sdesc);
             actor.Gameworld.Add(graffiti);
+			BreakSealForAccess(actor, target, "graffiti");
             target.AddEffect(new GraffitiEffect(actor, graffiti, RoomLayer.GroundLevel, string.Empty));
             handler.Handle(new EmoteOutput(new Emote("@ draw|draws graffiti on $0 with $1.", actor, target, implement.Parent)));
             handler.Send(new EmoteOutput(new Emote("You draw graffiti on $0 with $1.", actor, target, implement.Parent)));
@@ -577,6 +586,7 @@ To draw on locations or things that aren't normally meant for writing and drawin
                 return;
             }
 
+			BreakSealForAccess(actor, target, "drawn on");
             targetAsWritable.Draw(actor, implement, drawing);
             handler.Handle(new EmoteOutput(new Emote("@ draw|draws on $0 with $1.", actor, target, implement.Parent)));
         }, (handler, pars) => { handler.Send("You decide not to draw anything."); }, 1.0);
@@ -636,6 +646,7 @@ The syntax is #3title <item> <title>#0.", AutoHelp.HelpArgOrNoArg)]
             return;
         }
 
+		BreakSealForAccess(actor, target, "retitled");
         string oldTitle = targetAsWritable.Title ?? string.Empty;
         targetAsWritable.GiveTitle(actor, ss.SafeRemainingArgument);
         if (oldTitle.Equals(string.Empty))

--- a/MudSharpCore/Commands/Modules/ManipulationModule.cs
+++ b/MudSharpCore/Commands/Modules/ManipulationModule.cs
@@ -232,6 +232,536 @@ internal class ManipulationModule : Module<ICharacter>
 		return success && amount > 0.0;
 	}
 
+	private static string DescribeMeasurement(ICharacter actor, MeasurementResult result)
+	{
+		return actor.Gameworld.UnitManager.DescribeExact(result.ReportedValue, result.UnitType, actor).ColourValue();
+	}
+
+	private static bool TryParseCalibrationBias(ICharacter actor, IMeasuringInstrument instrument, string text,
+		out double bias, out bool percentageBias)
+	{
+		if (text.Contains('%') || text.EndsWith("percent", StringComparison.InvariantCultureIgnoreCase) ||
+		    text.EndsWith("percentage", StringComparison.InvariantCultureIgnoreCase))
+		{
+			percentageBias = true;
+			return text.TryParsePercentage(actor.Account.Culture, out bias);
+		}
+
+		percentageBias = false;
+		if (actor.Gameworld.UnitManager.TryGetBaseUnits(text, instrument.UnitType, actor, out bias))
+		{
+			return true;
+		}
+
+		return double.TryParse(text, actor, out bias);
+	}
+
+	[PlayerCommand("Seal", "seal")]
+	[RequiredCharacterState(CharacterState.Able)]
+	[DelayBlock("general", "You must first stop {0} before you can do that.")]
+	[NoCombatCommand]
+	[NoMovementCommand]
+	[HelpInfo("seal",
+		@"The #3seal#0 command is used to apply a seal stamp to an item with a sealable component.
+
+The syntax is #3seal <target> with <stamp> [using <medium>]#0.", AutoHelp.HelpArgOrNoArg)]
+	protected static void Seal(ICharacter actor, string command)
+	{
+		var ss = new StringStack(command.RemoveFirstWord());
+		if (ss.IsFinished)
+		{
+			actor.OutputHandler.Send($"The syntax is {"seal <target> with <stamp> [using <medium>]".ColourCommand()}.");
+			return;
+		}
+
+		var targetText = ss.PopSpeech();
+		if (ss.IsFinished || !ss.PopSpeech().EqualTo("with"))
+		{
+			actor.OutputHandler.Send($"The syntax is {"seal <target> with <stamp> [using <medium>]".ColourCommand()}.");
+			return;
+		}
+
+		var stampText = ss.PopSpeech();
+		if (string.IsNullOrWhiteSpace(stampText))
+		{
+			actor.OutputHandler.Send("Which stamp do you want to use?");
+			return;
+		}
+
+		string mediumText = string.Empty;
+		if (!ss.IsFinished)
+		{
+			if (!ss.PopSpeech().EqualTo("using") || ss.IsFinished)
+			{
+				actor.OutputHandler.Send($"The syntax is {"seal <target> with <stamp> [using <medium>]".ColourCommand()}.");
+				return;
+			}
+
+			mediumText = ss.SafeRemainingArgument;
+		}
+
+		var target = actor.TargetItem(targetText);
+		if (target is null)
+		{
+			actor.OutputHandler.Send("You don't see anything like that to seal.");
+			return;
+		}
+
+		var stampItem = actor.TargetItem(stampText);
+		if (stampItem is null)
+		{
+			actor.OutputHandler.Send("You don't see any seal stamp like that.");
+			return;
+		}
+
+		IGameItem? medium = null;
+		if (!string.IsNullOrWhiteSpace(mediumText))
+		{
+			medium = actor.TargetItem(mediumText);
+			if (medium is null)
+			{
+				actor.OutputHandler.Send("You don't see any sealing medium like that.");
+				return;
+			}
+		}
+
+		var sealable = target.GetItemType<ISealable>();
+		if (sealable is null)
+		{
+			actor.OutputHandler.Send($"{target.HowSeen(actor, true)} is not something that can be sealed.");
+			return;
+		}
+
+		var stamp = stampItem.GetItemType<ISealStamp>();
+		if (stamp is null)
+		{
+			actor.OutputHandler.Send($"{stampItem.HowSeen(actor, true)} is not a seal stamp.");
+			return;
+		}
+
+		var (truth, error) = actor.CanManipulateItem(target);
+		if (!truth)
+		{
+			actor.OutputHandler.Send(error);
+			return;
+		}
+
+		(truth, error) = actor.CanManipulateItem(stampItem);
+		if (!truth)
+		{
+			actor.OutputHandler.Send(error);
+			return;
+		}
+
+		if (medium is not null)
+		{
+			(truth, error) = actor.CanManipulateItem(medium);
+			if (!truth)
+			{
+				actor.OutputHandler.Send(error);
+				return;
+			}
+		}
+
+		if (!sealable.CanSeal(actor, stamp, medium, out error))
+		{
+			actor.OutputHandler.Send(error);
+			return;
+		}
+
+		sealable.Seal(actor, stamp, medium);
+		actor.OutputHandler.Handle(medium is null
+			? new EmoteOutput(new Emote("@ seal|seals $0 with $1.", actor, target, stampItem))
+			: new EmoteOutput(new Emote("@ seal|seals $0 with $1 using $2.", actor, target, stampItem, medium)));
+	}
+
+	[PlayerCommand("Break", "break")]
+	[RequiredCharacterState(CharacterState.Able)]
+	[DelayBlock("general", "You must first stop {0} before you can do that.")]
+	[NoCombatCommand]
+	[NoMovementCommand]
+	[HelpInfo("break seal",
+		"The #3break seal#0 command breaks the seal on a sealed item without otherwise opening, reading, or writing it. The syntax is #3break seal <target>#0.",
+		AutoHelp.HelpArgOrNoArg)]
+	protected static void Break(ICharacter actor, string command)
+	{
+		var ss = new StringStack(command.RemoveFirstWord());
+		if (ss.IsFinished || !ss.PopSpeech().EqualTo("seal"))
+		{
+			actor.OutputHandler.Send($"The syntax is {"break seal <target>".ColourCommand()}.");
+			return;
+		}
+
+		if (ss.IsFinished)
+		{
+			actor.OutputHandler.Send("Which sealed item do you want to break the seal on?");
+			return;
+		}
+
+		var target = actor.TargetItem(ss.SafeRemainingArgument);
+		if (target is null)
+		{
+			actor.OutputHandler.Send("You don't see anything like that to break a seal on.");
+			return;
+		}
+
+		var sealable = target.GetItemType<ISealable>();
+		if (sealable is null)
+		{
+			actor.OutputHandler.Send($"{target.HowSeen(actor, true)} is not something that can be sealed.");
+			return;
+		}
+
+		var (truth, error) = actor.CanManipulateItem(target);
+		if (!truth)
+		{
+			actor.OutputHandler.Send(error);
+			return;
+		}
+
+		if (!sealable.BreakSeal(actor, "manually broken"))
+		{
+			actor.OutputHandler.Send($"{target.HowSeen(actor, true)} is not currently sealed.");
+		}
+	}
+
+	[PlayerCommand("Inspect", "inspect")]
+	[HelpInfo("inspect",
+		@"The #3inspect#0 command supports focused item inspections.
+
+	#3inspect seal <target>#0 - inspects seal state and impression metadata
+	#3inspect calibration <instrument>#0 - inspects measuring-instrument calibration", AutoHelp.HelpArgOrNoArg)]
+	protected static void Inspect(ICharacter actor, string command)
+	{
+		var ss = new StringStack(command.RemoveFirstWord());
+		switch (ss.PopForSwitch())
+		{
+			case "seal":
+				InspectSeal(actor, ss);
+				return;
+			case "calibration":
+			case "calibrate":
+			case "cal":
+				InspectCalibration(actor, ss);
+				return;
+			default:
+				actor.OutputHandler.Send($"The syntax is {"inspect seal <target>".ColourCommand()} or {"inspect calibration <instrument>".ColourCommand()}.");
+				return;
+		}
+	}
+
+	private static void InspectSeal(ICharacter actor, StringStack ss)
+	{
+		if (ss.IsFinished)
+		{
+			actor.OutputHandler.Send("Which item do you want to inspect the seal on?");
+			return;
+		}
+
+		var target = actor.TargetItem(ss.SafeRemainingArgument);
+		if (target is null)
+		{
+			actor.OutputHandler.Send("You don't see anything like that to inspect a seal on.");
+			return;
+		}
+
+		var sealable = target.GetItemType<ISealable>();
+		if (sealable is null)
+		{
+			actor.OutputHandler.Send($"{target.HowSeen(actor, true)} is not something that can be sealed.");
+			return;
+		}
+
+		actor.OutputHandler.Send(sealable.InspectSeal(actor));
+	}
+
+	private static void InspectCalibration(ICharacter actor, StringStack ss)
+	{
+		if (ss.IsFinished)
+		{
+			actor.OutputHandler.Send("Which measuring instrument do you want to inspect?");
+			return;
+		}
+
+		var target = actor.TargetItem(ss.SafeRemainingArgument);
+		if (target is null)
+		{
+			actor.OutputHandler.Send("You don't see any measuring instrument like that.");
+			return;
+		}
+
+		var instrument = target.GetItemType<IMeasuringInstrument>();
+		if (instrument is null)
+		{
+			actor.OutputHandler.Send($"{target.HowSeen(actor, true)} is not a measuring instrument.");
+			return;
+		}
+
+		actor.OutputHandler.Send(instrument.InspectCalibration(actor));
+	}
+
+	[PlayerCommand("Compare", "compare")]
+	[HelpInfo("compare",
+		"The #3compare seal#0 command compares a seal impression against a seal stamp or another sealed item. The syntax is #3compare seal <sealed item> with <stamp|sealed item>#0.",
+		AutoHelp.HelpArgOrNoArg)]
+	protected static void Compare(ICharacter actor, string command)
+	{
+		var ss = new StringStack(command.RemoveFirstWord());
+		if (ss.IsFinished || !ss.PopSpeech().EqualTo("seal"))
+		{
+			actor.OutputHandler.Send($"The syntax is {"compare seal <sealed item> with <stamp|sealed item>".ColourCommand()}.");
+			return;
+		}
+
+		if (ss.IsFinished)
+		{
+			actor.OutputHandler.Send("Which sealed item do you want to compare?");
+			return;
+		}
+
+		var sealedText = ss.PopSpeech();
+		if (ss.IsFinished || !ss.PopSpeech().EqualTo("with") || ss.IsFinished)
+		{
+			actor.OutputHandler.Send($"The syntax is {"compare seal <sealed item> with <stamp|sealed item>".ColourCommand()}.");
+			return;
+		}
+
+		var comparisonText = ss.SafeRemainingArgument;
+		var sealedItem = actor.TargetItem(sealedText);
+		if (sealedItem is null)
+		{
+			actor.OutputHandler.Send("You don't see any sealed item like that.");
+			return;
+		}
+
+		var sealable = sealedItem.GetItemType<ISealable>();
+		if (sealable?.CurrentSeal is null)
+		{
+			actor.OutputHandler.Send($"{sealedItem.HowSeen(actor, true)} does not have any seal impression to compare.");
+			return;
+		}
+
+		var comparisonItem = actor.TargetItem(comparisonText);
+		if (comparisonItem is null)
+		{
+			actor.OutputHandler.Send("You don't see anything like that to compare against.");
+			return;
+		}
+
+		var stamp = comparisonItem.GetItemType<ISealStamp>();
+		var otherSealable = comparisonItem.GetItemType<ISealable>();
+		var matches = stamp is not null
+			? sealable.SealMatches(stamp)
+			: otherSealable is not null && sealable.SealMatches(otherSealable);
+		if (stamp is null && otherSealable is null)
+		{
+			actor.OutputHandler.Send($"{comparisonItem.HowSeen(actor, true)} is neither a seal stamp nor an item with a seal impression.");
+			return;
+		}
+
+		actor.OutputHandler.Send(matches
+			? $"{sealedItem.HowSeen(actor, true)} appears to match {comparisonItem.HowSeen(actor)}."
+			: $"{sealedItem.HowSeen(actor, true)} does not appear to match {comparisonItem.HowSeen(actor)}.");
+	}
+
+	[PlayerCommand("Weigh", "weigh")]
+	[RequiredCharacterState(CharacterState.Able)]
+	[DelayBlock("general", "You must first stop {0} before you can do that.")]
+	[NoCombatCommand]
+	[NoMovementCommand]
+	[HelpInfo("weigh",
+		"The #3weigh#0 command weighs an item using a measuring instrument. The syntax is #3weigh <item> on <instrument>#0.",
+		AutoHelp.HelpArgOrNoArg)]
+	protected static void Weigh(ICharacter actor, string command)
+	{
+		var ss = new StringStack(command.RemoveFirstWord());
+		if (ss.IsFinished)
+		{
+			actor.OutputHandler.Send($"The syntax is {"weigh <item> on <instrument>".ColourCommand()}.");
+			return;
+		}
+
+		var targetText = ss.PopSpeech();
+		if (ss.IsFinished || !ss.PopSpeech().EqualTo("on") || ss.IsFinished)
+		{
+			actor.OutputHandler.Send($"The syntax is {"weigh <item> on <instrument>".ColourCommand()}.");
+			return;
+		}
+
+		var target = actor.TargetItem(targetText);
+		if (target is null)
+		{
+			actor.OutputHandler.Send("You don't see anything like that to weigh.");
+			return;
+		}
+
+		var instrumentItem = actor.TargetItem(ss.SafeRemainingArgument);
+		if (instrumentItem is null)
+		{
+			actor.OutputHandler.Send("You don't see any weighing instrument like that.");
+			return;
+		}
+
+		var instrument = instrumentItem.GetItemType<IMeasuringInstrument>();
+		if (instrument is null || instrument.Mode != MeasuringInstrumentMode.Weight)
+		{
+			actor.OutputHandler.Send($"{instrumentItem.HowSeen(actor, true)} is not a weighing instrument.");
+			return;
+		}
+
+		var (truth, error) = actor.CanManipulateItem(instrumentItem);
+		if (!truth)
+		{
+			actor.OutputHandler.Send(error);
+			return;
+		}
+
+		if (!instrument.CanMeasure(target, out error))
+		{
+			actor.OutputHandler.Send(error);
+			return;
+		}
+
+		var result = instrument.Measure(actor, target);
+		actor.OutputHandler.Handle(new EmoteOutput(new Emote("@ weigh|weighs $0 on $1.", actor, target, instrumentItem)));
+		actor.OutputHandler.Send($"{target.HowSeen(actor, true)} weighs {DescribeMeasurement(actor, result)} according to {instrumentItem.HowSeen(actor)}.");
+	}
+
+	[PlayerCommand("Measure", "measure")]
+	[RequiredCharacterState(CharacterState.Able)]
+	[DelayBlock("general", "You must first stop {0} before you can do that.")]
+	[NoCombatCommand]
+	[NoMovementCommand]
+	[HelpInfo("measure",
+		"The #3measure#0 command measures weight or liquid volume with a measuring instrument. Length measurement is not implemented in this pass. The syntax is #3measure <target> with <instrument>#0.",
+		AutoHelp.HelpArgOrNoArg)]
+	protected static void Measure(ICharacter actor, string command)
+	{
+		var ss = new StringStack(command.RemoveFirstWord());
+		if (ss.IsFinished)
+		{
+			actor.OutputHandler.Send($"The syntax is {"measure <target> with <instrument>".ColourCommand()}.");
+			return;
+		}
+
+		var targetText = ss.PopSpeech();
+		if (ss.IsFinished || !ss.PopSpeech().EqualTo("with") || ss.IsFinished)
+		{
+			actor.OutputHandler.Send($"The syntax is {"measure <target> with <instrument>".ColourCommand()}.");
+			return;
+		}
+
+		var target = actor.TargetItem(targetText);
+		if (target is null)
+		{
+			actor.OutputHandler.Send("You don't see anything like that to measure.");
+			return;
+		}
+
+		var instrumentItem = actor.TargetItem(ss.SafeRemainingArgument);
+		if (instrumentItem is null)
+		{
+			actor.OutputHandler.Send("You don't see any measuring instrument like that.");
+			return;
+		}
+
+		var instrument = instrumentItem.GetItemType<IMeasuringInstrument>();
+		if (instrument is null)
+		{
+			actor.OutputHandler.Send($"{instrumentItem.HowSeen(actor, true)} is not a measuring instrument.");
+			return;
+		}
+
+		var (truth, error) = actor.CanManipulateItem(instrumentItem);
+		if (!truth)
+		{
+			actor.OutputHandler.Send(error);
+			return;
+		}
+
+		if (!instrument.CanMeasure(target, out error))
+		{
+			actor.OutputHandler.Send(error);
+			return;
+		}
+
+		var result = instrument.Measure(actor, target);
+		actor.OutputHandler.Handle(new EmoteOutput(new Emote("@ measure|measures $0 with $1.", actor, target, instrumentItem)));
+		var verb = result.Mode == MeasuringInstrumentMode.FluidVolume ? "contains" : "measures";
+		actor.OutputHandler.Send($"{target.HowSeen(actor, true)} {verb} {DescribeMeasurement(actor, result)} according to {instrumentItem.HowSeen(actor)}.");
+	}
+
+	[PlayerCommand("Calibrate", "calibrate")]
+	[RequiredCharacterState(CharacterState.Able)]
+	[DelayBlock("general", "You must first stop {0} before you can do that.")]
+	[NoCombatCommand]
+	[NoMovementCommand]
+	[HelpInfo("calibrate",
+		@"The #3calibrate#0 command honestly calibrates a measuring instrument or deliberately calibrates it wrong.
+
+	#3calibrate <instrument>#0
+	#3calibrate <instrument> wrong <+/-amount|+/-percent>#0", AutoHelp.HelpArgOrNoArg)]
+	protected static void Calibrate(ICharacter actor, string command)
+	{
+		var ss = new StringStack(command.RemoveFirstWord());
+		if (ss.IsFinished)
+		{
+			actor.OutputHandler.Send($"The syntax is {"calibrate <instrument>".ColourCommand()} or {"calibrate <instrument> wrong <+/-amount|+/-percent>".ColourCommand()}.");
+			return;
+		}
+
+		var instrumentItem = actor.TargetItem(ss.PopSpeech());
+		if (instrumentItem is null)
+		{
+			actor.OutputHandler.Send("You don't see any measuring instrument like that.");
+			return;
+		}
+
+		var instrument = instrumentItem.GetItemType<IMeasuringInstrument>();
+		if (instrument is null)
+		{
+			actor.OutputHandler.Send($"{instrumentItem.HowSeen(actor, true)} is not a measuring instrument.");
+			return;
+		}
+
+		var (truth, error) = actor.CanManipulateItem(instrumentItem);
+		if (!truth)
+		{
+			actor.OutputHandler.Send(error);
+			return;
+		}
+
+		if (ss.IsFinished)
+		{
+			instrument.Calibrate(actor);
+			actor.OutputHandler.Handle(new EmoteOutput(new Emote("@ calibrate|calibrates $0.", actor, instrumentItem)));
+			return;
+		}
+
+		if (!ss.PopSpeech().EqualTo("wrong") || ss.IsFinished)
+		{
+			actor.OutputHandler.Send($"The syntax is {"calibrate <instrument>".ColourCommand()} or {"calibrate <instrument> wrong <+/-amount|+/-percent>".ColourCommand()}.");
+			return;
+		}
+
+		if (!TryParseCalibrationBias(actor, instrument, ss.SafeRemainingArgument, out var bias, out var percentageBias))
+		{
+			actor.OutputHandler.Send($"The bias must be a percentage or a {instrument.UnitType.DescribeEnum().ToLowerInvariant()} amount.");
+			return;
+		}
+
+		if (!instrument.CalibrateWrong(actor, bias, percentageBias, out error))
+		{
+			actor.OutputHandler.Send(error);
+			return;
+		}
+
+		actor.OutputHandler.Handle(new EmoteOutput(new Emote("@ calibrate|calibrates $0 with a bad measure.", actor, instrumentItem)));
+		actor.OutputHandler.Send(percentageBias
+			? $"{instrumentItem.HowSeen(actor, true)} is now deliberately biased by {bias.ToString("P2", actor).ColourValue()}."
+			: $"{instrumentItem.HowSeen(actor, true)} is now deliberately biased by {actor.Gameworld.UnitManager.DescribeExact(bias, instrument.UnitType, actor).ColourValue()}.");
+	}
+
 	[PlayerCommand("Haul", "haul")]
     [RequiredCharacterState(CharacterState.Able)]
     [DelayBlock("general", "drag", "You must first stop {0} before you can do that.")]

--- a/MudSharpCore/GameItems/Components/MeasuringInstrumentGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/MeasuringInstrumentGameItemComponent.cs
@@ -1,0 +1,251 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Form.Shape;
+using MudSharp.Framework;
+using MudSharp.Framework.Units;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.GameItems.Prototypes;
+using MudSharp.PerceptionEngine;
+using MudSharp.RPG.Checks;
+using System;
+using System.Text;
+using System.Xml.Linq;
+
+namespace MudSharp.GameItems.Components;
+
+public class MeasuringInstrumentGameItemComponent : GameItemComponent, IMeasuringInstrument
+{
+	private MeasuringInstrumentGameItemComponentProto _prototype;
+	private double _calibrationBias;
+	private bool _calibrationBiasIsPercentage;
+	private bool _hasDeliberateBias;
+	private int _usesSinceCalibration;
+	private int _driftDirection;
+
+	public override IGameItemComponentProto Prototype => _prototype;
+	public MeasuringInstrumentMode Mode => _prototype.Mode;
+	public UnitType UnitType => _prototype.UnitType;
+	public double Precision => _prototype.Precision;
+	public double Capacity => _prototype.Capacity;
+	public double CalibrationBias => _calibrationBias;
+	public bool CalibrationBiasIsPercentage => _calibrationBiasIsPercentage;
+	public bool HasDeliberateBias => _hasDeliberateBias;
+	public int UsesSinceCalibration => _usesSinceCalibration;
+
+	protected override void UpdateComponentNewPrototype(IGameItemComponentProto newProto)
+	{
+		_prototype = (MeasuringInstrumentGameItemComponentProto)newProto;
+	}
+
+	public MeasuringInstrumentGameItemComponent(MeasuringInstrumentGameItemComponentProto proto, IGameItem parent,
+		bool temporary = false) : base(parent, proto, temporary)
+	{
+		_prototype = proto;
+		_driftDirection = StableDriftDirection();
+	}
+
+	public MeasuringInstrumentGameItemComponent(MudSharp.Models.GameItemComponent component,
+		MeasuringInstrumentGameItemComponentProto proto, IGameItem parent) : base(component, parent)
+	{
+		_prototype = proto;
+		_noSave = true;
+		LoadFromXml(XElement.Parse(component.Definition));
+		_noSave = false;
+	}
+
+	public MeasuringInstrumentGameItemComponent(MeasuringInstrumentGameItemComponent rhs, IGameItem newParent,
+		bool temporary = false) : base(rhs, newParent, temporary)
+	{
+		_prototype = rhs._prototype;
+		_calibrationBias = rhs._calibrationBias;
+		_calibrationBiasIsPercentage = rhs._calibrationBiasIsPercentage;
+		_hasDeliberateBias = rhs._hasDeliberateBias;
+		_usesSinceCalibration = rhs._usesSinceCalibration;
+		_driftDirection = rhs._driftDirection;
+	}
+
+	private int StableDriftDirection()
+	{
+		var basis = Parent.Id != 0 ? Parent.Id : Parent.Prototype?.Id ?? _prototype.Id;
+		return basis % 2 == 0 ? 1 : -1;
+	}
+
+	private void LoadFromXml(XElement root)
+	{
+		_calibrationBias = double.Parse(root.Element("CalibrationBias")?.Value ?? "0.0");
+		_calibrationBiasIsPercentage = bool.Parse(root.Element("CalibrationBiasIsPercentage")?.Value ?? "false");
+		_hasDeliberateBias = bool.Parse(root.Element("HasDeliberateBias")?.Value ?? "false");
+		_usesSinceCalibration = int.Parse(root.Element("UsesSinceCalibration")?.Value ?? "0");
+		_driftDirection = int.Parse(root.Element("DriftDirection")?.Value ?? "0");
+		if (_driftDirection == 0)
+		{
+			_driftDirection = StableDriftDirection();
+		}
+	}
+
+	public override IGameItemComponent Copy(IGameItem newParent, bool temporary = false)
+	{
+		return new MeasuringInstrumentGameItemComponent(this, newParent, temporary);
+	}
+
+	protected override string SaveToXml()
+	{
+		return new XElement("Definition",
+			new XElement("CalibrationBias", _calibrationBias),
+			new XElement("CalibrationBiasIsPercentage", _calibrationBiasIsPercentage),
+			new XElement("HasDeliberateBias", _hasDeliberateBias),
+			new XElement("UsesSinceCalibration", _usesSinceCalibration),
+			new XElement("DriftDirection", _driftDirection)).ToString();
+	}
+
+	public bool CanMeasure(IGameItem target, out string error)
+	{
+		var value = TrueValue(target);
+		if (value is null)
+		{
+			error = Mode switch
+			{
+				MeasuringInstrumentMode.Weight => "That instrument can only weigh physical items.",
+				MeasuringInstrumentMode.FluidVolume => "That instrument can only measure the contents of liquid containers.",
+				_ => "That instrument cannot measure anything in that mode."
+			};
+			return false;
+		}
+
+		if (value.Value > Capacity)
+		{
+			error = $"That is beyond the instrument's capacity of {Gameworld.UnitManager.DescribeExact(Capacity, UnitType, "metric")}.";
+			return false;
+		}
+
+		error = string.Empty;
+		return true;
+	}
+
+	public MeasurementResult Measure(ICharacter actor, IGameItem target)
+	{
+		if (!CanMeasure(target, out var error))
+		{
+			throw new InvalidOperationException(error);
+		}
+
+		var trueValue = TrueValue(target)!.Value;
+		_usesSinceCalibration++;
+		var drift = CurrentDrift(trueValue);
+		var bias = _calibrationBiasIsPercentage ? trueValue * _calibrationBias : _calibrationBias;
+		var reported = RoundToPrecision(Math.Max(0.0, trueValue + drift + bias));
+		Changed = true;
+		return new MeasurementResult(Mode, UnitType, trueValue, reported, drift, bias, _usesSinceCalibration);
+	}
+
+	public void Calibrate(ICharacter actor)
+	{
+		_calibrationBias = 0.0;
+		_calibrationBiasIsPercentage = false;
+		_hasDeliberateBias = false;
+		_usesSinceCalibration = 0;
+		_driftDirection = StableDriftDirection();
+		Changed = true;
+	}
+
+	public bool CalibrateWrong(ICharacter actor, double bias, bool percentageBias, out string error)
+	{
+		if (percentageBias && Math.Abs(bias) > _prototype.MaximumWrongCalibration)
+		{
+			error = $"That bias is too large. This instrument can only be wrong-calibrated by up to {_prototype.MaximumWrongCalibration.ToString("P2", actor)}.";
+			return false;
+		}
+
+		if (!percentageBias && Math.Abs(bias) > Capacity * _prototype.MaximumWrongCalibration)
+		{
+			error = $"That bias is too large. This instrument can only be wrong-calibrated by up to {Gameworld.UnitManager.DescribeExact(Capacity * _prototype.MaximumWrongCalibration, UnitType, actor)}.";
+			return false;
+		}
+
+		_calibrationBias = bias;
+		_calibrationBiasIsPercentage = percentageBias;
+		_hasDeliberateBias = true;
+		_usesSinceCalibration = 0;
+		_driftDirection = StableDriftDirection();
+		Changed = true;
+		error = string.Empty;
+		return true;
+	}
+
+	public string InspectCalibration(ICharacter actor)
+	{
+		var passed = actor.IsAdministrator() ||
+		             actor.Gameworld.GetCheck(CheckType.AppraiseItemCheck)
+		                  .Check(actor, _prototype.CalibrationInspectionDifficulty, Parent)
+		                  .IsPass();
+		if (!passed)
+		{
+			return $"{Parent.HowSeen(actor, true)} is a {Mode.DescribeEnum().ToLowerInvariant()} measuring instrument, but you cannot determine its calibration.";
+		}
+
+		var sb = new StringBuilder();
+		sb.AppendLine($"{Parent.HowSeen(actor, true)} measures {Mode.DescribeEnum().ColourName()}.");
+		sb.AppendLine($"Capacity: {Gameworld.UnitManager.DescribeExact(Capacity, UnitType, actor).ColourValue()}");
+		sb.AppendLine($"Precision: {Gameworld.UnitManager.DescribeExact(Precision, UnitType, actor).ColourValue()}");
+		sb.AppendLine($"Uses Since Calibration: {_usesSinceCalibration.ToString("N0", actor).ColourValue()}");
+		sb.AppendLine($"Stable Drift Direction: {(_driftDirection >= 0 ? "high" : "low").ColourValue()}");
+		sb.AppendLine($"Estimated Drift At Capacity: {Gameworld.UnitManager.DescribeExact(CurrentDrift(Capacity), UnitType, actor).ColourValue()}");
+		if (_hasDeliberateBias)
+		{
+			sb.AppendLine(_calibrationBiasIsPercentage
+				? $"Deliberate Bias: {_calibrationBias.ToString("P2", actor).ColourError()}"
+				: $"Deliberate Bias: {Gameworld.UnitManager.DescribeExact(_calibrationBias, UnitType, actor).ColourError()}");
+		}
+		else
+		{
+			sb.AppendLine("Deliberate Bias: None".ColourValue());
+		}
+
+		return sb.ToString();
+	}
+
+	private double? TrueValue(IGameItem target)
+	{
+		return Mode switch
+		{
+			MeasuringInstrumentMode.Weight => target.Weight,
+			MeasuringInstrumentMode.FluidVolume => target.GetItemType<ILiquidContainer>()?.LiquidVolume,
+			_ => null
+		};
+	}
+
+	private double CurrentDrift(double trueValue)
+	{
+		var qualityStepsBelowLegendary = (int)ItemQuality.Legendary - (int)Parent.Quality;
+		var qualityMultiplier = Math.Clamp(1.0 + qualityStepsBelowLegendary * 0.2, 0.25, 4.0);
+		var driftPercent = Math.Min(_prototype.MaximumDrift, _usesSinceCalibration * _prototype.BaseDriftPerUse * qualityMultiplier);
+		return trueValue * driftPercent * _driftDirection;
+	}
+
+	private double RoundToPrecision(double value)
+	{
+		if (Precision <= 0.0)
+		{
+			return value;
+		}
+
+		return Math.Round(value / Precision, MidpointRounding.AwayFromZero) * Precision;
+	}
+
+	public override bool DescriptionDecorator(DescriptionType type)
+	{
+		return type is DescriptionType.Full or DescriptionType.Evaluate;
+	}
+
+	public override string Decorate(IPerceiver voyeur, string name, string description, DescriptionType type,
+		bool colour, PerceiveIgnoreFlags flags)
+	{
+		return type switch
+		{
+			DescriptionType.Full => $"{description}\n\nIt is marked for measuring {Mode.DescribeEnum().ToLowerInvariant()}.",
+			DescriptionType.Evaluate when voyeur is ICharacter ch => InspectCalibration(ch),
+			_ => description
+		};
+	}
+}

--- a/MudSharpCore/GameItems/Components/SealStampGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/SealStampGameItemComponent.cs
@@ -1,0 +1,104 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Form.Shape;
+using MudSharp.Framework;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.GameItems.Prototypes;
+using MudSharp.PerceptionEngine;
+using MudSharp.RPG.Checks;
+using System;
+using System.Xml.Linq;
+
+namespace MudSharp.GameItems.Components;
+
+public class SealStampGameItemComponent : GameItemComponent, ISealStamp
+{
+	private SealStampGameItemComponentProto _prototype;
+	public override IGameItemComponentProto Prototype => _prototype;
+
+	protected override void UpdateComponentNewPrototype(IGameItemComponentProto newProto)
+	{
+		_prototype = (SealStampGameItemComponentProto)newProto;
+	}
+
+	public SealStampGameItemComponent(SealStampGameItemComponentProto proto, IGameItem parent, bool temporary = false) :
+		base(parent, proto, temporary)
+	{
+		_prototype = proto;
+	}
+
+	public SealStampGameItemComponent(MudSharp.Models.GameItemComponent component, SealStampGameItemComponentProto proto,
+		IGameItem parent) : base(component, parent)
+	{
+		_prototype = proto;
+		_noSave = true;
+		LoadFromXml(XElement.Parse(component.Definition));
+		_noSave = false;
+	}
+
+	public SealStampGameItemComponent(SealStampGameItemComponent rhs, IGameItem newParent, bool temporary = false) :
+		base(rhs, newParent, temporary)
+	{
+		_prototype = rhs._prototype;
+	}
+
+	private void LoadFromXml(XElement root)
+	{
+	}
+
+	public override IGameItemComponent Copy(IGameItem newParent, bool temporary = false)
+	{
+		return new SealStampGameItemComponent(this, newParent, temporary);
+	}
+
+	protected override string SaveToXml()
+	{
+		return new XElement("Definition").ToString();
+	}
+
+	public string SealDesign => _prototype.SealDesign;
+	public string IssuerText => _prototype.IssuerText;
+	public string OwnerText => _prototype.OwnerText;
+	public string ClanText => _prototype.ClanText;
+	public string OfficeText => _prototype.OfficeText;
+	public string StampMaterial => _prototype.StampMaterial;
+	public Difficulty ForgeryDifficulty => _prototype.ForgeryDifficulty;
+
+	public bool CanSeal(ICharacter actor, IGameItem target, IGameItem? medium, out string error)
+	{
+		return _prototype.CanSeal(actor, Parent, target, medium, out error);
+	}
+
+	public SealImpression CreateImpression(ICharacter actor, IGameItem target, IGameItem? medium)
+	{
+		return new SealImpression(
+			SealDesign,
+			IssuerText,
+			OwnerText,
+			ClanText,
+			OfficeText,
+			string.IsNullOrWhiteSpace(StampMaterial) ? Parent.Material?.Name ?? string.Empty : StampMaterial,
+			ForgeryDifficulty,
+			actor.Id,
+			actor.HowSeen(actor),
+			DateTime.UtcNow,
+			medium?.HowSeen(actor) ?? string.Empty);
+	}
+
+	public override bool DescriptionDecorator(DescriptionType type)
+	{
+		return type is DescriptionType.Full or DescriptionType.Evaluate;
+	}
+
+	public override string Decorate(IPerceiver voyeur, string name, string description, DescriptionType type,
+		bool colour, PerceiveIgnoreFlags flags)
+	{
+		return type switch
+		{
+			DescriptionType.Full => $"{description}\n\nIt bears a seal design of {SealDesign.ColourValue()}.",
+			DescriptionType.Evaluate => $"It is a seal stamp with design {SealDesign.ColourValue()} and {(string.IsNullOrWhiteSpace(StampMaterial) ? "unspecified" : StampMaterial).ColourValue()} material metadata.",
+			_ => description
+		};
+	}
+}

--- a/MudSharpCore/GameItems/Components/SealableGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/SealableGameItemComponent.cs
@@ -1,0 +1,297 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Events;
+using MudSharp.Form.Shape;
+using MudSharp.Framework;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.GameItems.Prototypes;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Outputs;
+using MudSharp.PerceptionEngine.Parsers;
+using MudSharp.RPG.Checks;
+using System;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+namespace MudSharp.GameItems.Components;
+
+public class SealableGameItemComponent : GameItemComponent, ISealable
+{
+	private SealableGameItemComponentProto _prototype;
+	private bool _isSealed;
+	private bool _sealBroken;
+	private bool _hasSealResidue;
+
+	public override IGameItemComponentProto Prototype => _prototype;
+	public bool IsSealed => _isSealed;
+	public bool SealBroken => _sealBroken;
+	public bool HasSealResidue => _hasSealResidue;
+	public SealImpression? CurrentSeal { get; private set; }
+	public Difficulty InspectionDifficulty => _prototype.InspectionDifficulty;
+
+	protected override void UpdateComponentNewPrototype(IGameItemComponentProto newProto)
+	{
+		_prototype = (SealableGameItemComponentProto)newProto;
+	}
+
+	public SealableGameItemComponent(SealableGameItemComponentProto proto, IGameItem parent, bool temporary = false) :
+		base(parent, proto, temporary)
+	{
+		_prototype = proto;
+	}
+
+	public SealableGameItemComponent(MudSharp.Models.GameItemComponent component, SealableGameItemComponentProto proto,
+		IGameItem parent) : base(component, parent)
+	{
+		_prototype = proto;
+		_noSave = true;
+		LoadFromXml(XElement.Parse(component.Definition));
+		_noSave = false;
+	}
+
+	public SealableGameItemComponent(SealableGameItemComponent rhs, IGameItem newParent, bool temporary = false) :
+		base(rhs, newParent, temporary)
+	{
+		_prototype = rhs._prototype;
+		_isSealed = rhs._isSealed;
+		_sealBroken = rhs._sealBroken;
+		_hasSealResidue = rhs._hasSealResidue;
+		CurrentSeal = rhs.CurrentSeal;
+	}
+
+	private void LoadFromXml(XElement root)
+	{
+		_isSealed = bool.Parse(root.Element("IsSealed")?.Value ?? "false");
+		_sealBroken = bool.Parse(root.Element("SealBroken")?.Value ?? "false");
+		_hasSealResidue = bool.Parse(root.Element("HasSealResidue")?.Value ?? "false");
+		var seal = root.Element("Seal");
+		if (seal is null)
+		{
+			return;
+		}
+
+		CurrentSeal = new SealImpression(
+			seal.Element("SealDesign")?.Value ?? string.Empty,
+			seal.Element("IssuerText")?.Value ?? string.Empty,
+			seal.Element("OwnerText")?.Value ?? string.Empty,
+			seal.Element("ClanText")?.Value ?? string.Empty,
+			seal.Element("OfficeText")?.Value ?? string.Empty,
+			seal.Element("StampMaterial")?.Value ?? string.Empty,
+			(Difficulty)int.Parse(seal.Element("ForgeryDifficulty")?.Value ?? ((int)Difficulty.Normal).ToString()),
+			long.Parse(seal.Element("SealingCharacterId")?.Value ?? "0"),
+			seal.Element("SealingCharacterName")?.Value ?? string.Empty,
+			DateTime.Parse(seal.Element("SealedAt")?.Value ?? DateTime.MinValue.ToString("O")),
+			seal.Element("SealMedium")?.Value ?? string.Empty);
+	}
+
+	public override IGameItemComponent Copy(IGameItem newParent, bool temporary = false)
+	{
+		return new SealableGameItemComponent(this, newParent, temporary);
+	}
+
+	protected override string SaveToXml()
+	{
+		return new XElement("Definition",
+			new XElement("IsSealed", _isSealed),
+			new XElement("SealBroken", _sealBroken),
+			new XElement("HasSealResidue", _hasSealResidue),
+			CurrentSeal is null ? null :
+				new XElement("Seal",
+					new XElement("SealDesign", new XCData(CurrentSeal.SealDesign)),
+					new XElement("IssuerText", new XCData(CurrentSeal.IssuerText)),
+					new XElement("OwnerText", new XCData(CurrentSeal.OwnerText)),
+					new XElement("ClanText", new XCData(CurrentSeal.ClanText)),
+					new XElement("OfficeText", new XCData(CurrentSeal.OfficeText)),
+					new XElement("StampMaterial", new XCData(CurrentSeal.StampMaterial)),
+					new XElement("ForgeryDifficulty", (int)CurrentSeal.ForgeryDifficulty),
+					new XElement("SealingCharacterId", CurrentSeal.SealingCharacterId),
+					new XElement("SealingCharacterName", new XCData(CurrentSeal.SealingCharacterName)),
+					new XElement("SealedAt", CurrentSeal.SealedAt.ToString("O")),
+					new XElement("SealMedium", new XCData(CurrentSeal.SealMedium)))).ToString();
+	}
+
+	public bool CanSeal(ICharacter actor, ISealStamp stamp, IGameItem? medium, out string error)
+	{
+		if (_isSealed)
+		{
+			error = $"{Parent.HowSeen(actor, true)} is already sealed.";
+			return false;
+		}
+
+		if (!_prototype.IsAllowedMedium(medium))
+		{
+			error = $"{medium?.HowSeen(actor, true) ?? "That"} is not an allowed seal medium for {Parent.HowSeen(actor)}.";
+			return false;
+		}
+
+		if (!stamp.CanSeal(actor, Parent, medium, out error))
+		{
+			return false;
+		}
+
+		error = string.Empty;
+		return true;
+	}
+
+	public void Seal(ICharacter actor, ISealStamp stamp, IGameItem? medium)
+	{
+		CurrentSeal = stamp.CreateImpression(actor, Parent, medium);
+		_isSealed = true;
+		_sealBroken = false;
+		_hasSealResidue = false;
+		Changed = true;
+	}
+
+	public bool BreakSeal(ICharacter? actor, string reason)
+	{
+		if (!_isSealed)
+		{
+			return false;
+		}
+
+		_isSealed = false;
+		_sealBroken = true;
+		_hasSealResidue = _prototype.BrokenSealLeavesResidue;
+		Changed = true;
+
+		if (actor is not null)
+		{
+			actor.OutputHandler.Handle(new EmoteOutput(new Emote("@ break|breaks the seal on $0.", actor, Parent)));
+		}
+		else
+		{
+			Parent.Handle("The seal breaks.");
+		}
+
+		return true;
+	}
+
+	public string InspectSeal(ICharacter actor)
+	{
+		if (CurrentSeal is null)
+		{
+			return _hasSealResidue
+				? $"{Parent.HowSeen(actor, true)} has broken seal residue, but no intact impression."
+				: $"{Parent.HowSeen(actor, true)} is not sealed.";
+		}
+
+		var passed = actor.IsAdministrator() ||
+		             actor.Gameworld.GetCheck(CheckType.AppraiseItemCheck).Check(actor, InspectionDifficulty, Parent).IsPass();
+		if (!passed)
+		{
+			return _isSealed
+				? $"{Parent.HowSeen(actor, true)} is sealed, but you cannot make out reliable details of the impression."
+				: $"{Parent.HowSeen(actor, true)} has a broken seal, but you cannot make out reliable details of the impression.";
+		}
+
+		var sb = new StringBuilder();
+		sb.AppendLine(_isSealed
+			? $"{Parent.HowSeen(actor, true)} is sealed with the following impression:"
+			: $"{Parent.HowSeen(actor, true)} has a broken seal with the following impression:");
+		sb.AppendLine($"Design: {CurrentSeal.SealDesign.ColourValue()}");
+		if (!string.IsNullOrWhiteSpace(CurrentSeal.IssuerText))
+		{
+			sb.AppendLine($"Issuer: {CurrentSeal.IssuerText.ColourName()}");
+		}
+
+		if (!string.IsNullOrWhiteSpace(CurrentSeal.OwnerText))
+		{
+			sb.AppendLine($"Owner: {CurrentSeal.OwnerText.ColourName()}");
+		}
+
+		if (!string.IsNullOrWhiteSpace(CurrentSeal.ClanText))
+		{
+			sb.AppendLine($"Clan: {CurrentSeal.ClanText.ColourName()}");
+		}
+
+		if (!string.IsNullOrWhiteSpace(CurrentSeal.OfficeText))
+		{
+			sb.AppendLine($"Office: {CurrentSeal.OfficeText.ColourName()}");
+		}
+
+		if (!string.IsNullOrWhiteSpace(CurrentSeal.StampMaterial))
+		{
+			sb.AppendLine($"Stamp Material: {CurrentSeal.StampMaterial.ColourValue()}");
+		}
+
+		if (!string.IsNullOrWhiteSpace(CurrentSeal.SealMedium))
+		{
+			sb.AppendLine($"Seal Medium: {CurrentSeal.SealMedium.ColourValue()}");
+		}
+
+		sb.AppendLine($"Forgery Difficulty: {CurrentSeal.ForgeryDifficulty.DescribeColoured()}");
+		return sb.ToString();
+	}
+
+	public bool SealMatches(ISealStamp stamp)
+	{
+		return CurrentSeal is not null &&
+		       CurrentSeal.SealDesign.EqualTo(stamp.SealDesign) &&
+		       CurrentSeal.IssuerText.EqualTo(stamp.IssuerText) &&
+		       CurrentSeal.OwnerText.EqualTo(stamp.OwnerText) &&
+		       CurrentSeal.ClanText.EqualTo(stamp.ClanText) &&
+		       CurrentSeal.OfficeText.EqualTo(stamp.OfficeText) &&
+		       CurrentSeal.StampMaterial.EqualTo(stamp.StampMaterial);
+	}
+
+	public bool SealMatches(ISealable sealable)
+	{
+		return CurrentSeal is not null &&
+		       sealable.CurrentSeal is not null &&
+		       CurrentSeal.SealDesign.EqualTo(sealable.CurrentSeal.SealDesign) &&
+		       CurrentSeal.IssuerText.EqualTo(sealable.CurrentSeal.IssuerText) &&
+		       CurrentSeal.OwnerText.EqualTo(sealable.CurrentSeal.OwnerText) &&
+		       CurrentSeal.ClanText.EqualTo(sealable.CurrentSeal.ClanText) &&
+		       CurrentSeal.OfficeText.EqualTo(sealable.CurrentSeal.OfficeText) &&
+		       CurrentSeal.StampMaterial.EqualTo(sealable.CurrentSeal.StampMaterial);
+	}
+
+	public override bool HandleEvent(EventType type, params dynamic[] arguments)
+	{
+		if (type == EventType.ItemOpened && _isSealed)
+		{
+			BreakSeal(arguments.OfType<ICharacter>().FirstOrDefault(), "opened");
+			return true;
+		}
+
+		return false;
+	}
+
+	public override bool HandlesEvent(params EventType[] types)
+	{
+		return types.Contains(EventType.ItemOpened);
+	}
+
+	public override bool DescriptionDecorator(DescriptionType type)
+	{
+		return type is DescriptionType.Full or DescriptionType.Evaluate;
+	}
+
+	public override string Decorate(IPerceiver voyeur, string name, string description, DescriptionType type,
+		bool colour, PerceiveIgnoreFlags flags)
+	{
+		if (type == DescriptionType.Evaluate && voyeur is ICharacter ch)
+		{
+			return InspectSeal(ch);
+		}
+
+		if (type != DescriptionType.Full)
+		{
+			return description;
+		}
+
+		if (_isSealed && CurrentSeal is not null)
+		{
+			return $"{description}\n\nIt is sealed with an impression of {CurrentSeal.SealDesign.ColourValue()}.";
+		}
+
+		if (_hasSealResidue)
+		{
+			return $"{description}\n\nIt has the broken residue of a seal.";
+		}
+
+		return description;
+	}
+}

--- a/MudSharpCore/GameItems/GameItemFutureprogs.cs
+++ b/MudSharpCore/GameItems/GameItemFutureprogs.cs
@@ -79,6 +79,25 @@ public partial class GameItem
             { "layer", ProgVariableTypes.Text },
             { "isfood", ProgVariableTypes.Boolean },
             { "isliquidcontainer", ProgVariableTypes.Boolean },
+            { "issealstamp", ProgVariableTypes.Boolean },
+            { "issealable", ProgVariableTypes.Boolean },
+            { "issealed", ProgVariableTypes.Boolean },
+            { "sealbroken", ProgVariableTypes.Boolean },
+            { "sealresidue", ProgVariableTypes.Boolean },
+            { "sealdesign", ProgVariableTypes.Text },
+            { "sealissuer", ProgVariableTypes.Text },
+            { "sealowner", ProgVariableTypes.Text },
+            { "sealclan", ProgVariableTypes.Text },
+            { "sealoffice", ProgVariableTypes.Text },
+            { "sealmaterial", ProgVariableTypes.Text },
+            { "sealmedium", ProgVariableTypes.Text },
+            { "sealingcharacterid", ProgVariableTypes.Number },
+            { "ismeasuringinstrument", ProgVariableTypes.Boolean },
+            { "measuringmode", ProgVariableTypes.Text },
+            { "calibrationbias", ProgVariableTypes.Number },
+            { "calibrationbiasispercent", ProgVariableTypes.Boolean },
+            { "calibrationdeliberate", ProgVariableTypes.Boolean },
+            { "usessincecalibration", ProgVariableTypes.Number },
             { "variables", ProgVariableTypes.Dictionary | ProgVariableTypes.Text},
             { "condition", ProgVariableTypes.Number },
             { "quality", ProgVariableTypes.Number },
@@ -147,6 +166,25 @@ public partial class GameItem
             { "layer", "A text description of the layer this item is currently in" },
             { "isfood", "True if the item is food" },
             { "isliquidcontainer", "True if the item is a liquid container" },
+            { "issealstamp", "True if the item is a seal stamp" },
+            { "issealable", "True if the item can hold a seal impression" },
+            { "issealed", "True if the item currently has an intact seal" },
+            { "sealbroken", "True if the item has had a seal broken" },
+            { "sealresidue", "True if the item has broken seal residue" },
+            { "sealdesign", "The design text of the current or broken seal impression, if any" },
+            { "sealissuer", "The issuer metadata of the current or broken seal impression, if any" },
+            { "sealowner", "The owner metadata of the current or broken seal impression, if any" },
+            { "sealclan", "The clan metadata of the current or broken seal impression, if any" },
+            { "sealoffice", "The office metadata of the current or broken seal impression, if any" },
+            { "sealmaterial", "The stamp material metadata of the current or broken seal impression, if any" },
+            { "sealmedium", "The sealing medium description of the current or broken seal impression, if any" },
+            { "sealingcharacterid", "The ID of the character who applied the current or broken seal impression, if any" },
+            { "ismeasuringinstrument", "True if the item is a measuring instrument" },
+            { "measuringmode", "The measuring mode of the measuring instrument, if any" },
+            { "calibrationbias", "The current deliberate calibration bias in base units or percent depending on calibrationbiasispercent" },
+            { "calibrationbiasispercent", "True if calibrationbias is a percentage rather than a base-unit amount" },
+            { "calibrationdeliberate", "True if the current calibration has a deliberate wrong-measure bias" },
+            { "usessincecalibration", "The number of measurements made since the instrument was last calibrated" },
             { "variables", "Returns a dictionary of variable names and variable values"},
             { "condition", "A value from 0.0 to 1.0 representing the current condition percentage of the item" },
             { "quality", "The quality of the item as a number between 0 (terrible) and 11 (legendary)" },
@@ -354,6 +392,60 @@ public partial class GameItem
                 return new BooleanVariable(IsItemType<IEdible>());
             case "isliquidcontainer":
                 return new BooleanVariable(IsItemType<ILiquidContainer>());
+            case "issealstamp":
+                return new BooleanVariable(IsItemType<ISealStamp>());
+            case "issealable":
+                return new BooleanVariable(IsItemType<ISealable>());
+            case "issealed":
+                return new BooleanVariable(GetItemType<ISealable>()?.IsSealed == true);
+            case "sealbroken":
+                return new BooleanVariable(GetItemType<ISealable>()?.SealBroken == true);
+            case "sealresidue":
+                return new BooleanVariable(GetItemType<ISealable>()?.HasSealResidue == true);
+            case "sealdesign":
+                return GetItemType<ISealable>()?.CurrentSeal is { } sealDesign
+                    ? new TextVariable(sealDesign.SealDesign)
+                    : new NullVariable(ProgVariableTypes.Text);
+            case "sealissuer":
+                return GetItemType<ISealable>()?.CurrentSeal is { } sealIssuer
+                    ? new TextVariable(sealIssuer.IssuerText)
+                    : new NullVariable(ProgVariableTypes.Text);
+            case "sealowner":
+                return GetItemType<ISealable>()?.CurrentSeal is { } sealOwner
+                    ? new TextVariable(sealOwner.OwnerText)
+                    : new NullVariable(ProgVariableTypes.Text);
+            case "sealclan":
+                return GetItemType<ISealable>()?.CurrentSeal is { } sealClan
+                    ? new TextVariable(sealClan.ClanText)
+                    : new NullVariable(ProgVariableTypes.Text);
+            case "sealoffice":
+                return GetItemType<ISealable>()?.CurrentSeal is { } sealOffice
+                    ? new TextVariable(sealOffice.OfficeText)
+                    : new NullVariable(ProgVariableTypes.Text);
+            case "sealmaterial":
+                return GetItemType<ISealable>()?.CurrentSeal is { } sealMaterial
+                    ? new TextVariable(sealMaterial.StampMaterial)
+                    : new NullVariable(ProgVariableTypes.Text);
+            case "sealmedium":
+                return GetItemType<ISealable>()?.CurrentSeal is { } sealMedium
+                    ? new TextVariable(sealMedium.SealMedium)
+                    : new NullVariable(ProgVariableTypes.Text);
+            case "sealingcharacterid":
+                return new NumberVariable(GetItemType<ISealable>()?.CurrentSeal?.SealingCharacterId ?? 0);
+            case "ismeasuringinstrument":
+                return new BooleanVariable(IsItemType<IMeasuringInstrument>());
+            case "measuringmode":
+                return GetItemType<IMeasuringInstrument>() is { } instrumentMode
+                    ? new TextVariable(instrumentMode.Mode.DescribeEnum())
+                    : new NullVariable(ProgVariableTypes.Text);
+            case "calibrationbias":
+                return new NumberVariable(GetItemType<IMeasuringInstrument>()?.CalibrationBias ?? 0.0);
+            case "calibrationbiasispercent":
+                return new BooleanVariable(GetItemType<IMeasuringInstrument>()?.CalibrationBiasIsPercentage == true);
+            case "calibrationdeliberate":
+                return new BooleanVariable(GetItemType<IMeasuringInstrument>()?.HasDeliberateBias == true);
+            case "usessincecalibration":
+                return new NumberVariable(GetItemType<IMeasuringInstrument>()?.UsesSinceCalibration ?? 0);
             case "variables":
                 Dictionary<string, IProgVariable> dict = new(StringComparer.InvariantCultureIgnoreCase);
                 foreach ((ICharacteristicDefinition definition, ICharacteristicValue value) in RawCharacteristics)

--- a/MudSharpCore/GameItems/Prototypes/MeasuringInstrumentGameItemComponentProto.cs
+++ b/MudSharpCore/GameItems/Prototypes/MeasuringInstrumentGameItemComponentProto.cs
@@ -1,0 +1,258 @@
+#nullable enable
+
+using MudSharp.Accounts;
+using MudSharp.Character;
+using MudSharp.Framework;
+using MudSharp.Framework.Revision;
+using MudSharp.Framework.Units;
+using MudSharp.GameItems.Components;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.PerceptionEngine;
+using MudSharp.RPG.Checks;
+using System;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace MudSharp.GameItems.Prototypes;
+
+public class MeasuringInstrumentGameItemComponentProto : GameItemComponentProto, IMeasuringInstrumentPrototype
+{
+	public override string TypeDescription => "MeasuringInstrument";
+
+	public MeasuringInstrumentMode Mode { get; protected set; } = MeasuringInstrumentMode.Weight;
+	public UnitType UnitType => Mode == MeasuringInstrumentMode.Weight ? UnitType.Mass : UnitType.FluidVolume;
+	public double Precision { get; protected set; } = 0.01;
+	public double Capacity { get; protected set; } = 100.0;
+	public double BaseDriftPerUse { get; protected set; } = 0.0005;
+	public double MaximumDrift { get; protected set; } = 0.05;
+	public double MaximumWrongCalibration { get; protected set; } = 0.5;
+	public Difficulty CalibrationInspectionDifficulty { get; protected set; } = Difficulty.Normal;
+
+	protected MeasuringInstrumentGameItemComponentProto(IFuturemud gameworld, IAccount originator) : base(gameworld,
+		originator, "MeasuringInstrument")
+	{
+	}
+
+	protected MeasuringInstrumentGameItemComponentProto(MudSharp.Models.GameItemComponentProto proto,
+		IFuturemud gameworld) : base(proto, gameworld)
+	{
+	}
+
+	protected override void LoadFromXml(XElement root)
+	{
+		Mode = root.Element("Mode")?.Value.TryParseEnum<MeasuringInstrumentMode>(out var mode) == true
+			? mode
+			: MeasuringInstrumentMode.Weight;
+		Precision = double.Parse(root.Element("Precision")?.Value ?? "0.01");
+		Capacity = double.Parse(root.Element("Capacity")?.Value ?? "100.0");
+		BaseDriftPerUse = double.Parse(root.Element("BaseDriftPerUse")?.Value ?? "0.0005");
+		MaximumDrift = double.Parse(root.Element("MaximumDrift")?.Value ?? "0.05");
+		MaximumWrongCalibration = double.Parse(root.Element("MaximumWrongCalibration")?.Value ?? "0.5");
+		CalibrationInspectionDifficulty = (Difficulty)int.Parse(root.Element("CalibrationInspectionDifficulty")?.Value ?? ((int)Difficulty.Normal).ToString());
+	}
+
+	protected override string SaveToXml()
+	{
+		return new XElement("Definition",
+			new XElement("Mode", Mode.ToString()),
+			new XElement("Precision", Precision),
+			new XElement("Capacity", Capacity),
+			new XElement("BaseDriftPerUse", BaseDriftPerUse),
+			new XElement("MaximumDrift", MaximumDrift),
+			new XElement("MaximumWrongCalibration", MaximumWrongCalibration),
+			new XElement("CalibrationInspectionDifficulty", (int)CalibrationInspectionDifficulty)).ToString();
+	}
+
+	public override IGameItemComponent CreateNew(IGameItem parent, ICharacter? loader = null, bool temporary = false)
+	{
+		return new MeasuringInstrumentGameItemComponent(this, parent, temporary);
+	}
+
+	public override IGameItemComponent LoadComponent(MudSharp.Models.GameItemComponent component, IGameItem parent)
+	{
+		return new MeasuringInstrumentGameItemComponent(component, this, parent);
+	}
+
+	public static void RegisterComponentInitialiser(GameItemComponentManager manager)
+	{
+		manager.AddBuilderLoader("measuringinstrument", true,
+			(gameworld, account) => new MeasuringInstrumentGameItemComponentProto(gameworld, account));
+		manager.AddDatabaseLoader("MeasuringInstrument",
+			(proto, gameworld) => new MeasuringInstrumentGameItemComponentProto(proto, gameworld));
+		manager.AddTypeHelpInfo(
+			"MeasuringInstrument",
+			$"Lets an item {"[measure weight or liquid volume]".Colour(Telnet.Yellow)} with calibration drift",
+			BuildingHelpText);
+	}
+
+	public override IEditableRevisableItem CreateNewRevision(ICharacter initiator)
+	{
+		return CreateNewRevision(initiator,
+			(proto, gameworld) => new MeasuringInstrumentGameItemComponentProto(proto, gameworld));
+	}
+
+	private const string BuildingHelpText = @"You can use the following options with this component:
+
+	#3name <name>#0 - sets the name of the component
+	#3desc <desc>#0 - sets the description of the component
+	#3mode weight|fluidvolume#0 - sets what this instrument measures
+	#3precision <amount>#0 - sets the rounding precision
+	#3capacity <amount>#0 - sets the maximum measurable amount
+	#3drift <percent>#0 - sets the drift accumulated per use at standard quality
+	#3maxdrift <percent>#0 - sets the maximum honest drift
+	#3maxwrong <percent>#0 - sets the maximum deliberate wrong-calibration bias
+	#3difficulty <difficulty>#0 - sets the appraise difficulty to inspect calibration";
+
+	public override string ShowBuildingHelp => BuildingHelpText;
+
+	public override bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "mode":
+			case "type":
+				return BuildingCommandMode(actor, command);
+			case "precision":
+			case "rounding":
+				return BuildingCommandPrecision(actor, command);
+			case "capacity":
+			case "cap":
+				return BuildingCommandCapacity(actor, command);
+			case "drift":
+			case "base":
+			case "basedrift":
+				return BuildingCommandDrift(actor, command);
+			case "maxdrift":
+			case "maximumdrift":
+				return BuildingCommandMaximumDrift(actor, command);
+			case "maxwrong":
+			case "maximumwrong":
+			case "wrong":
+				return BuildingCommandMaximumWrong(actor, command);
+			case "difficulty":
+			case "inspect":
+			case "inspection":
+				return BuildingCommandDifficulty(actor, command);
+			default:
+				return base.BuildingCommand(actor, command);
+		}
+	}
+
+	private bool BuildingCommandMode(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !command.SafeRemainingArgument.TryParseEnum<MeasuringInstrumentMode>(out var mode))
+		{
+			actor.OutputHandler.Send($"Which mode should this instrument use? Valid values are {Enum.GetValues<MeasuringInstrumentMode>().Select(x => x.DescribeEnum().ColourName()).ListToString()}.");
+			return false;
+		}
+
+		Mode = mode;
+		Changed = true;
+		actor.OutputHandler.Send($"This instrument will now measure {Mode.DescribeEnum().ColourName()}.");
+		return true;
+	}
+
+	private bool BuildingCommandPrecision(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished ||
+		    !Gameworld.UnitManager.TryGetBaseUnits(command.SafeRemainingArgument, UnitType, actor, out var value) ||
+		    value <= 0.0)
+		{
+			actor.OutputHandler.Send($"What positive {UnitType.DescribeEnum().ColourName()} precision should this instrument round to?");
+			return false;
+		}
+
+		Precision = value;
+		Changed = true;
+		actor.OutputHandler.Send($"This instrument will round measurements to {Gameworld.UnitManager.DescribeExact(Precision, UnitType, actor).ColourValue()}.");
+		return true;
+	}
+
+	private bool BuildingCommandCapacity(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished ||
+		    !Gameworld.UnitManager.TryGetBaseUnits(command.SafeRemainingArgument, UnitType, actor, out var value) ||
+		    value <= 0.0)
+		{
+			actor.OutputHandler.Send($"What positive {UnitType.DescribeEnum().ColourName()} capacity should this instrument have?");
+			return false;
+		}
+
+		Capacity = value;
+		Changed = true;
+		actor.OutputHandler.Send($"This instrument can now measure up to {Gameworld.UnitManager.DescribeExact(Capacity, UnitType, actor).ColourValue()}.");
+		return true;
+	}
+
+	private bool BuildingCommandDrift(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !command.SafeRemainingArgument.TryParsePercentage(actor.Account.Culture, out var value) ||
+		    value < 0.0)
+		{
+			actor.OutputHandler.Send("What non-negative percentage drift should this instrument gain per use at standard quality?");
+			return false;
+		}
+
+		BaseDriftPerUse = value;
+		Changed = true;
+		actor.OutputHandler.Send($"This instrument will drift by {BaseDriftPerUse.ToString("P3", actor).ColourValue()} per use at standard quality.");
+		return true;
+	}
+
+	private bool BuildingCommandMaximumDrift(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !command.SafeRemainingArgument.TryParsePercentage(actor.Account.Culture, out var value) ||
+		    value < 0.0)
+		{
+			actor.OutputHandler.Send("What non-negative maximum honest drift percentage should this instrument have?");
+			return false;
+		}
+
+		MaximumDrift = value;
+		Changed = true;
+		actor.OutputHandler.Send($"This instrument's honest calibration drift is capped at {MaximumDrift.ToString("P3", actor).ColourValue()}.");
+		return true;
+	}
+
+	private bool BuildingCommandMaximumWrong(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !command.SafeRemainingArgument.TryParsePercentage(actor.Account.Culture, out var value) ||
+		    value < 0.0)
+		{
+			actor.OutputHandler.Send("What non-negative maximum deliberate wrong-calibration percentage should this instrument allow?");
+			return false;
+		}
+
+		MaximumWrongCalibration = value;
+		Changed = true;
+		actor.OutputHandler.Send($"This instrument's deliberate wrong calibration is capped at {MaximumWrongCalibration.ToString("P3", actor).ColourValue()}.");
+		return true;
+	}
+
+	private bool BuildingCommandDifficulty(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !CheckExtensions.GetDifficulty(command.SafeRemainingArgument, out var difficulty))
+		{
+			actor.OutputHandler.Send($"What difficulty should it be to inspect calibration? Valid values are {Enum.GetValues<Difficulty>().Select(x => x.Describe().ColourValue()).ListToString()}.");
+			return false;
+		}
+
+		CalibrationInspectionDifficulty = difficulty;
+		Changed = true;
+		actor.OutputHandler.Send($"This component's calibration inspection difficulty is now {CalibrationInspectionDifficulty.DescribeColoured()}.");
+		return true;
+	}
+
+	public override string ComponentDescriptionOLC(ICharacter actor)
+	{
+		return $@"{"MeasuringInstrument Game Item Component".Colour(Telnet.Cyan)} (#{Id.ToString("N0", actor)}r{RevisionNumber.ToString("N0", actor)}, {Name})
+
+Mode: {Mode.DescribeEnum().ColourName()}
+Capacity: {Gameworld.UnitManager.DescribeExact(Capacity, UnitType, actor).ColourValue()}
+Precision: {Gameworld.UnitManager.DescribeExact(Precision, UnitType, actor).ColourValue()}
+Base Drift Per Use: {BaseDriftPerUse.ToString("P3", actor).ColourValue()}
+Maximum Drift: {MaximumDrift.ToString("P3", actor).ColourValue()}
+Maximum Wrong Calibration: {MaximumWrongCalibration.ToString("P3", actor).ColourValue()}
+Calibration Inspection Difficulty: {CalibrationInspectionDifficulty.DescribeColoured()}";
+	}
+}

--- a/MudSharpCore/GameItems/Prototypes/SealStampGameItemComponentProto.cs
+++ b/MudSharpCore/GameItems/Prototypes/SealStampGameItemComponentProto.cs
@@ -1,0 +1,237 @@
+#nullable enable
+
+using MudSharp.Accounts;
+using MudSharp.Character;
+using MudSharp.Framework;
+using MudSharp.Framework.Revision;
+using MudSharp.FutureProg;
+using MudSharp.GameItems.Components;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.PerceptionEngine;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace MudSharp.GameItems.Prototypes;
+
+public class SealStampGameItemComponentProto : GameItemComponentProto, ISealStampPrototype
+{
+	public override string TypeDescription => "SealStamp";
+
+	public string SealDesign { get; protected set; } = "an anonymous seal";
+	public string IssuerText { get; protected set; } = string.Empty;
+	public string OwnerText { get; protected set; } = string.Empty;
+	public string ClanText { get; protected set; } = string.Empty;
+	public string OfficeText { get; protected set; } = string.Empty;
+	public string StampMaterial { get; protected set; } = string.Empty;
+	public Difficulty ForgeryDifficulty { get; protected set; } = Difficulty.Normal;
+	public IFutureProg? AuthorityProg { get; protected set; }
+
+	protected SealStampGameItemComponentProto(IFuturemud gameworld, IAccount originator) : base(gameworld, originator, "SealStamp")
+	{
+	}
+
+	protected SealStampGameItemComponentProto(MudSharp.Models.GameItemComponentProto proto, IFuturemud gameworld) :
+		base(proto, gameworld)
+	{
+	}
+
+	protected override void LoadFromXml(XElement root)
+	{
+		SealDesign = root.Element("SealDesign")?.Value ?? "an anonymous seal";
+		IssuerText = root.Element("IssuerText")?.Value ?? string.Empty;
+		OwnerText = root.Element("OwnerText")?.Value ?? string.Empty;
+		ClanText = root.Element("ClanText")?.Value ?? string.Empty;
+		OfficeText = root.Element("OfficeText")?.Value ?? string.Empty;
+		StampMaterial = root.Element("StampMaterial")?.Value ?? string.Empty;
+		ForgeryDifficulty = (Difficulty)int.Parse(root.Element("ForgeryDifficulty")?.Value ?? ((int)Difficulty.Normal).ToString());
+		AuthorityProg = Gameworld.FutureProgs.Get(long.Parse(root.Element("AuthorityProg")?.Value ?? "0"));
+	}
+
+	protected override string SaveToXml()
+	{
+		return new XElement("Definition",
+			new XElement("SealDesign", new XCData(SealDesign)),
+			new XElement("IssuerText", new XCData(IssuerText)),
+			new XElement("OwnerText", new XCData(OwnerText)),
+			new XElement("ClanText", new XCData(ClanText)),
+			new XElement("OfficeText", new XCData(OfficeText)),
+			new XElement("StampMaterial", new XCData(StampMaterial)),
+			new XElement("ForgeryDifficulty", (int)ForgeryDifficulty),
+			new XElement("AuthorityProg", AuthorityProg?.Id ?? 0L)).ToString();
+	}
+
+	public override IGameItemComponent CreateNew(IGameItem parent, ICharacter? loader = null, bool temporary = false)
+	{
+		return new SealStampGameItemComponent(this, parent, temporary);
+	}
+
+	public override IGameItemComponent LoadComponent(MudSharp.Models.GameItemComponent component, IGameItem parent)
+	{
+		return new SealStampGameItemComponent(component, this, parent);
+	}
+
+	public static void RegisterComponentInitialiser(GameItemComponentManager manager)
+	{
+		manager.AddBuilderLoader("sealstamp", true,
+			(gameworld, account) => new SealStampGameItemComponentProto(gameworld, account));
+		manager.AddDatabaseLoader("SealStamp",
+			(proto, gameworld) => new SealStampGameItemComponentProto(proto, gameworld));
+		manager.AddTypeHelpInfo(
+			"SealStamp",
+			$"Turns an item into a {"[seal stamp]".Colour(Telnet.Yellow)} for sealing sealable items",
+			BuildingHelpText);
+	}
+
+	public override IEditableRevisableItem CreateNewRevision(ICharacter initiator)
+	{
+		return CreateNewRevision(initiator, (proto, gameworld) => new SealStampGameItemComponentProto(proto, gameworld));
+	}
+
+	private const string BuildingHelpText = @"You can use the following options with this component:
+
+	#3name <name>#0 - sets the name of the component
+	#3desc <desc>#0 - sets the description of the component
+	#3design <text>#0 - sets the seal design text
+	#3issuer <text>#0 - sets the issuer metadata
+	#3owner <text>#0 - sets the owner metadata
+	#3clan <text>#0 - sets the clan metadata
+	#3office <text>#0 - sets the office metadata
+	#3material <text>#0 - sets the stamp material metadata
+	#3forgery <difficulty>#0 - sets how hard the seal is to convincingly forge
+	#3prog <prog>|clear#0 - optional boolean prog taking character, target item, stamp item, and optional medium item";
+
+	public override string ShowBuildingHelp => BuildingHelpText;
+
+	public override bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "design":
+				return BuildingCommandText(actor, command, "design", value => SealDesign = value);
+			case "issuer":
+				return BuildingCommandText(actor, command, "issuer metadata", value => IssuerText = value);
+			case "owner":
+				return BuildingCommandText(actor, command, "owner metadata", value => OwnerText = value);
+			case "clan":
+				return BuildingCommandText(actor, command, "clan metadata", value => ClanText = value);
+			case "office":
+				return BuildingCommandText(actor, command, "office metadata", value => OfficeText = value);
+			case "material":
+				return BuildingCommandText(actor, command, "stamp material metadata", value => StampMaterial = value);
+			case "forgery":
+			case "difficulty":
+				return BuildingCommandForgery(actor, command);
+			case "prog":
+			case "authority":
+				return BuildingCommandProg(actor, command);
+			default:
+				return base.BuildingCommand(actor, command);
+		}
+	}
+
+	private bool BuildingCommandText(ICharacter actor, StringStack command, string field, System.Action<string> setter)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send($"What {field} should this seal stamp use?");
+			return false;
+		}
+
+		var text = command.SafeRemainingArgument;
+		setter(text);
+		Changed = true;
+		actor.OutputHandler.Send($"This seal stamp's {field} is now {text.ColourValue()}.");
+		return true;
+	}
+
+	private bool BuildingCommandForgery(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !CheckExtensions.GetDifficulty(command.SafeRemainingArgument, out var difficulty))
+		{
+			actor.OutputHandler.Send($"What difficulty should it be to forge this seal? Valid values are {Enum.GetValues<Difficulty>().Select(x => x.Describe().ColourValue()).ListToString()}.");
+			return false;
+		}
+
+		ForgeryDifficulty = difficulty;
+		Changed = true;
+		actor.OutputHandler.Send($"This seal will now be {ForgeryDifficulty.DescribeColoured()} to forge convincingly.");
+		return true;
+	}
+
+	private bool BuildingCommandProg(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which boolean FutureProg should control whether this stamp can seal something? Use #3clear#0 to remove one.".SubstituteANSIColour());
+			return false;
+		}
+
+		if (command.SafeRemainingArgument.EqualTo("clear"))
+		{
+			AuthorityProg = null;
+			Changed = true;
+			actor.OutputHandler.Send("This seal stamp no longer uses an authority prog.");
+			return true;
+		}
+
+		var prog = new ProgLookupFromBuilderInput(actor, command.SafeRemainingArgument, ProgVariableTypes.Boolean,
+			[
+				ProgVariableTypes.Character,
+				ProgVariableTypes.Item,
+				ProgVariableTypes.Item,
+				ProgVariableTypes.Item
+			]).LookupProg();
+		if (prog is null)
+		{
+			return false;
+		}
+
+		AuthorityProg = prog;
+		Changed = true;
+		actor.OutputHandler.Send($"This seal stamp will now use the {prog.MXPClickableFunctionNameWithId()} prog to control sealing authority.");
+		return true;
+	}
+
+	public bool CanSeal(ICharacter actor, IGameItem stamp, IGameItem target, IGameItem? medium, out string error)
+	{
+		error = string.Empty;
+		if (AuthorityProg is null)
+		{
+			return true;
+		}
+
+		var permitted = AuthorityProg.MatchesParameters([
+			ProgVariableTypes.Character,
+			ProgVariableTypes.Item,
+			ProgVariableTypes.Item,
+			ProgVariableTypes.Item
+		])
+			? AuthorityProg.Execute<bool?>(actor, target, stamp, medium) == true
+			: AuthorityProg.Execute<bool?>(actor, target, stamp) == true;
+
+		if (permitted)
+		{
+			return true;
+		}
+
+		error = $"{stamp.HowSeen(actor, true)} is not authorised to seal {target.HowSeen(actor)}.";
+		return false;
+	}
+
+	public override string ComponentDescriptionOLC(ICharacter actor)
+	{
+		return $@"{"SealStamp Game Item Component".Colour(Telnet.Cyan)} (#{Id.ToString("N0", actor)}r{RevisionNumber.ToString("N0", actor)}, {Name})
+
+Design: {SealDesign.ColourValue()}
+Issuer: {(string.IsNullOrEmpty(IssuerText) ? "None".ColourError() : IssuerText.ColourValue())}
+Owner: {(string.IsNullOrEmpty(OwnerText) ? "None".ColourError() : OwnerText.ColourValue())}
+Clan: {(string.IsNullOrEmpty(ClanText) ? "None".ColourError() : ClanText.ColourValue())}
+Office: {(string.IsNullOrEmpty(OfficeText) ? "None".ColourError() : OfficeText.ColourValue())}
+Material: {(string.IsNullOrEmpty(StampMaterial) ? "Unspecified".ColourError() : StampMaterial.ColourValue())}
+Forgery Difficulty: {ForgeryDifficulty.DescribeColoured()}
+Authority Prog: {(AuthorityProg?.MXPClickableFunctionNameWithId() ?? "None".ColourError())}";
+	}
+}

--- a/MudSharpCore/GameItems/Prototypes/SealableGameItemComponentProto.cs
+++ b/MudSharpCore/GameItems/Prototypes/SealableGameItemComponentProto.cs
@@ -1,0 +1,206 @@
+#nullable enable
+
+using MudSharp.Accounts;
+using MudSharp.Character;
+using MudSharp.Framework;
+using MudSharp.Framework.Revision;
+using MudSharp.GameItems.Components;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.PerceptionEngine;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace MudSharp.GameItems.Prototypes;
+
+public class SealableGameItemComponentProto : GameItemComponentProto, ISealablePrototype
+{
+	private readonly List<string> _allowedMedia = [];
+
+	public override string TypeDescription => "Sealable";
+	public IEnumerable<string> AllowedMedia => _allowedMedia;
+	public Difficulty InspectionDifficulty { get; protected set; } = Difficulty.Normal;
+	public bool BrokenSealLeavesResidue { get; protected set; } = true;
+
+	protected SealableGameItemComponentProto(IFuturemud gameworld, IAccount originator) : base(gameworld, originator, "Sealable")
+	{
+		_allowedMedia.AddRange(["wax", "clay"]);
+	}
+
+	protected SealableGameItemComponentProto(MudSharp.Models.GameItemComponentProto proto, IFuturemud gameworld) :
+		base(proto, gameworld)
+	{
+	}
+
+	protected override void LoadFromXml(XElement root)
+	{
+		_allowedMedia.Clear();
+		_allowedMedia.AddRange(root.Element("AllowedMedia")?.Elements("Medium").Select(x => x.Value) ?? Enumerable.Empty<string>());
+		InspectionDifficulty = (Difficulty)int.Parse(root.Element("InspectionDifficulty")?.Value ?? ((int)Difficulty.Normal).ToString());
+		BrokenSealLeavesResidue = bool.Parse(root.Element("BrokenSealLeavesResidue")?.Value ?? "true");
+	}
+
+	protected override string SaveToXml()
+	{
+		return new XElement("Definition",
+			new XElement("AllowedMedia",
+				from medium in _allowedMedia
+				select new XElement("Medium", new XCData(medium))),
+			new XElement("InspectionDifficulty", (int)InspectionDifficulty),
+			new XElement("BrokenSealLeavesResidue", BrokenSealLeavesResidue)).ToString();
+	}
+
+	public override IGameItemComponent CreateNew(IGameItem parent, ICharacter? loader = null, bool temporary = false)
+	{
+		return new SealableGameItemComponent(this, parent, temporary);
+	}
+
+	public override IGameItemComponent LoadComponent(MudSharp.Models.GameItemComponent component, IGameItem parent)
+	{
+		return new SealableGameItemComponent(component, this, parent);
+	}
+
+	public static void RegisterComponentInitialiser(GameItemComponentManager manager)
+	{
+		manager.AddBuilderLoader("sealable", true,
+			(gameworld, account) => new SealableGameItemComponentProto(gameworld, account));
+		manager.AddDatabaseLoader("Sealable",
+			(proto, gameworld) => new SealableGameItemComponentProto(proto, gameworld));
+		manager.AddTypeHelpInfo(
+			"Sealable",
+			$"Lets an item be {"[sealed]".Colour(Telnet.Yellow)} with a seal stamp for tamper evidence",
+			BuildingHelpText);
+	}
+
+	public override IEditableRevisableItem CreateNewRevision(ICharacter initiator)
+	{
+		return CreateNewRevision(initiator, (proto, gameworld) => new SealableGameItemComponentProto(proto, gameworld));
+	}
+
+	private const string BuildingHelpText = @"You can use the following options with this component:
+
+	#3name <name>#0 - sets the name of the component
+	#3desc <desc>#0 - sets the description of the component
+	#3media add <text>#0 - adds an allowed seal medium keyword, tag, or material name
+	#3media remove <text>#0 - removes an allowed seal medium
+	#3media clear#0 - allows any seal medium
+	#3residue#0 - toggles whether broken seals leave residue
+	#3difficulty <difficulty>#0 - sets the seal inspection difficulty";
+
+	public override string ShowBuildingHelp => BuildingHelpText;
+
+	public override bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "media":
+			case "medium":
+				return BuildingCommandMedia(actor, command);
+			case "residue":
+				return BuildingCommandResidue(actor);
+			case "difficulty":
+			case "inspect":
+			case "inspection":
+				return BuildingCommandDifficulty(actor, command);
+			default:
+				return base.BuildingCommand(actor, command);
+		}
+	}
+
+	private bool BuildingCommandMedia(ICharacter actor, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "add":
+				if (command.IsFinished)
+				{
+					actor.OutputHandler.Send("What medium keyword, tag, or material name do you want to allow?");
+					return false;
+				}
+
+				var text = command.SafeRemainingArgument.ToLowerInvariant();
+				if (!_allowedMedia.Any(x => x.EqualTo(text)))
+				{
+					_allowedMedia.Add(text);
+				}
+
+				Changed = true;
+				actor.OutputHandler.Send($"This component now allows {text.ColourValue()} as a seal medium.");
+				return true;
+			case "remove":
+			case "rem":
+			case "delete":
+			case "del":
+				if (command.IsFinished)
+				{
+					actor.OutputHandler.Send("Which medium do you want to remove?");
+					return false;
+				}
+
+				text = command.SafeRemainingArgument;
+				if (!_allowedMedia.RemoveAll(x => x.EqualTo(text)).Equals(0))
+				{
+					Changed = true;
+					actor.OutputHandler.Send($"This component no longer allows {text.ColourValue()} as a seal medium.");
+					return true;
+				}
+
+				actor.OutputHandler.Send("There was no such allowed medium.");
+				return false;
+			case "clear":
+				_allowedMedia.Clear();
+				Changed = true;
+				actor.OutputHandler.Send("This component now allows any seal medium.");
+				return true;
+			default:
+				actor.OutputHandler.Send($"Allowed media are: {(_allowedMedia.Any() ? _allowedMedia.Select(x => x.ColourValue()).ListToString() : "any".ColourValue())}.");
+				return false;
+		}
+	}
+
+	private bool BuildingCommandResidue(ICharacter actor)
+	{
+		BrokenSealLeavesResidue = !BrokenSealLeavesResidue;
+		Changed = true;
+		actor.OutputHandler.Send($"Broken seals will {(BrokenSealLeavesResidue ? "now" : "no longer")} leave residue.");
+		return true;
+	}
+
+	private bool BuildingCommandDifficulty(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !CheckExtensions.GetDifficulty(command.SafeRemainingArgument, out var difficulty))
+		{
+			actor.OutputHandler.Send($"What difficulty should it be to inspect seals? Valid values are {Enum.GetValues<Difficulty>().Select(x => x.Describe().ColourValue()).ListToString()}.");
+			return false;
+		}
+
+		InspectionDifficulty = difficulty;
+		Changed = true;
+		actor.OutputHandler.Send($"This component's seal inspection difficulty is now {InspectionDifficulty.DescribeColoured()}.");
+		return true;
+	}
+
+	public bool IsAllowedMedium(IGameItem? medium)
+	{
+		if (medium is null || !_allowedMedia.Any())
+		{
+			return true;
+		}
+
+		return _allowedMedia.Any(allowed =>
+			medium.Material?.Name.EqualTo(allowed) == true ||
+			medium.Keywords.Any(keyword => keyword.EqualTo(allowed)) ||
+			medium.Tags.Any(tag => tag.Name.EqualTo(allowed)));
+	}
+
+	public override string ComponentDescriptionOLC(ICharacter actor)
+	{
+		return $@"{"Sealable Game Item Component".Colour(Telnet.Cyan)} (#{Id.ToString("N0", actor)}r{RevisionNumber.ToString("N0", actor)}, {Name})
+
+Allowed Media: {(_allowedMedia.Any() ? _allowedMedia.Select(x => x.ColourValue()).ListToString() : "Any".ColourValue())}
+Inspection Difficulty: {InspectionDifficulty.DescribeColoured()}
+Broken Seals Leave Residue: {BrokenSealLeavesResidue.ToColouredString()}";
+	}
+}


### PR DESCRIPTION
## Summary
- add SealStamp, Sealable, and MeasuringInstrument component families and command/FutureProg integration
- seed utility component prototypes for seal and measurement examples
- add antiquity item prototypes identified by the component gap report and update docs/tests

## Verification
- dotnet build DatabaseSeeder\DatabaseSeeder.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510
- dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510
- dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-build --filter "SeedAntiquityComponentGapCoverageForTesting_RerunDoesNotDuplicateAndSeedsReportComponents|ItemSeeder_AntiquityComponentGapItems_RerunDoesNotDuplicateAndUsesReportComponents"
- dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-build --filter SealAndMeasurementComponentTests
- git diff --check