### PR TITLE
Expand FutureProg utility function catalogue

### DIFF
--- a/MudSharpCore Unit Tests/FutureProgDateTimeFunctionTests.cs
+++ b/MudSharpCore Unit Tests/FutureProgDateTimeFunctionTests.cs
@@ -206,6 +206,38 @@ public class FutureProgDateTimeFunctionTests
 	}
 
 	[TestMethod]
+	public void DateTimeComponentFunctions_ExecuteRepresentativeHelpers()
+	{
+		var dateProg = Compile<decimal>(
+			"DateTimeComponentDate",
+			ProgVariableTypes.Number,
+			[
+				Tuple.Create(ProgVariableTypes.DateTime, "date")
+			],
+			"return dateyear(@date) + datemonth(@date) + dateday(@date)");
+
+		Assert.AreEqual(2060M, dateProg.Execute<decimal>(new System.DateTime(2026, 5, 29, 13, 45, 0, DateTimeKind.Utc)));
+
+		var spanProg = Compile<TimeSpan>(
+			"DateTimeComponentSpan",
+			ProgVariableTypes.TimeSpan,
+			[],
+			"return maketimespan(1, 2, 3, 4, 5)");
+
+		Assert.AreEqual(new TimeSpan(1, 2, 3, 4, 5), spanProg.Execute<TimeSpan>());
+
+		var totalProg = Compile<decimal>(
+			"DateTimeComponentTotal",
+			ProgVariableTypes.Number,
+			[
+				Tuple.Create(ProgVariableTypes.TimeSpan, "duration")
+			],
+			"return totalhours(@duration)");
+
+		Assert.AreEqual(26M, totalProg.Execute<decimal>(TimeSpan.FromHours(26)));
+	}
+
+	[TestMethod]
 	public void ToMudDate_InvalidText_ReturnsNever()
 	{
 		var prog = Compile<MudDateTime>(

--- a/MudSharpCore Unit Tests/FutureProgFunctionDocumentationTests.cs
+++ b/MudSharpCore Unit Tests/FutureProgFunctionDocumentationTests.cs
@@ -82,6 +82,147 @@ public class FutureProgFunctionDocumentationTests
 		Assert.IsTrue(overloads.All(x => x.FunctionHelp.Contains("radians", StringComparison.OrdinalIgnoreCase)));
 	}
 
+	[TestMethod]
+	public void BuiltInFunctionCatalogue_UtilityPass_AddsExpectedPureHelperFamilies()
+	{
+		FutureProgTestBootstrap.EnsureInitialised();
+
+		var expectedFunctions = new[]
+		{
+			"textlength",
+			"uppercase",
+			"lowercase",
+			"propercase",
+			"titlecase",
+			"trim",
+			"trimstart",
+			"trimend",
+			"lefttext",
+			"righttext",
+			"midtext",
+			"textcontains",
+			"textcontainscase",
+			"startswith",
+			"startswithcase",
+			"endswith",
+			"endswithcase",
+			"textindexof",
+			"textindexofcase",
+			"textlastindexof",
+			"textlastindexofcase",
+			"replacetext",
+			"replacetextcase",
+			"inserttext",
+			"removetext",
+			"repeattext",
+			"isemptytext",
+			"isblanktext",
+			"wordcount",
+			"linecount",
+			"firstword",
+			"lastword",
+			"textbefore",
+			"textafter",
+			"textbetween",
+			"padleft",
+			"padright",
+			"truncatetext",
+			"truncateellipsis",
+			"normalizewhitespace",
+			"counttext",
+			"counttextcase",
+			"reversetext",
+			"capitalizefirst",
+			"collectioncount",
+			"collectionany",
+			"collectionempty",
+			"collectionfirst",
+			"collectionlast",
+			"collectionat",
+			"collectionreverse",
+			"collectiontake",
+			"collectionskip",
+			"collectionrange",
+			"collectionappend",
+			"collectionprepend",
+			"collectionwithoutindex",
+			"collectionconcat",
+			"collectioncontains",
+			"collectionindexof",
+			"collectiondistinct",
+			"collectionshuffle",
+			"collectionisvalidindex",
+			"dictionarycount",
+			"dictionaryany",
+			"dictionaryempty",
+			"dictionarykeys",
+			"dictionaryvalues",
+			"dictionarycontainskey",
+			"dictionaryget",
+			"dictionarygetdefault",
+			"dictionarycontainsvalue",
+			"dictionarywithoutkey",
+			"dictionaryset",
+			"dictionaryfirstkey",
+			"collectiondictionarycount",
+			"collectiondictionarylongcount",
+			"collectiondictionaryany",
+			"collectiondictionaryempty",
+			"collectiondictionarykeys",
+			"collectiondictionaryvalues",
+			"collectiondictionarycontainskey",
+			"collectiondictionaryget",
+			"collectiondictionarygetfirst",
+			"collectiondictionarycontainsvalue",
+			"collectiondictionarywithoutkey",
+			"dateyear",
+			"datemonth",
+			"dateday",
+			"datehour",
+			"dateminute",
+			"datesecond",
+			"datemillisecond",
+			"datedayofyear",
+			"datedayofweek",
+			"dateisweekend",
+			"dateonly",
+			"spandays",
+			"spanhours",
+			"spanminutes",
+			"spanseconds",
+			"spanmilliseconds",
+			"totaldays",
+			"totalhours",
+			"totalminutes",
+			"totalseconds",
+			"totalmilliseconds",
+			"spanabs",
+			"spannegate",
+			"timespanfromdays",
+			"timespanfromhours",
+			"timespanfromminutes",
+			"timespanfromseconds",
+			"timespanfrommilliseconds",
+			"maketimespan"
+		};
+
+		Assert.IsTrue(expectedFunctions.Length >= 50, "The review pass should add at least 50 catalogue entries.");
+
+		var registeredFunctions = FutureProg.GetFunctionCompilerInformations()
+		                                    .Select(x => x.FunctionName)
+		                                    .ToHashSet(StringComparer.InvariantCultureIgnoreCase);
+		var missing = expectedFunctions
+		              .Where(x => !registeredFunctions.Contains(x))
+		              .OrderBy(x => x)
+		              .ToList();
+
+		Assert.AreEqual(
+			0,
+			missing.Count,
+			$"Expected FutureProg utility function registrations were missing:{Environment.NewLine}{string.Join(Environment.NewLine, missing)}"
+		);
+	}
+
 	private static IEnumerable<string> ValidateFunction(FunctionCompilerInformation function)
 	{
 		var signature = $"{function.FunctionName}({string.Join(", ", function.Parameters.Select(x => x.Describe()))})";

--- a/MudSharpCore Unit Tests/ProgTests.cs
+++ b/MudSharpCore Unit Tests/ProgTests.cs
@@ -236,6 +236,65 @@ return @item");
         Assert.AreEqual("Text after a blank line", result[3], $"Result #1 was {result[3]}");
     }
 
+	[TestMethod]
+	public void TextUtilityFunctions_ExecuteRepresentativeHelpers()
+	{
+		FutureProg textProg = new(_gameworld,
+			"TextUtilityText",
+			ProgVariableTypes.Text,
+			Array.Empty<Tuple<ProgVariableTypes, string>>(),
+			@"return normalizewhitespace(replacetext(""alpha   BETA"", ""beta"", ""gamma""))");
+		Assert.IsTrue(textProg.Compile(), textProg.CompileError);
+		Assert.AreEqual("alpha gamma", textProg.Execute<string>());
+
+		FutureProg boolProg = new(_gameworld,
+			"TextUtilityBool",
+			ProgVariableTypes.Boolean,
+			Array.Empty<Tuple<ProgVariableTypes, string>>(),
+			@"return startswith(""FutureMUD"", ""future"") and endswithcase(""FutureMUD"", ""MUD"")");
+		Assert.IsTrue(boolProg.Compile(), boolProg.CompileError);
+		Assert.IsTrue(boolProg.ExecuteBool());
+
+		FutureProg numberProg = new(_gameworld,
+			"TextUtilityNumber",
+			ProgVariableTypes.Number,
+			Array.Empty<Tuple<ProgVariableTypes, string>>(),
+			@"return counttext(""ha ha HA"", ""ha"")");
+		Assert.IsTrue(numberProg.Compile(), numberProg.CompileError);
+		Assert.AreEqual(3, numberProg.ExecuteInt());
+	}
+
+	[TestMethod]
+	public void CollectionUtilityFunctions_PreserveTypedCollections()
+	{
+		FutureProg prog = new(_gameworld,
+			"CollectionUtilityTyped",
+			ProgVariableTypes.Text,
+			Array.Empty<Tuple<ProgVariableTypes, string>>(),
+			@"var parts = SplitText(""alpha,beta,gamma"", "","")
+var extended = collectionappend(@parts, ""delta"")
+var window = collectionrange(@extended, 1, 2)
+return concat(@window, ""|"")");
+		Assert.IsTrue(prog.Compile(), prog.CompileError);
+		Assert.AreEqual("beta|gamma", prog.Execute<string>());
+	}
+
+	[TestMethod]
+	public void CollectionUtilityFunctions_ConcatRejectsSecondCollectionThatCannotAssignToFirst()
+	{
+		FutureProg prog = new(_gameworld,
+			"CollectionConcatUnsafeVariance",
+			ProgVariableTypes.Character | ProgVariableTypes.Collection,
+			new[]
+			{
+				Tuple.Create(ProgVariableTypes.Character | ProgVariableTypes.Collection, "characters"),
+				Tuple.Create(ProgVariableTypes.Toon | ProgVariableTypes.Collection, "toons")
+			},
+			"return collectionconcat(@characters, @toons)");
+
+		Assert.IsFalse(prog.Compile(), "A toon collection should not be concat-able into a character collection return type.");
+	}
+
     [TestMethod]
     public void TestGetTypeByName()
     {

--- a/MudSharpCore/FutureProg/Functions/BuiltIn/CollectionUtilityFunctions.cs
+++ b/MudSharpCore/FutureProg/Functions/BuiltIn/CollectionUtilityFunctions.cs
@@ -1,0 +1,359 @@
+using MudSharp.Framework;
+using MudSharp.FutureProg.Variables;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MudSharp.FutureProg.Functions.BuiltIn;
+
+internal class CollectionUtilityFunction : BuiltInFunction
+{
+	private readonly CollectionOperation _operation;
+	private readonly ProgVariableTypes _metadataReturnType;
+
+	private enum CollectionOperation
+	{
+		Count,
+		Any,
+		Empty,
+		First,
+		Last,
+		At,
+		Reverse,
+		Take,
+		Skip,
+		Range,
+		Append,
+		Prepend,
+		WithoutIndex,
+		Concat,
+		Contains,
+		IndexOf,
+		Distinct,
+		Shuffle,
+		IsValidIndex
+	}
+
+	private CollectionUtilityFunction(IList<IFunction> parameters, CollectionOperation operation,
+		ProgVariableTypes metadataReturnType) : base(parameters)
+	{
+		_operation = operation;
+		_metadataReturnType = metadataReturnType;
+	}
+
+	private ProgVariableTypes ElementType => ParameterFunctions[0].ReturnType ^ ProgVariableTypes.Collection;
+
+	public override ProgVariableTypes ReturnType
+	{
+		get
+		{
+			return _operation switch
+			{
+				CollectionOperation.First or CollectionOperation.Last or CollectionOperation.At => ElementType,
+				CollectionOperation.Reverse or CollectionOperation.Take or CollectionOperation.Skip or CollectionOperation.Range
+					or CollectionOperation.Append or CollectionOperation.Prepend or CollectionOperation.WithoutIndex
+					or CollectionOperation.Concat or CollectionOperation.Distinct or CollectionOperation.Shuffle => ParameterFunctions[0].ReturnType,
+				_ => _metadataReturnType
+			};
+		}
+		protected set { }
+	}
+
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		if (base.Execute(variables) == StatementResult.Error)
+		{
+			return StatementResult.Error;
+		}
+
+		var collection = GetCollection(0);
+		switch (_operation)
+		{
+			case CollectionOperation.Count:
+				Result = new NumberVariable(collection.Count);
+				return StatementResult.Normal;
+			case CollectionOperation.Any:
+				Result = new BooleanVariable(collection.Count > 0);
+				return StatementResult.Normal;
+			case CollectionOperation.Empty:
+				Result = new BooleanVariable(collection.Count == 0);
+				return StatementResult.Normal;
+			case CollectionOperation.First:
+				Result = collection.FirstOrDefault() ?? new NullVariable(ElementType);
+				return StatementResult.Normal;
+			case CollectionOperation.Last:
+				Result = collection.LastOrDefault() ?? new NullVariable(ElementType);
+				return StatementResult.Normal;
+			case CollectionOperation.At:
+				Result = At(collection, GetInteger(1)) ?? new NullVariable(ElementType);
+				return StatementResult.Normal;
+			case CollectionOperation.Reverse:
+				Result = ToCollection(collection.AsEnumerable().Reverse());
+				return StatementResult.Normal;
+			case CollectionOperation.Take:
+				Result = ToCollection(collection.Take(Math.Max(0, GetInteger(1))));
+				return StatementResult.Normal;
+			case CollectionOperation.Skip:
+				Result = ToCollection(collection.Skip(Math.Max(0, GetInteger(1))));
+				return StatementResult.Normal;
+			case CollectionOperation.Range:
+				Result = ToCollection(collection.Skip(Math.Max(0, GetInteger(1))).Take(Math.Max(0, GetInteger(2))));
+				return StatementResult.Normal;
+			case CollectionOperation.Append:
+				Result = ToCollection(collection.Append(ParameterFunctions[1].Result ?? new NullVariable(ElementType)));
+				return StatementResult.Normal;
+			case CollectionOperation.Prepend:
+				Result = ToCollection(collection.Prepend(ParameterFunctions[1].Result ?? new NullVariable(ElementType)));
+				return StatementResult.Normal;
+			case CollectionOperation.WithoutIndex:
+				Result = ToCollection(collection.Where((_, index) => index != GetInteger(1)));
+				return StatementResult.Normal;
+			case CollectionOperation.Concat:
+				Result = ToCollection(collection.Concat(GetCollection(1)));
+				return StatementResult.Normal;
+			case CollectionOperation.Contains:
+				Result = new BooleanVariable(collection.Any(x => ValuesEqual(x, ParameterFunctions[1].Result)));
+				return StatementResult.Normal;
+			case CollectionOperation.IndexOf:
+				Result = new NumberVariable(IndexOf(collection, ParameterFunctions[1].Result));
+				return StatementResult.Normal;
+			case CollectionOperation.Distinct:
+				Result = ToCollection(Distinct(collection));
+				return StatementResult.Normal;
+			case CollectionOperation.Shuffle:
+				Result = ToCollection(collection.OrderBy(_ => Random.Shared.Next()));
+				return StatementResult.Normal;
+			case CollectionOperation.IsValidIndex:
+				var index = GetInteger(1);
+				Result = new BooleanVariable(index >= 0 && index < collection.Count);
+				return StatementResult.Normal;
+			default:
+				throw new NotSupportedException($"Unknown collection utility operation {_operation}.");
+		}
+	}
+
+	private List<IProgVariable> GetCollection(int index)
+	{
+		return ParameterFunctions[index].Result?.GetObject is IList list
+			? list.OfType<IProgVariable>().ToList()
+			: new List<IProgVariable>();
+	}
+
+	private int GetInteger(int index)
+	{
+		return ParameterFunctions[index].Result?.GetObject is decimal value ? (int)value : 0;
+	}
+
+	private IProgVariable At(IReadOnlyList<IProgVariable> collection, int index)
+	{
+		return index >= 0 && index < collection.Count ? collection[index] : null;
+	}
+
+	private CollectionVariable ToCollection(IEnumerable<IProgVariable> collection)
+	{
+		return new CollectionVariable(collection.ToList(), ElementType);
+	}
+
+	private static bool ValuesEqual(IProgVariable lhs, IProgVariable rhs)
+	{
+		if (lhs is null || rhs is null)
+		{
+			return lhs is null && rhs is null;
+		}
+
+		if (lhs.GetObject is string lhsText && rhs.GetObject is string rhsText)
+		{
+			return string.Equals(lhsText, rhsText, StringComparison.InvariantCultureIgnoreCase);
+		}
+
+		return Equals(lhs.GetObject, rhs.GetObject);
+	}
+
+	private static int IndexOf(IReadOnlyList<IProgVariable> collection, IProgVariable item)
+	{
+		for (var i = 0; i < collection.Count; i++)
+		{
+			if (ValuesEqual(collection[i], item))
+			{
+				return i;
+			}
+		}
+
+		return -1;
+	}
+
+	private static IEnumerable<IProgVariable> Distinct(IEnumerable<IProgVariable> collection)
+	{
+		List<IProgVariable> seen = new();
+		foreach (var item in collection)
+		{
+			if (seen.Any(x => ValuesEqual(x, item)))
+			{
+				continue;
+			}
+
+			seen.Add(item);
+			yield return item;
+		}
+	}
+
+	private static bool ItemCompatibleWithCollection(IEnumerable<ProgVariableTypes> types, IFuturemud gameworld)
+	{
+		var actual = types.ToList();
+		var elementType = actual[0] ^ ProgVariableTypes.Collection;
+		return elementType == ProgVariableTypes.Void || actual[1].CompatibleWith(elementType);
+	}
+
+	private static bool CollectionsCompatible(IEnumerable<ProgVariableTypes> types, IFuturemud gameworld)
+	{
+		var actual = types.ToList();
+		var firstType = actual[0] ^ ProgVariableTypes.Collection;
+		var secondType = actual[1] ^ ProgVariableTypes.Collection;
+		return firstType == ProgVariableTypes.Void ||
+		       secondType == ProgVariableTypes.Void ||
+		       secondType.CompatibleWith(firstType);
+	}
+
+	private static void RegisterCollectionFunction(string name, CollectionOperation operation, ProgVariableTypes returnType,
+		IEnumerable<ProgVariableTypes> parameters, IEnumerable<string> parameterNames,
+		IEnumerable<string> parameterHelp, string functionHelp,
+		Func<IEnumerable<ProgVariableTypes>, IFuturemud, bool> filter = null)
+	{
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			name,
+			parameters,
+			(pars, gameworld) => new CollectionUtilityFunction(pars, operation, returnType),
+			parameterNames,
+			parameterHelp,
+			functionHelp,
+			"Collections",
+			returnType,
+			filter
+		));
+	}
+
+	private static void RegisterUnaryCollectionFunction(string name, CollectionOperation operation,
+		ProgVariableTypes returnType, string functionHelp)
+	{
+		RegisterCollectionFunction(
+			name,
+			operation,
+			returnType,
+			new[] { ProgVariableTypes.Collection },
+			new[] { "collection" },
+			new[] { "The collection to inspect or transform" },
+			functionHelp
+		);
+	}
+
+	private static void RegisterCollectionNumberFunction(string name, CollectionOperation operation,
+		ProgVariableTypes returnType, string numberName, string numberHelp, string functionHelp)
+	{
+		RegisterCollectionFunction(
+			name,
+			operation,
+			returnType,
+			new[] { ProgVariableTypes.Collection, ProgVariableTypes.Number },
+			new[] { "collection", numberName },
+			new[] { "The collection to inspect or transform", numberHelp },
+			functionHelp
+		);
+	}
+
+	public static void RegisterFunctionCompiler()
+	{
+		RegisterUnaryCollectionFunction("collectioncount", CollectionOperation.Count, ProgVariableTypes.Number,
+			"Returns the number of items in the supplied collection.");
+		RegisterUnaryCollectionFunction("collectionany", CollectionOperation.Any, ProgVariableTypes.Boolean,
+			"Returns true if the supplied collection contains at least one item.");
+		RegisterUnaryCollectionFunction("collectionempty", CollectionOperation.Empty, ProgVariableTypes.Boolean,
+			"Returns true if the supplied collection has no items.");
+		RegisterUnaryCollectionFunction("collectionfirst", CollectionOperation.First, ProgVariableTypes.CollectionItem,
+			"Returns the first item in the supplied collection, or null if the collection is empty.");
+		RegisterUnaryCollectionFunction("collectionlast", CollectionOperation.Last, ProgVariableTypes.CollectionItem,
+			"Returns the last item in the supplied collection, or null if the collection is empty.");
+		RegisterUnaryCollectionFunction("collectionreverse", CollectionOperation.Reverse, ProgVariableTypes.Collection | ProgVariableTypes.CollectionItem,
+			"Returns a new collection with the supplied collection's items in reverse order.");
+		RegisterUnaryCollectionFunction("collectiondistinct", CollectionOperation.Distinct, ProgVariableTypes.Collection | ProgVariableTypes.CollectionItem,
+			"Returns a new collection with duplicate values removed, keeping the first occurrence of each value.");
+		RegisterUnaryCollectionFunction("collectionshuffle", CollectionOperation.Shuffle, ProgVariableTypes.Collection | ProgVariableTypes.CollectionItem,
+			"Returns a new collection with the supplied collection's items in random order.");
+
+		RegisterCollectionNumberFunction("collectionat", CollectionOperation.At, ProgVariableTypes.CollectionItem,
+			"index", "The zero-based index of the item to retrieve",
+			"Returns the item at the zero-based index, or null if the index is outside the collection.");
+		RegisterCollectionNumberFunction("collectiontake", CollectionOperation.Take, ProgVariableTypes.Collection | ProgVariableTypes.CollectionItem,
+			"count", "The maximum number of items to keep from the start of the collection",
+			"Returns a new collection containing up to count items from the start of the supplied collection.");
+		RegisterCollectionNumberFunction("collectionskip", CollectionOperation.Skip, ProgVariableTypes.Collection | ProgVariableTypes.CollectionItem,
+			"count", "The number of items to skip from the start of the collection",
+			"Returns a new collection excluding up to count items from the start of the supplied collection.");
+		RegisterCollectionNumberFunction("collectionwithoutindex", CollectionOperation.WithoutIndex, ProgVariableTypes.Collection | ProgVariableTypes.CollectionItem,
+			"index", "The zero-based index of the item to omit",
+			"Returns a new collection with the item at the zero-based index omitted. Invalid indexes return a copy of the original collection.");
+		RegisterCollectionNumberFunction("collectionisvalidindex", CollectionOperation.IsValidIndex, ProgVariableTypes.Boolean,
+			"index", "The zero-based index to test",
+			"Returns true if the supplied zero-based index points at an item in the collection.");
+
+		RegisterCollectionFunction(
+			"collectionrange",
+			CollectionOperation.Range,
+			ProgVariableTypes.Collection | ProgVariableTypes.CollectionItem,
+			new[] { ProgVariableTypes.Collection, ProgVariableTypes.Number, ProgVariableTypes.Number },
+			new[] { "collection", "index", "count" },
+			new[] { "The collection to slice", "The zero-based index at which the slice begins", "The maximum number of items to return" },
+			"Returns a new collection containing up to count items from the supplied zero-based index."
+		);
+		RegisterCollectionFunction(
+			"collectionappend",
+			CollectionOperation.Append,
+			ProgVariableTypes.Collection | ProgVariableTypes.CollectionItem,
+			new[] { ProgVariableTypes.Collection, ProgVariableTypes.CollectionItem },
+			new[] { "collection", "item" },
+			new[] { "The collection to copy", "The item to append to the end of the returned collection" },
+			"Returns a new collection with the supplied item appended to the end.",
+			ItemCompatibleWithCollection
+		);
+		RegisterCollectionFunction(
+			"collectionprepend",
+			CollectionOperation.Prepend,
+			ProgVariableTypes.Collection | ProgVariableTypes.CollectionItem,
+			new[] { ProgVariableTypes.Collection, ProgVariableTypes.CollectionItem },
+			new[] { "collection", "item" },
+			new[] { "The collection to copy", "The item to prepend to the start of the returned collection" },
+			"Returns a new collection with the supplied item prepended to the start.",
+			ItemCompatibleWithCollection
+		);
+		RegisterCollectionFunction(
+			"collectionconcat",
+			CollectionOperation.Concat,
+			ProgVariableTypes.Collection | ProgVariableTypes.CollectionItem,
+			new[] { ProgVariableTypes.Collection, ProgVariableTypes.Collection },
+			new[] { "first", "second" },
+			new[] { "The collection whose type and leading items should be used", "The collection whose items should be appended" },
+			"Returns a new collection with the second collection appended to the first collection.",
+			CollectionsCompatible
+		);
+		RegisterCollectionFunction(
+			"collectioncontains",
+			CollectionOperation.Contains,
+			ProgVariableTypes.Boolean,
+			new[] { ProgVariableTypes.Collection, ProgVariableTypes.CollectionItem },
+			new[] { "collection", "item" },
+			new[] { "The collection to search", "The item to search for" },
+			"Returns true if the supplied collection contains the supplied item. Text comparison ignores case.",
+			ItemCompatibleWithCollection
+		);
+		RegisterCollectionFunction(
+			"collectionindexof",
+			CollectionOperation.IndexOf,
+			ProgVariableTypes.Number,
+			new[] { ProgVariableTypes.Collection, ProgVariableTypes.CollectionItem },
+			new[] { "collection", "item" },
+			new[] { "The collection to search", "The item whose position should be returned" },
+			"Returns the zero-based index of the first matching item in the supplied collection, or -1 if absent. Text comparison ignores case.",
+			ItemCompatibleWithCollection
+		);
+	}
+}

--- a/MudSharpCore/FutureProg/Functions/DateTime/DateTimeComponentFunctions.cs
+++ b/MudSharpCore/FutureProg/Functions/DateTime/DateTimeComponentFunctions.cs
@@ -1,0 +1,338 @@
+using MudSharp.FutureProg.Variables;
+using System;
+using System.Collections.Generic;
+
+namespace MudSharp.FutureProg.Functions.DateTime;
+
+internal class DateTimeComponentFunction : BuiltInFunction
+{
+	private readonly DateTimeOperation _operation;
+	private readonly ProgVariableTypes _returnType;
+
+	private enum DateTimeOperation
+	{
+		DateYear,
+		DateMonth,
+		DateDay,
+		DateHour,
+		DateMinute,
+		DateSecond,
+		DateMillisecond,
+		DateDayOfYear,
+		DateDayOfWeek,
+		DateIsWeekend,
+		DateOnly,
+		SpanDays,
+		SpanHours,
+		SpanMinutes,
+		SpanSeconds,
+		SpanMilliseconds,
+		TotalDays,
+		TotalHours,
+		TotalMinutes,
+		TotalSeconds,
+		TotalMilliseconds,
+		SpanAbsolute,
+		SpanNegate,
+		TimeSpanFromDays,
+		TimeSpanFromHours,
+		TimeSpanFromMinutes,
+		TimeSpanFromSeconds,
+		TimeSpanFromMilliseconds,
+		MakeTimeSpan
+	}
+
+	private DateTimeComponentFunction(IList<IFunction> parameters, DateTimeOperation operation,
+		ProgVariableTypes returnType) : base(parameters)
+	{
+		_operation = operation;
+		_returnType = returnType;
+	}
+
+	public override ProgVariableTypes ReturnType
+	{
+		get => _returnType;
+		protected set { }
+	}
+
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		if (base.Execute(variables) == StatementResult.Error)
+		{
+			return StatementResult.Error;
+		}
+
+		switch (_operation)
+		{
+			case DateTimeOperation.DateYear:
+				Result = new NumberVariable(GetDateTime(0).Year);
+				return StatementResult.Normal;
+			case DateTimeOperation.DateMonth:
+				Result = new NumberVariable(GetDateTime(0).Month);
+				return StatementResult.Normal;
+			case DateTimeOperation.DateDay:
+				Result = new NumberVariable(GetDateTime(0).Day);
+				return StatementResult.Normal;
+			case DateTimeOperation.DateHour:
+				Result = new NumberVariable(GetDateTime(0).Hour);
+				return StatementResult.Normal;
+			case DateTimeOperation.DateMinute:
+				Result = new NumberVariable(GetDateTime(0).Minute);
+				return StatementResult.Normal;
+			case DateTimeOperation.DateSecond:
+				Result = new NumberVariable(GetDateTime(0).Second);
+				return StatementResult.Normal;
+			case DateTimeOperation.DateMillisecond:
+				Result = new NumberVariable(GetDateTime(0).Millisecond);
+				return StatementResult.Normal;
+			case DateTimeOperation.DateDayOfYear:
+				Result = new NumberVariable(GetDateTime(0).DayOfYear);
+				return StatementResult.Normal;
+			case DateTimeOperation.DateDayOfWeek:
+				Result = new NumberVariable((int)GetDateTime(0).DayOfWeek);
+				return StatementResult.Normal;
+			case DateTimeOperation.DateIsWeekend:
+				var day = GetDateTime(0).DayOfWeek;
+				Result = new BooleanVariable(day is DayOfWeek.Saturday or DayOfWeek.Sunday);
+				return StatementResult.Normal;
+			case DateTimeOperation.DateOnly:
+				Result = new DateTimeVariable(GetDateTime(0).Date);
+				return StatementResult.Normal;
+			case DateTimeOperation.SpanDays:
+				Result = new NumberVariable(GetTimeSpan(0).Days);
+				return StatementResult.Normal;
+			case DateTimeOperation.SpanHours:
+				Result = new NumberVariable(GetTimeSpan(0).Hours);
+				return StatementResult.Normal;
+			case DateTimeOperation.SpanMinutes:
+				Result = new NumberVariable(GetTimeSpan(0).Minutes);
+				return StatementResult.Normal;
+			case DateTimeOperation.SpanSeconds:
+				Result = new NumberVariable(GetTimeSpan(0).Seconds);
+				return StatementResult.Normal;
+			case DateTimeOperation.SpanMilliseconds:
+				Result = new NumberVariable(GetTimeSpan(0).Milliseconds);
+				return StatementResult.Normal;
+			case DateTimeOperation.TotalDays:
+				Result = new NumberVariable(GetTimeSpan(0).TotalDays);
+				return StatementResult.Normal;
+			case DateTimeOperation.TotalHours:
+				Result = new NumberVariable(GetTimeSpan(0).TotalHours);
+				return StatementResult.Normal;
+			case DateTimeOperation.TotalMinutes:
+				Result = new NumberVariable(GetTimeSpan(0).TotalMinutes);
+				return StatementResult.Normal;
+			case DateTimeOperation.TotalSeconds:
+				Result = new NumberVariable(GetTimeSpan(0).TotalSeconds);
+				return StatementResult.Normal;
+			case DateTimeOperation.TotalMilliseconds:
+				Result = new NumberVariable(GetTimeSpan(0).TotalMilliseconds);
+				return StatementResult.Normal;
+			case DateTimeOperation.SpanAbsolute:
+				Result = new TimeSpanVariable(SafeTimeSpan(() => GetTimeSpan(0).Duration()));
+				return StatementResult.Normal;
+			case DateTimeOperation.SpanNegate:
+				Result = new TimeSpanVariable(SafeTimeSpan(() => GetTimeSpan(0).Negate()));
+				return StatementResult.Normal;
+			case DateTimeOperation.TimeSpanFromDays:
+				Result = new TimeSpanVariable(SafeTimeSpan(() => TimeSpan.FromDays(GetDouble(0))));
+				return StatementResult.Normal;
+			case DateTimeOperation.TimeSpanFromHours:
+				Result = new TimeSpanVariable(SafeTimeSpan(() => TimeSpan.FromHours(GetDouble(0))));
+				return StatementResult.Normal;
+			case DateTimeOperation.TimeSpanFromMinutes:
+				Result = new TimeSpanVariable(SafeTimeSpan(() => TimeSpan.FromMinutes(GetDouble(0))));
+				return StatementResult.Normal;
+			case DateTimeOperation.TimeSpanFromSeconds:
+				Result = new TimeSpanVariable(SafeTimeSpan(() => TimeSpan.FromSeconds(GetDouble(0))));
+				return StatementResult.Normal;
+			case DateTimeOperation.TimeSpanFromMilliseconds:
+				Result = new TimeSpanVariable(SafeTimeSpan(() => TimeSpan.FromMilliseconds(GetDouble(0))));
+				return StatementResult.Normal;
+			case DateTimeOperation.MakeTimeSpan:
+				Result = new TimeSpanVariable(MakeTimeSpan());
+				return StatementResult.Normal;
+			default:
+				throw new NotSupportedException($"Unknown DateTime utility operation {_operation}.");
+		}
+	}
+
+	private System.DateTime GetDateTime(int index)
+	{
+		return ParameterFunctions[index].Result?.GetObject is System.DateTime value ? value : default;
+	}
+
+	private TimeSpan GetTimeSpan(int index)
+	{
+		return ParameterFunctions[index].Result?.GetObject is TimeSpan value ? value : default;
+	}
+
+	private double GetDouble(int index)
+	{
+		return ParameterFunctions[index].Result?.GetObject is decimal value ? (double)value : 0.0;
+	}
+
+	private TimeSpan MakeTimeSpan()
+	{
+		return SafeTimeSpan(() =>
+			TimeSpan.FromDays(GetDouble(0)) +
+			TimeSpan.FromHours(GetDouble(1)) +
+			TimeSpan.FromMinutes(GetDouble(2)) +
+			TimeSpan.FromSeconds(GetDouble(3)) +
+			TimeSpan.FromMilliseconds(GetDouble(4))
+		);
+	}
+
+	private static TimeSpan SafeTimeSpan(Func<TimeSpan> factory)
+	{
+		try
+		{
+			return factory();
+		}
+		catch (OverflowException)
+		{
+			return TimeSpan.Zero;
+		}
+	}
+
+	private static void RegisterDateFunction(string name, DateTimeOperation operation, ProgVariableTypes returnType,
+		string functionHelp)
+	{
+		RegisterFunction(
+			name,
+			operation,
+			returnType,
+			new[] { ProgVariableTypes.DateTime },
+			new[] { "date" },
+			new[] { "The real-world DateTime value to inspect or transform" },
+			functionHelp
+		);
+	}
+
+	private static void RegisterSpanFunction(string name, DateTimeOperation operation, ProgVariableTypes returnType,
+		string functionHelp)
+	{
+		RegisterFunction(
+			name,
+			operation,
+			returnType,
+			new[] { ProgVariableTypes.TimeSpan },
+			new[] { "timespan" },
+			new[] { "The TimeSpan value to inspect or transform" },
+			functionHelp
+		);
+	}
+
+	private static void RegisterNumberToSpanFunction(string name, DateTimeOperation operation, string parameterName,
+		string functionHelp)
+	{
+		RegisterFunction(
+			name,
+			operation,
+			ProgVariableTypes.TimeSpan,
+			new[] { ProgVariableTypes.Number },
+			new[] { parameterName },
+			new[] { $"The number of {parameterName} to convert into a TimeSpan" },
+			functionHelp
+		);
+	}
+
+	private static void RegisterFunction(string name, DateTimeOperation operation, ProgVariableTypes returnType,
+		IEnumerable<ProgVariableTypes> parameters, IEnumerable<string> parameterNames,
+		IEnumerable<string> parameterHelp, string functionHelp)
+	{
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			name,
+			parameters,
+			(pars, gameworld) => new DateTimeComponentFunction(pars, operation, returnType),
+			parameterNames,
+			parameterHelp,
+			functionHelp,
+			"DateTime",
+			returnType
+		));
+	}
+
+	public static void RegisterFunctionCompiler()
+	{
+		RegisterDateFunction("dateyear", DateTimeOperation.DateYear, ProgVariableTypes.Number,
+			"Returns the year component of the supplied real-world DateTime value.");
+		RegisterDateFunction("datemonth", DateTimeOperation.DateMonth, ProgVariableTypes.Number,
+			"Returns the month component of the supplied real-world DateTime value, from 1 to 12.");
+		RegisterDateFunction("dateday", DateTimeOperation.DateDay, ProgVariableTypes.Number,
+			"Returns the day-of-month component of the supplied real-world DateTime value.");
+		RegisterDateFunction("datehour", DateTimeOperation.DateHour, ProgVariableTypes.Number,
+			"Returns the hour component of the supplied real-world DateTime value, from 0 to 23.");
+		RegisterDateFunction("dateminute", DateTimeOperation.DateMinute, ProgVariableTypes.Number,
+			"Returns the minute component of the supplied real-world DateTime value.");
+		RegisterDateFunction("datesecond", DateTimeOperation.DateSecond, ProgVariableTypes.Number,
+			"Returns the second component of the supplied real-world DateTime value.");
+		RegisterDateFunction("datemillisecond", DateTimeOperation.DateMillisecond, ProgVariableTypes.Number,
+			"Returns the millisecond component of the supplied real-world DateTime value.");
+		RegisterDateFunction("datedayofyear", DateTimeOperation.DateDayOfYear, ProgVariableTypes.Number,
+			"Returns the one-based day-of-year number for the supplied real-world DateTime value.");
+		RegisterDateFunction("datedayofweek", DateTimeOperation.DateDayOfWeek, ProgVariableTypes.Number,
+			"Returns the day-of-week number for the supplied real-world DateTime value, where Sunday is 0 and Saturday is 6.");
+		RegisterDateFunction("dateisweekend", DateTimeOperation.DateIsWeekend, ProgVariableTypes.Boolean,
+			"Returns true if the supplied real-world DateTime value falls on Saturday or Sunday.");
+		RegisterDateFunction("dateonly", DateTimeOperation.DateOnly, ProgVariableTypes.DateTime,
+			"Returns the supplied real-world DateTime value with the time component set to midnight.");
+
+		RegisterSpanFunction("spandays", DateTimeOperation.SpanDays, ProgVariableTypes.Number,
+			"Returns the day component of the supplied TimeSpan value.");
+		RegisterSpanFunction("spanhours", DateTimeOperation.SpanHours, ProgVariableTypes.Number,
+			"Returns the hour component of the supplied TimeSpan value after whole days are removed.");
+		RegisterSpanFunction("spanminutes", DateTimeOperation.SpanMinutes, ProgVariableTypes.Number,
+			"Returns the minute component of the supplied TimeSpan value after whole hours are removed.");
+		RegisterSpanFunction("spanseconds", DateTimeOperation.SpanSeconds, ProgVariableTypes.Number,
+			"Returns the second component of the supplied TimeSpan value after whole minutes are removed.");
+		RegisterSpanFunction("spanmilliseconds", DateTimeOperation.SpanMilliseconds, ProgVariableTypes.Number,
+			"Returns the millisecond component of the supplied TimeSpan value after whole seconds are removed.");
+		RegisterSpanFunction("totaldays", DateTimeOperation.TotalDays, ProgVariableTypes.Number,
+			"Returns the total duration of the supplied TimeSpan value expressed in days, including fractional days.");
+		RegisterSpanFunction("totalhours", DateTimeOperation.TotalHours, ProgVariableTypes.Number,
+			"Returns the total duration of the supplied TimeSpan value expressed in hours, including fractional hours.");
+		RegisterSpanFunction("totalminutes", DateTimeOperation.TotalMinutes, ProgVariableTypes.Number,
+			"Returns the total duration of the supplied TimeSpan value expressed in minutes, including fractional minutes.");
+		RegisterSpanFunction("totalseconds", DateTimeOperation.TotalSeconds, ProgVariableTypes.Number,
+			"Returns the total duration of the supplied TimeSpan value expressed in seconds, including fractional seconds.");
+		RegisterSpanFunction("totalmilliseconds", DateTimeOperation.TotalMilliseconds, ProgVariableTypes.Number,
+			"Returns the total duration of the supplied TimeSpan value expressed in milliseconds, including fractional milliseconds.");
+		RegisterSpanFunction("spanabs", DateTimeOperation.SpanAbsolute, ProgVariableTypes.TimeSpan,
+			"Returns the absolute value of the supplied TimeSpan. Unrepresentable values return a zero TimeSpan.");
+		RegisterSpanFunction("spannegate", DateTimeOperation.SpanNegate, ProgVariableTypes.TimeSpan,
+			"Returns the supplied TimeSpan with its sign reversed. Unrepresentable values return a zero TimeSpan.");
+
+		RegisterNumberToSpanFunction("timespanfromdays", DateTimeOperation.TimeSpanFromDays, "days",
+			"Returns a TimeSpan representing the supplied number of days.");
+		RegisterNumberToSpanFunction("timespanfromhours", DateTimeOperation.TimeSpanFromHours, "hours",
+			"Returns a TimeSpan representing the supplied number of hours.");
+		RegisterNumberToSpanFunction("timespanfromminutes", DateTimeOperation.TimeSpanFromMinutes, "minutes",
+			"Returns a TimeSpan representing the supplied number of minutes.");
+		RegisterNumberToSpanFunction("timespanfromseconds", DateTimeOperation.TimeSpanFromSeconds, "seconds",
+			"Returns a TimeSpan representing the supplied number of seconds.");
+		RegisterNumberToSpanFunction("timespanfrommilliseconds", DateTimeOperation.TimeSpanFromMilliseconds, "milliseconds",
+			"Returns a TimeSpan representing the supplied number of milliseconds.");
+
+		RegisterFunction(
+			"maketimespan",
+			DateTimeOperation.MakeTimeSpan,
+			ProgVariableTypes.TimeSpan,
+			new[]
+			{
+				ProgVariableTypes.Number, ProgVariableTypes.Number, ProgVariableTypes.Number,
+				ProgVariableTypes.Number, ProgVariableTypes.Number
+			},
+			new[] { "days", "hours", "minutes", "seconds", "milliseconds" },
+			new[]
+			{
+				"The day component of the TimeSpan",
+				"The hour component of the TimeSpan",
+				"The minute component of the TimeSpan",
+				"The second component of the TimeSpan",
+				"The millisecond component of the TimeSpan"
+			},
+			"Returns a TimeSpan constructed from the supplied day, hour, minute, second and millisecond components. Unrepresentable values return a zero TimeSpan."
+		);
+	}
+}

--- a/MudSharpCore/FutureProg/Functions/Dictionaries/DictionaryUtilityFunctions.cs
+++ b/MudSharpCore/FutureProg/Functions/Dictionaries/DictionaryUtilityFunctions.cs
@@ -1,0 +1,423 @@
+using MudSharp.Framework;
+using MudSharp.FutureProg.Variables;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MudSharp.FutureProg.Functions.Dictionaries;
+
+internal class DictionaryUtilityFunction : BuiltInFunction
+{
+	private readonly DictionaryOperation _operation;
+	private readonly ProgVariableTypes _metadataReturnType;
+
+	private enum DictionaryOperation
+	{
+		DictionaryCount,
+		DictionaryAny,
+		DictionaryEmpty,
+		DictionaryKeys,
+		DictionaryValues,
+		DictionaryContainsKey,
+		DictionaryGet,
+		DictionaryGetDefault,
+		DictionaryContainsValue,
+		DictionaryWithoutKey,
+		DictionarySet,
+		DictionaryFirstKey,
+		CollectionDictionaryCount,
+		CollectionDictionaryLongCount,
+		CollectionDictionaryAny,
+		CollectionDictionaryEmpty,
+		CollectionDictionaryKeys,
+		CollectionDictionaryValues,
+		CollectionDictionaryContainsKey,
+		CollectionDictionaryGet,
+		CollectionDictionaryGetFirst,
+		CollectionDictionaryContainsValue,
+		CollectionDictionaryWithoutKey
+	}
+
+	private DictionaryUtilityFunction(IList<IFunction> parameters, DictionaryOperation operation,
+		ProgVariableTypes metadataReturnType) : base(parameters)
+	{
+		_operation = operation;
+		_metadataReturnType = metadataReturnType;
+	}
+
+	private ProgVariableTypes ElementType
+	{
+		get
+		{
+			return ParameterFunctions[0].ReturnType.HasFlag(ProgVariableTypes.CollectionDictionary)
+				? ParameterFunctions[0].ReturnType ^ ProgVariableTypes.CollectionDictionary
+				: ParameterFunctions[0].ReturnType ^ ProgVariableTypes.Dictionary;
+		}
+	}
+
+	public override ProgVariableTypes ReturnType
+	{
+		get
+		{
+			return _operation switch
+			{
+				DictionaryOperation.DictionaryGet or DictionaryOperation.DictionaryGetDefault
+					or DictionaryOperation.CollectionDictionaryGetFirst => ElementType,
+				DictionaryOperation.DictionaryValues or DictionaryOperation.CollectionDictionaryValues
+					or DictionaryOperation.CollectionDictionaryGet => ProgVariableTypes.Collection | ElementType,
+				DictionaryOperation.DictionaryWithoutKey or DictionaryOperation.DictionarySet
+					or DictionaryOperation.CollectionDictionaryWithoutKey => ParameterFunctions[0].ReturnType,
+				_ => _metadataReturnType
+			};
+		}
+		protected set { }
+	}
+
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		if (base.Execute(variables) == StatementResult.Error)
+		{
+			return StatementResult.Error;
+		}
+
+		switch (_operation)
+		{
+			case DictionaryOperation.DictionaryCount:
+				Result = new NumberVariable(GetDictionary().Count);
+				return StatementResult.Normal;
+			case DictionaryOperation.DictionaryAny:
+				Result = new BooleanVariable(GetDictionary().Count > 0);
+				return StatementResult.Normal;
+			case DictionaryOperation.DictionaryEmpty:
+				Result = new BooleanVariable(GetDictionary().Count == 0);
+				return StatementResult.Normal;
+			case DictionaryOperation.DictionaryKeys:
+				Result = new CollectionVariable(GetDictionary().Keys.Select(x => new TextVariable(x)).ToList<IProgVariable>(), ProgVariableTypes.Text);
+				return StatementResult.Normal;
+			case DictionaryOperation.DictionaryValues:
+				Result = new CollectionVariable(GetDictionary().Values.ToList(), ElementType);
+				return StatementResult.Normal;
+			case DictionaryOperation.DictionaryContainsKey:
+				Result = new BooleanVariable(GetDictionary().ContainsKey(GetText(1)));
+				return StatementResult.Normal;
+			case DictionaryOperation.DictionaryGet:
+				Result = GetDictionary().TryGetValue(GetText(1), out var value) ? value : new NullVariable(ElementType);
+				return StatementResult.Normal;
+			case DictionaryOperation.DictionaryGetDefault:
+				Result = GetDictionary().TryGetValue(GetText(1), out var defaultedValue)
+					? defaultedValue
+					: ParameterFunctions[2].Result ?? new NullVariable(ElementType);
+				return StatementResult.Normal;
+			case DictionaryOperation.DictionaryContainsValue:
+				Result = new BooleanVariable(GetDictionary().Values.Any(x => ValuesEqual(x, ParameterFunctions[1].Result)));
+				return StatementResult.Normal;
+			case DictionaryOperation.DictionaryWithoutKey:
+				Result = new DictionaryVariable(
+					GetDictionary()
+						.Where(x => !string.Equals(x.Key, GetText(1), StringComparison.InvariantCulture))
+						.ToDictionary(x => x.Key, x => x.Value),
+					ElementType
+				);
+				return StatementResult.Normal;
+			case DictionaryOperation.DictionarySet:
+				Result = SetDictionaryValue(GetText(1), ParameterFunctions[2].Result ?? new NullVariable(ElementType));
+				return StatementResult.Normal;
+			case DictionaryOperation.DictionaryFirstKey:
+				Result = new TextVariable(GetDictionary().Keys.FirstOrDefault() ?? string.Empty);
+				return StatementResult.Normal;
+			case DictionaryOperation.CollectionDictionaryCount:
+				Result = new NumberVariable(GetCollectionDictionary().Keys.Count());
+				return StatementResult.Normal;
+			case DictionaryOperation.CollectionDictionaryLongCount:
+				Result = new NumberVariable(GetCollectionDictionary().Sum(x => x.Value.Count));
+				return StatementResult.Normal;
+			case DictionaryOperation.CollectionDictionaryAny:
+				Result = new BooleanVariable(GetCollectionDictionary().Any(x => x.Value.Count > 0));
+				return StatementResult.Normal;
+			case DictionaryOperation.CollectionDictionaryEmpty:
+				Result = new BooleanVariable(GetCollectionDictionary().All(x => x.Value.Count == 0));
+				return StatementResult.Normal;
+			case DictionaryOperation.CollectionDictionaryKeys:
+				Result = new CollectionVariable(GetCollectionDictionary().Keys.Select(x => new TextVariable(x)).ToList<IProgVariable>(), ProgVariableTypes.Text);
+				return StatementResult.Normal;
+			case DictionaryOperation.CollectionDictionaryValues:
+				Result = new CollectionVariable(GetCollectionDictionary().SelectMany(x => x.Value).ToList(), ElementType);
+				return StatementResult.Normal;
+			case DictionaryOperation.CollectionDictionaryContainsKey:
+				Result = new BooleanVariable(GetCollectionDictionary().ContainsKey(GetText(1)));
+				return StatementResult.Normal;
+			case DictionaryOperation.CollectionDictionaryGet:
+				Result = new CollectionVariable(GetCollectionDictionary().ContainsKey(GetText(1)) ? GetCollectionDictionary()[GetText(1)].ToList() : new List<IProgVariable>(), ElementType);
+				return StatementResult.Normal;
+			case DictionaryOperation.CollectionDictionaryGetFirst:
+				Result = GetCollectionDictionary().ContainsKey(GetText(1))
+					? GetCollectionDictionary()[GetText(1)].FirstOrDefault() ?? new NullVariable(ElementType)
+					: new NullVariable(ElementType);
+				return StatementResult.Normal;
+			case DictionaryOperation.CollectionDictionaryContainsValue:
+				Result = new BooleanVariable(GetCollectionDictionary().SelectMany(x => x.Value).Any(x => ValuesEqual(x, ParameterFunctions[1].Result)));
+				return StatementResult.Normal;
+			case DictionaryOperation.CollectionDictionaryWithoutKey:
+				Result = new CollectionDictionaryVariable(CloneCollectionDictionaryWithoutKey(GetText(1)), ElementType);
+				return StatementResult.Normal;
+			default:
+				throw new NotSupportedException($"Unknown dictionary utility operation {_operation}.");
+		}
+	}
+
+	private Dictionary<string, IProgVariable> GetDictionary()
+	{
+		return ParameterFunctions[0].Result?.GetObject as Dictionary<string, IProgVariable> ??
+		       new Dictionary<string, IProgVariable>();
+	}
+
+	private CollectionDictionary<string, IProgVariable> GetCollectionDictionary()
+	{
+		return ParameterFunctions[0].Result?.GetObject as CollectionDictionary<string, IProgVariable> ??
+		       new CollectionDictionary<string, IProgVariable>();
+	}
+
+	private string GetText(int index)
+	{
+		return ParameterFunctions[index].Result?.GetObject?.ToString() ?? string.Empty;
+	}
+
+	private DictionaryVariable SetDictionaryValue(string key, IProgVariable item)
+	{
+		var clone = GetDictionary().ToDictionary(x => x.Key, x => x.Value);
+		clone[key] = item;
+		return new DictionaryVariable(clone, ElementType);
+	}
+
+	private CollectionDictionary<string, IProgVariable> CloneCollectionDictionaryWithoutKey(string key)
+	{
+		CollectionDictionary<string, IProgVariable> clone = new();
+		foreach (var item in GetCollectionDictionary())
+		{
+			if (string.Equals(item.Key, key, StringComparison.InvariantCulture))
+			{
+				continue;
+			}
+
+			clone.AddRange(item.Key, item.Value);
+		}
+
+		return clone;
+	}
+
+	private static bool ValuesEqual(IProgVariable lhs, IProgVariable rhs)
+	{
+		if (lhs is null || rhs is null)
+		{
+			return lhs is null && rhs is null;
+		}
+
+		if (lhs.GetObject is string lhsText && rhs.GetObject is string rhsText)
+		{
+			return string.Equals(lhsText, rhsText, StringComparison.InvariantCultureIgnoreCase);
+		}
+
+		return Equals(lhs.GetObject, rhs.GetObject);
+	}
+
+	private static bool DictionaryValueCompatible(IEnumerable<ProgVariableTypes> types, IFuturemud gameworld)
+	{
+		var actual = types.ToList();
+		var elementType = actual[0] ^ ProgVariableTypes.Dictionary;
+		return elementType == ProgVariableTypes.Void || actual[1].CompatibleWith(elementType);
+	}
+
+	private static bool DictionaryDefaultCompatible(IEnumerable<ProgVariableTypes> types, IFuturemud gameworld)
+	{
+		var actual = types.ToList();
+		var elementType = actual[0] ^ ProgVariableTypes.Dictionary;
+		return elementType == ProgVariableTypes.Void || actual[2].CompatibleWith(elementType);
+	}
+
+	private static bool CollectionDictionaryValueCompatible(IEnumerable<ProgVariableTypes> types, IFuturemud gameworld)
+	{
+		var actual = types.ToList();
+		var elementType = actual[0] ^ ProgVariableTypes.CollectionDictionary;
+		return elementType == ProgVariableTypes.Void || actual[1].CompatibleWith(elementType);
+	}
+
+	private static void RegisterDictionaryFunction(string name, DictionaryOperation operation, ProgVariableTypes returnType,
+		IEnumerable<ProgVariableTypes> parameters, IEnumerable<string> parameterNames,
+		IEnumerable<string> parameterHelp, string functionHelp,
+		Func<IEnumerable<ProgVariableTypes>, IFuturemud, bool> filter = null)
+	{
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			name,
+			parameters,
+			(pars, gameworld) => new DictionaryUtilityFunction(pars, operation, returnType),
+			parameterNames,
+			parameterHelp,
+			functionHelp,
+			"Dictionaries",
+			returnType,
+			filter
+		));
+	}
+
+	private static void RegisterUnaryDictionaryFunction(string name, DictionaryOperation operation,
+		ProgVariableTypes returnType, string functionHelp)
+	{
+		RegisterDictionaryFunction(
+			name,
+			operation,
+			returnType,
+			new[] { ProgVariableTypes.Dictionary },
+			new[] { "dictionary" },
+			new[] { "The dictionary to inspect or transform" },
+			functionHelp
+		);
+	}
+
+	private static void RegisterUnaryCollectionDictionaryFunction(string name, DictionaryOperation operation,
+		ProgVariableTypes returnType, string functionHelp)
+	{
+		RegisterDictionaryFunction(
+			name,
+			operation,
+			returnType,
+			new[] { ProgVariableTypes.CollectionDictionary },
+			new[] { "dictionary" },
+			new[] { "The collection dictionary to inspect or transform" },
+			functionHelp
+		);
+	}
+
+	public static void RegisterFunctionCompiler()
+	{
+		RegisterUnaryDictionaryFunction("dictionarycount", DictionaryOperation.DictionaryCount, ProgVariableTypes.Number,
+			"Returns the number of keyed values in the supplied dictionary.");
+		RegisterUnaryDictionaryFunction("dictionaryany", DictionaryOperation.DictionaryAny, ProgVariableTypes.Boolean,
+			"Returns true if the supplied dictionary has at least one keyed value.");
+		RegisterUnaryDictionaryFunction("dictionaryempty", DictionaryOperation.DictionaryEmpty, ProgVariableTypes.Boolean,
+			"Returns true if the supplied dictionary has no keyed values.");
+		RegisterUnaryDictionaryFunction("dictionarykeys", DictionaryOperation.DictionaryKeys, ProgVariableTypes.Collection | ProgVariableTypes.Text,
+			"Returns a text collection containing all keys in the supplied dictionary.");
+		RegisterUnaryDictionaryFunction("dictionaryvalues", DictionaryOperation.DictionaryValues, ProgVariableTypes.Collection | ProgVariableTypes.CollectionItem,
+			"Returns a collection containing all values in the supplied dictionary.");
+		RegisterUnaryDictionaryFunction("dictionaryfirstkey", DictionaryOperation.DictionaryFirstKey, ProgVariableTypes.Text,
+			"Returns the first key in the supplied dictionary, or blank if the dictionary is empty.");
+
+		RegisterDictionaryFunction(
+			"dictionarycontainskey",
+			DictionaryOperation.DictionaryContainsKey,
+			ProgVariableTypes.Boolean,
+			new[] { ProgVariableTypes.Dictionary, ProgVariableTypes.Text },
+			new[] { "dictionary", "key" },
+			new[] { "The dictionary to inspect", "The text key to search for" },
+			"Returns true if the supplied dictionary contains the specified text key."
+		);
+		RegisterDictionaryFunction(
+			"dictionaryget",
+			DictionaryOperation.DictionaryGet,
+			ProgVariableTypes.CollectionItem,
+			new[] { ProgVariableTypes.Dictionary, ProgVariableTypes.Text },
+			new[] { "dictionary", "key" },
+			new[] { "The dictionary to inspect", "The text key whose value should be returned" },
+			"Returns the value stored at the specified text key, or null if the key is absent."
+		);
+		RegisterDictionaryFunction(
+			"dictionarygetdefault",
+			DictionaryOperation.DictionaryGetDefault,
+			ProgVariableTypes.CollectionItem,
+			new[] { ProgVariableTypes.Dictionary, ProgVariableTypes.Text, ProgVariableTypes.CollectionItem },
+			new[] { "dictionary", "key", "default" },
+			new[] { "The dictionary to inspect", "The text key whose value should be returned", "The value to return when the key is absent" },
+			"Returns the value stored at the specified text key, or the supplied default value if the key is absent.",
+			DictionaryDefaultCompatible
+		);
+		RegisterDictionaryFunction(
+			"dictionarycontainsvalue",
+			DictionaryOperation.DictionaryContainsValue,
+			ProgVariableTypes.Boolean,
+			new[] { ProgVariableTypes.Dictionary, ProgVariableTypes.CollectionItem },
+			new[] { "dictionary", "value" },
+			new[] { "The dictionary to inspect", "The value to search for" },
+			"Returns true if any value in the dictionary matches the supplied value. Text comparison ignores case.",
+			DictionaryValueCompatible
+		);
+		RegisterDictionaryFunction(
+			"dictionarywithoutkey",
+			DictionaryOperation.DictionaryWithoutKey,
+			ProgVariableTypes.Dictionary | ProgVariableTypes.CollectionItem,
+			new[] { ProgVariableTypes.Dictionary, ProgVariableTypes.Text },
+			new[] { "dictionary", "key" },
+			new[] { "The dictionary to copy", "The text key to omit from the returned dictionary" },
+			"Returns a new dictionary with the specified key omitted. If the key is absent, the returned dictionary is a copy of the original."
+		);
+		RegisterDictionaryFunction(
+			"dictionaryset",
+			DictionaryOperation.DictionarySet,
+			ProgVariableTypes.Dictionary | ProgVariableTypes.CollectionItem,
+			new[] { ProgVariableTypes.Dictionary, ProgVariableTypes.Text, ProgVariableTypes.CollectionItem },
+			new[] { "dictionary", "key", "value" },
+			new[] { "The dictionary to copy", "The text key to set in the returned dictionary", "The value to store at that key" },
+			"Returns a new dictionary with the specified key set to the supplied value. The original dictionary is not changed.",
+			DictionaryDefaultCompatible
+		);
+
+		RegisterUnaryCollectionDictionaryFunction("collectiondictionarycount", DictionaryOperation.CollectionDictionaryCount, ProgVariableTypes.Number,
+			"Returns the number of keys in the supplied collection dictionary.");
+		RegisterUnaryCollectionDictionaryFunction("collectiondictionarylongcount", DictionaryOperation.CollectionDictionaryLongCount, ProgVariableTypes.Number,
+			"Returns the total number of values stored across all keys in the supplied collection dictionary.");
+		RegisterUnaryCollectionDictionaryFunction("collectiondictionaryany", DictionaryOperation.CollectionDictionaryAny, ProgVariableTypes.Boolean,
+			"Returns true if the supplied collection dictionary contains at least one value.");
+		RegisterUnaryCollectionDictionaryFunction("collectiondictionaryempty", DictionaryOperation.CollectionDictionaryEmpty, ProgVariableTypes.Boolean,
+			"Returns true if the supplied collection dictionary contains no values.");
+		RegisterUnaryCollectionDictionaryFunction("collectiondictionarykeys", DictionaryOperation.CollectionDictionaryKeys, ProgVariableTypes.Collection | ProgVariableTypes.Text,
+			"Returns a text collection containing all keys in the supplied collection dictionary.");
+		RegisterUnaryCollectionDictionaryFunction("collectiondictionaryvalues", DictionaryOperation.CollectionDictionaryValues, ProgVariableTypes.Collection | ProgVariableTypes.CollectionItem,
+			"Returns a collection containing all values across all keys in the supplied collection dictionary.");
+
+		RegisterDictionaryFunction(
+			"collectiondictionarycontainskey",
+			DictionaryOperation.CollectionDictionaryContainsKey,
+			ProgVariableTypes.Boolean,
+			new[] { ProgVariableTypes.CollectionDictionary, ProgVariableTypes.Text },
+			new[] { "dictionary", "key" },
+			new[] { "The collection dictionary to inspect", "The text key to search for" },
+			"Returns true if the supplied collection dictionary contains the specified text key."
+		);
+		RegisterDictionaryFunction(
+			"collectiondictionaryget",
+			DictionaryOperation.CollectionDictionaryGet,
+			ProgVariableTypes.Collection | ProgVariableTypes.CollectionItem,
+			new[] { ProgVariableTypes.CollectionDictionary, ProgVariableTypes.Text },
+			new[] { "dictionary", "key" },
+			new[] { "The collection dictionary to inspect", "The text key whose values should be returned" },
+			"Returns the collection of values stored at the specified text key, or an empty collection if the key is absent."
+		);
+		RegisterDictionaryFunction(
+			"collectiondictionarygetfirst",
+			DictionaryOperation.CollectionDictionaryGetFirst,
+			ProgVariableTypes.CollectionItem,
+			new[] { ProgVariableTypes.CollectionDictionary, ProgVariableTypes.Text },
+			new[] { "dictionary", "key" },
+			new[] { "The collection dictionary to inspect", "The text key whose first value should be returned" },
+			"Returns the first value stored at the specified text key, or null if the key is absent or has no values."
+		);
+		RegisterDictionaryFunction(
+			"collectiondictionarycontainsvalue",
+			DictionaryOperation.CollectionDictionaryContainsValue,
+			ProgVariableTypes.Boolean,
+			new[] { ProgVariableTypes.CollectionDictionary, ProgVariableTypes.CollectionItem },
+			new[] { "dictionary", "value" },
+			new[] { "The collection dictionary to inspect", "The value to search for across all keys" },
+			"Returns true if any value in the collection dictionary matches the supplied value. Text comparison ignores case.",
+			CollectionDictionaryValueCompatible
+		);
+		RegisterDictionaryFunction(
+			"collectiondictionarywithoutkey",
+			DictionaryOperation.CollectionDictionaryWithoutKey,
+			ProgVariableTypes.CollectionDictionary | ProgVariableTypes.CollectionItem,
+			new[] { ProgVariableTypes.CollectionDictionary, ProgVariableTypes.Text },
+			new[] { "dictionary", "key" },
+			new[] { "The collection dictionary to copy", "The text key to omit from the returned collection dictionary" },
+			"Returns a new collection dictionary with the specified key omitted. If the key is absent, the returned collection dictionary is a copy of the original."
+		);
+	}
+}

--- a/MudSharpCore/FutureProg/Functions/Textual/TextUtilityFunctions.cs
+++ b/MudSharpCore/FutureProg/Functions/Textual/TextUtilityFunctions.cs
@@ -1,0 +1,637 @@
+using MudSharp.Framework;
+using MudSharp.FutureProg.Variables;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MudSharp.FutureProg.Functions.Textual;
+
+internal class TextUtilityFunction : BuiltInFunction
+{
+	private readonly TextOperation _operation;
+	private readonly ProgVariableTypes _returnType;
+
+	private enum TextOperation
+	{
+		Length,
+		Uppercase,
+		Lowercase,
+		Propercase,
+		Titlecase,
+		Trim,
+		TrimStart,
+		TrimEnd,
+		Left,
+		Right,
+		Mid,
+		Contains,
+		ContainsCase,
+		StartsWith,
+		StartsWithCase,
+		EndsWith,
+		EndsWithCase,
+		IndexOf,
+		IndexOfCase,
+		LastIndexOf,
+		LastIndexOfCase,
+		Replace,
+		ReplaceCase,
+		Insert,
+		Remove,
+		Repeat,
+		IsEmpty,
+		IsBlank,
+		WordCount,
+		LineCount,
+		FirstWord,
+		LastWord,
+		Before,
+		After,
+		Between,
+		PadLeft,
+		PadRight,
+		Truncate,
+		TruncateEllipsis,
+		NormalizeWhitespace,
+		Count,
+		CountCase,
+		Reverse,
+		CapitalizeFirst
+	}
+
+	private TextUtilityFunction(IList<IFunction> parameters, TextOperation operation, ProgVariableTypes returnType) : base(parameters)
+	{
+		_operation = operation;
+		_returnType = returnType;
+	}
+
+	public override ProgVariableTypes ReturnType
+	{
+		get => _returnType;
+		protected set { }
+	}
+
+	public override StatementResult Execute(IVariableSpace variables)
+	{
+		if (base.Execute(variables) == StatementResult.Error)
+		{
+			return StatementResult.Error;
+		}
+
+		var source = GetText(0);
+		switch (_operation)
+		{
+			case TextOperation.Length:
+				Result = new NumberVariable(source.Length);
+				return StatementResult.Normal;
+			case TextOperation.Uppercase:
+				Result = new TextVariable(source.ToUpperInvariant());
+				return StatementResult.Normal;
+			case TextOperation.Lowercase:
+				Result = new TextVariable(source.ToLowerInvariant());
+				return StatementResult.Normal;
+			case TextOperation.Propercase:
+				Result = new TextVariable(source.ProperSentences());
+				return StatementResult.Normal;
+			case TextOperation.Titlecase:
+				Result = new TextVariable(source.TitleCase());
+				return StatementResult.Normal;
+			case TextOperation.Trim:
+				Result = new TextVariable(source.Trim());
+				return StatementResult.Normal;
+			case TextOperation.TrimStart:
+				Result = new TextVariable(source.TrimStart());
+				return StatementResult.Normal;
+			case TextOperation.TrimEnd:
+				Result = new TextVariable(source.TrimEnd());
+				return StatementResult.Normal;
+			case TextOperation.Left:
+				Result = new TextVariable(Left(source, GetInteger(1)));
+				return StatementResult.Normal;
+			case TextOperation.Right:
+				Result = new TextVariable(Right(source, GetInteger(1)));
+				return StatementResult.Normal;
+			case TextOperation.Mid:
+				Result = new TextVariable(Mid(source, GetInteger(1), GetInteger(2)));
+				return StatementResult.Normal;
+			case TextOperation.Contains:
+				Result = new BooleanVariable(source.Contains(GetText(1), StringComparison.InvariantCultureIgnoreCase));
+				return StatementResult.Normal;
+			case TextOperation.ContainsCase:
+				Result = new BooleanVariable(source.Contains(GetText(1), StringComparison.InvariantCulture));
+				return StatementResult.Normal;
+			case TextOperation.StartsWith:
+				Result = new BooleanVariable(source.StartsWith(GetText(1), StringComparison.InvariantCultureIgnoreCase));
+				return StatementResult.Normal;
+			case TextOperation.StartsWithCase:
+				Result = new BooleanVariable(source.StartsWith(GetText(1), StringComparison.InvariantCulture));
+				return StatementResult.Normal;
+			case TextOperation.EndsWith:
+				Result = new BooleanVariable(source.EndsWith(GetText(1), StringComparison.InvariantCultureIgnoreCase));
+				return StatementResult.Normal;
+			case TextOperation.EndsWithCase:
+				Result = new BooleanVariable(source.EndsWith(GetText(1), StringComparison.InvariantCulture));
+				return StatementResult.Normal;
+			case TextOperation.IndexOf:
+				Result = new NumberVariable(source.IndexOf(GetText(1), StringComparison.InvariantCultureIgnoreCase));
+				return StatementResult.Normal;
+			case TextOperation.IndexOfCase:
+				Result = new NumberVariable(source.IndexOf(GetText(1), StringComparison.InvariantCulture));
+				return StatementResult.Normal;
+			case TextOperation.LastIndexOf:
+				Result = new NumberVariable(source.LastIndexOf(GetText(1), StringComparison.InvariantCultureIgnoreCase));
+				return StatementResult.Normal;
+			case TextOperation.LastIndexOfCase:
+				Result = new NumberVariable(source.LastIndexOf(GetText(1), StringComparison.InvariantCulture));
+				return StatementResult.Normal;
+			case TextOperation.Replace:
+				Result = new TextVariable(Replace(source, GetText(1), GetText(2), StringComparison.InvariantCultureIgnoreCase));
+				return StatementResult.Normal;
+			case TextOperation.ReplaceCase:
+				Result = new TextVariable(Replace(source, GetText(1), GetText(2), StringComparison.InvariantCulture));
+				return StatementResult.Normal;
+			case TextOperation.Insert:
+				Result = new TextVariable(Insert(source, GetInteger(1), GetText(2)));
+				return StatementResult.Normal;
+			case TextOperation.Remove:
+				Result = new TextVariable(Remove(source, GetInteger(1), GetInteger(2)));
+				return StatementResult.Normal;
+			case TextOperation.Repeat:
+				Result = new TextVariable(string.Concat(Enumerable.Repeat(source, Math.Max(0, GetInteger(1)))));
+				return StatementResult.Normal;
+			case TextOperation.IsEmpty:
+				Result = new BooleanVariable(string.IsNullOrEmpty(source));
+				return StatementResult.Normal;
+			case TextOperation.IsBlank:
+				Result = new BooleanVariable(string.IsNullOrWhiteSpace(source));
+				return StatementResult.Normal;
+			case TextOperation.WordCount:
+				Result = new NumberVariable(GetWords(source).Length);
+				return StatementResult.Normal;
+			case TextOperation.LineCount:
+				Result = new NumberVariable(GetLineCount(source));
+				return StatementResult.Normal;
+			case TextOperation.FirstWord:
+				Result = new TextVariable(GetWords(source).FirstOrDefault() ?? string.Empty);
+				return StatementResult.Normal;
+			case TextOperation.LastWord:
+				Result = new TextVariable(GetWords(source).LastOrDefault() ?? string.Empty);
+				return StatementResult.Normal;
+			case TextOperation.Before:
+				Result = new TextVariable(Before(source, GetText(1), StringComparison.InvariantCultureIgnoreCase));
+				return StatementResult.Normal;
+			case TextOperation.After:
+				Result = new TextVariable(After(source, GetText(1), StringComparison.InvariantCultureIgnoreCase));
+				return StatementResult.Normal;
+			case TextOperation.Between:
+				Result = new TextVariable(Between(source, GetText(1), GetText(2)));
+				return StatementResult.Normal;
+			case TextOperation.PadLeft:
+				Result = new TextVariable(source.PadLeft(Math.Max(0, GetInteger(1))));
+				return StatementResult.Normal;
+			case TextOperation.PadRight:
+				Result = new TextVariable(source.PadRight(Math.Max(0, GetInteger(1))));
+				return StatementResult.Normal;
+			case TextOperation.Truncate:
+				Result = new TextVariable(Left(source, GetInteger(1)));
+				return StatementResult.Normal;
+			case TextOperation.TruncateEllipsis:
+				Result = new TextVariable(TruncateEllipsis(source, GetInteger(1)));
+				return StatementResult.Normal;
+			case TextOperation.NormalizeWhitespace:
+				Result = new TextVariable(NormalizeWhitespace(source));
+				return StatementResult.Normal;
+			case TextOperation.Count:
+				Result = new NumberVariable(Count(source, GetText(1), StringComparison.InvariantCultureIgnoreCase));
+				return StatementResult.Normal;
+			case TextOperation.CountCase:
+				Result = new NumberVariable(Count(source, GetText(1), StringComparison.InvariantCulture));
+				return StatementResult.Normal;
+			case TextOperation.Reverse:
+				Result = new TextVariable(new string(source.Reverse().ToArray()));
+				return StatementResult.Normal;
+			case TextOperation.CapitalizeFirst:
+				Result = new TextVariable(CapitalizeFirst(source));
+				return StatementResult.Normal;
+			default:
+				throw new NotSupportedException($"Unknown text utility operation {_operation}.");
+		}
+	}
+
+	private string GetText(int index)
+	{
+		return ParameterFunctions[index].Result?.GetObject?.ToString() ?? string.Empty;
+	}
+
+	private int GetInteger(int index)
+	{
+		return ParameterFunctions[index].Result?.GetObject is decimal value ? (int)value : 0;
+	}
+
+	private static string Left(string text, int count)
+	{
+		if (count <= 0)
+		{
+			return string.Empty;
+		}
+
+		return text.Length <= count ? text : text[..count];
+	}
+
+	private static string Right(string text, int count)
+	{
+		if (count <= 0)
+		{
+			return string.Empty;
+		}
+
+		return text.Length <= count ? text : text[^count..];
+	}
+
+	private static string Mid(string text, int index, int count)
+	{
+		index = Math.Max(0, index);
+		count = Math.Max(0, count);
+		if (index >= text.Length || count == 0)
+		{
+			return string.Empty;
+		}
+
+		return text.Substring(index, Math.Min(count, text.Length - index));
+	}
+
+	private static string Replace(string text, string search, string replacement, StringComparison comparison)
+	{
+		return string.IsNullOrEmpty(search) ? text : text.Replace(search, replacement, comparison);
+	}
+
+	private static string Insert(string text, int index, string insertion)
+	{
+		index = Math.Clamp(index, 0, text.Length);
+		return text.Insert(index, insertion);
+	}
+
+	private static string Remove(string text, int index, int count)
+	{
+		index = Math.Max(0, index);
+		count = Math.Max(0, count);
+		if (index >= text.Length || count == 0)
+		{
+			return text;
+		}
+
+		return text.Remove(index, Math.Min(count, text.Length - index));
+	}
+
+	private static string[] GetWords(string text)
+	{
+		return text.Split((char[])null, StringSplitOptions.RemoveEmptyEntries);
+	}
+
+	private static int GetLineCount(string text)
+	{
+		if (string.IsNullOrEmpty(text))
+		{
+			return 0;
+		}
+
+		return text.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n').Length;
+	}
+
+	private static string Before(string text, string marker, StringComparison comparison)
+	{
+		if (string.IsNullOrEmpty(marker))
+		{
+			return string.Empty;
+		}
+
+		var index = text.IndexOf(marker, comparison);
+		return index < 0 ? string.Empty : text[..index];
+	}
+
+	private static string After(string text, string marker, StringComparison comparison)
+	{
+		if (string.IsNullOrEmpty(marker))
+		{
+			return string.Empty;
+		}
+
+		var index = text.IndexOf(marker, comparison);
+		return index < 0 ? string.Empty : text[(index + marker.Length)..];
+	}
+
+	private static string Between(string text, string startMarker, string endMarker)
+	{
+		if (string.IsNullOrEmpty(startMarker) || string.IsNullOrEmpty(endMarker))
+		{
+			return string.Empty;
+		}
+
+		var start = text.IndexOf(startMarker, StringComparison.InvariantCultureIgnoreCase);
+		if (start < 0)
+		{
+			return string.Empty;
+		}
+
+		start += startMarker.Length;
+		var end = text.IndexOf(endMarker, start, StringComparison.InvariantCultureIgnoreCase);
+		return end < 0 ? string.Empty : text[start..end];
+	}
+
+	private static string TruncateEllipsis(string text, int count)
+	{
+		if (count <= 0)
+		{
+			return string.Empty;
+		}
+
+		if (text.Length <= count)
+		{
+			return text;
+		}
+
+		return count <= 3 ? text[..count] : $"{text[..(count - 3)]}...";
+	}
+
+	private static string NormalizeWhitespace(string text)
+	{
+		List<char> output = new();
+		var inWhitespace = false;
+		foreach (var character in text)
+		{
+			if (char.IsWhiteSpace(character))
+			{
+				if (!inWhitespace && output.Count > 0)
+				{
+					output.Add(' ');
+				}
+
+				inWhitespace = true;
+				continue;
+			}
+
+			output.Add(character);
+			inWhitespace = false;
+		}
+
+		if (output.Count > 0 && output[^1] == ' ')
+		{
+			output.RemoveAt(output.Count - 1);
+		}
+
+		return new string(output.ToArray());
+	}
+
+	private static int Count(string text, string search, StringComparison comparison)
+	{
+		if (string.IsNullOrEmpty(search))
+		{
+			return 0;
+		}
+
+		var count = 0;
+		var index = 0;
+		while ((index = text.IndexOf(search, index, comparison)) >= 0)
+		{
+			count++;
+			index += search.Length;
+		}
+
+		return count;
+	}
+
+	private static string CapitalizeFirst(string text)
+	{
+		return string.IsNullOrEmpty(text) ? string.Empty : $"{char.ToUpperInvariant(text[0])}{text[1..]}";
+	}
+
+	private static void RegisterTextFunction(string name, TextOperation operation, ProgVariableTypes returnType,
+		IEnumerable<ProgVariableTypes> parameters, IEnumerable<string> parameterNames,
+		IEnumerable<string> parameterHelp, string functionHelp)
+	{
+		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
+			name,
+			parameters,
+			(pars, gameworld) => new TextUtilityFunction(pars, operation, returnType),
+			parameterNames,
+			parameterHelp,
+			functionHelp,
+			"Text",
+			returnType
+		));
+	}
+
+	private static void RegisterUnaryTextFunction(string name, TextOperation operation, ProgVariableTypes returnType,
+		string functionHelp)
+	{
+		RegisterTextFunction(
+			name,
+			operation,
+			returnType,
+			new[] { ProgVariableTypes.Text },
+			new[] { "text" },
+			new[] { "The text value to inspect or transform" },
+			functionHelp
+		);
+	}
+
+	private static void RegisterTextAndNeedleFunction(string name, TextOperation operation, ProgVariableTypes returnType,
+		string functionHelp)
+	{
+		RegisterTextFunction(
+			name,
+			operation,
+			returnType,
+			new[] { ProgVariableTypes.Text, ProgVariableTypes.Text },
+			new[] { "text", "search" },
+			new[] { "The text value to inspect", "The text fragment to search for" },
+			functionHelp
+		);
+	}
+
+	public static void RegisterFunctionCompiler()
+	{
+		RegisterUnaryTextFunction("textlength", TextOperation.Length, ProgVariableTypes.Number,
+			"Returns the number of characters in the supplied text.");
+		RegisterUnaryTextFunction("uppercase", TextOperation.Uppercase, ProgVariableTypes.Text,
+			"Returns the supplied text converted to upper case.");
+		RegisterUnaryTextFunction("lowercase", TextOperation.Lowercase, ProgVariableTypes.Text,
+			"Returns the supplied text converted to lower case.");
+		RegisterUnaryTextFunction("propercase", TextOperation.Propercase, ProgVariableTypes.Text,
+			"Returns the supplied text with sentence-style capitalisation.");
+		RegisterUnaryTextFunction("titlecase", TextOperation.Titlecase, ProgVariableTypes.Text,
+			"Returns the supplied text with title-style capitalisation.");
+		RegisterUnaryTextFunction("trim", TextOperation.Trim, ProgVariableTypes.Text,
+			"Returns the supplied text with leading and trailing whitespace removed.");
+		RegisterUnaryTextFunction("trimstart", TextOperation.TrimStart, ProgVariableTypes.Text,
+			"Returns the supplied text with leading whitespace removed.");
+		RegisterUnaryTextFunction("trimend", TextOperation.TrimEnd, ProgVariableTypes.Text,
+			"Returns the supplied text with trailing whitespace removed.");
+		RegisterUnaryTextFunction("isemptytext", TextOperation.IsEmpty, ProgVariableTypes.Boolean,
+			"Returns true if the supplied text is empty.");
+		RegisterUnaryTextFunction("isblanktext", TextOperation.IsBlank, ProgVariableTypes.Boolean,
+			"Returns true if the supplied text is empty or contains only whitespace.");
+		RegisterUnaryTextFunction("wordcount", TextOperation.WordCount, ProgVariableTypes.Number,
+			"Returns the number of whitespace-separated words in the supplied text.");
+		RegisterUnaryTextFunction("linecount", TextOperation.LineCount, ProgVariableTypes.Number,
+			"Returns the number of lines in the supplied text. Empty text returns zero.");
+		RegisterUnaryTextFunction("firstword", TextOperation.FirstWord, ProgVariableTypes.Text,
+			"Returns the first whitespace-separated word in the supplied text, or blank if there is none.");
+		RegisterUnaryTextFunction("lastword", TextOperation.LastWord, ProgVariableTypes.Text,
+			"Returns the last whitespace-separated word in the supplied text, or blank if there is none.");
+		RegisterUnaryTextFunction("normalizewhitespace", TextOperation.NormalizeWhitespace, ProgVariableTypes.Text,
+			"Returns the supplied text with all whitespace runs collapsed to single spaces and edge whitespace removed.");
+		RegisterUnaryTextFunction("reversetext", TextOperation.Reverse, ProgVariableTypes.Text,
+			"Returns the supplied text with its characters in reverse order.");
+		RegisterUnaryTextFunction("capitalizefirst", TextOperation.CapitalizeFirst, ProgVariableTypes.Text,
+			"Returns the supplied text with its first character converted to upper case.");
+
+		RegisterTextFunction(
+			"lefttext",
+			TextOperation.Left,
+			ProgVariableTypes.Text,
+			new[] { ProgVariableTypes.Text, ProgVariableTypes.Number },
+			new[] { "text", "count" },
+			new[] { "The text value to slice", "The maximum number of characters to return from the left side" },
+			"Returns up to count characters from the left side of the supplied text."
+		);
+		RegisterTextFunction(
+			"righttext",
+			TextOperation.Right,
+			ProgVariableTypes.Text,
+			new[] { ProgVariableTypes.Text, ProgVariableTypes.Number },
+			new[] { "text", "count" },
+			new[] { "The text value to slice", "The maximum number of characters to return from the right side" },
+			"Returns up to count characters from the right side of the supplied text."
+		);
+		RegisterTextFunction(
+			"midtext",
+			TextOperation.Mid,
+			ProgVariableTypes.Text,
+			new[] { ProgVariableTypes.Text, ProgVariableTypes.Number, ProgVariableTypes.Number },
+			new[] { "text", "index", "count" },
+			new[] { "The text value to slice", "The zero-based starting index", "The maximum number of characters to return" },
+			"Returns up to count characters from the supplied text starting at the zero-based index."
+		);
+		RegisterTextFunction(
+			"inserttext",
+			TextOperation.Insert,
+			ProgVariableTypes.Text,
+			new[] { ProgVariableTypes.Text, ProgVariableTypes.Number, ProgVariableTypes.Text },
+			new[] { "text", "index", "insertion" },
+			new[] { "The text value to edit", "The zero-based insertion index", "The text to insert" },
+			"Returns the supplied text with another text value inserted at the zero-based index."
+		);
+		RegisterTextFunction(
+			"removetext",
+			TextOperation.Remove,
+			ProgVariableTypes.Text,
+			new[] { ProgVariableTypes.Text, ProgVariableTypes.Number, ProgVariableTypes.Number },
+			new[] { "text", "index", "count" },
+			new[] { "The text value to edit", "The zero-based index at which removal begins", "The maximum number of characters to remove" },
+			"Returns the supplied text with up to count characters removed from the zero-based index."
+		);
+		RegisterTextFunction(
+			"repeattext",
+			TextOperation.Repeat,
+			ProgVariableTypes.Text,
+			new[] { ProgVariableTypes.Text, ProgVariableTypes.Number },
+			new[] { "text", "count" },
+			new[] { "The text value to repeat", "The number of times to repeat the text" },
+			"Returns the supplied text repeated count times."
+		);
+		RegisterTextFunction(
+			"padleft",
+			TextOperation.PadLeft,
+			ProgVariableTypes.Text,
+			new[] { ProgVariableTypes.Text, ProgVariableTypes.Number },
+			new[] { "text", "width" },
+			new[] { "The text value to pad", "The minimum width of the returned text" },
+			"Returns the supplied text padded on the left with spaces until it reaches the specified width."
+		);
+		RegisterTextFunction(
+			"padright",
+			TextOperation.PadRight,
+			ProgVariableTypes.Text,
+			new[] { ProgVariableTypes.Text, ProgVariableTypes.Number },
+			new[] { "text", "width" },
+			new[] { "The text value to pad", "The minimum width of the returned text" },
+			"Returns the supplied text padded on the right with spaces until it reaches the specified width."
+		);
+		RegisterTextFunction(
+			"truncatetext",
+			TextOperation.Truncate,
+			ProgVariableTypes.Text,
+			new[] { ProgVariableTypes.Text, ProgVariableTypes.Number },
+			new[] { "text", "count" },
+			new[] { "The text value to truncate", "The maximum number of characters to keep" },
+			"Returns the supplied text truncated to at most count characters."
+		);
+		RegisterTextFunction(
+			"truncateellipsis",
+			TextOperation.TruncateEllipsis,
+			ProgVariableTypes.Text,
+			new[] { ProgVariableTypes.Text, ProgVariableTypes.Number },
+			new[] { "text", "count" },
+			new[] { "The text value to truncate", "The maximum number of characters to return, including the ellipsis" },
+			"Returns the supplied text truncated to count characters, using an ellipsis when there is room."
+		);
+
+		RegisterTextAndNeedleFunction("textcontains", TextOperation.Contains, ProgVariableTypes.Boolean,
+			"Returns true if the supplied text contains the search fragment, ignoring case.");
+		RegisterTextAndNeedleFunction("textcontainscase", TextOperation.ContainsCase, ProgVariableTypes.Boolean,
+			"Returns true if the supplied text contains the search fragment with case-sensitive matching.");
+		RegisterTextAndNeedleFunction("startswith", TextOperation.StartsWith, ProgVariableTypes.Boolean,
+			"Returns true if the supplied text starts with the search fragment, ignoring case.");
+		RegisterTextAndNeedleFunction("startswithcase", TextOperation.StartsWithCase, ProgVariableTypes.Boolean,
+			"Returns true if the supplied text starts with the search fragment with case-sensitive matching.");
+		RegisterTextAndNeedleFunction("endswith", TextOperation.EndsWith, ProgVariableTypes.Boolean,
+			"Returns true if the supplied text ends with the search fragment, ignoring case.");
+		RegisterTextAndNeedleFunction("endswithcase", TextOperation.EndsWithCase, ProgVariableTypes.Boolean,
+			"Returns true if the supplied text ends with the search fragment with case-sensitive matching.");
+		RegisterTextAndNeedleFunction("textindexof", TextOperation.IndexOf, ProgVariableTypes.Number,
+			"Returns the zero-based index of the first search fragment in the supplied text, ignoring case, or -1 if absent.");
+		RegisterTextAndNeedleFunction("textindexofcase", TextOperation.IndexOfCase, ProgVariableTypes.Number,
+			"Returns the zero-based index of the first search fragment in the supplied text with case-sensitive matching, or -1 if absent.");
+		RegisterTextAndNeedleFunction("textlastindexof", TextOperation.LastIndexOf, ProgVariableTypes.Number,
+			"Returns the zero-based index of the last search fragment in the supplied text, ignoring case, or -1 if absent.");
+		RegisterTextAndNeedleFunction("textlastindexofcase", TextOperation.LastIndexOfCase, ProgVariableTypes.Number,
+			"Returns the zero-based index of the last search fragment in the supplied text with case-sensitive matching, or -1 if absent.");
+		RegisterTextAndNeedleFunction("textbefore", TextOperation.Before, ProgVariableTypes.Text,
+			"Returns the text before the first search fragment, ignoring case, or blank if the fragment is absent.");
+		RegisterTextAndNeedleFunction("textafter", TextOperation.After, ProgVariableTypes.Text,
+			"Returns the text after the first search fragment, ignoring case, or blank if the fragment is absent.");
+		RegisterTextAndNeedleFunction("counttext", TextOperation.Count, ProgVariableTypes.Number,
+			"Returns the number of non-overlapping occurrences of the search fragment in the supplied text, ignoring case.");
+		RegisterTextAndNeedleFunction("counttextcase", TextOperation.CountCase, ProgVariableTypes.Number,
+			"Returns the number of non-overlapping occurrences of the search fragment in the supplied text with case-sensitive matching.");
+
+		RegisterTextFunction(
+			"replacetext",
+			TextOperation.Replace,
+			ProgVariableTypes.Text,
+			new[] { ProgVariableTypes.Text, ProgVariableTypes.Text, ProgVariableTypes.Text },
+			new[] { "text", "search", "replacement" },
+			new[] { "The text value to edit", "The text fragment to replace", "The replacement text" },
+			"Returns the supplied text with all occurrences of search replaced, ignoring case."
+		);
+		RegisterTextFunction(
+			"replacetextcase",
+			TextOperation.ReplaceCase,
+			ProgVariableTypes.Text,
+			new[] { ProgVariableTypes.Text, ProgVariableTypes.Text, ProgVariableTypes.Text },
+			new[] { "text", "search", "replacement" },
+			new[] { "The text value to edit", "The text fragment to replace", "The replacement text" },
+			"Returns the supplied text with all case-sensitive occurrences of search replaced."
+		);
+		RegisterTextFunction(
+			"textbetween",
+			TextOperation.Between,
+			ProgVariableTypes.Text,
+			new[] { ProgVariableTypes.Text, ProgVariableTypes.Text, ProgVariableTypes.Text },
+			new[] { "text", "start", "end" },
+			new[] { "The text value to inspect", "The starting marker", "The ending marker" },
+			"Returns the text between the first start marker and following end marker, ignoring marker case, or blank if either marker is absent."
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- Add pure FutureProg helper families for text, collections, dictionaries/collection dictionaries, and DateTime/TimeSpan values
- Register full function metadata for the new catalogue entries, including help text, parameter names, parameter help, categories, and return types
- Add catalogue, metadata, and representative runtime tests, including the collection concat variance regression

## Validation
- dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510
- dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 --filter "(FullyQualifiedName~FutureProgFunctionDocumentationTests)|(Name=TextUtilityFunctions_ExecuteRepresentativeHelpers)|(Name=CollectionUtilityFunctions_PreserveTypedCollections)|(Name=DateTimeComponentFunctions_ExecuteRepresentativeHelpers)"
- dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 --filter "(FullyQualifiedName~FutureProgFunctionDocumentationTests)|(Name=CollectionUtilityFunctions_PreserveTypedCollections)|(Name=CollectionUtilityFunctions_ConcatRejectsSecondCollectionThatCannotAssignToFirst)"
- git diff --check

Note: a full MudSharpCore unit-test run had 1104/1105 passing with the pre-existing/reproducible failure `VehicleTowServiceTests.Move_WithThreeVehicleTrain_MovesAllVehicles`, outside this FutureProg change.