### PR TITLE
Extend NPC templates with load additions across builders, progs, magic, and work systems

### DIFF
--- a/Design Documents/AI/Event_System_for_AI_and_Hooks.md
+++ b/Design Documents/AI/Event_System_for_AI_and_Hooks.md
@@ -259,12 +259,15 @@ Builders attach hooks to targets with:
 
 - `hook install <hook> <target>`
 - `hook remove <hook> <target>`
+- `npc set hook add <hook>` for hooks that should be installed on newly created NPCs from a template
 
 Targets are usually:
 
 - a room (`here`)
 - a character
 - an item
+
+NPC-template hook attachments are not default hooks. They are explicit template load additions and run only when a new NPC is created from that template. The NPC-template builder accepts hooks whose event type is character/NPC-facing, command-input-facing, heartbeat-facing, or `NPCOnGameLoadFinished`; the same check is repeated at load time so drifted or incompatible hooks are skipped with warnings.
 
 ### Default Hooks
 Builders manage installation rules with:

--- a/Design Documents/AI/NPC_AI_and_Group_AI_Runtime.md
+++ b/Design Documents/AI/NPC_AI_and_Group_AI_Runtime.md
@@ -142,6 +142,8 @@ NPC templates persist through `NPCTemplates` rows. In addition to the template `
 
 Blank unique names are treated as unset. Nonblank unique names are trimmed, cannot be entirely numeric, and must be unique case-insensitively among active template revisions: `Current`, `PendingRevision`, and `UnderDesign`. Historical `Rejected`, `Revised`, and `Obsolete` revisions may duplicate them.
 
+The same template `Definition` XML also owns load-time additions that apply only when a new NPC is created from the template. These additions are shared by simple and variable NPC templates and are not part of the general `ICharacterTemplate` contract. Current load-time additions include clan memberships, outfit templates, hooks, bank accounts, implants, and prosthetics.
+
 NPC-template and live-NPC attachment are separate:
 
 - template linkage: `NpcTemplatesArtificalIntelligences`
@@ -219,9 +221,19 @@ Group AI instances subscribe themselves directly on creation/load:
 - `npc set ai add <which>`
 - `npc set ai remove <which>`
 
+`NPCTemplateBase` also stores non-AI load additions that builders manage from the same template-editing surface:
+
+- `npc set clan ...` for clan memberships, paygrades, and appointments
+- `npc set outfit ...` for outfit templates to materialise on load
+- `npc set hook ...` for character/NPC-valid hooks
+- `npc set bank ...` for NPC-owned bank accounts and opening balances
+- `npc set implant ...` and `npc set prosthetic ...` for installed body equipment
+
 NPC-template lookup resolves numeric ids first, exact `UniqueName` second, then legacy name matching. This applies to normal builder surfaces such as `npc show`, `npc edit`, `npc clone`, `npc load`, spawners, magic effects, agriculture herd templates, and craft NPC products.
 
 When a new `NPC` is created from a template, the template's AI list is copied into the NPC's `_AIs` collection. The references still point at shared AI definitions.
+
+Load additions run during new NPC creation after the NPC is registered with the gameworld and before the template `OnLoadProg`, caller-specific on-load progs, and `NPCOnGameLoadFinished`. They do not reapply to already-persisted NPCs during server boot. Builder-time commands validate references where possible, but load-time validation is authoritative so drifted clans, appointments, hooks, outfit templates, account types, item prototypes, or body compatibility are skipped with warnings rather than preventing the NPC from loading.
 
 ### Live NPC Overrides
 Builders can also attach or remove AIs from an already spawned NPC with the `ai add` / `ai remove` builder flow in `NPCBuilderModule`.

--- a/Design Documents/Economy/Economy_System_Workflows_and_Integration.md
+++ b/Design Documents/Economy/Economy_System_Workflows_and_Integration.md
@@ -158,6 +158,8 @@ Current builder-facing bank work includes:
 - attaching open and close permission progs
 - tuning fees, interest, and payment-item limits
 
+NPC templates can create character-owned bank accounts as load-time additions for newly created NPCs. The template stores the account type, optional account name, and opening balance; the live account is created after the NPC has a registered character id. Account-type eligibility progs are checked at load time, and invalid or drifted account types are skipped with warnings. Opening balances are applied as fee-free account credits because they represent authored starting state rather than an in-world deposit transaction.
+
 ### Clan Finance
 Clan finance depends on the clan system plus the bank/property/economic-zone layers. Builders can create or select a clan-owned bank account with `clan set bankaccount <account>`, or clear it with `clan set bankaccount none` and operate from the clan's physical and virtual treasuries.
 

--- a/Design Documents/Items/Item_System_Content_Workflows.md
+++ b/Design Documents/Items/Item_System_Content_Workflows.md
@@ -194,6 +194,10 @@ Important setters:
 
 Template item keys are stable within the template and are used for container references. Prototypes must be current and manually loadable. Worn entries must use wearable prototypes and a valid wear profile. Container entries must point at another template item whose prototype has container capability, and container references must not be cyclic.
 
+NPC templates can reference outfit templates as load-time additions. When a new NPC is created from the template, the outfit template materialises before the NPC template `OnLoadProg`, so scripts and AI can see the created gear. The NPC template stores only the outfit template id and optional created outfit name; item prototype validation and safe placement remain owned by the outfit template materializer.
+
+NPC templates can also create installed implants and prosthetics as load-time body equipment. These entries store template-local keys, current item prototype references, optional target bodyparts, and optional implant power or neural-link keys. At load time the engine creates real item instances, verifies that the created item exposes the expected implant or prosthetic component and is compatible with the NPC body, installs it through the normal body methods, then applies any power or neural links that resolve to installed implants.
+
 ### Extra arguments
 The builder-facing load flow supports:
 - skin selection

--- a/FutureMUDLibrary/NPC/Templates/INPCTemplate.cs
+++ b/FutureMUDLibrary/NPC/Templates/INPCTemplate.cs
@@ -23,6 +23,7 @@ namespace MudSharp.NPC.Templates
         List<IArtificialIntelligence> ArtificialIntelligences { get; }
         ICharacterTemplate GetCharacterTemplate(ICell? cell = null);
         ICharacter CreateNewCharacter(ICell location);
+        IEnumerable<string> ApplyTemplateLoadAdditions(ICharacter character, bool logWarnings = true);
         INPCTemplate Clone(ICharacter builder);
         string ReferenceDescription(IPerceiver voyeur);
     }

--- a/MudSharpCore Unit Tests/NPCTemplateLoadAdditionSourceTests.cs
+++ b/MudSharpCore Unit Tests/NPCTemplateLoadAdditionSourceTests.cs
@@ -1,0 +1,107 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class NPCTemplateLoadAdditionSourceTests
+{
+    [TestMethod]
+    public void NpcTemplateLoadAdditions_AreSharedDefinitionXmlForSimpleAndVariableTemplates()
+    {
+        string baseSource = File.ReadAllText(GetSourcePath("MudSharpCore", "NPC", "Templates",
+            "NPCTemplateBase.LoadAdditions.cs"));
+        string simpleSource = File.ReadAllText(GetSourcePath("MudSharpCore", "NPC", "Templates",
+            "SimpleNPCTemplate.cs"));
+        string variableSource = File.ReadAllText(GetSourcePath("MudSharpCore", "NPC", "Templates",
+            "VariableNPCTemplate.cs"));
+        string interfaceSource = File.ReadAllText(GetSourcePath("FutureMUDLibrary", "NPC", "Templates",
+            "INPCTemplate.cs"));
+
+        StringAssert.Contains(interfaceSource, "ApplyTemplateLoadAdditions");
+        StringAssert.Contains(baseSource, "\"TemplateLoadAdditions\"");
+        StringAssert.Contains(baseSource, "\"ClanMemberships\"");
+        StringAssert.Contains(baseSource, "\"Outfits\"");
+        StringAssert.Contains(baseSource, "\"Hooks\"");
+        StringAssert.Contains(baseSource, "\"BankAccounts\"");
+        StringAssert.Contains(baseSource, "\"BodyLoadout\"");
+        StringAssert.Contains(simpleSource, "SaveTemplateLoadAdditions()");
+        StringAssert.Contains(variableSource, "SaveTemplateLoadAdditions()");
+    }
+
+    [TestMethod]
+    public void NpcTemplateLoadAdditions_ExposeCommonBuilderCommands()
+    {
+        string baseSource = File.ReadAllText(GetSourcePath("MudSharpCore", "NPC", "Templates",
+            "NPCTemplateBase.cs"));
+        string builderSource = File.ReadAllText(GetSourcePath("MudSharpCore", "NPC", "Templates",
+            "NPCTemplateBase.LoadAdditionBuilding.cs"));
+
+        StringAssert.Contains(baseSource, "case \"clan\":");
+        StringAssert.Contains(baseSource, "case \"outfit\":");
+        StringAssert.Contains(baseSource, "case \"hook\":");
+        StringAssert.Contains(baseSource, "case \"bank\":");
+        StringAssert.Contains(baseSource, "case \"implant\":");
+        StringAssert.Contains(baseSource, "case \"prosthetic\":");
+        StringAssert.Contains(builderSource, "BuildingCommandClan");
+        StringAssert.Contains(builderSource, "BuildingCommandOutfit");
+        StringAssert.Contains(builderSource, "BuildingCommandHook");
+        StringAssert.Contains(builderSource, "BuildingCommandBank");
+        StringAssert.Contains(builderSource, "BuildingCommandImplant");
+        StringAssert.Contains(builderSource, "BuildingCommandProsthetic");
+    }
+
+    [TestMethod]
+    public void NpcTemplateLoadAdditions_RunBeforeOnLoadProgInNpcCreationPaths()
+    {
+        AssertApplyBeforeOnLoad("MudSharpCore", "Commands", "Modules", "NPCBuilderModule.cs");
+        AssertApplyBeforeOnLoad("MudSharpCore", "FutureProg", "Functions", "BuiltIn", "LoadNpcFunction.cs");
+        AssertApplyBeforeOnLoad("MudSharpCore", "NPC", "NPCSpawner.cs");
+        AssertApplyBeforeOnLoad("MudSharpCore", "Magic", "SpellEffects", "CreateNPCEffect.cs");
+        AssertApplyBeforeOnLoad("MudSharpCore", "Magic", "SpellEffects", "MagicPhase3Effects.cs");
+        AssertApplyBeforeOnLoad("MudSharpCore", "Work", "Agriculture", "AgricultureField.cs");
+        AssertApplyBeforeOnLoad("MudSharpCore", "Work", "Crafts", "Products", "NPCProduct.cs");
+    }
+
+    [TestMethod]
+    public void NpcTemplateLoadAdditions_KeepPostIdAndDriftValidationRules()
+    {
+        string source = File.ReadAllText(GetSourcePath("MudSharpCore", "NPC", "Templates",
+            "NPCTemplateBase.LoadAdditions.cs"));
+
+        StringAssert.Contains(source, "Gameworld.SaveManager.DirectInitialise(lateItem)");
+        StringAssert.Contains(source, "type.CanOpenAccount(character)");
+        StringAssert.Contains(source, "account.DoAccountCredit");
+        StringAssert.Contains(source, "appointment.IsAppointedByElection");
+        StringAssert.Contains(source, "!clan.FreePosition(appointment)");
+        StringAssert.Contains(source, "HookIsValidForCharacter");
+        StringAssert.Contains(source, "character.Body.InstallImplant(implant)");
+        StringAssert.Contains(source, "character.Body.InstallProsthetic(prosthetic)");
+    }
+
+    private static void AssertApplyBeforeOnLoad(params string[] parts)
+    {
+        string source = File.ReadAllText(GetSourcePath(parts));
+        int applyIndex = source.IndexOf(".ApplyTemplateLoadAdditions", StringComparison.Ordinal);
+        int onLoadIndex = source.IndexOf(".OnLoadProg?.Execute", StringComparison.Ordinal);
+
+        Assert.IsTrue(applyIndex >= 0, $"{parts[^1]} should apply NPC template load additions.");
+        Assert.IsTrue(onLoadIndex >= 0, $"{parts[^1]} should still run the template OnLoadProg.");
+        Assert.IsTrue(applyIndex < onLoadIndex,
+            $"{parts[^1]} should apply NPC template load additions before the template OnLoadProg.");
+    }
+
+    private static string GetSourcePath(params string[] parts)
+    {
+        return Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..",
+            "..",
+            "..",
+            "..",
+            Path.Combine(parts)));
+    }
+}

--- a/MudSharpCore/Commands/Modules/NPCBuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/NPCBuilderModule.cs
@@ -59,6 +59,13 @@ namespace MudSharp.Commands.Modules
             ICharacter newCharacter = template.CreateNewCharacter(character.Location);
             character.Gameworld.Add(newCharacter, true);
             newCharacter.RoomLayer = character.RoomLayer;
+            var warnings = template.ApplyTemplateLoadAdditions(newCharacter, false).ToList();
+            if (warnings.Any())
+            {
+                character.OutputHandler.Send(
+                    $"NPC template load warnings:\n{warnings.Select(x => $"\t{x.ColourError()}").ListToLines()}");
+            }
+
             template.OnLoadProg?.Execute(newCharacter);
 
             if (newCharacter.Location.IsSwimmingLayer(newCharacter.RoomLayer) && newCharacter.Race.CanSwim)

--- a/MudSharpCore/FutureProg/Functions/BuiltIn/LoadNpcFunction.cs
+++ b/MudSharpCore/FutureProg/Functions/BuiltIn/LoadNpcFunction.cs
@@ -85,8 +85,9 @@ internal class LoadNpcFunction : BuiltInFunction
 
         ICharacter npc = proto.CreateNewCharacter(location);
         _gameworld.Add(npc, true);
-        proto.OnLoadProg?.Execute(npc);
         npc.RoomLayer = layer;
+        proto.ApplyTemplateLoadAdditions(npc);
+        proto.OnLoadProg?.Execute(npc);
         location.Login(npc);
         Result = npc;
         return StatementResult.Normal;

--- a/MudSharpCore/Magic/SpellEffects/CreateNPCEffect.cs
+++ b/MudSharpCore/Magic/SpellEffects/CreateNPCEffect.cs
@@ -106,6 +106,7 @@ class CreateNPCEffect : IMagicSpellEffectTemplate
             newCharacter.RoomLayer = caster.RoomLayer;
         }
 
+        template.ApplyTemplateLoadAdditions(newCharacter);
         template.OnLoadProg?.Execute(newCharacter);
         _onLoadProg?.Execute(newCharacter, caster, Spell);
 

--- a/MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs
+++ b/MudSharpCore/Magic/SpellEffects/MagicPhase3Effects.cs
@@ -1167,11 +1167,12 @@ public class CorpseSpawnEffect : IMagicSpellEffectTemplate
 		var cell = item.TrueLocations.FirstOrDefault() ?? caster.Location;
 		if (NPCPrototypeId > 0 && Gameworld.NpcTemplates.Get(NPCPrototypeId) is INPCTemplate template)
 		{
-			var ch = template.CreateNewCharacter(cell);
-			Gameworld.Add(ch, true);
-			ch.RoomLayer = item.RoomLayer;
-			template.OnLoadProg?.Execute(ch);
-			if (ch.Location.IsSwimmingLayer(ch.RoomLayer) && ch.Race.CanSwim)
+            var ch = template.CreateNewCharacter(cell);
+            Gameworld.Add(ch, true);
+            ch.RoomLayer = item.RoomLayer;
+            template.ApplyTemplateLoadAdditions(ch);
+            template.OnLoadProg?.Execute(ch);
+            if (ch.Location.IsSwimmingLayer(ch.RoomLayer) && ch.Race.CanSwim)
 			{
 				ch.PositionState = PositionSwimming.Instance;
 			}

--- a/MudSharpCore/NPC/NPCSpawner.cs
+++ b/MudSharpCore/NPC/NPCSpawner.cs
@@ -635,6 +635,7 @@ Note that the #6Multi#0 strategy has additional building commands:
         chTemplate = ((SimpleCharacterTemplate)chTemplate) with { SelectedStartingLocation = location };
         NPC newCharacter = new(Gameworld, chTemplate, npcTemplate);
         Gameworld.Add(newCharacter, true);
+        npcTemplate.ApplyTemplateLoadAdditions(newCharacter);
         OnSpawnProg?.Execute(newCharacter);
         npcTemplate.OnLoadProg?.Execute(newCharacter);
 

--- a/MudSharpCore/NPC/Templates/NPCTemplateBase.LoadAdditionBuilding.cs
+++ b/MudSharpCore/NPC/Templates/NPCTemplateBase.LoadAdditionBuilding.cs
@@ -1,0 +1,843 @@
+using MudSharp.Character;
+using MudSharp.Community;
+using MudSharp.Economy;
+using MudSharp.Events.Hooks;
+using MudSharp.Framework;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Prototypes;
+using System;
+using System.Globalization;
+using System.Linq;
+
+#nullable enable
+#nullable disable warnings
+
+namespace MudSharp.NPC.Templates;
+
+public abstract partial class NPCTemplateBase
+{
+    private bool BuildingCommandClan(ICharacter actor, StringStack command)
+    {
+        switch (command.PopSpeech().ToLowerInvariant())
+        {
+            case "add":
+                return BuildingCommandClanAdd(actor, command);
+            case "remove":
+            case "delete":
+            case "rem":
+                return BuildingCommandClanRemove(actor, command);
+            case "paygrade":
+                return BuildingCommandClanPaygrade(actor, command);
+            case "appointment":
+            case "appt":
+                return BuildingCommandClanAppointment(actor, command);
+            case "list":
+            case "":
+                actor.OutputHandler.Send(ShowTemplateLoadAdditions(actor));
+                return true;
+            default:
+                actor.OutputHandler.Send("You can use #3clan add#0, #3clan remove#0, #3clan paygrade#0 or #3clan appointment#0.".SubstituteANSIColour());
+                return false;
+        }
+    }
+
+    private bool BuildingCommandClanAdd(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which clan do you want to add to this NPC template?");
+            return false;
+        }
+
+        var clan = Gameworld.Clans.GetByIdOrName(command.PopSpeech());
+        if (clan is null)
+        {
+            actor.OutputHandler.Send("There is no such clan.");
+            return false;
+        }
+
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which rank should this NPC have in that clan?");
+            return false;
+        }
+
+        var rank = clan.Ranks.GetByIdOrName(command.PopSpeech());
+        if (rank is null)
+        {
+            actor.OutputHandler.Send($"The {clan.FullName.ColourName()} clan has no such rank.");
+            return false;
+        }
+
+        IPaygrade? paygrade = null;
+        if (!command.IsFinished)
+        {
+            var token = command.PopSpeech();
+            if (!token.EqualTo("paygrade"))
+            {
+                actor.OutputHandler.Send("The only optional clan membership argument is #3paygrade <paygrade>#0.".SubstituteANSIColour());
+                return false;
+            }
+
+            if (command.IsFinished)
+            {
+                actor.OutputHandler.Send("Which paygrade do you want to use?");
+                return false;
+            }
+
+            paygrade = clan.Paygrades.GetByIdOrName(command.PopSpeech());
+            if (paygrade is null)
+            {
+                actor.OutputHandler.Send($"The {clan.FullName.ColourName()} clan has no such paygrade.");
+                return false;
+            }
+
+            if (!rank.Paygrades.Contains(paygrade))
+            {
+                actor.OutputHandler.Send($"The {paygrade.Name.ColourName()} paygrade is not valid for the {rank.Name.ColourName()} rank.");
+                return false;
+            }
+        }
+
+        _templateClanMemberships.RemoveAll(x => x.ClanId == clan.Id);
+        _templateClanMemberships.Add(new TemplateClanMembership
+        {
+            ClanId = clan.Id,
+            RankId = rank.Id,
+            PaygradeId = paygrade?.Id
+        });
+        Changed = true;
+        actor.OutputHandler.Send(
+            $"This NPC template will now load with membership in {clan.FullName.ColourName()} as {rank.Name.TitleCase().ColourValue()}{(paygrade is null ? string.Empty : $" on paygrade {paygrade.Name.TitleCase().ColourValue()}")}.");
+        return true;
+    }
+
+    private bool BuildingCommandClanRemove(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which clan membership do you want to remove from this NPC template?");
+            return false;
+        }
+
+        var clan = Gameworld.Clans.GetByIdOrName(command.SafeRemainingArgument);
+        if (clan is null)
+        {
+            actor.OutputHandler.Send("There is no such clan.");
+            return false;
+        }
+
+        if (_templateClanMemberships.RemoveAll(x => x.ClanId == clan.Id) == 0)
+        {
+            actor.OutputHandler.Send("This NPC template does not have a load-time membership for that clan.");
+            return false;
+        }
+
+        Changed = true;
+        actor.OutputHandler.Send($"This NPC template no longer loads with membership in {clan.FullName.ColourName()}.");
+        return true;
+    }
+
+    private bool BuildingCommandClanPaygrade(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which clan membership do you want to change the paygrade for?");
+            return false;
+        }
+
+        var clan = Gameworld.Clans.GetByIdOrName(command.PopSpeech());
+        if (clan is null)
+        {
+            actor.OutputHandler.Send("There is no such clan.");
+            return false;
+        }
+
+        var membership = _templateClanMemberships.FirstOrDefault(x => x.ClanId == clan.Id);
+        if (membership is null)
+        {
+            actor.OutputHandler.Send("This NPC template does not have a load-time membership for that clan.");
+            return false;
+        }
+
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which paygrade do you want to use, or #3none#0 to clear it?".SubstituteANSIColour());
+            return false;
+        }
+
+        if (command.SafeRemainingArgument.EqualToAny("none", "clear", "remove"))
+        {
+            membership.PaygradeId = null;
+            Changed = true;
+            actor.OutputHandler.Send($"This NPC template no longer specifies a paygrade for {clan.FullName.ColourName()}.");
+            return true;
+        }
+
+        var paygrade = clan.Paygrades.GetByIdOrName(command.SafeRemainingArgument);
+        if (paygrade is null)
+        {
+            actor.OutputHandler.Send($"The {clan.FullName.ColourName()} clan has no such paygrade.");
+            return false;
+        }
+
+        var rank = clan.Ranks.FirstOrDefault(x => x.Id == membership.RankId);
+        if (rank is null)
+        {
+            actor.OutputHandler.Send(
+                $"This NPC template's stored rank for {clan.FullName.ColourName()} no longer exists. Use #3clan add {clan.Name} <rank>#0 to reset the membership.".SubstituteANSIColour());
+            return false;
+        }
+
+        if (!rank.Paygrades.Contains(paygrade))
+        {
+            actor.OutputHandler.Send($"The {paygrade.Name.ColourName()} paygrade is not valid for the {rank.Name.ColourName()} rank.");
+            return false;
+        }
+
+        membership.PaygradeId = paygrade.Id;
+        Changed = true;
+        actor.OutputHandler.Send($"This NPC template will use the {paygrade.Name.ColourName()} paygrade for {clan.FullName.ColourName()}.");
+        return true;
+    }
+
+    private bool BuildingCommandClanAppointment(ICharacter actor, StringStack command)
+    {
+        var action = command.PopSpeech();
+        var add = action.EqualTo("add");
+        if (!add && !action.EqualToAny("remove", "delete", "rem"))
+        {
+            actor.OutputHandler.Send("Do you want to #3add#0 or #3remove#0 a clan appointment?".SubstituteANSIColour());
+            return false;
+        }
+
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which clan membership is the appointment for?");
+            return false;
+        }
+
+        var clan = Gameworld.Clans.GetByIdOrName(command.PopSpeech());
+        if (clan is null)
+        {
+            actor.OutputHandler.Send("There is no such clan.");
+            return false;
+        }
+
+        var membership = _templateClanMemberships.FirstOrDefault(x => x.ClanId == clan.Id);
+        if (membership is null)
+        {
+            actor.OutputHandler.Send("This NPC template does not have a load-time membership for that clan.");
+            return false;
+        }
+
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which appointment do you want to change?");
+            return false;
+        }
+
+        var appointment = clan.Appointments.GetByIdOrName(command.SafeRemainingArgument);
+        if (appointment is null)
+        {
+            actor.OutputHandler.Send($"The {clan.FullName.ColourName()} clan has no such appointment.");
+            return false;
+        }
+
+        if (add)
+        {
+            if (membership.AppointmentIds.Contains(appointment.Id))
+            {
+                actor.OutputHandler.Send("This NPC template already includes that appointment.");
+                return false;
+            }
+
+            membership.AppointmentIds.Add(appointment.Id);
+            Changed = true;
+            actor.OutputHandler.Send($"This NPC template will try to load with the {appointment.Name.ColourName()} appointment.");
+            return true;
+        }
+
+        if (!membership.AppointmentIds.Remove(appointment.Id))
+        {
+            actor.OutputHandler.Send("This NPC template does not include that appointment.");
+            return false;
+        }
+
+        Changed = true;
+        actor.OutputHandler.Send($"This NPC template will no longer try to load with the {appointment.Name.ColourName()} appointment.");
+        return true;
+    }
+
+    private bool BuildingCommandOutfit(ICharacter actor, StringStack command)
+    {
+        var action = command.PopSpeech();
+        switch (action.ToLowerInvariant())
+        {
+            case "add":
+                return BuildingCommandOutfitAdd(actor, command);
+            case "remove":
+            case "delete":
+            case "rem":
+                return BuildingCommandOutfitRemove(actor, command);
+            case "list":
+            case "":
+                actor.OutputHandler.Send(ShowTemplateLoadAdditions(actor));
+                return true;
+            default:
+                actor.OutputHandler.Send("You can use #3outfit add <template> [name <name>]#0 or #3outfit remove <template|#>#0.".SubstituteANSIColour());
+                return false;
+        }
+    }
+
+    private bool BuildingCommandOutfitAdd(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which outfit template should be materialised when this NPC loads?");
+            return false;
+        }
+
+        var outfit = Gameworld.OutfitTemplates.GetByIdOrName(command.PopSpeech());
+        if (outfit is null)
+        {
+            actor.OutputHandler.Send("There is no such outfit template.");
+            return false;
+        }
+
+        if (_templateOutfits.Any(x => x.OutfitTemplateId == outfit.Id))
+        {
+            actor.OutputHandler.Send("This NPC template already includes that outfit template.");
+            return false;
+        }
+
+        string? name = null;
+        if (!command.IsFinished)
+        {
+            var token = command.PopSpeech();
+            if (!token.EqualTo("name") || command.IsFinished)
+            {
+                actor.OutputHandler.Send("The optional outfit argument is #3name <created outfit name>#0.".SubstituteANSIColour());
+                return false;
+            }
+
+            name = command.SafeRemainingArgument;
+        }
+
+        _templateOutfits.Add(new TemplateOutfitLoad { OutfitTemplateId = outfit.Id, OutfitName = NullIfBlank(name) });
+        Changed = true;
+        actor.OutputHandler.Send($"This NPC template will materialise {$"{outfit.Name} (#{outfit.Id:N0})".ColourName()} when loaded.");
+        return true;
+    }
+
+    private bool BuildingCommandOutfitRemove(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which outfit template do you want to remove?");
+            return false;
+        }
+
+        TemplateOutfitLoad? outfit = null;
+        if (int.TryParse(command.SafeRemainingArgument, out var index) && index >= 1 && index <= _templateOutfits.Count)
+        {
+            outfit = _templateOutfits[index - 1];
+        }
+        else
+        {
+            var template = Gameworld.OutfitTemplates.GetByIdOrName(command.SafeRemainingArgument);
+            if (template is not null)
+            {
+                outfit = _templateOutfits.FirstOrDefault(x => x.OutfitTemplateId == template.Id);
+            }
+        }
+
+        if (outfit is null)
+        {
+            actor.OutputHandler.Send("This NPC template does not include that outfit template.");
+            return false;
+        }
+
+        _templateOutfits.Remove(outfit);
+        Changed = true;
+        actor.OutputHandler.Send("This NPC template will no longer materialise that outfit template when loaded.");
+        return true;
+    }
+
+    private bool BuildingCommandHook(ICharacter actor, StringStack command)
+    {
+        var action = command.PopSpeech();
+        var add = action.EqualTo("add");
+        if (!add && !action.EqualToAny("remove", "delete", "rem"))
+        {
+            actor.OutputHandler.Send("Do you want to #3add#0 or #3remove#0 a hook?".SubstituteANSIColour());
+            return false;
+        }
+
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which hook do you want to change?");
+            return false;
+        }
+
+        var hook = Gameworld.Hooks.GetByIdOrName(command.SafeRemainingArgument);
+        if (hook is null)
+        {
+            actor.OutputHandler.Send("There is no such hook.");
+            return false;
+        }
+
+        if (add)
+        {
+            if (!HookIsValidForCharacter(hook))
+            {
+                actor.OutputHandler.Send("That hook is not valid for character/NPC installation.");
+                return false;
+            }
+
+            if (_templateHookIds.Contains(hook.Id))
+            {
+                actor.OutputHandler.Send("This NPC template already includes that hook.");
+                return false;
+            }
+
+            _templateHookIds.Add(hook.Id);
+            Changed = true;
+            actor.OutputHandler.Send($"This NPC template will install the {hook.Name.ColourName()} hook when loaded.");
+            return true;
+        }
+
+        if (!_templateHookIds.Remove(hook.Id))
+        {
+            actor.OutputHandler.Send("This NPC template does not include that hook.");
+            return false;
+        }
+
+        Changed = true;
+        actor.OutputHandler.Send($"This NPC template will no longer install the {hook.Name.ColourName()} hook when loaded.");
+        return true;
+    }
+
+    private bool BuildingCommandBank(ICharacter actor, StringStack command)
+    {
+        switch (command.PopSpeech().ToLowerInvariant())
+        {
+            case "add":
+                return BuildingCommandBankAdd(actor, command);
+            case "remove":
+            case "delete":
+            case "rem":
+                return BuildingCommandBankRemove(actor, command);
+            case "name":
+                return BuildingCommandBankName(actor, command);
+            case "balance":
+                return BuildingCommandBankBalance(actor, command);
+            case "list":
+            case "":
+                actor.OutputHandler.Send(ShowTemplateLoadAdditions(actor));
+                return true;
+            default:
+                actor.OutputHandler.Send("You can use #3bank add#0, #3bank remove#0, #3bank name#0 or #3bank balance#0.".SubstituteANSIColour());
+                return false;
+        }
+    }
+
+    private bool BuildingCommandBankAdd(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which bank account type should be created when this NPC loads?");
+            return false;
+        }
+
+        var type = Gameworld.BankAccountTypes.GetByIdOrName(command.PopSpeech());
+        if (type is null)
+        {
+            actor.OutputHandler.Send("There is no such bank account type.");
+            return false;
+        }
+
+        var account = new TemplateBankAccount { BankAccountTypeId = type.Id };
+        while (!command.IsFinished)
+        {
+            var token = command.PopSpeech();
+            if (token.EqualTo("balance"))
+            {
+                if (command.IsFinished || !decimal.TryParse(command.PopSpeech(), NumberStyles.Number,
+                        actor, out var balance))
+                {
+                    actor.OutputHandler.Send("You must specify a valid opening balance.");
+                    return false;
+                }
+
+                account.OpeningBalance = balance;
+                continue;
+            }
+
+            if (token.EqualTo("name"))
+            {
+                if (command.IsFinished)
+                {
+                    actor.OutputHandler.Send("What account name do you want to use?");
+                    return false;
+                }
+
+                account.Name = command.SafeRemainingArgument;
+                break;
+            }
+
+            actor.OutputHandler.Send("Bank account options are #3balance <amount>#0 and #3name <account name>#0.".SubstituteANSIColour());
+            return false;
+        }
+
+        _templateBankAccounts.Add(account);
+        Changed = true;
+        actor.OutputHandler.Send($"This NPC template will create a {type.Name.ColourName()} bank account when loaded.");
+        return true;
+    }
+
+    private bool BuildingCommandBankRemove(ICharacter actor, StringStack command)
+    {
+        var account = GetTemplateBankAccount(actor, command);
+        if (account is null)
+        {
+            return false;
+        }
+
+        _templateBankAccounts.Remove(account);
+        Changed = true;
+        actor.OutputHandler.Send("This NPC template will no longer create that bank account.");
+        return true;
+    }
+
+    private bool BuildingCommandBankName(ICharacter actor, StringStack command)
+    {
+        var account = GetTemplateBankAccount(actor, command);
+        if (account is null)
+        {
+            return false;
+        }
+
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("What account name do you want to use, or #3none#0 to clear it?".SubstituteANSIColour());
+            return false;
+        }
+
+        account.Name = command.SafeRemainingArgument.EqualToAny("none", "clear", "remove")
+            ? null
+            : command.SafeRemainingArgument;
+        Changed = true;
+        actor.OutputHandler.Send("You update the created account name for this NPC template.");
+        return true;
+    }
+
+    private bool BuildingCommandBankBalance(ICharacter actor, StringStack command)
+    {
+        var account = GetTemplateBankAccount(actor, command);
+        if (account is null)
+        {
+            return false;
+        }
+
+        if (command.IsFinished || !decimal.TryParse(command.PopSpeech(), NumberStyles.Number, actor, out var balance))
+        {
+            actor.OutputHandler.Send("What opening balance should this account have?");
+            return false;
+        }
+
+        account.OpeningBalance = balance;
+        Changed = true;
+        actor.OutputHandler.Send($"This NPC template will credit that account with {balance.ToString("N2", actor).ColourValue()} when loaded.");
+        return true;
+    }
+
+    private TemplateBankAccount? GetTemplateBankAccount(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which bank account entry do you want to change?");
+            return null;
+        }
+
+        var text = command.PopSpeech();
+        if (int.TryParse(text, out var index) && index >= 1 && index <= _templateBankAccounts.Count)
+        {
+            return _templateBankAccounts[index - 1];
+        }
+
+        var type = Gameworld.BankAccountTypes.GetByIdOrName(text);
+        if (type is null)
+        {
+            actor.OutputHandler.Send("There is no such bank account type or entry number.");
+            return null;
+        }
+
+        var matches = _templateBankAccounts
+                      .Where(x => x.BankAccountTypeId == type.Id)
+                      .ToList();
+        if (matches.Count > 1)
+        {
+            actor.OutputHandler.Send(
+                $"This NPC template creates multiple {type.Name.ColourName()} bank accounts. Please use the entry number from #3bank list#0.".SubstituteANSIColour());
+            return null;
+        }
+
+        var account = matches.FirstOrDefault();
+        if (account is null)
+        {
+            actor.OutputHandler.Send("This NPC template does not create that bank account type.");
+        }
+
+        return account;
+    }
+
+    private bool BuildingCommandImplant(ICharacter actor, StringStack command)
+    {
+        switch (command.PopSpeech().ToLowerInvariant())
+        {
+            case "add":
+                return BuildingCommandBodyItemAdd(actor, command, TemplateBodyItemType.Implant);
+            case "remove":
+            case "delete":
+            case "rem":
+                return BuildingCommandBodyItemRemove(actor, command, TemplateBodyItemType.Implant);
+            case "power":
+                return BuildingCommandImplantPower(actor, command);
+            case "neural":
+            case "control":
+            case "link":
+                return BuildingCommandImplantNeural(actor, command);
+            case "list":
+            case "":
+                actor.OutputHandler.Send(ShowTemplateLoadAdditions(actor));
+                return true;
+            default:
+                actor.OutputHandler.Send("You can use #3implant add#0, #3implant remove#0, #3implant power#0 or #3implant neural#0.".SubstituteANSIColour());
+                return false;
+        }
+    }
+
+    private bool BuildingCommandProsthetic(ICharacter actor, StringStack command)
+    {
+        switch (command.PopSpeech().ToLowerInvariant())
+        {
+            case "add":
+                return BuildingCommandBodyItemAdd(actor, command, TemplateBodyItemType.Prosthetic);
+            case "remove":
+            case "delete":
+            case "rem":
+                return BuildingCommandBodyItemRemove(actor, command, TemplateBodyItemType.Prosthetic);
+            case "list":
+            case "":
+                actor.OutputHandler.Send(ShowTemplateLoadAdditions(actor));
+                return true;
+            default:
+                actor.OutputHandler.Send("You can use #3prosthetic add <key> <proto> [bodypart <part>]#0 or #3prosthetic remove <key>#0.".SubstituteANSIColour());
+                return false;
+        }
+    }
+
+    private bool BuildingCommandBodyItemAdd(ICharacter actor, StringStack command, TemplateBodyItemType type)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send($"What template-local key should this {type.DescribeEnum().ToLowerInvariant()} use?");
+            return false;
+        }
+
+        var key = command.PopSpeech();
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            actor.OutputHandler.Send("The key cannot be blank.");
+            return false;
+        }
+
+        if (_templateBodyItems.Any(x => x.Key.EqualTo(key)))
+        {
+            actor.OutputHandler.Send("This NPC template already has a body loadout item with that key.");
+            return false;
+        }
+
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which item prototype should be created?");
+            return false;
+        }
+
+        var proto = Gameworld.ItemProtos.GetByIdOrUniqueNameOrName(command.PopSpeech());
+        if (proto is null)
+        {
+            actor.OutputHandler.Send("There is no such item prototype.");
+            return false;
+        }
+
+        if (type == TemplateBodyItemType.Implant && proto.Components.All(x => x is not IImplantPrototype))
+        {
+            actor.OutputHandler.Send("That item prototype does not have an implant component.");
+            return false;
+        }
+
+        if (type == TemplateBodyItemType.Prosthetic && proto.Components.All(x => x is not IProstheticPrototype))
+        {
+            actor.OutputHandler.Send("That item prototype does not have a prosthetic component.");
+            return false;
+        }
+
+        long? bodypartId = null;
+        if (!command.IsFinished)
+        {
+            var token = command.PopSpeech();
+            if (!token.EqualTo("bodypart") || command.IsFinished)
+            {
+                actor.OutputHandler.Send("The optional body loadout argument is #3bodypart <part>#0.".SubstituteANSIColour());
+                return false;
+            }
+
+            var bodypart = Gameworld.BodypartPrototypes.GetByIdOrName(command.SafeRemainingArgument);
+            if (bodypart is null)
+            {
+                actor.OutputHandler.Send("There is no such bodypart.");
+                return false;
+            }
+
+            bodypartId = bodypart.Id;
+        }
+
+        _templateBodyItems.Add(new TemplateBodyItem
+        {
+            Type = type,
+            Key = key,
+            ItemProtoId = proto.Id,
+            BodypartId = bodypartId
+        });
+        Changed = true;
+        actor.OutputHandler.Send($"This NPC template will create and install {proto.EditHeader().ColourName()} as {key.ColourCommand()} when loaded.");
+        return true;
+    }
+
+    private bool BuildingCommandBodyItemRemove(ICharacter actor, StringStack command, TemplateBodyItemType type)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which body loadout key do you want to remove?");
+            return false;
+        }
+
+        var key = command.SafeRemainingArgument;
+        var item = _templateBodyItems.FirstOrDefault(x => x.Type == type && x.Key.EqualTo(key));
+        if (item is null)
+        {
+            actor.OutputHandler.Send("This NPC template does not have such a body loadout item.");
+            return false;
+        }
+
+        _templateBodyItems.Remove(item);
+        foreach (var implant in _templateBodyItems.Where(x => x.Type == TemplateBodyItemType.Implant))
+        {
+            if (implant.PowerSourceKey.EqualTo(key))
+            {
+                implant.PowerSourceKey = null;
+            }
+
+            if (implant.NeuralLinkKey.EqualTo(key))
+            {
+                implant.NeuralLinkKey = null;
+            }
+        }
+
+        Changed = true;
+        actor.OutputHandler.Send($"This NPC template will no longer create the {key.ColourCommand()} body loadout item.");
+        return true;
+    }
+
+    private bool BuildingCommandImplantPower(ICharacter actor, StringStack command)
+    {
+        var item = GetTemplateImplant(actor, command);
+        if (item is null)
+        {
+            return false;
+        }
+
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which implant key should power this implant, or #3none#0 to clear it?".SubstituteANSIColour());
+            return false;
+        }
+
+        var powerKey = command.SafeRemainingArgument;
+        if (powerKey.EqualToAny("none", "clear", "remove"))
+        {
+            item.PowerSourceKey = null;
+            Changed = true;
+            actor.OutputHandler.Send($"The {item.Key.ColourCommand()} implant will no longer configure a power source.");
+            return true;
+        }
+
+        var power = _templateBodyItems.FirstOrDefault(x => x.Type == TemplateBodyItemType.Implant && x.Key.EqualTo(powerKey));
+        if (power is null)
+        {
+            actor.OutputHandler.Send("There is no implant body loadout item with that key.");
+            return false;
+        }
+
+        item.PowerSourceKey = power.Key;
+        Changed = true;
+        actor.OutputHandler.Send($"The {item.Key.ColourCommand()} implant will try to use {power.Key.ColourCommand()} as its power source.");
+        return true;
+    }
+
+    private bool BuildingCommandImplantNeural(ICharacter actor, StringStack command)
+    {
+        var item = GetTemplateImplant(actor, command);
+        if (item is null)
+        {
+            return false;
+        }
+
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which neural implant key should control this implant, or #3none#0 to clear it?".SubstituteANSIColour());
+            return false;
+        }
+
+        var neuralKey = command.SafeRemainingArgument;
+        if (neuralKey.EqualToAny("none", "clear", "remove"))
+        {
+            item.NeuralLinkKey = null;
+            Changed = true;
+            actor.OutputHandler.Send($"The {item.Key.ColourCommand()} implant will no longer configure a neural link.");
+            return true;
+        }
+
+        var neural = _templateBodyItems.FirstOrDefault(x => x.Type == TemplateBodyItemType.Implant && x.Key.EqualTo(neuralKey));
+        if (neural is null)
+        {
+            actor.OutputHandler.Send("There is no implant body loadout item with that key.");
+            return false;
+        }
+
+        item.NeuralLinkKey = neural.Key;
+        Changed = true;
+        actor.OutputHandler.Send($"The {item.Key.ColourCommand()} implant will try to link to {neural.Key.ColourCommand()}.");
+        return true;
+    }
+
+    private TemplateBodyItem? GetTemplateImplant(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which implant body loadout key do you want to change?");
+            return null;
+        }
+
+        var key = command.PopSpeech();
+        var item = _templateBodyItems.FirstOrDefault(x => x.Type == TemplateBodyItemType.Implant && x.Key.EqualTo(key));
+        if (item is null)
+        {
+            actor.OutputHandler.Send("This NPC template does not have an implant body loadout item with that key.");
+        }
+
+        return item;
+    }
+}

--- a/MudSharpCore/NPC/Templates/NPCTemplateBase.LoadAdditions.cs
+++ b/MudSharpCore/NPC/Templates/NPCTemplateBase.LoadAdditions.cs
@@ -1,0 +1,735 @@
+using MudSharp.Body;
+using MudSharp.Character;
+using MudSharp.Community;
+using MudSharp.Economy;
+using MudSharp.Events;
+using MudSharp.Events.Hooks;
+using MudSharp.Framework;
+using MudSharp.Framework.Save;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.GameItems.Prototypes;
+using MudSharp.PerceptionEngine;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+#nullable enable
+#nullable disable warnings
+
+namespace MudSharp.NPC.Templates;
+
+public abstract partial class NPCTemplateBase
+{
+    private readonly List<TemplateClanMembership> _templateClanMemberships = new();
+    private readonly List<TemplateOutfitLoad> _templateOutfits = new();
+    private readonly List<long> _templateHookIds = new();
+    private readonly List<TemplateBankAccount> _templateBankAccounts = new();
+    private readonly List<TemplateBodyItem> _templateBodyItems = new();
+
+    private sealed class TemplateClanMembership
+    {
+        public long ClanId { get; init; }
+        public long RankId { get; set; }
+        public long? PaygradeId { get; set; }
+        public List<long> AppointmentIds { get; } = new();
+
+        public XElement SaveToXml()
+        {
+            return new XElement("Membership",
+                new XAttribute("clan", ClanId),
+                new XAttribute("rank", RankId),
+                new XAttribute("paygrade", PaygradeId ?? 0L),
+                from item in AppointmentIds
+                select new XElement("Appointment", new XAttribute("id", item))
+            );
+        }
+    }
+
+    private sealed class TemplateOutfitLoad
+    {
+        public long OutfitTemplateId { get; init; }
+        public string? OutfitName { get; set; }
+
+        public XElement SaveToXml()
+        {
+            return new XElement("Outfit",
+                new XAttribute("template", OutfitTemplateId),
+                new XAttribute("name", OutfitName ?? string.Empty)
+            );
+        }
+    }
+
+    private sealed class TemplateBankAccount
+    {
+        public long BankAccountTypeId { get; init; }
+        public string? Name { get; set; }
+        public decimal OpeningBalance { get; set; }
+
+        public XElement SaveToXml()
+        {
+            return new XElement("Account",
+                new XAttribute("type", BankAccountTypeId),
+                new XAttribute("name", Name ?? string.Empty),
+                new XAttribute("balance", OpeningBalance.ToString(CultureInfo.InvariantCulture))
+            );
+        }
+    }
+
+    private enum TemplateBodyItemType
+    {
+        Implant,
+        Prosthetic
+    }
+
+    private sealed class TemplateBodyItem
+    {
+        public TemplateBodyItemType Type { get; init; }
+        public string Key { get; init; } = string.Empty;
+        public long ItemProtoId { get; set; }
+        public long? BodypartId { get; set; }
+        public string? PowerSourceKey { get; set; }
+        public string? NeuralLinkKey { get; set; }
+
+        public XElement SaveToXml()
+        {
+            return new XElement(Type == TemplateBodyItemType.Implant ? "Implant" : "Prosthetic",
+                new XAttribute("key", Key),
+                new XAttribute("proto", ItemProtoId),
+                new XAttribute("bodypart", BodypartId ?? 0L),
+                new XAttribute("power", PowerSourceKey ?? string.Empty),
+                new XAttribute("neural", NeuralLinkKey ?? string.Empty)
+            );
+        }
+    }
+
+    protected void LoadTemplateLoadAdditions(XElement definition)
+    {
+        var root = definition.Element("TemplateLoadAdditions");
+        if (root is null)
+        {
+            return;
+        }
+
+        foreach (var item in root.Element("ClanMemberships")?.Elements("Membership") ?? Enumerable.Empty<XElement>())
+        {
+            var membership = new TemplateClanMembership
+            {
+                ClanId = long.Parse(item.Attribute("clan")?.Value ?? "0"),
+                RankId = long.Parse(item.Attribute("rank")?.Value ?? "0"),
+                PaygradeId = LongOrNull(item.Attribute("paygrade")?.Value)
+            };
+            foreach (var appointment in item.Elements("Appointment"))
+            {
+                var id = long.Parse(appointment.Attribute("id")?.Value ?? "0");
+                if (id > 0)
+                {
+                    membership.AppointmentIds.Add(id);
+                }
+            }
+
+            if (membership.ClanId > 0 && membership.RankId > 0)
+            {
+                _templateClanMemberships.Add(membership);
+            }
+        }
+
+        foreach (var item in root.Element("Outfits")?.Elements("Outfit") ?? Enumerable.Empty<XElement>())
+        {
+            var id = long.Parse(item.Attribute("template")?.Value ?? "0");
+            if (id <= 0)
+            {
+                continue;
+            }
+
+            _templateOutfits.Add(new TemplateOutfitLoad
+            {
+                OutfitTemplateId = id,
+                OutfitName = string.IsNullOrWhiteSpace(item.Attribute("name")?.Value)
+                    ? null
+                    : item.Attribute("name")!.Value
+            });
+        }
+
+        foreach (var item in root.Element("Hooks")?.Elements("Hook") ?? Enumerable.Empty<XElement>())
+        {
+            var id = long.Parse(item.Attribute("id")?.Value ?? "0");
+            if (id > 0)
+            {
+                _templateHookIds.Add(id);
+            }
+        }
+
+        foreach (var item in root.Element("BankAccounts")?.Elements("Account") ?? Enumerable.Empty<XElement>())
+        {
+            var id = long.Parse(item.Attribute("type")?.Value ?? "0");
+            if (id <= 0)
+            {
+                continue;
+            }
+
+            _templateBankAccounts.Add(new TemplateBankAccount
+            {
+                BankAccountTypeId = id,
+                Name = string.IsNullOrWhiteSpace(item.Attribute("name")?.Value)
+                    ? null
+                    : item.Attribute("name")!.Value,
+                OpeningBalance = decimal.Parse(item.Attribute("balance")?.Value ?? "0.0",
+                    CultureInfo.InvariantCulture)
+            });
+        }
+
+        foreach (var item in root.Element("BodyLoadout")?.Elements() ?? Enumerable.Empty<XElement>())
+        {
+            if (!item.Name.LocalName.EqualToAny("Implant", "Prosthetic"))
+            {
+                continue;
+            }
+
+            var key = item.Attribute("key")?.Value;
+            var protoId = long.Parse(item.Attribute("proto")?.Value ?? "0");
+            if (string.IsNullOrWhiteSpace(key) || protoId <= 0)
+            {
+                continue;
+            }
+
+            _templateBodyItems.Add(new TemplateBodyItem
+            {
+                Type = item.Name.LocalName.EqualTo("Implant")
+                    ? TemplateBodyItemType.Implant
+                    : TemplateBodyItemType.Prosthetic,
+                Key = key.Trim(),
+                ItemProtoId = protoId,
+                BodypartId = LongOrNull(item.Attribute("bodypart")?.Value),
+                PowerSourceKey = NullIfBlank(item.Attribute("power")?.Value),
+                NeuralLinkKey = NullIfBlank(item.Attribute("neural")?.Value)
+            });
+        }
+    }
+
+    protected XElement SaveTemplateLoadAdditions()
+    {
+        return new XElement("TemplateLoadAdditions",
+            new XElement("ClanMemberships", _templateClanMemberships.Select(x => x.SaveToXml())),
+            new XElement("Outfits", _templateOutfits.Select(x => x.SaveToXml())),
+            new XElement("Hooks",
+                _templateHookIds.Select(x => new XElement("Hook", new XAttribute("id", x)))),
+            new XElement("BankAccounts", _templateBankAccounts.Select(x => x.SaveToXml())),
+            new XElement("BodyLoadout", _templateBodyItems.Select(x => x.SaveToXml()))
+        );
+    }
+
+    protected string ShowTemplateLoadAdditions(ICharacter actor)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine();
+        sb.AppendLine("Load-Time Additions:");
+
+        sb.AppendLine("\tClan Memberships:");
+        if (_templateClanMemberships.Count == 0)
+        {
+            sb.AppendLine("\t\tNone");
+        }
+        else
+        {
+            foreach (var membership in _templateClanMemberships)
+            {
+                var clan = Gameworld.Clans.Get(membership.ClanId);
+                var rank = clan?.Ranks.FirstOrDefault(x => x.Id == membership.RankId);
+                var paygrade = clan?.Paygrades.FirstOrDefault(x => x.Id == membership.PaygradeId);
+                var appointments = membership.AppointmentIds
+                                             .Select(x => clan?.Appointments.FirstOrDefault(y => y.Id == x))
+                                             .Where(x => x is not null)
+                                             .Select(x => x!.Name.TitleCase().ColourName())
+                                             .DefaultIfEmpty("None".ColourCommand())
+                                             .ListToString();
+                sb.AppendLine(
+                    $"\t\t{clan?.FullName.ColourName() ?? $"Missing Clan #{membership.ClanId:N0}".ColourError()} - {rank?.Name.TitleCase().ColourValue() ?? $"Missing Rank #{membership.RankId:N0}".ColourError()} / {paygrade?.Name.TitleCase().ColourValue() ?? "No Paygrade".ColourCommand()} / Appointments: {appointments}");
+            }
+        }
+
+        sb.AppendLine("\tOutfit Templates:");
+        if (_templateOutfits.Count == 0)
+        {
+            sb.AppendLine("\t\tNone");
+        }
+        else
+        {
+            for (var i = 0; i < _templateOutfits.Count; i++)
+            {
+                var outfit = _templateOutfits[i];
+                var template = Gameworld.OutfitTemplates.Get(outfit.OutfitTemplateId);
+                sb.AppendLine(
+                    $"\t\t{(i + 1).ToString("N0", actor).ColourValue()}: {(template is null ? $"Missing Outfit #{outfit.OutfitTemplateId:N0}".ColourError() : $"{template.Name} (#{template.Id:N0})".ColourName())}{(string.IsNullOrWhiteSpace(outfit.OutfitName) ? string.Empty : $" as {outfit.OutfitName.ColourCommand()}")}");
+            }
+        }
+
+        sb.AppendLine("\tHooks:");
+        if (_templateHookIds.Count == 0)
+        {
+            sb.AppendLine("\t\tNone");
+        }
+        else
+        {
+            foreach (var hookId in _templateHookIds)
+            {
+                var hook = Gameworld.Hooks.Get(hookId);
+                sb.AppendLine($"\t\t{hook?.Name.ColourName() ?? $"Missing Hook #{hookId:N0}".ColourError()}");
+            }
+        }
+
+        sb.AppendLine("\tBank Accounts:");
+        if (_templateBankAccounts.Count == 0)
+        {
+            sb.AppendLine("\t\tNone");
+        }
+        else
+        {
+            for (var i = 0; i < _templateBankAccounts.Count; i++)
+            {
+                var account = _templateBankAccounts[i];
+                var type = Gameworld.BankAccountTypes.Get(account.BankAccountTypeId);
+                sb.AppendLine(
+                    $"\t\t{(i + 1).ToString("N0", actor).ColourValue()}: {type?.Name.ColourName() ?? $"Missing Account Type #{account.BankAccountTypeId:N0}".ColourError()} / {(account.Name ?? "Default Name").ColourCommand()} / {account.OpeningBalance.ToString("N2", actor).ColourValue()}");
+            }
+        }
+
+        sb.AppendLine("\tBody Loadout:");
+        if (_templateBodyItems.Count == 0)
+        {
+            sb.AppendLine("\t\tNone");
+        }
+        else
+        {
+            foreach (var item in _templateBodyItems)
+            {
+                var proto = Gameworld.ItemProtos.Get(item.ItemProtoId);
+                var bodypart = item.BodypartId.HasValue
+                    ? Gameworld.BodypartPrototypes.Get(item.BodypartId.Value)
+                    : null;
+                sb.AppendLine(
+                    $"\t\t{item.Type.DescribeEnum().ColourValue()} {item.Key.ColourCommand()}: {proto?.EditHeader().ColourName() ?? $"Missing Item Proto #{item.ItemProtoId:N0}".ColourError()}{(bodypart is null ? string.Empty : $" in {bodypart.FullDescription().ColourValue()}")}{(string.IsNullOrWhiteSpace(item.PowerSourceKey) ? string.Empty : $" / power {item.PowerSourceKey.ColourCommand()}")}{(string.IsNullOrWhiteSpace(item.NeuralLinkKey) ? string.Empty : $" / neural {item.NeuralLinkKey.ColourCommand()}")}");
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    public IEnumerable<string> ApplyTemplateLoadAdditions(ICharacter character, bool logWarnings = true)
+    {
+        var warnings = new List<string>();
+        ApplyClanMemberships(character, warnings);
+        ApplyHooks(character, warnings);
+
+        var needsPostIdWork = _templateOutfits.Any() || _templateBankAccounts.Any() || _templateBodyItems.Any();
+        if (needsPostIdWork && character is ILateInitialisingItem { IdHasBeenRegistered: false } lateItem)
+        {
+            Gameworld.SaveManager.DirectInitialise(lateItem);
+        }
+
+        ApplyBankAccounts(character, warnings);
+        ApplyBodyLoadout(character, warnings);
+        ApplyOutfits(character, warnings);
+
+        if (logWarnings && warnings.Any())
+        {
+            foreach (var warning in warnings)
+            {
+                Gameworld.SystemMessage(
+                    $"NPC template {EditHeader()} load warning: {warning}", true);
+            }
+        }
+
+        return warnings;
+    }
+
+    private void ApplyClanMemberships(ICharacter character, List<string> warnings)
+    {
+        foreach (var item in _templateClanMemberships)
+        {
+            var clan = Gameworld.Clans.Get(item.ClanId);
+            if (clan is null)
+            {
+                warnings.Add($"Clan #{item.ClanId:N0} no longer exists.");
+                continue;
+            }
+
+            var rank = clan.Ranks.FirstOrDefault(x => x.Id == item.RankId);
+            if (rank is null)
+            {
+                warnings.Add($"Rank #{item.RankId:N0} no longer exists in clan {clan.FullName}.");
+                continue;
+            }
+
+            var paygrade = item.PaygradeId.HasValue
+                ? clan.Paygrades.FirstOrDefault(x => x.Id == item.PaygradeId.Value)
+                : null;
+            if (item.PaygradeId.HasValue && (paygrade is null || !rank.Paygrades.Contains(paygrade)))
+            {
+                warnings.Add($"Paygrade #{item.PaygradeId.Value:N0} is no longer valid for {clan.FullName} rank {rank.Name}.");
+                paygrade = null;
+            }
+
+            var membership = character.ClanMemberships.FirstOrDefault(x => x.Clan == clan);
+            if (membership is null)
+            {
+                membership = new ClanMembership(Gameworld)
+                {
+                    Clan = clan,
+                    Rank = rank,
+                    Paygrade = paygrade,
+                    PersonalName = character.CurrentName,
+                    JoinDate = clan.Calendar.CurrentDate
+                };
+                clan.Memberships.Add(membership);
+                character.AddMembership(membership);
+            }
+            else
+            {
+                membership.Rank = rank;
+                membership.Paygrade = paygrade;
+                membership.Changed = CharacterIdHasBeenRegistered(character);
+            }
+
+            foreach (var appointmentId in item.AppointmentIds)
+            {
+                var appointment = clan.Appointments.FirstOrDefault(x => x.Id == appointmentId);
+                if (appointment is null)
+                {
+                    warnings.Add($"Appointment #{appointmentId:N0} no longer exists in clan {clan.FullName}.");
+                    continue;
+                }
+
+                if (appointment.IsAppointedByElection)
+                {
+                    warnings.Add($"Appointment {appointment.Name} in clan {clan.FullName} is now elected and was skipped.");
+                    continue;
+                }
+
+                if (appointment.MinimumRankToHold is not null &&
+                    appointment.MinimumRankToHold.RankNumber > membership.Rank.RankNumber)
+                {
+                    warnings.Add(
+                        $"Appointment {appointment.Name} in clan {clan.FullName} now requires rank {appointment.MinimumRankToHold.Name} and was skipped.");
+                    continue;
+                }
+
+                if (!clan.FreePosition(appointment))
+                {
+                    warnings.Add($"Appointment {appointment.Name} in clan {clan.FullName} has no free positions and was skipped.");
+                    continue;
+                }
+
+                if (!membership.Appointments.Contains(appointment))
+                {
+                    membership.Appointments.Add(appointment);
+                    membership.Changed = CharacterIdHasBeenRegistered(character);
+                }
+            }
+        }
+    }
+
+    private void ApplyHooks(ICharacter character, List<string> warnings)
+    {
+        foreach (var hookId in _templateHookIds)
+        {
+            var hook = Gameworld.Hooks.Get(hookId);
+            if (hook is null)
+            {
+                warnings.Add($"Hook #{hookId:N0} no longer exists.");
+                continue;
+            }
+
+            if (!HookIsValidForCharacter(hook))
+            {
+                warnings.Add($"Hook {hook.Name} is not valid for character/NPC installation.");
+                continue;
+            }
+
+            if (character.InstallHook(hook) && CharacterIdHasBeenRegistered(character))
+            {
+                character.HooksChanged = true;
+            }
+        }
+    }
+
+    private void ApplyBankAccounts(ICharacter character, List<string> warnings)
+    {
+        foreach (var item in _templateBankAccounts)
+        {
+            var type = Gameworld.BankAccountTypes.Get(item.BankAccountTypeId);
+            if (type is null)
+            {
+                warnings.Add($"Bank account type #{item.BankAccountTypeId:N0} no longer exists.");
+                continue;
+            }
+
+            var canOpen = type.CanOpenAccount(character);
+            if (!canOpen.Truth)
+            {
+                warnings.Add($"Bank account type {type.Name} could not be opened: {canOpen.Reason}");
+                continue;
+            }
+
+            var account = type.OpenAccount(character);
+            if (!string.IsNullOrWhiteSpace(item.Name))
+            {
+                account.SetName(item.Name);
+            }
+
+            if (item.OpeningBalance != 0.0M)
+            {
+                account.DoAccountCredit(item.OpeningBalance, $"NPC template {EditHeader()} opening balance");
+            }
+        }
+    }
+
+    private void ApplyOutfits(ICharacter character, List<string> warnings)
+    {
+        foreach (var item in _templateOutfits)
+        {
+            var template = Gameworld.OutfitTemplates.Get(item.OutfitTemplateId);
+            if (template is null)
+            {
+                warnings.Add($"Outfit template #{item.OutfitTemplateId:N0} no longer exists.");
+                continue;
+            }
+
+            try
+            {
+                template.Materialise(character, item.OutfitName);
+            }
+            catch (Exception ex)
+            {
+                warnings.Add($"Outfit template {template.Name} could not be materialised: {ex.Message}");
+            }
+        }
+    }
+
+    private void ApplyBodyLoadout(ICharacter character, List<string> warnings)
+    {
+        var installedImplants = new Dictionary<string, IImplant>(StringComparer.InvariantCultureIgnoreCase);
+        foreach (var item in _templateBodyItems)
+        {
+            var proto = Gameworld.ItemProtos.Get(item.ItemProtoId);
+            if (proto is null)
+            {
+                warnings.Add($"Item proto #{item.ItemProtoId:N0} for body loadout key {item.Key} no longer exists.");
+                continue;
+            }
+
+            var created = proto.CreateNew(character, null, 1, string.Empty).FirstOrDefault();
+            if (created is null)
+            {
+                warnings.Add($"Item proto {proto.EditHeader()} did not create an item for body loadout key {item.Key}.");
+                continue;
+            }
+
+            var installed = false;
+            switch (item.Type)
+            {
+                case TemplateBodyItemType.Implant:
+                    installed = InstallTemplateImplant(character, item, created, installedImplants, warnings);
+                    break;
+                case TemplateBodyItemType.Prosthetic:
+                    installed = InstallTemplateProsthetic(character, item, created, warnings);
+                    break;
+            }
+
+            if (!installed)
+            {
+                created.Delete();
+            }
+        }
+
+        foreach (var item in _templateBodyItems.Where(x => x.Type == TemplateBodyItemType.Implant))
+        {
+            if (!installedImplants.TryGetValue(item.Key, out var implant))
+            {
+                continue;
+            }
+
+            if (!string.IsNullOrWhiteSpace(item.PowerSourceKey))
+            {
+                if (!installedImplants.TryGetValue(item.PowerSourceKey, out var plantImplant) ||
+                    plantImplant.Parent.GetItemType<IImplantPowerPlant>() is not IImplantPowerPlant plant)
+                {
+                    warnings.Add($"Implant {item.Key} could not be powered by missing or invalid implant key {item.PowerSourceKey}.");
+                }
+                else if (implant.Parent.GetItemType<IImplantPowerSupply>() is not IImplantPowerSupply supply)
+                {
+                    warnings.Add($"Implant {item.Key} is not a powered implant and cannot use power source {item.PowerSourceKey}.");
+                }
+                else
+                {
+                    supply.PowerPlant = plant;
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(item.NeuralLinkKey))
+            {
+                if (implant is IImplantNeuralLink)
+                {
+                    warnings.Add($"Implant {item.Key} is a neural interface and cannot be linked to another neural interface.");
+                }
+                else if (!installedImplants.TryGetValue(item.NeuralLinkKey, out var neuralImplant) ||
+                         neuralImplant is not IImplantNeuralLink neural)
+                {
+                    warnings.Add($"Implant {item.Key} could not be linked to missing or invalid neural key {item.NeuralLinkKey}.");
+                }
+                else
+                {
+                    foreach (var other in character.Body.Implants.OfType<IImplantNeuralLink>().Except(neural))
+                    {
+                        other.RemoveLink(implant);
+                    }
+
+                    neural.AddLink(implant);
+                    if (implant is IImplantRespondToCommands commandImplant)
+                    {
+                        commandImplant.AliasForCommands = $"implant{commandImplant.Id:F0}";
+                    }
+                }
+            }
+        }
+    }
+
+    private bool InstallTemplateImplant(ICharacter character, TemplateBodyItem item, IGameItem created,
+        Dictionary<string, IImplant> installedImplants, List<string> warnings)
+    {
+        var implant = created.GetItemType<IImplant>();
+        if (implant is null)
+        {
+            warnings.Add($"{created.HowSeen(character, true)} for body loadout key {item.Key} is not an implant.");
+            return false;
+        }
+
+        if (implant.TargetBody is null || !character.Body.Prototype.CountsAs(implant.TargetBody))
+        {
+            warnings.Add($"{created.HowSeen(character, true)} is not designed for {character.Body.Prototype.Name} bodies.");
+            return false;
+        }
+
+        if (item.BodypartId.HasValue)
+        {
+            var bodypart = character.Body.Prototype.AllBodypartsBonesAndOrgans
+                                    .FirstOrDefault(x => x.Id == item.BodypartId.Value);
+            if (bodypart is null)
+            {
+                warnings.Add($"Bodypart #{item.BodypartId.Value:N0} is not present on {character.Body.Prototype.Name} bodies.");
+                return false;
+            }
+
+            implant.TargetBodypart = bodypart;
+        }
+
+        if (implant.TargetBodypart is null)
+        {
+            warnings.Add($"{created.HowSeen(character, true)} does not have a target bodypart.");
+            return false;
+        }
+
+        Gameworld.Add(created);
+        if (created is ILateInitialisingItem lateItem)
+        {
+            Gameworld.SaveManager.DirectInitialise(lateItem);
+        }
+
+        character.Body.InstallImplant(implant);
+        created.HandleEvent(EventType.ItemFinishedLoading, created);
+        created.Login();
+        installedImplants[item.Key] = implant;
+        return true;
+    }
+
+    private bool InstallTemplateProsthetic(ICharacter character, TemplateBodyItem item, IGameItem created,
+        List<string> warnings)
+    {
+        var prosthetic = created.GetItemType<IProsthetic>();
+        if (prosthetic is null)
+        {
+            warnings.Add($"{created.HowSeen(character, true)} for body loadout key {item.Key} is not a prosthetic.");
+            return false;
+        }
+
+        if (prosthetic.TargetBody is null || !character.Body.Prototype.CountsAs(prosthetic.TargetBody))
+        {
+            warnings.Add($"{created.HowSeen(character, true)} is not designed for {character.Body.Prototype.Name} bodies.");
+            return false;
+        }
+
+        var bodypart = prosthetic.TargetBodypart;
+        if (item.BodypartId.HasValue)
+        {
+            var configured = character.Body.Prototype.AllBodypartsBonesAndOrgans
+                                      .FirstOrDefault(x => x.Id == item.BodypartId.Value);
+            if (configured is null ||
+                !(configured == bodypart || configured.CountsAs(bodypart) || bodypart.CountsAs(configured)))
+            {
+                warnings.Add($"Bodypart #{item.BodypartId.Value:N0} is not compatible with prosthetic {created.HowSeen(character)}.");
+                return false;
+            }
+        }
+
+        if (!character.Body.SeveredRoots.Any(x => x == bodypart || x.CountsAs(bodypart) || bodypart.CountsAs(x)))
+        {
+            warnings.Add($"{character.HowSeen(character, true)} does not have a sever suitable for prosthetic {created.HowSeen(character)}.");
+            return false;
+        }
+
+        if (character.Body.Prosthetics.Any(x =>
+                x.TargetBodypart == bodypart ||
+                x.TargetBodypart.CountsAs(bodypart) ||
+                bodypart.CountsAs(x.TargetBodypart)))
+        {
+            warnings.Add($"{character.HowSeen(character, true)} already has a prosthetic for {bodypart.FullDescription()}.");
+            return false;
+        }
+
+        Gameworld.Add(created);
+        if (created is ILateInitialisingItem lateItem)
+        {
+            Gameworld.SaveManager.DirectInitialise(lateItem);
+        }
+
+        character.Body.InstallProsthetic(prosthetic);
+        created.HandleEvent(EventType.ItemFinishedLoading, created);
+        created.Login();
+        return true;
+    }
+
+    private static long? LongOrNull(string? text)
+    {
+        if (!long.TryParse(text, out var value) || value <= 0)
+        {
+            return null;
+        }
+
+        return value;
+    }
+
+    private static string? NullIfBlank(string? text)
+    {
+        return string.IsNullOrWhiteSpace(text) ? null : text.Trim();
+    }
+
+    private static bool CharacterIdHasBeenRegistered(ICharacter character)
+    {
+        return character is not ILateInitialisingItem item || item.IdHasBeenRegistered;
+    }
+
+    private static bool HookIsValidForCharacter(IHook hook)
+    {
+        if (hook.Type is EventType.CommandInput or EventType.SelfCommandInput
+            or EventType.FiveSecondTick or EventType.TenSecondTick or EventType.MinuteTick or EventType.HourTick
+            or EventType.NPCOnGameLoadFinished)
+        {
+            return true;
+        }
+
+        return hook.Type.ToString().StartsWith("Character", StringComparison.InvariantCultureIgnoreCase);
+    }
+}

--- a/MudSharpCore/NPC/Templates/NPCTemplateBase.cs
+++ b/MudSharpCore/NPC/Templates/NPCTemplateBase.cs
@@ -25,7 +25,7 @@ using EditableItem = MudSharp.Framework.Revision.EditableItem;
 
 namespace MudSharp.NPC.Templates;
 
-public abstract class NPCTemplateBase : EditableItem, INPCTemplate
+public abstract partial class NPCTemplateBase : EditableItem, INPCTemplate
 {
     protected NPCTemplateBase(NpcTemplate template, IFuturemud gameworld) : base(template.EditableItem)
     {
@@ -53,6 +53,8 @@ public abstract class NPCTemplateBase : EditableItem, INPCTemplate
         {
             DefaultCombatSetting = gameworld.CharacterCombatSettings.Get(long.Parse(element.Value));
         }
+
+        LoadTemplateLoadAdditions(definition);
 
         foreach (NpcTemplatesArtificalIntelligences ai in template.NpctemplatesArtificalIntelligences)
         {
@@ -120,6 +122,20 @@ public abstract class NPCTemplateBase : EditableItem, INPCTemplate
             case "buildercomment":
             case "buildernotes":
                 return BuildingCommandBuilderNotes(actor, command);
+            case "clan":
+                return BuildingCommandClan(actor, command);
+            case "outfit":
+                return BuildingCommandOutfit(actor, command);
+            case "hook":
+                return BuildingCommandHook(actor, command);
+            case "bank":
+            case "account":
+            case "bankaccount":
+                return BuildingCommandBank(actor, command);
+            case "implant":
+                return BuildingCommandImplant(actor, command);
+            case "prosthetic":
+                return BuildingCommandProsthetic(actor, command);
             default:
                 actor.OutputHandler.Send($@"{HelpText}
 	#3unique <name>#0 - sets a unique lookup name for this NPC template
@@ -133,7 +149,23 @@ public abstract class NPCTemplateBase : EditableItem, INPCTemplate
 	#3combatsetting <setting>#0 - sets the default combat setting for this NPC
 	#3combatsetting none#0 - clears the combat setting override
 	#3ai add <which>#0 - adds an AI routine to this NPC
-	#3ai remove <which>#0 - removes an AI routine from this NPC".SubstituteANSIColour());
+	#3ai remove <which>#0 - removes an AI routine from this NPC
+	#3clan add <clan> <rank> [paygrade <paygrade>]#0 - adds a load-time clan membership
+	#3clan remove <clan>#0 - removes a load-time clan membership
+	#3clan appointment add <clan> <appointment>#0 - adds a load-time clan appointment
+	#3clan appointment remove <clan> <appointment>#0 - removes a load-time clan appointment
+	#3outfit add <template> [name <name>]#0 - materialises an outfit template when loaded
+	#3outfit remove <template|#>#0 - removes a load-time outfit template
+	#3hook add <hook>#0 - installs a hook when loaded
+	#3hook remove <hook>#0 - removes a load-time hook
+	#3bank add <type> [balance <amount>] [name <name>]#0 - creates a bank account when loaded
+	#3bank remove <type|#>#0 - removes a load-time bank account
+	#3implant add <key> <proto> [bodypart <part>]#0 - installs an implant item when loaded
+	#3implant remove <key>#0 - removes a load-time implant
+	#3implant power <key> <power-key|none>#0 - configures implant power
+	#3implant neural <key> <neural-key|none>#0 - configures implant neural control
+	#3prosthetic add <key> <proto>#0 - installs a prosthetic item when loaded
+	#3prosthetic remove <key>#0 - removes a load-time prosthetic".SubstituteANSIColour());
                 return false;
         }
     }

--- a/MudSharpCore/NPC/Templates/SimpleNPCTemplate.cs
+++ b/MudSharpCore/NPC/Templates/SimpleNPCTemplate.cs
@@ -433,6 +433,7 @@ public class SimpleNPCTemplate : NPCTemplateBase
                 }
             }
 
+            sb.Append(ShowTemplateLoadAdditions(actor));
 
             return sb.ToString();
         }
@@ -752,6 +753,7 @@ public class SimpleNPCTemplate : NPCTemplateBase
                 new XElement("OnLoadProg", OnLoadProg?.Id ?? 0),
                 new XElement("HealthStrategy", HealthStrategy?.Id ?? 0L),
                 new XElement("DefaultCombatSetting", DefaultCombatSetting?.Id ?? 0L),
+                SaveTemplateLoadAdditions(),
                 new XElement("SelectedSdesc", new XCData(SelectedSdesc ?? "")),
                 new XElement("SelectedFullDesc", new XCData(SelectedFullDesc ?? "")),
                 new XElement("SelectedRace", SelectedRace?.Id ?? -1),

--- a/MudSharpCore/NPC/Templates/VariableNPCTemplate.cs
+++ b/MudSharpCore/NPC/Templates/VariableNPCTemplate.cs
@@ -287,6 +287,7 @@ public class VariableNPCTemplate : NPCTemplateBase
                 new XElement("OnLoadProg", OnLoadProg?.Id ?? 0),
                 new XElement("HealthStrategy", HealthStrategy?.Id ?? 0L),
                 new XElement("DefaultCombatSetting", DefaultCombatSetting?.Id ?? 0L),
+                SaveTemplateLoadAdditions(),
                 new XElement("GenderChances", new object[]
                 {
                     from item in _genderChances
@@ -722,6 +723,8 @@ public class VariableNPCTemplate : NPCTemplateBase
         {
             sb.AppendLine($"AI #{ai.Id}: {ai.Name}");
         }
+
+        sb.Append(ShowTemplateLoadAdditions(actor));
 
         if (!CanSubmit())
         {

--- a/MudSharpCore/Work/Agriculture/AgricultureField.cs
+++ b/MudSharpCore/Work/Agriculture/AgricultureField.cs
@@ -1141,12 +1141,13 @@ public class AgricultureField : SaveableItem, IAgricultureField
 			return false;
 		}
 
-		for (var i = 0; i < count; i++)
-		{
-			var npc = definition.NpcTemplate.CreateNewCharacter(Cell);
-			Gameworld.Add(npc, true);
-			definition.NpcTemplate.OnLoadProg?.Execute(npc);
-			Cell.Login(npc);
+        for (var i = 0; i < count; i++)
+        {
+            var npc = definition.NpcTemplate.CreateNewCharacter(Cell);
+            Gameworld.Add(npc, true);
+            definition.NpcTemplate.ApplyTemplateLoadAdditions(npc);
+            definition.NpcTemplate.OnLoadProg?.Execute(npc);
+            Cell.Login(npc);
 			npc.HandleEvent(EventType.NPCOnGameLoadFinished, npc);
 		}
 

--- a/MudSharpCore/Work/Crafts/Products/NPCProduct.cs
+++ b/MudSharpCore/Work/Crafts/Products/NPCProduct.cs
@@ -58,6 +58,8 @@ internal class NPCProduct : BaseProduct
                 {
                     RoomLayer = layer
                 };
+                location.Gameworld.Add(newCharacter, true);
+                NPCTemplate.ApplyTemplateLoadAdditions(newCharacter);
                 NPCTemplate.OnLoadProg?.Execute(newCharacter);
                 OnLoadProg?.Execute(newCharacter);
                 if (newCharacter.Location.IsSwimmingLayer(newCharacter.RoomLayer) && newCharacter.Race.CanSwim)


### PR DESCRIPTION
## Summary
- Added load-addition support to NPC templates and exposed it through the NPC builder workflow.
- Updated NPC loading and creation paths so templates can carry additional load data through spawners, spell effects, and related runtime entry points.
- Covered the new template load-addition source behavior with unit tests.
- Kept the affected design docs in sync for AI, economy, and item workflow references.

## Testing
- Added/updated unit coverage for NPC template load-addition source handling.
- Not run (not requested).