### PR TITLE
Fix legal patrol execution flow and strategy handling

### DIFF
--- a/Design Documents/Economy/Law_System_Runtime.md
+++ b/Design Documents/Economy/Law_System_Runtime.md
@@ -46,6 +46,14 @@ Execution patrols require:
 
 The primary executioner is the patrol leader. Other selected patrol members act as supporting guards. Guards help retrieve equipment, subdue resistance, drag the prisoner, and participate in firing squads when that method is used.
 
+## Door Duties Patrols
+
+The `DoorDuties` patrol strategy is a stationary enforcer strategy for locations where doors are expected to be locked and unlocked by posted guards, such as prison entrances, jail foyers, cell blocks, or secure checkpoints.
+
+The first node on the patrol route is the duty location. During preparation, patrol members travel to the legal authority preparation room and the patrol leader tries to retrieve the patrol's required key set for the locks on doors attached to that duty location. Key matching uses the same lock/key checks as ordinary character movement, so builders must provide compatible key items in the preparation room or on the patrol leader. If all selected enforcers are already at the duty location and the leader already has the required keys, the patrol can begin there without returning to preparation.
+
+While stationed at the duty location, patrol members who have the relevant duty-door keys receive a patrol-managed door-guard mode effect. This makes them eligible for the normal `DoorguardAI` door-opening and door-closing behavior without relying on a builder to manually toggle the NPC-only `doorguard` command. The patrol-managed effect is removed when the patrol leaves door duty, completes, aborts, or switches into active enforcement. Manually configured `DoorguardMode` effects are left alone.
+
 ## Builder Configuration
 
 Strategy-specific settings are edited through the patrol route `config` command after selecting the execution strategy.
@@ -54,6 +62,7 @@ Core options:
 
 - `method cdg|drug|firing`: selects coup de grace with a weapon, administered drug, or firing squad.
 - `equipment here|<room>|none`: sets the room used to collect tools. `none` falls back to the legal authority preparation room.
+- `keys [on|off]`: controls whether the execution patrol must collect keys for the condemned prisoner's retrieval route before leaving the equipment room.
 - `drug <id|name>`: selects the drug used by the administered-drug method.
 - `dose <grams>`: sets the administered amount per attempt.
 - `vector injected|ingested|inhaled|touched`: sets the drug delivery vector.
@@ -84,7 +93,7 @@ The execution patrol progresses through these stages:
 
 1. Select a due condemned character and apply `ExecutionPatrolNoQuit`.
 2. Move patrol members to the equipment room.
-3. Collect restraints and method-specific tools.
+3. Collect restraints, method-specific tools, and, when configured, keys for the prisoner's retrieval route.
 4. Move the leader to the prisoner and send the retrieval emote.
 5. Give the prisoner the configured compliance window to use `HELPLESS` or submit to the guards.
 6. If the prisoner resists, guards switch to control-oriented combat settings where available and attempt to subdue them.
@@ -96,7 +105,7 @@ The execution patrol progresses through these stages:
 12. Confirm death, retrying up to the configured attempt limit if necessary.
 13. Mark execution-punishment crimes as served, remove `AwaitingExecution`, remove the no-quit effect, report any final corpse to the corpse-recovery queue when a morgue is configured, and complete the patrol.
 
-If required rooms, tools, paths, or targets become unavailable for too long, the patrol aborts and removes only the execution-specific no-quit effect. The `AwaitingExecution` effect remains so a later patrol can try again.
+If required rooms, tools, keys, paths, or targets become unavailable for too long, the patrol aborts and removes only the execution-specific no-quit effect. The `AwaitingExecution` effect remains so a later patrol can try again.
 
 ## Trials and PC Judges
 
@@ -143,6 +152,23 @@ Inactive patrol-route output reports both whether the route should begin and, wh
 The `showenforcers [authority|zone]` admin command reports the enforcer roster for a legal authority or any authority that enforces a specified zone. It includes on-duty state, patrol-pool eligibility, enforcement-authority match, current location, active patrol assignment, and the first reason a listed enforcer cannot be selected for patrol dispatch. The patrol pool requires an NPC with an `EnforcerAI`, an active `EnforcerEffect` for that legal authority, a currently matching enforcement authority, and no active patrol assignment.
 
 On-duty enforcers also report visible final-character-death corpses through the same local-authority corpse-report mechanism used by the player `REPORT CORPSE` command. The report is only queued when the corpse is visible, belongs to a zone with a responding legal authority, has an economic-zone morgue configured, and does not already have a pending or assigned recovery report.
+
+## Legal Status Diagnostics
+
+The `legal status [authority]` admin command and the player-facing `legalstatus [authority]` / `lawstatus [authority]` command report legal-system setup health. Administrators can view every legal authority, or their currently edited authority when using `legal status` with an editor open. PC enforcers can view only authorities for which they currently have an enforcement authority.
+
+The status report separates setup issues from ordinary runtime waiting. For example, a patrol route waiting for a crime trigger, corpse report, due condemned prisoner, active-patrol slot, or allowed time of day is not treated as broken setup. Missing route nodes, unready routes, missing required enforcers, missing enforcement zones, incomplete strategy configuration, and failed strategy-specific enforcer selection are reported as setup problems.
+
+The report also checks the common legal-system stock failures:
+
+- execution patrols using coup de grace need a suitable melee weapon in the equipment room
+- execution patrols using administered drugs need a valid configured drug and an injector item
+- firing-squad patrols need ranged weapons in the equipment room
+- execution routes warn when no restraint items are stocked in either the equipment room or execution room
+- execution routes with retrieval keys enabled check stocked keys against locked prison, jail, and prisoner-route doors
+- door-duty routes check accessible stocked preparation-room keys against locked doors at the duty location, requiring one compatible key set per patrol rather than duplicate keys for every assigned enforcer
+
+Trial coverage diagnostics flag missing Judge, Sheriff, or Prosecutor patrol routes when the authority has a conviction-capable enforcement authority. Execution coverage diagnostics flag missing execution patrol routes when at least one law can produce an execution sentence.
 
 ## Crime-Driven Patrol Dispatch
 

--- a/Design Documents/Economy/Law_System_Runtime.md
+++ b/Design Documents/Economy/Law_System_Runtime.md
@@ -76,7 +76,7 @@ Custom emotes:
 
 Script steps are ordered emotes run after the last-words window and before the killing method. Builders can use `script add`, `script delete`, `script swap`, and `script clear`.
 
-Execution emotes use the executioner as `$0` and the condemned prisoner as `$1`.
+Execution emotes use the executioner as `$0` and the condemned prisoner as `$1` outside quoted speech. Quoted speech is parsed before ordinary emote targets, so execution patrols also support named spoken placeholders: `%condemned%`, `%prisoner%`, and `%target%` for the condemned person's visible name, and `%executioner%` for the executioner.
 
 ## Runtime Flow
 
@@ -89,12 +89,12 @@ The execution patrol progresses through these stages:
 5. Give the prisoner the configured compliance window to use `HELPLESS` or submit to the guards.
 6. If the prisoner resists, guards switch to control-oriented combat settings where available and attempt to subdue them.
 7. Drag the helpless or submitted prisoner to the execution location.
-8. Restrain the prisoner with locally available restraints.
+8. Secure the prisoner for execution. A prisoner is secured if they are already helpless, remain submitted as the patrol's drag target, are under enough grapple or restraint control to be helpless, or can be made helpless by the guards. Ordinary partial restraints, such as hand bindings that do not actually make the target helpless, are not by themselves enough to proceed.
 9. Offer the configured last-words window.
 10. Play each configured execution script step.
 11. Carry out the configured execution method.
 12. Confirm death, retrying up to the configured attempt limit if necessary.
-13. Mark execution-punishment crimes as served, remove `AwaitingExecution`, remove the no-quit effect, and complete the patrol.
+13. Mark execution-punishment crimes as served, remove `AwaitingExecution`, remove the no-quit effect, report any final corpse to the corpse-recovery queue when a morgue is configured, and complete the patrol.
 
 If required rooms, tools, paths, or targets become unavailable for too long, the patrol aborts and removes only the execution-specific no-quit effect. The `AwaitingExecution` effect remains so a later patrol can try again.
 
@@ -141,6 +141,8 @@ Room `look` descriptions include yellow command hints when a character can surre
 Inactive patrol-route output reports both whether the route should begin and, when it should not, the first blocking reason. Reasons include routes not marked ready, missing patrol nodes, crime-targeted or corpse-recovery routes waiting for a trigger, strategy-specific configuration or target blockers, a false start prog, no required enforcers, no enforcement zones, or a current time of day outside the route schedule.
 
 The `showenforcers [authority|zone]` admin command reports the enforcer roster for a legal authority or any authority that enforces a specified zone. It includes on-duty state, patrol-pool eligibility, enforcement-authority match, current location, active patrol assignment, and the first reason a listed enforcer cannot be selected for patrol dispatch. The patrol pool requires an NPC with an `EnforcerAI`, an active `EnforcerEffect` for that legal authority, a currently matching enforcement authority, and no active patrol assignment.
+
+On-duty enforcers also report visible final-character-death corpses through the same local-authority corpse-report mechanism used by the player `REPORT CORPSE` command. The report is only queued when the corpse is visible, belongs to a zone with a responding legal authority, has an economic-zone morgue configured, and does not already have a pending or assigned recovery report.
 
 ## Crime-Driven Patrol Dispatch
 
@@ -194,7 +196,7 @@ For administered drugs, the configured drug is dosed directly into the condemned
 
 For firing squads, patrol members try to wield, load, ready, and fire ranged weapons. The method succeeds for the tick if at least one available shooter fires.
 
-Restraints are collected from the equipment room and then applied in the execution room. The patrol first prefers guards already holding valid restraints, but can also use restraint items available locally in the execution room.
+Restraints are collected from the equipment room and then applied in the execution room when useful. The patrol first prefers guards already holding valid restraints, but can also use restraint items available locally in the execution room. Restraints are treated as a securing aid rather than a magic execution flag: if the applied restraint does not actually make the condemned helpless, guards return to subduing or rely on an existing voluntary submission/drag state before the killing method proceeds.
 
 ## Player Constraint
 

--- a/MudSharpCore Unit Tests/LegalPatrolStrategyTests.cs
+++ b/MudSharpCore Unit Tests/LegalPatrolStrategyTests.cs
@@ -93,6 +93,84 @@ public class LegalPatrolStrategyTests
 	}
 
 	[TestMethod]
+	public void PatrolTickActiveEnforcement_HelplessTarget_ShouldDragBeforeCombatBranch()
+	{
+		string source = File.ReadAllText(GetCoreSourcePath("RPG", "Law", "PatrolStrategies", "PatrolStrategyBase.cs"));
+		int helplessCheck = source.IndexOf("TryStartDraggingHelplessCriminal(patrol, criminal)", StringComparison.Ordinal);
+		int combatCheck = source.IndexOf("// Is criminal in combat with enforcers?", StringComparison.Ordinal);
+
+		Assert.IsTrue(helplessCheck >= 0, "The active-enforcement loop should explicitly handle helpless criminals.");
+		Assert.IsTrue(combatCheck > helplessCheck, "Helpless arrest targets must be dragged before the combat branch can re-engage them.");
+		StringAssert.Contains(source, "private bool TryStartDraggingHelplessCriminal(IPatrol patrol, ICharacter criminal)");
+		StringAssert.Contains(source, "LeaveCombatIfAble(member);");
+		StringAssert.Contains(source, "criminal.Combat?.Combatants.OfType<ICharacter>().Any(x => patrol.PatrolMembers.ContainsPhysicalInstance(x)) == true");
+	}
+
+	[TestMethod]
+	public void ExecutionPatrolStrategy_ShouldAcceptHelplessOrSubmittedCondemnedAsSecured()
+	{
+		string source = File.ReadAllText(GetCoreSourcePath("RPG", "Law", "PatrolStrategies", "ExecutionPatrolStrategy.cs"));
+
+		StringAssert.Contains(source, "private bool CondemnedIsSecuredForExecution(IPatrol patrol)");
+		StringAssert.Contains(source, "AllLimbsIneffectiveFromRestraint();");
+		StringAssert.Contains(source, "Where(x => x.Reason == LimbIneffectiveReason.Restrained)");
+		StringAssert.Contains(source, "SetStage(ExecutionPatrolStage.SubduingPrisoner);");
+		StringAssert.Contains(source, "ReleaseCondemnedFromPatrolDrag(patrol);");
+		Assert.IsFalse(source.Contains("if (_condemned.Body.EffectsOfType<RestraintEffect>().Any())", StringComparison.Ordinal));
+	}
+
+	[TestMethod]
+	public void ExecutionPatrolStrategy_ShouldSupportSpokenNamePlaceholders()
+	{
+		string source = File.ReadAllText(GetCoreSourcePath("RPG", "Law", "PatrolStrategies", "ExecutionPatrolStrategy.cs"));
+
+		StringAssert.Contains(source, "\"@ announce|announces, \\\"%condemned% has been sentenced to death by lawful authority.\\\"\"");
+		StringAssert.Contains(source, "Use normal emote targets outside speech: $0 is the executioner and $1 is the condemned.");
+		StringAssert.Contains(source, "private static string ExpandExecutionEmotePlaceholders");
+		StringAssert.Contains(source, ".Replace(CondemnedPlaceholder, condemnedName, StringComparison.OrdinalIgnoreCase)");
+		StringAssert.Contains(source, ".Replace(ExecutionerPlaceholder, executionerName, StringComparison.OrdinalIgnoreCase)");
+	}
+
+	[TestMethod]
+	public void ExecutionPatrolStrategy_ShouldReportFinalCorpseForRecovery()
+	{
+		string source = File.ReadAllText(GetCoreSourcePath("RPG", "Law", "PatrolStrategies", "ExecutionPatrolStrategy.cs"));
+
+		StringAssert.Contains(source, "private void ReportExecutionCorpseForRecovery(IPatrol patrol)");
+		StringAssert.Contains(source, "LegalAuthority.ReportCorpseToLocalAuthority(Gameworld, corpseItem, patrol.PatrolLeader, out _);");
+		StringAssert.Contains(source, "ReportExecutionCorpseForRecovery(patrol);");
+	}
+
+	[TestMethod]
+	public void CorpseReporting_ShouldUseSharedLocalAuthorityMechanism()
+	{
+		string legalAuthoritySource = File.ReadAllText(GetCoreSourcePath("RPG", "Law", "LegalAuthority.CorpseRecovery.cs"));
+		string crimeModuleSource = File.ReadAllText(GetCoreSourcePath("Commands", "Modules", "CrimeModule.cs"));
+
+		StringAssert.Contains(legalAuthoritySource, "public static ICorpseRecoveryReport ReportCorpseToLocalAuthority(IFuturemud gameworld, IGameItem corpse,");
+		StringAssert.Contains(legalAuthoritySource, "corpse?.GetItemType<ICorpse>()");
+		StringAssert.Contains(legalAuthoritySource, "corpseComponent.RepresentsFinalCharacterDeath");
+		StringAssert.Contains(legalAuthoritySource, "gameworld.LegalAuthorities.FirstOrDefault(x => x.EnforcementZones.Contains(sourceCell.Zone))");
+		StringAssert.Contains(legalAuthoritySource, "Estate.DetermineZone(gameworld, sourceCell)");
+		StringAssert.Contains(legalAuthoritySource, "authority.ActiveCorpseRecoveryReport(corpse) != null");
+		StringAssert.Contains(crimeModuleSource, "LegalAuthority.ReportCorpseToLocalAuthority(actor.Gameworld, corpseItem, actor, out string errorMessage)");
+	}
+
+	[TestMethod]
+	public void EnforcerAI_ShouldAutomaticallyReportVisibleCorpsesWhileOnDuty()
+	{
+		string source = File.ReadAllText(GetCoreSourcePath("NPC", "AI", "EnforcerAI.cs"));
+
+		StringAssert.Contains(source, "private void ReportVisibleCorpses(ICharacter enforcer)");
+		StringAssert.Contains(source, "enforcer.Location.LayerGameItems(enforcer.RoomLayer)");
+		StringAssert.Contains(source, ".Where(x => enforcer.CanSee(x))");
+		StringAssert.Contains(source, "x.GetItemType<ICorpse>() is { RepresentsFinalCharacterDeath: true }");
+		StringAssert.Contains(source, "MudSharp.RPG.Law.LegalAuthority.ReportCorpseToLocalAuthority(Gameworld, corpseItem, enforcer, out _) != null");
+		StringAssert.Contains(source, "new Emote(\"@ report|reports a corpse to the authorities.\",");
+		StringAssert.Contains(source, "ReportVisibleCorpses(enforcer);");
+	}
+
+	[TestMethod]
 	public void PatrolRouteDiagnostics_ShouldExposeReasonWhenInactiveRouteCannotBegin()
 	{
 		string routeInterfaceSource = File.ReadAllText(GetLibrarySourcePath("RPG", "Law", "IPatrolRoute.cs"));

--- a/MudSharpCore Unit Tests/LegalPatrolStrategyTests.cs
+++ b/MudSharpCore Unit Tests/LegalPatrolStrategyTests.cs
@@ -22,9 +22,11 @@ public class LegalPatrolStrategyTests
 	{
 		CollectionAssert.Contains(PatrolStrategyFactory.Strategies.ToList(), "ReactivePatrol");
 		CollectionAssert.Contains(PatrolStrategyFactory.Strategies.ToList(), "InvestigationPatrol");
+		CollectionAssert.Contains(PatrolStrategyFactory.Strategies.ToList(), "DoorDuties");
 
 		Assert.IsTrue(PatrolStrategyFactory.Strategies.Contains("ReactivePatrol"));
 		Assert.IsTrue(PatrolStrategyFactory.Strategies.Contains("InvestigationPatrol"));
+		Assert.IsTrue(PatrolStrategyFactory.Strategies.Contains("DoorDuties"));
 	}
 
 	[TestMethod]
@@ -142,6 +144,56 @@ public class LegalPatrolStrategyTests
 	}
 
 	[TestMethod]
+	public void DoorDutiesPatrolStrategy_ShouldPrepareKeysAndEnableDoorGuardMode()
+	{
+		string source = File.ReadAllText(GetCoreSourcePath("RPG", "Law", "PatrolStrategies", "DoorDutiesPatrolStrategy.cs"));
+		string effectSource = File.ReadAllText(GetCoreSourcePath("Effects", "Concrete", "PatrolDoorguardMode.cs"));
+		string factorySource = File.ReadAllText(GetCoreSourcePath("RPG", "Law", "PatrolStrategyFactory.cs"));
+		string patrolSource = File.ReadAllText(GetCoreSourcePath("RPG", "Law", "Patrol.cs"));
+		string movementSource = File.ReadAllText(GetCoreSourcePath("NPC", "AI", "Strategies", "MovementStrategyFactory.cs"));
+
+		StringAssert.Contains(factorySource, "\"DoorDuties\"");
+		StringAssert.Contains(factorySource, "case \"door duties\":");
+		StringAssert.Contains(source, "public override string Name => \"DoorDuties\";");
+		StringAssert.Contains(source, "PrepareKeysForCells(member, dutyCells);");
+		StringAssert.Contains(source, "member == patrol.PatrolLeader");
+		StringAssert.Contains(source, "HasKeysForCells(patrol.PatrolLeader, dutyCells)");
+		StringAssert.Contains(source, "new PatrolDoorguardMode(member)");
+		StringAssert.Contains(source, "RemoveAllEffects<PatrolDoorguardMode>(fireRemovalAction: true)");
+		StringAssert.Contains(source, "public override void HandlePatrolCompleted(IPatrol patrol)");
+		StringAssert.Contains(source, "public override void HandlePatrolAborted(IPatrol patrol)");
+		StringAssert.Contains(patrolSource, "HandlePatrolCompleted(this)");
+		StringAssert.Contains(patrolSource, "HandlePatrolAborted(this)");
+		StringAssert.Contains(movementSource, "AffectedBy<IDoorguardModeEffect>()");
+		Assert.IsFalse(movementSource.Contains("AffectedBy<DoorguardMode>()", StringComparison.Ordinal));
+		StringAssert.Contains(source, "PathSearch.PathIncludeUnlockableDoors");
+		StringAssert.Contains(source, "UseKeys = true");
+		StringAssert.Contains(source, "OpenDoors = true");
+		StringAssert.Contains(source, "DisableDoorGuardMode(patrol);");
+		StringAssert.Contains(effectSource, "IDoorguardModeEffect");
+		Assert.IsFalse(effectSource.Contains("SavingEffect => true", StringComparison.Ordinal));
+	}
+
+	[TestMethod]
+	public void PatrolStrategies_ShouldShareKeyPreparationArchitecture()
+	{
+		string baseSource = File.ReadAllText(GetCoreSourcePath("RPG", "Law", "PatrolStrategies", "PatrolStrategyBase.cs"));
+		string executionSource = File.ReadAllText(GetCoreSourcePath("RPG", "Law", "PatrolStrategies", "ExecutionPatrolStrategy.cs"));
+
+		StringAssert.Contains(baseSource, "protected static IEnumerable<IKey> AccessibleKeys(ICharacter member)");
+		StringAssert.Contains(baseSource, "protected static bool PrepareKeysForLocks(ICharacter member, IEnumerable<ILock> locks)");
+		StringAssert.Contains(baseSource, "new InventoryPlanActionHold(member.Gameworld, 0, 0,");
+		StringAssert.Contains(baseSource, "protected static bool PrepareKeysForCells(ICharacter member, IEnumerable<ICell> cells)");
+		StringAssert.Contains(baseSource, "protected static void PrepareInventoryPlan(ICharacter member, IInventoryPlanTemplate template)");
+		StringAssert.Contains(executionSource, "public bool RequireKeysForRetrieval { get; private set; }");
+		StringAssert.Contains(executionSource, "#3keys [on|off]#0");
+		StringAssert.Contains(executionSource, "PrepareRetrievalKeys(member);");
+		StringAssert.Contains(executionSource, "private bool RetrievalKeysReady(IPatrol patrol)");
+		StringAssert.Contains(executionSource, "new XAttribute(\"keys\", RequireKeysForRetrieval)");
+		StringAssert.Contains(executionSource, "bool.TryParse(root.Attribute(\"keys\")?.Value, out bool keys)");
+	}
+
+	[TestMethod]
 	public void CorpseReporting_ShouldUseSharedLocalAuthorityMechanism()
 	{
 		string legalAuthoritySource = File.ReadAllText(GetCoreSourcePath("RPG", "Law", "LegalAuthority.CorpseRecovery.cs"));
@@ -168,6 +220,35 @@ public class LegalPatrolStrategyTests
 		StringAssert.Contains(source, "MudSharp.RPG.Law.LegalAuthority.ReportCorpseToLocalAuthority(Gameworld, corpseItem, enforcer, out _) != null");
 		StringAssert.Contains(source, "new Emote(\"@ report|reports a corpse to the authorities.\",");
 		StringAssert.Contains(source, "ReportVisibleCorpses(enforcer);");
+	}
+
+	[TestMethod]
+	public void LegalStatus_ShouldSurfaceLegalSetupAndEquipmentIssues()
+	{
+		string source = File.ReadAllText(GetCoreSourcePath("Commands", "Modules", "LegalModule.cs"));
+
+		Assert.IsTrue(source.Contains("[PlayerCommand(\"LegalStatus\", \"legalstatus\", \"lawstatus\")]", StringComparison.Ordinal));
+		Assert.IsTrue(source.Contains("case \"status\":", StringComparison.Ordinal));
+		Assert.IsTrue(source.Contains("private sealed record LegalSetupIssue", StringComparison.Ordinal));
+		Assert.IsTrue(source.Contains("BuildLegalStatusReport(actor, authorities, actor.IsAdministrator())", StringComparison.Ordinal));
+		Assert.IsTrue(source.Contains("GetLegalAuthoritiesForLegalStatus", StringComparison.Ordinal));
+		Assert.IsTrue(source.Contains("x.GetEnforcementAuthority(actor) is not null", StringComparison.Ordinal));
+		Assert.IsTrue(source.Contains("WhyCannotStaffPatrolRoute", StringComparison.Ordinal));
+		Assert.IsTrue(source.Contains("route.PatrolStrategy.SelectEnforcers(route, pool, requirement.Value)", StringComparison.Ordinal));
+		Assert.IsTrue(source.Contains("No Judge patrol route is configured", StringComparison.Ordinal));
+		Assert.IsTrue(source.Contains("No Prosecutor patrol route is configured", StringComparison.Ordinal));
+		Assert.IsTrue(source.Contains("No Sheriff patrol route is configured", StringComparison.Ordinal));
+		Assert.IsTrue(source.Contains("no ExecutionPatrol route is configured", StringComparison.Ordinal));
+		Assert.IsTrue(source.Contains("IsExecutionMeleeWeapon", StringComparison.Ordinal));
+		Assert.IsTrue(source.Contains("ComponentsInCell<IInject>(equipment, actor)", StringComparison.Ordinal));
+		Assert.IsTrue(source.Contains("ComponentsInCell<IRestraint>(equipment, actor).Concat(ComponentsInCell<IRestraint>(executionLocation, actor))", StringComparison.Ordinal));
+		Assert.IsTrue(source.Contains("strategy.DrugId <= 0 || actor.Gameworld.Drugs.Get(strategy.DrugId) is null", StringComparison.Ordinal));
+		Assert.IsTrue(source.Contains("ExecutionRetrievalKeyIssues", StringComparison.Ordinal));
+		Assert.IsTrue(source.Contains("DoorDutyKeyIssues", StringComparison.Ordinal));
+		Assert.IsTrue(source.Contains("LocksMissingKeys", StringComparison.Ordinal));
+		Assert.IsTrue(source.Contains("AccessibleStockItems", StringComparison.Ordinal));
+		Assert.IsFalse(source.Contains("SelectMany(x => x.DeepItems)", StringComparison.Ordinal));
+		Assert.IsTrue(source.Contains("legalstatus <legal authority>", StringComparison.Ordinal));
 	}
 
 	[TestMethod]

--- a/MudSharpCore/Commands/Modules/CrimeModule.cs
+++ b/MudSharpCore/Commands/Modules/CrimeModule.cs
@@ -7,7 +7,6 @@ using MudSharp.Construction;
 using MudSharp.Economy;
 using MudSharp.Economy.Banking;
 using MudSharp.Economy.Currency;
-using MudSharp.Economy.Estates;
 using MudSharp.Economy.Payment;
 using MudSharp.Economy.Property;
 using MudSharp.Effects.Concrete;
@@ -435,47 +434,12 @@ The syntax for this command is as follows:
         }
 
         IGameItem corpseItem = actor.TargetItem(ss.SafeRemainingArgument);
-        ICorpse corpse = corpseItem?.GetItemType<ICorpse>();
-        if (corpse == null)
+        if (LegalAuthority.ReportCorpseToLocalAuthority(actor.Gameworld, corpseItem, actor, out string errorMessage) == null)
         {
-            actor.OutputHandler.Send("You do not see any such corpse here.");
+            actor.OutputHandler.Send(errorMessage);
             return;
         }
 
-        if (!corpse.RepresentsFinalCharacterDeath)
-        {
-            actor.OutputHandler.Send("Those are body remains rather than the final corpse of a dead character, and cannot be reported to the morgue.");
-            return;
-        }
-
-        ICell sourceCell = corpseItem.Location ?? corpseItem.TrueLocations.FirstOrDefault();
-        if (sourceCell == null)
-        {
-            actor.OutputHandler.Send("That corpse is not currently in a reportable location.");
-            return;
-        }
-
-        ILegalAuthority authority = actor.Gameworld.LegalAuthorities.FirstOrDefault(x => x.EnforcementZones.Contains(sourceCell.Zone));
-        if (authority == null)
-        {
-            actor.OutputHandler.Send("There is no local legal authority that can respond to this corpse.");
-            return;
-        }
-
-        IEconomicZone zone = Estate.DetermineZone(actor.Gameworld, sourceCell);
-        if (zone == null || zone.MorgueOfficeCell == null || zone.MorgueStorageCell == null)
-        {
-            actor.OutputHandler.Send("There is no configured morgue for the economic zone that covers this corpse.");
-            return;
-        }
-
-        if (authority.ActiveCorpseRecoveryReport(corpseItem) != null)
-        {
-            actor.OutputHandler.Send("That corpse has already been reported to the authorities.");
-            return;
-        }
-
-        authority.ReportCorpse(corpseItem, zone, actor);
         actor.OutputHandler.Handle(new EmoteOutput(
             new Emote("@ report|reports a corpse to the authorities.", actor)));
     }

--- a/MudSharpCore/Commands/Modules/LegalModule.cs
+++ b/MudSharpCore/Commands/Modules/LegalModule.cs
@@ -3,13 +3,18 @@ using MudSharp.Accounts;
 using MudSharp.Celestial;
 using MudSharp.Character;
 using MudSharp.Character.Name;
+using MudSharp.Combat;
 using MudSharp.Construction;
+using MudSharp.Construction.Boundary;
 using MudSharp.Economy.Currency;
 using MudSharp.Effects.Concrete;
 using MudSharp.Framework;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Interfaces;
 using MudSharp.NPC;
 using MudSharp.NPC.AI;
 using MudSharp.RPG.Law;
+using MudSharp.RPG.Law.PatrolStrategies;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -43,6 +48,7 @@ public class LegalModule : Module<ICharacter>
 	#3legal classes [<legal authority>]#0 - shows all the classes
 	#3legal enforcements [<legal authority>]#0 - shows all enforcer authorities
 	#3legal roster [<legal authority>|<zone>]#0 - shows the enforcer roster and patrol eligibility
+	#3legal status [<legal authority>]#0 - diagnoses legal authority setup, patrol coverage and required equipment
 	#3legal patrols [<legal authority>]#0 - shows all patrol routes
 	#3legal cancelpatrol <legal authority> <patrol>#0 - cancels an active patrol
 
@@ -111,6 +117,9 @@ You can also use the following options to change the properties of an authority 
             case "enforcers":
                 LegalAuthorityEnforcerRoster(actor, ss);
                 return;
+            case "status":
+                LegalAuthorityStatus(actor, ss);
+                return;
             case "patrols":
                 LegalAuthorityPatrols(actor, ss);
                 return;
@@ -143,6 +152,578 @@ You can also use the following options to change the properties of an authority 
     {
         ILegalAuthority editing = actor.CombinedEffectsOfType<BuilderEditingEffect<ILegalAuthority>>().FirstOrDefault()?.EditingItem;
         ShowEnforcerRoster(actor, ss, editing);
+    }
+
+    private const string LegalStatusHelpText = @"The #3legalstatus#0 command shows setup diagnostics for legal authorities. Administrators can see all authorities and detailed room/route references. PC enforcers can see status for authorities they currently serve.
+
+The syntax is:
+
+	#3legalstatus#0 - shows your legal authorities, or all authorities if you are an admin
+	#3legalstatus <legal authority>#0 - shows one legal authority";
+
+    [PlayerCommand("LegalStatus", "legalstatus", "lawstatus")]
+    [HelpInfo("legalstatus", LegalStatusHelpText, AutoHelp.HelpArgOrNoArg)]
+    protected static void LegalStatus(ICharacter actor, string command)
+    {
+        LegalAuthorityStatus(actor, new StringStack(command.RemoveFirstWord()), null);
+    }
+
+    private sealed record LegalSetupIssue(string Severity, string Area, string Detail);
+
+    private static void LegalAuthorityStatus(ICharacter actor, StringStack ss)
+    {
+        ILegalAuthority editing = actor.CombinedEffectsOfType<BuilderEditingEffect<ILegalAuthority>>().FirstOrDefault()?.EditingItem;
+        LegalAuthorityStatus(actor, ss, editing);
+    }
+
+    private static void LegalAuthorityStatus(ICharacter actor, StringStack ss, ILegalAuthority defaultAuthority)
+    {
+        List<ILegalAuthority> authorities = GetLegalAuthoritiesForLegalStatus(actor, ss, defaultAuthority);
+        if (authorities is null)
+        {
+            return;
+        }
+
+        if (!authorities.Any())
+        {
+            actor.OutputHandler.Send(actor.IsAdministrator()
+                ? "There are no legal authorities configured."
+                : "You are not currently an enforcer for any legal authority.");
+            return;
+        }
+
+        actor.OutputHandler.Send(BuildLegalStatusReport(actor, authorities, actor.IsAdministrator()));
+    }
+
+    private static List<ILegalAuthority> GetLegalAuthoritiesForLegalStatus(ICharacter actor, StringStack ss,
+        ILegalAuthority defaultAuthority)
+    {
+        if (ss.IsFinished)
+        {
+            if (defaultAuthority is not null && actor.IsAdministrator())
+            {
+                return new List<ILegalAuthority> { defaultAuthority };
+            }
+
+            return actor.IsAdministrator()
+                ? actor.Gameworld.LegalAuthorities.ToList()
+                : actor.Gameworld.LegalAuthorities.Where(x => x.GetEnforcementAuthority(actor) is not null).ToList();
+        }
+
+        string targetText = ss.SafeRemainingArgument;
+        ILegalAuthority legal = actor.Gameworld.LegalAuthorities.GetByIdOrName(targetText);
+        if (legal is null)
+        {
+            actor.OutputHandler.Send($"There is no legal authority identified by {targetText.ColourCommand()}.");
+            return null;
+        }
+
+        if (!actor.IsAdministrator() && legal.GetEnforcementAuthority(actor) is null)
+        {
+            actor.OutputHandler.Send($"You are not an enforcer for {legal.Name.ColourName()}.");
+            return null;
+        }
+
+        return new List<ILegalAuthority> { legal };
+    }
+
+    private static string BuildLegalStatusReport(ICharacter actor, IEnumerable<ILegalAuthority> authorities,
+        bool detailed)
+    {
+        StringBuilder sb = new();
+        foreach (ILegalAuthority legal in authorities)
+        {
+            if (sb.Length > 0)
+            {
+                sb.AppendLine();
+            }
+
+            List<ICharacter> freeEnforcers = FreePatrolEnforcers(actor, legal);
+            CollectionDictionary<IEnforcementAuthority, ICharacter> enforcerCounts = FreeEnforcerCounts(legal, freeEnforcers);
+            List<LegalSetupIssue> issues = LegalSetupIssues(actor, legal, freeEnforcers, enforcerCounts, detailed).ToList();
+
+            sb.AppendLine($"Legal Status for {legal.Name} Authority".GetLineWithTitleInner(actor, Telnet.BoldBlue, Telnet.BoldWhite));
+            sb.AppendLine();
+            sb.AppendLine($"Overall: {(issues.Any(x => x.Severity == "Problem") ? "Problems Found".ColourError() : issues.Any() ? "Warnings Found".Colour(Telnet.Yellow) : "No Issues Detected".ColourValue())}");
+            sb.AppendLine($"Enforcement Zones: {legal.EnforcementZones.Count().ToStringN0Colour(actor)}");
+            sb.AppendLine($"Patrol Routes: {legal.PatrolRoutes.Count().ToStringN0Colour(actor)}");
+            sb.AppendLine($"Active Patrols: {legal.Patrols.Count().ToStringN0Colour(actor)}");
+            sb.AppendLine($"Free Patrol Enforcers: {freeEnforcers.Count.ToStringN0Colour(actor)}");
+            sb.AppendLine();
+
+            if (!issues.Any())
+            {
+                sb.AppendLine("No setup issues were detected for this legal authority.".ColourValue());
+                continue;
+            }
+
+            sb.AppendLine(StringUtilities.GetTextTable(
+                from issue in issues
+                select new List<string>
+                {
+                    FormatLegalStatusSeverity(issue.Severity),
+                    issue.Area.ColourName(),
+                    issue.Detail
+                },
+                new List<string>
+                {
+                    "Severity",
+                    "Area",
+                    "Issue"
+                },
+                actor,
+                Telnet.Magenta,
+                2,
+                true));
+        }
+
+        return sb.ToString();
+    }
+
+    private static string FormatLegalStatusSeverity(string severity)
+    {
+        return severity switch
+        {
+            "Problem" => severity.ColourError(),
+            "Warning" => severity.Colour(Telnet.Yellow),
+            _ => severity.ColourValue()
+        };
+    }
+
+    private static List<ICharacter> FreePatrolEnforcers(ICharacter actor, ILegalAuthority legal)
+    {
+        return actor.Gameworld.NPCs
+                    .Where(x => IsInPatrolPool(legal, x))
+                    .ToList();
+    }
+
+    private static CollectionDictionary<IEnforcementAuthority, ICharacter> FreeEnforcerCounts(ILegalAuthority legal,
+        IEnumerable<ICharacter> freeEnforcers)
+    {
+        CollectionDictionary<IEnforcementAuthority, ICharacter> enforcerCounts = new();
+        foreach (IGrouping<IEnforcementAuthority, ICharacter> group in freeEnforcers.GroupBy(x => legal.GetEnforcementAuthority(x)))
+        {
+            enforcerCounts.AddRange(group.Key, group);
+        }
+
+        return enforcerCounts;
+    }
+
+    private static IEnumerable<LegalSetupIssue> LegalSetupIssues(ICharacter actor, ILegalAuthority legal,
+        List<ICharacter> freeEnforcers, CollectionDictionary<IEnforcementAuthority, ICharacter> enforcerCounts,
+        bool detailed)
+    {
+        foreach (LegalSetupIssue issue in CoreLegalSetupIssues(actor, legal, freeEnforcers, detailed))
+        {
+            yield return issue;
+        }
+
+        foreach (LegalSetupIssue issue in PatrolCoverageIssues(actor, legal, enforcerCounts, detailed))
+        {
+            yield return issue;
+        }
+
+        foreach (LegalSetupIssue issue in ExecutionEquipmentIssues(actor, legal, detailed))
+        {
+            yield return issue;
+        }
+
+        foreach (LegalSetupIssue issue in DoorDutyKeyIssues(actor, legal, detailed))
+        {
+            yield return issue;
+        }
+    }
+
+    private static IEnumerable<LegalSetupIssue> CoreLegalSetupIssues(ICharacter actor, ILegalAuthority legal,
+        List<ICharacter> freeEnforcers, bool detailed)
+    {
+        if (!legal.EnforcementZones.Any())
+        {
+            yield return new LegalSetupIssue("Problem", "Core Setup", "No enforcement zones are configured.");
+        }
+
+        if (!legal.EnforcementAuthorities.Any())
+        {
+            yield return new LegalSetupIssue("Problem", "Core Setup", "No enforcement authorities are configured.");
+        }
+
+        if (!legal.LegalClasses.Any())
+        {
+            yield return new LegalSetupIssue("Warning", "Core Setup", "No legal classes are configured.");
+        }
+
+        if (!legal.Laws.Any())
+        {
+            yield return new LegalSetupIssue("Warning", "Core Setup", "No laws are configured.");
+        }
+
+        List<string> missingLocations = new();
+        if (legal.PreparingLocation is null)
+        {
+            missingLocations.Add("preparation room");
+        }
+
+        if (legal.MarshallingLocation is null)
+        {
+            missingLocations.Add("marshalling room");
+        }
+
+        if (legal.EnforcerStowingLocation is null)
+        {
+            missingLocations.Add("enforcer stow room");
+        }
+
+        if (legal.PrisonLocation is null)
+        {
+            missingLocations.Add("prison administration room");
+        }
+
+        if (legal.PrisonerBelongingsStorageLocation is null)
+        {
+            missingLocations.Add("prisoner belongings room");
+        }
+
+        if (legal.CourtLocation is null)
+        {
+            missingLocations.Add("courtroom");
+        }
+
+        if (!legal.CellLocations.Any())
+        {
+            missingLocations.Add("holding cells");
+        }
+
+        if (missingLocations.Any())
+        {
+            yield return new LegalSetupIssue("Problem", "Core Setup",
+                $"Missing {missingLocations.ListToString()}.");
+        }
+
+        if (!freeEnforcers.Any())
+        {
+            yield return new LegalSetupIssue("Problem", "Enforcers",
+                "No NPC enforcers are currently eligible for the patrol pool.");
+        }
+    }
+
+    private static IEnumerable<LegalSetupIssue> PatrolCoverageIssues(ICharacter actor, ILegalAuthority legal,
+        CollectionDictionary<IEnforcementAuthority, ICharacter> enforcerCounts, bool detailed)
+    {
+        if (!legal.PatrolRoutes.Any())
+        {
+            yield return new LegalSetupIssue("Problem", "Patrols", "No patrol routes are configured.");
+            yield break;
+        }
+
+        if (!legal.PatrolRoutes.Any(x => x.IsReady))
+        {
+            yield return new LegalSetupIssue("Problem", "Patrols", "No patrol routes are marked ready.");
+        }
+
+        bool hasConvictingAuthority = legal.EnforcementAuthorities.Any(x => x.CanConvict);
+        if (hasConvictingAuthority && !HasPatrolStrategy(legal, "Judge"))
+        {
+            yield return new LegalSetupIssue("Problem", "Trial Patrols",
+                "No Judge patrol route is configured, so NPC trials cannot be judged.");
+        }
+
+        if (hasConvictingAuthority && !HasPatrolStrategy(legal, "Sheriff"))
+        {
+            yield return new LegalSetupIssue("Warning", "Trial Patrols",
+                "No Sheriff patrol route is configured to fetch remand prisoners for trial.");
+        }
+
+        if (hasConvictingAuthority && !HasPatrolStrategy(legal, "Prosecutor"))
+        {
+            yield return new LegalSetupIssue("Warning", "Trial Patrols",
+                "No Prosecutor patrol route is configured for automated trial prosecution.");
+        }
+
+        if (LawsCanSentenceExecution(legal) && !HasPatrolStrategy(legal, "ExecutionPatrol"))
+        {
+            yield return new LegalSetupIssue("Problem", "Execution Patrols",
+                "At least one law can sentence execution, but no ExecutionPatrol route is configured.");
+        }
+
+        foreach (IPatrolRoute route in legal.PatrolRoutes)
+        {
+            string reason = route.WhyCannotBeginPatrol();
+            if (IsSetupBlockingPatrolReason(reason))
+            {
+                yield return new LegalSetupIssue("Problem", "Patrol Route",
+                    $"{RouteLabel(route, actor, detailed)} cannot begin: {reason}.");
+            }
+
+            string staffingReason = WhyCannotStaffPatrolRoute(route, enforcerCounts, actor, detailed);
+            if (!string.IsNullOrEmpty(staffingReason))
+            {
+                yield return new LegalSetupIssue("Problem", "Patrol Staffing", staffingReason);
+            }
+        }
+    }
+
+    private static bool HasPatrolStrategy(ILegalAuthority legal, string strategyName)
+    {
+        return legal.PatrolRoutes.Any(x => x.PatrolStrategy.Name.Equals(strategyName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool LawsCanSentenceExecution(ILegalAuthority legal)
+    {
+        return legal.Laws.Any(x => x.PunishmentStrategy.SaveResult().Contains("type=\"execute\"", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool IsSetupBlockingPatrolReason(string reason)
+    {
+        if (string.IsNullOrEmpty(reason))
+        {
+            return false;
+        }
+
+        return !reason.Contains("wait for", StringComparison.OrdinalIgnoreCase) &&
+               !reason.Contains("current time of day", StringComparison.OrdinalIgnoreCase) &&
+               !reason.Contains("no due condemned", StringComparison.OrdinalIgnoreCase) &&
+               !reason.Contains("already an active", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string WhyCannotStaffPatrolRoute(IPatrolRoute route,
+        CollectionDictionary<IEnforcementAuthority, ICharacter> enforcerCounts, ICharacter actor, bool detailed)
+    {
+        if (!route.IsReady || !route.PatrollerNumbers.Any())
+        {
+            return string.Empty;
+        }
+
+        foreach (KeyValuePair<IEnforcementAuthority, int> requirement in route.PatrollerNumbers)
+        {
+            List<ICharacter> pool = enforcerCounts[requirement.Key].ToList();
+            if (pool.Count < requirement.Value)
+            {
+                return $"{RouteLabel(route, actor, detailed)} requires {requirement.Value.ToStringN0(actor)} {requirement.Key.Name.Pluralise(requirement.Value != 1).ColourName()} enforcers, but only {pool.Count.ToStringN0Colour(actor)} are free.";
+            }
+
+            int selectable = route.PatrolStrategy.SelectEnforcers(route, pool, requirement.Value).Count();
+            if (selectable < requirement.Value)
+            {
+                return $"{RouteLabel(route, actor, detailed)} requires {requirement.Value.ToStringN0(actor)} selectable {requirement.Key.Name.Pluralise(requirement.Value != 1).ColourName()} enforcers for the {route.PatrolStrategy.Name.ColourName()} strategy, but only {selectable.ToStringN0Colour(actor)} match the strategy selection rules.";
+            }
+        }
+
+        return string.Empty;
+    }
+
+    private static string RouteLabel(IPatrolRoute route, ICharacter actor, bool detailed)
+    {
+        return detailed
+            ? $"{route.Name.ColourName()} (#{route.Id.ToStringN0(actor)})"
+            : route.Name.ColourName();
+    }
+
+    private static IEnumerable<LegalSetupIssue> ExecutionEquipmentIssues(ICharacter actor, ILegalAuthority legal,
+        bool detailed)
+    {
+        foreach (IPatrolRoute route in legal.PatrolRoutes.Where(x => x.PatrolStrategy is ExecutionPatrolStrategy))
+        {
+            ExecutionPatrolStrategy strategy = (ExecutionPatrolStrategy)route.PatrolStrategy;
+            ICell equipment = strategy.EquipmentLocationId > 0
+                ? actor.Gameworld.Cells.Get(strategy.EquipmentLocationId)
+                : legal.PreparingLocation;
+            ICell executionLocation = route.PatrolNodes.FirstOrDefault();
+            string routeLabel = RouteLabel(route, actor, detailed);
+
+            if (equipment is null)
+            {
+                yield return new LegalSetupIssue("Problem", "Execution Equipment",
+                    $"{routeLabel} has no valid equipment/preparation room.");
+                continue;
+            }
+
+            switch (strategy.Method)
+            {
+                case ExecutionPatrolExecutionMethod.CoupDeGraceWithWeapon:
+                    if (!ItemsInCell(equipment, actor).Any(IsExecutionMeleeWeapon))
+                    {
+                        yield return new LegalSetupIssue("Problem", "Execution Equipment",
+                            $"{routeLabel} uses coup de grace but no suitable melee execution weapon is stocked{LocationSuffix(equipment, actor, detailed)}.");
+                    }
+
+                    break;
+                case ExecutionPatrolExecutionMethod.AdministerDrug:
+                    if (strategy.DrugId <= 0 || actor.Gameworld.Drugs.Get(strategy.DrugId) is null)
+                    {
+                        yield return new LegalSetupIssue("Problem", "Execution Equipment",
+                            $"{routeLabel} uses administered drugs but has no valid drug configured.");
+                    }
+
+                    if (!ComponentsInCell<IInject>(equipment, actor).Any())
+                    {
+                        yield return new LegalSetupIssue("Problem", "Execution Equipment",
+                            $"{routeLabel} uses administered drugs but no injector item is stocked{LocationSuffix(equipment, actor, detailed)}.");
+                    }
+
+                    break;
+                case ExecutionPatrolExecutionMethod.FiringSquad:
+                    if (!ComponentsInCell<IRangedWeapon>(equipment, actor).Any())
+                    {
+                        yield return new LegalSetupIssue("Problem", "Execution Equipment",
+                            $"{routeLabel} uses firing squad but no ranged weapons are stocked{LocationSuffix(equipment, actor, detailed)}.");
+                    }
+
+                    break;
+            }
+
+            if (!ComponentsInCell<IRestraint>(equipment, actor).Concat(ComponentsInCell<IRestraint>(executionLocation, actor)).Any())
+            {
+                yield return new LegalSetupIssue("Warning", "Execution Equipment",
+                    $"{routeLabel} has no restraint items stocked in the equipment or execution room; guards will need a helpless or submitted prisoner to proceed.");
+            }
+
+            if (strategy.RequireKeysForRetrieval)
+            {
+                foreach (LegalSetupIssue issue in ExecutionRetrievalKeyIssues(actor, legal, route, equipment, detailed))
+                {
+                    yield return issue;
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<LegalSetupIssue> ExecutionRetrievalKeyIssues(ICharacter actor, ILegalAuthority legal,
+        IPatrolRoute route, ICell equipment, bool detailed)
+    {
+        List<ICell> prisonerCells = legal.CellLocations.Concat(legal.JailLocations).Distinct().ToList();
+        if (!prisonerCells.Any())
+        {
+            yield return new LegalSetupIssue("Problem", "Execution Keys",
+                $"{RouteLabel(route, actor, detailed)} requires retrieval keys but no prisoner cell or jail locations are configured.");
+            yield break;
+        }
+
+        List<ILock> locks = DoorLocksForCells(prisonerCells)
+                           .Concat(DoorLocksForPaths(equipment, prisonerCells))
+                           .Distinct()
+                           .ToList();
+        if (!locks.Any())
+        {
+            yield break;
+        }
+
+        List<ILock> missingLocks = LocksMissingKeys(locks, KeysInCell(equipment, actor)).ToList();
+        if (missingLocks.Any())
+        {
+            yield return new LegalSetupIssue("Problem", "Execution Keys",
+                $"{RouteLabel(route, actor, detailed)} requires retrieval keys, but {missingLocks.Count.ToStringN0Colour(actor)} prison-route lock{(missingLocks.Count == 1 ? "" : "s")} lack stocked matching keys{LocationSuffix(equipment, actor, detailed)}.");
+        }
+    }
+
+    private static IEnumerable<LegalSetupIssue> DoorDutyKeyIssues(ICharacter actor, ILegalAuthority legal,
+        bool detailed)
+    {
+        foreach (IPatrolRoute route in legal.PatrolRoutes.Where(x => x.PatrolStrategy.Name.Equals("DoorDuties", StringComparison.OrdinalIgnoreCase)))
+        {
+            ICell dutyLocation = route.PatrolNodes.FirstOrDefault();
+            if (dutyLocation is null || legal.PreparingLocation is null)
+            {
+                continue;
+            }
+
+            List<ILock> locks = DoorLocksForCells(new[] { dutyLocation }).ToList();
+            if (!locks.Any())
+            {
+                yield return new LegalSetupIssue("Info", "Door Duties",
+                    $"{RouteLabel(route, actor, detailed)} is configured for door duties, but the duty location has no doors with locks.");
+                continue;
+            }
+
+            List<ILock> missingLocks = LocksMissingKeys(locks, KeysInCell(legal.PreparingLocation, actor)).ToList();
+            if (missingLocks.Any())
+            {
+                yield return new LegalSetupIssue("Problem", "Door Duties",
+                    $"{RouteLabel(route, actor, detailed)} needs keys for {missingLocks.Count.ToStringN0Colour(actor)} duty-door lock{(missingLocks.Count == 1 ? "" : "s")} that are not stocked in the preparation room.");
+            }
+        }
+    }
+
+    private static IEnumerable<IGameItem> ItemsInCell(ICell cell, ICharacter accessor)
+    {
+        return cell?.GameItems.SelectMany(x => AccessibleStockItems(x, accessor)).Distinct() ??
+               Enumerable.Empty<IGameItem>();
+    }
+
+    private static IEnumerable<IGameItem> AccessibleStockItems(IGameItem item, ICharacter accessor)
+    {
+        yield return item;
+
+        IContainer container = item.GetItemType<IContainer>();
+        if (container is null)
+        {
+            yield break;
+        }
+
+        IOpenable openable = item.GetItemType<IOpenable>();
+        if (openable is not null && !openable.IsOpen && (accessor is null || !openable.CanOpen(accessor.Body)))
+        {
+            yield break;
+        }
+
+        foreach (IGameItem contained in container.Contents.SelectMany(x => AccessibleStockItems(x, accessor)))
+        {
+            yield return contained;
+        }
+    }
+
+    private static IEnumerable<T> ComponentsInCell<T>(ICell cell, ICharacter accessor) where T : class, IGameItemComponent
+    {
+        return ItemsInCell(cell, accessor).SelectNotNull(x => x.GetItemType<T>());
+    }
+
+    private static IEnumerable<IKey> KeysInCell(ICell cell, ICharacter accessor)
+    {
+        return ComponentsInCell<IKey>(cell, accessor);
+    }
+
+    private static bool IsExecutionMeleeWeapon(IGameItem item)
+    {
+        return item.GetItemType<IMeleeWeapon>()?.WeaponType.Attacks.OfType<IFixedBodypartWeaponAttack>().Any() == true;
+    }
+
+    private static IEnumerable<ILock> DoorLocksForCells(IEnumerable<ICell> cells)
+    {
+        return cells
+               .Where(x => x is not null)
+               .SelectMany(x => x.ExitsFor(null, true))
+               .Where(x => x.Exit.Door?.Locks.Any() == true)
+               .DistinctBy(x => x.Exit)
+               .SelectMany(x => x.Exit.Door.Locks)
+               .Distinct();
+    }
+
+    private static IEnumerable<ILock> DoorLocksForPaths(ICell origin, IEnumerable<ICell> destinations)
+    {
+        if (origin is null)
+        {
+            return Enumerable.Empty<ILock>();
+        }
+
+        return destinations
+               .Where(x => x is not null)
+               .SelectMany(x => origin.PathBetween(x, 50, PathSearch.IgnorePresenceOfDoors))
+               .Where(x => x.Exit.Door?.Locks.Any() == true)
+               .DistinctBy(x => x.Exit)
+               .SelectMany(x => x.Exit.Door.Locks)
+               .Distinct();
+    }
+
+    private static IEnumerable<ILock> LocksMissingKeys(IEnumerable<ILock> locks, IEnumerable<IKey> keys)
+    {
+        List<IKey> keyList = keys.ToList();
+        return locks.Where(x => keyList.All(y => !y.Unlocks(x.LockType, x.Pattern)));
+    }
+
+    private static string LocationSuffix(ICell location, ICharacter actor, bool detailed)
+    {
+        return detailed && location is not null
+            ? $" in {location.GetFriendlyReference(actor)}"
+            : string.Empty;
     }
 
     private static List<ILegalAuthority> GetLegalAuthoritiesForEnforcerRoster(ICharacter actor, StringStack ss,

--- a/MudSharpCore/Effects/Concrete/PatrolDoorguardMode.cs
+++ b/MudSharpCore/Effects/Concrete/PatrolDoorguardMode.cs
@@ -1,0 +1,24 @@
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+
+namespace MudSharp.Effects.Concrete;
+
+public class PatrolDoorguardMode : Effect, IDoorguardModeEffect
+{
+	public PatrolDoorguardMode(IPerceivable owner)
+		: base(owner)
+	{
+	}
+
+	protected override string SpecificEffectType => "PatrolDoorguardMode";
+
+	public override string Describe(IPerceiver voyeur)
+	{
+		return "Patrol Door Guard Mode";
+	}
+
+	public override string ToString()
+	{
+		return "Patrol Door Guard Mode Effect";
+	}
+}

--- a/MudSharpCore/NPC/AI/EnforcerAI.cs
+++ b/MudSharpCore/NPC/AI/EnforcerAI.cs
@@ -8,8 +8,13 @@ using MudSharp.Events;
 using MudSharp.Framework;
 using MudSharp.FutureProg;
 using MudSharp.FutureProg.Statements.Manipulation;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Interfaces;
 using MudSharp.Models;
 using MudSharp.Movement;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Outputs;
+using MudSharp.PerceptionEngine.Parsers;
 using MudSharp.RPG.Law;
 using System;
 using System.Collections.Generic;
@@ -412,6 +417,26 @@ public class EnforcerAI : ArtificialIntelligenceBase
         return enforcer.EffectsOfType<EnforcerEffect>().FirstOrDefault();
     }
 
+    private void ReportVisibleCorpses(ICharacter enforcer)
+    {
+        bool reportedAny = false;
+        foreach (IGameItem corpseItem in enforcer.Location.LayerGameItems(enforcer.RoomLayer)
+                                             .Where(x => enforcer.CanSee(x))
+                                             .Where(x => x.GetItemType<ICorpse>() is { RepresentsFinalCharacterDeath: true }))
+        {
+            if (MudSharp.RPG.Law.LegalAuthority.ReportCorpseToLocalAuthority(Gameworld, corpseItem, enforcer, out _) != null)
+            {
+                reportedAny = true;
+            }
+        }
+
+        if (reportedAny)
+        {
+            enforcer.OutputHandler.Handle(new EmoteOutput(new Emote("@ report|reports a corpse to the authorities.",
+                enforcer)));
+        }
+    }
+
     private bool WitnessedCrime(ICharacter criminal, ICharacter victim, ICharacter enforcer, ICrime crime)
     {
         // Enforcers always report crimes whether they're on duty or off duty
@@ -509,6 +534,8 @@ public class EnforcerAI : ArtificialIntelligenceBase
         {
             return false;
         }
+
+        ReportVisibleCorpses(enforcer);
 
         if (HandleGeneral(enforcer))
         {

--- a/MudSharpCore/NPC/AI/Strategies/MovementStrategyFactory.cs
+++ b/MudSharpCore/NPC/AI/Strategies/MovementStrategyFactory.cs
@@ -3,6 +3,7 @@ using MudSharp.Character;
 using MudSharp.Commands.Socials;
 using MudSharp.Construction.Boundary;
 using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
 using MudSharp.Framework;
 using MudSharp.GameItems;
 using MudSharp.GameItems.Inventory;
@@ -289,7 +290,7 @@ public class MovementStrategyFactory
                 {
                     bool result = false;
                     foreach (ICharacter tch in ch.Location.Characters.Where(x =>
-                                 x.AffectedBy<DoorguardMode>() && !x.AffectedBy<DoorguardOpeningDoor>()))
+                                 x.AffectedBy<IDoorguardModeEffect>() && !x.AffectedBy<DoorguardOpeningDoor>()))
                     {
                         result = CheckDoorGuard(ch, tch, exit);
                         if (result)
@@ -301,7 +302,7 @@ public class MovementStrategyFactory
                     if (!result)
                     {
                         foreach (ICharacter tch in exit.Destination.Characters.Where(x =>
-                                     x.AffectedBy<DoorguardMode>() && !x.AffectedBy<DoorguardOpeningDoor>()))
+                                     x.AffectedBy<IDoorguardModeEffect>() && !x.AffectedBy<DoorguardOpeningDoor>()))
                         {
                             result = CheckDoorGuard(ch, tch, exit);
                             if (result)
@@ -353,7 +354,7 @@ public class MovementStrategyFactory
                 {
                     bool result = false;
                     foreach (ICharacter tch in ch.Location.Characters.Where(x =>
-                                 x.AffectedBy<DoorguardMode>() && !x.AffectedBy<DoorguardOpeningDoor>()))
+                                 x.AffectedBy<IDoorguardModeEffect>() && !x.AffectedBy<DoorguardOpeningDoor>()))
                     {
                         result = CheckDoorGuard(ch, tch, exit);
                         if (result)
@@ -365,7 +366,7 @@ public class MovementStrategyFactory
                     if (!result)
                     {
                         foreach (ICharacter tch in exit.Destination.Characters.Where(x =>
-                                     x.AffectedBy<DoorguardMode>() && !x.AffectedBy<DoorguardOpeningDoor>()))
+                                     x.AffectedBy<IDoorguardModeEffect>() && !x.AffectedBy<DoorguardOpeningDoor>()))
                         {
                             result = CheckDoorGuard(ch, tch, exit);
                             if (result)
@@ -408,7 +409,7 @@ public class MovementStrategyFactory
             {
                 bool result = false;
                 foreach (ICharacter tch in ch.Location.Characters.Where(x =>
-                             x.AffectedBy<DoorguardMode>() && !x.AffectedBy<DoorguardOpeningDoor>()))
+                             x.AffectedBy<IDoorguardModeEffect>() && !x.AffectedBy<DoorguardOpeningDoor>()))
                 {
                     result = CheckDoorGuard(ch, tch, exit);
                     if (result)
@@ -420,7 +421,7 @@ public class MovementStrategyFactory
                 if (!result)
                 {
                     foreach (ICharacter tch in exit.Destination.Characters.Where(x =>
-                                 x.AffectedBy<DoorguardMode>() && !x.AffectedBy<DoorguardOpeningDoor>()))
+                                 x.AffectedBy<IDoorguardModeEffect>() && !x.AffectedBy<DoorguardOpeningDoor>()))
                     {
                         result = CheckDoorGuard(ch, tch, exit);
                         if (result)

--- a/MudSharpCore/RPG/Law/LegalAuthority.CorpseRecovery.cs
+++ b/MudSharpCore/RPG/Law/LegalAuthority.CorpseRecovery.cs
@@ -1,5 +1,7 @@
 using MudSharp.Character;
+using MudSharp.Construction;
 using MudSharp.Economy;
+using MudSharp.Economy.Estates;
 using MudSharp.Framework;
 using MudSharp.GameItems;
 using MudSharp.GameItems.Interfaces;
@@ -12,6 +14,53 @@ public partial class LegalAuthority
 {
     private readonly List<ICorpseRecoveryReport> _corpseRecoveryReports = new();
     public IEnumerable<ICorpseRecoveryReport> CorpseRecoveryReports => _corpseRecoveryReports;
+
+    public static ICorpseRecoveryReport ReportCorpseToLocalAuthority(IFuturemud gameworld, IGameItem corpse,
+        ICharacter reporter, out string errorMessage)
+    {
+        errorMessage = string.Empty;
+        ICorpse corpseComponent = corpse?.GetItemType<ICorpse>();
+        if (corpseComponent == null)
+        {
+            errorMessage = "You do not see any such corpse here.";
+            return null;
+        }
+
+        if (!corpseComponent.RepresentsFinalCharacterDeath)
+        {
+            errorMessage = "Those are body remains rather than the final corpse of a dead character, and cannot be reported to the morgue.";
+            return null;
+        }
+
+        ICell sourceCell = corpse.Location ?? corpse.TrueLocations.FirstOrDefault();
+        if (sourceCell == null)
+        {
+            errorMessage = "That corpse is not currently in a reportable location.";
+            return null;
+        }
+
+        ILegalAuthority authority = gameworld.LegalAuthorities.FirstOrDefault(x => x.EnforcementZones.Contains(sourceCell.Zone));
+        if (authority == null)
+        {
+            errorMessage = "There is no local legal authority that can respond to this corpse.";
+            return null;
+        }
+
+        IEconomicZone zone = Estate.DetermineZone(gameworld, sourceCell);
+        if (zone == null || zone.MorgueOfficeCell == null || zone.MorgueStorageCell == null)
+        {
+            errorMessage = "There is no configured morgue for the economic zone that covers this corpse.";
+            return null;
+        }
+
+        if (authority.ActiveCorpseRecoveryReport(corpse) != null)
+        {
+            errorMessage = "That corpse has already been reported to the authorities.";
+            return null;
+        }
+
+        return authority.ReportCorpse(corpse, zone, reporter);
+    }
 
     public ICorpseRecoveryReport ActiveCorpseRecoveryReport(IGameItem corpse)
     {

--- a/MudSharpCore/RPG/Law/Patrol.cs
+++ b/MudSharpCore/RPG/Law/Patrol.cs
@@ -148,6 +148,7 @@ public class Patrol : SaveableItem, IPatrol
 
     public void ConcludePatrol()
     {
+        (PatrolStrategy as PatrolStrategyBase)?.HandlePatrolCompleted(this);
         foreach (ICharacter member in PatrolMembers.ToList())
         {
             member.RemoveAllEffects<PatrolMemberEffect>(fireRemovalAction: true);
@@ -186,6 +187,7 @@ public class Patrol : SaveableItem, IPatrol
 
     public void AbortPatrol()
     {
+        (PatrolStrategy as PatrolStrategyBase)?.HandlePatrolAborted(this);
         foreach (ICharacter member in PatrolMembers.ToList())
         {
             member.RemoveAllEffects<PatrolMemberEffect>(fireRemovalAction: true);
@@ -198,6 +200,7 @@ public class Patrol : SaveableItem, IPatrol
 
     public void CompletePatrol()
     {
+        (PatrolStrategy as PatrolStrategyBase)?.HandlePatrolCompleted(this);
         PatrolPhase = PatrolPhase.Return;
         LastMajorNode = NextMajorNode;
         NextMajorNode = null;

--- a/MudSharpCore/RPG/Law/PatrolStrategies/DoorDutiesPatrolStrategy.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/DoorDutiesPatrolStrategy.cs
@@ -1,0 +1,247 @@
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Construction.Boundary;
+using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MudSharp.RPG.Law.PatrolStrategies;
+
+public class DoorDutiesPatrolStrategy : PatrolStrategyBase
+{
+	public override string Name => "DoorDuties";
+
+	public DoorDutiesPatrolStrategy(IFuturemud gameworld)
+		: base(gameworld)
+	{
+	}
+
+	private static ICell DutyLocation(IPatrol patrol)
+	{
+		return patrol.PatrolRoute.PatrolNodes.FirstOrDefault();
+	}
+
+	private static void EnableDoorGuardMode(IPatrol patrol)
+	{
+		ICell dutyLocation = DutyLocation(patrol);
+		if (dutyLocation is null)
+		{
+			return;
+		}
+
+		ICell[] dutyCells = { dutyLocation };
+		foreach (ICharacter member in patrol.PatrolMembers.Where(x => x.Location == dutyLocation))
+		{
+			if (!member.AffectedBy<IDoorguardModeEffect>() && HasKeysForCells(member, dutyCells))
+			{
+				member.AddEffect(new PatrolDoorguardMode(member));
+			}
+		}
+	}
+
+	private static void DisableDoorGuardMode(IPatrol patrol)
+	{
+		foreach (ICharacter member in patrol.PatrolMembers)
+		{
+			member.RemoveAllEffects<PatrolDoorguardMode>(fireRemovalAction: true);
+		}
+	}
+
+	private static void CompleteDoorDuty(IPatrol patrol)
+	{
+		DisableDoorGuardMode(patrol);
+		patrol.CompletePatrol();
+	}
+
+	private static void AbortDoorDuty(IPatrol patrol)
+	{
+		DisableDoorGuardMode(patrol);
+		patrol.AbortPatrol();
+	}
+
+	public override void HandlePatrolCompleted(IPatrol patrol)
+	{
+		DisableDoorGuardMode(patrol);
+	}
+
+	public override void HandlePatrolAborted(IPatrol patrol)
+	{
+		DisableDoorGuardMode(patrol);
+	}
+
+	protected override void PatrolTickActiveEnforcement(IPatrol patrol)
+	{
+		DisableDoorGuardMode(patrol);
+		base.PatrolTickActiveEnforcement(patrol);
+	}
+
+	protected override void PatrolTickPreparationPhase(IPatrol patrol)
+	{
+		ICell dutyLocation = DutyLocation(patrol);
+		if (dutyLocation is null)
+		{
+			AbortDoorDuty(patrol);
+			return;
+		}
+
+		ICell[] dutyCells = { dutyLocation };
+		if (patrol.PatrolMembers.All(x => x.Location == dutyLocation) &&
+			HasKeysForCells(patrol.PatrolLeader, dutyCells))
+		{
+			patrol.PatrolPhase = PatrolPhase.Patrol;
+			patrol.LastArrivedTime = DateTime.UtcNow;
+			patrol.LastMajorNode = patrol.LegalAuthority.MarshallingLocation;
+			patrol.NextMajorNode = dutyLocation;
+			EnableDoorGuardMode(patrol);
+			return;
+		}
+
+		foreach (ICharacter member in patrol.PatrolMembers)
+		{
+			if (member.Location != patrol.LegalAuthority.PreparingLocation)
+			{
+				if (!member.CombinedEffectsOfType<FollowingPath>().Any())
+				{
+					List<ICellExit> path = member.PathBetween(patrol.LegalAuthority.PreparingLocation, 25,
+						PathSearch.PathIncludeUnlockableDoors(member)).ToList();
+					if (path.Any())
+					{
+						FollowingPath fp = new(member, path)
+						{
+							UseDoorguards = true,
+							UseKeys = true,
+							OpenDoors = true
+						};
+						member.AddEffect(fp);
+						fp.FollowPathAction();
+					}
+				}
+
+				continue;
+			}
+
+			if (member == patrol.PatrolLeader)
+			{
+				PrepareKeysForCells(member, dutyCells);
+			}
+		}
+
+		if (patrol.PatrolMembers.Any(x => x.Location != patrol.LegalAuthority.PreparingLocation))
+		{
+			if (DateTime.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(3))
+			{
+				AbortDoorDuty(patrol);
+			}
+
+			return;
+		}
+
+		if (!HasKeysForCells(patrol.PatrolLeader, dutyCells))
+		{
+			if (DateTime.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(3))
+			{
+				AbortDoorDuty(patrol);
+			}
+
+			return;
+		}
+
+		if (DateTime.UtcNow - patrol.LastArrivedTime <= TimeSpan.FromMinutes(1))
+		{
+			return;
+		}
+
+		FormParty(patrol);
+		patrol.PatrolPhase = PatrolPhase.Deployment;
+		patrol.LastArrivedTime = DateTime.UtcNow;
+		patrol.LastMajorNode = patrol.PatrolLeader.Location;
+		patrol.NextMajorNode = dutyLocation;
+	}
+
+	protected override void PatrolTickPatrolPhase(IPatrol patrol)
+	{
+		if (patrol.ActiveEnforcementTarget != null)
+		{
+			return;
+		}
+
+		ICell dutyLocation = DutyLocation(patrol);
+		if (dutyLocation is null)
+		{
+			AbortDoorDuty(patrol);
+			return;
+		}
+
+		if (patrol.PatrolLeader.Location == dutyLocation)
+		{
+			EnableDoorGuardMode(patrol);
+		}
+
+		if (DateTime.UtcNow - patrol.LastArrivedTime >= patrol.PatrolRoute.LingerTimeMajorNode)
+		{
+			CompleteDoorDuty(patrol);
+			return;
+		}
+
+		if (!patrol.PatrolRoute.TimeOfDays.Contains(patrol.PatrolLeader.Location.CurrentTimeOfDay))
+		{
+			CompleteDoorDuty(patrol);
+			return;
+		}
+
+		if (patrol.PatrolLeader.Location != dutyLocation)
+		{
+			FollowingPath effect = patrol.PatrolLeader.CombinedEffectsOfType<FollowingPath>().FirstOrDefault();
+			if (effect != null)
+			{
+				return;
+			}
+
+			List<ICellExit> path = patrol.PatrolLeader
+											 .PathBetween(dutyLocation, 20,
+												 PathSearch.PathIncludeUnlockableDoors(patrol.PatrolLeader))
+											 .ToList();
+			if (path.Count == 0)
+			{
+				path = patrol.PatrolLeader.PathBetween(dutyLocation, 50,
+					PathSearch.IgnorePresenceOfDoors).ToList();
+				if (path.Count == 0)
+				{
+					if (DateTime.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(3))
+					{
+						AbortDoorDuty(patrol);
+						return;
+					}
+
+					return;
+				}
+			}
+
+			FollowingPath fp = new(patrol.PatrolLeader, path)
+			{
+				UseDoorguards = true,
+				UseKeys = true,
+				OpenDoors = true
+			};
+			patrol.PatrolLeader.AddEffect(fp);
+			fp.FollowPathAction();
+		}
+	}
+
+	public override IEnumerable<ICharacter> SelectEnforcers(IPatrolRoute patrol, IEnumerable<ICharacter> pool,
+		int numberToPick)
+	{
+		ICell node = patrol.PatrolNodes.First();
+		List<ICharacter> selected = new();
+		selected.AddRange(pool.Where(x => x.Location == node).PickUpToRandom(numberToPick));
+		if (selected.Count >= numberToPick)
+		{
+			return selected;
+		}
+
+		return selected.Concat(pool.Except(selected).PickUpToRandom(numberToPick - selected.Count));
+	}
+}

--- a/MudSharpCore/RPG/Law/PatrolStrategies/ExecutionPatrolStrategy.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/ExecutionPatrolStrategy.cs
@@ -5,6 +5,7 @@ using MudSharp.Combat.Moves;
 using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
 using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
 using MudSharp.Framework;
 using MudSharp.GameItems;
 using MudSharp.GameItems.Interfaces;
@@ -68,6 +69,11 @@ public class ExecutionPatrolStrategy : PatrolStrategyBase, IConfigurablePatrolSt
 	private bool _arrivalEmoteSent;
 	private bool _restraintEmoteSent;
 	private bool _lastWordsEmoteSent;
+
+	private const string CondemnedPlaceholder = "%condemned%";
+	private const string PrisonerPlaceholder = "%prisoner%";
+	private const string TargetPlaceholder = "%target%";
+	private const string ExecutionerPlaceholder = "%executioner%";
 
 	public override string Name => "ExecutionPatrol";
 
@@ -143,7 +149,7 @@ public class ExecutionPatrolStrategy : PatrolStrategyBase, IConfigurablePatrolSt
 	public string CompletionEmote { get; private set; } = "@ confirm|confirms that $1's sentence has been carried out.";
 	private readonly List<string> _executionScript = new()
 	{
-		"@ announce|announces, \"$1 has been sentenced to death by lawful authority.\"",
+		"@ announce|announces, \"%condemned% has been sentenced to death by lawful authority.\"",
 		"@ pause|pauses solemnly before the sentence is carried out."
 	};
 
@@ -163,7 +169,9 @@ public class ExecutionPatrolStrategy : PatrolStrategyBase, IConfigurablePatrolSt
 	#3script add <emote>#0 - adds a scripted execution step
 	#3script delete <##>#0 - deletes a scripted execution step
 	#3script swap <##> <##>#0 - swaps two scripted execution steps
-	#3script clear#0 - clears the scripted execution steps";
+	#3script clear#0 - clears the scripted execution steps
+
+Use normal emote targets outside speech: $0 is the executioner and $1 is the condemned. Inside quoted speech, use %condemned% or %executioner% for spoken names.";
 
 	public bool ReadyToBegin(IPatrolRoute patrol)
 	{
@@ -668,6 +676,24 @@ public class ExecutionPatrolStrategy : PatrolStrategyBase, IConfigurablePatrolSt
 			return true;
 		}
 
+		foreach (ICharacter member in patrol.PatrolMembers.Where(x => x.ColocatedWith(_condemned)))
+		{
+			if (member.Combat?.CanFreelyLeaveCombat(member) == true)
+			{
+				member.Combat.LeaveCombat(member);
+			}
+		}
+
+		if (_condemned.Combat?.Combatants.OfType<ICharacter>().Any(x => patrol.PatrolMembers.ContainsPhysicalInstance(x)) == true)
+		{
+			return false;
+		}
+
+		if (_condemned.Combat is not null && _condemned.MeleeRange)
+		{
+			return false;
+		}
+
 		ICharacter dragger = patrol.PatrolMembers
 		                            .Where(x => x.ColocatedWith(_condemned))
 		                            .Where(x => x.State.IsAble())
@@ -727,12 +753,6 @@ public class ExecutionPatrolStrategy : PatrolStrategyBase, IConfigurablePatrolSt
 
 		if (patrol.PatrolLeader.Location == executionLocation && _condemned.Location == executionLocation)
 		{
-			_condemned.RemoveAllEffects<Dragging.DragTarget>(fireRemovalAction: true);
-			foreach (ICharacter member in patrol.PatrolMembers)
-			{
-				member.RemoveAllEffects<Dragging>(x => x.Target == _condemned, fireRemovalAction: true);
-			}
-
 			if (!_arrivalEmoteSent)
 			{
 				DoEmote(patrol.PatrolLeader, ArrivalEmote, _condemned);
@@ -761,7 +781,7 @@ public class ExecutionPatrolStrategy : PatrolStrategyBase, IConfigurablePatrolSt
 			return;
 		}
 
-		if (_condemned.Body.EffectsOfType<RestraintEffect>().Any())
+		if (CondemnedIsSecuredForExecution(patrol))
 		{
 			SetStage(ExecutionPatrolStage.LastWords);
 			return;
@@ -775,14 +795,17 @@ public class ExecutionPatrolStrategy : PatrolStrategyBase, IConfigurablePatrolSt
 				_restraintEmoteSent = true;
 			}
 
-			SetStage(ExecutionPatrolStage.LastWords);
+			if (CondemnedIsSecuredForExecution(patrol))
+			{
+				SetStage(ExecutionPatrolStage.LastWords);
+				return;
+			}
+
+			SetStage(ExecutionPatrolStage.SubduingPrisoner);
 			return;
 		}
 
-		if (DateTime.UtcNow - _stageBegan > TimeSpan.FromMinutes(3))
-		{
-			AbortExecution(patrol);
-		}
+		SetStage(ExecutionPatrolStage.SubduingPrisoner);
 	}
 
 	private bool TryRestrainCondemned(IPatrol patrol)
@@ -875,7 +898,7 @@ public class ExecutionPatrolStrategy : PatrolStrategyBase, IConfigurablePatrolSt
 			return false;
 		}
 
-		if (!_condemned.Body.EffectsOfType<RestraintEffect>().Any())
+		if (!CondemnedIsSecuredForExecution(patrol))
 		{
 			ResetCeremonyProgress();
 			SetStage(ExecutionPatrolStage.RestrainingPrisoner);
@@ -883,6 +906,23 @@ public class ExecutionPatrolStrategy : PatrolStrategyBase, IConfigurablePatrolSt
 		}
 
 		return true;
+	}
+
+	private bool CondemnedIsSecuredForExecution(IPatrol patrol)
+	{
+		return _condemned.IsHelpless ||
+		       IsBeingDraggedByPatrol(patrol) ||
+		       AllLimbsIneffectiveFromRestraint();
+	}
+
+	private bool AllLimbsIneffectiveFromRestraint()
+	{
+		List<ILimbIneffectiveEffect> restraintEffects = _condemned.Body
+		                                                  .EffectsOfType<ILimbIneffectiveEffect>()
+		                                                  .Where(x => x.Reason == LimbIneffectiveReason.Restrained)
+		                                                  .ToList();
+		return restraintEffects.Any() &&
+		       _condemned.Body.Limbs.All(limb => restraintEffects.Any(effect => effect.AppliesToLimb(limb)));
 	}
 
 	private void ResetCeremonyProgress()
@@ -1097,6 +1137,7 @@ public class ExecutionPatrolStrategy : PatrolStrategyBase, IConfigurablePatrolSt
 	{
 		if (_condemned is not null)
 		{
+			ReleaseCondemnedFromPatrolDrag(patrol);
 			_condemned.RemoveAllEffects<ExecutionPatrolNoQuit>(x => x.Patrol == patrol, fireRemovalAction: true);
 			_condemned.RemoveAllEffects<AwaitingExecution>(x => x.LegalAuthority == patrol.LegalAuthority, fireRemovalAction: true);
 			foreach (ICrime crime in patrol.LegalAuthority.ResolvedCrimesForIndividual(_condemned)
@@ -1104,6 +1145,8 @@ public class ExecutionPatrolStrategy : PatrolStrategyBase, IConfigurablePatrolSt
 			{
 				crime.SentenceHasBeenServed = true;
 			}
+
+			ReportExecutionCorpseForRecovery(patrol);
 		}
 
 		ResetRuntimeState();
@@ -1114,11 +1157,27 @@ public class ExecutionPatrolStrategy : PatrolStrategyBase, IConfigurablePatrolSt
 	{
 		if (_condemned is not null)
 		{
+			ReleaseCondemnedFromPatrolDrag(patrol);
 			_condemned.RemoveAllEffects<ExecutionPatrolNoQuit>(x => x.Patrol == patrol, fireRemovalAction: true);
 		}
 
 		ResetRuntimeState();
 		patrol.AbortPatrol();
+	}
+
+	private void ReleaseCondemnedFromPatrolDrag(IPatrol patrol)
+	{
+		_condemned.RemoveAllEffects<Dragging.DragTarget>(fireRemovalAction: true);
+		foreach (ICharacter member in patrol.PatrolMembers)
+		{
+			member.RemoveAllEffects<Dragging>(x => x.Target == _condemned, fireRemovalAction: true);
+		}
+	}
+
+	private void ReportExecutionCorpseForRecovery(IPatrol patrol)
+	{
+		IGameItem corpseItem = _condemned.Corpse?.Parent;
+		LegalAuthority.ReportCorpseToLocalAuthority(Gameworld, corpseItem, patrol.PatrolLeader, out _);
 	}
 
 	private void ResetRuntimeState()
@@ -1139,7 +1198,7 @@ public class ExecutionPatrolStrategy : PatrolStrategyBase, IConfigurablePatrolSt
 
 	private static void DoEmote(ICharacter actor, string emoteText, ICharacter condemned)
 	{
-		Emote emote = new(emoteText, actor, actor, condemned);
+		Emote emote = new(ExpandExecutionEmotePlaceholders(emoteText, actor, condemned), actor, actor, condemned);
 		if (!emote.Valid)
 		{
 			actor.OutputHandler.Send(emote.ErrorMessage);
@@ -1147,6 +1206,16 @@ public class ExecutionPatrolStrategy : PatrolStrategyBase, IConfigurablePatrolSt
 		}
 
 		actor.OutputHandler.Handle(new EmoteOutput(emote));
+	}
+
+	private static string ExpandExecutionEmotePlaceholders(string emoteText, ICharacter executioner, ICharacter condemned)
+	{
+		string condemnedName = condemned.HowSeen(executioner, colour: false, flags: PerceiveIgnoreFlags.IgnoreSelf);
+		string executionerName = executioner.HowSeen(executioner, colour: false, flags: PerceiveIgnoreFlags.IgnoreSelf);
+		return emoteText.Replace(CondemnedPlaceholder, condemnedName, StringComparison.OrdinalIgnoreCase)
+		                .Replace(PrisonerPlaceholder, condemnedName, StringComparison.OrdinalIgnoreCase)
+		                .Replace(TargetPlaceholder, condemnedName, StringComparison.OrdinalIgnoreCase)
+		                .Replace(ExecutionerPlaceholder, executionerName, StringComparison.OrdinalIgnoreCase);
 	}
 
 	public bool BuildingCommand(ICharacter actor, IPatrolRoute patrol, StringStack command)
@@ -1483,7 +1552,7 @@ public class ExecutionPatrolStrategy : PatrolStrategyBase, IConfigurablePatrolSt
 
 	private static bool ValidateEmote(ICharacter actor, string emote)
 	{
-		Emote test = new(emote, actor, actor, actor);
+		Emote test = new(ExpandExecutionEmotePlaceholders(emote, actor, actor), actor, actor, actor);
 		if (test.Valid)
 		{
 			return true;

--- a/MudSharpCore/RPG/Law/PatrolStrategies/ExecutionPatrolStrategy.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/ExecutionPatrolStrategy.cs
@@ -131,6 +131,7 @@ public class ExecutionPatrolStrategy : PatrolStrategyBase, IConfigurablePatrolSt
 
 	public ExecutionPatrolExecutionMethod Method { get; private set; } = ExecutionPatrolExecutionMethod.CoupDeGraceWithWeapon;
 	public long EquipmentLocationId { get; private set; }
+	public bool RequireKeysForRetrieval { get; private set; }
 	public long DrugId { get; private set; }
 	public double DrugGrams { get; private set; } = 1.0;
 	public DrugVector DrugVector { get; private set; } = DrugVector.Injected;
@@ -157,6 +158,7 @@ public class ExecutionPatrolStrategy : PatrolStrategyBase, IConfigurablePatrolSt
 
 	#3method cdg|drug|firing#0 - sets the execution method
 	#3equipment here|<room>|none#0 - sets the room used to retrieve tools, defaulting to the legal authority preparation room
+	#3keys [on|off]#0 - toggles whether the patrol must retrieve keys for the prisoner's location before departure
 	#3drug <id|name>#0 - sets the drug for the administer-drug method
 	#3dose <grams>#0 - sets the grams of drug administered per attempt
 	#3vector injected|ingested|inhaled|touched#0 - sets the drug vector
@@ -474,29 +476,13 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 		SetStage(ExecutionPatrolStage.RetrievingPrisoner);
 	}
 
-	private void FormParty(IPatrol patrol)
-	{
-		if (patrol.PatrolLeader.Party is not null)
-		{
-			patrol.PatrolLeader.LeaveParty();
-		}
-
-		Party party = new(patrol.PatrolLeader);
-		patrol.PatrolLeader.JoinParty(party);
-		foreach (ICharacter member in patrol.PatrolMembers.Where(x => x.ColocatedWith(patrol.PatrolLeader)).ToList())
-		{
-			if (member == patrol.PatrolLeader)
-			{
-				continue;
-			}
-
-			member.LeaveParty();
-			member.JoinParty(party);
-		}
-	}
-
 	private void DoPreparationRoomAction(ICharacter member, bool isLeader)
 	{
+		if (isLeader && RequireKeysForRetrieval)
+		{
+			PrepareRetrievalKeys(member);
+		}
+
 		PrepareRestraints(member);
 
 		switch (Method)
@@ -525,26 +511,48 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 		PrepareInventoryPlan(member, _restraintTemplate);
 	}
 
-	private static void PrepareInventoryPlan(ICharacter member, IInventoryPlanTemplate template)
+	private IEnumerable<ICellExit> RetrievalKeyExitsFor(ICharacter member)
 	{
-		IInventoryPlan plan = template.CreatePlan(member);
-		if (plan.PlanIsFeasible() == InventoryPlanFeasibility.Feasible)
+		if (_condemned is null)
 		{
-			plan.ExecuteWholePlan();
+			return Enumerable.Empty<ICellExit>();
 		}
 
-		plan.FinalisePlanNoRestore();
+		List<ICellExit> path = member.PathBetween(_condemned, 50, PathSearch.IgnorePresenceOfDoors).ToList();
+		if (!path.Any() && _condemned.Location is not null)
+		{
+			path = member.PathBetween(_condemned.Location, 50, PathSearch.IgnorePresenceOfDoors).ToList();
+		}
+
+		return path
+		       .Concat(_condemned.Location?.ExitsFor(member, true) ?? Enumerable.Empty<ICellExit>())
+		       .Where(x => x.Exit.Door?.Locks.Any() == true)
+		       .DistinctBy(x => x.Exit)
+		       .ToList();
+	}
+
+	private bool PrepareRetrievalKeys(ICharacter member)
+	{
+		return PrepareKeysForExits(member, RetrievalKeyExitsFor(member));
+	}
+
+	private bool RetrievalKeysReady(IPatrol patrol)
+	{
+		return !RequireKeysForRetrieval ||
+		       HasKeysForExits(patrol.PatrolLeader, RetrievalKeyExitsFor(patrol.PatrolLeader));
 	}
 
 	private bool EquipmentReady(IPatrol patrol)
 	{
-		return Method switch
+		bool equipmentReady = Method switch
 		{
 			ExecutionPatrolExecutionMethod.CoupDeGraceWithWeapon => GetCoupDeGraceAttack(patrol.PatrolLeader) is not null,
 			ExecutionPatrolExecutionMethod.AdministerDrug => DrugId > 0,
 			ExecutionPatrolExecutionMethod.FiringSquad => patrol.PatrolMembers.Any(x => ReadyRangedWeapons(x)),
 			_ => false
 		};
+
+		return equipmentReady && RetrievalKeysReady(patrol);
 	}
 
 	private bool ReadyRangedWeapons(ICharacter shooter)
@@ -1228,6 +1236,9 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 			case "equip":
 			case "room":
 				return BuildingCommandEquipment(actor, command);
+			case "keys":
+			case "key":
+				return BuildingCommandKeys(actor, command);
 			case "drug":
 				return BuildingCommandDrug(actor, command);
 			case "dose":
@@ -1332,6 +1343,30 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 
 		EquipmentLocationId = location.Id;
 		actor.OutputHandler.Send($"This execution patrol will retrieve equipment from {location.HowSeen(actor)}.");
+		return true;
+	}
+
+	private bool BuildingCommandKeys(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			RequireKeysForRetrieval = !RequireKeysForRetrieval;
+		}
+		else if (command.SafeRemainingArgument.EqualToAny("on", "true", "yes", "require", "required"))
+		{
+			RequireKeysForRetrieval = true;
+		}
+		else if (command.SafeRemainingArgument.EqualToAny("off", "false", "no", "optional", "none"))
+		{
+			RequireKeysForRetrieval = false;
+		}
+		else
+		{
+			actor.OutputHandler.Send("Do you want this patrol to require retrieval keys: on or off?");
+			return false;
+		}
+
+		actor.OutputHandler.Send($"This execution patrol will {RequireKeysForRetrieval.NowNoLonger()} require keys for the prisoner's retrieval route.");
 		return true;
 	}
 
@@ -1572,6 +1607,7 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 		sb.AppendLine($"Execution Location: {execution?.GetFriendlyReference(actor) ?? "None".ColourError()}");
 		sb.AppendLine($"Equipment Location: {equipment?.GetFriendlyReference(actor) ?? "None".ColourError()}");
 		sb.AppendLine($"Method: {Method.DescribeEnum().ColourValue()}");
+		sb.AppendLine($"Require Retrieval Keys: {RequireKeysForRetrieval.ToColouredString()}");
 		sb.AppendLine($"Drug: {drug?.Name.ColourName() ?? "None".ColourError()}");
 		sb.AppendLine($"Drug Dose: {DrugGrams.ToString("N3", actor).ColourValue()} grams via {DrugVector.DescribeEnum().ColourValue()}");
 		sb.AppendLine($"Compliance Window: {ComplianceWindowSeconds.ToString("N0", actor).ColourValue()} seconds");
@@ -1600,6 +1636,7 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 		return new XElement("ExecutionPatrol",
 			new XAttribute("method", (int)Method),
 			new XAttribute("equipment", EquipmentLocationId),
+			new XAttribute("keys", RequireKeysForRetrieval),
 			new XAttribute("drug", DrugId),
 			new XAttribute("druggrams", DrugGrams.ToString(CultureInfo.InvariantCulture)),
 			new XAttribute("drugvector", (int)DrugVector),
@@ -1648,6 +1685,11 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 		if (long.TryParse(root.Attribute("equipment")?.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out long equipment))
 		{
 			EquipmentLocationId = equipment;
+		}
+
+		if (bool.TryParse(root.Attribute("keys")?.Value, out bool keys))
+		{
+			RequireKeysForRetrieval = keys;
 		}
 
 		if (long.TryParse(root.Attribute("drug")?.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out long drug))

--- a/MudSharpCore/RPG/Law/PatrolStrategies/PatrolStrategyBase.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/PatrolStrategyBase.cs
@@ -215,6 +215,62 @@ public abstract class PatrolStrategyBase : IPatrolStrategy
         }
     }
 
+    private static bool IsBeingDraggedByPatrol(IPatrol patrol, ICharacter criminal)
+    {
+        return patrol.PatrolMembers.Any(x => x.CombinedEffectsOfType<Dragging>().Any(y => y.Target == criminal));
+    }
+
+    private bool TryStartDraggingHelplessCriminal(IPatrol patrol, ICharacter criminal)
+    {
+        if (!criminal.IsHelpless)
+        {
+            return false;
+        }
+
+        foreach (ICharacter member in patrol.PatrolMembers.Where(x => x.ColocatedWith(criminal)))
+        {
+            LeaveCombatIfAble(member);
+        }
+
+        if (criminal.Combat?.Combatants.OfType<ICharacter>().Any(x => patrol.PatrolMembers.ContainsPhysicalInstance(x)) == true)
+        {
+            return true;
+        }
+
+        if (criminal.Combat is not null && criminal.MeleeRange)
+        {
+            return true;
+        }
+
+        ICharacter random = patrol.PatrolMembers
+                                   .Where(x => x.ColocatedWith(criminal))
+                                   .Where(x => x.State.IsAble())
+                                   .FirstOrDefault(x => x.SamePhysicalInstance(patrol.PatrolLeader)) ??
+                            patrol.PatrolMembers
+                                  .Where(x => x.ColocatedWith(criminal))
+                                  .Where(x => x.State.IsAble())
+                                  .GetRandomElement();
+        if (random is null)
+        {
+            return true;
+        }
+
+        random.ExecuteCommand($"drag {random.BestKeywordFor(criminal)}");
+        if (random.CombinedEffectsOfType<Dragging>().Any(x => x.Target == criminal))
+        {
+            foreach (ICharacter other in patrol.PatrolMembers
+                                                .Where(x => !x.SamePhysicalInstance(random))
+                                                .Where(x => x.ColocatedWith(random)))
+            {
+                LeaveCombatIfAble(other);
+
+                other.ExecuteCommand($"drag help {other.BestKeywordFor(random)}");
+            }
+        }
+
+        return true;
+    }
+
     protected virtual void PatrolTickActiveEnforcement(IPatrol patrol)
     {
         ICharacter criminal = patrol.ActiveEnforcementTarget;
@@ -238,7 +294,7 @@ public abstract class PatrolStrategyBase : IPatrolStrategy
             return;
         }
 
-        if (patrol.PatrolMembers.Any(x => x.CombinedEffectsOfType<Dragging>().Any(x => x.Target == criminal)))
+        if (IsBeingDraggedByPatrol(patrol, criminal))
         {
             criminal.RemoveAllEffects(x => x.IsEffectType<WarnedByEnforcer>(), true);
         }
@@ -250,7 +306,7 @@ public abstract class PatrolStrategyBase : IPatrolStrategy
         }
 
         // Is criminal detained by an enforcer?
-        if (patrol.PatrolMembers.Any(x => x.CombinedEffectsOfType<Dragging>().Any(x => x.Target == criminal)))
+        if (IsBeingDraggedByPatrol(patrol, criminal))
         {
             // Get rest of team to join drag
             foreach (ICharacter member in patrol.PatrolMembers)
@@ -309,6 +365,12 @@ public abstract class PatrolStrategyBase : IPatrolStrategy
             return;
         }
 
+        // Is criminal incapacitated?
+        if (TryStartDraggingHelplessCriminal(patrol, criminal))
+        {
+            return;
+        }
+
         // Is criminal in combat with enforcers?
         if (criminal.Combat?.Combatants.OfType<ICharacter>().Any(x => patrol.PatrolMembers.ContainsPhysicalInstance(x)) == true)
         {
@@ -331,39 +393,6 @@ public abstract class PatrolStrategyBase : IPatrolStrategy
             foreach (ICharacter enforcer in patrol.PatrolMembers.Where(x => !engagedPatrolMembers.ContainsPhysicalInstance(x)).ToArray())
             {
                 enforcer.ExecuteCommand($"support {enforcer.BestKeywordFor(engagedPatrolMembers.GetRandomElement())}");
-            }
-
-            return;
-        }
-
-        // Is criminal incapacitated?
-        if (criminal.IsHelpless)
-        {
-            // Grab the criminal
-            ICharacter random = patrol.PatrolMembers
-                                       .Where(x => x.ColocatedWith(criminal))
-                                       .Where(x => x.State.IsAble())
-                                       .FirstOrDefault(x => x.SamePhysicalInstance(leader)) ??
-                                patrol.PatrolMembers
-                                      .Where(x => x.ColocatedWith(criminal))
-                                      .Where(x => x.State.IsAble())
-                                      .GetRandomElement();
-            if (random is null)
-            {
-                return;
-            }
-
-            LeaveCombatIfAble(random);
-
-            random.ExecuteCommand($"drag {random.BestKeywordFor(criminal)}");
-            if (random.CombinedEffectsOfType<Dragging>().Any(x => x.Target == criminal))
-            {
-                foreach (ICharacter other in patrol.PatrolMembers.Where(x => !x.SamePhysicalInstance(random)))
-                {
-                    LeaveCombatIfAble(other);
-
-                    other.ExecuteCommand($"drag help {other.BestKeywordFor(random)}");
-                }
             }
 
             return;

--- a/MudSharpCore/RPG/Law/PatrolStrategies/PatrolStrategyBase.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/PatrolStrategyBase.cs
@@ -500,6 +500,134 @@ public abstract class PatrolStrategyBase : IPatrolStrategy
         // Do nothing
     }
 
+    public virtual void HandlePatrolCompleted(IPatrol patrol)
+    {
+        // Do nothing
+    }
+
+    public virtual void HandlePatrolAborted(IPatrol patrol)
+    {
+        // Do nothing
+    }
+
+    protected static void PrepareInventoryPlan(ICharacter member, IInventoryPlanTemplate template)
+    {
+        IInventoryPlan plan = template.CreatePlan(member);
+        if (plan.PlanIsFeasible() == InventoryPlanFeasibility.Feasible)
+        {
+            plan.ExecuteWholePlan();
+        }
+
+        plan.FinalisePlanNoRestore();
+    }
+
+    protected static IEnumerable<IKey> AccessibleKeys(ICharacter member)
+    {
+        return member.Body.ExternalItems
+                     .SelectMany(x => x.ShallowAccessibleItems(member))
+                     .SelectNotNull(x => x.GetItemType<IKey>());
+    }
+
+    protected static bool KeyWorksForLock(ICharacter member, ILock theLock, IKey key)
+    {
+        return theLock.CanUnlock(member, key) || theLock.CanLock(member, key);
+    }
+
+    protected static bool HasKeyForLock(ICharacter member, ILock theLock)
+    {
+        return AccessibleKeys(member).Any(x => KeyWorksForLock(member, theLock, x));
+    }
+
+    protected static IEnumerable<ILock> DoorLocksForExits(IEnumerable<ICellExit> exits)
+    {
+        return exits
+               .SelectNotNull(x => x.Exit.Door)
+               .SelectMany(x => x.Locks)
+               .Distinct();
+    }
+
+    protected static IEnumerable<ICellExit> DoorExitsForCells(ICharacter member, IEnumerable<ICell> cells)
+    {
+        return cells
+               .SelectMany(x => x.ExitsFor(member, true))
+               .Where(x => x.Exit.Door?.Locks.Any() == true)
+               .DistinctBy(x => x.Exit);
+    }
+
+    protected static bool HasKeysForLocks(ICharacter member, IEnumerable<ILock> locks)
+    {
+        return locks.Distinct().All(x => HasKeyForLock(member, x));
+    }
+
+    protected static bool HasKeysForExits(ICharacter member, IEnumerable<ICellExit> exits)
+    {
+        return HasKeysForLocks(member, DoorLocksForExits(exits));
+    }
+
+    protected static bool HasKeysForCells(ICharacter member, IEnumerable<ICell> cells)
+    {
+        return HasKeysForExits(member, DoorExitsForCells(member, cells));
+    }
+
+    protected static bool PrepareKeysForLocks(ICharacter member, IEnumerable<ILock> locks)
+    {
+        List<ILock> requiredLocks = locks.Distinct().ToList();
+        foreach (ILock theLock in requiredLocks)
+        {
+            if (HasKeyForLock(member, theLock))
+            {
+                continue;
+            }
+
+            IInventoryPlanTemplate template = new InventoryPlanTemplate(member.Gameworld,
+                new InventoryPlanActionHold(member.Gameworld, 0, 0,
+                    item => item.GetItemType<IKey>() is IKey key && KeyWorksForLock(member, theLock, key),
+                    null,
+                    1)
+                {
+                    ItemsAlreadyInPlaceMultiplier = 10.0
+                });
+            PrepareInventoryPlan(member, template);
+        }
+
+        return HasKeysForLocks(member, requiredLocks);
+    }
+
+    protected static bool PrepareKeysForExits(ICharacter member, IEnumerable<ICellExit> exits)
+    {
+        return PrepareKeysForLocks(member, DoorLocksForExits(exits));
+    }
+
+    protected static bool PrepareKeysForCells(ICharacter member, IEnumerable<ICell> cells)
+    {
+        return PrepareKeysForExits(member, DoorExitsForCells(member, cells));
+    }
+
+    protected static void FormParty(IPatrol patrol)
+    {
+        if (patrol.PatrolLeader.Party != null)
+        {
+            patrol.PatrolLeader.LeaveParty();
+        }
+
+        Party party = new(patrol.PatrolLeader);
+        patrol.PatrolLeader.JoinParty(party);
+        foreach (ICharacter member in patrol.PatrolMembers.Where(x => x.ColocatedWith(patrol.PatrolLeader)).ToList())
+        {
+            if (member == patrol.PatrolLeader)
+            {
+                continue;
+            }
+
+            if (member.Party != null)
+            {
+                member.LeaveParty();
+            }
+
+            member.JoinParty(party);
+        }
+    }
+
     protected virtual void PatrolTickPreparationPhase(IPatrol patrol)
     {
         foreach (ICharacter member in patrol.PatrolMembers)
@@ -524,27 +652,7 @@ public abstract class PatrolStrategyBase : IPatrolStrategy
 
         if (DateTime.UtcNow - patrol.LastArrivedTime > TimeSpan.FromMinutes(1))
         {
-            if (patrol.PatrolLeader.Party != null)
-            {
-                patrol.PatrolLeader.LeaveParty();
-            }
-
-            Party party = new(patrol.PatrolLeader);
-            patrol.PatrolLeader.JoinParty(party);
-            foreach (ICharacter member in patrol.PatrolMembers.Where(x => x.ColocatedWith(patrol.PatrolLeader)).ToList())
-            {
-                if (member == patrol.PatrolLeader)
-                {
-                    continue;
-                }
-
-                if (member.Party != null)
-                {
-                    member.LeaveParty();
-                    member.JoinParty(party);
-                }
-            }
-
+            FormParty(patrol);
             patrol.PatrolPhase = PatrolPhase.Deployment;
             patrol.LastArrivedTime = DateTime.UtcNow;
             patrol.LastMajorNode = patrol.PatrolLeader.Location;

--- a/MudSharpCore/RPG/Law/PatrolStrategyFactory.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategyFactory.cs
@@ -15,6 +15,7 @@ public static class PatrolStrategyFactory
         "InvestigationPatrol",
         "CorpseRecovery",
         "StationEnforcer",
+        "DoorDuties",
         "Judge",
         "Sheriff",
         "Prosecutor",
@@ -46,6 +47,11 @@ public static class PatrolStrategyFactory
                 return new CorpseRecoveryPatrolStrategy(gameworld);
             case "stationenforcer":
                 return new StationEnforcerPatrolStrategy(gameworld);
+            case "doorduties":
+            case "door duties":
+            case "doorduty":
+            case "door duty":
+                return new DoorDutiesPatrolStrategy(gameworld);
             case "judge":
                 return new JudgePatrolStrategy(gameworld);
             case "sheriff":


### PR DESCRIPTION
## Summary
- Correct the legal patrol execution path so patrol strategies, door duties, and enforcer AI move through the expected state transitions.
- Tighten legal patrol and corpse recovery handling to align runtime behavior with the law system design.
- Update the law system runtime documentation to reflect the revised patrol flow.
- Add and adjust unit coverage for legal patrol strategy behavior.

## Testing
- Added/updated unit tests covering legal patrol strategy execution.
- Not run (not requested).