### PR TITLE
Fix pathfinding index live cell additions

### DIFF
--- a/Design Documents/World/Pathfinding_System.md
+++ b/Design Documents/World/Pathfinding_System.md
@@ -11,9 +11,9 @@ FutureMUD has two pathfinding modes:
 
 ## Incremental Indexing
 
-Topology invalidation is deliberately cheap. Exit overlay rebuilds, transient exit registration/removal, and cell deletion mark the index dirty and cancel any in-progress builder, but they do not rebuild the index synchronously.
+Topology invalidation is deliberately cheap. Exit overlay rebuilds, transient exit registration/removal, and cell deletion mark the index dirty and cancel any in-progress builder, but they do not rebuild the index synchronously. Cell creation is also detected from the live cell count; if a cell appears during an idle rebuild, the active builder finishes the snapshot it started with and immediately queues the next rebuild.
 
-The main engine loop calls `PathfindingService.DoIdleWork(...)` during the existing idle window, before lazy-load flushing receives the remaining time budget. The default loop cap is small, currently 3ms per tick, and the builder also has a work-unit cap so tests and future tuning can force multi-slice rebuilds. A new snapshot is published only after all queued cells have been processed.
+The main engine loop calls `PathfindingService.DoIdleWork(...)` during the existing idle window, before lazy-load flushing receives the remaining time budget. The default loop cap is small, currently 3ms per tick, and the builder also has a work-unit cap so tests and future tuning can force multi-slice rebuilds. Each builder captures the cell list at the start of its build so live cell additions between idle slices cannot mutate the enumerator it is using. A new snapshot is published only after all queued cells have been processed.
 
 Door and lock changes do not invalidate the topology snapshot. Hierarchical queries validate every returned segment against live exits and the caller's suitability predicate, so stale topology can suggest a candidate route but cannot return an invalid path through a locked, closed, actor-blocked, or otherwise unsuitable exit.
 

--- a/MudSharpCore Unit Tests/PathfindingServiceLiveMutationTests.cs
+++ b/MudSharpCore Unit Tests/PathfindingServiceLiveMutationTests.cs
@@ -1,0 +1,72 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Construction;
+using MudSharp.Construction.Boundary;
+using MudSharp.Framework;
+using System;
+using System.Collections.Generic;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class PathfindingServiceLiveMutationTests
+{
+	[TestMethod]
+	public void IdleBuildSurvivesCellAddedBetweenSlices()
+	{
+		All<ICell> allCells = new();
+		Mock<IFuturemud> gameworld = new();
+		gameworld.Setup(x => x.Cells).Returns(allCells);
+		PathfindingService service = new(gameworld.Object)
+		{
+			MaximumCellsPerIdleSlice = 1
+		};
+
+		CellStub cellA = new()
+		{
+			Id = 4001,
+			Name = "Original A",
+			Gameworld = gameworld.Object,
+			Room = new RoomStub { X = 0, Y = 0, Z = 0 }.ToMock(),
+			Exits = new List<CellExitStub>()
+		};
+		CellStub cellB = new()
+		{
+			Id = 4002,
+			Name = "Original B",
+			Gameworld = gameworld.Object,
+			Room = new RoomStub { X = 11, Y = 0, Z = 0 }.ToMock(),
+			Exits = new List<CellExitStub>()
+		};
+		CellStub addedCell = new()
+		{
+			Id = 4003,
+			Name = "Added Mid Build",
+			Gameworld = gameworld.Object,
+			Room = new RoomStub { X = 22, Y = 0, Z = 0 }.ToMock(),
+			Exits = new List<CellExitStub>()
+		};
+
+		List<Mock<ICell>> initialMocks = new() { cellA.ToMock(), cellB.ToMock() };
+		allCells.Add(cellA.GetObject(initialMocks));
+		allCells.Add(cellB.GetObject(initialMocks));
+
+		service.RequestIndexWarmup();
+		service.DoIdleWork(TimeSpan.FromSeconds(1));
+
+		List<Mock<ICell>> addedMocks = new() { addedCell.ToMock() };
+		allCells.Add(addedCell.GetObject(addedMocks));
+
+		service.DoIdleWork(TimeSpan.FromSeconds(1));
+		service.DoIdleWork(TimeSpan.FromSeconds(1));
+
+		Assert.IsTrue(service.Diagnostics.CurrentSnapshotVersion > 0,
+			"Expected a live cell addition between idle slices not to crash the in-progress index build.");
+		Assert.AreEqual(2, service.Diagnostics.SnapshotCellCount,
+			"Expected the in-progress build to publish the complete snapshot it started with.");
+		Assert.IsTrue(service.Diagnostics.IsDirty,
+			"Expected the completed snapshot to stay dirty because the live cell list changed during the build.");
+		Assert.IsTrue(service.Diagnostics.IsBuildQueued,
+			"Expected the service to queue another build for the newly added live cell.");
+	}
+}

--- a/MudSharpCore/Construction/Boundary/PathfindingService.cs
+++ b/MudSharpCore/Construction/Boundary/PathfindingService.cs
@@ -53,10 +53,15 @@ public class PathfindingService : IPathfindingService
 
 	public void RequestIndexWarmup()
 	{
-		if (_snapshot.Version == 0 || _dirty)
+		if (_snapshot.Version == 0 || _dirty || HasLiveCellCountChanged())
 		{
 			_warmupRequested = true;
 		}
+	}
+
+	private bool HasLiveCellCountChanged()
+	{
+		return _snapshot.Version > 0 && _snapshot.CellCount != _gameworld.Cells.Count;
 	}
 
 	public void DoIdleWork(TimeSpan budget)
@@ -68,6 +73,11 @@ public class PathfindingService : IPathfindingService
 
 		if (_builder == null)
 		{
+			if (!_dirty && HasLiveCellCountChanged())
+			{
+				_dirty = true;
+			}
+
 			if (!_dirty && !_warmupRequested)
 			{
 				return;
@@ -90,7 +100,8 @@ public class PathfindingService : IPathfindingService
 		_snapshot = slice.Snapshot;
 		_lastBuildDuration = slice.Snapshot.BuildDuration;
 		_builder = null;
-		_dirty = false;
+		_dirty = HasLiveCellCountChanged();
+		_warmupRequested = _dirty;
 	}
 
 	public bool TryFindLongRangePath(ICell source, IReadOnlyCollection<ICell> targets, uint maximumDistance,
@@ -258,19 +269,20 @@ public class PathfindingService : IPathfindingService
 		private readonly IFuturemud _gameworld;
 		private readonly long _version;
 		private readonly int _bucketSize;
-		private readonly IEnumerator<ICell> _cells;
+		private readonly IReadOnlyList<ICell> _cells;
 		private readonly Stopwatch _buildStopwatch = new();
 		private readonly Dictionary<ClusterKey, int> _clusterIds = new();
 		private readonly Dictionary<long, int> _cellClusters = new();
 		private readonly List<TopologyEdge> _topologyEdges = new();
+		private int _cellIndex;
 
 		public PathfindingIndexBuilder(IFuturemud gameworld, long version, int bucketSize)
 		{
 			_gameworld = gameworld;
 			_version = version;
 			_bucketSize = bucketSize;
-			_cells = _gameworld.Cells.GetEnumerator();
-			QueuedCellCount = _gameworld.Cells.Count;
+			_cells = _gameworld.Cells.ToList();
+			QueuedCellCount = _cells.Count;
 			_buildStopwatch.Start();
 		}
 
@@ -284,9 +296,8 @@ public class PathfindingService : IPathfindingService
 			int edgesScanned = 0;
 			while (cellsProcessed < maximumCells && sliceStopwatch.Elapsed < budget)
 			{
-				if (!_cells.MoveNext())
+				if (_cellIndex >= _cells.Count)
 				{
-					_cells.Dispose();
 					_buildStopwatch.Stop();
 					return new IndexBuildSlice
 					{
@@ -298,7 +309,7 @@ public class PathfindingService : IPathfindingService
 					};
 				}
 
-				edgesScanned += ProcessCell(_cells.Current);
+				edgesScanned += ProcessCell(_cells[_cellIndex++]);
 				cellsProcessed++;
 				ProcessedCellCount++;
 			}


### PR DESCRIPTION
## Summary
- snapshot pathfinding index builds over a captured cell list so live cell additions cannot invalidate the active enumerator
- detect live cell-count drift after/before idle builds and queue a follow-up rebuild for new cells
- add focused regression coverage and update the pathfinding design notes

## Validation
- dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 --filter 'FullyQualifiedName~PathSearchTests|FullyQualifiedName~PathfindingServiceLiveMutationTests'
- git diff --check HEAD~1..HEAD