### PR TITLE
Expose trial progress, legal status, and surrender prompts

### DIFF
--- a/Design Documents/Economy/Law_System_Runtime.md
+++ b/Design Documents/Economy/Law_System_Runtime.md
@@ -102,11 +102,13 @@ If required rooms, tools, paths, or targets become unavailable for too long, the
 
 Trials are represented by the `OnTrial` effect for the relevant legal authority. NPC judges drive ordinary `OnTrial` effects through the automated plea, argument, verdict, and sentencing phases. PC-held trials use the same effect as a court-session marker, but set the manual-trial flag so NPC judge AI will not advance or finalise the case.
 
+Automated trial effects persist their current phase, manual-trial flag, remaining per-charge queue, pleas, argument outcomes, and punishment results. If the game reboots mid-trial, the resumed `trial` view continues revealing only the charges, pleas, verdicts, and sentences that had actually been reached before the reboot.
+
 A PC judge is any enforcer whose enforcement authority has `CanConvict` for the jurisdiction and whose authority can judge the defendant's legal class.
 
 Judge-facing trial commands:
 
-- `trial`: shows the active trial in the current room.
+- `trial`: shows the active trial in the current room. The active-trial view includes a per-charge progress table. Automated trials reveal coded details as the judge reaches each phase: charges, pleas, prosecution and defense argument quality, verdicts, and then announced sentences. During sentencing, a consolidated sentence summary appears below the table and grows only as individual sentences are announced. PC-held trials use the same table, but plea and argument quality are marked as roleplayed/manual surfaces and verdict/sentence columns reflect recorded `convict` and `acquit` results.
 - `trial docket [jurisdiction]`: lists defendants awaiting trial for the judge's jurisdictions, including remand/bail/trial status, open charge counts, a compact charge-name summary, wrapped charge ID details, and prior local convictions.
 - `trial summon <target>`: from the jurisdiction courtroom, calls a remand prisoner or present defendant before the court and begins a PC-held trial.
 - `convict <target> <crime> <sentence>`: records a guilty verdict and sentence for one charge.
@@ -129,6 +131,8 @@ When the return deadline expires, the bail heartbeat attempts to record a `Viola
 The `trial docket` command distinguishes active bail from bail-revoked at-large defendants so PC judges can see why a person is not currently summonable.
 
 Prisoners can engage legal counsel while physically held in a remand cell, and advocates can hire counsel for remand prisoners from a remand cell as well as from the legal authority's prison location. `engagelawyer list` only lists remand prisoners who do not already have counsel. When a remand prisoner hires counsel for themselves without specifying a bank account, the cash payment can draw from their carried cash and from the prison-belongings bundle stored for that legal authority, allowing legal fees to be paid from money confiscated during remand intake.
+
+`score` includes legal status addenda for characters on remand, on bail, serving a custodial sentence, or awaiting execution. Execution status uses the more precise time display so condemned characters can see the scheduled execution time.
 
 ## Patrol Route Diagnostics
 

--- a/Design Documents/Economy/Law_System_Runtime.md
+++ b/Design Documents/Economy/Law_System_Runtime.md
@@ -134,6 +134,8 @@ Prisoners can engage legal counsel while physically held in a remand cell, and a
 
 `score` includes legal status addenda for characters on remand, on bail, serving a custodial sentence, or awaiting execution. Execution status uses the more precise time display so condemned characters can see the scheduled execution time.
 
+Room `look` descriptions include yellow command hints when a character can surrender to legal authorities in that room. Characters on bail see a `RETURNBAIL` prompt at the jurisdiction's prison location, and characters warned by an enforcement patrol see a `SURRENDER` prompt while an accepting patrol member is present.
+
 ## Patrol Route Diagnostics
 
 Inactive patrol-route output reports both whether the route should begin and, when it should not, the first blocking reason. Reasons include routes not marked ready, missing patrol nodes, crime-targeted or corpse-recovery routes waiting for a trigger, strategy-specific configuration or target blockers, a false start prog, no required enforcers, no enforcement zones, or a current time of day outside the route schedule.

--- a/MudSharpCore Unit Tests/LegalTrialFlowTests.cs
+++ b/MudSharpCore Unit Tests/LegalTrialFlowTests.cs
@@ -17,6 +17,7 @@ using MudSharp.TimeAndDate.Date;
 using MudSharp.TimeAndDate.Time;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml.Linq;
 using DbCrime = MudSharp.Models.Crime;
 
@@ -241,6 +242,100 @@ public class LegalTrialFlowTests
 		StringAssert.Contains(effects[2].ScoreAddendum.StripANSIColour(), "custodial sentence");
 		StringAssert.Contains(effects[3].ScoreAddendum.StripANSIColour(), "awaiting execution");
 		StringAssert.Contains(effects[3].ScoreAddendum.StripANSIColour(), MudDateTime.Never.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Immortal));
+	}
+
+	[TestMethod]
+	public void LegalSurrenderRoomDescriptionAddenda_ShouldPromptForReturnBailAtPrison()
+	{
+		Mock<ICell> prison = new();
+		Mock<ICell> elsewhere = new();
+
+		Mock<ILegalAuthority> authority = new();
+		authority.SetupGet(x => x.Name).Returns("Test Authority");
+		authority.SetupGet(x => x.PrisonLocation).Returns(prison.Object);
+
+		Mock<ICharacter> actor = new();
+		actor.SetupGet(x => x.Location).Returns(prison.Object);
+		OnBail bail = new(actor.Object, authority.Object, MudDateTime.Never);
+		OnBail[] bailEffects = [bail];
+		actor.Setup(x => x.EffectsOfType<OnBail>(It.IsAny<Predicate<OnBail>>()))
+		     .Returns((Predicate<OnBail>? predicate) => bailEffects.Where(x => predicate?.Invoke(x) ?? true));
+		actor.Setup(x => x.EffectsOfType<WarnedByEnforcer>(It.IsAny<Predicate<WarnedByEnforcer>>()))
+		     .Returns(Array.Empty<WarnedByEnforcer>());
+
+		List<string> prisonAddenda = Cell.LegalSurrenderRoomDescriptionAddenda(actor.Object, prison.Object)
+		                                  .Select(x => x.StripANSIColour())
+		                                  .ToList();
+		List<string> elsewhereAddenda = Cell.LegalSurrenderRoomDescriptionAddenda(actor.Object, elsewhere.Object)
+		                                      .Select(x => x.StripANSIColour())
+		                                      .ToList();
+
+		Assert.AreEqual(1, prisonAddenda.Count);
+		StringAssert.Contains(prisonAddenda[0], "on bail");
+		StringAssert.Contains(prisonAddenda[0], "RETURNBAIL");
+		StringAssert.Contains(prisonAddenda[0], "Test Authority");
+		Assert.AreEqual(0, elsewhereAddenda.Count);
+	}
+
+	[TestMethod]
+	public void LegalSurrenderRoomDescriptionAddenda_ShouldPromptForWantedSurrenderWhenEnforcersArePresent()
+	{
+		Mock<ICell> cell = new();
+
+		Mock<ILegalAuthority> authority = new();
+		authority.SetupGet(x => x.Name).Returns("Test Authority");
+
+		Mock<ICrime> crime = new();
+		Mock<ICharacter> actor = new();
+		actor.SetupGet(x => x.Location).Returns(cell.Object);
+		Mock<ICharacter> enforcer = new();
+		enforcer.Setup(x => x.ColocatedWith(actor.Object)).Returns(true);
+
+		Mock<IPatrol> patrol = new();
+		patrol.SetupGet(x => x.PatrolMembers).Returns([enforcer.Object]);
+
+		WarnedByEnforcer warned = new(actor.Object, authority.Object, crime.Object, patrol.Object);
+		WarnedByEnforcer[] warningEffects = [warned];
+		actor.Setup(x => x.EffectsOfType<OnBail>(It.IsAny<Predicate<OnBail>>()))
+		     .Returns(Array.Empty<OnBail>());
+		actor.Setup(x => x.EffectsOfType<WarnedByEnforcer>(It.IsAny<Predicate<WarnedByEnforcer>>()))
+		     .Returns((Predicate<WarnedByEnforcer>? predicate) => warningEffects.Where(x => predicate?.Invoke(x) ?? true));
+
+		List<string> addenda = Cell.LegalSurrenderRoomDescriptionAddenda(actor.Object, cell.Object)
+		                           .Select(x => x.StripANSIColour())
+		                           .ToList();
+
+		Assert.AreEqual(1, addenda.Count);
+		StringAssert.Contains(addenda[0], "wanted");
+		StringAssert.Contains(addenda[0], "SURRENDER");
+		StringAssert.Contains(addenda[0], "Test Authority");
+	}
+
+	[TestMethod]
+	public void LegalSurrenderRoomDescriptionAddenda_ShouldNotPromptForWantedSurrenderWithoutPresentEnforcers()
+	{
+		Mock<ICell> cell = new();
+
+		Mock<ILegalAuthority> authority = new();
+		authority.SetupGet(x => x.Name).Returns("Test Authority");
+
+		Mock<ICrime> crime = new();
+		Mock<ICharacter> actor = new();
+		actor.SetupGet(x => x.Location).Returns(cell.Object);
+		Mock<ICharacter> enforcer = new();
+		enforcer.Setup(x => x.ColocatedWith(actor.Object)).Returns(false);
+
+		Mock<IPatrol> patrol = new();
+		patrol.SetupGet(x => x.PatrolMembers).Returns([enforcer.Object]);
+
+		WarnedByEnforcer warned = new(actor.Object, authority.Object, crime.Object, patrol.Object);
+		WarnedByEnforcer[] warningEffects = [warned];
+		actor.Setup(x => x.EffectsOfType<OnBail>(It.IsAny<Predicate<OnBail>>()))
+		     .Returns(Array.Empty<OnBail>());
+		actor.Setup(x => x.EffectsOfType<WarnedByEnforcer>(It.IsAny<Predicate<WarnedByEnforcer>>()))
+		     .Returns((Predicate<WarnedByEnforcer>? predicate) => warningEffects.Where(x => predicate?.Invoke(x) ?? true));
+
+		Assert.AreEqual(0, Cell.LegalSurrenderRoomDescriptionAddenda(actor.Object, cell.Object).Count());
 	}
 
 	[TestMethod]

--- a/MudSharpCore Unit Tests/LegalTrialFlowTests.cs
+++ b/MudSharpCore Unit Tests/LegalTrialFlowTests.cs
@@ -6,12 +6,15 @@ using MudSharp.Character;
 using MudSharp.Construction;
 using MudSharp.Effects;
 using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
 using MudSharp.Framework;
 using MudSharp.Framework.Save;
 using MudSharp.FutureProg;
 using MudSharp.PerceptionEngine;
 using MudSharp.RPG.Law;
 using MudSharp.TimeAndDate;
+using MudSharp.TimeAndDate.Date;
+using MudSharp.TimeAndDate.Time;
 using System;
 using System.Collections.Generic;
 using System.Xml.Linq;
@@ -60,6 +63,63 @@ public class LegalTrialFlowTests
 	}
 
 	[TestMethod]
+	public void OnTrial_LoadEffect_ShouldPreserveCrimeQueueAndPunishments()
+	{
+		Mock<ILegalAuthority> authority = new();
+		authority.SetupGet(x => x.Id).Returns(1L);
+		authority.SetupGet(x => x.Name).Returns("Test Authority");
+
+		Mock<ICrime> firstCrime = new();
+		firstCrime.SetupGet(x => x.Id).Returns(10L);
+
+		Mock<ICrime> secondCrime = new();
+		secondCrime.SetupGet(x => x.Id).Returns(11L);
+
+		All<ILegalAuthority> legalAuthorities = new();
+		legalAuthorities.Add(authority.Object);
+
+		All<ICrime> crimes = new();
+		crimes.Add(firstCrime.Object);
+		crimes.Add(secondCrime.Object);
+
+		Mock<IFuturemud> gameworld = new();
+		gameworld.SetupGet(x => x.LegalAuthorities).Returns(legalAuthorities);
+		gameworld.SetupGet(x => x.Crimes).Returns(crimes);
+		gameworld.SetupGet(x => x.FutureProgs).Returns(new All<IFutureProg>());
+
+		Mock<ICharacter> owner = new();
+		owner.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+
+		OnTrial.InitialiseEffectType();
+		OnTrial trial = new(owner.Object, authority.Object, DateTime.UtcNow, [firstCrime.Object, secondCrime.Object])
+		{
+			Phase = TrialPhase.Sentencing
+		};
+		trial.Punishments[firstCrime.Object] = new PunishmentResult
+		{
+			Fine = 12.5M,
+			CustodialSentence = MudTimeSpan.FromDays(3.0),
+			GoodBehaviourBondLength = MudTimeSpan.FromDays(30.0),
+			Execution = true
+		};
+		trial.Punishments[secondCrime.Object] = new PunishmentResult();
+		Assert.AreSame(firstCrime.Object, trial.NextCrime());
+
+		OnTrial loaded = (OnTrial)Effect.LoadEffect(trial.SaveToXml(new Dictionary<IEffect, TimeSpan>()), owner.Object);
+
+		Assert.AreEqual(TrialPhase.Sentencing, loaded.Phase);
+		Assert.IsTrue(loaded.Punishments.ContainsKey(firstCrime.Object));
+		Assert.IsTrue(loaded.Punishments.ContainsKey(secondCrime.Object));
+		Assert.AreEqual(12.5M, loaded.Punishments[firstCrime.Object].Fine);
+		Assert.AreEqual(MudTimeSpan.FromDays(3.0), loaded.Punishments[firstCrime.Object].CustodialSentence);
+		Assert.AreEqual(MudTimeSpan.FromDays(30.0), loaded.Punishments[firstCrime.Object].GoodBehaviourBondLength);
+		Assert.IsTrue(loaded.Punishments[firstCrime.Object].Execution);
+		Assert.IsTrue(loaded.HasSentenceBeenAnnounced(firstCrime.Object));
+		Assert.IsFalse(loaded.HasSentenceBeenAnnounced(secondCrime.Object));
+		Assert.AreSame(secondCrime.Object, loaded.NextCrime());
+	}
+
+	[TestMethod]
 	public void OnTrial_Applies_ShouldFilterByLegalAuthority()
 	{
 		Mock<ILegalAuthority> authority = new();
@@ -79,6 +139,108 @@ public class LegalTrialFlowTests
 
 		Assert.IsTrue(trial.Applies(authority.Object));
 		Assert.IsFalse(trial.Applies(otherAuthority.Object));
+	}
+
+	[TestMethod]
+	public void OnTrial_HasPleaBeenEntered_ShouldFollowPleaQueue()
+	{
+		Mock<ILegalAuthority> authority = new();
+		authority.SetupGet(x => x.Id).Returns(1L);
+		authority.SetupGet(x => x.Name).Returns("Test Authority");
+
+		Mock<ICrime> firstCrime = new();
+		firstCrime.SetupGet(x => x.Id).Returns(10L);
+
+		Mock<ICrime> secondCrime = new();
+		secondCrime.SetupGet(x => x.Id).Returns(11L);
+
+		Mock<ICharacter> owner = new();
+		owner.Setup(x => x.EffectsOfType<ConsideringPlea>(It.IsAny<Predicate<ConsideringPlea>>()))
+		     .Returns(Array.Empty<ConsideringPlea>());
+
+		OnTrial trial = new(owner.Object, authority.Object, DateTime.UtcNow, [firstCrime.Object, secondCrime.Object])
+		{
+			Phase = TrialPhase.Plea
+		};
+
+		Assert.IsFalse(trial.HasPleaBeenEntered(firstCrime.Object));
+		Assert.IsFalse(trial.HasPleaBeenEntered(secondCrime.Object));
+
+		ICrime? askedCrime = trial.NextCrime();
+		trial.Pleas[askedCrime!] = false;
+
+		Assert.IsTrue(trial.HasPleaBeenEntered(firstCrime.Object));
+		Assert.IsFalse(trial.HasPleaBeenEntered(secondCrime.Object));
+	}
+
+	[TestMethod]
+	public void OnTrial_RevealState_ShouldNotRevealSentencesBeforeSentencingAnnouncement()
+	{
+		Mock<ILegalAuthority> authority = new();
+		authority.SetupGet(x => x.Id).Returns(1L);
+		authority.SetupGet(x => x.Name).Returns("Test Authority");
+
+		Mock<ICrime> firstCrime = new();
+		firstCrime.SetupGet(x => x.Id).Returns(10L);
+
+		Mock<ICrime> secondCrime = new();
+		secondCrime.SetupGet(x => x.Id).Returns(11L);
+
+		Mock<ICharacter> owner = new();
+		OnTrial trial = new(owner.Object, authority.Object, DateTime.UtcNow, [firstCrime.Object, secondCrime.Object])
+		{
+			Phase = TrialPhase.Verdict
+		};
+
+		Assert.IsFalse(trial.HasVerdictBeenAnnounced(firstCrime.Object));
+		Assert.IsFalse(trial.HasSentenceBeenAnnounced(firstCrime.Object));
+
+		ICrime? verdictCrime = trial.NextCrime();
+		trial.Punishments[verdictCrime!] = new PunishmentResult { Fine = 10.0M };
+
+		Assert.IsTrue(trial.HasVerdictBeenAnnounced(firstCrime.Object));
+		Assert.IsFalse(trial.HasSentenceBeenAnnounced(firstCrime.Object));
+		Assert.IsFalse(trial.HasVerdictBeenAnnounced(secondCrime.Object));
+
+		trial.ResetCrimeQueue();
+		trial.Phase = TrialPhase.Sentencing;
+
+		Assert.IsTrue(trial.HasVerdictBeenAnnounced(firstCrime.Object));
+		Assert.IsFalse(trial.HasSentenceBeenAnnounced(firstCrime.Object));
+
+		Assert.AreSame(firstCrime.Object, trial.NextCrime());
+		Assert.IsTrue(trial.HasSentenceBeenAnnounced(firstCrime.Object));
+	}
+
+	[TestMethod]
+	public void LegalCustodyEffects_ShouldShowInScore()
+	{
+		Mock<ILegalAuthority> authority = new();
+		authority.SetupGet(x => x.Id).Returns(1L);
+		authority.SetupGet(x => x.Name).Returns("Test Authority");
+
+		Mock<ICharacter> owner = new();
+
+		var effects = new IScoreAddendumEffect[]
+		{
+			new AwaitingSentencing(owner.Object, authority.Object, MudDateTime.Never),
+			new OnBail(owner.Object, authority.Object, MudDateTime.Never),
+			new ServingCustodialSentence(owner.Object, authority.Object, TimeSpan.FromDays(5.0), MudDateTime.Never),
+			new AwaitingExecution(owner.Object, authority.Object, MudDateTime.Never)
+		};
+
+		foreach (IScoreAddendumEffect effect in effects)
+		{
+			Assert.IsTrue(effect.ShowInScore);
+			Assert.IsFalse(effect.ShowInHealth);
+			StringAssert.Contains(effect.ScoreAddendum.StripANSIColour(), "Test Authority");
+		}
+
+		StringAssert.Contains(effects[0].ScoreAddendum.StripANSIColour(), "on remand");
+		StringAssert.Contains(effects[1].ScoreAddendum.StripANSIColour(), "on bail");
+		StringAssert.Contains(effects[2].ScoreAddendum.StripANSIColour(), "custodial sentence");
+		StringAssert.Contains(effects[3].ScoreAddendum.StripANSIColour(), "awaiting execution");
+		StringAssert.Contains(effects[3].ScoreAddendum.StripANSIColour(), MudDateTime.Never.ToString(CalendarDisplayMode.Short, TimeDisplayTypes.Immortal));
 	}
 
 	[TestMethod]

--- a/MudSharpCore/Commands/Modules/CrimeModule.cs
+++ b/MudSharpCore/Commands/Modules/CrimeModule.cs
@@ -2668,6 +2668,207 @@ The syntax is as follows:
             flags: OutputFlags.SuppressSource));
     }
 
+    private static string DescribeTrialPlea(OnTrial trial, ICrime crime)
+    {
+        if (trial.ManualTrial)
+        {
+            return "N/A".Colour(Telnet.Yellow);
+        }
+
+        if (!trial.HasPleaBeenEntered(crime))
+        {
+            return trial.CurrentPleaCrime == crime ? "Awaiting Plea".ColourCommand() : "Pending".Colour(Telnet.Yellow);
+        }
+
+        return trial.Pleas[crime] ? "Guilty".Colour(Telnet.Red) : "Not Guilty".Colour(Telnet.Green);
+    }
+
+    private static string DescribeTrialArgumentQuality(OnTrial trial, ICrime crime, bool defense)
+    {
+        if (trial.ManualTrial)
+        {
+            return "Roleplayed".ColourName();
+        }
+
+        CheckOutcome result = defense
+            ? trial.GetResultDefense(crime)[crime.DefenseDifficulty]
+            : trial.GetResultProsecution(crime)[crime.ProsecutionDifficulty];
+
+        if (result.Outcome == Outcome.NotTested)
+        {
+            return "Pending".Colour(Telnet.Yellow);
+        }
+
+        return result.IsAbjectFailure ? "Abject Failure".Colour(Telnet.BoldMagenta) : result.Outcome.DescribeColour();
+    }
+
+    private static string DescribeTrialVerdict(OnTrial trial, ICrime crime)
+    {
+        if (!trial.HasVerdictBeenAnnounced(crime))
+        {
+            return "Pending".Colour(Telnet.Yellow);
+        }
+
+        return (trial.ManualTrial ? crime.HasBeenConvicted : trial.Punishments.ContainsKey(crime))
+            ? "Guilty".Colour(Telnet.Red)
+            : "Not Guilty".Colour(Telnet.Green);
+    }
+
+    private static string DescribeTrialSentence(OnTrial trial, ICrime crime, ICharacter actor)
+    {
+        if (!trial.HasVerdictBeenAnnounced(crime))
+        {
+            return "Pending".Colour(Telnet.Yellow);
+        }
+
+        if (trial.ManualTrial)
+        {
+            return crime.HasBeenConvicted ? crime.DescribePunishment(actor) : "None".Colour(Telnet.Green);
+        }
+
+        if (!trial.Punishments.TryGetValue(crime, out PunishmentResult punishment))
+        {
+            return "None".Colour(Telnet.Green);
+        }
+
+        if (!trial.HasSentenceBeenAnnounced(crime))
+        {
+            return "Pending".Colour(Telnet.Yellow);
+        }
+
+        string description = punishment.Describe(actor, trial.LegalAuthority);
+        return string.IsNullOrWhiteSpace(description.StripANSIColour()) ? "No punishment".Colour(Telnet.Green) : description;
+    }
+
+    private static PunishmentResult ManualCrimePunishmentResult(ICrime crime)
+    {
+        return new PunishmentResult
+        {
+            Execution = crime.ExecutionPunishment,
+            Fine = crime.FineRecorded,
+            CustodialSentence = crime.CustodialSentenceLength,
+            GoodBehaviourBondLength = crime.GoodBehaviourBond
+        };
+    }
+
+    private static IEnumerable<PunishmentResult> RevealedTrialPunishments(OnTrial trial)
+    {
+        if (trial.ManualTrial)
+        {
+            return trial.Crimes
+                        .Where(x => x.HasBeenFinalised && x.HasBeenConvicted)
+                        .Select(ManualCrimePunishmentResult);
+        }
+
+        return trial.Punishments
+                    .Where(x => trial.HasSentenceBeenAnnounced(x.Key))
+                    .Select(x => x.Value);
+    }
+
+    private static bool HasPendingTrialSentences(OnTrial trial)
+    {
+        if (trial.ManualTrial)
+        {
+            return trial.Crimes.Any(x => !x.HasBeenFinalised);
+        }
+
+        return trial.Punishments.Any(x => !trial.HasSentenceBeenAnnounced(x.Key));
+    }
+
+    private static void AppendTrialProgressTable(StringBuilder sb, ICharacter actor, OnTrial trial)
+    {
+        List<string> headers = ["#", "Charge"];
+        bool showPlea = trial.ManualTrial || trial.Phase >= TrialPhase.Plea;
+        bool showArguments = trial.ManualTrial || trial.Phase >= TrialPhase.Case;
+        bool showVerdict = trial.ManualTrial || trial.Phase >= TrialPhase.Verdict;
+        bool showSentence = trial.ManualTrial || trial.Phase >= TrialPhase.Sentencing;
+
+        if (showPlea)
+        {
+            headers.Add("Plea");
+        }
+
+        if (showArguments)
+        {
+            headers.Add("Prosecution");
+            headers.Add("Defense");
+        }
+
+        if (showVerdict)
+        {
+            headers.Add("Verdict");
+        }
+
+        if (showSentence)
+        {
+            headers.Add("Sentence");
+        }
+
+        List<List<string>> rows = new();
+        foreach (ICrime crime in trial.Crimes)
+        {
+            List<string> row =
+            [
+                trial.ChargeNumber(crime).ToStringN0(actor),
+                crime.Name.ColourName()
+            ];
+
+            if (showPlea)
+            {
+                row.Add(DescribeTrialPlea(trial, crime));
+            }
+
+            if (showArguments)
+            {
+                row.Add(DescribeTrialArgumentQuality(trial, crime, false));
+                row.Add(DescribeTrialArgumentQuality(trial, crime, true));
+            }
+
+            if (showVerdict)
+            {
+                row.Add(DescribeTrialVerdict(trial, crime));
+            }
+
+            if (showSentence)
+            {
+                row.Add(DescribeTrialSentence(trial, crime, actor));
+            }
+
+            rows.Add(row);
+        }
+
+        sb.AppendLine(StringUtilities.GetTextTable(rows, headers, actor, Telnet.BoldOrange, truncatableColumnIndex: 1));
+    }
+
+    private static void AppendTrialConsolidatedSentence(StringBuilder sb, ICharacter actor, OnTrial trial)
+    {
+        if (!trial.ManualTrial && trial.Phase < TrialPhase.Sentencing)
+        {
+            return;
+        }
+
+        List<PunishmentResult> punishments = RevealedTrialPunishments(trial).ToList();
+        bool pending = HasPendingTrialSentences(trial);
+
+        sb.AppendLine();
+        if (punishments.Count == 0)
+        {
+            sb.AppendLine(pending
+                ? "Consolidated Sentence: no sentences have been announced yet.".Colour(Telnet.Yellow)
+                : "Consolidated Sentence: no sentence.".Colour(Telnet.Green));
+            return;
+        }
+
+        PunishmentResult result = punishments.Aggregate(new PunishmentResult(), (current, punishment) => current + punishment);
+        string description = result.Describe(actor, trial.LegalAuthority);
+        if (string.IsNullOrWhiteSpace(description.StripANSIColour()))
+        {
+            description = "no punishment".Colour(Telnet.Green);
+        }
+
+        sb.AppendLine($"Consolidated Sentence{(pending ? " So Far" : "")}: {description}");
+    }
+
     [PlayerCommand("Trial", "trial")]
     [RequiredCharacterState(CharacterState.Able)]
     [HelpInfo("trial", @"The #3trial#0 command will show you details about any trial currently taking place in your location. Judges can also view the trial docket for their jurisdictions and summon remand prisoners to court for PC-held trials.
@@ -2722,6 +2923,9 @@ The syntax is as follows:
         sb.AppendLine($"Prosecutor: {trial.Prosecutor?.HowSeen(actor) ?? "Unknown".ColourError()}");
         sb.AppendLine($"Defense Lawyer: {trial.Defender?.HowSeen(actor) ?? "Unknown".ColourError()}");
         sb.AppendLine($"Trial Phase: {trial.Phase.DescribeEnum(true).ColourValue()}");
+        sb.AppendLine();
+        AppendTrialProgressTable(sb, actor, trial);
+        AppendTrialConsolidatedSentence(sb, actor, trial);
         actor.OutputHandler.Send(sb.ToString());
     }
 }

--- a/MudSharpCore/Construction/CellDescription.cs
+++ b/MudSharpCore/Construction/CellDescription.cs
@@ -10,6 +10,7 @@ using MudSharp.Framework;
 using MudSharp.GameItems.Interfaces;
 using MudSharp.Magic;
 using MudSharp.Planes;
+using MudSharp.RPG.Law;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -658,6 +659,8 @@ public partial class Cell
             descSubSB.AppendLine($"You can use the MORGUE command here.".ColourIncludingReset(Telnet.Yellow));
         }
 
+        AppendLegalSurrenderRoomDescriptionAddenda(descSubSB, character, ref addedAdditionalLines);
+
         AppendPlaneRoomDescriptionAddendum(descSubSB, character, voyeur, flags, ref addedAdditionalLines);
 
         if (Characters.Any(x => x.AffectedBy<OnTrial>()))
@@ -667,6 +670,59 @@ public partial class Cell
 
         sb.Append(descSubSB.ToString().Wrap(character.Account.InnerLineFormatLength));
         return sb.ToString().Wrap(character?.Account.LineFormatLength ?? 120);
+    }
+
+    private void AppendLegalSurrenderRoomDescriptionAddenda(StringBuilder descSubSB, ICharacter character,
+        ref bool addedAdditionalLines)
+    {
+        if (character is null || !Gameworld.GetStaticBool("ShowShopInRoomDescription"))
+        {
+            return;
+        }
+
+        foreach (string addendum in LegalSurrenderRoomDescriptionAddenda(character, this))
+        {
+            if (!addedAdditionalLines)
+            {
+                addedAdditionalLines = true;
+                descSubSB.AppendLine();
+            }
+
+            if (character.Account.TabRoomDescriptions == true)
+            {
+                descSubSB.Append("\t");
+            }
+
+            descSubSB.AppendLine(addendum);
+        }
+    }
+
+    internal static IEnumerable<string> LegalSurrenderRoomDescriptionAddenda(ICharacter character, ICell cell)
+    {
+        if (character.Location != cell)
+        {
+            yield break;
+        }
+
+        foreach (ILegalAuthority authority in character.EffectsOfType<OnBail>()
+                                                       .Select(x => x.LegalAuthority)
+                                                       .Where(x => x.PrisonLocation == cell)
+                                                       .Distinct())
+        {
+            yield return
+                $"You are on bail in the {authority.Name.ColourName()} jurisdiction. Use the command RETURNBAIL here to surrender yourself back to custody."
+                    .ColourIncludingReset(Telnet.Yellow);
+        }
+
+        foreach (ILegalAuthority authority in character.EffectsOfType<WarnedByEnforcer>()
+                                                       .Where(x => x.WhichPatrol.PatrolMembers.Any(y => y.ColocatedWith(character)))
+                                                       .Select(x => x.WhichAuthority)
+                                                       .Distinct())
+        {
+            yield return
+                $"You are wanted by the {authority.Name.ColourName()} authorities, and officers are here to accept your surrender. Use the command SURRENDER here to submit to them."
+                    .ColourIncludingReset(Telnet.Yellow);
+        }
     }
 
     private string RoomNameForPlane(string baseRoomName, IPerceiver voyeur, PerceiveIgnoreFlags flags)

--- a/MudSharpCore/Effects/Concrete/AwaitingExecution.cs
+++ b/MudSharpCore/Effects/Concrete/AwaitingExecution.cs
@@ -1,4 +1,5 @@
 ﻿using MudSharp.Character;
+using MudSharp.Effects.Interfaces;
 using MudSharp.Framework;
 using MudSharp.RPG.Law;
 using MudSharp.TimeAndDate;
@@ -7,7 +8,7 @@ using System.Xml.Linq;
 
 namespace MudSharp.Effects.Concrete;
 
-public class AwaitingExecution : Effect
+public class AwaitingExecution : Effect, IScoreAddendumEffect
 {
     #region Static Initialisation
 
@@ -62,6 +63,13 @@ public class AwaitingExecution : Effect
     }
 
     public override bool SavingEffect => true;
+
+    public bool ShowInScore => true;
+
+    public bool ShowInHealth => false;
+
+    public string ScoreAddendum =>
+        $"You are awaiting execution in the {LegalAuthority.Name.ColourName()} jurisdiction at {ExecutionDate.ToString(TimeAndDate.Date.CalendarDisplayMode.Short, TimeAndDate.Time.TimeDisplayTypes.Immortal).ColourValue()}.";
 
     public override bool Applies(object target)
     {

--- a/MudSharpCore/Effects/Concrete/AwaitingSentencing.cs
+++ b/MudSharpCore/Effects/Concrete/AwaitingSentencing.cs
@@ -1,4 +1,5 @@
 ﻿using MudSharp.Character;
+using MudSharp.Effects.Interfaces;
 using MudSharp.Framework;
 using MudSharp.FutureProg;
 using MudSharp.PerceptionEngine;
@@ -15,7 +16,7 @@ using System.Xml.Linq;
 
 namespace MudSharp.Effects.Concrete;
 
-public class AwaitingSentencing : Effect, IEffect
+public class AwaitingSentencing : Effect, IEffect, IScoreAddendumEffect
 {
     #region Static Initialisation
 
@@ -71,6 +72,13 @@ public class AwaitingSentencing : Effect, IEffect
     }
 
     public override bool SavingEffect => true;
+
+    public bool ShowInScore => true;
+
+    public bool ShowInHealth => false;
+
+    public string ScoreAddendum =>
+        $"You are on remand in the {LegalAuthority.Name.ColourName()} jurisdiction since {ArrestTime.ToString(TimeAndDate.Date.CalendarDisplayMode.Short, TimeAndDate.Time.TimeDisplayTypes.Short).ColourValue()}.";
 
     public override bool Applies(object target)
     {

--- a/MudSharpCore/Effects/Concrete/OnBail.cs
+++ b/MudSharpCore/Effects/Concrete/OnBail.cs
@@ -91,5 +91,5 @@ public class OnBail : Effect, IEffect, IScoreAddendumEffect
     public bool ShowInHealth => false;
 
     public string ScoreAddendum =>
-        $"You are on bail until {ReturnDueDate.ToString(TimeAndDate.Date.CalendarDisplayMode.Short, TimeAndDate.Time.TimeDisplayTypes.Short).ColourValue()}.";
+        $"You are on bail in the {LegalAuthority.Name.ColourName()} jurisdiction until {ReturnDueDate.ToString(TimeAndDate.Date.CalendarDisplayMode.Short, TimeAndDate.Time.TimeDisplayTypes.Short).ColourValue()}.";
 }

--- a/MudSharpCore/Effects/Concrete/OnTrial.cs
+++ b/MudSharpCore/Effects/Concrete/OnTrial.cs
@@ -7,8 +7,10 @@ using MudSharp.PerceptionEngine.Outputs;
 using MudSharp.PerceptionEngine.Parsers;
 using MudSharp.RPG.Checks;
 using MudSharp.RPG.Law;
+using MudSharp.TimeAndDate;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -167,6 +169,82 @@ public class OnTrial : Effect, IEffect
         return _crimes.IndexOf(crime) + 1;
     }
 
+    public ICrime? CurrentPleaCrime
+    {
+        get
+        {
+            ICharacter? defendant = Owner as ICharacter;
+            return defendant?.EffectsOfType<ConsideringPlea>(x => x.LegalAuthority == LegalAuthority)
+                             ?.FirstOrDefault()
+                             ?.Crime;
+        }
+    }
+
+    public bool HasPleaBeenEntered(ICrime crime)
+    {
+        if (ManualTrial || Phase < TrialPhase.Plea)
+        {
+            return false;
+        }
+
+        if (Phase > TrialPhase.Plea)
+        {
+            return true;
+        }
+
+        return !CrimeQueue.Contains(crime) && CurrentPleaCrime != crime;
+    }
+
+    public bool HasProsecutionArgumentBeenPresented(ICrime crime)
+    {
+        return GetResultProsecution(crime)[crime.ProsecutionDifficulty].Outcome != Outcome.NotTested;
+    }
+
+    public bool HasDefenseArgumentBeenPresented(ICrime crime)
+    {
+        return GetResultDefense(crime)[crime.DefenseDifficulty].Outcome != Outcome.NotTested;
+    }
+
+    public bool HasVerdictBeenAnnounced(ICrime crime)
+    {
+        if (ManualTrial)
+        {
+            return crime.HasBeenFinalised;
+        }
+
+        if (Phase < TrialPhase.Verdict)
+        {
+            return false;
+        }
+
+        if (Phase > TrialPhase.Verdict)
+        {
+            return true;
+        }
+
+        return !CrimeQueue.Contains(crime);
+    }
+
+    public bool HasSentenceBeenAnnounced(ICrime crime)
+    {
+        if (ManualTrial)
+        {
+            return crime.HasBeenFinalised;
+        }
+
+        if (!HasVerdictBeenAnnounced(crime) || Phase < TrialPhase.Sentencing)
+        {
+            return false;
+        }
+
+        if (!_punishments.ContainsKey(crime))
+        {
+            return true;
+        }
+
+        return !CrimeQueue.Contains(crime);
+    }
+
     public bool CasesFinishedArguing()
     {
         return NextDefenseCrime() is null && NextProsecutionCrime() is null;
@@ -274,8 +352,13 @@ public class OnTrial : Effect, IEffect
                 prosecutionOutcome[(Difficulty)int.Parse(result.Attribute("difficulty")!.Value)] = CheckOutcome.SimpleOutcome(CheckType.ProsecuteLegalCase, (Outcome)int.Parse(result.Attribute("outcome")!.Value));
             }
             _crimeProsecutionCases[crime] = prosecutionOutcome;
+            XElement? punishment = item.Element("Punishment");
+            if (punishment is not null)
+            {
+                _punishments[crime] = LoadPunishmentResult(punishment);
+            }
         }
-        ResetCrimeQueue();
+        LoadCrimeQueue(root.Element("CrimeQueue"));
         _phase = (TrialPhase)int.Parse(root.Element("Phase")?.Value ?? "0");
         _manualTrial = bool.Parse(root.Element("ManualTrial")?.Value ?? "false");
     }
@@ -284,6 +367,49 @@ public class OnTrial : Effect, IEffect
 
     #region Saving and Loading
 
+    private static XElement SavePunishmentResult(PunishmentResult result)
+    {
+        return new XElement("Punishment",
+            new XElement("Execution", result.Execution),
+            new XElement("Fine", result.Fine.ToString(CultureInfo.InvariantCulture)),
+            new XElement("CustodialSentence", new XCData(result.CustodialSentence.GetRoundTripParseText)),
+            new XElement("GoodBehaviourBond", new XCData(result.GoodBehaviourBondLength.GetRoundTripParseText))
+        );
+    }
+
+    private static PunishmentResult LoadPunishmentResult(XElement punishment)
+    {
+        return new PunishmentResult
+        {
+            Execution = bool.Parse(punishment.Element("Execution")?.Value ?? "false"),
+            Fine = decimal.Parse(punishment.Element("Fine")?.Value ?? "0.0", CultureInfo.InvariantCulture),
+            CustodialSentence = LoadMudTimeSpan(punishment.Element("CustodialSentence")?.Value),
+            GoodBehaviourBondLength = LoadMudTimeSpan(punishment.Element("GoodBehaviourBond")?.Value)
+        };
+    }
+
+    private static MudTimeSpan LoadMudTimeSpan(string? text)
+    {
+        return MudTimeSpan.TryParse(text ?? string.Empty, out MudTimeSpan result) ? result : MudTimeSpan.Zero;
+    }
+
+    private void LoadCrimeQueue(XElement? queueElement)
+    {
+        if (queueElement is null)
+        {
+            ResetCrimeQueue();
+            return;
+        }
+
+        var crimesById = _crimes.ToDictionary(x => x.Id);
+        CrimeQueue = new Queue<ICrime>(
+            queueElement
+                .Elements("Crime")
+                .Select(x => long.Parse(x.Attribute("id")?.Value ?? "0"))
+                .SelectNotNull(x => crimesById.GetValueOrDefault(x))
+        );
+    }
+
     protected override XElement SaveDefinition()
     {
         return new XElement("Effect",
@@ -291,6 +417,12 @@ public class OnTrial : Effect, IEffect
             new XElement("LastTrialAction", LastTrialAction.ToString("O")),
             new XElement("Phase", (int)Phase),
             new XElement("ManualTrial", ManualTrial),
+            new XElement("CrimeQueue",
+                from crime in CrimeQueue
+                select new XElement("Crime",
+                    new XAttribute("id", crime.Id)
+                )
+            ),
             new XElement("Crimes",
                 from crime in Crimes
                 select new XElement("Crime",
@@ -309,7 +441,8 @@ public class OnTrial : Effect, IEffect
                             new XAttribute("difficulty", (int)item.Key),
                             new XAttribute("outcome", (int)item.Value.Outcome)
                         )
-                    )
+                    ),
+                    _punishments.TryGetValue(crime, out PunishmentResult? punishment) ? SavePunishmentResult(punishment) : null
                 )
             )
         );

--- a/MudSharpCore/Effects/Concrete/ServingCustodialSentence.cs
+++ b/MudSharpCore/Effects/Concrete/ServingCustodialSentence.cs
@@ -1,4 +1,5 @@
 ﻿using MudSharp.Character;
+using MudSharp.Effects.Interfaces;
 using MudSharp.Framework;
 using MudSharp.FutureProg;
 using MudSharp.PerceptionEngine;
@@ -15,7 +16,7 @@ using System.Xml.Linq;
 
 namespace MudSharp.Effects.Concrete;
 
-public class ServingCustodialSentence : Effect, IEffect
+public class ServingCustodialSentence : Effect, IEffect, IScoreAddendumEffect
 {
     #region Static Initialisation
 
@@ -75,6 +76,13 @@ public class ServingCustodialSentence : Effect, IEffect
     }
 
     public override bool SavingEffect => true;
+
+    public bool ShowInScore => true;
+
+    public bool ShowInHealth => false;
+
+    public string ScoreAddendum =>
+        $"You are serving a {TotalTime.Describe(Owner as IPerceiver).ColourValue()} custodial sentence in the {LegalAuthority.Name.ColourName()} jurisdiction until {ReleaseDate.ToString(TimeAndDate.Date.CalendarDisplayMode.Short, TimeAndDate.Time.TimeDisplayTypes.Short).ColourValue()}.";
 
     public override bool Applies(object target)
     {


### PR DESCRIPTION
## Summary
- Add per-charge trial progress rendering to `trial`, including phase-aware plea, argument, verdict, and sentencing visibility.
- Preserve and reload trial queue state so resumed trials only reveal outcomes that were actually reached before a reboot.
- Surface legal custody status in `score` for remand, bail, custodial sentence, and execution cases.
- Add room description hints for `RETURNBAIL` and `SURRENDER` when a character can legally surrender in place.
- Update the law runtime design doc to match the new behavior.

## Testing
- Added unit coverage for trial save/load state, plea and verdict reveal behavior, score addenda, and surrender room-description prompts.
- Not run (not requested).