### PR TITLE
Fix law enforcement patrol diagnostics

### DIFF
--- a/Design Documents/Economy/Law_System_Runtime.md
+++ b/Design Documents/Economy/Law_System_Runtime.md
@@ -152,6 +152,8 @@ Reactive patrol configuration:
 
 Violent-crime classification includes assaults, deadly assaults, battery, murder-family offences, torture, grievous bodily harm, intimidation, resisting arrest, arson, extortion, sexual violence, kidnapping, slavery, animal cruelty, mayhem, and rioting.
 
+When a patrol is actively enforcing a known crime, patrol members are treated as acting under that enforcement authority only against the active target. Assault, battery, and grievous bodily harm reporting is suppressed for arrest-capable enforcement; deadly-force, attempted-murder, murder-family, and mayhem reporting is suppressed only when the active law's enforcement strategy permits lethal force. Execution patrols receive the same protection against their condemned target while the execution no-quit escort is active. This is deliberately narrow: unrelated targets, stale patrol fights, and off-duty enforcer violence still pass through the ordinary automatic crime hooks.
+
 ### Investigation Patrols
 
 The `InvestigationPatrol` strategy dispatches to reported crimes whose trial evidence is still weak: crimes with an unknown criminal identity or incomplete recorded suspect characteristics. The patrol travels to the crime scene, spends its configured search time there, records investigative evidence, and returns.

--- a/Design Documents/Economy/Law_System_Runtime.md
+++ b/Design Documents/Economy/Law_System_Runtime.md
@@ -107,12 +107,14 @@ A PC judge is any enforcer whose enforcement authority has `CanConvict` for the 
 Judge-facing trial commands:
 
 - `trial`: shows the active trial in the current room.
-- `trial docket [jurisdiction]`: lists defendants awaiting trial for the judge's jurisdictions, including remand/bail/trial status, charge IDs, charge names, and prior local convictions.
+- `trial docket [jurisdiction]`: lists defendants awaiting trial for the judge's jurisdictions, including remand/bail/trial status, open charge counts, a compact charge-name summary, wrapped charge ID details, and prior local convictions.
 - `trial summon <target>`: from the jurisdiction courtroom, calls a remand prisoner or present defendant before the court and begins a PC-held trial.
 - `convict <target> <crime> <sentence>`: records a guilty verdict and sentence for one charge.
 - `acquit <target> <crime>`: records a not-guilty verdict for one charge.
 
 `trial summon` uses the same court-transfer mechanics and player-facing emotes as the sheriff's automated trial fetch. It clears remand and enforcer-custody state for that jurisdiction, creates a manual `OnTrial`, and moves the defendant to the court if they are being held in a remand cell. Defendants on bail or at large after bail revocation must first return to custody.
+
+`trial docket` keeps the main table compact by showing the number of open charges and a short grouped charge summary. Charge IDs are printed below the table by defendant and wrapped to the judge's output width, so defendants with many charges do not force the table beyond the terminal.
 
 While any `OnTrial` exists in the court for a legal authority, sheriff patrols will not fetch a new automatic trial for that authority. NPC judge AI also ignores manual trials, so a PC-held trial will not be taken over by the automated judge. Once the PC judge has finalised all known charges with `convict` or `acquit`, the manual trial state is removed and the defendant is released, sent to prison, or sent to holding for execution according to the recorded sentences.
 
@@ -125,6 +127,14 @@ When bail is posted, the `OnBail` effect records a return deadline. The deadline
 When the return deadline expires, the bail heartbeat attempts to record a `ViolateBail` crime, revokes the bail effect, and forfeits the recorded bail on the pending crimes. The defendant becomes arrestable again through ordinary enforcement because the underlying crimes are no longer marked as bailed, but the system does not teleport, summon, try, or convict them while they are at large.
 
 The `trial docket` command distinguishes active bail from bail-revoked at-large defendants so PC judges can see why a person is not currently summonable.
+
+Prisoners can engage legal counsel while physically held in a remand cell, and advocates can hire counsel for remand prisoners from a remand cell as well as from the legal authority's prison location. `engagelawyer list` only lists remand prisoners who do not already have counsel.
+
+## Patrol Route Diagnostics
+
+Inactive patrol-route output reports both whether the route should begin and, when it should not, the first blocking reason. Reasons include routes not marked ready, missing patrol nodes, crime-targeted or corpse-recovery routes waiting for a trigger, strategy-specific configuration or target blockers, a false start prog, no required enforcers, no enforcement zones, or a current time of day outside the route schedule.
+
+The `showenforcers [authority|zone]` admin command reports the enforcer roster for a legal authority or any authority that enforces a specified zone. It includes on-duty state, patrol-pool eligibility, enforcement-authority match, current location, active patrol assignment, and the first reason a listed enforcer cannot be selected for patrol dispatch. The patrol pool requires an NPC with an `EnforcerAI`, an active `EnforcerEffect` for that legal authority, a currently matching enforcement authority, and no active patrol assignment.
 
 ## Crime-Driven Patrol Dispatch
 

--- a/FutureMUDLibrary/RPG/Law/IConfigurablePatrolStrategy.cs
+++ b/FutureMUDLibrary/RPG/Law/IConfigurablePatrolStrategy.cs
@@ -10,4 +10,8 @@ public interface IConfigurablePatrolStrategy : IPatrolStrategy
 	string ShowConfiguration(ICharacter actor, IPatrolRoute patrol);
 	string SaveStrategyData();
 	bool ReadyToBegin(IPatrolRoute patrol);
+	string WhyCannotBegin(IPatrolRoute patrol)
+	{
+		return ReadyToBegin(patrol) ? string.Empty : "The patrol strategy's configuration is not ready.";
+	}
 }

--- a/FutureMUDLibrary/RPG/Law/IPatrolRoute.cs
+++ b/FutureMUDLibrary/RPG/Law/IPatrolRoute.cs
@@ -23,5 +23,6 @@ namespace MudSharp.RPG.Law
         IPatrolStrategy PatrolStrategy { get; }
         bool IsReady { get; }
         bool ShouldBeginPatrol();
+        string WhyCannotBeginPatrol();
     }
 }

--- a/MudSharpCore Unit Tests/LegalCommandPresentationTests.cs
+++ b/MudSharpCore Unit Tests/LegalCommandPresentationTests.cs
@@ -1,0 +1,86 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class LegalCommandPresentationTests
+{
+	[TestMethod]
+	public void EngageLawyer_RemandsCellsAndSelfTarget_ShouldBeSupported()
+	{
+		string source = File.ReadAllText(GetCoreSourcePath("Commands", "Modules", "CrimeModule.cs"));
+		string block = ExtractBlock(source, "protected static void EngageLawyer", "[PlayerCommand(\"PayFine\"");
+
+		StringAssert.Contains(block, "ss.PopSpeech();");
+		StringAssert.Contains(block, "x.IsInRemandCell(actor)");
+		StringAssert.Contains(block, ".Where(x => !x.AffectedBy<HasLegalCounsel>())");
+		StringAssert.Contains(block, "in a remand cell");
+		StringAssert.Contains(block, "\"ENGAGELAWYER LIST\".MXPSend(\"engagelawyer list\")");
+	}
+
+	[TestMethod]
+	public void TrialDocket_LargeChargeLists_ShouldUseBoundedSummaryAndWrappedDetails()
+	{
+		string source = File.ReadAllText(GetCoreSourcePath("Commands", "Modules", "CrimeModule.cs"));
+		string block = ExtractBlock(source, "private static void TrialDocket", "private static void TrialSummon");
+
+		StringAssert.Contains(source, "private static string DescribeTrialDocketChargeSummary");
+		StringAssert.Contains(source, "private static string DescribeTrialDocketCrimeIds");
+		StringAssert.Contains(source, "const int maximumVisibleIds = 8;");
+		StringAssert.Contains(block, "\"Open\",");
+		StringAssert.Contains(block, "\"Charge Summary\",");
+		StringAssert.Contains(block, "Charge IDs by Defendant:");
+		StringAssert.Contains(block, ".Wrap(actor.InnerLineFormatLength, \"\\t\")");
+		Assert.IsFalse(block.Contains("crimes.Select(x => x.Id.ToStringN0(actor)).ListToString()", StringComparison.Ordinal));
+		Assert.IsFalse(block.Contains("crimes.Select(x => x.Name).Distinct().ListToString()", StringComparison.Ordinal));
+	}
+
+	[TestMethod]
+	public void ShowEnforcers_ShouldReportRosterEligibilityAndUsePatrolPoolRules()
+	{
+		string legalModuleSource = File.ReadAllText(GetCoreSourcePath("Commands", "Modules", "LegalModule.cs"));
+		string patrolControllerSource = File.ReadAllText(GetCoreSourcePath("RPG", "Law", "PatrolController.cs"));
+
+		StringAssert.Contains(legalModuleSource, "[PlayerCommand(\"ShowEnforcers\", \"showenforcers\")]");
+		StringAssert.Contains(legalModuleSource, "case \"roster\":");
+		StringAssert.Contains(legalModuleSource, "actor.Gameworld.Zones.GetByIdOrName(targetText)");
+		StringAssert.Contains(legalModuleSource, "private static string WhyCannotJoinPatrolPool");
+		StringAssert.Contains(legalModuleSource, "does not have an Enforcer AI");
+		StringAssert.Contains(legalModuleSource, "\"Duty\"");
+		StringAssert.Contains(legalModuleSource, "\"Pool\"");
+		StringAssert.Contains(legalModuleSource, "\"Authority\"");
+		StringAssert.Contains(legalModuleSource, "Patrol Pool Details:");
+		Assert.IsTrue(legalModuleSource.Contains("Location {item.Location}; Patrol {item.Patrol}; Status {item.Status}", StringComparison.Ordinal));
+		Assert.IsTrue(patrolControllerSource.Contains("npc.AIs.Any(y => y is EnforcerAI)", StringComparison.Ordinal));
+	}
+
+	private static string ExtractBlock(string source, string startMarker, string endMarker)
+	{
+		int start = source.IndexOf(startMarker, StringComparison.Ordinal);
+		Assert.IsTrue(start >= 0, $"Could not find start marker {startMarker}");
+
+		int end = source.IndexOf(endMarker, start, StringComparison.Ordinal);
+		Assert.IsTrue(end > start, $"Could not find end marker {endMarker}");
+
+		return source[start..end];
+	}
+
+	private static string GetCoreSourcePath(params string[] segments)
+	{
+		return Path.GetFullPath(Path.Combine(
+			new[]
+			{
+				AppContext.BaseDirectory,
+				"..",
+				"..",
+				"..",
+				"..",
+				"MudSharpCore"
+			}.Concat(segments).ToArray()));
+	}
+}

--- a/MudSharpCore Unit Tests/LegalPatrolStrategyTests.cs
+++ b/MudSharpCore Unit Tests/LegalPatrolStrategyTests.cs
@@ -92,6 +92,24 @@ public class LegalPatrolStrategyTests
 		StringAssert.Contains(detainedBlock, "if (!leader.CouldMove(false, null).Success)");
 	}
 
+	[TestMethod]
+	public void PatrolRouteDiagnostics_ShouldExposeReasonWhenInactiveRouteCannotBegin()
+	{
+		string routeInterfaceSource = File.ReadAllText(GetLibrarySourcePath("RPG", "Law", "IPatrolRoute.cs"));
+		string configurableStrategySource = File.ReadAllText(GetLibrarySourcePath("RPG", "Law", "IConfigurablePatrolStrategy.cs"));
+		string routeSource = File.ReadAllText(GetCoreSourcePath("RPG", "Law", "PatrolRoute.cs"));
+		string executionStrategySource = File.ReadAllText(GetCoreSourcePath("RPG", "Law", "PatrolStrategies", "ExecutionPatrolStrategy.cs"));
+		string legalModuleSource = File.ReadAllText(GetCoreSourcePath("Commands", "Modules", "LegalModule.cs"));
+
+		StringAssert.Contains(routeInterfaceSource, "string WhyCannotBeginPatrol();");
+		StringAssert.Contains(configurableStrategySource, "string WhyCannotBegin(IPatrolRoute patrol)");
+		StringAssert.Contains(routeSource, "public string WhyCannotBeginPatrol()");
+		StringAssert.Contains(routeSource, "crime-targeted routes wait for a matching reported crime");
+		StringAssert.Contains(routeSource, "the start patrol prog returned false");
+		StringAssert.Contains(executionStrategySource, "there is no due condemned prisoner for this authority");
+		StringAssert.Contains(legalModuleSource, "Reason: {whyCannotBegin.ColourError()}");
+	}
+
 	private static Mock<ICrime> CreateCrime(CrimeTypes crimeType, DateTime realTime, bool known)
 	{
 		var law = new Mock<ILaw>();
@@ -121,6 +139,20 @@ public class LegalPatrolStrategyTests
 				"..",
 				"..",
 				"MudSharpCore"
+			}.Concat(segments).ToArray()));
+	}
+
+	private static string GetLibrarySourcePath(params string[] segments)
+	{
+		return Path.GetFullPath(Path.Combine(
+			new[]
+			{
+				AppContext.BaseDirectory,
+				"..",
+				"..",
+				"..",
+				"..",
+				"FutureMUDLibrary"
 			}.Concat(segments).ToArray()));
 	}
 }

--- a/MudSharpCore Unit Tests/LegalPatrolStrategyTests.cs
+++ b/MudSharpCore Unit Tests/LegalPatrolStrategyTests.cs
@@ -9,6 +9,7 @@ using MudSharp.RPG.Law;
 using MudSharp.RPG.Law.PatrolStrategies;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace MudSharp_Unit_Tests;
@@ -76,6 +77,21 @@ public class LegalPatrolStrategyTests
 		Assert.IsFalse(InvestigationPatrolStrategy.NeedsInvestigation(crime.Object));
 	}
 
+	[TestMethod]
+	public void PatrolTickActiveEnforcement_DragCustody_ClearsCombatBeforePathingToJail()
+	{
+		string source = File.ReadAllText(GetCoreSourcePath("RPG", "Law", "PatrolStrategies", "PatrolStrategyBase.cs"));
+		int detainedStart = source.IndexOf("// Is criminal detained by an enforcer?", StringComparison.Ordinal);
+		int moveToPrison = source.IndexOf("// Move to prison", detainedStart, StringComparison.Ordinal);
+		Assert.IsTrue(detainedStart >= 0);
+		Assert.IsTrue(moveToPrison > detainedStart);
+
+		string detainedBlock = source[detainedStart..moveToPrison];
+		StringAssert.Contains(detainedBlock, "foreach (ICharacter member in patrol.PatrolMembers)");
+		StringAssert.Contains(detainedBlock, "LeaveCombatIfAble(member);");
+		StringAssert.Contains(detainedBlock, "if (!leader.CouldMove(false, null).Success)");
+	}
+
 	private static Mock<ICrime> CreateCrime(CrimeTypes crimeType, DateTime realTime, bool known)
 	{
 		var law = new Mock<ILaw>();
@@ -92,5 +108,19 @@ public class LegalPatrolStrategyTests
 		crime.SetupGet(x => x.RealTimeOfCrime).Returns(realTime);
 		crime.SetupGet(x => x.Law).Returns(law.Object);
 		return crime;
+	}
+
+	private static string GetCoreSourcePath(params string[] segments)
+	{
+		return Path.GetFullPath(Path.Combine(
+			new[]
+			{
+				AppContext.BaseDirectory,
+				"..",
+				"..",
+				"..",
+				"..",
+				"MudSharpCore"
+			}.Concat(segments).ToArray()));
 	}
 }

--- a/MudSharpCore Unit Tests/MovementTests.cs
+++ b/MudSharpCore Unit Tests/MovementTests.cs
@@ -10,6 +10,7 @@ using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
 using MudSharp.Effects.Concrete;
 using MudSharp.Effects.Interfaces;
+using MudSharp.Form.Shape;
 using MudSharp.Framework;
 using MudSharp.Movement;
 using MudSharp.PerceptionEngine;
@@ -114,6 +115,49 @@ public class MovementTests
     }
 
     [TestMethod]
+    public void DescribeBeginMove_DraggedCharacter_DoesNotAlsoShowWalking()
+    {
+        Mock<IFuturemud> gameworld = new();
+        gameworld.Setup(x => x.GetStaticDouble("MaximumMoveTimeMilliseconds")).Returns(1000.0);
+
+        Mock<ICharacter> voyeur = CreateVisibleCharacter("Voyeur", gameworld.Object);
+        Mock<ICharacter> dragger = CreateVisibleCharacter("Enforcer", gameworld.Object);
+        Mock<ICharacter> target = CreateVisibleCharacter("Prisoner", gameworld.Object);
+        Mock<IMoveSpeed> walking = new();
+        walking.SetupGet(x => x.PresentParticiple).Returns("walking");
+        walking.SetupGet(x => x.FirstPersonVerb).Returns("walk");
+        walking.SetupGet(x => x.ThirdPersonVerb).Returns("walks");
+        dragger.SetupGet(x => x.CurrentSpeed).Returns(walking.Object);
+        target.SetupGet(x => x.CurrentSpeed).Returns(walking.Object);
+        voyeur.Setup(x => x.CanSee(dragger.Object, It.IsAny<PerceiveIgnoreFlags>())).Returns(true);
+        voyeur.Setup(x => x.CanSee(target.Object, It.IsAny<PerceiveIgnoreFlags>())).Returns(true);
+        dragger.Setup(x => x.HowSeen(voyeur.Object, false, DescriptionType.Short, true, PerceiveIgnoreFlags.None))
+               .Returns("the enforcer");
+        target.Setup(x => x.HowSeen(voyeur.Object, false, DescriptionType.Short, true, PerceiveIgnoreFlags.None))
+              .Returns("the prisoner");
+
+        Mock<ICellExit> exit = new();
+        exit.SetupGet(x => x.OutboundMovementSuffix).Returns("towards the north");
+        Dragging dragging = new(dragger.Object, null!, target.Object);
+        Movement movement = new(
+            dragger.Object,
+            null!,
+            [dragger.Object],
+            Enumerable.Empty<ICharacter>(),
+            Enumerable.Empty<ICharacter>(),
+            Enumerable.Empty<ICharacter>(),
+            [target.Object],
+            [dragging],
+            exit.Object);
+
+        string description = movement.DescribeBeginMove(voyeur.Object);
+
+        StringAssert.Contains(description, "The enforcer begins dragging the prisoner towards the north.");
+        Assert.IsFalse(description.Contains("the prisoner begins walking"),
+            "Dragged characters should not be echoed as voluntary walkers.");
+    }
+
+    [TestMethod]
     public void FinalStep_ZeroGravityMoverStartsDrift()
     {
         (Movement? movement, Mock<ICharacter>? mover, Mock<ICellExit>? exit, Mock<ICell>? destination, Queue<string>? queuedCommands) = CreateMovementWithMover();
@@ -208,6 +252,23 @@ public class MovementTests
         character.Setup(x => x.EffectsOfType<Dragging>()).Returns([]);
         character.Setup(x => x.Equals(It.IsAny<ICharacter>()))
             .Returns<ICharacter>(other => ReferenceEquals(other, character.Object));
+        return character;
+    }
+
+    private static Mock<ICharacter> CreateVisibleCharacter(string name, IFuturemud gameworld)
+    {
+        var character = new Mock<ICharacter>();
+        character.SetupGet(x => x.Name).Returns(name);
+        character.SetupGet(x => x.FrameworkItemType).Returns("Character");
+        character.SetupGet(x => x.Gameworld).Returns(gameworld);
+        character.SetupGet(x => x.RoomLayer).Returns(RoomLayer.GroundLevel);
+        character.SetupGet(x => x.RidingMount).Returns((ICharacter?)null);
+        character.SetupGet(x => x.Riders).Returns([]);
+        character.Setup(x => x.EffectsOfType<ISneakEffect>(It.IsAny<Predicate<ISneakEffect>>()))
+            .Returns(Enumerable.Empty<ISneakEffect>());
+        character.Setup(x => x.AffectedBy<ISneakMoveEffect>(It.IsAny<Predicate<ISneakMoveEffect>>()))
+            .Returns(false);
+        character.Setup(x => x.IsSelf(It.IsAny<IPerceivable>())).Returns<IPerceivable>(other => ReferenceEquals(other, character.Object));
         return character;
     }
 }

--- a/MudSharpCore Unit Tests/RPG/Law/AutomaticCrimeExtensionsTests.cs
+++ b/MudSharpCore Unit Tests/RPG/Law/AutomaticCrimeExtensionsTests.cs
@@ -226,6 +226,73 @@ public class AutomaticCrimeExtensionsTests
 	}
 
 	[TestMethod]
+	public void IsLawfulEnforcementActionAgainst_ActiveArrestTarget_AllowsAssaultButNotMurder()
+	{
+		Mock<IFuturemud> gameworld = CreateGameworld(out _, out _, out _);
+		Mock<ICell> location = CreateCell(1L, CreateZone(10L).Object);
+		Mock<ICharacter> enforcer = CreateCharacter(20L, gameworld.Object, location.Object);
+		Mock<ICharacter> suspect = CreateCharacter(30L, gameworld.Object, location.Object);
+		Mock<IPatrol> patrol = CreatePatrol(enforcer.Object, suspect.Object, EnforcementStrategy.ArrestAndDetain);
+		PatrolMemberEffect effect = new(enforcer.Object, patrol.Object);
+		enforcer.Setup(x => x.CombinedEffectsOfType<PatrolMemberEffect>()).Returns([effect]);
+		suspect.Setup(x => x.EffectsOfType<ExecutionPatrolNoQuit>(It.IsAny<Predicate<ExecutionPatrolNoQuit>>()))
+		       .Returns(Enumerable.Empty<ExecutionPatrolNoQuit>());
+
+		Assert.IsTrue(enforcer.Object.IsLawfulEnforcementActionAgainst(suspect.Object, CrimeTypes.Assault));
+		Assert.IsFalse(enforcer.Object.IsLawfulEnforcementActionAgainst(suspect.Object, CrimeTypes.Murder));
+	}
+
+	[TestMethod]
+	public void CheckGreviousBodilyHarmForWound_LawfulArrestEnforcement_DoesNotReportCrime()
+	{
+		Mock<IFuturemud> gameworld = CreateGameworld(out Mock<ILegalAuthority> authority, out _, out _);
+		Mock<ICell> location = CreateCell(1L, CreateZone(10L).Object);
+		Mock<ICharacter> enforcer = CreateCharacter(20L, gameworld.Object, location.Object);
+		Mock<ICharacter> suspect = CreateCharacter(30L, gameworld.Object, location.Object);
+		Mock<IPatrol> patrol = CreatePatrol(enforcer.Object, suspect.Object, EnforcementStrategy.ArrestAndDetain);
+		PatrolMemberEffect effect = new(enforcer.Object, patrol.Object);
+		enforcer.Setup(x => x.CombinedEffectsOfType<PatrolMemberEffect>()).Returns([effect]);
+		suspect.Setup(x => x.EffectsOfType<ExecutionPatrolNoQuit>(It.IsAny<Predicate<ExecutionPatrolNoQuit>>()))
+		       .Returns(Enumerable.Empty<ExecutionPatrolNoQuit>());
+		Mock<IWound> wound = new();
+		wound.SetupGet(x => x.Parent).Returns(suspect.Object);
+		wound.SetupGet(x => x.ActorOrigin).Returns(enforcer.Object);
+		wound.SetupGet(x => x.Severity).Returns(WoundSeverity.Grievous);
+		wound.SetupGet(x => x.DamageType).Returns(DamageType.Crushing);
+
+		AutomaticCrimeExtensions.CheckGreviousBodilyHarmForWound(wound.Object);
+
+		authority.Verify(x => x.CheckPossibleCrime(It.IsAny<ICharacter>(), CrimeTypes.GreviousBodilyHarm,
+			It.IsAny<ICharacter>(), It.IsAny<IGameItem>(), It.IsAny<string>(),
+			It.IsAny<IEnumerable<ICharacter>>(), It.IsAny<bool>(), It.IsAny<ICell>()), Times.Never);
+	}
+
+	[TestMethod]
+	public void CheckMurderForDeath_LawfulLethalEnforcement_DoesNotReportCrime()
+	{
+		Mock<IFuturemud> gameworld = CreateGameworld(out Mock<ILegalAuthority> authority, out _, out _);
+		Mock<ICell> deathLocation = CreateCell(1L, CreateZone(10L).Object);
+		Mock<ICharacter> enforcer = CreateCharacter(20L, gameworld.Object, deathLocation.Object);
+		Mock<ICharacter> suspect = CreateCharacter(30L, gameworld.Object, deathLocation.Object);
+		Mock<IPatrol> patrol = CreatePatrol(enforcer.Object, suspect.Object, EnforcementStrategy.LethalForceArrestAndDetain);
+		PatrolMemberEffect effect = new(enforcer.Object, patrol.Object);
+		enforcer.Setup(x => x.CombinedEffectsOfType<PatrolMemberEffect>()).Returns([effect]);
+		suspect.Setup(x => x.EffectsOfType<ExecutionPatrolNoQuit>(It.IsAny<Predicate<ExecutionPatrolNoQuit>>()))
+		       .Returns(Enumerable.Empty<ExecutionPatrolNoQuit>());
+		Mock<IWound> wound = CreateMurderWound(enforcer.Object, null!, WoundSeverity.Horrifying,
+			DateTime.UtcNow.AddMinutes(-5), false);
+		Mock<IBody> body = new();
+		body.SetupGet(x => x.Wounds).Returns([wound.Object]);
+		suspect.SetupGet(x => x.Body).Returns(body.Object);
+
+		AutomaticCrimeExtensions.CheckMurderForDeath(suspect.Object);
+
+		authority.Verify(x => x.CheckPossibleCrime(It.IsAny<ICharacter>(), CrimeTypes.Murder,
+			It.IsAny<ICharacter>(), It.IsAny<IGameItem>(), It.IsAny<string>(),
+			It.IsAny<IEnumerable<ICharacter>>(), It.IsAny<bool>(), It.IsAny<ICell>()), Times.Never);
+	}
+
+	[TestMethod]
 	public void CheckLawfulMovement_TrespassingWouldBeCrime_BlocksMovement()
 	{
 		Mock<IFuturemud> gameworld = CreateGameworld(out Mock<ILegalAuthority> authority, out All<IProperty> properties,
@@ -429,6 +496,20 @@ public class AutomaticCrimeExtensionsTests
 		property.SetupGet(x => x.PropertyLocations).Returns(new[] { location });
 		property.Setup(x => x.HotelRoomForCell(It.IsAny<ICell>())).Returns((IHotelRoom)null!);
 		return property;
+	}
+
+	private static Mock<IPatrol> CreatePatrol(ICharacter enforcer, ICharacter target, EnforcementStrategy strategy)
+	{
+		Mock<ILaw> law = new();
+		law.SetupGet(x => x.EnforcementStrategy).Returns(strategy);
+		Mock<ICrime> crime = new();
+		crime.SetupGet(x => x.Law).Returns(law.Object);
+		Mock<IPatrol> patrol = new();
+		patrol.SetupGet(x => x.Id).Returns(200L);
+		patrol.SetupGet(x => x.PatrolMembers).Returns([enforcer]);
+		patrol.SetupGet(x => x.ActiveEnforcementTarget).Returns(target);
+		patrol.SetupGet(x => x.ActiveEnforcementCrime).Returns(crime.Object);
+		return patrol;
 	}
 
 	private static Mock<IGameItem> CreateItem(long id, string name)

--- a/MudSharpCore/Character/CharacterCombat.cs
+++ b/MudSharpCore/Character/CharacterCombat.cs
@@ -586,7 +586,10 @@ public partial class Character
         {
             if (target is ICharacter tch)
             {
-                CrimeExtensions.CheckPossibleCrimeAllAuthorities(this, CrimeTypes.Assault, tch, null, "");
+                if (!this.IsLawfulEnforcementActionAgainst(tch, CrimeTypes.Assault))
+                {
+                    CrimeExtensions.CheckPossibleCrimeAllAuthorities(this, CrimeTypes.Assault, tch, null, "");
+                }
             }
             else if (target is IGameItem item)
             {

--- a/MudSharpCore/Combat/Moves/RangedWeaponAttackBase.cs
+++ b/MudSharpCore/Combat/Moves/RangedWeaponAttackBase.cs
@@ -304,8 +304,11 @@ public abstract class RangedWeaponAttackBase : CombatMoveBase, IRangedWeaponAtta
 
         if (targetChar is not null)
         {
-            CrimeExtensions.CheckPossibleCrimeAllAuthorities(Assailant, CrimeTypes.AssaultWithADeadlyWeapon, targetChar,
-                null, "");
+            if (!Assailant.IsLawfulEnforcementActionAgainst(targetChar, CrimeTypes.AssaultWithADeadlyWeapon))
+            {
+                CrimeExtensions.CheckPossibleCrimeAllAuthorities(Assailant, CrimeTypes.AssaultWithADeadlyWeapon, targetChar,
+                    null, "");
+            }
         }
         else
         {

--- a/MudSharpCore/Commands/Modules/CombatModule.cs
+++ b/MudSharpCore/Commands/Modules/CombatModule.cs
@@ -1394,7 +1394,8 @@ The syntax:
                 }
             }
 
-            if (CrimeExtensions.HandleCrimesAndLawfulActing(actor, CrimeTypes.AttemptedMurder, target))
+            if (!actor.IsLawfulEnforcementActionAgainst(target, CrimeTypes.AttemptedMurder) &&
+                CrimeExtensions.HandleCrimesAndLawfulActing(actor, CrimeTypes.AttemptedMurder, target))
             {
                 return;
             }
@@ -1410,8 +1411,11 @@ The syntax:
                     actor, target, weapon.Parent)));
             actor.AddEffect(new PreparingCoupDeGrace(actor, weapon, wattack, target) { Emote = emote },
                 TimeSpan.FromSeconds(25));
-            CrimeExtensions.CheckPossibleCrimeAllAuthorities(actor, CrimeTypes.AttemptedMurder, target, weapon.Parent,
-                "");
+            if (!actor.IsLawfulEnforcementActionAgainst(target, CrimeTypes.AttemptedMurder))
+            {
+                CrimeExtensions.CheckPossibleCrimeAllAuthorities(actor, CrimeTypes.AttemptedMurder, target, weapon.Parent,
+                    "");
+            }
             return;
         }
 
@@ -2088,7 +2092,8 @@ The syntax for this command is #3hit <target>#0.", AutoHelp.HelpArgOrNoArg)]
             return;
         }
 
-        if (CrimeExtensions.HandleCrimesAndLawfulActing(actor, CrimeTypes.Assault, target))
+        if (!actor.IsLawfulEnforcementActionAgainst(target, CrimeTypes.Assault) &&
+            CrimeExtensions.HandleCrimesAndLawfulActing(actor, CrimeTypes.Assault, target))
         {
             return;
         }
@@ -2882,7 +2887,8 @@ The syntax is as follows:
                 return;
             }
 
-            if (CrimeExtensions.HandleCrimesAndLawfulActing(actor, CrimeTypes.AssaultWithADeadlyWeapon,
+            if (!actor.IsLawfulEnforcementActionAgainst((ICharacter)aiming.Aim.Target, CrimeTypes.AssaultWithADeadlyWeapon) &&
+                CrimeExtensions.HandleCrimesAndLawfulActing(actor, CrimeTypes.AssaultWithADeadlyWeapon,
                     (ICharacter)aiming.Aim.Target))
             {
                 return;

--- a/MudSharpCore/Commands/Modules/CrimeModule.cs
+++ b/MudSharpCore/Commands/Modules/CrimeModule.cs
@@ -2051,7 +2051,7 @@ The syntax is simply #3returnbail#0.", AutoHelp.HelpArg)]
 
 Once you have engaged a lawyer, they will automatically attend your trial and defend you. The fee paid is taken immediately and cannot be refunded.
 
-You must either be in custody or otherwise at the jurisdiction's prison location to use this command.
+You must either be in custody, in one of the jurisdiction's remand cells, or otherwise at the jurisdiction's prison location to use this command.
 
 The syntax is as follows:
 
@@ -2071,6 +2071,11 @@ The syntax is as follows:
         if (ss.IsFinished || ss.PeekSpeech().EqualTo("me"))
         {
             who = actor;
+            if (!ss.IsFinished)
+            {
+                ss.PopSpeech();
+            }
+
             if (actor.AffectedBy<HasLegalCounsel>())
             {
                 actor.OutputHandler.Send("You already have legal counsel. You must fire your legal counsel before you can engage a new one.");
@@ -2089,19 +2094,23 @@ The syntax is as follows:
         }
         else
         {
-            jurisdiction = actor.Gameworld.LegalAuthorities.FirstOrDefault(x => x.PrisonLocation == actor.Location);
+            jurisdiction = actor.Gameworld.LegalAuthorities.FirstOrDefault(x =>
+                x.PrisonLocation == actor.Location ||
+                x.IsInRemandCell(actor));
             if (jurisdiction is null)
             {
-                actor.OutputHandler.Send($"You are not at the prison location of any legal jurisdiction.");
+                actor.OutputHandler.Send($"You are not at the prison location or in a remand cell of any legal jurisdiction.");
                 return;
             }
 
             List<ICharacter> prisoners = jurisdiction.CellLocations.SelectMany(x => x.Characters)
-                                        .Where(x => x.AffectedBy<AwaitingSentencing>(jurisdiction)).ToList();
+                                        .Where(x => x.AffectedBy<AwaitingSentencing>(jurisdiction))
+                                        .Where(x => !x.AffectedBy<HasLegalCounsel>())
+                                        .ToList();
             string whoText = ss.PopSpeech();
             if (whoText.EqualTo("list"))
             {
-                if (prisoners.All(x => x.AffectedBy<HasLegalCounsel>()))
+                if (!prisoners.Any())
                 {
                     actor.OutputHandler.Send("There are no prisoners in the cells who do not have a lawyer engaged.");
                     return;
@@ -2123,7 +2132,7 @@ The syntax is as follows:
             if (who is null)
             {
                 actor.OutputHandler.Send(
-                    $"There is no such prisoner who does not have legal representation currently on remand. Please see {"ENGAGELAWYER LIST".MXPSend("bailout list")} for a list of prisoners needing legal counsel.");
+                    $"There is no such prisoner who does not have legal representation currently on remand. Please see {"ENGAGELAWYER LIST".MXPSend("engagelawyer list")} for a list of prisoners needing legal counsel.");
                 return;
             }
 
@@ -2396,6 +2405,49 @@ The syntax is as follows:
         return string.Empty;
     }
 
+    private static string DescribeTrialDocketChargeSummary(IEnumerable<ICrime> crimes, IFormatProvider voyeur)
+    {
+        List<string> summaries = crimes
+                                 .GroupBy(x => x.Name)
+                                 .OrderByDescending(x => x.Count())
+                                 .ThenBy(x => x.Key)
+                                 .Select(x => x.Count() == 1 ? x.Key : $"{x.Key} x{x.Count().ToStringN0(voyeur)}")
+                                 .ToList();
+        if (!summaries.Any())
+        {
+            return "None";
+        }
+
+        List<string> visible = summaries.Take(3).ToList();
+        if (summaries.Count > visible.Count)
+        {
+            visible.Add($"{(summaries.Count - visible.Count).ToStringN0(voyeur)} more");
+        }
+
+        return visible.ListToString();
+    }
+
+    private static string DescribeTrialDocketCrimeIds(IEnumerable<ICrime> crimes, IFormatProvider voyeur)
+    {
+        List<string> ids = crimes
+                           .OrderBy(x => x.RealTimeOfCrime)
+                           .Select(x => $"#{x.Id.ToStringN0(voyeur)}")
+                           .ToList();
+        if (!ids.Any())
+        {
+            return "None";
+        }
+
+        const int maximumVisibleIds = 8;
+        List<string> visible = ids.Take(maximumVisibleIds).ToList();
+        if (ids.Count > visible.Count)
+        {
+            visible.Add($"+{(ids.Count - visible.Count).ToStringN0(voyeur)} more");
+        }
+
+        return visible.ListToString();
+    }
+
     private static void TrialDocket(ICharacter actor, StringStack ss)
     {
         List<ILegalAuthority> authorities = JudgementAuthorities(actor);
@@ -2451,8 +2503,8 @@ The syntax is as follows:
                     defendant.PersonalName.GetName(NameStyle.FullName),
                     DescribeTrialDocketStatus(defendant, authority),
                     DescribeTrialDocketSince(defendant, authority),
-                    crimes.Select(x => x.Id.ToStringN0(actor)).ListToString(),
-                    crimes.Select(x => x.Name).Distinct().ListToString(),
+                    crimes.Count.ToStringN0(actor),
+                    DescribeTrialDocketChargeSummary(crimes, actor),
                     priors.ToStringN0(actor)
                 },
                 new List<string>
@@ -2461,13 +2513,24 @@ The syntax is as follows:
                     "Name",
                     "Status",
                     "Since/Due",
-                    "Crime IDs",
-                    "Charges",
+                    "Open",
+                    "Charge Summary",
                     "Priors"
                 },
                 actor,
                 Telnet.Red
             ));
+            sb.AppendLine();
+            sb.AppendLine("Charge IDs by Defendant:");
+            foreach (ICharacter defendant in defendants)
+            {
+                List<ICrime> crimes = authority.KnownCrimesForIndividual(defendant)
+                                               .OrderBy(x => x.RealTimeOfCrime)
+                                               .ToList();
+                sb.AppendLine(
+                    $"\t{defendant.PersonalName.GetName(NameStyle.FullName).ColourName()}: {DescribeTrialDocketCrimeIds(crimes, actor)}"
+                        .Wrap(actor.InnerLineFormatLength, "\t"));
+            }
             sb.AppendLine();
             sb.AppendLine("Use #3crimeinfo <id>#0 for charge details, #3rapsheet <visible target>#0 for full local history, and #3trial summon <target>#0 from the courtroom to begin a PC-held trial.".SubstituteANSIColour());
             sb.AppendLine();

--- a/MudSharpCore/Commands/Modules/LegalModule.cs
+++ b/MudSharpCore/Commands/Modules/LegalModule.cs
@@ -2,9 +2,13 @@
 using MudSharp.Accounts;
 using MudSharp.Celestial;
 using MudSharp.Character;
+using MudSharp.Character.Name;
+using MudSharp.Construction;
 using MudSharp.Economy.Currency;
 using MudSharp.Effects.Concrete;
 using MudSharp.Framework;
+using MudSharp.NPC;
+using MudSharp.NPC.AI;
 using MudSharp.RPG.Law;
 using System;
 using System.Collections.Generic;
@@ -38,6 +42,7 @@ public class LegalModule : Module<ICharacter>
 	#3legal laws [<legal authority>]#0 - shows all the laws
 	#3legal classes [<legal authority>]#0 - shows all the classes
 	#3legal enforcements [<legal authority>]#0 - shows all enforcer authorities
+	#3legal roster [<legal authority>|<zone>]#0 - shows the enforcer roster and patrol eligibility
 	#3legal patrols [<legal authority>]#0 - shows all patrol routes
 	#3legal cancelpatrol <legal authority> <patrol>#0 - cancels an active patrol
 
@@ -102,6 +107,10 @@ You can also use the following options to change the properties of an authority 
             case "enforcements":
                 LegalAuthorityEnforcements(actor, ss);
                 return;
+            case "roster":
+            case "enforcers":
+                LegalAuthorityEnforcerRoster(actor, ss);
+                return;
             case "patrols":
                 LegalAuthorityPatrols(actor, ss);
                 return;
@@ -128,6 +137,218 @@ You can also use the following options to change the properties of an authority 
         }
 
         actor.OutputHandler.Send(LegalAuthorityHelpText.SubstituteANSIColour());
+    }
+
+    private static void LegalAuthorityEnforcerRoster(ICharacter actor, StringStack ss)
+    {
+        ILegalAuthority editing = actor.CombinedEffectsOfType<BuilderEditingEffect<ILegalAuthority>>().FirstOrDefault()?.EditingItem;
+        ShowEnforcerRoster(actor, ss, editing);
+    }
+
+    private static List<ILegalAuthority> GetLegalAuthoritiesForEnforcerRoster(ICharacter actor, StringStack ss,
+        ILegalAuthority defaultAuthority)
+    {
+        if (ss.IsFinished)
+        {
+            if (defaultAuthority is not null)
+            {
+                return new List<ILegalAuthority> { defaultAuthority };
+            }
+
+            return actor.Gameworld.LegalAuthorities.ToList();
+        }
+
+        string targetText = ss.SafeRemainingArgument;
+        ILegalAuthority legal = actor.Gameworld.LegalAuthorities.GetByIdOrName(targetText);
+        if (legal is not null)
+        {
+            return new List<ILegalAuthority> { legal };
+        }
+
+        IZone zone = actor.Gameworld.Zones.GetByIdOrName(targetText);
+        if (zone is null)
+        {
+            actor.OutputHandler.Send(
+                $"The text {targetText.ColourCommand()} is not a valid legal authority or enforcement zone.");
+            return null;
+        }
+
+        List<ILegalAuthority> authorities = actor.Gameworld.LegalAuthorities
+                                                 .Where(x => x.EnforcementZones.Contains(zone))
+                                                 .ToList();
+        if (!authorities.Any())
+        {
+            actor.OutputHandler.Send(
+                $"The zone {zone.Name.ColourName()} is not an enforcement zone for any legal authority.");
+            return null;
+        }
+
+        return authorities;
+    }
+
+    private static bool HasEnforcerAI(ICharacter enforcer)
+    {
+        return enforcer is INPC npc && npc.AIs.Any(x => x is EnforcerAI);
+    }
+
+    private static IPatrol ActivePatrolForEnforcer(ILegalAuthority legal, ICharacter enforcer)
+    {
+        return legal.Patrols.FirstOrDefault(x => x.PatrolMembers.ContainsPhysicalInstance(enforcer));
+    }
+
+    private static string WhyCannotJoinPatrolPool(ILegalAuthority legal, ICharacter enforcer)
+    {
+        if (enforcer is not INPC)
+        {
+            return "not an NPC; automatic patrols only use NPCs";
+        }
+
+        if (!HasEnforcerAI(enforcer))
+        {
+            return "does not have an Enforcer AI";
+        }
+
+        if (!enforcer.AffectedBy<EnforcerEffect>(legal))
+        {
+            return "not currently on duty for this authority";
+        }
+
+        if (legal.GetEnforcementAuthority(enforcer) is null)
+        {
+            return "does not currently match any enforcement authority";
+        }
+
+        IPatrol activePatrol = ActivePatrolForEnforcer(legal, enforcer);
+        if (activePatrol is not null)
+        {
+            return $"already assigned to {activePatrol.PatrolRoute.Name} ({activePatrol.PatrolPhase.DescribeEnum()})";
+        }
+
+        return string.Empty;
+    }
+
+    private static bool IsInPatrolPool(ILegalAuthority legal, ICharacter enforcer)
+    {
+        return string.IsNullOrEmpty(WhyCannotJoinPatrolPool(legal, enforcer));
+    }
+
+    private static IEnumerable<ICharacter> EnforcerRosterCandidates(ICharacter actor, ILegalAuthority legal)
+    {
+        List<ICharacter> activePatrolMembers = legal.Patrols
+                                                   .SelectMany(x => x.PatrolMembers)
+                                                   .DistinctPhysicalInstances()
+                                                   .ToList();
+
+        return actor.Gameworld.Actors
+                    .Where(x =>
+                        x.AffectedBy<EnforcerEffect>(legal) ||
+                        activePatrolMembers.ContainsPhysicalInstance(x) ||
+                        legal.GetEnforcementAuthority(x) is not null)
+                    .DistinctPhysicalInstances();
+    }
+
+    private static string DescribeEnforcerRosterAuthority(ILegalAuthority legal, ICharacter enforcer)
+    {
+        IEnforcementAuthority currentAuthority = legal.GetEnforcementAuthority(enforcer);
+        if (currentAuthority is not null)
+        {
+            return currentAuthority.Name.ColourName();
+        }
+
+        EnforcerEffect effect = enforcer.EffectsOfType<EnforcerEffect>(x => x.LegalAuthority == legal).FirstOrDefault();
+        return effect?.EnforcementAuthority?.Name.ColourError() ?? "None".ColourError();
+    }
+
+    private static string DescribeEnforcerRosterPatrol(ILegalAuthority legal, ICharacter enforcer)
+    {
+        IPatrol activePatrol = ActivePatrolForEnforcer(legal, enforcer);
+        if (activePatrol is null)
+        {
+            return "None";
+        }
+
+        return $"{activePatrol.PatrolRoute.Name.ColourName()} ({activePatrol.PatrolPhase.DescribeEnum().ColourValue()})";
+    }
+
+    private static void ShowEnforcerRoster(ICharacter actor, StringStack ss, ILegalAuthority defaultAuthority = null)
+    {
+        List<ILegalAuthority> authorities = GetLegalAuthoritiesForEnforcerRoster(actor, ss, defaultAuthority);
+        if (authorities is null)
+        {
+            return;
+        }
+
+        StringBuilder sb = new();
+        foreach (ILegalAuthority legal in authorities)
+        {
+            List<(ICharacter Enforcer, bool OnDuty, bool InPool, string Authority, string Location, string Patrol, string Status)> rows =
+                EnforcerRosterCandidates(actor, legal)
+                    .Select(x =>
+                    {
+                        string whyNot = WhyCannotJoinPatrolPool(legal, x);
+                        bool inPool = string.IsNullOrEmpty(whyNot);
+                        return (
+                            Enforcer: x,
+                            OnDuty: x.AffectedBy<EnforcerEffect>(legal),
+                            InPool: inPool,
+                            Authority: DescribeEnforcerRosterAuthority(legal, x),
+                            Location: x.Location?.GetFriendlyReference(actor) ?? "Nowhere".ColourError(),
+                            Patrol: DescribeEnforcerRosterPatrol(legal, x),
+                            Status: inPool ? "eligible for patrol pool".ColourValue() : whyNot.ColourError()
+                        );
+                    })
+                    .OrderByDescending(x => x.InPool)
+                    .ThenByDescending(x => x.OnDuty)
+                    .ThenBy(x => x.Authority.StripANSIColour())
+                    .ThenBy(x => x.Enforcer.HowSeen(actor, flags: PerceiveIgnoreFlags.IgnoreCanSee).StripANSIColour())
+                    .ToList();
+
+            if (sb.Length > 0)
+            {
+                sb.AppendLine();
+            }
+
+            sb.AppendLine($"Enforcer Roster for {legal.Name} Authority".GetLineWithTitleInner(actor, Telnet.BoldBlue, Telnet.BoldWhite));
+            sb.AppendLine();
+            sb.AppendLine($"Enforcement Zones: {legal.EnforcementZones.Select(x => x.Name.ColourName()).DefaultIfEmpty("None".ColourError()).ListToString()}");
+            sb.AppendLine($"Configured Authorities: {legal.EnforcementAuthorities.Select(x => x.Name.ColourName()).DefaultIfEmpty("None".ColourError()).ListToString()}");
+            sb.AppendLine($"On Duty: {rows.Count(x => x.OnDuty).ToStringN0Colour(actor)}");
+            sb.AppendLine($"In Patrol Pool: {rows.Count(x => x.InPool).ToStringN0Colour(actor)}");
+            sb.AppendLine($"Assigned To Patrols: {rows.Count(x => x.Patrol != "None").ToStringN0Colour(actor)}");
+            sb.AppendLine();
+            sb.AppendLine(StringUtilities.GetTextTable(
+                from item in rows
+                select new List<string>
+                {
+                    item.Enforcer.Id.ToStringN0(actor),
+                    item.Enforcer.HowSeen(actor, flags: PerceiveIgnoreFlags.IgnoreCanSee),
+                    item.OnDuty.ToColouredString(),
+                    item.InPool.ToColouredString(),
+                    item.Authority
+                },
+                new List<string>
+                {
+                    "Id",
+                    "Enforcer",
+                    "Duty",
+                    "Pool",
+                    "Authority"
+                },
+                actor,
+                Telnet.Magenta,
+                1,
+                true));
+            sb.AppendLine();
+            sb.AppendLine("Patrol Pool Details:");
+            foreach (var item in rows)
+            {
+                sb.AppendLine(
+                    $"\t#{item.Enforcer.Id.ToStringN0(actor)} {item.Enforcer.PersonalName.GetName(NameStyle.FullName).ColourName()}: Location {item.Location}; Patrol {item.Patrol}; Status {item.Status}"
+                        .Wrap(actor.InnerLineFormatLength, "\t"));
+            }
+        }
+
+        actor.OutputHandler.Send(sb.ToString());
     }
 
     private static void LegalCancelPatrol(ICharacter actor, StringStack ss)
@@ -583,7 +804,7 @@ You can also use the following options to change the properties of an authority 
                           .Where(x =>
                               x.AffectedBy<EnforcerEffect>(legal))
                           .ToList();
-            List<ICharacter> freeEnforcers = enforcers.Where(x => legal.Patrols.All(y => !y.PatrolMembers.ContainsPhysicalInstance(x))).ToList();
+            List<ICharacter> freeEnforcers = enforcers.Where(x => IsInPatrolPool(legal, x)).ToList();
             CollectionDictionary<IEnforcementAuthority, ICharacter> enforcerCounts = new();
             foreach (IGrouping<IEnforcementAuthority, ICharacter> group in freeEnforcers.GroupBy(x => legal.GetEnforcementAuthority(x)))
             {
@@ -626,10 +847,30 @@ You can also use the following options to change the properties of an authority 
                 sb.AppendLine($"Strategy: {patrol.PatrolStrategy.Name.ColourValue()}");
                 sb.AppendLine($"Required Enforcers: {patrol.PatrollerNumbers.Select(x => $"{x.Value.ToStringN0(actor)} {x.Key.Name.Pluralise(x.Value != 1).ColourName()}").ListToString()}");
                 sb.AppendLine($"Is Ready: {patrol.IsReady.ToColouredString()}");
-                sb.AppendLine($"Should Begin: {patrol.ShouldBeginPatrol().ToColouredString()}");
+                string whyCannotBegin = patrol.WhyCannotBeginPatrol();
+                sb.AppendLine($"Should Begin: {string.IsNullOrEmpty(whyCannotBegin).ToColouredString()}");
+                if (!string.IsNullOrEmpty(whyCannotBegin))
+                {
+                    sb.AppendLine($"Reason: {whyCannotBegin.ColourError()}");
+                }
             }
         }
 
         actor.OutputHandler.Send(sb.ToString());
+    }
+
+    [PlayerCommand("ShowEnforcers", "showenforcers")]
+    [CommandPermission(PermissionLevel.JuniorAdmin)]
+    [HelpInfo("showenforcers", @"The #3showenforcers#0 command shows the enforcer roster for a legal authority or enforcement zone, including who is on duty, who is currently eligible for the automatic patrol pool, where they are, and why any listed enforcer cannot join a patrol.
+
+The syntax is:
+
+	#3showenforcers#0 - shows all legal authorities
+	#3showenforcers <legal authority>#0 - shows one legal authority
+	#3showenforcers <zone>#0 - shows authorities that enforce a zone", AutoHelp.HelpArgOrNoArg)]
+    protected static void ShowEnforcers(ICharacter actor, string command)
+    {
+        StringStack ss = new(command.RemoveFirstWord());
+        ShowEnforcerRoster(actor, ss);
     }
 }

--- a/MudSharpCore/Movement/Movement.cs
+++ b/MudSharpCore/Movement/Movement.cs
@@ -582,7 +582,7 @@ public class Movement : IMovement
                          .ToList();
         foreach (Dragging effect in DragEffects)
         {
-            List<ICharacter> draggers = Draggers.Concat(Helpers).Where(x => effect.CharacterDraggers.Contains(x) && voyeur.CanSee(x))
+            List<ICharacter> draggers = Draggers.Concat(Helpers).Where(x => effect.CharacterDraggers.ContainsPhysicalInstance(x) && voyeur.CanSee(x))
                                    .ToList();
             if (!draggers.Any())
             {
@@ -590,7 +590,7 @@ public class Movement : IMovement
             }
 
             sb.AppendLine($"{draggers.Select(x => x.RidingMount is not null ? $"{x.HowSeen(voyeur)} (riding {x.RidingMount.HowSeen(voyeur)})" : x.HowSeen(voyeur)).ListToString()} {(draggers.Count == 1 ? "drags" : "drag")} {effect.Target.HowSeen(voyeur)} {suffix}.".Proper());
-            seenMovers.RemoveAll(x => draggers.Contains(x));
+            RemoveDraggingParticipantsFromSeenMovers(seenMovers, draggers, effect.Target);
         }
 
         if (seenMovers.Count > 0)
@@ -630,7 +630,7 @@ public class Movement : IMovement
                          .ToList();
         foreach (Dragging effect in DragEffects)
         {
-            List<ICharacter> draggers = Draggers.Concat(Helpers).Where(x => effect.CharacterDraggers.Contains(x) && voyeur.CanSee(x))
+            List<ICharacter> draggers = Draggers.Concat(Helpers).Where(x => effect.CharacterDraggers.ContainsPhysicalInstance(x) && voyeur.CanSee(x))
                                    .ToList();
             if (!draggers.Any())
             {
@@ -638,7 +638,7 @@ public class Movement : IMovement
             }
 
             sb.AppendLine($"{draggers.Select(x => x.RidingMount is not null ? $"{x.HowSeen(voyeur)} (riding {x.RidingMount.HowSeen(voyeur)})" : x.HowSeen(voyeur)).ListToString()} {(draggers.Count == 1 && !draggers.First().IsSelf(voyeur) ? "begins" : "begin")} dragging {effect.Target.HowSeen(voyeur)} {suffix}.".Proper());
-            seenMovers.RemoveAll(x => draggers.Contains(x));
+            RemoveDraggingParticipantsFromSeenMovers(seenMovers, draggers, effect.Target);
         }
 
         if (seenMovers.Count > 0)
@@ -675,7 +675,7 @@ public class Movement : IMovement
                          .ToList();
         foreach (Dragging effect in DragEffects)
         {
-            List<ICharacter> draggers = Draggers.Concat(Helpers).Where(x => effect.CharacterDraggers.Contains(x) && voyeur.CanSee(x))
+            List<ICharacter> draggers = Draggers.Concat(Helpers).Where(x => effect.CharacterDraggers.ContainsPhysicalInstance(x) && voyeur.CanSee(x))
                                    .ToList();
             if (!draggers.Any())
             {
@@ -683,7 +683,7 @@ public class Movement : IMovement
             }
 
             sb.AppendLine($"{draggers.Select(x => x.RidingMount is not null ? $"{x.HowSeen(voyeur)} (riding {x.RidingMount.HowSeen(voyeur)})" : x.HowSeen(voyeur)).ListToString()} {(draggers.Count == 1 ? "is" : "are")} dragging {effect.Target.HowSeen(voyeur)} {suffix}.".Proper());
-            seenMovers.RemoveAll(x => draggers.Contains(x));
+            RemoveDraggingParticipantsFromSeenMovers(seenMovers, draggers, effect.Target);
         }
 
         if (seenMovers.Count > 0)
@@ -707,6 +707,12 @@ public class Movement : IMovement
         }
 
         return sb.ToString().StripANSIColour().Colour(Telnet.Yellow);
+    }
+
+    private static void RemoveDraggingParticipantsFromSeenMovers(List<ICharacter> seenMovers, IEnumerable<ICharacter> draggers, IPerceivable target)
+    {
+        seenMovers.RemoveAll(x => draggers.ContainsPhysicalInstance(x) ||
+                                  CharacterInstanceIdentityComparer.SamePhysicalInstanceOrBody(x, target));
     }
 
     /// <inheritdoc />

--- a/MudSharpCore/NPC/AI/EnforcerAI.cs
+++ b/MudSharpCore/NPC/AI/EnforcerAI.cs
@@ -429,8 +429,12 @@ public class EnforcerAI : ArtificialIntelligenceBase
             return true;
         }
 
-        // Pause AI while moving or in combat
-        if (enforcer.Movement != null || enforcer.Combat != null)
+        // Pause AI while moving or in unrelated combat
+        if (enforcer.Movement != null ||
+            enforcer.Combat != null &&
+            enforcer.CombinedEffectsOfType<PatrolMemberEffect>().All(x =>
+                x.Patrol?.ActiveEnforcementTarget is null ||
+                enforcer.CombatTarget != x.Patrol.ActiveEnforcementTarget))
         {
             return true;
         }

--- a/MudSharpCore/RPG/Law/AutomaticCrimeExtensions.cs
+++ b/MudSharpCore/RPG/Law/AutomaticCrimeExtensions.cs
@@ -24,6 +24,11 @@ public static class AutomaticCrimeExtensions
 	public static bool HandleCrimeAndLawfulActing(IFuturemud gameworld, ICharacter criminal, CrimeTypes crime,
 		ICharacter victim = null, IGameItem target = null, string additionalInformation = "", ICell crimeLocation = null)
 	{
+		if (victim is not null && criminal.IsLawfulEnforcementActionAgainst(victim, crime))
+		{
+			return false;
+		}
+
 		if (criminal.IsAdministrator())
 		{
 			return false;
@@ -47,6 +52,11 @@ public static class AutomaticCrimeExtensions
 	public static bool CheckWouldBeACrime(IFuturemud gameworld, ICharacter criminal, CrimeTypes crime,
 		ICharacter victim = null, IGameItem target = null, string additionalInformation = "", ICell crimeLocation = null)
 	{
+		if (victim is not null && criminal.IsLawfulEnforcementActionAgainst(victim, crime))
+		{
+			return false;
+		}
+
 		foreach (var authority in gameworld.LegalAuthorities)
 		{
 			var isCrime = crimeLocation is null
@@ -65,6 +75,11 @@ public static class AutomaticCrimeExtensions
 		ICharacter victim = null, IGameItem target = null, string additionalInformation = "",
 		IEnumerable<ICharacter> witnesses = null, bool notifyVictim = true, ICell crimeLocation = null)
 	{
+		if (victim is not null && criminal.IsLawfulEnforcementActionAgainst(victim, crime))
+		{
+			return;
+		}
+
 		foreach (var authority in gameworld.LegalAuthorities)
 		{
 			if (crimeLocation is null)

--- a/MudSharpCore/RPG/Law/EnforcementCrimeExtensions.cs
+++ b/MudSharpCore/RPG/Law/EnforcementCrimeExtensions.cs
@@ -1,0 +1,92 @@
+using MudSharp.Character;
+using MudSharp.Effects.Concrete;
+using System.Linq;
+
+#nullable enable
+
+namespace MudSharp.RPG.Law;
+
+public static class EnforcementCrimeExtensions
+{
+	public static bool IsLawfulEnforcementActionAgainst(this ICharacter actor, ICharacter victim, CrimeTypes crime)
+	{
+		if (actor is null ||
+		    victim is null ||
+		    CharacterInstanceIdentityComparer.SamePhysicalInstance(actor, victim))
+		{
+			return false;
+		}
+
+		foreach (var patrolEffect in actor.CombinedEffectsOfType<PatrolMemberEffect>() ??
+		                             Enumerable.Empty<PatrolMemberEffect>())
+		{
+			var patrol = patrolEffect.Patrol;
+			if (patrol is null || !patrol.PatrolMembers.ContainsPhysicalInstance(actor))
+			{
+				continue;
+			}
+
+			if (IsActiveEnforcementTarget(victim, patrol) &&
+			    IsAuthorisedByEnforcementStrategy(crime, patrol.ActiveEnforcementCrime!.Law.EnforcementStrategy))
+			{
+				return true;
+			}
+
+			if (IsExecutionTarget(victim, patrol) && IsAuthorisedExecutionCrime(crime))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static bool IsActiveEnforcementTarget(ICharacter victim, IPatrol patrol)
+	{
+		return patrol.ActiveEnforcementTarget is not null &&
+		       patrol.ActiveEnforcementCrime?.Law is not null &&
+		       CharacterInstanceIdentityComparer.SamePhysicalInstance(victim, patrol.ActiveEnforcementTarget);
+	}
+
+	private static bool IsExecutionTarget(ICharacter victim, IPatrol patrol)
+	{
+		return victim.EffectsOfType<ExecutionPatrolNoQuit>(x => x.Patrol == patrol)?.Any() == true;
+	}
+
+	private static bool IsAuthorisedByEnforcementStrategy(CrimeTypes crime, EnforcementStrategy strategy)
+	{
+		switch (crime)
+		{
+			case CrimeTypes.Assault:
+			case CrimeTypes.Battery:
+			case CrimeTypes.GreviousBodilyHarm:
+				return strategy.IsArrestable() || strategy.IsKillable();
+			case CrimeTypes.AssaultWithADeadlyWeapon:
+			case CrimeTypes.AttemptedMurder:
+			case CrimeTypes.Manslaughter:
+			case CrimeTypes.Murder:
+			case CrimeTypes.Mayhem:
+				return strategy.IsKillable();
+			default:
+				return false;
+		}
+	}
+
+	private static bool IsAuthorisedExecutionCrime(CrimeTypes crime)
+	{
+		switch (crime)
+		{
+			case CrimeTypes.Assault:
+			case CrimeTypes.AssaultWithADeadlyWeapon:
+			case CrimeTypes.Battery:
+			case CrimeTypes.AttemptedMurder:
+			case CrimeTypes.Manslaughter:
+			case CrimeTypes.Murder:
+			case CrimeTypes.GreviousBodilyHarm:
+			case CrimeTypes.Mayhem:
+				return true;
+			default:
+				return false;
+		}
+	}
+}

--- a/MudSharpCore/RPG/Law/PatrolController.cs
+++ b/MudSharpCore/RPG/Law/PatrolController.cs
@@ -1,6 +1,8 @@
 ﻿using MudSharp.Character;
 using MudSharp.Effects.Concrete;
 using MudSharp.Framework;
+using MudSharp.NPC;
+using MudSharp.NPC.AI;
 using MudSharp.RPG.Law.PatrolStrategies;
 using MudSharp.Server;
 using System;
@@ -55,6 +57,8 @@ public class PatrolController : IPatrolController
             LegalAuthority.Gameworld.NPCs
                           .Where(x =>
                               x.AffectedBy<EnforcerEffect>(LegalAuthority) &&
+                              x is INPC npc &&
+                              npc.AIs.Any(y => y is EnforcerAI) &&
                               LegalAuthority.GetEnforcementAuthority(x) is not null &&
                               LegalAuthority.Patrols.All(y => !y.PatrolMembers.ContainsPhysicalInstance(x))
                           )

--- a/MudSharpCore/RPG/Law/PatrolRoute.cs
+++ b/MudSharpCore/RPG/Law/PatrolRoute.cs
@@ -163,16 +163,62 @@ public class PatrolRoute : SaveableItem, IPatrolRoute, IEditableItem
 
     public bool ShouldBeginPatrol()
     {
-        return
-            IsReady &&
-            PatrolNodes.Any() &&
-            PatrolStrategy is not ICrimeTargetedPatrolStrategy &&
-            PatrolStrategy is not CorpseRecoveryPatrolStrategy &&
-            (PatrolStrategy as IConfigurablePatrolStrategy)?.ReadyToBegin(this) != false &&
-            StartPatrolProg?.Execute<bool?>() != false &&
-            PatrollerNumbers.Any() &&
-            LegalAuthority.EnforcementZones.Any() &&
-            TimeOfDays.Contains(LegalAuthority.EnforcementZones.First().CurrentTimeOfDay);
+        return string.IsNullOrEmpty(WhyCannotBeginPatrol());
+    }
+
+    public string WhyCannotBeginPatrol()
+    {
+        if (!IsReady)
+        {
+            return "the route is not marked ready";
+        }
+
+        if (!PatrolNodes.Any())
+        {
+            return "the route has no patrol nodes";
+        }
+
+        if (PatrolStrategy is ICrimeTargetedPatrolStrategy)
+        {
+            return "crime-targeted routes wait for a matching reported crime";
+        }
+
+        if (PatrolStrategy is CorpseRecoveryPatrolStrategy)
+        {
+            return "corpse recovery routes wait for a pending corpse recovery report";
+        }
+
+        if (PatrolStrategy is IConfigurablePatrolStrategy configurable)
+        {
+            var strategyReason = configurable.WhyCannotBegin(this);
+            if (!string.IsNullOrEmpty(strategyReason))
+            {
+                return strategyReason;
+            }
+        }
+
+        if (StartPatrolProg?.Execute<bool?>() == false)
+        {
+            return "the start patrol prog returned false";
+        }
+
+        if (!PatrollerNumbers.Any())
+        {
+            return "the route does not require any enforcers";
+        }
+
+        if (!LegalAuthority.EnforcementZones.Any())
+        {
+            return "the legal authority has no enforcement zones";
+        }
+
+        var currentTimeOfDay = LegalAuthority.EnforcementZones.First().CurrentTimeOfDay;
+        if (!TimeOfDays.Contains(currentTimeOfDay))
+        {
+            return $"the current time of day ({currentTimeOfDay.Describe()}) is not one of the route's allowed times";
+        }
+
+        return string.Empty;
     }
 
     public int Priority { get; protected set; }

--- a/MudSharpCore/RPG/Law/PatrolStrategies/ExecutionPatrolStrategy.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/ExecutionPatrolStrategy.cs
@@ -167,10 +167,32 @@ public class ExecutionPatrolStrategy : PatrolStrategyBase, IConfigurablePatrolSt
 
 	public bool ReadyToBegin(IPatrolRoute patrol)
 	{
-		return GetExecutionLocation(patrol) is not null &&
-			   ConfigurationIsComplete() &&
-			   patrol.LegalAuthority.Patrols.All(x => x.PatrolStrategy.Name != Name) &&
-			   SelectDueCondemned(patrol.LegalAuthority) is not null;
+		return string.IsNullOrEmpty(WhyCannotBegin(patrol));
+	}
+
+	public string WhyCannotBegin(IPatrolRoute patrol)
+	{
+		if (GetExecutionLocation(patrol) is null)
+		{
+			return "the first patrol node must be the execution location";
+		}
+
+		if (!ConfigurationIsComplete())
+		{
+			return "the execution method configuration is incomplete";
+		}
+
+		if (patrol.LegalAuthority.Patrols.Any(x => x.PatrolStrategy.Name == Name))
+		{
+			return "there is already an active execution patrol for this authority";
+		}
+
+		if (SelectDueCondemned(patrol.LegalAuthority) is null)
+		{
+			return "there is no due condemned prisoner for this authority";
+		}
+
+		return string.Empty;
 	}
 
 	private bool ConfigurationIsComplete()

--- a/MudSharpCore/RPG/Law/PatrolStrategies/PatrolStrategyBase.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/PatrolStrategyBase.cs
@@ -207,6 +207,14 @@ public abstract class PatrolStrategyBase : IPatrolStrategy
         }
     }
 
+    private static void LeaveCombatIfAble(ICharacter member)
+    {
+        if (member.Combat?.CanFreelyLeaveCombat(member) == true)
+        {
+            member.Combat.LeaveCombat(member);
+        }
+    }
+
     protected virtual void PatrolTickActiveEnforcement(IPatrol patrol)
     {
         ICharacter criminal = patrol.ActiveEnforcementTarget;
@@ -245,6 +253,11 @@ public abstract class PatrolStrategyBase : IPatrolStrategy
         if (patrol.PatrolMembers.Any(x => x.CombinedEffectsOfType<Dragging>().Any(x => x.Target == criminal)))
         {
             // Get rest of team to join drag
+            foreach (ICharacter member in patrol.PatrolMembers)
+            {
+                LeaveCombatIfAble(member);
+            }
+
             if (!leader.CouldMove(false, null).Success)
             {
                 return;
@@ -327,21 +340,27 @@ public abstract class PatrolStrategyBase : IPatrolStrategy
         if (criminal.IsHelpless)
         {
             // Grab the criminal
-            ICharacter random = patrol.PatrolMembers.GetRandomElement();
-            if (random.Combat?.CanFreelyLeaveCombat(random) == true)
+            ICharacter random = patrol.PatrolMembers
+                                       .Where(x => x.ColocatedWith(criminal))
+                                       .Where(x => x.State.IsAble())
+                                       .FirstOrDefault(x => x.SamePhysicalInstance(leader)) ??
+                                patrol.PatrolMembers
+                                      .Where(x => x.ColocatedWith(criminal))
+                                      .Where(x => x.State.IsAble())
+                                      .GetRandomElement();
+            if (random is null)
             {
-                random.Combat?.LeaveCombat(random);
+                return;
             }
+
+            LeaveCombatIfAble(random);
 
             random.ExecuteCommand($"drag {random.BestKeywordFor(criminal)}");
             if (random.CombinedEffectsOfType<Dragging>().Any(x => x.Target == criminal))
             {
                 foreach (ICharacter other in patrol.PatrolMembers.Where(x => !x.SamePhysicalInstance(random)))
                 {
-                    if (other.Combat?.CanFreelyLeaveCombat(other) == true)
-                    {
-                        other.Combat?.LeaveCombat(other);
-                    }
+                    LeaveCombatIfAble(other);
 
                     other.ExecuteCommand($"drag help {other.BestKeywordFor(random)}");
                 }


### PR DESCRIPTION
Summary: Fixes enforcement patrol custody movement/drag text/crime immunity, remand lawyer hiring, compact trial docket formatting, patrol start reasons, and adds showenforcers/legal roster diagnostics for patrol-pool eligibility. Validation: dotnet build MudSharpCore Unit Tests project; targeted legal/movement tests passed 37; dotnet build MudSharpCore project; git diff --check clean except LF-to-CRLF warnings.