### PR TITLE
Harden forced command execution

### DIFF
--- a/Design Documents/AI/Event_System_for_AI_and_Hooks.md
+++ b/Design Documents/AI/Event_System_for_AI_and_Hooks.md
@@ -151,6 +151,8 @@ The hook subsystem also includes additional concrete types such as:
 - `CommandHookFutureProg`
 - `GPTHook`
 
+`CommandHook` and `CommandHookFutureProg` can make an event parameter execute an authored command. When that parameter is a staff PC, the command executes in temporary mortal mode so admin-only command roots and admin-only branches inside player-facing commands are not exposed through hook authorship.
+
 For most AI and content-authoring work, the primary practical types are still `FutureProgHook`, `HookOnInput`, and `DefaultHook`.
 
 ## Save/Load Behavior

--- a/Design Documents/Magic/Armageddon_Magic_Psionics_Gap_Report.md
+++ b/Design Documents/Magic/Armageddon_Magic_Psionics_Gap_Report.md
@@ -119,7 +119,7 @@ Completed on 2026-05-01.
 - Added `magictag` / `removemagictag` and FutureProg helpers `hasmagictag`, `magictagvalue`, `magictagvalues`, and `magictags`.
 - Added first-class item and corpse effects: `itemdamage`, `destroyitem`, `itemenchant`, `corpsemark`, `corpsepreserve`, `corpseconsume`, and `corpsespawn`.
 - Added transient paired magical portals through `portal`, backed by effect-owned transient exits rather than permanent database exits.
-- Added safe command-forcing through `forcecommand`, with staff/editor/account-destructive roots blocked and wiz-only audit output.
+- Added safe command-forcing through `forcecommand`, with staff/editor/account-destructive roots blocked, staff PCs temporarily forced in mortal mode, and wiz-only audit output.
 - Added caster-scoped subjective short/full description overrides through `subjectivesdesc` and `subjectivedesc`.
 
 Deferred from V1 but later resolved in V2: general dispel/shorten support, portal inspection and item anchors, richer item-enchantment hooks, and psionic identity/passive-traffic policy.
@@ -391,7 +391,7 @@ Status: Coercion V1, psionic identity concealment, passive thought/feeling traff
 
 FutureMUD already has good mind-link primitives and now has:
 
-- `forcecommand`, which runs as the target's own command context through `ExecuteCommand`, respects `IIgnoreForceEffect`, blocks staff/editor/account-destructive command roots, and emits wiz-only audit output.
+- `forcecommand`, which runs as the target's own command context, respects `IIgnoreForceEffect`, blocks staff/editor/account-destructive command roots, temporarily forces staff PCs in mortal mode, and emits wiz-only audit output.
 - `subjectivedesc`, which applies a spell-owned full-description override.
 - `subjectivesdesc`, which applies a spell-owned short-description override.
 - caster-scoped subjective-description support through fixed-viewer handling.
@@ -550,7 +550,7 @@ These are the next-best return once the basic statuses exist.
 5. Add a command-safe psionic coercion framework.
    - Completed for Coercion V1 with `forcecommand`.
    - Extended in V4 with `projectemotion`, `suggest`, and mode-based `coerce`.
-   - The command-forcing implementation executes through the target's own `ExecuteCommand`, respects `IIgnoreForceEffect`, blocks staff/editor/account-destructive roots, and emits wiz-only audit output.
+   - The command-forcing implementation executes through the target's own command context, respects `IIgnoreForceEffect`, blocks staff/editor/account-destructive roots, temporarily forces staff PCs in mortal mode, and emits wiz-only audit output.
    - The V4 non-command path shares opt-out checks, listener delivery, and audit output. V5b adds timed residual traces for psionic activity; broader consent-policy models and permanent consequence ledgers remain future work.
 
 ### Phase 3: Tricky Design Work

--- a/MudSharpCore Unit Tests/CommandExecutionSecurityTests.cs
+++ b/MudSharpCore Unit Tests/CommandExecutionSecurityTests.cs
@@ -1,0 +1,255 @@
+#nullable enable
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Accounts;
+using MudSharp.Character;
+using MudSharp.Commands;
+using MudSharp.Commands.Trees;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.Magic;
+using MudSharp.Magic.SpellEffects;
+using MudSharp.Magic.SpellTriggers;
+using MudSharp.RPG.Checks;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class CommandExecutionSecurityTests
+{
+	[TestInitialize]
+	public void TestInitialize()
+	{
+		SpellTriggerFactory.SetupFactory();
+		SpellEffectFactory.SetupFactory();
+	}
+
+	[TestMethod]
+	public void CommandExecutionSecurity_CanForceTarget_AppliesAdminRankRules()
+	{
+		var actor = Character(PermissionLevel.Admin).Object;
+		var lowerAdmin = Character(PermissionLevel.JuniorAdmin).Object;
+		var sameAdmin = Character(PermissionLevel.Admin).Object;
+		var higherAdmin = Character(PermissionLevel.SeniorAdmin).Object;
+		var player = Character(PermissionLevel.Player).Object;
+		var founder = Character(PermissionLevel.Founder).Object;
+
+		Assert.IsTrue(CommandExecutionGuards.CanForceTarget(actor, lowerAdmin));
+		Assert.IsTrue(CommandExecutionGuards.CanForceTarget(actor, player));
+		Assert.IsFalse(CommandExecutionGuards.CanForceTarget(actor, sameAdmin));
+		Assert.IsFalse(CommandExecutionGuards.CanForceTarget(actor, higherAdmin));
+		Assert.IsTrue(CommandExecutionGuards.CanForceTarget(founder, higherAdmin));
+		Assert.IsTrue(CommandExecutionGuards.CanForceTarget(founder, sameAdmin));
+	}
+
+	[TestMethod]
+	public void CommandExecutionSecurity_CanUseAsTarget_BlocksAdminsExceptForFounders()
+	{
+		var actor = Character(PermissionLevel.Admin).Object;
+		var founder = Character(PermissionLevel.Founder).Object;
+		var juniorAdmin = Character(PermissionLevel.JuniorAdmin).Object;
+		var guide = Character(PermissionLevel.Guide).Object;
+		var player = Character(PermissionLevel.Player).Object;
+
+		Assert.IsFalse(CommandExecutionGuards.CanUseAsTarget(actor, juniorAdmin));
+		Assert.IsTrue(CommandExecutionGuards.CanUseAsTarget(actor, guide));
+		Assert.IsTrue(CommandExecutionGuards.CanUseAsTarget(actor, player));
+		Assert.IsTrue(CommandExecutionGuards.CanUseAsTarget(founder, juniorAdmin));
+	}
+
+	[TestMethod]
+	public void CommandExecutionSecurity_ExecuteForcedCommand_DowngradesStaffPcAndRestoresOnSuccess()
+	{
+		var target = CharacterWithMutablePermission(PermissionLevel.HighAdmin, true, out var permission);
+		PermissionLevel? observedPermission = null;
+		target.Setup(x => x.ExecuteCommand("look"))
+		      .Callback(() => observedPermission = permission.Value)
+		      .Returns(true);
+
+		var result = CommandExecutionGuards.ExecuteForcedCommand(target.Object, "look");
+
+		Assert.IsTrue(result);
+		Assert.AreEqual(PermissionLevel.Player, observedPermission);
+		Assert.AreEqual(PermissionLevel.HighAdmin, permission.Value);
+		target.Verify(x => x.ChangePermissionLevel(PermissionLevel.Player), Times.Once);
+		target.Verify(x => x.ChangePermissionLevel(PermissionLevel.HighAdmin), Times.Once);
+	}
+
+	[TestMethod]
+	public void CommandExecutionSecurity_ExecuteForcedCommand_RestoresStaffPcAfterException()
+	{
+		var target = CharacterWithMutablePermission(PermissionLevel.SeniorAdmin, true, out var permission);
+		target.Setup(x => x.ExecuteCommand("explode"))
+		      .Throws(new InvalidOperationException("Command failed."));
+
+		Assert.ThrowsException<InvalidOperationException>(() =>
+			CommandExecutionGuards.ExecuteForcedCommand(target.Object, "explode"));
+
+		Assert.AreEqual(PermissionLevel.SeniorAdmin, permission.Value);
+		target.Verify(x => x.ChangePermissionLevel(PermissionLevel.Player), Times.Once);
+		target.Verify(x => x.ChangePermissionLevel(PermissionLevel.SeniorAdmin), Times.Once);
+	}
+
+	[TestMethod]
+	public void CommandExecutionSecurity_ExecuteForcedCommand_DoesNotDowngradePlayersOrNpcs()
+	{
+		var player = CharacterWithMutablePermission(PermissionLevel.Player, true, out var playerPermission);
+		var npc = CharacterWithMutablePermission(PermissionLevel.NPC, false, out var npcPermission);
+		PermissionLevel? observedPlayerPermission = null;
+		PermissionLevel? observedNpcPermission = null;
+		player.Setup(x => x.ExecuteCommand("look"))
+		      .Callback(() => observedPlayerPermission = playerPermission.Value)
+		      .Returns(true);
+		npc.Setup(x => x.ExecuteCommand("look"))
+		   .Callback(() => observedNpcPermission = npcPermission.Value)
+		   .Returns(true);
+
+		CommandExecutionGuards.ExecuteForcedCommand(player.Object, "look");
+		CommandExecutionGuards.ExecuteForcedCommand(npc.Object, "look");
+
+		Assert.AreEqual(PermissionLevel.Player, observedPlayerPermission);
+		Assert.AreEqual(PermissionLevel.NPC, observedNpcPermission);
+		player.Verify(x => x.ChangePermissionLevel(It.IsAny<PermissionLevel>()), Times.Never);
+		npc.Verify(x => x.ChangePermissionLevel(It.IsAny<PermissionLevel>()), Times.Never);
+	}
+
+	[TestMethod]
+	public void CommandExecutionSecurity_ForceCommandEffect_ExecutesStaffPcInMortalMode()
+	{
+		var gameworld = new Mock<IFuturemud>();
+		var spell = new Mock<IMagicSpell>();
+		spell.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		var effect = SpellEffectFactory.LoadEffect(new XElement("Effect",
+			new XAttribute("type", "forcecommand"),
+			new XElement("Command", new XCData("look"))), spell.Object);
+		var target = CharacterWithMutablePermission(PermissionLevel.HighAdmin, true, out var permission);
+		target.Setup(x => x.AffectedBy<IIgnoreForceEffect>()).Returns(false);
+		var commands = new Mock<ICharacterCommandManager>();
+		commands.Setup(x => x.LocateCommand(target.Object, ref It.Ref<string>.IsAny))
+		        .Returns((IExecutable<ICharacter>)null!);
+		var commandTree = new Mock<ICharacterCommandTree>();
+		commandTree.SetupGet(x => x.Commands).Returns(commands.Object);
+		target.SetupGet(x => x.CommandTree).Returns(commandTree.Object);
+		PermissionLevel? observedPermission = null;
+		target.Setup(x => x.ExecuteCommand("look"))
+		      .Callback(() => observedPermission = permission.Value)
+		      .Returns(true);
+
+		effect.GetOrApplyEffect(Character(PermissionLevel.Player).Object, target.Object, OpposedOutcomeDegree.None,
+			SpellPower.Insignificant, new Mock<IMagicSpellEffectParent>().Object, []);
+
+		Assert.AreEqual(PermissionLevel.Player, observedPermission);
+		Assert.AreEqual(PermissionLevel.HighAdmin, permission.Value);
+		target.Verify(x => x.ChangePermissionLevel(PermissionLevel.Player), Times.Once);
+		target.Verify(x => x.ChangePermissionLevel(PermissionLevel.HighAdmin), Times.Once);
+	}
+
+	[TestMethod]
+	public void CommandExecutionSecurity_ForceCommandEffect_StillRespectsIgnoreForceEffect()
+	{
+		var spell = new Mock<IMagicSpell>();
+		spell.SetupGet(x => x.Gameworld).Returns(new Mock<IFuturemud>().Object);
+		var effect = SpellEffectFactory.LoadEffect(new XElement("Effect",
+			new XAttribute("type", "forcecommand"),
+			new XElement("Command", new XCData("look"))), spell.Object);
+		var target = CharacterWithMutablePermission(PermissionLevel.HighAdmin, true, out _);
+		target.Setup(x => x.AffectedBy<IIgnoreForceEffect>()).Returns(true);
+
+		effect.GetOrApplyEffect(Character(PermissionLevel.Player).Object, target.Object, OpposedOutcomeDegree.None,
+			SpellPower.Insignificant, new Mock<IMagicSpellEffectParent>().Object, []);
+
+		target.Verify(x => x.ExecuteCommand(It.IsAny<string>()), Times.Never);
+		target.Verify(x => x.ChangePermissionLevel(It.IsAny<PermissionLevel>()), Times.Never);
+	}
+
+	[TestMethod]
+	public void CommandExecutionSecurity_ForceFanoutUsesCorrectWorldCollections()
+	{
+		var source = File.ReadAllText(GetSourcePath("MudSharpCore", "Commands", "Modules", "StorytellerModule.cs"));
+		var allBranch = Slice(source, "targetText.Equals(\"all\"", "targetText.Equals(\"players\"");
+		var playersBranch = Slice(source, "targetText.Equals(\"players\"", "targetText.Equals(\"npcs\"");
+		var npcsBranch = Slice(source, "targetText.Equals(\"npcs\"", "targetText.Equals(\"here\"");
+
+		StringAssert.Contains(allBranch, "character.Gameworld.Actors");
+		StringAssert.Contains(playersBranch, "character.Gameworld.Characters");
+		StringAssert.Contains(npcsBranch, "character.Gameworld.NPCs");
+		StringAssert.Contains(allBranch, "CommandExecutionGuards.CanForceTarget(character, x)");
+		StringAssert.Contains(playersBranch, "CommandExecutionGuards.CanForceTarget(character, x)");
+		StringAssert.Contains(npcsBranch, "CommandExecutionGuards.CanForceTarget(character, x)");
+	}
+
+	[TestMethod]
+	public void CommandExecutionSecurity_AuthoredIndirectCommandPathsUseSecureHelper()
+	{
+		var guardedSources = new[]
+		{
+			("MudSharpCore", "FutureProg", "Statements", "Force.cs"),
+			("MudSharpCore", "FutureProg", "Statements", "Delay.cs"),
+			("MudSharpCore", "Effects", "Concrete", "Dreaming.cs"),
+			("MudSharpCore", "Framework", "Scheduling", "Schedules.cs"),
+			("MudSharpCore", "Magic", "SpellEffects", "MagicPhase3Effects.cs")
+		};
+
+		foreach (var parts in guardedSources)
+		{
+			var source = File.ReadAllText(GetSourcePath(parts.Item1, parts.Item2, parts.Item3, parts.Item4));
+			Assert.IsTrue(source.Contains("CommandExecutionGuards.", StringComparison.Ordinal),
+				$"{parts.Item4} should use CommandExecutionGuards for authored forced commands.");
+		}
+
+		var hookSource = File.ReadAllText(GetSourcePath("MudSharpCore", "Events", "Hooks", "CommandHook.cs"));
+		StringAssert.Contains(hookSource, "if (target is ICharacter character)");
+		StringAssert.Contains(hookSource, "CommandExecutionGuards.ExecuteForcedCommand(character, command);");
+	}
+
+	private static Mock<ICharacter> Character(PermissionLevel permissionLevel, bool isPlayerCharacter = true)
+	{
+		var character = new Mock<ICharacter>();
+		character.SetupGet(x => x.PermissionLevel).Returns(permissionLevel);
+		character.SetupGet(x => x.IsPlayerCharacter).Returns(isPlayerCharacter);
+		return character;
+	}
+
+	private static Mock<ICharacter> CharacterWithMutablePermission(PermissionLevel startingPermission,
+		bool isPlayerCharacter, out MutablePermission permission)
+	{
+		permission = new MutablePermission(startingPermission);
+		var capturedPermission = permission;
+		var character = new Mock<ICharacter>();
+		character.SetupGet(x => x.PermissionLevel).Returns(() => capturedPermission.Value);
+		character.SetupGet(x => x.IsPlayerCharacter).Returns(isPlayerCharacter);
+		character.Setup(x => x.ChangePermissionLevel(It.IsAny<PermissionLevel>()))
+		         .Callback<PermissionLevel>(value => capturedPermission.Value = value);
+		return character;
+	}
+
+	private static string Slice(string source, string startText, string endText)
+	{
+		var start = source.IndexOf(startText, StringComparison.Ordinal);
+		Assert.IsTrue(start >= 0, $"Could not find source marker {startText}.");
+		var end = source.IndexOf(endText, start, StringComparison.Ordinal);
+		Assert.IsTrue(end > start, $"Could not find source marker {endText} after {startText}.");
+		return source[start..end];
+	}
+
+	private static string GetSourcePath(params string[] parts)
+	{
+		return Path.GetFullPath(Path.Combine(
+			AppContext.BaseDirectory,
+			"..",
+			"..",
+			"..",
+			"..",
+			Path.Combine(parts)));
+	}
+
+	private sealed class MutablePermission(PermissionLevel value)
+	{
+		public PermissionLevel Value { get; set; } = value;
+	}
+}

--- a/MudSharpCore/Commands/Modules/StorytellerModule.cs
+++ b/MudSharpCore/Commands/Modules/StorytellerModule.cs
@@ -580,7 +580,7 @@ With no limits, all retained room speech context is shown.", AutoHelp.HelpArgOrN
     [PlayerCommand("Force", "force")]
     [CommandPermission(PermissionLevel.JuniorAdmin)]
     [HelpInfo("force",
-        "This command allows you to force someone or a group of someones to do a specified command. All admins will see that you used this command. There are a few different versions:\n\tforce <target> <command> - forces an individual target to do a command\n\tforce here <command> - forces all characters (PC and NPC, excluding yourself and other admins)\n\tforce npchere <command> - same as here, but excludes all PCs\n\tforce all <command> - can only be used by senior admins and up - forces ALL PCs and NPCs in the game\n\tforce players <command> - can only be used by senior admins and up - forces all PCs in the game\n\tforce npcs <command> - can only be used by senior admins and up - forces all NPCs in the game ",
+        "This command allows you to force someone or a group of someones to do a specified command. All admins will see that you used this command. Non-Implementors cannot force admins of equal or higher authority; group forms skip those admins. There are a few different versions:\n\tforce <target> <command> - forces an individual target to do a command\n\tforce here <command> - forces all eligible visible characters (PC and NPC) in the room\n\tforce npchere <command> - same as here, but excludes all PCs\n\tforce all <command> - can only be used by senior admins and up - forces all eligible PCs and NPCs in the game\n\tforce players <command> - can only be used by senior admins and up - forces all eligible PCs in the game\n\tforce npcs <command> - can only be used by senior admins and up - forces all NPCs in the game\n\nThere is no FORCE LOCAL form; use FORCE HERE for the local room.",
         AutoHelp.HelpArgOrNoArg)]
     protected static void Force(ICharacter character, string input)
     {
@@ -605,8 +605,9 @@ With no limits, all retained room speech context is shown.", AutoHelp.HelpArgOrN
                             $"@ force|forces everyone in the game to do the command '{ss.RemainingArgument}'",
                             character),
                         flags: OutputFlags.WizOnly), true);
-                    foreach (ICharacter person in character.Gameworld.Characters
-                                                    .Where(x => !x.AffectedBy<IIgnoreForceEffect>())
+                    foreach (ICharacter person in character.Gameworld.Actors
+                                                    .Where(x => !x.AffectedBy<IIgnoreForceEffect>() &&
+                                                                CommandExecutionGuards.CanForceTarget(character, x))
                                                     .ToList())
                     {
                         person.ExecuteCommand(ss.RemainingArgument);
@@ -642,7 +643,9 @@ With no limits, all retained room speech context is shown.", AutoHelp.HelpArgOrN
                             $"@ force|forces all players in the game to do the command '{ss.RemainingArgument}'",
                             character),
                         flags: OutputFlags.WizOnly), true);
-                    foreach (ICharacter person in character.Gameworld.Actors.Where(x => !x.AffectedBy<IIgnoreForceEffect>())
+                    foreach (ICharacter person in character.Gameworld.Characters
+                                                    .Where(x => !x.AffectedBy<IIgnoreForceEffect>() &&
+                                                                CommandExecutionGuards.CanForceTarget(character, x))
                                                     .ToList())
                     {
                         person.ExecuteCommand(ss.RemainingArgument);
@@ -678,7 +681,9 @@ With no limits, all retained room speech context is shown.", AutoHelp.HelpArgOrN
                             $"@ force|forces all NPCs in the game to do the command '{ss.RemainingArgument}'",
                             character),
                         flags: OutputFlags.WizOnly), true);
-                    foreach (ICharacter person in character.Gameworld.NPCs.Where(x => !x.AffectedBy<IIgnoreForceEffect>())
+                    foreach (ICharacter person in character.Gameworld.NPCs
+                                                    .Where(x => !x.AffectedBy<IIgnoreForceEffect>() &&
+                                                                CommandExecutionGuards.CanForceTarget(character, x))
                                                     .ToList())
                     {
                         person.ExecuteCommand(ss.RemainingArgument);
@@ -708,7 +713,8 @@ With no limits, all retained room speech context is shown.", AutoHelp.HelpArgOrN
                 flags: OutputFlags.WizOnly));
             foreach (ICharacter person in character.Location.Characters
                                             .Where(x => !x.AffectedBy<IIgnoreForceEffect>() &&
-                                                        !x.AffectedBy<IAdminInvisEffect>())
+                                                        !x.AffectedBy<IAdminInvisEffect>() &&
+                                                        CommandExecutionGuards.CanForceTarget(character, x))
                                             .ToList())
             {
                 person.ExecuteCommand(ss.RemainingArgument);
@@ -723,7 +729,8 @@ With no limits, all retained room speech context is shown.", AutoHelp.HelpArgOrN
                     $"@ force|forces all NPCs in the room to do the command '{ss.RemainingArgument}'", character),
                 flags: OutputFlags.WizOnly));
             foreach (ICharacter person in character.Location.Characters.Where(x => !x.AffectedBy<IIgnoreForceEffect>())
-                                            .Where(x => x is INPC).ToList())
+                                            .Where(x => x is INPC && CommandExecutionGuards.CanForceTarget(character, x))
+                                            .ToList())
             {
                 person.ExecuteCommand(ss.RemainingArgument);
             }
@@ -751,6 +758,13 @@ With no limits, all retained room speech context is shown.", AutoHelp.HelpArgOrN
             return;
         }
 
+        if (!CommandExecutionGuards.CanForceTarget(character, target))
+        {
+            character.OutputHandler.Send(
+                $"{target.HowSeen(character, true)} is an admin of equal or higher authority, so you cannot FORCE them.");
+            return;
+        }
+
         character.OutputHandler.Handle(new EmoteOutput(new Emote(
                 $"@ force|forces $0 to do the command '{ss.RemainingArgument}'", character, target),
             flags: OutputFlags.WizOnly));
@@ -759,6 +773,9 @@ With no limits, all retained room speech context is shown.", AutoHelp.HelpArgOrN
 
     [PlayerCommand("As", "as")]
     [CommandPermission(PermissionLevel.Admin)]
+    [HelpInfo("as",
+        "This command allows you to briefly execute a command as another visible character. Only Implementors may use AS on another admin; non-Implementor admins may only AS non-admin characters.",
+        AutoHelp.HelpArgOrNoArg)]
     protected static void As(ICharacter character, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -782,14 +799,28 @@ With no limits, all retained room speech context is shown.", AutoHelp.HelpArgOrN
             return;
         }
 
+        if (!CommandExecutionGuards.CanUseAsTarget(character, target))
+        {
+            character.OutputHandler.Send(
+                $"{target.HowSeen(character, true)} is an admin, so only Implementors can use AS on them.");
+            return;
+        }
+
         IController oldController = target.Controller;
+        IController actorController = character.Controller;
         character.OutputHandler.Handle(new EmoteOutput(new Emote(
                 $"@ force|forces $0 to do the command '{ss.RemainingArgument}'", character, target),
             flags: OutputFlags.WizOnly));
-        target.SilentAssumeControl(character.Controller);
-        target.ExecuteCommand(ss.RemainingArgument);
-        target.SilentAssumeControl(oldController);
-        character.SilentAssumeControl(character.Controller);
+        target.SilentAssumeControl(actorController);
+        try
+        {
+            target.ExecuteCommand(ss.RemainingArgument);
+        }
+        finally
+        {
+            target.SilentAssumeControl(oldController);
+            character.SilentAssumeControl(actorController);
+        }
     }
 
     public const string LoadCurrencyHelp = @"This command is used to load an amount of currency into the world. Currency exists as a virtual currency pile object and so cannot be loaded directly using the normal methods.

--- a/MudSharpCore/Effects/Concrete/Dreaming.cs
+++ b/MudSharpCore/Effects/Concrete/Dreaming.cs
@@ -120,7 +120,7 @@ public class Dreaming : Effect, IDreamingEffect
                     ownerAsCharacter.RemoveAllEffects(x => x.IsEffectType<NoWake>());
                 }
 
-                ownerAsCharacter.OutOfContextExecuteCommand(command);
+                CommandExecutionGuards.OutOfContextExecuteForcedCommand(ownerAsCharacter, command);
             }
         }
 

--- a/MudSharpCore/Events/Hooks/CommandHook.cs
+++ b/MudSharpCore/Events/Hooks/CommandHook.cs
@@ -1,4 +1,5 @@
 ﻿using MudSharp.Framework;
+using MudSharp.Character;
 using System;
 using System.Linq;
 using System.Xml.Linq;
@@ -28,8 +29,16 @@ public class CommandHook : HookBase, ICommandHook
                                                                                  return false;
                                                                              }
 
-                                                                             ((IControllable)paramlist.ElementAt(_commandExecuterIndex)).ExecuteCommand(
-                                                                                 CommandToExecute(paramlist));
+                                                                             var target = (IControllable)paramlist.ElementAt(_commandExecuterIndex);
+                                                                             var command = CommandToExecute(paramlist);
+                                                                             if (target is ICharacter character)
+                                                                             {
+                                                                                 CommandExecutionGuards.ExecuteForcedCommand(character, command);
+                                                                             }
+                                                                             else
+                                                                             {
+                                                                                 target.ExecuteCommand(command);
+                                                                             }
                                                                              return true;
                                                                          };
 

--- a/MudSharpCore/Framework/CommandExecutionGuards.cs
+++ b/MudSharpCore/Framework/CommandExecutionGuards.cs
@@ -1,0 +1,74 @@
+using MudSharp.Accounts;
+using MudSharp.Character;
+
+namespace MudSharp.Framework;
+
+internal static class CommandExecutionGuards
+{
+	public const PermissionLevel AdminTargetThreshold = PermissionLevel.JuniorAdmin;
+
+	public static bool CanForceTarget(ICharacter actor, ICharacter target)
+	{
+		if (actor.PermissionLevel >= PermissionLevel.Founder)
+		{
+			return true;
+		}
+
+		if (target.PermissionLevel < AdminTargetThreshold)
+		{
+			return true;
+		}
+
+		return target.PermissionLevel < actor.PermissionLevel;
+	}
+
+	public static bool CanUseAsTarget(ICharacter actor, ICharacter target)
+	{
+		return actor.PermissionLevel >= PermissionLevel.Founder ||
+		       target.PermissionLevel < AdminTargetThreshold;
+	}
+
+	public static bool ExecuteForcedCommand(ICharacter target, string command)
+	{
+		if (!ShouldExecuteAsMortal(target))
+		{
+			return target.ExecuteCommand(command);
+		}
+
+		var originalPermission = target.PermissionLevel;
+		target.ChangePermissionLevel(PermissionLevel.Player);
+		try
+		{
+			return target.ExecuteCommand(command);
+		}
+		finally
+		{
+			target.ChangePermissionLevel(originalPermission);
+		}
+	}
+
+	public static void OutOfContextExecuteForcedCommand(ICharacter target, string command)
+	{
+		if (!ShouldExecuteAsMortal(target))
+		{
+			target.OutOfContextExecuteCommand(command);
+			return;
+		}
+
+		var originalPermission = target.PermissionLevel;
+		target.ChangePermissionLevel(PermissionLevel.Player);
+		try
+		{
+			target.OutOfContextExecuteCommand(command);
+		}
+		finally
+		{
+			target.ChangePermissionLevel(originalPermission);
+		}
+	}
+
+	private static bool ShouldExecuteAsMortal(ICharacter target)
+	{
+		return target.IsPlayerCharacter && target.PermissionLevel > PermissionLevel.Player;
+	}
+}

--- a/MudSharpCore/Framework/Scheduling/Schedules.cs
+++ b/MudSharpCore/Framework/Scheduling/Schedules.cs
@@ -76,7 +76,7 @@ public class CommandSchedule : ScheduleBase
 
     public override void Fire()
     {
-        Actor.OutOfContextExecuteCommand(Command);
+        CommandExecutionGuards.OutOfContextExecuteForcedCommand(Actor, Command);
     }
 
     public override bool PertainsTo(IFrameworkItem item)

--- a/MudSharpCore/FutureProg/Statements/Delay.cs
+++ b/MudSharpCore/FutureProg/Statements/Delay.cs
@@ -141,7 +141,9 @@ For example:
 
 	#Odelay#0 #25000#0 #M@guard#0 #N""say Golly, the weather sure is nice today!""#0
 
-If you specify a delay of 0 the command will be executed immediately - this is really an alternative to the FORCE statement in this usage.");
+If you specify a delay of 0 the command will be executed immediately - this is really an alternative to the FORCE statement in this usage.
+
+If the target is a staff PC, the delayed command is executed in temporary mortal mode. Admin-only commands are not available for the duration, and admin checks inside player-facing commands behave as if the target were a normal player.");
     }
 
     public override StatementResult Execute(IVariableSpace variables)
@@ -174,13 +176,13 @@ If you specify a delay of 0 the command will be executed immediately - this is r
         double delay = Convert.ToDouble(DelayFunction.Result.GetObject);
         if (delay <= 0)
         {
-            ((IControllable)CharacterFunction.Result).ExecuteCommand(TextFunction.Result.GetObject.ToString());
+            CommandExecutionGuards.ExecuteForcedCommand(character, TextFunction.Result.GetObject.ToString());
             return StatementResult.Normal;
         }
 
         string text = TextFunction.Result.GetObject.ToString();
         character.AddEffect(new DelayedAction(character,
-            perceivable => { character.ExecuteCommand(text); },
+            perceivable => { CommandExecutionGuards.ExecuteForcedCommand(character, text); },
             "delayed command"), TimeSpan.FromMilliseconds(delay));
         return StatementResult.Normal;
     }

--- a/MudSharpCore/FutureProg/Statements/Force.cs
+++ b/MudSharpCore/FutureProg/Statements/Force.cs
@@ -1,4 +1,5 @@
 ﻿using MudSharp.Framework;
+using MudSharp.Character;
 using MudSharp.FutureProg.Compiler;
 using MudSharp.FutureProg.Functions;
 using System;
@@ -125,7 +126,9 @@ The syntax is as follows:
 
 For example:
 
-	#Lforce#0 #M@guard#0 #N""say Golly, the weather sure is nice today!""#0");
+	#Lforce#0 #M@guard#0 #N""say Golly, the weather sure is nice today!""#0
+
+If the target is a staff PC, the forced command is executed in temporary mortal mode. Admin-only commands are not available for the duration, and admin checks inside player-facing commands behave as if the target were a normal player.");
     }
 
     public override StatementResult Execute(IVariableSpace variables)
@@ -142,7 +145,8 @@ For example:
             return StatementResult.Error;
         }
 
-        ((IControllable)CharacterFunction.Result).ExecuteCommand(TextFunction.Result.GetObject.ToString());
+        CommandExecutionGuards.ExecuteForcedCommand((ICharacter)CharacterFunction.Result,
+            TextFunction.Result.GetObject.ToString());
         return StatementResult.Normal;
     }
 }

--- a/MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs
+++ b/MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs
@@ -1552,7 +1552,7 @@ public class ForceCommandEffect : IMagicSpellEffectTemplate
 		Gameworld.SystemMessage(new EmoteOutput(new Emote(
 			$"@ magically compel|compels $0 to execute '{Command}'", caster, character),
 			flags: OutputFlags.WizOnly), true);
-		character.ExecuteCommand(Command);
+		CommandExecutionGuards.ExecuteForcedCommand(character, Command);
 		return null;
 	}
 
@@ -1577,7 +1577,7 @@ public class ForceCommandEffect : IMagicSpellEffectTemplate
 
 	public IMagicSpellEffectTemplate Clone() => new ForceCommandEffect(SaveToXml(), Spell);
 
-	public const string HelpText = "#3command <command>#0 - sets the command the target will execute";
+	public const string HelpText = "#3command <command>#0 - sets the command the target will execute. Staff PCs execute in temporary mortal mode.";
 
 	public bool BuildingCommand(ICharacter actor, StringStack command)
 	{

--- a/MudSharpCore/RPG/Dreams/Dream.cs
+++ b/MudSharpCore/RPG/Dreams/Dream.cs
@@ -424,7 +424,7 @@ public class Dream : SaveableItem, IDream
         else
         {
             actor.OutputHandler.Send(
-                $"The {value.ToOrdinal()} stage will now execute the following commands:\n\n{_dreamStages[value - 1].DreamerCommand.ColourCommand()}");
+                $"The {value.ToOrdinal()} stage will now execute the following commands:\n\n{_dreamStages[value - 1].DreamerCommand.ColourCommand()}\n\nIf the dreamer is a staff PC, these commands will execute in temporary mortal mode.");
         }
 
         return true;


### PR DESCRIPTION
## Summary
- add `CommandExecutionGuards` for FORCE/AS target eligibility and scoped staff-PC mortal mode
- harden FORCE fan-outs, direct FORCE, and AS against admin privilege proxying
- route authored forced command paths through the secured helper and update docs/help text
- add focused `CommandExecutionSecurity` unit coverage

## Validation
- `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 --filter CommandExecutionSecurity -p:NoWarn=NU1902%3BNU1510`
- `git diff --check`
- `git diff --cached --check`