### PR TITLE
Version update to 1.6.0

### DIFF
--- a/DiscordBotCore/DiscordBotCore.csproj
+++ b/DiscordBotCore/DiscordBotCore.csproj
@@ -4,9 +4,9 @@
 	<OutputType>Exe</OutputType>
 	<TargetFramework>net10.0</TargetFramework>
 	<RootNamespace>Discord_Bot</RootNamespace>
-	<AssemblyVersion>1.5.0</AssemblyVersion>
-	<FileVersion>1.5.0</FileVersion>
-	<Version>1.5.0</Version>
+	<AssemblyVersion>1.6.0</AssemblyVersion>
+	<FileVersion>1.6.0</FileVersion>
+	<Version>1.6.0</Version>
   </PropertyGroup>
 
 	<PropertyGroup>

--- a/FutureMUD.Web/Content/PatchNotes/2026-07-16-discord-bot-1-6-0.md
+++ b/FutureMUD.Web/Content/PatchNotes/2026-07-16-discord-bot-1-6-0.md
@@ -1,0 +1,21 @@
+---
+title: Discord Bot 1.6.0
+summary: Adds new staff inspection commands and improves the reliability and security of the bot's connection to the FutureMUD Engine.
+date: 2026-07-16
+tags: discord-bot, release, security
+---
+**Upgrade note:** Discord Bot 1.6.0 requires the .NET 10 runtime. Install it before replacing an older bot build.
+
+## New Staff Commands
+
+- Added `map <cell>` so authorised staff can view the map around a specific cell from Discord.
+- Added `showaccount <name|id>` and `showcharacter <id>` so authorised staff can inspect account and character details from Discord. The linked MUD account must also have the required in-game authority.
+
+## Reliability And Security
+
+- Fixed the connection protocol between the bot and the Engine so commands and responses continue to work when network messages arrive in partial or combined frames.
+- Fixed multiline command text, connection-state checks, stale request responses, and shutdown announcements, including the distinction between a reboot and a full stop.
+- Added a size limit for incomplete Engine messages so a malformed or hostile connection cannot make the bot buffer data indefinitely.
+- Updated the Discord and logging dependencies alongside the move to .NET 10.
+
+The release supports Windows x64 and Linux x64. Download the appropriate build from the [FutureMUD downloads page](/downloads) after publication completes.


### PR DESCRIPTION
## Summary
- update Discord Bot version metadata to 1.6.0
- add public website patch notes covering changes since v1.5.0
- document the .NET 10 upgrade requirement and supported runtimes

## Verification
- `dotnet test "DiscordBotCore Unit Tests/DiscordBotCore Unit Tests.csproj" -c Release -m:1 -p:RestoreBuildInParallel=false -p:NuGetAudit=false` (5 passed, 1 skipped placeholder)
- `dotnet test "FutureMUD.Web.Tests/FutureMUD.Web.Tests.csproj" -c Release -m:1 -p:RestoreBuildInParallel=false -p:NuGetAudit=false` (14 passed)
- representative `win-x64` framework-dependent, single-file, native-bundled, untrimmed publish succeeded