### PR TITLE
Allow inherited characteristic values in item seeder

### DIFF
--- a/DatabaseSeeder Unit Tests/ItemSeederAddCraftTests.cs
+++ b/DatabaseSeeder Unit Tests/ItemSeederAddCraftTests.cs
@@ -110,12 +110,14 @@ public class ItemSeederAddCraftTests
 
 		context.CharacteristicDefinitions.AddRange(
 			CharacteristicDefinition(1, "Colour"),
-			CharacteristicDefinition(2, "Origin")
+			CharacteristicDefinition(2, "Origin"),
+			CharacteristicDefinition(3, "Fine Colour", parentId: 1)
 		);
 		context.CharacteristicValues.AddRange(
 			CharacteristicValue(1, 1, "red"),
 			CharacteristicValue(2, 1, "blue"),
-			CharacteristicValue(3, 2, "mine")
+			CharacteristicValue(3, 2, "mine"),
+			CharacteristicValue(4, 1, "bone white")
 		);
 
 		context.FutureProgs.AddRange(
@@ -205,12 +207,13 @@ public class ItemSeederAddCraftTests
 		};
 	}
 
-	private static CharacteristicDefinition CharacteristicDefinition(long id, string name)
+	private static CharacteristicDefinition CharacteristicDefinition(long id, string name, long? parentId = null)
 	{
 		return new CharacteristicDefinition
 		{
 			Id = id,
 			Name = name,
+			ParentId = parentId,
 			Type = 0,
 			Pattern = string.Empty,
 			Description = name,
@@ -404,6 +407,37 @@ public class ItemSeederAddCraftTests
 		Assert.AreEqual("1", liquidProduct.Element("Liquid")!.Value);
 		Assert.AreEqual("0.75", liquidProduct.Element("LiquidVolume")!.Value);
 		Assert.AreEqual(4, craft.CraftProducts.Single(x => x.IsFailProduct).MaterialDefiningInputIndex);
+	}
+
+	[TestMethod]
+	public void ItemSeeder_AddCraft_AllowsChildCharacteristicDefinitionsToUseParentValues()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedPrerequisites(context);
+
+		Assert.IsFalse(context.CharacteristicValues.Any(x => x.DefinitionId == 3 && x.Name == "bone white"));
+
+		var craft = new ItemSeeder().AddCraftFromImportsForTesting(
+			context,
+			"test inherited characteristic craft",
+			"Testing",
+			BasicPhases(),
+			["Commodity - 250 grams of iron; characteristic Fine Colour bone white"],
+			BasicTools(),
+			["CommodityProduct - 200 grams of iron commodity; tag Scrap Metal; characteristic Fine Colour=bone white"],
+			[]
+		);
+
+		var commodityInput = XElement.Parse(craft.CraftInputs.Single(x => x.InputType == "Commodity").Definition);
+		var inputCharacteristic = commodityInput.Element("Characteristics")!.Elements("Characteristic").Single();
+		Assert.AreEqual("3", inputCharacteristic.Attribute("definition")!.Value);
+		Assert.AreEqual("4", inputCharacteristic.Attribute("value")!.Value);
+
+		var commodityProduct = XElement.Parse(craft.CraftProducts.Single(x => x.ProductType == "CommodityProduct").Definition);
+		var productCharacteristic = commodityProduct.Element("Characteristics")!.Elements("Characteristic").Single();
+		Assert.AreEqual("3", productCharacteristic.Attribute("definition")!.Value);
+		Assert.AreEqual("4", productCharacteristic.Attribute("value")!.Value);
+		Assert.AreEqual("-1", productCharacteristic.Attribute("input")!.Value);
 	}
 
 	[TestMethod]

--- a/DatabaseSeeder Unit Tests/ItemSeederHellenicClothingCraftingTests.cs
+++ b/DatabaseSeeder Unit Tests/ItemSeederHellenicClothingCraftingTests.cs
@@ -157,7 +157,9 @@ public class ItemSeederHellenicClothingCraftingTests
 		var itemSeederSource = ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.cs");
 
 		AssertContains(itemSeederSource, "BuildTagFullPath");
-		AssertContains(itemSeederSource, "_tagsByFullPath = tagList.ToDictionary");
+		AssertContains(itemSeederSource, "_tagsByFullPath = tagList");
+		AssertContains(itemSeederSource, ".GroupBy(BuildTagFullPath, StringComparer.OrdinalIgnoreCase)");
+		AssertContains(itemSeederSource, ".ToDictionary(x => x.Key, x => x.OrderBy(tag => tag.Id).First(), StringComparer.OrdinalIgnoreCase)");
 		Assert.IsFalse(itemSeederSource.Contains("TODO - initialised _tagsByFullPath", StringComparison.OrdinalIgnoreCase));
 	}
 

--- a/DatabaseSeeder/Seeders/ItemSeederCrafting.cs
+++ b/DatabaseSeeder/Seeders/ItemSeederCrafting.cs
@@ -899,14 +899,45 @@ return ""There is no useful clay that is accessible in the biome you're in.""");
         return definition ?? throw new ApplicationException($"Unknown characteristic definition {text}");
     }
 
-    private CharacteristicValue LookupCharacteristicValue(CharacteristicDefinition definition, string text)
-    {
-        string trimmed = text.Trim();
-        CharacteristicValue? value = long.TryParse(trimmed.TrimStart('#'), out long id)
-            ? _context!.CharacteristicValues.FirstOrDefault(x => x.Id == id && x.DefinitionId == definition.Id)
-            : _context!.CharacteristicValues.FirstOrDefault(x => x.DefinitionId == definition.Id && x.Name.Equals(trimmed, StringComparison.OrdinalIgnoreCase));
-        return value ?? throw new ApplicationException($"Unknown value {text} for characteristic {definition.Name}");
-    }
+	private CharacteristicValue LookupCharacteristicValue(CharacteristicDefinition definition, string text)
+	{
+		string trimmed = text.Trim();
+		CharacteristicValue? value;
+		if (long.TryParse(trimmed.TrimStart('#'), out long id))
+		{
+			value = _context!.CharacteristicValues.FirstOrDefault(x => x.Id == id);
+			if (value is not null && !IsCharacteristicValueForDefinition(definition, value))
+			{
+				value = null;
+			}
+		}
+		else
+		{
+			value = _context!.CharacteristicValues.FirstOrDefault(x => x.DefinitionId == definition.Id && x.Name.Equals(trimmed, StringComparison.OrdinalIgnoreCase)) ??
+			        _context.CharacteristicValues.AsEnumerable().FirstOrDefault(x => x.Name.Equals(trimmed, StringComparison.OrdinalIgnoreCase) && IsCharacteristicValueForDefinition(definition, x));
+		}
+
+		return value ?? throw new ApplicationException($"Unknown value {text} for characteristic {definition.Name}");
+	}
+
+	private bool IsCharacteristicValueForDefinition(CharacteristicDefinition definition, CharacteristicValue value)
+	{
+		CharacteristicDefinition? current = definition;
+		while (current is not null)
+		{
+			if (value.DefinitionId == current.Id)
+			{
+				return true;
+			}
+
+			current = current.ParentId is null
+				? null
+				: _context!.CharacteristicDefinitions.Local.FirstOrDefault(x => x.Id == current.ParentId.Value) ??
+				  _context.CharacteristicDefinitions.FirstOrDefault(x => x.Id == current.ParentId.Value);
+		}
+
+		return false;
+	}
 
 	private long LookupCommodityPileTagId(IEnumerable<string> options)
 	{


### PR DESCRIPTION
## Summary
- Resolve characteristic values against a definition’s parent chain when importing crafts, so child characteristics like `Fine Colour` can use values defined on `Colour`.
- Add a regression test for the antiquity craft case that was failing on `bone white`.
- Update the Hellenic clothing source guard to match the current duplicate-safe tag lookup implementation.

## Testing
- `dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 --filter ItemSeederAddCraftTests`
- `dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 --filter "FullyQualifiedName~ItemSeederHellenicClothingCraftingTests|FullyQualifiedName~ItemSeederNorthernAndKushiteClothingCraftingTests|FullyQualifiedName~ItemSeederRemainingAntiquityClothingCraftingTests"`