### PR TITLE
Add comprehensive Renaissance shared clothing catalogue

### DIFF
--- a/Design Documents/Seeding/FutureMUD_Renaissance_Clothing_Accessories_Design_Reference.md
+++ b/Design Documents/Seeding/FutureMUD_Renaissance_Clothing_Accessories_Design_Reference.md
@@ -1,22 +1,352 @@
 # FutureMUD Renaissance Clothing and Accessories Design Reference
 
-## Scope
+## Status and scope
 
-This branch owns the Renaissance clothing delta beyond the three generic shared pre-industrial accessories. Era-specific rows use `Era / Renaissance Era` and cover approximately 1400-1600 CE.
+This document is the design authority for the Renaissance clothing branch, approximately 1400-1600 CE. It replaces the former catalogue scaffold with an implementation-oriented shared-culture catalogue. The branch owns clothing, underlayers, footwear, headwear, textile accessories, profession overlays, skins, outfits, and clothing crafts that are not supplied by the shared pre-industrial baseline.
 
-## Catalogue slices
+The completed first-pass catalogue contains **395 unique proposed prototypes** and **436 culture placements**. Forty-one placements deliberately admit an existing shared prototype into another culture grouping rather than cloning the same silhouette. The catalogue is split into this authority document and three regional volumes:
 
-- Western/central European shirts, chemises, smocks, doublets, jerkins, bodices, gowns, kirtles, hose, breeches, farthingales, ruffs, partlets, cloaks, capes, caps, hats, coifs, veils, gloves, masks, and fans.
-- Ottoman, Safavid, Indo-Persian, South Asian, Ming, Joseon, Japanese, Ryukyuan, and South-east Asian robes, jackets, skirts, trousers, kaftans, jamas, turbans, sashes, hakama, kosode, kataginu, and court/scholar headgear where form differs.
-- African, Sahelian, Ethiopian, Swahili, Mesoamerican, Andean, Caribbean, and North American Indigenous garment families where textile, hide, featherwork, beadwork, or wrapped construction justifies prototypes.
-- Printer, scholar, merchant, notary, sailor, artisan, apothecary, artist, musician, actor/pageant, guard, and court-servant overlays.
+| Volume | Unique prototypes | Primary coverage |
+| --- | ---: | --- |
+| This authority and common-form catalogue | 55 | forms credible across several Shared groupings, dependency contracts, outfit rules |
+| [Western, Mediterranean, and European Frontier Catalogue](./FutureMUD_Renaissance_Clothing_Catalogue_Western_Mediterranean.md) | 130 | Western European, Iberian Atlantic, Northern/Central/Eastern European, Ottoman-Islamicate |
+| [Asian and Steppe Catalogue](./FutureMUD_Renaissance_Clothing_Catalogue_Asia_Steppe.md) | 110 | Persianate, Indo-Persian, South Asian, Ming/Joseon, Japanese/Ryukyuan, South-east Asian, steppe/caravan |
+| [African, American, Contact, and Maritime Catalogue](./FutureMUD_Renaissance_Clothing_Catalogue_Africa_Americas_Maritime.md) | 100 | African court/Atlantic, Sahel/Red Sea/Swahili, Mesoamerican, Andean, Caribbean, North American contact, colonial and maritime overlays |
+| **Total** | **395** | all Shared Renaissance material-culture groupings in the master culture manifest |
 
-Use skins for colour, trim, local names, household/guild/heraldic marks, religious signs, exact textile motifs, and status. New prototypes require a distinct silhouette, material behaviour, component, wear profile, production method, or institutional role.
+This is a design catalogue, not a claim that every listed form is common in every place between 1400 and 1600. Culture manifests, date gates, institutions, professions, crafts, shops, and outfit definitions control actual admission.
 
-## Dependency contract
+## Relationship to implemented shared stock
 
-Use the exact ledger in `FutureMUD_Renaissance_PrimaryIndustry_UsefulSeeder_Impact_Reference.md`. Linen, wool, cotton, silk, leather, felt, canvas, broadcloth, velvet, satin, lace, taffeta, ribbon, calico, and chintz are live exact materials.
+Do not clone the three implemented general accessories:
 
-## Implementation order and acceptance
+- `preindustrial_clothing_plain_leather_belt`
+- `preindustrial_clothing_iron_buckled_leather_belt`
+- `preindustrial_clothing_simple_woven_sash`
 
-Define shared silhouettes, culture-family exceptions, professional overlays, and authored outfit slots before skins and crafts. Portable garments include `Holdable` and valid wearable/destroyable components. Public text stays form-based, and complete outfits fail closed on missing authored pieces.
+They should be admitted wherever historically credible and skinned for colour, textile, buckle finish, embroidery, household marks, or local terminology. A new belt or sash prototype is justified only by a materially different construction or gameplay role, such as a very broad wrapped waistcloth, a rigid ceremonial belt, a sword-bearing baldric, or a container-bearing working girdle.
+
+## Catalogue admission rules
+
+A proposed prototype is retained only when at least one of the following changes materially:
+
+1. silhouette or visible construction;
+2. primary material behaviour;
+3. wearable coverage or layering profile;
+4. functional item component;
+5. production method;
+6. institutional or professional gameplay role;
+7. contact/export form that builders need to distinguish from local continuity.
+
+Colour, trim, embroidery, woven motif, heraldry, guild or household marks, dynastic signs, religious symbols, exact local names, imported presentation, and most status differences are skins. Material substitutions remain skins only where the silhouette, weight, insulation, and craft inputs remain credible.
+
+## Stable-reference and authoring contract
+
+- Era-specific references use `renaissance_...`; genuinely multi-group forms in this document use `renaissance_shared_clothing_...`.
+- Public keywords and short descriptions remain form-based and in-world. Builder notes may record historical inspirations and narrower local names.
+- Portable garments include `Holdable`, a valid wearable component, `Destroyable_Clothing`, an insulation component appropriate to the material, and `Armour_LightClothing` unless a later armour decision explicitly supersedes it.
+- `$colour` appears only where `Variable_BasicColour` is included and the material can reasonably be dyed.
+- Decorative claims do not imply armour, concealment, storage, disguise, warmth, or weatherproofing mechanics unless a matching component exists.
+- Paired garments such as hose, stockings, sleeves, leggings, gloves, and sandals are authored as one paired item unless a deliberate one-sided gameplay use is approved.
+- Full descriptions describe cut, fastening, seams, drape, material, and visible wear. They do not mention seeding, tags, prototypes, or unsupported historical universality.
+
+## Catalogue row schema
+
+Each row records:
+
+| Field | Meaning |
+| --- | --- |
+| Stable reference | Proposed idempotent prototype reference |
+| Public form | Form-based noun phrase used to author keywords and short description |
+| Material | Exact live primary material, or a named dependency from the material gap ledger |
+| Wear profile | Abstract profile below; implementation must resolve it to an exact seeded component |
+| Variation family | Minimum useful skin set; not additional prototypes unless construction changes |
+| Admission | Shared culture, profession, institution, or date gate |
+
+## Wear-profile dependency ledger
+
+The current export already demonstrates `Wear_Shirt`, `Wear_Shorts`, `Wear_Bra`, `Wear_Waist`, and `Wear_Sash`. Other exact stock profiles must be resolved against `Seeded_Item_Components.json` during implementation. The catalogue uses semantic profile ids so that no guessed component name becomes an accidental dependency.
+
+| Profile id | Required coverage/layering | Resolution status |
+| --- | --- | --- |
+| `WP-UNDER-WAIST` | drawers or loincloth beneath lower-body clothing | map to `Wear_Shorts` where coverage is correct |
+| `WP-BREAST-WRAP` | wrapped breast support beneath upper layers | map to `Wear_Bra` |
+| `WP-SHIRT` | short or long upper-body underlayer | map to `Wear_Shirt` where hem coverage is correct |
+| `WP-LONG-UNDERLAYER` | ankle- or calf-length under-robe/shift | **blocking audit**; add a long-underlayer profile if no exact stock component exists |
+| `WP-VEST` | sleeveless torso layer above a shirt and below a coat | **blocking audit** |
+| `WP-JACKET` | waist/hip-length sleeved outer torso layer | **blocking audit** |
+| `WP-ROBE-CLOSED` | long closed or pull-over robe covering torso and legs | **new profile likely required** |
+| `WP-ROBE-OPEN` | long front-opening robe/coat layered over clothing | **new profile likely required** |
+| `WP-TROUSERS` | joined lower-body garment covering both legs | **blocking audit** |
+| `WP-WRAP-SKIRT` | wrapped lower-body cloth with overlap | **new profile likely required** |
+| `WP-SKIRT` | sewn or gathered lower-body garment | **blocking audit** |
+| `WP-STOCKINGS` | paired close legwear extending above the knee | **new paired-hose profile likely required** |
+| `WP-LEG-WRAPS` | paired lower-leg wraps or gaiters | **new profile likely required** |
+| `WP-CLOAK` | neck/shoulder-fastened outer wrap covering back and arms | **blocking audit** |
+| `WP-SHOULDER` | mantle, shawl, or shoulder cloth that does not occupy coat layering | **new profile likely required** |
+| `WP-FOOT-SANDAL` | open footwear | **blocking audit** |
+| `WP-FOOT-SHOE` | closed low footwear | **blocking audit** |
+| `WP-FOOT-BOOT` | closed footwear extending above ankle | **blocking audit** |
+| `WP-OVERSHOE` | footwear worn over shoes or footwraps | **new layering profile required** |
+| `WP-HEAD-CAP` | close or soft cap | **blocking audit** |
+| `WP-HEAD-HAT` | brimmed or structured hat | **blocking audit** |
+| `WP-HEADWRAP` | wound cloth occupying the headwear layer | **new profile likely required** |
+| `WP-HEAD-VEIL` | veil draped from head without full face coverage | **new profile likely required** |
+| `WP-HOOD` | separate hood covering head and neck | **blocking audit** |
+| `WP-FACE-VEIL` | textile face covering compatible with headwear | **new layering profile required** |
+| `WP-FACE-MASK` | rigid or textile mask occupying face layer | **blocking audit** |
+| `WP-HANDS` | paired gloves or mittens | **blocking audit** |
+| `WP-NECK` | kerchief, collar, or neck cloth | **blocking audit** |
+| `WP-SLEEVES` | detachable paired sleeves layered with bodice/doublet | **new layering profile required** |
+| `WP-HANDHELD` | fan or similar carried accessory | use `Holdable`; no wearable component |
+
+### New component work called out by this pass
+
+At minimum, implementation must supply exact wearable definitions for any unresolved stock gaps above. The forms most unlikely to map cleanly to existing generic wear components are:
+
+- long closed robes and gowns;
+- open robes and long coats;
+- wrap skirts and waistcloths;
+- paired hose/stockings and lower-leg wraps;
+- shoulder mantles and shawls that should layer independently of cloaks;
+- headwraps/turbans and head-draped veils;
+- face veils that layer with headwear;
+- detachable sleeves;
+- overshoes worn above another footwear layer.
+
+These are wearable/layering components, not new item-component *types*. No new engine component type is proposed by this catalogue.
+
+## Material dependency ledger
+
+### Live exact materials used directly
+
+`linen`, `wool`, `cotton`, `silk`, `leather`, `felt`, `canvas`, `broadcloth`, `velvet`, `satin`, `lace`, `taffeta`, `ribbon`, `calico`, and `chintz` are live exact materials and cover the implementation-critical majority of the catalogue.
+
+### Proposed new exact materials
+
+| Proposed material | Priority | Why a separate material is useful | Fallback before seeding |
+| --- | --- | --- | --- |
+| `hemp cloth` | high | common hard-wearing fibre with different craft and trade chain from linen | `linen` or `canvas`, with reduced cultural specificity |
+| `ramie cloth` | high | East and South-east Asian bast-fibre textile distinct from cotton/linen | fine `linen` |
+| `barkcloth` | high | materially distinct beaten-bark clothing in tropical and Pacific-facing contexts | none without misrepresentation |
+| `camelid wool` | high | Andean fibre source and supply chain distinct from sheep wool | `wool`, but loses production identity |
+| `raffia cloth` | medium | woven palm fibre used in several African dress traditions | coarse `linen` only as a temporary abstraction |
+| `brocade` | medium | patterned supplementary-weft luxury textile with distinct cost/craft behaviour | `silk` or `satin` skin |
+| `damask` | medium | reversible figured textile used across several court markets | `silk` or `linen` skin |
+| `silk gauze` | medium | open, translucent silk behaviour needed for veils and court layers | `silk` |
+| `featherwork` | medium | manufactured feather mosaic/panel composite used as a primary visible surface | `feather` if live, otherwise descriptive trim only |
+| `beadwork` | low | composite surface for regalia and contact goods | keep beads as descriptive trim |
+
+The first implementation wave can proceed with live materials except for prototypes explicitly marked `barkcloth`, `camelid wool`, or `raffia cloth`; those should fail closed rather than silently change material culture.
+
+## Tag additions
+
+`Era / Renaissance Era` is live. The culture-family paths below are not maintained stock and must be seeded idempotently before catalogue rows depend on them:
+
+```text
+Culture / Renaissance / Shared / Western European Renaissance
+Culture / Renaissance / Shared / Iberian Atlantic
+Culture / Renaissance / Shared / Central European
+Culture / Renaissance / Shared / Northern Baltic
+Culture / Renaissance / Shared / Central Eastern Frontier
+Culture / Renaissance / Shared / Eastern Orthodox Northern
+Culture / Renaissance / Shared / Ottoman Islamicate
+Culture / Renaissance / Shared / Persianate Indo-Persian
+Culture / Renaissance / Shared / South Asian
+Culture / Renaissance / Shared / East Asian Literati
+Culture / Renaissance / Shared / Japanese
+Culture / Renaissance / Shared / Maritime East Asian
+Culture / Renaissance / Shared / South-east Asian Mainland
+Culture / Renaissance / Shared / Maritime South-east Asian
+Culture / Renaissance / Shared / Steppe and Caravan
+Culture / Renaissance / Shared / African Court Atlantic
+Culture / Renaissance / Shared / Sahelian Islamic
+Culture / Renaissance / Shared / Red Sea
+Culture / Renaissance / Shared / Indian Ocean
+Culture / Renaissance / Shared / Mesoamerican
+Culture / Renaissance / Shared / Andean
+Culture / Renaissance / Shared / Caribbean Contact
+Culture / Renaissance / Shared / North American Contact
+Culture / Renaissance / Shared / Colonial Atlantic
+Culture / Renaissance / Shared / Global Maritime
+```
+
+The following functional/market paths should be audited and added only where absent:
+
+```text
+Market / Clothing / Work Clothing
+Market / Clothing / Ceremonial Clothing
+Market / Clothing / Religious Clothing
+Market / Clothing / Maritime Clothing
+Functions / Worn Items / Underlayers
+Functions / Worn Items / Robes
+Functions / Worn Items / Outerwear
+Functions / Worn Items / Footwear
+Functions / Worn Items / Headwear
+Functions / Worn Items / Facewear
+Functions / Worn Items / Handwear
+Functions / Worn Items / Neckwear
+Functions / Worn Items / Detachable Garment Parts
+Institution / Court
+Institution / Religious
+Institution / Guild
+Institution / Maritime
+Institution / Performance
+Institution / Service Household
+```
+
+Status and profession tags must not replace culture/date admission. A court garment can be locally made, imported, gifted, or inherited; those distinctions belong in skins, shops, manifests, and builder notes.
+
+## Common-form prototype catalogue — 55 unique prototypes
+
+These forms are shared only in the catalogue sense: several culture families can plausibly use the same underlying construction. Each culture still requires an admission decision.
+
+### Underlayers and close bodywear — 10
+
+| Stable reference | Public form | Material | Wear profile | Variation family | Admission |
+| --- | --- | --- | --- | --- | --- |
+| `renaissance_shared_clothing_drawstring_drawers` | loose drawstring drawers | linen | `WP-UNDER-WAIST` | knee/calf length; plain/fine; undyed/dyed | broad urban, court, military, and maritime underlayer where sewn drawers are credible |
+| `renaissance_shared_clothing_wrapped_loincloth` | wrapped loincloth | linen | `WP-UNDER-WAIST` | narrow/broad; tucked/tied; cotton skin | tropical, labour, maritime, American, African, South/South-east Asian admissions |
+| `renaissance_shared_clothing_breast_wrap` | folded breast wrap | linen | `WP-BREAST-WRAP` | narrow/broad; tied front/back; cotton skin | multiple wrapped-underlayer traditions; not universal |
+| `renaissance_shared_clothing_short_undershirt` | short undershirt | linen | `WP-SHIRT` | sleeveless/short sleeve; square/round neck | warm-climate and layered urban use |
+| `renaissance_shared_clothing_long_undershirt` | long undershirt | linen | `WP-SHIRT` | thigh/knee hem; narrow/full sleeve | broad sewn-underlayer admission |
+| `renaissance_shared_clothing_sleeveless_undervest` | sleeveless undervest | linen | `WP-VEST` | fitted/loose; low/high neck | layered court, military, and work dress where supported |
+| `renaissance_shared_clothing_straight_underrobe` | straight under-robe | linen | `WP-LONG-UNDERLAYER` | calf/ankle; narrow/full sleeve; cotton skin | robe systems across Ottoman, Persianate, Asian, African, and European contexts |
+| `renaissance_shared_clothing_footed_stockings` | footed cloth stockings | wool | `WP-STOCKINGS` | knee/thigh high; clocked/plain; silk skin | Western, Central/Eastern European, Ottoman and court contact admissions |
+| `renaissance_shared_clothing_soleless_stockings` | soleless cloth stockings | wool | `WP-STOCKINGS` | knee/thigh high; stirrup/plain | cultures using separate footwraps or shoes |
+| `renaissance_shared_clothing_leg_wraps` | paired lower-leg wraps | wool | `WP-LEG-WRAPS` | narrow/broad; spiral/cross-wrapped; linen skin | work, travel, military, northern, steppe, and rural admissions |
+
+### Core upper- and lower-body forms — 12
+
+| Stable reference | Public form | Material | Wear profile | Variation family | Admission |
+| --- | --- | --- | --- | --- | --- |
+| `renaissance_shared_clothing_straight_tunic` | straight-cut tunic | linen | `WP-SHIRT` | hip/knee length; split/unsplit hem; wool/cotton skins | broad continuity form where a regional silhouette is not more specific |
+| `renaissance_shared_clothing_side_slit_tunic` | side-slit tunic | cotton | `WP-SHIRT` | short/long slit; narrow/full sleeve; silk skin | African, South Asian, Persianate, steppe, and maritime Asian admissions |
+| `renaissance_shared_clothing_crossfront_jacket` | cross-front jacket | cotton | `WP-JACKET` | left/right overlap; tied/belted; silk/ramie skins | East, South-east, Central, and contact-zone Asian admissions |
+| `renaissance_shared_clothing_wrap_jacket` | short wrap jacket | linen | `WP-JACKET` | sleeveless/long sleeve; inner/outer ties | work and warm-climate contexts across several groupings |
+| `renaissance_shared_clothing_front_opening_long_coat` | front-opening long coat | wool | `WP-ROBE-OPEN` | calf/ankle; fitted/loose; fur-lined skin | steppe, Eastern European, Ottoman, Persianate, and northern travel contexts |
+| `renaissance_shared_clothing_sleeveless_overvest` | sleeveless over-vest | wool | `WP-VEST` | short/long; open/fastened; leather skin | work, travel, military, and court layering |
+| `renaissance_shared_clothing_quilted_jacket` | quilted jacket | cotton | `WP-JACKET` | hip/thigh length; light/heavy quilting; silk skin | civilian warmth and under-armour use; no armour claim beyond clothing components |
+| `renaissance_shared_clothing_straight_trousers` | straight-legged trousers | wool | `WP-TROUSERS` | ankle/calf; drawstring/fly-front skin; cotton/linen skins | broad trouser-using culture groups |
+| `renaissance_shared_clothing_narrow_trousers` | narrow-legged trousers | wool | `WP-TROUSERS` | footed/stirrup/plain; cotton/silk skins | riding, court, steppe, Ottoman, Persianate, South Asian, East Asian admissions |
+| `renaissance_shared_clothing_full_trousers` | full gathered trousers | cotton | `WP-TROUSERS` | ankle/calf gathering; very full/moderate; silk skin | Ottoman, Persianate, South Asian, African and maritime Asian contexts |
+| `renaissance_shared_clothing_wrap_skirt` | overlapping wrap skirt | cotton | `WP-WRAP-SKIRT` | knee/ankle; narrow/broad overlap; silk/barkcloth skins | South/South-east/East Asian, African, American, and maritime admissions |
+| `renaissance_shared_clothing_gathered_skirt` | gathered sewn skirt | wool | `WP-SKIRT` | ankle/calf; narrow/full; linen/cotton/silk skins | European, African, American contact, and urban work admissions |
+
+### Outerwear and shoulder layers — 8
+
+| Stable reference | Public form | Material | Wear profile | Variation family | Admission |
+| --- | --- | --- | --- | --- | --- |
+| `renaissance_shared_clothing_rectangular_mantle` | rectangular shoulder mantle | wool | `WP-SHOULDER` | pinned/tied/draped; short/long; cotton/camelid skins | widespread draped outer layer with local skins |
+| `renaissance_shared_clothing_hooded_cloak` | hooded full cloak | wool | `WP-CLOAK` | semicircular/rectangular; clasp/ties; lined/unlined | cool, wet, travel, maritime, and northern admissions |
+| `renaissance_shared_clothing_sleeveless_cape` | sleeveless short cape | wool | `WP-CLOAK` | hip/knee; open/fastened; velvet skin | court, civic, clerical, travel, and military-overdress admissions |
+| `renaissance_shared_clothing_shoulder_shawl` | broad shoulder shawl | wool | `WP-SHOULDER` | rectangular/triangular; plain/fringed; cotton/silk skins | Persianate, South Asian, steppe, African, Andean, European elite/contact admissions |
+| `renaissance_shared_clothing_rain_cape` | close-woven rain cape | wool | `WP-CLOAK` | hooded/collarless; hip/knee | maritime, mountain, pastoral, and travel contexts; descriptive water shedding only |
+| `renaissance_shared_clothing_fur_lined_coat` | fur-lined travelling coat | wool | `WP-ROBE-OPEN` | calf/ankle; broad/narrow collar; prestige/work skins | northern, steppe, Muscovite, Central/Eastern European admissions; audit exact fur material |
+| `renaissance_shared_clothing_travelling_coat` | loose travelling coat | broadcloth | `WP-ROBE-OPEN` | knee/calf; hood/collar; canvas skin | merchant, courier, pilgrim, maritime, and caravan overlays |
+| `renaissance_shared_clothing_ceremonial_mantle` | long ceremonial mantle | velvet | `WP-SHOULDER` | train/no train; clasp/ties; silk/brocade skins | court, civic, religious, diplomatic, and performance contexts only |
+
+### Footwear — 8
+
+| Stable reference | Public form | Material | Wear profile | Variation family | Admission |
+| --- | --- | --- | --- | --- | --- |
+| `renaissance_shared_clothing_leather_sandals` | pair of leather sandals | leather | `WP-FOOT-SANDAL` | thong/strap; flat/raised sole; plain/decorated | warm-climate, religious, labour, African, Asian, and American admissions |
+| `renaissance_shared_clothing_textile_sandals` | pair of woven sandals | canvas | `WP-FOOT-SANDAL` | braided/woven; open/closed toe; hemp/raffia skins | East Asian, South-east Asian, African, maritime, and rural work contexts |
+| `renaissance_shared_clothing_soft_slippers` | pair of soft slippers | leather | `WP-FOOT-SHOE` | backless/heeled-back; pointed/round; velvet/silk skins | court, domestic, Ottoman, Persianate, South Asian, East Asian, African urban admissions |
+| `renaissance_shared_clothing_low_leather_shoes` | pair of low leather shoes | leather | `WP-FOOT-SHOE` | latchet/tie; round/pointed; plain/slashed skin | broad urban and rural admissions where closed sewn shoes are credible |
+| `renaissance_shared_clothing_ankle_boots` | pair of ankle boots | leather | `WP-FOOT-BOOT` | side-laced/pull-on; soft/stiff shaft | travel, riding, work, military, maritime, and steppe contexts |
+| `renaissance_shared_clothing_high_riding_boots` | pair of high riding boots | leather | `WP-FOOT-BOOT` | knee/thigh; soft/stiff shaft; turned cuff skin | cavalry, courier, steppe, frontier, elite travel admissions |
+| `renaissance_shared_clothing_wooden_soled_overshoes` | pair of wooden-soled overshoes | wood | `WP-OVERSHOE` | low/high platform; strap/closed upper | wet streets, bathhouse, court, East Asian, Ottoman, European urban admissions where locally credible |
+| `renaissance_shared_clothing_footwraps` | pair of cloth footwraps | linen | `WP-STOCKINGS` | square/long strip; wool skin | military, labour, rural, northern, steppe, and low-shoe admissions |
+
+### Head, face, and neck forms — 9
+
+| Stable reference | Public form | Material | Wear profile | Variation family | Admission |
+| --- | --- | --- | --- | --- | --- |
+| `renaissance_shared_clothing_close_cloth_cap` | close-fitting cloth cap | linen | `WP-HEAD-CAP` | tied/untied; eared/plain; cotton/silk skins | under-hat, domestic, work, religious, East Asian, European, African admissions |
+| `renaissance_shared_clothing_soft_brimless_cap` | soft brimless cap | wool | `WP-HEAD-CAP` | rounded/pointed; folded/unfolded; felt/silk skins | urban, rural, scholar, sailor, steppe, African and European admissions |
+| `renaissance_shared_clothing_felt_brimmed_hat` | brimmed felt hat | felt | `WP-HEAD-HAT` | narrow/broad brim; low/high crown; band/feather skins | European, Ottoman contact, maritime, colonial, and trade contexts |
+| `renaissance_shared_clothing_straw_brimmed_hat` | woven straw hat | straw | `WP-HEAD-HAT` | flat/conical crown; narrow/broad brim; chin ties | field, maritime, tropical, East/South-east Asian, African, American admissions; audit exact straw material |
+| `renaissance_shared_clothing_cloth_headwrap` | long cloth headwrap | cotton | `WP-HEADWRAP` | narrow/broad; compact/voluminous; linen/silk skins | Ottoman, Persianate, South Asian, African, steppe, maritime and contact contexts |
+| `renaissance_shared_clothing_long_head_veil` | long head-draped veil | linen | `WP-HEAD-VEIL` | shoulder/waist length; opaque/shear silk skin | religious, court, married-status, mourning, and regional admissions |
+| `renaissance_shared_clothing_short_head_veil` | short head veil | linen | `WP-HEAD-VEIL` | pinned/tied; back/side drape; lace/silk skins | European, Mediterranean, Ottoman, African, and contact-zone admissions |
+| `renaissance_shared_clothing_separate_hood` | separate cloth hood | wool | `WP-HOOD` | close/loose; shoulder cape/no cape; linen skin | European, northern, maritime, religious, travelling admissions |
+| `renaissance_shared_clothing_face_veil` | draped face veil | silk | `WP-FACE-VEIL` | nose-to-chin/full lower face; tied/pinned; cotton skin | culture/date/status-gated Ottoman, Persianate, South Asian, African, and ceremonial admissions |
+
+### Handheld and small worn accessories — 8
+
+| Stable reference | Public form | Material | Wear profile | Variation family | Admission |
+| --- | --- | --- | --- | --- | --- |
+| `renaissance_shared_clothing_cloth_gloves` | pair of cloth gloves | wool | `WP-HANDS` | short/long cuff; plain/embroidered; silk skin | cool-climate, court, clerical, scholarly, ceremonial admissions |
+| `renaissance_shared_clothing_leather_gloves` | pair of leather gloves | leather | `WP-HANDS` | short/gauntlet cuff; work/fine; perfumed skin | riding, work, court, falconry skin, maritime and military support |
+| `renaissance_shared_clothing_mittens` | pair of cloth mittens | wool | `WP-HANDS` | short/long cuff; felt/fur-lined skins | northern, mountain, steppe, maritime cold-weather admissions |
+| `renaissance_shared_clothing_neck_kerchief` | tied neck kerchief | linen | `WP-NECK` | narrow/broad; tied front/back; cotton/lace skins | work, sailor, artisan, domestic, court accessory admissions |
+| `renaissance_shared_clothing_shoulder_scarf` | long shoulder scarf | silk | `WP-SHOULDER` | narrow/broad; fringed/plain; cotton/wool skins | court, diplomatic, religious, military-status and performance overlays |
+| `renaissance_shared_clothing_folding_hand_fan` | folding hand fan | wood | `WP-HANDHELD` | paper/silk leaf; plain/painted; court/merchant skins | late-period East Asian, European court/contact, Ottoman and maritime trade admissions; date gate required |
+| `renaissance_shared_clothing_half_mask` | shaped half mask | leather | `WP-FACE-MASK` | eye/upper-face; plain/painted; velvet skin | theatre, pageant, festival, court entertainment, disguise-support only if a component is later added |
+| `renaissance_shared_clothing_detachable_sleeves` | pair of detachable sleeves | silk | `WP-SLEEVES` | tight/full; tied/laced; linen/wool/velvet skins | Western European, Ottoman, Persianate, South Asian and courtly layered admissions where construction supports it |
+
+## Shared placement table — 41 deliberate reuses
+
+The regional volumes contain 41 placements that point back to common or another regional prototype. They are admissions, not aliases and not additional item rows. Examples include low leather shoes admitted into colonial Atlantic outfits, shoulder shawls admitted into Andean elite/contact outfits, quilted jackets admitted into Japanese and steppe military underlayers, and cloth headwraps admitted across Ottoman, Persianate, South Asian, African, and maritime cultures. Each regional volume records its reuse count; all stable references remain unique.
+
+## Profession and institution overlays
+
+Profession overlays are outfits and skins unless a garment has a distinct construction or function. Minimum authored outfit families:
+
+| Overlay | Required slots | Typical catalogue sources |
+| --- | --- | --- |
+| field labourer | underlayer, shirt/tunic, lower garment, head protection, footwear, optional apron | common forms plus local culture volume |
+| artisan | shirt/tunic, lower garment, work apron or over-vest, cap/headwrap, footwear | common forms; Western, Asian, African urban variants |
+| merchant | underlayer, core garment, outer robe/coat, headwear, footwear, optional gloves | all urban culture groupings |
+| scholar/notary/administrator | underlayer, long garment or fitted suit, outer layer, headwear, footwear | Western, Ottoman/Persianate, East Asian literati, African Islamic volumes |
+| printer/book worker | shirt/tunic, lower garment, ink-marked apron, cap/headwrap, shoes | Western and East Asian print contexts |
+| sailor/dock worker | shirt or short tunic, drawers/trousers/wrap, kerchief/headwrap, weather layer, footwear or bare-foot admission | Atlantic, Indian Ocean, East/South-east Asian and contact volumes |
+| apothecary/medical worker | washable underlayer, gown/robe/coat, apron, close headwear, shoes | culture-specific urban forms; no modern white-coat default |
+| artist/musician | ordinary status outfit plus tool-safe apron or performance skin | Western court/civic, Ottoman/Persianate, Asian court, African court |
+| actor/pageant participant | ordinary underlayer plus mask, mantle, detachable sleeves, staged costume skins | institutional performance tag; theatrical inspiration in builder notes |
+| guard/court servant | local ordinary dress with livery/status skins; outer coat/tabard only where silhouette differs | court and civic volumes |
+| religious functionary | culture-specific long garment, mantle/vestment, headwear and footwear | cross-confessional institutional sections; never a generic universal priest outfit |
+
+Outfits must fail closed when a required authored slot is missing. Shared slots must be explicit. A skin may not change the wearable component or convert a one-piece garment into a multi-piece outfit.
+
+## Craft and production implications
+
+The catalogue assumes `Tailoring`/`Textilecraft` as the principal skill family. Implementation should group crafts by construction rather than create one craft per cosmetic skin:
+
+- cut-and-sewn linen/cotton underlayers;
+- wool broadcloth garments;
+- fitted doublet/bodice and structured Western work;
+- long robe/kaftan/coat construction;
+- wrapped and draped garments;
+- quilting and padded clothing;
+- felt and woven headwear;
+- shoemaking, sandal making, and boot making;
+- glove making;
+- veil, lace, ribbon, and fine accessory work;
+- regional bast-fibre, barkcloth, camelid, raffia, featherwork, and beadwork chains once materials resolve.
+
+Crafts must consume exact material stock and exact tools. Decorative skins should not multiply base crafts unless the decoration has its own material input and skill gate.
+
+## Implementation sequence
+
+1. Seed or resolve culture and functional tags.
+2. Audit live wearable components and add the blocking profiles from the dependency ledger.
+3. Seed high-priority materials where prototypes cannot be represented honestly by live stock.
+4. Implement the 55 common forms and verify stable-reference idempotence.
+5. Implement regional volumes in dependency order: common admissions first, then distinct silhouettes.
+6. Add skins, beginning with plain/work, standard urban, luxury/court, religious/institutional, and imported/contact variants.
+7. Add authored outfits and shop/culture/date manifests.
+8. Add crafts only after exact skills, tools, materials, tags, and output references resolve.
+
+## Acceptance criteria
+
+- All 395 stable references are unique and every one has an explicit culture/date admission.
+- The 41 shared placements reuse an existing stable reference rather than cloning it.
+- Every portable item has `Holdable`; every garment has a valid exact wearable and destroyable component.
+- No item uses a material, tag, component, skill, or stable reference that is absent at implementation time.
+- Public descriptions are form-based and do not universalise a local historical name.
+- Skins do not change silhouette, component behaviour, coverage, capacity, or production technology.
+- Contact and colonial rows identify imported, imposed, hybrid, or local-continuity status rather than presenting colonial systems as culturally neutral.
+- Religious and ceremonial clothing is admitted through an institution and date context, not a generic universal category.
+- Complete outfits fail closed on missing authored pieces and identify intentionally shared slots.

--- a/Design Documents/Seeding/FutureMUD_Renaissance_Clothing_Catalogue_Africa_Americas_Maritime.md
+++ b/Design Documents/Seeding/FutureMUD_Renaissance_Clothing_Catalogue_Africa_Americas_Maritime.md
@@ -1,0 +1,277 @@
+# FutureMUD Renaissance Clothing Catalogue — African, American, Contact, and Maritime Shared Cultures
+
+## Purpose and sensitivity boundary
+
+This volume defines **100 unique clothing prototypes** for:
+
+- Shared African court / Atlantic;
+- Shared Sahelian Islamic;
+- Shared Red Sea;
+- Shared Indian Ocean and Swahili coast;
+- Shared Mesoamerican;
+- Shared Andean;
+- Shared Caribbean contact;
+- Shared North American contact;
+- Shared first-contact / colonial, Shared colonial Atlantic, and Shared global maritime overlays.
+
+The design authority and common catalogue are in [FutureMUD Renaissance Clothing and Accessories Design Reference](./FutureMUD_Renaissance_Clothing_Accessories_Design_Reference.md).
+
+These are builder-facing Shared groupings, not assertions that large regions had uniform dress. Every implementation row requires a narrower inspiration, date anchor, social/institutional setting, and local-admission note. Ritual, office, royal, diplomatic, military, mourning, initiation, and sacred garments must not enter ordinary shop stock merely because a prototype exists.
+
+Contact and colonial rows must identify whether a form is local continuity, imported, imposed, mission-associated, made for export, or genuinely hybrid. They must not frame colonisation as neutral cultural exchange or treat imported European dress as automatic technological progression.
+
+## Volume-specific dependency notes
+
+High-priority materials:
+
+- `raffia cloth` for woven and fringed palm-fibre garments;
+- `barkcloth` for beaten-bark garments and capes;
+- `camelid wool` for Andean textiles;
+- `featherwork` for garments whose primary visible surface is structured feather mosaic or tied feather panels;
+- `beadwork` for garments whose construction is a bead lattice or densely beaded panel rather than ordinary textile with decorative beads.
+
+`cotton`, `linen`, `wool`, `leather`, `silk`, `felt`, and `canvas` are live and cover many rows. Exact `fur`, `hide`, `straw`, shell, horsehair, and wood-like dependencies must be audited against the maintained material export.
+
+Additional semantic wearable profiles used here:
+
+- `WP-DOUBLE-WRAP`: two coordinated wrapper panels authored as one garment where they are inseparable in silhouette;
+- `WP-RECTANGULAR-BLOUSE`: rectangular sleeveless or short-sleeved upper garment with head opening;
+- `WP-TRIANGLE-SHOULDER`: triangular or diamond-shaped shoulder garment;
+- `WP-WRAP-DRESS`: one broad cloth wrapped as a full-length dress;
+- `WP-BREECHCLOTH`: front-and-back panel lower garment distinct from a short loin wrap;
+- `WP-MOCCASIN`: soft closed hide footwear with gathered or seamed upper;
+- `WP-FEATHER-CROWN`: structured feather headwear occupying the hat layer;
+- `WP-FULL-MASK`: full rigid face covering;
+- `WP-HYBRID-TUNIC`: contact-zone tunic profile only where European fastening materially changes a local cut.
+
+Use existing exact components when coverage/layering matches. Otherwise these are blocking wearable definitions, not new engine component types.
+
+## A. Shared African court / Atlantic catalogue — 25
+
+### Wrapped, sewn, and court textile garments — 12
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_africancourt_narrow_waistwrapper` | narrow woven waist wrapper | cotton | `WP-WRAP-SKIRT` | knee/calf; work, household, court-attendant, trade-cloth skins; narrower inspiration required |
+| `renaissance_africancourt_broad_waistwrapper` | broad full-length waist wrapper | cotton | `WP-WRAP-SKIRT` | ankle length; plain, indigo, patterned, silk-import skins as locally admitted |
+| `renaissance_africancourt_sewn_tubewrapper` | sewn tubular wrapper | cotton | `WP-TUBE-SKIRT` | narrow/full tube; market, household, court, ceremonial skins |
+| `renaissance_africancourt_doublelayer_wrapper` | layered double wrapper | cotton | `WP-DOUBLE-WRAP` | two coordinated panels integral to silhouette; court, marriage, ceremony, prosperous urban gate |
+| `renaissance_africancourt_sleeveless_straighttunic` | sleeveless straight woven tunic | cotton | `WP-RECTANGULAR-BLOUSE` | hip/knee; plain, striped, patterned, prestige skins |
+| `renaissance_africancourt_shortsleeve_tunic` | short-sleeved straight tunic | cotton | `WP-SHIRT` | hip/knee; work, merchant, household, court-attendant skins |
+| `renaissance_africancourt_longsleeve_sideslit_tunic` | long-sleeved side-slit tunic | cotton | `WP-SHIRT` | knee/calf; urban, court, diplomatic, merchant skins |
+| `renaissance_africancourt_broadsleeve_courtrobe` | broad-sleeved full court robe | silk | `WP-ROBE-CLOSED` | court/office/diplomatic gate; imported textile status recorded in manifest |
+| `renaissance_africancourt_fitted_shortjacket` | fitted short court jacket | cotton | `WP-JACKET` | waist/hip; court, guard, diplomatic-contact, silk skins |
+| `renaissance_africancourt_long_open_courtcoat` | long open-front court coat | silk | `WP-ROBE-OPEN` | court/office/procession gate; brocade and imported-cloth skins |
+| `renaissance_africancourt_full_gathered_courtskirt` | full gathered court skirt | cotton | `WP-SKIRT` | ankle length; plain/patterned/silk; court and ceremony admission |
+| `renaissance_africancourt_panelled_danceskirt` | panelled ceremonial dance skirt | cotton | `WP-SKIRT` | performance, court, festival, ritual gate; bells and jewellery remain separate items |
+
+### Raffia, barkcloth, beadwork, featherwork, and hide regalia — 9
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_africancourt_raffia_fringe_skirt` | fringed raffia skirt | raffia cloth | `WP-SKIRT` | **material dependency**; court, performance, initiation, festival only through local manifest |
+| `renaissance_africancourt_raffia_shouldercape` | layered raffia shoulder cape | raffia cloth | `WP-SHOULDER` | **material dependency**; ceremonial/status gate; length and dye are skins |
+| `renaissance_africancourt_barkcloth_straighttunic` | straight barkcloth tunic | barkcloth | `WP-RECTANGULAR-BLOUSE` | **material dependency**; local forest/central-African-facing admission only |
+| `renaissance_africancourt_barkcloth_wrapskirt` | broad barkcloth wrap skirt | barkcloth | `WP-WRAP-SKIRT` | **material dependency**; work, household, court skin only where locally credible |
+| `renaissance_africancourt_beadwork_ceremonialapron` | dense beaded ceremonial apron | beadwork | `WP-WRAP-SKIRT` | **material dependency**; court/office/ritual gate; beads are structural surface |
+| `renaissance_africancourt_beaded_chestmantle` | lattice beaded chest mantle | beadwork | `WP-SHOULDER` | **material dependency**; court/regalia/diplomatic gate; not ordinary jewellery stock |
+| `renaissance_africancourt_featherwork_shouldermantle` | layered feather shoulder mantle | featherwork | `WP-SHOULDER` | **material dependency**; court/ritual/military-status gate; species/pattern in skin notes |
+| `renaissance_africancourt_hide_prestigecloak` | spotted-hide prestige cloak | leather | `WP-CLOAK` | use generic leather only temporarily; court/office/warrior-status gate and ethical source note |
+| `renaissance_africancourt_indigo_worksmock` | loose indigo work smock | cotton | `WP-LONG-UNDERLAYER` | artisan, dyer, market, agricultural, household skins; colour family is a skin |
+
+### Headwear and distinctive court footwear — 4
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_africancourt_tall_wovencap` | tall close-woven cap | cotton | `WP-HEAD-CAP` | plain, striped, embroidered, court/office skins |
+| `renaissance_africancourt_soft_embroideredcap` | soft embroidered round cap | cotton | `WP-HEAD-CAP` | merchant, court, scholar/contact, household skins |
+| `renaissance_africancourt_structured_crownheadcloth` | crown-shaped structured headcloth | cotton | `WP-STRUCTURED-HEADWRAP` | court/office/ceremony gate; fold and motif are skins |
+| `renaissance_africancourt_raised_woodensandals` | pair of raised wooden court sandals | wood | `WP-FOOT-SANDAL` | court/household/ceremonial gate; low/high platform skins |
+
+## B. Shared Sahelian Islamic, Red Sea, and Indian Ocean catalogue — 20
+
+### Sahelian Islamic shared forms — 8
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_sahel_broad_rectangular_robe` | broad rectangular over-robe | cotton | `WP-ROBE-CLOSED` | boubou-like builder anchor; scholar, merchant, court, ordinary skins by local date/status |
+| `renaissance_sahel_narrow_longtunic` | narrow long side-slit tunic | cotton | `WP-SHIRT` | knee/calf; work, rider, merchant, scholar skins |
+| `renaissance_sahel_embroidered_necktunic` | broad embroidered-neck tunic | cotton | `WP-ROBE-CLOSED` | embroidery as skin; merchant, scholar, court, festival gate |
+| `renaissance_sahel_veryfull_trousers` | very full drawstring trousers | cotton | `WP-TROUSERS` | ankle/calf gathering; riding, court, merchant, work skins |
+| `renaissance_sahel_leather_ridingcoat` | long leather riding coat | leather | `WP-ROBE-OPEN` | caravan, cavalry, courier, elite travel; no armour claim |
+| `renaissance_sahel_scholar_turban` | layered scholar's turban | cotton | `WP-STRUCTURED-HEADWRAP` | madrasa, court, legal, merchant skins; local institution/status gate |
+| `renaissance_sahel_conical_leatherhat` | conical leather riding hat | leather | `WP-HEAD-HAT` | rider, caravan, rural, military-status skins |
+| `renaissance_sahel_indigo_faceveil` | long indigo face veil | cotton | `WP-FACE-VEIL` | culture/gender/status gate; not universal Sahelian clothing |
+
+### Ethiopian / Red Sea shared forms — 6
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_redsea_full_shoulderwrap` | full body-and-shoulder wrap | cotton | `WP-DRAPED-FULL` | highland/Red Sea-facing admission; plain, bordered, court, religious skins |
+| `renaissance_redsea_narrow_cotton_tunic` | narrow long cotton tunic | cotton | `WP-SHIRT` | knee/calf; work, soldier, court-attendant, religious skins |
+| `renaissance_redsea_long_courtshirt` | long full-sleeved court shirt | cotton | `WP-ROBE-CLOSED` | court, diplomatic, church-associated, merchant skins |
+| `renaissance_redsea_embroidered_shouldercape` | embroidered shoulder cape | cotton | `WP-SHOULDER` | court, church, procession, diplomatic gate; symbols remain skins |
+| `renaissance_redsea_leather_highlandcloak` | broad leather highland cloak | leather | `WP-CLOAK` | herder, rider, soldier, travel skins; hide source in builder note |
+| `renaissance_redsea_white_headhood` | white head-draped hood | cotton | `WP-HOOD` | religious, court, household, mourning/status skins by local manifest |
+
+### Swahili / Indian Ocean shared forms — 6
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_indianocean_long_coastalrobe` | long collarless coastal robe | cotton | `WP-ROBE-CLOSED` | Swahili/Indian Ocean urban gate; plain, striped, imported-silk skins |
+| `renaissance_indianocean_short_coastaltunic` | short loose coastal tunic | cotton | `WP-SHIRT` | sailor, artisan, merchant, household, work skins |
+| `renaissance_indianocean_open_merchantcoat` | light open-front merchant coat | cotton | `WP-ROBE-OPEN` | port merchant, broker, scholar, diplomatic-contact skins |
+| `renaissance_indianocean_sewn_wrapskirt` | sewn coastal wrap skirt | cotton | `WP-TUBE-SKIRT` | household, market, maritime, fine imported-cloth skins |
+| `renaissance_indianocean_embroidered_roundcap` | close embroidered round cap | cotton | `WP-HEAD-CAP` | merchant, scholar, mosque/madrasa, sailor skins; institution gate where relevant |
+| `renaissance_indianocean_toeloop_sandals` | pair of toe-loop leather sandals | leather | `WP-FOOT-SANDAL` | urban, maritime, traveller, elite-decorated skins; distinct toe-loop construction |
+
+## C. Shared Mesoamerican catalogue — 18
+
+Public names remain descriptive. Builder notes may record narrower Mexica, Maya/Postclassic, Mixtec, or other anchors only where the associated local manifest supports them.
+
+### Core garments — 8
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_mesoamerican_panelled_loincloth` | long panelled loin garment | cotton | `WP-BREECHCLOTH` | narrow/broad front and back panels; work, warrior-status, court skins |
+| `renaissance_mesoamerican_shouldertied_cloak` | shoulder-tied rectangular cloak | cotton | `WP-SHOULDER` | hip/ankle; plain, patterned, tribute, court skins; knot side is cosmetic |
+| `renaissance_mesoamerican_rectangular_blouse` | rectangular sleeveless woven blouse | cotton | `WP-RECTANGULAR-BLOUSE` | hip/thigh; plain, patterned, court, household skins; huipil-like anchor |
+| `renaissance_mesoamerican_triangle_shouldergarment` | triangular shoulder garment | cotton | `WP-TRIANGLE-SHOULDER` | short/long points; household, court, ceremony, fine skins; quechquemitl-like anchor |
+| `renaissance_mesoamerican_short_wrapskirt` | short woven wrap skirt | cotton | `WP-WRAP-SKIRT` | knee/calf; household, market, work, patterned skins |
+| `renaissance_mesoamerican_long_wrapskirt` | long woven wrap skirt | cotton | `WP-WRAP-SKIRT` | ankle; plain, patterned, court, ceremony skins |
+| `renaissance_mesoamerican_side_seamed_tunic` | side-seamed sleeveless tunic | cotton | `WP-RECTANGULAR-BLOUSE` | knee/thigh; court, military-status, ritual, ordinary skins by local admission |
+| `renaissance_mesoamerican_full_ceremonialtunic` | long full ceremonial tunic | cotton | `WP-ROBE-CLOSED` | court/ritual/office gate; woven and embroidered presentation are skins |
+
+### Featherwork, barkcloth, shell/bead, hide, masks, and footwear — 10
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_mesoamerican_featherwork_mantle` | mosaic feather mantle | featherwork | `WP-SHOULDER` | **material dependency**; court/ritual/office/diplomatic gate |
+| `renaissance_mesoamerican_featherwork_tunic` | panelled feather tunic | featherwork | `WP-RECTANGULAR-BLOUSE` | **material dependency**; elite/ritual/military-status only through local manifest |
+| `renaissance_mesoamerican_tall_feathercrown` | tall radiating feather crown | featherwork | `WP-FEATHER-CROWN` | **material dependency**; office/ritual/court gate; exact species and colour are skins |
+| `renaissance_mesoamerican_broad_featherheadband` | broad feathered headband | featherwork | `WP-HEAD-HAT` | court, warrior-status, dance, ritual skins; not ordinary universal wear |
+| `renaissance_mesoamerican_woven_headcap` | close woven fibre cap | cotton | `WP-HEAD-CAP` | plain, patterned, court, work skins |
+| `renaissance_mesoamerican_woven_fibresandals` | pair of woven fibre sandals | canvas | `WP-FOOT-SANDAL` | cotton/agave-like builder skins; exact agave fibre may be future material |
+| `renaissance_mesoamerican_shellbead_apron` | shell-and-bead ceremonial apron | beadwork | `WP-WRAP-SKIRT` | **material dependency**; ritual/office/court gate |
+| `renaissance_mesoamerican_painted_barkclothcape` | painted barkcloth shoulder cape | barkcloth | `WP-SHOULDER` | **material dependency**; ritual, tribute, court, festival gate |
+| `renaissance_mesoamerican_spottedhide_mantle` | spotted-hide shoulder mantle | leather | `WP-SHOULDER` | court/warrior-status/ritual gate; source and symbolism in builder note |
+| `renaissance_mesoamerican_carved_fullfacemask` | carved full-face mask | wood | `WP-FULL-MASK` | ritual, performance, court pageant gate; no disguise mechanic unless later supported |
+
+## D. Shared Andean catalogue — 14
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_andean_straight_sleevelesstunic` | straight sleeveless knee tunic | camelid wool | `WP-RECTANGULAR-BLOUSE` | **material dependency**; work, state service, local, plain skins |
+| `renaissance_andean_fine_tapestrytunic` | fine tapestry-woven tunic | camelid wool | `WP-RECTANGULAR-BLOUSE` | **material dependency**; court/state/office/ceremonial gate; motif is skin |
+| `renaissance_andean_short_worktunic` | short coarse work tunic | camelid wool | `WP-RECTANGULAR-BLOUSE` | **material dependency**; labour, messenger, rural, military-support skins |
+| `renaissance_andean_wrapped_fulllengthdress` | wrapped full-length dress | camelid wool | `WP-WRAP-DRESS` | **material dependency**; anaku-like anchor; household, court, ceremony skins |
+| `renaissance_andean_pinned_wrapskirt` | pinned broad wrap skirt | camelid wool | `WP-WRAP-SKIRT` | **material dependency**; pin is presentation unless fastening state is supported |
+| `renaissance_andean_paired_shouldermantle` | broad pinned shoulder mantle | camelid wool | `WP-SHOULDER` | **material dependency**; household, market, court, local motif skins |
+| `renaissance_andean_ceremonial_broadmantle` | long ceremonial mantle | camelid wool | `WP-SHOULDER` | **material dependency**; state/court/ritual/diplomatic gate |
+| `renaissance_andean_fringed_camelidshawl` | fringed camelid-wool shawl | camelid wool | `WP-SHOULDER` | **material dependency**; ordinary, elite, messenger, cold-weather skins |
+| `renaissance_andean_featherwork_tunic` | feather-panelled ceremonial tunic | featherwork | `WP-RECTANGULAR-BLOUSE` | **material dependency**; court/state/ritual gate and trade-status note |
+| `renaissance_andean_feathered_headband` | broad feathered headband | featherwork | `WP-HEAD-HAT` | **material dependency**; office/ritual/status gate |
+| `renaissance_andean_woven_earflapcap` | woven ear-flap cap | camelid wool | `WP-HEAD-CAP` | **material dependency**; regional/date/status skins; chullo-like anchor used cautiously |
+| `renaissance_andean_long_headcloth` | long woven headcloth | camelid wool | `WP-HEADWRAP` | **material dependency**; wrapped, draped, court, local skins |
+| `renaissance_andean_braided_fibresandals` | pair of braided fibre sandals | canvas | `WP-FOOT-SANDAL` | exact plant fibre future dependency; work, messenger, military-support skins |
+| `renaissance_andean_fringed_ceremonialapron` | fringed ceremonial waist apron | camelid wool | `WP-WRAP-SKIRT` | **material dependency**; court/ritual/performance/status gate |
+
+## E. Shared Caribbean and North American contact catalogue — 13
+
+### Caribbean contact shared forms — 6
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_caribbean_cotton_wrapskirt` | short cotton wrap skirt | cotton | `WP-WRAP-SKIRT` | Taíno/Caribbean-facing local admission; plain, woven-pattern, status skins |
+| `renaissance_caribbean_cotton_loinapron` | panelled cotton loin apron | cotton | `WP-BREECHCLOTH` | work, household, status, contact skins; narrower local anchor required |
+| `renaissance_caribbean_sleeveless_cottontunic` | loose sleeveless cotton tunic | cotton | `WP-RECTANGULAR-BLOUSE` | local continuity or contact-hybrid status must be recorded |
+| `renaissance_caribbean_woven_shouldercape` | short woven shoulder cape | cotton | `WP-SHOULDER` | status, ceremony, travel, contact skins; not universal ordinary dress |
+| `renaissance_caribbean_feathered_headband` | narrow feathered headband | featherwork | `WP-HEAD-HAT` | **material dependency**; status/ritual/dance gate |
+| `renaissance_caribbean_woven_fibresandals` | pair of woven fibre sandals | canvas | `WP-FOOT-SANDAL` | exact fibre future dependency; local/contact admission only |
+
+### North American Indigenous contact shared forms — 7
+
+This remains a deliberately broad placeholder pending region-specific later catalogues. Every use requires a narrower inspiration and should prefer skins or future regional prototypes over treating the continent as one culture.
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_northamerican_hide_breechcloth` | long hide breechcloth | leather | `WP-BREECHCLOTH` | regional/contact gate; tanned hide source and panel cut in builder note |
+| `renaissance_northamerican_paired_hideleggings` | pair of long hide leggings | leather | `WP-LEG-WRAPS` | separate-looking paired item; regional cut, fringe, paint, bead skins |
+| `renaissance_northamerican_hide_shirt` | loose hide shirt | leather | `WP-SHIRT` | regional/date/contact gate; fringe and beadwork are skins unless structural |
+| `renaissance_northamerican_hide_wrapdress` | full hide wrap dress | leather | `WP-WRAP-DRESS` | regional/date/contact gate; belted or shouldered skins |
+| `renaissance_northamerican_fur_robe` | broad fur robe | fur | `WP-SHOULDER` | exact fur material; cold-weather, prestige, trade, household skins |
+| `renaissance_northamerican_feathered_mantle` | layered feather mantle | featherwork | `WP-SHOULDER` | **material dependency**; ritual/status/diplomatic gate, not generic stock |
+| `renaissance_northamerican_soft_moccasins` | pair of soft hide moccasins | leather | `WP-MOCCASIN` | regional seams, cuff, bead/paint skins; distinct from hard-soled shoes |
+
+## F. Shared first-contact, colonial Atlantic, and global maritime catalogue — 10
+
+These rows exist only where construction creates a distinct prototype. Most imported clothing should use an existing stable reference plus an imported/contact skin and manifest record.
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_maritime_canvas_watchcoat` | long hooded canvas watch coat | canvas | `WP-ROBE-OPEN` | shipboard watch, storm, dock, voyage gate; no waterproof mechanic claim |
+| `renaissance_maritime_treated_canvas_cape` | short treated-canvas deck cape | canvas | `WP-CLOAK` | shipboard/dock gate; tar/oil treatment descriptive until material or state exists |
+| `renaissance_maritime_knitted_waistcoat` | sleeveless knitted wool waistcoat | wool | `WP-VEST` | sailor, fisher, dockworker, cold-watch skins; not a later formal waistcoat |
+| `renaissance_maritime_loose_decktrousers` | loose ankle-length deck trousers | canvas | `WP-TROUSERS` | Atlantic/Indian Ocean/Asian shipboard admission by local crew context |
+| `renaissance_maritime_sleeveless_decksmock` | sleeveless canvas deck smock | canvas | `WP-SHIRT` | hot-weather shipboard, dock, boatyard, cargo-work skins |
+| `renaissance_contact_mission_catechistrobe` | plain long mission-associated robe | linen | `WP-ROBE-CLOSED` | imposed/adopted/locally made status must be recorded; mission institution required |
+| `renaissance_contact_hybrid_lacedtunic` | side-slit cotton tunic with front lacing | cotton | `WP-HYBRID-TUNIC` | genuine contact-zone hybrid only; local cut plus introduced lacing materially visible |
+| `renaissance_contact_hybrid_buttoned_wrapjacket` | wrap jacket with buttoned front | cotton | `WP-JACKET` | contact-zone craft/fastening gate; button functionality remains descriptive unless component supports it |
+| `renaissance_contact_tradecloth_panelskirt` | pieced trade-cloth panel skirt | cotton | `WP-SKIRT` | imported cloth/local construction recorded explicitly; panel piecing integral |
+| `renaissance_contact_broadbrim_sunhood` | broad-brimmed cloth sun hood | canvas | `WP-HOOD` | colonial/contact labour, maritime, mission, travel gate; never universal local continuity |
+
+## Shared admissions — 15 placements, no new prototypes
+
+| Existing stable reference | Admitted grouping/context | Reason no clone is needed |
+| --- | --- | --- |
+| `renaissance_shared_clothing_wrapped_loincloth` | African, South/Indian Ocean, Caribbean, Mesoamerican, North American work contexts | ordinary wrapped form; panelled breechcloths remain distinct |
+| `renaissance_shared_clothing_breast_wrap` | African, Caribbean, South/Indian Ocean and contact outfits | same folded support layer where locally admitted |
+| `renaissance_shared_clothing_side_slit_tunic` | Sahel, Indian Ocean, African court, contact-zone ordinary dress | same sewn tunic silhouette; local weave/motif are skins |
+| `renaissance_shared_clothing_straight_tunic` | Red Sea, African court, Caribbean/contact, North American trade-cloth use | plain continuity form where no rectangular-blouse or hide construction applies |
+| `renaissance_shared_clothing_full_trousers` | Sahel, Red Sea cavalry/contact, Indian Ocean port use | same gathered trouser form |
+| `renaissance_shared_clothing_wrap_skirt` | African, Caribbean, Mesoamerican, Andean ordinary forms | use only where overlap construction matches; tube/pinned/dress forms remain distinct |
+| `renaissance_shared_clothing_gathered_skirt` | African court, contact, mission and port outfits | same sewn gathered skirt where local panel/tube form is absent |
+| `renaissance_shared_clothing_rectangular_mantle` | Sahel, Red Sea, Mesoamerican, Andean, North American | ordinary rectangular drape; tied/pinned or feather/hide forms remain distinct |
+| `renaissance_shared_clothing_shoulder_shawl` | Red Sea, Indian Ocean, Andean, Sahelian and contact elite use | same rectangular shoulder layer; fibre and motif are skins/material variants |
+| `renaissance_shared_clothing_leather_sandals` | Sahel, Red Sea, African court, Caribbean/contact | ordinary strapped sandal; toe-loop, raised wood, and woven forms remain distinct |
+| `renaissance_shared_clothing_textile_sandals` | African, Mesoamerican, Andean, Caribbean fibre footwear | same woven sandal where fibre structure does not change silhouette |
+| `renaissance_shared_clothing_cloth_headwrap` | African court, Sahel, Red Sea, Indian Ocean, Caribbean/contact | unstructured winding; crown-shaped and scholar turbans remain distinct |
+| `renaissance_shared_clothing_straw_brimmed_hat` | African/Indian Ocean field, Caribbean, colonial/contact labour | same brimmed woven sun hat; conical palm forms remain distinct |
+| `renaissance_shared_clothing_soft_brimless_cap` | African court, Sahel, Indian Ocean port, contact crews | same soft cap; embroidery and weave are skins |
+| `renaissance_shared_clothing_rain_cape` | Andean highland, Indian Ocean, Caribbean/contact travel | textile rain cape where credible; barkcloth, straw, hide and treated-canvas forms remain distinct |
+
+## Contact and sensitivity metadata required on every row
+
+Every implementation manifest entry in this volume must record:
+
+| Field | Required content |
+| --- | --- |
+| narrower inspiration | named local society, polity, region, port, or contact zone; “African” or “Indigenous” alone is insufficient |
+| date window | supported years or century segment within 1400-1600 |
+| context | ordinary, labour, court, office, ritual, military-status, mission, maritime, diplomatic, mourning, initiation, performance, or trade |
+| production status | local continuity, locally made imported fibre, imported finished garment, tribute, diplomatic gift, imposed dress, mission issue, export production, or hybrid |
+| prevalence | ubiquitous/common/limited/rare/unique ceremonial stock as appropriate |
+| sensitivity note | sacred/status restriction, colonial coercion, protected motif, animal source, or uncertain broad-placeholder status |
+| skin boundary | which motif, colour, bead, feather, shell, hide pattern, or imported textile belongs in skins rather than prototypes |
+
+## Outfit minimums
+
+| Shared grouping | Ordinary outfit | Restricted/status outfit |
+| --- | --- | --- |
+| African court / Atlantic | wrapper or skirt, tunic/blouse as locally admitted, headcloth/cap, sandals or bare-foot admission | court robe/coat, structured headcloth, bead/feather/hide regalia, raised sandals |
+| Sahelian Islamic | tunic, full trousers or wrapper, robe, cap/turban, sandals | scholar/court robe, structured turban, riding coat, status footwear |
+| Red Sea / Indian Ocean | wrap/tunic/robe, headcloth/cap, sandals | court/church/mosque-associated outer layer, embroidered cape, merchant coat |
+| Mesoamerican | loin garment or skirt, blouse/tunic, tied cloak, sandals | featherwork, hide mantle, ceremonial tunic, office/ritual headwear |
+| Andean | tunic or wrapped dress/skirt, shoulder mantle, headcloth/cap, sandals | tapestry/feather tunic, ceremonial mantle/apron, status headwear |
+| Caribbean / North American contact | local continuity outfit first; imported pieces only by explicit contact date | diplomatic, ritual, trade, mission, imposed, or hybrid outfit with status recorded |
+| global maritime | crew-local ordinary outfit plus shipboard weather/work layer | officer, pilot, merchant, mission, or colonial-office skins only when historically admitted |
+
+## Volume acceptance
+
+- Exactly 100 unique stable references are defined here.
+- The 15 shared admissions create no new prototype.
+- Every row has a narrower inspiration and date/context gate before implementation.
+- Ritual, royal, office, sacred, military-status, and diplomatic regalia is not ordinary market stock.
+- Featherwork, beadwork, barkcloth, raffia, camelid wool, fur, hide, shell, and imported textile dependencies resolve exactly or fail closed.
+- Contact rows distinguish local continuity, import, coercion, mission issue, export, and hybrid construction.
+- North American contact remains an explicit placeholder and cannot be used without a narrower regional design pass.

--- a/Design Documents/Seeding/FutureMUD_Renaissance_Clothing_Catalogue_Asia_Steppe.md
+++ b/Design Documents/Seeding/FutureMUD_Renaissance_Clothing_Catalogue_Asia_Steppe.md
@@ -1,0 +1,250 @@
+# FutureMUD Renaissance Clothing Catalogue — Asian and Steppe Shared Cultures
+
+## Purpose
+
+This volume defines **110 unique clothing prototypes** for:
+
+- Shared Persianate / Indo-Persian;
+- Shared South Asian;
+- Shared East Asian literati, including Ming and Joseon admissions;
+- Shared Japanese and Shared maritime East Asian, including Ryukyuan admissions;
+- Shared South-east Asian mainland and Shared maritime South-east Asian;
+- Shared steppe and caravan.
+
+The shared rules, exact-material contract, tag plan, common forms, and profile ledger are in [FutureMUD Renaissance Clothing and Accessories Design Reference](./FutureMUD_Renaissance_Clothing_Accessories_Design_Reference.md). Public names remain form-based. Historical names in notes are builder anchors and skin vocabulary, not universal in-world terminology.
+
+## Volume-specific dependency notes
+
+This volume makes the high-priority material gaps concrete:
+
+- `ramie cloth` and `hemp cloth` are needed for faithful East Asian and Japanese common/work garments;
+- `barkcloth` is needed for several maritime South-east Asian contexts;
+- `brocade` and `silk gauze` are useful court materials but can initially be represented by `silk` skins if no craft behaviour depends on the distinction;
+- exact `straw`, `fur`, and horsehair-like materials must be audited before rows using them are implemented.
+
+Additional semantic wearable profiles used here are:
+
+- `WP-SIDEFAST-ROBE`: long side-fastened or strongly asymmetric robe;
+- `WP-DRAPED-FULL`: one unstitched garment wrapped around lower body and draped over torso/shoulder;
+- `WP-TUBE-SKIRT`: sewn tubular lower-body garment;
+- `WP-PLEATED-TROUSERS`: very full pleated divided or undivided lower garment;
+- `WP-SHOULDER-WINGS`: sleeveless formal shoulder piece layered above a robe;
+- `WP-SOCKS`: close foot garment worn under footwear;
+- `WP-STRUCTURED-HEADWRAP`: turban or headcloth shaped around an internal cap/form;
+- `WP-MONASTIC-DRAPE`: institution-gated draped robe occupying torso and shoulder layers.
+
+Use an exact live wearable component where coverage and layering match. Otherwise seed the profile idempotently before its rows.
+
+## A. Shared Persianate / Indo-Persian catalogue — 22
+
+### Underlayers, trousers, coats, and court robes — 17
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_persianate_long_inner_shirt` | long collarless inner shirt | linen | `WP-SHIRT` | thigh/knee length; narrow/full sleeve; plain, fine, cotton skins |
+| `renaissance_persianate_asymmetric_underrobe` | side-fastened inner robe | cotton | `WP-SIDEFAST-ROBE` | calf/ankle; narrow/full sleeve; court, merchant, military skins |
+| `renaissance_persianate_close_ankle_trousers` | close ankle-length trousers | cotton | `WP-TROUSERS` | plain, striped, silk, and riding skins; not identical to bunched South Asian legwear |
+| `renaissance_persianate_wide_pleated_trousers` | wide pleated trousers | wool | `WP-TROUSERS` | moderate/very full; steppe-border, court, military, travel skins |
+| `renaissance_persianate_short_fitted_coat` | short fitted front-opening coat | wool | `WP-JACKET` | hip/thigh, narrow/full sleeve; qaba-like builder anchor |
+| `renaissance_persianate_long_fitted_coat` | long fitted front-opening coat | broadcloth | `WP-ROBE-OPEN` | calf/ankle, split/unsplit skirt; merchant, scholar, court skins |
+| `renaissance_persianate_flared_skirt_coat` | fitted flared-skirt coat | broadcloth | `WP-ROBE-OPEN` | narrow torso and widening skirt; riding, court, official skins |
+| `renaissance_persianate_broad_skirt_courtrobe` | broad-skirted court robe | silk | `WP-ROBE-OPEN` | full skirt and long sleeves; figured, satin, velvet skins |
+| `renaissance_persianate_short_sleeve_overrobe` | short-sleeved long over-robe | silk | `WP-ROBE-OPEN` | inner sleeves visible; court, diplomatic, official admissions |
+| `renaissance_persianate_sleeveless_overrobe` | sleeveless long over-robe | silk | `WP-ROBE-OPEN` | inner robe visible; court, merchant, household skins |
+| `renaissance_indopersian_sidefastened_jama` | side-fastened flared long coat | cotton | `WP-SIDEFAST-ROBE` | moderate skirt, narrow sleeves; Timurid/Mughal/Deccan builder anchor |
+| `renaissance_indopersian_fullskirt_jama` | full-skirted side-fastened coat | silk | `WP-SIDEFAST-ROBE` | broad circular skirt; court, cavalry, ceremony and fine cotton skins |
+| `renaissance_indopersian_diagonal_tie_jama` | diagonally tied long coat | cotton | `WP-SIDEFAST-ROBE` | visible diagonal closure integral; plain, striped, court skins |
+| `renaissance_persianate_quilted_longcoat` | quilted long coat | cotton | `WP-ROBE-OPEN` | light/heavy quilting; travel, winter, military underlayer; no armour claim |
+| `renaissance_persianate_fur_edged_longcoat` | fur-edged long coat | broadcloth | `WP-ROBE-OPEN` | exact fur audit; northern Persianate, court, merchant, diplomatic skins |
+| `renaissance_persianate_sleeveless_longvest` | sleeveless long vest | wool | `WP-VEST` | hip/knee/calf skins only where profile permits; plain, furred, velvet variants |
+| `renaissance_persianate_broadsleeve_scholarrobe` | broad-sleeved scholar robe | silk | `WP-ROBE-OPEN` | scholar, judge, court, manuscript-house skins; institution/status gate |
+
+### Structured headwear and distinctive footwear — 5
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_persianate_conical_turban` | conical structured turban | cotton | `WP-STRUCTURED-HEADWRAP` | compact/full winding; scholar, military, court, merchant skins |
+| `renaissance_persianate_tall_turban` | tall structured turban | silk | `WP-STRUCTURED-HEADWRAP` | court/official/diplomatic gate; plume and jewels remain skin presentation |
+| `renaissance_persianate_domed_courtcap` | domed fitted court cap | velvet | `WP-HEAD-CAP` | plain, embroidered, fur-edged, jewelled-presentation skins |
+| `renaissance_persianate_pointed_slippers` | pair of pointed soft slippers | leather | `WP-FOOT-SHOE` | backless/closed back, plain, velvet-covered, embroidered skins |
+| `renaissance_persianate_soft_ridingboots` | pair of soft high riding boots | leather | `WP-FOOT-BOOT` | knee/calf, turned/plain cuff; cavalry, courier, court, caravan skins |
+
+## B. Shared South Asian catalogue — 22
+
+### Draped and stitched lower garments — 5
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_southasian_pleated_waistcloth` | long pleated waistcloth | cotton | `WP-WRAP-SKIRT` | knee/ankle, narrow/broad pleats, work/temple/court skins; dhoti-like builder anchor |
+| `renaissance_southasian_split_riding_waistcloth` | divided riding waistcloth | cotton | `WP-PLEATED-TROUSERS` | wrapped to form two leg divisions; cavalry, courier, court, rural skins |
+| `renaissance_southasian_stitched_loindrawers` | close stitched loin drawers | cotton | `WP-UNDER-WAIST` | short/knee, plain/fine; underlayer, labour, martial skins |
+| `renaissance_southasian_gathered_longskirt` | full gathered long skirt | cotton | `WP-SKIRT` | ankle length; work, urban, dance, silk court skins |
+| `renaissance_southasian_panelled_longskirt` | panelled flared long skirt | silk | `WP-SKIRT` | narrow/broad panels, plain/figured, court/merchant/ceremonial skins |
+
+### Tunics, bodices, robes, and coats — 13
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_southasian_short_sideslit_tunic` | short side-slit tunic | cotton | `WP-SHIRT` | hip/thigh, narrow/full sleeve; work, urban, scholar skins |
+| `renaissance_southasian_long_sideslit_tunic` | long side-slit tunic | cotton | `WP-ROBE-CLOSED` | knee/calf, narrow/full sleeve; court, temple, merchant, rural skins |
+| `renaissance_southasian_flaredskirt_tunic` | flared-skirt long tunic | cotton | `WP-ROBE-CLOSED` | fitted torso and widened skirt; dance, court, prosperous urban skins |
+| `renaissance_southasian_fitted_shortbodice` | fitted short bodice | cotton | `WP-FITTED-TORSO` | sleeveless/short sleeve only with exact profile; work, court, dance skins |
+| `renaissance_southasian_backtied_bodice` | back-tied short bodice | cotton | `WP-FITTED-TORSO` | narrow/broad back ties; plain, silk, embroidered skins |
+| `renaissance_southasian_longsleeve_bodice` | long-sleeved fitted bodice | silk | `WP-FITTED-TORSO` | court, dance, temple-patron, fine urban skins |
+| `renaissance_southasian_shoulderdraped_garment` | full shoulder-draped garment | cotton | `WP-DRAPED-FULL` | lower wrap and shoulder fall are one item; sari-like builder anchor; silk court skins |
+| `renaissance_southasian_short_wrapjacket` | short cross-tied jacket | cotton | `WP-JACKET` | waist/hip; work, household, martial, silk skins |
+| `renaissance_southasian_long_crossover_robe` | long cross-over robe | cotton | `WP-SIDEFAST-ROBE` | knee/ankle; angarkha-like builder anchor; plain, court, scholar skins |
+| `renaissance_southasian_sleeveless_courtovercoat` | sleeveless long court overcoat | silk | `WP-ROBE-OPEN` | calf/ankle; court, ministerial, diplomatic, merchant skins |
+| `renaissance_southasian_quilted_cotton_longcoat` | quilted cotton long coat | cotton | `WP-ROBE-OPEN` | light/heavy quilting; winter, travel, cavalry, guard skins |
+| `renaissance_southasian_bunched_ankletrousers` | narrow bunched ankle trousers | cotton | `WP-TROUSERS` | excess length gathered at ankle; court, cavalry, dance, silk skins |
+| `renaissance_southasian_headbanded_courtveil` | headbanded long court veil | silk | `WP-HEAD-VEIL` | headband is integral; shoulder/waist length; court, bridal, ceremonial gate |
+
+### Structured headwear and footwear — 4
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_southasian_fancrested_turban` | fan-crested structured turban | silk | `WP-STRUCTURED-HEADWRAP` | court, military command, procession, diplomatic skins; crest presentation is cosmetic |
+| `renaissance_southasian_flat_wound_turban` | broad flat-wound turban | cotton | `WP-STRUCTURED-HEADWRAP` | work, merchant, scholar, court, regional skins |
+| `renaissance_southasian_curvedtoe_shoes` | pair of curved-toe shoes | leather | `WP-FOOT-SHOE` | low/high vamp, plain, embroidered, velvet-covered skins |
+| `renaissance_southasian_toepost_woodensandals` | pair of toe-post wooden sandals | wood | `WP-FOOT-SANDAL` | plain/carved, low/raised sole; household, temple, scholar, elite skins |
+
+## C. Shared East Asian literati catalogue — Ming and Joseon — 26
+
+### Ming-inspired shared forms — 17
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_ming_crosscollar_innerrobe` | cross-collared inner robe | ramie cloth | `WP-SIDEFAST-ROBE` | **material dependency**; hemp/linen fallback only by explicit temporary decision |
+| `renaissance_ming_roundcollar_longrobe` | round-collared long robe | silk | `WP-ROBE-CLOSED` | scholar, official, merchant, court, cotton common skins |
+| `renaissance_ming_straightcollar_openrobe` | straight-collared open robe | silk | `WP-ROBE-OPEN` | narrow/broad sleeves; scholar, household, court, merchant skins |
+| `renaissance_ming_widesleeve_scholarrobe` | broad-sleeved scholar robe | silk | `WP-ROBE-CLOSED` | literati, teacher, ritual, court skins; institution/status admission |
+| `renaissance_ming_narrowsleeve_workerrobe` | narrow-sleeved work robe | cotton | `WP-ROBE-CLOSED` | artisan, merchant, rural, servant, guard skins |
+| `renaissance_ming_long_sleeveless_overvest` | long sleeveless over-vest | silk | `WP-VEST` | calf/ankle; court, household, official, merchant skins |
+| `renaissance_ming_short_sidefastened_jacket` | short side-fastened jacket | cotton | `WP-JACKET` | waist/hip; work, household, child-size skin, silk court skin |
+| `renaissance_ming_long_sidefastened_jacket` | long side-fastened jacket | cotton | `WP-JACKET` | thigh/knee; urban, rural, merchant, winter skins |
+| `renaissance_ming_pleated_panelskirt` | pleated panel skirt | silk | `WP-SKIRT` | narrow/broad pleats; court, prosperous urban, cotton work skins |
+| `renaissance_ming_horseface_panelskirt` | flat-fronted pleated panel skirt | silk | `WP-SKIRT` | broad front/back panels integral; court/urban/date gate |
+| `renaissance_ming_wide_drawstring_trousers` | wide drawstring trousers | cotton | `WP-TROUSERS` | ankle/calf; work, household, martial, ramie skins |
+| `renaissance_ming_narrow_ankletrousers` | narrow ankle-length trousers | cotton | `WP-TROUSERS` | riding, work, military, court-underlayer skins |
+| `renaissance_ming_cloudshoulder_capelet` | shaped shoulder capelet | silk | `WP-SHOULDER` | lobed/rounded outline; court, ceremony, theatrical skins; motif is skin |
+| `renaissance_ming_winged_officialhat` | winged formal official hat | silk | `WP-HEAD-HAT` | official institution/rank gate; wing length and surface skins |
+| `renaissance_ming_soft_scholarcap` | soft folded scholar cap | silk | `WP-HEAD-CAP` | scholar, teacher, merchant, household skins |
+| `renaissance_ming_gauze_officialhat` | structured gauze official hat | silk gauze | `WP-HEAD-HAT` | **material dependency**; official/date gate; plain silk fallback only temporarily |
+| `renaissance_ming_cloth_courtboots` | pair of high cloth court boots | cotton | `WP-FOOT-BOOT` | black/plain, official, scholar, court, felt-lined winter skins |
+
+### Joseon-inspired shared forms — 9
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_joseon_long_crossfront_underrobe` | long cross-front under-robe | ramie cloth | `WP-SIDEFAST-ROBE` | **material dependency**; hemp/linen temporary fallback; scholar/common/court skins |
+| `renaissance_joseon_short_crossfront_jacket` | short cross-front jacket | ramie cloth | `WP-JACKET` | waist/hip; work, household, cotton, silk court skins |
+| `renaissance_joseon_long_crossfront_jacket` | long cross-front jacket | silk | `WP-JACKET` | thigh/knee; early-Joseon date gate; court, scholar, prosperous urban skins |
+| `renaissance_joseon_full_gathered_wrapskirt` | full gathered wrap skirt | silk | `WP-WRAP-SKIRT` | broad overlap and high waist; cotton/ramie common skins |
+| `renaissance_joseon_broadsleeve_scholaroverrobe` | broad-sleeved scholar over-robe | silk | `WP-ROBE-OPEN` | scholar, official, teacher, ritual skins |
+| `renaissance_joseon_pleated_officialovercoat` | pleated long official coat | silk | `WP-ROBE-OPEN` | official/rank/institution gate; colour and insignia are skins |
+| `renaissance_joseon_tall_horsehairhat` | tall translucent brimmed hat | horsehair | `WP-HEAD-HAT` | **material audit**; scholar/official/date gate; no generic straw substitution |
+| `renaissance_joseon_rounded_officialcap` | rounded formal official cap | silk | `WP-HEAD-CAP` | court/official/ritual gate; winged variants require a new silhouette |
+| `renaissance_joseon_white_clothshoes` | pair of white cloth shoes | cotton | `WP-FOOT-SHOE` | plain, padded, court, mourning/status skins as admitted locally |
+
+## D. Shared Japanese and maritime East Asian catalogue — 20
+
+### Japanese shared forms — 16
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_japanese_smallsleeve_wraprobe` | small-sleeved wrap robe | silk | `WP-SIDEFAST-ROBE` | kosode-like anchor; hemp/cotton work, silk court, patterned skins |
+| `renaissance_japanese_unlined_summerrobe` | unlined summer wrap robe | hemp cloth | `WP-SIDEFAST-ROBE` | **material dependency**; ramie/linen temporary decision only; katabira-like anchor |
+| `renaissance_japanese_heavy_outerrobe` | heavy lined outer robe | silk | `WP-ROBE-OPEN` | court, warrior household, formal, theatrical skins; uchikake-like anchor |
+| `renaissance_japanese_broadsleeve_formalrobe` | broad-sleeved formal robe | silk | `WP-SIDEFAST-ROBE` | court, shrine/temple, warrior ceremony, performance gate |
+| `renaissance_japanese_shoulderwing_vest` | stiff shoulder-wing vest | broadcloth | `WP-SHOULDER-WINGS` | kataginu-like anchor; warrior, official, pageant, formal household admission |
+| `renaissance_japanese_short_openjacket` | short open-front jacket | silk | `WP-JACKET` | early haori-like anchor; merchant, warrior, travel, cotton work skins |
+| `renaissance_japanese_full_pleated_hakama` | full pleated lower garment | silk | `WP-PLEATED-TROUSERS` | undivided or visually skirt-like construction fixed by this prototype; court/ritual skins |
+| `renaissance_japanese_divided_riding_hakama` | divided pleated riding trousers | silk | `WP-PLEATED-TROUSERS` | warrior, courier, equestrian, formal skins; distinct divided construction |
+| `renaissance_japanese_field_trousers` | close field trousers | hemp cloth | `WP-TROUSERS` | **material dependency**; farmer, hunter, messenger, foot-soldier skins |
+| `renaissance_japanese_quilted_sleevelessvest` | quilted sleeveless vest | cotton | `WP-VEST` | winter, worker, warrior-underlayer, household skins |
+| `renaissance_japanese_straw_raincape` | layered straw rain cape | straw | `WP-CLOAK` | exact straw audit; farmer, traveller, courier, foot-soldier admissions |
+| `renaissance_japanese_woven_strawcoat` | long woven straw coat | straw | `WP-ROBE-OPEN` | exact straw audit; rain/snow travel presentation, no waterproof mechanic claim |
+| `renaissance_japanese_soft_folded_courtcap` | tall folded soft cap | silk | `WP-HEAD-CAP` | eboshi-like anchor; court, warrior, shrine, formal-status skins |
+| `renaissance_japanese_lacquered_conicalhat` | lacquered conical hat | wood | `WP-HEAD-HAT` | traveller, warrior, monk, courier, official skins; lacquer is presentation unless material exists |
+| `renaissance_japanese_splittoe_socks` | pair of split-toe socks | cotton | `WP-SOCKS` | ankle/calf, plain, padded, formal skins; compatible footwear profile required |
+| `renaissance_japanese_wooden_clogs` | pair of raised wooden clogs | wood | `WP-FOOT-SHOE` | low/high teeth, plain/lacquered, urban/rural/rain skins |
+
+### Ryukyuan and maritime East Asian shared forms — 4
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_ryukyu_widesleeve_summerrobe` | broad-sleeved tropical wrap robe | ramie cloth | `WP-SIDEFAST-ROBE` | **material dependency**; court, maritime merchant, household, ceremonial skins |
+| `renaissance_ryukyu_short_wrapjacket` | short tropical wrap jacket | cotton | `WP-JACKET` | household, work, maritime, court silk skins |
+| `renaissance_ryukyu_pleated_wrapskirt` | pleated tropical wrap skirt | cotton | `WP-WRAP-SKIRT` | ankle/calf, plain/patterned, work/court skins |
+| `renaissance_ryukyu_formal_courtcap` | structured island court cap | silk | `WP-HEAD-HAT` | tribute/diplomatic/court gate; colour and rank presentation are skins |
+
+## E. Shared South-east Asian mainland and maritime catalogue — 12
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_seasia_sewn_tubeskirt` | sewn tubular skirt | cotton | `WP-TUBE-SKIRT` | ankle/calf; plain, patterned, silk court, work skins |
+| `renaissance_seasia_pleated_courtwaistcloth` | pleated formal waistcloth | silk | `WP-WRAP-SKIRT` | broad front pleats; mainland court, temple patron, diplomatic skins |
+| `renaissance_seasia_split_riding_waistcloth` | divided riding waistcloth | cotton | `WP-PLEATED-TROUSERS` | riding, martial, court, travel skins; wrapped divided construction |
+| `renaissance_seasia_short_collarless_jacket` | short collarless jacket | cotton | `WP-JACKET` | waist/hip, narrow/full sleeve, work, merchant, court skins |
+| `renaissance_seasia_long_crossfront_courtrobe` | long cross-front court robe | silk | `WP-SIDEFAST-ROBE` | mainland court/official/ritual gate; patterned and brocade skins |
+| `renaissance_seasia_sleeveless_courtvest` | long sleeveless court vest | silk | `WP-VEST` | hip/knee; court, diplomatic, temple-service skins |
+| `renaissance_seasia_fitted_dancebodice` | fitted ceremonial dance bodice | silk | `WP-FITTED-TORSO` | performance/temple/court gate; bead and metallic decoration are skins |
+| `renaissance_seasia_full_ceremonialskirt` | full panelled ceremonial skirt | silk | `WP-SKIRT` | court, temple, performance, bridal skins; train only as description |
+| `renaissance_seasia_structured_headclothcrown` | crown-shaped structured headcloth | silk | `WP-STRUCTURED-HEADWRAP` | court/official/ritual gate; folding and colour are skins |
+| `renaissance_seasia_palmleaf_conicalhat` | broad palm-leaf conical hat | barkcloth | `WP-HEAD-HAT` | **material dependency or exact palm/straw audit**; field, river, market, maritime skins |
+| `renaissance_seasia_wrapped_monasticrobe` | draped monastic shoulder robe | cotton | `WP-MONASTIC-DRAPE` | named Buddhist institution and local date gate; colour/order skins |
+| `renaissance_seasia_short_maritime_trousers` | short full maritime trousers | cotton | `WP-TROUSERS` | sailor, fisher, dockworker, boatman, martial skins |
+
+## F. Shared steppe and caravan catalogue — 8
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_steppe_sidefastened_furcoat` | side-fastened fur-lined long coat | wool | `WP-SIDEFAST-ROBE` | exact fur audit; court, caravan, herder, winter, diplomatic skins |
+| `renaissance_steppe_short_split_ridingcoat` | short split-skirt riding coat | wool | `WP-JACKET` | cavalry, courier, herder, caravan guard skins |
+| `renaissance_steppe_sleeveless_ridingvest` | sleeveless riding vest | leather | `WP-VEST` | leather, felt, wool, fur-edged skins; travel and mounted work |
+| `renaissance_steppe_quilted_ridingrobe` | quilted side-fastened riding robe | cotton | `WP-SIDEFAST-ROBE` | light/heavy quilting; winter, military, caravan, court skins |
+| `renaissance_steppe_wide_ridingtrousers` | wide reinforced riding trousers | wool | `WP-TROUSERS` | leather-seat presentation skin, plain/felted, elite/work variants |
+| `renaissance_steppe_pointed_feltcap` | pointed felt riding cap | felt | `WP-HEAD-CAP` | plain, fur-edged, feathered-presentation skins |
+| `renaissance_steppe_fur_earflaphat` | furred ear-flap hat | fur | `WP-HEAD-HAT` | **exact material required**; tied-up/down is descriptive unless component supports state |
+| `renaissance_steppe_soft_highboots` | pair of soft high riding boots | leather | `WP-FOOT-BOOT` | knee/calf, turned/plain cuff, felt-lined winter skin |
+
+## Shared admissions — 14 placements, no new prototypes
+
+| Existing stable reference | Admitted grouping/context | Reason no clone is needed |
+| --- | --- | --- |
+| `renaissance_shared_clothing_straight_underrobe` | Persianate, South Asian, Ming/Joseon, South-east Asian underlayers | straight robe construction unchanged; local collar/trim skins |
+| `renaissance_shared_clothing_narrow_trousers` | Persianate, South Asian, Ming/Joseon, Japanese riding/work | same joined narrow-trouser behaviour |
+| `renaissance_shared_clothing_full_trousers` | Persianate, South Asian, South-east Asian maritime | same full gathered construction where no distinctive fastening exists |
+| `renaissance_shared_clothing_crossfront_jacket` | Ming/Joseon, Japanese/Ryukyuan, mainland South-east Asian work | same cross-front short-jacket silhouette; skins carry local cut |
+| `renaissance_shared_clothing_wrap_skirt` | South Asian work, East/South-east Asian, Ryukyuan | ordinary overlapping wrap where tube/panel construction is absent |
+| `renaissance_shared_clothing_quilted_jacket` | Persianate, Japanese, steppe, Ming/Joseon winter/military underlayers | same short quilted construction |
+| `renaissance_shared_clothing_shoulder_shawl` | Persianate, South Asian, steppe, East Asian court/contact | same rectangular shoulder layer; fibre/motif skins |
+| `renaissance_shared_clothing_textile_sandals` | Japanese, Ming/Joseon rural, South-east Asian, South Asian work | same woven sandal form where split-toe or toe-post construction is absent |
+| `renaissance_shared_clothing_soft_slippers` | Persianate, South Asian, Ming/Joseon court/household | rounded ordinary slipper; pointed/curved forms remain distinct rows |
+| `renaissance_shared_clothing_cloth_headwrap` | Persianate, South Asian, South-east Asian, steppe work | unstructured winding; structured turbans retain distinct prototypes |
+| `renaissance_shared_clothing_long_head_veil` | Persianate, South Asian, South-east Asian court/religious | ordinary head-draped veil; headbanded form remains distinct |
+| `renaissance_shared_clothing_close_cloth_cap` | under-turban, scholar, household, religious use | same close cap construction |
+| `renaissance_shared_clothing_footwraps` | steppe, Japanese field, Ming/Joseon work and military | same cloth wrapping under footwear |
+| `renaissance_shared_clothing_rain_cape` | Japanese, South-east Asian, Himalayan/steppe-border travel | use where textile cape is correct; straw coats remain distinct |
+
+## Outfit minimums by Shared grouping
+
+| Grouping | Ordinary outfit | High-status/institutional outfit |
+| --- | --- | --- |
+| Persianate / Indo-Persian | inner shirt, trousers, fitted coat or jama, headwrap/cap, slippers or boots | layered silk robe, structured turban/cap, court footwear, optional shawl |
+| South Asian | waistcloth or skirt, tunic/bodice or draped full garment, headcloth, sandals | silk panelled skirt or jama/robe, structured turban/veil, curved shoes, court overcoat |
+| Ming / Joseon literati | inner robe, trousers/skirt, jacket/robe, cloth shoes, cap | broad-sleeved or official robe, institution-gated hat, court boots/shoes |
+| Japanese / Ryukyuan | wrap robe, hakama/skirt as admitted, socks/sandals/clogs, cap/hat | formal robe, shoulder-wing vest or outer robe, pleated lower garment, formal cap |
+| South-east Asian | tube/wrap skirt or maritime trousers, short jacket/upper cloth, sandals/hat | silk court robe/skirt/vest, structured headcloth, ceremonial footwear |
+| steppe / caravan | shirt/robe, riding trousers, side-fastened coat/vest, cap, boots | fur-lined or quilted robe, formal cap, shawl, high riding boots |
+
+Outfits use local admission and date gates. They must not automatically attach modern ethnic identity, national uniformity, or universal gender rules to a silhouette.
+
+## Volume acceptance
+
+- Exactly 110 unique stable references are defined here.
+- The 14 shared admissions create no prototype.
+- Wrapped, side-fastened, cross-collared, and pleated forms are not forced into Western dress profiles.
+- Ming, Joseon, Japanese, Ryukyuan, Persianate, South Asian, South-east Asian, and steppe rows retain distinct silhouettes where a skin would misrepresent construction.
+- `ramie cloth`, `hemp cloth`, `barkcloth`, silk-gauze, straw, fur, and horsehair dependencies fail closed or use an explicitly documented temporary fallback.
+- Court, official, scholar, monastic, and ritual garments require institutional/status admission rather than ordinary market ubiquity.

--- a/Design Documents/Seeding/FutureMUD_Renaissance_Clothing_Catalogue_Western_Mediterranean.md
+++ b/Design Documents/Seeding/FutureMUD_Renaissance_Clothing_Catalogue_Western_Mediterranean.md
@@ -1,0 +1,254 @@
+# FutureMUD Renaissance Clothing Catalogue — Western, Mediterranean, and European Frontier Shared Cultures
+
+## Purpose
+
+This volume defines **130 unique clothing prototypes** for the following Renaissance Shared material-culture groupings:
+
+- Shared Western European Renaissance, including Italian, Franco-Flemish, British Isles, and German/HRE/Swiss admissions;
+- Shared Iberian / Atlantic;
+- Shared Northern / Baltic, Shared Central European, Shared Central/Eastern frontier, and Shared Eastern Orthodox / northern;
+- Shared Reformation / Catholic institutional clothing where construction differs;
+- Shared Ottoman-Islamicate.
+
+The authority, dependency ledger, common forms, and implementation rules are in [FutureMUD Renaissance Clothing and Accessories Design Reference](./FutureMUD_Renaissance_Clothing_Accessories_Design_Reference.md). Historical terms in the notes are builder anchors, not mandatory public item names.
+
+## Volume-specific wearable gaps
+
+In addition to the common-profile audit, this volume requires exact wearable/layering definitions for fitted doublets, bodices, one-piece gowns, joined hose, trunk hose/breeches, structured skirt supports, collars/ruffs, liturgical over-vestments, and turban-over-cap constructions. Proposed semantic profiles used below are:
+
+- `WP-FITTED-TORSO`: doublet, jerkin, or bodice layer;
+- `WP-DRESS`: one-piece or bodice-and-skirt garment covering torso and legs;
+- `WP-HOSE`: paired joined or split close legwear;
+- `WP-BREECHES`: joined upper-leg garment compatible with stockings;
+- `WP-SKIRT-SUPPORT`: farthingale or wheel support beneath a skirt;
+- `WP-COLLAR`: partlet, ruff, or independent neck/upper-chest layer;
+- `WP-VESTMENT`: ceremonial layer worn above a long religious garment;
+- `WP-TURBAN-CAP`: wrapped headwear whose cap and winding are one item.
+
+If an exact live component already supplies the coverage and layering, use it. Otherwise these are blocking new seeded wearable components, not new component types.
+
+## A. Shared Western European Renaissance and cross-confessional institutional catalogue — 75
+
+### Shirts, chemises, shifts, and work underlayers — 8
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_western_gathered_linen_shirt` | gathered linen shirt | linen | `WP-SHIRT` | low or moderate neck gathering; plain work, fine urban, and embroidered court skins |
+| `renaissance_western_pleated_linen_shirt` | finely pleated linen shirt | linen | `WP-SHIRT` | narrow or broad pleats; detachable wrist frills remain skins unless coverage changes |
+| `renaissance_western_high_collar_shirt` | high-collared linen shirt | linen | `WP-SHIRT` | standing or turned collar; late-fifteenth through sixteenth-century urban/court gate |
+| `renaissance_western_open_neck_work_shirt` | open-neck work shirt | linen | `WP-SHIRT` | fuller cut and reinforced neck; labourer, sailor, artisan, and rural skins |
+| `renaissance_western_square_neck_chemise` | square-necked chemise | linen | `WP-LONG-UNDERLAYER` | calf or ankle hem; narrow/full sleeves; Western court and urban outfits |
+| `renaissance_western_high_neck_chemise` | high-necked chemise | linen | `WP-LONG-UNDERLAYER` | gathered or banded neck; plain/fine skins; sixteenth-century gate |
+| `renaissance_western_work_smock` | loose work smock | linen | `WP-LONG-UNDERLAYER` | knee/calf length; reinforced or plain; field, workshop, laundry, and market work |
+| `renaissance_western_long_shift` | long linen shift | linen | `WP-LONG-UNDERLAYER` | ankle/calf; sleeveless or long-sleeved skins only where the wear profile remains identical |
+
+### Doublets, jerkins, and bodices — 18
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_western_sleeveless_doublet` | fitted sleeveless doublet | broadcloth | `WP-FITTED-TORSO` | plain work, merchant, quilted, and velvet court skins |
+| `renaissance_western_short_skirted_doublet` | short-skirted doublet | broadcloth | `WP-FITTED-TORSO` | narrow tabs or continuous skirt; early and mid-century skins |
+| `renaissance_western_long_skirted_doublet` | long-skirted doublet | broadcloth | `WP-FITTED-TORSO` | hip-length skirts; plain, guarded, and slashed skins |
+| `renaissance_western_peascod_doublet` | pointed-front doublet | broadcloth | `WP-FITTED-TORSO` | late-sixteenth-century date gate; wool, satin, and velvet skins |
+| `renaissance_western_padded_doublet` | padded fitted doublet | wool | `WP-FITTED-TORSO` | civilian warmth and shaped silhouette; no armour claim beyond clothing components |
+| `renaissance_western_slashed_doublet` | slashed-sleeve doublet | broadcloth | `WP-FITTED-TORSO` | restrained, mercenary-influenced, and court skins; slash colours remain cosmetic |
+| `renaissance_western_leather_jerkin` | fitted leather jerkin | leather | `WP-FITTED-TORSO` | sleeved/sleeveless only if component coverage matches; work, travel, guard skins |
+| `renaissance_western_cloth_jerkin` | fitted cloth jerkin | broadcloth | `WP-FITTED-TORSO` | plain, guarded, slashed, and livery skins |
+| `renaissance_western_sleeveless_jerkin` | sleeveless skirted jerkin | broadcloth | `WP-FITTED-TORSO` | short/long skirt skins; merchant, artisan, and court-servant admissions |
+| `renaissance_western_long_skirted_jerkin` | long-skirted jerkin | wool | `WP-FITTED-TORSO` | thigh-length, buttoned or laced; Central/Western urban use |
+| `renaissance_western_front_laced_bodice` | front-laced fitted bodice | broadcloth | `WP-FITTED-TORSO` | square/rounded neck; work, urban, and fine skins |
+| `renaissance_western_side_laced_bodice` | side-laced fitted bodice | broadcloth | `WP-FITTED-TORSO` | one- or two-sided lacing; fitted court and prosperous urban use |
+| `renaissance_western_back_laced_bodice` | back-laced fitted bodice | broadcloth | `WP-FITTED-TORSO` | requires assisted-dressing context only in builder notes, not mechanics |
+| `renaissance_western_square_neck_bodice` | square-necked bodice | broadcloth | `WP-FITTED-TORSO` | plain, guarded, brocade-skin, and velvet-skin families |
+| `renaissance_western_high_neck_bodice` | high-necked bodice | broadcloth | `WP-FITTED-TORSO` | sixteenth-century court/urban gate; detachable sleeves admitted separately |
+| `renaissance_western_stiffened_pair_of_bodies` | stiffened fitted bodies | canvas | `WP-FITTED-TORSO` | late-sixteenth-century gate; canvas, satin-covered, and court skins; no modern corset terminology publicly |
+| `renaissance_western_stomachered_bodice` | stomacher-fronted bodice | broadcloth | `WP-FITTED-TORSO` | separate-looking front panel is integral to this prototype; rich textile skins |
+| `renaissance_western_sleeveless_overbodice` | sleeveless over-bodice | velvet | `WP-FITTED-TORSO` | worn above chemise or undergown; plain wool and luxury silk skins |
+
+### Kirtles, gowns, hose, breeches, and skirt structures — 23
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_western_plain_kirtle` | plain fitted kirtle | wool | `WP-DRESS` | work, townswoman, and household skins; sewn bodice-and-skirt silhouette |
+| `renaissance_western_fitted_kirtle` | close-fitted kirtle | broadcloth | `WP-DRESS` | square/rounded neck and narrow/full skirt skins |
+| `renaissance_western_sleeveless_kirtle` | sleeveless fitted kirtle | broadcloth | `WP-DRESS` | intended to display chemise or detachable sleeves |
+| `renaissance_western_front_opening_kirtle` | front-opening kirtle | broadcloth | `WP-DRESS` | laced, hooked, or buttoned skins; no fastener mechanics claimed |
+| `renaissance_western_high_waisted_gown` | high-waisted fitted gown | broadcloth | `WP-DRESS` | early Renaissance court and prosperous urban gate |
+| `renaissance_western_square_neck_gown` | square-necked fitted gown | broadcloth | `WP-DRESS` | plain, velvet, satin, and guarded skins |
+| `renaissance_western_round_gown` | full round gown | broadcloth | `WP-DRESS` | continuous full skirt; urban/court and formal household use |
+| `renaissance_western_fitted_court_gown` | fitted court gown | velvet | `WP-DRESS` | silk/satin/brocade skins; heraldry and jewellery remain separate presentation |
+| `renaissance_western_front_opening_gown` | front-opening overgown | broadcloth | `WP-ROBE-OPEN` | reveals kirtle/petticoat; plain, furred, and guarded skins |
+| `renaissance_western_loose_house_gown` | loose house gown | wool | `WP-ROBE-OPEN` | domestic, scholar, invalid, and prosperous merchant skins |
+| `renaissance_western_robe_style_gown` | long robe-style gown | broadcloth | `WP-ROBE-OPEN` | furred or unlined; civic, merchant, scholar, and court contexts |
+| `renaissance_western_hanging_sleeve_overgown` | hanging-sleeve overgown | velvet | `WP-ROBE-OPEN` | open or closed hanging sleeve skins; court and ceremonial admission |
+| `renaissance_western_false_sleeve_overgown` | false-sleeve overgown | broadcloth | `WP-ROBE-OPEN` | decorative dependent sleeves are integral silhouette |
+| `renaissance_western_trained_gown` | long-trained formal gown | velvet | `WP-DRESS` | court, bridal, civic-pageant, and performance contexts; train is descriptive |
+| `renaissance_western_joined_hose` | pair of joined hose | wool | `WP-HOSE` | footed/soleless and plain/guarded skins; fitted lower-body profile |
+| `renaissance_western_split_hose` | pair of split hose | wool | `WP-HOSE` | two-colour mi-parti skin permitted; one paired item |
+| `renaissance_western_trunk_hose` | rounded trunk hose | broadcloth | `WP-BREECHES` | modest/full volume; paning requires separate prototype below |
+| `renaissance_western_paned_trunk_hose` | paned trunk hose | broadcloth | `WP-BREECHES` | contrasting lining and slash treatment remain skins |
+| `renaissance_western_venetian_breeches` | loose knee-length breeches | broadcloth | `WP-BREECHES` | full but unpaned; urban, court, and maritime-contact skins |
+| `renaissance_western_pluderhosen` | extremely full gathered breeches | broadcloth | `WP-BREECHES` | German/HRE/mercenary date and culture gate; lining colours are skins |
+| `renaissance_western_spanish_farthingale` | conical skirt support | canvas | `WP-SKIRT-SUPPORT` | late-fifteenth/sixteenth-century Iberian and court diffusion gate |
+| `renaissance_western_wheel_farthingale` | wheel-shaped skirt support | canvas | `WP-SKIRT-SUPPORT` | late-sixteenth-century elite gate; not ordinary workwear |
+| `renaissance_western_full_petticoat` | full sewn petticoat | wool | `WP-SKIRT` | plain, quilted, guarded, and silk skins; under- or visible-skirt admission |
+
+### Outerwear, headwear, collars, footwear, and gloves — 16
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_western_short_cloak` | short shoulder cloak | wool | `WP-CLOAK` | hip/thigh length; plain, guarded, and velvet skins |
+| `renaissance_western_full_circle_cloak` | full circular cloak | broadcloth | `WP-CLOAK` | calf/ankle length; hooded version uses common hooded-cloak prototype instead |
+| `renaissance_western_furred_gown` | fur-edged long gown | broadcloth | `WP-ROBE-OPEN` | scholar, magistrate, merchant, and court skins; audit exact fur material |
+| `renaissance_western_flat_cap` | broad flat cap | felt | `WP-HEAD-CAP` | narrow/broad crown; plain, feathered, badge, and velvet skins |
+| `renaissance_western_round_bonnet` | soft round bonnet | wool | `WP-HEAD-CAP` | brimmed/brimless skins only where component remains cap-like |
+| `renaissance_western_linen_coif` | tied linen coif | linen | `WP-HEAD-CAP` | plain, embroidered, work, domestic, and under-hood skins |
+| `renaissance_western_netted_caul` | close netted hair caul | silk | `WP-HEAD-CAP` | plain, pearl-pattern skin, metallic-thread skin; no jewellery component implied |
+| `renaissance_western_french_hood` | crescent-framed court hood | velvet | `WP-HEAD-HAT` | restrained and jewelled-presentation skins; sixteenth-century court gate |
+| `renaissance_western_gable_hood` | angular framed court hood | velvet | `WP-HEAD-HAT` | English/Tudor gate; plain and rich skins |
+| `renaissance_western_partlet` | shoulder-covering partlet | linen | `WP-COLLAR` | opaque, silk, lace, and high-neck skins; layers above bodice/gown |
+| `renaissance_western_standing_ruff` | stiff standing ruff | linen | `WP-COLLAR` | small, medium, and cartwheel skins only if coverage remains compatible; late-century gate |
+| `renaissance_western_square_toed_shoes` | pair of broad square-toed shoes | leather | `WP-FOOT-SHOE` | plain, slashed, velvet-covered, and court skins |
+| `renaissance_western_pattens` | pair of strapped pattens | wood | `WP-OVERSHOE` | low/high wood sole; wet-street and travel admission |
+| `renaissance_western_chopines` | pair of tall platform overshoes | wood | `WP-OVERSHOE` | Venetian/Mediterranean elite gate; moderate and tall variants may need separate sizes, not prototypes |
+| `renaissance_western_fitted_dress_gloves` | pair of fitted dress gloves | leather | `WP-HANDS` | plain, embroidered, slashed-cuff, scented-presentation skins |
+| `renaissance_western_dress_apron` | fine full dress apron | linen | `WP-WRAP-SKIRT` | narrow/full, plain/lace-edged, domestic and status-display skins; distinct from work apron by cut |
+
+### Shared Reformation / Catholic institutional clothing — 10
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_institution_plain_cassock` | long close-buttoned cassock | broadcloth | `WP-ROBE-CLOSED` | clerical, academic, civic-official skins; institution/date gate |
+| `renaissance_institution_preaching_gown` | full-sleeved preaching gown | broadcloth | `WP-ROBE-OPEN` | Reformation preacher, university, magistrate, and scholar skins |
+| `renaissance_institution_monastic_habit` | long belted monastic habit | wool | `WP-ROBE-CLOSED` | order colour and cut mostly skins; local institution required |
+| `renaissance_institution_monastic_scapular` | long monastic scapular | wool | `WP-VESTMENT` | narrow/broad and hooded-order skins; worn above habit |
+| `renaissance_institution_full_cowl` | hooded monastic cowl | wool | `WP-CLOAK` | shoulder cape and deep hood integral; monastic gate |
+| `renaissance_institution_linen_surplus` | loose white surplice | linen | `WP-VESTMENT` | knee/calf, narrow/full sleeve; church/chapel gate |
+| `renaissance_institution_liturgical_alb` | long white liturgical robe | linen | `WP-ROBE-CLOSED` | plain, apparelled, and lace-trim skins; church gate |
+| `renaissance_institution_chasuble` | sleeveless liturgical over-vestment | silk | `WP-VESTMENT` | broad/narrow cut; colour, embroidery, and seasonal use are skins/manifests |
+| `renaissance_institution_processional_cope` | long clasped ceremonial cope | silk | `WP-CLOAK` | hooded shield and embroidery are skins; procession/liturgy gate |
+| `renaissance_institution_academic_robe` | long academic robe | broadcloth | `WP-ROBE-OPEN` | faculty, university, legal, and civic skins; institution required |
+
+## B. Shared Iberian / Atlantic catalogue — 10
+
+These rows add Atlantic-facing work, pilgrimage, confraternity, and weather silhouettes not already covered by common or Western prototypes.
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_iberian_canvas_deck_smock` | short canvas deck smock | canvas | `WP-SHIRT` | sleeveless/long-sleeved only with matching coverage; sailor, dock, fishing skins |
+| `renaissance_iberian_short_sailor_jacket` | short close-fitting sailor jacket | wool | `WP-JACKET` | single/double row presentation, plain/guarded; no modern naval-uniform claim |
+| `renaissance_iberian_full_shipboard_breeches` | full calf-length shipboard breeches | canvas | `WP-TROUSERS` | drawstring or buttoned skins; Atlantic sailor and dockworker gate |
+| `renaissance_iberian_hooded_weather_cape` | short hooded weather cape | broadcloth | `WP-CLOAK` | hip/knee length; shipboard, pilgrim, courier, and coastal skins |
+| `renaissance_iberian_knitted_sailor_cap` | close knitted sailor cap | wool | `WP-HEAD-CAP` | rolled/unrolled edge, plain/striped; maritime gate |
+| `renaissance_iberian_broad_crowned_hat` | broad-crowned felt hat | felt | `WP-HEAD-HAT` | narrow/broad brim and cord/feather skins; Iberian urban, rural, maritime gate |
+| `renaissance_iberian_lace_edged_headveil` | lace-edged head veil | linen | `WP-HEAD-VEIL` | short/long, opaque/sheer skin; court, church, married-status admissions |
+| `renaissance_iberian_confraternity_robe` | hooded confraternity robe | linen | `WP-ROBE-CLOSED` | colour, badge, and penitential skin; named institution/procession required |
+| `renaissance_iberian_pilgrim_shoulder_cape` | short pilgrim shoulder cape | wool | `WP-SHOULDER` | hooded/unhooded skin; pilgrimage and shrine-route gate |
+| `renaissance_iberian_high_sea_boots` | pair of high sea boots | leather | `WP-FOOT-BOOT` | soft/stiff shaft and turned cuff skins; maritime/travel gate, no waterproof mechanic claim |
+
+## C. Shared Northern, Central, and Eastern European frontier catalogue — 15
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_frontier_fur_trimmed_short_coat` | fur-trimmed short coat | wool | `WP-JACKET` | hip/thigh length; merchant, noble, frontier, and winter skins |
+| `renaissance_frontier_long_furred_overcoat` | long furred overcoat | broadcloth | `WP-ROBE-OPEN` | calf/ankle; broad/narrow collar; northern and Muscovite trade networks |
+| `renaissance_frontier_close_buttoned_longcoat` | close-buttoned long coat | wool | `WP-ROBE-OPEN` | Polish-Lithuanian/Hungarian builder anchor; fitted and loose skins |
+| `renaissance_frontier_split_sleeve_noblecoat` | split-sleeved noble coat | broadcloth | `WP-ROBE-OPEN` | decorative sleeve openings integral; court/frontier elite gate |
+| `renaissance_frontier_belted_wool_caftan` | belted long wool coat | wool | `WP-ROBE-OPEN` | Eastern Orthodox, steppe-border, merchant, and town skins; sash admitted from baseline |
+| `renaissance_frontier_sleeveless_long_gown` | sleeveless long overgown | broadcloth | `WP-DRESS` | sarafan-like builder anchor; under-robe visible, court/town/rural skins |
+| `renaissance_frontier_muscovite_long_caftan` | long full-skirted caftan | broadcloth | `WP-ROBE-OPEN` | Muscovite court, merchant, service, and winter skins |
+| `renaissance_frontier_short_riding_coat` | short split-skirt riding coat | wool | `WP-JACKET` | cavalry, courier, noble, and frontier skins |
+| `renaissance_frontier_wide_hungarian_trousers` | wide riding trousers | wool | `WP-TROUSERS` | full upper leg, narrower calf; Hungarian/frontier riding gate |
+| `renaissance_frontier_high_felt_cap` | high-crowned felt cap | felt | `WP-HEAD-HAT` | plain, corded, feathered, and military-status skins |
+| `renaissance_frontier_fur_brimmed_cap` | soft fur-brimmed cap | wool | `WP-HEAD-CAP` | low/high crown; merchant, court, town, and winter skins |
+| `renaissance_frontier_tall_fur_hat` | tall cylindrical fur hat | fur | `WP-HEAD-HAT` | Muscovite, frontier elite, and diplomatic gate; exact fur material required |
+| `renaissance_frontier_knitted_northern_cap` | long knitted wool cap | wool | `WP-HEAD-CAP` | short/long crown, folded edge, sailor/rural/town skins |
+| `renaissance_frontier_felted_winter_boots` | pair of felted winter boots | felt | `WP-FOOT-BOOT` | soft felt shaft, leather-soled skin; northern/steppe winter admission |
+| `renaissance_frontier_split_skirt_riding_boots` | pair of stiff high riding boots | leather | `WP-FOOT-BOOT` | knee/thigh and turned-cuff skins; cavalry/frontier gate |
+
+## D. Shared Ottoman-Islamicate catalogue — 30
+
+Public names remain form-based. Builder notes may record Ottoman terms such as gömlek, şalvar, entari, kaftan, dolama, yelek, ferace, and kavuk only as inspirations.
+
+### Underlayers, trousers, and core robes — 16
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_ottoman_collarless_inner_shirt` | collarless long inner shirt | linen | `WP-SHIRT` | knee/thigh, narrow/full sleeve, plain/fine skins |
+| `renaissance_ottoman_ankle_gathered_drawers` | full ankle-gathered drawers | linen | `WP-TROUSERS` | moderate/very full; cotton and silk skins; underlayer or warm-weather use |
+| `renaissance_ottoman_narrow_riding_trousers` | narrow riding trousers | wool | `WP-TROUSERS` | footed/stirrup/plain skins; cavalry, courier, court admission |
+| `renaissance_ottoman_full_salwar_trousers` | very full gathered trousers | cotton | `WP-TROUSERS` | ankle/calf gathering; plain, striped, and silk skins |
+| `renaissance_ottoman_short_entari_coat` | short fitted front-opening coat | cotton | `WP-JACKET` | hip/thigh, narrow/full sleeve, work/court skins |
+| `renaissance_ottoman_long_entari_robe` | long fitted front-opening robe | silk | `WP-ROBE-OPEN` | calf/ankle, plain/striped/figured skins; urban and court admission |
+| `renaissance_ottoman_fitted_kaftan` | fitted long kaftan | silk | `WP-ROBE-OPEN` | narrow skirt and sleeves; court/official/merchant skins |
+| `renaissance_ottoman_loose_kaftan` | loose full long kaftan | silk | `WP-ROBE-OPEN` | broad skirt, side slits, plain/figured skins |
+| `renaissance_ottoman_short_sleeve_kaftan` | short-sleeved long kaftan | silk | `WP-ROBE-OPEN` | intended to reveal inner sleeves; court and ceremonial admission |
+| `renaissance_ottoman_sleeveless_kaftan` | sleeveless long kaftan | silk | `WP-ROBE-OPEN` | inner robe visible; court, official, and household skins |
+| `renaissance_ottoman_broad_sleeve_ceremonial_kaftan` | broad-sleeved ceremonial kaftan | brocade | `WP-ROBE-OPEN` | **material dependency**; court gift, office, diplomatic, and ceremony gate |
+| `renaissance_ottoman_fur_lined_winter_kaftan` | fur-lined winter kaftan | broadcloth | `WP-ROBE-OPEN` | exact fur audit; court, military command, merchant, winter skins |
+| `renaissance_ottoman_dolman_riding_coat` | close-fitted split-skirt riding coat | wool | `WP-JACKET` | cavalry and courier gate; braid/guard skins |
+| `renaissance_ottoman_short_cavalry_jacket` | short fitted cavalry jacket | wool | `WP-JACKET` | hip length and narrow sleeves; military/status skins without armour claim |
+| `renaissance_ottoman_sleeved_outer_robe` | long sleeved outer robe | broadcloth | `WP-ROBE-OPEN` | plain, official, scholar, and merchant skins |
+| `renaissance_ottoman_broad_sleeve_outerrobe` | broad-sleeved full outer robe | silk | `WP-ROBE-OPEN` | court, judge, scholar, and ceremonial skins |
+
+### Women's layered forms, vests, padded clothing, and religious outerwear — 8
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_ottoman_fitted_frontopening_gown` | fitted front-opening long gown | silk | `WP-DRESS` | narrow/full skirt, open/closed neckline, urban/court skins |
+| `renaissance_ottoman_loose_layered_gown` | loose layered long gown | cotton | `WP-DRESS` | indoor, household, merchant, and fine silk skins |
+| `renaissance_ottoman_full_outdoor_overrobe` | full enveloping outdoor over-robe | broadcloth | `WP-ROBE-OPEN` | urban/status/date gate; face covering remains separate item |
+| `renaissance_ottoman_broad_sleeveless_vest` | broad sleeveless long vest | wool | `WP-VEST` | hip/knee length; plain, furred, velvet skins |
+| `renaissance_ottoman_short_fitted_vest` | short fitted sleeveless vest | silk | `WP-VEST` | household, merchant, court, musician skins |
+| `renaissance_ottoman_quilted_undercoat` | quilted long undercoat | cotton | `WP-ROBE-CLOSED` | light/heavy quilting; civilian warmth and under-armour admission |
+| `renaissance_ottoman_dervish_wool_cloak` | broad rough wool cloak | wool | `WP-CLOAK` | Sufi institution and order gate; colour/patch skins require local manifest |
+| `renaissance_ottoman_tall_dervish_cap` | tall felt devotional cap | felt | `WP-HEAD-HAT` | Sufi institution/order gate; exact shape and colour as skins where silhouette remains stable |
+
+### Structured turbans and distinctive footwear — 6
+
+| Stable reference | Public form | Material | Wear profile | Variation and admission notes |
+| --- | --- | --- | --- | --- |
+| `renaissance_ottoman_wrapped_cap_turban` | compact cap-wound turban | cotton | `WP-TURBAN-CAP` | work, scholar, merchant, and official skins; cap and winding one prototype |
+| `renaissance_ottoman_small_court_turban` | small structured court turban | silk | `WP-TURBAN-CAP` | official, court-servant, scholar, and diplomatic skins |
+| `renaissance_ottoman_high_court_turban` | high structured court turban | silk | `WP-TURBAN-CAP` | office/rank/date-gated; exact winding and aigrette presentation are skins |
+| `renaissance_ottoman_quilted_turban` | padded quilted turban | cotton | `WP-TURBAN-CAP` | military/cavalry/court skins; no armour mechanics beyond clothing |
+| `renaissance_ottoman_pointed_slippers` | pair of pointed soft slippers | leather | `WP-FOOT-SHOE` | backless/heeled-back, plain/embroidered/velvet-covered skins |
+| `renaissance_ottoman_high_bath_sandals` | pair of high wooden bath sandals | wood | `WP-OVERSHOE` | bathhouse and elite household gate; strap decoration as skins |
+
+## Shared admissions — 12 placements, no new prototypes
+
+| Existing stable reference | Admitted grouping/context | Reason no clone is needed |
+| --- | --- | --- |
+| `renaissance_shared_clothing_drawstring_drawers` | Western, frontier, Iberian work outfits | same loose under-breech construction |
+| `renaissance_shared_clothing_long_undershirt` | frontier and Ottoman provincial outfits | local naming and trim do not change form |
+| `renaissance_shared_clothing_footed_stockings` | Western court, Central European town, Ottoman contact | same paired close legwear; skins carry clocks/colour |
+| `renaissance_shared_clothing_leg_wraps` | Northern/Baltic labour and frontier military | same wrapped lower-leg construction |
+| `renaissance_shared_clothing_hooded_cloak` | Iberian pilgrimage, Northern travel, Ottoman frontier | same cloak construction; use local skins |
+| `renaissance_shared_clothing_low_leather_shoes` | Western work, frontier town, Ottoman provincial | ordinary low sewn shoe |
+| `renaissance_shared_clothing_ankle_boots` | Iberian travel and Central European work | ordinary ankle boot construction |
+| `renaissance_shared_clothing_felt_brimmed_hat` | Western, Iberian, colonial-contact outfit admission | brim/crown cosmetics are skins unless structure changes |
+| `renaissance_shared_clothing_close_cloth_cap` | under-hood, domestic, scholar, and religious use | same close cap layer |
+| `renaissance_shared_clothing_leather_gloves` | riding, guard, maritime, and work outfits | same glove construction; cuff treatment is cosmetic |
+| `renaissance_shared_clothing_neck_kerchief` | artisan, sailor, servant, and rural outfits | same tied cloth form |
+| `renaissance_shared_clothing_detachable_sleeves` | Western bodice/kirtle and Ottoman court layering | same paired detachable sleeve behaviour; skins carry local cut/trim |
+
+## Skin minimums
+
+Every implemented prototype should receive, where historically credible:
+
+1. plain work or household skin;
+2. standard urban/rural skin;
+3. prosperous merchant or skilled-artisan skin;
+4. court, civic, religious, or military-status skin only when admitted;
+5. imported/contact skin only when the manifest records trade status.
+
+No prototype needs every tier. Fur, brocade, damask, lace, metallic-thread, and jewelled-presentation skins must fail closed when their exact material inputs or intended status market are unavailable.
+
+## Volume acceptance
+
+- Exactly 130 unique stable references are defined here.
+- The 12 shared admissions create no item prototype.
+- Ottoman, Eastern European, and Iberian forms are not reduced to cosmetic Western skins where silhouette differs.
+- Religious rows require a concrete institution and do not create a universal priest costume.
+- Late silhouettes such as peascod doublets, standing ruffs, wheel farthingales, and structured late court dress are date-gated within the Renaissance window.
+- Public names remain form-based; local historical terms remain builder anchors and skin notes.


### PR DESCRIPTION
## Summary

- Replace the Renaissance clothing scaffold with an implementation-oriented design authority and a 55-prototype common-form catalogue.
- Add three regional catalogue volumes covering every Shared Renaissance material-culture grouping.
- Define 395 unique prototype references and 41 deliberate cross-culture admissions, for 436 total catalogue placements without duplicate silhouettes.
- Add exact stable-reference, skin, outfit, craft, admission, and sensitivity rules.
- Call out blocking wearable/layering profiles, proposed culture and functional tags, and material gaps including hemp cloth, ramie cloth, barkcloth, camelid wool, raffia cloth, featherwork, and beadwork.

## Catalogue totals

| Volume | Unique prototypes | Reuse admissions |
| --- | ---: | ---: |
| Design authority / common forms | 55 | — |
| Western, Mediterranean, and European frontier | 130 | 12 |
| Asian and steppe | 110 | 14 |
| African, American, contact, and maritime | 100 | 15 |
| **Total** | **395** | **41** |

## Design boundaries

- Existing `preindustrial_clothing_*` belt and sash rows remain shared dependencies rather than Renaissance clones.
- Public names are form-based; local historical terminology, motifs, heraldry, status, and imported presentation are skins or builder notes.
- Culture/date/institution manifests control prevalence.
- Contact and colonial rows explicitly distinguish local continuity, imports, coercion, mission issue, export, and hybrid construction.
- No new engine item-component type is proposed; unresolved work is confined to wearable/layering definitions and seeded data dependencies.

## Validation

- Section counts sum to 395 unique proposed stable references.
- Regional reuse tables sum to 41 non-prototype admissions.
- All four documents cross-link to the design authority and use the live Renaissance era/material dependency contract.
- No runtime seeder code or existing shared item prototype is changed in this pass.