### PR TITLE
Fix network connection workflow hardening

### DIFF
--- a/FutureMUDLibrary/Framework/Telnet.cs
+++ b/FutureMUDLibrary/Framework/Telnet.cs
@@ -161,6 +161,11 @@ namespace MudSharp.Framework
         public const byte GA = 249;
 
         /// <summary>
+        /// Telnet End Of Record command.
+        /// </summary>
+        public const byte EOR = 239;
+
+        /// <summary>
         ///     Signals to the Telnet Engine that it should not wrap the text on this line.
         /// </summary>
         public const char NoWordWrapChar = '\x0002';

--- a/FutureMUDLibrary/Network/IPlayerConnection.cs
+++ b/FutureMUDLibrary/Network/IPlayerConnection.cs
@@ -1,6 +1,5 @@
 ﻿using MudSharp.Framework;
 using System;
-using System.Net.Sockets;
 
 namespace MudSharp.Network
 {
@@ -28,7 +27,6 @@ namespace MudSharp.Network
         void PrepareOutgoing();
         void PrepareIncoming();
         void SendOutgoing();
-        void Reconnect(TcpClient client);
         void NegotiateClientSet();
     }
 }

--- a/MudSharpCore Unit Tests/NetworkWorkflowTests.cs
+++ b/MudSharpCore Unit Tests/NetworkWorkflowTests.cs
@@ -1,0 +1,224 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Accounts;
+using MudSharp.Character;
+using MudSharp.Framework;
+using MudSharp.Network;
+using MudSharp.PerceptionEngine.Handlers;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class NetworkWorkflowTests
+{
+	[TestMethod]
+	public async Task PlayerConnection_DoesNotEnqueuePartialCommandBeforeLineEnding()
+	{
+		var fixture = await CreateConnectionFixture();
+		try
+		{
+			WriteClientBytes(fixture.Client, Encoding.ASCII.GetBytes("loo"));
+			await Task.Delay(25);
+			fixture.Connection.PrepareIncoming();
+
+			Assert.IsFalse(fixture.Connection.HasIncomingCommands);
+
+			WriteClientBytes(fixture.Client, Encoding.ASCII.GetBytes("k\r"));
+			await Task.Delay(25);
+			fixture.Connection.PrepareIncoming();
+
+			Assert.IsTrue(fixture.Connection.HasIncomingCommands);
+			fixture.Connection.AttemptCommand();
+			CollectionAssert.AreEqual(new[] { "look" }, fixture.Commands);
+		}
+		finally
+		{
+			fixture.Dispose();
+		}
+	}
+
+	[TestMethod]
+	public async Task PlayerConnection_PreservesSplitTelnetNegotiationAndUsesEorPrompt()
+	{
+		var fixture = await CreateConnectionFixture();
+		try
+		{
+			WriteClientBytes(fixture.Client, [Telnet.IAC, Telnet.DO]);
+			await Task.Delay(25);
+			fixture.Connection.PrepareIncoming();
+
+			Assert.IsFalse(fixture.Connection.HasIncomingCommands);
+
+			WriteClientBytes(fixture.Client, [Telnet.TELOPT_EOR]);
+			await Task.Delay(25);
+			fixture.Connection.PrepareIncoming();
+
+			fixture.Connection.AddOutgoing("hello");
+			fixture.Connection.SendOutgoing();
+
+			var bytes = await ReadAvailableBytes(fixture.Client, 2);
+			Assert.IsTrue(bytes.Length >= 2, "Expected output bytes from server.");
+			CollectionAssert.AreEqual(new[] { Telnet.IAC, Telnet.EOR }, bytes[^2..]);
+		}
+		finally
+		{
+			fixture.Dispose();
+		}
+	}
+
+	[TestMethod]
+	public async Task PlayerConnection_DoesNotWarnWhenTimeoutDisabled()
+	{
+		var fixture = await CreateConnectionFixture(timeout: 0);
+		try
+		{
+			fixture.Connection.WarnTimeout();
+
+			Assert.IsFalse(fixture.Connection.HasOutgoingCommands);
+		}
+		finally
+		{
+			fixture.Dispose();
+		}
+	}
+
+	[TestMethod]
+	public void TcpServer_FloodWindowExpiresEvenAfterThreshold()
+	{
+		var server = new TCPServer(IPAddress.Loopback, 0);
+		var address = IPAddress.Loopback;
+		var now = DateTime.UtcNow;
+
+		for (var i = 0; i < 30; i++)
+		{
+			Assert.IsFalse(server.RecordConnectionAttempt(address, now));
+		}
+
+		Assert.IsTrue(server.RecordConnectionAttempt(address, now));
+
+		var later = now + server.IpFloodKeepAlive + TimeSpan.FromSeconds(1);
+		Assert.IsFalse(server.RecordConnectionAttempt(address, later));
+		Assert.AreEqual(1, server.ConnectionDictionary[address].NumberOfConnections);
+	}
+
+	[TestMethod]
+	public void PlayerOutputHandler_PaginatesAfterWrappingLongLines()
+	{
+		var handler = CreatePlayerOutputHandler(pageLength: 10, lineLength: 20);
+		var text = string.Join(" ", Enumerable.Repeat("word", 100));
+
+		handler.Send(text);
+
+		StringAssert.Contains(handler.BufferedOutput, "Type more");
+	}
+
+	[TestMethod]
+	public void PlayerOutputHandler_MoreDoesNotPromptWhenFinalPageExactlyFits()
+	{
+		var handler = CreatePlayerOutputHandler(pageLength: 10, lineLength: 80);
+		var text = string.Join("\n", Enumerable.Range(1, 20).Select(x => $"line {x}"));
+
+		handler.Send(text);
+		handler.Flush();
+		handler.More();
+
+		Assert.IsFalse(handler.BufferedOutput.Contains("Type more", StringComparison.Ordinal));
+	}
+
+	private static PlayerOutputHandler CreatePlayerOutputHandler(int pageLength, int lineLength)
+	{
+		var account = new Mock<IAccount>();
+		account.SetupGet(x => x.PageLength).Returns(pageLength);
+		account.SetupGet(x => x.LineFormatLength).Returns(lineLength);
+		account.SetupGet(x => x.AppendNewlinesBetweenMultipleEchoesPerPrompt).Returns(false);
+
+		var character = new Mock<ICharacter>();
+		character.SetupGet(x => x.Account).Returns(account.Object);
+
+		return new PlayerOutputHandler(new StringBuilder(), character.Object);
+	}
+
+	private static async Task<ConnectionFixture> CreateConnectionFixture(int timeout = 60000)
+	{
+		var listener = new TcpListener(IPAddress.Loopback, 0);
+		listener.Start();
+		var endpoint = (IPEndPoint)listener.LocalEndpoint;
+		var client = new TcpClient();
+		var connectTask = client.ConnectAsync(endpoint.Address, endpoint.Port);
+		var serverClient = await listener.AcceptTcpClientAsync();
+		await connectTask;
+
+		var commands = new List<string>();
+		var account = new Mock<IAccount>();
+		account.SetupProperty(x => x.UseUnicode, false);
+		account.SetupGet(x => x.LineFormatLength).Returns(80);
+		account.SetupGet(x => x.PageLength).Returns(50);
+
+		var context = new Mock<IFuturemudControlContext>();
+		context.SetupGet(x => x.Account).Returns(account.Object);
+		context.SetupGet(x => x.Timeout).Returns(timeout);
+		context.SetupGet(x => x.OutputHandler).Returns(new NonPlayerOutputHandler());
+		context.SetupGet(x => x.Closing).Returns(false);
+		context.Setup(x => x.HandleCommand(It.IsAny<string>()))
+		       .Callback<string>(commands.Add);
+
+		var connection = new PlayerConnection(serverClient);
+		connection.Bind(context.Object);
+		await ReadAvailableBytes(client);
+
+		return new ConnectionFixture(listener, client, connection, commands);
+	}
+
+	private static void WriteClientBytes(TcpClient client, byte[] bytes)
+	{
+		client.GetStream().Write(bytes, 0, bytes.Length);
+	}
+
+	private static async Task<byte[]> ReadAvailableBytes(TcpClient client, int minimumBytes = 0)
+	{
+		var bytes = new List<byte>();
+		var buffer = new byte[1024];
+		var stopwatch = Stopwatch.StartNew();
+		while (stopwatch.ElapsedMilliseconds < 1000)
+		{
+			while (client.Available > 0)
+			{
+				var count = client.GetStream().Read(buffer, 0, Math.Min(buffer.Length, client.Available));
+				bytes.AddRange(buffer.Take(count));
+			}
+
+			if (minimumBytes == 0 || bytes.Count >= minimumBytes)
+			{
+				break;
+			}
+
+			await Task.Delay(10);
+		}
+
+		return bytes.ToArray();
+	}
+
+	private sealed record ConnectionFixture(
+		TcpListener Listener,
+		TcpClient Client,
+		PlayerConnection Connection,
+		List<string> Commands) : IDisposable
+	{
+		public void Dispose()
+		{
+			Connection.Dispose();
+			Client.Dispose();
+			Listener.Stop();
+		}
+	}
+}

--- a/MudSharpCore Unit Tests/VehicleTowServiceTests.cs
+++ b/MudSharpCore Unit Tests/VehicleTowServiceTests.cs
@@ -551,6 +551,8 @@ public class VehicleTowServiceTests
 		profile.SetupGet(x => x.RequiredPowerSpikeInWatts).Returns(requiredPower);
 		vehicle.Prototype.SetupGet(x => x.MovementProfiles).Returns([profile.Object]);
 		vehicle.Vehicle.SetupGet(x => x.Controller).Returns(controller);
+		Mock.Get(controller).SetupGet(x => x.Location).Returns(vehicle.Vehicle.Object.Location);
+		Mock.Get(controller).SetupGet(x => x.RoomLayer).Returns(vehicle.Vehicle.Object.RoomLayer);
 	}
 
 	private static Mock<ICellExit> CreateExit(ICell origin, ICell destination, SizeCategory maximumSize)

--- a/MudSharpCore/Framework/Futuremud.cs
+++ b/MudSharpCore/Framework/Futuremud.cs
@@ -2551,44 +2551,53 @@ public sealed partial class Futuremud : IFuturemud, IDisposable
 
     private void ProcessPendingCommands()
     {
+        List<IPlayerConnection> playersWithCommands;
+        List<IPlayerConnection> connections;
         lock (_connections)
         {
-            foreach (
-                IPlayerConnection player in
-                _connections.Where(
-                                player => player.HasIncomingCommands && player.State == ConnectionState.Open)
-                            .Shuffle())
-            {
-                player?.AttemptCommand();
-            }
+            playersWithCommands = _connections
+                                  .Where(player => player.HasIncomingCommands && player.State == ConnectionState.Open)
+                                  .ToList();
+            connections = _connections.ToList();
+        }
 
-            foreach (IPlayerConnection connection in _connections.ToList())
-            {
-                connection?.PrepareOutgoing();
-            }
+        foreach (IPlayerConnection player in playersWithCommands.Shuffle())
+        {
+            player?.AttemptCommand();
+        }
+
+        foreach (IPlayerConnection connection in connections)
+        {
+            connection?.PrepareOutgoing();
         }
     }
 
     public void ForceOutgoingMessages()
     {
+        List<IPlayerConnection> connections;
         lock (_connections)
         {
-            foreach (IPlayerConnection connection in _connections.ToList())
-            {
-                connection.PrepareOutgoing();
-                connection.SendOutgoing();
-            }
+            connections = _connections.ToList();
+        }
+
+        foreach (IPlayerConnection connection in connections)
+        {
+            connection.PrepareOutgoing();
+            connection.SendOutgoing();
         }
     }
 
     private void WarnIdlers()
     {
+        List<IPlayerConnection> connections;
         lock (_connections)
         {
-            foreach (IPlayerConnection connection in _connections.Where(x => x.State == ConnectionState.Open))
-            {
-                connection.WarnTimeout();
-            }
+            connections = _connections.Where(x => x.State == ConnectionState.Open).ToList();
+        }
+
+        foreach (IPlayerConnection connection in connections)
+        {
+            connection.WarnTimeout();
         }
     }
 

--- a/MudSharpCore/Framework/FuturemudControlContext.cs
+++ b/MudSharpCore/Framework/FuturemudControlContext.cs
@@ -162,14 +162,24 @@ public sealed class FuturemudControlContext : IFuturemudControlContext
         observee.AddObserver(this);
     }
 
-    // TODO Reimplement
     public void UpdateObservers()
     {
-        //if (_observedBy.Count <= 0) return;
-        //var sb = new StringBuilder(OutgoingStream.ToString());
-        //sb.Insert(0, "\nWatch: ", 1);
-        //sb.AppendLine("\nEnd Watch");
-        //_observedBy.ForEach(x => x.OutgoingStream.Append(sb.ToString()));
+        if (!_observedBy.Any() || OutputHandler?.HasBufferedOutput != true ||
+            string.IsNullOrEmpty(OutputHandler.BufferedOutput))
+        {
+            return;
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine();
+        sb.AppendLine("Watch:");
+        sb.Append(OutputHandler.BufferedOutput);
+        sb.AppendLine();
+        sb.AppendLine("End Watch");
+        foreach (var observer in _observedBy.ToList())
+        {
+            observer.OutputHandler.Send(sb.ToString(), false, true);
+        }
     }
 
     void IMonitorable.AddObserver(IMonitor observer)
@@ -204,7 +214,7 @@ public sealed class FuturemudControlContext : IFuturemudControlContext
         Account = null;
         _context?.LoseControl(this);
         _context = null;
-        foreach (IMonitorable observee in _observes)
+        foreach (IMonitorable observee in _observes.ToList())
         {
             RemoveObservee(observee);
         }
@@ -268,6 +278,9 @@ public sealed class FuturemudControlContext : IFuturemudControlContext
 
     public void CloseSubContext()
     {
-        throw new NotImplementedException();
+        if (_context is ISubContextController controller)
+        {
+            controller.CloseSubContext();
+        }
     }
 }

--- a/MudSharpCore/Menus/Menu.cs
+++ b/MudSharpCore/Menus/Menu.cs
@@ -37,7 +37,14 @@ public abstract class Menu : IControllable, IHaveFuturemud, ISubContextControlle
 
     public virtual void CloseSubContext()
     {
-        throw new NotImplementedException();
+        if (_subContext == null)
+        {
+            return;
+        }
+
+        _subContext.LoseControl(this);
+        _subContext = _subContext.NextContext;
+        _subContext?.AssumeControl(this);
     }
 
     public override string ToString()

--- a/MudSharpCore/NPC/NPCController.cs
+++ b/MudSharpCore/NPC/NPCController.cs
@@ -45,7 +45,7 @@ public class NPCController : IFuturemudAccountController, IFuturemudPlayerContro
     {
         _context?.LoseControl(this);
         _context = null;
-        foreach (IMonitorable observee in _observes)
+        foreach (IMonitorable observee in _observes.ToList())
         {
             RemoveObservee(observee);
         }

--- a/MudSharpCore/Network/PlayerConnection.cs
+++ b/MudSharpCore/Network/PlayerConnection.cs
@@ -6,48 +6,42 @@ using MudSharp.Server;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Sockets;
 using System.Text;
-using System.Threading;
 
 namespace MudSharp.Network;
 
 public class PlayerConnection : IPlayerConnection
 {
-    private static readonly byte[] ByteSeparators = [(byte)'\n', Telnet.END_IAC];
-
-    private static readonly byte[] WillMxp = [Telnet.IAC, Telnet.WILL, Telnet.TELOPT_MXP, Telnet.END_IAC];
+    private static readonly byte[] WillMxp = [Telnet.IAC, Telnet.WILL, Telnet.TELOPT_MXP];
 
     private static readonly byte[] StartMxp =
     [
-        Telnet.IAC, Telnet.SB, Telnet.TELOPT_MXP, Telnet.IAC, Telnet.SE,
-        Telnet.END_IAC
+        Telnet.IAC, Telnet.SB, Telnet.TELOPT_MXP, Telnet.IAC, Telnet.SE
     ];
 
-    private static readonly byte[] WillEOR = [Telnet.IAC, Telnet.WILL, Telnet.TELOPT_EOR, Telnet.END_IAC];
+    private static readonly byte[] WillEOR = [Telnet.IAC, Telnet.WILL, Telnet.TELOPT_EOR];
 
-    private static readonly byte[] DoEOR = [Telnet.IAC, Telnet.DO, Telnet.TELOPT_EOR, Telnet.END_IAC];
+    private static readonly byte[] DoEOR = [Telnet.IAC, Telnet.DO, Telnet.TELOPT_EOR];
 
     private static readonly byte[] Prompt =
     [
         Telnet.IAC,
-        Telnet.GA,
-        Telnet.END_IAC
+        Telnet.GA
     ];
 
     private static readonly byte[] AlternatePrompt =
     [
         Telnet.IAC,
-        Telnet.TELOPT_EOR,
-        Telnet.END_IAC
+        Telnet.EOR
     ];
 
     private static readonly byte[] BeginWillNegotiation = [Telnet.IAC, Telnet.WILL];
 
     private static readonly byte[] DoMxp = [Telnet.IAC, Telnet.DO, Telnet.TELOPT_MXP];
-    private static readonly byte[] DontMXP = [Telnet.IAC, Telnet.DONT, Telnet.TELOPT_MXP];
-    private static byte[] _dontMxp = [Telnet.IAC, Telnet.DONT, Telnet.TELOPT_MXP];
     private static readonly byte[] SupportsBytes = Encoding.ASCII.GetBytes("\x1B[1z<SUPPORTS");
 
     private static readonly byte[] WillCharset =
@@ -104,9 +98,15 @@ public class PlayerConnection : IPlayerConnection
     private readonly TcpClient _client;
     private readonly Stopwatch _inactivityStopwatch = new();
     private readonly Queue<string> _incomingCommands = new();
+    private readonly List<byte> _incomingCommandBuffer = new(Constants.PlayerConnectionBufferSize);
     private readonly byte[] _inputBuffer = new byte[Constants.PlayerConnectionBufferSize];
     private readonly StringBuilder _outgoingCommands = new();
+    private readonly List<byte> _telnetNegotiationBuffer = new(32);
     private bool _useAlternatePrompt;
+    private bool _inTelnetNegotiation;
+    private bool _inTelnetSubcommand;
+    private bool _pendingTelnetSubcommandEnd;
+    private bool _disposed;
 
     private bool _fiveMinuteWarning,
         _twoMinuteWarning,
@@ -123,7 +123,7 @@ public class PlayerConnection : IPlayerConnection
         MXPSupport = new MXPSupport();
         try
         {
-            client.Client.Send(WillMxp);
+            SendAll(WillMxp);
         }
         catch (SocketException e)
         {
@@ -149,7 +149,9 @@ public class PlayerConnection : IPlayerConnection
         {
             try
             {
-                return _client?.Client?.RemoteEndPoint?.ToString().Split(':')[0] ?? "0.0.0.0";
+                return _client?.Client?.RemoteEndPoint is IPEndPoint endpoint
+                    ? endpoint.Address.ToString()
+                    : "0.0.0.0";
             }
             catch (Exception)
             {
@@ -184,7 +186,7 @@ public class PlayerConnection : IPlayerConnection
 
     public void WarnTimeout()
     {
-        if (ControlPuppet == null)
+        if (ControlPuppet == null || ControlPuppet.Timeout <= 0)
         {
             return;
         }
@@ -226,7 +228,7 @@ public class PlayerConnection : IPlayerConnection
     {
         try
         {
-            _client.Client.Send(WillCharset);
+            SendAll(WillCharset);
         }
         catch (SocketException e)
         {
@@ -240,28 +242,32 @@ public class PlayerConnection : IPlayerConnection
         }
     }
 
-    ~PlayerConnection()
-    {
-        Dispose(false);
-    }
-
     private void Dispose(bool disposed)
     {
-        ControlPuppet?.DetachConnection();
-        ControlPuppet = null;
-        Futuremud.Games.First().Destroy(this);
-        State = ConnectionState.Closed;
-        try
+        if (_disposed)
         {
-            _client?.Client?.Shutdown(SocketShutdown.Both);
-        }
-        catch
-        {
-            // We don't care about exceptions at this stage, we're already disposing of the socket
+            return;
         }
 
-        _client?.Close();
-        _stream?.Dispose();
+        _disposed = true;
+        ControlPuppet?.DetachConnection();
+        ControlPuppet = null;
+        State = ConnectionState.Closed;
+        Futuremud.Games.FirstOrDefault()?.Destroy(this);
+        if (disposed)
+        {
+            try
+            {
+                _client?.Client?.Shutdown(SocketShutdown.Both);
+            }
+            catch
+            {
+                // We don't care about exceptions at this stage, we're already disposing of the socket
+            }
+
+            _stream?.Dispose();
+            _client?.Close();
+        }
     }
 
     private void DiscardConnection()
@@ -273,29 +279,31 @@ public class PlayerConnection : IPlayerConnection
 
     public void Bind(IFuturemudControlContext context)
     {
-        State = ConnectionState.Open;
         ControlPuppet = context;
         try
         {
             _stream = _client.GetStream();
+            State = ConnectionState.Open;
+            _inactivityStopwatch.Start();
         }
         catch (ObjectDisposedException e)
         {
             Console.WriteLine("ObjectDisposedException in PlayerConnection.Bind: " + e.Message);
             State = ConnectionState.Closed;
+            ControlPuppet = null;
         }
         catch (InvalidOperationException e)
         {
             Console.WriteLine("InvalidOperationException in PlayerConnection.Bind: " + e.Message);
             State = ConnectionState.Closed;
+            ControlPuppet = null;
         }
         catch (SocketException e)
         {
             Console.WriteLine("SocketException ({0}) in PlayerConnection.Bind: " + e.Message, e.ErrorCode);
             State = ConnectionState.Closed;
+            ControlPuppet = null;
         }
-
-        _inactivityStopwatch.Start();
     }
 
     public void AttemptCommand()
@@ -388,6 +396,7 @@ public class PlayerConnection : IPlayerConnection
             }
 
             ControlPuppet.CuePrompt();
+            ControlPuppet.UpdateObservers();
 
             lock (_outgoingCommands)
             {
@@ -444,17 +453,36 @@ public class PlayerConnection : IPlayerConnection
         ResetWarnings();
     }
 
+    private void SendAll(byte[] bytes)
+    {
+        if (bytes.Length == 0)
+        {
+            return;
+        }
+
+        var offset = 0;
+        while (offset < bytes.Length)
+        {
+            var sent = _client.Client.Send(bytes, offset, bytes.Length - offset, SocketFlags.None);
+            if (sent <= 0)
+            {
+                throw new SocketException((int)SocketError.ConnectionReset);
+            }
+
+            offset += sent;
+        }
+    }
+
     private void HandleTelnetNegotiation(IEnumerable<byte> negotiation)
     {
         byte[] negSeq = negotiation.ToArray();
-        string text = Encoding.ASCII.GetString(negSeq);
 
         if (negSeq.SequenceEqual(DoMxp))
         {
             MXPSupport.UseMXP = true;
-            _client.Client.Send(StartMxp);
-            _client.Client.Send(MXP.StartMXPBytes());
-            _client.Client.Send(WillEOR);
+            SendAll(StartMxp);
+            SendAll(MXP.StartMXPBytes());
+            SendAll(WillEOR);
             return;
         }
 
@@ -466,7 +494,7 @@ public class PlayerConnection : IPlayerConnection
 
         if (negSeq.SequenceEqual(DoCharset))
         {
-            _client.Client.Send(RequestUTF8);
+            SendAll(RequestUTF8);
             return;
         }
 
@@ -496,31 +524,118 @@ public class PlayerConnection : IPlayerConnection
         if (negSeq.Take(BeginWillNegotiation.Length).SequenceEqual(BeginWillNegotiation))
         {
             negSeq[1] = Telnet.WONT;
-            _client.Client.Send(negSeq.ToArray());
+            SendAll(negSeq.ToArray());
             return;
         }
+    }
+
+    private void ResetTelnetNegotiation()
+    {
+        _telnetNegotiationBuffer.Clear();
+        _inTelnetNegotiation = false;
+        _inTelnetSubcommand = false;
+        _pendingTelnetSubcommandEnd = false;
+    }
+
+    private void ProcessIncomingByte(Encoding encoding, byte value)
+    {
+        if (_inTelnetNegotiation)
+        {
+            _telnetNegotiationBuffer.Add(value);
+
+            if (_telnetNegotiationBuffer.Count == 2 && value == Telnet.IAC)
+            {
+                _incomingCommandBuffer.Add(Telnet.IAC);
+                ResetTelnetNegotiation();
+                return;
+            }
+
+            if (_telnetNegotiationBuffer.Count == 2 && value == Telnet.SB)
+            {
+                _inTelnetSubcommand = true;
+                return;
+            }
+
+            if (_telnetNegotiationBuffer.Count == 2 &&
+                value != Telnet.WILL &&
+                value != Telnet.WONT &&
+                value != Telnet.DO &&
+                value != Telnet.DONT)
+            {
+                HandleTelnetNegotiation(_telnetNegotiationBuffer);
+                ResetTelnetNegotiation();
+                return;
+            }
+
+            if (_inTelnetSubcommand)
+            {
+                if (_pendingTelnetSubcommandEnd)
+                {
+                    if (value == Telnet.SE)
+                    {
+                        HandleTelnetNegotiation(_telnetNegotiationBuffer);
+                        ResetTelnetNegotiation();
+                        return;
+                    }
+
+                    _pendingTelnetSubcommandEnd = false;
+                }
+
+                if (value == Telnet.IAC)
+                {
+                    _pendingTelnetSubcommandEnd = true;
+                }
+
+                return;
+            }
+
+            if (_telnetNegotiationBuffer.Count >= 3)
+            {
+                HandleTelnetNegotiation(_telnetNegotiationBuffer);
+                ResetTelnetNegotiation();
+            }
+
+            return;
+        }
+
+        if (value == Telnet.IAC)
+        {
+            _inTelnetNegotiation = true;
+            _telnetNegotiationBuffer.Clear();
+            _telnetNegotiationBuffer.Add(value);
+            return;
+        }
+
+        if (value == (byte)'\r')
+        {
+            EnqueueCommand(encoding, _incomingCommandBuffer);
+            _incomingCommandBuffer.Clear();
+            return;
+        }
+
+        if (value == (byte)'\n')
+        {
+            if (_incomingCommandBuffer.Count > 0)
+            {
+                EnqueueCommand(encoding, _incomingCommandBuffer);
+                _incomingCommandBuffer.Clear();
+            }
+
+            return;
+        }
+
+        _incomingCommandBuffer.Add(value);
     }
 
     public void PrepareIncoming()
     {
         try
         {
-            // Temporarily disabled 09-04-2017 suspected as culprit in randomly disconnecting people when the server is lagging
-            //// Check if the socket is still open
-            //if (_client.Client.Poll(1000, SelectMode.SelectRead) && (_client.Client.Available == 0)) {
-            //    DiscardConnection();
-            //}
-
-            // Use ACK polling to detect disconnections
-            bool blocking = _client.Client.Blocking;
-            if (_inactivityStopwatch.ElapsedMilliseconds > 15000 &&
-                _inactivityStopwatch.ElapsedMilliseconds % 50 == 0)
+            if (_client.Client.Poll(0, SelectMode.SelectRead) && _client.Client.Available == 0)
             {
-                _client.Client.Blocking = false;
-                _client.Client.Send(new byte[1], 1, SocketFlags.None);
+                DiscardConnection();
+                return;
             }
-
-            _client.Client.Blocking = blocking;
 
             if (!_stream.DataAvailable)
             {
@@ -528,110 +643,27 @@ public class PlayerConnection : IPlayerConnection
             }
 
             int bytes = _stream.Read(_inputBuffer, 0, Constants.PlayerConnectionBufferSize);
+            if (bytes == 0)
+            {
+                DiscardConnection();
+                return;
+            }
 
             Encoding encoding = ControlPuppet?.Account?.UseUnicode ?? false
                 ? Encoding.UTF8
                 : Encoding.GetEncoding("iso-8859-1");
 
-            // Note - this is mistakenly chopping up lines in between SB/SE negotiations. Do a more C-like per-character parse
             byte[] byteArray = _inputBuffer.Take(bytes).ToArray();
-            List<byte> sb = new(Constants.PlayerConnectionBufferSize);
-            bool inTelnetNegotiation = false;
-            bool inTelnetSubcommand = false;
-            bool pendingTelnetSubcommandEnd = false;
             for (int i = 0; i < byteArray.Length; i++)
             {
-                if (inTelnetNegotiation)
-                {
-                    if (byteArray[i] == Telnet.SB)
-                    {
-                        sb.Add(byteArray[i]);
-                        inTelnetSubcommand = true;
-                        continue;
-                    }
-
-                    if (byteArray[i] == Telnet.IAC && inTelnetSubcommand)
-                    {
-                        sb.Add(byteArray[i]);
-                        pendingTelnetSubcommandEnd = true;
-                        continue;
-                    }
-
-                    if (byteArray[i] == Telnet.SE)
-                    {
-                        if (pendingTelnetSubcommandEnd)
-                        {
-                            sb.Add(byteArray[i]);
-                            inTelnetNegotiation = false;
-                            inTelnetSubcommand = false;
-                            pendingTelnetSubcommandEnd = false;
-                            HandleTelnetNegotiation(sb);
-                            sb.Clear();
-                            continue;
-                        }
-
-                        if (!inTelnetSubcommand)
-                        {
-                            sb.Add(byteArray[i]);
-                            inTelnetNegotiation = false;
-                            HandleTelnetNegotiation(sb);
-                            sb.Clear();
-                            continue;
-                        }
-
-                        sb.Add(byteArray[i]);
-                        continue;
-                    }
-
-                    sb.Add(byteArray[i]);
-                    continue;
-                }
-
-                if (byteArray[i] == Telnet.IAC)
-                {
-                    inTelnetNegotiation = true;
-                    if (sb.Count > 0)
-                    {
-                        EnqueueCommand(encoding, sb);
-                        sb.Clear();
-                    }
-
-                    sb.Add(byteArray[i]);
-                    continue;
-                }
-
-                if (byteArray[i] == 10 && sb.Count == 0)
-                {
-                    continue;
-                }
-
-                if (byteArray[i] == 13)
-                {
-                    if (sb.Count == 0)
-                    {
-                        // Player must have just sent 'return'
-                        EnqueueCommand(encoding, sb);
-                        continue;
-                    }
-
-                    EnqueueCommand(encoding, sb);
-                    sb.Clear();
-                    continue;
-                }
-
-                sb.Add(byteArray[i]);
+                ProcessIncomingByte(encoding, byteArray[i]);
             }
 
-            if (sb.Count > 0)
+            if (_incomingCommandBuffer.Count >= SupportsBytes.Length &&
+                _incomingCommandBuffer.Take(SupportsBytes.Length).SequenceEqual(SupportsBytes))
             {
-                if (inTelnetNegotiation)
-                {
-                    HandleTelnetNegotiation(sb);
-                }
-                else
-                {
-                    EnqueueCommand(encoding, sb);
-                }
+                EnqueueCommand(encoding, _incomingCommandBuffer);
+                _incomingCommandBuffer.Clear();
             }
         }
         catch (SocketException e)
@@ -642,6 +674,14 @@ public class PlayerConnection : IPlayerConnection
             }
         }
         catch (ObjectDisposedException)
+        {
+            DiscardConnection();
+        }
+        catch (IOException)
+        {
+            DiscardConnection();
+        }
+        catch (InvalidOperationException)
         {
             DiscardConnection();
         }
@@ -661,14 +701,14 @@ public class PlayerConnection : IPlayerConnection
             {
                 if (ControlPuppet.Account?.UseUnicode ?? false)
                 {
-                    _client.Client.Send(Encoding.UTF8.GetBytes(_outgoingCommands.ToString()));
+                    SendAll(Encoding.UTF8.GetBytes(_outgoingCommands.ToString()));
                 }
                 else
                 {
-                    _client.Client.Send(Encoding.GetEncoding("iso-8859-1").GetBytes(_outgoingCommands.ToString().ConvertToLatin1()));
+                    SendAll(Encoding.GetEncoding("iso-8859-1").GetBytes(_outgoingCommands.ToString().ConvertToLatin1()));
                 }
 
-                _client.Client.Send(_useAlternatePrompt ? AlternatePrompt : Prompt);
+                SendAll(_useAlternatePrompt ? AlternatePrompt : Prompt);
                 _outgoingCommands.Clear();
                 HasOutgoingCommands = false;
                 if (State == ConnectionState.Closing)
@@ -684,6 +724,14 @@ public class PlayerConnection : IPlayerConnection
                 }
             }
             catch (ObjectDisposedException)
+            {
+                DiscardConnection();
+            }
+            catch (IOException)
+            {
+                DiscardConnection();
+            }
+            catch (InvalidOperationException)
             {
                 DiscardConnection();
             }
@@ -704,10 +752,8 @@ public class PlayerConnection : IPlayerConnection
 
     private bool HasTimedOut()
     {
-        return _inactivityStopwatch.ElapsedMilliseconds > (ControlPuppet?.Timeout ?? 0);
+        var timeout = ControlPuppet?.Timeout ?? 0;
+        return timeout > 0 && _inactivityStopwatch.ElapsedMilliseconds > timeout;
     }
 
-    public void Reconnect(TcpClient client)
-    {
-    }
 }

--- a/MudSharpCore/Network/TcpServer.cs
+++ b/MudSharpCore/Network/TcpServer.cs
@@ -14,6 +14,7 @@ public sealed class TCPServer : IServer
     private AddConnectionCallback _addConnection;
     private IEnumerable<IPlayerConnection> _connections;
 
+    private TcpListener _listener;
     private Task _listeningThread;
     private CancellationTokenSource _listeningThreadCancellationToken;
 
@@ -44,17 +45,14 @@ public sealed class TCPServer : IServer
         }
 
         _listeningThreadCancellationToken = new CancellationTokenSource();
-        _listeningThread = Task.Factory.StartNew(ListeningDelegate, _listeningThreadCancellationToken.Token);
+        _listeningThread = Task.Factory.StartNew(ListeningDelegate, _listeningThreadCancellationToken.Token,
+            TaskCreationOptions.LongRunning, TaskScheduler.Default);
     }
 
     public void Stop()
     {
-        lock (_connections)
-        {
-            _listeningThreadCancellationToken.Cancel();
-        }
-
-        _listeningThread = null;
+        _listeningThreadCancellationToken?.Cancel();
+        _listener?.Stop();
     }
 
     /// <summary>
@@ -81,87 +79,126 @@ public sealed class TCPServer : IServer
 
     public TimeSpan IpFloodKeepAlive { get; } = TimeSpan.FromSeconds(60);
 
+    internal bool RecordConnectionAttempt(IPAddress address, DateTime utcNow)
+    {
+        PruneConnectionDictionary(utcNow);
+        if (ConnectionDictionary.TryGetValue(address, out TcpConnectionInformation info))
+        {
+            info.NumberOfConnections += 1;
+        }
+        else
+        {
+            ConnectionDictionary[address] = info = new TcpConnectionInformation
+            { StartOfPeriod = utcNow, NumberOfConnections = 1 };
+        }
+
+        return info.NumberOfConnections > 30;
+    }
+
+    internal void PruneConnectionDictionary(DateTime utcNow)
+    {
+        foreach (KeyValuePair<IPAddress, TcpConnectionInformation> connection in ConnectionDictionary.ToArray())
+        {
+            if (utcNow - connection.Value.StartOfPeriod > IpFloodKeepAlive)
+            {
+                ConnectionDictionary.Remove(connection.Key);
+            }
+        }
+    }
+
     public void ListeningDelegate()
     {
-        TcpListener tcp = new(IPAddress.Any, Port);
-        tcp.Start();
-        ConsoleUtilities.WriteLine("Successfully started listening on #2{0}#0.", IPAddress);
-        while (true)
+        TcpListener tcp = new(IPAddress, Port);
+        _listener = tcp;
+        try
         {
-            IEnumerable<IPlayerConnection> connections;
-            lock (_connections)
+            tcp.Start();
+            ConsoleUtilities.WriteLine("Successfully started listening on #2{0}#0.", IPAddress);
+            while (!_listeningThreadCancellationToken.IsCancellationRequested)
             {
-                connections = _connections.Where(x => x.State != ConnectionState.Closed).ToList();
-            }
+                IEnumerable<IPlayerConnection> connections;
+                lock (_connections)
+                {
+                    connections = _connections.Where(x => x.State != ConnectionState.Closed).ToList();
+                }
 
-            foreach (IPlayerConnection connection in connections)
+                foreach (IPlayerConnection connection in connections)
+                {
+                    try
+                    {
+                        if (connection.HasOutgoingCommands)
+                        {
+                            connection.SendOutgoing();
+                        }
+
+                        connection.PrepareIncoming();
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine("Warning: Exception in TCPServer.ListeningDelegate connection poll - " + e);
+                        connection.State = ConnectionState.Closing;
+                    }
+                }
+
+                lock (_connections)
+                {
+                    connections = _connections.Where(x => x.State == ConnectionState.Closing).ToList();
+                }
+
+                foreach (IPlayerConnection connection in connections)
+                {
+                    connection.Dispose();
+                }
+
+                while (tcp.Pending())
+                {
+                    TcpClient client = tcp.AcceptTcpClient();
+                    IPAddress address = ((IPEndPoint)client.Client.RemoteEndPoint).Address;
+
+                    if (RecordConnectionAttempt(address, DateTime.UtcNow))
+                    {
+                        client.Client.Shutdown(SocketShutdown.Both);
+                        client.Close();
+                        continue;
+                    }
+
+                    Console.WriteLine("Accepted TCP connection from {0}", client.Client.RemoteEndPoint);
+                    try
+                    {
+                        PlayerConnection newCon = new(client);
+                        _addConnection(newCon);
+                    }
+                    catch (SocketException e)
+                    {
+                        Console.WriteLine("SocketException ({0}) in PlayerConnection Constructor: " + e.Message,
+                            e.ErrorCode);
+                    }
+                    catch (ObjectDisposedException e)
+                    {
+                        Console.WriteLine("ObjectDisposedException in PlayerConnection Constructor: " + e.Message);
+                    }
+                }
+
+                PruneConnectionDictionary(DateTime.UtcNow);
+
+                Thread.Sleep(100);
+            }
+        }
+        catch (SocketException) when (_listeningThreadCancellationToken.IsCancellationRequested)
+        {
+            // Expected when Stop interrupts the listener.
+        }
+        catch (ObjectDisposedException) when (_listeningThreadCancellationToken.IsCancellationRequested)
+        {
+            // Expected when Stop interrupts the listener.
+        }
+        finally
+        {
+            tcp.Stop();
+            if (ReferenceEquals(_listener, tcp))
             {
-                if (connection.HasOutgoingCommands)
-                {
-                    connection.SendOutgoing();
-                }
-
-                connection.PrepareIncoming();
+                _listener = null;
             }
-
-            lock (_connections)
-            {
-                connections = _connections.Where(x => x.State == ConnectionState.Closing).ToList();
-            }
-
-            foreach (IPlayerConnection connection in connections)
-            {
-                connection.Dispose();
-            }
-
-            while (tcp.Pending())
-            {
-                TcpClient client = tcp.AcceptTcpClient();
-                IPAddress address = ((IPEndPoint)client.Client.RemoteEndPoint).Address;
-                if (ConnectionDictionary.ContainsKey(address))
-                {
-                    ConnectionDictionary[address].NumberOfConnections += 1;
-                }
-                else
-                {
-                    ConnectionDictionary[address] = new TcpConnectionInformation
-                    { StartOfPeriod = DateTime.UtcNow, NumberOfConnections = 1 };
-                }
-
-                if (ConnectionDictionary[address].NumberOfConnections > 30)
-                {
-                    client.Client.Shutdown(SocketShutdown.Both);
-                    client.Close();
-                    continue;
-                }
-
-                Console.WriteLine("Accepted TCP connection from {0}", client.Client.RemoteEndPoint);
-                try
-                {
-                    PlayerConnection newCon = new(client);
-                    _addConnection(newCon);
-                }
-                catch (SocketException e)
-                {
-                    Console.WriteLine("SocketException ({0}) in PlayerConnection Constructor: " + e.Message,
-                        e.ErrorCode);
-                }
-                catch (ObjectDisposedException e)
-                {
-                    Console.WriteLine("ObjectDisposedException in PlayerConnection Constructor: " + e.Message);
-                }
-            }
-
-            foreach (KeyValuePair<IPAddress, TcpConnectionInformation> connection in ConnectionDictionary.ToArray())
-            {
-                if (connection.Value.NumberOfConnections < 30 &&
-                    DateTime.UtcNow - connection.Value.StartOfPeriod > IpFloodKeepAlive)
-                {
-                    ConnectionDictionary.Remove(connection.Key);
-                }
-            }
-
-            Thread.Sleep(100);
         }
     }
 }

--- a/MudSharpCore/PerceptionEngine/Handlers/PlayerOutputHandler.cs
+++ b/MudSharpCore/PerceptionEngine/Handlers/PlayerOutputHandler.cs
@@ -55,18 +55,22 @@ public class PlayerOutputHandler : IOutputHandler
             Outgoing.Append('\n');
         }
 
-        if (!nopage && Perceiver != null && text.Count(x => x == '\n') > Perceiver.Account.PageLength * 1.25)
+        if (!nopage && Perceiver?.Account != null)
         {
-            StringReader reader = new(text);
-            StringBuilder sb = new();
-            for (int i = 0; i < Perceiver.Account.PageLength; i++)
+            var wrappedText = text.Wrap(Perceiver.Account.LineFormatLength);
+            if (wrappedText.Count(x => x == '\n') > Perceiver.Account.PageLength * 1.25)
             {
-                sb.AppendLine(reader.ReadLine());
-            }
+                StringReader reader = new(wrappedText);
+                StringBuilder sb = new();
+                for (int i = 0; i < Perceiver.Account.PageLength; i++)
+                {
+                    sb.AppendLine(reader.ReadLine());
+                }
 
-            PagedString = reader.ReadToEnd();
-            sb.AppendLineFormat("*** Type more to read further ***".Colour(Telnet.Yellow));
-            text = sb.ToString();
+                PagedString = reader.ReadToEnd();
+                sb.AppendLineFormat("*** Type more to read further ***".Colour(Telnet.Yellow));
+                text = sb.ToString();
+            }
         }
 
         if (newline)
@@ -129,7 +133,11 @@ public class PlayerOutputHandler : IOutputHandler
         }
 
         PagedString = reader.ReadToEnd();
-        sb.AppendLineFormat("*** Type {0} to read further ***", "more".Colour(Telnet.Yellow));
+        if (!string.IsNullOrEmpty(PagedString))
+        {
+            sb.AppendLineFormat("*** Type {0} to read further ***", "more".Colour(Telnet.Yellow));
+        }
+
         Outgoing.Append(sb);
     }
 


### PR DESCRIPTION
## Summary
- harden player input framing across split reads and telnet negotiations, including correct EOR/GA prompt bytes and full socket send loops
- make TCP listener shutdown, configured bind IP, flood-window expiry, and per-connection poll failures safer
- restore observer/subcontext lifecycle behavior and page output after wrapping
- add network workflow regression tests for partial commands, split telnet negotiation, flood windows, paging, and disabled timeouts

## Validation
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510` passed: 1112 tests
- `dotnet test 'FutureMUDLibrary Unit Tests\FutureMUDLibrary Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510` passed: 351 tests
- `git diff --check HEAD~1..HEAD` passed

Note: the core test command emitted existing analyzer `RS2008` warnings from `FutureMUD_Analyzers`; tests still passed.