### PR TITLE
Bound player connection input buffers to prevent unbounded pre-line/telnet buffering

### DIFF
--- a/MudSharpCore Unit Tests/NetworkWorkflowTests.cs
+++ b/MudSharpCore Unit Tests/NetworkWorkflowTests.cs
@@ -48,6 +48,48 @@ public class NetworkWorkflowTests
 	}
 
 	[TestMethod]
+	public async Task PlayerConnection_DisconnectsWhenPartialCommandExceedsBufferLimit()
+	{
+		var fixture = await CreateConnectionFixture();
+		try
+		{
+			var bytes = Enumerable.Repeat((byte)'x', Constants.PlayerConnectionBufferSize + 1).ToArray();
+			WriteClientBytes(fixture.Client, bytes);
+
+			await PumpIncomingUntilClosing(fixture.Connection);
+
+			Assert.AreEqual(ConnectionState.Closing, fixture.Connection.State);
+			Assert.IsFalse(fixture.Connection.HasIncomingCommands);
+		}
+		finally
+		{
+			fixture.Dispose();
+		}
+	}
+
+	[TestMethod]
+	public async Task PlayerConnection_DisconnectsWhenTelnetSubcommandExceedsBufferLimit()
+	{
+		var fixture = await CreateConnectionFixture();
+		try
+		{
+			var bytes = new[] { Telnet.IAC, Telnet.SB }
+				.Concat(Enumerable.Repeat((byte)'x', Constants.PlayerConnectionBufferSize))
+				.ToArray();
+			WriteClientBytes(fixture.Client, bytes);
+
+			await PumpIncomingUntilClosing(fixture.Connection);
+
+			Assert.AreEqual(ConnectionState.Closing, fixture.Connection.State);
+			Assert.IsFalse(fixture.Connection.HasIncomingCommands);
+		}
+		finally
+		{
+			fixture.Dispose();
+		}
+	}
+
+	[TestMethod]
 	public async Task PlayerConnection_PreservesSplitTelnetNegotiationAndUsesEorPrompt()
 	{
 		var fixture = await CreateConnectionFixture();
@@ -133,6 +175,15 @@ public class NetworkWorkflowTests
 		handler.More();
 
 		Assert.IsFalse(handler.BufferedOutput.Contains("Type more", StringComparison.Ordinal));
+	}
+
+	private static async Task PumpIncomingUntilClosing(PlayerConnection connection)
+	{
+		for (var i = 0; i < 10 && connection.State != ConnectionState.Closing; i++)
+		{
+			await Task.Delay(25);
+			connection.PrepareIncoming();
+		}
 	}
 
 	private static PlayerOutputHandler CreatePlayerOutputHandler(int pageLength, int lineLength)

--- a/MudSharpCore/Network/PlayerConnection.cs
+++ b/MudSharpCore/Network/PlayerConnection.cs
@@ -537,15 +537,44 @@ public class PlayerConnection : IPlayerConnection
         _pendingTelnetSubcommandEnd = false;
     }
 
+    private bool TryAppendIncomingCommandByte(byte value)
+    {
+        if (_incomingCommandBuffer.Count >= Constants.PlayerConnectionBufferSize)
+        {
+            DiscardConnection();
+            _incomingCommandBuffer.Clear();
+            return false;
+        }
+
+        _incomingCommandBuffer.Add(value);
+        return true;
+    }
+
+    private bool TryAppendTelnetNegotiationByte(byte value)
+    {
+        if (_telnetNegotiationBuffer.Count >= Constants.PlayerConnectionBufferSize)
+        {
+            DiscardConnection();
+            ResetTelnetNegotiation();
+            return false;
+        }
+
+        _telnetNegotiationBuffer.Add(value);
+        return true;
+    }
+
     private void ProcessIncomingByte(Encoding encoding, byte value)
     {
         if (_inTelnetNegotiation)
         {
-            _telnetNegotiationBuffer.Add(value);
+            if (!TryAppendTelnetNegotiationByte(value))
+            {
+                return;
+            }
 
             if (_telnetNegotiationBuffer.Count == 2 && value == Telnet.IAC)
             {
-                _incomingCommandBuffer.Add(Telnet.IAC);
+                TryAppendIncomingCommandByte(Telnet.IAC);
                 ResetTelnetNegotiation();
                 return;
             }
@@ -624,7 +653,7 @@ public class PlayerConnection : IPlayerConnection
             return;
         }
 
-        _incomingCommandBuffer.Add(value);
+        TryAppendIncomingCommandByte(value);
     }
 
     public void PrepareIncoming()
@@ -657,6 +686,10 @@ public class PlayerConnection : IPlayerConnection
             for (int i = 0; i < byteArray.Length; i++)
             {
                 ProcessIncomingByte(encoding, byteArray[i]);
+                if (State == ConnectionState.Closing)
+                {
+                    return;
+                }
             }
 
             if (_incomingCommandBuffer.Count >= SupportsBytes.Length &&


### PR DESCRIPTION
### Motivation
- Fix a security issue where `PlayerConnection` accumulated unterminated input and telnet subnegotiations in unbounded per-connection buffers, enabling a remote unauthenticated client to exhaust server memory and cause DoS. 
- Preserve the improved split-read/telnet handling while enforcing a maximum accumulation length to restore the prior protection against runaway per-connection buffers.

### Description
- Add bounded append helpers `TryAppendIncomingCommandByte` and `TryAppendTelnetNegotiationByte` that reject writes once `Constants.PlayerConnectionBufferSize` is reached and they drop/reset the connection state.  
- Route all normal input and telnet negotiation input through these helpers in `ProcessIncomingByte` to enforce the cap while preserving telnet state-machine behaviour (including escaped `IAC` handling and EOR support).  
- Stop processing the remainder of the current read when the connection is moved to `Closing` so a single overflowing read cannot continue building buffers on a closing connection.  
- Add regression tests in `MudSharpCore Unit Tests/NetworkWorkflowTests.cs` covering an oversized unterminated command and an oversized unterminated telnet subcommand, plus a small `PumpIncomingUntilClosing` helper used by those tests.

### Testing
- Ran `git diff --check` which produced no whitespace errors.  
- Ran `dotnet restore MudSharpCore/MudSharpCore.csproj` and `dotnet restore 'MudSharpCore Unit Tests/MudSharpCore Unit Tests.csproj'` which completed successfully.  
- Attempted a full solution restore (`dotnet restore MudSharp.sln`) but it failed in this Linux environment due to Windows-targeting projects requiring `EnableWindowsTargeting`.  
- Attempted to run `dotnet test` for the unit-test project, but the test run timed out in this environment while building; the new tests are present and exercise the overflow behaviour but an environment build timeout prevented a complete run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23533fb4348323a1695578a336fca8)