### PR TITLE
Remediate magic security findings

### DIFF
--- a/Design Documents/Characters/Multiple_Body_Form_System.md
+++ b/Design Documents/Characters/Multiple_Body_Form_System.md
@@ -207,6 +207,8 @@ Transformation echoes are per-form metadata:
 
 The default static string is currently `@ transform|transforms into ^1.`, where `^1` is the new body in the emote context rendered with the emote system's non-self token so the transforming player sees their own new short description instead of `you`.
 
+Custom transformation echoes are sanitised when they are loaded, edited, or emitted. This preserves ordinary emote syntax while preventing literal brace characters in persisted or builder-supplied text from breaking the emote parser during a body switch.
+
 ### Player Command Surface
 
 The player-facing command is intentionally small:
@@ -264,6 +266,8 @@ Auto-transforming merits are the current racial or intrinsic transformation path
 The `transformform` spell effect is implemented by [TransformFormEffect.cs](../../MudSharpCore/Magic/SpellEffects/TransformFormEffect.cs) and its active runtime effect [SpellTransformFormEffect.cs](../../MudSharpCore/Effects/Concrete/SpellEffects/SpellTransformFormEffect.cs).
 
 The spell effect ensures or reuses a keyed form and contributes a forced transformation demand while the spell effect applies. The spell stores the prior body id so it can revert after expiry or save/load. If the prior body is unavailable or cannot be switched into, the resolver attempts another valid owned form. If no fallback works, the character remains in the current form and staff-facing diagnostics are emitted rather than deleting the cached form.
+
+When a spell transform effect is removed, the forced-transformation resolver excludes the effect currently being removed from its active-demand scan. This matters because effect removal callbacks run before the effect has disappeared from the character's effect list; excluding the removing effect prevents expired spell transforms from keeping their forced form alive until a later reevaluation.
 
 Spell builders can configure the same first-creation form metadata as merits, plus a stable `FormKey`, priority band, and priority offset. Repeated casts of the same spell and key reuse the same body.
 

--- a/Design Documents/Magic/Magic_System_Implemented_Types.md
+++ b/Design Documents/Magic/Magic_System_Implemented_Types.md
@@ -51,13 +51,13 @@ It is intended for:
 | `spellremainingduration`, `spellduration`, `setspellduration`, `addspellduration`, `subtractspellduration`, `removespell` | Spell effects | Reads, changes, or removes active spell-parent effects for a specific spell on a character |
 
 ## Power Types
-Current count: 32 power tokens, including 31 builder-creatable tokens and the non-builder `armor` runtime alias. V4 added 9 builder-creatable psionic powers, and the Old SOI parity slice added 7 more psionic power tokens in per-power files under `MudSharpCore/Magic/Powers/`. V5b adds residual trace support to existing psionic powers without changing this token count.
+Current count: 32 documented power tokens, including 31 builder-creatable tokens and the non-builder `armor` runtime alias. Compatibility display-name and case aliases are not counted as distinct builder tokens. V4 added 9 builder-creatable psionic powers, and the Old SOI parity slice added 7 more psionic power tokens in per-power files under `MudSharpCore/Magic/Powers/`. V5b adds residual trace support to existing psionic powers without changing this token count.
 
 | Builder/runtime token | Class | Subsystem | Where registered or dispatched | Builder-creatable | Purpose |
 | --- | --- | --- | --- | --- | --- |
 | `armour` | `MagicArmourPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/MagicArmourPower.cs` via `MagicPowerFactory` | Yes | Applies magical armour behavior |
 | `armor` | `MagicArmourPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/MagicArmourPower.cs` via `MagicPowerFactory` | No | Runtime compatibility alias for the armour power model |
-| `anesthesia` | `MindAnesthesiaPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/MindAnesthesiaPower.cs` via `MagicPowerFactory` | Yes | Applies mental anesthesia behavior |
+| `anesthesia` builder / `mindanesthesia` database | `MindAnesthesiaPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/MindAnesthesiaPower.cs` via `MagicPowerFactory` | Yes | Applies mental anesthesia behavior |
 | `allspeak` | `AllspeakPower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/AllspeakPower.cs` via `MagicPowerFactory` | Yes | Sustains spoken-language comprehension without adding permanent language knowledge or literacy |
 | `babble` | `BabblePower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/BabblePower.cs` via `MagicPowerFactory` | Yes | Applies hostile timed speech obfuscation before language comprehension can decode speech |
 | `choke` | `ChokePower` | Power | Static `RegisterLoader` in `MudSharpCore/Magic/Powers/ChokePower.cs` via `MagicPowerFactory` | Yes | Applies choking or constriction behavior |
@@ -90,6 +90,8 @@ Current count: 32 power tokens, including 31 builder-creatable tokens and the no
 | n/a | `MagicPowerBase` | Power support | Shared base in `MudSharpCore/Magic/Powers/MagicPowerBase.cs` | No | Shared costs, progs, help text, crime handling, builder support, and base psionic trace configuration |
 | n/a | `SustainedMagicPower` | Power support | Shared base in `MudSharpCore/Magic/Powers/SustainedMagicPower.cs` | No | Shared support for sustained powers |
 | n/a | `MagicalMeleeAttackPower` | Power support | Shared base in `MudSharpCore/Magic/Powers/MagicalMeleeAttackPower.cs` | No | Shared support base for melee-style magical attacks |
+
+Compatibility load aliases are registered for older persisted rows and display-name saves, including `Armor`, `Armour`, `Magic Attack`, `Connect Mind`, and `Invisibility`. New seeded rows should prefer each class's canonical `DatabaseType`.
 
 ## Spell Trigger Types
 

--- a/Design Documents/Magic/Magic_System_Powers.md
+++ b/Design Documents/Magic/Magic_System_Powers.md
@@ -108,6 +108,14 @@ The persisted model stores:
 - a `PowerModel` token
 - subtype XML in `Definition`
 
+Power load invariants:
+
+- `DatabaseType` is the authoritative persisted `PowerModel` token for new rows.
+- Builder tokens and display names may differ from the database token, but load aliases should be registered for older display-name or spelling variants that may already exist in world data.
+- `Definition` XML must round-trip every required subtype field. Loaders should tolerate legacy element names where that can be done unambiguously, but new saves should emit the canonical element names.
+- Builder-controlled numeric settings must reject non-finite values and enforce a practical upper bound before persistence.
+- Player-authored or externally supplied text that is embedded into runtime emotes must be sanitised before it reaches the emote parser.
+
 ## Builder Workflow
 ### Entry point
 The builder entry point is `magic power`.
@@ -162,6 +170,7 @@ Current seeder implications:
 - the school must already exist
 - any referenced resources, progs, and other content must already exist
 - the `PowerModel` token and `Definition` XML must match the concrete runtime class
+- persisted `PowerModel` values should use the canonical `DatabaseType`; aliases exist for backwards compatibility, not as preferred seed data
 
 Recommended manual data order:
 
@@ -242,6 +251,7 @@ These are the currently builder-creatable power tokens registered through `Magic
 Important current-state note:
 
 - `MagicArmourPower` also registers a runtime load alias of `armor` in addition to the builder-facing `armour` token. That alias matters to developers and seeder authors working with persisted `PowerModel` values, but it is not exposed as a distinct builder creation type.
+- Several power classes also register legacy display-name aliases such as `Magic Attack`, `Connect Mind`, `Invisibility`, and `mindanesthesia` so older rows can still load. New rows should still use the lower-case database tokens.
 
 ### Psionic identity and passive traffic
 The mind-link stack now shares a first-class concealment policy through `IMindContactConcealmentEffect`.
@@ -255,6 +265,8 @@ The mind-link stack now shares a first-class concealment policy through `IMindCo
 
 Passive psionic traffic can use either the existing `telepathy` flow or the dedicated V4 `hear` power, depending on whether the content wants ordinary telepathic communication or a sustained listener. Configure `telepathy` with `thinks`, `feels`, and `thinkemote` to represent broad passive links such as Thoughtsense or Immersion. When the thinker is sustaining `mindconceal`, passive `think` and `feel` traffic uses the concealed identity instead of leaking the actor's short description or personal name.
 
+`mindbroadcast` persists its range as `PowerDistance`; loaders also accept the older `Distance` element. Broadcast text is sanitised before it is embedded into the internal emote used for psychic speech delivery.
+
 V4 adds a shared psionic traffic/coercion helper used by `projectemotion`, `suggest`, and `coerce`. It handles involuntary mental delivery, eligible listener forwarding, opt-out/refusal checks, consistent source/target messaging, and wiz-audit output. `coerce` supports stamina, hunger, thirst, and thought modes; it does not run the victim's command parser.
 
 V5b adds timed residual psionic traces. `PsionicActivityNotifier` still broadcasts activity pings to `sensitivity`, and now also creates saveable `PsionicTrace` effects for powers with tracing enabled. Traces are placed on the source, involved targets, and the source cell where useful, using ordinary `EffectData` persistence and timed expiry rather than a permanent audit ledger. The trace facts include source, optional target, source cell, school, power, activity kind, created time, duration, read difficulty, and fallback identity text for unreadable sources.
@@ -262,6 +274,8 @@ V5b adds timed residual psionic traces. `PsionicActivityNotifier` still broadcas
 `trace <target>` reports active mind links first. It then reports residual traces if any exist, including cases where the active link has ended or where both live links and residual evidence are present. Residual trace identity checks re-evaluate `mindconceal` against the current trace reader, so observer-specific concealment progs still decide whether that reader sees the source or the configured unknown identity text.
 
 This is intentionally separate from true projection or possession. `mindconceal` hides identity across mind-contact and passive telepathy surfaces; `clairaudience` forwards remote audible output through another mind's location; neither creates a second acting body or remote command shell.
+
+`clairvoyance` uses `RemoteLookRenderer` to render a normal LOOK-style view from the target's current location without moving the caster. The renderer respects ordinary visibility and darkness checks; clairvoyance should not grant implicit `IgnoreCanSee` or `IgnoreDark` perception.
 
 The Old SOI parity slice adds seven builder-created psionic powers. `dangersense` and `sensitivity` are sustained self powers; `empathy`, `hex`, `clairvoyance`, and `psychicbolt` are targeted powers; `prescience` is a board-submission power. They reuse the shared power XML, cost, psionic-crime, and builder-command systems, with subtype XML for Old SOI-style defaults and FutureMUD-specific extensions such as wound remapping, configurable check categories, activity filters, and capability-read difficulty.
 

--- a/Design Documents/Magic/Magic_System_Spells.md
+++ b/Design Documents/Magic/Magic_System_Spells.md
@@ -134,6 +134,7 @@ Current behavior is:
 - `reflect` wards only retarget ordinary `character` spells back at the caster
 - non-character-targeted invokes downgrade `reflect` to `fail`
 - self-targeted character casts do not reflect back onto the same caster; they also downgrade to `fail`
+- a blocked or resisted target aborts that invoke before caster-side spell effects are applied
 
 ### 9. Resist check
 If a resisting target beats the caster's result, the target-resisted emote is shown and the spell does not apply to that target.
@@ -332,7 +333,7 @@ Key runtime semantics:
 - `paralysis` uses the forced-paralysis health hook.
 - `flying` extends the normal flight checks without forcing a flying position state.
 - `waterbreathing` extends breathing logic by granting additional breathable fluids.
-- `poison` and `disease` create spell-owned payloads with origin metadata, and the matching removal effects only clear matching payloads created by those spell effects.
+- `poison` and `disease` create spell-owned payloads with origin metadata, and the matching removal effects only clear matching payloads created by those spell effects. Poison cleanup also recognises matching legacy originless saved payloads so older rows can be repaired without removing unrelated active poisons.
 - `detectmagick`, `detectinvisible`, `detectethereal`, and `infravision` rely on additive `IEffect.PerceptionGranting` support rather than replacing a target's base perception flags.
 - `detectmagick` also exposes active magical auras from ordinary character, item, and room description flows whenever the perceiver can sense magic.
 - `comprehendlanguage` bypasses language comprehension checks, but not illiteracy or unknown-script gating.
@@ -343,6 +344,12 @@ Other Phase 1 primitives:
 - `magicresourcedelta` works against any `IHaveMagicResource` target and relies on the holder's normal clamping rules.
 - `spellarmour` reuses the shared `MagicArmourConfiguration` model so spell armour and power armour stay in sync.
 - `roomflag` / `removeroomflag` is the early room-state primitive for `peaceful`, `nodream`, `alarm`, `darkness`, and `wardtag`.
+
+Persistence and numeric-safety invariants for current primitives:
+
+- XML loaders for builder-authored effects must tolerate legacy element names where that is unambiguous, while new saves should emit one canonical shape. For example, `createliquid` now saves `LiquidId` and still loads older `Liquid` rows.
+- Builder-controlled effect parameters that later feed `TimeSpan`, movement loops, need deltas, or weather/lifecycle state must reject `NaN`, infinity, and impractically large values before persistence. Loaders clamp legacy rows into bounded defaults instead of letting malformed data crash the game loop.
+- `telepathy` spell effects apply to the spell caster as the listener for the intended target only; they do not become global passive listeners when no applicability prog is present.
 
 ### Wind movement and fall-control primitives
 The Wind parity slice adds first-class movement and fall-control effects rather than modelling them as generic tags.
@@ -361,6 +368,7 @@ Key runtime semantics:
 - `featherfall` applies configurable fall-distance and fall-damage multipliers. It mitigates impact harm while leaving normal descent and fall exits intact.
 - `removeinvisibility` removes only `SpellInvisibilityEffect` child effects from the target. `dispelinvisibility` is a builder/load alias that saves as `removeinvisibility`.
 - `forcedpathmovement` uses a `characterexit` trigger's `exit` parameter, validates each exit with the normal movement and crossing checks, and can force a target through one or more same-direction exits. `handsofwind` is a builder/load alias that saves as `forcedpathmovement`.
+- `forcedpathmovement` caps repeated same-direction movement at a small bounded step count so player-triggered wind spells cannot monopolise the command loop.
 - `transference` swaps the caster and target character locations, optionally including followers, dragged targets, riders, and room-layer swapping.
 - Magical flight expiry now calls the flight-continuation check instead of the start-flight check, so a target only drops when no remaining spell, immwalk, or physical flight source can sustain them.
 - `dispelmagic effect invisibility|flight|levitation|featherfall` can target these Wind statuses through the general dispel flow.
@@ -395,6 +403,7 @@ Important builder implications:
 - overlapping forced sources are resolved centrally in this default order: merit or intrinsic, drug or chemical, spell or power, admin forced
 - if no explicit short or full description pattern is supplied, the runtime tries to pick a random valid pattern for the target form and only falls back to generic text when no valid pattern exists
 - switching emits the form's configured transformation echo after the new body has been stabilised; `default` uses the `DefaultFormTransformationEcho` static string and a blank echo suppresses the emote entirely
+- custom transformation echoes are sanitised before being stored or emitted so brace characters cannot break emote parsing
 - switch activation intentionally delays normal health and consequence feedback until organ functions and positioning have been recalculated, preventing transient `can't breathe` or `tumble to the ground` noise during valid transformations
 
 The `transformform` builder effect currently supports:
@@ -453,6 +462,10 @@ The persistent sensory/combat slice adds:
 - `burning` / `ignite`: spell-owned recurring burning for characters or items, with configurable per-tick damage, pain, stun, thermal load, oxidation requirement, and visible addenda.
 - `trackmark` / `tracktrail`: spell-owned track intensity modification for characters, with visual/olfactory multipliers or bonuses and optional magically-marked track circumstances.
 - `dispelmagic effect burning` and `dispelmagic effect trackmark` for targeted cleanup.
+
+Burning and need-delta effects share the spell numeric-safety invariant: persisted non-finite values fall back to safe defaults, large finite values are clamped to bounded maxima, and builders reject unsafe values before saving.
+
+Weather-freeze effects own the freeze counter they acquire. Immediate freezes and "next transition" freezes both clean up through the same active effect, so expiry or removal unfreezes owned weather state or unsubscribes a pending transition listener.
 
 Simple portals remain saved spell effects, not database exits. The `portal` effect creates paired transient exits registered with `IExitManager`; active magical portals expose `IMagicPortalExit` metadata and can be inspected with `magic portals`. Anchor tags can be placed on rooms or items/objects with `magictag`; `portal` resolves caster-owned room anchors first, then caster-owned item anchors by using the item location. If more than one caster-owned anchor matches the configured tag/value, the lowest-ID matching room or item is selected deterministically instead of treating duplicate anchors as a runtime error. Builders can inspect active anchors with `magic anchors [tag]`.
 

--- a/MudSharpCore Unit Tests/MagicEngineV3Tests.cs
+++ b/MudSharpCore Unit Tests/MagicEngineV3Tests.cs
@@ -20,6 +20,7 @@ using MudSharp.PerceptionEngine;
 using MudSharp.RPG.Checks;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 
@@ -91,6 +92,141 @@ public class MagicEngineV3Tests
 		var saved = dispel.SaveToXml();
 		Assert.AreEqual(bool.TrueString.ToLowerInvariant(), saved.Element("Contest")?.Value.ToLowerInvariant());
 		Assert.AreEqual("3", saved.Element("ContestBonus")?.Value);
+	}
+
+	[TestMethod]
+	public void MagicSecurity_CreateLiquidEffect_RoundTripsLoadableLiquidIdXml()
+	{
+		var spell = CreateSpellMock();
+		var effect = SpellEffectFactory.LoadEffect(new XElement("Effect",
+			new XAttribute("type", "createliquid"),
+			new XElement("LiquidId", 123L),
+			new XElement("AmountFormula", new XCData("power + outcome"))), spell.Object);
+
+		var saved = effect.SaveToXml();
+
+		Assert.AreEqual("123", saved.Element("LiquidId")?.Value);
+		Assert.IsNull(saved.Element("Liquid"));
+
+		var legacy = SpellEffectFactory.LoadEffect(new XElement("Effect",
+			new XAttribute("type", "createliquid"),
+			new XElement("Liquid", 456L),
+			new XElement("AmountFormula", new XCData("power"))), spell.Object);
+
+		Assert.AreEqual("456", legacy.SaveToXml().Element("LiquidId")?.Value);
+	}
+
+	[TestMethod]
+	public void MagicSecurity_LoadedSpellEffects_ClampUnsafePersistedNumericValues()
+	{
+		var spell = CreateSpellMock();
+
+		var burning = SpellEffectFactory.LoadEffect(new XElement("Effect",
+			new XAttribute("type", "burning"),
+			new XElement("TickSeconds", double.NaN),
+			new XElement("MinimumOxidation", double.NaN)), spell.Object);
+		var burningXml = burning.SaveToXml();
+		Assert.AreEqual("10", burningXml.Element("TickSeconds")?.Value);
+		Assert.AreEqual("0.1", burningXml.Element("MinimumOxidation")?.Value);
+
+		var forcedMovement = SpellEffectFactory.LoadEffect(new XElement("Effect",
+			new XAttribute("type", "forcedpathmovement"),
+			new XElement("Steps", int.MaxValue),
+			new XElement("AllowFallExits", false)), spell.Object);
+		Assert.AreEqual(MagicBuilderValidation.MaximumForcedPathMovementSteps.ToString(),
+			forcedMovement.SaveToXml().Element("Steps")?.Value);
+
+		var needDelta = SpellEffectFactory.LoadEffect(new XElement("Effect",
+			new XAttribute("type", "needdelta"),
+			new XElement("Hunger", double.NaN),
+			new XElement("Thirst", 1E300),
+			new XElement("Drunk", double.PositiveInfinity)), spell.Object);
+		var needXml = needDelta.SaveToXml();
+		Assert.AreEqual("0", needXml.Element("Hunger")?.Value);
+		Assert.AreEqual(MagicBuilderValidation.MaximumNeedDeltaHours.ToString(), needXml.Element("Thirst")?.Value);
+		Assert.AreEqual("0", needXml.Element("Drunk")?.Value);
+	}
+
+	[TestMethod]
+	public void MagicSecurity_MagicPowerSerializers_PersistLoadableXmlAndAliases()
+	{
+		var attackSource = File.ReadAllText(GetSourcePath("MudSharpCore", "Magic", "Powers", "MagicAttackPower.cs"));
+		StringAssert.Contains(attackSource, "public override string DatabaseType => \"magicattack\";");
+		StringAssert.Contains(attackSource, "RegisterLoader(\"Magic Attack\"");
+
+		var connectSource = File.ReadAllText(GetSourcePath("MudSharpCore", "Magic", "Powers", "ConnectMindPower.cs"));
+		StringAssert.Contains(connectSource, "public override string DatabaseType => \"connectmind\";");
+		StringAssert.Contains(connectSource, "RegisterLoader(\"Connect Mind\"");
+
+		var invisibilitySource = File.ReadAllText(GetSourcePath("MudSharpCore", "Magic", "Powers", "InvisibilityPower.cs"));
+		StringAssert.Contains(invisibilitySource, "public override string DatabaseType => \"invisibility\";");
+		StringAssert.Contains(invisibilitySource, "RegisterLoader(\"Invisibility\"");
+		StringAssert.Contains(invisibilitySource, "new XElement(\"StartPowerVerb\", BeginVerb)");
+		StringAssert.Contains(invisibilitySource, "new XElement(\"EndPowerVerb\", EndVerb)");
+		StringAssert.Contains(invisibilitySource, "new XElement(\"MinimumSuccessThreshold\", (int)MinimumSuccessThreshold)");
+		StringAssert.Contains(invisibilitySource, "root.Element(\"StartPowerVerb\") ?? root.Element(\"ConnectVerb\")");
+
+		var armourSource = File.ReadAllText(GetSourcePath("MudSharpCore", "Magic", "Powers", "MagicArmourPower.cs"));
+		StringAssert.Contains(armourSource, "public override string DatabaseType => \"armour\";");
+		StringAssert.Contains(armourSource, "RegisterLoader(\"Armour\"");
+		StringAssert.Contains(armourSource, "new XElement(\"MinimumSuccessThreshold\", (int)MinimumSuccessThreshold)");
+
+		var anesthesiaSource = File.ReadAllText(GetSourcePath("MudSharpCore", "Magic", "Powers", "MindAnesthesiaPower.cs"));
+		StringAssert.Contains(anesthesiaSource, "public override string DatabaseType => \"mindanesthesia\";");
+		StringAssert.Contains(anesthesiaSource, "RegisterLoader(\"mindanesthesia\"");
+		StringAssert.Contains(anesthesiaSource, "TryParseFiniteDouble(command.SafeRemainingArgument");
+		StringAssert.Contains(anesthesiaSource, "MaximumResistanceIntervalSeconds");
+
+		var broadcastSource = File.ReadAllText(GetSourcePath("MudSharpCore", "Magic", "Powers", "MindBroadcastPower.cs"));
+		StringAssert.Contains(broadcastSource, "new XElement(\"PowerDistance\", (int)PowerDistance)");
+		StringAssert.Contains(broadcastSource, "root.Element(\"PowerDistance\") ?? root.Element(\"Distance\")");
+		StringAssert.Contains(broadcastSource, "text.Sanitise().ProperSentences().Fullstop()");
+	}
+
+	[TestMethod]
+	public void MagicSecurity_RuntimeSources_EnforceVisibilityCleanupAndLifecycleInvariants()
+	{
+		var remoteLookSource = File.ReadAllText(GetSourcePath("MudSharpCore", "Magic", "RemoteLookRenderer.cs"));
+		StringAssert.Contains(remoteLookSource, "var flags = PerceiveIgnoreFlags.None;");
+		Assert.IsFalse(remoteLookSource.Contains("IgnoreCanSee", StringComparison.Ordinal));
+		Assert.IsFalse(remoteLookSource.Contains("IgnoreDark", StringComparison.Ordinal));
+
+		var weatherFreezeSource = File.ReadAllText(GetSourcePath("MudSharpCore", "Effects", "Concrete",
+			"SpellEffects", "SpellWeatherFreezeEffect.cs"));
+		StringAssert.Contains(weatherFreezeSource, "public override void RemovalEffect()");
+		StringAssert.Contains(weatherFreezeSource, "ReleaseFreeze();");
+		StringAssert.Contains(weatherFreezeSource, "_controller.WeatherChanged += WeatherChanged;");
+		StringAssert.Contains(weatherFreezeSource, "_controller?.WeatherChanged -= WeatherChanged;");
+
+		var forcedTransformSource = File.ReadAllText(GetSourcePath("MudSharpCore", "Effects", "Concrete",
+			"SpellEffects", "SpellTransformFormEffect.cs"));
+		StringAssert.Contains(forcedTransformSource, "character.ReevaluateForcedBodyTransformation(this);");
+
+		var characterFormsSource = File.ReadAllText(GetSourcePath("MudSharpCore", "Character", "CharacterForms.cs"));
+		StringAssert.Contains(characterFormsSource, "echo.Sanitise()");
+		StringAssert.Contains(characterFormsSource, "transformationEcho?.Sanitise()");
+
+		var transformFormSource = File.ReadAllText(GetSourcePath("MudSharpCore", "Magic", "SpellEffects",
+			"TransformFormEffect.cs"));
+		StringAssert.Contains(transformFormSource, "root.Element(\"TransformationEcho\")?.Value.Sanitise()");
+		StringAssert.Contains(transformFormSource, "text.Sanitise()");
+
+		var telepathySource = File.ReadAllText(GetSourcePath("MudSharpCore", "Effects", "Concrete",
+			"SpellEffects", "SpellTelepathyEffect.cs"));
+		StringAssert.Contains(telepathySource, "public override bool Applies(object target)");
+		StringAssert.Contains(telepathySource, "ReferenceEquals(target, ParentEffect.Caster)");
+
+		var teleportSource = File.ReadAllText(GetSourcePath("MudSharpCore", "Character", "CharacterMovement.cs"));
+		Assert.IsFalse(teleportSource.Contains(".SelectMany(x => x.Cells)", StringComparison.Ordinal));
+
+		var spellSource = File.ReadAllText(GetSourcePath("MudSharpCore", "Magic", "MagicSpell.cs"));
+		StringAssert.Contains(spellSource, "EchoInterdiction(originalTarget, interdiction, false);");
+		StringAssert.Contains(spellSource, "return true;");
+
+		var poisonSource = File.ReadAllText(GetSourcePath("MudSharpCore", "Effects", "Concrete",
+			"SpellEffects", "StandaloneSpellStatusEffects.cs"));
+		StringAssert.Contains(poisonSource, "RemoveDrugDosages(IsLegacyUnownedDose)");
+		StringAssert.Contains(poisonSource, "ReferenceEquals(x.Originator, this) || IsLegacyUnownedDose(x)");
 	}
 
 	[TestMethod]
@@ -344,5 +480,22 @@ public class MagicEngineV3Tests
 		collection.Setup(x => x.GetEnumerator()).Returns(() => ((IEnumerable<T>)items).GetEnumerator());
 		collection.As<IEnumerable<T>>().Setup(x => x.GetEnumerator()).Returns(() => ((IEnumerable<T>)items).GetEnumerator());
 		return collection;
+	}
+
+	private static string GetSourcePath(params string[] parts)
+	{
+		var directory = AppContext.BaseDirectory;
+		while (directory is not null)
+		{
+			var candidate = Path.Combine(new[] { directory }.Concat(parts).ToArray());
+			if (File.Exists(candidate))
+			{
+				return candidate;
+			}
+
+			directory = Directory.GetParent(directory)?.FullName;
+		}
+
+		throw new FileNotFoundException($"Could not locate source file {Path.Combine(parts)}.");
 	}
 }

--- a/MudSharpCore/Character/CharacterForcedTransformations.cs
+++ b/MudSharpCore/Character/CharacterForcedTransformations.cs
@@ -43,6 +43,11 @@ public partial class Character
 
 	public void ReevaluateForcedBodyTransformation()
 	{
+		ReevaluateForcedBodyTransformation(null);
+	}
+
+	internal void ReevaluateForcedBodyTransformation(SpellTransformFormEffect excludingSpellTransform)
+	{
 		if (_reevaluatingForcedBodyTransformation || _isSwitchingBodies)
 		{
 			return;
@@ -52,7 +57,7 @@ public partial class Character
 		try
 		{
 			RefreshForcedTransformationHeartbeatRegistration();
-			var demands = OrderedForcedTransformationDemands().ToList();
+			var demands = OrderedForcedTransformationDemands(excludingSpellTransform).ToList();
 			var baselineEffect = EffectsOfType<ForcedTransformationBaselineEffect>().FirstOrDefault();
 			if (demands.Any())
 			{
@@ -129,9 +134,9 @@ public partial class Character
 			.FirstOrDefault(x => x.Body == CurrentBody || CanSwitchBody(x.Body, BodySwitchIntent.Forced, out _));
 	}
 
-	private IEnumerable<ForcedTransformationDemand> OrderedForcedTransformationDemands()
+	private IEnumerable<ForcedTransformationDemand> OrderedForcedTransformationDemands(SpellTransformFormEffect excludingSpellTransform = null)
 	{
-		return GetActiveForcedTransformationDemands()
+		return GetActiveForcedTransformationDemands(excludingSpellTransform)
 			.OrderByDescending(x => x.PriorityBand)
 			.ThenByDescending(x => x.PriorityOffset)
 			.ThenByDescending(x => x.TieBreaker)
@@ -139,7 +144,7 @@ public partial class Character
 			.ThenBy(x => x.Form.Alias);
 	}
 
-	private IEnumerable<ForcedTransformationDemand> GetActiveForcedTransformationDemands()
+	private IEnumerable<ForcedTransformationDemand> GetActiveForcedTransformationDemands(SpellTransformFormEffect excludingSpellTransform = null)
 	{
 		foreach (var merit in AutoTransformingBodyFormMerits().Where(x => x.Applies(this)))
 		{
@@ -153,7 +158,8 @@ public partial class Character
 				merit.ForcedTransformationPriorityOffset, merit.Id, $"merit #{merit.Id.ToString("N0")}");
 		}
 
-		foreach (var effect in EffectsOfType<SpellTransformFormEffect>().Where(x => x.Applies()))
+		foreach (var effect in EffectsOfType<SpellTransformFormEffect>()
+		         .Where(x => !ReferenceEquals(x, excludingSpellTransform) && x.Applies()))
 		{
 			var form = GetProvisionedFormForSpellTransform(effect);
 			if (form is null)

--- a/MudSharpCore/Character/CharacterForms.cs
+++ b/MudSharpCore/Character/CharacterForms.cs
@@ -198,7 +198,7 @@ public partial class Character
 			return;
 		}
 
-		OutputHandler.Handle(new EmoteOutput(new Emote(echo, this, oldBody, newBody)));
+		OutputHandler.Handle(new EmoteOutput(new Emote(echo.Sanitise(), this, oldBody, newBody)));
 	}
 
 	private CharacterForm DefaultFormFor(IBody body)
@@ -538,7 +538,7 @@ public partial class Character
 			return false;
 		}
 
-		form.TransformationEcho = transformationEcho;
+		form.TransformationEcho = transformationEcho?.Sanitise();
 		Changed = true;
 		whyNot = string.Empty;
 		return true;

--- a/MudSharpCore/Character/CharacterMovement.cs
+++ b/MudSharpCore/Character/CharacterMovement.cs
@@ -188,24 +188,10 @@ public partial class Character
     private static void ReconcileTeleportCellMembership(ICharacter character, ICell target, ICell source)
     {
         ICell canonicalCell = character.Location ?? target;
-        HashSet<IZone> zones = new()
-        {
-            target.Zone,
-            canonicalCell.Zone
-        };
-        if (source is not null)
-        {
-            zones.Add(source.Zone);
-        }
-
-        List<ICell> duplicateCells = zones
-            .SelectMany(x => x.Cells)
-            .Distinct()
-            .Where(x => !ReferenceEquals(x, canonicalCell))
-            .Where(x => x.Characters.Contains(character))
-            .ToList();
-
-        foreach (ICell duplicateCell in duplicateCells)
+        foreach (ICell duplicateCell in new[] { source, target }
+                 .Where(x => x is not null && !ReferenceEquals(x, canonicalCell))
+                 .Distinct()
+                 .Where(x => x.Characters.Contains(character)))
         {
             duplicateCell.Leave(character);
         }

--- a/MudSharpCore/Effects/Concrete/SpellEffects/SpellPersistentSensoryCombatEffects.cs
+++ b/MudSharpCore/Effects/Concrete/SpellEffects/SpellPersistentSensoryCombatEffects.cs
@@ -8,6 +8,7 @@ using MudSharp.Framework;
 using MudSharp.FutureProg;
 using MudSharp.GameItems;
 using MudSharp.Health;
+using MudSharp.Magic;
 using MudSharp.Movement;
 using MudSharp.RPG.Checks;
 using System;
@@ -35,8 +36,9 @@ public class SpellBurningEffect : MagicSpellEffectBase, IDescriptionAdditionEffe
 		PainPerTick = Math.Max(0.0, painPerTick);
 		StunPerTick = Math.Max(0.0, stunPerTick);
 		ThermalLoadPerTick = Math.Max(0.0, thermalLoadPerTick);
-		TickInterval = TimeSpan.FromSeconds(Math.Max(1.0, tickSeconds));
-		MinimumOxidation = Math.Max(0.0, minimumOxidation);
+		TickInterval = TimeSpan.FromSeconds(MagicBuilderValidation.ClampFinite(tickSeconds, 1.0,
+			MagicBuilderValidation.MaximumSpellTickSeconds, 10.0));
+		MinimumOxidation = MagicBuilderValidation.ClampFinite(minimumOxidation, 0.0, double.MaxValue, 0.0);
 		SelfOxidising = selfOxidising;
 		SDescAddendum = sdescAddendum;
 		DescAddendum = descAddendum;
@@ -52,8 +54,12 @@ public class SpellBurningEffect : MagicSpellEffectBase, IDescriptionAdditionEffe
 		PainPerTick = Math.Max(0.0, double.Parse(trueRoot?.Element("PainPerTick")?.Value ?? "0"));
 		StunPerTick = Math.Max(0.0, double.Parse(trueRoot?.Element("StunPerTick")?.Value ?? "0"));
 		ThermalLoadPerTick = Math.Max(0.0, double.Parse(trueRoot?.Element("ThermalLoadPerTick")?.Value ?? "0"));
-		TickInterval = TimeSpan.FromSeconds(Math.Max(1.0, double.Parse(trueRoot?.Element("TickSeconds")?.Value ?? "10")));
-		MinimumOxidation = Math.Max(0.0, double.Parse(trueRoot?.Element("MinimumOxidation")?.Value ?? "0"));
+		TickInterval = TimeSpan.FromSeconds(MagicBuilderValidation.ClampFinite(
+			MagicBuilderValidation.ParseFiniteOrDefault(trueRoot?.Element("TickSeconds")?.Value, 10.0), 1.0,
+			MagicBuilderValidation.MaximumSpellTickSeconds, 10.0));
+		MinimumOxidation = MagicBuilderValidation.ClampFinite(
+			MagicBuilderValidation.ParseFiniteOrDefault(trueRoot?.Element("MinimumOxidation")?.Value, 0.0), 0.0,
+			double.MaxValue, 0.0);
 		SelfOxidising = bool.Parse(trueRoot?.Element("SelfOxidising")?.Value ?? "false");
 		SDescAddendum = trueRoot?.Element("SDescAddendum")?.Value ?? "(burning)";
 		DescAddendum = trueRoot?.Element("DescAddendum")?.Value ?? "@ is burning with magical fire.";

--- a/MudSharpCore/Effects/Concrete/SpellEffects/SpellTelepathyEffect.cs
+++ b/MudSharpCore/Effects/Concrete/SpellEffects/SpellTelepathyEffect.cs
@@ -55,6 +55,13 @@ public class SpellTelepathyEffect : MagicSpellEffectBase, ITelepathyEffect
         return true;
     }
 
+    public override bool Applies(object target)
+    {
+        return ParentEffect?.Caster is not null &&
+               ReferenceEquals(target, ParentEffect.Caster) &&
+               base.Applies(target);
+    }
+
     public bool ShowName(ICharacter thinker)
     {
         return false;

--- a/MudSharpCore/Effects/Concrete/SpellEffects/SpellTransformFormEffect.cs
+++ b/MudSharpCore/Effects/Concrete/SpellEffects/SpellTransformFormEffect.cs
@@ -79,7 +79,10 @@ public class SpellTransformFormEffect : SimpleSpellStatusEffectBase
 	public override void RemovalEffect()
 	{
 		base.RemovalEffect();
-		(Owner as ICharacter)?.ReevaluateForcedBodyTransformation();
+		if (Owner is MudSharp.Character.Character character)
+		{
+			character.ReevaluateForcedBodyTransformation(this);
+		}
 	}
 
 	public override string Describe(IPerceiver voyeur)

--- a/MudSharpCore/Effects/Concrete/SpellEffects/SpellWeatherFreezeEffect.cs
+++ b/MudSharpCore/Effects/Concrete/SpellEffects/SpellWeatherFreezeEffect.cs
@@ -13,24 +13,31 @@ namespace MudSharp.Effects.Concrete.SpellEffects;
 public class SpellWeatherFreezeEffect : MagicSpellEffectBase
 {
     private readonly IWeatherController _controller;
+    private bool _weatherIsFrozen;
+    private bool _pendingNextTransition;
 
     public static void InitialiseEffectType()
     {
         RegisterFactory("SpellWeatherFreeze", (effect, owner) => new SpellWeatherFreezeEffect(effect, owner));
     }
 
-    public SpellWeatherFreezeEffect(IPerceivable owner, IMagicSpellEffectParent parent, IFutureProg prog, IWeatherEvent? weatherEvent = null) : base(owner, parent, prog)
+    public SpellWeatherFreezeEffect(IPerceivable owner, IMagicSpellEffectParent parent, IFutureProg prog, IWeatherEvent? weatherEvent = null, bool nextTransition = false) : base(owner, parent, prog)
     {
         WeatherEvent = weatherEvent;
         _controller = (owner as ICell)?.WeatherController ?? (owner as IZone)?.WeatherController;
-        if (_controller != null)
+        if (_controller == null)
         {
-            if (WeatherEvent != null)
-            {
-                _controller.SetWeather(WeatherEvent);
-            }
-            _controller.FreezeWeather();
+            return;
         }
+
+        if (nextTransition)
+        {
+            _controller.WeatherChanged += WeatherChanged;
+            _pendingNextTransition = true;
+            return;
+        }
+
+        ApplyFreeze();
     }
 
     protected SpellWeatherFreezeEffect(XElement root, IPerceivable owner) : base(root, owner)
@@ -41,12 +48,31 @@ public class SpellWeatherFreezeEffect : MagicSpellEffectBase
         _controller = (owner as ICell)?.WeatherController ?? (owner as IZone)?.WeatherController;
         if (_controller != null)
         {
-            if (WeatherEvent != null)
-            {
-                _controller.SetWeather(WeatherEvent);
-            }
-            _controller.FreezeWeather();
+            ApplyFreeze();
         }
+    }
+
+    private void ApplyFreeze()
+    {
+        if (_controller == null || _weatherIsFrozen)
+        {
+            return;
+        }
+
+        if (WeatherEvent != null)
+        {
+            _controller.SetWeather(WeatherEvent);
+        }
+
+        _controller.FreezeWeather();
+        _weatherIsFrozen = true;
+    }
+
+    private void WeatherChanged(IWeatherController sender, IWeatherEvent oldWeather, IWeatherEvent newWeather)
+    {
+        sender.WeatherChanged -= WeatherChanged;
+        _pendingNextTransition = false;
+        ApplyFreeze();
     }
 
     protected override XElement SaveDefinition()
@@ -70,7 +96,30 @@ public class SpellWeatherFreezeEffect : MagicSpellEffectBase
 
     public override void ExpireEffect()
     {
+        ReleaseFreeze();
         base.ExpireEffect();
+    }
+
+    public override void RemovalEffect()
+    {
+        ReleaseFreeze();
+        base.RemovalEffect();
+    }
+
+    private void ReleaseFreeze()
+    {
+        if (_pendingNextTransition)
+        {
+            _controller?.WeatherChanged -= WeatherChanged;
+            _pendingNextTransition = false;
+        }
+
+        if (!_weatherIsFrozen)
+        {
+            return;
+        }
+
         _controller?.UnfreezeWeather();
+        _weatherIsFrozen = false;
     }
 }

--- a/MudSharpCore/Effects/Concrete/SpellEffects/StandaloneSpellStatusEffects.cs
+++ b/MudSharpCore/Effects/Concrete/SpellEffects/StandaloneSpellStatusEffects.cs
@@ -9,6 +9,7 @@ using MudSharp.Health;
 using MudSharp.Health.Infections;
 using MudSharp.Magic;
 using MudSharp.RPG.Checks;
+using System;
 using System.Linq;
 using System.Xml.Linq;
 
@@ -481,6 +482,7 @@ public class SpellPoisonEffect : SimpleSpellStatusEffectBase
 		base.InitialEffect();
 		if (Owner is ICharacter character)
 		{
+			character.Body.RemoveDrugDosages(IsLegacyUnownedDose);
 			character.Body.Dose(Drug, Vector, Grams, this);
 		}
 	}
@@ -489,10 +491,18 @@ public class SpellPoisonEffect : SimpleSpellStatusEffectBase
 	{
 		if (Owner is ICharacter character)
 		{
-			character.Body.RemoveDrugDosages(x => ReferenceEquals(x.Originator, this));
+			character.Body.RemoveDrugDosages(x => ReferenceEquals(x.Originator, this) || IsLegacyUnownedDose(x));
 		}
 
 		base.RemovalEffect();
+	}
+
+	private bool IsLegacyUnownedDose(DrugDosage dosage)
+	{
+		return dosage.Originator is null &&
+		       dosage.Drug == Drug &&
+		       dosage.OriginalVector == Vector &&
+		       Math.Abs(dosage.Grams - Grams) < 0.001;
 	}
 
 	protected override XElement SaveDefinition()

--- a/MudSharpCore/Magic/MagicBuilderValidation.cs
+++ b/MudSharpCore/Magic/MagicBuilderValidation.cs
@@ -1,0 +1,39 @@
+#nullable enable
+
+using System;
+
+namespace MudSharp.Magic;
+
+public static class MagicBuilderValidation
+{
+	public const int MaximumForcedPathMovementSteps = 100;
+	public const double MaximumSpellTickSeconds = 86_400.0;
+	public const double MaximumNeedDeltaHours = 1_000.0;
+	public const double MaximumNeedDeltaAlcoholLitres = 25.0;
+	public const double MaximumResistanceIntervalSeconds = 86_400.0;
+
+	public static bool TryParseFiniteDouble(string text, out double value)
+	{
+		return double.TryParse(text, out value) && double.IsFinite(value);
+	}
+
+	public static bool TryParseFiniteDoubleInRange(string text, double minimum, double maximum, out double value)
+	{
+		return TryParseFiniteDouble(text, out value) && value >= minimum && value <= maximum;
+	}
+
+	public static double ClampFinite(double value, double minimum, double maximum, double defaultValue)
+	{
+		if (!double.IsFinite(value))
+		{
+			return defaultValue;
+		}
+
+		return Math.Clamp(value, minimum, maximum);
+	}
+
+	public static double ParseFiniteOrDefault(string? text, double defaultValue)
+	{
+		return text is not null && TryParseFiniteDouble(text, out var value) ? value : defaultValue;
+	}
+}

--- a/MudSharpCore/Magic/MagicSpell.cs
+++ b/MudSharpCore/Magic/MagicSpell.cs
@@ -1605,7 +1605,7 @@ public class MagicSpell : SaveableItem, IMagicSpell
 			if (interdiction is not null && !reflected)
 			{
 				EchoInterdiction(originalTarget, interdiction, false);
-				return false;
+				return true;
 			}
 
 			if (TargetResisted(actualTarget, out OpposedOutcome outcome, reflected))
@@ -1632,7 +1632,10 @@ public class MagicSpell : SaveableItem, IMagicSpell
 		{
 			foreach (IPerceivable individual in pg.Members)
 			{
-				ProcessSpellTarget(individual, false);
+				if (ProcessSpellTarget(individual, false))
+				{
+					return;
+				}
 			}
 		}
 		else if (target is ICharacter tch && tch != magician)
@@ -1644,7 +1647,10 @@ public class MagicSpell : SaveableItem, IMagicSpell
 		}
 		else if (target is not null)
 		{
-			ProcessSpellTarget(target, false);
+			if (ProcessSpellTarget(target, false))
+			{
+				return;
+			}
 		}
 
 		if (_casterSpellEffects.Any())

--- a/MudSharpCore/Magic/Powers/ConnectMindPower.cs
+++ b/MudSharpCore/Magic/Powers/ConnectMindPower.cs
@@ -28,6 +28,8 @@ public class ConnectMindPower : SustainedMagicPower
     {
         MagicPowerFactory.RegisterLoader("connectmind",
             (power, gameworld) => new ConnectMindPower(power, gameworld));
+        MagicPowerFactory.RegisterLoader("Connect Mind",
+            (power, gameworld) => new ConnectMindPower(power, gameworld));
         MagicPowerFactory.RegisterBuilderLoader("connectmind", (gameworld, school, name, actor, command) =>
         {
             if (command.IsFinished)

--- a/MudSharpCore/Magic/Powers/InvisibilityPower.cs
+++ b/MudSharpCore/Magic/Powers/InvisibilityPower.cs
@@ -24,6 +24,7 @@ public class InvisibilityPower : SustainedMagicPower
     public static void RegisterLoader()
     {
         MagicPowerFactory.RegisterLoader("invisibility", (power, gameworld) => new InvisibilityPower(power, gameworld));
+        MagicPowerFactory.RegisterLoader("Invisibility", (power, gameworld) => new InvisibilityPower(power, gameworld));
         MagicPowerFactory.RegisterBuilderLoader("invisibility", (gameworld, school, name, actor, command) =>
         {
             if (command.IsFinished)
@@ -46,10 +47,11 @@ public class InvisibilityPower : SustainedMagicPower
     protected override XElement SaveDefinition()
     {
         XElement definition = new("Definition",
-                new XElement("ConnectVerb", BeginVerb),
-                new XElement("DisconnectVerb", EndVerb),
+                new XElement("StartPowerVerb", BeginVerb),
+                new XElement("EndPowerVerb", EndVerb),
     new XElement("SkillCheckDifficulty", (int)SkillCheckDifficulty),
     new XElement("SkillCheckTrait", SkillCheckTrait.Id),
+    new XElement("MinimumSuccessThreshold", (int)MinimumSuccessThreshold),
     new XElement("InvisibilityAppliesProg", InvisibilityAppliesProg.Id),
     new XElement("CanEndPowerProg", CanEndPowerProg.Id),
     new XElement("WhyCantEndPowerProg", WhyCantEndPowerProg.Id),
@@ -66,7 +68,7 @@ public class InvisibilityPower : SustainedMagicPower
     private InvisibilityPower(Models.MagicPower power, IFuturemud gameworld) : base(power, gameworld)
     {
         XElement root = XElement.Parse(power.Definition);
-        XElement element = root.Element("StartPowerVerb");
+        XElement element = root.Element("StartPowerVerb") ?? root.Element("ConnectVerb");
         if (element == null)
         {
             throw new ApplicationException(
@@ -75,7 +77,7 @@ public class InvisibilityPower : SustainedMagicPower
 
         BeginVerb = element.Value;
 
-        element = root.Element("EndPowerVerb");
+        element = root.Element("EndPowerVerb") ?? root.Element("DisconnectVerb");
         if (element == null)
         {
             throw new ApplicationException($"There was no EndPowerVerb in the definition XML for power {Id} ({Name}).");
@@ -128,13 +130,7 @@ public class InvisibilityPower : SustainedMagicPower
         SkillCheckTrait = Gameworld.Traits.Get(long.Parse(element.Value));
 
         element = root.Element("MinimumSuccessThreshold");
-        if (element == null)
-        {
-            throw new ApplicationException(
-                $"There was no MinimumSuccessThreshold in the definition XML for power {Id} ({Name}).");
-        }
-
-        MinimumSuccessThreshold = (Outcome)int.Parse(element.Value);
+        MinimumSuccessThreshold = element is null ? Outcome.Fail : (Outcome)int.Parse(element.Value);
 
         element = root.Element("InvisibilityAppliesProg");
         if (element == null)

--- a/MudSharpCore/Magic/Powers/MagicArmourPower.cs
+++ b/MudSharpCore/Magic/Powers/MagicArmourPower.cs
@@ -30,6 +30,8 @@ public class MagicArmourPower : SustainedMagicPower
     {
         MagicPowerFactory.RegisterLoader("armour", (power, gameworld) => new MagicArmourPower(power, gameworld));
         MagicPowerFactory.RegisterLoader("armor", (power, gameworld) => new MagicArmourPower(power, gameworld));
+        MagicPowerFactory.RegisterLoader("Armour", (power, gameworld) => new MagicArmourPower(power, gameworld));
+        MagicPowerFactory.RegisterLoader("Armor", (power, gameworld) => new MagicArmourPower(power, gameworld));
         MagicPowerFactory.RegisterBuilderLoader("armour", (gameworld, school, name, actor, command) =>
         {
             if (command.IsFinished)
@@ -56,6 +58,7 @@ public class MagicArmourPower : SustainedMagicPower
     new XElement("EndVerb", EndVerb),
     new XElement("SkillCheckDifficulty", (int)SkillCheckDifficulty),
     new XElement("SkillCheckTrait", SkillCheckTrait.Id),
+    new XElement("MinimumSuccessThreshold", (int)MinimumSuccessThreshold),
     new XElement("EmoteText", new XCData(EmoteText)),
     new XElement("FailEmoteText", new XCData(FailEmoteText)),
     new XElement("EndPowerEmoteText", new XCData(EndPowerEmoteText))
@@ -144,13 +147,7 @@ public class MagicArmourPower : SustainedMagicPower
         SkillCheckTrait = Gameworld.Traits.Get(long.Parse(element.Value));
 
         element = root.Element("MinimumSuccessThreshold");
-        if (element == null)
-        {
-            throw new ApplicationException(
-                $"There was no MinimumSuccessThreshold in the definition XML for power {Id} ({Name}).");
-        }
-
-        MinimumSuccessThreshold = (Outcome)int.Parse(element.Value);
+        MinimumSuccessThreshold = element is null ? Outcome.Fail : (Outcome)int.Parse(element.Value);
         ArmourConfiguration = new MagicArmourConfiguration(root, Gameworld);
     }
 

--- a/MudSharpCore/Magic/Powers/MagicAttackPower.cs
+++ b/MudSharpCore/Magic/Powers/MagicAttackPower.cs
@@ -30,6 +30,7 @@ public class MagicAttackPower : MagicPowerBase, IMagicAttackPower
     public static void RegisterLoader()
     {
         MagicPowerFactory.RegisterLoader("magicattack", (power, gameworld) => new MagicAttackPower(power, gameworld));
+        MagicPowerFactory.RegisterLoader("Magic Attack", (power, gameworld) => new MagicAttackPower(power, gameworld));
         MagicPowerFactory.RegisterBuilderLoader("magicattack", (gameworld, school, name, actor, command) =>
         {
             if (command.IsFinished)

--- a/MudSharpCore/Magic/Powers/MindAnesthesiaPower.cs
+++ b/MudSharpCore/Magic/Powers/MindAnesthesiaPower.cs
@@ -28,6 +28,7 @@ public class MindAnesthesiaPower : SustainedMagicPower
     public static void RegisterLoader()
     {
         MagicPowerFactory.RegisterLoader("anesthesia", (power, gameworld) => new MindAnesthesiaPower(power, gameworld));
+        MagicPowerFactory.RegisterLoader("mindanesthesia", (power, gameworld) => new MindAnesthesiaPower(power, gameworld));
         MagicPowerFactory.RegisterBuilderLoader("anesthesia", (gameworld, school, name, actor, command) =>
         {
             if (command.IsFinished)
@@ -879,7 +880,7 @@ public class MindAnesthesiaPower : SustainedMagicPower
             return false;
         }
 
-        if (!double.TryParse(command.SafeRemainingArgument, out double value))
+        if (!MagicBuilderValidation.TryParseFiniteDouble(command.SafeRemainingArgument, out double value))
         {
             actor.OutputHandler.Send($"The text {command.SafeRemainingArgument.ColourCommand()} is not a valid number.");
             return false;
@@ -893,6 +894,12 @@ public class MindAnesthesiaPower : SustainedMagicPower
             Changed = true;
             actor.OutputHandler.Send($"The target will no longer get any kind of resistance check to this power.");
             return true;
+        }
+
+        if (value > MagicBuilderValidation.MaximumResistanceIntervalSeconds)
+        {
+            actor.OutputHandler.Send($"The resistance interval must be no more than {MagicBuilderValidation.MaximumResistanceIntervalSeconds.ToString("N0", actor).ColourValue()} seconds.");
+            return false;
         }
 
         ResistCheckInterval = TimeSpan.FromSeconds(value);

--- a/MudSharpCore/Magic/Powers/MindBroadcastPower.cs
+++ b/MudSharpCore/Magic/Powers/MindBroadcastPower.cs
@@ -61,7 +61,7 @@ public class MindBroadcastPower : MagicPowerBase
     new XElement("SkillCheckDifficulty", (int)SkillCheckDifficulty),
     new XElement("CanInvokePowerProg", CanInvokePowerProg?.Id ?? 0L),
     new XElement("WhyCantInvokePowerProg", WhyCantInvokePowerProg?.Id ?? 0L),
-                new XElement("Distance", (int)PowerDistance)
+                new XElement("PowerDistance", (int)PowerDistance)
         );
         AddBaseDefinition(definition);
         return definition;
@@ -101,7 +101,7 @@ public class MindBroadcastPower : MagicPowerBase
 
         UnknownIdentityDescription = element.Value;
 
-        PowerDistance = (MagicPowerDistance)int.Parse(root.Element("PowerDistance")?.Value ?? "2");
+        PowerDistance = (MagicPowerDistance)int.Parse((root.Element("PowerDistance") ?? root.Element("Distance"))?.Value ?? "2");
 
         element = root.Element("TargetCanSeeIdentityProg");
         if (element == null)
@@ -269,11 +269,11 @@ public class MindBroadcastPower : MagicPowerBase
         {
             foreach (ICharacter target in targets.AsEnumerable())
             {
-                EmoteOutput emote = new(new Emote($"{GetAppropriateTargetEmote(actor, target)} \"{text.ProperSentences().Fullstop()}\"", actor, PermitLanguageOptions.IgnoreLanguage, actor, target), flags: OutputFlags.NoLanguage);
+                EmoteOutput emote = new(new Emote($"{GetAppropriateTargetEmote(actor, target)} \"{text.Sanitise().ProperSentences().Fullstop()}\"", actor, PermitLanguageOptions.IgnoreLanguage, actor, target), flags: OutputFlags.NoLanguage);
                 target.OutputHandler.Send(emote);
             }
 
-            actor.OutputHandler.Send(new EmoteOutput(new Emote($"{EmoteText} \"{text.ProperSentences().Fullstop()}\"", actor, PermitLanguageOptions.IgnoreLanguage, actor), flags: OutputFlags.NoLanguage));
+            actor.OutputHandler.Send(new EmoteOutput(new Emote($"{EmoteText} \"{text.Sanitise().ProperSentences().Fullstop()}\"", actor, PermitLanguageOptions.IgnoreLanguage, actor), flags: OutputFlags.NoLanguage));
         }
 
         PsionicActivityNotifier.Notify(actor, this, "a psychic broadcast", targets);

--- a/MudSharpCore/Magic/RemoteLookRenderer.cs
+++ b/MudSharpCore/Magic/RemoteLookRenderer.cs
@@ -19,7 +19,7 @@ public static class RemoteLookRenderer
 {
 	public static string DescribeRemoteCell(ICharacter viewer, ICell location, RoomLayer layer)
 	{
-		var flags = PerceiveIgnoreFlags.IgnoreCanSee | PerceiveIgnoreFlags.IgnoreDark;
+		var flags = PerceiveIgnoreFlags.None;
 		var sb = new StringBuilder();
 		sb.AppendLine(location.HowSeen(viewer, type: DescriptionType.Full));
 

--- a/MudSharpCore/Magic/SpellEffects/CreateLiquidEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/CreateLiquidEffect.cs
@@ -47,7 +47,7 @@ public class CreateLiquidEffect : IMagicSpellEffectTemplate
     protected CreateLiquidEffect(XElement root, IMagicSpell spell)
     {
         Spell = spell;
-        _liquidId = long.Parse(root.Element("LiquidId").Value);
+        _liquidId = long.Parse((root.Element("LiquidId") ?? root.Element("Liquid"))!.Value);
         AmountFormula = new Expression(root.Element("AmountFormula").Value);
     }
     public IFuturemud Gameworld => Spell.Gameworld;
@@ -64,7 +64,7 @@ public class CreateLiquidEffect : IMagicSpellEffectTemplate
     {
         return new XElement("Effect",
             new XAttribute("type", "createliquid"),
-            new XElement("Liquid", _liquidId),
+            new XElement("LiquidId", _liquidId),
             new XElement("AmountFormula", new XCData(AmountFormula.OriginalExpression))
         );
     }

--- a/MudSharpCore/Magic/SpellEffects/NeedDeltaEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/NeedDeltaEffect.cs
@@ -36,9 +36,12 @@ public class NeedDeltaEffect : IMagicSpellEffectTemplate
     protected NeedDeltaEffect(XElement root, IMagicSpell spell)
     {
         Spell = spell;
-        HungerDelta = double.Parse(root.Element("Hunger")!.Value);
-        ThirstDelta = double.Parse(root.Element("Thirst")!.Value);
-        DrunkDelta = double.Parse(root.Element("Drunk")!.Value);
+        HungerDelta = MagicBuilderValidation.ClampFinite(MagicBuilderValidation.ParseFiniteOrDefault(root.Element("Hunger")?.Value, 0.0),
+            -MagicBuilderValidation.MaximumNeedDeltaHours, MagicBuilderValidation.MaximumNeedDeltaHours, 0.0);
+        ThirstDelta = MagicBuilderValidation.ClampFinite(MagicBuilderValidation.ParseFiniteOrDefault(root.Element("Thirst")?.Value, 0.0),
+            -MagicBuilderValidation.MaximumNeedDeltaHours, MagicBuilderValidation.MaximumNeedDeltaHours, 0.0);
+        DrunkDelta = MagicBuilderValidation.ClampFinite(MagicBuilderValidation.ParseFiniteOrDefault(root.Element("Drunk")?.Value, 0.0),
+            -MagicBuilderValidation.MaximumNeedDeltaAlcoholLitres, MagicBuilderValidation.MaximumNeedDeltaAlcoholLitres, 0.0);
     }
 
     public IMagicSpell Spell { get; }
@@ -80,9 +83,12 @@ public class NeedDeltaEffect : IMagicSpellEffectTemplate
 
     private bool BuildingCommandHunger(ICharacter actor, StringStack command)
     {
-        if (command.IsFinished || !double.TryParse(command.SafeRemainingArgument, out double value))
+        if (command.IsFinished ||
+            !MagicBuilderValidation.TryParseFiniteDoubleInRange(command.SafeRemainingArgument,
+                -MagicBuilderValidation.MaximumNeedDeltaHours, MagicBuilderValidation.MaximumNeedDeltaHours,
+                out double value))
         {
-            actor.OutputHandler.Send("You must enter a valid value in hours.");
+            actor.OutputHandler.Send($"You must enter a valid value in hours between {-MagicBuilderValidation.MaximumNeedDeltaHours:N0} and {MagicBuilderValidation.MaximumNeedDeltaHours:N0}.");
             return false;
         }
         HungerDelta = value;
@@ -93,9 +99,12 @@ public class NeedDeltaEffect : IMagicSpellEffectTemplate
 
     private bool BuildingCommandThirst(ICharacter actor, StringStack command)
     {
-        if (command.IsFinished || !double.TryParse(command.SafeRemainingArgument, out double value))
+        if (command.IsFinished ||
+            !MagicBuilderValidation.TryParseFiniteDoubleInRange(command.SafeRemainingArgument,
+                -MagicBuilderValidation.MaximumNeedDeltaHours, MagicBuilderValidation.MaximumNeedDeltaHours,
+                out double value))
         {
-            actor.OutputHandler.Send("You must enter a valid value in hours.");
+            actor.OutputHandler.Send($"You must enter a valid value in hours between {-MagicBuilderValidation.MaximumNeedDeltaHours:N0} and {MagicBuilderValidation.MaximumNeedDeltaHours:N0}.");
             return false;
         }
         ThirstDelta = value;
@@ -106,9 +115,12 @@ public class NeedDeltaEffect : IMagicSpellEffectTemplate
 
     private bool BuildingCommandDrunk(ICharacter actor, StringStack command)
     {
-        if (command.IsFinished || !double.TryParse(command.SafeRemainingArgument, out double value))
+        if (command.IsFinished ||
+            !MagicBuilderValidation.TryParseFiniteDoubleInRange(command.SafeRemainingArgument,
+                -MagicBuilderValidation.MaximumNeedDeltaAlcoholLitres,
+                MagicBuilderValidation.MaximumNeedDeltaAlcoholLitres, out double value))
         {
-            actor.OutputHandler.Send("You must enter a valid value in litres of alcohol.");
+            actor.OutputHandler.Send($"You must enter a valid value in litres of alcohol between {-MagicBuilderValidation.MaximumNeedDeltaAlcoholLitres:N0} and {MagicBuilderValidation.MaximumNeedDeltaAlcoholLitres:N0}.");
             return false;
         }
         DrunkDelta = value;

--- a/MudSharpCore/Magic/SpellEffects/PersistentSensoryCombatSpellEffects.cs
+++ b/MudSharpCore/Magic/SpellEffects/PersistentSensoryCombatSpellEffects.cs
@@ -83,8 +83,12 @@ public class BurningEffect : IMagicSpellEffectTemplate
 		PainFormula = new Expression(root.Element("PainFormula")?.Value ?? "power");
 		StunFormula = new Expression(root.Element("StunFormula")?.Value ?? "power * 0.5");
 		ThermalFormula = new Expression(root.Element("ThermalFormula")?.Value ?? "0");
-		TickSeconds = Math.Max(1.0, double.Parse(root.Element("TickSeconds")?.Value ?? "10"));
-		MinimumOxidation = Math.Max(0.0, double.Parse(root.Element("MinimumOxidation")?.Value ?? "0.1"));
+		TickSeconds = MagicBuilderValidation.ClampFinite(
+			MagicBuilderValidation.ParseFiniteOrDefault(root.Element("TickSeconds")?.Value, 10.0),
+			1.0, MagicBuilderValidation.MaximumSpellTickSeconds, 10.0);
+		MinimumOxidation = MagicBuilderValidation.ClampFinite(
+			MagicBuilderValidation.ParseFiniteOrDefault(root.Element("MinimumOxidation")?.Value, 0.1),
+			0.0, double.MaxValue, 0.1);
 		SelfOxidising = bool.Parse(root.Element("SelfOxidising")?.Value ?? "false");
 		SDescAddendum = root.Element("SDescAddendum")?.Value ?? "(burning)";
 		DescAddendum = root.Element("DescAddendum")?.Value ?? "@ is wreathed in magical flames.";
@@ -269,9 +273,11 @@ public class BurningEffect : IMagicSpellEffectTemplate
 
 	private bool BuildingCommandTick(ICharacter actor, StringStack command)
 	{
-		if (command.IsFinished || !double.TryParse(command.SafeRemainingArgument, out var seconds) || seconds < 1.0)
+		if (command.IsFinished ||
+		    !MagicBuilderValidation.TryParseFiniteDoubleInRange(command.SafeRemainingArgument, 1.0,
+			    MagicBuilderValidation.MaximumSpellTickSeconds, out var seconds))
 		{
-			actor.OutputHandler.Send("You must enter a number of seconds of at least 1.0.");
+			actor.OutputHandler.Send($"You must enter a number of seconds between {1.0.ToString("N1", actor).ColourValue()} and {MagicBuilderValidation.MaximumSpellTickSeconds.ToString("N0", actor).ColourValue()}.");
 			return false;
 		}
 
@@ -283,7 +289,7 @@ public class BurningEffect : IMagicSpellEffectTemplate
 
 	private bool BuildingCommandOxygen(ICharacter actor, StringStack command)
 	{
-		if (command.IsFinished || !double.TryParse(command.SafeRemainingArgument, out var factor) || factor < 0.0)
+		if (command.IsFinished || !MagicBuilderValidation.TryParseFiniteDouble(command.SafeRemainingArgument, out var factor) || factor < 0.0)
 		{
 			actor.OutputHandler.Send("You must enter an atmospheric oxidation factor of 0.0 or greater.");
 			return false;

--- a/MudSharpCore/Magic/SpellEffects/TransformFormEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/TransformFormEffect.cs
@@ -95,7 +95,7 @@ public class TransformFormEffect : IMagicSpellEffectTemplate
 		_transformationEcho = root.Element("TransformationEcho")?.Attribute("mode")?.Value switch
 		{
 			"none" => string.Empty,
-			_ => root.Element("TransformationEcho")?.Value
+			_ => root.Element("TransformationEcho")?.Value.Sanitise()
 		};
 		if (_transformationEcho == string.Empty &&
 		    root.Element("TransformationEcho")?.Attribute("mode")?.Value != "none")
@@ -487,7 +487,7 @@ public class TransformFormEffect : IMagicSpellEffectTemplate
 			? null
 			: text.EqualToAny("none", "suppress", "blank")
 				? string.Empty
-				: text;
+				: text.Sanitise();
 		Spell.Changed = true;
 		actor.OutputHandler.Send(_transformationEcho switch
 		{

--- a/MudSharpCore/Magic/SpellEffects/WeatherChangeFreezeEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/WeatherChangeFreezeEffect.cs
@@ -124,22 +124,11 @@ public class WeatherChangeFreezeEffect : IMagicSpellEffectTemplate
 
         if (NextTransition)
         {
-            void Handler(IWeatherController sender, IWeatherEvent oldw, IWeatherEvent neww)
-            {
-                sender.WeatherChanged -= Handler;
-                sender.SetWeather(WeatherEvent);
-                sender.FreezeWeather();
-                SpellWeatherFreezeEffect eff = new(loc, parent, null);
-                parent.AddSpellEffect(eff);
-                loc.AddEffect(eff);
-            }
-            loc.WeatherController.WeatherChanged += Handler;
-            return null;
+            return new SpellWeatherFreezeEffect(loc, parent, null, WeatherEvent, true);
         }
         else
         {
             loc.WeatherController.SetWeather(WeatherEvent);
-            loc.WeatherController.FreezeWeather();
             return new SpellWeatherFreezeEffect(loc, parent, null);
         }
     }

--- a/MudSharpCore/Magic/SpellEffects/WeatherFreezeEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/WeatherFreezeEffect.cs
@@ -77,7 +77,6 @@ public class WeatherFreezeEffect : IMagicSpellEffectTemplate
         {
             return null;
         }
-        loc.WeatherController.FreezeWeather();
         return new SpellWeatherFreezeEffect(loc, parent, null);
     }
 

--- a/MudSharpCore/Magic/SpellEffects/WindSpellEffects.cs
+++ b/MudSharpCore/Magic/SpellEffects/WindSpellEffects.cs
@@ -525,7 +525,8 @@ public class ForcedPathMovementEffect : IMagicSpellEffectTemplate
 	protected ForcedPathMovementEffect(XElement root, IMagicSpell spell)
 	{
 		Spell = spell;
-		Steps = Math.Max(1, int.Parse(root.Element("Steps")?.Value ?? "1"));
+		Steps = Math.Clamp(int.Parse(root.Element("Steps")?.Value ?? "1"), 1,
+			MagicBuilderValidation.MaximumForcedPathMovementSteps);
 		AllowFallExits = bool.Parse(root.Element("AllowFallExits")?.Value ?? "false");
 	}
 
@@ -684,9 +685,11 @@ public class ForcedPathMovementEffect : IMagicSpellEffectTemplate
 
 	private bool BuildingCommandSteps(ICharacter actor, StringStack command)
 	{
-		if (!int.TryParse(command.SafeRemainingArgument, out var value) || value < 1)
+		if (!int.TryParse(command.SafeRemainingArgument, out var value) ||
+		    value < 1 ||
+		    value > MagicBuilderValidation.MaximumForcedPathMovementSteps)
 		{
-			actor.OutputHandler.Send("You must enter a positive number of steps.");
+			actor.OutputHandler.Send($"You must enter a positive number of steps no more than {MagicBuilderValidation.MaximumForcedPathMovementSteps.ToString("N0", actor).ColourValue()}.");
 			return false;
 		}
 


### PR DESCRIPTION
## Summary
- Remediate the Codex Security findings in triage group `Magic, Psionics & Spell Effects`.
- Add shared finite/bounded magic builder validation and apply it to burn ticks, need deltas, wind movement, and mind anesthesia intervals.
- Fix magic/psionic privacy, lifecycle, persistence, and emote-sanitization invariants across remote look, telepathy, transform forms, weather freeze, poison cleanup, liquid/power XML, wards, and teleport membership reconciliation.
- Update magic and body-form design docs with the enforced invariants.

## Validation
- `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510` passed.
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 --filter "FullyQualifiedName~MagicEngineV3Tests|FullyQualifiedName~CommandExecutionSecurityTests"` passed, 23/23.
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1` passed, 1123/1123.
- `git diff --check` passed with only CRLF normalization warnings.