### PR TITLE
Fix single-runtime release publishing

### DIFF
--- a/.github/workflows/backfill-products.yml
+++ b/.github/workflows/backfill-products.yml
@@ -12,6 +12,8 @@ on:
           - engine-v1.55.0
           - seeder-v2.3.0
           - discordbot-v1.5.0
+          - terrainplanner-v1.1.0
+          - terrainapi-v1.0.1
 
 permissions:
   contents: read
@@ -46,6 +48,8 @@ jobs:
             'engine-v1.55.0' = 'a68f25871ce238e8e9331c0e33d7b585d174c0e4'
             'seeder-v2.3.0' = '256c79e8ca2d613d04e0dce9060dd8851ef3369a'
             'discordbot-v1.5.0' = '0450383162182554683f824810772e3741306157'
+            'terrainplanner-v1.1.0' = '92f9ceab12d4eebc135f30b7cdfe577ccb78835b'
+            'terrainapi-v1.0.1' = '1ad01d6dfd1dda1eea183a3416134588f1ed9932'
           }
           $tag = '${{ inputs.releaseTag }}'
           $sourceRevision = $releaseCommits[$tag]
@@ -63,7 +67,7 @@ jobs:
               runtime = $_
               os = if ($_.StartsWith('win-')) { 'windows-latest' } else { 'ubuntu-latest' }
             }
-          }) | ConvertTo-Json -Compress
+          }) | ConvertTo-Json -Compress -AsArray
 
           "product=$($definition.id)" >> $env:GITHUB_OUTPUT
           "version=$version" >> $env:GITHUB_OUTPUT

--- a/.github/workflows/publish-products.yml
+++ b/.github/workflows/publish-products.yml
@@ -37,7 +37,7 @@ jobs:
           $version = $tag.Substring($definition.tagPrefix.Length)
           $projectVersion = (dotnet msbuild $definition.projectPath -getProperty:Version -nologo).Trim()
           if ($version -notmatch '^\d+\.\d+\.\d+$' -or $version -ne $projectVersion) { throw "Tag version $version must exactly match project Version $projectVersion." }
-          $matrix = @($definition.runtimes | ForEach-Object { @{ runtime = $_; os = if ($_.StartsWith('win-')) { 'windows-latest' } else { 'ubuntu-latest' } } }) | ConvertTo-Json -Compress
+          $matrix = @($definition.runtimes | ForEach-Object { @{ runtime = $_; os = if ($_.StartsWith('win-')) { 'windows-latest' } else { 'ubuntu-latest' } } }) | ConvertTo-Json -Compress -AsArray
           "product=$($definition.id)" >> $env:GITHUB_OUTPUT
           "version=$version" >> $env:GITHUB_OUTPUT
           "project=$($definition.projectPath)" >> $env:GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- always serialize release runtime matrices as JSON arrays
- allow exact-commit backfills for Terrain Planner 1.1.0 and Terrain API 1.0.1

This fixes the Planner workflow failure without moving its published tag and gives both newly versioned products a safe current-workflow backfill path.