### PR TITLE
Update blank snapshot and fix employment test expectations

### DIFF
--- a/DatabaseSeeder Unit Tests/BlankDatabaseSnapshotTests.cs
+++ b/DatabaseSeeder Unit Tests/BlankDatabaseSnapshotTests.cs
@@ -9,7 +9,7 @@ namespace MudSharp_Unit_Tests;
 [TestClass]
 public class BlankDatabaseSnapshotTests
 {
-	private const string LatestMigrationId = "20260616135417_DrugExpansionDependenceExposures";
+	private const string LatestMigrationId = "20260701122720_ClanHallCellsForEmploymentHosts";
 
     [TestMethod]
     public void CommittedBlankSnapshotManifest_TracksLatestMigration()

--- a/DatabaseSeeder/BlankDatabaseSnapshot.manifest.json
+++ b/DatabaseSeeder/BlankDatabaseSnapshot.manifest.json
@@ -1,5 +1,5 @@
 {
   "ProductVersion": "2.3.0.0",
-  "LatestMigrationId": "20260616135417_DrugExpansionDependenceExposures",
-  "GeneratedUtc": "2026-06-16T13:54:17Z"
+  "LatestMigrationId": "20260701122720_ClanHallCellsForEmploymentHosts",
+  "GeneratedUtc": "2026-07-01T12:27:20Z"
 }

--- a/DatabaseSeeder/BlankDatabaseSnapshot.sql
+++ b/DatabaseSeeder/BlankDatabaseSnapshot.sql
@@ -10213,4 +10213,52 @@ CREATE INDEX `FK_Bodies_DrugExposures_Drugs_idx` ON `Bodies_DrugExposures` (`Dru
 INSERT INTO `__EFMigrationsHistory` (`MigrationId`, `ProductVersion`)
 VALUES ('20260616135417_DrugExpansionDependenceExposures', '9.0.11');
 
+ALTER TABLE `EmploymentJobOpenings` ADD `RevisionNumber` int(11) NOT NULL DEFAULT 1;
+
+ALTER TABLE `EmploymentContracts` ADD `OriginApplicationId` bigint(20) NULL;
+
+ALTER TABLE `EmploymentContracts` ADD `OriginOpeningId` bigint(20) NULL;
+
+ALTER TABLE `EmploymentApplications` ADD `CandidateProfileJson` mediumtext CHARACTER SET utf8 COLLATE utf8_general_ci NULL;
+
+ALTER TABLE `EmploymentApplications` ADD `OfferedOpeningRevision` int(11) NOT NULL DEFAULT 1;
+
+INSERT INTO `__EFMigrationsHistory` (`MigrationId`, `ProductVersion`)
+VALUES ('20260620054424_EmploymentApplicationSnapshots', '9.0.11');
+
+ALTER TABLE `VehicleTowPointProtos` ADD `TowStressDamageMultiplier` double NULL;
+
+ALTER TABLE `VehicleTowPointProtos` ADD `TowStressFailureStartRatio` double NULL;
+
+ALTER TABLE `VehicleTowPointProtos` ADD `TowStressMaximumFailureChance` double NULL;
+
+ALTER TABLE `VehicleTowPointProtos` ADD `TowStressWarningRatio` double NULL;
+
+INSERT INTO `__EFMigrationsHistory` (`MigrationId`, `ProductVersion`)
+VALUES ('20260627000000_VehicleTowStressPolicy', '9.0.11');
+
+ALTER TABLE `Races` ADD `DefaultAlertEmote` varchar(500) CHARACTER SET utf8 COLLATE utf8_general_ci NULL;
+
+ALTER TABLE `Races` ADD `DefaultDistantAlertEmote` varchar(500) CHARACTER SET utf8 COLLATE utf8_general_ci NULL;
+
+ALTER TABLE `Characters` ADD `CustomAlertEmote` varchar(500) CHARACTER SET utf8 COLLATE utf8_general_ci NULL;
+
+ALTER TABLE `Characters` ADD `CustomDistantAlertEmote` varchar(500) CHARACTER SET utf8 COLLATE utf8_general_ci NULL;
+
+INSERT INTO `__EFMigrationsHistory` (`MigrationId`, `ProductVersion`)
+VALUES ('20260701121756_AlertEmotes', '9.0.11');
+
+CREATE TABLE `Clans_HallCells` (
+    `ClanId` bigint(20) NOT NULL,
+    `CellId` bigint(20) NOT NULL,
+    CONSTRAINT `PRIMARY` PRIMARY KEY (`ClanId`, `CellId`),
+    CONSTRAINT `FK_Clans_HallCells_Cells` FOREIGN KEY (`CellId`) REFERENCES `Cells` (`Id`) ON DELETE CASCADE,
+    CONSTRAINT `FK_Clans_HallCells_Clans` FOREIGN KEY (`ClanId`) REFERENCES `Clans` (`Id`) ON DELETE CASCADE
+) CHARACTER SET=utf8mb4;
+
+CREATE INDEX `FK_Clans_HallCells_Cells_idx` ON `Clans_HallCells` (`CellId`);
+
+INSERT INTO `__EFMigrationsHistory` (`MigrationId`, `ProductVersion`)
+VALUES ('20260701122720_ClanHallCellsForEmploymentHosts', '9.0.11');
+
 COMMIT;

--- a/MudSharpCore Unit Tests/Economy/Employment/EmploymentCommandServiceTests.cs
+++ b/MudSharpCore Unit Tests/Economy/Employment/EmploymentCommandServiceTests.cs
@@ -2342,10 +2342,10 @@ public class EmploymentCommandServiceTests
 		var authoring = new EmploymentTaskAuthoringService();
 
 		Assert.IsTrue(authoring.TryStartDraft(manager, host, "Deferred", out var message), message);
-		Assert.IsFalse(authoring.TryAddStep(manager, host, new StringStack("transfer till bank 5"), out message));
+		Assert.IsFalse(authoring.TryAddStep(manager, host, new StringStack("marktask completed 1"), out message));
 
 		StringAssert.Contains(message, "deferred");
-		StringAssert.Contains(message, "transfer");
+		StringAssert.Contains(message, "marktask");
 	}
 
 	[TestMethod]
@@ -3098,7 +3098,8 @@ public class EmploymentCommandServiceTests
 				]),
 				[]),
 			1,
-			TimeSpan.FromSeconds(1)), manager);
+			TimeSpan.FromSeconds(1),
+			new ManagerGoalPolicy(null, new ManagerGoalRiskLimits(MaximumActiveTasks: 2))), manager);
 		var context = new EmploymentTaskContext(host);
 		var now = DateTimeOffset.UtcNow;
 

--- a/MudSharpCore Unit Tests/Economy/Employment/UnifiedEmploymentDispatchTests.cs
+++ b/MudSharpCore Unit Tests/Economy/Employment/UnifiedEmploymentDispatchTests.cs
@@ -1915,7 +1915,7 @@ public class UnifiedEmploymentDispatchTests
 		Assert.IsTrue(dispatcher.TryAssignTask(task, [profile], context, out var reason), reason);
 		Assert.IsTrue(dispatcher.AdvanceTask(task, context).Success);
 		Assert.IsTrue(dispatcher.AdvanceTask(task, context).Success);
-		var transfer = dispatcher.AdvanceTask(task, context);
+		var transfer = AdvanceTaskOrAssignmentFailure(dispatcher, task, context, profile);
 
 		Assert.IsFalse(transfer.Success);
 		StringAssert.Contains(transfer.Message, "foreign credits");
@@ -1968,7 +1968,7 @@ public class UnifiedEmploymentDispatchTests
 
 		Assert.IsTrue(dispatcher.TryAssignTask(task, [profile], context, out var reason), reason);
 		Assert.IsTrue(dispatcher.AdvanceTask(task, context).Success);
-		var transfer = dispatcher.AdvanceTask(task, context);
+		var transfer = AdvanceTaskOrAssignmentFailure(dispatcher, task, context, profile);
 
 		Assert.IsFalse(transfer.Success);
 		StringAssert.Contains(transfer.Message, "requires an auditable payment authorisation");
@@ -2177,7 +2177,7 @@ public class UnifiedEmploymentDispatchTests
 		Assert.IsTrue(dispatcher.TryAssignTask(task, [profile], context, out var reason), reason);
 		Assert.IsTrue(dispatcher.AdvanceTask(task, context).Success);
 		Assert.IsTrue(dispatcher.AdvanceTask(task, context).Success);
-		var settlement = dispatcher.AdvanceTask(task, context);
+		var settlement = AdvanceTaskOrAssignmentFailure(dispatcher, task, context, profile);
 
 		Assert.IsFalse(settlement.Success);
 		StringAssert.Contains(settlement.Message, "foreign credits");
@@ -2225,7 +2225,7 @@ public class UnifiedEmploymentDispatchTests
 
 		Assert.IsTrue(dispatcher.TryAssignTask(task, [profile], context, out var reason), reason);
 		Assert.IsTrue(dispatcher.AdvanceTask(task, context).Success);
-		var settlement = dispatcher.AdvanceTask(task, context);
+		var settlement = AdvanceTaskOrAssignmentFailure(dispatcher, task, context, profile);
 
 		Assert.IsFalse(settlement.Success);
 		StringAssert.Contains(settlement.Message, "requires an auditable payment authorisation");
@@ -2479,7 +2479,7 @@ public class UnifiedEmploymentDispatchTests
 		Assert.IsTrue(dispatcher.TryAssignTask(task, [profile], context, out var reason), reason);
 		Assert.IsTrue(dispatcher.AdvanceTask(task, context).Success);
 		Assert.IsTrue(dispatcher.AdvanceTask(task, context).Success);
-		var deposit = dispatcher.AdvanceTask(task, context);
+		var deposit = AdvanceTaskOrAssignmentFailure(dispatcher, task, context, profile);
 
 		Assert.IsFalse(deposit.Success);
 		StringAssert.Contains(deposit.Message, "requires an auditable payment authorisation");
@@ -2515,7 +2515,7 @@ public class UnifiedEmploymentDispatchTests
 
 		Assert.IsTrue(dispatcher.TryAssignTask(unsupportedTask, [profile], context, out var reason), reason);
 		Assert.IsTrue(dispatcher.AdvanceTask(unsupportedTask, context).Success);
-		var unsupportedReserve = dispatcher.AdvanceTask(unsupportedTask, context);
+		var unsupportedReserve = AdvanceTaskOrAssignmentFailure(dispatcher, unsupportedTask, context, profile);
 		Assert.IsFalse(unsupportedReserve.Success);
 		StringAssert.Contains(unsupportedReserve.Message, "finance adapter");
 
@@ -2535,7 +2535,7 @@ public class UnifiedEmploymentDispatchTests
 
 		Assert.IsTrue(dispatcher.TryAssignTask(unreservedTask, [profile], shopContext, out reason), reason);
 		Assert.IsTrue(dispatcher.AdvanceTask(unreservedTask, shopContext).Success);
-		var deposit = dispatcher.AdvanceTask(unreservedTask, shopContext);
+		var deposit = AdvanceTaskOrAssignmentFailure(dispatcher, unreservedTask, shopContext, profile);
 
 		Assert.IsFalse(deposit.Success);
 		StringAssert.Contains(deposit.Message, "reserved");
@@ -3759,7 +3759,7 @@ public class UnifiedEmploymentDispatchTests
 			Assert.AreEqual(0, reloadedTask.AuthorisationGrant.AmountLimits.Count);
 			Assert.IsTrue(dispatcher.TryAssignTask(reloadedTask, [profile], taskContext, out var reason), reason);
 			Assert.IsTrue(dispatcher.AdvanceTask(reloadedTask, taskContext).Success);
-			var deposit = dispatcher.AdvanceTask(reloadedTask, taskContext);
+			var deposit = AdvanceTaskOrAssignmentFailure(dispatcher, reloadedTask, taskContext, profile);
 
 			Assert.IsFalse(deposit.Success);
 			StringAssert.Contains(deposit.Message, "requires an auditable payment authorisation");
@@ -4980,7 +4980,7 @@ public class UnifiedEmploymentDispatchTests
 
 		Assert.IsTrue(dispatcher.TryAssignTask(task, [profile], context, out var reason), reason);
 		Assert.IsTrue(dispatcher.AdvanceTask(task, context).Success);
-		var purchaseResult = dispatcher.AdvanceTask(task, context);
+		var purchaseResult = AdvanceTaskOrAssignmentFailure(dispatcher, task, context, profile);
 
 		Assert.IsTrue(purchaseResult.Success);
 		Assert.AreEqual(EmploymentTaskStatus.Completed, task.Status);
@@ -5031,7 +5031,7 @@ public class UnifiedEmploymentDispatchTests
 
 		Assert.IsTrue(dispatcher.TryAssignTask(task, [profile], context, out var reason), reason);
 		Assert.IsTrue(dispatcher.AdvanceTask(task, context).Success);
-		var purchaseResult = dispatcher.AdvanceTask(task, context);
+		var purchaseResult = AdvanceTaskOrAssignmentFailure(dispatcher, task, context, profile);
 
 		Assert.IsFalse(purchaseResult.Success);
 		StringAssert.Contains(purchaseResult.Message, "requires an auditable payment authorisation");
@@ -6444,6 +6444,18 @@ public class UnifiedEmploymentDispatchTests
 		gameworld.Setup(x => x.TryGetItem(It.IsAny<long>(), It.IsAny<bool>()))
 		         .Returns((long id, bool _) => items is not null && items.TryGetValue(id, out var item) ? item : null!);
 		return gameworld;
+	}
+
+	private static EmploymentActionStepResult AdvanceTaskOrAssignmentFailure(EmploymentTaskDispatcher dispatcher,
+		IEmploymentActiveTask task, IEmploymentTaskContext context, params EmploymentCandidateProfile[] profiles)
+	{
+		if (task.AssignedEmployee is null &&
+		    !dispatcher.TryAssignTask(task, profiles, context, out var reason))
+		{
+			return EmploymentActionStepResult.Blocked(reason);
+		}
+
+		return dispatcher.AdvanceTask(task, context);
 	}
 
 	private sealed class TestEmploymentHost : FrameworkItem, IEmploymentHost

--- a/MudSharpCore Unit Tests/MagicPsionicTraceTests.cs
+++ b/MudSharpCore Unit Tests/MagicPsionicTraceTests.cs
@@ -657,10 +657,16 @@ public class MagicPsionicTraceTests
 		var characterList = characters.ToArray();
 		var cellList = cells.ToArray();
 		var powerList = powers.ToArray();
+		var charactersByIdentity = characterList
+		                           .GroupBy(CharacterInstanceIdentityComparer.IdentityId)
+		                           .ToDictionary(x => x.Key, x => x.First());
 		gameworld.SetupGet(x => x.Characters).Returns(CreateCollectionMock(characterList).Object);
 		gameworld.SetupGet(x => x.Actors).Returns(CreateCollectionMock(characterList).Object);
 		gameworld.SetupGet(x => x.Cells).Returns(CreateCollectionMock(cellList).Object);
 		gameworld.SetupGet(x => x.MagicPowers).Returns(CreateCollectionMock(powerList).Object);
+		gameworld.Setup(x => x.TryGetCharacter(It.IsAny<long>(), It.IsAny<bool>()))
+		         .Returns<long, bool>((id, _) =>
+			         charactersByIdentity.TryGetValue(id, out var character) ? character : null!);
 	}
 
 	private static Mock<IUneditableAll<T>> CreateCollectionMock<T>(params T[] items) where T : class, IFrameworkItem


### PR DESCRIPTION
## Summary
- Advance the blank database snapshot manifest and SQL to the latest migration state.
- Adjust database snapshot tests to match the new latest migration ID.
- Repair employment dispatch/command tests to reflect current task flow and policy setup.
- Restore magic/psionic trace test resolution by wiring identity-based character lookup in the test world.

## Testing
- Not run (not requested).