### PR TITLE
Make FutureProg parameter lookup case-insensitive

### DIFF
--- a/Design Documents/Core/FutureProg_Type_System.md
+++ b/Design Documents/Core/FutureProg_Type_System.md
@@ -98,6 +98,8 @@ Type display and description logic is centralised through the registry-backed `D
 
 ## Runtime Safety Invariants
 
+FutureProg parameter and local-variable references are case-insensitive. Persisted parameter names retain their authored casing for display and integration schemas, while compiler and runtime variable spaces normalise those names for lookup. A prog may not define two parameters whose names differ only by case.
+
 Collection variables must expose `IProgVariable` elements at runtime, even when a helper or dot reference builds a collection from scalar CLR values such as `string`, `decimal`, `bool`, `DateTime`, `TimeSpan`, `MudDateTime`, or `Gender`. The `CollectionVariable` constructor normalises those scalar elements so collection extension functions, admin result display, and dot references like `first`, `last`, and `reverse` all see the same element shape.
 
 Variable-register persistence must be total for every type that can be registered and saved. Value types, including `LiquidMixture`, serialise through value XML rather than reference IDs; unsupported or null preserved values must not create null `IVariableValue` entries. Resetting a stored register value removes the persisted override row and falls back to the default value.

--- a/MudSharpCore Unit Tests/ProgTests.cs
+++ b/MudSharpCore Unit Tests/ProgTests.cs
@@ -345,6 +345,65 @@ return concat(@window, ""|"")");
 		Assert.IsTrue(shieldGlint.Compile(), shieldGlint.CompileError);
 	}
 
+	[TestMethod]
+	public void SeededAiStorytellerTool_MixedCaseParameter_CompilesAndExecutes()
+	{
+		FutureProg prog = new(_gameworld,
+			"AIStorytellerToolRecordCue",
+			ProgVariableTypes.Text,
+			new[] { Tuple.Create(ProgVariableTypes.Text, "Cue") },
+			"""return "Narrative cue captured: " + @Cue""");
+
+		Assert.IsTrue(prog.Compile(), prog.CompileError);
+		Assert.AreEqual("Narrative cue captured: Hold the western gate.", prog.Execute<string>("Hold the western gate."));
+	}
+
+	[TestMethod]
+	public void SeededArenaBoxingScoring_CamelCaseParameters_Compile()
+	{
+		Tuple<ProgVariableTypes, string>[] parameters =
+		[
+			Tuple.Create(ProgVariableTypes.Character | ProgVariableTypes.Collection, "participants"),
+			Tuple.Create(ProgVariableTypes.Number | ProgVariableTypes.Collection, "sideIndices"),
+			Tuple.Create(ProgVariableTypes.Location, "arenaCell"),
+			Tuple.Create(ProgVariableTypes.Text, "eventTypeName"),
+			Tuple.Create(ProgVariableTypes.Text, "arenaName"),
+			Tuple.Create(ProgVariableTypes.Text, "eventName"),
+			Tuple.Create(ProgVariableTypes.Character | ProgVariableTypes.Collection, "scoringAttackers"),
+			Tuple.Create(ProgVariableTypes.Character | ProgVariableTypes.Collection, "scoringDefenders"),
+			Tuple.Create(ProgVariableTypes.Number | ProgVariableTypes.Collection, "scoringAttackerSides"),
+			Tuple.Create(ProgVariableTypes.Number | ProgVariableTypes.Collection, "scoringDefenderSides"),
+			Tuple.Create(ProgVariableTypes.Number | ProgVariableTypes.Collection, "landedHits"),
+			Tuple.Create(ProgVariableTypes.Number | ProgVariableTypes.Collection, "undefendedHits"),
+			Tuple.Create(ProgVariableTypes.Text | ProgVariableTypes.Collection, "impactLocations"),
+			Tuple.Create(ProgVariableTypes.Text | ProgVariableTypes.Collection, "impactBodyparts")
+		];
+		FutureProg prog = new(_gameworld,
+			"ArenaBoxingScoring",
+			ProgVariableTypes.Number | ProgVariableTypes.Collection,
+			parameters,
+			"return arenaboxingscores(@sideIndices, @scoringAttackerSides, @landedHits, @undefendedHits, @impactLocations)");
+
+		Assert.IsTrue(prog.Compile(), prog.CompileError);
+	}
+
+	[TestMethod]
+	public void Compile_ParametersDifferingOnlyByCase_ReturnsClearError()
+	{
+		FutureProg prog = new(_gameworld,
+			"DuplicateParameterCase",
+			ProgVariableTypes.Text,
+			new[]
+			{
+				Tuple.Create(ProgVariableTypes.Text, "Cue"),
+				Tuple.Create(ProgVariableTypes.Text, "cue")
+			},
+			"return @Cue");
+
+		Assert.IsFalse(prog.Compile());
+		Assert.AreEqual("Parameter Cue is defined more than once.", prog.CompileError);
+	}
+
     [TestMethod]
     public void TestGetTypeByName()
     {

--- a/MudSharpCore/FutureProg/FutureProg.cs
+++ b/MudSharpCore/FutureProg/FutureProg.cs
@@ -237,6 +237,15 @@ public class FutureProg : SaveableItem, IFutureProg
 			return false;
 		}
 
+		var duplicateParameter = NamedParameters
+			.GroupBy(x => x.Item2, StringComparer.InvariantCultureIgnoreCase)
+			.FirstOrDefault(x => x.Count() > 1);
+		if (duplicateParameter is not null)
+		{
+			CompileError = $"Parameter {duplicateParameter.Key} is defined more than once.";
+			return false;
+		}
+
         Stopwatch sw = new();
         sw.Start();
         // Split the raw text into lines
@@ -248,7 +257,9 @@ public class FutureProg : SaveableItem, IFutureProg
         }
 
         // Create the initial variable space from the parameters
-        Dictionary<string, ProgVariableTypes> variableSpace = NamedParameters.ToDictionary(x => x.Item2, x => x.Item1);
+        Dictionary<string, ProgVariableTypes> variableSpace = NamedParameters.ToDictionary(
+			x => x.Item2.ToLowerInvariant(),
+			x => x.Item1);
 
         // If the program has a non-void return type, create the return variable
         if (ReturnType != ProgVariableTypes.Void)
@@ -559,12 +570,12 @@ public class FutureProg : SaveableItem, IFutureProg
         {
             try
             {
-                variableSpaceDict.Add(NamedParameters[i].Item2, GetVariable(NamedParameters[i].Item1, variables.ElementAtOrDefault(i)));
+                variableSpaceDict.Add(NamedParameters[i].Item2.ToLowerInvariant(), GetVariable(NamedParameters[i].Item1, variables.ElementAtOrDefault(i)));
             }
             catch (Exception e)
             {
                 Gameworld.DiscordConnection.NotifyProgError(Id, FunctionName, $"There was an exception while assigning parameter #{i} ({NamedParameters[i].Item2}) in prog {Id} ({FunctionName}).\nParameters:\n{NamedParameters.Select(x => $"{x.Item2}: {variables.ElementAtOrDefault(NamedParameters.IndexOf(x))?.ToString() ?? "null"}").ArrangeStringsOntoLines(1, 120)}\n\nException:\n\n{e}");
-                variableSpaceDict.Add(NamedParameters[i].Item2, new NullVariable(NamedParameters[i].Item1));
+                variableSpaceDict.Add(NamedParameters[i].Item2.ToLowerInvariant(), new NullVariable(NamedParameters[i].Item1));
             }
 
         }
@@ -596,12 +607,12 @@ public class FutureProg : SaveableItem, IFutureProg
         {
             try
             {
-                variableSpaceDict.Add(NamedParameters[i].Item2, GetVariable(NamedParameters[i].Item1, variables.ElementAtOrDefault(i)));
+                variableSpaceDict.Add(NamedParameters[i].Item2.ToLowerInvariant(), GetVariable(NamedParameters[i].Item1, variables.ElementAtOrDefault(i)));
             }
             catch (Exception e)
             {
                 Gameworld.DiscordConnection.NotifyProgError(Id, FunctionName, $"There was an exception while assigning parameter #{i} ({NamedParameters[i].Item2}) in prog {Id} ({FunctionName}).\nParameters:\n{NamedParameters.Select(x => $"{x.Item2}: {variables.ElementAtOrDefault(NamedParameters.IndexOf(x))?.ToString() ?? "null"}").ArrangeStringsOntoLines(1, 120)}\n\nException:\n\n{e}");
-                variableSpaceDict.Add(NamedParameters[i].Item2, new NullVariable(NamedParameters[i].Item1));
+                variableSpaceDict.Add(NamedParameters[i].Item2.ToLowerInvariant(), new NullVariable(NamedParameters[i].Item1));
             }
 
         }


### PR DESCRIPTION
## Summary
- Normalize FutureProg parameter names for case-insensitive compilation and runtime lookup.
- Reject duplicate parameters that differ only by case with a clear error.
- Document the parameter-name safety invariant.
- Add regression coverage for seeded AI storyteller and arena progs.

## Testing
- Added and ran targeted FutureProg unit tests covering mixed-case execution, camelCase parameters, and duplicate-case validation.