### PR TITLE
Fix seeder repeatability and celestial prompts

### DIFF
--- a/DatabaseSeeder Unit Tests/AnimalButcherySeederTests.cs
+++ b/DatabaseSeeder Unit Tests/AnimalButcherySeederTests.cs
@@ -179,6 +179,11 @@ public class AnimalButcherySeederTests
 
 	private static void SeedCorePrerequisites(FuturemudDatabaseContext context)
 	{
+		SeedCorePrerequisites(context, "Butchery");
+	}
+
+	private static void SeedCorePrerequisites(FuturemudDatabaseContext context, string butcheryTraitName)
+	{
 		context.Accounts.Add(new Account
 		{
 			Id = 1,
@@ -243,7 +248,7 @@ public class AnimalButcherySeederTests
 		context.TraitDefinitions.Add(new TraitDefinition
 		{
 			Id = 1,
-			Name = "Butchery",
+			Name = butcheryTraitName,
 			Type = 0,
 			OwnerScope = 0,
 			TraitGroup = "Crafting",
@@ -272,6 +277,12 @@ public class AnimalButcherySeederTests
 			IsHiddenFromPlayers = false
 		});
 
+		context.SaveChanges();
+	}
+
+	private static void RenameButcheryTrait(FuturemudDatabaseContext context, string name)
+	{
+		context.TraitDefinitions.Single().Name = name;
 		context.SaveChanges();
 	}
 
@@ -490,6 +501,21 @@ public class AnimalButcherySeederTests
 		{
 			Assert.IsNull(context.Races.Single(x => x.Name == raceName).RaceButcheryProfileId, raceName);
 		}
+	}
+
+	[TestMethod]
+	public void SeedData_FullCatalogue_AcceptsGerundButcheringSkillName()
+	{
+		using var context = BuildContext();
+		SeedFullCatalogueContext(context);
+		RenameButcheryTrait(context, "Butchering");
+		var seeder = new AnimalButcherySeeder();
+
+		Assert.AreEqual(ShouldSeedResult.ReadyToInstall, seeder.ShouldSeedData(context));
+		seeder.SeedData(context, new Dictionary<string, string>());
+
+		Assert.IsTrue(context.RaceButcheryProfilesBreakdownChecks.All(x => x.TraitDefinitionId == 1));
+		Assert.AreEqual(ShouldSeedResult.MayAlreadyBeInstalled, seeder.ShouldSeedData(context));
 	}
 
 	[TestMethod]

--- a/DatabaseSeeder Unit Tests/CelestialSeederTests.cs
+++ b/DatabaseSeeder Unit Tests/CelestialSeederTests.cs
@@ -19,6 +19,35 @@ namespace MudSharp_Unit_Tests;
 [TestClass]
 public class CelestialSeederTests
 {
+    private static readonly string[] EpochSuggestionCalendarModes =
+    [
+        "gregorian-us",
+        "gregorian-uk",
+        "gregorian-us-ce",
+        "gregorian-uk-ce",
+        "julian",
+        "latin-7day",
+        "latin-8day",
+        "latin-ancient",
+        "middle-earth",
+        "tranquility",
+        "republicain",
+        "mission",
+        "seasonal-360",
+        "islamic-hijri",
+        "hebrew",
+        "old-persian",
+        "babylonian",
+        "chinese-minguo",
+        "chinese-lunisolar",
+        "korean-dangi",
+        "korean-modern",
+        "korean-lunisolar",
+        "japanese-koki",
+        "japanese-modern",
+        "japanese-lunisolar"
+    ];
+
     private static FuturemudDatabaseContext BuildContext()
     {
         DbContextOptions<FuturemudDatabaseContext> options = new DbContextOptionsBuilder<FuturemudDatabaseContext>()
@@ -276,6 +305,51 @@ public class CelestialSeederTests
         Assert.AreEqual(ShouldSeedResult.ExtraPackagesAvailable, seeder.ShouldSeedData(context));
     }
 
+    [TestMethod]
+    public void SeederQuestions_MoonAndGasGiantPromptsGiveSupportingContext()
+    {
+        Dictionary<string, string> questions = new CelestialSeeder().SeederQuestions
+            .ToDictionary(x => x.Id, x => x.Question, StringComparer.OrdinalIgnoreCase);
+
+        StringAssert.Contains(questions["installmoon"], "lunar phases");
+        StringAssert.Contains(questions["installmoon"], "moon-surface sky views");
+        StringAssert.Contains(questions["mooncalendar"], "same calendar used by your Earth-facing sun");
+        StringAssert.Contains(questions["moonname"], "The Moon");
+        StringAssert.Contains(questions["installgasgiantmoon"], "Jupiter dominating the sky");
+        StringAssert.Contains(questions["gasgiantcalendar"], "All four linked objects");
+        StringAssert.Contains(questions["gasgiantsunepoch"], "distant solar orbit");
+        StringAssert.Contains(questions["gasgiantmoonepoch"], "keeps the linked Jupiter and Sol views coherent");
+    }
+
+    [TestMethod]
+    public void ResolveEpochDisplays_AllSupportedTimeSeederCalendarModes_ProvideSuggestedDefaults()
+    {
+        foreach (string mode in EpochSuggestionCalendarModes)
+        {
+            using FuturemudDatabaseContext context = BuildContext();
+            long calendarId = SeedCalendar(context, mode, "1200", mode == "middle-earth" ? "3" : null);
+            string calendarAnswer = calendarId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            Dictionary<string, string> answers = new(StringComparer.OrdinalIgnoreCase)
+            {
+                ["suncalendar"] = calendarAnswer,
+                ["mooncalendar"] = calendarAnswer,
+                ["gasgiantcalendar"] = calendarAnswer
+            };
+
+            ConsoleQuestionDisplay sun = CelestialSeeder.ResolveSunEpochDisplay(context, answers);
+            ConsoleQuestionDisplay moon = CelestialSeeder.ResolveMoonEpochDisplay(context, answers);
+            ConsoleQuestionDisplay gasGiantSun = CelestialSeeder.ResolveGasGiantSunEpochDisplay(context, answers);
+            ConsoleQuestionDisplay gasGiantMoon = CelestialSeeder.ResolveGasGiantMoonEpochDisplay(context, answers);
+
+            Assert.IsFalse(string.IsNullOrWhiteSpace(sun.DefaultAnswer), $"{mode}: sun default missing.");
+            Assert.IsFalse(string.IsNullOrWhiteSpace(moon.DefaultAnswer), $"{mode}: moon default missing.");
+            Assert.IsFalse(string.IsNullOrWhiteSpace(gasGiantSun.DefaultAnswer), $"{mode}: gas giant sun default missing.");
+            Assert.IsFalse(string.IsNullOrWhiteSpace(gasGiantMoon.DefaultAnswer), $"{mode}: gas giant moon default missing.");
+            StringAssert.Contains(sun.Prompt, "The selected calendar is");
+            StringAssert.Contains(moon.Prompt, "21st day of the year");
+            StringAssert.Contains(gasGiantMoon.Prompt, "epoch-aligned");
+        }
+    }
     [TestMethod]
     public void ResolveSunEpochDisplay_GregorianCalendar_ShowsCalendarSpecificExampleAndDefault()
     {

--- a/DatabaseSeeder Unit Tests/PrimaryProductionSeederSourceTests.cs
+++ b/DatabaseSeeder Unit Tests/PrimaryProductionSeederSourceTests.cs
@@ -716,7 +716,7 @@ public class PrimaryProductionSeederSourceTests
 			"Slag Commodity",
 			"Metal Ingot Commodity",
 			"Salt Commodity",
-			"Potash Commodity",
+			"Soda Ash Commodity",
 			"Glass Blank Commodity",
 			"Tar Commodity",
 			"Peat Fuel Commodity",

--- a/DatabaseSeeder Unit Tests/PrimaryProductionSeederTests.cs
+++ b/DatabaseSeeder Unit Tests/PrimaryProductionSeederTests.cs
@@ -194,6 +194,21 @@ public class PrimaryProductionSeederTests
 		AssertContains(materials, "RemoveTag(materials[\"native nickel\"], \"Native Gold Ore\")");
 	}
 
+	[TestMethod]
+	public void PrimaryProductionProjectPhases_SetDescriptionBeforeFirstSave()
+	{
+		string source = ReadSource("DatabaseSeeder", "Seeders", "PrimaryProductionSeeder.cs");
+		string ensurePhase = SliceFrom(source, "private static ProjectPhase EnsurePhase", "private static void EnsurePrimaryLabour");
+
+		int descriptionIndex = ensurePhase.IndexOf("Description = seed.Description", StringComparison.Ordinal);
+		int addIndex = ensurePhase.IndexOf("context.ProjectPhases.Add(phase);", StringComparison.Ordinal);
+		int saveIndex = ensurePhase.IndexOf("context.SaveChanges();", StringComparison.Ordinal);
+
+		Assert.IsTrue(descriptionIndex >= 0, "New project phases must have their required description populated.");
+		Assert.IsTrue(descriptionIndex < addIndex, "ProjectPhase.Description should be assigned before the phase is added.");
+		Assert.IsTrue(descriptionIndex < saveIndex, "ProjectPhase.Description should be assigned before the first SaveChanges.");
+	}
+
 	private static void AssertContains(string source, string expected)
 	{
 		Assert.IsTrue(source.Contains(expected, StringComparison.Ordinal),

--- a/DatabaseSeeder Unit Tests/UsefulSeederItemPackageTests.cs
+++ b/DatabaseSeeder Unit Tests/UsefulSeederItemPackageTests.cs
@@ -11,6 +11,7 @@ using MudSharp.Health;
 using MudSharp.Models;
 using MudSharp.RPG.Checks;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
 using MaterialBehaviourType = MudSharp.Form.Material.MaterialBehaviourType;
@@ -116,6 +117,93 @@ public class UsefulSeederItemPackageTests
 		context.SaveChanges();
 	}
 
+	private static Dictionary<string, string> BuildUsefulAnswers(string covers = "no")
+	{
+		return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+		{
+			["ai"] = "no",
+			["covers"] = covers,
+			["items"] = "no",
+			["modernitems"] = "no",
+			["tags"] = "no",
+			["autobuilder"] = "no",
+			["hints"] = "no",
+			["dreams"] = "no"
+		};
+	}
+
+	private static Terrain CreateTerrain(long id, string name, string tagInformation)
+	{
+		return new Terrain
+		{
+			Id = id,
+			Name = name,
+			HideDifficulty = 0,
+			SpotDifficulty = 0,
+			InfectionType = 0,
+			InfectionVirulence = 0,
+			InfectionMultiplier = 0,
+			StaminaCost = 0,
+			TerrainANSIColour = "7",
+			TerrainEditorColour = "#FFFFFFFF",
+			TerrainBehaviourMode = "outdoors",
+			DefaultTerrain = id == 1,
+			MovementRate = 1,
+			ForagableProfileId = 0,
+			AtmosphereType = "Gas",
+			DefaultCellOutdoorsType = 0,
+			GravityModel = 0,
+			TerrainEditorText = name[..Math.Min(2, name.Length)],
+			CanHaveTracks = false,
+			TrackIntensityMultiplierVisual = 1.0,
+			TrackIntensityMultiplierOlfactory = 1.0,
+			TagInformation = tagInformation
+		};
+	}
+
+	private static void SeedRangedCoverTerrainPrerequisites(FuturemudDatabaseContext context)
+	{
+		Tag urban = CreateTag(101, "Urban");
+		Tag rural = CreateTag(102, "Rural");
+		Tag terrestrial = CreateTag(103, "Terrestrial");
+		context.Tags.AddRange(urban, rural, terrestrial);
+		context.Terrains.AddRange(
+			CreateTerrain(1, "City Street", urban.Id.ToString()),
+			CreateTerrain(2, "Country Field", $"{rural.Id},{terrestrial.Id}"));
+		context.SaveChanges();
+	}
+
+	private static void SeedItemPackageCoverOverlap(FuturemudDatabaseContext context)
+	{
+		string[] names =
+		[
+			"Uneven Ground",
+			"Upright Table",
+			"Overturned Table",
+			"Smoke",
+			"Sandbag",
+			"Tree"
+		];
+
+		long id = context.RangedCovers.Any() ? context.RangedCovers.Max(x => x.Id) + 1 : 1;
+		foreach (string name in names)
+		{
+			context.RangedCovers.Add(new RangedCover
+			{
+				Id = id++,
+				Name = name,
+				CoverType = 0,
+				CoverExtent = 0,
+				HighestPositionState = 1,
+				DescriptionString = name,
+				ActionDescriptionString = name,
+				MaximumSimultaneousCovers = 0,
+				CoverStaysWhileMoving = false
+			});
+		}
+
+		context.SaveChanges();
+	}
 	private static GameItemComponentProto CreateComponentMarker(long id, string name, string type = "Test")
 	{
 		return new GameItemComponentProto
@@ -344,6 +432,58 @@ public class UsefulSeederItemPackageTests
 		Assert.AreEqual(ShouldSeedResult.MayAlreadyBeInstalled, UsefulSeeder.ClassifyItemPackagePresence(context));
 	}
 
+	[TestMethod]
+	public void ClassifyTagPackagePresence_FunctionsTagWithoutUsefulMarker_ReturnsReadyToInstall()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedGeneralPrerequisites(context);
+		context.Tags.Add(CreateTag(10, "Functions"));
+		context.SaveChanges();
+
+		Assert.AreEqual(ShouldSeedResult.ReadyToInstall, UsefulSeeder.ClassifyTagPackagePresence(context));
+
+		context.Tags.Add(CreateTag(11, "Aluminothermic Welding Portion"));
+		context.SaveChanges();
+
+		Assert.AreEqual(ShouldSeedResult.MayAlreadyBeInstalled, UsefulSeeder.ClassifyTagPackagePresence(context));
+	}
+
+	[TestMethod]
+	public void ClassifyRangedCoverPackagePresence_ItemPackageCoverOverlapOnly_ReturnsReadyToInstall()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedGeneralPrerequisites(context);
+		SeedRangedCoverTerrainPrerequisites(context);
+		SeedItemPackageCoverOverlap(context);
+
+		Assert.AreEqual(ShouldSeedResult.ReadyToInstall, UsefulSeeder.ClassifyRangedCoverPackagePresence(context));
+	}
+
+	[TestMethod]
+	public void SeedData_CoversWithExistingItemPackageCoverRows_AddsMissingCoversAndLinks()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedGeneralPrerequisites(context);
+		SeedRangedCoverTerrainPrerequisites(context);
+		SeedItemPackageCoverOverlap(context);
+		UsefulSeeder seeder = new();
+
+		var coversQuestion = seeder.SeederQuestions.Single(x => x.Id == "covers");
+		Assert.IsTrue(coversQuestion.Filter(context, BuildUsefulAnswers()));
+
+		string result = seeder.SeedData(context, BuildUsefulAnswers(covers: "yes"));
+
+		Assert.AreEqual("The operation completed successfully.", result);
+		Assert.AreEqual(1, context.RangedCovers.Count(x => x.Name == "Smoke"));
+		Assert.AreEqual(1, context.RangedCovers.Count(x => x.Name == "Corridor Doorway"));
+
+		Terrain cityStreet = context.Terrains.Single(x => x.Name == "City Street");
+		RangedCover doorway = context.RangedCovers.Single(x => x.Name == "Corridor Doorway");
+		Assert.IsTrue(context.TerrainsRangedCovers.Any(x =>
+			x.TerrainId == cityStreet.Id &&
+			x.RangedCoverId == doorway.Id));
+		Assert.AreEqual(ShouldSeedResult.MayAlreadyBeInstalled, UsefulSeeder.ClassifyRangedCoverPackagePresence(context));
+	}
 	[TestMethod]
 	public void SeedLockAndWaterSourceCoverageForTesting_RerunDoesNotDuplicateAndCreatesPublicVariants()
 	{

--- a/DatabaseSeeder/SeederMetadataRegistry.cs
+++ b/DatabaseSeeder/SeederMetadataRegistry.cs
@@ -368,8 +368,8 @@ public static class SeederMetadataRegistry
                         context.Materials.Any(x => x.Name == "meat") &&
                         context.Materials.Any(x => x.Name == "bone") &&
                         context.Materials.Any(x => x.Name == "animal skin")),
-                    Requirement("The Butchery skill and at least one stock animal race must already exist.", context =>
-                        context.TraitDefinitions.Any(x => x.Name == "Butchery") &&
+                    Requirement("The Butchery/Butchering skill and at least one stock animal race must already exist.", context =>
+                        HasTrait(context, "Butchery", "Butchering") &&
                         context.Races.Any())
                 ],
                 RerunSummary: "Reruns reuse stock animal butchery item, product and profile names, then attach missing eligible stock races.",

--- a/DatabaseSeeder/Seeders/AnimalButcherySeeder.cs
+++ b/DatabaseSeeder/Seeders/AnimalButcherySeeder.cs
@@ -22,6 +22,7 @@ public sealed class AnimalButcherySeeder : IDatabaseSeeder
 	private const int MaximumStockItemPrototypeCount = 220;
 
 	private const string ButcheryOutputTag = "Butchery Output";
+	private static readonly string[] ButcheryTraitAliases = ["Butchery", "Butchering"];
 	private const string RawMeatCutTag = "Raw Meat Cut";
 	private const string RawHideTag = "Raw Hide";
 	private const string OffalTag = "Offal";
@@ -231,7 +232,7 @@ It creates reusable butchery outputs, raw carcass cuts, hides, glands, trophies 
 		       context.Materials.Any(x => x.Name == "meat") &&
 		       context.Materials.Any(x => x.Name == "bone") &&
 		       context.Materials.Any(x => x.Name == "animal skin") &&
-		       context.TraitDefinitions.Any(x => x.Name == "Butchery") &&
+		       ResolveButcheryTrait(context) is not null &&
 		       context.Races.Any() &&
 		       context.BodyProtos.Any();
 	}
@@ -1255,7 +1256,8 @@ It creates reusable butchery outputs, raw carcass cuts, hides, glands, trophies 
 			.Include(x => x.RaceButcheryProfilesSkinningEmotes)
 			.Include(x => x.RaceButcheryProfilesButcheryProducts)
 			.ToDictionary(x => x.Name, x => x, StringComparer.OrdinalIgnoreCase);
-		var trait = context.TraitDefinitions.First(x => x.Name == "Butchery");
+		var trait = ResolveButcheryTrait(context) ??
+		            throw new InvalidOperationException("Animal butchery requires the Butchery or Butchering trait.");
 		var cutting = context.Tags.First(x => x.Name == "Cutting");
 		var results = new Dictionary<string, RaceButcheryProfile>(StringComparer.OrdinalIgnoreCase);
 
@@ -1420,6 +1422,18 @@ It creates reusable butchery outputs, raw carcass cuts, hides, glands, trophies 
 	private static bool IsStockProfile(RaceButcheryProfile? profile)
 	{
 		return profile is not null && profile.Name.StartsWith(StockPrefix, StringComparison.OrdinalIgnoreCase);
+	}
+
+	private static TraitDefinition? ResolveButcheryTrait(FuturemudDatabaseContext context)
+	{
+		return context.TraitDefinitions
+		              .AsEnumerable()
+		              .FirstOrDefault(x => ButcheryTraitAliases.Any(alias => NormaliseName(x.Name) == NormaliseName(alias)));
+	}
+
+	private static string NormaliseName(string text)
+	{
+		return new string(text.Where(char.IsLetterOrDigit).ToArray()).ToLowerInvariant();
 	}
 
 	internal sealed record StockButcheryMaterialSpec(

--- a/DatabaseSeeder/Seeders/CelestialSeeder.cs
+++ b/DatabaseSeeder/Seeders/CelestialSeeder.cs
@@ -117,35 +117,55 @@ What epoch date do you want to use?",
             (context, answers) => AnswerIsYes(answers, "installsun"),
             ValidateDate),
         ("installmoon",
-            @"Do you want to install the Earth's Moon package? This installs the planetary moon plus the matching Earth and Sol moon-view celestials.",
+            @"Do you want to install an Earth Moon package? This option assumes an Earth-like planet with a single large natural satellite, and installs the moon plus the linked Earth and Sun objects needed for moon-surface sky views.
+
+Use this if your game should have lunar phases, full/new moon event helpers, or areas that can be viewed from the moon looking back at the parent planet and sun.
+
+Please answer #3yes#F or #3no#F: ",
             (context, answers) => AnswerIsYes(answers, "installsun") || HasSingleEarthSunCandidate(context),
             ValidateYesNo),
         ("mooncalendar",
-            @"Which calendar should the Earth Moon package be tied to?",
+            @"Which calendar should the Earth Moon package be tied to for lunar phase and orbital calculations?
+
+This should usually be the same calendar used by your Earth-facing sun, so solar and lunar events are expressed in the same date system. Please specify a calendar name or ID: ",
             (context, answers) => AnswerIsYes(answers, "installmoon"),
             ValidateCalendar),
         ("moonname",
-            @"What name would you like to give to your moon?",
+            @"What name would you like to give to the Earth-facing moon? For example, for Earth's moon you might enter 'The Moon', 'Luna', or another setting-specific name.
+
+Your choice: ",
             (context, answers) => AnswerIsYes(answers, "installmoon"),
             (answer, context) => (true, string.Empty)),
         ("moonepoch",
-            @"What epoch date should be used for the moon? This is a date that is known to be a full moon. For the stock Earth moon package, the suggested default is the 21st day of the year in the calendar you selected.",
+            @"What epoch date should be used for the Earth-facing moon? This is the full-moon reference date used to line up lunar phase calculations.
+
+For the stock Earth moon package, the suggested default is the 21st day of the year in the calendar you selected.",
             (context, answers) => AnswerIsYes(answers, "installmoon"),
             ValidateDate),
         ("installgasgiantmoon",
-            @"Do you want to install the Gas Giant Moon package? This installs a Jupiter-facing Sun, Ganymede, Jupiter-from-Ganymede, and Sol-from-Ganymede.",
+            @"Do you want to install the Gas Giant Moon package? This option models a habitable viewpoint on Ganymede, with Jupiter dominating the sky and Sol appearing as the distant sun.
+
+It installs four linked objects: a Jupiter-facing Sun, Ganymede as the local moon/world, Jupiter-from-Ganymede, and Sol-from-Ganymede. Use it for science-fiction or alien sky examples rather than an Earth surface.
+
+Please answer #3yes#F or #3no#F: ",
             (context, answers) => true,
             ValidateYesNo),
         ("gasgiantcalendar",
-            @"Which calendar should the Gas Giant Moon package be tied to?",
+            @"Which calendar should the Gas Giant Moon package be tied to for the Jupiter-facing sun, Ganymede phase, and moon-surface sky calculations?
+
+All four linked objects in this package use the same calendar. Please specify a calendar name or ID: ",
             (context, answers) => AnswerIsYes(answers, "installgasgiantmoon"),
             ValidateCalendar),
         ("gasgiantsunepoch",
-            @"What epoch date should be used for the Jupiter-facing Sun? This should be the start-of-year epoch for your chosen calendar.",
+            @"What epoch date should be used for the Jupiter-facing Sun? This aligns the distant solar orbit with the selected calendar.
+
+For the stock gas giant package, use the start-of-year epoch for your chosen calendar unless you have a custom astronomy reference date.",
             (context, answers) => AnswerIsYes(answers, "installgasgiantmoon"),
             ValidateDate),
         ("gasgiantmoonepoch",
-            @"What epoch date should be used for Ganymede? This should be a date that is known to be a full Ganymede as seen from Jupiter. The stock package uses an epoch-aligned default at the start of the selected calendar year.",
+            @"What epoch date should be used for Ganymede? This is the phase reference for Ganymede as seen from Jupiter, and it keeps the linked Jupiter and Sol views coherent.
+
+The stock package uses an epoch-aligned default at the start of the selected calendar year.",
             (context, answers) => AnswerIsYes(answers, "installgasgiantmoon"),
             ValidateDate)
     ];
@@ -499,16 +519,36 @@ The selected calendar is {info.CalendarName}.
 
     private static List<string> SplitDateParts(string value)
     {
-        return Regex.Split(value, @"[-/\\\s]+")
+        return Regex.Split(value, GetDateSeparatorPattern(value))
             .Where(x => !string.IsNullOrWhiteSpace(x))
             .ToList();
     }
 
     private static List<string> SplitDateSeparators(string value)
     {
-        return Regex.Matches(value, @"[-/\\\s]+")
+        return Regex.Matches(value, GetDateSeparatorPattern(value))
             .Select(x => x.Value)
             .ToList();
+    }
+
+    private static string GetDateSeparatorPattern(string value)
+    {
+        if (value.Contains('/'))
+        {
+            return @"/+";
+        }
+
+        if (value.Contains('\\'))
+        {
+            return @"\\+";
+        }
+
+        if (Regex.IsMatch(value, @"\s"))
+        {
+            return @"\s+";
+        }
+
+        return @"-+";
     }
 
     private static int FindYearIndex(IReadOnlyList<string> parts)

--- a/DatabaseSeeder/Seeders/PrimaryProductionSeeder.cs
+++ b/DatabaseSeeder/Seeders/PrimaryProductionSeeder.cs
@@ -960,7 +960,8 @@ public sealed class PrimaryProductionSeeder : IDatabaseSeeder
 			{
 				ProjectId = project.Id,
 				ProjectRevisionNumber = project.RevisionNumber,
-				PhaseNumber = 1
+				PhaseNumber = 1,
+				Description = seed.Description
 			};
 			context.ProjectPhases.Add(phase);
 			context.SaveChanges();

--- a/DatabaseSeeder/Seeders/UsefulSeeder.cs
+++ b/DatabaseSeeder/Seeders/UsefulSeeder.cs
@@ -137,6 +137,105 @@ public partial class UsefulSeeder : IDatabaseSeeder
         "SolidFuelHeaterCooler_WoodStove"
     ];
 
+    private const string StockTagPackageMarker = "Aluminothermic Welding Portion";
+
+    private static readonly string[] StockRangedCoverPackageMarkers =
+    [
+        "Corridor Doorway",
+        "Large Crater",
+        "Chunk of Rubble",
+        "Bush",
+        "Refuse Heap",
+        "Stone Wall",
+        "Rubble Wall",
+        "Small Rock",
+        "Large Rock",
+        "Fallen Log",
+        "Pile of Crates",
+        "Barrel Stack",
+        "Low Hedge",
+        "Thick Hedge",
+        "Tall Grass",
+        "Shrubs",
+        "Vehicle",
+        "Broken Vehicle",
+        "Collapsed Building",
+        "Window Frame",
+        "Ruined Wall",
+        "Stalagmites",
+        "Pile of Junk",
+        "Pile of Bones",
+        "Dead Body",
+        "Sand Dune",
+        "Snow Drift",
+        "Fallen Statue",
+        "Street Corner",
+        "Alley Trash Bin",
+        "Park Bench",
+        "Street Lamp",
+        "Old Well",
+        "Rock Outcropping",
+        "Fallen Tree",
+        "Fallen Pillar",
+        "Thick Smoke",
+        "Dense Fog",
+        "Tall Reeds",
+        "Thick Seaweed",
+        "Dense Vegetation",
+        "Boulder Cluster",
+        "Abandoned Cart",
+        "Bushy Tree",
+        "Shrubbery",
+        "Counter",
+        "Desk",
+        "Staircase",
+        "Corner"
+    ];
+
+    private static readonly IReadOnlyDictionary<string, string[]> StockRangedCoverNamesByTerrainTag =
+        new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Urban"] =
+            [
+                "Corridor Doorway",
+                "Window Frame",
+                "Corner",
+                "Street Corner",
+                "Alley Trash Bin"
+            ],
+            ["Rural"] =
+            [
+                "Tree",
+                "Bush",
+                "Bushy Tree",
+                "Shrubbery",
+                "Fallen Log",
+                "Fallen Tree",
+                "Old Well"
+            ],
+            ["Terrestrial"] =
+            [
+                "Uneven Ground",
+                "Large Crater",
+                "Stone Wall",
+                "Rubble Wall",
+                "Small Rock",
+                "Large Rock",
+                "Boulder Cluster",
+                "Rock Outcropping",
+                "Sand Dune",
+                "Snow Drift",
+                "Low Hedge",
+                "Thick Hedge",
+                "Tall Grass",
+                "Shrubs",
+                "Fallen Pillar"
+            ],
+            ["Aquatic"] = ["Thick Seaweed"],
+            ["Littoral"] = ["Sand Dune", "Tall Reeds"],
+            ["Riparian"] = ["Tall Reeds", "Dense Vegetation"]
+        };
+
     public bool SafeToRunMoreThanOnce => true;
 
     public IEnumerable<(string Id, string Question,
@@ -155,7 +254,8 @@ public partial class UsefulSeeder : IDatabaseSeeder
                 }),
             ("covers",
                 "Do you want to install a collection of simple ranged covers?\n\nPlease answer #3yes#f or #3no#f: ",
-                (context, questions) => context.RangedCovers.Count() <= 1,
+                (context, questions) => context.Terrains.Count() > 1 &&
+                                        ClassifyRangedCoverPackagePresence(context) != ShouldSeedResult.MayAlreadyBeInstalled,
                 (answer, context) =>
                 {
                         if (answer.EqualToAny("yes", "y", "no", "n")) { return (true, string.Empty); } return (false, "Invalid answer");
@@ -295,13 +395,12 @@ public partial class UsefulSeeder : IDatabaseSeeder
             ClassifyAiPackagePresence(context),
             ClassifyItemPackagePresence(context),
             ClassifyModernPackagePresence(context),
-            context.Tags.Any(x => x.Name == "Functions")
-                ? ShouldSeedResult.MayAlreadyBeInstalled
-                : ShouldSeedResult.ReadyToInstall
+            ClassifyTagPackagePresence(context)
         ];
 
         if (context.Terrains.Count() > 1)
         {
+            packageStates.Add(ClassifyRangedCoverPackagePresence(context));
             packageStates.Add(ClassifyAutobuilderPackagePresence(context));
         }
 
@@ -334,6 +433,7 @@ Inside the package there are a few numbered #D""Core Item Packages""#3. The reas
     internal static IReadOnlyCollection<string> StockAiExampleNamesForTesting => StockAiExampleNames;
     internal static IReadOnlyCollection<string> StockItemMarkersForTesting => StockItemMarkers;
     internal static IReadOnlyCollection<string> StockModernItemMarkersForTesting => StockModernItemMarkers;
+    internal static IReadOnlyCollection<string> StockRangedCoverPackageMarkersForTesting => StockRangedCoverPackageMarkers;
 
     internal static ShouldSeedResult ClassifyItemPackagePresence(FuturemudDatabaseContext context)
     {
@@ -357,6 +457,40 @@ Inside the package there are a few numbered #D""Core Item Packages""#3. The reas
         return SeederRepeatabilityHelper.ClassifyByPresence(presenceChecks);
     }
 
+    internal static ShouldSeedResult ClassifyTagPackagePresence(FuturemudDatabaseContext context)
+    {
+        return context.Tags.Any(x => x.Name == StockTagPackageMarker)
+            ? ShouldSeedResult.MayAlreadyBeInstalled
+            : ShouldSeedResult.ReadyToInstall;
+    }
+
+    internal static ShouldSeedResult ClassifyRangedCoverPackagePresence(FuturemudDatabaseContext context)
+    {
+        HashSet<string> stockCoverNames = new(StockRangedCoverPackageMarkers, StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, RangedCover> packageCovers = context.RangedCovers
+            .AsEnumerable()
+            .Where(x => stockCoverNames.Contains(x.Name))
+            .ToDictionary(x => x.Name, x => x, StringComparer.OrdinalIgnoreCase);
+
+        List<bool> presenceChecks = StockRangedCoverPackageMarkers
+            .Select(packageCovers.ContainsKey)
+            .ToList();
+
+        foreach (Terrain terrain in context.Terrains.ToList())
+        {
+            foreach (string coverName in GetStockRangedCoverNamesForTerrain(context, terrain)
+                         .Where(stockCoverNames.Contains)
+                         .Distinct(StringComparer.OrdinalIgnoreCase))
+            {
+                presenceChecks.Add(packageCovers.TryGetValue(coverName, out RangedCover? cover) &&
+                                   context.TerrainsRangedCovers.Any(x =>
+                                       x.TerrainId == terrain.Id &&
+                                       x.RangedCoverId == cover.Id));
+            }
+        }
+
+        return SeederRepeatabilityHelper.ClassifyByPresence(presenceChecks);
+    }
     private static ShouldSeedResult CombinePackageStates(params ShouldSeedResult[] packageStates)
     {
         if (packageStates.All(x => x == ShouldSeedResult.ReadyToInstall))
@@ -416,6 +550,30 @@ Inside the package there are a few numbered #D""Core Item Packages""#3. The reas
         return cover;
     }
 
+    private static IEnumerable<string> GetStockRangedCoverNamesForTerrain(FuturemudDatabaseContext context, Terrain terrain)
+    {
+        Dictionary<long, string> tagsById = context.Tags.ToDictionary(x => x.Id, x => x.Name);
+        List<string> tagNames = terrain.TagInformation?.Split(',', StringSplitOptions.RemoveEmptyEntries)
+            .Select(x => long.TryParse(x, out long val) && tagsById.ContainsKey(val)
+                ? tagsById[val]
+                : null)
+            .OfType<string>()
+            .ToList() ?? new List<string>();
+
+        foreach (string tag in tagNames)
+        {
+            if (!StockRangedCoverNamesByTerrainTag.TryGetValue(tag, out string[]? names))
+            {
+                continue;
+            }
+
+            foreach (string name in names)
+            {
+                yield return name;
+            }
+        }
+    }
+
     private void SeedTerrainAutobuilder(FuturemudDatabaseContext context,
             IReadOnlyDictionary<string, string> questionAnswers, ICollection<string> errors)
     {
@@ -424,12 +582,6 @@ Inside the package there are a few numbered #D""Core Item Packages""#3. The reas
 
     private void SeedRangedCovers(FuturemudDatabaseContext context, ICollection<string> errors)
     {
-        if (context.RangedCovers.Any())
-        {
-            errors.Add("Detected that ranged covers were already installed. Did not seed any covers.");
-            return;
-        }
-
         List<(string Name, int Type, int Extent, int Position, string Desc, string Action, int Max, bool Moving)> covers = new()
         {
                         ("Uneven Ground", 0, 0, 6, "prone, using the uneven ground as cover", "$0 go|goes prone and begin|begins to use the uneven ground as cover", 0, true),
@@ -491,73 +643,27 @@ Inside the package there are a few numbered #D""Core Item Packages""#3. The reas
 
         foreach ((string Name, int Type, int Extent, int Position, string Desc, string Action, int Max, bool Moving) item in covers)
         {
-            context.RangedCovers.Add(new RangedCover
-            {
-                Name = item.Name,
-                CoverType = item.Type,
-                CoverExtent = item.Extent,
-                HighestPositionState = item.Position,
-                DescriptionString = item.Desc,
-                ActionDescriptionString = item.Action,
-                MaximumSimultaneousCovers = item.Max,
-                CoverStaysWhileMoving = item.Moving
-            });
+            CreateOrGetRangedCover(context, item.Name, item.Type, item.Extent, item.Position, item.Desc, item.Action, item.Max,
+                item.Moving);
         }
         context.SaveChanges();
 
-        Dictionary<string, RangedCover> coversByName = context.RangedCovers.ToDictionary(x => x.Name, x => x);
-        Dictionary<long, string> tagsById = context.Tags.ToDictionary(x => x.Id, x => x.Name);
-
-        Dictionary<string, string[]> coversForTags = new()
-        {
-            ["Urban"] = new[]
-                {
-                                "Corridor Doorway", "Window Frame",
-                                "Corner", "Street Corner", "Alley Trash Bin"
-                        },
-            ["Rural"] = new[]
-                {
-                                "Tree", "Bush", "Bushy Tree", "Shrubbery", "Fallen Log", "Fallen Tree",
-                                "Old Well"
-                        },
-            ["Terrestrial"] = new[]
-                {
-                                "Uneven Ground", "Large Crater", "Stone Wall", "Rubble Wall", "Small Rock",
-                                "Large Rock", "Boulder Cluster", "Rock Outcropping", "Sand Dune", "Snow Drift",
-                                "Low Hedge", "Thick Hedge", "Tall Grass", "Shrubs", "Fallen Pillar"
-                        },
-            ["Aquatic"] = new[] { "Thick Seaweed" },
-            ["Littoral"] = new[] { "Sand Dune", "Tall Reeds" },
-            ["Riparian"] = new[] { "Tall Reeds", "Dense Vegetation" }
-        };
+        Dictionary<string, RangedCover> coversByName = context.RangedCovers.ToDictionary(x => x.Name, x => x, StringComparer.OrdinalIgnoreCase);
 
         foreach (Terrain? terrain in context.Terrains.ToList())
         {
-			List<string> tagNames = terrain.TagInformation?.Split(',', StringSplitOptions.RemoveEmptyEntries)
-					.Select(x => long.TryParse(x, out long val) && tagsById.ContainsKey(val)
-							? tagsById[val]
-							: null)
-					.OfType<string>()
-					.ToList() ?? new List<string>();
-
             HashSet<long> coverIds = new();
-			foreach (string tag in tagNames)
-			{
-				if (!coversForTags.TryGetValue(tag, out string[]? names))
+            foreach (string name in GetStockRangedCoverNamesForTerrain(context, terrain))
+            {
+                if (coversByName.TryGetValue(name, out RangedCover? cover))
                 {
-                    continue;
-                }
-
-                foreach (string name in names)
-                {
-                    if (coversByName.TryGetValue(name, out RangedCover? cover))
-                    {
-                        coverIds.Add(cover.Id);
-                    }
+                    coverIds.Add(cover.Id);
                 }
             }
 
-            foreach (long id in coverIds)
+            foreach (long id in coverIds.Where(id => !context.TerrainsRangedCovers.Any(x =>
+                         x.TerrainId == terrain.Id &&
+                         x.RangedCoverId == id)))
             {
                 context.TerrainsRangedCovers.Add(new TerrainsRangedCovers
                 {

--- a/Design Documents/World/Celestial_System_Seeder.md
+++ b/Design Documents/World/Celestial_System_Seeder.md
@@ -27,8 +27,11 @@ The seeder now gives calendar-aware epoch guidance instead of assuming Gregorian
 - It resolves the chosen calendar and formats examples using that calendar's authored date style
 - pressing `Enter` on an epoch question accepts the displayed suggested default
 - start-of-year prompts use the first day of the first month in the selected calendar's current year
-- the Earth moon prompt uses day 21 of the first month in the selected calendar's current year as the stock full-moon reference
+- the Earth moon prompt uses day 21 of the selected calendar year as the stock full-moon reference
 - the Ganymede prompt uses the first day of the first month in the selected calendar's current year as the stock epoch-aligned reference
+- all TimeSeeder calendar modes, including the astronomical and historical calendars, must produce non-empty suggested epoch defaults for the sun, moon, Jupiter-facing sun, and Ganymede prompts
+
+Moon and planetary-moon package prompts should give the same quality of context as the Earth-facing sun prompts. The Earth moon questions should explain lunar phases, full-moon reference dates, and why the moon calendar usually matches the Earth-facing sun calendar. The gas giant package questions should explain that the package is a Ganymede viewpoint, that all four linked objects share one calendar, and that its sun and moon epoch dates keep the Jupiter, Ganymede, and Sol views coherent.
 
 Typical examples are:
 
@@ -39,7 +42,7 @@ Typical examples are:
 For the stock packages, the suggested defaults are:
 
 - Earth-facing sun: first day of the first month
-- Earth moon: day 21 of the first month
+- Earth moon: day 21 of the selected calendar year
 - Jupiter-facing sun: first day of the first month
 - Ganymede: first day of the first month
 


### PR DESCRIPTION
## Summary
- populate primary production phase descriptions before the first save
- accept both Butchery and Butchering trait names for animal butchery prerequisites and seeding
- make UsefulSeeder package-state detection marker-based for tags and ranged covers, and let ranged-cover seeding add missing covers/terrain links when item-package covers already exist
- improve Celestial Seeder moon and gas giant prompt context, and cover epoch suggestions across all TimeSeeder calendar modes

## Validation
- `dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore -m:1 --filter 'FullyQualifiedName~CelestialSeederTests|FullyQualifiedName~PrimaryProductionSeederTests|FullyQualifiedName~PrimaryProductionSeederSourceTests|FullyQualifiedName~AnimalButcherySeederTests|FullyQualifiedName~UsefulSeederItemPackageTests|FullyQualifiedName~CoreDataSeederTerrainTests'` - Passed, 60/60
- `git diff --check` - clean, with existing CRLF conversion warnings
- `dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore -m:1` - still fails 13 unrelated tests: blank snapshot manifest latest-migration mismatch, missing Antiquity crafting docs, and uncatalogued Antiquity stable references