### PR TITLE
Harden arena lifecycle, betting, and rating validation

### DIFF
--- a/Design Documents/Combat/Combat_Arenas_Design.md
+++ b/Design Documents/Combat/Combat_Arenas_Design.md
@@ -41,6 +41,10 @@ This feature must remain **data-driven**, **extensible**, and **safe under failu
 - `Animal Bohort` now seeds with the shared `isanimal(character)` eligibility helper and a blank stock NPC loader prog that intentionally returns an empty character collection for builder override.
 - Arena scoring progs now receive appended live scoring telemetry collections for scoring attackers/defenders, side indices, landed-hit flags, undefended-hit flags, normalized impact locations, and impact bodypart descriptions. These collections are populated only for successful live combat resolutions where both combatants are active participants in the same arena event.
 - The seeded boxing scoring prog now awards exactly 1 point per landed, undefended strike to the head or torso, independent of wound count.
+- Arena guardrails now cap live scoring telemetry snapshots and clear them during cleanup/completion/abort, require signup commands to originate from the arena venue before staging teleports occur, and require surrender to be tied to the participant's current arena bout rather than unrelated combat.
+- Arena betting and ratings now use persistent character IDs for participant/self-bet checks, bound bet-history output, rating values, Elo K-factors, and recurring schedule intervals, settle multi-winner pari-mutuel pools by distributing the losing pool once across all winners, and reject missing-winner Elo results without rating changes.
+- Arena manager rating lookup now resolves only visible characters or characters with existing ratings in the managed arena, avoiding arbitrary offline character materialisation and true-description disclosure.
+- Arena date/time entry paths rely on shared date parsing that rejects daylight-saving invalid local times as normal validation failures instead of throwing command exceptions.
 
 ## 2) Core Concepts (finalized)
 - **Combat Arena** = venue + operator. Belongs to an **Economic Zone**; behaves like a business (P&L, tax per period; bank/virtual cash; solvency enforced).

--- a/Design Documents/Combat/Combat_Arenas_Implementation_Plan.md
+++ b/Design Documents/Combat/Combat_Arenas_Implementation_Plan.md
@@ -34,6 +34,10 @@ Current Runtime Snapshot (2026-04-10)
 - `Animal Bohort` now uses the shared `isanimal(character)` helper plus a blank stock NPC loader prog returning `emptycharacters()`, giving builders a safe override point.
 - Arena scoring progs now receive append-only live combat telemetry collections (attackers, defenders, side indices, landed flags, undefended flags, normalized impact locations, impact bodypart descriptions) so body-location-aware formats such as boxing can score from live strikes without schema changes.
 - The stock boxing scoring prog now counts one point per landed undefended head or torso strike, while wrestling remains a knockout-driven 1v1 format with no inventory loadout.
+- Arena security guardrails now cap and clear scoring telemetry snapshots, clear participation effects across live and cached actors, require public signup to originate from the arena venue, and restrict surrender to the participant's current arena bout.
+- Arena numeric guardrails now bound bet-history page size, fixed-odds rating math, persisted rating updates, Elo K-factors, and recurring schedule intervals; daylight-saving invalid local command times fail validation instead of throwing.
+- Arena betting and ratings integrity now use persistent character IDs for participant/self-bet checks, distribute pari-mutuel multi-winner losing pools only once across all winners, and skip Elo updates for malformed win outcomes without winning sides.
+- Arena manager rating lookup now avoids arbitrary offline character loads by resolving only visible targets or existing rating summaries in the managed arena.
 
 ---
 

--- a/FutureMUDLibrary Unit Tests/DateUtilitiesTests.cs
+++ b/FutureMUDLibrary Unit Tests/DateUtilitiesTests.cs
@@ -1,7 +1,12 @@
+#nullable enable
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Accounts;
 using MudSharp.Framework;
 using MudSharp.TimeAndDate;
 using System;
+using System.Globalization;
 
 namespace MudSharp_Unit_Tests;
 
@@ -37,5 +42,43 @@ public class DateUtilitiesTests
 		Assert.AreEqual("2 years", TimeSpan.FromDays(730).Describe());
 		Assert.AreEqual("2 years", TimeSpan.FromDays(730).DescribePrecise());
 		Assert.AreEqual("2y", TimeSpan.FromDays(730).DescribePreciseBrief());
+	}
+
+	[TestMethod]
+	public void TryParseDateTimeOrRelative_DstInvalidLocalTime_ReturnsFalse()
+	{
+		TimeZoneInfo? timezone = ResolveNewYorkTimeZone();
+		if (timezone is null)
+		{
+			Assert.Inconclusive("No New York time zone was available on this test host.");
+		}
+
+		Mock<IAccount> account = new();
+		account.SetupGet(x => x.Culture).Returns(CultureInfo.InvariantCulture);
+		account.SetupGet(x => x.TimeZone).Returns(timezone!);
+
+		bool result = DateUtilities.TryParseDateTimeOrRelative("2026-03-08 02:30", account.Object, false, out DateTime parsed);
+
+		Assert.IsFalse(result);
+		Assert.AreEqual(default, parsed);
+	}
+
+	private static TimeZoneInfo? ResolveNewYorkTimeZone()
+	{
+		foreach (string id in new[] { "America/New_York", "Eastern Standard Time" })
+		{
+			try
+			{
+				return TimeZoneInfo.FindSystemTimeZoneById(id);
+			}
+			catch (TimeZoneNotFoundException)
+			{
+			}
+			catch (InvalidTimeZoneException)
+			{
+			}
+		}
+
+		return null;
 	}
 }

--- a/FutureMUDLibrary Unit Tests/FutureMUDLibrary Unit Tests.csproj
+++ b/FutureMUDLibrary Unit Tests/FutureMUDLibrary Unit Tests.csproj
@@ -11,6 +11,7 @@
 		<PackageReference Include="Moq" Version="4.20.70" />
 		<PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
 		<PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+		<PackageReference Include="TimeSpanParserUtil" Version="1.2.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/FutureMUDLibrary/Framework/DateUtilities.cs
+++ b/FutureMUDLibrary/Framework/DateUtilities.cs
@@ -330,10 +330,18 @@ public static partial class DateUtilities
 
         if (DateTime.TryParse(text, account.Culture, DateTimeStyles.None, out DateTime parsed))
         {
-            utcDateTime = parsed.Kind == DateTimeKind.Unspecified
-                ? TimeZoneInfo.ConvertTimeToUtc(parsed, account.TimeZone)
-                : parsed.ToUniversalTime();
-            return true;
+            try
+            {
+                utcDateTime = parsed.Kind == DateTimeKind.Unspecified
+                    ? TimeZoneInfo.ConvertTimeToUtc(parsed, account.TimeZone)
+                    : parsed.ToUniversalTime();
+                return true;
+            }
+            catch (ArgumentException)
+            {
+                utcDateTime = default;
+                return false;
+            }
         }
 
         if (!allowRelative)

--- a/MudSharpCore Unit Tests/Arenas/ArenaBettingServiceTests.cs
+++ b/MudSharpCore Unit Tests/Arenas/ArenaBettingServiceTests.cs
@@ -164,6 +164,30 @@ public class ArenaBettingServiceTests
     }
 
     [TestMethod]
+    public void CanBet_ReturnsFalse_WhenParticipantCharacterReferenceDiffers()
+    {
+        using FuturemudDatabaseContext context = BuildContext();
+        Mock<IArenaFinanceService> financeMock = new();
+        Mock<IArenaBetPaymentService> paymentMock = new();
+        ArenaBettingService service = CreateService(context, financeMock, paymentMock, new Dictionary<long, ICharacter>());
+        Mock<ICharacter> actor = new();
+        actor.SetupGet(x => x.Id).Returns(10L);
+        Mock<ICharacter> cachedParticipantCharacter = new();
+        cachedParticipantCharacter.SetupGet(x => x.Id).Returns(10L);
+        Mock<IArenaParticipant> participant = new();
+        participant.SetupGet(x => x.CharacterId).Returns(10L);
+        participant.SetupGet(x => x.Character).Returns(cachedParticipantCharacter.Object);
+        Mock<ICombatArena> arena = new();
+        IArenaEvent evt = BuildEvent(arena, BettingModel.FixedOdds, ArenaEventState.RegistrationOpen,
+            new[] { participant.Object }, sideCount: 2);
+
+        (bool Truth, string Reason) result = service.CanBet(actor.Object, evt);
+
+        Assert.IsFalse(result.Truth);
+        StringAssert.Contains(result.Reason, "Participants cannot bet");
+    }
+
+    [TestMethod]
     public void PlaceBet_FixedOdds_CreatesBetAndCreditsArena()
     {
         using FuturemudDatabaseContext context = BuildContext();
@@ -342,6 +366,29 @@ public class ArenaBettingServiceTests
     }
 
     [TestMethod]
+    public void GetQuote_FixedOdds_ExtremeStartingRatings_DoesNotThrow()
+    {
+        using FuturemudDatabaseContext context = BuildContext();
+        Mock<IArenaFinanceService> financeMock = new();
+        Mock<IArenaBetPaymentService> paymentMock = new();
+        ArenaBettingService service = CreateService(context, financeMock, paymentMock, new Dictionary<long, ICharacter>());
+        Mock<ICombatArena> arena = new();
+        IArenaParticipant[] participants =
+        [
+            BuildParticipant(1L, 0, decimal.MaxValue),
+            BuildParticipant(2L, 1, ArenaRatingsService.DefaultRating)
+        ];
+        IArenaEvent evt = BuildEvent(arena, BettingModel.FixedOdds, ArenaEventState.RegistrationOpen, participants,
+            sideCount: 2);
+
+        decimal? quote = service.GetQuote(evt, 0).FixedOdds;
+
+        Assert.IsTrue(quote.HasValue);
+        Assert.IsTrue(quote.Value >= 1.1m);
+        Assert.IsTrue(quote.Value <= 20.0m);
+    }
+
+    [TestMethod]
     public void Settle_Solvent_CreatesPayoutRecords()
     {
         using FuturemudDatabaseContext context = BuildContext();
@@ -410,6 +457,51 @@ public class ArenaBettingServiceTests
 
         ArenaBetPayout payout = context.ArenaBetPayouts.Single();
         Assert.AreEqual(70m, payout.Amount);
+    }
+
+    [TestMethod]
+    public void Settle_PariMutuelMultipleWinningSides_DistributesLosingPoolOnce()
+    {
+        using FuturemudDatabaseContext context = BuildContext();
+        Mock<IArenaFinanceService> financeMock = new();
+        financeMock.Setup(x => x.IsSolvent(It.IsAny<ICombatArena>(), It.IsAny<decimal>())).Returns((true, string.Empty));
+        Mock<ICombatArena> arena = new();
+        arena.Setup(x => x.EnsureFunds(It.IsAny<decimal>())).Returns((true, string.Empty));
+        Mock<ICurrency> currency = new();
+        currency.Setup(x => x.Describe(It.IsAny<decimal>(), It.IsAny<CurrencyDescriptionPatternType>()))
+            .Returns<decimal, CurrencyDescriptionPatternType>((amount, _) => amount.ToString("F2"));
+        arena.SetupGet(x => x.Currency).Returns(currency.Object);
+        Mock<IArenaBetPaymentService> paymentMock = new();
+        paymentMock.Setup(x => x.CollectStake(It.IsAny<ICharacter>(), It.IsAny<IArenaEvent>(), It.IsAny<decimal>()))
+            .Returns((true, string.Empty));
+        paymentMock.Setup(x => x.TryDisburse(It.IsAny<ICharacter>(), It.IsAny<IArenaEvent>(), It.IsAny<decimal>()))
+            .Returns(true);
+        Dictionary<long, ICharacter> characters = new();
+        foreach (long id in new[] { 21L, 22L, 23L })
+        {
+            Mock<ICharacter> character = new();
+            character.SetupGet(x => x.Id).Returns(id);
+            Mock<IOutputHandler> outputHandler = new();
+            outputHandler.Setup(x => x.Send(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>())).Returns(true);
+            outputHandler.Setup(x => x.Send(It.IsAny<IOutput>(), It.IsAny<bool>(), It.IsAny<bool>())).Returns(true);
+            character.SetupGet(x => x.OutputHandler).Returns(outputHandler.Object);
+            characters[id] = character.Object;
+        }
+
+        ArenaBettingService service = CreateService(context, financeMock, paymentMock, characters);
+        IArenaEvent evt = BuildEvent(arena, BettingModel.PariMutuel, ArenaEventState.RegistrationOpen, sideCount: 3);
+        service.PlaceBet(characters[21L], evt, 0, 100m);
+        service.PlaceBet(characters[22L], evt, 1, 100m);
+        service.PlaceBet(characters[23L], evt, 2, 100m);
+
+        service.Settle(evt, ArenaOutcome.Win, new[] { 0, 1 });
+
+        List<decimal> payouts = context.ArenaBetPayouts
+            .OrderBy(x => x.CharacterId)
+            .Select(x => x.Amount)
+            .ToList();
+        CollectionAssert.AreEqual(new[] { 145.0m, 145.0m }, payouts);
+        Assert.AreEqual(290.0m, payouts.Sum());
     }
 
     [TestMethod]
@@ -517,6 +609,39 @@ public class ArenaBettingServiceTests
         ArenaBetSummary history = service.GetBetHistory(actor.Object, 5).Single();
 
         Assert.AreEqual(75m, history.CollectedPayout);
+    }
+
+    [TestMethod]
+    public void GetBetHistory_ClampsRequestedCount()
+    {
+        using FuturemudDatabaseContext context = BuildContext();
+        SeedArenaGraph(context, arenaId: 3, eventTypeId: 3, eventId: 3, state: ArenaEventState.Completed);
+        for (int i = 0; i < ArenaBettingService.MaximumBetHistoryCount + 25; i++)
+        {
+            context.ArenaBets.Add(new ArenaBet
+            {
+                ArenaEventId = 3,
+                CharacterId = 66,
+                SideIndex = 0,
+                Stake = 1m,
+                PlacedAt = DateTime.UtcNow.AddMinutes(-i),
+                FixedDecimalOdds = 2.0m,
+                IsCancelled = false,
+                ModelSnapshot = "{}"
+            });
+        }
+        context.SaveChanges();
+
+        Mock<IArenaFinanceService> financeMock = new();
+        Mock<IArenaBetPaymentService> paymentMock = new();
+        Mock<ICharacter> actor = new();
+        actor.SetupGet(x => x.Id).Returns(66L);
+        ArenaBettingService service = CreateService(context, financeMock, paymentMock,
+            new Dictionary<long, ICharacter> { { 66L, actor.Object } });
+
+        IReadOnlyCollection<ArenaBetSummary> history = service.GetBetHistory(actor.Object, int.MaxValue);
+
+        Assert.AreEqual(ArenaBettingService.MaximumBetHistoryCount, history.Count);
     }
 
     [TestMethod]

--- a/MudSharpCore Unit Tests/Arenas/ArenaEventCleanupTests.cs
+++ b/MudSharpCore Unit Tests/Arenas/ArenaEventCleanupTests.cs
@@ -47,6 +47,58 @@ public class ArenaEventCleanupTests
         combat.Verify(x => x.LeaveCombat(character.Object), Times.Once);
     }
 
+    [TestMethod]
+    public void Cleanup_ClearsScoringSnapshots()
+    {
+        Mock<ICharacter> attacker = new();
+        attacker.SetupGet(x => x.Id).Returns(500L);
+        attacker.SetupGet(x => x.IsPlayerCharacter).Returns(true);
+        attacker.Setup(x => x.CombinedEffectsOfType<ArenaPreparingEffect>())
+            .Returns([]);
+        attacker.Setup(x => x.CombinedEffectsOfType<ArenaStagingEffect>())
+            .Returns([]);
+        attacker.Setup(x => x.CombinedEffectsOfType<ArenaParticipantPreparationEffect>())
+            .Returns([]);
+        Mock<ICharacter> defender = new();
+        defender.SetupGet(x => x.Id).Returns(501L);
+
+        Mock<IFuturemud> gameworld = BuildGameworld(attacker.Object);
+        MudSharp.Arenas.ArenaEvent arenaEvent = (MudSharp.Arenas.ArenaEvent)BuildLiveEvent(gameworld.Object);
+        for (int i = 0; i < 600; i++)
+        {
+            arenaEvent.RecordScoringCandidate(new ArenaScoringSnapshot(
+                attacker.Object,
+                defender.Object,
+                0,
+                1,
+                1,
+                1,
+                "head",
+                "head"));
+        }
+
+        Assert.AreEqual(512, arenaEvent.ScoringSnapshots.Count);
+
+        arenaEvent.Cleanup();
+
+        Assert.AreEqual(0, arenaEvent.ScoringSnapshots.Count);
+    }
+
+    [TestMethod]
+    public void CanSurrender_RegisteredParticipantWithoutArenaBoutCombat_ReturnsFalse()
+    {
+        Mock<ICharacter> character = new();
+        character.SetupGet(x => x.Id).Returns(500L);
+        character.SetupGet(x => x.IsPlayerCharacter).Returns(true);
+
+        Mock<IFuturemud> gameworld = BuildGameworld(character.Object);
+        IArenaEvent arenaEvent = BuildLiveEvent(gameworld.Object);
+
+        (bool truth, _) = arenaEvent.CanSurrender(character.Object);
+
+        Assert.IsFalse(truth);
+    }
+
     private static IArenaEvent BuildLiveEvent(IFuturemud gameworld)
     {
         Arena arenaModel = new()

--- a/MudSharpCore Unit Tests/Arenas/ArenaParticipationServiceTests.cs
+++ b/MudSharpCore Unit Tests/Arenas/ArenaParticipationServiceTests.cs
@@ -98,6 +98,35 @@ public class ArenaParticipationServiceTests
     }
 
     [TestMethod]
+    public void ClearParticipation_Event_RemovesCachedActorEffect()
+    {
+        Mock<ICharacter> cachedParticipant = new();
+        cachedParticipant.SetupGet(x => x.Id).Returns(200L);
+        cachedParticipant.SetupGet(x => x.Name).Returns("Cached Participant");
+        cachedParticipant.SetupGet(x => x.FrameworkItemType).Returns("Character");
+        cachedParticipant.SetupGet(x => x.IsPlayerCharacter).Returns(true);
+        cachedParticipant.SetupGet(x => x.Gameworld).Returns(_gameworld.Object);
+
+        Mock<IArenaEvent> arenaEvent = new();
+        arenaEvent.SetupGet(x => x.Id).Returns(21);
+        arenaEvent.SetupGet(x => x.Name).Returns("Cached Event");
+        arenaEvent.SetupGet(x => x.Participants).Returns(Array.Empty<IArenaParticipant>());
+
+        ArenaParticipationEffect effect = new(cachedParticipant.Object, arenaEvent.Object);
+        cachedParticipant.Setup(x => x.CombinedEffectsOfType<ArenaParticipationEffect>())
+                .Returns(new[] { effect });
+        All<ICharacter> actors = new();
+        All<ICharacter> cachedActors = new();
+        cachedActors.Add(cachedParticipant.Object);
+        _gameworld.SetupGet(x => x.Actors).Returns(actors);
+        _gameworld.SetupGet(x => x.CachedActors).Returns(cachedActors);
+
+        _service.ClearParticipation(arenaEvent.Object);
+
+        cachedParticipant.Verify(x => x.RemoveEffect(effect, true), Times.Once);
+    }
+
+    [TestMethod]
     public void HasParticipation_ReturnsTrueWhenEffectPresent()
     {
         Mock<ICharacter> participant = new();

--- a/MudSharpCore Unit Tests/Arenas/ArenaRatingsServiceTests.cs
+++ b/MudSharpCore Unit Tests/Arenas/ArenaRatingsServiceTests.cs
@@ -100,6 +100,29 @@ public class ArenaRatingsServiceTests
     }
 
     [TestMethod]
+    public void ApplyDefaultElo_WinWithoutWinningSides_DoesNotUpdateRatings()
+    {
+        using FuturemudDatabaseContext context = BuildContext();
+        ArenaRatingsService service = CreateService(context);
+        Mock<ICombatArena> arena = new();
+        arena.SetupGet(x => x.Id).Returns(6L);
+
+        (Mock<IArenaParticipant> Participant, Mock<ICharacter> Character, Mock<ICombatantClass> CombatantClass) participantA = BuildParticipant(31L, 301L, 0, 1500.0m);
+        (Mock<IArenaParticipant> Participant, Mock<ICharacter> Character, Mock<ICombatantClass> CombatantClass) participantB = BuildParticipant(41L, 401L, 1, 1500.0m);
+
+        Mock<IArenaEvent> evt = new();
+        evt.SetupGet(x => x.Arena).Returns(arena.Object);
+        evt.SetupGet(x => x.Participants)
+           .Returns(new[] { participantA.Participant.Object, participantB.Participant.Object });
+        evt.SetupGet(x => x.Outcome).Returns(ArenaOutcome.Win);
+        evt.SetupGet(x => x.WinningSides).Returns(Array.Empty<int>());
+
+        service.ApplyDefaultElo(evt.Object);
+
+        Assert.AreEqual(0, context.ArenaRatings.Count());
+    }
+
+    [TestMethod]
     public void ApplyDefaultElo_UsesCharacterIds_WhenCharactersAreNotLoaded()
     {
         using FuturemudDatabaseContext context = BuildContext();
@@ -150,6 +173,34 @@ public class ArenaRatingsServiceTests
         Dictionary<long, decimal> ratings = context.ArenaRatings.ToDictionary(x => x.CharacterId, x => x.Rating);
         Assert.AreEqual(1508.00m, ratings[70L]);
         Assert.AreEqual(1492.00m, ratings[80L]);
+    }
+
+    [TestMethod]
+    public void ApplyDefaultElo_ExtremeKFactorAndRatings_ClampsResults()
+    {
+        using FuturemudDatabaseContext context = BuildContext();
+        ArenaRatingsService service = CreateService(context);
+        Mock<ICombatArena> arena = new();
+        arena.SetupGet(x => x.Id).Returns(13L);
+        Mock<IArenaEventType> eventType = new();
+        eventType.SetupGet(x => x.EloStyle).Returns(ArenaEloStyle.TeamAverage);
+        eventType.SetupGet(x => x.EloKFactor).Returns(decimal.MaxValue);
+
+        (Mock<IArenaParticipant> Participant, Mock<ICharacter> Character, Mock<ICombatantClass> CombatantClass) winner = BuildParticipant(90L, 900L, 0, decimal.MaxValue);
+        (Mock<IArenaParticipant> Participant, Mock<ICharacter> Character, Mock<ICombatantClass> CombatantClass) loser = BuildParticipant(91L, 901L, 1, decimal.MinValue);
+
+        Mock<IArenaEvent> evt = new();
+        evt.SetupGet(x => x.Arena).Returns(arena.Object);
+        evt.SetupGet(x => x.EventType).Returns(eventType.Object);
+        evt.SetupGet(x => x.Participants).Returns(new[] { winner.Participant.Object, loser.Participant.Object });
+        evt.SetupGet(x => x.Outcome).Returns(ArenaOutcome.Win);
+        evt.SetupGet(x => x.WinningSides).Returns([0]);
+
+        service.ApplyDefaultElo(evt.Object);
+
+        Dictionary<long, decimal> ratings = context.ArenaRatings.ToDictionary(x => x.CharacterId, x => x.Rating);
+        Assert.AreEqual(ArenaRatingLimits.MaximumRating, ratings[90L]);
+        Assert.AreEqual(ArenaRatingLimits.MinimumRating, ratings[91L]);
     }
 
     [TestMethod]

--- a/MudSharpCore Unit Tests/Arenas/ArenaSchedulerTests.cs
+++ b/MudSharpCore Unit Tests/Arenas/ArenaSchedulerTests.cs
@@ -200,6 +200,21 @@ public class ArenaSchedulerTests
         _scheduler.Verify(x => x.AddSchedule(It.IsAny<ISchedule>()), Times.Never);
     }
 
+    [TestMethod]
+    public void SyncRecurringSchedule_OverlargeInterval_DoesNotAddSchedule()
+    {
+        Mock<IArenaEventType> eventType = BuildEventType();
+        eventType.SetupGet(x => x.Id).Returns(42L);
+        eventType.SetupGet(x => x.AutoScheduleEnabled).Returns(true);
+        eventType.SetupGet(x => x.AutoScheduleInterval).Returns(TimeSpan.MaxValue);
+        eventType.SetupGet(x => x.AutoScheduleReferenceTime).Returns(new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        _service.SyncRecurringSchedule(eventType.Object);
+
+        _scheduler.Verify(x => x.Destroy(eventType.Object, ScheduleType.ArenaRecurringEvent), Times.Once);
+        _scheduler.Verify(x => x.AddSchedule(It.IsAny<ISchedule>()), Times.Never);
+    }
+
     private static Mock<IArenaEventType> BuildEventType()
     {
         Mock<IArenaEventType> eventType = new();

--- a/MudSharpCore Unit Tests/RandomNameProfileTests.cs
+++ b/MudSharpCore Unit Tests/RandomNameProfileTests.cs
@@ -1,0 +1,52 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Character.Name;
+using MudSharp.Form.Shape;
+using MudSharp.Framework;
+using MudSharp.FutureProg;
+using System;
+using System.Collections.Generic;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class RandomNameProfileTests
+{
+	[TestMethod]
+	public void GetRandomPersonalName_WhenDiceRequestsMoreUniqueNamesThanAvailable_ReturnsWithoutHanging()
+	{
+		Mock<IFuturemud> gameworld = new();
+		Mock<IUneditableAll<IFutureProg>> futureProgs = new();
+		futureProgs.Setup(x => x.Get(It.IsAny<long>())).Returns((IFutureProg?)null);
+		gameworld.SetupGet(x => x.FutureProgs).Returns(futureProgs.Object);
+		gameworld.SetupGet(x => x.AlwaysFalseProg).Returns(new Mock<IFutureProg>().Object);
+		Mock<INameCulture> culture = new();
+		culture.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		culture.Setup(x => x.NamePattern(It.IsAny<NameStyle>()))
+			.Returns(Tuple.Create("{0}", new List<NameUsage> { NameUsage.BirthName }));
+		MudSharp.Models.RandomNameProfile model = new()
+		{
+			Id = 1,
+			Name = "Arena Stage Names",
+			Gender = (int)Gender.Indeterminate
+		};
+		model.RandomNameProfilesDiceExpressions.Add(new MudSharp.Models.RandomNameProfilesDiceExpressions
+		{
+			NameUsage = (int)NameUsage.BirthName,
+			DiceExpression = "2"
+		});
+		model.RandomNameProfilesElements.Add(new MudSharp.Models.RandomNameProfilesElements
+		{
+			NameUsage = (int)NameUsage.BirthName,
+			Name = "alex",
+			Weighting = 100
+		});
+		RandomNameProfile profile = new(model, culture.Object);
+
+		IPersonalName personalName = profile.GetRandomPersonalName(nonSaving: true);
+
+		Assert.AreEqual("Alex", personalName.GetName(NameStyle.SimpleFull));
+	}
+}

--- a/MudSharpCore/Arenas/Betting/ArenaBettingService.cs
+++ b/MudSharpCore/Arenas/Betting/ArenaBettingService.cs
@@ -18,6 +18,8 @@ namespace MudSharp.Arenas;
 /// </summary>
 public class ArenaBettingService : IArenaBettingService
 {
+    public const int MaximumBetHistoryCount = 100;
+
     private readonly IFuturemud _gameworld;
     private readonly IArenaFinanceService _financeService;
     private readonly IArenaBetPaymentService _paymentService;
@@ -55,7 +57,7 @@ public class ArenaBettingService : IArenaBettingService
                 return (false, "Betting is closed for this event.");
         }
 
-        if (arenaEvent.Participants.Any(x => x.Character == actor))
+        if (arenaEvent.Participants.Any(x => x.CharacterId == actor.Id))
         {
             return (false, "Participants cannot bet on their own bout.");
         }
@@ -241,7 +243,7 @@ public class ArenaBettingService : IArenaBettingService
                 continue;
             }
 
-            decimal payout = CalculatePayout(arenaEvent, bet, pools);
+            decimal payout = CalculatePayout(arenaEvent, bet, pools, outcome, winningSet);
             if (payout <= 0)
             {
                 continue;
@@ -430,6 +432,7 @@ public class ArenaBettingService : IArenaBettingService
             return Array.Empty<ArenaBetSummary>();
         }
 
+        count = Math.Min(count, MaximumBetHistoryCount);
         using IDisposable? scope = BeginContext(out FuturemudDatabaseContext? context);
         Dictionary<long, PayoutTotals> payoutTotals = GetPayoutTotals(context, actor.Id);
         var bets = context.ArenaBets
@@ -611,7 +614,8 @@ public class ArenaBettingService : IArenaBettingService
         };
     }
 
-    private decimal CalculatePayout(IArenaEvent arenaEvent, ArenaBet bet, IReadOnlyCollection<ArenaBetPool> pools)
+    private decimal CalculatePayout(IArenaEvent arenaEvent, ArenaBet bet, IReadOnlyCollection<ArenaBetPool> pools,
+        ArenaOutcome outcome, IReadOnlySet<int> winningSides)
     {
         switch (arenaEvent.EventType.BettingModel)
         {
@@ -632,14 +636,32 @@ public class ArenaBettingService : IArenaBettingService
                 }
 
                 // Winners always get at least their original stake back.
-                decimal losingPool = Math.Max(0.0m, totalPool - pool.TotalStake);
-                decimal share = bet.Stake / pool.TotalStake;
+                decimal winningPoolTotal = pools
+                    .Where(x => IsWinningPool(x, outcome, winningSides))
+                    .Sum(x => x.TotalStake);
+                if (winningPoolTotal <= 0.0m)
+                {
+                    return bet.Stake;
+                }
+
+                decimal losingPool = Math.Max(0.0m, totalPool - winningPoolTotal);
+                decimal share = bet.Stake / winningPoolTotal;
                 decimal takeRate = Clamp(pool.TakeRate, 0.0m, 1.0m);
                 decimal distributableLosingPool = losingPool * (1.0m - takeRate);
                 return bet.Stake + share * distributableLosingPool;
             default:
                 return 0.0m;
         }
+    }
+
+    private static bool IsWinningPool(ArenaBetPool pool, ArenaOutcome outcome, IReadOnlySet<int> winningSides)
+    {
+        return outcome switch
+        {
+            ArenaOutcome.Win => pool.SideIndex.HasValue && winningSides.Contains(pool.SideIndex.Value),
+            ArenaOutcome.Draw => !pool.SideIndex.HasValue,
+            _ => false
+        };
     }
 
     private decimal ComputeFixedOdds(IArenaEvent arenaEvent, int? sideIndex)
@@ -700,12 +722,12 @@ public class ArenaBettingService : IArenaBettingService
     {
         if (participant.StartingRating.HasValue)
         {
-            return participant.StartingRating.Value;
+            return ArenaRatingLimits.ClampRating(participant.StartingRating.Value);
         }
 
         return participant.Character is null
             ? null
-            : _gameworld.ArenaRatingsService.GetRating(participant.Character, participant.CombatantClass);
+            : ArenaRatingLimits.ClampRating(_gameworld.ArenaRatingsService.GetRating(participant.Character, participant.CombatantClass));
     }
 
     private static IReadOnlyDictionary<int, decimal> ComputeSideWinProbabilities(
@@ -716,11 +738,16 @@ public class ArenaBettingService : IArenaBettingService
             return new Dictionary<int, decimal>();
         }
 
+        decimal maxRating = sideRatings.Values.Max();
         Dictionary<int, double> strengths = sideRatings.ToDictionary(
             x => x.Key,
-            x => Math.Pow(10.0, (double)(x.Value / 400.0m)));
+            x =>
+            {
+                double strength = Math.Pow(10.0, (double)((x.Value - maxRating) / 400.0m));
+                return double.IsFinite(strength) && strength > 0.0 ? strength : 0.0;
+            });
         double totalStrength = strengths.Sum(x => x.Value);
-        if (totalStrength <= 0.0)
+        if (!double.IsFinite(totalStrength) || totalStrength <= 0.0)
         {
             decimal equalShare = 1.0m / sideRatings.Count;
             return sideRatings.Keys.ToDictionary(x => x, _ => equalShare);

--- a/MudSharpCore/Arenas/Core/ArenaEvent.cs
+++ b/MudSharpCore/Arenas/Core/ArenaEvent.cs
@@ -29,6 +29,8 @@ namespace MudSharp.Arenas;
 
 public sealed class ArenaEvent : SaveableItem, IArenaEvent
 {
+	private const int MaximumScoringSnapshots = 512;
+
 	private readonly List<ArenaParticipant> _participants = new();
 	private readonly List<ArenaReservation> _reservations = new();
 	private readonly List<ArenaScoringSnapshot> _scoringSnapshots = new();
@@ -388,13 +390,18 @@ public sealed class ArenaEvent : SaveableItem, IArenaEvent
             return (false, "Surrender is not permitted for this event.");
         }
 
-        if (_participants.All(x => x.Character?.Id != participant.Id))
-        {
-            return (false, "You are not a participant in this event.");
-        }
+		if (_participants.All(x => x.CharacterId != participant.Id))
+		{
+			return (false, "You are not a participant in this event.");
+		}
 
-        if (_surrenderedParticipantIds.Contains(participant.Id))
-        {
+		if (!IsArenaBoutCombat(participant))
+		{
+			return (false, "You can only surrender while you are fighting in this arena bout.");
+		}
+
+		if (_surrenderedParticipantIds.Contains(participant.Id))
+		{
             return (false, "You have already surrendered this bout.");
         }
 
@@ -533,6 +540,11 @@ public sealed class ArenaEvent : SaveableItem, IArenaEvent
         {
             return (false, "You are already signed up for this event.");
         }
+
+		if (!ignoreNpcRestriction && character.IsPlayerCharacter && !IsAtArenaVenue(character))
+		{
+			return (false, "You must be at the arena to sign up for that event.");
+		}
 
         if (_participants.Count(x => x.SideIndex == sideIndex) >= side.Capacity)
         {
@@ -691,6 +703,10 @@ public sealed class ArenaEvent : SaveableItem, IArenaEvent
 		}
 
 		_scoringSnapshots.Add(snapshot);
+		if (_scoringSnapshots.Count > MaximumScoringSnapshots)
+		{
+			_scoringSnapshots.RemoveRange(0, _scoringSnapshots.Count - MaximumScoringSnapshots);
+		}
 	}
 
 	internal bool TryGetParticipantSideIndex(ICharacter character, out int sideIndex)
@@ -1497,8 +1513,44 @@ public sealed class ArenaEvent : SaveableItem, IArenaEvent
         RestorePlayerParticipants();
         ClearParticipantPhaseEffects();
         ClearObservationEffects();
+        _scoringSnapshots.Clear();
         _surrenderedParticipantIds.Clear();
     }
+
+	private bool IsArenaBoutCombat(ICharacter participant)
+	{
+		if (participant.Combat is null)
+		{
+			return false;
+		}
+
+		if (!Arena.ArenaCells.Contains(participant.Location))
+		{
+			return false;
+		}
+
+		HashSet<long> participantIds = _participants.Select(x => x.CharacterId).ToHashSet();
+		List<ICharacter> combatants = participant.Combat.Combatants.OfType<ICharacter>().ToList();
+		return combatants.Any(x => x.Id == participant.Id) &&
+		       combatants.Any(x => x.Id != participant.Id) &&
+		       combatants.All(x => participantIds.Contains(x.Id));
+	}
+
+	private bool IsAtArenaVenue(ICharacter character)
+	{
+		ICell? location = character.Location;
+		if (location is null)
+		{
+			return false;
+		}
+
+		return Arena.WaitingCells.Contains(location) ||
+		       Arena.ArenaCells.Contains(location) ||
+		       Arena.ObservationCells.Contains(location) ||
+		       Arena.InfirmaryCells.Contains(location) ||
+		       Arena.AfterFightCells.Contains(location) ||
+		       Arena.NpcStablesCells.Contains(location);
+	}
 
     private void DisengageParticipantCombats()
     {

--- a/MudSharpCore/Arenas/Core/ArenaEventType.cs
+++ b/MudSharpCore/Arenas/Core/ArenaEventType.cs
@@ -50,7 +50,7 @@ public sealed class ArenaEventType : SaveableItem, IArenaEventType
         EloStyle = Enum.IsDefined(typeof(ArenaEloStyle), model.EloStyle)
             ? (ArenaEloStyle)model.EloStyle
             : ArenaEloStyle.TeamAverage;
-        EloKFactor = model.EloKFactor > 0.0m ? model.EloKFactor : DefaultEloKFactor;
+        EloKFactor = model.EloKFactor > 0.0m ? ArenaRatingLimits.ClampKFactor(model.EloKFactor) : DefaultEloKFactor;
         EliminationMode = Enum.IsDefined(typeof(ArenaEliminationMode), model.EliminationMode)
             ? (ArenaEliminationMode)model.EliminationMode
             : ArenaEliminationMode.NoElimination;
@@ -363,6 +363,14 @@ public sealed class ArenaEventType : SaveableItem, IArenaEventType
             return false;
         }
 
+        if (interval > ArenaScheduler.MaximumRecurringInterval)
+        {
+            actor.OutputHandler.Send(
+                $"The interval cannot be longer than {ArenaScheduler.MaximumRecurringInterval.Describe(actor).ColourValue()}."
+                    .ColourError());
+            return false;
+        }
+
         if (!command.IsFinished && command.PeekSpeech().EqualToAny("from", "at", "start", "starting"))
         {
             command.PopSpeech();
@@ -596,6 +604,13 @@ public sealed class ArenaEventType : SaveableItem, IArenaEventType
             return false;
         }
 
+        if (value > ArenaRatingLimits.MaximumEloKFactor)
+        {
+            actor.OutputHandler.Send(
+                $"The Elo K-factor cannot be greater than {ArenaRatingLimits.MaximumEloKFactor.ToString("N2", actor).ColourValue()}.");
+            return false;
+        }
+
         EloKFactor = value;
         Changed = true;
         actor.OutputHandler.Send($"Elo K-factor is now {EloKFactor.ToString("N2", actor).ColourValue()}.");
@@ -737,7 +752,10 @@ public sealed class ArenaEventType : SaveableItem, IArenaEventType
 
     public void ConfigureAutoSchedule(TimeSpan? interval, DateTime? referenceTime)
     {
-        bool isEnabled = interval.HasValue && interval.Value > TimeSpan.Zero && referenceTime.HasValue;
+        bool isEnabled = interval.HasValue &&
+                         interval.Value > TimeSpan.Zero &&
+                         interval.Value <= ArenaScheduler.MaximumRecurringInterval &&
+                         referenceTime.HasValue;
         AutoScheduleInterval = isEnabled ? interval : null;
         AutoScheduleReferenceTime = isEnabled ? referenceTime : null;
         Changed = true;

--- a/MudSharpCore/Arenas/Lifecycle/ArenaScheduler.cs
+++ b/MudSharpCore/Arenas/Lifecycle/ArenaScheduler.cs
@@ -12,6 +12,8 @@ namespace MudSharp.Arenas;
 /// </summary>
 public class ArenaScheduler : IArenaScheduler
 {
+    public static readonly TimeSpan MaximumRecurringInterval = TimeSpan.FromSeconds(int.MaxValue);
+
     private static readonly TimeSpan ResolvingGracePeriod = TimeSpan.FromSeconds(2);
     private static readonly TimeSpan CleanupGracePeriod = TimeSpan.FromSeconds(1);
     private static readonly TimeSpan LivePollingInterval = TimeSpan.FromSeconds(2);
@@ -284,6 +286,7 @@ public class ArenaScheduler : IArenaScheduler
         return eventType.AutoScheduleEnabled &&
                eventType.AutoScheduleInterval.HasValue &&
                eventType.AutoScheduleInterval.Value > TimeSpan.Zero &&
+               eventType.AutoScheduleInterval.Value <= MaximumRecurringInterval &&
                eventType.AutoScheduleReferenceTime.HasValue;
     }
 
@@ -304,13 +307,18 @@ public class ArenaScheduler : IArenaScheduler
         }
 
         long cycles = elapsedTicks / intervalTicks;
-        DateTime next = reference.AddTicks(cycles * intervalTicks);
-        if (next < now)
+        long nextTicks = reference.Ticks + cycles * intervalTicks;
+        if (nextTicks < now.Ticks)
         {
-            next = next.AddTicks(intervalTicks);
+            if (DateTime.MaxValue.Ticks - nextTicks < intervalTicks)
+            {
+                return DateTime.MaxValue;
+            }
+
+            nextTicks += intervalTicks;
         }
 
-        return next;
+        return new DateTime(nextTicks, reference.Kind);
     }
 
     private static bool IsEventFull(IArenaEvent arenaEvent)

--- a/MudSharpCore/Arenas/Participation/ArenaParticipationService.cs
+++ b/MudSharpCore/Arenas/Participation/ArenaParticipationService.cs
@@ -97,7 +97,12 @@ public class ArenaParticipationService : IArenaParticipationService
             throw new ArgumentNullException(nameof(arenaEvent));
         }
 
-        List<ICharacter> affectedParticipants = _gameworld.Actors
+        List<ICharacter> affectedParticipants = arenaEvent.Participants
+            .Select(x => x.Character)
+            .OfType<ICharacter>()
+            .Concat(_gameworld.Actors)
+            .Concat(_gameworld.CachedActors)
+            .DistinctBy(x => x.Id)
             .Where(x => x.CombinedEffectsOfType<ArenaParticipationEffect>()
                 .Any(effect => effect.Matches(arenaEvent)))
             .ToList();

--- a/MudSharpCore/Arenas/Ratings/ArenaEloStrategies.cs
+++ b/MudSharpCore/Arenas/Ratings/ArenaEloStrategies.cs
@@ -227,9 +227,7 @@ internal static class ArenaEloMath
     {
         return outcome switch
         {
-            ArenaOutcome.Win => winningSides.Count == 0
-                ? (totalSides == 2 ? 1.0m : 0.0m)
-                : (winningSides.Contains(sideIndex) ? 1.0m : 0.0m),
+            ArenaOutcome.Win => winningSides.Contains(sideIndex) ? 1.0m : 0.0m,
             ArenaOutcome.Draw => 0.5m,
             _ => 0.0m
         };

--- a/MudSharpCore/Arenas/Ratings/ArenaRatingLimits.cs
+++ b/MudSharpCore/Arenas/Ratings/ArenaRatingLimits.cs
@@ -1,0 +1,46 @@
+#nullable enable
+
+namespace MudSharp.Arenas;
+
+internal static class ArenaRatingLimits
+{
+	internal const decimal MinimumRating = 0.0m;
+	internal const decimal MaximumRating = 10000.0m;
+	internal const decimal MaximumEloKFactor = 200.0m;
+
+	internal static decimal ClampRating(decimal rating)
+	{
+		if (rating < MinimumRating)
+		{
+			return MinimumRating;
+		}
+
+		return rating > MaximumRating ? MaximumRating : rating;
+	}
+
+	internal static decimal ClampKFactor(decimal kFactor)
+	{
+		if (kFactor <= 0.0m)
+		{
+			return 32.0m;
+		}
+
+		return kFactor > MaximumEloKFactor ? MaximumEloKFactor : kFactor;
+	}
+
+	internal static decimal AddAndClampRating(decimal rating, decimal delta)
+	{
+		decimal current = ClampRating(rating);
+		if (delta >= 0.0m && delta > MaximumRating - current)
+		{
+			return MaximumRating;
+		}
+
+		if (delta < 0.0m && delta < MinimumRating - current)
+		{
+			return MinimumRating;
+		}
+
+		return ClampRating(current + delta);
+	}
+}

--- a/MudSharpCore/Arenas/Ratings/ArenaRatingsService.cs
+++ b/MudSharpCore/Arenas/Ratings/ArenaRatingsService.cs
@@ -69,7 +69,7 @@ public class ArenaRatingsService : IArenaRatingsService
                 x.Character.Name ?? $"Character #{x.CharacterId}",
                 x.CombatantClassId,
                 x.CombatantClass.Name ?? $"Class #{x.CombatantClassId}",
-                x.Rating,
+                ArenaRatingLimits.ClampRating(x.Rating),
                 x.LastUpdatedAt))
             .ToList();
     }
@@ -98,7 +98,7 @@ public class ArenaRatingsService : IArenaRatingsService
                 x.Character.Name ?? $"Character #{x.CharacterId}",
                 x.CombatantClassId,
                 x.CombatantClass.Name ?? $"Class #{x.CombatantClassId}",
-                x.Rating,
+                ArenaRatingLimits.ClampRating(x.Rating),
                 x.LastUpdatedAt))
             .ToList();
     }
@@ -108,7 +108,7 @@ public class ArenaRatingsService : IArenaRatingsService
         using IDisposable? scope = BeginContext(out FuturemudDatabaseContext? context);
         ArenaRating? rating = context.ArenaRatings.FirstOrDefault(x => x.CharacterId == characterId &&
                                                        x.CombatantClassId == combatantClass.Id);
-        return rating?.Rating ?? DefaultRating;
+        return rating is null ? DefaultRating : ArenaRatingLimits.ClampRating(rating.Rating);
     }
 
     /// <inheritdoc />
@@ -176,7 +176,7 @@ public class ArenaRatingsService : IArenaRatingsService
                 context.ArenaRatings.Add(rating);
             }
 
-            rating.Rating = Math.Round(rating.Rating + delta, 2, MidpointRounding.AwayFromZero);
+            rating.Rating = Math.Round(ArenaRatingLimits.AddAndClampRating(rating.Rating, delta), 2, MidpointRounding.AwayFromZero);
             rating.LastUpdatedAt = now;
         }
 
@@ -209,10 +209,15 @@ public class ArenaRatingsService : IArenaRatingsService
             return;
         }
         HashSet<int> winningSet = winningSides?.ToHashSet() ?? new HashSet<int>();
+        if (outcome == ArenaOutcome.Win && winningSet.Count == 0)
+        {
+            return;
+        }
+
         IArenaEventType? eventType = arenaEvent.EventType;
         ArenaEloStyle style = eventType?.EloStyle ?? ArenaEloStyle.TeamAverage;
         decimal kFactor = eventType is { EloKFactor: > 0.0m }
-            ? eventType.EloKFactor
+            ? ArenaRatingLimits.ClampKFactor(eventType.EloKFactor)
             : DefaultKFactor;
         IArenaEloStrategy strategy = _eloStrategies.TryGetValue(style, out IArenaEloStrategy? selectedStrategy)
             ? selectedStrategy
@@ -242,7 +247,10 @@ public class ArenaRatingsService : IArenaRatingsService
                     characterId = x.Character?.Id ?? 0L;
                 }
 
-                return new ArenaRatingParticipant(characterId, x.SideIndex, x.CombatantClass, x.StartingRating);
+                decimal? startingRating = x.StartingRating.HasValue
+                    ? ArenaRatingLimits.ClampRating(x.StartingRating.Value)
+                    : null;
+                return new ArenaRatingParticipant(characterId, x.SideIndex, x.CombatantClass, startingRating);
             })
             .Where(x => x.CharacterId > 0)
             .ToList();

--- a/MudSharpCore/Character/Name/RandomNameProfile.cs
+++ b/MudSharpCore/Character/Name/RandomNameProfile.cs
@@ -188,22 +188,20 @@ public class RandomNameProfile : SaveableItem, IEditableItem, IRandomNameProfile
             }
 
             int number = Dice.Roll(element.Value);
-            for (int i = 0; i < number; i++)
+            List<(string Value, int Weight)> availableNames = _randomNamesDictionary[element.Key]
+                .Where(x => !allResults.Contains(x.Value))
+                .ToList();
+            for (int i = 0; i < number && availableNames.Any(); i++)
             {
-                string result = _randomNamesDictionary[element.Key].GetWeightedRandom();
+                string result = availableNames.GetWeightedRandom(x => x.Weight).Value;
                 if (result == null)
                 {
                     break;
                 }
 
-                if (allResults.Contains(result))
-                {
-                    i--;
-                    continue;
-                }
-
                 resultsDictionary[element.Key].Add(result);
                 allResults.Add(result);
+                availableNames.RemoveAll(x => x.Value == result);
             }
         }
 

--- a/MudSharpCore/Commands/Modules/ArenaModule.cs
+++ b/MudSharpCore/Commands/Modules/ArenaModule.cs
@@ -499,6 +499,14 @@ Use #3arena tasks actions#0 and #3arena tasks conditions#0 for the full task act
             return;
         }
 
+        if (interval > ArenaScheduler.MaximumRecurringInterval)
+        {
+            actor.OutputHandler.Send(
+                $"The interval cannot be longer than {ArenaScheduler.MaximumRecurringInterval.Describe(actor).ColourValue()}."
+                    .ColourError());
+            return;
+        }
+
         if (!ss.IsFinished && ss.PeekSpeech().EqualToAny("from", "at", "start", "starting"))
         {
             ss.PopSpeech();
@@ -813,15 +821,19 @@ Use #3arena tasks actions#0 and #3arena tasks conditions#0 for the full task act
             return;
         }
 
-        ICharacter? target = ResolveCharacter(actor, characterText);
+        ArenaRatingLookupTarget? target = ResolveArenaRatingLookupTarget(actor, arena, characterText);
         if (target is null)
         {
             actor.OutputHandler.Send("There is no character matching that description.".ColourError());
             return;
         }
 
-        Dictionary<long, ArenaRatingSummary> summaries = actor.Gameworld.ArenaRatingsService.GetCharacterRatings(arena, target)
-            .ToDictionary(x => x.CombatantClassId, x => x);
+        Dictionary<long, ArenaRatingSummary> summaries = target.Character is not null
+            ? actor.Gameworld.ArenaRatingsService.GetCharacterRatings(arena, target.Character)
+                .ToDictionary(x => x.CombatantClassId, x => x)
+            : actor.Gameworld.ArenaRatingsService.GetArenaRatings(arena)
+                .Where(x => x.CharacterId == target.CharacterId)
+                .ToDictionary(x => x.CombatantClassId, x => x);
         List<string[]> rows = arena.CombatantClasses
             .OrderBy(x => x.Name)
             .Select(combatantClass =>
@@ -836,24 +848,30 @@ Use #3arena tasks actions#0 and #3arena tasks conditions#0 for the full task act
                     };
                 }
 
+                if (target.Character is null)
+                {
+                    return null;
+                }
+
                 return new[]
                 {
                     combatantClass.Name.ColourName(),
-                    actor.Gameworld.ArenaRatingsService.GetRating(target, combatantClass).ToString("N2", actor)
+                    actor.Gameworld.ArenaRatingsService.GetRating(target.Character, combatantClass).ToString("N2", actor)
                         .ColourValue(),
                     "Never".ColourValue()
                 };
             })
+            .OfType<string[]>()
             .ToList();
 
         if (!rows.Any())
         {
-            actor.OutputHandler.Send("That arena has no combatant classes to report ratings for.".ColourError());
+            actor.OutputHandler.Send("That character has no ratings in this arena.".ColourError());
             return;
         }
 
         actor.OutputHandler.Send(
-            $"Ratings for {target.HowSeen(actor, flags: PerceiveIgnoreFlags.TrueDescription).ColourName()} in {arena.Name.ColourName()}:\n" +
+            $"Ratings for {target.DisplayName.ColourName()} in {arena.Name.ColourName()}:\n" +
             StringUtilities.GetTextTable(rows, new[] { "Class", "Rating", "Updated" }, actor, Telnet.Green));
     }
 
@@ -1729,6 +1747,14 @@ Use #3arena tasks actions#0 and #3arena tasks conditions#0 for the full task act
                 actor.OutputHandler.Send("You must specify a positive number of wagers to show.".ColourError());
                 return;
             }
+
+            if (count > ArenaBettingService.MaximumBetHistoryCount)
+            {
+                actor.OutputHandler.Send(
+                    $"You can show at most {ArenaBettingService.MaximumBetHistoryCount.ToString("N0", actor).ColourValue()} wagers at once."
+                        .ColourError());
+                return;
+            }
         }
 
         List<ArenaBetSummary> bets = actor.Gameworld.ArenaBettingService.GetBetHistory(actor, count).ToList();
@@ -1912,7 +1938,9 @@ Use #3arena tasks actions#0 and #3arena tasks conditions#0 for the full task act
         return explicitArena;
     }
 
-    private static ICharacter? ResolveCharacter(ICharacter actor, string text)
+    private sealed record ArenaRatingLookupTarget(long CharacterId, string DisplayName, ICharacter? Character);
+
+    private static ArenaRatingLookupTarget? ResolveArenaRatingLookupTarget(ICharacter actor, ICombatArena arena, string text)
     {
         if (string.IsNullOrWhiteSpace(text))
         {
@@ -1922,15 +1950,27 @@ Use #3arena tasks actions#0 and #3arena tasks conditions#0 for the full task act
         ICharacter? localMatch = actor.TargetActor(text);
         if (localMatch is not null)
         {
-            return localMatch;
+            return new ArenaRatingLookupTarget(
+                localMatch.Id,
+                localMatch.HowSeen(actor, flags: PerceiveIgnoreFlags.IgnoreSelf),
+                localMatch);
         }
 
+        List<ArenaRatingSummary> arenaRatings = actor.Gameworld.ArenaRatingsService.GetArenaRatings(arena).ToList();
         if (long.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out long id))
         {
-            return actor.Gameworld.TryGetCharacter(id, true);
+            ArenaRatingSummary? rating = arenaRatings.FirstOrDefault(x => x.CharacterId == id);
+            return rating is null
+                ? null
+                : new ArenaRatingLookupTarget(rating.CharacterId, rating.CharacterName, null);
         }
 
-        return actor.Gameworld.Characters.GetByIdOrName(text);
+        List<ArenaRatingLookupTarget> matches = arenaRatings
+            .Where(x => x.CharacterName.EqualTo(text))
+            .GroupBy(x => x.CharacterId)
+            .Select(x => new ArenaRatingLookupTarget(x.Key, x.First().CharacterName, null))
+            .ToList();
+        return matches.Count == 1 ? matches[0] : null;
     }
 
     private static bool IsEligibleForCombatantClass(ICharacter character, ICombatantClass combatantClass)
@@ -2141,6 +2181,7 @@ Use #3arena tasks actions#0 and #3arena tasks conditions#0 for the full task act
         return eventType.AutoScheduleEnabled &&
                eventType.AutoScheduleInterval.HasValue &&
                eventType.AutoScheduleInterval.Value > TimeSpan.Zero &&
+               eventType.AutoScheduleInterval.Value <= ArenaScheduler.MaximumRecurringInterval &&
                eventType.AutoScheduleReferenceTime.HasValue;
     }
 
@@ -2161,13 +2202,18 @@ Use #3arena tasks actions#0 and #3arena tasks conditions#0 for the full task act
         }
 
         long cycles = elapsedTicks / intervalTicks;
-        DateTime next = reference.AddTicks(cycles * intervalTicks);
-        if (next < now)
+        long nextTicks = reference.Ticks + cycles * intervalTicks;
+        if (nextTicks < now.Ticks)
         {
-            next = next.AddTicks(intervalTicks);
+            if (DateTime.MaxValue.Ticks - nextTicks < intervalTicks)
+            {
+                return DateTime.MaxValue;
+            }
+
+            nextTicks += intervalTicks;
         }
 
-        return next;
+        return new DateTime(nextTicks, reference.Kind);
     }
 
     private static bool TryParseSideSpecifier(string? text, out int? sideIndex)


### PR DESCRIPTION
## Summary
- Triage and remediate arena-related security findings in the `Arena, Betting & Competition` group.
- Harden signup, surrender, autoscheduling, scoring cleanup, rating settlement, bet history limits, and pari-mutuel payouts against malformed or extreme inputs.
- Add defensive clamps and shared invariants for arena ratings and scheduling, plus a bounded random-name selection path.
- Update arena design docs to reflect the new lifecycle and safety behavior.

## Testing
- Added and updated focused unit tests for arena betting, ratings, participation cleanup, scheduler overflow handling, scoring cleanup, random-name generation, and DST-invalid date parsing.
- Ran targeted `MudSharpCore` and `FutureMUDLibrary` test subsets, plus a `MudSharpCore` debug build and diff whitespace checks; all passed.