### PR TITLE
Add durable portal topology

### DIFF
--- a/Design Documents/Magic/Armageddon_Magic_Psionics_Gap_Report.md
+++ b/Design Documents/Magic/Armageddon_Magic_Psionics_Gap_Report.md
@@ -434,7 +434,7 @@ These tasks should be ordinary implementation work inside the existing magic, pe
 These are the remaining true blockers. They should not be represented as one-off spell effects until the supporting model exists.
 
 - Simultaneous-body possession and projection: `Send Shadow`, possession-style `Shadowwalk`, `Possess Corpse`, and body-left-behind `Disembody` need command routing, perception routing, source-body vulnerability, inventory rules, combat/death rules, reconnect behaviour, and staff observability.
-- Durable portal/rune topology: standing gates, persistent rune networks, portal objects, and topology edits that must survive beyond saved spell effects need a deliberate persistence and lifecycle model.
+- Durable portal/rune topology: implemented as DB-backed `MagicPortalNetworks`, endpoints, and explicit links that materialise into topology-managed transient exits. V1 covers standing room gates, directly placed rune/portal objects, builder repair, and spell-created topology. One-way links and mobile/carried rune endpoints remain future extensions.
 - Objective or group-scoped illusions: if illusions must alter room state for multiple observers, stack with other illusions, and expose consistent dispel/priority rules, they need a general perception-overlay policy rather than only `subjectivedesc` / `subjectivesdesc`.
 - World-specific metaphysics: `Determine Relationship`, `Solace`, `Dragon Bane`, `Cathexis`, and richer `Planeshift` interpretations need a model for land/elemental relationships, plane travel graphs, and any clan/tribe/identity consequences.
 - Durable psionic trace consequences: the live `trace` power inspects active links, but traces that persist as world facts or feed staff/audit consequences need a shared psionic trail model.
@@ -475,7 +475,7 @@ V5 should tackle the remaining architecture blockers after V3/V4 make the easy a
 - simultaneous-body possession and projection
 - objective or group-scoped illusion state that changes room facts for multiple observers
 - durable psionic trace/trail consequences that survive beyond live link inspection
-- persistent rune/gate/portal topology if saved effects and transient exits are not enough
+- persistent rune/gate/portal topology is now implemented for explicit bidirectional networks; future work is limited to one-way links or mobile/carried rune endpoint semantics if content needs them
 - world-specific metaphysics such as land relationships, elemental patronage, or clan-keyed psionic consequences
 
 `Control` and `Compel` remain policy-sensitive when authored as command-forcing effects. `Suggest`, `Project Emotion`, and most `Coerce` variants now have non-command delivery paths, but content authors should still pair them with clear IC/OOC policy and staff-facing audit expectations.
@@ -552,10 +552,11 @@ These are the parity items with the most engine-level uncertainty.
    - `Travel Gate`
    - `Portal`
    - `Create Rune`
-   - Status: simple room-target teleport, simple planar shifting, caster-owned room or item/object tag anchors, transient effect-owned paired exits, and active portal/anchor inspection are live.
+   - Status: simple room-target teleport, simple planar shifting, caster-owned room or item/object tag anchors, transient effect-owned paired exits, active portal/anchor inspection, and durable portal/rune networks are live.
    - Remaining work:
-     - persistent paired gates, standing rune networks, and portal objects beyond saved effects
-     - richer destination safety models and world-topology persistence
+     - one-way topology links, if required by content
+     - mobile/carried rune endpoint semantics, if required by content
+     - richer destination safety models beyond zone and planar validation
 
 3. Subjective illusions and perception overrides.
    - `Masquerade`
@@ -616,7 +617,7 @@ Engine V2 has shipped the deeper parity layer without jumping into simultaneous-
 
 Engine V3 shipped the small edge-status slice that sat outside Engine V2: poison detection, insomnia, cure blindness, and optional strength-contested dispel matching. Engine V5a has now also shipped the smaller persistent sensory/combat primitives for burn-over-time and magical track marking. The next remaining work should focus on the larger pieces Engine V2 deliberately left outside these slices:
 
-- durable portal/rune topology if saved effects and transient exits are not enough for standing gate networks
+- durable portal/rune topology V1 is available for standing gate networks; use future slices only for one-way links, mobile rune objects, or richer safety policy
 - richer illusion stacking and perception policy
 - advanced psionic coercion and trace consequences
 - the simultaneous-body possession/projection model

--- a/Design Documents/Magic/Magic_System_Implemented_Types.md
+++ b/Design Documents/Magic/Magic_System_Implemented_Types.md
@@ -168,6 +168,7 @@ V4 added 2 builder-creatable tag-aware ward effect tokens: `roomtagward` and `pe
 | `paralysis` | `ParalysisEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/StandaloneStatusSpellEffects.cs` via `SpellEffectFactory` | Yes | Applies forced paralysis through the health effect system |
 | `poison` | `PoisonEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/StandaloneStatusSpellEffects.Configured.cs` via `SpellEffectFactory` | Yes | Applies a configurable spell-owned drug payload |
 | `portal` | `PortalSpellEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs` via `SpellEffectFactory` | Yes | Creates effect-owned paired transient exits between the caster's room and a target room, room anchor, or item/object anchor |
+| `portalnetwork` | `PortalTopologySpellEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/PortalTopologySpellEffect.cs` via `SpellEffectFactory` | Yes | Creates or updates durable portal/rune topology endpoints and optionally explicit links inside a `MagicPortalNetwork` |
 | `rage` | `RageSpellEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/RageSpellEffect.cs` via `SpellEffectFactory` | Yes | Applies rage |
 | `relocate` | `RelocateEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/RelocateEffect.cs` via `SpellEffectFactory` | Yes | Relocates a target |
 | `removeblindness` | `RemoveBlindnessEffect` | Spell effect | Static `RegisterFactory` in `MudSharpCore/Magic/SpellEffects/BlindnessEffect.cs` via `SpellEffectFactory` | Yes | Removes spell-owned blindness effects |
@@ -237,6 +238,11 @@ V4 added 2 builder-creatable tag-aware ward effect tokens: `roomtagward` and `pe
 | --- | --- | --- |
 | `IExitManager.TransientExits` | `IEnumerable<IExit>` | Read-only enumeration of registered transient exits for builder/admin inspection |
 | n/a | `IMagicPortalExit` | Optional metadata contract implemented by transient magical portals for source, destination, caster, spell, source effect, and portal command text |
+| n/a | `IMagicPortalNetwork` | Durable portal/rune topology root containing command/display defaults, active/cross-zone policy, endpoints, and explicit links |
+| n/a | `IMagicPortalEndpoint` | Durable room or directly placed item endpoint for a portal/rune network |
+| n/a | `IMagicPortalLink` | Explicit bidirectional link between two endpoints in a portal/rune network |
+| n/a | `IMagicPortalTopologyExit` | Metadata contract implemented by topology-managed transient exits for network, link, and endpoint identity |
+| n/a | `IMagicPortalTopologyService` | Runtime service that rebuilds durable topology into transient exits and cleans up spell-created topology |
 | n/a | `IMagicProjectilePayloadEffect` | First-class projectile/ranged payload enhancement contract used by ammunition, power packs, and thrown weapons |
 | n/a | `IMagicCraftToolEnhancementEffect` | First-class craft-tool enhancement contract for tool fitness, phase speed, and tool usage multipliers |
 | n/a | `IMagicPowerOrFuelEnhancementEffect` | First-class powered-item enhancement contract for production, consumption, and fuel-use multipliers |

--- a/Design Documents/Magic/Magic_System_Spells.md
+++ b/Design Documents/Magic/Magic_System_Spells.md
@@ -454,7 +454,11 @@ The persistent sensory/combat slice adds:
 - `trackmark` / `tracktrail`: spell-owned track intensity modification for characters, with visual/olfactory multipliers or bonuses and optional magically-marked track circumstances.
 - `dispelmagic effect burning` and `dispelmagic effect trackmark` for targeted cleanup.
 
-Portals remain saved spell effects, not database exits or a gate table. The `portal` effect creates paired transient exits registered with `IExitManager`; active magical portals expose `IMagicPortalExit` metadata and can be inspected with `magic portals`. Anchor tags can be placed on rooms or items/objects with `magictag`; `portal` resolves caster-owned room anchors first, then caster-owned item anchors by using the item location. Builders can inspect active anchors with `magic anchors [tag]`.
+Simple portals remain saved spell effects, not database exits. The `portal` effect creates paired transient exits registered with `IExitManager`; active magical portals expose `IMagicPortalExit` metadata and can be inspected with `magic portals`. Anchor tags can be placed on rooms or items/objects with `magictag`; `portal` resolves caster-owned room anchors first, then caster-owned item anchors by using the item location. Builders can inspect active anchors with `magic anchors [tag]`.
+
+Durable portal/rune topology is now first-class magic data. `MagicPortalNetworks`, endpoints, and explicit links are persisted in the database, loaded after rooms/items, and materialised at runtime as topology-managed transient exits rather than permanent `Exits` rows. Builders manage standing networks with `magic portalnetwork` / `magic portalnet`, including active state, cross-zone policy, portal command text, room or directly placed item endpoints, explicit links, and `refresh` repair. The `portalnetwork` spell effect can create an endpoint at the caster room, target room, or target item and optionally link it to an existing endpoint key. Permanent casts may also update an existing endpoint key. Spell-created topology is cleaned up when the spell effect ends unless the effect is marked `permanent`.
+
+V1 topology links are bidirectional because the runtime projection uses the existing bidirectional `TransientExit` primitive. Item endpoints are active only while the referenced item is directly located in a room; carried, contained, or inventory-held rune items are treated as invalid until placed again.
 
 `itemenchant` now has first-class hooks beyond visible aura text, glow, weapon bonuses, and armour reduction:
 
@@ -508,6 +512,8 @@ Recommended manual data order:
 3. traits and trait expressions
 4. spell-known prog and any supporting target-filter or helper progs
 5. spell
+
+Durable portal networks are authored after rooms/items exist. If spells create topology, create the target `MagicPortalNetwork` first, then configure the spell's `portalnetwork` effect with the network and endpoint keys it should maintain.
 
 ## Developer Extension Workflow
 ### Adding a new trigger type

--- a/FutureMUDLibrary/Effects/Interfaces/IMagicPortalTopologyExit.cs
+++ b/FutureMUDLibrary/Effects/Interfaces/IMagicPortalTopologyExit.cs
@@ -1,0 +1,13 @@
+#nullable enable
+
+using MudSharp.Magic;
+
+namespace MudSharp.Effects.Interfaces;
+
+public interface IMagicPortalTopologyExit : IMagicPortalExit
+{
+	IMagicPortalNetwork Network { get; }
+	IMagicPortalLink Link { get; }
+	IMagicPortalEndpoint SourceEndpoint { get; }
+	IMagicPortalEndpoint DestinationEndpoint { get; }
+}

--- a/FutureMUDLibrary/Framework/IFuturemud.cs
+++ b/FutureMUDLibrary/Framework/IFuturemud.cs
@@ -217,6 +217,7 @@ namespace MudSharp.Framework
         IUneditableAll<IMagicResource> MagicResources { get; }
         IUneditableAll<IMagicResourceRegenerator> MagicResourceRegenerators { get; }
         IUneditableAll<IMagicSpell> MagicSpells { get; }
+        IUneditableAll<IMagicPortalNetwork> MagicPortalNetworks { get; }
 
         IUneditableAll<IMarket> Markets { get; }
         IUneditableAll<IMarketCategory> MarketCategories { get; }
@@ -481,6 +482,7 @@ namespace MudSharp.Framework
         void Add(IMagicPower power);
         void Add(IMagicResource resource);
         void Add(IMagicResourceRegenerator regenerator);
+        void Add(IMagicPortalNetwork network);
         void Add(IChargenAdvice advice);
         void Add(ICharacterIntroTemplate template);
         void Add(ICraft craft);
@@ -686,6 +688,7 @@ namespace MudSharp.Framework
         void Destroy(IVehiclePrototype proto);
         void Destroy(IVehicle vehicle);
         void Destroy(IVehicleHitchLink link);
+        void Destroy(IMagicPortalNetwork network);
         void Destroy(IAccount account);
         void Destroy(ICell cell);
         void Destroy(IRoom room);

--- a/FutureMUDLibrary/Framework/IFuturemudLoader.cs
+++ b/FutureMUDLibrary/Framework/IFuturemudLoader.cs
@@ -47,6 +47,7 @@
         void LoadVehiclePrototypes();
         void LoadVehicles();
         void LoadVehicleHitchLinks();
+        void LoadMagicPortalTopology();
         void LoadGameItemSkins();
         void LoadGameItemGroups();
         void LoadTraits();

--- a/FutureMUDLibrary/Magic/IMagicPortalTopology.cs
+++ b/FutureMUDLibrary/Magic/IMagicPortalTopology.cs
@@ -1,0 +1,65 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.Framework.Revision;
+using MudSharp.Framework.Save;
+using MudSharp.GameItems;
+using System.Collections.Generic;
+
+namespace MudSharp.Magic;
+
+public interface IMagicPortalNetwork : IEditableItem, ISaveable
+{
+	IMagicSchool? School { get; }
+	bool IsActive { get; }
+	bool AllowCrossZone { get; }
+	string Verb { get; }
+	string OutboundKeyword { get; }
+	string InboundKeyword { get; }
+	string OutboundTarget { get; }
+	string InboundTarget { get; }
+	string OutboundDescription { get; }
+	string InboundDescription { get; }
+	double TimeMultiplier { get; }
+	IEnumerable<IMagicPortalEndpoint> Endpoints { get; }
+	IEnumerable<IMagicPortalLink> Links { get; }
+}
+
+public interface IMagicPortalEndpoint : IFrameworkItem, IHaveFuturemud
+{
+	IMagicPortalNetwork Network { get; }
+	string Key { get; }
+	MagicPortalEndpointType EndpointType { get; }
+	long? CellId { get; }
+	long? GameItemId { get; }
+	bool IsActive { get; }
+	ICell? CurrentCell { get; }
+	string WhyInvalid { get; }
+}
+
+public interface IMagicPortalLink : IFrameworkItem, IHaveFuturemud
+{
+	IMagicPortalNetwork Network { get; }
+	IMagicPortalEndpoint SourceEndpoint { get; }
+	IMagicPortalEndpoint DestinationEndpoint { get; }
+	bool IsActive { get; }
+	string WhyInvalid { get; }
+}
+
+public interface IMagicPortalTopologyService
+{
+	IEnumerable<IMagicPortalTopologyExit> MaterializedExits(IFuturemud gameworld);
+	void RebuildAll(IFuturemud gameworld);
+	void RebuildNetwork(IMagicPortalNetwork network);
+	void RebuildNetworksForItem(IFuturemud gameworld, IGameItem item);
+	void RemoveNetworkExits(IMagicPortalNetwork network);
+	IMagicPortalEndpoint? CreateOrUpdateEndpoint(ICharacter actor, IMagicPortalNetwork network, string key, string name,
+		MagicPortalEndpointType endpointType, ICell? cell, IGameItem? item, bool replace, long? spellId,
+		out string reason);
+	IMagicPortalLink? CreateLink(ICharacter actor, IMagicPortalNetwork network, IMagicPortalEndpoint source,
+		IMagicPortalEndpoint destination, long? spellId, out string reason);
+	void DeleteSpellCreatedTopology(IFuturemud gameworld, IEnumerable<long> endpointIds, IEnumerable<long> linkIds);
+}

--- a/FutureMUDLibrary/Magic/MagicPortalEndpointType.cs
+++ b/FutureMUDLibrary/Magic/MagicPortalEndpointType.cs
@@ -1,0 +1,9 @@
+#nullable enable
+
+namespace MudSharp.Magic;
+
+public enum MagicPortalEndpointType
+{
+	Cell = 0,
+	Item = 1
+}

--- a/FutureMUDLibrary/Magic/MagicPortalTopologyAnchorMode.cs
+++ b/FutureMUDLibrary/Magic/MagicPortalTopologyAnchorMode.cs
@@ -1,0 +1,10 @@
+#nullable enable
+
+namespace MudSharp.Magic;
+
+public enum MagicPortalTopologyAnchorMode
+{
+	CasterRoom = 0,
+	TargetRoom = 1,
+	TargetItem = 2
+}

--- a/MudSharpCore Unit Tests/MagicPhase3Tests.cs
+++ b/MudSharpCore Unit Tests/MagicPhase3Tests.cs
@@ -37,6 +37,7 @@ public class MagicPhase3Tests
 		"corpseconsume",
 		"corpsespawn",
 		"portal",
+		"portalnetwork",
 		"forcecommand",
 		"subjectivedesc",
 		"subjectivesdesc"
@@ -214,6 +215,11 @@ public class MagicPhase3Tests
 			new XElement("TimeMultiplier", 1.0), new XElement("AllowCrossZone", false),
 			new XElement("AnchorTag", new XCData("anchor")), new XElement("AnchorValue", new XCData("north")),
 			new XElement("DestinationProg", 0));
+		yield return new XElement("Effect", new XAttribute("type", "portalnetwork"),
+			new XElement("NetworkId", 0), new XElement("EndpointKey", new XCData("north")),
+			new XElement("AnchorMode", (int)MagicPortalTopologyAnchorMode.TargetRoom),
+			new XElement("LinkEndpointKey", new XCData("south")), new XElement("ReplaceExisting", true),
+			new XElement("Permanent", false));
 		yield return new XElement("Effect", new XAttribute("type", "forcecommand"),
 			new XElement("Command", new XCData("look")));
 		yield return new XElement("Effect", new XAttribute("type", "subjectivedesc"),

--- a/MudSharpCore Unit Tests/MagicPortalTopologyTests.cs
+++ b/MudSharpCore Unit Tests/MagicPortalTopologyTests.cs
@@ -1,0 +1,409 @@
+#nullable enable
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Body;
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Construction.Boundary;
+using MudSharp.Database;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.GameItems;
+using MudSharp.Magic;
+using MudSharp.RPG.Checks;
+using MudSharp.Planes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Xml.Linq;
+using DB = MudSharp.Models;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class MagicPortalTopologyTests
+{
+	[TestMethod]
+	public void RebuildNetwork_ValidLink_MaterializesTopologyPortal()
+	{
+		var (gameworld, manager, source, destination, network) = BuildTopology();
+		gameworld.SetupGet(x => x.ExitManager).Returns(manager);
+
+		new MagicPortalTopologyService().RebuildNetwork(network);
+
+		var portal = manager.TransientExits.OfType<IMagicPortalTopologyExit>().Single();
+		Assert.AreSame(network, portal.Network);
+		Assert.AreSame(source.Object, portal.Source);
+		Assert.AreSame(destination.Object, portal.Destination);
+		Assert.AreEqual("enter", portal.Verb);
+		Assert.AreEqual("north", portal.SourceEndpoint.Key);
+		Assert.AreEqual("south", portal.DestinationEndpoint.Key);
+	}
+
+	[TestMethod]
+	public void RebuildNetwork_RepeatedRebuild_DoesNotDuplicateAndPreservesLegacyPortal()
+	{
+		var (gameworld, manager, source, destination, network) = BuildTopology();
+		gameworld.SetupGet(x => x.ExitManager).Returns(manager);
+		var legacy = new TransientExit(gameworld.Object, source.Object, destination.Object, "enter", "gate", "gate",
+			"a gate", "a gate", "through", "through", 1.0);
+		manager.RegisterTransientExit(legacy);
+
+		new MagicPortalTopologyService().RebuildNetwork(network);
+		new MagicPortalTopologyService().RebuildNetwork(network);
+
+		Assert.AreSame(legacy, manager.TransientExits.First(x => ReferenceEquals(x, legacy)));
+		Assert.AreEqual(1, manager.TransientExits.OfType<IMagicPortalTopologyExit>().Count());
+		Assert.AreEqual(2, manager.TransientExits.Count());
+	}
+
+	[TestMethod]
+	public void RebuildNetwork_ItemEndpointWithoutDirectLocation_DoesNotMaterialize()
+	{
+		var zone = new Mock<IZone>().Object;
+		var gameworld = CreateGameworld();
+		var manager = new ExitManager(gameworld.Object);
+		gameworld.SetupGet(x => x.ExitManager).Returns(manager);
+		var source = CreateCell(1, "Source", gameworld.Object, zone);
+		var item = new Mock<IGameItem>();
+		item.SetupGet(x => x.Id).Returns(99);
+		item.SetupGet(x => x.Name).Returns("Rune Stone");
+		item.SetupGet(x => x.FrameworkItemType).Returns("GameItem");
+		item.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		item.SetupGet(x => x.Location).Returns((ICell)null!);
+		gameworld.Setup(x => x.TryGetItem(99, true)).Returns(item.Object);
+		var cells = new All<ICell>();
+		cells.Add(source.Object);
+		gameworld.SetupGet(x => x.Cells).Returns(cells);
+
+		var network = BuildNetwork(gameworld.Object, source.Object, itemId: 99);
+		var networks = new All<IMagicPortalNetwork>();
+		networks.Add(network);
+		gameworld.SetupGet(x => x.MagicPortalNetworks).Returns(networks);
+
+		new MagicPortalTopologyService().RebuildNetwork(network);
+
+		Assert.IsFalse(manager.TransientExits.Any());
+		StringAssert.Contains(network.Links.Single().WhyInvalid, "not directly located");
+	}
+
+	[TestMethod]
+	public void RebuildNetwork_ItemEndpointWithEffectiveButNotDirectLocation_DoesNotMaterialize()
+	{
+		var zone = new Mock<IZone>().Object;
+		var gameworld = CreateGameworld();
+		var manager = new ExitManager(gameworld.Object);
+		gameworld.SetupGet(x => x.ExitManager).Returns(manager);
+		var source = CreateCell(1, "Source", gameworld.Object, zone);
+		var destination = CreateCell(2, "Destination", gameworld.Object, zone);
+		var item = new Mock<IGameItem>();
+		item.SetupGet(x => x.Id).Returns(99);
+		item.SetupGet(x => x.Name).Returns("Rune Stone");
+		item.SetupGet(x => x.FrameworkItemType).Returns("GameItem");
+		item.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		item.SetupGet(x => x.Location).Returns(destination.Object);
+		item.SetupGet(x => x.ContainedIn).Returns((IGameItem)null!);
+		item.SetupGet(x => x.InInventoryOf).Returns(new Mock<IBody>().Object);
+		gameworld.Setup(x => x.TryGetItem(99, true)).Returns(item.Object);
+		var cells = new All<ICell>();
+		cells.Add(source.Object);
+		cells.Add(destination.Object);
+		gameworld.SetupGet(x => x.Cells).Returns(cells);
+
+		var network = BuildNetwork(gameworld.Object, source.Object, itemId: 99);
+		var networks = new All<IMagicPortalNetwork>();
+		networks.Add(network);
+		gameworld.SetupGet(x => x.MagicPortalNetworks).Returns(networks);
+
+		new MagicPortalTopologyService().RebuildNetwork(network);
+
+		Assert.IsFalse(manager.TransientExits.Any());
+		StringAssert.Contains(network.Links.Single().WhyInvalid, "not directly located");
+	}
+
+	[TestMethod]
+	public void RebuildNetworksForItem_ItemEndpointMovedOut_RemovesMaterializedTopologyPortal()
+	{
+		var zone = new Mock<IZone>().Object;
+		var gameworld = CreateGameworld();
+		var manager = new ExitManager(gameworld.Object);
+		gameworld.SetupGet(x => x.ExitManager).Returns(manager);
+		var source = CreateCell(1, "Source", gameworld.Object, zone);
+		var destination = CreateCell(2, "Destination", gameworld.Object, zone);
+		var destinationItems = new List<IGameItem>();
+		destination.SetupGet(x => x.GameItems).Returns(destinationItems);
+		ICell? itemLocation = destination.Object;
+		var item = new Mock<IGameItem>();
+		item.SetupGet(x => x.Id).Returns(99);
+		item.SetupGet(x => x.Name).Returns("Rune Stone");
+		item.SetupGet(x => x.FrameworkItemType).Returns("GameItem");
+		item.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		item.SetupGet(x => x.Location).Returns(() => itemLocation);
+		item.SetupGet(x => x.ContainedIn).Returns((IGameItem)null!);
+		item.SetupGet(x => x.InInventoryOf).Returns((IBody)null!);
+		destinationItems.Add(item.Object);
+		gameworld.Setup(x => x.TryGetItem(99, true)).Returns(item.Object);
+		var cells = new All<ICell>();
+		cells.Add(source.Object);
+		cells.Add(destination.Object);
+		gameworld.SetupGet(x => x.Cells).Returns(cells);
+		var network = BuildNetwork(gameworld.Object, source.Object, itemId: 99);
+		var networks = new All<IMagicPortalNetwork>();
+		networks.Add(network);
+		gameworld.SetupGet(x => x.MagicPortalNetworks).Returns(networks);
+		var service = new MagicPortalTopologyService();
+		service.RebuildNetwork(network);
+		Assert.AreEqual(1, manager.TransientExits.OfType<IMagicPortalTopologyExit>().Count());
+
+		destinationItems.Clear();
+		itemLocation = null;
+		service.RebuildNetworksForItem(gameworld.Object, item.Object);
+
+		Assert.IsFalse(manager.TransientExits.OfType<IMagicPortalTopologyExit>().Any());
+	}
+
+	[TestMethod]
+	public void PortalTopologySpellEffect_PermanentMissingLink_DoesNotMoveExistingEndpoint()
+	{
+		var state = CaptureFMDBState();
+		using var context = BuildContext();
+		try
+		{
+			PrimeFMDB(context);
+			var zone = new Mock<IZone>().Object;
+			var gameworld = CreateGameworld();
+			var manager = new ExitManager(gameworld.Object);
+			gameworld.SetupGet(x => x.ExitManager).Returns(manager);
+			var source = CreateCell(1, "Source", gameworld.Object, zone);
+			var destination = CreateCell(2, "Destination", gameworld.Object, zone);
+			var cells = new All<ICell>();
+			cells.Add(source.Object);
+			cells.Add(destination.Object);
+			gameworld.SetupGet(x => x.Cells).Returns(cells);
+			var persistedEndpoint = new DB.MagicPortalEndpoint
+			{
+				Id = 11,
+				MagicPortalNetworkId = 10,
+				Key = "north",
+				Name = "North",
+				AnchorType = (int)MagicPortalEndpointType.Cell,
+				CellId = source.Object.Id,
+				IsActive = true,
+				CreatedDateTime = DateTime.UtcNow
+			};
+			context.MagicPortalEndpoints.Add(persistedEndpoint);
+			context.SaveChanges();
+			var network = new MagicPortalNetwork(new DB.MagicPortalNetwork
+			{
+				Id = 10,
+				Name = "Test Network",
+				IsActive = true,
+				AllowCrossZone = false,
+				Verb = "enter",
+				OutboundKeyword = "portal",
+				InboundKeyword = "portal",
+				OutboundTarget = "a standing portal",
+				InboundTarget = "a standing portal",
+				OutboundDescription = "through",
+				InboundDescription = "through",
+				TimeMultiplier = 1.0,
+				CreatedDateTime = DateTime.UtcNow,
+				MagicPortalEndpoints =
+				[
+					new DB.MagicPortalEndpoint
+					{
+						Id = persistedEndpoint.Id,
+						MagicPortalNetworkId = persistedEndpoint.MagicPortalNetworkId,
+						Key = persistedEndpoint.Key,
+						Name = persistedEndpoint.Name,
+						AnchorType = persistedEndpoint.AnchorType,
+						CellId = persistedEndpoint.CellId,
+						IsActive = persistedEndpoint.IsActive,
+						CreatedDateTime = persistedEndpoint.CreatedDateTime
+					}
+				],
+				MagicPortalLinks = []
+			}, gameworld.Object);
+			var networks = new All<IMagicPortalNetwork>();
+			networks.Add(network);
+			gameworld.SetupGet(x => x.MagicPortalNetworks).Returns(networks);
+			var spell = new Mock<IMagicSpell>();
+			spell.SetupGet(x => x.Id).Returns(50);
+			spell.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+			var effect = SpellEffectFactory.LoadEffect(new XElement("Effect", new XAttribute("type", "portalnetwork"),
+				new XElement("NetworkId", network.Id),
+				new XElement("EndpointKey", new XCData("north")),
+				new XElement("AnchorMode", (int)MagicPortalTopologyAnchorMode.TargetRoom),
+				new XElement("LinkEndpointKey", new XCData("missing")),
+				new XElement("ReplaceExisting", true),
+				new XElement("Permanent", true)), spell.Object);
+			var caster = new Mock<ICharacter>();
+			caster.SetupGet(x => x.Id).Returns(100);
+			caster.SetupGet(x => x.Location).Returns(source.Object);
+			caster.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+
+			var result = effect.GetOrApplyEffect(caster.Object, destination.Object, OpposedOutcomeDegree.None,
+				SpellPower.Insignificant, new Mock<IMagicSpellEffectParent>().Object, []);
+
+			Assert.IsNull(result);
+			Assert.AreEqual(source.Object.Id, context.MagicPortalEndpoints.Single().CellId);
+			Assert.AreEqual(source.Object.Id, network.Endpoints.Single().CellId);
+		}
+		finally
+		{
+			RestoreFMDBState(state);
+		}
+	}
+
+	private static (Mock<IFuturemud> Gameworld, ExitManager Manager, Mock<ICell> Source, Mock<ICell> Destination,
+		MagicPortalNetwork Network) BuildTopology()
+	{
+		var zone = new Mock<IZone>().Object;
+		var gameworld = CreateGameworld();
+		var manager = new ExitManager(gameworld.Object);
+		var source = CreateCell(1, "Source", gameworld.Object, zone);
+		var destination = CreateCell(2, "Destination", gameworld.Object, zone);
+		var cells = new All<ICell>();
+		cells.Add(source.Object);
+		cells.Add(destination.Object);
+		gameworld.SetupGet(x => x.Cells).Returns(cells);
+		var network = BuildNetwork(gameworld.Object, source.Object, destination.Object);
+		var networks = new All<IMagicPortalNetwork>();
+		networks.Add(network);
+		gameworld.SetupGet(x => x.MagicPortalNetworks).Returns(networks);
+		return (gameworld, manager, source, destination, network);
+	}
+
+	private static Mock<IFuturemud> CreateGameworld()
+	{
+		var plane = new Mock<IPlane>();
+		plane.SetupGet(x => x.Id).Returns(1);
+		plane.SetupGet(x => x.Name).Returns("Prime");
+		plane.SetupGet(x => x.DisplayOrder).Returns(0);
+		var planes = new All<IPlane>();
+		planes.Add(plane.Object);
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.DefaultPlane).Returns(plane.Object);
+		gameworld.SetupGet(x => x.Planes).Returns(planes);
+		gameworld.SetupGet(x => x.MagicSchools).Returns(new All<IMagicSchool>());
+		gameworld.SetupGet(x => x.Items).Returns(new All<IGameItem>());
+		return gameworld;
+	}
+
+	private static Mock<ICell> CreateCell(long id, string name, IFuturemud gameworld, IZone zone)
+	{
+		var cell = new Mock<ICell>();
+		cell.SetupGet(x => x.Id).Returns(id);
+		cell.SetupGet(x => x.Name).Returns(name);
+		cell.SetupGet(x => x.FrameworkItemType).Returns("Cell");
+		cell.SetupGet(x => x.Gameworld).Returns(gameworld);
+		cell.SetupGet(x => x.Zone).Returns(zone);
+		var gameItems = new List<IGameItem>();
+		cell.SetupGet(x => x.GameItems).Returns(gameItems);
+		cell.Setup(x => x.EffectsOfType<IPlanarOverlayEffect>(It.IsAny<Predicate<IPlanarOverlayEffect>>()))
+		    .Returns([]);
+		return cell;
+	}
+
+	private static MagicPortalNetwork BuildNetwork(IFuturemud gameworld, ICell source, ICell? destination = null,
+		long? itemId = null)
+	{
+		var dbNetwork = new DB.MagicPortalNetwork
+		{
+			Id = 10,
+			Name = "Test Network",
+			IsActive = true,
+			AllowCrossZone = false,
+			Verb = "enter",
+			OutboundKeyword = "portal",
+			InboundKeyword = "portal",
+			OutboundTarget = "a standing portal",
+			InboundTarget = "a standing portal",
+			OutboundDescription = "through",
+			InboundDescription = "through",
+			TimeMultiplier = 1.0,
+			CreatedDateTime = DateTime.UtcNow,
+			MagicPortalEndpoints =
+			[
+				new DB.MagicPortalEndpoint
+				{
+					Id = 11,
+					MagicPortalNetworkId = 10,
+					Key = "north",
+					Name = "North",
+					AnchorType = (int)MagicPortalEndpointType.Cell,
+					CellId = source.Id,
+					IsActive = true,
+					CreatedDateTime = DateTime.UtcNow
+				},
+				new DB.MagicPortalEndpoint
+				{
+					Id = 12,
+					MagicPortalNetworkId = 10,
+					Key = "south",
+					Name = "South",
+					AnchorType = itemId.HasValue ? (int)MagicPortalEndpointType.Item : (int)MagicPortalEndpointType.Cell,
+					CellId = destination?.Id,
+					GameItemId = itemId,
+					IsActive = true,
+					CreatedDateTime = DateTime.UtcNow
+				}
+			],
+			MagicPortalLinks =
+			[
+				new DB.MagicPortalLink
+				{
+					Id = 20,
+					MagicPortalNetworkId = 10,
+					SourceEndpointId = 11,
+					DestinationEndpointId = 12,
+					IsActive = true,
+					CreatedDateTime = DateTime.UtcNow
+				}
+			]
+		};
+
+		return new MagicPortalNetwork(dbNetwork, gameworld);
+	}
+
+	private sealed record FMDBState(FuturemudDatabaseContext? Context, object? Connection, uint InstanceCount);
+
+	private static FuturemudDatabaseContext BuildContext()
+	{
+		var options = new DbContextOptionsBuilder<FuturemudDatabaseContext>()
+			.UseInMemoryDatabase(Guid.NewGuid().ToString())
+			.ConfigureWarnings(x => x.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+			.Options;
+
+		return new FuturemudDatabaseContext(options);
+	}
+
+	private static FMDBState CaptureFMDBState()
+	{
+		return new FMDBState(
+			(FuturemudDatabaseContext?)typeof(FMDB).GetProperty("Context", BindingFlags.Public | BindingFlags.Static)!
+				.GetValue(null),
+			typeof(FMDB).GetProperty("Connection", BindingFlags.Public | BindingFlags.Static)!.GetValue(null),
+			(uint)typeof(FMDB).GetProperty("InstanceCount", BindingFlags.NonPublic | BindingFlags.Static)!
+				.GetValue(null)!);
+	}
+
+	private static void PrimeFMDB(FuturemudDatabaseContext context)
+	{
+		typeof(FMDB).GetProperty("Context", BindingFlags.Public | BindingFlags.Static)!.SetValue(null, context);
+		typeof(FMDB).GetProperty("Connection", BindingFlags.Public | BindingFlags.Static)!.SetValue(null, null);
+		typeof(FMDB).GetProperty("InstanceCount", BindingFlags.NonPublic | BindingFlags.Static)!.SetValue(null, 1u);
+	}
+
+	private static void RestoreFMDBState(FMDBState state)
+	{
+		typeof(FMDB).GetProperty("Context", BindingFlags.Public | BindingFlags.Static)!.SetValue(null, state.Context);
+		typeof(FMDB).GetProperty("Connection", BindingFlags.Public | BindingFlags.Static)!.SetValue(null, state.Connection);
+		typeof(FMDB).GetProperty("InstanceCount", BindingFlags.NonPublic | BindingFlags.Static)!
+			.SetValue(null, state.InstanceCount);
+	}
+}

--- a/MudSharpCore/Commands/Helpers/EditableItemHelperMagic.cs
+++ b/MudSharpCore/Commands/Helpers/EditableItemHelperMagic.cs
@@ -188,6 +188,100 @@ The core syntax is as follows:
         GetEditHeader = item => $"Magic Spell #{item.Id:N0} ({item.Name})"
     };
 
+    public static EditableItemHelper MagicPortalNetworkHelper { get; } = new()
+    {
+        ItemName = "Magic Portal Network",
+        ItemNamePlural = "Magic Portal Networks",
+        SetEditableItemAction = (actor, item) =>
+        {
+            actor.RemoveAllEffects<BuilderEditingEffect<IMagicPortalNetwork>>();
+            if (item == null)
+            {
+                return;
+            }
+
+            actor.AddEffect(new BuilderEditingEffect<IMagicPortalNetwork>(actor) { EditingItem = (IMagicPortalNetwork)item });
+        },
+        GetEditableItemFunc = actor =>
+            actor.CombinedEffectsOfType<BuilderEditingEffect<IMagicPortalNetwork>>().FirstOrDefault()?.EditingItem,
+        GetAllEditableItems = actor => actor.Gameworld.MagicPortalNetworks.ToList(),
+        GetEditableItemByIdFunc = (actor, id) => actor.Gameworld.MagicPortalNetworks.Get(id),
+        GetEditableItemByIdOrNameFunc = (actor, input) => actor.Gameworld.MagicPortalNetworks.GetByIdOrName(input),
+        AddItemToGameWorldAction = item => item.Gameworld.Add((IMagicPortalNetwork)item),
+        CastToType = typeof(IMagicPortalNetwork),
+        EditableNewAction = (actor, input) =>
+        {
+            if (input.IsFinished)
+            {
+                actor.OutputHandler.Send("You must specify a name for your new magic portal network.");
+                return;
+            }
+
+            var name = input.PopSpeech().TitleCase();
+            if (actor.Gameworld.MagicPortalNetworks.Any(x => x.Name.EqualTo(name)))
+            {
+                actor.OutputHandler.Send($"There is already a magic portal network called {name.ColourName()}.");
+                return;
+            }
+
+            IMagicSchool school = null;
+            if (!input.IsFinished)
+            {
+                school = actor.Gameworld.MagicSchools.GetByIdOrName(input.SafeRemainingArgument);
+                if (school is null)
+                {
+                    actor.OutputHandler.Send("There is no such magic school.");
+                    return;
+                }
+            }
+
+            var network = new MagicPortalNetwork(actor.Gameworld, name, school, actor);
+            actor.Gameworld.Add(network);
+            actor.RemoveAllEffects<BuilderEditingEffect<IMagicPortalNetwork>>();
+            actor.AddEffect(new BuilderEditingEffect<IMagicPortalNetwork>(actor) { EditingItem = network });
+            actor.OutputHandler.Send($"You create a new magic portal network called {network.Name.ColourName()}, which you are now editing.");
+        },
+        EditableCloneAction = (actor, input) =>
+        {
+            actor.OutputHandler.Send("Magic portal networks cannot be cloned yet; create a new network and add endpoints/links explicitly.");
+        },
+        GetListTableHeaderFunc = character => new List<string>
+        {
+            "Id",
+            "Name",
+            "School",
+            "Active",
+            "Endpoints",
+            "Links"
+        },
+        GetListTableContentsFunc = (character, networks) => from network in networks.OfType<IMagicPortalNetwork>()
+                                                             select new List<string>
+                                                             {
+                                                                 network.Id.ToString("N0", character),
+                                                                 network.Name,
+                                                                 network.School?.Name ?? "",
+                                                                 network.IsActive.ToColouredString(),
+                                                                 network.Endpoints.Count().ToString("N0", character),
+                                                                 network.Links.Count().ToString("N0", character)
+                                                             },
+        CustomSearch = (networks, keyword, gameworld) => networks,
+        DefaultCommandHelp = @"This command is used to work with durable magic portal/rune networks.
+
+The core syntax is as follows:
+
+	#3magic portalnetwork list#0 - lists all portal networks
+	#3magic portalnetwork edit new <name> [school]#0 - creates a new portal network
+	#3magic portalnetwork edit <which>#0 - begins editing a portal network
+	#3magic portalnetwork close#0 - stops editing a portal network
+	#3magic portalnetwork show <which>#0 - shows a portal network
+	#3magic portalnetwork set active#0 - toggles runtime materialisation
+	#3magic portalnetwork set endpoint add room <key> <cell|here> [name]#0 - adds or replaces a room endpoint
+	#3magic portalnetwork set endpoint add item <key> <item id> [name]#0 - adds or replaces an item endpoint
+	#3magic portalnetwork set link add <from> <to>#0 - explicitly links two endpoints
+	#3magic portalnetwork set refresh#0 - rebuilds active runtime portal exits",
+        GetEditHeader = item => $"Magic Portal Network #{item.Id:N0} ({item.Name})"
+    };
+
     public static EditableItemHelper MagicSchoolHelper { get; } = new()
     {
         ItemName = "Magic School",

--- a/MudSharpCore/Commands/Modules/MagicModule.cs
+++ b/MudSharpCore/Commands/Modules/MagicModule.cs
@@ -236,6 +236,11 @@ public class MagicModule : Module<ICharacter>
             case "portals":
                 MagicPortals(actor, ss);
                 return;
+            case "portalnetwork":
+            case "portalnet":
+            case "runes":
+                MagicPortalNetwork(actor, ss);
+                return;
             case "anchors":
                 MagicAnchors(actor, ss);
                 return;
@@ -255,6 +260,7 @@ public class MagicModule : Module<ICharacter>
 	#3magic power#0 - magic powers are customisable hard-coded powers for a magic school
 	#3magic spell#0 - magic spells are completely flexible and editable templates for magical effects
 	#3magic portals#0 - inspects active transient magical portals
+	#3magic portalnetwork#0 - edits durable portal/rune topology
 	#3magic anchors [tag]#0 - inspects active magic-tag anchors on rooms and items
 
 #ENote - It's relatively easy to add new spell effect types. Reach out to Japheth on the FutureMUD discord if you want something added.#0".SubstituteANSIColour());
@@ -310,7 +316,7 @@ public class MagicModule : Module<ICharacter>
                 $"#{portal.Destination.Id.ToString("N0", actor)} {portal.Destination.Name}",
                 $"{portal.Verb} {portal.OutboundKeyword}",
                 portal.Caster?.HowSeen(actor, flags: PerceiveIgnoreFlags.IgnoreCanSee) ?? "None",
-                portal.Spell?.Name ?? "Unknown",
+                portal is IMagicPortalTopologyExit topology ? topology.Network.Name : portal.Spell?.Name ?? "Unknown",
                 duration > TimeSpan.Zero ? duration.Describe(actor) : "persistent"
             },
             new List<string>
@@ -320,11 +326,16 @@ public class MagicModule : Module<ICharacter>
                 "Destination",
                 "Command",
                 "Caster",
-                "Spell",
+                "Spell/Network",
                 "Duration"
             },
             actor,
             Telnet.Magenta));
+    }
+
+    public static void MagicPortalNetwork(ICharacter actor, StringStack command)
+    {
+        BuilderModule.GenericBuildingCommand(actor, command, EditableItemHelper.MagicPortalNetworkHelper);
     }
 
     public static void MagicAnchors(ICharacter actor, StringStack command)

--- a/MudSharpCore/Construction/Cell.cs
+++ b/MudSharpCore/Construction/Cell.cs
@@ -29,6 +29,7 @@ using MudSharp.FutureProg;
 using MudSharp.FutureProg.Variables;
 using MudSharp.GameItems;
 using MudSharp.GameItems.Interfaces;
+using MudSharp.Magic;
 using MudSharp.Models;
 using MudSharp.Movement;
 using MudSharp.PerceptionEngine;
@@ -241,6 +242,7 @@ public partial class Cell : Location, IDisposable, ICell
             if (mergeTarget != null)
             {
                 mergeTarget.Merge(thing);
+                new MagicPortalTopologyService().RebuildNetworksForItem(Gameworld, thing);
                 thing.Delete();
                 return;
             }
@@ -263,6 +265,7 @@ public partial class Cell : Location, IDisposable, ICell
 
         ContentsChanged = true;
         CheckFallExitStatus();
+        new MagicPortalTopologyService().RebuildNetworksForItem(Gameworld, thing);
     }
 
     private RoomLayer HandleEnterLayers(IGameItem thing)
@@ -298,6 +301,7 @@ public partial class Cell : Location, IDisposable, ICell
         Room.Extract(thing);
         ContentsChanged = true;
         CheckFallExitStatus();
+        new MagicPortalTopologyService().RebuildNetworksForItem(Gameworld, thing);
     }
 
     public IRoom Room { get; }

--- a/MudSharpCore/Effects/Concrete/SpellEffects/SpellPortalTopologyEffect.cs
+++ b/MudSharpCore/Effects/Concrete/SpellEffects/SpellPortalTopologyEffect.cs
@@ -1,0 +1,72 @@
+#nullable enable
+
+using MudSharp.Framework;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Magic;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace MudSharp.Effects.Concrete.SpellEffects;
+
+public class SpellPortalTopologyEffect : MagicSpellEffectBase
+{
+	public static void InitialiseEffectType()
+	{
+		RegisterFactory("SpellPortalTopology", (effect, owner) => new SpellPortalTopologyEffect(effect, owner));
+	}
+
+	public SpellPortalTopologyEffect(IPerceivable owner, IMagicSpellEffectParent parent,
+		IEnumerable<long> createdEndpointIds, IEnumerable<long> createdLinkIds, bool permanent)
+		: base(owner, parent, null)
+	{
+		CreatedEndpointIds = createdEndpointIds.ToList();
+		CreatedLinkIds = createdLinkIds.ToList();
+		Permanent = permanent;
+	}
+
+	private SpellPortalTopologyEffect(XElement root, IPerceivable owner) : base(root, owner)
+	{
+		var trueRoot = root.Element("Effect");
+		Permanent = bool.Parse(trueRoot?.Element("Permanent")?.Value ?? "false");
+		CreatedEndpointIds = trueRoot?.Element("Endpoints")?.Elements("Endpoint")
+			.Select(x => long.Parse(x.Value))
+			.ToList() ?? [];
+		CreatedLinkIds = trueRoot?.Element("Links")?.Elements("Link")
+			.Select(x => long.Parse(x.Value))
+			.ToList() ?? [];
+	}
+
+	public IReadOnlyList<long> CreatedEndpointIds { get; }
+	public IReadOnlyList<long> CreatedLinkIds { get; }
+	public bool Permanent { get; }
+
+	public override void RemovalEffect()
+	{
+		if (!Permanent)
+		{
+			new MagicPortalTopologyService().DeleteSpellCreatedTopology(Gameworld, CreatedEndpointIds, CreatedLinkIds);
+		}
+
+		base.RemovalEffect();
+	}
+
+	protected override XElement SaveDefinition()
+	{
+		return new XElement("Effect",
+			new XElement("ApplicabilityProg", ApplicabilityProg?.Id ?? 0),
+			new XElement("Permanent", Permanent),
+			new XElement("Endpoints", CreatedEndpointIds.Select(x => new XElement("Endpoint", x))),
+			new XElement("Links", CreatedLinkIds.Select(x => new XElement("Link", x)))
+		);
+	}
+
+	public override string Describe(IPerceiver voyeur)
+	{
+		return Permanent
+			? "Maintaining a permanent portal topology creation marker."
+			: $"Maintaining spell-owned portal topology ({CreatedEndpointIds.Count.ToString("N0", voyeur)} endpoints, {CreatedLinkIds.Count.ToString("N0", voyeur)} links).";
+	}
+
+	protected override string SpecificEffectType => "SpellPortalTopology";
+}

--- a/MudSharpCore/Framework/Futuremud.cs
+++ b/MudSharpCore/Framework/Futuremud.cs
@@ -1389,6 +1389,11 @@ public sealed partial class Futuremud : IFuturemud, IDisposable
         _vehicleHitchLinks.Add(link);
     }
 
+    public void Add(IMagicPortalNetwork network)
+    {
+        _magicPortalNetworks.Add(network);
+    }
+
     public void Add(ITemporalListener listener)
     {
         _listeners.Add(listener);
@@ -2367,6 +2372,12 @@ public sealed partial class Futuremud : IFuturemud, IDisposable
     public void Destroy(IVehicleHitchLink link)
     {
         _vehicleHitchLinks.Remove(link);
+    }
+
+    public void Destroy(IMagicPortalNetwork network)
+    {
+        new MagicPortalTopologyService().RemoveNetworkExits(network);
+        _magicPortalNetworks.Remove(network);
     }
 
     public void Destroy(IAccount account)

--- a/MudSharpCore/Framework/FuturemudLoaders.cs
+++ b/MudSharpCore/Framework/FuturemudLoaders.cs
@@ -394,6 +394,7 @@ public sealed partial class Futuremud : IFuturemudLoader, IFuturemud, IDisposabl
             game.LoadNPCs(); // Needs to come after InitialiseCharacterClass and LightModel loading
             game.LoadVehicles(); // Needs world items and characters available for exterior/occupant recovery
             game.LoadVehicleHitchLinks(); // Needs vehicles, world items and NPCs available for endpoint recovery
+            game.LoadMagicPortalTopology(); // Needs world items and cells available before exit pathing preload
             FinalisePostCharacterLoadObjects();
             game.LoadGroupAIs(); // Needs to come after LoadNPCs
             ExitManager.PreloadCriticalExits(); // Needs to come after LoadGameItemProtos
@@ -4029,6 +4030,32 @@ For information on the syntax to use in emotes (such as those included in bracke
 #endif
         int count = _vehicleHitchLinks.Count;
         ConsoleUtilities.WriteLine("Loaded #2{0:N0}#0 {1}.", count, count == 1 ? "Vehicle Hitch Link" : "Vehicle Hitch Links");
+    }
+
+    void IFuturemudLoader.LoadMagicPortalTopology()
+    {
+        ConsoleUtilities.WriteLine("\nLoading #5Magic Portal Topology#0...");
+#if DEBUG
+        Stopwatch sw = new();
+        sw.Start();
+#endif
+        List<Models.MagicPortalNetwork> networks = FMDB.Context.MagicPortalNetworks
+            .Include(x => x.MagicPortalEndpoints)
+            .Include(x => x.MagicPortalLinks)
+            .AsNoTracking()
+            .ToList();
+        foreach (Models.MagicPortalNetwork network in networks)
+        {
+            _magicPortalNetworks.Add(new Magic.MagicPortalNetwork(network, this));
+        }
+
+        new Magic.MagicPortalTopologyService().RebuildAll(this);
+#if DEBUG
+        sw.Stop();
+        ConsoleUtilities.WriteLine($"Duration: #2{sw.ElapsedMilliseconds}ms#0");
+#endif
+        int count = _magicPortalNetworks.Count;
+        ConsoleUtilities.WriteLine("Loaded #2{0:N0}#0 {1}.", count, count == 1 ? "Magic Portal Network" : "Magic Portal Networks");
     }
 
     void IFuturemudLoader.LoadGameItemSkins()

--- a/MudSharpCore/Framework/FuturemudVariables.cs
+++ b/MudSharpCore/Framework/FuturemudVariables.cs
@@ -212,6 +212,7 @@ public sealed partial class Futuremud : IDisposable
     private readonly All<IMagicResource> _magicResources = new();
     private readonly All<IMagicResourceRegenerator> _magicResourceRegenerators = new();
     private readonly All<IMagicSpell> _magicSpells = new();
+    private readonly All<IMagicPortalNetwork> _magicPortalNetworks = new();
 
     private readonly All<IMarket> _markets = new();
     private readonly All<IMarketCategory> _marketCategories = new();
@@ -486,6 +487,7 @@ public sealed partial class Futuremud : IDisposable
     public IUneditableAll<IMagicResource> MagicResources => _magicResources;
     public IUneditableAll<IMagicResourceRegenerator> MagicResourceRegenerators => _magicResourceRegenerators;
     public IUneditableAll<IMagicSpell> MagicSpells => _magicSpells;
+    public IUneditableAll<IMagicPortalNetwork> MagicPortalNetworks => _magicPortalNetworks;
     public IUneditableAll<IMarket> Markets => _markets;
     public IUneditableAll<IMarketCategory> MarketCategories => _marketCategories;
     public IUneditableAll<IMarketInfluenceTemplate> MarketInfluenceTemplates => _marketInfluenceTemplates;

--- a/MudSharpCore/Magic/MagicPortalTopology.cs
+++ b/MudSharpCore/Magic/MagicPortalTopology.cs
@@ -1,0 +1,1162 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Construction.Boundary;
+using MudSharp.Database;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.Framework.Save;
+using MudSharp.FutureProg;
+using MudSharp.GameItems;
+using MudSharp.PerceptionEngine;
+using MudSharp.Planes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using DB = MudSharp.Models;
+
+namespace MudSharp.Magic;
+
+public class MagicPortalNetwork : SaveableItem, IMagicPortalNetwork
+{
+	private readonly List<MagicPortalEndpoint> _endpoints = new();
+	private readonly List<MagicPortalLink> _links = new();
+	private long? _schoolId;
+	private IMagicSchool? _school;
+
+	public MagicPortalNetwork(DB.MagicPortalNetwork dbitem, IFuturemud gameworld)
+	{
+		Gameworld = gameworld;
+		_id = dbitem.Id;
+		_name = dbitem.Name;
+		_schoolId = dbitem.MagicSchoolId;
+		IsActive = dbitem.IsActive;
+		AllowCrossZone = dbitem.AllowCrossZone;
+		Verb = dbitem.Verb;
+		OutboundKeyword = dbitem.OutboundKeyword;
+		InboundKeyword = dbitem.InboundKeyword;
+		OutboundTarget = dbitem.OutboundTarget;
+		InboundTarget = dbitem.InboundTarget;
+		OutboundDescription = dbitem.OutboundDescription;
+		InboundDescription = dbitem.InboundDescription;
+		TimeMultiplier = dbitem.TimeMultiplier <= 0.0 ? 1.0 : dbitem.TimeMultiplier;
+
+		foreach (var endpoint in dbitem.MagicPortalEndpoints.OrderBy(x => x.Id))
+		{
+			_endpoints.Add(new MagicPortalEndpoint(this, endpoint));
+		}
+
+		foreach (var link in dbitem.MagicPortalLinks.OrderBy(x => x.Id))
+		{
+			var source = _endpoints.FirstOrDefault(x => x.Id == link.SourceEndpointId);
+			var destination = _endpoints.FirstOrDefault(x => x.Id == link.DestinationEndpointId);
+			if (source is null || destination is null)
+			{
+				continue;
+			}
+
+			_links.Add(new MagicPortalLink(this, link, source, destination));
+		}
+	}
+
+	public MagicPortalNetwork(IFuturemud gameworld, string name, IMagicSchool? school, ICharacter? creator = null)
+	{
+		Gameworld = gameworld;
+		_name = name;
+		_school = school;
+		_schoolId = school?.Id;
+		IsActive = true;
+		AllowCrossZone = false;
+		Verb = "enter";
+		OutboundKeyword = "portal";
+		InboundKeyword = "portal";
+		OutboundTarget = "a standing portal";
+		InboundTarget = "a standing portal";
+		OutboundDescription = "through";
+		InboundDescription = "through";
+		TimeMultiplier = 1.0;
+
+		using (new FMDB())
+		{
+			var dbitem = new DB.MagicPortalNetwork
+			{
+				Name = Name,
+				MagicSchoolId = _schoolId,
+				IsActive = IsActive,
+				AllowCrossZone = AllowCrossZone,
+				Verb = Verb,
+				OutboundKeyword = OutboundKeyword,
+				InboundKeyword = InboundKeyword,
+				OutboundTarget = OutboundTarget,
+				InboundTarget = InboundTarget,
+				OutboundDescription = OutboundDescription,
+				InboundDescription = InboundDescription,
+				TimeMultiplier = TimeMultiplier,
+				CreatedByCharacterId = creator?.Id,
+				CreatedDateTime = DateTime.UtcNow
+			};
+			FMDB.Context.MagicPortalNetworks.Add(dbitem);
+			FMDB.Context.SaveChanges();
+			_id = dbitem.Id;
+		}
+	}
+
+	public override string FrameworkItemType => "MagicPortalNetwork";
+	public IMagicSchool? School => _school ??= _schoolId.HasValue ? Gameworld.MagicSchools.Get(_schoolId.Value) : null;
+	public bool IsActive { get; private set; }
+	public bool AllowCrossZone { get; private set; }
+	public string Verb { get; private set; }
+	public string OutboundKeyword { get; private set; }
+	public string InboundKeyword { get; private set; }
+	public string OutboundTarget { get; private set; }
+	public string InboundTarget { get; private set; }
+	public string OutboundDescription { get; private set; }
+	public string InboundDescription { get; private set; }
+	public double TimeMultiplier { get; private set; }
+	public IEnumerable<IMagicPortalEndpoint> Endpoints => _endpoints;
+	public IEnumerable<IMagicPortalLink> Links => _links;
+
+	internal MagicPortalEndpoint? EndpointByKeyOrId(string text)
+	{
+		var byKey = _endpoints.FirstOrDefault(x => x.Key.EqualTo(text) || x.Name.EqualTo(text));
+		if (byKey is not null)
+		{
+			return byKey;
+		}
+
+		return long.TryParse(text, out var id) ? _endpoints.FirstOrDefault(x => x.Id == id) : null;
+	}
+
+	internal void AddEndpoint(MagicPortalEndpoint endpoint)
+	{
+		_endpoints.Add(endpoint);
+	}
+
+	internal void AddLink(MagicPortalLink link)
+	{
+		_links.Add(link);
+	}
+
+	public override void Save()
+	{
+		var dbitem = FMDB.Context.MagicPortalNetworks.Find(Id);
+		if (dbitem is null)
+		{
+			Changed = false;
+			return;
+		}
+
+		dbitem.Name = Name;
+		dbitem.MagicSchoolId = _schoolId;
+		dbitem.IsActive = IsActive;
+		dbitem.AllowCrossZone = AllowCrossZone;
+		dbitem.Verb = Verb;
+		dbitem.OutboundKeyword = OutboundKeyword;
+		dbitem.InboundKeyword = InboundKeyword;
+		dbitem.OutboundTarget = OutboundTarget;
+		dbitem.InboundTarget = InboundTarget;
+		dbitem.OutboundDescription = OutboundDescription;
+		dbitem.InboundDescription = InboundDescription;
+		dbitem.TimeMultiplier = TimeMultiplier;
+		Changed = false;
+	}
+
+	public const string HelpText = @"You can use the following options with this portal network:
+
+	#3name <name>#0 - renames this network
+	#3school <which|none>#0 - sets or clears the associated magic school
+	#3active#0 - toggles whether this network materialises exits
+	#3crosszone#0 - toggles whether links can cross zones
+	#3verb <verb>#0 - sets the movement verb
+	#3outkey <keyword>#0 - sets the outbound command keyword
+	#3inkey <keyword>#0 - sets the inbound command keyword
+	#3outtarget <text>#0 - sets the outbound portal target text
+	#3intarget <text>#0 - sets the inbound portal target text
+	#3outdesc <text>#0 - sets the outbound movement preposition
+	#3indesc <text>#0 - sets the inbound movement preposition
+	#3speed <multiplier>#0 - sets the movement time multiplier
+	#3endpoint add room <key> <cell|here> [name]#0 - adds or replaces a room endpoint
+	#3endpoint add item <key> <item id> [name]#0 - adds or replaces a directly placed item endpoint
+	#3endpoint remove <key|id>#0 - removes an endpoint and its links
+	#3endpoint active <key|id>#0 - toggles an endpoint
+	#3endpoint key <key|id> <new key>#0 - changes an endpoint key
+	#3link add <from> <to>#0 - adds an explicit bidirectional link
+	#3link remove <id|from to>#0 - removes a link
+	#3link active <id>#0 - toggles a link
+	#3refresh#0 - rebuilds the runtime transient exits";
+
+	public bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "name":
+				return BuildingCommandName(actor, command);
+			case "school":
+				return BuildingCommandSchool(actor, command);
+			case "active":
+				IsActive = !IsActive;
+				Changed = true;
+				new MagicPortalTopologyService().RebuildNetwork(this);
+				actor.OutputHandler.Send($"This portal network is now {(IsActive ? "active" : "inactive").ColourValue()}.");
+				return true;
+			case "crosszone":
+				AllowCrossZone = !AllowCrossZone;
+				Changed = true;
+				new MagicPortalTopologyService().RebuildNetwork(this);
+				actor.OutputHandler.Send($"This portal network will {(AllowCrossZone ? "now" : "no longer").ColourValue()} allow cross-zone links.");
+				return true;
+			case "verb":
+				return BuildingCommandText(actor, command, "movement verb", x => Verb = x, true);
+			case "outkey":
+				return BuildingCommandText(actor, command, "outbound keyword", x => OutboundKeyword = x.CollapseString(), true);
+			case "inkey":
+				return BuildingCommandText(actor, command, "inbound keyword", x => InboundKeyword = x.CollapseString(), true);
+			case "outtarget":
+				return BuildingCommandText(actor, command, "outbound target text", x => OutboundTarget = x, true);
+			case "intarget":
+				return BuildingCommandText(actor, command, "inbound target text", x => InboundTarget = x, true);
+			case "outdesc":
+				return BuildingCommandText(actor, command, "outbound movement preposition", x => OutboundDescription = x, true);
+			case "indesc":
+				return BuildingCommandText(actor, command, "inbound movement preposition", x => InboundDescription = x, true);
+			case "speed":
+				return BuildingCommandSpeed(actor, command);
+			case "endpoint":
+				return BuildingCommandEndpoint(actor, command);
+			case "link":
+				return BuildingCommandLink(actor, command);
+			case "refresh":
+			case "repair":
+				new MagicPortalTopologyService().RebuildNetwork(this);
+				actor.OutputHandler.Send("This portal network has been refreshed.");
+				return true;
+			default:
+				actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
+				return false;
+		}
+	}
+
+	private bool BuildingCommandName(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("What do you want to rename this portal network to?");
+			return false;
+		}
+
+		var name = command.SafeRemainingArgument.TitleCase();
+		if (Gameworld.MagicPortalNetworks.Any(x => x.Id != Id && x.Name.EqualTo(name)))
+		{
+			actor.OutputHandler.Send($"There is already a portal network called {name.ColourName()}.");
+			return false;
+		}
+
+		actor.OutputHandler.Send($"You rename portal network {Name.ColourName()} to {name.ColourName()}.");
+		_name = name;
+		Changed = true;
+		return true;
+	}
+
+	private bool BuildingCommandSchool(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which magic school should this portal network be associated with, or #3none#0?".SubstituteANSIColour());
+			return false;
+		}
+
+		if (command.SafeRemainingArgument.EqualTo("none"))
+		{
+			_school = null;
+			_schoolId = null;
+			Changed = true;
+			actor.OutputHandler.Send("This portal network is no longer associated with any magic school.");
+			return true;
+		}
+
+		var school = Gameworld.MagicSchools.GetByIdOrName(command.SafeRemainingArgument);
+		if (school is null)
+		{
+			actor.OutputHandler.Send("There is no such magic school.");
+			return false;
+		}
+
+		_school = school;
+		_schoolId = school.Id;
+		Changed = true;
+		actor.OutputHandler.Send($"This portal network is now associated with {school.Name.Colour(school.PowerListColour)}.");
+		return true;
+	}
+
+	private bool BuildingCommandText(ICharacter actor, StringStack command, string label, Action<string> setter,
+		bool rebuild)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send($"What should the {label} be?");
+			return false;
+		}
+
+		setter(command.SafeRemainingArgument);
+		Changed = true;
+		if (rebuild)
+		{
+			new MagicPortalTopologyService().RebuildNetwork(this);
+		}
+
+		actor.OutputHandler.Send($"The portal network {label} has been updated.");
+		return true;
+	}
+
+	private bool BuildingCommandSpeed(ICharacter actor, StringStack command)
+	{
+		if (!double.TryParse(command.SafeRemainingArgument, out var speed) || speed <= 0.0)
+		{
+			actor.OutputHandler.Send("You must enter a positive movement time multiplier.");
+			return false;
+		}
+
+		TimeMultiplier = speed;
+		Changed = true;
+		new MagicPortalTopologyService().RebuildNetwork(this);
+		actor.OutputHandler.Send($"This portal network now has a movement time multiplier of {speed.ToString("N2", actor).ColourValue()}.");
+		return true;
+	}
+
+	private bool BuildingCommandEndpoint(ICharacter actor, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "add":
+				return BuildingCommandEndpointAdd(actor, command);
+			case "remove":
+			case "delete":
+				return BuildingCommandEndpointRemove(actor, command);
+			case "active":
+				return BuildingCommandEndpointActive(actor, command);
+			case "key":
+				return BuildingCommandEndpointKey(actor, command);
+			default:
+				actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
+				return false;
+		}
+	}
+
+	private bool BuildingCommandEndpointAdd(ICharacter actor, StringStack command)
+	{
+		var typeText = command.PopForSwitch();
+		if (!typeText.EqualToAny("room", "cell", "item"))
+		{
+			actor.OutputHandler.Send("You must specify whether you are adding a #3room#0 or #3item#0 endpoint.".SubstituteANSIColour());
+			return false;
+		}
+
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("What key should this endpoint use?");
+			return false;
+		}
+
+		var key = command.PopSpeech().ToLowerInvariant();
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which room/cell or item should this endpoint use?");
+			return false;
+		}
+
+		var targetText = command.PopSpeech();
+		var name = command.IsFinished ? key.TitleCase() : command.SafeRemainingArgument.TitleCase();
+		ICell? cell = null;
+		IGameItem? item = null;
+		var endpointType = typeText.EqualToAny("room", "cell") ? MagicPortalEndpointType.Cell : MagicPortalEndpointType.Item;
+		if (endpointType == MagicPortalEndpointType.Cell)
+		{
+			cell = targetText.EqualTo("here") ? actor.Location : long.TryParse(targetText, out var id) ? Gameworld.Cells.Get(id) : null;
+			if (cell is null)
+			{
+				actor.OutputHandler.Send("There is no such cell.");
+				return false;
+			}
+		}
+		else
+		{
+			if (!long.TryParse(targetText, out var id))
+			{
+				actor.OutputHandler.Send("You must specify an item ID for item portal endpoints.");
+				return false;
+			}
+
+			item = Gameworld.TryGetItem(id, true);
+			if (item is null)
+			{
+				actor.OutputHandler.Send("There is no such item.");
+				return false;
+			}
+		}
+
+		var endpoint = new MagicPortalTopologyService().CreateOrUpdateEndpoint(actor, this, key, name, endpointType,
+			cell, item, true, null, out var reason);
+		if (endpoint is null)
+		{
+			actor.OutputHandler.Send(reason.ColourError());
+			return false;
+		}
+
+		actor.OutputHandler.Send($"Endpoint {endpoint.Key.ColourName()} is now bound to {DescribeEndpointTarget(endpoint, actor)}.");
+		return true;
+	}
+
+	private bool BuildingCommandEndpointRemove(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which endpoint do you want to remove?");
+			return false;
+		}
+
+		var endpoint = EndpointByKeyOrId(command.SafeRemainingArgument);
+		if (endpoint is null)
+		{
+			actor.OutputHandler.Send("There is no such endpoint.");
+			return false;
+		}
+
+		DeleteEndpoint(endpoint);
+		new MagicPortalTopologyService().RebuildNetwork(this);
+		actor.OutputHandler.Send($"Endpoint {endpoint.Key.ColourName()} has been removed.");
+		return true;
+	}
+
+	private bool BuildingCommandEndpointActive(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which endpoint do you want to toggle?");
+			return false;
+		}
+
+		var endpoint = EndpointByKeyOrId(command.SafeRemainingArgument);
+		if (endpoint is null)
+		{
+			actor.OutputHandler.Send("There is no such endpoint.");
+			return false;
+		}
+
+		endpoint.SetActive(!endpoint.IsActive);
+		new MagicPortalTopologyService().RebuildNetwork(this);
+		actor.OutputHandler.Send($"Endpoint {endpoint.Key.ColourName()} is now {(endpoint.IsActive ? "active" : "inactive").ColourValue()}.");
+		return true;
+	}
+
+	private bool BuildingCommandEndpointKey(ICharacter actor, StringStack command)
+	{
+		if (command.CountRemainingArguments() < 2)
+		{
+			actor.OutputHandler.Send("You must specify the endpoint and its new key.");
+			return false;
+		}
+
+		var endpoint = EndpointByKeyOrId(command.PopSpeech());
+		if (endpoint is null)
+		{
+			actor.OutputHandler.Send("There is no such endpoint.");
+			return false;
+		}
+
+		var newKey = command.SafeRemainingArgument.ToLowerInvariant();
+		if (_endpoints.Any(x => x.Id != endpoint.Id && x.Key.EqualTo(newKey)))
+		{
+			actor.OutputHandler.Send($"There is already an endpoint with the key {newKey.ColourCommand()}.");
+			return false;
+		}
+
+		endpoint.SetKey(newKey);
+		new MagicPortalTopologyService().RebuildNetwork(this);
+		actor.OutputHandler.Send($"Endpoint {endpoint.Name.ColourName()} now uses the key {newKey.ColourCommand()}.");
+		return true;
+	}
+
+	private bool BuildingCommandLink(ICharacter actor, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "add":
+				return BuildingCommandLinkAdd(actor, command);
+			case "remove":
+			case "delete":
+				return BuildingCommandLinkRemove(actor, command);
+			case "active":
+				return BuildingCommandLinkActive(actor, command);
+			default:
+				actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
+				return false;
+		}
+	}
+
+	private bool BuildingCommandLinkAdd(ICharacter actor, StringStack command)
+	{
+		if (command.CountRemainingArguments() < 2)
+		{
+			actor.OutputHandler.Send("You must specify the two endpoints to link.");
+			return false;
+		}
+
+		var source = EndpointByKeyOrId(command.PopSpeech());
+		var destination = EndpointByKeyOrId(command.SafeRemainingArgument);
+		if (source is null || destination is null)
+		{
+			actor.OutputHandler.Send("One or both of those endpoints do not exist.");
+			return false;
+		}
+
+		var link = new MagicPortalTopologyService().CreateLink(actor, this, source, destination, null, out var reason);
+		if (link is null)
+		{
+			actor.OutputHandler.Send(reason.ColourError());
+			return false;
+		}
+
+		actor.OutputHandler.Send($"Endpoint {source.Key.ColourName()} is now linked to {destination.Key.ColourName()}.");
+		return true;
+	}
+
+	private bool BuildingCommandLinkRemove(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which link do you want to remove?");
+			return false;
+		}
+
+		var first = command.PopSpeech();
+		MagicPortalLink? link;
+		if (long.TryParse(first, out var id))
+		{
+			link = _links.FirstOrDefault(x => x.Id == id);
+		}
+		else
+		{
+			var source = EndpointByKeyOrId(first);
+			var destination = EndpointByKeyOrId(command.SafeRemainingArgument);
+			link = source is null || destination is null ? null : LinkBetween(source, destination);
+		}
+
+		if (link is null)
+		{
+			actor.OutputHandler.Send("There is no such link.");
+			return false;
+		}
+
+		DeleteLink(link);
+		new MagicPortalTopologyService().RebuildNetwork(this);
+		actor.OutputHandler.Send($"Link #{link.Id.ToString("N0", actor)} has been removed.");
+		return true;
+	}
+
+	private bool BuildingCommandLinkActive(ICharacter actor, StringStack command)
+	{
+		if (!long.TryParse(command.SafeRemainingArgument, out var id))
+		{
+			actor.OutputHandler.Send("Which link ID do you want to toggle?");
+			return false;
+		}
+
+		var link = _links.FirstOrDefault(x => x.Id == id);
+		if (link is null)
+		{
+			actor.OutputHandler.Send("There is no such link.");
+			return false;
+		}
+
+		link.SetActive(!link.IsActive);
+		new MagicPortalTopologyService().RebuildNetwork(this);
+		actor.OutputHandler.Send($"Link #{link.Id.ToString("N0", actor)} is now {(link.IsActive ? "active" : "inactive").ColourValue()}.");
+		return true;
+	}
+
+	internal MagicPortalLink? LinkBetween(MagicPortalEndpoint source, MagicPortalEndpoint destination)
+	{
+		return _links.FirstOrDefault(x =>
+			x.SourceEndpoint.Id == source.Id && x.DestinationEndpoint.Id == destination.Id ||
+			x.SourceEndpoint.Id == destination.Id && x.DestinationEndpoint.Id == source.Id);
+	}
+
+	internal void DeleteEndpoint(MagicPortalEndpoint endpoint)
+	{
+		foreach (var link in _links.Where(x => x.SourceEndpoint.Id == endpoint.Id || x.DestinationEndpoint.Id == endpoint.Id).ToList())
+		{
+			DeleteLink(link);
+		}
+
+		using (new FMDB())
+		{
+			var dbitem = FMDB.Context.MagicPortalEndpoints.Find(endpoint.Id);
+			if (dbitem is not null)
+			{
+				FMDB.Context.MagicPortalEndpoints.Remove(dbitem);
+				FMDB.Context.SaveChanges();
+			}
+		}
+
+		_endpoints.Remove(endpoint);
+	}
+
+	internal void DeleteLink(MagicPortalLink link)
+	{
+		using (new FMDB())
+		{
+			var dbitem = FMDB.Context.MagicPortalLinks.Find(link.Id);
+			if (dbitem is not null)
+			{
+				FMDB.Context.MagicPortalLinks.Remove(dbitem);
+				FMDB.Context.SaveChanges();
+			}
+		}
+
+		_links.Remove(link);
+	}
+
+	private static string DescribeEndpointTarget(IMagicPortalEndpoint endpoint, IPerceiver voyeur)
+	{
+		return endpoint.EndpointType switch
+		{
+			MagicPortalEndpointType.Cell => endpoint.CurrentCell is null
+				? $"missing cell #{endpoint.CellId?.ToString("N0", voyeur) ?? "0"}".ColourError()
+				: $"room #{endpoint.CurrentCell.Id.ToString("N0", voyeur)} {endpoint.CurrentCell.Name.ColourName()}",
+			MagicPortalEndpointType.Item => endpoint.CurrentCell is null
+				? $"item #{endpoint.GameItemId?.ToString("N0", voyeur) ?? "0"} not directly placed".ColourError()
+				: $"item #{endpoint.GameItemId?.ToString("N0", voyeur) ?? "0"} in room #{endpoint.CurrentCell.Id.ToString("N0", voyeur)} {endpoint.CurrentCell.Name.ColourName()}",
+			_ => "unknown".ColourError()
+		};
+	}
+
+	public string Show(ICharacter actor)
+	{
+		var sb = new StringBuilder();
+		sb.AppendLine($"Portal Network #{Id.ToString("N0", actor)} - {Name}".GetLineWithTitle(actor, Telnet.Cyan, Telnet.BoldWhite));
+		sb.AppendLine($"School: {School?.Name.Colour(School.PowerListColour) ?? "None".ColourError()}");
+		sb.AppendLine($"Active: {IsActive.ToColouredString()}");
+		sb.AppendLine($"Cross Zone: {AllowCrossZone.ToColouredString()}");
+		sb.AppendLine($"Command: {$"{Verb} {OutboundKeyword}".ColourCommand()} / {$"{Verb} {InboundKeyword}".ColourCommand()}");
+		sb.AppendLine($"Targets: {OutboundTarget.ColourName()} / {InboundTarget.ColourName()}");
+		sb.AppendLine($"Descriptions: {OutboundDescription.ColourCommand()} / {InboundDescription.ColourCommand()}");
+		sb.AppendLine($"Speed: {TimeMultiplier.ToString("N2", actor).ColourValue()}");
+		sb.AppendLine();
+		sb.AppendLine("Endpoints".GetLineWithTitleInner(actor, Telnet.Cyan, Telnet.BoldWhite));
+		sb.AppendLine(_endpoints.Any()
+			? StringUtilities.GetTextTable(
+				from endpoint in _endpoints.OrderBy(x => x.Key)
+				select new List<string>
+				{
+					endpoint.Id.ToString("N0", actor),
+					endpoint.Key,
+					endpoint.Name,
+					endpoint.EndpointType.DescribeEnum(),
+					endpoint.IsActive.ToColouredString(),
+					DescribeEndpointTarget(endpoint, actor),
+					string.IsNullOrWhiteSpace(endpoint.WhyInvalid) ? "valid".Colour(Telnet.Green) : endpoint.WhyInvalid.ColourError()
+				},
+				new List<string> { "Id", "Key", "Name", "Type", "Active", "Target", "Status" },
+				actor,
+				Telnet.Cyan)
+			: "No endpoints defined.");
+		sb.AppendLine();
+		sb.AppendLine("Links".GetLineWithTitleInner(actor, Telnet.Cyan, Telnet.BoldWhite));
+		sb.AppendLine(_links.Any()
+			? StringUtilities.GetTextTable(
+				from link in _links.OrderBy(x => x.SourceEndpoint.Key).ThenBy(x => x.DestinationEndpoint.Key)
+				select new List<string>
+				{
+					link.Id.ToString("N0", actor),
+					link.SourceEndpoint.Key,
+					link.DestinationEndpoint.Key,
+					link.IsActive.ToColouredString(),
+					string.IsNullOrWhiteSpace(link.WhyInvalid) ? "valid".Colour(Telnet.Green) : link.WhyInvalid.ColourError()
+				},
+				new List<string> { "Id", "From", "To", "Active", "Status" },
+				actor,
+				Telnet.Cyan)
+			: "No links defined.");
+		return sb.ToString();
+	}
+}
+
+public class MagicPortalEndpoint : FrameworkItem, IMagicPortalEndpoint
+{
+	private readonly MagicPortalNetwork _network;
+
+	public MagicPortalEndpoint(MagicPortalNetwork network, DB.MagicPortalEndpoint dbitem)
+	{
+		_network = network;
+		_id = dbitem.Id;
+		_name = dbitem.Name;
+		Key = dbitem.Key;
+		EndpointType = (MagicPortalEndpointType)dbitem.AnchorType;
+		CellId = dbitem.CellId;
+		GameItemId = dbitem.GameItemId;
+		IsActive = dbitem.IsActive;
+	}
+
+	public MagicPortalEndpoint(MagicPortalNetwork network, DB.MagicPortalEndpoint dbitem, string key, string name,
+		MagicPortalEndpointType endpointType, long? cellId, long? gameItemId)
+	{
+		_network = network;
+		_id = dbitem.Id;
+		_name = name;
+		Key = key;
+		EndpointType = endpointType;
+		CellId = cellId;
+		GameItemId = gameItemId;
+		IsActive = true;
+	}
+
+	public override string FrameworkItemType => "MagicPortalEndpoint";
+	public IFuturemud Gameworld => _network.Gameworld;
+	public IMagicPortalNetwork Network => _network;
+	public string Key { get; private set; }
+	public MagicPortalEndpointType EndpointType { get; private set; }
+	public long? CellId { get; private set; }
+	public long? GameItemId { get; private set; }
+	public bool IsActive { get; private set; }
+
+	public ICell? CurrentCell
+	{
+		get
+		{
+			if (!IsActive)
+			{
+				return null;
+			}
+
+			return EndpointType switch
+			{
+				MagicPortalEndpointType.Cell => CellId.HasValue ? Gameworld.Cells.Get(CellId.Value) : null,
+				MagicPortalEndpointType.Item => GameItemId.HasValue ? DirectCellForItem(Gameworld.TryGetItem(GameItemId.Value, true)) : null,
+				_ => null
+			};
+		}
+	}
+
+	public string WhyInvalid
+	{
+		get
+		{
+			if (!IsActive)
+			{
+				return "endpoint is inactive";
+			}
+
+			if (EndpointType == MagicPortalEndpointType.Item)
+			{
+				if (!GameItemId.HasValue)
+				{
+					return "item endpoint has no item id";
+				}
+
+				var item = Gameworld.TryGetItem(GameItemId.Value, true);
+				if (item is null)
+				{
+					return "the target item is missing";
+				}
+
+				return DirectCellForItem(item) is null ? "the target item is not directly located in a room" : string.Empty;
+			}
+
+			return EndpointType switch
+			{
+				MagicPortalEndpointType.Cell when !CellId.HasValue => "cell endpoint has no cell id",
+				MagicPortalEndpointType.Cell when Gameworld.Cells.Get(CellId!.Value) is null => "the target cell is missing",
+				_ => string.Empty
+			};
+		}
+	}
+
+	private static ICell? DirectCellForItem(IGameItem? item)
+	{
+		if (item is null || item.ContainedIn is not null || item.InInventoryOf is not null)
+		{
+			return null;
+		}
+
+		var cell = item.Location;
+		if (cell is null)
+		{
+			return null;
+		}
+
+		return cell.GameItems.Any(x => ReferenceEquals(x, item) || x.Id == item.Id) ? cell : null;
+	}
+
+	public void Update(string key, string name, MagicPortalEndpointType endpointType, long? cellId, long? gameItemId)
+	{
+		Key = key;
+		_name = name;
+		EndpointType = endpointType;
+		CellId = cellId;
+		GameItemId = gameItemId;
+		using (new FMDB())
+		{
+			var dbitem = FMDB.Context.MagicPortalEndpoints.Find(Id);
+			if (dbitem is not null)
+			{
+				dbitem.Key = Key;
+				dbitem.Name = Name;
+				dbitem.AnchorType = (int)EndpointType;
+				dbitem.CellId = CellId;
+				dbitem.GameItemId = GameItemId;
+				dbitem.IsActive = IsActive;
+				FMDB.Context.SaveChanges();
+			}
+		}
+	}
+
+	public void SetActive(bool value)
+	{
+		IsActive = value;
+		using (new FMDB())
+		{
+			var dbitem = FMDB.Context.MagicPortalEndpoints.Find(Id);
+			if (dbitem is not null)
+			{
+				dbitem.IsActive = IsActive;
+				FMDB.Context.SaveChanges();
+			}
+		}
+	}
+
+	public void SetKey(string key)
+	{
+		Key = key;
+		using (new FMDB())
+		{
+			var dbitem = FMDB.Context.MagicPortalEndpoints.Find(Id);
+			if (dbitem is not null)
+			{
+				dbitem.Key = Key;
+				FMDB.Context.SaveChanges();
+			}
+		}
+	}
+}
+
+public class MagicPortalLink : FrameworkItem, IMagicPortalLink
+{
+	private readonly MagicPortalNetwork _network;
+
+	public MagicPortalLink(MagicPortalNetwork network, DB.MagicPortalLink dbitem, MagicPortalEndpoint source,
+		MagicPortalEndpoint destination)
+	{
+		_network = network;
+		_id = dbitem.Id;
+		_name = $"{source.Key} <-> {destination.Key}";
+		SourceEndpoint = source;
+		DestinationEndpoint = destination;
+		IsActive = dbitem.IsActive;
+	}
+
+	public override string FrameworkItemType => "MagicPortalLink";
+	public IFuturemud Gameworld => _network.Gameworld;
+	public IMagicPortalNetwork Network => _network;
+	public MagicPortalEndpoint SourceEndpoint { get; }
+	public MagicPortalEndpoint DestinationEndpoint { get; }
+	IMagicPortalEndpoint IMagicPortalLink.SourceEndpoint => SourceEndpoint;
+	IMagicPortalEndpoint IMagicPortalLink.DestinationEndpoint => DestinationEndpoint;
+	public bool IsActive { get; private set; }
+
+	public string WhyInvalid
+	{
+		get
+		{
+			if (!_network.IsActive)
+			{
+				return "network is inactive";
+			}
+
+			if (!IsActive)
+			{
+				return "link is inactive";
+			}
+
+			if (!string.IsNullOrWhiteSpace(SourceEndpoint.WhyInvalid))
+			{
+				return $"source endpoint {SourceEndpoint.Key}: {SourceEndpoint.WhyInvalid}";
+			}
+
+			if (!string.IsNullOrWhiteSpace(DestinationEndpoint.WhyInvalid))
+			{
+				return $"destination endpoint {DestinationEndpoint.Key}: {DestinationEndpoint.WhyInvalid}";
+			}
+
+			var source = SourceEndpoint.CurrentCell;
+			var destination = DestinationEndpoint.CurrentCell;
+			if (source is null || destination is null)
+			{
+				return "one or both endpoint rooms are unavailable";
+			}
+
+			if (source.Id == destination.Id)
+			{
+				return "source and destination resolve to the same room";
+			}
+
+			if (!_network.AllowCrossZone && !ReferenceEquals(source.Zone, destination.Zone))
+			{
+				return "cross-zone links are disabled";
+			}
+
+			if (!source.CanInteractPlanar(destination, PlanarInteractionKind.Magic))
+			{
+				return "the endpoint rooms cannot interact across planes";
+			}
+
+			return string.Empty;
+		}
+	}
+
+	public void SetActive(bool value)
+	{
+		IsActive = value;
+		using (new FMDB())
+		{
+			var dbitem = FMDB.Context.MagicPortalLinks.Find(Id);
+			if (dbitem is not null)
+			{
+				dbitem.IsActive = IsActive;
+				FMDB.Context.SaveChanges();
+			}
+		}
+	}
+}
+
+public class MagicPortalTopologyExit : TransientExit, IMagicPortalTopologyExit
+{
+	public MagicPortalTopologyExit(IMagicPortalNetwork network, IMagicPortalLink link, ICell source, ICell destination)
+		: base(network.Gameworld, source, destination, network.Verb, network.OutboundKeyword, network.InboundKeyword,
+			network.OutboundTarget, network.InboundTarget, network.OutboundDescription, network.InboundDescription,
+			network.TimeMultiplier)
+	{
+		Network = network;
+		Link = link;
+		SourceEndpoint = link.SourceEndpoint;
+		DestinationEndpoint = link.DestinationEndpoint;
+	}
+
+	public IMagicPortalNetwork Network { get; }
+	public IMagicPortalLink Link { get; }
+	public IMagicPortalEndpoint SourceEndpoint { get; }
+	public IMagicPortalEndpoint DestinationEndpoint { get; }
+}
+
+public class MagicPortalTopologyService : IMagicPortalTopologyService
+{
+	public IEnumerable<IMagicPortalTopologyExit> MaterializedExits(IFuturemud gameworld)
+	{
+		return gameworld.ExitManager.TransientExits.OfType<IMagicPortalTopologyExit>();
+	}
+
+	public void RebuildAll(IFuturemud gameworld)
+	{
+		foreach (var network in gameworld.MagicPortalNetworks.ToList())
+		{
+			RebuildNetwork(network);
+		}
+	}
+
+	public void RebuildNetwork(IMagicPortalNetwork network)
+	{
+		RemoveNetworkExits(network);
+		if (!network.IsActive)
+		{
+			return;
+		}
+
+		foreach (var link in network.Links)
+		{
+			if (!string.IsNullOrWhiteSpace(link.WhyInvalid))
+			{
+				continue;
+			}
+
+			var source = link.SourceEndpoint.CurrentCell;
+			var destination = link.DestinationEndpoint.CurrentCell;
+			if (source is null || destination is null)
+			{
+				continue;
+			}
+
+			network.Gameworld.ExitManager.RegisterTransientExit(
+				new MagicPortalTopologyExit(network, link, source, destination));
+		}
+	}
+
+	public void RebuildNetworksForItem(IFuturemud gameworld, IGameItem item)
+	{
+		foreach (var network in gameworld.MagicPortalNetworks
+			         .Where(x => x.Endpoints.Any(y =>
+				         y.EndpointType == MagicPortalEndpointType.Item &&
+				         y.GameItemId == item.Id))
+			         .ToList())
+		{
+			RebuildNetwork(network);
+		}
+	}
+
+	public void RemoveNetworkExits(IMagicPortalNetwork network)
+	{
+		foreach (var exit in MaterializedExits(network.Gameworld).Where(x => x.Network.Id == network.Id).ToList())
+		{
+			network.Gameworld.ExitManager.UnregisterTransientExit(exit.Exit);
+		}
+	}
+
+	public IMagicPortalEndpoint? CreateOrUpdateEndpoint(ICharacter actor, IMagicPortalNetwork network, string key,
+		string name, MagicPortalEndpointType endpointType, ICell? cell, IGameItem? item, bool replace, long? spellId,
+		out string reason)
+	{
+		reason = string.Empty;
+		if (network is not MagicPortalNetwork concreteNetwork)
+		{
+			reason = "That portal network cannot be edited by this runtime.";
+			return null;
+		}
+
+		key = key.Trim().ToLowerInvariant();
+		name = string.IsNullOrWhiteSpace(name) ? key.TitleCase() : name.Trim();
+		if (string.IsNullOrWhiteSpace(key))
+		{
+			reason = "Portal endpoints must have a key.";
+			return null;
+		}
+
+		if (endpointType == MagicPortalEndpointType.Cell && cell is null)
+		{
+			reason = "Cell endpoints must reference a room.";
+			return null;
+		}
+
+		if (endpointType == MagicPortalEndpointType.Item && item is null)
+		{
+			reason = "Item endpoints must reference an item.";
+			return null;
+		}
+
+		var existing = concreteNetwork.EndpointByKeyOrId(key);
+		if (existing is not null)
+		{
+			if (!replace)
+			{
+				reason = $"There is already an endpoint with the key {key}.";
+				return null;
+			}
+
+			existing.Update(key, name, endpointType, cell?.Id, item?.Id);
+			RebuildNetwork(network);
+			return existing;
+		}
+
+		DB.MagicPortalEndpoint dbitem;
+		using (new FMDB())
+		{
+			dbitem = new DB.MagicPortalEndpoint
+			{
+				MagicPortalNetworkId = network.Id,
+				Key = key,
+				Name = name,
+				AnchorType = (int)endpointType,
+				CellId = cell?.Id,
+				GameItemId = item?.Id,
+				IsActive = true,
+				CreatedByCharacterId = actor.Id,
+				CreatedBySpellId = spellId,
+				CreatedDateTime = DateTime.UtcNow
+			};
+			FMDB.Context.MagicPortalEndpoints.Add(dbitem);
+			FMDB.Context.SaveChanges();
+		}
+
+		var endpoint = new MagicPortalEndpoint(concreteNetwork, dbitem, key, name, endpointType, cell?.Id, item?.Id);
+		concreteNetwork.AddEndpoint(endpoint);
+		RebuildNetwork(network);
+		return endpoint;
+	}
+
+	public IMagicPortalLink? CreateLink(ICharacter actor, IMagicPortalNetwork network, IMagicPortalEndpoint source,
+		IMagicPortalEndpoint destination, long? spellId, out string reason)
+	{
+		reason = string.Empty;
+		if (network is not MagicPortalNetwork concreteNetwork ||
+			source is not MagicPortalEndpoint concreteSource ||
+			destination is not MagicPortalEndpoint concreteDestination)
+		{
+			reason = "That portal network cannot be edited by this runtime.";
+			return null;
+		}
+
+		if (source.Id == destination.Id)
+		{
+			reason = "A portal link cannot target the same endpoint twice.";
+			return null;
+		}
+
+		if (source.Network.Id != network.Id || destination.Network.Id != network.Id)
+		{
+			reason = "Both endpoints must belong to the same portal network.";
+			return null;
+		}
+
+		if (concreteNetwork.LinkBetween(concreteSource, concreteDestination) is not null)
+		{
+			reason = "Those endpoints are already linked.";
+			return null;
+		}
+
+		DB.MagicPortalLink dbitem;
+		using (new FMDB())
+		{
+			dbitem = new DB.MagicPortalLink
+			{
+				MagicPortalNetworkId = network.Id,
+				SourceEndpointId = source.Id,
+				DestinationEndpointId = destination.Id,
+				IsActive = true,
+				CreatedByCharacterId = actor.Id,
+				CreatedBySpellId = spellId,
+				CreatedDateTime = DateTime.UtcNow
+			};
+			FMDB.Context.MagicPortalLinks.Add(dbitem);
+			FMDB.Context.SaveChanges();
+		}
+
+		var link = new MagicPortalLink(concreteNetwork, dbitem, concreteSource, concreteDestination);
+		concreteNetwork.AddLink(link);
+		RebuildNetwork(network);
+		return link;
+	}
+
+	public void DeleteSpellCreatedTopology(IFuturemud gameworld, IEnumerable<long> endpointIds, IEnumerable<long> linkIds)
+	{
+		var endpointSet = endpointIds.ToHashSet();
+		var linkSet = linkIds.ToHashSet();
+		var affectedNetworks = gameworld.MagicPortalNetworks
+			.OfType<MagicPortalNetwork>()
+			.Where(x => x.Endpoints.Any(y => endpointSet.Contains(y.Id)) || x.Links.Any(y => linkSet.Contains(y.Id)))
+			.ToList();
+
+		foreach (var network in affectedNetworks)
+		{
+			foreach (var link in network.Links.OfType<MagicPortalLink>().Where(x => linkSet.Contains(x.Id)).ToList())
+			{
+				network.DeleteLink(link);
+			}
+
+			foreach (var endpoint in network.Endpoints.OfType<MagicPortalEndpoint>().Where(x => endpointSet.Contains(x.Id)).ToList())
+			{
+				network.DeleteEndpoint(endpoint);
+			}
+
+			RebuildNetwork(network);
+		}
+	}
+}

--- a/MudSharpCore/Magic/SpellEffects/PortalTopologySpellEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/PortalTopologySpellEffect.cs
@@ -1,0 +1,330 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Effects.Concrete.SpellEffects;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.GameItems;
+using MudSharp.RPG.Checks;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace MudSharp.Magic.SpellEffects;
+
+public class PortalTopologySpellEffect : IMagicSpellEffectTemplate
+{
+	public static void RegisterFactory()
+	{
+		SpellEffectFactory.RegisterLoadTimeFactory("portalnetwork", (root, spell) => new PortalTopologySpellEffect(root, spell));
+		SpellEffectFactory.RegisterBuilderFactory("portalnetwork", BuilderFactory,
+			"Creates or links a durable portal/rune topology endpoint",
+			HelpText,
+			false,
+			true,
+			SpellTriggerFactory.MagicTriggerTypes
+				.Where(x => IsCompatibleWithTrigger(SpellTriggerFactory.BuilderInfoForType(x).TargetTypes))
+				.ToArray());
+	}
+
+	private static (IMagicSpellEffectTemplate Trigger, string Error) BuilderFactory(StringStack commands,
+		IMagicSpell spell)
+	{
+		return (new PortalTopologySpellEffect(new XElement("Effect",
+			new XAttribute("type", "portalnetwork"),
+			new XElement("NetworkId", 0L),
+			new XElement("EndpointKey", new XCData("rune")),
+			new XElement("AnchorMode", (int)MagicPortalTopologyAnchorMode.TargetRoom),
+			new XElement("LinkEndpointKey", new XCData(string.Empty)),
+			new XElement("ReplaceExisting", true),
+			new XElement("Permanent", false)
+		), spell), string.Empty);
+	}
+
+	protected PortalTopologySpellEffect(XElement root, IMagicSpell spell)
+	{
+		Spell = spell;
+		NetworkId = long.Parse(root.Element("NetworkId")?.Value ?? "0");
+		EndpointKey = root.Element("EndpointKey")?.Value ?? "rune";
+		AnchorMode = (MagicPortalTopologyAnchorMode)int.Parse(root.Element("AnchorMode")?.Value ?? ((int)MagicPortalTopologyAnchorMode.TargetRoom).ToString());
+		LinkEndpointKey = root.Element("LinkEndpointKey")?.Value ?? string.Empty;
+		ReplaceExisting = bool.Parse(root.Element("ReplaceExisting")?.Value ?? "true");
+		Permanent = bool.Parse(root.Element("Permanent")?.Value ?? "false");
+	}
+
+	public IMagicSpell Spell { get; }
+	public IFuturemud Gameworld => Spell.Gameworld;
+	public long NetworkId { get; private set; }
+	public string EndpointKey { get; private set; }
+	public MagicPortalTopologyAnchorMode AnchorMode { get; private set; }
+	public string LinkEndpointKey { get; private set; }
+	public bool ReplaceExisting { get; private set; }
+	public bool Permanent { get; private set; }
+
+	public XElement SaveToXml()
+	{
+		return new XElement("Effect",
+			new XAttribute("type", "portalnetwork"),
+			new XElement("NetworkId", NetworkId),
+			new XElement("EndpointKey", new XCData(EndpointKey)),
+			new XElement("AnchorMode", (int)AnchorMode),
+			new XElement("LinkEndpointKey", new XCData(LinkEndpointKey)),
+			new XElement("ReplaceExisting", ReplaceExisting),
+			new XElement("Permanent", Permanent)
+		);
+	}
+
+	public bool IsInstantaneous => false;
+	public bool RequiresTarget => AnchorMode != MagicPortalTopologyAnchorMode.CasterRoom;
+
+	public static bool IsCompatibleWithTrigger(string types)
+	{
+		return types is "character" or "room" or "rooms" or "item" or "item&room" or "character&room" or "perceivable";
+	}
+
+	public bool IsCompatibleWithTrigger(IMagicTrigger trigger) => IsCompatibleWithTrigger(trigger.TargetTypes);
+
+	public IMagicSpellEffect? GetOrApplyEffect(ICharacter caster, IPerceivable? target, OpposedOutcomeDegree outcome,
+		SpellPower power, IMagicSpellEffectParent parent, SpellAdditionalParameter[] additionalParameters)
+	{
+		var network = Gameworld.MagicPortalNetworks.Get(NetworkId);
+		if (network is null)
+		{
+			return null;
+		}
+
+		ICell? cell = null;
+		IGameItem? item = null;
+		var endpointType = MagicPortalEndpointType.Cell;
+		switch (AnchorMode)
+		{
+			case MagicPortalTopologyAnchorMode.CasterRoom:
+				cell = caster.Location;
+				break;
+			case MagicPortalTopologyAnchorMode.TargetRoom:
+				cell = target as ICell ??
+				       additionalParameters.FirstOrDefault(x => x.ParameterName.EqualTo("room"))?.Item as ICell;
+				break;
+			case MagicPortalTopologyAnchorMode.TargetItem:
+				item = target as IGameItem;
+				endpointType = MagicPortalEndpointType.Item;
+				break;
+			default:
+				return null;
+		}
+
+		if (endpointType == MagicPortalEndpointType.Cell && cell is null)
+		{
+			return null;
+		}
+
+		if (endpointType == MagicPortalEndpointType.Item && item is null)
+		{
+			return null;
+		}
+
+		var existingEndpoint = network.Endpoints.FirstOrDefault(x => x.Key.EqualTo(EndpointKey));
+		if (existingEndpoint is not null && !Permanent)
+		{
+			return null;
+		}
+
+		IMagicPortalEndpoint? linkTarget = null;
+		if (!string.IsNullOrWhiteSpace(LinkEndpointKey))
+		{
+			if (LinkEndpointKey.EqualTo(EndpointKey))
+			{
+				return null;
+			}
+
+			linkTarget = network.Endpoints.FirstOrDefault(x => x.Key.EqualTo(LinkEndpointKey));
+			if (linkTarget is null)
+			{
+				return null;
+			}
+		}
+
+		var service = new MagicPortalTopologyService();
+		var endpoint = service.CreateOrUpdateEndpoint(caster, network, EndpointKey, EndpointKey.TitleCase(),
+			endpointType, cell, item, ReplaceExisting, Spell.Id, out _);
+		if (endpoint is null)
+		{
+			return null;
+		}
+
+		var createdEndpoints = new List<long>();
+		var createdLinks = new List<long>();
+		if (existingEndpoint is null)
+		{
+			createdEndpoints.Add(endpoint.Id);
+		}
+
+		if (!string.IsNullOrWhiteSpace(LinkEndpointKey))
+		{
+			var existingLink = network is MagicPortalNetwork concreteNetwork &&
+			                   endpoint is MagicPortalEndpoint concreteEndpoint &&
+			                   linkTarget is MagicPortalEndpoint concreteTarget
+				? concreteNetwork.LinkBetween(concreteEndpoint, concreteTarget)
+				: null;
+
+			if (existingLink is null)
+			{
+				var link = service.CreateLink(caster, network, endpoint, linkTarget!, Spell.Id, out _);
+				if (link is null)
+				{
+					if (createdEndpoints.Any())
+					{
+						service.DeleteSpellCreatedTopology(Gameworld, createdEndpoints, createdLinks);
+					}
+
+					return null;
+				}
+
+				createdLinks.Add(link.Id);
+			}
+		}
+
+		var effectOwner = target ?? (IPerceivable?)cell ?? item;
+		if (effectOwner is null)
+		{
+			return null;
+		}
+
+		return new SpellPortalTopologyEffect(effectOwner, parent, createdEndpoints, createdLinks, Permanent);
+	}
+
+	public IMagicSpellEffectTemplate Clone() => new PortalTopologySpellEffect(SaveToXml(), Spell);
+
+	public const string HelpText = @"You can use the following options with this effect:
+
+	#3network <id|name>#0 - sets the durable portal network to edit
+	#3key <key>#0 - sets the endpoint key this spell creates or updates
+	#3anchor caster#0 - creates the endpoint in the caster's room
+	#3anchor room#0 - creates the endpoint at the target room
+	#3anchor item#0 - creates the endpoint on the target item while directly placed
+	#3link none|<endpoint key>#0 - optionally links the created endpoint to an existing endpoint
+	#3replace#0 - toggles whether a permanent cast can update an existing endpoint key
+	#3permanent#0 - toggles whether spell expiry cleans up created topology";
+
+	public bool BuildingCommand(ICharacter actor, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "network":
+				return BuildingCommandNetwork(actor, command);
+			case "key":
+				return BuildingCommandKey(actor, command);
+			case "anchor":
+				return BuildingCommandAnchor(actor, command);
+			case "link":
+				return BuildingCommandLink(actor, command);
+			case "replace":
+				ReplaceExisting = !ReplaceExisting;
+				break;
+			case "permanent":
+				Permanent = !Permanent;
+				break;
+			default:
+				actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
+				return false;
+		}
+
+		Spell.Changed = true;
+		actor.OutputHandler.Send("The portal topology effect has been updated.");
+		return true;
+	}
+
+	private bool BuildingCommandNetwork(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which portal network should this effect use?");
+			return false;
+		}
+
+		var network = Gameworld.MagicPortalNetworks.GetByIdOrName(command.SafeRemainingArgument);
+		if (network is null)
+		{
+			actor.OutputHandler.Send("There is no such magic portal network.");
+			return false;
+		}
+
+		NetworkId = network.Id;
+		Spell.Changed = true;
+		actor.OutputHandler.Send($"This effect will now edit the {network.Name.ColourName()} portal network.");
+		return true;
+	}
+
+	private bool BuildingCommandKey(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("What endpoint key should this effect create or update?");
+			return false;
+		}
+
+		EndpointKey = command.SafeRemainingArgument.ToLowerInvariant();
+		Spell.Changed = true;
+		actor.OutputHandler.Send($"This effect will now create or update endpoint key {EndpointKey.ColourCommand()}.");
+		return true;
+	}
+
+	private bool BuildingCommandAnchor(ICharacter actor, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "caster":
+			case "casterroom":
+			case "here":
+				AnchorMode = MagicPortalTopologyAnchorMode.CasterRoom;
+				break;
+			case "room":
+			case "targetroom":
+				AnchorMode = MagicPortalTopologyAnchorMode.TargetRoom;
+				break;
+			case "item":
+			case "targetitem":
+				AnchorMode = MagicPortalTopologyAnchorMode.TargetItem;
+				break;
+			default:
+				actor.OutputHandler.Send("Valid anchor modes are #3caster#0, #3room#0, and #3item#0.".SubstituteANSIColour());
+				return false;
+		}
+
+		Spell.Changed = true;
+		actor.OutputHandler.Send($"This effect now uses the {AnchorMode.DescribeEnum().ColourName()} anchor mode.");
+		return true;
+	}
+
+	private bool BuildingCommandLink(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which existing endpoint key should be linked to this endpoint, or #3none#0?".SubstituteANSIColour());
+			return false;
+		}
+
+		if (command.SafeRemainingArgument.EqualTo("none"))
+		{
+			LinkEndpointKey = string.Empty;
+		}
+		else
+		{
+			LinkEndpointKey = command.SafeRemainingArgument.ToLowerInvariant();
+		}
+
+		Spell.Changed = true;
+		actor.OutputHandler.Send(string.IsNullOrWhiteSpace(LinkEndpointKey)
+			? "This effect will not create a link."
+			: $"This effect will link its endpoint to {LinkEndpointKey.ColourCommand()}.");
+		return true;
+	}
+
+	public string Show(ICharacter actor)
+	{
+		var network = Gameworld.MagicPortalNetworks.Get(NetworkId);
+		return $"PortalNetwork - Network: {network?.Name.ColourName() ?? "None".ColourError()} - Key: {EndpointKey.ColourCommand()} - Anchor: {AnchorMode.DescribeEnum().ColourName()} - Link: {(string.IsNullOrWhiteSpace(LinkEndpointKey) ? "none" : LinkEndpointKey.ColourCommand())} - Replace: {ReplaceExisting.ToColouredString()} - Permanent: {Permanent.ToColouredString()}";
+	}
+}

--- a/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextMagicPortalTopology.cs
+++ b/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextMagicPortalTopology.cs
@@ -1,0 +1,99 @@
+using Microsoft.EntityFrameworkCore;
+using MudSharp.Models;
+
+namespace MudSharp.Database;
+
+public partial class FuturemudDatabaseContext
+{
+	public virtual DbSet<MagicPortalNetwork> MagicPortalNetworks { get; set; }
+	public virtual DbSet<MagicPortalEndpoint> MagicPortalEndpoints { get; set; }
+	public virtual DbSet<MagicPortalLink> MagicPortalLinks { get; set; }
+
+	private static void ConfigureMagicPortalTopology(ModelBuilder modelBuilder)
+	{
+		modelBuilder.Entity<MagicPortalNetwork>(entity =>
+		{
+			entity.ToTable("MagicPortalNetworks");
+			entity.HasKey(e => e.Id).HasName("PRIMARY");
+			entity.HasIndex(e => e.MagicSchoolId).HasDatabaseName("FK_MagicPortalNetworks_MagicSchools_idx");
+			entity.HasIndex(e => e.CreatedByCharacterId).HasDatabaseName("FK_MagicPortalNetworks_Characters_idx");
+			entity.HasIndex(e => e.CreatedBySpellId).HasDatabaseName("FK_MagicPortalNetworks_MagicSpells_idx");
+
+			entity.Property(e => e.Id).HasColumnType("bigint(20)");
+			entity.Property(e => e.Name).IsRequired().HasColumnType("varchar(200)").HasCharSet("utf8").UseCollation("utf8_general_ci");
+			entity.Property(e => e.MagicSchoolId).HasColumnType("bigint(20)");
+			entity.Property(e => e.IsActive).HasColumnType("bit(1)").HasDefaultValue(true);
+			entity.Property(e => e.AllowCrossZone).HasColumnType("bit(1)");
+			entity.Property(e => e.Verb).IsRequired().HasColumnType("varchar(100)").HasCharSet("utf8").UseCollation("utf8_general_ci");
+			entity.Property(e => e.OutboundKeyword).IsRequired().HasColumnType("varchar(100)").HasCharSet("utf8").UseCollation("utf8_general_ci");
+			entity.Property(e => e.InboundKeyword).IsRequired().HasColumnType("varchar(100)").HasCharSet("utf8").UseCollation("utf8_general_ci");
+			entity.Property(e => e.OutboundTarget).IsRequired().HasColumnType("varchar(500)").HasCharSet("utf8").UseCollation("utf8_general_ci");
+			entity.Property(e => e.InboundTarget).IsRequired().HasColumnType("varchar(500)").HasCharSet("utf8").UseCollation("utf8_general_ci");
+			entity.Property(e => e.OutboundDescription).IsRequired().HasColumnType("varchar(100)").HasCharSet("utf8").UseCollation("utf8_general_ci");
+			entity.Property(e => e.InboundDescription).IsRequired().HasColumnType("varchar(100)").HasCharSet("utf8").UseCollation("utf8_general_ci");
+			entity.Property(e => e.TimeMultiplier).HasColumnType("double").HasDefaultValue(1.0);
+			entity.Property(e => e.CreatedByCharacterId).HasColumnType("bigint(20)");
+			entity.Property(e => e.CreatedBySpellId).HasColumnType("bigint(20)");
+			entity.Property(e => e.CreatedDateTime).HasColumnType("datetime");
+
+			entity.HasOne(e => e.MagicSchool).WithMany().HasForeignKey(e => e.MagicSchoolId).OnDelete(DeleteBehavior.SetNull).HasConstraintName("FK_MagicPortalNetworks_MagicSchools");
+			entity.HasOne(e => e.CreatedByCharacter).WithMany().HasForeignKey(e => e.CreatedByCharacterId).OnDelete(DeleteBehavior.SetNull).HasConstraintName("FK_MagicPortalNetworks_Characters");
+			entity.HasOne(e => e.CreatedBySpell).WithMany().HasForeignKey(e => e.CreatedBySpellId).OnDelete(DeleteBehavior.SetNull).HasConstraintName("FK_MagicPortalNetworks_MagicSpells");
+		});
+
+		modelBuilder.Entity<MagicPortalEndpoint>(entity =>
+		{
+			entity.ToTable("MagicPortalEndpoints");
+			entity.HasKey(e => e.Id).HasName("PRIMARY");
+			entity.HasIndex(e => new { e.MagicPortalNetworkId, e.Key }).IsUnique().HasDatabaseName("IX_MagicPortalEndpoints_Network_Key");
+			entity.HasIndex(e => e.CellId).HasDatabaseName("FK_MagicPortalEndpoints_Cells_idx");
+			entity.HasIndex(e => e.GameItemId).HasDatabaseName("FK_MagicPortalEndpoints_GameItems_idx");
+			entity.HasIndex(e => e.CreatedByCharacterId).HasDatabaseName("FK_MagicPortalEndpoints_Characters_idx");
+			entity.HasIndex(e => e.CreatedBySpellId).HasDatabaseName("FK_MagicPortalEndpoints_MagicSpells_idx");
+
+			entity.Property(e => e.Id).HasColumnType("bigint(20)");
+			entity.Property(e => e.MagicPortalNetworkId).HasColumnType("bigint(20)");
+			entity.Property(e => e.Key).IsRequired().HasColumnType("varchar(100)").HasCharSet("utf8").UseCollation("utf8_general_ci");
+			entity.Property(e => e.Name).IsRequired().HasColumnType("varchar(200)").HasCharSet("utf8").UseCollation("utf8_general_ci");
+			entity.Property(e => e.AnchorType).HasColumnType("int(11)");
+			entity.Property(e => e.CellId).HasColumnType("bigint(20)");
+			entity.Property(e => e.GameItemId).HasColumnType("bigint(20)");
+			entity.Property(e => e.IsActive).HasColumnType("bit(1)").HasDefaultValue(true);
+			entity.Property(e => e.CreatedByCharacterId).HasColumnType("bigint(20)");
+			entity.Property(e => e.CreatedBySpellId).HasColumnType("bigint(20)");
+			entity.Property(e => e.CreatedDateTime).HasColumnType("datetime");
+
+			entity.HasOne(e => e.MagicPortalNetwork).WithMany(e => e.MagicPortalEndpoints).HasForeignKey(e => e.MagicPortalNetworkId).HasConstraintName("FK_MagicPortalEndpoints_MagicPortalNetworks");
+			entity.HasOne(e => e.Cell).WithMany().HasForeignKey(e => e.CellId).OnDelete(DeleteBehavior.SetNull).HasConstraintName("FK_MagicPortalEndpoints_Cells");
+			entity.HasOne(e => e.GameItem).WithMany().HasForeignKey(e => e.GameItemId).OnDelete(DeleteBehavior.SetNull).HasConstraintName("FK_MagicPortalEndpoints_GameItems");
+			entity.HasOne(e => e.CreatedByCharacter).WithMany().HasForeignKey(e => e.CreatedByCharacterId).OnDelete(DeleteBehavior.SetNull).HasConstraintName("FK_MagicPortalEndpoints_Characters");
+			entity.HasOne(e => e.CreatedBySpell).WithMany().HasForeignKey(e => e.CreatedBySpellId).OnDelete(DeleteBehavior.SetNull).HasConstraintName("FK_MagicPortalEndpoints_MagicSpells");
+		});
+
+		modelBuilder.Entity<MagicPortalLink>(entity =>
+		{
+			entity.ToTable("MagicPortalLinks");
+			entity.HasKey(e => e.Id).HasName("PRIMARY");
+			entity.HasIndex(e => new { e.MagicPortalNetworkId, e.SourceEndpointId, e.DestinationEndpointId }).IsUnique().HasDatabaseName("IX_MagicPortalLinks_Network_Source_Destination");
+			entity.HasIndex(e => e.SourceEndpointId).HasDatabaseName("FK_MagicPortalLinks_SourceEndpoints_idx");
+			entity.HasIndex(e => e.DestinationEndpointId).HasDatabaseName("FK_MagicPortalLinks_DestinationEndpoints_idx");
+			entity.HasIndex(e => e.CreatedByCharacterId).HasDatabaseName("FK_MagicPortalLinks_Characters_idx");
+			entity.HasIndex(e => e.CreatedBySpellId).HasDatabaseName("FK_MagicPortalLinks_MagicSpells_idx");
+
+			entity.Property(e => e.Id).HasColumnType("bigint(20)");
+			entity.Property(e => e.MagicPortalNetworkId).HasColumnType("bigint(20)");
+			entity.Property(e => e.SourceEndpointId).HasColumnType("bigint(20)");
+			entity.Property(e => e.DestinationEndpointId).HasColumnType("bigint(20)");
+			entity.Property(e => e.IsActive).HasColumnType("bit(1)").HasDefaultValue(true);
+			entity.Property(e => e.CreatedByCharacterId).HasColumnType("bigint(20)");
+			entity.Property(e => e.CreatedBySpellId).HasColumnType("bigint(20)");
+			entity.Property(e => e.CreatedDateTime).HasColumnType("datetime");
+
+			entity.HasOne(e => e.MagicPortalNetwork).WithMany(e => e.MagicPortalLinks).HasForeignKey(e => e.MagicPortalNetworkId).HasConstraintName("FK_MagicPortalLinks_MagicPortalNetworks");
+			entity.HasOne(e => e.SourceEndpoint).WithMany(e => e.MagicPortalLinksAsSource).HasForeignKey(e => e.SourceEndpointId).OnDelete(DeleteBehavior.Cascade).HasConstraintName("FK_MagicPortalLinks_SourceEndpoints");
+			entity.HasOne(e => e.DestinationEndpoint).WithMany(e => e.MagicPortalLinksAsDestination).HasForeignKey(e => e.DestinationEndpointId).OnDelete(DeleteBehavior.Cascade).HasConstraintName("FK_MagicPortalLinks_DestinationEndpoints");
+			entity.HasOne(e => e.CreatedByCharacter).WithMany().HasForeignKey(e => e.CreatedByCharacterId).OnDelete(DeleteBehavior.SetNull).HasConstraintName("FK_MagicPortalLinks_Characters");
+			entity.HasOne(e => e.CreatedBySpell).WithMany().HasForeignKey(e => e.CreatedBySpellId).OnDelete(DeleteBehavior.SetNull).HasConstraintName("FK_MagicPortalLinks_MagicSpells");
+		});
+	}
+}

--- a/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextShopDeals.cs
+++ b/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextShopDeals.cs
@@ -14,6 +14,7 @@ namespace MudSharp.Database
             ConfigureVirtualCash(modelBuilder);
             ConfigureAgriculture(modelBuilder);
             ConfigureVehicles(modelBuilder);
+            ConfigureMagicPortalTopology(modelBuilder);
 
             modelBuilder.Entity<ShopDeal>(entity =>
             {

--- a/MudsharpDatabaseLibrary/Migrations/20260529230237_MagicPortalTopology.Designer.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260529230237_MagicPortalTopology.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MudSharp.Database;
 
@@ -11,9 +12,11 @@ using MudSharp.Database;
 namespace MudSharp.Migrations
 {
     [DbContext(typeof(FuturemudDatabaseContext))]
-    partial class FutureMUDContextModelSnapshot : ModelSnapshot
+    [Migration("20260529230237_MagicPortalTopology")]
+    partial class MagicPortalTopology
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MudsharpDatabaseLibrary/Migrations/20260529230237_MagicPortalTopology.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260529230237_MagicPortalTopology.cs
@@ -1,0 +1,255 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MudSharp.Migrations
+{
+    /// <inheritdoc />
+    public partial class MagicPortalTopology : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "MagicPortalNetworks",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint(20)", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    Name = table.Column<string>(type: "varchar(200)", nullable: false, collation: "utf8_general_ci")
+                        .Annotation("MySql:CharSet", "utf8"),
+                    MagicSchoolId = table.Column<long>(type: "bigint(20)", nullable: true),
+                    IsActive = table.Column<ulong>(type: "bit(1)", nullable: false, defaultValue: 1ul),
+                    AllowCrossZone = table.Column<ulong>(type: "bit(1)", nullable: false),
+                    Verb = table.Column<string>(type: "varchar(100)", nullable: false, collation: "utf8_general_ci")
+                        .Annotation("MySql:CharSet", "utf8"),
+                    OutboundKeyword = table.Column<string>(type: "varchar(100)", nullable: false, collation: "utf8_general_ci")
+                        .Annotation("MySql:CharSet", "utf8"),
+                    InboundKeyword = table.Column<string>(type: "varchar(100)", nullable: false, collation: "utf8_general_ci")
+                        .Annotation("MySql:CharSet", "utf8"),
+                    OutboundTarget = table.Column<string>(type: "varchar(500)", nullable: false, collation: "utf8_general_ci")
+                        .Annotation("MySql:CharSet", "utf8"),
+                    InboundTarget = table.Column<string>(type: "varchar(500)", nullable: false, collation: "utf8_general_ci")
+                        .Annotation("MySql:CharSet", "utf8"),
+                    OutboundDescription = table.Column<string>(type: "varchar(100)", nullable: false, collation: "utf8_general_ci")
+                        .Annotation("MySql:CharSet", "utf8"),
+                    InboundDescription = table.Column<string>(type: "varchar(100)", nullable: false, collation: "utf8_general_ci")
+                        .Annotation("MySql:CharSet", "utf8"),
+                    TimeMultiplier = table.Column<double>(type: "double", nullable: false, defaultValue: 1.0),
+                    CreatedByCharacterId = table.Column<long>(type: "bigint(20)", nullable: true),
+                    CreatedBySpellId = table.Column<long>(type: "bigint(20)", nullable: true),
+                    CreatedDateTime = table.Column<DateTime>(type: "datetime", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PRIMARY", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_MagicPortalNetworks_Characters",
+                        column: x => x.CreatedByCharacterId,
+                        principalTable: "Characters",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_MagicPortalNetworks_MagicSchools",
+                        column: x => x.MagicSchoolId,
+                        principalTable: "MagicSchools",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_MagicPortalNetworks_MagicSpells",
+                        column: x => x.CreatedBySpellId,
+                        principalTable: "MagicSpells",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "MagicPortalEndpoints",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint(20)", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    MagicPortalNetworkId = table.Column<long>(type: "bigint(20)", nullable: false),
+                    Key = table.Column<string>(type: "varchar(100)", nullable: false, collation: "utf8_general_ci")
+                        .Annotation("MySql:CharSet", "utf8"),
+                    Name = table.Column<string>(type: "varchar(200)", nullable: false, collation: "utf8_general_ci")
+                        .Annotation("MySql:CharSet", "utf8"),
+                    AnchorType = table.Column<int>(type: "int(11)", nullable: false),
+                    CellId = table.Column<long>(type: "bigint(20)", nullable: true),
+                    GameItemId = table.Column<long>(type: "bigint(20)", nullable: true),
+                    IsActive = table.Column<ulong>(type: "bit(1)", nullable: false, defaultValue: 1ul),
+                    CreatedByCharacterId = table.Column<long>(type: "bigint(20)", nullable: true),
+                    CreatedBySpellId = table.Column<long>(type: "bigint(20)", nullable: true),
+                    CreatedDateTime = table.Column<DateTime>(type: "datetime", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PRIMARY", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_MagicPortalEndpoints_Cells",
+                        column: x => x.CellId,
+                        principalTable: "Cells",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_MagicPortalEndpoints_Characters",
+                        column: x => x.CreatedByCharacterId,
+                        principalTable: "Characters",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_MagicPortalEndpoints_GameItems",
+                        column: x => x.GameItemId,
+                        principalTable: "GameItems",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_MagicPortalEndpoints_MagicPortalNetworks",
+                        column: x => x.MagicPortalNetworkId,
+                        principalTable: "MagicPortalNetworks",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_MagicPortalEndpoints_MagicSpells",
+                        column: x => x.CreatedBySpellId,
+                        principalTable: "MagicSpells",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "MagicPortalLinks",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint(20)", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    MagicPortalNetworkId = table.Column<long>(type: "bigint(20)", nullable: false),
+                    SourceEndpointId = table.Column<long>(type: "bigint(20)", nullable: false),
+                    DestinationEndpointId = table.Column<long>(type: "bigint(20)", nullable: false),
+                    IsActive = table.Column<ulong>(type: "bit(1)", nullable: false, defaultValue: 1ul),
+                    CreatedByCharacterId = table.Column<long>(type: "bigint(20)", nullable: true),
+                    CreatedBySpellId = table.Column<long>(type: "bigint(20)", nullable: true),
+                    CreatedDateTime = table.Column<DateTime>(type: "datetime", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PRIMARY", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_MagicPortalLinks_Characters",
+                        column: x => x.CreatedByCharacterId,
+                        principalTable: "Characters",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_MagicPortalLinks_DestinationEndpoints",
+                        column: x => x.DestinationEndpointId,
+                        principalTable: "MagicPortalEndpoints",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_MagicPortalLinks_MagicPortalNetworks",
+                        column: x => x.MagicPortalNetworkId,
+                        principalTable: "MagicPortalNetworks",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_MagicPortalLinks_MagicSpells",
+                        column: x => x.CreatedBySpellId,
+                        principalTable: "MagicSpells",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_MagicPortalLinks_SourceEndpoints",
+                        column: x => x.SourceEndpointId,
+                        principalTable: "MagicPortalEndpoints",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_MagicPortalEndpoints_Cells_idx",
+                table: "MagicPortalEndpoints",
+                column: "CellId");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_MagicPortalEndpoints_Characters_idx",
+                table: "MagicPortalEndpoints",
+                column: "CreatedByCharacterId");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_MagicPortalEndpoints_GameItems_idx",
+                table: "MagicPortalEndpoints",
+                column: "GameItemId");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_MagicPortalEndpoints_MagicSpells_idx",
+                table: "MagicPortalEndpoints",
+                column: "CreatedBySpellId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MagicPortalEndpoints_Network_Key",
+                table: "MagicPortalEndpoints",
+                columns: new[] { "MagicPortalNetworkId", "Key" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "FK_MagicPortalLinks_Characters_idx",
+                table: "MagicPortalLinks",
+                column: "CreatedByCharacterId");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_MagicPortalLinks_DestinationEndpoints_idx",
+                table: "MagicPortalLinks",
+                column: "DestinationEndpointId");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_MagicPortalLinks_MagicSpells_idx",
+                table: "MagicPortalLinks",
+                column: "CreatedBySpellId");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_MagicPortalLinks_SourceEndpoints_idx",
+                table: "MagicPortalLinks",
+                column: "SourceEndpointId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MagicPortalLinks_Network_Source_Destination",
+                table: "MagicPortalLinks",
+                columns: new[] { "MagicPortalNetworkId", "SourceEndpointId", "DestinationEndpointId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "FK_MagicPortalNetworks_Characters_idx",
+                table: "MagicPortalNetworks",
+                column: "CreatedByCharacterId");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_MagicPortalNetworks_MagicSchools_idx",
+                table: "MagicPortalNetworks",
+                column: "MagicSchoolId");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_MagicPortalNetworks_MagicSpells_idx",
+                table: "MagicPortalNetworks",
+                column: "CreatedBySpellId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "MagicPortalLinks");
+
+            migrationBuilder.DropTable(
+                name: "MagicPortalEndpoints");
+
+            migrationBuilder.DropTable(
+                name: "MagicPortalNetworks");
+        }
+    }
+}

--- a/MudsharpDatabaseLibrary/Models/MagicPortalEndpoint.cs
+++ b/MudsharpDatabaseLibrary/Models/MagicPortalEndpoint.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+
+namespace MudSharp.Models;
+
+public class MagicPortalEndpoint
+{
+	public MagicPortalEndpoint()
+	{
+		MagicPortalLinksAsDestination = new HashSet<MagicPortalLink>();
+		MagicPortalLinksAsSource = new HashSet<MagicPortalLink>();
+	}
+
+	public long Id { get; set; }
+	public long MagicPortalNetworkId { get; set; }
+	public string Key { get; set; }
+	public string Name { get; set; }
+	public int AnchorType { get; set; }
+	public long? CellId { get; set; }
+	public long? GameItemId { get; set; }
+	public bool IsActive { get; set; }
+	public long? CreatedByCharacterId { get; set; }
+	public long? CreatedBySpellId { get; set; }
+	public DateTime CreatedDateTime { get; set; }
+
+	public virtual MagicPortalNetwork MagicPortalNetwork { get; set; }
+	public virtual Cell Cell { get; set; }
+	public virtual GameItem GameItem { get; set; }
+	public virtual Character CreatedByCharacter { get; set; }
+	public virtual MagicSpell CreatedBySpell { get; set; }
+	public virtual ICollection<MagicPortalLink> MagicPortalLinksAsDestination { get; set; }
+	public virtual ICollection<MagicPortalLink> MagicPortalLinksAsSource { get; set; }
+}

--- a/MudsharpDatabaseLibrary/Models/MagicPortalLink.cs
+++ b/MudsharpDatabaseLibrary/Models/MagicPortalLink.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace MudSharp.Models;
+
+public class MagicPortalLink
+{
+	public long Id { get; set; }
+	public long MagicPortalNetworkId { get; set; }
+	public long SourceEndpointId { get; set; }
+	public long DestinationEndpointId { get; set; }
+	public bool IsActive { get; set; }
+	public long? CreatedByCharacterId { get; set; }
+	public long? CreatedBySpellId { get; set; }
+	public DateTime CreatedDateTime { get; set; }
+
+	public virtual MagicPortalNetwork MagicPortalNetwork { get; set; }
+	public virtual MagicPortalEndpoint SourceEndpoint { get; set; }
+	public virtual MagicPortalEndpoint DestinationEndpoint { get; set; }
+	public virtual Character CreatedByCharacter { get; set; }
+	public virtual MagicSpell CreatedBySpell { get; set; }
+}

--- a/MudsharpDatabaseLibrary/Models/MagicPortalNetwork.cs
+++ b/MudsharpDatabaseLibrary/Models/MagicPortalNetwork.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+
+namespace MudSharp.Models;
+
+public class MagicPortalNetwork
+{
+	public MagicPortalNetwork()
+	{
+		MagicPortalEndpoints = new HashSet<MagicPortalEndpoint>();
+		MagicPortalLinks = new HashSet<MagicPortalLink>();
+	}
+
+	public long Id { get; set; }
+	public string Name { get; set; }
+	public long? MagicSchoolId { get; set; }
+	public bool IsActive { get; set; }
+	public bool AllowCrossZone { get; set; }
+	public string Verb { get; set; }
+	public string OutboundKeyword { get; set; }
+	public string InboundKeyword { get; set; }
+	public string OutboundTarget { get; set; }
+	public string InboundTarget { get; set; }
+	public string OutboundDescription { get; set; }
+	public string InboundDescription { get; set; }
+	public double TimeMultiplier { get; set; }
+	public long? CreatedByCharacterId { get; set; }
+	public long? CreatedBySpellId { get; set; }
+	public DateTime CreatedDateTime { get; set; }
+
+	public virtual MagicSchool MagicSchool { get; set; }
+	public virtual Character CreatedByCharacter { get; set; }
+	public virtual MagicSpell CreatedBySpell { get; set; }
+	public virtual ICollection<MagicPortalEndpoint> MagicPortalEndpoints { get; set; }
+	public virtual ICollection<MagicPortalLink> MagicPortalLinks { get; set; }
+}


### PR DESCRIPTION
## Summary
- Add persistent portal network, endpoint, and link models for durable magic portal/rune topology.
- Add runtime topology service/effects, builder commands, and movement rebuild hooks for portal anchors.
- Update magic design/gap docs and add focused portal topology regression coverage.

## Validation
- `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 --filter FullyQualifiedName~MagicPortalTopologyTests`
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 --filter FullyQualifiedName~MagicPhase3Tests`
- `git diff --check`