### PR TITLE
Restrict senddiscord to standard FutureProg; fix number unboxing and add regression tests

### DIFF
--- a/MudSharpCore Unit Tests/ComputerWorkspaceRuntimeTests.cs
+++ b/MudSharpCore Unit Tests/ComputerWorkspaceRuntimeTests.cs
@@ -142,6 +142,7 @@ return 42");
 		Assert.IsFalse(functions.Any(x => x.FunctionName.EqualTo("LoadItem")));
 		Assert.IsTrue(functions.Any(x => x.FunctionName.EqualTo("UserInput")));
 		Assert.IsTrue(functions.Any(x => x.FunctionName.EqualTo("WaitSignal")));
+		Assert.IsFalse(functions.Any(x => x.FunctionName.EqualTo("SendDiscord")));
 		Assert.IsFalse(service.GetFunctionHelp(FutureProgCompilationContext.ComputerFunction)
 			.Any(x => x.FunctionName.EqualTo("UserInput")));
 		Assert.IsFalse(service.GetFunctionHelp(FutureProgCompilationContext.ComputerFunction)

--- a/MudSharpCore Unit Tests/ProgTests.cs
+++ b/MudSharpCore Unit Tests/ProgTests.cs
@@ -272,6 +272,20 @@ return @parts",
 	}
 
 	[TestMethod]
+	public void ComputerProgramContext_RejectsSendDiscordFunction()
+	{
+		FutureProg prog = new(_gameworld,
+			"ComputerSendDiscord",
+			ProgVariableTypes.Boolean,
+			Array.Empty<Tuple<ProgVariableTypes, string>>(),
+			@"return senddiscord(123, ""title"", ""message"")",
+			FutureProgCompilationContext.ComputerProgram);
+
+		Assert.IsFalse(prog.Compile());
+		StringAssert.Contains(prog.CompileError, "not available in computer program compilation");
+	}
+
+	[TestMethod]
 	public void ComputerProgramContext_RejectsUnsupportedTypes()
 	{
 		FutureProg prog = new(_gameworld,

--- a/MudSharpCore/FutureProg/Functions/Discord/SendDiscordMessageFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Discord/SendDiscordMessageFunction.cs
@@ -35,7 +35,8 @@ internal class SendDiscordMessageFunction : BuiltInFunction
                 new List<string> { "The numeric Discord channel ID to send to.", "The title or heading of the outgoing message.", "The body text of the outgoing Discord message." },
                 "Sends a Discord message through the configured Discord connection using channel ID, title, and message text. Returns false if any argument is null; returns true after queueing the send even if no Discord connection is currently configured.",
                 "Discord",
-                ProgVariableTypes.Boolean
+                ProgVariableTypes.Boolean,
+                allowedContexts: new[] { FutureProgCompilationContext.StandardFutureProg }
             )
         );
     }
@@ -54,7 +55,7 @@ internal class SendDiscordMessageFunction : BuiltInFunction
             return StatementResult.Normal;
         }
 
-        ulong channelId = (ulong)(double)channelResult.GetObject;
+        var channelId = (ulong)Math.Truncate(Convert.ToDecimal(channelResult.GetObject));
 
         IProgVariable titleResult = ParameterFunctions[1].Result;
         if (titleResult?.GetObject == null)


### PR DESCRIPTION
### Motivation

- The `senddiscord` built-in was accidentally exposed to player-authored computer functions/programs by declaring an allowed primitive return/parameter set and a non-denied category, enabling misuse of the Discord bridge without privileges. 
- The runtime also unboxed FutureProg `Number` values (backed by `decimal`) by casting to `double`, producing `InvalidCastException` on execution. 
- The change aims to re-lock the primitive Discord bridge to standard FutureProg contexts and eliminate the unboxing crash while preserving existing admin/staff usage.

### Description

- Limit `senddiscord` to non-computer contexts by registering it with `allowedContexts: new[] { FutureProgCompilationContext.StandardFutureProg }` in `SendDiscordMessageFunction`. 
- Replace the unsafe boxed-decimal-to-double cast with `Convert.ToDecimal(...)` followed by `Math.Truncate(...)` and cast to `ulong` to safely derive the channel id in `SendDiscordMessageFunction`. 
- Add regression coverage to `MudSharpCore Unit Tests`: hide `SendDiscord` from computer help in `ComputerWorkspaceRuntimeTests.cs` and add `ComputerProgramContext_RejectsSendDiscordFunction` to `ProgTests.cs` to assert compilation rejection in computer program context. 
- Preserve existing behaviour for standard FutureProg (admin/staff) callers and only restrict compilation/visibility for computer contexts.

### Testing

- Attempted a full solution restore with `dotnet restore MudSharp.sln -m:1 -p:RestoreBuildInParallel=false -p:NuGetAudit=false` which fails in this environment due to platform-targeted projects, so focused restores were used instead. 
- Restored the core project with `dotnet restore MudSharpCore/MudSharpCore.csproj -m:1 -p:RestoreBuildInParallel=false -p:NuGetAudit=false` and built it with `dotnet build MudSharpCore/MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510` which completed successfully. 
- Restored the unit-test project with `dotnet restore "MudSharpCore Unit Tests/MudSharpCore Unit Tests.csproj" -m:1 -p:RestoreBuildInParallel=false -p:NuGetAudit=false` and ran the specific tests with `dotnet test "MudSharpCore Unit Tests/MudSharpCore Unit Tests.csproj" -c Debug --no-restore -m:1 --filter "ComputerProgramContext_RejectsSendDiscordFunction|ComputerHelpService_FiltersToComputerSafeMetadata" -p:NoWarn=NU1902%3BNU1510 --logger "console;verbosity=normal"`. 
- The filtered test run reported both tests passed (2 passed, 0 failed), and the patched build completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1db5e6ccb08323a61f7ff7b0031a5a)