### PR TITLE
Add alert command and enforcer response

### DIFF
--- a/Design Documents/AI/Event_System_for_AI_and_Hooks.md
+++ b/Design Documents/AI/Event_System_for_AI_and_Hooks.md
@@ -427,10 +427,13 @@ These drive aggressive AI, combat-ending behavior, rescue behavior, and herd thr
 ### Crime and Law
 Current AI-relevant legal events include:
 
+- `CharacterAlertHeard`
 - `WitnessedCrime`
 - `VictimOfCrime`
 
 These are important for law-enforcement style behaviors and related content logic.
+
+`CharacterAlertHeard` is raised when a character actually hears the `ALERT` command after the alert's audible propagation and local hearing/listen checks. Its payload is `(alerter, witness, origin location, direction text, room range, emote text)`. The direction text is `"here"` for the origin room and a formatted relative direction such as "to the east" or "far away to the north" for nearby rooms. AIs should treat this as a heard signal, not as omniscient knowledge of the alerting character.
 
 ### Speech and Command Input
 Current speech/input events include:

--- a/Design Documents/AI/NPC_AI_and_Group_AI_Runtime.md
+++ b/Design Documents/AI/NPC_AI_and_Group_AI_Runtime.md
@@ -468,7 +468,7 @@ The table below covers every current concrete AI file in `MudSharpCore/NPC/AI`.
 | `DenBuilderAI` | Yes | Craft-backed den or nest builder that claims a home cell and can defend it | Uses persisted per-NPC home/anchor state |
 | `DoorguardAI` | Yes | Manages NPCs who respond to knocks, open/close doors, and enforce door access rules | Strongly tied to doors and command timing |
 | `TollkeeperAI` | Yes | Uses the existing guard-exit effect to block the NPC's active `toll <direction>` exit, demands a FutureProg-priced toll for the prospective movement group, and grants temporary passage after payment | The shared AI stores pricing, emotes and deposit behaviour; per-NPC toll position is stored on the persisted `TollkeeperMode` effect, paid-passage state is stored on `TollExitPermit`, and the block can either add guard exemptions for the movers or move aside for the permit window |
-| `EnforcerAI` | Yes | Legal-authority AI that identifies and reacts to wanted criminals | Heavy legal-system integration |
+| `EnforcerAI` | Yes | Legal-authority AI that identifies and reacts to wanted criminals | Heavy legal-system integration; can override its default `ALERT` emotes and responds to heard alerts while on patrol |
 | `FlyingWanderer` | Yes | Movement AI for flying creatures that wander through valid rooms/layers | Movement-focused specialization |
 | `IdleEmoterAI` | Yes | Periodic idle-emote generator | Lightweight ambience AI |
 | `JudgeAI` | Yes | Courtroom/legal progression AI built on top of `EnforcerAI` | Specialized judicial behavior |

--- a/Design Documents/Economy/Law_System_Runtime.md
+++ b/Design Documents/Economy/Law_System_Runtime.md
@@ -170,6 +170,21 @@ The report also checks the common legal-system stock failures:
 
 Trial coverage diagnostics flag missing Judge, Sheriff, or Prosecutor patrol routes when the authority has a conviction-capable enforcement authority. Execution coverage diagnostics flag missing execution patrol routes when at least one law can produce an execution sentence.
 
+## Alerts and Enforcer Response
+
+The `ALERT` command sends a loud non-language emote in the origin room and a direction-aware audible echo to nearby rooms. The distant echo must include `{0}`, which is replaced with relative direction and distance text such as "to the east" or "far away to the north". Alert delivery is gated by ordinary hearing checks, including local audio difficulty, listener hearing, deafness, and other hearing-profile effects. Characters receive `CharacterAlertHeard` only when they actually hear the alert.
+
+Alert emotes resolve in this order:
+
+- a character's stored custom alert emote
+- an NPC AI override from `IOverrideAlertEmote`
+- a race-level default alert emote
+- the global static setting default
+
+The same order applies independently to the distant alert echo. Race and AI defaults are nullable overrides; clearing them falls back to the next layer.
+
+On-duty NPC enforcers, meaning enforcers with an active `PatrolMemberEffect`, respond to heard alerts by pathing toward the alert origin when they are generally able to move, not already in combat, and not already pursuing an active enforcement target. If they arrive at a room where another enforcer from the same legal authority is already fighting, they attempt to engage that enforcer's current combat target. Enforcers also emit their own `ALERT` when they enter combat, allowing nearby on-duty enforcers who hear the alert to converge.
+
 ## Crime-Driven Patrol Dispatch
 
 Most patrol routes are scheduled from their route readiness, time-of-day, priority, and enforcer-number requirements. Crime-driven patrol strategies use the same route and enforcer configuration, but the patrol controller only dispatches them when a matching reported crime exists. These patrols are not launched as ordinary scheduled patrols.

--- a/FutureMUDLibrary/Character/Heritage/IRace.cs
+++ b/FutureMUDLibrary/Character/Heritage/IRace.cs
@@ -149,6 +149,9 @@ namespace MudSharp.Character.Heritage
 
         IBodyCommunicationStrategy CommunicationStrategy { get; }
 
+        string DefaultAlertEmote { get; }
+        string DefaultDistantAlertEmote { get; }
+
         Alignment DefaultHandedness { get; }
         IEnumerable<Alignment> HandednessOptions { get; }
 

--- a/FutureMUDLibrary/Character/ICharacter.cs
+++ b/FutureMUDLibrary/Character/ICharacter.cs
@@ -483,6 +483,8 @@ namespace MudSharp.Character
 
         void ConvertGrapplesToDrags();
         bool NoMercy { get; set; }
+        string? CustomAlertEmote { get; set; }
+        string? CustomDistantAlertEmote { get; set; }
         IEnumerable<INameCulture> NameCultures { get; }
         INameCulture NameCultureForGender(Gender gender);
         Difficulty IlluminationSightDifficulty();

--- a/FutureMUDLibrary/Events/EventTypeEnum.cs
+++ b/FutureMUDLibrary/Events/EventTypeEnum.cs
@@ -699,6 +699,9 @@ namespace MudSharp.Events
         OfferingBurned = 127,
 
         [EventInfo("Fires on perceivables witnessing an offering focus burning an offering.", ["item", "character", "item", "perceivable"], ["focus", "actor", "offering", "witness"], [ProgVariableTypeCode.Item, ProgVariableTypeCode.Character, ProgVariableTypeCode.Item, ProgVariableTypeCode.Perceivable])]
-        OfferingBurnedWitness = 128
+        OfferingBurnedWitness = 128,
+
+        [EventInfo("Fires on a character when they hear an alert.", ["character", "perceivable", "location", "text", "number", "text"], ["alerter", "witness", "origin", "direction", "range", "emote"], [ProgVariableTypeCode.Character, ProgVariableTypeCode.Perceivable, ProgVariableTypeCode.Location, ProgVariableTypeCode.Text, ProgVariableTypeCode.Number, ProgVariableTypeCode.Text])]
+        CharacterAlertHeard = 129
     }
 }

--- a/FutureMUDLibrary/Framework/DefaultStaticSettings.cs
+++ b/FutureMUDLibrary/Framework/DefaultStaticSettings.cs
@@ -1166,6 +1166,8 @@ Your password will be used to access your account, and will be stored securely o
         {"GunshotHeardEcho", "A gun shot can be heard {0}."},
         {"ExplosionHeardEcho", "An explosion can be heard {0}."},
         {"LaserHeardEcho", "A laser blast can be heard {0}."},
+        {"DefaultAlertEmote", "@ whistle|whistles a sharp, loud alert."},
+        {"DefaultDistantAlertEmote", "A sharp, loud alert can be heard {0}."},
     };
 
     private static string GetDefaultScarGenerationChanceMatrix()

--- a/FutureMUDLibrary/NPC/AI/IOverrideAlertEmote.cs
+++ b/FutureMUDLibrary/NPC/AI/IOverrideAlertEmote.cs
@@ -1,0 +1,9 @@
+#nullable enable
+
+namespace MudSharp.NPC.AI;
+
+public interface IOverrideAlertEmote
+{
+	string? AlertEmote { get; }
+	string? DistantAlertEmote { get; }
+}

--- a/MudSharpCore Unit Tests/AlertCommandSourceIntegrationTests.cs
+++ b/MudSharpCore Unit Tests/AlertCommandSourceIntegrationTests.cs
@@ -1,0 +1,102 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Communication;
+using MudSharp.Events;
+using MudSharp.Framework;
+using System;
+using System.IO;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class AlertCommandSourceIntegrationTests
+{
+	[TestMethod]
+	public void StaticDefaults_IncludeAlertEmotes()
+	{
+		Assert.IsTrue(DefaultStaticSettings.DefaultStaticStrings.ContainsKey("DefaultAlertEmote"));
+		Assert.IsTrue(DefaultStaticSettings.DefaultStaticStrings.ContainsKey("DefaultDistantAlertEmote"));
+		Assert.AreEqual("@ whistle|whistles a sharp, loud alert.",
+			DefaultStaticSettings.DefaultStaticStrings["DefaultAlertEmote"]);
+		Assert.AreEqual("A sharp, loud alert can be heard {0}.",
+			DefaultStaticSettings.DefaultStaticStrings["DefaultDistantAlertEmote"]);
+	}
+
+	[TestMethod]
+	public void EventType_CharacterAlertHeard_IsAppendOnlyRegistered()
+	{
+		Assert.AreEqual(129, (int)EventType.CharacterAlertHeard);
+	}
+
+	[TestMethod]
+	public void CommunicationModule_ExposesAlertCommandAndCustomisation()
+	{
+		var source = File.ReadAllText(GetSourcePath("MudSharpCore", "Commands", "Modules",
+			"CommunicationsModule.cs"));
+
+		StringAssert.Contains(source, "[PlayerCommand(\"Alert\", \"alert\")]");
+		StringAssert.Contains(source, "AlertUtilities.DoAlert(actor);");
+		StringAssert.Contains(source, "AlertUtilities.DoAlert(actor, emoteText);");
+		StringAssert.Contains(source, "actor.CustomAlertEmote = emoteText;");
+		StringAssert.Contains(source, "actor.CustomDistantAlertEmote = emoteText;");
+		StringAssert.Contains(source, "AlertUtilities.ValidateStoredAlertEmote(emoteText, actor, out var error)");
+		StringAssert.Contains(source, "AlertUtilities.ValidateStoredDistantAlertEmote(emoteText, actor, out var error)");
+	}
+
+	[TestMethod]
+	public void AlertUtilities_UsesHearingChecksAndFiresHeardEvent()
+	{
+		var source = File.ReadAllText(GetSourcePath("MudSharpCore", "Communication", "AlertUtilities.cs"));
+
+		StringAssert.Contains(source, "public const uint AlertRoomRange = 2;");
+		StringAssert.Contains(source, "public const AudioVolume AlertVolume = AudioVolume.ExtremelyLoud;");
+		StringAssert.Contains(source, "public const int MaximumStoredAlertEmoteLength = 500;");
+		StringAssert.Contains(source, "actor.Body.Communications.CanVocalise(actor.Body, AlertVolume)");
+		StringAssert.Contains(source, "witness.CanHear(actor)");
+		StringAssert.Contains(source, "witness.Location.LocalAudioDifficulty(witness, volume, proximity)");
+		StringAssert.Contains(source, "CheckType.GenericListenCheck");
+		StringAssert.Contains(source, "witness.HandleEvent(EventType.CharacterAlertHeard");
+		StringAssert.Contains(source, "actor.Location.CellsInVicinity(AlertRoomRange");
+		StringAssert.Contains(source, "npc.AIs.OfType<IOverrideAlertEmote>()");
+	}
+
+	[TestMethod]
+	public void StoredAlertValidators_RejectValuesTooLongForPersistenceColumns()
+	{
+		var perceiver = new DummyPerceiver();
+		var longLocal = $"@ whistle|whistles {new string('a', AlertUtilities.MaximumStoredAlertEmoteLength)}";
+		var longDistant = $"A sharp, loud alert can be heard {{0}} {new string('a', AlertUtilities.MaximumStoredAlertEmoteLength)}";
+
+		Assert.IsFalse(AlertUtilities.ValidateStoredAlertEmote(longLocal, perceiver, out var localError));
+		StringAssert.Contains(localError, AlertUtilities.MaximumStoredAlertEmoteLength.ToString("N0"));
+		Assert.IsFalse(AlertUtilities.ValidateStoredDistantAlertEmote(longDistant, perceiver, out var distantError));
+		StringAssert.Contains(distantError, AlertUtilities.MaximumStoredAlertEmoteLength.ToString("N0"));
+	}
+
+	[TestMethod]
+	public void EnforcerAI_RespondsToAlertAndCombatEvents()
+	{
+		var source = File.ReadAllText(GetSourcePath("MudSharpCore", "NPC", "AI", "EnforcerAI.cs"));
+
+		StringAssert.Contains(source, "EnforcerAI : ArtificialIntelligenceBase, IOverrideAlertEmote");
+		StringAssert.Contains(source, "case EventType.CharacterAlertHeard:");
+		StringAssert.Contains(source, "case EventType.EngageInCombat:");
+		StringAssert.Contains(source, "case EventType.EngagedInCombat:");
+		StringAssert.Contains(source, "AlertUtilities.DoAlert(enforcer, echoFailure: false);");
+		StringAssert.Contains(source, "patrolMember is null || patrolMember.Patrol.ActiveEnforcementTarget is not null");
+		StringAssert.Contains(source, "enforcer.PathBetween(origin, 20, PathSearch.PathIncludeUnlockableDoors(enforcer))");
+		StringAssert.Contains(source, "AssistNearbyEnforcerInCombat(enforcer, effect)");
+	}
+
+	private static string GetSourcePath(params string[] parts)
+	{
+		return Path.GetFullPath(Path.Combine(
+			AppContext.BaseDirectory,
+			"..",
+			"..",
+			"..",
+			"..",
+			Path.Combine(parts)));
+	}
+}

--- a/MudSharpCore/Character/Character.cs
+++ b/MudSharpCore/Character/Character.cs
@@ -604,6 +604,8 @@ public partial class Character : PerceiverItem, ICharacter, ICharacterIdentity, 
         dbchar.RoomBrief = BriefRoomDescs;
         dbchar.CombatBrief = BriefCombatMode;
         dbchar.NoMercy = NoMercy;
+        dbchar.CustomAlertEmote = CustomAlertEmote;
+        dbchar.CustomDistantAlertEmote = CustomDistantAlertEmote;
 
         if (NamesChanged)
         {
@@ -1442,7 +1444,9 @@ public partial class Character : PerceiverItem, ICharacter, ICharacterIdentity, 
             PositionModifier = (int)PositionModifier.None,
             PositionEmote = string.Empty,
             EffectData = SaveEffects().ToString(),
-            CurrentCombatSettingId = CombatSettings?.Id
+            CurrentCombatSettingId = CombatSettings?.Id,
+            CustomAlertEmote = CustomAlertEmote,
+            CustomDistantAlertEmote = CustomDistantAlertEmote
         };
 
         InsertInitialForms(dbitem);
@@ -1607,6 +1611,8 @@ public partial class Character : PerceiverItem, ICharacter, ICharacterIdentity, 
         _state |= CharacterState.Stasis;
         _status = (CharacterStatus)character.Status;
         _noMercy = character.NoMercy;
+        _customAlertEmote = character.CustomAlertEmote;
+        _customDistantAlertEmote = character.CustomDistantAlertEmote;
         BriefRoomDescs = character.RoomBrief;
         BriefCombatMode = character.CombatBrief;
         LoadNames(character);
@@ -1848,6 +1854,26 @@ public partial class Character : PerceiverItem, ICharacter, ICharacterIdentity, 
         set
         {
             _noMercy = value;
+            Changed = true;
+        }
+    }
+
+    public string? CustomAlertEmote
+    {
+        get => _customAlertEmote;
+        set
+        {
+            _customAlertEmote = value;
+            Changed = true;
+        }
+    }
+
+    public string? CustomDistantAlertEmote
+    {
+        get => _customDistantAlertEmote;
+        set
+        {
+            _customDistantAlertEmote = value;
             Changed = true;
         }
     }
@@ -3793,6 +3819,8 @@ public partial class Character : PerceiverItem, ICharacter, ICharacterIdentity, 
 
     private bool _outfitsChanged;
     private bool _noMercy;
+    private string? _customAlertEmote;
+    private string? _customDistantAlertEmote;
 
     public bool OutfitsChanged
     {

--- a/MudSharpCore/Character/CharacterEvents.cs
+++ b/MudSharpCore/Character/CharacterEvents.cs
@@ -47,6 +47,7 @@ public partial class Character
             case EventType.CharacterGotItemContainerWitness:
             case EventType.CharacterGotItemWitness:
             case EventType.CharacterHidesWitness:
+            case EventType.CharacterAlertHeard:
             case EventType.CharacterIncapacitatedWitness:
             case EventType.CharacterLeaveCellWitness:
             case EventType.CharacterMountedWitness:

--- a/MudSharpCore/Character/Heritage/Race.cs
+++ b/MudSharpCore/Character/Heritage/Race.cs
@@ -154,6 +154,8 @@ public partial class Race : SaveableItem, IRace
             RaceUsesStamina = ParentRace.RaceUsesStamina;
             _optInMaterialEdibility = ParentRace.OptInMaterialEdibility;
             EatCorpseEmoteText = ParentRace.EatCorpseEmoteText;
+            DefaultAlertEmote = ParentRace.DefaultAlertEmote;
+            DefaultDistantAlertEmote = ParentRace.DefaultDistantAlertEmote;
             CanEatCorpses = ParentRace.CanEatCorpses;
             BiteWeight = ParentRace.BiteWeight;
             TemperatureRangeCeiling = ParentRace.TemperatureRangeCeiling;
@@ -253,6 +255,8 @@ public partial class Race : SaveableItem, IRace
             RaceUsesStamina = true;
             _optInMaterialEdibility = false;
             EatCorpseEmoteText = "@ eat|eats {0}$1";
+            DefaultAlertEmote = null;
+            DefaultDistantAlertEmote = null;
             CanEatCorpses = false;
             BiteWeight = 1000;
             TemperatureRangeCeiling = 40;
@@ -322,6 +326,8 @@ public partial class Race : SaveableItem, IRace
                 CanEatCorpses = CanEatCorpses,
                 BiteWeight = BiteWeight,
                 EatCorpseEmoteText = EatCorpseEmoteText,
+                DefaultAlertEmote = DefaultAlertEmote,
+                DefaultDistantAlertEmote = DefaultDistantAlertEmote,
                 CanEatMaterialsOptIn = OptInMaterialEdibility,
                 TemperatureRangeFloor = TemperatureRangeFloor,
                 TemperatureRangeCeiling = TemperatureRangeCeiling,
@@ -575,6 +581,8 @@ public partial class Race : SaveableItem, IRace
         }
 
         EatCorpseEmoteText = race.EatCorpseEmoteText;
+        DefaultAlertEmote = race.DefaultAlertEmote;
+        DefaultDistantAlertEmote = race.DefaultDistantAlertEmote;
         CanEatCorpses = race.CanEatCorpses;
         BiteWeight = race.BiteWeight;
         TemperatureRangeCeiling = race.TemperatureRangeCeiling;
@@ -673,6 +681,8 @@ public partial class Race : SaveableItem, IRace
         RaceUsesStamina = rhs.RaceUsesStamina;
         _optInMaterialEdibility = rhs.OptInMaterialEdibility;
         EatCorpseEmoteText = rhs.EatCorpseEmoteText;
+        DefaultAlertEmote = rhs.DefaultAlertEmote;
+        DefaultDistantAlertEmote = rhs.DefaultDistantAlertEmote;
         CanEatCorpses = rhs.CanEatCorpses;
         BiteWeight = rhs.BiteWeight;
         TemperatureRangeCeiling = rhs.TemperatureRangeCeiling;
@@ -789,6 +799,8 @@ public partial class Race : SaveableItem, IRace
                 CanEatCorpses = CanEatCorpses,
                 BiteWeight = BiteWeight,
                 EatCorpseEmoteText = EatCorpseEmoteText,
+                DefaultAlertEmote = DefaultAlertEmote,
+                DefaultDistantAlertEmote = DefaultDistantAlertEmote,
                 CanEatMaterialsOptIn = OptInMaterialEdibility,
                 TemperatureRangeFloor = TemperatureRangeFloor,
                 TemperatureRangeCeiling = TemperatureRangeCeiling,
@@ -1220,6 +1232,8 @@ public partial class Race : SaveableItem, IRace
         dbitem.CanEatCorpses = CanEatCorpses;
         dbitem.BiteWeight = BiteWeight;
         dbitem.EatCorpseEmoteText = EatCorpseEmoteText;
+        dbitem.DefaultAlertEmote = DefaultAlertEmote;
+        dbitem.DefaultDistantAlertEmote = DefaultDistantAlertEmote;
         dbitem.CanEatMaterialsOptIn = OptInMaterialEdibility;
         dbitem.TemperatureRangeFloor = TemperatureRangeFloor;
         dbitem.TemperatureRangeCeiling = TemperatureRangeCeiling;
@@ -1896,6 +1910,8 @@ public partial class Race : SaveableItem, IRace
     }
 
     public IBodyCommunicationStrategy CommunicationStrategy { get; set; }
+    public string DefaultAlertEmote { get; set; }
+    public string DefaultDistantAlertEmote { get; set; }
 
     public IRaceButcheryProfile ButcheryProfile { get; set; }
 

--- a/MudSharpCore/Character/Heritage/RaceBuilding.cs
+++ b/MudSharpCore/Character/Heritage/RaceBuilding.cs
@@ -4,6 +4,7 @@ using MudSharp.Body.Traits;
 using MudSharp.Body.Traits.Subtypes;
 using MudSharp.CharacterCreation.Resources;
 using MudSharp.Combat;
+using MudSharp.Communication;
 using MudSharp.Effects.Concrete;
 using MudSharp.Form.Material;
 using MudSharp.Form.Shape;
@@ -96,6 +97,8 @@ public partial class Race
 	#3blood none#0 - disables bleeding for this race
 	#3bloodmodel <model>#0 - sets the blood antigen typing model for this race
 	#3bloodmodel none#0 - clears a blood antigen typing model from this race
+	#3alertemote <emote|clear>#0 - sets or clears the default ALERT emote for this race
+	#3alertfar <emote|clear>#0 - sets or clears the default distant ALERT echo; use {0} for the direction
 	#3tempfloor <temperature>#0 - sets the base minimum tolerable temperature for this race
 	#3tempceiling <temperature>#0 - sets the base maximum tolerable temperature for this race
 	#3trackvisual <%>#0 - sets the intensity modifier of visual tracks left behind
@@ -214,6 +217,15 @@ public partial class Race
                 return BuildingCommandBlood(actor, command);
             case "bloodmodel":
                 return BuildingCommandBloodModel(actor, command);
+            case "alert":
+            case "alertemote":
+            case "alertlocal":
+                return BuildingCommandAlertEmote(actor, command);
+            case "alertfar":
+            case "alertdistant":
+            case "distantalert":
+            case "distantalertemote":
+                return BuildingCommandDistantAlertEmote(actor, command);
             case "temperaturefloor":
             case "tempfloor":
                 return BuildingCommandTemperatureFloor(actor, command);
@@ -1026,6 +1038,64 @@ public partial class Race
         EatCorpseEmoteText = emoteText;
         Changed = true;
         actor.OutputHandler.Send($"The emote when this race eats corpses is now {EatCorpseEmoteText.ColourCommand()}");
+        return true;
+    }
+
+    private bool BuildingCommandAlertEmote(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("What should be the default ALERT emote for this race, or #3clear#0 to clear it?".SubstituteANSIColour());
+            return false;
+        }
+
+        if (command.SafeRemainingArgument.EqualToAny("clear", "none", "delete", "remove"))
+        {
+            DefaultAlertEmote = null;
+            Changed = true;
+            actor.OutputHandler.Send("This race will now use the global default ALERT emote.");
+            return true;
+        }
+
+        var emoteText = command.SafeRemainingArgument;
+        if (!AlertUtilities.ValidateStoredAlertEmote(emoteText, actor, out var error))
+        {
+            actor.OutputHandler.Send(error);
+            return false;
+        }
+
+        DefaultAlertEmote = emoteText;
+        Changed = true;
+        actor.OutputHandler.Send($"The default ALERT emote for this race is now {DefaultAlertEmote.ColourCommand()}.");
+        return true;
+    }
+
+    private bool BuildingCommandDistantAlertEmote(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("What should be the default distant ALERT echo for this race, or #3clear#0 to clear it? Use #6{0}#0 for the direction text.".SubstituteANSIColour());
+            return false;
+        }
+
+        if (command.SafeRemainingArgument.EqualToAny("clear", "none", "delete", "remove"))
+        {
+            DefaultDistantAlertEmote = null;
+            Changed = true;
+            actor.OutputHandler.Send("This race will now use the global default distant ALERT echo.");
+            return true;
+        }
+
+        var emoteText = command.SafeRemainingArgument;
+        if (!AlertUtilities.ValidateStoredDistantAlertEmote(emoteText, actor, out var error))
+        {
+            actor.OutputHandler.Send(error);
+            return false;
+        }
+
+        DefaultDistantAlertEmote = emoteText;
+        Changed = true;
+        actor.OutputHandler.Send($"The default distant ALERT echo for this race is now {DefaultDistantAlertEmote.ColourCommand()}.");
         return true;
     }
 
@@ -2685,6 +2755,10 @@ public partial class Race
             $"Communication: {CommunicationStrategy.Name.ColourValue()}",
             $"Genders: {AllowedGenders.Select(x => Gendering.Get(x).GenderClass(true).Colour(Telnet.Cyan)).ListToString()}",
             $"Butchery: {ButcheryProfile?.Name.Colour(Telnet.Green) ?? "None".Colour(Telnet.Red)}"
+        );
+        sb.AppendLineColumns((uint)actor.LineFormatLength, 2,
+            $"Alert Emote: {DefaultAlertEmote?.ColourCommand() ?? "None".ColourError()}",
+            $"Distant Alert: {DefaultDistantAlertEmote?.ColourCommand() ?? "None".ColourError()}"
         );
         sb.AppendLineColumns((uint)actor.LineFormatLength, 3,
             $"Breathing: {BreathingStrategy.Name.ColourValue()}",

--- a/MudSharpCore/Commands/Modules/CommunicationsModule.cs
+++ b/MudSharpCore/Commands/Modules/CommunicationsModule.cs
@@ -1,6 +1,7 @@
 ﻿using MudSharp.Accounts;
 using MudSharp.Character;
 using MudSharp.Character.Name;
+using MudSharp.Communication;
 using MudSharp.Communication.Language;
 using MudSharp.Community.Boards;
 using MudSharp.Database;
@@ -986,6 +987,135 @@ The syntax is:
         }
 
         actor.Body.Shout(target, message, emote);
+    }
+
+    [PlayerCommand("Alert", "alert")]
+    [HelpInfo("alert",
+        @"The #3alert#0 command sends a loud non-language alert, like a shout, whistle, howl or other urgent vocalisation, to nearby rooms. NPC AIs can react to hearing alerts.
+
+The syntax is:
+
+	#3alert#0 - uses your stored alert emote or the race/global default
+	#3alert <emote>#0 - sends a one-time alert emote
+	#3alert show#0 - shows your current alert settings
+	#3alert set <emote>#0 - stores your default in-room alert emote
+	#3alert setdistant <emote>#0 - stores your nearby-room alert echo; use #6{0}#0 for the direction
+	#3alert clear#0 - clears your in-room alert emote
+	#3alert cleardistant#0 - clears your nearby-room alert echo
+	#3alert clearall#0 - clears both stored alert emotes
+
+Your in-room emote uses normal emote syntax. If you omit the #6@#0 token, your short description is automatically inserted at the start.", AutoHelp.HelpArgOrNoArg)]
+    [DisplayOptions(CommandDisplayOptions.DisplayCommandWords)]
+    [RequiredCharacterState(CharacterState.Conscious)]
+    protected static void Alert(ICharacter actor, string input)
+    {
+        var ss = new StringStack(input.RemoveFirstWord());
+        if (ss.IsFinished)
+        {
+            AlertUtilities.DoAlert(actor);
+            return;
+        }
+
+        switch (ss.PeekSpeech().ToLowerInvariant())
+        {
+            case "show":
+                ss.PopSpeech();
+                AlertShow(actor);
+                return;
+            case "set":
+            case "setlocal":
+            case "setemote":
+                ss.PopSpeech();
+                AlertSet(actor, ss);
+                return;
+            case "setdistant":
+            case "setfar":
+            case "setremote":
+                ss.PopSpeech();
+                AlertSetDistant(actor, ss);
+                return;
+            case "clear":
+            case "clearlocal":
+                ss.PopSpeech();
+                actor.CustomAlertEmote = null;
+                actor.OutputHandler.Send("You clear your custom ALERT emote. You will now use your AI, race or global default.");
+                return;
+            case "cleardistant":
+            case "clearfar":
+            case "clearremote":
+                ss.PopSpeech();
+                actor.CustomDistantAlertEmote = null;
+                actor.OutputHandler.Send("You clear your custom distant ALERT echo. You will now use your AI, race or global default.");
+                return;
+            case "clearall":
+                ss.PopSpeech();
+                actor.CustomAlertEmote = null;
+                actor.CustomDistantAlertEmote = null;
+                actor.OutputHandler.Send("You clear both of your custom ALERT emotes. You will now use your AI, race or global defaults.");
+                return;
+        }
+
+        var emoteText = ss.SafeRemainingArgument;
+        if (!AlertUtilities.ValidateStoredAlertEmote(emoteText, actor, out var error))
+        {
+            actor.OutputHandler.Send(error);
+            return;
+        }
+
+        AlertUtilities.DoAlert(actor, emoteText);
+    }
+
+    private static void AlertShow(ICharacter actor)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("ALERT Emotes".GetLineWithTitle(actor, Telnet.Cyan, Telnet.BoldWhite));
+        sb.AppendLine();
+        sb.AppendLine($"Custom Local: {actor.CustomAlertEmote?.ColourCommand() ?? "None".ColourError()}");
+        sb.AppendLine($"Custom Distant: {actor.CustomDistantAlertEmote?.ColourCommand() ?? "None".ColourError()}");
+        sb.AppendLine($"Race Local: {actor.Race.DefaultAlertEmote?.ColourCommand() ?? "None".ColourError()}");
+        sb.AppendLine($"Race Distant: {actor.Race.DefaultDistantAlertEmote?.ColourCommand() ?? "None".ColourError()}");
+        sb.AppendLine();
+        sb.AppendLine($"Effective Local: {AlertUtilities.ResolveAlertEmote(actor).ColourCommand()}");
+        sb.AppendLine($"Effective Distant: {AlertUtilities.ResolveDistantAlertEmote(actor).ColourCommand()}");
+        actor.OutputHandler.Send(sb.ToString());
+    }
+
+    private static void AlertSet(ICharacter actor, StringStack ss)
+    {
+        if (ss.IsFinished)
+        {
+            actor.OutputHandler.Send("What emote do you want to use for your default ALERT?");
+            return;
+        }
+
+        var emoteText = ss.SafeRemainingArgument;
+        if (!AlertUtilities.ValidateAlertEmote(emoteText, actor, out var error))
+        {
+            actor.OutputHandler.Send(error);
+            return;
+        }
+
+        actor.CustomAlertEmote = emoteText;
+        actor.OutputHandler.Send($"Your default ALERT emote is now {actor.CustomAlertEmote.ColourCommand()}.");
+    }
+
+    private static void AlertSetDistant(ICharacter actor, StringStack ss)
+    {
+        if (ss.IsFinished)
+        {
+            actor.OutputHandler.Send("What distant echo do you want people in nearby rooms to receive? Use #6{0}#0 for the direction text.".SubstituteANSIColour());
+            return;
+        }
+
+        var emoteText = ss.SafeRemainingArgument;
+        if (!AlertUtilities.ValidateStoredDistantAlertEmote(emoteText, actor, out var error))
+        {
+            actor.OutputHandler.Send(error);
+            return;
+        }
+
+        actor.CustomDistantAlertEmote = emoteText;
+        actor.OutputHandler.Send($"Your distant ALERT echo is now {actor.CustomDistantAlertEmote.ColourCommand()}.");
     }
 
     [PlayerCommand("LoudSay", "loudsay", "loudtell")]

--- a/MudSharpCore/Communication/AlertUtilities.cs
+++ b/MudSharpCore/Communication/AlertUtilities.cs
@@ -1,0 +1,318 @@
+#nullable enable
+
+using MudSharp.Body.CommunicationStrategies;
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Construction.Boundary;
+using MudSharp.Events;
+using MudSharp.Form.Audio;
+using MudSharp.Framework;
+using MudSharp.NPC;
+using MudSharp.NPC.AI;
+using MudSharp.PerceptionEngine;
+using MudSharp.PerceptionEngine.Outputs;
+using MudSharp.PerceptionEngine.Parsers;
+using MudSharp.RPG.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MudSharp.Communication;
+
+public static class AlertUtilities
+{
+	public const uint AlertRoomRange = 2;
+	public const AudioVolume AlertVolume = AudioVolume.ExtremelyLoud;
+	public const int MaximumStoredAlertEmoteLength = 500;
+	private const string SampleDirectionText = "immediately to the north";
+
+	public static bool ValidateAlertEmote(string emoteText, IPerceiver source, out string error)
+	{
+		var emote = new PlayerEmote(emoteText, source, true, PermitLanguageOptions.IgnoreLanguage);
+		if (emote.Valid)
+		{
+			error = string.Empty;
+			return true;
+		}
+
+		error = emote.ErrorMessage;
+		return false;
+	}
+
+	public static bool ValidateDistantAlertEmote(string emoteText, IPerceiver source, out string error)
+	{
+		if (!emoteText.Contains("{0}", StringComparison.InvariantCulture))
+		{
+			error = "The distant alert emote must include {0} where the direction and distance text should appear.";
+			return false;
+		}
+
+		if (!TryFormatDistantAlertEmote(emoteText, SampleDirectionText, out var formattedText, out error))
+		{
+			return false;
+		}
+
+		var emote = new Emote(formattedText, source, PermitLanguageOptions.IgnoreLanguage, source);
+		if (emote.Valid)
+		{
+			error = string.Empty;
+			return true;
+		}
+
+		error = emote.ErrorMessage;
+		return false;
+	}
+
+	public static bool ValidateStoredAlertEmote(string emoteText, IPerceiver source, out string error)
+	{
+		if (!ValidateStoredAlertLength(emoteText, out error))
+		{
+			return false;
+		}
+
+		return ValidateAlertEmote(emoteText, source, out error);
+	}
+
+	public static bool ValidateStoredDistantAlertEmote(string emoteText, IPerceiver source, out string error)
+	{
+		if (!ValidateStoredAlertLength(emoteText, out error))
+		{
+			return false;
+		}
+
+		return ValidateDistantAlertEmote(emoteText, source, out error);
+	}
+
+	public static bool DoAlert(ICharacter actor, string? alertEmote = null, string? distantAlertEmote = null, bool echoFailure = true)
+	{
+		if (!actor.Body.Communications.CanVocalise(actor.Body, AlertVolume))
+		{
+			if (echoFailure)
+			{
+				actor.OutputHandler.Send(actor.Body.Communications.WhyCannotVocalise(actor.Body, AlertVolume));
+			}
+
+			return false;
+		}
+
+		var localText = alertEmote.IfNullOrWhiteSpace(ResolveAlertEmote(actor));
+		var distantText = distantAlertEmote.IfNullOrWhiteSpace(ResolveDistantAlertEmote(actor));
+		var localEmote = BuildLocalEmote(actor, localText);
+		if (!localEmote.Valid)
+		{
+			if (echoFailure)
+			{
+				actor.OutputHandler.Send(localEmote.ErrorMessage);
+			}
+
+			return false;
+		}
+
+		if (!ValidateDistantAlertEmote(distantText, actor, out var distantError))
+		{
+			if (echoFailure)
+			{
+				actor.OutputHandler.Send(distantError);
+			}
+
+			return false;
+		}
+
+		actor.OutputHandler.Handle(new EmoteOutput(localEmote));
+		FireAlertEventForSameLayer(actor, localText);
+		SendAlertToOtherLayers(actor, distantText);
+		SendAlertToNearbyRooms(actor, distantText);
+		return true;
+	}
+
+	public static string ResolveAlertEmote(ICharacter actor)
+	{
+		return actor.CustomAlertEmote.IfNullOrWhiteSpace(
+			ResolveNpcAlertOverride(actor).IfNullOrWhiteSpace(
+				actor.Race.DefaultAlertEmote.IfNullOrWhiteSpace(actor.Gameworld.GetStaticString("DefaultAlertEmote"))
+			)
+		);
+	}
+
+	public static string ResolveDistantAlertEmote(ICharacter actor)
+	{
+		return actor.CustomDistantAlertEmote.IfNullOrWhiteSpace(
+			ResolveNpcDistantAlertOverride(actor).IfNullOrWhiteSpace(
+				actor.Race.DefaultDistantAlertEmote.IfNullOrWhiteSpace(actor.Gameworld.GetStaticString("DefaultDistantAlertEmote"))
+			)
+		);
+	}
+
+	private static string? ResolveNpcAlertOverride(ICharacter actor)
+	{
+		return actor is INPC npc
+			? npc.AIs.OfType<IOverrideAlertEmote>()
+			     .Select(x => x.AlertEmote)
+			     .FirstOrDefault(x => !string.IsNullOrWhiteSpace(x))
+			: null;
+	}
+
+	private static string? ResolveNpcDistantAlertOverride(ICharacter actor)
+	{
+		return actor is INPC npc
+			? npc.AIs.OfType<IOverrideAlertEmote>()
+			     .Select(x => x.DistantAlertEmote)
+			     .FirstOrDefault(x => !string.IsNullOrWhiteSpace(x))
+			: null;
+	}
+
+	private static PlayerEmote BuildLocalEmote(ICharacter actor, string emoteText)
+	{
+		if (actor.Body.Communications is HumanoidCommunicationStrategy humanoid && humanoid.IsGagged(actor.Body))
+		{
+			return new PlayerEmote("@ make|makes a muffled alert into &0's gag.", actor, true,
+				PermitLanguageOptions.IgnoreLanguage);
+		}
+
+		return new PlayerEmote(emoteText, actor, true, PermitLanguageOptions.IgnoreLanguage);
+	}
+
+	private static string BuildDistantText(ICharacter actor, string emoteText, string directionText)
+	{
+		if (actor.Body.Communications is HumanoidCommunicationStrategy humanoid && humanoid.IsGagged(actor.Body))
+		{
+			return $"A muffled alert can be heard {directionText}.";
+		}
+
+		return TryFormatDistantAlertEmote(emoteText, directionText, out var text, out _)
+			? text
+			: actor.Gameworld.GetStaticString("DefaultDistantAlertEmote");
+	}
+
+	private static void FireAlertEventForSameLayer(ICharacter actor, string localText)
+	{
+		foreach (var witness in actor.Location.LayerCharacters(actor.RoomLayer).Except(actor).ToList())
+		{
+			if (!CanHearAlert(actor, witness, AlertVolume, witness.GetProximity(actor)))
+			{
+				continue;
+			}
+
+			witness.HandleEvent(EventType.CharacterAlertHeard, actor, witness, actor.Location, "here", 0.0, localText);
+		}
+	}
+
+	private static void SendAlertToOtherLayers(ICharacter actor, string distantText)
+	{
+		foreach (var layer in actor.Location.Terrain(null).TerrainLayers.Except(actor.RoomLayer))
+		{
+			var layerText = layer.IsHigherThan(actor.RoomLayer) ? "from below" : "from above";
+			foreach (var witness in actor.Location.LayerCharacters(layer).ToList())
+			{
+				var volume = AudioVolume.Decent;
+				if (!CanHearAlert(actor, witness, volume, Proximity.Distant))
+				{
+					continue;
+				}
+
+				witness.OutputHandler.Send(new EmoteOutput(
+					new Emote(BuildDistantText(actor, distantText, layerText), actor, PermitLanguageOptions.IgnoreLanguage, actor),
+					flags: OutputFlags.PurelyAudible));
+				witness.HandleEvent(EventType.CharacterAlertHeard, actor, witness, actor.Location, layerText, 1.0,
+					distantText);
+			}
+		}
+	}
+
+	private static void SendAlertToNearbyRooms(ICharacter actor, string distantText)
+	{
+		var allCells = actor.Location.CellsInVicinity(AlertRoomRange, exit => true, cell => true).ToList();
+		var surrounds = actor.Location.Surrounds.ToList();
+		foreach (var cell in allCells)
+		{
+			if (cell == actor.Location)
+			{
+				continue;
+			}
+
+			foreach (var witness in cell.Characters.ToList())
+			{
+				var path = DirectionPathFrom(cell, actor);
+				var distance = path.Count;
+				var directionText = DirectionText(actor, cell, witness, path, surrounds.Contains(cell));
+				var volume = distance <= 1 ? AudioVolume.Decent : AudioVolume.Faint;
+				if (!CanHearAlert(actor, witness, volume, Proximity.VeryDistant))
+				{
+					continue;
+				}
+
+				witness.OutputHandler.Send(new EmoteOutput(
+					new Emote(BuildDistantText(actor, distantText, directionText), actor,
+						PermitLanguageOptions.IgnoreLanguage, actor),
+					flags: OutputFlags.PurelyAudible));
+				witness.HandleEvent(EventType.CharacterAlertHeard, actor, witness, actor.Location, directionText,
+					(double)Math.Max(1, distance), distantText);
+			}
+		}
+	}
+
+	private static List<ICellExit> DirectionPathFrom(ICell cell, ICharacter actor)
+	{
+		return cell.PathBetween(actor, AlertRoomRange, PathSearch.IgnorePresenceOfDoors).ToList();
+	}
+
+	private static string DirectionText(ICharacter actor, ICell cell, ICharacter witness, List<ICellExit> path,
+		bool neighbouringCell)
+	{
+		if (neighbouringCell)
+		{
+			return actor.Location.GetExitTo(cell, witness)?.InboundDirectionSuffix ?? "from somewhere unknown";
+		}
+
+		return path.Any()
+			? path.DescribeDirectionsToFrom()
+			: "from somewhere unknown";
+	}
+
+	private static bool CanHearAlert(ICharacter actor, ICharacter witness, AudioVolume volume, Proximity proximity)
+	{
+		if (witness.IsSelf(actor))
+		{
+			return true;
+		}
+
+		if (!witness.CanHear(actor))
+		{
+			return false;
+		}
+
+		var difficulty = witness.Location.LocalAudioDifficulty(witness, volume, proximity);
+		return witness.Gameworld.GetCheck(CheckType.GenericListenCheck)
+		              .Check(witness, difficulty, actor)
+		              .IsPass();
+	}
+
+	private static bool TryFormatDistantAlertEmote(string emoteText, string directionText, out string formattedText,
+		out string error)
+	{
+		try
+		{
+			formattedText = string.Format(emoteText, directionText);
+			error = string.Empty;
+			return true;
+		}
+		catch (FormatException)
+		{
+			formattedText = string.Empty;
+			error = "That distant alert emote has invalid format placeholders. Use only {0} for the direction and distance.";
+			return false;
+		}
+	}
+
+	private static bool ValidateStoredAlertLength(string emoteText, out string error)
+	{
+		if (emoteText.Length <= MaximumStoredAlertEmoteLength)
+		{
+			error = string.Empty;
+			return true;
+		}
+
+		error = $"Stored ALERT emotes must be {MaximumStoredAlertEmoteLength.ToString("N0")} characters or fewer.";
+		return false;
+	}
+}

--- a/MudSharpCore/NPC/AI/EnforcerAI.cs
+++ b/MudSharpCore/NPC/AI/EnforcerAI.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore.Internal;
 using MudSharp.Body.Position;
 using MudSharp.Character;
+using MudSharp.Communication;
 using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
 using MudSharp.Effects.Concrete;
@@ -26,7 +27,7 @@ using System.Xml.Linq;
 
 namespace MudSharp.NPC.AI;
 
-public class EnforcerAI : ArtificialIntelligenceBase
+public class EnforcerAI : ArtificialIntelligenceBase, IOverrideAlertEmote
 {
     public static void RegisterLoader()
     {
@@ -52,6 +53,8 @@ public class EnforcerAI : ArtificialIntelligenceBase
         ThrowInPrisonEchoProg = long.TryParse(root.Element("ThrowInPrisonEchoProg")?.Value ?? "0", out value)
             ? Gameworld.FutureProgs.Get(value)
             : Gameworld.FutureProgs.GetByName(root.Element("ThrowInPrisonEchoProg")!.Value);
+        AlertEmote = root.Element("AlertEmote")?.Value;
+        DistantAlertEmote = root.Element("DistantAlertEmote")?.Value;
     }
 
     protected EnforcerAI()
@@ -75,7 +78,9 @@ public class EnforcerAI : ArtificialIntelligenceBase
             new XElement("WarnEchoProg", WarnEchoProg?.Id ?? 0L),
             new XElement("WarnStartMoveEchoProg", WarnStartMoveEchoProg?.Id ?? 0L),
             new XElement("FailToComplyEchoProg", FailToComplyEchoProg?.Id ?? 0L),
-            new XElement("ThrowInPrisonEchoProg", ThrowInPrisonEchoProg?.Id ?? 0L)
+            new XElement("ThrowInPrisonEchoProg", ThrowInPrisonEchoProg?.Id ?? 0L),
+            new XElement("AlertEmote", AlertEmote ?? string.Empty),
+            new XElement("DistantAlertEmote", DistantAlertEmote ?? string.Empty)
         ).ToString();
     }
 
@@ -84,6 +89,8 @@ public class EnforcerAI : ArtificialIntelligenceBase
     public IFutureProg WarnStartMoveEchoProg { get; protected set; }
     public IFutureProg FailToComplyEchoProg { get; protected set; }
     public IFutureProg ThrowInPrisonEchoProg { get; protected set; }
+    public string AlertEmote { get; private set; }
+    public string DistantAlertEmote { get; private set; }
 
     /// <inheritdoc />
     public override string Show(ICharacter actor)
@@ -97,6 +104,8 @@ public class EnforcerAI : ArtificialIntelligenceBase
         sb.AppendLine($"Warn Start Move Prog: {WarnStartMoveEchoProg?.MXPClickableFunctionName() ?? "None".ColourError()}");
         sb.AppendLine($"Warn Fail Comply Prog: {FailToComplyEchoProg?.MXPClickableFunctionName() ?? "None".ColourError()}");
         sb.AppendLine($"Thrown In Prison Prog: {ThrowInPrisonEchoProg?.MXPClickableFunctionName() ?? "None".ColourError()}");
+        sb.AppendLine($"Alert Emote: {AlertEmote?.ColourCommand() ?? "None".ColourError()}");
+        sb.AppendLine($"Distant Alert Emote: {DistantAlertEmote?.ColourCommand() ?? "None".ColourError()}");
         return sb.ToString();
     }
 
@@ -110,6 +119,8 @@ public class EnforcerAI : ArtificialIntelligenceBase
 	#3warncomply clear#0 - clears the warn comply prog
 	#3prison <prog>#0 - sets the prog executed when the enforcer throws someone in a jail cell
 	#3prison clear#0 - clears the prison prog
+	#3alertemote <emote|clear>#0 - sets an AI-specific ALERT emote
+	#3alertfar <emote|clear>#0 - sets an AI-specific distant ALERT echo; use {0} for the direction
 
 #BNote - all the progs with this AI return commands to be executed. Enter multiple commands separated by newlines in the text the prog returns. You can do additional things in the prog too - you can just return an empty text if you want the NPCs not to execute any commands but instead handle the logic in the prog some other way.#0";
 
@@ -135,8 +146,75 @@ public class EnforcerAI : ArtificialIntelligenceBase
             case "prison":
             case "prisonprog":
                 return BuildingCommandPrisonProg(actor, command);
+            case "alert":
+            case "alertemote":
+            case "alertlocal":
+                return BuildingCommandAlertEmote(actor, command);
+            case "alertfar":
+            case "alertdistant":
+            case "distantalert":
+            case "distantalertemote":
+                return BuildingCommandDistantAlertEmote(actor, command);
         }
         return base.BuildingCommand(actor, command.GetUndo());
+    }
+
+    private bool BuildingCommandAlertEmote(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("What ALERT emote should this AI use, or #3clear#0 to clear it?".SubstituteANSIColour());
+            return false;
+        }
+
+        if (command.SafeRemainingArgument.EqualToAny("clear", "none", "delete", "remove"))
+        {
+            AlertEmote = null;
+            Changed = true;
+            actor.OutputHandler.Send("This AI will now use its race or global default ALERT emote.");
+            return true;
+        }
+
+        var emoteText = command.SafeRemainingArgument;
+        if (!AlertUtilities.ValidateAlertEmote(emoteText, actor, out var error))
+        {
+            actor.OutputHandler.Send(error);
+            return false;
+        }
+
+        AlertEmote = emoteText;
+        Changed = true;
+        actor.OutputHandler.Send($"This AI's ALERT emote is now {AlertEmote.ColourCommand()}.");
+        return true;
+    }
+
+    private bool BuildingCommandDistantAlertEmote(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("What distant ALERT echo should this AI use, or #3clear#0 to clear it? Use #6{0}#0 for the direction text.".SubstituteANSIColour());
+            return false;
+        }
+
+        if (command.SafeRemainingArgument.EqualToAny("clear", "none", "delete", "remove"))
+        {
+            DistantAlertEmote = null;
+            Changed = true;
+            actor.OutputHandler.Send("This AI will now use its race or global default distant ALERT echo.");
+            return true;
+        }
+
+        var emoteText = command.SafeRemainingArgument;
+        if (!AlertUtilities.ValidateDistantAlertEmote(emoteText, actor, out var error))
+        {
+            actor.OutputHandler.Send(error);
+            return false;
+        }
+
+        DistantAlertEmote = emoteText;
+        Changed = true;
+        actor.OutputHandler.Send($"This AI's distant ALERT echo is now {DistantAlertEmote.ColourCommand()}.");
+        return true;
     }
 
     private bool BuildingCommandPrisonProg(ICharacter actor, StringStack command)
@@ -367,6 +445,15 @@ public class EnforcerAI : ArtificialIntelligenceBase
             case EventType.WitnessedCrime:
                 ch = (ICharacter)arguments[2];
                 break;
+            case EventType.CharacterAlertHeard:
+                ch = (ICharacter)arguments[1];
+                break;
+            case EventType.EngageInCombat:
+                ch = (ICharacter)arguments[0];
+                break;
+            case EventType.EngagedInCombat:
+                ch = (ICharacter)arguments[1];
+                break;
         }
 
         if (ch is null || ch.State.IsDead() || ch.State.IsInStatis())
@@ -387,6 +474,11 @@ public class EnforcerAI : ArtificialIntelligenceBase
             case EventType.WitnessedCrime:
                 return WitnessedCrime((ICharacter)arguments[0], (ICharacter)arguments[1], ch,
                     (ICrime)arguments[3]);
+            case EventType.CharacterAlertHeard:
+                return CharacterAlertHeard((ICharacter)arguments[0], ch, (ICell)arguments[2]);
+            case EventType.EngageInCombat:
+            case EventType.EngagedInCombat:
+                return EnforcerEnteredCombat(ch);
             case EventType.FiveSecondTick:
                 return CharacterFiveSecondTick(ch);
         }
@@ -443,6 +535,75 @@ public class EnforcerAI : ArtificialIntelligenceBase
         crime.LegalAuthority.ReportCrime(crime, enforcer,
             IdentityIsKnownProg?.Execute<bool?>(enforcer, criminal) == true, 1.0);
         return false;
+    }
+
+    private bool EnforcerEnteredCombat(ICharacter enforcer)
+    {
+        if (EnforcerEffect(enforcer) == null)
+        {
+            return false;
+        }
+
+        return AlertUtilities.DoAlert(enforcer, echoFailure: false);
+    }
+
+    private bool CharacterAlertHeard(ICharacter alerter, ICharacter enforcer, ICell origin)
+    {
+        if (alerter == enforcer || origin is null || EnforcerEffect(enforcer) == null)
+        {
+            return false;
+        }
+
+        var patrolMember = enforcer.CombinedEffectsOfType<PatrolMemberEffect>().FirstOrDefault();
+        if (patrolMember is null || patrolMember.Patrol.ActiveEnforcementTarget is not null)
+        {
+            return false;
+        }
+
+        if (!IsGenerallyAble(enforcer, ignoreMovement: true) || enforcer.Combat is not null)
+        {
+            return false;
+        }
+
+        if (enforcer.Location == origin)
+        {
+            return AssistNearbyEnforcerInCombat(enforcer, EnforcerEffect(enforcer));
+        }
+
+        var path = enforcer.PathBetween(origin, 20, PathSearch.PathIncludeUnlockableDoors(enforcer)).ToList();
+        if (!path.Any())
+        {
+            return false;
+        }
+
+        enforcer.RemoveAllEffects<FollowingPath>(fireRemovalAction: true);
+        var fp = new FollowingPath(enforcer, path) { UseDoorguards = true, UseKeys = true, OpenDoors = true };
+        enforcer.AddEffect(fp);
+        fp.FollowPathAction();
+        return true;
+    }
+
+    private bool AssistNearbyEnforcerInCombat(ICharacter enforcer, EnforcerEffect enforcerEffect)
+    {
+        if (enforcerEffect is null || enforcer.Combat is not null)
+        {
+            return false;
+        }
+
+        var ally = enforcer.Location.Characters
+                           .Except(enforcer)
+                           .Where(x => x.Combat is not null)
+                           .FirstOrDefault(x =>
+                               x.EffectsOfType<EnforcerEffect>().Any(y => y.LegalAuthority == enforcerEffect.LegalAuthority) &&
+                               x.CombatTarget is not null &&
+                               x.CombatTarget != enforcer);
+        if (ally?.CombatTarget is null || !enforcer.CanEngage(ally.CombatTarget))
+        {
+            return false;
+        }
+
+        enforcer.Engage(ally.CombatTarget, false);
+        return true;
     }
 
     private bool HandleGeneral(ICharacter enforcer)
@@ -540,6 +701,11 @@ public class EnforcerAI : ArtificialIntelligenceBase
         if (HandleGeneral(enforcer))
         {
             return false;
+        }
+
+        if (AssistNearbyEnforcerInCombat(enforcer, effect))
+        {
+            return true;
         }
 
         IPatrol patrol = enforcer.CombinedEffectsOfType<PatrolMemberEffect>().FirstOrDefault()?.Patrol;
@@ -641,6 +807,9 @@ public class EnforcerAI : ArtificialIntelligenceBase
                 case EventType.TargetSlain:
                 case EventType.TruceOffered:
                 case EventType.WitnessedCrime:
+                case EventType.CharacterAlertHeard:
+                case EventType.EngageInCombat:
+                case EventType.EngagedInCombat:
                 case EventType.FiveSecondTick:
                     return true;
             }

--- a/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextConfiguring1.cs
+++ b/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextConfiguring1.cs
@@ -3094,6 +3094,16 @@ namespace MudSharp.Database
 
                 entity.Property(e => e.CurrencyId).HasColumnType("bigint(20)");
 
+                entity.Property(e => e.CustomAlertEmote)
+                    .HasColumnType("varchar(500)")
+                    .HasCharSet("utf8")
+                    .UseCollation("utf8_general_ci");
+
+                entity.Property(e => e.CustomDistantAlertEmote)
+                    .HasColumnType("varchar(500)")
+                    .HasCharSet("utf8")
+                    .UseCollation("utf8_general_ci");
+
                 entity.Property(e => e.EstateHeirId).HasColumnType("bigint(20)");
 
                 entity.Property(e => e.EstateHeirType)

--- a/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextConfiguring3.cs
+++ b/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextConfiguring3.cs
@@ -1964,6 +1964,16 @@ namespace MudSharp.Database
                     .HasCharSet("utf8")
                     .UseCollation("utf8_general_ci");
 
+                entity.Property(e => e.DefaultAlertEmote)
+                    .HasColumnType("varchar(500)")
+                    .HasCharSet("utf8")
+                    .UseCollation("utf8_general_ci");
+
+                entity.Property(e => e.DefaultDistantAlertEmote)
+                    .HasColumnType("varchar(500)")
+                    .HasCharSet("utf8")
+                    .UseCollation("utf8_general_ci");
+
                 entity.Property(e => e.CorpseModelId).HasColumnType("bigint(20)");
 
                 entity.Property(e => e.DefaultHandedness)

--- a/MudsharpDatabaseLibrary/Migrations/20260701121756_AlertEmotes.Designer.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260701121756_AlertEmotes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MudSharp.Database;
 
@@ -11,9 +12,11 @@ using MudSharp.Database;
 namespace MudSharp.Migrations
 {
     [DbContext(typeof(FuturemudDatabaseContext))]
-    partial class FutureMUDContextModelSnapshot : ModelSnapshot
+    [Migration("20260701121756_AlertEmotes")]
+    partial class AlertEmotes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MudsharpDatabaseLibrary/Migrations/20260701121756_AlertEmotes.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260701121756_AlertEmotes.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MudSharp.Migrations
+{
+    /// <inheritdoc />
+    public partial class AlertEmotes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "DefaultAlertEmote",
+                table: "Races",
+                type: "varchar(500)",
+                nullable: true,
+                collation: "utf8_general_ci")
+                .Annotation("MySql:CharSet", "utf8");
+
+            migrationBuilder.AddColumn<string>(
+                name: "DefaultDistantAlertEmote",
+                table: "Races",
+                type: "varchar(500)",
+                nullable: true,
+                collation: "utf8_general_ci")
+                .Annotation("MySql:CharSet", "utf8");
+
+            migrationBuilder.AddColumn<string>(
+                name: "CustomAlertEmote",
+                table: "Characters",
+                type: "varchar(500)",
+                nullable: true,
+                collation: "utf8_general_ci")
+                .Annotation("MySql:CharSet", "utf8");
+
+            migrationBuilder.AddColumn<string>(
+                name: "CustomDistantAlertEmote",
+                table: "Characters",
+                type: "varchar(500)",
+                nullable: true,
+                collation: "utf8_general_ci")
+                .Annotation("MySql:CharSet", "utf8");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DefaultAlertEmote",
+                table: "Races");
+
+            migrationBuilder.DropColumn(
+                name: "DefaultDistantAlertEmote",
+                table: "Races");
+
+            migrationBuilder.DropColumn(
+                name: "CustomAlertEmote",
+                table: "Characters");
+
+            migrationBuilder.DropColumn(
+                name: "CustomDistantAlertEmote",
+                table: "Characters");
+        }
+    }
+}

--- a/MudsharpDatabaseLibrary/Models/Character.cs
+++ b/MudsharpDatabaseLibrary/Models/Character.cs
@@ -102,6 +102,8 @@ public partial class Character
     public string NameInfo { get; set; }
     public int RoomLayer { get; set; }
     public bool NoMercy { get; set; }
+    public string CustomAlertEmote { get; set; }
+    public string CustomDistantAlertEmote { get; set; }
     public long? EstateHeirId { get; set; }
     public string EstateHeirType { get; set; }
 

--- a/MudsharpDatabaseLibrary/Models/Race.cs
+++ b/MudsharpDatabaseLibrary/Models/Race.cs
@@ -52,6 +52,8 @@ namespace MudSharp.Models
         public int SizeProne { get; set; }
         public int SizeSitting { get; set; }
         public string CommunicationStrategyType { get; set; }
+        public string DefaultAlertEmote { get; set; }
+        public string DefaultDistantAlertEmote { get; set; }
         public int DefaultHandedness { get; set; }
         public string HandednessOptions { get; set; }
         public string MaximumDragWeightExpression { get; set; }


### PR DESCRIPTION
## Summary
- Add ALERT command with default, race, AI, and character emote overrides plus hearing event dispatch.
- Integrate enforcer AI alert response and combat alerting.
- Enforce persisted custom ALERT emotes at the 500-character column limit.

## Validation
- dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 --filter AlertCommandSourceIntegrationTests
- dotnet build MudSharpCore\MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510
- git diff --check HEAD~1 HEAD