### PR TITLE
Fix shop repricing reductions

### DIFF
--- a/Design Documents/Economy/Economy_System_Runtime.md
+++ b/Design Documents/Economy/Economy_System_Runtime.md
@@ -201,7 +201,7 @@ Runtime safety invariants:
 
 - shop purchases revalidate stock selection and payment authority immediately before removing stock, including delayed confirmation purchases
 - permanent-shop public stock comes from shopfront-held items and shallow shopfront/stockroom display paths, not private workshops or deeply nested private containers
-- merchandise repricing rejects unsafe overflow multipliers rather than allowing decimal arithmetic to crash command handling
+- merchandise repricing permits ordinary reductions and rejects unsafe markup multipliers rather than allowing decimal arithmetic to crash command handling
 - item preview follows normal container visibility rules; closed opaque containers do not reveal contents through shop preview
 
 ### Markets, Influences, Populations, and Shoppers

--- a/MudSharpCore Unit Tests/ShopTests.cs
+++ b/MudSharpCore Unit Tests/ShopTests.cs
@@ -430,6 +430,19 @@ public class ShopTests
     }
 
     [TestMethod]
+    public void MerchandiseReprice_AcceptsReductionMultiplier()
+    {
+        Mock<IGameItemProto> proto = RegisterPrototype(39);
+        Merchandise merch = new(_shop, "discounted", proto.Object, 10.0M, false, null, null);
+
+        Assert.IsTrue(merch.CanReprice(0.5M));
+        merch.Reprice(0.5M);
+
+        Assert.AreEqual(5.0M, merch.BasePrice);
+        Assert.AreEqual(5.0M, merch.AutoReorderPrice);
+    }
+
+    [TestMethod]
     public void TagTargetedDeal_OnlyAppliesToMatchingMerchandise()
     {
         Mock<ITag> tag = RegisterTag(1, "Discounted");

--- a/MudSharpCore/Economy/Shops/Merchandise.cs
+++ b/MudSharpCore/Economy/Shops/Merchandise.cs
@@ -1154,8 +1154,20 @@ public class Merchandise : LateInitialisingItem, IMerchandise
     public bool CanReprice(decimal multiplier)
     {
         return multiplier > 0.0M &&
-               (BasePrice <= 0.0M || BasePrice <= decimal.MaxValue / multiplier) &&
-               (AutoReorderPrice <= 0.0M || AutoReorderPrice <= decimal.MaxValue / multiplier);
+               PriceCanReprice(BasePrice, multiplier) &&
+               PriceCanReprice(AutoReorderPrice, multiplier);
+    }
+
+    private static bool PriceCanReprice(decimal price, decimal multiplier)
+    {
+        if (price == 0.0M || multiplier <= 1.0M)
+        {
+            return true;
+        }
+
+        return price > 0.0M
+            ? price <= decimal.MaxValue / multiplier
+            : price >= decimal.MinValue / multiplier;
     }
 
     public void Reprice(decimal multiplier)


### PR DESCRIPTION
## Summary
- Fix merchandise repricing validation so ordinary reduction multipliers, such as `50%`, do not overflow while checking decimal bounds.
- Preserve overflow protection for unsafe upward repricing multipliers.
- Add a focused shop regression test and update the economy runtime invariant note.

## Validation
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 --filter ShopTests --verbosity minimal`
- `git diff --check`
- `git diff --cached --check`