### PR TITLE
Add automatic crime application support

### DIFF
--- a/Design Documents/Economy/Law_System_Runtime.md
+++ b/Design Documents/Economy/Law_System_Runtime.md
@@ -4,6 +4,26 @@
 
 This document records the current runtime behavior of the legal authority, sentencing, and patrol systems. It is intended as a builder-facing and implementer-facing reference for the coded law system rather than a setting-specific legal guide.
 
+## Automatic Crime Application
+
+Automatic enforcement is opt-in per law. A law only applies from coded hooks when `law auto` is enabled, the offender and victim legal-class filters pass, and the optional law prog returns true. `law repeat` controls whether repeated automatic applications against the same law, target, object, and location are suppressed for the short repeat window.
+
+Automatic crime hooks now pass a context text string to the crime record and to law progs that opt into the extended signatures. Existing law prog signatures continue to receive the crime name as their text argument. Builders can use the extended `text text` signatures to receive both the crime name and the automatic context.
+
+Currently supported automatic hooks include:
+
+- `Murder`: applied when a character dies with recent qualifying wounds from another character. Each responsible attacker is checked separately. By default the wound must be at least `Severe`, no more than `7200` real-time seconds old, have a recorded wound time, and not be a friendly-combat wound. Builders can tune this with `AutomaticMurderMinimumWoundSeverity`, `AutomaticMurderWoundAttributionWindowSeconds`, and `AutomaticMurderIncludeFriendlyWounds`. Context includes victim id, wound count, maximum wound severity, damage type, bodypart, wound age, friendly status, and whether the accused was present at the death scene.
+- `GreviousBodilyHarm`: applied when a wound caused by another character meets or exceeds `AutomaticGreviousBodilyHarmMinimumSeverity`, defaulting to `Grievous`. Context includes victim id, severity, damage type, and bodypart.
+- `Trespassing`: applied when a character enters a property cell without owner, leaseholder, tenant, hotel-room, or `PermitWork` authorisation and the property has criminal-code enforcement enabled. Context includes property and cell ids.
+- `Gambling`: applied after an arena wager validates, collects the stake, persists the bet, and credits the arena. Lawful-action protection blocks the wager before money changes hands. Context includes arena id, event id, stake, and betting model.
+- `TrafficingContraband`: applied when a character enters a legal-authority enforcement zone from outside that authority while carrying an item that satisfies a `TrafficingContraband` automatic law. The enum spelling is preserved for compatibility. Context includes item, origin cell, destination cell, and actor ids.
+
+Automatic movement hooks evaluate voluntary movers before the movement begins, so a party member with lawful-action protection can block the whole movement before they enter. Dragged movement targets are not charged for automatic entry crimes.
+
+Crime records retain the raw automatic context for administrator diagnostics. `crime info` presents non-admin judges and enforcers with a summarised automatic-evidence block instead of raw context ids, for example an automatic murder record shows the death-investigation source, wound basis, injury details, timing, scene presence, any implement, and a note that this is mechanical evidence rather than an automatic guilty verdict.
+
+Builder customisation remains data-driven: use legal authority enforcement zones for jurisdiction, property `lawful` settings and authorisations for trespass policy, the murder and grievous-wound static settings for injury thresholds, and law progs for venue, route, item, victim, offender, or circumstance-specific exceptions.
+
 ## Death Sentences
 
 Death sentences are represented by `PunishmentResult.Execution`. When multiple punishments are combined, the execution flag is preserved alongside fines, custodial sentences, and good-behaviour bonds.

--- a/FutureMUDLibrary/Framework/DefaultStaticSettings.cs
+++ b/FutureMUDLibrary/Framework/DefaultStaticSettings.cs
@@ -17,6 +17,10 @@ public static class DefaultStaticSettings
         new Dictionary<string, string>
         {
             { "CPRAllowed", "true" },
+            { "AutomaticGreviousBodilyHarmMinimumSeverity", "Grievous" },
+            { "AutomaticMurderMinimumWoundSeverity", "Severe" },
+            { "AutomaticMurderWoundAttributionWindowSeconds", "7200" },
+            { "AutomaticMurderIncludeFriendlyWounds", "false" },
             { AgricultureScoreTypeExtensions.CustomScoreConfigurationStaticConfiguration, AgricultureScoreTypeExtensions.DefaultCustomScoreConfigurationText },
             { AgriculturePlantingWindowExtensions.SeasonGroupWindowsStaticConfiguration, AgriculturePlantingWindowExtensions.DefaultSeasonGroupWindowsConfigurationText },
             { "AdvantagePerLayerSwoopAttack", "1.0"},

--- a/FutureMUDLibrary/Health/IWound.cs
+++ b/FutureMUDLibrary/Health/IWound.cs
@@ -21,6 +21,7 @@ namespace MudSharp.Health
     public interface IWound : IPerceivable
     {
         bool IsFriendlyWound { get; }
+        DateTime? RealTimeOfWound { get; }
         bool Repairable { get; }
         /// <summary>
         ///     Contains an IGameItem with the game item that is lodged in this wound. It will be null if there is no lodged

--- a/FutureMUDLibrary/RPG/Law/CrimeExtensions.cs
+++ b/FutureMUDLibrary/RPG/Law/CrimeExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using MudSharp.Character;
 using MudSharp.Commands.Trees;
+using MudSharp.Construction;
 using MudSharp.Framework;
 using MudSharp.GameItems;
 using System;
@@ -114,6 +115,20 @@ namespace MudSharp.RPG.Law
             return false;
         }
 
+        public static bool CheckWouldBeACrimeAtLocation(this CrimeTypes type, ICharacter actor, ICell location,
+            ICharacter victim = null, IGameItem target = null, string additionalInformation = "")
+        {
+            foreach (ILegalAuthority authority in actor.Gameworld.LegalAuthorities)
+            {
+                if (authority.WouldBeACrimeAtLocation(actor, type, victim, target, additionalInformation, location))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         public static void CheckPossibleCrimeAllAuthorities(ICharacter criminal, CrimeTypes crime, ICharacter victim, IGameItem item,
             string additionalInformation)
         {
@@ -129,6 +144,17 @@ namespace MudSharp.RPG.Law
             foreach (ILegalAuthority authority in criminal.Gameworld.LegalAuthorities)
             {
                 authority.CheckPossibleCrime(criminal, crime, victim, item, additionalInformation, witnesses, notifyVictim);
+            }
+        }
+
+        public static void CheckPossibleCrimeAllAuthorities(ICharacter criminal, CrimeTypes crime, ICharacter victim,
+            IGameItem item, string additionalInformation, IEnumerable<ICharacter> witnesses, bool notifyVictim,
+            ICell crimeLocation)
+        {
+            foreach (ILegalAuthority authority in criminal.Gameworld.LegalAuthorities)
+            {
+                authority.CheckPossibleCrime(criminal, crime, victim, item, additionalInformation, witnesses,
+                    notifyVictim, crimeLocation);
             }
         }
 

--- a/FutureMUDLibrary/RPG/Law/ICrime.cs
+++ b/FutureMUDLibrary/RPG/Law/ICrime.cs
@@ -29,6 +29,7 @@ namespace MudSharp.RPG.Law
         ICharacter? Victim { get; }
         long? ThirdPartyId { get; }
         string? ThirdPartyFrameworkItemType { get; }
+        string? AdditionalInformation { get; }
         IEnumerable<long> WitnessIds { get; }
         void AddWitness(long witnessId);
         bool IsKnownCrime { get; set; }

--- a/FutureMUDLibrary/RPG/Law/ILaw.cs
+++ b/FutureMUDLibrary/RPG/Law/ILaw.cs
@@ -29,6 +29,6 @@ namespace MudSharp.RPG.Law
         void Delete();
         void RemoveAllReferencesTo(ILegalClass legalClass);
         void ApplyInflation(decimal rate);
-        bool IsCrime(ICharacter criminal, ICharacter victim, IGameItem item);
+        bool IsCrime(ICharacter criminal, ICharacter victim, IGameItem item, string additionalInformation = "");
     }
 }

--- a/FutureMUDLibrary/RPG/Law/ILegalAuthority.cs
+++ b/FutureMUDLibrary/RPG/Law/ILegalAuthority.cs
@@ -53,8 +53,12 @@ namespace MudSharp.RPG.Law
         IEnumerable<ICrime> CheckPossibleCrime(ICharacter criminal, CrimeTypes crime, ICharacter victim, IGameItem item, string additionalInformation);
         IEnumerable<ICrime> CheckPossibleCrime(ICharacter criminal, CrimeTypes crime, ICharacter victim, IGameItem item,
             string additionalInformation, IEnumerable<ICharacter> witnesses, bool notifyVictim);
+        IEnumerable<ICrime> CheckPossibleCrime(ICharacter criminal, CrimeTypes crime, ICharacter victim, IGameItem item,
+            string additionalInformation, IEnumerable<ICharacter> witnesses, bool notifyVictim, ICell crimeLocation);
         bool WouldBeACrime(ICharacter criminal, CrimeTypes crime, ICharacter victim, IGameItem item,
             string additionalInformation);
+        bool WouldBeACrimeAtLocation(ICharacter criminal, CrimeTypes crime, ICharacter victim, IGameItem item,
+            string additionalInformation, ICell crimeLocation);
         ILegalClass GetLegalClass(ICharacter character);
         IEnforcementAuthority GetEnforcementAuthority(ICharacter character);
         void ReportCrime(ICrime crime, ICharacter witness, bool identityKnown, double reliability);

--- a/MudSharpCore Unit Tests/Arenas/ArenaBettingServiceTests.cs
+++ b/MudSharpCore Unit Tests/Arenas/ArenaBettingServiceTests.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using MudSharp.Accounts;
 using MudSharp.Arenas;
 using MudSharp.Character;
 using MudSharp.Database;
@@ -9,6 +10,7 @@ using MudSharp.Economy.Currency;
 using MudSharp.Framework;
 using MudSharp.Models;
 using MudSharp.PerceptionEngine;
+using MudSharp.RPG.Law;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -26,7 +28,7 @@ public class ArenaBettingServiceTests
         return new FuturemudDatabaseContext(options);
     }
 
-    private static ArenaBettingService CreateService(FuturemudDatabaseContext context, Mock<IArenaFinanceService> financeMock, Mock<IArenaBetPaymentService> paymentMock, Dictionary<long, ICharacter> characters)
+    private static ArenaBettingService CreateService(FuturemudDatabaseContext context, Mock<IArenaFinanceService> financeMock, Mock<IArenaBetPaymentService> paymentMock, Dictionary<long, ICharacter> characters, IEnumerable<ILegalAuthority>? legalAuthorities = null)
     {
         Mock<IUneditableAll<ICharacter>> charactersSet = new();
         charactersSet.Setup(x => x.Get(It.IsAny<long>())).Returns<long>(id => characters.TryGetValue(id, out ICharacter? value) ? value : null!);
@@ -36,6 +38,12 @@ public class ArenaBettingServiceTests
         Mock<IFuturemud> gameworld = new();
         gameworld.Setup(x => x.Characters).Returns(charactersSet.Object);
         gameworld.Setup(x => x.TryGetCharacter(It.IsAny<long>(), It.IsAny<bool>())).Returns<long, bool>((id, _) => characters.TryGetValue(id, out ICharacter? value) ? value : null!);
+        All<ILegalAuthority> authoritySet = new();
+        foreach (ILegalAuthority authority in legalAuthorities ?? Enumerable.Empty<ILegalAuthority>())
+        {
+            authoritySet.Add(authority);
+        }
+        gameworld.SetupGet(x => x.LegalAuthorities).Returns(authoritySet);
         return new ArenaBettingService(gameworld.Object, financeMock.Object, paymentMock.Object, () => context);
     }
 
@@ -76,6 +84,15 @@ public class ArenaBettingServiceTests
         participant.SetupGet(x => x.SideIndex).Returns(sideIndex);
         participant.SetupGet(x => x.StartingRating).Returns(startingRating);
         return participant.Object;
+    }
+
+    private static Mock<ILegalAuthority> CreateLegalAuthority(long id)
+    {
+        Mock<ILegalAuthority> authority = new();
+        authority.SetupGet(x => x.Id).Returns(id);
+        authority.SetupGet(x => x.Name).Returns($"Authority {id}");
+        authority.SetupGet(x => x.FrameworkItemType).Returns("LegalAuthority");
+        return authority;
     }
 
     private static void SeedArenaGraph(FuturemudDatabaseContext context, long arenaId, long eventTypeId, long eventId,
@@ -168,6 +185,134 @@ public class ArenaBettingServiceTests
         Assert.IsTrue(bet.FixedDecimalOdds.HasValue);
         arena.Verify(x => x.Credit(100m, It.Is<string>(s => s.Contains("stake"))), Times.Once);
         paymentMock.Verify(x => x.CollectStake(actor.Object, evt, 100m), Times.Once);
+    }
+
+    [TestMethod]
+    public void PlaceBet_GamblingCrimeConfigured_ReportsCrimeAfterSuccessfulStakeCollection()
+    {
+        using FuturemudDatabaseContext context = BuildContext();
+        Mock<IArenaFinanceService> financeMock = new();
+        Mock<IArenaBetPaymentService> paymentMock = new();
+        var stakeCollected = false;
+        paymentMock.Setup(x => x.CollectStake(It.IsAny<ICharacter>(), It.IsAny<IArenaEvent>(), It.IsAny<decimal>()))
+                   .Callback(() => stakeCollected = true)
+                   .Returns((true, string.Empty));
+        Mock<IAccount> account = new();
+        account.SetupGet(x => x.ActLawfully).Returns(false);
+        Mock<ICharacter> actor = new();
+        actor.Setup(x => x.Id).Returns(10L);
+        actor.SetupGet(x => x.Account).Returns(account.Object);
+        Dictionary<long, ICharacter> characters = new()
+        { { 10L, actor.Object } };
+        Mock<ICombatArena> arena = new();
+        arena.SetupGet(x => x.Id).Returns(77L);
+        IArenaEvent evt = BuildEvent(arena, BettingModel.FixedOdds, ArenaEventState.RegistrationOpen);
+        Mock<ILegalAuthority> authority = CreateLegalAuthority(99L);
+        authority.Setup(x => x.CheckPossibleCrime(actor.Object, CrimeTypes.Gambling, null!, null!,
+                It.Is<string>(s => s.Contains("automatic=arena-bet") && s.Contains("stake=100")),
+                null!, true))
+            .Callback(() => Assert.IsTrue(stakeCollected))
+            .Returns(Array.Empty<ICrime>());
+        ArenaBettingService service = CreateService(context, financeMock, paymentMock, characters,
+            new[] { authority.Object });
+
+        service.PlaceBet(actor.Object, evt, 0, 100m);
+
+        authority.Verify(x => x.CheckPossibleCrime(actor.Object, CrimeTypes.Gambling, null!, null!,
+            It.Is<string>(s => s.Contains("automatic=arena-bet") && s.Contains("stake=100")),
+            null!, true), Times.Once);
+        paymentMock.Verify(x => x.CollectStake(actor.Object, evt, 100m), Times.Once);
+    }
+
+    [TestMethod]
+    public void PlaceBet_StakeCollectionFails_DoesNotReportGamblingCrime()
+    {
+        using FuturemudDatabaseContext context = BuildContext();
+        Mock<IArenaFinanceService> financeMock = new();
+        Mock<IArenaBetPaymentService> paymentMock = new();
+        paymentMock.Setup(x => x.CollectStake(It.IsAny<ICharacter>(), It.IsAny<IArenaEvent>(), It.IsAny<decimal>()))
+                   .Returns((false, "no funds"));
+        Mock<ICharacter> actor = new();
+        actor.Setup(x => x.Id).Returns(10L);
+        Dictionary<long, ICharacter> characters = new()
+        { { 10L, actor.Object } };
+        Mock<ICombatArena> arena = new();
+        arena.SetupGet(x => x.Id).Returns(77L);
+        IArenaEvent evt = BuildEvent(arena, BettingModel.FixedOdds, ArenaEventState.RegistrationOpen);
+        Mock<ILegalAuthority> authority = CreateLegalAuthority(99L);
+        ArenaBettingService service = CreateService(context, financeMock, paymentMock, characters,
+            new[] { authority.Object });
+
+        Assert.ThrowsException<InvalidOperationException>(() => service.PlaceBet(actor.Object, evt, 0, 100m));
+
+        Assert.AreEqual(0, context.ArenaBets.Count());
+        authority.Verify(x => x.CheckPossibleCrime(It.IsAny<ICharacter>(), It.IsAny<CrimeTypes>(),
+            It.IsAny<ICharacter>(), It.IsAny<MudSharp.GameItems.IGameItem>(), It.IsAny<string>(),
+            It.IsAny<IEnumerable<ICharacter>>(), It.IsAny<bool>()), Times.Never);
+        arena.Verify(x => x.Credit(It.IsAny<decimal>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public void PlaceBet_InvalidSide_DoesNotCollectStakeOrReportCrime()
+    {
+        using FuturemudDatabaseContext context = BuildContext();
+        Mock<IArenaFinanceService> financeMock = new();
+        Mock<IArenaBetPaymentService> paymentMock = new();
+        Mock<ICharacter> actor = new();
+        actor.Setup(x => x.Id).Returns(10L);
+        Dictionary<long, ICharacter> characters = new()
+        { { 10L, actor.Object } };
+        Mock<ICombatArena> arena = new();
+        arena.SetupGet(x => x.Id).Returns(77L);
+        IArenaEvent evt = BuildEvent(arena, BettingModel.FixedOdds, ArenaEventState.RegistrationOpen);
+        Mock<ILegalAuthority> authority = CreateLegalAuthority(99L);
+        ArenaBettingService service = CreateService(context, financeMock, paymentMock, characters,
+            new[] { authority.Object });
+
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => service.PlaceBet(actor.Object, evt, 99, 100m));
+
+        paymentMock.Verify(x => x.CollectStake(It.IsAny<ICharacter>(), It.IsAny<IArenaEvent>(), It.IsAny<decimal>()),
+            Times.Never);
+        authority.Verify(x => x.CheckPossibleCrime(It.IsAny<ICharacter>(), It.IsAny<CrimeTypes>(),
+            It.IsAny<ICharacter>(), It.IsAny<MudSharp.GameItems.IGameItem>(), It.IsAny<string>(),
+            It.IsAny<IEnumerable<ICharacter>>(), It.IsAny<bool>()), Times.Never);
+        Assert.AreEqual(0, context.ArenaBets.Count());
+    }
+
+    [TestMethod]
+    public void PlaceBet_ActLawfullyWouldBeGamblingCrime_DoesNotCollectStake()
+    {
+        using FuturemudDatabaseContext context = BuildContext();
+        Mock<IArenaFinanceService> financeMock = new();
+        Mock<IArenaBetPaymentService> paymentMock = new();
+        Mock<IOutputHandler> outputHandler = new();
+        Mock<IAccount> account = new();
+        account.SetupGet(x => x.ActLawfully).Returns(true);
+        Mock<ICharacter> actor = new();
+        actor.Setup(x => x.Id).Returns(10L);
+        actor.SetupGet(x => x.Account).Returns(account.Object);
+        actor.SetupGet(x => x.OutputHandler).Returns(outputHandler.Object);
+        Dictionary<long, ICharacter> characters = new()
+        { { 10L, actor.Object } };
+        Mock<ICombatArena> arena = new();
+        arena.SetupGet(x => x.Id).Returns(77L);
+        IArenaEvent evt = BuildEvent(arena, BettingModel.FixedOdds, ArenaEventState.RegistrationOpen);
+        Mock<ILegalAuthority> authority = CreateLegalAuthority(99L);
+        authority.Setup(x => x.WouldBeACrime(actor.Object, CrimeTypes.Gambling, null!, null!,
+                It.IsAny<string>()))
+            .Returns(true);
+        ArenaBettingService service = CreateService(context, financeMock, paymentMock, characters,
+            new[] { authority.Object });
+
+        Assert.ThrowsException<InvalidOperationException>(() => service.PlaceBet(actor.Object, evt, 0, 100m));
+
+        paymentMock.Verify(x => x.CollectStake(It.IsAny<ICharacter>(), It.IsAny<IArenaEvent>(), It.IsAny<decimal>()),
+            Times.Never);
+        authority.Verify(x => x.CheckPossibleCrime(It.IsAny<ICharacter>(), It.IsAny<CrimeTypes>(), It.IsAny<ICharacter>(),
+            It.IsAny<MudSharp.GameItems.IGameItem>(), It.IsAny<string>(), It.IsAny<IEnumerable<ICharacter>>(),
+            It.IsAny<bool>()), Times.Never);
+        outputHandler.Verify(x => x.Send(It.Is<string>(s => s.Contains("That action would be a crime")),
+            It.IsAny<bool>(), It.IsAny<bool>()), Times.Once);
     }
 
     [TestMethod]

--- a/MudSharpCore Unit Tests/RPG/Law/AutomaticCrimeExtensionsTests.cs
+++ b/MudSharpCore Unit Tests/RPG/Law/AutomaticCrimeExtensionsTests.cs
@@ -1,0 +1,454 @@
+#nullable enable
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Accounts;
+using MudSharp.Body;
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Construction.Boundary;
+using MudSharp.Economy.Property;
+using MudSharp.Effects.Concrete;
+using MudSharp.Form.Shape;
+using MudSharp.Framework;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.Health;
+using MudSharp.PerceptionEngine;
+using MudSharp.RPG.Law;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace MudSharp_Unit_Tests.RPG.Law;
+
+[TestClass]
+public class AutomaticCrimeExtensionsTests
+{
+	[TestMethod]
+	public void CheckMurderForDeath_ResponsibleWound_ReportsMurderAtDeathLocation()
+	{
+		Mock<IFuturemud> gameworld = CreateGameworld(out Mock<ILegalAuthority> authority, out _, out _);
+		Mock<ICell> deathLocation = CreateCell(1L, CreateZone(10L).Object);
+		Mock<ICharacter> attacker = CreateCharacter(20L, gameworld.Object, deathLocation.Object);
+		Mock<ICharacter> victim = CreateCharacter(30L, gameworld.Object, deathLocation.Object);
+		Mock<IGameItem> weapon = CreateItem(40L, "knife");
+		Mock<IWound> wound = new();
+		wound.SetupGet(x => x.ActorOrigin).Returns(attacker.Object);
+		wound.SetupGet(x => x.ToolOrigin).Returns(weapon.Object);
+		wound.SetupGet(x => x.Severity).Returns(WoundSeverity.Horrifying);
+		wound.SetupGet(x => x.DamageType).Returns(DamageType.Piercing);
+		wound.SetupGet(x => x.RealTimeOfWound).Returns(DateTime.UtcNow.AddMinutes(-5));
+		wound.SetupGet(x => x.IsFriendlyWound).Returns(false);
+		Mock<IBody> body = new();
+		body.SetupGet(x => x.Wounds).Returns(new[] { wound.Object });
+		victim.SetupGet(x => x.Body).Returns(body.Object);
+
+		AutomaticCrimeExtensions.CheckMurderForDeath(victim.Object);
+
+		authority.Verify(x => x.CheckPossibleCrime(attacker.Object, CrimeTypes.Murder, victim.Object, weapon.Object,
+			It.Is<string>(s => s.Contains("automatic=death") && s.Contains("maxseverity=Horrifying")),
+			It.IsAny<IEnumerable<ICharacter>>(), false, deathLocation.Object), Times.Once);
+	}
+
+	[TestMethod]
+	public void CheckMurderForDeath_FriendlyWound_DoesNotReportMurderByDefault()
+	{
+		Mock<IFuturemud> gameworld = CreateGameworld(out Mock<ILegalAuthority> authority, out _, out _);
+		Mock<ICell> deathLocation = CreateCell(1L, CreateZone(10L).Object);
+		Mock<ICharacter> attacker = CreateCharacter(20L, gameworld.Object, deathLocation.Object);
+		Mock<ICharacter> victim = CreateCharacter(30L, gameworld.Object, deathLocation.Object);
+		Mock<IWound> wound = CreateMurderWound(attacker.Object, null!, WoundSeverity.Horrifying,
+			DateTime.UtcNow.AddMinutes(-5), true);
+		Mock<IBody> body = new();
+		body.SetupGet(x => x.Wounds).Returns(new[] { wound.Object });
+		victim.SetupGet(x => x.Body).Returns(body.Object);
+
+		AutomaticCrimeExtensions.CheckMurderForDeath(victim.Object);
+
+		authority.Verify(x => x.CheckPossibleCrime(It.IsAny<ICharacter>(), CrimeTypes.Murder,
+			It.IsAny<ICharacter>(), It.IsAny<IGameItem>(), It.IsAny<string>(),
+			It.IsAny<IEnumerable<ICharacter>>(), It.IsAny<bool>(), It.IsAny<ICell>()), Times.Never);
+	}
+
+	[TestMethod]
+	public void CheckMurderForDeath_OldWound_DoesNotReportMurder()
+	{
+		Mock<IFuturemud> gameworld = CreateGameworld(out Mock<ILegalAuthority> authority, out _, out _);
+		Mock<ICell> deathLocation = CreateCell(1L, CreateZone(10L).Object);
+		Mock<ICharacter> attacker = CreateCharacter(20L, gameworld.Object, deathLocation.Object);
+		Mock<ICharacter> victim = CreateCharacter(30L, gameworld.Object, deathLocation.Object);
+		Mock<IWound> wound = CreateMurderWound(attacker.Object, null!, WoundSeverity.Horrifying,
+			DateTime.UtcNow.AddHours(-3), false);
+		Mock<IBody> body = new();
+		body.SetupGet(x => x.Wounds).Returns(new[] { wound.Object });
+		victim.SetupGet(x => x.Body).Returns(body.Object);
+
+		AutomaticCrimeExtensions.CheckMurderForDeath(victim.Object);
+
+		authority.Verify(x => x.CheckPossibleCrime(It.IsAny<ICharacter>(), CrimeTypes.Murder,
+			It.IsAny<ICharacter>(), It.IsAny<IGameItem>(), It.IsAny<string>(),
+			It.IsAny<IEnumerable<ICharacter>>(), It.IsAny<bool>(), It.IsAny<ICell>()), Times.Never);
+	}
+
+	[TestMethod]
+	public void CheckMurderForDeath_UnknownWoundTime_DoesNotReportMurder()
+	{
+		Mock<IFuturemud> gameworld = CreateGameworld(out Mock<ILegalAuthority> authority, out _, out _);
+		Mock<ICell> deathLocation = CreateCell(1L, CreateZone(10L).Object);
+		Mock<ICharacter> attacker = CreateCharacter(20L, gameworld.Object, deathLocation.Object);
+		Mock<ICharacter> victim = CreateCharacter(30L, gameworld.Object, deathLocation.Object);
+		Mock<IWound> wound = CreateMurderWound(attacker.Object, null!, WoundSeverity.Horrifying, null, false);
+		Mock<IBody> body = new();
+		body.SetupGet(x => x.Wounds).Returns(new[] { wound.Object });
+		victim.SetupGet(x => x.Body).Returns(body.Object);
+
+		AutomaticCrimeExtensions.CheckMurderForDeath(victim.Object);
+
+		authority.Verify(x => x.CheckPossibleCrime(It.IsAny<ICharacter>(), CrimeTypes.Murder,
+			It.IsAny<ICharacter>(), It.IsAny<IGameItem>(), It.IsAny<string>(),
+			It.IsAny<IEnumerable<ICharacter>>(), It.IsAny<bool>(), It.IsAny<ICell>()), Times.Never);
+	}
+
+	[TestMethod]
+	public void CheckMurderForDeath_BelowConfiguredSeverity_DoesNotReportMurder()
+	{
+		Mock<IFuturemud> gameworld = CreateGameworld(out Mock<ILegalAuthority> authority, out _, out _);
+		Mock<ICell> deathLocation = CreateCell(1L, CreateZone(10L).Object);
+		Mock<ICharacter> attacker = CreateCharacter(20L, gameworld.Object, deathLocation.Object);
+		Mock<ICharacter> victim = CreateCharacter(30L, gameworld.Object, deathLocation.Object);
+		Mock<IWound> wound = CreateMurderWound(attacker.Object, null!, WoundSeverity.Moderate,
+			DateTime.UtcNow.AddMinutes(-5), false);
+		Mock<IBody> body = new();
+		body.SetupGet(x => x.Wounds).Returns(new[] { wound.Object });
+		victim.SetupGet(x => x.Body).Returns(body.Object);
+
+		AutomaticCrimeExtensions.CheckMurderForDeath(victim.Object);
+
+		authority.Verify(x => x.CheckPossibleCrime(It.IsAny<ICharacter>(), CrimeTypes.Murder,
+			It.IsAny<ICharacter>(), It.IsAny<IGameItem>(), It.IsAny<string>(),
+			It.IsAny<IEnumerable<ICharacter>>(), It.IsAny<bool>(), It.IsAny<ICell>()), Times.Never);
+	}
+
+	[TestMethod]
+	public void CheckMurderForDeath_AttackerAbsent_DoesNotPassDeathWitnesses()
+	{
+		Mock<IFuturemud> gameworld = CreateGameworld(out Mock<ILegalAuthority> authority, out _, out _);
+		Mock<ICell> deathLocation = CreateCell(1L, CreateZone(10L).Object);
+		Mock<ICharacter> attacker = CreateCharacter(20L, gameworld.Object, deathLocation.Object);
+		Mock<ICharacter> victim = CreateCharacter(30L, gameworld.Object, deathLocation.Object);
+		Mock<ICharacter> witness = CreateCharacter(40L, gameworld.Object, deathLocation.Object);
+		witness.Setup(x => x.CanSee(victim.Object)).Returns(true);
+		deathLocation.Setup(x => x.LayerCharacters(RoomLayer.GroundLevel)).Returns(new[] { witness.Object });
+		Mock<IWound> wound = CreateMurderWound(attacker.Object, null!, WoundSeverity.Horrifying,
+			DateTime.UtcNow.AddMinutes(-5), false);
+		Mock<IBody> body = new();
+		body.SetupGet(x => x.Wounds).Returns(new[] { wound.Object });
+		victim.SetupGet(x => x.Body).Returns(body.Object);
+
+		AutomaticCrimeExtensions.CheckMurderForDeath(victim.Object);
+
+		authority.Verify(x => x.CheckPossibleCrime(attacker.Object, CrimeTypes.Murder, victim.Object, null!,
+			It.Is<string>(s => s.Contains("automatic=death") && s.Contains("attackerpresent=false")),
+			It.Is<IEnumerable<ICharacter>>(w => !w.Any()), false, deathLocation.Object), Times.Once);
+	}
+
+	[TestMethod]
+	public void AutomaticCrimeContext_DeathEvidenceForPcJudge_HidesRawContext()
+	{
+		Mock<ICharacter> enforcer = new();
+		enforcer.Setup(x => x.IsAdministrator(It.IsAny<PermissionLevel>())).Returns(false);
+		var output = AutomaticCrimeContext.DescribeForCrimeInfo(
+			"automatic=death; victim=#30; wounds=1; maxseverity=Severe; damagetype=Piercing; bodypart=left arm; woundage=5 minutes; friendly=false; attackerpresent=true",
+			enforcer.Object, null, false);
+
+		StringAssert.Contains(output, "Automatic death investigation");
+		StringAssert.Contains(output, "recent non-friendly wound");
+		StringAssert.Contains(output, "left arm");
+		Assert.IsFalse(output.Contains("automatic=death"));
+		Assert.IsFalse(output.Contains("victim=#30"));
+		Assert.IsFalse(output.Contains("Raw Context"));
+	}
+
+	[TestMethod]
+	public void CrimeConstructor_ExplicitLocation_DerivesMudTimeFromCrimeLocation()
+	{
+		var crime = File.ReadAllText(GetSourcePath("MudSharpCore", "RPG", "Law", "Crime.cs"));
+		var constructorStart = crime.IndexOf(
+			"public Crime(ICharacter criminal, ICharacter? victim, IEnumerable<ICharacter> witnesses, ILaw law",
+			StringComparison.Ordinal);
+		var constructorEnd = crime.IndexOf("Gameworld.SaveManager.AddInitialisation(this);", constructorStart,
+			StringComparison.Ordinal);
+		Assert.IsTrue(constructorStart > 0);
+		Assert.IsTrue(constructorEnd > constructorStart);
+
+		var constructor = crime[constructorStart..constructorEnd];
+		StringAssert.Contains(constructor, "var resolvedCrimeLocation = crimeLocation ?? criminal.Location;");
+		StringAssert.Contains(constructor, "TimeOfCrime = resolvedCrimeLocation.DateTime();");
+		StringAssert.Contains(constructor, "CrimeLocation = resolvedCrimeLocation;");
+	}
+
+	[TestMethod]
+	public void SimpleWoundDatabaseInsert_PersistsFriendlyWoundExtras()
+	{
+		var simpleWound = File.ReadAllText(GetSourcePath("MudSharpCore", "Health", "Wounds", "SimpleWound.cs"));
+		var insertStart = simpleWound.IndexOf("public override object DatabaseInsert()", StringComparison.Ordinal);
+		var insertEnd = simpleWound.IndexOf("return dbitem;", insertStart, StringComparison.Ordinal);
+		Assert.IsTrue(insertStart > 0);
+		Assert.IsTrue(insertEnd > insertStart);
+
+		var insert = simpleWound[insertStart..insertEnd];
+		StringAssert.Contains(insert, "dbitem.ExtraInformation = SaveExtras();");
+	}
+
+	[TestMethod]
+	public void CheckGreviousBodilyHarmForWound_ConfiguredSeverity_ReportsCrime()
+	{
+		Mock<IFuturemud> gameworld = CreateGameworld(out Mock<ILegalAuthority> authority, out _, out _);
+		gameworld.Setup(x => x.GetStaticConfiguration(AutomaticCrimeExtensions.GreviousBodilyHarmMinimumSeveritySetting))
+		         .Returns("Grievous");
+		Mock<ICell> location = CreateCell(1L, CreateZone(10L).Object);
+		Mock<ICharacter> attacker = CreateCharacter(20L, gameworld.Object, location.Object);
+		Mock<ICharacter> victim = CreateCharacter(30L, gameworld.Object, location.Object);
+		Mock<IGameItem> weapon = CreateItem(40L, "club");
+		Mock<IWound> wound = new();
+		wound.SetupGet(x => x.Parent).Returns(victim.Object);
+		wound.SetupGet(x => x.ActorOrigin).Returns(attacker.Object);
+		wound.SetupGet(x => x.ToolOrigin).Returns(weapon.Object);
+		wound.SetupGet(x => x.Severity).Returns(WoundSeverity.Grievous);
+		wound.SetupGet(x => x.DamageType).Returns(DamageType.Crushing);
+
+		AutomaticCrimeExtensions.CheckGreviousBodilyHarmForWound(wound.Object);
+
+		authority.Verify(x => x.CheckPossibleCrime(attacker.Object, CrimeTypes.GreviousBodilyHarm, victim.Object,
+			weapon.Object, It.Is<string>(s => s.Contains("automatic=wound") && s.Contains("severity=Grievous")),
+			null!, true, location.Object), Times.Once);
+	}
+
+	[TestMethod]
+	public void CheckLawfulMovement_TrespassingWouldBeCrime_BlocksMovement()
+	{
+		Mock<IFuturemud> gameworld = CreateGameworld(out Mock<ILegalAuthority> authority, out All<IProperty> properties,
+			out _);
+		Mock<IZone> zone = CreateZone(10L);
+		Mock<ICell> origin = CreateCell(1L, zone.Object);
+		Mock<ICell> destination = CreateCell(2L, zone.Object);
+		Mock<ICellExit> exit = CreateExit(origin.Object, destination.Object);
+		Mock<IProperty> property = CreateProperty(50L, "Warehouse", destination.Object);
+		properties.Add(property.Object);
+		Mock<IAccount> account = new();
+		account.SetupGet(x => x.ActLawfully).Returns(true);
+		Mock<IOutputHandler> output = new();
+		Mock<ICharacter> actor = CreateCharacter(20L, gameworld.Object, origin.Object);
+		actor.SetupGet(x => x.Account).Returns(account.Object);
+		actor.SetupGet(x => x.OutputHandler).Returns(output.Object);
+		authority.Setup(x => x.WouldBeACrimeAtLocation(actor.Object, CrimeTypes.Trespassing, null!, null!,
+				It.Is<string>(s => s.Contains("automatic=property-entry")), destination.Object))
+			.Returns(true);
+
+		var blocked = AutomaticCrimeExtensions.CheckLawfulMovement(actor.Object, exit.Object);
+
+		Assert.IsTrue(blocked);
+		output.Verify(x => x.Send(It.Is<string>(s => s.Contains("That movement would be a crime")),
+			It.IsAny<bool>(), It.IsAny<bool>()), Times.Once);
+	}
+
+	[TestMethod]
+	public void CheckLawfulMovement_LawfulFollowerWouldTrespass_BlocksWholeMovement()
+	{
+		Mock<IFuturemud> gameworld = CreateGameworld(out Mock<ILegalAuthority> authority, out All<IProperty> properties,
+			out _);
+		Mock<IZone> zone = CreateZone(10L);
+		Mock<ICell> origin = CreateCell(1L, zone.Object);
+		Mock<ICell> destination = CreateCell(2L, zone.Object);
+		Mock<ICellExit> exit = CreateExit(origin.Object, destination.Object);
+		Mock<IProperty> property = CreateProperty(50L, "Warehouse", destination.Object);
+		properties.Add(property.Object);
+		Mock<IAccount> followerAccount = new();
+		followerAccount.SetupGet(x => x.ActLawfully).Returns(true);
+		Mock<IOutputHandler> leaderOutput = new();
+		Mock<IOutputHandler> followerOutput = new();
+		Mock<ICharacter> leader = CreateCharacter(20L, gameworld.Object, origin.Object);
+		leader.SetupGet(x => x.OutputHandler).Returns(leaderOutput.Object);
+		Mock<ICharacter> follower = CreateCharacter(21L, gameworld.Object, origin.Object);
+		follower.SetupGet(x => x.Account).Returns(followerAccount.Object);
+		follower.SetupGet(x => x.OutputHandler).Returns(followerOutput.Object);
+		follower.Setup(x => x.HowSeen(leader.Object, true, DescriptionType.Short, true, PerceiveIgnoreFlags.None))
+		        .Returns("Follower");
+		authority.Setup(x => x.WouldBeACrimeAtLocation(follower.Object, CrimeTypes.Trespassing, null!, null!,
+				It.Is<string>(s => s.Contains("automatic=property-entry")), destination.Object))
+			.Returns(true);
+
+		var blocked = AutomaticCrimeExtensions.CheckLawfulMovement(new[] { leader.Object, follower.Object }, exit.Object,
+			leader.Object);
+
+		Assert.IsTrue(blocked);
+		followerOutput.Verify(x => x.Send(It.Is<string>(s => s.Contains("That movement would be a crime")),
+			It.IsAny<bool>(), It.IsAny<bool>()), Times.Once);
+		leaderOutput.Verify(x => x.Send(It.Is<string>(s => s.Contains("refuses to move")),
+			It.IsAny<bool>(), It.IsAny<bool>()), Times.Once);
+	}
+
+	[TestMethod]
+	public void CheckLocationEntryCrimes_ContrabandBoundary_ReportsTrafficking()
+	{
+		Mock<IFuturemud> gameworld = CreateGameworld(out Mock<ILegalAuthority> authority, out _, out _);
+		Mock<IZone> originZone = CreateZone(10L);
+		Mock<IZone> destinationZone = CreateZone(11L);
+		Mock<ICell> origin = CreateCell(1L, originZone.Object);
+		Mock<ICell> destination = CreateCell(2L, destinationZone.Object);
+		Mock<ICellExit> exit = CreateExit(origin.Object, destination.Object);
+		authority.SetupGet(x => x.EnforcementZones).Returns(new[] { destinationZone.Object });
+		Mock<ICharacter> actor = CreateCharacter(20L, gameworld.Object, destination.Object);
+		Mock<IGameItem> contraband = CreateItem(40L, "contraband");
+		actor.SetupGet(x => x.Inventory).Returns(new[] { contraband.Object });
+		authority.Setup(x => x.WouldBeACrimeAtLocation(actor.Object, CrimeTypes.TrafficingContraband, null!,
+				contraband.Object, It.Is<string>(s => s.Contains("automatic=contraband-boundary")), destination.Object))
+			.Returns(true);
+
+		AutomaticCrimeExtensions.CheckLocationEntryCrimes(actor.Object, destination.Object, exit.Object);
+
+		authority.Verify(x => x.CheckPossibleCrime(actor.Object, CrimeTypes.TrafficingContraband, null!,
+			contraband.Object, It.Is<string>(s => s.Contains("automatic=contraband-boundary")),
+			null!, true, destination.Object), Times.Once);
+	}
+
+	[TestMethod]
+	public void CheckLocationEntryCrimes_DraggedMovementTarget_DoesNotReportEntryCrime()
+	{
+		Mock<IFuturemud> gameworld = CreateGameworld(out Mock<ILegalAuthority> authority, out All<IProperty> properties,
+			out _);
+		Mock<IZone> zone = CreateZone(10L);
+		Mock<ICell> origin = CreateCell(1L, zone.Object);
+		Mock<ICell> destination = CreateCell(2L, zone.Object);
+		Mock<ICellExit> exit = CreateExit(origin.Object, destination.Object);
+		Mock<IProperty> property = CreateProperty(50L, "Warehouse", destination.Object);
+		properties.Add(property.Object);
+		Mock<ICharacter> actor = CreateCharacter(20L, gameworld.Object, destination.Object);
+
+		AutomaticCrimeExtensions.CheckLocationEntryCrimes(actor.Object, destination.Object, exit.Object, false);
+
+		authority.Verify(x => x.CheckPossibleCrime(It.IsAny<ICharacter>(), It.IsAny<CrimeTypes>(),
+			It.IsAny<ICharacter>(), It.IsAny<IGameItem>(), It.IsAny<string>(), It.IsAny<IEnumerable<ICharacter>>(),
+			It.IsAny<bool>(), It.IsAny<ICell>()), Times.Never);
+		authority.Verify(x => x.WouldBeACrimeAtLocation(It.IsAny<ICharacter>(), It.IsAny<CrimeTypes>(),
+			It.IsAny<ICharacter>(), It.IsAny<IGameItem>(), It.IsAny<string>(), It.IsAny<ICell>()), Times.Never);
+	}
+
+	private static Mock<IFuturemud> CreateGameworld(out Mock<ILegalAuthority> authority,
+		out All<IProperty> properties, out All<ILegalAuthority> authorities)
+	{
+		authority = new Mock<ILegalAuthority>();
+		authority.SetupGet(x => x.Id).Returns(100L);
+		authority.SetupGet(x => x.Name).Returns("Test Authority");
+		authority.SetupGet(x => x.FrameworkItemType).Returns("LegalAuthority");
+		authority.SetupGet(x => x.EnforcementZones).Returns(Array.Empty<IZone>());
+		authority.Setup(x => x.CheckPossibleCrime(It.IsAny<ICharacter>(), It.IsAny<CrimeTypes>(),
+				It.IsAny<ICharacter>(), It.IsAny<IGameItem>(), It.IsAny<string>(), It.IsAny<IEnumerable<ICharacter>>(),
+				It.IsAny<bool>(), It.IsAny<ICell>()))
+			.Returns(Array.Empty<ICrime>());
+		authorities = new All<ILegalAuthority>();
+		authorities.Add(authority.Object);
+		properties = new All<IProperty>();
+		Mock<IFuturemud> gameworld = new();
+		gameworld.SetupGet(x => x.LegalAuthorities).Returns(authorities);
+		gameworld.SetupGet(x => x.Properties).Returns(properties);
+		gameworld.Setup(x => x.GetStaticConfiguration(It.IsAny<string>())).Returns<string>(key => key switch
+		{
+			AutomaticCrimeExtensions.GreviousBodilyHarmMinimumSeveritySetting => "Grievous",
+			AutomaticCrimeExtensions.MurderMinimumSeveritySetting => "Severe",
+			AutomaticCrimeExtensions.MurderWoundAttributionWindowSecondsSetting => "7200",
+			AutomaticCrimeExtensions.MurderIncludeFriendlyWoundsSetting => "false",
+			_ => "0"
+		});
+		return gameworld;
+	}
+
+	private static Mock<IWound> CreateMurderWound(ICharacter attacker, IGameItem weapon, WoundSeverity severity,
+		DateTime? realTimeOfWound, bool isFriendly)
+	{
+		Mock<IWound> wound = new();
+		wound.SetupGet(x => x.ActorOrigin).Returns(attacker);
+		wound.SetupGet(x => x.ToolOrigin).Returns(weapon);
+		wound.SetupGet(x => x.Severity).Returns(severity);
+		wound.SetupGet(x => x.DamageType).Returns(DamageType.Piercing);
+		wound.SetupGet(x => x.RealTimeOfWound).Returns(realTimeOfWound);
+		wound.SetupGet(x => x.IsFriendlyWound).Returns(isFriendly);
+		return wound;
+	}
+
+	private static Mock<ICharacter> CreateCharacter(long id, IFuturemud gameworld, ICell location)
+	{
+		Mock<ICharacter> character = new();
+		character.SetupGet(x => x.Id).Returns(id);
+		character.SetupGet(x => x.Name).Returns($"Character {id}");
+		character.SetupGet(x => x.FrameworkItemType).Returns("Character");
+		character.SetupGet(x => x.Gameworld).Returns(gameworld);
+		character.SetupGet(x => x.Location).Returns(location);
+		character.SetupGet(x => x.RoomLayer).Returns(RoomLayer.GroundLevel);
+		character.Setup(x => x.IsAdministrator(It.IsAny<PermissionLevel>())).Returns(false);
+		character.Setup(x => x.AffectedBy(It.IsAny<Predicate<PermitWork>>())).Returns(false);
+		return character;
+	}
+
+	private static Mock<ICell> CreateCell(long id, IZone zone)
+	{
+		Mock<ICell> cell = new();
+		cell.SetupGet(x => x.Id).Returns(id);
+		cell.SetupGet(x => x.Name).Returns($"Cell {id}");
+		cell.SetupGet(x => x.FrameworkItemType).Returns("Cell");
+		cell.SetupGet(x => x.Zone).Returns(zone);
+		cell.Setup(x => x.LayerCharacters(It.IsAny<RoomLayer>())).Returns(Array.Empty<ICharacter>());
+		return cell;
+	}
+
+	private static Mock<IZone> CreateZone(long id)
+	{
+		Mock<IZone> zone = new();
+		zone.SetupGet(x => x.Id).Returns(id);
+		zone.SetupGet(x => x.Name).Returns($"Zone {id}");
+		zone.SetupGet(x => x.FrameworkItemType).Returns("Zone");
+		return zone;
+	}
+
+	private static Mock<ICellExit> CreateExit(ICell origin, ICell destination)
+	{
+		Mock<ICellExit> exit = new();
+		exit.SetupGet(x => x.Origin).Returns(origin);
+		exit.SetupGet(x => x.Destination).Returns(destination);
+		return exit;
+	}
+
+	private static Mock<IProperty> CreateProperty(long id, string name, ICell location)
+	{
+		Mock<IProperty> property = new();
+		property.SetupGet(x => x.Id).Returns(id);
+		property.SetupGet(x => x.Name).Returns(name);
+		property.SetupGet(x => x.FrameworkItemType).Returns("Property");
+		property.SetupGet(x => x.ApplyCriminalCodeInProperty).Returns(true);
+		property.SetupGet(x => x.PropertyLocations).Returns(new[] { location });
+		property.Setup(x => x.HotelRoomForCell(It.IsAny<ICell>())).Returns((IHotelRoom)null!);
+		return property;
+	}
+
+	private static Mock<IGameItem> CreateItem(long id, string name)
+	{
+		Mock<IGameItem> item = new();
+		item.SetupGet(x => x.Id).Returns(id);
+		item.SetupGet(x => x.Name).Returns(name);
+		item.SetupGet(x => x.FrameworkItemType).Returns("Item");
+		item.Setup(x => x.GetItemType<IContainer>()).Returns((IContainer)null!);
+		return item;
+	}
+
+	private static string GetSourcePath(params string[] parts)
+	{
+		return Path.GetFullPath(Path.Combine(
+			AppContext.BaseDirectory,
+			"..",
+			"..",
+			"..",
+			"..",
+			Path.Combine(parts)));
+	}
+}

--- a/MudSharpCore/Arenas/Betting/ArenaBettingService.cs
+++ b/MudSharpCore/Arenas/Betting/ArenaBettingService.cs
@@ -5,6 +5,7 @@ using MudSharp.Database;
 using MudSharp.Economy.Currency;
 using MudSharp.Framework;
 using MudSharp.Models;
+using MudSharp.RPG.Law;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -88,16 +89,26 @@ public class ArenaBettingService : IArenaBettingService
             throw new InvalidOperationException(reason);
         }
 
-        (bool Success, string Error) stakeResult = _paymentService.CollectStake(actor, arenaEvent, stake);
-        if (!stakeResult.Success)
-        {
-            throw new InvalidOperationException(stakeResult.Error);
-        }
-
         BettingModel bettingModel = arenaEvent.EventType.BettingModel;
         if (sideIndex.HasValue && arenaEvent.EventType.Sides.All(x => x.Index != sideIndex.Value))
         {
             throw new ArgumentOutOfRangeException(nameof(sideIndex));
+        }
+
+        var crimeContext =
+            $"automatic=arena-bet; arena=#{arenaEvent.Arena.Id}; event=#{arenaEvent.Id}; stake={stake}; model={arenaEvent.EventType.BettingModel.DescribeEnum()}";
+        if (actor.Account?.ActLawfully == true &&
+            AutomaticCrimeExtensions.CheckWouldBeACrime(_gameworld, actor, CrimeTypes.Gambling, null, null,
+                crimeContext))
+        {
+            actor.OutputHandler.Send($"That action would be a crime.\n{CrimeExtensions.StandardDisableIllegalFlagText}");
+            throw new InvalidOperationException("That wager would be a crime.");
+        }
+
+        (bool Success, string Error) stakeResult = _paymentService.CollectStake(actor, arenaEvent, stake);
+        if (!stakeResult.Success)
+        {
+            throw new InvalidOperationException(stakeResult.Error);
         }
 
         using IDisposable? scope = BeginContext(out FuturemudDatabaseContext? context);
@@ -145,6 +156,7 @@ public class ArenaBettingService : IArenaBettingService
         context.SaveChanges();
 
         arenaEvent.Arena.Credit(stake, $"Arena bet stake for event #{arenaEvent.Id}");
+        AutomaticCrimeExtensions.CheckPossibleCrime(_gameworld, actor, CrimeTypes.Gambling, null, null, crimeContext);
     }
 
     /// <inheritdoc />

--- a/MudSharpCore/Character/CharacterHealth.cs
+++ b/MudSharpCore/Character/CharacterHealth.cs
@@ -22,6 +22,7 @@ using MudSharp.PerceptionEngine;
 using MudSharp.PerceptionEngine.Handlers;
 using MudSharp.PerceptionEngine.Outputs;
 using MudSharp.PerceptionEngine.Parsers;
+using MudSharp.RPG.Law;
 using MudSharp.TimeAndDate.Date;
 using MudSharp.TimeAndDate.Time;
 using System;
@@ -51,6 +52,8 @@ public partial class Character
         {
             return backupRemains;
         }
+
+        AutomaticCrimeExtensions.CheckMurderForDeath(this);
 
         IBoard deathBoard = Gameworld.Boards.Get(Gameworld.GetStaticLong("DeathsBoardId"));
         if (deathBoard != null)

--- a/MudSharpCore/Construction/Cell.cs
+++ b/MudSharpCore/Construction/Cell.cs
@@ -36,6 +36,7 @@ using MudSharp.PerceptionEngine;
 using MudSharp.PerceptionEngine.Outputs;
 using MudSharp.PerceptionEngine.Parsers;
 using MudSharp.RPG.Checks;
+using MudSharp.RPG.Law;
 using MudSharp.TimeAndDate.Date;
 using MudSharp.TimeAndDate.Time;
 using MudSharp.Work.Agriculture;
@@ -690,6 +691,13 @@ public partial class Cell : Location, IDisposable, ICell
         {
             witness.HandleEvent(EventType.CharacterEnterCellWitness, movingCharacter, this,
                 movingCharacter.Movement?.Exit, witness);
+        }
+
+        if (exit is not null && !noSave)
+        {
+            var isDraggedMovementTarget = movingCharacter.Movement?.Targets.Contains(movingCharacter) == true;
+            AutomaticCrimeExtensions.CheckLocationEntryCrimes(movingCharacter, this, exit,
+                !isDraggedMovementTarget);
         }
 
         CheckFallExitStatus();

--- a/MudSharpCore/Health/WoundExtensions.cs
+++ b/MudSharpCore/Health/WoundExtensions.cs
@@ -7,6 +7,7 @@ using MudSharp.GameItems;
 using MudSharp.PerceptionEngine;
 using MudSharp.PerceptionEngine.Outputs;
 using MudSharp.PerceptionEngine.Parsers;
+using MudSharp.RPG.Law;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -60,6 +61,7 @@ public static class WoundExtensions
             }
 
             wound.Parent.ProcessPassiveWound(wound);
+            AutomaticCrimeExtensions.CheckGreviousBodilyHarmForWound(wound);
         }
 
         foreach (IMortalPerceiver parent in parents)

--- a/MudSharpCore/Health/Wounds/BoneFracture.cs
+++ b/MudSharpCore/Health/Wounds/BoneFracture.cs
@@ -79,6 +79,7 @@ public class BoneFracture : PerceivedItem, IImmobilisableWound
         Bodypart = bodypart;
         _actorOriginId = actorOrigin?.Id ?? 0;
         _toolOriginId = toolOrigin?.Id ?? 0;
+        RealTimeOfWound = DateTime.UtcNow;
         if (actorOrigin?.Combat?.Friendly == true)
         {
             IsFriendlyWound = true;
@@ -100,6 +101,7 @@ public class BoneFracture : PerceivedItem, IImmobilisableWound
         Bodypart = Gameworld.BodypartPrototypes.Get(wound.BodypartProtoId ?? 0);
         _actorOriginId = wound.ActorOriginId ?? 0;
         _toolOriginId = wound.ToolOriginId ?? 0;
+        RealTimeOfWound = wound.RealTimeOfWound;
 
         XElement root = XElement.Parse(wound.ExtraInformation);
         XElement element = root.Element("Stage");
@@ -386,6 +388,7 @@ public class BoneFracture : PerceivedItem, IImmobilisableWound
         dbitem.LodgedItemId = Lodged?.Id;
         dbitem.ActorOriginId = _actorOriginId != 0 ? _actorOriginId : default(long?);
         dbitem.ToolOriginId = _toolOriginId != 0 ? _toolOriginId : default(long?);
+        dbitem.RealTimeOfWound = RealTimeOfWound;
         dbitem.ExtraInformation = SaveExtras();
         return dbitem;
     }
@@ -1422,6 +1425,7 @@ public class BoneFracture : PerceivedItem, IImmobilisableWound
     }
 
     public bool IsFriendlyWound { get; protected set; }
+    public DateTime? RealTimeOfWound { get; protected set; }
 
     #endregion
 }

--- a/MudSharpCore/Health/Wounds/HealingSimpleWound.cs
+++ b/MudSharpCore/Health/Wounds/HealingSimpleWound.cs
@@ -60,6 +60,7 @@ public class HealingSimpleWound : PerceivedItem, IWound
         _lodged = lodged;
         _actorOriginId = actorOrigin?.Id ?? 0;
         _toolOriginId = toolOrigin?.Id ?? 0;
+        RealTimeOfWound = DateTime.UtcNow;
         BleedStatus = BleedStatus.NeverBled;
         if (actorOrigin?.Combat?.Friendly == true)
         {
@@ -370,6 +371,7 @@ public class HealingSimpleWound : PerceivedItem, IWound
         dbitem.LodgedItemId = Lodged?.Id;
         dbitem.ActorOriginId = _actorOriginId != 0 ? _actorOriginId : default(long?);
         dbitem.ToolOriginId = _toolOriginId != 0 ? _toolOriginId : default(long?);
+        dbitem.RealTimeOfWound = RealTimeOfWound;
         dbitem.ExtraInformation = SaveExtras();
         return dbitem;
     }
@@ -397,6 +399,7 @@ public class HealingSimpleWound : PerceivedItem, IWound
 
         _actorOriginId = wound.ActorOriginId ?? 0;
         _toolOriginId = wound.ToolOriginId ?? 0;
+        RealTimeOfWound = wound.RealTimeOfWound;
         XElement root = XElement.Parse(wound.ExtraInformation ?? "<Empty/>");
         IsFriendlyWound = bool.Parse(root.Element("IsFriendlyWound")?.Value ?? "false");
         if (int.TryParse(root.Element("ScarSurgicalProcedureType")?.Value, out int scarSurgeryType) &&
@@ -411,6 +414,7 @@ public class HealingSimpleWound : PerceivedItem, IWound
     #region IWound Members
 
     public bool IsFriendlyWound { get; protected set; }
+    public DateTime? RealTimeOfWound { get; protected set; }
 
     public void SetNewOwner(IHaveWounds newOwner)
     {

--- a/MudSharpCore/Health/Wounds/RobotWound.cs
+++ b/MudSharpCore/Health/Wounds/RobotWound.cs
@@ -57,6 +57,7 @@ public class RobotWound : PerceivedItem, IWound
         Lodged = lodged;
         _toolOriginId = toolOrigin?.Id ?? 0;
         _actorOriginId = actorOrigin?.Id ?? 0;
+        RealTimeOfWound = DateTime.UtcNow;
         if (actorOrigin?.Combat?.Friendly == true)
         {
             IsFriendlyWound = true;
@@ -128,6 +129,7 @@ public class RobotWound : PerceivedItem, IWound
         dbitem.LodgedItemId = Lodged?.Id;
         dbitem.ActorOriginId = _actorOriginId != 0 ? _actorOriginId : default(long?);
         dbitem.ToolOriginId = _toolOriginId != 0 ? _toolOriginId : default(long?);
+        dbitem.RealTimeOfWound = RealTimeOfWound;
         dbitem.ExtraInformation = SaveExtras();
         return dbitem;
     }
@@ -156,6 +158,7 @@ public class RobotWound : PerceivedItem, IWound
 
         _actorOriginId = wound.ActorOriginId ?? 0;
         _toolOriginId = wound.ToolOriginId ?? 0;
+        RealTimeOfWound = wound.RealTimeOfWound;
 
         XElement root = XElement.Parse(wound.ExtraInformation);
         XElement element = root.Element("BleedStatus");
@@ -901,4 +904,5 @@ public class RobotWound : PerceivedItem, IWound
 
     public Difficulty ConcentrationDifficulty => Difficulty.Automatic;
     public bool IsFriendlyWound { get; protected set; }
+    public DateTime? RealTimeOfWound { get; protected set; }
 }

--- a/MudSharpCore/Health/Wounds/SimpleOrganicWound.cs
+++ b/MudSharpCore/Health/Wounds/SimpleOrganicWound.cs
@@ -134,6 +134,7 @@ public class SimpleOrganicWound : PerceivedItem, IWound
         _lodged = lodged;
         _actorOriginId = actorOrigin?.Id ?? 0;
         _toolOriginId = toolOrigin?.Id ?? 0;
+        RealTimeOfWound = DateTime.UtcNow;
         if (actorOrigin?.Combat?.Friendly == true)
         {
             IsFriendlyWound = true;
@@ -538,6 +539,7 @@ public class SimpleOrganicWound : PerceivedItem, IWound
         dbitem.LodgedItemId = Lodged?.Id;
         dbitem.ActorOriginId = _actorOriginId != 0 ? _actorOriginId : default(long?);
         dbitem.ToolOriginId = _toolOriginId != 0 ? _toolOriginId : default(long?);
+        dbitem.RealTimeOfWound = RealTimeOfWound;
         dbitem.ExtraInformation = SaveExtras();
         return dbitem;
     }
@@ -570,6 +572,7 @@ public class SimpleOrganicWound : PerceivedItem, IWound
 
         _actorOriginId = wound.ActorOriginId ?? 0;
         _toolOriginId = wound.ToolOriginId ?? 0;
+        RealTimeOfWound = wound.RealTimeOfWound;
 
         XElement root = XElement.Parse(wound.ExtraInformation);
         XElement element = root.Element("DamageDescription");
@@ -2228,6 +2231,7 @@ public class SimpleOrganicWound : PerceivedItem, IWound
     }
 
     public bool IsFriendlyWound { get; protected set; }
+    public DateTime? RealTimeOfWound { get; protected set; }
 
     #endregion
 }

--- a/MudSharpCore/Health/Wounds/SimpleWound.cs
+++ b/MudSharpCore/Health/Wounds/SimpleWound.cs
@@ -62,6 +62,7 @@ public class SimpleWound : PerceivedItem, IWound
         _toolOriginId = toolOrigin?.Id ?? 0;
         _vehicleId = vehicleId;
         _vehicleDamageZoneId = vehicleDamageZoneId;
+        RealTimeOfWound = DateTime.UtcNow;
         BleedStatus = BleedStatus.NeverBled;
         if (actorOrigin?.Combat?.Friendly == true)
         {
@@ -223,6 +224,8 @@ public class SimpleWound : PerceivedItem, IWound
         dbitem.LodgedItemId = Lodged?.Id;
         dbitem.ActorOriginId = _actorOriginId != 0 ? _actorOriginId : default(long?);
         dbitem.ToolOriginId = _toolOriginId != 0 ? _toolOriginId : default(long?);
+        dbitem.RealTimeOfWound = RealTimeOfWound;
+        dbitem.ExtraInformation = SaveExtras();
         return dbitem;
     }
 
@@ -249,6 +252,7 @@ public class SimpleWound : PerceivedItem, IWound
 
         _actorOriginId = wound.ActorOriginId ?? 0;
         _toolOriginId = wound.ToolOriginId ?? 0;
+        RealTimeOfWound = wound.RealTimeOfWound;
         _vehicleId = wound.VehicleId;
         _vehicleDamageZoneId = wound.VehicleDamageZoneId;
         XElement root = XElement.Parse(wound.ExtraInformation ?? "<Empty/>");
@@ -420,6 +424,7 @@ public class SimpleWound : PerceivedItem, IWound
     }
 
     public bool IsFriendlyWound { get; protected set; }
+    public DateTime? RealTimeOfWound { get; protected set; }
 
     public string Describe(WoundExaminationType type, Outcome outcome)
     {

--- a/MudSharpCore/Movement/Movement.cs
+++ b/MudSharpCore/Movement/Movement.cs
@@ -16,6 +16,7 @@ using MudSharp.PerceptionEngine.Lists;
 using MudSharp.PerceptionEngine.Outputs;
 using MudSharp.PerceptionEngine.Parsers;
 using MudSharp.RPG.Checks;
+using MudSharp.RPG.Law;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -275,6 +276,17 @@ public class Movement : IMovement
                 originalMover.OutputHandler.Send($"You decide not to move because {failedMovers.Select(x => x.HowSeen(originalMover)).ListToString()} cannot move with you.\n{"Note: To disable this setting, turn off your party's leave none behind setting.".ColourCommand()}");
                 return null;
             }
+        }
+
+        List<ICharacter> voluntaryMovers = draggers
+            .Concat(helpers)
+            .Concat(nondraggers)
+            .Concat(mounts)
+            .Distinct()
+            .ToList();
+        if (AutomaticCrimeExtensions.CheckLawfulMovement(voluntaryMovers, exit, originalMover))
+        {
+            return null;
         }
 
         return new Movement(originalMover, originalMover.Party, draggers, helpers, nondraggers, mounts, targets, effects, exit);

--- a/MudSharpCore/RPG/Law/AutomaticCrimeContext.cs
+++ b/MudSharpCore/RPG/Law/AutomaticCrimeContext.cs
@@ -1,0 +1,210 @@
+#nullable enable
+using MudSharp.Character;
+using MudSharp.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MudSharp.RPG.Law;
+
+internal sealed class AutomaticCrimeContext
+{
+	private readonly IReadOnlyDictionary<string, string> _values;
+
+	private AutomaticCrimeContext(IReadOnlyDictionary<string, string> values)
+	{
+		_values = values;
+	}
+
+	public string? Kind => Value("automatic");
+
+	public static string DescribeForCrimeInfo(string additionalInformation, ICharacter enforcer,
+		IPerceivable? thirdParty, bool includeRawContext)
+	{
+		var sb = new StringBuilder();
+		sb.AppendLine("Automatic Evidence:");
+		if (!TryParse(additionalInformation, out var context))
+		{
+			sb.AppendLine($"\tSource: {"Automatic engine report".ColourName()}");
+			sb.AppendLine("\tBasis: This crime was recorded automatically by the engine.");
+			AppendRawContext(sb, additionalInformation, includeRawContext);
+			return sb.ToString().TrimEnd();
+		}
+
+		foreach (var line in context.EvidenceLines(enforcer, thirdParty))
+		{
+			sb.AppendLine($"\t{line}");
+		}
+
+		AppendRawContext(sb, additionalInformation, includeRawContext);
+		return sb.ToString().TrimEnd();
+	}
+
+	private IEnumerable<string> EvidenceLines(ICharacter enforcer, IPerceivable? thirdParty)
+	{
+		switch (Kind?.ToLowerInvariant())
+		{
+			case "death":
+				return DeathEvidenceLines(enforcer, thirdParty);
+			case "wound":
+				return WoundEvidenceLines(enforcer, thirdParty);
+			case "property-entry":
+				return PropertyEntryEvidenceLines();
+			case "arena-bet":
+				return ArenaBetEvidenceLines();
+			case "contraband-boundary":
+				return ContrabandBoundaryEvidenceLines(enforcer, thirdParty);
+			default:
+				return UnknownEvidenceLines();
+		}
+	}
+
+	private IEnumerable<string> DeathEvidenceLines(ICharacter enforcer, IPerceivable? thirdParty)
+	{
+		var severity = SafeValue("maxseverity") ?? "an unknown-severity";
+		var damageType = SafeValue("damagetype") ?? "unknown";
+		var bodypart = SafeValue("bodypart");
+		var age = SafeValue("woundage");
+		var friendly = SafeValue("friendly")?.EqualTo("true") == true ? "friendly" : "non-friendly";
+		var attackerPresent = SafeValue("attackerpresent")?.EqualTo("true") == true;
+		var injury = $"{severity} {damageType} wound";
+		if (!string.IsNullOrWhiteSpace(bodypart))
+		{
+			injury = $"{injury} to {bodypart}";
+		}
+
+		yield return $"Source: {"Automatic death investigation".ColourName()}";
+		yield return $"Basis: A recent {friendly} wound was attributed to the accused.";
+		yield return $"Injury: {injury.ColourValue()}";
+		if (!string.IsNullOrWhiteSpace(age))
+		{
+			yield return $"Timing: The wound was recorded {age.ColourValue()} before death.";
+		}
+
+		yield return $"Scene: {(attackerPresent ? "The accused was present at the death scene." : "The accused was not seen at the death scene.").ColourValue()}";
+		yield return $"Implement: {DescribeThirdParty(enforcer, thirdParty)}";
+		yield return "Note: This is mechanical evidence for the court to weigh, not an automatic guilty verdict.";
+	}
+
+	private IEnumerable<string> WoundEvidenceLines(ICharacter enforcer, IPerceivable? thirdParty)
+	{
+		var severity = SafeValue("severity") ?? "an unknown-severity";
+		var damageType = SafeValue("damagetype") ?? "unknown";
+		var bodypart = SafeValue("bodypart");
+		var injury = $"{severity} {damageType} wound";
+		if (!string.IsNullOrWhiteSpace(bodypart))
+		{
+			injury = $"{injury} to {bodypart}";
+		}
+
+		yield return $"Source: {"Automatic injury report".ColourName()}";
+		yield return "Basis: A qualifying wound was attributed to the accused.";
+		yield return $"Injury: {injury.ColourValue()}";
+		yield return $"Implement: {DescribeThirdParty(enforcer, thirdParty)}";
+	}
+
+	private IEnumerable<string> PropertyEntryEvidenceLines()
+	{
+		yield return $"Source: {"Automatic property entry report".ColourName()}";
+		yield return "Basis: Entry into a protected property was recorded without matching authorisation.";
+		if (SafeValue("propertyname") is { } propertyName)
+		{
+			yield return $"Property: {propertyName.ColourValue()}";
+		}
+	}
+
+	private IEnumerable<string> ArenaBetEvidenceLines()
+	{
+		yield return $"Source: {"Automatic wagering report".ColourName()}";
+		yield return "Basis: An arena wager was placed.";
+		if (SafeValue("stake") is { } stake)
+		{
+			yield return $"Stake: {stake.ColourValue()}";
+		}
+
+		if (SafeValue("model") is { } model)
+		{
+			yield return $"Bet Type: {model.ColourValue()}";
+		}
+	}
+
+	private IEnumerable<string> ContrabandBoundaryEvidenceLines(ICharacter enforcer, IPerceivable? thirdParty)
+	{
+		yield return $"Source: {"Automatic border contraband report".ColourName()}";
+		yield return "Basis: Entry into a protected jurisdiction was recorded while carrying a potential contraband item.";
+		yield return $"Item: {DescribeThirdParty(enforcer, thirdParty, SafeValue("itemname"))}";
+	}
+
+	private IEnumerable<string> UnknownEvidenceLines()
+	{
+		yield return $"Source: {"Automatic engine report".ColourName()}";
+		yield return "Basis: This crime was recorded automatically by the engine.";
+		if (SafeValue("automatic") is { } signal)
+		{
+			yield return $"Signal: {signal.ColourValue()}";
+		}
+	}
+
+	private static bool TryParse(string text, out AutomaticCrimeContext context)
+	{
+		var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+		foreach (var segment in text.Split(';'))
+		{
+			var trimmed = segment.Trim();
+			if (trimmed.Length == 0)
+			{
+				continue;
+			}
+
+			var index = trimmed.IndexOf('=');
+			if (index <= 0)
+			{
+				continue;
+			}
+
+			var key = trimmed[..index].Trim();
+			var value = trimmed[(index + 1)..].Trim();
+			if (key.Length == 0)
+			{
+				continue;
+			}
+
+			values[key] = value;
+		}
+
+		context = new AutomaticCrimeContext(values);
+		return values.ContainsKey("automatic");
+	}
+
+	private string? Value(string key)
+	{
+		return _values.TryGetValue(key, out var value) ? value : null;
+	}
+
+	private string? SafeValue(string key)
+	{
+		var value = Value(key);
+		if (string.IsNullOrWhiteSpace(value) || value.StartsWith('#'))
+		{
+			return null;
+		}
+
+		return value;
+	}
+
+	private static string DescribeThirdParty(ICharacter enforcer, IPerceivable? thirdParty, string? fallback = null)
+	{
+		return thirdParty?.HowSeen(enforcer, flags: PerceiveIgnoreFlags.TrueDescription) ??
+		       fallback?.ColourValue() ??
+		       "No identified implement".ColourError();
+	}
+
+	private static void AppendRawContext(StringBuilder sb, string additionalInformation, bool includeRawContext)
+	{
+		if (includeRawContext)
+		{
+			sb.AppendLine($"\tRaw Context: {additionalInformation.ColourCommand()}");
+		}
+	}
+}

--- a/MudSharpCore/RPG/Law/AutomaticCrimeExtensions.cs
+++ b/MudSharpCore/RPG/Law/AutomaticCrimeExtensions.cs
@@ -1,0 +1,389 @@
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Construction.Boundary;
+using MudSharp.Economy.Property;
+using MudSharp.Effects.Concrete;
+using MudSharp.Framework;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.Health;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace MudSharp.RPG.Law;
+
+public static class AutomaticCrimeExtensions
+{
+	public const string GreviousBodilyHarmMinimumSeveritySetting = "AutomaticGreviousBodilyHarmMinimumSeverity";
+	public const string MurderMinimumSeveritySetting = "AutomaticMurderMinimumWoundSeverity";
+	public const string MurderWoundAttributionWindowSecondsSetting = "AutomaticMurderWoundAttributionWindowSeconds";
+	public const string MurderIncludeFriendlyWoundsSetting = "AutomaticMurderIncludeFriendlyWounds";
+
+	public static bool HandleCrimeAndLawfulActing(IFuturemud gameworld, ICharacter criminal, CrimeTypes crime,
+		ICharacter victim = null, IGameItem target = null, string additionalInformation = "", ICell crimeLocation = null)
+	{
+		if (criminal.IsAdministrator())
+		{
+			return false;
+		}
+
+		if (!CheckWouldBeACrime(gameworld, criminal, crime, victim, target, additionalInformation, crimeLocation))
+		{
+			return false;
+		}
+
+		if (criminal.Account?.ActLawfully == true)
+		{
+			criminal.OutputHandler.Send($"That action would be a crime.\n{CrimeExtensions.StandardDisableIllegalFlagText}");
+			return true;
+		}
+
+		CheckPossibleCrime(gameworld, criminal, crime, victim, target, additionalInformation, null, true, crimeLocation);
+		return false;
+	}
+
+	public static bool CheckWouldBeACrime(IFuturemud gameworld, ICharacter criminal, CrimeTypes crime,
+		ICharacter victim = null, IGameItem target = null, string additionalInformation = "", ICell crimeLocation = null)
+	{
+		foreach (var authority in gameworld.LegalAuthorities)
+		{
+			var isCrime = crimeLocation is null
+				? authority.WouldBeACrime(criminal, crime, victim, target, additionalInformation)
+				: authority.WouldBeACrimeAtLocation(criminal, crime, victim, target, additionalInformation, crimeLocation);
+			if (isCrime)
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	public static void CheckPossibleCrime(IFuturemud gameworld, ICharacter criminal, CrimeTypes crime,
+		ICharacter victim = null, IGameItem target = null, string additionalInformation = "",
+		IEnumerable<ICharacter> witnesses = null, bool notifyVictim = true, ICell crimeLocation = null)
+	{
+		foreach (var authority in gameworld.LegalAuthorities)
+		{
+			if (crimeLocation is null)
+			{
+				authority.CheckPossibleCrime(criminal, crime, victim, target, additionalInformation, witnesses, notifyVictim);
+			}
+			else
+			{
+				authority.CheckPossibleCrime(criminal, crime, victim, target, additionalInformation, witnesses,
+					notifyVictim, crimeLocation);
+			}
+		}
+	}
+
+	public static void CheckMurderForDeath(ICharacter victim)
+	{
+		var deathLocation = victim.Location;
+		if (deathLocation is null)
+		{
+			return;
+		}
+
+		var now = DateTime.UtcNow;
+		var minimumSeverity = MinimumMurderWoundSeverity(victim.Gameworld);
+		var attributionWindow = MurderWoundAttributionWindow(victim.Gameworld);
+		var includeFriendlyWounds = IncludeFriendlyMurderWounds(victim.Gameworld);
+		var presentCharacters = deathLocation
+			.LayerCharacters(victim.RoomLayer)
+			.Except(victim)
+			.ToList();
+
+		foreach (var group in victim.Body.Wounds
+			         .Where(x => IsEligibleMurderWound(x, victim, now, minimumSeverity, attributionWindow,
+				         includeFriendlyWounds))
+			         .GroupBy(x => x.ActorOrigin))
+		{
+			var attacker = group.Key;
+			if (attacker.IsAdministrator())
+			{
+				continue;
+			}
+
+			var mostSerious = group.OrderByDescending(x => x.Severity).First();
+			var attackerPresent = presentCharacters.Contains(attacker);
+			var witnesses = attackerPresent
+				? presentCharacters
+					.Where(x => x != attacker)
+					.Where(x => x.CanSee(victim))
+					.Where(x => x.CanSee(attacker))
+					.ToList()
+				: new List<ICharacter>();
+			var context =
+				$"automatic=death; victim=#{victim.Id}; wounds={group.Count()}; maxseverity={mostSerious.Severity.Describe()}; damagetype={mostSerious.DamageType.Describe()}; bodypart={ContextValue(mostSerious.Bodypart?.FullDescription() ?? "unknown")}; woundage={ContextValue(DescribeWoundAge(mostSerious.RealTimeOfWound, now))}; friendly={mostSerious.IsFriendlyWound.ToString().ToLowerInvariant()}; attackerpresent={attackerPresent.ToString().ToLowerInvariant()}";
+			CheckPossibleCrime(attacker.Gameworld, attacker, CrimeTypes.Murder, victim, mostSerious.ToolOrigin, context,
+				witnesses, false, deathLocation);
+		}
+	}
+
+	private static bool IsEligibleMurderWound(IWound wound, ICharacter victim, DateTime now,
+		WoundSeverity minimumSeverity, TimeSpan attributionWindow, bool includeFriendlyWounds)
+	{
+		if (wound.ActorOrigin is null || wound.ActorOrigin == victim || wound.ActorOrigin.IsAdministrator())
+		{
+			return false;
+		}
+
+		if (!includeFriendlyWounds && wound.IsFriendlyWound)
+		{
+			return false;
+		}
+
+		if (wound.Severity < minimumSeverity)
+		{
+			return false;
+		}
+
+		if (wound.RealTimeOfWound is not { } woundTime)
+		{
+			return false;
+		}
+
+		var woundAge = now - woundTime;
+		return woundAge >= TimeSpan.Zero && woundAge <= attributionWindow;
+	}
+
+	public static void CheckGreviousBodilyHarmForWound(IWound wound)
+	{
+		if (wound.Parent is not ICharacter victim || wound.ActorOrigin is null || wound.ActorOrigin == victim)
+		{
+			return;
+		}
+
+		var minimumSeverity = MinimumGreviousBodilyHarmSeverity(victim.Gameworld);
+		if (wound.Severity < minimumSeverity)
+		{
+			return;
+		}
+
+		var context =
+			$"automatic=wound; victim=#{victim.Id}; severity={wound.Severity.Describe()}; damagetype={wound.DamageType.Describe()}; bodypart={ContextValue(wound.Bodypart?.FullDescription() ?? "unknown")}";
+		CheckPossibleCrime(wound.ActorOrigin.Gameworld, wound.ActorOrigin, CrimeTypes.GreviousBodilyHarm, victim,
+			wound.ToolOrigin, context, null, true, victim.Location);
+	}
+
+	public static WoundSeverity MinimumMurderWoundSeverity(IFuturemud gameworld)
+	{
+		var setting = gameworld.GetStaticConfiguration(MurderMinimumSeveritySetting);
+		return WoundExtensions.TryParseWoundSeverity(setting, out var severity) ? severity : WoundSeverity.Severe;
+	}
+
+	public static TimeSpan MurderWoundAttributionWindow(IFuturemud gameworld)
+	{
+		var setting = gameworld.GetStaticConfiguration(MurderWoundAttributionWindowSecondsSetting);
+		if (!double.TryParse(setting, NumberStyles.Float, CultureInfo.InvariantCulture, out var seconds) || seconds <= 0.0)
+		{
+			seconds = 7200.0;
+		}
+
+		return TimeSpan.FromSeconds(seconds);
+	}
+
+	public static bool IncludeFriendlyMurderWounds(IFuturemud gameworld)
+	{
+		var setting = gameworld.GetStaticConfiguration(MurderIncludeFriendlyWoundsSetting);
+		return bool.TryParse(setting, out var value) && value;
+	}
+
+	public static WoundSeverity MinimumGreviousBodilyHarmSeverity(IFuturemud gameworld)
+	{
+		var setting = gameworld.GetStaticConfiguration(GreviousBodilyHarmMinimumSeveritySetting);
+		return WoundExtensions.TryParseWoundSeverity(setting, out var severity) ? severity : WoundSeverity.Grievous;
+	}
+
+	public static bool CheckLawfulMovement(ICharacter actor, ICellExit exit)
+	{
+		return CheckLawfulMovement(new[] { actor }, exit, actor);
+	}
+
+	public static bool CheckLawfulMovement(IEnumerable<ICharacter> actors, ICellExit exit, ICharacter movementLeader = null)
+	{
+		foreach (var actor in actors.Where(x => x is not null).Distinct())
+		{
+			if (actor.Account?.ActLawfully != true)
+			{
+				continue;
+			}
+
+			if (!WouldTrespass(actor.Gameworld, actor, exit.Destination, out _) &&
+			    !WouldTrafficContraband(actor.Gameworld, actor, exit, out _))
+			{
+				continue;
+			}
+
+			actor.OutputHandler.Send($"That movement would be a crime.\n{CrimeExtensions.StandardDisableIllegalFlagText}");
+			if (movementLeader is not null && movementLeader != actor)
+			{
+				movementLeader.OutputHandler.Send(
+					$"{actor.HowSeen(movementLeader, true)} refuses to move because that movement would be a crime.");
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	public static void CheckLocationEntryCrimes(ICharacter actor, ICell enteredCell, ICellExit exit,
+		bool isVoluntaryEntry = true)
+	{
+		if (!isVoluntaryEntry || actor.IsAdministrator())
+		{
+			return;
+		}
+
+		if (WouldTrespass(actor.Gameworld, actor, enteredCell, out var trespassContext))
+		{
+			CheckPossibleCrime(actor.Gameworld, actor, CrimeTypes.Trespassing, null, null, trespassContext, null, true,
+				enteredCell);
+		}
+
+		if (!IsLegalAuthorityBoundaryEntry(actor.Gameworld, exit))
+		{
+			return;
+		}
+
+		foreach (var item in InventoryItemsForContrabandCheck(actor))
+		{
+			var context = ContrabandTrafficContext(actor, exit, item);
+			if (!CheckWouldBeACrime(actor.Gameworld, actor, CrimeTypes.TrafficingContraband, null, item, context,
+				    enteredCell))
+			{
+				continue;
+			}
+
+			CheckPossibleCrime(actor.Gameworld, actor, CrimeTypes.TrafficingContraband, null, item, context, null, true,
+				enteredCell);
+		}
+	}
+
+	private static bool WouldTrespass(IFuturemud gameworld, ICharacter actor, ICell destination, out string context)
+	{
+		context = string.Empty;
+		var property = gameworld.Properties.FirstOrDefault(x => x.PropertyLocations.Contains(destination));
+		if (property is null || !property.ApplyCriminalCodeInProperty || IsAuthorisedForProperty(actor, property, destination))
+		{
+			return false;
+		}
+
+		context = TrespassContext(property, destination);
+		return CheckWouldBeACrime(gameworld, actor, CrimeTypes.Trespassing, null, null, context, destination);
+	}
+
+	private static bool IsAuthorisedForProperty(ICharacter actor, IProperty property, ICell destination)
+	{
+		return property.IsAuthorisedOwner(actor) ||
+		       property.IsAuthorisedLeaseHolder(actor) ||
+		       property.Lease?.IsTenant(actor, false) == true ||
+		       property.HotelRoomForCell(destination)?.ActiveRental?.Guest == actor ||
+		       actor.AffectedBy<PermitWork>(x => x.Property == property || x.Cell == destination);
+	}
+
+	private static string TrespassContext(IProperty property, ICell destination)
+	{
+		return $"automatic=property-entry; property=#{property.Id}; propertyname={ContextValue(property.Name)}; cell=#{destination.Id}";
+	}
+
+	private static bool WouldTrafficContraband(IFuturemud gameworld, ICharacter actor, ICellExit exit, out string context)
+	{
+		context = string.Empty;
+		if (!IsLegalAuthorityBoundaryEntry(gameworld, exit))
+		{
+			return false;
+		}
+
+		foreach (var item in InventoryItemsForContrabandCheck(actor))
+		{
+			context = ContrabandTrafficContext(actor, exit, item);
+			if (CheckWouldBeACrime(gameworld, actor, CrimeTypes.TrafficingContraband, null, item, context,
+				    exit.Destination))
+			{
+				return true;
+			}
+		}
+
+		context = string.Empty;
+		return false;
+	}
+
+	private static bool IsLegalAuthorityBoundaryEntry(IFuturemud gameworld, ICellExit exit)
+	{
+		return exit?.Origin?.Zone is not null &&
+		       exit.Destination?.Zone is not null &&
+		       gameworld.LegalAuthorities.Any(x =>
+			       x.EnforcementZones.Contains(exit.Destination.Zone) &&
+			       !x.EnforcementZones.Contains(exit.Origin.Zone));
+	}
+
+	private static string ContrabandTrafficContext(ICharacter actor, ICellExit exit, IGameItem item)
+	{
+		return
+			$"automatic=contraband-boundary; item=#{item.Id}; itemname={ContextValue(item.Name)}; from=#{exit.Origin.Id}; to=#{exit.Destination.Id}; actor=#{actor.Id}";
+	}
+
+	private static string DescribeWoundAge(DateTime? woundTime, DateTime now)
+	{
+		if (woundTime is null)
+		{
+			return "unknown";
+		}
+
+		var age = now - woundTime.Value;
+		if (age < TimeSpan.Zero)
+		{
+			age = TimeSpan.Zero;
+		}
+
+		return age.Describe();
+	}
+
+	private static string ContextValue(string value)
+	{
+		return value
+			.Replace(';', ',')
+			.Replace('\r', ' ')
+			.Replace('\n', ' ')
+			.Trim();
+	}
+
+	private static IEnumerable<IGameItem> InventoryItemsForContrabandCheck(ICharacter actor)
+	{
+		var seen = new HashSet<IGameItem>();
+		foreach (var item in actor.Inventory)
+		{
+			foreach (var candidate in InventoryItemsForContrabandCheck(item, seen))
+			{
+				yield return candidate;
+			}
+		}
+	}
+
+	private static IEnumerable<IGameItem> InventoryItemsForContrabandCheck(IGameItem item, ISet<IGameItem> seen)
+	{
+		if (item is null || !seen.Add(item))
+		{
+			yield break;
+		}
+
+		yield return item;
+		if (item.GetItemType<IContainer>() is not { } container)
+		{
+			yield break;
+		}
+
+		foreach (var content in container.Contents)
+		{
+			foreach (var candidate in InventoryItemsForContrabandCheck(content, seen))
+			{
+				yield return candidate;
+			}
+		}
+	}
+}

--- a/MudSharpCore/RPG/Law/Crime.cs
+++ b/MudSharpCore/RPG/Law/Crime.cs
@@ -34,19 +34,21 @@ public class Crime : LateInitialisingItem, ICrime
     }
 
     public Crime(ICharacter criminal, ICharacter? victim, IEnumerable<ICharacter> witnesses, ILaw law,
-        IFrameworkItem? thirdparty = null)
+        IFrameworkItem? thirdparty = null, string? additionalInformation = null, ICell? crimeLocation = null)
     {
         Gameworld = criminal.Gameworld;
+        var resolvedCrimeLocation = crimeLocation ?? criminal.Location;
         CriminalId = criminal.Id;
         _criminal = criminal;
         VictimId = victim?.Id;
-        TimeOfCrime = criminal.Location.DateTime();
+        TimeOfCrime = resolvedCrimeLocation.DateTime();
         RealTimeOfCrime = DateTime.UtcNow;
-        CrimeLocation = criminal.Location;
+        CrimeLocation = resolvedCrimeLocation;
         _witnessIds.AddRange(witnesses.Select(x => x.Id));
         Law = law;
         ThirdPartyId = thirdparty?.Id;
         ThirdPartyFrameworkItemType = thirdparty?.FrameworkItemType;
+        AdditionalInformation = additionalInformation;
         CriminalShortDescription = criminal.HowSeen(criminal,
             flags: PerceiveIgnoreFlags.IgnoreCanSee | PerceiveIgnoreFlags.IgnoreSelf);
         CriminalDescription = criminal.HowSeen(criminal, type: DescriptionType.Full,
@@ -78,6 +80,7 @@ public class Crime : LateInitialisingItem, ICrime
         _hasBeenEnforced = dbitem.HasBeenEnforced;
         CriminalShortDescription = dbitem.CriminalShortDescription;
         CriminalDescription = dbitem.CriminalFullDescription;
+        AdditionalInformation = dbitem.AdditionalInformation;
         _fineRecorded = dbitem.FineRecorded;
         _custodialSentenceLength = TimeSpan.FromSeconds(dbitem.CustodialSentenceLength);
         _calculatedBail = dbitem.CalculatedBail;
@@ -128,6 +131,7 @@ public class Crime : LateInitialisingItem, ICrime
         dbitem.BailHasBeenPosted = _bailPosted;
         dbitem.HasBeenEnforced = _hasBeenEnforced;
         dbitem.LocationId = CrimeLocation?.Id;
+        dbitem.AdditionalInformation = AdditionalInformation;
         dbitem.CriminalShortDescription = CriminalShortDescription ?? string.Empty;
         dbitem.CriminalFullDescription = CriminalDescription ?? string.Empty;
         dbitem.CriminalCharacteristics = _criminalCharacteristics.Select(x => $"{x.Key.Id} {x.Value.Id}")
@@ -156,6 +160,7 @@ public class Crime : LateInitialisingItem, ICrime
             AccuserId = AccuserId,
             ThirdPartyId = ThirdPartyId,
             ThirdPartyIItemType = ThirdPartyFrameworkItemType,
+            AdditionalInformation = AdditionalInformation,
             TimeOfReport = TimeOfReport?.GetDateTimeString(),
             IsKnownCrime = _isKnownCrime,
             IsCriminalIdentityKnown = CriminalIdentityIsKnown,
@@ -321,6 +326,7 @@ public class Crime : LateInitialisingItem, ICrime
 
     public long? ThirdPartyId { get; }
     public string? ThirdPartyFrameworkItemType { get; }
+    public string? AdditionalInformation { get; }
 
     public IPerceivable? ThirdParty => ThirdPartyId.HasValue
         ? Gameworld.GetPerceivable(ThirdPartyFrameworkItemType, ThirdPartyId.Value)
@@ -697,6 +703,12 @@ public class Crime : LateInitialisingItem, ICrime
         sb.AppendLine($"Time of Crime: {TimeOfCrime.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Short).ColourValue()}");
         sb.AppendLine($"Location of Crime: {CrimeLocation?.HowSeen(enforcer, flags: PerceiveIgnoreFlags.IgnoreCanSee) ?? "An Unknown Location".ColourRoom()}");
         sb.AppendLine($"Third Party / Object: {ThirdParty?.HowSeen(enforcer, flags: PerceiveIgnoreFlags.TrueDescription) ?? "None".ColourError()}");
+        if (!string.IsNullOrWhiteSpace(AdditionalInformation))
+        {
+            sb.AppendLine(AutomaticCrimeContext.DescribeForCrimeInfo(AdditionalInformation, enforcer, ThirdParty,
+                enforcer.IsAdministrator()));
+        }
+
         if (enforcer.IsAdministrator())
         {
             sb.AppendLine();

--- a/MudSharpCore/RPG/Law/Law.cs
+++ b/MudSharpCore/RPG/Law/Law.cs
@@ -83,6 +83,10 @@ public class Law : SaveableItem, ILaw
         CanBeArrested = dbitem.CanBeArrested;
         CanBeOfferedBail = dbitem.CanBeOfferedBail;
         LawAppliesProg = Gameworld.FutureProgs.Get(dbitem.LawAppliesProgId ?? 0);
+        if (LawAppliesProg is not null)
+        {
+            CalculateLawAppliesInvoker(LawAppliesProg);
+        }
         ActivePeriod = TimeSpan.FromSeconds(dbitem.ActivePeriod);
         EnforcementStrategy = Enum.Parse<EnforcementStrategy>(dbitem.EnforcementStrategy);
         EnforcementPriority = dbitem.EnforcementPriority;
@@ -135,7 +139,7 @@ public class Law : SaveableItem, ILaw
     public ILegalAuthority Authority { get; protected set; }
     public CrimeTypes CrimeType { get; protected set; }
     public IFutureProg LawAppliesProg { get; protected set; }
-    public Func<ICharacter, ICharacter, IGameItem, long, string, bool> LawAppliesInvoker { get; protected set; }
+    public Func<ICharacter, ICharacter, IGameItem, long, string, string, bool> LawAppliesInvoker { get; protected set; }
     public bool CanBeAppliedAutomatically { get; protected set; }
     public bool DoNotAutomaticallyApplyRepeats { get; protected set; }
     private readonly List<ILegalClass> _victimClasses = new();
@@ -249,6 +253,7 @@ public class Law : SaveableItem, ILaw
 	#3offender <class>#0 - toggles a particular class being an eligable perpetrator of this crime
 	#3prog clear#0 - clears any filtering prog
 	#3prog <prog>#0 - sets a prog as the filter prog to determine whether it applies
+	#3prog#0 filters may use extended #3text text#0 signatures to receive crime name and automatic context
 	#3period <time>#0 - sets how long this time will go before becoming a cold case
 	#3strategy <which>#0 - sets the enforcement strategy
 	#3repeats#0 - toggles whether to repeatedly apply a crime in a short period
@@ -309,7 +314,7 @@ public class Law : SaveableItem, ILaw
     {
         if (prog.MatchesParameters(new[] { ProgVariableTypes.Character, ProgVariableTypes.Character }))
         {
-            LawAppliesInvoker = (criminal, victim, item, id, crime) =>
+            LawAppliesInvoker = (criminal, victim, item, id, crime, information) =>
                 LawAppliesProg.Execute<bool?>(criminal, victim) == true;
             return true;
         }
@@ -317,7 +322,7 @@ public class Law : SaveableItem, ILaw
         if (prog.MatchesParameters(new[]
                 { ProgVariableTypes.Character, ProgVariableTypes.Character, ProgVariableTypes.Item }))
         {
-            LawAppliesInvoker = (criminal, victim, item, id, crime) =>
+            LawAppliesInvoker = (criminal, victim, item, id, crime, information) =>
                 LawAppliesProg.Execute<bool?>(criminal, victim, item) == true;
             return true;
         }
@@ -327,7 +332,7 @@ public class Law : SaveableItem, ILaw
                 ProgVariableTypes.Character, ProgVariableTypes.Character, ProgVariableTypes.Number
             }))
         {
-            LawAppliesInvoker = (criminal, victim, item, id, crime) =>
+            LawAppliesInvoker = (criminal, victim, item, id, crime, information) =>
                 LawAppliesProg.Execute<bool?>(criminal, victim, id) == true;
             return true;
         }
@@ -338,7 +343,7 @@ public class Law : SaveableItem, ILaw
                 ProgVariableTypes.Number
             }))
         {
-            LawAppliesInvoker = (criminal, victim, item, id, crime) =>
+            LawAppliesInvoker = (criminal, victim, item, id, crime, information) =>
                 LawAppliesProg.Execute<bool?>(criminal, victim, item, id) == true;
             return true;
         }
@@ -349,7 +354,7 @@ public class Law : SaveableItem, ILaw
                 ProgVariableTypes.Text
             }))
         {
-            LawAppliesInvoker = (criminal, victim, item, id, crime) =>
+            LawAppliesInvoker = (criminal, victim, item, id, crime, information) =>
                 LawAppliesProg.Execute<bool?>(criminal, victim, id, crime) == true;
             return true;
         }
@@ -360,7 +365,7 @@ public class Law : SaveableItem, ILaw
                 ProgVariableTypes.Number, ProgVariableTypes.Text
             }))
         {
-            LawAppliesInvoker = (criminal, victim, item, id, crime) =>
+            LawAppliesInvoker = (criminal, victim, item, id, crime, information) =>
                 LawAppliesProg.Execute<bool?>(criminal, victim, item, id, crime) == true;
             return true;
         }
@@ -368,7 +373,7 @@ public class Law : SaveableItem, ILaw
         if (prog.MatchesParameters(new[]
                 { ProgVariableTypes.Character, ProgVariableTypes.Character, ProgVariableTypes.Text }))
         {
-            LawAppliesInvoker = (criminal, victim, item, id, crime) =>
+            LawAppliesInvoker = (criminal, victim, item, id, crime, information) =>
                 LawAppliesProg.Execute<bool?>(criminal, victim, crime) == true;
             return true;
         }
@@ -379,8 +384,52 @@ public class Law : SaveableItem, ILaw
                 ProgVariableTypes.Text
             }))
         {
-            LawAppliesInvoker = (criminal, victim, item, id, crime) =>
+            LawAppliesInvoker = (criminal, victim, item, id, crime, information) =>
                 LawAppliesProg.Execute<bool?>(criminal, victim, item, crime) == true;
+            return true;
+        }
+
+        if (prog.MatchesParameters(new[]
+            {
+                ProgVariableTypes.Character, ProgVariableTypes.Character, ProgVariableTypes.Number,
+                ProgVariableTypes.Text, ProgVariableTypes.Text
+            }))
+        {
+            LawAppliesInvoker = (criminal, victim, item, id, crime, information) =>
+                LawAppliesProg.Execute<bool?>(criminal, victim, id, crime, information) == true;
+            return true;
+        }
+
+        if (prog.MatchesParameters(new[]
+            {
+                ProgVariableTypes.Character, ProgVariableTypes.Character, ProgVariableTypes.Item,
+                ProgVariableTypes.Number, ProgVariableTypes.Text, ProgVariableTypes.Text
+            }))
+        {
+            LawAppliesInvoker = (criminal, victim, item, id, crime, information) =>
+                LawAppliesProg.Execute<bool?>(criminal, victim, item, id, crime, information) == true;
+            return true;
+        }
+
+        if (prog.MatchesParameters(new[]
+            {
+                ProgVariableTypes.Character, ProgVariableTypes.Character, ProgVariableTypes.Text,
+                ProgVariableTypes.Text
+            }))
+        {
+            LawAppliesInvoker = (criminal, victim, item, id, crime, information) =>
+                LawAppliesProg.Execute<bool?>(criminal, victim, crime, information) == true;
+            return true;
+        }
+
+        if (prog.MatchesParameters(new[]
+            {
+                ProgVariableTypes.Character, ProgVariableTypes.Character, ProgVariableTypes.Item,
+                ProgVariableTypes.Text, ProgVariableTypes.Text
+            }))
+        {
+            LawAppliesInvoker = (criminal, victim, item, id, crime, information) =>
+                LawAppliesProg.Execute<bool?>(criminal, victim, item, crime, information) == true;
             return true;
         }
 
@@ -429,12 +478,12 @@ public class Law : SaveableItem, ILaw
             return false;
         }
 
-        Func<ICharacter, ICharacter, IGameItem, long, string, bool> oldInvoker = LawAppliesInvoker;
+        Func<ICharacter, ICharacter, IGameItem, long, string, string, bool> oldInvoker = LawAppliesInvoker;
         if (!CalculateLawAppliesInvoker(prog))
         {
             LawAppliesInvoker = oldInvoker;
             actor.OutputHandler.Send(
-                "The prog you specify must take one of the following patterns of parameters:\n\tcharacter character\n\tcharacter character number\n\tcharacter character number text\n\tcharacter character text\n\tcharacter character item\n\tcharacter character item number\n\tcharacter character item number text\n\tcharacter character item text");
+                "The prog you specify must take one of the following patterns of parameters:\n\tcharacter character\n\tcharacter character number\n\tcharacter character number text\n\tcharacter character number text text\n\tcharacter character text\n\tcharacter character text text\n\tcharacter character item\n\tcharacter character item number\n\tcharacter character item number text\n\tcharacter character item number text text\n\tcharacter character item text\n\tcharacter character item text text");
             return false;
         }
 
@@ -680,7 +729,7 @@ public class Law : SaveableItem, ILaw
         return sb.ToString();
     }
 
-    public bool IsCrime(ICharacter criminal, ICharacter victim, IGameItem item)
+    public bool IsCrime(ICharacter criminal, ICharacter victim, IGameItem item, string additionalInformation = "")
     {
         ILegalClass crimLegal = Authority.GetLegalClass(criminal);
         if (crimLegal == null)
@@ -708,7 +757,8 @@ public class Law : SaveableItem, ILaw
         }
 
         if (LawAppliesProg != null &&
-            !LawAppliesInvoker(criminal, victim, item, Id, CrimeType.DescribeEnum()))
+            (LawAppliesInvoker is null ||
+             !LawAppliesInvoker(criminal, victim, item, Id, CrimeType.DescribeEnum(), additionalInformation ?? string.Empty)))
         {
             return false;
         }

--- a/MudSharpCore/RPG/Law/LegalAuthority.cs
+++ b/MudSharpCore/RPG/Law/LegalAuthority.cs
@@ -714,12 +714,21 @@ public partial class LegalAuthority : SaveableItem, ILegalAuthority
     public IEnumerable<ICrime> CheckPossibleCrime(ICharacter criminal, CrimeTypes crime, ICharacter victim,
         IGameItem item, string additionalInformation, IEnumerable<ICharacter> explicitWitnesses, bool notifyVictim)
     {
+        return CheckPossibleCrime(criminal, crime, victim, item, additionalInformation, explicitWitnesses, notifyVictim,
+            criminal.Location);
+    }
+
+    public IEnumerable<ICrime> CheckPossibleCrime(ICharacter criminal, CrimeTypes crime, ICharacter victim,
+        IGameItem item, string additionalInformation, IEnumerable<ICharacter> explicitWitnesses, bool notifyVictim,
+        ICell crimeLocation)
+    {
         if (criminal.IsAdministrator())
         {
             return Enumerable.Empty<ICrime>();
         }
 
-        if (!EnforcementZones.Contains(criminal.Location.Zone))
+        ICell location = crimeLocation ?? criminal.Location;
+        if (!EnforcementZones.Contains(location.Zone))
         {
             return Enumerable.Empty<ICrime>();
         }
@@ -732,17 +741,22 @@ public partial class LegalAuthority : SaveableItem, ILegalAuthority
                 continue;
             }
 
-            if (!law.IsCrime(criminal, victim, item))
+            if (!law.IsCrime(criminal, victim, item, additionalInformation))
             {
                 continue;
             }
 
             if (law.DoNotAutomaticallyApplyRepeats && _unknownCrimesLookup[criminal.Id]
                                                       .Concat(_knownCrimesLookup[criminal.Id]).Any(x =>
+                                                          x.Law.Id == law.Id &&
                                                           x.Victim == victim &&
-                                                          (x.ThirdPartyId == item?.Id ||
-                                                           x.ThirdPartyFrameworkItemType != "item") &&
-                                                          x.CrimeLocation == criminal.Location &&
+                                                          (item is null
+                                                              ? x.ThirdPartyId is null
+                                                              : x.ThirdPartyId == item.Id &&
+                                                                string.Equals(x.ThirdPartyFrameworkItemType,
+                                                                    item.FrameworkItemType,
+                                                                    StringComparison.OrdinalIgnoreCase)) &&
+                                                          x.CrimeLocation == location &&
                                                           DateTime.UtcNow - x.RealTimeOfCrime < TimeSpan.FromMinutes(10)
                                                       ))
             {
@@ -750,10 +764,10 @@ public partial class LegalAuthority : SaveableItem, ILegalAuthority
             }
 
             List<ICharacter> witnesses = explicitWitnesses is null
-                ? criminal.Location.LayerCharacters(criminal.RoomLayer).Except(criminal)
+                ? location.LayerCharacters(criminal.RoomLayer).Except(criminal)
                           .Where(x => x.CanSee(criminal)).ToList()
                 : explicitWitnesses.Except(criminal).Distinct().ToList();
-            Crime newCrime = new(criminal, victim, witnesses, law, item);
+            Crime newCrime = new(criminal, victim, witnesses, law, item, additionalInformation, location);
             _unknownCrimes.Add(newCrime);
             _unknownCrimesLookup.Add(criminal.Id, newCrime);
             Gameworld.Add(newCrime);
@@ -777,7 +791,14 @@ public partial class LegalAuthority : SaveableItem, ILegalAuthority
     public bool WouldBeACrime(ICharacter criminal, CrimeTypes crime, ICharacter victim, IGameItem item,
         string additionalInformation)
     {
-        if (!EnforcementZones.Contains(criminal.Location.Zone))
+        return WouldBeACrimeAtLocation(criminal, crime, victim, item, additionalInformation, criminal.Location);
+    }
+
+    public bool WouldBeACrimeAtLocation(ICharacter criminal, CrimeTypes crime, ICharacter victim, IGameItem item,
+        string additionalInformation, ICell crimeLocation)
+    {
+        ICell location = crimeLocation ?? criminal.Location;
+        if (!EnforcementZones.Contains(location.Zone))
         {
             return false;
         }
@@ -789,7 +810,7 @@ public partial class LegalAuthority : SaveableItem, ILegalAuthority
                 continue;
             }
 
-            if (!law.IsCrime(criminal, victim, item))
+            if (!law.IsCrime(criminal, victim, item, additionalInformation))
             {
                 continue;
             }

--- a/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextConfiguring4.cs
+++ b/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextConfiguring4.cs
@@ -2178,6 +2178,8 @@ namespace MudSharp.Database
 
                 entity.Property(e => e.LodgedItemId).HasColumnType("bigint(20)");
 
+                entity.Property(e => e.RealTimeOfWound).HasColumnType("datetime");
+
                 entity.Property(e => e.ToolOriginId).HasColumnType("bigint(20)");
 
                 entity.Property(e => e.WoundType)

--- a/MudsharpDatabaseLibrary/Migrations/20260601012012_AutomaticCrimeContext.Designer.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260601012012_AutomaticCrimeContext.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MudSharp.Database;
 
@@ -11,9 +12,11 @@ using MudSharp.Database;
 namespace MudSharp.Migrations
 {
     [DbContext(typeof(FuturemudDatabaseContext))]
-    partial class FutureMUDContextModelSnapshot : ModelSnapshot
+    [Migration("20260601012012_AutomaticCrimeContext")]
+    partial class AutomaticCrimeContext
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MudsharpDatabaseLibrary/Migrations/20260601012012_AutomaticCrimeContext.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260601012012_AutomaticCrimeContext.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MudSharp.Migrations
+{
+    /// <inheritdoc />
+    public partial class AutomaticCrimeContext : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AdditionalInformation",
+                table: "Crimes",
+                type: "longtext",
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AddColumn<System.DateTime>(
+                name: "RealTimeOfWound",
+                table: "Wounds",
+                type: "datetime",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AdditionalInformation",
+                table: "Crimes");
+
+            migrationBuilder.DropColumn(
+                name: "RealTimeOfWound",
+                table: "Wounds");
+        }
+    }
+}

--- a/MudsharpDatabaseLibrary/Models/Crime.cs
+++ b/MudsharpDatabaseLibrary/Models/Crime.cs
@@ -18,6 +18,7 @@ namespace MudSharp.Models
         public long? AccuserId { get; set; }
         public long? ThirdPartyId { get; set; }
         public string? ThirdPartyIItemType { get; set; }
+        public string? AdditionalInformation { get; set; }
         public string CriminalShortDescription { get; set; } = null!;
         public string CriminalFullDescription { get; set; } = null!;
         public string CriminalCharacteristics { get; set; } = null!;

--- a/MudsharpDatabaseLibrary/Models/Wound.cs
+++ b/MudsharpDatabaseLibrary/Models/Wound.cs
@@ -27,6 +27,7 @@ namespace MudSharp.Models
         public string ExtraInformation { get; set; }
         public long? ActorOriginId { get; set; }
         public long? ToolOriginId { get; set; }
+        public DateTime? RealTimeOfWound { get; set; }
         public string WoundType { get; set; }
 
         public virtual Character ActorOrigin { get; set; }


### PR DESCRIPTION
## Summary
- Add automatic crime context plumbing for law progs and persisted crime records.
- Add coded automatic application support for murder, grievous bodily harm, trespass, gambling, and contraband boundary movement.
- Add wound timestamp persistence and murder attribution guardrails for severity, age, and friendly wounds.
- Add PC judge-facing automatic evidence summaries while preserving raw context for admins.
- Update law runtime documentation and focused unit coverage.

## Validation
- `dotnet test "MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj" -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 --filter "FullyQualifiedName~AutomaticCrimeExtensionsTests|FullyQualifiedName~ArenaBettingServiceTests"` passed: 27/27.
- `git diff --check` passed.
- `git diff --cached --check` passed.