### PR TITLE
Make item seeder skill lookup alias-aware

### DIFF
--- a/DatabaseSeeder Unit Tests/ItemSeederAddCraftTests.cs
+++ b/DatabaseSeeder Unit Tests/ItemSeederAddCraftTests.cs
@@ -143,6 +143,21 @@ public class ItemSeederAddCraftTests
 		context.SaveChanges();
 	}
 
+	private static void AddSkillTrait(FuturemudDatabaseContext context, long id, string name)
+	{
+		context.TraitDefinitions.Add(new TraitDefinition
+		{
+			Id = id,
+			Name = name,
+			Type = 0,
+			OwnerScope = 0,
+			TraitGroup = "Crafting",
+			ChargenBlurb = string.Empty,
+			ValueExpression = string.Empty
+		});
+		context.SaveChanges();
+	}
+
 	private static Tag Tag(long id, string name)
 	{
 		return new Tag { Id = id, Name = name };
@@ -470,6 +485,32 @@ public class ItemSeederAddCraftTests
 	}
 
 	[TestMethod]
+	public void ItemSeeder_AddCraft_TraitGateResolvesStockPackageAliasTraitName()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedPrerequisites(context);
+		AddSkillTrait(context, 9, "Woodcraft");
+
+		var craft = new ItemSeeder().AddTraitGatedCraftFromImportsForTesting(
+			context,
+			"test stock alias craft",
+			"Testing",
+			"Carpentry",
+			40,
+			BasicPhases(),
+			BasicInputs(),
+			BasicTools(),
+			BasicProducts(),
+			[]
+		);
+
+		Assert.AreEqual(9, craft.CheckTraitId);
+		Assert.AreEqual("Woodcraft", craft.CheckTrait.Name);
+		var appear = context.FutureProgs.Single(x => x.FunctionName == "ItemSeederAppearWoodcraft40");
+		Assert.IsTrue(appear.FunctionText.Contains(@"ToTrait(""9"")"));
+	}
+
+	[TestMethod]
 	public void ItemSeeder_AddCraft_KnowledgeGateUpsertsKnowledgeAndChecksKnowledgeOnly()
 	{
 		using FuturemudDatabaseContext context = BuildContext();
@@ -544,6 +585,38 @@ public class ItemSeederAddCraftTests
 		Assert.IsTrue(appear.FunctionText.Contains(">= 55"));
 		Assert.IsTrue(whyCannot.FunctionText.Contains("Master Pattern Cutting"));
 		Assert.IsTrue(whyCannot.FunctionText.Contains("at least 55"));
+	}
+
+	[TestMethod]
+	public void ItemSeeder_AddCraft_KnowledgeGateResolvesSpacedStockPackageAliasTraitName()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedPrerequisites(context);
+		AddSkillTrait(context, 9, "Wood Work");
+
+		var craft = new ItemSeeder().AddKnowledgeGatedCraftFromImportsForTesting(
+			context,
+			"test knowledge alias craft",
+			"Testing",
+			"Ancient Toolmaking",
+			"Carpentry",
+			35,
+			BasicPhases(),
+			BasicInputs(),
+			BasicTools(),
+			BasicProducts(),
+			[],
+			knowledgeSubtype: "Repair Kits"
+		);
+
+		Assert.AreEqual(9, craft.CheckTraitId);
+		Assert.AreEqual("Wood Work", craft.CheckTrait.Name);
+		var appear = context.FutureProgs.Single(x =>
+			x.FunctionName == "ItemSeederAppearKnowledgeAncientToolmakingWoodWork35");
+		var whyCannot = context.FutureProgs.Single(x =>
+			x.FunctionName == "ItemSeederWhyCannotUseKnowledgeAncientToolmakingWoodWork35");
+		Assert.IsTrue(appear.FunctionText.Contains(@"ToTrait(""9"")"));
+		Assert.IsTrue(whyCannot.FunctionText.Contains("Wood Work"));
 	}
 
 	[TestMethod]

--- a/DatabaseSeeder/Seeders/ItemSeeder.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.cs
@@ -142,6 +142,7 @@ The items and crafts are fairly universal and of approximately medieval to renei
         {
             _traits[trait.Name] = trait;
         }
+		IndexStockSkillPackageTraitAliases();
 
         foreach (GameItemProto item in _context.GameItemProtos)
         {

--- a/DatabaseSeeder/Seeders/ItemSeederCrafting.cs
+++ b/DatabaseSeeder/Seeders/ItemSeederCrafting.cs
@@ -84,6 +84,62 @@ public partial class ItemSeeder
 		public IReadOnlyList<CraftProductSpec> FailProducts { get; init; } = [];
 	}
 
+	// Exact names still win; these are stock skill package variants and legacy spellings in priority order.
+	private static readonly IReadOnlyList<IReadOnlyList<string>> StockSkillPackageTraitAliases =
+	[
+		["Armourcrafting", "Armourer", "Armour Crafting", "Armour Craft", "Armorcrafting", "Armorer", "Armor Crafting", "Armor Craft"],
+		["Weaponcrafting", "Weaponsmith", "Weapon Crafting", "Weapon Craft", "Weaponcraft", "Weaponsmithing"],
+		["Blacksmithing", "Metalcraft", "Metalworking", "Metal Work", "Metalwork", "Smithing"],
+		["Silversmithing", "Silversmith", "Silver Smithing", "Silver Smith"],
+		["Bowmaking", "Bowyer", "Bow Making", "Bowyer Craft"],
+		["Fletching", "Fletcher"],
+		["Pottery", "Potter"],
+		["Weaving", "Weaver"],
+		["Spinning", "Spinner"],
+		["Threshing", "Thresher"],
+		["Milling", "Miller"],
+		["Baking", "Baker"],
+		["Dyeing", "Dyecraft", "Dye Craft", "Dyer"],
+		["Glassworking", "Glasswork", "Glass Work", "Glassworker"],
+		["Gemcraft", "Gem Craft", "Gemcutting", "Gem Cutting"],
+		["Perfumery", "Perfumer"],
+		["Brewing", "Brewer"],
+		["Distilling", "Distiller"],
+		["Cooking", "Cookery", "Cook"],
+		["Carpentry", "Woodcraft", "Woodworking", "Wood Work", "Woodwork", "Carpenter", "Joinery", "Constructing", "Construction"],
+		["Basketry", "Basketmaker", "Basket Making"],
+		["Coopering", "Cooper"],
+		["Ropemaking", "Ropemaker", "Rope Making"],
+		["Lacquerwork", "Lacquerer", "Lacquer Work"],
+		["Lumberjacking", "Lumberjack"],
+		["Masonry", "Stonecraft", "Stoneworking", "Stone Work", "Stonework", "Mason"],
+		["Scrimshawing", "Scrimshaw"],
+		["Tailoring", "Textilecraft", "Textile Craft", "Textilework", "Textile Work", "Tailor"],
+		["Mechanics", "Mechanic"],
+		["Cobbling", "Cobbler"],
+		["Locksmithing", "Locksmith"],
+		["Wheelmaking", "Wheelwright", "Wheel Making"],
+		["Candlemaking", "Candlery", "Candle Making"],
+		["Leathermaking", "Hideworking", "Leatherworking", "Leather Work", "Leatherwork", "Leather Making", "Hide Work"],
+		["Winemaking", "Winemaker", "Wine Making"],
+		["Foraging", "Forage"],
+		["Skinning", "Skin"],
+		["Butchering", "Butchery"],
+		["Salvaging", "Salvage"],
+		["Surviving", "Survival"],
+		["Animal Breeding", "Husbandry"],
+		["Beekeeping", "Beekeeper"],
+		["Law", "Lawyer"],
+		["Labouring", "Labourer", "Laboring", "Laborer"],
+		["Supervising", "Supervisor"],
+		["Painting", "Paint"],
+		["Civil Engineering", "Civil Engineer"],
+		["Administration", "Administrator"],
+		["Performance", "Performer"],
+		["Investigation", "Investigator"],
+		["Smelting", "Smelter"]
+	];
+
 	private static readonly IReadOnlyDictionary<string, string> HellenicAntiquityClothingStableReferences =
 		new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
 		{
@@ -1999,11 +2055,79 @@ return ""There is no useful clay that is accessible in the biome you're in.""");
 		}
 	}
 
+	private void IndexStockSkillPackageTraitAliases()
+	{
+		foreach (IReadOnlyList<string> aliases in StockSkillPackageTraitAliases)
+		{
+			TraitDefinition? trait = aliases
+				.Select(LookupLoadedTraitDefinition)
+				.FirstOrDefault(x => x is not null);
+			if (trait is null)
+			{
+				continue;
+			}
+
+			foreach (string alias in aliases.Where(alias => !_traits.ContainsKey(alias)))
+			{
+				_traits[alias] = trait;
+			}
+		}
+	}
+
+	private TraitDefinition? LookupLoadedTraitDefinition(string traitName)
+	{
+		if (_traits.TryGetValue(traitName, out TraitDefinition? trait) && trait is not null)
+		{
+			return trait;
+		}
+
+		string normalisedName = NormaliseTraitLookupName(traitName);
+		return _traits.Values.FirstOrDefault(x =>
+			NormaliseTraitLookupName(x.Name).Equals(normalisedName, StringComparison.Ordinal));
+	}
+
+	private static string NormaliseTraitLookupName(string traitName)
+	{
+		return new string(traitName.Where(char.IsLetterOrDigit).ToArray()).ToLowerInvariant();
+	}
+
+	private IEnumerable<string> TraitDefinitionLookupNames(string traitName)
+	{
+		string trimmedName = traitName.Trim();
+		HashSet<string> names = new(StringComparer.OrdinalIgnoreCase);
+		if (names.Add(trimmedName))
+		{
+			yield return trimmedName;
+		}
+
+		string normalisedName = NormaliseTraitLookupName(trimmedName);
+		foreach (IReadOnlyList<string> aliases in StockSkillPackageTraitAliases.Where(x =>
+			         x.Any(alias => NormaliseTraitLookupName(alias).Equals(normalisedName, StringComparison.Ordinal))))
+		{
+			foreach (string alias in aliases)
+			{
+				if (names.Add(alias))
+				{
+					yield return alias;
+				}
+			}
+		}
+	}
+
 	private TraitDefinition LookupTraitDefinition(string traitName)
 	{
-		return _traits.TryGetValue(traitName, out TraitDefinition? trait) && trait is not null
-			? trait
-			: throw new ApplicationException($"Unknown trait {traitName}");
+		List<string> attemptedNames = TraitDefinitionLookupNames(traitName).ToList();
+		foreach (string name in attemptedNames)
+		{
+			TraitDefinition? trait = LookupLoadedTraitDefinition(name);
+			if (trait is not null)
+			{
+				return trait;
+			}
+		}
+
+		throw new ApplicationException(
+			$"Unknown trait {traitName}. Tried: {string.Join(", ", attemptedNames)}");
 	}
 
 	private static string SanitiseFutureProgNamePart(string text)


### PR DESCRIPTION
## Summary
- Added prioritized stock skill-package aliases for item seeder craft trait lookups.
- Indexed those aliases during item seeder dependency initialization so gerund/imperative package variants resolve consistently.
- Added regression coverage for trait-gated and knowledge-gated crafts resolving `Carpentry` to installed wood-work style skills.

## Validation
- `dotnet test 'DatabaseSeeder Unit Tests\\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore -m:1 --filter ItemSeederAddCraftTests -p:NoWarn=NU1902%3BNU1510`
- `dotnet test 'DatabaseSeeder Unit Tests\\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore -m:1 --filter ItemSeederAntiquityRemainingCraftingTests -p:NoWarn=NU1902%3BNU1510`
- `git diff --check`

## Note
- Full DatabaseSeeder unit suite currently has two pre-existing failures unrelated to this change: stale `BlankDatabaseSnapshot.manifest.json` migration tracking and an older source-scan assertion for `_tagsByFullPath`.