### PR TITLE
Add drug system design documentation

### DIFF
--- a/Design Documents/Drugs/Drug_Builder_Guide.md
+++ b/Design Documents/Drugs/Drug_Builder_Guide.md
@@ -1,0 +1,339 @@
+# FutureMUD Drug Builder Guide
+
+## Purpose
+This guide is for builders, seeder developers, and AI agents creating drug content in FutureMUD.
+
+Use [Drug System Design](./Drug_System_Design.md) when you need implementation details.
+
+## Mental Model
+A drug is the pharmacology. It says what the substance does, which delivery routes can work, how strong it is per gram, and how quickly it clears.
+
+A delivery wrapper is what gets the drug into a body. Pills, foods, liquids, gases, smokes, salves, syringes, venoms, weapon coatings, incense burners, and spells are all delivery wrappers.
+
+Build drug content in this order:
+
+1. Define the drug.
+2. Choose the legal vectors.
+3. Add effect families and any required payloads.
+4. Create one or more delivery wrappers.
+5. Test the actual route in-game or with a focused seeder/unit test.
+
+## Delivery Vectors
+| Vector | Use for | Common wrappers | Notes |
+| --- | --- | --- | --- |
+| `Ingested` | Pills, teas, draughts, tinctures, edible poison, medicated food, drinkable liquids | `Pill`, `PreparedFood`, drinkable `ILiquid`, feed/drink flows | Slowest absorption. Drinking applies only if the drug has this vector. |
+| `Injected` | Syringes, IV medication, venom fangs, poisoned weapon wounds, injected spells | `Syringe`, `IVBag`, `EnvenomingAttack`, weapon poison coating, spell poison | Fast absorption. Injected-liquid health strategies do not enforce the vector, so authoring discipline matters. |
+| `Inhaled` | Smoke, vapour, anesthetic gas, inhalers, incense/fumigation | `Smokeable`, `IncenseBurner`, inhaler gas canisters, gas materials | Fast absorption. Smokeable, incense, and inhaler runtime paths check this vector. |
+| `Touched` | Salves, poultices, contact poison, topical anesthetic | `TopicalCream`, contact weapon poison | Slow topical absorption. Ordinary wetness alone does not dose drugs. |
+
+## Creating A Drug
+Use the `drug` builder command.
+
+Typical flow:
+
+```text
+drug edit new Foxglove Tincture
+drug set intensity 50%
+drug set metabolism 6%
+drug set ingested
+drug set type intensity OrganFunction 25%
+drug set type organfunction Heart
+drug set type intensity Nausea 25%
+drug set type intensity VisionImpairment 10%
+drug show
+drug close
+```
+
+Useful commands:
+
+```text
+drug list
+drug list *Analgesic
+drug show <drug>
+drug edit <drug>
+drug edit new <name>
+drug clone <old> <new name>
+drug set name <name>
+drug set intensity <%>
+drug set metabolism <%>
+drug set injected
+drug set ingested
+drug set inhaled
+drug set touch
+drug set type intensity <DrugType> <%>
+```
+
+Set an effect intensity to `0%` or less to remove that effect type.
+
+## Effect Families
+| Effect | Builder use | Extra setup |
+| --- | --- | --- |
+| `Analgesic` | Pain relief | None |
+| `Anesthesia` | Sedation and broad check penalties | None |
+| `Antibiotic` | Resistance to ordinary, infectious, necrotic, and gangrene infections | None |
+| `Antifungal` | Resistance to fungal infections | None |
+| `Immunosuppressive` | Immune penalty | None |
+| `NeutraliseDrugEffect` | Antiemetics, antipyretics, broad antagonists by effect family | `drug set type neutralise <DrugType>` |
+| `NeutraliseSpecificDrug` | Overdose reversal or antidotes for named drugs | `drug set type neutralisespecific <drug>` |
+| `BodypartDamage` | Organ/tissue toxic damage | `drug set type damage <bodypart type>` |
+| `Pacifism` | Calm, euphoria, reduced violence drive | None |
+| `Rage` | Irritation through forced violence at high intensity | None |
+| `Adrenaline` | Heart racing, general activity penalties, heart support, heat/cardiac stress | None |
+| `StaminaRegen` | Immediate stamina gain per drug tick | None |
+| `Nausea` | Nausea, check penalties, vomiting at high effective intensity | None |
+| `HealingRate` | Healing speed and difficulty changes | `drug set type healingrate <rate%> <difficulty%>` |
+| `MagicAbility` | Temporary magic capabilities | `drug set type magic <capability>` |
+| `Paralysis` | Numbness and forced paralysis past threshold | None |
+| `OrganFunction` | Functional bonus or support to organ types | `drug set type organfunction <organ type>` |
+| `VisionImpairment` | Reduced vision multiplier | None |
+| `ThermalImbalance` | Heat/cold imbalance pressure through the shared temperature model | None |
+| `PlanarState` | Manifested or noncorporeal planar overlay | `drug set type planar <corporeal|noncorporeal> [plane] [visible]` |
+
+The required extra setup commands only work after you add a matching effect intensity.
+
+## Potency And Duration
+There are three separate knobs:
+
+- `drug set intensity <%>` controls whole-drug potency per gram.
+- `drug set type intensity <type> <%>` controls one effect family's share of that potency.
+- `drug set metabolism <%>` controls how fast active grams clear.
+
+Lower metabolism lasts longer. Higher metabolism clears faster.
+
+Most dose wrappers ask for grams. A drug with high intensity, high type intensity, and high grams will be strong. A drug with low metabolism will stay active longer.
+
+## Drug Liquids And Tinctures
+There is no separate tincture class. A tincture is usually an ingested drug delivered through a liquid.
+
+Recommended pattern:
+
+1. Create an ingested drug such as `Foxglove Tincture`.
+2. Create or clone a liquid for the tincture.
+3. Set taste, smell, water/alcohol values, and draught prog if needed.
+4. Set the drug and dose ratio on the liquid.
+5. Put the liquid into a bottle, vial, cup, syringe, IV bag, or craft output as appropriate.
+
+Typical material commands:
+
+```text
+liquid edit <liquid>
+liquid set drug Foxglove Tincture
+liquid set drugvolume 5%
+liquid set taste 2 bitter metallic
+liquid set smell 1 sharp herbal
+liquid set alcohol 0.20
+liquid show
+```
+
+`liquid set drugvolume` accepts a ratio-style percentage and displays the resulting payload as grams per litre.
+
+Important caveats:
+
+- Liquid authoring does not check the drug vector.
+- Drinking a liquid only doses drugs with `Ingested`.
+- Injecting a liquid through living health strategies doses the liquid drug as injected even if the drug definition does not advertise `Injected`.
+- Liquid injection consequences are separate from drug effects. Set them deliberately for syringe, IV, and venom liquids.
+
+For a drinkable medicine, make the drug `Ingested`. For an injectable medicine, make the drug `Injected` and set an appropriate liquid injection consequence. For something that can be both swallowed and injected, set both vectors and balance the dose carefully.
+
+## Drug Foods
+Prepared food can carry drug doses directly.
+
+Use direct food drug doses when the whole serving has a known payload, such as a medicated cake, poisoned ration, or bitter herbal bolus.
+
+Prepared food also absorbs liquids. If a food absorbs a drug liquid, compatible ingested drug payloads become food drug doses.
+
+Content guidance:
+
+- Use `PreparedFood` drug doses for designed edible medicines or poisons.
+- Use liquid absorption for emergent contamination or recipes involving soaking, steeping, glazing, or poisoning food with a liquid.
+- Use stale/spoiled drug doses for effects that should only appear after freshness changes.
+- Keep the dose per serving explicit. Eating a fraction of the serving applies the same fraction of the drug grams.
+
+## Pills And Capsules
+Use `Pill` for a one-use swallowed item. The item is deleted when swallowed.
+
+Prototype commands:
+
+```text
+comp edit new pill Pill_Opioid_Analgesic
+comp set drug Opioid Analgesic
+comp set dose 0.5g
+comp set prog clear
+```
+
+The chosen drug must support `Ingested`.
+
+Use pills for tablets, capsules, pellets, measured draught lumps, or any simple swallowed medicine where a fixed dose is enough.
+
+## Salves, Poultices, Ointments, And Creams
+Use `TopicalCream` for a topical item that is applied to a bodypart.
+
+Prototype commands:
+
+```text
+comp edit new topicalcream TopicalCream_Aloe_Burn_Salve
+comp set quantity 50g
+comp set drug add "Aloe Burn Salve" 0.1 0.75
+comp set prog clear
+```
+
+The drug must support `Touched`.
+
+The `drug add` numbers are:
+
+- grams of drug per gram of cream
+- absorption fraction from `0` to `1`
+
+Runtime dose is:
+
+`amount applied * grams per gram * absorption fraction`
+
+Topical application requires access to the target bodypart. Blocking worn items can prevent application.
+
+## Smokeables
+Use `Smokeable` for a held item that must be lit and smoked by the user.
+
+Prototype commands:
+
+```text
+comp edit new smokeable Smokeable_Henbane_Smoke
+comp set fuel 900
+comp set drag 30
+comp set drug "Henbane Smoke"
+comp set dose 0.05g
+comp set playerdesc The bitter herbal smell of henbane clings to this individual.
+comp set roomdesc The bitter herbal smell of henbane smoke hangs in the air here.
+```
+
+The drug must support `Inhaled`.
+
+Use smokeables for cigarettes, pipes, herbs, fumes inhaled directly from a burning item, and other personal inhaled doses.
+
+## Incense And Fumigation
+Use `IncenseBurner` for room-scale or area-scale scent and optional inhaled drug pulses.
+
+Relevant prototype commands:
+
+```text
+comp set drug <inhaled drug>
+comp set dose <weight>
+comp set pulse <seconds>
+comp set drugrange <rooms>
+comp set range <rooms>
+comp set linger <multiplier>
+comp set tag <fuel tag>
+```
+
+The drug must support `Inhaled`.
+
+Each pulse doses characters in affected cells. Dose falls off by distance as `grams per pulse / (distance + 1)`. Drug dosing range is capped by the scent range.
+
+Use incense for temple smoke, anesthetic vapour rooms, fumigation, ritual narcotics, or poisonous gas-like content when it should be tied to burning fuel and room ambience rather than gas canisters.
+
+## Inhalers And Drug Gases
+A gas can carry a drug payload just like a liquid. Inhaler components consume gas and dose the character if the gas drug supports `Inhaled`.
+
+Typical gas setup:
+
+```text
+gas edit <gas>
+gas set drug Bronchodilator
+gas set drugvolume 2%
+gas set smell 1 sharp medicinal
+gas show
+```
+
+Use inhalers when the item should consume a gas supply per puff. Use smokeables when the item itself burns. Use incense burners when the source doses a room or vicinity.
+
+## Syringes, IVs, And Injectable Liquids
+Syringes and IV bags deliver liquids through `IHealthStrategy.InjectedLiquid(...)`.
+
+Player command:
+
+```text
+inject <item> <target> <bodypart> [<amount>]
+```
+
+The target must be helpless, self-injecting, or willing to accept the intervention. The bodypart must be accessible.
+
+For injectable medicine:
+
+1. Give the drug the `Injected` vector.
+2. Put the drug on a liquid.
+3. Set liquid dose ratio.
+4. Set the liquid injection consequence.
+5. Put the liquid in a syringe, IV bag, or other `IInject`/infusion item.
+
+Remember that the health strategy also processes the liquid itself. A harmless injected carrier should usually be `Benign`. Blood products and IV fluids should use the relevant blood, hydrating, or blood-volume consequences.
+
+## Venoms And Weapon Poisons
+Venom normally combines three pieces:
+
+1. A drug, usually `Injected | Touched`.
+2. A liquid carrying that drug.
+3. A delivery path such as `EnvenomingAttack`, `dip`, or poison `apply`.
+
+Natural envenoming attacks use `EnvenomingAttack` additional data:
+
+- venom liquid
+- maximum quantity
+- minimum wound severity
+
+Weapon poison uses liquid coating on melee weapons or ammunition. The liquid must carry a drug with `Touched` or `Injected`.
+
+Player-facing poison commands include:
+
+```text
+apply <source> to <weapon> [volume <amount>]
+apply <source> to <ammo> [count <number|all>] [volume <amount>]
+dip <weapon> in <source>
+dip <ammo> in <source> [count <number|all>]
+```
+
+Injected weapon poison delivery depends on wound severity, wound nature, and damage-type multipliers. Contact poison is the fallback if no injected delivery succeeds and the drug supports `Touched`.
+
+## Magic Poison And Removal
+Magic spell effects can add or remove drug payloads through the spell-effect builders:
+
+```text
+effect poison
+effect set drug <drug>
+effect set vector <vector>
+effect set formula <expr>
+
+effect removepoison
+effect set drug <drug>
+effect set vector <vector>
+effect set formula <expr>
+```
+
+The poison effect stores an originator object so removal can target the dose it created. Use this route when the delivery is magical, curse-like, or script-managed rather than item-mediated.
+
+## Seeder Patterns
+Use `HealthSeeder` as the primary stock drug catalogue reference. Its pattern is:
+
+1. Upsert named drugs by stable name.
+2. Rewrite stock-owned intensity rows for those drugs.
+3. Add `Pill_`, `TopicalCream_`, and `Smokeable_` component prototypes only for vectors the drug supports.
+
+Use `AnimalSeeder` as the venom reference. Its pattern is:
+
+1. Create a race-specific venom drug.
+2. Create a matching liquid with `Drug`, `DrugGramsPerUnitVolume`, taste/smell text, and injection consequence.
+3. Attach that liquid to an `EnvenomingAttack`.
+
+Use `ItemSeeder.Rework.AntiquityMedical` as an example of item prototypes that consume the stock drug delivery component names, such as `Pill_Willow_Bark_Tea`, `TopicalCream_Honey_Poultice`, and `Smokeable_Henbane_Smoke`.
+
+## Testing Checklist
+Before considering a drug content slice complete:
+
+- `drug show <drug>` lists the intended vectors and effect families.
+- Every effect family with required payloads has that payload configured.
+- Every delivery wrapper uses a compatible vector.
+- Liquid and gas materials have sensible `DrugGramsPerUnitVolume` values.
+- Injectable liquids have deliberate injection consequences.
+- Food doses are per serving and scale correctly with partial eating.
+- Smoke, incense, and inhalers apply grams per drag, pulse, or puff as intended.
+- Weapon poison liquids have touched or injected vectors and enough liquid capacity.
+- Stock seeder additions are idempotent and update the maintained seeded component catalogue when required.

--- a/Design Documents/Drugs/Drug_System_Design.md
+++ b/Design Documents/Drugs/Drug_System_Design.md
@@ -1,0 +1,454 @@
+# FutureMUD Drug System Design
+
+## Purpose
+This document describes the current FutureMUD drug implementation for developers. It is an implementation map, not a redesign proposal.
+
+The content-facing companion is [Drug Builder Guide](./Drug_Builder_Guide.md).
+
+## Implementation Map
+| Surface | Primary types |
+| --- | --- |
+| Public contract | `FutureMUDLibrary/Health/IDrug.cs`, `FutureMUDLibrary/Health/DrugType.cs`, `FutureMUDLibrary/Health/IngestedDrugExtensions.cs` |
+| Body state | `IBody.Dose(...)`, `Body.ActiveDrugDosages`, `Body.LatentDrugDosages`, `MudSharpCore/Body/Implementations/BodyDrugs.cs` |
+| Concrete editable item | `MudSharpCore/Health/Drug.cs` |
+| Persistence | `Drugs`, `DrugsIntensities`, `BodiesDrugDoses`, `Liquids.DrugId`, `Liquids.DrugGramsPerUnitVolume`, `Gases.DrugId`, `Gases.DrugGramsPerUnitVolume` |
+| Material payloads | `IFluid`, `ILiquid`, `IGas`, `LiquidMixture`, `LiquidInstance` |
+| Item delivery | `Pill`, `PreparedFood`, `TopicalCream`, `Smokeable`, `IncenseBurner`, `Syringe`, `IVBag`, inhaler components |
+| Combat delivery | `EnvenomingAttack`, `WeaponPoisonDeliveryHelper`, `WeaponPoisonCoating` |
+| Magic delivery | `PoisonEffect`, `RemovePoisonEffect`, `SpellPoisonEffect` |
+| FutureProg | `todrug`, `drugintensity`, `drugeffectintensity`, drug dot references, character drug collections |
+| Resistances | `ISpecificDrugResistanceMerit`, `IDrugEffectResistanceMerit` |
+| Stock data | `HealthSeeder` drug catalogue and delivery components, `AnimalSeeder` venom profiles |
+
+## Core Model
+`IDrug` is an editable framework item and FutureProg variable. A drug definition is pharmacology only. Delivery comes from bodies, items, fluids, gases, attacks, spells, and scripts.
+
+`IDrug` exposes:
+
+- `DrugVectors`: a flag set of legal delivery vectors.
+- `DrugTypes`: the effect families present on the drug.
+- `IntensityPerGram`: the global potency multiplier.
+- `RelativeMetabolisationRate`: how quickly active grams are removed relative to other drugs.
+- `IntensityForType(type)`: `IntensityPerGram * relative effect intensity`.
+- `AdditionalInfoFor<T>(type)`: typed payload data for effect families that need more than a scalar.
+- `DescribeEffect(type, voyeur)`: builder/admin-facing effect text.
+- `Clone(newName)`: creates a new persisted drug row copied from an existing definition.
+
+`DrugVector` supports `Injected`, `Ingested`, `Inhaled`, and `Touched`. `DrugVector.None` is present as a zero value, but it is not useful as an authored delivery route.
+
+`DrugType` supports:
+
+- `Anesthesia`
+- `Analgesic`
+- `Immunosuppressive`
+- `NeutraliseDrugEffect`
+- `BodypartDamage`
+- `Pacifism`
+- `Rage`
+- `Adrenaline`
+- `StaminaRegen`
+- `Nausea`
+- `HealingRate`
+- `MagicAbility`
+- `NeutraliseSpecificDrug`
+- `Paralysis`
+- `Antibiotic`
+- `OrganFunction`
+- `VisionImpairment`
+- `ThermalImbalance`
+- `Antifungal`
+- `PlanarState`
+
+## Additional Info Payloads
+Most drug types only need a scalar intensity. These drug types have extra payload classes in `IDrug.cs`:
+
+| Drug type | Payload | Stored meaning |
+| --- | --- | --- |
+| `NeutraliseDrugEffect` | `NeutraliseDrugAdditionalInfo` | Space-separated `DrugType` integer ids to neutralise |
+| `NeutraliseSpecificDrug` | `NeutraliseSpecificDrugAdditionalInfo` | Space-separated drug ids to neutralise |
+| `BodypartDamage` | `BodypartDamageAdditionalInfo` | Bodypart or organ type ids to damage |
+| `HealingRate` | `HealingRateAdditionalInfo` | Healing-rate intensity and healing-difficulty intensity |
+| `MagicAbility` | `MagicAbilityAdditionalInfo` | Magic capability ids to grant |
+| `OrganFunction` | `OrganFunctionAdditionalInfo` | Organ type ids to modify |
+| `PlanarState` | `PlanarStateAdditionalInfo` | State, plane id, and default-plane visibility |
+
+The concrete `Drug` loader parses the persisted `AdditionalEffects` string into these payload types. Missing or malformed id payload tokens are skipped by the list parsers rather than crashing load. `PlanarState` defaults to `noncorporeal` on the default plane if old or partial payload data is encountered.
+
+## Persistence
+`Drug` rows store the stable definition: name, vectors, intensity per gram, and metabolisation rate.
+
+`DrugIntensity` rows are keyed by `(DrugId, DrugType)` and store the per-effect relative intensity plus the optional payload string. `Drug.Save()` rewrites all intensity rows for the drug rather than patching individual rows.
+
+`BodyDrugDose` rows store active and latent dose state on a body. The persisted state includes body id, drug id, grams, original vector, and active flag. The runtime `Originator` field on `DrugDosage` is not persisted; it is useful for live systems such as spell poison effects that need to remove the dose they created.
+
+Liquids and gases can both carry a drug payload through `IFluid.Drug` and `IFluid.DrugGramsPerUnitVolume`. This is material-level content, not part of the drug definition itself.
+
+## Dosing And Heartbeat Flow
+All normal dose entry points call `IBody.Dose(IDrug drug, DrugVector vector, double grams, object originator = null)`.
+
+`Body.Dose(...)`:
+
+1. Adds the grams to a matching latent dose with the same drug, original vector, and originator, or creates a new latent dose.
+2. Marks drug state changed.
+3. Ensures the ten-second drug heartbeat is running.
+
+The body only keeps the drug heartbeat active while the body is active and there are active doses, latent doses, alcohol, or other `ICauseDrugEffect` sources.
+
+On each drug heartbeat, the body:
+
+1. Moves part of each latent dose into active dose state.
+2. Applies all drug effects from active doses and external drug-effect sources.
+3. Metabolises active doses down.
+4. Checks health status.
+
+Latent absorption rates per ten-second heartbeat are:
+
+| Original vector | Latent-to-active rate |
+| --- | --- |
+| `Injected` | `0.5` |
+| `Inhaled` | `0.4` |
+| `Touched` | `0.05` |
+| `Ingested` | `0.02` |
+
+Active drug removal uses:
+
+`LiverAlcoholRemovalKilogramsPerHour * 10000.0 / 3600.0 * drug.RelativeMetabolisationRate`
+
+Lower relative metabolisation values last longer. Higher values clear faster.
+
+`Body.Dose(...)` does not validate that the supplied vector is present in `drug.DrugVectors`. Validation is mostly performed by authoring surfaces and delivery components. Low-level callers and seeders should check vector compatibility explicitly.
+
+## Effect Aggregation
+`Body.ApplyDrugEffects()` builds two counters: net effect intensity by `DrugType`, and neutralising intensity by `DrugType`.
+
+The order is:
+
+1. Add nausea pressure from alcohol.
+2. Build active grams per drug.
+3. Apply `NeutraliseSpecificDrug` by subtracting grams from named target drugs before their effects are expanded.
+4. Add `ICauseDrugEffect` contributions from other active effects.
+5. Apply `ISpecificDrugResistanceMerit` multipliers to grams for each concrete drug.
+6. Expand each drug's active grams into effect intensities using `IntensityForType(type)`.
+7. Accumulate special payload data for healing, organ function, bodypart damage, magic capability, and planar state.
+8. Apply `IDrugEffectResistanceMerit` multipliers to summed effect intensities.
+9. Create, update, or remove concrete effects based on net intensity after neutralisation.
+
+Most effect intensities are normalised by body mass using:
+
+`netIntensity / (Weight * BaseWeightToKilograms * 0.001)`
+
+Some effect families intentionally use different aggregation semantics:
+
+- `HealingRate` accumulates configured healing-rate and difficulty payload values and applies them through `HealingRateDrug`.
+- `MagicAbility` grants configured capabilities only when the accumulated capability intensity is greater than `1.0`.
+- `BodypartDamage` creates passive cellular wounds based on configured bodypart types and `OrganDamagePerDrugIntensity`.
+- `PlanarState` chooses the strongest active planar payload and applies that overlay if the net effect remains positive.
+- `ThermalImbalance` pushes progress into the shared `ThermalImbalance` consequence model rather than storing a drug-specific overlay.
+
+## Supported Drug Effects
+| Drug type | Runtime behavior |
+| --- | --- |
+| `Analgesic` | Creates or updates `Analgesic`, which implements `IPainReductionEffect` with both flat and multiplicative pain reduction. |
+| `Anesthesia` | Creates or updates `Anesthesia`, which applies broad check penalties through `ICheckBonusEffect` except for excluded time, wound close, recovery, healing, and infection checks. High values produce drowsiness and breathing-reflex messaging. |
+| `Antibiotic` | Creates or updates `Antibiotic`, an `IInfectionResistanceEffect` for simple, infectious, necrotic, and gangrene infections. |
+| `Antifungal` | Creates or updates `Antifungal`, an `IInfectionResistanceEffect` for fungal infections. |
+| `Immunosuppressive` | Creates or updates `Immunosupressant`, which applies a negative immune bonus. |
+| `NeutraliseDrugEffect` | Does not create an effect. Its payload names drug-effect families whose net intensities are reduced. |
+| `NeutraliseSpecificDrug` | Does not create an effect. Its payload names concrete drugs whose active grams are reduced before effect expansion. |
+| `BodypartDamage` | Applies passive cellular damage to matching organs, bodyparts, and bones using the configured payload types and static organ-damage settings. |
+| `Pacifism` | Creates or updates `PacifismDrug`, which exposes `IPacifismEffect` and score/health messaging at higher intensities. |
+| `Rage` | Creates or updates `MurderousRage`, which exposes `IRageEffect`, score/health messaging, and can force violent behavior at high intensity. |
+| `Adrenaline` | Creates or updates `AdrenalineRush`; also applies heart support floors, thermal load, and possible cardiac cellular damage through static settings. |
+| `StaminaRegen` | Immediately grants stamina each drug heartbeat from net normalised intensity. |
+| `Nausea` | Creates or updates `Nausea`, which combines drug intensity with blood alcohol content and hunger/thirst state for check penalties, score text, and vomiting. |
+| `HealingRate` | Creates or updates `HealingRateDrug`, setting a healing-rate multiplier and integer healing-difficulty stage bonus. |
+| `MagicAbility` | Creates or updates `DrugInducedMagicCapability`, granting configured magic capabilities while sufficient active intensity remains. |
+| `Paralysis` | Creates or updates `DrugInducedParalysis`, which implements forced paralysis at `DrugParalysisThreshold` and score/health messaging above half threshold. |
+| `OrganFunction` | Creates or updates `OrganFunctionDrugEffect`, mapping configured organ types to organ-function bonuses. |
+| `VisionImpairment` | Creates or updates `VisionImpairmentDrugEffect`; vision multiplier is clamped at `max(0, 1 - intensity)`. |
+| `ThermalImbalance` | Applies progress to the shared thermal imbalance model if `TemperatureImbalanceEnabled` is true. |
+| `PlanarState` | Creates or updates `DrugInducedPlanarStateEffect`, a priority-50 planar overlay that can make a body manifested or noncorporeal on a chosen plane. |
+
+Important static configuration keys include:
+
+- `AnasthesiaIntensityToBonusConversionRate`
+- `AntibioticInfectionBonusToIntensityMultiplier`
+- `AntifungalInfectionBonusToIntensityMultiplier`
+- `ImmunosupressantImmuneBonusPerIntensity`
+- `NauseaIntensityToBonusConversionRate`
+- `DrugParalysisThreshold`
+- `OrganDamageFloor`
+- `OrganDamagePerDrugIntensity`
+- `AdrenalineCheckPenaltyPerIntensity`
+- `AdrenalineHeartSupportFloorPerIntensity`
+- `AdrenalineHeartSupportMaximumFloor`
+- `AdrenalineThermalGainPerIntensity`
+- `AdrenalineCardiacDamagePerIntensity`
+
+## Delivery Vectors
+### Ingested
+Ingested dosing is used by pills, prepared foods, drinks, fed foods, and liquid doses that are consumed.
+
+Entry points include:
+
+- `PillGameItemComponent.Swallow(...)`
+- `PreparedFoodGameItemComponent.Eat(...)`
+- `BodyNeeds.Drink(...)` and `BodyNeeds.SilentDrink(...)`
+- `IngestedDrugExtensions.ApplyIngestedDrugDoses(...)`
+
+`Pill` and `PreparedFood` authoring validates that the chosen drug supports `DrugVector.Ingested`. Liquid materials can be assigned any drug, but ingested dose helpers only apply the payload if the drug supports the ingested vector.
+
+### Injected
+Injected dosing is used by syringes, IV bags, envenoming natural attacks, weapon poison injected through wounds, some legal execution content, and magic poison effects configured with an injected vector.
+
+Entry points include:
+
+- `SyringeGameItemComponent.Inject(...)`
+- `IVBagGameItemComponent` heartbeat infusion
+- `EnvenomingAttackMove`
+- `EnvenomingClinchAttack`
+- `WeaponPoisonDeliveryHelper`
+- `PoisonEffect` / `SpellPoisonEffect`
+
+Living and brain-style health strategies apply the liquid's drug as `DrugVector.Injected` and then process the liquid's `LiquidInjectionConsequence`. `RobotHealthStrategy.InjectedLiquid(...)` ignores drug payloads on injected liquids and only accepts appropriate blood-replacement style liquids.
+
+The injected-liquid health strategy path does not check `drug.DrugVectors.HasFlag(Injected)`. Builders and seeders should not rely on the vector flag as a safety gate for syringe, IV, or envenoming content.
+
+### Inhaled
+Inhaled dosing is used by smokeables, inhalers, incense burners, gas payloads, and magic poison effects configured with an inhaled vector.
+
+Entry points include:
+
+- `SmokeableGameItemComponent.Smoke(...)`
+- `ExternalInhalerGameItemComponent.Puff(...)`
+- `IntegratedInhalerGameItemComponent.Puff(...)`
+- `IncenseBurnerGameItemComponent.PulseDrug(...)`
+- `PoisonEffect` / `SpellPoisonEffect`
+
+Smokeable and incense-burner prototypes validate that the drug supports `DrugVector.Inhaled`. Inhaler components also check the gas drug's inhaled flag before dosing. Gas material authoring itself does not enforce the flag.
+
+### Touched
+Touched dosing is used by topical creams and contact weapon poison delivery.
+
+Entry points include:
+
+- `TopicalCreamGameItemComponent.Apply(...)`
+- `WeaponPoisonDeliveryHelper.DoseContact(...)`
+- `PoisonEffect` / `SpellPoisonEffect`
+
+Topical cream prototypes validate that the drug supports `DrugVector.Touched`. Weapon poison delivery filters coating mixtures by the touched flag before applying contact dosing.
+
+Ordinary surface wetness is not a general-purpose skin-absorption system. Body and item surface liquids persist wetness, descriptions, residues, cleaning requirements, and liquid surface reactions. They do not automatically apply `DrugVector.Touched` doses unless a delivery component or helper explicitly calls `Body.Dose(...)`.
+
+## Drug Liquids, Gases, Foods, And Tinctures
+`IFluid` is the shared contract for liquids and gases. A fluid can carry one drug and a grams-per-unit-volume value.
+
+For liquids:
+
+- Drinking uses `ApplyIngestedDrugDoses(...)`, so only ingested-vector drugs are dosed.
+- Injection uses `IHealthStrategy.InjectedLiquid(...)`, so living health strategies dose the drug as injected.
+- Weapon poison uses the liquid mixture and filters for touched or injected vector compatibility.
+- Prepared food can absorb liquid and convert ingested drug payloads into food drug doses.
+- Liquid surface contamination and reactions are separate from drug dosing.
+
+For gases:
+
+- Inhalers consume gas and dose the gas drug if it supports the inhaled vector.
+- Gas material authoring stores the payload; the inhaler decides whether it becomes a body dose.
+
+Prepared foods store direct `FoodDrugDose` entries and optional stale/spoiled drug doses. Eating applies a proportion of those grams based on bites consumed. Food can also absorb liquid contamination or liquid exposure, adding ingredient ledger rows and ingested drug doses for compatible drug liquids.
+
+Tinctures, draughts, teas, salves, poultices, ointments, smokes, and venom are content conventions rather than distinct pharmacology classes. For example:
+
+- A tincture is usually an ingested drug plus a liquid material or prepared-dose item.
+- A salve or poultice is usually a touched drug plus `TopicalCream`.
+- Smoke or fumigation is usually an inhaled drug plus `Smokeable` or `IncenseBurner`.
+- Venom is usually an injected and touched drug plus a liquid material and either `EnvenomingAttack` or weapon poison coating.
+
+## Builder And Admin Surface
+`drug` is the primary builder command. It is backed by `EditableItemHelper.DrugHelper` and `Drug.BuildingCommand(...)`.
+
+Supported editing operations include:
+
+- create, clone, edit, list, show, and close
+- rename
+- set global intensity
+- set relative metabolism
+- toggle vectors
+- add, update, or remove effect intensities
+- configure payload data for bodypart damage, organ function, healing rate, magic capability, neutralisation, specific-drug neutralisation, and planar state
+
+`show drug <which>` and `show drugs` expose read-only display paths. Staff can use `drugs <target>` to inspect active and latent dosages through `DrugDosageDescriber`.
+
+## FutureProg Surface
+Drugs are `ProgVariableTypes.Drug`.
+
+Lookup and inspection include:
+
+- `todrug(number)` and `todrug(text)`
+- `drugintensity(character, drug)`
+- `drugeffectintensity(character, number)`
+- character properties for active drugs, active amounts, latent drugs, and latent amounts
+- drug dot references for id, name, intensity, metabolisation rate, vectors, types, and intensities
+
+Current implementation caveats:
+
+- `Drug.GetProperty` handles `itensities` rather than `intensities`, while the compiler/help advertises `intensities`.
+- The character `latentdrugamounts` property currently sums matching active doses rather than latent doses.
+
+Consumers that need exact dosage state from C# should read `Body.ActiveDrugDosages` and `Body.LatentDrugDosages` directly.
+
+## Stock Seeding
+`HealthSeeder` seeds a tech-level drug catalogue and then creates delivery component prototypes for supported vectors:
+
+- `Pill_<DrugName>` for ingested-vector drugs.
+- `TopicalCream_<DrugName>` for touched-vector drugs.
+- `Smokeable_<DrugName>` for inhaled-vector drugs.
+
+The stock catalogue includes primitive, pre-modern, and modern examples across analgesia, anesthesia, infection control, nausea control, organ support, paralysis, adrenaline, stamina support, healing-rate modification, immunosuppression, and neutralisation.
+
+`AnimalSeeder` creates race-specific venom drugs, matching venom liquids, and envenoming natural attacks. Venom profiles typically use `Injected | Touched`, a liquid injection consequence, a high `DrugGramsPerUnitVolume`, and `EnvenomingAttack` additional info.
+
+`Design Documents/Data/Seeded_Item_Components.json` is the maintained catalogue for seeded delivery component prototypes.
+
+## Extension Guidelines
+When adding a new drug effect family:
+
+1. Add the `DrugType` enum value.
+2. Add a `DrugAdditionalInfo` payload class only if the effect needs structured extra data.
+3. Update `Drug.AdditionalInfoFor(...)`, builder help, builder commands, `Show(...)`, and `DescribeEffect(...)`.
+4. Update `Body.ApplyDrugEffects()` to aggregate, apply resistance and neutralisation correctly, create/update effects, and remove effects when net intensity is gone.
+5. Add or reuse concrete effect interfaces so other systems can query the result.
+6. Update FutureProg docs if the new effect needs scripting support.
+7. Add focused tests around parsing, builder setup, effect application, cleanup, and seeder examples.
+8. Update this document and the builder guide.
+
+When adding a new delivery mechanism:
+
+1. Keep pharmacology on `IDrug`; keep delivery-specific state on the item, fluid, attack, spell, or command surface.
+2. Validate vector compatibility in authoring and again at runtime where feasible.
+3. Preserve grams as the common dose unit.
+4. Decide whether the dose should be latent through `Body.Dose(...)` or immediate through an existing health-strategy pathway such as `InjectedLiquid(...)`.
+5. Include originator objects when later removal or grouping matters.
+6. Add a seeded example only when the content package owns both the drug and the delivery wrapper.
+
+## Expansion Ideas
+These are strong candidates for future drug-effect families. They are deliberately framed as runtime slices rather than only content ideas, because each one opens a health-system interaction that the current effect catalogue does not model directly.
+
+### Coagulation And Bleeding Control
+Add a `DrugType.Coagulation` family for hemostatic and anticoagulant drugs.
+
+Runtime shape:
+
+- Add a concrete `DrugCoagulationEffect` and an `IBleedingModifierEffect` interface.
+- Query the interface from external organic wound bleeding, trauma-controlled wound reopen checks, closed-wound failure checks, and `InternalBleeding`.
+- Treat positive intensity as clotting support and negative intensity as anticoagulation, or use payload mode flags if builder-facing clarity is preferred.
+- Keep the effect body-mass-normalised like most existing scalar drug effects.
+- No-op for bodies without blood, bodies whose race has no `BloodLiquid`, non-organic wound types that do not bleed, and bodies with no active bleeding or reopen checks to modify.
+
+Content enabled:
+
+- Injectable clotting agents for battlefield medicine.
+- Poisoned blades that keep wounds bleeding.
+- Venoms that create dangerous internal bleeding without adding direct cellular damage every heartbeat.
+- Low-tech styptic powders, yarrow preparations, and alchemical blood thinners.
+
+Implementation notes:
+
+- The main health-system update is the new query point, not the drug builder surface.
+- Internal bleeding should use a multiplier on `BloodlossPerTick` rather than a direct wound-state rewrite so active bleeding still owns its own lifecycle.
+- Static settings should cap maximum clotting and anticoagulant multipliers to avoid zero-risk healing or runaway blood loss.
+
+### Respiratory Drive And Hypoxia Modulation
+Add a respiratory drug family for stimulants, depressants, bronchodilators, airway relaxants, and antitoxins.
+
+Runtime shape:
+
+- Add a `DrugType.Respiration` family and a concrete `DrugRespirationEffect`.
+- Add an `IRespirationModifierEffect` interface used by breathing strategies and hypoxia damage paths.
+- Model at least three payload knobs: breathing-drive multiplier, hypoxia-damage multiplier, and airway/obstruction support.
+- Let depressants reduce breathing drive and increase hypoxia risk; let stimulants or bronchodilators improve marginal breathing without bypassing hard impossibilities.
+- No-op for `NeedsToBreathe == false`, dead bodies, non-living strategies that do not run breathing, or bodies already in normal equilibrium when the configured mode only affects crisis states.
+
+Content enabled:
+
+- Opioid-style respiratory depressants that are dangerous when mixed with anesthesia.
+- Emergency respiratory stimulants for overdose recovery.
+- Smoke, gas, or venom antitoxins that reduce hypoxia pressure.
+- Asthma-like bronchodilator inhalers without needing a full disease subsystem first.
+
+Implementation notes:
+
+- The first pass can make the hook a no-op unless the body cannot breathe, is not breathing, or is taking hypoxia damage.
+- This is a good place to document a respiratory equilibrium rule: drugs modify the consequences of being out of equilibrium, but do not create free oxygen or make an unbreathable atmosphere breathable.
+- If a later disease system adds bronchospasm or airway inflammation, it should use the same interface rather than a separate drug-only check.
+
+### Metabolic And Need-Rate Drugs
+Add a `DrugType.NeedRate` family that reuses the existing `INeedRateEffect` pattern already used by spell effects.
+
+Runtime shape:
+
+- Add a `NeedRateAdditionalInfo` payload with hunger, thirst, and drunkenness multipliers plus passive/active applicability flags.
+- Add `DrugNeedRateEffect : Effect, INeedRateEffect`.
+- Have `Body.ApplyDrugEffects()` aggregate the strongest or multiplied payload values and create/update/remove the effect like other scalar overlays.
+- No-op for `NoNeeds` models, dead/no-needs characters, and any need axis omitted by payload.
+
+Content enabled:
+
+- Appetite suppressants and appetite stimulants.
+- Diuretics or dehydration poisons.
+- Hangover treatments that increase alcohol cleanup pressure through the needs/drunkenness model.
+- Performance stimulants that trade stamina or wakefulness for thirst and hunger pressure.
+
+Implementation notes:
+
+- This is one of the cheapest high-value additions because the health-adjacent interface already exists.
+- Builder payload commands should display multipliers as percentages to match current health-strategy builder conventions.
+- Seeder examples should include one benign medicine and one toxic or illicit example so builders see both directions.
+
+### Sleep, Wakefulness, And Consciousness Thresholds
+Add a sleep/arousal drug family separate from `Anesthesia`.
+
+Runtime shape:
+
+- Add a `DrugType.Arousal` or `DrugType.SleepWakefulness` family.
+- Add an `ArousalAdditionalInfo` payload with mode flags such as sedative, stimulant, sleep-inducing, sleep-preventing, passout-threshold modifier, and recovery-threshold modifier.
+- Add `DrugInducedArousalEffect`, reusing existing interfaces where possible: `ISleepEffect`, `IPreventSleepEffect`, `ICheckBonusEffect`, and a new consciousness-threshold modifier interface if needed.
+- No-op for bodies whose current health strategy does not evaluate consciousness, for no-needs/dead bodies where sleep is irrelevant, and for modes that only apply when the character is near a passout/unconsciousness threshold.
+
+Content enabled:
+
+- Sedatives and tranquilizers that make sleep easier without the broad penalties of anesthesia.
+- Stimulants that prevent sleep and temporarily resist passing out.
+- Knockout drugs that push a marginal target into sleep or unconsciousness.
+- Counteragents that help a patient wake after anesthesia or poison.
+
+Implementation notes:
+
+- Keep this separate from `Anesthesia`: anesthesia is broad check suppression and surgical unconsciousness flavor, while arousal controls sleep/wake state and threshold pressure.
+- Score and health text should only appear past meaningful intensity thresholds to avoid noisy status output for mild caffeine-like content.
+- Forced sleep should respect combat, posture, and existing state-transition rules rather than directly setting character state from the drug effect.
+
+### Tolerance, Dependence, And Withdrawal
+Add a persistent exposure-history layer for drugs that opt in to tolerance or dependence.
+
+Runtime shape:
+
+- Add dependence metadata to drugs through a `DrugDependenceAdditionalInfo` payload or a separate opt-in table if the model becomes broader than one `DrugType`.
+- Track exposure from active and latent drug heartbeats by body, concrete drug, and optionally effect family.
+- Use exposure to modify effective intensity, metabolisation, or both before `Body.ApplyDrugEffects()` expands grams into effect intensities.
+- Create withdrawal effects when exposure decays below a configured threshold after sustained use.
+- No-op for drugs without dependence metadata, non-persisted temporary bodies if the implementation cannot safely persist history, and worlds that disable the feature through static configuration.
+
+Content enabled:
+
+- Tolerance to painkillers, sedatives, stimulants, alcohol-like content, and magical enhancers.
+- Withdrawal nausea, pain sensitivity, irritability, insomnia, tremors, stamina penalties, or check penalties.
+- Treatment content such as tapering medications and antagonist drugs.
+- Setting-specific addiction arcs without hard-coding a single addiction model.
+
+Implementation notes:
+
+- Withdrawal should express itself through existing effect pathways where possible: nausea, pain sensitivity, sleep disruption, rage or pacifism pressure, stamina regeneration penalties, need-rate changes, and general check penalties.
+- The persistence design should avoid saving every heartbeat as a row. Prefer one compact exposure record per body/drug or body/effect family with last-updated time and accumulated exposure.
+- Builder UX should make this opt-in and conservative, because persistent dependence is a large gameplay commitment for live worlds.

--- a/Design Documents/Drugs/README.md
+++ b/Design Documents/Drugs/README.md
@@ -1,0 +1,11 @@
+# Drug System Documentation
+
+This folder contains the dedicated drug-system documentation for FutureMUD.
+
+## Documents
+- [Drug System Design](./Drug_System_Design.md) is the developer-facing implementation map. It explains `IDrug`, persistence, dosing, metabolism, delivery vectors, effect aggregation, and extension points.
+- [Drug Builder Guide](./Drug_Builder_Guide.md) is the content-facing guide for builders, seeder developers, and AI agents authoring drugs, medicines, venoms, poisons, tinctures, food doses, smokeables, salves, and related delivery items.
+
+## Relationship To Health
+Drugs are implemented as part of the health runtime, but they are intentionally cross-cutting. A finished drug feature may involve health code, item components, fluid materials, combat attacks, magic spell effects, FutureProg hooks, and DatabaseSeeder content.
+

--- a/Design Documents/Health/Health_System_Design.md
+++ b/Design Documents/Health/Health_System_Design.md
@@ -16,6 +16,7 @@ This is the head document for the health system set:
 - [Health Medical Interactions](./Health_Medical_Interactions.md) covers bedside treatment, surgery, CPR, defibrillation, drugs, and the main command surface.
 - [Health Adjacencies and Items](./Health_Adjacencies_and_Items.md) covers breathing, needs, corpses, severed bodyparts, implants, artificial organs, rebreathers, cannulae, prosthetics, and cross-cutting effects.
 - [Health Seeder State and Gaps](./Health_Seeder_State_and_Gaps.md) covers how stock content is currently seeded and where the current implementation is partial, broader than the stock data, or a natural extension point.
+- [Drug System Design](../Drugs/Drug_System_Design.md) and [Drug Builder Guide](../Drugs/Drug_Builder_Guide.md) cover the dedicated drug implementation and content-authoring workflow.
 - [Antiquity Medical Crafting Suite](../Crafting/Antiquity_Medical_Crafting_Suite.md) records the antiquity medical item and craft pass, including low-tech treatment goods, herbal remedies, prosthetics, and forage yield hooks.
 
 ## Core Mental Model

--- a/Design Documents/README.md
+++ b/Design Documents/README.md
@@ -69,6 +69,11 @@ This folder is organised by subsystem so implementation notes, builder workflows
 - [Seeded Gases](./Data/Seeded_Gases.json)
 - [Seeded Tag Hierarchy](./Data/SeededTagHierarchy.csv)
 
+## Drugs
+- [Drug System Documentation](./Drugs/README.md)
+- [Drug System Design](./Drugs/Drug_System_Design.md)
+- [Drug Builder Guide](./Drugs/Drug_Builder_Guide.md)
+
 ## Economy
 - [Economy System Runtime](./Economy/Economy_System_Runtime.md)
 - [Economy System Workflows and Integration](./Economy/Economy_System_Workflows_and_Integration.md)


### PR DESCRIPTION
## Summary
- Add a dedicated drug system documentation folder with a developer-facing system design and builder-facing guide
- Document IDrug, vectors, delivery mechanisms, supported effects, FutureProg surfaces, stock seeding, and extension rules
- Add five implementation-shaped expansion ideas for future drug effects and related health-system hooks
- Link the drug docs from the design index and health system reading guide

## Validation
- git diff --check
- Markdown link check for the drug system design doc
- Manual trailing-whitespace check over Design Documents/Drugs/*.md

No runtime tests were run because this is documentation-only.