### PR TITLE
Fix antiquity seeder craft lookup and save batching

### DIFF
--- a/DatabaseSeeder Unit Tests/ItemSeederAddCraftTests.cs
+++ b/DatabaseSeeder Unit Tests/ItemSeederAddCraftTests.cs
@@ -545,6 +545,35 @@ public class ItemSeederAddCraftTests
 	}
 
 	[TestMethod]
+	public void ItemSeeder_AddCraft_KnowledgeGateResolvesMedicineFromSplitMedicalSkills()
+	{
+		using FuturemudDatabaseContext context = BuildContext();
+		SeedPrerequisites(context);
+		AddSkillTrait(context, 9, "First Aid");
+
+		var craft = new ItemSeeder().AddKnowledgeGatedCraftFromImportsForTesting(
+			context,
+			"test medical knowledge alias craft",
+			"Testing",
+			"Ancient Medical Treatment Supplies",
+			"Medicine",
+			20,
+			BasicPhases(),
+			BasicInputs(),
+			BasicTools(),
+			BasicProducts(),
+			[],
+			knowledgeSubtype: "Treatment Supplies"
+		);
+
+		Assert.AreEqual(9, craft.CheckTraitId);
+		Assert.AreEqual("First Aid", craft.CheckTrait.Name);
+		var appear = context.FutureProgs.Single(x =>
+			x.FunctionName == "ItemSeederAppearKnowledgeAncientMedicalTreatmentSuppliesFirstAid20");
+		Assert.IsTrue(appear.FunctionText.Contains(@"ToTrait(""9"")"));
+	}
+
+	[TestMethod]
 	public void ItemSeeder_AddCraft_KnowledgeGateUpsertsKnowledgeAndChecksKnowledgeOnly()
 	{
 		using FuturemudDatabaseContext context = BuildContext();

--- a/DatabaseSeeder/Seeders/ItemSeeder.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.cs
@@ -81,7 +81,9 @@ The items and crafts are fairly universal and of approximately medieval to renei
     private Dictionary<string, FutureProg> _progs = new(StringComparer.InvariantCultureIgnoreCase);
     private DictionaryWithDefault<string, TraitDefinition> _traits = new(StringComparer.OrdinalIgnoreCase);
     private Dictionary<string, GameItemProto> _items = new(StringComparer.InvariantCultureIgnoreCase);
+	private Dictionary<string, Craft> _craftsByNameAndCategory = new(StringComparer.OrdinalIgnoreCase);
     private long _nextId = 1;
+	private bool _deferCraftProductSave;
 
     private FuturemudDatabaseContext? _context;
     private IReadOnlyDictionary<string, string>? _questionAnswers;
@@ -152,6 +154,12 @@ The items and crafts are fairly universal and of approximately medieval to renei
                 _items[item.UniqueName] = item;
             }
         }
+
+		_craftsByNameAndCategory = _context.Crafts.Local
+			.AsEnumerable()
+			.Concat(_context.Crafts.AsEnumerable())
+			.GroupBy(x => CraftLookupKey(x.Name, x.Category), StringComparer.OrdinalIgnoreCase)
+			.ToDictionary(x => x.Key, x => x.OrderBy(craft => craft.Id).First(), StringComparer.OrdinalIgnoreCase);
     }
 
     MudSharp.Models.GameItemProto? CreateItemLegacy(string noun, string sdesc, string? ldesc, string fdesc, SizeCategory size, ItemQuality quality, double weightInGrams, decimal inherentCost, bool skinnable, bool hideFromPlayers, string material, IEnumerable<string> tags, IEnumerable<string> components)

--- a/DatabaseSeeder/Seeders/ItemSeederCrafting.cs
+++ b/DatabaseSeeder/Seeders/ItemSeederCrafting.cs
@@ -130,6 +130,7 @@ public partial class ItemSeeder
 		["Surviving", "Survival"],
 		["Animal Breeding", "Husbandry"],
 		["Beekeeping", "Beekeeper"],
+		["Medicine", "First Aid", "Healing", "Patient Care", "Diagnosis", "Surgery", "Pharmacology", "Herbalism"],
 		["Law", "Lawyer"],
 		["Labouring", "Labourer", "Laboring", "Laborer"],
 		["Supervising", "Supervisor"],
@@ -1920,6 +1921,7 @@ return ""There is no useful clay that is accessible in the biome you're in.""");
             IsPracticalCheck = true
         };
 		_context!.Crafts.Add(dbitem);
+		_craftsByNameAndCategory[CraftLookupKey(dbitem.Name, dbitem.Category)] = dbitem;
         int i = 1;
         foreach (CraftPhaseSpec phase in spec.Phases)
         {
@@ -1960,7 +1962,10 @@ return ""There is no useful clay that is accessible in the biome you're in.""");
             dbitem.CraftProducts.Add(ConvertToProduct(dbitem, product));
         }
 
-		_context.SaveChanges();
+		if (!_deferCraftProductSave)
+		{
+			_context.SaveChanges();
+		}
         return dbitem;
 	}
 
@@ -1970,14 +1975,16 @@ return ""There is no useful clay that is accessible in the biome you're in.""");
         return match.Product == 0 ? null : Math.Max(0, match.Input - 1);
     }
 
+	private static string CraftLookupKey(string name, string category)
+	{
+		return $"{name.Trim()}\u001F{category.Trim()}";
+	}
+
 	private Craft? FindExistingCraft(string name, string category)
 	{
-		return _context!.Crafts.Local.AsEnumerable().FirstOrDefault(x =>
-			       x.Name.Equals(name, StringComparison.OrdinalIgnoreCase) &&
-			       x.Category.Equals(category, StringComparison.OrdinalIgnoreCase)) ??
-		       _context.Crafts.AsEnumerable().FirstOrDefault(x =>
-			       x.Name.Equals(name, StringComparison.OrdinalIgnoreCase) &&
-			       x.Category.Equals(category, StringComparison.OrdinalIgnoreCase));
+		return _craftsByNameAndCategory.TryGetValue(CraftLookupKey(name, category), out Craft? craft)
+			? craft
+			: null;
 	}
 
 	private IReadOnlyList<CraftValidationError> ValidateCraftSpec(CraftDefinitionSpec spec)
@@ -2173,6 +2180,14 @@ return ""There is no useful clay that is accessible in the biome you're in.""");
 		return text.Replace(@"\", @"\\").Replace("\"", "\\\"");
 	}
 
+	private void SaveFutureProgsIfRequired(params FutureProg[] progs)
+	{
+		if (progs.Any(prog => _context!.Entry(prog).State == EntityState.Added))
+		{
+			_context!.SaveChanges();
+		}
+	}
+
 	private FutureProg EnsureAlwaysTrueProg()
 	{
 		return EnsureFutureProg("AlwaysTrue", "Utility", "General", ProgVariableTypes.Boolean, "",
@@ -2219,7 +2234,10 @@ return ""There is no useful clay that is accessible in the biome you're in.""");
 		knowledge.LearningSessionsRequired = Math.Max(1, learningSessionsRequired);
 		knowledge.CanAcquireProg = alwaysTrueProg;
 		knowledge.CanLearnProg = alwaysTrueProg;
-		_context.SaveChanges();
+		if (_context.Entry(knowledge).State == EntityState.Added)
+		{
+			_context.SaveChanges();
+		}
 		return knowledge;
 	}
 
@@ -2241,7 +2259,7 @@ return ""There is no useful clay that is accessible in the biome you're in.""");
 			[(ProgVariableTypes.Character, "ch")], booleanText);
 		FutureProg whyCannotUseProg = EnsureFutureProg($"ItemSeederWhyCannotUse{suffix}", "Crafting", "Access", ProgVariableTypes.Text, "",
 			[(ProgVariableTypes.Character, "ch")], whyText);
-		_context!.SaveChanges();
+		SaveFutureProgsIfRequired(appearProg, canUseProg, whyCannotUseProg);
 		return (appearProg, canUseProg, whyCannotUseProg, trait);
 	}
 
@@ -2289,7 +2307,7 @@ return ""You need at least {minimumTraitValue.Value.ToString(System.Globalizatio
 			[(ProgVariableTypes.Character, "ch")], booleanText);
 		FutureProg whyCannotUseProg = EnsureFutureProg($"ItemSeederWhyCannotUse{suffix}", "Crafting", "Access", ProgVariableTypes.Text, "",
 			[(ProgVariableTypes.Character, "ch")], whyText);
-		_context!.SaveChanges();
+		SaveFutureProgsIfRequired(appearProg, canUseProg, whyCannotUseProg);
 		return (appearProg, canUseProg, whyCannotUseProg, trait, knowledge);
 	}
 
@@ -2361,43 +2379,52 @@ return ""You need at least {minimumTraitValue.Value.ToString(System.Globalizatio
         // Reset nextID
 		_nextId = _context!.Crafts.Select(x => x.Id).ToList().DefaultIfEmpty(0).Max(x => x) + 1;
 
-		SeedHistoricFoundationCrafts();
-		SeedPrimaryProductionCommodityCrafts();
-		SeedAntiquityHellenicClothingCrafts();
-		SeedAntiquityEgyptianClothingCrafts();
-		SeedAntiquityRomanClothingCrafts();
-		SeedAntiquityCelticClothingCrafts();
-		SeedAntiquityGermanicClothingCrafts();
-		SeedAntiquityKushiteClothingCrafts();
-		SeedAntiquityPunicClothingCrafts();
-		SeedAntiquityPersianClothingCrafts();
-		SeedAntiquityEtruscanClothingCrafts();
-		SeedAntiquityAnatolianClothingCrafts();
-		SeedAntiquityScythianSarmatianClothingCrafts();
-		SeedAntiquityEquipmentCrafts();
-		SeedAntiquityJewelleryCrafts();
-		SeedAntiquityWritingCrafts();
-		SeedAntiquityMedicalCrafts();
-		SeedAntiquityFurnitureAndContainerCrafts();
-		SeedAntiquityRepairKitCrafts();
-		SeedAntiquityLeatherPreparationCrafts();
-		SeedAntiquityLeatherClothingCrafts();
-		SeedAntiquityLeatherArmourCrafts();
-		SeedAntiquityLeatherContainerCrafts();
-		SeedAntiquityLeatherFurnishingCrafts();
-		SeedAntiquityApiaryCrafts();
-		SeedAntiquityAgriculturalProcessingCrafts();
-		SeedAntiquityFoodCrafts();
-		SeedMedievalProductionChainCrafts();
-		SeedMedievalClothingCrafts();
-		SeedMedievalEquipmentCrafts();
-		SeedMedievalWritingAdministrationCrafts();
-		SeedMedievalMedicalApothecaryCrafts();
-		SeedMedievalJewelleryDevotionalCrafts();
-		SeedMedievalFurnitureAndContainerCrafts();
-		SeedMedievalFoodBeverageCrafts();
-		SeedMedievalRepairKitCrafts();
-		SeedMedievalComponentGapCrafts();
+		var previousDeferCraftProductSave = _deferCraftProductSave;
+		_deferCraftProductSave = true;
+		try
+		{
+			SeedHistoricFoundationCrafts();
+			SeedPrimaryProductionCommodityCrafts();
+			SeedAntiquityHellenicClothingCrafts();
+			SeedAntiquityEgyptianClothingCrafts();
+			SeedAntiquityRomanClothingCrafts();
+			SeedAntiquityCelticClothingCrafts();
+			SeedAntiquityGermanicClothingCrafts();
+			SeedAntiquityKushiteClothingCrafts();
+			SeedAntiquityPunicClothingCrafts();
+			SeedAntiquityPersianClothingCrafts();
+			SeedAntiquityEtruscanClothingCrafts();
+			SeedAntiquityAnatolianClothingCrafts();
+			SeedAntiquityScythianSarmatianClothingCrafts();
+			SeedAntiquityEquipmentCrafts();
+			SeedAntiquityJewelleryCrafts();
+			SeedAntiquityWritingCrafts();
+			SeedAntiquityMedicalCrafts();
+			SeedAntiquityFurnitureAndContainerCrafts();
+			SeedAntiquityRepairKitCrafts();
+			SeedAntiquityLeatherPreparationCrafts();
+			SeedAntiquityLeatherClothingCrafts();
+			SeedAntiquityLeatherArmourCrafts();
+			SeedAntiquityLeatherContainerCrafts();
+			SeedAntiquityLeatherFurnishingCrafts();
+			SeedAntiquityApiaryCrafts();
+			SeedAntiquityAgriculturalProcessingCrafts();
+			SeedAntiquityFoodCrafts();
+			SeedMedievalProductionChainCrafts();
+			SeedMedievalClothingCrafts();
+			SeedMedievalEquipmentCrafts();
+			SeedMedievalWritingAdministrationCrafts();
+			SeedMedievalMedicalApothecaryCrafts();
+			SeedMedievalJewelleryDevotionalCrafts();
+			SeedMedievalFurnitureAndContainerCrafts();
+			SeedMedievalFoodBeverageCrafts();
+			SeedMedievalRepairKitCrafts();
+			SeedMedievalComponentGapCrafts();
+		}
+		finally
+		{
+			_deferCraftProductSave = previousDeferCraftProductSave;
+		}
 	}
 
 	private void SeedCraftsLegacy()


### PR DESCRIPTION
## Summary
- Cache existing crafts by name and category to avoid repeated linear lookups during seeding
- Batch craft product persistence while the antiquity and medieval craft seeders run, then save once at the end
- Extend medicine knowledge-gate mapping so split medical skills resolve to the correct trait
- Add coverage for the new medicine knowledge-gate resolution path

## Testing
- Added unit coverage for medicine knowledge-gate resolution from split medical skills
- Not run (not requested)