### PR TITLE
Add subdue combat strategy and grapple-for-control support

### DIFF
--- a/Design Documents/Combat/Combat_Strategy_Runtime.md
+++ b/Design Documents/Combat/Combat_Strategy_Runtime.md
@@ -190,6 +190,14 @@ A melee-range avoidance strategy that tries to create distance without leaving t
 
 Expected active no-move cases: already safely out of melee, no viable pushback/trip/stagger attack, target can still oppose a withdrawal, or standard melee blockers.
 
+### Subdue
+
+A melee hostage-taking and arrest strategy. It keeps the standard melee defensive, inventory, fixed-action, and movement pipeline, but its active attack preference looks first for allowed weapon attacks that trip, stagger, stun, disarm, hinder, draw attention, or otherwise create advantage before falling back to ordinary melee selection while the target is still fully resisting. Combat setting percentages still gate the weapon, auxiliary, and natural channels. If authored auxiliary control actions are available, they are part of the same preference pool; natural control attacks are used as a fallback so unarmed or naturally armed creatures can still participate.
+
+Once the target is already grappled by the subduer, is focusing on another combatant, has negative offensive or defensive advantage, is helpless, is not upright, is staggered, is critically injured, has active wound pain/stun/shock/damage, or has pain/damage limb-ineffective effects, `Subdue` attempts only the clinch and grapple-control portion of `GrappleForControl`. If no control move is legal in that state, it falls back to the subdual-priority attack pool rather than ordinary melee. This lets secondary enforcers move straight to restraint and lets a primary subduer use weapon pressure until there is a realistic opening for control.
+
+Expected active no-move cases: standard melee blockers, no target, no legal attack or auxiliary control action, no legal grapple/clinch path and no subdual-priority attack when the target is ready for control, or combat policy refusing attacks.
+
 ## Movement and Layer Considerations
 
 The ranged advance strategies handle three spatial cases:

--- a/FutureMUDLibrary/Combat/CombatEnums.cs
+++ b/FutureMUDLibrary/Combat/CombatEnums.cs
@@ -181,7 +181,8 @@ namespace MudSharp.Combat
         Swooper,
         Drowner,
         Dropper,
-        PhysicalAvoider
+        PhysicalAvoider,
+        Subdue
     }
 
     public enum RangedWeaponType

--- a/MudSharpCore Unit Tests/CombatStrategyRuntimeTests.cs
+++ b/MudSharpCore Unit Tests/CombatStrategyRuntimeTests.cs
@@ -18,7 +18,10 @@ using MudSharp.Effects.Interfaces;
 using MudSharp.Framework;
 using MudSharp.Framework.Scheduling;
 using MudSharp.GameItems;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.Health;
 using MudSharp.Magic.Powers;
+using MudSharp.Movement;
 using MudSharp.RPG.Checks;
 using System;
 using System.Collections.Generic;
@@ -37,6 +40,8 @@ public class CombatStrategyRuntimeTests
 		Mock<IFuturemud> gameworld = new();
 		gameworld.Setup(x => x.GetStaticDouble("DodgeMoveStaminaCost")).Returns(10.0);
 		gameworld.Setup(x => x.GetStaticDouble("DodgeRangeMoveStaminaCost")).Returns(1.0);
+		gameworld.Setup(x => x.GetStaticDouble("StartClinchMoveStaminaCost")).Returns(1.0);
+		gameworld.SetupGet(x => x.ManualCombatCommands).Returns(new All<IManualCombatCommand>());
 
 		Mock<ICheck> check = new();
 		check.Setup(x => x.TargetNumber(
@@ -51,6 +56,9 @@ public class CombatStrategyRuntimeTests
 
 		typeof(CombatBase)
 			.GetProperty("GraceMoveStaminaCost", BindingFlags.Static | BindingFlags.NonPublic)!
+			.SetValue(null, new TraitExpression("1", gameworld.Object));
+		typeof(CombatBase)
+			.GetProperty("PowerMoveStaminaCost", BindingFlags.Static | BindingFlags.NonPublic)!
 			.SetValue(null, new TraitExpression("1", gameworld.Object));
 		typeof(StandardCheck)
 			.GetField("_bonusesPerDifficultyLevel", BindingFlags.Static | BindingFlags.NonPublic)!
@@ -198,14 +206,19 @@ public class CombatStrategyRuntimeTests
 		Assert.AreEqual("Drowner", CombatStrategyMode.Drowner.Describe());
 		Assert.AreEqual("Dropper", CombatStrategyMode.Dropper.Describe());
 		Assert.AreEqual("Physical Avoider", CombatStrategyMode.PhysicalAvoider.Describe());
+		Assert.AreEqual("Subdue", CombatStrategyMode.Subdue.Describe());
 
 		Assert.IsTrue(CombatStrategyMode.Drowner.IsMeleeStrategy());
 		Assert.IsTrue(CombatStrategyMode.Dropper.IsMeleeStrategy());
 		Assert.IsTrue(CombatStrategyMode.PhysicalAvoider.IsMeleeStrategy());
+		Assert.IsTrue(CombatStrategyMode.Subdue.IsMeleeStrategy());
 		Assert.IsTrue(CombatStrategyMode.PhysicalAvoider.IsRangedStrategy());
 		Assert.IsTrue(CombatStrategyMode.Drowner.IsMeleeDesiredStrategy());
 		Assert.IsTrue(CombatStrategyMode.Dropper.IsMeleeDesiredStrategy());
+		Assert.IsTrue(CombatStrategyMode.Subdue.IsMeleeDesiredStrategy());
+		Assert.IsFalse(CombatStrategyMode.Subdue.IsRangedStrategy());
 		Assert.IsTrue(CombatStrategyMode.PhysicalAvoider.IsRangedStartDesiringStrategy());
+		Assert.IsInstanceOfType(CombatStrategyFactory.GetStrategy(CombatStrategyMode.Subdue), typeof(SubdueStrategy));
 	}
 
 	[TestMethod]
@@ -527,6 +540,7 @@ public class CombatStrategyRuntimeTests
 		string melee = File.ReadAllText(GetCoreSourcePath("Combat", "Strategies", "StandardMeleeStrategy.cs"));
 		string ranged = File.ReadAllText(GetCoreSourcePath("Combat", "Strategies", "RangeBaseStrategy.cs"));
 		string avoider = File.ReadAllText(GetCoreSourcePath("Combat", "Strategies", "PhysicalAvoiderStrategy.cs"));
+		string subdue = File.ReadAllText(GetCoreSourcePath("Combat", "Strategies", "SubdueStrategy.cs"));
 		string clinch = File.ReadAllText(GetCoreSourcePath("Combat", "Strategies", "ClinchStrategy.cs"));
 		string swooper = File.ReadAllText(GetCoreSourcePath("Combat", "Strategies", "SwooperStrategy.cs"));
 
@@ -547,7 +561,7 @@ public class CombatStrategyRuntimeTests
 		StringAssert.Contains(melee, "combatant.CombatSettings.AuxiliaryPercentage");
 		StringAssert.Contains(ranged, "combatant.CombatSettings.AuxiliaryPercentage");
 
-		foreach (string source in new[] { strategyBase, melee, avoider, clinch, swooper })
+		foreach (string source in new[] { strategyBase, melee, avoider, subdue, clinch, swooper })
 		{
 			StringAssert.Contains(source, "ManualCombatCommandResolver.AiWeightMultiplier");
 			StringAssert.Contains(source, "GetWeightedRandom");
@@ -557,6 +571,260 @@ public class CombatStrategyRuntimeTests
 			"Manual combat commands should not add a separate strategy percentage bucket.");
 		Assert.IsFalse(settingsContract.Contains("ManualCombatPercentage", StringComparison.Ordinal),
 			"Manual combat commands should stay as multipliers over existing action categories.");
+	}
+
+	[TestMethod]
+	public void SubdueStrategySources_ControlAndGrapplePriorities_ArePresent()
+	{
+		string subdue = File.ReadAllText(GetCoreSourcePath("Combat", "Strategies", "SubdueStrategy.cs"));
+
+		StringAssert.Contains(subdue, "CombatStrategyMode.Subdue");
+		StringAssert.Contains(subdue, "GrappleForControlStrategy.Instance.AttemptGrappleForControlOnly");
+		StringAssert.Contains(subdue, "IsSecondaryCombatant");
+		StringAssert.Contains(subdue, "IsTargetDisadvantaged");
+		StringAssert.Contains(subdue, "IsTargetInjured");
+		StringAssert.Contains(subdue, "BuiltInCombatMoveType.StaggeringBlow");
+		StringAssert.Contains(subdue, "BuiltInCombatMoveType.UnbalancingBlow");
+		StringAssert.Contains(subdue, "CombatMoveIntentions.Disarm");
+		StringAssert.Contains(subdue, "UsableAuxiliaryMoves");
+		Assert.IsFalse(subdue.Contains("GrappleForControlStrategy.Instance.ChooseMove", StringComparison.Ordinal));
+	}
+
+	[TestMethod]
+	public void SubdueStrategy_ChooseMove_SecondaryTargetStartsClinchForControl()
+	{
+		var normalAttack = CreateWeaponAttack(BuiltInCombatMoveType.UseWeaponAttack, CombatMoveIntentions.None);
+		var scenario = CreateSubdueMoveSelectionScenario(new[] { normalAttack.Object }, 1.0, _ => true);
+
+		ICombatMove? move = SubdueStrategy.Instance.ChooseMove(scenario.Actor.Object);
+
+		Assert.IsInstanceOfType(move, typeof(StartClinchMove));
+	}
+
+	[TestMethod]
+	public void SubdueStrategy_ChooseMove_FailedControlUsesSubdualWeaponAttack()
+	{
+		var staggeringAttack = CreateWeaponAttack(BuiltInCombatMoveType.StaggeringBlow, CombatMoveIntentions.None);
+		var scenario = CreateSubdueMoveSelectionScenario(new[] { staggeringAttack.Object }, 1000.0, value => value < 100.0);
+
+		ICombatMove? move = SubdueStrategy.Instance.ChooseMove(scenario.Actor.Object);
+
+		Assert.IsInstanceOfType(move, typeof(StaggeringBlowMove));
+	}
+
+	[TestMethod]
+	public void SubdueStrategy_ChooseMove_FailedControlDoesNotFallBackToOrdinaryMelee()
+	{
+		var normalAttack = CreateWeaponAttack(BuiltInCombatMoveType.UseWeaponAttack, CombatMoveIntentions.None);
+		var scenario = CreateSubdueMoveSelectionScenario(new[] { normalAttack.Object }, 1000.0, value => value < 100.0);
+
+		ICombatMove? move = SubdueStrategy.Instance.ChooseMove(scenario.Actor.Object);
+
+		Assert.IsNull(move);
+	}
+
+	private static Mock<IWeaponAttack> CreateWeaponAttack(BuiltInCombatMoveType moveType,
+		CombatMoveIntentions intentions)
+	{
+		Mock<IWeaponAttack> attack = new();
+		attack.SetupGet(x => x.Id).Returns((long)moveType);
+		attack.SetupGet(x => x.MoveType).Returns(moveType);
+		attack.SetupGet(x => x.Intentions).Returns(intentions);
+		attack.SetupGet(x => x.StaminaCost).Returns(1.0);
+		attack.SetupGet(x => x.Weighting).Returns(1.0);
+		attack.SetupGet(x => x.BaseDelay).Returns(1.0);
+		attack.SetupGet(x => x.RecoveryDifficultyFailure).Returns(Difficulty.Normal);
+		attack.SetupGet(x => x.RecoveryDifficultySuccess).Returns(Difficulty.Easy);
+		attack.SetupGet(x => x.ExertionLevel).Returns(ExertionLevel.Normal);
+		return attack;
+	}
+
+	private static (Mock<ICharacter> Actor, Mock<ICharacter> Target) CreateSubdueMoveSelectionScenario(
+		IEnumerable<IWeaponAttack> weaponAttacks,
+		double startClinchCost,
+		Func<double, bool> canSpendStamina)
+	{
+		var attackList = weaponAttacks.ToList();
+		Mock<IFuturemud> gameworld = CreateGameworld();
+		gameworld.Setup(x => x.GetStaticDouble("StartClinchMoveStaminaCost")).Returns(startClinchCost);
+
+		Mock<ICombat> combat = new();
+		combat.SetupGet(x => x.Friendly).Returns(false);
+
+		Mock<ICharacterCombatSettings> settings = new();
+		settings.SetupGet(x => x.InventoryManagement).Returns(AutomaticInventorySettings.FullyManual);
+		settings.SetupGet(x => x.ManualPositionManagement).Returns(true);
+		settings.SetupGet(x => x.MinimumStaminaToAttack).Returns(0.0);
+		settings.SetupGet(x => x.AttackHelpless).Returns(true);
+		settings.SetupGet(x => x.AttackCriticallyInjured).Returns(true);
+		settings.SetupGet(x => x.AttackDisarmed).Returns(true);
+		settings.SetupGet(x => x.WeaponUsePercentage).Returns(1.0);
+		settings.SetupGet(x => x.NaturalWeaponPercentage).Returns(0.0);
+		settings.SetupGet(x => x.AuxiliaryPercentage).Returns(0.0);
+		settings.SetupGet(x => x.MagicUsePercentage).Returns(0.0);
+		settings.SetupGet(x => x.PsychicUsePercentage).Returns(0.0);
+		settings.SetupGet(x => x.FallbackToUnarmedIfNoWeapon).Returns(false);
+		settings.SetupGet(x => x.RequiredIntentions).Returns(CombatMoveIntentions.None);
+		settings.SetupGet(x => x.ForbiddenIntentions).Returns(CombatMoveIntentions.None);
+		settings.SetupGet(x => x.PreferredIntentions).Returns(CombatMoveIntentions.None);
+		settings.SetupGet(x => x.MeleeAttackOrderPreferences)
+		        .Returns(new List<MeleeAttackOrderPreference> { MeleeAttackOrderPreference.Weapon });
+		settings.Setup(x => x.ManualCombatCommandWeightMultiplier(It.IsAny<IManualCombatCommand>()))
+		        .Returns(1.0);
+
+		Mock<IRace> race = new();
+		race.SetupGet(x => x.CombatSettings).Returns(new RacialCombatSettings
+		{
+			CanAttack = true,
+			CanDefend = true,
+			CanUseWeapons = true
+		});
+		race.Setup(x => x.UsableAuxiliaryMoves(It.IsAny<ICharacter>(), It.IsAny<IPerceiver>(), false))
+		    .Returns(Array.Empty<IAuxiliaryCombatAction>());
+		race.Setup(x => x.UsableNaturalWeaponAttacks(It.IsAny<ICharacter>(), It.IsAny<IPerceiver>(), false,
+			      It.IsAny<BuiltInCombatMoveType[]>()))
+		    .Returns(Array.Empty<INaturalAttack>());
+
+		Mock<IGameItem> weaponItem = new();
+		Mock<IMeleeWeapon> weapon = new();
+		Mock<IWeaponType> weaponType = new();
+		weaponItem.Setup(x => x.GetItemType<IMeleeWeapon>()).Returns(weapon.Object);
+		weaponItem.Setup(x => x.IsItemType<IMeleeWeapon>()).Returns(true);
+		weapon.SetupGet(x => x.Parent).Returns(weaponItem.Object);
+		weapon.SetupGet(x => x.WeaponType).Returns(weaponType.Object);
+		weapon.SetupGet(x => x.Classification).Returns(WeaponClassification.NonLethal);
+		weaponType.Setup(x => x.UsableAttacks(
+				It.IsAny<IPerceiver>(),
+				It.IsAny<IGameItem>(),
+				It.IsAny<IPerceiver>(),
+				It.IsAny<AttackHandednessOptions>(),
+				false,
+				It.IsAny<BuiltInCombatMoveType[]>()))
+			.Returns((IPerceiver attacker, IGameItem item, IPerceiver attackTarget,
+				AttackHandednessOptions handedness, bool ignorePosition, BuiltInCombatMoveType[] types) =>
+				attackList.Where(x => types.Contains(x.MoveType)));
+
+		Mock<IBody> actorBody = new();
+		actorBody.SetupGet(x => x.WieldedItems).Returns(new[] { weaponItem.Object });
+		actorBody.SetupGet(x => x.HeldOrWieldedItems).Returns(new[] { weaponItem.Object });
+		actorBody.SetupGet(x => x.Implants).Returns(Array.Empty<IImplant>());
+		actorBody.SetupGet(x => x.Prosthetics).Returns(Array.Empty<IProsthetic>());
+		actorBody.Setup(x => x.WieldedHandCount(weaponItem.Object)).Returns(1);
+		actorBody.Setup(x => x.EffectsOfType<IPacifismEffect>(It.IsAny<Predicate<IPacifismEffect>>()))
+		         .Returns(Array.Empty<IPacifismEffect>());
+
+		Mock<IBody> targetBody = new();
+		targetBody.SetupGet(x => x.HeldOrWieldedItems).Returns(Array.Empty<IGameItem>());
+		targetBody.Setup(x => x.EffectsOfType<ILimbIneffectiveEffect>(It.IsAny<Predicate<ILimbIneffectiveEffect>>()))
+		          .Returns(Array.Empty<ILimbIneffectiveEffect>());
+
+		Mock<ICharacter> actor = new();
+		Mock<ICharacter> target = new();
+		Mock<ICharacter> ally = new();
+
+		actor.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		actor.SetupGet(x => x.Race).Returns(race.Object);
+		actor.SetupGet(x => x.Body).Returns(actorBody.Object);
+		actor.SetupProperty(x => x.CombatSettings, settings.Object);
+		actor.SetupProperty(x => x.State, CharacterState.Awake);
+		actor.SetupProperty(x => x.PositionState, PositionStanding.Instance);
+		actor.SetupProperty(x => x.CombatTarget, target.Object);
+		actor.SetupProperty(x => x.Combat, combat.Object);
+		actor.SetupProperty(x => x.MeleeRange, true);
+		actor.SetupGet(x => x.CurrentStamina).Returns(100.0);
+		actor.SetupGet(x => x.RidingMount).Returns((ICharacter?)null);
+		actor.SetupGet(x => x.Encumbrance).Returns(EncumbranceLevel.Unencumbered);
+		actor.SetupGet(x => x.EncumbrancePercentage).Returns(0.0);
+		actor.SetupGet(x => x.Effects).Returns(Array.Empty<IEffect>());
+		actor.Setup(x => x.CombinedEffectsOfType<IEffect>()).Returns(Array.Empty<IEffect>());
+		actor.Setup(x => x.CanMove(CanMoveFlags.IgnoreCancellableActionBlockers)).Returns(CanMoveResponse.True);
+		actor.Setup(x => x.CanSpendStamina(It.IsAny<double>()))
+		     .Returns((double value) => canSpendStamina(value));
+		actor.Setup(x => x.ColocatedWith(target.Object)).Returns(true);
+		SetupEmptyCombatEffects(actor);
+
+		target.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+		target.SetupGet(x => x.Race).Returns(race.Object);
+		target.SetupGet(x => x.Body).Returns(targetBody.Object);
+		target.SetupProperty(x => x.CombatSettings, settings.Object);
+		target.SetupProperty(x => x.State, CharacterState.Awake);
+		target.SetupProperty(x => x.PositionState, PositionStanding.Instance);
+		target.SetupProperty(x => x.CombatTarget, ally.Object);
+		target.SetupProperty(x => x.MeleeRange, true);
+		target.SetupGet(x => x.IsHelpless).Returns(false);
+		target.SetupGet(x => x.RidingMount).Returns((ICharacter?)null);
+		target.Setup(x => x.EffectsOfType<ClinchEffect>(It.IsAny<Predicate<ClinchEffect>>()))
+		      .Returns(Array.Empty<ClinchEffect>());
+
+		combat.SetupGet(x => x.Combatants).Returns(new IPerceiver[] { actor.Object, target.Object, ally.Object });
+		return (actor, target);
+	}
+
+	private static void SetupEmptyCombatEffects(Mock<ICharacter> character)
+	{
+		character.Setup(x => x.EffectsOfType<SelectedCombatAction>(It.IsAny<Predicate<SelectedCombatAction>>()))
+		         .Returns(Array.Empty<SelectedCombatAction>());
+		character.Setup(x => x.EffectsOfType<Rescue>(It.IsAny<Predicate<Rescue>>()))
+		         .Returns(Array.Empty<Rescue>());
+		character.Setup(x => x.EffectsOfType<IGuardCharacterEffect>(It.IsAny<Predicate<IGuardCharacterEffect>>()))
+		         .Returns(Array.Empty<IGuardCharacterEffect>());
+		character.Setup(x => x.EffectsOfType<ICombatGetItemEffect>(It.IsAny<Predicate<ICombatGetItemEffect>>()))
+		         .Returns(Array.Empty<ICombatGetItemEffect>());
+		character.Setup(x => x.EffectsOfType<ClinchEffect>(It.IsAny<Predicate<ClinchEffect>>()))
+		         .Returns(Array.Empty<ClinchEffect>());
+		character.Setup(x => x.EffectsOfType<ClinchCooldown>(It.IsAny<Predicate<ClinchCooldown>>()))
+		         .Returns(Array.Empty<ClinchCooldown>());
+		character.Setup(x => x.EffectsOfType<IGrappling>(It.IsAny<Predicate<IGrappling>>()))
+		         .Returns(Array.Empty<IGrappling>());
+		character.Setup(x => x.EffectsOfType<CombatCoupDeGrace>(It.IsAny<Predicate<CombatCoupDeGrace>>()))
+		         .Returns(Array.Empty<CombatCoupDeGrace>());
+		character.Setup(x => x.EffectsOfType<FixedCombatMoveType>(It.IsAny<Predicate<FixedCombatMoveType>>()))
+		         .Returns(Array.Empty<FixedCombatMoveType>());
+	}
+
+	[TestMethod]
+	public void SubdueStrategy_ShouldGrappleForControl_WhenTargetIsSecondaryDisadvantagedOrInjured()
+	{
+		Mock<ICharacter> actor = new();
+		actor.Setup(x => x.EffectsOfType<IGrappling>(It.IsAny<Predicate<IGrappling>>()))
+		     .Returns(Array.Empty<IGrappling>());
+
+		Mock<IBody> body = new();
+		body.Setup(x => x.EffectsOfType<ILimbIneffectiveEffect>(It.IsAny<Predicate<ILimbIneffectiveEffect>>()))
+		    .Returns(Array.Empty<ILimbIneffectiveEffect>());
+
+		Mock<IHealthStrategy> health = new();
+		IEnumerable<IWound> wounds = Array.Empty<IWound>();
+
+		Mock<ICharacter> target = new();
+		target.SetupGet(x => x.Body).Returns(body.Object);
+		target.SetupGet(x => x.HealthStrategy).Returns(health.Object);
+		target.SetupGet(x => x.Wounds).Returns(() => wounds);
+		target.SetupGet(x => x.IsHelpless).Returns(false);
+		target.SetupProperty(x => x.CombatTarget, actor.Object);
+		target.SetupProperty(x => x.State, CharacterState.Awake);
+		target.SetupProperty(x => x.PositionState, PositionStanding.Instance);
+		target.SetupProperty(x => x.DefensiveAdvantage, 0.0);
+		target.SetupProperty(x => x.OffensiveAdvantage, 0.0);
+		target.Setup(x => x.EffectsOfType<Staggered>(It.IsAny<Predicate<Staggered>>()))
+		      .Returns(Array.Empty<Staggered>());
+		health.Setup(x => x.IsCriticallyInjured(target.Object)).Returns(false);
+
+		Assert.IsFalse(SubdueStrategy.ShouldGrappleForControl(actor.Object, target.Object));
+
+		Mock<ICharacter> ally = new();
+		target.Object.CombatTarget = ally.Object;
+		Assert.IsTrue(SubdueStrategy.ShouldGrappleForControl(actor.Object, target.Object));
+
+		target.Object.CombatTarget = actor.Object;
+		target.Object.DefensiveAdvantage = -1.0;
+		Assert.IsTrue(SubdueStrategy.ShouldGrappleForControl(actor.Object, target.Object));
+
+		target.Object.DefensiveAdvantage = 0.0;
+		Mock<IWound> wound = new();
+		wound.SetupGet(x => x.CurrentDamage).Returns(1.0);
+		wounds = new[] { wound.Object };
+		Assert.IsTrue(SubdueStrategy.ShouldGrappleForControl(actor.Object, target.Object));
 	}
 
 	private static string GetSourcePath(params string[] segments)

--- a/MudSharpCore/Combat/CombatExtensions.cs
+++ b/MudSharpCore/Combat/CombatExtensions.cs
@@ -408,6 +408,8 @@ public static class CombatExtensions
                 return "Dropper";
             case CombatStrategyMode.PhysicalAvoider:
                 return "Physical Avoider";
+            case CombatStrategyMode.Subdue:
+                return "Subdue";
             default:
                 throw new ApplicationException("Unknown CombatStrategyMode in Describe.");
         }
@@ -466,6 +468,8 @@ public static class CombatExtensions
                 return "grapple opponents, carry them upward while flying, and drop them";
             case CombatStrategyMode.PhysicalAvoider:
                 return "use trips, staggers and pushbacks to keep enemies out of melee range";
+            case CombatStrategyMode.Subdue:
+                return "use melee control attacks to stagger, trip or disarm opponents, then grapple them for control";
             default:
                 throw new ApplicationException("Unknown CombatStrategyMode in Describe.");
         }
@@ -496,6 +500,7 @@ public static class CombatExtensions
             case CombatStrategyMode.Drowner:
             case CombatStrategyMode.Dropper:
             case CombatStrategyMode.PhysicalAvoider:
+            case CombatStrategyMode.Subdue:
                 return true;
             default:
                 return false;
@@ -551,6 +556,7 @@ public static class CombatExtensions
             case CombatStrategyMode.MeleeShooter:
             case CombatStrategyMode.Drowner:
             case CombatStrategyMode.Dropper:
+            case CombatStrategyMode.Subdue:
                 return true;
             default:
                 return false;

--- a/MudSharpCore/Combat/CombatStrategyFactory.cs
+++ b/MudSharpCore/Combat/CombatStrategyFactory.cs
@@ -58,6 +58,8 @@ public class CombatStrategyFactory
                 return Strategies.DropperStrategy.Instance;
             case CombatStrategyMode.PhysicalAvoider:
                 return Strategies.PhysicalAvoiderStrategy.Instance;
+            case CombatStrategyMode.Subdue:
+                return Strategies.SubdueStrategy.Instance;
             default:
                 throw new NotImplementedException("Unknown CombatStrategyMode in CombatStrategyFactory.GetStrategy: " +
                                                   mode.Describe());

--- a/MudSharpCore/Combat/Strategies/ClinchStrategy.cs
+++ b/MudSharpCore/Combat/Strategies/ClinchStrategy.cs
@@ -305,7 +305,7 @@ public class ClinchStrategy : StandardMeleeStrategy
         return natAttacks.Any();
     }
 
-    private ICombatMove CheckClinching(ICharacter ch)
+    protected ICombatMove AttemptStartClinch(ICharacter ch, bool allowStandardMeleeFallback)
     {
         if (ch.PositionState.Upright &&
                 !ch.EffectsOfType<ClinchEffect>().Any() &&
@@ -315,7 +315,7 @@ public class ClinchStrategy : StandardMeleeStrategy
         {
             if (!StartClinchMove.CanClinchWhileMounted(ch, charTarget))
             {
-                if (ch.CombatStrategyMode == CombatStrategyMode.Clinch && HasViableMeleeAttack(ch))
+                if (allowStandardMeleeFallback && ch.CombatStrategyMode == CombatStrategyMode.Clinch && HasViableMeleeAttack(ch))
                 {
                     ch.Send($"You cannot reach {charTarget.HowSeen(ch)} well enough to clinch while you are mounted, so you fight normally.");
                     ch.CombatStrategyMode = CombatStrategyMode.StandardMelee;
@@ -329,6 +329,17 @@ public class ClinchStrategy : StandardMeleeStrategy
             {
                 return new StartClinchMove(charTarget) { Assailant = ch };
             }
+        }
+
+        return null;
+    }
+
+    private ICombatMove CheckClinching(ICharacter ch)
+    {
+        ICombatMove move;
+        if ((move = AttemptStartClinch(ch, true)) != null)
+        {
+            return move;
         }
 
         if (ch.EffectsOfType<ClinchEffect>().Any(x => x.Target == ch.CombatTarget))

--- a/MudSharpCore/Combat/Strategies/GrappleForControlStrategy.cs
+++ b/MudSharpCore/Combat/Strategies/GrappleForControlStrategy.cs
@@ -1,6 +1,7 @@
 ﻿using MudSharp.Body;
 using MudSharp.Character;
 using MudSharp.Combat.Moves;
+using MudSharp.Effects.Concrete;
 using MudSharp.Effects.Interfaces;
 using MudSharp.Framework;
 using System;
@@ -24,6 +25,20 @@ public class GrappleForControlStrategy : ClinchStrategy
     protected override ICombatMove AttemptClinchAttack(ICharacter ch)
     {
         return AttemptGrapple(ch) ?? base.AttemptClinchAttack(ch);
+    }
+
+    public ICombatMove AttemptGrappleForControlOnly(ICharacter ch)
+    {
+        ICombatMove move;
+        if ((move = AttemptStartClinch(ch, false)) != null)
+        {
+            return move;
+        }
+
+        return ch.EffectsOfType<ClinchEffect>().Any(x => x.Target == ch.CombatTarget) ||
+               ch.EffectsOfType<IGrappling>().Any(x => x.Target == ch.CombatTarget)
+            ? AttemptGrapple(ch)
+            : null;
     }
 
     protected virtual ICombatMove AttemptGrappleInProgress(ICharacter ch, IGrappling grapple,

--- a/MudSharpCore/Combat/Strategies/SubdueStrategy.cs
+++ b/MudSharpCore/Combat/Strategies/SubdueStrategy.cs
@@ -1,0 +1,298 @@
+#nullable enable
+
+using MudSharp.Character;
+using MudSharp.Combat.Moves;
+using MudSharp.Effects.Concrete;
+using MudSharp.Effects.Interfaces;
+using MudSharp.Framework;
+using MudSharp.GameItems.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MudSharp.Combat.Strategies;
+
+public class SubdueStrategy : StandardMeleeStrategy
+{
+	private static readonly BuiltInCombatMoveType[] SubdualWeaponMoveTypes =
+	{
+		BuiltInCombatMoveType.UseWeaponAttack,
+		BuiltInCombatMoveType.StaggeringBlow,
+		BuiltInCombatMoveType.UnbalancingBlow,
+		BuiltInCombatMoveType.Pushback
+	};
+
+	private static readonly BuiltInCombatMoveType[] InherentlySubdualWeaponMoveTypes =
+	{
+		BuiltInCombatMoveType.StaggeringBlow,
+		BuiltInCombatMoveType.UnbalancingBlow,
+		BuiltInCombatMoveType.Pushback
+	};
+
+	private static readonly BuiltInCombatMoveType[] SubdualNaturalMoveTypes =
+	{
+		BuiltInCombatMoveType.NaturalWeaponAttack,
+		BuiltInCombatMoveType.StaggeringBlowUnarmed,
+		BuiltInCombatMoveType.StaggeringBlowClinch,
+		BuiltInCombatMoveType.UnbalancingBlowUnarmed,
+		BuiltInCombatMoveType.UnbalancingBlowClinch,
+		BuiltInCombatMoveType.PushbackUnarmed,
+		BuiltInCombatMoveType.PushbackClinch
+	};
+
+	private static readonly BuiltInCombatMoveType[] InherentlySubdualNaturalMoveTypes =
+	{
+		BuiltInCombatMoveType.StaggeringBlowUnarmed,
+		BuiltInCombatMoveType.StaggeringBlowClinch,
+		BuiltInCombatMoveType.UnbalancingBlowUnarmed,
+		BuiltInCombatMoveType.UnbalancingBlowClinch,
+		BuiltInCombatMoveType.PushbackUnarmed,
+		BuiltInCombatMoveType.PushbackClinch
+	};
+
+	private const CombatMoveIntentions SubdualIntentions =
+		CombatMoveIntentions.Submit |
+		CombatMoveIntentions.Grapple |
+		CombatMoveIntentions.Disadvantage |
+		CombatMoveIntentions.Advantage |
+		CombatMoveIntentions.Attention |
+		CombatMoveIntentions.Trip |
+		CombatMoveIntentions.Stun |
+		CombatMoveIntentions.Hinder |
+		CombatMoveIntentions.Disarm;
+
+	protected SubdueStrategy()
+	{
+	}
+
+	public new static SubdueStrategy Instance { get; } = new();
+
+	public override CombatStrategyMode Mode => CombatStrategyMode.Subdue;
+
+	protected override ICombatMove? HandleAttacks(IPerceiver combatant)
+	{
+		if (combatant is not ICharacter ch || ch.CombatTarget is not ICharacter target)
+		{
+			return base.HandleAttacks(combatant);
+		}
+
+		if (ShouldGrappleForControl(ch, target))
+		{
+			var grappleMove = GrappleForControlStrategy.Instance.AttemptGrappleForControlOnly(ch);
+			if (grappleMove is not null)
+			{
+				return grappleMove;
+			}
+
+			return HandleSubdualAttacksOnly(ch);
+		}
+
+		return base.HandleAttacks(combatant);
+	}
+
+	private ICombatMove? HandleSubdualAttacksOnly(ICharacter ch)
+	{
+		if (!WillAttackTarget(ch))
+		{
+			return null;
+		}
+
+		var move = CheckFixedAttacks(ch);
+		if (move is not null)
+		{
+			return move;
+		}
+
+		if (ch.CurrentStamina < ch.CombatSettings.MinimumStaminaToAttack)
+		{
+			return null;
+		}
+
+		return TrySubdualAttack(ch);
+	}
+
+	protected override ICombatMove? HandleGeneralAttacks(ICharacter combatant)
+	{
+		return TrySubdualAttack(combatant) ?? base.HandleGeneralAttacks(combatant);
+	}
+
+	internal static bool ShouldGrappleForControl(ICharacter ch, ICharacter target)
+	{
+		if (ch.EffectsOfType<IGrappling>().Any(x => x.Target == target))
+		{
+			return true;
+		}
+
+		return IsSecondaryCombatant(ch, target) ||
+		       IsTargetDisadvantaged(target) ||
+		       IsTargetInjured(target);
+	}
+
+	private static bool IsSecondaryCombatant(ICharacter ch, ICharacter target)
+	{
+		return target.CombatTarget is not null && target.CombatTarget != ch;
+	}
+
+	private static bool IsTargetDisadvantaged(ICharacter target)
+	{
+		return target.IsHelpless ||
+		       !CharacterState.Able.HasFlag(target.State) ||
+		       !target.PositionState.Upright ||
+		       target.DefensiveAdvantage < 0.0 ||
+		       target.OffensiveAdvantage < 0.0 ||
+		       target.EffectsOfType<Staggered>().Any();
+	}
+
+	private static bool IsTargetInjured(ICharacter target)
+	{
+		return target.HealthStrategy.IsCriticallyInjured(target) ||
+		       target.Wounds.Any(x =>
+			       x.CurrentDamage > 0.0 ||
+			       x.CurrentPain > 0.0 ||
+			       x.CurrentStun > 0.0 ||
+			       x.CurrentShock > 0.0) ||
+		       target.Body.EffectsOfType<ILimbIneffectiveEffect>().Any(x =>
+			       x.Reason.In(
+				       LimbIneffectiveReason.Pain,
+				       LimbIneffectiveReason.Damage,
+				       LimbIneffectiveReason.SpinalDamage,
+				       LimbIneffectiveReason.Severing));
+	}
+
+	private static bool HasSubdualPriority(IWeaponAttack attack)
+	{
+		return InherentlySubdualWeaponMoveTypes.Contains(attack.MoveType) ||
+		       (attack.Intentions & SubdualIntentions) != 0;
+	}
+
+	private static bool HasSubdualPriority(INaturalAttack attack)
+	{
+		return InherentlySubdualNaturalMoveTypes.Contains(attack.Attack.MoveType) ||
+		       (attack.Attack.Intentions & SubdualIntentions) != 0;
+	}
+
+	private static bool HasSubdualPriority(IAuxiliaryCombatAction action)
+	{
+		return (action.Intentions & SubdualIntentions) != 0;
+	}
+
+	private static ICombatMove? TrySubdualAttack(ICharacter combatant)
+	{
+		if (combatant.CombatTarget is not ICharacter target)
+		{
+			return null;
+		}
+
+		var candidates = new List<(Func<ICombatMove> Factory, double Weight)>();
+		if (combatant.CombatSettings.WeaponUsePercentage > 0.0)
+		{
+			AddWeaponCandidates(combatant, target, candidates);
+		}
+
+		if (combatant.CombatSettings.AuxiliaryPercentage > 0.0)
+		{
+			AddAuxiliaryCandidates(combatant, target, candidates);
+		}
+
+		if (combatant.PositionState.Upright &&
+		    (combatant.CombatSettings.NaturalWeaponPercentage > 0.0 ||
+		     (combatant.CombatSettings.FallbackToUnarmedIfNoWeapon && !candidates.Any())))
+		{
+			AddNaturalCandidates(combatant, target, candidates);
+		}
+
+		if (!candidates.Any())
+		{
+			return null;
+		}
+
+		return candidates.GetWeightedRandom(x => x.Weight).Factory();
+	}
+
+	private static void AddWeaponCandidates(ICharacter combatant, ICharacter target,
+		ICollection<(Func<ICombatMove> Factory, double Weight)> candidates)
+	{
+		var iterations = 0;
+		foreach (var preference in combatant.CombatSettings.MeleeAttackOrderPreferences.AsEnumerable().Reverse())
+		{
+			var weaponsForThisIteration = preference switch
+			{
+				MeleeAttackOrderPreference.Weapon => combatant.Body.WieldedItems
+				                                            .SelectNotNull(x => x!.GetItemType<IMeleeWeapon>()),
+				MeleeAttackOrderPreference.Implant => combatant.Body.Implants
+				                                             .OfType<IImplantMeleeWeapon>()
+				                                             .Where(x => x.WeaponIsActive)
+				                                             .Cast<IMeleeWeapon>(),
+				MeleeAttackOrderPreference.Prosthetic => combatant.Body.Prosthetics
+				                                                .OfType<IProstheticMeleeWeapon>()
+				                                                .Where(x => x.WeaponIsActive)
+				                                                .Cast<IMeleeWeapon>(),
+				_ => Enumerable.Empty<IMeleeWeapon>()
+			};
+
+			iterations++;
+			var preferenceMultiplier = iterations;
+			foreach (var weapon in weaponsForThisIteration)
+			{
+				var attacks = weapon.WeaponType
+				                    .UsableAttacks(combatant, weapon.Parent, target, weapon.HandednessForWeapon(combatant),
+					                    false, SubdualWeaponMoveTypes)
+				                    .Where(HasSubdualPriority)
+				                    .Where(x => combatant.CanSpendStamina(MeleeWeaponAttack.MoveStaminaCost(combatant, x)))
+				                    .ToList();
+				foreach (var attack in attacks)
+				{
+					var weight = attack.Weighting *
+					             preferenceMultiplier *
+					             ManualCombatCommandResolver.AiWeightMultiplier(combatant, attack) *
+					             (attack.MoveType == BuiltInCombatMoveType.Pushback ? 1.5 : 4.0);
+					if (weight <= 0.0)
+					{
+						continue;
+					}
+
+					candidates.Add((() => CombatMoveFactory.CreateWeaponAttack(combatant, weapon, attack, target), weight));
+				}
+			}
+		}
+	}
+
+	private static void AddAuxiliaryCandidates(ICharacter combatant, ICharacter target,
+		ICollection<(Func<ICombatMove> Factory, double Weight)> candidates)
+	{
+		foreach (var action in combatant.Race
+		                                .UsableAuxiliaryMoves(combatant, target, false)
+		                                .Where(HasSubdualPriority)
+		                                .Where(x =>
+			                                combatant.CanSpendStamina(AuxiliaryMove.MoveStaminaCost(combatant, x))))
+		{
+			var weight = action.Weighting * ManualCombatCommandResolver.AiWeightMultiplier(combatant, action) * 2.0;
+			if (weight <= 0.0)
+			{
+				continue;
+			}
+
+			candidates.Add((() => new AuxiliaryMove(combatant, target, action), weight));
+		}
+	}
+
+	private static void AddNaturalCandidates(ICharacter combatant, ICharacter target,
+		ICollection<(Func<ICombatMove> Factory, double Weight)> candidates)
+	{
+		foreach (var attack in combatant.Race
+		                                .UsableNaturalWeaponAttacks(combatant, target, false, SubdualNaturalMoveTypes)
+		                                .Where(HasSubdualPriority)
+		                                .Where(x => combatant.CanSpendStamina(NaturalAttackMove.MoveStaminaCost(combatant,
+			                                x.Attack))))
+		{
+			var weight = attack.Attack.Weighting *
+			             ManualCombatCommandResolver.AiWeightMultiplier(combatant, attack.Attack);
+			if (weight <= 0.0)
+			{
+				continue;
+			}
+
+			candidates.Add((() => CombatMoveFactory.CreateNaturalWeaponAttack(combatant, attack, target), weight));
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Added `Subdue` as a new combat strategy mode and wired it through enum description, strategy factory, and melee-strategy classification.
- Implemented `SubdueStrategy` to prefer control-oriented attacks, then switch to grapple-for-control when the target is already disadvantaged or injured.
- Extended clinch/grapple flow with a control-only entry point so subdue can attempt restraint without falling back to ordinary melee.
- Updated combat strategy runtime docs to describe the new behavior and expected no-move cases.
- Expanded combat strategy unit coverage for the new mode, strategy selection, and control/grapple priority paths.

## Testing
- Added and updated unit tests covering strategy enumeration, factory resolution, subdual attack selection, and grapple-for-control branching.
- Not run (not requested).