### PR TITLE
Fix cell-set exit targeting and tighten cardinal direction aliases

### DIFF
--- a/Design Documents/Building/Room_Building_Builder_Guide.md
+++ b/Design Documents/Building/Room_Building_Builder_Guide.md
@@ -413,6 +413,7 @@ cell set door <exit> clear
 
 `cell set door` controls whether an exit accepts a door and, if so, what size. It does not by itself install a specific door item.
 Player `look` and `exits` output shows door-capable exits without an installed door in bold white; installed doors still show their door state and description directly on the exit.
+Cardinal exit arguments accept the whitelisted short and common forms: `n`, `north`, `nw`, `northwest`, `north-west`, and `north west` (and the equivalent forms for other directions). They do not use arbitrary prefixes, so `north` targets the north exit even if a north-west exit also exists.
 
 Climb and fall:
 

--- a/FutureMUDLibrary Unit Tests/CardinalDirectionExtensionsTests.cs
+++ b/FutureMUDLibrary Unit Tests/CardinalDirectionExtensionsTests.cs
@@ -1,0 +1,45 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Construction;
+using MudSharp.Framework;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class CardinalDirectionExtensionsTests
+{
+	[TestMethod]
+	public void DescribeBrief_NorthWest_ReturnsNw()
+	{
+		Assert.AreEqual("nw", CardinalDirection.NorthWest.DescribeBrief());
+	}
+
+	[DataTestMethod]
+	[DataRow("nw")]
+	[DataRow("northwest")]
+	[DataRow("north-west")]
+	[DataRow("north west")]
+	public void CardinalExitStrings_NorthWestAliasesResolve(string alias)
+	{
+		Assert.IsTrue(CardinalDirectionExtensions.CardinalExitStrings.TryGetValue(alias, out var direction));
+		Assert.AreEqual(CardinalDirection.NorthWest, direction);
+	}
+
+	[DataTestMethod]
+	[DataRow("nor")]
+	[DataRow("northw")]
+	[DataRow("northwe")]
+	public void CardinalExitStrings_PartialPrefixesDoNotResolve(string alias)
+	{
+		Assert.IsFalse(CardinalDirectionExtensions.CardinalExitStrings.ContainsKey(alias));
+		Assert.IsFalse(Constants.CardinalDirectionStringToDirection.ContainsKey(alias));
+	}
+
+	[TestMethod]
+	public void CardinalDirectionStringToDirection_DownKeepsDnAlias()
+	{
+		Assert.IsTrue(Constants.CardinalDirectionStringToDirection.TryGetValue("dn", out var direction));
+		Assert.AreEqual(CardinalDirection.Down, direction);
+	}
+}

--- a/FutureMUDLibrary/Construction/CardinalDirection.cs
+++ b/FutureMUDLibrary/Construction/CardinalDirection.cs
@@ -26,54 +26,8 @@ namespace MudSharp.Construction
 
     public static partial class CardinalDirectionExtensions
     {
-        public static IReadOnlyDictionary<string, CardinalDirection> CardinalExitStrings { get; } = new Dictionary<string, CardinalDirection>(StringComparer.OrdinalIgnoreCase)
-        {
-            { "n", CardinalDirection.North },
-            { "no", CardinalDirection.North },
-            { "nor", CardinalDirection.North },
-            { "nort", CardinalDirection.North },
-            { "north", CardinalDirection.North },
-            { "e", CardinalDirection.East },
-            { "ea", CardinalDirection.East },
-            { "eas", CardinalDirection.East },
-            { "east", CardinalDirection.East },
-            { "s", CardinalDirection.South },
-            { "so", CardinalDirection.South },
-            { "sou", CardinalDirection.South },
-            { "sout", CardinalDirection.South },
-            { "south", CardinalDirection.South },
-            { "w", CardinalDirection.West },
-            { "we", CardinalDirection.West },
-            { "wes", CardinalDirection.West },
-            { "west", CardinalDirection.West },
-            { "ne", CardinalDirection.NorthEast },
-            { "northeast", CardinalDirection.NorthEast },
-            { "northe", CardinalDirection.NorthEast },
-            { "northea", CardinalDirection.NorthEast },
-            { "northes", CardinalDirection.NorthEast },
-            { "nw", CardinalDirection.NorthWest },
-            { "northwest", CardinalDirection.NorthWest },
-            { "northw", CardinalDirection.NorthWest },
-            { "northwe", CardinalDirection.NorthWest },
-            { "northwes", CardinalDirection.NorthWest },
-            { "se", CardinalDirection.SouthEast },
-            { "southeast", CardinalDirection.SouthEast },
-            { "southe", CardinalDirection.SouthEast },
-            { "southea", CardinalDirection.SouthEast },
-            { "southeas", CardinalDirection.SouthEast },
-            { "sw", CardinalDirection.SouthWest },
-            { "southwest", CardinalDirection.SouthWest },
-            { "southw", CardinalDirection.SouthWest },
-            { "southwe", CardinalDirection.SouthWest },
-            { "southwes", CardinalDirection.SouthWest },
-            { "u", CardinalDirection.Up },
-            { "up", CardinalDirection.Up },
-            { "d", CardinalDirection.Down },
-            { "do", CardinalDirection.Down },
-            { "dow", CardinalDirection.Down },
-            { "down", CardinalDirection.Down },
-            { "dn", CardinalDirection.Down },
-        };
+        public static IReadOnlyDictionary<string, CardinalDirection> CardinalExitStrings { get; } =
+            new Dictionary<string, CardinalDirection>(Constants.CardinalDirectionStringToDirection, StringComparer.OrdinalIgnoreCase);
         public static List<CardinalDirection> ContainedDirections(this (int Northness, int Southness, int Westness, int Eastness, int Upness, int Downness, int Unknownness) directions)
         {
             List<CardinalDirection> list = new();
@@ -456,7 +410,7 @@ namespace MudSharp.Construction
                 case CardinalDirection.NorthEast:
                     return "ne";
                 case CardinalDirection.NorthWest:
-                    return "se";
+                    return "nw";
                 case CardinalDirection.South:
                     return "s";
                 case CardinalDirection.SouthEast:

--- a/FutureMUDLibrary/Framework/Constants.cs
+++ b/FutureMUDLibrary/Framework/Constants.cs
@@ -81,6 +81,7 @@ namespace MudSharp.Framework
                 {"u", CardinalDirection.Up},
                 {"up", CardinalDirection.Up},
                 {"d", CardinalDirection.Down},
+                {"dn", CardinalDirection.Down},
                 {"down", CardinalDirection.Down}
             };
 

--- a/MudSharpCore Unit Tests/Commands/RoomBuilderModuleExitLookupTests.cs
+++ b/MudSharpCore Unit Tests/Commands/RoomBuilderModuleExitLookupTests.cs
@@ -1,0 +1,124 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Commands.Modules;
+using MudSharp.Construction;
+using MudSharp.Construction.Boundary;
+using MudSharp.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MudSharp_Unit_Tests.Commands;
+
+[TestClass]
+public class RoomBuilderModuleExitLookupTests
+{
+	[DataTestMethod]
+	[DataRow("north Normal", CardinalDirection.North, "Normal")]
+	[DataRow("n Normal", CardinalDirection.North, "Normal")]
+	[DataRow("nw Normal", CardinalDirection.NorthWest, "Normal")]
+	[DataRow("northwest Normal", CardinalDirection.NorthWest, "Normal")]
+	[DataRow("north-west Normal", CardinalDirection.NorthWest, "Normal")]
+	[DataRow("north west Normal", CardinalDirection.NorthWest, "Normal")]
+	public void GetCellExitForBuilderInput_CardinalAliasTargetsExactDirection(string command,
+		CardinalDirection expectedDirection, string expectedRemainder)
+	{
+		var north = CreateExit(1, CardinalDirection.North, "North");
+		var northwest = CreateExit(2, CardinalDirection.NorthWest, "North-West");
+		var input = new StringStack(command);
+
+		var result = RoomBuilderModule.GetCellExitForBuilderInput(
+			[northwest.Object, north.Object],
+			input,
+			CreatePerceiver().Object);
+
+		Assert.IsNotNull(result);
+		Assert.AreEqual(expectedDirection, result.OutboundDirection);
+		Assert.AreEqual(expectedRemainder, input.RemainingArgument);
+	}
+
+	[TestMethod]
+	public void GetCellExitForBuilderInput_IdTargetsExitById()
+	{
+		var north = CreateExit(1, CardinalDirection.North, "North");
+		var northwest = CreateExit(2, CardinalDirection.NorthWest, "North-West");
+		var input = new StringStack("2 clear");
+
+		var result = RoomBuilderModule.GetCellExitForBuilderInput(
+			[north.Object, northwest.Object],
+			input,
+			CreatePerceiver().Object);
+
+		Assert.AreSame(northwest.Object, result);
+		Assert.AreEqual("clear", input.RemainingArgument);
+	}
+
+	[TestMethod]
+	public void GetCellExitForBuilderInput_NonCardinalKeywordRequiresExactKeyword()
+	{
+		var gate = CreateExit(3, CardinalDirection.Unknown, "gate");
+		var input = new StringStack("gate Normal");
+
+		var result = RoomBuilderModule.GetCellExitForBuilderInput(
+			[gate.Object],
+			input,
+			CreatePerceiver().Object);
+
+		Assert.AreSame(gate.Object, result);
+		Assert.AreEqual("Normal", input.RemainingArgument);
+	}
+
+	[TestMethod]
+	public void GetCellExitForBuilderInput_NonCardinalKeywordDoesNotUsePrefixMatching()
+	{
+		var gate = CreateExit(3, CardinalDirection.Unknown, "gate");
+		var input = new StringStack("ga Normal");
+
+		var result = RoomBuilderModule.GetCellExitForBuilderInput(
+			[gate.Object],
+			input,
+			CreatePerceiver().Object);
+
+		Assert.IsNull(result);
+		Assert.AreEqual("Normal", input.RemainingArgument);
+	}
+
+	private static Mock<ICellExit> CreateExit(long id, CardinalDirection direction, params string[] keywords)
+	{
+		var parent = new Mock<IExit>();
+		parent.SetupGet(x => x.Id).Returns(id);
+
+		var exit = new Mock<ICellExit>();
+		exit.SetupGet(x => x.Exit).Returns(parent.Object);
+		exit.SetupGet(x => x.OutboundDirection).Returns(direction);
+		exit.SetupGet(x => x.Keywords).Returns(keywords);
+		exit.Setup(x => x.GetKeywordsFor(It.IsAny<IPerceiver>())).Returns(keywords);
+		exit.Setup(x => x.HasKeyword(It.IsAny<string>(), It.IsAny<IPerceiver>(), It.IsAny<bool>(),
+				It.IsAny<bool>()))
+		    .Returns<string, IPerceiver, bool, bool>((target, _, abbreviated, useContainsOverStartsWith) =>
+			    HasKeyword(keywords, target, abbreviated, useContainsOverStartsWith));
+		return exit;
+	}
+
+	private static Mock<IPerceiver> CreatePerceiver()
+	{
+		var perceiver = new Mock<IPerceiver>();
+		perceiver.Setup(x => x.HasDubFor(It.IsAny<IKeyworded>(), It.IsAny<string>())).Returns(false);
+		return perceiver;
+	}
+
+	private static bool HasKeyword(IEnumerable<string> keywords, string target, bool abbreviated,
+		bool useContainsOverStartsWith)
+	{
+		if (!abbreviated)
+		{
+			return keywords.Any(x => x.Equals(target, StringComparison.InvariantCultureIgnoreCase));
+		}
+
+		return useContainsOverStartsWith
+			? keywords.Any(x => x.Contains(target, StringComparison.InvariantCultureIgnoreCase))
+			: keywords.Any(x => x.StartsWith(target, StringComparison.InvariantCultureIgnoreCase));
+	}
+}

--- a/MudSharpCore/Commands/Modules/RoomBuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/RoomBuilderModule.cs
@@ -1716,8 +1716,34 @@ You can use the following subcommands:
 
     #region CellSet
 
+    internal const string CellSetHelpText = @"Valid options for #3cell set#0 are as follows:
+
+	#3cell set name <name>#0 - sets the name of the cell
+	#3cell set desc#0 - drops you into an editor to edit the cell description
+	#3cell set suggestdesc#0 - uses configured AI description generation to suggest a description
+	#3cell set terrain <id|name>#0 - sets the terrain of this cell
+	#3cell set hearing <id|name>#0 - sets the hearing/noise profile for this cell
+	#3cell set lightmultiplier <multiplier>#0 - sets the multiplier for natural light
+	#3cell set lightlevel <lux>#0 - sets the added light for the location to the specified lux level
+	#3cell set type outdoors|indoors|cave|windows|exposed#0 - sets the cell exposure type
+	#3cell set door <exit id|direction|keyword> clear#0 - clears the exit from accepting doors
+	#3cell set door <exit id|direction|keyword> <size>#0 - sets the exit to accept doors of the specified size
+	#3cell set forage clear#0 - clears an existing forage profile
+	#3cell set forage <id|name>#0 - sets the forage profile to the specified profile
+	#3cell set atmosphere liquid|gas <id|name>#0 - sets the atmosphere to the specified fluid
+	#3cell set atmosphere none#0 - sets the location to have no atmosphere
+	#3cell set safequit#0 - toggles whether the current room is a safe quit room
+	#3cell set register <varname> <value>#0 - sets the specified prog variable for the current cell
+	#3cell set register delete <varname>#0 - resets the specified prog variable to its default value";
+
     private static void CellSet(ICharacter actor, StringStack input)
     {
+        if (input.IsFinished || input.Peek().EqualTo("help") || input.Peek().EqualTo("?"))
+        {
+            actor.OutputHandler.Send(CellSetHelpText.SubstituteANSIColour());
+            return;
+        }
+
         if (input.Peek().EqualTo("exit"))
         {
             input.PopSpeech();
@@ -1809,8 +1835,7 @@ You can use the following subcommands:
                 CellSetSafeQuit(actor, input);
                 break;
             default:
-                actor.OutputHandler.Send("That is not a valid option for the " + "cell edit".Colour(Telnet.Cyan) +
-                                        " command.");
+                actor.OutputHandler.Send(CellSetHelpText.SubstituteANSIColour());
                 return;
         }
     }
@@ -2103,6 +2128,39 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
             whichVariable);
     }
 
+    internal static ICellExit GetCellExitForBuilderInput(IEnumerable<ICellExit> exits, StringStack input,
+        IPerceiver voyeur)
+    {
+        if (input.IsFinished)
+        {
+            return null;
+        }
+
+        var currentExits = exits.ToList();
+        var exitText = input.PopSpeech();
+        if (long.TryParse(exitText, out var id))
+        {
+            return currentExits.FirstOrDefault(x => x.Exit.Id == id);
+        }
+
+        if (!input.IsFinished)
+        {
+            var twoWordDirection = $"{exitText} {input.PeekSpeech()}";
+            if (Constants.CardinalDirectionStringToDirection.TryGetValue(twoWordDirection, out var direction))
+            {
+                input.PopSpeech();
+                return currentExits.FirstOrDefault(x => x.OutboundDirection == direction);
+            }
+        }
+
+        if (Constants.CardinalDirectionStringToDirection.TryGetValue(exitText, out var singleWordDirection))
+        {
+            return currentExits.FirstOrDefault(x => x.OutboundDirection == singleWordDirection);
+        }
+
+        return currentExits.GetFromItemListByKeyword(exitText, voyeur, abbreviated: false);
+    }
+
     private static void CellSetDoor(ICharacter actor, StringStack input)
     {
         if (input.IsFinished)
@@ -2112,9 +2170,7 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
         }
 
         IEnumerable<ICellExit> currentOverlayExits = actor.Location.ExitsFor(actor);
-        ICellExit exit = long.TryParse(input.PopSpeech(), out long id)
-            ? currentOverlayExits.FirstOrDefault(x => x.Exit.Id == id)
-            : currentOverlayExits.GetFromItemListByKeyword(input.Last, actor);
+        ICellExit exit = GetCellExitForBuilderInput(currentOverlayExits, input, actor);
         if (exit == null)
         {
             actor.OutputHandler.Send("There is no such exit for you to edit.");
@@ -2599,9 +2655,7 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
         }
 
         IEnumerable<ICellExit> currentOverlayExits = actor.Location.ExitsFor(actor, true);
-        ICellExit exit = long.TryParse(input.PopSpeech(), out long id)
-            ? currentOverlayExits.FirstOrDefault(x => x.Exit.Id == id)
-            : currentOverlayExits.GetFromItemListByKeyword(input.Last, actor);
+        ICellExit exit = GetCellExitForBuilderInput(currentOverlayExits, input, actor);
         if (exit == null)
         {
             actor.OutputHandler.Send("There is no such exit for you to edit.");
@@ -2657,9 +2711,7 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
         }
 
         IEnumerable<ICellExit> currentOverlayExits = actor.Location.ExitsFor(actor, true);
-        ICellExit exit = long.TryParse(input.PopSpeech(), out long id)
-            ? currentOverlayExits.FirstOrDefault(x => x.Exit.Id == id)
-            : currentOverlayExits.GetFromItemListByKeyword(input.Last, actor);
+        ICellExit exit = GetCellExitForBuilderInput(currentOverlayExits, input, actor);
         if (exit == null)
         {
             actor.OutputHandler.Send("There is no such exit for you to edit.");
@@ -2685,9 +2737,7 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
         }
 
         IEnumerable<ICellExit> currentOverlayExits = actor.Location.ExitsFor(actor, true);
-        ICellExit exit = long.TryParse(input.PopSpeech(), out long id)
-            ? currentOverlayExits.FirstOrDefault(x => x.Exit.Id == id)
-            : currentOverlayExits.GetFromItemListByKeyword(input.Last, actor);
+        ICellExit exit = GetCellExitForBuilderInput(currentOverlayExits, input, actor);
         if (exit == null)
         {
             actor.OutputHandler.Send("There is no such exit for you to edit.");
@@ -2722,9 +2772,7 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
         }
 
         IEnumerable<ICellExit> currentOverlayExits = actor.Location.ExitsFor(actor, true);
-        ICellExit exit = long.TryParse(input.PopSpeech(), out long id)
-            ? currentOverlayExits.FirstOrDefault(x => x.Exit.Id == id)
-            : currentOverlayExits.GetFromItemListByKeyword(input.Last, actor);
+        ICellExit exit = GetCellExitForBuilderInput(currentOverlayExits, input, actor);
         if (exit == null)
         {
             actor.OutputHandler.Send("There is no such exit for you to edit.");
@@ -2760,9 +2808,7 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
         }
 
         IEnumerable<ICellExit> currentOverlayExits = actor.Location.ExitsFor(actor, true);
-        ICellExit exit = long.TryParse(input.PopSpeech(), out long id)
-            ? currentOverlayExits.FirstOrDefault(x => x.Exit.Id == id)
-            : currentOverlayExits.GetFromItemListByKeyword(input.Last, actor);
+        ICellExit exit = GetCellExitForBuilderInput(currentOverlayExits, input, actor);
         if (exit == null)
         {
             actor.OutputHandler.Send("There is no such exit for you to edit.");
@@ -2815,9 +2861,7 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
         }
 
         IEnumerable<ICellExit> currentOverlayExits = actor.Location.ExitsFor(actor, true);
-        ICellExit exit = long.TryParse(input.PopSpeech(), out long id)
-            ? currentOverlayExits.FirstOrDefault(x => x.Exit.Id == id)
-            : currentOverlayExits.GetFromItemListByKeyword(input.Last, actor);
+        ICellExit exit = GetCellExitForBuilderInput(currentOverlayExits, input, actor);
         if (exit == null)
         {
             actor.OutputHandler.Send("There is no such exit for you to edit.");
@@ -2857,9 +2901,7 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
         }
 
         IEnumerable<ICellExit> currentOverlayExits = actor.Location.ExitsFor(actor, true);
-        ICellExit exit = long.TryParse(input.PopSpeech(), out long id)
-            ? currentOverlayExits.FirstOrDefault(x => x.Exit.Id == id)
-            : currentOverlayExits.GetFromItemListByKeyword(input.Last, actor);
+        ICellExit exit = GetCellExitForBuilderInput(currentOverlayExits, input, actor);
         if (exit == null)
         {
             actor.OutputHandler.Send("There is no such exit for you to edit.");
@@ -2906,9 +2948,7 @@ Note: reverse any condition with a ! (e.g. !dawn, !snow, !*rain, !summer)");
         }
 
         IEnumerable<ICellExit> currentOverlayExits = actor.Location.ExitsFor(actor, true);
-        ICellExit exit = long.TryParse(input.PopSpeech(), out long id)
-            ? currentOverlayExits.FirstOrDefault(x => x.Exit.Id == id)
-            : currentOverlayExits.GetFromItemListByKeyword(input.Last, actor);
+        ICellExit exit = GetCellExitForBuilderInput(currentOverlayExits, input, actor);
         if (exit == null)
         {
             actor.OutputHandler.Send("There is no such exit for you to edit.");

--- a/MudSharpCore/Construction/Boundary/CellExit.cs
+++ b/MudSharpCore/Construction/Boundary/CellExit.cs
@@ -179,8 +179,8 @@ public class CellExit : ICellExit
 
     public virtual bool IsExit(string verb)
     {
-        return CardinalDirectionExtensions.CardinalExitStrings.ContainsKey(verb) &&
-               CardinalDirectionExtensions.CardinalExitStrings[verb] == OutboundDirection;
+        return CardinalDirectionExtensions.CardinalExitStrings.TryGetValue(verb, out var direction) &&
+               direction == OutboundDirection;
     }
 
     public virtual bool IsExitKeyword(string keyword)


### PR DESCRIPTION
## Summary
- Restrict cardinal exit lookup to explicit short and common direction forms so `north` and `nw` resolve to the intended exits without broad prefix matching.
- Reuse the same exit-resolution path across `cell set` subcommands to support IDs, exact cardinal aliases, and exact keywords consistently.
- Fix the brief description for `northwest` and add coverage for the new lookup behavior.
- Update the room builder guide to document the accepted cardinal forms.

## Testing
- Added unit coverage for cardinal direction aliases, rejected partial prefixes, and builder exit lookup behavior.
- Not run (not requested)