### PR TITLE
Limit Discord bot TCP frame buffering

### DIFF
--- a/DiscordBotCore Unit Tests/DiscordBotProtocolTests.cs
+++ b/DiscordBotCore Unit Tests/DiscordBotProtocolTests.cs
@@ -1,7 +1,10 @@
 using Discord_Bot;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
+using System.Net;
+using System.Net.Sockets;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace MudSharp_Unit_Tests;
 
@@ -24,6 +27,34 @@ public class DiscordBotProtocolTests
 
 		Assert.AreEqual(DiscordBotProtocol.EngineCommandDelimiter, encoded[^1]);
 		CollectionAssert.AreEqual(expectedPayload, encoded.Take(encoded.Length - 1).ToArray());
+	}
+
+	[TestMethod]
+	public async Task CheckIncomingAsync_ClosesConnectionWhenIncompleteFrameExceedsLimit()
+	{
+		using var listener = new TcpListener(IPAddress.Loopback, 0);
+		listener.Start();
+		var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+		using var client = new TcpClient();
+		var acceptTask = listener.AcceptTcpClientAsync();
+		await client.ConnectAsync(IPAddress.Loopback, port);
+		using var serverClient = await acceptTask;
+		var connection = new TcpConnection(serverClient, null!, null!);
+
+		var oversizedPayload = Enumerable
+			.Repeat((byte)2, TcpConnection.MaximumIncomingCommandBytes + 1)
+			.ToArray();
+		await client.GetStream().WriteAsync(oversizedPayload);
+
+		for (var i = 0; i < 32 && !connection.Closing; i++)
+		{
+			await Task.Delay(10);
+			await connection.CheckIncomingAsync();
+		}
+
+		Assert.IsTrue(connection.Closing);
+		Assert.IsFalse(connection.TcpClientAuthenticated);
 	}
 
 	[TestMethod]

--- a/DiscordBotCore/TcpConnection.cs
+++ b/DiscordBotCore/TcpConnection.cs
@@ -14,83 +14,102 @@ namespace Discord_Bot;
 
 public class TcpConnection
 {
-    private readonly TcpClient _tcpClient;
-    private readonly NetworkStream _networkStream;
-    private static readonly byte[] ByteSeparators = { 1 };
-    private readonly List<byte> _incomingBytes = new();
-    private readonly DiscordClient _discordClient;
-    private readonly DiscordBot _discordBot;
-    public bool TcpClientAuthenticated { get; private set; }
-    public bool Closing { get; private set; }
+	private const int ReadBufferSize = 4096;
+	public const int MaximumIncomingCommandBytes = 64 * 1024;
+	private readonly TcpClient _tcpClient;
+	private readonly NetworkStream _networkStream;
+	private static readonly byte[] ByteSeparators = { 1 };
+	private readonly List<byte> _incomingBytes = new();
+	private readonly DiscordClient _discordClient;
+	private readonly DiscordBot _discordBot;
+	public bool TcpClientAuthenticated { get; private set; }
+	public bool Closing { get; private set; }
 
-    public TcpConnection(TcpClient tcpClient, DiscordClient discordClient, DiscordBot discordBot)
-    {
-        _tcpClient = tcpClient;
-        _networkStream = _tcpClient.GetStream();
-        _discordClient = discordClient;
-        _discordBot = discordBot;
-    }
+	public TcpConnection(TcpClient tcpClient, DiscordClient discordClient, DiscordBot discordBot)
+	{
+		_tcpClient = tcpClient;
+		_networkStream = _tcpClient.GetStream();
+		_discordClient = discordClient;
+		_discordBot = discordBot;
+	}
 
-    public async Task CheckIncomingAsync()
-    {
-        try
-        {
-            if (!_networkStream.DataAvailable)
-            {
-                return;
-            }
+	public async Task CheckIncomingAsync()
+	{
+		try
+		{
+			if (!_networkStream.DataAvailable)
+			{
+				return;
+			}
 
-            byte[] inputBuffer = new byte[4096];
-            int bytes = _networkStream.Read(inputBuffer, 0, 4096);
-            if (bytes == 0)
-            {
-                Closing = true;
-                _tcpClient?.Close();
-                _networkStream?.Close();
-                TcpClientAuthenticated = false;
-                return;
-            }
+			byte[] inputBuffer = new byte[ReadBufferSize];
+			int bytes = _networkStream.Read(inputBuffer, 0, ReadBufferSize);
+			if (bytes == 0)
+			{
+				CloseTcpConnection();
+				return;
+			}
 
-            _incomingBytes.AddRange(inputBuffer.Take(bytes));
-            while (TryReadIncomingCommand(out byte[] command))
-            {
-                if (command.Length == 0)
-                {
-                    continue;
-                }
+			_incomingBytes.AddRange(inputBuffer.Take(bytes));
+			while (TryReadIncomingCommand(out byte[] command))
+			{
+				if (command.Length == 0)
+				{
+					continue;
+				}
 
-                await HandleTcpCommandAsync(Encoding.Unicode.GetString(command));
-            }
-        }
-        catch (SocketException e)
-        {
-            Closing = true;
-            _tcpClient?.Close();
-            _networkStream?.Close();
-            TcpClientAuthenticated = false;
-            Log.Information($"TCP Connection encountered a SocketException: {e.Message}");
-        }
+				await HandleTcpCommandAsync(Encoding.Unicode.GetString(command));
+			}
+		}
+		catch (SocketException e)
+		{
+			CloseTcpConnection();
+			Log.Information($"TCP Connection encountered a SocketException: {e.Message}");
+		}
 #if DEBUG
-        catch (Exception e)
-        {
-            Console.WriteLine(e.Message);
-        }
+		catch (Exception e)
+		{
+			Console.WriteLine(e.Message);
+		}
 #endif
-    }
+	}
 
-    private bool TryReadIncomingCommand(out byte[] command)
-    {
-        int delimiterIndex = _incomingBytes.IndexOf(ByteSeparators[0]);
-        if (delimiterIndex == -1)
-        {
-            command = Array.Empty<byte>();
-            return false;
-        }
+	private bool TryReadIncomingCommand(out byte[] command)
+	{
+		int delimiterIndex = _incomingBytes.IndexOf(ByteSeparators[0]);
+		if (delimiterIndex == -1)
+		{
+			command = Array.Empty<byte>();
+			if (_incomingBytes.Count > MaximumIncomingCommandBytes)
+			{
+				Log.Warning("Closing TCP connection after receiving an incomplete Discord bot command larger than {MaximumIncomingCommandBytes} bytes.", MaximumIncomingCommandBytes);
+				CloseTcpConnection();
+			}
+			return false;
+		}
 
-        command = _incomingBytes.GetRange(0, delimiterIndex).ToArray();
-        _incomingBytes.RemoveRange(0, delimiterIndex + 1);
-        return true;
-    }
+		if (delimiterIndex > MaximumIncomingCommandBytes)
+		{
+			command = Array.Empty<byte>();
+			Log.Warning("Closing TCP connection after receiving a Discord bot command larger than {MaximumIncomingCommandBytes} bytes.", MaximumIncomingCommandBytes);
+			CloseTcpConnection();
+			return false;
+		}
+
+		command = _incomingBytes.GetRange(0, delimiterIndex).ToArray();
+		_incomingBytes.RemoveRange(0, delimiterIndex + 1);
+		return true;
+	}
+
+	private void CloseTcpConnection()
+	{
+		Closing = true;
+		_incomingBytes.Clear();
+		_tcpClient?.Close();
+		_networkStream?.Close();
+		TcpClientAuthenticated = false;
+	}
+
 
     private async Task HandleTcpCommandAsync(string getString)
     {
@@ -462,10 +481,7 @@ public class TcpConnection
         }
 
         (string account, bool reboot) = DiscordBotProtocol.ParseShutdownNotification(shutdownAccount);
-        Closing = true;
-        _tcpClient?.Close();
-        _networkStream?.Close();
-        TcpClientAuthenticated = false;
+        CloseTcpConnection();
         if (reboot)
         {
             await _discordBot.AnnounceToDiscord($"{_discordBot.GameName} has been shutdown by {account}. It should be back in a couple of minutes.");
@@ -504,10 +520,7 @@ public class TcpConnection
         }
         catch (SocketException e)
         {
-            Closing = true;
-            _tcpClient?.Close();
-            _networkStream?.Close();
-            TcpClientAuthenticated = false;
+            CloseTcpConnection();
             Log.Information($"TCP Connection encountered a SocketException: {e.Message}");
         }
     }


### PR DESCRIPTION
### Motivation
- Prevent unbounded memory growth in the Discord bot TCP path caused by accumulating delimiter-free bytes before authentication. 
- Ensure unauthenticated TCP peers cannot exhaust process memory by streaming incomplete frames. 

### Description
- Add a per-connection maximum frame size `MaximumIncomingCommandBytes` and read buffer constant `ReadBufferSize` in `DiscordBotCore/TcpConnection.cs`. 
- Enforce the maximum in `TryReadIncomingCommand` and close the connection with a warning if an incomplete or oversized frame exceeds the configured limit. 
- Centralise connection teardown in a new `CloseTcpConnection` helper that clears `_incomingBytes` and closes streams so buffered bytes are dropped on close. 
- Add a unit test `CheckIncomingAsync_ClosesConnectionWhenIncompleteFrameExceedsLimit` in `DiscordBotCore Unit Tests/DiscordBotProtocolTests.cs` that sends an oversized delimiter-free payload and asserts the connection is closed and unauthenticated. 

### Testing
- Ran `git diff --check` to validate the working tree formatting which passed. 
- Ran repository restore/build steps that restored projects and built `ExpressionEngine` successfully, but a full `dotnet test` on `DiscordBotCore Unit Tests` timed out in this environment while compiling dependencies. 
- Attempted `dotnet build` of `DiscordBotCore` which also timed out in this environment while compiling project dependencies; no unit-test failures were observed because the test run did not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1db0360374832395edd41fae8d9e8a)