### PR TITLE
Version update to 2.0.1

### DIFF
--- a/FutureMUD.Web/Content/PatchNotes/2026-07-18-engine-2-0-1.md
+++ b/FutureMUD.Web/Content/PatchNotes/2026-07-18-engine-2-0-1.md
@@ -1,0 +1,22 @@
+---
+title: FutureMUD Engine 2.0.1
+summary: Fixes movement confirmations and swim-to-land posture, reconciles legacy puddles, and improves weather-controller and FutureProg builder workflows.
+date: 2026-07-18
+tags: engine, release
+---
+No additional setup is required for this update. Engine 2.0.1 keeps the .NET 10 and MySQL 8.0 requirements and the Windows x64, Linux x64, and Linux ARM64 package set from Engine 2.0.0.
+
+## Bug Fixes
+
+- Fixed forced safe-movement confirmation so both `east!` and `east !` remain confirmed when movement is rechecked at the room boundary. The confirmation still bypasses only safe-movement warnings; normal movement restrictions continue to apply.
+- Fixed swimming characters reaching land but remaining in the swimming position. They now adopt their most upright available land-movement position, with a safe fallback when no normal land posture is available.
+- Fixed rooms showing both legacy saved puddle items and the newer virtual liquid surface. Existing puddle liquid is now folded into the room surface and the old item is removed before the room contents are presented.
+- Fixed zone weather-controller assignments not being written when a zone was saved.
+
+## Builder and Documentation Improvements
+
+- Fixed weather-controller creation so regional climates and zones can be selected reliably by ID or name, including multi-word zone names. The `wc edit new` help now reflects the supported syntax.
+- Made FutureProg parameter and local-variable references case-insensitive. Authored casing is still retained for display, while duplicate parameter names that differ only by case now produce a clear compile error.
+- Restored FutureMUD colour markup in item-component summaries on the published Engine documentation pages.
+
+See `/downloads` for release archives and checksums, `/getting-started` for installation requirements, and `/docs` for the published Engine reference.

--- a/MudSharpCore/MudSharpCore.csproj
+++ b/MudSharpCore/MudSharpCore.csproj
@@ -10,9 +10,9 @@
 	<Product>FutureMUD</Product>
 	<ApplicationIcon>FM Logo.ico</ApplicationIcon>
 	<AssemblyName>MudSharp</AssemblyName>
-	<Version>2.0.0</Version>
-	<AssemblyVersion>2.0.0</AssemblyVersion>
-	<FileVersion>2.0.0</FileVersion>
+	<Version>2.0.1</Version>
+	<AssemblyVersion>2.0.1</AssemblyVersion>
+	<FileVersion>2.0.1</FileVersion>
   </PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
## Summary

- bump FutureMUD Engine `Version`, `AssemblyVersion`, and `FileVersion` to 2.0.1
- publish website-ready Engine 2.0.1 patch notes covering the changes since `engine-v2.0.0`
- retain the existing .NET 10, MySQL 8.0, and three-runtime release contract

## Validation

- `dotnet test "MudSharpCore Unit Tests\\MudSharpCore Unit Tests.csproj" -c Release --no-restore -m:1 -nr:false -p:NoWarn=NU1902%3BNU1510` — 1,703 passed
- `dotnet test "FutureMUD.Web.Tests\\FutureMUD.Web.Tests.csproj" -c Release --no-restore -m:1 -nr:false -p:NoWarn=NU1902%3BNU1510 -p:NuGetAudit=false` — 49 passed
- representative `win-x64` framework-dependent, single-file, native-bundled, untrimmed Release publish succeeded
- packaged documentation export reported Engine 2.0.1 with 414 commands, 541 prog functions, 274 prog types, 13 collection extensions, and 202 item components
- `git diff --cached --check` passed before commit