### PR TITLE
Harden vehicle occupancy and co-location checks to prevent remote driving

### DIFF
--- a/Design Documents/Vehicle_System.md
+++ b/Design Documents/Vehicle_System.md
@@ -261,7 +261,7 @@ Projected vehicle system items are exposed through ordinary item targeting. The 
 Boarding rules currently check:
 
 - the target item has a linked vehicle exterior component
-- the actor is not already aboard
+- the actor is not already aboard any vehicle
 - the actor is in the vehicle's canonical cell
 - the actor is on the vehicle's canonical room layer
 - the requested slot exists
@@ -272,6 +272,7 @@ Boarding rules currently check:
 Driving rules currently check:
 
 - the actor is the vehicle controller
+- the actor is in the same canonical cell and room layer as the vehicle
 - the vehicle is at the exit origin
 - the vehicle prototype has a `CellExit` movement profile
 - the movement profile is not disabled by vehicle damage effects
@@ -406,6 +407,7 @@ It moves a vehicle between adjacent cells through normal exits.
 Current validation:
 
 - actor must be the controller
+- actor must be in the same canonical cell and room layer as the vehicle
 - vehicle must be at the exit origin
 - vehicle prototype must support `CellExit`
 - movement profile must not be damage-disabled
@@ -426,7 +428,7 @@ Current movement behaviour:
 - schedule the movement delay through the normal movement scheduler
 - move the exterior item to the destination cell and target layer
 - invoke exterior `IConnectable` force-move cleanup so cables, chargers, and similar independent connections do not remain logically connected across cells
-- move occupants to the destination cell and layer as participants in the vehicle movement
+- move co-located occupants to the destination cell and layer as participants in the vehicle movement, clearing any stale occupancy records that are no longer co-located with the vehicle
 - consume configured fuel and power
 - move all recursively towed vehicles, hitch items, and occupants
 - mark vehicle as `Cell` and `Stationary`

--- a/MudSharpCore Unit Tests/VehicleMovementCommandTests.cs
+++ b/MudSharpCore Unit Tests/VehicleMovementCommandTests.cs
@@ -71,6 +71,8 @@ public class VehicleMovementCommandTests
 		var origin = new Mock<ICell>();
 		origin.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
 		origin.Setup(x => x.LayerCharacters(RoomLayer.GroundLevel)).Returns([actor.Object]);
+		actor.SetupGet(x => x.Location).Returns(origin.Object);
+		actor.SetupGet(x => x.RoomLayer).Returns(RoomLayer.GroundLevel);
 		var destination = new Mock<ICell>();
 		destination.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
 		destination.Setup(x => x.LayerCharacters(RoomLayer.GroundLevel)).Returns([]);

--- a/MudSharpCore Unit Tests/VehicleMovementStrategyTests.cs
+++ b/MudSharpCore Unit Tests/VehicleMovementStrategyTests.cs
@@ -48,6 +48,37 @@ public class VehicleMovementStrategyTests
 	}
 
 	[TestMethod]
+	public void CanMove_WhenActorIsInDifferentLocation_Fails()
+	{
+		var strategy = new CellExitVehicleMovementStrategy();
+		var controller = new Mock<ICharacter>();
+		var vehicle = CreateVehicle(controller.Object, [VehicleMovementProfileType.CellExit], SizeCategory.Large);
+		var actorLocation = new Mock<ICell>();
+		controller.SetupGet(x => x.Location).Returns(actorLocation.Object);
+		var exit = CreateExit(vehicle.Location, SizeCategory.Huge);
+
+		var result = strategy.CanMove(vehicle, controller.Object, exit, out var reason);
+
+		Assert.IsFalse(result);
+		Assert.AreEqual("You must be in the same location as the vehicle to move it.", reason);
+	}
+
+	[TestMethod]
+	public void CanMove_WhenActorIsOnDifferentRoomLayer_Fails()
+	{
+		var strategy = new CellExitVehicleMovementStrategy();
+		var controller = new Mock<ICharacter>();
+		var vehicle = CreateVehicle(controller.Object, [VehicleMovementProfileType.CellExit], SizeCategory.Large);
+		controller.SetupGet(x => x.RoomLayer).Returns(RoomLayer.InTrees);
+		var exit = CreateExit(vehicle.Location, SizeCategory.Huge);
+
+		var result = strategy.CanMove(vehicle, controller.Object, exit, out var reason);
+
+		Assert.IsFalse(result);
+		Assert.AreEqual("You must be on the same room layer as the vehicle to move it.", reason);
+	}
+
+	[TestMethod]
 	public void CanMove_WhenExitIsTooSmall_Fails()
 	{
 		var strategy = new CellExitVehicleMovementStrategy();
@@ -234,6 +265,59 @@ public class VehicleMovementStrategyTests
 	}
 
 	[TestMethod]
+	public void CanBoard_WhenActorIsAlreadyOccupyingAnotherVehicle_Fails()
+	{
+		var location = new Mock<ICell>();
+		location.SetupGet(x => x.Id).Returns(42L);
+
+		var slot = new Mock<IVehicleOccupantSlotPrototype>();
+		slot.SetupGet(x => x.Id).Returns(1L);
+		slot.SetupGet(x => x.Capacity).Returns(1);
+
+		var prototype = new Mock<IVehiclePrototype>();
+		prototype.SetupGet(x => x.OccupantSlots).Returns([slot.Object]);
+
+		var prototypes = new Mock<IUneditableRevisableAll<IVehiclePrototype>>();
+		prototypes.Setup(x => x.Get(10L, 0)).Returns(prototype.Object);
+
+		var cells = new Mock<IUneditableAll<ICell>>();
+		cells.Setup(x => x.Get(42L)).Returns(location.Object);
+
+		var actor = new Mock<ICharacter>();
+		actor.SetupGet(x => x.Location).Returns(location.Object);
+		actor.SetupGet(x => x.RoomLayer).Returns(RoomLayer.GroundLevel);
+
+		var otherVehicle = new Mock<IVehicle>();
+		otherVehicle.Setup(x => x.IsOccupant(actor.Object)).Returns(true);
+		var vehicleList = new List<IVehicle> { otherVehicle.Object };
+		var vehicles = new Mock<IUneditableAll<IVehicle>>();
+		vehicles.Setup(x => x.GetEnumerator()).Returns(() => vehicleList.GetEnumerator());
+
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.Cells).Returns(cells.Object);
+		gameworld.SetupGet(x => x.VehiclePrototypes).Returns(prototypes.Object);
+		gameworld.SetupGet(x => x.Vehicles).Returns(vehicles.Object);
+		actor.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+
+		var vehicle = new Vehicle(new DB.Vehicle
+		{
+			Id = 1L,
+			Name = "Test Vehicle",
+			VehicleProtoId = 10L,
+			VehicleProtoRevision = 0,
+			LocationType = (int)VehicleLocationType.Cell,
+			CurrentCellId = 42L,
+			CurrentRoomLayer = (int)RoomLayer.GroundLevel,
+			MovementStatus = (int)VehicleMovementStatus.Stationary
+		}, gameworld.Object);
+
+		var result = vehicle.CanBoard(actor.Object, slot.Object, out var reason);
+
+		Assert.IsFalse(result);
+		Assert.AreEqual("You are already aboard another vehicle.", reason);
+	}
+
+	[TestMethod]
 	public void RecoverInterruptedMovement_ClearsMovingTransitState()
 	{
 		var location = new Mock<ICell>();
@@ -287,9 +371,13 @@ public class VehicleMovementStrategyTests
 		var prototype = new Mock<IVehiclePrototype>();
 		prototype.SetupGet(x => x.MovementProfiles).Returns(profiles);
 
+		Mock.Get(controller).SetupGet(x => x.Location).Returns(location.Object);
+		Mock.Get(controller).SetupGet(x => x.RoomLayer).Returns(RoomLayer.GroundLevel);
+
 		var vehicle = new Mock<IVehicle>();
 		vehicle.SetupGet(x => x.Controller).Returns(controller);
 		vehicle.SetupGet(x => x.Location).Returns(location.Object);
+		vehicle.SetupGet(x => x.RoomLayer).Returns(RoomLayer.GroundLevel);
 		vehicle.SetupGet(x => x.Prototype).Returns(prototype.Object);
 		vehicle.SetupGet(x => x.ExteriorItem).Returns(item.Object);
 		return vehicle.Object;

--- a/MudSharpCore/Vehicles/CellExitVehicleMovementStrategy.cs
+++ b/MudSharpCore/Vehicles/CellExitVehicleMovementStrategy.cs
@@ -72,6 +72,18 @@ public class CellExitVehicleMovementStrategy : IVehicleMovementStrategy
 			return false;
 		}
 
+		if (actor.Location != vehicle.Location)
+		{
+			reason = "You must be in the same location as the vehicle to move it.";
+			return false;
+		}
+
+		if (actor.RoomLayer != vehicle.RoomLayer)
+		{
+			reason = "You must be on the same room layer as the vehicle to move it.";
+			return false;
+		}
+
 		var profile = vehicle.Prototype.MovementProfiles
 		                     .Where(x => x.MovementType == VehicleMovementProfileType.CellExit)
 		                     .OrderByDescending(x => x.IsDefault)

--- a/MudSharpCore/Vehicles/Vehicle.cs
+++ b/MudSharpCore/Vehicles/Vehicle.cs
@@ -219,6 +219,12 @@ public class Vehicle : SaveableItem, IVehicle
 			return false;
 		}
 
+		if (actor.Gameworld.Vehicles.Any(x => !ReferenceEquals(x, this) && x.IsOccupant(actor)))
+		{
+			reason = "You are already aboard another vehicle.";
+			return false;
+		}
+
 		if (Location is not null && actor.Location != Location)
 		{
 			reason = "You must be in the same location as the vehicle to board it.";
@@ -486,6 +492,12 @@ public class Vehicle : SaveableItem, IVehicle
 
 		foreach (var occupant in Occupants.ToList())
 		{
+			if (origin is not null && (occupant.Location != origin || occupant.RoomLayer != _roomLayer))
+			{
+				ForceDisembark(occupant);
+				continue;
+			}
+
 			origin?.Leave(occupant);
 			occupant.RoomLayer = layer;
 			occupant.Moved(movement);

--- a/MudSharpCore/Vehicles/VehicleMovement.cs
+++ b/MudSharpCore/Vehicles/VehicleMovement.cs
@@ -26,7 +26,9 @@ internal static class VehicleMovementCommand
 	public static VehicleMovementCommandResult TryMoveControlledVehicle(ICharacter actor, string rawInput,
 		bool requireVehicle)
 	{
-		var vehicle = actor.Gameworld.Vehicles.FirstOrDefault(x => x.Controller == actor);
+		var vehicle = actor.Gameworld.Vehicles.FirstOrDefault(x => x.Controller == actor &&
+		                                                        x.Location == actor.Location &&
+		                                                        x.RoomLayer == actor.RoomLayer);
 		if (vehicle is null)
 		{
 			if (requireVehicle)


### PR DESCRIPTION
### Motivation
- The vehicle subsystem allowed a character to be recorded as occupant/controller of multiple vehicles and to drive a non-local vehicle, enabling remote movement and teleportation of stale occupants.
- Movement validation did not assert that the controller was physically co-located with the vehicle, and movement applied teleportation to all recorded occupants regardless of their actual locations.

### Description
- Enforce a single active vehicle occupancy by rejecting boarding when `actor.Gameworld.Vehicles` contains another vehicle reporting the actor as an occupant (`Vehicle.CanBoard`).
- Require controller co-location when selecting and validating a controlled vehicle by scoping the `TryMoveControlledVehicle` selection to vehicles with `Location == actor.Location` and `RoomLayer == actor.RoomLayer`, and by adding `actor.Location == vehicle.Location` and `actor.RoomLayer == vehicle.RoomLayer` checks to `CellExitVehicleMovementStrategy.CanMove`.
- Avoid teleporting stale occupants during movement by forcing-disembark of any recorded occupant who is no longer co-located with the vehicle in `Vehicle.MoveToCell` before moving remaining co-located occupants.
- Add regression unit tests to cover the new co-location and single-occupancy invariants and update an existing movement test to set `actor.Location` and `actor.RoomLayer` appropriately (`MudSharpCore Unit Tests/VehicleMovementStrategyTests.cs`, `VehicleMovementCommandTests.cs`).
- Update the vehicle system design document to record the single-vehicle occupancy rule, controller co-location requirement, and stale-occupancy cleanup behavior (`Design Documents/Vehicle_System.md`).

### Testing
- Ran targeted restores: `dotnet restore MudSharpCore/MudSharpCore.csproj -m:1 -p:RestoreBuildInParallel=false -p:NuGetAudit=false` and `dotnet restore 'MudSharpCore Unit Tests/MudSharpCore Unit Tests.csproj' -m:1 -p:RestoreBuildInParallel=false -p:NuGetAudit=false`, which completed successfully for the targeted projects.
- Performed a targeted build of `MudSharpCore` after restore; the targeted build completed (project-level restore/build succeeded after dependency restore).
- Attempted filtered unit test run with `dotnet test` for vehicle movement tests, which timed out during compilation in this environment (large dependency graph and long Roslyn compile time); no failing test assertions were observed prior to the timeout.
- Full solution restore `dotnet restore MudSharp.sln` is blocked in this Linux environment by Windows-targeting projects requiring `EnableWindowsTargeting=true`, so a full-solution test pass was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d8bd8566c8323938972c4a0d1bd46)