### PR TITLE
Refine NPC door-closing during shared path movement

### DIFF
--- a/Design Documents/AI/NPC_AI_and_Group_AI_Runtime.md
+++ b/Design Documents/AI/NPC_AI_and_Group_AI_Runtime.md
@@ -440,6 +440,8 @@ It centralizes common movement concerns such as:
 - movement delays
 - location filtering
 
+When `CloseDoorsBehind` is enabled, shared `FollowingPath` movement leaves an open door alone while another character is actively moving through the same exit. This considers traffic in either direction and other members of a coordinated movement. If the NPC had to unlock the door for that traversal, security takes precedence: it still closes the door and, when key use is enabled, locks it again behind itself.
+
 ### `PathingAIWithProgTargetsBase`
 Use this when pathing destinations should come from content configuration instead of hard-coded logic.
 

--- a/MudSharpCore Unit Tests/FollowingPathDoorTests.cs
+++ b/MudSharpCore Unit Tests/FollowingPathDoorTests.cs
@@ -1,0 +1,106 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Body;
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Construction.Boundary;
+using MudSharp.Effects.Concrete;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.Movement;
+
+#nullable enable
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class FollowingPathDoorTests
+{
+	[TestMethod]
+	public void HasOtherWalkers_OtherCharacterUsingSameExit_ReturnsTrue()
+	{
+		var fixture = CreateFixture(otherUsesSameExit: true);
+
+		Assert.IsTrue(FollowingPath.HasOtherWalkers(fixture.Actor.Object, fixture.CellExit.Object));
+	}
+
+	[TestMethod]
+	public void HasOtherWalkers_OtherCharacterUsingDifferentExit_ReturnsFalse()
+	{
+		var fixture = CreateFixture(otherUsesSameExit: false);
+
+		Assert.IsFalse(FollowingPath.HasOtherWalkers(fixture.Actor.Object, fixture.CellExit.Object));
+	}
+
+	[TestMethod]
+	public void HasOtherWalkers_NoOtherMovement_ReturnsFalse()
+	{
+		var fixture = CreateFixture(otherUsesSameExit: null);
+
+		Assert.IsFalse(FollowingPath.HasOtherWalkers(fixture.Actor.Object, fixture.CellExit.Object));
+	}
+
+	[TestMethod]
+	public void CloseDoorBehind_OtherWalkerUsingExit_DoesNotClose()
+	{
+		var fixture = CreateFixture(otherUsesSameExit: true, includeOpenDoor: true);
+
+		FollowingPath.CloseDoorBehind(fixture.Actor.Object, fixture.CellExit.Object, useKeys: false);
+
+		fixture.Body.Verify(x => x.Close(fixture.Door!.Object, default!, default!), Times.Never);
+	}
+
+	[TestMethod]
+	public void CloseDoorBehind_MustSecureWithOtherWalker_Closes()
+	{
+		var fixture = CreateFixture(otherUsesSameExit: true, includeOpenDoor: true);
+
+		FollowingPath.CloseDoorBehind(fixture.Actor.Object, fixture.CellExit.Object, useKeys: false,
+			mustSecure: true);
+
+		fixture.Body.Verify(x => x.Close(fixture.Door!.Object, default!, default!), Times.Once);
+	}
+
+	private static DoorMovementFixture CreateFixture(bool? otherUsesSameExit, bool includeOpenDoor = false)
+	{
+		var actor = new Mock<ICharacter>();
+		var other = new Mock<ICharacter>();
+		actor.Setup(x => x.SamePhysicalInstance(other.Object)).Returns(false);
+		var body = new Mock<IBody>();
+		actor.Setup(x => x.Body).Returns(body.Object);
+
+		var origin = new Mock<ICell>();
+		var destination = new Mock<ICell>();
+		origin.Setup(x => x.Characters).Returns(new[] { actor.Object, other.Object });
+		destination.Setup(x => x.Characters).Returns([]);
+
+		var exit = new Mock<IExit>();
+		Mock<IDoor>? door = null;
+		if (includeOpenDoor)
+		{
+			door = new Mock<IDoor>();
+			door.Setup(x => x.IsOpen).Returns(true);
+			exit.Setup(x => x.Door).Returns(door.Object);
+		}
+
+		var cellExit = new Mock<ICellExit>();
+		cellExit.Setup(x => x.Exit).Returns(exit.Object);
+		cellExit.Setup(x => x.Origin).Returns(origin.Object);
+		cellExit.Setup(x => x.Destination).Returns(destination.Object);
+
+		if (otherUsesSameExit.HasValue)
+		{
+			var movementExit = otherUsesSameExit.Value ? exit : new Mock<IExit>();
+			var movementCellExit = new Mock<ICellExit>();
+			movementCellExit.Setup(x => x.Exit).Returns(movementExit.Object);
+			var movement = new Mock<IMovement>();
+			movement.Setup(x => x.Exit).Returns(movementCellExit.Object);
+			movement.Setup(x => x.Cancelled).Returns(false);
+			other.Setup(x => x.Movement).Returns(movement.Object);
+		}
+
+		return new DoorMovementFixture(actor, body, cellExit, door);
+	}
+
+	private sealed record DoorMovementFixture(Mock<ICharacter> Actor, Mock<IBody> Body,
+		Mock<ICellExit> CellExit, Mock<IDoor>? Door);
+}

--- a/MudSharpCore Unit Tests/LegalPatrolStrategyTests.cs
+++ b/MudSharpCore Unit Tests/LegalPatrolStrategyTests.cs
@@ -389,7 +389,8 @@ public class LegalPatrolStrategyTests
 		StringAssert.Contains(pathSource, "CloseDoorsBehind = closeDoorsBehind");
 		StringAssert.Contains(pathSource, "exit.Destination == ch.Location");
 		StringAssert.Contains(pathSource, "MovementStrategyResult.Waiting");
-		StringAssert.Contains(pathSource, "CloseDoorBehind(ch, exit, UseKeys)");
+		StringAssert.Contains(pathSource, "CloseDoorBehind(ch, exit, UseKeys, mustSecure)");
+		StringAssert.Contains(pathSource, "HasOtherWalkers(ch, exit)");
 		StringAssert.Contains(pathSource, "ShallowAccessibleItems(ch)");
 		StringAssert.Contains(movementSource, "DoorGuardIsOpeningDoor(exit)");
 		StringAssert.Contains(movementSource, "WouldOpenResponseType.WillOpenIfKnock");
@@ -398,6 +399,7 @@ public class LegalPatrolStrategyTests
 		StringAssert.Contains(enforcerSource, "FollowingPath.CreateFullFriendlyPath(enforcer, path, closeDoorsBehind: true)");
 		StringAssert.Contains(patrolBaseSource, "FollowingPath.CreateFullFriendlyPath(member, path, closeDoorsBehind: true)");
 		StringAssert.Contains(unlockSource, "ShallowAccessibleItems(Character)");
+		StringAssert.Contains(unlockSource, "RecordUnlockedExit(Exit)");
 		Assert.IsFalse(unlockSource.Contains("Character.Move(Exit)", StringComparison.Ordinal));
 		StringAssert.Contains(lockSource, "new Queue<Tuple<IKey, IInventoryPlan>>(plans)");
 	}

--- a/MudSharpCore/Effects/Concrete/FollowingPath.cs
+++ b/MudSharpCore/Effects/Concrete/FollowingPath.cs
@@ -20,6 +20,8 @@ namespace MudSharp.Effects.Concrete;
 
 public class FollowingPath : Effect, IEffectSubtype, IRemoveOnCombatStart
 {
+    private readonly HashSet<IExit> _unlockedExits = new();
+
     public Queue<ICellExit> Exits { get; set; }
 
     public FollowingPath(ICharacter owner, IEnumerable<ICellExit> exits) : base(owner, null)
@@ -94,7 +96,7 @@ public class FollowingPath : Effect, IEffectSubtype, IRemoveOnCombatStart
 		        Exits.Dequeue();
 		        if (CloseDoorsBehind)
 		        {
-			        CloseDoorBehind(ch, exit, UseKeys);
+			        CloseDoorBehind(ch, exit, UseKeys, ConsumeUnlockedExit(exit));
 		        }
 
 		        if (Exits.Count == 0 && RemoveWhenExitsEmpty)
@@ -161,9 +163,10 @@ public class FollowingPath : Effect, IEffectSubtype, IRemoveOnCombatStart
 			return;
 		}
 
+		var mustSecure = ConsumeUnlockedExit(exit);
 		if (ch.Location == exit.Destination)
 		{
-			CloseDoorBehind(ch, exit, UseKeys);
+			CloseDoorBehind(ch, exit, UseKeys, mustSecure);
 			return;
 		}
 
@@ -175,19 +178,61 @@ public class FollowingPath : Effect, IEffectSubtype, IRemoveOnCombatStart
 		{
 			if (ch.Location == exit.Destination)
 			{
-				CloseDoorBehind(ch, exit, UseKeys);
+				CloseDoorBehind(ch, exit, UseKeys, mustSecure);
 			}
 		}, "closing a door behind them"), delay);
 	}
 
-	public static void CloseDoorBehind(ICharacter ch, ICellExit exit, bool useKeys)
+	public void RecordUnlockedExit(ICellExit exit)
 	{
-		if (exit?.Exit.Door?.IsOpen != true)
+		if (exit?.Exit is not null)
+		{
+			_unlockedExits.Add(exit.Exit);
+		}
+	}
+
+	private bool ConsumeUnlockedExit(ICellExit exit)
+	{
+		return exit?.Exit is not null && _unlockedExits.Remove(exit.Exit);
+	}
+
+	internal static bool HasOtherWalkers(ICharacter ch, ICellExit exit)
+	{
+		if (ch is null || exit?.Exit is null)
+		{
+			return false;
+		}
+
+		return exit.Origin.Characters
+		           .Concat(exit.Destination.Characters)
+		           .Where(x => !ch.SamePhysicalInstance(x))
+		           .Select(x => x.Movement)
+		           .Where(x => x is not null && !x.Cancelled)
+		           .Any(x => ReferenceEquals(x.Exit.Exit, exit.Exit));
+	}
+
+	public static void CloseDoorBehind(ICharacter ch, ICellExit exit, bool useKeys, bool mustSecure = false)
+	{
+		var door = exit?.Exit.Door;
+		if (door is null)
 		{
 			return;
 		}
 
-		ch.Body.Close(exit.Exit.Door, null, null);
+		if (door.IsOpen)
+		{
+			if (!mustSecure && HasOtherWalkers(ch, exit))
+			{
+				return;
+			}
+
+			ch.Body.Close(door, null, null);
+		}
+		else if (!mustSecure)
+		{
+			return;
+		}
+
 		if (!useKeys)
 		{
 			return;
@@ -198,7 +243,7 @@ public class FollowingPath : Effect, IEffectSubtype, IRemoveOnCombatStart
 		             .SelectNotNull(x => x.GetItemType<IKey>())
 		             .ToList();
 		var usableKeys = keys
-		                 .Where(x => exit.Exit.Door.Locks.Any(y => !y.IsLocked && y.CanLock(ch, x)))
+		                 .Where(x => door.Locks.Any(y => !y.IsLocked && y.CanLock(ch, x)))
 		                 .Select(x => Tuple.Create(x, GetHoldPlanForItem(ch, x.Parent)))
 		                 .Where(x => x.Item2.PlanIsFeasible() == InventoryPlanFeasibility.Feasible)
 		                 .ToList();
@@ -207,7 +252,7 @@ public class FollowingPath : Effect, IEffectSubtype, IRemoveOnCombatStart
 			return;
 		}
 
-		LockDoor effect = new(ch, exit.Exit.Door, usableKeys);
+		LockDoor effect = new(ch, door, usableKeys);
 		ch.AddEffect(effect);
 		ch.RemoveEffect(effect, true);
 	}

--- a/MudSharpCore/Effects/Concrete/UnlockDoor.cs
+++ b/MudSharpCore/Effects/Concrete/UnlockDoor.cs
@@ -50,15 +50,23 @@ public class UnlockDoor : Effect, IEffectSubtype
             if (plan.PlanIsFeasible() == InventoryPlanFeasibility.Feasible)
             {
                 plan.ExecuteWholePlan();
+                var unlockedDoor = false;
                 foreach (ILock theLock in Door.Locks)
                 {
                     if (theLock.CanUnlock(Character, key))
                     {
                         theLock.Unlock(Character, key, Door.Parent, null);
+                        unlockedDoor = true;
                     }
                 }
 
                 plan.FinalisePlan();
+                if (unlockedDoor)
+                {
+                    Character.EffectsOfType<FollowingPath>()
+                             .FirstOrDefault(x => x.Exits.Any(y => ReferenceEquals(y.Exit, Exit.Exit)))
+                             ?.RecordUnlockedExit(Exit);
+                }
             }
 
             if (Door.CanOpen(Character.Body))

--- a/MudSharpCore/NPC/AI/PathingAIBase.cs
+++ b/MudSharpCore/NPC/AI/PathingAIBase.cs
@@ -289,6 +289,13 @@ public abstract class PathingAIBase : ArtificialIntelligenceBase
             return;
         }
 
+		// FollowingPath closes after the whole movement has resolved. Closing here would happen while
+		// other members of the same movement may still be crossing the threshold.
+		if (ch.EffectsOfType<FollowingPath>().Any(x => x.CloseDoorsBehind))
+		{
+			return;
+		}
+
         if (CloseDoorsBehind)
         {
             FollowingPath.CloseDoorBehind(ch, exit, UseKeys);


### PR DESCRIPTION
## Summary
- Delay door closing for `FollowingPath` until shared movement has cleared the exit, so NPCs do not shut a door on other walkers still using the same passage.
- Preserve security behavior when the NPC had to unlock the door by recording that exit and forcing close-and-relock afterward.
- Update pathing AI to avoid duplicate early closes when `FollowingPath` is already responsible.
- Add unit coverage for other-walker detection, forced security closure, and the unlock-to-lock flow.
- Sync the NPC/group AI runtime design note with the new behavior.

## Testing
- Added targeted unit tests in `MudSharpCore Unit Tests` for the new door-closing rules.
- Updated existing strategy assertions to cover the revised follow-path and unlock-door behavior.
- Not run (not requested).