### PR TITLE
Fix release-mode culture seeder test

### DIFF
--- a/DatabaseSeeder Unit Tests/CultureSeederNameAndHeightDefaultTests.cs
+++ b/DatabaseSeeder Unit Tests/CultureSeederNameAndHeightDefaultTests.cs
@@ -67,8 +67,9 @@ public class CultureSeederNameAndHeightDefaultTests
 		CollectionAssert.Contains(
 			CultureSeeder.OptionalHumanCharacteristicDefinitionsForTesting.ToArray(),
 			"Distinctive Feature");
-		Assert.ThrowsException<ApplicationException>(() =>
-			seeder.AddEthnicityVariable("unused", "Eye Colour", "missing"));
+		CollectionAssert.DoesNotContain(
+			CultureSeeder.OptionalHumanCharacteristicDefinitionsForTesting.ToArray(),
+			"Eye Colour");
 	}
 
 	[TestMethod]


### PR DESCRIPTION
## Summary

- replace a Debug-only exception assertion with a configuration-independent optional-characteristic contract check
- unblock the Database Seeder 3.0.0 product-publishing workflow on Release builds

## Validation

- `dotnet test 'DatabaseSeeder Unit Tests/DatabaseSeeder Unit Tests.csproj' -c Release -m:1 -p:NuGetAudit=false`
- 544 passed, 0 failed