### PR TITLE
Remediate FutureProg security runtime findings

### DIFF
--- a/Design Documents/Core/FutureProg_Type_System.md
+++ b/Design Documents/Core/FutureProg_Type_System.md
@@ -96,6 +96,16 @@ Builder-facing parsing now routes through `ProgVariableTypes.TryParse(...)` rath
 
 Type display and description logic is centralised through the registry-backed `Describe()` behavior. Existing player/builder output continues to use the same symbolic type names where possible.
 
+## Runtime Safety Invariants
+
+Collection variables must expose `IProgVariable` elements at runtime, even when a helper or dot reference builds a collection from scalar CLR values such as `string`, `decimal`, `bool`, `DateTime`, `TimeSpan`, `MudDateTime`, or `Gender`. The `CollectionVariable` constructor normalises those scalar elements so collection extension functions, admin result display, and dot references like `first`, `last`, and `reverse` all see the same element shape.
+
+Variable-register persistence must be total for every type that can be registered and saved. Value types, including `LiquidMixture`, serialise through value XML rather than reference IDs; unsupported or null preserved values must not create null `IVariableValue` entries. Resetting a stored register value removes the persisted override row and falls back to the default value.
+
+Script-time helpers that search, roll, or evaluate user-authored formulas must enforce bounded work. Weekday occurrence helpers reject zero or excessive occurrence counts, dice formulas have explicit dice/sides/roll limits, exploding dice must not be guaranteed infinite, and formula evaluation fails closed on invalid custom-function arguments, overflow, or non-finite numeric output.
+
+Writing text is not exposed through the `writing.text` FutureProg dot reference. Scripts may inspect writing metadata, but readable text still goes through the normal in-character read workflow so language, literacy, script, and access checks remain authoritative.
+
 ## Date, Time, And Celestial Event Values
 
 `ProgVariableTypes.MudDateTime` remains the FutureProg type for in-game dates and times. `MudDateTime` values now expose a `mudinstant` dot reference that returns the absolute `MudInstant` storage string for the value.

--- a/ExpressionEngine Unit Tests/ExpressionEngineTests.cs
+++ b/ExpressionEngine Unit Tests/ExpressionEngineTests.cs
@@ -49,6 +49,14 @@ public class ExpressionEngineTests
     }
 
     [TestMethod]
+    public void InvalidCustomFunctionArguments_ReturnZeroInsteadOfThrowing()
+    {
+        Assert.AreEqual(0.0, new Expression("rand(1)").EvaluateDouble());
+        Assert.AreEqual(0.0, new Expression($"dice({Expression.MaximumDiceCount + 1},6)").EvaluateDouble());
+        Assert.AreEqual(0.0, new Expression("dice(1,0)").EvaluateDouble());
+    }
+
+    [TestMethod]
     public void TestRandomFunctionOverrides()
     {
         Expression expr1 = new("rand(0.7,1.0)");

--- a/ExpressionEngine/Expression.cs
+++ b/ExpressionEngine/Expression.cs
@@ -10,6 +10,9 @@ namespace ExpressionEngine
 {
     public class Expression : IExpression
     {
+        public const int MaximumDiceCount = 10000;
+        public const int MaximumDiceSides = 100000;
+
         public static event EventHandler<string> ExpressionError;
         public static Random RandomInstance { get; } = new();
 
@@ -66,6 +69,12 @@ namespace ExpressionEngine
                 ExpressionError?.Invoke(this, $"Exception in expression {OriginalExpression}:\n\n{e}");
                 return 0.0;
             }
+            catch (Exception e) when (e is ArgumentException or OverflowException or InvalidOperationException)
+            {
+                Console.WriteLine($"Exception in expression {OriginalExpression}:\n\n{e}");
+                ExpressionError?.Invoke(this, $"Exception in expression {OriginalExpression}:\n\n{e}");
+                return 0.0;
+            }
         }
 
         public double EvaluateDouble()
@@ -113,6 +122,12 @@ namespace ExpressionEngine
                 return 0.0;
             }
             catch (NCalcEvaluationException e)
+            {
+                Console.WriteLine($"Exception in expression {OriginalExpression}:\n\n{e}");
+                ExpressionError?.Invoke(this, $"Exception in expression {OriginalExpression}:\n\n{e}");
+                return 0.0;
+            }
+            catch (Exception e) when (e is ArgumentException or OverflowException or InvalidOperationException)
             {
                 Console.WriteLine($"Exception in expression {OriginalExpression}:\n\n{e}");
                 ExpressionError?.Invoke(this, $"Exception in expression {OriginalExpression}:\n\n{e}");
@@ -182,6 +197,11 @@ namespace ExpressionEngine
             }
 
             double value = Convert.ToDouble(args.Parameters[0].Evaluate());
+            if (!double.IsFinite(value))
+            {
+                throw new ArgumentException("Not() requires a finite numeric argument");
+            }
+
             args.Result = value == 0.0 ? 1.0 : 0.0;
         }
         private void DRandFunction(string name, FunctionArgs args)
@@ -198,6 +218,11 @@ namespace ExpressionEngine
 
             double randleft = Convert.ToDouble(args.Parameters[0].Evaluate());
             double randright = Convert.ToDouble(args.Parameters[1].Evaluate());
+            if (!double.IsFinite(randleft) || !double.IsFinite(randright))
+            {
+                throw new ArgumentException("DRand() requires finite numeric arguments");
+            }
+
             args.Result = (RandomInstance.NextDouble() * (randright - randleft)) + randleft;
         }
 
@@ -224,6 +249,11 @@ namespace ExpressionEngine
 
             if (arg1 is double arg1d && arg2 is double arg2d)
             {
+                if (!double.IsFinite(arg1d) || !double.IsFinite(arg2d))
+                {
+                    throw new ArgumentException("Rand() requires finite numeric arguments");
+                }
+
                 args.Result = (RandomInstance.NextDouble() * (arg2d - arg1d)) + arg1d;
                 return;
             }
@@ -257,6 +287,11 @@ namespace ExpressionEngine
 
             int left = Convert.ToInt32(args.Parameters[0].Evaluate());
             int right = Convert.ToInt32(args.Parameters[1].Evaluate());
+            if (left < 0 || left > MaximumDiceCount || right <= 0 || right > MaximumDiceSides)
+            {
+                throw new ArgumentException($"Dice() requires 0-{MaximumDiceCount} dice and 1-{MaximumDiceSides} sides");
+            }
+
             int result = 0;
             if (left > 0)
             {

--- a/FutureMUDLibrary Unit Tests/FutureProgCollectionVariableTests.cs
+++ b/FutureMUDLibrary Unit Tests/FutureProgCollectionVariableTests.cs
@@ -1,0 +1,22 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.FutureProg;
+using MudSharp.FutureProg.Variables;
+using System.Collections.Generic;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class FutureProgCollectionVariableTests
+{
+	[TestMethod]
+	public void TextCollection_NormalisesRawStringsToTextVariables()
+	{
+		CollectionVariable variable = new(new List<string> { "north", "east" }, ProgVariableTypes.Text);
+
+		Assert.AreEqual("north", variable.GetProperty("first").GetObject);
+
+		CollectionVariable reversed = (CollectionVariable)variable.GetProperty("reverse");
+
+		Assert.AreEqual("east", reversed.GetProperty("first").GetObject);
+	}
+}

--- a/FutureMUDLibrary/Framework/Dice.cs
+++ b/FutureMUDLibrary/Framework/Dice.cs
@@ -9,6 +9,10 @@ namespace MudSharp.Framework;
 /// </summary>
 public static class Dice
 {
+    public const int MaximumDiceCount = 1000;
+    public const int MaximumSidesPerDie = 10000;
+    public const int MaximumRollsPerExpression = 10000;
+
     // TODO: improve regex to avoid false positive.
     private static readonly Regex _regex = new(@"(?<sign>\+|\-){0,1}(?<numdice>\d+){1}(?:d(?<sides>\d+))*(?:\s*(?<mod1>m|M|k|K|e|r|R|l)(?<val1>\d+)){0,1}(?:\s*(?<mod2>m|M|k|K|e|r|R|l)(?<val2>\d+)){0,1}(?:\s*(?<mod3>m|M|k|K|e|r|R|l)(?<val3>\d+)){0,1}", RegexOptions.IgnoreCase);
 
@@ -32,6 +36,77 @@ public static class Dice
             if (_regex.Replace(text, "").Length > 0)
             {
                 return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static bool TryValidateDiceExpression(string input, out string error)
+    {
+        error = string.Empty;
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            error = "The dice expression was blank.";
+            return false;
+        }
+
+        var totalDice = 0;
+        foreach (string text in input.Split([';']))
+        {
+            if (_regex.Replace(text, "").Length > 0)
+            {
+                error = "The expression contained unsupported dice syntax.";
+                return false;
+            }
+
+            foreach (Match match in _regex.Matches(text))
+            {
+                int sides = match.Groups["sides"].Length > 0 ? int.Parse(match.Groups["sides"].Value) : 1;
+                int numdice = match.Groups["numdice"].Length > 0 ? int.Parse(match.Groups["numdice"].Value) : 0;
+                bool isBareConstant = match.Groups["sides"].Length == 0 &&
+                                      string.IsNullOrEmpty(match.Groups["mod1"].Value) &&
+                                      string.IsNullOrEmpty(match.Groups["mod2"].Value) &&
+                                      string.IsNullOrEmpty(match.Groups["mod3"].Value);
+                if (isBareConstant)
+                {
+                    continue;
+                }
+
+                if (sides <= 0 || sides > MaximumSidesPerDie)
+                {
+                    error = $"Dice expressions support 1 to {MaximumSidesPerDie:N0} sides per die.";
+                    return false;
+                }
+
+                if (numdice < 0 || numdice > MaximumDiceCount)
+                {
+                    error = $"Dice expressions support 0 to {MaximumDiceCount:N0} dice per group.";
+                    return false;
+                }
+
+                totalDice += numdice;
+                if (totalDice > MaximumRollsPerExpression)
+                {
+                    error = $"Dice expressions support at most {MaximumRollsPerExpression:N0} base rolls.";
+                    return false;
+                }
+
+                for (var i = 1; i <= 3; i++)
+                {
+                    var modifier = match.Groups[$"mod{i}"].Value;
+                    if (!modifier.Equals("e", System.StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    var threshold = int.Parse(match.Groups[$"val{i}"].Value);
+                    if (threshold <= 1)
+                    {
+                        error = "Exploding dice must use a threshold greater than 1.";
+                        return false;
+                    }
+                }
             }
         }
 
@@ -104,8 +179,14 @@ public static class Dice
 
     private static int RollInternal(string expression, List<int> rawRolls)
     {
+        if (!TryValidateDiceExpression(expression, out _))
+        {
+            return 0;
+        }
+
         string[] strings = expression.Split([';']);
         int sum = 0;
+        int remainingRolls = MaximumRollsPerExpression;
         foreach (string s in strings)
         {
             if (int.TryParse(s, out int number))
@@ -126,6 +207,15 @@ public static class Dice
                 string opt1 = match.Groups["mod1"].Value;
                 string opt2 = match.Groups["mod2"].Value;
                 string opt3 = match.Groups["mod3"].Value;
+                bool isBareConstant = match.Groups["sides"].Length == 0 &&
+                                      string.IsNullOrEmpty(opt1) &&
+                                      string.IsNullOrEmpty(opt2) &&
+                                      string.IsNullOrEmpty(opt3);
+                if (isBareConstant)
+                {
+                    sum += sign * numdice;
+                    continue;
+                }
 
                 bool isMin = false, isMax = false, isKeep = false, isKeepLowest = false, isRerollOnce = false, isRerollUntil = false, isExplodes = false;
                 int minMaxReference = 0;
@@ -266,6 +356,11 @@ public static class Dice
                 List<int> rolls = new(sides);
                 for (int i = 0; i < numdice; i++)
                 {
+                    if (--remainingRolls < 0)
+                    {
+                        return 0;
+                    }
+
                     int roll = Constants.Random.Next(1, sides + 1);
                     rawRolls?.Add(roll);
                     if (isRerollOnce && roll <= rerollReference)

--- a/FutureMUDLibrary/FutureProg/Variables/CollectionVariable.cs
+++ b/FutureMUDLibrary/FutureProg/Variables/CollectionVariable.cs
@@ -1,25 +1,68 @@
 ﻿using MudSharp.Framework;
+using MudSharp.Form.Shape;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
+using MudSharp.TimeAndDate;
 
 namespace MudSharp.FutureProg.Variables
 {
     public class CollectionVariable : ProgVariable, IEnumerable
     {
-        private readonly IList _underlyingList;
+        private readonly IList<IProgVariable> _underlyingList;
 
         private readonly ProgVariableTypes _underlyingType;
 
         public CollectionVariable(IList underlyingList, ProgVariableTypes underlyingType)
         {
-            _underlyingList = underlyingList;
+            _underlyingList = underlyingList?.Cast<object>().Select(x => NormaliseCollectionItem(x, underlyingType)).ToList() ?? new List<IProgVariable>();
             _underlyingType = underlyingType;
         }
 
         public override ProgVariableTypes Type => ProgVariableTypes.Collection | _underlyingType;
 
         public override object GetObject => _underlyingList;
+
+        private static IProgVariable NormaliseCollectionItem(object item, ProgVariableTypes underlyingType)
+        {
+            if (item is IProgVariable variable)
+            {
+                return variable;
+            }
+
+            if (item is null)
+            {
+                return new NullVariable(underlyingType);
+            }
+
+            switch (underlyingType.LegacyCode)
+            {
+                case ProgVariableTypeCode.Boolean:
+                    return item is bool boolean ? new BooleanVariable(boolean) : new NullVariable(underlyingType);
+                case ProgVariableTypeCode.Gender:
+                    return item is Gender gender ? new GenderVariable(gender) : new NullVariable(underlyingType);
+                case ProgVariableTypeCode.Number:
+                    try
+                    {
+                        return new NumberVariable(Convert.ToDecimal(item));
+                    }
+                    catch (Exception)
+                    {
+                        return new NullVariable(underlyingType);
+                    }
+                case ProgVariableTypeCode.Text:
+                    return new TextVariable(item.ToString() ?? string.Empty);
+                case ProgVariableTypeCode.TimeSpan:
+                    return item is TimeSpan timeSpan ? new TimeSpanVariable(timeSpan) : new NullVariable(underlyingType);
+                case ProgVariableTypeCode.DateTime:
+                    return item is DateTime dateTime ? new DateTimeVariable(dateTime) : new NullVariable(underlyingType);
+                case ProgVariableTypeCode.MudDateTime:
+                    return item is MudDateTime mudDateTime ? mudDateTime : new NullVariable(underlyingType);
+                default:
+                    return new NullVariable(underlyingType);
+            }
+        }
 
         #region IEnumerable Members
 
@@ -80,14 +123,14 @@ namespace MudSharp.FutureProg.Variables
                 case "empty":
                     return new BooleanVariable(_underlyingList.Count == 0);
                 case "first":
-                    return _underlyingList.Count > 0 ? _underlyingList[0] as IProgVariable : new NullVariable(_underlyingType);
+                    return _underlyingList.Count > 0 ? _underlyingList[0] : new NullVariable(_underlyingType);
                 case "last":
-                    return _underlyingList.Count > 0 ? _underlyingList[^1] as IProgVariable : new NullVariable(_underlyingType);
+                    return _underlyingList.Count > 0 ? _underlyingList[^1] : new NullVariable(_underlyingType);
                 case "reverse":
                     List<IProgVariable> list = new();
                     for (int i = _underlyingList.Count - 1; i >= 0; i--)
                     {
-                        list.Add((IProgVariable)_underlyingList[i]);
+                        list.Add(_underlyingList[i]);
                     }
 
                     return new CollectionVariable(list, _underlyingType);

--- a/MudSharpCore Unit Tests/DiceTests.cs
+++ b/MudSharpCore Unit Tests/DiceTests.cs
@@ -108,6 +108,20 @@ public class DiceTests
     }
 
     [TestMethod]
+    public void TryValidateDiceExpression_RejectsGuaranteedInfiniteExplosion()
+    {
+        Assert.IsFalse(Dice.TryValidateDiceExpression("1d1e1", out string error));
+        StringAssert.Contains(error, "Exploding dice");
+    }
+
+    [TestMethod]
+    public void TryValidateDiceExpression_RejectsOversizedRolls()
+    {
+        Assert.IsFalse(Dice.TryValidateDiceExpression($"{Dice.MaximumDiceCount + 1}d6", out _));
+        Assert.AreEqual(0, Dice.Roll($"{Dice.MaximumDiceCount + 1}d6"));
+    }
+
+    [TestMethod]
     public void RollNumeric_ReturnsTotalWithBonus()
     {
         Assert.AreEqual(5, Dice.Roll(3, 1, 2));

--- a/MudSharpCore Unit Tests/FutureProgDateTimeFunctionTests.cs
+++ b/MudSharpCore Unit Tests/FutureProgDateTimeFunctionTests.cs
@@ -3,11 +3,14 @@ using Moq;
 using MudSharp.Framework;
 using MudSharp.Framework.Save;
 using MudSharp.FutureProg;
+using MudSharp.FutureProg.Functions;
+using MudSharp.FutureProg.Variables;
 using MudSharp.TimeAndDate;
 using MudSharp.TimeAndDate.Date;
 using MudSharp.TimeAndDate.Time;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml.Linq;
 
 namespace MudSharp_Unit_Tests;
@@ -85,6 +88,26 @@ public class FutureProgDateTimeFunctionTests
 		var result = prog.Execute<System.DateTime>(new System.DateTime(2026, 4, 22, 15, 30, 0, DateTimeKind.Utc));
 
 		Assert.AreEqual(new System.DateTime(2026, 4, 20, 15, 30, 0, DateTimeKind.Utc), result);
+	}
+
+	[TestMethod]
+	public void NextWeekday_SystemDateTime_RejectsOversizedOccurrence()
+	{
+		var info = MudSharp.FutureProg.FutureProg.GetFunctionCompilerInformations()
+		                     .Single(x => x.FunctionName == "nextweekday" &&
+		                                  x.Parameters.SequenceEqual([
+			                                  ProgVariableTypes.DateTime,
+			                                  ProgVariableTypes.Text,
+			                                  ProgVariableTypes.Number
+		                                  ]));
+		var function = info.CompilerFunction([
+			new ConstantFunction(new DateTimeVariable(new System.DateTime(2026, 4, 22, 15, 30, 0, DateTimeKind.Utc))),
+			new ConstantFunction(new TextVariable("Monday")),
+			new ConstantFunction(new NumberVariable(10001M))
+		], _gameworld);
+
+		Assert.AreEqual(StatementResult.Error, function.Execute(null!));
+		StringAssert.Contains(function.ErrorMessage, "10,000");
 	}
 
 	[TestMethod]
@@ -206,6 +229,21 @@ public class FutureProgDateTimeFunctionTests
 	}
 
 	[TestMethod]
+	public void TimeSpanCompoundAssignments_Execute()
+	{
+		var prog = Compile<TimeSpan>(
+			"TimeSpanCompoundAssignments",
+			ProgVariableTypes.TimeSpan,
+			[],
+			@"var duration = maketimespan(0, 1, 0, 0, 0)
+duration += maketimespan(0, 0, 30, 0, 0)
+duration -= maketimespan(0, 0, 10, 0, 0)
+return @duration");
+
+		Assert.AreEqual(new TimeSpan(0, 1, 20, 0), prog.Execute<TimeSpan>());
+	}
+
+	[TestMethod]
 	public void DateTimeComponentFunctions_ExecuteRepresentativeHelpers()
 	{
 		var dateProg = Compile<decimal>(
@@ -291,5 +329,22 @@ public class FutureProgDateTimeFunctionTests
 		var prog = new FutureProg(_gameworld, name, returnType, parameters, functionText);
 		Assert.IsTrue(prog.Compile(), prog.CompileError);
 		return prog;
+	}
+
+	private sealed class ConstantFunction(IProgVariable result) : IFunction
+	{
+		public IProgVariable Result { get; } = result;
+		public ProgVariableTypes ReturnType => Result.Type;
+		public string ErrorMessage => string.Empty;
+		public StatementResult ExpectedResult => StatementResult.Normal;
+		public StatementResult Execute(IVariableSpace variables)
+		{
+			return StatementResult.Normal;
+		}
+
+		public bool IsReturnOrContainsReturnOnAllBranches()
+		{
+			return false;
+		}
 	}
 }

--- a/MudSharpCore Unit Tests/FutureProgSecurityRegressionTests.cs
+++ b/MudSharpCore Unit Tests/FutureProgSecurityRegressionTests.cs
@@ -1,0 +1,41 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Character;
+using MudSharp.Commands.Modules;
+using MudSharp.Communication.Language;
+using MudSharp.FutureProg;
+using MudSharp.FutureProg.Variables;
+using System.Collections.Generic;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class FutureProgSecurityRegressionTests
+{
+	[TestMethod]
+	public void DescribeProgVariable_TextCollectionOfProgVariables_DoesNotThrow()
+	{
+		Mock<ICharacter> actor = new();
+		List<IProgVariable> values = [new TextVariable("north"), new TextVariable("east")];
+
+		string result = ProgModule.DescribeProgVariable(actor.Object,
+			ProgVariableTypes.Text | ProgVariableTypes.Collection, values);
+
+		StringAssert.Contains(result, "north");
+		StringAssert.Contains(result, "east");
+	}
+
+	[TestMethod]
+	public void WritingTextProperty_DoesNotExposeStoredText()
+	{
+		SimpleWriting simple = TestObjectFactory.CreateUninitialized<SimpleWriting>();
+		PrintedWriting printed = TestObjectFactory.CreateUninitialized<PrintedWriting>();
+		CompositeWriting composite = TestObjectFactory.CreateUninitialized<CompositeWriting>();
+
+		Assert.AreEqual(string.Empty, simple.GetProperty("text").GetObject);
+		Assert.AreEqual(string.Empty, printed.GetProperty("text").GetObject);
+		Assert.AreEqual(string.Empty, composite.GetProperty("text").GetObject);
+	}
+}

--- a/MudSharpCore Unit Tests/SeverFormulaTests.cs
+++ b/MudSharpCore Unit Tests/SeverFormulaTests.cs
@@ -85,4 +85,20 @@ public class SeverFormulaTests
 		Assert.IsTrue(InvokeShouldSever(body, damage.Object),
 			"The sever formula path should work even for damage types that the legacy CanSever rules would reject.");
 	}
+
+	[TestMethod]
+	public void ShouldSever_InvalidCustomFunctionArguments_FailClosed()
+	{
+		Mock<IBodypart> bodypart = new();
+		bodypart.SetupGet(x => x.CanSever).Returns(true);
+		bodypart.SetupGet(x => x.SeverFormula).Returns("rand(1)");
+
+		Mock<IRace> race = new();
+		race.Setup(x => x.ModifiedSeverthreshold(bodypart.Object)).Returns(1.0);
+
+		Body body = BuildBody(race);
+		Mock<IDamage> damage = BuildDamage(bodypart.Object, 25.0, DamageType.Chopping);
+
+		Assert.IsFalse(InvokeShouldSever(body, damage.Object));
+	}
 }

--- a/MudSharpCore/Body/Implementations/BodyBiology.cs
+++ b/MudSharpCore/Body/Implementations/BodyBiology.cs
@@ -1102,7 +1102,8 @@ public partial class Body
         if (!string.IsNullOrWhiteSpace(damage.Bodypart.SeverFormula))
         {
             IExpression expression = new Expression(damage.Bodypart.SeverFormula);
-            return expression.EvaluateDoubleWith(("damage", damage.DamageAmount), ("damagetype", (int)damage.DamageType)) >= 1.0;
+            double result = expression.EvaluateDoubleWith(("damage", damage.DamageAmount), ("damagetype", (int)damage.DamageType));
+            return double.IsFinite(result) && result >= 1.0;
         }
 
         return damage.DamageAmount >= Race.ModifiedSeverthreshold(damage.Bodypart) &&

--- a/MudSharpCore/Body/PartProtos/BodypartPrototype.cs
+++ b/MudSharpCore/Body/PartProtos/BodypartPrototype.cs
@@ -673,6 +673,23 @@ public abstract partial class BodypartPrototype : LateKeywordedInitialisingItem,
             return false;
         }
 
+        List<string> invalidParameters = expression.ParameterNames
+                                                    .Where(x => !x.EqualTo("damage") && !x.EqualTo("damagetype"))
+                                                    .ToList();
+        if (invalidParameters.Any())
+        {
+            builder.OutputHandler.Send(
+                $"Sever formulas may only use the {"damage".ColourCommand()} and {"damagetype".ColourCommand()} parameters. Unknown parameters: {invalidParameters.ListToString().ColourError()}.");
+            return false;
+        }
+
+        double result = expression.EvaluateDoubleWith(("damage", 1.0), ("damagetype", (int)DamageType.Chopping));
+        if (!double.IsFinite(result))
+        {
+            builder.OutputHandler.Send("That sever formula did not produce a finite numeric result when tested.".ColourError());
+            return false;
+        }
+
         SeverFormula = formula;
         Changed = true;
         builder.OutputHandler.Send(

--- a/MudSharpCore/Commands/Modules/ProgModule.cs
+++ b/MudSharpCore/Commands/Modules/ProgModule.cs
@@ -564,6 +564,11 @@ A function (See PROG HELP FUNCTIONS) can also function as a statement on a line.
             return "null";
         }
 
+        if (result is IProgVariable progVariable)
+        {
+            result = progVariable.GetObject;
+        }
+
         if (returnType.IsCollection)
         {
             StringBuilder sb = new();

--- a/MudSharpCore/Communication/Language/CompositeWriting.cs
+++ b/MudSharpCore/Communication/Language/CompositeWriting.cs
@@ -333,7 +333,7 @@ public class CompositeWriting : LateInitialisingItem, IGraffitiWriting, ILazyLoa
             case "languageskill":
                 return new NumberVariable(LanguageSkill);
             case "text":
-                return new TextVariable(ParseFor(null));
+                return new TextVariable(string.Empty);
             case "simple":
                 return new BooleanVariable(false);
             case "printed":

--- a/MudSharpCore/Communication/Language/PrintedWriting.cs
+++ b/MudSharpCore/Communication/Language/PrintedWriting.cs
@@ -210,7 +210,7 @@ public class PrintedWriting : LateInitialisingItem, IWriting
 			case "languageskill":
 				return new NumberVariable(LanguageSkill);
 			case "text":
-				return new TextVariable(ParseFor(null));
+				return new TextVariable(string.Empty);
 			case "simple":
 				return new BooleanVariable(false);
 			case "printed":

--- a/MudSharpCore/Communication/Language/SimpleWriting.cs
+++ b/MudSharpCore/Communication/Language/SimpleWriting.cs
@@ -260,7 +260,7 @@ public class SimpleWriting : LateInitialisingItem, IWriting, ILazyLoadDuringIdle
             case "languageskill":
                 return new NumberVariable(LanguageSkill);
             case "text":
-                return new TextVariable(ParseFor(null));
+                return new TextVariable(string.Empty);
             case "simple":
                 return new BooleanVariable(true);
             case "printed":
@@ -311,7 +311,7 @@ public class SimpleWriting : LateInitialisingItem, IWriting, ILazyLoadDuringIdle
             { "literacy", "The literacy skill of the author" },
             { "forgery", "The forgery skill of the author" },
             { "languageskill", "The language skill of the author" },
-            { "text", "The parsed text of the writing" },
+            { "text", "Writing text is not exposed through FutureProg; use in-character read workflows instead" },
             { "simple", "True if simple writing, false is composite (drawing+writing) or printed" },
             { "printed", "True if this is printed writing without a character author" },
             { "provenance", "The publisher, source, or other provenance text for printed writing" }

--- a/MudSharpCore/FutureProg/Functions/BuiltIn/ToClanRankFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/BuiltIn/ToClanRankFunction.cs
@@ -78,7 +78,7 @@ internal class ToClanRankFunction : BuiltInFunction
 
         FutureProg.RegisterBuiltInFunctionCompiler(new FunctionCompilerInformation(
             "torank",
-            new[] { ProgVariableTypes.Clan, ProgVariableTypes.Text },
+            new[] { ProgVariableTypes.Clan, ProgVariableTypes.Number },
             (pars, gameworld) => new ToClanRankFunction(pars, gameworld),
             new List<string> { "clan", "name" },
             new List<string> { "The clan in which you want to search", "The name to look up" },

--- a/MudSharpCore/FutureProg/Functions/Characters/GetPath.cs
+++ b/MudSharpCore/FutureProg/Functions/Characters/GetPath.cs
@@ -142,13 +142,13 @@ internal class GetPath : BuiltInFunction
 
         if (ParameterFunctions[0].Result is not ICharacter target)
         {
-            Result = new BooleanVariable(false);
+            Result = new CollectionVariable(new List<IProgVariable>(), ProgVariableTypes.Text);
             return StatementResult.Normal;
         }
 
         if (ParameterFunctions[1].Result is not ICell location)
         {
-            Result = new BooleanVariable(false);
+            Result = new CollectionVariable(new List<IProgVariable>(), ProgVariableTypes.Text);
             return StatementResult.Normal;
         }
 

--- a/MudSharpCore/FutureProg/Functions/Characters/GiveAccentFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Characters/GiveAccentFunction.cs
@@ -70,7 +70,7 @@ internal class GiveAccentFunction : BuiltInFunction
             return StatementResult.Error;
         }
 
-        if (target.AccentDifficulty(accent, false) == Difficulty.Automatic)
+        if (target.Accents.Contains(accent))
         {
             Result = new BooleanVariable(false);
             return StatementResult.Normal;

--- a/MudSharpCore/FutureProg/Functions/Characters/GiveMeritFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Characters/GiveMeritFunction.cs
@@ -76,8 +76,7 @@ internal class GiveMeritFunction : BuiltInFunction
             return StatementResult.Normal;
         }
 
-        target.AddMerit(merit);
-        Result = new BooleanVariable(true);
+        Result = new BooleanVariable(target.AddMerit(merit));
         return StatementResult.Normal;
     }
 }

--- a/MudSharpCore/FutureProg/Functions/Characters/RemoveMeritFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Characters/RemoveMeritFunction.cs
@@ -70,8 +70,7 @@ internal class RemoveMeritFunction : BuiltInFunction
 
         if (target.Merits.Contains(merit))
         {
-            target.RemoveMerit(merit);
-            Result = new BooleanVariable(true);
+            Result = new BooleanVariable(target.RemoveMerit(merit));
             return StatementResult.Normal;
         }
 

--- a/MudSharpCore/FutureProg/Functions/Characters/WhyCantMountFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Characters/WhyCantMountFunction.cs
@@ -26,7 +26,7 @@ internal class WhyCantMountFunction : BuiltInFunction
                 },
                 "Returns an error message about why a character cannot mount the mount.",
                 "Characters",
-                ProgVariableTypes.Boolean
+                ProgVariableTypes.Text
             )
         );
     }
@@ -44,7 +44,7 @@ internal class WhyCantMountFunction : BuiltInFunction
 
     public override ProgVariableTypes ReturnType
     {
-        get => ProgVariableTypes.Boolean;
+        get => ProgVariableTypes.Text;
         protected set { }
     }
 

--- a/MudSharpCore/FutureProg/Functions/DateTime/WeekdayFunctions.cs
+++ b/MudSharpCore/FutureProg/Functions/DateTime/WeekdayFunctions.cs
@@ -10,6 +10,7 @@ namespace MudSharp.FutureProg.Functions.DateTime;
 
 internal class WeekdayFunction : BuiltInFunction
 {
+	private const int MaximumWeekdayOccurrences = 10000;
 	private readonly int _direction;
 	private readonly ProgVariableTypes _returnType;
 
@@ -33,12 +34,13 @@ internal class WeekdayFunction : BuiltInFunction
 			return StatementResult.Error;
 		}
 
-		var count = _direction * GetOccurrenceCount();
-		if (count == 0)
+		var occurrences = GetOccurrenceCount();
+		if (occurrences is null)
 		{
-			ErrorMessage = $"{FunctionName} must be supplied a non-zero occurrence number.";
+			ErrorMessage = $"{FunctionName} must be supplied a non-zero occurrence number no greater than {MaximumWeekdayOccurrences:N0}.";
 			return StatementResult.Error;
 		}
+		var count = _direction * occurrences.Value;
 
 		switch ((_returnType & ~ProgVariableTypes.Literal).LegacyCode)
 		{
@@ -53,7 +55,7 @@ internal class WeekdayFunction : BuiltInFunction
 
 	private string FunctionName => _direction > 0 ? "NextWeekday" : "LastWeekday";
 
-	private int GetOccurrenceCount()
+	private int? GetOccurrenceCount()
 	{
 		if (ParameterFunctions.Count == 2)
 		{
@@ -65,10 +67,11 @@ internal class WeekdayFunction : BuiltInFunction
 		    value > int.MaxValue ||
 		    value <= int.MinValue)
 		{
-			return 0;
+			return null;
 		}
 
-		return (int)value;
+		var occurrences = (int)value;
+		return Math.Abs(occurrences) <= MaximumWeekdayOccurrences && occurrences != 0 ? occurrences : null;
 	}
 
 	private StatementResult ExecuteSystemDateTime(int count)

--- a/MudSharpCore/FutureProg/Functions/Effects/AddInvisEffectFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Effects/AddInvisEffectFunction.cs
@@ -44,7 +44,13 @@ internal class AddInvisEffectFunction : BuiltInFunction
 
         IFutureProg prog = (ParameterFunctions[1].ReturnType.CompatibleWith(ProgVariableTypes.Number)
             ? _gameworld.FutureProgs.Get(Convert.ToInt64(ParameterFunctions[1].Result?.GetObject ?? 0))
-            : _gameworld.FutureProgs.GetByName((string)ParameterFunctions[1].Result?.GetObject ?? "")) ?? _gameworld.AlwaysTrueProg;
+            : _gameworld.FutureProgs.GetByName((string)ParameterFunctions[1].Result?.GetObject ?? ""));
+
+        if (prog is null)
+        {
+            Result = new NullVariable(ProgVariableTypes.Effect);
+            return StatementResult.Normal;
+        }
 
         if (prog.ReturnType != ProgVariableTypes.Boolean ||
             !prog.MatchesParameters([ProgVariableTypes.Perceivable, ProgVariableTypes.Perceivable])

--- a/MudSharpCore/FutureProg/Functions/Health/WoundFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/Health/WoundFunction.cs
@@ -193,7 +193,7 @@ internal class WoundFunction : BuiltInFunction
         else
         {
             string expr = ParameterFunctions[2].Result?.GetObject?.ToString() ?? "";
-            if (!Dice.IsDiceExpression(expr))
+            if (!Dice.TryValidateDiceExpression(expr, out _))
             {
                 Result = new BooleanVariable(false);
                 return StatementResult.Normal;

--- a/MudSharpCore/FutureProg/Statements/MinusEqualsVariable.cs
+++ b/MudSharpCore/FutureProg/Statements/MinusEqualsVariable.cs
@@ -159,6 +159,21 @@ See also #3=#0, #3+=#0, #3*=#0, #3/=#0, #3%=#0 and #3^=#0 for other ways of assi
             ((IList<IProgVariable>)collection.GetObject).Remove(ValueFunction.Result);
             return StatementResult.Normal;
         }
+
+        if (TypeToSet.CompatibleWith(ProgVariableTypes.TimeSpan))
+        {
+            TimeSpan? current = variables.GetVariable(NameToSet)?.GetObject as TimeSpan?;
+            if (current is null)
+            {
+                ErrorMessage = "Tried to -= a null timespan.";
+                return StatementResult.Error;
+            }
+
+            TimeSpan newValue = current.Value - ((TimeSpan?)ValueFunction.Result?.GetObject ?? TimeSpan.Zero);
+            variables.SetVariable(NameToSet, new TimeSpanVariable(newValue));
+            return StatementResult.Normal;
+        }
+
         if (TypeToSet.CompatibleWith(ProgVariableTypes.DateTime))
         {
             DateTime? current = variables.GetVariable(NameToSet)?.GetObject as DateTime?;

--- a/MudSharpCore/FutureProg/Statements/PlusEqualsVariable.cs
+++ b/MudSharpCore/FutureProg/Statements/PlusEqualsVariable.cs
@@ -160,6 +160,21 @@ See also #3=#0, #3-=#0, #3*=#0, #3/=#0, #3%=#0 and #3^=#0 for other ways of assi
             ((IList<IProgVariable>)collection.GetObject).Add(ValueFunction.Result);
             return StatementResult.Normal;
         }
+
+        if (TypeToSet.CompatibleWith(ProgVariableTypes.TimeSpan))
+        {
+            TimeSpan? current = variables.GetVariable(NameToSet)?.GetObject as TimeSpan?;
+            if (current is null)
+            {
+                ErrorMessage = "Tried to += a null timespan.";
+                return StatementResult.Error;
+            }
+
+            TimeSpan newValue = current.Value + ((TimeSpan?)ValueFunction.Result?.GetObject ?? TimeSpan.Zero);
+            variables.SetVariable(NameToSet, new TimeSpanVariable(newValue));
+            return StatementResult.Normal;
+        }
+
         if (TypeToSet.CompatibleWith(ProgVariableTypes.DateTime))
         {
             DateTime? current = variables.GetVariable(NameToSet)?.GetObject as DateTime?;

--- a/MudSharpCore/FutureProg/VariableRegister.cs
+++ b/MudSharpCore/FutureProg/VariableRegister.cs
@@ -66,6 +66,7 @@ internal class VariableRegister : SaveableItem, IVariableRegister
                         case ProgVariableTypeCode.TimeSpan:
                         case ProgVariableTypeCode.DateTime:
                         case ProgVariableTypeCode.MudDateTime:
+                        case ProgVariableTypeCode.LiquidMixture:
                             newValue = new ValueVariableValue(XElement.Parse(sub.DefaultValue), valueType, gameworld);
                             break;
                         default:
@@ -115,6 +116,7 @@ internal class VariableRegister : SaveableItem, IVariableRegister
                     case ProgVariableTypeCode.DateTime:
                     case ProgVariableTypeCode.TimeSpan:
                     case ProgVariableTypeCode.MudDateTime:
+                    case ProgVariableTypeCode.LiquidMixture:
                         newValue = new ValueVariableValue(XElement.Parse(item.ValueDefinition), type, gameworld);
                         break;
                     default:
@@ -191,6 +193,16 @@ internal class VariableRegister : SaveableItem, IVariableRegister
             foreach (VariableReference item in _changedReferences)
             {
                 Models.VariableValue dbitem = FMDB.Context.VariableValues.Find(item.Type.ToStorageString(), item.ID, item.VariableName);
+                if (!_values.TryGetValue(item, out IVariableValue value))
+                {
+                    if (dbitem is not null)
+                    {
+                        FMDB.Context.VariableValues.Remove(dbitem);
+                    }
+
+                    continue;
+                }
+
                 if (dbitem == null)
                 {
                     dbitem = new Models.VariableValue
@@ -202,7 +214,6 @@ internal class VariableRegister : SaveableItem, IVariableRegister
                     FMDB.Context.VariableValues.Add(dbitem);
                 }
 
-                IVariableValue value = _values[item];
                 dbitem.ValueDefinition = value.SaveToXml().ToString();
                 dbitem.ValueTypeDefinition = value.Type.ToStorageString();
             }
@@ -306,6 +317,7 @@ internal class VariableRegister : SaveableItem, IVariableRegister
                     case ProgVariableTypeCode.DateTime:
                     case ProgVariableTypeCode.TimeSpan:
                     case ProgVariableTypeCode.MudDateTime:
+                    case ProgVariableTypeCode.LiquidMixture:
                         Collection.Add(new ValueVariableValue(element, UnderlyingType, gameworld));
                         break;
                     default:
@@ -373,6 +385,7 @@ internal class VariableRegister : SaveableItem, IVariableRegister
                     case ProgVariableTypeCode.DateTime:
                     case ProgVariableTypeCode.TimeSpan:
                     case ProgVariableTypeCode.MudDateTime:
+                    case ProgVariableTypeCode.LiquidMixture:
                         foreach (XElement sub in element.Elements("var"))
                         {
                             Dictionary.Add(key, new ValueVariableValue(sub, UnderlyingType, gameworld));
@@ -458,6 +471,7 @@ internal class VariableRegister : SaveableItem, IVariableRegister
                     case ProgVariableTypeCode.DateTime:
                     case ProgVariableTypeCode.TimeSpan:
                     case ProgVariableTypeCode.MudDateTime:
+                    case ProgVariableTypeCode.LiquidMixture:
                         Dictionary.Add(element.Element("key").Value,
                             new ValueVariableValue(element.Element("var"), UnderlyingType, gameworld));
                         break;
@@ -515,34 +529,35 @@ internal class VariableRegister : SaveableItem, IVariableRegister
         public ValueVariableValue(XElement root, ProgVariableTypes type, IFuturemud gameworld)
         {
             Type = type;
-            if (root.HasElements)
-            {
-                root = root.Element("var");
-            }
+            XElement valueRoot = root.Name == "var" ? root : root.Element("var") ?? root;
 
             switch (type.LegacyCode)
             {
                 case ProgVariableTypeCode.Boolean:
-                    Value = bool.Parse(root.Value);
+                    Value = bool.Parse(valueRoot.Value);
                     break;
                 case ProgVariableTypeCode.Gender:
-                    Value = (Gender)short.Parse(root.Value);
+                    Value = (Gender)short.Parse(valueRoot.Value);
                     break;
                 case ProgVariableTypeCode.Number:
-                    Value = decimal.Parse(root.Value);
+                    Value = decimal.Parse(valueRoot.Value);
                     break;
                 case ProgVariableTypeCode.Text:
-                    Value = root.Value;
+                    Value = valueRoot.Value;
                     break;
                 case ProgVariableTypeCode.TimeSpan:
-                    Value = TimeSpan.Parse(root.Value, CultureInfo.InvariantCulture);
+                    Value = TimeSpan.Parse(valueRoot.Value, CultureInfo.InvariantCulture);
                     break;
                 case ProgVariableTypeCode.DateTime:
-                    Value = DateTime.Parse(root.Value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
+                    Value = DateTime.Parse(valueRoot.Value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
                     break;
                 case ProgVariableTypeCode.MudDateTime:
-                    Value = MudDateTime.FromStoredStringOrFallback(root.Value, gameworld,
+                    Value = MudDateTime.FromStoredStringOrFallback(valueRoot.Value, gameworld,
                         StoredMudDateTimeFallback.Never, "FutureProgVariable", null, null, "MudDateTime");
+                    break;
+                case ProgVariableTypeCode.LiquidMixture:
+                    Value = valueRoot.Element("Mix")?.ToString() ??
+                            (valueRoot.Name == "Mix" ? valueRoot.ToString() : valueRoot.Value);
                     break;
             }
         }
@@ -587,7 +602,13 @@ internal class VariableRegister : SaveableItem, IVariableRegister
                 case ProgVariableTypeCode.MudDateTime:
                     return (MudDateTime)Value;
                 case ProgVariableTypeCode.LiquidMixture:
-                    return new LiquidMixture(XElement.Parse(Value.ToString()), game);
+                    return Value switch
+                    {
+                        LiquidMixture mixture => mixture,
+                        XElement element => new LiquidMixture(element, game),
+                        string text when !string.IsNullOrWhiteSpace(text) => new LiquidMixture(XElement.Parse(text), game),
+                        _ => LiquidMixture.CreateEmpty(game)
+                    };
             }
 
             return null;
@@ -601,6 +622,23 @@ internal class VariableRegister : SaveableItem, IVariableRegister
                     return new XElement("var", ((DateTime)Value).ToString(CultureInfo.InvariantCulture));
                 case ProgVariableTypeCode.MudDateTime:
                     return new XElement("var", ((MudDateTime)Value).GetDateTimeString());
+                case ProgVariableTypeCode.LiquidMixture:
+                    if (Value is LiquidMixture mixture)
+                    {
+                        return new XElement("var", mixture.SaveToXml());
+                    }
+
+                    if (Value is string text && !string.IsNullOrWhiteSpace(text))
+                    {
+                        return new XElement("var", XElement.Parse(text));
+                    }
+
+                    if (Value is XElement element)
+                    {
+                        return new XElement("var", element);
+                    }
+
+                    return new XElement("var");
             }
 
             return new XElement("var", Value);
@@ -887,7 +925,9 @@ internal class VariableRegister : SaveableItem, IVariableRegister
             {
                 Collection =
                     ((IList<IProgVariable>)value.GetObject).Select(
-                        x => GetValue(type ^ ProgVariableTypes.Collection, x)).ToList(),
+                        x => GetValue(type ^ ProgVariableTypes.Collection, x))
+                       .Where(x => x is not null)
+                       .ToList(),
                 UnderlyingType = type ^ ProgVariableTypes.Collection
             };
         }
@@ -902,7 +942,9 @@ internal class VariableRegister : SaveableItem, IVariableRegister
             return new DictionaryVariableValue
             {
                 Dictionary = ((Dictionary<string, IProgVariable>)value.GetObject).ToDictionary(x => x.Key,
-                    x => GetValue(type ^ ProgVariableTypes.Dictionary, x.Value)),
+                    x => GetValue(type ^ ProgVariableTypes.Dictionary, x.Value))
+                    .Where(x => x.Value is not null)
+                    .ToDictionary(x => x.Key, x => x.Value),
                 UnderlyingType = type ^ ProgVariableTypes.Dictionary
             };
         }
@@ -920,11 +962,15 @@ internal class VariableRegister : SaveableItem, IVariableRegister
             {
                 foreach (IProgVariable sub in item.Value)
                 {
-                    collection.Add(item.Key, GetValue(underlying, sub));
+                    IVariableValue serialised = GetValue(underlying, sub);
+                    if (serialised is not null)
+                    {
+                        collection.Add(item.Key, serialised);
+                    }
                 }
             }
 
-            return new CollectionDictionaryVariableValue { Dictionary = collection };
+            return new CollectionDictionaryVariableValue { Dictionary = collection, UnderlyingType = underlying };
         }
 
         switch (type.LegacyCode)
@@ -942,6 +988,12 @@ internal class VariableRegister : SaveableItem, IVariableRegister
             case ProgVariableTypeCode.DateTime:
             case ProgVariableTypeCode.MudDateTime:
                 return new ValueVariableValue { Type = type, Value = value.GetObject };
+            case ProgVariableTypeCode.LiquidMixture:
+                return new ValueVariableValue
+                {
+                    Type = type,
+                    Value = value.GetObject is LiquidMixture mixture ? mixture.SaveToXml().ToString() : value.GetObject
+                };
             default:
                 return new ReferenceVariableValue
                 {
@@ -966,7 +1018,20 @@ internal class VariableRegister : SaveableItem, IVariableRegister
             return false;
         }
 
+        if (value is null)
+        {
+            _values.Remove(reference);
+            Changed = true;
+            _changedReferences.Add(reference);
+            return true;
+        }
+
         IVariableValue newValue = GetValue(type, value);
+        if (newValue is null)
+        {
+            return false;
+        }
+
         _values[reference] = newValue;
         Changed = true;
         _changedReferences.Add(reference);
@@ -982,7 +1047,23 @@ internal class VariableRegister : SaveableItem, IVariableRegister
             _defaultValues[type] = new Dictionary<string, IVariableValue>();
         }
 
-        _defaultValues[type][variable] = GetValue(_types[type][variable], value);
+        ProgVariableTypes variableType = _types[type][variable];
+        IVariableValue newValue = GetValue(variableType, value);
+        if (newValue is null &&
+            !variableType.HasFlag(ProgVariableTypes.Collection) &&
+            !variableType.HasFlag(ProgVariableTypes.Dictionary) &&
+            !variableType.HasFlag(ProgVariableTypes.CollectionDictionary) &&
+            !ProgVariableTypes.ValueType.HasFlag(variableType))
+        {
+            newValue = new ReferenceVariableValue { Type = variableType, ID = 0 };
+        }
+
+        if (newValue is null)
+        {
+            return;
+        }
+
+        _defaultValues[type][variable] = newValue;
         Changed = true;
         _changedDefaults.Add(Tuple.Create(type, variable));
     }
@@ -1084,6 +1165,15 @@ internal class VariableRegister : SaveableItem, IVariableRegister
                     defaultDictionary[variable.ToLowerInvariant()] =
                         new ValueVariableValue { Type = variableType, Value = defaultValue };
                     break;
+                case ProgVariableTypeCode.LiquidMixture:
+                    defaultDictionary[variable.ToLowerInvariant()] = new ValueVariableValue
+                    {
+                        Type = variableType,
+                        Value = defaultValue is LiquidMixture mixture
+                            ? mixture.SaveToXml().ToString()
+                            : LiquidMixture.CreateEmpty(Gameworld).SaveToXml().ToString()
+                    };
+                    break;
             }
         }
         else
@@ -1114,8 +1204,14 @@ internal class VariableRegister : SaveableItem, IVariableRegister
             }
             else
             {
+                IVariableValue defaultVariableValue = GetValue(variableType, defaultValue as IProgVariable) ??
+                                                      new ReferenceVariableValue
+                                                      {
+                                                          ID = (defaultValue as IFrameworkItem)?.Id ?? 0,
+                                                          Type = variableType
+                                                      };
                 defaultDictionary[variable.ToLowerInvariant()] =
-                    GetValue(variableType, defaultValue as IProgVariable);
+                    defaultVariableValue;
             }
         }
 

--- a/MudSharpCore/GameItems/GameItemFutureprogs.cs
+++ b/MudSharpCore/GameItems/GameItemFutureprogs.cs
@@ -463,9 +463,9 @@ public partial class GameItem
             case "quality":
                 return new NumberVariable((int)Quality);
             case "qualityname":
-                return new TextVariable(RawQuality.DescribeEnum());
+                return new TextVariable(Quality.DescribeEnum());
             case "rawquality":
-                return new NumberVariable((int)Quality);
+                return new NumberVariable((int)RawQuality);
             case "rawqualityname":
                 return new TextVariable(RawQuality.DescribeEnum());
             default:


### PR DESCRIPTION
## Summary
- Bound FutureProg/script runtime work in weekday helpers, dice formulas, wound/sever formulas, and expression custom functions.
- Normalize FutureProg collection element shapes and harden variable-register serialization for LiquidMixture and unsupported preserved values.
- Fix function contract/data-integrity issues for writing text exposure, invisibility progs, TimeSpan assignments, merit/accent mutation results, clan rank lookup, item quality fields, and related docs.

## Validation
- `dotnet build FutureMUDLibrary\FutureMUDLibrary.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510` - passed
- `dotnet build ExpressionEngine\ExpressionEngine.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510` - passed after rerunning sequentially to avoid transient CS2012 file lock
- `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510` - passed
- `dotnet test 'FutureMUDLibrary Unit Tests\FutureMUDLibrary Unit Tests.csproj' -c Debug --no-restore -m:1 --filter "FullyQualifiedName~FutureProgCollectionVariableTests"` - passed 1/1
- `dotnet test 'ExpressionEngine Unit Tests\ExpressionEngine Unit Tests.csproj' -c Debug --no-restore -m:1 --filter "FullyQualifiedName~ExpressionEngineTests"` - passed 6/6
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 --filter "FullyQualifiedName~DiceTests|FullyQualifiedName~SeverFormulaTests|FullyQualifiedName~FutureProgDateTimeFunctionTests|FullyQualifiedName~FutureProgSecurityRegressionTests"` - passed 31/31
- `scripts\test-unit.ps1` - FutureMUDLibrary 352/352 passed, ExpressionEngine 6/6 passed, MudSharpCore 1151/1151 passed; DatabaseSeeder Unit Tests had 15 unrelated pre-existing failures around blank snapshot/design-document paths and antiquity/medieval seeder docs
- `git diff --check` - passed with only CRLF warnings