### PR TITLE
Preserve null drug additional info when cloning scalar effects

### DIFF
--- a/Design Documents/Drugs/Drug_System_Design.md
+++ b/Design Documents/Drugs/Drug_System_Design.md
@@ -60,7 +60,9 @@ The content-facing companion is [Drug Builder Guide](./Drug_Builder_Guide.md).
 - `PlanarState`
 
 ## Additional Info Payloads
-Most drug types only need a scalar intensity. These drug types have extra payload classes in `IDrug.cs`:
+Most drug types only need a scalar intensity. For those scalar-only effects, the runtime `ExtraInfo` payload is
+intentionally `null` and is persisted as a null `AdditionalEffects` value; load, save, and clone paths should preserve
+that null rather than inventing placeholder metadata. These drug types have extra payload classes in `IDrug.cs`:
 
 | Drug type | Payload | Stored meaning |
 | --- | --- | --- |

--- a/MudSharpCore Unit Tests/DrugMetadataTests.cs
+++ b/MudSharpCore Unit Tests/DrugMetadataTests.cs
@@ -1,17 +1,58 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using MudSharp.Database;
 using MudSharp.Framework;
 using MudSharp.FutureProg;
 using MudSharp.Health;
 using MudSharp.Models;
+using System;
 using System.Collections;
 using System.Linq;
+using System.Reflection;
 
 namespace MudSharp_Unit_Tests;
 
 [TestClass]
 public class DrugMetadataTests
 {
+    private sealed record FMDBState(FuturemudDatabaseContext Context, object Connection, uint InstanceCount);
+
+    private static FuturemudDatabaseContext BuildContext()
+    {
+        DbContextOptions<FuturemudDatabaseContext> options = new DbContextOptionsBuilder<FuturemudDatabaseContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(x => x.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+        return new FuturemudDatabaseContext(options);
+    }
+
+    private static FMDBState CaptureFMDBState()
+    {
+        return new FMDBState(
+            (FuturemudDatabaseContext)typeof(FMDB).GetProperty("Context", BindingFlags.Public | BindingFlags.Static)!
+                .GetValue(null),
+            typeof(FMDB).GetProperty("Connection", BindingFlags.Public | BindingFlags.Static)!.GetValue(null),
+            (uint)typeof(FMDB).GetProperty("InstanceCount", BindingFlags.NonPublic | BindingFlags.Static)!
+                .GetValue(null)!);
+    }
+
+    private static void RestoreFMDBState(FMDBState state)
+    {
+        typeof(FMDB).GetProperty("Context", BindingFlags.Public | BindingFlags.Static)!.SetValue(null, state.Context);
+        typeof(FMDB).GetProperty("Connection", BindingFlags.Public | BindingFlags.Static)!.SetValue(null, state.Connection);
+        typeof(FMDB).GetProperty("InstanceCount", BindingFlags.NonPublic | BindingFlags.Static)!
+            .SetValue(null, state.InstanceCount);
+    }
+
+    private static void PrimeFMDB(FuturemudDatabaseContext context)
+    {
+        typeof(FMDB).GetProperty("Context", BindingFlags.Public | BindingFlags.Static)!.SetValue(null, context);
+        typeof(FMDB).GetProperty("Connection", BindingFlags.Public | BindingFlags.Static)!.SetValue(null, null);
+        typeof(FMDB).GetProperty("InstanceCount", BindingFlags.NonPublic | BindingFlags.Static)!.SetValue(null, 1u);
+    }
+
     [TestMethod]
     public void DrugAdditionalInfo_LoadsEmptyAndLegacyFixedPointIdLists()
     {
@@ -179,5 +220,46 @@ public class DrugMetadataTests
 
         CollectionAssert.AreEqual(intensities, legacyAlias);
         CollectionAssert.AreEqual(new object[] { 0.25m, 0.75m }, intensities);
+    }
+
+    [TestMethod]
+    public void Clone_ScalarOnlyEffects_PreserveNullAdditionalInfo()
+    {
+        FMDBState state = CaptureFMDBState();
+        using FuturemudDatabaseContext context = BuildContext();
+        try
+        {
+            PrimeFMDB(context);
+            MudSharp.Models.Drug model = new()
+            {
+                Id = 1,
+                Name = "simple analgesic",
+                DrugVectors = (int)DrugVector.Ingested,
+                IntensityPerGram = 1.0,
+                RelativeMetabolisationRate = 1.0
+            };
+            model.DrugsIntensities.Add(new DrugIntensity
+            {
+                DrugType = (int)DrugType.Analgesic,
+                RelativeIntensity = 0.5
+            });
+            MudSharp.Health.Drug drug = new(model, new Mock<IFuturemud>().Object);
+
+            MudSharp.Health.Drug clone = (MudSharp.Health.Drug)drug.Clone("simple analgesic copy");
+
+            Assert.AreEqual("simple analgesic copy", clone.Name);
+            Assert.AreEqual(0.5, clone.IntensityForType(DrugType.Analgesic));
+            Assert.IsNull(clone.DrugTypeMulipliers[DrugType.Analgesic].ExtraInfo);
+
+            MudSharp.Models.Drug persisted = context.Drugs
+                .Include(x => x.DrugsIntensities)
+                .Single();
+            Assert.AreEqual("simple analgesic copy", persisted.Name);
+            Assert.IsNull(persisted.DrugsIntensities.Single().AdditionalEffects);
+        }
+        finally
+        {
+            RestoreFMDBState(state);
+        }
     }
 }

--- a/MudSharpCore/Health/Drug.cs
+++ b/MudSharpCore/Health/Drug.cs
@@ -56,7 +56,12 @@ public class Drug : SaveableItem, IDrug
         RelativeMetabolisationRate = rhs.RelativeMetabolisationRate;
         foreach (KeyValuePair<DrugType, (double Multiplier, DrugAdditionalInfo ExtraInfo)> item in rhs.DrugTypeMulipliers)
         {
-            DrugTypeMulipliers[item.Key] = (item.Value.Multiplier, AdditionalInfoFor(item.Key, item.Value.ExtraInfo.DatabaseString));
+            DrugTypeMulipliers[item.Key] = (
+                item.Value.Multiplier,
+                item.Value.ExtraInfo is null
+                    ? null
+                    : AdditionalInfoFor(item.Key, item.Value.ExtraInfo.DatabaseString)
+            );
         }
 
         DoDatabaseInsert();


### PR DESCRIPTION
## Summary
- Keep scalar-only drug effects carrying a `null` `ExtraInfo` through clone/save paths instead of synthesizing placeholder metadata.
- Update the drug design document to state the null-payload contract explicitly.
- Add a regression test covering clone behavior and persisted `AdditionalEffects` for scalar-only drugs.

## Testing
- Added unit coverage in `MudSharpCore Unit Tests` for cloning a scalar-only drug and verifying the cloned and persisted additional info remain `null`.
- Not run (not requested).