### PR TITLE
Fix law trial remand payment issues

### DIFF
--- a/DatabaseSeeder Unit Tests/SeederRepeatabilityHelperTests.cs
+++ b/DatabaseSeeder Unit Tests/SeederRepeatabilityHelperTests.cs
@@ -450,6 +450,34 @@ public class SeederRepeatabilityHelperTests
     }
 
     [TestMethod]
+    public void LawSeeder_SeedData_AutomaticViolentLawsSuppressRepeats()
+    {
+        using FuturemudDatabaseContext context = BuildContext();
+        AddLawSeederPrerequisites(context);
+
+        SeedLawSeeder(context);
+
+        CrimeTypes[] violentCrimeTypes =
+        [
+            CrimeTypes.Assault,
+            CrimeTypes.GreviousBodilyHarm,
+            CrimeTypes.Murder
+        ];
+
+        foreach (CrimeTypes crimeType in violentCrimeTypes)
+        {
+            List<Law> laws = context.Laws
+                                    .Where(x => x.CrimeType == (int)crimeType)
+                                    .Where(x => x.CanBeAppliedAutomatically)
+                                    .ToList();
+
+            Assert.IsTrue(laws.Any(), $"Expected at least one automatic law for {crimeType}.");
+            Assert.IsTrue(laws.All(x => x.DoNotAutomaticallyApplyRepeats),
+                $"Expected automatic {crimeType} laws to suppress repeated applications.");
+        }
+    }
+
+    [TestMethod]
     public void LawSeeder_SeedData_Tiered_SplitsVictimBasedCrimesAndLeavesVictimlessCrimesFlat()
     {
         using FuturemudDatabaseContext context = BuildContext();

--- a/DatabaseSeeder/Seeders/LawSeeder.cs
+++ b/DatabaseSeeder/Seeders/LawSeeder.cs
@@ -1666,7 +1666,7 @@ return true",
         law.CanBeAppliedAutomatically = context.Automatic;
         law.CanBeArrested = context.CanBeArrested;
         law.CanBeOfferedBail = context.CanBeOfferedBail;
-        law.DoNotAutomaticallyApplyRepeats = context.NoRepeats;
+        law.DoNotAutomaticallyApplyRepeats = context.NoRepeats || (context.Automatic && type.IsViolentCrime());
         law.EnforcementPriority = DefaultEnforcementPriority(type);
         law.ActivePeriod = DefaultActivePeriod(type).TotalSeconds;
         law.EnforcementStrategy = enforcement.DescribeEnum();

--- a/Design Documents/Economy/Law_System_Runtime.md
+++ b/Design Documents/Economy/Law_System_Runtime.md
@@ -6,7 +6,7 @@ This document records the current runtime behavior of the legal authority, sente
 
 ## Automatic Crime Application
 
-Automatic enforcement is opt-in per law. A law only applies from coded hooks when `law auto` is enabled, the offender and victim legal-class filters pass, and the optional law prog returns true. `law repeat` controls whether repeated automatic applications against the same law, target, object, and location are suppressed for the short repeat window.
+Automatic enforcement is opt-in per law. A law only applies from coded hooks when `law auto` is enabled, the offender and victim legal-class filters pass, and the optional law prog returns true. `law repeat` controls whether repeated automatic applications against the same law, target, object, and location are suppressed for the short repeat window. Violent victim-targeted automatic crimes are additionally treated as encounter repeats for the same offender and victim during that window, so a single fight does not create fresh assault or grievous-bodily-harm counts for every blow, weapon, or room transition.
 
 Automatic crime hooks now pass a context text string to the crime record and to law progs that opt into the extended signatures. Existing law prog signatures continue to receive the crime name as their text argument. Builders can use the extended `text text` signatures to receive both the crime name and the automatic context.
 
@@ -128,7 +128,7 @@ When the return deadline expires, the bail heartbeat attempts to record a `Viola
 
 The `trial docket` command distinguishes active bail from bail-revoked at-large defendants so PC judges can see why a person is not currently summonable.
 
-Prisoners can engage legal counsel while physically held in a remand cell, and advocates can hire counsel for remand prisoners from a remand cell as well as from the legal authority's prison location. `engagelawyer list` only lists remand prisoners who do not already have counsel.
+Prisoners can engage legal counsel while physically held in a remand cell, and advocates can hire counsel for remand prisoners from a remand cell as well as from the legal authority's prison location. `engagelawyer list` only lists remand prisoners who do not already have counsel. When a remand prisoner hires counsel for themselves without specifying a bank account, the cash payment can draw from their carried cash and from the prison-belongings bundle stored for that legal authority, allowing legal fees to be paid from money confiscated during remand intake.
 
 ## Patrol Route Diagnostics
 

--- a/MudSharpCore Unit Tests/LegalCommandPresentationTests.cs
+++ b/MudSharpCore Unit Tests/LegalCommandPresentationTests.cs
@@ -21,6 +21,9 @@ public class LegalCommandPresentationTests
 		StringAssert.Contains(block, ".Where(x => !x.AffectedBy<HasLegalCounsel>())");
 		StringAssert.Contains(block, "in a remand cell");
 		StringAssert.Contains(block, "\"ENGAGELAWYER LIST\".MXPSend(\"engagelawyer list\")");
+		StringAssert.Contains(block, "PrisonerBelongingsBundles(jurisdiction, actor)");
+		StringAssert.Contains(block, "actor.Body.ExternalItems.Concat(remandBelongings)");
+		StringAssert.Contains(block, "remand belongings");
 	}
 
 	[TestMethod]

--- a/MudSharpCore Unit Tests/LegalTrialFlowTests.cs
+++ b/MudSharpCore Unit Tests/LegalTrialFlowTests.cs
@@ -7,12 +7,15 @@ using MudSharp.Construction;
 using MudSharp.Effects;
 using MudSharp.Effects.Concrete;
 using MudSharp.Framework;
+using MudSharp.Framework.Save;
 using MudSharp.FutureProg;
+using MudSharp.PerceptionEngine;
 using MudSharp.RPG.Law;
 using MudSharp.TimeAndDate;
 using System;
 using System.Collections.Generic;
 using System.Xml.Linq;
+using DbCrime = MudSharp.Models.Crime;
 
 namespace MudSharp_Unit_Tests;
 
@@ -152,5 +155,49 @@ public class LegalTrialFlowTests
 
 		Assert.IsTrue(authority.Object.IsInRemandCell(character.Object));
 		Assert.IsFalse(authority.Object.IsInRemandCell(otherCharacter.Object));
+	}
+
+	[TestMethod]
+	public void CrimeDescribeCrimeAtTrial_MissingVictim_ShouldUseUnnamedVictim()
+	{
+		Mock<ICellOverlay> overlay = new();
+		overlay.SetupGet(x => x.CellName).Returns("The Entrance to Easy Street");
+
+		Mock<ICell> location = new();
+		location.SetupGet(x => x.Id).Returns(1L);
+		location.SetupGet(x => x.CurrentOverlay).Returns(overlay.Object);
+
+		All<ICell> cells = new();
+		cells.Add(location.Object);
+
+		Mock<IFuturemud> gameworld = new();
+		gameworld.SetupGet(x => x.Cells).Returns(cells);
+		gameworld.SetupGet(x => x.SaveManager).Returns(new Mock<ISaveManager>().Object);
+
+		Mock<ILaw> law = new();
+		law.SetupGet(x => x.Id).Returns(10L);
+		law.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		law.SetupGet(x => x.CrimeType).Returns(CrimeTypes.GreviousBodilyHarm);
+
+		Crime crime = new(new DbCrime
+		{
+			Id = 20L,
+			LawId = 10L,
+			CriminalId = 30L,
+			VictimId = 40L,
+			LocationId = 1L,
+			TimeOfCrime = MudDateTime.Never.GetDateTimeString(),
+			RealTimeOfCrime = DateTime.UtcNow,
+			CriminalShortDescription = "a defendant",
+			CriminalFullDescription = "A defendant is here.",
+			CriminalCharacteristics = string.Empty,
+			WitnessIds = string.Empty
+		}, law.Object, gameworld.Object);
+
+		string description = crime.DescribeCrimeAtTrial(new Mock<IPerceiver>().Object);
+
+		StringAssert.Contains(description,
+			"caused grievous bodily harm to an unnamed victim at The Entrance to Easy Street");
+		Assert.IsFalse(description.Contains("to at", StringComparison.OrdinalIgnoreCase));
 	}
 }

--- a/MudSharpCore Unit Tests/RPG/Law/LegalAuthorityRepeatSuppressionTests.cs
+++ b/MudSharpCore Unit Tests/RPG/Law/LegalAuthorityRepeatSuppressionTests.cs
@@ -1,0 +1,126 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.GameItems;
+using MudSharp.RPG.Law;
+using System;
+
+namespace MudSharp_Unit_Tests.RPG.Law;
+
+[TestClass]
+public class LegalAuthorityRepeatSuppressionTests
+{
+	[TestMethod]
+	public void ShouldSuppressAutomaticRepeatCrime_ViolentSameVictimDifferentWeaponAndLocation_Suppresses()
+	{
+		DateTime now = DateTime.UtcNow;
+		Mock<ILaw> law = CreateLaw(1L, CrimeTypes.GreviousBodilyHarm, doNotRepeat: false);
+		Mock<ICharacter> victim = CreateCharacter(10L);
+		Mock<IGameItem> newWeapon = CreateItem(22L, "weapon");
+		Mock<ICell> newLocation = CreateCell(32L);
+		Mock<ICrime> existingCrime = CreateCrime(law.Object, 10L, now.AddMinutes(-2), 21L, "weapon",
+			CreateCell(31L).Object);
+
+		bool result = LegalAuthority.ShouldSuppressAutomaticRepeatCrime(law.Object, [existingCrime.Object],
+			victim.Object, newWeapon.Object, newLocation.Object, now);
+
+		Assert.IsTrue(result);
+	}
+
+	[TestMethod]
+	public void ShouldSuppressAutomaticRepeatCrime_NonViolentRepeatDisabled_DoesNotSuppress()
+	{
+		DateTime now = DateTime.UtcNow;
+		Mock<ILaw> law = CreateLaw(1L, CrimeTypes.Theft, doNotRepeat: false);
+		Mock<ICharacter> victim = CreateCharacter(10L);
+		Mock<IGameItem> item = CreateItem(20L, "GameItem");
+		Mock<ICell> location = CreateCell(30L);
+		Mock<ICrime> existingCrime = CreateCrime(law.Object, 10L, now.AddMinutes(-2), 20L, "GameItem",
+			location.Object);
+
+		bool result = LegalAuthority.ShouldSuppressAutomaticRepeatCrime(law.Object, [existingCrime.Object],
+			victim.Object, item.Object, location.Object, now);
+
+		Assert.IsFalse(result);
+	}
+
+	[TestMethod]
+	public void ShouldSuppressAutomaticRepeatCrime_NonViolentRepeatEnabledSameItemAndLocation_Suppresses()
+	{
+		DateTime now = DateTime.UtcNow;
+		Mock<ILaw> law = CreateLaw(1L, CrimeTypes.Theft, doNotRepeat: true);
+		Mock<ICharacter> victim = CreateCharacter(10L);
+		Mock<IGameItem> item = CreateItem(20L, "GameItem");
+		Mock<ICell> existingLocation = CreateCell(30L);
+		Mock<ICell> newLocation = CreateCell(30L);
+		Mock<ICrime> existingCrime = CreateCrime(law.Object, 10L, now.AddMinutes(-2), 20L, "GameItem",
+			existingLocation.Object);
+
+		bool result = LegalAuthority.ShouldSuppressAutomaticRepeatCrime(law.Object, [existingCrime.Object],
+			victim.Object, item.Object, newLocation.Object, now);
+
+		Assert.IsTrue(result);
+	}
+
+	[TestMethod]
+	public void ShouldSuppressAutomaticRepeatCrime_OlderViolentCrime_DoesNotSuppress()
+	{
+		DateTime now = DateTime.UtcNow;
+		Mock<ILaw> law = CreateLaw(1L, CrimeTypes.Assault, doNotRepeat: false);
+		Mock<ICharacter> victim = CreateCharacter(10L);
+		Mock<ICrime> existingCrime = CreateCrime(law.Object, 10L, now.AddMinutes(-11), null, null,
+			CreateCell(30L).Object);
+
+		bool result = LegalAuthority.ShouldSuppressAutomaticRepeatCrime(law.Object, [existingCrime.Object],
+			victim.Object, null!, CreateCell(31L).Object, now);
+
+		Assert.IsFalse(result);
+	}
+
+	private static Mock<ILaw> CreateLaw(long id, CrimeTypes crimeType, bool doNotRepeat)
+	{
+		Mock<ILaw> law = new();
+		law.SetupGet(x => x.Id).Returns(id);
+		law.SetupGet(x => x.CrimeType).Returns(crimeType);
+		law.SetupGet(x => x.DoNotAutomaticallyApplyRepeats).Returns(doNotRepeat);
+		return law;
+	}
+
+	private static Mock<ICrime> CreateCrime(ILaw law, long? victimId, DateTime realTimeOfCrime, long? itemId,
+		string? itemType, ICell location)
+	{
+		Mock<ICrime> crime = new();
+		crime.SetupGet(x => x.Law).Returns(law);
+		crime.SetupGet(x => x.VictimId).Returns(victimId);
+		crime.SetupGet(x => x.RealTimeOfCrime).Returns(realTimeOfCrime);
+		crime.SetupGet(x => x.ThirdPartyId).Returns(itemId);
+		crime.SetupGet(x => x.ThirdPartyFrameworkItemType).Returns(itemType);
+		crime.SetupGet(x => x.CrimeLocation).Returns(location);
+		return crime;
+	}
+
+	private static Mock<ICharacter> CreateCharacter(long id)
+	{
+		Mock<ICharacter> character = new();
+		character.SetupGet(x => x.Id).Returns(id);
+		return character;
+	}
+
+	private static Mock<IGameItem> CreateItem(long id, string frameworkItemType)
+	{
+		Mock<IGameItem> item = new();
+		item.SetupGet(x => x.Id).Returns(id);
+		item.SetupGet(x => x.FrameworkItemType).Returns(frameworkItemType);
+		return item;
+	}
+
+	private static Mock<ICell> CreateCell(long id)
+	{
+		Mock<ICell> cell = new();
+		cell.SetupGet(x => x.Id).Returns(id);
+		return cell;
+	}
+}

--- a/MudSharpCore/Commands/Modules/CrimeModule.cs
+++ b/MudSharpCore/Commands/Modules/CrimeModule.cs
@@ -2057,7 +2057,7 @@ The syntax is as follows:
 
 	#3engagelawyer list#0 - see a list of people who could have lawyers engaged
 	#3engagelawyer me|<target>#0 - see a list of lawyers you could hire
-	#3engagelawyer me|<target> <which> [<bank account>] - engage a specific lawyer, paying with either cash or a bank account", AutoHelp.HelpArgOrNoArg)]
+	#3engagelawyer me|<target> <which> [<bank account>] - engage a specific lawyer, paying with either cash, remand belongings cash, or a bank account", AutoHelp.HelpArgOrNoArg)]
     protected static void EngageLawyer(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -2219,17 +2219,28 @@ The syntax is as follows:
         }
         else
         {
-            OtherCashPayment payment = new(jurisdiction.Currency, actor);
-            if (payment.AccessibleMoneyForPayment() < fee)
+            List<IGameItem> remandBelongings = actor == who && jurisdiction.IsInRemandCell(actor)
+                ? PrisonerBelongingsBundles(jurisdiction, actor).ToList()
+                : new List<IGameItem>();
+            OtherCashPayment payment = remandBelongings.Any()
+                ? new OtherCashPayment(jurisdiction.Currency, actor, actor.Body.ExternalItems.Concat(remandBelongings))
+                : new OtherCashPayment(jurisdiction.Currency, actor);
+            decimal accessible = payment.AccessibleMoneyForPayment();
+            if (accessible < fee)
             {
+                string availableText = remandBelongings.Any()
+                    ? "available between your carried cash and your remand belongings"
+                    : "holding";
                 actor.OutputHandler.Send(
-                    $"You aren't holding enough money to pay {jurisdiction.Currency.Describe(fee, CurrencyDescriptionPatternType.Short).ColourValue()} in legal fees.\nYou are only holding {jurisdiction.Currency.Describe(payment.AccessibleMoneyForPayment(), CurrencyDescriptionPatternType.Short).ColourValue()}.");
+                    $"You don't have enough money to pay {jurisdiction.Currency.Describe(fee, CurrencyDescriptionPatternType.Short).ColourValue()} in legal fees.\nYou are only {availableText} {jurisdiction.Currency.Describe(accessible, CurrencyDescriptionPatternType.Short).ColourValue()}.");
                 return;
             }
 
             payment.TakePayment(fee);
             lawyerBankAccount?.DepositFromTransaction(fee, $"Lawyer fee for {who.PersonalName.GetName(NameStyle.FullName)}");
-            actionText = "with cash";
+            actionText = remandBelongings.Any()
+                ? "with cash from &0's carried money or remand belongings"
+                : "with cash";
         }
 
         if (actor == who)
@@ -2244,6 +2255,13 @@ The syntax is as follows:
 
         target.AddEffect(new Lawyering(target, jurisdiction) { EngagedByCharacter = who });
         who.AddEffect(new HasLegalCounsel(who, target));
+    }
+
+    private static IEnumerable<IGameItem> PrisonerBelongingsBundles(ILegalAuthority jurisdiction, ICharacter prisoner)
+    {
+        return jurisdiction.PrisonerBelongingsStorageLocation?.GameItems
+                           .Where(x => x.AffectedBy<PrisonerBelongings>(prisoner)) ??
+               Enumerable.Empty<IGameItem>();
     }
 
     [PlayerCommand("PayFine", "payfine")]

--- a/MudSharpCore/Economy/Payment/CashPayment.cs
+++ b/MudSharpCore/Economy/Payment/CashPayment.cs
@@ -2,6 +2,7 @@
 using MudSharp.Economy.Currency;
 using MudSharp.GameItems;
 using MudSharp.GameItems.Interfaces;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace MudSharp.Economy.Payment;
@@ -16,6 +17,8 @@ public abstract class CashPayment : IPaymentMethod
 
     public ICurrency Currency { get; set; }
     public ICharacter Actor { get; set; }
+
+    protected virtual IEnumerable<IGameItem> PaymentItems => Actor.Body.ExternalItems;
 
     protected static decimal CountAccessibleMoney(IGameItem item, ICurrency whichCurrency, bool respectGetRules)
     {
@@ -40,7 +43,7 @@ public abstract class CashPayment : IPaymentMethod
 
     public decimal AccessibleMoneyForPayment()
     {
-        return Actor.Body.ExternalItems.Sum(x => CountAccessibleMoney(x, Currency, true));
+        return PaymentItems.Sum(x => CountAccessibleMoney(x, Currency, true));
     }
 
     public abstract void TakePayment(decimal price);

--- a/MudSharpCore/Economy/Payment/OtherCashPayment.cs
+++ b/MudSharpCore/Economy/Payment/OtherCashPayment.cs
@@ -11,15 +11,27 @@ namespace MudSharp.Economy.Payment;
 
 public class OtherCashPayment : CashPayment
 {
+    private readonly IReadOnlyCollection<IGameItem> _paymentItems = Array.Empty<IGameItem>();
+    private readonly bool _useCustomPaymentItems;
+
     public OtherCashPayment(ICurrency currency, ICharacter actor) : base(currency, actor)
     {
     }
+
+    public OtherCashPayment(ICurrency currency, ICharacter actor, IEnumerable<IGameItem> paymentItems) : this(currency,
+        actor)
+    {
+        _paymentItems = paymentItems.ToList();
+        _useCustomPaymentItems = true;
+    }
+
+    protected override IEnumerable<IGameItem> PaymentItems => _useCustomPaymentItems ? _paymentItems : base.PaymentItems;
 
     #region Overrides of CashPayment
 
     public override void TakePayment(decimal price)
     {
-        IEnumerable<ICurrencyPile> currency = Actor.Body.ExternalItems.RecursiveGetItems<ICurrencyPile>(true);
+        IEnumerable<ICurrencyPile> currency = PaymentItems.RecursiveGetItems<ICurrencyPile>(true);
         Dictionary<ICurrencyPile, Dictionary<ICoin, int>> targetCoins = Currency.FindCurrency(currency, price);
         decimal value = targetCoins.Sum(x => x.Value.Sum(y => y.Value * y.Key.Value));
         IEnumerable<IGameItem> containers = targetCoins.SelectNotNull(x => x.Key.Parent.ContainedIn).Distinct();

--- a/MudSharpCore/RPG/Law/Crime.cs
+++ b/MudSharpCore/RPG/Law/Crime.cs
@@ -532,7 +532,7 @@ public class Crime : LateInitialisingItem, ICrime
             case CrimeTypes.Torture:
                 return $"tortured {victimDesc}{locationAddendum}";
             case CrimeTypes.GreviousBodilyHarm:
-                return $"caused grevious bodily harm to {victimDesc}{locationAddendum}";
+                return $"caused grievous bodily harm to {victimDesc}{locationAddendum}";
             case CrimeTypes.Theft:
                 return $"stole {thirdPartyDesc} from {victimDesc}{locationAddendum}";
             case CrimeTypes.Fraud:
@@ -686,9 +686,7 @@ public class Crime : LateInitialisingItem, ICrime
 
     public string DescribeCrimeAtTrial(IPerceiver voyeur)
     {
-        string victimDesc =
-            Victim?.PersonalName.GetName(NameStyle.FullName) ??
-            "unnamed victims";
+        string victimDesc = DescribeVictimAtTrial(Victim);
         string locationAddendum =
             CrimeLocation != null ?
                 $" at {CrimeLocation.CurrentOverlay.CellName}" :
@@ -697,6 +695,12 @@ public class Crime : LateInitialisingItem, ICrime
         return
             DescribeCrimeInternal(voyeur, victimDesc, locationAddendum, thirdPartyDesc)
                 .Replace("was ", "$1|were|was ");
+    }
+
+    private static string DescribeVictimAtTrial(ICharacter? victim)
+    {
+        string? name = victim?.PersonalName.GetName(NameStyle.FullName);
+        return string.IsNullOrWhiteSpace(name) ? "an unnamed victim" : name;
     }
 
     public string DescribeCrime(IPerceiver voyeur)

--- a/MudSharpCore/RPG/Law/LegalAuthority.cs
+++ b/MudSharpCore/RPG/Law/LegalAuthority.cs
@@ -27,6 +27,8 @@ namespace MudSharp.RPG.Law;
 
 public partial class LegalAuthority : SaveableItem, ILegalAuthority
 {
+    private static readonly TimeSpan AutomaticRepeatSuppressionWindow = TimeSpan.FromMinutes(10);
+
     public LegalAuthority(string name, ICurrency currency, IFuturemud gameworld)
     {
         Gameworld = gameworld;
@@ -705,19 +707,9 @@ public partial class LegalAuthority : SaveableItem, ILegalAuthority
             }
 
             var criminalIdentityId = CharacterInstanceIdentityComparer.IdentityId(criminal);
-            if (law.DoNotAutomaticallyApplyRepeats && _unknownCrimesLookup[criminalIdentityId]
-                                                      .Concat(_knownCrimesLookup[criminalIdentityId]).Any(x =>
-                                                          x.Law.Id == law.Id &&
-                                                          x.Victim == victim &&
-                                                          (item is null
-                                                              ? x.ThirdPartyId is null
-                                                              : x.ThirdPartyId == item.Id &&
-                                                                string.Equals(x.ThirdPartyFrameworkItemType,
-                                                                    item.FrameworkItemType,
-                                                                    StringComparison.OrdinalIgnoreCase)) &&
-                                                          x.CrimeLocation == location &&
-                                                          DateTime.UtcNow - x.RealTimeOfCrime < TimeSpan.FromMinutes(10)
-                                                      ))
+            if (ShouldSuppressAutomaticRepeatCrime(law,
+                    _unknownCrimesLookup[criminalIdentityId].Concat(_knownCrimesLookup[criminalIdentityId]), victim,
+                    item, location, DateTime.UtcNow))
             {
                 continue;
             }
@@ -745,6 +737,68 @@ public partial class LegalAuthority : SaveableItem, ILegalAuthority
         }
 
         return crimes;
+    }
+
+    internal static bool ShouldSuppressAutomaticRepeatCrime(ILaw law, IEnumerable<ICrime> existingCrimes,
+        ICharacter victim, IGameItem item, ICell location, DateTime now)
+    {
+        bool suppressViolentEncounterRepeats = law.CrimeType.IsViolentCrime() && victim is not null;
+        if (!law.DoNotAutomaticallyApplyRepeats && !suppressViolentEncounterRepeats)
+        {
+            return false;
+        }
+
+        long? victimId = victim is null ? null : CharacterInstanceIdentityComparer.IdentityId(victim);
+        return existingCrimes.Any(x =>
+            IsRepeatCrimeMatch(law, x, victimId, item, location, now, suppressViolentEncounterRepeats));
+    }
+
+    private static bool IsRepeatCrimeMatch(ILaw law, ICrime existingCrime, long? victimId, IGameItem item,
+        ICell location, DateTime now, bool suppressViolentEncounterRepeats)
+    {
+        if (existingCrime.Law?.Id != law.Id)
+        {
+            return false;
+        }
+
+        TimeSpan age = now - existingCrime.RealTimeOfCrime;
+        if (age < TimeSpan.Zero || age >= AutomaticRepeatSuppressionWindow)
+        {
+            return false;
+        }
+
+        if (existingCrime.VictimId != victimId)
+        {
+            return false;
+        }
+
+        if (suppressViolentEncounterRepeats)
+        {
+            return true;
+        }
+
+        if (!SameCrimeItem(existingCrime, item))
+        {
+            return false;
+        }
+
+        return SameCrimeLocation(existingCrime.CrimeLocation, location);
+    }
+
+    private static bool SameCrimeItem(ICrime existingCrime, IGameItem item)
+    {
+        return item is null
+            ? existingCrime.ThirdPartyId is null
+            : existingCrime.ThirdPartyId == item.Id &&
+              string.Equals(existingCrime.ThirdPartyFrameworkItemType, item.FrameworkItemType,
+                  StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool SameCrimeLocation(ICell existingLocation, ICell location)
+    {
+        return existingLocation is null || location is null
+            ? existingLocation is null && location is null
+            : existingLocation == location || existingLocation.Id == location.Id;
     }
 
     public bool WouldBeACrime(ICharacter criminal, CrimeTypes crime, ICharacter victim, IGameItem item,


### PR DESCRIPTION
## Summary
- Allow remand prisoners to hire lawyers with carried cash plus cash held in their prisoner belongings bundle
- Keep trial charge readouts grammatical when a victim character cannot be resolved, including grievous bodily harm wording
- Suppress repeated automatic violent same-victim charges during the short repeat window and seed stock automatic violent laws accordingly

## Validation
- dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 -p:UseSharedCompilation=false --filter FullyQualifiedName~LegalTrialFlowTests|FullyQualifiedName~LegalCommandPresentationTests|FullyQualifiedName~LegalAuthorityRepeatSuppressionTests|FullyQualifiedName~AutomaticCrimeExtensionsTests
- dotnet test 'DatabaseSeeder Unit Tests\DatabaseSeeder Unit Tests.csproj' -c Debug --no-restore -m:1 --filter FullyQualifiedName~LawSeeder_SeedData_AutomaticViolentLawsSuppressRepeats
- git diff --check

## Notes
- A full DatabaseSeeder Unit Tests run still has the existing CommittedBlankSnapshotManifest_TracksLatestMigration snapshot-manifest mismatch; the new focused law-seeder test passed.