### PR TITLE
Update seeded race descriptions from rewrite catalogue

### DIFF
--- a/DatabaseSeeder Unit Tests/AnimalSeederTemplateTests.cs
+++ b/DatabaseSeeder Unit Tests/AnimalSeederTemplateTests.cs
@@ -1241,7 +1241,7 @@ public class AnimalSeederTemplateTests
     {
         string dogRaceDescription = AnimalSeeder.BuildRaceDescriptionForTesting(AnimalSeeder.RaceTemplatesForTesting["Dog"]);
         Assert.AreEqual(3, ParagraphCount(dogRaceDescription));
-        StringAssert.Contains(dogRaceDescription, "Adults are most often represented");
+        StringAssert.Contains(dogRaceDescription, "Dogs are social canids shaped by long association with settlements");
 
         string dogEthnicityDescription = AnimalSeeder.BuildEthnicityDescriptionForTesting("Dog", "Retriever");
         Assert.AreEqual(3, ParagraphCount(dogEthnicityDescription));

--- a/DatabaseSeeder Unit Tests/MythicalAnimalSeederTemplateTests.cs
+++ b/DatabaseSeeder Unit Tests/MythicalAnimalSeederTemplateTests.cs
@@ -1133,14 +1133,14 @@ public class MythicalAnimalSeederTemplateTests
         Assert.IsNotNull(dragon.DescriptionVariants);
         Assert.AreEqual(3, ParagraphCount(MythicalAnimalSeeder.BuildRaceDescriptionForTesting(dragon)));
         Assert.AreEqual(3, ParagraphCount(MythicalAnimalSeeder.BuildEthnicityDescriptionForTesting(dragon)));
-        StringAssert.Contains(MythicalAnimalSeeder.BuildRaceDescriptionForTesting(dragon), "broad wings, curving horns");
+        StringAssert.Contains(MythicalAnimalSeeder.BuildRaceDescriptionForTesting(dragon), "sovereign presences wherever they settle");
         StringAssert.Contains(MythicalAnimalSeeder.BuildEthnicityDescriptionForTesting(dragon), "overlapping scales");
 
         MythicalAnimalSeeder.MythicalRaceTemplate centaur = MythicalAnimalSeeder.TemplatesForTesting["Centaur"];
         Assert.IsNotNull(centaur.OverlayDescriptionVariants);
         Assert.AreEqual(3, ParagraphCount(MythicalAnimalSeeder.BuildRaceDescriptionForTesting(centaur)));
         Assert.AreEqual(3, ParagraphCount(MythicalAnimalSeeder.BuildEthnicityDescriptionForTesting(centaur)));
-        StringAssert.Contains(MythicalAnimalSeeder.BuildRaceDescriptionForTesting(centaur), "powerful equine lower body");
+        StringAssert.Contains(MythicalAnimalSeeder.BuildRaceDescriptionForTesting(centaur), "Centaurs combine human torsos and arms with four-legged equine bodies");
         StringAssert.Contains(MythicalAnimalSeeder.BuildEthnicityDescriptionForTesting(centaur), "broad horse-frame");
     }
 }

--- a/DatabaseSeeder Unit Tests/RacialDescriptionRewriteTests.cs
+++ b/DatabaseSeeder Unit Tests/RacialDescriptionRewriteTests.cs
@@ -1,0 +1,87 @@
+#nullable enable
+
+using DatabaseSeeder.Seeders;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class RacialDescriptionRewriteTests
+{
+	private const string ApprovedRewriteHash =
+		"a672c9240cd52e5ba4d718e06211b4f7568c15a86f9340dae6ef8002fe0b177c";
+
+	[TestMethod]
+	public void SeededRaceDescriptions_MatchApprovedRewriteSet()
+	{
+		var descriptions = GetSeededRaceDescriptions().ToList();
+
+		Assert.AreEqual(305, descriptions.Count);
+		Assert.AreEqual(201, descriptions.Count(x => x.Seeder == "Animal Seeder"));
+		Assert.AreEqual(43, descriptions.Count(x => x.Seeder == "Mythical Animal Seeder"));
+		Assert.AreEqual(15, descriptions.Count(x => x.Seeder == "Robot Seeder"));
+		Assert.AreEqual(46, descriptions.Count(x => x.Seeder == "Supernatural Seeder"));
+		Assert.IsFalse(descriptions.Any(x => string.IsNullOrWhiteSpace(x.Description)));
+		Assert.IsTrue(descriptions.All(x => ParagraphCount(x.Description) == 3));
+
+		var canonical = new StringBuilder();
+		foreach (var row in descriptions.OrderBy(x => x.Seeder, StringComparer.Ordinal)
+			         .ThenBy(x => x.Race, StringComparer.Ordinal))
+		{
+			canonical
+				.Append(row.Seeder)
+				.Append('\t')
+				.Append(row.Race)
+				.Append('\t')
+				.Append(NormaliseLineEndings(row.Description))
+				.Append('\n');
+		}
+
+		var hash = Convert
+			.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical.ToString())))
+			.ToLowerInvariant();
+		Assert.AreEqual(ApprovedRewriteHash, hash);
+	}
+
+	private static IEnumerable<(string Seeder, string Race, string Description)> GetSeededRaceDescriptions()
+	{
+		foreach ((var raceName, var template) in AnimalSeeder.RaceTemplatesForTesting)
+		{
+			yield return ("Animal Seeder", raceName, AnimalSeeder.BuildRaceDescriptionForTesting(template));
+		}
+
+		foreach ((var raceName, var template) in MythicalAnimalSeeder.TemplatesForTesting)
+		{
+			yield return ("Mythical Animal Seeder", raceName, MythicalAnimalSeeder.BuildRaceDescriptionForTesting(template));
+		}
+
+		foreach ((var raceName, var template) in RobotSeeder.TemplatesForTesting)
+		{
+			yield return ("Robot Seeder", raceName, RobotSeeder.BuildRaceDescriptionForTesting(template));
+		}
+
+		foreach ((var raceName, var template) in SupernaturalSeeder.TemplatesForTesting)
+		{
+			yield return ("Supernatural Seeder", raceName, SupernaturalSeeder.BuildRaceDescriptionForTesting(template));
+		}
+	}
+
+	private static string NormaliseLineEndings(string text)
+	{
+		return text
+			.Replace("\r\n", "\n", StringComparison.Ordinal)
+			.Replace("\r", "\n", StringComparison.Ordinal);
+	}
+
+	private static int ParagraphCount(string text)
+	{
+		return NormaliseLineEndings(text)
+			.Split(["\n\n"], StringSplitOptions.RemoveEmptyEntries)
+			.Length;
+	}
+}

--- a/DatabaseSeeder Unit Tests/RobotSeederTemplateTests.cs
+++ b/DatabaseSeeder Unit Tests/RobotSeederTemplateTests.cs
@@ -244,7 +244,7 @@ public class RobotSeederTemplateTests
         RobotSeeder.RobotRaceTemplate robotHumanoid = RobotSeeder.TemplatesForTesting["Robot Humanoid"];
         Assert.AreEqual(3, ParagraphCount(RobotSeeder.BuildRaceDescriptionForTesting(robotHumanoid)));
         Assert.AreEqual(3, ParagraphCount(RobotSeeder.BuildEthnicityDescriptionForTesting(robotHumanoid)));
-        StringAssert.Contains(RobotSeeder.BuildRaceDescriptionForTesting(robotHumanoid), "articulated plated chassis");
+        StringAssert.Contains(RobotSeeder.BuildRaceDescriptionForTesting(robotHumanoid), "made to share tools, doors, clothing and equipment with people");
 
         RobotSeeder.RobotRaceTemplate cyborg = RobotSeeder.TemplatesForTesting["Cyborg"];
         Assert.AreEqual(3, ParagraphCount(RobotSeeder.BuildRaceDescriptionForTesting(cyborg)));

--- a/DatabaseSeeder/Seeders/AnimalSeeder.AquaticTemplates.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.AquaticTemplates.cs
@@ -2,6 +2,7 @@
 
 using MudSharp.Body;
 using MudSharp.GameItems;
+using System;
 using System.Collections.Generic;
 
 namespace DatabaseSeeder.Seeders;
@@ -21,12 +22,13 @@ public partial class AnimalSeeder
             AnimalDescriptionPack pack,
             AnimalBreathingMode breathingMode,
             bool canClimb = false,
-            string combatStrategyKey = "Beast Brawler")
+            string combatStrategyKey = "Beast Brawler",
+            string? description = null)
         {
             return new AnimalRaceTemplate(
                 name,
                 adjective,
-                null,
+                description ?? throw new InvalidOperationException($"Animal race {name} is missing a seeded description."),
                 bodyKey,
                 size,
                 canClimb,
@@ -55,36 +57,188 @@ public partial class AnimalSeeder
             );
         }
 
-        foreach ((string, SizeCategory, double, string, string, string, string, string, string) fish in new[]
-        {
-            ("Carp", SizeCategory.Small, 0.2, "Small Fish", "fish", "It is broad-backed and thick-scaled, with a blunt head and deep body.",
-                "Its heavy flanks and slow powerful tailbeats suit muddy ponds and quiet rivers.", "It looks durable rather than fast.", "pond, river and silted water"),
-            ("Cod", SizeCategory.Small, 0.2, "Medium Fish", "fish", "It is pale-sided and thick-bodied, with a broad head and tapering tail.", "Its body is that of a practical cold-water hunter built to cruise and gulp.", "It hangs in the water with patient, practical intent.", "cold sea and offshore bank"),
-            ("Haddock", SizeCategory.Small, 0.2, "Medium Fish", "fish", "It is neat-bodied and silvery, marked in darker mottling along the back.", "Its fin shape and taut body suit active swimming through open water.", "It looks alert and constantly in motion.", "cool sea and coastal shelf"),
-            ("Koi", SizeCategory.Small, 0.2, "Small Fish", "fish", "It is deep-bodied and ornamental, its scales often bright and richly patterned.", "Its rounded shape and bold colouration make it stand out more than most fish would dare.", "It drifts with serene, showy confidence.", "garden pond and still water"),
-            ("Pilchard", SizeCategory.Small, 0.2, "Small Fish", "fish", "It is slim and silvery, built in the plain, efficient shape of a schooling fish.", "Its narrow body and shining flanks help it disappear among many of its own kind.", "It looks made for constant quick movement in company.", "coastal sea and schooling water"),
-            ("Perch", SizeCategory.Small, 0.2, "Small Fish", "fish", "It is neatly built, with a spined dorsal fin and barred body.", "Its profile looks half predator, half ambusher, ideal for striking from reed shade.", "It waits more than it rushes.", "lake, river and weed bed"),
-            ("Herring", SizeCategory.VerySmall, 0.1, "Small Fish", "fish", "It is narrow-bodied and silver bright, with a simple schooling silhouette.", "Its shape is all speed, synchrony and life spent among flashes of similar bodies.", "It looks nervous and constantly ready to turn as one with a shoal.", "open sea and cold coastal water"),
-            ("Mackerel", SizeCategory.VerySmall, 0.1, "Small Fish", "fish", "It is sleek and metallic, marked in dark bars over a silver body.", "Its torpedo shape and strong tail mark it as a relentless swimmer.", "It has the restless speed of something that never fully stops.", "open water and current"),
-            ("Anchovy", SizeCategory.VerySmall, 0.1, "Small Fish", "fish", "It is very small and slim, almost pure silver and motion.", "Its body is built around schooling, darting and avoiding bigger mouths.", "It seems little more than a quick bright line in the water.", "coastal water and estuary"),
-            ("Sardine", SizeCategory.VerySmall, 0.1, "Small Fish", "fish", "It is compact and silver-scaled, with a schooling fish's simple efficient body.", "Its flanks catch light readily, vanishing and reappearing with every turn.", "It looks born to move in a living glittering mass.", "coastal sea and schooling water"),
-            ("Pollock", SizeCategory.Small, 0.2, "Medium Fish", "fish", "It is long and pale, with a strong tail and deep mouth.", "Its build looks suited to active hunting in cool water rather than lurking on the bottom.", "It gives off a lean, hungry practicality.", "offshore water and cold sea"),
-            ("Salmon", SizeCategory.Small, 0.2, "Medium Fish", "fish", "It is sleek and powerful, with clean fins and a muscular body.", "Its shape is that of a tireless swimmer made for long distances and hard currents.", "It looks as though it could climb water itself if it had to.", "river mouth and migrating current"),
-            ("Tuna", SizeCategory.Normal, 0.8, "Large Fish", "fish", "It is thick and torpedo-shaped, all dense muscle and efficient fin.", "Its body seems built for speed, endurance and open-water pursuit.", "It exudes relentless forward momentum even while still.", "blue water and pelagic sea")
-        })
-        {
-            yield return Aquatic(fish.Item1, fish.Item1, "Piscine", fish.Item2, fish.Item3, fish.Item4, fish.Item5,
-                AquaticPack($"a {fish.Item1.ToLowerInvariant()} fry", $"a young {fish.Item1.ToLowerInvariant()}", $"a {fish.Item1.ToLowerInvariant()}",
-                    fish.Item6, fish.Item7, fish.Item8, fish.Item9),
-                fish.Item1 switch
-                {
-                    "Carp" => AnimalBreathingMode.Freshwater,
-                    "Koi" => AnimalBreathingMode.Freshwater,
-                    "Perch" => AnimalBreathingMode.Freshwater,
-                    "Salmon" => AnimalBreathingMode.Freshwater,
-                    _ => AnimalBreathingMode.Saltwater
-                });
-        }
+        yield return Aquatic("Carp", "Carp", "Piscine", SizeCategory.Small, 0.2, "Small Fish", "fish",
+            AquaticPack("a carp fry", "a young carp", "a carp",
+                "It is broad-backed and thick-scaled, with a blunt head and deep body.",
+                "Its heavy flanks and slow powerful tailbeats suit muddy ponds and quiet rivers.",
+                "It looks durable rather than fast.",
+                "pond, river and silted water"),
+            AnimalBreathingMode.Freshwater,
+            description: """
+            Carp are sturdy freshwater fish of ponds, canals and silted rivers, more often noticed by a slow bronze roll beneath the surface than by any dramatic strike. They make quiet water feel occupied and patient.
+
+            A carp's deep body, blunt head and heavy scales suit muddy bottoms, weed beds and the lazy search for food among stirred sediment. It is not built to dazzle with speed; it survives by endurance, wariness and an ability to prosper where the water is far from clear.
+
+            People meet carp as food, ornament, pond life and familiar river stock. Their value is often domestic and practical, but a large carp moving under still water can still carry the old mystery of things living just out of reach.
+            """);
+        yield return Aquatic("Cod", "Cod", "Piscine", SizeCategory.Small, 0.2, "Medium Fish", "fish",
+            AquaticPack("a cod fry", "a young cod", "a cod",
+                "It is pale-sided and thick-bodied, with a broad head and tapering tail.",
+                "Its body is that of a practical cold-water hunter built to cruise and gulp.",
+                "It hangs in the water with patient, practical intent.",
+                "cold sea and offshore bank"),
+            AnimalBreathingMode.Saltwater,
+            description: """
+            Cod are practical cold-sea fish of offshore banks and working waters. They belong less to glittering shoals near the surface than to the steady, edible abundance that draws boats into hard weather and long labour.
+
+            The broad head, pale flanks and tapering body make a cod look built to cruise, gulp and endure. It has the plain efficiency of a bottom-haunting hunter rather than the nervous flash of smaller schooling fish.
+
+            Around coastal communities, cod are livelihood before spectacle: catch, ration, trade good and reason to sail. Their presence ties deep water to kitchens, markets and the risks people accept to bring food ashore.
+            """);
+        yield return Aquatic("Haddock", "Haddock", "Piscine", SizeCategory.Small, 0.2, "Medium Fish", "fish",
+            AquaticPack("a haddock fry", "a young haddock", "a haddock",
+                "It is neat-bodied and silvery, marked in darker mottling along the back.",
+                "Its fin shape and taut body suit active swimming through open water.",
+                "It looks alert and constantly in motion.",
+                "cool sea and coastal shelf"),
+            AnimalBreathingMode.Saltwater,
+            description: """
+            Haddock are cool-water sea fish of coastal shelves and offshore banks, neat-bodied and restless in the shifting light below the surface. They are recognisable as working-sea creatures rather than ornamental ones.
+
+            Dark mottling along the back, pale sides and taut fins give a haddock an alert, clean-lined look. It seems made for active movement through cold water, feeding without the brute heaviness of cod or the flash of a surface shoal.
+
+            For people, haddock are ordinary in the important way: food, trade and the daily proof that the sea supports settlement at a price. They add texture to fishing cultures without demanding legend around every net.
+            """);
+        yield return Aquatic("Koi", "Koi", "Piscine", SizeCategory.Small, 0.2, "Small Fish", "fish",
+            AquaticPack("a koi fry", "a young koi", "a koi",
+                "It is deep-bodied and ornamental, its scales often bright and richly patterned.",
+                "Its rounded shape and bold colouration make it stand out more than most fish would dare.",
+                "It drifts with serene, showy confidence.",
+                "garden pond and still water"),
+            AnimalBreathingMode.Freshwater,
+            description: """
+            Koi are ornamental carp whose colours turn still water into display. In a pond or garden pool they draw the eye deliberately, moving like living brushstrokes through reflection, weed and shadow.
+
+            Their rounded bodies, broad fins and patterned scales make them poor candidates for invisibility and excellent signs of care. A koi does not need speed to command attention; it carries value in colour, size, calm and the way it changes the mood of water around it.
+
+            People keep koi as symbols, luxuries, pets and cultivated beauties. They are domesticated spectacle rather than wild hazard, though their serenity depends on a maintained place where predators and hunger have been kept at a polite distance.
+            """);
+        yield return Aquatic("Pilchard", "Pilchard", "Piscine", SizeCategory.Small, 0.2, "Small Fish", "fish",
+            AquaticPack("a pilchard fry", "a young pilchard", "a pilchard",
+                "It is slim and silvery, built in the plain, efficient shape of a schooling fish.",
+                "Its narrow body and shining flanks help it disappear among many of its own kind.",
+                "It looks made for constant quick movement in company.",
+                "coastal sea and schooling water"),
+            AnimalBreathingMode.Saltwater,
+            description: """
+            Pilchards are small coastal schooling fish, silver-bodied and easily lost in the flashing agreement of many bodies turning together. A single pilchard is minor; a mass of them can make the sea appear to glitter with nerves.
+
+            Their slim bodies and quick tails favour synchrony over individuality. They live by becoming difficult to single out, folding one bright movement into another until predator, fisher and current all read the shoal before the fish.
+
+            They matter as bait, food and seasonal sign. Where pilchards run, larger mouths and human boats often follow, turning a modest fish into the centre of a wider coastal rhythm.
+            """);
+        yield return Aquatic("Perch", "Perch", "Piscine", SizeCategory.Small, 0.2, "Small Fish", "fish",
+            AquaticPack("a perch fry", "a young perch", "a perch",
+                "It is neatly built, with a spined dorsal fin and barred body.",
+                "Its profile looks half predator, half ambusher, ideal for striking from reed shade.",
+                "It waits more than it rushes.",
+                "lake, river and weed bed"),
+            AnimalBreathingMode.Freshwater,
+            description: """
+            Perch are freshwater fish of lakes, slow rivers and weed beds, marked by a watchful stillness that suits reed shade and broken light. They feel like fish of edges rather than open water.
+
+            A spined dorsal fin, barred sides and compact predatory shape give a perch a prickly readiness. It waits well, holds position well and strikes from cover with more purpose than its size might suggest.
+
+            People know perch as catch, pond predator and familiar sign of healthy freshwater. They are not grand fish, but they make small waters feel alive with ambush, appetite and quick local knowledge.
+            """);
+        yield return Aquatic("Herring", "Herring", "Piscine", SizeCategory.VerySmall, 0.1, "Small Fish", "fish",
+            AquaticPack("a herring fry", "a young herring", "a herring",
+                "It is narrow-bodied and silver bright, with a simple schooling silhouette.",
+                "Its shape is all speed, synchrony and life spent among flashes of similar bodies.",
+                "It looks nervous and constantly ready to turn as one with a shoal.",
+                "open sea and cold coastal water"),
+            AnimalBreathingMode.Saltwater,
+            description: """
+            Herring are narrow silver fish of cold coastal water and open sea, most impressive when they vanish into a shoal and return as a single shifting brightness. They are creatures of number, timing and collective motion.
+
+            Their simple bodies are tuned for speed, turning and survival among countless near-identical neighbours. Light breaks across their flanks in brief flashes, making the individual hard to hold in the eye.
+
+            They feed birds, larger fish, markets and whole fishing seasons. Herring are humble only one at a time; in abundance they become weather, economy and migration made edible.
+            """);
+        yield return Aquatic("Mackerel", "Mackerel", "Piscine", SizeCategory.VerySmall, 0.1, "Small Fish", "fish",
+            AquaticPack("a mackerel fry", "a young mackerel", "a mackerel",
+                "It is sleek and metallic, marked in dark bars over a silver body.",
+                "Its torpedo shape and strong tail mark it as a relentless swimmer.",
+                "It has the restless speed of something that never fully stops.",
+                "open water and current"),
+            AnimalBreathingMode.Saltwater,
+            description: """
+            Mackerel are fast open-water fish, metallic and restless, with dark bars over silver flanks that seem to retain the motion of current even when still. They belong to active water rather than mud or weed.
+
+            The torpedo shape, strong tail and tight fins give a mackerel a sense of constant forward intent. It looks less like a creature that waits for opportunity than one that creates it by never quite stopping.
+
+            For fishers and coastal tables, mackerel mean season, speed and oily abundance. Their arrival can feel sudden and generous, a bright run of life cutting through the sea before moving on.
+            """);
+        yield return Aquatic("Anchovy", "Anchovy", "Piscine", SizeCategory.VerySmall, 0.1, "Small Fish", "fish",
+            AquaticPack("a anchovy fry", "a young anchovy", "a anchovy",
+                "It is very small and slim, almost pure silver and motion.",
+                "Its body is built around schooling, darting and avoiding bigger mouths.",
+                "It seems little more than a quick bright line in the water.",
+                "coastal water and estuary"),
+            AnimalBreathingMode.Saltwater,
+            description: """
+            Anchovies are tiny silver fish of coastal waters and estuaries, quick enough to be glimpsed more as flicker than form. Their importance comes from scale of numbers rather than individual presence.
+
+            Each anchovy is a narrow bright line built for schooling, darting and becoming hard to isolate. In motion they make the water seem to tremble, as if the shoal were one nervous surface with many small hearts.
+
+            They are bait, food and foundation, feeding larger fish, birds and human appetites alike. An anchovy is easy to overlook until one follows the chain of hunger that depends on it.
+            """);
+        yield return Aquatic("Sardine", "Sardine", "Piscine", SizeCategory.VerySmall, 0.1, "Small Fish", "fish",
+            AquaticPack("a sardine fry", "a young sardine", "a sardine",
+                "It is compact and silver-scaled, with a schooling fish's simple efficient body.",
+                "Its flanks catch light readily, vanishing and reappearing with every turn.",
+                "It looks born to move in a living glittering mass.",
+                "coastal sea and schooling water"),
+            AnimalBreathingMode.Saltwater,
+            description: """
+            Sardines are compact schooling fish of coastal seas, plain at first glance but brilliant when a shoal turns in sunlight. They bring the open water's abundance close enough for nets, gulls and market baskets.
+
+            Their small bodies favour tight coordination, quick changes of direction and the safety of many flanks catching light together. A sardine's life is individual only in the biological sense; visually and ecologically, it is part of a moving crowd.
+
+            People meet sardines as food, bait and seasonal plenty. They carry the practical romance of fishing towns: salt, oil, silver scales and the knowledge that small fish can feed large communities.
+            """);
+        yield return Aquatic("Pollock", "Pollock", "Piscine", SizeCategory.Small, 0.2, "Medium Fish", "fish",
+            AquaticPack("a pollock fry", "a young pollock", "a pollock",
+                "It is long and pale, with a strong tail and deep mouth.",
+                "Its build looks suited to active hunting in cool water rather than lurking on the bottom.",
+                "It gives off a lean, hungry practicality.",
+                "offshore water and cold sea"),
+            AnimalBreathingMode.Saltwater,
+            description: """
+            Pollock are lean cold-water fish of offshore currents, less iconic than cod but shaped by the same practical sea. They carry a hungry, cruising quality that suits grey water and working boats.
+
+            A long pale body, strong tail and deep mouth make a pollock look like an active hunter rather than a bottom-bound weight. It moves through cool water with efficient appetite, built to take advantage of whatever the current carries near.
+
+            For people, pollock are catch, trade and provision: rarely glamorous, often necessary. They give the sea's labouring edge another familiar name in the net.
+            """);
+        yield return Aquatic("Salmon", "Salmon", "Piscine", SizeCategory.Small, 0.2, "Medium Fish", "fish",
+            AquaticPack("a salmon fry", "a young salmon", "a salmon",
+                "It is sleek and powerful, with clean fins and a muscular body.",
+                "Its shape is that of a tireless swimmer made for long distances and hard currents.",
+                "It looks as though it could climb water itself if it had to.",
+                "river mouth and migrating current"),
+            AnimalBreathingMode.Freshwater,
+            description: """
+            Salmon are powerful migrating fish, equally tied to river mouths, cold currents and the hard upstream work of return. Their lives make water feel like a road with memory.
+
+            The clean fins, muscular body and determined head suggest endurance more than ornament. A salmon can be beautiful, but the deeper impression is purpose: silver strength driving through current, falls and exhaustion toward spawning ground.
+
+            People read salmon as food, wealth, season and omen of river health. Where they run, settlements gather stories about return, plenty and the thin line between abundance and loss.
+            """);
+        yield return Aquatic("Tuna", "Tuna", "Piscine", SizeCategory.Normal, 0.8, "Large Fish", "fish",
+            AquaticPack("a tuna fry", "a young tuna", "a tuna",
+                "It is thick and torpedo-shaped, all dense muscle and efficient fin.",
+                "Its body seems built for speed, endurance and open-water pursuit.",
+                "It exudes relentless forward momentum even while still.",
+                "blue water and pelagic sea"),
+            AnimalBreathingMode.Saltwater,
+            description: """
+            Tuna are dense open-ocean swimmers, built for blue water, speed and relentless distance. They feel less like fish of place than fish of motion, belonging to currents too wide for shore-bound habits.
+
+            The thick torpedo body, compact fins and heavy muscle make a tuna seem engineered by the need to keep moving. Even hauled still, it carries the impression of stored velocity and deep-water pressure.
+
+            People value tuna as prize, food and proof of serious fishing reach. A tuna connects the table to far horizons, hard gear and the dangerous generosity of the pelagic sea.
+            """);
 
         yield return Aquatic("Shark", "Shark", "Piscine", SizeCategory.Large, 1.5, "Shark", "shark",
             AquaticPack("a shark pup", "a young shark", "a shark",
@@ -93,7 +247,14 @@ public partial class AnimalSeeder
                 "It carries itself with the remorseless calm of something that expects to eat what it catches.",
                 "open sea and dark water"),
             AnimalBreathingMode.Saltwater,
-            combatStrategyKey: "Beast Drowner");
+            combatStrategyKey: "Beast Drowner",
+            description: """
+            Sharks are apex marine predators whose presence changes the meaning of open water. A fin, a pale belly in the dark or the slow turn of a powerful body can make a whole stretch of sea feel suddenly claimed.
+
+            Their shape is spare and severe: heavy tail, cutting fins, cold eyes and a mouth built from layered teeth. They do not need frantic movement to threaten; the calm approach is often worse, because it suggests confidence in the outcome.
+
+            People meet sharks as danger, omen, quarry and ecological fact. They are not simply large fish but the sea's reminder that beneath trade routes, beaches and boats there are older forms of appetite.
+            """);
 
         yield return Aquatic("Small Crab", "Small Crab", "Decapod", SizeCategory.VerySmall, 0.2, "Crab", "crab-small",
             AquaticPack("a tiny crab larva", "a young small crab", "a small crab",
@@ -102,7 +263,14 @@ public partial class AnimalSeeder
                 "It skitters with prickly sideways certainty.",
                 "tidal rock, shoreline pool and shallow reef"),
             AnimalBreathingMode.Saltwater,
-            combatStrategyKey: "Beast Clincher");
+            combatStrategyKey: "Beast Clincher",
+            description: """
+            Small crabs occupy reefs, tidal flats, rocky seabeds, creeks, estuaries and mangroves as armoured aquatic arthropods. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            Look closer and the outline is all jointed legs, shells, claws, antennae and tails that make armour part of ordinary movement. In motion they are marked by sideways certainty, sudden retreats and stubborn little assertions of space, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They are familiar around nets and shallows, but their claws and shells make them feel like small machines made of hunger. Around settlements, roads or camps, small crabs add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Aquatic("Crab", "Crab", "Decapod", SizeCategory.Small, 0.6, "Crab", "crab-large",
             AquaticPack("a crab larva", "a young crab", "a crab",
                 "It is broad-shelled and low to the ground, with stalked eyes and heavy claws.",
@@ -110,7 +278,14 @@ public partial class AnimalSeeder
                 "It skitters sideways with abrupt mechanical decisiveness.",
                 "reef, mangrove and tidal flat"),
             AnimalBreathingMode.Saltwater,
-            combatStrategyKey: "Beast Clincher");
+            combatStrategyKey: "Beast Clincher",
+            description: """
+            Where reefs, tidal flats, rocky seabeds, creeks, estuaries and mangroves meets daily life, crabs are recognisable as armoured aquatic arthropods. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The first things to register are jointed legs, shells, claws, antennae and tails that make armour part of ordinary movement. In motion they are marked by sideways certainty, sudden retreats and stubborn little assertions of space, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They are familiar around nets and shallows, but their claws and shells make them feel like small machines made of hunger. Around settlements, roads or camps, crabs add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Aquatic("Giant Crab", "Giant Crab", "Decapod", SizeCategory.Normal, 1.2, "Large Crab", "crab-giant",
             AquaticPack("a giant crab larva", "a young giant crab", "a giant crab",
                 "It is enormous for a crab, all shell, claw and stubborn lateral movement.",
@@ -118,35 +293,70 @@ public partial class AnimalSeeder
                 "It has the blunt confidence of a creature that trusts its armour.",
                 "reef shelf and deep tidal cave"),
             AnimalBreathingMode.Saltwater,
-            combatStrategyKey: "Beast Clincher");
+            combatStrategyKey: "Beast Clincher",
+            description: """
+            Giant crabs are armoured aquatic arthropods of reefs, tidal flats, rocky seabeds, creeks, estuaries and mangroves. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            Physically they are defined by jointed legs, shells, claws, antennae and tails that make armour part of ordinary movement. The impression is completed by sideways certainty, sudden retreats and stubborn little assertions of space, giving the animal a readable rhythm even before it acts.
+
+            They are familiar around nets and shallows, but their claws and shells make them feel like small machines made of hunger. Around settlements, roads or camps, giant crabs add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Aquatic("Lobster", "Lobster", "Malacostracan", SizeCategory.Small, 0.6, "Crustacean", "crab-large",
             AquaticPack("a lobster larva", "a young lobster", "a lobster",
                 "It is long-bodied and armoured, with heavy claws and a muscular tail fan.",
                 "Its segmented abdomen and antennae give it a more elongate, primeval look than a crab.",
                 "It creeps with slow, wary intent until startled into sudden retreat.",
                 "reef crevice and rocky seabed"),
-            AnimalBreathingMode.Saltwater);
+            AnimalBreathingMode.Saltwater,
+            description: """
+            In reefs, tidal flats, rocky seabeds, creeks, estuaries and mangroves, lobsters fill the role of armoured aquatic arthropods. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            Physically they are defined by jointed legs, shells, claws, antennae and tails that make armour part of ordinary movement. The impression is completed by sideways certainty, sudden retreats and stubborn little assertions of space, giving the animal a readable rhythm even before it acts.
+
+            They are familiar around nets and shallows, but their claws and shells make them feel like small machines made of hunger. Around settlements, roads or camps, lobsters add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Aquatic("Shrimp", "Shrimp", "Malacostracan", SizeCategory.VerySmall, 0.1, "Crustacean", "crab-small",
             AquaticPack("a shrimp larva", "a young shrimp", "a shrimp",
                 "It is narrow, translucent and finely jointed, with long feelers and a curled body.",
                 "Its tail and antennae make it look like a scrap of articulated motion more than a settled animal.",
                 "It flicks backward through the water in sudden nervous bursts.",
                 "reef, estuary and weed bed"),
-            AnimalBreathingMode.Saltwater);
+            AnimalBreathingMode.Saltwater,
+            description: """
+            Shrimp occupy reefs, tidal flats, rocky seabeds, creeks, estuaries and mangroves as armoured aquatic arthropods. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            Physically they are defined by jointed legs, shells, claws, antennae and tails that make armour part of ordinary movement. The impression is completed by sideways certainty, sudden retreats and stubborn little assertions of space, giving the animal a readable rhythm even before it acts.
+
+            They are familiar around nets and shallows, but their claws and shells make them feel like small machines made of hunger. Around settlements, roads or camps, shrimp add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Aquatic("Prawn", "Prawn", "Malacostracan", SizeCategory.VerySmall, 0.15, "Crustacean", "crab-small",
             AquaticPack("a prawn larva", "a young prawn", "a prawn",
                 "It is slender-bodied and semi-translucent, with long antennae and delicate claws.",
                 "Its tail looks stronger and more active than the rest of its lightly armoured body.",
                 "It appears ready to snap backward away from danger at any moment.",
                 "estuary, mangrove and warm shallows"),
-            AnimalBreathingMode.Saltwater);
+            AnimalBreathingMode.Saltwater,
+            description: """
+            Where reefs, tidal flats, rocky seabeds, creeks, estuaries and mangroves meets daily life, prawns are recognisable as armoured aquatic arthropods. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            Physically they are defined by jointed legs, shells, claws, antennae and tails that make armour part of ordinary movement. The impression is completed by sideways certainty, sudden retreats and stubborn little assertions of space, giving the animal a readable rhythm even before it acts.
+
+            They are familiar around nets and shallows, but their claws and shells make them feel like small machines made of hunger. Around settlements, roads or camps, prawns add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Aquatic("Crayfish", "Crayfish", "Malacostracan", SizeCategory.VerySmall, 0.2, "Crustacean", "crab-small",
             AquaticPack("a crayfish larva", "a young crayfish", "a crayfish",
                 "It is a small fresh-water crustacean with a shell-backed body, claws and curling tail.",
                 "Its squat armour and feelers make it look like a tiny river-bottom bruiser.",
                 "It creeps with stubborn purpose and sudden jerks of retreat.",
                 "stream, creek bed and muddy bank"),
-            AnimalBreathingMode.Freshwater);
+            AnimalBreathingMode.Freshwater,
+            description: """
+            Crayfish are armoured aquatic arthropods of reefs, tidal flats, rocky seabeds, creeks, estuaries and mangroves. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            The body plan is clear: jointed legs, shells, claws, antennae and tails that make armour part of ordinary movement. Watch one move and the emphasis falls on sideways certainty, sudden retreats and stubborn little assertions of space, a pattern that tells more than size alone.
+
+            They are familiar around nets and shallows, but their claws and shells make them feel like small machines made of hunger. Around settlements, roads or camps, crayfish add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
 
         yield return Aquatic("Jellyfish", "Jellyfish", "Jellyfish", SizeCategory.Small, 0.1, "Jellyfish", "jellyfish",
             AquaticPack("a young jellyfish", "a young jellyfish", "a jellyfish",
@@ -155,7 +365,14 @@ public partial class AnimalSeeder
                 "It pulses and drifts with eerie, indifferent grace.",
                 "open water and current"),
             AnimalBreathingMode.Partless,
-            combatStrategyKey: "Beast Artillery");
+            combatStrategyKey: "Beast Artillery",
+            description: """
+            In open water, current lines and quiet coastal drift, jellyfish fill the role of soft-bodied drifting sea creatures. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The body plan is clear: translucent bells, trailing tendrils and almost impossible delicacy. Watch one move and the emphasis falls on slow pulses, passive drift and eerie indifference, a pattern that tells more than size alone.
+
+            They are beautiful at a distance and painful at a touch, teaching caution where the water looks empty. Around settlements, roads or camps, jellyfish add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
 
         yield return Aquatic("Octopus", "Octopus", "Cephalopod", SizeCategory.Small, 0.4, "Cephalopod", "cephalopod",
             AquaticPack("a young octopus", "a young octopus", "an octopus",
@@ -163,7 +380,14 @@ public partial class AnimalSeeder
                 "Its suckered limbs and changing skin make it look too adaptable and too aware for comfort.",
                 "It seems to think before it moves, and that alone is unsettling.",
                 "reef, wreck and rocky sea floor"),
-            AnimalBreathingMode.Saltwater, true, "Beast Clincher");
+            AnimalBreathingMode.Saltwater, true, "Beast Clincher",
+            description: """
+            Octopuses occupy reefs, wrecks, rocky floors, open sea and deep water as intelligent soft-bodied sea hunters. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            The body plan is clear: mantles, arms, suckers, large eyes and bodies able to change, cling and vanish. Watch one move and the emphasis falls on deliberate stillness broken by jets of speed or sudden camouflage, a pattern that tells more than size alone.
+
+            They feel less like simple animals than watchful problems, especially when a hand reaches where an arm can answer. Around settlements, roads or camps, octopuses add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Aquatic("Squid", "Squid", "Cephalopod", SizeCategory.Small, 0.4, "Cephalopod", "cephalopod",
             AquaticPack("a young squid", "a young squid", "a squid",
                 "It is narrow-bodied and swift, with fins along the mantle and a crown of arms at the front.",
@@ -171,7 +395,14 @@ public partial class AnimalSeeder
                 "It always seems one moment away from vanishing into darker water.",
                 "open sea and deep current"),
             AnimalBreathingMode.Saltwater,
-            combatStrategyKey: "Beast Clincher");
+            combatStrategyKey: "Beast Clincher",
+            description: """
+            Where reefs, wrecks, rocky floors, open sea and deep water meets daily life, squid are recognisable as intelligent soft-bodied sea hunters. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The body plan is clear: mantles, arms, suckers, large eyes and bodies able to change, cling and vanish. Watch one move and the emphasis falls on deliberate stillness broken by jets of speed or sudden camouflage, a pattern that tells more than size alone.
+
+            They feel less like simple animals than watchful problems, especially when a hand reaches where an arm can answer. Around settlements, roads or camps, squid add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Aquatic("Giant Squid", "Giant Squid", "Cephalopod", SizeCategory.Large, 1.0, "Giant Cephalopod", "cephalopod",
             AquaticPack("a young giant squid", "a young giant squid", "a giant squid",
                 "It is an outsized cephalopod, all long mantle, heavy arms and impossible dark eyes.",
@@ -179,7 +410,14 @@ public partial class AnimalSeeder
                 "It suggests abyssal depth and cold water where light does not matter much.",
                 "deep ocean and black water"),
             AnimalBreathingMode.Saltwater,
-            combatStrategyKey: "Beast Clincher");
+            combatStrategyKey: "Beast Clincher",
+            description: """
+            Giant squid are intelligent soft-bodied sea hunters of reefs, wrecks, rocky floors, open sea and deep water. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            The most telling cues are mantles, arms, suckers, large eyes and bodies able to change, cling and vanish. Those features support deliberate stillness broken by jets of speed or sudden camouflage, making the creature feel suited to its ground rather than merely placed there.
+
+            They feel less like simple animals than watchful problems, especially when a hand reaches where an arm can answer. Around settlements, roads or camps, giant squid add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
 
         yield return Aquatic("Sea Lion", "Sea Lion", "Pinniped", SizeCategory.Normal, 0.8, "Pinniped", "pinniped",
             AquaticPack("a sea lion pup", "a young sea lion", "a sea lion",
@@ -187,21 +425,42 @@ public partial class AnimalSeeder
                 "Its body speaks of a creature equally willing to haul out on rock or surge through surf.",
                 "It has the loud self-assurance of a communal coastal animal.",
                 "rocky shore and rolling surf"),
-            AnimalBreathingMode.Blowhole);
+            AnimalBreathingMode.Blowhole,
+            description: """
+            In ice edges, rocky shores, sandbars and rolling surf, sea lions fill the role of flippered marine mammals. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            Most of its character sits in sleek coats, whiskered muzzles, blubbered bodies and limbs made for water first. Those features support awkward land movement transformed into easy swimming power, making the creature feel suited to its ground rather than merely placed there.
+
+            They gather where sea and land meet, noisy, watchful and more formidable than their soft-eyed faces imply. Around settlements, roads or camps, sea lions add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Aquatic("Seal", "Seal", "Pinniped", SizeCategory.Normal, 0.8, "Pinniped", "pinniped",
             AquaticPack("a seal pup", "a young seal", "a seal",
                 "It is smooth and streamlined, with huge dark eyes and whiskers around a neat muzzle.",
                 "Its body is all blubber, grace and flipper-powered practicality.",
                 "It looks soft until it begins to move, and then it becomes something fluid and efficient.",
                 "ice edge, sandbar and cold coast"),
-            AnimalBreathingMode.Blowhole);
+            AnimalBreathingMode.Blowhole,
+            description: """
+            Seals occupy ice edges, rocky shores, sandbars and rolling surf as flippered marine mammals. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            What distinguishes the line is sleek coats, whiskered muzzles, blubbered bodies and limbs made for water first. Those features support awkward land movement transformed into easy swimming power, making the creature feel suited to its ground rather than merely placed there.
+
+            They gather where sea and land meet, noisy, watchful and more formidable than their soft-eyed faces imply. Around settlements, roads or camps, seals add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Aquatic("Walrus", "Walrus", "Pinniped", SizeCategory.Large, 1.2, "Walrus", "pinniped",
             AquaticPack("a walrus calf", "a young walrus", "a walrus",
                 "It is vast, whiskered and thick-skinned, with tusks curving down from a heavy face.",
                 "Its blubbery body and tusks together make it seem both absurd and dangerous at once.",
                 "It carries itself with ancient, cumbersome authority.",
                 "ice floe and cold northern shore"),
-            AnimalBreathingMode.Blowhole);
+            AnimalBreathingMode.Blowhole,
+            description: """
+            Where ice edges, rocky shores, sandbars and rolling surf meets daily life, walruses are recognisable as flippered marine mammals. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The creature is best read through sleek coats, whiskered muzzles, blubbered bodies and limbs made for water first. Those features support awkward land movement transformed into easy swimming power, making the creature feel suited to its ground rather than merely placed there.
+
+            They gather where sea and land meet, noisy, watchful and more formidable than their soft-eyed faces imply. Around settlements, roads or camps, walruses add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
 
         yield return Aquatic("Dolphin", "Dolphin", "Cetacean", SizeCategory.Normal, 0.8, "Dolphin", "dolphin",
             AquaticPack("a dolphin calf", "a young dolphin", "a dolphin",
@@ -210,7 +469,14 @@ public partial class AnimalSeeder
                 "It moves with confident playful intelligence.",
                 "open coastal water and warm current"),
             AnimalBreathingMode.Blowhole,
-            combatStrategyKey: "Beast Skirmisher");
+            combatStrategyKey: "Beast Skirmisher",
+            description: """
+            Dolphins are large breath-holding marine mammals of coastal waters, cold currents, pelagic seas and migratory routes. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            Its profile is built around smooth skin, flukes, deep chests and shapes designed for long movement through water. In motion they are marked by fluid assurance and an intelligence that changes the mood of the sea around them, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They turn ocean into encounter rather than emptiness, inspiring awe, fear and stories wherever their backs break the surface. For characters nearby, a dolphin is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Aquatic("Porpoise", "Porpoise", "Cetacean", SizeCategory.Normal, 0.8, "Dolphin", "dolphin",
             AquaticPack("a porpoise calf", "a young porpoise", "a porpoise",
                 "It is shorter and more compact than a dolphin, with a neat blunt head and dark smooth skin.",
@@ -218,7 +484,14 @@ public partial class AnimalSeeder
                 "It surfaces and dives with understated assurance.",
                 "coastal current and cool sea"),
             AnimalBreathingMode.Blowhole,
-            combatStrategyKey: "Beast Skirmisher");
+            combatStrategyKey: "Beast Skirmisher",
+            description: """
+            In coastal waters, cold currents, pelagic seas and migratory routes, porpoises fill the role of large breath-holding marine mammals. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The creature presents smooth skin, flukes, deep chests and shapes designed for long movement through water. In motion they are marked by fluid assurance and an intelligence that changes the mood of the sea around them, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They turn ocean into encounter rather than emptiness, inspiring awe, fear and stories wherever their backs break the surface. For characters nearby, a porpoise is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Aquatic("Orca", "Orca", "Cetacean", SizeCategory.Large, 1.6, "Small Whale", "orca",
             AquaticPack("an orca calf", "a young orca", "an orca",
                 "It is black-and-white and powerfully built, with a massive jawline and heavy tail stock.",
@@ -226,7 +499,14 @@ public partial class AnimalSeeder
                 "It cuts through the water with top-predator certainty.",
                 "cold current and open sea"),
             AnimalBreathingMode.Blowhole,
-            combatStrategyKey: "Beast Behemoth");
+            combatStrategyKey: "Beast Behemoth",
+            description: """
+            Orcas occupy coastal waters, cold currents, pelagic seas and migratory routes as large breath-holding marine mammals. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            At a glance, the form resolves into smooth skin, flukes, deep chests and shapes designed for long movement through water. In motion they are marked by fluid assurance and an intelligence that changes the mood of the sea around them, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They turn ocean into encounter rather than emptiness, inspiring awe, fear and stories wherever their backs break the surface. For characters nearby, a orca is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Aquatic("Baleen Whale", "Baleen Whale", "Cetacean", SizeCategory.VeryLarge, 2.0, "Large Whale", "baleen-whale",
             AquaticPack("a whale calf", "a young whale", "a baleen whale",
                 "It is enormous, smooth-backed and impossibly heavy even by marine standards.",
@@ -234,7 +514,14 @@ public partial class AnimalSeeder
                 "It moves like weather given flesh.",
                 "deep sea and migratory water"),
             AnimalBreathingMode.Blowhole,
-            combatStrategyKey: "Beast Behemoth");
+            combatStrategyKey: "Beast Behemoth",
+            description: """
+            Where coastal waters, cold currents, pelagic seas and migratory routes meets daily life, baleen whales are recognisable as large breath-holding marine mammals. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The visible essentials are smooth skin, flukes, deep chests and shapes designed for long movement through water. In motion they are marked by fluid assurance and an intelligence that changes the mood of the sea around them, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They turn ocean into encounter rather than emptiness, inspiring awe, fear and stories wherever their backs break the surface. For characters nearby, a baleen whale is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Aquatic("Toothed Whale", "Toothed Whale", "Cetacean", SizeCategory.VeryLarge, 2.0, "Large Whale", "toothed-whale",
             AquaticPack("a whale calf", "a young whale", "a toothed whale",
                 "It is huge and deep-bodied, with a blunt skull and muscular flukes.",
@@ -242,6 +529,13 @@ public partial class AnimalSeeder
                 "It advances through the sea with grim, inexorable power.",
                 "deep ocean and pelagic current"),
             AnimalBreathingMode.Blowhole,
-            combatStrategyKey: "Beast Behemoth");
+            combatStrategyKey: "Beast Behemoth",
+            description: """
+            Toothed whales are large breath-holding marine mammals of coastal waters, cold currents, pelagic seas and migratory routes. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            Physically they are defined by smooth skin, flukes, deep chests and shapes designed for long movement through water. The impression is completed by fluid assurance and an intelligence that changes the mood of the sea around them, giving the animal a readable rhythm even before it acts.
+
+            They turn ocean into encounter rather than emptiness, inspiring awe, fear and stories wherever their backs break the surface. For characters nearby, a toothed whale is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
     }
 }

--- a/DatabaseSeeder/Seeders/AnimalSeeder.ArachnidTemplates.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.ArachnidTemplates.cs
@@ -18,12 +18,13 @@ public partial class AnimalSeeder
             double health,
             string model,
             string loadout,
-            AnimalDescriptionPack pack)
+            AnimalDescriptionPack pack,
+            string description)
         {
             return new AnimalRaceTemplate(
                 name,
                 name,
-                null,
+                description,
                 bodyKey,
                 size,
                 false,
@@ -45,18 +46,39 @@ public partial class AnimalSeeder
                 "It is a many-legged little hunter, all delicate limbs and poised body.",
                 "Its fangs and dark clustered eyes lend a sinister edge to an otherwise tiny frame.",
                 "It waits with taut stillness until movement invites violence.",
-                "web, wall corner and dark crevice"));
+                "web, wall corner and dark crevice"),
+            description: """
+            In webs, stone cracks, burrows, warm scrub and dry ruins, spiders fill the role of many-legged arachnids. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The first things to register are jointed legs, hard or hairy bodies, clustered eyes, fangs, claws or arched stingers. In motion they are marked by taut stillness, deliberate menace and sudden predatory commitment, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They make dark corners and loose stones feel occupied, whether as minor pests or genuine hazards. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Arthropod("Tarantula", "Arachnid", SizeCategory.Small, 0.25, "Arachnid", "tarantula",
             InsectPack("a tarantula spiderling", "a young tarantula", "a tarantula",
                 "It is thick-bodied and hairy, with a heavy abdomen and surprisingly substantial legs.",
                 "Its sheer size for a spider makes the fangs and clustered eyes much harder to dismiss.",
                 "It advances slowly, with a confidence that borders on contempt.",
-                "burrow, scrub and warm stone"));
+                "burrow, scrub and warm stone"),
+            description: """
+            Tarantulas occupy webs, stone cracks, burrows, warm scrub and dry ruins as many-legged arachnids. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            Its profile is built around jointed legs, hard or hairy bodies, clustered eyes, fangs, claws or arched stingers. In motion they are marked by taut stillness, deliberate menace and sudden predatory commitment, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They make dark corners and loose stones feel occupied, whether as minor pests or genuine hazards. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Arthropod("Scorpion", "Scorpion", SizeCategory.Small, 0.3, "Scorpion", "scorpion",
             InsectPack("a young scorpion", "a young scorpion", "a scorpion",
                 "It is armoured and low to the ground, with grasping claws and a curved tail arched over the body.",
                 "The sting held over its back gives it a constant look of loaded malice.",
                 "It creeps with deliberate menace, every movement measured and ready.",
-                "rock crack, desert floor and dry ruin"));
+                "rock crack, desert floor and dry ruin"),
+            description: """
+            Where webs, stone cracks, burrows, warm scrub and dry ruins meets daily life, scorpions are recognisable as many-legged arachnids. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The creature presents jointed legs, hard or hairy bodies, clustered eyes, fangs, claws or arched stingers. In motion they are marked by taut stillness, deliberate menace and sudden predatory commitment, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They make dark corners and loose stones feel occupied, whether as minor pests or genuine hazards. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
     }
 }

--- a/DatabaseSeeder/Seeders/AnimalSeeder.BirdTemplates.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.BirdTemplates.cs
@@ -17,7 +17,7 @@ public partial class AnimalSeeder
             string model,
             string loadout,
             AnimalDescriptionPack pack,
-            string? description = null,
+            string description,
             string combatStrategyKey = "Beast Skirmisher")
         {
             return new AnimalRaceTemplate(
@@ -47,323 +47,673 @@ public partial class AnimalSeeder
                 "It is plump and short-necked, with neat feathers and a bobbing head.",
                 "Iridescent tones gleam faintly about its neck whenever the light catches them.",
                 "It struts and coos with urban confidence.",
-                "town squares, rooftops and cliff ledges"));
+                "town squares, rooftops and cliff ledges"),
+            description: """
+            In gardens, thickets, orchards, hedgerows and open sky, pigeons fill the role of small birds of hedges, eaves and woodland edges. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The eye is drawn to light bones, neat plumage, quick beaks and wings made for brief, precise flights. Those features support flickering hops, sudden flutters and a constant awareness of cover, making the creature feel suited to its ground rather than merely placed there.
+
+            They add movement and sound to settled places, becoming part of the weather of daily life. A pigeon can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
         yield return Bird("Parrot", SizeCategory.VerySmall, 0.1, "Small Bird", "bird-small",
             BirdPack("a parrot chick", "a young parrot", "a parrot",
                 "It is bright-feathered and compact, with a hooked beak and expressive eyes.",
                 "Its beak and feet both look clever enough to manipulate seed, perch and object alike.",
                 "It watches the world with obvious intelligence and curiosity.",
-                "jungle canopy and warm woodland"));
+                "jungle canopy and warm woodland"),
+            description: """
+            Parrots occupy jungle canopy, warm woodland, orchards and river forests as bright, clever climbing birds. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            At a glance, the form resolves into hooked beaks, gripping feet, expressive eyes and plumage that refuses to be ignored. In motion they are marked by social mischief, noisy attention and careful manipulation of anything within reach, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They are companionable only on their own terms, clever enough to charm a household and ruin a latch. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Bird("Swallow", SizeCategory.VerySmall, 0.1, "Songbird", "bird-small",
             BirdPack("a swallow chick", "a young swallow", "a swallow",
                 "It is slim and delicate, with pointed wings and a forked tail.",
                 "Its entire body looks designed around speed and precision in the air.",
                 "It seems almost too restless to stay still for long.",
-                "barn eaves, cliff faces and open sky"));
+                "barn eaves, cliff faces and open sky"),
+            description: """
+            Where gardens, thickets, orchards, hedgerows and open sky meets daily life, swallows are recognisable as small birds of hedges, eaves and woodland edges. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            Physically they are defined by light bones, neat plumage, quick beaks and wings made for brief, precise flights. The impression is completed by flickering hops, sudden flutters and a constant awareness of cover, giving the animal a readable rhythm even before it acts.
+
+            They add movement and sound to settled places, becoming part of the weather of daily life. A swallow can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
         yield return Bird("Sparrow", SizeCategory.VerySmall, 0.05, "Songbird", "bird-small",
             BirdPack("a sparrow chick", "a young sparrow", "a sparrow",
                 "It is tiny and brown-feathered, with a compact beak and bright round eye.",
                 "Its short hops and quick movements make it look like a living scrap of feather and urgency.",
                 "It busies itself with constant pecks, flutters and little bursts of motion.",
-                "hedges, eaves and garden edge"));
+                "hedges, eaves and garden edge"),
+            description: """
+            Sparrows are small birds of hedges, eaves and woodland edges of gardens, thickets, orchards, hedgerows and open sky. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            The body plan is clear: light bones, neat plumage, quick beaks and wings made for brief, precise flights. Watch one move and the emphasis falls on flickering hops, sudden flutters and a constant awareness of cover, a pattern that tells more than size alone.
+
+            They add movement and sound to settled places, becoming part of the weather of daily life. A sparrow can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
         yield return Bird("Finch", SizeCategory.VerySmall, 0.05, "Songbird", "bird-small",
             BirdPack("a finch chick", "a young finch", "a finch",
                 "It is tiny, neat and brightly marked, with a short seed-cracking beak.",
                 "Its trim profile and clean plumage give it a delicate, jewel-like quality.",
                 "It flicks and chirrs with lively, nervous energy.",
-                "woodland edge, scrub and orchard"));
+                "woodland edge, scrub and orchard"),
+            description: """
+            In gardens, thickets, orchards, hedgerows and open sky, finches fill the role of small birds of hedges, eaves and woodland edges. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The body plan is clear: light bones, neat plumage, quick beaks and wings made for brief, precise flights. Watch one move and the emphasis falls on flickering hops, sudden flutters and a constant awareness of cover, a pattern that tells more than size alone.
+
+            They add movement and sound to settled places, becoming part of the weather of daily life. A finch can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
         yield return Bird("Robin", SizeCategory.VerySmall, 0.05, "Songbird", "bird-small",
             BirdPack("a robin chick", "a young robin", "a robin",
                 "It is small and round-bodied, with soft plumage and an alert stance.",
                 "Its breast stands out brightly against the softer browns and greys of the rest of its body.",
                 "It looks bold for so small a bird, ready to claim a branch or patch of ground as its own.",
-                "woodland edge, garden and hedgerow"));
+                "woodland edge, garden and hedgerow"),
+            description: """
+            Robins occupy gardens, thickets, orchards, hedgerows and open sky as small birds of hedges, eaves and woodland edges. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            The body plan is clear: light bones, neat plumage, quick beaks and wings made for brief, precise flights. Watch one move and the emphasis falls on flickering hops, sudden flutters and a constant awareness of cover, a pattern that tells more than size alone.
+
+            They add movement and sound to settled places, becoming part of the weather of daily life. A robin can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
         yield return Bird("Wren", SizeCategory.VerySmall, 0.05, "Songbird", "bird-small",
             BirdPack("a wren chick", "a young wren", "a wren",
                 "It is tiny and compact, with a cocked tail and fine brown plumage.",
                 "Its small sharp beak and bright eye make it look busy even while standing still.",
                 "It seems constantly on the verge of vanishing into a crack or clump of brush.",
-                "hedge, thicket and undergrowth"));
+                "hedge, thicket and undergrowth"),
+            description: """
+            Where gardens, thickets, orchards, hedgerows and open sky meets daily life, wrens are recognisable as small birds of hedges, eaves and woodland edges. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The body plan is clear: light bones, neat plumage, quick beaks and wings made for brief, precise flights. Watch one move and the emphasis falls on flickering hops, sudden flutters and a constant awareness of cover, a pattern that tells more than size alone.
+
+            They add movement and sound to settled places, becoming part of the weather of daily life. A wren can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
         yield return Bird("Quail", SizeCategory.VerySmall, 0.1, "Small Bird", "bird-fowl",
             BirdPack("a quail chick", "a young quail", "a quail",
                 "It is squat and earth-toned, with rounded wings and a neat compact body.",
                 "Its markings are ideal for melting into dry grass and leaf litter.",
                 "It looks much happier running under cover than taking to the air.",
                 "grassland and scrub undergrowth"),
-            combatStrategyKey: "Beast Coward");
+            combatStrategyKey: "Beast Coward",
+            description: """
+            Quails are earth-bound or ground-loving birds of field margins, moors, coops, scrub and forest floors. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            Physically they are defined by sturdy legs, rounded bodies and plumage meant for concealment, display or barnyard work. The impression is completed by more trust in running, scratching and sudden short flight than in open soaring, giving the animal a readable rhythm even before it acts.
+
+            They belong to hunting, farming and local noise, small presences that can still dominate a yard or thicket. Around settlements, roads or camps, quails add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Bird("Duck", SizeCategory.Small, 0.2, "Waterfowl", "bird-fowl",
             BirdPack("a duckling", "a young drake", "a duck",
                 "It is broad-billed and web-footed, with water-shedding plumage and a low-slung body.",
                 "Its bill and feet make its life on water obvious at a glance.",
                 "It carries itself with a comic, practical assurance.",
                 "pond, marsh and slow river"),
-            combatStrategyKey: "Beast Brawler");
+            combatStrategyKey: "Beast Brawler",
+            description: """
+            Ducks occupy ponds, lakes, marshes, slow rivers and sheltered coasts as broad-bodied water birds. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            The most telling cues are webbed feet, water-shedding feathers and bills shaped for grazing, filtering or dabbling. Those features support practical movement between water, mud and bank, making the creature feel suited to its ground rather than merely placed there.
+
+            They are familiar around water, useful as food or ornament, and capable of surprising force when defending space. A duck can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
         yield return Bird("Goose", SizeCategory.Small, 0.4, "Waterfowl", "bird-fowl",
             BirdPack("a gosling", "a young goose", "a goose",
                 "It is long-necked and broad-bodied, with a heavy bill and strong webbed feet.",
                 "Its reach and angry hiss suggest that it is much more formidable than its shape first implies.",
                 "It looks argumentative even at rest.",
                 "lake edge, marsh pasture and open water"),
-            combatStrategyKey: "Beast Brawler");
+            combatStrategyKey: "Beast Brawler",
+            description: """
+            Where ponds, lakes, marshes, slow rivers and sheltered coasts meets daily life, geese are recognisable as broad-bodied water birds. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            Most of its character sits in webbed feet, water-shedding feathers and bills shaped for grazing, filtering or dabbling. Those features support practical movement between water, mud and bank, making the creature feel suited to its ground rather than merely placed there.
+
+            They are familiar around water, useful as food or ornament, and capable of surprising force when defending space. A goose can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
         yield return Bird("Swan", SizeCategory.Small, 0.4, "Waterfowl", "bird-fowl",
             BirdPack("a cygnet", "a young swan", "a swan",
                 "It is long-necked and elegantly proportioned, clothed in clean layered plumage.",
                 "Its broad wings and poised carriage give it a regal, almost theatrical profile.",
                 "It glides or stalks with deliberate grace.",
                 "lake, broad river and ornamental water"),
-            combatStrategyKey: "Beast Brawler");
+            combatStrategyKey: "Beast Brawler",
+            description: """
+            Swans are broad-bodied water birds of ponds, lakes, marshes, slow rivers and sheltered coasts. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            Look closer and the outline is all webbed feet, water-shedding feathers and bills shaped for grazing, filtering or dabbling. In motion they are marked by practical movement between water, mud and bank, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They are familiar around water, useful as food or ornament, and capable of surprising force when defending space. Around settlements, roads or camps, swans add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Bird("Grouse", SizeCategory.Small, 0.2, "Small Bird", "bird-fowl",
             BirdPack("a grouse chick", "a young grouse", "a grouse",
                 "It is round-bodied and heavily feathered, marked in mottled browns and greys.",
                 "Its camouflage is excellent, and its dense plumage suits cold scrub and rough ground.",
                 "It seems far more comfortable bursting into brief noisy flight than soaring.",
-                "moor, heath and rough forest floor"));
+                "moor, heath and rough forest floor"),
+            description: """
+            In field margins, moors, coops, scrub and forest floors, grouses fill the role of earth-bound or ground-loving birds. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            Physically they are defined by sturdy legs, rounded bodies and plumage meant for concealment, display or barnyard work. The impression is completed by more trust in running, scratching and sudden short flight than in open soaring, giving the animal a readable rhythm even before it acts.
+
+            They belong to hunting, farming and local noise, small presences that can still dominate a yard or thicket. Around settlements, roads or camps, grouses add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Bird("Pheasant", SizeCategory.Small, 0.2, "Small Bird", "bird-fowl",
             BirdPack("a pheasant chick", "a young pheasant", "a pheasant",
                 "It is long-tailed and elegant, with layered feathers and a light but athletic build.",
                 "Its head and neck carry the sort of colouring that can flare brilliantly in full-grown males.",
                 "It has the alert, skittish poise of a bird that trusts its legs before its wings.",
-                "field margin, light woodland and hedgerow"));
+                "field margin, light woodland and hedgerow"),
+            description: """
+            Pheasants occupy field margins, moors, coops, scrub and forest floors as earth-bound or ground-loving birds. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            Physically they are defined by sturdy legs, rounded bodies and plumage meant for concealment, display or barnyard work. The impression is completed by more trust in running, scratching and sudden short flight than in open soaring, giving the animal a readable rhythm even before it acts.
+
+            They belong to hunting, farming and local noise, small presences that can still dominate a yard or thicket. Around settlements, roads or camps, pheasants add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Bird("Chicken", SizeCategory.Small, 0.2, "Waterfowl", "bird-fowl",
             BirdPack("a chick", "a young chicken", "a chicken",
                 "It is compact and practical, with a thick body, short wings and sturdy scratching feet.",
                 "Its comb, wattles and blunt beak give it an unmistakably domestic look.",
                 "It fusses and scratches with constant barnyard purpose.",
                 "yard, coop and farmstead"),
-            combatStrategyKey: "Beast Brawler");
+            combatStrategyKey: "Beast Brawler",
+            description: """
+            Where field margins, moors, coops, scrub and forest floors meets daily life, chickens are recognisable as earth-bound or ground-loving birds. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            Physically they are defined by sturdy legs, rounded bodies and plumage meant for concealment, display or barnyard work. The impression is completed by more trust in running, scratching and sudden short flight than in open soaring, giving the animal a readable rhythm even before it acts.
+
+            They belong to hunting, farming and local noise, small presences that can still dominate a yard or thicket. Around settlements, roads or camps, chickens add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Bird("Turkey", SizeCategory.Small, 0.35, "Waterfowl", "bird-fowl",
             BirdPack("a poult", "a young turkey", "a turkey",
                 "It is broad and heavy, with a fan-like tail and powerful legs.",
                 "Its bare head and fleshy wattles give it an oddly severe look.",
                 "It struts with a mixture of caution and bluster.",
                 "woodland edge and rough pasture"),
-            combatStrategyKey: "Beast Brawler");
+            combatStrategyKey: "Beast Brawler",
+            description: """
+            Turkeys are earth-bound or ground-loving birds of field margins, moors, coops, scrub and forest floors. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            The body plan is clear: sturdy legs, rounded bodies and plumage meant for concealment, display or barnyard work. Watch one move and the emphasis falls on more trust in running, scratching and sudden short flight than in open soaring, a pattern that tells more than size alone.
+
+            They belong to hunting, farming and local noise, small presences that can still dominate a yard or thicket. Around settlements, roads or camps, turkeys add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Bird("Seagull", SizeCategory.Small, 0.2, "Small Bird", "bird-small",
             BirdPack("a gull chick", "a young gull", "a gull",
                 "It is light-bodied and strong-winged, with a sharp bill and webbed feet.",
                 "Its hard eyes and hooked posture suggest a bird always ready to steal or scavenge.",
                 "It moves with loud, unapologetic confidence.",
-                "shoreline, harbour and windswept coast"));
+                "shoreline, harbour and windswept coast"),
+            description: """
+            Seagulls are coastal and ocean-going birds of harbours, cliffs, shorelines, open sea and salt wind. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            What distinguishes the line is strong wings, practical bills and bodies conditioned by distance and weather. Those features support wind-reading confidence and a scavenger's eye for opportunity, making the creature feel suited to its ground rather than merely placed there.
+
+            Their calls and silhouettes mark coasts, storms and ships, turning empty water into watched space. Around settlements, roads or camps, seagulls add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Bird("Albatross", SizeCategory.Small, 0.35, "Raptor", "bird-small",
             BirdPack("an albatross chick", "a young albatross", "an albatross",
                 "It is long-winged and ocean-built, with a sturdy bill and narrow body.",
                 "Its immense wings suggest a creature that belongs more to the wind than to the earth.",
                 "It gives the impression of effortless distance and cold salt air.",
                 "open ocean and lonely cliff rookery"),
-            combatStrategyKey: "Beast Swooper");
+            combatStrategyKey: "Beast Swooper",
+            description: """
+            In harbours, cliffs, shorelines, open sea and salt wind, albatrosses fill the role of coastal and ocean-going birds. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The creature is best read through strong wings, practical bills and bodies conditioned by distance and weather. Those features support wind-reading confidence and a scavenger's eye for opportunity, making the creature feel suited to its ground rather than merely placed there.
+
+            Their calls and silhouettes mark coasts, storms and ships, turning empty water into watched space. Around settlements, roads or camps, albatrosses add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Bird("Heron", SizeCategory.Small, 0.2, "Wader", "bird-small",
             BirdPack("a heron chick", "a young heron", "a heron",
                 "It is narrow-bodied and long-necked, with immense legs and a dagger bill.",
                 "Its posture is all patient angles, every line arranged for stalking and striking into water.",
                 "It stands with statuesque stillness until movement becomes necessary.",
-                "reedbed, tidal flat and shallow river"));
+                "reedbed, tidal flat and shallow river"),
+            description: """
+            Herons occupy reedbeds, tidal flats, flooded fields and shallow rivers as long-legged wading birds. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            Its strongest visual signs are lifted bodies, long legs, patient necks and bills made for probing or sudden strikes. Those features support measured stillness followed by precise movement, making the creature feel suited to its ground rather than merely placed there.
+
+            They give marshland a ceremonial quiet, as if every pool and reedbed has its own sentinel. Around settlements, roads or camps, herons add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Bird("Crane", SizeCategory.Small, 0.2, "Wader", "bird-small",
             BirdPack("a crane chick", "a young crane", "a crane",
                 "It is tall, elegant and long-legged, with a lifted neck and measured stride.",
                 "Its clean lines and poised head give it a ceremonial, almost courtly quality.",
                 "It moves with calm precision and guarded dignity.",
-                "wet meadow, marsh and open floodplain"));
+                "wet meadow, marsh and open floodplain"),
+            description: """
+            Where reedbeds, tidal flats, flooded fields and shallow rivers meets daily life, cranes are recognisable as long-legged wading birds. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The eye is drawn to lifted bodies, long legs, patient necks and bills made for probing or sudden strikes. Those features support measured stillness followed by precise movement, making the creature feel suited to its ground rather than merely placed there.
+
+            They give marshland a ceremonial quiet, as if every pool and reedbed has its own sentinel. Around settlements, roads or camps, cranes add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Bird("Flamingo", SizeCategory.Small, 0.2, "Wader", "bird-small",
             BirdPack("a flamingo chick", "a young flamingo", "a flamingo",
                 "It is long-legged and improbably narrow, balanced above broad webbed feet.",
                 "Its bent bill and tall stance make it look perfectly specialized for filtering food from shallow water.",
                 "It seems built from equal parts grace and absurdity.",
-                "salt flat, lagoon and shallow estuary"));
+                "salt flat, lagoon and shallow estuary"),
+            description: """
+            Flamingos are long-legged wading birds of reedbeds, tidal flats, flooded fields and shallow rivers. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            At a glance, the form resolves into lifted bodies, long legs, patient necks and bills made for probing or sudden strikes. In motion they are marked by measured stillness followed by precise movement, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They give marshland a ceremonial quiet, as if every pool and reedbed has its own sentinel. For characters nearby, a flamingo is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Bird("Peacock", SizeCategory.Small, 0.2, "Small Bird", "bird-fowl",
             BirdPack("a peachick", "a young peafowl", "a peafowl",
                 "It is long-bodied and richly feathered, with a proud neck and elaborate tail coverts.",
                 "Its carriage alone suggests a bird that expects to be noticed.",
                 "It moves like something born for display rather than concealment.",
-                "garden, palace grounds and light woodland"));
+                "garden, palace grounds and light woodland"),
+            description: """
+            In field margins, moors, coops, scrub and forest floors, peacocks fill the role of earth-bound or ground-loving birds. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The body plan is clear: sturdy legs, rounded bodies and plumage meant for concealment, display or barnyard work. Watch one move and the emphasis falls on more trust in running, scratching and sudden short flight than in open soaring, a pattern that tells more than size alone.
+
+            They belong to hunting, farming and local noise, small presences that can still dominate a yard or thicket. Around settlements, roads or camps, peacocks add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Bird("Ibis", SizeCategory.Small, 0.2, "Wader", "bird-small",
             BirdPack("an ibis chick", "a young ibis", "an ibis",
                 "It is slim, long-necked and down-curved of bill, with a tidy compact body.",
                 "Its beak looks perfect for probing wet mud and shallow water.",
                 "It picks its way through marshy ground with neat concentration.",
-                "marsh, floodplain and river shallows"));
+                "marsh, floodplain and river shallows"),
+            description: """
+            In reedbeds, tidal flats, flooded fields and shallow rivers, ibises fill the role of long-legged wading birds. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The visible essentials are lifted bodies, long legs, patient necks and bills made for probing or sudden strikes. In motion they are marked by measured stillness followed by precise movement, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They give marshland a ceremonial quiet, as if every pool and reedbed has its own sentinel. For characters nearby, a ibis is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Bird("Pelican", SizeCategory.Small, 0.5, "Waterfowl", "bird-small",
             BirdPack("a pelican chick", "a young pelican", "a pelican",
                 "It is broad-winged and heavy-billed, with a loose throat pouch beneath the beak.",
                 "Its enormous bill dominates its entire profile and looks made to scoop whole buckets of water.",
                 "It has the ungainly authority of a bird too specialized to care how it looks.",
-                "coast, estuary and warm lake"));
+                "coast, estuary and warm lake"),
+            description: """
+            In ponds, lakes, marshes, slow rivers and sheltered coasts, pelicans fill the role of broad-bodied water birds. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The first things to register are webbed feet, water-shedding feathers and bills shaped for grazing, filtering or dabbling. In motion they are marked by practical movement between water, mud and bank, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They are familiar around water, useful as food or ornament, and capable of surprising force when defending space. Around settlements, roads or camps, pelicans add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Bird("Crow", SizeCategory.Small, 0.2, "Small Bird", "bird-small",
             BirdPack("a crow chick", "a young crow", "a crow",
                 "It is black-feathered and sharp-beaked, with bright intelligent eyes.",
                 "Its careful gaze gives it the unsettling impression of actually considering what it sees.",
                 "It carries itself with clever, opportunistic self-possession.",
-                "woodland edge, field and refuse heap"));
+                "woodland edge, field and refuse heap"),
+            description: """
+            Crows are black-feathered clever birds of woodland edges, cliffs, fields, refuse heaps and lonely moors. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            Physically they are defined by dark plumage, strong bills and eyes that seem to weigh what they see. The impression is completed by opportunistic patience and deliberate, intelligent motion, giving the animal a readable rhythm even before it acts.
+
+            They gather around waste, battlefields and roads, where their intelligence makes them feel less like scenery than witnesses. For characters nearby, a crow is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Bird("Raven", SizeCategory.Small, 0.2, "Small Bird", "bird-small",
             BirdPack("a raven chick", "a young raven", "a raven",
                 "It is larger and heavier than a crow, with deep black plumage and a thick bill.",
                 "Its shaggy throat and heavy head give it a sombre, ancient look.",
                 "It watches with a grave intensity that seems almost human.",
-                "cliff, conifer forest and lonely moor"));
+                "cliff, conifer forest and lonely moor"),
+            description: """
+            In woodland edges, cliffs, fields, refuse heaps and lonely moors, ravens fill the role of black-feathered clever birds. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            Physically they are defined by dark plumage, strong bills and eyes that seem to weigh what they see. The impression is completed by opportunistic patience and deliberate, intelligent motion, giving the animal a readable rhythm even before it acts.
+
+            They gather around waste, battlefields and roads, where their intelligence makes them feel less like scenery than witnesses. For characters nearby, a raven is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Bird("Emu", SizeCategory.Normal, 0.8, "Flightless Bird", "bird-flightless",
             BirdPack("an emu chick", "a young emu", "an emu",
                 "It is tall and long-legged, clothed in shaggy weatherproof feathers.",
                 "Its narrow head and powerful thighs make it look built for speed over rough ground.",
                 "It seems more likely to outrun danger than to rise above it.",
                 "scrubland and open plain"),
-            combatStrategyKey: "Beast Physical Avoider");
+            combatStrategyKey: "Beast Physical Avoider",
+            description: """
+            Emus occupy scrubland, open plain, rainforest floor, fern cover and cold shore as large or specialised flightless birds. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            Physically they are defined by powerful legs, reduced wings and bodies committed to running, swimming or ground life. The impression is completed by a grounded confidence that replaces flight with speed, strength or stubborn endurance, giving the animal a readable rhythm even before it acts.
+
+            They unsettle expectations of what birds should be, especially when their feet, claws or mass become the main danger. For characters nearby, a emu is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Bird("Ostrich", SizeCategory.Normal, 0.8, "Flightless Bird", "bird-flightless",
             BirdPack("an ostrich chick", "a young ostrich", "an ostrich",
                 "It is huge, long-necked and massively legged, its body topped by soft black-and-white plumage.",
                 "Its feet and legs are terrifyingly strong for any creature willing to stand in kicking distance.",
                 "It carries itself with wary hauteur and tremendous athletic tension.",
                 "savannah and dry open plain"),
-            combatStrategyKey: "Beast Physical Avoider");
+            combatStrategyKey: "Beast Physical Avoider",
+            description: """
+            Where scrubland, open plain, rainforest floor, fern cover and cold shore meets daily life, ostriches are recognisable as large or specialised flightless birds. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            Physically they are defined by powerful legs, reduced wings and bodies committed to running, swimming or ground life. The impression is completed by a grounded confidence that replaces flight with speed, strength or stubborn endurance, giving the animal a readable rhythm even before it acts.
+
+            They unsettle expectations of what birds should be, especially when their feet, claws or mass become the main danger. For characters nearby, a ostrich is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Bird("Moa", SizeCategory.Normal, 0.8, "Flightless Bird", "bird-flightless",
             BirdPack("a moa chick", "a young moa", "a moa",
                 "It is immense and heavy-bodied, with stout legs and a thick neck.",
                 "It has the grounded, prehistoric solidity of a bird that never needed the sky.",
                 "It lumbers with powerful, long-paced strides.",
                 "open forest and grassy upland"),
-            combatStrategyKey: "Beast Behemoth");
+            combatStrategyKey: "Beast Behemoth",
+            description: """
+            Moas are large or specialised flightless birds of scrubland, open plain, rainforest floor, fern cover and cold shore. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            The body plan is clear: powerful legs, reduced wings and bodies committed to running, swimming or ground life. Watch one move and the emphasis falls on a grounded confidence that replaces flight with speed, strength or stubborn endurance, a pattern that tells more than size alone.
+
+            They unsettle expectations of what birds should be, especially when their feet, claws or mass become the main danger. For characters nearby, a moa is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Bird("Vulture", SizeCategory.Small, 0.35, "Raptor", "bird-raptor",
             BirdPack("a vulture chick", "a young vulture", "a vulture",
                 "It is broad-winged and bare-headed, with a hooked bill and a hunched stance.",
                 "Its naked head and deep chest make it look purpose-built for feeding where others would balk.",
                 "It has the patient circling assurance of a scavenger with time on its side.",
                 "cliff, thermal and arid plain"),
-            combatStrategyKey: "Beast Swooper");
+            combatStrategyKey: "Beast Swooper",
+            description: """
+            Vultures are birds of prey of cliffs, thermals, mountain air, open fields and forest edges. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            The most telling cues are hooked beaks, talons, keen eyes and wings designed around height and sudden attack. Those features support watchful patience overhead and decisive violence when they commit, making the creature feel suited to its ground rather than merely placed there.
+
+            They are admired, trained, feared and read as omens because they make the sky feel predatory. For characters nearby, a vulture is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Bird("Hawk", SizeCategory.Small, 0.35, "Raptor", "bird-raptor",
             BirdPack("a hawk chick", "a young hawk", "a hawk",
                 "It is sharp-winged and compact, with bright predatory eyes and a hooked bill.",
                 "Its talons and chest look built for sudden impact and secure killing grip.",
                 "It seems alert to every movement around it.",
                 "woodland edge, hill country and open field"),
-            combatStrategyKey: "Beast Swooper");
+            combatStrategyKey: "Beast Swooper",
+            description: """
+            In cliffs, thermals, mountain air, open fields and forest edges, hawks fill the role of birds of prey. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            Most of its character sits in hooked beaks, talons, keen eyes and wings designed around height and sudden attack. Those features support watchful patience overhead and decisive violence when they commit, making the creature feel suited to its ground rather than merely placed there.
+
+            They are admired, trained, feared and read as omens because they make the sky feel predatory. For characters nearby, a hawk is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Bird("Eagle", SizeCategory.Normal, 0.7, "Raptor", "bird-raptor",
             BirdPack("an eaglet", "a young eagle", "an eagle",
                 "It is broad-winged and heavy-bodied, with a fierce hooked bill and enormous talons.",
                 "Its head and shoulders carry the hard, imperial line of a dominant aerial predator.",
                 "It watches the world with remorseless patience.",
                 "mountain, cliff and open sky"),
-            combatStrategyKey: "Beast Dropper");
+            combatStrategyKey: "Beast Dropper",
+            description: """
+            Eagles occupy cliffs, thermals, mountain air, open fields and forest edges as birds of prey. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            What distinguishes the line is hooked beaks, talons, keen eyes and wings designed around height and sudden attack. Those features support watchful patience overhead and decisive violence when they commit, making the creature feel suited to its ground rather than merely placed there.
+
+            They are admired, trained, feared and read as omens because they make the sky feel predatory. For characters nearby, a eagle is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Bird("Falcon", SizeCategory.Small, 0.35, "Raptor", "bird-raptor",
             BirdPack("a falcon chick", "a young falcon", "a falcon",
                 "It is streamlined and narrow-winged, with a small hooked bill and an athlete's frame.",
                 "Its wings and body together suggest sudden acceleration more than lingering soar.",
                 "It looks taut, precise and built for devastating speed.",
                 "cliff face, open plain and high air"),
-            combatStrategyKey: "Beast Swooper");
+            combatStrategyKey: "Beast Swooper",
+            description: """
+            Where cliffs, thermals, mountain air, open fields and forest edges meets daily life, falcons are recognisable as birds of prey. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The creature is best read through hooked beaks, talons, keen eyes and wings designed around height and sudden attack. Those features support watchful patience overhead and decisive violence when they commit, making the creature feel suited to its ground rather than merely placed there.
+
+            They are admired, trained, feared and read as omens because they make the sky feel predatory. For characters nearby, a falcon is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Bird("Woodpecker", SizeCategory.Small, 0.35, "Small Bird", "bird-small",
             BirdPack("a woodpecker chick", "a young woodpecker", "a woodpecker",
                 "It is compact and upright, with a chisel beak and climbing feet.",
                 "Its tail and claws give it the strange purposeful look of a creature designed to cling to bark.",
                 "It looks restless, mechanical and industrious all at once.",
-                "forest trunk and orchard tree"));
+                "forest trunk and orchard tree"),
+            description: """
+            Woodpeckers are bright, clever climbing birds of jungle canopy, warm woodland, orchards and river forests. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            The body plan is clear: hooked beaks, gripping feet, expressive eyes and plumage that refuses to be ignored. Watch one move and the emphasis falls on social mischief, noisy attention and careful manipulation of anything within reach, a pattern that tells more than size alone.
+
+            They are companionable only on their own terms, clever enough to charm a household and ruin a latch. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Bird("Owl", SizeCategory.Small, 0.35, "Raptor", "bird-raptor",
             BirdPack("an owlet", "a young owl", "an owl",
                 "It is broad-headed and soft-feathered, with a round face and great front-facing eyes.",
                 "Its silent plumage and hooked beak make it look like a patient engine of nocturnal death.",
                 "It gives off an eerie stillness even when awake.",
                 "forest, ruin and moonlit field"),
-            combatStrategyKey: "Beast Swooper");
+            combatStrategyKey: "Beast Swooper",
+            description: """
+            Owls are birds of prey of cliffs, thermals, mountain air, open fields and forest edges. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            Its profile is built around hooked beaks, talons, keen eyes and wings designed around height and sudden attack. In motion they are marked by watchful patience overhead and decisive violence when they commit, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They are admired, trained, feared and read as omens because they make the sky feel predatory. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Bird("Kingfisher", SizeCategory.Small, 0.35, "Small Bird", "bird-small",
             BirdPack("a kingfisher chick", "a young kingfisher", "a kingfisher",
                 "It is neat and jewel-bright, with a large head and long pointed bill.",
                 "Its beak and compact muscular body are perfect for sudden dives into water.",
                 "It seems all alert balance and explosive precision.",
-                "stream bank and shaded river"));
+                "stream bank and shaded river"),
+            description: """
+            Where jungle canopy, warm woodland, orchards and river forests meets daily life, kingfishers are recognisable as bright, clever climbing birds. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            Physically they are defined by hooked beaks, gripping feet, expressive eyes and plumage that refuses to be ignored. The impression is completed by social mischief, noisy attention and careful manipulation of anything within reach, giving the animal a readable rhythm even before it acts.
+
+            They are companionable only on their own terms, clever enough to charm a household and ruin a latch. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Bird("Stork", SizeCategory.Small, 0.35, "Wader", "bird-small",
             BirdPack("a stork chick", "a young stork", "a stork",
                 "It is tall and clean-lined, carried on long legs beneath a narrow body and powerful wings.",
                 "Its long bill and poised stride make it look every inch a wetland hunter.",
                 "It advances with quiet confidence and measured economy.",
-                "marsh, river shallows and flooded field"));
+                "marsh, river shallows and flooded field"),
+            description: """
+            Storks occupy reedbeds, tidal flats, flooded fields and shallow rivers as long-legged wading birds. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            Look closer and the outline is all lifted bodies, long legs, patient necks and bills made for probing or sudden strikes. In motion they are marked by measured stillness followed by precise movement, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They give marshland a ceremonial quiet, as if every pool and reedbed has its own sentinel. For characters nearby, a stork is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Bird("Mandarin Duck", SizeCategory.Small, 0.2, "Waterfowl", "bird-fowl",
             BirdPack("a mandarin duckling", "a young mandarin duck", "a mandarin duck",
                 "It is compact and ornate, with layered plumage that can show sails, stripes and polished colour.",
                 "Its tidy bill and webbed feet mark it as a duck even beneath its dramatic display feathers.",
                 "It moves with quick waterfowl practicality under a startlingly decorative surface.",
                 "wooded pond, slow river and sheltered wetland"),
-            combatStrategyKey: "Beast Brawler");
+            combatStrategyKey: "Beast Brawler",
+            description: """
+            Mandarin ducks occupy ponds, lakes, marshes, slow rivers and sheltered coasts as broad-bodied water birds. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            Its profile is built around webbed feet, water-shedding feathers and bills shaped for grazing, filtering or dabbling. In motion they are marked by practical movement between water, mud and bank, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They are familiar around water, useful as food or ornament, and capable of surprising force when defending space. Around settlements, roads or camps, mandarin ducks add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Bird("Red-Crowned Crane", SizeCategory.Small, 0.25, "Wader", "bird-small",
             BirdPack("a red-crowned crane chick", "a young red-crowned crane", "a red-crowned crane",
                 "It is tall and white-bodied, with black wing edges and a vivid red crown.",
                 "Its long neck, measured stride and precise bearing give it a ceremonial stillness.",
                 "It seems made for marshland dances and patient, elegant watchfulness.",
-                "reed marsh, snowy wetland and open floodplain"));
+                "reed marsh, snowy wetland and open floodplain"),
+            description: """
+            Where reedbeds, tidal flats, flooded fields and shallow rivers meets daily life, red-crowned cranes are recognisable as long-legged wading birds. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The first things to register are lifted bodies, long legs, patient necks and bills made for probing or sudden strikes. In motion they are marked by measured stillness followed by precise movement, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They give marshland a ceremonial quiet, as if every pool and reedbed has its own sentinel. For characters nearby, a red-crowned crane is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Bird("Macaw", SizeCategory.Small, 0.25, "Small Bird", "bird-small",
             BirdPack("a macaw chick", "a young macaw", "a macaw",
                 "It is large for a parrot, bright-feathered and long-tailed, with a heavy hooked beak.",
                 "Its strong bill and clever feet make it look capable of worrying apart nut, branch or latch.",
                 "It watches noisily and intelligently, confident in both colour and volume.",
-                "rainforest canopy and warm river forest"));
+                "rainforest canopy and warm river forest"),
+            description: """
+            Where jungle canopy, warm woodland, orchards and river forests meets daily life, macaws are recognisable as bright, clever climbing birds. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The visible essentials are hooked beaks, gripping feet, expressive eyes and plumage that refuses to be ignored. In motion they are marked by social mischief, noisy attention and careful manipulation of anything within reach, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They are companionable only on their own terms, clever enough to charm a household and ruin a latch. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Bird("Toucan", SizeCategory.Small, 0.25, "Small Bird", "bird-small",
             BirdPack("a toucan chick", "a young toucan", "a toucan",
                 "It is compact-bodied and dominated by an enormous bright bill.",
                 "Its light frame and oversized beak give it a striking, almost impossible silhouette.",
                 "It hops and turns with alert canopy confidence.",
-                "tropical forest canopy and fruiting river trees"));
+                "tropical forest canopy and fruiting river trees"),
+            description: """
+            Toucans are bright, clever climbing birds of jungle canopy, warm woodland, orchards and river forests. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            Physically they are defined by hooked beaks, gripping feet, expressive eyes and plumage that refuses to be ignored. The impression is completed by social mischief, noisy attention and careful manipulation of anything within reach, giving the animal a readable rhythm even before it acts.
+
+            They are companionable only on their own terms, clever enough to charm a household and ruin a latch. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Bird("Hummingbird", SizeCategory.Tiny, 0.05, "Songbird", "bird-small",
             BirdPack("a hummingbird chick", "a young hummingbird", "a hummingbird",
                 "It is tiny and jewel-bright, with needle bill, minute feet and wings built for hovering.",
                 "Every part of it looks compressed toward speed, precision and nectar-seeking.",
                 "It vibrates through the air with impossible urgency.",
-                "flowering scrub, garden edge and tropical forest margin"));
+                "flowering scrub, garden edge and tropical forest margin"),
+            description: """
+            Hummingbirds are small birds of hedges, eaves and woodland edges of gardens, thickets, orchards, hedgerows and open sky. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            Its strongest visual signs are light bones, neat plumage, quick beaks and wings made for brief, precise flights. Those features support flickering hops, sudden flutters and a constant awareness of cover, making the creature feel suited to its ground rather than merely placed there.
+
+            They add movement and sound to settled places, becoming part of the weather of daily life. A hummingbird can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
         yield return Bird("Condor", SizeCategory.Normal, 0.7, "Raptor", "bird-raptor",
             BirdPack("a condor chick", "a young condor", "a condor",
                 "It is immense and black-winged, with pale flight feathers and a bare watchful head.",
                 "Its wingspan and patient gaze make it look like a cliff wind given bone and appetite.",
                 "It carries the grave economy of a scavenger that can wait longer than hunger can hide.",
                 "Andean cliff, high thermal and open mountain sky"),
-            combatStrategyKey: "Beast Swooper");
+            combatStrategyKey: "Beast Swooper",
+            description: """
+            In cliffs, thermals, mountain air, open fields and forest edges, condors fill the role of birds of prey. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The creature presents hooked beaks, talons, keen eyes and wings designed around height and sudden attack. In motion they are marked by watchful patience overhead and decisive violence when they commit, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They are admired, trained, feared and read as omens because they make the sky feel predatory. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Bird("Rhea", SizeCategory.Normal, 0.7, "Flightless Bird", "bird-flightless",
             BirdPack("a rhea chick", "a young rhea", "a rhea",
                 "It is long-legged and grey-brown, with a small head and soft, loose feathers.",
                 "Its body has the open-country build of a bird that trusts running far more than hiding.",
                 "It moves with wary speed across wide grassland.",
                 "pampas, scrub plain and open savannah"),
-            combatStrategyKey: "Beast Physical Avoider");
+            combatStrategyKey: "Beast Physical Avoider",
+            description: """
+            In scrubland, open plain, rainforest floor, fern cover and cold shore, rheas fill the role of large or specialised flightless birds. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The body plan is clear: powerful legs, reduced wings and bodies committed to running, swimming or ground life. Watch one move and the emphasis falls on a grounded confidence that replaces flight with speed, strength or stubborn endurance, a pattern that tells more than size alone.
+
+            They unsettle expectations of what birds should be, especially when their feet, claws or mass become the main danger. For characters nearby, a rhea is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Bird("Hoatzin", SizeCategory.Small, 0.2, "Small Bird", "bird-fowl",
             BirdPack("a hoatzin chick", "a young hoatzin", "a hoatzin",
                 "It is crested and long-tailed, with chestnut and olive plumage arranged in untidy splendour.",
                 "Its odd body and leaf-eating habits give it an ancient, swamp-bound awkwardness.",
                 "It clambers and flutters with more character than grace.",
                 "flooded forest, oxbow lake and river thicket"),
-            combatStrategyKey: "Beast Coward");
+            combatStrategyKey: "Beast Coward",
+            description: """
+            Hoatzins occupy field margins, moors, coops, scrub and forest floors as earth-bound or ground-loving birds. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            The body plan is clear: sturdy legs, rounded bodies and plumage meant for concealment, display or barnyard work. Watch one move and the emphasis falls on more trust in running, scratching and sudden short flight than in open soaring, a pattern that tells more than size alone.
+
+            They belong to hunting, farming and local noise, small presences that can still dominate a yard or thicket. Around settlements, roads or camps, hoatzins add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Bird("Cockatoo", SizeCategory.Small, 0.25, "Small Bird", "bird-small",
             BirdPack("a cockatoo chick", "a young cockatoo", "a cockatoo",
                 "It is pale and strong-beaked, with an expressive crest and intelligent dark eyes.",
                 "Its bill and gripping feet suggest a bird equally ready to crack seed or test anything left unattended.",
                 "It carries itself with bright, social mischief.",
-                "eucalypt woodland, orchard edge and open forest"));
+                "eucalypt woodland, orchard edge and open forest"),
+            description: """
+            In jungle canopy, warm woodland, orchards and river forests, cockatoos fill the role of bright, clever climbing birds. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            Physically they are defined by hooked beaks, gripping feet, expressive eyes and plumage that refuses to be ignored. The impression is completed by social mischief, noisy attention and careful manipulation of anything within reach, giving the animal a readable rhythm even before it acts.
+
+            They are companionable only on their own terms, clever enough to charm a household and ruin a latch. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Bird("Kookaburra", SizeCategory.Small, 0.25, "Small Bird", "bird-small",
             BirdPack("a kookaburra chick", "a young kookaburra", "a kookaburra",
                 "It is sturdy and big-headed, with a long heavy bill and compact brown-and-white plumage.",
                 "Its whole body seems arranged around a sudden downward strike from a branch.",
                 "It watches the ground with blunt predatory patience.",
                 "woodland branch, river gum and open forest"),
-            combatStrategyKey: "Beast Swooper");
+            combatStrategyKey: "Beast Swooper",
+            description: """
+            Kookaburras occupy jungle canopy, warm woodland, orchards and river forests as bright, clever climbing birds. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            Physically they are defined by hooked beaks, gripping feet, expressive eyes and plumage that refuses to be ignored. The impression is completed by social mischief, noisy attention and careful manipulation of anything within reach, giving the animal a readable rhythm even before it acts.
+
+            They are companionable only on their own terms, clever enough to charm a household and ruin a latch. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Bird("Cassowary", SizeCategory.Normal, 0.9, "Flightless Bird", "bird-flightless",
             BirdPack("a cassowary chick", "a young cassowary", "a cassowary",
                 "It is tall, black-feathered and heavy-legged, with a casque rising from a brilliantly coloured head.",
                 "Its deep body, dagger-like claws and forward drive make it look dangerously prehistoric.",
                 "It has the tense, private menace of a forest bird that does not like being approached.",
                 "rainforest floor and dense tropical thicket"),
-            combatStrategyKey: "Beast Brawler");
+            combatStrategyKey: "Beast Brawler",
+            description: """
+            Cassowaries occupy scrubland, open plain, rainforest floor, fern cover and cold shore as large or specialised flightless birds. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            The body plan is clear: powerful legs, reduced wings and bodies committed to running, swimming or ground life. Watch one move and the emphasis falls on a grounded confidence that replaces flight with speed, strength or stubborn endurance, a pattern that tells more than size alone.
+
+            They unsettle expectations of what birds should be, especially when their feet, claws or mass become the main danger. For characters nearby, a cassowary is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Bird("Lyrebird", SizeCategory.Small, 0.2, "Small Bird", "bird-fowl",
             BirdPack("a lyrebird chick", "a young lyrebird", "a lyrebird",
                 "It is brown and ground-dwelling, with strong legs and an elaborate trailing tail in full display.",
                 "Its careful posture and bright eye give it the air of a performer that notices everything.",
                 "It slips through leaf litter with secretive, theatrical precision.",
                 "damp forest floor and ferny gully"),
-            combatStrategyKey: "Beast Coward");
+            combatStrategyKey: "Beast Coward",
+            description: """
+            Where field margins, moors, coops, scrub and forest floors meets daily life, lyrebirds are recognisable as earth-bound or ground-loving birds. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The body plan is clear: sturdy legs, rounded bodies and plumage meant for concealment, display or barnyard work. Watch one move and the emphasis falls on more trust in running, scratching and sudden short flight than in open soaring, a pattern that tells more than size alone.
+
+            They belong to hunting, farming and local noise, small presences that can still dominate a yard or thicket. Around settlements, roads or camps, lyrebirds add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Bird("Kiwi", SizeCategory.Small, 0.2, "Small Bird", "bird-flightless",
             BirdPack("a kiwi chick", "a young kiwi", "a kiwi",
                 "It is round, brown and almost wingless, with hairlike feathers and a long probing bill.",
                 "Its nose-led face and sturdy legs make it look built for searching through dark leaf litter.",
                 "It shuffles with shy nocturnal purpose.",
                 "forest floor, fern cover and damp burrow"),
-            combatStrategyKey: "Beast Coward");
+            combatStrategyKey: "Beast Coward",
+            description: """
+            Where scrubland, open plain, rainforest floor, fern cover and cold shore meets daily life, kiwis are recognisable as large or specialised flightless birds. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The body plan is clear: powerful legs, reduced wings and bodies committed to running, swimming or ground life. Watch one move and the emphasis falls on a grounded confidence that replaces flight with speed, strength or stubborn endurance, a pattern that tells more than size alone.
+
+            They unsettle expectations of what birds should be, especially when their feet, claws or mass become the main danger. For characters nearby, a kiwi is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Bird("Penguin", SizeCategory.Small, 0.2, "Waterfowl", "bird-fowl",
             BirdPack("a penguin chick", "a young penguin", "a penguin",
                 "It is dense-bodied and short-winged, with flipper-like limbs and tight waterproof feathers.",
                 "Its upright stance looks almost comical until its heavy body turns decisively toward the water.",
                 "It seems awkward on land in exactly the way something superb underwater often does.",
-                "icy shore and cold sea"));
+                "icy shore and cold sea"),
+            description: """
+            Where ponds, lakes, marshes, slow rivers and sheltered coasts meets daily life, penguins are recognisable as broad-bodied water birds. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The creature presents webbed feet, water-shedding feathers and bills shaped for grazing, filtering or dabbling. In motion they are marked by practical movement between water, mud and bank, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They are familiar around water, useful as food or ornament, and capable of surprising force when defending space. Around settlements, roads or camps, penguins add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
     }
 }

--- a/DatabaseSeeder/Seeders/AnimalSeeder.Definitions.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.Definitions.cs
@@ -139,7 +139,7 @@ public partial class AnimalSeeder
     internal sealed record AnimalRaceTemplate(
         string Name,
         string Adjective,
-        string? Description,
+        string Description,
         string BodyKey,
         SizeCategory Size,
         bool CanClimb,

--- a/DatabaseSeeder/Seeders/AnimalSeeder.InsectTemplates.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.InsectTemplates.cs
@@ -18,12 +18,13 @@ public partial class AnimalSeeder
             double health,
             string model,
             string loadout,
-            AnimalDescriptionPack pack)
+            AnimalDescriptionPack pack,
+            string description)
         {
             return new AnimalRaceTemplate(
                 name,
                 name,
-                null,
+                description,
                 bodyKey,
                 size,
                 false,
@@ -47,72 +48,156 @@ public partial class AnimalSeeder
                 "It is tiny, hard-bodied and narrowly segmented, with strong little mandibles.",
                 "Its antennae and purposeful gait make it look wholly given over to work.",
                 "It hurries with the single-minded discipline of a colony creature.",
-                "nest tunnel and colony mound"));
+                "nest tunnel and colony mound"),
+            description: """
+            In nest tunnels, flowers, bark, grass, eaves, drains and rotting cover, ants fill the role of chitinous small arthropods. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            Physically they are defined by segmented bodies, antennae, mandibles, wings or springing legs according to the line. The impression is completed by busy, precise movement that can seem mindless or unnervingly purposeful, giving the animal a readable rhythm even before it acts.
+
+            They are small enough to overlook and numerous enough to matter, shaping harvests, homes and old fears. For characters nearby, a ant is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Insect("Beetle", "Beetle", SizeCategory.VerySmall, 0.1, "Insect", "bombardier-beetle",
             InsectPack("a beetle grub", "a young beetle", "a beetle",
                 "It is armoured and compact, the body protected by hard shell and jointed legs.",
                 "Its casing makes it seem more like a moving seed or stone than a vulnerable animal.",
                 "It trundles with patient little determination.",
-                "leaf litter, bark and rotten wood"));
+                "leaf litter, bark and rotten wood"),
+            description: """
+            Beetles occupy nest tunnels, flowers, bark, grass, eaves, drains and rotting cover as chitinous small arthropods. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            Physically they are defined by segmented bodies, antennae, mandibles, wings or springing legs according to the line. The impression is completed by busy, precise movement that can seem mindless or unnervingly purposeful, giving the animal a readable rhythm even before it acts.
+
+            They are small enough to overlook and numerous enough to matter, shaping harvests, homes and old fears. For characters nearby, a beetle is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Insect("Centipede", "Centipede", SizeCategory.VerySmall, 0.12, "Centipede", "insect-mandible",
             InsectPack("a centipede hatchling", "a young centipede", "a centipede",
                 "It is long, low and many-legged, with a segmented body and restless venomous mandibles.",
                 "Its rippling gait and twitching antennae make it look like a line of bad intentions given chitin.",
                 "It scuttles in a smooth, unnerving rush that never seems to stop.",
-                "stone crack, leaf litter and damp rot"));
+                "stone crack, leaf litter and damp rot"),
+            description: """
+            Where nest tunnels, flowers, bark, grass, eaves, drains and rotting cover meets daily life, centipedes are recognisable as chitinous small arthropods. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            Physically they are defined by segmented bodies, antennae, mandibles, wings or springing legs according to the line. The impression is completed by busy, precise movement that can seem mindless or unnervingly purposeful, giving the animal a readable rhythm even before it acts.
+
+            They are small enough to overlook and numerous enough to matter, shaping harvests, homes and old fears. For characters nearby, a centipede is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Insect("Mantis", "Insectoid", SizeCategory.Small, 0.2, "Insect", "insect-mandible",
             InsectPack("a mantis nymph", "a young mantis", "a mantis",
                 "It is narrow-bodied and green-limbed, with a triangular head and folded grasping forelegs.",
                 "Its posture is so intent and predatory that it looks like a prayer made entirely of murder.",
                 "It holds itself unnaturally still until something edible moves.",
-                "leaf, stem and warm scrub"));
+                "leaf, stem and warm scrub"),
+            description: """
+            Mantises are chitinous small arthropods of nest tunnels, flowers, bark, grass, eaves, drains and rotting cover. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            The body plan is clear: segmented bodies, antennae, mandibles, wings or springing legs according to the line. Watch one move and the emphasis falls on busy, precise movement that can seem mindless or unnervingly purposeful, a pattern that tells more than size alone.
+
+            They are small enough to overlook and numerous enough to matter, shaping harvests, homes and old fears. For characters nearby, a mantis is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Insect("Dragonfly", "Winged Insectoid", SizeCategory.VerySmall, 0.1, "Winged Insect", "insect-mandible",
             InsectPack("a dragonfly nymph", "a young dragonfly", "a dragonfly",
                 "It is long-bodied and fine-waisted, with large eyes and two pairs of transparent wings.",
                 "Its huge eyes and whirring wings make it look built entirely around pursuit and balance.",
                 "It hovers with an eerie precision before darting away like a thrown needle.",
-                "pond edge and still water"));
+                "pond edge and still water"),
+            description: """
+            In nest tunnels, flowers, bark, grass, eaves, drains and rotting cover, dragonflies fill the role of chitinous small arthropods. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The body plan is clear: segmented bodies, antennae, mandibles, wings or springing legs according to the line. Watch one move and the emphasis falls on busy, precise movement that can seem mindless or unnervingly purposeful, a pattern that tells more than size alone.
+
+            They are small enough to overlook and numerous enough to matter, shaping harvests, homes and old fears. For characters nearby, a dragonfly is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Insect("Bee", "Winged Insectoid", SizeCategory.VerySmall, 0.1, "Winged Insect", "insect-stinger",
             InsectPack("a bee larva", "a young bee", "a bee",
                 "It is fuzzy-bodied and striped, with busy wings and a compact abdomen.",
                 "Its hind legs and pollen-dusted body make its relationship with flowers immediately obvious.",
                 "It darts from bloom to bloom with humming urgency.",
-                "flower patch and hive"));
+                "flower patch and hive"),
+            description: """
+            Bees occupy nest tunnels, flowers, bark, grass, eaves, drains and rotting cover as chitinous small arthropods. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            The body plan is clear: segmented bodies, antennae, mandibles, wings or springing legs according to the line. Watch one move and the emphasis falls on busy, precise movement that can seem mindless or unnervingly purposeful, a pattern that tells more than size alone.
+
+            They are small enough to overlook and numerous enough to matter, shaping harvests, homes and old fears. For characters nearby, a bee is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Insect("Butterfly", "Winged Insectoid", SizeCategory.VerySmall, 0.1, "Winged Insect", "insect-mandible",
             InsectPack("a caterpillar", "a young butterfly", "a butterfly",
                 "It is delicately winged and brightly patterned, with a narrow body and fine antennae.",
                 "Its wings are all display and fragility, painted more boldly than a practical creature really should be.",
                 "It flutters in erratic graceful arcs between rests.",
-                "flowering meadow and garden edge"));
+                "flowering meadow and garden edge"),
+            description: """
+            Where nest tunnels, flowers, bark, grass, eaves, drains and rotting cover meets daily life, butterflies are recognisable as chitinous small arthropods. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The body plan is clear: segmented bodies, antennae, mandibles, wings or springing legs according to the line. Watch one move and the emphasis falls on busy, precise movement that can seem mindless or unnervingly purposeful, a pattern that tells more than size alone.
+
+            They are small enough to overlook and numerous enough to matter, shaping harvests, homes and old fears. For characters nearby, a butterfly is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Insect("Wasp", "Winged Insectoid", SizeCategory.VerySmall, 0.1, "Winged Insect", "insect-stinger",
             InsectPack("a wasp larva", "a young wasp", "a wasp",
                 "It is narrow-waisted and sharply striped, with a harder, meaner look than a bee.",
                 "Its polished body and obvious sting give it a brittle, weaponized elegance.",
                 "It hangs in the air with aggressive focus.",
-                "eaves, thicket and summer air"));
+                "eaves, thicket and summer air"),
+            description: """
+            Wasps are chitinous small arthropods of nest tunnels, flowers, bark, grass, eaves, drains and rotting cover. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            Its strongest visual signs are segmented bodies, antennae, mandibles, wings or springing legs according to the line. Those features support busy, precise movement that can seem mindless or unnervingly purposeful, making the creature feel suited to its ground rather than merely placed there.
+
+            They are small enough to overlook and numerous enough to matter, shaping harvests, homes and old fears. For characters nearby, a wasp is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Insect("Hornet", "Winged Insectoid", SizeCategory.VerySmall, 0.15, "Winged Insect", "insect-stinger",
             InsectPack("a hornet larva", "a young hornet", "a hornet",
                 "It is larger and heavier than a common wasp, with a thick abdomen and loud wings.",
                 "Its jaws and sting both look substantial enough to matter to things far bigger than itself.",
                 "It hovers with audible threat and bad intent.",
-                "woodland edge and paper nest"));
+                "woodland edge and paper nest"),
+            description: """
+            In nest tunnels, flowers, bark, grass, eaves, drains and rotting cover, hornets fill the role of chitinous small arthropods. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The eye is drawn to segmented bodies, antennae, mandibles, wings or springing legs according to the line. Those features support busy, precise movement that can seem mindless or unnervingly purposeful, making the creature feel suited to its ground rather than merely placed there.
+
+            They are small enough to overlook and numerous enough to matter, shaping harvests, homes and old fears. For characters nearby, a hornet is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Insect("Moth", "Winged Insectoid", SizeCategory.VerySmall, 0.08, "Winged Insect", "insect-mandible",
             InsectPack("a moth larva", "a young moth", "a moth",
                 "It is soft-bodied and powder-winged, with feathered antennae and muted colours.",
                 "Its wings look built more for drifting and fluttering than aggressive flight.",
                 "It seems drawn toward light and warmth rather than conflict.",
-                "lamplit eave and night garden"));
+                "lamplit eave and night garden"),
+            description: """
+            Moths occupy nest tunnels, flowers, bark, grass, eaves, drains and rotting cover as chitinous small arthropods. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            The most telling cues are segmented bodies, antennae, mandibles, wings or springing legs according to the line. Those features support busy, precise movement that can seem mindless or unnervingly purposeful, making the creature feel suited to its ground rather than merely placed there.
+
+            They are small enough to overlook and numerous enough to matter, shaping harvests, homes and old fears. For characters nearby, a moth is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Insect("Grasshopper", "Insectoid", SizeCategory.VerySmall, 0.12, "Insect", "insect-mandible",
             InsectPack("a grasshopper nymph", "a young grasshopper", "a grasshopper",
                 "It is long-legged and green-brown, the hindlegs built like springs beneath a light body.",
                 "Its folded limbs make it look perpetually compressed and ready to launch.",
                 "It pauses only briefly before another hopping burst.",
-                "grass, scrub and warm field"));
+                "grass, scrub and warm field"),
+            description: """
+            Where nest tunnels, flowers, bark, grass, eaves, drains and rotting cover meets daily life, grasshoppers are recognisable as chitinous small arthropods. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            Most of its character sits in segmented bodies, antennae, mandibles, wings or springing legs according to the line. Those features support busy, precise movement that can seem mindless or unnervingly purposeful, making the creature feel suited to its ground rather than merely placed there.
+
+            They are small enough to overlook and numerous enough to matter, shaping harvests, homes and old fears. For characters nearby, a grasshopper is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Insect("Cockroach", "Insectoid", SizeCategory.VerySmall, 0.1, "Insect", "insect-mandible",
             InsectPack("a roach nymph", "a young roach", "a cockroach",
                 "It is broad-backed and dark, with spined legs and a flattened armoured body.",
                 "Its shape is unlovely but undeniably effective, built to survive neglect and violence alike.",
                 "It runs with fast, ugly persistence.",
-                "crack, drain and ruined corner"));
+                "crack, drain and ruined corner"),
+            description: """
+            Cockroaches are chitinous small arthropods of nest tunnels, flowers, bark, grass, eaves, drains and rotting cover. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            Look closer and the outline is all segmented bodies, antennae, mandibles, wings or springing legs according to the line. In motion they are marked by busy, precise movement that can seem mindless or unnervingly purposeful, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They are small enough to overlook and numerous enough to matter, shaping harvests, homes and old fears. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
     }
 }

--- a/DatabaseSeeder/Seeders/AnimalSeeder.Mammals.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.Mammals.cs
@@ -20,7 +20,7 @@ public partial class AnimalSeeder
             string ageProfile,
             string loadout,
             AnimalDescriptionPack pack,
-            string? description = null,
+            string description,
             bool canClimb = false,
             string? bloodProfile = null,
             IReadOnlyList<AnimalBodypartUsageTemplate>? usages = null,
@@ -77,7 +77,14 @@ public partial class AnimalSeeder
                 "Its wide-set eyes and alert ears leave it looking permanently watchful.",
                 "It looks ready to bolt at the first hint of danger.",
                 "burrows, hedgerows and open grassland"),
-            combatStrategyKey: "Beast Coward");
+            combatStrategyKey: "Beast Coward",
+            description: """
+            Rabbits are small, long-eared grazing mammals of burrows, hedgerows, heath and open grassland. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            At a glance, the form resolves into soft fur, high-set ears and hindquarters built for abrupt leaps. In motion they are marked by watchful, spring-loaded movement and an instinct for vanishing into cover, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They are usually read as prey animals: nervous, quick and most dangerous only when cornered or handled carelessly. A rabbit can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
         yield return Mammal("Hare", "Hare", "Toed Quadruped", SizeCategory.VerySmall, 0.5, "Lagomorph",
             "tiny-fast", "small-herbivore",
             MammalPack("a leveret", "a young jack hare", "a young jill hare", "a jack hare", "a jill hare",
@@ -85,14 +92,28 @@ public partial class AnimalSeeder
                 "Its powerful hindquarters look built for explosive speed across open ground.",
                 "It stands tense and light on its feet, as if made to run.",
                 "heath, scrub and open country"),
-            combatStrategyKey: "Beast Coward");
+            combatStrategyKey: "Beast Coward",
+            description: """
+            In burrows, hedgerows, heath and open grassland, hares fill the role of small, long-eared grazing mammals. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The visible essentials are soft fur, high-set ears and hindquarters built for abrupt leaps. In motion they are marked by watchful, spring-loaded movement and an instinct for vanishing into cover, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They are usually read as prey animals: nervous, quick and most dangerous only when cornered or handled carelessly. A hare can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
         yield return Mammal("Beaver", "Beaver", "Toed Quadruped", SizeCategory.Small, 0.8, "Mustelid",
             "standard-mammal", "small-predator",
             MammalPack("a beaver kit", "a young male beaver", "a young female beaver", "a male beaver", "a female beaver",
                 "It is stocky and brown-furred, with a broad flat tail and heavy incisors.",
                 "Its teeth and webbed feet betray a life of gnawing timber and working in water.",
                 "It has the purposeful, busy air of a tireless builder.",
-                "riverbanks and quiet waterways"));
+                "riverbanks and quiet waterways"),
+            description: """
+            Beavers occupy riverbanks, marsh margins and sheltered waterways as water-edge mammals. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            Look closer and the outline is all dense fur, practical paws and frames shaped by swimming as much as by walking. In motion they are marked by purposeful movement between mud, bank and water, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They make river country feel inhabited, useful to trappers and watchers but never quite domestic in their habits. A beaver can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
         yield return Mammal("Otter", "Otter", "Toed Quadruped", SizeCategory.VerySmall, 0.5, "Mustelid",
             "standard-mammal", "small-predator",
             MammalPack("an otter pup", "a young male otter", "a young female otter", "a male otter", "a female otter",
@@ -100,7 +121,14 @@ public partial class AnimalSeeder
                 "Its whiskered muzzle and supple frame suit it to swift hunting in water.",
                 "It moves with playful grace and easy confidence.",
                 "rivers, marshes and sheltered coasts"),
-            combatStrategyKey: "Beast Skirmisher");
+            combatStrategyKey: "Beast Skirmisher",
+            description: """
+            Where riverbanks, marsh margins and sheltered waterways meets daily life, otters are recognisable as water-edge mammals. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The first things to register are dense fur, practical paws and frames shaped by swimming as much as by walking. In motion they are marked by purposeful movement between mud, bank and water, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They make river country feel inhabited, useful to trappers and watchers but never quite domestic in their habits. A otter can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
         yield return Mammal("Dog", "Canine", "Toed Quadruped", SizeCategory.Small, 0.8, "Small Canid",
             "standard-mammal", "doglike",
             MammalPack("a puppy", "a young dog", "a young dog", "a dog", "a bitch",
@@ -109,7 +137,13 @@ public partial class AnimalSeeder
                 "It carries itself with the curious, companionable energy of a domestic hunter.",
                 "farmsteads, roads and human settlements") with
             { AddDogBreedDescriptions = true },
-            "Common domestic dogs", bloodProfile: "canine");
+            """
+            Dogs are social canids shaped by long association with settlements of farmsteads, roads, camps and the edges of habitation. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            Physically they are defined by keen noses, alert ears and bodies that vary widely by line and purpose. The impression is completed by companionable attention mixed with a hunter's readiness, giving the animal a readable rhythm even before it acts.
+
+            They can be workmate, guardian, scavenger or threat depending on training and treatment. A dog can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """, bloodProfile: "canine");
         yield return Mammal("Cat", "Feline", "Toed Quadruped", SizeCategory.Small, 0.5, "Domestic Cat",
             "standard-mammal", "cat",
             MammalPack("a kitten", "a young tomcat", "a young cat", "a tomcat", "a cat",
@@ -118,7 +152,13 @@ public partial class AnimalSeeder
                 "It has the poised, self-contained air of a patient little predator.",
                 "hearths, rooftops and the edges of human habitation") with
             { UseCatCoatDescriptions = true },
-            "Common domestic cats", bloodProfile: "feline");
+            """
+            Cats occupy hearths, rooftops, barns and the quieter corners of settlements as small, graceful domestic felids. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            The body plan is clear: supple spines, bright eyes, whiskers and fine retractile claws. Watch one move and the emphasis falls on poised self-possession and sudden little bursts of predatory focus, a pattern that tells more than size alone.
+
+            They live close to people without ever seeming fully owned, useful around vermin and inscrutable around affection. A cat can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """, bloodProfile: "feline");
         yield return Mammal("Wolf", "Lupine", "Toed Quadruped", SizeCategory.Normal, 1.0, "Large Canid",
             "standard-mammal", "wolfpack",
             MammalPack("a wolf pup", "a young male wolf", "a young female wolf", "a male wolf", "a female wolf",
@@ -126,7 +166,13 @@ public partial class AnimalSeeder
                 "Its heavy jaws, triangular ears and keen eyes make it look every inch a pack hunter.",
                 "It carries itself with wary confidence and relentless focus.",
                 "forest, tundra and broken wilderness"),
-            "Wild grey wolves", bloodProfile: "canine");
+            """
+            In woodland edges, scrub, dry plains and open wilderness, wolfs fill the role of lean, sharp-sensed canid predators. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            Physically they are defined by long muzzles, quick feet and a rangy build meant for scent, pursuit and opportunism. The impression is completed by wary confidence and a habit of testing distance before committing, giving the animal a readable rhythm even before it acts.
+
+            Their presence at the edge of camp or pasture is enough to make livestock restless and travellers attentive. A wolf can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """, bloodProfile: "canine");
         yield return Mammal("Fox", "Vulpine", "Toed Quadruped", SizeCategory.Small, 0.8, "Small Canid",
             "standard-mammal", "small-predator",
             MammalPack("a fox kit", "a young dog fox", "a young vixen", "a dog fox", "a vixen",
@@ -134,7 +180,13 @@ public partial class AnimalSeeder
                 "Its pointed muzzle, sharp ears and brush tail give it a quick, crafty look.",
                 "It seems perpetually ready to slip away into cover.",
                 "woodland edges, scrub and farmland"),
-            "Foxes", combatStrategyKey: "Beast Skirmisher");
+            """
+            Foxes occupy woodland edges, scrub, dry plains and open wilderness as lean, sharp-sensed canid predators. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            Physically they are defined by long muzzles, quick feet and a rangy build meant for scent, pursuit and opportunism. The impression is completed by wary confidence and a habit of testing distance before committing, giving the animal a readable rhythm even before it acts.
+
+            Their presence at the edge of camp or pasture is enough to make livestock restless and travellers attentive. A fox can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """, combatStrategyKey: "Beast Skirmisher");
         yield return Mammal("Coyote", "Coyote", "Toed Quadruped", SizeCategory.Small, 0.8, "Small Canid",
             "standard-mammal", "wolfpack",
             MammalPack("a coyote pup", "a young male coyote", "a young female coyote", "a male coyote", "a female coyote",
@@ -142,7 +194,13 @@ public partial class AnimalSeeder
                 "Its wary amber eyes and oversized ears mark it as a watchful opportunist.",
                 "It looks nervous, clever and ready to run or bite in an instant.",
                 "dry scrub, prairie and rough hill country"),
-            "Coyote");
+            """
+            Where woodland edges, scrub, dry plains and open wilderness meets daily life, coyotes are recognisable as lean, sharp-sensed canid predators. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            Physically they are defined by long muzzles, quick feet and a rangy build meant for scent, pursuit and opportunism. The impression is completed by wary confidence and a habit of testing distance before committing, giving the animal a readable rhythm even before it acts.
+
+            Their presence at the edge of camp or pasture is enough to make livestock restless and travellers attentive. A coyote can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
         yield return Mammal("Hyena", "Hyena", "Toed Quadruped", SizeCategory.Small, 0.8, "Small Canid",
             "standard-mammal", "wolfpack",
             MammalPack("a hyena cub", "a young male hyena", "a young female hyena", "a male hyena", "a female hyena",
@@ -150,7 +208,13 @@ public partial class AnimalSeeder
                 "Its heavy jaws look capable of breaking bone with ugly ease.",
                 "It gives off a rough, shambling power rather than feline grace.",
                 "savannah, thorn scrub and dry plains"),
-            "Hyena");
+            """
+            Hyenas occupy savannah, thorn scrub and dry plains as rough, heavy-jawed predators and scavengers. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            At a glance, the form resolves into sloped backs, powerful necks, coarse coats and jaws made for cracking bone. In motion they are marked by shambling confidence and watchful opportunism, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They gather around carrion, camps and battlefields, where their laughter-like calls make the dark feel occupied. Around settlements, roads or camps, hyenas add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Mammal("Lion", "Leonine", "Toed Quadruped", SizeCategory.Normal, 1.3, "Big Felid",
             "standard-mammal", "big-cat",
             MammalPack("a lion cub", "a young lion", "a young lioness", "a lion", "a lioness",
@@ -158,7 +222,13 @@ public partial class AnimalSeeder
                 "Its broad head and predatory shoulders make it look built to dominate prey with raw strength.",
                 "It carries itself with slow assurance and the easy authority of an apex hunter.",
                 "grassland and open savannah"),
-            "Lions");
+            """
+            Where grassland, forest edge, jungle, rocky scrub and broken cover meets daily life, lions are recognisable as large predatory felids. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The body plan is clear: heavy shoulders, padded paws, deep jaws and muscle arranged for ambush and impact. Watch one move and the emphasis falls on a coiled, silent confidence that makes stillness feel dangerous, a pattern that tells more than size alone.
+
+            They are not merely wildlife but territorial facts, the kind of animals that reshape routes, grazing patterns and local caution. A lion can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
         yield return Mammal("Tiger", "Tigrine", "Toed Quadruped", SizeCategory.Normal, 1.3, "Big Felid",
             "standard-mammal", "big-cat",
             MammalPack("a tiger cub", "a young tiger", "a young tigress", "a tiger", "a tigress",
@@ -166,7 +236,13 @@ public partial class AnimalSeeder
                 "Its broad skull, huge forequarters and deep jaws speak of ambush and overpowering force.",
                 "It moves with the silent certainty of a predator that expects the world to part before it.",
                 "thick jungle, swamp and broken forest"),
-            "Tigers");
+            """
+            Tigers are large predatory felids of grassland, forest edge, jungle, rocky scrub and broken cover. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            The most telling cues are heavy shoulders, padded paws, deep jaws and muscle arranged for ambush and impact. Those features support a coiled, silent confidence that makes stillness feel dangerous, making the creature feel suited to its ground rather than merely placed there.
+
+            They are not merely wildlife but territorial facts, the kind of animals that reshape routes, grazing patterns and local caution. A tiger can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
         yield return Mammal("Sabretooth Tiger", "Sabretoothed", "Toed Quadruped", SizeCategory.Large, 1.5, "Big Felid",
             "standard-mammal", "big-cat",
             MammalPack("a sabretooth cub", "a young male sabretooth", "a young female sabretooth", "a male sabretooth", "a female sabretooth",
@@ -174,7 +250,13 @@ public partial class AnimalSeeder
                 "Its forequarters are built for grappling impact rather than speed alone, and the paired sabres give it a terrifying silhouette.",
                 "It carries itself with the confidence of a predator that ends struggles up close and violently.",
                 "cold steppe, broken woodland and glacial plain"),
-            "Sabretooth tigers", bloodProfile: "feline", combatStrategyKey: "Beast Brawler");
+            """
+            In grassland, forest edge, jungle, rocky scrub and broken cover, sabretooth tigers fill the role of large predatory felids. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            Most of its character sits in heavy shoulders, padded paws, deep jaws and muscle arranged for ambush and impact. Those features support a coiled, silent confidence that makes stillness feel dangerous, making the creature feel suited to its ground rather than merely placed there.
+
+            They are not merely wildlife but territorial facts, the kind of animals that reshape routes, grazing patterns and local caution. A sabretooth tiger can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """, bloodProfile: "feline", combatStrategyKey: "Beast Brawler");
         yield return Mammal("Cheetah", "Cheetah", "Toed Quadruped", SizeCategory.Small, 0.8, "Big Felid",
             "standard-mammal", "wolfpack",
             MammalPack("a cheetah cub", "a young male cheetah", "a young female cheetah", "a male cheetah", "a female cheetah",
@@ -182,7 +264,13 @@ public partial class AnimalSeeder
                 "Its narrow chest, fine waist and springy back look made for speed more than wrestling strength.",
                 "It stands alert and taut, like something meant to explode into motion.",
                 "open savannah and sparse scrub"),
-            "Cheetah", combatStrategyKey: "Beast Skirmisher");
+            """
+            Cheetahs occupy grassland, forest edge, jungle, rocky scrub and broken cover as large predatory felids. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            What distinguishes the line is heavy shoulders, padded paws, deep jaws and muscle arranged for ambush and impact. Those features support a coiled, silent confidence that makes stillness feel dangerous, making the creature feel suited to its ground rather than merely placed there.
+
+            They are not merely wildlife but territorial facts, the kind of animals that reshape routes, grazing patterns and local caution. A cheetah can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """, combatStrategyKey: "Beast Skirmisher");
         yield return Mammal("Leopard", "Leopard", "Toed Quadruped", SizeCategory.Small, 0.8, "Big Felid",
             "standard-mammal", "wolfpack",
             MammalPack("a leopard cub", "a young male leopard", "a young female leopard", "a male leopard", "a female leopard",
@@ -190,7 +278,13 @@ public partial class AnimalSeeder
                 "Its heavy shoulders and powerful neck suggest an animal built to drag kills into trees.",
                 "It has the quiet, coiled air of a born ambush predator.",
                 "forest, rocky scrub and broken woodland"),
-            "Leopard", combatStrategyKey: "Beast Skirmisher");
+            """
+            Where grassland, forest edge, jungle, rocky scrub and broken cover meets daily life, leopards are recognisable as large predatory felids. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The creature is best read through heavy shoulders, padded paws, deep jaws and muscle arranged for ambush and impact. Those features support a coiled, silent confidence that makes stillness feel dangerous, making the creature feel suited to its ground rather than merely placed there.
+
+            They are not merely wildlife but territorial facts, the kind of animals that reshape routes, grazing patterns and local caution. A leopard can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """, combatStrategyKey: "Beast Skirmisher");
         yield return Mammal("Panther", "Panther", "Toed Quadruped", SizeCategory.Small, 0.8, "Big Felid",
             "standard-mammal", "wolfpack",
             MammalPack("a panther cub", "a young male panther", "a young female panther", "a male panther", "a female panther",
@@ -198,7 +292,13 @@ public partial class AnimalSeeder
                 "Its eyes and whiskered muzzle stand out sharply against its shadow-black fur.",
                 "It moves like a piece of living night, smooth and deliberate.",
                 "forest canopy, jungle edge and rocky cover"),
-            "Panther", combatStrategyKey: "Beast Skirmisher");
+            """
+            Panthers are large predatory felids of grassland, forest edge, jungle, rocky scrub and broken cover. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            Its profile is built around heavy shoulders, padded paws, deep jaws and muscle arranged for ambush and impact. In motion they are marked by a coiled, silent confidence that makes stillness feel dangerous, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They are not merely wildlife but territorial facts, the kind of animals that reshape routes, grazing patterns and local caution. Around settlements, roads or camps, panthers add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """, combatStrategyKey: "Beast Skirmisher");
         yield return Mammal("Jaguar", "Jaguar", "Toed Quadruped", SizeCategory.Small, 0.8, "Big Felid",
             "standard-mammal", "wolfpack",
             MammalPack("a jaguar cub", "a young male jaguar", "a young female jaguar", "a male jaguar", "a female jaguar",
@@ -206,7 +306,13 @@ public partial class AnimalSeeder
                 "Its jaws look unusually deep and powerful even for a great cat.",
                 "It has a dense, forceful presence rather than a runner's lightness.",
                 "rainforest, swamp and riverbank"),
-            "Jaguar", combatStrategyKey: "Beast Skirmisher");
+            """
+            In grassland, forest edge, jungle, rocky scrub and broken cover, jaguars fill the role of large predatory felids. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The creature presents heavy shoulders, padded paws, deep jaws and muscle arranged for ambush and impact. In motion they are marked by a coiled, silent confidence that makes stillness feel dangerous, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They are not merely wildlife but territorial facts, the kind of animals that reshape routes, grazing patterns and local caution. Around settlements, roads or camps, jaguars add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """, combatStrategyKey: "Beast Skirmisher");
         yield return Mammal("Jackal", "Jackal", "Toed Quadruped", SizeCategory.Small, 0.8, "Small Canid",
             "standard-mammal", "doglike",
             MammalPack("a jackal pup", "a young male jackal", "a young female jackal", "a male jackal", "a female jackal",
@@ -214,7 +320,13 @@ public partial class AnimalSeeder
                 "Its tall ears and restless expression make it look perpetually alert for danger or carrion.",
                 "It gives off a scavenger's cunning and a hunter's opportunism.",
                 "dry plains, scrub and broken desert"),
-            "Jackal");
+            """
+            Jackals are lean, sharp-sensed canid predators of woodland edges, scrub, dry plains and open wilderness. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            The body plan is clear: long muzzles, quick feet and a rangy build meant for scent, pursuit and opportunism. Watch one move and the emphasis falls on wary confidence and a habit of testing distance before committing, a pattern that tells more than size alone.
+
+            Their presence at the edge of camp or pasture is enough to make livestock restless and travellers attentive. A jackal can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
         yield return Mammal("Deer", "Cervine", "Ungulate", SizeCategory.Normal, 0.8, "Small Ungulate",
             "stock-mammal", "antlered-herbivore",
             MammalPack("a fawn", "a young stag", "a young doe", "a stag", "a doe",
@@ -222,7 +334,13 @@ public partial class AnimalSeeder
                 "Its large ears, dark eyes and delicate muzzle give it a perpetually sensitive look.",
                 "It stands ready to leap away at any sudden sound.",
                 "woodland, meadow and forest edge"),
-            "Deer", usages: antlered, combatStrategyKey: "Beast Coward");
+            """
+            Where pastures, plains, woodland edges, marshes and cold open country meets daily life, deer are recognisable as hoofed grazing animals. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The visible essentials are long legs, weight-bearing hooves and frames shaped for grazing, migration or sudden flight. In motion they are marked by herd-aware caution and a readiness to bolt, charge or hold ground according to size, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They are central to hunting, herding and wilderness travel, familiar enough to be useful but never entirely harmless. Around settlements, roads or camps, deer add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """, usages: antlered, combatStrategyKey: "Beast Coward");
         yield return Mammal("Moose", "Moose", "Ungulate", SizeCategory.Large, 1.5, "Large Ungulate",
             "stock-mammal", "antlered-herbivore",
             MammalPack("a moose calf", "a young bull moose", "a young cow moose", "a bull moose", "a cow moose",
@@ -230,7 +348,13 @@ public partial class AnimalSeeder
                 "Its pendulous muzzle and deep shoulders make it look awkward until it begins to move.",
                 "It has the placid bulk of an animal that can still become terrifyingly violent when pressed.",
                 "swamp, taiga and cold forest"),
-            "Moose", usages: antlered, combatStrategyKey: "Beast Behemoth");
+            """
+            Moose are hoofed grazing animals of pastures, plains, woodland edges, marshes and cold open country. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            Physically they are defined by long legs, weight-bearing hooves and frames shaped for grazing, migration or sudden flight. The impression is completed by herd-aware caution and a readiness to bolt, charge or hold ground according to size, giving the animal a readable rhythm even before it acts.
+
+            They are central to hunting, herding and wilderness travel, familiar enough to be useful but never entirely harmless. Around settlements, roads or camps, moose add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """, usages: antlered, combatStrategyKey: "Beast Behemoth");
         yield return Mammal("Elk", "Elk", "Ungulate", SizeCategory.Large, 1.3, "Large Ungulate",
             "large-hooved", "antlered-herbivore",
             MammalPack("an elk calf", "a young bull elk", "a young cow elk", "a bull elk", "a cow elk",
@@ -238,7 +362,13 @@ public partial class AnimalSeeder
                 "Its broad muzzle and sweeping antlers give it the look of a grazer that can still become dangerous in an instant.",
                 "It holds itself with a rangy, watchful calm more suited to open woodland than close pens.",
                 "mountain meadow, open forest and cold grassland"),
-            "Elk", usages: antlered, combatStrategyKey: "Beast Behemoth");
+            """
+            In pastures, plains, woodland edges, marshes and cold open country, elk fill the role of hoofed grazing animals. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            Physically they are defined by long legs, weight-bearing hooves and frames shaped for grazing, migration or sudden flight. The impression is completed by herd-aware caution and a readiness to bolt, charge or hold ground according to size, giving the animal a readable rhythm even before it acts.
+
+            They are central to hunting, herding and wilderness travel, familiar enough to be useful but never entirely harmless. Around settlements, roads or camps, elk add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """, usages: antlered, combatStrategyKey: "Beast Behemoth");
         yield return Mammal("Reindeer", "Reindeer", "Ungulate", SizeCategory.Large, 1.1, "Large Ungulate",
             "stock-mammal", "antlered-herbivore",
             MammalPack("a reindeer calf", "a young bull reindeer", "a young cow reindeer", "a bull reindeer", "a cow reindeer",
@@ -246,7 +376,13 @@ public partial class AnimalSeeder
                 "Its muzzle is blunt and furred, and even its antlers look shaped by hard seasons and long migration.",
                 "It moves with steady endurance, as though distance and weather were ordinary inconveniences.",
                 "tundra, lichen plain and northern woodland"),
-            "Reindeer", usages: antleredGeneral, combatStrategyKey: "Beast Behemoth");
+            """
+            Reindeer occupy pastures, plains, woodland edges, marshes and cold open country as hoofed grazing animals. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            Physically they are defined by long legs, weight-bearing hooves and frames shaped for grazing, migration or sudden flight. The impression is completed by herd-aware caution and a readiness to bolt, charge or hold ground according to size, giving the animal a readable rhythm even before it acts.
+
+            They are central to hunting, herding and wilderness travel, familiar enough to be useful but never entirely harmless. Around settlements, roads or camps, reindeer add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """, usages: antleredGeneral, combatStrategyKey: "Beast Behemoth");
         yield return Mammal("Pig", "Porcine", "Ungulate", SizeCategory.Normal, 1.0, "Small Ungulate",
             "stock-mammal", "herbivore-charge",
             MammalPack("a piglet", "a young boar", "a young sow", "a boar", "a sow",
@@ -254,7 +390,13 @@ public partial class AnimalSeeder
                 "Its rooting nose and wedge-shaped head make it look built to shove through earth and brush.",
                 "It has a blunt, practical sort of confidence.",
                 "farm pens, muddy woodland and scrub"),
-            "Pigs", usages: udder);
+            """
+            In muddy woodland, scrub, farm pens and marsh edges, pigs fill the role of stout rooting ungulates. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The body plan is clear: wedge-shaped heads, bristled hides, practical snouts and stubborn shoulders. Watch one move and the emphasis falls on blunt confidence and a habit of shoving through whatever stands in the way, a pattern that tells more than size alone.
+
+            They are valuable as domestic animals or dangerous as wild animals, especially when tusks, young or food are involved. Around settlements, roads or camps, pigs add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """, usages: udder);
         yield return Mammal("Boar", "Boar", "Ungulate", SizeCategory.Normal, 1.2, "Small Ungulate",
             "stock-mammal", "tusked-herbivore",
             MammalPack("a piglet", "a young boar", "a young sow", "a boar", "a sow",
@@ -262,7 +404,14 @@ public partial class AnimalSeeder
                 "Its protruding tusks and dense neck make it look ready to crash straight through trouble.",
                 "It gives off the prickly aggression of a wild rooting animal.",
                 "thick scrub, marsh edge and rough woodland"),
-            usages: tuskedMale, combatStrategyKey: "Beast Behemoth");
+            usages: tuskedMale, combatStrategyKey: "Beast Behemoth",
+            description: """
+            Boars occupy muddy woodland, scrub, farm pens and marsh edges as stout rooting ungulates. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            The body plan is clear: wedge-shaped heads, bristled hides, practical snouts and stubborn shoulders. Watch one move and the emphasis falls on blunt confidence and a habit of shoving through whatever stands in the way, a pattern that tells more than size alone.
+
+            They are valuable as domestic animals or dangerous as wild animals, especially when tusks, young or food are involved. Around settlements, roads or camps, boars add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Mammal("Warthog", "Warthog", "Ungulate", SizeCategory.Normal, 1.2, "Small Ungulate",
             "stock-mammal", "tusked-herbivore",
             MammalPack("a warthog piglet", "a young male warthog", "a young female warthog", "a male warthog", "a female warthog",
@@ -270,7 +419,14 @@ public partial class AnimalSeeder
                 "Its curved tusks and facial bosses give it a rugged, ill-tempered look.",
                 "It looks as though it would rather charge than retreat.",
                 "dry savannah and thorn scrub"),
-            usages: tuskedMale, combatStrategyKey: "Beast Behemoth");
+            usages: tuskedMale, combatStrategyKey: "Beast Behemoth",
+            description: """
+            Where muddy woodland, scrub, farm pens and marsh edges meets daily life, warthogs are recognisable as stout rooting ungulates. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The body plan is clear: wedge-shaped heads, bristled hides, practical snouts and stubborn shoulders. Watch one move and the emphasis falls on blunt confidence and a habit of shoving through whatever stands in the way, a pattern that tells more than size alone.
+
+            They are valuable as domestic animals or dangerous as wild animals, especially when tusks, young or food are involved. Around settlements, roads or camps, warthogs add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Mammal("Sheep", "Ovine", "Ungulate", SizeCategory.Normal, 0.8, "Small Ungulate",
             "stock-mammal", "bovid",
             MammalPack("a lamb", "a young ram", "a young ewe", "a ram", "a ewe",
@@ -278,7 +434,13 @@ public partial class AnimalSeeder
                 "Its thick fleece makes it look larger and softer than the muscle beneath would suggest.",
                 "It has the mild, herd-bound stillness of a grazing prey animal.",
                 "pasture, upland meadow and folded hills"),
-            "Sheep", bloodProfile: "ovine", usages: hornedFemale, combatStrategyKey: "Beast Coward");
+            """
+            Sheep are sure-footed herd animals of pastures, crags, upland meadows and folded hills. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            Its strongest visual signs are narrow faces, hooves built for uncertain ground, thick coats or fleece, and wary horizontal gazes. Those features support herd-bound caution mixed with stubborn, practical footing, making the creature feel suited to its ground rather than merely placed there.
+
+            They mark the working edge of pastoral life, providing fibre, milk or meat while testing fences and patience. Around settlements, roads or camps, sheep add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """, bloodProfile: "ovine", usages: hornedFemale, combatStrategyKey: "Beast Coward");
         yield return Mammal("Goat", "Caprine", "Ungulate", SizeCategory.Normal, 0.8, "Small Ungulate",
             "standard-mammal", "goat",
             MammalPack("a kid goat", "a young billy goat", "a young nanny goat", "a billy goat", "a nanny goat",
@@ -286,7 +448,13 @@ public partial class AnimalSeeder
                 "Its beard, angular skull and sweeping horns give it a stubbornly self-possessed look.",
                 "It looks happiest when climbing where other animals should not.",
                 "crags, rough pasture and broken hills"),
-            "Goats", usages: hornedFemale, combatStrategyKey: "Beast Skirmisher");
+            """
+            In pastures, crags, upland meadows and folded hills, goats fill the role of sure-footed herd animals. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The eye is drawn to narrow faces, hooves built for uncertain ground, thick coats or fleece, and wary horizontal gazes. Those features support herd-bound caution mixed with stubborn, practical footing, making the creature feel suited to its ground rather than merely placed there.
+
+            They mark the working edge of pastoral life, providing fibre, milk or meat while testing fences and patience. Around settlements, roads or camps, goats add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """, usages: hornedFemale, combatStrategyKey: "Beast Skirmisher");
         yield return Mammal("Llama", "Llama", "Ungulate", SizeCategory.Normal, 1.0, "Large Ungulate",
             "stock-mammal", "camelid-spitter",
             MammalPack("a cria", "a young male llama", "a young female llama", "a male llama", "a female llama",
@@ -294,7 +462,13 @@ public partial class AnimalSeeder
                 "Its upright neck and neatly placed feet give it a wary, elegant silhouette.",
                 "It holds itself with an aloof, steady calm.",
                 "high pasture, dry plain and mountain track"),
-            "Llamas", usages: udder, combatStrategyKey: "Beast Artillery");
+            """
+            Llamas occupy high pasture, dry plain, desert track and mountain road as long-necked, dry-country herd animals. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            The most telling cues are padded feet, long lashes, thick coats or humps and a frame made for distance. Those features support aloof patience and stubborn endurance, making the creature feel suited to its ground rather than merely placed there.
+
+            They belong to caravan, pack and upland work, carrying themselves as if hardship were a normal condition of travel. Around settlements, roads or camps, llamas add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """, usages: udder, combatStrategyKey: "Beast Artillery");
         yield return Mammal("Alpaca", "Alpaca", "Ungulate", SizeCategory.Normal, 0.8, "Large Ungulate",
             "stock-mammal", "camelid-spitter",
             MammalPack("a cria", "a young male alpaca", "a young female alpaca", "a male alpaca", "a female alpaca",
@@ -302,7 +476,13 @@ public partial class AnimalSeeder
                 "Its rounded face and oversized eyes give it a gentle, almost toy-like look.",
                 "It moves with quiet delicacy and herd-bred caution.",
                 "cool pasture and upland meadow"),
-            "Alpacas", usages: udder, combatStrategyKey: "Beast Artillery");
+            """
+            Where high pasture, dry plain, desert track and mountain road meets daily life, alpacas are recognisable as long-necked, dry-country herd animals. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            Most of its character sits in padded feet, long lashes, thick coats or humps and a frame made for distance. Those features support aloof patience and stubborn endurance, making the creature feel suited to its ground rather than merely placed there.
+
+            They belong to caravan, pack and upland work, carrying themselves as if hardship were a normal condition of travel. Around settlements, roads or camps, alpacas add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """, usages: udder, combatStrategyKey: "Beast Artillery");
         yield return Mammal("Camel", "Camelid", "Ungulate", SizeCategory.Large, 1.2, "Horse",
             "large-hooved", "camelid-spitter",
             MammalPack("a camel calf", "a young bull camel", "a young cow camel", "a bull camel", "a cow camel",
@@ -310,14 +490,27 @@ public partial class AnimalSeeder
                 "Its deep chest and swaying hump make the whole frame look engineered for thirst, distance and bad terrain.",
                 "It carries itself with patient hauteur and the stubborn composure of an animal that expects the world to be hot and difficult.",
                 "desert caravan, dry steppe and stony waste"),
-            "Camels", usages: udder, combatStrategyKey: "Beast Artillery");
+            """
+            Camels are long-necked, dry-country herd animals of high pasture, dry plain, desert track and mountain road. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            Look closer and the outline is all padded feet, long lashes, thick coats or humps and a frame made for distance. In motion they are marked by aloof patience and stubborn endurance, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They belong to caravan, pack and upland work, carrying themselves as if hardship were a normal condition of travel. For characters nearby, a camel is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """, usages: udder, combatStrategyKey: "Beast Artillery");
         yield return Mammal("Bear", "Ursine", "Toed Quadruped", SizeCategory.Large, 1.4, "Bear",
             "large-hooved", "bear",
             MammalPack("a bear cub", "a young male bear", "a young female bear", "a male bear", "a female bear",
                 "It is huge and broad, with dense fur, thick shoulders and a heavy swinging gait.",
                 "Its paws are enormous and its claws long enough to dig, tear and hold with dreadful force.",
                 "It radiates blunt strength and the certainty that it is difficult to stop once angered.",
-                "forest, mountain and rough northern country"));
+                "forest, mountain and rough northern country"),
+            description: """
+            In forest, mountain, bamboo thicket and rough northern country, bears fill the role of broad, powerful ursine mammals. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The first things to register are dense fur, deep chests, massive paws and claws meant to dig, climb, tear and hold. In motion they are marked by slow weight until provoked, when the strength becomes immediate and alarming, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They are respected at a distance, feared around stores and cubs, and remembered wherever the wilderness presses close. For characters nearby, a bear is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Mammal("Mouse", "Murine", "Toed Quadruped", SizeCategory.Tiny, 0.1, "Small Rodent",
             "tiny-fast", "nuisance-bite",
             MammalPack("a mouse pinkie", "a young buck mouse", "a young doe mouse", "a buck mouse", "a doe mouse",
@@ -325,7 +518,14 @@ public partial class AnimalSeeder
                 "Its whiskers and oversized ears are constantly in motion.",
                 "It looks born to dart from cover to cover and vanish into impossibly small gaps.",
                 "granaries, burrows and the hidden corners of habitation"),
-            combatStrategyKey: "Beast Coward");
+            combatStrategyKey: "Beast Coward",
+            description: """
+            Mice are small gnawing mammals of burrows, granaries, drains, cages, grass cover and hidden settlement corners. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            Physically they are defined by sharp incisors, twitching whiskers, quick feet and compact bodies built for sheltering in tight places. The impression is completed by nervous speed, constant investigation and sudden disappearance, giving the animal a readable rhythm even before it acts.
+
+            They are pests, pets, prey or omens of neglect depending on where they appear and how many follow. For characters nearby, a mouse is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Mammal("Rat", "Rat", "Toed Quadruped", SizeCategory.Tiny, 0.2, "Small Rodent",
             "tiny-fast", "nuisance-bite",
             MammalPack("a rat pup", "a young buck rat", "a young doe rat", "a buck rat", "a doe rat",
@@ -333,7 +533,14 @@ public partial class AnimalSeeder
                 "Its blunt muzzle and heavy incisors give it a more robust look than a mouse.",
                 "It moves with shabby confidence and constant low-level vigilance.",
                 "sewers, granaries and ruined corners"),
-            combatStrategyKey: "Beast Coward");
+            combatStrategyKey: "Beast Coward",
+            description: """
+            In burrows, granaries, drains, cages, grass cover and hidden settlement corners, rats fill the role of small gnawing mammals. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            Physically they are defined by sharp incisors, twitching whiskers, quick feet and compact bodies built for sheltering in tight places. The impression is completed by nervous speed, constant investigation and sudden disappearance, giving the animal a readable rhythm even before it acts.
+
+            They are pests, pets, prey or omens of neglect depending on where they appear and how many follow. For characters nearby, a rat is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Mammal("Hamster", "Cricetid", "Toed Quadruped", SizeCategory.Tiny, 0.1, "Small Rodent",
             "tiny-fast", "nuisance-bite",
             MammalPack("a hamster pup", "a young male hamster", "a young female hamster", "a male hamster", "a female hamster",
@@ -341,7 +548,14 @@ public partial class AnimalSeeder
                 "Its small paws and blunt face make it look built for digging and hoarding.",
                 "It gives off a nervous but stubborn domestic energy.",
                 "burrows, cages and dry scrub"),
-            combatStrategyKey: "Beast Coward");
+            combatStrategyKey: "Beast Coward",
+            description: """
+            Hamsters occupy burrows, granaries, drains, cages, grass cover and hidden settlement corners as small gnawing mammals. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            Physically they are defined by sharp incisors, twitching whiskers, quick feet and compact bodies built for sheltering in tight places. The impression is completed by nervous speed, constant investigation and sudden disappearance, giving the animal a readable rhythm even before it acts.
+
+            They are pests, pets, prey or omens of neglect depending on where they appear and how many follow. For characters nearby, a hamster is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Mammal("Guinea Pig", "Guinea Pig", "Toed Quadruped", SizeCategory.Tiny, 0.1, "Small Rodent",
             "tiny-fast", "nuisance-bite",
             MammalPack("a guinea pig pup", "a young boar guinea pig", "a young sow guinea pig", "a boar guinea pig", "a sow guinea pig",
@@ -349,7 +563,14 @@ public partial class AnimalSeeder
                 "Its bright eyes and twitching nose make it look gentle and perpetually concerned.",
                 "It seems more likely to whistle in alarm than to stand its ground.",
                 "grassy cover and domestic hutches"),
-            combatStrategyKey: "Beast Coward");
+            combatStrategyKey: "Beast Coward",
+            description: """
+            Where burrows, granaries, drains, cages, grass cover and hidden settlement corners meets daily life, guinea pigs are recognisable as small gnawing mammals. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            Physically they are defined by sharp incisors, twitching whiskers, quick feet and compact bodies built for sheltering in tight places. The impression is completed by nervous speed, constant investigation and sudden disappearance, giving the animal a readable rhythm even before it acts.
+
+            They are pests, pets, prey or omens of neglect depending on where they appear and how many follow. For characters nearby, a guinea pig is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Mammal("Ferret", "Ferret", "Toed Quadruped", SizeCategory.VerySmall, 0.2, "Mustelid",
             "standard-mammal", "small-predator",
             MammalPack("a ferret kit", "a young hob ferret", "a young jill ferret", "a hob ferret", "a jill ferret",
@@ -357,7 +578,14 @@ public partial class AnimalSeeder
                 "Its sharp little face and lively black eyes make it look permanently curious.",
                 "It moves in quick, snaking bursts full of mischief and predatory interest.",
                 "burrows, barns and cramped passages"),
-            combatStrategyKey: "Beast Skirmisher");
+            combatStrategyKey: "Beast Skirmisher",
+            description: """
+            Ferrets occupy burrows, barns, hedgerows, riverbanks, snow country and ruined walls as low, flexible small predators. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            The body plan is clear: long bodies, short legs, sharp faces and teeth that make their size easy to misjudge. Watch one move and the emphasis falls on snaking bursts of predatory curiosity, a pattern that tells more than size alone.
+
+            They are tolerated for hunting vermin, cursed for raiding stores and admired uneasily for their fearless persistence. For characters nearby, a ferret is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Mammal("Stoat", "Stoat", "Toed Quadruped", SizeCategory.VerySmall, 0.15, "Mustelid",
             "standard-mammal", "small-predator",
             MammalPack("a stoat kit", "a young male stoat", "a young female stoat", "a male stoat", "a female stoat",
@@ -365,7 +593,13 @@ public partial class AnimalSeeder
                 "Its little body is made for darting into holes after prey, and in cold regions its coat can pale almost to white.",
                 "It twitches with predatory focus despite its size, every movement fast and exact.",
                 "hedgerow, stone wall and snowy field"),
-            "Stoats", combatStrategyKey: "Beast Skirmisher");
+            """
+            Where burrows, barns, hedgerows, riverbanks, snow country and ruined walls meets daily life, stoats are recognisable as low, flexible small predators. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The body plan is clear: long bodies, short legs, sharp faces and teeth that make their size easy to misjudge. Watch one move and the emphasis falls on snaking bursts of predatory curiosity, a pattern that tells more than size alone.
+
+            They are tolerated for hunting vermin, cursed for raiding stores and admired uneasily for their fearless persistence. For characters nearby, a stoat is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """, combatStrategyKey: "Beast Skirmisher");
         yield return Mammal("Weasel", "Weasel", "Toed Quadruped", SizeCategory.VerySmall, 0.2, "Mustelid",
             "standard-mammal", "small-predator",
             MammalPack("a weasel kit", "a young male weasel", "a young female weasel", "a male weasel", "a female weasel",
@@ -373,7 +607,13 @@ public partial class AnimalSeeder
                 "Its teeth look too sharp for such a small face, and its paws are quick and clever.",
                 "It gives the impression of restless, purposeful violence in miniature.",
                 "hedgerow, burrow and rough grass"),
-            "Weasels", combatStrategyKey: "Beast Skirmisher");
+            """
+            Weasels are low, flexible small predators of burrows, barns, hedgerows, riverbanks, snow country and ruined walls. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            What distinguishes the line is long bodies, short legs, sharp faces and teeth that make their size easy to misjudge. Those features support snaking bursts of predatory curiosity, making the creature feel suited to its ground rather than merely placed there.
+
+            They are tolerated for hunting vermin, cursed for raiding stores and admired uneasily for their fearless persistence. For characters nearby, a weasel is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """, combatStrategyKey: "Beast Skirmisher");
         yield return Mammal("Polecat", "Polecat", "Toed Quadruped", SizeCategory.VerySmall, 0.25, "Mustelid",
             "standard-mammal", "small-predator",
             MammalPack("a polecat kit", "a young male polecat", "a young female polecat", "a male polecat", "a female polecat",
@@ -381,7 +621,13 @@ public partial class AnimalSeeder
                 "Its face is pointed and expressive, and the whole animal has the musky look of something that would rather bite than be cornered.",
                 "It moves in low, sinuous bursts that make every tunnel and hedge-line look like cover.",
                 "hedgebank, rough pasture and ruin"),
-            "Polecats", combatStrategyKey: "Beast Skirmisher");
+            """
+            In burrows, barns, hedgerows, riverbanks, snow country and ruined walls, polecats fill the role of low, flexible small predators. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The creature is best read through long bodies, short legs, sharp faces and teeth that make their size easy to misjudge. Those features support snaking bursts of predatory curiosity, making the creature feel suited to its ground rather than merely placed there.
+
+            They are tolerated for hunting vermin, cursed for raiding stores and admired uneasily for their fearless persistence. For characters nearby, a polecat is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """, combatStrategyKey: "Beast Skirmisher");
         yield return Mammal("Mink", "Mink", "Toed Quadruped", SizeCategory.VerySmall, 0.25, "Mustelid",
             "standard-mammal", "small-predator",
             MammalPack("a mink kit", "a young male mink", "a young female mink", "a male mink", "a female mink",
@@ -389,7 +635,13 @@ public partial class AnimalSeeder
                 "Its long tail and slightly webbed feet hint at a hunter equally comfortable on bank or in water.",
                 "It gives off the quiet intent of a predator that has never needed to be large to be dangerous.",
                 "riverbank, marsh edge and reed-choked pool"),
-            "Minks", combatStrategyKey: "Beast Skirmisher");
+            """
+            Minks occupy burrows, barns, hedgerows, riverbanks, snow country and ruined walls as low, flexible small predators. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            Its strongest visual signs are long bodies, short legs, sharp faces and teeth that make their size easy to misjudge. Those features support snaking bursts of predatory curiosity, making the creature feel suited to its ground rather than merely placed there.
+
+            They are tolerated for hunting vermin, cursed for raiding stores and admired uneasily for their fearless persistence. For characters nearby, a mink is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """, combatStrategyKey: "Beast Skirmisher");
         yield return Mammal("Shrew", "Shrew", "Toed Quadruped", SizeCategory.Tiny, 0.1, "Small Rodent",
             "tiny-fast", "small-predator",
             MammalPack("a shrew pup", "a young male shrew", "a young female shrew", "a male shrew", "a female shrew",
@@ -397,7 +649,13 @@ public partial class AnimalSeeder
                 "Its needle teeth and frantic little paws make it look far too fierce for something so small.",
                 "It lives at a pitch of constant hunger and nervous violence, never still for long.",
                 "leaf litter, root tangle and damp grass"),
-            "Shrews", combatStrategyKey: "Beast Skirmisher");
+            """
+            Shrews are small gnawing mammals of burrows, granaries, drains, cages, grass cover and hidden settlement corners. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            The body plan is clear: sharp incisors, twitching whiskers, quick feet and compact bodies built for sheltering in tight places. Watch one move and the emphasis falls on nervous speed, constant investigation and sudden disappearance, a pattern that tells more than size alone.
+
+            They are pests, pets, prey or omens of neglect depending on where they appear and how many follow. For characters nearby, a shrew is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """, combatStrategyKey: "Beast Skirmisher");
         yield return Mammal("Badger", "Badger", "Toed Quadruped", SizeCategory.Small, 0.8, "Mustelid",
             "standard-mammal", "small-predator",
             MammalPack("a badger cub", "a young boar badger", "a young sow badger", "a boar badger", "a sow badger",
@@ -405,7 +663,13 @@ public partial class AnimalSeeder
                 "Its shoulders and foreclaws are thick and workmanlike, made for earth and stubborn labor.",
                 "It has the dour, immovable look of an animal that dislikes being disturbed.",
                 "setts, hedgebanks and mixed woodland"),
-            "Badgers");
+            """
+            Where burrows, barns, hedgerows, riverbanks, snow country and ruined walls meets daily life, badgers are recognisable as low, flexible small predators. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The eye is drawn to long bodies, short legs, sharp faces and teeth that make their size easy to misjudge. Those features support snaking bursts of predatory curiosity, making the creature feel suited to its ground rather than merely placed there.
+
+            They are tolerated for hunting vermin, cursed for raiding stores and admired uneasily for their fearless persistence. For characters nearby, a badger is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """);
         yield return Mammal("Wolverine", "Wolverine", "Toed Quadruped", SizeCategory.Small, 0.5, "Mustelid",
             "standard-mammal", "small-predator",
             MammalPack("a wolverine cub", "a young male wolverine", "a young female wolverine", "a male wolverine", "a female wolverine",
@@ -413,7 +677,13 @@ public partial class AnimalSeeder
                 "Its teeth and shoulders make it look disproportionately formidable for its size.",
                 "It radiates surly endurance and a willingness to fight far above its weight.",
                 "snow country, tundra and cold forest"),
-            "Wolverines");
+            """
+            Wolverines are low, flexible small predators of burrows, barns, hedgerows, riverbanks, snow country and ruined walls. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            At a glance, the form resolves into long bodies, short legs, sharp faces and teeth that make their size easy to misjudge. In motion they are marked by snaking bursts of predatory curiosity, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They are tolerated for hunting vermin, cursed for raiding stores and admired uneasily for their fearless persistence. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Mammal("Cow", "Bovine", "Ungulate", SizeCategory.Large, 1.5, "Large Ungulate",
             "stock-mammal", "bovid",
             MammalPack("a calf", "a young bull", "a young cow", "a bull", "a cow",
@@ -421,7 +691,13 @@ public partial class AnimalSeeder
                 "Its calm eyes and sweeping ribs speak of a lifetime spent grazing and ruminating.",
                 "It has the placid, heavy patience of domestic stock.",
                 "pasture, open field and cattle yard"),
-            "Cows", bloodProfile: "bovine", usages: hornedFemale, combatStrategyKey: "Beast Coward");
+            """
+            In pasture, prairie, marsh, open range and cattle yards, cows fill the role of heavy-bodied horned grazers. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The visible essentials are broad chests, dense shoulders, sweeping horns and heavy necks built for mass rather than grace. In motion they are marked by slow patience backed by sudden, punishing force, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They anchor pastoral life and frontier danger alike, becoming ordinary only to those who forget how much weight they carry. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """, bloodProfile: "bovine", usages: hornedFemale, combatStrategyKey: "Beast Coward");
         yield return Mammal("Ox", "Ox", "Ungulate", SizeCategory.Large, 1.7, "Large Ungulate",
             "stock-mammal", "bovid",
             MammalPack("a calf", "a young bull", "a young cow", "an ox", "a cow",
@@ -429,7 +705,13 @@ public partial class AnimalSeeder
                 "Its sheer frame suggests hauling power rather than speed or elegance.",
                 "It stands with the settled endurance of a working beast.",
                 "field, road and draft yard"),
-            "Oxen", usages: hornedFemale, combatStrategyKey: "Beast Brawler");
+            """
+            Oxen occupy pasture, prairie, marsh, open range and cattle yards as heavy-bodied horned grazers. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            Look closer and the outline is all broad chests, dense shoulders, sweeping horns and heavy necks built for mass rather than grace. In motion they are marked by slow patience backed by sudden, punishing force, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They anchor pastoral life and frontier danger alike, becoming ordinary only to those who forget how much weight they carry. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """, usages: hornedFemale, combatStrategyKey: "Beast Brawler");
         yield return Mammal("Bison", "Bison", "Ungulate", SizeCategory.Large, 1.5, "Large Ungulate",
             "stock-mammal", "bovid",
             MammalPack("a bison calf", "a young bull bison", "a young cow bison", "a bull bison", "a cow bison",
@@ -437,7 +719,13 @@ public partial class AnimalSeeder
                 "Its dense shoulder hump and horned brow make it look like a wall of living muscle.",
                 "It has a slow, gathered momentum that hints at tremendous explosive power.",
                 "prairie, steppe and open range"),
-            "Bisons", usages: hornedFemale, combatStrategyKey: "Beast Behemoth");
+            """
+            Where pasture, prairie, marsh, open range and cattle yards meets daily life, bison are recognisable as heavy-bodied horned grazers. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The first things to register are broad chests, dense shoulders, sweeping horns and heavy necks built for mass rather than grace. In motion they are marked by slow patience backed by sudden, punishing force, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They anchor pastoral life and frontier danger alike, becoming ordinary only to those who forget how much weight they carry. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """, usages: hornedFemale, combatStrategyKey: "Beast Behemoth");
         yield return Mammal("Buffalo", "Buffalo", "Ungulate", SizeCategory.Large, 1.5, "Large Ungulate",
             "stock-mammal", "bovid",
             MammalPack("a buffalo calf", "a young bull buffalo", "a young cow buffalo", "a bull buffalo", "a cow buffalo",
@@ -445,7 +733,13 @@ public partial class AnimalSeeder
                 "Its thick hide and low-slung head make it look like an animal built to weather punishment.",
                 "It stands with a dour, dangerous calm.",
                 "marsh, floodplain and rough pasture"),
-            "Buffalos", usages: hornedFemale, combatStrategyKey: "Beast Behemoth");
+            """
+            Buffalo are heavy-bodied horned grazers of pasture, prairie, marsh, open range and cattle yards. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            Physically they are defined by broad chests, dense shoulders, sweeping horns and heavy necks built for mass rather than grace. The impression is completed by slow patience backed by sudden, punishing force, giving the animal a readable rhythm even before it acts.
+
+            They anchor pastoral life and frontier danger alike, becoming ordinary only to those who forget how much weight they carry. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """, usages: hornedFemale, combatStrategyKey: "Beast Behemoth");
         yield return Mammal("Horse", "Equine", "Ungulate", SizeCategory.Large, 1.5, "Horse",
             "large-hooved", "herbivore-charge",
             MammalPack("a foal", "a colt", "a filly", "a stallion", "a mare",
@@ -453,7 +747,13 @@ public partial class AnimalSeeder
                 "Its long face, lively ears and large dark eyes give it an intelligent, responsive look.",
                 "It carries itself with a mixture of high-strung energy and practiced athleticism.",
                 "plain, pasture and stable"),
-            "Horse", canClimb: false, bloodProfile: "equine", usages: udder, combatStrategyKey: "Beast Physical Avoider");
+            """
+            In plains, stables, pack trails, roads and open pasture, horses fill the role of strong-legged working and riding animals. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            Physically they are defined by deep chests, long faces, powerful hindquarters and limbs made for travel. The impression is completed by athletic alertness, endurance and a social awareness that rewards skilled handling, giving the animal a readable rhythm even before it acts.
+
+            They are companions of road, war and labour, valuable precisely because speed and trust are never completely separate. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """, canClimb: false, bloodProfile: "equine", usages: udder, combatStrategyKey: "Beast Physical Avoider");
         yield return Mammal("Donkey", "Asinine", "Ungulate", SizeCategory.Normal, 1.2, "Donkey",
             "large-hooved", "herbivore-charge",
             MammalPack("a donkey foal", "a young jack donkey", "a young jenny donkey", "a jack donkey", "a jenny donkey",
@@ -461,7 +761,13 @@ public partial class AnimalSeeder
                 "Its deep chest, sure-footed stance and patient eyes give it the look of an animal made for dry tracks and difficult loads.",
                 "It carries itself with wary stubbornness and a surprising reserve of endurance.",
                 "scrub pasture, stony road and stable yard"),
-            "Donkeys", canClimb: false, bloodProfile: "equine", usages: udder, combatStrategyKey: "Beast Physical Avoider");
+            """
+            Donkeys occupy plains, stables, pack trails, roads and open pasture as strong-legged working and riding animals. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            Physically they are defined by deep chests, long faces, powerful hindquarters and limbs made for travel. The impression is completed by athletic alertness, endurance and a social awareness that rewards skilled handling, giving the animal a readable rhythm even before it acts.
+
+            They are companions of road, war and labour, valuable precisely because speed and trust are never completely separate. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """, canClimb: false, bloodProfile: "equine", usages: udder, combatStrategyKey: "Beast Physical Avoider");
         yield return Mammal("Mule", "Mule", "Ungulate", SizeCategory.Large, 1.4, "Mule",
             "large-hooved", "herbivore-charge",
             MammalPack("a mule foal", "a young john mule", "a young molly mule", "a john mule", "a molly mule",
@@ -469,7 +775,13 @@ public partial class AnimalSeeder
                 "Its strong back, dense muscle and sure-footed balance make it look bred for loads, slopes and long unfashionable roads.",
                 "It stands with practical patience, but every line suggests that forcing it would be harder than persuading it.",
                 "pack trail, mountain road and working stable"),
-            "Mules", canClimb: false, bloodProfile: "equine", usages: udder, combatStrategyKey: "Beast Physical Avoider");
+            """
+            Where plains, stables, pack trails, roads and open pasture meets daily life, mules are recognisable as strong-legged working and riding animals. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            Physically they are defined by deep chests, long faces, powerful hindquarters and limbs made for travel. The impression is completed by athletic alertness, endurance and a social awareness that rewards skilled handling, giving the animal a readable rhythm even before it acts.
+
+            They are companions of road, war and labour, valuable precisely because speed and trust are never completely separate. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """, canClimb: false, bloodProfile: "equine", usages: udder, combatStrategyKey: "Beast Physical Avoider");
         yield return Mammal("Rhinocerous", "Ceratorhine", "Ungulate", SizeCategory.Large, 1.5, "Pachyderm",
             "large-hooved", "rhino",
             MammalPack("a rhino calf", "a young bull rhino", "a young cow rhino", "a bull rhino", "a cow rhino",
@@ -477,7 +789,13 @@ public partial class AnimalSeeder
                 "Its snout carries a formidable horn and its barrel body looks difficult to injure or divert.",
                 "It gives off an air of dangerous, heavy indifference.",
                 "grassland, thorn scrub and muddy wallow"),
-            "Rhinocerouses", usages: rhinoHorn, combatStrategyKey: "Beast Behemoth");
+            """
+            Rhinoceroses are enormous thick-skinned giants of savannah, forest edge, tundra, mudbank and watering place. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            The body plan is clear: pillar limbs, immense heads, heavy hides and imposing tusks, horns or trunks. Watch one move and the emphasis falls on deliberate momentum that makes their size feel like terrain in motion, a pattern that tells more than size alone.
+
+            They are never background animals; wherever they live, roads, fences, armies and settlements must account for them. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """, usages: rhinoHorn, combatStrategyKey: "Beast Behemoth");
         yield return Mammal("Hippopotamus", "Hippopotamine", "Ungulate", SizeCategory.Large, 1.5, "Pachyderm",
             "stock-mammal", "hippo",
             MammalPack("a hippo calf", "a young bull hippo", "a young cow hippo", "a bull hippo", "a cow hippo",
@@ -485,7 +803,13 @@ public partial class AnimalSeeder
                 "Its mouth is absurdly broad, and the tusks within it look more than capable of maiming anything nearby.",
                 "It has the bad-tempered stillness of an animal secure in its size.",
                 "river, mudbank and reed-choked water"),
-            "Hippopotamuses", usages: tuskedGeneral, combatStrategyKey: "Beast Behemoth");
+            """
+            In savannah, forest edge, tundra, mudbank and watering place, hippopotamuses fill the role of enormous thick-skinned giants. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The body plan is clear: pillar limbs, immense heads, heavy hides and imposing tusks, horns or trunks. Watch one move and the emphasis falls on deliberate momentum that makes their size feel like terrain in motion, a pattern that tells more than size alone.
+
+            They are never background animals; wherever they live, roads, fences, armies and settlements must account for them. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """, usages: tuskedGeneral, combatStrategyKey: "Beast Behemoth");
         yield return Mammal("Elephant", "Elephantine", "Ungulate", SizeCategory.VeryLarge, 2.0, "Pachyderm",
             "elephant", "elephant",
             MammalPack("an elephant calf", "a young bull elephant", "a young cow elephant", "a bull elephant", "a cow elephant",
@@ -493,7 +817,13 @@ public partial class AnimalSeeder
                 "Its trunk, fanlike ears and sweeping ivory tusks make it one of the most imposing animals imaginable.",
                 "It moves with slow certainty, each step suggesting immense restrained force.",
                 "savannah, forest edge and watering place"),
-            "Elephants", usages: tuskedGeneral, combatStrategyKey: "Beast Behemoth");
+            """
+            Elephants occupy savannah, forest edge, tundra, mudbank and watering place as enormous thick-skinned giants. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            The body plan is clear: pillar limbs, immense heads, heavy hides and imposing tusks, horns or trunks. Watch one move and the emphasis falls on deliberate momentum that makes their size feel like terrain in motion, a pattern that tells more than size alone.
+
+            They are never background animals; wherever they live, roads, fences, armies and settlements must account for them. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """, usages: tuskedGeneral, combatStrategyKey: "Beast Behemoth");
         yield return Mammal("Mammoth", "Mammothine", "Ungulate", SizeCategory.VeryLarge, 2.2, "Pachyderm",
             "elephant", "elephant",
             MammalPack("a mammoth calf", "a young bull mammoth", "a young cow mammoth", "a bull mammoth", "a cow mammoth",
@@ -501,7 +831,13 @@ public partial class AnimalSeeder
                 "Its domed skull, humped shoulders and sweeping tusks make it look like winter itself learned to charge.",
                 "It moves with heavy, deliberate momentum, each stride carrying the patient force of an age-old giant.",
                 "tundra, glacial plain and cold steppe"),
-            "Mammoths", usages: tuskedGeneral, combatStrategyKey: "Beast Behemoth");
+            """
+            Where savannah, forest edge, tundra, mudbank and watering place meets daily life, mammoths are recognisable as enormous thick-skinned giants. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The body plan is clear: pillar limbs, immense heads, heavy hides and imposing tusks, horns or trunks. Watch one move and the emphasis falls on deliberate momentum that makes their size feel like terrain in motion, a pattern that tells more than size alone.
+
+            They are never background animals; wherever they live, roads, fences, armies and settlements must account for them. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """, usages: tuskedGeneral, combatStrategyKey: "Beast Behemoth");
         yield return Mammal("Oliphant", "Oliphantine", "Ungulate", SizeCategory.Huge, 3.0, "Oliphant",
             "elephant", "elephant",
             MammalPack("an oliphant calf", "a young bull oliphant", "a young cow oliphant", "a bull oliphant", "a cow oliphant",
@@ -509,7 +845,13 @@ public partial class AnimalSeeder
                 "Its sheer height and thick hide make ordinary elephants look almost modest beside it.",
                 "It moves with slow, ground-shaking confidence, built to scatter formations and carry heavy burdens through dust, heat and battle noise.",
                 "broad savannah, dry steppe and war-camp stockyards"),
-            "Enormous elephantine war beasts", usages: tuskedGeneral, combatStrategyKey: "Beast Behemoth");
+            """
+            Oliphants are enormous thick-skinned giants of savannah, forest edge, tundra, mudbank and watering place. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            The most telling cues are pillar limbs, immense heads, heavy hides and imposing tusks, horns or trunks. Those features support deliberate momentum that makes their size feel like terrain in motion, making the creature feel suited to its ground rather than merely placed there.
+
+            They are never background animals; wherever they live, roads, fences, armies and settlements must account for them. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """, usages: tuskedGeneral, combatStrategyKey: "Beast Behemoth");
         yield return Mammal("Giraffe", "Giraffine", "Ungulate", SizeCategory.VeryLarge, 1.0, "Large Ungulate",
             "large-hooved", "herbivore-charge",
             MammalPack("a giraffe calf", "a young bull giraffe", "a young cow giraffe", "a bull giraffe", "a cow giraffe",
@@ -517,7 +859,14 @@ public partial class AnimalSeeder
                 "Its small horn-like ossicones and impossibly elevated head give it a peculiar dignity.",
                 "It lopes rather than walks, with an awkward grace all its own.",
                 "dry savannah and scattered acacia country"),
-            combatStrategyKey: "Beast Physical Avoider");
+            combatStrategyKey: "Beast Physical Avoider",
+            description: """
+            Where pastures, plains, woodland edges, marshes and cold open country meets daily life, giraffes are recognisable as hoofed grazing animals. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            Physically they are defined by long legs, weight-bearing hooves and frames shaped for grazing, migration or sudden flight. The impression is completed by herd-aware caution and a readiness to bolt, charge or hold ground according to size, giving the animal a readable rhythm even before it acts.
+
+            They are central to hunting, herding and wilderness travel, familiar enough to be useful but never entirely harmless. Around settlements, roads or camps, giraffes add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """);
         yield return Mammal("Giant Panda", "Panda", "Toed Quadruped", SizeCategory.Normal, 1.1, "Bear",
             "stock-mammal", "bear",
             MammalPack("a panda cub", "a young male panda", "a young female panda", "a male giant panda", "a female giant panda",
@@ -525,7 +874,13 @@ public partial class AnimalSeeder
                 "Its powerful jaws and thick forelimbs look built for stripping bamboo as much as for defence.",
                 "It carries itself with shambling calm, but the bulk behind that gentleness is obvious.",
                 "misty bamboo forest and high mountain woodland"),
-            "Giant pandas", canClimb: true, combatStrategyKey: "Beast Behemoth");
+            """
+            Giant pandas occupy forest, mountain, bamboo thicket and rough northern country as broad, powerful ursine mammals. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            Its profile is built around dense fur, deep chests, massive paws and claws meant to dig, climb, tear and hold. In motion they are marked by slow weight until provoked, when the strength becomes immediate and alarming, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They are respected at a distance, feared around stores and cubs, and remembered wherever the wilderness presses close. For characters nearby, a giant panda is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """, canClimb: true, combatStrategyKey: "Beast Behemoth");
         yield return Mammal("Red Panda", "Ailurine", "Toed Quadruped", SizeCategory.VerySmall, 0.4, "Mustelid",
             "standard-mammal", "small-predator",
             MammalPack("a red panda cub", "a young male red panda", "a young female red panda", "a male red panda", "a female red panda",
@@ -533,7 +888,13 @@ public partial class AnimalSeeder
                 "Its neat paws and flexible body make it look at home among branches and cold forest cover.",
                 "It moves with quiet, treewise caution.",
                 "temperate bamboo forest and mossy highland woodland"),
-            "Red pandas", canClimb: true, combatStrategyKey: "Beast Skirmisher");
+            """
+            Where forest, mountain, bamboo thicket and rough northern country meets daily life, red pandas are recognisable as broad, powerful ursine mammals. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The creature presents dense fur, deep chests, massive paws and claws meant to dig, climb, tear and hold. In motion they are marked by slow weight until provoked, when the strength becomes immediate and alarming, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They are respected at a distance, feared around stores and cubs, and remembered wherever the wilderness presses close. For characters nearby, a red panda is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """, canClimb: true, combatStrategyKey: "Beast Skirmisher");
         yield return Mammal("Macaque", "Macacine", "Toed Quadruped", SizeCategory.Small, 0.7, "Primate",
             "standard-mammal", "small-predator",
             MammalPack("a macaque infant", "a young male macaque", "a young female macaque", "a male macaque", "a female macaque",
@@ -541,7 +902,13 @@ public partial class AnimalSeeder
                 "Its eyes are bright and socially watchful, missing little of what happens nearby.",
                 "It carries itself with bold curiosity and the quick temper of a troop animal.",
                 "forest edge, temple grove and rocky mountain woodland"),
-            "Macaques", canClimb: true, combatStrategyKey: "Beast Skirmisher");
+            """
+            In forest edges, temple groves, rocky woodland and settlement margins, macaques fill the role of quick-limbed social primates. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            Most of its character sits in grasping hands, mobile faces, watchful eyes and bodies suited to climbing and quarrelling. Those features support bold curiosity, troop awareness and sudden temper, making the creature feel suited to its ground rather than merely placed there.
+
+            They are close enough to seem clever and far enough from people to make that cleverness troublesome. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """, canClimb: true, combatStrategyKey: "Beast Skirmisher");
         yield return Mammal("Capybara", "Capybara", "Toed Quadruped", SizeCategory.Small, 0.7, "Capybara",
             "standard-mammal", "small-herbivore",
             MammalPack("a capybara pup", "a young male capybara", "a young female capybara", "a male capybara", "a female capybara",
@@ -549,7 +916,13 @@ public partial class AnimalSeeder
                 "Its webbed feet and placid eyes suit a grazer that treats water as easy refuge.",
                 "It has a composed, social calm that makes its size feel less threatening than practical.",
                 "riverbank, marsh grass and flooded savannah"),
-            "Capybaras", combatStrategyKey: "Beast Coward");
+            """
+            In burrows, granaries, drains, cages, grass cover and hidden settlement corners, capybaras fill the role of small gnawing mammals. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The body plan is clear: sharp incisors, twitching whiskers, quick feet and compact bodies built for sheltering in tight places. Watch one move and the emphasis falls on nervous speed, constant investigation and sudden disappearance, a pattern that tells more than size alone.
+
+            They are pests, pets, prey or omens of neglect depending on where they appear and how many follow. For characters nearby, a capybara is best treated as a living presence with habits and limits, not as scenery waiting to be ignored.
+            """, combatStrategyKey: "Beast Coward");
         yield return Mammal("Sloth", "Folivoran", "Toed Quadruped", SizeCategory.Small, 0.5, "Sloth",
             "standard-mammal", "small-herbivore",
             MammalPack("a sloth infant", "a young male sloth", "a young female sloth", "a male sloth", "a female sloth",
@@ -557,7 +930,13 @@ public partial class AnimalSeeder
                 "Its whole frame seems arranged for hanging from branches rather than hurrying across ground.",
                 "It moves with deliberate slowness, spending motion as though every gesture must matter.",
                 "rainforest canopy and humid river forest"),
-            "Sloths", canClimb: true, combatStrategyKey: "Beast Coward");
+            """
+            Where riverbanks, rainforest floors, termite scrub and dry woodland meets daily life, sloths are recognisable as unusual mammals with highly specialised bodies. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The visible essentials are distinctive snouts, claws, armour, bills or tails that make their habits visible at a glance. In motion they are marked by methodical caution and strange efficiency, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They tend to be remembered by silhouette first, then by the trouble or wonder their specialisation creates. A sloth can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """, canClimb: true, combatStrategyKey: "Beast Coward");
         yield return Mammal("Anteater", "Myrmecophagine", "Toed Quadruped", SizeCategory.Normal, 0.8, "Anteater",
             "standard-mammal", "small-predator",
             MammalPack("an anteater pup", "a young male anteater", "a young female anteater", "a male anteater", "a female anteater",
@@ -565,7 +944,13 @@ public partial class AnimalSeeder
                 "Its narrow head and heavy claws look specialised for opening mounds and defending itself awkwardly but seriously.",
                 "It snuffles with intent, as though scent matters more than almost anything it sees.",
                 "savannah, gallery forest and termite-rich scrub"),
-            "Anteaters", combatStrategyKey: "Beast Skirmisher");
+            """
+            Anteaters are unusual mammals with highly specialised bodies of riverbanks, rainforest floors, termite scrub and dry woodland. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            Physically they are defined by distinctive snouts, claws, armour, bills or tails that make their habits visible at a glance. The impression is completed by methodical caution and strange efficiency, giving the animal a readable rhythm even before it acts.
+
+            They tend to be remembered by silhouette first, then by the trouble or wonder their specialisation creates. A anteater can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """, combatStrategyKey: "Beast Skirmisher");
         yield return Mammal("Armadillo", "Dasypodid", "Toed Quadruped", SizeCategory.VerySmall, 0.5, "Armadillo",
             "standard-mammal", "small-herbivore",
             MammalPack("an armadillo pup", "a young male armadillo", "a young female armadillo", "a male armadillo", "a female armadillo",
@@ -573,7 +958,13 @@ public partial class AnimalSeeder
                 "Its banded armour gives it the look of a burrowing creature wrapped in natural mail.",
                 "It noses along close to the ground, cautious and methodical.",
                 "dry scrub, grassland and forest floor"),
-            "Armadillos", combatStrategyKey: "Beast Coward");
+            """
+            In riverbanks, rainforest floors, termite scrub and dry woodland, armadillos fill the role of unusual mammals with highly specialised bodies. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            Physically they are defined by distinctive snouts, claws, armour, bills or tails that make their habits visible at a glance. The impression is completed by methodical caution and strange efficiency, giving the animal a readable rhythm even before it acts.
+
+            They tend to be remembered by silhouette first, then by the trouble or wonder their specialisation creates. A armadillo can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """, combatStrategyKey: "Beast Coward");
         yield return Mammal("Tapir", "Tapirine", "Ungulate", SizeCategory.Normal, 1.0, "Large Ungulate",
             "stock-mammal", "herbivore-charge",
             MammalPack("a tapir calf", "a young male tapir", "a young female tapir", "a male tapir", "a female tapir",
@@ -581,7 +972,13 @@ public partial class AnimalSeeder
                 "Its compact power and padded feet make it look like a forest animal made to push through dense cover.",
                 "It has a shy, heavy-footed caution until startled into surprising force.",
                 "rainforest, swamp margin and shadowed river trail"),
-            "Tapirs", combatStrategyKey: "Beast Physical Avoider");
+            """
+            Tapirs are hoofed grazing animals of pastures, plains, woodland edges, marshes and cold open country. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            The body plan is clear: long legs, weight-bearing hooves and frames shaped for grazing, migration or sudden flight. Watch one move and the emphasis falls on herd-aware caution and a readiness to bolt, charge or hold ground according to size, a pattern that tells more than size alone.
+
+            They are central to hunting, herding and wilderness travel, familiar enough to be useful but never entirely harmless. Around settlements, roads or camps, tapirs add practical consequences: food, noise, labour, risk, nuisance or warning.
+            """, combatStrategyKey: "Beast Physical Avoider");
         yield return Mammal("Kangaroo", "Macropod", "Toed Quadruped", SizeCategory.Normal, 0.9, "Kangaroo",
             "stock-mammal", "small-herbivore",
             MammalPack("a joey", "a young buck kangaroo", "a young doe kangaroo", "a buck kangaroo", "a doe kangaroo",
@@ -589,7 +986,13 @@ public partial class AnimalSeeder
                 "Its feet, tail and deep haunches make it look built for bounding distance over open country.",
                 "It holds itself alert and spring-loaded, ready to flee or lash out if pressed.",
                 "dry woodland, scrubland and open plain"),
-            "Kangaroos", combatStrategyKey: "Beast Physical Avoider");
+            """
+            Kangaroos occupy dry woodland, scrub, gum forest, burrows and open plains as distinctive pouched mammals. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            What distinguishes the line is specialised paws, tails, hindquarters or climbing grips suited to their particular niche. Those features support watchful, energy-conserving movement broken by sudden bounds, climbs or stubborn shoves, making the creature feel suited to its ground rather than merely placed there.
+
+            They make a landscape feel particular, carrying local habits that travellers quickly learn not to treat as ordinary livestock. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """, combatStrategyKey: "Beast Physical Avoider");
         yield return Mammal("Wallaby", "Macropod", "Toed Quadruped", SizeCategory.Small, 0.7, "Kangaroo",
             "stock-mammal", "small-herbivore",
             MammalPack("a joey", "a young buck wallaby", "a young doe wallaby", "a buck wallaby", "a doe wallaby",
@@ -597,7 +1000,13 @@ public partial class AnimalSeeder
                 "Its body is the smaller cousin of a kangaroo's, made for quick bounds through brush and rock.",
                 "It looks wary, nimble and ready to vanish into cover.",
                 "brushland, rocky scrub and open forest"),
-            "Wallabies", combatStrategyKey: "Beast Physical Avoider");
+            """
+            Where dry woodland, scrub, gum forest, burrows and open plains meets daily life, wallabies are recognisable as distinctive pouched mammals. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The creature is best read through specialised paws, tails, hindquarters or climbing grips suited to their particular niche. Those features support watchful, energy-conserving movement broken by sudden bounds, climbs or stubborn shoves, making the creature feel suited to its ground rather than merely placed there.
+
+            They make a landscape feel particular, carrying local habits that travellers quickly learn not to treat as ordinary livestock. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """, combatStrategyKey: "Beast Physical Avoider");
         yield return Mammal("Koala", "Phascolarctid", "Toed Quadruped", SizeCategory.Small, 0.5, "Koala",
             "standard-mammal", "small-herbivore",
             MammalPack("a koala joey", "a young male koala", "a young female koala", "a male koala", "a female koala",
@@ -605,7 +1014,13 @@ public partial class AnimalSeeder
                 "Its claws and compact body make it look made for clinging to trunks and high branches.",
                 "It seems sleepy and particular, wrapped in the calm of an animal that trusts its tree.",
                 "eucalyptus woodland and open gum forest"),
-            "Koalas", canClimb: true, combatStrategyKey: "Beast Coward");
+            """
+            Koalas are distinctive pouched mammals of dry woodland, scrub, gum forest, burrows and open plains. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            Its profile is built around specialised paws, tails, hindquarters or climbing grips suited to their particular niche. In motion they are marked by watchful, energy-conserving movement broken by sudden bounds, climbs or stubborn shoves, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They make a landscape feel particular, carrying local habits that travellers quickly learn not to treat as ordinary livestock. A koala can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """, canClimb: true, combatStrategyKey: "Beast Coward");
         yield return Mammal("Wombat", "Vombatid", "Toed Quadruped", SizeCategory.Small, 0.8, "Wombat",
             "standard-mammal", "small-herbivore",
             MammalPack("a wombat joey", "a young male wombat", "a young female wombat", "a male wombat", "a female wombat",
@@ -613,7 +1028,13 @@ public partial class AnimalSeeder
                 "Its low body and heavy shoulders look engineered for burrows and stubborn defence.",
                 "It moves with practical determination and very little interest in being hurried.",
                 "burrow, dry woodland and grassy scrub"),
-            "Wombats", combatStrategyKey: "Beast Brawler");
+            """
+            In dry woodland, scrub, gum forest, burrows and open plains, wombats fill the role of distinctive pouched mammals. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The creature presents specialised paws, tails, hindquarters or climbing grips suited to their particular niche. In motion they are marked by watchful, energy-conserving movement broken by sudden bounds, climbs or stubborn shoves, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They make a landscape feel particular, carrying local habits that travellers quickly learn not to treat as ordinary livestock. A wombat can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """, combatStrategyKey: "Beast Brawler");
         yield return Mammal("Platypus", "Monotreme", "Toed Quadruped", SizeCategory.VerySmall, 0.3, "Mustelid",
             "standard-mammal", "small-predator",
             MammalPack("a puggle", "a young male platypus", "a young female platypus", "a male platypus", "a female platypus",
@@ -621,7 +1042,13 @@ public partial class AnimalSeeder
                 "Its odd mix of bill, tail and swimming paws makes it look assembled for quiet river hunting.",
                 "It seems shy and secretive, more comfortable beneath rippled water than on open ground.",
                 "freshwater creek, burrowed bank and shaded pool"),
-            "Platypuses", combatStrategyKey: "Beast Skirmisher");
+            """
+            Platypuses occupy riverbanks, rainforest floors, termite scrub and dry woodland as unusual mammals with highly specialised bodies. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            Physically they are defined by distinctive snouts, claws, armour, bills or tails that make their habits visible at a glance. The impression is completed by methodical caution and strange efficiency, giving the animal a readable rhythm even before it acts.
+
+            They tend to be remembered by silhouette first, then by the trouble or wonder their specialisation creates. A platypus can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """, combatStrategyKey: "Beast Skirmisher");
         yield return Mammal("Tasmanian Devil", "Dasyurid", "Toed Quadruped", SizeCategory.Small, 0.8, "Mustelid",
             "standard-mammal", "small-predator",
             MammalPack("a Tasmanian devil joey", "a young male Tasmanian devil", "a young female Tasmanian devil", "a male Tasmanian devil", "a female Tasmanian devil",
@@ -629,7 +1056,13 @@ public partial class AnimalSeeder
                 "Its head and teeth look oversized for its body, made for tearing carrion and quarrelling over scraps.",
                 "It radiates noisy, low-slung ferocity.",
                 "scrub, forest edge and carrion-rich night country"),
-            "Tasmanian devils", combatStrategyKey: "Beast Skirmisher");
+            """
+            Tasmanian devils occupy dry woodland, scrub, gum forest, burrows and open plains as distinctive pouched mammals. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            At a glance, the form resolves into specialised paws, tails, hindquarters or climbing grips suited to their particular niche. In motion they are marked by watchful, energy-conserving movement broken by sudden bounds, climbs or stubborn shoves, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They make a landscape feel particular, carrying local habits that travellers quickly learn not to treat as ordinary livestock. A tasmanian devil can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """, combatStrategyKey: "Beast Skirmisher");
         yield return Mammal("Dingo", "Canine", "Toed Quadruped", SizeCategory.Small, 0.8, "Small Canid",
             "standard-mammal", "doglike",
             MammalPack("a dingo pup", "a young male dingo", "a young female dingo", "a male dingo", "a female dingo",
@@ -637,6 +1070,12 @@ public partial class AnimalSeeder
                 "Its alert eyes and efficient frame give it the look of a wild canid built for distance and opportunism.",
                 "It watches with wary confidence, neither tame nor wastefully aggressive.",
                 "dry woodland, spinifex plain and desert edge"),
-            "Dingoes", bloodProfile: "canine", combatStrategyKey: "Beast Skirmisher");
+            """
+            In woodland edges, scrub, dry plains and open wilderness, dingos fill the role of lean, sharp-sensed canid predators. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The body plan is clear: long muzzles, quick feet and a rangy build meant for scent, pursuit and opportunism. Watch one move and the emphasis falls on wary confidence and a habit of testing distance before committing, a pattern that tells more than size alone.
+
+            Their presence at the edge of camp or pasture is enough to make livestock restless and travellers attentive. A dingo can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """, bloodProfile: "canine", combatStrategyKey: "Beast Skirmisher");
     }
 }

--- a/DatabaseSeeder/Seeders/AnimalSeeder.ReptileTemplates.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.ReptileTemplates.cs
@@ -20,12 +20,13 @@ public partial class AnimalSeeder
             string loadout,
             string ageProfile,
             AnimalDescriptionPack pack,
-            string combatStrategyKey = "Beast Brawler")
+            string combatStrategyKey = "Beast Brawler",
+            string? description = null)
         {
             return new AnimalRaceTemplate(
                 name,
                 name,
-                null,
+                description ?? throw new InvalidOperationException($"Animal race {name} is missing a seeded description."),
                 bodyKey,
                 size,
                 false,
@@ -49,129 +50,276 @@ public partial class AnimalSeeder
                 "It is small, scaled and quick, with a narrow head and darting tongue.",
                 "Its feet are neatly clawed and its long tail works constantly for balance.",
                 "It moves in short bursts of stillness and speed.",
-                "sun-warmed rock and scrub"));
+                "sun-warmed rock and scrub"),
+            description: """
+            Lizards are scaled cold-blooded animals of sun-warmed stone, scrub, branches, river margins, deserts and marshes. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            Physically they are defined by scales, claws, tails and watchful eyes shaped by basking, ambush and quick retreat. The impression is completed by economical stillness broken by abrupt speed, giving the animal a readable rhythm even before it acts.
+
+            They are easy to dismiss until the mouth opens, the tail lashes, or the still water moves. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Reptile("Gecko", "Reptilian", SizeCategory.VerySmall, 0.1, "Reptilian", "reptile", "reptile",
             ReptilePack("a hatchling gecko", "a young gecko", "a gecko",
                 "It is slight and soft-scaled, with large eyes and an agile little body.",
                 "Its toes look oddly adept at gripping stone and wall alike.",
                 "It seems made for sudden darting movement and impossible perches.",
-                "warm wall, tree trunk and night garden"));
+                "warm wall, tree trunk and night garden"),
+            description: """
+            In sun-warmed stone, scrub, branches, river margins, deserts and marshes, geckos fill the role of scaled cold-blooded animals. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            Physically they are defined by scales, claws, tails and watchful eyes shaped by basking, ambush and quick retreat. The impression is completed by economical stillness broken by abrupt speed, giving the animal a readable rhythm even before it acts.
+
+            They are easy to dismiss until the mouth opens, the tail lashes, or the still water moves. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Reptile("Skink", "Reptilian", SizeCategory.VerySmall, 0.12, "Reptilian", "reptile", "reptile",
             ReptilePack("a hatchling skink", "a young skink", "a skink",
                 "It is smooth-scaled and glossy, with a narrow wedge of a head and a quick, shining body.",
                 "Its tiny limbs and glassy scales make it look like something poured from bronze and taught to run.",
                 "It flickers between cover and sunlight in nervous bursts of speed.",
-                "leaf litter, warm stone and dry scrub"));
+                "leaf litter, warm stone and dry scrub"),
+            description: """
+            Skinks occupy sun-warmed stone, scrub, branches, river margins, deserts and marshes as scaled cold-blooded animals. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            Physically they are defined by scales, claws, tails and watchful eyes shaped by basking, ambush and quick retreat. The impression is completed by economical stillness broken by abrupt speed, giving the animal a readable rhythm even before it acts.
+
+            They are easy to dismiss until the mouth opens, the tail lashes, or the still water moves. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Reptile("Iguana", "Reptilian", SizeCategory.Small, 0.4, "Reptilian", "reptile", "reptile",
             ReptilePack("a hatchling iguana", "a young iguana", "an iguana",
                 "It is long and scaled, with a dewlap at the throat and a ridged crest along the back.",
                 "Its tail and claws suggest a powerful climber with no wish to be handled.",
                 "It has the sleepy arrogance of a sunning reptile entirely confident in its own indifference.",
-                "branch, warm rock and humid woodland"));
+                "branch, warm rock and humid woodland"),
+            description: """
+            Where sun-warmed stone, scrub, branches, river margins, deserts and marshes meets daily life, iguanas are recognisable as scaled cold-blooded animals. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            Physically they are defined by scales, claws, tails and watchful eyes shaped by basking, ambush and quick retreat. The impression is completed by economical stillness broken by abrupt speed, giving the animal a readable rhythm even before it acts.
+
+            They are easy to dismiss until the mouth opens, the tail lashes, or the still water moves. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Reptile("Monitor Lizard", "Reptilian", SizeCategory.Small, 0.7, "Reptilian", "reptile", "reptile",
             ReptilePack("a hatchling monitor lizard", "a young monitor lizard", "a monitor lizard",
                 "It is long-necked and powerfully built, with a muscular tail and a head that looks all teeth and suspicion.",
                 "Its claws and heavy body suggest a reptile equally capable of digging, climbing and tearing at prey.",
                 "It moves with deliberate confidence, as though it expects smaller creatures to yield the path.",
-                "river margin, dry woodland and broken rock"));
+                "river margin, dry woodland and broken rock"),
+            description: """
+            Monitor lizards are scaled cold-blooded animals of sun-warmed stone, scrub, branches, river margins, deserts and marshes. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            The body plan is clear: scales, claws, tails and watchful eyes shaped by basking, ambush and quick retreat. Watch one move and the emphasis falls on economical stillness broken by abrupt speed, a pattern that tells more than size alone.
+
+            They are easy to dismiss until the mouth opens, the tail lashes, or the still water moves. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Reptile("Chameleon", "Reptilian", SizeCategory.VerySmall, 0.12, "Reptilian", "reptile", "reptile",
             ReptilePack("a hatchling chameleon", "a young chameleon", "a chameleon",
                 "It is narrow-bodied and turret-eyed, with grasping feet and skin that shifts through subtle colour.",
                 "Its curled tail and independently watchful eyes make it look perfectly adapted to branches and patience.",
                 "It advances one careful step at a time, as if every movement must be negotiated with the leaves.",
-                "branch, thorn scrub and warm woodland"));
+                "branch, thorn scrub and warm woodland"),
+            description: """
+            In sun-warmed stone, scrub, branches, river margins, deserts and marshes, chameleons fill the role of scaled cold-blooded animals. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The body plan is clear: scales, claws, tails and watchful eyes shaped by basking, ambush and quick retreat. Watch one move and the emphasis falls on economical stillness broken by abrupt speed, a pattern that tells more than size alone.
+
+            They are easy to dismiss until the mouth opens, the tail lashes, or the still water moves. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Reptile("Komodo Dragon", "Reptilian", SizeCategory.Normal, 1.0, "Reptilian", "reptile", "reptile",
             ReptilePack("a hatchling Komodo dragon", "a young Komodo dragon", "a Komodo dragon",
                 "It is huge for a lizard, deep-bodied and rough-scaled, with a heavy tail and muscular neck.",
                 "Its head and jaws look brutally practical, more like a patient butcher than a quick darting hunter.",
                 "It moves with slow predatory certainty, conserving effort until violence is close.",
-                "dry island forest, savannah scrub and rocky shore"));
+                "dry island forest, savannah scrub and rocky shore"),
+            description: """
+            Komodo dragons occupy sun-warmed stone, scrub, branches, river margins, deserts and marshes as scaled cold-blooded animals. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            The body plan is clear: scales, claws, tails and watchful eyes shaped by basking, ambush and quick retreat. Watch one move and the emphasis falls on economical stillness broken by abrupt speed, a pattern that tells more than size alone.
+
+            They are easy to dismiss until the mouth opens, the tail lashes, or the still water moves. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Reptile("Tegu", "Reptilian", SizeCategory.Small, 0.6, "Reptilian", "reptile", "reptile",
             ReptilePack("a hatchling tegu", "a young tegu", "a tegu",
                 "It is stout and glossy-scaled, with strong limbs, a blunt head and a muscular tail.",
                 "Its jaws and claws suggest a versatile reptile equally willing to root, raid or bite.",
                 "It moves with confident curiosity through warm cover.",
-                "rainforest edge, savannah scrub and riverbank"));
+                "rainforest edge, savannah scrub and riverbank"),
+            description: """
+            Where sun-warmed stone, scrub, branches, river margins, deserts and marshes meets daily life, tegus are recognisable as scaled cold-blooded animals. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The body plan is clear: scales, claws, tails and watchful eyes shaped by basking, ambush and quick retreat. Watch one move and the emphasis falls on economical stillness broken by abrupt speed, a pattern that tells more than size alone.
+
+            They are easy to dismiss until the mouth opens, the tail lashes, or the still water moves. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Reptile("Caiman", "Reptilian", SizeCategory.Normal, 1.0, "Crocodilian", "crocodilian", "reptile",
             ReptilePack("a hatchling caiman", "a young caiman", "a caiman",
                 "It is dark and armoured, with a narrow crocodilian head and a powerful tail.",
                 "Its eyes and nostrils sit high, made for watching from still water with almost nothing exposed.",
                 "It waits with compact, aquatic menace.",
                 "tropical marsh, oxbow lake and reed-choked river"),
-            combatStrategyKey: "Beast Drowner");
+            combatStrategyKey: "Beast Drowner",
+            description: """
+            Caimen are scaled cold-blooded animals of sun-warmed stone, scrub, branches, river margins, deserts and marshes. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            What distinguishes the line is scales, claws, tails and watchful eyes shaped by basking, ambush and quick retreat. Those features support economical stillness broken by abrupt speed, making the creature feel suited to its ground rather than merely placed there.
+
+            They are easy to dismiss until the mouth opens, the tail lashes, or the still water moves. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Reptile("Frilled Lizard", "Reptilian", SizeCategory.VerySmall, 0.2, "Reptilian", "reptile", "reptile",
             ReptilePack("a hatchling frilled lizard", "a young frilled lizard", "a frilled lizard",
                 "It is lean and long-tailed, with a folded collar of skin about its neck.",
                 "When tense, that frill threatens to transform its silhouette from small lizard to startling warning sign.",
                 "It looks ready to flare, sprint and scramble away in one abrupt sequence.",
-                "dry woodland, termite mound and warm scrub"));
+                "dry woodland, termite mound and warm scrub"),
+            description: """
+            In sun-warmed stone, scrub, branches, river margins, deserts and marshes, frilled lizards fill the role of scaled cold-blooded animals. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The creature is best read through scales, claws, tails and watchful eyes shaped by basking, ambush and quick retreat. Those features support economical stillness broken by abrupt speed, making the creature feel suited to its ground rather than merely placed there.
+
+            They are easy to dismiss until the mouth opens, the tail lashes, or the still water moves. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Reptile("Thorny Devil", "Reptilian", SizeCategory.VerySmall, 0.15, "Reptilian", "reptile", "reptile",
             ReptilePack("a hatchling thorny devil", "a young thorny devil", "a thorny devil",
                 "It is small and squat, covered in spikes, ridges and desert-coloured armour.",
                 "Its false-head hump and thorned outline make it look like a walking burr.",
                 "It moves with slow, stiff caution through heat and sand.",
-                "red desert, spinifex and dry sandy plain"));
+                "red desert, spinifex and dry sandy plain"),
+            description: """
+            Thorny devils occupy sun-warmed stone, scrub, branches, river margins, deserts and marshes as scaled cold-blooded animals. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            Its strongest visual signs are scales, claws, tails and watchful eyes shaped by basking, ambush and quick retreat. Those features support economical stillness broken by abrupt speed, making the creature feel suited to its ground rather than merely placed there.
+
+            They are easy to dismiss until the mouth opens, the tail lashes, or the still water moves. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Reptile("Blue-Tongued Skink", "Reptilian", SizeCategory.VerySmall, 0.18, "Reptilian", "reptile", "reptile",
             ReptilePack("a hatchling blue-tongued skink", "a young blue-tongued skink", "a blue-tongued skink",
                 "It is glossy, thick-bodied and short-legged, with a blunt head and a vivid blue tongue.",
                 "Its heavy body and warning display make it look more stubborn than swift.",
                 "It holds its ground with small reptilian confidence.",
-                "garden edge, woodland floor and dry grass"));
+                "garden edge, woodland floor and dry grass"),
+            description: """
+            Where sun-warmed stone, scrub, branches, river margins, deserts and marshes meets daily life, blue-tongued skinks are recognisable as scaled cold-blooded animals. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The eye is drawn to scales, claws, tails and watchful eyes shaped by basking, ambush and quick retreat. Those features support economical stillness broken by abrupt speed, making the creature feel suited to its ground rather than merely placed there.
+
+            They are easy to dismiss until the mouth opens, the tail lashes, or the still water moves. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Reptile("Bearded Dragon", "Reptilian", SizeCategory.VerySmall, 0.2, "Reptilian", "reptile", "reptile",
             ReptilePack("a hatchling bearded dragon", "a young bearded dragon", "a bearded dragon",
                 "It is broad-headed and spiky, with a rough beard of scales beneath the throat.",
                 "Its flattened body and watchful basking posture suit hot stone, dust and open scrub.",
                 "It seems calm until its throat darkens and the small warning display begins.",
-                "arid woodland, rock ledge and sun-warmed scrub"));
+                "arid woodland, rock ledge and sun-warmed scrub"),
+            description: """
+            Bearded dragons are scaled cold-blooded animals of sun-warmed stone, scrub, branches, river margins, deserts and marshes. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            At a glance, the form resolves into scales, claws, tails and watchful eyes shaped by basking, ambush and quick retreat. In motion they are marked by economical stillness broken by abrupt speed, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They are easy to dismiss until the mouth opens, the tail lashes, or the still water moves. A bearded dragon can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
         yield return Reptile("Gila Monster", "Reptilian", SizeCategory.Small, 0.35, "Reptilian", "reptile", "reptile",
             ReptilePack("a hatchling Gila monster", "a young Gila monster", "a Gila monster",
                 "It is heavy and bead-scaled, boldly patterned in black and orange-pink.",
                 "Its slow movement and strong jaws give it a warning quality quite unlike a harmless basking lizard.",
                 "It advances with deliberate, venomous confidence.",
-                "desert wash, rocky scrub and hot burrow"));
+                "desert wash, rocky scrub and hot burrow"),
+            description: """
+            In sun-warmed stone, scrub, branches, river margins, deserts and marshes, gila monsters fill the role of scaled cold-blooded animals. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The visible essentials are scales, claws, tails and watchful eyes shaped by basking, ambush and quick retreat. In motion they are marked by economical stillness broken by abrupt speed, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They are easy to dismiss until the mouth opens, the tail lashes, or the still water moves. A gila monster can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
         yield return Reptile("Basilisk Lizard", "Reptilian", SizeCategory.VerySmall, 0.2, "Reptilian", "reptile", "reptile",
             ReptilePack("a hatchling basilisk lizard", "a young basilisk lizard", "a basilisk lizard",
                 "It is light and crested, with long toes, a whip tail and a nervous bright-eyed face.",
                 "Its limbs and splayed feet look adapted for explosive runs over water and mud.",
                 "It balances between branch and bank like a lizard prepared to flee in any direction.",
-                "streamside forest, riverbank and tropical thicket"));
+                "streamside forest, riverbank and tropical thicket"),
+            description: """
+            Basilisk lizards occupy sun-warmed stone, scrub, branches, river margins, deserts and marshes as scaled cold-blooded animals. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            Look closer and the outline is all scales, claws, tails and watchful eyes shaped by basking, ambush and quick retreat. In motion they are marked by economical stillness broken by abrupt speed, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They are easy to dismiss until the mouth opens, the tail lashes, or the still water moves. A basilisk lizard can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
         yield return Reptile("Turtle", "Reptilian", SizeCategory.Small, 0.5, "Chelonian", "chelonian", "reptile",
             ReptilePack("a hatchling turtle", "a young turtle", "a turtle",
                 "It is shell-backed and deliberate, with a broad body housed beneath a domed carapace.",
                 "Its beaked mouth and sturdy limbs give it a look at once ancient and stubborn.",
                 "It proceeds with patient certainty, unconcerned by urgency.",
-                "pond edge, marsh and slow river"));
+                "pond edge, marsh and slow river"),
+            description: """
+            Where sun-warmed stone, scrub, branches, river margins, deserts and marshes meets daily life, turtles are recognisable as scaled cold-blooded animals. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The first things to register are scales, claws, tails and watchful eyes shaped by basking, ambush and quick retreat. In motion they are marked by economical stillness broken by abrupt speed, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They are easy to dismiss until the mouth opens, the tail lashes, or the still water moves. A turtle can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
         yield return Reptile("Tortoise", "Reptilian", SizeCategory.Small, 0.6, "Chelonian", "chelonian", "reptile",
             ReptilePack("a hatchling tortoise", "a young tortoise", "a tortoise",
                 "It is thick-shelled and land-bound, with a high carapace and sturdy columnar limbs.",
                 "Its beak and shell together make it look more like a walking fortress than an agile animal.",
                 "It advances with stubborn, ancient patience.",
-                "dry scrub, warm plain and dusty yard"));
+                "dry scrub, warm plain and dusty yard"),
+            description: """
+            Tortoises are scaled cold-blooded animals of sun-warmed stone, scrub, branches, river margins, deserts and marshes. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            Physically they are defined by scales, claws, tails and watchful eyes shaped by basking, ambush and quick retreat. The impression is completed by economical stillness broken by abrupt speed, giving the animal a readable rhythm even before it acts.
+
+            They are easy to dismiss until the mouth opens, the tail lashes, or the still water moves. A tortoise can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
         yield return Reptile("Crocodile", "Reptilian", SizeCategory.Large, 1.4, "Crocodilian", "crocodilian", "reptile",
             ReptilePack("a hatchling crocodile", "a young crocodile", "a crocodile",
                 "It is low and broad, with plated hide, a long jaw and a powerful tail.",
                 "Its teeth are impossible to ignore, and the entire body looks built around sudden explosive force.",
                 "It lies with perfect stillness until movement becomes violence.",
                 "riverbank, swamp and warm backwater"),
-            combatStrategyKey: "Beast Drowner");
+            combatStrategyKey: "Beast Drowner",
+            description: """
+            In sun-warmed stone, scrub, branches, river margins, deserts and marshes, crocodiles fill the role of scaled cold-blooded animals. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            Physically they are defined by scales, claws, tails and watchful eyes shaped by basking, ambush and quick retreat. The impression is completed by economical stillness broken by abrupt speed, giving the animal a readable rhythm even before it acts.
+
+            They are easy to dismiss until the mouth opens, the tail lashes, or the still water moves. A crocodile can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
         yield return Reptile("Alligator", "Reptilian", SizeCategory.Large, 1.2, "Crocodilian", "crocodilian", "reptile",
             ReptilePack("a hatchling alligator", "a young alligator", "an alligator",
                 "It is armoured and broad-snouted, with dark hide and a tail thick with muscle.",
                 "Its profile is blunt and heavy, all the more dangerous for being so calm.",
                 "It has the patient menace of something that expects prey to come within reach eventually.",
                 "marsh, bayou and reed-choked water"),
-            combatStrategyKey: "Beast Drowner");
+            combatStrategyKey: "Beast Drowner",
+            description: """
+            Alligators occupy sun-warmed stone, scrub, branches, river margins, deserts and marshes as scaled cold-blooded animals. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            Physically they are defined by scales, claws, tails and watchful eyes shaped by basking, ambush and quick retreat. The impression is completed by economical stillness broken by abrupt speed, giving the animal a readable rhythm even before it acts.
+
+            They are easy to dismiss until the mouth opens, the tail lashes, or the still water moves. A alligator can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
         yield return Reptile("Frog", "Anuran", SizeCategory.VerySmall, 0.1, "Anuran", "anuran", "amphibian",
             ReptilePack("a tadpole", "a young frog", "a frog",
                 "It is compact and damp-skinned, with wide-set eyes and powerful hindlegs folded beneath the body.",
                 "Its shape is all crouch, leap and sudden stillness.",
                 "It looks ready to spring out of danger faster than anything should.",
-                "pond edge, reed bed and wet grass"));
+                "pond edge, reed bed and wet grass"),
+            description: """
+            Where pond edges, reed beds, damp soil and evening grass meets daily life, frogs are recognisable as damp-skinned amphibians. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            Physically they are defined by wide mouths, folded hindlegs, soft skin and eyes set for watching from cover. The impression is completed by crouched patience followed by sudden, elastic leaps or hops, giving the animal a readable rhythm even before it acts.
+
+            They are humble signs of wet ground and night air, noticed most when their calls fill the dark. A frog can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
         yield return Reptile("Toad", "Anuran", SizeCategory.VerySmall, 0.12, "Anuran", "anuran", "amphibian",
             ReptilePack("a tadpole", "a young toad", "a toad",
                 "It is squat and warty-skinned, with a broad mouth and heavy hindlegs.",
                 "Its rougher skin and thicker body give it a sturdier, earthier look than a frog.",
                 "It waits in stillness broken by abrupt ungainly hops.",
-                "garden edge, damp soil and evening grass"));
+                "garden edge, damp soil and evening grass"),
+            description: """
+            Toads are damp-skinned amphibians of pond edges, reed beds, damp soil and evening grass. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            The body plan is clear: wide mouths, folded hindlegs, soft skin and eyes set for watching from cover. Watch one move and the emphasis falls on crouched patience followed by sudden, elastic leaps or hops, a pattern that tells more than size alone.
+
+            They are humble signs of wet ground and night air, noticed most when their calls fill the dark. A toad can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
     }
 }

--- a/DatabaseSeeder/Seeders/AnimalSeeder.Serpents.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.Serpents.cs
@@ -12,12 +12,13 @@ public partial class AnimalSeeder
     private static IEnumerable<AnimalRaceTemplate> GetSerpentRaceTemplates()
     {
         static AnimalRaceTemplate Snake(string name, SizeCategory size, double health, string loadout, string description,
-            string feature, string behaviour, string habitat, string combatStrategyKey = "Beast Clincher")
+            string feature, string behaviour, string habitat, string combatStrategyKey = "Beast Clincher",
+            string? raceDescription = null)
         {
             return new AnimalRaceTemplate(
                 name,
                 name,
-                null,
+                raceDescription ?? throw new InvalidOperationException($"Animal race {name} is missing a seeded description."),
                 "Serpentine",
                 size,
                 string.Equals(name, "Tree Python", StringComparison.OrdinalIgnoreCase) ||
@@ -42,57 +43,134 @@ public partial class AnimalSeeder
             "It is heavy-bodied and beautifully patterned, its coils thick with latent strength.",
             "Its head is wedge-shaped and calm, giving away little of what those muscles can do.",
             "It carries itself with the slow confidence of a constrictor that trusts its body more than venom.",
-            "forest floor and humid undergrowth");
+            "forest floor and humid undergrowth",
+            raceDescription: """
+            In forest floors, scrub, branches, deserts, marshes and warm ruins, pythons fill the role of legless, scaled predators. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The body plan is clear: smooth coils, wedge-shaped heads, watchful tongues and muscles hidden beneath patterned scales. Watch one move and the emphasis falls on patient stillness followed by sudden, exact movement, a pattern that tells more than size alone.
+
+            They are treated with caution even when small, because a serpent's danger is rarely measured by noise or size alone. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Snake("Tree Python", SizeCategory.Normal, 0.4, "serpent-constrictor",
             "It is lithe and branch-coloured, its body patterned to vanish among leaves and bark.",
             "Its tail and balance suggest a serpent comfortable above the ground as well as on it.",
             "It coils with patient precision, as though every branch were already mapped in its head.",
-            "branch, canopy and warm woodland");
+            "branch, canopy and warm woodland",
+            raceDescription: """
+            Tree pythons occupy forest floors, scrub, branches, deserts, marshes and warm ruins as legless, scaled predators. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            The body plan is clear: smooth coils, wedge-shaped heads, watchful tongues and muscles hidden beneath patterned scales. Watch one move and the emphasis falls on patient stillness followed by sudden, exact movement, a pattern that tells more than size alone.
+
+            They are treated with caution even when small, because a serpent's danger is rarely measured by noise or size alone. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Snake("Boa", SizeCategory.Normal, 0.6, "serpent-constrictor",
             "It is thick-bodied and muscular, patterned in warm browns that blur into mottled cover.",
             "Its body has the dense, deliberate strength of a snake made to hold struggling prey.",
             "It moves with unhurried certainty, wasting no motion.",
-            "jungle floor and broken scrub");
+            "jungle floor and broken scrub",
+            raceDescription: """
+            Where forest floors, scrub, branches, deserts, marshes and warm ruins meets daily life, boas are recognisable as legless, scaled predators. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The body plan is clear: smooth coils, wedge-shaped heads, watchful tongues and muscles hidden beneath patterned scales. Watch one move and the emphasis falls on patient stillness followed by sudden, exact movement, a pattern that tells more than size alone.
+
+            They are treated with caution even when small, because a serpent's danger is rarely measured by noise or size alone. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Snake("Anaconda", SizeCategory.Large, 1.0, "serpent-constrictor",
             "It is huge and river-dark, its olive body marked by darker saddles and circles.",
             "Its immense girth gives it the oppressive presence of something built to overpower by sheer mass.",
             "It glides with awful patience, whether through water or mud.",
-            "swamp, oxbow and flooded jungle");
+            "swamp, oxbow and flooded jungle",
+            raceDescription: """
+            Anacondas are legless, scaled predators of forest floors, scrub, branches, deserts, marshes and warm ruins. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            Its strongest visual signs are smooth coils, wedge-shaped heads, watchful tongues and muscles hidden beneath patterned scales. Those features support patient stillness followed by sudden, exact movement, making the creature feel suited to its ground rather than merely placed there.
+
+            They are treated with caution even when small, because a serpent's danger is rarely measured by noise or size alone. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Snake("Cobra", SizeCategory.Small, 0.2, "serpent-neurotoxic",
             "It is slender and smooth-scaled, with a neck capable of spreading into a threatening hood.",
             "Its lifted posture and focused stare are as much a warning as its venom.",
             "It radiates poised hostility, ready to strike from a short violent distance.",
-            "scrub, ruin and warm grassland");
+            "scrub, ruin and warm grassland",
+            raceDescription: """
+            In forest floors, scrub, branches, deserts, marshes and warm ruins, cobras fill the role of legless, scaled predators. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The eye is drawn to smooth coils, wedge-shaped heads, watchful tongues and muscles hidden beneath patterned scales. Those features support patient stillness followed by sudden, exact movement, making the creature feel suited to its ground rather than merely placed there.
+
+            They are treated with caution even when small, because a serpent's danger is rarely measured by noise or size alone. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Snake("Adder", SizeCategory.Small, 0.2, "serpent-hemotoxic",
             "It is short, thick and darkly patterned, with a triangular head and heavy body.",
             "Its build is compact and efficient, ideal for short-range ambush rather than pursuit.",
             "It lies still with the quiet, ugly confidence of a pitfall in living form.",
-            "heath, rocky ground and cool scrub");
+            "heath, rocky ground and cool scrub",
+            raceDescription: """
+            Adders occupy forest floors, scrub, branches, deserts, marshes and warm ruins as legless, scaled predators. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            The most telling cues are smooth coils, wedge-shaped heads, watchful tongues and muscles hidden beneath patterned scales. Those features support patient stillness followed by sudden, exact movement, making the creature feel suited to its ground rather than merely placed there.
+
+            They are treated with caution even when small, because a serpent's danger is rarely measured by noise or size alone. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Snake("Rattlesnake", SizeCategory.Small, 0.2, "serpent-hemotoxic",
             "It is dusty-scaled and thick-bodied, with a broad head and a rattle at the end of its tail.",
             "Its tail advertises danger in a way few serpents ever bother to do.",
             "It looks like an animal willing to warn once and punish once.",
-            "desert, scrub and dry canyon");
+            "desert, scrub and dry canyon",
+            raceDescription: """
+            Where forest floors, scrub, branches, deserts, marshes and warm ruins meets daily life, rattlesnakes are recognisable as legless, scaled predators. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            Most of its character sits in smooth coils, wedge-shaped heads, watchful tongues and muscles hidden beneath patterned scales. Those features support patient stillness followed by sudden, exact movement, making the creature feel suited to its ground rather than merely placed there.
+
+            They are treated with caution even when small, because a serpent's danger is rarely measured by noise or size alone. Their value in a scene comes from making the environment feel inhabited, with human plans forced to account for another creature's needs.
+            """);
         yield return Snake("Viper", SizeCategory.Small, 0.2, "serpent-cytotoxic",
             "It is broad-headed and rough-scaled, its body set in heavy looping curves.",
             "Its triangular skull and thick neck make the danger obvious at a glance.",
             "It remains still until movement matters, then seems all teeth and impact.",
-            "rocky scrub and tangled brush");
+            "rocky scrub and tangled brush",
+            raceDescription: """
+            Vipers are legless, scaled predators of forest floors, scrub, branches, deserts, marshes and warm ruins. Their habits give them a visible place in the scene, whether they are glimpsed in the wild, kept near habitation or encountered at the edge of danger.
+
+            Look closer and the outline is all smooth coils, wedge-shaped heads, watchful tongues and muscles hidden beneath patterned scales. In motion they are marked by patient stillness followed by sudden, exact movement, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They are treated with caution even when small, because a serpent's danger is rarely measured by noise or size alone. A viper can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
         yield return Snake("Mamba", SizeCategory.Small, 0.2, "serpent-neurotoxic",
             "It is long, clean-scaled and unnervingly elegant, its body all speed and reach.",
             "Its narrow coffin-shaped head gives it a hard, severe silhouette.",
             "It has a tense, predatory quickness that suggests lightning-fast violence.",
             "dry woodland and warm savannah",
-            "Beast Skirmisher");
+            "Beast Skirmisher",
+            raceDescription: """
+            In forest floors, scrub, branches, deserts, marshes and warm ruins, mambas fill the role of legless, scaled predators. They are noticed through movement, sound, tracks and local caution as much as through the body itself.
+
+            The first things to register are smooth coils, wedge-shaped heads, watchful tongues and muscles hidden beneath patterned scales. In motion they are marked by patient stillness followed by sudden, exact movement, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They are treated with caution even when small, because a serpent's danger is rarely measured by noise or size alone. A mamba can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
         yield return Snake("Coral Snake", SizeCategory.Small, 0.2, "serpent-neurotoxic",
             "It is slim and brilliantly banded, its scales arranged in warning colours too vivid to ignore.",
             "Its beauty feels deliberate, almost theatrical, like a banner for its own danger.",
             "It moves in a neat, purposeful line, calm in the confidence of its venom.",
-            "leaf litter and warm woodland");
+            "leaf litter and warm woodland",
+            raceDescription: """
+            Coral snakes occupy forest floors, scrub, branches, deserts, marshes and warm ruins as legless, scaled predators. Their lives are shaped by feeding, sheltering, avoiding danger and exploiting the opportunities their build allows.
+
+            Its profile is built around smooth coils, wedge-shaped heads, watchful tongues and muscles hidden beneath patterned scales. In motion they are marked by patient stillness followed by sudden, exact movement, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They are treated with caution even when small, because a serpent's danger is rarely measured by noise or size alone. A coral snake can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
         yield return Snake("Moccasin", SizeCategory.Small, 0.2, "serpent-hemotoxic",
             "It is dark and muscular, with a broad head and heavy body built for close wet-country ambush.",
             "Its thick neck and blunt face give it a solid, ugly forcefulness.",
             "It looks as though it would rather hold its ground than flee.",
-            "swamp, marsh edge and dark water");
+            "swamp, marsh edge and dark water",
+            raceDescription: """
+            Where forest floors, scrub, branches, deserts, marshes and warm ruins meets daily life, moccasins are recognisable as legless, scaled predators. Their presence can be ordinary, useful, troublesome or alarming depending on how close they come.
+
+            The creature presents smooth coils, wedge-shaped heads, watchful tongues and muscles hidden beneath patterned scales. In motion they are marked by patient stillness followed by sudden, exact movement, so even a quiet specimen suggests the instincts and pressures that shaped it.
+
+            They are treated with caution even when small, because a serpent's danger is rarely measured by noise or size alone. A moccasin can serve as background wildlife, valuable domestic animal, troublesome vermin or a serious hazard, depending on the scene and the way nearby people have learned to live with it.
+            """);
     }
 }

--- a/DatabaseSeeder/Seeders/AnimalSeeder.StockProse.cs
+++ b/DatabaseSeeder/Seeders/AnimalSeeder.StockProse.cs
@@ -149,16 +149,7 @@ public partial class AnimalSeeder
 
     internal static string BuildRaceDescriptionForTesting(AnimalRaceTemplate template)
     {
-        AnimalDescriptionVariant primaryAdult = GetPrimaryAdultVariant(template.DescriptionPack);
-        AnimalDescriptionVariant secondaryAdult = GetSecondaryAdultVariant(template.DescriptionPack) ?? primaryAdult;
-        string summary = string.IsNullOrWhiteSpace(template.Description)
-            ? $"{template.Name}s are stock {template.Adjective.ToLowerInvariant()} animals seeded for the default FutureMUD catalogue."
-            : $"{SeederDescriptionHelpers.EnsureTrailingPeriod(template.Description)} Adults are most often represented as {primaryAdult.ShortDescription}.";
-        return SeederDescriptionHelpers.JoinParagraphs(
-            summary,
-            primaryAdult.FullDescription,
-            BuildAnimalInteractionParagraph(template.Name, secondaryAdult.FullDescription)
-        );
+        return template.Description;
     }
 
     internal static string BuildEthnicityDescriptionForTesting(string raceName, string ethnicityName)

--- a/DatabaseSeeder/Seeders/MythicalAnimalSeeder.Definitions.cs
+++ b/DatabaseSeeder/Seeders/MythicalAnimalSeeder.Definitions.cs
@@ -310,7 +310,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.VeryLarge,
                 "Horse",
                 GreatBeast(),
-                "Dragons are immense, winged reptiles with claws, horns and a powerful tail.",
+                """
+                Dragons are immense horned reptiles whose wings, claws and scaled hides make them sovereign presences wherever they settle. Their size alone would make them dangerous, but the deeper threat lies in the sense that every movement is chosen by a mind older and colder than an ordinary beast's.
+
+                Heat, hoarded treasure, scorched stone and old territorial memory gather naturally around them. A dragon's lair is rarely just a den; it becomes a centre of fear, tribute, rumour and calculation, because people must decide whether to placate it, hunt it or keep far beyond the reach of its shadow.
+
+                They work best as apex powers rather than simple monsters. A dragon may be tyrant, oracle, disaster, patron or sleeping peril, but even a peaceful one makes the surrounding country feel negotiated rather than free.
+                """,
                 "In most worlds dragons stand apart from ordinary beasts, looming over landscapes as apex predators, hoard-lords, or living catastrophes that lesser peoples must placate, evade, or confront with great preparation.",
                 Variants(
                     ("a horn-crowned dragon",
@@ -349,7 +355,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.Large,
                 "Big Felid",
                 Beast(),
-                "Griffins combine an eagle's head and wings with a leonine hindbody and foreclaws.",
+                """
+                Griffins unite the hooked beak, bright eyes and broad wings of a raptor with the hindquarters and pouncing force of a great cat. The result is not a patched-together animal, but a proud aerial hunter whose body looks equally suited to cliff wind and violent impact.
+
+                They claim high places with the confidence of creatures that see roads, herds and armies from above. Their talons make them dangerous in the first instant of contact, while the leonine part of the body gives them enough weight and courage to hold prey or intruder once grounded.
+
+                Where griffins are known, they tend to gather meanings of vigilance, nobility and territorial wrath. They may serve as sacred beasts, heraldic emblems, royal mounts or wild threats, but they never feel tame in the ordinary sense.
+                """,
                 "Griffins often fill the role of proud sky-hunters and sacred or royal beasts, creatures that dominate high crags and open skies while also appearing in heraldry, legend and elite riding traditions.",
                 Variants(
                     ("a hooked-beaked griffin",
@@ -375,7 +387,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.Large,
                 "Horse",
                 Beast(),
-                "Hippogriffs blend an eagle's forequarters and wings with an equine lower body.",
+                """
+                Hippogriffs are eagle-fronted, winged equine beasts, carrying the alert violence of a raptor on a frame large enough for the saddle. Their grace can make them look approachable until the beak, talons and sudden lunging balance remind the observer that this is no ordinary horse.
+
+                Their power sits in transition: a gallop can become a launch, a turn of the neck can become a strike, and the animal's proud carriage can change without warning into prey-focused urgency. They seem made for open slopes, hard winds and riders who understand that respect matters more than reins.
+
+                They occupy the border between wild mount and dangerous sky-beast. In settled hands they become prestige animals, scouts and cavalry wonders; in the wild they remain territorial grazers with enough predatory blood to punish careless confidence.
+                """,
                 "Hippogriffs often occupy the boundary between wild mount and dangerous aerial grazer, prized by riders who can tame them and feared by travellers who mistake their grace for docility.",
                 Variants(
                     ("a keen-eyed hippogriff",
@@ -399,7 +417,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.Large,
                 "Horse",
                 GreatBeast(),
-                "Unicorns are horse-like beings distinguished by a single spiralled horn and uncanny grace.",
+                """
+                Unicorns are horse-like beings marked by a single spiralled horn and an unnerving purity of motion. The familiar equine outline makes the strangeness sharper, because the creature seems almost ordinary until its gaze, stillness and flawless poise begin to feel deliberate.
+
+                The horn turns the body into a sign as much as a weapon. Around a unicorn, sanctuaries, moonlit glades and guarded springs feel less like scenery than rightful territory, as though the beast belongs to places where violence has to justify itself.
+
+                They are rarely treated as livestock, even when they can be approached. A unicorn may be mount, omen, guardian or prize, but it carries a moral pressure into the scene: the crude reach for it, the wary give way, and the worthy are measured before they are allowed near.
+                """,
                 "Unicorns are usually treated less as livestock than as numinous presences, creatures tied to sanctuaries, omens, purity traditions, and stories in which the worthy may approach what the crude can never catch.",
                 Variants(
                     ("a spiralled-horn unicorn",
@@ -425,7 +449,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.Large,
                 "Horse",
                 GreatBeast(),
-                "Pegasi are winged horses capable of powerful, sustained flight.",
+                """
+                Pegasi are winged horses built for both gallop and sky. Their deep chests, powerful shoulders and feathered wings give the familiar nobility of an equine body a startling vertical promise, as if a pasture animal had learned to refuse the ground.
+
+                They are creatures of open air, long approaches and difficult capture. The wings are not decoration; they change everything about how the animal flees, threatens, courts and chooses its range, giving even a quiet pegasus a sense of stored lift.
+
+                Among people, pegasi become noble mounts, courier beasts, sacred herd animals or symbols of freedom that are harder to keep than to admire. In the wild, they remain strong-willed sky-grazers whose beauty does not erase their strength.
+                """,
                 "Pegasi are commonly imagined as noble aerial mounts and heraldic wonders, but in the wild they remain strong-willed creatures whose flight ranges and herd instincts make them difficult to manage.",
                 Variants(
                     ("a feather-winged pegasus",
@@ -455,7 +485,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.Large,
                 "Large Canid",
                 GreatBeast(),
-                "Wargs are oversized, wolf-like predators bred toward savagery, endurance and a frightening, almost deliberate malice.",
+                """
+                Wargs are oversized wolf-like predators with harsh intelligence in the eyes and a body pushed toward endurance, pursuit and mauling force. They look close enough to wolves to be recognised, but too heavy, deliberate and malicious to be mistaken for natural pack animals.
+
+                Their strength lies in discipline as much as size. A warg reads the ground, the herd and the frightened line of retreat with predatory economy, making it valuable to raiders and terrifying to travellers who hear howls beyond the firelight.
+
+                They fit war camps, dark hunts and borderlands where fear is cultivated as a weapon. Whether bred, cursed or simply born monstrous, a warg makes the night feel organised against anyone moving through it.
+                """,
                 "Wargs usually occupy the role of war-beasts and terror-hounds, creatures associated with raiders, dark hunts and borderland fear rather than with any tame place in ordinary husbandry.",
                 Variants(
                     ("a long-fanged warg",
@@ -478,7 +514,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.VeryLarge,
                 "Large Canid",
                 GreatBeast(),
-                "Dire-wolves are colossal wolf-beasts, broader, heavier and markedly more dangerous than even wargs.",
+                """
+                Dire-wolves are colossal wolf-beasts, broader and heavier than wargs and built to bring down prey by weight as much as speed. Their heads are massive, their paws large enough to leave frightening tracks, and their presence turns a howl into a tactical fact.
+
+                They belong to winter timber, deep ravines and long pursuit across country where exhaustion kills before the jaws arrive. A dire-wolf does not need supernatural ornament to feel mythic; scale, pack confidence and relentless motion are enough.
+
+                They serve as pack-lords, wilderness punishments and the kind of predator that changes travel routes. A single dire-wolf is a crisis; a pack suggests that the land itself has chosen teeth.
+                """,
                 "Dire-wolves fill the mythic niche of winter pack-lords and devastating pursuit predators, the sort of beasts that turn tracks, howls and dark tree lines into immediate threats.",
                 Variants(
                     ("a hulking dire-wolf",
@@ -501,7 +543,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.VeryLarge,
                 "Bear",
                 GreatBeast(),
-                "Dire-bears are towering ursine horrors of immense mass, deep fur and ruinous claw strength.",
+                """
+                Dire-bears are immense ursine horrors, thick with fur, shoulder mass and ruinous claws. They retain the blunt solidity of ordinary bears, but expanded until every gesture feels capable of breaking timber, stone or bone.
+
+                Their menace is not speed or cunning display, but occupying space with total physical certainty. Caves, old forests and mountain passes feel different when a dire-bear claims them, because retreat becomes the sensible shape of survival.
+
+                They make excellent ancient den-lords, forest tyrants and frontier nightmares. People may speak of them as spirits of wilderness anger or simply as animals too large to reason with; either reading works once one is close enough to smell it.
+                """,
                 "Dire-bears usually stand in myth as ancient den-lords, forest tyrants and unstoppable wilderness threats whose mere presence can empty roads, camps and frontier holdings.",
                 Variants(
                     ("a mountain-sized dire-bear",
@@ -525,7 +573,13 @@ public partial class MythicalAnimalSeeder
                 "Human Male",
                 "Human Female",
                 StandardHumanoid(),
-                "Minotaurs are broad, horned humanoids with a bestial cast to their features and physiques.",
+                """
+                Minotaurs are broad horned humanoids whose bodies carry the force of a bull without surrendering personhood. Heavy brows, deep chests, thick necks and sweeping horns make them immediately imposing, especially in enclosed places where their charge has nowhere to dissipate.
+
+                They are shaped for labour, intimidation and brutal close fighting, but their mythic strength is also architectural. Corridors, gates, arenas and maze-like strongholds suit them because their sheer build makes every narrow passage feel contested.
+
+                A minotaur can be warrior, guardian, exile, citizen or monster depending on the society around it. What remains constant is the pressure of contained force: a person whose physical presence makes diplomacy, fear and violence share the same room.
+                """,
                 "Minotaurs are commonly cast as warriors, guardians and dwellers of enclosed strongholds, their size and imposing presence making them natural figures of labour, soldiery and intimidation in mythic societies.",
                 [
                     Attack("Horn Gore", ItemQuality.Standard, "rhorn", "lhorn"),
@@ -550,7 +604,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.VeryLarge,
                 "Horse",
                 GreatBeast(),
-                "Eastern dragons are long, sinuous drakes that prowl on four clawed limbs without relying on wings for flight.",
+                """
+                Eastern dragons are long, sinuous drakes whose clawed limbs and flowing bodies carry majesty without the need for wings. Their motion suggests river current, cloud-drift and coiled strength, with ornament and scale arranged into a profile of ancient authority.
+
+                They feel less like hoard-bound beasts than powers of movement and season. Waterways, storms, imperial courts and mountain cloud can all become natural theatres for them, because their shape implies rulership over change rather than simple predation.
+
+                Where one appears, people tend to read omen before animal. An eastern dragon may bless, threaten, test, advise or destroy, but it arrives with the gravity of something that has watched dynasties, floods and vows outlive their makers.
+                """,
                 "Eastern dragons often appear as imperial, spiritual or elemental beings rather than mere monsters, entwined with rivers, weather, dynasties and the idea of ancient, watchful power.",
                 Variants(
                     ("a long-bodied eastern dragon",
@@ -580,7 +640,13 @@ public partial class MythicalAnimalSeeder
                 "Human Male",
                 "Human Female",
                 LongLivedHumanoid(),
-                "Naga are humanoid from the waist up, with serpentine lower bodies and a sinuous, coiled bearing.",
+                """
+                Nagas are serpent-bodied people, humanoid from the waist up and powerful through the coiling length below. Their posture is courtly and dangerous at once, because the same body that can recline in ceremony can also strike, bind and rise with sudden force.
+
+                They suit river temples, marsh courts, old libraries and thresholds where patience is a political weapon. Scales, careful hands, still eyes and low-centred movement make them feel grounded in water, stone and ritual rather than ordinary settlement life.
+
+                As a people, naga can be nobles, guardians, scholars, sorcerers or hidden neighbours. Their danger is not merely venom or strength, but the impression that they think in longer coils than those who bargain with them.
+                """,
                 "Naga usually occupy the role of riverine nobles, temple guardians or old marsh powers, creatures whose poise and patience make them feel as political and ceremonial as they are dangerous.",
                 [
                     Attack("Carnivore Bite", ItemQuality.Standard, "mouth"),
@@ -604,7 +670,13 @@ public partial class MythicalAnimalSeeder
                 "Human Male",
                 "Human Female",
                 LongLivedHumanoid(),
-                "Merfolk have human torsos and arms paired with powerful piscine tails built for swimming.",
+                """
+                Mermaids and merfolk join recognisably human torsos and arms to powerful piscine tails. The form is intimate and alien at once: a person from the shoulders upward, a creature of current, scale and depth below.
+
+                For them, land feels temporary. Hands can trade, beckon, rescue or threaten, but the tail belongs to reefs, kelp-dark water and long movement beneath the surface, where ordinary human grace would fail almost immediately.
+
+                They are shoreline enigmas, sea-dwellers, raiders, singers, traders and guardians depending on the culture that knows them. A merfolk presence turns any meeting at the water's edge into an exchange between two incompatible homes.
+                """,
                 "Merfolk usually fill the mythic niche of sea-dwellers, reef guardians and shoreline enigmas, engaging with landfolk through trade, song, rescue, raiding or careful distance depending on the setting.",
                 [
                     Attack("Carnivore Bite", ItemQuality.Bad, "mouth"),
@@ -626,7 +698,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.Large,
                 "Big Felid",
                 GreatBeast(),
-                "Manticores are broad-winged leonine predators with a venomous tail-spike.",
+                """
+                Manticores are leonine winged predators armed with a venomous tail-spike. The body promises layered danger: claws at the first rush, jaws at close range, wings for sudden approach, and a tail that keeps threatening even when the front of the beast is checked.
+
+                They belong to badlands, lonely heights, caravan roads and ruined watchposts where rumour travels faster than certainty. Their silhouette is memorable enough that witnesses embroider it, but the practical facts are simple: a manticore can reach, maul and poison from too many angles.
+
+                They work as nightmare apex predators rather than ordinary wildlife. Hunters, travellers and border guards learn to treat each reported sighting as serious, because underestimating one means being wrong only once.
+                """,
                 "Manticores occupy the role of nightmare apex predators, the sort of thing that turns caravan routes, borderlands and lonely heights into places where every rumour deserves to be believed.",
                 Variants(
                     ("a stinger-tailed manticore",
@@ -659,7 +737,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.Large,
                 "Raptor",
                 GreatBeast(),
-                "Wyverns are draconic two-legged fliers, all leathery wings, grasping talons and snapping jaws.",
+                """
+                Wyverns are two-legged draconic fliers, leaner and more openly predatory than true dragons. Leathery wings, taloned legs, snapping jaws and a lashing tail give them a stripped-down brutality, as if every part of the body exists for diving, seizing and tearing.
+
+                They favour cliffs, ruins, dry ranges and hard open air where altitude decides survival. A wyvern does not carry the patient authority of a dragon; it carries the hunger of something that wants the high ground and punishes anything crossing below it.
+
+                They are raiders of herds, terror of lonely roads and vicious trophies for those who claim to master the sky. Their role is simple but potent: flight made savage enough to alter how people move through exposed country.
+                """,
                 "Wyverns are often treated as brutal cousins to true dragons, less regal but no less feared, and they commonly dominate cliffs, ruins and badlands where flight and aggression decide territory.",
                 Variants(
                     ("a taloned wyvern",
@@ -686,7 +770,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.Large,
                 "Raptor",
                 GreatBeast(),
-                "Fell beasts are vast, carrion-winged reptilian mounts with long necks, grasping talons and a hateful predatory bearing.",
+                """
+                Fell beasts are vast carrion-winged reptilian mounts with gaunt necks, grasping talons and a hateful downward focus. They look less like noble drakes than battlefield nightmares made to carry terror over walls and ranks.
+
+                The silhouette suggests endurance under burden as much as predation. A fell beast can circle, stoop, snatch and bear a rider through smoke or storm, but nothing about it feels domesticated; obedience seems wrung from fear, cruelty or a darker bond.
+
+                They suit black cavalry, mountain eyries and ominous flights over threatened lands. Even without a rider, one makes the sky feel occupied by hostile intent.
+                """,
                 "Fell beasts fit dark-rider, war-mount and aerial terror roles, giving builders a ready stock creature for evil cavalry, mountain eyries, siege scouting or ominous flights over threatened lands.",
                 Variants(
                     ("a carrion-winged fell beast",
@@ -713,7 +803,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.Normal,
                 "Raptor",
                 GreatBeast(),
-                "Phoenixes are radiant birds of fire and ash, here seeded without any resurrection-specific mechanics.",
+                """
+                Phoenixes are radiant firebirds whose beauty carries heat, ash and renewal in equal measure. They resemble great raptors or ceremonial birds, but light clings to them in a way that makes ordinary plumage seem dull and temporary.
+
+                Their importance is symbolic before it is tactical. Feathers, ember-bright eyes and furnace-coloured wings make the phoenix a walking omen of endings that refuse to stay ended, even where no literal rebirth is assumed.
+
+                They may be sacred beasts, fire-spirits, rare predators or living signs kept far from common touch. A phoenix is beautiful enough to draw reverence and dangerous enough to punish anyone who mistakes beauty for safety.
+                """,
                 "Phoenixes fill the symbolic role of sacred fire, omen and renewal, but even stripped of miraculous mechanics they remain rare, intimidating creatures whose beauty does not make them safe.",
                 Variants(
                     ("a radiant phoenix",
@@ -736,7 +832,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.Normal,
                 "Serpent",
                 GreatBeast(),
-                "Basilisks are immense, sinister serpents famed for their malignant aspect and deadly bite.",
+                """
+                Basilisks are immense sinister serpents whose stillness feels malignant rather than merely patient. Their coils have the weight of old venom, and their gaze makes the air around them feel unsafe even before the strike comes.
+
+                They belong to ruins, tombs, dry wells and desolate ground where life has already learned to keep its distance. A basilisk does not need to be enormous in every telling; what matters is the concentrated impression of poison, curse and predatory certainty.
+
+                They serve as lurking calamities, not animals to be studied casually. Tracks, shed skin or the silence of nearby creatures can be enough to make sensible travellers turn back.
+                """,
                 "Basilisks are classic terror-beasts of ruins, tombs and desolate places, remembered less as animals to study than as lurking calamities whose presence can poison whole stretches of land or memory.",
                 Variants(
                     ("a heavy-coiled basilisk",
@@ -759,7 +861,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.Small,
                 "Small Bird",
                 Beast(),
-                "Cockatrices are vicious little reptilian birds with pecking beaks and slashing talons.",
+                """
+                Cockatrices are vicious little reptilian birds, all stabbing beak, clawed feet and spiteful motion. Their size makes them easy to underestimate, which is part of their danger around farms, granaries, yards and broken stone.
+
+                They carry the nuisance energy of barnyard fowl twisted into something sharper and less forgiving. Scaled patches, stiff feathers and restless pecking give them a half-domestic, half-monstrous quality that makes them especially unwelcome near food stores or children.
+
+                They work as invasive pests, cursed omens and small hazards that multiply into real trouble. A cockatrice rarely dominates a landscape, but it can make a familiar corner of that landscape feel treacherous.
+                """,
                 "Cockatrices fill the ecological niche of invasive, spiteful scavenger-predators in many stories, and their small size only makes them more troublesome around farms, granaries and rocky ruins.",
                 Variants(
                     ("a reptilian cockatrice",
@@ -782,7 +890,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.Large,
                 "Giant Insect",
                 GreatBeast(),
-                "Giant beetles are heavily armoured insects enlarged to the scale of mounts or siege vermin, with crushing mandibles and hard chitin plates.",
+                """
+                Giant beetles are armoured insects enlarged until chitin becomes architecture. Heavy shells, crushing mandibles and deliberate movement give them the presence of living siege equipment rather than ordinary vermin.
+
+                Their strength is blunt resilience. Blades, claws and panic all meet the same hard casing, while the beetle continues forward with a slow insistence that makes cramped tunnels or courtyards feel smaller by the moment.
+
+                They can be dungeon vermin, battlefield beasts, uncanny mounts or labour creatures kept by societies willing to live beside huge clicking mandibles. Whether feared or harnessed, they are valued for being difficult to stop.
+                """,
                 "Giant beetles commonly fill the role of living battering creatures, dungeon vermin or uncanny beasts of burden, valued and feared for the same brute resilience that makes them hard to kill.",
                 Variants(
                     ("a plate-backed giant beetle",
@@ -804,7 +918,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.Large,
                 "Giant Insect",
                 GreatBeast(),
-                "Giant ants are outsized eusocial insects with chitinous bodies, crushing mandibles and the relentless purpose of a colony made monstrous.",
+                """
+                Giant ants are eusocial insects made monstrous, their segmented bodies and crushing jaws driven by the tireless logic of a colony. An individual is alarming; the thought of many moving with the same purpose is worse.
+
+                They turn soil, tunnels and earthen walls into organised territory. Antennae, mandibles and disciplined motion make them feel less like wandering beasts than extensions of a hidden command beneath the ground.
+
+                They suit hive warrens, siege tunnels and landscapes where numbers matter more than heroics. People fear giant ants not only because they bite, but because their labour can reshape the battlefield before anyone notices.
+                """,
                 "Giant ants commonly fill the niche of hive-tunnel vermin, uncanny labour-beasts and living siege pests, creatures whose discipline and numbers can make even simple burrows feel militarised.",
                 Variants(
                     ("an iron-jawed giant ant",
@@ -826,7 +946,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.Large,
                 "Giant Insect",
                 GreatBeast(),
-                "Giant mantises are towering predatory insects whose grasping forelegs and triangular heads make them look like ambush made flesh.",
+                """
+                Giant mantises are towering predatory insects whose folded forelegs look like weapons held in prayer. Their triangular heads and rigid patience give them a terrible stillness, as though the entire body has become a trap waiting for permission to close.
+
+                Camouflage, height and sudden reach define them. A giant mantis can vanish among trees, carved pillars or tall reeds until movement betrays prey, then convert silence into violence in a single precise strike.
+
+                They work as garden horrors, temple guardians, jungle ambushers and sacred predators in cultures that respect patience as a form of cruelty. Their danger lies in how little warning they need.
+                """,
                 "Giant mantises usually occupy the niche of patient killer-beasts and temple-garden horrors, creatures remembered for stillness, sudden violence and an unnerving impression of intent.",
                 Variants(
                     ("a scythe-limbed giant mantis",
@@ -849,7 +975,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.Large,
                 "Giant Arachnid",
                 GreatBeast(),
-                "Giant spiders are monstrous web-spinners with long stabbing legs, clustered eyes and fangs large enough to punch through armour gaps.",
+                """
+                Giant spiders are monstrous web-spinners with long stabbing legs, clustered eyes and fangs too large to dismiss as mere nuisance. The whole shape is built for patience, angles and the sudden conversion of stillness into murder.
+
+                Silk changes the territory around them. Ruins, caverns and forest canopies become layered with paths, snares and hidden retreats, so that the spider's presence is felt before the spider itself appears.
+
+                They are lair predators and ambush horrors, especially effective where visibility is broken and ceilings matter. A giant spider turns architecture and woodland into a question: what has already been prepared above you?
+                """,
                 "Giant spiders commonly fill the niche of ambush horrors and lair-predators, creatures that turn ruins, caverns and forest canopies into places people cross only with dread.",
                 Variants(
                     ("a web-dark giant spider",
@@ -873,7 +1005,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.Large,
                 "Giant Scorpion",
                 GreatBeast(),
-                "Giant scorpions are armoured arachnid horrors with grasping pedipalps and a venom-laden tail arched high above the body.",
+                """
+                Giant scorpions are armoured arachnid horrors with broad pincers and a venomous tail carried like a drawn spear. Every part of the animal advertises threat, from the low plated body to the slow deliberate lift of the stinger.
+
+                They suit dry ruins, desert flats and stone hollows where a patient ambusher can wait in heat and shadow. Their claws make escape difficult, while the tail keeps danger poised even when the front of the creature is occupied.
+
+                They are apex vermin of harsh places, useful as guardian beasts only to those willing to risk being remembered as fools. A giant scorpion makes open ground feel like a kill zone.
+                """,
                 "Giant scorpions usually occupy the niche of desert apex vermin and ruin-haunters, monstrous ambush predators whose claws and tail make even open ground feel like a kill zone.",
                 Variants(
                     ("a barbed giant scorpion",
@@ -900,7 +1038,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.Large,
                 "Giant Centipede",
                 GreatBeast(),
-                "Giant centipedes are long, many-legged horrors with rippling segmented bodies and venomous-looking mandibles large enough to tear flesh.",
+                """
+                Giant centipedes are elongated predators of chitin, rippling legs and venomous mouthparts. Their movement is often the most disturbing part: a wave of limbs carrying a narrow hunger forward through gaps that look too small for anything so large.
+
+                They belong to cracks, culverts, root-tangles and buried passages where length is an advantage and panic favours the creature behind you. The head appears first, but the body keeps coming, making pursuit feel almost endless.
+
+                They serve as tunnel terrors and ruin-crawlers, less majestic than dragons and more intimate in their horror. A giant centipede makes darkness feel crowded.
+                """,
                 "Giant centipedes fill the role of burrowing terror and ruin-crawler, the sort of subterranean menace that turns cracks, culverts and cellar dark into things worth fearing.",
                 Variants(
                     ("a rippling giant centipede",
@@ -922,7 +1066,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.Large,
                 "Giant Worm",
                 GreatBeast(),
-                "Giant worms are immense burrowers of ringed flesh and grinding mouths, built to tunnel through earth and swallow prey whole.",
+                """
+                Giant worms are immense burrowers of ringed flesh and grinding mouths, built for soil, pressure and appetite. They have little of a predator's elegance, but their simple forward hunger is frightening because the ground itself becomes their cover.
+
+                Their passage leaves churned earth, collapsed galleries and sudden holes where safety used to be. The absence of eyes or expression makes them worse, turning them into a muscular event rather than an animal with moods to read.
+
+                They work as subterranean hazards, chthonic monsters and living disasters beneath farms, roads and fortifications. A giant worm does not need malice to be ruinous; movement is enough.
+                """,
                 "Giant worms fill the role of chthonic hazard and living natural disaster, the sort of subterranean terror that makes roads, farms and city foundations feel provisional at best.",
                 Variants(
                     ("a burrowing giant worm",
@@ -946,7 +1096,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.VeryLarge,
                 "Colossal Worm",
                 GreatBeast(),
-                "Colossal worms are vast subterranean predators whose tunnel-boring bulk and circular jaws make them feel more like moving geology than living flesh.",
+                """
+                Colossal worms are vast subterranean predators whose bulk makes them feel like moving geology. Their circular jaws, endless ringed bodies and tunnel-boring strength place them beyond ordinary hunting into the realm of landscape-scale danger.
+
+                Where one moves, roads buckle, wells vanish and fortifications discover that foundations are only promises made to the earth. Its body is so large that people may meet the effects of its passage long before they understand there is a creature beneath them.
+
+                They are land-swallowing behemoths and siege-breaking terrors. A colossal worm changes the question from how to kill a monster to whether the ground can be trusted at all.
+                """,
                 "Colossal worms occupy the mythic niche of land-swallowing behemoths and siege-breaking burrowers, creatures large enough to turn settlement and battlefield alike into unstable ground.",
                 Variants(
                     ("a land-swallowing colossal worm",
@@ -970,7 +1126,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.VeryLarge,
                 "Giant Centipede",
                 GreatBeast(),
-                "Ankhegs are immense burrowing arthropods with powerful mandibles and corrosive acid they can spit at prey or intruders.",
+                """
+                Ankhegs are immense burrowing arthropods with plated bodies, powerful mandibles and corrosive acid. They combine the tunnelling threat of a subterranean beast with the ranged danger of something that can spit ruin before closing to bite.
+
+                Their territory is marked by sudden sinkholes, cut roots, acrid residue and earthworks that look too purposeful for weather. When an ankheg erupts from below, armour and walls feel less reassuring than they did moments earlier.
+
+                They fit farmland horror, siege vermin and buried border threats. An ankheg makes ordinary ground defensive terrain for the monster, not for those standing on it.
+                """,
                 "Ankhegs usually occupy the niche of siege vermin and subterranean apex predators, monstrous tunnelers whose acid and sudden eruptions make farmland, roads and fortifications feel insecure.",
                 Variants(
                     ("an acid-spitting ankheg",
@@ -993,7 +1155,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.Large,
                 "Horse",
                 GreatBeast(),
-                "Hippocamps marry an equine forebody to a powerful fish-tail suited to open water.",
+                """
+                Hippocamps are aquatic myth-beasts with equine forebodies flowing into powerful fish-tails. Their lifted necks and horse-like chests suggest pride and trainability, while the tail places their true strength in surf, current and open water.
+
+                They make the sea feel rideable without making it tame. A hippocamp can rear among waves, tow through foam or vanish beneath green water, carrying the familiar dignity of a horse into a medium that refuses ordinary hooves.
+
+                They serve as sacred sea-herd animals, ceremonial mounts and elusive prizes for coastal peoples. Their presence turns harbours, reefs and beaches into places where pageantry and danger share the tide.
+                """,
                 "Hippocamps often serve as steeds, sacred sea-herd animals or elusive prizes for coastal peoples, their strange shape making them valuable to myth, pageantry and any culture that dreams of riding the surf.",
                 Variants(
                     ("a sea-tailed hippocamp",
@@ -1017,7 +1185,13 @@ public partial class MythicalAnimalSeeder
                 "Human Male",
                 "Human Female",
                 LongLivedHumanoid(),
-                "Selkies are graceful seal-folk who can move comfortably between shore and sea.",
+                """
+                Selkies are graceful seal-folk who move between shore and sea, carrying the softness of human society and the sleek reserve of cold water in the same body. Even in human shape, they often seem oriented toward tide, rock and departure.
+
+                Their strangeness is liminal rather than monstrous. Smooth movement, watchful eyes and sea-born composure mark them as people of coves and islands, at home in the spaces where landfolk become uncertain and the water takes over.
+
+                They are traders, kin, lovers, exiles, rescuers or secretive neighbours depending on the coast that knows them. A selkie brings with them the ache of two homes and the knowledge that neither fully releases its claim.
+                """,
                 "Selkies usually inhabit the role of liminal coastal people, bound to coves, islands and cold waters, where they are known through trade, kinship, secrecy and stories of departure and return.",
                 [
                     Attack("Carnivore Bite", ItemQuality.Bad, "mouth"),
@@ -1039,7 +1213,13 @@ public partial class MythicalAnimalSeeder
                 "Human Male",
                 "Human Female",
                 LongLivedHumanoid(),
-                "Myconids are humanoid fungal folk with broad caps, soft flesh and an unsettlingly quiet demeanor.",
+                """
+                Myconids are humanoid fungal folk with cap-like heads, spongy flesh and a silence that feels communal rather than empty. They seem grown into personhood rather than born in the ordinary animal sense.
+
+                Spores, damp darkness and patient exchange shape their presence. A myconid settlement is likely to feel less like a town than a living network of shared breath, hidden messages and slow decisions made beneath stone.
+
+                They serve as underworld neighbours, spore-keepers, strange diplomats and eerie communities whose customs follow biology before politics. They are not automatically hostile, but they are never entirely familiar.
+                """,
                 "Myconids usually occupy the mythic niche of hidden underworld communities, patient spore-keepers and eerie but not always hostile neighbours whose alien biology shapes every custom they keep.",
                 Variants(
                     ("a cap-headed myconid",
@@ -1066,7 +1246,13 @@ public partial class MythicalAnimalSeeder
                 "Human Male",
                 "Human Female",
                 LongLivedHumanoid(),
-                "Plantfolk are humanoid vegetative beings of bark, fibre and leaf.",
+                """
+                Plantfolk are humanoid vegetative beings of bark, fibre, stem and leaf. They stand close enough to personhood to speak, work and remember, yet every surface of them suggests growth rather than flesh.
+
+                Season, light and soil matter to them in ways ordinary cultures cannot ignore. Their gestures may seem slow or deliberate, but the patience is not emptiness; it is the rhythm of something that measures change by rooting, blooming and withering.
+
+                They can be gardeners, wardens, elders, wanderers or whole societies shaped by climate and place. A plantfolk presence makes the natural world feel less like a backdrop and more like a participant with a face.
+                """,
                 "Plantfolk often stand in myth as wardens, gardeners, slow-speaking elders or embodiments of a place itself, with social rhythms shaped by season, light, soil and patient memory.",
                 Variants(
                     ("a bark-skinned plantfolk",
@@ -1089,7 +1275,13 @@ public partial class MythicalAnimalSeeder
                 "Large Ungulate",
                 "Large Ungulate",
                 LongLivedHumanoid(),
-                "Ents are towering treefolk of bark, root and living wood whose movements feel ponderous only until they decide to act.",
+                """
+                Ents are towering treefolk of bark, root and living wood, so large that personhood has to be read through the shape of trunk, branch and slow intent. Their movements feel ponderous only until one remembers how much mass is moving.
+
+                They carry old forest memory in every knot, leaf and root-heavy limb. Knots, leaves, moss and root-heavy feet suggest seasons survived, fires remembered and paths watched long after shorter-lived peoples forgot why they mattered.
+
+                They are wardens, shepherds and terrifying avengers of woodland places. An ent makes any forest negotiation feel unequal, because the other party may be speaking for centuries of patience.
+                """,
                 "Ents usually fill the role of ancient wardens, forest shepherds and patient but terrifying avengers, beings whose scale and age make most mortal concerns seem brief and hurried.",
                 Variants(
                     ("a bark-armoured ent",
@@ -1117,7 +1309,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.Large,
                 "Large Ungulate",
                 GreatBeast(),
-                "Huorns are dark, half-wild tree-beings: less openly personlike than ents, but still capable of movement, hunger and terrible intent.",
+                """
+                Huorns are dark half-wild tree-beings, less openly social than ents and harder to distinguish from hostile woodland until they move. The silhouette keeps the ambiguity of trunks and branches while adding hunger, anger and slow pursuit.
+
+                They make stillness threatening. A huorn may stand like a tree for long stretches, then drag root and limb into motion with the terrible suggestion that the forest has decided to walk after all.
+
+                They are old-wood hazards, angry guardians and marching trees for places where the boundary between plant and person has gone wrong. Travellers fear huorns because the safest-looking grove may already be watching.
+                """,
                 "Huorns work as dangerous old-forest hazards, angry woodland guardians and uncanny marching trees for games that want tree-shepherd ecology without making every awakened tree a social NPC.",
                 Variants(
                     ("a shadowed huorn",
@@ -1146,7 +1344,13 @@ public partial class MythicalAnimalSeeder
                 "Human Male",
                 "Human Female",
                 LongLivedHumanoid(),
-                "Dryads are graceful tree-spirits whose forms remain recognisably humanoid while still carrying the living marks of bark, bloom and leaf.",
+                """
+                Dryads are graceful tree-spirits whose humanoid forms carry bark-grain, leaf, blossom and the poise of living wood. Their beauty is not decorative alone; it is inseparable from place, season and the fierce intimacy of a chosen grove.
+
+                They often seem less like visitors than expressions of the trees around them. A dryad's mood can make a glade feel welcoming, judging or dangerous, and even gentle movement may echo wind through branches rather than ordinary flesh.
+
+                They are grove-keepers, emissaries, tempters, guardians and spirits of rooted memory. To deal with a dryad is rarely to deal with one person only; it is to meet a place in human shape.
+                """,
                 "Dryads usually occupy the niche of grove-keepers, emissaries of old forests and alluring but dangerous spirits of place, balancing beauty, patience and a fierce protectiveness toward their homes.",
                 [
                     Attack("Jab", ItemQuality.Bad, "rhand", "lhand"),
@@ -1171,7 +1375,13 @@ public partial class MythicalAnimalSeeder
                 "Human Male",
                 "Human Female",
                 LongLivedHumanoid(),
-                "Owlkin are feathered, winged people with a keen gaze and a marked avian cast.",
+                """
+                Owlkin are feathered, winged people with broad faces, intense eyes and the quiet authority of nocturnal hunters. Their avian cast marks them without erasing their personhood, giving them a body suited to silence, height and sudden attention.
+
+                They belong naturally to roosts, towers, cliff settlements, night libraries and sentry posts. Feathers soften their outline, but the eyes sharpen it again, making their stillness feel observant rather than passive.
+
+                As a people, owlkin can be scholars, scouts, hunters, judges or watchful neighbours. Their presence brings the habits of the night into social space: patience, listening and the sense that little has gone unnoticed.
+                """,
                 "Owlkin commonly fill the role of nocturnal scholars, hunters and sentries, their cultural identity often bound to keen perception, silence, altitude and a strong sense of territory.",
                 [
                     Attack("Jab", ItemQuality.Standard, "rhand", "lhand"),
@@ -1201,7 +1411,13 @@ public partial class MythicalAnimalSeeder
                 "Human Male",
                 "Human Female",
                 LongLivedHumanoid(),
-                "Avian people are broad-winged birdfolk whose forms remain largely humanoid aside from their wings and avian features.",
+                """
+                Avian people are broad-winged birdfolk whose forms remain largely humanoid while carrying feathers, wings and birdlike lines of face or limb. They read as citizens of height and air rather than monsters, but the body changes every assumption about movement.
+
+                Roosting space, weather, lift and vantage shape how they live. Their wings are practical anatomy and social fact at once, influencing architecture, clothing, labour, defence and the politics of who controls the high places.
+
+                They can be aerial scouts, couriers, artisans, soldiers or whole cultures organised around wind and vertical distance. An avian person makes a room feel built too low unless it has learned to include the sky.
+                """,
                 "Avian peoples usually read as aerial citizens rather than monsters, with cultures oriented toward roosting space, wind, lookout duties and the practical consequences of living with wings and height.",
                 [
                     Attack("Jab", ItemQuality.Standard, "rhand", "lhand"),
@@ -1231,7 +1447,13 @@ public partial class MythicalAnimalSeeder
                 "Horse",
                 "Horse",
                 LongLivedHumanoid(),
-                "Centaurs combine human torsos and arms with a four-legged equine lower body.",
+                """
+                Centaurs combine human torsos and arms with four-legged equine bodies, creating people whose scale, speed and stability differ sharply from ordinary humanoids. They are not riders and mounts fused for convenience; they are a complete body with its own balance and dignity.
+
+                Open country suits them because distance answers the form. A centaur's stride changes travel, warfare, grazing, architecture and social etiquette, while the human upper body keeps tools, speech and gesture fully in play.
+
+                They are natural nomads, outriders, herders, border guardians or settled peoples who must build the world to their own measure. A centaur makes the horizon feel socially relevant.
+                """,
                 "Centaurs are frequently cast as nomads, outriders and peoples of open country, their societies shaped by speed, horizon, herd memory and a bodily scale that changes how they build, travel and fight.",
                 [
                     Attack("Hoof Stomp", ItemQuality.Good, "rfhoof", "lfhoof", "rrhoof", "lrhoof"),
@@ -1253,7 +1475,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.Large,
                 "Horse",
                 GreatBeast(),
-                "Pegacorns combine the broad wings of a pegasus with the spiralled horn of a unicorn.",
+                """
+                Pegacorns combine the wings of a pegasus with the spiralled horn of a unicorn, giving the equine form both skyward power and sacred focus. They look almost impossible even beside other mythic horses, as if two separate omens had agreed to share one body.
+
+                The wings promise speed, escape and command of open air; the horn adds judgment, sanctity and the danger of being chosen or refused. Around a pegacorn, ceremony comes easily because the creature already looks like a rare event.
+
+                They serve as impossible mounts, heraldic wonders and signs of extraordinary favour. A pegacorn should feel scarce, coveted and difficult to approach without turning the encounter into a test.
+                """,
                 "Pegacorns occupy the rarest and most ceremonial niche of the winged equines, appearing in myths as omens, impossible mounts and embodiments of wonder that blend swiftness with sanctity.",
                 Variants(
                     ("a horned winged pegacorn",
@@ -1283,7 +1511,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.Large,
                 "Horse",
                 GreatBeast(),
-                "Qilin are antlered or horned auspicious beasts, often imagined with deerlike grace, scaled hides and a solemn supernatural presence.",
+                """
+                Qilin are auspicious horned beasts of deerlike grace, scaled ornament and solemn presence. The form balances gentleness and authority, giving the impression that each step has been considered before the hoof touches ground.
+
+                They carry the atmosphere of wise rule, sacred warning and restrained power. Horn, mane, scale and gaze make them beautiful, but not tame; a qilin's calm feels conditional on the moral shape of what stands before it.
+
+                They are omens, guardian beasts and rare signs that a place or person has drawn numinous attention. A qilin encounter should feel less like spotting wildlife and more like being quietly weighed.
+                """,
                 "Qilin commonly fill the role of sacred omens, guardian beasts and symbols of wise rule, appearing less as ordinary mounts than as rare signs that a place or person has drawn the attention of the numinous world.",
                 Variants(
                     ("a scale-maned qilin",
@@ -1309,7 +1543,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.Large,
                 "Raptor",
                 GreatBeast(),
-                "Garudas are immense mythic birds of prey, radiant and fierce, with the bearing of divine hunters rather than ordinary animals.",
+                """
+                Garuda are immense mythic birds of prey with radiant bearing and devastating talons. They resemble raptors raised into sacred stature, every feathered line sharpened toward speed, height and violent purpose.
+
+                Their nature is bound to sky guardianship and serpent-slaying force. A garuda does not merely fly above the world; it watches from a domain where coils, lies and ground-bound threats can be seen and struck from impossible angles.
+
+                They may be royal messengers, divine hunters, protectors or terrifying enemies. Wherever they appear, the sky becomes an active power rather than empty distance.
+                """,
                 "Garudas are often cast as serpent-slayers, sky guardians and royal or sacred messengers, creatures whose aerial dominance makes them both protectors and devastating enemies.",
                 Variants(
                     ("a radiant garuda",
@@ -1333,7 +1573,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.Large,
                 "Raptor",
                 GreatBeast(),
-                "Giant eagles are immense, keen-eyed raptors with the size and bearing to serve as sky-lords rather than ordinary birds.",
+                """
+                Giant eagles are immense keen-eyed raptors with the size and bearing to rule high thermals and remote eyries. Their wings can cast moving shadow over the ground, while their talons make the distance between sky and prey suddenly irrelevant.
+
+                They carry a fierce intelligence without needing humanoid expression. The hooked beak, gold-bright gaze and broad shoulders suggest a creature that understands territory, debt and insult in its own uncompromising way.
+
+                They can be noble allies, proud mounts, mountain powers or dangerous hunters. A giant eagle changes travel and warfare simply by existing above them.
+                """,
                 "Giant eagles are useful as noble aerial allies, remote mountain powers, dangerous rescue mounts or proud territorial hunters who can reshape travel and warfare wherever they nest.",
                 Variants(
                     ("a broad-winged giant eagle",
@@ -1363,7 +1609,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.Large,
                 "Bear",
                 Beast(),
-                "Bunyips are ominous waterhole beasts, imagined as heavy, lurking predators of swamp, billabong and reed-choked dark.",
+                """
+                Bunyips are ominous waterhole beasts of swamp, billabong and reed-choked dark. Their forms are usually heavy, wet and half-hidden, defined as much by what the water conceals as by what the witness manages to see.
+
+                They make drinking places dangerous. Mud, ripples, sudden silence and the smell of stagnant water can all become part of the bunyip's presence, turning a practical stop on a journey into a boundary with the unknown.
+
+                They work as regional monsters, warning stories and wetland predators tied to places where settlement thins out. A bunyip should make shallow water feel deep enough to have intentions.
+                """,
                 "Bunyips work well as regional monsters tied to dangerous wetlands, warning stories and places where ordinary drinking water becomes a boundary between settlement and the unknown.",
                 Variants(
                     ("a mud-dark bunyip",
@@ -1387,7 +1639,13 @@ public partial class MythicalAnimalSeeder
                 SizeCategory.VeryLarge,
                 "Giant Worm",
                 GreatBeast(),
-                "Yacumama are enormous river serpents, vast enough in legend to make waterways themselves feel alive and hungry.",
+                """
+                Yacumama are enormous river serpents so vast that the waterway around them can seem alive. Their coils and head belong to flood, depth and moving current rather than the scale of ordinary snakes.
+
+                They are most frightening when only partly perceived: a swell against the current, a wake without a boat, a bank crumbling where no animal should be large enough to touch it. The river becomes both habitat and body.
+
+                They are guardians, devourers and mythic terrors of great waters. A yacumama encounter turns travel by canoe, ferry or riverbank into the question of whether the river permits passage.
+                """,
                 "Yacumama fit as mythic guardians or terrors of Amazonian-scale rivers, embodying flood, depth and the fear that the water below a canoe might move with its own will.",
                 Variants(
                     ("a river-vast yacumama",
@@ -1467,12 +1725,7 @@ public partial class MythicalAnimalSeeder
 
     internal static string BuildRaceDescriptionForTesting(MythicalRaceTemplate template)
     {
-        StockDescriptionVariant? supportingVariant = (template.DescriptionVariants ?? template.OverlayDescriptionVariants)?.FirstOrDefault();
-        return SeederDescriptionHelpers.JoinParagraphs(
-            SeederDescriptionHelpers.EnsureTrailingPeriod(template.Description),
-            supportingVariant?.FullDescription ?? $"This race is represented by the {template.Name} stock catalogue.",
-            SeederDescriptionHelpers.EnsureTrailingPeriod(template.RoleDescription)
-        );
+        return template.Description;
     }
 
     internal static string BuildEthnicityDescriptionForTesting(MythicalRaceTemplate template)

--- a/DatabaseSeeder/Seeders/RobotSeeder.Definitions.cs
+++ b/DatabaseSeeder/Seeders/RobotSeeder.Definitions.cs
@@ -62,7 +62,13 @@ public partial class RobotSeeder
             ["Robot Humanoid"] = new(
                 "Robot Humanoid",
                 "Robot Humanoid",
-                "A humanoid robotic chassis designed to retain broad compatibility with standard humanoid clothing, armour, and equipment.",
+                """
+                Robot humanoids are humanoid robotic chassis made to share tools, doors, clothing and equipment with people. They read as machine bodies first, with their silhouette and materials making intended function obvious before any label is needed.
+
+                Their construction emphasises general service, labour, security and companionship. Plates, joints, sensors, tracks, wheels, limbs or tool-heads feel like designed anatomy rather than decorative additions.
+
+                They belong naturally in technological societies as labourers, guards, servants, drones, companions or threats. Individual units may be polished, battered, autonomous or closely controlled, but the chassis line feels like a real part of the world rather than an isolated device.
+                """,
                 "These general-purpose chassis sit at the practical centre of a robot ecosystem, taking on service, labour, security and companionship roles wherever a society wants machine bodies that can share tools and spaces with people.",
                 "Humanoid",
                 false,
@@ -92,7 +98,13 @@ public partial class RobotSeeder
             ["Spider Crawler Robot"] = new(
                 "Spider Crawler Robot",
                 "Spider Crawler Robot",
-                "A humanoid upper chassis mounted on a sprawling multi-legged crawler base.",
+                """
+                Spider crawler robots are humanoid upper chassis mounted on a sprawling multi-legged crawler base. They read as machine bodies first, with their silhouette and materials making intended function obvious before any label is needed.
+
+                Their construction emphasises maintenance, hazardous access and intimidating patrol work where stability matters. Plates, joints, sensors, tracks, wheels, limbs or tool-heads feel like designed anatomy rather than decorative additions.
+
+                They belong naturally in technological societies as labourers, guards, servants, drones, companions or threats. Individual units may be polished, battered, autonomous or closely controlled, but the chassis line feels like a real part of the world rather than an isolated device.
+                """,
                 "Spider crawler frames suit environments where balance, stability and low-profile mobility matter more than social comfort, making them natural fits for maintenance, hazardous access and intimidating patrol work.",
                 "Robot Humanoid",
                 false,
@@ -129,7 +141,13 @@ public partial class RobotSeeder
             ["Circular Saw Robot"] = new(
                 "Circular Saw Robot",
                 "Circular Saw Robot",
-                "A worker-frame robot with integrated circular saw hand attachments in place of normal manipulators.",
+                """
+                Circular saw robots are worker-frame robots with circular saw assemblies replacing normal manipulators. They read as machine bodies first, with their silhouette and materials making intended function obvious before any label is needed.
+
+                Their construction emphasises industrial cutting, salvage and demolition where finesse is secondary to dangerous utility. Plates, joints, sensors, tracks, wheels, limbs or tool-heads feel like designed anatomy rather than decorative additions.
+
+                They belong naturally in technological societies as labourers, guards, servants, drones, companions or threats. Individual units may be polished, battered, autonomous or closely controlled, but the chassis line feels like a real part of the world rather than an isolated device.
+                """,
                 "Circular saw frames belong in industrial yards, salvage crews and demolition teams, where builders trade finesse for brute cutting power and accept that anyone meeting the machine will read it as dangerous first.",
                 "Robot Humanoid",
                 false,
@@ -159,7 +177,13 @@ public partial class RobotSeeder
             ["Pneumatic Hammer Robot"] = new(
                 "Pneumatic Hammer Robot",
                 "Pneumatic Hammer Robot",
-                "A demolition robot with paired pneumatic hammer hand attachments.",
+                """
+                Pneumatic hammer robots are demolition robots with paired pneumatic hammer arms. They read as machine bodies first, with their silhouette and materials making intended function obvious before any label is needed.
+
+                Their construction emphasises breaching, wrecking and impact-heavy labour. Plates, joints, sensors, tracks, wheels, limbs or tool-heads feel like designed anatomy rather than decorative additions.
+
+                They belong naturally in technological societies as labourers, guards, servants, drones, companions or threats. Individual units may be polished, battered, autonomous or closely controlled, but the chassis line feels like a real part of the world rather than an isolated device.
+                """,
                 "Pneumatic hammer frames are purpose-built for heavy breaching and wrecking work, the kind of robot deployed when collateral noise and violent impact matter less than getting through hard material quickly.",
                 "Robot Humanoid",
                 false,
@@ -189,7 +213,13 @@ public partial class RobotSeeder
             ["Sword-Hand Robot"] = new(
                 "Sword-Hand Robot",
                 "Sword-Hand Robot",
-                "A martial chassis with monoblade sword hands replacing both palms.",
+                """
+                Sword-hand robots are martial robots whose palms are replaced by monoblade sword assemblies. They read as machine bodies first, with their silhouette and materials making intended function obvious before any label is needed.
+
+                Their construction emphasises close combat, ceremonial menace and intimidation. Plates, joints, sensors, tracks, wheels, limbs or tool-heads feel like designed anatomy rather than decorative additions.
+
+                They belong naturally in technological societies as labourers, guards, servants, drones, companions or threats. Individual units may be polished, battered, autonomous or closely controlled, but the chassis line feels like a real part of the world rather than an isolated device.
+                """,
                 "Sword-hand frames are openly martial machines, used where intimidation, close combat and ceremonial menace are more important than subtlety or compatibility with ordinary civilian work.",
                 "Robot Humanoid",
                 false,
@@ -219,7 +249,13 @@ public partial class RobotSeeder
             ["Winged Robot"] = new(
                 "Winged Robot",
                 "Winged Robot",
-                "A humanoid robot fitted with broad articulated wings for lift and wing-buffet attacks.",
+                """
+                Winged robots are humanoid robots fitted with broad articulated wings. They read as machine bodies first, with their silhouette and materials making intended function obvious before any label is needed.
+
+                Their construction emphasises courier work, scouting, prestige guardianship and forceful spatial control. Plates, joints, sensors, tracks, wheels, limbs or tool-heads feel like designed anatomy rather than decorative additions.
+
+                They belong naturally in technological societies as labourers, guards, servants, drones, companions or threats. Individual units may be polished, battered, autonomous or closely controlled, but the chassis line feels like a real part of the world rather than an isolated device.
+                """,
                 "Winged frames serve couriers, scouts and prestige guardians that need a striking silhouette as much as mobility, and they blur the line between practical machine and deliberate display piece.",
                 "Robot Humanoid",
                 false,
@@ -254,7 +290,13 @@ public partial class RobotSeeder
             ["Jet Robot"] = new(
                 "Jet Robot",
                 "Jet Robot",
-                "A humanoid robot with paired vector-thrust jet pods replacing biological-style wings.",
+                """
+                Jet robots are humanoid robots with paired vector-thrust jet pods. They read as machine bodies first, with their silhouette and materials making intended function obvious before any label is needed.
+
+                Their construction emphasises rapid response, pursuit and dramatic high-speed repositioning. Plates, joints, sensors, tracks, wheels, limbs or tool-heads feel like designed anatomy rather than decorative additions.
+
+                They belong naturally in technological societies as labourers, guards, servants, drones, companions or threats. Individual units may be polished, battered, autonomous or closely controlled, but the chassis line feels like a real part of the world rather than an isolated device.
+                """,
                 "Jet-backed frames are specialised pursuit and rapid-response machines, built for speed, aggressive repositioning and the kind of dramatic deployment that reminds onlookers they are watching hardware rather than a person.",
                 "Robot Humanoid",
                 false,
@@ -287,7 +329,13 @@ public partial class RobotSeeder
             ["Mandible Robot"] = new(
                 "Mandible Robot",
                 "Mandible Robot",
-                "A predatory humanoid robot whose lower face houses heavy shearing mandibles.",
+                """
+                Mandible robots are predator-coded humanoid robots with heavy shearing mandibles in the lower face. They read as machine bodies first, with their silhouette and materials making intended function obvious before any label is needed.
+
+                Their construction emphasises capture, fear, close work and deliberately unsettling observation. Plates, joints, sensors, tracks, wheels, limbs or tool-heads feel like designed anatomy rather than decorative additions.
+
+                They belong naturally in technological societies as labourers, guards, servants, drones, companions or threats. Individual units may be polished, battered, autonomous or closely controlled, but the chassis line feels like a real part of the world rather than an isolated device.
+                """,
                 "Mandible-faced frames are predator-coded by design, used where fear, capture or brutal close work matter, and they show how readily robot aesthetics can be tuned to unsettle organic observers.",
                 "Robot Humanoid",
                 false,
@@ -318,7 +366,13 @@ public partial class RobotSeeder
             ["Wheeled Robot"] = new(
                 "Wheeled Robot",
                 "Wheeled Robot",
-                "A humanoid robot mounted on paired wheel assemblies instead of conventional lower legs and feet.",
+                """
+                Wheeled robots are humanoid robots mounted on paired wheel assemblies instead of lower legs. They read as machine bodies first, with their silhouette and materials making intended function obvious before any label is needed.
+
+                Their construction emphasises warehouses, corridors and smooth artificial environments. Plates, joints, sensors, tracks, wheels, limbs or tool-heads feel like designed anatomy rather than decorative additions.
+
+                They belong naturally in technological societies as labourers, guards, servants, drones, companions or threats. Individual units may be polished, battered, autonomous or closely controlled, but the chassis line feels like a real part of the world rather than an isolated device.
+                """,
                 "Wheeled humanoid frames make sense in warehouses, corridors and other smooth artificial environments where speed and endurance matter more than stairs, rubble or natural terrain.",
                 "Robot Humanoid",
                 false,
@@ -350,7 +404,13 @@ public partial class RobotSeeder
             ["Tracked Robot"] = new(
                 "Tracked Robot",
                 "Tracked Robot",
-                "A humanoid robot whose lower body is replaced by compact armoured track pods.",
+                """
+                Tracked robots are humanoid robots whose lower bodies are compact armoured track pods. They read as machine bodies first, with their silhouette and materials making intended function obvious before any label is needed.
+
+                Their construction emphasises rough service, security and engineering in debris-heavy spaces. Plates, joints, sensors, tracks, wheels, limbs or tool-heads feel like designed anatomy rather than decorative additions.
+
+                They belong naturally in technological societies as labourers, guards, servants, drones, companions or threats. Individual units may be polished, battered, autonomous or closely controlled, but the chassis line feels like a real part of the world rather than an isolated device.
+                """,
                 "Tracked humanoid frames are ruggedised for security, engineering and rough-service environments, favouring traction and persistence over grace whenever terrain or debris would defeat a simpler machine.",
                 "Robot Humanoid",
                 false,
@@ -382,7 +442,13 @@ public partial class RobotSeeder
             ["Cyborg"] = new(
                 "Cyborg",
                 "Cyborg Humanoid",
-                "A human-passing cybernetic chassis with synthetic flesh styling over a wholly robotic internal design.",
+                """
+                Cyborgs are human-passing cybernetic bodies with synthetic flesh over robotic internals. They read as machine bodies first, with their silhouette and materials making intended function obvious before any label is needed.
+
+                Their construction emphasises social infiltration, uneasy personhood and machine life in human institutions. Plates, joints, sensors, tracks, wheels, limbs or tool-heads feel like designed anatomy rather than decorative additions.
+
+                They belong naturally in technological societies as labourers, guards, servants, drones, companions or threats. Individual units may be polished, battered, autonomous or closely controlled, but the chassis line feels like a real part of the world rather than an isolated device.
+                """,
                 "Cyborg lines occupy the uneasy social space between person and platform, useful wherever a machine must move through human institutions unnoticed or where a mechanical being is deliberately made to look almost, but not quite, organic.",
                 "Human",
                 true,
@@ -412,7 +478,13 @@ public partial class RobotSeeder
             ["Roomba Robot"] = new(
                 "Roomba Robot",
                 "Roomba Robot",
-                "A compact disc-shaped maintenance robot that hustles about on low drive wheels.",
+                """
+                Roomba robots are compact disc-shaped maintenance robots on low drive wheels. They read as machine bodies first, with their silhouette and materials making intended function obvious before any label is needed.
+
+                Their construction emphasises floor care, vent work and the quiet labour that keeps facilities functioning. Plates, joints, sensors, tracks, wheels, limbs or tool-heads feel like designed anatomy rather than decorative additions.
+
+                They belong naturally in technological societies as labourers, guards, servants, drones, companions or threats. Individual units may be polished, battered, autonomous or closely controlled, but the chassis line feels like a real part of the world rather than an isolated device.
+                """,
                 "These compact maintenance units belong wherever floors, vents and under-furniture spaces need constant machine attention, and they exemplify the low-status but ubiquitous labour that keeps larger facilities functioning.",
                 null,
                 false,
@@ -441,7 +513,13 @@ public partial class RobotSeeder
             ["Tracked Utility Robot"] = new(
                 "Tracked Utility Robot",
                 "Tracked Utility Robot",
-                "A low-slung utility robot that moves on compact rubberised tracks instead of wheels.",
+                """
+                Tracked utility robots are low-slung utility robots moving on compact rubberised tracks. They read as machine bodies first, with their silhouette and materials making intended function obvious before any label is needed.
+
+                Their construction emphasises dirty service spaces, broken flooring and practical field maintenance. Plates, joints, sensors, tracks, wheels, limbs or tool-heads feel like designed anatomy rather than decorative additions.
+
+                They belong naturally in technological societies as labourers, guards, servants, drones, companions or threats. Individual units may be polished, battered, autonomous or closely controlled, but the chassis line feels like a real part of the world rather than an isolated device.
+                """,
                 "Tracked utility units are the practical answer for dirty or uneven service spaces, used where a low maintenance drone still needs enough grip and toughness to cross debris, mud or broken flooring.",
                 null,
                 false,
@@ -470,7 +548,13 @@ public partial class RobotSeeder
             ["Robot Dog"] = new(
                 "Robot Dog",
                 "Robot Dog",
-                "A quadruped robotic hound with articulated paws, a sensor-snouted head, and a durable service frame.",
+                """
+                Robot dogs are quadruped robotic hounds with articulated paws and sensor-snouted heads. They read as machine bodies first, with their silhouette and materials making intended function obvious before any label is needed.
+
+                Their construction emphasises patrol, tracking, companionship and guard work. Plates, joints, sensors, tracks, wheels, limbs or tool-heads feel like designed anatomy rather than decorative additions.
+
+                They belong naturally in technological societies as labourers, guards, servants, drones, companions or threats. Individual units may be polished, battered, autonomous or closely controlled, but the chassis line feels like a real part of the world rather than an isolated device.
+                """,
                 "Robotic hounds fill the familiar roles of patrol animal, tracker and companion machine, exploiting a shape people already understand while replacing fur and instinct with plating, sensors and obedient routines.",
                 null,
                 false,
@@ -504,7 +588,13 @@ public partial class RobotSeeder
             ["Robot Cockroach"] = new(
                 "Robot Cockroach",
                 "Robot Cockroach",
-                "A tiny insectoid robot with a chitinous shell, twitching antennae, and razor mandibles.",
+                """
+                Robot cockroaches are tiny insectoid robots with segmented shells, antennae and mandibles. They read as machine bodies first, with their silhouette and materials making intended function obvious before any label is needed.
+
+                Their construction emphasises inspection, infiltration and survival in cramped hostile places. Plates, joints, sensors, tracks, wheels, limbs or tool-heads feel like designed anatomy rather than decorative additions.
+
+                They belong naturally in technological societies as labourers, guards, servants, drones, companions or threats. Individual units may be polished, battered, autonomous or closely controlled, but the chassis line feels like a real part of the world rather than an isolated device.
+                """,
                 "Robot cockroaches belong to the world of inspection, infiltration and survival in cramped places, useful precisely because they can go where people and larger machines are unwelcome or unable to follow.",
                 null,
                 false,
@@ -537,12 +627,7 @@ public partial class RobotSeeder
 
     internal static string BuildRaceDescriptionForTesting(RobotRaceTemplate template)
     {
-        StockDescriptionVariant? supportingVariant = (template.DescriptionVariants ?? template.OverlayDescriptionVariants)?.FirstOrDefault();
-        return SeederDescriptionHelpers.JoinParagraphs(
-            SeederDescriptionHelpers.EnsureTrailingPeriod(template.Description),
-            supportingVariant?.FullDescription ?? $"This stock robot line is represented by the {template.Name} chassis catalogue.",
-            SeederDescriptionHelpers.EnsureTrailingPeriod(template.RoleDescription)
-        );
+        return template.Description;
     }
 
     internal static string BuildEthnicityDescriptionForTesting(RobotRaceTemplate template)

--- a/DatabaseSeeder/Seeders/SupernaturalSeeder.Definitions.cs
+++ b/DatabaseSeeder/Seeders/SupernaturalSeeder.Definitions.cs
@@ -272,14 +272,6 @@ public partial class SupernaturalSeeder
 				));
 		}
 
-		static string RaceDescription(string name, string family, string role)
-		{
-			return SeederDescriptionHelpers.JoinParagraphs(
-				$"{name} are part of the stock supernatural {family} catalogue seeded for builders who want powerful non-mortal characters, NPCs, patrons or adversaries.",
-				$"The template focuses on {role}, supplying a complete playable engine shape while leaving cosmology, theology and setting-specific allegiance under builder control.",
-				"By default the race is builder-only in chargen. Its anatomy, needs, planar profile, description variables and combat hooks are installed so it can function immediately once a builder chooses to expose it.");
-		}
-
 		static string RoleDescription(string name, string role)
 		{
 			return SeederDescriptionHelpers.JoinParagraphs(
@@ -304,9 +296,9 @@ public partial class SupernaturalSeeder
 			bool weapons = true,
 			bool humanoid = true,
 			string combat = "Melee (Auto)",
-			double health = 1.0)
+			double health = 1.0,
+			string? description = null)
 		{
-			string familyName = family.ToString().ToLowerInvariant();
 			return new(
 				name,
 				family,
@@ -315,7 +307,7 @@ public partial class SupernaturalSeeder
 				planar,
 				needs,
 				stats,
-				RaceDescription(name, familyName, role),
+				description ?? throw new InvalidOperationException($"Supernatural race {name} is missing a seeded description."),
 				RoleDescription(name, role),
 				Variants(name.ToLowerInvariant(), characteristics.First().Values.First().ToLowerInvariant(), role.ToLowerInvariant()),
 				attacks,
@@ -452,76 +444,324 @@ public partial class SupernaturalSeeder
 			Attack("Raking Maul", ItemQuality.Good, "rhand", "lhand")
 		};
 
-		foreach ((string rank, int index) in AngelicRankOrder.Select((rank, index) => (rank, index)))
-		{
-			string body = rank switch
-			{
-				"Ophanim" => "Supernatural Ophanic Wheel",
-				"Chayot HaKodesh" or "Seraphim" => "Supernatural Many-Winged Angel",
-				"Ishim" => "Supernatural Angelic Humanoid",
-				_ => "Supernatural Winged Angel"
-			};
-			SupernaturalAttackTemplate[] attacks = rank switch
-			{
-				"Ophanim" => ophanicAngelAttacks,
-				"Chayot HaKodesh" or "Erelim" or "Hashmallim" or "Seraphim" => highAngelAttacks,
-				"Ishim" => angelAttacks,
-				_ => wingedAngelAttacks
-			};
-			Add(Template(rank, SupernaturalFamily.Angel, body, index < 2 ? SizeCategory.Large : SizeCategory.Normal,
-				SupernaturalPlanarProfile.DualNatured, SupernaturalNeedsProfile.NonLiving,
-				Stats(2 + Math.Max(0, 4 - index / 2), 2 + Math.Max(0, 4 - index / 2), 1, 1, 4, 3, 5, "2d4+6"),
-				"celestial order and divine emissary play", attacks, [radiant, wings, eyes], "Celestial Host", "Angelic Name",
-				health: 1.2));
-		}
+		        Add(Template("Chayot HaKodesh", SupernaturalFamily.Angel, "Supernatural Many-Winged Angel", SizeCategory.Large,
+            SupernaturalPlanarProfile.DualNatured, SupernaturalNeedsProfile.NonLiving,
+            Stats(6, 6, 1, 1, 4, 3, 5, "2d4+6"),
+            "celestial order and divine emissary play", highAngelAttacks, [radiant, wings, eyes], "Celestial Host", "Angelic Name",
+            health: 1.2,
+            description: """
+            The Chayot HaKodesh are high angelic living-creatures, many-winged and overwhelming, whose presence suggests a throne-room seen through fire and storm. They are not simply messengers; they are bearers of holy motion, sacred authority and the terrible vitality nearest the divine centre.
 
-		foreach ((string rank, int index) in AngelicRankOrder.Select((rank, index) => (rank, index)))
-		{
-			string fallenName = $"Fallen {rank}";
-			string body = rank == "Ophanim" ? "Supernatural Ophanic Wheel" : "Supernatural Horned Fiend";
-			SupernaturalAttackTemplate[] attacks = rank == "Ophanim"
-				? fallenOphanicAttacks
-				: index < 4
-					? highDemonAttacks
-					: demonAttacks;
-			Add(Template(fallenName, SupernaturalFamily.Demon, body, index < 2 ? SizeCategory.Large : SizeCategory.Normal,
-				SupernaturalPlanarProfile.AstralNative, SupernaturalNeedsProfile.NonLiving,
-				Stats(3 + Math.Max(0, 3 - index / 3), 2 + Math.Max(0, 3 - index / 3), 1, 1, 4, 2, 4, "2d4+5"),
-				"fallen celestial adversary and infernal court play", attacks, [infernal, horns, tail, eyes], "Fallen Host",
-				"Demonic Name", health: 1.2));
-		}
+            Their forms may combine wings, eyes, radiant crowns and impossible animal majesty into a body that feels too symbolically dense for mortal comfort. To look on one is to feel that life itself has been appointed, ordered and armed.
+
+            They belong in scenes of revelation, cosmic procession, divine judgement and awe. A Chayot HaKodesh should make even powerful mortals feel like witnesses standing at the edge of something vastly older than law or kingship.
+            """));
+        Add(Template("Ophanim", SupernaturalFamily.Angel, "Supernatural Ophanic Wheel", SizeCategory.Large,
+            SupernaturalPlanarProfile.DualNatured, SupernaturalNeedsProfile.NonLiving,
+            Stats(6, 6, 1, 1, 4, 3, 5, "2d4+6"),
+            "celestial order and divine emissary play", ophanicAngelAttacks, [radiant, wings, eyes], "Celestial Host", "Angelic Name",
+            health: 1.2,
+            description: """
+            The Ophanim are wheel-like angelic powers of motion, vigilance and judgement. Their nature is not merely winged or humanoid but geometric, a turning holiness marked by eyes, radiance and the sense that nothing escapes being seen.
+
+            They embody the frightening precision of divine order in motion. Where other angels may speak or descend, an Ophan seems to revolve through command itself, bringing verdict, transport and witness in one impossible form.
+
+            They suit visions, gates, celestial engines and moments when judgement feels impersonal but alive. An Ophan should make space feel measured from every direction at once.
+            """));
+        Add(Template("Erelim", SupernaturalFamily.Angel, "Supernatural Winged Angel", SizeCategory.Normal,
+            SupernaturalPlanarProfile.DualNatured, SupernaturalNeedsProfile.NonLiving,
+            Stats(5, 5, 1, 1, 4, 3, 5, "2d4+6"),
+            "celestial order and divine emissary play", highAngelAttacks, [radiant, wings, eyes], "Celestial Host", "Angelic Name",
+            health: 1.2,
+            description: """
+            The Erelim are mighty angelic guardians associated with solemn strength, courage and the gravity of sacred loss. They are less intimate than messengers and less abstract than wheels, standing instead as luminous powers of endurance and witness.
+
+            Their bearing should feel grave rather than gentle: bright wings, still eyes and the composure of beings who have stood beside death, judgement and difficult mercy without turning away. They are the angels who remain when awe must become duty.
+
+            They fit tombs of saints, battlefields after the noise has ended, royal thresholds and divine courts where courage is measured by restraint. An Erel reads as a guardian of weighty moments.
+            """));
+        Add(Template("Hashmallim", SupernaturalFamily.Angel, "Supernatural Winged Angel", SizeCategory.Normal,
+            SupernaturalPlanarProfile.DualNatured, SupernaturalNeedsProfile.NonLiving,
+            Stats(5, 5, 1, 1, 4, 3, 5, "2d4+6"),
+            "celestial order and divine emissary play", highAngelAttacks, [radiant, wings, eyes], "Celestial Host", "Angelic Name",
+            health: 1.2,
+            description: """
+            The Hashmallim are angelic beings of charged silence, luminous fire and restrained speech. Their presence suggests power held behind a veil, as though the air has become bright with words too dangerous to utter lightly.
+
+            They are not merely radiant; they feel electrically poised. Light, hush, ember and sudden command gather around them, making their stillness more unnerving than many creatures' threats.
+
+            They suit revelations delayed, sacred councils, hidden sanctums and divine commands that arrive after unbearable quiet. A Hashmal should make silence feel active, intelligent and close to ignition.
+            """));
+        Add(Template("Seraphim", SupernaturalFamily.Angel, "Supernatural Many-Winged Angel", SizeCategory.Normal,
+            SupernaturalPlanarProfile.DualNatured, SupernaturalNeedsProfile.NonLiving,
+            Stats(4, 4, 1, 1, 4, 3, 5, "2d4+6"),
+            "celestial order and divine emissary play", highAngelAttacks, [radiant, wings, eyes], "Celestial Host", "Angelic Name",
+            health: 1.2,
+            description: """
+            The Seraphim are burning many-winged angels of praise, purification and unbearable nearness to holy fire. Their radiance is not decorative; it is cleansing, exalting and dangerous to anything unprepared for it.
+
+            Their wings, voices and flame-bright presence make worship feel like force. A Seraph can comfort through glory, but the same glory can sear away corruption, falsehood or presumption without needing a blade.
+
+            They belong in sanctuaries, apocalyptic visions and moments when divinity is felt as heat rather than law. A Seraph should make beauty and danger indistinguishable.
+            """));
+        Add(Template("Malakhim", SupernaturalFamily.Angel, "Supernatural Winged Angel", SizeCategory.Normal,
+            SupernaturalPlanarProfile.DualNatured, SupernaturalNeedsProfile.NonLiving,
+            Stats(4, 4, 1, 1, 4, 3, 5, "2d4+6"),
+            "celestial order and divine emissary play", wingedAngelAttacks, [radiant, wings, eyes], "Celestial Host", "Angelic Name",
+            health: 1.2,
+            description: """
+            The Malakhim are angelic messengers and envoys, defined by service, command-bearing and the terrible clarity of a word delivered from beyond mortal authority. They are often the most recognisably emissary-like of the angelic orders.
+
+            Their power lies in arrival and declaration. Wings, radiance and calm bearing matter, but the central fact is that a Malakh carries a message that can bless, warn, sentence or redirect a life.
+
+            They suit dreams, roads, thresholds and sudden appearances in ordinary places. A Malakh should feel approachable enough to speak with and alien enough that the conversation changes everything.
+            """));
+        Add(Template("Elohim", SupernaturalFamily.Angel, "Supernatural Winged Angel", SizeCategory.Normal,
+            SupernaturalPlanarProfile.DualNatured, SupernaturalNeedsProfile.NonLiving,
+            Stats(3, 3, 1, 1, 4, 3, 5, "2d4+6"),
+            "celestial order and divine emissary play", wingedAngelAttacks, [radiant, wings, eyes], "Celestial Host", "Angelic Name",
+            health: 1.2,
+            description: """
+            The Elohim are angelic powers of authority, judgement and delegated dominion. They appear less as attendants and more as luminous magistrates, bearing the weight of law, creation and command in their posture.
+
+            Their nature is sovereign without being divine in themselves. Eyes, voice, radiance and composure should suggest beings entrusted with power that can shape outcomes, settle disputes and enact sentences far beyond mortal courts.
+
+            They belong in councils, high courts, covenants and scenes where spiritual law takes visible form. An Elohim should make authority feel numinous, exacting and difficult to appeal.
+            """));
+        Add(Template("Bene Elohim", SupernaturalFamily.Angel, "Supernatural Winged Angel", SizeCategory.Normal,
+            SupernaturalPlanarProfile.DualNatured, SupernaturalNeedsProfile.NonLiving,
+            Stats(3, 3, 1, 1, 4, 3, 5, "2d4+6"),
+            "celestial order and divine emissary play", wingedAngelAttacks, [radiant, wings, eyes], "Celestial Host", "Angelic Name",
+            health: 1.2,
+            description: """
+            The Bene Elohim are angelic scions and watchers, luminous beings close enough to creation to be fascinated by it and high enough to be dangerous when they intervene. Their nature carries inheritance, attention and the temptation of proximity.
+
+            They read as celestial nobles, observers or patrons whose interest in mortal affairs may be protective, curious or troubling. Their radiance is less impersonal than an Ophan's and less ceremonial than a Seraph's, but it carries its own pressure.
+
+            They suit watchtowers, pacts, hidden tutelage and stories where divine order brushes against mortal desire. A Bene Elohim should feel like a watcher whose attention is itself a consequence.
+            """));
+        Add(Template("Cherubim", SupernaturalFamily.Angel, "Supernatural Winged Angel", SizeCategory.Normal,
+            SupernaturalPlanarProfile.DualNatured, SupernaturalNeedsProfile.NonLiving,
+            Stats(2, 2, 1, 1, 4, 3, 5, "2d4+6"),
+            "celestial order and divine emissary play", wingedAngelAttacks, [radiant, wings, eyes], "Celestial Host", "Angelic Name",
+            health: 1.2,
+            description: """
+            The Cherubim are angelic guardians of thresholds, sanctuaries and forbidden things. Their role is protective but not soft; they stand where approach must be earned, halted or judged.
+
+            They may bear wings, bright eyes, composite features or an almost sculptural poise, but the essential impression is warding. A Cherub makes a gate feel real even before the wall is seen, because the body itself says that passage is conditional.
+
+            They suit temple doors, sealed gardens, relic chambers and the borders between mercy and prohibition. A Cherub should make trespass feel like a theological mistake as much as a tactical one.
+            """));
+        Add(Template("Ishim", SupernaturalFamily.Angel, "Supernatural Angelic Humanoid", SizeCategory.Normal,
+            SupernaturalPlanarProfile.DualNatured, SupernaturalNeedsProfile.NonLiving,
+            Stats(2, 2, 1, 1, 4, 3, 5, "2d4+6"),
+            "celestial order and divine emissary play", angelAttacks, [radiant, wings, eyes], "Celestial Host", "Angelic Name",
+            health: 1.2,
+            description: """
+            The Ishim are the most human-facing of the angelic orders, close to mortal lives, prayers, dreams and crises. Their forms may be less overwhelming than higher angels, but their nearness makes them unsettling in a more intimate way.
+
+            They can speak across tables, appear on roads and stand beside the dying without shattering the scene around them. Their radiance is often moderated, hidden or focused through eyes, voice and timing rather than vast anatomy.
+
+            They suit counsel, warning, quiet miracles and moments when the divine chooses to be comprehensible. An Ishim should feel like a stranger who knows exactly when to arrive.
+            """));
+
+		        Add(Template("Fallen Chayot HaKodesh", SupernaturalFamily.Demon, "Supernatural Horned Fiend", SizeCategory.Large,
+            SupernaturalPlanarProfile.AstralNative, SupernaturalNeedsProfile.NonLiving,
+            Stats(6, 5, 1, 1, 4, 2, 4, "2d4+5"),
+            "fallen celestial adversary and infernal court play", highDemonAttacks, [infernal, horns, tail, eyes], "Fallen Host",
+            "Demonic Name", health: 1.2,
+            description: """
+            Fallen Chayot HaKodesh are ruined living-creatures of high angelic order, bearers of sacred motion whose vitality has been bent into rebellion, tyranny or blasphemous sovereignty. They retain grandeur, which makes the corruption worse.
+
+            Their many wings, crowns, eyes and composite majesty may still burn, but the fire no longer comforts. They suggest a throne procession broken from its rightful course, still powerful enough to drag lesser beings into its wake.
+
+            They suit fallen courts, apocalyptic war, corrupted revelation and ancient exiles who remember standing near the centre of holiness. A Fallen Chayot HaKodesh should feel like sacred life weaponised against its source.
+            """));
+        Add(Template("Fallen Ophanim", SupernaturalFamily.Demon, "Supernatural Ophanic Wheel", SizeCategory.Large,
+            SupernaturalPlanarProfile.AstralNative, SupernaturalNeedsProfile.NonLiving,
+            Stats(6, 5, 1, 1, 4, 2, 4, "2d4+5"),
+            "fallen celestial adversary and infernal court play", fallenOphanicAttacks, [infernal, horns, tail, eyes], "Fallen Host",
+            "Demonic Name", health: 1.2,
+            description: """
+            Fallen Ophanim are darkened wheels of judgement, revolving angelic powers whose perfect motion has become accusation, obsession or merciless sentence. They remain terrifyingly ordered, but the order no longer implies justice.
+
+            Their eyes may watch without compassion, and their turning geometry can make pursuit feel inevitable. Rather than chaos, they embody corrupted inevitability: a verdict that keeps arriving whether or not it is deserved.
+
+            They fit cursed gates, infernal engines, fallen courts and visions of judgement stripped of mercy. A Fallen Ophan should make space feel trapped inside a sentence.
+            """));
+        Add(Template("Fallen Erelim", SupernaturalFamily.Demon, "Supernatural Horned Fiend", SizeCategory.Normal,
+            SupernaturalPlanarProfile.AstralNative, SupernaturalNeedsProfile.NonLiving,
+            Stats(6, 5, 1, 1, 4, 2, 4, "2d4+5"),
+            "fallen celestial adversary and infernal court play", highDemonAttacks, [infernal, horns, tail, eyes], "Fallen Host",
+            "Demonic Name", health: 1.2,
+            description: """
+            Fallen Erelim are mighty guardians whose solemn strength has curdled into grief, wrath or bitter honour. They still carry the bearing of sacred soldiers and witnesses, but their endurance now serves a broken cause.
+
+            Their radiance may be bruised, their wings scarred and their silence heavy with remembered duty. They are not frivolous tempters; they are the dangerous dead weight of courage severed from mercy.
+
+            They belong beside ruined battlefields, forsaken tombs and rebel hosts that speak in the language of loss. A Fallen Erel should feel tragic without becoming safe.
+            """));
+        Add(Template("Fallen Hashmallim", SupernaturalFamily.Demon, "Supernatural Horned Fiend", SizeCategory.Normal,
+            SupernaturalPlanarProfile.AstralNative, SupernaturalNeedsProfile.NonLiving,
+            Stats(5, 4, 1, 1, 4, 2, 4, "2d4+5"),
+            "fallen celestial adversary and infernal court play", highDemonAttacks, [infernal, horns, tail, eyes], "Fallen Host",
+            "Demonic Name", health: 1.2,
+            description: """
+            Fallen Hashmallim are corrupted angels of charged silence and hidden flame. Where their unfallen kin hold command in luminous restraint, these beings make silence feel like suppression, threat and the pause before cruelty.
+
+            Their light may stutter, smoke or burn behind the skin of the world, accompanied by voices withheld until the worst possible moment. They feel like revelations twisted into blackmail or commands stripped of grace.
+
+            They suit secret inquisitions, infernal councils, forbidden vaults and pacts sealed without witnesses. A Fallen Hashmal should make quiet feel unsafe to break.
+            """));
+        Add(Template("Fallen Seraphim", SupernaturalFamily.Demon, "Supernatural Horned Fiend", SizeCategory.Normal,
+            SupernaturalPlanarProfile.AstralNative, SupernaturalNeedsProfile.NonLiving,
+            Stats(5, 4, 1, 1, 4, 2, 4, "2d4+5"),
+            "fallen celestial adversary and infernal court play", demonAttacks, [infernal, horns, tail, eyes], "Fallen Host",
+            "Demonic Name", health: 1.2,
+            description: """
+            Fallen Seraphim are burning angels whose praise has become hunger, pride or purification without love. They remain beautiful in the way fire is beautiful: capable of making observers forget that beauty can consume.
+
+            Their many wings and furnace-bright presence still carry the memory of sanctity, but the heat now judges by possession, rage or zeal. They do not merely destroy; they insist destruction is a form of truth.
+
+            They belong in volcanic sanctuaries, blasphemous choirs and holy wars gone rotten. A Fallen Seraph should make flame feel articulate, ecstatic and merciless.
+            """));
+        Add(Template("Fallen Malakhim", SupernaturalFamily.Demon, "Supernatural Horned Fiend", SizeCategory.Normal,
+            SupernaturalPlanarProfile.AstralNative, SupernaturalNeedsProfile.NonLiving,
+            Stats(5, 4, 1, 1, 4, 2, 4, "2d4+5"),
+            "fallen celestial adversary and infernal court play", demonAttacks, [infernal, horns, tail, eyes], "Fallen Host",
+            "Demonic Name", health: 1.2,
+            description: """
+            Fallen Malakhim are messengers whose sacred office has become deception, false revelation or weaponised command. They understand the power of a delivered word and have learned to bend that power toward ruin.
+
+            They need not look monstrous at first. A calm voice, a timely arrival and a message that almost sounds righteous can be more dangerous than claws, because their corruption works through trust and obedience.
+
+            They suit false prophets, cursed dreams, poisoned diplomacy and infernal errands. A Fallen Malakh should make every instruction suspect, especially the persuasive ones.
+            """));
+        Add(Template("Fallen Elohim", SupernaturalFamily.Demon, "Supernatural Horned Fiend", SizeCategory.Normal,
+            SupernaturalPlanarProfile.AstralNative, SupernaturalNeedsProfile.NonLiving,
+            Stats(4, 3, 1, 1, 4, 2, 4, "2d4+5"),
+            "fallen celestial adversary and infernal court play", demonAttacks, [infernal, horns, tail, eyes], "Fallen Host",
+            "Demonic Name", health: 1.2,
+            description: """
+            Fallen Elohim are corrupted powers of authority and judgement, luminous magistrates turned tyrants, usurpers or divine pretenders. Their danger lies in command that still sounds lawful even when its centre has gone hollow.
+
+            They carry sovereignty like a weapon. Radiance, voice and bearing suggest courts, edicts and punishments, but the justice they enact bends toward domination, pride or cosmic grievance.
+
+            They belong in fallen principalities, cults of obedience and thrones built from stolen reverence. A Fallen Elohim should make rebellion feel morally necessary and terrifyingly costly.
+            """));
+        Add(Template("Fallen Bene Elohim", SupernaturalFamily.Demon, "Supernatural Horned Fiend", SizeCategory.Normal,
+            SupernaturalPlanarProfile.AstralNative, SupernaturalNeedsProfile.NonLiving,
+            Stats(4, 3, 1, 1, 4, 2, 4, "2d4+5"),
+            "fallen celestial adversary and infernal court play", demonAttacks, [infernal, horns, tail, eyes], "Fallen Host",
+            "Demonic Name", health: 1.2,
+            description: """
+            Fallen Bene Elohim are watchers and celestial scions who crossed the boundary between attention and appetite. Their fall often feels intimate: fascination with mortal life becoming possession, interference or forbidden allegiance.
+
+            They may retain beauty, nobility and the manners of patrons, which makes them especially dangerous. Their corruption is not always crude; it can arrive as gifts, tutelage, desire or protection that slowly becomes a claim.
+
+            They suit stories of oathbreakers, secret lineages, forbidden teachers and watchers who loved the world badly. A Fallen Bene Elohim should make divine interest feel compromised.
+            """));
+        Add(Template("Fallen Cherubim", SupernaturalFamily.Demon, "Supernatural Horned Fiend", SizeCategory.Normal,
+            SupernaturalPlanarProfile.AstralNative, SupernaturalNeedsProfile.NonLiving,
+            Stats(4, 3, 1, 1, 4, 2, 4, "2d4+5"),
+            "fallen celestial adversary and infernal court play", demonAttacks, [infernal, horns, tail, eyes], "Fallen Host",
+            "Demonic Name", health: 1.2,
+            description: """
+            Fallen Cherubim are guardians whose warding nature has become exclusion, imprisonment or desecration. They still understand gates, thresholds and holy boundaries, but now use that knowledge to deny, trap or profane.
+
+            Their wings and composite forms may seem carved for defence, yet the space around them feels like a locked room rather than a sanctuary. They are the memory of protection turned into a weapon against those seeking refuge.
+
+            They fit cursed temples, sealed prisons, corrupted gardens and gatehouses no one should have built. A Fallen Cherub should make passage feel like a bargain with the wrong keeper.
+            """));
+        Add(Template("Fallen Ishim", SupernaturalFamily.Demon, "Supernatural Horned Fiend", SizeCategory.Normal,
+            SupernaturalPlanarProfile.AstralNative, SupernaturalNeedsProfile.NonLiving,
+            Stats(3, 2, 1, 1, 4, 2, 4, "2d4+5"),
+            "fallen celestial adversary and infernal court play", demonAttacks, [infernal, horns, tail, eyes], "Fallen Host",
+            "Demonic Name", health: 1.2,
+            description: """
+            Fallen Ishim are near-mortal angels whose closeness to human life has turned into manipulation, envy or intimate cruelty. They know the language of comfort, advice and timely arrival, and that knowledge makes them dangerous.
+
+            Their forms may pass almost gently through mortal society, marked only by a tarnished glow, too-knowing gaze or the sense that sympathy has become a hook. They corrupt through proximity rather than spectacle.
+
+            They suit tempters, false counsellors, household curses and tragedies where help arrives wearing the wrong face. A Fallen Ishim should make the familiar feel spiritually unsafe.
+            """));
 
 		Add(Template("Incubus", SupernaturalFamily.Demon, "Supernatural Horned Fiend", SizeCategory.Normal,
 			SupernaturalPlanarProfile.AstralNative, SupernaturalNeedsProfile.NonLiving, Stats(1, 1, 2, 2, 3, 2, 4, "2d4+4"),
-			"social predator and temptation storylines", demonAttacks, [infernal, horns, tail], "Fallen Host", "Demonic Name"));
+			"social predator and temptation storylines", demonAttacks, [infernal, horns, tail], "Fallen Host", "Demonic Name",
+			description: """
+			Incubi are demonic social predators whose power works through attention, desire and the careful reading of weakness. They are dangerous not because they cannot be resisted, but because they make resistance feel like a private negotiation already half lost.
+
+			Their demonic nature may appear through horns, infernal marks, unnatural beauty or a gaze too practised to be merely charming. The body is a lure, but the real weapon is intimacy sharpened into appetite.
+
+			They belong in courts, dreams, salons, cults and private rooms where corruption can look like consent until the cost is clear. An incubus should feel personal, elegant and predatory.
+			"""));
 		Add(Template("Succubus", SupernaturalFamily.Demon, "Supernatural Horned Fiend", SizeCategory.Normal,
 			SupernaturalPlanarProfile.AstralNative, SupernaturalNeedsProfile.NonLiving, Stats(1, 1, 2, 2, 3, 2, 4, "2d4+4"),
-			"social predator and temptation storylines", demonAttacks, [infernal, horns, tail], "Fallen Host", "Demonic Name"));
+			"social predator and temptation storylines", demonAttacks, [infernal, horns, tail], "Fallen Host", "Demonic Name",
+			description: """
+			Succubi are demonic tempters and social hunters, using allure, empathy and performance as instruments of appetite. Their danger is rarely brute force first; it is the ability to make longing, vanity or loneliness answer when called.
+
+			Infernal marks, poised movement and deliberate beauty should never reduce them to ornament. A succubus is a strategist of closeness, capable of turning conversation, promise and touch into territory.
+
+			They suit intrigue, dream-haunting, cult recruitment and bargains that begin pleasantly enough to be remembered with shame. A succubus should make desire feel like a doorway with something waiting behind it.
+			"""));
 		Add(Template("Fury", SupernaturalFamily.Demon, "Supernatural Horned Fiend", SizeCategory.Normal,
 			SupernaturalPlanarProfile.DualNatured, SupernaturalNeedsProfile.NonLiving, Stats(3, 2, 3, 1, 3, 3, 3, "2d4+3"),
 			"vengeance spirit and relentless hunter play", highDemonAttacks, [infernal, wings, eyes], "Fallen Host", "Demonic Name",
-			combat: "Beast Brawler"));
+			combat: "Beast Brawler",
+			description: """
+			Furies are demonic powers of vengeance, pursuit and punishment given a body sharp enough to chase guilt across borders. Their nature is not patient temptation but relentless consequence.
+
+			Wings, burning eyes, talons or infernal scars can all serve the same impression: a being animated by outrage refined into purpose. A Fury does not merely hate; it prosecutes with claws, voice and motion.
+
+			They belong in blood-debts, broken oaths, cursed lineages and hunts that do not end when the quarry changes roads. A Fury should make wrongdoing feel tracked.
+			"""));
 		Add(Template("Imp", SupernaturalFamily.Demon, "Supernatural Familiar", SizeCategory.Small,
 			SupernaturalPlanarProfile.AstralNative, SupernaturalNeedsProfile.NonLiving, Stats(-2, -1, 3, 2, 1, 2, 2, "1d4+2"),
 			"minor demon, spy and nuisance familiar play", demonAttacks, [infernal, horns, tail], "Fallen Host", "Demonic Name",
-			weapons: false, combat: "Beast Skirmisher", health: 0.75));
+			weapons: false, combat: "Beast Skirmisher", health: 0.75,
+			description: """
+			Imps are minor demons of nuisance, spying, sabotage and malicious curiosity. Their small size makes them easy to dismiss until one remembers how much harm can be done by a creature that fits through vents, shutters and careless wards.
+
+			They tend toward quick limbs, sharp faces, restless tails and a gleeful sense of stolen permission. An imp is rarely the centre of a grand evil, but it is often the hand that opens the latch.
+
+			They suit familiars gone wrong, infernal errands, comic malice and genuinely dangerous infiltration. An imp should feel irritating, clever and harder to catch than pride allows.
+			"""));
 		Add(Template("Familiar", SupernaturalFamily.Demon, "Supernatural Familiar", SizeCategory.Small,
 			SupernaturalPlanarProfile.AstralNative, SupernaturalNeedsProfile.NonLiving, Stats(-3, -1, 4, 2, 2, 3, 2, "1d4+2"),
 			"bound companion, spy and occult assistant play", demonAttacks, [infernal, tail, eyes], "Fallen Host", "Demonic Name",
-			weapons: false, combat: "Beast Skirmisher", health: 0.7));
+			weapons: false, combat: "Beast Skirmisher", health: 0.7,
+			description: """
+			Demonic familiars are bound companion-spirits and occult assistants whose usefulness is inseparable from suspicion. They may serve, advise, spy or fetch, but every obedience carries the question of who benefits most from the bond.
+
+			Their forms are often small, animal-like or impish, marked by infernal eyes, unnatural stillness or a tail that seems to have its own opinions. They belong close to the hand, shoulder, hearth or ritual circle.
+
+			They suit witches, warlocks, forbidden libraries and quiet betrayals. A familiar should feel useful enough to keep and dangerous enough that keeping it says something about its master.
+			"""));
 		Add(Template("Fiend", SupernaturalFamily.Demon, "Supernatural Horned Fiend", SizeCategory.Large,
 			SupernaturalPlanarProfile.AstralNative, SupernaturalNeedsProfile.NonLiving, Stats(5, 4, 0, 0, 3, 2, 3, "2d4+4"),
 			"brutal infernal monster and war-demon play", highDemonAttacks, [infernal, horns, tail], "Fallen Host", "Demonic Name",
-			combat: "Beast Brawler", health: 1.3));
+			combat: "Beast Brawler", health: 1.3,
+			description: """
+			Fiends are large brutal demons, broad enough for war and coarse enough that subtlety seems optional rather than impossible. They are the infernal body made direct: horn, claw, fang, tail and appetite arranged for domination.
+
+			Their nature is not merely bestial. A fiend carries malice with structure, as if cruelty has been trained into tactics and then wrapped in muscle. It can guard, command, punish or simply break what softer tempters have prepared.
+
+			They suit battlefields, infernal courts, sacrificial chambers and any scene that needs demonic force without refinement. A fiend should make violence feel organised and eager.
+			"""));
 		Add(Template("Balrog", SupernaturalFamily.Demon, "Supernatural Horned Fiend", SizeCategory.Huge,
 			SupernaturalPlanarProfile.DualNatured, SupernaturalNeedsProfile.NonLiving, Stats(8, 7, 0, 0, 5, 3, 6, "2d6+6"),
 			"ancient fire-and-shadow war demon play", highDemonAttacks, [infernal, horns, tail, eyes], "Fallen Host", "Demonic Name",
-			combat: "Beast Brawler", health: 1.7) with
+			combat: "Beast Brawler", health: 1.7,
+			description: """
+			Balrogs are ancient demons of fire, shadow and war, vast enough to make ordinary fiends seem newly made. The horned frame feels like old catastrophe given shape, carrying smoke, furnace heat and the memory of battles that became legend.
+
+			They are not common soldiers of darkness. A balrog suggests command, ruin and deep time: a being that has burned through kingdoms, slept beneath stone or waited in places where old rebellions never fully cooled.
+
+			They belong in abyssal halls, volcanic sanctums, mythic war histories and final thresholds. A balrog should make retreat feel less cowardly than literate.
+			""") with
 		{
-			Description = SeederDescriptionHelpers.JoinParagraphs(
-				"Balrogs are ancient fire-and-shadow demons seeded as overwhelming supernatural adversaries rather than ordinary mortal peoples.",
-				"The stock template gives them horned fiend anatomy, infernal breath, claws, tail attacks, forced-movement hooks and non-living supernatural needs so builders can deploy them immediately.",
-				"They are intentionally builder-only by default, suited to deep ruins, mythic war histories, divine rebellions or staff-controlled boss encounters."),
 			RoleDescription = SeederDescriptionHelpers.JoinParagraphs(
 				"Balrogs are intended for ancient fire-and-shadow war demon play.",
 				"They provide a Middle-earth-ready stock demon without hard-coding any one cosmology, allegiance or named individual.",
@@ -545,74 +785,207 @@ public partial class SupernaturalSeeder
 		Add(Template("Hellhound", SupernaturalFamily.Demon, "Supernatural Hellhound", SizeCategory.Large,
 			SupernaturalPlanarProfile.Material, SupernaturalNeedsProfile.NonLiving, Stats(4, 3, 2, 0, 2, 4, 2, "1d4+2"),
 			"infernal hunting beast play", hellhoundAttacks,
-			[infernal, eyes], "Fallen Host", "Demonic Name", weapons: false, humanoid: false, combat: "Beast Brawler", health: 1.2));
+			[infernal, eyes], "Fallen Host", "Demonic Name", weapons: false, humanoid: false, combat: "Beast Brawler", health: 1.2,
+			description: """
+			Hellhounds are infernal hunting beasts shaped like great hounds and disciplined by malice, smoke and fire. They are not simply demonic dogs; they are pursuit made supernatural, bred or summoned to find what fear tries to hide.
+
+			Burning eyes, heavy jaws, ember breath and dark paws give them the presence of a pack animal from a worse country. Their obedience is frightening because it suggests a master, a scent and a purpose already chosen.
+
+			They suit cursed hunts, gate guards, infernal kennels and nights when escape fails one footprint at a time. A hellhound should make running feel like participation in the ritual.
+			"""));
 
 		Add(Template("Demigod", SupernaturalFamily.Divine, "Supernatural Divine Humanoid", SizeCategory.Normal,
 			SupernaturalPlanarProfile.DualNatured, SupernaturalNeedsProfile.NonLiving, Stats(3, 3, 1, 1, 3, 2, 5, "2d4+5"),
-			"divine-blooded heroes, avatars and staff-guided legends", angelAttacks, [radiant, eyes], "Celestial Host", "Angelic Name"));
+			"divine-blooded heroes, avatars and staff-guided legends", angelAttacks, [radiant, eyes], "Celestial Host", "Angelic Name",
+			description: """
+			Demigods are divine-blooded beings whose mortal shape is charged with more power than flesh can comfortably hold. Their supernatural nature is apparent through radiant inheritance, heroic danger and the tension between person and symbol, giving them a presence that mortal bodies cannot convincingly imitate.
+
+			They have a coherent physical and spiritual identity of their own. Anatomy, motion, gaze, voice and silence all contribute to the impression that this is not a mortal body with an unusual costume, but a being governed by different conditions of existence.
+
+			Their precise court, curse, theology, bloodline or summoning tradition may differ from place to place. What remains constant is the race's visible force: a complete supernatural presence that can stand on its own in play.
+			"""));
 		Add(Template("Lesser God", SupernaturalFamily.Divine, "Supernatural Many-Winged Angel", SizeCategory.Large,
 			SupernaturalPlanarProfile.DualNatured, SupernaturalNeedsProfile.NonLiving, Stats(6, 6, 2, 2, 6, 4, 8, "2d6+8"),
 			"local deities, patrons and divine NPCs", highAngelAttacks, [radiant, wings, eyes], "Celestial Host", "Angelic Name",
-			health: 1.5));
+			health: 1.5,
+			description: """
+			Lesser gods are local divine beings whose presence gathers worship, place and miracle into a person-like form. Their supernatural nature is apparent through patronage, awe and the authority of a shrine given a body, giving them a presence that mortal bodies cannot convincingly imitate.
+
+			They have a coherent physical and spiritual identity of their own. Anatomy, motion, gaze, voice and silence all contribute to the impression that this is not a mortal body with an unusual costume, but a being governed by different conditions of existence.
+
+			Their precise court, curse, theology, bloodline or summoning tradition may differ from place to place. What remains constant is the race's visible force: a complete supernatural presence that can stand on its own in play.
+			"""));
 		Add(Template("Greater God", SupernaturalFamily.Divine, "Supernatural Many-Winged Angel", SizeCategory.VeryLarge,
 			SupernaturalPlanarProfile.DualNatured, SupernaturalNeedsProfile.NonLiving, Stats(8, 8, 2, 2, 8, 5, 10, "2d6+10"),
 			"major deities and administrator-facing divine examples", highAngelAttacks, [radiant, wings, eyes], "Celestial Host",
-			"Angelic Name", health: 1.8));
+			"Angelic Name", health: 1.8,
+			description: """
+			Greater gods are major divine beings whose forms are less bodies than overwhelming statements of power. Their supernatural nature is apparent through majesty, impossible scale and the sense of a law temporarily taking shape, giving them a presence that mortal bodies cannot convincingly imitate.
+
+			They have a coherent physical and spiritual identity of their own. Anatomy, motion, gaze, voice and silence all contribute to the impression that this is not a mortal body with an unusual costume, but a being governed by different conditions of existence.
+
+			Their precise court, curse, theology, bloodline or summoning tradition may differ from place to place. What remains constant is the race's visible force: a complete supernatural presence that can stand on its own in play.
+			"""));
 
 		Add(Template("Spirit", SupernaturalFamily.Spirit, "Supernatural Spirit Form", SizeCategory.Normal,
 			SupernaturalPlanarProfile.Incorporeal, SupernaturalNeedsProfile.NonLiving, Stats(-1, 0, 2, 1, 3, 3, 3, "2d4+3"),
-			"generic incorporeal spirits", spiritAttacks, [spirit, eyes], "Spirit Court", "Spirit Name", combat: "Beast Skirmisher"));
+			"generic incorporeal spirits", spiritAttacks, [spirit, eyes], "Spirit Court", "Spirit Name", combat: "Beast Skirmisher",
+			description: """
+			Spirits are incorporeal beings shaped by memory, place, force or idea. Their supernatural nature is apparent through thin outlines, strange light and movement that does not fully obey weight, giving them a presence that mortal bodies cannot convincingly imitate.
+
+			They have a coherent physical and spiritual identity of their own. Anatomy, motion, gaze, voice and silence all contribute to the impression that this is not a mortal body with an unusual costume, but a being governed by different conditions of existence.
+
+			Their precise court, curse, theology, bloodline or summoning tradition may differ from place to place. What remains constant is the race's visible force: a complete supernatural presence that can stand on its own in play.
+			"""));
 		Add(Template("Ghost", SupernaturalFamily.Spirit, "Supernatural Spirit Form", SizeCategory.Normal,
 			SupernaturalPlanarProfile.Incorporeal, SupernaturalNeedsProfile.NonLiving, Stats(-2, 0, 2, 1, 3, 3, 3, "2d4+3"),
-			"dead souls and haunting NPCs", spiritAttacks, [spirit, death], "Spirit Court", "Spirit Name", combat: "Beast Skirmisher"));
+			"dead souls and haunting NPCs", spiritAttacks, [spirit, death], "Spirit Court", "Spirit Name", combat: "Beast Skirmisher",
+			description: """
+			Ghosts are spirits of the dead whose forms remember the lives they have lost. Their supernatural nature is apparent through grave-pale light, unfinished emotion and the quiet pressure of haunting, giving them a presence that mortal bodies cannot convincingly imitate.
+
+			They have a coherent physical and spiritual identity of their own. Anatomy, motion, gaze, voice and silence all contribute to the impression that this is not a mortal body with an unusual costume, but a being governed by different conditions of existence.
+
+			Their precise court, curse, theology, bloodline or summoning tradition may differ from place to place. What remains constant is the race's visible force: a complete supernatural presence that can stand on its own in play.
+			"""));
 		Add(Template("Specter", SupernaturalFamily.Spirit, "Supernatural Spirit Form", SizeCategory.Normal,
 			SupernaturalPlanarProfile.Incorporeal, SupernaturalNeedsProfile.NonLiving, Stats(-1, 1, 3, 2, 4, 4, 3, "2d4+3"),
 			"predatory hauntings and feared incorporeal monsters", spiritAttacks, [spirit, death], "Spirit Court", "Spirit Name",
-			combat: "Beast Skirmisher"));
+			combat: "Beast Skirmisher",
+			description: """
+			Specters are predatory hauntings that have shed much of the person they once were. Their supernatural nature is apparent through thin malice, cold motion and hunger without a living body, giving them a presence that mortal bodies cannot convincingly imitate.
+
+			They have a coherent physical and spiritual identity of their own. Anatomy, motion, gaze, voice and silence all contribute to the impression that this is not a mortal body with an unusual costume, but a being governed by different conditions of existence.
+
+			Their precise court, curse, theology, bloodline or summoning tradition may differ from place to place. What remains constant is the race's visible force: a complete supernatural presence that can stand on its own in play.
+			"""));
 		Add(Template("Wraith", SupernaturalFamily.Spirit, "Supernatural Spirit Form", SizeCategory.Normal,
 			SupernaturalPlanarProfile.Incorporeal, SupernaturalNeedsProfile.NonLiving, Stats(0, 1, 3, 2, 4, 4, 4, "2d4+4"),
-			"dangerous deathly spirits", spiritAttacks, [spirit, death], "Spirit Court", "Spirit Name", combat: "Beast Skirmisher"));
+			"dangerous deathly spirits", spiritAttacks, [spirit, death], "Spirit Court", "Spirit Name", combat: "Beast Skirmisher",
+			description: """
+			Wraiths are dangerous deathly spirits whose presence drains warmth and courage. Their supernatural nature is apparent through shadow, grave-light and the implacable hunger of the unquiet dead, giving them a presence that mortal bodies cannot convincingly imitate.
+
+			They have a coherent physical and spiritual identity of their own. Anatomy, motion, gaze, voice and silence all contribute to the impression that this is not a mortal body with an unusual costume, but a being governed by different conditions of existence.
+
+			Their precise court, curse, theology, bloodline or summoning tradition may differ from place to place. What remains constant is the race's visible force: a complete supernatural presence that can stand on its own in play.
+			"""));
 		Add(Template("Ancestral Spirit", SupernaturalFamily.Spirit, "Supernatural Spirit Form", SizeCategory.Normal,
 			SupernaturalPlanarProfile.Incorporeal, SupernaturalNeedsProfile.NonLiving, Stats(-1, 0, 1, 1, 4, 3, 4, "2d4+4"),
-			"ancestor worship, family guardians and cultural spirit play", spiritAttacks, [spirit, eyes], "Spirit Court", "Spirit Name"));
+			"ancestor worship, family guardians and cultural spirit play", spiritAttacks, [spirit, eyes], "Spirit Court", "Spirit Name",
+			description: """
+			Ancestral spirits are incorporeal ancestors whose identity is tied to family, lineage and remembered obligation. Their supernatural nature is apparent through old names, inherited regard and the watchfulness of the dead over the living, giving them a presence that mortal bodies cannot convincingly imitate.
+
+			They have a coherent physical and spiritual identity of their own. Anatomy, motion, gaze, voice and silence all contribute to the impression that this is not a mortal body with an unusual costume, but a being governed by different conditions of existence.
+
+			Their precise court, curse, theology, bloodline or summoning tradition may differ from place to place. What remains constant is the race's visible force: a complete supernatural presence that can stand on its own in play.
+			"""));
 		Add(Template("Nature Spirit", SupernaturalFamily.Spirit, "Supernatural Spirit Form", SizeCategory.Normal,
 			SupernaturalPlanarProfile.Incorporeal, SupernaturalNeedsProfile.NonLiving, Stats(0, 1, 2, 1, 3, 4, 4, "2d4+4"),
-			"wilderness, grove and land-spirit play", spiritAttacks, [spirit, eyes], "Spirit Court", "Spirit Name"));
+			"wilderness, grove and land-spirit play", spiritAttacks, [spirit, eyes], "Spirit Court", "Spirit Name",
+			description: """
+			Nature spirits are spirits of grove, stream, hill, storm, beast or season. Their supernatural nature is apparent through wild signs, changing light and a body that echoes the place it belongs to, giving them a presence that mortal bodies cannot convincingly imitate.
+
+			They have a coherent physical and spiritual identity of their own. Anatomy, motion, gaze, voice and silence all contribute to the impression that this is not a mortal body with an unusual costume, but a being governed by different conditions of existence.
+
+			Their precise court, curse, theology, bloodline or summoning tradition may differ from place to place. What remains constant is the race's visible force: a complete supernatural presence that can stand on its own in play.
+			"""));
 		Add(Template("Elemental Spirit", SupernaturalFamily.Spirit, "Supernatural Spirit Form", SizeCategory.Normal,
 			SupernaturalPlanarProfile.Incorporeal, SupernaturalNeedsProfile.NonLiving, Stats(1, 1, 2, 1, 3, 3, 4, "2d4+4"),
-			"fire, storm, water, earth and other elemental courts", spiritAttacks, [spirit, eyes], "Spirit Court", "Spirit Name"));
+			"fire, storm, water, earth and other elemental courts", spiritAttacks, [spirit, eyes], "Spirit Court", "Spirit Name",
+			description: """
+			Elemental spirits are spirits shaped by fire, storm, water, earth or other primal forces. Their supernatural nature is apparent through elemental motion, unstable outline and a body more force than flesh, giving them a presence that mortal bodies cannot convincingly imitate.
+
+			They have a coherent physical and spiritual identity of their own. Anatomy, motion, gaze, voice and silence all contribute to the impression that this is not a mortal body with an unusual costume, but a being governed by different conditions of existence.
+
+			Their precise court, curse, theology, bloodline or summoning tradition may differ from place to place. What remains constant is the race's visible force: a complete supernatural presence that can stand on its own in play.
+			"""));
 
 		Add(Template("Werewolf", SupernaturalFamily.Therianthrope, "Organic Humanoid", SizeCategory.Normal,
 			SupernaturalPlanarProfile.Material, SupernaturalNeedsProfile.Living, Stats(1, 1, 1, 0, 1, 2, 0),
 			"cursed or hereditary shapeshifter play", werewolfAttacks, [beast],
-			"Therianthrope", "Mortal Name"));
+			"Therianthrope", "Mortal Name",
+			description: """
+			Werewolfs are living shapeshifters marked by the wolf beneath the human skin. Their supernatural nature is apparent through yellow eyes, coarse hackles, sharpened instincts and the pressure of a curse or bloodline, giving them a presence that mortal bodies cannot convincingly imitate.
+
+			They have a coherent physical and spiritual identity of their own. Anatomy, motion, gaze, voice and silence all contribute to the impression that this is not a mortal body with an unusual costume, but a being governed by different conditions of existence.
+
+			Their precise court, curse, theology, bloodline or summoning tradition may differ from place to place. What remains constant is the race's visible force: a complete supernatural presence that can stand on its own in play.
+			"""));
 		Add(Template("Werewolf Hybrid", SupernaturalFamily.Therianthrope, "Supernatural Werewolf Hybrid", SizeCategory.Large,
 			SupernaturalPlanarProfile.Material, SupernaturalNeedsProfile.Living, Stats(4, 3, 2, 0, 2, 3, 0),
 			"wolf-man battle forms and cursed transformation play", werewolfHybridAttacks,
-			[beast], "Therianthrope", "Mortal Name", weapons: false, combat: "Beast Brawler", health: 1.25));
+			[beast], "Therianthrope", "Mortal Name", weapons: false, combat: "Beast Brawler", health: 1.25,
+			description: """
+			Werewolf hybrids are wolf-man battle forms in which human structure and lupine violence meet openly. Their supernatural nature is apparent through muzzled features, claws, hackles and a forward-leaning hunger for the fight, giving them a presence that mortal bodies cannot convincingly imitate.
+
+			They have a coherent physical and spiritual identity of their own. Anatomy, motion, gaze, voice and silence all contribute to the impression that this is not a mortal body with an unusual costume, but a being governed by different conditions of existence.
+
+			Their precise court, curse, theology, bloodline or summoning tradition may differ from place to place. What remains constant is the race's visible force: a complete supernatural presence that can stand on its own in play.
+			"""));
 
 		Add(Template("Vampire", SupernaturalFamily.Undead, "Organic Humanoid", SizeCategory.Normal,
 			SupernaturalPlanarProfile.Material, SupernaturalNeedsProfile.NonLiving, Stats(2, 2, 2, 1, 3, 3, 3, "2d4+3"),
-			"deathless social predators without hard-coded feeding mechanics", undeadAttacks, [death, eyes], "Undead Remnant", "Undead Name"));
+			"deathless social predators without hard-coded feeding mechanics", undeadAttacks, [death, eyes], "Undead Remnant", "Undead Name",
+			description: """
+			Vampires are deathless social predators who preserve personhood while losing ordinary life. Their supernatural nature is apparent through pale stillness, sharpened hunger and the elegance of a corpse that learned to smile, giving them a presence that mortal bodies cannot convincingly imitate.
+
+			They have a coherent physical and spiritual identity of their own. Anatomy, motion, gaze, voice and silence all contribute to the impression that this is not a mortal body with an unusual costume, but a being governed by different conditions of existence.
+
+			Their precise court, curse, theology, bloodline or summoning tradition may differ from place to place. What remains constant is the race's visible force: a complete supernatural presence that can stand on its own in play.
+			"""));
 		Add(Template("Lich", SupernaturalFamily.Undead, "Supernatural Lich Skeleton", SizeCategory.Normal,
 			SupernaturalPlanarProfile.DualNatured, SupernaturalNeedsProfile.NonLiving, Stats(-1, 1, 0, 1, 6, 4, 6, "2d6+6"),
-			"undead sorcerers, ancient powers and staff-controlled antagonists", undeadAttacks, [death, corpse, eyes], "Undead Remnant", "Undead Name"));
+			"undead sorcerers, ancient powers and staff-controlled antagonists", undeadAttacks, [death, corpse, eyes], "Undead Remnant", "Undead Name",
+			description: """
+			Liches are undead sorcerers whose bodies are vessels for will, memory and forbidden endurance. Their supernatural nature is apparent through bone, parchment flesh, occult focus and intellect surviving rot, giving them a presence that mortal bodies cannot convincingly imitate.
+
+			They have a coherent physical and spiritual identity of their own. Anatomy, motion, gaze, voice and silence all contribute to the impression that this is not a mortal body with an unusual costume, but a being governed by different conditions of existence.
+
+			Their precise court, curse, theology, bloodline or summoning tradition may differ from place to place. What remains constant is the race's visible force: a complete supernatural presence that can stand on its own in play.
+			"""));
 		Add(Template("Ghoul", SupernaturalFamily.Undead, "Supernatural Decayed Undead", SizeCategory.Normal,
 			SupernaturalPlanarProfile.Material, SupernaturalNeedsProfile.NonLiving, Stats(2, 2, 1, 0, 1, 2, 0),
 			"grave-hungry undead servants without bespoke feeding mechanics", undeadAttacks, [death, corpse], "Undead Remnant", "Undead Name",
-			weapons: false, combat: "Beast Brawler"));
+			weapons: false, combat: "Beast Brawler",
+			description: """
+			Ghouls are grave-hungry undead whose bodies are animated by appetite and decay. Their supernatural nature is apparent through ashen flesh, clawing hands and the practical ugliness of carrion hunger, giving them a presence that mortal bodies cannot convincingly imitate.
+
+			They have a coherent physical and spiritual identity of their own. Anatomy, motion, gaze, voice and silence all contribute to the impression that this is not a mortal body with an unusual costume, but a being governed by different conditions of existence.
+
+			Their precise court, curse, theology, bloodline or summoning tradition may differ from place to place. What remains constant is the race's visible force: a complete supernatural presence that can stand on its own in play.
+			"""));
 		Add(Template("Zombie", SupernaturalFamily.Undead, "Supernatural Decayed Undead", SizeCategory.Normal,
 			SupernaturalPlanarProfile.Material, SupernaturalNeedsProfile.NonLiving, Stats(2, 4, -2, -2, -2, -1, 0),
 			"durable animated corpses and simple undead threats", undeadAttacks, [death, corpse], "Undead Remnant", "Undead Name",
-			weapons: false, combat: "Beast Brawler", health: 1.35));
+			weapons: false, combat: "Beast Brawler", health: 1.35,
+			description: """
+			Zombies are animated corpses driven by stubborn motion rather than living thought. Their supernatural nature is apparent through dead weight, ruined flesh and a body that keeps moving past every natural limit, giving them a presence that mortal bodies cannot convincingly imitate.
+
+			They have a coherent physical and spiritual identity of their own. Anatomy, motion, gaze, voice and silence all contribute to the impression that this is not a mortal body with an unusual costume, but a being governed by different conditions of existence.
+
+			Their precise court, curse, theology, bloodline or summoning tradition may differ from place to place. What remains constant is the race's visible force: a complete supernatural presence that can stand on its own in play.
+			"""));
 		Add(Template("Skeleton", SupernaturalFamily.Undead, "Supernatural Skeleton", SizeCategory.Normal,
 			SupernaturalPlanarProfile.Material, SupernaturalNeedsProfile.NonLiving, Stats(0, 1, 1, 0, 0, 1, 0),
 			"animated bones and low-maintenance undead guards", undeadAttacks, [death, corpse], "Undead Remnant", "Undead Name",
-			weapons: true, health: 0.9));
+			weapons: true, health: 0.9,
+			description: """
+			Skeletons are animated bones held together by magic, curse or command. Their supernatural nature is apparent through bare joints, rattling movement and the unnerving economy of a body stripped to structure, giving them a presence that mortal bodies cannot convincingly imitate.
+
+			They have a coherent physical and spiritual identity of their own. Anatomy, motion, gaze, voice and silence all contribute to the impression that this is not a mortal body with an unusual costume, but a being governed by different conditions of existence.
+
+			Their precise court, curse, theology, bloodline or summoning tradition may differ from place to place. What remains constant is the race's visible force: a complete supernatural presence that can stand on its own in play.
+			"""));
 		Add(Template("Mummy", SupernaturalFamily.Undead, "Supernatural Decayed Undead", SizeCategory.Normal,
 			SupernaturalPlanarProfile.Material, SupernaturalNeedsProfile.NonLiving, Stats(3, 4, -1, -1, 3, 1, 2, "1d4+2"),
 			"preserved cursed dead and ancient tomb guardians", undeadAttacks, [death, corpse], "Undead Remnant", "Undead Name",
-			weapons: true, combat: "Beast Brawler", health: 1.4));
+			weapons: true, combat: "Beast Brawler", health: 1.4,
+			description: """
+			Mummies are preserved cursed dead whose bodies carry tomb, ritual and old punishment with them. Their supernatural nature is apparent through wrappings, dry flesh, resin, dust and a patience that belongs to sealed rooms, giving them a presence that mortal bodies cannot convincingly imitate.
+
+			They have a coherent physical and spiritual identity of their own. Anatomy, motion, gaze, voice and silence all contribute to the impression that this is not a mortal body with an unusual costume, but a being governed by different conditions of existence.
+
+			Their precise court, curse, theology, bloodline or summoning tradition may differ from place to place. What remains constant is the race's visible force: a complete supernatural presence that can stand on its own in play.
+			"""));
 
 		return templates;
 	}


### PR DESCRIPTION
## Summary
- Replaced programmatic race-description composition with direct seeded description literals sourced from the rewrite catalogue.
- Expanded compact generated race-definition loops where needed so descriptions are direct per-race calls.
- Added a canonical hash/count regression test over the 305 seeded race descriptions.

## Validation
- `dotnet build DatabaseSeeder\DatabaseSeeder.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- `dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore -m:1 --filter 'FullyQualifiedName~RacialDescriptionRewriteTests|FullyQualifiedName~StockDescriptions_RaceEthnicityAndCulture_AreThreeParagraphsAndRepresentative|FullyQualifiedName~TemplatesForTesting_RobotRaceEthnicityAndCultureDescriptions_AreThreeParagraphs|FullyQualifiedName~TemplatesForTesting_Descriptions_UseThreeParagraphProseAndHumanoidOverlayVariants|FullyQualifiedName~ValidateTemplateCatalogForTesting_CurrentCatalog_HasNoIssues'`
- `git diff --check`