### PR TITLE
Fix FutureMUD web systemd runtime compatibility

### DIFF
--- a/FutureMUD.Web/Deployment/futuremud-web.service
+++ b/FutureMUD.Web/Deployment/futuremud-web.service
@@ -4,7 +4,7 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-Type=notify
+Type=simple
 User=futuremud-web
 Group=futuremud-web
 WorkingDirectory=/opt/futuremud-web/current
@@ -26,7 +26,6 @@ RestrictSUIDSGID=true
 RestrictNamespaces=true
 RestrictRealtime=true
 LockPersonality=true
-MemoryDenyWriteExecute=true
 ReadWritePaths=/var/lib/futuremud-web
 CapabilityBoundingSet=
 SystemCallArchitectures=native


### PR DESCRIPTION
## Summary
- use `Type=simple` because the ASP.NET application does not emit `sd_notify` readiness notifications
- remove `MemoryDenyWriteExecute` because the .NET JIT requires executable memory mappings

## Validation
- deployed the equivalent unit on the provisioned Amazon Linux 2023 host
- `futuremud-web.service` reaches `active (running)`
- `GET http://127.0.0.1:5070/health/ready` returns `{"status":"ready"}`
- diff is limited to `FutureMUD.Web/Deployment/futuremud-web.service`