### PR TITLE
Restrict auction house builder commands

### DIFF
--- a/Design Documents/Economy/Economy_System_Runtime.md
+++ b/Design Documents/Economy/Economy_System_Runtime.md
@@ -315,6 +315,7 @@ Current verified runtime characteristics:
 - it routes proceeds into an optional bank account or its virtual cash reserve
 - it is surfaced through economy commands rather than being embedded into shops
 - configured flat and percentage auction fees are retained by the auction house, with sellers receiving net proceeds
+- auction-house building commands, including revenue-account and fee configuration, are administrator-only and reject non-admin callers before editing state
 - bid receipts are retained in the auction house reserve first; refunds and seller payouts draw from virtual cash before falling back to the linked bank account
 - standard player auction commands now work for both item and property lots, including estate-liquidation property lots whose names are ordinary property names rather than inventory items
 - hotel lost-property bundles can be listed as item lots by the property when their retention period expires

--- a/Design Documents/Economy/Economy_System_Workflows_and_Integration.md
+++ b/Design Documents/Economy/Economy_System_Workflows_and_Integration.md
@@ -275,7 +275,7 @@ Current player-facing capability note:
 - auction houses can now host both item lots and property-share lots, and ordinary character-listed property auctions sell whatever ownership share the listing character currently owns in that property
 - auction-house settlement keeps the configured flat plus percentage fee and pays the seller the net proceeds from the virtual reserve first, then from the linked bank account if needed
 - sellers can choose a bank payout target or `cash`; cash seller proceeds are claimed from the auction house through the same cash-claim path as bidder refunds
-- builders can use `auction set bank none`, `auction set deposit <amount>`, `auction set withdraw <amount>`, and `auction set ledger [count]` to run or inspect a bankless auction house
+- administrators can use `auction set bank none`, `auction set deposit <amount>`, `auction set withdraw <amount>`, and `auction set ledger [count]` to run or inspect a bankless auction house; the auction-house builder path rejects non-admin callers before opening or changing auction-house state
 - buyout purchases complete the auction immediately and move item lots into the normal claim workflow
 
 Contributor note:

--- a/MudSharpCore Unit Tests/Economy/AuctionCommandSecurityTests.cs
+++ b/MudSharpCore Unit Tests/Economy/AuctionCommandSecurityTests.cs
@@ -1,0 +1,60 @@
+#nullable enable
+
+using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MudSharp_Unit_Tests.Economy;
+
+[TestClass]
+public class AuctionCommandSecurityTests
+{
+	[TestMethod]
+	public void AuctionBuilderSubcommandsRequireAdministratorBeforeGenericBuilderDispatch()
+	{
+		var source = File.ReadAllText(GetSourcePath("MudSharpCore", "Commands", "Modules", "EconomyModule.cs"));
+		var methodIndex = source.IndexOf("protected static void Auction(ICharacter actor, string command)", StringComparison.Ordinal);
+		Assert.IsTrue(methodIndex > 0, "The player-facing auction command should exist.");
+
+		var builderCaseIndex = source.IndexOf("case \"edit\":", methodIndex, StringComparison.Ordinal);
+		Assert.IsTrue(builderCaseIndex > methodIndex, "The auction command should explicitly branch builder subcommands.");
+
+		var builderDispatchIndex = source.IndexOf(
+			"BuilderModule.GenericBuildingCommand(actor, ss.GetUndo(), EditableItemHelper.AuctionHelper);",
+			builderCaseIndex,
+			StringComparison.Ordinal);
+		Assert.IsTrue(builderDispatchIndex > builderCaseIndex, "The auction command should still use the standard auction-house builder helper for admin subcommands.");
+
+		var builderBranch = source[builderCaseIndex..builderDispatchIndex];
+		StringAssert.Contains(builderBranch, "if (!actor.IsAdministrator())");
+		StringAssert.Contains(builderBranch, "return;");
+	}
+
+	[TestMethod]
+	public void AuctionHouseBuildingCommandRejectsNonAdministrators()
+	{
+		var source = File.ReadAllText(GetSourcePath("MudSharpCore", "Economy", "Auctions", "AuctionHouse.cs"));
+		var methodIndex = source.IndexOf(
+			"public bool BuildingCommand(ICharacter actor, StringStack command)",
+			StringComparison.Ordinal);
+		Assert.IsTrue(methodIndex > 0, "AuctionHouse should expose an editable-item BuildingCommand.");
+
+		var switchIndex = source.IndexOf("switch (command.PopForSwitch())", methodIndex, StringComparison.Ordinal);
+		Assert.IsTrue(switchIndex > methodIndex, "AuctionHouse BuildingCommand should dispatch builder subcommands.");
+
+		var methodPreamble = source[methodIndex..switchIndex];
+		StringAssert.Contains(methodPreamble, "if (!actor.IsAdministrator())");
+		StringAssert.Contains(methodPreamble, "return false;");
+	}
+
+	private static string GetSourcePath(params string[] parts)
+	{
+		return Path.GetFullPath(Path.Combine(
+			AppContext.BaseDirectory,
+			"..",
+			"..",
+			"..",
+			"..",
+			Path.Combine(parts)));
+	}
+}

--- a/MudSharpCore/Commands/Modules/EconomyModule.cs
+++ b/MudSharpCore/Commands/Modules/EconomyModule.cs
@@ -6190,6 +6190,12 @@ Note: Admins can use the #3auction cancel#0 subcommand on other people's items";
             case "view":
             case "clone":
             case "list":
+                if (!actor.IsAdministrator())
+                {
+                    actor.OutputHandler.Send("Only administrators can use auction house building commands.");
+                    return;
+                }
+
                 BuilderModule.GenericBuildingCommand(actor, ss.GetUndo(), EditableItemHelper.AuctionHelper);
                 return;
         }

--- a/MudSharpCore/Economy/Auctions/AuctionHouse.cs
+++ b/MudSharpCore/Economy/Auctions/AuctionHouse.cs
@@ -728,6 +728,12 @@ public partial class AuctionHouse : SaveableItem, IAuctionHouse, IPostCharacterL
 
     public bool BuildingCommand(ICharacter actor, StringStack command)
     {
+        if (!actor.IsAdministrator())
+        {
+            actor.OutputHandler.Send("Only administrators can edit auction houses.");
+            return false;
+        }
+
         switch (command.PopForSwitch())
         {
             case "name":


### PR DESCRIPTION
### Motivation
- Prevent an unprivileged player from using the player-facing `auction` command to edit auction-house financial settings (fee rate, profits account) and thereby divert sale proceeds after retained-fee settlement logic was introduced.

### Description
- Require administrator privileges before dispatching builder-style subcommands (`edit`, `close`, `set`, `show`, `view`, `clone`, `list`) in the player-facing `Auction` command in `EconomyModule` by checking `actor.IsAdministrator()` before calling the generic builder helper.
- Add a defensive authorization gate at the top of `AuctionHouse.BuildingCommand(ICharacter, StringStack)` so non-admin callers are rejected with a clear message and cannot mutate auction-house state even if reached by other code paths.
- Add a source-level unit test `MudSharpCore Unit Tests/Economy/AuctionCommandSecurityTests.cs` that asserts both authorization checks are present in source.
- Update economy design documentation (`Design Documents/Economy/*`) to document that auction-house builder commands and fee/account configuration are administrator-only.

### Testing
- Ran source assertions via a small Python check that validated the `auction` dispatch branch contains an `if (!actor.IsAdministrator())` guard and that `AuctionHouse.BuildingCommand` prefaces the `switch` with an `if (!actor.IsAdministrator())` check (passed).
- Ran static checks (`git diff --check`) with no issues reported (passed).
- Performed targeted package restores: `dotnet restore MudSharpCore/MudSharpCore.csproj` and `dotnet restore 'MudSharpCore Unit Tests/MudSharpCore Unit Tests.csproj'` completed successfully; full solution `dotnet restore MudSharp.sln` failed on this Linux environment because some projects target Windows and require `EnableWindowsTargeting=true` (environment limitation, not related to the change).
- Attempted to run the targeted unit-test filter for the new tests via `dotnet test` but the test execution timed out during project build in this environment, so the MSTest run did not complete here; the added source-level assertions provide deterministic coverage independent of runtime test execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d99dd34e88323a9f4d92280b386f3)