### PR TITLE
Fix duplicate tag seeding in the item seeder

### DIFF
--- a/DatabaseSeeder Unit Tests/UsefulSeederItemPackageTests.cs
+++ b/DatabaseSeeder Unit Tests/UsefulSeederItemPackageTests.cs
@@ -559,6 +559,12 @@ public class UsefulSeederItemPackageTests
 	{
 		using FuturemudDatabaseContext context = BuildContext();
 		SeedGeneralPrerequisites(context);
+		context.Tags.AddRange(
+			new Tag { Id = 1, Name = "Functions" },
+			new Tag { Id = 2, Name = "Tools", ParentId = 1 },
+			new Tag { Id = 3, Name = "Scientific Tools", ParentId = 2 },
+			new Tag { Id = 4, Name = "Measurement Tools", ParentId = 3 });
+		context.SaveChanges();
 		SeedMarketCategories(context);
 		UsefulSeeder usefulSeeder = new();
 		usefulSeeder.SeedAntiquityComponentGapCoverageForTesting(context);
@@ -605,6 +611,20 @@ public class UsefulSeederItemPackageTests
 		GameItemProto oilCup = LoadItem(context, "antiquity_oil_measure_cup");
 		CollectionAssert.Contains(ComponentNames(oilCup), "LContainer_DrinkingGlass");
 		CollectionAssert.Contains(ComponentNames(oilCup), "MeasuringInstrument_Antiquity_OilCup");
+		Assert.AreEqual(1, context.Tags.Count(x => x.Name == "Measurement Tools"),
+			"The item seeder should reuse the existing measurement tag instead of creating a shorter duplicate path.");
+		var measurementTag = context.Tags.Single(x => x.Name == "Measurement Tools");
+		CollectionAssert.Contains(
+			context.GameItemProtosTags
+			       .Where(x => x.GameItemProtoId == oilCup.Id)
+			       .Select(x => x.TagId)
+			       .ToArray(),
+			measurementTag.Id);
+		Assert.IsFalse(context.Tags
+		                      .AsEnumerable()
+		                      .GroupBy(x => x.Name, StringComparer.OrdinalIgnoreCase)
+		                      .Any(x => x.Count() > 1),
+			"Seeded item tag creation should not create duplicate tag names.");
 
 		GameItemProto publicWell = LoadItem(context, "antiquity_stone_public_well");
 		CollectionAssert.Contains(ComponentNames(publicWell), "WaterSource_Antiquity_PublicWell");

--- a/DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityFood.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Rework.AntiquityFood.cs
@@ -516,13 +516,20 @@ public partial class ItemSeeder
 			}
 
 			var parentId = parent?.Id;
+			_tags.TryGetValue(part, out var cachedTag);
 			existing = _context!.Tags.Local
 			                    .FirstOrDefault(x => x.Name.Equals(part, StringComparison.OrdinalIgnoreCase) &&
 			                                         x.ParentId == parentId) ??
 			           _context.Tags
 			                   .AsEnumerable()
 			                   .FirstOrDefault(x => x.Name.Equals(part, StringComparison.OrdinalIgnoreCase) &&
-			                                        x.ParentId == parentId);
+			                                        x.ParentId == parentId) ??
+			           cachedTag ??
+			           _context.Tags.Local
+			                   .FirstOrDefault(x => x.Name.Equals(part, StringComparison.OrdinalIgnoreCase)) ??
+			           _context.Tags
+			                   .AsEnumerable()
+			                   .FirstOrDefault(x => x.Name.Equals(part, StringComparison.OrdinalIgnoreCase));
 			if (existing is null)
 			{
 				existing = new Tag

--- a/DatabaseSeeder/Seeders/ItemSeeder.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.cs
@@ -97,7 +97,10 @@ The items and crafts are fairly universal and of approximately medieval to renei
         }
 
         _components = _context.GameItemComponentProtos.ToDictionary(x => x.Name, x => x, StringComparer.OrdinalIgnoreCase);
-        _tags = _context.Tags.ToDictionary(x => x.Name, x => x, StringComparer.OrdinalIgnoreCase);
+        _tags = _context.Tags
+            .AsEnumerable()
+            .GroupBy(x => x.Name, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(x => x.Key, x => x.OrderBy(tag => tag.Id).First(), StringComparer.OrdinalIgnoreCase);
         var tagList = _context.Tags.ToList();
         var tagsById = tagList.ToDictionary(x => x.Id);
         Dictionary<long, string> fullPathCache = new();
@@ -125,7 +128,9 @@ The items and crafts are fairly universal and of approximately medieval to renei
             return path;
         }
 
-        _tagsByFullPath = tagList.ToDictionary(BuildTagFullPath, x => x, StringComparer.OrdinalIgnoreCase);
+        _tagsByFullPath = tagList
+            .GroupBy(BuildTagFullPath, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(x => x.Key, x => x.OrderBy(tag => tag.Id).First(), StringComparer.OrdinalIgnoreCase);
         _materials = _context.Materials.ToDictionary(x => x.Name, x => x, StringComparer.OrdinalIgnoreCase);
         _liquids = _context.Liquids.ToDictionary(x => x.Name, x => x, StringComparer.OrdinalIgnoreCase);
         _nextId = _context.GameItemProtos.Any()

--- a/DatabaseSeeder/Seeders/UsefulSeeder.ItemComponents.cs
+++ b/DatabaseSeeder/Seeders/UsefulSeeder.ItemComponents.cs
@@ -7684,13 +7684,20 @@ public partial class UsefulSeeder
             foreach (var part in parts)
             {
                 long? parentId = parent?.Id;
+                _tags.TryGetValue(part, out var cachedTag);
                 var tag = context.Tags.Local
                                  .FirstOrDefault(x => x.Name.Equals(part, StringComparison.OrdinalIgnoreCase) &&
                                                       x.ParentId == parentId) ??
                           context.Tags
                                  .AsEnumerable()
                                  .FirstOrDefault(x => x.Name.Equals(part, StringComparison.OrdinalIgnoreCase) &&
-                                                      x.ParentId == parentId);
+                                                      x.ParentId == parentId) ??
+                          cachedTag ??
+                          context.Tags.Local
+                                 .FirstOrDefault(x => x.Name.Equals(part, StringComparison.OrdinalIgnoreCase)) ??
+                          context.Tags
+                                 .AsEnumerable()
+                                 .FirstOrDefault(x => x.Name.Equals(part, StringComparison.OrdinalIgnoreCase));
                 if (tag is null)
                 {
                     var existing = context.Tags.Any() ? context.Tags.Max(x => x.Id) : 0L;

--- a/DatabaseSeeder/Seeders/UsefulSeeder.Tags.cs
+++ b/DatabaseSeeder/Seeders/UsefulSeeder.Tags.cs
@@ -15,8 +15,19 @@ namespace DatabaseSeeder.Seeders
 
         private void AddTag(FuturemudDatabaseContext context, string name, string parent)
         {
-            if (_tags.Any(x => x.Key.Equals(name, StringComparison.InvariantCultureIgnoreCase)))
+            if (_tags.TryGetValue(name, out _))
             {
+                return;
+            }
+
+            var existing = context.Tags.Local
+                                  .FirstOrDefault(x => x.Name.Equals(name, StringComparison.OrdinalIgnoreCase)) ??
+                           context.Tags
+                                  .AsEnumerable()
+                                  .FirstOrDefault(x => x.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+            if (existing is not null)
+            {
+                _tags[name] = existing;
                 return;
             }
 
@@ -1506,7 +1517,6 @@ namespace DatabaseSeeder.Seeders
             AddTag(context, "Roofing Materials", "Construction Materials");
 
             AddTag(context, "Household Consumables", "Market");
-            AddTag(context, "Soap", "Household Consumables");
             AddTag(context, "Lamp Oil", "Household Consumables");
             AddTag(context, "Cleaning Supplies", "Household Consumables");
             AddTag(context, "Candlemaking Wax", "Household Consumables");


### PR DESCRIPTION
## Summary
- Made tag lookup and tag-path resolution tolerate pre-existing duplicate names by reusing the first installed tag instead of crashing.
- Updated the item-path helpers used by rework and stock item seeding to upsert by tag name, preventing duplicate `Measurement Tools` rows from being created.
- Removed a stale duplicate `Soap` tag entry from the seeded tag catalogue.
- Added a regression test that seeds an existing measurement-tag hierarchy and verifies reruns reuse it without duplicating tag names.

## Testing
- `dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore -m:1 --filter UsefulSeederItemPackageTests -p:NoWarn=NU1902%3BNU1510`
- `dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore -m:1 --filter ItemSeederReworkMetadataTests -p:NoWarn=NU1902%3BNU1510`
- `git diff --check`