### PR TITLE
Fix execution retries, prosecutor assignment, and independent custody handling

### DIFF
--- a/Design Documents/Economy/Law_System_Runtime.md
+++ b/Design Documents/Economy/Law_System_Runtime.md
@@ -92,7 +92,7 @@ Execution emotes use the executioner as `$0` and the condemned prisoner as `$1` 
 The execution patrol progresses through these stages:
 
 1. Select a due condemned character and apply `ExecutionPatrolNoQuit`.
-2. Move patrol members to the equipment room.
+2. Move the patrol leader to the equipment room, with other members regrouping on the leader before preparing equipment.
 3. Collect restraints, method-specific tools, and, when configured, keys for the prisoner's retrieval route.
 4. Move the leader to the prisoner and send the retrieval emote.
 5. Give the prisoner the configured compliance window to use `HELPLESS` or submit to the guards.
@@ -107,11 +107,15 @@ The execution patrol progresses through these stages:
 
 If required rooms, tools, keys, paths, or targets become unavailable for too long, the patrol aborts and removes only the execution-specific no-quit effect. The `AwaitingExecution` effect remains so a later patrol can try again.
 
+If the patrol reaches the configured execution-attempt limit without killing the condemned prisoner, it announces the failed execution, releases any execution drag and no-quit state, delays the `AwaitingExecution` date by at least one in-game day from the current legal clock, sends the prisoner back to a holding cell, and then aborts the patrol. This keeps the sentence active but prevents an immediate silent relaunch loop.
+
 ## Trials and PC Judges
 
 Trials are represented by the `OnTrial` effect for the relevant legal authority. NPC judges drive ordinary `OnTrial` effects through the automated plea, argument, verdict, and sentencing phases. PC-held trials use the same effect as a court-session marker, but set the manual-trial flag so NPC judge AI will not advance or finalise the case.
 
 Automated trial effects persist their current phase, manual-trial flag, remaining per-charge queue, pleas, argument outcomes, and punishment results. If the game reboots mid-trial, the resumed `trial` view continues revealing only the charges, pleas, verdicts, and sentences that had actually been reached before the reboot.
+
+Automated trials use separate judge and prosecutor roles. The judge AI can read charges, collect pleas, move phases, announce verdicts, and sentence, but it does not argue the prosecution case. A prosecutor patrol member in the court claims the prosecution role and presents prosecution arguments; if no valid prosecutor patrol member is present, the trial waits rather than having the judge fill both roles.
 
 A PC judge is any enforcer whose enforcement authority has `CanConvict` for the jurisdiction and whose authority can judge the defendant's legal class.
 
@@ -152,6 +156,8 @@ Inactive patrol-route output reports both whether the route should begin and, wh
 The `showenforcers [authority|zone]` admin command reports the enforcer roster for a legal authority or any authority that enforces a specified zone. It includes on-duty state, patrol-pool eligibility, enforcement-authority match, current location, active patrol assignment, and the first reason a listed enforcer cannot be selected for patrol dispatch. The patrol pool requires an NPC with an `EnforcerAI`, an active `EnforcerEffect` for that legal authority, a currently matching enforcement authority, and no active patrol assignment.
 
 On-duty enforcers also report visible final-character-death corpses through the same local-authority corpse-report mechanism used by the player `REPORT CORPSE` command. The report is only queued when the corpse is visible, belongs to a zone with a responding legal authority, has an economic-zone morgue configured, and does not already have a pending or assigned recovery report.
+
+On-duty enforcers who are not currently assigned to a patrol can still take immediate custody of a helpless nearby criminal when the legal authority has a known, unfinalised, arrestable crime for that person. The enforcer begins dragging the criminal, clears any enforcer-side grapple or clinch state used to subdue them, paths to the authority prison location, and then uses the normal incarceration flow. This fallback is intentionally limited to arrestable detention cases; kill-on-sight enforcement and ordinary active fights remain patrol/combat behavior.
 
 ## Legal Status Diagnostics
 

--- a/MudSharpCore Unit Tests/LegalPatrolStrategyTests.cs
+++ b/MudSharpCore Unit Tests/LegalPatrolStrategyTests.cs
@@ -105,7 +105,60 @@ public class LegalPatrolStrategyTests
 		Assert.IsTrue(combatCheck > helplessCheck, "Helpless arrest targets must be dragged before the combat branch can re-engage them.");
 		StringAssert.Contains(source, "private bool TryStartDraggingHelplessCriminal(IPatrol patrol, ICharacter criminal)");
 		StringAssert.Contains(source, "LeaveCombatIfAble(member);");
-		StringAssert.Contains(source, "criminal.Combat?.Combatants.OfType<ICharacter>().Any(x => patrol.PatrolMembers.ContainsPhysicalInstance(x)) == true");
+		StringAssert.Contains(source, "EnforcementCustodyHelper.BeginDragging(random, criminal");
+		StringAssert.Contains(source, "EnforcementCustodyHelper.ReleaseGrapplesAndCombatAgainst(criminal, localPatrolMembers);");
+		int helperStart = source.IndexOf("private bool TryStartDraggingHelplessCriminal(IPatrol patrol, ICharacter criminal)", StringComparison.Ordinal);
+		int helperEnd = source.IndexOf("protected virtual void PatrolTickActiveEnforcement(IPatrol patrol)", helperStart, StringComparison.Ordinal);
+		string helperBlock = source[helperStart..helperEnd];
+		Assert.IsFalse(helperBlock.Contains("criminal.Combat?.Combatants.OfType<ICharacter>().Any(x => patrol.PatrolMembers.ContainsPhysicalInstance(x)) == true", StringComparison.Ordinal));
+	}
+
+	[TestMethod]
+	public void EnforcementCustodyHelper_ShouldConvertHelplessTargetsToDragCustody()
+	{
+		string source = File.ReadAllText(GetCoreSourcePath("RPG", "Law", "EnforcementCustodyHelper.cs"));
+
+		StringAssert.Contains(source, "public static ICrime SelectArrestableCrime(ILegalAuthority authority, ICharacter criminal)");
+		StringAssert.Contains(source, ".Where(x => x.Law.EnforcementStrategy.IsArrestable())");
+		StringAssert.Contains(source, "public static Dragging BeginDragging(ICharacter dragger, ICharacter criminal, IEnumerable<ICharacter> helpers)");
+		StringAssert.Contains(source, "var drag = new Dragging(dragger, null, criminal);");
+		StringAssert.Contains(source, "public static void ReleaseGrapplesAndCombatAgainst(ICharacter criminal, IEnumerable<ICharacter> enforcers)");
+		StringAssert.Contains(source, "RemoveAllEffects<IGrappling>");
+		StringAssert.Contains(source, "RemoveAllEffects<ClinchEffect>");
+		StringAssert.Contains(source, "LeaveCombatIfAble(criminal);");
+	}
+
+	[TestMethod]
+	public void EnforcerAI_ShouldTakeIndependentCustodyOfHelplessCriminals()
+	{
+		string source = File.ReadAllText(GetCoreSourcePath("NPC", "AI", "EnforcerAI.cs"));
+
+		StringAssert.Contains(source, "return TargetIncapacitated((ICharacter)arguments[1], ch);");
+		StringAssert.Contains(source, "private bool TryHandleIndependentCustody(ICharacter enforcer, EnforcerEffect effect)");
+		StringAssert.Contains(source, "enforcer.CombinedEffectsOfType<PatrolMemberEffect>().Any()");
+		StringAssert.Contains(source, "TryBeginIndependentCustody(character, victim, effect)");
+		StringAssert.Contains(source, "EnforcementCustodyHelper.BeginDragging(enforcer, criminal, Enumerable.Empty<ICharacter>())");
+		StringAssert.Contains(source, "MoveIndependentCustodyToPrison(enforcer, effect, criminal, crime)");
+		StringAssert.Contains(source, "PathSearch.PathIncludeUnlockableDoors(enforcer)");
+		StringAssert.Contains(source, "TryHandleIndependentCustody(enforcer, effect)");
+	}
+
+	[TestMethod]
+	public void AutomatedTrials_ShouldKeepJudgeAndProsecutorRolesSeparate()
+	{
+		string judgeSource = File.ReadAllText(GetCoreSourcePath("NPC", "AI", "JudgeAI.cs"));
+		string prosecutorSource = File.ReadAllText(GetCoreSourcePath("RPG", "Law", "PatrolStrategies", "ProsectutorPatrolStrategy.cs"));
+
+		StringAssert.Contains(judgeSource, "EnsureAutomatedProsecutor(trialEffect);");
+		StringAssert.Contains(judgeSource, "private static bool IsAutomatedProsecutor(ICharacter character, ILegalAuthority authority)");
+		StringAssert.Contains(judgeSource, "x.Patrol.PatrolStrategy.Name == \"Prosecutor\"");
+		StringAssert.Contains(judgeSource, "trialEffect.Prosecutor ??= court.Characters.FirstOrDefault");
+		Assert.IsFalse(judgeSource.Contains("trialEffect.Prosecutor ??= enforcer;", StringComparison.Ordinal));
+		Assert.IsFalse(judgeSource.Contains("trialEffect.HandleArgueCommand(enforcer, false);", StringComparison.Ordinal));
+
+		StringAssert.Contains(prosecutorSource, "trial.Prosecutor = patrol.PatrolLeader;");
+		StringAssert.Contains(prosecutorSource, "CharacterInstanceIdentityComparer.SamePhysicalInstanceOrBody(trial.Prosecutor, patrol.PatrolLeader)");
+		StringAssert.Contains(prosecutorSource, "trial.HandleArgueCommand(patrol.PatrolLeader, false);");
 	}
 
 	[TestMethod]
@@ -141,6 +194,40 @@ public class LegalPatrolStrategyTests
 		StringAssert.Contains(source, "private void ReportExecutionCorpseForRecovery(IPatrol patrol)");
 		StringAssert.Contains(source, "LegalAuthority.ReportCorpseToLocalAuthority(Gameworld, corpseItem, patrol.PatrolLeader, out _);");
 		StringAssert.Contains(source, "ReportExecutionCorpseForRecovery(patrol);");
+	}
+
+	[TestMethod]
+	public void ExecutionPatrolStrategy_ShouldRemandAndDelayAfterFailedExecutionAttempts()
+	{
+		string source = File.ReadAllText(GetCoreSourcePath("RPG", "Law", "PatrolStrategies", "ExecutionPatrolStrategy.cs"));
+		int maxAttemptCheck = source.IndexOf("if (_executionAttempts >= MaximumExecutionAttempts)", StringComparison.Ordinal);
+		int killingAttempt = source.IndexOf("bool attempted = Method switch", maxAttemptCheck, StringComparison.Ordinal);
+
+		Assert.IsTrue(maxAttemptCheck >= 0, "The killing loop should still enforce a maximum attempts guard.");
+		Assert.IsTrue(killingAttempt > maxAttemptCheck, "The maximum attempts guard should run before another killing attempt.");
+		StringAssert.Contains(source[maxAttemptCheck..killingAttempt], "HandleFailedExecutionAttempts(patrol);");
+		StringAssert.Contains(source, "public string FailureEmote { get; private set; }");
+		StringAssert.Contains(source, "private void HandleFailedExecutionAttempts(IPatrol patrol)");
+		StringAssert.Contains(source, "DoEmote(patrol.PatrolLeader, FailureEmote, _condemned);");
+		StringAssert.Contains(source, "_condemned.RemoveAllEffects<ExecutionPatrolNoQuit>(x => x.Patrol == patrol, fireRemovalAction: true);");
+		StringAssert.Contains(source, "DelayAwaitingExecution(patrol.LegalAuthority);");
+		StringAssert.Contains(source, "patrol.LegalAuthority.SendCharacterToHoldingCell(_condemned);");
+		StringAssert.Contains(source, "private void DelayAwaitingExecution(ILegalAuthority authority)");
+		StringAssert.Contains(source, "MudDateTime retryDate = CurrentLegalTime(authority) + MudTimeSpan.FromDays(1);");
+		StringAssert.Contains(source, "effect.ExtendSentence(retryDate - effect.ExecutionDate);");
+	}
+
+	[TestMethod]
+	public void ExecutionPatrolStrategy_ShouldUseLeaderLedEquipmentPreparation()
+	{
+		string source = File.ReadAllText(GetCoreSourcePath("RPG", "Law", "PatrolStrategies", "ExecutionPatrolStrategy.cs"));
+		int leaderMove = source.IndexOf("if (patrol.PatrolLeader.Location != equipment)", StringComparison.Ordinal);
+		int memberLoop = source.IndexOf("foreach (ICharacter member in patrol.PatrolMembers)", leaderMove, StringComparison.Ordinal);
+
+		Assert.IsTrue(leaderMove >= 0, "Execution preparation should move the leader to equipment first.");
+		Assert.IsTrue(memberLoop > leaderMove, "Member equipment orders should wait until the leader is at the equipment room.");
+		StringAssert.Contains(source[leaderMove..memberLoop], "MoveCharacterTo(patrol.PatrolLeader, equipment, 25);");
+		StringAssert.Contains(source[leaderMove..memberLoop], "return;");
 	}
 
 	[TestMethod]

--- a/MudSharpCore/NPC/AI/EnforcerAI.cs
+++ b/MudSharpCore/NPC/AI/EnforcerAI.cs
@@ -376,10 +376,10 @@ public class EnforcerAI : ArtificialIntelligenceBase
 
         switch (type)
         {
-            case EventType.CharacterIncapacitatedWitness:
-                return CharacterIncapacitatedWitness((ICharacter)arguments[0], ch);
-            case EventType.TargetIncapacitated:
-                return TargetIncapacitated(ch, (ICharacter)arguments[0]);
+			case EventType.CharacterIncapacitatedWitness:
+				return CharacterIncapacitatedWitness((ICharacter)arguments[0], ch);
+			case EventType.TargetIncapacitated:
+				return TargetIncapacitated((ICharacter)arguments[1], ch);
             case EventType.NoLongerEngagedInMelee:
             case EventType.TargetSlain:
             case EventType.TruceOffered:
@@ -394,19 +394,26 @@ public class EnforcerAI : ArtificialIntelligenceBase
         return false;
     }
 
-    private bool CharacterIncapacitatedWitness(ICharacter victim, ICharacter character)
-    {
-        return false;
-    }
+	private bool CharacterIncapacitatedWitness(ICharacter victim, ICharacter character)
+	{
+		EnforcerEffect effect = EnforcerEffect(character);
+		return effect is not null && TryBeginIndependentCustody(character, victim, effect);
+	}
 
-    private bool TargetIncapacitated(ICharacter victim, ICharacter character)
-    {
-        PatrolMemberEffect patrolMember = character.CombinedEffectsOfType<PatrolMemberEffect>().FirstOrDefault();
-        if (patrolMember == null || patrolMember.Patrol.ActiveEnforcementTarget != victim || patrolMember.Patrol
-                .ActiveEnforcementCrime?.Law.EnforcementStrategy.ShowMercyToIncapacitatedTarget() !=
-            false)
-        {
-            character.Combat?.TruceRequested(character);
+	private bool TargetIncapacitated(ICharacter victim, ICharacter character)
+	{
+		PatrolMemberEffect patrolMember = character.CombinedEffectsOfType<PatrolMemberEffect>().FirstOrDefault();
+		EnforcerEffect effect = EnforcerEffect(character);
+		if (patrolMember is null && effect is not null && TryBeginIndependentCustody(character, victim, effect))
+		{
+			return true;
+		}
+
+		if (patrolMember == null || patrolMember.Patrol.ActiveEnforcementTarget != victim || patrolMember.Patrol
+			    .ActiveEnforcementCrime?.Law.EnforcementStrategy.ShowMercyToIncapacitatedTarget() !=
+		    false)
+		{
+			character.Combat?.TruceRequested(character);
         }
 
         return false;
@@ -434,13 +441,170 @@ public class EnforcerAI : ArtificialIntelligenceBase
         {
             enforcer.OutputHandler.Handle(new EmoteOutput(new Emote("@ report|reports a corpse to the authorities.",
                 enforcer)));
-        }
-    }
+		}
+	}
 
-    private bool WitnessedCrime(ICharacter criminal, ICharacter victim, ICharacter enforcer, ICrime crime)
-    {
-        // Enforcers always report crimes whether they're on duty or off duty
-        crime.LegalAuthority.ReportCrime(crime, enforcer,
+	private bool TryHandleIndependentCustody(ICharacter enforcer, EnforcerEffect effect)
+	{
+		if (!CanActIndependently(enforcer, effect))
+		{
+			return false;
+		}
+
+		if (TryContinueIndependentCustody(enforcer, effect))
+		{
+			return true;
+		}
+
+		foreach (var criminal in enforcer.Location.LayerCharacters(enforcer.RoomLayer))
+		{
+			if (TryBeginIndependentCustody(enforcer, criminal, effect))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private bool TryBeginIndependentCustody(ICharacter enforcer, ICharacter criminal, EnforcerEffect effect)
+	{
+		if (!CanActIndependently(enforcer, effect))
+		{
+			return false;
+		}
+
+		if (!CanTakeIndependentCustody(enforcer, criminal, effect, out ICrime crime))
+		{
+			return false;
+		}
+
+		enforcer.RemoveAllEffects<FollowingPath>(fireRemovalAction: true);
+		if (EnforcementCustodyHelper.BeginDragging(enforcer, criminal, Enumerable.Empty<ICharacter>()) is null)
+		{
+			return false;
+		}
+
+		EnforcementCustodyHelper.ReleaseGrapplesAndCombatAgainst(criminal, new[] { enforcer });
+		criminal.RemoveAllEffects<WarnedByEnforcer>(x => x.WhichAuthority == effect.LegalAuthority, true);
+		return MoveIndependentCustodyToPrison(enforcer, effect, criminal, crime);
+	}
+
+	private bool TryContinueIndependentCustody(ICharacter enforcer, EnforcerEffect effect)
+	{
+		foreach (var drag in enforcer.CombinedEffectsOfType<Dragging>())
+		{
+			if (drag.Target is not ICharacter criminal)
+			{
+				continue;
+			}
+
+			ICrime crime = EnforcementCustodyHelper.SelectArrestableCrime(effect.LegalAuthority, criminal);
+			if (crime is null)
+			{
+				continue;
+			}
+
+			return MoveIndependentCustodyToPrison(enforcer, effect, criminal, crime);
+		}
+
+		return false;
+	}
+
+	private bool CanActIndependently(ICharacter enforcer, EnforcerEffect effect)
+	{
+		return enforcer.State.IsAble() &&
+		       !enforcer.CombinedEffectsOfType<PatrolMemberEffect>().Any() &&
+		       effect.LegalAuthority.GetEnforcementAuthority(enforcer) is not null;
+	}
+
+	private bool CanTakeIndependentCustody(ICharacter enforcer, ICharacter criminal, EnforcerEffect effect, out ICrime crime)
+	{
+		crime = null;
+		if (criminal is null ||
+		    CharacterInstanceIdentityComparer.SamePhysicalInstanceOrBody(enforcer, criminal) ||
+		    !criminal.ColocatedWith(enforcer) ||
+		    !criminal.IsHelpless ||
+		    criminal.State.IsDead() ||
+		    criminal.State.IsInStatis() ||
+		    criminal.IdentityIsObscured ||
+		    criminal.AffectedBy<InCustodyOfEnforcer>(effect.LegalAuthority) ||
+		    criminal.AffectedBy<Dragging.DragTarget>(effect.LegalAuthority) ||
+		    criminal.AffectedBy<OnTrial>(effect.LegalAuthority))
+		{
+			return false;
+		}
+
+		if (criminal.Combat is not null &&
+		    criminal.MeleeRange &&
+		    criminal.Combat.Combatants
+		            .OfType<ICharacter>()
+		            .Any(x =>
+			            !CharacterInstanceIdentityComparer.SamePhysicalInstanceOrBody(x, criminal) &&
+			            !CharacterInstanceIdentityComparer.SamePhysicalInstanceOrBody(x, enforcer)))
+		{
+			return false;
+		}
+
+		crime = EnforcementCustodyHelper.SelectArrestableCrime(effect.LegalAuthority, criminal);
+		return crime is not null;
+	}
+
+	private bool MoveIndependentCustodyToPrison(ICharacter enforcer, EnforcerEffect effect, ICharacter criminal, ICrime crime)
+	{
+		var authority = effect.LegalAuthority;
+		if (enforcer.Location == authority.PrisonLocation)
+		{
+			criminal.RemoveAllEffects<Dragging.DragTarget>(fireRemovalAction: true);
+			foreach (string action in (ThrowInPrisonEchoProg?.Execute<string>(enforcer, criminal, crime) ??
+			                           string.Empty).Split('\n'))
+			{
+				enforcer.ExecuteCommand(action);
+			}
+
+			authority.IncarcerateCriminal(criminal);
+			authority.OnPrisonerImprisoned?.Execute(criminal);
+			return true;
+		}
+
+		FollowingPath fp = enforcer.CombinedEffectsOfType<FollowingPath>().FirstOrDefault();
+		if (fp is not null && fp.Exits.LastOrDefault()?.Destination != authority.PrisonLocation)
+		{
+			enforcer.RemoveEffect(fp, true);
+			fp = null;
+		}
+
+		if (fp is not null)
+		{
+			if (enforcer.CouldMove(false, null).Success)
+			{
+				fp.FollowPathAction();
+			}
+
+			return true;
+		}
+
+		var path = enforcer.PathBetween(authority.PrisonLocation, 50,
+			PathSearch.PathIncludeUnlockableDoors(enforcer)).ToList();
+		if (!path.Any())
+		{
+			return true;
+		}
+
+		fp = new FollowingPath(enforcer, path) { UseDoorguards = true, UseKeys = true, OpenDoors = true };
+		enforcer.AddEffect(fp);
+		if (enforcer.CouldMove(false, null).Success)
+		{
+			fp.FollowPathAction();
+		}
+
+		return true;
+	}
+
+	private bool WitnessedCrime(ICharacter criminal, ICharacter victim, ICharacter enforcer, ICrime crime)
+	{
+		// Enforcers always report crimes whether they're on duty or off duty
+		crime.LegalAuthority.ReportCrime(crime, enforcer,
             IdentityIsKnownProg?.Execute<bool?>(enforcer, criminal) == true, 1.0);
         return false;
     }
@@ -535,12 +699,17 @@ public class EnforcerAI : ArtificialIntelligenceBase
             return false;
         }
 
-        ReportVisibleCorpses(enforcer);
+		ReportVisibleCorpses(enforcer);
 
-        if (HandleGeneral(enforcer))
-        {
-            return false;
-        }
+		if (TryHandleIndependentCustody(enforcer, effect))
+		{
+			return true;
+		}
+
+		if (HandleGeneral(enforcer))
+		{
+			return false;
+		}
 
         IPatrol patrol = enforcer.CombinedEffectsOfType<PatrolMemberEffect>().FirstOrDefault()?.Patrol;
         FollowingPath fp = enforcer.CombinedEffectsOfType<FollowingPath>().FirstOrDefault();

--- a/MudSharpCore/NPC/AI/JudgeAI.cs
+++ b/MudSharpCore/NPC/AI/JudgeAI.cs
@@ -1197,11 +1197,12 @@ With each of the emotes, you can use the following tokens:
         return DoTrialTick(enforcer, defendant, trialEffect);
     }
 
-    private bool DoTrialTick(ICharacter enforcer, ICharacter defendant, OnTrial trialEffect)
-    {
-        Gendering gender = defendant.ApparentGender(enforcer);
-        string[] crimeNames = trialEffect.Crimes.Select(x => x.Law.CrimeType.DescribeEnum(true)).Distinct().ToArray();
-        switch (trialEffect.Phase)
+	private bool DoTrialTick(ICharacter enforcer, ICharacter defendant, OnTrial trialEffect)
+	{
+		EnsureAutomatedProsecutor(trialEffect);
+		Gendering gender = defendant.ApparentGender(enforcer);
+		string[] crimeNames = trialEffect.Crimes.Select(x => x.Law.CrimeType.DescribeEnum(true)).Distinct().ToArray();
+		switch (trialEffect.Phase)
         {
             case TrialPhase.AwaitingLawyers:
                 return DoTrialTickAwaitingLawyers(enforcer, defendant, trialEffect, gender, crimeNames);
@@ -1221,21 +1222,42 @@ With each of the emotes, you can use the following tokens:
                 return DoTrialTickSentencing(enforcer, defendant, trialEffect, gender, crimeNames);
             default:
                 throw new ArgumentOutOfRangeException();
-        }
-    }
+		}
+	}
 
-    private bool DoTrialTickAwaitingLawyers(ICharacter enforcer, ICharacter defendant, OnTrial trialEffect, Gendering gender, string[] crimeNames)
-    {
-        if (DateTime.UtcNow - trialEffect.LastTrialAction < TrialPhaseDelay(trialEffect.Phase, trialEffect.Crimes.Count()))
+	private static bool IsAutomatedProsecutor(ICharacter character, ILegalAuthority authority)
+	{
+		return character.CombinedEffectsOfType<PatrolMemberEffect>()
+		                .Any(x =>
+			                x.Patrol?.LegalAuthority == authority &&
+			                x.Patrol.PatrolStrategy.Name == "Prosecutor");
+	}
+
+	private static void EnsureAutomatedProsecutor(OnTrial trialEffect)
+	{
+		var court = trialEffect.LegalAuthority.CourtLocation;
+		if (trialEffect.Prosecutor is not null &&
+		    (trialEffect.Prosecutor.Location != court ||
+		     !IsAutomatedProsecutor(trialEffect.Prosecutor, trialEffect.LegalAuthority)))
+		{
+			trialEffect.Prosecutor = null;
+		}
+
+		trialEffect.Prosecutor ??= court.Characters.FirstOrDefault(x => IsAutomatedProsecutor(x, trialEffect.LegalAuthority));
+	}
+
+	private bool DoTrialTickAwaitingLawyers(ICharacter enforcer, ICharacter defendant, OnTrial trialEffect, Gendering gender, string[] crimeNames)
+	{
+		if (DateTime.UtcNow - trialEffect.LastTrialAction < TrialPhaseDelay(trialEffect.Phase, trialEffect.Crimes.Count()))
         {
             return false;
         }
 
-        Construction.ICell court = trialEffect.LegalAuthority.CourtLocation;
-        trialEffect.Prosecutor ??= enforcer;
+		Construction.ICell court = trialEffect.LegalAuthority.CourtLocation;
+		EnsureAutomatedProsecutor(trialEffect);
 
-        if (trialEffect.Defender is null)
-        {
+		if (trialEffect.Defender is null)
+		{
             HasLegalCounsel counselEffect = defendant.EffectsOfType<HasLegalCounsel>().FirstOrDefault();
             if (counselEffect is not null)
             {
@@ -1268,13 +1290,13 @@ With each of the emotes, you can use the following tokens:
                     lawyer.NPC.AddEffect(new Lawyering(lawyer.NPC, trialEffect.LegalAuthority));
                     defendant.OutputHandler.Send("#2[System Message]#0 You have a court-appointed lawyer, who is on their way.".SubstituteANSIColour());
                 }
-            }
-        }
+			}
+		}
 
-        if (trialEffect.Defender.Location == court && trialEffect.Prosecutor.Location == court)
-        {
-            trialEffect.Phase = TrialPhase.Introduction;
-            trialEffect.LastTrialAction = DateTime.UtcNow;
+		if (trialEffect.Defender?.Location == court && trialEffect.Prosecutor?.Location == court)
+		{
+			trialEffect.Phase = TrialPhase.Introduction;
+			trialEffect.LastTrialAction = DateTime.UtcNow;
             return true;
         }
 
@@ -1285,13 +1307,13 @@ With each of the emotes, you can use the following tokens:
             {
                 trialEffect.Defender.RemoveAllEffects(x => x.IsEffectType<Lawyering>());
                 trialEffect.Defender = null;
-                defendant.RemoveAllEffects(x => x.IsEffectType<HasLegalCounsel>());
-            }
+				defendant.RemoveAllEffects(x => x.IsEffectType<HasLegalCounsel>());
+			}
 
-            if (trialEffect.Prosecutor.Location != court)
-            {
-                trialEffect.Prosecutor = null;
-            }
+			if (trialEffect.Prosecutor?.Location != court)
+			{
+				trialEffect.Prosecutor = null;
+			}
         }
 
         return false;
@@ -1620,18 +1642,11 @@ With each of the emotes, you can use the following tokens:
         return true;
     }
 
-    private bool DoTrialTickCase(ICharacter enforcer, ICharacter defendant, OnTrial trialEffect, Gendering gender, string[] crimeNames)
-    {
-        if (trialEffect.Prosecutor == enforcer && DateTime.UtcNow - trialEffect.LastTrialAction < TimeSpan.FromSeconds(5) && trialEffect.NextProsecutionCrime() is not null)
-        {
-            trialEffect.HandleArgueCommand(enforcer, false);
-            trialEffect.LastTrialAction = DateTime.UtcNow;
-            return false;
-        }
-
-        if (!trialEffect.CasesFinishedArguing() && DateTime.UtcNow - trialEffect.LastTrialAction < TrialPhaseDelay(trialEffect.Phase, trialEffect.Crimes.Count()))
-        {
-            return false;
+	private bool DoTrialTickCase(ICharacter enforcer, ICharacter defendant, OnTrial trialEffect, Gendering gender, string[] crimeNames)
+	{
+		if (!trialEffect.CasesFinishedArguing() && DateTime.UtcNow - trialEffect.LastTrialAction < TrialPhaseDelay(trialEffect.Phase, trialEffect.Crimes.Count()))
+		{
+			return false;
         }
 
         enforcer.OutputHandler.Handle(new EmoteOutput(new Emote(

--- a/MudSharpCore/RPG/Law/EnforcementCustodyHelper.cs
+++ b/MudSharpCore/RPG/Law/EnforcementCustodyHelper.cs
@@ -1,0 +1,109 @@
+using MudSharp.Character;
+using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.PerceptionEngine.Outputs;
+using MudSharp.PerceptionEngine.Parsers;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MudSharp.RPG.Law;
+
+public static class EnforcementCustodyHelper
+{
+	public static ICrime SelectArrestableCrime(ILegalAuthority authority, ICharacter criminal)
+	{
+		var crimes = authority.KnownCrimesForIndividual(criminal)
+		                      .Where(x => x.CriminalIdentityIsKnown)
+		                      .Where(x => !x.HasBeenFinalised)
+		                      .Where(x => !x.BailPosted)
+		                      .Where(x => x.Law.EnforcementStrategy.IsArrestable())
+		                      .ToList();
+
+		if (!crimes.Any())
+		{
+			return null;
+		}
+
+		return crimes
+		       .WhereMax(x => x.Law.EnforcementStrategy)
+		       .OrderByDescending(x => x.Law.EnforcementPriority)
+		       .First();
+	}
+
+	public static bool IsBeingDraggedBy(IEnumerable<ICharacter> enforcers, ICharacter criminal)
+	{
+		return enforcers.Any(x => x.CombinedEffectsOfType<Dragging>().Any(y => y.Target == criminal));
+	}
+
+	public static Dragging BeginDragging(ICharacter dragger, ICharacter criminal, IEnumerable<ICharacter> helpers)
+	{
+		if (criminal.AffectedBy<Dragging.DragTarget>())
+		{
+			return null;
+		}
+
+		var drag = new Dragging(dragger, null, criminal);
+		dragger.AddEffect(drag);
+		dragger.OutputHandler.Send(new EmoteOutput(new Emote("@ begin|begins to drag $1.", dragger, dragger, criminal)));
+
+		foreach (var helper in helpers
+		                      .Where(x => !CharacterInstanceIdentityComparer.SamePhysicalInstanceOrBody(x, dragger))
+		                      .Where(x => x.ColocatedWith(dragger))
+		                      .Where(x => x.State.IsAble())
+		                      .Where(x => x.Effects.All(y => !y.Applies() || !y.IsBlockingEffect("general"))))
+		{
+			drag.AddHelper(helper, null);
+			helper.OutputHandler.Send(new EmoteOutput(new Emote("@ begin|begins to help $1 to drag $2.", helper, helper, dragger, criminal)));
+		}
+
+		return drag;
+	}
+
+	public static void ReleaseGrapplesAndCombatAgainst(ICharacter criminal, IEnumerable<ICharacter> enforcers)
+	{
+		var enforcerList = enforcers
+		                   .Where(x => x.ColocatedWith(criminal))
+		                   .ToList();
+
+		foreach (var enforcer in enforcerList)
+		{
+			enforcer.RemoveAllEffects<IGrappling>(
+				x => CharacterInstanceIdentityComparer.SamePhysicalInstanceOrBody(x.Target, criminal),
+				true);
+			enforcer.RemoveAllEffects<ClinchEffect>(
+				x => CharacterInstanceIdentityComparer.SamePhysicalInstanceOrBody(x.Target, criminal),
+				true);
+			criminal.RemoveAllEffects<ClinchEffect>(
+				x => CharacterInstanceIdentityComparer.SamePhysicalInstanceOrBody(x.Target, enforcer),
+				true);
+
+			if (enforcer.CombatTarget is ICharacter enforcerTarget &&
+			    CharacterInstanceIdentityComparer.SamePhysicalInstanceOrBody(enforcerTarget, criminal))
+			{
+				enforcer.CombatTarget = null;
+			}
+
+			if (criminal.CombatTarget is ICharacter criminalTarget &&
+			    CharacterInstanceIdentityComparer.SamePhysicalInstanceOrBody(criminalTarget, enforcer))
+			{
+				criminal.CombatTarget = null;
+			}
+		}
+
+		foreach (var enforcer in enforcerList)
+		{
+			LeaveCombatIfAble(enforcer);
+		}
+
+		LeaveCombatIfAble(criminal);
+	}
+
+	private static void LeaveCombatIfAble(ICharacter character)
+	{
+		if (character.Combat?.CanFreelyLeaveCombat(character) == true)
+		{
+			character.Combat.LeaveCombat(character);
+		}
+	}
+}

--- a/MudSharpCore/RPG/Law/PatrolStrategies/ExecutionPatrolStrategy.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/ExecutionPatrolStrategy.cs
@@ -148,6 +148,7 @@ public class ExecutionPatrolStrategy : PatrolStrategyBase, IConfigurablePatrolSt
 	public string DrugEmote { get; private set; } = "@ administer|administers the execution drug to $1.";
 	public string FiringSquadEmote { get; private set; } = "@ give|gives the order to fire on $1.";
 	public string CompletionEmote { get; private set; } = "@ confirm|confirms that $1's sentence has been carried out.";
+	public string FailureEmote { get; private set; } = "@ signal|signals that $1's execution cannot be completed and must be rescheduled.";
 	private readonly List<string> _executionScript = new()
 	{
 		"@ announce|announces, \"%condemned% has been sentenced to death by lawful authority.\"",
@@ -167,7 +168,7 @@ public class ExecutionPatrolStrategy : PatrolStrategyBase, IConfigurablePatrolSt
 	#3scriptdelay <seconds>#0 - sets the delay between script steps
 	#3confirmdelay <seconds>#0 - sets how long to wait between execution attempts
 	#3attempts <number>#0 - sets the maximum execution attempts before aborting
-	#3emote retrieve|resist|arrival|restrain|lastwords|drug|firing|complete <emote>#0 - sets a custom emote
+	#3emote retrieve|resist|arrival|restrain|lastwords|drug|firing|complete|failure <emote>#0 - sets a custom emote
 	#3script add <emote>#0 - adds a scripted execution step
 	#3script delete <##>#0 - deletes a scripted execution step
 	#3script swap <##> <##>#0 - swaps two scripted execution steps
@@ -435,6 +436,17 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 		if (equipment is null)
 		{
 			AbortExecution(patrol);
+			return;
+		}
+
+		if (patrol.PatrolLeader.Location != equipment)
+		{
+			MoveCharacterTo(patrol.PatrolLeader, equipment, 25);
+			if (DateTime.UtcNow - _stageBegan > TimeSpan.FromMinutes(3))
+			{
+				AbortExecution(patrol);
+			}
+
 			return;
 		}
 
@@ -995,7 +1007,7 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 
 		if (_executionAttempts >= MaximumExecutionAttempts)
 		{
-			AbortExecution(patrol);
+			HandleFailedExecutionAttempts(patrol);
 			return;
 		}
 
@@ -1171,6 +1183,36 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 
 		ResetRuntimeState();
 		patrol.AbortPatrol();
+	}
+
+	private void HandleFailedExecutionAttempts(IPatrol patrol)
+	{
+		if (_condemned is not null)
+		{
+			DoEmote(patrol.PatrolLeader, FailureEmote, _condemned);
+			ReleaseCondemnedFromPatrolDrag(patrol);
+			_condemned.RemoveAllEffects<ExecutionPatrolNoQuit>(x => x.Patrol == patrol, fireRemovalAction: true);
+			DelayAwaitingExecution(patrol.LegalAuthority);
+			patrol.LegalAuthority.SendCharacterToHoldingCell(_condemned);
+		}
+
+		ResetRuntimeState();
+		patrol.AbortPatrol();
+	}
+
+	private void DelayAwaitingExecution(ILegalAuthority authority)
+	{
+		MudDateTime retryDate = CurrentLegalTime(authority) + MudTimeSpan.FromDays(1);
+		foreach (AwaitingExecution effect in _condemned.EffectsOfType<AwaitingExecution>(x => x.LegalAuthority == authority).ToList())
+		{
+			if (effect.ExecutionDate < retryDate)
+			{
+				effect.ExtendSentence(retryDate - effect.ExecutionDate);
+				continue;
+			}
+
+			effect.ExtendSentence(MudTimeSpan.FromDays(1));
+		}
 	}
 
 	private void ReleaseCondemnedFromPatrolDrag(IPatrol patrol)
@@ -1470,7 +1512,7 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 	{
 		if (command.IsFinished)
 		{
-			actor.OutputHandler.Send("Which emote do you want to set: retrieve, resist, arrival, restrain, lastwords, drug, firing or complete?");
+			actor.OutputHandler.Send("Which emote do you want to set: retrieve, resist, arrival, restrain, lastwords, drug, firing, complete or failure?");
 			return false;
 		}
 
@@ -1519,6 +1561,10 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 			case "complete":
 			case "completion":
 				CompletionEmote = emote;
+				break;
+			case "failure":
+			case "fail":
+				FailureEmote = emote;
 				break;
 			default:
 				actor.OutputHandler.Send("That is not a valid execution patrol emote.");
@@ -1653,7 +1699,8 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 				new XElement("LastWords", new XCData(LastWordsEmote)),
 				new XElement("Drug", new XCData(DrugEmote)),
 				new XElement("FiringSquad", new XCData(FiringSquadEmote)),
-				new XElement("Completion", new XCData(CompletionEmote))
+				new XElement("Completion", new XCData(CompletionEmote)),
+				new XElement("Failure", new XCData(FailureEmote))
 			),
 			new XElement("Script", _executionScript.Select(x => new XElement("Step", new XCData(x))))
 		).ToString();
@@ -1751,6 +1798,7 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 			DrugEmote = emotes.Element("Drug")?.Value ?? DrugEmote;
 			FiringSquadEmote = emotes.Element("FiringSquad")?.Value ?? FiringSquadEmote;
 			CompletionEmote = emotes.Element("Completion")?.Value ?? CompletionEmote;
+			FailureEmote = emotes.Element("Failure")?.Value ?? FailureEmote;
 		}
 
 		XElement script = root.Element("Script");

--- a/MudSharpCore/RPG/Law/PatrolStrategies/PatrolStrategyBase.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/PatrolStrategyBase.cs
@@ -215,61 +215,56 @@ public abstract class PatrolStrategyBase : IPatrolStrategy
         }
     }
 
-    private static bool IsBeingDraggedByPatrol(IPatrol patrol, ICharacter criminal)
-    {
-        return patrol.PatrolMembers.Any(x => x.CombinedEffectsOfType<Dragging>().Any(y => y.Target == criminal));
-    }
+	private static bool IsBeingDraggedByPatrol(IPatrol patrol, ICharacter criminal)
+	{
+		return EnforcementCustodyHelper.IsBeingDraggedBy(patrol.PatrolMembers, criminal);
+	}
 
-    private bool TryStartDraggingHelplessCriminal(IPatrol patrol, ICharacter criminal)
-    {
-        if (!criminal.IsHelpless)
+	private bool TryStartDraggingHelplessCriminal(IPatrol patrol, ICharacter criminal)
+	{
+		if (!criminal.IsHelpless)
         {
             return false;
         }
 
-        foreach (ICharacter member in patrol.PatrolMembers.Where(x => x.ColocatedWith(criminal)))
-        {
-            LeaveCombatIfAble(member);
-        }
+		var localPatrolMembers = patrol.PatrolMembers
+		                               .Where(x => x.ColocatedWith(criminal))
+		                               .ToList();
 
-        if (criminal.Combat?.Combatants.OfType<ICharacter>().Any(x => patrol.PatrolMembers.ContainsPhysicalInstance(x)) == true)
-        {
-            return true;
-        }
+		foreach (ICharacter member in localPatrolMembers)
+		{
+			LeaveCombatIfAble(member);
+		}
 
-        if (criminal.Combat is not null && criminal.MeleeRange)
-        {
-            return true;
-        }
+		if (criminal.Combat is not null &&
+		    criminal.MeleeRange &&
+		    criminal.Combat.Combatants
+		            .OfType<ICharacter>()
+		            .Any(x =>
+			            !CharacterInstanceIdentityComparer.SamePhysicalInstanceOrBody(x, criminal) &&
+			            !patrol.PatrolMembers.ContainsPhysicalInstance(x)))
+		{
+			return true;
+		}
 
-        ICharacter random = patrol.PatrolMembers
-                                   .Where(x => x.ColocatedWith(criminal))
-                                   .Where(x => x.State.IsAble())
-                                   .FirstOrDefault(x => x.SamePhysicalInstance(patrol.PatrolLeader)) ??
-                            patrol.PatrolMembers
-                                  .Where(x => x.ColocatedWith(criminal))
-                                  .Where(x => x.State.IsAble())
-                                  .GetRandomElement();
-        if (random is null)
-        {
-            return true;
-        }
+		ICharacter random = localPatrolMembers
+		                           .Where(x => x.State.IsAble())
+		                           .FirstOrDefault(x => x.SamePhysicalInstance(patrol.PatrolLeader)) ??
+		                    localPatrolMembers
+		                   .Where(x => x.State.IsAble())
+		                   .GetRandomElement();
+		if (random is null)
+		{
+			return true;
+		}
 
-        random.ExecuteCommand($"drag {random.BestKeywordFor(criminal)}");
-        if (random.CombinedEffectsOfType<Dragging>().Any(x => x.Target == criminal))
-        {
-            foreach (ICharacter other in patrol.PatrolMembers
-                                                .Where(x => !x.SamePhysicalInstance(random))
-                                                .Where(x => x.ColocatedWith(random)))
-            {
-                LeaveCombatIfAble(other);
+		if (EnforcementCustodyHelper.BeginDragging(random, criminal, localPatrolMembers.Where(x => !x.SamePhysicalInstance(random))) is not null)
+		{
+			EnforcementCustodyHelper.ReleaseGrapplesAndCombatAgainst(criminal, localPatrolMembers);
+		}
 
-                other.ExecuteCommand($"drag help {other.BestKeywordFor(random)}");
-            }
-        }
-
-        return true;
-    }
+		return true;
+	}
 
     protected virtual void PatrolTickActiveEnforcement(IPatrol patrol)
     {

--- a/MudSharpCore/RPG/Law/PatrolStrategies/ProsectutorPatrolStrategy.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/ProsectutorPatrolStrategy.cs
@@ -1,4 +1,5 @@
 ﻿using MudSharp.Construction.Boundary;
+using MudSharp.Character;
 using MudSharp.Effects.Concrete;
 using MudSharp.Framework;
 using System;
@@ -92,14 +93,28 @@ public class ProsectutorPatrolStrategy : PatrolStrategyBase
 
         // Argue in the trials
         OnTrial trial = patrol.PatrolLeader.Location.Characters.SelectNotNull(x => x.EffectsOfType<OnTrial>().FirstOrDefault()).FirstOrDefault();
-        if (trial is null)
-        {
-            return;
-        }
+		if (trial is null)
+		{
+			return;
+		}
 
-        if (trial.Phase.In(TrialPhase.Case, TrialPhase.ClosingArguments) && Dice.Roll(1, 3) == 1)
-        {
-            trial.HandleArgueCommand(patrol.PatrolLeader, false);
+		if (trial.Prosecutor is null ||
+		    trial.Prosecutor.Location != patrol.LegalAuthority.CourtLocation ||
+		    !trial.Prosecutor.CombinedEffectsOfType<PatrolMemberEffect>().Any(x =>
+			    x.Patrol?.LegalAuthority == patrol.LegalAuthority &&
+			    x.Patrol.PatrolStrategy.Name == "Prosecutor"))
+		{
+			trial.Prosecutor = patrol.PatrolLeader;
+		}
+
+		if (!CharacterInstanceIdentityComparer.SamePhysicalInstanceOrBody(trial.Prosecutor, patrol.PatrolLeader))
+		{
+			return;
+		}
+
+		if (trial.Phase.In(TrialPhase.Case, TrialPhase.ClosingArguments) && Dice.Roll(1, 3) == 1)
+		{
+			trial.HandleArgueCommand(patrol.PatrolLeader, false);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Update execution patrol flow to use leader-led equipment prep, delay and remand after failed attempts, and document the new retry behavior.
- Separate automated judge and prosecutor roles so trials no longer rely on the judge filling both positions.
- Add shared enforcement custody helpers and let enforcers independently detain helpless arrestable criminals outside patrol duty.
- Extend legal system design docs and regression tests to cover the new behavior.

## Testing
- Added/updated unit coverage for execution retry handling, prosecutor/judge role separation, and independent custody flow.
- Not run (not requested).