### PR TITLE
Harden signed unit parsing to avoid FormatException from malformed inputs

### DIFF
--- a/MudSharpCore Unit Tests/UnitManagerParsingTests.cs
+++ b/MudSharpCore Unit Tests/UnitManagerParsingTests.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Framework.Units;
+using System.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class UnitManagerParsingTests
+{
+	[TestMethod]
+	[DataRow("++1m")]
+	[DataRow("--1kg")]
+	[DataRow("+-1m")]
+	[DataRow("1.2.3m")]
+	public void GetUnitMatches_MalformedUnitValue_ReturnsNoMatches(string pattern)
+	{
+		var matches = UnitManager.GetUnitMatches(pattern);
+
+		Assert.IsFalse(matches.Any());
+	}
+
+	[TestMethod]
+	public void TryParseUnitValue_SignedUnitValue_ParsesWithInvariantCulture()
+	{
+		var match = UnitManager.GetUnitMatches("-1.5m").Single();
+
+		Assert.IsTrue(UnitManager.TryParseUnitValue(match, out var value));
+		Assert.AreEqual(-1.5, value);
+	}
+
+	[TestMethod]
+	public void GetUnitMatches_MultipleUnitValues_ReturnsAllMatches()
+	{
+		var matches = UnitManager.GetUnitMatches("5ft 2in");
+
+		Assert.AreEqual(2, matches.Count);
+		Assert.AreEqual("5", matches[0].Groups[1].Value);
+		Assert.AreEqual("ft", matches[0].Groups[2].Value);
+		Assert.AreEqual("2", matches[1].Groups[1].Value);
+		Assert.AreEqual("in", matches[1].Groups[2].Value);
+	}
+}

--- a/MudSharpCore/Framework/Units/UnitManager.cs
+++ b/MudSharpCore/Framework/Units/UnitManager.cs
@@ -4,6 +4,7 @@ using MudSharp.Models;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using CultureInfo = System.Globalization.CultureInfo;
@@ -12,7 +13,7 @@ namespace MudSharp.Framework.Units;
 
 public class UnitManager : IUnitManager
 {
-    private static readonly Regex PatternRegex = new(@"([+-]*\d{1,}[\.\d]{0,})[ ]{0,1}([a-zA-Z'""]{1,})");
+    private static readonly Regex PatternRegex = new(@"\G\s*([+-]?\d+(?:\.\d*)?)[ ]{0,1}([a-zA-Z'""]{1,})\s*");
     private readonly List<IUnit> _units = new();
 
     private readonly CollectionDictionary<string, IUnit> _unitSystems =
@@ -93,7 +94,7 @@ public class UnitManager : IUnitManager
     public double GetBaseUnits(string pattern, UnitType type, out bool success)
     {
         double baseSum = 0;
-        List<Match> matches = PatternRegex.Matches(pattern).ToList();
+        List<Match> matches = GetUnitMatches(pattern);
         if (!matches.Any())
         {
             success = false;
@@ -111,7 +112,13 @@ public class UnitManager : IUnitManager
                 return 0.0;
             }
 
-            baseSum += double.Parse(match.Groups[1].Value) * unit.MultiplierFromBase;
+            if (!TryParseUnitValue(match, out double unitValue))
+            {
+                success = false;
+                return 0.0;
+            }
+
+            baseSum += unitValue * unit.MultiplierFromBase;
         }
 
         success = true;
@@ -121,7 +128,7 @@ public class UnitManager : IUnitManager
     public bool TryGetBaseUnits(string pattern, UnitType type, IPerceiver who, out double value)
     {
         value = 0.0;
-        List<Match> matches = PatternRegex.Matches(pattern).ToList();
+        List<Match> matches = GetUnitMatches(pattern);
         if (!matches.Any())
         {
             if (double.TryParse(pattern, out double dvalue))
@@ -150,7 +157,13 @@ public class UnitManager : IUnitManager
                 return false;
             }
 
-            value += double.Parse(match.Groups[1].Value) * unit.MultiplierFromBase;
+            if (!TryParseUnitValue(match, out double unitValue))
+            {
+                value = 0.0;
+                return false;
+            }
+
+            value += unitValue * unit.MultiplierFromBase;
         }
 
         return true;
@@ -159,7 +172,7 @@ public class UnitManager : IUnitManager
     public bool TryGetBaseUnits(string pattern, UnitType type, IAccount who, out double value)
     {
         value = 0.0;
-        List<Match> matches = PatternRegex.Matches(pattern).ToList();
+        List<Match> matches = GetUnitMatches(pattern);
         if (!matches.Any())
         {
             if (double.TryParse(pattern, out double dvalue))
@@ -188,10 +201,33 @@ public class UnitManager : IUnitManager
                 return false;
             }
 
-            value += double.Parse(match.Groups[1].Value) * unit.MultiplierFromBase;
+            if (!TryParseUnitValue(match, out double unitValue))
+            {
+                value = 0.0;
+                return false;
+            }
+
+            value += unitValue * unit.MultiplierFromBase;
         }
 
         return true;
+    }
+
+    internal static List<Match> GetUnitMatches(string pattern)
+    {
+        List<Match> matches = PatternRegex.Matches(pattern).ToList();
+        if (!matches.Any())
+        {
+            return matches;
+        }
+
+        Match lastMatch = matches[^1];
+        return lastMatch.Index + lastMatch.Length == pattern.Length ? matches : new List<Match>();
+    }
+
+    internal static bool TryParseUnitValue(Match match, out double value)
+    {
+        return double.TryParse(match.Groups[1].Value, NumberStyles.Float, CultureInfo.InvariantCulture, out value);
     }
 
     private void InitialiseUnitManager(IFuturemud game)


### PR DESCRIPTION
### Motivation
- Prevent malformed signed unit inputs like `++1m`, `--1kg`, or `+-1m` from being accepted by the unit parser and later thrown into `double.Parse`, which could propagate to player-input handling and cause a server-wide `Environment.Exit(0)` crash. 
- Ensure numeric parsing uses a single optional sign and invariant-culture parsing so remote user input cannot trigger an unhandled exception. 

### Description
- Tighten the unit regex to require at most one leading sign and to anchor/consume matched unit text by updating `PatternRegex` to `"\\G\\s*([+-]?\\d+(?:\\.\\d*)?)[ ]{0,1}([a-zA-Z'\"]{1,})\\s*"` in `MudSharpCore/Framework/Units/UnitManager.cs`. 
- Add `GetUnitMatches(string)` to only accept regex matches that consume the full unit input and reject partial/ambiguous matches. 
- Replace unsafe `double.Parse` calls with `TryParseUnitValue(Match, out double)` that uses `double.TryParse(..., NumberStyles.Float, CultureInfo.InvariantCulture, out value)` and propagate parse failures as a normal `false`/error return rather than throwing. 
- Add targeted tests `MudSharpCore Unit Tests/UnitManagerParsingTests.cs` to verify malformed repeated-sign strings are rejected and that valid signed and compound unit values parse correctly. 

### Testing
- Ran targeted restore/build for the core project with `dotnet restore MudSharpCore/MudSharpCore.csproj` and `dotnet build MudSharpCore/MudSharpCore.csproj`, which completed successfully. 
- Restored and ran the unit test project with `dotnet restore 'MudSharpCore Unit Tests/MudSharpCore Unit Tests.csproj'` and `dotnet test` against the new `UnitManagerParsingTests`, and the targeted tests passed (`Passed: 6, Failed: 0`). 
- Attempting a full-solution `dotnet restore MudSharp.sln` failed in this container due to Windows-targeted projects requiring `EnableWindowsTargeting=true`, so the full-solution restore was not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e6baad0c48323b04aa3d0db87f788)