### PR TITLE
Improve magic school verb help

### DIFF
--- a/Design Documents/Magic/Magic_System_Powers.md
+++ b/Design Documents/Magic/Magic_System_Powers.md
@@ -60,10 +60,14 @@ At runtime:
 1. the engine checks whether the character has a capability whose school verb matches the command word
 2. `MagicGeneric` resolves the school or schools behind that verb
 3. the player can use:
+   - `<schoolverb>` for current status, resources, and sustained powers
    - `<schoolverb> powers`
    - `<schoolverb> help <powername>`
    - the concrete power verb itself
-4. the chosen power's `UseCommand` method executes the type-specific behavior
+   - `<schoolverb> spells`
+   - `<schoolverb> spell <spellname>` / `<schoolverb> spellhelp <spellname>`
+   - `<schoolverb> cast <spellname> <power> ...`
+4. for powers, the chosen power's `UseCommand` method executes the type-specific behavior; for spells, trigger-specific help supplies the remaining cast arguments
 
 ### What `MagicPowerBase` handles
 `MagicPowerBase` is the shared runtime and builder foundation for most powers.

--- a/MudSharpCore Unit Tests/MagicEngineV4Tests.cs
+++ b/MudSharpCore Unit Tests/MagicEngineV4Tests.cs
@@ -4,6 +4,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using MudSharp.Body.Traits;
 using MudSharp.Character;
+using MudSharp.Commands.Modules;
 using MudSharp.Construction;
 using MudSharp.Effects;
 using MudSharp.Effects.Concrete;
@@ -68,6 +69,22 @@ public class MagicEngineV4Tests
 			Assert.IsTrue(power.IsPsionic, $"{type} should load as psionic.");
 			CollectionAssert.Contains(power.Verbs.ToArray(), PrimaryVerb(type));
 		}
+	}
+
+	[TestMethod]
+	public void MagicModule_SchoolVerbHelpText_ListsFullPlayerCommandSurface()
+	{
+		var help = MagicModule.SchoolVerbHelpText("psi");
+
+		StringAssert.Contains(help, "You can use the following options with this magic command:");
+		StringAssert.Contains(help, "#3psi#0 - see your current status, resources and sustained powers");
+		StringAssert.Contains(help, "#3psi powers#0 - lists your powers");
+		StringAssert.Contains(help, "#3psi help <power>#0 - shows help for a power");
+		StringAssert.Contains(help, "#3psi <power command> [arguments]#0 - invokes a power");
+		StringAssert.Contains(help, "#3psi spells#0 - lists spells for this school");
+		StringAssert.Contains(help, "#3psi spell <spell>#0 - shows help for a spell");
+		StringAssert.Contains(help, "#3psi spellhelp <spell>#0 - shows help for a spell");
+		StringAssert.Contains(help, "#3psi cast <spell> <power> [arguments]#0 - casts a spell");
 	}
 
 	[TestMethod]

--- a/MudSharpCore/Commands/Modules/MagicModule.cs
+++ b/MudSharpCore/Commands/Modules/MagicModule.cs
@@ -56,8 +56,7 @@ public class MagicModule : Module<ICharacter>
 
         if (cmdText.EqualToAny("?", "help") && ss.IsFinished)
         {
-            actor.OutputHandler.Send(
-                $"You can use the {$"{invoked} powers".ColourCommand()} command to list all of your powers, {$"{invoked} help <powername>".ColourCommand()} to get help on the usage of a power, or {$"{invoked} <power command>".ColourCommand()} to invoke that power (see individual power help for the commands).");
+            actor.OutputHandler.Send(SchoolVerbHelpText(invoked).SubstituteANSIColour());
             return;
         }
 
@@ -188,6 +187,20 @@ public class MagicModule : Module<ICharacter>
         string verb = power.Verbs.FirstOrDefault(x => x.EqualTo(cmdText)) ??
                    power.Verbs.First(x => x.StartsWith(cmdText, StringComparison.InvariantCultureIgnoreCase));
         power.UseCommand(actor, verb, ss);
+    }
+
+    public static string SchoolVerbHelpText(string invoked)
+    {
+        return @$"You can use the following options with this magic command:
+
+	#3{invoked}#0 - see your current status, resources and sustained powers
+	#3{invoked} powers#0 - lists your powers
+	#3{invoked} help <power>#0 - shows help for a power
+	#3{invoked} <power command> [arguments]#0 - invokes a power; see individual power help for the syntax
+	#3{invoked} spells#0 - lists spells for this school
+	#3{invoked} spell <spell>#0 - shows help for a spell
+	#3{invoked} spellhelp <spell>#0 - shows help for a spell
+	#3{invoked} cast <spell> <power> [arguments]#0 - casts a spell; see individual spell help for target syntax";
     }
 
     private static void MagicStatus(ICharacter actor, IMagicSchool school)


### PR DESCRIPTION
## Summary
- Expand player-facing school verb help to list the complete magic command surface
- Include status, powers, power help, power invocation, spells, spell help aliases, and casting syntax
- Update the magic powers design doc and add a focused regression test for the generated command list

## Validation
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 --filter MagicModule_SchoolVerbHelpText_ListsFullPlayerCommandSurface -p:NoWarn=NU1902%3BNU1510`
- `git diff --check -- 'MudSharpCore\Commands\Modules\MagicModule.cs' 'MudSharpCore Unit Tests\MagicEngineV4Tests.cs' 'Design Documents\Magic\Magic_System_Powers.md'`