### PR TITLE
Refactor spell effect show presentation

### DIFF
--- a/Design Documents/Magic/Magic_System_Spells.md
+++ b/Design Documents/Magic/Magic_System_Spells.md
@@ -170,6 +170,8 @@ At cast time:
 
 If all effects are instantaneous, the parent effect is not retained.
 
+In builder display, `magic spell show` presents target-side effects and caster-side effects as separate titled sections. Each effect owns its own builder-facing summary through `Show(ICharacter)`, which should return a compact multi-line description beginning with the effect name and followed by labelled rows for its configured values. `MagicSpell.Show` only numbers, indents, and wraps those returned lines; it must not parse packed one-line effect summaries.
+
 Some effects now also rely on trigger-supplied additional parameters:
 
 - `exit` from the `exit` and `characterexit` triggers
@@ -596,6 +598,7 @@ Recommended steps:
 Important implementation note:
 
 - `SpellEffectFactory` discovers effect registrations by scanning `IMagicSpellEffectTemplate` implementers and invoking static `RegisterFactory`
+- Effect `Show(ICharacter)` methods should use the shared spell-effect presentation helper to return effect-owned multi-line builder summaries. Keep labels and values in the concrete effect rather than encoding a single packed line for `MagicSpell.Show` to interpret.
 
 ### Design guidance
 - Use triggers to own invocation and targeting rules.

--- a/MudSharpCore/Magic/MagicSpell.cs
+++ b/MudSharpCore/Magic/MagicSpell.cs
@@ -1239,40 +1239,14 @@ public class MagicSpell : SaveableItem, IMagicSpell
         sb.AppendLine();
         sb.AppendLine(Description.SubstituteANSIColour().Wrap(actor.InnerLineFormatLength, "\t"));
         sb.AppendLine();
-        sb.AppendLine("Effects:");
+		AppendSpellEffectSection(sb, actor, "Effects", SpellEffects, School.PowerListColour);
         sb.AppendLine();
-        int i = 0;
-        if (SpellEffects.Any())
-        {
-            foreach (IMagicSpellEffectTemplate effect in SpellEffects)
-            {
-                sb.AppendLine($"\t{(++i).ToString("N0", actor)}) {effect.Show(actor)}");
-            }
-        }
-        else
-        {
-            sb.AppendLine("\tNone");
-        }
-
-        sb.AppendLine();
-        sb.AppendLine("Caster Effects:");
-        sb.AppendLine();
-        i = 0;
-        if (CasterSpellEffects.Any())
-        {
-            foreach (IMagicSpellEffectTemplate effect in CasterSpellEffects)
-            {
-                sb.AppendLine($"\t{(++i).ToString("N0", actor)}) {effect.Show(actor)}");
-            }
-        }
-        else
-        {
-            sb.AppendLine("\tNone");
-        }
+		AppendSpellEffectSection(sb, actor, "Caster Effects", CasterSpellEffects, School.PowerListColour);
 
         sb.AppendLine();
         sb.AppendLine("Casting Costs:");
         sb.AppendLine();
+        int i = 0;
         if (_castingCosts.Any())
         {
             foreach ((IMagicResource resource, ITraitExpression formula) in _castingCosts)
@@ -1309,6 +1283,47 @@ public class MagicSpell : SaveableItem, IMagicSpell
 
         return sb.ToString();
     }
+
+	private static void AppendSpellEffectSection(StringBuilder sb, ICharacter actor, string title,
+		IEnumerable<IMagicSpellEffectTemplate> effects, ANSIColour rulerColour)
+	{
+		sb.AppendLine(title.GetLineWithTitleInner(actor, rulerColour, Telnet.BoldWhite));
+		var effectList = effects.ToList();
+		if (effectList.Count == 0)
+		{
+			sb.AppendLine("\tNone");
+			return;
+		}
+
+		for (var i = 0; i < effectList.Count; i++)
+		{
+			AppendSpellEffectEntry(sb, actor, i + 1, effectList[i].Show(actor));
+			if (i < effectList.Count - 1)
+			{
+				sb.AppendLine();
+			}
+		}
+	}
+
+	internal static void AppendSpellEffectEntry(StringBuilder sb, ICharacter actor, int effectNumber,
+		string effectDescription)
+	{
+		var lines = (effectDescription ?? "Unknown".ColourError())
+			.SubstituteANSIColour()
+			.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None)
+			.Where(x => !string.IsNullOrWhiteSpace(x))
+			.ToList();
+		if (lines.Count == 0)
+		{
+			lines.Add("Unknown".ColourError());
+		}
+
+		sb.AppendLine($"\t{effectNumber.ToString("N0", actor)}) {lines[0].Trim()}");
+		foreach (var line in lines.Skip(1))
+		{
+			sb.AppendLine(line.Trim().Wrap(actor.InnerLineFormatLength, "\t   "));
+		}
+	}
 
     #endregion
 

--- a/MudSharpCore/Magic/SpellEffects/AstralProjectionSpellEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/AstralProjectionSpellEffect.cs
@@ -285,8 +285,22 @@ public class AstralProjectionSpellEffect : IMagicSpellEffectTemplate
 	public string Show(ICharacter actor)
 	{
 		var plane = Gameworld.Planes.Get(EffectivePlaneId());
-		return
-			$"AstralProjection [{FormKey.ColourCommand()}] Race {_race.Name.ColourName()}, Ethnicity {_ethnicity?.Name.ColourName() ?? "Auto".ColourValue()}, Gender {_gender?.DescribeEnum().ColourValue() ?? "Auto".ColourValue()}, Alias {(_alias ?? "auto").ColourCommand()}, Plane {(plane?.Name ?? $"#{EffectivePlaneId().ToString("N0", actor)}").ColourName()}, Anchor {_anchorPolicy.DescribeEnum().ColourValue()}, ProjectionEcho {DescribeEcho(_projectionEcho, DefaultProjectionEcho)}, AnchorEcho {DescribeEcho(_anchorEcho, DefaultAnchorEcho)}, AnchorRoomEcho {DescribeEcho(_anchorRoomEcho, DefaultAnchorRoomEcho)}, ProjectionRoomEcho {DescribeEcho(_projectionRoomEcho, DefaultProjectionRoomEcho)}, CollapseEcho {DescribeEcho(_collapseEcho, DefaultCollapseEcho)}, Backlash {DescribeEcho(_backlashEcho, string.Empty)}, SDescOverride {DescribeEcho(_projectionSDescOverride, string.Empty)}";
+		return SpellEffectPresentation.Describe(actor, "Astral Projection",
+			("Form Key", FormKey.ColourCommand()),
+			("Race", _race.Name.ColourName()),
+			("Ethnicity", _ethnicity?.Name.ColourName() ?? "Auto".ColourValue()),
+			("Gender", _gender?.DescribeEnum().ColourValue() ?? "Auto".ColourValue()),
+			("Alias", (_alias ?? "auto").ColourCommand()),
+			("Plane", (plane?.Name ?? $"#{EffectivePlaneId().ToString("N0", actor)}").ColourName()),
+			("Anchor Policy", _anchorPolicy.DescribeEnum().ColourValue()),
+			("Projection Echo", DescribeEcho(_projectionEcho, DefaultProjectionEcho)),
+			("Anchor Echo", DescribeEcho(_anchorEcho, DefaultAnchorEcho)),
+			("Anchor Room Echo", DescribeEcho(_anchorRoomEcho, DefaultAnchorRoomEcho)),
+			("Projection Room Echo", DescribeEcho(_projectionRoomEcho, DefaultProjectionRoomEcho)),
+			("Collapse Echo", DescribeEcho(_collapseEcho, DefaultCollapseEcho)),
+			("Backlash", DescribeEcho(_backlashEcho, string.Empty)),
+			("SDesc Override", DescribeEcho(_projectionSDescOverride, string.Empty))
+		);
 	}
 
 	public bool BuildingCommand(ICharacter actor, StringStack command)

--- a/MudSharpCore/Magic/SpellEffects/BlindnessEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/BlindnessEffect.cs
@@ -51,7 +51,7 @@ public class BlindnessEffect : IMagicSpellEffectTemplate
 
     public string Show(ICharacter actor)
     {
-        return "Blindness";
+        return SpellEffectPresentation.Describe(actor, "Blindness");
     }
 
     public bool IsInstantaneous => false;
@@ -139,7 +139,7 @@ public class RemoveBlindnessEffect : IMagicSpellEffectTemplate
 
     public string Show(ICharacter actor)
     {
-        return "Remove Blindness";
+        return SpellEffectPresentation.Describe(actor, "Remove Blindness");
     }
 
     public bool IsInstantaneous => true;

--- a/MudSharpCore/Magic/SpellEffects/BodyBackupSpellEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/BodyBackupSpellEffect.cs
@@ -191,8 +191,19 @@ public class BodyBackupSpellEffect : IMagicSpellEffectTemplate
 
 	public string Show(ICharacter actor)
 	{
-		return
-			$"BodyBackup [{FormKey.ColourCommand()}] Race {_race.Name.ColourName()}, Ethnicity {_ethnicity?.Name.ColourName() ?? "Auto".ColourValue()}, Gender {_gender?.DescribeEnum().ColourValue() ?? "Auto".ColourValue()}, Alias {(_alias ?? "auto").ColourCommand()}, Priority {_priority.ToString("N0", actor).ColourValue()}, Remains {_remainsContext.DescribeEnum().ColourValue()}, Consume {_consumeOnUse.ToColouredString()}, OldEcho {DescribeEcho(_oldLocationEcho, BodyBackupEffect.DefaultOldLocationEcho)}, NewEcho {DescribeEcho(_newLocationEcho, BodyBackupEffect.DefaultNewLocationEcho)}, SelfEcho {DescribeEcho(_selfEcho, BodyBackupEffect.DefaultSelfEcho)}";
+		return SpellEffectPresentation.Describe(actor, "Body Backup",
+			("Form Key", FormKey.ColourCommand()),
+			("Race", _race.Name.ColourName()),
+			("Ethnicity", _ethnicity?.Name.ColourName() ?? "Auto".ColourValue()),
+			("Gender", _gender?.DescribeEnum().ColourValue() ?? "Auto".ColourValue()),
+			("Alias", (_alias ?? "auto").ColourCommand()),
+			("Priority", _priority.ToString("N0", actor).ColourValue()),
+			("Remains", _remainsContext.DescribeEnum().ColourValue()),
+			("Consume On Use", _consumeOnUse.ToColouredString()),
+			("Old Body Echo", DescribeEcho(_oldLocationEcho, BodyBackupEffect.DefaultOldLocationEcho)),
+			("Backup Body Echo", DescribeEcho(_newLocationEcho, BodyBackupEffect.DefaultNewLocationEcho)),
+			("Self Echo", DescribeEcho(_selfEcho, BodyBackupEffect.DefaultSelfEcho))
+		);
 	}
 
 	public bool BuildingCommand(ICharacter actor, StringStack command)

--- a/MudSharpCore/Magic/SpellEffects/ChangeCharacteristicEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/ChangeCharacteristicEffect.cs
@@ -153,8 +153,10 @@ public class ChangeCharacteristicEffect : IMagicSpellEffectTemplate
     #region Building Commands
     public string Show(ICharacter actor)
     {
-        // A one-line description of the spell effect
-        return $"Change {WhichCharacteristic.Name.ColourValue()} to {CharacteristicValueTarget?.Name.ColourValue() ?? $"profile {CharacteristicProfileTarget?.Name.ColourValue() ?? "unknown".ColourError()}"}";
+        return SpellEffectPresentation.Describe(actor, "Change Characteristic",
+            ("Definition", WhichCharacteristic.Name.ColourValue()),
+            ("Value", CharacteristicValueTarget?.Name.ColourValue() ?? "None".ColourError()),
+            ("Profile", CharacteristicProfileTarget?.Name.ColourValue() ?? "None".ColourError()));
     }
 
     public const string HelpText = @"You can use the following options with this spell effect:

--- a/MudSharpCore/Magic/SpellEffects/CopyCloneSpellEffects.cs
+++ b/MudSharpCore/Magic/SpellEffects/CopyCloneSpellEffects.cs
@@ -241,8 +241,19 @@ public partial class CopySpellEffect : IMagicSpellEffectTemplate
 	public string Show(ICharacter actor)
 	{
 		var plane = Gameworld.Planes.Get(EffectivePlaneId());
-		return
-			$"CreateCopy [{FormKey.ColourCommand()}] Race {_race.Name.ColourName()}, Ethnicity {_ethnicity?.Name.ColourName() ?? "Auto".ColourValue()}, Gender {_gender?.DescribeEnum().ColourValue() ?? "Auto".ColourValue()}, Alias {(_alias ?? "auto").ColourCommand()}, Focusable {_playerFocusable.ToColouredString()}, Persistence {_persistencePolicy.DescribeEnum().ColourValue()}, Intangible {_intangible.ToColouredString()}, Plane {(plane?.Name ?? $"#{EffectivePlaneId().ToString("N0", actor)}").ColourName()}, CollapseEcho {DescribeEcho(_collapseEcho, DefaultCollapseEcho)}, Backlash {DescribeEcho(_backlashEcho, string.Empty)}";
+		return SpellEffectPresentation.Describe(actor, "Create Copy",
+			("Form Key", FormKey.ColourCommand()),
+			("Race", _race.Name.ColourName()),
+			("Ethnicity", _ethnicity?.Name.ColourName() ?? "Auto".ColourValue()),
+			("Gender", _gender?.DescribeEnum().ColourValue() ?? "Auto".ColourValue()),
+			("Alias", (_alias ?? "auto").ColourCommand()),
+			("Focusable", _playerFocusable.ToColouredString()),
+			("Persistence", _persistencePolicy.DescribeEnum().ColourValue()),
+			("Intangible", _intangible.ToColouredString()),
+			("Plane", (plane?.Name ?? $"#{EffectivePlaneId().ToString("N0", actor)}").ColourName()),
+			("Collapse Echo", DescribeEcho(_collapseEcho, DefaultCollapseEcho)),
+			("Backlash", DescribeEcho(_backlashEcho, string.Empty))
+		);
 	}
 
 	public bool BuildingCommand(ICharacter actor, StringStack command)
@@ -830,8 +841,17 @@ public class CloneSpellEffect : IMagicSpellEffectTemplate
 
 	public string Show(ICharacter actor)
 	{
-		return
-			$"CreateClone [{FormKey.ColourCommand()}] Race {_race.Name.ColourName()}, Ethnicity {_ethnicity?.Name.ColourName() ?? "Auto".ColourValue()}, Gender {_gender?.DescribeEnum().ColourValue() ?? "Auto".ColourValue()}, Alias {(_alias ?? "auto").ColourCommand()}, Focusable {_playerFocusable.ToColouredString()}, Persistence {_persistencePolicy.DescribeEnum().ColourValue()}, DeathEcho {CopySpellEffect.DescribeEchoForClone(_deathEcho, DefaultDeathEcho)}, Backlash {CopySpellEffect.DescribeEchoForClone(_backlashEcho, string.Empty)}";
+		return SpellEffectPresentation.Describe(actor, "Create Clone",
+			("Form Key", FormKey.ColourCommand()),
+			("Race", _race.Name.ColourName()),
+			("Ethnicity", _ethnicity?.Name.ColourName() ?? "Auto".ColourValue()),
+			("Gender", _gender?.DescribeEnum().ColourValue() ?? "Auto".ColourValue()),
+			("Alias", (_alias ?? "auto").ColourCommand()),
+			("Focusable", _playerFocusable.ToColouredString()),
+			("Persistence", _persistencePolicy.DescribeEnum().ColourValue()),
+			("Death Echo", CopySpellEffect.DescribeEchoForClone(_deathEcho, DefaultDeathEcho)),
+			("Backlash", CopySpellEffect.DescribeEchoForClone(_backlashEcho, string.Empty))
+		);
 	}
 
 	public bool BuildingCommand(ICharacter actor, StringStack command)

--- a/MudSharpCore/Magic/SpellEffects/CreateItemEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/CreateItemEffect.cs
@@ -228,8 +228,12 @@ Parameters for quality formula:
 	#6outcome#0 - the outcome of the skill check 0 (Marginal) to 5 (Total)";
     public string Show(ICharacter actor)
     {
-        return
-            $"CreateItem - {Quantity.ToStringN0(actor)}x {ItemPrototype?.EditHeaderColour(actor) ?? "nothing".ColourError()}, Quality: {ItemQuality.OriginalExpression.ColourCommand()}, Load String: {LoadString.ColourCommand()}";
+        return SpellEffectPresentation.Describe(actor, "Create Item",
+            ("Prototype", ItemPrototype?.EditHeaderColour(actor) ?? "nothing".ColourError()),
+            ("Skin", ItemSkin?.EditHeader() ?? "None".ColourError()),
+            ("Quantity", Quantity.ToStringN0(actor).ColourValue()),
+            ("Quality", ItemQuality.OriginalExpression.ColourCommand()),
+            ("Load String", string.IsNullOrWhiteSpace(LoadString) ? "None".ColourError() : LoadString.ColourCommand()));
     }
 
     public bool BuildingCommand(ICharacter actor, StringStack command)

--- a/MudSharpCore/Magic/SpellEffects/CreateLiquidEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/CreateLiquidEffect.cs
@@ -173,8 +173,9 @@ Parameters for amount formula:
 
     public string Show(ICharacter actor)
     {
-        return
-            $"CreateLiquid - {AmountFormula.OriginalExpression.ColourCommand()}ml of {Liquid?.Name.Colour(Liquid.DisplayColour) ?? "nothing".ColourError()}";
+        return SpellEffectPresentation.Describe(actor, "Create Liquid",
+            ("Liquid", Liquid?.Name.Colour(Liquid.DisplayColour) ?? "nothing".ColourError()),
+            ("Amount", $"{AmountFormula.OriginalExpression} ml".ColourCommand()));
     }
 
     public bool BuildingCommand(ICharacter actor, StringStack command)

--- a/MudSharpCore/Magic/SpellEffects/CreateNPCEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/CreateNPCEffect.cs
@@ -138,8 +138,9 @@ class CreateNPCEffect : IMagicSpellEffectTemplate
 
     public string Show(ICharacter actor)
     {
-        return
-            $"CreateNPC - {NPCTemplate?.EditHeader() ?? "nothing".ColourError()} - OnLoad: {_onLoadProg?.MXPClickableFunctionName() ?? "none".ColourError()}";
+        return SpellEffectPresentation.Describe(actor, "Create NPC",
+            ("Template", NPCTemplate?.EditHeader() ?? "nothing".ColourError()),
+            ("On Load", _onLoadProg?.MXPClickableFunctionName() ?? "none".ColourError()));
     }
 
     public bool BuildingCommand(ICharacter actor, StringStack command)

--- a/MudSharpCore/Magic/SpellEffects/DamageEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/DamageEffect.cs
@@ -156,7 +156,10 @@ public class DamageEffect : IMagicSpellEffectTemplate
         string target = BodypartId != 0
             ? Gameworld.BodypartPrototypes.Get(BodypartId)?.Name ?? "none"
             : Limb != (LimbType)(-1) ? Limb.DescribeEnum() : "random";
-        return $"Damage {DamageType.DescribeEnum()} - {DamageExpression.OriginalFormulaText.ColourCommand()} target {target}";
+        return SpellEffectPresentation.Describe(actor, "Damage",
+            ("Type", DamageType.DescribeEnum().ColourValue()),
+            ("Formula", DamageExpression.OriginalFormulaText.ColourCommand()),
+            ("Target", target.ColourValue()));
     }
 
     public bool IsInstantaneous => true;

--- a/MudSharpCore/Magic/SpellEffects/DeafnessEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/DeafnessEffect.cs
@@ -49,7 +49,7 @@ public class DeafnessEffect : IMagicSpellEffectTemplate
 
     public string Show(ICharacter actor)
     {
-        return "Deafness";
+        return SpellEffectPresentation.Describe(actor, "Deafness");
     }
 
     public bool IsInstantaneous => false;

--- a/MudSharpCore/Magic/SpellEffects/DispelMagicEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/DispelMagicEffect.cs
@@ -503,6 +503,15 @@ public class DispelMagicEffect : IMagicSpellEffectTemplate
 
 	public string Show(ICharacter actor)
 	{
-		return $"DispelMagic - {Mode.DescribeEnum().ColourValue()} - Caster {CasterPolicy.DescribeEnum().ColourValue()} - Hostile {AllowHostile.ToColouredString()} - School #{SchoolId.ToString("N0", actor).ColourValue()} - Spell #{SpellId.ToString("N0", actor).ColourValue()} - Tag {(string.IsNullOrWhiteSpace(Tag) ? "any".ColourValue() : $"{Tag}={TagValue}".ColourName())} - Effect {EffectKey.ColourCommand()} - Contest {Contest.ToColouredString()} ({ContestBonus.ToString("N0", actor).ColourValue()})";
+		return SpellEffectPresentation.Describe(actor, "Dispel Magic",
+			("Mode", Mode.DescribeEnum().ColourValue()),
+			("Caster Policy", CasterPolicy.DescribeEnum().ColourValue()),
+			("Allow Hostile", AllowHostile.ToColouredString()),
+			("School", $"#{SchoolId.ToString("N0", actor).ColourValue()}"),
+			("Spell", $"#{SpellId.ToString("N0", actor).ColourValue()}"),
+			("Tag", string.IsNullOrWhiteSpace(Tag) ? "any".ColourValue() : $"{Tag}={TagValue}".ColourName()),
+			("Effect Key", EffectKey.ColourCommand()),
+			("Contest", $"{Contest.ToColouredString()} ({ContestBonus.ToString("N0", actor).ColourValue()})")
+		);
 	}
 }

--- a/MudSharpCore/Magic/SpellEffects/ExecuteProgEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/ExecuteProgEffect.cs
@@ -97,7 +97,8 @@ public class ExecuteProgEffect : IMagicSpellEffectTemplate
 	#3prog <which>#0 - sets the prog to be executed";
     public string Show(ICharacter actor)
     {
-        return $"Execute Prog [{Prog?.MXPClickableFunctionName() ?? "None".ColourError()}]";
+        return SpellEffectPresentation.Describe(actor, "Execute Prog",
+            ("Prog", Prog?.MXPClickableFunctionName() ?? "None".ColourError()));
     }
 
     public bool BuildingCommand(ICharacter actor, StringStack command)

--- a/MudSharpCore/Magic/SpellEffects/ExitBarrierEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/ExitBarrierEffect.cs
@@ -70,7 +70,7 @@ public class ExitBarrierEffect : IMagicSpellEffectTemplate
 
 	public string Show(ICharacter actor)
 	{
-		return "Exit Barrier".ColourName();
+		return SpellEffectPresentation.Describe(actor, "Exit Barrier");
 	}
 
 	public bool BuildingCommand(ICharacter actor, StringStack command)

--- a/MudSharpCore/Magic/SpellEffects/ForcedExitMovementEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/ForcedExitMovementEffect.cs
@@ -107,7 +107,7 @@ public class ForcedExitMovementEffect : IMagicSpellEffectTemplate
 
 	public string Show(ICharacter actor)
 	{
-		return "Forced Exit Movement".ColourName();
+		return SpellEffectPresentation.Describe(actor, "Forced Exit Movement");
 	}
 
 	public bool BuildingCommand(ICharacter actor, StringStack command)

--- a/MudSharpCore/Magic/SpellEffects/GlowEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/GlowEffect.cs
@@ -183,8 +183,10 @@ Note: You can use {0} in the sdesc/desc addenda to have a light-level descriptio
 
     public string Show(ICharacter actor)
     {
-        return
-            $"GlowEffect - {GlowLuxPerPower.ToString("N3", actor)} lux - {SDescAddendum.Colour(GlowAddendumColour)} - {DescAddendum.Colour(GlowAddendumColour)}";
+        return SpellEffectPresentation.Describe(actor, "Glow",
+            ("Lux Per Power", $"{GlowLuxPerPower.ToString("N3", actor)} lux".ColourValue()),
+            ("Short Addendum", SDescAddendum.Colour(GlowAddendumColour)),
+            ("Description Addendum", DescAddendum.Colour(GlowAddendumColour)));
     }
 
     #endregion

--- a/MudSharpCore/Magic/SpellEffects/HealEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/HealEffect.cs
@@ -77,8 +77,10 @@ public class HealEffect : IMagicSpellEffectTemplate
     #region Implementation of IEditableItem
     public string Show(ICharacter actor)
     {
-        return
-            $"HealEffect - {HealingAmount.OriginalFormulaText.ColourCommand()} - {(HealWorstWoundsFirst ? "[WorstFirst]".Colour(Telnet.BoldYellow) : "[RandomTarget]".Colour(Telnet.Magenta))} {(HealOverflow ? "[Overflow]".Colour(Telnet.BoldGreen) : "[Single]".Colour(Telnet.BoldYellow))}";
+        return SpellEffectPresentation.Describe(actor, "Heal",
+            ("Amount", HealingAmount.OriginalFormulaText.ColourCommand()),
+            ("Targeting", (HealWorstWoundsFirst ? "Worst wounds first" : "Random wounds").ColourValue()),
+            ("Overflow", HealOverflow.ToColouredString()));
     }
 
     public const string HelpText = @"You can use the following options with this effect:

--- a/MudSharpCore/Magic/SpellEffects/HealingRateSpellEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/HealingRateSpellEffect.cs
@@ -104,7 +104,9 @@ public class HealingRateSpellEffect : IMagicSpellEffectTemplate
 
     public string Show(ICharacter actor)
     {
-        return $"HealingRate - x{Multiplier.ToString("N2", actor)} {(Stages >= 0 ? "+" : "")}{Stages}";
+        return SpellEffectPresentation.Describe(actor, "Healing Rate",
+            ("Multiplier", Multiplier.ToString("N2", actor).ColourValue()),
+            ("Difficulty Stages", Stages.ToBonusString(actor)));
     }
 
     public bool IsInstantaneous => false;

--- a/MudSharpCore/Magic/SpellEffects/InvisibilityEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/InvisibilityEffect.cs
@@ -136,7 +136,8 @@ public class InvisibilityEffect : IMagicSpellEffectTemplate
 
     public string Show(ICharacter actor)
     {
-        return $"Invisibility - Filter: {FilterProg?.MXPClickableFunctionName() ?? "None".Colour(Telnet.Red)}";
+        return SpellEffectPresentation.Describe(actor, "Invisibility",
+            ("Filter", FilterProg?.MXPClickableFunctionName() ?? "None".Colour(Telnet.Red)));
     }
 
     #endregion

--- a/MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs
+++ b/MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs
@@ -160,7 +160,11 @@ public class MagicTagEffect : IMagicSpellEffectTemplate, IMagicInterdictionTagPr
 
 	public string Show(ICharacter actor)
 	{
-		return $"MagicTag - {Tag.ColourName()} = {Value.ColourValue()} - Replace: {ReplaceExisting.ToColouredString()}";
+		return SpellEffectPresentation.Describe(actor, "Magic Tag",
+			("Tag", Tag.ColourName()),
+			("Value", Value.ColourValue()),
+			("Replace Existing", ReplaceExisting.ToColouredString())
+		);
 	}
 }
 
@@ -275,7 +279,10 @@ public class RemoveMagicTagEffect : IMagicSpellEffectTemplate
 
 	public string Show(ICharacter actor)
 	{
-		return $"RemoveMagicTag - {Tag.ColourName()} - Value: {(MatchValue ? Value.ColourValue() : "any".ColourValue())}";
+		return SpellEffectPresentation.Describe(actor, "Remove Magic Tag",
+			("Tag", Tag.ColourName()),
+			("Value", MatchValue ? Value.ColourValue() : "any".ColourValue())
+		);
 	}
 }
 
@@ -436,7 +443,12 @@ public class ItemDamageEffect : IMagicSpellEffectTemplate
 
 	public string Show(ICharacter actor)
 	{
-		return $"ItemDamage - {DamageType.DescribeEnum().ColourValue()} - Dmg {DamageFormula.OriginalExpression.ColourCommand()}";
+		return SpellEffectPresentation.Describe(actor, "Item Damage",
+			("Damage Type", DamageType.DescribeEnum().ColourValue()),
+			("Damage Formula", DamageFormula.OriginalExpression.ColourCommand()),
+			("Pain Formula", PainFormula.OriginalExpression.ColourCommand()),
+			("Stun Formula", StunFormula.OriginalExpression.ColourCommand())
+		);
 	}
 }
 
@@ -525,7 +537,9 @@ public class DestroyItemEffect : IMagicSpellEffectTemplate
 
 	public string Show(ICharacter actor)
 	{
-		return $"DestroyItem - Respect Warnings: {RespectPurgeWarnings.ToColouredString()}";
+		return SpellEffectPresentation.Describe(actor, "Destroy Item",
+			("Respect Purge Warnings", RespectPurgeWarnings.ToColouredString())
+		);
 	}
 }
 
@@ -899,7 +913,20 @@ public class ItemEnchantEffect : IMagicSpellEffectTemplate
 
 	public string Show(ICharacter actor)
 	{
-		return $"ItemEnchant - {SDescAddendum.Colour(Colour)} - Glow {GlowLux.ToString("N2", actor).ColourValue()} - Attack {AttackCheckBonus.ToBonusString(actor)} - Armour {ArmourDamageReduction.ToString("N2", actor).ColourValue()} - Projectile {ProjectileDamageBonus.ToBonusString(actor)} - Tool {ToolFitnessBonus.ToBonusString(actor)} - Power x{PowerProductionMultiplier.ToString("N2", actor).ColourValue()}";
+		return SpellEffectPresentation.Describe(actor, "Item Enchant",
+			("SDesc Addendum", SDescAddendum.Colour(Colour)),
+			("Desc Addendum", DescAddendum.Colour(Colour)),
+			("Glow Lux", GlowLux.ToString("N2", actor).ColourValue()),
+			("Attack Check", AttackCheckBonus.ToBonusString(actor)),
+			("Item Damage", $"Quality {QualityBonus.ToBonusString(actor)}, Damage {DamageBonus.ToBonusString(actor)}, Pain {PainBonus.ToBonusString(actor)}, Stun {StunBonus.ToBonusString(actor)}"),
+			("Armour Reduction", ArmourDamageReduction.ToString("N2", actor).ColourValue()),
+			("Projectile Damage", $"Quality {ProjectileQualityBonus.ToBonusString(actor)}, Damage {ProjectileDamageBonus.ToBonusString(actor)}, Pain {ProjectilePainBonus.ToBonusString(actor)}, Stun {ProjectileStunBonus.ToBonusString(actor)}"),
+			("Tool Use", $"Fitness {ToolFitnessBonus.ToBonusString(actor)}, Speed x{ToolSpeedMultiplier.ToString("N2", actor).ColourValue()}, Usage x{ToolUsageMultiplier.ToString("N2", actor).ColourValue()}"),
+			("Power", $"Production x{PowerProductionMultiplier.ToString("N2", actor).ColourValue()}, Consumption x{PowerConsumptionMultiplier.ToString("N2", actor).ColourValue()}, Fuel x{FuelUseMultiplier.ToString("N2", actor).ColourValue()}"),
+			("Item Event", ItemEventType?.DescribeEnum().ColourValue() ?? "None".ColourError()),
+			("Item Event Prog", ItemEventProg?.MXPClickableFunctionName() ?? "None".ColourError()),
+			("Applicability Prog", ApplicabilityProg?.MXPClickableFunctionName() ?? "None".ColourError())
+		);
 	}
 }
 
@@ -1017,7 +1044,7 @@ public class CorpsePreserveEffect : IMagicSpellEffectTemplate
 	}
 
 	public bool BuildingCommand(ICharacter actor, StringStack command) => false;
-	public string Show(ICharacter actor) => "CorpsePreserve";
+	public string Show(ICharacter actor) => SpellEffectPresentation.Describe(actor, "Corpse Preserve");
 }
 
 public class CorpseConsumeEffect : IMagicSpellEffectTemplate
@@ -1067,7 +1094,7 @@ public class CorpseConsumeEffect : IMagicSpellEffectTemplate
 
 	public IMagicSpellEffectTemplate Clone() => new CorpseConsumeEffect(SaveToXml(), Spell);
 	public bool BuildingCommand(ICharacter actor, StringStack command) => false;
-	public string Show(ICharacter actor) => "CorpseConsume";
+	public string Show(ICharacter actor) => SpellEffectPresentation.Describe(actor, "Corpse Consume");
 }
 
 public class CorpseSpawnEffect : IMagicSpellEffectTemplate
@@ -1243,7 +1270,12 @@ public class CorpseSpawnEffect : IMagicSpellEffectTemplate
 
 	public string Show(ICharacter actor)
 	{
-		return $"CorpseSpawn - NPC #{NPCPrototypeId.ToString("N0", actor)} Item #{ItemPrototypeId.ToString("N0", actor)} x{Quantity.ToString("N0", actor)} Consume: {ConsumeCorpse.ToColouredString()}";
+		return SpellEffectPresentation.Describe(actor, "Corpse Spawn",
+			("NPC Prototype", $"#{NPCPrototypeId.ToString("N0", actor).ColourValue()}"),
+			("Item Prototype", $"#{ItemPrototypeId.ToString("N0", actor).ColourValue()}"),
+			("Quantity", Quantity.ToString("N0", actor).ColourValue()),
+			("Consume Corpse", ConsumeCorpse.ToColouredString())
+		);
 	}
 }
 
@@ -1488,7 +1520,19 @@ public class PortalSpellEffect : IMagicSpellEffectTemplate
 
 	public string Show(ICharacter actor)
 	{
-		return $"Portal - {Verb.ColourCommand()} {OutboundKeyword.ColourCommand()} - Cross Zone: {AllowCrossZone.ToColouredString()} - Anchor {AnchorTag.ColourName()}={AnchorValue.ColourValue()}";
+		return SpellEffectPresentation.Describe(actor, "Portal",
+			("Verb", Verb.ColourCommand()),
+			("Outbound Keyword", OutboundKeyword.ColourCommand()),
+			("Inbound Keyword", InboundKeyword.ColourCommand()),
+			("Outbound Target", OutboundTarget.ColourCommand()),
+			("Inbound Target", InboundTarget.ColourCommand()),
+			("Outbound Description", OutboundDescription.ColourCommand()),
+			("Inbound Description", InboundDescription.ColourCommand()),
+			("Time Multiplier", TimeMultiplier.ToString("N2", actor).ColourValue()),
+			("Allow Cross Zone", AllowCrossZone.ToColouredString()),
+			("Anchor", $"{AnchorTag.ColourName()}={AnchorValue.ColourValue()}"),
+			("Destination Prog", DestinationProg?.MXPClickableFunctionName() ?? "None".ColourError())
+		);
 	}
 }
 
@@ -1597,7 +1641,9 @@ public class ForceCommandEffect : IMagicSpellEffectTemplate
 		return true;
 	}
 
-	public string Show(ICharacter actor) => $"ForceCommand - {Command.ColourCommand()}";
+	public string Show(ICharacter actor) => SpellEffectPresentation.Describe(actor, "Force Command",
+		("Command", Command.ColourCommand())
+	);
 }
 
 public class SubjectiveDescriptionEffect : IMagicSpellEffectTemplate
@@ -1759,6 +1805,13 @@ public class SubjectiveDescriptionEffect : IMagicSpellEffectTemplate
 
 	public string Show(ICharacter actor)
 	{
-		return $"{EffectType} - Fixed Viewer: {FixedViewer.ToColouredString()} - Priority: {Priority.ToString("N0", actor).ColourValue()} - Key: {(string.IsNullOrWhiteSpace(OverrideKey) ? "none".ColourError() : OverrideKey.ColourValue())} - {Description.ColourValue()}";
+		return SpellEffectPresentation.Describe(actor,
+			DescriptionType == DescriptionType.Short ? "Subjective SDesc" : "Subjective Description",
+			("Fixed Viewer", FixedViewer.ToColouredString()),
+			("Priority", Priority.ToString("N0", actor).ColourValue()),
+			("Override Key", string.IsNullOrWhiteSpace(OverrideKey) ? "none".ColourError() : OverrideKey.ColourValue()),
+			("Applicability Prog", ApplicabilityProg?.MXPClickableFunctionName() ?? "None".ColourError()),
+			("Description", Description.ColourValue())
+		);
 	}
 }

--- a/MudSharpCore/Magic/SpellEffects/MagicResourceDeltaEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/MagicResourceDeltaEffect.cs
@@ -105,8 +105,9 @@ public class MagicResourceDeltaEffect : IMagicSpellEffectTemplate
 
 	public string Show(ICharacter actor)
 	{
-		return
-			$"Magic Resource Delta - {(Resource?.Name ?? "None".ColourError())} by {DeltaExpression.OriginalFormulaText.ColourCommand()}";
+		return SpellEffectPresentation.Describe(actor, "Magic Resource Delta",
+			("Resource", Resource?.Name.ColourValue() ?? "None".ColourError()),
+			("Formula", DeltaExpression.OriginalFormulaText.ColourCommand()));
 	}
 
 	public bool BuildingCommand(ICharacter actor, StringStack command)

--- a/MudSharpCore/Magic/SpellEffects/MagicalTetherEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/MagicalTetherEffect.cs
@@ -78,7 +78,8 @@ public class MagicalTetherEffect : IMagicSpellEffectTemplate
 
 	public string Show(ICharacter actor)
 	{
-		return $"MagicalTether {MaximumRooms.ToString("N0", actor).ColourValue()} rooms";
+		return SpellEffectPresentation.Describe(actor, "Magical Tether",
+			("Maximum Rooms", MaximumRooms.ToString("N0", actor).ColourValue()));
 	}
 
 	public bool IsInstantaneous => false;

--- a/MudSharpCore/Magic/SpellEffects/MendEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/MendEffect.cs
@@ -70,8 +70,10 @@ public class MendEffect : IMagicSpellEffectTemplate
     #region Implementation of IEditableItem
     public string Show(ICharacter actor)
     {
-        return
-            $"MendEffect - {HealingAmount.OriginalFormulaText.ColourCommand()} - {(HealWorstWoundsFirst ? "[WorstFirst]".Colour(Telnet.BoldYellow) : "[RandomTarget]".Colour(Telnet.Magenta))} {(HealOverflow ? "[Overflow]".Colour(Telnet.BoldGreen) : "[Single]".Colour(Telnet.BoldYellow))}";
+        return SpellEffectPresentation.Describe(actor, "Mend",
+            ("Amount", HealingAmount.OriginalFormulaText.ColourCommand()),
+            ("Targeting", (HealWorstWoundsFirst ? "Worst wounds first" : "Random wounds").ColourValue()),
+            ("Overflow", HealOverflow.ToColouredString()));
     }
 
     public const string HelpText = @"You can use the following options with this effect:

--- a/MudSharpCore/Magic/SpellEffects/NeedDeltaEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/NeedDeltaEffect.cs
@@ -131,7 +131,10 @@ public class NeedDeltaEffect : IMagicSpellEffectTemplate
 
     public string Show(ICharacter actor)
     {
-        return $"NeedDelta H:{HungerDelta.ToStringN2(actor)} T:{ThirstDelta.ToStringN2(actor)} D:{DrunkDelta.ToStringN2(actor)}";
+        return SpellEffectPresentation.Describe(actor, "Need Delta",
+            ("Hunger", HungerDelta.ToStringN2(actor).ColourValue()),
+            ("Thirst", ThirstDelta.ToStringN2(actor).ColourValue()),
+            ("Drunk", DrunkDelta.ToStringN2(actor).ColourValue()));
     }
 
     public bool IsInstantaneous => true;

--- a/MudSharpCore/Magic/SpellEffects/NeedRateSpellEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/NeedRateSpellEffect.cs
@@ -141,8 +141,12 @@ public class NeedRateSpellEffect : IMagicSpellEffectTemplate
 
     public string Show(ICharacter actor)
     {
-        string type = AppliesToPassive ? "Passive" : "Active";
-        return $"NeedRate {type} - H:{HungerMultiplier.ToStringP2(actor)} T:{ThirstMultiplier.ToStringP2(actor)} D:{DrunkennessMultiplier.ToStringP2(actor)}";
+        return SpellEffectPresentation.Describe(actor, "Need Rate",
+            ("Passive", AppliesToPassive.ToColouredString()),
+            ("Active", AppliesToActive.ToColouredString()),
+            ("Hunger", HungerMultiplier.ToStringP2(actor).ColourValue()),
+            ("Thirst", ThirstMultiplier.ToStringP2(actor).ColourValue()),
+            ("Drunk", DrunkennessMultiplier.ToStringP2(actor).ColourValue()));
     }
 
     public bool IsInstantaneous => false;

--- a/MudSharpCore/Magic/SpellEffects/PacifismSpellEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/PacifismSpellEffect.cs
@@ -78,7 +78,8 @@ public class PacifismSpellEffect : IMagicSpellEffectTemplate
 
     public string Show(ICharacter actor)
     {
-        return $"Pacifism - {Intensity.ToString("N2", actor)}";
+        return SpellEffectPresentation.Describe(actor, "Pacifism",
+            ("Intensity", Intensity.ToString("N2", actor).ColourValue()));
     }
 
     public bool IsInstantaneous => false;

--- a/MudSharpCore/Magic/SpellEffects/PersistentSensoryCombatSpellEffects.cs
+++ b/MudSharpCore/Magic/SpellEffects/PersistentSensoryCombatSpellEffects.cs
@@ -346,8 +346,17 @@ public class BurningEffect : IMagicSpellEffectTemplate
 
 	public string Show(ICharacter actor)
 	{
-		return
-			$"Burning - {DamageType.DescribeEnum().ColourValue()} - Dmg {DamageFormula.OriginalExpression.ColourCommand()} / Pain {PainFormula.OriginalExpression.ColourCommand()} / Stun {StunFormula.OriginalExpression.ColourCommand()} / Thermal {ThermalFormula.OriginalExpression.ColourCommand()} every {TickSeconds.ToString("N2", actor).ColourValue()}s";
+		return SpellEffectPresentation.Describe(actor, "Burning",
+			("Damage Type", DamageType.DescribeEnum().ColourValue()),
+			("Damage", DamageFormula.OriginalExpression.ColourCommand()),
+			("Pain", PainFormula.OriginalExpression.ColourCommand()),
+			("Stun", StunFormula.OriginalExpression.ColourCommand()),
+			("Thermal", ThermalFormula.OriginalExpression.ColourCommand()),
+			("Tick", $"{TickSeconds.ToString("N2", actor)}s".ColourValue()),
+			("Minimum Oxidation", MinimumOxidation.ToString("N2", actor).ColourValue()),
+			("Self Oxidising", SelfOxidising.ToColouredString()),
+			("Short Addendum", SDescAddendum.Colour(AddendumColour)),
+			("Description Addendum", DescAddendum.Colour(AddendumColour)));
 	}
 }
 
@@ -553,7 +562,12 @@ public class TrackMarkEffect : IMagicSpellEffectTemplate
 
 	public string Show(ICharacter actor)
 	{
-		return
-			$"TrackMark - Visual x{VisualTrackIntensityMultiplier.ToString("N2", actor).ColourValue()} +{VisualTrackIntensityBonus.ToString("N2", actor).ColourValue()} / Olfactory x{OlfactoryTrackIntensityMultiplier.ToString("N2", actor).ColourValue()} +{OlfactoryTrackIntensityBonus.ToString("N2", actor).ColourValue()} / Marked {MarkTracksMagical.ToColouredString()}";
+		return SpellEffectPresentation.Describe(actor, "Track Mark",
+			("Visual Multiplier", VisualTrackIntensityMultiplier.ToString("N2", actor).ColourValue()),
+			("Visual Bonus", VisualTrackIntensityBonus.ToString("N2", actor).ColourValue()),
+			("Olfactory Multiplier", OlfactoryTrackIntensityMultiplier.ToString("N2", actor).ColourValue()),
+			("Olfactory Bonus", OlfactoryTrackIntensityBonus.ToString("N2", actor).ColourValue()),
+			("Magical Tracks", MarkTracksMagical.ToColouredString()),
+			("Short Addendum", SDescAddendum.Colour(AddendumColour)));
 	}
 }

--- a/MudSharpCore/Magic/SpellEffects/PlanarStateSpellEffects.cs
+++ b/MudSharpCore/Magic/SpellEffects/PlanarStateSpellEffects.cs
@@ -108,7 +108,8 @@ public class PlanarStateSpellEffect : IMagicSpellEffectTemplate
 
 	public string Show(ICharacter actor)
 	{
-		return $"Planar State - {Definition.Describe(actor.Gameworld)}";
+		return SpellEffectPresentation.Describe(actor, _type.EqualTo("planeshift") ? "Plane Shift" : "Planar State",
+			("Definition", Definition.Describe(actor.Gameworld).ColourValue()));
 	}
 
 	public IMagicSpellEffect GetOrApplyEffect(ICharacter caster, IPerceivable target, OpposedOutcomeDegree outcome,
@@ -173,7 +174,7 @@ public class RemovePlanarStateSpellEffect : IMagicSpellEffectTemplate
 
 	public string Show(ICharacter actor)
 	{
-		return "Remove Planar State";
+		return SpellEffectPresentation.Describe(actor, "Remove Planar State");
 	}
 
 	public IMagicSpellEffect GetOrApplyEffect(ICharacter caster, IPerceivable target, OpposedOutcomeDegree outcome,

--- a/MudSharpCore/Magic/SpellEffects/PortalTopologySpellEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/PortalTopologySpellEffect.cs
@@ -325,6 +325,13 @@ public class PortalTopologySpellEffect : IMagicSpellEffectTemplate
 	public string Show(ICharacter actor)
 	{
 		var network = Gameworld.MagicPortalNetworks.Get(NetworkId);
-		return $"PortalNetwork - Network: {network?.Name.ColourName() ?? "None".ColourError()} - Key: {EndpointKey.ColourCommand()} - Anchor: {AnchorMode.DescribeEnum().ColourName()} - Link: {(string.IsNullOrWhiteSpace(LinkEndpointKey) ? "none" : LinkEndpointKey.ColourCommand())} - Replace: {ReplaceExisting.ToColouredString()} - Permanent: {Permanent.ToColouredString()}";
+		return SpellEffectPresentation.Describe(actor, "Portal Network",
+			("Network", network?.Name.ColourName() ?? "None".ColourError()),
+			("Endpoint Key", EndpointKey.ColourCommand()),
+			("Anchor", AnchorMode.DescribeEnum().ColourName()),
+			("Link", string.IsNullOrWhiteSpace(LinkEndpointKey) ? "none".ColourValue() : LinkEndpointKey.ColourCommand()),
+			("Replace Existing", ReplaceExisting.ToColouredString()),
+			("Permanent", Permanent.ToColouredString())
+		);
 	}
 }

--- a/MudSharpCore/Magic/SpellEffects/RageSpellEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/RageSpellEffect.cs
@@ -78,7 +78,9 @@ public class RageSpellEffect : IMagicSpellEffectTemplate
 
     public string Show(ICharacter actor)
     {
-        return $"Rage - {Intensity.ToString("N2", actor)}";
+        return SpellEffectPresentation.Describe(actor, "Rage",
+            ("Intensity", Intensity.ToString("N2", actor).ColourValue())
+        );
     }
 
     public bool IsInstantaneous => false;

--- a/MudSharpCore/Magic/SpellEffects/RelocateEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/RelocateEffect.cs
@@ -74,8 +74,10 @@ public class RelocateEffect : IMagicSpellEffectTemplate
     #region Implementation of IEditableItem
     public string Show(ICharacter actor)
     {
-        return
-            $"RelocateEffect - {HealingAmount.OriginalFormulaText.ColourCommand()} - {(HealWorstWoundsFirst ? "[WorstFirst]".Colour(Telnet.BoldYellow) : "[RandomTarget]".Colour(Telnet.Magenta))} {(HealOverflow ? "[Overflow]".Colour(Telnet.BoldGreen) : "[Single]".Colour(Telnet.BoldYellow))}";
+        return SpellEffectPresentation.Describe(actor, "Relocate",
+            ("Amount", HealingAmount.OriginalFormulaText.ColourCommand()),
+            ("Targeting", (HealWorstWoundsFirst ? "Worst wounds first" : "Easiest wounds first").ColourValue()),
+            ("Overflow", HealOverflow.ToColouredString()));
     }
 
     public const string HelpText = @"You can use the following options with this effect:

--- a/MudSharpCore/Magic/SpellEffects/ResurrectionEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/ResurrectionEffect.cs
@@ -105,8 +105,9 @@ public class ResurrectionEffect : IMagicSpellEffectTemplate
 
     public string Show(ICharacter actor)
     {
-        return
-            $"ResurrectEffect - Heal {HealWounds.ToColouredString()} - Restore Severs {RestoreSevers.ToColouredString()}";
+        return SpellEffectPresentation.Describe(actor, "Resurrect",
+            ("Heal Wounds", HealWounds.ToColouredString()),
+            ("Restore Severs", RestoreSevers.ToColouredString()));
     }
 
     #endregion

--- a/MudSharpCore/Magic/SpellEffects/RoomAtmosphereEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/RoomAtmosphereEffect.cs
@@ -149,7 +149,10 @@ public class RoomAtmosphereEffect : IMagicSpellEffectTemplate
 
     public string Show(ICharacter actor)
     {
-        return $"RoomAtmosphere {Atmosphere.Name.ColourValue()}";
+        return SpellEffectPresentation.Describe(actor, "Room Atmosphere",
+            ("Atmosphere", Atmosphere.Name.ColourValue()),
+            ("Type", (Atmosphere is IGas ? "Gas" : "Liquid").ColourValue()),
+            ("Description Addendum", string.IsNullOrWhiteSpace(DescAddendum) ? "None".ColourError() : DescAddendum.Colour(AddendumColour)));
     }
 
     public bool IsInstantaneous => false;

--- a/MudSharpCore/Magic/SpellEffects/RoomFlagEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/RoomFlagEffect.cs
@@ -161,12 +161,18 @@ public class RoomFlagEffect : RoomSpellEffectTemplateBase
 	{
 		return FlagType switch
 		{
-			RoomFlagKind.Peaceful => "Room Flag - Peaceful",
-			RoomFlagKind.NoDream => "Room Flag - NoDream",
-			RoomFlagKind.Alarm => $"Room Flag - Alarm [{AlarmEcho.ColourCommand()}]{(AlarmProg is null ? "" : $" ({AlarmProg.MXPClickableFunctionName()})")}",
-			RoomFlagKind.Darkness => $"Room Flag - Darkness [{DarknessLux.ToString("N2", actor).ColourValue()} lux]",
-			RoomFlagKind.WardTag => $"Room Flag - WardTag [{WardTag.ColourCommand()}]",
-			_ => "Room Flag - Unknown"
+			RoomFlagKind.Alarm => SpellEffectPresentation.Describe(actor, "Room Flag",
+				("Type", FlagType.DescribeEnum().ColourValue()),
+				("Echo", AlarmEcho.ColourCommand()),
+				("Prog", AlarmProg?.MXPClickableFunctionName() ?? "None".ColourError())),
+			RoomFlagKind.Darkness => SpellEffectPresentation.Describe(actor, "Room Flag",
+				("Type", FlagType.DescribeEnum().ColourValue()),
+				("Lux Penalty", $"{DarknessLux.ToString("N2", actor)} lux".ColourValue())),
+			RoomFlagKind.WardTag => SpellEffectPresentation.Describe(actor, "Room Flag",
+				("Type", FlagType.DescribeEnum().ColourValue()),
+				("Ward Tag", WardTag.ColourCommand())),
+			_ => SpellEffectPresentation.Describe(actor, "Room Flag",
+				("Type", FlagType.DescribeEnum().ColourValue()))
 		};
 	}
 
@@ -378,8 +384,11 @@ public class RemoveRoomFlagEffect : RoomSpellEffectTemplateBase
 	public override string Show(ICharacter actor)
 	{
 		return FlagType == RoomFlagKind.WardTag
-			? $"Remove Room Flag - WardTag [{WardTag.ColourCommand()}]"
-			: $"Remove Room Flag - {FlagType.DescribeEnum()}";
+			? SpellEffectPresentation.Describe(actor, "Remove Room Flag",
+				("Type", FlagType.DescribeEnum().ColourValue()),
+				("Ward Tag", WardTag.ColourCommand()))
+			: SpellEffectPresentation.Describe(actor, "Remove Room Flag",
+				("Type", FlagType.DescribeEnum().ColourValue()));
 	}
 
 	public override bool BuildingCommand(ICharacter actor, StringStack command)

--- a/MudSharpCore/Magic/SpellEffects/RoomGravityEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/RoomGravityEffect.cs
@@ -136,7 +136,9 @@ public class RoomGravityEffect : IMagicSpellEffectTemplate
 
 	public string Show(ICharacter actor)
 	{
-		return $"RoomGravity {GravityModel.DescribeColour()}";
+		return SpellEffectPresentation.Describe(actor, "Room Gravity",
+			("Gravity", GravityModel.DescribeColour()),
+			("Description Addendum", string.IsNullOrWhiteSpace(DescAddendum) ? "None".ColourError() : DescAddendum.Colour(AddendumColour)));
 	}
 
 	public bool IsInstantaneous => false;

--- a/MudSharpCore/Magic/SpellEffects/RoomLightEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/RoomLightEffect.cs
@@ -165,8 +165,9 @@ Note: You can use {0} in the desc addenda to have a light-level description (dim
 
     public string Show(ICharacter actor)
     {
-        return
-            $"RoomLightEffect - {AddedLuxPerPower.ToString("N3", actor)} lux - {DescAddendum.Colour(GlowAddendumColour)}";
+        return SpellEffectPresentation.Describe(actor, "Room Light",
+            ("Lux Per Power", $"{AddedLuxPerPower.ToString("N3", actor)} lux".ColourValue()),
+            ("Description Addendum", string.IsNullOrWhiteSpace(DescAddendum) ? "None".ColourError() : DescAddendum.Colour(GlowAddendumColour)));
     }
 
     #endregion

--- a/MudSharpCore/Magic/SpellEffects/RoomTemperatureEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/RoomTemperatureEffect.cs
@@ -168,8 +168,9 @@ public class RoomTemperatureEffect : IMagicSpellEffectTemplate
 
     public string Show(ICharacter actor)
     {
-        return
-            $"RoomTemperatureEffect - {TemperatureDeltaPerPower.ToString("N3", actor)} lux - {DescAddendum.Colour(AddendumColour)}";
+        return SpellEffectPresentation.Describe(actor, "Room Temperature",
+            ("Delta Per Power", Gameworld.UnitManager.DescribeBonus(TemperatureDeltaPerPower, Framework.Units.UnitType.TemperatureDelta, actor).ColourValue()),
+            ("Description Addendum", string.IsNullOrWhiteSpace(DescAddendum) ? "None".ColourError() : DescAddendum.Colour(AddendumColour)));
     }
 
     #endregion

--- a/MudSharpCore/Magic/SpellEffects/SelfDamageEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/SelfDamageEffect.cs
@@ -101,7 +101,9 @@ public class SelfDamageEffect : IMagicSpellEffectTemplate
 
     public string Show(ICharacter actor)
     {
-        return $"SelfDamage {DamageType.DescribeEnum()} - {DamageExpression.OriginalFormulaText.ColourCommand()}";
+        return SpellEffectPresentation.Describe(actor, "Self Damage",
+            ("Type", DamageType.DescribeEnum().ColourValue()),
+            ("Formula", DamageExpression.OriginalFormulaText.ColourCommand()));
     }
 
     public bool IsInstantaneous => true;

--- a/MudSharpCore/Magic/SpellEffects/SpellArmourEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/SpellArmourEffect.cs
@@ -83,7 +83,9 @@ public class SpellArmourEffect : CharacterSpellEffectTemplateBase
 
 	public override string Show(ICharacter actor)
 	{
-		return $"Spell Armour - {ArmourConfiguration.Show(actor)}";
+		return SpellEffectPresentation.Describe(actor, "Spell Armour",
+			("Configuration", ArmourConfiguration.Show(actor))
+		);
 	}
 
 	public override bool BuildingCommand(ICharacter actor, StringStack command)

--- a/MudSharpCore/Magic/SpellEffects/SpellEffectPresentation.cs
+++ b/MudSharpCore/Magic/SpellEffects/SpellEffectPresentation.cs
@@ -1,0 +1,31 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Framework;
+using System;
+using System.Linq;
+using System.Text;
+
+namespace MudSharp.Magic.SpellEffects;
+
+internal static class SpellEffectPresentation
+{
+	public static string Describe(ICharacter actor, string title, params (string Label, string Value)[] rows)
+	{
+		var sb = new StringBuilder();
+		sb.AppendLine(title.ColourName());
+		foreach (var row in rows.Where(x => !string.IsNullOrWhiteSpace(x.Label)))
+		{
+			var valueLines = row.Value
+				.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None)
+				.ToList();
+			sb.AppendLine($"\t{row.Label}: {valueLines.FirstOrDefault()?.TrimEnd()}");
+			foreach (var line in valueLines.Skip(1))
+			{
+				sb.AppendLine($"\t\t{line.TrimEnd()}");
+			}
+		}
+
+		return sb.ToString().TrimEnd('\r', '\n');
+	}
+}

--- a/MudSharpCore/Magic/SpellEffects/StaminaDeltaSpellEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/StaminaDeltaSpellEffect.cs
@@ -73,7 +73,8 @@ public class StaminaDeltaSpellEffect : IMagicSpellEffectTemplate
 
     public string Show(ICharacter actor)
     {
-        return $"StaminaDelta {AmountExpression.OriginalFormulaText}";
+        return SpellEffectPresentation.Describe(actor, "Stamina Delta",
+            ("Formula", AmountExpression.OriginalFormulaText.ColourCommand()));
     }
 
     public bool IsInstantaneous => true;

--- a/MudSharpCore/Magic/SpellEffects/StaminaExpenditureSpellEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/StaminaExpenditureSpellEffect.cs
@@ -67,7 +67,8 @@ public class StaminaExpenditureSpellEffect : IMagicSpellEffectTemplate
 
     public string Show(ICharacter actor)
     {
-        return $"StaminaExpendRate x{Multiplier.ToStringP2(actor)}";
+        return SpellEffectPresentation.Describe(actor, "Stamina Expenditure Rate",
+            ("Multiplier", Multiplier.ToStringP2(actor).ColourValue()));
     }
 
     public bool IsInstantaneous => false;

--- a/MudSharpCore/Magic/SpellEffects/StaminaRegenRateSpellEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/StaminaRegenRateSpellEffect.cs
@@ -67,7 +67,8 @@ public class StaminaRegenRateSpellEffect : IMagicSpellEffectTemplate
 
     public string Show(ICharacter actor)
     {
-        return $"StaminaRegenRate x{Multiplier.ToStringP2(actor)}";
+        return SpellEffectPresentation.Describe(actor, "Stamina Regen Rate",
+            ("Multiplier", Multiplier.ToStringP2(actor).ColourValue()));
     }
 
     public bool IsInstantaneous => false;

--- a/MudSharpCore/Magic/SpellEffects/StandaloneStatusSpellEffects.Configured.cs
+++ b/MudSharpCore/Magic/SpellEffects/StandaloneStatusSpellEffects.Configured.cs
@@ -46,6 +46,14 @@ public class PoisonEffect : CharacterSpellEffectTemplateBase
 	protected override string ShowText =>
 		$"Poison - {(Drug?.Name ?? "None")} via {Vector.Describe()} at {GramsExpression.OriginalFormulaText}";
 
+	public override string Show(ICharacter actor)
+	{
+		return SpellEffectPresentation.Describe(actor, "Poison",
+			("Drug", (Drug?.Name ?? "None").ColourValue()),
+			("Vector", Vector.Describe().ColourValue()),
+			("Grams", GramsExpression.OriginalFormulaText.ColourCommand()));
+	}
+
 	protected override void LoadFromXml(XElement root)
 	{
 		XElement? drugElement = root.Element("Drug");
@@ -199,6 +207,14 @@ public class RemovePoisonEffect : CharacterSpellEffectRemovalTemplateBase
 	protected override string BuilderEffectType => "removepoison";
 	protected override string ShowText => $"Remove Poison - {(Drug?.Name ?? "None")} via {Vector.Describe()} at {FormulaText}";
 
+	public override string Show(ICharacter actor)
+	{
+		return SpellEffectPresentation.Describe(actor, "Remove Poison",
+			("Drug", (Drug?.Name ?? "None").ColourValue()),
+			("Vector", Vector.Describe().ColourValue()),
+			("Formula", FormulaText.ColourCommand()));
+	}
+
 	protected override void LoadFromXml(XElement root)
 	{
 		XElement? drugElement = root.Element("Drug");
@@ -341,6 +357,15 @@ public class DiseaseEffect : CharacterSpellEffectTemplateBase
 	protected override string BuilderEffectType => "disease";
 	protected override string ShowText =>
 		$"Disease - {InfectionType.Describe()} @ {VirulenceDifficulty.DescribeEnum()} intensity {IntensityExpression.OriginalFormulaText} virulence {VirulenceExpression.OriginalFormulaText}";
+
+	public override string Show(ICharacter actor)
+	{
+		return SpellEffectPresentation.Describe(actor, "Disease",
+			("Type", InfectionType.Describe().ColourValue()),
+			("Virulence Difficulty", VirulenceDifficulty.DescribeEnum().ColourValue()),
+			("Intensity", IntensityExpression.OriginalFormulaText.ColourCommand()),
+			("Virulence", VirulenceExpression.OriginalFormulaText.ColourCommand()));
+	}
 
 	protected override void LoadFromXml(XElement root)
 	{
@@ -508,6 +533,15 @@ public class RemoveDiseaseEffect : CharacterSpellEffectRemovalTemplateBase
 	protected override string BuilderEffectType => "removedisease";
 	protected override string ShowText =>
 		$"Remove Disease - {InfectionType.Describe()} @ {VirulenceDifficulty.DescribeEnum()} intensity {IntensityFormulaText} virulence {VirulenceFormulaText}";
+
+	public override string Show(ICharacter actor)
+	{
+		return SpellEffectPresentation.Describe(actor, "Remove Disease",
+			("Type", InfectionType.Describe().ColourValue()),
+			("Virulence Difficulty", VirulenceDifficulty.DescribeEnum().ColourValue()),
+			("Intensity", IntensityFormulaText.ColourCommand()),
+			("Virulence", VirulenceFormulaText.ColourCommand()));
+	}
 
 	protected override void LoadFromXml(XElement root)
 	{

--- a/MudSharpCore/Magic/SpellEffects/StandaloneStatusSpellEffects.cs
+++ b/MudSharpCore/Magic/SpellEffects/StandaloneStatusSpellEffects.cs
@@ -101,7 +101,7 @@ public abstract class CharacterSpellEffectTemplateBase : IMagicSpellEffectTempla
 
 	public virtual string Show(ICharacter actor)
 	{
-		return ShowText;
+		return SpellEffectPresentation.Describe(actor, ShowText);
 	}
 
 	public bool IsCompatibleWithTrigger(IMagicTrigger trigger)

--- a/MudSharpCore/Magic/SpellEffects/TagWardSpellEffects.cs
+++ b/MudSharpCore/Magic/SpellEffects/TagWardSpellEffects.cs
@@ -68,8 +68,12 @@ public abstract class TagWardSpellEffectBase : IMagicSpellEffectTemplate
 
 	public string Show(ICharacter actor)
 	{
-		return
-			$"{EffectName.ColourName()} - {Tag.ColourValue()}{(MatchValue ? $"={Value.ColourValue()}" : "")} - {Coverage.DescribeEnum().ColourValue()} - {Mode.DescribeEnum().ColourValue()} - Prog: {Prog?.MXPClickableFunctionName() ?? "None".ColourError()}";
+		return SpellEffectPresentation.Describe(actor, EffectName,
+			("Tag", Tag.ColourValue()),
+			("Value", MatchValue ? Value.ColourValue() : "Any".ColourValue()),
+			("Coverage", Coverage.DescribeEnum().ColourValue()),
+			("Mode", Mode.DescribeEnum().ColourValue()),
+			("Prog", Prog?.MXPClickableFunctionName() ?? "None".ColourError()));
 	}
 
 	public bool BuildingCommand(ICharacter actor, StringStack command)

--- a/MudSharpCore/Magic/SpellEffects/TelepathySpellEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/TelepathySpellEffect.cs
@@ -88,7 +88,11 @@ public class TelepathySpellEffect : IMagicSpellEffectTemplate
 
     public string Show(ICharacter actor)
     {
-        return $"Telepathy {(ShowThinks ? "[Thinks]" : "")} {(ShowFeels ? "[Feels]" : "")} {(ShowEmote ? "[Emote]" : "")}";
+        return SpellEffectPresentation.Describe(actor, "Telepathy",
+            ("Thinks", ShowThinks.ToColouredString()),
+            ("Feels", ShowFeels.ToColouredString()),
+            ("Emotes", ShowEmote.ToColouredString())
+        );
     }
 
     public bool IsInstantaneous => false;

--- a/MudSharpCore/Magic/SpellEffects/TeleportEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/TeleportEffect.cs
@@ -102,8 +102,10 @@ public class TeleportEffect : IMagicSpellEffectTemplate
     #region Implementation of IEditableItem
     public string Show(ICharacter actor)
     {
-        return
-            $"Teleport {(TeleportParty ? "Self and Party".ColourCharacter() : "Self".ColourCharacter())} {(PreserveLayer ? "to same layer" : $"to {TargetLayer.DescribeEnum()}").ColourName()}";
+        return SpellEffectPresentation.Describe(actor, "Teleport",
+            ("Targets", TeleportParty ? "Self and Party".ColourCharacter() : "Self".ColourCharacter()),
+            ("Layer", PreserveLayer ? "Same Layer".ColourName() : TargetLayer.DescribeEnum().ColourName())
+        );
     }
 
     public const string HelpText = @"You can use the following options with this effect:

--- a/MudSharpCore/Magic/SpellEffects/TeleportTargetEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/TeleportTargetEffect.cs
@@ -103,8 +103,10 @@ public class TeleportTargetEffect : IMagicSpellEffectTemplate
     #region Implementation of IEditableItem
     public string Show(ICharacter actor)
     {
-        return
-            $"Teleport {(TeleportParty ? "Target and Party".ColourCharacter() : "Target".ColourCharacter())} {(PreserveLayer ? "to same layer" : $"to {TargetLayer.DescribeEnum()}").ColourName()}";
+        return SpellEffectPresentation.Describe(actor, "Teleport Target",
+            ("Targets", TeleportParty ? "Target and Party".ColourCharacter() : "Target".ColourCharacter()),
+            ("Layer", PreserveLayer ? "Same Layer".ColourName() : TargetLayer.DescribeEnum().ColourName())
+        );
     }
 
     public const string HelpText = @"You can use the following options with this effect:

--- a/MudSharpCore/Magic/SpellEffects/TraitBoostEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/TraitBoostEffect.cs
@@ -138,8 +138,10 @@ public class TraitBoostEffect : IMagicSpellEffectTemplate
 
     public string Show(ICharacter actor)
     {
-        return
-            $"TraitBoostEffect - {Trait?.Name.ColourValue() ?? "None".ColourError()} {Bonus.ToBonusString(actor)} (context: {TraitBonusContext.DescribeEnum().ColourValue()})";
+        return SpellEffectPresentation.Describe(actor, "Trait Boost",
+            ("Trait", Trait?.Name.ColourValue() ?? "None".ColourError()),
+            ("Bonus", Bonus.ToBonusString(actor)),
+            ("Context", TraitBonusContext.DescribeEnum().ColourValue()));
     }
 
     #region Implementation of IMagicSpellEffectTemplate

--- a/MudSharpCore/Magic/SpellEffects/TransformFormEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/TransformFormEffect.cs
@@ -229,13 +229,27 @@ public class TransformFormEffect : IMagicSpellEffectTemplate
 
 	public string Show(ICharacter actor)
 	{
-		return
-			$"TransformForm [{FormKey.ColourCommand()}] Race {_race?.Name.ColourName() ?? "None".ColourError()}, Ethnicity {_ethnicity?.Name.ColourName() ?? "Auto".ColourValue()}, Gender {_gender?.DescribeEnum().ColourValue() ?? "Auto".ColourValue()}, Alias {(_alias ?? "auto").ColourCommand()}, Trauma {_traumaMode.DescribeEnum().ColourValue()}, Echo {(_transformationEcho switch
+		return SpellEffectPresentation.Describe(actor, "Transform Form",
+			("Form Key", FormKey.ColourCommand()),
+			("Race", _race?.Name.ColourName() ?? "None".ColourError()),
+			("Ethnicity", _ethnicity?.Name.ColourName() ?? "Auto".ColourValue()),
+			("Gender", _gender?.DescribeEnum().ColourValue() ?? "Auto".ColourValue()),
+			("Alias", (_alias ?? "auto").ColourCommand()),
+			("Trauma", _traumaMode.DescribeEnum().ColourValue()),
+			("Echo", _transformationEcho switch
 			{
 				null => "Default".ColourValue(),
 				"" => "Suppressed".ColourError(),
 				_ => _transformationEcho.ColourCommand()
-			})}, Voluntary {_allowVoluntarySwitch.ToColouredString()}, CanProg {_canVoluntarilySwitchProg?.MXPClickableFunctionName() ?? "None".ColourError()}, WhyCant {_whyCannotVoluntarilySwitchProg?.MXPClickableFunctionName() ?? "None".ColourError()}, Visible {_canSeeFormProg?.MXPClickableFunctionName() ?? "None".ColourError()}, Priority {_priorityBand.DescribeEnum().ColourValue()} {_priorityOffset.ToString("+#;-#;0", actor).ColourValue()}, SDesc {_shortDescriptionPattern?.Pattern.ColourCommand() ?? "Random Valid".ColourValue()}, FDesc {_fullDescriptionPattern?.Pattern.ColourCommand() ?? "Random Valid".ColourValue()}";
+			}),
+			("Voluntary Switch", _allowVoluntarySwitch.ToColouredString()),
+			("Can Prog", _canVoluntarilySwitchProg?.MXPClickableFunctionName() ?? "None".ColourError()),
+			("Why Can't Prog", _whyCannotVoluntarilySwitchProg?.MXPClickableFunctionName() ?? "None".ColourError()),
+			("Visible Prog", _canSeeFormProg?.MXPClickableFunctionName() ?? "None".ColourError()),
+			("Priority", $"{_priorityBand.DescribeEnum().ColourValue()} {_priorityOffset.ToString("+#;-#;0", actor).ColourValue()}"),
+			("SDesc Pattern", _shortDescriptionPattern?.Pattern.ColourCommand() ?? "Random Valid".ColourValue()),
+			("FDesc Pattern", _fullDescriptionPattern?.Pattern.ColourCommand() ?? "Random Valid".ColourValue())
+		);
 	}
 
 	public bool BuildingCommand(ICharacter actor, StringStack command)

--- a/MudSharpCore/Magic/SpellEffects/WardSpellEffectBase.cs
+++ b/MudSharpCore/Magic/SpellEffects/WardSpellEffectBase.cs
@@ -87,8 +87,12 @@ public abstract class WardSpellEffectBase : IMagicSpellEffectTemplate
 
 	public string Show(ICharacter actor)
 	{
-		return
-			$"{EffectName.ColourName()} - {School.Name.Colour(School.PowerListColour)} - {Coverage.DescribeEnum().ColourValue()} - {Mode.DescribeEnum().ColourValue()}{(IncludesSubschools ? " incl. subschools" : "")} - Prog: {Prog?.MXPClickableFunctionName() ?? "None".ColourError()}";
+		return SpellEffectPresentation.Describe(actor, EffectName,
+			("School", School.Name.Colour(School.PowerListColour)),
+			("Coverage", Coverage.DescribeEnum().ColourValue()),
+			("Mode", Mode.DescribeEnum().ColourValue()),
+			("Includes Subschools", IncludesSubschools.ToColouredString()),
+			("Prog", Prog?.MXPClickableFunctionName() ?? "None".ColourError()));
 	}
 
 	public bool BuildingCommand(ICharacter actor, StringStack command)

--- a/MudSharpCore/Magic/SpellEffects/WeatherChangeEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/WeatherChangeEffect.cs
@@ -91,7 +91,10 @@ public class WeatherChangeEffect : IMagicSpellEffectTemplate
 
     public string Show(ICharacter actor)
     {
-        return $"WeatherChange {WeatherEvent.Name.ColourValue()} {(NextTransition ? "next" : "immediate")}";
+        return SpellEffectPresentation.Describe(actor, "Weather Change",
+            ("Weather Event", WeatherEvent.Name.ColourValue()),
+            ("Timing", (NextTransition ? "Next Transition" : "Immediate").ColourValue())
+        );
     }
 
     public bool IsInstantaneous => true;

--- a/MudSharpCore/Magic/SpellEffects/WeatherChangeFreezeEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/WeatherChangeFreezeEffect.cs
@@ -92,7 +92,10 @@ public class WeatherChangeFreezeEffect : IMagicSpellEffectTemplate
 
     public string Show(ICharacter actor)
     {
-        return $"WeatherChangeFreeze {WeatherEvent.Name.ColourValue()} {(NextTransition ? "next" : "immediate")}";
+        return SpellEffectPresentation.Describe(actor, "Weather Change Freeze",
+            ("Weather Event", WeatherEvent.Name.ColourValue()),
+            ("Timing", (NextTransition ? "Next Transition" : "Immediate").ColourValue())
+        );
     }
 
     public bool IsInstantaneous => false;

--- a/MudSharpCore/Magic/SpellEffects/WeatherFreezeEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/WeatherFreezeEffect.cs
@@ -48,7 +48,7 @@ public class WeatherFreezeEffect : IMagicSpellEffectTemplate
 
     public string Show(ICharacter actor)
     {
-        return "WeatherFreeze";
+        return SpellEffectPresentation.Describe(actor, "Weather Freeze");
     }
 
     public bool IsInstantaneous => false;

--- a/MudSharpCore/Magic/SpellEffects/WeightSpellEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/WeightSpellEffect.cs
@@ -81,7 +81,8 @@ public class WeightSpellEffect : IMagicSpellEffectTemplate
 
     public string Show(ICharacter actor)
     {
-        return $"Weight +{Gameworld.UnitManager.DescribeExact(AddedWeight, UnitType.Mass, actor)}";
+        return SpellEffectPresentation.Describe(actor, "Weight",
+            ("Added Weight", Gameworld.UnitManager.DescribeExact(AddedWeight, UnitType.Mass, actor).ColourValue()));
     }
 
     public bool IsInstantaneous => false;

--- a/MudSharpCore/Magic/SpellEffects/WindSpellEffects.cs
+++ b/MudSharpCore/Magic/SpellEffects/WindSpellEffects.cs
@@ -213,9 +213,12 @@ public class LevitationEffect : IMagicSpellEffectTemplate
 
 	public string Show(ICharacter actor)
 	{
-		return PreserveLayer
-			? $"Levitate - current layer - {SDescAddendum.Colour(AddendumColour)}"
-			: $"Levitate - {TargetLayer.DescribeEnum().ColourName()} - {SDescAddendum.Colour(AddendumColour)}";
+		return SpellEffectPresentation.Describe(actor, "Levitate",
+			("Layer", PreserveLayer ? "Current Layer".ColourName() : TargetLayer.DescribeEnum().ColourName()),
+			("SDesc Addendum", SDescAddendum.Colour(AddendumColour)),
+			("Desc Addendum", DescAddendum.Colour(AddendumColour)),
+			("Colour", AddendumColour.Name.Colour(AddendumColour))
+		);
 	}
 
 	public const string HelpText = @"You can use the following options with this effect:
@@ -406,8 +409,13 @@ public class FeatherFallEffect : IMagicSpellEffectTemplate
 
 	public string Show(ICharacter actor)
 	{
-		return
-			$"Feather Fall - distance x{FallDistanceMultiplier.ToString("N2", actor).ColourValue()} damage x{FallDamageMultiplier.ToString("N2", actor).ColourValue()} - {SDescAddendum.Colour(AddendumColour)}";
+		return SpellEffectPresentation.Describe(actor, "Feather Fall",
+			("Fall Distance Multiplier", FallDistanceMultiplier.ToString("N2", actor).ColourValue()),
+			("Fall Damage Multiplier", FallDamageMultiplier.ToString("N2", actor).ColourValue()),
+			("SDesc Addendum", SDescAddendum.Colour(AddendumColour)),
+			("Desc Addendum", DescAddendum.Colour(AddendumColour)),
+			("Colour", AddendumColour.Name.Colour(AddendumColour))
+		);
 	}
 
 	public const string HelpText = @"You can use the following options with this effect:
@@ -486,7 +494,7 @@ public class RemoveInvisibilityEffect : IMagicSpellEffectTemplate
 
 	public string Show(ICharacter actor)
 	{
-		return "Remove Invisibility";
+		return SpellEffectPresentation.Describe(actor, "Remove Invisibility");
 	}
 
 	public const string HelpText = "This effect has no additional builder options.";
@@ -701,7 +709,10 @@ public class ForcedPathMovementEffect : IMagicSpellEffectTemplate
 
 	public string Show(ICharacter actor)
 	{
-		return $"Forced Path Movement - {Steps.ToString("N0", actor).ColourValue()} steps - Fall Exits {AllowFallExits.ToColouredString()}";
+		return SpellEffectPresentation.Describe(actor, "Forced Path Movement",
+			("Steps", Steps.ToString("N0", actor).ColourValue()),
+			("Allow Fall Exits", AllowFallExits.ToColouredString())
+		);
 	}
 
 	public const string HelpText = @"You can use the following options with this effect:
@@ -819,7 +830,10 @@ public class TransferenceEffect : IMagicSpellEffectTemplate
 
 	public string Show(ICharacter actor)
 	{
-		return $"Transference - Followers {IncludeFollowers.ToColouredString()} - Swap Layers {SwapLayers.ToColouredString()}";
+		return SpellEffectPresentation.Describe(actor, "Transference",
+			("Include Followers", IncludeFollowers.ToColouredString()),
+			("Swap Layers", SwapLayers.ToColouredString())
+		);
 	}
 
 	public const string HelpText = @"You can use the following options with this effect:


### PR DESCRIPTION
## Summary
- Present spell effects and caster effects under titled sections in `magic spell show`
- Move detailed builder-facing spell effect presentation into effect-owned multi-line summaries
- Add a shared `SpellEffectPresentation` helper and document the new `Show(ICharacter)` convention

## Validation
- `dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `git diff --check`
- `git diff --cached --check`