### PR TITLE
Add incremental hierarchical pathfinding

### DIFF
--- a/Design Documents/README.md
+++ b/Design Documents/README.md
@@ -128,6 +128,7 @@ This folder is organised by subsystem so implementation notes, builder workflows
 - [Celestial Type: Sun](./World/Celestial_Type_Sun.md)
 - [Celestial Type: SunFromPlanetaryMoon](./World/Celestial_Type_SunFromPlanetaryMoon.md)
 - [Corporeality and Planes](./World/Corporeality_and_Planes.md)
+- [Pathfinding System](./World/Pathfinding_System.md)
 - [Position State System](./World/Position_State_System.md)
 - [Time and Date System](./World/Time_And_Date_System.md)
 - [Zero Gravity System](./World/Zero_Gravity_System.md)

--- a/Design Documents/World/Pathfinding_System.md
+++ b/Design Documents/World/Pathfinding_System.md
@@ -1,0 +1,50 @@
+# Pathfinding System
+
+## Runtime Model
+
+FutureMUD has two pathfinding modes:
+
+- Exact searches use the existing shortest-path helper behaviour and remain the default for all existing callers.
+- Hierarchical searches are opt-in through `PathSearchOptions` and are intended for long-distance AI, tooling, and administrative queries where a live-valid route is more important than a globally shortest route.
+
+`IExitManager` owns the `IPathfindingService`. The service keeps an immutable topology snapshot containing stable map facts only: cell ids, cluster ids, zone-aware coordinate buckets, and boundary connections between clusters. It does not cache actor suitability, door state, lock state, full paths, or live exit objects.
+
+## Incremental Indexing
+
+Topology invalidation is deliberately cheap. Exit overlay rebuilds, transient exit registration/removal, and cell deletion mark the index dirty and cancel any in-progress builder, but they do not rebuild the index synchronously.
+
+The main engine loop calls `PathfindingService.DoIdleWork(...)` during the existing idle window, before lazy-load flushing receives the remaining time budget. The default loop cap is small, currently 3ms per tick, and the builder also has a work-unit cap so tests and future tuning can force multi-slice rebuilds. A new snapshot is published only after all queued cells have been processed.
+
+Door and lock changes do not invalidate the topology snapshot. Hierarchical queries validate every returned segment against live exits and the caller's suitability predicate, so stale topology can suggest a candidate route but cannot return an invalid path through a locked, closed, actor-blocked, or otherwise unsuitable exit.
+
+## Query Behaviour
+
+`PathSearchAlgorithm.Exact` always uses the existing exact search.
+
+`PathSearchAlgorithm.Automatic` uses exact search below the configured threshold and hierarchical search at or above it.
+
+`PathSearchAlgorithm.Hierarchical` uses the last complete topology snapshot. If no snapshot exists, or if the query cannot assemble a live-valid route within its bounded retry count, it returns no path. It does not force a full-world exact fallback.
+
+Hierarchical routing works in two phases:
+
+1. Search the abstract cluster graph for candidate boundary exits.
+2. Resolve each segment between source, boundary cells, and target cells with the exact helper, using the caller's live suitability predicate.
+
+If a live segment or boundary exit fails validation, that abstract edge is blocked for the current query and another high-level route is attempted until the retry limit is reached.
+
+## Extension Points
+
+Opt-in overloads are available on the known-destination helper family:
+
+- `PathBetween(..., PathSearchOptions options)`
+- multi-target `PathBetween(..., PathSearchOptions options)`
+- `ExitsBetween(..., PathSearchOptions options)`
+- `DistanceBetween(..., PathSearchOptions options)`
+
+Vicinity scans and target-acquisition helpers remain exact-only in this version because they are usually local perception workflows and are sensitive to nearest-target semantics.
+
+## Operational Notes
+
+Pathfinding diagnostics expose the current snapshot version, dirty state, queued build state, snapshot counts, and last slice/build timings. These counters are intended for admin debugging and future performance tuning.
+
+The v1 implementation intentionally avoids background threads. Live game objects are not generally thread-safe, so the index is built in main-loop idle slices and published as a complete snapshot when ready.

--- a/FutureMUDLibrary/Construction/Boundary/IExitManager.cs
+++ b/FutureMUDLibrary/Construction/Boundary/IExitManager.cs
@@ -5,6 +5,8 @@ namespace MudSharp.Construction.Boundary
 {
     public interface IExitManager
     {
+        IPathfindingService PathfindingService { get; }
+
         /// <summary>
         ///     Retrieves the correct exit for the specified cell
         /// </summary>

--- a/FutureMUDLibrary/Construction/Boundary/IPathfindingService.cs
+++ b/FutureMUDLibrary/Construction/Boundary/IPathfindingService.cs
@@ -1,0 +1,57 @@
+using MudSharp.Framework;
+using System;
+using System.Collections.Generic;
+
+namespace MudSharp.Construction.Boundary;
+
+public enum PathSearchAlgorithm
+{
+	Exact,
+	Automatic,
+	Hierarchical
+}
+
+public sealed class PathSearchOptions
+{
+	public static PathSearchOptions Exact { get; } = new();
+	public static PathSearchOptions Automatic { get; } = new()
+	{
+		Algorithm = PathSearchAlgorithm.Automatic
+	};
+	public static PathSearchOptions Hierarchical { get; } = new()
+	{
+		Algorithm = PathSearchAlgorithm.Hierarchical
+	};
+
+	public PathSearchAlgorithm Algorithm { get; init; } = PathSearchAlgorithm.Exact;
+	public uint HierarchicalThreshold { get; init; } = 30;
+	public uint MaximumExactSegmentDistance { get; init; } = 64;
+	public int MaximumHierarchicalRetries { get; init; } = 4;
+}
+
+public sealed class PathfindingServiceDiagnostics
+{
+	public long CurrentSnapshotVersion { get; init; }
+	public bool IsDirty { get; init; }
+	public bool IsBuildQueued { get; init; }
+	public int SnapshotCellCount { get; init; }
+	public int SnapshotClusterCount { get; init; }
+	public int SnapshotBoundaryEdgeCount { get; init; }
+	public int QueuedCellCount { get; init; }
+	public int ProcessedCellCount { get; init; }
+	public int LastSliceCellsProcessed { get; init; }
+	public int LastSliceEdgesScanned { get; init; }
+	public TimeSpan LastBuildDuration { get; init; }
+	public TimeSpan LastSliceDuration { get; init; }
+}
+
+public interface IPathfindingService
+{
+	PathfindingServiceDiagnostics Diagnostics { get; }
+	void InvalidateTopology(ICell changedCell = null);
+	void RequestIndexWarmup();
+	void DoIdleWork(TimeSpan budget);
+	bool TryFindLongRangePath(ICell source, IReadOnlyCollection<ICell> targets, uint maximumDistance,
+		Func<ICellExit, bool> suitabilityFunction, bool ignoreLayers, PathSearchOptions options,
+		out IReadOnlyList<ICellExit> path);
+}

--- a/MudSharpCore Unit Tests/PathSearchTests.cs
+++ b/MudSharpCore Unit Tests/PathSearchTests.cs
@@ -43,6 +43,7 @@ public class PathSearchTests
                     List<CellExitStub> exits = new();
                     CellStub cell = new()
                     {
+                        Id = i * 50 + j + 1,
                         Room = new RoomStub
                         {
                             X = i,
@@ -145,6 +146,7 @@ public class PathSearchTests
                     List<CellExitStub> exits = new();
                     CellStub cell = new()
                     {
+                        Id = i * 50 + j + 1,
                         Room = new RoomStub
                         {
                             X = i,
@@ -209,6 +211,57 @@ public class PathSearchTests
     public static IPerceivable Person4Flight { get; set; }
     public static IPerceivable Person5Flight { get; set; }
 
+    private static (IFuturemud Gameworld, PathfindingService Service, ICell[] Cells) BuildLinearPath(int count)
+    {
+        All<ICell> allCells = new();
+        Mock<IFuturemud> gameworld = new();
+        Mock<IExitManager> exitManager = new();
+        PathfindingService service = new(gameworld.Object);
+        exitManager.Setup(x => x.PathfindingService).Returns(service);
+        gameworld.Setup(x => x.Cells).Returns(allCells);
+        gameworld.Setup(x => x.ExitManager).Returns(exitManager.Object);
+
+        CellStub[] cellStubs = Enumerable.Range(0, count)
+                                         .Select(i => new CellStub
+                                         {
+                                             Id = i + 1,
+                                             Name = $"Linear {i}",
+                                             Gameworld = gameworld.Object,
+                                             Room = new RoomStub { X = i, Y = 0, Z = 0 }.ToMock(),
+                                             Exits = new List<CellExitStub>()
+                                         })
+                                         .ToArray();
+        for (int i = 0; i < count - 1; i++)
+        {
+            cellStubs[i].Exits.Add(new CellExitStub
+            {
+                Destination = cellStubs[i + 1],
+                Exit = new ExitStub(),
+                OutboundDirection = CardinalDirection.East
+            });
+            cellStubs[i + 1].Exits.Add(new CellExitStub
+            {
+                Destination = cellStubs[i],
+                Exit = new ExitStub(),
+                OutboundDirection = CardinalDirection.West
+            });
+        }
+
+        List<Mock<ICell>> cellMocks = cellStubs.Select(x => x.ToMock()).ToList();
+        ICell[] cells = cellStubs.Select(x => x.GetObject(cellMocks)).ToArray();
+        foreach (ICell cell in cells)
+        {
+            allCells.Add(cell);
+        }
+
+        return (gameworld.Object, service, cells);
+    }
+
+    private static IPerceivable PerceivableAt(ICell cell, IFuturemud gameworld)
+    {
+        return new PerceivableStub { Location = cell, Gameworld = gameworld }.ToMock();
+    }
+
     [TestMethod]
     public void TestASharpPath()
     {
@@ -217,6 +270,245 @@ public class PathSearchTests
 
         path = Person1Flight.PathBetween(Person3Flight, 1, true).ToList();
         Assert.AreEqual(1, path.Count, $"It was expected that the two persons were 1 square apart but they were {path.Count} apart instead. \n\nPath was: {path.Select(x => x.OutboundDirection.DescribeBrief()).ListToString()}.\n\n{path.Select(x => x.Destination.Name).ListToString()}");
+    }
+
+    [TestMethod]
+    public void AutomaticPathBelowThresholdUsesExactSearch()
+    {
+        List<ICellExit> path = Person1Flight.PathBetween(Person2Flight, 15, true,
+            new PathSearchOptions { Algorithm = PathSearchAlgorithm.Automatic, HierarchicalThreshold = 100 }).ToList();
+
+        Assert.AreEqual(9, path.Count, "Expected automatic mode below threshold to preserve exact pathing.");
+    }
+
+    [TestMethod]
+    public void HierarchicalPathFindsLongLinearRouteAfterIdleBuild()
+    {
+        (IFuturemud gameworld, PathfindingService service, ICell[] cells) = BuildLinearPath(100);
+        service.RequestIndexWarmup();
+        service.DoIdleWork(TimeSpan.FromSeconds(5));
+
+        IPerceivable source = PerceivableAt(cells[0], gameworld);
+        IPerceivable target = PerceivableAt(cells[99], gameworld);
+        List<ICellExit> path = source.PathBetween(target, 150, _ => true, PathSearchOptions.Hierarchical).ToList();
+
+        Assert.AreEqual(99, path.Count, "Expected hierarchical pathing to produce the full long route.");
+        Assert.IsTrue(service.Diagnostics.CurrentSnapshotVersion > 0, "Expected idle work to publish an index snapshot.");
+    }
+
+    [TestMethod]
+    public void HierarchicalPathValidatesDoorStateWithoutRebuildingIndex()
+    {
+        All<ICell> allCells = new();
+        Mock<IFuturemud> gameworld = new();
+        Mock<IExitManager> exitManager = new();
+        PathfindingService service = new(gameworld.Object);
+        exitManager.Setup(x => x.PathfindingService).Returns(service);
+        gameworld.Setup(x => x.Cells).Returns(allCells);
+        gameworld.Setup(x => x.ExitManager).Returns(exitManager.Object);
+
+        DoorStub door = new() { IsOpen = true, Locked = false, State = DoorState.Open };
+        CellStub cellA = new()
+        {
+            Id = 1001,
+            Name = "A",
+            Gameworld = gameworld.Object,
+            Room = new RoomStub { X = 0, Y = 0, Z = 0 }.ToMock(),
+            Exits = new List<CellExitStub>()
+        };
+        CellStub cellB = new()
+        {
+            Id = 1002,
+            Name = "B",
+            Gameworld = gameworld.Object,
+            Room = new RoomStub { X = 11, Y = 0, Z = 0 }.ToMock(),
+            Exits = new List<CellExitStub>()
+        };
+        CellStub cellC = new()
+        {
+            Id = 1003,
+            Name = "C",
+            Gameworld = gameworld.Object,
+            Room = new RoomStub { X = 0, Y = 11, Z = 0 }.ToMock(),
+            Exits = new List<CellExitStub>()
+        };
+
+        cellA.Exits.Add(new CellExitStub
+        {
+            Destination = cellB,
+            Exit = new ExitStub { Door = door },
+            OutboundDirection = CardinalDirection.East
+        });
+        cellA.Exits.Add(new CellExitStub
+        {
+            Destination = cellC,
+            Exit = new ExitStub(),
+            OutboundDirection = CardinalDirection.South
+        });
+        cellC.Exits.Add(new CellExitStub
+        {
+            Destination = cellB,
+            Exit = new ExitStub(),
+            OutboundDirection = CardinalDirection.East
+        });
+
+        CellStub[] stubs = [cellA, cellB, cellC];
+        List<Mock<ICell>> mocks = stubs.Select(x => x.ToMock()).ToList();
+        ICell[] cells = stubs.Select(x => x.GetObject(mocks)).ToArray();
+        foreach (ICell cell in cells)
+        {
+            allCells.Add(cell);
+        }
+
+        service.RequestIndexWarmup();
+        service.DoIdleWork(TimeSpan.FromSeconds(5));
+        long snapshotVersion = service.Diagnostics.CurrentSnapshotVersion;
+        door.IsOpen = false;
+        door.Locked = true;
+
+        IPerceivable source = PerceivableAt(cells[0], gameworld.Object);
+        IPerceivable target = PerceivableAt(cells[1], gameworld.Object);
+        List<ICellExit> path = source.PathBetween(target, 10, true, PathSearchOptions.Hierarchical).ToList();
+
+        Assert.AreEqual(snapshotVersion, service.Diagnostics.CurrentSnapshotVersion,
+            "Changing door state should not rebuild the topology index.");
+        Assert.AreEqual(2, path.Count, "Expected pathing to reject the now-locked direct door and use the alternate route.");
+        Assert.AreSame(cells[2], path[0].Destination);
+        Assert.AreSame(cells[1], path[1].Destination);
+    }
+
+    [TestMethod]
+    public void HierarchicalPathRetriesAlternatePortalWhenFinalSegmentFails()
+    {
+        All<ICell> allCells = new();
+        Mock<IFuturemud> gameworld = new();
+        Mock<IExitManager> exitManager = new();
+        PathfindingService service = new(gameworld.Object);
+        exitManager.Setup(x => x.PathfindingService).Returns(service);
+        gameworld.Setup(x => x.Cells).Returns(allCells);
+        gameworld.Setup(x => x.ExitManager).Returns(exitManager.Object);
+
+        CellStub sourceCell = new()
+        {
+            Id = 2001,
+            Name = "Source",
+            Gameworld = gameworld.Object,
+            Room = new RoomStub { X = 0, Y = 0, Z = 0 }.ToMock(),
+            Exits = new List<CellExitStub>()
+        };
+        CellStub badPortal = new()
+        {
+            Id = 2002,
+            Name = "Bad Portal",
+            Gameworld = gameworld.Object,
+            Room = new RoomStub { X = 11, Y = 0, Z = 0 }.ToMock(),
+            Exits = new List<CellExitStub>()
+        };
+        CellStub goodPortal = new()
+        {
+            Id = 2003,
+            Name = "Good Portal",
+            Gameworld = gameworld.Object,
+            Room = new RoomStub { X = 12, Y = 0, Z = 0 }.ToMock(),
+            Exits = new List<CellExitStub>()
+        };
+        CellStub targetCell = new()
+        {
+            Id = 2004,
+            Name = "Target",
+            Gameworld = gameworld.Object,
+            Room = new RoomStub { X = 13, Y = 0, Z = 0 }.ToMock(),
+            Exits = new List<CellExitStub>()
+        };
+
+        sourceCell.Exits.Add(new CellExitStub
+        {
+            Destination = badPortal,
+            Exit = new ExitStub(),
+            OutboundDirection = CardinalDirection.East
+        });
+        sourceCell.Exits.Add(new CellExitStub
+        {
+            Destination = goodPortal,
+            Exit = new ExitStub(),
+            OutboundDirection = CardinalDirection.SouthEast
+        });
+        goodPortal.Exits.Add(new CellExitStub
+        {
+            Destination = targetCell,
+            Exit = new ExitStub(),
+            OutboundDirection = CardinalDirection.East
+        });
+
+        CellStub[] stubs = [sourceCell, badPortal, goodPortal, targetCell];
+        List<Mock<ICell>> mocks = stubs.Select(x => x.ToMock()).ToList();
+        ICell[] cells = stubs.Select(x => x.GetObject(mocks)).ToArray();
+        foreach (ICell cell in cells)
+        {
+            allCells.Add(cell);
+        }
+
+        service.RequestIndexWarmup();
+        service.DoIdleWork(TimeSpan.FromSeconds(5));
+
+        IPerceivable source = PerceivableAt(cells[0], gameworld.Object);
+        IPerceivable target = PerceivableAt(cells[3], gameworld.Object);
+        List<ICellExit> path = source
+                               .PathBetween(target, 10, _ => true, new PathSearchOptions
+                               {
+                                   Algorithm = PathSearchAlgorithm.Hierarchical,
+                                   MaximumHierarchicalRetries = 2
+                               })
+                               .ToList();
+
+        Assert.AreEqual(2, path.Count,
+            "Expected hierarchical pathing to retry the alternate target-cluster portal after the first final segment failed.");
+        Assert.AreSame(cells[2], path[0].Destination);
+        Assert.AreSame(cells[3], path[1].Destination);
+    }
+
+    [TestMethod]
+    public void TransientExitRegistrationInvalidatesPathfindingTopology()
+    {
+        All<ICell> allCells = new();
+        Mock<IFuturemud> gameworld = new();
+        gameworld.Setup(x => x.Cells).Returns(allCells);
+        ExitManager manager = new(gameworld.Object);
+        manager.PathfindingService.DoIdleWork(TimeSpan.FromSeconds(1));
+        Assert.IsFalse(manager.PathfindingService.Diagnostics.IsDirty,
+            "Expected the empty topology build to clear the initial dirty state.");
+
+        Mock<ICell> cell1 = new();
+        cell1.Setup(x => x.Id).Returns(3001);
+        Mock<ICell> cell2 = new();
+        cell2.Setup(x => x.Id).Returns(3002);
+        Mock<IExit> exit = new();
+        exit.Setup(x => x.Cells).Returns(new[] { cell1.Object, cell2.Object });
+
+        manager.RegisterTransientExit(exit.Object);
+
+        Assert.IsTrue(manager.PathfindingService.Diagnostics.IsDirty,
+            "Expected transient exits to invalidate the topology snapshot.");
+    }
+
+    [TestMethod]
+    public void IdleBuildPublishesOnlyAfterBudgetedSlicesComplete()
+    {
+        (_, PathfindingService service, _) = BuildLinearPath(3);
+        service.MaximumCellsPerIdleSlice = 1;
+        service.RequestIndexWarmup();
+
+        service.DoIdleWork(TimeSpan.FromSeconds(1));
+        Assert.AreEqual(0, service.Diagnostics.CurrentSnapshotVersion,
+            "Expected the first one-cell slice not to publish a partial snapshot.");
+        Assert.IsTrue(service.Diagnostics.IsBuildQueued);
+
+        service.DoIdleWork(TimeSpan.FromSeconds(1));
+        service.DoIdleWork(TimeSpan.FromSeconds(1));
+        service.DoIdleWork(TimeSpan.FromSeconds(1));
+
+        Assert.IsTrue(service.Diagnostics.CurrentSnapshotVersion > 0,
+            "Expected the snapshot to publish only after all queued cells were processed.");
     }
 
     [TestMethod]

--- a/MudSharpCore Unit Tests/Stubs.cs
+++ b/MudSharpCore Unit Tests/Stubs.cs
@@ -41,6 +41,7 @@ public class CellStub
     public List<CellExitStub> Exits { get; set; }
     public List<IPerceivable> Perceivables { get; set; } = new();
     public IRoom Room { get; init; }
+    public IFuturemud Gameworld { get; set; }
     public long Id { get; set; }
 
     public Mock<ICell> ToMock()
@@ -49,6 +50,7 @@ public class CellStub
         mock.Setup(t => t.Name).Returns(Name);
         mock.Setup(t => t.Room).Returns(Room);
         mock.Setup(t => t.Id).Returns(Id);
+        mock.Setup(t => t.Gameworld).Returns(() => Gameworld);
         mock.Name = Name;
         return mock;
     }
@@ -110,9 +112,9 @@ public class DoorStub
         get; set;
     }
 
-    public bool IsOpen { get; init; }
+    public bool IsOpen { get; set; }
 
-    public bool Locked { get; init; }
+    public bool Locked { get; set; }
 
     public DoorState State
     {
@@ -124,10 +126,10 @@ public class DoorStub
         Mock<IDoor> mock = new();
         mock.SetupGet(t => t.CanFireThrough).Returns(CanFireThrough);
         mock.SetupGet(t => t.CanPlayersSmash).Returns(CanPlayersSmash);
-        mock.SetupGet(t => t.IsOpen).Returns(IsOpen);
+        mock.SetupGet(t => t.IsOpen).Returns(() => IsOpen);
         mock.SetupGet(t => t.State).Returns(State);
         Mock<ILock> lockMock = new();
-        lockMock.SetupGet(x => x.IsLocked).Returns(Locked);
+        lockMock.SetupGet(x => x.IsLocked).Returns(() => Locked);
         mock.SetupGet(t => t.Locks).Returns(new[] { lockMock.Object });
         mock.SetupProperty(t => t.InstalledExit);
         mock.SetupProperty(t => t.HingeCell);
@@ -158,10 +160,12 @@ public class ExitStub
 public class PerceivableStub
 {
     public ICell Location { get; init; }
+    public IFuturemud Gameworld { get; set; }
     public IPerceivable ToMock()
     {
         Mock<IPerceivable> mock = new();
         mock.Setup(t => t.Location).Returns(Location);
+        mock.Setup(t => t.Gameworld).Returns(() => Gameworld);
         return mock.Object;
     }
 }

--- a/MudSharpCore/Construction/Boundary/ExitManager.cs
+++ b/MudSharpCore/Construction/Boundary/ExitManager.cs
@@ -18,9 +18,12 @@ public class ExitManager : IExitManager, IHaveFuturemud
     public ExitManager(IFuturemud gameworld)
     {
         Gameworld = gameworld;
+        PathfindingService = new PathfindingService(gameworld);
     }
 
     public IFuturemud Gameworld { get; protected set; }
+
+    public IPathfindingService PathfindingService { get; }
 
     /// <summary>
     ///     Called the first time that an exit for a particular cell and/or overlay is requested. Initialises the cell in the
@@ -264,6 +267,8 @@ public class ExitManager : IExitManager, IHaveFuturemud
                 TransientExitDictionary.Add(cell, exit);
             }
         }
+
+        PathfindingService.InvalidateTopology();
     }
 
     public void UnregisterTransientExit(IExit exit)
@@ -277,6 +282,8 @@ public class ExitManager : IExitManager, IHaveFuturemud
         {
             TransientExitDictionary.Remove(cell, exit);
         }
+
+        PathfindingService.InvalidateTopology();
     }
 
     public void UpdateCellOverlayExits(ICell cell, ICellOverlay overlay)
@@ -288,10 +295,13 @@ public class ExitManager : IExitManager, IHaveFuturemud
         }
 
         InitialiseCell(cell, overlay);
+        PathfindingService.InvalidateTopology(cell);
     }
 
     public void DeleteCell(ICell cell)
     {
+        PathfindingService.InvalidateTopology(cell);
+
         // Initialise the cell so all exits are in memory
         InitialiseCell(cell, null);
 

--- a/MudSharpCore/Construction/Boundary/PathfindingService.cs
+++ b/MudSharpCore/Construction/Boundary/PathfindingService.cs
@@ -1,0 +1,506 @@
+using MudSharp.Framework;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace MudSharp.Construction.Boundary;
+
+public class PathfindingService : IPathfindingService
+{
+	private const int CoordinateBucketSize = 10;
+
+	private readonly IFuturemud _gameworld;
+	private PathfindingSnapshot _snapshot = PathfindingSnapshot.Empty;
+	private PathfindingIndexBuilder _builder;
+	private bool _dirty = true;
+	private bool _warmupRequested = true;
+	private long _nextSnapshotVersion = 1;
+	private TimeSpan _lastBuildDuration;
+	private TimeSpan _lastSliceDuration;
+	private int _lastSliceCellsProcessed;
+	private int _lastSliceEdgesScanned;
+
+	public PathfindingService(IFuturemud gameworld)
+	{
+		_gameworld = gameworld;
+	}
+
+	public int MaximumCellsPerIdleSlice { get; set; } = 512;
+
+	public PathfindingServiceDiagnostics Diagnostics => new()
+	{
+		CurrentSnapshotVersion = _snapshot.Version,
+		IsDirty = _dirty,
+		IsBuildQueued = _builder != null || _warmupRequested,
+		SnapshotCellCount = _snapshot.CellCount,
+		SnapshotClusterCount = _snapshot.ClusterCount,
+		SnapshotBoundaryEdgeCount = _snapshot.BoundaryEdgeCount,
+		QueuedCellCount = _builder?.QueuedCellCount ?? 0,
+		ProcessedCellCount = _builder?.ProcessedCellCount ?? 0,
+		LastSliceCellsProcessed = _lastSliceCellsProcessed,
+		LastSliceEdgesScanned = _lastSliceEdgesScanned,
+		LastBuildDuration = _lastBuildDuration,
+		LastSliceDuration = _lastSliceDuration
+	};
+
+	public void InvalidateTopology(ICell changedCell = null)
+	{
+		_dirty = true;
+		_warmupRequested = true;
+		_builder = null;
+	}
+
+	public void RequestIndexWarmup()
+	{
+		if (_snapshot.Version == 0 || _dirty)
+		{
+			_warmupRequested = true;
+		}
+	}
+
+	public void DoIdleWork(TimeSpan budget)
+	{
+		if (budget <= TimeSpan.Zero)
+		{
+			return;
+		}
+
+		if (_builder == null)
+		{
+			if (!_dirty && !_warmupRequested)
+			{
+				return;
+			}
+
+			_builder = new PathfindingIndexBuilder(_gameworld, _nextSnapshotVersion++, CoordinateBucketSize);
+			_warmupRequested = false;
+		}
+
+		IndexBuildSlice slice = _builder.DoWork(budget, MaximumCellsPerIdleSlice);
+		_lastSliceDuration = slice.Duration;
+		_lastSliceCellsProcessed = slice.CellsProcessed;
+		_lastSliceEdgesScanned = slice.EdgesScanned;
+
+		if (!slice.Completed)
+		{
+			return;
+		}
+
+		_snapshot = slice.Snapshot;
+		_lastBuildDuration = slice.Snapshot.BuildDuration;
+		_builder = null;
+		_dirty = false;
+	}
+
+	public bool TryFindLongRangePath(ICell source, IReadOnlyCollection<ICell> targets, uint maximumDistance,
+		Func<ICellExit, bool> suitabilityFunction, bool ignoreLayers, PathSearchOptions options,
+		out IReadOnlyList<ICellExit> path)
+	{
+		path = Array.Empty<ICellExit>();
+		if (source == null || targets == null || targets.Count == 0 || suitabilityFunction == null ||
+		    maximumDistance == 0)
+		{
+			return false;
+		}
+
+		options ??= PathSearchOptions.Hierarchical;
+		RequestIndexWarmup();
+
+		PathfindingSnapshot snapshot = _snapshot;
+		if (snapshot.Version == 0 || !snapshot.TryGetCluster(source.Id, out int sourceCluster))
+		{
+			return false;
+		}
+
+		List<ICell> targetList = targets
+		                         .Where(x => x != null)
+		                         .DistinctBy(x => x.Id)
+		                         .ToList();
+		if (!targetList.Any())
+		{
+			return false;
+		}
+
+		HashSet<int> targetClusters = targetList
+		                              .Select(x => snapshot.TryGetCluster(x.Id, out int cluster) ? cluster : -1)
+		                              .Where(x => x >= 0)
+		                              .ToHashSet();
+		if (!targetClusters.Any())
+		{
+			return false;
+		}
+
+		if (targetClusters.Contains(sourceCluster))
+		{
+			List<ICellExit> localPath = PerceivedItemExtensions.FindShortestExitPathForPathfinding(source,
+				targetList, maximumDistance, suitabilityFunction, ignoreLayers);
+			if (localPath.Count > 0)
+			{
+				path = localPath;
+				return true;
+			}
+
+			return false;
+		}
+
+		HashSet<AbstractEdgeKey> blockedEdges = new();
+		int retries = Math.Max(1, options.MaximumHierarchicalRetries);
+		for (int i = 0; i < retries; i++)
+		{
+			List<AbstractEdge> route = snapshot.FindClusterRoute(sourceCluster, targetClusters, blockedEdges);
+			if (route.Count == 0)
+			{
+				return false;
+			}
+
+			if (TryAssembleLivePath(source, targetList, route, maximumDistance, suitabilityFunction, ignoreLayers,
+				    options, blockedEdges, out List<ICellExit> assembledPath))
+			{
+				path = assembledPath;
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private bool TryAssembleLivePath(ICell source, IReadOnlyCollection<ICell> targets,
+		IReadOnlyList<AbstractEdge> route, uint maximumDistance, Func<ICellExit, bool> suitabilityFunction,
+		bool ignoreLayers, PathSearchOptions options, ISet<AbstractEdgeKey> blockedEdges,
+		out List<ICellExit> path)
+	{
+		path = new List<ICellExit>();
+		ICell current = source;
+		uint remainingDistance = maximumDistance;
+		uint segmentLimit = Math.Max(1, Math.Min(options.MaximumExactSegmentDistance, maximumDistance));
+
+		foreach (AbstractEdge edge in route)
+		{
+			ICell fromCell = _gameworld.Cells.Get(edge.FromCellId);
+			ICell toCell = _gameworld.Cells.Get(edge.ToCellId);
+			if (fromCell == null || toCell == null)
+			{
+				blockedEdges.Add(edge.Key);
+				return false;
+			}
+
+			if (!ReferenceEquals(current, fromCell))
+			{
+				List<ICellExit> segment = PerceivedItemExtensions.FindShortestExitPathForPathfinding(current,
+					[fromCell], Math.Min(remainingDistance, segmentLimit), suitabilityFunction, ignoreLayers);
+				if (segment.Count == 0)
+				{
+					blockedEdges.Add(edge.Key);
+					return false;
+				}
+
+				path.AddRange(segment);
+				remainingDistance = maximumDistance >= path.Count ? maximumDistance - (uint)path.Count : 0;
+				if (remainingDistance == 0)
+				{
+					return false;
+				}
+			}
+
+			ICellExit liveExit = fromCell
+			                     .ExitsFor(null, ignoreLayers)
+			                     .FirstOrDefault(x => x.Destination?.Id == toCell.Id && suitabilityFunction(x));
+			if (liveExit == null)
+			{
+				blockedEdges.Add(edge.Key);
+				return false;
+			}
+
+			path.Add(liveExit);
+			if (path.Count > maximumDistance)
+			{
+				return false;
+			}
+
+			remainingDistance = maximumDistance - (uint)path.Count;
+			current = toCell;
+		}
+
+		if (targets.Any(x => ReferenceEquals(x, current) || x.Id == current.Id))
+		{
+			return path.Count <= maximumDistance;
+		}
+
+		List<ICellExit> finalSegment = PerceivedItemExtensions.FindShortestExitPathForPathfinding(current,
+			targets, Math.Min(remainingDistance, segmentLimit), suitabilityFunction, ignoreLayers);
+		if (finalSegment.Count == 0)
+		{
+			if (route.Count > 0)
+			{
+				blockedEdges.Add(route[^1].Key);
+			}
+
+			return false;
+		}
+
+		path.AddRange(finalSegment);
+		if (path.Count <= maximumDistance)
+		{
+			return true;
+		}
+
+		if (route.Count > 0)
+		{
+			blockedEdges.Add(route[^1].Key);
+		}
+
+		return false;
+	}
+
+	private sealed class PathfindingIndexBuilder
+	{
+		private readonly IFuturemud _gameworld;
+		private readonly long _version;
+		private readonly int _bucketSize;
+		private readonly IEnumerator<ICell> _cells;
+		private readonly Stopwatch _buildStopwatch = new();
+		private readonly Dictionary<ClusterKey, int> _clusterIds = new();
+		private readonly Dictionary<long, int> _cellClusters = new();
+		private readonly List<TopologyEdge> _topologyEdges = new();
+
+		public PathfindingIndexBuilder(IFuturemud gameworld, long version, int bucketSize)
+		{
+			_gameworld = gameworld;
+			_version = version;
+			_bucketSize = bucketSize;
+			_cells = _gameworld.Cells.GetEnumerator();
+			QueuedCellCount = _gameworld.Cells.Count;
+			_buildStopwatch.Start();
+		}
+
+		public int QueuedCellCount { get; }
+		public int ProcessedCellCount { get; private set; }
+
+		public IndexBuildSlice DoWork(TimeSpan budget, int maximumCells)
+		{
+			Stopwatch sliceStopwatch = Stopwatch.StartNew();
+			int cellsProcessed = 0;
+			int edgesScanned = 0;
+			while (cellsProcessed < maximumCells && sliceStopwatch.Elapsed < budget)
+			{
+				if (!_cells.MoveNext())
+				{
+					_cells.Dispose();
+					_buildStopwatch.Stop();
+					return new IndexBuildSlice
+					{
+						Completed = true,
+						CellsProcessed = cellsProcessed,
+						EdgesScanned = edgesScanned,
+						Duration = sliceStopwatch.Elapsed,
+						Snapshot = BuildSnapshot(_buildStopwatch.Elapsed)
+					};
+				}
+
+				edgesScanned += ProcessCell(_cells.Current);
+				cellsProcessed++;
+				ProcessedCellCount++;
+			}
+
+			return new IndexBuildSlice
+			{
+				Completed = false,
+				CellsProcessed = cellsProcessed,
+				EdgesScanned = edgesScanned,
+				Duration = sliceStopwatch.Elapsed
+			};
+		}
+
+		private int ProcessCell(ICell cell)
+		{
+			if (cell == null || cell.Id == 0)
+			{
+				return 0;
+			}
+
+			int clusterId = GetClusterId(ClusterKeyFor(cell));
+			_cellClusters[cell.Id] = clusterId;
+			int edgeCount = 0;
+			foreach (ICellExit exit in cell.ExitsFor(null, true))
+			{
+				if (exit?.Destination == null || exit.Destination.Id == 0)
+				{
+					continue;
+				}
+
+				_topologyEdges.Add(new TopologyEdge(cell.Id, exit.Destination.Id, exit.Exit?.Id ?? 0));
+				edgeCount++;
+			}
+
+			return edgeCount;
+		}
+
+		private int GetClusterId(ClusterKey key)
+		{
+			if (_clusterIds.TryGetValue(key, out int existing))
+			{
+				return existing;
+			}
+
+			int id = _clusterIds.Count;
+			_clusterIds[key] = id;
+			return id;
+		}
+
+		private ClusterKey ClusterKeyFor(ICell cell)
+		{
+			if (cell.Room == null)
+			{
+				return new ClusterKey(cell.Zone?.Id ?? 0, (int)(cell.Id / 64), 0, 0);
+			}
+
+			return new ClusterKey(cell.Zone?.Id ?? 0, FloorDiv(cell.Room.X, _bucketSize),
+				FloorDiv(cell.Room.Y, _bucketSize), FloorDiv(cell.Room.Z, _bucketSize));
+		}
+
+		private static int FloorDiv(int value, int divisor)
+		{
+			return value >= 0 ? value / divisor : -((-value + divisor - 1) / divisor);
+		}
+
+		private PathfindingSnapshot BuildSnapshot(TimeSpan buildDuration)
+		{
+			Dictionary<int, List<AbstractEdge>> boundaryEdges = new();
+			HashSet<AbstractEdgeKey> seenEdges = new();
+			foreach (TopologyEdge edge in _topologyEdges)
+			{
+				if (!_cellClusters.TryGetValue(edge.FromCellId, out int fromCluster) ||
+				    !_cellClusters.TryGetValue(edge.ToCellId, out int toCluster) ||
+				    fromCluster == toCluster)
+				{
+					continue;
+				}
+
+				AbstractEdge abstractEdge = new(fromCluster, toCluster, edge.FromCellId, edge.ToCellId, edge.ExitId);
+				if (!seenEdges.Add(abstractEdge.Key))
+				{
+					continue;
+				}
+
+				if (!boundaryEdges.TryGetValue(fromCluster, out List<AbstractEdge> edges))
+				{
+					edges = new List<AbstractEdge>();
+					boundaryEdges[fromCluster] = edges;
+				}
+
+				edges.Add(abstractEdge);
+			}
+
+			return new PathfindingSnapshot(_version, _cellClusters, boundaryEdges, _clusterIds.Count,
+				_cellClusters.Count, boundaryEdges.Values.Sum(x => x.Count), buildDuration);
+		}
+	}
+
+	private sealed class PathfindingSnapshot
+	{
+		public static PathfindingSnapshot Empty { get; } = new(0, new Dictionary<long, int>(),
+			new Dictionary<int, List<AbstractEdge>>(), 0, 0, 0, TimeSpan.Zero);
+
+		public PathfindingSnapshot(long version, IReadOnlyDictionary<long, int> cellClusters,
+			IReadOnlyDictionary<int, List<AbstractEdge>> boundaryEdges, int clusterCount, int cellCount,
+			int boundaryEdgeCount, TimeSpan buildDuration)
+		{
+			Version = version;
+			CellClusters = cellClusters;
+			BoundaryEdges = boundaryEdges;
+			ClusterCount = clusterCount;
+			CellCount = cellCount;
+			BoundaryEdgeCount = boundaryEdgeCount;
+			BuildDuration = buildDuration;
+		}
+
+		public long Version { get; }
+		public IReadOnlyDictionary<long, int> CellClusters { get; }
+		public IReadOnlyDictionary<int, List<AbstractEdge>> BoundaryEdges { get; }
+		public int ClusterCount { get; }
+		public int CellCount { get; }
+		public int BoundaryEdgeCount { get; }
+		public TimeSpan BuildDuration { get; }
+
+		public bool TryGetCluster(long cellId, out int cluster)
+		{
+			return CellClusters.TryGetValue(cellId, out cluster);
+		}
+
+		public List<AbstractEdge> FindClusterRoute(int sourceCluster, ISet<int> targetClusters,
+			ISet<AbstractEdgeKey> blockedEdges)
+		{
+			Queue<ClusterSearchStep> queue = new();
+			HashSet<int> seen = new()
+			{
+				sourceCluster
+			};
+			queue.Enqueue(new ClusterSearchStep(sourceCluster, null, null));
+
+			while (queue.Count > 0)
+			{
+				ClusterSearchStep step = queue.Dequeue();
+				if (targetClusters.Contains(step.Cluster))
+				{
+					return BuildClusterRoute(step);
+				}
+
+				if (!BoundaryEdges.TryGetValue(step.Cluster, out List<AbstractEdge> edges))
+				{
+					continue;
+				}
+
+				foreach (AbstractEdge edge in edges)
+				{
+					if (blockedEdges.Contains(edge.Key) || !seen.Add(edge.ToCluster))
+					{
+						continue;
+					}
+
+					queue.Enqueue(new ClusterSearchStep(edge.ToCluster, edge, step));
+				}
+			}
+
+			return new List<AbstractEdge>();
+		}
+
+		private static List<AbstractEdge> BuildClusterRoute(ClusterSearchStep step)
+		{
+			List<AbstractEdge> route = new();
+			ClusterSearchStep current = step;
+			while (current?.ViaEdge != null)
+			{
+				route.Add(current.ViaEdge.Value);
+				current = current.Parent;
+			}
+
+			route.Reverse();
+			return route;
+		}
+	}
+
+	private sealed record ClusterSearchStep(int Cluster, AbstractEdge? ViaEdge, ClusterSearchStep Parent);
+
+	private readonly record struct ClusterKey(long ZoneId, int X, int Y, int Z);
+
+	private readonly record struct TopologyEdge(long FromCellId, long ToCellId, long ExitId);
+
+	private readonly record struct AbstractEdge(int FromCluster, int ToCluster, long FromCellId, long ToCellId,
+		long ExitId)
+	{
+		public AbstractEdgeKey Key => new(FromCluster, ToCluster, FromCellId, ToCellId, ExitId);
+	}
+
+	private readonly record struct AbstractEdgeKey(int FromCluster, int ToCluster, long FromCellId, long ToCellId,
+		long ExitId);
+
+	private sealed class IndexBuildSlice
+	{
+		public bool Completed { get; init; }
+		public int CellsProcessed { get; init; }
+		public int EdgesScanned { get; init; }
+		public TimeSpan Duration { get; init; }
+		public PathfindingSnapshot Snapshot { get; init; }
+	}
+}

--- a/MudSharpCore/Framework/Futuremud.cs
+++ b/MudSharpCore/Framework/Futuremud.cs
@@ -420,6 +420,17 @@ public sealed partial class Futuremud : IFuturemud, IDisposable
                 {
                     long milliseconds = 250 - totalTime.ElapsedMilliseconds;
                     totalTime.Start();
+                    TimeSpan pathfindingBudget = TimeSpan.FromMilliseconds(Math.Min(milliseconds, 3));
+                    sw.Restart();
+                    ExitManager.PathfindingService.DoIdleWork(pathfindingBudget);
+                    if (sw.ElapsedMilliseconds > 50)
+                    {
+                        Console.ForegroundColor = ConsoleColor.DarkYellow;
+                        Console.WriteLine($"[PERF] - PathfindingService.DoIdleWork() took {sw.ElapsedMilliseconds}ms");
+                        Console.ResetColor();
+                    }
+
+                    milliseconds = Math.Max(0, milliseconds - sw.ElapsedMilliseconds);
                     SaveManager.FlushLazyLoad(TimeSpan.FromMilliseconds(milliseconds));
                 }
 

--- a/MudSharpCore/Framework/PerceivedItemExtensions.cs
+++ b/MudSharpCore/Framework/PerceivedItemExtensions.cs
@@ -316,6 +316,34 @@ public static class PerceivedItemExtensions
         return new List<ICellExit>();
     }
 
+    internal static List<ICellExit> FindShortestExitPathForPathfinding(ICell source, IEnumerable<ICell> targets,
+        uint maximumDistance, Func<ICellExit, bool> suitabilityFunction, bool ignoreLayers)
+    {
+        return FindShortestExitPath(source, targets, maximumDistance, suitabilityFunction, ignoreLayers);
+    }
+
+    private static List<ICellExit> FindPath(ICell source, IReadOnlyCollection<ICell> targets,
+        uint maximumDistance, Func<ICellExit, bool> suitabilityFunction, bool ignoreLayers, PathSearchOptions options)
+    {
+        options ??= PathSearchOptions.Exact;
+        if (options.Algorithm == PathSearchAlgorithm.Exact ||
+            options.Algorithm == PathSearchAlgorithm.Automatic && maximumDistance < options.HierarchicalThreshold)
+        {
+            return FindShortestExitPath(source, targets, maximumDistance, suitabilityFunction, ignoreLayers);
+        }
+
+        IPathfindingService service = source?.Gameworld?.ExitManager?.PathfindingService;
+        if (service == null)
+        {
+            return new List<ICellExit>();
+        }
+
+        return service.TryFindLongRangePath(source, targets, maximumDistance, suitabilityFunction, ignoreLayers,
+            options, out IReadOnlyList<ICellExit> path)
+            ? path.ToList()
+            : new List<ICellExit>();
+    }
+
     private static double SearchPriority(int distance, ICell cell, IReadOnlyCollection<IRoom> targetRooms)
     {
         if (cell?.Room == null || targetRooms == null || targetRooms.Count == 0)
@@ -460,6 +488,29 @@ public static class PerceivedItemExtensions
 
         List<ICellExit> path = FindShortestExitPath(source.Location, [target.Location], maximumDistance, _ => true,
             false);
+        return path.Count == 0 ? -1 : path.Count;
+    }
+
+    /// <summary>
+    ///     Determines the number of cell exits between two perceivables using the supplied search options. Exact mode
+    ///     preserves the ordinary shortest-path behaviour; automatic and hierarchical modes may use the topology index
+    ///     for long routes but still validate every returned exit against live state.
+    /// </summary>
+    public static int DistanceBetween(this IPerceivable source, IPerceivable target, uint maximumDistance,
+        PathSearchOptions options)
+    {
+        if (source?.Location == target?.Location)
+        {
+            return 0;
+        }
+
+        if (source == null || target == null || source.Location == null || target.Location == null)
+        {
+            return -1;
+        }
+
+        List<ICellExit> path = FindPath(source.Location, [target.Location], maximumDistance, _ => true,
+            false, options);
         return path.Count == 0 ? -1 : path.Count;
     }
 
@@ -656,6 +707,26 @@ public static class PerceivedItemExtensions
         }
 
         return FindShortestExitPath(source.Location, [target.Location], maximumDistance, _ => true, false);
+    }
+
+    /// <summary>
+    ///     Returns an ordered exit path between two perceivables using the supplied search options. Hierarchical searches
+    ///     are intended for long routes and may return a valid route that is not globally shortest.
+    /// </summary>
+    public static IEnumerable<ICellExit> ExitsBetween(this IPerceivable source, IPerceivable target,
+        uint maximumDistance, PathSearchOptions options)
+    {
+        if (source?.Location == target?.Location)
+        {
+            return Enumerable.Empty<ICellExit>();
+        }
+
+        if (source == null || target == null || source.Location == null || target.Location == null)
+        {
+            return Enumerable.Empty<ICellExit>();
+        }
+
+        return FindPath(source.Location, [target.Location], maximumDistance, _ => true, false, options);
     }
 
     /// <summary>
@@ -1051,6 +1122,25 @@ public static class PerceivedItemExtensions
     }
 
     /// <summary>
+    ///     Returns an ordered exit path between two perceivables using built-in door flags and opt-in long-range search
+    ///     options. Existing callers should continue to use the overload without options when they require exact
+    ///     shortest-path semantics.
+    /// </summary>
+    public static IEnumerable<ICellExit> PathBetween(this IPerceivable source, IPerceivable target,
+        uint maximumDistance, bool openDoors, PathSearchOptions options, bool pathTransparentDoors = false,
+        bool pathFireableDoors = false)
+    {
+        if (source?.Location == target?.Location ||
+            source == null || target == null || source.Location == null || target.Location == null)
+        {
+            return Enumerable.Empty<ICellExit>();
+        }
+
+        return FindPath(source.Location, [target.Location], maximumDistance,
+            exit => CanTraverse(exit, openDoors, pathTransparentDoors, pathFireableDoors), true, options);
+    }
+
+    /// <summary>
     ///     Returns the shortest ordered exit path between two perceivables using a caller-supplied exit suitability
     ///     predicate.
     /// </summary>
@@ -1075,6 +1165,23 @@ public static class PerceivedItemExtensions
         }
 
         return FindShortestExitPath(source.Location, [target.Location], maximumDistance, suitabilityFunction, true);
+    }
+
+    /// <summary>
+    ///     Returns an ordered exit path between two perceivables using a caller-supplied live suitability predicate and
+    ///     opt-in long-range search options. Hierarchical mode uses the topology index only for coarse routing; every
+    ///     returned exit still passes <paramref name="suitabilityFunction" /> at query time.
+    /// </summary>
+    public static IEnumerable<ICellExit> PathBetween(this IPerceivable source, IPerceivable target,
+        uint maximumDistance, Func<ICellExit, bool> suitabilityFunction, PathSearchOptions options)
+    {
+        if (source?.Location == target?.Location ||
+            source == null || target == null || source.Location == null || target.Location == null)
+        {
+            return Enumerable.Empty<ICellExit>();
+        }
+
+        return FindPath(source.Location, [target.Location], maximumDistance, suitabilityFunction, true, options);
     }
 
     /// <summary>
@@ -1111,6 +1218,32 @@ public static class PerceivedItemExtensions
         }
 
         return FindShortestExitPath(source.Location, targetLocations, maximumDistance, suitabilityFunction, true);
+    }
+
+    /// <summary>
+    ///     Returns an ordered exit path from a source to the nearest reachable target in a set using opt-in search
+    ///     options. Hierarchical mode may return any live-valid reachable target route rather than the globally nearest
+    ///     target.
+    /// </summary>
+    public static IEnumerable<ICellExit> PathBetween(this IPerceivable source, IEnumerable<IPerceivable> targets,
+        uint maximumDistance, Func<ICellExit, bool> suitabilityFunction, PathSearchOptions options)
+    {
+        if (source?.Location == null || targets == null || suitabilityFunction == null)
+        {
+            return Enumerable.Empty<ICellExit>();
+        }
+
+        List<ICell> targetLocations = targets
+                                      .Select(x => x?.Location)
+                                      .Where(x => x != null)
+                                      .Distinct(CellReferenceComparer.Instance)
+                                      .ToList();
+        if (!targetLocations.Any() || targetLocations.Any(x => ReferenceEquals(x, source.Location)))
+        {
+            return Enumerable.Empty<ICellExit>();
+        }
+
+        return FindPath(source.Location, targetLocations, maximumDistance, suitabilityFunction, true, options);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Add an opt-in incremental hierarchical pathfinding service owned by `IExitManager`.
- Build immutable topology snapshots during main-loop idle slices before lazy-load flushing.
- Add `PathSearchOptions` overloads for known-destination path helpers while preserving exact default behavior.
- Document the runtime model and add regression coverage for idle builds, invalidation, dynamic door state, long routes, and alternate portal retries.

## Validation
- `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510` (883 passed)
- `git diff --check`
- `git diff --cached --check`