### PR TITLE
Add votive offering and incense item components

### DIFF
--- a/DatabaseSeeder Unit Tests/UsefulSeederItemPackageTests.cs
+++ b/DatabaseSeeder Unit Tests/UsefulSeederItemPackageTests.cs
@@ -321,6 +321,8 @@ public class UsefulSeederItemPackageTests
 		Assert.IsTrue(UsefulSeeder.StockItemMarkersForTesting.Contains("SealStamp_Antiquity_BronzeSignet"));
 		Assert.IsTrue(UsefulSeeder.StockItemMarkersForTesting.Contains("Sealable_Envelope"));
 		Assert.IsTrue(UsefulSeeder.StockItemMarkersForTesting.Contains("MeasuringInstrument_Antiquity_BalanceScale"));
+		Assert.IsTrue(UsefulSeeder.StockItemMarkersForTesting.Contains("IncenseBurner_Antiquity_BronzeCenser"));
+		Assert.IsTrue(UsefulSeeder.StockItemMarkersForTesting.Contains("OfferingReceiver_Antiquity_HouseholdAltar"));
 
 		context.GameItemComponentProtos.Add(CreateComponentMarker(id++, "Container_Bookcase_Shelves"));
 		context.SaveChanges();
@@ -482,7 +484,11 @@ public class UsefulSeederItemPackageTests
 			"MeasuringInstrument_Antiquity_TaxAssessorKit",
 			"Container_Envelope",
 			"PaperSheet_Envelope",
-			"PaperSheet_Scroll"
+			"PaperSheet_Scroll",
+			"IncenseBurner_Antiquity_BronzeCenser",
+			"OfferingReceiver_Antiquity_HouseholdAltar",
+			"OfferingReceiver_Antiquity_VotiveBasin",
+			"OfferingReceiver_Antiquity_FuneralTray"
 		];
 
 		foreach (string name in expectedNames)
@@ -504,6 +510,14 @@ public class UsefulSeederItemPackageTests
 		                                      .Any(x => (string)x == "wax"));
 		Assert.AreEqual("Weight", (string)Definition("MeasuringInstrument_Antiquity_BalanceScale").Element("Mode")!);
 		Assert.AreEqual("FluidVolume", (string)Definition("MeasuringInstrument_Antiquity_OilCup").Element("Mode")!);
+		Assert.AreEqual(1, (int)Definition("IncenseBurner_Antiquity_BronzeCenser").Element("ScentRange")!);
+		Assert.AreEqual(4, (int)Definition("IncenseBurner_Antiquity_BronzeCenser").Element("ScentDifficulty")!);
+		Assert.IsTrue(Definition("IncenseBurner_Antiquity_BronzeCenser").Element("SourceScentDescription")!.Value
+			.Contains("resinous", StringComparison.OrdinalIgnoreCase));
+		Assert.AreEqual("ManualBurn",
+			(string)Definition("OfferingReceiver_Antiquity_HouseholdAltar").Element("ConsumptionMode")!);
+		Assert.AreEqual("BurnOnOffer",
+			(string)Definition("OfferingReceiver_Antiquity_VotiveBasin").Element("ConsumptionMode")!);
 
 		XElement loadedDie = Definition("Dice_Antiquity_LoadedD6");
 		Assert.AreEqual(6, loadedDie.Element("Faces")!.Elements("Face").Count());
@@ -598,6 +612,24 @@ public class UsefulSeederItemPackageTests
 		GameItemProto measuringRod = LoadItem(context, "antiquity_wooden_measuring_rod");
 		CollectionAssert.DoesNotContain(ComponentNames(measuringRod), "MeasuringInstrument_Antiquity_BalanceScale",
 			"Length measurement is deferred, so the rod should remain a non-measuring prop.");
+
+		GameItemProto censer = LoadItem(context, "antiquity_bronze_incense_censer");
+		CollectionAssert.Contains(ComponentNames(censer), "IncenseBurner_Antiquity_BronzeCenser");
+
+		GameItemProto incense = LoadItem(context, "antiquity_resin_incense_pellets");
+		CollectionAssert.Contains(ComponentNames(incense), "Holdable");
+		Assert.IsTrue(incense.GameItemProtosTags
+		                     .Select(x => context.Tags.Single(tag => tag.Id == x.TagId).Name)
+		                     .Contains("Incense Fuel"));
+
+		GameItemProto altar = LoadItem(context, "antiquity_household_altar");
+		CollectionAssert.Contains(ComponentNames(altar), "OfferingReceiver_Antiquity_HouseholdAltar");
+
+		GameItemProto votiveBasin = LoadItem(context, "antiquity_votive_offering_basin");
+		CollectionAssert.Contains(ComponentNames(votiveBasin), "OfferingReceiver_Antiquity_VotiveBasin");
+
+		GameItemProto funeralTray = LoadItem(context, "antiquity_funeral_offering_tray");
+		CollectionAssert.Contains(ComponentNames(funeralTray), "OfferingReceiver_Antiquity_FuneralTray");
 	}
 
 	[TestMethod]

--- a/DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityComponentGaps.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityComponentGaps.cs
@@ -141,6 +141,7 @@ public partial class ItemSeeder
 		const string SecurityTag = "Functions / Security Tools";
 		const string LeisureTag = "Functions / Household Items / Leisure Goods";
 		const string MedicalTag = "Functions / Medical Items";
+		const string IncenseFuelTag = "Functions / Household Items / Household Religious Items / Incense Fuel";
 
 		return
 		[
@@ -185,6 +186,31 @@ public partial class ItemSeeder
 				"This temple basin is shallow and carefully cleaned, with a smooth stone lip suited to ritual washing before prayer, sacrifice, or official entry.",
 				SizeCategory.Large, ItemQuality.Good, 42000.0, 70.0m, "stone", MaterialBehaviourType.Stone,
 				[ReligiousTag, CivicTag], ["WaterSource_Antiquity_RitualBasin", "Destroyable_Misc"]),
+			new("antiquity_bronze_incense_censer", "censer", "a bronze incense censer",
+				"This pierced bronze censer has a handled bowl and darkened vents for fragrant resin smoke, suited to household shrines, rites, and processions.",
+				SizeCategory.Small, ItemQuality.Good, 850.0, 36.0m, "bronze", MaterialBehaviourType.Metal,
+				[ReligiousTag, MarketTag], ["Holdable", "IncenseBurner_Antiquity_BronzeCenser", "Destroyable_HeavyMetal"],
+				"Burns items tagged as incense fuel, producing room-scale scent text and smell-trackable ambience."),
+			new("antiquity_resin_incense_pellets", "incense", "a packet of resin incense pellets",
+				"This small packet holds hard amber and dark resin pellets, mixed for a sweet aromatic smoke when burned in a censer.",
+				SizeCategory.Tiny, ItemQuality.Standard, 120.0, 12.0m, "resin", MaterialBehaviourType.Plant,
+				[ReligiousTag, IncenseFuelTag], ["Holdable", "Destroyable_Misc"],
+				"Tagged as incense fuel for the bronze incense censer component."),
+			new("antiquity_household_altar", "altar", "a low household altar",
+				"This low stone altar has a smoothed top, shallow soot marks, and enough working surface for small votive gifts, food, tablets, or tokens.",
+				SizeCategory.Large, ItemQuality.Standard, 40000.0, 90.0m, "stone", MaterialBehaviourType.Stone,
+				[ReligiousTag, FurnitureTag], ["OfferingReceiver_Antiquity_HouseholdAltar", "Destroyable_Furniture"],
+				"Receives broad item offerings and supports explicit offering burns; direct liquid libations remain future work."),
+			new("antiquity_votive_offering_basin", "basin", "a bronze votive offering basin",
+				"This bronze basin is smoke-darkened inside, with a low rim and tripod feet for receiving small offerings that are meant to be burned at once.",
+				SizeCategory.Normal, ItemQuality.Standard, 3800.0, 48.0m, "bronze", MaterialBehaviourType.Metal,
+				[ReligiousTag, MarketTag], ["Holdable", "OfferingReceiver_Antiquity_VotiveBasin", "Destroyable_HeavyMetal"],
+				"Burns accepted item offerings immediately on offer; not a poured-liquid libation vessel."),
+			new("antiquity_funeral_offering_tray", "tray", "a wooden funeral offering tray",
+				"This wooden tray has a raised lip, linen cord handles, and faint soot stains from offerings prepared beside a bier or grave.",
+				SizeCategory.Normal, ItemQuality.Standard, 1800.0, 24.0m, "cedar", MaterialBehaviourType.Wood,
+				[ReligiousTag, MedicalTag], ["Holdable", "OfferingReceiver_Antiquity_FuneralTray", "Destroyable_WoodenHeavy"],
+				"Receives funeral offerings for later manual burning; direct liquid libations remain future work."),
 			new("antiquity_irrigation_channel_outlet", "outlet", "an irrigation channel outlet",
 				"This shaped stone outlet guides water from a channel into fields or garden beds, with silt marks and tool-cut edges around its mouth.",
 				SizeCategory.VeryLarge, ItemQuality.Standard, 160000.0, 85.0m, "stone", MaterialBehaviourType.Stone,

--- a/DatabaseSeeder/Seeders/UsefulSeeder.ItemComponents.cs
+++ b/DatabaseSeeder/Seeders/UsefulSeeder.ItemComponents.cs
@@ -221,6 +221,7 @@ public partial class UsefulSeeder
         SeedDice(context, now, dbaccount, ref nextId);
         SeedAdditionalBuilderExamples(context, now, dbaccount, ref nextId);
         SeedSealAndMeasurementComponents(context, now, dbaccount, ref nextId);
+        SeedOfferingAndIncenseComponents(context, now, dbaccount, ref nextId);
         context.SaveChanges();
     }
 
@@ -6476,6 +6477,7 @@ public partial class UsefulSeeder
         SeedRepairKits(context, now, dbaccount, ref nextId);
         SeedAdditionalBuilderExamples(context, now, dbaccount, ref nextId);
         SeedSealAndMeasurementComponents(context, now, dbaccount, ref nextId);
+        SeedOfferingAndIncenseComponents(context, now, dbaccount, ref nextId);
         SeedSmokeables(context, now, dbaccount, ref nextId);
     }
 
@@ -7656,6 +7658,122 @@ public partial class UsefulSeeder
         _ = sealableWaxDocument;
         _ = sealableClayDocument;
         _ = sealableContainer;
+
+        nextId = currentId;
+        context.SaveChanges();
+
+        #endregion
+    }
+
+    private void SeedOfferingAndIncenseComponents(FuturemudDatabaseContext context, DateTime now, Account dbaccount,
+        ref long nextId)
+    {
+        #region Offering Receivers and Incense Burners
+
+        long currentId = nextId;
+
+        GameItemComponentProto UpsertStockComponent(string type, string name, string description, XElement definition)
+        {
+            return UpsertComponent(context, ref currentId, dbaccount, now, type, name, description, definition.ToString());
+        }
+
+        Tag EnsureTagPath(string path)
+        {
+            var parts = path.Split('/', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+            Tag? parent = null;
+            foreach (var part in parts)
+            {
+                long? parentId = parent?.Id;
+                var tag = context.Tags.Local
+                                 .FirstOrDefault(x => x.Name.Equals(part, StringComparison.OrdinalIgnoreCase) &&
+                                                      x.ParentId == parentId) ??
+                          context.Tags
+                                 .AsEnumerable()
+                                 .FirstOrDefault(x => x.Name.Equals(part, StringComparison.OrdinalIgnoreCase) &&
+                                                      x.ParentId == parentId);
+                if (tag is null)
+                {
+                    var existing = context.Tags.Any() ? context.Tags.Max(x => x.Id) : 0L;
+                    var local = context.Tags.Local.Any() ? context.Tags.Local.Max(x => x.Id) : 0L;
+                    tag = new Tag
+                    {
+                        Id = Math.Max(existing, local) + 1L,
+                        Name = part,
+                        Parent = parent,
+                        ParentId = parent?.Id
+                    };
+                    context.Tags.Add(tag);
+                }
+
+                _tags[tag.Name] = tag;
+                parent = tag;
+            }
+
+            return parent!;
+        }
+
+        XElement IncenseBurnerDefinition(Tag fuelTag, double maximumFuelWeight, double secondsPerUnitWeight,
+            int scentRange, string sourceScent, string distantScent, Difficulty scentDifficulty)
+        {
+            return new XElement("Definition",
+                new XElement("FuelTag", fuelTag.Id),
+                new XElement("MaximumFuelWeight", maximumFuelWeight),
+                new XElement("SecondsPerUnitWeight", secondsPerUnitWeight),
+                new XElement("ScentRange", scentRange),
+                new XElement("DrugRange", 0),
+                new XElement("DrugPulseSeconds", 10),
+                new XElement("LingeringMultiplier", 5.0),
+                new XElement("SourceScentDescription", new XCData(sourceScent)),
+                new XElement("DistantScentDescription", new XCData(distantScent)),
+                new XElement("ScentDifficulty", (int)scentDifficulty),
+                new XElement("Drug", 0),
+                new XElement("GramsPerPulse", 0.0));
+        }
+
+        XElement OfferingReceiverDefinition(double maximumContentsWeight, SizeCategory maximumItemSize,
+            string consumptionMode, string acceptEcho, string burnEcho)
+        {
+            return new XElement("Definition",
+                new XElement("AllowedTags"),
+                new XElement("BlockedTags"),
+                new XElement("MaximumContentsWeight", maximumContentsWeight),
+                new XElement("MaximumItemSize", (int)maximumItemSize),
+                new XElement("ConsumptionMode", consumptionMode),
+                new XElement("ResidueItemProto", 0),
+                new XElement("CanOfferProg", 0),
+                new XElement("OnOfferProg", 0),
+                new XElement("OnBurnProg", 0),
+                new XElement("AcceptEcho", new XCData(acceptEcho)),
+                new XElement("BurnEcho", new XCData(burnEcho)),
+                new XElement("RejectEcho", new XCData("$2 rejects $1.")));
+        }
+
+        Tag incenseFuelTag = EnsureTagPath("Functions / Household Items / Household Religious Items / Incense Fuel");
+
+        UpsertStockComponent("IncenseBurner", "IncenseBurner_Antiquity_BronzeCenser",
+            "Turns an item into a bronze censer that burns tagged incense fuel into room-scale ambient scent.",
+            IncenseBurnerDefinition(incenseFuelTag, 750.0, 45.0, 1,
+                "Sweet resinous smoke curls from $0.",
+                "A faint sweet resinous smoke drifts in from nearby.",
+                Difficulty.Easy));
+
+        UpsertStockComponent("OfferingReceiver", "OfferingReceiver_Antiquity_HouseholdAltar",
+            "Turns an item into a household altar that receives broad offerings and supports explicit burning.",
+            OfferingReceiverDefinition(50000.0, SizeCategory.VeryLarge, "ManualBurn",
+                "@ place|places $1 on $2 as an offering.",
+                "@ consign|consigns $1 to the flames on $2."));
+
+        UpsertStockComponent("OfferingReceiver", "OfferingReceiver_Antiquity_VotiveBasin",
+            "Turns an item into a votive basin that burns offerings immediately when offered.",
+            OfferingReceiverDefinition(15000.0, SizeCategory.Normal, "BurnOnOffer",
+                "@ lay|lays $1 in $2 as a votive offering.",
+                "@ burn|burns $1 in $2 as a votive offering."));
+
+        UpsertStockComponent("OfferingReceiver", "OfferingReceiver_Antiquity_FuneralTray",
+            "Turns an item into a funeral offering tray that can hold and ritually burn broad item offerings.",
+            OfferingReceiverDefinition(25000.0, SizeCategory.Large, "ManualBurn",
+                "@ arrange|arranges $1 on $2 as a funeral offering.",
+                "@ burn|burns $1 on $2 as a funeral offering."));
 
         nextId = currentId;
         context.SaveChanges();

--- a/DatabaseSeeder/Seeders/UsefulSeeder.cs
+++ b/DatabaseSeeder/Seeders/UsefulSeeder.cs
@@ -66,7 +66,9 @@ public partial class UsefulSeeder : IDatabaseSeeder
         "MarketGoodWeight_Antiquity_StapleFood",
         "SealStamp_Antiquity_BronzeSignet",
         "Sealable_Envelope",
-        "MeasuringInstrument_Antiquity_BalanceScale"
+        "MeasuringInstrument_Antiquity_BalanceScale",
+        "IncenseBurner_Antiquity_BronzeCenser",
+        "OfferingReceiver_Antiquity_HouseholdAltar"
     ];
 
     private static readonly string[] StockModernItemMarkers =

--- a/Design Documents/Crafting/Antiquity_Item_Component_Gap_Report.md
+++ b/Design Documents/Crafting/Antiquity_Item_Component_Gap_Report.md
@@ -366,29 +366,40 @@ Items enabled:
 - `antiquity_temple_divination_board`
 - `antiquity_tavern_game_set`
 
-### Offering and Ritual Focus Component
+### Offering Receiver and Incense Burner Components
 
-Missing functionality:
+Implemented V1 functionality:
 
-- offerings that are consumed, counted, accepted, rejected, spoiled, or recorded.
-- altars, censers, lamps, and libation tables that do more than hold items.
-- ritual state that FutureProgs, NPCs, clans, laws, or magic systems can inspect.
+- `IncenseBurner` is a lightable transparent container for tagged incense fuel. It burns contained fuel by weight, emits room LOOK scent text, spreads ambient scent to nearby cells, and exposes scent metadata to the `tracks` command without creating movement tracks.
+- `OfferingReceiver` is a transparent/open ritual focus that accepts broad item offerings, optionally gates them by tags, supports `offer <item> at <focus>` and `burn <item> at <focus>`, consumes burned offerings by default, and can create configured residue in later prototype variants.
+- `OfferingReceiver` runs `CanOfferProg`, `OnOfferProg`, and `OnBurnProg` with `(Character actor, Item focus, Item offering)`.
+- The event stream now exposes `OfferingReceived`, `OfferingReceivedWitness`, `OfferingBurned`, and `OfferingBurnedWitness`, with payloads `(focus, actor, offering)` and `(focus, actor, offering, witness)`.
 
-Rough component guidance:
+Still missing or deferred:
 
-- Component type names: `OfferingReceiver` and optionally `RitualFocus`.
-- Prototype settings: accepted item tags/materials/liquids, consumption behaviour, required actor checks, accepted-offering echo, rejected-offering echo, optional cooldown, optional owner clan/religion/cult metadata.
-- Runtime commands: `offer <item> at <focus>`, `pour <liquid> as offering`, `light incense at <focus>`, or reuse existing put/pour commands with component interception.
-- FutureProg hooks should read recent offerings, actor, accepted item, quantity, and focus identity.
+- Direct poured-liquid libations are not implemented in this pass. Use item/commodity offerings for V1; liquid-only rows remain future work until a `pour`/liquid offering path exists.
+- Ritual ownership metadata, offering history queries, spoilage counters, cooldowns, and law/clan/religion integrations remain future custom systems layered through progs/events.
+- Oil lamps remain under the ordinary lighting/smokeable/heater families unless a later ritual-lamp component is required.
+
+Seeded support:
+
+- `IncenseBurner_Antiquity_BronzeCenser`
+- `OfferingReceiver_Antiquity_HouseholdAltar`
+- `OfferingReceiver_Antiquity_VotiveBasin`
+- `OfferingReceiver_Antiquity_FuneralTray`
 
 Items enabled:
 
-- `antiquity_stone_household_altar`
-- `antiquity_temple_libation_table`
 - `antiquity_bronze_incense_censer`
-- `antiquity_votive_figurine_basin`
-- `antiquity_oil_lamp_shrine`
+- `antiquity_resin_incense_pellets`
+- `antiquity_household_altar`
+- `antiquity_votive_offering_basin`
 - `antiquity_funeral_offering_tray`
+
+Future liquid-only or specialised ritual rows:
+
+- `antiquity_temple_libation_table`
+- `antiquity_oil_lamp_shrine`
 - `antiquity_oracular_tripod`
 - `antiquity_blood_offering_bowl`
 
@@ -424,5 +435,5 @@ Items enabled:
 1. Add data-only items that use existing components cleanly: dice, lockpicks, drag aids, notice boards, and a first water-source set.
 2. Completed in `UsefulSeeder`: antiquity-specific component prototypes for `TimePiece`, `WaterSource`, `DragAid`, `Dice`, `Locksmithing Tool`, `ShopStall`, `MarketGoodWeight`, `SealStamp`, `Sealable`, and `MeasuringInstrument`.
 3. Add matching item prototypes that use those new component prototypes and update this document with the shipped names.
-4. Choose one new runtime component family for a first deeper gameplay pass. `Instrument` is the best first candidate because it is socially important, highly visible in roleplay, and relatively self-contained.
-5. Treat `OfferingReceiver` as the next most setting-defining component family. `SealStamp`/`Sealable` and the weight/fluid-volume portion of `MeasuringInstrument` are now implemented; length measurement remains a future item-dimension pass.
+4. `IncenseBurner` and `OfferingReceiver` now cover the first ritual-offering gameplay pass, including smell-trackable incense and item-offering burn hooks.
+5. Treat direct liquid libations, ritual ownership/history, and specialised oracular/funeral law integrations as later passes. `SealStamp`/`Sealable` and the weight/fluid-volume portion of `MeasuringInstrument` are implemented; length measurement remains a future item-dimension pass.

--- a/Design Documents/Items/Item_System_Component_Authoring.md
+++ b/Design Documents/Items/Item_System_Component_Authoring.md
@@ -149,6 +149,14 @@ Use `Sealable` as a separate attachable component rather than folding seal state
 
 Use `MeasuringInstrument` for physical measurement tools that should produce falsifiable reported quantities. The current implementation supports `Weight` and `FluidVolume` modes. Length, cubit, and surveying tools should remain prop-only until item dimensions exist. The prototype stores mode, precision, capacity, base drift per use, display unit text, and wrong-calibration limits. The live component stores stable drift direction, use count since calibration, calibration state, and any deliberate base-unit or percentage bias.
 
+### Incense and offering components
+
+Use `IncenseBurner` for room-scale aromatic burning rather than handheld smoking items. The prototype stores the required fuel tag, maximum contained fuel weight, seconds burned per unit of fuel weight, scent range, lingering multiplier, source and distant scent text, scent tracking difficulty, and optional inhaled drug pulse settings. The runtime component is its own transparent `IContainer` and an `ILightable`; builders load fuel with ordinary `put`, start it with `light`, and stop it with `extinguish`. Scent text appears through ambient description effects and can be discovered by smell checks in `tracks`.
+
+Use `OfferingReceiver` for altars, votive basins, funeral trays, and similar ritual foci that receive item offerings. The prototype stores optional allowed and blocked offering tags, capacity, maximum item size, consumption mode (`ManualBurn`, `BurnOnOffer`, or `RecordOnly`), optional residue item prototype, `CanOfferProg`, `OnOfferProg`, `OnBurnProg`, and accepted/rejected/burn emotes. The runtime component is also its own transparent `IContainer`, so ordinary `put` and `take` still work, while `offer <item> at <focus>` and `burn <item> at <focus>` provide ritual-aware workflows.
+
+`CanOfferProg`, `OnOfferProg`, and `OnBurnProg` all receive `(Character actor, Item focus, Item offering)`. `OfferingReceiver` also raises `OfferingReceived`, `OfferingReceivedWitness`, `OfferingBurned`, and `OfferingBurnedWitness`; witness events append the witnessing perceivable to the payload. V1 supports item and commodity offerings. Direct poured-liquid libations need a later liquid-specific command path rather than pretending that an item receiver can consume free liquid.
+
 ### Readable book components
 Books remain one component family rather than splitting blank books and published books into separate component types. `BookGameItemComponentProto` owns reusable authored defaults, while `BookGameItemComponent` owns live page state, torn pages, current page, title, and the actual readable rows attached to each loaded item.
 

--- a/Design Documents/Items/Item_System_Content_Workflows.md
+++ b/Design Documents/Items/Item_System_Content_Workflows.md
@@ -67,7 +67,13 @@ Power, telecom, and modern medical examples also include:
 - `comp edit new defibrillator`
 - `comp edit new externalorgan`
 
+Ritual-offering examples include:
+- `comp edit new incenseburner`
+- `comp edit new offeringreceiver`
+
 `UsefulSeeder` now ships stock component examples across those modern families, including lithium batteries, cellular devices, answering-machine tapes, computer/network gear, signal automation, gas containers, rebreathers, inhalers, defibrillators, and external-organ support machines. Its general item package also includes a broad furniture-container catalogue for tables, shelves, bookcases, racks, stands, cabinets, wardrobes, trunks, drawers, counters, bins, beds and display cases, size-labelled door, gate, glass-door, and locking-door component presets for door items intended to match exit `DoorSize` values from `Tiny` through `Gigantic`, and Skill-Package-aware `WornTraitChanger` presets for worn stealth, movement, dexterity, sight, hearing, and athletic bonuses or penalties; the item prototype size itself must still be set on the item. Food presets now have two stock surfaces: `CookingSeeder` installs general `PreparedFood` examples for direct load, forageable stock, stackable servings, and cooking recipe products, while the antiquity food pass keeps its prepared-food prototypes, liquids, vessels, tools, commodity tags, spoilage rules, and crafts in `ItemSeeder` partials so it can consume `AnimalButcherySeeder` outputs without duplicating them. `AnimalButcherySeeder` installs raw butchery output item prototypes for stock animal and beast-only mythical race profiles. Those outputs are non-edible props by default, use simple held, destroyable, stackable composition, and are tagged for raw meat cuts, raw hides, offal, trophies, venom organs, and crafting animal products. Soft organic outputs morph into the generic rotten-meat prototype, while durable hard products such as bone, tusk, horn, chitin, shell, feather, scale, tooth, beak, claw, and antler remain stable crafting materials. Fax-machine examples and breathing-filter cartridge ecosystems remain later dedicated content passes.
+
+`UsefulSeeder` also ships antiquity ritual examples: `IncenseBurner_Antiquity_BronzeCenser`, `OfferingReceiver_Antiquity_HouseholdAltar`, `OfferingReceiver_Antiquity_VotiveBasin`, and `OfferingReceiver_Antiquity_FuneralTray`. Pair the censer with items tagged `Functions / Household Items / Household Religious Items / Incense Fuel`; the seeded `antiquity_resin_incense_pellets` item is the stock test fuel.
 
 Prepared-food examples include:
 - `comp edit new preparedfood`
@@ -199,6 +205,17 @@ For telecommunications content, also validate:
 - whether dialling the hosted voicemail access number from the subscribed line announces mailbox counts, plays message contents, and honours keypad deletion commands
 - whether `dial <phone> <digits>` starts a call while idle and sends keypad digits once the call is already connected
 - whether keypad-driven targets receive `TelephoneDigitsReceived` with the expected source item and digit string
+
+For incense and offering content, validate:
+- ordinary `put` and `take` against the component's transparent container behaviour
+- `put <fuel> in <censer>`, `light <censer>`, source-room LOOK scent text, adjacent-room distant scent text, and `extinguish <censer>`
+- `tracks` smell discoveries for ambient scent, confirming that scent trails are listed separately from movement tracks
+- optional inhaled drug dosing only when the incense burner prototype explicitly configures a drug, dose, pulse, and drug range
+- `offer <item> at <focus>` for accepted and rejected offerings
+- `burn <item> at <focus>` for contained offerings, including default consumption and optional residue prototype replacement
+- `CanOfferProg`, `OnOfferProg`, and `OnBurnProg` with `(Character actor, Item focus, Item offering)`
+- `OfferingReceived`, `OfferingReceivedWitness`, `OfferingBurned`, and `OfferingBurnedWitness` event dispatch for downstream customisation
+- that direct free-liquid libations remain unsupported unless a later liquid-specific ritual component is added
 
 For the current signal-automation slice, also validate:
 - whether `computerhost` correctly tracks its powered state, mounted storage devices, terminal connections, network adapters, files, and stored executables

--- a/FutureMUDLibrary Unit Tests/EventTypeMetadataTests.cs
+++ b/FutureMUDLibrary Unit Tests/EventTypeMetadataTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MudSharp.Events;
 using MudSharp.Framework;
+using MudSharp.FutureProg;
 using System;
 using System.Linq;
 
@@ -38,5 +39,35 @@ public class EventTypeMetadataTests
             Assert.IsFalse(parameters.Any(x => string.IsNullOrWhiteSpace(x.name)),
                 $"{eventType} has a blank parameter name.");
         }
+    }
+
+    [TestMethod]
+    public void OfferingEventTypes_DefineExpectedHookPayloads()
+    {
+        AssertEventMetadata(EventType.OfferingReceived,
+            new[] { "item", "character", "item" },
+            new[] { "focus", "actor", "offering" },
+            new[] { ProgVariableTypes.Item, ProgVariableTypes.Character, ProgVariableTypes.Item });
+        AssertEventMetadata(EventType.OfferingReceivedWitness,
+            new[] { "item", "character", "item", "perceivable" },
+            new[] { "focus", "actor", "offering", "witness" },
+            new[] { ProgVariableTypes.Item, ProgVariableTypes.Character, ProgVariableTypes.Item, ProgVariableTypes.Perceivable });
+        AssertEventMetadata(EventType.OfferingBurned,
+            new[] { "item", "character", "item" },
+            new[] { "focus", "actor", "offering" },
+            new[] { ProgVariableTypes.Item, ProgVariableTypes.Character, ProgVariableTypes.Item });
+        AssertEventMetadata(EventType.OfferingBurnedWitness,
+            new[] { "item", "character", "item", "perceivable" },
+            new[] { "focus", "actor", "offering", "witness" },
+            new[] { ProgVariableTypes.Item, ProgVariableTypes.Character, ProgVariableTypes.Item, ProgVariableTypes.Perceivable });
+    }
+
+    private static void AssertEventMetadata(EventType eventType, string[] parameterTypes, string[] parameterNames,
+        ProgVariableTypes[] progTypes)
+    {
+        EventInfoAttribute info = eventType.GetAttribute<EventInfoAttribute>();
+        CollectionAssert.AreEqual(parameterTypes, info.Parameters.Select(x => x.type).ToArray());
+        CollectionAssert.AreEqual(parameterNames, info.Parameters.Select(x => x.name).ToArray());
+        CollectionAssert.AreEqual(progTypes, info.ProgTypes.ToArray());
     }
 }

--- a/FutureMUDLibrary/Effects/Interfaces/IScentTrailEffect.cs
+++ b/FutureMUDLibrary/Effects/Interfaces/IScentTrailEffect.cs
@@ -1,0 +1,17 @@
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.RPG.Checks;
+
+#nullable enable
+
+namespace MudSharp.Effects.Interfaces;
+
+public interface IScentTrailEffect : IDescriptionAdditionEffect
+{
+	long SourceItemId { get; }
+	string SourceDescription { get; }
+	RoomLayer RoomLayer { get; }
+	int Distance { get; }
+	Difficulty ScentDifficulty(ICharacter actor);
+	string DescribeForTracksCommand(ICharacter actor);
+}

--- a/FutureMUDLibrary/Events/EventTypeEnum.cs
+++ b/FutureMUDLibrary/Events/EventTypeEnum.cs
@@ -687,6 +687,18 @@ namespace MudSharp.Events
         ItemUnlocked = 123,
 
         [EventInfo("Fires on perceivables witnessing a lock item being unlocked. Actor and key may be null.", ["item", "character", "item", "perceivable", "perceivable"], ["lock", "actor", "key", "target", "witness"], [ProgVariableTypeCode.Item, ProgVariableTypeCode.Character, ProgVariableTypeCode.Item, ProgVariableTypeCode.Perceivable, ProgVariableTypeCode.Perceivable])]
-        ItemUnlockedWitness = 124
+        ItemUnlockedWitness = 124,
+
+        [EventInfo("Fires on an offering focus when it receives an offering.", ["item", "character", "item"], ["focus", "actor", "offering"], [ProgVariableTypeCode.Item, ProgVariableTypeCode.Character, ProgVariableTypeCode.Item])]
+        OfferingReceived = 125,
+
+        [EventInfo("Fires on perceivables witnessing an offering focus receiving an offering.", ["item", "character", "item", "perceivable"], ["focus", "actor", "offering", "witness"], [ProgVariableTypeCode.Item, ProgVariableTypeCode.Character, ProgVariableTypeCode.Item, ProgVariableTypeCode.Perceivable])]
+        OfferingReceivedWitness = 126,
+
+        [EventInfo("Fires on an offering focus when one of its offerings is burned.", ["item", "character", "item"], ["focus", "actor", "offering"], [ProgVariableTypeCode.Item, ProgVariableTypeCode.Character, ProgVariableTypeCode.Item])]
+        OfferingBurned = 127,
+
+        [EventInfo("Fires on perceivables witnessing an offering focus burning an offering.", ["item", "character", "item", "perceivable"], ["focus", "actor", "offering", "witness"], [ProgVariableTypeCode.Item, ProgVariableTypeCode.Character, ProgVariableTypeCode.Item, ProgVariableTypeCode.Perceivable])]
+        OfferingBurnedWitness = 128
     }
 }

--- a/FutureMUDLibrary/GameItems/Interfaces/IIncenseBurner.cs
+++ b/FutureMUDLibrary/GameItems/Interfaces/IIncenseBurner.cs
@@ -1,0 +1,12 @@
+using MudSharp.Character;
+
+#nullable enable
+
+namespace MudSharp.GameItems.Interfaces;
+
+public interface IIncenseBurner : ILightable, IContainer
+{
+	bool HasFuel { get; }
+	int ScentRange { get; }
+	void RefreshScentEffects(int seconds);
+}

--- a/FutureMUDLibrary/GameItems/Interfaces/IOfferingReceiver.cs
+++ b/FutureMUDLibrary/GameItems/Interfaces/IOfferingReceiver.cs
@@ -1,0 +1,25 @@
+using MudSharp.Character;
+using MudSharp.Framework;
+using MudSharp.PerceptionEngine;
+
+#nullable enable
+
+namespace MudSharp.GameItems.Interfaces;
+
+public enum OfferingConsumptionMode
+{
+	ManualBurn = 0,
+	BurnOnOffer = 1,
+	RecordOnly = 2
+}
+
+public interface IOfferingReceiver : IContainer
+{
+	OfferingConsumptionMode ConsumptionMode { get; }
+	bool CanOffer(ICharacter actor, IGameItem offering);
+	string WhyCannotOffer(ICharacter actor, IGameItem offering);
+	bool Offer(ICharacter actor, IGameItem offering, IEmote? playerEmote);
+	bool CanBurnOffering(ICharacter actor, IGameItem offering);
+	string WhyCannotBurnOffering(ICharacter actor, IGameItem offering);
+	bool BurnOffering(ICharacter actor, IGameItem offering, IEmote? playerEmote);
+}

--- a/FutureMUDLibrary/GameItems/Prototypes/GameItemComponentPrototypeInterfaces.cs
+++ b/FutureMUDLibrary/GameItems/Prototypes/GameItemComponentPrototypeInterfaces.cs
@@ -273,6 +273,10 @@ public interface IInjectPrototype : IExclusiveGameItemComponentPrototype<IInject
 {
 }
 
+public interface IIncenseBurnerPrototype : IExclusiveGameItemComponentPrototype<IIncenseBurner>, ILightablePrototype, IContainerPrototype
+{
+}
+
 public interface IInsertablePrototype : IExclusiveGameItemComponentPrototype<IInsertable>
 {
 }
@@ -354,6 +358,10 @@ public interface IObscureCharacteristicsPrototype : IExclusiveGameItemComponentP
 }
 
 public interface IObscureIdentityPrototype : IExclusiveGameItemComponentPrototype<IObscureIdentity>, IObscureCharacteristicsPrototype
+{
+}
+
+public interface IOfferingReceiverPrototype : IExclusiveGameItemComponentPrototype<IOfferingReceiver>, IContainerPrototype
 {
 }
 

--- a/MudSharpCore Unit Tests/SealAndMeasurementComponentTests.cs
+++ b/MudSharpCore Unit Tests/SealAndMeasurementComponentTests.cs
@@ -5,6 +5,10 @@ using Moq;
 using MudSharp.Accounts;
 using MudSharp.Character;
 using MudSharp.Commands.Modules;
+using MudSharp.Construction;
+using MudSharp.Effects;
+using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
 using MudSharp.Form.Material;
 using MudSharp.Form.Shape;
 using MudSharp.Framework;
@@ -16,6 +20,8 @@ using MudSharp.GameItems;
 using MudSharp.GameItems.Components;
 using MudSharp.GameItems.Interfaces;
 using MudSharp.GameItems.Prototypes;
+using MudSharp.Health;
+using MudSharp.Movement;
 using MudSharp.PerceptionEngine;
 using MudSharp.RPG.Checks;
 using System;
@@ -43,9 +49,13 @@ public class SealAndMeasurementComponentTests
 		CollectionAssert.Contains(primaryTypes, "sealstamp");
 		CollectionAssert.Contains(primaryTypes, "sealable");
 		CollectionAssert.Contains(primaryTypes, "measuringinstrument");
+		CollectionAssert.Contains(primaryTypes, "incenseburner");
+		CollectionAssert.Contains(primaryTypes, "offeringreceiver");
 		CollectionAssert.Contains(helpTypes, "SealStamp");
 		CollectionAssert.Contains(helpTypes, "Sealable");
 		CollectionAssert.Contains(helpTypes, "MeasuringInstrument");
+		CollectionAssert.Contains(helpTypes, "IncenseBurner");
+		CollectionAssert.Contains(helpTypes, "OfferingReceiver");
 	}
 
 	[TestMethod]
@@ -57,10 +67,58 @@ public class SealAndMeasurementComponentTests
 		               .OfType<PlayerCommand>()
 		               .ToDictionary(x => x.Name, StringComparer.OrdinalIgnoreCase);
 
-		foreach (var name in new[] { "Seal", "Break", "Inspect", "Compare", "Weigh", "Measure", "Calibrate" })
+		foreach (var name in new[] { "Seal", "Break", "Inspect", "Compare", "Weigh", "Measure", "Calibrate", "Offer", "Burn" })
 		{
 			Assert.IsTrue(commands.ContainsKey(name), $"Expected {name} command to be registered.");
 		}
+	}
+
+	[TestMethod]
+	public void IncenseAndOfferingPrototypes_LoadSaveAndExposeInterfaces()
+	{
+		var fuelTag = CreateTag(55L, "Incense Fuel");
+		var gameworld = CreateGameworld(fuelTag.Object);
+		var incenseProto = CreateIncenseProto(gameworld.Object, fuelTag.Object.Id);
+		var offeringProto = CreateOfferingProto(gameworld.Object);
+		var incense = incenseProto.CreateNew(CreateParent(gameworld.Object, 60L, "censer").Object, temporary: true);
+		var offering = offeringProto.CreateNew(CreateParent(gameworld.Object, 61L, "altar").Object, temporary: true);
+
+		Assert.IsInstanceOfType(incenseProto, typeof(IIncenseBurnerPrototype));
+		Assert.IsInstanceOfType(offeringProto, typeof(IOfferingReceiverPrototype));
+		Assert.AreSame(fuelTag.Object, incenseProto.FuelTag);
+		Assert.AreEqual(1, incenseProto.ScentRange);
+		Assert.AreEqual(OfferingConsumptionMode.BurnOnOffer, offeringProto.ConsumptionMode);
+		Assert.AreEqual(SizeCategory.Normal, offeringProto.MaximumItemSize);
+
+		Assert.IsInstanceOfType(incense, typeof(IIncenseBurner));
+		Assert.IsInstanceOfType(incense, typeof(ILightable));
+		Assert.IsInstanceOfType(incense, typeof(IContainer));
+		Assert.IsInstanceOfType(offering, typeof(IOfferingReceiver));
+		Assert.IsInstanceOfType(offering, typeof(IContainer));
+
+		StringAssert.Contains(InvokeSaveToXml(incenseProto), "<FuelTag>55</FuelTag>");
+		StringAssert.Contains(InvokeSaveToXml(offeringProto), "<ConsumptionMode>BurnOnOffer</ConsumptionMode>");
+		StringAssert.Contains(InvokeSaveToXml((GameItemComponent)incense), "<Lit>false</Lit>");
+		StringAssert.Contains(InvokeSaveToXml((GameItemComponent)offering), "<Definition");
+	}
+
+	[TestMethod]
+	public void AmbientScent_IsTrackableScentMetadataNotMovementTrack()
+	{
+		var gameworld = CreateGameworld();
+		var owner = new Mock<IPerceivable>();
+		owner.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		var actor = CreateActor(gameworld.Object, 70L);
+		var scent = new AmbientScent(owner.Object, 99L, "a bronze censer",
+			"Sweet resinous smoke lingers here.", RoomLayer.GroundLevel, 1, Difficulty.Easy);
+
+		Assert.IsInstanceOfType(scent, typeof(IScentTrailEffect));
+		Assert.IsFalse(scent is ITrack, "Ambient scents should augment tracks output without becoming movement tracks.");
+		Assert.AreEqual(99L, scent.SourceItemId);
+		Assert.AreEqual(RoomLayer.GroundLevel, scent.RoomLayer);
+		Assert.AreEqual(Difficulty.Easy, scent.ScentDifficulty(actor.Object));
+		StringAssert.Contains(scent.DescribeForTracksCommand(actor.Object), "bronze censer");
+		StringAssert.Contains(scent.SaveToXml(new Dictionary<IEffect, TimeSpan>()).ToString(), "AmbientScent");
 	}
 
 	[TestMethod]
@@ -223,6 +281,58 @@ public class SealAndMeasurementComponentTests
 			CultureInfo.InvariantCulture)!;
 	}
 
+	private static IncenseBurnerGameItemComponentProto CreateIncenseProto(IFuturemud gameworld, long fuelTagId)
+	{
+		return (IncenseBurnerGameItemComponentProto)Activator.CreateInstance(
+			typeof(IncenseBurnerGameItemComponentProto),
+			BindingFlags.Instance | BindingFlags.NonPublic,
+			null,
+			new object[]
+			{
+				ComponentProtoModel(103, "IncenseBurner", new XElement("Definition",
+					new XElement("FuelTag", fuelTagId),
+					new XElement("MaximumFuelWeight", 750.0),
+					new XElement("SecondsPerUnitWeight", 45.0),
+					new XElement("ScentRange", 1),
+					new XElement("DrugRange", 0),
+					new XElement("DrugPulseSeconds", 10),
+					new XElement("LingeringMultiplier", 5.0),
+					new XElement("SourceScentDescription", new XCData("Sweet resinous smoke curls from $0.")),
+					new XElement("DistantScentDescription", new XCData("A faint sweet smoke drifts in from nearby.")),
+					new XElement("ScentDifficulty", (int)Difficulty.Easy),
+					new XElement("Drug", 0),
+					new XElement("GramsPerPulse", 0.0)).ToString()),
+				gameworld
+			},
+			CultureInfo.InvariantCulture)!;
+	}
+
+	private static OfferingReceiverGameItemComponentProto CreateOfferingProto(IFuturemud gameworld)
+	{
+		return (OfferingReceiverGameItemComponentProto)Activator.CreateInstance(
+			typeof(OfferingReceiverGameItemComponentProto),
+			BindingFlags.Instance | BindingFlags.NonPublic,
+			null,
+			new object[]
+			{
+				ComponentProtoModel(104, "OfferingReceiver", new XElement("Definition",
+					new XElement("AllowedTags"),
+					new XElement("BlockedTags"),
+					new XElement("MaximumContentsWeight", 15000.0),
+					new XElement("MaximumItemSize", (int)SizeCategory.Normal),
+					new XElement("ConsumptionMode", "BurnOnOffer"),
+					new XElement("ResidueItemProto", 0),
+					new XElement("CanOfferProg", 0),
+					new XElement("OnOfferProg", 0),
+					new XElement("OnBurnProg", 0),
+					new XElement("AcceptEcho", new XCData("@ lay|lays $1 in $2.")),
+					new XElement("BurnEcho", new XCData("@ burn|burns $1 in $2.")),
+					new XElement("RejectEcho", new XCData("$2 rejects $1."))).ToString()),
+				gameworld
+			},
+			CultureInfo.InvariantCulture)!;
+	}
+
 	private static DbGameItemComponentProto ComponentProtoModel(long id, string type, string definition)
 	{
 		return new DbGameItemComponentProto
@@ -249,6 +359,13 @@ public class SealAndMeasurementComponentTests
 		return (string)component.GetType()
 		                .GetMethod("SaveToXml", BindingFlags.Instance | BindingFlags.NonPublic)!
 		                .Invoke(component, Array.Empty<object>())!;
+	}
+
+	private static string InvokeSaveToXml(GameItemComponentProto proto)
+	{
+		return (string)proto.GetType()
+		                    .GetMethod("SaveToXml", BindingFlags.Instance | BindingFlags.NonPublic)!
+		                    .Invoke(proto, Array.Empty<object>())!;
 	}
 
 	private static Mock<IGameItem> CreateParent(IFuturemud gameworld, long id, string seen, double weight = 0.0,
@@ -290,7 +407,17 @@ public class SealAndMeasurementComponentTests
 		return actor;
 	}
 
-	private static Mock<IFuturemud> CreateGameworld()
+	private static Mock<ITag> CreateTag(long id, string name)
+	{
+		var tag = new Mock<ITag>();
+		tag.SetupGet(x => x.Id).Returns(id);
+		tag.SetupGet(x => x.Name).Returns(name);
+		tag.SetupGet(x => x.FullName).Returns(name);
+		tag.Setup(x => x.IsA(It.IsAny<ITag>())).Returns<ITag>(other => ReferenceEquals(other, tag.Object));
+		return tag;
+	}
+
+	private static Mock<IFuturemud> CreateGameworld(params ITag[] tags)
 	{
 		var saveManager = new Mock<ISaveManager>();
 		var unitManager = new Mock<IUnitManager>();
@@ -303,6 +430,9 @@ public class SealAndMeasurementComponentTests
 		gameworld.SetupGet(x => x.SaveManager).Returns(saveManager.Object);
 		gameworld.SetupGet(x => x.UnitManager).Returns(unitManager.Object);
 		gameworld.SetupGet(x => x.FutureProgs).Returns(Repository<IFutureProg>());
+		gameworld.SetupGet(x => x.Tags).Returns(Repository(tags));
+		gameworld.SetupGet(x => x.Drugs).Returns(Repository<IDrug>());
+		gameworld.SetupGet(x => x.ItemProtos).Returns(RevisableRepository<IGameItemProto>());
 		return gameworld;
 	}
 
@@ -318,6 +448,23 @@ public class SealAndMeasurementComponentTests
 		repository.Setup(x => x.GetEnumerator())
 		          .Returns(() => ((IEnumerable<T>)items).GetEnumerator());
 		repository.SetupGet(x => x.Count).Returns(items.Length);
+		return repository.Object;
+	}
+
+	private static IUneditableRevisableAll<T> RevisableRepository<T>(params T[] items) where T : class, IRevisableItem
+	{
+		var repository = new Mock<IUneditableRevisableAll<T>>();
+		repository.Setup(x => x.Get(It.IsAny<long>()))
+		          .Returns<long>(id => items.FirstOrDefault(x => x.Id == id)!);
+		repository.Setup(x => x.Get(It.IsAny<long>(), It.IsAny<int>()))
+		          .Returns<long, int>((id, revision) => items.FirstOrDefault(x => x.Id == id && x.RevisionNumber == revision)!);
+		repository.Setup(x => x.GetByName(It.IsAny<string>(), It.IsAny<bool>()))
+		          .Returns<string, bool>((name, ignoreCase) => items.FirstOrDefault(x =>
+			          ignoreCase ? x.Name.EqualTo(name) : x.Name == name)!);
+		repository.Setup(x => x.Get(It.IsAny<string>()))
+		          .Returns<string>(name => items.Where(x => x.Name.EqualTo(name)).ToList());
+		repository.Setup(x => x.GetEnumerator())
+		          .Returns(() => ((IEnumerable<T>)items).GetEnumerator());
 		return repository.Object;
 	}
 }

--- a/MudSharpCore/Character/CharacterEvents.cs
+++ b/MudSharpCore/Character/CharacterEvents.cs
@@ -68,6 +68,8 @@ public partial class Character
             case EventType.ItemUnlockedWitness:
             case EventType.ItemWieldedWitness:
             case EventType.ItemWornWitness:
+            case EventType.OfferingBurnedWitness:
+            case EventType.OfferingReceivedWitness:
             case EventType.WitnessBleedTick:
                 foreach (IGameItem item in Body.ExternalItems)
                 {

--- a/MudSharpCore/Commands/Modules/ManipulationModule.cs
+++ b/MudSharpCore/Commands/Modules/ManipulationModule.cs
@@ -4062,6 +4062,164 @@ The syntax is as follows:
         puffable.Puff(character, emote);
     }
 
+    [PlayerCommand("Offer", "offer")]
+    [DelayBlock("general", "You must first stop {0} before you can do that.")]
+    [RequiredCharacterState(CharacterState.Able)]
+    [NoHideCommand]
+    [NoMeleeCombatCommand]
+    [HelpInfo("offer", @"The #3offer#0 command is used to ceremonially place an item on an offering focus, such as an altar, censer basin or votive tray. The focus may run progs, fire offering events, or immediately burn the offering depending on its component settings.
+
+The syntax is:
+
+	#3offer <item> at <focus>#0
+	#3offer <item> at <focus> (<emote>)#0
+
+Use quotes around multi-word item or focus names.", AutoHelp.HelpArg)]
+    protected static void Offer(ICharacter actor, string command)
+    {
+        var ss = new StringStack(command.RemoveFirstWord());
+        if (ss.IsFinished)
+        {
+            actor.OutputHandler.Send($"What do you want to offer? See {"help offer".ColourCommand()} for syntax.");
+            return;
+        }
+
+        var offeringText = ss.PopSpeech();
+        if (!ss.PopSpeech().EqualTo("at"))
+        {
+            actor.OutputHandler.Send($"You must specify a focus with the syntax {"offer <item> at <focus>".ColourCommand()}.");
+            return;
+        }
+
+        if (ss.IsFinished)
+        {
+            actor.OutputHandler.Send("What do you want to offer that at?");
+            return;
+        }
+
+        var focusText = ss.PopSpeech();
+        var offering = actor.TargetHeldItem(offeringText);
+        if (offering is null)
+        {
+            actor.OutputHandler.Send("You are not holding anything like that to offer.");
+            return;
+        }
+
+        var focusItem = actor.TargetItem(focusText);
+        if (focusItem is null)
+        {
+            actor.OutputHandler.Send("You do not see any offering focus like that.");
+            return;
+        }
+
+        var receiver = focusItem.GetItemType<IOfferingReceiver>();
+        if (receiver is null)
+        {
+            actor.OutputHandler.Send($"{focusItem.HowSeen(actor, true)} is not something that can receive offerings.");
+            return;
+        }
+
+        var (truth, error) = actor.CanManipulateItem(focusItem);
+        if (!truth)
+        {
+            actor.OutputHandler.Send(error);
+            return;
+        }
+
+        var emoteText = ss.PopParentheses();
+        PlayerEmote? emote = null;
+        if (!string.IsNullOrEmpty(emoteText))
+        {
+            emote = new PlayerEmote(emoteText, actor);
+            if (!emote.Valid)
+            {
+                actor.OutputHandler.Send(emote.ErrorMessage);
+                return;
+            }
+        }
+
+        receiver.Offer(actor, offering, emote);
+    }
+
+    [PlayerCommand("Burn", "burn")]
+    [DelayBlock("general", "You must first stop {0} before you can do that.")]
+    [RequiredCharacterState(CharacterState.Able)]
+    [NoHideCommand]
+    [NoMeleeCombatCommand]
+    [HelpInfo("burn", @"The #3burn#0 command burns an item that has already been placed on an offering focus. The focus may consume the item, leave configured residue, run progs, and fire offering burn events.
+
+The syntax is:
+
+	#3burn <offering> at <focus>#0
+	#3burn <offering> at <focus> (<emote>)#0
+
+Use quotes around multi-word offering or focus names.", AutoHelp.HelpArg)]
+    protected static void Burn(ICharacter actor, string command)
+    {
+        var ss = new StringStack(command.RemoveFirstWord());
+        if (ss.IsFinished)
+        {
+            actor.OutputHandler.Send($"What offering do you want to burn? See {"help burn".ColourCommand()} for syntax.");
+            return;
+        }
+
+        var offeringText = ss.PopSpeech();
+        if (!ss.PopSpeech().EqualTo("at"))
+        {
+            actor.OutputHandler.Send($"You must specify a focus with the syntax {"burn <offering> at <focus>".ColourCommand()}.");
+            return;
+        }
+
+        if (ss.IsFinished)
+        {
+            actor.OutputHandler.Send("What focus do you want to burn that offering at?");
+            return;
+        }
+
+        var focusText = ss.PopSpeech();
+        var focusItem = actor.TargetItem(focusText);
+        if (focusItem is null)
+        {
+            actor.OutputHandler.Send("You do not see any offering focus like that.");
+            return;
+        }
+
+        var receiver = focusItem.GetItemType<IOfferingReceiver>();
+        if (receiver is null)
+        {
+            actor.OutputHandler.Send($"{focusItem.HowSeen(actor, true)} is not something that can burn offerings.");
+            return;
+        }
+
+        var offering = receiver.Contents.GetFromItemListByKeyword(offeringText, actor);
+        if (offering is null)
+        {
+            actor.OutputHandler.Send($"{focusItem.HowSeen(actor, true)} does not bear any offering like that.");
+            return;
+        }
+
+        var (truth, error) = actor.CanManipulateItem(focusItem);
+        if (!truth)
+        {
+            actor.OutputHandler.Send(error);
+            return;
+        }
+
+        var emoteText = ss.PopParentheses();
+        PlayerEmote? emote = null;
+        if (!string.IsNullOrEmpty(emoteText))
+        {
+            emote = new PlayerEmote(emoteText, actor);
+            if (!emote.Valid)
+            {
+                actor.OutputHandler.Send(emote.ErrorMessage);
+                return;
+            }
+        }
+
+        receiver.BurnOffering(actor, offering, emote);
+    }
+
     [PlayerCommand("Light", "light")]
     [DelayBlock("general", "You must first stop {0} before you can do that.")]
     [RequiredCharacterState(CharacterState.Able)]

--- a/MudSharpCore/Commands/Modules/PerceptionModule.cs
+++ b/MudSharpCore/Commands/Modules/PerceptionModule.cs
@@ -10,6 +10,7 @@ using MudSharp.Construction.Boundary;
 using MudSharp.Economy;
 using MudSharp.Economy.Property;
 using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
 using MudSharp.Form.Material;
 using MudSharp.Form.Shape;
 using MudSharp.Framework;
@@ -1543,7 +1544,7 @@ Note: The targets are ordered in the same order that they appear in the #3target
     [NoMeleeCombatCommand]
     [NoMovementCommand]
     [RequiredCharacterState(CharacterState.Able)]
-    [HelpInfo("tracks", @"The #3tracks#0 command is used to begin searching the area for tracks from movement. You will continue to look for tracks until you use the #3stop#0 command. You can never be totally sure whether you have found all the tracks or whether you just aren't good enough to find the hardest ones.
+    [HelpInfo("tracks", @"The #3tracks#0 command is used to begin searching the area for tracks from movement and smell-trackable scent trails. You will continue to look for tracks until you use the #3stop#0 command. You can never be totally sure whether you have found all the tracks or whether you just aren't good enough to find the hardest ones.
 
 Depending on your racial abilities you may be able to use both visual and smell-based tracking. You don't need to do anything to specify these, it will be automatically applied if it applies.
 
@@ -1564,18 +1565,25 @@ The syntax is simply #3tracks#0.", AutoHelp.HelpArg)]
     private static void AdminTracks(ICharacter actor)
     {
         List<ITrack> tracks = actor.Location.Tracks.Where(x => x.RoomLayer == actor.RoomLayer).ToList();
-        if (tracks.Count == 0)
+        List<IScentTrailEffect> scents = actor.Location.EffectsOfType<IScentTrailEffect>()
+                                              .Where(x => x.RoomLayer == actor.RoomLayer)
+                                              .ToList();
+        if (tracks.Count == 0 && scents.Count == 0)
         {
-            actor.OutputHandler.Send("There are no tracks here.");
+            actor.OutputHandler.Send("There are no tracks or scent trails here.");
             return;
         }
         StringBuilder sb = new();
-        sb.AppendLine("There are the following tracks here:");
+        sb.AppendLine("There are the following tracks and scent trails here:");
         sb.AppendLine();
         int i = 1;
         foreach (ITrack track in tracks)
         {
             sb.AppendLine($"{i++.ToString("N0", actor)}) {track.DescribeForTracksCommand(actor)}");
+        }
+        foreach (IScentTrailEffect scent in scents)
+        {
+            sb.AppendLine($"{i++.ToString("N0", actor)}) {scent.DescribeForTracksCommand(actor)}");
         }
 
         actor.OutputHandler.Send(sb.ToString());

--- a/MudSharpCore/Effects/Concrete/AmbientScent.cs
+++ b/MudSharpCore/Effects/Concrete/AmbientScent.cs
@@ -1,0 +1,111 @@
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.RPG.Checks;
+using System.Xml.Linq;
+
+#nullable enable
+
+namespace MudSharp.Effects.Concrete;
+
+public class AmbientScent : Effect, IScentTrailEffect
+{
+	public AmbientScent(IPerceivable owner, long sourceItemId, string sourceDescription, string description,
+		RoomLayer roomLayer, int distance, Difficulty scentDifficulty, ANSIColour? colour = null)
+		: base(owner)
+	{
+		SourceItemId = sourceItemId;
+		SourceDescription = sourceDescription;
+		AdditionalText = description;
+		RoomLayer = roomLayer;
+		Distance = distance;
+		BaseScentDifficulty = scentDifficulty;
+		Colour = colour ?? Telnet.Yellow;
+	}
+
+	public AmbientScent(XElement effect, IPerceivable owner) : base(effect, owner)
+	{
+		var definition = effect.Element("Effect")!;
+		SourceItemId = long.Parse(definition.Element("SourceItemId")?.Value ?? "0");
+		SourceDescription = definition.Element("SourceDescription")?.Value ?? "something";
+		AdditionalText = definition.Element("AdditionalText")?.Value ?? string.Empty;
+		RoomLayer = (RoomLayer)int.Parse(definition.Element("RoomLayer")?.Value ?? ((int)RoomLayer.GroundLevel).ToString());
+		Distance = int.Parse(definition.Element("Distance")?.Value ?? "0");
+		BaseScentDifficulty = (Difficulty)int.Parse(definition.Element("ScentDifficulty")?.Value ?? ((int)Difficulty.Normal).ToString());
+		Colour = Telnet.GetColour(definition.Element("Colour")?.Value) ?? Telnet.Yellow;
+	}
+
+	public static void InitialiseEffectType()
+	{
+		RegisterFactory("AmbientScent", (effect, owner) => new AmbientScent(effect, owner));
+	}
+
+	public override bool SavingEffect => true;
+	protected override string SpecificEffectType => "AmbientScent";
+	public long SourceItemId { get; private set; }
+	public string SourceDescription { get; private set; }
+	public string AdditionalText { get; private set; }
+	public bool PlayerSet => false;
+	public RoomLayer RoomLayer { get; private set; }
+	public int Distance { get; private set; }
+	public Difficulty BaseScentDifficulty { get; private set; }
+	public ANSIColour Colour { get; private set; }
+
+	protected override XElement SaveDefinition()
+	{
+		return new XElement("Effect",
+			new XElement("SourceItemId", SourceItemId),
+			new XElement("SourceDescription", new XCData(SourceDescription)),
+			new XElement("AdditionalText", new XCData(AdditionalText)),
+			new XElement("RoomLayer", (int)RoomLayer),
+			new XElement("Distance", Distance),
+			new XElement("ScentDifficulty", (int)BaseScentDifficulty),
+			new XElement("Colour", Colour.Name));
+	}
+
+	public override bool Applies(object target)
+	{
+		return base.Applies(target) &&
+		       (target is not IPerceiver perceiver || perceiver.RoomLayer == RoomLayer);
+	}
+
+	public override string Describe(IPerceiver voyeur)
+	{
+		return $"Ambient scent from {SourceDescription} at distance {Distance.ToString("N0", voyeur)}: {AdditionalText}";
+	}
+
+	public string GetAdditionalText(IPerceiver voyeur, bool colour)
+	{
+		return colour ? AdditionalText.Colour(Colour) : AdditionalText;
+	}
+
+	public bool Matches(string sourceDescription, string additionalText, RoomLayer roomLayer, int distance,
+		Difficulty scentDifficulty)
+	{
+		return SourceDescription == sourceDescription &&
+		       AdditionalText == additionalText &&
+		       RoomLayer == roomLayer &&
+		       Distance == distance &&
+		       BaseScentDifficulty == scentDifficulty;
+	}
+
+	public Difficulty ScentDifficulty(ICharacter actor)
+	{
+		return BaseScentDifficulty;
+	}
+
+	public string DescribeForTracksCommand(ICharacter actor)
+	{
+		var distanceText = Distance switch
+		{
+			0 => "here",
+			1 => "nearby",
+			_ => $"{Distance.ToString("N0", actor)} rooms away"
+		};
+
+		return
+			$"{AdditionalText} The scent appears to come from {SourceDescription.ColourName()} {distanceText} and is {ScentDifficulty(actor).DescribeColoured()} to smell.";
+	}
+
+}

--- a/MudSharpCore/Effects/Concrete/LookingForTracks.cs
+++ b/MudSharpCore/Effects/Concrete/LookingForTracks.cs
@@ -39,6 +39,7 @@ public class LookingForTracks : Effect, IActionEffect, ILDescSuffixEffect, IRemo
     public ICharacter CharacterOwner { get; set; }
 
     private readonly List<ITrack> _alreadyFoundTracks = new();
+    private readonly List<IScentTrailEffect> _alreadyFoundScents = new();
 
     public string ActionDescription => "searching for tracks";
     public string LDescAddendumEmote => "searching for tracks";
@@ -105,12 +106,29 @@ public class LookingForTracks : Effect, IActionEffect, ILDescSuffixEffect, IRemo
         List<(ITrack Track, Difficulty Visual, Difficulty Olfactory)> successfulTracks = difficulties
                                .Where(x => visionResult[x.Visual].IsPass() || smellResult[x.Olfactory].IsPass())
                                .ToList();
+        List<IScentTrailEffect> scents = actor.Location.EffectsOfType<IScentTrailEffect>()
+                                              .Except(_alreadyFoundScents)
+                                              .Where(x => x.RoomLayer == actor.RoomLayer)
+                                              .ToList();
+        List<IScentTrailEffect> successfulScents = scents
+                                                   .Where(x => smellResult[x.ScentDifficulty(actor)].IsPass())
+                                                   .ToList();
+        if (successfulScents.Any() && (!successfulTracks.Any() || Constants.Random.Next(2) == 0))
+        {
+            IScentTrailEffect scent = successfulScents.GetRandomElement();
+            _alreadyFoundScents.Add(scent);
+            actor.OutputHandler.Send($"You found a scent trail...\n...{scent.DescribeForTracksCommand(actor)}");
+            return;
+        }
+
         (ITrack Track, Difficulty Visual, Difficulty Olfactory) track = successfulTracks.GetRandomElement();
         if (track.Track is null)
         {
             actor.OutputHandler.Send("You couldn't find any tracks, but you continue to search.");
             return;
         }
+
+        _alreadyFoundTracks.Add(track.Track);
 
         bool passedVisual = visionResult[track.Visual].IsPass();
         bool passedSmell = smellResult[track.Olfactory].IsPass();
@@ -121,7 +139,7 @@ public class LookingForTracks : Effect, IActionEffect, ILDescSuffixEffect, IRemo
         {
             sb.AppendLine($"...It was left by a #5{track.Track.Character.Gender.GenderClass()} {track.Track.Character.Race.Name}#0.".SubstituteANSIColour());
             sb.AppendLine($"...You can smell that its exertion level was {track.Track.ExertionLevel.DescribeEnum()} at the time.");
-            if (visionResult[track.Olfactory].Outcome == Outcome.MajorPass)
+            if (smellResult[track.Olfactory].Outcome == Outcome.MajorPass)
             {
                 IDub dub = actor.Dubs.FirstOrDefault(x => x.Owner == track.Track.Character);
                 if (dub is not null)
@@ -193,7 +211,7 @@ public class LookingForTracks : Effect, IActionEffect, ILDescSuffixEffect, IRemo
             sb.AppendLine($"...It was bleeding as it went.");
         }
         sb.AppendLine($"...It was left #2approximately {(actor.Location.DateTime() - track.Track.MudDateTime).Describe(actor)} ago#0.".SubstituteANSIColour());
-        sb.AppendLine($"...It was {track.Visual.DescribeColoured()} to see and {track.Visual.DescribeColoured()} to smell for you.");
+        sb.AppendLine($"...It was {track.Visual.DescribeColoured()} to see and {track.Olfactory.DescribeColoured()} to smell for you.");
 
         actor.OutputHandler.Send(sb.ToString());
 

--- a/MudSharpCore/GameItems/Components/IncenseBurnerGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/IncenseBurnerGameItemComponent.cs
@@ -1,0 +1,555 @@
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Effects;
+using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Form.Shape;
+using MudSharp.Framework;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.GameItems.Prototypes;
+using MudSharp.Health;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Outputs;
+using MudSharp.PerceptionEngine.Parsers;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+#nullable enable
+
+namespace MudSharp.GameItems.Components;
+
+public class IncenseBurnerGameItemComponent : GameItemComponent, IIncenseBurner
+{
+	private IncenseBurnerGameItemComponentProto _prototype;
+	private readonly List<IGameItem> _contents = [];
+	private long _pendingBurningItemId;
+	private IGameItem? _currentFuelItem;
+	private double _remainingBurnSeconds;
+	private int _drugPulseSecondsElapsed;
+	private bool _lit;
+
+	public IncenseBurnerGameItemComponent(IncenseBurnerGameItemComponentProto proto, IGameItem parent,
+		bool temporary = false) : base(parent, proto, temporary)
+	{
+		_prototype = proto;
+	}
+
+	public IncenseBurnerGameItemComponent(MudSharp.Models.GameItemComponent component,
+		IncenseBurnerGameItemComponentProto proto, IGameItem parent) : base(component, parent)
+	{
+		_prototype = proto;
+		_noSave = true;
+		LoadFromXml(XElement.Parse(component.Definition));
+		_noSave = false;
+	}
+
+	public IncenseBurnerGameItemComponent(IncenseBurnerGameItemComponent rhs, IGameItem newParent,
+		bool temporary = false) : base(rhs, newParent, temporary)
+	{
+		_prototype = rhs._prototype;
+		_remainingBurnSeconds = rhs._remainingBurnSeconds;
+		_pendingBurningItemId = rhs._pendingBurningItemId;
+		_drugPulseSecondsElapsed = rhs._drugPulseSecondsElapsed;
+		_lit = rhs._lit;
+	}
+
+	public override IGameItemComponentProto Prototype => _prototype;
+	public bool HasFuel => _currentFuelItem is not null || _contents.Any();
+	public int ScentRange => _prototype.ScentRange;
+
+	public bool Lit
+	{
+		get => _lit;
+		set
+		{
+			if (_lit == value)
+			{
+				return;
+			}
+
+			_lit = value;
+			Changed = true;
+			UpdateHeartbeatSubscription();
+		}
+	}
+
+	public override IGameItemComponent Copy(IGameItem newParent, bool temporary = false)
+	{
+		return new IncenseBurnerGameItemComponent(this, newParent, temporary);
+	}
+
+	protected override void UpdateComponentNewPrototype(IGameItemComponentProto newProto)
+	{
+		_prototype = (IncenseBurnerGameItemComponentProto)newProto;
+	}
+
+	public override void FinaliseLoad()
+	{
+		base.FinaliseLoad();
+		foreach (var item in _contents)
+		{
+			item.FinaliseLoadTimeTasks();
+		}
+
+		if (_pendingBurningItemId != 0)
+		{
+			_currentFuelItem = _contents.FirstOrDefault(x => x.Id == _pendingBurningItemId);
+			_pendingBurningItemId = 0;
+		}
+	}
+
+	public override void Login()
+	{
+		base.Login();
+		foreach (var item in _contents)
+		{
+			item.Login();
+		}
+
+		UpdateHeartbeatSubscription();
+	}
+
+	public override void Quit()
+	{
+		Gameworld.HeartbeatManager.SecondHeartbeat -= HeartbeatManagerOnSecondHeartbeat;
+		foreach (var item in _contents)
+		{
+			item.Quit();
+		}
+
+		base.Quit();
+	}
+
+	public override void Delete()
+	{
+		Gameworld.HeartbeatManager.SecondHeartbeat -= HeartbeatManagerOnSecondHeartbeat;
+		foreach (var item in _contents.ToList())
+		{
+			_contents.Remove(item);
+			item.ContainedIn = null;
+			item.Delete();
+		}
+
+		base.Delete();
+	}
+
+	protected override string SaveToXml()
+	{
+		return new XElement("Definition",
+			from item in _contents
+			select new XElement("Contained", item.Id),
+			new XElement("Lit", Lit),
+			new XElement("RemainingBurnSeconds", _remainingBurnSeconds),
+			new XElement("BurningItem", _currentFuelItem?.Id ?? 0),
+			new XElement("DrugPulseSecondsElapsed", _drugPulseSecondsElapsed)).ToString();
+	}
+
+	private void LoadFromXml(XElement root)
+	{
+		_lit = bool.Parse(root.Element("Lit")?.Value ?? "false");
+		_remainingBurnSeconds = double.Parse(root.Element("RemainingBurnSeconds")?.Value ?? "0.0");
+		_pendingBurningItemId = long.Parse(root.Element("BurningItem")?.Value ?? "0");
+		_drugPulseSecondsElapsed = int.Parse(root.Element("DrugPulseSecondsElapsed")?.Value ?? "0");
+		foreach (var item in root.Elements("Contained")
+		                         .Select(element => Gameworld.TryGetItem(long.Parse(element.Value), true))
+		                         .Where(item => item is not null))
+		{
+			_contents.Add(item!);
+			item!.Get(null);
+			item.LoadTimeSetContainedIn(Parent);
+		}
+	}
+
+	private void UpdateHeartbeatSubscription()
+	{
+		Gameworld.HeartbeatManager.SecondHeartbeat -= HeartbeatManagerOnSecondHeartbeat;
+		if (Lit)
+		{
+			Gameworld.HeartbeatManager.SecondHeartbeat += HeartbeatManagerOnSecondHeartbeat;
+		}
+	}
+
+	private void HeartbeatManagerOnSecondHeartbeat()
+	{
+		BurnFuel(1.0);
+	}
+
+	private bool CanEmitIntoLocation => Parent.Location is not null && Parent.ContainedIn is null;
+
+	internal void BurnFuel(double seconds)
+	{
+		if (!Lit)
+		{
+			return;
+		}
+
+		if (_currentFuelItem is null && !PrimeFuel())
+		{
+			Lit = false;
+			return;
+		}
+
+		if (CanEmitIntoLocation)
+		{
+			RefreshScentEffects((int)Math.Ceiling(seconds));
+			PulseDrug(seconds);
+		}
+
+		_remainingBurnSeconds -= seconds;
+		Changed = true;
+		if (_remainingBurnSeconds > 0.0 || _currentFuelItem is null)
+		{
+			return;
+		}
+
+		Parent.Handle(new EmoteOutput(new Emote("$0 burn|burns away in $1.", Parent, _currentFuelItem, Parent),
+			flags: OutputFlags.SuppressObscured), OutputRange.Local);
+		_contents.RemoveAll(x => ReferenceEquals(x, _currentFuelItem) || x.Id == _currentFuelItem.Id);
+		_currentFuelItem.Delete();
+		_currentFuelItem = null;
+		_remainingBurnSeconds = 0.0;
+		if (!_contents.Any())
+		{
+			Lit = false;
+		}
+	}
+
+	private bool PrimeFuel()
+	{
+		_currentFuelItem = _contents.FirstOrDefault();
+		if (_currentFuelItem is null)
+		{
+			return false;
+		}
+
+		_remainingBurnSeconds = Math.Max(1.0, _currentFuelItem.Weight * _prototype.SecondsPerUnitWeight);
+		Changed = true;
+		return true;
+	}
+
+	public void RefreshScentEffects(int seconds)
+	{
+		if (!CanEmitIntoLocation)
+		{
+			return;
+		}
+
+		var sourceDescription = Parent.HowSeen(null, flags: PerceiveIgnoreFlags.IgnoreCanSee);
+		foreach (var (cell, distance) in AffectedCells(_prototype.ScentRange))
+		{
+			var text = distance == 0 ? _prototype.SourceScentDescription : _prototype.DistantScentDescription;
+			if (string.IsNullOrWhiteSpace(text))
+			{
+				continue;
+			}
+
+			var difficulty = _prototype.ScentDifficulty.StageUp(distance);
+			var existing = cell.EffectsOfType<IScentTrailEffect>()
+			                   .FirstOrDefault(x => x.SourceItemId == Parent.Id && x.RoomLayer == Parent.RoomLayer);
+			var duration = TimeSpan.FromSeconds(Math.Max(1.0, seconds * _prototype.LingeringMultiplier + 2.0));
+			if (existing is AmbientScent ambientScent &&
+			    ambientScent.Matches(sourceDescription, text, Parent.RoomLayer, distance, difficulty))
+			{
+				Gameworld.EffectScheduler.ExtendSchedule(ambientScent, duration);
+				continue;
+			}
+
+			existing?.ExpireEffect();
+			var effect = new AmbientScent(cell, Parent.Id, sourceDescription, text, Parent.RoomLayer, distance,
+				difficulty);
+			cell.AddEffect(effect, duration);
+		}
+	}
+
+	private IEnumerable<(ICell Cell, int Distance)> AffectedCells(int range)
+	{
+		return Parent.CellsAndDistancesInVicinity((uint)Math.Max(0, range), true, false)
+		             .Where(x => x.Cell is not null);
+	}
+
+	private void PulseDrug(double seconds)
+	{
+		if (!CanEmitIntoLocation ||
+		    _prototype.Drug is null ||
+		    _prototype.GramsPerPulse <= 0.0 ||
+		    _prototype.DrugPulseSeconds <= 0)
+		{
+			return;
+		}
+
+		_drugPulseSecondsElapsed += (int)Math.Ceiling(seconds);
+		if (_drugPulseSecondsElapsed < _prototype.DrugPulseSeconds)
+		{
+			return;
+		}
+
+		_drugPulseSecondsElapsed = 0;
+		foreach (var (cell, distance) in AffectedCells(Math.Min(_prototype.DrugRange, _prototype.ScentRange)))
+		{
+			var dose = _prototype.GramsPerPulse / (distance + 1.0);
+			foreach (var character in cell.LayerCharacters(Parent.RoomLayer))
+			{
+				character.Body.Dose(_prototype.Drug, DrugVector.Inhaled, dose, Parent);
+			}
+		}
+	}
+
+	public override bool DescriptionDecorator(DescriptionType type)
+	{
+		return type is DescriptionType.Short or DescriptionType.Full or DescriptionType.Contents;
+	}
+
+	public override string Decorate(IPerceiver voyeur, string name, string description, DescriptionType type,
+		bool colour, PerceiveIgnoreFlags flags)
+	{
+		switch (type)
+		{
+			case DescriptionType.Short:
+				return Lit ? $"{description} {"(lit)".FluentColour(Telnet.Red, colour)}" : description;
+			case DescriptionType.Contents:
+				return _contents.Any()
+					? description + "\n\nIt contains:\n" + _contents.Select(x => "\t" + x.HowSeen(voyeur)).ListToString(separator: "\n", conjunction: "", twoItemJoiner: "\n")
+					: description + "\n\nIt is empty.";
+			case DescriptionType.Full:
+				return
+					$"{description}\n\nIt is {(Lit ? "lit".Colour(Telnet.Red) : "unlit".Colour(Telnet.Yellow))} and {(_currentFuelItem is null ? "has no fuel currently burning" : $"is burning {_currentFuelItem.HowSeen(voyeur)}")}.\nIt contains {_contents.Count.ToString("N0", voyeur).ColourValue()} fuel item{(_contents.Count == 1 ? string.Empty : "s")}.";
+			default:
+				return description;
+		}
+	}
+
+	public override bool Take(IGameItem item)
+	{
+		if (_contents.Remove(item))
+		{
+			item.ContainedIn = null;
+			Changed = true;
+			return true;
+		}
+
+		return false;
+	}
+
+	public override bool HandleDieOrMorph(IGameItem newItem, ICell location)
+	{
+		var newContainer = newItem?.GetItemType<IContainer>();
+		foreach (var item in _contents.ToList())
+		{
+			if (newContainer is not null && newContainer.CanPut(item))
+			{
+				newContainer.Put(null, item);
+			}
+			else if (location is not null)
+			{
+				location.Insert(item);
+				item.ContainedIn = null;
+			}
+			else
+			{
+				item.Delete();
+			}
+		}
+
+		_contents.Clear();
+		_currentFuelItem = null;
+		_remainingBurnSeconds = 0.0;
+		return false;
+	}
+
+	public IEnumerable<IGameItem> Contents => _contents;
+	public string ContentsPreposition => "in";
+	public bool Transparent => true;
+
+	public bool CanPut(IGameItem item)
+	{
+		return item != Parent &&
+		       (_prototype.FuelTag is null || item.IsA(_prototype.FuelTag)) &&
+		       _contents.Sum(x => x.Weight) + item.Weight <= _prototype.MaximumFuelWeight;
+	}
+
+	public void Put(ICharacter? putter, IGameItem item, bool allowMerge = true)
+	{
+		_contents.Add(item);
+		item.ContainedIn = Parent;
+		Changed = true;
+	}
+
+	public WhyCannotPutReason WhyCannotPut(IGameItem item)
+	{
+		if (item == Parent)
+		{
+			return WhyCannotPutReason.CantPutContainerInItself;
+		}
+
+		if (_prototype.FuelTag is not null && !item.IsA(_prototype.FuelTag))
+		{
+			return WhyCannotPutReason.NotCorrectItemType;
+		}
+
+		if (_contents.Sum(x => x.Weight) + item.Weight > _prototype.MaximumFuelWeight)
+		{
+			var capacity = CanPutAmount(item);
+			if (item.Quantity <= 1 || capacity <= 0)
+			{
+				return WhyCannotPutReason.ContainerFull;
+			}
+
+			return WhyCannotPutReason.ContainerFullButCouldAcceptLesserQuantity;
+		}
+
+		return WhyCannotPutReason.NotContainer;
+	}
+
+	public bool CanTake(ICharacter taker, IGameItem item, int quantity)
+	{
+		return _contents.Contains(item) &&
+		       item != _currentFuelItem &&
+		       item.CanGet(quantity).AsBool();
+	}
+
+	public IGameItem Take(ICharacter taker, IGameItem item, int quantity)
+	{
+		if (!CanTake(taker, item, quantity))
+		{
+			return null!;
+		}
+
+		Changed = true;
+		if (quantity == 0 || item.DropsWhole(quantity))
+		{
+			_contents.Remove(item);
+			item.ContainedIn = null;
+			return item;
+		}
+
+		return item.Get(null, quantity);
+	}
+
+	public WhyCannotGetContainerReason WhyCannotTake(ICharacter taker, IGameItem item)
+	{
+		if (item == _currentFuelItem)
+		{
+			return WhyCannotGetContainerReason.UnlawfulAction;
+		}
+
+		return _contents.Contains(item)
+			? WhyCannotGetContainerReason.NotContainer
+			: WhyCannotGetContainerReason.NotContained;
+	}
+
+	public int CanPutAmount(IGameItem item)
+	{
+		var remainingWeight = _prototype.MaximumFuelWeight - _contents.Sum(x => x.Weight);
+		if (remainingWeight <= 0.0)
+		{
+			return 0;
+		}
+
+		if (item.Quantity <= 0 || item.Weight <= 0.0)
+		{
+			return int.MaxValue;
+		}
+
+		return Math.Max(0, (int)(remainingWeight / (item.Weight / item.Quantity)));
+	}
+
+	public void Empty(ICharacter emptier, IContainer intoContainer, IEmote? playerEmote = null)
+	{
+		foreach (var item in _contents.ToList())
+		{
+			if (item == _currentFuelItem)
+			{
+				continue;
+			}
+
+			_contents.Remove(item);
+			item.ContainedIn = null;
+			if (intoContainer is not null && intoContainer.CanPut(item))
+			{
+				intoContainer.Put(emptier, item);
+				continue;
+			}
+
+			(emptier?.Location ?? Parent.TrueLocations.FirstOrDefault())?.Insert(item);
+		}
+
+		Changed = true;
+	}
+
+	public bool CanLight(ICharacter lightee, IPerceivable ignitionSource)
+	{
+		return (Parent.Location?.CanGetAccess(Parent, lightee) ?? true) &&
+		       !Lit &&
+		       HasFuel;
+	}
+
+	public string WhyCannotLight(ICharacter lightee, IPerceivable ignitionSource)
+	{
+		if (!(Parent.Location?.CanGetAccess(Parent, lightee) ?? true))
+		{
+			return Parent.Location.WhyCannotGetAccess(Parent, lightee);
+		}
+
+		if (Lit)
+		{
+			return $"{Parent.HowSeen(lightee, true)} is already lit.";
+		}
+
+		if (!HasFuel)
+		{
+			return $"{Parent.HowSeen(lightee, true)} has no fuel to burn.";
+		}
+
+		return $"You cannot light {Parent.HowSeen(lightee)}.";
+	}
+
+	public bool Light(ICharacter lightee, IPerceivable ignitionSource, IEmote playerEmote)
+	{
+		if (!CanLight(lightee, ignitionSource))
+		{
+			lightee.OutputHandler.Send(WhyCannotLight(lightee, ignitionSource));
+			return false;
+		}
+
+		lightee.OutputHandler.Handle(
+			new MixedEmoteOutput(new Emote("@ light|lights $1$?2| with $2||$", lightee, lightee, Parent,
+				ignitionSource)).Append(playerEmote));
+		Lit = true;
+		RefreshScentEffects(1);
+		return true;
+	}
+
+	public bool CanExtinguish(ICharacter lightee)
+	{
+		return (Parent.Location?.CanGetAccess(Parent, lightee) ?? true) && Lit;
+	}
+
+	public string WhyCannotExtinguish(ICharacter lightee)
+	{
+		if (!(Parent.Location?.CanGetAccess(Parent, lightee) ?? true))
+		{
+			return Parent.Location.WhyCannotGetAccess(Parent, lightee);
+		}
+
+		return !Lit
+			? $"{Parent.HowSeen(lightee, true)} is not lit."
+			: $"You cannot extinguish {Parent.HowSeen(lightee)}.";
+	}
+
+	public bool Extinguish(ICharacter lightee, IEmote playerEmote)
+	{
+		if (!CanExtinguish(lightee))
+		{
+			lightee.OutputHandler.Send(WhyCannotExtinguish(lightee));
+			return false;
+		}
+
+		lightee.OutputHandler.Handle(
+			new MixedEmoteOutput(new Emote("@ extinguish|extinguishes $1", lightee, lightee, Parent)).Append(playerEmote));
+		Lit = false;
+		return true;
+	}
+}

--- a/MudSharpCore/GameItems/Components/OfferingReceiverGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/OfferingReceiverGameItemComponent.cs
@@ -1,0 +1,411 @@
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Effects;
+using MudSharp.Events;
+using MudSharp.Form.Shape;
+using MudSharp.Framework;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.GameItems.Prototypes;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Outputs;
+using MudSharp.PerceptionEngine.Parsers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+#nullable enable
+
+namespace MudSharp.GameItems.Components;
+
+public class OfferingReceiverGameItemComponent : GameItemComponent, IOfferingReceiver
+{
+	private OfferingReceiverGameItemComponentProto _prototype;
+	private readonly List<IGameItem> _contents = [];
+
+	public OfferingReceiverGameItemComponent(OfferingReceiverGameItemComponentProto proto, IGameItem parent,
+		bool temporary = false) : base(parent, proto, temporary)
+	{
+		_prototype = proto;
+	}
+
+	public OfferingReceiverGameItemComponent(MudSharp.Models.GameItemComponent component,
+		OfferingReceiverGameItemComponentProto proto, IGameItem parent) : base(component, parent)
+	{
+		_prototype = proto;
+		_noSave = true;
+		LoadFromXml(XElement.Parse(component.Definition));
+		_noSave = false;
+	}
+
+	public OfferingReceiverGameItemComponent(OfferingReceiverGameItemComponent rhs, IGameItem newParent,
+		bool temporary = false) : base(rhs, newParent, temporary)
+	{
+		_prototype = rhs._prototype;
+	}
+
+	public override IGameItemComponentProto Prototype => _prototype;
+	public OfferingConsumptionMode ConsumptionMode => _prototype.ConsumptionMode;
+
+	public override IGameItemComponent Copy(IGameItem newParent, bool temporary = false)
+	{
+		return new OfferingReceiverGameItemComponent(this, newParent, temporary);
+	}
+
+	protected override void UpdateComponentNewPrototype(IGameItemComponentProto newProto)
+	{
+		_prototype = (OfferingReceiverGameItemComponentProto)newProto;
+	}
+
+	public override void FinaliseLoad()
+	{
+		base.FinaliseLoad();
+		foreach (var item in _contents)
+		{
+			item.FinaliseLoadTimeTasks();
+		}
+	}
+
+	public override void Login()
+	{
+		base.Login();
+		foreach (var item in _contents)
+		{
+			item.Login();
+		}
+	}
+
+	public override void Quit()
+	{
+		foreach (var item in _contents)
+		{
+			item.Quit();
+		}
+
+		base.Quit();
+	}
+
+	public override void Delete()
+	{
+		foreach (var item in _contents.ToList())
+		{
+			_contents.Remove(item);
+			item.ContainedIn = null;
+			item.Delete();
+		}
+
+		base.Delete();
+	}
+
+	protected override string SaveToXml()
+	{
+		return new XElement("Definition",
+			from item in _contents
+			select new XElement("Contained", item.Id)).ToString();
+	}
+
+	private void LoadFromXml(XElement root)
+	{
+		foreach (var item in root.Elements("Contained")
+		                         .Select(element => Gameworld.TryGetItem(long.Parse(element.Value), true))
+		                         .Where(item => item is not null))
+		{
+			_contents.Add(item!);
+			item!.Get(null);
+			item.LoadTimeSetContainedIn(Parent);
+		}
+	}
+
+	public override bool DescriptionDecorator(DescriptionType type)
+	{
+		return type is DescriptionType.Contents or DescriptionType.Full;
+	}
+
+	public override string Decorate(IPerceiver voyeur, string name, string description, DescriptionType type,
+		bool colour, PerceiveIgnoreFlags flags)
+	{
+		switch (type)
+		{
+			case DescriptionType.Contents:
+				return _contents.Any()
+					? description + "\n\nIt bears the following offerings:\n" + _contents.Select(x => "\t" + x.HowSeen(voyeur)).ListToString(separator: "\n", conjunction: "", twoItemJoiner: "\n")
+					: description + "\n\nIt bears no offerings.";
+			case DescriptionType.Full:
+				return
+					$"{description}\n\nIt can receive offerings up to {_prototype.MaximumItemSize.Describe().ColourName()} size and currently bears {_contents.Count.ToString("N0", voyeur).ColourValue()} offering{(_contents.Count == 1 ? string.Empty : "s")}.";
+			default:
+				return description;
+		}
+	}
+
+	public override bool Take(IGameItem item)
+	{
+		if (_contents.Remove(item))
+		{
+			item.ContainedIn = null;
+			Changed = true;
+			return true;
+		}
+
+		return false;
+	}
+
+	public override bool HandleDieOrMorph(IGameItem newItem, ICell location)
+	{
+		var newContainer = newItem?.GetItemType<IContainer>();
+		foreach (var item in _contents.ToList())
+		{
+			if (newContainer is not null && newContainer.CanPut(item))
+			{
+				newContainer.Put(null, item);
+			}
+			else if (location is not null)
+			{
+				location.Insert(item);
+				item.ContainedIn = null;
+			}
+			else
+			{
+				item.Delete();
+			}
+		}
+
+		_contents.Clear();
+		return false;
+	}
+
+	public IEnumerable<IGameItem> Contents => _contents;
+	public string ContentsPreposition => "on";
+	public bool Transparent => true;
+
+	public bool CanPut(IGameItem item)
+	{
+		return CanAcceptItem(null, item);
+	}
+
+	public void Put(ICharacter? putter, IGameItem item, bool allowMerge = true)
+	{
+		_contents.Add(item);
+		item.ContainedIn = Parent;
+		Changed = true;
+	}
+
+	public WhyCannotPutReason WhyCannotPut(IGameItem item)
+	{
+		if (item == Parent)
+		{
+			return WhyCannotPutReason.CantPutContainerInItself;
+		}
+
+		if (item.Size > _prototype.MaximumItemSize && !item.IsItemType<ICommodity>())
+		{
+			return WhyCannotPutReason.ItemTooLarge;
+		}
+
+		if (!TagRulesAccept(item))
+		{
+			return WhyCannotPutReason.NotCorrectItemType;
+		}
+
+		return _contents.Sum(x => x.Weight) + item.Weight > _prototype.MaximumContentsWeight
+			? WhyCannotPutReason.ContainerFull
+			: WhyCannotPutReason.NotContainer;
+	}
+
+	public bool CanTake(ICharacter taker, IGameItem item, int quantity)
+	{
+		return _contents.Contains(item) && item.CanGet(quantity).AsBool();
+	}
+
+	public IGameItem Take(ICharacter taker, IGameItem item, int quantity)
+	{
+		if (!CanTake(taker, item, quantity))
+		{
+			return null!;
+		}
+
+		Changed = true;
+		if (quantity == 0 || item.DropsWhole(quantity))
+		{
+			_contents.Remove(item);
+			item.ContainedIn = null;
+			return item;
+		}
+
+		return item.Get(null, quantity);
+	}
+
+	public WhyCannotGetContainerReason WhyCannotTake(ICharacter taker, IGameItem item)
+	{
+		return _contents.Contains(item)
+			? WhyCannotGetContainerReason.NotContainer
+			: WhyCannotGetContainerReason.NotContained;
+	}
+
+	public int CanPutAmount(IGameItem item)
+	{
+		return (int)((_prototype.MaximumContentsWeight - _contents.Sum(x => x.Weight)) / (item.Weight / item.Quantity));
+	}
+
+	public void Empty(ICharacter emptier, IContainer intoContainer, IEmote? playerEmote = null)
+	{
+		foreach (var item in _contents.ToList())
+		{
+			_contents.Remove(item);
+			item.ContainedIn = null;
+			if (intoContainer is not null && intoContainer.CanPut(item))
+			{
+				intoContainer.Put(emptier, item);
+				continue;
+			}
+
+			(emptier?.Location ?? Parent.TrueLocations.FirstOrDefault())?.Insert(item);
+		}
+
+		Changed = true;
+	}
+
+	public bool CanOffer(ICharacter actor, IGameItem offering)
+	{
+		return CanAcceptItem(actor, offering);
+	}
+
+	public string WhyCannotOffer(ICharacter actor, IGameItem offering)
+	{
+		if (offering is null)
+		{
+			return "You do not have such an item to offer.";
+		}
+
+		if (!CanAcceptItem(actor, offering))
+		{
+			return WhyCannotPut(offering) switch
+			{
+				WhyCannotPutReason.CantPutContainerInItself => "You cannot offer the focus to itself.",
+				WhyCannotPutReason.ContainerFull => $"{Parent.HowSeen(actor, true)} cannot hold {offering.HowSeen(actor)}.",
+				WhyCannotPutReason.ItemTooLarge => $"{offering.HowSeen(actor, true)} is too large to offer at {Parent.HowSeen(actor)}.",
+				WhyCannotPutReason.NotCorrectItemType => $"{offering.HowSeen(actor, true)} is not an acceptable offering for {Parent.HowSeen(actor)}.",
+				_ => $"{Parent.HowSeen(actor, true)} will not accept {offering.HowSeen(actor)}."
+			};
+		}
+
+		return string.Empty;
+	}
+
+	public bool Offer(ICharacter actor, IGameItem offering, IEmote? playerEmote)
+	{
+		if (!CanOffer(actor, offering))
+		{
+			actor.OutputHandler.Handle(new EmoteOutput(new Emote(_prototype.RejectEcho, actor, actor, offering, Parent)));
+			actor.OutputHandler.Send(WhyCannotOffer(actor, offering));
+			return false;
+		}
+
+		actor.Body.Put(offering, Parent, null, 0, null, true, false);
+		if (!_contents.Contains(offering))
+		{
+			return false;
+		}
+
+		actor.OutputHandler.Handle(
+			new MixedEmoteOutput(new Emote(_prototype.AcceptEcho, actor, actor, offering, Parent)).Append(playerEmote));
+		_prototype.OnOfferProg?.Execute(actor, Parent, offering);
+		HandleOfferingEvent(EventType.OfferingReceived, EventType.OfferingReceivedWitness, actor, offering);
+
+		if (_prototype.ConsumptionMode == OfferingConsumptionMode.BurnOnOffer)
+		{
+			BurnOffering(actor, offering, null);
+		}
+
+		return true;
+	}
+
+	public bool CanBurnOffering(ICharacter actor, IGameItem offering)
+	{
+		return _prototype.ConsumptionMode != OfferingConsumptionMode.RecordOnly &&
+		       offering is not null &&
+		       _contents.Contains(offering) &&
+		       (Parent.Location?.CanGetAccess(Parent, actor) ?? true);
+	}
+
+	public string WhyCannotBurnOffering(ICharacter actor, IGameItem offering)
+	{
+		if (_prototype.ConsumptionMode == OfferingConsumptionMode.RecordOnly)
+		{
+			return $"{Parent.HowSeen(actor, true)} records offerings but does not burn them.";
+		}
+
+		if (offering is null || !_contents.Contains(offering))
+		{
+			return $"That is not an offering on {Parent.HowSeen(actor)}.";
+		}
+
+		if (!(Parent.Location?.CanGetAccess(Parent, actor) ?? true))
+		{
+			return Parent.Location.WhyCannotGetAccess(Parent, actor);
+		}
+
+		return $"You cannot burn {offering.HowSeen(actor)} at {Parent.HowSeen(actor)}.";
+	}
+
+	public bool BurnOffering(ICharacter actor, IGameItem offering, IEmote? playerEmote)
+	{
+		if (!CanBurnOffering(actor, offering))
+		{
+			actor.OutputHandler.Send(WhyCannotBurnOffering(actor, offering));
+			return false;
+		}
+
+		actor.OutputHandler.Handle(
+			new MixedEmoteOutput(new Emote(_prototype.BurnEcho, actor, actor, offering, Parent)).Append(playerEmote));
+		_prototype.OnBurnProg?.Execute(actor, Parent, offering);
+		HandleOfferingEvent(EventType.OfferingBurned, EventType.OfferingBurnedWitness, actor, offering);
+
+		_contents.Remove(offering);
+		offering.ContainedIn = null;
+		if (_prototype.ResidueItemProto is null)
+		{
+			offering.Delete();
+		}
+		else
+		{
+			var residue = _prototype.ResidueItemProto.CreateNew(actor);
+			residue.RoomLayer = Parent.RoomLayer;
+			residue.ContainedIn = Parent;
+			_contents.Add(residue);
+			residue.Login();
+			offering.Delete();
+		}
+
+		Changed = true;
+		return true;
+	}
+
+	private bool CanAcceptItem(ICharacter? actor, IGameItem item)
+	{
+		return item != Parent &&
+		       (item.Size <= _prototype.MaximumItemSize || item.IsItemType<ICommodity>()) &&
+		       _contents.Sum(x => x.Weight) + item.Weight <= _prototype.MaximumContentsWeight &&
+		       TagRulesAccept(item) &&
+		       (actor is null || (_prototype.CanOfferProg?.ExecuteBool(false, actor, Parent, item) ?? true));
+	}
+
+	private bool TagRulesAccept(IGameItem item)
+	{
+		if (_prototype.BlockedTags.Any(tag => item.IsA(tag)))
+		{
+			return false;
+		}
+
+		return !_prototype.AllowedTags.Any() || _prototype.AllowedTags.Any(tag => item.IsA(tag));
+	}
+
+	private void HandleOfferingEvent(EventType itemEvent, EventType witnessEvent, ICharacter actor, IGameItem offering)
+	{
+		Parent.HandleEvent(itemEvent, Parent, actor, offering);
+		foreach (var witness in Parent.TrueLocations.SelectMany(x => x.EventHandlers))
+		{
+			witness.HandleEvent(witnessEvent, Parent, actor, offering, witness);
+		}
+	}
+}

--- a/MudSharpCore/GameItems/Prototypes/IncenseBurnerGameItemComponentProto.cs
+++ b/MudSharpCore/GameItems/Prototypes/IncenseBurnerGameItemComponentProto.cs
@@ -1,0 +1,393 @@
+using MudSharp.Accounts;
+using MudSharp.Character;
+using MudSharp.Framework;
+using MudSharp.Framework.Revision;
+using MudSharp.Framework.Units;
+using MudSharp.FutureProg;
+using MudSharp.GameItems.Components;
+using MudSharp.Health;
+using MudSharp.PerceptionEngine;
+using MudSharp.RPG.Checks;
+using System;
+using System.Xml.Linq;
+
+#nullable enable
+
+namespace MudSharp.GameItems.Prototypes;
+
+public class IncenseBurnerGameItemComponentProto : GameItemComponentProto, IIncenseBurnerPrototype
+{
+	protected IncenseBurnerGameItemComponentProto(IFuturemud gameworld, IAccount originator)
+		: base(gameworld, originator, "IncenseBurner")
+	{
+		MaximumFuelWeight = 1000.0;
+		SecondsPerUnitWeight = 60.0;
+		ScentRange = 1;
+		DrugRange = 0;
+		DrugPulseSeconds = 10;
+		LingeringMultiplier = 5.0;
+		SourceScentDescription = "A curl of fragrant smoke hangs in the air.";
+		DistantScentDescription = "A faint trace of fragrant smoke drifts in from nearby.";
+		ScentDifficulty = Difficulty.Normal;
+		Changed = true;
+	}
+
+	protected IncenseBurnerGameItemComponentProto(MudSharp.Models.GameItemComponentProto proto, IFuturemud gameworld)
+		: base(proto, gameworld)
+	{
+	}
+
+	public override string TypeDescription => "IncenseBurner";
+	public ITag? FuelTag { get; protected set; }
+	public double MaximumFuelWeight { get; protected set; }
+	public double SecondsPerUnitWeight { get; protected set; }
+	public int ScentRange { get; protected set; }
+	public int DrugRange { get; protected set; }
+	public int DrugPulseSeconds { get; protected set; }
+	public double LingeringMultiplier { get; protected set; }
+	public string SourceScentDescription { get; protected set; } = string.Empty;
+	public string DistantScentDescription { get; protected set; } = string.Empty;
+	public Difficulty ScentDifficulty { get; protected set; }
+	public IDrug? Drug { get; protected set; }
+	public double GramsPerPulse { get; protected set; }
+
+	protected override void LoadFromXml(XElement root)
+	{
+		FuelTag = Gameworld.Tags.Get(long.Parse(root.Element("FuelTag")?.Value ?? "0"));
+		MaximumFuelWeight = double.Parse(root.Element("MaximumFuelWeight")?.Value ?? "1000.0");
+		SecondsPerUnitWeight = double.Parse(root.Element("SecondsPerUnitWeight")?.Value ?? "60.0");
+		ScentRange = int.Parse(root.Element("ScentRange")?.Value ?? "1");
+		DrugRange = int.Parse(root.Element("DrugRange")?.Value ?? "0");
+		DrugPulseSeconds = int.Parse(root.Element("DrugPulseSeconds")?.Value ?? "10");
+		LingeringMultiplier = double.Parse(root.Element("LingeringMultiplier")?.Value ?? "5.0");
+		SourceScentDescription = root.Element("SourceScentDescription")?.Value ?? string.Empty;
+		DistantScentDescription = root.Element("DistantScentDescription")?.Value ?? string.Empty;
+		ScentDifficulty = (Difficulty)int.Parse(root.Element("ScentDifficulty")?.Value ?? ((int)Difficulty.Normal).ToString());
+		Drug = Gameworld.Drugs.Get(long.Parse(root.Element("Drug")?.Value ?? "0"));
+		GramsPerPulse = double.Parse(root.Element("GramsPerPulse")?.Value ?? "0.0");
+	}
+
+	protected override string SaveToXml()
+	{
+		return new XElement("Definition",
+			new XElement("FuelTag", FuelTag?.Id ?? 0),
+			new XElement("MaximumFuelWeight", MaximumFuelWeight),
+			new XElement("SecondsPerUnitWeight", SecondsPerUnitWeight),
+			new XElement("ScentRange", ScentRange),
+			new XElement("DrugRange", DrugRange),
+			new XElement("DrugPulseSeconds", DrugPulseSeconds),
+			new XElement("LingeringMultiplier", LingeringMultiplier),
+			new XElement("SourceScentDescription", new XCData(SourceScentDescription)),
+			new XElement("DistantScentDescription", new XCData(DistantScentDescription)),
+			new XElement("ScentDifficulty", (int)ScentDifficulty),
+			new XElement("Drug", Drug?.Id ?? 0),
+			new XElement("GramsPerPulse", GramsPerPulse)).ToString();
+	}
+
+	public override IGameItemComponent CreateNew(IGameItem parent, ICharacter? loader = null, bool temporary = false)
+	{
+		return new IncenseBurnerGameItemComponent(this, parent, temporary);
+	}
+
+	public override IGameItemComponent LoadComponent(MudSharp.Models.GameItemComponent component, IGameItem parent)
+	{
+		return new IncenseBurnerGameItemComponent(component, this, parent);
+	}
+
+	public override IEditableRevisableItem CreateNewRevision(ICharacter initiator)
+	{
+		return CreateNewRevision(initiator,
+			(proto, gameworld) => new IncenseBurnerGameItemComponentProto(proto, gameworld));
+	}
+
+	public static void RegisterComponentInitialiser(GameItemComponentManager manager)
+	{
+		manager.AddBuilderLoader("incenseburner", true,
+			(gameworld, account) => new IncenseBurnerGameItemComponentProto(gameworld, account));
+		manager.AddBuilderLoader("incense burner", false,
+			(gameworld, account) => new IncenseBurnerGameItemComponentProto(gameworld, account));
+		manager.AddDatabaseLoader("IncenseBurner",
+			(proto, gameworld) => new IncenseBurnerGameItemComponentProto(proto, gameworld));
+		manager.AddTypeHelpInfo(
+			"IncenseBurner",
+			$"A lightable container that burns tagged fuel into ambient scent",
+			BuildingHelpText);
+	}
+
+	private const string BuildingHelpText =
+		"You can use the following options with this component:\n\t#3name <name>#0 - sets the name of the component\n\t#3desc <desc>#0 - sets the description of the component\n\t#3tag <tag>|clear#0 - sets the required fuel tag\n\t#3capacity <weight>#0 - sets maximum fuel weight\n\t#3rate <seconds>#0 - sets burn seconds per unit weight\n\t#3range <rooms>#0 - sets scent spread range\n\t#3linger <multiplier>#0 - sets scent lingering multiplier\n\t#3source <text>|clear#0 - sets scent text in the source cell\n\t#3distant <text>|clear#0 - sets scent text in other cells\n\t#3difficulty <difficulty>#0 - sets scent tracking difficulty\n\t#3drug <drug>|clear#0 - sets optional inhaled drug\n\t#3dose <weight>#0 - sets drug dose per pulse\n\t#3pulse <seconds>#0 - sets drug pulse interval\n\t#3drugrange <rooms>#0 - sets drug dosing range";
+
+	public override string ShowBuildingHelp => BuildingHelpText;
+
+	public override bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopSpeech().ToLowerInvariant())
+		{
+			case "tag":
+			case "fueltag":
+				return BuildingCommandFuelTag(actor, command);
+			case "capacity":
+			case "maxfuel":
+				return BuildingCommandCapacity(actor, command);
+			case "rate":
+			case "secondsperweight":
+				return BuildingCommandRate(actor, command);
+			case "range":
+				return BuildingCommandRange(actor, command);
+			case "drugrange":
+				return BuildingCommandDrugRange(actor, command);
+			case "pulse":
+				return BuildingCommandPulse(actor, command);
+			case "linger":
+				return BuildingCommandLinger(actor, command);
+			case "source":
+			case "sourcedesc":
+				return BuildingCommandSource(actor, command);
+			case "distant":
+			case "distantdesc":
+				return BuildingCommandDistant(actor, command);
+			case "difficulty":
+				return BuildingCommandDifficulty(actor, command);
+			case "drug":
+				return BuildingCommandDrug(actor, command);
+			case "dose":
+			case "grams":
+				return BuildingCommandDose(actor, command);
+			default:
+				return base.BuildingCommand(actor, command.GetUndo());
+		}
+	}
+
+	public override string ComponentDescriptionOLC(ICharacter actor)
+	{
+		return
+			$"{"Incense Burner Item Component".Colour(Telnet.Cyan)} (#{Id:N0}r{RevisionNumber:N0}, {Name})\n\nFuel Tag: {FuelTag?.Name.ColourName() ?? "Any".ColourValue()}\nCapacity: {MaximumFuelWeight.ToString("N2", actor).ColourValue()} weight units\nBurn Rate: {SecondsPerUnitWeight.ToString("N2", actor).ColourValue()} seconds per unit weight\nScent Range: {ScentRange.ToString("N0", actor).ColourValue()} rooms\nScent Difficulty: {ScentDifficulty.DescribeColoured()}\nSource Scent: {SourceScentDescription.ColourCommand()}\nDistant Scent: {DistantScentDescription.ColourCommand()}\nDrug: {Drug?.Name.ColourName() ?? "None".ColourError()}\nDose: {GramsPerPulse.ToString("N4", actor).ColourValue()} grams every {DrugPulseSeconds.ToString("N0", actor).ColourValue()} seconds to {DrugRange.ToString("N0", actor).ColourValue()} rooms";
+	}
+
+	private bool BuildingCommandFuelTag(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send($"Which item tag should count as incense fuel? Use {"clear".ColourCommand()} to accept any item.");
+			return false;
+		}
+
+		if (command.SafeRemainingArgument.EqualTo("clear"))
+		{
+			FuelTag = null;
+			Changed = true;
+			actor.OutputHandler.Send("This incense burner will now accept any item as fuel.");
+			return true;
+		}
+
+		var tag = long.TryParse(command.SafeRemainingArgument, out var value)
+			? Gameworld.Tags.Get(value)
+			: Gameworld.Tags.GetByName(command.SafeRemainingArgument);
+		if (tag is null)
+		{
+			actor.OutputHandler.Send("There is no such tag.");
+			return false;
+		}
+
+		FuelTag = tag;
+		Changed = true;
+		actor.OutputHandler.Send($"This incense burner now accepts fuel tagged {tag.Name.ColourName()}.");
+		return true;
+	}
+
+	private bool BuildingCommandCapacity(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("What maximum fuel weight should it hold?");
+			return false;
+		}
+
+		var value = Gameworld.UnitManager.GetBaseUnits(command.SafeRemainingArgument, UnitType.Mass, out var success);
+		if (!success || value <= 0.0)
+		{
+			actor.OutputHandler.Send("You must enter a positive weight.");
+			return false;
+		}
+
+		MaximumFuelWeight = value;
+		Changed = true;
+		actor.OutputHandler.Send($"This incense burner now holds {Gameworld.UnitManager.DescribeExact(MaximumFuelWeight, UnitType.Mass, actor).ColourValue()} of fuel.");
+		return true;
+	}
+
+	private bool BuildingCommandRate(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !double.TryParse(command.PopSpeech(), out var value) || value <= 0.0)
+		{
+			actor.OutputHandler.Send("You must enter a positive number of seconds per unit weight.");
+			return false;
+		}
+
+		SecondsPerUnitWeight = value;
+		Changed = true;
+		actor.OutputHandler.Send($"Fuel will now burn for {SecondsPerUnitWeight.ToString("N2", actor).ColourValue()} seconds per unit weight.");
+		return true;
+	}
+
+	private bool BuildingCommandRange(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !int.TryParse(command.PopSpeech(), out var value) || value < 0)
+		{
+			actor.OutputHandler.Send("You must enter a non-negative number of rooms.");
+			return false;
+		}
+
+		ScentRange = value;
+		Changed = true;
+		actor.OutputHandler.Send($"Scent will now spread {ScentRange.ToString("N0", actor).ColourValue()} rooms.");
+		return true;
+	}
+
+	private bool BuildingCommandDrugRange(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !int.TryParse(command.PopSpeech(), out var value) || value < 0)
+		{
+			actor.OutputHandler.Send("You must enter a non-negative number of rooms.");
+			return false;
+		}
+
+		DrugRange = value;
+		Changed = true;
+		actor.OutputHandler.Send($"Drug dosing will now reach {DrugRange.ToString("N0", actor).ColourValue()} rooms.");
+		return true;
+	}
+
+	private bool BuildingCommandPulse(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !int.TryParse(command.PopSpeech(), out var value) || value <= 0)
+		{
+			actor.OutputHandler.Send("You must enter a positive number of seconds.");
+			return false;
+		}
+
+		DrugPulseSeconds = value;
+		Changed = true;
+		actor.OutputHandler.Send($"Drug dosing will now pulse every {DrugPulseSeconds.ToString("N0", actor).ColourValue()} seconds.");
+		return true;
+	}
+
+	private bool BuildingCommandLinger(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !double.TryParse(command.PopSpeech(), out var value) || value <= 0.0)
+		{
+			actor.OutputHandler.Send("You must enter a positive lingering multiplier.");
+			return false;
+		}
+
+		LingeringMultiplier = value;
+		Changed = true;
+		actor.OutputHandler.Send($"Scent effects will now linger {LingeringMultiplier.ToString("N2", actor).ColourValue()} times the refreshed burn seconds.");
+		return true;
+	}
+
+	private bool BuildingCommandSource(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send($"What text should appear in the source cell? Use {"clear".ColourCommand()} to clear it.");
+			return false;
+		}
+
+		SourceScentDescription = command.SafeRemainingArgument.EqualTo("clear")
+			? string.Empty
+			: command.SafeRemainingArgument.ProperSentences().Trim().SubstituteANSIColour();
+		Changed = true;
+		actor.OutputHandler.Send($"The source scent text is now: {SourceScentDescription.ColourCommand()}");
+		return true;
+	}
+
+	private bool BuildingCommandDistant(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send($"What text should appear in distant cells? Use {"clear".ColourCommand()} to clear it.");
+			return false;
+		}
+
+		DistantScentDescription = command.SafeRemainingArgument.EqualTo("clear")
+			? string.Empty
+			: command.SafeRemainingArgument.ProperSentences().Trim().SubstituteANSIColour();
+		Changed = true;
+		actor.OutputHandler.Send($"The distant scent text is now: {DistantScentDescription.ColourCommand()}");
+		return true;
+	}
+
+	private bool BuildingCommandDifficulty(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !command.SafeRemainingArgument.TryParseEnum<Difficulty>(out var value))
+		{
+			actor.OutputHandler.Send("You must enter a valid difficulty.");
+			return false;
+		}
+
+		ScentDifficulty = value;
+		Changed = true;
+		actor.OutputHandler.Send($"Scent tracking difficulty is now {ScentDifficulty.DescribeColoured()}.");
+		return true;
+	}
+
+	private bool BuildingCommandDrug(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send($"Which inhaled drug should this incense deliver? Use {"clear".ColourCommand()} to clear it.");
+			return false;
+		}
+
+		if (command.SafeRemainingArgument.EqualTo("clear"))
+		{
+			Drug = null;
+			Changed = true;
+			actor.OutputHandler.Send("This incense burner no longer delivers any drug.");
+			return true;
+		}
+
+		var drug = long.TryParse(command.SafeRemainingArgument, out var value)
+			? Gameworld.Drugs.Get(value)
+			: Gameworld.Drugs.GetByName(command.SafeRemainingArgument);
+		if (drug is null)
+		{
+			actor.OutputHandler.Send("There is no such drug.");
+			return false;
+		}
+
+		if (!drug.DrugVectors.HasFlag(DrugVector.Inhaled))
+		{
+			actor.OutputHandler.Send($"The drug {drug.Name.ColourName()} cannot be used because it does not support the inhaled vector.");
+			return false;
+		}
+
+		Drug = drug;
+		Changed = true;
+		actor.OutputHandler.Send($"This incense burner now delivers {drug.Name.ColourName()} while burning.");
+		return true;
+	}
+
+	private bool BuildingCommandDose(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("How much drug should each pulse deliver?");
+			return false;
+		}
+
+		var value = Gameworld.UnitManager.GetBaseUnits(command.SafeRemainingArgument, UnitType.Mass, out var success) *
+		            Gameworld.UnitManager.BaseWeightToKilograms * 1000.0;
+		if (!success || value <= 0.0)
+		{
+			actor.OutputHandler.Send("You must enter a positive drug weight.");
+			return false;
+		}
+
+		GramsPerPulse = value;
+		Changed = true;
+		actor.OutputHandler.Send($"Each drug pulse will now deliver {GramsPerPulse.ToString("N4", actor).ColourValue()} grams.");
+		return true;
+	}
+}

--- a/MudSharpCore/GameItems/Prototypes/OfferingReceiverGameItemComponentProto.cs
+++ b/MudSharpCore/GameItems/Prototypes/OfferingReceiverGameItemComponentProto.cs
@@ -1,0 +1,356 @@
+using MudSharp.Accounts;
+using MudSharp.Character;
+using MudSharp.Form.Shape;
+using MudSharp.Framework;
+using MudSharp.Framework.Revision;
+using MudSharp.Framework.Units;
+using MudSharp.FutureProg;
+using MudSharp.GameItems.Components;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Parsers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+#nullable enable
+
+namespace MudSharp.GameItems.Prototypes;
+
+public class OfferingReceiverGameItemComponentProto : GameItemComponentProto, IOfferingReceiverPrototype
+{
+	protected OfferingReceiverGameItemComponentProto(IFuturemud gameworld, IAccount originator)
+		: base(gameworld, originator, "OfferingReceiver")
+	{
+		MaximumContentsWeight = 100000.0;
+		MaximumItemSize = SizeCategory.Huge;
+		ConsumptionMode = OfferingConsumptionMode.ManualBurn;
+		AcceptEcho = "@ offer|offers $1 at $2.";
+		BurnEcho = "@ burn|burns $1 at $2.";
+		RejectEcho = "$2 rejects $1.";
+		Changed = true;
+	}
+
+	protected OfferingReceiverGameItemComponentProto(MudSharp.Models.GameItemComponentProto proto, IFuturemud gameworld)
+		: base(proto, gameworld)
+	{
+	}
+
+	public override string TypeDescription => "OfferingReceiver";
+	public List<ITag> AllowedTags { get; } = [];
+	public List<ITag> BlockedTags { get; } = [];
+	public double MaximumContentsWeight { get; protected set; }
+	public SizeCategory MaximumItemSize { get; protected set; }
+	public OfferingConsumptionMode ConsumptionMode { get; protected set; }
+	public IGameItemProto? ResidueItemProto { get; protected set; }
+	public IFutureProg? CanOfferProg { get; protected set; }
+	public IFutureProg? OnOfferProg { get; protected set; }
+	public IFutureProg? OnBurnProg { get; protected set; }
+	public string AcceptEcho { get; protected set; } = string.Empty;
+	public string BurnEcho { get; protected set; } = string.Empty;
+	public string RejectEcho { get; protected set; } = string.Empty;
+
+	protected override void LoadFromXml(XElement root)
+	{
+		AllowedTags.Clear();
+		AllowedTags.AddRange(root.Element("AllowedTags")?.Elements("Tag")
+		                         .Select(x => Gameworld.Tags.Get(long.Parse(x.Value)))
+		                         .Where(x => x is not null)
+		                         .Select(x => x!)
+		                         ?? Enumerable.Empty<ITag>());
+		BlockedTags.Clear();
+		BlockedTags.AddRange(root.Element("BlockedTags")?.Elements("Tag")
+		                         .Select(x => Gameworld.Tags.Get(long.Parse(x.Value)))
+		                         .Where(x => x is not null)
+		                         .Select(x => x!)
+		                         ?? Enumerable.Empty<ITag>());
+		MaximumContentsWeight = double.Parse(root.Element("MaximumContentsWeight")?.Value ?? "100000.0");
+		MaximumItemSize = (SizeCategory)int.Parse(root.Element("MaximumItemSize")?.Value ?? ((int)SizeCategory.Huge).ToString());
+		ConsumptionMode = root.Element("ConsumptionMode")?.Value.TryParseEnum<OfferingConsumptionMode>(out var mode) == true
+			? mode
+			: OfferingConsumptionMode.ManualBurn;
+		ResidueItemProto = Gameworld.ItemProtos.Get(long.Parse(root.Element("ResidueItemProto")?.Value ?? "0"));
+		CanOfferProg = Gameworld.FutureProgs.Get(long.Parse(root.Element("CanOfferProg")?.Value ?? "0"));
+		OnOfferProg = Gameworld.FutureProgs.Get(long.Parse(root.Element("OnOfferProg")?.Value ?? "0"));
+		OnBurnProg = Gameworld.FutureProgs.Get(long.Parse(root.Element("OnBurnProg")?.Value ?? "0"));
+		AcceptEcho = root.Element("AcceptEcho")?.Value ?? "@ offer|offers $1 at $2.";
+		BurnEcho = root.Element("BurnEcho")?.Value ?? "@ burn|burns $1 at $2.";
+		RejectEcho = root.Element("RejectEcho")?.Value ?? "$2 rejects $1.";
+	}
+
+	protected override string SaveToXml()
+	{
+		return new XElement("Definition",
+			new XElement("AllowedTags", AllowedTags.Select(x => new XElement("Tag", x.Id))),
+			new XElement("BlockedTags", BlockedTags.Select(x => new XElement("Tag", x.Id))),
+			new XElement("MaximumContentsWeight", MaximumContentsWeight),
+			new XElement("MaximumItemSize", (int)MaximumItemSize),
+			new XElement("ConsumptionMode", ConsumptionMode.ToString()),
+			new XElement("ResidueItemProto", ResidueItemProto?.Id ?? 0),
+			new XElement("CanOfferProg", CanOfferProg?.Id ?? 0),
+			new XElement("OnOfferProg", OnOfferProg?.Id ?? 0),
+			new XElement("OnBurnProg", OnBurnProg?.Id ?? 0),
+			new XElement("AcceptEcho", new XCData(AcceptEcho)),
+			new XElement("BurnEcho", new XCData(BurnEcho)),
+			new XElement("RejectEcho", new XCData(RejectEcho))).ToString();
+	}
+
+	public override IGameItemComponent CreateNew(IGameItem parent, ICharacter? loader = null, bool temporary = false)
+	{
+		return new OfferingReceiverGameItemComponent(this, parent, temporary);
+	}
+
+	public override IGameItemComponent LoadComponent(MudSharp.Models.GameItemComponent component, IGameItem parent)
+	{
+		return new OfferingReceiverGameItemComponent(component, this, parent);
+	}
+
+	public override IEditableRevisableItem CreateNewRevision(ICharacter initiator)
+	{
+		return CreateNewRevision(initiator,
+			(proto, gameworld) => new OfferingReceiverGameItemComponentProto(proto, gameworld));
+	}
+
+	public static void RegisterComponentInitialiser(GameItemComponentManager manager)
+	{
+		manager.AddBuilderLoader("offeringreceiver", true,
+			(gameworld, account) => new OfferingReceiverGameItemComponentProto(gameworld, account));
+		manager.AddBuilderLoader("offering receiver", false,
+			(gameworld, account) => new OfferingReceiverGameItemComponentProto(gameworld, account));
+		manager.AddDatabaseLoader("OfferingReceiver",
+			(proto, gameworld) => new OfferingReceiverGameItemComponentProto(proto, gameworld));
+		manager.AddTypeHelpInfo(
+			"OfferingReceiver",
+			$"A ritual focus that receives and optionally burns item offerings",
+			BuildingHelpText);
+	}
+
+	private const string BuildingHelpText =
+		"You can use the following options with this component:\n\t#3name <name>#0 - sets the name of the component\n\t#3desc <desc>#0 - sets the description of the component\n\t#3allow <tag>|clear#0 - toggles an allowed offering tag or clears all\n\t#3block <tag>|clear#0 - toggles a blocked offering tag or clears all\n\t#3capacity <weight>#0 - sets maximum contained offering weight\n\t#3size <size>#0 - sets maximum item size\n\t#3mode manual|onoffer|record#0 - sets consumption mode\n\t#3residue <proto>|clear#0 - sets optional residue prototype\n\t#3canprog <prog>|clear#0 - sets boolean offer gate prog\n\t#3offerprog <prog>|clear#0 - sets void offer prog\n\t#3burnprog <prog>|clear#0 - sets void burn prog\n\t#3acceptecho <emote>#0 - sets accepted offering emote\n\t#3burnecho <emote>#0 - sets burning emote\n\t#3rejectecho <emote>#0 - sets rejected offering emote";
+
+	public override string ShowBuildingHelp => BuildingHelpText;
+
+	public override bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopSpeech().ToLowerInvariant())
+		{
+			case "allow":
+			case "allowed":
+				return BuildingCommandTag(actor, command, AllowedTags, "allowed");
+			case "block":
+			case "blocked":
+				return BuildingCommandTag(actor, command, BlockedTags, "blocked");
+			case "capacity":
+				return BuildingCommandCapacity(actor, command);
+			case "size":
+				return BuildingCommandSize(actor, command);
+			case "mode":
+				return BuildingCommandMode(actor, command);
+			case "residue":
+				return BuildingCommandResidue(actor, command);
+			case "canprog":
+				return BuildingCommandProg(actor, command, "CanOffer", ProgVariableTypes.Boolean,
+					prog => CanOfferProg = prog);
+			case "offerprog":
+			case "onoffer":
+				return BuildingCommandProg(actor, command, "OnOffer", ProgVariableTypes.Void,
+					prog => OnOfferProg = prog);
+			case "burnprog":
+			case "onburn":
+				return BuildingCommandProg(actor, command, "OnBurn", ProgVariableTypes.Void,
+					prog => OnBurnProg = prog);
+			case "acceptecho":
+				return BuildingCommandEcho(actor, command, "accept", value => AcceptEcho = value);
+			case "burnecho":
+				return BuildingCommandEcho(actor, command, "burn", value => BurnEcho = value);
+			case "rejectecho":
+				return BuildingCommandEcho(actor, command, "reject", value => RejectEcho = value);
+			default:
+				return base.BuildingCommand(actor, command.GetUndo());
+		}
+	}
+
+	public override string ComponentDescriptionOLC(ICharacter actor)
+	{
+		return
+			$"{"Offering Receiver Item Component".Colour(Telnet.Cyan)} (#{Id:N0}r{RevisionNumber:N0}, {Name})\n\nMode: {ConsumptionMode.DescribeEnum().ColourName()}\nCapacity: {MaximumContentsWeight.ToString("N2", actor).ColourValue()} weight units\nMaximum Size: {MaximumItemSize.Describe().ColourName()}\nAllowed Tags: {(AllowedTags.Any() ? AllowedTags.Select(x => x.Name.ColourName()).ListToString() : "Any".ColourValue())}\nBlocked Tags: {(BlockedTags.Any() ? BlockedTags.Select(x => x.Name.ColourName()).ListToString() : "None".ColourValue())}\nResidue: {ResidueItemProto?.EditHeader().ColourName() ?? "None".ColourError()}\nCanOffer Prog: {CanOfferProg?.MXPClickableFunctionName() ?? "None".ColourError()}\nOnOffer Prog: {OnOfferProg?.MXPClickableFunctionName() ?? "None".ColourError()}\nOnBurn Prog: {OnBurnProg?.MXPClickableFunctionName() ?? "None".ColourError()}\nAccept Echo: {AcceptEcho.ColourCommand()}\nBurn Echo: {BurnEcho.ColourCommand()}\nReject Echo: {RejectEcho.ColourCommand()}";
+	}
+
+	private bool BuildingCommandTag(ICharacter actor, StringStack command, List<ITag> tags, string name)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send($"Which tag should be toggled in the {name} list? Use {"clear".ColourCommand()} to clear all.");
+			return false;
+		}
+
+		if (command.SafeRemainingArgument.EqualTo("clear"))
+		{
+			tags.Clear();
+			Changed = true;
+			actor.OutputHandler.Send($"The {name} tag list is now clear.");
+			return true;
+		}
+
+		var tag = long.TryParse(command.SafeRemainingArgument, out var value)
+			? Gameworld.Tags.Get(value)
+			: Gameworld.Tags.GetByName(command.SafeRemainingArgument);
+		if (tag is null)
+		{
+			actor.OutputHandler.Send("There is no such tag.");
+			return false;
+		}
+
+		if (tags.Contains(tag))
+		{
+			tags.Remove(tag);
+			actor.OutputHandler.Send($"The tag {tag.Name.ColourName()} is no longer {name}.");
+		}
+		else
+		{
+			tags.Add(tag);
+			actor.OutputHandler.Send($"The tag {tag.Name.ColourName()} is now {name}.");
+		}
+
+		Changed = true;
+		return true;
+	}
+
+	private bool BuildingCommandCapacity(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("What maximum offering weight should this focus hold?");
+			return false;
+		}
+
+		var value = Gameworld.UnitManager.GetBaseUnits(command.SafeRemainingArgument, UnitType.Mass, out var success);
+		if (!success || value <= 0.0)
+		{
+			actor.OutputHandler.Send("You must enter a positive weight.");
+			return false;
+		}
+
+		MaximumContentsWeight = value;
+		Changed = true;
+		actor.OutputHandler.Send($"This focus now holds {Gameworld.UnitManager.DescribeExact(MaximumContentsWeight, UnitType.Mass, actor).ColourValue()} of offerings.");
+		return true;
+	}
+
+	private bool BuildingCommandSize(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !command.SafeRemainingArgument.TryParseEnum<SizeCategory>(out var value))
+		{
+			actor.OutputHandler.Send("You must enter a valid item size.");
+			return false;
+		}
+
+		MaximumItemSize = value;
+		Changed = true;
+		actor.OutputHandler.Send($"This focus now accepts items up to {MaximumItemSize.Describe().ColourName()} size.");
+		return true;
+	}
+
+	private bool BuildingCommandMode(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which mode? Valid values are manual, onoffer and record.");
+			return false;
+		}
+
+		ConsumptionMode = command.PopSpeech().ToLowerInvariant() switch
+		{
+			"manual" => OfferingConsumptionMode.ManualBurn,
+			"onoffer" or "on-offer" or "burnonoffer" or "burn-on-offer" => OfferingConsumptionMode.BurnOnOffer,
+			"record" or "recordonly" or "record-only" => OfferingConsumptionMode.RecordOnly,
+			_ => ConsumptionMode
+		};
+
+		Changed = true;
+		actor.OutputHandler.Send($"This focus now uses {ConsumptionMode.DescribeEnum().ColourName()} mode.");
+		return true;
+	}
+
+	private bool BuildingCommandResidue(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send($"Which item prototype should be left as residue? Use {"clear".ColourCommand()} to delete offerings instead.");
+			return false;
+		}
+
+		if (command.SafeRemainingArgument.EqualTo("clear"))
+		{
+			ResidueItemProto = null;
+			Changed = true;
+			actor.OutputHandler.Send("Burned offerings will now leave no residue.");
+			return true;
+		}
+
+		var proto = Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(command.SafeRemainingArgument);
+		if (proto is null)
+		{
+			actor.OutputHandler.Send("There is no such item prototype.");
+			return false;
+		}
+
+		ResidueItemProto = proto;
+		Changed = true;
+		actor.OutputHandler.Send($"Burned offerings will now leave {proto.EditHeader().ColourName()}.");
+		return true;
+	}
+
+	private bool BuildingCommandProg(ICharacter actor, StringStack command, string progName,
+		ProgVariableTypes returnType, Action<IFutureProg?> setter)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send($"Which prog should be used for {progName}? Use {"clear".ColourCommand()} to clear it.");
+			return false;
+		}
+
+		if (command.SafeRemainingArgument.EqualTo("clear"))
+		{
+			setter(null);
+			Changed = true;
+			actor.OutputHandler.Send($"The {progName} prog is now clear.");
+			return true;
+		}
+
+		var prog = new ProgLookupFromBuilderInput(actor, command.SafeRemainingArgument, returnType,
+			new[] { ProgVariableTypes.Character, ProgVariableTypes.Item, ProgVariableTypes.Item }).LookupProg();
+		if (prog is null)
+		{
+			return false;
+		}
+
+		setter(prog);
+		Changed = true;
+		actor.OutputHandler.Send($"The {progName} prog is now {prog.MXPClickableFunctionName()}.");
+		return true;
+	}
+
+	private bool BuildingCommandEcho(ICharacter actor, StringStack command, string name, Action<string> setter)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send($"What emote should be shown for the {name} action?");
+			return false;
+		}
+
+		var text = command.SafeRemainingArgument;
+		var emote = new Emote(text, actor, actor);
+		if (!emote.Valid)
+		{
+			actor.OutputHandler.Send(emote.ErrorMessage);
+			return false;
+		}
+
+		setter(text);
+		Changed = true;
+		actor.OutputHandler.Send($"The {name} echo is now {text.ColourCommand()}.");
+		return true;
+	}
+}


### PR DESCRIPTION
## Summary
- add incense burner and offering receiver item components with scent tracking, ambient effects, offering/burn commands, and hook events
- seed antiquity incense/offering component prototypes and items, including stock marker coverage
- update item and antiquity docs plus focused runtime, event metadata, and seeder tests

## Validation
- dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510
- dotnet build DatabaseSeeder\DatabaseSeeder.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510
- dotnet test "MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj" -c Debug --no-restore --filter SealAndMeasurementComponentTests -p:NoWarn=NU1902%3BNU1510
- dotnet test "FutureMUDLibrary Unit Tests\FutureMUDLibrary Unit Tests.csproj" -c Debug --no-restore --filter EventTypeMetadataTests -p:NoWarn=NU1902%3BNU1510
- dotnet test "DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj" -c Debug --no-restore --filter UsefulSeederItemPackageTests -p:NoWarn=NU1902%3BNU1510
- scripts\test-unit-core.ps1