### PR TITLE
Remediate employment security findings

### DIFF
--- a/Design Documents/Economy/Economy_System_Runtime.md
+++ b/Design Documents/Economy/Economy_System_Runtime.md
@@ -374,7 +374,10 @@ Current operational boundaries:
 
 - task routing uses `IEmploymentTaskBoard`; the staff `IBoard` is only an employee/manager communication surface
 - financial actions require delegated authority plus explicit authorisation/reservation state and write employment audit evidence while reusing native finance records where available
-- item movement uses inventory plans where possible, with narrow fallbacks for behaviours the inventory-plan API does not model cleanly
+- executable shop-purchase tasks must be completed at a supplier shop location; commodity merchandise stays on the weighted purchase path and is not eligible for count-priced merchandise or item-selector purchases
+- payroll settlement debits backed employer funds before payables become claimable or settled; hosts without a native finance adapter must explicitly expose a currency-backed finance surface
+- item movement uses inventory plans where possible, with narrow fallbacks for behaviours the inventory-plan API does not model cleanly; physical employment logistics are constrained to the host's work locations and physical cash steps only consume task-custody currency piles
+- proprietor contracts cannot be terminated by non-admin managers, and manager goals must require the combined authority of the declared goal, its conditions, and its action plan
 - durable hotel roots and hotel room/rental/furnishing/lost-property internals are persisted through normalized hotel tables
 - central scheduled-rule evaluation runs once per minute and worker AI can also evaluate its current host before claiming work
 - legacy shop/stable employee XML, bank/arena manager lists, and the PC-facing job system are not migrated into the new contracts by default

--- a/MudSharpCore Unit Tests/Economy/Employment/EmploymentCommandServiceTests.cs
+++ b/MudSharpCore Unit Tests/Economy/Employment/EmploymentCommandServiceTests.cs
@@ -547,6 +547,29 @@ public class EmploymentCommandServiceTests
 	}
 
 	[TestMethod]
+	public void EmploymentCommandService_ManagersCannotCreateOrTerminateProprietorContracts()
+	{
+		var currency = Currency();
+		IEmploymentHost host = new TestEmploymentHost(1, "market shop", currency.Object);
+		var manager = Character(54, "Manager").Object;
+		var owner = Character(55, "Owner").Object;
+		var employee = Character(56, "Employee").Object;
+		host.Hire(manager, Offer(currency.Object, EmploymentRole.Manager,
+			EmploymentAuthority.HireEmployees | EmploymentAuthority.FireEmployees), null);
+		var proprietor = host.Hire(owner, Offer(currency.Object, EmploymentRole.Proprietor), null);
+		var service = new EmploymentCommandService();
+
+		Assert.IsFalse(service.TryHireDirectContract(manager, host, employee, EmploymentRole.Proprietor,
+			out var contract, out var hireMessage));
+		Assert.IsNull(contract);
+		StringAssert.Contains(hireMessage, "proprietor");
+
+		Assert.IsFalse(service.TryTerminateContract(manager, host, proprietor.Id, out var fireMessage));
+		StringAssert.Contains(fireMessage, "proprietor");
+		Assert.AreEqual(EmploymentStatus.Active, proprietor.Status);
+	}
+
+	[TestMethod]
 	public void EmploymentCommandService_ContractDelegationsCanBeGrantedAndRevoked()
 	{
 		var currency = Currency();
@@ -691,12 +714,14 @@ public class EmploymentCommandServiceTests
 	[TestMethod]
 	public void EmploymentCommandService_PayrollRunSettleAndListUsesOverdueDays()
 	{
+		VirtualCashLedger.ClearInMemoryForTests();
 		var currency = Currency();
-		IEmploymentHost host = new TestEmploymentHost(1, "market shop", currency.Object);
+		var (shop, state) = ShopHost(1, "market shop", currency.Object);
+		IEmploymentHost host = shop.Object;
 		var manager = Character(60, "Manager").Object;
 		var employee = Character(61, "Employee").Object;
 		var service = new EmploymentCommandService();
-		host.Hire(manager, Offer(currency.Object, EmploymentRole.Manager,
+		state.Hire(manager, Offer(currency.Object, EmploymentRole.Manager,
 			EmploymentAuthority.HireEmployees | EmploymentAuthority.ManagePayroll), null);
 		var compensation = new CompensationTerms(
 			new MoneyAmount(currency.Object, 10.0M),
@@ -704,7 +729,7 @@ public class EmploymentCommandServiceTests
 			PayCadence.Daily,
 			new MoneyAmount(currency.Object, 10.0M),
 			PaymentSource.HostCash);
-		var contract = host.Hire(employee, new EmploymentOffer(
+		var contract = state.Hire(employee, new EmploymentOffer(
 			EmploymentRole.Employee,
 			compensation,
 			WorkSchedule.AnyTime,
@@ -712,6 +737,9 @@ public class EmploymentCommandServiceTests
 			new PaymentMethod(PaymentMethodKind.Cash),
 			EmploymentAuthoritySet.Empty), manager);
 		host.Payroll.EvaluatePayroll(contract.StartedAt.AddDays(2).AddMinutes(1));
+		VirtualCashLedger.Credit(shop.Object, currency.Object,
+			host.Payroll.OutstandingLiabilities.Sum(x => x.Amount.Amount), null, shop.Object, "Seed",
+			"Seed payroll balance");
 
 		var list = service.RenderPayroll(manager, host);
 
@@ -1588,6 +1616,22 @@ public class EmploymentCommandServiceTests
 	}
 
 	[TestMethod]
+	public void EmploymentScheduledRuleAuthoring_RejectsOverflowCooldown()
+	{
+		var currency = Currency();
+		IEmploymentHost host = new TestEmploymentHost(1, "market shop", currency.Object);
+		var manager = Character(182, "Manager").Object;
+		host.Hire(manager, Offer(currency.Object, EmploymentRole.Manager,
+			EmploymentAuthority.CreateScheduledRules), null);
+		var service = new EmploymentScheduledRuleAuthoringService();
+
+		Assert.IsTrue(service.TryStartDraft(manager, host, "Overflow", out var message), message);
+		Assert.IsFalse(service.TrySetDraftCooldown(manager, host, "9999999999999999999999999999d", out message));
+		StringAssert.Contains(message, "positive duration");
+		Assert.AreEqual(0, host.TaskBoard.ScheduledRules.Count);
+	}
+
+	[TestMethod]
 	public void EmploymentCommandService_ScheduledRuleOneShotEvaluateAndCancel()
 	{
 		var currency = Currency();
@@ -1853,6 +1897,32 @@ public class EmploymentCommandServiceTests
 		return currency;
 	}
 
+	private static (Mock<IShop> Shop, IEmploymentHostState State) ShopHost(long id, string name, ICurrency currency)
+	{
+		var shop = new Mock<IShop>();
+		shop.SetupGet(x => x.Id).Returns(id);
+		shop.SetupGet(x => x.Name).Returns(name);
+		shop.SetupGet(x => x.FrameworkItemType).Returns("Shop");
+		shop.SetupGet(x => x.EmploymentHostName).Returns(name);
+		shop.SetupGet(x => x.EmploymentHostType).Returns(EmploymentHostType.Shop);
+		shop.SetupGet(x => x.Market).Returns((IMarket?)null);
+		shop.SetupGet(x => x.Currency).Returns(currency);
+		shop.SetupGet(x => x.BankAccount).Returns((IBankAccount)null!);
+		shop.SetupGet(x => x.CashBalance).Returns(() => VirtualCashLedger.Balance(shop.Object, currency));
+		var state = new EmploymentHostState(shop.Object);
+		shop.SetupGet(x => x.Employment).Returns(state);
+		shop.SetupGet(x => x.BusinessLedger).Returns(state.BusinessLedger);
+		shop.SetupGet(x => x.EmploymentRegister).Returns(state.EmploymentRegister);
+		shop.SetupGet(x => x.TaskBoard).Returns(state.TaskBoard);
+		shop.SetupGet(x => x.ManagerGoalBoard).Returns(state.ManagerGoalBoard);
+		shop.SetupGet(x => x.Payroll).Returns(state.Payroll);
+		shop.SetupGet(x => x.EmploymentContracts).Returns(() => state.EmploymentContracts);
+		shop.SetupGet(x => x.JobOpenings).Returns(() => state.JobOpenings);
+		shop.Setup(x => x.HasAuthority(It.IsAny<ICharacter>(), It.IsAny<EmploymentAuthority>()))
+		    .Returns((ICharacter actor, EmploymentAuthority authority) => state.HasAuthority(actor, authority));
+		return (shop, state);
+	}
+
 	private static Mock<ICell> Cell(long id, string name)
 	{
 		var cell = new Mock<ICell>();
@@ -1936,6 +2006,7 @@ public class EmploymentCommandServiceTests
 		output.Setup(x => x.Send(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>())).Returns(true);
 		character.SetupGet(x => x.Id).Returns(id);
 		character.SetupGet(x => x.Name).Returns(name);
+		character.SetupGet(x => x.PersonalName).Returns(personalName.Object);
 		character.SetupGet(x => x.Gameworld).Returns(gameworld!);
 		character.SetupGet(x => x.CurrentName).Returns(personalName.Object);
 		character.SetupGet(x => x.Body).Returns(body.Object);

--- a/MudSharpCore Unit Tests/Economy/Employment/UnifiedEmploymentDispatchTests.cs
+++ b/MudSharpCore Unit Tests/Economy/Employment/UnifiedEmploymentDispatchTests.cs
@@ -189,8 +189,10 @@ public class UnifiedEmploymentDispatchTests
 	[TestMethod]
 	public void Payroll_AccruesOverdueDaysAndSettlementClearsEmployerReputationAfterContractEnds()
 	{
+		VirtualCashLedger.ClearInMemoryForTests();
 		var currency = Currency();
-		IEmploymentHost host = new TestEmploymentHost("stable", currency.Object);
+		var (shop, state) = ShopHost(401, "stable", currency.Object, null);
+		IEmploymentHost host = shop.Object;
 		var employee = Character(10, "Employee").Object;
 		var compensation = new CompensationTerms(
 			new MoneyAmount(currency.Object, 10.0M),
@@ -198,7 +200,7 @@ public class UnifiedEmploymentDispatchTests
 			PayCadence.Daily,
 			new MoneyAmount(currency.Object, 10.0M),
 			PaymentSource.HostCash);
-		var contract = host.Hire(employee, new EmploymentOffer(
+		var contract = state.Hire(employee, new EmploymentOffer(
 			EmploymentRole.Employee,
 			compensation,
 			WorkSchedule.AnyTime,
@@ -211,6 +213,8 @@ public class UnifiedEmploymentDispatchTests
 
 		Assert.AreEqual(10, created.Count);
 		Assert.AreEqual(9, host.Payroll.MaximumOverdueDays(evaluationTime));
+		VirtualCashLedger.Credit(shop.Object, currency.Object, created.Sum(x => x.Amount.Amount), null, shop.Object,
+			"Seed", "Seed payroll balance");
 		host.Fire(contract, EmploymentTerminationReason.Resigned, null);
 		Assert.IsTrue(host.Payroll.TrySettlePayables(host.Payroll.OutstandingLiabilities, null, false,
 			"Settled after resignation.", out var message), message);
@@ -218,6 +222,38 @@ public class UnifiedEmploymentDispatchTests
 		Assert.IsTrue(host.Payroll.Payables.All(x => x.Status == EmploymentPayableStatus.Settled));
 		Assert.IsTrue(host.BusinessLedger.Entries.Any(x => x.EntryType == EmploymentLedgerEntryType.Wage));
 		Assert.IsTrue(host.EmploymentRegister.Entries.Any(x => x.EntryType == EmploymentRegisterEntryType.WageSettled));
+		Assert.AreEqual(0.0M, VirtualCashLedger.Balance(shop.Object, currency.Object));
+	}
+
+	[TestMethod]
+	public void Payroll_SettlementRequiresBackedEmployerFunds()
+	{
+		VirtualCashLedger.ClearInMemoryForTests();
+		var currency = Currency();
+		var (shop, state) = ShopHost(402, "stable", currency.Object, null);
+		IEmploymentHost host = shop.Object;
+		var employee = Character(10, "Employee").Object;
+		var compensation = new CompensationTerms(
+			new MoneyAmount(currency.Object, 10.0M),
+			null,
+			PayCadence.Daily,
+			new MoneyAmount(currency.Object, 10.0M),
+			PaymentSource.HostCash);
+		var contract = state.Hire(employee, new EmploymentOffer(
+			EmploymentRole.Employee,
+			compensation,
+			WorkSchedule.AnyTime,
+			EmploymentDuration.Indefinite,
+			new PaymentMethod(PaymentMethodKind.Cash),
+			EmploymentAuthoritySet.Empty), null);
+		host.Payroll.EvaluatePayroll(contract.StartedAt.AddDays(1).AddMinutes(1));
+
+		var settled = host.Payroll.TrySettlePayables(host.Payroll.OutstandingLiabilities, null, true,
+			"Settle without funds.", out var message);
+
+		Assert.IsFalse(settled);
+		StringAssert.Contains(message, "available for payroll settlement");
+		Assert.IsTrue(host.Payroll.Payables.All(x => x.Status == EmploymentPayableStatus.Accrued));
 	}
 
 	[TestMethod]
@@ -727,6 +763,7 @@ public class UnifiedEmploymentDispatchTests
 		actor.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
 		var cell = new Mock<ICell>();
 		cell.SetupGet(x => x.Id).Returns(456);
+		actor.SetupGet(x => x.Location).Returns(cell.Object);
 		var proto = new Mock<IGameItemProto>();
 		proto.SetupGet(x => x.Id).Returns(700);
 		var merchandise = Merchandise(10, "matching goods");
@@ -800,6 +837,7 @@ public class UnifiedEmploymentDispatchTests
 		actor.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
 		var cell = new Mock<ICell>();
 		cell.SetupGet(x => x.Id).Returns(457);
+		actor.SetupGet(x => x.Location).Returns(cell.Object);
 		var material = new Mock<ISolid>();
 		material.SetupGet(x => x.Id).Returns(800);
 		material.SetupGet(x => x.Name).Returns("iron");
@@ -871,6 +909,57 @@ public class UnifiedEmploymentDispatchTests
 			It.Is<IEnumerable<IGameItem>>(items => items.Single().Id == selectedItem.Object.Id)), Times.Once);
 		shop.Verify(x => x.Buy(actor.Object, merchandise.Object, It.IsAny<int>(), It.IsAny<IPaymentMethod>(), It.IsAny<string?>()),
 			Times.Never);
+	}
+
+	[TestMethod]
+	public void EmploymentPurchaseByMerchandiseSelector_DoesNotCountPriceCommodityMerchandise()
+	{
+		VirtualCashLedger.ClearInMemoryForTests();
+		var currency = Currency();
+		var (shop, _) = ShopHost(48, "Commodity Shop", currency.Object, null);
+		var actor = Character(2, "Purchaser");
+		var gameworld = new Mock<IFuturemud>();
+		var shops = new All<IShop> { shop.Object };
+		gameworld.SetupGet(x => x.Shops).Returns(shops);
+		shop.As<IHaveFuturemud>().SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		actor.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		var cell = Cell(458, "market").Object;
+		actor.SetupGet(x => x.Location).Returns(cell);
+		var merchandise = Merchandise(12, "iron commodity");
+		merchandise.SetupGet(x => x.MerchandiseType).Returns(MerchandiseType.Commodity);
+		shop.SetupGet(x => x.CurrentLocations).Returns(new[] { cell });
+		shop.SetupGet(x => x.Merchandises).Returns(new[] { merchandise.Object });
+		var purchase = new PurchaseActionStep(1, "iron commodity", "any", currency.Object,
+			new MoneyAmount(currency.Object, 10.0M));
+		var context = new EmploymentTaskContext(shop.Object);
+
+		Assert.IsFalse(context.CanPurchase(purchase, out var reason));
+		StringAssert.Contains(reason, "stock matching");
+		shop.Verify(x => x.PriceForMerchandise(It.IsAny<ICharacter?>(), merchandise.Object, It.IsAny<int>()),
+			Times.Never);
+	}
+
+	[TestMethod]
+	public void EmploymentPurchaseRequiresEmployeeAtSupplierLocation()
+	{
+		var currency = Currency();
+		var (shop, _) = ShopHost(49, "Local Shop", currency.Object, null);
+		var actor = Character(2, "Purchaser");
+		var gameworld = new Mock<IFuturemud>();
+		var shops = new All<IShop> { shop.Object };
+		gameworld.SetupGet(x => x.Shops).Returns(shops);
+		shop.As<IHaveFuturemud>().SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		actor.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		var shopCell = Cell(459, "market").Object;
+		var remoteCell = Cell(460, "warehouse").Object;
+		actor.SetupGet(x => x.Location).Returns(remoteCell);
+		shop.SetupGet(x => x.CurrentLocations).Returns(new[] { shopCell });
+		var purchase = new PurchaseActionStep(1, "thread", "any", currency.Object,
+			new MoneyAmount(currency.Object, 10.0M));
+		var context = new EmploymentTaskContext(shop.Object);
+
+		Assert.IsFalse(context.TryPurchase(actor.Object, purchase, out var reason, out _));
+		StringAssert.Contains(reason, "current location");
 	}
 
 	[TestMethod]
@@ -1286,6 +1375,31 @@ public class UnifiedEmploymentDispatchTests
 	}
 
 	[TestMethod]
+	public void PhysicalEmploymentLogistics_RejectsItemsOutsideHostLocations()
+	{
+		var currency = Currency();
+		var manager = Character(1, "Manager").Object;
+		var stockroomItems = new List<IGameItem>();
+		var shopfrontItems = new List<IGameItem>();
+		var externalItems = new List<IGameItem>();
+		var stockroom = PhysicalCell(60, "stockroom", stockroomItems).Object;
+		var shopfront = PhysicalCell(61, "shopfront", shopfrontItems).Object;
+		var externalCell = PhysicalCell(62, "private room", externalItems).Object;
+		var item = Item(610, "private ledger", trueLocations: [externalCell]).Object;
+		externalItems.Add(item);
+		var merchandise = Merchandise(800, "linen");
+		var shop = PermanentShop(900, "linen shop", currency.Object, manager,
+			EmploymentAuthority.AssignTasks | EmploymentAuthority.ManageDeliveryRoutes,
+			stockroom, [shopfront], [], [merchandise.Object], []);
+		var context = new ShopEmploymentTaskService().CreatePhysicalContext(shop.Shop.Object);
+
+		Assert.IsFalse(context.TryCollectTaskItem(manager, item, externalCell, out var reason));
+		StringAssert.Contains(reason, "assigned work locations");
+		Assert.AreEqual(1, externalItems.Count);
+		Assert.IsFalse(context.AvailableItems(externalCell).Any());
+	}
+
+	[TestMethod]
 	public void ShopEmploymentTaskService_RequiresDelegatedDeliveryAuthority()
 	{
 		var currency = Currency();
@@ -1335,6 +1449,26 @@ public class UnifiedEmploymentDispatchTests
 
 		Assert.AreEqual(1, tasks.Count);
 		Assert.IsTrue(host.EmploymentRegister.Entries.Any(x => x.EntryType == EmploymentRegisterEntryType.ManagerGoalEvaluated));
+	}
+
+	[TestMethod]
+	public void ManagerGoals_CannotUnderDeclareActionPlanAuthority()
+	{
+		var currency = Currency();
+		IEmploymentHost host = new TestEmploymentHost("hotel", currency.Object);
+		var limited = Character(2, "Limited").Object;
+		var destination = Cell(90, "storeroom").Object;
+		host.Hire(limited, Offer(currency.Object, EmploymentRole.Manager, EmploymentAuthority.CreateManagerGoals), null);
+		var definition = new ManagerGoalDefinition(
+			ManagerGoalType.MaintainHotelOperations,
+			EmploymentAuthority.None,
+			new ManagerGoalConfiguration("move room stock", new EmploymentActionPlan([
+				new DeliverItemsActionStep(destination)
+			])),
+			1,
+			TimeSpan.Zero);
+
+		Assert.ThrowsException<InvalidOperationException>(() => host.ManagerGoalBoard.CreateGoal(definition, limited));
 	}
 
 	[TestMethod]
@@ -1562,6 +1696,7 @@ public class UnifiedEmploymentDispatchTests
 			};
 			var gameworld = Gameworld(currency.Object, characters);
 			IEmploymentHost host = new PersistedEmploymentHost(151, "Payroll Shop", gameworld.Object, currency.Object);
+			VirtualCashLedger.Credit(host, currency.Object, 750.0M, null, host, "Seed", "Seed payroll balance");
 			var compensation = new CompensationTerms(
 				new MoneyAmount(currency.Object, 10.0M),
 				null,
@@ -2409,7 +2544,7 @@ public class UnifiedEmploymentDispatchTests
 		public IEmploymentHostState Employment { get; }
 	}
 
-	private sealed class PersistedEmploymentHost : FrameworkItem, IEmploymentHost, IHaveFuturemud
+	private sealed class PersistedEmploymentHost : FrameworkItem, IEmploymentHost, IHaveFuturemud, IHaveCurrency
 	{
 		private IEmploymentHostState? _employment;
 
@@ -2423,7 +2558,7 @@ public class UnifiedEmploymentDispatchTests
 
 		public override string FrameworkItemType => "PersistedEmploymentHost";
 		public IFuturemud Gameworld { get; }
-		public ICurrency Currency { get; }
+		public ICurrency Currency { get; set; }
 		public EmploymentHostType EmploymentHostType => MudSharp.Economy.Employment.EmploymentHostType.Shop;
 		public IMarket? Market => null;
 		public IEmploymentHostState Employment => _employment ??= EmploymentPersistenceStore.LoadOrCreate(this);

--- a/MudSharpCore/Commands/Helpers/EmploymentCommandService.cs
+++ b/MudSharpCore/Commands/Helpers/EmploymentCommandService.cs
@@ -664,6 +664,12 @@ internal sealed class EmploymentCommandService
 			return false;
 		}
 
+		if (role == EmploymentRole.Proprietor && !host.HasProprietorEmploymentAccess(actor))
+		{
+			message = "Only a proprietor or administrator can create proprietor employment contracts.";
+			return false;
+		}
+
 		var offer = new EmploymentOffer(
 			role,
 			UnpaidCompensation(),

--- a/MudSharpCore/Commands/Helpers/EmploymentScheduledRuleAuthoringService.cs
+++ b/MudSharpCore/Commands/Helpers/EmploymentScheduledRuleAuthoringService.cs
@@ -2349,14 +2349,23 @@ internal sealed class EmploymentScheduledRuleAuthoringService
 			return false;
 		}
 
-		duration = unit.CollapseString().ToLowerInvariant() switch
+		try
 		{
-			"s" or "sec" or "secs" or "second" or "seconds" => TimeSpan.FromSeconds((double)value),
-			"m" or "min" or "mins" or "minute" or "minutes" => TimeSpan.FromMinutes((double)value),
-			"h" or "hr" or "hrs" or "hour" or "hours" => TimeSpan.FromHours((double)value),
-			"d" or "day" or "days" => TimeSpan.FromDays((double)value),
-			_ => TimeSpan.Zero
-		};
+			duration = unit.CollapseString().ToLowerInvariant() switch
+			{
+				"s" or "sec" or "secs" or "second" or "seconds" => TimeSpan.FromSeconds((double)value),
+				"m" or "min" or "mins" or "minute" or "minutes" => TimeSpan.FromMinutes((double)value),
+				"h" or "hr" or "hrs" or "hour" or "hours" => TimeSpan.FromHours((double)value),
+				"d" or "day" or "days" => TimeSpan.FromDays((double)value),
+				_ => TimeSpan.Zero
+			};
+		}
+		catch (OverflowException)
+		{
+			duration = TimeSpan.Zero;
+			return false;
+		}
+
 		return duration > TimeSpan.Zero;
 	}
 

--- a/MudSharpCore/Economy/Employment/EmploymentActionSteps.cs
+++ b/MudSharpCore/Economy/Employment/EmploymentActionSteps.cs
@@ -221,7 +221,7 @@ public abstract class EmploymentActionStepBase : IEmploymentActionStep
 	public abstract EmploymentActionStepResult Execute(IEmploymentTaskContext context, ICharacter actor);
 }
 
-public sealed class PurchaseActionStep : EmploymentActionStepBase
+public sealed class PurchaseActionStep : EmploymentActionStepBase, IEmploymentActionStepLocationHint
 {
 	public PurchaseActionStep(string purchaseDescription, MoneyAmount amount, string? existingFinancialRecord = null)
 		: base(
@@ -362,6 +362,11 @@ public sealed class PurchaseActionStep : EmploymentActionStepBase
 		}
 
 		return EmploymentActionStepResult.CompletedResult($"Recorded audit-only purchase for {PurchaseDescription}.");
+	}
+
+	public IReadOnlyCollection<ICell> ExecutionLocationHints(IEmploymentTaskContext context, ICharacter actor)
+	{
+		return IsExecutablePurchase ? EmploymentFinanceService.PurchaseLocationHints(context, actor, this) : [];
 	}
 }
 
@@ -1652,9 +1657,16 @@ public sealed class ReturnAssetActionStep : EmploymentActionStepBase, IEmploymen
 			return false;
 		}
 
-		if (ResolveContainer(context, actor) is null)
+		var container = ResolveContainer(context, actor);
+		if (container is null)
 		{
 			reason = $"There is no return container matching {EmploymentItemSelectorResolver.Describe(ContainerSelector)}.";
+			return false;
+		}
+
+		if (container.GetItemType<IContainer>() is null)
+		{
+			reason = $"{container.Name} is not a container.";
 			return false;
 		}
 
@@ -1752,8 +1764,7 @@ public sealed class ReturnAssetActionStep : EmploymentActionStepBase, IEmploymen
 
 	private static bool ActorCarriesTaskItem(IEmploymentTaskContext context, ICharacter actor, IGameItem item)
 	{
-		return context.CarriedTaskItems(actor).Any(x => x.Id == item.Id) ||
-		       actor.Inventory.Any(x => x.Id == item.Id);
+		return context.CarriedTaskItems(actor).Any(x => x.Id == item.Id);
 	}
 }
 

--- a/MudSharpCore/Economy/Employment/EmploymentFinanceService.cs
+++ b/MudSharpCore/Economy/Employment/EmploymentFinanceService.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using MudSharp.Arenas;
 using MudSharp.Character;
+using MudSharp.Construction;
 using MudSharp.Economy;
 using MudSharp.Economy.Currency;
 using MudSharp.Framework;
@@ -942,7 +943,6 @@ internal static class EmploymentFinanceService
 
 		currency = resolvedCurrency;
 		var piles = context.CarriedTaskItems(actor)
-		                   .Concat(actor.Body.HeldItems)
 		                   .Where(x => x is not null)
 		                   .Select(x => x.GetItemType<ICurrencyPile>())
 		                   .Where(x => x is not null)
@@ -1107,6 +1107,53 @@ internal static class EmploymentFinanceService
 		}
 	}
 
+	internal static bool CanSettlePayroll(IEmploymentHost host, MoneyAmount amount, out string reason)
+	{
+		if (!TryResolveFinanceHost(host, amount, out var finance, out reason))
+		{
+			return false;
+		}
+
+		var available = AvailableFundsWithoutReservations(finance);
+		if (available >= amount.Amount)
+		{
+			reason = string.Empty;
+			return true;
+		}
+
+		reason =
+			$"{host.EmploymentHostName} only has {amount.Currency.Describe(available, CurrencyDescriptionPatternType.ShortDecimal)} available for payroll settlement, but {amount.Currency.Describe(amount.Amount, CurrencyDescriptionPatternType.ShortDecimal)} is required.";
+		return false;
+	}
+
+	internal static bool TrySettlePayroll(IEmploymentHost host, ICharacter? actor, MoneyAmount amount,
+		Guid correlationId, out string reason)
+	{
+		if (!TryResolveFinanceHost(host, amount, out var finance, out reason))
+		{
+			return false;
+		}
+
+		return DebitAvailable(finance, amount.Amount, actor, finance.Owner, "Payroll",
+			$"employment payroll settlement {correlationId:D}", EmploymentClock.CurrentDateTime(host), out reason);
+	}
+
+	internal static IReadOnlyCollection<ICell> PurchaseLocationHints(IEmploymentTaskContext context, ICharacter? actor,
+		PurchaseActionStep purchase)
+	{
+		var gameworld = (context.Employer as IHaveFuturemud)?.Gameworld ?? actor?.Gameworld;
+		if (gameworld is null)
+		{
+			return [];
+		}
+
+		return SupplierShops(gameworld, purchase.SupplierSelector ?? "any")
+		       .SelectMany(x => x.CurrentLocations)
+		       .Where(x => x is not null)
+		       .DistinctBy(x => x.Id)
+		       .ToList();
+	}
+
 	private static bool TryResolvePurchaseTarget(EmploymentTaskContext context, ICharacter? actor,
 		PurchaseActionStep purchase, out PurchaseTarget target, out string reason)
 	{
@@ -1119,14 +1166,10 @@ internal static class EmploymentFinanceService
 		}
 
 		var supplierSelector = purchase.SupplierSelector ?? "any";
-		var suppliers = supplierSelector.EqualTo("any")
-			? gameworld.Shops.ToList()
-			: gameworld.Shops.GetByIdOrName(supplierSelector) is { } supplier ? [supplier] : [];
+		var suppliers = SupplierShops(gameworld, supplierSelector);
 		var candidates = suppliers
-		                 .Where(x => x is not null)
-		                 .Cast<IShop>()
 		                 .Where(shop => actor is null ||
-		                                shop.CurrentLocations.Any(location => context.CanPath(actor, location)))
+		                                shop.CurrentLocations.Any(location => actor.Location?.Id == location.Id))
 		                 .Select(shop => ResolvePurchaseTargetInShop(context, actor, shop, purchase))
 		                 .Where(x => x is not null)
 		                 .Cast<PurchaseTarget>()
@@ -1141,9 +1184,17 @@ internal static class EmploymentFinanceService
 		}
 
 		reason = supplierSelector.EqualTo("any")
-			? $"No reachable shop has stock matching {purchase.PurchaseDescription}."
-			: $"No supplier shop matching {supplierSelector} has stock matching {purchase.PurchaseDescription}.";
+			? $"No supplier shop at the assigned employee's current location has stock matching {purchase.PurchaseDescription}."
+			: $"No supplier shop matching {supplierSelector} at the assigned employee's current location has stock matching {purchase.PurchaseDescription}.";
 		return false;
+	}
+
+	private static IReadOnlyCollection<IShop> SupplierShops(IFuturemud gameworld, string supplierSelector)
+	{
+		supplierSelector = string.IsNullOrWhiteSpace(supplierSelector) ? "any" : supplierSelector.Trim();
+		return supplierSelector.EqualTo("any")
+			? gameworld.Shops.ToList()
+			: gameworld.Shops.GetByIdOrName(supplierSelector) is { } supplier ? [supplier] : [];
 	}
 
 	private static PurchaseTarget? ResolvePurchaseTargetInShop(EmploymentTaskContext context, ICharacter? actor,
@@ -1173,6 +1224,11 @@ internal static class EmploymentFinanceService
 			return null;
 		}
 
+		if (merchandise.MerchandiseType == MerchandiseType.Commodity)
+		{
+			return null;
+		}
+
 		var quantity = purchase.Quantity ?? 1;
 		var stockedItems = shop.StockedItems(merchandise).ToList();
 		if (!string.IsNullOrWhiteSpace(purchase.KeywordFilter))
@@ -1196,6 +1252,11 @@ internal static class EmploymentFinanceService
 	{
 		foreach (var merchandise in shop.Merchandises)
 		{
+			if (merchandise.MerchandiseType == MerchandiseType.Commodity)
+			{
+				continue;
+			}
+
 			var matching = shop.StockedItems(merchandise)
 			                   .Where(x => ItemThresholdCondition.MatchesSelector(context, x, purchase.ItemSelector!))
 			                   .ToList();
@@ -1455,6 +1516,9 @@ internal static class EmploymentFinanceService
 			case IBank bank:
 				finance = new FinanceHost(bank, bank.PrimaryCurrency, null);
 				break;
+			case IHaveCurrency currencyHost:
+				finance = new FinanceHost(host, currencyHost.Currency, null);
+				break;
 			default:
 				reason =
 					$"{host.EmploymentHostName} does not expose a native employment finance adapter yet.";
@@ -1499,7 +1563,7 @@ internal static class EmploymentFinanceService
 		};
 	}
 
-	private static bool DebitAvailable(FinanceHost finance, decimal amount, ICharacter actor,
+	private static bool DebitAvailable(FinanceHost finance, decimal amount, ICharacter? actor,
 		IFrameworkItem counterparty, string sourceKind, string reference, MudDateTime? mudDateTime,
 		out string reason)
 	{
@@ -1521,7 +1585,7 @@ internal static class EmploymentFinanceService
 			sourceKind, reference, finance.BankAccount, mudDateTime, out reason, finance.Owner, reference);
 	}
 
-	private static bool DebitVirtual(FinanceHost finance, decimal amount, ICharacter actor,
+	private static bool DebitVirtual(FinanceHost finance, decimal amount, ICharacter? actor,
 		IFrameworkItem? counterparty, string sourceKind, string reference, MudDateTime? mudDateTime,
 		out string reason)
 	{
@@ -1543,7 +1607,7 @@ internal static class EmploymentFinanceService
 			sourceKind, reference, null, mudDateTime, out reason, finance.Owner, reference);
 	}
 
-	private static void CreditVirtual(FinanceHost finance, decimal amount, ICharacter actor,
+	private static void CreditVirtual(FinanceHost finance, decimal amount, ICharacter? actor,
 		IFrameworkItem? counterparty, string sourceKind, string reference, MudDateTime? mudDateTime)
 	{
 		if (finance.Owner is ICombatArena arena)

--- a/MudSharpCore/Economy/Employment/EmploymentHostState.cs
+++ b/MudSharpCore/Economy/Employment/EmploymentHostState.cs
@@ -169,6 +169,20 @@ public sealed class EmploymentHostState : IEmploymentHostState
 			throw new InvalidOperationException($"{authorisedBy.HowSeen(authorisedBy, colour: false)} is not authorised to fire employees for {Host.EmploymentHostName}.");
 		}
 
+		if (authorisedBy is not null && !authorisedBy.IsAdministrator())
+		{
+			if (concrete.Role == EmploymentRole.Proprietor)
+			{
+				throw new InvalidOperationException("Only an administrator can terminate a proprietor employment contract.");
+			}
+
+			if (concrete.Role == EmploymentRole.Manager &&
+			    !Host.HasActiveEmploymentRole(authorisedBy, EmploymentRole.Proprietor))
+			{
+				throw new InvalidOperationException("Only a proprietor or administrator can terminate manager employment contracts.");
+			}
+		}
+
 		if (concrete.Status == EmploymentStatus.Ended)
 		{
 			return;
@@ -783,6 +797,27 @@ public sealed class EmploymentPayroll : IEmploymentPayroll
 		{
 			message = "There are no outstanding employment payables to settle.";
 			return false;
+		}
+
+		var accruedAmounts = targets
+		                     .Where(x => x.Status == EmploymentPayableStatus.Accrued)
+		                     .GroupBy(x => x.Amount.Currency.Id)
+		                     .Select(x => new MoneyAmount(x.First().Amount.Currency, x.Sum(y => y.Amount.Amount)))
+		                     .ToList();
+		foreach (var amount in accruedAmounts)
+		{
+			if (!EmploymentFinanceService.CanSettlePayroll(_state.Host, amount, out message))
+			{
+				return false;
+			}
+		}
+
+		foreach (var amount in accruedAmounts)
+		{
+			if (!EmploymentFinanceService.TrySettlePayroll(_state.Host, actor, amount, Guid.NewGuid(), out message))
+			{
+				return false;
+			}
 		}
 
 		var newlyFunded = 0;

--- a/MudSharpCore/Economy/Employment/EmploymentTaskBoard.cs
+++ b/MudSharpCore/Economy/Employment/EmploymentTaskBoard.cs
@@ -126,6 +126,27 @@ public sealed class EmploymentTaskContext : IEmploymentTaskContext
 		return destination is null || !_unreachableCellIds.Contains(destination.Id);
 	}
 
+	private bool HasHostLogisticsBoundary => _usePhysicalItemMovement && Employer.EmploymentHostLocations().Any();
+
+	private bool IsHostLogisticsLocation(ICell? location)
+	{
+		return !HasHostLogisticsBoundary ||
+		       location is null ||
+		       Employer.EmploymentHostLocations().Any(x => x.Id == location.Id);
+	}
+
+	private bool TryRequireHostLogisticsLocation(ICell? location, string action, out string reason)
+	{
+		if (IsHostLogisticsLocation(location))
+		{
+			reason = string.Empty;
+			return true;
+		}
+
+		reason = $"Employment logistics can only {action} within this host's assigned work locations.";
+		return false;
+	}
+
 	public void SetAvailableItems(ICell location, IEnumerable<IGameItem> items)
 	{
 		_locationItems[location.Id] = items.ToList();
@@ -136,6 +157,11 @@ public sealed class EmploymentTaskContext : IEmploymentTaskContext
 	{
 		if (_usePhysicalItemMovement && !_configuredLocationItems.Contains(location.Id))
 		{
+			if (!IsHostLogisticsLocation(location))
+			{
+				return [];
+			}
+
 			return location.GameItems
 			               .SelectMany(x => x.DeepItems)
 			               .DistinctBy(x => x.Id)
@@ -493,6 +519,11 @@ public sealed class EmploymentTaskContext : IEmploymentTaskContext
 
 		foreach (var source in items.Select(x => x.Source).DistinctBy(x => x.Id))
 		{
+			if (!TryRequireHostLogisticsLocation(source, "collect task items", out reason))
+			{
+				return false;
+			}
+
 			if (!CanPath(actor, source))
 			{
 				reason = "The assigned employee cannot path to the source location.";
@@ -576,6 +607,11 @@ public sealed class EmploymentTaskContext : IEmploymentTaskContext
 	public bool TryDeliverTaskItems(ICharacter actor, ICell destination, IGameItem? container, string? containerTag,
 		out string reason)
 	{
+		if (!TryRequireHostLogisticsLocation(destination, "deliver task items", out reason))
+		{
+			return false;
+		}
+
 		if (!CanPath(actor, destination))
 		{
 			reason = "The assigned employee cannot path to the delivery destination.";
@@ -757,6 +793,11 @@ public sealed class EmploymentTaskContext : IEmploymentTaskContext
 		out EmploymentActionStepOperationalState operationalState)
 	{
 		operationalState = EmploymentActionStepOperationalState.Empty;
+		if (!TryRequireHostLogisticsLocation(destination, "return task containers", out reason))
+		{
+			return false;
+		}
+
 		if (!CanPath(actor, destination))
 		{
 			reason = "The assigned employee cannot path to the container return destination.";
@@ -3844,6 +3885,7 @@ public sealed class ManagerGoalBoard : IManagerGoalBoard
 
 	public IManagerGoal CreateGoal(ManagerGoalDefinition definition, ICharacter authorisedBy)
 	{
+		var requiredAuthority = RequiredAuthorityFor(definition);
 		if (!_host.HasAuthority(authorisedBy, EmploymentAuthority.CreateManagerGoals))
 		{
 			throw new InvalidOperationException($"{authorisedBy.HowSeen(authorisedBy, colour: false)} is not authorised to create manager goals for {_host.EmploymentHostName}.");
@@ -3851,7 +3893,7 @@ public sealed class ManagerGoalBoard : IManagerGoalBoard
 
 		if (!authorisedBy.IsAdministrator() &&
 		    !_host.EmploymentContracts.Where(x => x.Employee.Id == authorisedBy.Id && x.Status == EmploymentStatus.Active)
-		          .Any(x => x.Authority.ContainsAll(definition.RequiredAuthority)))
+		          .Any(x => x.Authority.ContainsAll(requiredAuthority)))
 		{
 			throw new InvalidOperationException("A manager cannot create a goal that requires authority they do not possess.");
 		}
@@ -3860,7 +3902,7 @@ public sealed class ManagerGoalBoard : IManagerGoalBoard
 			Interlocked.Increment(ref _nextId),
 			_host,
 			definition.GoalType,
-			definition.RequiredAuthority,
+			requiredAuthority,
 			ManagerGoalStatus.Active,
 			definition.Configuration,
 			definition.Priority,
@@ -3874,6 +3916,18 @@ public sealed class ManagerGoalBoard : IManagerGoalBoard
 		_host.DebugEmployment($"Created manager goal {definition.GoalType.DescribeEnum()} #{goal.Id:N0}.",
 			authorisedBy.Gameworld);
 		return goal;
+	}
+
+	private static EmploymentAuthoritySet RequiredAuthorityFor(ManagerGoalDefinition definition)
+	{
+		var authority = definition.RequiredAuthority.Authorities |
+		                (definition.Configuration.ActionPlan?.RequiredAuthority.Authorities ?? EmploymentAuthority.None);
+		foreach (var condition in definition.Configuration.Conditions ?? [])
+		{
+			authority |= condition.RequiredAuthority.Authorities;
+		}
+
+		return new EmploymentAuthoritySet(authority);
 	}
 
 	public void CancelGoal(IManagerGoal goal, ICharacter cancelledBy, string reason)


### PR DESCRIPTION
## Summary
- Remediates the Codex Security Review group `Economy — Employment, Jobs & Payroll` with invariant-level fixes for employment logistics, purchase locality, payroll funding, manager authority, and scheduled-rule duration parsing.
- Adds focused regressions for payroll funding, commodity purchase pricing, remote supplier purchases, host-bound logistics, manager/proprietor authority, manager-goal authority, and cooldown overflow.
- Updates the economy runtime design document with the new employment invariants.

## Validation
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 --filter "FullyQualifiedName~UnifiedEmploymentDispatchTests|FullyQualifiedName~EmploymentCommandServiceTests"` — passed, 119/119.
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510` — passed, 1145/1145.
- `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510` — passed, 0 warnings, 0 errors.
- `git diff --check` and `git diff --cached --check` — passed; only CRLF normalization warnings before commit.