### PR TITLE
Fix patrol custody recovery and loosen crimes access for unconscious characters

### DIFF
--- a/Design Documents/Economy/Law_System_Runtime.md
+++ b/Design Documents/Economy/Law_System_Runtime.md
@@ -165,6 +165,8 @@ The `showenforcers [authority|zone]` admin command reports the enforcer roster f
 
 On-duty enforcers also report visible final-character-death corpses through the same local-authority corpse-report mechanism used by the player `REPORT CORPSE` command. The report is only queued when the corpse is visible, belongs to a zone with a responding legal authority, has an economic-zone morgue configured, and does not already have a pending or assigned recovery report.
 
+Active patrol enforcers immediately hand an arrestable active-enforcement target over to the patrol custody loop when the target becomes helpless. If a patrol member is already dragging the wanted character, the patrol can recover that active target and continue the normal prison path instead of treating the drag as unrelated custody. Kill-on-sight enforcement does not use this custody recovery path.
+
 On-duty enforcers who are not currently assigned to a patrol can still take immediate custody of a helpless nearby criminal when the legal authority has a known, unfinalised, arrestable crime for that person. The enforcer begins dragging the criminal, clears any enforcer-side grapple or clinch state used to subdue them, paths to the authority prison location, and then uses the normal incarceration flow. This fallback is intentionally limited to arrestable detention cases; kill-on-sight enforcement and ordinary active fights remain patrol/combat behavior.
 
 ## Legal Status Diagnostics

--- a/MudSharpCore Unit Tests/LegalCommandPresentationTests.cs
+++ b/MudSharpCore Unit Tests/LegalCommandPresentationTests.cs
@@ -11,6 +11,16 @@ namespace MudSharp_Unit_Tests;
 public class LegalCommandPresentationTests
 {
 	[TestMethod]
+	public void CrimesCommand_ShouldBeAvailableWhileUnconscious()
+	{
+		string source = File.ReadAllText(GetCoreSourcePath("Commands", "Modules", "CrimeModule.cs"));
+		string block = ExtractBlock(source, "[PlayerCommand(\"Crimes\", \"crimes\")]", "protected static void Crimes");
+
+		StringAssert.Contains(block, "[RequiredCharacterState(CharacterState.UnconsciousOrBetter)]");
+		Assert.IsFalse(block.Contains("[RequiredCharacterState(CharacterState.Able)]", StringComparison.Ordinal));
+	}
+
+	[TestMethod]
 	public void EngageLawyer_RemandsCellsAndSelfTarget_ShouldBeSupported()
 	{
 		string source = File.ReadAllText(GetCoreSourcePath("Commands", "Modules", "CrimeModule.cs"));

--- a/MudSharpCore Unit Tests/LegalPatrolStrategyTests.cs
+++ b/MudSharpCore Unit Tests/LegalPatrolStrategyTests.cs
@@ -107,10 +107,24 @@ public class LegalPatrolStrategyTests
 		StringAssert.Contains(source, "LeaveCombatIfAble(member);");
 		StringAssert.Contains(source, "EnforcementCustodyHelper.BeginDragging(random, criminal");
 		StringAssert.Contains(source, "EnforcementCustodyHelper.ReleaseGrapplesAndCombatAgainst(criminal, localPatrolMembers);");
+		StringAssert.Contains(source, "crime.Law.EnforcementStrategy.IsArrestable() && TryStartDraggingHelplessCriminal(patrol, criminal)");
 		int helperStart = source.IndexOf("private bool TryStartDraggingHelplessCriminal(IPatrol patrol, ICharacter criminal)", StringComparison.Ordinal);
 		int helperEnd = source.IndexOf("protected virtual void PatrolTickActiveEnforcement(IPatrol patrol)", helperStart, StringComparison.Ordinal);
 		string helperBlock = source[helperStart..helperEnd];
 		Assert.IsFalse(helperBlock.Contains("criminal.Combat?.Combatants.OfType<ICharacter>().Any(x => patrol.PatrolMembers.ContainsPhysicalInstance(x)) == true", StringComparison.Ordinal));
+	}
+
+	[TestMethod]
+	public void PatrolTickGeneral_ShouldRecoverPatrolDraggedWantedTargets()
+	{
+		string source = File.ReadAllText(GetCoreSourcePath("RPG", "Law", "PatrolStrategies", "PatrolStrategyBase.cs"));
+
+		StringAssert.Contains(source, "var beingDraggedByPatrol = IsBeingDraggedByPatrol(patrol, person);");
+		StringAssert.Contains(source, "person.AffectedBy<Dragging.DragTarget>(authority) && !beingDraggedByPatrol");
+		StringAssert.Contains(source, "x.Law.EnforcementStrategy.IsArrestable()");
+		StringAssert.Contains(source, "if (beingDraggedByPatrol)");
+		StringAssert.Contains(source, "patrol.ActiveEnforcementTarget = person;");
+		StringAssert.Contains(source, "patrol.ActiveEnforcementCrime = targetCrime;");
 	}
 
 	[TestMethod]
@@ -137,6 +151,8 @@ public class LegalPatrolStrategyTests
 		StringAssert.Contains(source, "private bool TryHandleIndependentCustody(ICharacter enforcer, EnforcerEffect effect)");
 		StringAssert.Contains(source, "enforcer.CombinedEffectsOfType<PatrolMemberEffect>().Any()");
 		StringAssert.Contains(source, "TryBeginIndependentCustody(character, victim, effect)");
+		StringAssert.Contains(source, "CharacterInstanceIdentityComparer.SamePhysicalInstanceOrBody(victim, patrol.ActiveEnforcementTarget)");
+		StringAssert.Contains(source, "patrol.PatrolStrategy.HandlePatrolTick(patrol);");
 		StringAssert.Contains(source, "EnforcementCustodyHelper.BeginDragging(enforcer, criminal, Enumerable.Empty<ICharacter>())");
 		StringAssert.Contains(source, "MoveIndependentCustodyToPrison(enforcer, effect, criminal, crime)");
 		StringAssert.Contains(source, "PathSearch.PathIncludeUnlockableDoors(enforcer)");

--- a/MudSharpCore/Commands/Modules/CrimeModule.cs
+++ b/MudSharpCore/Commands/Modules/CrimeModule.cs
@@ -59,7 +59,7 @@ internal class CrimeModule : Module<ICharacter>
     }
 
     [PlayerCommand("Crimes", "crimes")]
-    [RequiredCharacterState(CharacterState.Able)]
+    [RequiredCharacterState(CharacterState.UnconsciousOrBetter)]
     [HelpInfo("crimes", @"The #3crimes#0 command is used to view the crimes that you have committed or the crimes that you know someone else has committed. Enforcers can see all reported crimes of an individual even if they didn't witness them.
 
 In some jurisdictions you may not necessarily know that you have committed a crime but you otherwise generally know about all of your own crimes, even if the authorities don't.

--- a/MudSharpCore/NPC/AI/EnforcerAI.cs
+++ b/MudSharpCore/NPC/AI/EnforcerAI.cs
@@ -501,15 +501,24 @@ public class EnforcerAI : ArtificialIntelligenceBase, IOverrideAlertEmote
 			return true;
 		}
 
-		if (patrolMember == null || patrolMember.Patrol.ActiveEnforcementTarget != victim || patrolMember.Patrol
-			    .ActiveEnforcementCrime?.Law.EnforcementStrategy.ShowMercyToIncapacitatedTarget() !=
-		    false)
+		IPatrol patrol = patrolMember?.Patrol;
+		if (patrol is not null &&
+		    CharacterInstanceIdentityComparer.SamePhysicalInstanceOrBody(victim, patrol.ActiveEnforcementTarget))
 		{
-			character.Combat?.TruceRequested(character);
-        }
+			if (patrol.ActiveEnforcementCrime?.Law.EnforcementStrategy.ShowMercyToIncapacitatedTarget() == false)
+			{
+				return false;
+			}
 
-        return false;
-    }
+			character.Combat?.TruceRequested(character);
+			patrol.PatrolStrategy.HandlePatrolTick(patrol);
+			return true;
+		}
+
+		character.Combat?.TruceRequested(character);
+
+		return false;
+	}
 
     protected EnforcerEffect EnforcerEffect(ICharacter enforcer)
     {

--- a/MudSharpCore/RPG/Law/PatrolStrategies/PatrolStrategyBase.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/PatrolStrategyBase.cs
@@ -88,9 +88,10 @@ public abstract class PatrolStrategyBase : IPatrolStrategy
                 continue;
             }
 
+            var beingDraggedByPatrol = IsBeingDraggedByPatrol(patrol, person);
             if (person.AffectedBy<InCustodyOfEnforcer>(patrol.LegalAuthority) ||
                 person.AffectedBy<WarnedByEnforcer>(authority) ||
-                person.AffectedBy<Dragging.DragTarget>(authority) ||
+                person.AffectedBy<Dragging.DragTarget>(authority) && !beingDraggedByPatrol ||
                 person.AffectedBy<OnTrial>(authority))
             {
                 continue;
@@ -99,19 +100,29 @@ public abstract class PatrolStrategyBase : IPatrolStrategy
             List<ICrime> crimes = authority.KnownCrimesForIndividual(person)
                                            .Where(x => x.CriminalIdentityIsKnown)
                                            .Where(x => !x.HasBeenFinalised)
+                                           .Where(x => !x.BailPosted)
+                                           .Where(x => beingDraggedByPatrol
+                                               ? x.Law.EnforcementStrategy.IsArrestable()
+                                               : x.Law.EnforcementStrategy >= MinimumEnforcementStrategyToAct)
                                            .ToList();
-            if (!crimes.Any(x => !x.BailPosted && x.Law.EnforcementStrategy >= MinimumEnforcementStrategyToAct))
+            if (!crimes.Any())
             {
                 continue;
             }
 
             ICrime targetCrime = crimes
-                              .Where(x => !x.BailPosted)
                               .WhereMax(x => x.Law.EnforcementStrategy)
                               .OrderByDescending(x => x.Law.EnforcementPriority)
                               .First();
             patrol.ActiveEnforcementTarget = person;
             patrol.ActiveEnforcementCrime = targetCrime;
+            if (beingDraggedByPatrol)
+            {
+                person.RemoveAllEffects(x => x.IsEffectType<WarnedByEnforcer>(), true);
+                patrol.PatrolLeader.RemoveAllEffects<FollowingPath>(fireRemovalAction: true);
+                return true;
+            }
+
             patrol.WarnCriminal(person, targetCrime);
             patrol.PatrolLeader.RemoveAllEffects<FollowingPath>(fireRemovalAction: true);
             patrol.LegalAuthority.HandleDiscordNotificationOfEnforcement(targetCrime, patrol);
@@ -358,7 +369,7 @@ public abstract class PatrolStrategyBase : IPatrolStrategy
         }
 
         // Is criminal incapacitated?
-        if (TryStartDraggingHelplessCriminal(patrol, criminal))
+        if (crime.Law.EnforcementStrategy.IsArrestable() && TryStartDraggingHelplessCriminal(patrol, criminal))
         {
             return;
         }


### PR DESCRIPTION
## Summary
- Allow `crimes` to be used while unconscious so players can inspect active/legal status after being downed.
- Teach patrol logic to recognize when a wanted character is already being dragged by the patrol and recover that custody path instead of treating it as unrelated drag state.
- Restrict helpless-target drag initiation to arrestable enforcement only, leaving kill-on-sight enforcement on the combat path.
- Update the law-system runtime notes to describe the new patrol custody recovery behavior.
- Add regression coverage for the command surface and patrol strategy flow.

## Testing
- Added/updated unit tests covering command availability and patrol-enforcement handling.
- Not run (not requested).