### PR TITLE
Add email registration bypass configuration

### DIFF
--- a/FutureMUDLibrary/Framework/DefaultStaticSettings.cs
+++ b/FutureMUDLibrary/Framework/DefaultStaticSettings.cs
@@ -699,6 +699,7 @@ public static class DefaultStaticSettings
             { "TemperatureImbalanceMaximumHyperthermiaKidneyPenalty", "0.85" },
             { "TemperatureImbalanceMaximumHyperthermiaLiverPenalty", "0.75" },
             { "UseSimpleAccountCreation", "false" },
+            { "DisableAccountRegistrationByEmail", "false" },
             { "DefaultAccountCulture", "en-UK" },
             { "DefaultAccountTimezone", "GMT Standard Time" },
             { "DefaultAccountUnitPreference", "Metric" },

--- a/MudSharpCore Unit Tests/AccountRegistrationConfigurationTests.cs
+++ b/MudSharpCore Unit Tests/AccountRegistrationConfigurationTests.cs
@@ -1,0 +1,84 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.CharacterCreation.Resources;
+using MudSharp.Framework;
+using MudSharp.Framework.Save;
+using RuntimeAccount = MudSharp.Accounts.Account;
+using DbAccount = MudSharp.Models.Account;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class AccountRegistrationConfigurationTests
+{
+	[TestMethod]
+	public void StaticDefaults_DisableAccountRegistrationByEmailDefaultsToFalse()
+	{
+		Assert.IsTrue(
+			DefaultStaticSettings.DefaultStaticConfigurations.ContainsKey(RuntimeAccount.DisableAccountRegistrationByEmailStaticConfiguration));
+		Assert.AreEqual(
+			"false",
+			DefaultStaticSettings.DefaultStaticConfigurations[RuntimeAccount.DisableAccountRegistrationByEmailStaticConfiguration]);
+	}
+
+	[TestMethod]
+	public void IsRegistered_WhenEmailRegistrationDisabled_TreatsUnregisteredAccountAsRegistered()
+	{
+		var account = CreateAccount(isRegistered: false, disableAccountRegistrationByEmail: true);
+
+		Assert.IsTrue(account.IsRegistered);
+	}
+
+	[TestMethod]
+	public void IsRegistered_WhenEmailRegistrationEnabled_UsesStoredRegistrationFlag()
+	{
+		var account = CreateAccount(isRegistered: false, disableAccountRegistrationByEmail: false);
+
+		Assert.IsFalse(account.IsRegistered);
+	}
+
+	[TestMethod]
+	public void IsRegistered_WhenStoredRegistered_RemainsRegistered()
+	{
+		var account = CreateAccount(isRegistered: true, disableAccountRegistrationByEmail: false);
+
+		Assert.IsTrue(account.IsRegistered);
+	}
+
+	private static RuntimeAccount CreateAccount(bool isRegistered, bool disableAccountRegistrationByEmail)
+	{
+		var gameworld = new Mock<IFuturemud>();
+		gameworld
+			.SetupGet(x => x.SaveManager)
+			.Returns(new Mock<ISaveManager>().Object);
+		gameworld
+			.Setup(x => x.ChargenResources)
+			.Returns(new All<IChargenResource>());
+		gameworld
+			.Setup(x => x.GetStaticBool(RuntimeAccount.DisableAccountRegistrationByEmailStaticConfiguration))
+			.Returns(disableAccountRegistrationByEmail);
+
+		var dbAccount = new DbAccount
+		{
+			Id = 1,
+			Name = "tester",
+			Email = "tester@example.com",
+			IsRegistered = isRegistered,
+			CultureName = "en-US",
+			TimeZoneId = "UTC",
+			UnitPreference = "Metric",
+			RegistrationCode = "ABCDEF",
+			CreationDate = System.DateTime.UtcNow,
+			FormatLength = 80,
+			InnerFormatLength = 80,
+			PageLength = 50,
+			ActLawfully = true,
+			HintsEnabled = true,
+			AutoReacquireTargets = true
+		};
+
+		return new RuntimeAccount(dbAccount, gameworld.Object);
+	}
+}

--- a/MudSharpCore/Accounts/Account.cs
+++ b/MudSharpCore/Accounts/Account.cs
@@ -17,6 +17,8 @@ namespace MudSharp.Accounts;
 
 public sealed class Account : SaveableItem, IAccount
 {
+    public const string DisableAccountRegistrationByEmailStaticConfiguration = "DisableAccountRegistrationByEmail";
+
     private static readonly object _creationMutex = new();
 
     private System.Globalization.CultureInfo _culture;
@@ -301,10 +303,27 @@ public sealed class Account : SaveableItem, IAccount
         }
     }
 
-    public bool IsRegistered { get; private set; }
+    private bool _isRegistered;
+
+    public bool IsRegistered
+    {
+        get => _isRegistered || AccountRegistrationByEmailDisabled(Gameworld);
+        private set => _isRegistered = value;
+    }
+
+    private static bool AccountRegistrationByEmailDisabled(IFuturemud gameworld)
+    {
+        return gameworld.GetStaticBool(DisableAccountRegistrationByEmailStaticConfiguration);
+    }
 
     public bool TryAccountRegistration(string text)
     {
+        if (AccountRegistrationByEmailDisabled(Gameworld))
+        {
+            IsRegistered = true;
+            return true;
+        }
+
         using (new FMDB())
         {
             Models.Account dbaccount = FMDB.Context.Accounts.Find(Id);
@@ -387,7 +406,7 @@ public sealed class Account : SaveableItem, IAccount
         Changed = false;
     }
 
-    public static bool Create(string name, string password, long salt, string culture, string timezone, bool unicode,
+    public static bool Create(IFuturemud gameworld, string name, string password, long salt, string culture, string timezone, bool unicode,
         int linewidth, string email, string unitPreference, string IP)
     {
         string nameLower = name.ToLowerInvariant().Trim();
@@ -401,6 +420,7 @@ public sealed class Account : SaveableItem, IAccount
                     return false;
                 }
 
+                var disableAccountRegistrationByEmail = AccountRegistrationByEmailDisabled(gameworld);
                 Models.Account newAccount = new()
                 {
                     Name = name.ToLowerInvariant(),
@@ -424,7 +444,7 @@ public sealed class Account : SaveableItem, IAccount
                     Email = email,
                     LastLoginTime = null,
                     LastLoginIp = null,
-                    IsRegistered = false,
+                    IsRegistered = disableAccountRegistrationByEmail,
                     RecoveryCode = null,
                     UnitPreference = unitPreference,
                     ActiveCharactersAllowed = 1,
@@ -433,8 +453,9 @@ public sealed class Account : SaveableItem, IAccount
                     HintsEnabled = true,
                     AutoReacquireTargets = true,
                     CreationDate = DateTime.UtcNow,
-                    RegistrationCode = SecurityUtilities.GetRandomString(8,
-                        Constants.ValidRandomCharacters.ToCharArray()),
+                    RegistrationCode = disableAccountRegistrationByEmail
+                        ? string.Empty
+                        : SecurityUtilities.GetRandomString(8, Constants.ValidRandomCharacters.ToCharArray()),
                     AuthorityGroup =
                         FMDB.Context.AuthorityGroups.First(x => x.AuthorityLevel == (int)PermissionLevel.Player),
                 };
@@ -446,8 +467,11 @@ public sealed class Account : SaveableItem, IAccount
                     FirstDate = newAccount.CreationDate
                 };
 
-                EmailHelper.Instance.SendEmail(EmailTemplateTypes.NewAccountVerification, email, name.Proper(),
-                    newAccount.RegistrationCode);
+                if (!disableAccountRegistrationByEmail)
+                {
+                    EmailHelper.Instance.SendEmail(EmailTemplateTypes.NewAccountVerification, email, name.Proper(),
+                        newAccount.RegistrationCode);
+                }
 
                 FMDB.Context.Accounts.Add(newAccount);
                 FMDB.Context.LoginIps.Add(ipLog);

--- a/MudSharpCore/Menus/MainMenu.cs
+++ b/MudSharpCore/Menus/MainMenu.cs
@@ -753,7 +753,7 @@ public class MainMenu : Menu, IController
 
     private void CreateAccount()
     {
-        bool newAccount = Account.Create(_accountName, _accountPassword, _accountSalt, _culture, _timezone, _unicode,
+        bool newAccount = Account.Create(Gameworld, _accountName, _accountPassword, _accountSalt, _culture, _timezone, _unicode,
             (int)_linewidth, _email, _unitPreference, AccountController.IPAddress);
 
         if (newAccount)


### PR DESCRIPTION
## Summary
- Add `DisableAccountRegistrationByEmail` static configuration with a default of `false`.
- Treat accounts as registered while the configuration is enabled, including newly created accounts.
- Skip new-account verification email sending when the bypass is enabled.
- Add focused tests for the default setting and runtime registration behavior.

## Validation
- `dotnet test "MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj" -c Debug --no-restore -m:1 --filter AccountRegistrationConfigurationTests -p:NoWarn=NU1902%3BNU1510`
- `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`