### PR TITLE
Gate employment scheduled-rule template views

### DIFF
--- a/MudSharpCore Unit Tests/Economy/Employment/EmploymentCommandServiceTests.cs
+++ b/MudSharpCore Unit Tests/Economy/Employment/EmploymentCommandServiceTests.cs
@@ -1774,6 +1774,49 @@ public class EmploymentCommandServiceTests
 	}
 
 	[TestMethod]
+	public void EmploymentCommandService_ScheduledRulePredicateAndTemplateViewsRequireOperationalAccess()
+	{
+		var currency = Currency();
+		IEmploymentHost host = new TestEmploymentHost(1, "market shop", currency.Object);
+		var manager = Character(90, "Manager").Object;
+		var outsider = Character(91, "Outsider").Object;
+		host.Hire(manager, Offer(currency.Object, EmploymentRole.Manager,
+			EmploymentAuthority.CreateScheduledRules |
+			EmploymentAuthority.ModifyScheduledRules |
+			EmploymentAuthority.PostToHostBoard), null);
+		var service = new EmploymentCommandService();
+
+		service.ExecuteForHost(manager, host, new StringStack("tasks rule draft new Reusable Window"));
+		service.ExecuteForHost(manager, host, new StringStack("tasks rule condition manual window-open"));
+		service.ExecuteForHost(manager, host, new StringStack("tasks rule draft expression #1"));
+		service.ExecuteForHost(manager, host, new StringStack("tasks rule predicate create window-open"));
+		service.ExecuteForHost(manager, host, new StringStack("tasks rule draft new Window Notice"));
+		service.ExecuteForHost(manager, host, new StringStack("tasks rule condition manual override"));
+		service.ExecuteForHost(manager, host, new StringStack("tasks rule draft expression @window-open or #1"));
+		service.ExecuteForHost(manager, host, new StringStack("tasks rule step board Window = Open the shop."));
+		service.ExecuteForHost(manager, host, new StringStack("tasks rule draft key window-template-key"));
+		service.ExecuteForHost(manager, host, new StringStack("tasks rule template save Window Template"));
+
+		var outsiderMessages = new List<string>();
+		Mock.Get(outsider.OutputHandler)
+		    .Setup(x => x.Send(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+		    .Callback<string, bool, bool>((text, _, _) => outsiderMessages.Add(text))
+		    .Returns(true);
+
+		service.ExecuteForHost(outsider, host, new StringStack("tasks rule predicates"));
+		service.ExecuteForHost(outsider, host, new StringStack("tasks rule predicate show 1"));
+		service.ExecuteForHost(outsider, host, new StringStack("tasks rule templates"));
+		service.ExecuteForHost(outsider, host, new StringStack("tasks rule template show 1"));
+
+		Assert.AreEqual(4, outsiderMessages.Count);
+		Assert.IsTrue(outsiderMessages.All(x => x.Contains("not an employee", StringComparison.OrdinalIgnoreCase)));
+		Assert.IsFalse(outsiderMessages.Any(x =>
+			x.Contains("window-open", StringComparison.OrdinalIgnoreCase) ||
+			x.Contains("window-template-key", StringComparison.OrdinalIgnoreCase) ||
+			x.Contains("Window Template", StringComparison.OrdinalIgnoreCase)));
+	}
+
+	[TestMethod]
 	public void EmploymentScheduledRuleAuthoring_MarketPriceCondition_ParsesAndEvaluates()
 	{
 		var currency = Currency();

--- a/MudSharpCore/Commands/Helpers/EmploymentCommandService.cs
+++ b/MudSharpCore/Commands/Helpers/EmploymentCommandService.cs
@@ -1814,17 +1814,21 @@ internal sealed class EmploymentCommandService
 		{
 			case "":
 			case "list":
-				actor.OutputHandler.Send(_scheduledRuleAuthoring.RenderPredicates(actor, host));
+				SendOperationalView(actor, host,
+					(viewer, employmentHost) => _scheduledRuleAuthoring.RenderPredicates(viewer, employmentHost));
 				return;
 			case "show":
 			case "view":
 				if (input.IsFinished)
 				{
-					actor.OutputHandler.Send(_scheduledRuleAuthoring.RenderPredicates(actor, host));
+					SendOperationalView(actor, host,
+						(viewer, employmentHost) => _scheduledRuleAuthoring.RenderPredicates(viewer, employmentHost));
 					return;
 				}
 
-				actor.OutputHandler.Send(_scheduledRuleAuthoring.RenderPredicates(actor, host, input.SafeRemainingArgument));
+				SendOperationalView(actor, host,
+					(viewer, employmentHost) => _scheduledRuleAuthoring.RenderPredicates(viewer, employmentHost,
+						input.SafeRemainingArgument));
 				return;
 			case "create":
 			case "save":
@@ -1871,17 +1875,21 @@ internal sealed class EmploymentCommandService
 		{
 			case "":
 			case "list":
-				actor.OutputHandler.Send(_scheduledRuleAuthoring.RenderTemplates(actor, host));
+				SendOperationalView(actor, host,
+					(viewer, employmentHost) => _scheduledRuleAuthoring.RenderTemplates(viewer, employmentHost));
 				return;
 			case "show":
 			case "view":
 				if (input.IsFinished)
 				{
-					actor.OutputHandler.Send(_scheduledRuleAuthoring.RenderTemplates(actor, host));
+					SendOperationalView(actor, host,
+						(viewer, employmentHost) => _scheduledRuleAuthoring.RenderTemplates(viewer, employmentHost));
 					return;
 				}
 
-				actor.OutputHandler.Send(_scheduledRuleAuthoring.RenderTemplates(actor, host, input.SafeRemainingArgument));
+				SendOperationalView(actor, host,
+					(viewer, employmentHost) => _scheduledRuleAuthoring.RenderTemplates(viewer, employmentHost,
+						input.SafeRemainingArgument));
 				return;
 			case "save":
 			case "create":


### PR DESCRIPTION
## Summary
- Gate scheduled-rule predicate list/show output through the existing operational employment view authorization wrapper.
- Gate scheduled-rule template list/show output through the same employee/admin policy.
- Add a regression test proving outsiders receive the employee denial instead of predicate/template details.

## Validation
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 --filter "FullyQualifiedName~EmploymentCommandService"` (62 passed)
- `git diff --check`
- `git diff --cached --check`