### PR TITLE
Consolidate virtual room surfaces and extend debug evaporation

### DIFF
--- a/Design Documents/Health/Health_System_Design.md
+++ b/Design Documents/Health/Health_System_Design.md
@@ -226,6 +226,8 @@ The health system now supports combat-driven burning via `FireProfile` and the `
 
 Liquids can now define `SurfaceReactionInfo`, loaded into `ILiquidSurfaceReaction` entries. These reactions are tag-driven and are evaluated by the surface-liquid exposure path when items or bodies become wet and when drying resolves residue creation. Ordinary wetness is no longer a scheduled saved effect; `SurfaceLiquidState` stores the mixture, residues, saturation, and last-resolved time for bodies and items.
 
+Room-scale spills use one `SurfaceLiquidState` per cell layer. The cell description owns presentation of that virtual surface so a normal room look renders it exactly once, while legacy puddle game items are consolidated into the same state before the visible item snapshot is built. The senior-admin `debug evaporate` routine dries both any remaining legacy puddle items and all loaded room-layer surface liquid; normal room-surface residue rules still apply.
+
 Each reaction can apply:
 
 - damage

--- a/MudSharpCore Unit Tests/LiquidContaminationV2SourceTests.cs
+++ b/MudSharpCore Unit Tests/LiquidContaminationV2SourceTests.cs
@@ -64,6 +64,33 @@ public class LiquidContaminationV2SourceTests
 	}
 
 	[TestMethod]
+	public void RoomLook_RendersVirtualSurfaceOnlyThroughCellDescription()
+	{
+		var cellDescription = File.ReadAllText(GetSourcePath("MudSharpCore", "Construction", "CellDescription.cs"));
+		var bodyPerception = File.ReadAllText(GetSourcePath("MudSharpCore", "Body", "Implementations", "BodyPerception.cs"));
+
+		StringAssert.Contains(cellDescription, "DescribeLiquidSurface(voyeur?.RoomLayer ?? RoomLayer.GroundLevel, voyeur, colour)");
+		Assert.IsFalse(bodyPerception.Contains("Location.DescribeLiquidSurface", StringComparison.Ordinal),
+			"The room surface is already part of Location.HowSeen and must not be appended again by the outer look routine.");
+	}
+
+	[TestMethod]
+	public void DebugEvaporate_DriesVirtualRoomSurfacesAsWellAsLegacyPuddles()
+	{
+		var staffModule = File.ReadAllText(GetSourcePath("MudSharpCore", "Commands", "Modules", "StaffModule.cs"));
+		var methodStart = staffModule.IndexOf("private static void DebugEvaporate", StringComparison.Ordinal);
+		var methodEnd = staffModule.IndexOf("private static void DebugFixBites", methodStart, StringComparison.Ordinal);
+		Assert.IsTrue(methodStart > 0);
+		Assert.IsTrue(methodEnd > methodStart);
+
+		var method = staffModule[methodStart..methodEnd];
+		StringAssert.Contains(method, "x.GetItemType<PuddleGameItemComponent>()");
+		StringAssert.Contains(method, "actor.Gameworld.Cells");
+		StringAssert.Contains(method, "x.SurfaceLiquidStates");
+		StringAssert.Contains(method, "state.Dry(state.LiquidVolume, roomSurface: true);");
+	}
+
+	[TestMethod]
 	public void EmptyOntoGround_UsesVirtualRoomSurface()
 	{
 		var manipulation = File.ReadAllText(GetSourcePath("MudSharpCore", "Commands", "Modules", "ManipulationModule.cs"));

--- a/MudSharpCore/Body/Implementations/BodyPerception.cs
+++ b/MudSharpCore/Body/Implementations/BodyPerception.cs
@@ -648,12 +648,6 @@ public partial class Body
         }
         else
         {
-            var virtualPuddleText = Location.DescribeLiquidSurface(RoomLayer, Actor, true);
-            if (!string.IsNullOrWhiteSpace(virtualPuddleText))
-            {
-                sb.AppendLine(virtualPuddleText.Wrap(InnerLineFormatLength));
-            }
-
             // Do puddle groups first
             List<PuddleGameItemComponent> puddles = items.SelectNotNull(x => x.GetItemType<PuddleGameItemComponent>()).ToList();
             List<PuddleGameItemComponent> bloodPuddles = puddles.Where(x => x.LiquidMixture.Instances.All(y => y is BloodLiquidInstance)).ToList();

--- a/MudSharpCore/Commands/Modules/StaffModule.cs
+++ b/MudSharpCore/Commands/Modules/StaffModule.cs
@@ -2432,7 +2432,7 @@ The following options are available:
 	#3debug listeners#0 - shows all listeners
 	#3debug fixmorph#0 - resets all morph timers of shop stocked items
 	#3debug fixbites#0 - resets all bite counts of shop stocked items
-	#3debug evaporate#0 - evaporate all puddles in the gameworld", AutoHelp.HelpArgOrNoArg)]
+	#3debug evaporate#0 - evaporate all legacy puddle items and virtual room-surface liquid in the gameworld", AutoHelp.HelpArgOrNoArg)]
     protected static void Debug(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -2503,16 +2503,29 @@ The following options are available:
 
     #region Debug Sub-Routines
 
-    private static void DebugEvaporate(ICharacter actor)
-    {
-        List<PuddleGameItemComponent> puddles = actor.Gameworld.Items.SelectNotNull(x => x.GetItemType<PuddleGameItemComponent>()).ToList();
-        foreach (PuddleGameItemComponent puddle in puddles)
-        {
-            puddle.ReduceLiquidQuantity(puddle.LiquidVolume, null, "debug");
-        }
+	private static void DebugEvaporate(ICharacter actor)
+	{
+		var puddles = actor.Gameworld.Items
+			.SelectNotNull(x => x.GetItemType<PuddleGameItemComponent>())
+			.ToList();
+		foreach (var puddle in puddles)
+		{
+			puddle.ReduceLiquidQuantity(puddle.LiquidVolume, null, "debug");
+		}
 
-        actor.OutputHandler.Send("Evaporated all puddles.");
-    }
+		var surfaceStates = actor.Gameworld.Cells
+			.SelectMany(x => x.SurfaceLiquidStates)
+			.Select(x => x.State)
+			.Where(x => x.IsWet)
+			.ToList();
+		foreach (var state in surfaceStates)
+		{
+			state.Dry(state.LiquidVolume, roomSurface: true);
+		}
+
+		actor.OutputHandler.Send(
+			$"Evaporated {puddles.Count.ToStringN0Colour(actor)} legacy {"puddle".Pluralise(puddles.Count != 1)} and liquid from {surfaceStates.Count.ToStringN0Colour(actor)} room {"surface".Pluralise(surfaceStates.Count != 1)}.");
+	}
 
     private static void DebugFixBites(ICharacter actor)
     {


### PR DESCRIPTION
## Summary

- Document virtual room-surface liquid rendering and legacy puddle consolidation.
- Prevent duplicate room-surface descriptions during perception.
- Extend `debug evaporate` to dry virtual room surfaces and legacy puddle items.
- Add source-level regression tests for rendering and evaporation behavior.

## Testing

- Added regression coverage in `LiquidContaminationV2SourceTests`.