### PR TITLE
Fix weather controller zone-name creation lookup

### DIFF
--- a/MudSharpCore Unit Tests/WeatherControllerBuilderTests.cs
+++ b/MudSharpCore Unit Tests/WeatherControllerBuilderTests.cs
@@ -1,0 +1,43 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Character;
+using MudSharp.Climate;
+using MudSharp.Commands.Helpers;
+using MudSharp.Construction;
+using MudSharp.Framework;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class WeatherControllerBuilderTests
+{
+	[TestMethod]
+	public void ParseWeatherControllerCreationArguments_ZoneName_ResolvesZone()
+	{
+		var regionalClimate = new Mock<IRegionalClimate>();
+		regionalClimate.SetupGet(x => x.Id).Returns(2);
+		regionalClimate.SetupGet(x => x.Name).Returns("Subpolar Oceanic");
+
+		var zone = new Mock<IZone>();
+		zone.SetupGet(x => x.Id).Returns(17);
+		zone.SetupGet(x => x.Name).Returns("Sydney Zone");
+
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.WeatherControllers).Returns(new All<IWeatherController>());
+		gameworld.SetupGet(x => x.RegionalClimates)
+			.Returns(new All<IRegionalClimate> { regionalClimate.Object });
+		gameworld.SetupGet(x => x.Zones).Returns(new All<IZone> { zone.Object });
+
+		var actor = new Mock<ICharacter>();
+		actor.SetupGet(x => x.Gameworld).Returns(gameworld.Object);
+
+		var result = EditableItemHelper.ParseWeatherControllerCreationArguments(
+			actor.Object,
+			new StringStack("\"ZZZ Pilot Weather\" \"Subpolar Oceanic\" \"Sydney Zone\""));
+
+		Assert.IsTrue(result.HasValue);
+		Assert.AreEqual("ZZZ Pilot Weather", result.Value.Name);
+		Assert.AreSame(regionalClimate.Object, result.Value.RegionalClimate);
+		Assert.AreSame(zone.Object, result.Value.Zone);
+	}
+}

--- a/MudSharpCore/Commands/Helpers/EditableItemHelperWeather.cs
+++ b/MudSharpCore/Commands/Helpers/EditableItemHelperWeather.cs
@@ -17,6 +17,55 @@ namespace MudSharp.Commands.Helpers;
 
 public partial class EditableItemHelper
 {
+	internal static (string Name, IRegionalClimate RegionalClimate, Construction.IZone Zone)?
+		ParseWeatherControllerCreationArguments(Character.ICharacter actor, StringStack input)
+	{
+		if (input.IsFinished)
+		{
+			actor.OutputHandler.Send("You must specify a name for your weather controller.");
+			return null;
+		}
+
+		var name = input.PopSpeech().TitleCase();
+		if (actor.Gameworld.WeatherControllers.Any(x => x.Name.EqualTo(name)))
+		{
+			actor.OutputHandler.Send(
+				$"There is already a weather controller called {name.ColourName()}. Names must be unique.");
+			return null;
+		}
+
+		if (input.IsFinished)
+		{
+			actor.OutputHandler.Send("Which regional climate is this a weather controller for?");
+			return null;
+		}
+
+		var regionalClimateText = input.PopSpeech();
+		var regionalClimate = actor.Gameworld.RegionalClimates.GetByIdOrName(regionalClimateText);
+		if (regionalClimate is null)
+		{
+			actor.OutputHandler.Send(
+				$"The text {regionalClimateText.ColourCommand()} is not a valid regional climate.");
+			return null;
+		}
+
+		if (input.IsFinished)
+		{
+			actor.OutputHandler.Send("Which zone do you want to use for the geographic information?");
+			return null;
+		}
+
+		var zoneText = input.SafeRemainingArgument;
+		var zone = actor.Gameworld.Zones.GetByIdOrName(zoneText);
+		if (zone is null)
+		{
+			actor.OutputHandler.Send($"The text {zoneText.ColourCommand()} is not a valid zone.");
+			return null;
+		}
+
+		return (name, regionalClimate, zone);
+	}
+
     public static EditableItemHelper WeatherEventHelper { get; } = new()
     {
         ItemName = "Weather Event",
@@ -386,50 +435,13 @@ public partial class EditableItemHelper
         CastToType = typeof(IWeatherController),
         EditableNewAction = (actor, input) =>
         {
-            if (input.IsFinished)
-            {
-                actor.OutputHandler.Send("You must specify a name for your weather controller.");
-                return;
-            }
+			var creationArguments = ParseWeatherControllerCreationArguments(actor, input);
+			if (creationArguments is null)
+			{
+				return;
+			}
 
-            string name = input.PopSpeech().TitleCase();
-            if (actor.Gameworld.WeatherControllers.Any(x => x.Name.EqualTo(name)))
-            {
-                actor.OutputHandler.Send($"There is already a weather controller called {name.ColourName()}. Names must be unique.");
-                return;
-            }
-
-            if (input.IsFinished)
-            {
-                actor.OutputHandler.Send("Which regional climate is this a weather controller for?");
-                return;
-            }
-
-            IRegionalClimate regionalClimate = actor.Gameworld.RegionalClimates.GetByIdOrName(input.PopSpeech());
-            if (regionalClimate is null)
-            {
-                actor.OutputHandler.Send($"The text {input.Last.ColourCommand()} is not a valid regional climate.");
-                return;
-            }
-
-            if (input.IsFinished)
-            {
-                actor.OutputHandler.Send("Which zone do you want to use for the geographic information?");
-                return;
-            }
-
-            Construction.IZone zone = actor.Gameworld.Zones.GetByIdOrName(input.SafeRemainingArgument);
-            if (zone is null)
-            {
-                actor.OutputHandler.Send($"The text {input.SafeRemainingArgument.ColourCommand()} is not a valid zone.");
-                return;
-            }
-
-            if (!int.TryParse(input.SafeRemainingArgument, out int onset) || onset < 0)
-            {
-                actor.OutputHandler.Send($"The text {input.SafeRemainingArgument.ColourCommand()} is not a valid number 0 or greater.");
-                return;
-            }
+			var (name, regionalClimate, zone) = creationArguments.Value;
 
             WeatherController wc = new(actor.Gameworld, name, regionalClimate, zone);
             actor.Gameworld.Add(wc);

--- a/MudSharpCore/Commands/Modules/WeatherModule.cs
+++ b/MudSharpCore/Commands/Modules/WeatherModule.cs
@@ -158,7 +158,7 @@ The syntax is as follows:
 
 	#3wc list [<filters>]#0 - lists all of the controllers
 	#3wc edit <which>#0 - begins editing a controller
-	#3wc edit new <name> <climate> <zone>#0 - creates a new controller
+	#3wc edit new <name> <climate id|name> <zone id|name>#0 - creates a new controller
 	#3wc close#0 - stops editing a controller
 	#3wc show <which>#0 - views information about a controller
 	#3wc show#0 - views information about your currently editing controller


### PR DESCRIPTION
## Summary

- Extract weather controller creation argument parsing into a testable helper.
- Resolve regional climates and zones by ID or name, including multi-word zone names.
- Update weather command help to document ID-or-name arguments.
- Add regression coverage for quoted climate and zone names.

## Testing

- Added a focused unit test covering weather controller creation with named regional climate and zone arguments.
- Full test suite not run (not requested).