### PR TITLE
Add clan employment hosts and hall-cell dispatch support

### DIFF
--- a/Design Documents/Economy/Clan_Command_Surface_and_Permissions.md
+++ b/Design Documents/Economy/Clan_Command_Surface_and_Permissions.md
@@ -160,6 +160,12 @@ The balance sheet is gated by `CanViewTreasury`. It summarises clan-owned bank a
 
 Payroll history is gated by `CanViewTreasury`. It records payroll accruals from normal payday processing, manual backpay adjustments, and pay collection events. Review commands can filter by individual member, rank, or appointment, and show both summary totals and recent audit rows.
 
+### Clan hall cells
+
+`clan hall <clan>`
+
+Administrators can toggle their current cell as a clan hall cell. Hall cells are non-property workplaces for the unified clan employment host; clan-owned property cells are included automatically when the clan has any ownership share in the property. Clan hall cells are listed in administrator clan views alongside treasury and administration cells.
+
 ## External Control Permissions
 
 External clan control has two distinct authority models:

--- a/Design Documents/Economy/Economy_System_Runtime.md
+++ b/Design Documents/Economy/Economy_System_Runtime.md
@@ -361,12 +361,12 @@ Unified employment is the newer host-facing employment and operations layer. It 
 
 Verified runtime parts include:
 
-- `IEmploymentHost` and host-state shells for shops, auction houses, combat arenas, banks, stables, and durable hotel roots
+- `IEmploymentHost` and host-state shells for shops, auction houses, combat arenas, banks, stables, durable hotel roots, and clans
 - persisted employment host state keyed by host type and host id
 - persisted staff `IBoard` references for host communication, separate from task routing
 - employment contracts, job openings, runtime opening revision/application profile guards, applications, compensation terms, payment methods, delegated authority, payroll liabilities, manager goals, scheduled rules, action plans, active tasks, step operational state, employment register rows, and employment ledger rows
 - `EmploymentWorkerAI` for NPC application, workplace travel, task claiming, action-step execution, payroll claiming, and arrears-driven resignation
-- shared `employment` command adapters plus local host aliases on `shop`, `stable`, `bank`, `auction`, `arena`, and `roomrent`
+- shared `employment` command adapters, including `employment clan <clan> ...`, plus local host aliases on `shop`, `stable`, `bank`, `auction`, `arena`, and `roomrent`
 - scheduled-rule authoring and condition catalogues for manual, time, stock, account, item, commodity, shop-account, register-float, tax, and weather conditions
 - action catalogues for retrieval, delivery, logistics, planning, authorisation/reservation, board posts, command steps, store-account payment, tax payment, bank/virtual-cash movement, shop/register float, physical task-custody cash, exact-stock shop purchases, and native craft start/resume/output custody
 
@@ -377,6 +377,8 @@ Current operational boundaries:
 - executable shop-purchase tasks must be completed at a supplier shop location; commodity merchandise stays on the weighted purchase path and is not eligible for count-priced merchandise or item-selector purchases
 - payroll accrual expires fixed-term contracts before evaluation, uses explicit schedule windows for hourly guaranteed-hours contracts, rejects unsupported paid cadences until explicit earning records exist, worker resignation uses employee-specific arrears, and settlement validates every accrued payable destination before funds move, debits backed employer funds before cash payables become claimable, and credits employee or specified bank-account payables through native bank transactions; hosts without a native finance adapter must explicitly expose a currency-backed finance surface
 - item movement uses inventory plans where possible, with narrow fallbacks for behaviours the inventory-plan API does not model cleanly; physical employment logistics are constrained to the host's work locations and physical cash steps only consume task-custody currency piles
+- clan employment work locations are all distinct cells in properties where the clan has any ownership share plus admin-managed clan hall cells for non-property workplaces
+- clan employment finance uses the clan bank account currency when present, otherwise an existing contract compensation currency where available; paid opening/task/payroll authoring that needs a host currency blocks if neither source exists, and supported clan cash movement uses `VirtualCashLedger` with the clan bank account as optional backing
 - worker AI does not autonomously retry active tasks once they enter `Blocked`; blocked logistics tasks preserve any task-item custody for manager review instead of producing repeated delivery attempts
 - proprietor contracts cannot be terminated by non-admin managers, and manager goals must require the combined authority of the declared goal, its conditions, and its action plan
 - durable hotel roots and hotel room/rental/furnishing/lost-property internals are persisted through normalized hotel tables
@@ -400,6 +402,8 @@ Budget drawdowns are persisted as `ClanBudgetTransaction` rows and also write vi
 Clan balance-sheet review is a reporting surface rather than a separate ledger. It aggregates currently loaded economy state from clan-owned bank accounts, virtual treasury balances, owned and leased properties, property lease revenue and commitments, shops tied to clan property or clan bank accounts, controlled economic-zone revenues, payroll commitments, budget commitments, and outstanding backpay.
 
 Clan payroll history is persisted separately from the employment/job subsystem. `ClanPayrollHistory` rows are written when clan payday processing accrues pay, when a character collects owed clan pay, and when authorised users make manual backpay adjustments. This gives clans an audit trail for their rank, appointment, and individual payroll activity without changing the broader `JobListingBase` / `OngoingJobListing` employment model.
+
+Unified clan employment is separate from this legacy clan payroll history. Clan-host contracts, openings, task boards, scheduled rules, manager goals, employment ledgers, and payroll liabilities live in the unified employment-host model; clan rank/appointment payroll remains the existing clan payday system.
 
 ### Estates
 Estates are now a live persisted subsystem.

--- a/Design Documents/Economy/Economy_System_Workflows_and_Integration.md
+++ b/Design Documents/Economy/Economy_System_Workflows_and_Integration.md
@@ -330,22 +330,23 @@ Job builders need:
 
 Unified employment builders additionally need:
 
-- a host that exposes `IEmploymentHost` such as a shop, stable, bank, auction house, arena, or approved durable hotel root
+- a host that exposes `IEmploymentHost` such as a shop, stable, bank, auction house, arena, approved durable hotel root, or clan
 - a manager or proprietor contract with delegated authority to create openings, accept applications, assign tasks, create scheduled rules, or approve finance as appropriate
 - an `EmploymentWorkerAI` definition with a currency-bound reservation wage, accepted payment methods, host filters, AI capabilities, path range, search cadence, and tasking/payroll settings
 - employment openings whose required AI capabilities line up with the tasks the worker is expected to perform
 - scheduled rules using `tasks conditions` and action plans using `tasks actions`, rather than long helpfile-embedded catalogues
 - explicit authorise/reserve/release steps before financial task steps that spend or move employer money
 - task item selectors using prototype id by default, `*<id>` for live item id, `&<id|name>` for verified tags, and visible keywords for room-targeted items
-- enough physical world layout for worker pathing, inventory plans, stockrooms, shopfronts, tills, containers, workstations, and delivery cells
+- enough physical world layout for worker pathing, inventory plans, stockrooms, shopfronts, tills, containers, workstations, delivery cells, and for clan hosts either clan-owned property cells or admin-managed clan hall cells
 
 Current unified-employment operating notes:
 
-- `employment <host type> <id|name> ...` is the explicit command surface; local host aliases such as `shop tasks ...`, `stable tasks ...`, `bank tasks ...`, `auction tasks ...`, `arena tasks ...`, and `roomrent tasks ...` resolve the current local host as shorthand.
+- `employment <host type> <id|name> ...` is the explicit command surface; `employment clan <clan> ...` resolves by clan id, name, full name, or alias. Local host aliases such as `shop tasks ...`, `stable tasks ...`, `bank tasks ...`, `auction tasks ...`, `arena tasks ...`, and `roomrent tasks ...` resolve the current local host as shorthand.
 - `tasks actions [all|category|action]` and `tasks conditions [all|category|condition]` are the canonical discovery surfaces for action and scheduled-rule syntax.
 - scheduled rules are AND-composed in this slice; OR expressions, reusable named predicates, and grouped expressions remain future work.
 - host staff boards are communication only. Scheduled rules, active tasks, and manager goals live on employment-host services and do not propagate through board posts.
 - hotels have durable root `Hotel` rows for employment ownership and finance, and hotel room/rental/furnishing/lost-property state is normalized into hotel-specific EF tables.
+- clan hosts use any-share clan-owned property cells plus `clan hall <clan>` cells as workplaces. A clan bank account supplies the preferred employment currency and optional backing account; otherwise existing contract compensation currency can supply the currency for continuing operations.
 
 ## Integration Guidance for Future Features
 This section is inferred implementation guidance based on current patterns.

--- a/Design Documents/Economy/Employment Hosts Implementation Review and Roadmap.md
+++ b/Design Documents/Economy/Employment Hosts Implementation Review and Roadmap.md
@@ -35,7 +35,7 @@ The current system includes:
 - manager goals that create work through the task board;
 - `EmploymentWorkerAI` job search, application, host selection, task claiming, pathing, and execution;
 - native or partially native integrations for shop purchases, bank movements, store accounts, tax payments, physical and register float, crafting, merchandise repricing, and opening administration;
-- host adoption for shops, auction houses, combat arenas, banks, stables, and hotels;
+- host adoption for shops, auction houses, combat arenas, banks, stables, hotels, and clans;
 - normalized persistence for the common employment spine;
 - custody, host-location, authority-loss, and blocked-task protections added after the initial logistics implementation.
 
@@ -103,7 +103,7 @@ Priority is not useful if it is only persisted or displayed. Goal evaluation, ta
 
 ### 3.6 Ownership and employment are related but distinct
 
-A clan or organisation that owns a business is not automatically the same employment host as that business. Parent organisations and operating units require an explicit relationship and scoped authority model.
+A clan or organisation that owns a business is not automatically the same employment host as that business. Parent organisations and operating units require an explicit relationship and scoped authority model. A clan may also be its own `IEmploymentHost` for headquarters-style staff, but that host does not merge or replace the separate employment hosts for shops, hotels, stables, or other businesses the clan owns.
 
 ## 4. User-story walkthrough and findings
 
@@ -901,6 +901,8 @@ Clan membership and clan appointment are not automatically employment contracts.
 A clan appointment may grant organisational authority without wages. A paid officer should have both an appointment or scoped grant and an employment contract.
 
 Existing clan budgets and treasury facilities can provide spending ceilings, but an employment task should consume an explicit authorisation grant linked to the relevant appointment budget rather than receiving unrestricted treasury access.
+
+As of 2026-07-01, `IClan` / `Clan` is a first-class `IEmploymentHost` with `EmploymentHostType.Clan` for organisation-host employment. Clan employment locations are all distinct cells in properties where the clan has any ownership share, plus admin-managed clan hall cells toggled with `clan hall <clan>` for non-property workplaces. Clan employment finance uses the clan bank account currency when present, otherwise existing contract compensation currency where available; paid opening/task/payroll authoring that needs a host currency must fail closed if neither source exists. Supported clan finance movements use `VirtualCashLedger` with the clan bank account as optional backing.
 
 Example mappings:
 

--- a/Design Documents/Economy/Unified Employment Dispatch Design.md
+++ b/Design Documents/Economy/Unified Employment Dispatch Design.md
@@ -2,7 +2,7 @@
 
 ## 1. Purpose
 
-The economy system currently has several independent concepts that are all variations of the same idea: a business or institution has proprietors, managers, employees, money, inventory, duties, operating policies, and recurring work. Shops, auction houses, arenas, banks, stables, and hotel businesses each expose some subset of these behaviours, but they do not share a common employment and task-dispatch model.
+The economy system currently has several independent concepts that are all variations of the same idea: a business or institution has proprietors, managers, employees, money, inventory, duties, operating policies, and recurring work. Shops, auction houses, arenas, banks, stables, hotel businesses, and clans each expose some subset of these behaviours, but they do not share a common employment and task-dispatch model.
 
 This design introduces a unified employment layer, a manager-goal layer, and a composable task-dispatch layer.
 
@@ -31,7 +31,7 @@ Terminology note: this document uses **employment opening** for the new host-lev
 ### In scope for the first production slice
 
 - A common employment-host interface named `IEmploymentHost`.
-- Host shells first: shops, auction houses, arenas, banks, stables, and hotels expose `IEmploymentHost` with contracts, authority, employment openings, a real host board reference, task board, manager-goal board, and operational register support before real dispatcher execution is required.
+- Host shells first: shops, auction houses, arenas, banks, stables, hotels, and clans expose `IEmploymentHost` with contracts, authority, employment openings, a real host board reference, task board, manager-goal board, and operational register support before real dispatcher execution is required.
 - Common domain objects for employment contracts, roles, manager authority, employment openings, applications, payment terms, working hours, and employment duration.
 - A simple employment status model with no probation concept.
 - Manager delegation: authorised managers can manage employees within their granted authority, including hiring, firing, creating employment openings, and eventually assigning or creating tasks.
@@ -86,7 +86,7 @@ This stance applies specifically to legacy employment-like data. It is not permi
 
 ## 6. Terminology
 
-- **Employment host / `IEmploymentHost`:** A shop, auction house, arena, bank, stable, hotel, or future organisation that can employ NPCs or player characters through the new employment model.
+- **Employment host / `IEmploymentHost`:** A shop, auction house, arena, bank, stable, hotel, clan, or future organisation that can employ NPCs or player characters through the new employment model.
 - **Hotel / `IHotel`:** A separate persisted economy host for hotel business state. A hotel links to property/cell data for ownership, location, and access control, but owns hotel rooms, rentals, patron balances, lost property, tax configuration, manager workflows, bank account, virtual reserve, and operational state.
 - **Employee agent:** A character, usually an NPC for this design, capable of accepting work and performing action steps.
 - **Employment contract:** The active or historical relationship between an employment host and an employee agent, including role, pay, schedule, duration, status, payment method, and authority.
@@ -942,7 +942,7 @@ Recommended integration scenario:
 
 Codex should update this section during implementation.
 
-Last reviewed against the implementation on 2026-06-19.
+Last reviewed against the implementation on 2026-07-01.
 
 ### Completed
 
@@ -950,7 +950,8 @@ Last reviewed against the implementation on 2026-06-19.
 - Added common in-engine host state services for hire/fire, active/simple employment status, delegated authority checks, job-opening creation, NPC candidate matching, reservation-wage rejection, payment-method selection, host `IBoard` access, employment register entries, and business ledger entries.
 - Added composable task-dispatch shells: manual, time-window, stock-threshold, and account-balance conditions; action plans; active task step state; scheduled task rules with idempotency/cooldown; dispatcher eligibility/blocking; and initial purchase, movement/delivery, craft-trigger, command, bank deposit, bank withdrawal, store-account payment, board-post, item retrieval, commodity retrieval, and item delivery action steps.
 - Added manager-goal board support with delegated-authority enforcement and task creation through the shared task board rather than bypassing host permissions.
-- Adopted the minimum host families as employment hosts: shops, auction houses, combat arenas, banks, stables, and hotels. Shops, auction houses, arenas, banks, and stables expose lazy host shells; hotels now have a separate `IHotel` / `Hotel` runtime entity linked to an `IProperty`.
+- Adopted the minimum host families as employment hosts: shops, auction houses, combat arenas, banks, stables, hotels, and clans. Shops, auction houses, arenas, banks, and stables expose lazy host shells; hotels now have a separate `IHotel` / `Hotel` runtime entity linked to an `IProperty`; clans use the clan entity itself as an organisation host for headquarters-style employment.
+- Added clan employment host support. Clan work locations are the distinct cells from any property where the clan holds any ownership share, plus the admin-managed `clan hall <clan>` cell list for non-property workplaces. Clan employment finance uses the clan bank account currency when present, otherwise an existing contract compensation currency where available; paid authoring flows that need a currency block if neither exists, and supported clan cash movement uses `VirtualCashLedger` with the clan bank account as optional backing.
 - Added normalized EF persistence for the employment spine: host state keyed by host type/id, persisted host-board reference, contracts, openings, opening requirements, applications, action plans, action steps, scheduled rules, task conditions, active tasks, step states, manager goals, operational register rows, and employment ledger rows. Existing hosts lazily create an empty persisted employment state and a staff `IBoard` on first access.
 - Wired shop, auction-house, arena, bank, stable, and hotel shells through the production employment persistence store while preserving the in-memory constructor path for isolated tests.
 - Added a persisted `Hotels` root table linked one-to-one to properties. `Property.Hotel` now lazily creates/loads the durable hotel entity.

--- a/FutureMUDLibrary/Community/IClan.cs
+++ b/FutureMUDLibrary/Community/IClan.cs
@@ -1,6 +1,7 @@
 ﻿using MudSharp.Character;
 using MudSharp.Construction;
 using MudSharp.Economy;
+using MudSharp.Economy.Employment;
 using MudSharp.Framework;
 using MudSharp.Framework.Save;
 using MudSharp.FutureProg;
@@ -14,7 +15,7 @@ using System.Linq;
 
 namespace MudSharp.Community
 {
-    public interface IClan : IFrameworkItem, ISaveable, IProgVariable, IHaveMultipleNames
+    public interface IClan : IFrameworkItem, ISaveable, IProgVariable, IHaveMultipleNames, IEmploymentHost
     {
         bool IsTemplate { get; set; }
         string Alias { get; set; }
@@ -27,10 +28,13 @@ namespace MudSharp.Community
 
         IEnumerable<ICell> TreasuryCells { get; }
         IEnumerable<ICell> AdministrationCells { get; }
+        IEnumerable<ICell> ClanHallCells { get; }
         void AddTreasuryCell(ICell cell);
         void RemoveTreasuryCell(ICell cell);
         void AddAdministrationCell(ICell cell);
         void RemoveAdministrationCell(ICell cell);
+        void AddClanHallCell(ICell cell);
+        void RemoveClanHallCell(ICell cell);
 
         IBankAccount ClanBankAccount { get; set; }
 

--- a/FutureMUDLibrary/Economy/Employment/EmploymentDomain.cs
+++ b/FutureMUDLibrary/Economy/Employment/EmploymentDomain.cs
@@ -17,7 +17,8 @@ public enum EmploymentHostType
 	Bank,
 	Stable,
 	Hotel,
-	Other
+	Other,
+	Clan = 7
 }
 
 public enum EmploymentRole

--- a/MudSharpCore Unit Tests/Economy/Employment/EmploymentCommandServiceTests.cs
+++ b/MudSharpCore Unit Tests/Economy/Employment/EmploymentCommandServiceTests.cs
@@ -14,6 +14,7 @@ using MudSharp.Character.Name;
 using MudSharp.Climate;
 using MudSharp.Commands.Helpers;
 using MudSharp.Commands.Modules;
+using MudSharp.Community;
 using MudSharp.Community.Boards;
 using MudSharp.Construction;
 using MudSharp.Database;
@@ -102,6 +103,10 @@ public class EmploymentCommandServiceTests
 			Assert.IsFalse(help.Contains("tasks step gettag", StringComparison.OrdinalIgnoreCase),
 				$"{name} help should point to the action catalogue instead of inlining the action list.");
 		}
+
+		StringAssert.Contains(EmploymentCommandService.EmploymentHelp, "#3clan#0");
+		Assert.IsTrue(EmploymentCommandService.EmploymentHelp.Contains("clan hosts are resolved",
+			StringComparison.OrdinalIgnoreCase));
 	}
 
 	[TestMethod]
@@ -114,6 +119,16 @@ public class EmploymentCommandServiceTests
 		var bank = HostMock<IBank>(4, "coin vault");
 		var stable = HostMock<IStable>(5, "east stable");
 		var hotel = HostMock<IHotel>(6, "harbour rooms");
+		var clan = HostMock<IClan>(8, "merchant league");
+		clan.SetupGet(x => x.FullName).Returns("The Honourable Merchant League");
+		clan.SetupGet(x => x.Alias).Returns("tml");
+		clan.SetupGet(x => x.Names).Returns(["merchant league", "The Honourable Merchant League", "tml"]);
+		clan.SetupGet(x => x.IsTemplate).Returns(false);
+		var templateClan = HostMock<IClan>(9, "template league");
+		templateClan.SetupGet(x => x.FullName).Returns("Template League");
+		templateClan.SetupGet(x => x.Alias).Returns("template");
+		templateClan.SetupGet(x => x.Names).Returns(["template league", "Template League", "template"]);
+		templateClan.SetupGet(x => x.IsTemplate).Returns(true);
 		var property = new Mock<IProperty>();
 		property.SetupGet(x => x.Id).Returns(7);
 		property.SetupGet(x => x.Name).Returns("harbour house");
@@ -129,6 +144,9 @@ public class EmploymentCommandServiceTests
 		banks.Add(bank.Object);
 		var stables = new All<IStable>();
 		stables.Add(stable.Object);
+		var clans = new All<IClan>();
+		clans.Add(clan.Object);
+		clans.Add(templateClan.Object);
 		var properties = new All<IProperty>();
 		properties.Add(property.Object);
 		gameworld.SetupGet(x => x.Shops).Returns(shops);
@@ -136,6 +154,7 @@ public class EmploymentCommandServiceTests
 		gameworld.SetupGet(x => x.CombatArenas).Returns(arenas);
 		gameworld.SetupGet(x => x.Banks).Returns(banks);
 		gameworld.SetupGet(x => x.Stables).Returns(stables);
+		gameworld.SetupGet(x => x.Clans).Returns(clans);
 		gameworld.SetupGet(x => x.Properties).Returns(properties);
 
 		var resolver = new EmploymentHostResolver();
@@ -146,6 +165,11 @@ public class EmploymentCommandServiceTests
 		Assert.AreSame(bank.Object, resolver.Resolve(gameworld.Object, "bank", "coin vault", out _));
 		Assert.AreSame(stable.Object, resolver.Resolve(gameworld.Object, "stable", "east stable", out _));
 		Assert.AreSame(hotel.Object, resolver.Resolve(gameworld.Object, "hotel", "harbour house", out _));
+		Assert.AreSame(clan.Object, resolver.Resolve(gameworld.Object, "clan", "8", out _));
+		Assert.AreSame(clan.Object, resolver.Resolve(gameworld.Object, "clan", "merchant league", out _));
+		Assert.AreSame(clan.Object, resolver.Resolve(gameworld.Object, "organisation", "tml", out _));
+		Assert.IsNull(resolver.Resolve(gameworld.Object, "clan", "template", out var templateError));
+		StringAssert.Contains(templateError, "Clan templates cannot be used as employment hosts");
 	}
 
 	[TestMethod]
@@ -1017,7 +1041,20 @@ public class EmploymentCommandServiceTests
 		var employee = Character(62, "Employee").Object;
 		var shop = EmploymentHostMock<IShop>(63, "debug market", EmploymentHostType.Shop,
 			out var state);
+		var clan = EmploymentHostMock<IClan>(64, "debug guild", EmploymentHostType.Clan,
+			out var clanState);
+		clan.SetupGet(x => x.FullName).Returns("Debug Guild");
+		clan.SetupGet(x => x.Alias).Returns("dg");
+		clan.SetupGet(x => x.Names).Returns(["debug guild", "Debug Guild", "dg"]);
+		clan.SetupGet(x => x.ClanBankAccount).Returns((IBankAccount)null!);
 		var contract = state.Hire(employee, new EmploymentOffer(
+			EmploymentRole.Employee,
+			Pay(currency.Object),
+			new WorkSchedule("Day shift", TimeSpan.FromHours(9.0), TimeSpan.FromHours(17.0)),
+			EmploymentDuration.Indefinite,
+			new PaymentMethod(PaymentMethodKind.Cash),
+			EmploymentAuthoritySet.Empty), null);
+		clanState.Hire(employee, new EmploymentOffer(
 			EmploymentRole.Employee,
 			Pay(currency.Object),
 			new WorkSchedule("Day shift", TimeSpan.FromHours(9.0), TimeSpan.FromHours(17.0)),
@@ -1026,8 +1063,11 @@ public class EmploymentCommandServiceTests
 			EmploymentAuthoritySet.Empty), null);
 		var shops = new All<IShop>();
 		shops.Add(shop.Object);
+		var clans = new All<IClan>();
+		clans.Add(clan.Object);
 		var gameworld = Gameworld();
 		gameworld.SetupGet(x => x.Shops).Returns(shops);
+		gameworld.SetupGet(x => x.Clans).Returns(clans);
 
 		var output = ImplementorModule.DebugAdvanceEmploymentPayrolls(
 			gameworld.Object,
@@ -1038,8 +1078,14 @@ public class EmploymentCommandServiceTests
 		Assert.AreEqual(80.0M, state.Payroll.Payables.Single().Amount.Amount);
 		Assert.IsTrue(state.EmploymentRegister.Entries.Any(x =>
 			x.EntryType == EmploymentRegisterEntryType.WageAccrued));
+		Assert.AreEqual(1, clanState.Payroll.Payables.Count);
+		Assert.AreEqual(1, clanState.Payroll.OutstandingLiabilities.Count);
+		Assert.AreEqual(80.0M, clanState.Payroll.Payables.Single().Amount.Amount);
+		Assert.IsTrue(clanState.EmploymentRegister.Entries.Any(x =>
+			x.EntryType == EmploymentRegisterEntryType.WageAccrued));
 		StringAssert.Contains(output, "Employment payroll debug run complete");
 		StringAssert.Contains(output, "debug market");
+		StringAssert.Contains(output, "debug guild");
 	}
 
 	[TestMethod]

--- a/MudSharpCore Unit Tests/Economy/Employment/EmploymentWorkerAITests.cs
+++ b/MudSharpCore Unit Tests/Economy/Employment/EmploymentWorkerAITests.cs
@@ -13,6 +13,7 @@ using MudSharp.Body;
 using MudSharp.Character;
 using MudSharp.Character.Name;
 using MudSharp.Commands.Modules;
+using MudSharp.Community;
 using MudSharp.Community.Boards;
 using MudSharp.Construction;
 using MudSharp.Economy;
@@ -99,6 +100,8 @@ public class EmploymentWorkerAITests
 		Assert.IsTrue(ai.BuildingCommand(actor, new StringStack("payment employeebankaccount")));
 		Assert.IsTrue(ai.BuildingCommand(actor, new StringStack("capability canusebankaccount")));
 		Assert.IsTrue(ai.BuildingCommand(actor, new StringStack("host stable")));
+		Assert.AreEqual(EmploymentHostType.Stable, ai.HostTypeFilter);
+		Assert.IsTrue(ai.BuildingCommand(actor, new StringStack("host organisation")));
 		Assert.IsTrue(ai.BuildingCommand(actor, new StringStack("range 12")));
 		Assert.IsTrue(ai.BuildingCommand(actor, new StringStack("cadence 2")));
 		Assert.IsTrue(ai.BuildingCommand(actor, new StringStack("arrears 4")));
@@ -108,7 +111,7 @@ public class EmploymentWorkerAITests
 		Assert.AreSame(currency.Object, ai.Currency);
 		Assert.IsTrue(ai.AcceptedPaymentMethods.Contains(PaymentMethodKind.EmployeeBankAccount));
 		Assert.IsTrue(ai.Capabilities.Contains(EmploymentAICapability.CanUseBankAccount));
-		Assert.AreEqual(EmploymentHostType.Stable, ai.HostTypeFilter);
+		Assert.AreEqual(EmploymentHostType.Clan, ai.HostTypeFilter);
 		Assert.AreEqual(12u, ai.MaxPathRange);
 		Assert.AreEqual(TimeSpan.FromMinutes(2), ai.SearchCadence);
 		Assert.AreEqual(4, ai.MaximumUnpaidOverdueDays);
@@ -155,6 +158,32 @@ public class EmploymentWorkerAITests
 			Times.AtLeastOnce);
 		gameworld.Verify(x => x.DebugMessage(It.Is<string>(text => text.Contains("applying to"))),
 			Times.AtLeastOnce);
+	}
+
+	[TestMethod]
+	public void EmploymentWorkerAI_UnemployedNpcAppliesForClanOpeningAtHallCell()
+	{
+		var currency = Currency();
+		var workplace = Cell(220, "guild hall");
+		var host = Clan(220, "merchant league", currency.Object, workplace.Object);
+		host.State.CreateJobOpening(Opening(currency.Object, 12.0M), null);
+		var gameworld = Gameworld(clans: [host.Clan.Object], currencies: [currency.Object]);
+		host.Clan.As<IHaveFuturemud>().SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		var worker = Character(221, "Worker", gameworld.Object, workplace.Object).Object;
+		var ai = LoadAI(gameworld.Object, """
+		                                  <Definition>
+		                                    <ReservationWage>0</ReservationWage>
+		                                    <HostTypeFilter>Clan</HostTypeFilter>
+		                                    <AcceptedPaymentMethods><Method>Cash</Method></AcceptedPaymentMethods>
+		                                    <Capabilities><Capability>CanDeliverItems</Capability></Capabilities>
+		                                  </Definition>
+		                                  """);
+
+		var acted = ai.HandleMinuteTick(worker);
+
+		Assert.IsTrue(acted);
+		Assert.AreEqual(1, host.State.Applications.Count);
+		Assert.AreEqual(JobApplicationStatus.Pending, host.State.Applications.Single().Status);
 	}
 
 	[TestMethod]
@@ -912,8 +941,43 @@ public class EmploymentWorkerAITests
 		return (stable, state);
 	}
 
+	private static (Mock<IClan> Clan, EmploymentHostState State) Clan(long id, string name, ICurrency currency,
+		ICell workplace)
+	{
+		var clan = new Mock<IClan>();
+		var state = new EmploymentHostState(clan.Object);
+		clan.SetupGet(x => x.Id).Returns(id);
+		clan.SetupGet(x => x.Name).Returns(name);
+		clan.SetupGet(x => x.FullName).Returns(name);
+		clan.SetupGet(x => x.Alias).Returns(name);
+		clan.SetupGet(x => x.Names).Returns([name]);
+		clan.SetupGet(x => x.FrameworkItemType).Returns("Clan");
+		clan.SetupGet(x => x.ClanHallCells).Returns([workplace]);
+		clan.SetupGet(x => x.ClanBankAccount).Returns((IBankAccount)null!);
+		clan.SetupGet(x => x.EmploymentHostName).Returns(name);
+		clan.SetupGet(x => x.EmploymentHostType).Returns(EmploymentHostType.Clan);
+		clan.SetupGet(x => x.Employment).Returns(state);
+		clan.SetupGet(x => x.EmploymentContracts).Returns(() => state.EmploymentContracts);
+		clan.SetupGet(x => x.JobOpenings).Returns(() => state.JobOpenings);
+		clan.SetupGet(x => x.TaskBoard).Returns(() => state.TaskBoard);
+		clan.SetupGet(x => x.Payroll).Returns(() => state.Payroll);
+		clan.SetupGet(x => x.EmploymentRegister).Returns(() => state.EmploymentRegister);
+		clan.SetupGet(x => x.BusinessLedger).Returns(() => state.BusinessLedger);
+		clan.SetupGet(x => x.Board).Returns(() => state.Board);
+		clan.SetupGet(x => x.ManagerGoalBoard).Returns(() => state.ManagerGoalBoard);
+		clan.SetupGet(x => x.Market).Returns((IMarket?)null);
+		clan.Setup(x => x.HasAuthority(It.IsAny<ICharacter>(), It.IsAny<EmploymentAuthority>()))
+		    .Returns((ICharacter actor, EmploymentAuthority authority) => state.HasAuthority(actor, authority));
+		clan.Setup(x => x.Fire(It.IsAny<IEmploymentContract>(), It.IsAny<EmploymentTerminationReason>(),
+			    It.IsAny<ICharacter?>()))
+		    .Callback<IEmploymentContract, EmploymentTerminationReason, ICharacter?>((contract, reason, authorisedBy) =>
+			    state.Fire(contract, reason, authorisedBy));
+		return (clan, state);
+	}
+
 	private static Mock<IFuturemud> Gameworld(IEnumerable<IShop>? shops = null, IEnumerable<IStable>? stables = null,
-		IEnumerable<IProperty>? properties = null, IEnumerable<ICurrency>? currencies = null)
+		IEnumerable<IClan>? clans = null, IEnumerable<IProperty>? properties = null,
+		IEnumerable<ICurrency>? currencies = null)
 	{
 		var gameworld = new Mock<IFuturemud>();
 		var shopCollection = new All<IShop>();
@@ -926,6 +990,12 @@ public class EmploymentWorkerAITests
 		foreach (var stable in stables ?? [])
 		{
 			stableCollection.Add(stable);
+		}
+
+		var clanCollection = new All<IClan>();
+		foreach (var clan in clans ?? [])
+		{
+			clanCollection.Add(clan);
 		}
 
 		var propertyCollection = new All<IProperty>();
@@ -947,6 +1017,7 @@ public class EmploymentWorkerAITests
 		gameworld.SetupGet(x => x.CombatArenas).Returns(new All<ICombatArena>());
 		gameworld.SetupGet(x => x.Banks).Returns(new All<IBank>());
 		gameworld.SetupGet(x => x.Stables).Returns(stableCollection);
+		gameworld.SetupGet(x => x.Clans).Returns(clanCollection);
 		gameworld.SetupGet(x => x.Properties).Returns(propertyCollection);
 		gameworld.SetupGet(x => x.Currencies).Returns(currencyCollection);
 		gameworld.SetupGet(x => x.Tags).Returns(new All<ITag>());

--- a/MudSharpCore Unit Tests/Economy/Employment/UnifiedEmploymentDispatchTests.cs
+++ b/MudSharpCore Unit Tests/Economy/Employment/UnifiedEmploymentDispatchTests.cs
@@ -10,6 +10,7 @@ using MudSharp.Accounts;
 using MudSharp.Arenas;
 using MudSharp.Character;
 using MudSharp.Character.Name;
+using MudSharp.Community;
 using MudSharp.Community.Boards;
 using MudSharp.Construction;
 using MudSharp.Database;
@@ -68,6 +69,26 @@ public class UnifiedEmploymentDispatchTests
 		Assert.IsTrue(typeof(IEmploymentHost).IsAssignableFrom(typeof(Stable)));
 		Assert.IsTrue(typeof(IEmploymentHost).IsAssignableFrom(typeof(IHotel)));
 		Assert.IsTrue(typeof(IEmploymentHost).IsAssignableFrom(typeof(Hotel)));
+		Assert.IsTrue(typeof(IEmploymentHost).IsAssignableFrom(typeof(IClan)));
+		Assert.IsTrue(typeof(IEmploymentHost).IsAssignableFrom(typeof(Clan)));
+		Assert.AreEqual(6, (int)EmploymentHostType.Other);
+		Assert.AreEqual(7, (int)EmploymentHostType.Clan);
+	}
+
+	[TestMethod]
+	public void ClanHallCellEntity_MapsToClanCellJoinTable()
+	{
+		using var context = BuildContext();
+
+		var entityType = context.Model.FindEntityType(typeof(MudSharp.Models.ClanHallCell));
+
+		Assert.IsNotNull(entityType);
+		Assert.AreEqual("Clans_HallCells", entityType!.GetTableName());
+		CollectionAssert.AreEqual(
+			new[] { "ClanId", "CellId" },
+			entityType.FindPrimaryKey()!.Properties.Select(x => x.Name).ToArray());
+		Assert.IsNotNull(entityType.FindNavigation(nameof(MudSharp.Models.ClanHallCell.Clan)));
+		Assert.IsNotNull(entityType.FindNavigation(nameof(MudSharp.Models.ClanHallCell.Cell)));
 	}
 
 	[TestMethod]
@@ -1298,8 +1319,19 @@ public class UnifiedEmploymentDispatchTests
 	{
 		var currency = Currency();
 		var (shop, state) = ShopHost(77, "Central Scheduler Shop", currency.Object, null);
+		var (clan, clanState) = ClanHost(78, "Central Scheduler Clan", currency.Object, null);
+		var (templateClan, templateClanState) = ClanHost(79, "Central Scheduler Clan Template", currency.Object, null);
+		templateClan.SetupGet(x => x.IsTemplate).Returns(true);
 		var manager = Character(77, "Manager").Object;
 		state.Hire(manager, Offer(currency.Object, EmploymentRole.Manager,
+			EmploymentAuthority.CreateScheduledRules |
+			EmploymentAuthority.AssignTasks |
+			EmploymentAuthority.PostToHostBoard), null);
+		clanState.Hire(manager, Offer(currency.Object, EmploymentRole.Manager,
+			EmploymentAuthority.CreateScheduledRules |
+			EmploymentAuthority.AssignTasks |
+			EmploymentAuthority.PostToHostBoard), null);
+		templateClanState.Hire(manager, Offer(currency.Object, EmploymentRole.Manager,
 			EmploymentAuthority.CreateScheduledRules |
 			EmploymentAuthority.AssignTasks |
 			EmploymentAuthority.PostToHostBoard), null);
@@ -1308,19 +1340,33 @@ public class UnifiedEmploymentDispatchTests
 			new EmploymentActionPlan([new BoardPostActionStep("Restock", "Please restock.")]),
 			TimeSpan.Zero,
 			manager);
+		clanState.TaskBoard.CreateScheduledRule("central clan report", "central-clan-report",
+			[],
+			new EmploymentActionPlan([new BoardPostActionStep("Clan", "Please inspect the hall.")]),
+			TimeSpan.Zero,
+			manager);
+		templateClanState.TaskBoard.CreateScheduledRule("central template report", "central-template-report",
+			[],
+			new EmploymentActionPlan([new BoardPostActionStep("Template", "Please inspect the template hall.")]),
+			TimeSpan.Zero,
+			manager);
 		var shops = new All<IShop> { shop.Object };
+		var clans = new All<IClan> { clan.Object, templateClan.Object };
 		var gameworld = new Mock<IFuturemud>();
 		gameworld.SetupGet(x => x.Shops).Returns(shops);
 		gameworld.SetupGet(x => x.AuctionHouses).Returns(new All<IAuctionHouse>());
 		gameworld.SetupGet(x => x.CombatArenas).Returns(new All<ICombatArena>());
 		gameworld.SetupGet(x => x.Banks).Returns(new All<IBank>());
 		gameworld.SetupGet(x => x.Stables).Returns(new All<IStable>());
+		gameworld.SetupGet(x => x.Clans).Returns(clans);
 		gameworld.SetupGet(x => x.Properties).Returns(new All<IProperty>());
 
 		var spawned = EmploymentScheduledRuleEvaluationService.EvaluateAll(gameworld.Object);
 
-		Assert.AreEqual(1, spawned);
+		Assert.AreEqual(2, spawned);
 		Assert.AreEqual(1, state.TaskBoard.ActiveTasks.Count);
+		Assert.AreEqual(1, clanState.TaskBoard.ActiveTasks.Count);
+		Assert.AreEqual(0, templateClanState.TaskBoard.ActiveTasks.Count);
 	}
 
 	[TestMethod]
@@ -1984,6 +2030,118 @@ public class UnifiedEmploymentDispatchTests
 			x.EntryType == EmploymentRegisterEntryType.AuditActionRecorded && x.CorrelationId == task.CorrelationId));
 		Assert.IsTrue(task.StepOperationalStates[2].TransactionReference?.Contains("Source Shop->Target Shop") == true);
 		Assert.IsTrue(task.StepOperationalStates[2].ReservationReference?.Contains("op=consume") == true);
+	}
+
+	[TestMethod]
+	public void EmploymentFinanceSteps_SettlesFundsToClanVirtualTreasury()
+	{
+		VirtualCashLedger.ClearInMemoryForTests();
+		var currency = Currency();
+		var clanBankAccount = BankAccount(currency.Object, 100.0M, id: 9101, accountNumber: 9101,
+			accountName: "clan operating");
+		var (sourceShop, sourceState) = ShopHost(246, "Source Shop", currency.Object, null);
+		var (targetClan, targetState) = ClanHost(247, "Merchant League", currency.Object, clanBankAccount.Object);
+		var gameworld = Gameworld(currency.Object, new Dictionary<long, ICharacter>(),
+			clansToAdd: [targetClan.Object]);
+		sourceShop.As<IHaveFuturemud>().SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		targetClan.As<IHaveFuturemud>().SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		var manager = Character(1, "Manager", gameworld: gameworld.Object).Object;
+		sourceState.Hire(manager, Offer(currency.Object, EmploymentRole.Manager,
+			EmploymentAuthority.AssignTasks |
+			EmploymentAuthority.ApprovePurchases |
+			EmploymentAuthority.ManageStockRules |
+			EmploymentAuthority.SettleHostAccounts), null);
+		VirtualCashLedger.Credit(sourceShop.Object, currency.Object, 25.0M, null, null, "Seed", "Seed balance");
+		var task = sourceState.TaskBoard.CreateActiveTask("clan settlement",
+			new EmploymentActionPlan([
+				new CataloguedActionShellStep("authorise", "clan settlement", new MoneyAmount(currency.Object, 12.0M)),
+				new CataloguedActionShellStep("reserve", "clan settlement", new MoneyAmount(currency.Object, 12.0M)),
+				new HostSettlementActionStep("clan:Merchant League", new MoneyAmount(currency.Object, 12.0M),
+					"settlement-clan-1")
+			]),
+			manager);
+		var dispatcher = new EmploymentTaskDispatcher();
+		var context = new EmploymentTaskContext(sourceShop.Object);
+		var profile = Profile(manager, 1.0M, PaymentMethodKind.Cash,
+			Caps(EmploymentAICapability.CanUseBankAccount));
+
+		Assert.IsTrue(dispatcher.TryAssignTask(task, [profile], context, out var reason), reason);
+		while (task.Status is not EmploymentTaskStatus.Completed and not EmploymentTaskStatus.Failed)
+		{
+			if (task.AssignedEmployee is null)
+			{
+				Assert.IsTrue(dispatcher.TryAssignTask(task, [profile], context, out reason), reason);
+			}
+
+			var result = dispatcher.AdvanceTask(task, context);
+			Assert.IsTrue(result.Success, result.Message);
+		}
+
+		Assert.AreEqual(EmploymentTaskStatus.Completed, task.Status);
+		Assert.AreEqual(13.0M, VirtualCashLedger.Balance(sourceShop.Object, currency.Object));
+		Assert.AreEqual(12.0M, VirtualCashLedger.Balance(targetClan.Object, currency.Object));
+		Assert.AreEqual(100.0M, clanBankAccount.Object.CurrentBalance);
+		Assert.IsTrue(targetState.BusinessLedger.Entries.Any(x =>
+			x.EntryType == EmploymentLedgerEntryType.HostSettlement && x.CorrelationId == task.CorrelationId));
+		Assert.IsTrue(targetState.EmploymentRegister.Entries.Any(x =>
+			x.EntryType == EmploymentRegisterEntryType.AuditActionRecorded && x.CorrelationId == task.CorrelationId));
+		Assert.IsTrue(task.StepOperationalStates[2].TransactionReference?.Contains("Source Shop->Merchant League") == true);
+	}
+
+	[TestMethod]
+	public void EmploymentFinanceSteps_BlocksSettlementToTemplateClan()
+	{
+		VirtualCashLedger.ClearInMemoryForTests();
+		var currency = Currency();
+		var clanBankAccount = BankAccount(currency.Object, 100.0M, id: 9102, accountNumber: 9102,
+			accountName: "template operating");
+		var (sourceShop, sourceState) = ShopHost(248, "Source Template Shop", currency.Object, null);
+		var (templateClan, _) = ClanHost(249, "Template League", currency.Object, clanBankAccount.Object);
+		templateClan.SetupGet(x => x.IsTemplate).Returns(true);
+		var gameworld = Gameworld(currency.Object, new Dictionary<long, ICharacter>(),
+			clansToAdd: [templateClan.Object]);
+		sourceShop.As<IHaveFuturemud>().SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		var manager = Character(1, "Manager", gameworld: gameworld.Object).Object;
+		sourceState.Hire(manager, Offer(currency.Object, EmploymentRole.Manager,
+			EmploymentAuthority.AssignTasks |
+			EmploymentAuthority.ApprovePurchases |
+			EmploymentAuthority.ManageStockRules |
+			EmploymentAuthority.SettleHostAccounts), null);
+		VirtualCashLedger.Credit(sourceShop.Object, currency.Object, 25.0M, null, null, "Seed", "Seed balance");
+		var task = sourceState.TaskBoard.CreateActiveTask("template clan settlement",
+			new EmploymentActionPlan([
+				new CataloguedActionShellStep("authorise", "template settlement", new MoneyAmount(currency.Object, 12.0M)),
+				new CataloguedActionShellStep("reserve", "template settlement", new MoneyAmount(currency.Object, 12.0M)),
+				new HostSettlementActionStep("clan:Template League", new MoneyAmount(currency.Object, 12.0M),
+					"settlement-template-clan-1")
+			]),
+			manager);
+		var dispatcher = new EmploymentTaskDispatcher();
+		var context = new EmploymentTaskContext(sourceShop.Object);
+		var profile = Profile(manager, 1.0M, PaymentMethodKind.Cash,
+			Caps(EmploymentAICapability.CanUseBankAccount));
+
+		Assert.IsTrue(dispatcher.TryAssignTask(task, [profile], context, out var reason), reason);
+		Assert.IsTrue(dispatcher.AdvanceTask(task, context).Success);
+		if (task.AssignedEmployee is null)
+		{
+			Assert.IsTrue(dispatcher.TryAssignTask(task, [profile], context, out reason), reason);
+		}
+
+		Assert.IsTrue(dispatcher.AdvanceTask(task, context).Success);
+		if (task.AssignedEmployee is null)
+		{
+			Assert.IsFalse(dispatcher.TryAssignTask(task, [profile], context, out reason));
+			StringAssert.Contains(reason, "Clan templates cannot be used as employment settlement targets");
+		}
+		else
+		{
+			var result = dispatcher.AdvanceTask(task, context);
+			Assert.IsFalse(result.Success);
+			StringAssert.Contains(result.Message, "Clan templates cannot be used as employment settlement targets");
+		}
+
+		Assert.AreEqual(0.0M, VirtualCashLedger.Balance(templateClan.Object, currency.Object));
 	}
 
 	[TestMethod]
@@ -3255,6 +3413,50 @@ public class UnifiedEmploymentDispatchTests
 		Assert.AreEqual(12.5M, hotel.CashBalance);
 		Assert.AreEqual(20.0M, hotel.AvailableFunds);
 		Assert.IsNotNull(typeof(IProperty).GetProperty(nameof(IProperty.Hotel)));
+	}
+
+	[TestMethod]
+	public void ClanEmploymentLocations_UseAnySharePropertyCellsAndHallCells()
+	{
+		var ownedCell = Cell(130, "guild office").Object;
+		var overlapCell = Cell(131, "shared guild hall").Object;
+		var hallCell = Cell(132, "field headquarters").Object;
+		var unrelatedCell = Cell(133, "private warehouse").Object;
+		var properties = new All<IProperty>();
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.Properties).Returns(properties);
+		var clan = new Mock<IClan>();
+		clan.SetupGet(x => x.Id).Returns(10);
+		clan.SetupGet(x => x.Name).Returns("merchant league");
+		clan.SetupGet(x => x.ClanHallCells).Returns([hallCell, overlapCell]);
+		clan.As<IHaveFuturemud>().SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		var otherClan = new Mock<IClan>();
+		otherClan.SetupGet(x => x.Id).Returns(11);
+		var owner = new Mock<IPropertyOwner>();
+		owner.SetupGet(x => x.Owner).Returns(clan.Object);
+		owner.SetupGet(x => x.ShareOfOwnership).Returns(0.05M);
+		var otherOwner = new Mock<IPropertyOwner>();
+		otherOwner.SetupGet(x => x.Owner).Returns(otherClan.Object);
+		otherOwner.SetupGet(x => x.ShareOfOwnership).Returns(1.0M);
+		var ownedProperty = new Mock<IProperty>();
+		ownedProperty.SetupGet(x => x.Id).Returns(210);
+		ownedProperty.SetupGet(x => x.Name).Returns("guild office property");
+		ownedProperty.SetupGet(x => x.PropertyOwners).Returns([owner.Object]);
+		ownedProperty.SetupGet(x => x.PropertyLocations).Returns([ownedCell, overlapCell]);
+		var unrelatedProperty = new Mock<IProperty>();
+		unrelatedProperty.SetupGet(x => x.Id).Returns(211);
+		unrelatedProperty.SetupGet(x => x.Name).Returns("private warehouse property");
+		unrelatedProperty.SetupGet(x => x.PropertyOwners).Returns([otherOwner.Object]);
+		unrelatedProperty.SetupGet(x => x.PropertyLocations).Returns([unrelatedCell]);
+		properties.Add(ownedProperty.Object);
+		properties.Add(unrelatedProperty.Object);
+
+		var locations = clan.Object.EmploymentHostLocations();
+
+		CollectionAssert.AreEquivalent(
+			new[] { ownedCell.Id, overlapCell.Id, hallCell.Id },
+			locations.Select(x => x.Id).ToArray());
+		Assert.AreEqual(3, locations.Count);
 	}
 
 	[TestMethod]
@@ -5684,6 +5886,36 @@ public class UnifiedEmploymentDispatchTests
 		return (shop, state);
 	}
 
+	private static (Mock<IClan> Clan, IEmploymentHostState State) ClanHost(long id, string name, ICurrency currency,
+		IBankAccount? bankAccount)
+	{
+		var clan = new Mock<IClan>();
+		clan.SetupGet(x => x.Id).Returns(id);
+		clan.SetupGet(x => x.Name).Returns(name);
+		clan.SetupGet(x => x.FullName).Returns(name);
+		clan.SetupGet(x => x.Alias).Returns(name);
+		clan.SetupGet(x => x.Names).Returns([name]);
+		clan.SetupGet(x => x.IsTemplate).Returns(false);
+		clan.SetupGet(x => x.FrameworkItemType).Returns("Clan");
+		clan.SetupGet(x => x.EmploymentHostName).Returns(name);
+		clan.SetupGet(x => x.EmploymentHostType).Returns(EmploymentHostType.Clan);
+		clan.SetupGet(x => x.Market).Returns((IMarket?)null);
+		clan.SetupGet(x => x.ClanBankAccount).Returns(() => bankAccount!);
+		clan.SetupGet(x => x.ClanHallCells).Returns([]);
+		var state = new EmploymentHostState(clan.Object);
+		clan.SetupGet(x => x.Employment).Returns(state);
+		clan.SetupGet(x => x.BusinessLedger).Returns(state.BusinessLedger);
+		clan.SetupGet(x => x.EmploymentRegister).Returns(state.EmploymentRegister);
+		clan.SetupGet(x => x.TaskBoard).Returns(state.TaskBoard);
+		clan.SetupGet(x => x.ManagerGoalBoard).Returns(state.ManagerGoalBoard);
+		clan.SetupGet(x => x.Payroll).Returns(state.Payroll);
+		clan.SetupGet(x => x.EmploymentContracts).Returns(() => state.EmploymentContracts);
+		clan.SetupGet(x => x.JobOpenings).Returns(() => state.JobOpenings);
+		clan.Setup(x => x.HasAuthority(It.IsAny<ICharacter>(), It.IsAny<EmploymentAuthority>()))
+		    .Returns((ICharacter actor, EmploymentAuthority authority) => state.HasAuthority(actor, authority));
+		return (clan, state);
+	}
+
 	private static (Mock<IBank> Bank, IEmploymentHostState State, List<string> Audit) BankHost(long id, string name,
 		ICurrency currency, DecimalCounter<ICurrency>? reserves = null, IEnumerable<IBankAccount>? accounts = null,
 		IEnumerable<ICell>? branches = null, IFuturemud? gameworld = null)
@@ -6146,7 +6378,8 @@ public class UnifiedEmploymentDispatchTests
 		IEnumerable<ICell>? cellsToAdd = null, IReadOnlyDictionary<long, IGameItem>? items = null,
 		IEnumerable<IBankAccount>? bankAccountsToAdd = null, IEnumerable<IShop>? shopsToAdd = null,
 		IEnumerable<ICombatArena>? combatArenasToAdd = null, IEnumerable<IBank>? banksToAdd = null,
-		IEnumerable<IStable>? stablesToAdd = null, IEnumerable<IProperty>? propertiesToAdd = null)
+		IEnumerable<IStable>? stablesToAdd = null, IEnumerable<IClan>? clansToAdd = null,
+		IEnumerable<IProperty>? propertiesToAdd = null)
 	{
 		var boards = new All<IBoard>();
 		var currencies = new All<ICurrency>();
@@ -6176,6 +6409,11 @@ public class UnifiedEmploymentDispatchTests
 		{
 			stables.Add(stable);
 		}
+		var clans = new All<IClan>();
+		foreach (var clan in clansToAdd ?? [])
+		{
+			clans.Add(clan);
+		}
 		var properties = new All<IProperty>();
 		foreach (var property in propertiesToAdd ?? [])
 		{
@@ -6196,6 +6434,7 @@ public class UnifiedEmploymentDispatchTests
 		gameworld.SetupGet(x => x.CombatArenas).Returns(combatArenas);
 		gameworld.SetupGet(x => x.Banks).Returns(banks);
 		gameworld.SetupGet(x => x.Stables).Returns(stables);
+		gameworld.SetupGet(x => x.Clans).Returns(clans);
 		gameworld.SetupGet(x => x.Properties).Returns(properties);
 		gameworld.SetupGet(x => x.Cells).Returns(cells);
 		gameworld.SetupGet(x => x.Calendars).Returns(calendars);

--- a/MudSharpCore/Commands/Helpers/EmploymentCommandService.cs
+++ b/MudSharpCore/Commands/Helpers/EmploymentCommandService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using MudSharp.Arenas;
 using MudSharp.Character;
+using MudSharp.Community;
 using MudSharp.Community.Boards;
 using MudSharp.Economy;
 using MudSharp.Economy.Currency;
@@ -38,7 +39,24 @@ internal sealed class EmploymentHostResolver : IEmploymentHostResolver
 			return null;
 		}
 
-		var host = hostType.CollapseString().ToLowerInvariant() switch
+		var hostTypeKey = hostType.CollapseString().ToLowerInvariant();
+		if (hostTypeKey is "clan" or "organisation" or "organization")
+		{
+			var clan = gameworld.Clans.GetByIdOrName(identifier);
+			if (clan?.IsTemplate == true)
+			{
+				error = $"Clan templates cannot be used as employment hosts: {clan.FullName.ColourName()}.";
+				return null;
+			}
+
+			if (clan is not null)
+			{
+				error = string.Empty;
+				return clan;
+			}
+		}
+
+		var host = hostTypeKey switch
 		{
 			"shop" or "store" => (IEmploymentHost?)gameworld.Shops.GetByIdOrName(identifier),
 			"auction" or "auctionhouse" => (IEmploymentHost?)gameworld.AuctionHouses.GetByIdOrName(identifier),
@@ -2316,9 +2334,16 @@ internal sealed class EmploymentCommandService
 			IBank bank => bank.PrimaryCurrency,
 			IStable stable => stable.Currency,
 			IHotel hotel => hotel.Currency,
-			_ => host.EmploymentContracts.Select(x => x.Compensation.FixedRate?.Currency ?? x.Compensation.MinimumEffectivePay?.Currency)
-			         .FirstOrDefault(x => x is not null)
+			IClan clan => clan.ClanBankAccount?.Currency ?? ResolveContractCurrency(host),
+			_ => ResolveContractCurrency(host)
 		};
+	}
+
+	private static ICurrency? ResolveContractCurrency(IEmploymentHost host)
+	{
+		return host.EmploymentContracts
+		           .Select(x => x.Compensation.FixedRate?.Currency ?? x.Compensation.MinimumEffectivePay?.Currency)
+		           .FirstOrDefault(x => x is not null);
 	}
 
 	private static EmploymentAuthoritySet DefaultOpeningAuthority(EmploymentRole role)
@@ -2874,6 +2899,6 @@ Communication and audit:
 	#3employment <host type> <host> employmentledger|empledger#0 - shows recent employment ledger entries
 	#3employment <host type> <host> board [read <##>|write <title>]#0 - uses the staff communication board
 
-Host types are #3shop#0, #3auction#0, #3arena#0, #3bank#0, #3stable#0, and #3hotel#0. Hotel hosts are resolved by property id or name.
+Host types are #3shop#0, #3auction#0, #3arena#0, #3bank#0, #3stable#0, #3hotel#0, and #3clan#0. Hotel hosts are resolved by property id or name; clan hosts are resolved by clan id, name, full name, or alias.
 Staff boards are only for employee communication; active tasks, scheduled tasks, and manager goals are routed through the employment task board. Use #3tasks actions#0 and #3tasks conditions#0 for the full action and condition catalogues. Item selectors use bare prototype ids, #3*item ids#0 for specific live items, #3&tag#0 for verified tags, and bare text for a visible keyword target. Scheduled-rule drafts can combine conditions with #3and#0, #3or#0, #3not#0, parentheses, numbered condition references such as #3#1#0, and named predicates such as #3@restock-window#0.";
 }

--- a/MudSharpCore/Commands/Helpers/EmploymentTaskAuthoringService.cs
+++ b/MudSharpCore/Commands/Helpers/EmploymentTaskAuthoringService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using MudSharp.Arenas;
 using MudSharp.Character;
+using MudSharp.Community;
 using MudSharp.Construction;
 using MudSharp.Economy;
 using MudSharp.Economy.Currency;
@@ -5461,9 +5462,17 @@ internal sealed class EmploymentTaskAuthoringService
 			IBank bank => bank.PrimaryCurrency,
 			IStable stable => stable.Currency,
 			IHotel hotel => hotel.Currency,
+			IClan clan => clan.ClanBankAccount?.Currency ?? ResolveContractCurrency(host),
 			_ => host.EmploymentContracts.Select(x => x.Compensation.FixedRate?.Currency ?? x.Compensation.MinimumEffectivePay?.Currency)
 			         .FirstOrDefault(x => x is not null)
 		};
+	}
+
+	private static ICurrency? ResolveContractCurrency(IEmploymentHost host)
+	{
+		return host.EmploymentContracts
+		           .Select(x => x.Compensation.FixedRate?.Currency ?? x.Compensation.MinimumEffectivePay?.Currency)
+		           .FirstOrDefault(x => x is not null);
 	}
 
 	private static string DescribeCapabilities(IReadOnlySet<EmploymentAICapability> capabilities)

--- a/MudSharpCore/Commands/Modules/ClanModule.cs
+++ b/MudSharpCore/Commands/Modules/ClanModule.cs
@@ -167,6 +167,7 @@ The following clan sub-commands are used to interact with clans:
 	#3clan treasury <clan> balance|ledger [count]#0 - reviews the clan's virtual treasury
 	#3clan treasury <clan> deposit|withdraw <amount>#0 - moves cash into or out of the clan's virtual treasury
 	#3clan admin <clan>#0 - sets your current location as an admin cell for a clan (ADMIN ONLY)
+	#3clan hall <clan>#0 - sets your current location as a clan hall cell for a clan (ADMIN ONLY)
 	#3clan vassal appoint <who> <clan> <position> [<liege clan>]#0 - appoints a person to a clan appointment in a vassal clan
 	#3clan vassal dismiss <who> <clan> <position> [<liege clan>]#0 - dismisses a person from a clan appointment in a vassal clan
 	#3clan vassal control <clan> <position> <liege appointment|none> [<liege clan>]#0 - sets which liege appointment controls a vassal appointment
@@ -338,6 +339,16 @@ All of the following commands must happen with an edited clan selected:
                 }
 
                 ClanAdministration(actor, ss);
+                return;
+            case "hall":
+            case "clanhall":
+            case "clan hall":
+                if (!actor.IsAdministrator())
+                {
+                    goto default;
+                }
+
+                ClanHall(actor, ss);
                 return;
             case "election":
                 ClanElection(actor, ss);
@@ -3002,6 +3013,9 @@ Your next payday is {3}.
             sb.AppendLine();
             sb.AppendLine(
                 $"Administration Cells:\n{clan.AdministrationCells.Select(x => x.GetFriendlyReference(actor)).DefaultIfEmpty("None").ListToLines(true)}");
+            sb.AppendLine();
+            sb.AppendLine(
+                $"Clan Hall Cells:\n{clan.ClanHallCells.Select(x => x.GetFriendlyReference(actor)).DefaultIfEmpty("None").ListToLines(true)}");
             sb.AppendLine();
         }
 
@@ -7603,6 +7617,36 @@ return 0",
         clan.Changed = true;
         actor.Send(
             $"Your current location is now a administration cell for the {clan.FullName.Colour(Telnet.Green)} clan.");
+    }
+
+    private static void ClanHall(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("For which clan do you want to toggle a clan hall cell?");
+            return;
+        }
+
+        IClan clan = GetTargetClan(actor, command.PopSpeech());
+        if (clan == null)
+        {
+            actor.OutputHandler.Send("There is no such clan.");
+            return;
+        }
+
+        if (clan.ClanHallCells.Contains(actor.Location))
+        {
+            clan.RemoveClanHallCell(actor.Location);
+            clan.Changed = true;
+            actor.Send(
+                $"Your current location is no longer a clan hall cell for the {clan.FullName.Colour(Telnet.Green)} clan.");
+            return;
+        }
+
+        clan.AddClanHallCell(actor.Location);
+        clan.Changed = true;
+        actor.Send(
+            $"Your current location is now a clan hall cell for the {clan.FullName.Colour(Telnet.Green)} clan.");
     }
 
     private static void ClanMaxBackpay(ICharacter actor, StringStack command)

--- a/MudSharpCore/Commands/Modules/ImplementorModule.cs
+++ b/MudSharpCore/Commands/Modules/ImplementorModule.cs
@@ -747,44 +747,7 @@ public class ImplementorModule : Module<ICharacter>
 
     private static IEnumerable<IEmploymentHost> DebugEmploymentHosts(IFuturemud gameworld)
     {
-        foreach (var shop in gameworld.Shops ?? Enumerable.Empty<IShop>())
-        {
-            yield return shop;
-        }
-
-        foreach (var auction in gameworld.AuctionHouses ?? Enumerable.Empty<IAuctionHouse>())
-        {
-            yield return auction;
-        }
-
-        foreach (var arena in gameworld.CombatArenas ?? Enumerable.Empty<ICombatArena>())
-        {
-            yield return arena;
-        }
-
-        foreach (var bank in gameworld.Banks ?? Enumerable.Empty<IBank>())
-        {
-            yield return bank;
-        }
-
-        foreach (var stable in gameworld.Stables ?? Enumerable.Empty<IStable>())
-        {
-            yield return stable;
-        }
-
-        foreach (var property in gameworld.Properties ?? Enumerable.Empty<IProperty>())
-        {
-            if (property is not MudSharp.Economy.Property.Property concreteProperty)
-            {
-                continue;
-            }
-
-            var hotel = concreteProperty.ExistingHotel;
-            if (hotel is not null)
-            {
-                yield return hotel;
-            }
-        }
+        return EmploymentHostDiscovery.LoadedHosts(gameworld);
     }
 
     private static void DebugUnfreezeTime(ICharacter actor)

--- a/MudSharpCore/Community/Clan.CommandHandling.cs
+++ b/MudSharpCore/Community/Clan.CommandHandling.cs
@@ -1523,6 +1523,8 @@ public partial class Clan
 			sb.AppendLine();
 			sb.AppendLine($"Administration Cells:\n{AdministrationCells.Select(x => x.GetFriendlyReference(actor)).DefaultIfEmpty("None").ListToLines(true)}");
 			sb.AppendLine();
+			sb.AppendLine($"Clan Hall Cells:\n{ClanHallCells.Select(x => x.GetFriendlyReference(actor)).DefaultIfEmpty("None").ListToLines(true)}");
+			sb.AppendLine();
 		}
 
 		sb.AppendLine("Ranks:");

--- a/MudSharpCore/Community/Clan.cs
+++ b/MudSharpCore/Community/Clan.cs
@@ -3,6 +3,7 @@ using MudSharp.Character;
 using MudSharp.Construction;
 using MudSharp.Database;
 using MudSharp.Economy;
+using MudSharp.Economy.Employment;
 using MudSharp.Framework;
 using MudSharp.Framework.Save;
 using MudSharp.FutureProg;
@@ -78,7 +79,21 @@ public partial class Clan : SaveableItem, IClan
             _administrationCells.Add(gameCell);
         }
 
+        foreach (ClanHallCell cell in clan.ClansHallCells)
+        {
+            ICell gameCell = gameworld.Cells.Get(cell.CellId);
+            gameCell.CellRequestsDeletion -= ClanHallCellRequestsDeletion;
+            gameCell.CellRequestsDeletion += ClanHallCellRequestsDeletion;
+            _clanHallCells.Add(gameCell);
+        }
+
         DiscordChannelId = clan.DiscordChannelId;
+    }
+
+    private void ClanHallCellRequestsDeletion(object sender, EventArgs e)
+    {
+        _clanHallCells.Remove((ICell)sender);
+        Changed = true;
     }
 
     private void AdminCellRequestsDeletion(object sender, EventArgs e)
@@ -124,6 +139,12 @@ public partial class Clan : SaveableItem, IClan
             foreach (ICell cell in AdministrationCells)
             {
                 clan.ClansAdministrationCells.Add(new Models.ClanAdministrationCell { Clan = clan, CellId = cell.Id });
+            }
+
+            FMDB.Context.ClansHallCells.RemoveRange(clan.ClansHallCells);
+            foreach (ICell cell in ClanHallCells)
+            {
+                clan.ClansHallCells.Add(new Models.ClanHallCell { Clan = clan, CellId = cell.Id });
             }
 
             FMDB.Context.ClansTreasuryCells.RemoveRange(clan.ClansTreasuryCells);
@@ -278,6 +299,9 @@ public partial class Clan : SaveableItem, IClan
     private readonly List<ICell> _administrationCells = new();
     public IEnumerable<ICell> AdministrationCells => _administrationCells;
 
+    private readonly List<ICell> _clanHallCells = new();
+    public IEnumerable<ICell> ClanHallCells => _clanHallCells;
+
     public void AddTreasuryCell(ICell cell)
     {
         _treasuryCells.Add(cell);
@@ -298,6 +322,31 @@ public partial class Clan : SaveableItem, IClan
         _administrationCells.Remove(cell);
         Changed = true;
     }
+    public void AddClanHallCell(ICell cell)
+    {
+        if (_clanHallCells.Contains(cell))
+        {
+            return;
+        }
+
+        cell.CellRequestsDeletion -= ClanHallCellRequestsDeletion;
+        cell.CellRequestsDeletion += ClanHallCellRequestsDeletion;
+        _clanHallCells.Add(cell);
+        Changed = true;
+    }
+    public void RemoveClanHallCell(ICell cell)
+    {
+        if (_clanHallCells.Remove(cell))
+        {
+            cell.CellRequestsDeletion -= ClanHallCellRequestsDeletion;
+            Changed = true;
+        }
+    }
+
+    private IEmploymentHostState _employment;
+    public IEmploymentHostState Employment => _employment ??= EmploymentPersistenceStore.LoadOrCreate(this);
+    public EmploymentHostType EmploymentHostType => MudSharp.Economy.Employment.EmploymentHostType.Clan;
+    public IMarket Market => null;
 
     private long? _clanBankAccountId;
     private IBankAccount _clanBankAccount;

--- a/MudSharpCore/Economy/Employment/EmploymentClock.cs
+++ b/MudSharpCore/Economy/Employment/EmploymentClock.cs
@@ -1,8 +1,11 @@
 using System;
 using System.Globalization;
+using System.Linq;
 using MudSharp.Arenas;
 using MudSharp.Character;
+using MudSharp.Community;
 using MudSharp.Economy.Property;
+using MudSharp.Framework;
 using MudSharp.TimeAndDate;
 using MudSharp.TimeAndDate.Date;
 using MudSharp.TimeAndDate.Time;
@@ -26,8 +29,31 @@ internal static class EmploymentClock
 			IBank bank => bank.EconomicZone,
 			IStable stable => stable.EconomicZone,
 			IHotel hotel => hotel.EconomicZone,
+			IClan clan => ResolveClanEconomicZone(clan),
 			_ => host.Market?.EconomicZone
 		};
+	}
+
+	private static IEconomicZone? ResolveClanEconomicZone(IClan clan)
+	{
+		if (clan is not IHaveFuturemud haveFuturemud)
+		{
+			return null;
+		}
+
+		var gameworld = haveFuturemud.Gameworld;
+		if (gameworld is null)
+		{
+			return null;
+		}
+
+		return (gameworld.EconomicZones ?? Enumerable.Empty<IEconomicZone>())
+		       .FirstOrDefault(x => x.ControllingClan == clan) ??
+		       (gameworld.Properties ?? Enumerable.Empty<IProperty>())
+		       .FirstOrDefault(x =>
+			       x.PropertyOwners.Any(y =>
+				       y.Owner is IClan ownerClan &&
+				       ownerClan.Id == clan.Id))?.EconomicZone;
 	}
 
 	public static DateTimeOffset CurrentInstant(IEmploymentHost host)
@@ -43,6 +69,11 @@ internal static class EmploymentClock
 
 	public static MudDateTime? CurrentDateTime(IEmploymentHost host)
 	{
+		if (host is IClan { Calendar: not null } clan)
+		{
+			return clan.Calendar.CurrentDateTime;
+		}
+
 		return EconomicZone(host)?.FinancialPeriodReferenceCalendar?.CurrentDateTime;
 	}
 
@@ -78,6 +109,21 @@ internal static class EmploymentClock
 
 	public static MudDateTime? ToMudDateTime(IEmploymentHost host, DateTimeOffset instant)
 	{
+		if (host is IClan { Calendar: not null } clan && IsEncodedInstant(instant))
+		{
+			var clock = clan.Calendar.FeedClock;
+			var seconds = Math.Max(0L, (instant.UtcDateTime.Ticks - EncodedEpoch.Ticks) / TimeSpan.TicksPerSecond);
+			return new MudInstant(
+					MudInstant.CurrentEpoch,
+					seconds,
+					clan.Calendar.Id,
+					clock.Id)
+				.ToMudDateTime(
+					clan.Calendar,
+					clock,
+					clock.PrimaryTimezone);
+		}
+
 		var zone = EconomicZone(host);
 		if (zone?.FinancialPeriodReferenceCalendar is null || zone.FinancialPeriodReferenceClock is null ||
 		    !IsEncodedInstant(instant))
@@ -85,10 +131,10 @@ internal static class EmploymentClock
 			return null;
 		}
 
-		var seconds = Math.Max(0L, (instant.UtcDateTime.Ticks - EncodedEpoch.Ticks) / TimeSpan.TicksPerSecond);
+		var zoneSeconds = Math.Max(0L, (instant.UtcDateTime.Ticks - EncodedEpoch.Ticks) / TimeSpan.TicksPerSecond);
 		return new MudInstant(
 				MudInstant.CurrentEpoch,
-				seconds,
+				zoneSeconds,
 				zone.FinancialPeriodReferenceCalendar.Id,
 				zone.FinancialPeriodReferenceClock.Id)
 			.ToMudDateTime(

--- a/MudSharpCore/Economy/Employment/EmploymentFinanceService.cs
+++ b/MudSharpCore/Economy/Employment/EmploymentFinanceService.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using MudSharp.Arenas;
 using MudSharp.Character;
+using MudSharp.Community;
 using MudSharp.Construction;
 using MudSharp.Economy;
 using MudSharp.Economy.Currency;
@@ -1807,6 +1808,26 @@ internal static class EmploymentFinanceService
 
 		var hostType = parts[0].CollapseString().ToLowerInvariant();
 		var identifier = parts[1];
+		if (hostType is "clan" or "organisation" or "organization")
+		{
+			var clan = gameworld.Clans.GetByIdOrName(identifier);
+			if (clan?.IsTemplate == true)
+			{
+				reason = $"Clan templates cannot be used as employment settlement targets: {clan.FullName}.";
+				return false;
+			}
+
+			if (clan is null)
+			{
+				reason = $"There is no {parts[0]} employment host matching {identifier}.";
+				return false;
+			}
+
+			host = clan;
+			reason = string.Empty;
+			return true;
+		}
+
 		IEmploymentHost? resolved = hostType switch
 		{
 			"shop" or "store" => (IEmploymentHost?)gameworld.Shops.GetByIdOrName(identifier),
@@ -1904,6 +1925,20 @@ internal static class EmploymentFinanceService
 			case IBank bank:
 				finance = new FinanceHost(bank, bank.PrimaryCurrency, null);
 				break;
+			case IClan clan:
+				var clanCurrency = clan.ClanBankAccount?.Currency ?? amount?.Currency ?? ResolveContractCurrency(clan);
+				if (clanCurrency is null)
+				{
+					reason =
+						$"{host.EmploymentHostName} does not have a clan bank account or existing contract currency for employment finance.";
+					return false;
+				}
+
+				finance = new FinanceHost(
+					clan,
+					clanCurrency,
+					clan.ClanBankAccount?.Currency == clanCurrency ? clan.ClanBankAccount : null);
+				break;
 			case IHaveCurrency currencyHost:
 				finance = new FinanceHost(host, currencyHost.Currency, null);
 				break;
@@ -1921,6 +1956,13 @@ internal static class EmploymentFinanceService
 
 		reason = string.Empty;
 		return true;
+	}
+
+	private static ICurrency? ResolveContractCurrency(IEmploymentHost host)
+	{
+		return host.EmploymentContracts
+		           .Select(x => x.Compensation.FixedRate?.Currency ?? x.Compensation.MinimumEffectivePay?.Currency)
+		           .FirstOrDefault(x => x is not null);
 	}
 
 	private static decimal AvailableFunds(EmploymentTaskContext context, FinanceHost finance, ICurrency currency)

--- a/MudSharpCore/Economy/Employment/EmploymentHostAccessExtensions.cs
+++ b/MudSharpCore/Economy/Employment/EmploymentHostAccessExtensions.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using MudSharp.Arenas;
 using MudSharp.Character;
+using MudSharp.Community;
 using MudSharp.Construction;
 using MudSharp.Economy;
+using MudSharp.Economy.Property;
 using MudSharp.Framework;
 
 #nullable enable
@@ -122,9 +124,28 @@ public static class EmploymentHostAccessExtensions
 			case IHotel hotel:
 				AddLocations(locations, hotel.Locations);
 				break;
+			case IClan clan:
+				AddClanLocations(locations, clan);
+				break;
 		}
 
 		return locations.DistinctBy(x => x.Id).ToList();
+	}
+
+	private static void AddClanLocations(List<ICell> locations, IClan clan)
+	{
+		if (clan is IHaveFuturemud { Gameworld: not null } haveFuturemud &&
+		    haveFuturemud.Gameworld.Properties is not null)
+		{
+			AddLocations(locations,
+				haveFuturemud.Gameworld.Properties
+				             .Where(x => x.PropertyOwners.Any(y =>
+					             y.Owner is IClan ownerClan &&
+					             ownerClan.Id == clan.Id))
+				             .SelectMany(x => x.PropertyLocations));
+		}
+
+		AddLocations(locations, clan.ClanHallCells);
 	}
 
 	public static IReadOnlyCollection<ICharacter> PresentEmploymentObservers(this IEmploymentHost host)

--- a/MudSharpCore/Economy/Employment/EmploymentHostDiscovery.cs
+++ b/MudSharpCore/Economy/Employment/EmploymentHostDiscovery.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using System.Linq;
+using MudSharp.Arenas;
+using MudSharp.Community;
+using MudSharp.Economy.Property;
+using MudSharp.Framework;
+
+#nullable enable
+
+namespace MudSharp.Economy.Employment;
+
+internal static class EmploymentHostDiscovery
+{
+	public static IEnumerable<IEmploymentHost> LoadedHosts(IFuturemud gameworld)
+	{
+		foreach (var shop in gameworld.Shops ?? Enumerable.Empty<IShop>())
+		{
+			yield return shop;
+		}
+
+		foreach (var auction in gameworld.AuctionHouses ?? Enumerable.Empty<IAuctionHouse>())
+		{
+			yield return auction;
+		}
+
+		foreach (var arena in gameworld.CombatArenas ?? Enumerable.Empty<ICombatArena>())
+		{
+			yield return arena;
+		}
+
+		foreach (var bank in gameworld.Banks ?? Enumerable.Empty<IBank>())
+		{
+			yield return bank;
+		}
+
+		foreach (var stable in gameworld.Stables ?? Enumerable.Empty<IStable>())
+		{
+			yield return stable;
+		}
+
+		foreach (var clan in (gameworld.Clans ?? Enumerable.Empty<IClan>())
+		         .Where(x => !x.IsTemplate))
+		{
+			yield return clan;
+		}
+
+		foreach (var hotel in (gameworld.Properties ?? Enumerable.Empty<IProperty>())
+		                  .OfType<MudSharp.Economy.Property.Property>()
+		                  .Select(x => x.ExistingHotel)
+		                  .Where(x => x is not null)
+		                  .Cast<IHotel>())
+		{
+			yield return hotel;
+		}
+	}
+}

--- a/MudSharpCore/Economy/Employment/EmploymentHostOperationsScheduler.cs
+++ b/MudSharpCore/Economy/Employment/EmploymentHostOperationsScheduler.cs
@@ -95,38 +95,6 @@ public static class EmploymentHostOperationsScheduler
 
 	private static IEnumerable<IEmploymentHost> EmploymentHosts(IFuturemud gameworld)
 	{
-		foreach (var shop in gameworld.Shops ?? Enumerable.Empty<IShop>())
-		{
-			yield return shop;
-		}
-
-		foreach (var auction in gameworld.AuctionHouses ?? Enumerable.Empty<IAuctionHouse>())
-		{
-			yield return auction;
-		}
-
-		foreach (var arena in gameworld.CombatArenas ?? Enumerable.Empty<ICombatArena>())
-		{
-			yield return arena;
-		}
-
-		foreach (var bank in gameworld.Banks ?? Enumerable.Empty<IBank>())
-		{
-			yield return bank;
-		}
-
-		foreach (var stable in gameworld.Stables ?? Enumerable.Empty<IStable>())
-		{
-			yield return stable;
-		}
-
-		foreach (var hotel in (gameworld.Properties ?? Enumerable.Empty<IProperty>())
-		                             .OfType<MudSharp.Economy.Property.Property>()
-		                             .Select(x => x.ExistingHotel)
-		                             .Where(x => x is not null)
-		                             .Cast<IHotel>())
-		{
-			yield return hotel;
-		}
+		return EmploymentHostDiscovery.LoadedHosts(gameworld);
 	}
 }

--- a/MudSharpCore/Economy/Employment/EmploymentLegacyBridgeReporter.cs
+++ b/MudSharpCore/Economy/Employment/EmploymentLegacyBridgeReporter.cs
@@ -191,38 +191,6 @@ public static class EmploymentLegacyBridgeReporter
 
 	private static IEnumerable<IEmploymentHost> EmploymentHosts(IFuturemud gameworld)
 	{
-		foreach (var shop in gameworld.Shops ?? Enumerable.Empty<IShop>())
-		{
-			yield return shop;
-		}
-
-		foreach (var auction in gameworld.AuctionHouses ?? Enumerable.Empty<IAuctionHouse>())
-		{
-			yield return auction;
-		}
-
-		foreach (var arena in gameworld.CombatArenas ?? Enumerable.Empty<ICombatArena>())
-		{
-			yield return arena;
-		}
-
-		foreach (var bank in gameworld.Banks ?? Enumerable.Empty<IBank>())
-		{
-			yield return bank;
-		}
-
-		foreach (var stable in gameworld.Stables ?? Enumerable.Empty<IStable>())
-		{
-			yield return stable;
-		}
-
-		foreach (var hotel in (gameworld.Properties ?? Enumerable.Empty<IProperty>())
-		                  .OfType<MudSharp.Economy.Property.Property>()
-		                  .Select(x => x.ExistingHotel)
-		                  .Where(x => x is not null)
-		                  .Cast<IHotel>())
-		{
-			yield return hotel;
-		}
+		return EmploymentHostDiscovery.LoadedHosts(gameworld);
 	}
 }

--- a/MudSharpCore/Economy/Employment/EmploymentPersistenceStore.cs
+++ b/MudSharpCore/Economy/Employment/EmploymentPersistenceStore.cs
@@ -7,6 +7,7 @@ using System.Text.Json.Serialization;
 using Microsoft.EntityFrameworkCore;
 using MudSharp.Arenas;
 using MudSharp.Character;
+using MudSharp.Community;
 using MudSharp.Community.Boards;
 using MudSharp.Construction;
 using MudSharp.Database;
@@ -1095,7 +1096,7 @@ public sealed class EmploymentPersistenceStore : IEmploymentPersistenceStore
 
 	private static long? ResolveCalendarId(IEmploymentHost host)
 	{
-		return ResolveEconomicZone(host)?.FinancialPeriodReferenceCalendar?.Id;
+		return host is IClan clan ? clan.Calendar?.Id : ResolveEconomicZone(host)?.FinancialPeriodReferenceCalendar?.Id;
 	}
 
 	private static IEconomicZone? ResolveEconomicZone(IEmploymentHost host)
@@ -1108,8 +1109,31 @@ public sealed class EmploymentPersistenceStore : IEmploymentPersistenceStore
 			IBank bank => bank.EconomicZone,
 			IStable stable => stable.EconomicZone,
 			IHotel hotel => hotel.EconomicZone,
+			IClan clan => ResolveClanEconomicZone(clan),
 			_ => null
 		};
+	}
+
+	private static IEconomicZone? ResolveClanEconomicZone(IClan clan)
+	{
+		if (clan is not IHaveFuturemud haveFuturemud)
+		{
+			return null;
+		}
+
+		var gameworld = haveFuturemud.Gameworld;
+		if (gameworld is null)
+		{
+			return null;
+		}
+
+		return (gameworld.EconomicZones ?? Enumerable.Empty<IEconomicZone>())
+		       .FirstOrDefault(x => x.ControllingClan == clan) ??
+		       (gameworld.Properties ?? Enumerable.Empty<IProperty>())
+		       .FirstOrDefault(x =>
+			       x.PropertyOwners.Any(y =>
+				       y.Owner is IClan ownerClan &&
+				       ownerClan.Id == clan.Id))?.EconomicZone;
 	}
 
 	private static IBoard ResolveBoard(FuturemudDatabaseContext context, IFuturemud gameworld, DbHostState state)
@@ -1138,8 +1162,16 @@ public sealed class EmploymentPersistenceStore : IEmploymentPersistenceStore
 			IBank bank => bank.PrimaryCurrency,
 			IStable stable => stable.Currency,
 			IHotel hotel => hotel.Currency,
+			IClan clan => clan.ClanBankAccount?.Currency ?? ResolveContractCurrency(host),
 			_ => null
 		};
+	}
+
+	private static ICurrency? ResolveContractCurrency(IEmploymentHost host)
+	{
+		return host.EmploymentContracts
+		           .Select(x => x.Compensation.FixedRate?.Currency ?? x.Compensation.MinimumEffectivePay?.Currency)
+		           .FirstOrDefault(x => x is not null);
 	}
 
 	private DbContract ToRecord(EmploymentContract contract)

--- a/MudSharpCore/Economy/Employment/EmploymentScheduledRuleEvaluationService.cs
+++ b/MudSharpCore/Economy/Employment/EmploymentScheduledRuleEvaluationService.cs
@@ -75,38 +75,6 @@ public static class EmploymentScheduledRuleEvaluationService
 
 	private static IEnumerable<IEmploymentHost> EmploymentHosts(IFuturemud gameworld)
 	{
-		foreach (var shop in gameworld.Shops)
-		{
-			yield return shop;
-		}
-
-		foreach (var auction in gameworld.AuctionHouses)
-		{
-			yield return auction;
-		}
-
-		foreach (var arena in gameworld.CombatArenas.OfType<ICombatArena>())
-		{
-			yield return arena;
-		}
-
-		foreach (var bank in gameworld.Banks)
-		{
-			yield return bank;
-		}
-
-		foreach (var stable in gameworld.Stables.OfType<IStable>())
-		{
-			yield return stable;
-		}
-
-		foreach (var hotel in gameworld.Properties
-		                             .OfType<MudSharp.Economy.Property.Property>()
-		                             .Select(x => x.ExistingHotel)
-		                             .Where(x => x is not null)
-		                             .Cast<IHotel>())
-		{
-			yield return hotel;
-		}
+		return EmploymentHostDiscovery.LoadedHosts(gameworld);
 	}
 }

--- a/MudSharpCore/Framework/FuturemudLoaders.cs
+++ b/MudSharpCore/Framework/FuturemudLoaders.cs
@@ -3753,6 +3753,7 @@ For information on the syntax to use in emotes (such as those included in bracke
 #endif
         List<Clan> clans = (from clan in FMDB.Context.Clans
                                       .Include(x => x.ClansAdministrationCells)
+                                      .Include(x => x.ClansHallCells)
                                       .Include(x => x.ClansTreasuryCells)
                                       .Include(x => x.Ranks)
                                       .ThenInclude(x => x.RanksAbbreviations)

--- a/MudSharpCore/NPC/AI/EmploymentWorkerAI.cs
+++ b/MudSharpCore/NPC/AI/EmploymentWorkerAI.cs
@@ -1140,50 +1140,14 @@ public class EmploymentWorkerAI : PathingAIBase
 			IBank bank => bank.BranchLocations.FirstOrDefault(),
 			IStable stable => stable.Location,
 			IHotel hotel => hotel.Locations.FirstOrDefault(),
+			MudSharp.Community.IClan clan => clan.EmploymentHostLocations().FirstOrDefault(),
 			_ => null
 		};
 	}
 
 	private static IEnumerable<IEmploymentHost> EmploymentHosts(IFuturemud gameworld)
 	{
-		foreach (var shop in gameworld.Shops ?? Enumerable.Empty<IShop>())
-		{
-			yield return shop;
-		}
-
-		foreach (var auction in gameworld.AuctionHouses ?? Enumerable.Empty<IAuctionHouse>())
-		{
-			yield return auction;
-		}
-
-		foreach (var arena in gameworld.CombatArenas ?? Enumerable.Empty<ICombatArena>())
-		{
-			yield return arena;
-		}
-
-		foreach (var bank in gameworld.Banks ?? Enumerable.Empty<IBank>())
-		{
-			yield return bank;
-		}
-
-		foreach (var stable in gameworld.Stables ?? Enumerable.Empty<IStable>())
-		{
-			yield return stable;
-		}
-
-		foreach (var property in gameworld.Properties ?? Enumerable.Empty<MudSharp.Economy.Property.IProperty>())
-		{
-			if (property is not MudSharp.Economy.Property.Property concreteProperty)
-			{
-				continue;
-			}
-
-			var hotel = concreteProperty.ExistingHotel;
-			if (hotel is not null)
-			{
-				yield return hotel;
-			}
-		}
+		return EmploymentHostDiscovery.LoadedHosts(gameworld);
 	}
 
 	private static bool TryParseHostType(string text, out EmploymentHostType hostType)
@@ -1201,6 +1165,11 @@ public class EmploymentWorkerAI : PathingAIBase
 			case "arena":
 			case "combatarena":
 				hostType = EmploymentHostType.Arena;
+				return true;
+			case "clan":
+			case "organisation":
+			case "organization":
+				hostType = EmploymentHostType.Clan;
 				return true;
 		}
 

--- a/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContext.cs
+++ b/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContext.cs
@@ -189,6 +189,7 @@ namespace MudSharp.Database
         public virtual DbSet<ClanPayrollHistory> ClanPayrollHistories { get; set; }
         public virtual DbSet<Clan> Clans { get; set; }
         public virtual DbSet<ClanAdministrationCell> ClansAdministrationCells { get; set; }
+        public virtual DbSet<ClanHallCell> ClansHallCells { get; set; }
         public virtual DbSet<ClanTreasuryCell> ClansTreasuryCells { get; set; }
         public virtual DbSet<ClimateModel> ClimateModels { get; set; }
         public virtual DbSet<ClimateModelSeason> ClimateModelSeason { get; set; }

--- a/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextConfiguring2.cs
+++ b/MudsharpDatabaseLibrary/Database/FuturemudDatabaseContextConfiguring2.cs
@@ -382,6 +382,31 @@ namespace MudSharp.Database
                     .HasConstraintName("FK_Clans_AdministrationCells_Clans");
             });
 
+            modelBuilder.Entity<ClanHallCell>(entity =>
+            {
+                entity.HasKey(e => new { e.ClanId, e.CellId })
+                    .HasName("PRIMARY");
+
+                entity.ToTable("Clans_HallCells");
+
+                entity.HasIndex(e => e.CellId)
+                    .HasDatabaseName("FK_Clans_HallCells_Cells_idx");
+
+                entity.Property(e => e.ClanId).HasColumnType("bigint(20)");
+
+                entity.Property(e => e.CellId).HasColumnType("bigint(20)");
+
+                entity.HasOne(d => d.Cell)
+                    .WithMany(p => p.ClansHallCells)
+                    .HasForeignKey(d => d.CellId)
+                    .HasConstraintName("FK_Clans_HallCells_Cells");
+
+                entity.HasOne(d => d.Clan)
+                    .WithMany(p => p.ClansHallCells)
+                    .HasForeignKey(d => d.ClanId)
+                    .HasConstraintName("FK_Clans_HallCells_Clans");
+            });
+
             modelBuilder.Entity<ClanTreasuryCell>(entity =>
             {
                 entity.HasKey(e => new { e.ClanId, e.CellId })

--- a/MudsharpDatabaseLibrary/Migrations/20260701122720_ClanHallCellsForEmploymentHosts.Designer.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260701122720_ClanHallCellsForEmploymentHosts.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MudSharp.Database;
 
@@ -11,9 +12,11 @@ using MudSharp.Database;
 namespace MudSharp.Migrations
 {
     [DbContext(typeof(FuturemudDatabaseContext))]
-    partial class FutureMUDContextModelSnapshot : ModelSnapshot
+    [Migration("20260701122720_ClanHallCellsForEmploymentHosts")]
+    partial class ClanHallCellsForEmploymentHosts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MudsharpDatabaseLibrary/Migrations/20260701122720_ClanHallCellsForEmploymentHosts.cs
+++ b/MudsharpDatabaseLibrary/Migrations/20260701122720_ClanHallCellsForEmploymentHosts.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MudSharp.Migrations
+{
+    /// <inheritdoc />
+    public partial class ClanHallCellsForEmploymentHosts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Clans_HallCells",
+                columns: table => new
+                {
+                    ClanId = table.Column<long>(type: "bigint(20)", nullable: false),
+                    CellId = table.Column<long>(type: "bigint(20)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PRIMARY", x => new { x.ClanId, x.CellId });
+                    table.ForeignKey(
+                        name: "FK_Clans_HallCells_Cells",
+                        column: x => x.CellId,
+                        principalTable: "Cells",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_Clans_HallCells_Clans",
+                        column: x => x.ClanId,
+                        principalTable: "Clans",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateIndex(
+                name: "FK_Clans_HallCells_Cells_idx",
+                table: "Clans_HallCells",
+                column: "CellId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Clans_HallCells");
+        }
+    }
+}

--- a/MudsharpDatabaseLibrary/Models/Cell.cs
+++ b/MudsharpDatabaseLibrary/Models/Cell.cs
@@ -18,6 +18,7 @@ namespace MudSharp.Models
             Characters = new HashSet<Character>();
             CharacterInstances = new HashSet<CharacterInstance>();
             ClansAdministrationCells = new HashSet<ClanAdministrationCell>();
+            ClansHallCells = new HashSet<ClanHallCell>();
             ClansTreasuryCells = new HashSet<ClanTreasuryCell>();
             Crimes = new HashSet<Crime>();
             HooksPerceivables = new HashSet<HooksPerceivable>();
@@ -49,6 +50,7 @@ namespace MudSharp.Models
         public virtual ICollection<Character> Characters { get; set; }
         public virtual ICollection<CharacterInstance> CharacterInstances { get; set; }
         public virtual ICollection<ClanAdministrationCell> ClansAdministrationCells { get; set; }
+        public virtual ICollection<ClanHallCell> ClansHallCells { get; set; }
         public virtual ICollection<ClanTreasuryCell> ClansTreasuryCells { get; set; }
         public virtual ICollection<Crime> Crimes { get; set; }
         public virtual ICollection<HooksPerceivable> HooksPerceivables { get; set; }

--- a/MudsharpDatabaseLibrary/Models/Clan.cs
+++ b/MudsharpDatabaseLibrary/Models/Clan.cs
@@ -13,6 +13,7 @@ namespace MudSharp.Models
             ClanBudgets = new HashSet<ClanBudget>();
             ClanPayrollHistories = new HashSet<ClanPayrollHistory>();
             ClansAdministrationCells = new HashSet<ClanAdministrationCell>();
+            ClansHallCells = new HashSet<ClanHallCell>();
             ClansTreasuryCells = new HashSet<ClanTreasuryCell>();
             ExternalClanControlsLiegeClan = new HashSet<ExternalClanControl>();
             ExternalClanControlsVassalClan = new HashSet<ExternalClanControl>();
@@ -56,6 +57,7 @@ namespace MudSharp.Models
         public virtual ICollection<ChargenRolesClanMemberships> ChargenRolesClanMemberships { get; set; }
         public virtual ICollection<ClanMembership> ClanMemberships { get; set; }
         public virtual ICollection<ClanAdministrationCell> ClansAdministrationCells { get; set; }
+        public virtual ICollection<ClanHallCell> ClansHallCells { get; set; }
         public virtual ICollection<ClanTreasuryCell> ClansTreasuryCells { get; set; }
         public virtual ICollection<ExternalClanControl> ExternalClanControlsLiegeClan { get; set; }
         public virtual ICollection<ExternalClanControl> ExternalClanControlsVassalClan { get; set; }

--- a/MudsharpDatabaseLibrary/Models/ClanHallCell.cs
+++ b/MudsharpDatabaseLibrary/Models/ClanHallCell.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+
+namespace MudSharp.Models
+{
+    public partial class ClanHallCell
+    {
+        public long ClanId { get; set; }
+        public long CellId { get; set; }
+
+        public virtual Cell Cell { get; set; }
+        public virtual Clan Clan { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- Add clan-backed employment host discovery, access control, finance, persistence, and scheduled operations.
- Extend clan command handling and implementor-facing commands for employment host management.
- Add the `ClanHallCell` persistence model and migration to support clan hall cells as employment hosts.
- Update the economy design docs to reflect the new runtime and workflow behavior.
- Expand unit coverage for command services, worker AI, and unified employment dispatch.

## Testing
- Added and updated unit tests covering employment command flow, worker AI behavior, and dispatch routing.
- Not run (not requested).