### PR TITLE
Retry FutureMUD web health checks during startup

### DIFF
--- a/FutureMUD.Web/Deployment/deploy-futuremud-web
+++ b/FutureMUD.Web/Deployment/deploy-futuremud-web
@@ -15,7 +15,7 @@ ln -sfn "$release" "${current}.new"
 mv -Tf "${current}.new" "$current"
 systemctl restart futuremud-web.service
 
-if ! curl --fail --silent --show-error --retry 12 --retry-delay 2 http://127.0.0.1:5070/health/ready >/dev/null; then
+if ! curl --fail --silent --show-error --retry 12 --retry-delay 2 --retry-connrefused http://127.0.0.1:5070/health/ready >/dev/null; then
 	if test -n "$previous" && test -d "$previous"; then
 		ln -sfn "$previous" "${current}.rollback"
 		mv -Tf "${current}.rollback" "$current"


### PR DESCRIPTION
## Summary
- retry connection-refused responses while Kestrel starts after a systemd restart
- retain the existing bounded 12-attempt, two-second-delay health check and rollback behavior

## Validation
- the preceding master deployment passed all 13 website tests and packaging, then reproduced the startup race at the activation health check
- applied the same option to the installed restricted deploy script
- production remains healthy on the rolled-back release