### PR TITLE
Fix economy seeder XML id references

### DIFF
--- a/DatabaseSeeder Unit Tests/EconomySeederTests.cs
+++ b/DatabaseSeeder Unit Tests/EconomySeederTests.cs
@@ -580,6 +580,12 @@ public class EconomySeederTests
 			.ToList();
 	}
 
+    private static void AssertPositiveExistingId(long id, ISet<long> validIds, string description)
+    {
+        Assert.IsTrue(id > 0, $"{description} should not use a placeholder ID.");
+        Assert.IsTrue(validIds.Contains(id), $"{description} should reference an existing seeded row.");
+    }
+
     private static List<XElement> GetPopulationIncomeImpacts(MarketInfluenceTemplate template)
     {
         return XElement.Parse(template.PopulationImpacts ?? "<PopulationImpacts />")
@@ -824,6 +830,71 @@ public class EconomySeederTests
                 0,
                 context.MarketCategories.Single(x => x.Name == familyName).MarketCategoryType,
                 $"{familyName} should remain standalone in the stock seeder.");
+        }
+    }
+
+    [TestMethod]
+    public void SeedData_DoesNotSerializePlaceholderIdsInStockXml()
+    {
+        using FuturemudDatabaseContext context = BuildContext();
+        SeedEconomyPrerequisites(context);
+
+        new EconomySeeder().SeedData(context, BuildAnswers());
+
+        HashSet<long> categoryIds = context.MarketCategories.Select(x => x.Id).ToHashSet();
+        HashSet<long> populationIds = context.MarketPopulations.Select(x => x.Id).ToHashSet();
+        HashSet<long> futureProgIds = context.FutureProgs.Select(x => x.Id).ToHashSet();
+
+        foreach (MarketCategory? category in context.MarketCategories.OrderBy(x => x.Name))
+        {
+            foreach ((long categoryId, _) in GetCombinationComponents(category))
+            {
+                AssertPositiveExistingId(categoryId, categoryIds, $"{category.Name} combination component {categoryId}");
+            }
+        }
+
+        foreach (MarketInfluenceTemplate? template in context.MarketInfluenceTemplates.OrderBy(x => x.Name))
+        {
+            foreach (XElement impact in XElement.Parse(template.Impacts ?? "<Impacts />").Elements("Impact"))
+            {
+                long categoryId = long.Parse(impact.Attribute("category")!.Value, CultureInfo.InvariantCulture);
+                AssertPositiveExistingId(categoryId, categoryIds, $"{template.Name} category impact {categoryId}");
+            }
+
+            foreach (XElement impact in GetPopulationIncomeImpacts(template))
+            {
+                long populationId = long.Parse(impact.Attribute("population")!.Value, CultureInfo.InvariantCulture);
+                AssertPositiveExistingId(populationId, populationIds, $"{template.Name} population impact {populationId}");
+            }
+        }
+
+        foreach (MarketPopulation? population in context.MarketPopulations.OrderBy(x => x.Name))
+        {
+            XElement needs = XElement.Parse(population.MarketPopulationNeeds ?? "<Needs />");
+            foreach (XElement need in needs.Elements("Need"))
+            {
+                long categoryId = long.Parse(need.Attribute("category")!.Value, CultureInfo.InvariantCulture);
+                AssertPositiveExistingId(categoryId, categoryIds, $"{population.Name} need category {categoryId}");
+            }
+
+            XElement stressPoints = XElement.Parse(population.MarketStressPoints ?? "<Stresses />");
+            foreach (XElement stress in stressPoints.Elements("Stress"))
+            {
+                long onStartId = long.Parse(stress.Attribute("onstart")!.Value, CultureInfo.InvariantCulture);
+                long onEndId = long.Parse(stress.Attribute("onend")!.Value, CultureInfo.InvariantCulture);
+                AssertPositiveExistingId(onStartId, futureProgIds, $"{population.Name} stress start prog {onStartId}");
+                AssertPositiveExistingId(onEndId, futureProgIds, $"{population.Name} stress end prog {onEndId}");
+            }
+        }
+
+        foreach (Shopper? shopper in context.Shoppers.OrderBy(x => x.Name))
+        {
+            XElement definition = XElement.Parse(shopper.Definition);
+            foreach (string progElementName in new[] { "WillShopAtShopProg", "ShopSelectionWeightProg", "WillBuyItemProg", "ItemBuyWeightProg" })
+            {
+                long progId = long.Parse(definition.Element(progElementName)!.Value, CultureInfo.InvariantCulture);
+                AssertPositiveExistingId(progId, futureProgIds, $"{shopper.Name} {progElementName} {progId}");
+            }
         }
     }
 

--- a/DatabaseSeeder/Seeders/EconomySeeder.cs
+++ b/DatabaseSeeder/Seeders/EconomySeeder.cs
@@ -1774,6 +1774,8 @@ It is intended to be additive across eras and safe to rerun to restore or refres
             result[tag.Id] = category;
         }
 
+        context.SaveChanges();
+
         foreach (Tag tag in marketTags)
         {
             if (!ShouldSeedCombinationCategory(tag, childTagsByParentId))
@@ -2159,6 +2161,7 @@ It is intended to be additive across eras and safe to rerun to restore or refres
         }
 
         List<PopulationSeedContext> populations = new();
+        List<(PopulationBlueprint Blueprint, MarketPopulation Population, IReadOnlyList<StressPointValue> StressPoints, decimal ScaledBudget)> seededPopulations = new();
         foreach (PopulationBlueprint blueprint in era.Populations)
         {
             string populationName = PopulationName(era, blueprint);
@@ -2190,13 +2193,20 @@ It is intended to be additive across eras and safe to rerun to restore or refres
             population.MarketPopulationNeeds = SaveNeeds(scaledNeeds);
             population.MarketStressPoints = SaveStressPoints(stressProgs);
 
-            populations.Add(new PopulationSeedContext(
+            seededPopulations.Add((
                 blueprint,
-                population.Id,
-                populationName,
+                population,
                 stressProgs,
                 ResolvePopulationBudget(blueprint, scaledNeeds.Sum(x => x.BaseExpenditure))));
         }
+
+        context.SaveChanges();
+        populations.AddRange(seededPopulations.Select(x => new PopulationSeedContext(
+            x.Blueprint,
+            RequirePersistedId(x.Population.Id, $"market population {x.Population.Name}"),
+            x.Population.Name,
+            x.StressPoints,
+            x.ScaledBudget)));
 
         return new PopulationContext(populations);
     }
@@ -2312,7 +2322,7 @@ It is intended to be additive across eras and safe to rerun to restore or refres
         PopulationBlueprint blueprint,
         IEnumerable<StressTemplateContext> stressTemplates)
     {
-        List<StressPointValue> results = new();
+        List<(StressTemplateContext Template, FutureProg StartProg, FutureProg EndProg)> progReferences = new();
         string populationName = PopulationName(era, blueprint);
         foreach (StressTemplateContext? template in stressTemplates.OrderBy(x => x.Level.Threshold))
         {
@@ -2346,15 +2356,18 @@ It is intended to be additive across eras and safe to rerun to restore or refres
                 (ProgVariableTypes.Boolean, "rising"),
                 (ProgVariableTypes.Market, "market"));
 
-            results.Add(new StressPointValue(
-                template.Level.DisplayName,
-                $"{populationName} is {template.Level.DisplayName.ToLowerInvariant()}, curbing lower-priority demand while also depressing supply in the sectors that population normally sustains.",
-                template.Level.Threshold,
-                startProg.Id,
-                endProg.Id));
+            progReferences.Add((template, startProg, endProg));
         }
 
-        return results;
+        context.SaveChanges();
+        return progReferences
+            .Select(x => new StressPointValue(
+                x.Template.Level.DisplayName,
+                $"{populationName} is {x.Template.Level.DisplayName.ToLowerInvariant()}, curbing lower-priority demand while also depressing supply in the sectors that population normally sustains.",
+                x.Template.Level.Threshold,
+                RequirePersistedId(x.StartProg.Id, $"stress start prog {x.StartProg.FunctionName}"),
+                RequirePersistedId(x.EndProg.Id, $"stress end prog {x.EndProg.FunctionName}")))
+            .ToList();
     }
 
     private static void EnsureShoppers(
@@ -2365,12 +2378,18 @@ It is intended to be additive across eras and safe to rerun to restore or refres
         decimal shopperScale,
         SupportProgSet supportProgs)
     {
+        List<(PopulationSeedContext Population, FutureProg BuyProg, FutureProg ItemWeightProg)> shopperProgs = populationContext.Populations
+            .Select(population => (
+                population,
+                BuyProg: EnsurePopulationBuyProg(context, era, population.Blueprint),
+                ItemWeightProg: EnsurePopulationItemWeightProg(context, era, population.Blueprint)))
+            .ToList();
+        context.SaveChanges();
+
         int[] nextShopOffsets = new[] { 2, 6, 10, 14, 18 };
-        for (int index = 0; index < populationContext.Populations.Count; index++)
+        for (int index = 0; index < shopperProgs.Count; index++)
         {
-            PopulationSeedContext population = populationContext.Populations[index];
-            FutureProg buyProg = EnsurePopulationBuyProg(context, era, population.Blueprint);
-            FutureProg itemWeightProg = EnsurePopulationItemWeightProg(context, era, population.Blueprint);
+            (PopulationSeedContext population, FutureProg buyProg, FutureProg itemWeightProg) = shopperProgs[index];
             Shopper shopper = SeederRepeatabilityHelper.EnsureNamedEntity(
                 context.Shoppers,
                 ShopperName(era, population.Blueprint),
@@ -2402,10 +2421,10 @@ It is intended to be additive across eras and safe to rerun to restore or refres
                 0);
             shopper.Definition = new XElement("Shopper",
                 new XElement("BudgetPerShop", budget.ToString(CultureInfo.InvariantCulture)),
-                new XElement("WillShopAtShopProg", supportProgs.AcceptAnyShopProg.Id),
-                new XElement("ShopSelectionWeightProg", supportProgs.EqualShopWeightProg.Id),
-                new XElement("WillBuyItemProg", buyProg.Id),
-                new XElement("ItemBuyWeightProg", itemWeightProg.Id),
+                new XElement("WillShopAtShopProg", RequirePersistedId(supportProgs.AcceptAnyShopProg.Id, $"shopper support prog {supportProgs.AcceptAnyShopProg.FunctionName}")),
+                new XElement("ShopSelectionWeightProg", RequirePersistedId(supportProgs.EqualShopWeightProg.Id, $"shopper support prog {supportProgs.EqualShopWeightProg.FunctionName}")),
+                new XElement("WillBuyItemProg", RequirePersistedId(buyProg.Id, $"shopper buy prog {buyProg.FunctionName}")),
+                new XElement("ItemBuyWeightProg", RequirePersistedId(itemWeightProg.Id, $"shopper item-weight prog {itemWeightProg.FunctionName}")),
                 new XElement("SkipEmptyShops", true)).ToString();
         }
     }
@@ -2475,14 +2494,14 @@ It is intended to be additive across eras and safe to rerun to restore or refres
                 new XAttribute("demand", impact.DemandImpact.ToString(CultureInfo.InvariantCulture)),
                 new XAttribute("supply", impact.SupplyImpact.ToString(CultureInfo.InvariantCulture)),
                 new XAttribute("price", impact.FlatPriceImpact.ToString(CultureInfo.InvariantCulture)),
-                new XAttribute("category", impact.CategoryId)))).ToString();
+                new XAttribute("category", RequirePersistedId(impact.CategoryId, "market impact category"))))).ToString();
     }
 
     private static string SavePopulationImpacts(IEnumerable<PopulationIncomeImpactValue> impacts)
     {
         return new XElement("PopulationImpacts",
             impacts.Select(impact => new XElement("PopulationImpact",
-                new XAttribute("population", impact.PopulationId),
+                new XAttribute("population", RequirePersistedId(impact.PopulationId, "population income impact population")),
                 new XAttribute("additive", impact.AdditiveIncomeImpact.ToString(CultureInfo.InvariantCulture)),
                 new XAttribute("multiplier", impact.MultiplicativeIncomeImpact.ToString(CultureInfo.InvariantCulture))))).ToString();
     }
@@ -2509,7 +2528,7 @@ It is intended to be additive across eras and safe to rerun to restore or refres
     {
         return new XElement("Needs",
             needs.Select(need => new XElement("Need",
-                new XAttribute("category", need.CategoryId),
+                new XAttribute("category", RequirePersistedId(need.CategoryId, "market population need category")),
                 new XAttribute("expenditure", need.BaseExpenditure.ToString(CultureInfo.InvariantCulture))))).ToString();
     }
 
@@ -2561,7 +2580,7 @@ It is intended to be additive across eras and safe to rerun to restore or refres
 	{
 		return new XElement("Components",
 			components.Select(component => new XElement("Component",
-				new XAttribute("category", component.Category.Id),
+				new XAttribute("category", RequirePersistedId(component.Category.Id, $"combination component category {component.Category.Name}")),
 				new XAttribute("weight", component.Weight.ToString(CultureInfo.InvariantCulture))))).ToString();
 	}
 
@@ -2570,10 +2589,20 @@ It is intended to be additive across eras and safe to rerun to restore or refres
         return new XElement("Stresses",
             stressPoints.Select(point => new XElement("Stress",
                 new XAttribute("stress", point.Threshold.ToString(CultureInfo.InvariantCulture)),
-                new XAttribute("onstart", point.OnStartProgId),
-                new XAttribute("onend", point.OnEndProgId),
+                new XAttribute("onstart", RequirePersistedId(point.OnStartProgId, $"stress start prog for {point.Name}")),
+                new XAttribute("onend", RequirePersistedId(point.OnEndProgId, $"stress end prog for {point.Name}")),
                 new XAttribute("name", point.Name),
                 new XCData(point.Description)))).ToString();
+    }
+
+    private static long RequirePersistedId(long id, string description)
+    {
+        if (id > 0)
+        {
+            return id;
+        }
+
+        throw new InvalidOperationException($"Cannot serialize {description} before it has a database ID.");
     }
 
     private static string ResolveTopFamilyName(Tag tag, IReadOnlyDictionary<long, Tag> tagsById)

--- a/Design Documents/Economy/Economy_System_Seeder_State_and_Gaps.md
+++ b/Design Documents/Economy/Economy_System_Seeder_State_and_Gaps.md
@@ -58,6 +58,7 @@ Current prerequisites for `EconomySeeder` are:
 Current rerun behavior for `EconomySeeder` is additive and repair-friendly:
 
 - rerunning the same era refreshes stock-owned categories, templates, populations, shoppers, and helper progs without duplicating them
+- reruns also refresh stock-owned XML references for combination-category components, population stress progs, population-income impacts, and shopper behavior progs, so databases seeded with earlier placeholder ID references can be repaired in place
 - running a different era installs another stock package alongside the existing one
 - deleting a stock-owned asset and rerunning restores it if the canonical seeded name still belongs to the package
 


### PR DESCRIPTION
## Summary
- Save seeded market categories, stress progs, populations, and shopper progs before serializing their IDs into stock economy XML.
- Add guards so future seeder changes fail immediately if they try to persist placeholder IDs.
- Add regression coverage for stock economy XML references and document rerun repair behavior.

## Validation
- `dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore -m:1 --filter EconomySeederTests` (21/21 passed)
- `git diff --check` (passed; CRLF notices only)

## Note
- Full `DatabaseSeeder Unit Tests` currently has unrelated failures from a stale blank snapshot manifest and missing antiquity crafting design documents.