### PR TITLE
Update seeded item component catalogue for health drug delivery components

### DIFF
--- a/DatabaseSeeder Unit Tests/HealthSeederTests.cs
+++ b/DatabaseSeeder Unit Tests/HealthSeederTests.cs
@@ -13,7 +13,10 @@ using MudSharp.RPG.Checks;
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Drug = MudSharp.Models.Drug;
 using DbFutureProg = MudSharp.Models.FutureProg;
@@ -545,6 +548,29 @@ public class HealthSeederTests
     }
 
     [TestMethod]
+    public void SeededItemComponentCatalogue_IncludesHealthDrugDeliveryComponents()
+    {
+        var healthSource = ReadSource("DatabaseSeeder", "Seeders", "HealthSeeder.cs");
+        var componentCatalogue = ReadSource("Design Documents", "Data", "Seeded_Item_Components.json");
+
+        using var document = JsonDocument.Parse(componentCatalogue);
+        var catalogueNames = document.RootElement
+            .EnumerateArray()
+            .Select(x => x.GetProperty("Component Name").GetString() ?? string.Empty)
+            .Where(x => x.Length > 0)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var missing = ExpectedHealthDrugDeliveryComponentNames(healthSource)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(x => x)
+            .Where(x => !catalogueNames.Contains(x))
+            .ToArray();
+
+        Assert.AreEqual(0, missing.Length,
+            $"Missing HealthSeeder delivery components from Seeded_Item_Components.json: {string.Join(", ", missing)}");
+    }
+
+    [TestMethod]
     public void ShouldSeedData_ModernTierInstallWithoutOtherTiers_ReturnsMayAlreadyInstalled()
     {
         using FuturemudDatabaseContext context = BuildContext();
@@ -642,5 +668,50 @@ public class HealthSeederTests
 
         HealthSeeder seeder = new();
         Assert.AreEqual(ShouldSeedResult.MayAlreadyBeInstalled, seeder.ShouldSeedData(context));
+    }
+
+    private static IEnumerable<string> ExpectedHealthDrugDeliveryComponentNames(string source)
+    {
+        foreach (System.Text.RegularExpressions.Match match in Regex.Matches(source,
+                     @"AddDrug\(""(?<name>[^""]+)"",\s*[^,]+,\s*[^,]+,\s*(?<vectors>DrugVector\.[^,]+),",
+                     RegexOptions.Multiline))
+        {
+            var drugName = match.Groups["name"].Value;
+            var vectors = match.Groups["vectors"].Value;
+            var componentName = SanitizeHealthDrugComponentName(drugName);
+
+            if (vectors.Contains("Ingested", StringComparison.Ordinal))
+            {
+                yield return $"Pill_{componentName}";
+            }
+
+            if (vectors.Contains("Touched", StringComparison.Ordinal))
+            {
+                yield return $"TopicalCream_{componentName}";
+            }
+
+            if (vectors.Contains("Inhaled", StringComparison.Ordinal))
+            {
+                yield return $"Smokeable_{componentName}";
+            }
+        }
+    }
+
+    private static string SanitizeHealthDrugComponentName(string text)
+    {
+        return new string(text.Select(x => char.IsLetterOrDigit(x) ? x : '_').ToArray())
+            .Trim('_')
+            .Replace("__", "_");
+    }
+
+    private static string ReadSource(params string[] parts)
+    {
+        return File.ReadAllText(Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..",
+            "..",
+            "..",
+            "..",
+            Path.Combine(parts))));
     }
 }

--- a/Design Documents/Data/Seeded_Item_Components.json
+++ b/Design Documents/Data/Seeded_Item_Components.json
@@ -3825,6 +3825,11 @@
         "Component Type":  "PencilSharpener"
     },
     {
+        "Component Name":  "Pill_Anticoagulant",
+        "Component Description":  "Turns an item into a pill containing Anticoagulant.",
+        "Component Type":  "Pill"
+    },
+    {
         "Component Name":  "Pill_Antiemetic",
         "Component Description":  "Turns an item into a pill containing Antiemetic.",
         "Component Type":  "Pill"
@@ -3907,6 +3912,11 @@
     {
         "Component Name":  "Pill_Opioid_Analgesic",
         "Component Description":  "Turns an item into a pill containing Opioid Analgesic.",
+        "Component Type":  "Pill"
+    },
+    {
+        "Component Name":  "Pill_Poppy_Latex_Draught",
+        "Component Description":  "Turns an item into a pill containing Poppy Latex Draught.",
         "Component Type":  "Pill"
     },
     {
@@ -4555,6 +4565,16 @@
         "Component Type":  "Smokeable"
     },
     {
+        "Component Name":  "Smokeable_Bronchial_Smoke",
+        "Component Description":  "Turns an item into an inhaled remedy delivering Bronchial Smoke.",
+        "Component Type":  "Smokeable"
+    },
+    {
+        "Component Name":  "Smokeable_Bronchodilator",
+        "Component Description":  "Turns an item into an inhaled remedy delivering Bronchodilator.",
+        "Component Type":  "Smokeable"
+    },
+    {
         "Component Name":  "Smokeable_Cigar",
         "Component Description":  "Turns an item into a longer-burning smokeable tobacco cigar.",
         "Component Type":  "Smokeable"
@@ -4562,6 +4582,26 @@
     {
         "Component Name":  "Smokeable_Cigarillo",
         "Component Description":  "Turns an item into a compact smokeable cigarillo.",
+        "Component Type":  "Smokeable"
+    },
+    {
+        "Component Name":  "Smokeable_Ether_Anaesthetic",
+        "Component Description":  "Turns an item into an inhaled remedy delivering Ether Anaesthetic.",
+        "Component Type":  "Smokeable"
+    },
+    {
+        "Component Name":  "Smokeable_General_Anaesthetic",
+        "Component Description":  "Turns an item into an inhaled remedy delivering General Anaesthetic.",
+        "Component Type":  "Smokeable"
+    },
+    {
+        "Component Name":  "Smokeable_Henbane_Smoke",
+        "Component Description":  "Turns an item into an inhaled remedy delivering Henbane Smoke.",
+        "Component Type":  "Smokeable"
+    },
+    {
+        "Component Name":  "Smokeable_Mandrake_Draught",
+        "Component Description":  "Turns an item into an inhaled remedy delivering Mandrake Draught.",
         "Component Type":  "Smokeable"
     },
     {
@@ -4770,6 +4810,11 @@
         "Component Type":  "Toggle Switch"
     },
     {
+        "Component Name":  "TopicalCream_Aloe_Burn_Salve",
+        "Component Description":  "Turns an item into a topical cream delivering Aloe Burn Salve.",
+        "Component Type":  "TopicalCream"
+    },
+    {
         "Component Name":  "TopicalCream_Antibiotic_Ointment",
         "Component Description":  "Turns an item into a topical cream delivering Antibiotic Ointment.",
         "Component Type":  "TopicalCream"
@@ -4782,6 +4827,11 @@
     {
         "Component Name":  "TopicalCream_Burn_Gel",
         "Component Description":  "Turns an item into a topical cream delivering Burn Gel.",
+        "Component Type":  "TopicalCream"
+    },
+    {
+        "Component Name":  "TopicalCream_Clotting_Agent",
+        "Component Description":  "Turns an item into a topical cream delivering Clotting Agent.",
         "Component Type":  "TopicalCream"
     },
     {
@@ -4817,6 +4867,11 @@
     {
         "Component Name":  "TopicalCream_Mould_Poultice",
         "Component Description":  "Turns an item into a topical cream delivering Mould Poultice.",
+        "Component Type":  "TopicalCream"
+    },
+    {
+        "Component Name":  "TopicalCream_Yarrow_Styptic",
+        "Component Description":  "Turns an item into a topical cream delivering Yarrow Styptic.",
         "Component Type":  "TopicalCream"
     },
     {


### PR DESCRIPTION
## Summary
- Added missing health-related drug delivery components to `Seeded_Item_Components.json`.
- Added a seeder test that derives expected delivery component names from `HealthSeeder` and verifies they are present in the maintained catalogue.
- Kept the catalogue and seeder coverage aligned for pill, smokeable, and topical cream variants.

## Testing
- Not run (not requested)