### PR TITLE
Harden legal AI edge cases

### DIFF
--- a/Design Documents/Economy/Law_System_Runtime.md
+++ b/Design Documents/Economy/Law_System_Runtime.md
@@ -105,7 +105,7 @@ The execution patrol progresses through these stages:
 4. Move the leader to the prisoner and send the retrieval emote.
 5. Give the prisoner the configured compliance window to use `HELPLESS` or submit to the guards.
 6. If the prisoner resists, guards switch to control-oriented combat settings where available and attempt to subdue them.
-7. Drag the helpless or submitted prisoner to the execution location.
+7. Drag the helpless or submitted prisoner to the execution location. If another character is already dragging the condemned prisoner, the execution patrol clears that conflicting drag state and takes over custody rather than bouncing indefinitely between subdual and transport.
 8. Secure the prisoner for execution. A prisoner is secured if they are already helpless, remain submitted as the patrol's drag target, are under enough grapple or restraint control to be helpless, or can be made helpless by the guards. Ordinary partial restraints, such as hand bindings that do not actually make the target helpless, are not by themselves enough to proceed.
 9. Offer the configured last-words window.
 10. Play each configured execution script step.
@@ -124,6 +124,8 @@ Trials are represented by the `OnTrial` effect for the relevant legal authority.
 Automated trial effects persist their current phase, manual-trial flag, remaining per-charge queue, pleas, argument outcomes, and punishment results. If the game reboots mid-trial, the resumed `trial` view continues revealing only the charges, pleas, verdicts, and sentences that had actually been reached before the reboot.
 
 Automated trials use separate judge and prosecutor roles. The judge AI can read charges, collect pleas, move phases, announce verdicts, and sentence, but it does not argue the prosecution case. A prosecutor patrol member in the court claims the prosecution role and presents prosecution arguments; if no valid prosecutor patrol member is present, the trial waits rather than having the judge fill both roles.
+
+While a defendant has an `OnTrial` effect, the trial is treated as courtroom custody: the defendant cannot voluntarily quit or walk out of the proceeding. Trial start paths apply the effect only after the defendant has arrived in court so automated remand-to-court transfers do not trip the movement blocker. If a lawyer or prosecutor disappears during automated case arguments, the judge waits instead of advancing with a missing role. After the grace period, a missing defender is cleared and the defendant falls back to self-defense; a missing prosecutor is cleared so the next valid prosecutor patrol member can reclaim the role.
 
 A PC judge is any enforcer whose enforcement authority has `CanConvict` for the jurisdiction and whose authority can judge the defendant's legal class.
 

--- a/MudSharpCore Unit Tests/LegalPatrolStrategyTests.cs
+++ b/MudSharpCore Unit Tests/LegalPatrolStrategyTests.cs
@@ -189,6 +189,11 @@ public class LegalPatrolStrategyTests
 
 		StringAssert.Contains(judgeSource, "EnsureAutomatedProsecutor(trialEffect);");
 		StringAssert.Contains(judgeSource, "private static bool IsAutomatedProsecutor(ICharacter character, ILegalAuthority authority)");
+		StringAssert.Contains(judgeSource, "private static bool TrialAdvocatesReady(ICharacter defendant, OnTrial trialEffect)");
+		StringAssert.Contains(judgeSource, "private static void RecoverMissingTrialAdvocates(ICharacter defendant, OnTrial trialEffect)");
+		StringAssert.Contains(judgeSource, "if (!trialEffect.CasesFinishedArguing() && !TrialAdvocatesReady(defendant, trialEffect))");
+		StringAssert.Contains(judgeSource, "trialEffect.Defender = defendant;");
+		StringAssert.Contains(judgeSource, "trialEffect.Prosecutor = null;");
 		StringAssert.Contains(judgeSource, "x.Patrol.PatrolStrategy.Name == \"Prosecutor\"");
 		StringAssert.Contains(judgeSource, "trialEffect.Prosecutor ??= court.Characters.FirstOrDefault");
 		Assert.IsFalse(judgeSource.Contains("trialEffect.Prosecutor ??= enforcer;", StringComparison.Ordinal));
@@ -197,6 +202,30 @@ public class LegalPatrolStrategyTests
 		StringAssert.Contains(prosecutorSource, "trial.Prosecutor = patrol.PatrolLeader;");
 		StringAssert.Contains(prosecutorSource, "CharacterInstanceIdentityComparer.SamePhysicalInstanceOrBody(trial.Prosecutor, patrol.PatrolLeader)");
 		StringAssert.Contains(prosecutorSource, "trial.HandleArgueCommand(patrol.PatrolLeader, false);");
+	}
+
+	[TestMethod]
+	public void TrialCreation_ShouldApplyOnTrialAfterCourtTransfer()
+	{
+		string sheriffSource = File.ReadAllText(GetCoreSourcePath("RPG", "Law", "PatrolStrategies", "SheriffPatrolStrategy.cs"));
+		string crimeModuleSource = File.ReadAllText(GetCoreSourcePath("Commands", "Modules", "CrimeModule.cs"));
+
+		int sheriffEnter = sheriffSource.IndexOf("authority.CourtLocation.Enter(trialCandidate);", StringComparison.Ordinal);
+		int sheriffTrial = sheriffSource.IndexOf("trialCandidate.AddEffect(new OnTrial", StringComparison.Ordinal);
+		Assert.IsTrue(sheriffEnter >= 0);
+		Assert.IsTrue(sheriffTrial > sheriffEnter);
+
+		int requestTrial = crimeModuleSource.IndexOf("[PlayerCommand(\"RequestTrial\", \"requesttrial\")]", StringComparison.Ordinal);
+		int requestEnter = crimeModuleSource.IndexOf("jurisdiction.CourtLocation.Enter(actor);", requestTrial, StringComparison.Ordinal);
+		int requestEffect = crimeModuleSource.IndexOf("actor.AddEffect(new OnTrial", requestTrial, StringComparison.Ordinal);
+		Assert.IsTrue(requestTrial >= 0);
+		Assert.IsTrue(requestEffect > requestEnter);
+
+		int summon = crimeModuleSource.IndexOf("private static void TrialSummon(ICharacter actor, StringStack ss)", StringComparison.Ordinal);
+		int summonEnter = crimeModuleSource.IndexOf("jurisdiction.CourtLocation.Enter(target);", summon, StringComparison.Ordinal);
+		int summonEffect = crimeModuleSource.IndexOf("target.AddEffect(new OnTrial(target, jurisdiction, DateTime.UtcNow, crimes, manualTrial: true));", summonEnter, StringComparison.Ordinal);
+		Assert.IsTrue(summon >= 0);
+		Assert.IsTrue(summonEffect > summonEnter);
 	}
 
 	[TestMethod]
@@ -224,6 +253,11 @@ public class LegalPatrolStrategyTests
 		StringAssert.Contains(source, "Where(x => x.Reason == LimbIneffectiveReason.Restrained)");
 		StringAssert.Contains(source, "SetStage(ExecutionPatrolStage.SubduingPrisoner);");
 		StringAssert.Contains(source, "ReleaseCondemnedFromPatrolDrag(patrol);");
+		StringAssert.Contains(source, "private bool ReleaseConflictingDragCustody(IPatrol patrol)");
+		StringAssert.Contains(source, "EffectsOfType<Dragging.DragTarget>()");
+		StringAssert.Contains(source, "!x.TheDrag.CharacterDraggers.Any(y =>");
+		StringAssert.Contains(source, "patrol.PatrolMembers.ContainsPhysicalInstance(y)");
+		StringAssert.Contains(source, "ReleaseConflictingDragCustody(patrol);");
 		Assert.IsFalse(source.Contains("if (_condemned.Body.EffectsOfType<RestraintEffect>().Any())", StringComparison.Ordinal));
 	}
 

--- a/MudSharpCore Unit Tests/LegalTrialFlowTests.cs
+++ b/MudSharpCore Unit Tests/LegalTrialFlowTests.cs
@@ -143,6 +143,29 @@ public class LegalTrialFlowTests
 	}
 
 	[TestMethod]
+	public void OnTrial_ShouldPreventQuitAndVoluntaryMovement()
+	{
+		Mock<ILegalAuthority> authority = new();
+		authority.SetupGet(x => x.Id).Returns(1L);
+		authority.SetupGet(x => x.Name).Returns("Test Authority");
+
+		Mock<ICrime> crime = new();
+		crime.SetupGet(x => x.Id).Returns(10L);
+
+		Mock<ICharacter> owner = new();
+
+		OnTrial trial = new(owner.Object, authority.Object, DateTime.UtcNow, [crime.Object]);
+		Assert.IsInstanceOfType(trial, typeof(INoQuitEffect));
+		Assert.AreEqual("You cannot quit while you are on trial.", ((INoQuitEffect)trial).NoQuitReason);
+
+		PerceivableRejectionResponse response = new();
+		owner.Raise(x => x.OnWantsToMove += null, owner.Object, response);
+
+		Assert.IsTrue(response.Rejected);
+		StringAssert.Contains(response.Reason, "trial is in progress");
+	}
+
+	[TestMethod]
 	public void OnTrial_HasPleaBeenEntered_ShouldFollowPleaQueue()
 	{
 		Mock<ILegalAuthority> authority = new();

--- a/MudSharpCore/Commands/Modules/CrimeModule.cs
+++ b/MudSharpCore/Commands/Modules/CrimeModule.cs
@@ -1663,7 +1663,6 @@ The syntax for this command is simply #3requesttrial#0.", AutoHelp.HelpArg)]
 
             List<ICrime> crimes = jurisdiction.KnownCrimesForIndividual(actor).ToList();
             actor.RemoveAllEffects<AwaitingSentencing>(x => x.LegalAuthority == jurisdiction, true);
-            actor.AddEffect(new OnTrial(actor, jurisdiction, DateTime.UtcNow, crimes));
             actor.OutputHandler.Handle(new EmoteOutput(
                 new Emote(actor.Gameworld.GetStaticString("RequestTrialEmoteOrigin"), actor, actor),
                 flags: OutputFlags.SuppressSource));
@@ -1674,6 +1673,7 @@ The syntax for this command is simply #3requesttrial#0.", AutoHelp.HelpArg)]
             actor.Location.Leave(actor);
             actor.RoomLayer = RoomLayer.GroundLevel;
             jurisdiction.CourtLocation.Enter(actor);
+            actor.AddEffect(new OnTrial(actor, jurisdiction, DateTime.UtcNow, crimes));
             actor.Body.Look(true);
             actor.OutputHandler.Handle(new EmoteOutput(
                 new Emote(actor.Gameworld.GetStaticString("RequestTrialEmoteCourt"), actor, actor),
@@ -2691,10 +2691,10 @@ The syntax is as follows:
 
         target.RemoveAllEffects<AwaitingSentencing>(x => x.LegalAuthority == jurisdiction, true);
         target.RemoveAllEffects<InCustodyOfEnforcer>(x => x.LegalAuthority == jurisdiction, true);
-        target.AddEffect(new OnTrial(target, jurisdiction, DateTime.UtcNow, crimes, manualTrial: true));
 
         if (target.Location == jurisdiction.CourtLocation)
         {
+            target.AddEffect(new OnTrial(target, jurisdiction, DateTime.UtcNow, crimes, manualTrial: true));
             actor.OutputHandler.Handle(new QuickEmote("@ call|calls $1 before the court to answer the charges.", actor, actor, target));
             return;
         }
@@ -2709,6 +2709,7 @@ The syntax is as follows:
         target.Location.Leave(target);
         target.RoomLayer = RoomLayer.GroundLevel;
         jurisdiction.CourtLocation.Enter(target);
+        target.AddEffect(new OnTrial(target, jurisdiction, DateTime.UtcNow, crimes, manualTrial: true));
         target.Body.Look(true);
         target.OutputHandler.Handle(new EmoteOutput(
             new Emote(actor.Gameworld.GetStaticString("FetchCriminalForTrialEmoteCourt"), target, target),

--- a/MudSharpCore/Effects/Concrete/OnTrial.cs
+++ b/MudSharpCore/Effects/Concrete/OnTrial.cs
@@ -1,4 +1,5 @@
 ﻿using MudSharp.Character;
+using MudSharp.Effects.Interfaces;
 using MudSharp.Framework;
 using MudSharp.FutureProg;
 using MudSharp.FutureProg.Statements;
@@ -31,11 +32,31 @@ public enum TrialPhase
 }
 
 #nullable enable
-public class OnTrial : Effect, IEffect
+public class OnTrial : Effect, IEffect, INoQuitEffect
 {
     private DateTime _lastTrialAction;
 
     public ILegalAuthority LegalAuthority { get; set; } = null!;
+
+	public ICharacter CharacterOwner => (ICharacter)Owner;
+
+	public string NoQuitReason => "You cannot quit while you are on trial.";
+
+	private void SubscribeEvents()
+	{
+		CharacterOwner.OnWantsToMove += Owner_OnWantsToMove;
+	}
+
+	private void UnsubscribeEvents()
+	{
+		CharacterOwner.OnWantsToMove -= Owner_OnWantsToMove;
+	}
+
+	private void Owner_OnWantsToMove(IPerceivable owner, PerceivableRejectionResponse response)
+	{
+		response.Rejected = true;
+		response.Reason = "You cannot leave while your trial is in progress.";
+	}
 
     public DateTime LastTrialAction
     {
@@ -100,6 +121,7 @@ public class OnTrial : Effect, IEffect
         {
             _prosecutor = value;
             _prosecutorId = value?.Id;
+			Changed = true;
         }
     }
 
@@ -113,6 +135,7 @@ public class OnTrial : Effect, IEffect
         {
             _defender = value;
             _defenderId = value?.Id;
+			Changed = true;
         }
     }
 
@@ -322,6 +345,7 @@ public class OnTrial : Effect, IEffect
         }
         ResetCrimeQueue();
         _phase = TrialPhase.AwaitingLawyers;
+		SubscribeEvents();
     }
 
     protected OnTrial(XElement effect, IPerceivable owner) : base(effect, owner)
@@ -361,6 +385,21 @@ public class OnTrial : Effect, IEffect
         LoadCrimeQueue(root.Element("CrimeQueue"));
         _phase = (TrialPhase)int.Parse(root.Element("Phase")?.Value ?? "0");
         _manualTrial = bool.Parse(root.Element("ManualTrial")?.Value ?? "false");
+		if (long.TryParse(root.Element("Prosecutor")?.Value, NumberStyles.Integer, CultureInfo.InvariantCulture,
+			    out var prosecutorId) &&
+		    prosecutorId > 0)
+		{
+			_prosecutorId = prosecutorId;
+		}
+
+		if (long.TryParse(root.Element("Defender")?.Value, NumberStyles.Integer, CultureInfo.InvariantCulture,
+			    out var defenderId) &&
+		    defenderId > 0)
+		{
+			_defenderId = defenderId;
+		}
+
+		SubscribeEvents();
     }
 
     #endregion
@@ -417,6 +456,8 @@ public class OnTrial : Effect, IEffect
             new XElement("LastTrialAction", LastTrialAction.ToString("O")),
             new XElement("Phase", (int)Phase),
             new XElement("ManualTrial", ManualTrial),
+			new XElement("Prosecutor", _prosecutorId ?? _prosecutor?.Id ?? 0L),
+			new XElement("Defender", _defenderId ?? _defender?.Id ?? 0L),
             new XElement("CrimeQueue",
                 from crime in CrimeQueue
                 select new XElement("Crime",
@@ -460,6 +501,11 @@ public class OnTrial : Effect, IEffect
     }
 
     public override bool SavingEffect => true;
+
+	public override void RemovalEffect()
+	{
+		UnsubscribeEvents();
+	}
 
     public override bool Applies(object target)
     {

--- a/MudSharpCore/NPC/AI/JudgeAI.cs
+++ b/MudSharpCore/NPC/AI/JudgeAI.cs
@@ -1303,9 +1303,10 @@ With each of the emotes, you can use the following tokens:
         // After 10 minutes, fire the lawyers that aren't there
         if (DateTime.UtcNow - trialEffect.LastTrialAction > TimeSpan.FromMinutes(10))
         {
-            if (trialEffect.Defender.Location != court)
+			var defender = trialEffect.Defender;
+			if (defender is not null && defender.Location != court)
             {
-                trialEffect.Defender.RemoveAllEffects(x => x.IsEffectType<Lawyering>());
+                defender.RemoveAllEffects(x => x.IsEffectType<Lawyering>());
                 trialEffect.Defender = null;
 				defendant.RemoveAllEffects(x => x.IsEffectType<HasLegalCounsel>());
 			}
@@ -1644,6 +1645,16 @@ With each of the emotes, you can use the following tokens:
 
 	private bool DoTrialTickCase(ICharacter enforcer, ICharacter defendant, OnTrial trialEffect, Gendering gender, string[] crimeNames)
 	{
+		if (!trialEffect.CasesFinishedArguing() && !TrialAdvocatesReady(defendant, trialEffect))
+		{
+			if (DateTime.UtcNow - trialEffect.LastTrialAction > TimeSpan.FromMinutes(10))
+			{
+				RecoverMissingTrialAdvocates(defendant, trialEffect);
+			}
+
+			return false;
+		}
+
 		if (!trialEffect.CasesFinishedArguing() && DateTime.UtcNow - trialEffect.LastTrialAction < TrialPhaseDelay(trialEffect.Phase, trialEffect.Crimes.Count()))
 		{
 			return false;
@@ -1668,6 +1679,39 @@ With each of the emotes, you can use the following tokens:
         trialEffect.LastTrialAction = DateTime.UtcNow;
         return true;
     }
+
+	private static bool TrialAdvocatesReady(ICharacter defendant, OnTrial trialEffect)
+	{
+		var court = trialEffect.LegalAuthority.CourtLocation;
+		return (trialEffect.Defender?.Location == court ||
+		        CharacterInstanceIdentityComparer.SamePhysicalInstanceOrBody(trialEffect.Defender, defendant)) &&
+		       trialEffect.Prosecutor?.Location == court;
+	}
+
+	private static void RecoverMissingTrialAdvocates(ICharacter defendant, OnTrial trialEffect)
+	{
+		var court = trialEffect.LegalAuthority.CourtLocation;
+		if (trialEffect.Defender is not null &&
+		    !CharacterInstanceIdentityComparer.SamePhysicalInstanceOrBody(trialEffect.Defender, defendant) &&
+		    trialEffect.Defender.Location != court)
+		{
+			trialEffect.Defender.RemoveAllEffects(x => x.IsEffectType<Lawyering>());
+			trialEffect.Defender = defendant;
+			defendant.RemoveAllEffects(x => x.IsEffectType<HasLegalCounsel>());
+			defendant.OutputHandler.Send("#2[System Message]#0 Your lawyer is no longer present, so you are now defending yourself in this case.".SubstituteANSIColour());
+		}
+
+		if (trialEffect.Defender is null)
+		{
+			trialEffect.Defender = defendant;
+			defendant.OutputHandler.Send("#2[System Message]#0 You are defending yourself in this case.".SubstituteANSIColour());
+		}
+
+		if (trialEffect.Prosecutor?.Location != court)
+		{
+			trialEffect.Prosecutor = null;
+		}
+	}
 
     private bool DoTrialTickPlea(ICharacter enforcer, ICharacter defendant, OnTrial trialEffect, Gendering gender, string[] crimeNames)
     {

--- a/MudSharpCore/RPG/Law/PatrolStrategies/ExecutionPatrolStrategy.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/ExecutionPatrolStrategy.cs
@@ -631,6 +631,21 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 		return patrol.PatrolMembers.Any(x => x.CombinedEffectsOfType<Dragging>().Any(y => y.Target == _condemned));
 	}
 
+	private bool ReleaseConflictingDragCustody(IPatrol patrol)
+	{
+		List<Dragging.DragTarget> conflictingDrags = _condemned
+		                                             .EffectsOfType<Dragging.DragTarget>()
+		                                             .Where(x => !x.TheDrag.CharacterDraggers.Any(y =>
+			                                             patrol.PatrolMembers.ContainsPhysicalInstance(y)))
+		                                             .ToList();
+		foreach (Dragging.DragTarget drag in conflictingDrags)
+		{
+			_condemned.RemoveEffect(drag, true);
+		}
+
+		return conflictingDrags.Any();
+	}
+
 	private void HandleSubduingPrisoner(IPatrol patrol)
 	{
 		if (_condemned.IsHelpless || IsBeingDraggedByPatrol(patrol))
@@ -681,6 +696,8 @@ Use normal emote targets outside speech: $0 is the executioner and $1 is the con
 		{
 			return true;
 		}
+
+		ReleaseConflictingDragCustody(patrol);
 
 		foreach (ICharacter member in patrol.PatrolMembers.Where(x => x.ColocatedWith(_condemned)))
 		{

--- a/MudSharpCore/RPG/Law/PatrolStrategies/SheriffPatrolStrategy.cs
+++ b/MudSharpCore/RPG/Law/PatrolStrategies/SheriffPatrolStrategy.cs
@@ -87,7 +87,6 @@ public class SheriffPatrolStrategy : PatrolStrategyBase
         // Fetch the criminal for trial
         List<ICrime> crimes = authority.KnownCrimesForIndividual(trialCandidate).ToList();
         trialCandidate.RemoveAllEffects<AwaitingSentencing>(x => x.LegalAuthority == authority, true);
-        trialCandidate.AddEffect(new OnTrial(trialCandidate, authority, DateTime.UtcNow, crimes));
         trialCandidate.OutputHandler.Handle(new EmoteOutput(
             new Emote(Gameworld.GetStaticString("FetchCriminalForTrialEmoteCell"), trialCandidate, trialCandidate),
             flags: OutputFlags.SuppressSource));
@@ -98,6 +97,7 @@ public class SheriffPatrolStrategy : PatrolStrategyBase
         trialCandidate.Location.Leave(trialCandidate);
         trialCandidate.RoomLayer = RoomLayer.GroundLevel;
         authority.CourtLocation.Enter(trialCandidate);
+        trialCandidate.AddEffect(new OnTrial(trialCandidate, authority, DateTime.UtcNow, crimes));
         trialCandidate.Body.Look(true);
         trialCandidate.OutputHandler.Handle(new EmoteOutput(
             new Emote(Gameworld.GetStaticString("FetchCriminalForTrialEmoteCourt"), trialCandidate, trialCandidate),


### PR DESCRIPTION
## Summary
- make OnTrial courtroom custody persistent across save/load and prevent quit or voluntary walk-outs during trial
- apply trial custody only after court transfer so defendants cannot get stranded outside court
- recover automated trials when defender/prosecutor characters vanish or leave before case argument
- let execution patrols clear conflicting non-patrol drag custody before taking the condemned to execution
- update the law runtime design notes for the hardened trial and execution flows

## Validation
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1 --filter "LegalTrialFlowTests|LegalPatrolStrategyTests"` passed 39 tests
- `dotnet test 'MudSharpCore Unit Tests\MudSharpCore Unit Tests.csproj' -c Debug --no-restore -m:1` passed 1571 tests
- `git diff --check` passed; only existing line-ending normalization warnings were reported