### PR TITLE
Fix mounted rider movement authorization bypass

### DIFF
--- a/Design Documents/AI/NPC_AI_and_Group_AI_Runtime.md
+++ b/Design Documents/AI/NPC_AI_and_Group_AI_Runtime.md
@@ -28,7 +28,7 @@ This document does not attempt to be a full event-system reference. Use the comp
 | Contract | Role |
 | --- | --- |
 | `IArtificialIntelligence` | Shared contract for reusable AI definitions that can be attached to NPC templates and live NPCs |
-| `IMountableAI` | Narrow extension for mount/rider behavior layered on top of normal AI behavior |
+| `IMountableAI` | Narrow extension for mount/rider behavior layered on top of normal AI behavior. Mounted movement is routed through the mount's rider-control path so only the primary rider can direct travel and `PermitControl` can deny control before any shared movement group is created. |
 | `IHandleEvents` | Event-handling surface inherited by AI definitions so they can react to engine events and heartbeat ticks |
 
 ### Group AI

--- a/MudSharpCore Unit Tests/MovementTests.cs
+++ b/MudSharpCore Unit Tests/MovementTests.cs
@@ -14,6 +14,7 @@ using MudSharp.Movement;
 using MudSharp.PerceptionEngine;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace MudSharp_Unit_Tests;
@@ -55,6 +56,26 @@ public class MovementTests
         Assert.IsNull(party.Object.Movement);
         mover.Verify(x => x.Move("north"), Times.Once);
         leader.Verify(x => x.Move(It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public void CharacterMove_MountedRiderDelegatesToMountAuthorizationBeforeCreatingMovement()
+    {
+        string movementSource = File.ReadAllText(GetCoreSourcePath("Character", "CharacterMovement.cs"));
+        int moveStart = movementSource.IndexOf("public bool Move(ICellExit exit", StringComparison.Ordinal);
+        int staminaStart = movementSource.IndexOf("protected double StaminaForMovement", StringComparison.Ordinal);
+
+        Assert.IsTrue(moveStart >= 0, "Character.Move(ICellExit) should exist.");
+        Assert.IsTrue(staminaStart > moveStart, "Character.Move(ICellExit) should appear before StaminaForMovement.");
+
+        string moveMethod = movementSource[moveStart..staminaStart];
+        int mountedGuard = moveMethod.IndexOf("if (RidingMount is not null)", StringComparison.Ordinal);
+        int riderMove = moveMethod.IndexOf("return RidingMount.RiderMove(exit, this, emote, ignoreSafeMovement);", StringComparison.Ordinal);
+        int createMovement = moveMethod.IndexOf("Movement.CreateMovement(this, exit, emote, ignoreSafeMovement)", StringComparison.Ordinal);
+
+        Assert.IsTrue(mountedGuard >= 0, "Mounted riders must be handled before generic movement creation.");
+        Assert.IsTrue(riderMove > mountedGuard, "Mounted rider movement must delegate through RiderMove.");
+        Assert.IsTrue(createMovement > riderMove, "RiderMove authorization must happen before creating a movement group.");
     }
 
     [TestMethod]
@@ -104,6 +125,20 @@ public class MovementTests
 
         mover.Object.Movement = movement;
         return (movement, mover, exit, destination, queuedCommands);
+    }
+
+    private static string GetCoreSourcePath(params string[] segments)
+    {
+        return Path.GetFullPath(Path.Combine(
+            new[]
+            {
+                AppContext.BaseDirectory,
+                "..",
+                "..",
+                "..",
+                "..",
+                "MudSharpCore"
+            }.Concat(segments).ToArray()));
     }
 
     private static Mock<ICharacter> CreateMoverMock(Queue<string> queuedCommands)

--- a/MudSharpCore/Character/CharacterMovement.cs
+++ b/MudSharpCore/Character/CharacterMovement.cs
@@ -571,6 +571,11 @@ public partial class Character
             return false;
         }
 
+        if (RidingMount is not null)
+        {
+            return RidingMount.RiderMove(exit, this, emote, ignoreSafeMovement);
+        }
+
         ConvertGrapplesToDrags();
 
         CanMoveFlags flags = CanMoveFlags.IgnoreWhetherExitCanBeCrossed | CanMoveFlags.IgnoreCancellableActionBlockers;


### PR DESCRIPTION
### Motivation
- Prevent mounted players from bypassing mount-control checks so only the primary rider (and mount AI via `PermitControl`) can direct mounted movement.
- Restore the original delegation path that enforces `IsPrimaryRider` and `PermitControl` before any shared movement group is created.

### Description
- Route `Character.Move(ICellExit...)` through `RidingMount.RiderMove(...)` when `RidingMount` is present, so the mount's `RiderMove` authorization runs before `Movement.CreateMovement` (file: `MudSharpCore/Character/CharacterMovement.cs`).
- Add a regression unit test that asserts the `Move` method contains the mounted-guard and delegates to `RiderMove` before `Movement.CreateMovement` is invoked (file: `MudSharpCore Unit Tests/MovementTests.cs`).
- Add a small source-path helper used by the test (file: `MudSharpCore Unit Tests/MovementTests.cs`).
- Update AI runtime documentation to record that mounted movement is routed through the mount-control path so `PermitControl` and primary-rider checks are applied before forming movement groups (file: `Design Documents/AI/NPC_AI_and_Group_AI_Runtime.md`).

### Testing
- Ran `dotnet restore "MudSharpCore Unit Tests/MudSharpCore Unit Tests.csproj" -m:1 -p:RestoreBuildInParallel=false -p:NuGetAudit=false`, which completed successfully.
- Performed a source-level assertion via a small Python check that confirmed the `if (RidingMount is not null)` guard, the `RidingMount.RiderMove(...)` delegation, and the presence of the new regression test; this check succeeded.
- Ran `git diff --check` as part of validation; no whitespace errors reported.
- Attempted to run a targeted build/test in the sandbox (explicit `dotnet build` / `dotnet test` commands) but the full compile/test run did not complete within the sandboxed environment (Roslyn / csc workload exceeded available runtime before completion), so the new unit test was not executed end-to-end here; a local CI or developer build is recommended to run the full test suite and validate behavior under normal build conditions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e3a08f388832384cb167732cd0e90)