### PR TITLE
Add regnal year support to calendar and date formatting

### DIFF
--- a/Design Documents/World/Time_And_Date_System.md
+++ b/Design Documents/World/Time_And_Date_System.md
@@ -172,8 +172,22 @@ A calendar definition includes:
 - ordered weekday names
 - base month definitions
 - intercalary month definitions
+- optional regnal period definitions
 
 The concrete `Calendar` creates generated `Year` instances as needed. Generated years are cached by year number. Calendar day counts, weekday counts, days-between-year counts, and first-weekday calculations are also cached.
+
+Regnal periods are calendar-local metadata layered on top of ordinary dates. They are persisted in optional calendar XML under `<regnalperiods>` with immutable keys, editable short/full display names, a required start date, and an optional end date. Missing XML loads as an empty regnal-period list so legacy calendars keep their existing behavior.
+
+A regnal period does not replace the calendar year. Dates are still stored and compared as ordinary `MudDate` values, and regnal display is recalculated from the base date each time. This lets a future projected regnal input such as `RY20 @charles-iii` convert to an ordinary date first, then later redisplay under a different current regnal period or as an ordinary year if later builder edits close the original period early.
+
+Regnal period XML uses this shape:
+
+```xml
+<regnalperiods>
+  <regnalperiod key="charles-iii" short="Charles III" full="King Charles III" start="15/march/1200" end="14/march/1208" />
+  <regnalperiod key="arthur" short="Arthur" full="King Arthur" start="15/march/1208" />
+</regnalperiods>
+```
 
 The first weekday of a year is computed from:
 
@@ -270,6 +284,7 @@ Primary dates update the owning calendar when advanced. Copied or parsed dates a
 - conversion to another calendar by day difference from each calendar's current date
 - date difference and year difference operations
 - round-trip parse text
+- lookup of the active regnal period and computed regnal year through the owning calendar
 - display through calendar masks
 
 `MudDate.AdvanceToNextWeekday` is exclusive of the current date. A positive occurrence count moves forward; a negative count moves backward; zero is a no-op.
@@ -302,11 +317,14 @@ The actor-facing parser accepts:
 - `now`
 - `soon`
 - dates in the supported calendar parse forms
+- regnal date forms such as `regnal:charles-iii:20:may:3`, `May 3rd RY20 @charles-iii`, and `3 May RY20 @charles-iii`
 - times such as `3:15pm`, `15:15:00`, and `15:15:00 UTC`
 - optional clock hour interval text
 - optional time-zone aliases
 
 When a time zone is specified, the parsed time is treated as local wall time in that time zone. Unknown time zones or meridian/period text are rejected cleanly.
+
+Regnal parsing accepts the canonical `RY<number> @key` form for unambiguous round-tripping. Natural period names may be accepted only when the text uniquely resolves to one configured period. Regnal parsing is allowed to project beyond a period's current end date so future-written text can still be converted to an ordinary date; display only uses a regnal period when the resulting base date falls within the period's actual bounds.
 
 `ToMudDateFunction` in FutureProg uses this parser and returns `MudDateTime.Never` for invalid text, missing calendars, missing clocks, or empty input.
 
@@ -492,7 +510,31 @@ Clock editing supports metadata, display masks, clock units, in-game speed, fixe
 
 Time-zone editing supports name/alias, description, and offset hours/minutes. Existing time zones cannot be moved between clocks; builders should clone to the target clock instead.
 
-Calendar editing supports metadata, display masks, feed clock, current date, epoch year and first weekday, era display text, weekday and month editing, normal special/non-weekday days, intercalary days/months, generated-year preview, validation, algorithm selection, day-boundary selection, and authority-location editing. Structural edits clear generated-year caches, normalize the current date, and mark the calendar changed.
+Calendar editing supports metadata, display masks, feed clock, current date, epoch year and first weekday, era display text, weekday and month editing, normal special/non-weekday days, intercalary days/months, generated-year preview, validation, algorithm selection, day-boundary selection, authority-location editing, and regnal-period editing. Structural edits clear generated-year caches, normalize the current date, and mark the calendar changed.
+
+Calendar display masks support ordinary date tokens plus regnal tokens:
+
+- `$rk`: regnal key with `@`, such as `@charles-iii`
+- `$rs`: regnal short name
+- `$rf`: regnal full name
+- `$rn`, `$rN`, `$rt`, `$rT`: numeric, wordy, ordinal, and wordy ordinal regnal year
+- `$rq`: canonical regnal reference, such as `RY20 @charles-iii`; outside a regnal period this falls back to ordinary year/era text
+- `$rp`: readable regnal phrase, such as `20th year of King Charles III`; outside a regnal period this falls back to ordinary ordinal year/era text
+
+Masks can branch on whether the displayed date is inside a regnal period with `$ir{<regnal text>}{<fallback text>}`. Branch contents may contain ordinary tokens, regnal tokens, and plain text, for example `$ir{$rt year of $rf}{$yo $EE}`. Nested conditionals are not supported; malformed blocks are left literal.
+
+Regnal period builder commands live under `calendar set regnal ...`:
+
+- `regnal list`
+- `regnal add <key> "<short>" "<full>" <start> [<end>|open]`
+- `regnal close <key> <end>`
+- `regnal name <key> short|full <text>`
+- `regnal start <key> <date>`
+- `regnal end <key> <date|open>`
+- `regnal remove <key>`
+- `regnal preview <date>`
+
+Period edits use the normal live-calendar structural confirmation path and validate the full period set before applying.
 
 Admin time displays now expose the current `MudInstant`, calendar algorithm type, day-boundary type, authority location when set, and celestial ephemeris support. Admins can preview deterministic astronomical events with:
 
@@ -572,6 +614,10 @@ These are important rules to preserve when changing the system:
 - Missing calendar algorithm/day-boundary XML must continue to load as fixed-month, clock-midnight calendars.
 - `MudInstant` must remain additive over existing calendar/clock state; existing persisted mud date/time strings stay valid and are not replaced in-place.
 - Calculated and astronomical calendar algorithms must produce deterministic generated years from authored metadata without storing generated years or observation ledgers.
+- Regnal period keys are immutable calendar-local identifiers. Display names can change without invalidating canonical `RY<number> @key` input.
+- Regnal periods may have no gaps or overlaps after the first regnal period starts. At most one period may be open-ended, and an open-ended period must be last.
+- Regnal year one begins on the period start date. Later regnal years begin on that same calendar month/day anniversary where the generated year supports it.
+- Regnal display must fall back to ordinary year display whenever a base date is outside every configured regnal period.
 
 ## Test Coverage
 The normal unit-test suites now include focused coverage for:
@@ -583,6 +629,7 @@ The normal unit-test suites now include focused coverage for:
 - clock, time-zone, and calendar builder command paths for high-value edits
 - `MudInstant` storage, ordering, conversion, and legacy backfill
 - legacy calendar XML loading without an algorithm element
+- regnal period XML loading/saving, legacy empty-period loading, display fallback, `$ir{}` branch behavior, canonical parser forms, future projection, and builder continuity validation
 - fixed, calculated, and astronomical calendar algorithm generation
 - astronomical event solver nth-next behavior and supported solar/lunar/visible-crescent events
 - FutureProg celestial event function registration with nth-next overloads

--- a/FutureMUDLibrary/TimeAndDate/Date/ICalendar.cs
+++ b/FutureMUDLibrary/TimeAndDate/Date/ICalendar.cs
@@ -49,6 +49,7 @@ namespace MudSharp.TimeAndDate.Date
         List<string> Weekdays { get; }
         List<MonthDefinition> Months { get; }
         List<IntercalaryMonth> Intercalaries { get; }
+        IReadOnlyList<IRegnalPeriod> RegnalPeriods { get; }
         void UpdateDays();
         void UpdateMonths();
         void UpdateYears();
@@ -118,6 +119,10 @@ namespace MudSharp.TimeAndDate.Date
         MudDate GetDate(string dateString);
         bool TryGetDate(string dateString, out MudDate date, out string error);
         bool TryGetDate(string dateString, IFormatProvider format, out MudDate date, out string error);
+        IRegnalPeriod GetRegnalPeriod(MudDate date);
+        RegnalDateInfo GetRegnalDate(MudDate date);
+        bool TryGetDateFromRegnalDate(string regnalPeriodKey, int regnalYear, int day, string month, bool allowProjected,
+            out MudDate date, out string error);
 
         string DisplayDate(CalendarDisplayMode mode);
         string DisplayDate(string mask);

--- a/FutureMUDLibrary/TimeAndDate/Date/MudDate.cs
+++ b/FutureMUDLibrary/TimeAndDate/Date/MudDate.cs
@@ -146,6 +146,10 @@ public class MudDate : IComparable
         get => _isPrimaryDate; set => _isPrimaryDate = value;
     }
 
+    public IRegnalPeriod RegnalPeriod => Calendar.GetRegnalPeriod(this);
+
+    public RegnalDateInfo RegnalDate => Calendar.GetRegnalDate(this);
+
     public bool IsIntercalaryDay()
     {
         return false; // TODO

--- a/FutureMUDLibrary/TimeAndDate/Date/RegnalDateInfo.cs
+++ b/FutureMUDLibrary/TimeAndDate/Date/RegnalDateInfo.cs
@@ -1,0 +1,23 @@
+#nullable enable
+
+namespace MudSharp.TimeAndDate.Date;
+
+public interface IRegnalPeriod
+{
+	string Key { get; }
+	string ShortName { get; }
+	string FullName { get; }
+	MudDate StartDate { get; }
+	MudDate? EndDate { get; }
+	bool IsOpenEnded { get; }
+	bool Contains(MudDate date);
+}
+
+public sealed record RegnalDateInfo(
+	IRegnalPeriod Period,
+	int RegnalYear,
+	MudDate Date,
+	MudDate RegnalYearStart)
+{
+	public string CanonicalYearText => $"RY{RegnalYear} @{Period.Key}";
+}

--- a/FutureMUDLibrary/TimeAndDate/MudDateTime.cs
+++ b/FutureMUDLibrary/TimeAndDate/MudDateTime.cs
@@ -20,7 +20,7 @@ namespace MudSharp.TimeAndDate
     {
         private static readonly Regex PlayerParseRegex = new(@"^(?<date>\d+[/-][a-z]+[/-]\d+) (?:(?<timezone>\w+)\s+){0,1}(?<time>\d+:\d+:\d+(?:\s*\w+)*)$", RegexOptions.IgnoreCase);
 
-        private static readonly Regex AlternatePlayerParseRegex = new(@"(?<date>(?<date1>[a-z0-9]+)[ /-](?<date2>[a-z0-9]+)[ /-](?<date3>[0-9]+)) (?<time>(?<hour>\d+):(?<minute>\d+):*(?<second>\d+)*(?<period>[a-z]+)*\s*(?<timezone>[a-z]+)*)", RegexOptions.IgnoreCase);
+        private static readonly Regex AlternatePlayerParseRegex = new(@"^(?<date>(?<date1>[a-z0-9]+)[ /-](?<date2>[a-z0-9]+)[ /-](?<date3>[0-9]+)) (?<time>.+)$", RegexOptions.IgnoreCase);
 
         private static readonly Regex ParseRegex =
             new(@"^(?<calendar>\d+)_(?<date>[^_]+)_(?<clock>\d+)_(?<time>(?<timezone>[^ ]+) .+)$");
@@ -57,6 +57,8 @@ You can enter dates in one of several formats:
 If you use all numbers, your input will be interpreted using the settings of your account culture - this may mean that it is read as #3day/month/year#0 (e.g. UK/Europe), #3month/day/year#0 (e.g. US) or #3year/month/day#0 (e.g. East Asia).
 
 You can also use #3/#0, #3-#0 or spaces to separate the three parts of your date.
+
+Calendars with regnal periods also accept forms like #3May 3rd RY20 @charles-iii#0 and #3regnal:charles-iii:20:may:3#0.
 
 #6Times#0
 
@@ -134,48 +136,19 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
                 return true;
             }
 
-            Match regexMatch = AlternatePlayerParseRegex.Match(text);
-            if (!regexMatch.Success)
+            if (TryParseFlexiblePlayerDateTime(text, calendar, clock, actor, out var date, out var time, out var tz,
+                    out error))
+            {
+                dt = new MudDateTime(date, time, tz);
+                return true;
+            }
+
+            if (string.IsNullOrEmpty(error))
             {
                 error = TryParseHelpText(actor, calendar, clock);
-                return false;
             }
 
-            if (!calendar.TryGetDate(regexMatch.Groups["date"].Value, actor, out MudDate date, out error))
-            {
-                return false;
-            }
-
-            int hour = int.Parse(regexMatch.Groups["hour"].Value);
-            int minute = int.Parse(regexMatch.Groups["minute"].Value);
-            int second = regexMatch.Groups["second"].Length > 0 ? int.Parse(regexMatch.Groups["second"].Value) : 0;
-            IMudTimeZone tz = regexMatch.Groups["timezone"].Length > 0
-                ? clock.Timezones.GetByIdOrName(regexMatch.Groups["timezone"].Value)
-                : clock.PrimaryTimezone;
-            if (tz == null)
-            {
-                error = $"The timezone \"{regexMatch.Groups["timezone"].Value}\" is not valid.";
-                return false;
-            }
-
-            if (regexMatch.Groups["period"].Length > 0)
-            {
-                int hourInterval = clock.HourIntervalNames.FindIndex(
-                    x => x.Equals(regexMatch.Groups["period"].Value, StringComparison.InvariantCultureIgnoreCase));
-                if (hourInterval < 0)
-                {
-                    error = $"The hour period \"{regexMatch.Groups["period"].Value}\" is not valid.";
-                    return false;
-                }
-
-                hour +=
-                    hourInterval *
-                    (clock.HoursPerDay / clock.NumberOfHourIntervals);
-            }
-
-            MudTime time = MudTime.FromLocalTime(second, minute, hour, tz, clock);
-            dt = new MudDateTime(date, time, tz);
-            return true;
+            return false;
         }
 
         /// <summary>
@@ -213,29 +186,83 @@ For example, #33:15pm#0, #315:15:00#0 and #315:15:00 UTC#0 would all be valid da
             }
 
             Match match = PlayerParseRegex.Match(text);
-            if (!match.Success)
+            if (match.Success)
             {
-                return false;
-            }
-            try
-            {
-                MudDate date = calendar.GetDate(match.Groups["date"].Value);
-                IMudTimeZone timezone = match.Groups["timezone"].Length > 0
-                ? clock.Timezones.GetByIdOrName(match.Groups["timezone"].Value)
-                : clock.PrimaryTimezone;
-                if (timezone == null)
+                try
+                {
+                    var date = calendar.GetDate(match.Groups["date"].Value);
+                    var timeText = match.Groups["timezone"].Length > 0
+                        ? $"{match.Groups["timezone"].Value} {match.Groups["time"].Value}"
+                        : match.Groups["time"].Value;
+                    if (!MudTime.TryParseLocalTime(timeText, clock, out var time, out _))
+                    {
+                        return false;
+                    }
+
+                    dt = new MudDateTime(date, time, time.Timezone);
+                    return true;
+                }
+                catch
                 {
                     return false;
                 }
-                MudTime time = clock.GetTime($"{timezone.Alias} {match.Groups["time"].Value}");
-                dt = new MudDateTime(date, time, timezone);
+            }
+
+            if (TryParseFlexiblePlayerDateTime(text, calendar, clock, null, out var flexibleDate, out var flexibleTime,
+                    out var flexibleTimezone, out _))
+            {
+                dt = new MudDateTime(flexibleDate, flexibleTime, flexibleTimezone);
                 return true;
             }
-            catch
-            {
-                return false;
-            }
+
+            return false;
         }
+
+        private static bool TryParseFlexiblePlayerDateTime(string text, ICalendar calendar, IClock clock,
+            IFormatProvider format, out MudDate date, out MudTime time, out IMudTimeZone timezone, out string error)
+        {
+            date = null;
+            time = null;
+            timezone = null;
+            error = string.Empty;
+
+            var match = AlternatePlayerParseRegex.Match(text);
+            if (match.Success)
+            {
+                if (calendar.TryGetDate(match.Groups["date"].Value, format, out date, out error) &&
+                    MudTime.TryParseLocalTime(match.Groups["time"].Value, clock, out time, out error))
+                {
+                    timezone = time.Timezone;
+                    return true;
+                }
+            }
+
+            var tokens = text.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+            for (var splitIndex = tokens.Length - 1; splitIndex > 0; splitIndex--)
+            {
+                var timeText = string.Join(" ", tokens.Skip(splitIndex));
+                if (!MudTime.TryParseLocalTime(timeText, clock, out var parsedTime, out var timeError))
+                {
+                    error = timeError;
+                    continue;
+                }
+
+                var dateText = string.Join(" ", tokens.Take(splitIndex));
+                if (!calendar.TryGetDate(dateText, format, out var parsedDate, out var dateError))
+                {
+                    error = dateError;
+                    continue;
+                }
+
+                date = parsedDate;
+                time = parsedTime;
+                timezone = parsedTime.Timezone;
+                return true;
+            }
+
+            return false;
+        }
+
         public static bool TryParse(string text, IFuturemud gameworld, out MudDateTime dt)
         {
             dt = null;

--- a/MudSharpCore Unit Tests/MudDateTimeTests.cs
+++ b/MudSharpCore Unit Tests/MudDateTimeTests.cs
@@ -202,6 +202,94 @@ public class MudDateTimeTests
     }
 
     [TestMethod]
+    public void Calendar_RegnalPeriods_LoadSaveDisplayAndParse()
+    {
+        var calendar = CreateRegnalCalendar();
+
+        Assert.AreEqual(2, calendar.RegnalPeriods.Count);
+        Assert.AreEqual(2, calendar.SaveToXml().Element("regnalperiods")!.Elements("regnalperiod").Count());
+
+        var charlesDate = calendar.GetDate("16/month3/1200");
+        Assert.AreEqual("RY1 @charles-iii", calendar.DisplayDate(charlesDate, "$rq"));
+        Assert.AreEqual("16/month3/1st year of King Charles III",
+            calendar.DisplayDate(charlesDate, "$dd/$mm/$ir{$rt year of $rf}{$yo $EE}"));
+
+        var ordinaryDate = calendar.GetDate("1/month1/1200");
+        Assert.AreEqual("1/month1/1200th after era",
+            calendar.DisplayDate(ordinaryDate, "$dd/$mm/$ir{$rt year of $rf}{$yo $EE}"));
+
+        Assert.IsTrue(calendar.TryGetDate("month5 3rd RY20 @charles-iii", out var canonical, out var canonicalError), canonicalError);
+        Assert.AreEqual("3/month5/1219", canonical.GetDateString());
+
+        Assert.IsTrue(calendar.TryGetDate("regnal:charles-iii:20:month5:3", out var structured, out var structuredError), structuredError);
+        Assert.AreEqual(canonical.GetDateString(), structured.GetDateString());
+
+        Assert.IsTrue(calendar.TryGetDate("3 month5 20 King Charles III", out var natural, out var naturalError), naturalError);
+        Assert.AreEqual(canonical.GetDateString(), natural.GetDateString());
+        Assert.AreEqual("RY12 @arthur", calendar.DisplayDate(canonical, "$rq"));
+    }
+
+    [TestMethod]
+    public void MudDateTime_TryParse_AcceptsRegnalDateInput()
+    {
+        var calendar = CreateRegnalCalendar();
+        var offsetTimezone = _testClock.Timezones.FirstOrDefault(x => x.Alias.EqualTo("O1"));
+        if (offsetTimezone is null)
+        {
+            offsetTimezone = new MudTimeZone(907, 1, 0, "Offset One", "O1", _testClock);
+            _testClock.AddTimezone(offsetTimezone);
+        }
+
+        Assert.IsTrue(MudDateTime.TryParse("month5 3rd RY20 @charles-iii 3:00:00 UTC", calendar, _testClock, null,
+            out var parsed, out var error), error);
+
+        Assert.AreEqual("3/month5/1219", parsed.Date.GetDateString());
+        Assert.AreEqual(3, parsed.Time.Hours);
+
+        Assert.IsTrue(MudDateTime.TryParse("month5 3rd RY20 @charles-iii 3:00:00 O1", calendar, _testClock, null,
+            out var parsedWithDigitTimezone, out var digitTimezoneError), digitTimezoneError);
+        Assert.AreEqual("3/month5/1219", parsedWithDigitTimezone.Date.GetDateString());
+        Assert.AreEqual(offsetTimezone, parsedWithDigitTimezone.TimeZone);
+
+        Assert.IsTrue(MudDateTime.TryParse("month5 3rd RY20 @charles-iii 3:00:00 O1", calendar, _testClock,
+            out var parsedWithoutActor));
+        Assert.AreEqual(offsetTimezone, parsedWithoutActor.TimeZone);
+
+        Assert.IsTrue(MudDateTime.TryParse("regnal:charles-iii:20:month5:3 3:00:00 O1", calendar, _testClock, null,
+            out var parsedStructuredWithDigitTimezone, out var structuredDigitTimezoneError), structuredDigitTimezoneError);
+        Assert.AreEqual("3/month5/1219", parsedStructuredWithDigitTimezone.Date.GetDateString());
+        Assert.AreEqual(offsetTimezone, parsedStructuredWithDigitTimezone.TimeZone);
+    }
+
+    [TestMethod]
+    public void CalendarBuilder_RegnalPeriods_ValidateContinuityAndOpenPeriod()
+    {
+        var actor = CreateBuilder();
+        var months = string.Join("", Enumerable.Range(1, 12).Select(x => MonthXml($"month{x}", x, 30)));
+        var calendar = new Calendar(XElement.Parse(BuildCalendarXml(string.Empty, months)), _gameworld)
+        {
+            Id = 526,
+            FeedClock = _testClock
+        };
+        calendar.SetDate("1/month1/1200");
+
+        Assert.IsTrue(calendar.BuildingCommand(actor.Object,
+            new StringStack("regnal add charles-iii \"Charles III\" \"King Charles III\" 15/month3/1200 14/month3/1208")));
+        Assert.IsFalse(calendar.BuildingCommand(actor.Object,
+            new StringStack("regnal add arthur Arthur \"King Arthur\" 16/month3/1208 open")));
+        Assert.IsTrue(calendar.BuildingCommand(actor.Object,
+            new StringStack("regnal add arthur Arthur \"King Arthur\" 15/month3/1208 open")));
+        Assert.IsFalse(calendar.BuildingCommand(actor.Object,
+            new StringStack("regnal add stephen Stephen \"King Stephen\" 15/month3/1210 open")));
+        Assert.IsTrue(calendar.BuildingCommand(actor.Object,
+            new StringStack("regnal end arthur 14/month3/1210")));
+        Assert.IsTrue(calendar.BuildingCommand(actor.Object,
+            new StringStack("regnal add stephen Stephen \"King Stephen\" 15/month3/1210 open")));
+        Assert.IsFalse(calendar.BuildingCommand(actor.Object,
+            new StringStack("regnal start stephen 16/month3/1210")));
+    }
+
+    [TestMethod]
     public void MudInstant_RoundTripsStorageOrderingAndLegacyBackfill()
     {
         _testCalendar.SetDate("27/jun/34");
@@ -303,6 +391,7 @@ public class MudDateTimeTests
     {
         Assert.AreEqual(CalendarAlgorithmType.FixedMonths, _testCalendar.AlgorithmType);
         Assert.AreEqual(CalendarDayBoundaryType.ClockMidnight, _testCalendar.DayBoundary);
+        Assert.AreEqual(0, _testCalendar.RegnalPeriods.Count);
         Assert.AreEqual(14, _testCalendar.CreateYear(34).Months.Count);
         Assert.AreEqual(365, _testCalendar.CountDaysInYear(34));
     }
@@ -367,7 +456,25 @@ public class MudDateTimeTests
         return actor;
     }
 
-    private static string BuildCalendarXml(string algorithmXml, string monthsXml, string dayBoundaryXml = @"<dayboundary type=""ClockMidnight"" />")
+    private static Calendar CreateRegnalCalendar()
+    {
+        var months = string.Join("", Enumerable.Range(1, 12).Select(x => MonthXml($"month{x}", x, 30)));
+        var regnalXml = @"<regnalperiods>
+  <regnalperiod key=""charles-iii"" short=""Charles III"" full=""King Charles III"" start=""15/month3/1200"" end=""14/month3/1208"" />
+  <regnalperiod key=""arthur"" short=""Arthur"" full=""King Arthur"" start=""15/month3/1208"" />
+</regnalperiods>";
+        var calendar = new Calendar(XElement.Parse(BuildCalendarXml(string.Empty, months,
+            @"<dayboundary type=""ClockMidnight"" />", regnalXml)), _gameworld)
+        {
+            Id = 906,
+            FeedClock = _testClock
+        };
+        calendar.SetDate("1/month1/1200");
+        return calendar;
+    }
+
+    private static string BuildCalendarXml(string algorithmXml, string monthsXml, string dayBoundaryXml = @"<dayboundary type=""ClockMidnight"" />",
+        string regnalXml = @"<regnalperiods />")
     {
         return $@"<calendar>
   <alias>test-calendar</alias>
@@ -396,6 +503,7 @@ public class MudDateTimeTests
   </weekdays>
   <months>{monthsXml}</months>
   <intercalarymonths />
+  {regnalXml}
   {algorithmXml}
   {dayBoundaryXml}
 </calendar>";

--- a/MudSharpCore/TimeAndDate/Date/Calendar.cs
+++ b/MudSharpCore/TimeAndDate/Date/Calendar.cs
@@ -214,6 +214,7 @@ public class Calendar : SaveableItem, ICalendar
 
         LoadDayBoundary(root.Element("dayboundary"));
         _algorithm = CalendarAlgorithmFactory.LoadFromXml(root.Element("algorithm"), AuthorityLocation);
+        LoadRegnalPeriods(root.Element("regnalperiods"));
     }
 
     public XElement SaveToXml()
@@ -244,6 +245,12 @@ public class Calendar : SaveableItem, ICalendar
                 {
                     from ic in _intercalaries
                     select ic.SaveToXml()
+                }
+            ), new XElement("regnalperiods",
+                new object[]
+                {
+                    from period in _regnalPeriods
+                    select period.SaveToXml()
                 }
             ), Algorithm.SaveToXml(), SaveDayBoundaryToXml());
     }
@@ -297,6 +304,119 @@ public class Calendar : SaveableItem, ICalendar
         }
 
         return element;
+    }
+
+    private void LoadRegnalPeriods(XElement element)
+    {
+        _regnalPeriods.Clear();
+        if (element?.HasElements != true)
+        {
+            return;
+        }
+
+        foreach (var subElement in element.Elements("regnalperiod"))
+        {
+            _regnalPeriods.Add(new RegnalPeriod(this, subElement));
+        }
+
+        if (!TryValidateRegnalPeriods(_regnalPeriods, out var error))
+        {
+            throw new XmlException($"Invalid regnal period configuration: {error}");
+        }
+
+        _regnalPeriods = SortRegnalPeriods(_regnalPeriods).ToList();
+    }
+
+    private static IEnumerable<RegnalPeriod> SortRegnalPeriods(IEnumerable<RegnalPeriod> periods)
+    {
+        return periods.OrderBy(x => x.StartDate.Year)
+                      .ThenBy(x => x.StartDate.Month.TrueOrder)
+                      .ThenBy(x => x.StartDate.Day);
+    }
+
+    private bool TryValidateRegnalPeriods(IEnumerable<RegnalPeriod> periods, out string error)
+    {
+        var ordered = SortRegnalPeriods(periods).ToList();
+        error = string.Empty;
+        if (!ordered.Any())
+        {
+            return true;
+        }
+
+        if (ordered.Any(x => string.IsNullOrWhiteSpace(x.Key)))
+        {
+            error = "All regnal periods must have a key.";
+            return false;
+        }
+
+        var badKey = ordered.FirstOrDefault(x => !RegnalKeyRegex.IsMatch(x.Key));
+        if (badKey is not null)
+        {
+            error = $"The regnal period key {badKey.Key.ColourCommand()} is invalid. Keys must use only letters, numbers and hyphens.";
+            return false;
+        }
+
+        var duplicateKey = ordered.GroupBy(x => x.Key, StringComparer.InvariantCultureIgnoreCase)
+                                  .FirstOrDefault(x => x.Count() > 1);
+        if (duplicateKey is not null)
+        {
+            error = $"The regnal period key {duplicateKey.Key.ColourCommand()} is used more than once.";
+            return false;
+        }
+
+        var missingName = ordered.FirstOrDefault(x => string.IsNullOrWhiteSpace(x.ShortName) || string.IsNullOrWhiteSpace(x.FullName));
+        if (missingName is not null)
+        {
+            error = $"The regnal period {missingName.Key.ColourCommand()} must have both short and full names.";
+            return false;
+        }
+
+        foreach (var period in ordered)
+        {
+            if (period.EndDate is not null && period.EndDate < period.StartDate)
+            {
+                error = $"The regnal period {period.Key.ColourCommand()} ends before it starts.";
+                return false;
+            }
+        }
+
+        for (var i = 0; i < ordered.Count; i++)
+        {
+            var period = ordered[i];
+            if (period.EndDate is null && i != ordered.Count - 1)
+            {
+                error = $"The open-ended regnal period {period.Key.ColourCommand()} must be the last period.";
+                return false;
+            }
+
+            if (i == 0)
+            {
+                continue;
+            }
+
+            var previous = ordered[i - 1];
+            if (previous.EndDate is null)
+            {
+                error = $"The open-ended regnal period {previous.Key.ColourCommand()} must be the last period.";
+                return false;
+            }
+
+            var expectedStart = new MudDate(previous.EndDate);
+            expectedStart.AdvanceDays(1);
+            if (period.StartDate < expectedStart)
+            {
+                error = $"The regnal period {period.Key.ColourCommand()} overlaps {previous.Key.ColourCommand()}.";
+                return false;
+            }
+
+            if (period.StartDate > expectedStart)
+            {
+                error = $"There is a gap between {previous.Key.ColourCommand()} and {period.Key.ColourCommand()}.";
+                return false;
+            }
+        }
+
+        return true;
     }
 
     #region Overrides of FrameworkItem
@@ -669,6 +789,10 @@ public class Calendar : SaveableItem, ICalendar
         protected set => _intercalaries = value;
     }
 
+    protected List<RegnalPeriod> _regnalPeriods = new();
+
+    public IReadOnlyList<IRegnalPeriod> RegnalPeriods => _regnalPeriods;
+
     #endregion
 
     #region Constructors
@@ -1038,6 +1162,245 @@ public class Calendar : SaveableItem, ICalendar
         return new MudDateTime(date, MudTime.FromLocalTime(0, 0, 0, timezone, FeedClock), timezone);
     }
 
+    public IRegnalPeriod GetRegnalPeriod(MudDate date)
+    {
+        return date is null ? null : _regnalPeriods.FirstOrDefault(x => x.Contains(date));
+    }
+
+    public RegnalDateInfo GetRegnalDate(MudDate date)
+    {
+        if (GetRegnalPeriod(date) is not RegnalPeriod period)
+        {
+            return null;
+        }
+
+        var regnalYear = Math.Max(1, date.Year - period.StartDate.Year + 1);
+        var regnalYearStart = GetRegnalYearStart(period, regnalYear);
+        while (regnalYear > 1 && date < regnalYearStart)
+        {
+            regnalYear--;
+            regnalYearStart = GetRegnalYearStart(period, regnalYear);
+        }
+
+        while (true)
+        {
+            var nextStart = GetRegnalYearStart(period, regnalYear + 1);
+            if (date < nextStart)
+            {
+                break;
+            }
+
+            regnalYear++;
+            regnalYearStart = nextStart;
+        }
+
+        return new RegnalDateInfo(period, regnalYear, date, regnalYearStart);
+    }
+
+    private MudDate GetRegnalYearStart(RegnalPeriod period, int regnalYear)
+    {
+        var date = new MudDate(period.StartDate);
+        date.AdvanceYears(regnalYear - 1, true);
+        return date;
+    }
+
+    public bool TryGetDateFromRegnalDate(string regnalPeriodKey, int regnalYear, int day, string month,
+        bool allowProjected, out MudDate date, out string error)
+    {
+        date = null;
+        error = string.Empty;
+        if (string.IsNullOrWhiteSpace(regnalPeriodKey))
+        {
+            error = "You must specify a regnal period key.";
+            return false;
+        }
+
+        var period = GetRegnalPeriodByKey(regnalPeriodKey.TrimStart('@'));
+        if (period is null)
+        {
+            error = $"There is no regnal period with the key {regnalPeriodKey.ColourCommand()}.";
+            return false;
+        }
+
+        if (regnalYear < 1)
+        {
+            error = "Regnal years begin at year 1.";
+            return false;
+        }
+
+        if (day < 1)
+        {
+            error = "The day must be a positive integer.";
+            return false;
+        }
+
+        var yearStart = GetRegnalYearStart(period, regnalYear);
+        var nextYearStart = GetRegnalYearStart(period, regnalYear + 1);
+        var possibleYears = yearStart.Year == nextYearStart.Year
+            ? new[] { yearStart.Year }
+            : new[] { yearStart.Year, nextYearStart.Year };
+
+        foreach (var year in possibleYears)
+        {
+            if (!TryGetOrdinaryDateInYear(day, month, year, out var candidate, out _))
+            {
+                continue;
+            }
+
+            if (candidate < yearStart || candidate >= nextYearStart)
+            {
+                continue;
+            }
+
+            if (!allowProjected && !period.Contains(candidate))
+            {
+                error = $"That date does not fall within the regnal period {period.FullName.ColourName()}.";
+                return false;
+            }
+
+            date = candidate;
+            return true;
+        }
+
+        error = $"There is no {day.ToOrdinal().ColourValue()} day of {month.ColourCommand()} in regnal year {regnalYear.ToStringN0Colour(System.Globalization.CultureInfo.InvariantCulture)} of {period.FullName.ColourName()}.";
+        return false;
+    }
+
+    private RegnalPeriod GetRegnalPeriodByKey(string key)
+    {
+        return _regnalPeriods.FirstOrDefault(x => x.Key.EqualTo(key));
+    }
+
+    private bool TryGetOrdinaryDateInYear(int day, string monthText, int year, out MudDate date, out string error)
+    {
+        date = null;
+        if (day < 1)
+        {
+            error = "The day must be a positive integer.";
+            return false;
+        }
+
+        var newYear = CreateYear(year);
+        var newMonth =
+            newYear.Months.FirstOrDefault(x => x.Alias.Equals(monthText, StringComparison.InvariantCultureIgnoreCase)) ??
+            newYear.Months.FirstOrDefault(x => x.FullName.Equals(monthText, StringComparison.InvariantCultureIgnoreCase)) ??
+            newYear.Months.FirstOrDefault(x => x.ShortName.Equals(monthText, StringComparison.InvariantCultureIgnoreCase));
+
+        if (newMonth is null)
+        {
+            if (!int.TryParse(monthText, out var monthNumber))
+            {
+                error = $"There will be no month with an alias of {monthText.ColourCommand()} in the year {year:N0}.";
+                return false;
+            }
+
+            newMonth = newYear.Months.FirstOrDefault(x => x.TrueOrder == monthNumber);
+            if (newMonth is null)
+            {
+                error = $"There is no {monthNumber.ToOrdinal().ColourValue()} month in the year {year:N0}.";
+                return false;
+            }
+        }
+
+        if (newMonth.Days < day)
+        {
+            error = $"The month of {newMonth.FullName.ColourName()} in the year {year:N0} does not have {day:N0} days.";
+            return false;
+        }
+
+        error = string.Empty;
+        date = new MudDate(this, day, year, newMonth, newYear, false);
+        return true;
+    }
+
+    private bool TryGetDateFromRegnalText(string dateString, bool allowProjected, out MudDate date, out string error)
+    {
+        date = null;
+        error = string.Empty;
+        var structured = StructuredRegnalDateRegex.Match(dateString);
+        if (structured.Success)
+        {
+            var day = structured.Groups["day"].Value.GetIntFromOrdinal() ?? 0;
+            return TryGetDateFromRegnalDate(structured.Groups["key"].Value,
+                int.Parse(structured.Groups["year"].Value), day, structured.Groups["month"].Value,
+                allowProjected, out date, out error);
+        }
+
+        var canonical = CanonicalRegnalDateRegex.Match(dateString);
+        if (canonical.Success)
+        {
+            if (!TryGetDayMonthFromParts(canonical.Groups["first"].Value, canonical.Groups["second"].Value,
+                    out var day, out var month))
+            {
+                error = "The day must be a number.";
+                return false;
+            }
+
+            return TryGetDateFromRegnalDate(canonical.Groups["key"].Value,
+                int.Parse(canonical.Groups["year"].Value), day, month,
+                allowProjected, out date, out error);
+        }
+
+        var natural = NaturalRegnalDateRegex.Match(dateString);
+        if (!natural.Success)
+        {
+            return false;
+        }
+
+        if (!TryGetDayMonthFromParts(natural.Groups["first"].Value, natural.Groups["second"].Value,
+                out var naturalDay, out var naturalMonth))
+        {
+            error = "The day must be a number.";
+            return false;
+        }
+
+        var periodText = natural.Groups["period"].Value;
+        var periods = _regnalPeriods.Where(x =>
+                                    x.Key.EqualTo(periodText) ||
+                                    x.ShortName.EqualTo(periodText) ||
+                                    x.FullName.EqualTo(periodText))
+                                .ToList();
+        if (periods.Count != 1)
+        {
+            error = periods.Count == 0
+                ? $"There is no regnal period called {periodText.ColourCommand()}."
+                : $"The regnal period name {periodText.ColourCommand()} is ambiguous. Use the @key form instead.";
+            return false;
+        }
+
+        return TryGetDateFromRegnalDate(periods[0].Key,
+            natural.Groups["year"].Value.GetIntFromOrdinal() ?? 0, naturalDay, naturalMonth,
+            allowProjected, out date, out error);
+    }
+
+    private static bool TryGetDayMonthFromParts(string first, string second, out int day, out string month)
+    {
+        if (first.GetIntFromOrdinal() is { } firstDay)
+        {
+            day = firstDay;
+            month = second;
+            return true;
+        }
+
+        if (second.GetIntFromOrdinal() is { } secondDay)
+        {
+            day = secondDay;
+            month = first;
+            return true;
+        }
+
+        day = 0;
+        month = string.Empty;
+        return false;
+    }
+
+    private static bool LooksLikeRegnalDateText(string text)
+    {
+        return text.StartsWith("regnal:", StringComparison.InvariantCultureIgnoreCase) ||
+               CanonicalRegnalDateRegex.IsMatch(text) ||
+               NaturalRegnalDateRegex.IsMatch(text);
+    }
+
     /// <summary>
     ///     Creates a new Date based on a date string. Throws an exception if it runs into an error.
     /// </summary>
@@ -1049,6 +1412,16 @@ public class Calendar : SaveableItem, ICalendar
     /// <returns>A new object of class Date containing the date information for the specified date in this calendar</returns>
     public MudDate GetDate(string dateString)
     {
+        if (TryGetDateFromRegnalText(dateString, true, out var regnalDate, out var regnalError))
+        {
+            return regnalDate;
+        }
+
+        if (LooksLikeRegnalDateText(dateString))
+        {
+            throw new MUDDateException(regnalError);
+        }
+
         // TODO - possibly make a culture specific version of this
         char[] splitOptions = { '-', '/', ' ' };
         List<string> dateStringSplit = dateString.Split('/').ToList();
@@ -1142,6 +1515,17 @@ You can also use #3/#0, #3-#0 or spaces to separate the three parts of your date
 
     public bool TryGetDate(string dateString, IFormatProvider format, out MudDate date, out string error)
     {
+        if (TryGetDateFromRegnalText(dateString, true, out date, out error))
+        {
+            return true;
+        }
+
+        if (LooksLikeRegnalDateText(dateString))
+        {
+            date = new MudDate(CurrentDate);
+            return false;
+        }
+
         char[] splitOptions = { '-', '/', ' ' };
         List<string> dateStringSplit = dateString.Split('/').ToList();
         if (dateStringSplit.Count != 3)
@@ -1295,6 +1679,17 @@ You can also use #3/#0, #3-#0 or spaces to separate the three parts of your date
 
     public bool TryGetDate(string dateString, out MudDate date, out string error)
     {
+        if (TryGetDateFromRegnalText(dateString, true, out date, out error))
+        {
+            return true;
+        }
+
+        if (LooksLikeRegnalDateText(dateString))
+        {
+            date = new MudDate(CurrentDate);
+            return false;
+        }
+
         // TODO - possibly make a culture specific version of this
         char[] splitOptions = { '-', '/', ' ' };
         List<string> dateStringSplit = dateString.Split('/').ToList();
@@ -1411,11 +1806,20 @@ You can also use #3/#0, #3-#0 or spaces to separate the three parts of your date
                     : WordyString);
     }
 
+    private static readonly Regex RegnalKeyRegex = new(@"^[a-z0-9][a-z0-9-]*$", RegexOptions.IgnoreCase);
+    private static readonly Regex StructuredRegnalDateRegex =
+        new(@"^regnal:(?<key>[a-z0-9][a-z0-9-]*):(?<year>\d+):(?<month>[^:]+):(?<day>\d+(?:st|nd|rd|th)?)$", RegexOptions.IgnoreCase);
+    private static readonly Regex CanonicalRegnalDateRegex =
+        new(@"^(?<first>[^\s]+)\s+(?<second>[^\s]+)\s+RY(?<year>\d+)\s+@(?<key>[a-z0-9][a-z0-9-]*)$", RegexOptions.IgnoreCase);
+    private static readonly Regex NaturalRegnalDateRegex =
+        new(@"^(?<first>[^\s]+)\s+(?<second>[^\s]+)\s+(?<year>\d+(?:st|nd|rd|th)?)\s+(?<period>.+)$", RegexOptions.IgnoreCase);
     private static readonly Regex DateRegex = new(@"\$(?<code>[a-z]{2,2})", RegexOptions.IgnoreCase);
 
     public string DisplayDate(MudDate theDate, string mask)
     {
-        return DateRegex.Replace(mask, m =>
+        var regnalDate = GetRegnalDate(theDate);
+        var expandedMask = ExpandRegnalConditionals(mask, regnalDate is not null);
+        return DateRegex.Replace(expandedMask, m =>
                         {
                             switch (m.Groups["code"].Value)
                             {
@@ -1507,11 +1911,79 @@ You can also use #3/#0, #3-#0 or spaces to separate the three parts of your date
                                     return theDate.Year < 1 ? AncientEraShortString : ModernEraShortString;
                                 case "EE":
                                     return theDate.Year < 1 ? AncientEraLongString : ModernEraLongString;
+                                case "rk":
+                                    return regnalDate is null ? "" : $"@{regnalDate.Period.Key}";
+                                case "rs":
+                                    return regnalDate?.Period.ShortName ?? "";
+                                case "rf":
+                                    return regnalDate?.Period.FullName ?? "";
+                                case "rn":
+                                    return regnalDate?.RegnalYear.ToString() ?? "";
+                                case "rN":
+                                    return regnalDate?.RegnalYear.ToWordyNumber() ?? "";
+                                case "rt":
+                                    return regnalDate?.RegnalYear.ToOrdinal() ?? "";
+                                case "rT":
+                                    return regnalDate?.RegnalYear.ToWordyOrdinal() ?? "";
+                                case "rq":
+                                    return regnalDate?.CanonicalYearText ??
+                                           $"{(theDate.Year < 1 ? (theDate.Year * -1 + 1).ToString() : theDate.Year.ToString())} {(theDate.Year < 1 ? AncientEraShortString : ModernEraShortString)}";
+                                case "rp":
+                                    return regnalDate is null
+                                        ? $"{(theDate.Year < 1 ? (theDate.Year * -1 + 1).ToOrdinal() : theDate.Year.ToOrdinal())} {(theDate.Year < 1 ? AncientEraLongString : ModernEraLongString)}"
+                                        : $"{regnalDate.RegnalYear.ToOrdinal()} year of {regnalDate.Period.FullName}";
                             }
 
                             return m.Value;
                         })
                         .NormaliseSpacing();
+    }
+
+    private static string ExpandRegnalConditionals(string mask, bool hasRegnalDate)
+    {
+        const string token = "$ir";
+        var sb = new StringBuilder(mask.Length);
+        var index = 0;
+        while (index < mask.Length)
+        {
+            var tokenIndex = mask.IndexOf(token, index, StringComparison.InvariantCultureIgnoreCase);
+            if (tokenIndex < 0)
+            {
+                sb.Append(mask, index, mask.Length - index);
+                break;
+            }
+
+            sb.Append(mask, index, tokenIndex - index);
+            var firstOpen = tokenIndex + token.Length;
+            if (firstOpen >= mask.Length || mask[firstOpen] != '{')
+            {
+                sb.Append(token);
+                index = firstOpen;
+                continue;
+            }
+
+            var firstClose = mask.IndexOf('}', firstOpen + 1);
+            if (firstClose < 0 || firstClose + 1 >= mask.Length || mask[firstClose + 1] != '{')
+            {
+                sb.Append(mask, tokenIndex, mask.Length - tokenIndex);
+                break;
+            }
+
+            var secondOpen = firstClose + 1;
+            var secondClose = mask.IndexOf('}', secondOpen + 1);
+            if (secondClose < 0)
+            {
+                sb.Append(mask, tokenIndex, mask.Length - tokenIndex);
+                break;
+            }
+
+            var regnalBranch = mask.Substring(firstOpen + 1, firstClose - firstOpen - 1);
+            var fallbackBranch = mask.Substring(secondOpen + 1, secondClose - secondOpen - 1);
+            sb.Append(hasRegnalDate ? regnalBranch : fallbackBranch);
+            index = secondClose + 1;
+        }
+
+        return sb.ToString();
     }
 
     #endregion
@@ -1662,6 +2134,7 @@ You can also use #3/#0, #3-#0 or spaces to separate the three parts of your date
 	#3epoch <year> <weekday>#0 - sets the epoch year and first weekday
 	#3short|long|wordy <mask>#0 - changes display masks
 	#3era <ancient|modern> <short|long> <text>#0 - changes era text
+	#3regnal list|add|close|name|start|end|remove|preview ...#0 - edits regnal period metadata
 	#3weekday add|rename|remove ...#0 - edits weekdays
 	#3month add|rename|alias|short|days|order|remove|nonweekday|special ...#0 - edits months
 	#3intercalary day|month ...#0 - edits intercalary day and month rules
@@ -1710,6 +2183,10 @@ You can also use #3/#0, #3-#0 or spaces to separate the three parts of your date
                 return BuildingCommandWordyMask(actor, command);
             case "era":
                 return BuildingCommandEra(actor, command);
+            case "regnal":
+            case "regnalperiod":
+            case "regnalperiods":
+                return BuildingCommandRegnal(actor, command);
             case "weekday":
             case "weekdays":
                 return BuildingCommandWeekday(actor, command);
@@ -2085,6 +2562,298 @@ You can also use #3/#0, #3-#0 or spaces to separate the three parts of your date
         Changed = true;
         actor.OutputHandler.Send("Era text set.");
         return true;
+    }
+
+    private bool BuildingCommandRegnal(ICharacter actor, StringStack command)
+    {
+        switch (command.PopForSwitch())
+        {
+            case "list":
+            case "":
+                return BuildingCommandRegnalList(actor);
+            case "add":
+            case "new":
+                return BuildingCommandRegnalAdd(actor, command);
+            case "close":
+                return BuildingCommandRegnalClose(actor, command);
+            case "name":
+                return BuildingCommandRegnalName(actor, command);
+            case "start":
+                return BuildingCommandRegnalStart(actor, command);
+            case "end":
+                return BuildingCommandRegnalEnd(actor, command);
+            case "remove":
+            case "delete":
+            case "del":
+                return BuildingCommandRegnalRemove(actor, command);
+            case "preview":
+                return BuildingCommandRegnalPreview(actor, command);
+            default:
+                actor.OutputHandler.Send("Syntax: regnal list|add|close|name|start|end|remove|preview ...");
+                return false;
+        }
+    }
+
+    private bool BuildingCommandRegnalList(ICharacter actor)
+    {
+        if (!_regnalPeriods.Any())
+        {
+            actor.OutputHandler.Send("This calendar does not define any regnal periods.");
+            return false;
+        }
+
+        var rows = SortRegnalPeriods(_regnalPeriods)
+                   .Select(period => new[]
+                   {
+                       period.Key,
+                       period.ShortName,
+                       period.FullName,
+                       DisplayDate(period.StartDate, CalendarDisplayMode.Short),
+                       period.EndDate is null ? "Open" : DisplayDate(period.EndDate, CalendarDisplayMode.Short)
+                   });
+        actor.OutputHandler.Send(StringUtilities.GetTextTable(rows,
+            new[] { "Key", "Short", "Full", "Start", "End" }, actor, Telnet.Cyan));
+        return false;
+    }
+
+    private bool BuildingCommandRegnalAdd(ICharacter actor, StringStack command)
+    {
+        var key = command.PopSpeech();
+        var shortName = command.PopSpeech();
+        var fullName = command.PopSpeech();
+        var startText = command.PopSpeech();
+        if (string.IsNullOrEmpty(key) || string.IsNullOrEmpty(shortName) || string.IsNullOrEmpty(fullName) ||
+            string.IsNullOrEmpty(startText))
+        {
+            actor.OutputHandler.Send("Syntax: regnal add <key> \"<short>\" \"<full>\" <start> [<end>|open]");
+            return false;
+        }
+
+        if (_regnalPeriods.Any(x => x.Key.EqualTo(key)))
+        {
+            actor.OutputHandler.Send($"There is already a regnal period with the key {key.ColourCommand()}.");
+            return false;
+        }
+
+        if (!TryGetDate(startText, actor, out var startDate, out var startError))
+        {
+            actor.OutputHandler.Send(startError);
+            return false;
+        }
+
+        MudDate endDate = null;
+        if (!command.IsFinished)
+        {
+            var endText = command.SafeRemainingArgument;
+            if (!endText.EqualTo("open"))
+            {
+                if (!TryGetDate(endText, actor, out endDate, out var endError))
+                {
+                    actor.OutputHandler.Send(endError);
+                    return false;
+                }
+            }
+        }
+
+        var proposed = CopyRegnalPeriods();
+        proposed.Add(new RegnalPeriod(key.ToLowerInvariant(), shortName, fullName, startDate, endDate));
+        return ApplyRegnalPeriodChange(actor, $"add regnal period {key}",
+            proposed, $"You add regnal period {fullName.ColourName()} with key {key.ColourCommand()}.");
+    }
+
+    private bool BuildingCommandRegnalClose(ICharacter actor, StringStack command)
+    {
+        var key = command.PopSpeech();
+        if (string.IsNullOrEmpty(key) || command.IsFinished)
+        {
+            actor.OutputHandler.Send("Syntax: regnal close <key> <end>");
+            return false;
+        }
+
+        if (!TryGetDate(command.SafeRemainingArgument, actor, out var endDate, out var error))
+        {
+            actor.OutputHandler.Send(error);
+            return false;
+        }
+
+        var proposed = CopyRegnalPeriods();
+        var period = proposed.FirstOrDefault(x => x.Key.EqualTo(key));
+        if (period is null)
+        {
+            actor.OutputHandler.Send($"There is no regnal period with the key {key.ColourCommand()}.");
+            return false;
+        }
+
+        period.EndDate = endDate;
+        return ApplyRegnalPeriodChange(actor, $"close regnal period {key}",
+            proposed, $"You close regnal period {period.FullName.ColourName()} on {DisplayDate(endDate, CalendarDisplayMode.Long).ColourValue()}.");
+    }
+
+    private bool BuildingCommandRegnalName(ICharacter actor, StringStack command)
+    {
+        var key = command.PopSpeech();
+        var which = command.PopForSwitch();
+        if (string.IsNullOrEmpty(key) || string.IsNullOrEmpty(which) || command.IsFinished)
+        {
+            actor.OutputHandler.Send("Syntax: regnal name <key> short|full <text>");
+            return false;
+        }
+
+        var proposed = CopyRegnalPeriods();
+        var period = proposed.FirstOrDefault(x => x.Key.EqualTo(key));
+        if (period is null)
+        {
+            actor.OutputHandler.Send($"There is no regnal period with the key {key.ColourCommand()}.");
+            return false;
+        }
+
+        switch (which)
+        {
+            case "short":
+                period.ShortName = command.SafeRemainingArgument;
+                break;
+            case "full":
+                period.FullName = command.SafeRemainingArgument;
+                break;
+            default:
+                actor.OutputHandler.Send("You must specify short or full.");
+                return false;
+        }
+
+        return ApplyRegnalPeriodChange(actor, $"rename regnal period {key}",
+            proposed, $"You update the {which.ColourCommand()} name for regnal period {key.ColourCommand()}.");
+    }
+
+    private bool BuildingCommandRegnalStart(ICharacter actor, StringStack command)
+    {
+        var key = command.PopSpeech();
+        if (string.IsNullOrEmpty(key) || command.IsFinished)
+        {
+            actor.OutputHandler.Send("Syntax: regnal start <key> <date>");
+            return false;
+        }
+
+        if (!TryGetDate(command.SafeRemainingArgument, actor, out var startDate, out var error))
+        {
+            actor.OutputHandler.Send(error);
+            return false;
+        }
+
+        var proposed = CopyRegnalPeriods();
+        var period = proposed.FirstOrDefault(x => x.Key.EqualTo(key));
+        if (period is null)
+        {
+            actor.OutputHandler.Send($"There is no regnal period with the key {key.ColourCommand()}.");
+            return false;
+        }
+
+        period.StartDate = startDate;
+        return ApplyRegnalPeriodChange(actor, $"change start of regnal period {key}",
+            proposed, $"You change the start date for {period.FullName.ColourName()} to {DisplayDate(startDate, CalendarDisplayMode.Long).ColourValue()}.");
+    }
+
+    private bool BuildingCommandRegnalEnd(ICharacter actor, StringStack command)
+    {
+        var key = command.PopSpeech();
+        if (string.IsNullOrEmpty(key) || command.IsFinished)
+        {
+            actor.OutputHandler.Send("Syntax: regnal end <key> <date|open>");
+            return false;
+        }
+
+        var endText = command.SafeRemainingArgument;
+        MudDate endDate = null;
+        if (!endText.EqualTo("open"))
+        {
+            if (!TryGetDate(endText, actor, out endDate, out var error))
+            {
+                actor.OutputHandler.Send(error);
+                return false;
+            }
+        }
+
+        var proposed = CopyRegnalPeriods();
+        var period = proposed.FirstOrDefault(x => x.Key.EqualTo(key));
+        if (period is null)
+        {
+            actor.OutputHandler.Send($"There is no regnal period with the key {key.ColourCommand()}.");
+            return false;
+        }
+
+        period.EndDate = endDate;
+        return ApplyRegnalPeriodChange(actor, $"change end of regnal period {key}",
+            proposed, endDate is null
+                ? $"You make {period.FullName.ColourName()} the open-ended regnal period."
+                : $"You change the end date for {period.FullName.ColourName()} to {DisplayDate(endDate, CalendarDisplayMode.Long).ColourValue()}.");
+    }
+
+    private bool BuildingCommandRegnalRemove(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Syntax: regnal remove <key>");
+            return false;
+        }
+
+        var key = command.SafeRemainingArgument;
+        var proposed = CopyRegnalPeriods();
+        var period = proposed.FirstOrDefault(x => x.Key.EqualTo(key));
+        if (period is null)
+        {
+            actor.OutputHandler.Send($"There is no regnal period with the key {key.ColourCommand()}.");
+            return false;
+        }
+
+        proposed.Remove(period);
+        return ApplyRegnalPeriodChange(actor, $"remove regnal period {key}",
+            proposed, $"You remove regnal period {period.FullName.ColourName()}.");
+    }
+
+    private bool BuildingCommandRegnalPreview(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Syntax: regnal preview <date>");
+            return false;
+        }
+
+        if (!TryGetDate(command.SafeRemainingArgument, actor, out var date, out var error))
+        {
+            actor.OutputHandler.Send(error);
+            return false;
+        }
+
+        if (GetRegnalDate(date) is not { } regnalDate)
+        {
+            actor.OutputHandler.Send($"{DisplayDate(date, CalendarDisplayMode.Long).ColourValue()} is not inside a regnal period.");
+            return false;
+        }
+
+        actor.OutputHandler.Send($"{DisplayDate(date, CalendarDisplayMode.Long).ColourValue()} is {regnalDate.CanonicalYearText.ColourCommand()} ({regnalDate.RegnalYear.ToOrdinal().ColourValue()} year of {regnalDate.Period.FullName.ColourName()}).");
+        return false;
+    }
+
+    private List<RegnalPeriod> CopyRegnalPeriods()
+    {
+        return _regnalPeriods.Select(x => x.Clone()).ToList();
+    }
+
+    private bool ApplyRegnalPeriodChange(ICharacter actor, string description, IEnumerable<RegnalPeriod> proposed,
+        string successMessage)
+    {
+        var proposedList = proposed.ToList();
+        if (!TryValidateRegnalPeriods(proposedList, out var error))
+        {
+            actor.OutputHandler.Send(error);
+            return false;
+        }
+
+        return ConfirmStructuralChange(actor, description, () =>
+        {
+            _regnalPeriods = SortRegnalPeriods(proposedList).ToList();
+            Changed = true;
+            actor.OutputHandler.Send(successMessage);
+        });
     }
 
     private bool BuildingCommandWeekday(ICharacter actor, StringStack command)
@@ -2721,6 +3490,11 @@ You can also use #3/#0, #3-#0 or spaces to separate the three parts of your date
         sb.AppendLine($"Wordy Mask: {WordyString.ColourCommand()}");
         sb.AppendLine($"Ancient Era: {AncientEraShortString.ColourValue()} / {AncientEraLongString.ColourValue()}");
         sb.AppendLine($"Modern Era: {ModernEraShortString.ColourValue()} / {ModernEraLongString.ColourValue()}");
+        sb.AppendLine($"Regnal Periods: {_regnalPeriods.Count.ToStringN0(actor).ColourValue()}");
+        foreach (var period in SortRegnalPeriods(_regnalPeriods))
+        {
+            sb.AppendLine($"\t{period.Key.ColourCommand()} - {period.ShortName.ColourName()} / {period.FullName.ColourName()} ({DisplayDate(period.StartDate, CalendarDisplayMode.Short).ColourValue()} to {(period.EndDate is null ? "Open".ColourValue() : DisplayDate(period.EndDate, CalendarDisplayMode.Short).ColourValue())})");
+        }
         sb.AppendLine($"Weekdays: {Weekdays.Select((x, i) => $"{(i + 1).ToStringN0(actor)}. {x.ColourValue()}").ListToString()}");
         sb.AppendLine("Months:");
         foreach (var month in Months.OrderBy(x => x.NominalOrder))

--- a/MudSharpCore/TimeAndDate/Date/RegnalPeriod.cs
+++ b/MudSharpCore/TimeAndDate/Date/RegnalPeriod.cs
@@ -1,0 +1,75 @@
+#nullable enable
+
+using MudSharp.Framework;
+using System.Xml.Linq;
+
+namespace MudSharp.TimeAndDate.Date;
+
+public class RegnalPeriod : IRegnalPeriod
+{
+	public RegnalPeriod(string key, string shortName, string fullName, MudDate startDate, MudDate? endDate)
+	{
+		Key = key;
+		ShortName = shortName;
+		FullName = fullName;
+		StartDate = new MudDate(startDate);
+		EndDate = endDate is null ? null : new MudDate(endDate);
+	}
+
+	public RegnalPeriod(ICalendar calendar, XElement element)
+	{
+		Key = element.Attribute("key")?.Value ?? element.Element("key")?.Value ?? string.Empty;
+		ShortName = element.Attribute("short")?.Value ?? element.Element("short")?.Value ?? string.Empty;
+		FullName = element.Attribute("full")?.Value ?? element.Element("full")?.Value ?? string.Empty;
+
+		var startText = element.Attribute("start")?.Value ?? element.Element("start")?.Value;
+		if (string.IsNullOrWhiteSpace(startText))
+		{
+			throw new MUDDateException("Regnal period did not have a start date.");
+		}
+
+		StartDate = calendar.GetDate(startText);
+
+		var endText = element.Attribute("end")?.Value ?? element.Element("end")?.Value;
+		EndDate = string.IsNullOrWhiteSpace(endText) || endText.EqualTo("open")
+			? null
+			: calendar.GetDate(endText);
+	}
+
+	public string Key { get; }
+
+	public string ShortName { get; set; }
+
+	public string FullName { get; set; }
+
+	public MudDate StartDate { get; set; }
+
+	public MudDate? EndDate { get; set; }
+
+	public bool IsOpenEnded => EndDate is null;
+
+	public bool Contains(MudDate date)
+	{
+		return date >= StartDate && (EndDate is null || date <= EndDate);
+	}
+
+	public RegnalPeriod Clone()
+	{
+		return new RegnalPeriod(Key, ShortName, FullName, StartDate, EndDate);
+	}
+
+	public XElement SaveToXml()
+	{
+		var element = new XElement("regnalperiod",
+			new XAttribute("key", Key),
+			new XAttribute("short", ShortName),
+			new XAttribute("full", FullName),
+			new XAttribute("start", StartDate.GetDateString()));
+		if (EndDate is not null)
+		{
+			element.Add(new XAttribute("end", EndDate.GetDateString()));
+		}
+
+		return element;
+	}
+}


### PR DESCRIPTION
## Summary
- Add regnal-year awareness to the date/time model and calendar interfaces.
- Introduce `RegnalDateInfo` and `RegnalPeriod` support in the core time system.
- Update `MudDateTime` and related date types to carry and render regnal context.
- Refresh the world time and date design document to match the new behavior.
- Extend unit coverage for `MudDateTime` regnal handling.

## Testing
- Added/updated unit tests covering regnal date formatting and calendar behavior.
- Not run (not requested).