### PR TITLE
Cap computer for-loop execution

### DIFF
--- a/Design Documents/Technology/FutureMUD_Computer_Programs_Concept_Design.md
+++ b/Design Documents/Technology/FutureMUD_Computer_Programs_Concept_Design.md
@@ -237,6 +237,8 @@ Computer compilation contexts work as an allow-list, not a deny-list. The curren
 
 Statements like `console`, `delay`, `delayprog`, `force`, `send`, and `setregister` remain standard-prog-only.
 
+Computer-context `while` and `for` loops are both bounded at runtime to 10,000 iterations per loop activation. Attempts to execute larger `for` counts, including values too large for the supported integer iteration range, fail the computer program or function instead of continuing synchronously on the game-processing thread.
+
 ### Additional Statements
 
 There are a few statements and wait behaviours that will be only available for Custom Computer Programs and not regular progs. In the currently shipped phase this list contains:

--- a/MudSharpCore Unit Tests/ComputerWorkspaceRuntimeTests.cs
+++ b/MudSharpCore Unit Tests/ComputerWorkspaceRuntimeTests.cs
@@ -175,6 +175,36 @@ return 42");
 	}
 
 	[TestMethod]
+	public void ComputerProgramExecutor_RejectsForLoopAboveBudget()
+	{
+		var program = CompileProgram(
+			"ExpensiveForLoop",
+			@"for (i : 10001)
+end for
+return 1");
+
+		var outcome = ComputerProgramExecutor.Execute(program, Array.Empty<object?>());
+
+		Assert.AreEqual(ComputerProcessStatus.Failed, outcome.Status);
+		StringAssert.Contains(outcome.Error, "For loop of greater than 10,000 iterations");
+	}
+
+	[TestMethod]
+	public void ComputerProgramExecutor_RejectsForLoopOverflowWithoutThrowing()
+	{
+		var program = CompileProgram(
+			"OverflowForLoop",
+			@"for (i : 2147483648)
+end for
+return 1");
+
+		var outcome = ComputerProgramExecutor.Execute(program, Array.Empty<object?>());
+
+		Assert.AreEqual(ComputerProcessStatus.Failed, outcome.Status);
+		StringAssert.Contains(outcome.Error, "For loop of greater than 10,000 iterations");
+	}
+
+	[TestMethod]
 	public void ComputerProgramExecutor_SuspendsAndResumesProgramWithSleep()
 	{
 		var program = CompileProgram(

--- a/MudSharpCore/Computers/ComputerProgramExecutor.cs
+++ b/MudSharpCore/Computers/ComputerProgramExecutor.cs
@@ -392,8 +392,16 @@ internal static class ComputerProgramExecutor
 								return Failure(forLoop.RepetitionsExpression.ErrorMessage);
 							}
 
-							forFrame.TotalIterations =
-								Convert.ToInt32((decimal?)forLoop.RepetitionsExpression.Result?.GetObject ?? 0.0M);
+							if (!ForLoop.TryGetIterationCount(
+								(decimal?)forLoop.RepetitionsExpression.Result?.GetObject ?? 0.0M,
+								forLoop.MaximumIterations,
+								out var totalIterations,
+								out var errorMessage))
+							{
+								return Failure(errorMessage);
+							}
+
+							forFrame.TotalIterations = totalIterations;
 						}
 
 						if (forFrame.TotalIterations <= 0 || forFrame.CurrentIndex > forFrame.TotalIterations)

--- a/MudSharpCore/FutureProg/Statements/ForLoop.cs
+++ b/MudSharpCore/FutureProg/Statements/ForLoop.cs
@@ -17,27 +17,58 @@ internal class ForLoop : Statement
     private static readonly Regex ForLoopEndCompileRegex = new(@"^\s*end for\s*$",
         RegexOptions.Multiline | RegexOptions.IgnoreCase);
 
-    protected IEnumerable<IStatement> ContainedBlock;
-    protected string LoopVarName;
+	protected IEnumerable<IStatement> ContainedBlock;
+	protected string LoopVarName;
 
-    protected IFunction RepetitionsFunction;
+	protected IFunction RepetitionsFunction;
+
+	internal const int DefaultMaximumIterations = 10000;
 
 	internal IFunction RepetitionsExpression => RepetitionsFunction;
 	internal string LoopVariableName => LoopVarName;
+	internal int? MaximumIterations { get; }
 	internal IReadOnlyList<IStatement> BodyStatements =>
 		ContainedBlock as IReadOnlyList<IStatement> ?? ContainedBlock.ToList();
 
-    public override bool IsReturnOrContainsReturnOnAllBranches()
-    {
-        return ContainedBlock.LastOrDefault()?.IsReturnOrContainsReturnOnAllBranches() ?? false;
-    }
+	public override bool IsReturnOrContainsReturnOnAllBranches()
+	{
+		return ContainedBlock.LastOrDefault()?.IsReturnOrContainsReturnOnAllBranches() ?? false;
+	}
 
-    public ForLoop(IFunction repetitions, string loopvarname, IEnumerable<IStatement> containedBlock)
-    {
-        RepetitionsFunction = repetitions;
-        LoopVarName = loopvarname;
-        ContainedBlock = containedBlock;
-    }
+	public ForLoop(IFunction repetitions, string loopvarname, IEnumerable<IStatement> containedBlock,
+		int? maximumIterations = null)
+	{
+		RepetitionsFunction = repetitions;
+		LoopVarName = loopvarname;
+		ContainedBlock = containedBlock;
+		MaximumIterations = maximumIterations;
+	}
+
+	internal static bool TryGetIterationCount(decimal repetitions, int? maximumIterations, out int iterations,
+		out string errorMessage)
+	{
+		if (maximumIterations is not null && repetitions > maximumIterations.Value)
+		{
+			iterations = 0;
+			errorMessage =
+				$"For loop of greater than {maximumIterations.Value:N0} iterations detected, aborting...";
+			return false;
+		}
+
+		try
+		{
+			iterations = Convert.ToInt32(repetitions);
+		}
+		catch (OverflowException)
+		{
+			iterations = 0;
+			errorMessage = "For loop iteration count was outside the supported range, aborting...";
+			return false;
+		}
+
+		errorMessage = string.Empty;
+		return true;
+	}
 
     private static ICompileInfo ForLoopCompile(IEnumerable<string> lines,
         IDictionary<string, ProgVariableTypes> variableSpace, int lineNumber, IFuturemud gameworld)
@@ -81,10 +112,13 @@ internal class ForLoop : Statement
             string line = lines.First();
             if (ForLoopEndCompileRegex.IsMatch(line))
             {
-                return CompileInfo.GetFactory()
-                                  .CreateNew(new ForLoop(function, varName, containedStatements), variableSpace,
-                                      lines.Skip(1),
-                                      lineNumber, currentLine + 1);
+				var maximumIterations = FutureProg.CurrentCompilationContext == FutureProgCompilationContext.StandardFutureProg
+					? (int?)null
+					: DefaultMaximumIterations;
+				return CompileInfo.GetFactory()
+				                  .CreateNew(new ForLoop(function, varName, containedStatements, maximumIterations), variableSpace,
+					                  lines.Skip(1),
+					                  lineNumber, currentLine + 1);
             }
 
             ICompileInfo statementInfo = FutureProg.CompileNextStatement(lines, localVariables, currentLine + 1, gameworld);
@@ -171,49 +205,55 @@ The scope of the variable declared as the iteration variable is limited to being
             "break, continue, end");
     }
 
-    public override StatementResult Execute(IVariableSpace variables)
-    {
-        StatementResult repetitionsResult = RepetitionsFunction.Execute(variables);
-        if (repetitionsResult != StatementResult.Normal)
-        {
-            return repetitionsResult;
-        }
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		StatementResult repetitionsResult = RepetitionsFunction.Execute(variables);
+		if (repetitionsResult != StatementResult.Normal)
+		{
+			return repetitionsResult;
+		}
 
-        int repetitions = Convert.ToInt32((decimal?)RepetitionsFunction.Result?.GetObject ?? 0.0M);
-        if (repetitions <= 0)
-        {
-            return StatementResult.Normal;
-        }
+		if (!TryGetIterationCount((decimal?)RepetitionsFunction.Result?.GetObject ?? 0.0M, MaximumIterations,
+			out var repetitions, out var errorMessage))
+		{
+			ErrorMessage = errorMessage;
+			return StatementResult.Error;
+		}
 
-        for (int i = 1; i <= repetitions; i++)
-        {
-            LocalVariableSpace localVariables = new(variables);
-            localVariables.SetVariable(LoopVarName, new NumberVariable(i));
+		if (repetitions <= 0)
+		{
+			return StatementResult.Normal;
+		}
 
-            foreach (IStatement statement in ContainedBlock)
-            {
-                StatementResult result = statement.Execute(localVariables);
-                if (result == StatementResult.Break)
-                {
-                    return StatementResult.Normal;
-                }
+		for (int i = 1; i <= repetitions; i++)
+		{
+			LocalVariableSpace localVariables = new(variables);
+			localVariables.SetVariable(LoopVarName, new NumberVariable(i));
 
-                if (result == StatementResult.Continue)
-                {
-                    break;
-                }
+			foreach (IStatement statement in ContainedBlock)
+			{
+				StatementResult result = statement.Execute(localVariables);
+				if (result == StatementResult.Break)
+				{
+					return StatementResult.Normal;
+				}
 
-                switch (result)
-                {
-                    case StatementResult.Return:
-                        return StatementResult.Return;
-                    case StatementResult.Error:
-                        ErrorMessage = statement.ErrorMessage;
-                        return StatementResult.Error;
-                }
-            }
-        }
+				if (result == StatementResult.Continue)
+				{
+					break;
+				}
 
-        return StatementResult.Normal;
-    }
+				switch (result)
+				{
+					case StatementResult.Return:
+						return StatementResult.Return;
+					case StatementResult.Error:
+						ErrorMessage = statement.ErrorMessage;
+						return StatementResult.Error;
+				}
+			}
+		}
+
+		return StatementResult.Normal;
+	}
 }


### PR DESCRIPTION
### Motivation
- Prevent player-run computer workspaces from blocking the game by executing unbounded or overflowing `for` loops that consume the main processing thread. 
- Match the existing `while`-loop safeguard by enforcing a per-activation iteration budget for computer-context loops and convert out-of-range counts to controlled failures.

### Description
- Add a per-FOR iteration budget and safe parsing to `ForLoop` by introducing `DefaultMaximumIterations`, an optional `MaximumIterations` instance field, and a shared `TryGetIterationCount` helper that rejects over-budget counts and handles `OverflowException` safely (`MudSharpCore/FutureProg/Statements/ForLoop.cs`).
- Wire the same bounded conversion path into the resumable program executor so programs use the safe iteration conversion before creating `ForFrame` state (`MudSharpCore/Computers/ComputerProgramExecutor.cs`).
- Make computer-context compilation set a default maximum of `10000` iterations while leaving standard FutureProg behaviour unchanged (compiler-time context branching in the `ForLoop` compiler). 
- Add targeted unit tests `ComputerProgramExecutor_RejectsForLoopAboveBudget` and `ComputerProgramExecutor_RejectsForLoopOverflowWithoutThrowing` to cover large and overflowing `for` counts (`MudSharpCore Unit Tests/ComputerWorkspaceRuntimeTests.cs`) and document the budget in the design doc (`Design Documents/Technology/FutureMUD_Computer_Programs_Concept_Design.md`).

### Testing
- Ran `git diff --check` with no issues.
- Ran `dotnet restore "MudSharpCore Unit Tests/MudSharpCore Unit Tests.csproj" -m:1 -p:RestoreBuildInParallel=false -p:NuGetAudit=false` which completed successfully for the test project restore.
- Attempts to run `dotnet test` / `dotnet build` for the full solution or the core runtime in this Linux container did not complete because the Roslyn/MSBuild worker stalled on this environment and the full solution restore fails on Linux due to Windows-targeting projects requiring `EnableWindowsTargeting=true`, so the new unit tests could not be fully exercised here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dce5a7250832380da46f34834c2ca)