### PR TITLE
Version update to 3.0.1

### DIFF
--- a/DatabaseSeeder/DatabaseSeeder.csproj
+++ b/DatabaseSeeder/DatabaseSeeder.csproj
@@ -4,9 +4,9 @@
 	<OutputType>Exe</OutputType>
 	<TargetFramework>net10.0</TargetFramework>
 	<Nullable>enable</Nullable>
-	<Version>3.0.0</Version>
-	<AssemblyVersion>3.0.0</AssemblyVersion>
-	<FileVersion>3.0.0</FileVersion>
+	<Version>3.0.1</Version>
+	<AssemblyVersion>3.0.1</AssemblyVersion>
+	<FileVersion>3.0.1</FileVersion>
   </PropertyGroup>
 
 	<PropertyGroup>

--- a/DatabaseSeeder/Seeders/ChargenFreeKnowledgeProgReconciler.cs
+++ b/DatabaseSeeder/Seeders/ChargenFreeKnowledgeProgReconciler.cs
@@ -144,12 +144,18 @@ internal static partial class ChargenFreeKnowledgeProgReconciler
 
 	private static FutureProg? FindTargetProg(FuturemudDatabaseContext context)
 	{
+		FutureProg? tracked = context.FutureProgs.Local
+			.FirstOrDefault(x => x.FunctionName.Equals(ProgName, StringComparison.OrdinalIgnoreCase));
+		if (tracked is not null)
+		{
+			return tracked;
+		}
+
 		FutureProg? persisted = context.FutureProgs
 			.Include(x => x.FutureProgsParameters)
 			.AsEnumerable()
 			.FirstOrDefault(x => x.FunctionName.Equals(ProgName, StringComparison.OrdinalIgnoreCase));
-		return persisted ?? context.FutureProgs.Local
-			.FirstOrDefault(x => x.FunctionName.Equals(ProgName, StringComparison.OrdinalIgnoreCase));
+		return persisted;
 	}
 
 	private static bool TryValidateTargetContract(FutureProg target, out FutureProgsParameter? characterParameter,
@@ -387,14 +393,14 @@ internal static partial class ChargenFreeKnowledgeProgReconciler
 
 	private static Regex MarkerRegex(string marker)
 	{
-		return new Regex($"^[\\t ]*{Regex.Escape(marker)}[\\t ]*$",
+		return new Regex($"^[\\t ]*{Regex.Escape(marker)}[\\t ]*\\r?$",
 			RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant);
 	}
 
 	[GeneratedRegex("^[A-Za-z][A-Za-z0-9_]*$", RegexOptions.CultureInvariant)]
 	private static partial Regex UserDefinedFunctionNameRegex();
 
-	[GeneratedRegex("^[\\t ]*return[\\t ]+@knowledges[\\t ]*$",
+	[GeneratedRegex("^[\\t ]*return[\\t ]+@knowledges[\\t ]*\\r?$",
 		RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant)]
 	private static partial Regex ReturnKnowledgesRegex();
 }

--- a/FutureMUD.Web/Content/PatchNotes/2026-07-19-database-seeder-3-0-1.md
+++ b/FutureMUD.Web/Content/PatchNotes/2026-07-19-database-seeder-3-0-1.md
@@ -1,0 +1,12 @@
+---
+title: Database Seeder 3.0.1
+summary: Corrects stock character-creation knowledge grants and improves the reliability of seeded weather and rain settings.
+date: 2026-07-19
+tags: seeder, release
+---
+No additional setup is required for this update.
+
+- Corrected stock character creation so eligible medical and writing-system knowledges are granted consistently from the installed health and culture packages.
+- Added safe rerun reconciliation for those stock knowledge grants while preserving customised character-creation logic.
+- Corrected seeded weather events so cloud and precipitation severity reduce natural light by appropriate amounts.
+- Corrected the full-rain and soak-only choices so they consistently enable or disable persistent puddles as selected.


### PR DESCRIPTION
## Summary
- update DatabaseSeeder assembly, file, and package versions to 3.0.1
- publish website patch notes for the 3.0.1 Seeder fixes
- make chargen free-knowledge reconciliation idempotent for tracked progs and robust across LF/CRLF FutureProg text

## Validation
- `dotnet test 'DatabaseSeeder Unit Tests/DatabaseSeeder Unit Tests.csproj' -c Release --no-build --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510` — 557 passed
- `dotnet test 'FutureMUD.Web.Tests/FutureMUD.Web.Tests.csproj' -c Release -m:1 -p:RestoreBuildInParallel=false -p:NuGetAudit=false -p:NoWarn=NU1902%3BNU1510` — 49 passed
- blank snapshot manifest checked against latest migration (`20260708120000_HospitalClinicalPlanning`)