### PR TITLE
Improve legal patrol and trial workflows

### DIFF
--- a/Design Documents/Economy/Law_System_Runtime.md
+++ b/Design Documents/Economy/Law_System_Runtime.md
@@ -78,6 +78,76 @@ The execution patrol progresses through these stages:
 
 If required rooms, tools, paths, or targets become unavailable for too long, the patrol aborts and removes only the execution-specific no-quit effect. The `AwaitingExecution` effect remains so a later patrol can try again.
 
+## Trials and PC Judges
+
+Trials are represented by the `OnTrial` effect for the relevant legal authority. NPC judges drive ordinary `OnTrial` effects through the automated plea, argument, verdict, and sentencing phases. PC-held trials use the same effect as a court-session marker, but set the manual-trial flag so NPC judge AI will not advance or finalise the case.
+
+A PC judge is any enforcer whose enforcement authority has `CanConvict` for the jurisdiction and whose authority can judge the defendant's legal class.
+
+Judge-facing trial commands:
+
+- `trial`: shows the active trial in the current room.
+- `trial docket [jurisdiction]`: lists defendants awaiting trial for the judge's jurisdictions, including remand/bail/trial status, charge IDs, charge names, and prior local convictions.
+- `trial summon <target>`: from the jurisdiction courtroom, calls a remand prisoner or present defendant before the court and begins a PC-held trial.
+- `convict <target> <crime> <sentence>`: records a guilty verdict and sentence for one charge.
+- `acquit <target> <crime>`: records a not-guilty verdict for one charge.
+
+`trial summon` uses the same court-transfer mechanics and player-facing emotes as the sheriff's automated trial fetch. It clears remand and enforcer-custody state for that jurisdiction, creates a manual `OnTrial`, and moves the defendant to the court if they are being held in a remand cell. Defendants on bail or at large after bail revocation must first return to custody.
+
+While any `OnTrial` exists in the court for a legal authority, sheriff patrols will not fetch a new automatic trial for that authority. NPC judge AI also ignores manual trials, so a PC-held trial will not be taken over by the automated judge. Once the PC judge has finalised all known charges with `convict` or `acquit`, the manual trial state is removed and the defendant is released, sent to prison, or sent to holding for execution according to the recorded sentences.
+
+## Bail and Automatic Trials
+
+Bail follows an arrest-first policy. A defendant on bail is not eligible for automatic court pickup, no-judge automatic sentencing, defendant-initiated `requesttrial`, or PC judge `trial summon`. They must return to remand custody before any trial path can proceed.
+
+When bail is posted, the `OnBail` effect records a return deadline. The deadline uses the legal authority's automatic-conviction timeframe from the current jurisdiction time. The original remand effect remains on the character, but trial systems also require the defendant to be physically held in one of the authority's remand cells.
+
+When the return deadline expires, the bail heartbeat attempts to record a `ViolateBail` crime, revokes the bail effect, and forfeits the recorded bail on the pending crimes. The defendant becomes arrestable again through ordinary enforcement because the underlying crimes are no longer marked as bailed, but the system does not teleport, summon, try, or convict them while they are at large.
+
+The `trial docket` command distinguishes active bail from bail-revoked at-large defendants so PC judges can see why a person is not currently summonable.
+
+## Crime-Driven Patrol Dispatch
+
+Most patrol routes are scheduled from their route readiness, time-of-day, priority, and enforcer-number requirements. Crime-driven patrol strategies use the same route and enforcer configuration, but the patrol controller only dispatches them when a matching reported crime exists. These patrols are not launched as ordinary scheduled patrols.
+
+Crime-driven routes still require:
+
+- a ready patrol route
+- at least one patrol node
+- required enforcer numbers
+- current time of day matching the route
+- the reported crime location to be within the strategy coverage radius of at least one patrol node
+
+The patrol remembers the reported crime as its runtime target. This target is transient patrol state, matching existing active-enforcement state; if a patrol is reloaded without that target, the crime-driven strategy concludes rather than enforcing an unknown target.
+
+### Reactive Patrols
+
+The `ReactivePatrol` strategy dispatches to recent reported violent crimes. It is intended to represent increased police presence after violence in an area. The first patrol destination is the crime location, after which the patrol cycles through nearby configured patrol nodes within the route's coverage radius until its configured duration expires. While deployed, it uses the same enforcement scan as ordinary enforcer patrols and can warn, subdue, arrest, or apply lethal-force enforcement according to the laws involved.
+
+Reactive patrol configuration:
+
+- `radius <rooms>` controls how far from a patrol node a violent crime can be and still dispatch the route.
+- `window <timespan>` controls how recent the reported violent crime must be.
+- `duration <timespan>` controls how long the increased-presence patrol remains active.
+
+Violent-crime classification includes assaults, deadly assaults, battery, murder-family offences, torture, grievous bodily harm, intimidation, resisting arrest, arson, extortion, sexual violence, kidnapping, slavery, animal cruelty, mayhem, and rioting.
+
+### Investigation Patrols
+
+The `InvestigationPatrol` strategy dispatches to reported crimes whose trial evidence is still weak: crimes with an unknown criminal identity or incomplete recorded suspect characteristics. The patrol travels to the crime scene, spends its configured search time there, records investigative evidence, and returns.
+
+Investigation evidence updates existing crime metadata used by trials:
+
+- `CriminalIdentityIsKnown` can be confirmed when the investigator can directly see the suspect at the scene.
+- recorded criminal characteristics are filled in according to the strategy's reliability.
+- prosecution difficulty now reflects identity certainty, witness count, physical/third-party evidence, crime-scene location, and collected characteristic evidence.
+
+Investigation patrol configuration:
+
+- `radius <rooms>` controls how far from a patrol node a reported crime can be and still dispatch the route.
+- `reliability <0.0-1.0>` controls how accurately suspect characteristics are recorded.
+- `search <timespan>` controls how long the patrol searches the scene before recording evidence.
+
 ## Equipment and Method Notes
 
 For coup de grace, the leader looks for a wielded melee weapon with a usable coup-de-grace fixed-bodypart attack. If no suitable weapon is held, the leader tries to retrieve one from the equipment room.

--- a/FutureMUDLibrary/RPG/Law/CrimeExtensions.cs
+++ b/FutureMUDLibrary/RPG/Law/CrimeExtensions.cs
@@ -33,6 +33,7 @@ namespace MudSharp.RPG.Law
             switch (type)
             {
                 case CrimeTypes.Assault:
+                case CrimeTypes.AssaultWithADeadlyWeapon:
                 case CrimeTypes.Battery:
                 case CrimeTypes.AttemptedMurder:
                 case CrimeTypes.Murder:
@@ -41,10 +42,24 @@ namespace MudSharp.RPG.Law
                 case CrimeTypes.GreviousBodilyHarm:
                 case CrimeTypes.Intimidation:
                 case CrimeTypes.ResistArrest:
+                case CrimeTypes.Arson:
+                case CrimeTypes.Extortion:
+                case CrimeTypes.Rape:
+                case CrimeTypes.SexualAssault:
+                case CrimeTypes.Kidnapping:
+                case CrimeTypes.Slavery:
+                case CrimeTypes.AnimalCruelty:
+                case CrimeTypes.Mayhem:
+                case CrimeTypes.Rioting:
                     return true;
                 default:
                     return false;
             }
+        }
+
+        public static bool IsInRemandCell(this ILegalAuthority authority, ICharacter character)
+        {
+            return character.Location is not null && authority.CellLocations.Contains(character.Location);
         }
 
         public static bool IsMoralCrime(this CrimeTypes type)

--- a/FutureMUDLibrary/RPG/Law/ICrime.cs
+++ b/FutureMUDLibrary/RPG/Law/ICrime.cs
@@ -48,6 +48,7 @@ namespace MudSharp.RPG.Law
         TimeSpan CustodialSentenceLength { get; set; }
         IReadOnlyDictionary<ICharacteristicDefinition, ICharacteristicValue> CriminalCharacteristics { get; }
         void SetCharacteristicValue(ICharacteristicDefinition definition, ICharacteristicValue value);
+        void RecordInvestigationEvidence(ICharacter investigator, double reliability, bool identityKnown);
         bool CriminalIdentityIsKnown { get; set; }
         string DescribeCrime(IPerceiver voyeur);
         string DescribeCrimeAtTrial(IPerceiver voyeur);

--- a/FutureMUDLibrary/RPG/Law/ICrimeTargetedPatrolStrategy.cs
+++ b/FutureMUDLibrary/RPG/Law/ICrimeTargetedPatrolStrategy.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace MudSharp.RPG.Law;
+
+public interface ICrimeTargetedPatrolStrategy : IConfigurablePatrolStrategy
+{
+	IEnumerable<ICrime> SelectDispatchCrimes(ILegalAuthority authority);
+	bool ShouldDispatchForCrime(IPatrolRoute patrol, ICrime crime);
+}

--- a/FutureMUDLibrary/RPG/Law/IPatrol.cs
+++ b/FutureMUDLibrary/RPG/Law/IPatrol.cs
@@ -28,9 +28,11 @@ namespace MudSharp.RPG.Law
         ICell OriginLocation { get; }
         ICell LastMajorNode { get; set; }
         ICell NextMajorNode { get; set; }
+        DateTime PatrolStartTime { get; }
         DateTime LastArrivedTime { get; set; }
         ICharacter ActiveEnforcementTarget { get; set; }
         ICrime ActiveEnforcementCrime { get; set; }
+        ICrime TargetCrime { get; set; }
         ICorpseRecoveryReport ActiveCorpseRecoveryReport { get; set; }
 
         void AbortPatrol();

--- a/MudSharpCore Unit Tests/LegalPatrolStrategyTests.cs
+++ b/MudSharpCore Unit Tests/LegalPatrolStrategyTests.cs
@@ -1,0 +1,96 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Character;
+using MudSharp.Form.Characteristics;
+using MudSharp.Framework;
+using MudSharp.RPG.Law;
+using MudSharp.RPG.Law.PatrolStrategies;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class LegalPatrolStrategyTests
+{
+	[TestMethod]
+	public void PatrolStrategyFactory_ShouldExposeCrimeTargetedStrategies()
+	{
+		CollectionAssert.Contains(PatrolStrategyFactory.Strategies.ToList(), "ReactivePatrol");
+		CollectionAssert.Contains(PatrolStrategyFactory.Strategies.ToList(), "InvestigationPatrol");
+
+		Assert.IsTrue(PatrolStrategyFactory.Strategies.Contains("ReactivePatrol"));
+		Assert.IsTrue(PatrolStrategyFactory.Strategies.Contains("InvestigationPatrol"));
+	}
+
+	[TestMethod]
+	public void IsViolentCrime_ShouldIncludeSeriousPersonalViolence()
+	{
+		Assert.IsTrue(CrimeTypes.AssaultWithADeadlyWeapon.IsViolentCrime());
+		Assert.IsTrue(CrimeTypes.Mayhem.IsViolentCrime());
+		Assert.IsTrue(CrimeTypes.Kidnapping.IsViolentCrime());
+		Assert.IsFalse(CrimeTypes.TaxEvasion.IsViolentCrime());
+	}
+
+	[TestMethod]
+	public void ReactiveEligibility_ShouldRequireRecentKnownUnenforcedViolentCrime()
+	{
+		var violent = CreateCrime(CrimeTypes.AssaultWithADeadlyWeapon, DateTime.UtcNow.AddMinutes(-2), known: true);
+		var oldViolent = CreateCrime(CrimeTypes.AssaultWithADeadlyWeapon, DateTime.UtcNow.AddHours(-2), known: true);
+		var nonViolent = CreateCrime(CrimeTypes.TaxEvasion, DateTime.UtcNow.AddMinutes(-2), known: true);
+
+		Assert.IsTrue(ReactivePatrolStrategy.IsEligibleResponseCrime(violent.Object, TimeSpan.FromMinutes(30)));
+		Assert.IsFalse(ReactivePatrolStrategy.IsEligibleResponseCrime(oldViolent.Object, TimeSpan.FromMinutes(30)));
+		Assert.IsFalse(ReactivePatrolStrategy.IsEligibleResponseCrime(nonViolent.Object, TimeSpan.FromMinutes(30)));
+
+		violent.SetupGet(x => x.HasBeenEnforced).Returns(true);
+		Assert.IsFalse(ReactivePatrolStrategy.IsEligibleResponseCrime(violent.Object, TimeSpan.FromMinutes(30)));
+	}
+
+	[TestMethod]
+	public void InvestigationEligibility_ShouldRequireMissingCharacteristicEvidence()
+	{
+		var character = new Mock<ICharacter>();
+		var definition = new Mock<ICharacteristicDefinition>();
+		character.SetupGet(x => x.CharacteristicDefinitions).Returns(new[] { definition.Object });
+
+		var crime = CreateCrime(CrimeTypes.Fraud, DateTime.UtcNow, known: true);
+		crime.SetupGet(x => x.Criminal).Returns(character.Object);
+		crime.SetupGet(x => x.CriminalIdentityIsKnown).Returns(false);
+		crime.SetupGet(x => x.CriminalCharacteristics).Returns(new Dictionary<ICharacteristicDefinition, ICharacteristicValue>());
+
+		Assert.IsTrue(InvestigationPatrolStrategy.NeedsInvestigation(crime.Object));
+
+		crime.SetupGet(x => x.CriminalIdentityIsKnown).Returns(true);
+		Assert.IsTrue(InvestigationPatrolStrategy.NeedsInvestigation(crime.Object));
+
+		var value = new Mock<ICharacteristicValue>();
+		crime.SetupGet(x => x.CriminalCharacteristics)
+		     .Returns(new Dictionary<ICharacteristicDefinition, ICharacteristicValue> { [definition.Object] = value.Object });
+		Assert.IsFalse(InvestigationPatrolStrategy.NeedsInvestigation(crime.Object));
+
+		crime.SetupGet(x => x.CriminalIdentityIsKnown).Returns(false);
+		Assert.IsFalse(InvestigationPatrolStrategy.NeedsInvestigation(crime.Object));
+	}
+
+	private static Mock<ICrime> CreateCrime(CrimeTypes crimeType, DateTime realTime, bool known)
+	{
+		var law = new Mock<ILaw>();
+		law.SetupGet(x => x.CrimeType).Returns(crimeType);
+		law.SetupGet(x => x.EnforcementStrategy).Returns(EnforcementStrategy.ArrestAndDetain);
+		law.SetupGet(x => x.EnforcementPriority).Returns(10);
+
+		var cell = new Mock<MudSharp.Construction.ICell>();
+		var crime = new Mock<ICrime>();
+		crime.SetupGet(x => x.IsKnownCrime).Returns(known);
+		crime.SetupGet(x => x.HasBeenFinalised).Returns(false);
+		crime.SetupGet(x => x.HasBeenEnforced).Returns(false);
+		crime.SetupGet(x => x.CrimeLocation).Returns(cell.Object);
+		crime.SetupGet(x => x.RealTimeOfCrime).Returns(realTime);
+		crime.SetupGet(x => x.Law).Returns(law.Object);
+		return crime;
+	}
+}

--- a/MudSharpCore Unit Tests/LegalTrialFlowTests.cs
+++ b/MudSharpCore Unit Tests/LegalTrialFlowTests.cs
@@ -1,0 +1,156 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Effects;
+using MudSharp.Effects.Concrete;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using MudSharp.RPG.Law;
+using MudSharp.TimeAndDate;
+using System;
+using System.Collections.Generic;
+using System.Xml.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class LegalTrialFlowTests
+{
+	[TestMethod]
+	public void OnTrial_LoadEffect_ShouldPreserveSavedPhase()
+	{
+		Mock<ILegalAuthority> authority = new();
+		authority.SetupGet(x => x.Id).Returns(1L);
+		authority.SetupGet(x => x.Name).Returns("Test Authority");
+
+		Mock<ICrime> crime = new();
+		crime.SetupGet(x => x.Id).Returns(10L);
+
+		All<ILegalAuthority> legalAuthorities = new();
+		legalAuthorities.Add(authority.Object);
+
+		All<ICrime> crimes = new();
+		crimes.Add(crime.Object);
+
+		Mock<IFuturemud> gameworld = new();
+		gameworld.SetupGet(x => x.LegalAuthorities).Returns(legalAuthorities);
+		gameworld.SetupGet(x => x.Crimes).Returns(crimes);
+		gameworld.SetupGet(x => x.FutureProgs).Returns(new All<IFutureProg>());
+
+		Mock<ICharacter> owner = new();
+		owner.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+
+		OnTrial.InitialiseEffectType();
+		OnTrial trial = new(owner.Object, authority.Object, DateTime.UtcNow, [crime.Object])
+		{
+			Phase = TrialPhase.Verdict,
+			ManualTrial = true
+		};
+
+		OnTrial loaded = (OnTrial)Effect.LoadEffect(trial.SaveToXml(new Dictionary<IEffect, TimeSpan>()), owner.Object);
+
+		Assert.AreEqual(TrialPhase.Verdict, loaded.Phase);
+		Assert.IsTrue(loaded.ManualTrial);
+	}
+
+	[TestMethod]
+	public void OnTrial_Applies_ShouldFilterByLegalAuthority()
+	{
+		Mock<ILegalAuthority> authority = new();
+		authority.SetupGet(x => x.Id).Returns(1L);
+		authority.SetupGet(x => x.Name).Returns("Test Authority");
+
+		Mock<ILegalAuthority> otherAuthority = new();
+		otherAuthority.SetupGet(x => x.Id).Returns(2L);
+		otherAuthority.SetupGet(x => x.Name).Returns("Other Authority");
+
+		Mock<ICrime> crime = new();
+		crime.SetupGet(x => x.Id).Returns(10L);
+
+		Mock<ICharacter> owner = new();
+
+		OnTrial trial = new(owner.Object, authority.Object, DateTime.UtcNow, [crime.Object]);
+
+		Assert.IsTrue(trial.Applies(authority.Object));
+		Assert.IsFalse(trial.Applies(otherAuthority.Object));
+	}
+
+	[TestMethod]
+	public void OnBail_LoadEffect_ShouldPreserveReturnDueDate()
+	{
+		Mock<ILegalAuthority> authority = new();
+		authority.SetupGet(x => x.Id).Returns(1L);
+		authority.SetupGet(x => x.Name).Returns("Test Authority");
+
+		All<ILegalAuthority> legalAuthorities = new();
+		legalAuthorities.Add(authority.Object);
+
+		Mock<IFuturemud> gameworld = new();
+		gameworld.SetupGet(x => x.LegalAuthorities).Returns(legalAuthorities);
+		gameworld.SetupGet(x => x.FutureProgs).Returns(new All<IFutureProg>());
+
+		Mock<ICharacter> owner = new();
+		owner.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+
+		OnBail.InitialiseEffectType();
+		OnBail bail = new(owner.Object, authority.Object, MudDateTime.Never);
+
+		OnBail loaded = (OnBail)Effect.LoadEffect(bail.SaveToXml(new Dictionary<IEffect, TimeSpan>()), owner.Object);
+
+		Assert.AreEqual(MudDateTime.Never.GetDateTimeString(), loaded.ReturnDueDate.GetDateTimeString());
+	}
+
+	[TestMethod]
+	public void OnBail_LoadEffect_ShouldReadLegacyArrestTimeAsReturnDueDate()
+	{
+		Mock<ILegalAuthority> authority = new();
+		authority.SetupGet(x => x.Id).Returns(1L);
+		authority.SetupGet(x => x.Name).Returns("Test Authority");
+
+		All<ILegalAuthority> legalAuthorities = new();
+		legalAuthorities.Add(authority.Object);
+
+		Mock<IFuturemud> gameworld = new();
+		gameworld.SetupGet(x => x.LegalAuthorities).Returns(legalAuthorities);
+		gameworld.SetupGet(x => x.FutureProgs).Returns(new All<IFutureProg>());
+
+		Mock<ICharacter> owner = new();
+		owner.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+
+		OnBail.InitialiseEffectType();
+		XElement legacy = new(
+			"Effect",
+			new XElement("ApplicabilityProg", 0),
+			new XElement("Type", "OnBail"),
+			new XElement("Original", 0),
+			new XElement("Remaining", 0),
+			new XElement("Effect",
+				new XElement("LegalAuthority", 1L),
+				new XElement("ArrestTime", new XCData(MudDateTime.Never.GetDateTimeString()))
+			)
+		);
+
+		OnBail loaded = (OnBail)Effect.LoadEffect(legacy, owner.Object);
+
+		Assert.AreEqual(MudDateTime.Never.GetDateTimeString(), loaded.ReturnDueDate.GetDateTimeString());
+	}
+
+	[TestMethod]
+	public void IsInRemandCell_ShouldRequirePhysicalCellPresence()
+	{
+		Mock<ICharacter> character = new();
+		Mock<ICharacter> otherCharacter = new();
+
+		Mock<ICell> cell = new();
+		character.SetupGet(x => x.Location).Returns(cell.Object);
+
+		Mock<ILegalAuthority> authority = new();
+		authority.SetupGet(x => x.CellLocations).Returns([cell.Object]);
+
+		Assert.IsTrue(authority.Object.IsInRemandCell(character.Object));
+		Assert.IsFalse(authority.Object.IsInRemandCell(otherCharacter.Object));
+	}
+}

--- a/MudSharpCore/Commands/Modules/CrimeModule.cs
+++ b/MudSharpCore/Commands/Modules/CrimeModule.cs
@@ -821,7 +821,7 @@ The syntax for this command is simply #3argue defense#0 or #3argue prosecution#0
         }
         else
         {
-            if (trialEffect.Defender != actor)
+            if (trialEffect.Prosecutor != actor)
             {
                 actor.OutputHandler.Send("You are not the prosecution lawyer for this case.");
                 return;
@@ -830,16 +830,98 @@ The syntax for this command is simply #3argue defense#0 or #3argue prosecution#0
         trialEffect.HandleArgueCommand(actor, defense);
     }
 
+    private static bool CanManuallyJudge(ICharacter actor, ICharacter target, ILegalAuthority jurisdiction, out string error)
+    {
+        error = string.Empty;
+        ILegalClass targetClass = jurisdiction.GetLegalClass(target);
+        IEnforcementAuthority enforcement = jurisdiction.GetEnforcementAuthority(actor);
+        if (enforcement is null)
+        {
+            if (actor.IsAdministrator())
+            {
+                return true;
+            }
+
+            error = $"You are not an enforcer in the {jurisdiction.Name.ColourName()} jurisdiction.";
+            return false;
+        }
+
+        if (!enforcement.CanConvict)
+        {
+            error = $"Your level of enforcement authority in the {jurisdiction.Name.ColourName()} jurisdiction is insufficient to judge people.";
+            return false;
+        }
+
+        if (!enforcement.AccusableClasses.Contains(targetClass))
+        {
+            error = $"Your level of enforcement authority does not allow you to judge members of the {targetClass.Name.ColourName()} legal class.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool CanRecordManualJudgement(ICharacter actor, ICharacter target, ILegalAuthority jurisdiction)
+    {
+        OnTrial trial = target.EffectsOfType<OnTrial>(x => x.LegalAuthority == jurisdiction).FirstOrDefault();
+        if (trial is not null)
+        {
+            if (trial.ManualTrial)
+            {
+                return true;
+            }
+
+            actor.OutputHandler.Send("Your target is already on trial before an NPC judge, and cannot have manual judgements recorded at this time.");
+            return false;
+        }
+
+        if (target.AffectedBy<OnTrial>())
+        {
+            actor.OutputHandler.Send("Your target is already on trial in another jurisdiction, and cannot have manual judgements recorded at this time.");
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void ResolveManualJudgementIfComplete(ICharacter target, ILegalAuthority jurisdiction)
+    {
+        if (jurisdiction.KnownCrimesForIndividual(target).Any())
+        {
+            return;
+        }
+
+        target.RemoveAllEffects<AwaitingSentencing>(x => x.LegalAuthority == jurisdiction, true);
+        target.RemoveAllEffects<OnTrial>(x => x.LegalAuthority == jurisdiction, true);
+        target.RemoveAllEffects<InCustodyOfEnforcer>(x => x.LegalAuthority == jurisdiction, true);
+
+        if (target.EffectsOfType<AwaitingExecution>(x => x.LegalAuthority == jurisdiction).Any())
+        {
+            jurisdiction.SendCharacterToHoldingCell(target);
+            return;
+        }
+
+        if (target.EffectsOfType<ServingCustodialSentence>(x => x.LegalAuthority == jurisdiction).Any())
+        {
+            jurisdiction.SendCharacterToPrison(target);
+            return;
+        }
+
+        jurisdiction.ReleaseCharacterToFreedom(target);
+    }
+
     [PlayerCommand("Convict", "convict")]
     [RequiredCharacterState(CharacterState.Able)]
     [MustBeAnEnforcer]
     [HelpInfo("convict", @"The #3convict#0 command is used to manually record a conviction of guilty and assign a punishment to a criminal who is being held in custody. This would be intended to be used by PC or NPC Enforcers when a trial is being roleplayed, in lieu of using the automated systems for these things.
 
-Typically this command would be used on a prisoner who another enforcer has used the #3takecustody#0 command over. Otherwise, NPC enforcers might drag them back to prison and any convictions for multiple crimes would be applied immediately rather than at a time of your choosing.
+Typically this command would be used on a prisoner who another enforcer has used the #3takecustody#0 command over, or on a defendant in a PC-held trial started with #3trial summon#0. Otherwise, NPC enforcers might drag them back to prison and any convictions for multiple crimes would be applied immediately rather than at a time of your choosing.
 
 Both you and the criminal need to be in the court room of the legal jurisdiction you're convicting them for.
 
 Note also the #3acquit#0 command which is used to register a finding of not guilty.
+
+When the last known charge is finalised in a PC-held trial, the defendant will be released, sent to prison, or sent to holding for execution according to the recorded sentences.
 
 There are the following syntaxes for this command:
 
@@ -879,26 +961,14 @@ You can use the following options for punishments, can can include multiples in 
             return;
         }
 
-        ILegalClass targetClass = jurisdiction.GetLegalClass(target);
-        IEnforcementAuthority enforcement = jurisdiction.GetEnforcementAuthority(actor);
-        if (enforcement is not null)
+        if (!CanManuallyJudge(actor, target, jurisdiction, out string judgementError))
         {
-            if (!enforcement.CanConvict)
-            {
-                actor.OutputHandler.Send($"Your level of enforcement authority in the {jurisdiction.Name.ColourName()} jurisdiction is insufficient to judge people.");
-                return;
-            }
-
-            if (!enforcement.AccusableClasses.Contains(targetClass))
-            {
-                actor.OutputHandler.Send($"Your level of enforcement authority does not allow you to judge members of the {targetClass.Name.ColourName()} legal class.");
-                return;
-            }
+            actor.OutputHandler.Send(judgementError);
+            return;
         }
 
-        if (target.AffectedBy<OnTrial>())
+        if (!CanRecordManualJudgement(actor, target, jurisdiction))
         {
-            actor.OutputHandler.Send("Your target is already on trial, and cannot have manual judgements recorded at this time.");
             return;
         }
 
@@ -1072,6 +1142,7 @@ You can use the following options for punishments, can can include multiples in 
             new DummyPerceivable(x => punishment.Describe(x, jurisdiction), customColour: Telnet.White)
             )));
         targetCrime.Convict(actor, punishment, "Manually convicted");
+        ResolveManualJudgementIfComplete(target, jurisdiction);
     }
 
     [PlayerCommand("CrimeInfo", "crimeinfo")]
@@ -1113,11 +1184,13 @@ The syntax is #3crimeinfo <id>#0.", AutoHelp.HelpArg)]
     [MustBeAnEnforcer]
     [HelpInfo("acquit", @"The #3acquit#0 command is used to manually record a conviction of not guilty to a criminal who is being held in custody. This would be intended to be used by PC or NPC Enforcers when a trial is being roleplayed, in lieu of using the automated systems for these things.
 
-Typically this command would be used on a prisoner who another enforcer has used the #3takecustody#0 command over. Otherwise, NPC enforcers might drag them back to prison before you're done and any convictions for multiple crimes would be applied immediately rather than at a time of your choosing.
+Typically this command would be used on a prisoner who another enforcer has used the #3takecustody#0 command over, or on a defendant in a PC-held trial started with #3trial summon#0. Otherwise, NPC enforcers might drag them back to prison before you're done and any convictions for multiple crimes would be applied immediately rather than at a time of your choosing.
 
 Both you and the criminal need to be in the court room of the legal jurisdiction you're acquiting them of.
 
 Note also the #3convict#0 command which is used to register a finding of guilty.
+
+When the last known charge is finalised in a PC-held trial, the defendant will be released, sent to prison, or sent to holding for execution according to the recorded sentences.
 
 There are the following syntaxes for this command:
 
@@ -1148,26 +1221,14 @@ There are the following syntaxes for this command:
             return;
         }
 
-        ILegalClass targetClass = jurisdiction.GetLegalClass(target);
-        IEnforcementAuthority enforcement = jurisdiction.GetEnforcementAuthority(actor);
-        if (enforcement is not null)
+        if (!CanManuallyJudge(actor, target, jurisdiction, out string judgementError))
         {
-            if (!enforcement.CanConvict)
-            {
-                actor.OutputHandler.Send($"Your level of enforcement authority in the {jurisdiction.Name.ColourName()} jurisdiction is insufficient to judge people.");
-                return;
-            }
-
-            if (!enforcement.AccusableClasses.Contains(targetClass))
-            {
-                actor.OutputHandler.Send($"Your level of enforcement authority does not allow you to judge members of the {targetClass.Name.ColourName()} legal class.");
-                return;
-            }
+            actor.OutputHandler.Send(judgementError);
+            return;
         }
 
-        if (target.AffectedBy<OnTrial>())
+        if (!CanRecordManualJudgement(actor, target, jurisdiction))
         {
-            actor.OutputHandler.Send("Your target is already on trial, and cannot have manual judgements recorded at this time.");
             return;
         }
 
@@ -1228,6 +1289,7 @@ There are the following syntaxes for this command:
             new DummyPerceivable(x => targetCrime.DescribeCrimeAtTrial(x), customColour: Telnet.White)
         )));
         targetCrime.Acquit(actor, "Manually acquitted");
+        ResolveManualJudgementIfComplete(target, jurisdiction);
     }
 
     [PlayerCommand("TakeCustody", "takecustody")]
@@ -1321,8 +1383,85 @@ There are the following syntaxes for this command:
     [PlayerCommand("TransferCustody", "transfercustody")]
     [RequiredCharacterState(CharacterState.Able)]
     [MustBeAnEnforcer]
+    [HelpInfo("transfercustody", @"The #3transfercustody#0 command is used by an enforcer who currently has custody of someone to transfer that custody to another present enforcer.
+
+The syntax is #3transfercustody <prisoner> <enforcer>#0.", AutoHelp.HelpArg)]
     protected static void TransferCustody(ICharacter actor, string input)
     {
+        StringStack ss = new(input.RemoveFirstWord());
+        if (ss.IsFinished)
+        {
+            actor.OutputHandler.Send("Whose custody do you want to transfer?");
+            return;
+        }
+
+        ICharacter target = actor.TargetActor(ss.PopSpeech());
+        if (target == null)
+        {
+            actor.OutputHandler.Send("You don't see anyone like that here.");
+            return;
+        }
+
+        if (ss.IsFinished)
+        {
+            actor.OutputHandler.Send("Who do you want to transfer custody to?");
+            return;
+        }
+
+        ICharacter newEnforcer = actor.TargetActor(ss.PopSpeech());
+        if (newEnforcer == null)
+        {
+            actor.OutputHandler.Send("You don't see any enforcer like that here.");
+            return;
+        }
+
+        if (target == actor)
+        {
+            actor.OutputHandler.Send("You cannot transfer custody of yourself.");
+            return;
+        }
+
+        if (newEnforcer == actor)
+        {
+            actor.OutputHandler.Send($"{target.HowSeen(actor, true)} is already in your custody.");
+            return;
+        }
+
+        if (newEnforcer == target)
+        {
+            actor.OutputHandler.Send("You cannot transfer custody to the person in custody.");
+            return;
+        }
+
+        List<InCustodyOfEnforcer> effects = target.CombinedEffectsOfType<InCustodyOfEnforcer>()
+                                                 .Where(x => x.Enforcer == actor || actor.IsAdministrator())
+                                                 .ToList();
+        if (!effects.Any())
+        {
+            actor.OutputHandler.Send($"{target.HowSeen(actor, true)} is not in your custody.");
+            return;
+        }
+
+        List<InCustodyOfEnforcer> transferable = effects
+                                                .Where(x => x.LegalAuthority.GetEnforcementAuthority(newEnforcer) is not null ||
+                                                            newEnforcer.IsAdministrator())
+                                                .ToList();
+        if (!transferable.Any())
+        {
+            actor.OutputHandler.Send(
+                $"{newEnforcer.HowSeen(actor, true)} is not an enforcer for any jurisdiction in which you have custody of {target.HowSeen(actor)}.");
+            return;
+        }
+
+        foreach (InCustodyOfEnforcer effect in transferable)
+        {
+            effect.Enforcer = newEnforcer;
+        }
+
+        actor.OutputHandler.Handle(new QuickEmote("@ transfer|transfers custody of $1 to $2.", actor, actor, target, newEnforcer));
+        target.OutputHandler.Send(
+            $"You are now in the custody of {newEnforcer.HowSeen(target)}. You could be guilty of a crime if you move away."
+                .ColourCommand());
     }
 
     [PlayerCommand("EndCustody", "endcustody")]
@@ -1483,9 +1622,17 @@ The syntax is either #3patrols#0 or #3patrols <jurisdiction>#0 if you are an enf
                 timespan.Humanize(2, perceiver.Account.Culture, TimeUnit.Year, TimeUnit.Second)))));
     }
 
+    private static MudDateTime BailReturnDueDate(ICharacter actor, ILegalAuthority authority)
+    {
+        MudDateTime now = authority.EnforcementZones.FirstOrDefault()?.DateTime() ?? actor.Location.DateTime();
+        return now + MudTimeSpan.FromSeconds(authority.AutomaticConvictionTime.TotalSeconds);
+    }
+
     [PlayerCommand("RequestTrial", "requesttrial")]
     [RequiredCharacterState(CharacterState.Able)]
     [HelpInfo("requesttrial", @"The #3requesttrial#0 command is used when you are being held in remand for crimes you have committed, and if possible, begins a trial for you so that you can answer for your crimes. In some cases a trial may commence after you've been waiting for a while regardless of whether you request one.
+
+You must be physically held in a remand cell and not out on bail to request a trial.
 
 The syntax for this command is simply #3requesttrial#0.", AutoHelp.HelpArg)]
     protected static void RequestTrial(ICharacter actor, string input)
@@ -1514,6 +1661,12 @@ The syntax for this command is simply #3requesttrial#0.", AutoHelp.HelpArg)]
         foreach (AwaitingSentencing effect in sentences)
         {
             ILegalAuthority jurisdiction = effect.LegalAuthority;
+            if (!jurisdiction.IsInRemandCell(actor))
+            {
+                errors.Add($"you are not being held in a {jurisdiction.Name.ColourName()} remand cell");
+                continue;
+            }
+
             if (jurisdiction.CourtLocation is null)
             {
                 errors.Add($"the {jurisdiction.Name.ColourName()} jurisdiction does not have a courtroom");
@@ -1532,7 +1685,7 @@ The syntax for this command is simply #3requesttrial#0.", AutoHelp.HelpArg)]
                 continue;
             }
 
-            if (jurisdiction.Patrols.Where(x => x.PatrolStrategy.Name != "Judge").All(x => x.PatrolLeader.Location != jurisdiction.CourtLocation))
+            if (jurisdiction.Patrols.Where(x => x.PatrolStrategy.Name == "Judge").All(x => x.PatrolLeader.Location != jurisdiction.CourtLocation))
             {
                 errors.Add($"the {jurisdiction.Name.ColourName()} jurisdiction does not have a judge available");
                 continue;
@@ -1563,7 +1716,7 @@ The syntax for this command is simply #3requesttrial#0.", AutoHelp.HelpArg)]
 
     [PlayerCommand("BailOut", "bailout")]
     [RequiredCharacterState(CharacterState.Able)]
-    [HelpInfo("bailout", @"The #3bailout#0 command is used to either request bail for yourself when incarcerated or pay for the bail of someone else.
+    [HelpInfo("bailout", @"The #3bailout#0 command is used to either request bail for yourself when incarcerated or pay for the bail of someone else. A person on bail must return before their bail deadline or their bail is forfeited and they can be charged with violating bail.
 
 You must either be in custody yourself or at the prison location of the jurisdiction to use this command.
 
@@ -1679,10 +1832,9 @@ The syntax is as follows:
 
                     bailText = "with cash from your stored belongings";
                 }
-
-                authority.CalculateAndSetBail(actor);
             }
 
+            authority.CalculateAndSetBail(actor);
             actor.OutputHandler.Handle(new EmoteOutput(
                 new Emote(actor.Gameworld.GetStaticString("BailReleaseSelfInitiatedEmoteOrigin"), actor, actor),
                 flags: OutputFlags.SuppressSource));
@@ -1693,7 +1845,7 @@ The syntax is as follows:
             actor.OutputHandler.Handle(new EmoteOutput(
                 new Emote(actor.Gameworld.GetStaticString("BailReleaseSelfInitiatedEmoteDestination"), actor, actor),
                 flags: OutputFlags.SuppressSource));
-            actor.AddEffect(new OnBail(actor, authority, effect.ArrestTime));
+            actor.AddEffect(new OnBail(actor, authority, BailReturnDueDate(actor, authority)));
             return;
         }
 
@@ -1746,11 +1898,25 @@ The syntax is as follows:
             return;
         }
 
-        decimal calculatedBail = Math.Truncate(jurisdiction.KnownCrimesForIndividual(who)
+        List<ICrime> bailableCrimes = jurisdiction.KnownCrimesForIndividual(who).ToList();
+        if (bailableCrimes.Any(x => !x.Law.CanBeOfferedBail))
+        {
+            actor.OutputHandler.Send(
+                $"Some of the crimes {who.HowSeen(actor, flags: PerceiveIgnoreFlags.IgnoreCanSee)} is accused of do not permit bail.");
+            return;
+        }
+
+        decimal calculatedBail = Math.Truncate(bailableCrimes
                                  .Sum(x => jurisdiction.BailCalculationProg?.Execute<decimal?>(who, x) ?? 0.0M));
+        if (calculatedBail <= 0.0M)
+        {
+            actor.OutputHandler.Send(
+                $"{who.HowSeen(actor, true, flags: PerceiveIgnoreFlags.IgnoreCanSee)} is not currently eligible for bail.");
+            return;
+        }
 
         string bailActionText;
-        if (ss.IsFinished)
+        if (!ss.IsFinished)
         {
             (IBankAccount account, string error) = Bank.FindBankAccount(ss.SafeRemainingArgument, null, actor);
             if (account is null)
@@ -1804,9 +1970,6 @@ The syntax is as follows:
             bailActionText = "with cash";
         }
 
-        MudDateTime arrestTime =
-            who.EffectsOfType<AwaitingSentencing>(x => x.LegalAuthority == jurisdiction).FirstOrDefault()?.ArrestTime ??
-            jurisdiction.EnforcementZones.First().DateTime();
         who.OutputHandler.Handle(new EmoteOutput(
             new Emote(actor.Gameworld.GetStaticString("BailReleaseExternalPartyEmoteOrigin"), who, who),
             flags: OutputFlags.SuppressSource));
@@ -1815,16 +1978,17 @@ The syntax is as follows:
         actor.OutputHandler.Send(new EmoteOutput(new Emote(
             string.Format(actor.Gameworld.GetStaticString("BailReleaseExternalPartyEmoteBailer"), bailActionText),
             actor, actor, who)));
+        jurisdiction.CalculateAndSetBail(who);
         jurisdiction.ReleaseCharacterToFreedom(who);
         who.OutputHandler.Handle(new EmoteOutput(
             new Emote(actor.Gameworld.GetStaticString("BailReleaseExternalPartyEmoteDestination"), who, who),
             flags: OutputFlags.SuppressSource));
-        actor.AddEffect(new OnBail(who, jurisdiction, arrestTime));
+        who.AddEffect(new OnBail(who, jurisdiction, BailReturnDueDate(who, jurisdiction)));
     }
 
     [PlayerCommand("ReturnBail", "returnbail")]
     [RequiredCharacterState(CharacterState.Able)]
-    [HelpInfo("returnbail", @"The #3returnbail#0 command is used to surrender yourself back to the custody of law enforcement when you are out on bail. You must do this before your bail term expires to avoid a criminal charge of skipping bail.
+    [HelpInfo("returnbail", @"The #3returnbail#0 command is used to surrender yourself back to the custody of law enforcement when you are out on bail. You must do this before your bail deadline expires to avoid forfeiting bail and potentially being charged with violating bail.
 
 You must use this command from the jurisdiction's prison location.
 
@@ -2184,13 +2348,275 @@ The syntax is as follows:
         }
     }
 
+    private static List<ILegalAuthority> JudgementAuthorities(ICharacter actor)
+    {
+        return actor.Gameworld.LegalAuthorities
+                    .Where(x => actor.IsAdministrator() || x.GetEnforcementAuthority(actor)?.CanConvict == true)
+                    .ToList();
+    }
+
+    private static string DescribeTrialDocketStatus(ICharacter defendant, ILegalAuthority authority)
+    {
+        OnTrial trial = defendant.EffectsOfType<OnTrial>(x => x.LegalAuthority == authority).FirstOrDefault();
+        if (trial is not null)
+        {
+            return trial.ManualTrial ? "PC Trial".ColourName() : "NPC Trial".ColourName();
+        }
+
+        if (defendant.AffectedBy<OnBail>(authority))
+        {
+            return "On Bail".ColourValue();
+        }
+
+        if (defendant.AffectedBy<AwaitingSentencing>(authority))
+        {
+            return authority.IsInRemandCell(defendant)
+                ? "Remand".Colour(Telnet.Yellow)
+                : "At Large / Bail Revoked".Colour(Telnet.Orange);
+        }
+
+        return "Pending".Colour(Telnet.Orange);
+    }
+
+    private static string DescribeTrialDocketSince(ICharacter defendant, ILegalAuthority authority)
+    {
+        OnBail bail = defendant.EffectsOfType<OnBail>(x => x.LegalAuthority == authority).FirstOrDefault();
+        if (bail is not null)
+        {
+            return bail.ReturnDueDate.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short);
+        }
+
+        AwaitingSentencing awaiting = defendant.EffectsOfType<AwaitingSentencing>(x => x.LegalAuthority == authority).FirstOrDefault();
+        if (awaiting is not null)
+        {
+            return awaiting.ArrestTime.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short);
+        }
+
+        return string.Empty;
+    }
+
+    private static void TrialDocket(ICharacter actor, StringStack ss)
+    {
+        List<ILegalAuthority> authorities = JudgementAuthorities(actor);
+        if (!authorities.Any())
+        {
+            actor.OutputHandler.Send("You are not authorised to judge criminal trials in any jurisdiction.");
+            return;
+        }
+
+        if (!ss.IsFinished)
+        {
+            ILegalAuthority authority = authorities.GetByIdOrName(ss.SafeRemainingArgument);
+            if (authority is null)
+            {
+                actor.OutputHandler.Send($"You are not authorised to judge criminal trials in any jurisdiction called {ss.SafeRemainingArgument.ColourCommand()}.");
+                return;
+            }
+
+            authorities = [authority];
+        }
+
+        StringBuilder sb = new();
+        foreach (ILegalAuthority authority in authorities.OrderBy(x => x.Name))
+        {
+            List<ICharacter> defendants = authority.KnownCrimes
+                                                  .Select(x => x.Criminal)
+                                                  .Distinct()
+                                                  .Where(x =>
+                                                      x.AffectedBy<AwaitingSentencing>(authority) ||
+                                                      x.AffectedBy<OnBail>(authority) ||
+                                                      x.AffectedBy<OnTrial>(authority)
+                                                  )
+                                                  .OrderBy(x => x.PersonalName.GetName(NameStyle.FullName))
+                                                  .ToList();
+
+            sb.AppendLine($"Trial Docket - {authority.Name.ColourName()}".GetLineWithTitleInner(actor, Telnet.Red, Telnet.BoldWhite));
+            sb.AppendLine();
+
+            if (!defendants.Any())
+            {
+                sb.AppendLine("There is nobody currently awaiting trial in this jurisdiction.");
+                sb.AppendLine();
+                continue;
+            }
+
+            sb.AppendLine(StringUtilities.GetTextTable(
+                from defendant in defendants
+                let crimes = authority.KnownCrimesForIndividual(defendant).OrderBy(x => x.RealTimeOfCrime).ToList()
+                let priors = authority.ResolvedCrimesForIndividual(defendant).Count(x => x.HasBeenConvicted)
+                select new List<string>
+                {
+                    defendant.HowSeen(actor, flags: PerceiveIgnoreFlags.IgnoreCanSee),
+                    defendant.PersonalName.GetName(NameStyle.FullName),
+                    DescribeTrialDocketStatus(defendant, authority),
+                    DescribeTrialDocketSince(defendant, authority),
+                    crimes.Select(x => x.Id.ToStringN0(actor)).ListToString(),
+                    crimes.Select(x => x.Name).Distinct().ListToString(),
+                    priors.ToStringN0(actor)
+                },
+                new List<string>
+                {
+                    "Description",
+                    "Name",
+                    "Status",
+                    "Since/Due",
+                    "Crime IDs",
+                    "Charges",
+                    "Priors"
+                },
+                actor,
+                Telnet.Red
+            ));
+            sb.AppendLine();
+            sb.AppendLine("Use #3crimeinfo <id>#0 for charge details, #3rapsheet <visible target>#0 for full local history, and #3trial summon <target>#0 from the courtroom to begin a PC-held trial.".SubstituteANSIColour());
+            sb.AppendLine();
+        }
+
+        actor.OutputHandler.Send(sb.ToString());
+    }
+
+    private static void TrialSummon(ICharacter actor, StringStack ss)
+    {
+        if (ss.IsFinished)
+        {
+            actor.OutputHandler.Send("Who do you want summoned to court for trial?");
+            return;
+        }
+
+        ILegalAuthority jurisdiction = JudgementAuthorities(actor).FirstOrDefault(x => x.CourtLocation == actor.Location);
+        if (jurisdiction is null)
+        {
+            actor.OutputHandler.Send("You must be in the courtroom of a jurisdiction where you are authorised to judge trials.");
+            return;
+        }
+
+        if (jurisdiction.CourtLocation is null)
+        {
+            actor.OutputHandler.Send($"The {jurisdiction.Name.ColourName()} jurisdiction does not have a courtroom.");
+            return;
+        }
+
+        string targetText = ss.PopSpeech();
+        ICharacter target = actor.TargetActor(targetText);
+        List<ICharacter> remandPrisoners = jurisdiction.CellLocations
+                                                       .SelectMany(x => x.Characters)
+                                                       .Where(x => x.AffectedBy<AwaitingSentencing>(jurisdiction))
+                                                       .ToList();
+        target ??= remandPrisoners.GetFromItemListByKeywordIncludingNames(targetText, actor);
+        if (target is null)
+        {
+            actor.OutputHandler.Send($"There is no remand prisoner or present defendant like {targetText.ColourCommand()} in the {jurisdiction.Name.ColourName()} jurisdiction.");
+            return;
+        }
+
+        if (target == actor)
+        {
+            actor.OutputHandler.Send("You cannot summon yourself to trial.");
+            return;
+        }
+
+        if (target.IdentityIsObscuredTo(actor))
+        {
+            actor.OutputHandler.Send($"You aren't sure who {target.HowSeen(actor)} is, so you can't summon them to trial.");
+            return;
+        }
+
+        if (!CanManuallyJudge(actor, target, jurisdiction, out string judgementError))
+        {
+            actor.OutputHandler.Send(judgementError);
+            return;
+        }
+
+        List<ICrime> crimes = jurisdiction.KnownCrimesForIndividual(target)
+                                          .OrderBy(x => x.RealTimeOfCrime)
+                                          .ToList();
+        if (!crimes.Any())
+        {
+            actor.OutputHandler.Send($"{target.HowSeen(actor, true, flags: PerceiveIgnoreFlags.IgnoreCanSee)} has no known unfinalised crimes in the {jurisdiction.Name.ColourName()} jurisdiction.");
+            return;
+        }
+
+        if (target.AffectedBy<OnBail>(jurisdiction))
+        {
+            actor.OutputHandler.Send($"{target.HowSeen(actor, true, flags: PerceiveIgnoreFlags.IgnoreCanSee)} is currently on bail and must return to custody before they can be summoned to trial.");
+            return;
+        }
+
+        if (!target.ColocatedWith(actor) && !remandPrisoners.Contains(target))
+        {
+            actor.OutputHandler.Send($"{target.HowSeen(actor, true, flags: PerceiveIgnoreFlags.IgnoreCanSee)} is not present in court or held on remand in this jurisdiction.");
+            return;
+        }
+
+        if (target.AffectedBy<OnTrial>())
+        {
+            actor.OutputHandler.Send($"{target.HowSeen(actor, true, flags: PerceiveIgnoreFlags.IgnoreCanSee)} is already on trial.");
+            return;
+        }
+
+        if (jurisdiction.CourtLocation.Characters.Any(x => x.EffectsOfType<OnTrial>(y => y.LegalAuthority == jurisdiction).Any()))
+        {
+            actor.OutputHandler.Send($"The {jurisdiction.Name.ColourName()} court is already hearing a trial.");
+            return;
+        }
+
+        target.RemoveAllEffects<AwaitingSentencing>(x => x.LegalAuthority == jurisdiction, true);
+        target.RemoveAllEffects<InCustodyOfEnforcer>(x => x.LegalAuthority == jurisdiction, true);
+        target.AddEffect(new OnTrial(target, jurisdiction, DateTime.UtcNow, crimes, manualTrial: true));
+
+        if (target.Location == jurisdiction.CourtLocation)
+        {
+            actor.OutputHandler.Handle(new QuickEmote("@ call|calls $1 before the court to answer the charges.", actor, actor, target));
+            return;
+        }
+
+        target.OutputHandler.Handle(new EmoteOutput(
+            new Emote(actor.Gameworld.GetStaticString("FetchCriminalForTrialEmoteCell"), target, target),
+            flags: OutputFlags.SuppressSource));
+        target.OutputHandler.Send(new EmoteOutput(
+            new Emote(actor.Gameworld.GetStaticString("FetchCriminalForTrialEmoteSelf"), target, target)));
+        target.Movement?.CancelForMoverOnly(target);
+        target.RemoveAllEffects(x => x.IsEffectType<IActionEffect>());
+        target.Location.Leave(target);
+        target.RoomLayer = RoomLayer.GroundLevel;
+        jurisdiction.CourtLocation.Enter(target);
+        target.Body.Look(true);
+        target.OutputHandler.Handle(new EmoteOutput(
+            new Emote(actor.Gameworld.GetStaticString("FetchCriminalForTrialEmoteCourt"), target, target),
+            flags: OutputFlags.SuppressSource));
+    }
+
     [PlayerCommand("Trial", "trial")]
     [RequiredCharacterState(CharacterState.Able)]
-    [HelpInfo("trial", @"The #3trial#0 command will show you details about any trial currently taking place in your location.
+    [HelpInfo("trial", @"The #3trial#0 command will show you details about any trial currently taking place in your location. Judges can also view the trial docket for their jurisdictions and summon remand prisoners to court for PC-held trials.
 
-The syntax is simply #3trial#0.", AutoHelp.HelpArg)]
+The syntax is as follows:
+
+	#3trial#0 - view the active trial in your current location
+	#3trial docket [jurisdiction]#0 - view people awaiting trial, their charges and prior convictions
+	#3trial summon <target>#0 - summon a remand prisoner to court for a PC-held trial", AutoHelp.HelpArg)]
     protected static void Trial(ICharacter actor, string input)
     {
+        StringStack ss = new(input.RemoveFirstWord());
+        if (!ss.IsFinished)
+        {
+            string command = ss.PopForSwitch();
+            switch (command)
+            {
+                case "docket":
+                case "list":
+                    TrialDocket(actor, ss);
+                    return;
+                case "summon":
+                case "call":
+                    TrialSummon(actor, ss);
+                    return;
+                default:
+                    actor.OutputHandler.Send("Do you want to view the trial #3docket#0 or #3summon#0 someone to trial?".SubstituteANSIColour());
+                    return;
+            }
+        }
+
         OnTrial trial = actor.Location.Characters.SelectNotNull(x => x.EffectsOfType<OnTrial>().FirstOrDefault()).FirstOrDefault();
         if (trial is null)
         {
@@ -2210,7 +2636,7 @@ The syntax is simply #3trial#0.", AutoHelp.HelpArg)]
                                   y.Patrol.PatrolStrategy.Name == "Judge"
                                   )
                               );
-        sb.AppendLine($"Judge: {judge?.HowSeen(actor) ?? "Unknown".ColourError()}");
+        sb.AppendLine($"Judge: {(trial.ManualTrial ? "PC-held trial".ColourName() : judge?.HowSeen(actor) ?? "Unknown".ColourError())}");
         sb.AppendLine($"Prosecutor: {trial.Prosecutor?.HowSeen(actor) ?? "Unknown".ColourError()}");
         sb.AppendLine($"Defense Lawyer: {trial.Defender?.HowSeen(actor) ?? "Unknown".ColourError()}");
         sb.AppendLine($"Trial Phase: {trial.Phase.DescribeEnum(true).ColourValue()}");

--- a/MudSharpCore/Effects/Concrete/InCustodyOfEnforcer.cs
+++ b/MudSharpCore/Effects/Concrete/InCustodyOfEnforcer.cs
@@ -34,6 +34,7 @@ public class InCustodyOfEnforcer : Effect, IEffect
         {
             _enforcer = value;
             _enforcerId = value.Id;
+            Changed = true;
         }
     }
 

--- a/MudSharpCore/Effects/Concrete/OnBail.cs
+++ b/MudSharpCore/Effects/Concrete/OnBail.cs
@@ -29,24 +29,25 @@ public class OnBail : Effect, IEffect, IScoreAddendumEffect
 
     #region Constructors
 
-    public OnBail(ICharacter owner, ILegalAuthority legalAuthority, MudDateTime arrestTime) : base(owner, null)
+    public OnBail(ICharacter owner, ILegalAuthority legalAuthority, MudDateTime returnDueDate) : base(owner, null)
     {
         LegalAuthority = legalAuthority;
-        ArrestTime = arrestTime;
+        ReturnDueDate = returnDueDate;
     }
 
     protected OnBail(XElement effect, IPerceivable owner) : base(effect, owner)
     {
         XElement root = effect.Element("Effect");
         LegalAuthority = Gameworld.LegalAuthorities.Get(long.Parse(root.Element("LegalAuthority").Value));
-        ArrestTime = MudDateTime.FromStoredStringOrFallback(root.Element("ArrestTime").Value, Gameworld,
-            StoredMudDateTimeFallback.CurrentDateTime, "Effect:OnBail", Owner?.Id, Owner?.Name, "ArrestTime");
+        XElement returnDueDate = root.Element("ReturnDueDate") ?? root.Element("ArrestTime");
+        ReturnDueDate = MudDateTime.FromStoredStringOrFallback(returnDueDate?.Value, Gameworld,
+            StoredMudDateTimeFallback.CurrentDateTime, "Effect:OnBail", Owner?.Id, Owner?.Name, "ReturnDueDate");
     }
 
     #endregion
 
     public ILegalAuthority LegalAuthority { get; set; }
-    public MudDateTime ArrestTime { get; set; }
+    public MudDateTime ReturnDueDate { get; set; }
 
     // Note: You can safely delete this entire region if your effect acts more like a flag and doesn't actually save any specific data on it (e.g. immwalk, admin telepathy, etc)
 
@@ -56,7 +57,7 @@ public class OnBail : Effect, IEffect, IScoreAddendumEffect
     {
         return new XElement("Effect",
             new XElement("LegalAuthority", LegalAuthority.Id),
-            new XElement("ArrestTime", new XCData(ArrestTime.GetDateTimeString()))
+            new XElement("ReturnDueDate", new XCData(ReturnDueDate.GetDateTimeString()))
         );
     }
 
@@ -69,7 +70,7 @@ public class OnBail : Effect, IEffect, IScoreAddendumEffect
     public override string Describe(IPerceiver voyeur)
     {
         return
-            $"On bail until {ArrestTime.ToString(TimeAndDate.Date.CalendarDisplayMode.Short, TimeAndDate.Time.TimeDisplayTypes.Short).ColourValue()}.";
+            $"On bail until {ReturnDueDate.ToString(TimeAndDate.Date.CalendarDisplayMode.Short, TimeAndDate.Time.TimeDisplayTypes.Short).ColourValue()}.";
     }
 
     public override bool SavingEffect => true;
@@ -90,5 +91,5 @@ public class OnBail : Effect, IEffect, IScoreAddendumEffect
     public bool ShowInHealth => false;
 
     public string ScoreAddendum =>
-        $"You are on bail until {ArrestTime.ToString(TimeAndDate.Date.CalendarDisplayMode.Short, TimeAndDate.Time.TimeDisplayTypes.Short).ColourValue()}.";
+        $"You are on bail until {ReturnDueDate.ToString(TimeAndDate.Date.CalendarDisplayMode.Short, TimeAndDate.Time.TimeDisplayTypes.Short).ColourValue()}.";
 }

--- a/MudSharpCore/Effects/Concrete/OnTrial.cs
+++ b/MudSharpCore/Effects/Concrete/OnTrial.cs
@@ -57,6 +57,18 @@ public class OnTrial : Effect, IEffect
         }
     }
 
+    private bool _manualTrial;
+
+    public bool ManualTrial
+    {
+        get => _manualTrial;
+        set
+        {
+            _manualTrial = value;
+            Changed = true;
+        }
+    }
+
     private readonly List<ICrime> _crimes;
     public Queue<ICrime> CrimeQueue { get; private set; } = null!;
 
@@ -218,10 +230,11 @@ public class OnTrial : Effect, IEffect
     #region Constructors
 
     public OnTrial(ICharacter owner, ILegalAuthority legalAuthority, DateTime lastTrialAction,
-        IEnumerable<ICrime> crimes) : base(owner, null)
+        IEnumerable<ICrime> crimes, bool manualTrial = false) : base(owner, null)
     {
         LegalAuthority = legalAuthority;
         _lastTrialAction = lastTrialAction;
+        _manualTrial = manualTrial;
         _crimes = crimes.ToList();
         foreach (ICrime crime in _crimes)
         {
@@ -263,7 +276,8 @@ public class OnTrial : Effect, IEffect
             _crimeProsecutionCases[crime] = prosecutionOutcome;
         }
         ResetCrimeQueue();
-        _phase = (TrialPhase)int.Parse(effect.Element("Phase")?.Value ?? "0");
+        _phase = (TrialPhase)int.Parse(root.Element("Phase")?.Value ?? "0");
+        _manualTrial = bool.Parse(root.Element("ManualTrial")?.Value ?? "false");
     }
 
     #endregion
@@ -276,6 +290,7 @@ public class OnTrial : Effect, IEffect
             new XElement("LegalAuthority", LegalAuthority.Id),
             new XElement("LastTrialAction", LastTrialAction.ToString("O")),
             new XElement("Phase", (int)Phase),
+            new XElement("ManualTrial", ManualTrial),
             new XElement("Crimes",
                 from crime in Crimes
                 select new XElement("Crime",
@@ -308,10 +323,20 @@ public class OnTrial : Effect, IEffect
 
     public override string Describe(IPerceiver voyeur)
     {
-        return $"On Trial in the {LegalAuthority.Name.ColourName()} authority - {Phase.DescribeEnum().ColourValue()}.";
+        return $"On Trial in the {LegalAuthority.Name.ColourName()} authority - {Phase.DescribeEnum().ColourValue()}{(ManualTrial ? " (PC judge)" : "")}.";
     }
 
     public override bool SavingEffect => true;
+
+    public override bool Applies(object target)
+    {
+        if (target is ILegalAuthority authority)
+        {
+            return base.Applies(target) && authority == LegalAuthority;
+        }
+
+        return base.Applies(target);
+    }
 
     #endregion
 }

--- a/MudSharpCore/NPC/AI/JudgeAI.cs
+++ b/MudSharpCore/NPC/AI/JudgeAI.cs
@@ -1182,12 +1182,18 @@ With each of the emotes, you can use the following tokens:
 
         ICharacter defendant =
             enforcerEffect.LegalAuthority.CourtLocation.Characters.FirstOrDefault(x =>
-                x.EffectsOfType<OnTrial>(y => y.LegalAuthority == enforcerEffect.LegalAuthority).Any());
+                x.EffectsOfType<OnTrial>(y =>
+                    y.LegalAuthority == enforcerEffect.LegalAuthority &&
+                    !y.ManualTrial
+                ).Any());
         if (defendant is null)
         {
             return false;
         }
-        OnTrial trialEffect = defendant.EffectsOfType<OnTrial>(x => x.LegalAuthority == enforcerEffect.LegalAuthority).First();
+        OnTrial trialEffect = defendant.EffectsOfType<OnTrial>(x =>
+            x.LegalAuthority == enforcerEffect.LegalAuthority &&
+            !x.ManualTrial
+        ).First();
         return DoTrialTick(enforcer, defendant, trialEffect);
     }
 
@@ -1398,8 +1404,7 @@ With each of the emotes, you can use the following tokens:
             return true;
         }
 
-        PunishmentResult result = sentenceCrime.Law.PunishmentStrategy.GetResult(defendant, sentenceCrime);
-        trialEffect.Punishments[sentenceCrime] = result;
+        PunishmentResult result = trialEffect.Punishments[sentenceCrime];
         enforcer.OutputHandler.Handle(new EmoteOutput(new Emote(
             string.Format(TrialSentencingEmote,
                 gender.Subjective(),

--- a/MudSharpCore/RPG/Law/Crime.cs
+++ b/MudSharpCore/RPG/Law/Crime.cs
@@ -437,6 +437,64 @@ public class Crime : LateInitialisingItem, ICrime
     public void SetCharacteristicValue(ICharacteristicDefinition definition, ICharacteristicValue value)
     {
         _criminalCharacteristics[definition] = value;
+        Changed = true;
+    }
+
+    public void RecordInvestigationEvidence(ICharacter investigator, double reliability, bool identityKnown)
+    {
+        reliability = Math.Clamp(reliability, 0.0, 1.0);
+        if (identityKnown)
+        {
+            CriminalIdentityIsKnown = true;
+        }
+
+        ICharacter? criminal = Criminal;
+        if (criminal is null)
+        {
+            Changed = true;
+            return;
+        }
+
+        ICharacter evidenceViewer = investigator ?? criminal;
+        List<ICharacteristicDefinition> definitions = criminal.CharacteristicDefinitions.ToList();
+        if (!definitions.Any())
+        {
+            Changed = true;
+            return;
+        }
+
+        int failures = RandomUtilities.ConsecutiveRoll(1.0, 1.0 - reliability, definitions.Count);
+        List<ICharacteristicDefinition> flubbedDetails = RandomUtilities.OldShuffle(definitions)
+                                                                        .Take(failures)
+                                                                        .ToList();
+        foreach (ICharacteristicDefinition definition in definitions)
+        {
+            ICharacteristicValue? detail = criminal.GetCharacteristic(definition, evidenceViewer);
+            if (detail is null)
+            {
+                continue;
+            }
+
+            if (flubbedDetails.Contains(definition))
+            {
+                if (!_criminalCharacteristics.ContainsKey(definition))
+                {
+                    ICharacteristicValue? alternate = Gameworld.CharacteristicValues
+                                                               .Where(x => x.Definition == definition)
+                                                               .GetRandomElement();
+                    if (alternate is not null)
+                    {
+                        _criminalCharacteristics[definition] = alternate;
+                    }
+                }
+
+                continue;
+            }
+
+            _criminalCharacteristics[definition] = detail;
+        }
+
+        Changed = true;
     }
 
     public bool CriminalIdentityIsKnown
@@ -842,6 +900,7 @@ public class Crime : LateInitialisingItem, ICrime
     {
         HasBeenConvicted = false;
         HasBeenFinalised = true;
+        LegalAuthority.FinaliseCrime(this);
     }
 
     public bool EligableForAutomaticConviction()
@@ -905,7 +964,7 @@ public class Crime : LateInitialisingItem, ICrime
             if (_accuserId is null)
             {
                 // TODO - witness profile biases
-                difficulty.StageDown();
+                difficulty = difficulty.StageDown(1);
             }
             return difficulty;
         }
@@ -916,12 +975,52 @@ public class Crime : LateInitialisingItem, ICrime
         get
         {
             Difficulty difficulty = Difficulty.Normal;
+            if (!IsKnownCrime)
+            {
+                difficulty = difficulty.StageUp(2);
+            }
+
+            if (!CriminalIdentityIsKnown)
+            {
+                difficulty = difficulty.StageUp(2);
+                int knownDetails = CriminalCharacteristics.Count;
+                int totalDetails = Criminal?.CharacteristicDefinitions.Count() ?? 0;
+                if (totalDetails > 0 && knownDetails >= Math.Max(1, totalDetails / 2))
+                {
+                    difficulty = difficulty.StageDown(1);
+                }
+            }
+
+            if (CrimeLocation is null)
+            {
+                difficulty = difficulty.StageUp(1);
+            }
+
+            int witnessCount = WitnessIds.Count();
+            if (witnessCount >= 4)
+            {
+                difficulty = difficulty.StageDown(2);
+            }
+            else if (witnessCount >= 2)
+            {
+                difficulty = difficulty.StageDown(1);
+            }
+            else if (witnessCount == 0 && AccuserId is null)
+            {
+                difficulty = difficulty.StageUp(1);
+            }
+
+            if (ThirdPartyId is not null)
+            {
+                difficulty = difficulty.StageDown(1);
+            }
+
             List<ICrime> crimes = LegalAuthority.ResolvedCrimesForIndividual(Criminal)
                                        .Where(x => x.HasBeenConvicted && x.CustodialSentenceLength > TimeSpan.Zero)
                                        .ToList();
             if (crimes.Any())
             {
-                difficulty.StageDown(2);
+                difficulty = difficulty.StageDown(2);
             }
             return difficulty;
         }

--- a/MudSharpCore/RPG/Law/LegalAuthority.cs
+++ b/MudSharpCore/RPG/Law/LegalAuthority.cs
@@ -333,16 +333,12 @@ public partial class LegalAuthority : SaveableItem, ILegalAuthority
                 continue;
             }
 
-            if (bailEffect.ArrestTime > now)
+            if (bailEffect.ReturnDueDate > now)
             {
                 continue;
             }
 
-            IEnumerable<ICrime> crimes = CheckPossibleCrime(criminal, CrimeTypes.ViolateBail, null, null, "");
-            if (!crimes.Any())
-            {
-                continue;
-            }
+            _ = CheckPossibleCrime(criminal, CrimeTypes.ViolateBail, null, null, "").Any();
 
             EndBail(criminal);
 
@@ -371,7 +367,9 @@ public partial class LegalAuthority : SaveableItem, ILegalAuthority
                     continue;
                 }
 
-                if (criminal.AffectedBy<OnBail>(this) || criminal.AffectedBy<OnTrial>(this))
+                if (criminal.AffectedBy<OnBail>(this) ||
+                    criminal.AffectedBy<OnTrial>(this) ||
+                    !this.IsInRemandCell(criminal))
                 {
                     continue;
                 }
@@ -382,52 +380,10 @@ public partial class LegalAuthority : SaveableItem, ILegalAuthority
                 }
 
                 List<ICrime> crimes = KnownCrimesForIndividual(criminal).ToList();
-                PunishmentResult result = new();
                 foreach (ICrime crime in crimes)
                 {
                     PunishmentResult crimeResult = crime.Law.PunishmentStrategy.GetResult(criminal, crime);
-                    result += crimeResult;
-                    crime.Convict(null, result, "Automatic conviction by the system");
-                    FinaliseCrime(crime);
-                }
-
-                if (result.Fine > 0)
-                {
-                    _finesOwed[criminal.Id] += result.Fine;
-                    _finePaymentDueDates[criminal.Id] = now + MudTimeSpan.FromMonths(1);
-                    Changed = true;
-                }
-
-                if (result.CustodialSentence > MudTimeSpan.Zero)
-                {
-                    ServingCustodialSentence servingEffect = criminal.EffectsOfType<ServingCustodialSentence>(x => x.LegalAuthority == this)
-                                                .FirstOrDefault();
-                    if (servingEffect == null)
-                    {
-                        servingEffect = new ServingCustodialSentence(criminal, this, result.CustodialSentence,
-                            now + result.CustodialSentence);
-                        criminal.AddEffect(servingEffect);
-                    }
-                    else
-                    {
-                        servingEffect.ExtendSentence(result.CustodialSentence);
-                    }
-                }
-
-                // Good Behaviour Bond
-                if (result.GoodBehaviourBondLength > MudTimeSpan.Zero)
-                {
-                    GoodBehaviourBond bondEffect = criminal.EffectsOfType<GoodBehaviourBond>(x => x.Authority == this)
-                                             .FirstOrDefault();
-                    if (bondEffect is null)
-                    {
-                        bondEffect = new GoodBehaviourBond(criminal, this, result.GoodBehaviourBondLength);
-                        criminal.AddEffect(bondEffect);
-                    }
-                    else
-                    {
-                        bondEffect.AddLengthToBond(result.GoodBehaviourBondLength);
-                    }
+                    crime.Convict(null, crimeResult, "Automatic conviction by the system");
                 }
 
                 criminal.RemoveAllEffects<AwaitingSentencing>(x => x.LegalAuthority == this);
@@ -859,46 +815,7 @@ public partial class LegalAuthority : SaveableItem, ILegalAuthority
             return;
         }
 
-        if (identityKnown)
-        {
-            crime.CriminalIdentityIsKnown = true;
-        }
-        else
-        {
-            int failures = RandomUtilities.ConsecutiveRoll(1.0, 1.0 - reliability,
-                crime.Criminal.CharacteristicDefinitions.Count());
-            List<Form.Characteristics.ICharacteristicDefinition> flubbedDetails = RandomUtilities.OldShuffle(crime.Criminal.CharacteristicDefinitions).Take(failures)
-                                                .ToList();
-            IEnumerable<Form.Characteristics.ICharacteristicValue> actualDetails =
-                crime.Criminal.CharacteristicDefinitions.Select(x => crime.Criminal.GetCharacteristic(x, witness));
-            foreach (Form.Characteristics.ICharacteristicValue detail in actualDetails)
-            {
-                if (!crime.CriminalCharacteristics.ContainsKey(detail.Definition) ||
-                    crime.CriminalCharacteristics[detail.Definition] != detail)
-                {
-                    if (!crime.CriminalCharacteristics.ContainsKey(detail.Definition))
-                    {
-                        if (flubbedDetails.Contains(detail.Definition))
-                        {
-                            crime.SetCharacteristicValue(detail.Definition,
-                                Gameworld.CharacteristicValues.Where(x => x.Definition == detail.Definition)
-                                         .GetRandomElement());
-                            continue;
-                        }
-
-                        crime.SetCharacteristicValue(detail.Definition, detail);
-                        continue;
-                    }
-
-                    if (flubbedDetails.Contains(detail.Definition))
-                    {
-                        continue;
-                    }
-
-                    crime.SetCharacteristicValue(detail.Definition, detail);
-                }
-            }
-        }
+        crime.RecordInvestigationEvidence(witness ?? crime.Criminal, reliability, identityKnown);
 
         Changed = true;
 
@@ -912,7 +829,7 @@ public partial class LegalAuthority : SaveableItem, ILegalAuthority
         _unknownCrimes.Remove(crime);
         _staleCrimes.Remove(crime);
         crime.TimeOfReport = crime.CrimeLocation?.DateTime() ??
-                             witness.Location?.DateTime() ?? EnforcementZones.First().DateTime();
+                             witness?.Location?.DateTime() ?? EnforcementZones.First().DateTime();
         if (crime.AccuserId == null)
         {
             crime.AccuserId = witness?.Id;

--- a/MudSharpCore/RPG/Law/Patrol.cs
+++ b/MudSharpCore/RPG/Law/Patrol.cs
@@ -20,7 +20,7 @@ namespace MudSharp.RPG.Law;
 public class Patrol : SaveableItem, IPatrol
 {
     public Patrol(ILegalAuthority authority, IPatrolRoute route, ICharacter leader, IEnumerable<ICharacter> members,
-        ICorpseRecoveryReport corpseRecoveryReport = null)
+        ICorpseRecoveryReport corpseRecoveryReport = null, ICrime targetCrime = null)
     {
         Gameworld = authority.Gameworld;
         LegalAuthority = authority;
@@ -29,9 +29,11 @@ public class Patrol : SaveableItem, IPatrol
             ? new CorpseRecoveryPatrolStrategy(Gameworld)
             : route.PatrolStrategy;
         PatrolPhase = PatrolPhase.Preperation;
+        PatrolStartTime = DateTime.UtcNow;
         LastArrivedTime = DateTime.UtcNow;
         PatrolLeader = leader;
         ActiveCorpseRecoveryReport = corpseRecoveryReport;
+        TargetCrime = targetCrime;
         _members.AddRange(members);
         using (new FMDB())
         {
@@ -66,6 +68,7 @@ public class Patrol : SaveableItem, IPatrol
         PatrolRoute = authority.PatrolRoutes.First(x => x.Id == patrol.PatrolRouteId);
         _id = patrol.Id;
         PatrolPhase = (PatrolPhase)patrol.PatrolPhase;
+        PatrolStartTime = DateTime.UtcNow;
         LastArrivedTime = DateTime.UtcNow;
         LastMajorNode = Gameworld.Cells.Get(patrol.LastMajorNodeId ?? 0);
         NextMajorNode = Gameworld.Cells.Get(patrol.NextMajorNodeId ?? 0);
@@ -97,9 +100,11 @@ public class Patrol : SaveableItem, IPatrol
     public PatrolPhase PatrolPhase { get; set; }
     public ICell LastMajorNode { get; set; }
     public ICell NextMajorNode { get; set; }
+    public DateTime PatrolStartTime { get; }
     public DateTime LastArrivedTime { get; set; }
     public ICharacter ActiveEnforcementTarget { get; set; }
     public ICrime ActiveEnforcementCrime { get; set; }
+    public ICrime TargetCrime { get; set; }
     public ICorpseRecoveryReport ActiveCorpseRecoveryReport { get; set; }
     public ICell OriginLocation => LegalAuthority.MarshallingLocation;
 
@@ -251,7 +256,7 @@ public class Patrol : SaveableItem, IPatrol
 
     public void InvalidateActiveCrime()
     {
-        ActiveEnforcementTarget.RemoveAllEffects<WarnedByEnforcer>(x => x.WhichCrime == ActiveEnforcementCrime, true);
+        ActiveEnforcementTarget?.RemoveAllEffects<WarnedByEnforcer>(x => x.WhichCrime == ActiveEnforcementCrime, true);
         ActiveEnforcementTarget = null;
         ActiveEnforcementCrime = null;
     }

--- a/MudSharpCore/RPG/Law/PatrolController.cs
+++ b/MudSharpCore/RPG/Law/PatrolController.cs
@@ -1,6 +1,7 @@
 ﻿using MudSharp.Character;
 using MudSharp.Effects.Concrete;
 using MudSharp.Framework;
+using MudSharp.RPG.Law.PatrolStrategies;
 using MudSharp.Server;
 using System;
 using System.Collections.Generic;
@@ -54,6 +55,7 @@ public class PatrolController : IPatrolController
             LegalAuthority.Gameworld.NPCs
                           .Where(x =>
                               x.AffectedBy<EnforcerEffect>(LegalAuthority) &&
+                              LegalAuthority.GetEnforcementAuthority(x) is not null &&
                               LegalAuthority.Patrols.All(y => !y.PatrolMembers.Contains(x))
                           )
                           .ToList();
@@ -68,14 +70,19 @@ public class PatrolController : IPatrolController
             return;
         }
 
-        List<ICrime> crimesRequiringInvestigation = LegalAuthority.UnknownCrimes
-                                                         .Where(x => x.Law.EnforcementStrategy >
-                                                                     EnforcementStrategy.NoActiveEnforcement)
-                                                         .OrderByDescending(x => x.Law.EnforcementPriority)
-                                                         .ToList();
+        if (TryLaunchCrimeTargetedPatrol<ReactivePatrolStrategy>(freeEnforcers, enforcerCounts))
+        {
+            return;
+        }
+
+        if (TryLaunchCrimeTargetedPatrol<InvestigationPatrolStrategy>(freeEnforcers, enforcerCounts))
+        {
+            return;
+        }
 
         Queue<IPatrolRoute> patrolsToLaunch = new(LegalAuthority.PatrolRoutes
                                                                     .Where(x =>
+                                                                        x.PatrolStrategy is not ICrimeTargetedPatrolStrategy &&
                                                                         LegalAuthority.Patrols.All(y =>
                                                                             y.PatrolRoute != x) &&
                                                                         x.ShouldBeginPatrol()
@@ -92,34 +99,10 @@ public class PatrolController : IPatrolController
                 continue;
             }
 
-            if (whichPatrol.PatrollerNumbers.Any(x => enforcerCounts[x.Key].Count() < x.Value))
+            if (!TryLaunchPatrol(whichPatrol, freeEnforcers, enforcerCounts, null, null))
             {
                 continue;
             }
-
-            List<ICharacter> patrolMembers = new();
-            foreach (KeyValuePair<IEnforcementAuthority, int> requirement in whichPatrol.PatrollerNumbers)
-            {
-                List<ICharacter> members = whichPatrol.PatrolStrategy
-                                         .SelectEnforcers(whichPatrol, enforcerCounts[requirement.Key],
-                                             requirement.Value).ToList();
-                if (members.Count == 0)
-                {
-                    continue;
-                }
-                patrolMembers.AddRange(members);
-                enforcerCounts.RemoveRange(requirement.Key, members);
-                freeEnforcers.RemoveAll(members.Contains);
-            }
-
-            if (patrolMembers.Count == 0)
-            {
-                continue;
-            }
-
-            ICharacter leader = patrolMembers.GetRandomElement();
-            Patrol patrol = new(LegalAuthority, whichPatrol, leader, patrolMembers);
-            LegalAuthority.AddPatrol(patrol);
 
             if (freeEnforcers.Count == 0)
             {
@@ -140,37 +123,85 @@ public class PatrolController : IPatrolController
 
         IPatrolRoute route = LegalAuthority.PatrolRoutes
             .Where(x => x.IsReady && x.PatrolNodes.Any() && x.PatrollerNumbers.Any())
-            .OrderByDescending(x => x.PatrolStrategy is PatrolStrategies.CorpseRecoveryPatrolStrategy)
+            .Where(x => LegalAuthority.Patrols.All(y => y.PatrolRoute != x))
+            .OrderByDescending(x => x.PatrolStrategy is CorpseRecoveryPatrolStrategy)
             .ThenByDescending(x => x.Priority)
             .FirstOrDefault();
-        if (route == null || route.PatrollerNumbers.Any(x => enforcerCounts[x.Key].Count() < x.Value))
+        if (route == null)
         {
             return false;
         }
 
-        List<ICharacter> patrolMembers = new();
+        return TryLaunchPatrol(route, freeEnforcers, enforcerCounts, pendingReport, null);
+    }
+
+    private bool TryLaunchCrimeTargetedPatrol<TStrategy>(List<ICharacter> freeEnforcers,
+        CollectionDictionary<IEnforcementAuthority, ICharacter> enforcerCounts)
+        where TStrategy : class, ICrimeTargetedPatrolStrategy
+    {
+        foreach (IPatrolRoute route in LegalAuthority.PatrolRoutes
+                     .Where(x => x.PatrolStrategy is TStrategy)
+                     .Where(x => LegalAuthority.Patrols.All(y => y.PatrolRoute != x))
+                     .OrderByDescending(x => x.Priority))
+        {
+            TStrategy strategy = (TStrategy)route.PatrolStrategy;
+            ICrime crime = strategy.SelectDispatchCrimes(LegalAuthority)
+                                   .Where(x => strategy.ShouldDispatchForCrime(route, x))
+                                   .Where(x => LegalAuthority.Patrols.All(y =>
+                                       y.TargetCrime != x ||
+                                       y.PatrolStrategy.GetType() != route.PatrolStrategy.GetType()))
+                                   .FirstOrDefault();
+            if (crime is null)
+            {
+                continue;
+            }
+
+            if (TryLaunchPatrol(route, freeEnforcers, enforcerCounts, null, crime))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private bool TryLaunchPatrol(IPatrolRoute route, List<ICharacter> freeEnforcers,
+        CollectionDictionary<IEnforcementAuthority, ICharacter> enforcerCounts,
+        ICorpseRecoveryReport pendingReport, ICrime targetCrime)
+    {
+        if (route.PatrollerNumbers.Any(x => enforcerCounts[x.Key].Count() < x.Value))
+        {
+            return false;
+        }
+
+        List<(IEnforcementAuthority Authority, List<ICharacter> Members)> selections = new();
         foreach (KeyValuePair<IEnforcementAuthority, int> requirement in route.PatrollerNumbers)
         {
             List<ICharacter> members = route.PatrolStrategy
                 .SelectEnforcers(route, enforcerCounts[requirement.Key], requirement.Value)
                 .ToList();
-            if (members.Count == 0)
+            if (members.Count < requirement.Value)
             {
                 return false;
             }
 
-            patrolMembers.AddRange(members);
-            enforcerCounts.RemoveRange(requirement.Key, members);
-            freeEnforcers.RemoveAll(members.Contains);
+            selections.Add((requirement.Key, members));
         }
 
+        List<ICharacter> patrolMembers = selections.SelectMany(x => x.Members).ToList();
         if (!patrolMembers.Any())
         {
             return false;
         }
 
+        foreach ((IEnforcementAuthority authority, List<ICharacter> members) in selections)
+        {
+            enforcerCounts.RemoveRange(authority, members);
+            freeEnforcers.RemoveAll(members.Contains);
+        }
+
         ICharacter leader = patrolMembers.GetRandomElement();
-        Patrol patrol = new(LegalAuthority, route, leader, patrolMembers, pendingReport);
+        Patrol patrol = new(LegalAuthority, route, leader, patrolMembers, pendingReport, targetCrime);
         LegalAuthority.AddPatrol(patrol);
         return true;
     }

--- a/MudSharpCore/RPG/Law/PatrolRoute.cs
+++ b/MudSharpCore/RPG/Law/PatrolRoute.cs
@@ -166,9 +166,12 @@ public class PatrolRoute : SaveableItem, IPatrolRoute, IEditableItem
         return
             IsReady &&
             PatrolNodes.Any() &&
+            PatrolStrategy is not ICrimeTargetedPatrolStrategy &&
+            PatrolStrategy is not CorpseRecoveryPatrolStrategy &&
             (PatrolStrategy as IConfigurablePatrolStrategy)?.ReadyToBegin(this) != false &&
             StartPatrolProg?.Execute<bool?>() != false &&
             PatrollerNumbers.Any() &&
+            LegalAuthority.EnforcementZones.Any() &&
             TimeOfDays.Contains(LegalAuthority.EnforcementZones.First().CurrentTimeOfDay);
     }
 
@@ -384,6 +387,8 @@ public class PatrolRoute : SaveableItem, IPatrolRoute, IEditableItem
         }
 
         _patrolNodes.Insert(value - 1, actor.Location);
+        actor.Location.CellProposedForDeletion -= Node_CellProposedForDeletion;
+        actor.Location.CellProposedForDeletion += Node_CellProposedForDeletion;
         Changed = true;
         actor.OutputHandler.Send(
             $"You insert your current location ({actor.Location.HowSeen(actor)}) as a major patrol node at position #{value.ToString("N0", actor).ColourValue()}.");
@@ -392,8 +397,36 @@ public class PatrolRoute : SaveableItem, IPatrolRoute, IEditableItem
 
     private bool BuildingCommandNodeSwap(ICharacter actor, StringStack command)
     {
-        actor.OutputHandler.Send("Todo");
-        return false;
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which two patrol node positions do you want to swap?");
+            return false;
+        }
+
+        if (!int.TryParse(command.PopSpeech(), out int first) ||
+            command.IsFinished ||
+            !int.TryParse(command.SafeRemainingArgument, out int second) ||
+            first < 1 ||
+            second < 1 ||
+            first > _patrolNodes.Count ||
+            second > _patrolNodes.Count)
+        {
+            actor.OutputHandler.Send(
+                $"You must enter two valid patrol node positions between {1.ToString("N0", actor).ColourValue()} and {_patrolNodes.Count.ToString("N0", actor).ColourValue()}.");
+            return false;
+        }
+
+        if (first == second)
+        {
+            actor.OutputHandler.Send("Those are the same patrol node position.");
+            return false;
+        }
+
+        (_patrolNodes[first - 1], _patrolNodes[second - 1]) = (_patrolNodes[second - 1], _patrolNodes[first - 1]);
+        Changed = true;
+        actor.OutputHandler.Send(
+            $"You swap patrol nodes {first.ToString("N0", actor).ColourValue()} and {second.ToString("N0", actor).ColourValue()} for the {Name.ColourName()} patrol route.");
+        return true;
     }
 
     private bool BuildingCommandNodeDelete(ICharacter actor, StringStack command)
@@ -402,7 +435,6 @@ public class PatrolRoute : SaveableItem, IPatrolRoute, IEditableItem
         {
             _patrolNodes.Remove(actor.Location);
             actor.Location.CellProposedForDeletion -= Node_CellProposedForDeletion;
-            actor.Location.CellProposedForDeletion += Node_CellProposedForDeletion;
             Changed = true;
             actor.OutputHandler.Send(
                 $"You remove your current location ({actor.Location.HowSeen(actor)}) from the list of patrol nodes.");
@@ -423,11 +455,10 @@ public class PatrolRoute : SaveableItem, IPatrolRoute, IEditableItem
         }
 
         _patrolNodes.Remove(location);
-        actor.Location.CellProposedForDeletion -= Node_CellProposedForDeletion;
-        actor.Location.CellProposedForDeletion += Node_CellProposedForDeletion;
+        location.CellProposedForDeletion -= Node_CellProposedForDeletion;
         Changed = true;
         actor.OutputHandler.Send(
-            $"You remove the location {actor.Location.HowSeen(actor)} from the list of patrol nodes.");
+            $"You remove the location {location.HowSeen(actor)} from the list of patrol nodes.");
         return true;
     }
 
@@ -567,7 +598,7 @@ public class PatrolRoute : SaveableItem, IPatrolRoute, IEditableItem
             return false;
         }
 
-        actor.OutputHandler.Send($"You rename the patrol route {_name.ColourName()} to {_name.ColourName()}.");
+        actor.OutputHandler.Send($"You rename the patrol route {_name.ColourName()} to {name.ColourName()}.");
         _name = name;
         Changed = true;
         return true;

--- a/MudSharpCore/RPG/Law/PatrolStrategies/CrimeTargetedPatrolStrategyBase.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/CrimeTargetedPatrolStrategyBase.cs
@@ -1,0 +1,301 @@
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Construction.Boundary;
+using MudSharp.Effects.Concrete;
+using MudSharp.Framework;
+using MudSharp.Movement;
+using MudSharp.TimeAndDate;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace MudSharp.RPG.Law.PatrolStrategies;
+
+public abstract class CrimeTargetedPatrolStrategyBase : ArmedPatrolStrategy, ICrimeTargetedPatrolStrategy
+{
+	protected CrimeTargetedPatrolStrategyBase(IFuturemud gameworld, string strategyData, string rootName) : base(gameworld)
+	{
+		RootName = rootName;
+		LoadStrategyData(strategyData);
+	}
+
+	protected string RootName { get; }
+	protected int CoverageRadius { get; set; } = 8;
+
+	protected virtual void LoadStrategyData(string strategyData)
+	{
+		if (string.IsNullOrWhiteSpace(strategyData))
+		{
+			return;
+		}
+
+		XElement root;
+		try
+		{
+			root = XElement.Parse(strategyData);
+		}
+		catch
+		{
+			return;
+		}
+
+		if (int.TryParse(root.Attribute("coverageRadius")?.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int radius))
+		{
+			CoverageRadius = Math.Max(0, radius);
+		}
+
+		LoadAdditionalStrategyData(root);
+	}
+
+	protected virtual void LoadAdditionalStrategyData(XElement root)
+	{
+	}
+
+	public abstract IEnumerable<ICrime> SelectDispatchCrimes(ILegalAuthority authority);
+
+	public virtual bool ShouldDispatchForCrime(IPatrolRoute patrol, ICrime crime)
+	{
+		return CrimeHasLocation(crime) &&
+		       RouteCoversCrime(patrol, crime) &&
+		       patrol.IsReady &&
+		       patrol.PatrolNodes.Any() &&
+		       patrol.PatrollerNumbers.Any() &&
+		       ReadyToBegin(patrol) &&
+		       (patrol is not PatrolRoute concreteRoute || concreteRoute.StartPatrolProg?.Execute<bool?>() != false) &&
+		       patrol.LegalAuthority.EnforcementZones.Any() &&
+		       patrol.TimeOfDays.Contains(patrol.LegalAuthority.EnforcementZones.First().CurrentTimeOfDay);
+	}
+
+	protected static bool CrimeHasLocation(ICrime crime)
+	{
+		return crime?.CrimeLocation is not null;
+	}
+
+	protected bool RouteCoversCrime(IPatrolRoute patrol, ICrime crime)
+	{
+		ICell location = crime.CrimeLocation;
+		return patrol.PatrolNodes.Any(x => x == location || PathLengthBetween(x, location, CoverageRadius) is not null);
+	}
+
+	protected static int? PathLengthBetween(ICell origin, ICell destination, int maximumDistance)
+	{
+		if (origin == destination)
+		{
+			return 0;
+		}
+
+		if (maximumDistance <= 0)
+		{
+			return null;
+		}
+
+		List<ICellExit> path = origin.PathBetween(destination, (uint)maximumDistance, PathSearch.IgnorePresenceOfDoors).ToList();
+		return path.Any() ? path.Count : null;
+	}
+
+	protected List<ICell> PatrolAreaNodes(IPatrol patrol, ICrime crime)
+	{
+		ICell location = crime.CrimeLocation;
+		List<ICell> nodes = new() { location };
+		nodes.AddRange(patrol.PatrolRoute.PatrolNodes
+		                     .Where(x => x != location)
+		                     .Select(x => (Cell: x, Distance: PathLengthBetween(x, location, CoverageRadius)))
+		                     .Where(x => x.Distance is not null)
+		                     .OrderBy(x => x.Distance!.Value)
+		                     .Select(x => x.Cell));
+		return nodes.Distinct().ToList();
+	}
+
+	protected ICell NextAreaNode(IPatrol patrol, ICrime crime, ICell current)
+	{
+		List<ICell> nodes = PatrolAreaNodes(patrol, crime);
+		if (nodes.Count == 0)
+		{
+			return crime.CrimeLocation;
+		}
+
+		int index = nodes.IndexOf(current);
+		if (index < 0 || index + 1 >= nodes.Count)
+		{
+			return nodes[0];
+		}
+
+		return nodes[index + 1];
+	}
+
+	public override void HandlePatrolTick(IPatrol patrol)
+	{
+		if (patrol.ActiveEnforcementTarget != null)
+		{
+			PatrolTickActiveEnforcement(patrol);
+			return;
+		}
+
+		if (PatrolTickGeneral(patrol))
+		{
+			return;
+		}
+
+		if (!TargetCrimeStillValid(patrol))
+		{
+			patrol.CompletePatrol();
+			return;
+		}
+
+		switch (patrol.PatrolPhase)
+		{
+			case PatrolPhase.Preperation:
+				PatrolTickPreparationPhase(patrol);
+				return;
+			case PatrolPhase.Deployment:
+				PatrolTickDeploymentPhase(patrol);
+				return;
+			case PatrolPhase.Patrol:
+				PatrolTickPatrolPhase(patrol);
+				return;
+			case PatrolPhase.Return:
+				PatrolTickReturnPhase(patrol);
+				return;
+		}
+	}
+
+	protected virtual bool TargetCrimeStillValid(IPatrol patrol)
+	{
+		return patrol.TargetCrime is not null &&
+		       patrol.TargetCrime.IsKnownCrime &&
+		       !patrol.TargetCrime.HasBeenFinalised &&
+		       patrol.TargetCrime.CrimeLocation is not null;
+	}
+
+	protected override void PatrolTickPreparationPhase(IPatrol patrol)
+	{
+		base.PatrolTickPreparationPhase(patrol);
+		if (patrol.PatrolPhase == PatrolPhase.Deployment && patrol.TargetCrime?.CrimeLocation is not null)
+		{
+			patrol.NextMajorNode = patrol.TargetCrime.CrimeLocation;
+		}
+	}
+
+	protected override void PatrolTickDeploymentPhase(IPatrol patrol)
+	{
+		MoveLeaderToTargetNode(patrol, patrol.TargetCrime.CrimeLocation);
+	}
+
+	protected override void PatrolTickPatrolPhase(IPatrol patrol)
+	{
+		if (patrol.NextMajorNode is null)
+		{
+			patrol.NextMajorNode = patrol.TargetCrime.CrimeLocation;
+		}
+
+		MoveLeaderToTargetNode(patrol, patrol.NextMajorNode);
+	}
+
+	protected void MoveLeaderToTargetNode(IPatrol patrol, ICell destination)
+	{
+		if (destination is null)
+		{
+			patrol.CompletePatrol();
+			return;
+		}
+
+		if (patrol.PatrolLeader.Location == destination)
+		{
+			patrol.PatrolPhase = PatrolPhase.Patrol;
+			HandleArrivedAtTargetNode(patrol, destination);
+			return;
+		}
+
+		if (patrol.PatrolLeader.CombinedEffectsOfType<FollowingPath>().Any())
+		{
+			return;
+		}
+
+		List<ICellExit> path = patrol.PatrolLeader.PathBetween(destination, 50,
+			PathSearch.PathIncludeUnlockableDoors(patrol.PatrolLeader)).ToList();
+		if (!path.Any())
+		{
+			path = patrol.PatrolLeader.PathBetween(destination, 50, PathSearch.IgnorePresenceOfDoors).ToList();
+			if (!path.Any())
+			{
+				if (DateTime.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(3))
+				{
+					patrol.CompletePatrol();
+				}
+
+				return;
+			}
+		}
+
+		FollowingPath fp = new(patrol.PatrolLeader, path)
+		{
+			UseDoorguards = true,
+			UseKeys = true,
+			OpenDoors = true
+		};
+		patrol.PatrolLeader.AddEffect(fp);
+		fp.FollowPathAction();
+	}
+
+	protected virtual void HandleArrivedAtTargetNode(IPatrol patrol, ICell node)
+	{
+		if (patrol.LastMajorNode != node)
+		{
+			patrol.LastMajorNode = node;
+			patrol.LastArrivedTime = DateTime.UtcNow;
+		}
+	}
+
+	public virtual string SaveStrategyData()
+	{
+		XElement root = new(RootName,
+			new XAttribute("coverageRadius", CoverageRadius.ToString(CultureInfo.InvariantCulture)));
+		SaveAdditionalStrategyData(root);
+		return root.ToString();
+	}
+
+	protected virtual void SaveAdditionalStrategyData(XElement root)
+	{
+	}
+
+	public virtual bool BuildingCommand(ICharacter actor, IPatrolRoute patrol, StringStack command)
+	{
+		switch (command.PopForSwitch())
+		{
+			case "radius":
+			case "coverage":
+				return BuildingCommandRadius(actor, command);
+		}
+
+		actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
+		return false;
+	}
+
+	protected bool BuildingCommandRadius(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished || !int.TryParse(command.SafeRemainingArgument, out int value) || value < 0)
+		{
+			actor.OutputHandler.Send("How many rooms away from a patrol node should this patrol respond to?");
+			return false;
+		}
+
+		CoverageRadius = value;
+		actor.OutputHandler.Send(
+			$"This patrol strategy will now respond to crimes within {CoverageRadius.ToString("N0", actor).ColourValue()} rooms of any patrol node.");
+		return true;
+	}
+
+	public virtual string ShowConfiguration(ICharacter actor, IPatrolRoute patrol)
+	{
+		return $"Coverage Radius: {CoverageRadius.ToString("N0", actor).ColourValue()} rooms\n";
+	}
+
+	public virtual bool ReadyToBegin(IPatrolRoute patrol)
+	{
+		return CoverageRadius >= 0;
+	}
+
+	public abstract string HelpText { get; }
+}

--- a/MudSharpCore/RPG/Law/PatrolStrategies/InvestigationPatrolStrategy.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/InvestigationPatrolStrategy.cs
@@ -1,148 +1,160 @@
-using MudSharp.Construction.Boundary;
-using MudSharp.Economy.Estates;
-using MudSharp.Effects.Concrete;
+using MudSharp.Character;
+using MudSharp.Construction;
 using MudSharp.Framework;
-using MudSharp.GameItems;
-using MudSharp.GameItems.Interfaces;
-using MudSharp.Movement;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Outputs;
+using MudSharp.PerceptionEngine.Parsers;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using System.Xml.Linq;
 
 namespace MudSharp.RPG.Law.PatrolStrategies;
 
-public class InvestigationPatrolStrategy : PatrolStrategyBase
+public class InvestigationPatrolStrategy : CrimeTargetedPatrolStrategyBase
 {
-    public InvestigationPatrolStrategy(IFuturemud gameworld) : base(gameworld)
-    {
-    }
+	public InvestigationPatrolStrategy(IFuturemud gameworld, string strategyData = null) : base(gameworld, strategyData,
+		"InvestigationPatrol")
+	{
+	}
 
-    public override string Name => "Investigation Patrol";
+	public override string Name => "InvestigationPatrol";
 
-    public override void HandlePatrolTick(IPatrol patrol)
-    {
-        if (patrol.ActiveCorpseRecoveryReport == null)
-        {
-            patrol.CompletePatrol();
-            return;
-        }
+	public double EvidenceReliability { get; private set; } = 0.85;
+	public TimeSpan SceneSearchTime { get; private set; } = TimeSpan.FromMinutes(2);
 
-        switch (patrol.PatrolPhase)
-        {
-            case PatrolPhase.Preperation:
-                PatrolTickPreparationPhase(patrol);
-                return;
-            case PatrolPhase.Deployment:
-                HandleDeployment(patrol);
-                return;
-            case PatrolPhase.Patrol:
-                HandleRecovery(patrol);
-                return;
-            case PatrolPhase.Return:
-                PatrolTickReturnPhase(patrol);
-                return;
-        }
-    }
+	protected override void LoadAdditionalStrategyData(XElement root)
+	{
+		if (double.TryParse(root.Attribute("evidenceReliability")?.Value, NumberStyles.Float,
+			    CultureInfo.InvariantCulture, out double reliability))
+		{
+			EvidenceReliability = Math.Clamp(reliability, 0.0, 1.0);
+		}
 
-    protected override void PatrolTickPatrolPhase(IPatrol patrol)
-    {
-        HandleRecovery(patrol);
-    }
+		if (double.TryParse(root.Attribute("sceneSearchSeconds")?.Value, NumberStyles.Float,
+			    CultureInfo.InvariantCulture, out double sceneSearch))
+		{
+			SceneSearchTime = TimeSpan.FromSeconds(Math.Max(1.0, sceneSearch));
+		}
+	}
 
-    protected override void PatrolTickPreparationPhase(IPatrol patrol)
-    {
-        base.PatrolTickPreparationPhase(patrol);
-        patrol.NextMajorNode = patrol.ActiveCorpseRecoveryReport?.SourceCell;
-    }
+	public override IEnumerable<ICrime> SelectDispatchCrimes(ILegalAuthority authority)
+	{
+		return authority.KnownCrimes
+		                .Where(NeedsInvestigation)
+		                .OrderByDescending(x => x.Law.EnforcementPriority)
+		                .ThenByDescending(x => x.RealTimeOfCrime);
+	}
 
-    private void HandleDeployment(IPatrol patrol)
-    {
-        ICorpseRecoveryReport report = patrol.ActiveCorpseRecoveryReport;
-        if (report == null)
-        {
-            patrol.CompletePatrol();
-            return;
-        }
+	public static bool NeedsInvestigation(ICrime crime)
+	{
+		if (crime is null ||
+		    !crime.IsKnownCrime ||
+		    crime.HasBeenFinalised ||
+		    crime.CrimeLocation is null)
+		{
+			return false;
+		}
 
-        ICorpse corpse = report.Corpse?.GetItemType<ICorpse>();
-        if (corpse == null || report.Corpse.Location == null || report.Corpse.Location != report.SourceCell)
-        {
-            report.MarkFailed();
-            patrol.ActiveCorpseRecoveryReport = null;
-            patrol.CompletePatrol();
-            return;
-        }
+		int totalCharacteristics = crime.Criminal?.CharacteristicDefinitions.Count() ?? 0;
+		return totalCharacteristics > 0 && crime.CriminalCharacteristics.Count < totalCharacteristics;
+	}
 
-        if (patrol.PatrolLeader.Location == report.SourceCell)
-        {
-            patrol.PatrolPhase = PatrolPhase.Patrol;
-            patrol.LastArrivedTime = DateTime.UtcNow;
-            return;
-        }
+	protected override bool TargetCrimeStillValid(IPatrol patrol)
+	{
+		return NeedsInvestigation(patrol.TargetCrime);
+	}
 
-        if (patrol.PatrolLeader.CombinedEffectsOfType<FollowingPath>().Any())
-        {
-            return;
-        }
+	protected override void HandleArrivedAtTargetNode(IPatrol patrol, ICell node)
+	{
+		base.HandleArrivedAtTargetNode(patrol, node);
+		if (DateTime.UtcNow - patrol.LastArrivedTime < SceneSearchTime)
+		{
+			return;
+		}
 
-        List<ICellExit> path = patrol.PatrolLeader.PathBetween(report.SourceCell, 50,
-            PathSearch.PathIncludeUnlockableDoors(patrol.PatrolLeader)).ToList();
-        if (!path.Any())
-        {
-            path = patrol.PatrolLeader.PathBetween(report.SourceCell, 50, PathSearch.IgnorePresenceOfDoors).ToList();
-            if (!path.Any())
-            {
-                if (DateTime.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(3))
-                {
-                    report.MarkFailed();
-                    patrol.ActiveCorpseRecoveryReport = null;
-                    patrol.CompletePatrol();
-                }
+		ICrime crime = patrol.TargetCrime;
+		ICharacter criminal = crime.Criminal;
+		bool identityKnown = criminal is not null &&
+		                     patrol.PatrolLeader.CanSee(criminal) &&
+		                     patrol.PatrolLeader.Location == criminal.Location;
+		crime.RecordInvestigationEvidence(patrol.PatrolLeader, EvidenceReliability, identityKnown);
+		patrol.PatrolLeader.OutputHandler.Handle(new EmoteOutput(new Emote(
+			"@ inspect|inspects the area carefully, collecting evidence about a reported crime.",
+			patrol.PatrolLeader,
+			patrol.PatrolLeader)));
+		patrol.CompletePatrol();
+	}
 
-                return;
-            }
-        }
+	public override string HelpText => @"Investigation patrol configuration:
 
-        FollowingPath fp = new(patrol.PatrolLeader, path) { UseDoorguards = true, UseKeys = true, OpenDoors = true };
-        patrol.PatrolLeader.AddEffect(fp);
-        fp.FollowPathAction();
-    }
+	#3radius <rooms>#0 - sets how far from a patrol node a reported crime may be to dispatch this patrol
+	#3reliability <0.0-1.0>#0 - sets how reliably the patrol records suspect details
+	#3search <timespan>#0 - sets how long the patrol searches the crime scene";
 
-    private void HandleRecovery(IPatrol patrol)
-    {
-        ICorpseRecoveryReport report = patrol.ActiveCorpseRecoveryReport;
-        if (report == null)
-        {
-            patrol.CompletePatrol();
-            return;
-        }
+	public override bool BuildingCommand(ICharacter actor, IPatrolRoute patrol, StringStack command)
+	{
+		switch (command.PeekSpeech().ToLowerInvariant())
+		{
+			case "reliability":
+			case "quality":
+				command.PopSpeech();
+				return BuildingCommandReliability(actor, command);
+			case "search":
+			case "scene":
+			case "time":
+				command.PopSpeech();
+				return BuildingCommandSearchTime(actor, command);
+			default:
+				return base.BuildingCommand(actor, patrol, command);
+		}
+	}
 
-        IGameItem corpseItem = report.Corpse;
-        if (corpseItem?.GetItemType<ICorpse>() == null)
-        {
-            report.MarkFailed();
-            patrol.ActiveCorpseRecoveryReport = null;
-            patrol.CompletePatrol();
-            return;
-        }
+	private bool BuildingCommandReliability(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished ||
+		    !double.TryParse(command.SafeRemainingArgument, NumberStyles.Float, CultureInfo.InvariantCulture, out double value) ||
+		    value < 0.0 ||
+		    value > 1.0)
+		{
+			actor.OutputHandler.Send("What reliability between 0.0 and 1.0 should this investigation use?");
+			return false;
+		}
 
-        if (corpseItem.Location != report.SourceCell)
-        {
-            report.MarkFailed();
-            patrol.ActiveCorpseRecoveryReport = null;
-            patrol.CompletePatrol();
-            return;
-        }
+		EvidenceReliability = value;
+		actor.OutputHandler.Send(
+			$"This investigation patrol will now record evidence with {EvidenceReliability.ToString("P0", actor).ColourValue()} reliability.");
+		return true;
+	}
 
-        if (patrol.PatrolLeader.Location != report.SourceCell)
-        {
-            patrol.PatrolPhase = PatrolPhase.Deployment;
-            return;
-        }
+	private bool BuildingCommandSearchTime(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished ||
+		    !MudSharp.TimeAndDate.MudTimeSpan.TryParse(command.SafeRemainingArgument, out MudSharp.TimeAndDate.MudTimeSpan value) ||
+		    value.TotalSeconds <= 0.0)
+		{
+			actor.OutputHandler.Send("How long should the patrol spend searching the crime scene?");
+			return false;
+		}
 
-        MorgueService.IntakeCorpse(report.EconomicZone, corpseItem);
-        report.MarkCompleted();
-        patrol.ActiveCorpseRecoveryReport = null;
-        patrol.CompletePatrol();
-    }
+		SceneSearchTime = value;
+		actor.OutputHandler.Send(
+			$"This investigation patrol will now spend {SceneSearchTime.Describe(actor).ColourValue()} searching the crime scene.");
+		return true;
+	}
+
+	public override string ShowConfiguration(ICharacter actor, IPatrolRoute patrol)
+	{
+		return base.ShowConfiguration(actor, patrol) +
+		       $"Evidence Reliability: {EvidenceReliability.ToString("P0", actor).ColourValue()}\n" +
+		       $"Scene Search Time: {SceneSearchTime.Describe(actor).ColourValue()}\n";
+	}
+
+	protected override void SaveAdditionalStrategyData(XElement root)
+	{
+		root.Add(
+			new XAttribute("evidenceReliability", EvidenceReliability.ToString(CultureInfo.InvariantCulture)),
+			new XAttribute("sceneSearchSeconds", SceneSearchTime.TotalSeconds.ToString(CultureInfo.InvariantCulture)));
+	}
 }

--- a/MudSharpCore/RPG/Law/PatrolStrategies/PatrolStrategyBase.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/PatrolStrategyBase.cs
@@ -78,7 +78,11 @@ public abstract class PatrolStrategyBase : IPatrolStrategy
         // Check for presence of criminals
         foreach (ICharacter person in patrol.PatrolLeader.Location.LayerCharacters(patrol.PatrolLeader.RoomLayer))
         {
-            if (person.IdentityIsObscured)
+            if (person == patrol.PatrolLeader ||
+                patrol.PatrolMembers.Contains(person) ||
+                person.State.IsDead() ||
+                person.State.IsInStatis() ||
+                person.IdentityIsObscured)
             // TODO - how to see through this
             {
                 continue;
@@ -92,7 +96,10 @@ public abstract class PatrolStrategyBase : IPatrolStrategy
                 continue;
             }
 
-            List<ICrime> crimes = authority.KnownCrimesForIndividual(person).ToList();
+            List<ICrime> crimes = authority.KnownCrimesForIndividual(person)
+                                           .Where(x => x.CriminalIdentityIsKnown)
+                                           .Where(x => !x.HasBeenFinalised)
+                                           .ToList();
             if (!crimes.Any(x => !x.BailPosted && x.Law.EnforcementStrategy >= MinimumEnforcementStrategyToAct))
             {
                 continue;
@@ -205,6 +212,17 @@ public abstract class PatrolStrategyBase : IPatrolStrategy
         ICharacter criminal = patrol.ActiveEnforcementTarget;
         ICrime crime = patrol.ActiveEnforcementCrime;
         ICharacter leader = patrol.PatrolLeader;
+
+        if (criminal is null ||
+            crime is null ||
+            criminal.State.IsDead() ||
+            criminal.State.IsInStatis() ||
+            crime.HasBeenFinalised ||
+            crime.BailPosted)
+        {
+            patrol.InvalidateActiveCrime();
+            return;
+        }
 
         if (criminal.AffectedBy<InCustodyOfEnforcer>(patrol.LegalAuthority))
         {

--- a/MudSharpCore/RPG/Law/PatrolStrategies/ReactivePatrolStrategy.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/ReactivePatrolStrategy.cs
@@ -1,0 +1,139 @@
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Framework;
+using MudSharp.TimeAndDate;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace MudSharp.RPG.Law.PatrolStrategies;
+
+public class ReactivePatrolStrategy : CrimeTargetedPatrolStrategyBase
+{
+	public ReactivePatrolStrategy(IFuturemud gameworld, string strategyData = null) : base(gameworld, strategyData,
+		"ReactivePatrol")
+	{
+	}
+
+	public override string Name => "ReactivePatrol";
+
+	public TimeSpan DispatchWindow { get; private set; } = TimeSpan.FromMinutes(30);
+	public TimeSpan MaximumDuration { get; private set; } = TimeSpan.FromMinutes(15);
+
+	protected override void LoadAdditionalStrategyData(XElement root)
+	{
+		if (double.TryParse(root.Attribute("dispatchWindowSeconds")?.Value, NumberStyles.Float,
+			    CultureInfo.InvariantCulture, out double dispatchWindow))
+		{
+			DispatchWindow = TimeSpan.FromSeconds(Math.Max(1.0, dispatchWindow));
+		}
+
+		if (double.TryParse(root.Attribute("maximumDurationSeconds")?.Value, NumberStyles.Float,
+			    CultureInfo.InvariantCulture, out double maximumDuration))
+		{
+			MaximumDuration = TimeSpan.FromSeconds(Math.Max(1.0, maximumDuration));
+		}
+	}
+
+	public override IEnumerable<ICrime> SelectDispatchCrimes(ILegalAuthority authority)
+	{
+		return authority.KnownCrimes
+		                .Where(x => IsEligibleResponseCrime(x, DispatchWindow))
+		                .OrderByDescending(x => x.Law.EnforcementPriority)
+		                .ThenByDescending(x => x.RealTimeOfCrime);
+	}
+
+	public static bool IsEligibleResponseCrime(ICrime crime, TimeSpan dispatchWindow)
+	{
+		return crime is not null &&
+		       crime.IsKnownCrime &&
+		       !crime.HasBeenFinalised &&
+		       !crime.HasBeenEnforced &&
+		       crime.CrimeLocation is not null &&
+		       crime.Law.CrimeType.IsViolentCrime() &&
+		       crime.Law.EnforcementStrategy > EnforcementStrategy.NoActiveEnforcement &&
+		       DateTime.UtcNow - crime.RealTimeOfCrime <= dispatchWindow;
+	}
+
+	protected override bool TargetCrimeStillValid(IPatrol patrol)
+	{
+		return base.TargetCrimeStillValid(patrol) &&
+		       IsEligibleResponseCrime(patrol.TargetCrime, DispatchWindow + MaximumDuration);
+	}
+
+	protected override void HandleArrivedAtTargetNode(IPatrol patrol, ICell node)
+	{
+		base.HandleArrivedAtTargetNode(patrol, node);
+
+		if (DateTime.UtcNow - patrol.PatrolStartTime >= MaximumDuration ||
+		    !patrol.PatrolRoute.TimeOfDays.Contains(patrol.PatrolLeader.Location.CurrentTimeOfDay))
+		{
+			patrol.CompletePatrol();
+			return;
+		}
+
+		if (DateTime.UtcNow - patrol.LastArrivedTime < patrol.PatrolRoute.LingerTimeMajorNode)
+		{
+			return;
+		}
+
+		patrol.NextMajorNode = NextAreaNode(patrol, patrol.TargetCrime, node);
+		if (patrol.NextMajorNode == node)
+		{
+			patrol.CompletePatrol();
+		}
+	}
+
+	public override string HelpText => @"Reactive patrol configuration:
+
+	#3radius <rooms>#0 - sets how far from a patrol node a violent reported crime may be to dispatch this patrol
+	#3window <timespan>#0 - sets how recent a violent crime report must be to dispatch this patrol
+	#3duration <timespan>#0 - sets how long the reactive patrol remains in the area";
+
+	public override bool BuildingCommand(ICharacter actor, IPatrolRoute patrol, StringStack command)
+	{
+		switch (command.PeekSpeech().ToLowerInvariant())
+		{
+			case "window":
+			case "dispatch":
+				command.PopSpeech();
+				return BuildingCommandTimeSpan(actor, command, "dispatch window", value => DispatchWindow = value);
+			case "duration":
+			case "length":
+				command.PopSpeech();
+				return BuildingCommandTimeSpan(actor, command, "maximum duration", value => MaximumDuration = value);
+			default:
+				return base.BuildingCommand(actor, patrol, command);
+		}
+	}
+
+	private static bool BuildingCommandTimeSpan(ICharacter actor, StringStack command, string name, Action<TimeSpan> setter)
+	{
+		if (command.IsFinished || !MudTimeSpan.TryParse(command.SafeRemainingArgument, out MudTimeSpan value) ||
+		    value.TotalSeconds <= 0.0)
+		{
+			actor.OutputHandler.Send($"What positive length of time should the {name} be?");
+			return false;
+		}
+
+		setter(value);
+		actor.OutputHandler.Send($"The reactive patrol {name} is now {value.Describe(actor).ColourValue()}.");
+		return true;
+	}
+
+	public override string ShowConfiguration(ICharacter actor, IPatrolRoute patrol)
+	{
+		return base.ShowConfiguration(actor, patrol) +
+		       $"Dispatch Window: {DispatchWindow.Describe(actor).ColourValue()}\n" +
+		       $"Maximum Duration: {MaximumDuration.Describe(actor).ColourValue()}\n";
+	}
+
+	protected override void SaveAdditionalStrategyData(XElement root)
+	{
+		root.Add(
+			new XAttribute("dispatchWindowSeconds", DispatchWindow.TotalSeconds.ToString(CultureInfo.InvariantCulture)),
+			new XAttribute("maximumDurationSeconds", MaximumDuration.TotalSeconds.ToString(CultureInfo.InvariantCulture)));
+	}
+}

--- a/MudSharpCore/RPG/Law/PatrolStrategies/SheriffPatrolStrategy.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/SheriffPatrolStrategy.cs
@@ -63,7 +63,9 @@ public class SheriffPatrolStrategy : PatrolStrategyBase
                 continue;
             }
 
-            if (criminal.AffectedBy<OnBail>(this) || criminal.AffectedBy<InCustodyOfEnforcer>())
+            if (criminal.AffectedBy<OnBail>(authority) ||
+                criminal.AffectedBy<InCustodyOfEnforcer>() ||
+                !authority.IsInRemandCell(criminal))
             {
                 continue;
             }

--- a/MudSharpCore/RPG/Law/PatrolStrategyFactory.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategyFactory.cs
@@ -11,6 +11,9 @@ public static class PatrolStrategyFactory
     public static IEnumerable<string> Strategies { get; } = new string[]
     {
         "ArmedPatrol",
+        "ReactivePatrol",
+        "InvestigationPatrol",
+        "CorpseRecovery",
         "StationEnforcer",
         "Judge",
         "Sheriff",
@@ -29,7 +32,17 @@ public static class PatrolStrategyFactory
         {
             case "armedpatrol":
                 return new ArmedPatrolStrategy(gameworld);
+            case "reactive":
+            case "reactivepatrol":
+            case "response":
+            case "responsepatrol":
+                return new ReactivePatrolStrategy(gameworld, strategyData);
+            case "investigation":
+            case "investigationpatrol":
+            case "investigation patrol":
+                return new InvestigationPatrolStrategy(gameworld, strategyData);
             case "corpserecovery":
+            case "corpse recovery":
                 return new CorpseRecoveryPatrolStrategy(gameworld);
             case "stationenforcer":
                 return new StationEnforcerPatrolStrategy(gameworld);


### PR DESCRIPTION
## Summary
- add reactive and investigation patrol strategies for crime-targeted law enforcement responses
- harden patrol AI, bail handling, trial custody flow, and PC judge trial support
- document the updated law runtime behaviour and add focused legal patrol/trial tests

## Validation
- dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510
- dotnet test "MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj" -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 --filter "FullyQualifiedName~LegalPatrolStrategyTests|FullyQualifiedName~LegalTrialFlowTests"
- git diff --check
- git diff --cached --check