### PR TITLE
Version update to 2.0.0

### DIFF
--- a/FutureMUD.Web/Content/PatchNotes/2026-07-16-engine-2-0-0.md
+++ b/FutureMUD.Web/Content/PatchNotes/2026-07-16-engine-2-0-0.md
@@ -8,7 +8,7 @@ tags: engine, release, upgrade, security
 
 Release packages are framework-dependent, single-file archives for Windows x64, Linux x64, and Linux ARM64. Linux hosts may need to restore the executable bit after extraction with `chmod +x MudSharp`.
 
-This is a very large release covering the 1,221 commits since Engine 1.55.0. The list below groups small related fixes so it remains useful to players, builders, administrators, and operators.
+This is a very large release covering more than 1,200 commits since Engine 1.55.0. The list below groups small related fixes so it remains useful to players, builders, administrators, and operators.
 
 ## Characters, Bodies, and Survival
 

--- a/FutureMUD.Web/Content/PatchNotes/2026-07-16-engine-2-0-0.md
+++ b/FutureMUD.Web/Content/PatchNotes/2026-07-16-engine-2-0-0.md
@@ -1,0 +1,197 @@
+---
+title: FutureMUD Engine 2.0.0
+summary: A major Engine release adding vehicles, agriculture, unified employment, hospitals, expanded magic and combat, multi-body characters, automation, and broad security and reliability improvements.
+date: 2026-07-16
+tags: engine, release, upgrade, security
+---
+**Upgrade note:** Back up your database, configuration, and world files before upgrading, and test the upgrade against a copy of your live database first. Engine 2.0.0 requires the .NET 10 runtime and MySQL 8.0. The Engine applies supported schema migrations during startup; do not point an older Engine build at a database after it has been upgraded to 2.0.0.
+
+Release packages are framework-dependent, single-file archives for Windows x64, Linux x64, and Linux ARM64. Linux hosts may need to restore the executable bit after extraction with `chmod +x MudSharp`.
+
+This is a very large release covering the 1,221 commits since Engine 1.55.0. The list below groups small related fixes so it remains useful to players, builders, administrators, and operators.
+
+## Characters, Bodies, and Survival
+
+- Added support for multiple simultaneous bodies belonging to one character identity, including focus switching, secondary-body lifecycle handling, reconnect and reboot persistence, admin creation controls, and clearer diagnostics.
+- Added body-form provisioning, body backups, projection, cloning, and possession workflows, with tighter authority checks around spawning, seizing, and controlling character instances.
+- Expanded racial hunger, thirst, satiation, and body-size scaling, including configurable racial limits and improved food-yield handling.
+- Improved character creation knowledge selection, race and role setup, skill aliases, and recovery from incomplete or drifted starting data.
+- Improved health strategies, wounds, infections, surgery interactions, offline healing, and the way injuries behave when a character changes bodies.
+- Added configurable temperature consequences and expanded climate-aware item and body behaviour.
+- Expanded drugs and dependence with more effect types, delivery vectors, stacking, withdrawal, offline progression, and safer cloning of drugs with optional metadata.
+- Improved character, race, name, characteristic, tattoo, scar, disfigurement, hearing-profile, wear-profile, and description builders.
+- Added optional email-registration bypass configuration for games that deliberately use a different account-approval workflow.
+- Fixed a range of character load-order, corpse stripping, inventory transfer, and duplicate-item persistence problems.
+
+## Combat, Weapons, and Arenas
+
+- Added complete sling and blowgun support using the normal ammunition system for damage, lodging, recovery, and poison delivery.
+- Added configurable weapon poisons and delivery through eligible weapon and ammunition attacks.
+- Added natural ranged attack families for spit, breath weapons, swooping breath attacks, buffeting attacks, and explosive natural attacks.
+- Improved natural ranged attacks so authored range, item targets, scatter impacts, bodypart selection, area targets, penetration, and on-use scripts resolve consistently.
+- Added builder support for fire profiles and liquid surface reactions, including damage, pain, stun, material tags, and extinguishing interactions on bodies and items.
+- Expanded weapon and shield type support and improved seeded combat definitions used by new worlds.
+- Added the Subdue combat strategy, including weapon-pressure and control behaviour suitable for guards, enforcers, and hostage-taking NPCs.
+- Improved default combat settings, auxiliary combat actions, clinch and grapple choices, target loss, surrender, helpless-target handling, and NPC combat strategy selection.
+- Expanded combat arenas with more scoring and elimination behaviour, surrender handling, ratings, betting, finance safeguards, NPC support, observation, cleanup, and builder diagnostics.
+- Fixed arena permission, payout, rating, restoration, and lifecycle edge cases.
+
+## Magic, Psionics, Planes, and Zero Gravity
+
+- Expanded the magic and psionics platform with additional powers, spell effects, triggers, resources, generators, wards, coercion, illusion, information, concealment, and trace behaviour.
+- Added persistent sensory and combat effects and improved how magical information is presented to different audiences.
+- Added possession support with stricter authority, cleanup, corpse, and character-instance handling.
+- Added planar presence and corporeality rules affecting perception, speech, targeting, movement, and interaction.
+- Added transient and durable magical portals, including persistence and safer topology updates when portals are created or removed.
+- Added zero-gravity movement with pushing, stopping, bumping, anchors, tethers, speed persistence, and transitions between gravity regimes.
+- Added more magic-, plane-, date-, character-, and effect-related FutureProg functions for builders.
+- Fixed psionic trace ownership, visibility, concealment, persistence, and security edge cases.
+
+## Time, Calendars, Celestials, and Weather
+
+- Introduced `MudInstant` as a calendar-aware way to represent moments across different in-game calendars and clocks.
+- Expanded date and time parsing, recurrence, scheduling, comparisons, and FutureProg support.
+- Added regnal periods and regnal-year presentation for calendars that use ruler-based dating.
+- Added astronomical event solving for configurable celestial events rather than assuming Earth-like calendars.
+- Improved calendar, clock, celestial, and timezone builders, including validation and clearer error messages.
+- Improved opposite-hemisphere climate behaviour, regional temperature fluctuation controls, and weather-event transitions.
+- Added climate descriptions and tiers and improved weather statistics, regional models, and builder-facing climate text.
+- Fixed ambiguous, invalid, boundary, and long-horizon calendar and celestial calculations.
+
+## World Building, Rooms, and Pathfinding
+
+- Added an incremental hierarchical pathfinding index for large worlds, with idle-slice rebuilding, live validation, automatic fallback, and diagnostics.
+- Updated pathfinding when builders create or remove cells, exits, and portals so routes do not require a reboot to become correct.
+- Improved actor-specific path suitability, closed and locked door handling, portal anchors, and route invalidation.
+- Expanded the room autobuilder and room-building workflow, including clearer conflict handling, cell targeting, previews, and documentation.
+- Improved terrain, atmosphere, forage, climate, zone-calendar, and live-world mutation handling.
+- Fixed duplicate portal anchors, stale topology, and several NPC door-opening and door-closing pathing problems.
+
+## Mounts, Stables, and Vehicles
+
+- Added stable businesses with accounts, users, tickets, lodging, fees, ledger entries, filters, redemption, and reboot-safe mount persistence.
+- Added riding and hitch equipment and tightened authorization for controlling, mounting, lodging, and redeeming animals.
+- Added the first stable vehicle release: builders can create vehicles with access points, compartments, occupant slots, cargo spaces, control stations, movement profiles, installations, damage zones, and repairable components.
+- Added manual cell-exit vehicle movement with explicit control handoff, player preflight and status information, crew and access checks, delayed movement, rollback, resource use, and operational readiness reporting.
+- Added vehicle damage, power and fuel requirements, cargo access, locking, occupancy, control stations, and builder validation.
+- Added persistent towing and a unified hitch graph supporting vehicle-to-vehicle and animal-to-vehicle combinations, including cycle prevention and safe detach and reboot behaviour.
+- Fixed remote vehicle control, invalid occupancy, duplicate catastrophe checks, fail-open movement, stale projected access and cargo markers, and unsafe control-station changes.
+- Vehicle 2.0 deliberately supports manual cell-exit `ItemScale` and `RoomContainer` vehicles. Scheduled routes, coordinate movement, and moving room-scale interiors remain future work.
+
+## Agriculture and Primary Production
+
+- Added fields with crops, seasons, weather stress, soil and custom scores, ownership gates, and daily progression.
+- Added player and builder field workflows for creating, inspecting, operating, saving, and removing agricultural areas.
+- Added herds, driving, drawing from and adding to herd populations, and broader animal-production support.
+- Added woodlands, orchards, apiaries, and project-driven primary-production operations.
+- Added commodity outputs, quality handling, characteristics, seed recovery, and FutureProg integration for agricultural and project results.
+- Expanded butchery, edible forage yields, terrain forage profiles, food recipes, crop profiles, and animal ecology support.
+- Improved project interruption, material reservation, payable contributions, and ownership or lease checks around production work.
+
+## NPCs, Groups, and AI Storytellers
+
+- Added more builder-authored NPC AI types for hunger, thirst, scavenging, ecology, combat, doors, and routine world interaction.
+- Expanded group AI registration, membership handling, strategies, event subscriptions, and example configurations.
+- Added richer NPC-template metadata and load additions, including outfit, item, role, knowledge, merit, and other template-driven setup.
+- Improved NPC door movement, warning visibility, combat-setting assignment, cleanup, and permission checks.
+- Expanded the AI Storyteller builder, command help, persisted memories and situations, surveillance inputs, tool loops, reference material, pause controls, and bounded error handling.
+- AI Storyteller use remains optional and requires a configured external model provider. Operators should review provider cost, rate limits, privacy, and failure behaviour before enabling it on a live game.
+
+## Clans, Communities, Language, and Events
+
+- Expanded clan templates, roles, appointments, property privileges, budgets, balance sheets, payroll history, and employment-host integration.
+- Improved clan elections, by-elections, cloning, ID rebinding, and appointment backfills so existing organisations upgrade more safely.
+- Improved clan command parsing, permission checks, financial visibility, and administrator workflows.
+- Expanded the runtime event surface and NPC event subscriptions available to builders and FutureProg authors.
+- Added a non-self emote token and improved audience-aware echo handling for social and scripted output.
+- Added skill and minimum-skill aliases to written-language markup and improved writing and language validation.
+- Expanded boards and community messaging through the new computer, mail, FTP, and telecommunications systems.
+
+## Economy, Commerce, and Property
+
+- Added shop deals with configurable eligibility, pricing, availability, and purchase behaviour.
+- Expanded markets with influence previews, weighted impacts, shocks, and clearer builder and operator feedback.
+- Added hotel room rentals, expiry, access, payment, and lost-property handling.
+- Improved auctions, including permissions, settlement, payout outcomes, insolvency handling, and protection against duplicate settlement.
+- Expanded clan finance, account access, authorization, payments, and administrative controls.
+- Added estates, wills, inheritance, claims, probate locations, corpse and morgue handling, liquidation, and auction integration.
+- Added durable ownership for items and private cells, including partial property shares, ownership repair paths, access checks, and FutureProg support.
+- Fixed property sale, lease, key, owner, calendar, and reboot edge cases across the economy system.
+
+## Employment and Project Work
+
+- Added a unified employment and task-host system for shops, clans, hospitals, projects, characters, and other supported hosts.
+- Added durable task provenance, scoped work grants, duty-aware assignment, consented applications, manager goals, action and host policy, capability checks, and bounded recovery after interruption or reboot.
+- Added supported wage authoring, earnings evidence, payables, disbursement states, and clearer handling when payment cannot be completed.
+- Added paid project contributions with custody, reservation, finance, cancellation, and recovery safeguards.
+- Improved blocked-task throttling, scheduler coalescing, empty-work gating, and host lookups to reduce repeated or unnecessary work.
+- Added builder and manager diagnostics that explain why work is blocked instead of silently retrying.
+- Parent organisations, consolidated accounting, cross-currency finance, autonomous vehicle or animal work, and deeper native workflows remain post-2.0 extensions.
+
+## Hospitals and Medical Workflows
+
+- Added hospitals as employment hosts with staff, opening and application workflows, manager controls, treatment services, room roles, and task dispatch.
+- Added treatment requests, stabilisation, full treatment, surgery, follow-up care, recovery rooms, cancellation, and visible patient status.
+- Added theatre and supply staging with custody, reservation, shortage reporting, replenishment, cleanup, and recovery after failed or interrupted work.
+- Added blood donation, blood stock, compatibility checks, transfusion and IV staging, donor-paid completion, and clearer billing and debt handling.
+- Added concise patient-facing service listings and richer manager and administrator diagnostics.
+- Fixed staff availability, missing-patient cancellation, clothing duplication, IV cleanup, treatment targeting, stock recovery, payment routing, and reboot behaviour across hospital workflows.
+
+## Law, Crime, Patrols, and Trials
+
+- Expanded automatic crime application across combat, movement, property, and other criminal actions.
+- Added configurable legal-class FutureProg support and richer evidence, identity, witness, and disguise handling.
+- Improved patrol dispatch, pursuit, door movement, warnings, custody, helpless-target handling, and lawful-force decisions.
+- Expanded bail, remand, automated and player-run trials, trial progress output, sentencing, execution, alerts, and failure recovery.
+- Added builder and administrator diagnostics for crimes, patrols, custody, trials, and execution state.
+- Fixed duplicate or missing crimes, incorrect enforcer behaviour, stalled trials, execution retries, corpse recovery, and several permission and visibility issues.
+
+## Computers, Power, Networks, and Telecommunications
+
+- Completed the first stable computer runtime with hosts, storage, terminals, files, persisted processes, workspaces, terminal input, waits, and execution controls.
+- Added built-in computer applications for mail, FTP, boards, and supporting host services.
+- Added telephone exchanges, call handling, extensions, signalling, fax machines, and related builder workflows.
+- Expanded electrical-grid components, controllers, sensors, cables, doors, locks, power behaviour, signals, and automation hooks.
+- Improved process restoration, power cycling, mounted-component load order, storage removal, terminal ownership, and reboot handling.
+- Tightened network, file, program, signal, Discord, and external-message authorization and input boundaries.
+
+## Items, Crafting, Writing, and Outfits
+
+- Expanded item components for seals, measurement, calibration, climate interaction, grids, telecommunications, medical equipment, repair kits, liquids, gases, writing, and other builder-authored behaviour.
+- Added item condition maintenance, contamination transfer and mixing, material reactions, and more durable save and clone behaviour.
+- Improved crafting with clearer guides, converters, component exclusivity, material and tool validation, cooked and liquid products, commodity outputs, and safer reservations.
+- Expanded outfit templates, covered placements, template loading, immutable writing, preloaded books, page handling, copying, tearing, and writing collection imports.
+- Added broader medieval and antiquity item, clothing, craft, material, medical, jewellery, household, industrial, and cultural authoring support used by the Database Seeder.
+- Improved item import mappings and the RPI world-file conversion path.
+- Fixed duplicate inserts, writing ID reuse, prototype readable persistence, torn-page copying, open-state checks, and markdown import validation.
+
+## FutureProg and Builder Tooling
+
+- Expanded FutureProg beyond the previous fixed-width type limit with versioned, extensible type masks while preserving legacy stored values.
+- Added a large set of date, time, celestial, magic, plane, character, clan, crime, economy, agriculture, vehicle, item, collection, dictionary, echo, and utility functions.
+- Improved function documentation, compiler information, type parsing, collection and dictionary handling, register persistence, and error reporting.
+- Improved command parsing across builders by handling quoted names and final free text more consistently.
+- Expanded install, uninstall, show, preview, help, list, filter, and diagnostic output across item components and major builder systems.
+- Improved text tables, localized values, colours, room and cell references, and large-output handling.
+- Fixed crashes in output handling and several command paths that could fail on unusual or missing data.
+
+## Security, Reliability, and Performance
+
+- Hardened authorization across administration, NPC AI, auxiliary combat, auctions, vehicles, mounts, magic, health, arenas, economy, employment, hospitals, property, automation, Discord, and FutureProg.
+- Added fail-closed validation for builder-authored references, unsupported work combinations, control relationships, payment paths, component compatibility, and privileged actions.
+- Bounded network frames, script evaluation, parser input, retries, loops, astronomical searches, and other work that could previously consume excessive memory or CPU.
+- Added automatic startup database backups and improved startup, shutdown, email, logging, error reporting, and recovery behaviour.
+- Improved persistence and load order for bodies, items, NPCs, mounted components, portals, calendars, ownership, hospitals, vehicles, paths, and scheduled work.
+- Added architecture-aware in-game Engine update support using published release metadata, no-store latest-runtime routes, SHA-256 verification, safe archive extraction, and staged restart scripts.
+- Added database-free documentation export so each Engine release can publish command, FutureProg function, FutureProg type, item-component, and builder-help reference material from the exact tagged source.
+- Expanded automated coverage across the Engine, including combat, arenas, employment, hospitals, law, magic, bodies, vehicles, agriculture, ownership, computers, pathfinding, writing, documentation, updater security, and FutureProg.
+
+## Deliberate 2.0 Boundaries
+
+- Vehicle routes, timetables, coordinate movement, and moving room-scale interiors are not part of this release.
+- AI Storyteller availability and quality depend on the external provider configured by each game.
+- Advanced multi-body social identity, disguise, recognition, and campaign-specific legal policy remain builder and game-design concerns rather than automatic Engine rules.
+- Some systems in this release are foundations that need game-specific content and builder configuration before players will encounter them.
+
+See `/downloads` for release archives and checksums, `/getting-started` for installation requirements, and the published Engine reference under `/docs` for commands and builder-facing metadata.
+


### PR DESCRIPTION
## Summary

- publish the complete FutureMUD Engine 2.0.0 patch notes covering Engine changes since 1.55.0
- put upgrade and compatibility guidance first
- document the supported 2.0 boundaries and public release/runtime links

## Validation

- `dotnet test FutureMUD.Web.Tests/FutureMUD.Web.Tests.csproj -c Release -m:1 -p:RestoreBuildInParallel=false -p:NuGetAudit=false` (14 passed)
- `dotnet test MudSharpCore Unit Tests/MudSharpCore Unit Tests.csproj -c Release -m:1 -nr:false -p:RestoreBuildInParallel=false -p:NuGetAudit=false` (1,692 passed)
- representative Windows x64 framework-dependent single-file publish succeeded
- packaged Engine exported all five documentation catalogue families (414 commands, 541 FutureProg functions, 274 types, 13 collection extensions, 202 item components)
- `git diff --check`