### PR TITLE
Fix forced movement confirmation and swim-to-land positioning

### DIFF
--- a/Design Documents/World/Position_State_System.md
+++ b/Design Documents/World/Position_State_System.md
@@ -97,6 +97,10 @@ For item positions, `_positionItemRegex` parses command, item, optional modifier
 - swim transitions require `PositionSwimming`;
 - zero-gravity cells require `PositionFloatingInZeroGravity` unless the transition is swim-only, swim-to-land, or fly-only.
 
+Safe-movement confirmation accepts `!` either attached to the movement verb (`east!`) or as a separate argument (`east !`). The confirmation remains in effect when the move is revalidated at the room threshold, but it bypasses only safe-movement warnings; ordinary posture, stamina, effect, exit-size, and other movement blockers still apply.
+
+On a `SwimToLand` transition, the swimmer uses their most upright available land-movement position after entering the destination (normally standing, with prostrate or prone fallbacks). If the body has no viable land-movement position, it arrives sprawled rather than retaining the swimming state on dry ground.
+
 `CanMoveInternal` rejects `Restricted` positions and `FreeIfNotInOn` positions that are currently in or on a target. It then chooses a moving position:
 
 - swimming, climbing, flying, and zero-gravity floating keep their own state;

--- a/MudSharpCore Unit Tests/MovementTests.cs
+++ b/MudSharpCore Unit Tests/MovementTests.cs
@@ -6,6 +6,7 @@ using MudSharp.Body;
 using MudSharp.Character;
 using MudSharp.Body.Position;
 using MudSharp.Body.Position.PositionStates;
+using MudSharp.Commands;
 using MudSharp.Construction;
 using MudSharp.Construction.Boundary;
 using MudSharp.Effects.Concrete;
@@ -24,6 +25,98 @@ namespace MudSharp_Unit_Tests;
 [TestClass]
 public class MovementTests
 {
+	[TestMethod]
+	public void CharacterCommandManager_AttachedForceSuffix_NormalisesMovementCommand()
+	{
+		var manager = new CharacterCommandManager();
+		var command = new Command<ICharacter>((_, _) => { }, name: "Move");
+		manager.Add("east", command);
+		var actor = new Mock<ICharacter>();
+		var input = "east! (carefully)";
+
+		var result = manager.LocateCommand(actor.Object, ref input);
+
+		Assert.AreSame(command, result);
+		Assert.AreEqual("east ! (carefully)", input);
+	}
+
+	[TestMethod]
+	public void CreateMovement_ForcedSafeMovement_UsesIgnoreSafeMovementFlag()
+	{
+		var exit = new Mock<ICellExit>();
+		var destination = new Mock<ICell>();
+		exit.SetupGet(x => x.Destination).Returns(destination.Object);
+		var mover = CreateMoverMock(new Queue<string>());
+		mover.Setup(x => x.CanMove(exit.Object, CanMoveFlags.None))
+			.Returns(new CanMoveResponse { Result = false, ErrorMessage = "Safe movement warning." });
+		mover.Setup(x => x.CanMove(exit.Object, CanMoveFlags.IgnoreSafeMovement))
+			.Returns(CanMoveResponse.True);
+
+		var movement = Movement.CreateMovement(mover.Object, exit.Object, ignoreSafeMovement: true);
+
+		Assert.IsNotNull(movement);
+		mover.Verify(x => x.CanMove(exit.Object, CanMoveFlags.IgnoreSafeMovement), Times.Once);
+		mover.Verify(x => x.CanMove(exit.Object, CanMoveFlags.None), Times.Never);
+	}
+
+	[TestMethod]
+	public void IntermediateStep_ForcedSafeMovement_PreservesConfirmationDuringRevalidation()
+	{
+		var origin = new Mock<ICell>();
+		var destination = new Mock<ICell>();
+		destination.SetupGet(x => x.Characters).Returns([]);
+		var exit = new Mock<ICellExit>();
+		exit.SetupGet(x => x.Origin).Returns(origin.Object);
+		exit.SetupGet(x => x.Destination).Returns(destination.Object);
+		var mover = CreateMoverMock(new Queue<string>());
+		var body = new Mock<IBody>();
+		mover.SetupGet(x => x.Body).Returns(body.Object);
+		mover.Setup(x => x.CanMove(exit.Object, CanMoveFlags.None))
+			.Returns(new CanMoveResponse { Result = false, ErrorMessage = "Safe movement warning." });
+		mover.Setup(x => x.CanMove(exit.Object, CanMoveFlags.IgnoreSafeMovement))
+			.Returns(CanMoveResponse.True);
+		mover.Setup(x => x.CanCross(exit.Object)).Returns((true, null!));
+
+		var movement = new Movement(
+			mover.Object,
+			null!,
+			Enumerable.Empty<ICharacter>(),
+			Enumerable.Empty<ICharacter>(),
+			[mover.Object],
+			Enumerable.Empty<ICharacter>(),
+			Enumerable.Empty<IPerceivable>(),
+			Enumerable.Empty<Dragging>(),
+			exit.Object,
+			ignoreSafeMovement: true);
+
+		movement.IntermediateStep();
+
+		Assert.IsFalse(movement.Cancelled);
+		mover.Verify(x => x.CanMove(exit.Object, CanMoveFlags.IgnoreSafeMovement), Times.Once);
+		mover.Verify(x => x.CanMove(exit.Object, CanMoveFlags.None), Times.Never);
+		mover.Verify(x => x.ExecuteMove(movement, It.IsAny<IMoveSpeed>()), Times.Once);
+	}
+
+	[TestMethod]
+	public void ExecuteMove_SwimToLand_ChoosesLandMovementPosition()
+	{
+		var movementSource = File.ReadAllText(GetCoreSourcePath("Character", "CharacterMovement.cs"));
+		var executeMoveStart = movementSource.IndexOf("public void ExecuteMove(IMovement movement",
+			StringComparison.Ordinal);
+		Assert.IsTrue(executeMoveStart >= 0, "Character.ExecuteMove should exist.");
+		var transitionStart = movementSource.IndexOf("case CellMovementTransition.SwimToLand:",
+			executeMoveStart, StringComparison.Ordinal);
+		Assert.IsTrue(transitionStart >= 0, "ExecuteMove should handle SwimToLand transitions.");
+		var transitionEnd = movementSource.IndexOf("break;", transitionStart, StringComparison.Ordinal);
+
+		Assert.IsTrue(transitionEnd > transitionStart, "The SwimToLand transition should terminate with break.");
+		var transitionBlock = movementSource[transitionStart..transitionEnd];
+		StringAssert.Contains(transitionBlock, "MostUprightLandMovementPosition()");
+		StringAssert.Contains(transitionBlock, "PositionSprawled.Instance");
+		Assert.IsFalse(transitionBlock.Contains("SetPosition(PositionSwimming.Instance", StringComparison.Ordinal),
+			"Reaching dry land must not preserve the swimming position.");
+	}
+
     [TestMethod]
     public void FinalStep_SoloMoverWithQueuedCommand_ExecutesQueuedMove()
     {

--- a/MudSharpCore/Character/Character.cs
+++ b/MudSharpCore/Character/Character.cs
@@ -15,6 +15,7 @@ using MudSharp.CharacterCreation;
 using MudSharp.CharacterCreation.Resources;
 using MudSharp.CharacterCreation.Roles;
 using MudSharp.Combat;
+using MudSharp.Commands;
 using MudSharp.Commands.Trees;
 using MudSharp.Communication.Language;
 using MudSharp.Communication.Language.Scramblers;
@@ -2146,6 +2147,11 @@ public partial class Character : PerceiverItem, ICharacter, ICharacterIdentity, 
     bool IControllable.ExecuteCommand(string command)
     {
         Gameworld?.LogManager.LogCharacterCommand(this, command);
+		if (CommandTree.Commands is CharacterCommandManager characterCommands)
+		{
+			command = characterCommands.NormaliseMovementForceSuffix(this, command);
+		}
+
         // Handle Command Interupt hooks first
         string cmd = new StringStack(command).PopSpeech();
         StringStack ss = new(command.RemoveFirstWord());

--- a/MudSharpCore/Character/CharacterMovement.cs
+++ b/MudSharpCore/Character/CharacterMovement.cs
@@ -275,6 +275,11 @@ public partial class Character
             return PositionState;
         }
 
+		return MostUprightLandMovementPosition(ignoreCouldMove);
+	}
+
+	private IPositionState MostUprightLandMovementPosition(bool ignoreCouldMove = false)
+	{
         if ((CanMovePosition(PositionStanding.Instance, ignoreCouldMove) ||
              PositionState == PositionStanding.Instance) &&
             (ignoreCouldMove || CouldMove(true, PositionStanding.Instance).Success))
@@ -1532,7 +1537,8 @@ public partial class Character
 
                 break;
             case CellMovementTransition.SwimToLand:
-                SetPosition(PositionSwimming.Instance, PositionModifier.None, null, null);
+				SetPosition(MostUprightLandMovementPosition() ?? PositionSprawled.Instance,
+					PositionModifier.None, null, null);
                 break;
         }
 

--- a/MudSharpCore/Commands/CommandManager.cs
+++ b/MudSharpCore/Commands/CommandManager.cs
@@ -513,8 +513,26 @@ public class CharacterCommandManager : CommandManager<ICharacter>, ICharacterCom
 
     public IEnumerable<ICommandHelpInfo> CommandHelpInfos => _tCommands.Values.SelectNotNull(x => x.HelpInfo);
 
+	internal string NormaliseMovementForceSuffix(ICharacter reference, string input)
+	{
+		var splitCommands = new StringStack(input);
+		var commandText = splitCommands.PopSpeech().ToLowerInvariant();
+		if (commandText.Length <= 1 || !commandText.EndsWith('!'))
+		{
+			return input;
+		}
+
+		var movementCommandText = commandText[..^1];
+		_tCommands.TryGetValue(movementCommandText, out var movementCommand);
+		CheckCommandConditions(ref movementCommand, reference, movementCommandText);
+		return movementCommand?.Name.EqualTo("Move") == true
+			? $"{movementCommandText} !{splitCommands.RemainingArgument.LeadingSpaceIfNotEmpty()}"
+			: input;
+	}
+
     public override IExecutable<ICharacter> LocateCommand(ICharacter reference, ref string input)
     {
+		input = NormaliseMovementForceSuffix(reference, input);
         StringStack splitCommands = new(input);
 
         string commandText = splitCommands.PopSpeech().ToLowerInvariant();

--- a/MudSharpCore/Movement/Movement.cs
+++ b/MudSharpCore/Movement/Movement.cs
@@ -35,6 +35,7 @@ public class Movement : IMovement
     private readonly IVehicleHitchGraphService _vehicleHitchGraphService = new VehicleHitchGraphService();
     private readonly IVehicleOperationalReadinessService _vehicleOperationalReadinessService = new VehicleOperationalReadinessService();
     private readonly Dictionary<long, VehicleHitchGraphMovePlan> _vehicleDragMovePlans = new();
+	private readonly bool _ignoreSafeMovement;
 
     #region Implementation of IMovement
 
@@ -162,9 +163,9 @@ public class Movement : IMovement
             return false;
         }
 
-        if (!ignoreSafeMovement &&
-            character.RidingMount is null &&
-            !character.CanMove(exit, CanMoveFlags.None).Result)
+		var moveFlags = ignoreSafeMovement ? CanMoveFlags.IgnoreSafeMovement : CanMoveFlags.None;
+		if (character.RidingMount is null &&
+		    !character.CanMove(exit, moveFlags).Result)
         {
             return false;
         }
@@ -246,7 +247,9 @@ public class Movement : IMovement
 
         foreach (ICharacter mover in primaryMovers)
         {
-            if (!EvaluateCharacterForAdditionToMovement(originalMover.Party, mover, exit, consideredMovers, nondraggers, mounts, draggers, helpers, nonConsensualMovers, targets, effects, false, false))
+			if (!EvaluateCharacterForAdditionToMovement(originalMover.Party, mover, exit, consideredMovers,
+			        nondraggers, mounts, draggers, helpers, nonConsensualMovers, targets, effects,
+			        ignoreSafeMovement, false))
             {
                 failedMovers.Add(mover);
             }
@@ -254,7 +257,8 @@ public class Movement : IMovement
 
         if (failedMovers.ContainsPhysicalInstance(originalMover))
         {
-            CanMoveResponse response = originalMover.CanMove(exit, CanMoveFlags.None);
+			var moveFlags = ignoreSafeMovement ? CanMoveFlags.IgnoreSafeMovement : CanMoveFlags.None;
+			CanMoveResponse response = originalMover.CanMove(exit, moveFlags);
             string message = response.ErrorMessage;
             if (string.IsNullOrEmpty(message))
             {
@@ -301,7 +305,8 @@ public class Movement : IMovement
             return null;
         }
 
-        return new Movement(originalMover, originalMover.Party, draggers, helpers, nondraggers, mounts, targets, effects, exit);
+		return new Movement(originalMover, originalMover.Party, draggers, helpers, nondraggers, mounts, targets,
+			effects, exit, ignoreSafeMovement);
     }
 
     public Movement(
@@ -313,10 +318,12 @@ public class Movement : IMovement
             IEnumerable<ICharacter> mounts,
             IEnumerable<IPerceivable> targets,
             IEnumerable<Dragging> dragEffects,
-            ICellExit exit
+			ICellExit exit,
+			bool ignoreSafeMovement = false
         )
     {
         _originalMover = originalMover;
+		_ignoreSafeMovement = ignoreSafeMovement;
         Exit = exit;
         Phase = MovementPhase.OriginalRoom;
         Party = party;
@@ -800,11 +807,15 @@ public class Movement : IMovement
             return;
         }
 
+		var moveFlags = _ignoreSafeMovement ? CanMoveFlags.IgnoreSafeMovement : CanMoveFlags.None;
         List<ICharacter> nonMovers = new();
-        nonMovers.AddRange(Mounts.Where(mount => !mount.CanMove(Exit, CanMoveFlags.None).Result));
-        nonMovers.AddRange(Draggers.Where(dragger => dragger.RidingMount is null).Where(dragger => !dragger.CanMove(Exit, CanMoveFlags.None).Result));
-        nonMovers.AddRange(Helpers.Where(dragger => dragger.RidingMount is null).Where(dragger => !dragger.CanMove(Exit, CanMoveFlags.None).Result));
-        nonMovers.AddRange(NonDraggers.Where(ch => ch.RidingMount is null).Where(ch => !ch.CanMove(Exit, CanMoveFlags.None).Result));
+		nonMovers.AddRange(Mounts.Where(mount => !mount.CanMove(Exit, moveFlags).Result));
+		nonMovers.AddRange(Draggers.Where(dragger => dragger.RidingMount is null)
+			.Where(dragger => !dragger.CanMove(Exit, moveFlags).Result));
+		nonMovers.AddRange(Helpers.Where(dragger => dragger.RidingMount is null)
+			.Where(dragger => !dragger.CanMove(Exit, moveFlags).Result));
+		nonMovers.AddRange(NonDraggers.Where(ch => ch.RidingMount is null)
+			.Where(ch => !ch.CanMove(Exit, moveFlags).Result));
         if (nonMovers.Count > 0)
         {
             if (Party is not null && Party.LeaveNoneBehind)


### PR DESCRIPTION
## Summary
- Normalize attached `!` movement confirmations such as `east!`.
- Preserve forced safe-movement confirmation during movement revalidation.
- Transition swimmers to their most upright viable land position, falling back to sprawled.
- Document the updated movement behavior.

## Testing
- Added focused movement unit tests covering command normalization, safe-movement bypass, revalidation, and swim-to-land transitions.
- Not run (not requested).