### PR TITLE
Persist zone weather controller IDs when saving

### DIFF
--- a/MudSharpCore Unit Tests/ZonePersistenceSourceIntegrationTests.cs
+++ b/MudSharpCore Unit Tests/ZonePersistenceSourceIntegrationTests.cs
@@ -1,0 +1,36 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class ZonePersistenceSourceIntegrationTests
+{
+	[TestMethod]
+	public void Save_PersistsWeatherControllerId()
+	{
+		var source = File.ReadAllText(GetSourcePath("MudSharpCore", "Construction", "Zone.cs"));
+		var saveStart = source.IndexOf("public override void Save()", StringComparison.Ordinal);
+		var registerStart = source.IndexOf("public static void RegisterPerceivableType", saveStart,
+			StringComparison.Ordinal);
+
+		Assert.IsTrue(saveStart >= 0, "Zone.Save() was not found.");
+		Assert.IsTrue(registerStart > saveStart, "The end of Zone.Save() was not found.");
+		StringAssert.Contains(source[saveStart..registerStart],
+			"dbzone.WeatherControllerId = WeatherController?.Id;");
+	}
+
+	private static string GetSourcePath(params string[] parts)
+	{
+		return Path.GetFullPath(Path.Combine(
+			AppContext.BaseDirectory,
+			"..",
+			"..",
+			"..",
+			"..",
+			Path.Combine(parts)));
+	}
+}

--- a/MudSharpCore/Construction/Zone.cs
+++ b/MudSharpCore/Construction/Zone.cs
@@ -262,6 +262,7 @@ public class Zone : Location, IEditableZone
             dbzone.Elevation = Geography.Elevation;
             dbzone.Name = Name;
             dbzone.ForagableProfileId = ForagableProfile?.Id;
+            dbzone.WeatherControllerId = WeatherController?.Id;
             FMDB.Context.ZonesTimezones.RemoveRange(dbzone.ZonesTimezones);
             foreach (KeyValuePair<IClock, IMudTimeZone> timezone in TimeZones)
             {


### PR DESCRIPTION
## Summary

- Save each zone’s weather controller ID to the database.
- Add regression coverage verifying the persistence assignment remains in `Zone.Save()`.

## Testing

- Added a source-level integration test for weather controller ID persistence.
- Not run (not requested).