### PR TITLE
Remediate character health security findings

### DIFF
--- a/DatabaseSeeder Unit Tests/CultureSeederNameAndHeightDefaultTests.cs
+++ b/DatabaseSeeder Unit Tests/CultureSeederNameAndHeightDefaultTests.cs
@@ -23,6 +23,26 @@ namespace MudSharp_Unit_Tests;
 public class CultureSeederNameAndHeightDefaultTests
 {
 	[TestMethod]
+	public void MedievalLevantineAndMorrocanNameRegexes_UsePrintableSpacesForPatronyms()
+	{
+		string source = File.ReadAllText(Path.Combine(
+			"..",
+			"..",
+			"..",
+			"..",
+			"DatabaseSeeder",
+			"Seeders",
+			"CultureSeederMedievalNamesComplex.cs"));
+
+		StringAssert.Contains(source,
+			"AddNameCulture(\"Levantine\", \"^(?<birthname>[\\\\w'-]{2,}) (?<patronym>(?:Ibnat|Bin|Ibn|Bint)[ ]*[\\\\w'-]{2,})");
+		StringAssert.Contains(source,
+			"AddNameCulture(\"Morrocan\", \"^(?<birthname>[\\\\w'-]{2,}) (?<patronym>(?:Ibnat|Bin|Ibn|Bint)[ ]*[\\\\w'-]{2,})");
+		Assert.IsFalse(source.Contains("(?:Ibnat|Bin|Ibn|Bint)\\\\s*"),
+			"Patronym separators must not use \\s because aliases can persist control whitespace.");
+	}
+
+	[TestMethod]
 	public void CultureRaceAttributeProfilesForTesting_SecondPassFantasyDefaults_AreDistinct()
 	{
 		IReadOnlyDictionary<string, NonHumanAttributeProfile> profiles =

--- a/DatabaseSeeder/Seeders/CultureSeederMedievalNamesComplex.cs
+++ b/DatabaseSeeder/Seeders/CultureSeederMedievalNamesComplex.cs
@@ -1504,7 +1504,7 @@ public partial class CultureSeeder
         #endregion
 
         #region Levantine
-        NameCulture levantine = AddNameCulture("Levantine", "^(?<birthname>[\\w'-]{2,}) (?<patronym>(?:Ibnat|Bin|Ibn|Bint)\\s*[\\w'-]{2,}) (?<surname>[\\w' -]{2,})$",
+        NameCulture levantine = AddNameCulture("Levantine", "^(?<birthname>[\\w'-]{2,}) (?<patronym>(?:Ibnat|Bin|Ibn|Bint)[ ]*[\\w'-]{2,}) (?<surname>[\\w' -]{2,})$",
             new[]{
                 ("Given Name", 1, 1, "Every person has a given name. This is the name given to the child by their parents.", NameUsage.BirthName),
                 ("Patronym", 1, 1, "Patronym is a name derived from the person's father, and is preceded by Ibn or Bin (for males), and Ibnat or Bint (for females), however ", NameUsage.Patronym),
@@ -2135,7 +2135,7 @@ public partial class CultureSeeder
         #endregion
 
         #region Morrocan
-        NameCulture morrocan = AddNameCulture("Morrocan", "^(?<birthname>[\\w'-]{2,}) (?<patronym>(?:Ibnat|Bin|Ibn|Bint)\\s*[\\w'-]{2,}) (?<surname>[\\w' -]{2,})$",
+        NameCulture morrocan = AddNameCulture("Morrocan", "^(?<birthname>[\\w'-]{2,}) (?<patronym>(?:Ibnat|Bin|Ibn|Bint)[ ]*[\\w'-]{2,}) (?<surname>[\\w' -]{2,})$",
             new[]{
                 ("Given Name", 1, 1, "Every person has a given name. This is the name given to the child by their parents.", NameUsage.BirthName),
                 ("Patronym", 1, 1, "Patronym is a name derived from the person's father, and is preceded by Ibn or Bin (for males), and Ibnat or Bint (for females), however ", NameUsage.Patronym),

--- a/FutureMUDLibrary/Character/ICharacter.cs
+++ b/FutureMUDLibrary/Character/ICharacter.cs
@@ -474,6 +474,7 @@ namespace MudSharp.Character
         IEnumerable<INameCulture> NameCultures { get; }
         INameCulture NameCultureForGender(Gender gender);
         Difficulty IlluminationSightDifficulty();
+        Difficulty IlluminationSightDifficulty(ICell location);
 #nullable enable
         ICharacter? RidingMount { get; set; }
 #nullable restore

--- a/FutureMUDLibrary/Framework/StringUtilities.cs
+++ b/FutureMUDLibrary/Framework/StringUtilities.cs
@@ -200,7 +200,14 @@ namespace MudSharp.Framework
 
             input = _substituteANSIColourRGBRegex.Replace(input, match =>
             {
-                return $"\x1b[38;2;{int.Parse(match.Groups["red"].Value)};{int.Parse(match.Groups["green"].Value)};{int.Parse(match.Groups["blue"].Value)}m";
+                if (!byte.TryParse(match.Groups["red"].Value, out var red) ||
+                    !byte.TryParse(match.Groups["green"].Value, out var green) ||
+                    !byte.TryParse(match.Groups["blue"].Value, out var blue))
+                {
+                    return match.Value;
+                }
+
+                return $"\x1b[38;2;{red};{green};{blue}m";
             });
 
             return _substituteANSIColourRegex.Replace(input, match =>

--- a/FutureMUDLibrary/Health/IDrug.cs
+++ b/FutureMUDLibrary/Health/IDrug.cs
@@ -7,6 +7,7 @@ using MudSharp.Magic;
 using MudSharp.Models;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace MudSharp.Health
@@ -42,7 +43,7 @@ namespace MudSharp.Health
         #region Overrides of DrugAdditionalInfo
 
         /// <inheritdoc />
-        public override string DatabaseString => NeutralisedTypes.Select(x => ((int)x).ToString("F0")).ListToCommaSeparatedValues(" ");
+        public override string DatabaseString => NeutralisedTypes.Select(x => ((int)x).ToString(System.Globalization.CultureInfo.InvariantCulture)).ListToCommaSeparatedValues(" ");
 
         #endregion
     }
@@ -54,7 +55,7 @@ namespace MudSharp.Health
         #region Overrides of DrugAdditionalInfo
 
         /// <inheritdoc />
-        public override string DatabaseString => NeutralisedIds.Select(x => x.ToString("F0")).ListToCommaSeparatedValues(" ");
+        public override string DatabaseString => NeutralisedIds.Select(x => x.ToString(System.Globalization.CultureInfo.InvariantCulture)).ListToCommaSeparatedValues(" ");
 
         #endregion
     }
@@ -62,7 +63,7 @@ namespace MudSharp.Health
     public class BodypartDamageAdditionalInfo : DrugAdditionalInfo
     {
         public required List<BodypartTypeEnum> BodypartTypes { get; set; }
-        public override string DatabaseString => BodypartTypes.Select(x => ((int)x).ToString("F0")).ListToCommaSeparatedValues(" ");
+        public override string DatabaseString => BodypartTypes.Select(x => ((int)x).ToString(System.Globalization.CultureInfo.InvariantCulture)).ListToCommaSeparatedValues(" ");
     }
 
     public class HealingRateAdditionalInfo : DrugAdditionalInfo
@@ -85,7 +86,7 @@ namespace MudSharp.Health
         #region Overrides of DrugAdditionalInfo
 
         /// <inheritdoc />
-        public override string DatabaseString => MagicCapabilityIds.Select(x => x.ToString("F0")).ListToCommaSeparatedValues(" ");
+        public override string DatabaseString => MagicCapabilityIds.Select(x => x.ToString(System.Globalization.CultureInfo.InvariantCulture)).ListToCommaSeparatedValues(" ");
 
         #endregion
     }
@@ -94,7 +95,7 @@ namespace MudSharp.Health
     {
         public required List<BodypartTypeEnum> OrganTypes { get; set; }
 
-        public override string DatabaseString => OrganTypes.Select(x => ((int)x).ToString("F0")).ListToCommaSeparatedValues(" ");
+        public override string DatabaseString => OrganTypes.Select(x => ((int)x).ToString(System.Globalization.CultureInfo.InvariantCulture)).ListToCommaSeparatedValues(" ");
     }
 
     public class PlanarStateAdditionalInfo : DrugAdditionalInfo

--- a/MudSharpCore Unit Tests/ChangingNeedsModelBaseTests.cs
+++ b/MudSharpCore Unit Tests/ChangingNeedsModelBaseTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MudSharp.Body;
 using MudSharp.Body.Needs;
+using MudSharp.Character.Heritage;
 
 namespace MudSharp_Unit_Tests;
 
@@ -21,6 +22,16 @@ public class ChangingNeedsModelBaseTests
     {
         Assert.AreEqual(0.0, ChangingNeedsModelBase.CalculateOversatiationLevel(540.0, 720.0), 1e-6);
         Assert.AreEqual(60.0, ChangingNeedsModelBase.CalculateOversatiationLevel(600.0, 720.0), 1e-6);
+    }
+
+    [TestMethod]
+    public void EffectiveSatiationLimit_RejectsTinyOrNonFiniteValues()
+    {
+        Assert.AreEqual(RacialSatiationDefaults.MaximumFoodSatiatedHours,
+            ChangingNeedsModelBase.GetEffectiveFoodSatiationLimit(double.Epsilon), 1e-6);
+        Assert.AreEqual(RacialSatiationDefaults.MaximumFoodSatiatedHours,
+            ChangingNeedsModelBase.GetEffectiveFoodSatiationLimit(double.PositiveInfinity), 1e-6);
+        Assert.AreEqual(1.0, ChangingNeedsModelBase.GetEffectiveFoodSatiationLimit(1.0), 1e-6);
     }
 
     [TestMethod]

--- a/MudSharpCore Unit Tests/CommonUtilitiesTests.cs
+++ b/MudSharpCore Unit Tests/CommonUtilitiesTests.cs
@@ -15,6 +15,13 @@ namespace MudSharp_Unit_Tests;
 [TestClass]
 public class CommonUtilitiesTests
 {
+    [TestMethod]
+    public void SubstituteANSIColour_InvalidRgbValuesRemainLiteral()
+    {
+        Assert.AreEqual("#`999999999999999999999999;0;0;", "#`999999999999999999999999;0;0;".SubstituteANSIColour());
+        Assert.AreEqual("#`256;0;0;", "#`256;0;0;".SubstituteANSIColour());
+    }
+
     [Flags]
     private enum TestEnum
     {

--- a/MudSharpCore Unit Tests/DrugMetadataTests.cs
+++ b/MudSharpCore Unit Tests/DrugMetadataTests.cs
@@ -1,0 +1,51 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Framework;
+using MudSharp.Health;
+using MudSharp.Models;
+using System.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class DrugMetadataTests
+{
+    [TestMethod]
+    public void DrugAdditionalInfo_LoadsEmptyAndLegacyFixedPointIdLists()
+    {
+        MudSharp.Models.Drug model = new()
+        {
+            Id = 1,
+            Name = "test",
+            DrugVectors = (int)DrugVector.Ingested,
+            IntensityPerGram = 1.0,
+            RelativeMetabolisationRate = 1.0
+        };
+        model.DrugsIntensities.Add(new DrugIntensity
+        {
+            DrugType = (int)DrugType.NeutraliseSpecificDrug,
+            RelativeIntensity = 1.0,
+            AdditionalEffects = ""
+        });
+        model.DrugsIntensities.Add(new DrugIntensity
+        {
+            DrugType = (int)DrugType.MagicAbility,
+            RelativeIntensity = 1.0,
+            AdditionalEffects = "1.00 2"
+        });
+
+        MudSharp.Health.Drug drug = new(model, new Mock<IFuturemud>().Object);
+
+        Assert.AreEqual(0, drug.AdditionalInfoFor<NeutraliseSpecificDrugAdditionalInfo>(DrugType.NeutraliseSpecificDrug).NeutralisedIds.Count);
+        CollectionAssert.AreEqual(new[] { 1L, 2L },
+            drug.AdditionalInfoFor<MagicAbilityAdditionalInfo>(DrugType.MagicAbility).MagicCapabilityIds.ToArray());
+    }
+
+    [TestMethod]
+    public void DrugAdditionalInfo_SerializesIntegerIdLists()
+    {
+        MagicAbilityAdditionalInfo info = new() { MagicCapabilityIds = [1, 2] };
+
+        Assert.AreEqual("1 2", info.DatabaseString);
+    }
+}

--- a/MudSharpCore Unit Tests/TattooTextSlotTests.cs
+++ b/MudSharpCore Unit Tests/TattooTextSlotTests.cs
@@ -7,6 +7,9 @@ using MudSharp.Character;
 using MudSharp.Communication.Language;
 using MudSharp.Form.Colour;
 using MudSharp.Framework;
+using MudSharp.FutureProg.Variables;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Interfaces;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -53,6 +56,35 @@ public class TattooTextSlotTests
             "Viewers who cannot read the writing should see the alternate text instead.");
     }
 
+    [TestMethod]
+    public void TattooTextCopy_RejectsWritingIdNotVisibleOnReadableItem()
+    {
+        TattooTestContext context = CreateTattooTestContext();
+        Mock<IWriting> writing = context.CreateWriting("Secret");
+        Mock<ICharacter> actor = context.CreateActor(writing.Object, []);
+
+        bool result = TattooTextCommandHelper.TryParseTextValues(actor.Object, context.Template.Object,
+            new StringStack("banner=copy:99"), true, out _, out _, out string error);
+
+        Assert.IsFalse(result);
+        StringAssert.Contains(error, "readable item");
+    }
+
+    [TestMethod]
+    public void TattooTextCopy_AllowsWritingVisibleOnReadableItem()
+    {
+        TattooTestContext context = CreateTattooTestContext();
+        Mock<IWriting> writing = context.CreateWriting("Visible");
+        Mock<IGameItem> item = context.CreateReadableItem(writing.Object);
+        Mock<ICharacter> actor = context.CreateActor(writing.Object, [item.Object]);
+
+        bool result = TattooTextCommandHelper.TryParseTextValues(actor.Object, context.Template.Object,
+            new StringStack("banner=copy:99"), true, out List<ITattooTextValue> values, out _, out string error);
+
+        Assert.IsTrue(result, error);
+        Assert.AreEqual("Visible", values.Single().Text);
+    }
+
     private static TattooTestContext CreateTattooTestContext()
     {
         Mock<ITraitDefinition> languageTrait = new();
@@ -76,6 +108,7 @@ public class TattooTextSlotTests
         gameworld.SetupGet(x => x.Languages).Returns(CreateCollection(language.Object));
         gameworld.SetupGet(x => x.Scripts).Returns(CreateCollection(script.Object));
         gameworld.SetupGet(x => x.Colours).Returns(CreateCollection(colour.Object));
+        gameworld.SetupGet(x => x.Items).Returns(CreateCollection<IGameItem>());
         gameworld.Setup(x => x.GetStaticInt("DefaultWritingStyleInText")).Returns((int)WritingStyleDescriptors.None);
         gameworld.Setup(x => x.GetStaticLong("DefaultWritingColourInText")).Returns(colour.Object.Id);
         gameworld.Setup(x => x.GetStaticString("DefaultAlternateTextValue")).Returns("unknown writing");
@@ -97,6 +130,7 @@ public class TattooTextSlotTests
         template.SetupGet(x => x.ShortDescription).Returns("a heart banner reading $template{banner}");
         template.SetupGet(x => x.FullDescription).Returns("A heart banner tattoo reading $template{banner}.");
         template.SetupGet(x => x.TextSlots).Returns([slot.Object]);
+        template.Setup(x => x.GetTextSlot("banner")).Returns(slot.Object);
         template.Setup(x => x.ResolveDescription(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, ITattooTextValue>>()))
             .Returns<string, IReadOnlyDictionary<string, ITattooTextValue>>((description, textValues) =>
             {
@@ -148,6 +182,47 @@ public class TattooTextSlotTests
             trait.SetupGet(x => x.Value).Returns(canRead ? 100.0 : 0.0);
             languageViewer.Setup(x => x.GetTrait(LanguageTrait.Object)).Returns(trait.Object);
             return perceiver;
+        }
+
+        public Mock<IWriting> CreateWriting(string text)
+        {
+            Mock<IWriting> writing = new();
+            writing.SetupGet(x => x.Id).Returns(99);
+            writing.SetupGet(x => x.Name).Returns("test writing");
+            writing.SetupGet(x => x.Language).Returns(Language.Object);
+            writing.SetupGet(x => x.Script).Returns(Script.Object);
+            writing.SetupGet(x => x.Style).Returns(WritingStyleDescriptors.None);
+            writing.SetupGet(x => x.WritingColour).Returns(Colour.Object);
+            writing.SetupGet(x => x.LanguageSkill).Returns(0.0);
+            writing.Setup(x => x.GetProperty("text")).Returns(new TextVariable(text));
+            return writing;
+        }
+
+        public Mock<IGameItem> CreateReadableItem(IWriting writing)
+        {
+            Mock<IReadable> readable = new();
+            readable.SetupGet(x => x.Writings).Returns([writing]);
+            readable.SetupGet(x => x.Readables).Returns([writing]);
+
+            Mock<IGameItem> item = new();
+            item.SetupGet(x => x.Id).Returns(100);
+            item.SetupGet(x => x.Name).Returns("paper");
+            item.Setup(x => x.GetItemTypes<IReadable>()).Returns([readable.Object]);
+            return item;
+        }
+
+        public Mock<ICharacter> CreateActor(IWriting writing, IGameItem[] visibleItems)
+        {
+            Mock<IFuturemud> gameworld = Gameworld;
+            gameworld.SetupGet(x => x.Writings).Returns(CreateCollection(writing));
+            gameworld.SetupGet(x => x.Items).Returns(CreateCollection(visibleItems));
+
+            Mock<ICharacter> actor = new();
+            actor.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+            actor.Setup(x => x.CanSee(It.IsAny<IGameItem>(), It.IsAny<PerceiveIgnoreFlags>()))
+                .Returns<IGameItem, PerceiveIgnoreFlags>((item, _) => visibleItems.Contains(item));
+            actor.Setup(x => x.CanRead(writing)).Returns(true);
+            return actor;
         }
     }
 }

--- a/MudSharpCore/Body/Disfigurements/TattooTextCommandHelper.cs
+++ b/MudSharpCore/Body/Disfigurements/TattooTextCommandHelper.cs
@@ -1,6 +1,8 @@
 using MudSharp.Character;
 using MudSharp.Communication.Language;
 using MudSharp.Framework;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -58,6 +60,12 @@ public static class TattooTextCommandHelper
                     return false;
                 }
 
+                if (!CanCopyWriting(actor, writing))
+                {
+                    errorMessage = "You must be able to see a readable item containing that writing to copy it.";
+                    return false;
+                }
+
                 string copiedText = GetWritingText(writing);
                 if (copiedText.Length > MaximumLengthFor(slot, writing.Script))
                 {
@@ -104,6 +112,14 @@ public static class TattooTextCommandHelper
     public static int MaximumLengthFor(ITattooTemplateTextSlot slot, IScript script)
     {
         return Math.Max(1, (int)Math.Floor(slot.MaximumLength * (script?.DocumentLengthModifier ?? 1.0)));
+    }
+
+    private static bool CanCopyWriting(ICharacter actor, IWriting writing)
+    {
+        return actor.Gameworld.Items
+                    .Where(x => actor.CanSee(x))
+                    .SelectMany(x => x.GetItemTypes<IReadable>())
+                    .Any(x => x.Writings.Contains(writing) || x.Readables.Contains(writing));
     }
 
     private static string GetWritingText(IWriting writing)

--- a/MudSharpCore/Body/Implementations/Body.cs
+++ b/MudSharpCore/Body/Implementations/Body.cs
@@ -155,8 +155,13 @@ public partial class Body : PerceiverItem, IBody
 
         foreach (ComboMerit merit in comboMerits)
         {
-            foreach (ICharacterMerit included in merit.CharacterMerits.Where(x => x.MeritScope == MeritScope.Character))
+            foreach (ICharacterMerit included in merit.CharacterMerits.Where(x => x.MeritScope == MeritScope.Body))
             {
+                if (_merits.Contains(included))
+                {
+                    continue;
+                }
+
                 _merits.Add(included);
             }
         }

--- a/MudSharpCore/Body/Implementations/BodyPerception.cs
+++ b/MudSharpCore/Body/Implementations/BodyPerception.cs
@@ -219,7 +219,7 @@ public partial class Body
             }
         }
 
-        if (flags.HasFlag(PerceiveIgnoreFlags.IgnoreDark) && thing.Location != null && Actor.IlluminationSightDifficulty() == Difficulty.Impossible)
+        if (flags.HasFlag(PerceiveIgnoreFlags.IgnoreDark) && thing.Location != null && Actor.IlluminationSightDifficulty(thing.Location) == Difficulty.Impossible)
         {
             if (!visionExemptThing && Actor.Party?.Members.Any(x => x.IsSelf(thing)) != true)
             {
@@ -896,10 +896,13 @@ public partial class Body
             List<IImplant> externalImplants = actor.Body.Implants.Where(x =>
                 x.External && !string.IsNullOrWhiteSpace(x.ExternalDescription)).ToList();
             List<IImplant> visibleExternalImplants = externalImplants.Where(x => actor.Body.ExposedBodyparts.Any(y => y.CountsAs(x.TargetBodypart))).ToList();
-            if (visibleExternalImplants.Any() || ((Actor.IsAdministrator() || Actor == actor) && externalImplants.Any()))
+            List<IImplant> displayedExternalImplants = Actor.IsAdministrator() || Actor == actor
+                ? externalImplants
+                : visibleExternalImplants;
+            if (displayedExternalImplants.Any())
             {
                 sb.AppendLine(
-                    $"{gender.Subjective(true)} {gender.Has()} {externalImplants.Select(x => $"{x.ExternalDescription.Colour(Telnet.Yellow)} in {gender.Possessive()} {x.TargetBodypart.FullDescription()}{(visibleExternalImplants.Contains(x) ? "" : " [Covered]".ColourCommand())}").ListToString()}."
+                    $"{gender.Subjective(true)} {gender.Has()} {displayedExternalImplants.Select(x => $"{x.ExternalDescription.Colour(Telnet.Yellow)} in {gender.Possessive()} {x.TargetBodypart.FullDescription()}{(visibleExternalImplants.Contains(x) ? "" : " [Covered]".ColourCommand())}").ListToString()}."
                         .Wrap(Actor.Account.InnerLineFormatLength));
             }
 

--- a/MudSharpCore/Body/Needs/ChangingNeedsModelBase.cs
+++ b/MudSharpCore/Body/Needs/ChangingNeedsModelBase.cs
@@ -13,6 +13,7 @@ namespace MudSharp.Body.Needs;
 
 public abstract class ChangingNeedsModelBase : INeedsModel
 {
+    public const double MinimumSatiationLimitHours = 0.1;
     public static double StaticRealSecondsToInGameSeconds { get; set; }
     protected double RealSecondsToInGameSeconds => StaticRealSecondsToInGameSeconds;
 
@@ -285,7 +286,7 @@ public abstract class ChangingNeedsModelBase : INeedsModel
 
     private static double GetEffectiveSatiationLimit(double configuredLimit, double fallbackLimit)
     {
-        if (double.IsNaN(configuredLimit) || double.IsInfinity(configuredLimit) || configuredLimit <= 0.0)
+        if (!double.IsFinite(configuredLimit) || configuredLimit < MinimumSatiationLimitHours)
         {
             return fallbackLimit;
         }

--- a/MudSharpCore/Body/PartProtos/BaseBoneProto.cs
+++ b/MudSharpCore/Body/PartProtos/BaseBoneProto.cs
@@ -325,7 +325,7 @@ public abstract class BaseBoneProto : BodypartPrototype, IBone
         if (part.BoneInfo.ContainsKey(this))
         {
             bool primary = part.BoneInfo[this].IsPrimaryInternalLocation;
-            part.BoneInfo[this] = new BodypartInternalInfo(hitchance, primary, group);
+            part.BoneInfo[this] = new BodypartInternalInfo(hitchance * 100.0, primary, group);
             using (new FMDB())
             {
                 BodypartProto dbtarget = FMDB.Context
@@ -344,7 +344,7 @@ public abstract class BaseBoneProto : BodypartPrototype, IBone
             return true;
         }
 
-        part.BoneInfo[this] = new BodypartInternalInfo(hitchance, false, group);
+        part.BoneInfo[this] = new BodypartInternalInfo(hitchance * 100.0, false, group);
         using (new FMDB())
         {
             BodypartInternalInfos dbinternal = new();

--- a/MudSharpCore/Body/Traits/Improvement/ClassicImprovement.cs
+++ b/MudSharpCore/Body/Traits/Improvement/ClassicImprovement.cs
@@ -419,6 +419,12 @@ Note: The formula for the #3amount#0 expression is a trait expression and also h
             return 0.0;
         }
 
+        TimeSpan noGainTimespan = TimeSpan.FromSeconds(Dice.Roll(NoGainSecondsDiceExpression));
+        if (person is IHaveEffects phe && noGainTimespan.TotalSeconds > 0)
+        {
+            phe.AddEffect(new NoTraitGain((IPerceivable)person, trait.Definition), noGainTimespan);
+        }
+
         double gain =
             ImprovementProg is not null && person is ICharacter ch ?
             ImprovementProg.ExecuteDouble(ch, trait.Definition) :
@@ -427,11 +433,6 @@ Note: The formula for the #3amount#0 expression is a trait expression and also h
         {
             trait.Gameworld.LogManager.CustomLogEntry(Logging.LogEntryType.SkillImprovement, $"-- NoGain [Gain amount was {gain:N2}]");
             return 0.0;
-        }
-        TimeSpan noGainTimespan = TimeSpan.FromSeconds(Dice.Roll(NoGainSecondsDiceExpression));
-        if (person is IHaveEffects phe && noGainTimespan.TotalSeconds > 0)
-        {
-            phe.AddEffect(new NoTraitGain((IPerceivable)person, trait.Definition), noGainTimespan);
         }
 
         trait.Gameworld.LogManager.CustomLogEntry(Logging.LogEntryType.SkillImprovement, $"-- Skill Gain of {gain:N4}");

--- a/MudSharpCore/Body/Traits/Improvement/TheoreticalImprovementModel.cs
+++ b/MudSharpCore/Body/Traits/Improvement/TheoreticalImprovementModel.cs
@@ -256,6 +256,11 @@ public class TheoreticalImprovementModel : ImprovementModel
             return 0.0;
         }
 
+        TimeSpan noGainTimespan = TimeSpan.FromSeconds(Dice.Roll(NoGainSecondsDiceExpression));
+        if (person is IHaveEffects phe && noGainTimespan.TotalSeconds > 0)
+        {
+            phe.AddEffect(new NoTraitGain((IPerceivable)person, trait.Definition), noGainTimespan);
+        }
 
         TheoreticalSkill tts = (trait as TheoreticalSkill);
         double gain = ImprovementProg is not null && person is ICharacter ch ?
@@ -265,12 +270,6 @@ public class TheoreticalImprovementModel : ImprovementModel
         {
             trait.Gameworld.LogManager.CustomLogEntry(Logging.LogEntryType.SkillImprovement, $"-- NoGain [Gain amount was {gain:N2}]");
             return 0.0;
-        }
-
-        TimeSpan noGainTimespan = TimeSpan.FromSeconds(Dice.Roll(NoGainSecondsDiceExpression));
-        if (person is IHaveEffects phe && noGainTimespan.TotalSeconds > 0)
-        {
-            phe.AddEffect(new NoTraitGain((IPerceivable)person, trait.Definition), noGainTimespan);
         }
 
         trait.Gameworld.LogManager.CustomLogEntry(Logging.LogEntryType.SkillImprovement, $"-- Skill Gain of {gain:N4}");

--- a/MudSharpCore/Character/Character.cs
+++ b/MudSharpCore/Character/Character.cs
@@ -250,6 +250,11 @@ public partial class Character : PerceiverItem, ICharacter
         {
             foreach (ICharacterMerit included in merit.CharacterMerits.Where(x => x.MeritScope == MeritScope.Character))
             {
+                if (_merits.Contains(included))
+                {
+                    continue;
+                }
+
                 _merits.Add(included);
             }
         }
@@ -1143,8 +1148,8 @@ public partial class Character : PerceiverItem, ICharacter
         sb.AppendLine($"Aliases: {Aliases.Select(x => x.GetName(NameStyle.FullWithNickname).ColourName()).ListToString()}");
         sb.AppendLine($"Current Name: {CurrentName.GetName(NameStyle.FullWithNickname).ColourName()}");
         sb.AppendLine($"Short Description: {HowSeen(voyeur, flags: PerceiveIgnoreFlags.IgnoreCanSee | PerceiveIgnoreFlags.IgnoreLoadThings | PerceiveIgnoreFlags.IgnoreObscured | PerceiveIgnoreFlags.IgnoreSelf | PerceiveIgnoreFlags.IgnoreDisguises)}");
-        sb.AppendLine($"SDesc Pattern: {_shortDescriptionPattern?.Id.ToStringN0Colour(voyeur) ?? "None".ColourError()}");
-        sb.AppendLine($"FDesc Pattern: {_fullDescriptionPattern?.Id.ToStringN0Colour(voyeur) ?? "None".ColourError()}");
+        sb.AppendLine($"SDesc Pattern: {Body.ShortDescriptionPattern?.Id.ToStringN0Colour(voyeur) ?? "None".ColourError()}");
+        sb.AppendLine($"FDesc Pattern: {Body.FullDescriptionPattern?.Id.ToStringN0Colour(voyeur) ?? "None".ColourError()}");
         sb.AppendLine($"Race: {Race.Name.ColourValue()}");
         sb.AppendLine($"Culture: {Culture.Name.ColourValue()}");
         sb.AppendLine($"Ethnicity: {Ethnicity.Name.ColourValue()}");
@@ -1812,8 +1817,13 @@ public partial class Character : PerceiverItem, ICharacter
 
     public Difficulty IlluminationSightDifficulty()
     {
+        return IlluminationSightDifficulty(Location);
+    }
+
+    public Difficulty IlluminationSightDifficulty(ICell location)
+    {
         Difficulty difficulty = Gameworld.LightModel.GetSightDifficulty(
-            Location.CurrentIllumination(this) *
+            location.CurrentIllumination(this) *
             Race.IlluminationPerceptionMultiplier
             );
 

--- a/MudSharpCore/Character/Heritage/RaceBuilding.cs
+++ b/MudSharpCore/Character/Heritage/RaceBuilding.cs
@@ -531,9 +531,10 @@ public partial class Race
     {
         if (command.IsFinished ||
             !double.TryParse(command.SafeRemainingArgument, actor.Account.Culture, out double value) ||
-            value <= 0.0)
+            !double.IsFinite(value) ||
+            value < MudSharp.Body.Needs.ChangingNeedsModelBase.MinimumSatiationLimitHours)
         {
-            actor.OutputHandler.Send("You must enter a valid number of hours greater than zero.");
+            actor.OutputHandler.Send($"You must enter a valid number of hours greater than or equal to {MudSharp.Body.Needs.ChangingNeedsModelBase.MinimumSatiationLimitHours.ToString("N2", actor).ColourValue()}.");
             return false;
         }
 
@@ -562,9 +563,10 @@ public partial class Race
     {
         if (command.IsFinished ||
             !double.TryParse(command.SafeRemainingArgument, actor.Account.Culture, out double value) ||
-            value <= 0.0)
+            !double.IsFinite(value) ||
+            value < MudSharp.Body.Needs.ChangingNeedsModelBase.MinimumSatiationLimitHours)
         {
-            actor.OutputHandler.Send("You must enter a valid number of hours greater than zero.");
+            actor.OutputHandler.Send($"You must enter a valid number of hours greater than or equal to {MudSharp.Body.Needs.ChangingNeedsModelBase.MinimumSatiationLimitHours.ToString("N2", actor).ColourValue()}.");
             return false;
         }
 
@@ -1014,8 +1016,7 @@ public partial class Race
         }
 
         string emoteText = command.SafeRemainingArgument;
-        Emote emote = new(emoteText, new DummyPerceiver(), new DummyPerceiver(), new DummyPerceiver(),
-            new DummyPerceiver());
+        Emote emote = new(emoteText, new DummyPerceiver(), new DummyPerceiver(), new DummyPerceiver());
         if (!emote.Valid)
         {
             actor.OutputHandler.Send(emote.ErrorMessage);

--- a/MudSharpCore/Character/Name/NameCulture.cs
+++ b/MudSharpCore/Character/Name/NameCulture.cs
@@ -145,6 +145,11 @@ public class NameCulture : SaveableItem, INameCulture
     {
         try
         {
+            if (string.IsNullOrWhiteSpace(pattern) || pattern.Any(char.IsControl))
+            {
+                return null;
+            }
+
             Match match = _nameEntryRegex.Match(pattern);
             if (!match.Success)
             {
@@ -159,6 +164,11 @@ public class NameCulture : SaveableItem, INameCulture
                 {
                     string[] names =
                         _nameCultureElements.First(x => x.Usage == item).MaximumCount > 1 ? match.Groups[name].Value.Split(new[] { ' ', '-' }, StringSplitOptions.RemoveEmptyEntries) : [match.Groups[name].Value];
+                    if (names.Any(x => x.Any(char.IsControl)))
+                    {
+                        return null;
+                    }
+
                     elements.Add(item, names.ToList());
                 }
             }

--- a/MudSharpCore/CharacterCreation/Chargen.cs
+++ b/MudSharpCore/CharacterCreation/Chargen.cs
@@ -1385,9 +1385,14 @@ public partial class Chargen : FrameworkItem, IChargen
                 foreach (XElement item in element.Elements())
                 {
                     long bodypartId = long.Parse(item.Attribute("bodypart").Value);
-                    SelectedDisfigurements.Add((
-                        Gameworld.DisfigurementTemplates.Get(long.Parse(item.Attribute("id").Value)),
-                        SelectedRace.BaseBody.AllExternalBodyparts.First(x => x.Id == bodypartId)));
+                    IDisfigurementTemplate disfigurement = Gameworld.DisfigurementTemplates.Get(long.Parse(item.Attribute("id").Value));
+                    IExternalBodypart bodypart = SelectedRace.BaseBody.AllExternalBodyparts.FirstOrDefault(x => x.Id == bodypartId);
+                    if (disfigurement is null || bodypart is null)
+                    {
+                        continue;
+                    }
+
+                    SelectedDisfigurements.Add((disfigurement, bodypart));
                 }
             }
 

--- a/MudSharpCore/CharacterCreation/Screens/SimpleCharacteristicsPickerScreenStoryboard.cs
+++ b/MudSharpCore/CharacterCreation/Screens/SimpleCharacteristicsPickerScreenStoryboard.cs
@@ -191,7 +191,7 @@ public class SimpleCharacteristicsPickerScreenStoryboard : ChargenScreenStoryboa
                 sb.AppendLine(
                     SelectedCharacteristics
                         .Select(x =>
-                            $"{x.Key.Name.TitleCase()}: {x.Value.Name.TitleCase().ColourValue()}"
+                            $"{x.Key.Name.TitleCase()}: {(x.Value?.Name.TitleCase().ColourValue() ?? "Not Selected".Colour(Telnet.Red))}"
                         )
                         .ArrangeStringsOntoLines((uint)Chargen.Account.LineFormatLength / 40, (uint)Chargen.Account.LineFormatLength)
                 );

--- a/MudSharpCore/CharacterCreation/Screens/SkillCostPickerScreen.cs
+++ b/MudSharpCore/CharacterCreation/Screens/SkillCostPickerScreen.cs
@@ -263,6 +263,7 @@ public class SkillCostPickerScreenStoryboard : ChargenScreenStoryboard
                                 .SelectMany(x => x.TraitAdjustments.Where(y => y.Value.giveIfMissing && y.Key is ISkillDefinition)).Select(x => x.Key)
                                 .Distinct()
                                 .Where(x => !FreeSkills.Contains(x))
+                                .Where(x => !x.Hidden)
                                 .ToList();
             Chargen.SelectedSkills.AddRange(FreeSkills);
             SetCurrentSelectables();
@@ -357,7 +358,7 @@ You get the following skills for free:
 
 You are also potentially getting the following skills from roles, but may get a higher value from selecting them here too:
 
-{RoleSkills.Select(x => x.Name.Colour(Telnet.Green)).DefaultIfEmpty("None".Colour(Telnet.Yellow)).ListToString().Wrap(Chargen.Account.InnerLineFormatLength)}" : "")}
+{RoleSkills.Where(x => !x.Hidden).Select(x => x.Name.Colour(Telnet.Green)).DefaultIfEmpty("None".Colour(Telnet.Yellow)).ListToString().Wrap(Chargen.Account.InnerLineFormatLength)}" : "")}
 
 You can select from the following skills:
 
@@ -381,7 +382,7 @@ You get the following skills for free:
 
 You are also potentially getting the following skills from roles, but may get a higher value from selecting them here too:
 
-{RoleSkills.Select(x => x.Name.Colour(Telnet.Green)).DefaultIfEmpty("None".Colour(Telnet.Yellow)).ListToString().Wrap(Chargen.Account.InnerLineFormatLength)}" : "")}
+{RoleSkills.Where(x => !x.Hidden).Select(x => x.Name.Colour(Telnet.Green)).DefaultIfEmpty("None".Colour(Telnet.Yellow)).ListToString().Wrap(Chargen.Account.InnerLineFormatLength)}" : "")}
 
 You can select from the following skills:
 

--- a/MudSharpCore/CharacterCreation/Screens/SkillPickerScreen.cs
+++ b/MudSharpCore/CharacterCreation/Screens/SkillPickerScreen.cs
@@ -158,6 +158,7 @@ public class SkillPickerScreenStoryboard : ChargenScreenStoryboard
                                 .SelectMany(x => x.TraitAdjustments.Where(y => y.Value.giveIfMissing && y.Key is ISkillDefinition)).Select(x => x.Key)
                                 .Distinct()
                                 .Where(x => !FreeSkills.Contains(x))
+                                .Where(x => !x.Hidden)
                                 .ToList();
             Chargen.SelectedSkills.AddRange(FreeSkills);
             SetCurrentSelectables();
@@ -192,7 +193,7 @@ You get the following skills for free:
 
 You are also potentially getting the following skills from roles, but may get a higher value from selecting them here too:
 
-{RoleSkills.Select(x => x.Name.Colour(Telnet.Green)).DefaultIfEmpty("None".Colour(Telnet.Yellow)).ListToString().Wrap(Chargen.Account.InnerLineFormatLength)}" : "")}
+{RoleSkills.Where(x => !x.Hidden).Select(x => x.Name.Colour(Telnet.Green)).DefaultIfEmpty("None".Colour(Telnet.Yellow)).ListToString().Wrap(Chargen.Account.InnerLineFormatLength)}" : "")}
 
 You can select from the following skills:
 
@@ -216,7 +217,7 @@ You get the following skills for free:
 
 You are also potentially getting the following skills from roles, but may get a higher value from selecting them here too:
 
-{RoleSkills.Select(x => x.Name.Colour(Telnet.Green)).DefaultIfEmpty("None".Colour(Telnet.Yellow)).ListToString().Wrap(Chargen.Account.InnerLineFormatLength)}" : "")}
+{RoleSkills.Where(x => !x.Hidden).Select(x => x.Name.Colour(Telnet.Green)).DefaultIfEmpty("None".Colour(Telnet.Yellow)).ListToString().Wrap(Chargen.Account.InnerLineFormatLength)}" : "")}
 
 You can select from the following skills:
 

--- a/MudSharpCore/Combat/Moves/RangedWeaponAttackBase.cs
+++ b/MudSharpCore/Combat/Moves/RangedWeaponAttackBase.cs
@@ -155,7 +155,7 @@ public abstract class RangedWeaponAttackBase : CombatMoveBase, IRangedWeaponAtta
         double visionModifiers = GetSpottingModifier(target.Location.Terrain(Assailant).SpotDifficulty);
 
         //Shot might be harder based on how dark the target environment is
-        Difficulty illuminationDifficulty = Assailant.IlluminationSightDifficulty();
+        Difficulty illuminationDifficulty = Assailant.IlluminationSightDifficulty(target.Location);
         visionModifiers += GetSpottingModifier(illuminationDifficulty);
 
         ICharacter targetAsCharacter = target as ICharacter;

--- a/MudSharpCore/Commands/Modules/ShowModule.cs
+++ b/MudSharpCore/Commands/Modules/ShowModule.cs
@@ -206,15 +206,35 @@ public class ShowModule : Module<ICharacter>
         switch (ss.PopForSwitch())
         {
             case "popbloodmodels":
+                if (!actor.IsAdministrator())
+                {
+                    actor.OutputHandler.Send("You are not authorised to view population blood models.");
+                    return;
+                }
                 Show_PopulationBloodModels(actor, ss);
                 return;
             case "bloodmodels":
+                if (!actor.IsAdministrator())
+                {
+                    actor.OutputHandler.Send("You are not authorised to view blood models.");
+                    return;
+                }
                 Show_BloodModels(actor, ss);
                 return;
             case "bloodantigens":
+                if (!actor.IsAdministrator())
+                {
+                    actor.OutputHandler.Send("You are not authorised to view blood antigens.");
+                    return;
+                }
                 Show_BloodAntigens(actor, ss);
                 return;
             case "bloodtypes":
+                if (!actor.IsAdministrator())
+                {
+                    actor.OutputHandler.Send("You are not authorised to view blood types.");
+                    return;
+                }
                 Show_BloodTypes(actor, ss);
                 return;
             case "speeds":

--- a/MudSharpCore/Construction/Cell.cs
+++ b/MudSharpCore/Construction/Cell.cs
@@ -506,7 +506,7 @@ public partial class Cell : Location, IDisposable, ICell
     {
         Difficulty spotDifficultyWeather =
             CurrentWeather(spotter)?.Precipitation.MinimumSightDifficulty() ?? Difficulty.Automatic;
-        Difficulty spotDifficultyLight = spotter is ICharacter ch ? ch.IlluminationSightDifficulty() : Difficulty.Automatic;
+        Difficulty spotDifficultyLight = spotter is ICharacter ch ? ch.IlluminationSightDifficulty(this) : Difficulty.Automatic;
         Difficulty spotDifficultyTerrain = Terrain(spotter).SpotDifficulty;
         return spotDifficultyLight.Highest(spotDifficultyWeather, spotDifficultyTerrain);
     }

--- a/MudSharpCore/Health/Bloodtypes/PopulationBloodModel.cs
+++ b/MudSharpCore/Health/Bloodtypes/PopulationBloodModel.cs
@@ -154,7 +154,7 @@ remove <bloodtype> - removes a blood type from this model";
             return false;
         }
 
-        if (command.IsFinished || !double.TryParse(command.SafeRemainingArgument, out double weight) || weight <= 0)
+        if (command.IsFinished || !double.TryParse(command.SafeRemainingArgument, out double weight) || weight <= 0 || !double.IsFinite(weight))
         {
             actor.OutputHandler.Send("You must supply a positive weight.");
             return false;
@@ -162,7 +162,12 @@ remove <bloodtype> - removes a blood type from this model";
 
         if (BloodModel is null)
         {
-            BloodModel = Gameworld.BloodModels.First(x => x.Bloodtypes.Contains(bt));
+            BloodModel = Gameworld.BloodModels.FirstOrDefault(x => x.Bloodtypes.Contains(bt));
+            if (BloodModel is null)
+            {
+                actor.OutputHandler.Send("That blood type is not attached to any blood model.");
+                return false;
+            }
         }
         else if (!BloodModel.Bloodtypes.Contains(bt))
         {

--- a/MudSharpCore/Health/Drug.cs
+++ b/MudSharpCore/Health/Drug.cs
@@ -10,6 +10,7 @@ using MudSharp.Magic;
 using MudSharp.Planes;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 
@@ -144,18 +145,14 @@ public class Drug : SaveableItem, IDrug
             case DrugType.NeutraliseDrugEffect:
                 return new NeutraliseDrugAdditionalInfo
                 {
-                    NeutralisedTypes = extra
-                                       .Split(' ')
-                                       .Select(int.Parse)
+                    NeutralisedTypes = ParseStoredIntList(extra)
                                        .Cast<DrugType>()
                                        .ToList()
                 };
             case DrugType.BodypartDamage:
                 return new BodypartDamageAdditionalInfo
                 {
-                    BodypartTypes = extra
-                                    .Split(' ', StringSplitOptions.RemoveEmptyEntries)
-                                    .Select(int.Parse)
+                    BodypartTypes = ParseStoredIntList(extra)
                                     .Cast<BodypartTypeEnum>()
                                     .ToList()
                 };
@@ -168,17 +165,12 @@ public class Drug : SaveableItem, IDrug
             case DrugType.MagicAbility:
                 return new MagicAbilityAdditionalInfo
                 {
-                    MagicCapabilityIds = extra
-                                             .Split(' ')
-                                             .Select(long.Parse)
-                                             .ToList()
+                    MagicCapabilityIds = ParseStoredLongList(extra)
                 };
             case DrugType.OrganFunction:
                 return new OrganFunctionAdditionalInfo
                 {
-                    OrganTypes = extra
-                                        .Split(' ', StringSplitOptions.RemoveEmptyEntries)
-                                        .Select(int.Parse)
+                    OrganTypes = ParseStoredIntList(extra)
                                         .Cast<BodypartTypeEnum>()
                                         .ToList()
                 };
@@ -195,14 +187,42 @@ public class Drug : SaveableItem, IDrug
             case DrugType.NeutraliseSpecificDrug:
                 return new NeutraliseSpecificDrugAdditionalInfo()
                 {
-                    NeutralisedIds = extra
-                                         .Split(' ')
-                     .Select(long.Parse)
-                     .ToList()
+                    NeutralisedIds = ParseStoredLongList(extra)
                 };
             default:
                 return null;
         }
+    }
+
+    private static List<int> ParseStoredIntList(string extra)
+    {
+        return ParseStoredLongList(extra)
+               .Where(x => x >= int.MinValue && x <= int.MaxValue)
+               .Select(x => (int)x)
+               .ToList();
+    }
+
+    private static List<long> ParseStoredLongList(string extra)
+    {
+        List<long> results = new();
+        foreach (string token in (extra ?? string.Empty).Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (long.TryParse(token, NumberStyles.Integer, CultureInfo.InvariantCulture, out long longValue))
+            {
+                results.Add(longValue);
+                continue;
+            }
+
+            if (decimal.TryParse(token, NumberStyles.Number, CultureInfo.InvariantCulture, out decimal decimalValue) &&
+                decimalValue == decimal.Truncate(decimalValue) &&
+                decimalValue >= long.MinValue &&
+                decimalValue <= long.MaxValue)
+            {
+                results.Add((long)decimalValue);
+            }
+        }
+
+        return results;
     }
 
     public const string HelpText = @"You can use the following options with this command:

--- a/MudSharpCore/Health/Surgery/BodypartSpecificSurgicalProcedure.cs
+++ b/MudSharpCore/Health/Surgery/BodypartSpecificSurgicalProcedure.cs
@@ -198,6 +198,11 @@ public abstract class BodypartSpecificSurgicalProcedure : SurgicalProcedure
         return ((surgeon, patient, parameters) =>
                 {
                     IBodypart bodypart = GetTargetBodypart(parameters);
+                    if (bodypart is null)
+                    {
+                        return false;
+                    }
+
                     if (patient.Body.ExposedBodyparts.Any(x => x.CountsAs(bodypart)))
                     {
                         return true;
@@ -208,6 +213,11 @@ public abstract class BodypartSpecificSurgicalProcedure : SurgicalProcedure
                 (surgeon, patient, parameters) =>
                 {
                     IBodypart bodypart = GetTargetBodypart(parameters);
+                    if (bodypart is null)
+                    {
+                        return "$1 does not have a valid target bodypart for this procedure.";
+                    }
+
                     return
                         $"$1's {bodypart.FullDescription()} is not exposed, and so the procedure cannot continue.";
                 },

--- a/MudSharpCore/Health/Surgery/ConfigureImplantPowerProcedure.cs
+++ b/MudSharpCore/Health/Surgery/ConfigureImplantPowerProcedure.cs
@@ -40,7 +40,7 @@ public class ConfigureImplantPowerProcedure : BodypartSpecificSurgicalProcedure
     /// <inheritdoc />
     public override IBodypart GetTargetBodypart(object[] parameters)
     {
-        return (IBodypart)parameters[0];
+        return parameters.ElementAtOrDefault(1) as IBodypart;
     }
 
     protected override object[] GetProcessedAdditionalArguments(ICharacter surgeon, ICharacter patient,


### PR DESCRIPTION
## Summary
- Remediate the `Character, Body, Chargen & Health` grouped Codex security findings with invariant-level fixes across chargen, body perception, health loaders, surgery, names, traits, and display surfaces.
- Add focused regressions for satiation bounds, ANSI colour parsing, tattoo copy visibility, drug metadata compatibility, and seeded name regex control-character handling.
- Harden persisted/imported legacy row handling while preserving backwards compatibility where malformed rows may already exist.

## Validation
- PASS: `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 --filter "FullyQualifiedName~ChangingNeedsModelBaseTests|FullyQualifiedName~CommonUtilitiesTests|FullyQualifiedName~TattooTextSlotTests|FullyQualifiedName~DrugMetadataTests|FullyQualifiedName~RobotRuntimeTests"` (37 passed)
- PASS: `dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore -m:1 --filter "FullyQualifiedName~CultureSeederNameAndHeightDefaultTests.MedievalLevantineAndMorrocanNameRegexes_UsePrintableSpacesForPatronyms"` (1 passed)
- PASS: `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1` (1,150 passed)
- PASS: `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510` (0 warnings, 0 errors)
- PASS: `dotnet build DatabaseSeeder\DatabaseSeeder.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510` (0 warnings, 0 errors)
- PASS: `git diff --check` and `git diff --cached --check` (line-ending normalization warnings only where reported)
- NOTE: Full `DatabaseSeeder Unit Tests` built, then failed 15 unrelated existing catalogue/design-document snapshot tests for missing retired `Design Documents\Crafting\...` files and a blank snapshot manifest mismatch.