### PR TITLE
Harden computer automation security surfaces

### DIFF
--- a/MudSharpCore Unit Tests/ComputerWorkspaceRuntimeTests.cs
+++ b/MudSharpCore Unit Tests/ComputerWorkspaceRuntimeTests.cs
@@ -142,6 +142,8 @@ return 42");
 		Assert.IsFalse(functions.Any(x => x.FunctionName.EqualTo("LoadItem")));
 		Assert.IsTrue(functions.Any(x => x.FunctionName.EqualTo("UserInput")));
 		Assert.IsTrue(functions.Any(x => x.FunctionName.EqualTo("WaitSignal")));
+		Assert.IsFalse(functions.Any(x => x.FunctionName.EqualTo("BeginInfluence")));
+		Assert.IsFalse(functions.Any(x => x.FunctionName.EqualTo("EndInfluence")));
 		Assert.IsFalse(functions.Any(x => x.FunctionName.EqualTo("SendDiscord")));
 		Assert.IsFalse(service.GetFunctionHelp(FutureProgCompilationContext.ComputerFunction)
 			.Any(x => x.FunctionName.EqualTo("UserInput")));
@@ -203,6 +205,20 @@ return 1");
 
 		Assert.AreEqual(ComputerProcessStatus.Failed, outcome.Status);
 		StringAssert.Contains(outcome.Error, "For loop of greater than 10,000 iterations");
+	}
+
+	[TestMethod]
+	public void ComputerProgramExecutor_RejectsUnboundedTextHelpersWithoutThrowing()
+	{
+		var program = CompileProgramWithReturnType(
+			"HugeRepeatText",
+			ProgVariableTypes.Text,
+			@"return repeattext(""A"", 1000000000)");
+
+		var outcome = ComputerProgramExecutor.Execute(program, Array.Empty<object?>());
+
+		Assert.AreEqual(ComputerProcessStatus.Failed, outcome.Status);
+		StringAssert.Contains(outcome.Error, "repeattext cannot create text longer");
 	}
 
 	[TestMethod]
@@ -758,7 +774,7 @@ return userinput()";
 	}
 
 	[TestMethod]
-	public void ComputerExecutionService_ExecuteBuiltInApplication_SysMonWritesToTerminalAndCreatesHostProcess()
+	public void ComputerExecutionService_ExecuteBuiltInApplication_SysMonWritesToTerminalAndPrunesCompletedProcess()
 	{
 		var scheduler = new Mock<IScheduler>();
 		var gameworld = CreateGameworld(scheduler);
@@ -795,7 +811,7 @@ return userinput()";
 		Assert.IsTrue(result.Success, result.ErrorMessage);
 		Assert.AreEqual(ComputerProcessStatus.Completed, result.Status);
 		Assert.IsNotNull(result.Process);
-		Assert.IsNotNull(host.GetProcess(result.Process!.Id));
+		Assert.IsNull(host.GetProcess(result.Process!.Id));
 		Assert.IsFalse(owner.Processes.Any(x => x.Id == result.Process.Id));
 		output.Verify(x => x.Send(
 				It.Is<string>(s => s.Contains("SysMon") && s.Contains("Processes:")),
@@ -939,7 +955,7 @@ return userinput()";
 		Assert.AreEqual(ComputerProcessWaitType.UserInput, liveProcess.WaitType);
 
 		Assert.IsTrue(service.TrySubmitTerminalInput(session, "exit", out var exitError), exitError);
-		Assert.AreEqual(ComputerProcessStatus.Completed, host.GetProcess(start.Process.Id)!.Status);
+		Assert.IsNull(host.GetProcess(start.Process.Id));
 		output.Verify(x => x.Send(
 				It.Is<string>(s => s.Contains("Copied") && s.Contains("notes.txt")),
 				true,
@@ -1813,6 +1829,15 @@ return userinput()";
 			var authentication = mailService.Authenticate(localHost, "alice@local.example", "secret");
 			Assert.IsTrue(authentication.Success, authentication.ErrorMessage);
 
+			Assert.IsFalse(mailService.SendMessage(
+					localHost,
+					authentication.Account!,
+					"bob@remote.example",
+					new string('S', 501),
+					"Test Body",
+					out var longSubjectError));
+			StringAssert.Contains(longSubjectError, "500");
+
 			Assert.IsTrue(mailService.SendMessage(
 					localHost,
 					authentication.Account!,
@@ -2387,13 +2412,20 @@ return userinput()";
 			Assert.IsTrue(service.TrySubmitTerminalInput(session, "use general", out var useError), useError);
 			Assert.IsTrue(service.TrySubmitTerminalInput(session, "read 1", out var readError), readError);
 			output.Verify(x => x.Send(
-				It.Is<string>(s => s.Contains("Welcome") && s.Contains("Welcome to the board service.")),
+				It.Is<string>(s => s.Contains("Log in first") && s.Contains("before reading posts")),
 				true,
 				true), Times.AtLeastOnce);
 
 			Assert.IsTrue(service.TrySubmitTerminalInput(session, "login alice@bbs.example secret", out var loginError), loginError);
 			output.Verify(x => x.Send(
 				It.Is<string>(s => s.Contains("alice@bbs.example") && s.Contains("log in")),
+				true,
+				true), Times.AtLeastOnce);
+
+			Assert.IsTrue(service.TrySubmitTerminalInput(session, "read 1", out var authenticatedReadError),
+				authenticatedReadError);
+			output.Verify(x => x.Send(
+				It.Is<string>(s => s.Contains("Welcome") && s.Contains("Welcome to the board service.")),
 				true,
 				true), Times.AtLeastOnce);
 
@@ -2417,12 +2449,18 @@ return userinput()";
 	private static ComputerWorkspaceProgram CompileProgram(string name, string source,
 		params ComputerExecutableParameter[] parameters)
 	{
+		return CompileProgramWithReturnType(name, ProgVariableTypes.Number, source, parameters);
+	}
+
+	private static ComputerWorkspaceProgram CompileProgramWithReturnType(string name, ProgVariableTypes returnType, string source,
+		params ComputerExecutableParameter[] parameters)
+	{
 		var gameworld = new Mock<IFuturemud>();
 		var (prog, error) = ComputerExecutableCompiler.Compile(
 			gameworld.Object,
 			name,
 			ComputerExecutableKind.Program,
-			ProgVariableTypes.Number,
+			returnType,
 			parameters,
 			source);
 
@@ -2430,7 +2468,7 @@ return userinput()";
 		var program = new ComputerWorkspaceProgram(1, gameworld.Object)
 		{
 			Name = name,
-			ReturnType = ProgVariableTypes.Number,
+			ReturnType = returnType,
 			Parameters = parameters,
 			SourceCode = source,
 			CompilationStatus = ComputerCompilationStatus.Compiled,

--- a/MudSharpCore Unit Tests/SignalAutomationTests.cs
+++ b/MudSharpCore Unit Tests/SignalAutomationTests.cs
@@ -139,6 +139,23 @@ return @togglevalue");
 	}
 
 	[TestMethod]
+	public void ComputerMutableFileSystem_WriteAndAppend_EnforceCapacity()
+	{
+		var fileSystem = new ComputerMutableFileSystem(5);
+
+		fileSystem.WriteFile("signal.txt", "12345");
+
+		Assert.AreEqual(5, fileSystem.UsedBytes);
+		Assert.ThrowsException<ComputerFileSystemCapacityException>(() => fileSystem.AppendFile("signal.txt", "6"));
+		Assert.ThrowsException<ComputerFileSystemCapacityException>(() => fileSystem.WriteFile("other.txt", "1"));
+
+		fileSystem.WriteFile("signal.txt", "12");
+		fileSystem.WriteFile("other.txt", "123");
+
+		Assert.AreEqual(5, fileSystem.UsedBytes);
+	}
+
+	[TestMethod]
 	public void ComputerFileTransferUtilities_EnumerateOwners_IncludesHostLocalFileSignalGenerator()
 	{
 		var gameworld = CreateGameworld();
@@ -1483,6 +1500,7 @@ return @togglevalue");
 			true);
 		cableItem.SetupGet(x => x.Components).Returns([cable]);
 		sharedCell.Setup(x => x.LayerGameItems(RoomLayer.GroundLevel)).Returns([sensorItem.Object, cableItem.Object]);
+		actor.Setup(x => x.CanSee(cableItem.Object, It.IsAny<PerceiveIgnoreFlags>())).Returns(true);
 		gameworld.Setup(x => x.TryGetItem(It.IsAny<long>(), It.IsAny<bool>()))
 			.Returns((long id, bool _) => id == sensorItem.Object.Id ? sensorItem.Object : null!);
 

--- a/MudSharpCore/Commands/Modules/ElectronicsModule.cs
+++ b/MudSharpCore/Commands/Modules/ElectronicsModule.cs
@@ -4144,6 +4144,7 @@ If more than one terminal could be used, specify one explicitly or connect first
 		var statusItems = EnumerateElectricalStatusItems(actor, item).ToList();
 		var anchorItem = ResolveSignalSearchAnchorItem(item);
 		var nearbyCables = EnumerateNearbySignalItems(actor, anchorItem)
+			.Where(x => actor.CanSee(x))
 			.SelectMany(x => x.Components.OfType<SignalCableSegmentGameItemComponent>())
 			.Distinct()
 			.OrderBy(x => x.Parent.Id)

--- a/MudSharpCore/Computers/ComputerBuiltInApplicationExecutors.cs
+++ b/MudSharpCore/Computers/ComputerBuiltInApplicationExecutors.cs
@@ -49,7 +49,18 @@ internal static class ComputerBuiltInApplicationExecutors
 			};
 		}
 
-		return executor.Execute(gameworld, actor, owner, session, process, application);
+		try
+		{
+			return executor.Execute(gameworld, actor, owner, session, process, application);
+		}
+		catch (ComputerFileSystemCapacityException ex)
+		{
+			return new ComputerProgramExecutionOutcome
+			{
+				Status = ComputerProcessStatus.Failed,
+				Error = ex.Message
+			};
+		}
 	}
 
 	public static bool IsImplemented(IComputerBuiltInApplication application)
@@ -342,7 +353,16 @@ internal sealed class FileManagerBuiltInApplicationExecutor : IComputerBuiltInAp
 		session.User.EditorMode(
 			(text, handler, _) =>
 			{
-				fileSystem.WriteFile(fileName, text);
+				try
+				{
+					fileSystem.WriteFile(fileName, text);
+				}
+				catch (ComputerFileSystemCapacityException ex)
+				{
+					handler.Send(ex.Message);
+					return;
+				}
+
 				handler.Send($"Saved {fileName.ColourName()} on {ownerDescription.ColourName()}. Continue with {"type <command>".ColourCommand()} to keep using FileManager.");
 			},
 			(handler, _) =>
@@ -918,8 +938,8 @@ internal sealed class BoardsBuiltInApplicationExecutor : IComputerBuiltInApplica
 			"logout" => HandleLogout(session, state, targetHost),
 			"boards" or "listboards" => HandleBoards(gameworld, session, state, targetHost, account, board),
 			"use" or "select" => HandleUse(gameworld, session, state, targetHost, ss),
-			"list" => HandleList(gameworld, session, state, targetHost, board),
-			"read" or "show" => HandleRead(gameworld, session, state, targetHost, board, ss),
+			"list" => HandleList(gameworld, session, state, targetHost, account, board),
+			"read" or "show" => HandleRead(gameworld, session, state, targetHost, account, board, ss),
 			"post" or "write" => HandlePost(gameworld, session, process, state, targetHost, account, board, ss),
 			"delete" or "del" => HandleDelete(gameworld, session, state, targetHost, account, board, ss),
 			"exit" or "quit" => ($"{application.Name.ColourName()} closing.", true),
@@ -1075,7 +1095,7 @@ internal sealed class BoardsBuiltInApplicationExecutor : IComputerBuiltInApplica
 	}
 
 	private static (string Output, bool Exit) HandleList(IFuturemud gameworld, IComputerTerminalSession session,
-		BoardsState state, IComputerHost? targetHost, IBoard? board)
+		BoardsState state, IComputerHost? targetHost, IComputerNetworkAccount? account, IBoard? board)
 	{
 		if (targetHost is null)
 		{
@@ -1083,9 +1103,15 @@ internal sealed class BoardsBuiltInApplicationExecutor : IComputerBuiltInApplica
 				false);
 		}
 
+		if (account is null)
+		{
+			return ($"Log in first with {"type login <user@domain> <password>".ColourCommand()} before listing posts.\n\n{RenderPrompt(session.User, state, targetHost, null, board, null)}",
+				false);
+		}
+
 		if (board is null)
 		{
-			return ($"Select one hosted board first with {"type use <board>".ColourCommand()}.\n\n{RenderPrompt(session.User, state, targetHost, ResolveLoggedInAccount(gameworld, session.Host, targetHost, state, out _), null, null)}",
+			return ($"Select one hosted board first with {"type use <board>".ColourCommand()}.\n\n{RenderPrompt(session.User, state, targetHost, account, null, null)}",
 				false);
 		}
 
@@ -1121,12 +1147,12 @@ internal sealed class BoardsBuiltInApplicationExecutor : IComputerBuiltInApplica
 		}
 
 		sb.AppendLine();
-		sb.Append(RenderPrompt(session.User, state, targetHost, ResolveLoggedInAccount(gameworld, session.Host, targetHost, state, out _), board, null));
+		sb.Append(RenderPrompt(session.User, state, targetHost, account, board, null));
 		return (sb.ToString(), false);
 	}
 
 	private static (string Output, bool Exit) HandleRead(IFuturemud gameworld, IComputerTerminalSession session,
-		BoardsState state, IComputerHost? targetHost, IBoard? board, StringStack ss)
+		BoardsState state, IComputerHost? targetHost, IComputerNetworkAccount? account, IBoard? board, StringStack ss)
 	{
 		if (targetHost is null)
 		{
@@ -1134,22 +1160,28 @@ internal sealed class BoardsBuiltInApplicationExecutor : IComputerBuiltInApplica
 				false);
 		}
 
+		if (account is null)
+		{
+			return ($"Log in first with {"type login <user@domain> <password>".ColourCommand()} before reading posts.\n\n{RenderPrompt(session.User, state, targetHost, null, board, null)}",
+				false);
+		}
+
 		if (board is null)
 		{
-			return ($"Select one hosted board first with {"type use <board>".ColourCommand()}.\n\n{RenderPrompt(session.User, state, targetHost, ResolveLoggedInAccount(gameworld, session.Host, targetHost, state, out _), null, null)}",
+			return ($"Select one hosted board first with {"type use <board>".ColourCommand()}.\n\n{RenderPrompt(session.User, state, targetHost, account, null, null)}",
 				false);
 		}
 
 		if (ss.IsFinished || !long.TryParse(ss.PopSpeech(), out var postId))
 		{
-			return ($"Which board post do you want to read?\n\n{RenderPrompt(session.User, state, targetHost, ResolveLoggedInAccount(gameworld, session.Host, targetHost, state, out _), board, null)}",
+			return ($"Which board post do you want to read?\n\n{RenderPrompt(session.User, state, targetHost, account, board, null)}",
 				false);
 		}
 
 		var post = gameworld.ComputerBoardService.ReadPost(targetHost, board, postId, out var error);
 		if (post is null)
 		{
-			return ($"{error}\n\n{RenderPrompt(session.User, state, targetHost, ResolveLoggedInAccount(gameworld, session.Host, targetHost, state, out _), board, null)}",
+			return ($"{error}\n\n{RenderPrompt(session.User, state, targetHost, account, board, null)}",
 				false);
 		}
 
@@ -1166,7 +1198,7 @@ internal sealed class BoardsBuiltInApplicationExecutor : IComputerBuiltInApplica
 		sb.AppendLine();
 		sb.AppendLine(post.Text);
 		sb.AppendLine();
-		sb.Append(RenderPrompt(session.User, state, targetHost, ResolveLoggedInAccount(gameworld, session.Host, targetHost, state, out _), board, null));
+		sb.Append(RenderPrompt(session.User, state, targetHost, account, board, null));
 		return (sb.ToString(), false);
 	}
 
@@ -1287,7 +1319,7 @@ internal sealed class BoardsBuiltInApplicationExecutor : IComputerBuiltInApplica
 		sb.AppendLine($"{application.Name.ColourName()} commands:");
 		sb.AppendLine($"\t{"hosts".ColourCommand()} - list reachable hosts advertising Boards");
 		sb.AppendLine($"\t{"open <host>".ColourCommand()} - choose which boards service host to use");
-		sb.AppendLine($"\t{"login <user@domain> <password>".ColourCommand()} - authenticate for posting and deletion");
+		sb.AppendLine($"\t{"login <user@domain> <password>".ColourCommand()} - authenticate for reading, posting and deletion");
 		sb.AppendLine($"\t{"logout".ColourCommand()} - log out of the current network identity");
 		sb.AppendLine($"\t{"boards".ColourCommand()} - list boards exposed by the selected host");
 		sb.AppendLine($"\t{"use <board>".ColourCommand()} - select one hosted board");

--- a/MudSharpCore/Computers/ComputerExecutionContext.cs
+++ b/MudSharpCore/Computers/ComputerExecutionContext.cs
@@ -14,6 +14,7 @@ internal sealed class ComputerExecutionContext
 	public ICharacter? Actor { get; init; }
 	public IComputerTerminalSession? Session { get; init; }
 	public ComputerRuntimeProcess? Process { get; init; }
+	public int LaunchDepth { get; init; }
 	public string? PendingTerminalInput { get; internal set; }
 	public ComputerSignal? PendingSignalInput { get; internal set; }
 

--- a/MudSharpCore/Computers/ComputerExecutionService.cs
+++ b/MudSharpCore/Computers/ComputerExecutionService.cs
@@ -304,7 +304,8 @@ public class ComputerExecutionService : IComputerExecutionService
 					Host = owner.ExecutionHost,
 					Gameworld = _gameworld,
 					Actor = actor,
-					Session = session
+					Session = session,
+					LaunchDepth = (ComputerExecutionContextScope.Current?.LaunchDepth ?? 0) + 1
 				});
 
 				var result = function.CompiledProg!.Execute(parameters.ToArray());
@@ -334,7 +335,8 @@ public class ComputerExecutionService : IComputerExecutionService
 				Gameworld = _gameworld,
 				Actor = actor,
 				Session = session,
-				Process = process
+				Process = process,
+				LaunchDepth = (ComputerExecutionContextScope.Current?.LaunchDepth ?? 0) + 1
 			});
 
 			var outcome = ComputerProgramExecutor.Execute(program, parameters);
@@ -400,7 +402,8 @@ public class ComputerExecutionService : IComputerExecutionService
 				Gameworld = _gameworld,
 				Actor = actor,
 				Session = session,
-				Process = process
+				Process = process,
+				LaunchDepth = (ComputerExecutionContextScope.Current?.LaunchDepth ?? 0) + 1
 			});
 
 			var outcome = ComputerBuiltInApplicationExecutors.Execute(
@@ -411,6 +414,10 @@ public class ComputerExecutionService : IComputerExecutionService
 				process,
 				resolvedApplication);
 			outcome = ApplyExecutionOutcome_NoLock(owner.ExecutionHost, process, outcome);
+			if (outcome.Status is ComputerProcessStatus.Completed or ComputerProcessStatus.Failed or ComputerProcessStatus.Killed)
+			{
+				processOwner.DeleteProcessDefinition(process);
+			}
 
 			return new ComputerExecutionResult
 			{
@@ -571,8 +578,20 @@ public class ComputerExecutionService : IComputerExecutionService
 		{
 			EnsureLoaded();
 		}
+		else
+		{
+			EnsureLoadedForOwner(session.CurrentOwner);
+		}
+
+		if (!ReferenceEquals(session.CurrentOwner, session.Host))
+		{
+			EnsureLoadedForOwner(session.Host);
+		}
+
 		lock (_sync)
 		{
+			RegisterOwner_NoLock(session.CurrentOwner);
+			RegisterOwner_NoLock(session.Host);
 			if (!session.Host.Powered)
 			{
 				error = $"{session.Host.Name} is not currently powered.";
@@ -1281,7 +1300,9 @@ public class ComputerExecutionService : IComputerExecutionService
 			Handler = handler
 		};
 
-		if (triggerImmediately && Math.Abs(source.CurrentSignal.Value) > 0.0000001)
+		if (triggerImmediately &&
+		    double.IsFinite(source.CurrentSignal.Value) &&
+		    Math.Abs(source.CurrentSignal.Value) > 0.0000001)
 		{
 			HandleSignalWaitTriggered_NoLock(owner, process, source.CurrentSignal);
 		}
@@ -1330,7 +1351,7 @@ public class ComputerExecutionService : IComputerExecutionService
 	private void HandleSignalWaitTriggered_NoLock(IComputerExecutableOwner owner, ComputerRuntimeProcess process,
 		ComputerSignal signal)
 	{
-		if (Math.Abs(signal.Value) < 0.0000001)
+		if (!double.IsFinite(signal.Value) || Math.Abs(signal.Value) < 0.0000001)
 		{
 			return;
 		}
@@ -1363,7 +1384,8 @@ public class ComputerExecutionService : IComputerExecutionService
 			Host = owner.ExecutionHost,
 			Gameworld = _gameworld,
 			Process = liveProcess,
-			PendingSignalInput = signal
+			PendingSignalInput = signal,
+			LaunchDepth = (ComputerExecutionContextScope.Current?.LaunchDepth ?? 0) + 1
 		});
 
 		liveProcess.Status = ComputerProcessStatus.Running;
@@ -1389,7 +1411,18 @@ public class ComputerExecutionService : IComputerExecutionService
 
 	private IEnumerable<ComputerRuntimeProcess> FindWaitingUserInputProcesses_NoLock(IComputerTerminalSession session)
 	{
-		return FindWaitingUserInputProcesses_NoLock(session.User.Id, session.Terminal.TerminalItemId, null);
+		return ResolveProcesses_NoLock(session.CurrentOwner)
+			.Concat(ReferenceEquals(session.CurrentOwner, session.Host)
+				? Enumerable.Empty<IComputerProcess>()
+				: ResolveProcesses_NoLock(session.Host))
+			.OfType<ComputerRuntimeProcess>()
+			.Where(x => x.Status == ComputerProcessStatus.Sleeping)
+			.Where(x => x.WaitType == ComputerProcessWaitType.UserInput)
+			.Where(x => x.WaitingCharacterId == session.User.Id)
+			.Where(x => x.WaitingTerminalItemId == session.Terminal.TerminalItemId)
+			.GroupBy(x => x.Id)
+			.Select(x => x.First())
+			.ToList();
 	}
 
 	private IEnumerable<ComputerRuntimeProcess> FindWaitingUserInputProcesses_NoLock(long waitingCharacterId,
@@ -1447,17 +1480,18 @@ public class ComputerExecutionService : IComputerExecutionService
 				Actor = session.User,
 				Session = session,
 				Process = liveProcess,
-			PendingTerminalInput = text
-		});
+				PendingTerminalInput = text,
+				LaunchDepth = (ComputerExecutionContextScope.Current?.LaunchDepth ?? 0) + 1
+			});
 
-		liveProcess.Status = ComputerProcessStatus.Running;
-		liveProcess.WaitType = ComputerProcessWaitType.None;
-		liveProcess.WakeTimeUtc = null;
-		liveProcess.WaitArgument = null;
-		liveProcess.WaitingCharacterId = null;
-		liveProcess.WaitingTerminalItemId = null;
-		liveProcess.LastUpdatedAtUtc = DateTime.UtcNow;
-		PersistProcess_NoLock(owner, liveProcess);
+			liveProcess.Status = ComputerProcessStatus.Running;
+			liveProcess.WaitType = ComputerProcessWaitType.None;
+			liveProcess.WakeTimeUtc = null;
+			liveProcess.WaitArgument = null;
+			liveProcess.WaitingCharacterId = null;
+			liveProcess.WaitingTerminalItemId = null;
+			liveProcess.LastUpdatedAtUtc = DateTime.UtcNow;
+			PersistProcess_NoLock(owner, liveProcess);
 
 			var outcome = ComputerProgramExecutor.Execute(program, Enumerable.Empty<object?>(), liveProcess.StateJson);
 			outcome = ApplyExecutionOutcome_NoLock(owner, liveProcess, outcome);
@@ -1475,7 +1509,8 @@ public class ComputerExecutionService : IComputerExecutionService
 				Actor = session.User,
 				Session = session,
 				Process = liveProcess,
-				PendingTerminalInput = text
+				PendingTerminalInput = text,
+				LaunchDepth = (ComputerExecutionContextScope.Current?.LaunchDepth ?? 0) + 1
 			});
 
 			liveProcess.Status = ComputerProcessStatus.Running;
@@ -1495,6 +1530,12 @@ public class ComputerExecutionService : IComputerExecutionService
 				liveProcess,
 				builtInApplication);
 			outcome = ApplyExecutionOutcome_NoLock(owner, liveProcess, outcome);
+			if (outcome.Status is ComputerProcessStatus.Completed or ComputerProcessStatus.Failed or ComputerProcessStatus.Killed &&
+			    owner is IComputerMutableOwner mutableOwner)
+			{
+				mutableOwner.DeleteProcessDefinition(liveProcess);
+			}
+
 			error = outcome.Status == ComputerProcessStatus.Failed ? outcome.Error ?? string.Empty : string.Empty;
 			return outcome.Status != ComputerProcessStatus.Failed;
 		}
@@ -1797,7 +1838,8 @@ public class ComputerExecutionService : IComputerExecutionService
 				Owner = owner,
 				Host = owner.ExecutionHost,
 				Gameworld = _gameworld,
-				Process = liveProcess
+				Process = liveProcess,
+				LaunchDepth = (ComputerExecutionContextScope.Current?.LaunchDepth ?? 0) + 1
 			});
 
 			liveProcess.Status = ComputerProcessStatus.Running;

--- a/MudSharpCore/Computers/ComputerFileTransferService.cs
+++ b/MudSharpCore/Computers/ComputerFileTransferService.cs
@@ -9,7 +9,11 @@ namespace MudSharp.Computers;
 
 public sealed class ComputerFileTransferService : IComputerFileTransferService
 {
+	private const int MaximumFailedAuthenticationAttemptsBeforeBackoff = 5;
+	private static readonly TimeSpan AuthenticationBackoffDuration = TimeSpan.FromSeconds(30);
 	private readonly IFuturemud _gameworld;
+	private readonly Dictionary<string, (int FailedAttempts, DateTime? NextAttemptUtc)> _authenticationBackoffs =
+		new(StringComparer.InvariantCultureIgnoreCase);
 
 	public ComputerFileTransferService(IFuturemud gameworld)
 	{
@@ -132,30 +136,54 @@ public sealed class ComputerFileTransferService : IComputerFileTransferService
 			};
 		}
 
-		var account = ResolveAccount(targetHost, normalisedUserName);
-		if (account is null || !account.Enabled)
+		var backoffKey = $"{targetHost.FileOwnerId}:{normalisedUserName}";
+		if (_authenticationBackoffs.TryGetValue(backoffKey, out var backoff) &&
+		    backoff.NextAttemptUtc is not null &&
+		    backoff.NextAttemptUtc > DateTime.UtcNow)
 		{
 			return new ComputerFtpAuthenticationResult
 			{
 				Success = false,
-				ErrorMessage = $"There is no enabled FTP account named {normalisedUserName.ColourName()} on {targetHost.Name.ColourName()}."
+				ErrorMessage = "FTP login attempts are temporarily delayed. Try again shortly."
+			};
+		}
+
+		var account = ResolveAccount(targetHost, normalisedUserName);
+		if (account is null || !account.Enabled)
+		{
+			RecordAuthenticationFailure(backoffKey);
+			return new ComputerFtpAuthenticationResult
+			{
+				Success = false,
+				ErrorMessage = "The FTP username or password is not correct."
 			};
 		}
 
 		if (!SecurityUtilities.VerifyPassword(password, account.PasswordHash, account.PasswordSalt))
 		{
+			RecordAuthenticationFailure(backoffKey);
 			return new ComputerFtpAuthenticationResult
 			{
 				Success = false,
-				ErrorMessage = "That password is not correct."
+				ErrorMessage = "The FTP username or password is not correct."
 			};
 		}
 
+		_authenticationBackoffs.Remove(backoffKey);
 		return new ComputerFtpAuthenticationResult
 		{
 			Success = true,
 			Account = account
 		};
+	}
+
+	private void RecordAuthenticationFailure(string backoffKey)
+	{
+		_authenticationBackoffs.TryGetValue(backoffKey, out var backoff);
+		var attempts = backoff.FailedAttempts + 1;
+		_authenticationBackoffs[backoffKey] = attempts >= MaximumFailedAuthenticationAttemptsBeforeBackoff
+			? (0, DateTime.UtcNow + AuthenticationBackoffDuration)
+			: (attempts, null);
 	}
 
 	public IComputerFtpAccount? GetAccount(IComputerHost sourceHost, IComputerHost targetHost, string userName,
@@ -373,8 +401,16 @@ public sealed class ComputerFileTransferService : IComputerFileTransferService
 			return false;
 		}
 
-		action(fileSystem);
-		return true;
+		try
+		{
+			action(fileSystem);
+			return true;
+		}
+		catch (ComputerFileSystemCapacityException ex)
+		{
+			error = ex.Message;
+			return false;
+		}
 	}
 
 	private bool TryEnsureAuthenticatedAccount(IComputerHost sourceHost, IComputerHost targetHost, IComputerFtpAccount account,

--- a/MudSharpCore/Computers/ComputerFtpBuiltInApplicationExecutor.cs
+++ b/MudSharpCore/Computers/ComputerFtpBuiltInApplicationExecutor.cs
@@ -12,17 +12,24 @@ namespace MudSharp.Computers;
 
 internal sealed class FtpBuiltInApplicationExecutor : IComputerBuiltInApplicationExecutor
 {
+	private const int MaximumFailedLoginAttemptsBeforeBackoff = 5;
+	private static readonly TimeSpan FailedLoginBackoff = TimeSpan.FromSeconds(30);
+
 	private sealed class FtpState
 	{
 		public long? RemoteHostItemId { get; set; }
 		public string RemoteHostName { get; set; } = string.Empty;
 		public string RemoteAccountUserName { get; set; } = string.Empty;
 		public string SelectedRemoteOwnerIdentifier { get; set; } = "host";
+		public int FailedLoginAttempts { get; set; }
+		public DateTime? NextLoginAttemptUtc { get; set; }
 
 		public void ClearAuthentication()
 		{
 			RemoteAccountUserName = string.Empty;
 			SelectedRemoteOwnerIdentifier = "host";
+			FailedLoginAttempts = 0;
+			NextLoginAttemptUtc = null;
 		}
 
 		public void ClearConnection()
@@ -237,13 +244,28 @@ internal sealed class FtpBuiltInApplicationExecutor : IComputerBuiltInApplicatio
 				false);
 		}
 
+		if (state.NextLoginAttemptUtc is not null && state.NextLoginAttemptUtc > DateTime.UtcNow)
+		{
+			return ($"FTP login attempts are temporarily delayed. Try again shortly.\n\n{RenderPrompt(session.User, state, remoteHost, null, null)}",
+				false);
+		}
+
 		var authentication = gameworld.ComputerFileTransferService.Authenticate(session.Host, remoteHost, userName,
 			ss.SafeRemainingArgument);
 		if (!authentication.Success || authentication.Account is null)
 		{
+			state.FailedLoginAttempts++;
+			if (state.FailedLoginAttempts >= MaximumFailedLoginAttemptsBeforeBackoff)
+			{
+				state.FailedLoginAttempts = 0;
+				state.NextLoginAttemptUtc = DateTime.UtcNow + FailedLoginBackoff;
+			}
+
 			return ($"{authentication.ErrorMessage}\n\n{RenderPrompt(session.User, state, remoteHost, null, null)}", false);
 		}
 
+		state.FailedLoginAttempts = 0;
+		state.NextLoginAttemptUtc = null;
 		state.RemoteAccountUserName = authentication.Account.UserName;
 		state.SelectedRemoteOwnerIdentifier = "host";
 		return ($"You log in to FTP on {remoteHost.Name.ColourName()} as {authentication.Account.UserName.ColourName()}.\n\n{RenderPrompt(session.User, state, remoteHost, authentication.Account, null)}",

--- a/MudSharpCore/Computers/ComputerMailService.cs
+++ b/MudSharpCore/Computers/ComputerMailService.cs
@@ -12,6 +12,8 @@ namespace MudSharp.Computers;
 
 public sealed class ComputerMailService : IComputerMailService
 {
+	private const int MaximumSubjectLength = 500;
+
 	private sealed class RuntimeMailAccount : IComputerMailAccount
 	{
 		public long Id { get; init; }
@@ -568,6 +570,13 @@ public sealed class ComputerMailService : IComputerMailService
 			return false;
 		}
 
+		var trimmedSubject = subject.Trim();
+		if (trimmedSubject.Length > MaximumSubjectLength)
+		{
+			error = $"Mail subjects must be {MaximumSubjectLength:N0} characters or fewer.";
+			return false;
+		}
+
 		if (string.IsNullOrWhiteSpace(body))
 		{
 			error = "You must set a body before posting the message.";
@@ -595,7 +604,7 @@ public sealed class ComputerMailService : IComputerMailService
 			{
 				SenderAddress = senderAccount.Address,
 				RecipientAddress = recipientAddress.ToLowerInvariant(),
-				Subject = subject.Trim(),
+				Subject = trimmedSubject,
 				Body = body,
 				SentAtUtc = DateTime.UtcNow
 			};

--- a/MudSharpCore/Computers/ComputerOwnerRuntimeModels.cs
+++ b/MudSharpCore/Computers/ComputerOwnerRuntimeModels.cs
@@ -10,6 +10,13 @@ using MudSharp.FutureProg;
 
 namespace MudSharp.Computers;
 
+public sealed class ComputerFileSystemCapacityException : InvalidOperationException
+{
+	public ComputerFileSystemCapacityException(string message) : base(message)
+	{
+	}
+}
+
 public abstract class ComputerRuntimeExecutableBase : IComputerExecutableDefinition
 {
 	protected ComputerRuntimeExecutableBase(long id, IFuturemud gameworld)
@@ -151,16 +158,43 @@ public sealed class ComputerMutableFileSystem : IComputerFileSystem
 			?.TextContents ?? string.Empty;
 	}
 
+	private void EnsureCapacityForWrite(ComputerMutableTextFile? existing, string replacementContents)
+	{
+		var replacementSize = Encoding.UTF8.GetByteCount(replacementContents ?? string.Empty);
+		var resultingSize = UsedBytes - (existing?.SizeInBytes ?? 0L) + replacementSize;
+		if (resultingSize <= CapacityInBytes)
+		{
+			return;
+		}
+
+		throw new ComputerFileSystemCapacityException(
+			$"That write would use {resultingSize:N0} bytes, exceeding the file system capacity of {CapacityInBytes:N0} bytes.");
+	}
+
+	private void EnsureCapacityForAppend(string appendedContents)
+	{
+		var resultingSize = UsedBytes + Encoding.UTF8.GetByteCount(appendedContents ?? string.Empty);
+		if (resultingSize <= CapacityInBytes)
+		{
+			return;
+		}
+
+		throw new ComputerFileSystemCapacityException(
+			$"That append would use {resultingSize:N0} bytes, exceeding the file system capacity of {CapacityInBytes:N0} bytes.");
+	}
+
 	public void WriteFile(string fileName, string textContents)
 	{
 		var now = DateTime.UtcNow;
+		var contents = textContents ?? string.Empty;
 		var existing = _files.FirstOrDefault(x => x.FileName.Equals(fileName, StringComparison.InvariantCultureIgnoreCase));
+		EnsureCapacityForWrite(existing, contents);
 		if (existing is null)
 		{
 			_files.Add(new ComputerMutableTextFile
 			{
 				FileName = fileName,
-				TextContents = textContents ?? string.Empty,
+				TextContents = contents,
 				CreatedAtUtc = now,
 				LastModifiedAtUtc = now
 			});
@@ -172,7 +206,7 @@ public sealed class ComputerMutableFileSystem : IComputerFileSystem
 			return;
 		}
 
-		existing.TextContents = textContents ?? string.Empty;
+		existing.TextContents = contents;
 		existing.LastModifiedAtUtc = now;
 		FileChanged?.Invoke(this, new ComputerFileSystemChange
 		{
@@ -184,13 +218,15 @@ public sealed class ComputerMutableFileSystem : IComputerFileSystem
 	public void AppendFile(string fileName, string textContents)
 	{
 		var now = DateTime.UtcNow;
+		var contents = textContents ?? string.Empty;
 		var existing = _files.FirstOrDefault(x => x.FileName.Equals(fileName, StringComparison.InvariantCultureIgnoreCase));
+		EnsureCapacityForAppend(contents);
 		if (existing is null)
 		{
 			_files.Add(new ComputerMutableTextFile
 			{
 				FileName = fileName,
-				TextContents = textContents ?? string.Empty,
+				TextContents = contents,
 				CreatedAtUtc = now,
 				LastModifiedAtUtc = now
 			});
@@ -202,7 +238,7 @@ public sealed class ComputerMutableFileSystem : IComputerFileSystem
 			return;
 		}
 
-		existing.TextContents += textContents ?? string.Empty;
+		existing.TextContents += contents;
 		existing.LastModifiedAtUtc = now;
 		FileChanged?.Invoke(this, new ComputerFileSystemChange
 		{

--- a/MudSharpCore/Computers/ComputerProgramExecutor.cs
+++ b/MudSharpCore/Computers/ComputerProgramExecutor.cs
@@ -473,6 +473,10 @@ internal static class ComputerProgramExecutor
 					StateJson = PersistFrames(frames)
 				};
 			}
+			catch (Exception ex) when (ex is not OutOfMemoryException)
+			{
+				return Failure($"Computer program execution failed: {ex.Message}");
+			}
 		}
 
 		return Complete(program.ReturnType, frames);

--- a/MudSharpCore/FutureProg/ComputerCompilationRestrictions.cs
+++ b/MudSharpCore/FutureProg/ComputerCompilationRestrictions.cs
@@ -59,6 +59,7 @@ internal static class ComputerCompilationRestrictions
 		"Items",
 		"Lookup",
 		"Manipulation",
+		"Markets",
 		"NPCs",
 		"Outfits",
 		"Perception",

--- a/MudSharpCore/FutureProg/Functions/Computers/ComputerRuntimeFunctions.cs
+++ b/MudSharpCore/FutureProg/Functions/Computers/ComputerRuntimeFunctions.cs
@@ -180,10 +180,17 @@ internal class WriteFileFunction : ComputerRuntimeBuiltInFunction
 			return StatementResult.Normal;
 		}
 
-		fileSystem.WriteFile(
-			ParameterFunctions[0].Result?.GetObject?.ToString() ?? string.Empty,
-			ParameterFunctions[1].Result?.GetObject?.ToString() ?? string.Empty);
-		Result = new BooleanVariable(true);
+		try
+		{
+			fileSystem.WriteFile(
+				ParameterFunctions[0].Result?.GetObject?.ToString() ?? string.Empty,
+				ParameterFunctions[1].Result?.GetObject?.ToString() ?? string.Empty);
+			Result = new BooleanVariable(true);
+		}
+		catch (ComputerFileSystemCapacityException)
+		{
+			Result = new BooleanVariable(false);
+		}
 		return StatementResult.Normal;
 	}
 }
@@ -229,10 +236,17 @@ internal class AppendFileFunction : ComputerRuntimeBuiltInFunction
 			return StatementResult.Normal;
 		}
 
-		fileSystem.AppendFile(
-			ParameterFunctions[0].Result?.GetObject?.ToString() ?? string.Empty,
-			ParameterFunctions[1].Result?.GetObject?.ToString() ?? string.Empty);
-		Result = new BooleanVariable(true);
+		try
+		{
+			fileSystem.AppendFile(
+				ParameterFunctions[0].Result?.GetObject?.ToString() ?? string.Empty,
+				ParameterFunctions[1].Result?.GetObject?.ToString() ?? string.Empty);
+			Result = new BooleanVariable(true);
+		}
+		catch (ComputerFileSystemCapacityException)
+		{
+			Result = new BooleanVariable(false);
+		}
 		return StatementResult.Normal;
 	}
 }
@@ -523,6 +537,12 @@ internal class WaitSignalFunction : ComputerRuntimeBuiltInFunction
 		var pendingSignal = context.ConsumePendingSignalInput();
 		if (pendingSignal.HasValue)
 		{
+			if (!double.IsFinite(pendingSignal.Value.Value))
+			{
+				ErrorMessage = "The received signal value was not a finite number.";
+				return StatementResult.Error;
+			}
+
 			Result = new NumberVariable(Convert.ToDecimal(pendingSignal.Value.Value));
 			return StatementResult.Normal;
 		}
@@ -545,6 +565,8 @@ internal class WaitSignalFunction : ComputerRuntimeBuiltInFunction
 
 internal class LaunchProgramFunction : ComputerRuntimeBuiltInFunction
 {
+	private const int MaximumNestedLaunchDepth = 8;
+
 	public static void RegisterFunctionCompiler()
 	{
 		FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
@@ -584,10 +606,22 @@ internal class LaunchProgramFunction : ComputerRuntimeBuiltInFunction
 			return StatementResult.Normal;
 		}
 
+		if (context.LaunchDepth >= MaximumNestedLaunchDepth)
+		{
+			Result = new NumberVariable(0.0M);
+			return StatementResult.Normal;
+		}
+
 		var executable = context.Actor.Gameworld.ComputerExecutionService.GetExecutable(
 			context.Owner,
 			ParameterFunctions[0].Result?.GetObject?.ToString() ?? string.Empty);
 		if (executable is not IComputerProgramDefinition)
+		{
+			Result = new NumberVariable(0.0M);
+			return StatementResult.Normal;
+		}
+
+		if (context.Process?.Program.Id == executable.Id)
 		{
 			Result = new NumberVariable(0.0M);
 			return StatementResult.Normal;

--- a/MudSharpCore/FutureProg/Functions/Textual/TextUtilityFunctions.cs
+++ b/MudSharpCore/FutureProg/Functions/Textual/TextUtilityFunctions.cs
@@ -8,6 +8,7 @@ namespace MudSharp.FutureProg.Functions.Textual;
 
 internal class TextUtilityFunction : BuiltInFunction
 {
+	private const int MaximumGeneratedTextLength = 65536;
 	private readonly TextOperation _operation;
 	private readonly ProgVariableTypes _returnType;
 
@@ -157,8 +158,7 @@ internal class TextUtilityFunction : BuiltInFunction
 				Result = new TextVariable(Remove(source, GetInteger(1), GetInteger(2)));
 				return StatementResult.Normal;
 			case TextOperation.Repeat:
-				Result = new TextVariable(string.Concat(Enumerable.Repeat(source, Math.Max(0, GetInteger(1)))));
-				return StatementResult.Normal;
+				return ExecuteRepeat(source, Math.Max(0, GetInteger(1)));
 			case TextOperation.IsEmpty:
 				Result = new BooleanVariable(string.IsNullOrEmpty(source));
 				return StatementResult.Normal;
@@ -187,11 +187,9 @@ internal class TextUtilityFunction : BuiltInFunction
 				Result = new TextVariable(Between(source, GetText(1), GetText(2)));
 				return StatementResult.Normal;
 			case TextOperation.PadLeft:
-				Result = new TextVariable(source.PadLeft(Math.Max(0, GetInteger(1))));
-				return StatementResult.Normal;
+				return ExecutePad(source, Math.Max(0, GetInteger(1)), true);
 			case TextOperation.PadRight:
-				Result = new TextVariable(source.PadRight(Math.Max(0, GetInteger(1))));
-				return StatementResult.Normal;
+				return ExecutePad(source, Math.Max(0, GetInteger(1)), false);
 			case TextOperation.Truncate:
 				Result = new TextVariable(Left(source, GetInteger(1)));
 				return StatementResult.Normal;
@@ -225,7 +223,52 @@ internal class TextUtilityFunction : BuiltInFunction
 
 	private int GetInteger(int index)
 	{
-		return ParameterFunctions[index].Result?.GetObject is decimal value ? (int)value : 0;
+		if (ParameterFunctions[index].Result?.GetObject is not decimal value)
+		{
+			return 0;
+		}
+
+		if (value > int.MaxValue)
+		{
+			return int.MaxValue;
+		}
+
+		if (value < int.MinValue)
+		{
+			return int.MinValue;
+		}
+
+		return (int)value;
+	}
+
+	private StatementResult ExecuteRepeat(string source, int count)
+	{
+		if (count == 0 || source.Length == 0)
+		{
+			Result = new TextVariable(string.Empty);
+			return StatementResult.Normal;
+		}
+
+		if ((long)source.Length * count > MaximumGeneratedTextLength)
+		{
+			ErrorMessage = $"repeattext cannot create text longer than {MaximumGeneratedTextLength:N0} characters.";
+			return StatementResult.Error;
+		}
+
+		Result = new TextVariable(string.Concat(Enumerable.Repeat(source, count)));
+		return StatementResult.Normal;
+	}
+
+	private StatementResult ExecutePad(string source, int width, bool padLeft)
+	{
+		if (width > MaximumGeneratedTextLength)
+		{
+			ErrorMessage = $"pad text functions cannot create text longer than {MaximumGeneratedTextLength:N0} characters.";
+			return StatementResult.Error;
+		}
+
+		Result = new TextVariable(padLeft ? source.PadLeft(width) : source.PadRight(width));
+		return StatementResult.Normal;
 	}
 
 	private static string Left(string text, int count)

--- a/MudSharpCore/GameItems/Components/AutomationMountHostGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/AutomationMountHostGameItemComponent.cs
@@ -128,6 +128,11 @@ public class AutomationMountHostGameItemComponent : GameItemComponent, IAutomati
 			return false;
 		}
 
+		if (WouldCreateMountCycle(module.Parent, out error))
+		{
+			return false;
+		}
+
 		var bay = _prototype.Bays.FirstOrDefault(x => x.Name.Equals(bayName, StringComparison.InvariantCultureIgnoreCase));
 		if (bay is null)
 		{
@@ -235,8 +240,22 @@ public class AutomationMountHostGameItemComponent : GameItemComponent, IAutomati
 
 	public bool CanConnect(ICharacter? actor, IConnectable other)
 	{
-		return other is IAutomationMountable mountable &&
-		       _prototype.Bays.Any(x =>
+		if (actor is not null && !CanAccessMounts(actor, out _))
+		{
+			return false;
+		}
+
+		if (other is not IAutomationMountable mountable)
+		{
+			return false;
+		}
+
+		if (WouldCreateMountCycle(mountable.Parent, out _))
+		{
+			return false;
+		}
+
+		return _prototype.Bays.Any(x =>
 			       !_mountedByBay.ContainsKey(x.Name) &&
 			       x.MountType.Equals(mountable.MountType, StringComparison.InvariantCultureIgnoreCase)) &&
 		       other.FreeConnections.Any(x => Connections.Any(y => y.CompatibleWith(x)));
@@ -277,6 +296,16 @@ public class AutomationMountHostGameItemComponent : GameItemComponent, IAutomati
 
 	public string WhyCannotConnect(ICharacter? actor, IConnectable other)
 	{
+		if (actor is not null && !CanAccessMounts(actor, out var accessError))
+		{
+			return accessError;
+		}
+
+		if (other is IAutomationMountable mountable && WouldCreateMountCycle(mountable.Parent, out var cycleError))
+		{
+			return cycleError;
+		}
+
 		return $"{Parent.HowSeen(actor)} has no compatible free automation mount bays.";
 	}
 
@@ -458,5 +487,46 @@ public class AutomationMountHostGameItemComponent : GameItemComponent, IAutomati
 	private static ConnectorType ConnectorForBay(AutomationMountBayDefinition bay)
 	{
 		return new ConnectorType(Gender.Female, $"Automation:{bay.MountType}", false);
+	}
+
+	private bool WouldCreateMountCycle(IGameItem moduleItem, out string error)
+	{
+		if (ReferenceEquals(moduleItem, Parent))
+		{
+			error = "An automation module cannot be installed into itself.";
+			return true;
+		}
+
+		if (IsMountedOnOrInside(Parent, moduleItem) || IsMountedOnOrInside(moduleItem, Parent))
+		{
+			error = "That automation installation would create a cyclic mount.";
+			return true;
+		}
+
+		error = string.Empty;
+		return false;
+	}
+
+	private static bool IsMountedOnOrInside(IGameItem start, IGameItem target)
+	{
+		var visited = new HashSet<IGameItem>();
+		var current = start;
+		while (visited.Add(current))
+		{
+			if (ReferenceEquals(current, target))
+			{
+				return true;
+			}
+
+			var mountHost = current.GetItemType<IAutomationMountable>()?.MountHost;
+			if (mountHost is null)
+			{
+				return false;
+			}
+
+			current = mountHost.Parent;
+		}
+
+		return true;
 	}
 }

--- a/MudSharpCore/GameItems/Components/ElectronicDoorGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/ElectronicDoorGameItemComponent.cs
@@ -14,10 +14,12 @@ namespace MudSharp.GameItems.Components;
 
 public class ElectronicDoorGameItemComponent : DoorGameItemComponentBase, IRuntimeConfigurableSignalSinkComponent
 {
+	private const int MaximumMissingSourceReconnectAttempts = 5;
 	private new ElectronicDoorGameItemComponentProto _prototype;
 	private readonly LocalSignalSinkSubscription _binding;
 	private bool _desiredOpen;
 	private bool _heartbeatSubscribed;
+	private int _missingSourceReconnectAttemptsRemaining;
 	private LocalSignalBinding? _runtimeBinding;
 	private double? _runtimeActivationThreshold;
 	private bool? _runtimeActiveWhenAboveThreshold;
@@ -115,6 +117,7 @@ public class ElectronicDoorGameItemComponent : DoorGameItemComponentBase, IRunti
 	public override void Login()
 	{
 		base.Login();
+		_missingSourceReconnectAttemptsRemaining = MaximumMissingSourceReconnectAttempts;
 		ReconnectSource();
 	}
 
@@ -137,12 +140,20 @@ public class ElectronicDoorGameItemComponent : DoorGameItemComponentBase, IRunti
 		_binding.Reconnect(CurrentBinding);
 		if (_binding.UpstreamSource is not null)
 		{
+			_missingSourceReconnectAttemptsRemaining = MaximumMissingSourceReconnectAttempts;
 			RemoveHeartbeatSubscription();
 			return;
 		}
 
 		ApplySignalValue(0.0);
-		EnsureHeartbeatSubscription();
+		if (_missingSourceReconnectAttemptsRemaining-- > 0)
+		{
+			EnsureHeartbeatSubscription();
+		}
+		else
+		{
+			RemoveHeartbeatSubscription();
+		}
 	}
 
 	public void ReceiveSignal(ComputerSignal signal, ISignalSource source)
@@ -239,6 +250,7 @@ public class ElectronicDoorGameItemComponent : DoorGameItemComponentBase, IRunti
 	public bool ConfigureSignalBinding(ISignalSourceComponent source, string? endpointKey, out string error)
 	{
 		_runtimeBinding = SignalComponentUtilities.CreateBinding(source, endpointKey);
+		_missingSourceReconnectAttemptsRemaining = MaximumMissingSourceReconnectAttempts;
 		Changed = true;
 		ReconnectSource();
 		error = string.Empty;
@@ -248,6 +260,7 @@ public class ElectronicDoorGameItemComponent : DoorGameItemComponentBase, IRunti
 	public void ClearSignalBinding()
 	{
 		_runtimeBinding = null;
+		_missingSourceReconnectAttemptsRemaining = MaximumMissingSourceReconnectAttempts;
 		Changed = true;
 		ReconnectSource();
 	}

--- a/MudSharpCore/GameItems/Components/ElectronicLockGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/ElectronicLockGameItemComponent.cs
@@ -106,7 +106,8 @@ public class ElectronicLockGameItemComponent : ProgLockGameItemComponent, IRunti
 			return;
 		}
 
-		ApplySignalValue(0.0);
+		CurrentValue = 0.0;
+		SetLocked(true, true);
 	}
 
 	public void ReceiveSignal(ComputerSignal signal, ISignalSource source)

--- a/MudSharpCore/GameItems/Components/KeypadGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/KeypadGameItemComponent.cs
@@ -17,8 +17,12 @@ namespace MudSharp.GameItems.Components;
 
 public class KeypadGameItemComponent : PoweredMachineBaseGameItemComponent, ISelectable, ISignalSourceComponent
 {
+	private const int MaximumFailedAttemptsBeforeLockout = 5;
+	private static readonly TimeSpan FailedAttemptLockoutDuration = TimeSpan.FromSeconds(30);
 	private KeypadGameItemComponentProto _prototype;
 	private DateTime? _activeUntil;
+	private DateTime? _lockedUntil;
+	private int _failedAttempts;
 	private bool _heartbeatSubscribed;
 	private ComputerSignal _currentSignal;
 
@@ -181,12 +185,34 @@ public class KeypadGameItemComponent : PoweredMachineBaseGameItemComponent, ISel
 					flags: OutputFlags.SuppressObscured).Append(playerEmote));
 		}
 
+		if (_lockedUntil is not null && _lockedUntil > DateTime.UtcNow)
+		{
+			character.Send("The keypad refuses further entries for a short time.");
+			return false;
+		}
+
+		if (_lockedUntil is not null)
+		{
+			_lockedUntil = null;
+			_failedAttempts = 0;
+		}
+
 		if (!argument.Trim().Equals(_prototype.Code, StringComparison.InvariantCulture))
 		{
+			_failedAttempts++;
+			if (_failedAttempts >= MaximumFailedAttemptsBeforeLockout)
+			{
+				_failedAttempts = 0;
+				_lockedUntil = DateTime.UtcNow + FailedAttemptLockoutDuration;
+				EnsureHeartbeatSubscription();
+			}
+
 			character.Send("Nothing happens.");
 			return false;
 		}
 
+		_failedAttempts = 0;
+		_lockedUntil = null;
 		_activeUntil = DateTime.UtcNow + _prototype.SignalDuration;
 		EnsureHeartbeatSubscription();
 		RefreshSignalState(true);
@@ -201,13 +227,27 @@ public class KeypadGameItemComponent : PoweredMachineBaseGameItemComponent, ISel
 
 	private void HeartbeatTick()
 	{
-		if (_activeUntil is null || _activeUntil > DateTime.UtcNow)
+		if ((_activeUntil is null || _activeUntil > DateTime.UtcNow) &&
+		    (_lockedUntil is null || _lockedUntil > DateTime.UtcNow))
 		{
 			return;
 		}
 
-		_activeUntil = null;
-		RemoveHeartbeatSubscription();
+		if (_activeUntil is not null && _activeUntil <= DateTime.UtcNow)
+		{
+			_activeUntil = null;
+		}
+
+		if (_lockedUntil is not null && _lockedUntil <= DateTime.UtcNow)
+		{
+			_lockedUntil = null;
+		}
+
+		if (_activeUntil is null && _lockedUntil is null)
+		{
+			RemoveHeartbeatSubscription();
+		}
+
 		RefreshSignalState(true);
 	}
 

--- a/MudSharpCore/GameItems/Components/MicrocontrollerGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/MicrocontrollerGameItemComponent.cs
@@ -31,6 +31,7 @@ public class MicrocontrollerGameItemComponent : PoweredMachineBaseGameItemCompon
 	private string _compileError = string.Empty;
 	private IConnectable? _mountedHost;
 	private long? _pendingMountedHostId;
+	private bool _propagatingSignal;
 
 	public MicrocontrollerGameItemComponent(MicrocontrollerGameItemComponentProto proto, IGameItem parent,
 		bool temporary = false)
@@ -233,6 +234,11 @@ public class MicrocontrollerGameItemComponent : PoweredMachineBaseGameItemCompon
 
 	private void HandleSourceSignalChanged(ISignalSourceComponent source, ComputerSignal signal)
 	{
+		if (_propagatingSignal || !double.IsFinite(signal.Value))
+		{
+			return;
+		}
+
 		foreach (var item in _inputSources.Where(x => ReferenceEquals(x.Value, source)).ToList())
 		{
 			_inputValues[item.Key] = signal.Value;
@@ -254,6 +260,12 @@ public class MicrocontrollerGameItemComponent : PoweredMachineBaseGameItemCompon
 			.ToArray();
 
 		var result = (double)_compiledLogic.ExecuteDecimal(0.0M, arguments);
+		if (!double.IsFinite(result))
+		{
+			SetOutput(default);
+			return;
+		}
+
 		SetOutput(new ComputerSignal(result, null, null));
 	}
 
@@ -357,7 +369,15 @@ public class MicrocontrollerGameItemComponent : PoweredMachineBaseGameItemCompon
 		}
 
 		_currentSignal = signal;
-		SignalChanged?.Invoke(this, _currentSignal);
+		_propagatingSignal = true;
+		try
+		{
+			SignalChanged?.Invoke(this, _currentSignal);
+		}
+		finally
+		{
+			_propagatingSignal = false;
+		}
 	}
 
 	public override bool Take(IGameItem item)

--- a/MudSharpCore/GameItems/Components/NetworkSwitchGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/NetworkSwitchGameItemComponent.cs
@@ -381,6 +381,16 @@ public class NetworkSwitchGameItemComponent : PoweredMachineBaseGameItemComponen
 
 	private void NotifyConnectedAdaptersTopologyChanged()
 	{
+		NotifyConnectedAdaptersTopologyChanged(new HashSet<NetworkSwitchGameItemComponent>());
+	}
+
+	private void NotifyConnectedAdaptersTopologyChanged(HashSet<NetworkSwitchGameItemComponent> visitedSwitches)
+	{
+		if (!visitedSwitches.Add(this))
+		{
+			return;
+		}
+
 		foreach (var adapter in _connectedItems
 			         .Select(x => x.Item2)
 			         .OfType<NetworkAdapterGameItemComponent>()
@@ -394,7 +404,7 @@ public class NetworkSwitchGameItemComponent : PoweredMachineBaseGameItemComponen
 			         .OfType<NetworkSwitchGameItemComponent>()
 			         .ToList())
 		{
-			switchItem.NotifyConnectedAdaptersTopologyChanged();
+			switchItem.NotifyConnectedAdaptersTopologyChanged(visitedSwitches);
 		}
 	}
 

--- a/MudSharpCore/GameItems/Components/PoweredMachineBaseGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/PoweredMachineBaseGameItemComponent.cs
@@ -73,7 +73,9 @@ public abstract class PoweredMachineBaseGameItemComponent : GameItemComponent, I
 
 	protected virtual void LoadFromXml(XElement root)
 	{
-		_switchedOn = bool.Parse(root.Element("SwitchedOn").Value);
+		_switchedOn = bool.TryParse(root.Element("SwitchedOn")?.Value, out var switchedOn)
+			? switchedOn
+			: !_prototype.Switchable;
 	}
 
 	public override void FinaliseLoad()

--- a/MudSharpCore/GameItems/Prototypes/KeypadGameItemComponentProto.cs
+++ b/MudSharpCore/GameItems/Prototypes/KeypadGameItemComponentProto.cs
@@ -33,7 +33,7 @@ public class KeypadGameItemComponentProto : PoweredMachineBaseGameItemComponentP
 	{
 		UseMountHostPowerSource = true;
 		Wattage = 35.0;
-		Code = "1234";
+		Code = string.Empty;
 		SignalValue = 1.0;
 		SignalDuration = TimeSpan.FromSeconds(1);
 		EntryEmote = "@ tap|taps digits into $1";
@@ -61,9 +61,17 @@ public class KeypadGameItemComponentProto : PoweredMachineBaseGameItemComponentP
 	protected override void LoadFromXml(XElement root)
 	{
 		base.LoadFromXml(root);
-		Code = root.Element("Code")?.Value ?? "1234";
-		SignalValue = double.Parse(root.Element("SignalValue")?.Value ?? "1.0");
-		SignalDuration = TimeSpan.FromSeconds(double.Parse(root.Element("SignalDurationSeconds")?.Value ?? "1.0"));
+		Code = root.Element("Code")?.Value ?? string.Empty;
+		SignalValue = double.TryParse(root.Element("SignalValue")?.Value, out var signalValue) && double.IsFinite(signalValue)
+			? signalValue
+			: 1.0;
+		SignalDuration = TimeSpan.FromSeconds(
+			double.TryParse(root.Element("SignalDurationSeconds")?.Value, out var duration) &&
+			double.IsFinite(duration) &&
+			duration > 0.0 &&
+			duration <= TimeSpan.MaxValue.TotalSeconds
+				? duration
+				: 1.0);
 		EntryEmote = root.Element("EntryEmote")?.Value ?? "@ tap|taps digits into $1";
 	}
 
@@ -127,7 +135,7 @@ public class KeypadGameItemComponentProto : PoweredMachineBaseGameItemComponentP
 			return false;
 		}
 
-		if (!double.TryParse(command.SafeRemainingArgument, out var value))
+		if (!double.TryParse(command.SafeRemainingArgument, out var value) || !double.IsFinite(value))
 		{
 			actor.Send("You must enter a valid number for the signal value.");
 			return false;
@@ -148,7 +156,10 @@ public class KeypadGameItemComponentProto : PoweredMachineBaseGameItemComponentP
 			return false;
 		}
 
-		if (!double.TryParse(command.SafeRemainingArgument, out var value) || value <= 0.0)
+		if (!double.TryParse(command.SafeRemainingArgument, out var value) ||
+		    !double.IsFinite(value) ||
+		    value <= 0.0 ||
+		    value > TimeSpan.MaxValue.TotalSeconds)
 		{
 			actor.Send("You must enter a positive number of seconds.");
 			return false;

--- a/MudSharpCore/GameItems/Prototypes/TimerSensorGameItemComponentProto.cs
+++ b/MudSharpCore/GameItems/Prototypes/TimerSensorGameItemComponentProto.cs
@@ -61,11 +61,20 @@ public class TimerSensorGameItemComponentProto : PoweredMachineBaseGameItemCompo
 	protected override void LoadFromXml(XElement root)
 	{
 		base.LoadFromXml(root);
-		ActiveValue = double.Parse(root.Element("ActiveValue")?.Value ?? "1.0");
-		InactiveValue = double.Parse(root.Element("InactiveValue")?.Value ?? "0.0");
-		ActiveDuration = TimeSpan.FromSeconds(double.Parse(root.Element("ActiveDurationSeconds")?.Value ?? "5.0"));
-		InactiveDuration =
-			TimeSpan.FromSeconds(double.Parse(root.Element("InactiveDurationSeconds")?.Value ?? "55.0"));
+		ActiveValue = TryParseFiniteDouble(root.Element("ActiveValue")?.Value ?? string.Empty, out var activeValue)
+			? activeValue
+			: 1.0;
+		InactiveValue = TryParseFiniteDouble(root.Element("InactiveValue")?.Value ?? string.Empty, out var inactiveValue)
+			? inactiveValue
+			: 0.0;
+		ActiveDuration = TimeSpan.FromSeconds(
+			TryParsePositiveDuration(root.Element("ActiveDurationSeconds")?.Value ?? string.Empty, out var activeDuration)
+				? activeDuration
+				: 5.0);
+		InactiveDuration = TimeSpan.FromSeconds(
+			TryParsePositiveDuration(root.Element("InactiveDurationSeconds")?.Value ?? string.Empty, out var inactiveDuration)
+				? inactiveDuration
+				: 55.0);
 		StartActive = bool.Parse(root.Element("StartActive")?.Value ?? "false");
 	}
 
@@ -113,7 +122,7 @@ public class TimerSensorGameItemComponentProto : PoweredMachineBaseGameItemCompo
 			return false;
 		}
 
-		if (!double.TryParse(command.SafeRemainingArgument, out var value))
+		if (!TryParseFiniteDouble(command.SafeRemainingArgument, out var value))
 		{
 			actor.Send("You must enter a valid number for the active signal value.");
 			return false;
@@ -134,7 +143,7 @@ public class TimerSensorGameItemComponentProto : PoweredMachineBaseGameItemCompo
 			return false;
 		}
 
-		if (!double.TryParse(command.SafeRemainingArgument, out var value))
+		if (!TryParseFiniteDouble(command.SafeRemainingArgument, out var value))
 		{
 			actor.Send("You must enter a valid number for the inactive signal value.");
 			return false;
@@ -155,7 +164,7 @@ public class TimerSensorGameItemComponentProto : PoweredMachineBaseGameItemCompo
 			return false;
 		}
 
-		if (!double.TryParse(command.SafeRemainingArgument, out var value) || value <= 0.0)
+		if (!TryParsePositiveDuration(command.SafeRemainingArgument, out var value))
 		{
 			actor.Send("You must enter a positive number of seconds.");
 			return false;
@@ -176,7 +185,7 @@ public class TimerSensorGameItemComponentProto : PoweredMachineBaseGameItemCompo
 			return false;
 		}
 
-		if (!double.TryParse(command.SafeRemainingArgument, out var value) || value <= 0.0)
+		if (!TryParsePositiveDuration(command.SafeRemainingArgument, out var value))
 		{
 			actor.Send("You must enter a positive number of seconds.");
 			return false;
@@ -216,6 +225,18 @@ public class TimerSensorGameItemComponentProto : PoweredMachineBaseGameItemCompo
 		actor.Send(
 			$"This timer sensor will now begin in its {(StartActive ? "active".ColourValue() : "inactive".ColourName())} phase.");
 		return true;
+	}
+
+	private static bool TryParseFiniteDouble(string text, out double value)
+	{
+		return double.TryParse(text, out value) && double.IsFinite(value);
+	}
+
+	private static bool TryParsePositiveDuration(string text, out double value)
+	{
+		return TryParseFiniteDouble(text, out value) &&
+		       value > 0.0 &&
+		       value <= TimeSpan.MaxValue.TotalSeconds;
 	}
 
 	public override bool CanSubmit()


### PR DESCRIPTION
## Summary
- Remediates the Codex security triage group `Computers, Automation & Electronics`.
- Adds invariant-level bounds and authorization checks across computer programs, file/mail transfer paths, FTP/board access, signal propagation, diagnostics, keypad/lock handling, and automation mounts.
- Adds targeted regression coverage for computer workspace/runtime and signal automation surfaces.

## Validation
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 --filter "FullyQualifiedName~ComputerWorkspaceRuntimeTests|FullyQualifiedName~SignalAutomationTests" -p:NoWarn=NU1902%3BNU1510` -> passed 104/104
- `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510` -> passed, 0 warnings/errors
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510` -> passed 1121/1121
- `git diff --check` -> passed; CRLF conversion warnings only during staging