### PR TITLE
Implement durable psionic trace effects

### DIFF
--- a/Design Documents/Magic/Armageddon_Magic_Psionics_Gap_Report.md
+++ b/Design Documents/Magic/Armageddon_Magic_Psionics_Gap_Report.md
@@ -20,11 +20,11 @@ and the current runtime implementations under `MudSharpCore/Magic`.
 - `Native now` means the behaviour can be authored today with existing spell effects or power types and no new C# runtime type.
 - `Builder+Prog now` means the behaviour can be reached today with existing magic primitives plus FutureProg logic, NPC/item prototypes, or on-load content scaffolding. These are "close enough" paths, not always exact one-to-one reproductions.
 - `Needs engine primitive` means the current magic surface is missing a concrete trigger, target type, spell effect, power type, hook, or formula, but the existing character, room, item, perception, combat, plane, or form systems are enough to host it. These are implementation tasks, not architectural blockers.
-- `Needs supporting system` means the effect cannot be represented honestly until a broader runtime model is added or reworked. Examples include simultaneous active bodies, durable portal topology, objective multi-viewer illusions, or world-specific metaphysics.
+- `Needs supporting system` means the effect cannot be represented honestly until a broader runtime model is added or reworked. Examples include simultaneous active bodies, objective multi-viewer illusions, or world-specific metaphysics.
 - Existing powers count as valid coverage even when Armageddon exposed the original ability as a spell. If you want strict `cast`-spell parity rather than "same subsystem can do it", several defensive entries would slide from `Native now` to `Needs engine primitive`.
 - A handful of Armageddon entries are under-specified in the dump (`Daylight`, `Empower`, `Drown`, `Cause Disease`, `Acid Spray`, some passive psionics). The first pass counted those conservatively unless the name clearly mapped to an existing FutureMUD primitive.
 - The original first-pass counts used a single `Needs engine work` bucket. This revision keeps those historical lists in the appendix, but current planning uses the two-way split above.
-- Status reviewed on 2026-05-28 against `Magic_System_Implemented_Types.md`, `Magic_System_Spells.md`, `Magic_System_Powers.md`, and the registered runtime types under `MudSharpCore/Magic`. Exact family-by-family counts were not recomputed in this pass; the stale top-line counts have therefore been removed from the planning sections. V4 added 9 builder-registered psionic power tokens and 2 builder-registered tag-aware ward effect tokens. The 2026-05-05 Old SOI parity slice added 7 more builder-registered psionic power tokens: `dangersense`, `empathy`, `hex`, `clairvoyance`, `prescience`, `sensitivity`, and `psychicbolt`. The 2026-05-28 persistent sensory/combat slice added 4 builder-registered spell-effect tokens: `burning`, `ignite`, `trackmark`, and `tracktrail`.
+- Status reviewed on 2026-05-28 against `Magic_System_Implemented_Types.md`, `Magic_System_Spells.md`, `Magic_System_Powers.md`, and the registered runtime types under `MudSharpCore/Magic`. Exact family-by-family counts were not recomputed in this pass; the stale top-line counts have therefore been removed from the planning sections. V4 added 9 builder-registered psionic power tokens and 2 builder-registered tag-aware ward effect tokens. The 2026-05-05 Old SOI parity slice added 7 more builder-registered psionic power tokens: `dangersense`, `empathy`, `hex`, `clairvoyance`, `prescience`, `sensitivity`, and `psychicbolt`. The 2026-05-28 persistent sensory/combat slice added 4 builder-registered spell-effect tokens: `burning`, `ignite`, `trackmark`, and `tracktrail`. The 2026-06-01 V5b trace slice added a saveable psionic trace effect and shared notifier-driven trace creation without adding new power tokens.
 
 ## Executive Summary
 
@@ -34,7 +34,7 @@ The major correction from the old report is that "requires engine work" is no lo
 | --- | --- | --- |
 | Buildable now | Existing spell effects, powers, triggers, planes, body forms, tags, wards, portals, or progs can author the behaviour today. | `Ethereal`, simple `Planeshift`, `Mark`, basic `Portal`, `Thoughtsense`, `Immersion`, `Conceal`, `Glyph`, `Vampiric Blade` |
 | Needs engine primitive | A new effect, power, hook, or formula is needed, but the surrounding model already exists. | open/close exit mutation, exact `Identify`/`Dead Speak`/`Recite` UX, source-specific anti-status or metaphysical wrappers |
-| Needs supporting system | The spell implies a runtime model that FutureMUD does not yet have. | true possession/projection, body-left-behind disembodiment, durable gate/rune topology, objective multi-viewer illusions, land/elemental relationship metaphysics |
+| Needs supporting system | The spell implies a runtime model that FutureMUD does not yet have. | true possession/projection, body-left-behind disembodiment, objective multi-viewer illusions, land/elemental relationship metaphysics |
 
 Key takeaways:
 
@@ -42,8 +42,8 @@ Key takeaways:
 - The current system is strong at direct damage, healing, stamina/need adjustment, item or liquid conjuration, NPC summoning, invisibility, telepathy, self-only magical armour, planar state shifts, persistent burn/track spell effects, and single-active-body transformation.
 - Previous phases closed three medium-difficulty primitive gaps: local exit targeting, prog-resolved summon-style remote targeting, and reusable room or personal wards with shared spell and power interception.
 - The plane and body-form work moves several old blockers into the buildable bucket: `Ethereal`, `Detect Ethereal`, `Dispel Ethereal`, simple `Planeshift`, ghostly manifestation, and polymorph-style transformations can now use first-class effects rather than bespoke tags.
-- The biggest remaining architecture blockers are durable portal topology beyond saved effects, objective or group-scoped illusion policy, world-specific metaphysics, and true "dual body" mechanics like possession or shadow projection.
-- Psionics are now better covered than the first pass suggested. The current mind-link stack handles contact, barriers, mind-looking, audits, expulsion, sense, messaging, direct mental attacks, passive thought/feeling traffic, identity concealment, trace inspection, psionic hearing, clairaudience, clairvoyance, language comprehension, babbling, magical or psychic sensitivity, danger sense, empathy, hexes, prescient board questions, emotion/thought injection, stun-only psychic bolts, and non-command coerce modes. Durable trace consequences and projection-style powers still need supporting-system work.
+- The biggest remaining architecture blockers are objective or group-scoped illusion policy, world-specific metaphysics, and true "dual body" mechanics like possession or shadow projection. Durable portal topology V1 and durable psionic trace V1 are now implemented.
+- Psionics are now better covered than the first pass suggested. The current mind-link stack handles contact, barriers, mind-looking, audits, expulsion, sense, messaging, direct mental attacks, passive thought/feeling traffic, identity concealment, active and residual trace inspection, psionic hearing, clairaudience, clairvoyance, language comprehension, babbling, magical or psychic sensitivity, danger sense, empathy, hexes, prescient board questions, emotion/thought injection, stun-only psychic bolts, and non-command coerce modes. Projection-style powers still need supporting-system work.
 
 ## Current Family Themes
 
@@ -57,7 +57,7 @@ Key takeaways:
 | Lightning | direct attacks, stamina effects, paralysis, footprint-style magical track marking | source-specific lightning wrappers only if content needs more than existing damage/status/trackmark primitives | none obvious from the current report |
 | Void | wards, portals, marks/runes, corpse preservation/consumption/spawn, resource drains, item enchantments, strength-contested dispel matching | exact `Identify`/`Dead Speak`/`Recite` surfaces if they need first-class UX | durable portal/rune topology, possession, disembodiment, setting-specific `Solace` / `Dragon Bane` / `Cathexis` |
 | Unspecified / incomplete magic | `Puddle`; `Cause Disease` if the dump only requires disease application | `Acid Spray`, exact `Drown` if not covered by existing damage/need/breathing primitives | source clarification may be needed before classification |
-| Psionics | contact, barriers, locate/probe/expel/sense, mindblast, rejuvenate, dome, telepathy, passive traffic, identity concealment, `Trace`, `Hear`, `Clairaudience`, `Clairvoyance`, `Allspeak`, `Babble`, `Magicksense`, `Danger Sense`, `Empathy`, `Hex`, `Prescience`, `Sensitivity`, `Psychic Bolt`, `Project Emotion`, `Suggest`, `Coerce`, and animal/wild contact variants via `connectmind` eligibility progs | content-specific `Cathexis`, `Mindwipe`, or beast/wild wrappers if they require unique UX beyond existing links and policy hooks | projection/remote-presence semantics, durable psionic trace/consequence models, and objective multi-viewer illusion state |
+| Psionics | contact, barriers, locate/probe/expel/sense, mindblast, rejuvenate, dome, telepathy, passive traffic, identity concealment, active link and residual trace inspection, `Trace`, `Hear`, `Clairaudience`, `Clairvoyance`, `Allspeak`, `Babble`, `Magicksense`, `Danger Sense`, `Empathy`, `Hex`, `Prescience`, `Sensitivity`, `Psychic Bolt`, `Project Emotion`, `Suggest`, `Coerce`, and animal/wild contact variants via `connectmind` eligibility progs | content-specific `Cathexis`, `Mindwipe`, or beast/wild wrappers if they require unique UX beyond existing links and policy hooks | projection/remote-presence semantics and objective multi-viewer illusion state |
 
 ## Where FutureMUD Is Already Strong
 
@@ -126,7 +126,7 @@ Deferred from V1 but later resolved in V2: general dispel/shorten support, porta
 
 Deferred from V1 but later resolved in V4: advanced non-command coercion policy and subjective illusion priority/dispel keys.
 
-Deferred from V1 and still relevant: durable portal/rune topology, objective or group-scoped illusions, durable trace consequences, and true possession/projection.
+Deferred from V1 and still relevant: objective or group-scoped illusions and true possession/projection. Durable portal/rune topology was later resolved in V5 topology work; timed durable trace consequences were later resolved in V5b.
 
 ### Engine V2: dispels, richer enchantments, portal inspection, and psionic identity
 
@@ -140,7 +140,7 @@ Completed on 2026-05-02.
 
 Deferred from V2 but later resolved in V3 or V4: strength-contested dispel formulas, richer subjective-illusion priority and dispel policy, advanced non-command coercion primitives, and tag-aware ward matching.
 
-Deferred from V2 and still relevant: persistent gate/rune topology if saved effects are not enough, durable trace consequences, objective or group-scoped illusion state, and the simultaneous-body possession/projection model.
+Deferred from V2 and still relevant: objective or group-scoped illusion state and the simultaneous-body possession/projection model. Persistent gate/rune topology and timed residual traces were resolved in later V5 slices.
 
 ### Engine V4: psionic and perception policy layer
 
@@ -163,7 +163,18 @@ Completed on 2026-05-28.
 - Added `trackmark` / `tracktrail`, a spell-owned character effect that modifies future visual or olfactory track intensity and can add a magically-marked track circumstance. Created tracks display the magical trace in tracking output and can be targeted with `dispelmagic effect trackmark`.
 - Added `ITrackIntensityEffect` and `TrackCircumstances.MagicallyMarked` so movement remains responsible for creating tracks while spell effects can modify the intensities and circumstances of those tracks.
 
-This closes the smaller `Immolate` and `Fluorescent Footsteps` style engine-primitive gap without pretending to solve durable psionic traces, objective illusions, or persistent world topology.
+This closes the smaller `Immolate` and `Fluorescent Footsteps` style engine-primitive gap without pretending to solve objective illusions or persistent world topology.
+
+### Engine V5b: durable psionic trace/trail V1
+
+Completed on 2026-06-01.
+
+- Added saveable `PsionicTrace` effects with source, optional target, source cell, school, power, activity kind, timestamp, duration, read difficulty, and concealment fallback identity text.
+- Extended `PsionicActivityNotifier` so existing sensitivity pings still fire and trace-enabled powers also leave residual traces on involved characters and the source cell.
+- Added base power trace configuration for enabled state, duration, read difficulty, and trace description. Existing XML without trace fields loads with tracing disabled for compatibility.
+- Extended `trace <target>` so active link output remains first, followed by residual traces when present.
+
+This closes timed durable psionic trace/trail V1 without adding a permanent staff ledger or solving objective illusions, possession/projection, or world-specific metaphysics.
 
 ## Current Reclassification From Planes And Body Forms
 
@@ -376,7 +387,7 @@ Remaining work:
 
 ### 8. Subjective perception, coercive psionics, and passive mind traffic
 
-Status: Coercion V1, psionic identity concealment, passive thought/feeling traffic, and the V4 psionic/perception policy layer are implemented. The older report text that listed identity hiding, passive traffic, basic trace/hear/clairaudience powers, and non-command coercion primitives as open blockers is stale.
+Status: Coercion V1, psionic identity concealment, passive thought/feeling traffic, the V4 psionic/perception policy layer, and the V5b residual trace/trail layer are implemented. The older report text that listed identity hiding, passive traffic, basic trace/hear/clairaudience powers, non-command coercion primitives, and durable trace/trail consequences as open blockers is stale.
 
 FutureMUD already has good mind-link primitives and now has:
 
@@ -386,7 +397,7 @@ FutureMUD already has good mind-link primitives and now has:
 - caster-scoped subjective-description support through fixed-viewer handling.
 - `mindconceal`, which supplies sustained identity concealment and an audit difficulty modifier.
 - passive `think` / `feel` / `thinkemote` traffic through `telepathy`, with concealment consulted before identities are exposed.
-- `trace`, which inspects active mind links around a target mind and respects `mindconceal` audit difficulty and unknown-identity output.
+- `trace`, which inspects active mind links and residual psionic traces around a target mind, respects `mindconceal` audit difficulty and unknown-identity output, and reads traces created by successful psionic activity.
 - `hear`, which sustains psionic thought/feeling listening over configured scope without becoming ordinary room audio.
 - `clairaudience`, which sustains contact-based remote hearing through another mind's location and forwards audible output only.
 - `allspeak`, which grants sustained spoken-language comprehension through `IComprehendLanguageEffect` without permanent language skill or literacy bypass.
@@ -408,13 +419,13 @@ This now covers:
 It does not yet cover:
 
 - robust refusal/consent policy beyond opt-out effects, ordinary targeting checks, and hard safety block lists.
-- durable trace consequences beyond live link inspection and `mindconceal` making audits harder.
+- permanent staff/audit ledgers or campaign-specific consequences attached to residual traces.
 - objective room-state illusions or multi-viewer/group-scoped illusions that need a general perception-overlay model.
 
 That means the remaining work splits cleanly:
 
 - Needs engine primitive: none from the V4 psionic/perception policy slice. Content-specific `Cathexis`, `Mindwipe`, or beast/wild wrappers may still need dedicated UX if progs and existing link effects are not enough.
-- Needs supporting system: projection-style psionics, durable trace consequence models if traces must persist as world facts, and objective multi-viewer illusions if they need a general perception-overlay framework.
+- Needs supporting system: projection-style psionics, permanent trace consequence ledgers if traces must outlive timed effects, and objective multi-viewer illusions if they need a general perception-overlay framework.
 
 ## Future Work
 
@@ -437,7 +448,7 @@ These are the remaining true blockers. They should not be represented as one-off
 - Durable portal/rune topology: implemented as DB-backed `MagicPortalNetworks`, endpoints, and explicit links that materialise into topology-managed transient exits. V1 covers standing room gates, directly placed rune/portal objects, builder repair, and spell-created topology. One-way links and mobile/carried rune endpoints remain future extensions.
 - Objective or group-scoped illusions: if illusions must alter room state for multiple observers, stack with other illusions, and expose consistent dispel/priority rules, they need a general perception-overlay policy rather than only `subjectivedesc` / `subjectivesdesc`.
 - World-specific metaphysics: `Determine Relationship`, `Solace`, `Dragon Bane`, `Cathexis`, and richer `Planeshift` interpretations need a model for land/elemental relationships, plane travel graphs, and any clan/tribe/identity consequences.
-- Durable psionic trace consequences: the live `trace` power inspects active links, but traces that persist as world facts or feed staff/audit consequences need a shared psionic trail model.
+- Durable psionic trace consequences: V5b implements timed residual trace effects on involved characters and the source cell using normal effect persistence. Permanent global investigation ledgers or staff/campaign consequence tables remain future work if a setting requires traces to outlive the timed effect.
 
 ## Next Logical Steps
 
@@ -468,13 +479,23 @@ Status: completed on 2026-05-28.
 - `trackmark` / `tracktrail` are available for magically intensified or magically marked tracks.
 - `dispelmagic` can target these with `effect burning` and `effect trackmark`.
 
+### V5b: durable psionic trace/trail V1
+
+Status: implemented on 2026-06-01.
+
+- Successful psionic powers can create timed, saveable `PsionicTrace` effects on the source, target or targets, and the source cell.
+- `PsionicActivityNotifier` remains the shared sensitivity-ping path and now also creates residual traces when a power's trace configuration is enabled.
+- Base power XML supports trace enablement, duration, read difficulty, and authored trace description. Older saved power XML without trace fields loads with tracing disabled.
+- `trace <target>` still reports active mind links, and now also reports residual traces when active links have ended or when both active and residual evidence exists.
+- Concealed sources use the configured unknown identity unless the trace reader clears the raised difficulty.
+
 ### V5: supporting-system buildout
 
 V5 should tackle the remaining architecture blockers after V3/V4 make the easy and medium gaps boring:
 
 - simultaneous-body possession and projection
 - objective or group-scoped illusion state that changes room facts for multiple observers
-- durable psionic trace/trail consequences that survive beyond live link inspection
+- permanent psionic trace consequence ledgers, only if content needs traces to survive beyond the timed V5b effect
 - persistent rune/gate/portal topology is now implemented for explicit bidirectional networks; future work is limited to one-way links or mobile/carried rune endpoint semantics if content needs them
 - world-specific metaphysics such as land relationships, elemental patronage, or clan-keyed psionic consequences
 
@@ -530,7 +551,7 @@ These are the next-best return once the basic statuses exist.
    - Completed for Coercion V1 with `forcecommand`.
    - Extended in V4 with `projectemotion`, `suggest`, and mode-based `coerce`.
    - The command-forcing implementation executes through the target's own `ExecuteCommand`, respects `IIgnoreForceEffect`, blocks staff/editor/account-destructive roots, and emits wiz-only audit output.
-   - The V4 non-command path shares opt-out checks, listener delivery, and audit output. Durable trace consequences and broader consent-policy models remain future work.
+   - The V4 non-command path shares opt-out checks, listener delivery, and audit output. V5b adds timed residual traces for psionic activity; broader consent-policy models and permanent consequence ledgers remain future work.
 
 ### Phase 3: Tricky Design Work
 
@@ -608,6 +629,7 @@ Engine V2 has shipped the deeper parity layer without jumping into simultaneous-
    - `mindconceal` supplies the sustained identity-concealment effect and audit difficulty modifier.
    - `connectmind`, `mindsay`, `mindbroadcast`, `mindaudit`, `mindexpel`, and passive `think`/`feel` telepathy now consult the shared concealment contract.
    - Thoughtsense/Immersion-style passive traffic should use the existing `telepathy` `thinks` / `feels` / `thinkemote` flow.
+   - V5b residual traces now use normal timed effect persistence rather than a permanent audit table.
 
 6. Still deferred.
    - True possession, send-shadow projection, and body-left-behind disembodiment remain out of scope until the simultaneous-body model is designed.
@@ -615,11 +637,11 @@ Engine V2 has shipped the deeper parity layer without jumping into simultaneous-
 
 ## Recommended Next Shipping Slice After Engine V2
 
-Engine V3 shipped the small edge-status slice that sat outside Engine V2: poison detection, insomnia, cure blindness, and optional strength-contested dispel matching. Engine V5a has now also shipped the smaller persistent sensory/combat primitives for burn-over-time and magical track marking. The next remaining work should focus on the larger pieces Engine V2 deliberately left outside these slices:
+Engine V3 shipped the small edge-status slice that sat outside Engine V2: poison detection, insomnia, cure blindness, and optional strength-contested dispel matching. Engine V5a shipped the smaller persistent sensory/combat primitives for burn-over-time and magical track marking. Engine V5b shipped timed durable psionic traces. The next remaining work should focus on the larger pieces Engine V2 deliberately left outside these slices:
 
 - durable portal/rune topology V1 is available for standing gate networks; use future slices only for one-way links, mobile rune objects, or richer safety policy
 - richer illusion stacking and perception policy
-- advanced psionic coercion and trace consequences
+- permanent psionic trace consequence ledgers only if the timed V5b model proves insufficient
 - the simultaneous-body possession/projection model
 
 ## Appendix: Classification By Family

--- a/Design Documents/Magic/Magic_System_Implemented_Types.md
+++ b/Design Documents/Magic/Magic_System_Implemented_Types.md
@@ -51,7 +51,7 @@ It is intended for:
 | `spellremainingduration`, `spellduration`, `setspellduration`, `addspellduration`, `subtractspellduration`, `removespell` | Spell effects | Reads, changes, or removes active spell-parent effects for a specific spell on a character |
 
 ## Power Types
-Current count: 32 power tokens, including 31 builder-creatable tokens and the non-builder `armor` runtime alias. V4 added 9 builder-creatable psionic powers, and the Old SOI parity slice added 7 more psionic power tokens in per-power files under `MudSharpCore/Magic/Powers/`.
+Current count: 32 power tokens, including 31 builder-creatable tokens and the non-builder `armor` runtime alias. V4 added 9 builder-creatable psionic powers, and the Old SOI parity slice added 7 more psionic power tokens in per-power files under `MudSharpCore/Magic/Powers/`. V5b adds residual trace support to existing psionic powers without changing this token count.
 
 | Builder/runtime token | Class | Subsystem | Where registered or dispatched | Builder-creatable | Purpose |
 | --- | --- | --- | --- | --- | --- |
@@ -86,8 +86,8 @@ Current count: 32 power tokens, including 31 builder-creatable tokens and the no
 | `sensitivity` | `SensitivityPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/SensitivityPower.cs` via `MagicPowerFactory` | Yes | Sustains magical or psychic perception, receives activity pings, and actively scans auras or capabilities |
 | `suggest` | `SuggestPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/SuggestPower.cs` via `MagicPowerFactory` | Yes | Injects an involuntary thought, optionally wrapped with an emotional delivery |
 | `telepathy` | `TelepathyPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/TelepathyPower.cs` via `MagicPowerFactory` | Yes | Telepathic communication or related perception |
-| `trace` | `TracePower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/TracePower.cs` via `MagicPowerFactory` | Yes | Inspects active mind links around a target mind while respecting concealment difficulty |
-| n/a | `MagicPowerBase` | Power support | Shared base in `MudSharpCore/Magic/Powers/MagicPowerBase.cs` | No | Shared costs, progs, help text, crime handling, and builder support |
+| `trace` | `TracePower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/TracePower.cs` via `MagicPowerFactory` | Yes | Inspects active mind links and residual psionic traces around a target mind while respecting concealment difficulty |
+| n/a | `MagicPowerBase` | Power support | Shared base in `MudSharpCore/Magic/Powers/MagicPowerBase.cs` | No | Shared costs, progs, help text, crime handling, builder support, and base psionic trace configuration |
 | n/a | `SustainedMagicPower` | Power support | Shared base in `MudSharpCore/Magic/Powers/SustainedMagicPower.cs` | No | Shared support for sustained powers |
 | n/a | `MagicalMeleeAttackPower` | Power support | Shared base in `MudSharpCore/Magic/Powers/MagicalMeleeAttackPower.cs` | No | Shared support base for melee-style magical attacks |
 
@@ -248,6 +248,7 @@ V4 added 2 builder-creatable tag-aware ward effect tokens: `roomtagward` and `pe
 | n/a | `IMagicPowerOrFuelEnhancementEffect` | First-class powered-item enhancement contract for production, consumption, and fuel-use multipliers |
 | n/a | `IMagicItemEventEffect` | First-class item event callback contract for enchanted items |
 | n/a | `IMindContactConcealmentEffect` | Shared psionic identity-concealment contract used by mind links, mind speech, broadcasts, audits, expulsion text, and passive telepathic traffic |
+| n/a | `IPsionicTraceEffect` | Shared residual psionic trace contract used by `trace`, notifier-created trace effects, and future trace-aware systems |
 | n/a | `IPreventFallingEffect` | Shared fall-prevention contract used by levitation and future suspension effects |
 | n/a | `ILevitationEffect` | Spell-owned levitation marker for target-specific suspension |
 | n/a | `IFallDamageMitigationEffect` | Shared fall mitigation contract exposing fall-distance and fall-damage multipliers |
@@ -261,7 +262,7 @@ V4 added 2 builder-creatable tag-aware ward effect tokens: `roomtagward` and `pe
 | n/a | `IBabbleSpeechEffect` | Speech-obfuscation contract used by communication strategies before language comprehension |
 | n/a | `PsionicSustainedPowerEffectBase<TPower>` | Shared base for V4 sustained psionic effects |
 | n/a | `BodypartMappingUtilities` | Shared bodypart mapping helper used by body-form wound migration and `empathy` wound transfer |
-| n/a | `PsionicActivityNotifier` | Shared activity ping helper used by new psionic powers and consumed by `sensitivity` |
+| n/a | `PsionicActivityNotifier` | Shared activity ping helper used by new psionic powers and consumed by `sensitivity`; V5b also uses it as the single residual trace creation point |
 | n/a | `RemoteLookRenderer` | LOOK-style remote cell renderer used by `clairvoyance` |
 | n/a | `MagicAllspeakEffect` | Sustained `IComprehendLanguageEffect` used by `allspeak` |
 | n/a | `MagicMagicksenseEffect` | Sustained `SenseMagical` perception grant used by `magicksense` |
@@ -282,6 +283,14 @@ V4 added 2 builder-creatable tag-aware ward effect tokens: `roomtagward` and `pe
 | `SpellTrackMark` | `SpellTrackMarkEffect` | Spell-owned track-intensity child effect that exposes `ITrackIntensityEffect` and short-description addenda |
 | n/a | `ITrackIntensityEffect` | Movement hook consumed when creating departure and arrival tracks so active effects can alter visual or olfactory track intensity and add circumstances |
 | `MagicallyMarked` | `TrackCircumstances.MagicallyMarked` | Track circumstance displayed by tracking output as an unnatural magical trace |
+
+## Engine V5b Support Types
+
+V5b adds durable psionic trace/trail V1 without adding new builder power tokens.
+
+| Saved effect type | Class | Summary |
+| --- | --- | --- |
+| `PsionicTrace` | `PsionicTraceEffect` | Saveable timed effect that records recent magical or psychic activity on involved characters and source cells, including source, optional target, school, power, activity kind, timestamp, duration, read difficulty, and concealment fallback identity text |
 
 ## Notes
 - Schools are first-class records rather than subtype-driven types, so they are documented in the overview and backbone docs rather than listed here as a type family.

--- a/Design Documents/Magic/Magic_System_Powers.md
+++ b/Design Documents/Magic/Magic_System_Powers.md
@@ -133,6 +133,10 @@ All ordinary power types get these common commands:
 - `help`
 - `cost <verb> <which> <number>`
 - `psionic` / `psi`, which toggles the psionics crime category
+- `trace` / `traces`, which toggles residual trace creation for psionic activity
+- `traceduration <timespan>`, which sets how long residual traces persist
+- `tracedifficulty <difficulty>`, which sets the base difficulty to read residual traces
+- `tracedesc <description>`, which sets the residual trace text reported by `trace`
 
 Each concrete power type then adds its own subtype commands in its overridden `BuildingCommand`.
 
@@ -195,6 +199,7 @@ Add a new power type when the behavior does not fit the spell system well and de
 - Keep help text player-facing, not developer-facing.
 - If the power can consume resources under different verbs, define those costs per verb through the base `InvocationCosts` support.
 - If the power should be treated as psionic rather than magical, make `IsPsionic` explicit and make sure the saved XML includes it through the base helper.
+- For psionic powers that should leave investigable residue, enable the base trace configuration instead of adding per-power trace effects. Older XML without trace fields loads with tracing disabled for compatibility; newly builder-created psionic powers use a modest enabled default.
 
 ## Current Implemented Power Types
 ### Builder-registered power types
@@ -232,7 +237,7 @@ These are the currently builder-creatable power tokens registered through `Magic
 | `sensitivity` | `SensitivityPower` | Sustained magical/psychic sensitivity, activity pings, active aura scans, and hard capability reads |
 | `suggest` | `SuggestPower` | Injects an involuntary thought, optionally with an emotional wrapper |
 | `telepathy` | `TelepathyPower` | Telepathic communication or related perception |
-| `trace` | `TracePower` | Inspects active mind links around a target mind while respecting concealment |
+| `trace` | `TracePower` | Inspects active mind links and residual psionic traces around a target mind while respecting concealment |
 
 Important current-state note:
 
@@ -252,6 +257,10 @@ Passive psionic traffic can use either the existing `telepathy` flow or the dedi
 
 V4 adds a shared psionic traffic/coercion helper used by `projectemotion`, `suggest`, and `coerce`. It handles involuntary mental delivery, eligible listener forwarding, opt-out/refusal checks, consistent source/target messaging, and wiz-audit output. `coerce` supports stamina, hunger, thirst, and thought modes; it does not run the victim's command parser.
 
+V5b adds timed residual psionic traces. `PsionicActivityNotifier` still broadcasts activity pings to `sensitivity`, and now also creates saveable `PsionicTrace` effects for powers with tracing enabled. Traces are placed on the source, involved targets, and the source cell where useful, using ordinary `EffectData` persistence and timed expiry rather than a permanent audit ledger. The trace facts include source, optional target, source cell, school, power, activity kind, created time, duration, read difficulty, and concealment fallback identity text.
+
+`trace <target>` reports active mind links first. It then reports residual traces if any exist, including cases where the active link has ended or where both live links and residual evidence are present. If the source was concealed, the trace reader must clear the raised difficulty or sees the configured unknown identity text.
+
 This is intentionally separate from true projection or possession. `mindconceal` hides identity across mind-contact and passive telepathy surfaces; `clairaudience` forwards remote audible output through another mind's location; neither creates a second acting body or remote command shell.
 
 The Old SOI parity slice adds seven builder-created psionic powers. `dangersense` and `sensitivity` are sustained self powers; `empathy`, `hex`, `clairvoyance`, and `psychicbolt` are targeted powers; `prescience` is a board-submission power. They reuse the shared power XML, cost, psionic-crime, and builder-command systems, with subtype XML for Old SOI-style defaults and FutureMUD-specific extensions such as wound remapping, configurable check categories, activity filters, and capability-read difficulty.
@@ -267,7 +276,7 @@ These matter to developers extending the subsystem, but they are not standalone 
 | `PsionicTrafficHelper` | Shared policy helper for involuntary thought/feeling delivery, eligible listener forwarding, opt-out checks, blocked command roots, and audit output |
 | `PsionicSustainedPowerEffectBase<TPower>` | Shared runtime base for the V4 sustained psionic effects |
 | `BodypartMappingUtilities` | Shared bodypart remapping helper used by form transformation-style wound migration and `empathy` wound transfer |
-| `PsionicActivityNotifier` | Broadcast helper for magical or psychic activity pings consumed by `sensitivity` |
+| `PsionicActivityNotifier` | Broadcast helper for magical or psychic activity pings consumed by `sensitivity`; also the shared residual trace creation point for trace-enabled powers |
 | `RemoteLookRenderer` | LOOK-style remote cell renderer used by `clairvoyance` without relocating the viewer |
 | `MagicAllspeakEffect` | Sustained `IComprehendLanguageEffect` used by `allspeak` |
 | `MagicDangerSenseEffect` | Sustained danger-sense heartbeat effect that scans nearby cells and refreshes defensive warnings |
@@ -278,6 +287,7 @@ These matter to developers extending the subsystem, but they are not standalone 
 | `PsionicHearEffect` | Sustained `ITelepathyEffect` listener used by `hear` |
 | `PsionicClairaudienceEffect` | Remote audible-observation effect used by `clairaudience` |
 | `PsionicSensitivityEffect` | Sustained magical/psychic perception grant and activity listener used by `sensitivity` |
+| `PsionicTraceEffect` | Saving timed trace effect used by `trace` to inspect residual psionic activity |
 
 ## Important Current-State Notes
 - School verbs are the player namespace for powers. There is no separate general player command that bypasses the school.

--- a/FutureMUDLibrary/Effects/Interfaces/IPsionicTraceEffect.cs
+++ b/FutureMUDLibrary/Effects/Interfaces/IPsionicTraceEffect.cs
@@ -1,0 +1,28 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Magic;
+using MudSharp.RPG.Checks;
+using System;
+
+namespace MudSharp.Effects.Interfaces;
+
+public interface IPsionicTraceEffect : IMagicEffect
+{
+	Guid TraceId { get; }
+	long SourceCharacterId { get; }
+	long? TargetCharacterId { get; }
+	long? SourceCellId { get; }
+	ICharacter? SourceCharacter { get; }
+	ICharacter? TargetCharacter { get; }
+	ICell? SourceCell { get; }
+	PsionicActivityKind ActivityKind { get; }
+	string ActivityDescription { get; }
+	string UnknownIdentityDescription { get; }
+	DateTime CreatedUtc { get; }
+	TimeSpan TraceDuration { get; }
+	Difficulty ReadDifficulty { get; }
+	int ConcealmentDifficultyStages { get; }
+	bool Involves(ICharacter character);
+}

--- a/FutureMUDLibrary/Magic/PsionicActivityKind.cs
+++ b/FutureMUDLibrary/Magic/PsionicActivityKind.cs
@@ -1,0 +1,9 @@
+#nullable enable
+
+namespace MudSharp.Magic;
+
+public enum PsionicActivityKind
+{
+	Magical = 0,
+	Psychic = 1
+}

--- a/MudSharpCore Unit Tests/MagicPsionicTraceTests.cs
+++ b/MudSharpCore Unit Tests/MagicPsionicTraceTests.cs
@@ -1,0 +1,644 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Body.Traits;
+using MudSharp.Character;
+using MudSharp.Character.Name;
+using MudSharp.Construction;
+using MudSharp.Effects;
+using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.Framework.Scheduling;
+using MudSharp.FutureProg;
+using MudSharp.Magic;
+using MudSharp.Magic.Powers;
+using MudSharp.Models;
+using MudSharp.PerceptionEngine;
+using MudSharp.RPG.Checks;
+using MudSharp.RPG.Law;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Xml.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class MagicPsionicTraceTests
+{
+	[TestInitialize]
+	public void TestInitialize()
+	{
+		PsionicTraceEffect.InitialiseEffectType();
+	}
+
+	[TestMethod]
+	public void PsionicTraceEffect_SaveLoad_RoundTripsTraceFactsAndSchedule()
+	{
+		var gameworld = CreateGameworld();
+		var power = MagicPowerFactory.LoadPower(CreateTracePowerModel(includeTrace: true), gameworld.Object);
+		var cell = CreateCell(31, gameworld.Object);
+		var source = CreateCharacter(11, "source", gameworld.Object, cell.Object);
+		var target = CreateCharacter(12, "target", gameworld.Object, cell.Object);
+		ConfigureCollections(gameworld, [source.Object, target.Object], [cell.Object], [power]);
+
+		var traceId = Guid.NewGuid();
+		var created = new DateTime(2026, 6, 1, 3, 0, 0, DateTimeKind.Utc);
+		var effect = new PsionicTraceEffect(source.Object, source.Object, target.Object, cell.Object, power,
+			PsionicActivityKind.Psychic, "a suggested thought", "a veiled mind", Difficulty.Hard, 2,
+			traceId, created, TimeSpan.FromMinutes(45));
+
+		var xml = effect.SaveToXml(new Dictionary<IEffect, TimeSpan> { [effect] = TimeSpan.FromMinutes(12) });
+		var loaded = (IPsionicTraceEffect)Effect.LoadEffect(xml, source.Object);
+
+		Assert.AreEqual("PsionicTrace", xml.Element("Type")!.Value);
+		Assert.AreEqual((long)TimeSpan.FromMinutes(12).TotalMilliseconds, long.Parse(xml.Element("Remaining")!.Value));
+		Assert.AreEqual(traceId, loaded.TraceId);
+		Assert.AreEqual(source.Object.Id, loaded.SourceCharacterId);
+		Assert.AreEqual(target.Object.Id, loaded.TargetCharacterId);
+		Assert.AreEqual(cell.Object.Id, loaded.SourceCellId);
+		Assert.AreEqual(PsionicActivityKind.Psychic, loaded.ActivityKind);
+		Assert.AreEqual("a suggested thought", loaded.ActivityDescription);
+		Assert.AreEqual("a veiled mind", loaded.UnknownIdentityDescription);
+		Assert.AreEqual(Difficulty.Hard, loaded.ReadDifficulty);
+		Assert.AreEqual(2, loaded.ConcealmentDifficultyStages);
+		Assert.AreEqual(created, loaded.CreatedUtc);
+		Assert.AreEqual(TimeSpan.FromMinutes(45), loaded.TraceDuration);
+		Assert.AreSame(source.Object, loaded.SourceCharacter);
+		Assert.AreSame(target.Object, loaded.TargetCharacter);
+		Assert.AreSame(cell.Object, loaded.SourceCell);
+		Assert.IsTrue(loaded.Involves(source.Object));
+		Assert.IsTrue(loaded.Involves(target.Object));
+	}
+
+	[TestMethod]
+	public void MagicPowerTraceXml_LoadsOldDefinitionsDisabledAndRoundTripsExplicitTraceConfig()
+	{
+		var gameworld = CreateGameworld();
+		var oldPower = (MagicPowerBase)MagicPowerFactory.LoadPower(CreateTracePowerModel(includeTrace: false), gameworld.Object);
+		var oldSaved = InvokeSaveDefinition(oldPower);
+
+		Assert.IsFalse(oldPower.CreatesPsionicTrace);
+		Assert.IsNotNull(oldSaved.Element("PsionicTrace"));
+		Assert.AreEqual("false", oldSaved.Element("PsionicTrace")!.Element("Enabled")!.Value);
+
+		var tracedPower = (MagicPowerBase)MagicPowerFactory.LoadPower(CreateTracePowerModel(includeTrace: true,
+			durationSeconds: 900, readDifficulty: Difficulty.VeryHard, traceDescription: "a sharp residual cut"),
+			gameworld.Object);
+		var tracedSaved = InvokeSaveDefinition(tracedPower);
+
+		Assert.IsTrue(tracedPower.CreatesPsionicTrace);
+		Assert.AreEqual(TimeSpan.FromMinutes(15), tracedPower.PsionicTraceDuration);
+		Assert.AreEqual(Difficulty.VeryHard, tracedPower.PsionicTraceReadDifficulty);
+		Assert.AreEqual("a sharp residual cut", tracedPower.PsionicTraceDescription);
+		Assert.AreEqual("true", tracedSaved.Element("PsionicTrace")!.Element("Enabled")!.Value);
+		Assert.AreEqual("900", tracedSaved.Element("PsionicTrace")!.Element("DurationSeconds")!.Value);
+		Assert.AreEqual(((int)Difficulty.VeryHard).ToString(), tracedSaved.Element("PsionicTrace")!.Element("ReadDifficulty")!.Value);
+		Assert.AreEqual("a sharp residual cut", tracedSaved.Element("PsionicTrace")!.Element("Description")!.Value);
+	}
+
+	[TestMethod]
+	public void TraceDurationBuilderCommand_RejectedDurationDoesNotMutateExistingValue()
+	{
+		var gameworld = CreateGameworld();
+		var power = (MagicPowerBase)MagicPowerFactory.LoadPower(CreateTracePowerModel(includeTrace: true,
+			durationSeconds: 900), gameworld.Object);
+		var actor = CreateCharacter(11, "builder", gameworld.Object, null);
+		var originalDuration = power.PsionicTraceDuration;
+
+		var result = power.BuildingCommand(actor.Object, new StringStack("traceduration 0"));
+
+		Assert.IsFalse(result);
+		Assert.AreEqual(originalDuration, power.PsionicTraceDuration);
+	}
+
+	[TestMethod]
+	public void PsionicActivityNotifier_CreatesSourceTargetAndCellTracesWithOneTraceId()
+	{
+		var gameworld = CreateGameworld();
+		var power = MagicPowerFactory.LoadPower(CreateTracePowerModel(includeTrace: true,
+			durationSeconds: 600, traceDescription: "a residual suggestion"), gameworld.Object);
+		var cell = CreateCell(31, gameworld.Object);
+		var sourceTraces = new List<IPsionicTraceEffect>();
+		var targetTraces = new List<IPsionicTraceEffect>();
+		var cellTraces = new List<IPsionicTraceEffect>();
+		var source = CreateCharacter(11, "source", gameworld.Object, cell.Object, sourceTraces);
+		var target = CreateCharacter(12, "target", gameworld.Object, cell.Object, targetTraces);
+		ConfigureTraceOwner(cell, cellTraces);
+		ConfigureCollections(gameworld, [source.Object, target.Object], [cell.Object], [power]);
+
+		PsionicActivityNotifier.Notify(source.Object, power, "a suggestion", target.Object);
+
+		Assert.AreEqual(1, sourceTraces.Count);
+		Assert.AreEqual(1, targetTraces.Count);
+		Assert.AreEqual(1, cellTraces.Count);
+		Assert.AreEqual(sourceTraces[0].TraceId, targetTraces[0].TraceId);
+		Assert.AreEqual(sourceTraces[0].TraceId, cellTraces[0].TraceId);
+		Assert.IsTrue(sourceTraces.All(x => x.TraceDuration == TimeSpan.FromMinutes(10)));
+		Assert.AreEqual("a residual suggestion", targetTraces[0].ActivityDescription);
+		Assert.AreEqual(target.Object.Id, sourceTraces[0].TargetCharacterId);
+		Assert.AreEqual(target.Object.Id, targetTraces[0].TargetCharacterId);
+		Assert.AreEqual(cell.Object.Id, cellTraces[0].SourceCellId);
+		Assert.IsTrue(cellTraces[0].Involves(source.Object));
+		Assert.IsTrue(cellTraces[0].Involves(target.Object));
+	}
+
+	[TestMethod]
+	public void PsionicActivityNotifier_DoesNotDuplicateTraceWhenSourceIsAlsoTarget()
+	{
+		var gameworld = CreateGameworld();
+		var power = MagicPowerFactory.LoadPower(CreateTracePowerModel(includeTrace: true), gameworld.Object);
+		var cell = CreateCell(31, gameworld.Object);
+		var sourceTraces = new List<IPsionicTraceEffect>();
+		var cellTraces = new List<IPsionicTraceEffect>();
+		var source = CreateCharacter(11, "source", gameworld.Object, cell.Object, sourceTraces);
+		ConfigureTraceOwner(cell, cellTraces);
+		ConfigureCollections(gameworld, [source.Object], [cell.Object], [power]);
+
+		PsionicActivityNotifier.Notify(source.Object, power, "self scan", source.Object);
+
+		Assert.AreEqual(1, sourceTraces.Count);
+		Assert.AreEqual(1, cellTraces.Count);
+		Assert.AreEqual(sourceTraces[0].TraceId, cellTraces[0].TraceId);
+	}
+
+	[TestMethod]
+	public void PsionicActivityNotifier_PreservesSensitivityNotificationWhileRecordingTrace()
+	{
+		var listenerOutput = string.Empty;
+		var gameworld = CreateGameworld();
+		var tracePower = MagicPowerFactory.LoadPower(CreateTracePowerModel(includeTrace: true), gameworld.Object);
+		var sensitivityPower = (SensitivityPower)MagicPowerFactory.LoadPower(CreateSensitivityPowerModel(), gameworld.Object);
+		var cell = CreateCell(31, gameworld.Object);
+		var sourceTraces = new List<IPsionicTraceEffect>();
+		var source = CreateCharacter(11, "source", gameworld.Object, cell.Object, sourceTraces);
+		var listener = CreateCharacter(12, "listener", gameworld.Object, cell.Object);
+		var sensitivity = new PsionicSensitivityEffect(listener.Object, sensitivityPower);
+		listener.Setup(x => x.EffectsOfType<PsionicSensitivityEffect>(It.IsAny<Predicate<PsionicSensitivityEffect>?>()))
+		        .Returns<Predicate<PsionicSensitivityEffect>?>(predicate => predicate is null || predicate(sensitivity) ? [sensitivity] : []);
+		listener.SetupGet(x => x.OutputHandler).Returns(CreateOutputHandler(text => listenerOutput += text).Object);
+		ConfigureCollections(gameworld, [source.Object, listener.Object], [cell.Object], [tracePower, sensitivityPower]);
+
+		PsionicActivityNotifier.Notify(source.Object, tracePower, "a psychic disturbance");
+
+		Assert.AreEqual(1, sourceTraces.Count);
+		StringAssert.Contains(listenerOutput, "Activity");
+	}
+
+	[TestMethod]
+	public void PsionicActivityNotifier_RecordsConcealmentFallbackAndRaisedDifficulty()
+	{
+		var gameworld = CreateGameworld();
+		var power = MagicPowerFactory.LoadPower(CreateTracePowerModel(includeTrace: true), gameworld.Object);
+		var cell = CreateCell(31, gameworld.Object);
+		var sourceTraces = new List<IPsionicTraceEffect>();
+		var targetTraces = new List<IPsionicTraceEffect>();
+		var source = CreateCharacter(11, "source", gameworld.Object, cell.Object, sourceTraces);
+		var target = CreateCharacter(12, "target", gameworld.Object, cell.Object, targetTraces);
+		var concealment = new Mock<IMindContactConcealmentEffect>();
+		concealment.SetupGet(x => x.UnknownIdentityDescription).Returns("a masked mind");
+		concealment.SetupGet(x => x.AuditDifficultyStages).Returns(2);
+		concealment.Setup(x => x.ConcealsIdentityFrom(source.Object, target.Object, power.School)).Returns(true);
+		source.Setup(x => x.EffectsOfType<IMindContactConcealmentEffect>(It.IsAny<Predicate<IMindContactConcealmentEffect>?>()))
+		      .Returns<Predicate<IMindContactConcealmentEffect>?>(predicate =>
+		      {
+			      var effects = new[] { concealment.Object };
+			      return predicate is null ? effects : effects.Where(x => predicate(x));
+		      });
+		ConfigureCollections(gameworld, [source.Object, target.Object], [cell.Object], [power]);
+
+		PsionicActivityNotifier.Notify(source.Object, power, "a concealed suggestion", target.Object);
+
+		Assert.AreEqual("a masked mind", targetTraces[0].UnknownIdentityDescription);
+		Assert.AreEqual(2, targetTraces[0].ConcealmentDifficultyStages);
+	}
+
+	[TestMethod]
+	public void TracePower_ReportsResidualTraceWhenNoActiveLinkExists()
+	{
+		var output = string.Empty;
+		var gameworld = CreateGameworld();
+		var power = MagicPowerFactory.LoadPower(CreateTracePowerModel(includeTrace: true,
+			traceDescription: "a residual touch"), gameworld.Object);
+		var cell = CreateCell(31, gameworld.Object);
+		var targetTraces = new List<IPsionicTraceEffect>();
+		var actor = CreateCharacter(11, "actor", gameworld.Object, cell.Object);
+		var source = CreateCharacter(12, "source", gameworld.Object, cell.Object);
+		var target = CreateCharacter(13, "target", gameworld.Object, cell.Object, targetTraces);
+		actor.SetupGet(x => x.OutputHandler).Returns(CreateOutputHandler(text => output += text).Object);
+		cell.SetupGet(x => x.Characters).Returns([actor.Object, target.Object]);
+		ConfigureCollections(gameworld, [actor.Object, source.Object, target.Object], [cell.Object], [power]);
+		targetTraces.Add(new PsionicTraceEffect(target.Object, source.Object, target.Object, cell.Object, power,
+			PsionicActivityKind.Psychic, "a residual touch", "an unknown mind", Difficulty.Normal, 0,
+			Guid.NewGuid(), DateTime.UtcNow - TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(30)));
+
+		power.UseCommand(actor.Object, "trace", new StringStack("target"));
+
+		StringAssert.Contains(output, "Residual psionic traces around");
+		StringAssert.Contains(output, "A residual touch");
+		StringAssert.Contains(output, "source");
+	}
+
+	[TestMethod]
+	public void TracePower_UsesUnknownIdentityWhenConcealmentRaisesDifficultyPastResult()
+	{
+		var output = string.Empty;
+		var gameworld = CreateGameworld(passDifficulties: difficulty => difficulty <= Difficulty.Normal);
+		var power = MagicPowerFactory.LoadPower(CreateTracePowerModel(includeTrace: true,
+			traceDescription: "a hidden touch"), gameworld.Object);
+		var cell = CreateCell(31, gameworld.Object);
+		var targetTraces = new List<IPsionicTraceEffect>();
+		var actor = CreateCharacter(11, "actor", gameworld.Object, cell.Object);
+		var source = CreateCharacter(12, "source", gameworld.Object, cell.Object);
+		var target = CreateCharacter(13, "target", gameworld.Object, cell.Object, targetTraces);
+		actor.SetupGet(x => x.OutputHandler).Returns(CreateOutputHandler(text => output += text).Object);
+		cell.SetupGet(x => x.Characters).Returns([actor.Object, target.Object]);
+		ConfigureCollections(gameworld, [actor.Object, source.Object, target.Object], [cell.Object], [power]);
+		targetTraces.Add(new PsionicTraceEffect(target.Object, source.Object, target.Object, cell.Object, power,
+			PsionicActivityKind.Psychic, "a hidden touch", "a masked mind", Difficulty.Normal, 2,
+			Guid.NewGuid(), DateTime.UtcNow - TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(30)));
+
+		power.UseCommand(actor.Object, "trace", new StringStack("target"));
+
+		StringAssert.Contains(output, "a masked mind");
+		Assert.IsFalse(output.Contains("source", StringComparison.InvariantCultureIgnoreCase));
+	}
+
+	[TestMethod]
+	public void TracePower_ActiveLinkOutputStillIncludesActiveMindLinks()
+	{
+		var output = string.Empty;
+		var gameworld = CreateGameworld();
+		var connectPower = (ConnectMindPower)MagicPowerFactory.LoadPower(CreateConnectMindPowerModel(), gameworld.Object);
+		var tracePower = MagicPowerFactory.LoadPower(CreateTracePowerModel(includeTrace: true), gameworld.Object);
+		var cell = CreateCell(31, gameworld.Object);
+		var actor = CreateCharacter(11, "actor", gameworld.Object, cell.Object);
+		var target = CreateCharacter(12, "target", gameworld.Object, cell.Object);
+		var linked = CreateCharacter(13, "linked", gameworld.Object, cell.Object);
+		actor.SetupGet(x => x.OutputHandler).Returns(CreateOutputHandler(text => output += text).Object);
+		cell.SetupGet(x => x.Characters).Returns([actor.Object, target.Object]);
+		ConfigureCollections(gameworld, [actor.Object, target.Object, linked.Object], [cell.Object], [connectPower, tracePower]);
+		var connectEffect = new ConnectMindEffect(target.Object, linked.Object, connectPower);
+		target.Setup(x => x.EffectsOfType<ConnectMindEffect>(It.IsAny<Predicate<ConnectMindEffect>?>()))
+		      .Returns<Predicate<ConnectMindEffect>?>(predicate => predicate is null || predicate(connectEffect) ? [connectEffect] : []);
+
+		tracePower.UseCommand(actor.Object, "trace", new StringStack("target"));
+
+		StringAssert.Contains(output, "You trace the active mind links around target");
+		StringAssert.Contains(output, "outbound");
+		StringAssert.Contains(output, "linked");
+	}
+
+	private static XElement InvokeSaveDefinition(IMagicPower power)
+	{
+		return (XElement)power.GetType()
+		                      .GetMethod("SaveDefinition", BindingFlags.Instance | BindingFlags.NonPublic)!
+		                      .Invoke(power, [])!;
+	}
+
+	private static MagicPower CreateTracePowerModel(bool includeTrace, double durationSeconds = 1800.0,
+		Difficulty readDifficulty = Difficulty.Normal, string traceDescription = "a residual trace")
+	{
+		return new MagicPower
+		{
+			Id = 100,
+			Name = "Trace",
+			Blurb = "Trace",
+			ShowHelp = "Trace.",
+			MagicSchoolId = 1,
+			PowerModel = "trace",
+			Definition = TargetedDefinition("trace", MagicPowerDistance.SameLocationOnly, includeTrace, durationSeconds,
+				readDifficulty, traceDescription).ToString()
+		};
+	}
+
+	private static MagicPower CreateSensitivityPowerModel()
+	{
+		return new MagicPower
+		{
+			Id = 101,
+			Name = "Sensitivity",
+			Blurb = "Sensitivity",
+			ShowHelp = "Sensitivity.",
+			MagicSchoolId = 1,
+			PowerModel = "sensitivity",
+			Definition = SustainedDefinition("sensitivity", "endsensitivity", includeTrace: false,
+				new XElement("ScanVerb", "senscan"),
+				new XElement("ScanDistance", MagicPowerDistance.SameLocationOnly),
+				new XElement("GrantedPerceptions", PerceptionTypes.SenseMagical | PerceptionTypes.SensePsychic),
+				new XElement("ActivityKinds", "Magical,Psychic"),
+				new XElement("ActivityRange", 2U),
+				new XElement("ActivityDifficulty", (int)Difficulty.Normal),
+				new XElement("CapabilityDifficulty", (int)Difficulty.ExtremelyHard),
+				new XElement("PermitCapabilityRead", true),
+				new XElement("NotifySelf", false),
+				new XElement("ActivityEcho", new XCData("Activity."))).ToString()
+		};
+	}
+
+	private static MagicPower CreateConnectMindPowerModel()
+	{
+		return new MagicPower
+		{
+			Id = 102,
+			Name = "Connect Mind",
+			Blurb = "Connect mind",
+			ShowHelp = "Connect mind.",
+			MagicSchoolId = 1,
+			PowerModel = "connectmind",
+			Definition = new XElement("Definition",
+				BaseElements(includeTrace: false),
+				new XElement("ConnectVerb", "connect"),
+				new XElement("DisconnectVerb", "disconnect"),
+				new XElement("PowerDistance", MagicPowerDistance.SameLocationOnly),
+				new XElement("SkillCheckDifficulty", (int)Difficulty.Normal),
+				new XElement("SkillCheckTrait", 1L),
+				new XElement("MinimumSuccessThreshold", (int)Outcome.MinorPass),
+				new XElement("TargetCanSeeIdentityProg", 0L),
+				new XElement("TargetEligibilityProg", 0L),
+				new XElement("ExclusiveConnection", true),
+				new XElement("EmoteForConnect", new XCData("Connect.")),
+				new XElement("SelfEmoteForConnect", new XCData("Connect self.")),
+				new XElement("EmoteForDisconnect", new XCData("Disconnect.")),
+				new XElement("SelfEmoteForDisconnect", new XCData("Disconnect self.")),
+				new XElement("UnknownIdentityDescription", new XCData("unknown")),
+				new XElement("EmoteForFailConnect", new XCData("Fail.")),
+				new XElement("SelfEmoteForFailConnect", new XCData("Fail self.")),
+				new XElement("OutcomeEchoes"),
+				new XElement("ConcentrationPointsToSustain", 1.0),
+				new XElement("SustainPenalty", 0.0),
+				new XElement("DetectableWithDetectMagic", (int)Difficulty.Normal),
+				new XElement("SustainResourceCosts")
+			).ToString()
+		};
+	}
+
+	private static XElement TargetedDefinition(string verb, MagicPowerDistance distance, bool includeTrace,
+		double durationSeconds, Difficulty readDifficulty, string traceDescription)
+	{
+		return new XElement("Definition",
+			BaseElements(includeTrace, durationSeconds, readDifficulty, traceDescription),
+			new XElement("Verb", verb),
+			new XElement("PowerDistance", distance),
+			new XElement("SkillCheckDifficulty", (int)Difficulty.Normal),
+			new XElement("SkillCheckTrait", 1L),
+			new XElement("MinimumSuccessThreshold", (int)Outcome.MinorPass),
+			new XElement("DetectableWithDetectMagic", (int)Difficulty.Normal),
+			new XElement("FailEcho", new XCData("Fail.")),
+			new XElement("SuccessEcho", new XCData(string.Empty))
+		);
+	}
+
+	private static XElement SustainedDefinition(string begin, string end, bool includeTrace, params object[] additional)
+	{
+		var definition = new XElement("Definition",
+			BaseElements(includeTrace),
+			new XElement("BeginVerb", begin),
+			new XElement("EndVerb", end),
+			new XElement("SkillCheckDifficulty", (int)Difficulty.Normal),
+			new XElement("SkillCheckTrait", 1L),
+			new XElement("MinimumSuccessThreshold", (int)Outcome.MinorPass),
+			new XElement("BeginEmote", new XCData("Begin.")),
+			new XElement("EndEmote", new XCData("End.")),
+			new XElement("FailEmote", new XCData("Fail.")),
+			new XElement("ConcentrationPointsToSustain", 1.0),
+			new XElement("SustainPenalty", 0.0),
+			new XElement("DetectableWithDetectMagic", (int)Difficulty.Normal),
+			new XElement("SustainResourceCosts")
+		);
+		foreach (var item in additional)
+		{
+			definition.Add(item);
+		}
+
+		return definition;
+	}
+
+	private static object[] BaseElements(bool includeTrace, double durationSeconds = 1800.0,
+		Difficulty readDifficulty = Difficulty.Normal, string traceDescription = "a residual trace")
+	{
+		var elements = new List<object>
+		{
+			new XElement("CanInvokePowerProg", 0L),
+			new XElement("WhyCantInvokePowerProg", 0L),
+			new XElement("IsPsionic", true),
+			new XElement("InvocationCosts")
+		};
+		if (includeTrace)
+		{
+			elements.Add(new XElement("PsionicTrace",
+				new XElement("Enabled", true),
+				new XElement("DurationSeconds", durationSeconds),
+				new XElement("ReadDifficulty", (int)readDifficulty),
+				new XElement("Description", new XCData(traceDescription))));
+		}
+
+		return elements.ToArray();
+	}
+
+	private static Mock<IFuturemud> CreateGameworld(Func<Difficulty, bool>? passDifficulties = null)
+	{
+		var trueProg = CreateProg(0, true).Object;
+		var falseProg = CreateProg(1, false).Object;
+		var heartbeat = new Mock<IHeartbeatManager>();
+		var check = CreateCheck(CheckType.MagicTelepathyCheck, passDifficulties);
+		var sensitivityCheck = CreateCheck(CheckType.SensitivityPower, _ => true);
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.FutureProgs).Returns(CreateCollectionMock(trueProg, falseProg).Object);
+		gameworld.SetupGet(x => x.MagicSchools).Returns(CreateCollectionMock(CreateSchool().Object).Object);
+		gameworld.SetupGet(x => x.Traits).Returns(CreateCollectionMock(CreateTrait().Object).Object);
+		gameworld.SetupGet(x => x.AlwaysTrueProg).Returns(trueProg);
+		gameworld.SetupGet(x => x.AlwaysFalseProg).Returns(falseProg);
+		gameworld.SetupGet(x => x.UniversalErrorTextProg).Returns(trueProg);
+		gameworld.SetupGet(x => x.HeartbeatManager).Returns(heartbeat.Object);
+		gameworld.SetupGet(x => x.LegalAuthorities).Returns(CreateCollectionMock<ILegalAuthority>().Object);
+		gameworld.Setup(x => x.GetCheck(CheckType.MagicTelepathyCheck)).Returns(check.Object);
+		gameworld.Setup(x => x.GetCheck(CheckType.SensitivityPower)).Returns(sensitivityCheck.Object);
+		ConfigureCollections(gameworld, [], [], []);
+		return gameworld;
+	}
+
+	private static Mock<ICheck> CreateCheck(CheckType type, Func<Difficulty, bool>? passDifficulties)
+	{
+		passDifficulties ??= _ => true;
+		var check = new Mock<ICheck>();
+		check.SetupGet(x => x.Type).Returns(type);
+		check.Setup(x => x.Check(It.IsAny<IPerceivableHaveTraits>(), It.IsAny<Difficulty>(),
+				It.IsAny<ITraitDefinition>(), It.IsAny<IPerceivable?>(), It.IsAny<double>(),
+				It.IsAny<TraitUseType>(), It.IsAny<(string Parameter, object value)[]>()))
+		     .Returns<IPerceivableHaveTraits, Difficulty, ITraitDefinition, IPerceivable?, double, TraitUseType,
+			     (string Parameter, object value)[]>((_, difficulty, _, _, _, _, _) =>
+			     CheckOutcome.SimpleOutcome(type, passDifficulties(difficulty) ? Outcome.Pass : Outcome.Fail));
+		check.Setup(x => x.CheckAgainstAllDifficulties(It.IsAny<IPerceivableHaveTraits>(), It.IsAny<Difficulty>(),
+				It.IsAny<ITraitDefinition>(), It.IsAny<IPerceivable?>(), It.IsAny<double>(),
+				It.IsAny<TraitUseType>(), It.IsAny<(string Parameter, object value)[]>()))
+		     .Returns<IPerceivableHaveTraits, Difficulty, ITraitDefinition, IPerceivable?, double, TraitUseType,
+			     (string Parameter, object value)[]>((_, _, _, _, _, _, _) =>
+			     Enum.GetValues<Difficulty>()
+			         .ToDictionary(x => x,
+				         x => CheckOutcome.SimpleOutcome(type, passDifficulties(x) ? Outcome.Pass : Outcome.Fail)));
+		return check;
+	}
+
+	private static Mock<IMagicSchool> CreateSchool()
+	{
+		var school = new Mock<IMagicSchool>();
+		school.SetupGet(x => x.Id).Returns(1);
+		school.SetupGet(x => x.Name).Returns("Psionics");
+		school.SetupGet(x => x.PowerListColour).Returns(Telnet.BoldMagenta);
+		school.SetupGet(x => x.SchoolVerb).Returns("psi");
+		school.SetupGet(x => x.SchoolAdjective).Returns("psychic");
+		return school;
+	}
+
+	private static Mock<ITraitDefinition> CreateTrait()
+	{
+		var trait = new Mock<ITraitDefinition>();
+		trait.SetupGet(x => x.Id).Returns(1);
+		trait.SetupGet(x => x.Name).Returns("Psionics");
+		return trait;
+	}
+
+	private static Mock<IFutureProg> CreateProg(long id, bool truth)
+	{
+		var prog = new Mock<IFutureProg>();
+		prog.SetupGet(x => x.Id).Returns(id);
+		prog.SetupGet(x => x.Name).Returns($"Prog {id}");
+		prog.SetupGet(x => x.FunctionName).Returns($"Prog{id}");
+		prog.SetupGet(x => x.ReturnType).Returns(ProgVariableTypes.Boolean);
+		prog.Setup(x => x.ExecuteBool(It.IsAny<object[]>())).Returns(truth);
+		prog.Setup(x => x.Execute<bool?>(It.IsAny<object[]>())).Returns(truth);
+		prog.Setup(x => x.Execute(It.IsAny<object[]>())).Returns(truth);
+		prog.Setup(x => x.MatchesParameters(It.IsAny<IEnumerable<ProgVariableTypes>>())).Returns(true);
+		prog.Setup(x => x.MXPClickableFunctionName()).Returns($"Prog{id}");
+		return prog;
+	}
+
+	private static Mock<ICharacter> CreateCharacter(long id, string name, IFuturemud gameworld, ICell? location,
+		List<IPsionicTraceEffect>? traceEffects = null)
+	{
+		var character = new Mock<ICharacter>();
+		character.SetupGet(x => x.Id).Returns(id);
+		character.SetupGet(x => x.Name).Returns(name);
+		character.SetupGet(x => x.FrameworkItemType).Returns("Character");
+		character.SetupGet(x => x.Gameworld).Returns(gameworld);
+		character.SetupGet(x => x.Location).Returns(location!);
+		var personalName = new Mock<IPersonalName>();
+		personalName.Setup(x => x.GetName(It.IsAny<NameStyle>())).Returns(name);
+		character.SetupGet(x => x.PersonalName).Returns(personalName.Object);
+		character.As<IHavePersonalName>().SetupGet(x => x.PersonalName).Returns(personalName.Object);
+		character.SetupGet(x => x.CurrentName).Returns(personalName.Object);
+		character.SetupGet(x => x.Keywords).Returns([name]);
+		character.Setup(x => x.HasKeyword(It.IsAny<string>(), It.IsAny<IPerceiver>(), It.IsAny<bool>(), It.IsAny<bool>()))
+		         .Returns<string, IPerceiver, bool, bool>((keyword, _, abbreviated, contains) =>
+			         contains
+				         ? name.Contains(keyword, StringComparison.InvariantCultureIgnoreCase)
+				         : abbreviated
+					         ? name.StartsWith(keyword, StringComparison.InvariantCultureIgnoreCase)
+					         : name.EqualTo(keyword));
+		character.Setup(x => x.HasDubFor(It.IsAny<IKeyworded>(), It.IsAny<string>())).Returns(false);
+		character.Setup(x => x.HasDubFor(It.IsAny<IKeyworded>(), It.IsAny<IEnumerable<string>>())).Returns(false);
+		character.Setup(x => x.HowSeen(It.IsAny<IPerceiver>(), It.IsAny<bool>(), It.IsAny<MudSharp.Form.Shape.DescriptionType>(),
+				It.IsAny<bool>(), It.IsAny<PerceiveIgnoreFlags>()))
+		         .Returns(name);
+		character.Setup(x => x.EffectsOfType<IPsionicTraceEffect>(It.IsAny<Predicate<IPsionicTraceEffect>?>()))
+		         .Returns<Predicate<IPsionicTraceEffect>?>(predicate => Filter(traceEffects ?? [], predicate));
+		character.Setup(x => x.EffectsOfType<IMindContactConcealmentEffect>(It.IsAny<Predicate<IMindContactConcealmentEffect>?>()))
+		         .Returns([]);
+		character.Setup(x => x.EffectsOfType<IMagicInterdictionEffect>(It.IsAny<Predicate<IMagicInterdictionEffect>?>()))
+		         .Returns([]);
+		character.Setup(x => x.EffectsOfType<ConnectMindEffect>(It.IsAny<Predicate<ConnectMindEffect>?>()))
+		         .Returns([]);
+		character.Setup(x => x.EffectsOfType<MindConnectedToEffect>(It.IsAny<Predicate<MindConnectedToEffect>?>()))
+		         .Returns([]);
+		character.Setup(x => x.CombinedEffectsOfType<ConnectMindEffect>())
+		         .Returns([]);
+		character.Setup(x => x.CombinedEffectsOfType<MindConnectedToEffect>())
+		         .Returns([]);
+		character.Setup(x => x.AddEffect(It.IsAny<IEffect>(), It.IsAny<TimeSpan>()))
+		         .Callback<IEffect, TimeSpan>((effect, _) =>
+		         {
+			         if (effect is IPsionicTraceEffect trace)
+			         {
+				         traceEffects?.Add(trace);
+			         }
+		         });
+		character.Setup(x => x.AddEffect(It.IsAny<IEffect>()));
+		character.SetupGet(x => x.OutputHandler).Returns(CreateOutputHandler(_ => { }).Object);
+		return character;
+	}
+
+	private static Mock<ICell> CreateCell(long id, IFuturemud gameworld)
+	{
+		var cell = new Mock<ICell>();
+		cell.SetupGet(x => x.Id).Returns(id);
+		cell.SetupGet(x => x.Name).Returns($"Cell {id}");
+		cell.SetupGet(x => x.FrameworkItemType).Returns("Cell");
+		cell.SetupGet(x => x.Gameworld).Returns(gameworld);
+		cell.SetupGet(x => x.Location).Returns(cell.Object);
+		cell.SetupGet(x => x.Characters).Returns([]);
+		cell.Setup(x => x.ExitsFor(It.IsAny<IPerceiver>(), It.IsAny<bool>())).Returns([]);
+		cell.Setup(x => x.EffectsOfType<IMagicInterdictionEffect>(It.IsAny<Predicate<IMagicInterdictionEffect>?>()))
+		    .Returns([]);
+		ConfigureTraceOwner(cell, []);
+		return cell;
+	}
+
+	private static void ConfigureTraceOwner<T>(Mock<T> owner, List<IPsionicTraceEffect> traces)
+		where T : class, IPerceivable
+	{
+		owner.Setup(x => x.EffectsOfType<IPsionicTraceEffect>(It.IsAny<Predicate<IPsionicTraceEffect>?>()))
+		     .Returns<Predicate<IPsionicTraceEffect>?>(predicate => Filter(traces, predicate));
+		owner.Setup(x => x.AddEffect(It.IsAny<IEffect>(), It.IsAny<TimeSpan>()))
+		     .Callback<IEffect, TimeSpan>((effect, _) =>
+		     {
+			     if (effect is IPsionicTraceEffect trace)
+			     {
+				     traces.Add(trace);
+			     }
+		     });
+	}
+
+	private static IEnumerable<T> Filter<T>(IEnumerable<T> items, Predicate<T>? predicate)
+	{
+		return predicate is null ? items : items.Where(x => predicate(x));
+	}
+
+	private static Mock<IOutputHandler> CreateOutputHandler(Action<string> onSend)
+	{
+		var handler = new Mock<IOutputHandler>();
+		handler.Setup(x => x.Send(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+		       .Callback<string, bool, bool>((text, _, _) => onSend(text))
+		       .Returns(true);
+		return handler;
+	}
+
+	private static void ConfigureCollections(Mock<IFuturemud> gameworld, IEnumerable<ICharacter> characters,
+		IEnumerable<ICell> cells, IEnumerable<IMagicPower> powers)
+	{
+		var characterList = characters.ToArray();
+		var cellList = cells.ToArray();
+		var powerList = powers.ToArray();
+		gameworld.SetupGet(x => x.Characters).Returns(CreateCollectionMock(characterList).Object);
+		gameworld.SetupGet(x => x.Actors).Returns(CreateCollectionMock(characterList).Object);
+		gameworld.SetupGet(x => x.Cells).Returns(CreateCollectionMock(cellList).Object);
+		gameworld.SetupGet(x => x.MagicPowers).Returns(CreateCollectionMock(powerList).Object);
+	}
+
+	private static Mock<IUneditableAll<T>> CreateCollectionMock<T>(params T[] items) where T : class, IFrameworkItem
+	{
+		var byId = items.ToDictionary(x => x.Id, x => x);
+		var collection = new Mock<IUneditableAll<T>>();
+		collection.SetupGet(x => x.Count).Returns(items.Length);
+		collection.Setup(x => x.Get(It.IsAny<long>())).Returns<long>(id => byId.GetValueOrDefault(id));
+		collection.Setup(x => x.GetByName(It.IsAny<string>())).Returns<string>(name =>
+			items.FirstOrDefault(x => x.Name.EqualTo(name)));
+		collection.Setup(x => x.GetByIdOrName(It.IsAny<string>(), It.IsAny<bool>())).Returns<string, bool>((text, _) =>
+			long.TryParse(text, out var id) ? byId.GetValueOrDefault(id) : items.FirstOrDefault(x => x.Name.EqualTo(text)));
+		collection.Setup(x => x.GetEnumerator()).Returns(() => ((IEnumerable<T>)items).GetEnumerator());
+		return collection;
+	}
+}

--- a/MudSharpCore/Effects/Concrete/PsionicTraceEffect.cs
+++ b/MudSharpCore/Effects/Concrete/PsionicTraceEffect.cs
@@ -1,0 +1,120 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.Magic;
+using MudSharp.RPG.Checks;
+using System;
+using System.Globalization;
+using System.Xml.Linq;
+
+namespace MudSharp.Effects.Concrete;
+
+public sealed class PsionicTraceEffect : Effect, IPsionicTraceEffect
+{
+	public static void InitialiseEffectType()
+	{
+		RegisterFactory("PsionicTrace", (effect, owner) => new PsionicTraceEffect(effect, owner));
+	}
+
+	public PsionicTraceEffect(IPerceivable owner, ICharacter source, ICharacter? target, ICell? sourceCell,
+		IMagicPower power, PsionicActivityKind activityKind, string activityDescription,
+		string unknownIdentityDescription, Difficulty readDifficulty, int concealmentDifficultyStages,
+		Guid traceId, DateTime createdUtc, TimeSpan traceDuration) : base(owner)
+	{
+		TraceId = traceId;
+		SourceCharacterId = source.Id;
+		TargetCharacterId = target?.Id;
+		SourceCellId = sourceCell?.Id;
+		PowerId = power.Id;
+		SchoolId = power.School.Id;
+		ActivityKind = activityKind;
+		ActivityDescription = activityDescription;
+		UnknownIdentityDescription = unknownIdentityDescription;
+		ReadDifficulty = readDifficulty;
+		ConcealmentDifficultyStages = concealmentDifficultyStages;
+		CreatedUtc = createdUtc;
+		TraceDuration = traceDuration;
+	}
+
+	private PsionicTraceEffect(XElement root, IPerceivable owner) : base(root, owner)
+	{
+		var trueRoot = root.Element("Effect");
+		TraceId = Guid.Parse(trueRoot?.Element("TraceId")?.Value ?? Guid.NewGuid().ToString());
+		SourceCharacterId = long.Parse(trueRoot?.Element("SourceCharacterId")?.Value ?? "0");
+		TargetCharacterId = long.TryParse(trueRoot?.Element("TargetCharacterId")?.Value, out var targetId) &&
+		                    targetId > 0
+			? targetId
+			: null;
+		SourceCellId = long.TryParse(trueRoot?.Element("SourceCellId")?.Value, out var cellId) && cellId > 0
+			? cellId
+			: null;
+		PowerId = long.Parse(trueRoot?.Element("PowerId")?.Value ?? "0");
+		SchoolId = long.Parse(trueRoot?.Element("SchoolId")?.Value ?? "0");
+		ActivityKind = Enum.Parse<PsionicActivityKind>(trueRoot?.Element("ActivityKind")?.Value ??
+		                                                nameof(PsionicActivityKind.Psychic), true);
+		ActivityDescription = trueRoot?.Element("ActivityDescription")?.Value ?? "psychic activity";
+		UnknownIdentityDescription = trueRoot?.Element("UnknownIdentityDescription")?.Value ?? "an unknown mind";
+		ReadDifficulty = (Difficulty)int.Parse(trueRoot?.Element("ReadDifficulty")?.Value ??
+		                                       ((int)Difficulty.Normal).ToString());
+		ConcealmentDifficultyStages = int.Parse(trueRoot?.Element("ConcealmentDifficultyStages")?.Value ?? "0");
+		CreatedUtc = DateTime.Parse(trueRoot?.Element("CreatedUtc")?.Value ?? DateTime.UtcNow.ToString("O"),
+			CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+		TraceDuration = TimeSpan.FromSeconds(double.Parse(trueRoot?.Element("TraceDurationSeconds")?.Value ?? "0",
+			CultureInfo.InvariantCulture));
+	}
+
+	public Guid TraceId { get; }
+	public long SourceCharacterId { get; }
+	public long? TargetCharacterId { get; }
+	public long? SourceCellId { get; }
+	public long PowerId { get; }
+	public long SchoolId { get; }
+	public PsionicActivityKind ActivityKind { get; }
+	public string ActivityDescription { get; }
+	public string UnknownIdentityDescription { get; }
+	public DateTime CreatedUtc { get; }
+	public TimeSpan TraceDuration { get; }
+	public Difficulty ReadDifficulty { get; }
+	public int ConcealmentDifficultyStages { get; }
+	public override bool SavingEffect => true;
+	public IMagicSchool School => Gameworld.MagicSchools.Get(SchoolId)!;
+	public IMagicPower PowerOrigin => Gameworld.MagicPowers.Get(PowerId)!;
+	public Difficulty DetectMagicDifficulty => ReadDifficulty;
+	public ICharacter? SourceCharacter => SourceCharacterId > 0 ? Gameworld.Actors.Get(SourceCharacterId) : null;
+	public ICharacter? TargetCharacter => TargetCharacterId is > 0 ? Gameworld.Actors.Get(TargetCharacterId.Value) : null;
+	public ICell? SourceCell => SourceCellId is > 0 ? Gameworld.Cells.Get(SourceCellId.Value) : null;
+
+	public bool Involves(ICharacter character)
+	{
+		return character.Id == SourceCharacterId || character.Id == TargetCharacterId;
+	}
+
+	public override string Describe(IPerceiver voyeur)
+	{
+		return $"{ActivityKind.DescribeEnum()} trace of {ActivityDescription.ColourValue()} from {PowerOrigin?.Name.ColourName() ?? "an unknown power".ColourError()}.";
+	}
+
+	protected override XElement SaveDefinition()
+	{
+		return new XElement("Effect",
+			new XElement("TraceId", TraceId),
+			new XElement("SourceCharacterId", SourceCharacterId),
+			new XElement("TargetCharacterId", TargetCharacterId ?? 0L),
+			new XElement("SourceCellId", SourceCellId ?? 0L),
+			new XElement("PowerId", PowerId),
+			new XElement("SchoolId", SchoolId),
+			new XElement("ActivityKind", ActivityKind),
+			new XElement("ActivityDescription", new XCData(ActivityDescription)),
+			new XElement("UnknownIdentityDescription", new XCData(UnknownIdentityDescription)),
+			new XElement("ReadDifficulty", (int)ReadDifficulty),
+			new XElement("ConcealmentDifficultyStages", ConcealmentDifficultyStages),
+			new XElement("CreatedUtc", CreatedUtc.ToString("O", CultureInfo.InvariantCulture)),
+			new XElement("TraceDurationSeconds", TraceDuration.TotalSeconds)
+		);
+	}
+
+	protected override string SpecificEffectType => "PsionicTrace";
+}

--- a/MudSharpCore/Magic/Powers/ClairaudiencePower.cs
+++ b/MudSharpCore/Magic/Powers/ClairaudiencePower.cs
@@ -42,6 +42,7 @@ public sealed class ClairaudiencePower : SustainedMagicPower
 	private ClairaudiencePower(IFuturemud gameworld, IMagicSchool school, string name, ITraitDefinition trait) : base(gameworld, school, name)
 	{
 		IsPsionic = true;
+		EnablePsionicTraceDefaults();
 		Blurb = "Hear audible output through a contacted mind";
 		_showHelpText = $"Use {school.SchoolVerb.ToUpperInvariant()} CLAIRAUDIENCE <target> to hear audible output at that mind's location.";
 		BeginVerb = "clairaudience";
@@ -163,6 +164,7 @@ public sealed class ClairaudiencePower : SustainedMagicPower
 
 		actor.AddEffect(new MagicClairaudienceConcentrationEffect(actor, this, target), GetDuration(outcome.SuccessDegrees()));
 		actor.OutputHandler.Send(new EmoteOutput(new Emote(BeginEmote, actor, actor, target)));
+		PsionicActivityNotifier.Notify(actor, this, "remote psychic hearing", target);
 		ConsumePowerCosts(actor, BeginVerb);
 	}
 

--- a/MudSharpCore/Magic/Powers/ClairvoyancePower.cs
+++ b/MudSharpCore/Magic/Powers/ClairvoyancePower.cs
@@ -72,7 +72,7 @@ public sealed class ClairvoyancePower : PsionicTargetedPowerBase
 		}
 
 		actor.OutputHandler.Send(RemoteLookRenderer.DescribeRemoteCell(actor, target.Location, target.RoomLayer));
-		PsionicActivityNotifier.Notify(actor, this, "a remote psychic viewing");
+		PsionicActivityNotifier.Notify(actor, this, "a remote psychic viewing", target);
 		ConsumePowerCosts(actor, Verb);
 	}
 }

--- a/MudSharpCore/Magic/Powers/CoercePower.cs
+++ b/MudSharpCore/Magic/Powers/CoercePower.cs
@@ -132,6 +132,7 @@ public sealed class CoercePower : PsionicTargetedPowerBase
 				break;
 		}
 
+		PsionicActivityNotifier.Notify(actor, this, $"psionic coercion ({mode.DescribeEnum().ToLowerInvariant()})", target);
 		ConsumePowerCosts(actor, Verb);
 	}
 

--- a/MudSharpCore/Magic/Powers/ConnectMindPower.cs
+++ b/MudSharpCore/Magic/Powers/ConnectMindPower.cs
@@ -298,6 +298,8 @@ public class ConnectMindPower : SustainedMagicPower
         SelfEmoteForFailConnect = "You reach out and try to connect to $1's mind, but cannot reach stability.";
         EmoteForDisconnect = "You feel the presence of {0} withdraw from your mind.";
         SelfEmoteForDisconnect = "You lose your connection to $1's mind.";
+        IsPsionic = true;
+        EnablePsionicTraceDefaults();
         DoDatabaseInsert();
     }
 
@@ -485,6 +487,7 @@ public class ConnectMindPower : SustainedMagicPower
         if (result.IsPass())
         {
             actor.AddEffect(new ConnectMindEffect(actor, target, this), GetDuration(result.SuccessDegrees()));
+            PsionicActivityNotifier.Notify(actor, this, "a mind connection", target);
         }
 
         ConsumePowerCosts(actor, BeginVerb);
@@ -518,6 +521,7 @@ public class ConnectMindPower : SustainedMagicPower
         }
 
         actor.RemoveEffect(targetEffect, true);
+        PsionicActivityNotifier.Notify(actor, this, "a mind disconnection", targetEffect.TargetCharacter);
         ConsumePowerCosts(actor, EndVerb);
     }
 

--- a/MudSharpCore/Magic/Powers/EmpathyPower.cs
+++ b/MudSharpCore/Magic/Powers/EmpathyPower.cs
@@ -142,7 +142,7 @@ public sealed class EmpathyPower : PsionicTargetedPowerBase
 			actor.OutputHandler.Send(new EmoteOutput(new Emote(StartEcho, actor, actor, target)));
 		}
 
-		PsionicActivityNotifier.Notify(actor, this, "an empathic wound transfer");
+		PsionicActivityNotifier.Notify(actor, this, "an empathic wound transfer", target);
 		ConsumePowerCosts(actor, Verb);
 	}
 

--- a/MudSharpCore/Magic/Powers/HexPower.cs
+++ b/MudSharpCore/Magic/Powers/HexPower.cs
@@ -120,7 +120,7 @@ public sealed class HexPower : PsionicTargetedPowerBase
 			target.OutputHandler.Send(new EmoteOutput(new Emote(TargetEcho, target, actor, target)));
 		}
 
-		PsionicActivityNotifier.Notify(actor, this, "a hostile psychic curse");
+		PsionicActivityNotifier.Notify(actor, this, "a hostile psychic curse", target);
 		ConsumePowerCosts(actor, Verb);
 	}
 

--- a/MudSharpCore/Magic/Powers/MagicPowerBase.cs
+++ b/MudSharpCore/Magic/Powers/MagicPowerBase.cs
@@ -8,6 +8,7 @@ using MudSharp.FutureProg;
 using MudSharp.Models;
 using MudSharp.PerceptionEngine;
 using MudSharp.Planes;
+using MudSharp.RPG.Checks;
 using MudSharp.RPG.Law;
 using System;
 using System.Collections.Generic;
@@ -41,6 +42,7 @@ public abstract class MagicPowerBase : SaveableItem, IMagicPower
         {
             IsPsionic = false;
         }
+        LoadPsionicTraceDefinition(root);
         XElement element = root.Element("CanInvokePowerProg");
         if (element == null)
         {
@@ -106,6 +108,10 @@ public abstract class MagicPowerBase : SaveableItem, IMagicPower
         School = school;
         _name = name;
         IsPsionic = false;
+        CreatesPsionicTrace = false;
+        PsionicTraceDuration = TimeSpan.FromMinutes(30);
+        PsionicTraceReadDifficulty = Difficulty.Normal;
+        PsionicTraceDescription = string.Empty;
         CanInvokePowerProg = Gameworld.AlwaysTrueProg;
         WhyCantInvokePowerProg = Gameworld.UniversalErrorTextProg;
     }
@@ -344,6 +350,11 @@ public abstract class MagicPowerBase : SaveableItem, IMagicPower
     /// </summary>
     public bool IsPsionic { get; protected set; }
 
+    public bool CreatesPsionicTrace { get; protected set; }
+    public TimeSpan PsionicTraceDuration { get; protected set; }
+    public Difficulty PsionicTraceReadDifficulty { get; protected set; }
+    public string PsionicTraceDescription { get; protected set; }
+
     public virtual string ShowHelp(ICharacter voyeur)
     {
         StringBuilder sb = new();
@@ -451,6 +462,10 @@ public abstract class MagicPowerBase : SaveableItem, IMagicPower
 	#3help#0 - drops you into an editor to write the player help file
 	#3cost <verb> <which> <number>#0 - sets the cost of using a particular verb
 	#3psionic#0 - toggles whether this power is psionic for crime and policy purposes
+	#3trace#0 - toggles durable psionic trace creation
+	#3traceduration <timespan|seconds>#0 - sets how long durable traces last
+	#3tracedifficulty <difficulty>#0 - sets how hard traces are to read
+	#3tracedesc <text>#0 - sets the activity text for traces
 {SubtypeHelpText}";
 
     public virtual bool BuildingCommand(ICharacter actor, StringStack command)
@@ -480,15 +495,131 @@ public abstract class MagicPowerBase : SaveableItem, IMagicPower
             case "psionic":
             case "psi":
                 return BuildingCommandPsionic(actor);
+            case "trace":
+            case "traces":
+                return BuildingCommandTrace(actor);
+            case "traceduration":
+            case "tracetime":
+                return BuildingCommandTraceDuration(actor, command);
+            case "tracedifficulty":
+            case "tracediff":
+                return BuildingCommandTraceDifficulty(actor, command);
+            case "tracedesc":
+            case "tracedescription":
+                return BuildingCommandTraceDescription(actor, command);
         }
 
         actor.OutputHandler.Send(HelpText.SubstituteANSIColour());
         return false;
     }
 
+    protected void EnablePsionicTraceDefaults(string description = "")
+    {
+        CreatesPsionicTrace = true;
+        PsionicTraceDuration = PsionicTraceDuration <= TimeSpan.Zero ? TimeSpan.FromMinutes(30) : PsionicTraceDuration;
+        if (!string.IsNullOrWhiteSpace(description))
+        {
+            PsionicTraceDescription = description;
+        }
+    }
+
+    private void LoadPsionicTraceDefinition(XElement root)
+    {
+        PsionicTraceDuration = TimeSpan.FromMinutes(30);
+        PsionicTraceReadDifficulty = Difficulty.Normal;
+        PsionicTraceDescription = string.Empty;
+        XElement trace = root.Element("PsionicTrace");
+        if (trace is null)
+        {
+            CreatesPsionicTrace = false;
+            return;
+        }
+
+        CreatesPsionicTrace = bool.Parse(trace.Element("Enabled")?.Value ?? "false");
+        PsionicTraceDuration = TimeSpan.FromSeconds(double.Parse(trace.Element("DurationSeconds")?.Value ?? "1800"));
+        PsionicTraceReadDifficulty = (Difficulty)int.Parse(trace.Element("ReadDifficulty")?.Value ?? ((int)Difficulty.Normal).ToString());
+        PsionicTraceDescription = trace.Element("Description")?.Value ?? string.Empty;
+    }
+
+    private bool BuildingCommandTrace(ICharacter actor)
+    {
+        CreatesPsionicTrace = !CreatesPsionicTrace;
+        Changed = true;
+        actor.OutputHandler.Send($"This power will {CreatesPsionicTrace.NowNoLonger()} leave durable psionic traces.");
+        return true;
+    }
+
+    private bool BuildingCommandTraceDuration(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("How long should traces from this power last?");
+            return false;
+        }
+
+        TimeSpan newDuration;
+        if (!double.TryParse(command.SafeRemainingArgument, out var seconds))
+        {
+            if (!TimeSpan.TryParse(command.SafeRemainingArgument, actor, out var parsed))
+            {
+                actor.OutputHandler.Send("That is not a valid number of seconds or timespan.");
+                return false;
+            }
+
+            newDuration = parsed;
+        }
+        else
+        {
+            newDuration = TimeSpan.FromSeconds(seconds);
+        }
+
+        if (newDuration <= TimeSpan.Zero)
+        {
+            actor.OutputHandler.Send("Trace duration must be positive.");
+            return false;
+        }
+
+        PsionicTraceDuration = newDuration;
+        Changed = true;
+        actor.OutputHandler.Send($"Traces from this power will now last {PsionicTraceDuration.Describe(actor).ColourValue()}.");
+        return true;
+    }
+
+    private bool BuildingCommandTraceDifficulty(ICharacter actor, StringStack command)
+    {
+        if (!command.SafeRemainingArgument.TryParseEnum(out Difficulty difficulty))
+        {
+            actor.OutputHandler.Send($"Valid difficulties are {Enum.GetValues<Difficulty>().Select(x => x.DescribeColoured()).ListToString()}.");
+            return false;
+        }
+
+        PsionicTraceReadDifficulty = difficulty;
+        Changed = true;
+        actor.OutputHandler.Send($"Trace reads now use {difficulty.DescribeColoured()} difficulty.");
+        return true;
+    }
+
+    private bool BuildingCommandTraceDescription(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("What should traces from this power be described as?");
+            return false;
+        }
+
+        PsionicTraceDescription = command.SafeRemainingArgument;
+        Changed = true;
+        actor.OutputHandler.Send($"Trace activity will now be described as {PsionicTraceDescription.ColourValue()}.");
+        return true;
+    }
+
     private bool BuildingCommandPsionic(ICharacter actor)
     {
         IsPsionic = !IsPsionic;
+        if (IsPsionic && !CreatesPsionicTrace)
+        {
+            EnablePsionicTraceDefaults();
+        }
         Changed = true;
         actor.OutputHandler.Send($"This power is {IsPsionic.NowNoLonger()} considered psionic.");
         return true;
@@ -693,6 +824,13 @@ public abstract class MagicPowerBase : SaveableItem, IMagicPower
         sb.AppendLine($"Type: {PowerType.ColourValue()}");
         sb.AppendLine($"School: {School.Name.Colour(School.PowerListColour)}");
         sb.AppendLine($"Psionic: {IsPsionic.ToColouredString()}");
+        sb.AppendLine($"Leaves Traces: {CreatesPsionicTrace.ToColouredString()}");
+        if (CreatesPsionicTrace)
+        {
+            sb.AppendLine($"Trace Duration: {PsionicTraceDuration.Describe(actor).ColourValue()}");
+            sb.AppendLine($"Trace Read Difficulty: {PsionicTraceReadDifficulty.DescribeColoured()}");
+            sb.AppendLine($"Trace Description: {(string.IsNullOrWhiteSpace(PsionicTraceDescription) ? "Default".ColourValue() : PsionicTraceDescription.ColourCommand())}");
+        }
         sb.AppendLine($"Blurb: {Blurb.ColourCommand()}");
         sb.AppendLine($"Can Invoke Prog: {CanInvokePowerProg?.MXPClickableFunctionName() ?? "None".ColourError()}");
         sb.AppendLine($"Why Can't Invoke Prog: {WhyCantInvokePowerProg?.MXPClickableFunctionName() ?? "None".ColourError()}");
@@ -725,6 +863,12 @@ public abstract class MagicPowerBase : SaveableItem, IMagicPower
     protected void AddBaseDefinition(XElement root)
     {
         root.Add(new XElement("IsPsionic", IsPsionic));
+        root.Add(new XElement("PsionicTrace",
+            new XElement("Enabled", CreatesPsionicTrace),
+            new XElement("DurationSeconds", PsionicTraceDuration.TotalSeconds),
+            new XElement("ReadDifficulty", (int)PsionicTraceReadDifficulty),
+            new XElement("Description", new XCData(PsionicTraceDescription ?? string.Empty))
+        ));
         root.Add(new XElement("CanInvokePowerProg", CanInvokePowerProg.Id));
         root.Add(new XElement("WhyCantInvokePowerProg", WhyCantInvokePowerProg.Id));
         root.Add(new XElement("InvocationCosts",

--- a/MudSharpCore/Magic/Powers/MindAuditPower.cs
+++ b/MudSharpCore/Magic/Powers/MindAuditPower.cs
@@ -74,6 +74,8 @@ public class MindAuditPower : MagicPowerBase
         EmoteTextSelf = "You close your eyes and search your mind for foreign presences.";
         EchoToDetectedTarget = "You feel as if your presence in $0's mind has been detected.";
         ShouldEchoDetectionProg = Gameworld.AlwaysFalseProg;
+        IsPsionic = true;
+        EnablePsionicTraceDefaults();
         DoDatabaseInsert();
     }
 
@@ -181,6 +183,7 @@ public class MindAuditPower : MagicPowerBase
         ICheck check = Gameworld.GetCheck(CheckType.MindAuditPower);
         Dictionary<Difficulty, CheckOutcome> results = check.CheckAgainstAllDifficulties(actor, Difficulty.Normal, SkillCheckTrait);
         StringBuilder sb = new();
+        List<ICharacter> detectedTargets = new();
         foreach (MindConnectedToEffect effect in actor.EffectsOfType<MindConnectedToEffect>())
         {
             string difficultyText = SkillCheckDifficultyProg.Execute<string>(effect.OriginatorCharacter, actor);
@@ -204,6 +207,7 @@ public class MindAuditPower : MagicPowerBase
                            effect.OriginatorCharacter.HowSeen(actor,
                                flags: PerceiveIgnoreFlags.IgnoreCanSee | PerceiveIgnoreFlags.IgnoreDisguises);
             sb.AppendLine($"You detect the presence of {identity} in your mind.");
+            detectedTargets.Add(effect.OriginatorCharacter);
 
             if (!string.IsNullOrEmpty(EchoToDetectedTarget) && ShouldEchoDetectionProg.Execute<bool?>(effect.OriginatorCharacter, actor) == true)
             {
@@ -217,6 +221,7 @@ public class MindAuditPower : MagicPowerBase
         }
 
         actor.OutputHandler.Send(sb.ToString());
+        PsionicActivityNotifier.Notify(actor, this, "a mental audit", detectedTargets);
         ConsumePowerCosts(actor, Verb);
     }
 

--- a/MudSharpCore/Magic/Powers/MindBroadcastPower.cs
+++ b/MudSharpCore/Magic/Powers/MindBroadcastPower.cs
@@ -84,6 +84,8 @@ public class MindBroadcastPower : MagicPowerBase
         UseLanguage = false;
         UseAccent = false;
         PowerDistance = MagicPowerDistance.AdjacentLocationsOnly;
+        IsPsionic = true;
+        EnablePsionicTraceDefaults();
         DoDatabaseInsert();
     }
 
@@ -248,18 +250,15 @@ public class MindBroadcastPower : MagicPowerBase
             return;
         }
 
-        IEnumerable<ICharacter> targets = AcquireAllValidTargets(actor, PowerDistance);
+        var targets = AcquireAllValidTargets(actor, PowerDistance)
+                      .Where(x => TargetIncluded?.Execute<bool?>(x) != false)
+                      .ToList();
 
         if (UseLanguage)
         {
             PsychicLanguageInfo langInfo = new(actor.CurrentLanguage, UseAccent ? actor.CurrentAccent : null, text, outcome, actor);
             foreach (ICharacter target in targets.AsEnumerable())
             {
-                if (TargetIncluded?.Execute<bool?>(target) == false)
-                {
-                    continue;
-                }
-
                 LanguageOutput emote = new(new Emote(GetAppropriateTargetEmote(actor, target), actor, actor, target), langInfo, null);
                 target.OutputHandler.Send(emote);
             }
@@ -270,17 +269,14 @@ public class MindBroadcastPower : MagicPowerBase
         {
             foreach (ICharacter target in targets.AsEnumerable())
             {
-                if (TargetIncluded?.Execute<bool?>(target) == false)
-                {
-                    continue;
-                }
-
                 EmoteOutput emote = new(new Emote($"{GetAppropriateTargetEmote(actor, target)} \"{text.ProperSentences().Fullstop()}\"", actor, PermitLanguageOptions.IgnoreLanguage, actor, target), flags: OutputFlags.NoLanguage);
                 target.OutputHandler.Send(emote);
             }
 
             actor.OutputHandler.Send(new EmoteOutput(new Emote($"{EmoteText} \"{text.ProperSentences().Fullstop()}\"", actor, PermitLanguageOptions.IgnoreLanguage, actor), flags: OutputFlags.NoLanguage));
         }
+
+        PsionicActivityNotifier.Notify(actor, this, "a psychic broadcast", targets);
     }
 
     public override IEnumerable<string> Verbs => new[] { Verb };

--- a/MudSharpCore/Magic/Powers/MindExpelPower.cs
+++ b/MudSharpCore/Magic/Powers/MindExpelPower.cs
@@ -70,6 +70,8 @@ public class MindExpelPower : MagicPowerBase
         EmoteTextSelf = "You close your eyes and attempt to cast out all foreign presences.";
         EchoToExpelledTarget = "You were ejected from $0's mind.";
         EchoToNonExpelledTarget = "You sense that $0 tried to expel you from &0's mind, but failed.";
+        IsPsionic = true;
+        EnablePsionicTraceDefaults();
         DoDatabaseInsert();
     }
 
@@ -178,6 +180,7 @@ public class MindExpelPower : MagicPowerBase
         ICheck check = Gameworld.GetCheck(CheckType.MindExpelPower);
         Dictionary<Difficulty, CheckOutcome> results = check.CheckAgainstAllDifficulties(actor, Difficulty.Normal, SkillCheckTrait);
         StringBuilder sb = new();
+        List<ICharacter> expelledTargets = new();
         foreach (MindConnectedToEffect effect in actor.EffectsOfType<MindConnectedToEffect>())
         {
             string difficultyText = SkillCheckDifficultyProg.Execute<string>(effect.OriginatorCharacter, actor);
@@ -200,6 +203,7 @@ public class MindExpelPower : MagicPowerBase
                            effect.OriginatorCharacter.HowSeen(actor,
                                flags: PerceiveIgnoreFlags.IgnoreCanSee | PerceiveIgnoreFlags.IgnoreDisguises);
             sb.AppendLine($"You successfully expel the presence of {identity} from your mind.");
+            expelledTargets.Add(effect.OriginatorCharacter);
 
             if (!string.IsNullOrEmpty(EchoToExpelledTarget))
             {
@@ -213,6 +217,7 @@ public class MindExpelPower : MagicPowerBase
         }
 
         actor.OutputHandler.Send(sb.ToString());
+        PsionicActivityNotifier.Notify(actor, this, "a mental expulsion", expelledTargets);
         ConsumePowerCosts(actor, Verb);
     }
 

--- a/MudSharpCore/Magic/Powers/MindSayPower.cs
+++ b/MudSharpCore/Magic/Powers/MindSayPower.cs
@@ -81,6 +81,8 @@ public class MindSayPower : MagicPowerBase
         TellVerb = "tell";
         UseLanguage = false;
         UseAccent = false;
+        IsPsionic = true;
+        EnablePsionicTraceDefaults();
         DoDatabaseInsert();
     }
 
@@ -277,6 +279,8 @@ public class MindSayPower : MagicPowerBase
             actor.OutputHandler.Send(new EmoteOutput(new Emote(
                 string.Format(EmoteText, text.ProperSentences().Fullstop()), actor, PermitLanguageOptions.IgnoreLanguage, actor, effect.TargetCharacter)));
         }
+
+        PsionicActivityNotifier.Notify(actor, this, "a directed mental message", effect.TargetCharacter);
     }
 
     public override IEnumerable<string> Verbs => new[] { SayVerb, TellVerb };

--- a/MudSharpCore/Magic/Powers/PresciencePower.cs
+++ b/MudSharpCore/Magic/Powers/PresciencePower.cs
@@ -51,6 +51,7 @@ public sealed class PresciencePower : MagicPowerBase
 		base(gameworld, school, name)
 	{
 		IsPsionic = true;
+		EnablePsionicTraceDefaults();
 		Blurb = "Submit a prescient question to an administrator board";
 		_showHelpText =
 			$"Use {school.SchoolVerb.ToUpperInvariant()} PRESCIENCE to enter a question for staff to answer through dreams or other story methods.";

--- a/MudSharpCore/Magic/Powers/ProjectEmotionPower.cs
+++ b/MudSharpCore/Magic/Powers/ProjectEmotionPower.cs
@@ -84,6 +84,7 @@ public sealed class ProjectEmotionPower : PsionicTargetedPowerBase
 		}
 
 		PsionicTrafficHelper.DeliverEmotion(actor, target, School, command.SafeRemainingArgument);
+		PsionicActivityNotifier.Notify(actor, this, "projected emotion", target);
 		ConsumePowerCosts(actor, Verb);
 	}
 }

--- a/MudSharpCore/Magic/Powers/PsionicSustainedSelfPowerBase.cs
+++ b/MudSharpCore/Magic/Powers/PsionicSustainedSelfPowerBase.cs
@@ -41,6 +41,7 @@ public abstract class PsionicSustainedSelfPowerBase : SustainedMagicPower
 		: base(gameworld, school, name)
 	{
 		IsPsionic = true;
+		EnablePsionicTraceDefaults();
 		BeginVerb = DefaultBeginVerb;
 		EndVerb = DefaultEndVerb;
 		SkillCheckTrait = trait;
@@ -135,6 +136,7 @@ public abstract class PsionicSustainedSelfPowerBase : SustainedMagicPower
 
 		actor.AddEffect(CreateEffect(actor), GetDuration(outcome.SuccessDegrees()));
 		actor.OutputHandler.Send(new EmoteOutput(new Emote(BeginEmote, actor, actor)));
+		PsionicActivityNotifier.Notify(actor, this, $"sustaining {Name}");
 		ConsumePowerCosts(actor, BeginVerb);
 	}
 

--- a/MudSharpCore/Magic/Powers/PsionicTargetedPowerBase.cs
+++ b/MudSharpCore/Magic/Powers/PsionicTargetedPowerBase.cs
@@ -41,6 +41,7 @@ public abstract class PsionicTargetedPowerBase : MagicPowerBase
 		base(gameworld, school, name)
 	{
 		IsPsionic = true;
+		EnablePsionicTraceDefaults();
 		Verb = DefaultVerb;
 		PowerDistance = MagicPowerDistance.AnyConnectedMindOrConnectedTo;
 		SkillCheckTrait = trait;

--- a/MudSharpCore/Magic/Powers/PsychicBoltPower.cs
+++ b/MudSharpCore/Magic/Powers/PsychicBoltPower.cs
@@ -115,7 +115,7 @@ public sealed class PsychicBoltPower : PsionicTargetedPowerBase
 			target.OutputHandler.Send(new EmoteOutput(new Emote(TargetEcho, target, actor, target)));
 		}
 
-		PsionicActivityNotifier.Notify(actor, this, "a bolt of hostile psychic force");
+		PsionicActivityNotifier.Notify(actor, this, "a bolt of hostile psychic force", target);
 		ConsumePowerCosts(actor, Verb);
 	}
 

--- a/MudSharpCore/Magic/Powers/SuggestPower.cs
+++ b/MudSharpCore/Magic/Powers/SuggestPower.cs
@@ -100,6 +100,7 @@ public sealed class SuggestPower : PsionicTargetedPowerBase
 		}
 
 		PsionicTrafficHelper.DeliverThought(actor, target, School, thought);
+		PsionicActivityNotifier.Notify(actor, this, "a suggested thought", target);
 		ConsumePowerCosts(actor, Verb);
 	}
 

--- a/MudSharpCore/Magic/Powers/TracePower.cs
+++ b/MudSharpCore/Magic/Powers/TracePower.cs
@@ -74,30 +74,57 @@ public sealed class TracePower : PsionicTargetedPowerBase
 		var results = Gameworld.GetCheck(CheckType.MagicTelepathyCheck)
 		                       .CheckAgainstAllDifficulties(actor, SkillCheckDifficulty, SkillCheckTrait, target);
 		var links = TraceLinks(target).DistinctBy(x => x.Character).ToList();
-		if (!links.Any())
+		var traces = TraceResiduals(target).DistinctBy(x => x.TraceId).OrderByDescending(x => x.CreatedUtc).ToList();
+		if (!links.Any() && !traces.Any())
 		{
-			actor.OutputHandler.Send($"{target.HowSeen(actor, true)} has no active mind links that you can detect.");
+			actor.OutputHandler.Send($"{target.HowSeen(actor, true)} has no active mind links or residual psionic traces that you can detect.");
+			PsionicActivityNotifier.Notify(actor, this, "a psionic trace scan", target);
 			ConsumePowerCosts(actor, Verb);
 			return;
 		}
 
 		var sb = new StringBuilder();
-		sb.AppendLine($"You trace the active mind links around {target.HowSeen(actor, true)}:");
-		foreach (var link in links)
+		if (links.Any())
 		{
-			var concealment = link.Character.EffectsOfType<IMindContactConcealmentEffect>()
-			                      .FirstOrDefault(x => x.ConcealsIdentityFrom(link.Character, actor, School));
-			var difficulty = concealment is null
-				? SkillCheckDifficulty
-				: SkillCheckDifficulty.StageUp(concealment.AuditDifficultyStages);
-			var visible = results[difficulty] >= MinimumSuccessThreshold;
-			var description = visible
-				? link.Character.HowSeen(actor, flags: PerceiveIgnoreFlags.IgnoreConsciousness)
-				: concealment?.UnknownIdentityDescription.ColourCharacter() ?? "an unknown mind".ColourCharacter();
-			sb.AppendLine($"\t{link.Direction}: {description} [{link.School.Name.Colour(link.School.PowerListColour)}]");
+			sb.AppendLine($"You trace the active mind links around {target.HowSeen(actor, true)}:");
+			foreach (var link in links)
+			{
+				var concealment = link.Character.EffectsOfType<IMindContactConcealmentEffect>()
+				                      .FirstOrDefault(x => x.ConcealsIdentityFrom(link.Character, actor, School));
+				var difficulty = concealment is null
+					? SkillCheckDifficulty
+					: SkillCheckDifficulty.StageUp(concealment.AuditDifficultyStages);
+				var visible = results[difficulty] >= MinimumSuccessThreshold;
+				var description = visible
+					? link.Character.HowSeen(actor, flags: PerceiveIgnoreFlags.IgnoreConsciousness)
+					: concealment?.UnknownIdentityDescription.ColourCharacter() ?? "an unknown mind".ColourCharacter();
+				sb.AppendLine($"\t{link.Direction}: {description} [{link.School.Name.Colour(link.School.PowerListColour)}]");
+			}
+		}
+
+		if (traces.Any())
+		{
+			if (links.Any())
+			{
+				sb.AppendLine();
+			}
+
+			sb.AppendLine($"Residual psionic traces around {target.HowSeen(actor, true)}:");
+			foreach (var trace in traces)
+			{
+				var difficulty = trace.ReadDifficulty.StageUp(trace.ConcealmentDifficultyStages);
+				var visible = results[difficulty] >= MinimumSuccessThreshold;
+				var source = visible && trace.SourceCharacter is not null
+					? trace.SourceCharacter.HowSeen(actor, flags: PerceiveIgnoreFlags.IgnoreConsciousness)
+					: trace.UnknownIdentityDescription.ColourCharacter();
+				var school = trace.School?.Name.Colour(trace.School.PowerListColour) ?? "unknown school".ColourError();
+				var age = (DateTime.UtcNow - trace.CreatedUtc).Describe(actor);
+				sb.AppendLine($"\t{trace.ActivityDescription.ProperSentences()} from {source} [{school}], about {age} ago.");
+			}
 		}
 
 		actor.OutputHandler.Send(sb.ToString());
+		PsionicActivityNotifier.Notify(actor, this, "a psionic trace scan", target);
 		ConsumePowerCosts(actor, Verb);
 	}
 
@@ -111,6 +138,24 @@ public sealed class TracePower : PsionicTargetedPowerBase
 		foreach (var effect in target.EffectsOfType<MindConnectedToEffect>())
 		{
 			yield return (effect.OriginatorCharacter, "inbound", effect.School);
+		}
+	}
+
+	private static IEnumerable<IPsionicTraceEffect> TraceResiduals(ICharacter target)
+	{
+		foreach (var trace in target.EffectsOfType<IPsionicTraceEffect>())
+		{
+			yield return trace;
+		}
+
+		if (target.Location is null)
+		{
+			yield break;
+		}
+
+		foreach (var trace in target.Location.EffectsOfType<IPsionicTraceEffect>().Where(x => x.Involves(target)))
+		{
+			yield return trace;
 		}
 	}
 }

--- a/MudSharpCore/Magic/PsionicActivityNotifier.cs
+++ b/MudSharpCore/Magic/PsionicActivityNotifier.cs
@@ -1,16 +1,15 @@
 #nullable enable
 
 using MudSharp.Character;
+using MudSharp.Construction;
 using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace MudSharp.Magic;
-
-public enum PsionicActivityKind
-{
-	Magical = 0,
-	Psychic = 1
-}
 
 public readonly record struct PsionicActivity(
 	ICharacter Source,
@@ -20,7 +19,12 @@ public readonly record struct PsionicActivity(
 
 public static class PsionicActivityNotifier
 {
-	public static void Notify(ICharacter source, IMagicPower power, string description)
+	public static void Notify(ICharacter source, IMagicPower power, string description, ICharacter? target = null)
+	{
+		Notify(source, power, description, target is null ? [] : [target]);
+	}
+
+	public static void Notify(ICharacter source, IMagicPower power, string description, IEnumerable<ICharacter> targets)
 	{
 		var activity = new PsionicActivity(source, power, power.IsPsionic ? PsionicActivityKind.Psychic : PsionicActivityKind.Magical,
 			description);
@@ -28,6 +32,49 @@ public static class PsionicActivityNotifier
 		foreach (var effect in source.Gameworld.Characters.SelectMany(x => x.EffectsOfType<PsionicSensitivityEffect>()).ToList())
 		{
 			effect.NotifyActivity(activity);
+		}
+
+		if (power is not Powers.MagicPowerBase powerBase ||
+		    !powerBase.CreatesPsionicTrace ||
+		    powerBase.PsionicTraceDuration <= TimeSpan.Zero)
+		{
+			return;
+		}
+
+		var traceId = Guid.NewGuid();
+		var targetList = targets.Where(x => x is not null).Distinct().ToList();
+		var owners = new List<IPerceivable> { source };
+		owners.AddRange(targetList);
+		if (source.Location is not null)
+		{
+			owners.Add(source.Location);
+		}
+
+		foreach (var owner in owners.Distinct())
+		{
+			var traceTarget = owner is ICharacter characterOwner && targetList.Contains(characterOwner)
+				? characterOwner
+				: targetList.Count == 1
+					? targetList[0]
+					: null;
+			var concealment = traceTarget is null
+				? null
+				: source.EffectsOfType<IMindContactConcealmentEffect>()
+				        .FirstOrDefault(x => x.ConcealsIdentityFrom(source, traceTarget, power.School));
+			var unknownDescription = concealment?.UnknownIdentityDescription ?? "an unknown mind";
+			var concealmentStages = concealment?.AuditDifficultyStages ?? 0;
+
+			if (owner.EffectsOfType<IPsionicTraceEffect>().Any(x => x.TraceId == traceId))
+			{
+				continue;
+			}
+
+			owner.AddEffect(new PsionicTraceEffect(owner, source, traceTarget, source.Location, powerBase, activity.Kind,
+				string.IsNullOrWhiteSpace(powerBase.PsionicTraceDescription)
+					? description
+					: powerBase.PsionicTraceDescription,
+				unknownDescription, powerBase.PsionicTraceReadDifficulty, concealmentStages, traceId,
+				DateTime.UtcNow, powerBase.PsionicTraceDuration), powerBase.PsionicTraceDuration);
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add saveable timed psionic trace effects and public trace activity metadata.
- Extend psionic activity notification, base power trace configuration, and successful psionic power paths to record residual traces.
- Update trace output/docs and add focused MagicPsionicTraceTests coverage.

## Validation
- `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 --filter FullyQualifiedName~MagicPsionicTraceTests`
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 --filter FullyQualifiedName~MagicEngineV4Tests`
- `git diff --check`