### PR TITLE
Remediate crafting and materials security findings

### DIFF
--- a/MudSharpCore Unit Tests/AgricultureOperationTests.cs
+++ b/MudSharpCore Unit Tests/AgricultureOperationTests.cs
@@ -1,13 +1,20 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using MudSharp.Accounts;
+using MudSharp.Body;
 using MudSharp.Celestial;
+using MudSharp.Character;
+using MudSharp.Character.Heritage;
 using MudSharp.Climate;
 using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
 using MudSharp.Framework;
 using MudSharp.Framework.Save;
 using MudSharp.Work.Agriculture;
+using MudSharp.Work.Crafts;
+using MudSharp.Work.Crafts.Inputs;
 using MudSharp.Economy.Property;
+using MudSharp.NPC.Templates;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -430,6 +437,71 @@ public class AgricultureOperationTests
 		StringAssert.Contains(result, "fallow or pasture");
 		Assert.AreEqual(7, source.Herds.Single().HeadCount);
 		Assert.IsFalse(destination.Herds.Any());
+	}
+
+	[TestMethod]
+	public void AgricultureFieldInput_ScoutInput_RejectsOwnedFieldWithoutAuthorisation()
+	{
+		var gameworld = BuildGameworldWithCustomScore(enabled: false);
+		var cell = new Mock<ICell>();
+		cell.SetupGet(x => x.Id).Returns(1L);
+		cell.SetupGet(x => x.Name).Returns("Owned Crop Field");
+		cell.SetupGet(x => x.FrameworkItemType).Returns("Cell");
+		cell.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		var cells = new All<ICell>();
+		cells.Add(cell.Object);
+		gameworld.SetupGet(x => x.Cells).Returns(cells);
+		var field = BuildFieldWithCustomScore(gameworld.Object, 50, AgricultureFieldUse.Fallow);
+		cell.SetupGet(x => x.AgricultureField).Returns(field);
+		var property = new Mock<IProperty>();
+		property.SetupGet(x => x.Id).Returns(1L);
+		property.SetupGet(x => x.Name).Returns("Owned Farm");
+		property.SetupGet(x => x.FrameworkItemType).Returns("Property");
+		property.SetupGet(x => x.PropertyLocations).Returns([cell.Object]);
+		var properties = new All<IProperty>();
+		properties.Add(property.Object);
+		gameworld.SetupGet(x => x.Properties).Returns(properties);
+		var actor = new Mock<ICharacter>();
+		actor.SetupGet(x => x.Location).Returns(cell.Object);
+		actor.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		actor.Setup(x => x.IsAdministrator(It.IsAny<PermissionLevel>())).Returns(false);
+		var input = AgricultureFieldInputFromDefinition(gameworld.Object,
+			new XElement("Definition",
+				new XElement("RequiredUse", AgricultureFieldUse.Fallow),
+				new XElement("CropDefinitionId", 0),
+				new XElement("WoodlandDefinitionId", 0),
+				new XElement("MinimumFieldCondition", 0),
+				new XElement("MinimumHealth", 0),
+				new XElement("MinimumYield", 0),
+				new XElement("YieldConsumed", 0)));
+
+		Assert.IsFalse(input.ScoutInput(actor.Object).Any());
+	}
+
+	[TestMethod]
+	public void AbsorbNpcIntoHerd_RejectsNonAnimalNpc()
+	{
+		var (gameworld, herd) = BuildTwoFieldGameworld();
+		gameworld.SetupGet(x => x.BodyPrototypes).Returns(new All<IBodyPrototype>());
+		var source = BuildFieldWithHerd(gameworld.Object, 1, 1, AgricultureFieldUse.Pasture, herd, 0, 60.0);
+		var baseBody = new Mock<IBodyPrototype>();
+		baseBody.SetupGet(x => x.Id).Returns(1L);
+		baseBody.SetupGet(x => x.Name).Returns("Humanoid");
+		baseBody.SetupGet(x => x.FrameworkItemType).Returns("BodyPrototype");
+		var race = new Mock<IRace>();
+		race.SetupGet(x => x.BaseBody).Returns(baseBody.Object);
+		var npc = new Mock<ICharacter>();
+		npc.SetupGet(x => x.IsPlayerCharacter).Returns(false);
+		npc.SetupGet(x => x.Location).Returns(source.Cell);
+		npc.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		npc.SetupGet(x => x.Race).Returns(race.Object);
+		var actor = new Mock<ICharacter>();
+
+		var success = source.AbsorbNpcIntoHerd(npc.Object, herd, actor.Object, out var result);
+
+		Assert.IsFalse(success);
+		StringAssert.Contains(result, "non-player animal");
+		npc.Verify(x => x.Quit(It.IsAny<bool>()), Times.Never);
 	}
 
 	[TestMethod]
@@ -928,6 +1000,24 @@ public class AgricultureOperationTests
 		}
 
 		return new AgricultureField(model, gameworld);
+	}
+
+	private static AgricultureFieldInput AgricultureFieldInputFromDefinition(IFuturemud gameworld, XElement definition)
+	{
+		var model = new MudSharp.Models.CraftInput
+		{
+			Id = 1,
+			InputQualityWeight = 1.0,
+			OriginalAdditionTime = DateTime.UtcNow,
+			Definition = definition.ToString()
+		};
+
+		return (AgricultureFieldInput)Activator.CreateInstance(
+			typeof(AgricultureFieldInput),
+			BindingFlags.Instance | BindingFlags.NonPublic,
+			null,
+			[model, new Mock<ICraft>().Object, gameworld],
+			null)!;
 	}
 
 	private sealed record TestApiaryState(int HiveCount, int ColonyHealth, int Stores, int YieldPotential,

--- a/MudSharpCore Unit Tests/CommandExecutionSecurityTests.cs
+++ b/MudSharpCore Unit Tests/CommandExecutionSecurityTests.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -13,8 +14,13 @@ using MudSharp.Commands.Modules;
 using MudSharp.Commands;
 using MudSharp.Commands.Trees;
 using MudSharp.Communication;
+using MudSharp.Construction;
+using MudSharp.Construction.Boundary;
 using MudSharp.Effects.Interfaces;
+using MudSharp.Form.Material;
+using MudSharp.Form.Shape;
 using MudSharp.Framework;
+using MudSharp.Framework.Revision;
 using MudSharp.GameItems;
 using MudSharp.GameItems.Interfaces;
 using MudSharp.Magic;
@@ -22,6 +28,9 @@ using MudSharp.Magic.SpellEffects;
 using MudSharp.Magic.SpellTriggers;
 using MudSharp.PerceptionEngine;
 using MudSharp.RPG.Checks;
+using MudSharp.Work.Agriculture;
+using MudSharp.Work.Crafts;
+using MudSharp.Work.Crafts.Inputs;
 
 namespace MudSharp_Unit_Tests;
 
@@ -238,12 +247,136 @@ public class CommandExecutionSecurityTests
 		output.Verify(x => x.Send("You cannot reach that.", true, false), Times.Once);
 	}
 
+	[TestMethod]
+	public void CraftListCommands_EmptyQuotedFilter_DoesNotThrow()
+	{
+		var actor = Character(PermissionLevel.Player);
+		var output = OutputHandler();
+		actor.SetupGet(x => x.OutputHandler).Returns(output.Object);
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.Crafts).Returns(RevisableRepository(Array.Empty<ICraft>()).Object);
+		actor.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+
+		InvokeStatic(typeof(CraftModule), "Crafts", actor.Object, "crafts \"\"");
+		InvokeStatic(typeof(CraftModule), "CookList", actor.Object, new StringStack("\"\""));
+	}
+
+	[TestMethod]
+	public void ConditionRepairInput_DoesNotSatisfyConsumedGameItemContract()
+	{
+		Assert.IsFalse(typeof(ICraftInputConsumesGameItem).IsAssignableFrom(typeof(ConditionRepairInput)));
+	}
+
+	[TestMethod]
+	public void FieldHerdDrive_BlockedExit_DoesNotMoveHerd()
+	{
+		var actor = Character(PermissionLevel.Player);
+		var output = OutputHandler();
+		actor.SetupGet(x => x.OutputHandler).Returns(output.Object);
+		var sourceField = new Mock<IAgricultureField>();
+		var destinationField = new Mock<IAgricultureField>();
+		var sourceCell = new Mock<ICell>();
+		var destinationCell = new Mock<ICell>();
+		var exit = new Mock<ICellExit>();
+		var herd = new Mock<IAgricultureHerdDefinition>();
+		herd.SetupGet(x => x.Id).Returns(1L);
+		herd.SetupGet(x => x.Name).Returns("cattle");
+		var herds = new Mock<IUneditableAll<IAgricultureHerdDefinition>>();
+		herds.Setup(x => x.GetByIdOrName("cattle", It.IsAny<bool>())).Returns(herd.Object);
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.AgricultureHerdDefinitions).Returns(herds.Object);
+
+		sourceCell.SetupGet(x => x.AgricultureField).Returns(sourceField.Object);
+		sourceCell.Setup(x => x.GetExitKeyword("north", actor.Object)).Returns(exit.Object);
+		destinationCell.SetupGet(x => x.AgricultureField).Returns(destinationField.Object);
+		exit.SetupGet(x => x.Destination).Returns(destinationCell.Object);
+		actor.SetupGet(x => x.Location).Returns(sourceCell.Object);
+		actor.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		actor.Setup(x => x.CanCross(exit.Object)).Returns((false, (IEmoteOutput)null!));
+
+		InvokeStatic(typeof(AgricultureModule), "FieldHerdDrive", actor.Object, new StringStack("cattle north 1"));
+
+		sourceField.Verify(x => x.DriveHerdTo(It.IsAny<IAgricultureField>(), It.IsAny<IAgricultureHerdDefinition>(),
+			It.IsAny<int>(), actor.Object, out It.Ref<string>.IsAny), Times.Never);
+		output.Verify(x => x.Send("You cannot drive the herd through that exit.", true, false), Times.Once);
+	}
+
+	[TestMethod]
+	public void FillGas_SourceCannotBeManipulated_DoesNotDrainSource()
+	{
+		var actor = Character(PermissionLevel.Player);
+		var output = OutputHandler();
+		actor.SetupGet(x => x.OutputHandler).Returns(output.Object);
+		var gas = new Mock<IGas>();
+		gas.Setup(x => x.GasCountAs(gas.Object)).Returns(true);
+		var targetContainer = new Mock<IGasContainer>();
+		targetContainer.SetupProperty(x => x.Gas);
+		targetContainer.SetupProperty(x => x.GasVolumeAtOneAtmosphere, 0.0);
+		targetContainer.SetupGet(x => x.GasCapacityAtOneAtmosphere).Returns(10.0);
+		var sourceContainer = new Mock<IGasContainer>();
+		sourceContainer.SetupProperty(x => x.Gas, gas.Object);
+		sourceContainer.SetupProperty(x => x.GasVolumeAtOneAtmosphere, 5.0);
+		sourceContainer.SetupGet(x => x.GasCapacityAtOneAtmosphere).Returns(10.0);
+		var target = new Mock<IGameItem>();
+		target.Setup(x => x.GetItemType<IGasContainer>()).Returns(targetContainer.Object);
+		target.Setup(x => x.HowSeen(actor.Object, It.IsAny<bool>(), It.IsAny<DescriptionType>(), It.IsAny<bool>(),
+			It.IsAny<PerceiveIgnoreFlags>())).Returns("vial");
+		var source = new Mock<IGameItem>();
+		source.Setup(x => x.GetItemType<IGasContainer>()).Returns(sourceContainer.Object);
+		source.Setup(x => x.HowSeen(actor.Object, It.IsAny<bool>(), It.IsAny<DescriptionType>(), It.IsAny<bool>(),
+			It.IsAny<PerceiveIgnoreFlags>())).Returns("source");
+		actor.Setup(x => x.TargetHeldItem("vial")).Returns(target.Object);
+		actor.Setup(x => x.TargetItem("source")).Returns(source.Object);
+		actor.Setup(x => x.CanManipulateItem(target.Object)).Returns((true, string.Empty));
+		actor.Setup(x => x.CanManipulateItem(source.Object)).Returns((false, "You cannot reach that."));
+
+		InvokeStatic(typeof(ManipulationModule), "FillGas", actor.Object, "fillgas vial source");
+
+		Assert.AreEqual(5.0, sourceContainer.Object.GasVolumeAtOneAtmosphere, 0.0001);
+		Assert.AreEqual(0.0, targetContainer.Object.GasVolumeAtOneAtmosphere, 0.0001);
+		output.Verify(x => x.Send("You cannot reach that.", true, false), Times.Once);
+	}
+
+	[TestMethod]
+	public void ExportCraftCsvCell_QuotesAndNeutralisesSpreadsheetFormulae()
+	{
+		var method = typeof(ImplementorModule).GetMethod("EncodeCraftExportCsvCell",
+			BindingFlags.Static | BindingFlags.NonPublic)!;
+
+		Assert.AreEqual("\"'=1+1\"", method.Invoke(null, ["=1+1"]));
+		Assert.AreEqual("\"text, with \"\"quotes\"\"\"", method.Invoke(null, ["text, with \"quotes\""]));
+	}
+
 	private static Mock<ICharacter> Character(PermissionLevel permissionLevel, bool isPlayerCharacter = true)
 	{
 		var character = new Mock<ICharacter>();
 		character.SetupGet(x => x.PermissionLevel).Returns(permissionLevel);
 		character.SetupGet(x => x.IsPlayerCharacter).Returns(isPlayerCharacter);
 		return character;
+	}
+
+	private static Mock<IOutputHandler> OutputHandler()
+	{
+		var output = new Mock<IOutputHandler>();
+		output.Setup(x => x.Send(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>())).Returns(true);
+		output.Setup(x => x.Send(It.IsAny<IOutput>(), It.IsAny<bool>(), It.IsAny<bool>())).Returns(true);
+		return output;
+	}
+
+	private static void InvokeStatic(Type type, string methodName, params object[] arguments)
+	{
+		var method = type.GetMethod(methodName, BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public)!;
+		method.Invoke(null, arguments);
+	}
+
+	private static Mock<IUneditableRevisableAll<T>> RevisableRepository<T>(IEnumerable<T> items) where T : class, IRevisableItem
+	{
+		var list = items.ToList();
+		var mock = new Mock<IUneditableRevisableAll<T>>();
+		mock.As<IEnumerable<T>>()
+		    .Setup(x => x.GetEnumerator())
+		    .Returns(() => list.GetEnumerator());
+		return mock;
 	}
 
 	private static Mock<ICharacter> CharacterWithMutablePermission(PermissionLevel startingPermission,

--- a/MudSharpCore Unit Tests/CraftToolUsageTests.cs
+++ b/MudSharpCore Unit Tests/CraftToolUsageTests.cs
@@ -20,12 +20,21 @@ using MudSharp.RPG.Checks;
 using MudSharp.Work.Crafts;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace MudSharp_Unit_Tests;
 
 [TestClass]
 public class CraftToolUsageTests
 {
+    [TestMethod]
+    public void PhaseLengths_InvalidPersistedDuration_ReturnsZeroInsteadOfThrowing()
+    {
+        var craft = BuildCraftWithPhase(double.PositiveInfinity);
+
+        Assert.AreEqual(TimeSpan.Zero, craft.PhaseLengths.Single());
+    }
+
     [TestMethod]
     public void HandleCraftPhase_ToolUsedInMultiplePhases_UsesToolEachPhase()
     {
@@ -169,6 +178,65 @@ public class CraftToolUsageTests
         Assert.IsTrue(craft.HandleCraftPhase(character.Object, effect.Object, craftComponent.Object, 2));
 
         toolItemComponent.Verify(x => x.UseTool(null!, It.IsAny<TimeSpan>()), Times.Exactly(2));
+    }
+
+    private static Craft BuildCraftWithPhase(double phaseLengthInSeconds)
+    {
+        Mock<IUneditableAll<ITag>> tags = new();
+        tags.Setup(x => x.Get(It.IsAny<long>())).Returns((ITag)null!);
+        Mock<IUneditableAll<ITraitDefinition>> traits = new();
+        traits.Setup(x => x.Get(It.IsAny<long>())).Returns((ITraitDefinition)null!);
+        Mock<IUneditableAll<IFutureProg>> progs = new();
+        progs.Setup(x => x.Get(It.IsAny<long>())).Returns((IFutureProg)null!);
+        Mock<IFuturemud> gameworld = new();
+        gameworld.SetupGet(x => x.Tags).Returns(tags.Object);
+        gameworld.SetupGet(x => x.Traits).Returns(traits.Object);
+        gameworld.SetupGet(x => x.FutureProgs).Returns(progs.Object);
+        gameworld.Setup(x => x.DebugMessage(It.IsAny<string>()));
+
+        MudSharp.Models.Craft craftModel = new()
+        {
+            Id = 1,
+            RevisionNumber = 0,
+            Name = "Invalid Phase Craft",
+            Blurb = "Test",
+            ActionDescription = "crafting",
+            Category = "test",
+            Interruptable = false,
+            ToolQualityWeighting = 1.0,
+            InputQualityWeighting = 1.0,
+            CheckQualityWeighting = 1.0,
+            FreeSkillChecks = 0,
+            FailThreshold = (int)Outcome.MinorFail,
+            CheckDifficulty = (int)Difficulty.Normal,
+            FailPhase = 1,
+            QualityFormula = "5",
+            ActiveCraftItemSdesc = "a craft",
+            IsPracticalCheck = true,
+            EditableItem = new MudSharp.Models.EditableItem
+            {
+                RevisionNumber = 0,
+                RevisionStatus = (int)RevisionStatus.Current,
+                BuilderAccountId = 1,
+                BuilderDate = DateTime.UtcNow,
+                BuilderComment = string.Empty,
+                ReviewerComment = string.Empty
+            }
+        };
+        craftModel.CraftPhases.Add(new MudSharp.Models.CraftPhase
+        {
+            PhaseNumber = 1,
+            PhaseLengthInSeconds = phaseLengthInSeconds,
+            Echo = "Phase 1",
+            FailEcho = "Fail 1",
+            ExertionLevel = 0,
+            StaminaUsage = 0.0
+        });
+
+        return new Craft(craftModel, gameworld.Object)
+        {
+            QualityFormula = null
+        };
     }
 
     [TestMethod]

--- a/MudSharpCore Unit Tests/GridSystemTests.cs
+++ b/MudSharpCore Unit Tests/GridSystemTests.cs
@@ -955,7 +955,24 @@ public class GridSystemTests
         LiquidMixture mixture = CreateMixture(gameworld.Object, (CreateLiquid(1, "water").Object, 1.0));
 
         Assert.AreEqual(0.0, component.LiquidCapacity, 0.0001);
-        Assert.ThrowsException<InvalidOperationException>(() => component.MergeLiquid(mixture, null!, "test"));
+        component.MergeLiquid(mixture, null!, "test");
+        Assert.AreEqual(0.0, component.LiquidCapacity, 0.0001);
+    }
+
+    [TestMethod]
+    public void GridLiquidSourceGameItemComponent_ReduceLiquidQuantity_RemovesFromGrid()
+    {
+        Mock<IFuturemud> gameworld = CreateGameworld();
+        Mock<IGameItem> parent = new();
+        parent.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+        GridLiquidSourceGameItemComponentProto proto = CreateGridLiquidSourceProto(gameworld.Object);
+        GridLiquidSourceGameItemComponent component = new(proto, parent.Object, true);
+        var grid = new Mock<ILiquidGrid>();
+        component.LiquidGrid = grid.Object;
+
+        component.ReduceLiquidQuantity(2.5, null!, "drink");
+
+        grid.Verify(x => x.RemoveLiquidAmount(2.5, null, "drink"), Times.Once);
     }
 
     [TestMethod]

--- a/MudSharpCore Unit Tests/HandToolDurabilityTests.cs
+++ b/MudSharpCore Unit Tests/HandToolDurabilityTests.cs
@@ -54,6 +54,46 @@ public class HandToolDurabilityTests
         Assert.IsTrue(component.CanUseTool(toolTag.Object, TimeSpan.FromSeconds(5)));
     }
 
+    [TestMethod]
+    public void CanUseTool_ImportedOverflowFormulaForQuality_ReturnsFalse()
+    {
+        Mock<IFuturemud> gameworld = new();
+
+        Mock<ITag> toolTag = new();
+        toolTag.Setup(x => x.IsA(It.IsAny<ITag>())).Returns(true);
+
+        Mock<IGameItem> parent = new();
+        parent.SetupProperty(x => x.Condition, 1.0);
+        parent.SetupProperty(x => x.Quality, ItemQuality.Good);
+        parent.SetupGet(x => x.Tags).Returns([toolTag.Object]);
+        parent.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+
+        MudSharp.Models.GameItemComponentProto protoModel = new()
+        {
+            Id = 1,
+            Name = "Test Hand Tool",
+            Description = string.Empty,
+            Type = "HandTool",
+            RevisionNumber = 0,
+            EditableItem = new MudSharp.Models.EditableItem
+            {
+                RevisionNumber = 0,
+                RevisionStatus = 0,
+                BuilderAccountId = 1,
+                BuilderDate = DateTime.UtcNow,
+                BuilderComment = string.Empty,
+                ReviewerComment = string.Empty
+            },
+            Definition =
+                "<Definition><BaseMultiplier>1.0</BaseMultiplier><MultiplierReductionPerQuality>0.0</MultiplierReductionPerQuality><ToolDurabilitySecondsExpression>if(quality == 6, 1e20, 3600)</ToolDurabilitySecondsExpression></Definition>"
+        };
+
+        TestHandToolGameItemComponentProto proto = new(protoModel, gameworld.Object);
+        HandToolGameItemComponent component = new(proto, parent.Object, temporary: true);
+
+        Assert.IsFalse(component.CanUseTool(toolTag.Object, TimeSpan.FromSeconds(5)));
+    }
+
     private class TestHandToolGameItemComponentProto : HandToolGameItemComponentProto
     {
         public TestHandToolGameItemComponentProto(MudSharp.Models.GameItemComponentProto proto, IFuturemud gameworld)

--- a/MudSharpCore Unit Tests/LiquidContaminationV2SourceTests.cs
+++ b/MudSharpCore Unit Tests/LiquidContaminationV2SourceTests.cs
@@ -98,6 +98,21 @@ public class LiquidContaminationV2SourceTests
 	}
 
 	[TestMethod]
+	public void Cleaning_DoesNotQueueEffectsWithoutRequiredLiquid()
+	{
+		var gameModule = File.ReadAllText(GetSourcePath("MudSharpCore", "Commands", "Modules",
+			"GameModule.cs"));
+		var queueStart = gameModule.IndexOf("private static Queue<ICleanableEffect> GetCleanableEffectQueue", StringComparison.Ordinal);
+		var queueEnd = gameModule.IndexOf("private static void CleanTarget", queueStart, StringComparison.Ordinal);
+		Assert.IsTrue(queueStart > 0);
+		Assert.IsTrue(queueEnd > queueStart);
+
+		var cleanQueue = gameModule[queueStart..queueEnd];
+		StringAssert.Contains(cleanQueue, "x.LiquidRequired != null");
+		Assert.IsFalse(cleanQueue.Contains("x.LiquidRequired == null ||", StringComparison.Ordinal));
+	}
+
+	[TestMethod]
 	public void WashingMachine_SpinDriesSurfaceStateAndCompletesCycle()
 	{
 		var washingMachine = File.ReadAllText(GetSourcePath("MudSharpCore", "GameItems", "Components",

--- a/MudSharpCore Unit Tests/LiquidProductTests.cs
+++ b/MudSharpCore Unit Tests/LiquidProductTests.cs
@@ -39,7 +39,13 @@ public class LiquidProductTests
 		Assert.AreEqual(1, products.Count);
 		Assert.AreSame(item.Object, products[0]);
 		container.Verify(x => x.MergeLiquid(It.Is<LiquidMixture>(m => Math.Abs(m.TotalVolume - 3.0) < 0.0001), null, "craft"), Times.Once);
+		item.Verify(x => x.HandleEvent(EventType.ItemFinishedLoading, item.Object), Times.Never);
+
+		var location = new Mock<ICell>();
+		data.ReleaseProducts(location.Object, RoomLayer.GroundLevel);
+
 		item.Verify(x => x.HandleEvent(EventType.ItemFinishedLoading, item.Object), Times.Once);
+		item.Verify(x => x.Login(), Times.Once);
 	}
 
 	[TestMethod]

--- a/MudSharpCore Unit Tests/MaterialTests.cs
+++ b/MudSharpCore Unit Tests/MaterialTests.cs
@@ -7,6 +7,12 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+using Moq;
+using MudSharp.Form.Material;
+using MudSharp.Framework;
+using MudSharp.GameItems;
+using MudSharp.Health;
+
 namespace MudSharp_Unit_Tests;
 
 [TestClass]
@@ -59,5 +65,117 @@ public class MaterialTests
         secondsDictionary[1500] = SecondsToEvaporate(1500);
 
         Assert.IsTrue(true);
+    }
+
+    [TestMethod]
+    public void GasCountsAs_CyclicChainForOutsideTarget_ReturnsFalse()
+    {
+        var gameworld = new Mock<IFuturemud>();
+        var gases = new All<IGas>();
+        gameworld.SetupGet(x => x.Gases).Returns(gases);
+        gameworld.SetupGet(x => x.Tags).Returns(new All<ITag>());
+        gameworld.SetupGet(x => x.Drugs).Returns(new All<IDrug>());
+        var gasA = new Gas(GasModel(1, "gas a", 2), gameworld.Object);
+        var gasB = new Gas(GasModel(2, "gas b", 1), gameworld.Object);
+        var gasC = new Gas(GasModel(3, "gas c", null), gameworld.Object);
+        gases.Add(gasA);
+        gases.Add(gasB);
+        gases.Add(gasC);
+
+        Assert.IsFalse(gasA.CountsAs(gasC));
+        Assert.AreEqual(ItemQuality.Terrible, gasA.CountAsQuality(gasC));
+        Assert.AreEqual(0.0, gasA.CountsAsMultiplier(gasC), 0.0001);
+    }
+
+    [TestMethod]
+    public void LiquidCountsAs_CyclicChainForOutsideTarget_ReturnsFalse()
+    {
+        var gameworld = new Mock<IFuturemud>();
+        var liquids = new All<ILiquid>();
+        gameworld.SetupGet(x => x.Liquids).Returns(liquids);
+        gameworld.SetupGet(x => x.Gases).Returns(new All<IGas>());
+        gameworld.SetupGet(x => x.Tags).Returns(new All<ITag>());
+        gameworld.SetupGet(x => x.Drugs).Returns(new All<IDrug>());
+        var liquidA = new Liquid(LiquidModel(1, "liquid a", 2), gameworld.Object);
+        var liquidB = new Liquid(LiquidModel(2, "liquid b", 1), gameworld.Object);
+        var liquidC = new Liquid(LiquidModel(3, "liquid c", null), gameworld.Object);
+        liquids.Add(liquidA);
+        liquids.Add(liquidB);
+        liquids.Add(liquidC);
+
+        Assert.IsFalse(liquidA.CountsAs(liquidC));
+        Assert.IsFalse(liquidA.LiquidCountsAs(liquidC));
+        Assert.AreEqual(ItemQuality.Terrible, liquidA.CountAsQuality(liquidC));
+        Assert.AreEqual(0.0, liquidA.CountsAsMultiplier(liquidC), 0.0001);
+    }
+
+    private static MudSharp.Models.Gas GasModel(long id, string name, long? countsAsId)
+    {
+        return new MudSharp.Models.Gas
+        {
+            Id = id,
+            Name = name,
+            Description = name,
+            Density = 1.0,
+            Organic = false,
+            ThermalConductivity = 0.14,
+            ElectricalConductivity = 0.0001,
+            SpecificHeatCapacity = 420.0,
+            SmellText = string.Empty,
+            VagueSmellText = string.Empty,
+            SmellIntensity = 100.0,
+            Viscosity = 1.0,
+            CountAsId = countsAsId,
+            CountsAsQuality = (int)ItemQuality.Standard,
+            DisplayColour = Telnet.BoldCyan.Name,
+            BoilingPoint = double.MinValue,
+            DrugGramsPerUnitVolume = 0.0,
+            OxidationFactor = 1.0
+        };
+    }
+
+    private static MudSharp.Models.Liquid LiquidModel(long id, string name, long? countsAsId)
+    {
+        return new MudSharp.Models.Liquid
+        {
+            Id = id,
+            Name = name,
+            Description = name,
+            LongDescription = name,
+            Density = 1000.0,
+            Organic = false,
+            ThermalConductivity = 0.14,
+            ElectricalConductivity = 0.0001,
+            SpecificHeatCapacity = 420.0,
+            TasteText = string.Empty,
+            VagueTasteText = string.Empty,
+            TasteIntensity = 100.0,
+            SmellText = string.Empty,
+            VagueSmellText = string.Empty,
+            SmellIntensity = 100.0,
+            AlcoholLitresPerLitre = 0.0,
+            WaterLitresPerLitre = 1.0,
+            FoodSatiatedHoursPerLitre = 0.0,
+            DrinkSatiatedHoursPerLitre = 0.0,
+            BoilingPoint = 100.0,
+            FreezingPoint = 0.0,
+            Viscosity = 1.0,
+            IgnitionPoint = 0.0,
+            CountAsId = countsAsId,
+            CountAsQuality = (int)ItemQuality.Standard,
+            DisplayColour = Telnet.BoldCyan.Name,
+            DampDescription = "It is damp",
+            WetDescription = "It is wet",
+            DrenchedDescription = "It is drenched",
+            DampShortDescription = "(damp)",
+            WetShortDescription = "(wet)",
+            DrenchedShortDescription = "(drenched)",
+            SolventVolumeRatio = 1.0,
+            DrugGramsPerUnitVolume = 0.0,
+            InjectionConsequence = (int)LiquidInjectionConsequence.Harmful,
+            ResidueVolumePercentage = 0.05,
+            RelativeEnthalpy = 1.0,
+            SurfaceReactionInfo = "<Reactions />"
+        };
     }
 }

--- a/MudSharpCore/Commands/Modules/AgricultureModule.cs
+++ b/MudSharpCore/Commands/Modules/AgricultureModule.cs
@@ -555,6 +555,21 @@ Admin Syntax:
 			return;
 		}
 
+		var (canCross, failureOutput) = actor.CanCross(exit);
+		if (!canCross)
+		{
+			if (failureOutput != null)
+			{
+				actor.OutputHandler.Send(failureOutput);
+			}
+			else
+			{
+				actor.OutputHandler.Send("You cannot drive the herd through that exit.");
+			}
+
+			return;
+		}
+
 		var count = 0;
 		if (!ss.IsFinished)
 		{

--- a/MudSharpCore/Commands/Modules/CraftModule.cs
+++ b/MudSharpCore/Commands/Modules/CraftModule.cs
@@ -50,6 +50,11 @@ internal class CraftModule : Module<ICharacter>
         {
             parameters = true;
             string arg = ss.PopSpeech();
+            if (string.IsNullOrEmpty(arg))
+            {
+                continue;
+            }
+
             if (arg[0] == '+')
             {
                 crafts = crafts
@@ -549,6 +554,11 @@ You can use the following syntax:
         {
             parameters = true;
             var arg = ss.PopSpeech();
+            if (string.IsNullOrEmpty(arg))
+            {
+                continue;
+            }
+
             if (arg[0] == '+')
             {
                 crafts = crafts

--- a/MudSharpCore/Commands/Modules/GameModule.cs
+++ b/MudSharpCore/Commands/Modules/GameModule.cs
@@ -1996,13 +1996,13 @@ You can also type 'forage' on its own to see what kinds of yields you can search
             return item.Effects.Contains(effect) &&
                    actor.ContextualItems.Contains(item) &&
                    actor.CanSee(item) &&
-                   (effect.CleaningToolTag != null || effect.LiquidRequired != null) &&
+                   effect.LiquidRequired != null &&
                    (effect.CleaningToolTag == null ||
                     actor.Body.HeldOrWieldedItems.Any(x => x.IsA(effect.CleaningToolTag))) &&
-                   (effect.LiquidRequired == null || actor.ContextualItems
-                                                          .SelectNotNull(x => x.GetItemType<ILiquidContainer>()).Any(
-                                                              x => x.LiquidMixture?.CountsAs(effect.LiquidRequired)
-                                                                    .Truth == true && x.IsOpen));
+                   actor.ContextualItems
+                        .SelectNotNull(x => x.GetItemType<ILiquidContainer>()).Any(
+                            x => x.LiquidMixture?.CountsAs(effect.LiquidRequired)
+                                  .Truth == true && x.IsOpen);
         }
 
         return item =>
@@ -2255,8 +2255,9 @@ You can also type 'forage' on its own to see what kinds of yields you can search
 
         cleanableEffects =
             cleanableEffects.Where(
+                                x => x.LiquidRequired != null)
+                            .Where(
                                 x =>
-                                    x.LiquidRequired == null ||
                                     actor.ContextualItems.Any(y => IsSuitable(x, y)))
                             .ToList();
 

--- a/MudSharpCore/Commands/Modules/ImplementorModule.cs
+++ b/MudSharpCore/Commands/Modules/ImplementorModule.cs
@@ -885,101 +885,101 @@ public class ImplementorModule : Module<ICharacter>
     private static void DebugExportCrafts(ICharacter actor, StringStack ss)
     {
         StringBuilder sb = new();
-        sb.AppendLine("Id,Revision,Name,Category,Blurb,Status,Action,Item SDesc,Appear Prog,CanUse Prog,WhyCantUse Prog,OnStart Prog,OnCancel Prog,OnFinishProg,Trait,Difficulty,Threshold,FreeChecks,FailPhase,Interruptable,PhaseLength1,PhaseLength2,PhaseLength3,PhaseLength4,PhaseLength5,PhaseLength6,PhaseLength7,PhaseLength8,PhaseLength9,PhaseLength10,PhaseEcho1,PhaseEcho2,PhaseEcho3,PhaseEcho4,PhaseEcho5,PhaseEcho6,PhaseEcho7,PhaseEcho8,PhaseEcho9,PhaseEcho10,PhaseFailEcho1,PhaseFailEcho2,PhaseFailEcho3,PhaseFailEcho4,PhaseFailEcho5,PhaseFailEcho6,PhaseFailEcho7,PhaseFailEcho8,PhaseFailEcho9,PhaseFailEcho10,Input1,Input2,Input3,Input4,Input5,Input6,Input7,Input8,Input9,Input10,Tool1,Tool2,Tool3,Tool4,Tool5,Tool6,Tool7,Tool8,Tool9,Tool10,Product1,Product2,Product3,Product4,Product5,Product6,Product7,Product8,Product9,Product10,FailProduct1,FailProduct2,FailProduct3,FailProduct4,FailProduct5,FailProduct6,FailProduct7,FailProduct8,FailProduct9,FailProduct10");
+        AppendCraftExportRow(sb,
+        [
+            "Id", "Revision", "Name", "Category", "Blurb", "Status", "Action", "Item SDesc", "Appear Prog",
+            "CanUse Prog", "WhyCantUse Prog", "OnStart Prog", "OnCancel Prog", "OnFinishProg", "Trait", "Difficulty",
+            "Threshold", "FreeChecks", "FailPhase", "Interruptable", "PhaseLength1", "PhaseLength2", "PhaseLength3",
+            "PhaseLength4", "PhaseLength5", "PhaseLength6", "PhaseLength7", "PhaseLength8", "PhaseLength9",
+            "PhaseLength10", "PhaseEcho1", "PhaseEcho2", "PhaseEcho3", "PhaseEcho4", "PhaseEcho5", "PhaseEcho6",
+            "PhaseEcho7", "PhaseEcho8", "PhaseEcho9", "PhaseEcho10", "PhaseFailEcho1", "PhaseFailEcho2",
+            "PhaseFailEcho3", "PhaseFailEcho4", "PhaseFailEcho5", "PhaseFailEcho6", "PhaseFailEcho7",
+            "PhaseFailEcho8", "PhaseFailEcho9", "PhaseFailEcho10", "Input1", "Input2", "Input3", "Input4",
+            "Input5", "Input6", "Input7", "Input8", "Input9", "Input10", "Tool1", "Tool2", "Tool3", "Tool4",
+            "Tool5", "Tool6", "Tool7", "Tool8", "Tool9", "Tool10", "Product1", "Product2", "Product3",
+            "Product4", "Product5", "Product6", "Product7", "Product8", "Product9", "Product10", "FailProduct1",
+            "FailProduct2", "FailProduct3", "FailProduct4", "FailProduct5", "FailProduct6", "FailProduct7",
+            "FailProduct8", "FailProduct9", "FailProduct10"
+        ]);
         foreach (ICraft craft in actor.Gameworld.Crafts)
         {
-            sb.Append($"{craft.Id},{craft.RevisionNumber},\"{craft.Name}\",\"{craft.Category}\",\"{craft.Blurb}\",{craft.Status.DescribeEnum()},\"{craft.ActionDescription}\",\"{craft.ActiveCraftItemSDesc}\",");
-            sb.Append($"{craft.AppearInCraftsListProg?.Name ?? ""},{craft.CanUseProg?.Name ?? ""},{craft.WhyCannotUseProg?.Name ?? ""},{craft.OnUseProgStart?.Name ?? ""},{craft.OnUseProgCancel?.Name ?? ""},{craft.OnUseProgComplete?.Name ?? ""},");
-            sb.Append($"{craft.CheckTrait?.Name ?? ""},{craft.CheckDifficulty.DescribeEnum()},{craft.FailThreshold.DescribeEnum()},{craft.FreeSkillChecks},{craft.FailPhase},{craft.Interruptable}");
+            List<string> row =
+            [
+                craft.Id.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                craft.RevisionNumber.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                craft.Name,
+                craft.Category,
+                craft.Blurb,
+                craft.Status.DescribeEnum(),
+                craft.ActionDescription,
+                craft.ActiveCraftItemSDesc,
+                craft.AppearInCraftsListProg?.Name ?? string.Empty,
+                craft.CanUseProg?.Name ?? string.Empty,
+                craft.WhyCannotUseProg?.Name ?? string.Empty,
+                craft.OnUseProgStart?.Name ?? string.Empty,
+                craft.OnUseProgCancel?.Name ?? string.Empty,
+                craft.OnUseProgComplete?.Name ?? string.Empty,
+                craft.CheckTrait?.Name ?? string.Empty,
+                craft.CheckDifficulty.DescribeEnum(),
+                craft.FailThreshold.DescribeEnum(),
+                craft.FreeSkillChecks.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                craft.FailPhase.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                craft.Interruptable.ToString(System.Globalization.CultureInfo.InvariantCulture)
+            ];
+
             List<TimeSpan> lengths = craft.PhaseLengths.ToList();
             for (int i = 0; i < 10; i++)
             {
-                if (i < lengths.Count)
-                {
-                    sb.Append($",{lengths[i].TotalSeconds}");
-                    continue;
-                }
-
-                sb.Append(",");
+                row.Add(i < lengths.Count
+                    ? lengths[i].TotalSeconds.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                    : string.Empty);
             }
 
             List<string> echoes = craft.PhaseEchoes.ToList();
             for (int i = 0; i < 10; i++)
             {
-                if (i < echoes.Count)
-                {
-                    sb.Append($",\"{echoes[i]}\"");
-                    continue;
-                }
-
-                sb.Append(",");
+                row.Add(i < echoes.Count ? echoes[i] : string.Empty);
             }
 
             List<string> failEchoes = craft.FailPhaseEchoes.ToList();
             for (int i = 0; i < 10; i++)
             {
-                if (i < failEchoes.Count)
-                {
-                    sb.Append($",\"{failEchoes[i]}\"");
-                    continue;
-                }
-
-                sb.Append(",");
+                row.Add(i < failEchoes.Count ? failEchoes[i] : string.Empty);
             }
 
             List<ICraftInput> inputs = craft.Inputs.ToList();
             for (int i = 0; i < 10; i++)
             {
-                if (i < inputs.Count)
-                {
-                    ICraftInput input = inputs[i];
-                    sb.Append($",\"{input.InputType} - {input.HowSeen(actor).StripANSIColour()}\"");
-                    continue;
-                }
-
-                sb.Append(",");
+                row.Add(i < inputs.Count
+                    ? $"{inputs[i].InputType} - {inputs[i].HowSeen(actor).StripANSIColour()}"
+                    : string.Empty);
             }
 
             List<ICraftTool> tools = craft.Tools.ToList();
             for (int i = 0; i < 10; i++)
             {
-                if (i < tools.Count)
-                {
-                    ICraftTool tool = tools[i];
-                    sb.Append($",\"{tool.ToolType} - {tool.DesiredState.DescribeEnum()} - {tool.HowSeen(actor).StripANSIColour()}\"");
-                    continue;
-                }
-
-                sb.Append(",");
+                row.Add(i < tools.Count
+                    ? $"{tools[i].ToolType} - {tools[i].DesiredState.DescribeEnum()} - {tools[i].HowSeen(actor).StripANSIColour()}"
+                    : string.Empty);
             }
 
             List<ICraftProduct> products = craft.Products.ToList();
             for (int i = 0; i < 10; i++)
             {
-                if (i < products.Count)
-                {
-                    ICraftProduct product = products[i];
-                    sb.Append($",\"{product.ProductType} - {product.HowSeen(actor).StripANSIColour()}\"");
-                    continue;
-                }
-
-                sb.Append(",");
+                row.Add(i < products.Count
+                    ? $"{products[i].ProductType} - {products[i].HowSeen(actor).StripANSIColour()}"
+                    : string.Empty);
             }
 
             List<ICraftProduct> failProducts = craft.FailProducts.ToList();
             for (int i = 0; i < 10; i++)
             {
-                if (i < failProducts.Count)
-                {
-                    ICraftProduct product = failProducts[i];
-                    sb.Append($",\"{product.ProductType} - {product.HowSeen(actor).StripANSIColour()}\"");
-                    continue;
-                }
-
-                sb.Append(",");
+                row.Add(i < failProducts.Count
+                    ? $"{failProducts[i].ProductType} - {failProducts[i].HowSeen(actor).StripANSIColour()}"
+                    : string.Empty);
             }
 
-            sb.AppendLine();
+            AppendCraftExportRow(sb, row);
         }
 
         using FileStream fs = new($"CraftsExport{DateTime.UtcNow.ToFileTimeUtc()}.csv", FileMode.Create);
@@ -989,6 +989,22 @@ public class ImplementorModule : Module<ICharacter>
         writer.Close();
         actor.OutputHandler.Send($"Successfully exported crafts list to {fs.Name.ColourCommand()}");
         fs.Close();
+    }
+
+    private static void AppendCraftExportRow(StringBuilder sb, IEnumerable<string> cells)
+    {
+        sb.AppendLine(string.Join(",", cells.Select(EncodeCraftExportCsvCell)));
+    }
+
+    private static string EncodeCraftExportCsvCell(string value)
+    {
+        var text = value ?? string.Empty;
+        if (text.Length > 0 && text[0].In('=', '+', '-', '@', '\t', '\r', '\n'))
+        {
+            text = $"'{text}";
+        }
+
+        return $"\"{text.Replace("\"", "\"\"")}\"";
     }
 
     private static void DebugTestCover(ICharacter actor, StringStack ss)

--- a/MudSharpCore/Commands/Modules/ManipulationModule.cs
+++ b/MudSharpCore/Commands/Modules/ManipulationModule.cs
@@ -3530,6 +3530,13 @@ The syntax to use this command is as follows:
             return;
         }
 
+        (truth, error) = character.CanManipulateItem(source);
+        if (!truth)
+        {
+            character.Send(error);
+            return;
+        }
+
         if (targetContainer.Gas == null)
         {
             targetContainer.Gas = sourceContainer.Gas;

--- a/MudSharpCore/Form/Material/Gas.cs
+++ b/MudSharpCore/Form/Material/Gas.cs
@@ -151,10 +151,57 @@ public class Gas : Fluid, IGas
 
     public bool GasCountAs(IGas otherGas)
     {
-        return CountsAsGas == otherGas || (CountsAsGas?.GasCountAs(otherGas) ?? false);
+        return GasCountsAs(otherGas, new HashSet<long>());
     }
 
     public override bool CountsAs(IFluid other)
+    {
+        return CountsAs(other, new HashSet<long>());
+    }
+
+    public override ItemQuality CountAsQuality(IFluid other)
+    {
+        return CountAsQuality(other, new HashSet<long>());
+    }
+
+    #region Overrides of Fluid
+
+    /// <inheritdoc />
+    public override double CountsAsMultiplier(IFluid other)
+    {
+        return CountsAsMultiplier(other, new HashSet<long>());
+    }
+
+    private bool GasCountsAs(IGas otherGas, HashSet<long> visited)
+    {
+        if (otherGas == null)
+        {
+            return false;
+        }
+
+        if (otherGas == this)
+        {
+            return true;
+        }
+
+        if (!visited.Add(Id))
+        {
+            return false;
+        }
+
+        var countsAs = CountsAsGas;
+        if (countsAs is null)
+        {
+            return false;
+        }
+
+        return countsAs == otherGas ||
+               (countsAs is Gas concrete
+                   ? concrete.GasCountsAs(otherGas, visited)
+                   : countsAs.GasCountAs(otherGas));
+    }
+
+    private bool CountsAs(IFluid other, HashSet<long> visited)
     {
         if (other == null)
         {
@@ -167,20 +214,24 @@ public class Gas : Fluid, IGas
         }
 
         IGas otherGas = other as IGas;
-        if (otherGas is null)
+        if (otherGas is null || !visited.Add(Id))
         {
             return false;
         }
 
-        if (CountsAsGas is null)
+        var countsAs = CountsAsGas;
+        if (countsAs is null)
         {
             return false;
         }
 
-        return CountsAsGas.CountsAs(other);
+        return countsAs == otherGas ||
+               (countsAs is Gas concrete
+                   ? concrete.CountsAs(other, visited)
+                   : countsAs.CountsAs(other));
     }
 
-    public override ItemQuality CountAsQuality(IFluid other)
+    private ItemQuality CountAsQuality(IFluid other, HashSet<long> visited)
     {
         if (other == null)
         {
@@ -193,28 +244,28 @@ public class Gas : Fluid, IGas
         }
 
         IGas otherGas = other as IGas;
-        if (otherGas is null)
+        if (otherGas is null || !visited.Add(Id))
         {
             return ItemQuality.Terrible;
         }
 
-        if (otherGas == CountsAsGas)
+        var countsAs = CountsAsGas;
+        if (countsAs is null)
+        {
+            return ItemQuality.Terrible;
+        }
+
+        if (otherGas == countsAs)
         {
             return CountsAsQuality;
         }
 
-        if (CountsAsGas is null)
-        {
-            return ItemQuality.Terrible;
-        }
-
-        return CountsAsGas.CountAsQuality(other);
+        return countsAs is Gas concrete
+            ? concrete.CountAsQuality(other, visited)
+            : countsAs.CountAsQuality(other);
     }
 
-    #region Overrides of Fluid
-
-    /// <inheritdoc />
-    public override double CountsAsMultiplier(IFluid other)
+    private double CountsAsMultiplier(IFluid other, HashSet<long> visited)
     {
         if (other == null)
         {
@@ -227,22 +278,26 @@ public class Gas : Fluid, IGas
         }
 
         IGas otherGas = other as IGas;
-        if (otherGas is null)
+        if (otherGas is null || !visited.Add(Id))
         {
             return 0.0;
         }
 
-        if (otherGas == CountsAsGas)
+        var countsAs = CountsAsGas;
+        if (otherGas == countsAs)
         {
             return (int)CountsAsQuality / 11.0;
         }
 
-        if (CountsAsGas is null)
+        if (countsAs is null)
         {
             return 0.0;
         }
 
-        return CountsAsGas.CountsAsMultiplier(other) * ((int)CountsAsGas.CountsAsQuality / 11.0);
+        return (countsAs is Gas concrete
+                   ? concrete.CountsAsMultiplier(other, visited)
+                   : countsAs.CountsAsMultiplier(other)) *
+               ((int)countsAs.CountsAsQuality / 11.0);
     }
 
     #endregion
@@ -512,6 +567,12 @@ public class Gas : Fluid, IGas
         if (gas is null)
         {
             actor.OutputHandler.Send("There is no such gas.");
+            return false;
+        }
+
+        if (gas == this || gas.CountsAs(this))
+        {
+            actor.OutputHandler.Send("You cannot create a circular counts-as chain.");
             return false;
         }
 

--- a/MudSharpCore/Form/Material/Liquid.cs
+++ b/MudSharpCore/Form/Material/Liquid.cs
@@ -350,6 +350,22 @@ public class Liquid : Fluid, ILiquid
     /// <inheritdoc />
     public override bool CountsAs(IFluid other)
     {
+        return CountsAs(other, new HashSet<long>());
+    }
+
+    /// <inheritdoc />
+    public override ItemQuality CountAsQuality(IFluid other)
+    {
+        return CountAsQuality(other, new HashSet<long>());
+    }
+
+    public override double CountsAsMultiplier(IFluid other)
+    {
+        return CountsAsMultiplier(other, new HashSet<long>());
+    }
+
+    private bool CountsAs(IFluid other, HashSet<long> visited)
+    {
         if (other == null)
         {
             return false;
@@ -361,21 +377,24 @@ public class Liquid : Fluid, ILiquid
         }
 
         ILiquid otherLiquid = other as ILiquid;
-        if (otherLiquid is null)
+        if (otherLiquid is null || !visited.Add(Id))
         {
             return false;
         }
 
-        if (CountsAsLiquid is null)
+        var countsAs = CountsAsLiquid;
+        if (countsAs is null)
         {
             return false;
         }
 
-        return CountsAsLiquid.CountsAs(other);
+        return countsAs == otherLiquid ||
+               (countsAs is Liquid concrete
+                   ? concrete.CountsAs(other, visited)
+                   : countsAs.CountsAs(other));
     }
 
-    /// <inheritdoc />
-    public override ItemQuality CountAsQuality(IFluid other)
+    private ItemQuality CountAsQuality(IFluid other, HashSet<long> visited)
     {
         if (other == null)
         {
@@ -388,25 +407,28 @@ public class Liquid : Fluid, ILiquid
         }
 
         ILiquid otherLiquid = other as ILiquid;
-        if (otherLiquid is null)
+        if (otherLiquid is null || !visited.Add(Id))
         {
             return ItemQuality.Terrible;
         }
 
-        if (otherLiquid == CountsAsLiquid)
+        var countsAs = CountsAsLiquid;
+        if (countsAs is null)
+        {
+            return ItemQuality.Terrible;
+        }
+
+        if (otherLiquid == countsAs)
         {
             return CountsAsQuality;
         }
 
-        if (CountsAsLiquid is null)
-        {
-            return ItemQuality.Terrible;
-        }
-
-        return CountsAsLiquid.CountAsQuality(other);
+        return countsAs is Liquid concrete
+            ? concrete.CountAsQuality(other, visited)
+            : countsAs.CountAsQuality(other);
     }
 
-    public override double CountsAsMultiplier(IFluid other)
+    private double CountsAsMultiplier(IFluid other, HashSet<long> visited)
     {
         if (other == null)
         {
@@ -419,22 +441,26 @@ public class Liquid : Fluid, ILiquid
         }
 
         ILiquid otherLiquid = other as ILiquid;
-        if (otherLiquid is null)
+        if (otherLiquid is null || !visited.Add(Id))
         {
             return 0.0;
         }
 
-        if (otherLiquid == CountsAsLiquid)
+        var countsAs = CountsAsLiquid;
+        if (otherLiquid == countsAs)
         {
             return (int)CountsAsQuality / 11.0;
         }
 
-        if (CountsAsLiquid is null)
+        if (countsAs is null)
         {
             return 0.0;
         }
 
-        return CountsAsLiquid.CountsAsMultiplier(other) * ((int)CountsAsLiquid.CountsAsQuality / 11.0);
+        return (countsAs is Liquid concrete
+                   ? concrete.CountsAsMultiplier(other, visited)
+                   : countsAs.CountsAsMultiplier(other)) *
+               ((int)countsAs.CountsAsQuality / 11.0);
     }
 
     #endregion
@@ -454,8 +480,36 @@ public class Liquid : Fluid, ILiquid
 
     public bool LiquidCountsAs(ILiquid otherLiquid)
     {
-        return otherLiquid != null && (otherLiquid == this || CountsAsLiquid == otherLiquid ||
-                                       (CountsAsLiquid?.LiquidCountsAs(otherLiquid) ?? false));
+        return LiquidCountsAs(otherLiquid, new HashSet<long>());
+    }
+
+    private bool LiquidCountsAs(ILiquid otherLiquid, HashSet<long> visited)
+    {
+        if (otherLiquid == null)
+        {
+            return false;
+        }
+
+        if (otherLiquid == this)
+        {
+            return true;
+        }
+
+        if (!visited.Add(Id))
+        {
+            return false;
+        }
+
+        var countsAs = CountsAsLiquid;
+        if (countsAs is null)
+        {
+            return false;
+        }
+
+        return countsAs == otherLiquid ||
+               (countsAs is Liquid concrete
+                   ? concrete.LiquidCountsAs(otherLiquid, visited)
+                   : countsAs.LiquidCountsAs(otherLiquid));
     }
 
     public ItemQuality LiquidCountsAsQuality(ILiquid otherLiquid)
@@ -961,6 +1015,12 @@ public class Liquid : Fluid, ILiquid
             return false;
         }
 
+        if (liquid == this || liquid.CountsAs(this))
+        {
+            actor.OutputHandler.Send("You cannot create a circular counts-as chain.");
+            return false;
+        }
+
         _countsAs = liquid;
         _countsAsId = liquid.Id;
         CountsAsQuality = ItemQuality.Standard;
@@ -1318,6 +1378,12 @@ public class Liquid : Fluid, ILiquid
         dbitem.TasteIntensity = TasteIntensity;
         dbitem.TasteText = TasteText;
         dbitem.VagueTasteText = VagueTasteText;
+        dbitem.DampDescription = DampDescription;
+        dbitem.WetDescription = WetDescription;
+        dbitem.DrenchedDescription = DrenchedDescription;
+        dbitem.DampShortDescription = DampShortDescription;
+        dbitem.WetShortDescription = WetShortDescription;
+        dbitem.DrenchedShortDescription = DrenchedShortDescription;
         dbitem.InjectionConsequence = (int)InjectionConsequence;
         dbitem.GasFormId = _gasFormId;
         dbitem.SurfaceReactionInfo = SaveSurfaceReactions();

--- a/MudSharpCore/GameItems/Components/GridLiquidSourceGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/GridLiquidSourceGameItemComponent.cs
@@ -59,11 +59,11 @@ public class GridLiquidSourceGameItemComponent : GameItemComponent, ILiquidConta
 
     public void ReduceLiquidQuantity(double amount, ICharacter who, string action)
     {
+        RemoveLiquidAmount(amount, who, action);
     }
 
     public void MergeLiquid(LiquidMixture otherMixture, ICharacter who, string action)
     {
-        throw new InvalidOperationException("You cannot add liquid directly to a grid liquid source.");
     }
 
     public LiquidMixture? RemoveLiquidAmount(double amount, ICharacter who, string action)

--- a/MudSharpCore/GameItems/Components/HandToolGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/HandToolGameItemComponent.cs
@@ -70,23 +70,18 @@ public class HandToolGameItemComponent : GameItemComponent, IToolItem
 
     private TimeSpan MaximumDuration()
     {
-        double maximum = _prototype.ToolDurabilitySecondsExpression.EvaluateDoubleWith(("quality", (int)Parent.Quality));
-        if (maximum <= 0.0)
-        {
-            return TimeSpan.Zero;
-        }
-        return TimeSpan.FromSeconds(maximum);
+        return ToolDurabilityExpressionHelper.EvaluateDuration(_prototype.ToolDurabilitySecondsExpression, Parent.Quality);
     }
 
     private TimeSpan EffectiveDurationAvailable()
     {
-        double maximum = _prototype.ToolDurabilitySecondsExpression.EvaluateDoubleWith(("quality", (int)Parent.Quality));
-        if (maximum <= 0.0)
+        var maximum = MaximumDuration();
+        if (maximum <= TimeSpan.Zero)
         {
             return TimeSpan.Zero;
         }
-        double remaining = Parent.Condition * maximum;
-        return TimeSpan.FromSeconds(remaining);
+
+        return TimeSpan.FromSeconds(Parent.Condition * maximum.TotalSeconds);
     }
 
     public bool CountAsTool(ITag toolTag)

--- a/MudSharpCore/GameItems/Components/PowerToolGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/PowerToolGameItemComponent.cs
@@ -70,23 +70,18 @@ public class PowerToolGameItemComponent : GameItemComponent, IToolItem, IConsume
     #region IToolItem Implementation
     private TimeSpan MaximumDuration()
     {
-        double maximum = _prototype.ToolDurabilitySecondsExpression.EvaluateDoubleWith(("quality", (int)Parent.Quality));
-        if (maximum <= 0.0)
-        {
-            return TimeSpan.Zero;
-        }
-        return TimeSpan.FromSeconds(maximum);
+        return ToolDurabilityExpressionHelper.EvaluateDuration(_prototype.ToolDurabilitySecondsExpression, Parent.Quality);
     }
 
     private TimeSpan EffectiveDurationAvailable()
     {
-        double maximum = _prototype.ToolDurabilitySecondsExpression.EvaluateDoubleWith(("quality", (int)Parent.Quality));
-        if (maximum <= 0.0)
+        var maximum = MaximumDuration();
+        if (maximum <= TimeSpan.Zero)
         {
             return TimeSpan.Zero;
         }
-        double remaining = Parent.Condition * maximum;
-        return TimeSpan.FromSeconds(remaining);
+
+        return TimeSpan.FromSeconds(Parent.Condition * maximum.TotalSeconds);
     }
 
     public bool CountAsTool(ITag toolTag)

--- a/MudSharpCore/GameItems/Prototypes/HandToolGameItemComponentProto.cs
+++ b/MudSharpCore/GameItems/Prototypes/HandToolGameItemComponentProto.cs
@@ -139,8 +139,12 @@ public class HandToolGameItemComponentProto : GameItemComponentProto, IToolItemP
         try
         {
             Expression expr = new(exprText);
-            // Test it
-            expr.EvaluateDoubleWith(("quality", (int)ItemQuality.Standard));
+            if (!ToolDurabilityExpressionHelper.TryValidate(expr, out var error))
+            {
+                actor.OutputHandler.Send(error);
+                return false;
+            }
+
             ToolDurabilitySecondsExpression = expr;
             Changed = true;
             actor.OutputHandler.Send(
@@ -220,9 +224,9 @@ The formula for usage hours is {8} - best {9} typ {10} worst {11}",
             (BaseMultiplier - (int)ItemQuality.Terrible * MultiplierReductionPerQuality).ToString("P3", actor)
             .ColourValue(),
             ToolDurabilitySecondsExpression.OriginalExpression.Colour(Telnet.Yellow),
-            TimeSpan.FromSeconds(ToolDurabilitySecondsExpression.EvaluateDoubleWith(("quality", (int)ItemQuality.Legendary))).DescribePreciseBrief(actor).ColourValue(),
-            TimeSpan.FromSeconds(ToolDurabilitySecondsExpression.EvaluateDoubleWith(("quality", (int)ItemQuality.Standard))).DescribePreciseBrief(actor).ColourValue(),
-            TimeSpan.FromSeconds(ToolDurabilitySecondsExpression.EvaluateDoubleWith(("quality", (int)ItemQuality.Terrible))).DescribePreciseBrief(actor).ColourValue()
+            ToolDurabilityExpressionHelper.EvaluateDuration(ToolDurabilitySecondsExpression, ItemQuality.Legendary).DescribePreciseBrief(actor).ColourValue(),
+            ToolDurabilityExpressionHelper.EvaluateDuration(ToolDurabilitySecondsExpression, ItemQuality.Standard).DescribePreciseBrief(actor).ColourValue(),
+            ToolDurabilityExpressionHelper.EvaluateDuration(ToolDurabilitySecondsExpression, ItemQuality.Terrible).DescribePreciseBrief(actor).ColourValue()
         );
     }
 }

--- a/MudSharpCore/GameItems/Prototypes/PowerToolGameItemComponentProto.cs
+++ b/MudSharpCore/GameItems/Prototypes/PowerToolGameItemComponentProto.cs
@@ -151,8 +151,12 @@ public class PowerToolGameItemComponentProto : GameItemComponentProto, IToolItem
         try
         {
             Expression expr = new(exprText);
-            // Test it
-            expr.EvaluateDoubleWith(("quality", (int)ItemQuality.Standard));
+            if (!ToolDurabilityExpressionHelper.TryValidate(expr, out var error))
+            {
+                actor.OutputHandler.Send(error);
+                return false;
+            }
+
             ToolDurabilitySecondsExpression = expr;
             Changed = true;
             actor.OutputHandler.Send(
@@ -254,9 +258,9 @@ The formula for usage hours is {9} - best {10} typ {11} worst {12}",
             (BaseMultiplier - (int)ItemQuality.Terrible * MultiplierReductionPerQuality).ToString("P3", actor)
             .ColourValue(),
             ToolDurabilitySecondsExpression.OriginalExpression.Colour(Telnet.Yellow),
-            TimeSpan.FromSeconds(ToolDurabilitySecondsExpression.EvaluateDoubleWith(("quality", (int)ItemQuality.Legendary))).DescribePreciseBrief(actor).ColourValue(),
-            TimeSpan.FromSeconds(ToolDurabilitySecondsExpression.EvaluateDoubleWith(("quality", (int)ItemQuality.Standard))).DescribePreciseBrief(actor).ColourValue(),
-            TimeSpan.FromSeconds(ToolDurabilitySecondsExpression.EvaluateDoubleWith(("quality", (int)ItemQuality.Terrible))).DescribePreciseBrief(actor).ColourValue()
+            ToolDurabilityExpressionHelper.EvaluateDuration(ToolDurabilitySecondsExpression, ItemQuality.Legendary).DescribePreciseBrief(actor).ColourValue(),
+            ToolDurabilityExpressionHelper.EvaluateDuration(ToolDurabilitySecondsExpression, ItemQuality.Standard).DescribePreciseBrief(actor).ColourValue(),
+            ToolDurabilityExpressionHelper.EvaluateDuration(ToolDurabilitySecondsExpression, ItemQuality.Terrible).DescribePreciseBrief(actor).ColourValue()
         );
     }
 }

--- a/MudSharpCore/GameItems/ToolDurabilityExpressionHelper.cs
+++ b/MudSharpCore/GameItems/ToolDurabilityExpressionHelper.cs
@@ -1,0 +1,59 @@
+#nullable enable
+
+using ExpressionEngine;
+using MudSharp.Framework;
+using System;
+
+namespace MudSharp.GameItems;
+
+internal static class ToolDurabilityExpressionHelper
+{
+	public static bool TryValidate(IExpression expression, out string error)
+	{
+		foreach (var quality in Enum.GetValues<ItemQuality>())
+		{
+			double seconds;
+			try
+			{
+				seconds = expression.EvaluateDoubleWith(("quality", (int)quality));
+			}
+			catch (Exception ex)
+			{
+				error = $"The expression fails for {quality.Describe().ColourValue()} quality: {ex.Message.ColourError()}";
+				return false;
+			}
+
+			if (!IsValidDurationSeconds(seconds))
+			{
+				error =
+					$"The expression must produce a finite, non-negative duration no greater than {TimeSpan.MaxValue.TotalSeconds.ToString("N0").ColourValue()} seconds for every item quality. It produced {seconds.ToString("G17").ColourError()} for {quality.Describe().ColourValue()} quality.";
+				return false;
+			}
+		}
+
+		error = string.Empty;
+		return true;
+	}
+
+	public static TimeSpan EvaluateDuration(IExpression expression, ItemQuality quality)
+	{
+		try
+		{
+			var seconds = expression.EvaluateDoubleWith(("quality", (int)quality));
+			return IsValidDurationSeconds(seconds)
+				? TimeSpan.FromSeconds(seconds)
+				: TimeSpan.Zero;
+		}
+		catch
+		{
+			return TimeSpan.Zero;
+		}
+	}
+
+	private static bool IsValidDurationSeconds(double seconds)
+	{
+		return double.IsFinite(seconds) &&
+		       seconds >= 0.0 &&
+		       seconds <= TimeSpan.MaxValue.TotalSeconds;
+	}
+}

--- a/MudSharpCore/Magic/SpellEffects/CreateLiquidEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/CreateLiquidEffect.cs
@@ -138,6 +138,11 @@ public class CreateLiquidEffect : IMagicSpellEffectTemplate
                 mixture.SetLiquidVolume(amount);
             }
 
+            if (amount <= 0.0 || mixture.TotalVolume <= 0.0)
+            {
+                return null;
+            }
+
             if (container.LiquidMixture?.CanMerge(mixture) == true)
             {
                 container.MergeLiquid(mixture, null, "spell");

--- a/MudSharpCore/Work/Agriculture/AgricultureField.cs
+++ b/MudSharpCore/Work/Agriculture/AgricultureField.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Xml.Linq;
 using Microsoft.EntityFrameworkCore;
 using MudSharp.Character;
+using MudSharp.Character.Heritage;
 using MudSharp.Climate;
 using MudSharp.Construction;
 using MudSharp.Database;
@@ -1157,9 +1158,16 @@ public class AgricultureField : SaveableItem, IAgricultureField
 
 	public bool AbsorbNpcIntoHerd(ICharacter npc, IAgricultureHerdDefinition definition, ICharacter actor, out string result)
 	{
-		if (npc == null || npc.IsPlayerCharacter || npc.Location != Cell)
+		if (npc == null || npc.IsPlayerCharacter || npc.Location != Cell || !AnimalLineageHelper.IsAnimal(npc))
 		{
 			result = "You can only absorb a non-player animal in this field.";
+			return false;
+		}
+
+		if (definition.NpcTemplate != null && npc is INPC concreteNpc &&
+		    concreteNpc.Template?.Id != definition.NpcTemplate.Id)
+		{
+			result = $"You can only absorb animals that match the {definition.Name} herd definition.";
 			return false;
 		}
 

--- a/MudSharpCore/Work/Crafts/Craft.cs
+++ b/MudSharpCore/Work/Crafts/Craft.cs
@@ -430,7 +430,8 @@ public class Craft : Framework.Revision.EditableItem, ICraft
     public ITraitDefinition CheckTrait { get; set; }
     public Difficulty CheckDifficulty { get; set; }
     public IEnumerable<string> PhaseEchoes => _craftPhases.Select(x => x.Echo);
-    public IEnumerable<TimeSpan> PhaseLengths => _craftPhases.Select(x => TimeSpan.FromSeconds(x.PhaseLengthInSeconds));
+    public IEnumerable<TimeSpan> PhaseLengths => _craftPhases.Select(x =>
+        TryGetPhaseLength(x.PhaseLengthInSeconds, out var phaseLength) ? phaseLength : TimeSpan.Zero);
     public IEnumerable<string> FailPhaseEchoes => _craftPhases.Select(x => x.FailEcho);
     public int FailPhase { get; set; }
     public ITraitExpression QualityFormula { get; set; }
@@ -1002,8 +1003,53 @@ public class Craft : Framework.Revision.EditableItem, ICraft
         {
             _craftIsValid = Inputs.All(x => x.IsValid()) && Tools.All(x => x.IsValid()) &&
                             Products.All(x => x.IsValid()) && FailProducts.All(x => x.IsValid()) &&
+                            _craftPhases.All(x => IsValidPhaseLength(x.PhaseLengthInSeconds)) &&
                             PhaseEchoes.Any() && AppearInCraftsListProg != null;
         }
+    }
+
+    private static bool IsValidPhaseLength(double seconds)
+    {
+        return double.IsFinite(seconds) &&
+               seconds >= 0.0 &&
+               seconds <= TimeSpan.MaxValue.TotalSeconds;
+    }
+
+    private static bool TryGetPhaseLength(double seconds, out TimeSpan phaseLength)
+    {
+        if (!IsValidPhaseLength(seconds))
+        {
+            phaseLength = TimeSpan.Zero;
+            return false;
+        }
+
+        phaseLength = TimeSpan.FromSeconds(seconds);
+        return true;
+    }
+
+    private static bool TryParsePhaseLength(ICharacter actor, string text, out double seconds)
+    {
+        if (!double.TryParse(text, out seconds))
+        {
+            actor.OutputHandler.Send("You must specify a number of seconds for the phase to last.");
+            return false;
+        }
+
+        if (IsValidPhaseLength(seconds))
+        {
+            return true;
+        }
+
+        actor.OutputHandler.Send(
+            $"Phase length must be a finite, non-negative number no greater than {TimeSpan.MaxValue.TotalSeconds.ToString("N0", actor).ColourValue()} seconds.");
+        return false;
+    }
+
+    private static string DescribePhaseLength(ICraftPhase phase, ICharacter actor)
+    {
+        return TryGetPhaseLength(phase.PhaseLengthInSeconds, out var phaseLength)
+            ? phaseLength.DescribePreciseBrief(actor)
+            : "Invalid".ColourError();
     }
 
     public bool AppearInCraftsList(ICharacter actor)
@@ -1216,7 +1262,15 @@ public class Craft : Framework.Revision.EditableItem, ICraft
             phaseLengthSeconds *= tool.PhaseLengthMultiplier(item);
         }
 
-        TimeSpan phaseLength = TimeSpan.FromSeconds(phaseLengthSeconds);
+        if (!TryGetPhaseLength(phaseLengthSeconds, out var phaseLength))
+        {
+            character.OutputHandler.Handle(new EmoteOutput(
+                new Emote($"@ stop|stops {ActionDescription} because this craft has an invalid phase duration.",
+                    character, character)));
+            PauseCraft(character, component, effect);
+            return false;
+        }
+
         foreach ((IGameItem item, ICraftTool tool) in tools)
         {
             tool.UseTool(item, phaseLength, component.HasFailed);
@@ -1916,9 +1970,8 @@ public class Craft : Framework.Revision.EditableItem, ICraft
             return false;
         }
 
-        if (!double.TryParse(command.PopSpeech(), out double value))
+        if (!TryParsePhaseLength(actor, command.PopSpeech(), out double value))
         {
-            actor.OutputHandler.Send("You must specify a number of seconds for the phase to last.");
             return false;
         }
 
@@ -1980,9 +2033,8 @@ public class Craft : Framework.Revision.EditableItem, ICraft
             return false;
         }
 
-        if (!double.TryParse(command.PopSpeech(), out double seconds))
+        if (!TryParsePhaseLength(actor, command.PopSpeech(), out double seconds))
         {
-            actor.OutputHandler.Send("You must specify a number of seconds for the phase to last.");
             return false;
         }
 
@@ -2560,7 +2612,7 @@ public class Craft : Framework.Revision.EditableItem, ICraft
         {
             phaseStrings.Add([
                 phase.PhaseNumber.ToStringN0(actor).Colour(Telnet.Cyan),
-                TimeSpan.FromSeconds(phase.PhaseLengthInSeconds).DescribePreciseBrief(actor),
+                DescribePhaseLength(phase, actor),
                 phase.StaminaUsage.ToStringN2Colour(actor),
                 phase.ExertionLevel.Describe(),
                 phase.Echo

--- a/MudSharpCore/Work/Crafts/Inputs/AgricultureFieldInput.cs
+++ b/MudSharpCore/Work/Crafts/Inputs/AgricultureFieldInput.cs
@@ -123,7 +123,7 @@ public class AgricultureFieldInput : BaseInput
 	{
 		var location = character.Location;
 		var field = location?.AgricultureField;
-		return location != null && field != null && FieldMatches(field)
+		return location != null && field != null && FieldMatches(field) && CanActorUseField(character, field)
 			? [location]
 			: Enumerable.Empty<IPerceivable>();
 	}
@@ -192,6 +192,15 @@ public class AgricultureFieldInput : BaseInput
 		}
 
 		return MinimumHealth == 0 && MinimumYield == 0 && YieldConsumed == 0;
+	}
+
+	private static bool CanActorUseField(ICharacter actor, IAgricultureField field)
+	{
+		var property = actor.Gameworld.Properties.FirstOrDefault(x => x.PropertyLocations.Contains(field.Cell));
+		return property == null ||
+		       actor.IsAdministrator() ||
+		       property.IsAuthorisedOwner(actor) ||
+		       property.IsAuthorisedLeaseHolder(actor);
 	}
 
 	private static int FieldHealth(IAgricultureField field)

--- a/MudSharpCore/Work/Crafts/Inputs/ConditionRepairInput.cs
+++ b/MudSharpCore/Work/Crafts/Inputs/ConditionRepairInput.cs
@@ -13,7 +13,7 @@ using System.Xml.Linq;
 
 namespace MudSharp.Work.Crafts.Inputs;
 
-public class ConditionRepairInput : BaseInput, ICraftInputConsumesGameItem
+public class ConditionRepairInput : BaseInput
 {
     public override string InputType => "ConditionRepair";
     public ITag TargetTag { get; set; }

--- a/MudSharpCore/Work/Crafts/Products/CookedFoodProduct.cs
+++ b/MudSharpCore/Work/Crafts/Products/CookedFoodProduct.cs
@@ -87,7 +87,6 @@ public class CookedFoodProduct : BaseProduct
 			var item = CreateOneItem(component, proto, referenceQuality, material);
 			item.GetItemType<IStackable>().Quantity = Quantity;
 			InitialisePreparedFood(component, item);
-			item.HandleEvent(EventType.ItemFinishedLoading, item);
 			return new SimpleProductData(new[] { item });
 		}
 
@@ -96,7 +95,6 @@ public class CookedFoodProduct : BaseProduct
 		{
 			var item = CreateOneItem(component, proto, referenceQuality, material);
 			InitialisePreparedFood(component, item);
-			item.HandleEvent(EventType.ItemFinishedLoading, item);
 			items.Add(item);
 		}
 

--- a/MudSharpCore/Work/Crafts/Products/InputVariableProduct.cs
+++ b/MudSharpCore/Work/Crafts/Products/InputVariableProduct.cs
@@ -122,7 +122,6 @@ internal class InputVariableProduct : BaseProduct
                 newItem.Material = material;
             }
 
-            newItem.HandleEvent(EventType.ItemFinishedLoading, newItem);
             return new SimpleProductData(new[] { newItem });
         }
 
@@ -142,7 +141,6 @@ internal class InputVariableProduct : BaseProduct
                 item.Material = material;
             }
 
-            item.HandleEvent(EventType.ItemFinishedLoading, item);
         }
 
         return new SimpleProductData(items);

--- a/MudSharpCore/Work/Crafts/Products/LiquidProduct.cs
+++ b/MudSharpCore/Work/Crafts/Products/LiquidProduct.cs
@@ -99,7 +99,6 @@ public class LiquidProduct : BaseProduct
 			}
 
 			Gameworld.Add(item);
-			item.HandleEvent(EventType.ItemFinishedLoading, item);
 			items.Add(item);
 		}
 

--- a/MudSharpCore/Work/Crafts/Products/ProgVariableProduct.cs
+++ b/MudSharpCore/Work/Crafts/Products/ProgVariableProduct.cs
@@ -215,7 +215,6 @@ namespace MudSharp.Work.Crafts.Products
                     newItem.Material = material;
                 }
 
-                newItem.HandleEvent(EventType.ItemFinishedLoading, newItem);
                 return new SimpleProductData(new[] { newItem });
             }
 
@@ -235,7 +234,6 @@ namespace MudSharp.Work.Crafts.Products
                     item.Material = material;
                 }
 
-                item.HandleEvent(EventType.ItemFinishedLoading, item);
             }
 
             return new SimpleProductData(items);

--- a/MudSharpCore/Work/Crafts/Products/SimpleProduct.cs
+++ b/MudSharpCore/Work/Crafts/Products/SimpleProduct.cs
@@ -77,7 +77,6 @@ public class SimpleProduct : BaseProduct
             }
 
             newItem.GetItemType<IStackable>().Quantity = Quantity;
-            newItem.HandleEvent(EventType.ItemFinishedLoading, newItem);
             return new SimpleProductData(new[] { newItem });
         }
 
@@ -98,7 +97,6 @@ public class SimpleProduct : BaseProduct
             {
                 item.Material = material;
             }
-            item.HandleEvent(EventType.ItemFinishedLoading, item);
             items.Add(item);
         }
 

--- a/MudSharpCore/Work/Crafts/Products/SimpleVariableProduct.cs
+++ b/MudSharpCore/Work/Crafts/Products/SimpleVariableProduct.cs
@@ -188,7 +188,6 @@ public class SimpleVariableProduct : SimpleProduct
                 newItem.Material = material;
             }
 
-            newItem.HandleEvent(EventType.ItemFinishedLoading, newItem);
             return new SimpleProductData(new[] { newItem });
         }
 
@@ -208,7 +207,6 @@ public class SimpleVariableProduct : SimpleProduct
                 item.Material = material;
             }
 
-            item.HandleEvent(EventType.ItemFinishedLoading, item);
         }
 
         return new SimpleProductData(items);

--- a/MudSharpCore/Work/Crafts/Products/UnusedInputProduct.cs
+++ b/MudSharpCore/Work/Crafts/Products/UnusedInputProduct.cs
@@ -144,7 +144,6 @@ public class UnusedInputProduct : BaseProduct
                 newItem.Quality = referenceQuality;
             }
 
-            newItem.HandleEvent(EventType.ItemFinishedLoading, newItem);
             return new UnusedInputProductData(new[] { newItem });
         }
 
@@ -158,7 +157,6 @@ public class UnusedInputProduct : BaseProduct
             {
                 item.Quality = referenceQuality;
             }
-            item.HandleEvent(EventType.ItemFinishedLoading, item);
         }
 
         return new UnusedInputProductData(items);


### PR DESCRIPTION
## Summary
- Remediates all 15 Codex Security findings in triage_group `Crafting, Agriculture, Materials & Resources`.
- Adds authorization/resource/lifecycle guards for agriculture, craft inputs/products, tool durability, grid liquids, gas filling, cleaning, fluid counts-as chains, phase durations, CSV export, and liquid soak persistence.
- Adds focused regression coverage across the touched core runtime areas.

## Validation
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 --filter "FullyQualifiedName~CommandExecutionSecurityTests|FullyQualifiedName~AgricultureOperationTests|FullyQualifiedName~GridSystemTests|FullyQualifiedName~HandToolDurabilityTests|FullyQualifiedName~LiquidProductTests|FullyQualifiedName~LiquidContaminationV2SourceTests|FullyQualifiedName~MaterialTests|FullyQualifiedName~CraftToolUsageTests" -p:NoWarn=NU1902%3BNU1510` -> Passed, 111/111
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510` -> Passed, 1157/1157
- `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510` -> Build succeeded, 0 warnings, 0 errors
- `git diff --check` -> exit 0; only LF-to-CRLF working-copy notices