### PR TITLE
Expand Renaissance household catalogue to 1,000 prototypes

### DIFF
--- a/Design Documents/Seeding/FutureMUD_Renaissance_Container_Service_Expansion_Catalogue.md
+++ b/Design Documents/Seeding/FutureMUD_Renaissance_Container_Service_Expansion_Catalogue.md
@@ -1,0 +1,83 @@
+# FutureMUD Renaissance Container and Service Expansion Catalogue Index
+
+## Scope
+
+This index governs **180 proposed prototypes** and carries the shared row, component-code, tag-code, and culture-admission contract for its linked section catalogues. The item rows are split by furniture/container family for maintainability; together the linked sections are the complete volume.
+
+No row is omitted or duplicated by the split.
+## Row contract
+
+Rows are:
+
+```text
+stable_reference|sdesc|material|size/quality|empty_weight_g/cost_farthings|exact_components|culture_code|tag_codes|variation_basis
+```
+
+Every row inherits `Era / Renaissance Era` and its exact culture tag. Components are written out rather than abbreviated in this volume. Size codes: `T=Tiny`, `VS=VerySmall`, `S=Small`, `N=Normal`, `L=Large`, `VL=VeryLarge`, `H=Huge`, `EN=Enormous`.
+
+Quality codes: `P=Poor`, `SS=Substandard`, `S=Standard`, `G=Good`, `VG=VeryGood`, `GR=Great`, `E=Excellent`.
+
+Costs are in farthings and weights are empty grams.
+
+## Tag codes
+
+| Code | Exact tags added by the row |
+| --- | --- |
+| `FU-S` | `Functions / Container`; `Functions / Household Items / Household Furniture`; `Market / Household Goods / Simple Furniture` |
+| `FU-N` | `Functions / Container`; `Functions / Household Items / Household Furniture`; `Market / Household Goods / Standard Furniture` |
+| `FU-L` | `Functions / Container`; `Functions / Household Items / Household Furniture`; `Market / Household Goods / Luxury Furniture` |
+| `TR-S` / `TR-N` / `TR-L` | Container plus simple, standard, or luxury household-wares market tag |
+| `PC-S` / `PC-N` / `PC-L` | Personal container plus simple, standard, or luxury household-wares market tag |
+| `DW-S` / `DW-N` / `DW-L` | Domestic container/ware plus simple, standard, or luxury household-wares market tag |
+| `OPEN` | `Functions / Container / Open Container` |
+| `WATER` | `Functions / Container / Watertight Container` |
+| `POROUS` | `Functions / Container / Porous Container` |
+| `MIL` | `Market / Military Goods` |
+| `COURT`, `RELIGIOUS`, `GUILD`, `MARITIME`, `PERFORMANCE`, `SERVICE` | Matching live `Institution / ...` tag |
+
+## Culture codes and admission
+
+| Code | Culture grouping | Exact inherited tag | Date gate | New rows |
+| --- | --- | --- | ---: | ---: |
+| `WER` | Western European Renaissance | `Culture / Renaissance / Shared / Western European Renaissance` | 1450-1600 | 37 |
+| `IBA` | Iberian Atlantic | `Culture / Renaissance / Shared / Iberian Atlantic` | 1450-1600 | 30 |
+| `CEN` | Central European | `Culture / Renaissance / Shared / Central European` | 1450-1600 | 29 |
+| `NBA` | Northern Baltic | `Culture / Renaissance / Shared / Northern Baltic` | 1450-1600 | 19 |
+| `CEF` | Central Eastern Frontier | `Culture / Renaissance / Shared / Central Eastern Frontier` | 1500-1600 | 19 |
+| `EON` | Eastern Orthodox Northern | `Culture / Renaissance / Shared / Eastern Orthodox Northern` | 1500-1600 | 19 |
+| `OTT` | Ottoman Islamicate | `Culture / Renaissance / Shared / Ottoman Islamicate` | 1450-1600 | 31 |
+| `PIP` | Persianate Indo-Persian | `Culture / Renaissance / Shared / Persianate Indo-Persian` | 1450-1600 | 28 |
+| `SAS` | South Asian | `Culture / Renaissance / Shared / South Asian` | 1450-1600 | 28 |
+| `EAL` | East Asian Literati | `Culture / Renaissance / Shared / East Asian Literati` | 1400-1600 | 33 |
+| `JPN` | Japanese | `Culture / Renaissance / Shared / Japanese` | 1450-1600 | 29 |
+| `MEA` | Maritime East Asian | `Culture / Renaissance / Shared / Maritime East Asian` | 1450-1600 | 18 |
+| `SEM` | South-east Asian Mainland | `Culture / Renaissance / Shared / South-east Asian Mainland` | 1450-1600 | 18 |
+| `MSEA` | Maritime South-east Asian | `Culture / Renaissance / Shared / Maritime South-east Asian` | 1450-1600 | 23 |
+| `STP` | Steppe and Caravan | `Culture / Renaissance / Shared / Steppe and Caravan` | 1450-1600 | 19 |
+| `ACA` | African Court Atlantic | `Culture / Renaissance / Shared / African Court Atlantic` | 1450-1600 | 23 |
+| `SAI` | Sahelian Islamic | `Culture / Renaissance / Shared / Sahelian Islamic` | 1450-1600 | 17 |
+| `RSE` | Red Sea | `Culture / Renaissance / Shared / Red Sea` | 1450-1600 | 17 |
+| `IND` | Indian Ocean | `Culture / Renaissance / Shared / Indian Ocean` | 1450-1600 | 23 |
+| `MES` | Mesoamerican | `Culture / Renaissance / Shared / Mesoamerican` | 1400-1600 | 19 |
+| `AND` | Andean | `Culture / Renaissance / Shared / Andean` | 1400-1600 | 19 |
+| `CAR` | Caribbean Contact | `Culture / Renaissance / Shared / Caribbean Contact` | 1450-1600 | 15 |
+| `NAC` | North American Contact | `Culture / Renaissance / Shared / North American Contact` | 1450-1600 | 15 |
+| `COL` | Colonial Atlantic | `Culture / Renaissance / Shared / Colonial Atlantic` | 1500-1600 | 28 |
+| `MAR` | Global Maritime | `Culture / Renaissance / Shared / Global Maritime` | 1450-1600 | 44 |
+
+## Catalogue sections
+
+| Section | Rows | File |
+| --- | ---: | --- |
+| Trade and institutional containers | 65 | [FutureMUD_Renaissance_Container_Service_Expansion_Catalogue_Trade.md](./FutureMUD_Renaissance_Container_Service_Expansion_Catalogue_Trade.md) |
+| Personal containers | 45 | [FutureMUD_Renaissance_Container_Service_Expansion_Catalogue_Personal.md](./FutureMUD_Renaissance_Container_Service_Expansion_Catalogue_Personal.md) |
+| Domestic dry-service containers | 30 | [FutureMUD_Renaissance_Container_Service_Expansion_Catalogue_Domestic.md](./FutureMUD_Renaissance_Container_Service_Expansion_Catalogue_Domestic.md) |
+| Domestic and trade liquid containers | 40 | [FutureMUD_Renaissance_Container_Service_Expansion_Catalogue_Liquid.md](./FutureMUD_Renaissance_Container_Service_Expansion_Catalogue_Liquid.md) |
+
+**Volume total: 180 rows.**
+
+## Index validation
+
+- The linked files contain exactly 180 rows in the declared family split.
+- Stable references and short descriptions are unique across the complete 600-row expansion.
+- Component codes, tag codes, culture codes, size codes, and quality codes resolve through this index.

--- a/Design Documents/Seeding/FutureMUD_Renaissance_Container_Service_Expansion_Catalogue_Domestic.md
+++ b/Design Documents/Seeding/FutureMUD_Renaissance_Container_Service_Expansion_Catalogue_Domestic.md
@@ -1,0 +1,48 @@
+# Domestic dry-service containers — Renaissance expansion section
+
+> Parent contract: [FutureMUD_Renaissance_Container_Service_Expansion_Catalogue.md](./FutureMUD_Renaissance_Container_Service_Expansion_Catalogue.md)
+
+This section contains **30 proposed prototypes**. Component codes, culture codes, tag codes, size/quality abbreviations, admission rules, and portability rules are defined by the parent index and the expansion manifest.
+
+## Domestic dry-service containers — 30
+
+Rows expand divided boxes, lidded baskets/hampers, trays, platters, caddies, and fitted table-service storage.
+
+```text
+renaissance_container_expansion_wer_domestic_lidded_food_basket_01|a willow bedchamber lidded food basket|willow|N/S|1210/13|Holdable;Destroyable_Furniture;Container_PreIndustrial_LiddedBasket|WER|DW-N,POROUS,COURT|closable porous food basket; portable
+renaissance_container_expansion_iba_domestic_household_platter_02|a plain copper household platter|copper|S/S|980/19|Holdable;Destroyable_HeavyMetal;Container_Plate|IBA|DW-N,OPEN,RELIGIOUS|open plate-like serving capacity; portable
+renaissance_container_expansion_iba_domestic_table_service_box_01|a pewter banquet table service box|pewter|S/SS|1010/9|Holdable;Destroyable_HeavyMetal;Container_Archive_Box|IBA|DW-S|portable service-set storage; portable
+renaissance_container_expansion_cen_domestic_condiment_box_02|an oak workshop compartmented condiment box|oak|S/GR|520/36|Holdable;Destroyable_Furniture;Container_PreIndustrial_CompartmentBox|CEN|DW-L|small divided household storage; portable
+renaissance_container_expansion_cen_domestic_lidded_food_basket_01|a wicker household lidded food basket|wicker|N/G|1300/15|Holdable;Destroyable_Furniture;Container_PreIndustrial_LiddedBasket|CEN|DW-N,POROUS,COURT|closable porous food basket; portable
+renaissance_container_expansion_nba_domestic_bread_basket_01|a plaited willow hall-service bread basket|willow|N/VG|1110/33|Holdable;Destroyable_Furniture;Container_PreIndustrial_LiddedBasket|NBA|DW-L,POROUS|closable porous bread storage; portable
+renaissance_container_expansion_ott_domestic_serving_tray_01|a painted boxwood coffee-service serving tray|boxwood|S/S|680/11|Holdable;Destroyable_Furniture;Container_Tray|OTT|DW-N,OPEN|open serving surface; portable
+renaissance_container_expansion_pip_domestic_condiment_box_02|a copper household compartmented condiment box|copper|S/S|1200/17|Holdable;Destroyable_HeavyMetal;Container_PreIndustrial_CompartmentBox|PIP|DW-N,GUILD|small divided household storage; portable
+renaissance_container_expansion_pip_domestic_serving_tray_01|a carved carved cedar household serving tray|cedar|N/G|1580/37|Holdable;Destroyable_Furniture;Container_Tray|PIP|DW-N,OPEN,GUILD|open serving surface; portable
+renaissance_container_expansion_sas_domestic_household_platter_01|an incised earthenware household platter|earthenware|S/VG|990/17|Holdable;Destroyable_Glassware;Container_Plate|SAS|DW-L,OPEN,SERVICE|open plate-like serving capacity; portable
+renaissance_container_expansion_eal_domestic_serving_tray_01|a carved lacquer household serving tray|lacquer|S/G|680/21|Holdable;Destroyable_Furniture;Container_Tray|EAL|DW-N,OPEN|open serving surface; portable
+renaissance_container_expansion_jpn_domestic_tea_herb_caddy_01|a bamboo household tea or herb caddy|bamboo|VS/S|90/2|Holdable;Destroyable_Furniture;Container_Seal_Box|JPN|DW-N|small close-fitted dry storage; portable
+renaissance_container_expansion_sem_domestic_table_service_box_01|a teak household table service box|teak|N/G|2350/51|Holdable;Destroyable_Furniture;Container_Archive_Box|SEM|DW-N|portable service-set storage; portable
+renaissance_container_expansion_msea_domestic_condiment_box_03|a brass betel-service compartmented condiment box|brass|S/VG|1070/44|Holdable;Destroyable_HeavyMetal;Container_PreIndustrial_CompartmentBox|MSEA|DW-L,MARITIME|small divided household storage; portable
+renaissance_container_expansion_msea_domestic_tea_herb_caddy_02|a bronze household tea or herb caddy|bronze|S/S|970/22|Holdable;Destroyable_HeavyMetal;Container_Seal_Box|MSEA|DW-N,RELIGIOUS|small close-fitted dry storage; portable
+renaissance_container_expansion_msea_domestic_utensil_case_01|an iron-banded bronze banquet utensil case|bronze|S/S|930/21|Holdable;Destroyable_HeavyMetal;Container_PreIndustrial_CompartmentBox|MSEA|DW-N,RELIGIOUS|fitted household utensil storage; portable
+renaissance_container_expansion_aca_domestic_household_hamper_01|a reed ritual deep household hamper|reed|L/S|4020/20|Holdable;Destroyable_Furniture;Container_PreIndustrial_LiddedHamper|ACA|DW-N,POROUS|large closable household hamper; portable
+renaissance_container_expansion_aca_domestic_utensil_case_02|a chased bronze ritual utensil case|bronze|N/GR|3490/167|Holdable;Destroyable_HeavyMetal;Container_PreIndustrial_CompartmentBox|ACA|DW-L|fitted household utensil storage; portable
+renaissance_container_expansion_sai_domestic_condiment_box_02|a cedar caravan compartmented condiment box|cedar|VS/P|130/2|Holdable;Destroyable_Furniture;Container_PreIndustrial_CompartmentBox|SAI|DW-S|small divided household storage; portable
+renaissance_container_expansion_sai_domestic_table_service_box_01|a wrought-iron court table service box|wrought iron|S/S|1090/20|Holdable;Destroyable_HeavyMetal;Container_Archive_Box|SAI|DW-N,GUILD|portable service-set storage; portable
+renaissance_container_expansion_ind_domestic_serving_tray_01|an incised ceramic guest-service serving tray|ceramic|N/G|3730/39|Holdable;Destroyable_Glassware;Container_Tray|IND|DW-N,OPEN|open serving surface; portable
+renaissance_container_expansion_ind_domestic_serving_tray_02|a moulded stoneware banquet serving tray|stoneware|S/G|920/15|Holdable;Destroyable_Glassware;Container_Tray|IND|DW-N,OPEN|open serving surface; portable
+renaissance_container_expansion_ind_domestic_utensil_case_03|a riveted copper banquet utensil case|copper|S/S|1080/18|Holdable;Destroyable_HeavyMetal;Container_PreIndustrial_CompartmentBox|IND|DW-N|fitted household utensil storage; portable
+renaissance_container_expansion_mes_domestic_household_platter_01|an incised earthenware market household platter|earthenware|S/G|890/12|Holdable;Destroyable_Glassware;Container_Plate|MES|DW-N,OPEN|open plate-like serving capacity; portable
+renaissance_container_expansion_car_domestic_nested_service_tray_01|a clay contact-gift nested service tray|clay|N/S|3160/13|Holdable;Destroyable_Glassware;Container_Tray|CAR|DW-N,OPEN,COURT|broad open service surface; portable
+renaissance_container_expansion_col_domestic_condiment_box_01|a walnut assay-office compartmented condiment box|walnut|S/G|560/19|Holdable;Destroyable_Furniture;Container_PreIndustrial_CompartmentBox|COL|DW-N,GUILD|small divided household storage; portable
+renaissance_container_expansion_col_domestic_serving_tray_02|a carved cedar household serving tray|cedar|N/SS|2100/14|Holdable;Destroyable_Furniture;Container_Tray|COL|DW-S,OPEN,RELIGIOUS|open serving surface; portable
+renaissance_container_expansion_mar_domestic_condiment_box_02|a cedar cabin-service compartmented condiment box|cedar|VS/S|140/4|Holdable;Destroyable_Furniture;Container_PreIndustrial_CompartmentBox|MAR|DW-N|small divided household storage; portable
+renaissance_container_expansion_mar_domestic_lidded_food_basket_01|a willow victualling lidded food basket|willow|N/G|1090/18|Holdable;Destroyable_Furniture;Container_PreIndustrial_LiddedBasket|MAR|DW-N,POROUS|closable porous food basket; portable
+renaissance_container_expansion_mar_domestic_table_service_box_03|a wrought-iron cabin-service table service box|wrought iron|S/G|950/29|Holdable;Destroyable_HeavyMetal;Container_Archive_Box|MAR|DW-N|portable service-set storage; portable
+```
+
+## Section validation
+
+- 30 rows and 30 unique stable references.
+- Rows inherit `Era / Renaissance Era` and the exact culture tag identified by their culture code.
+- No full descriptions are supplied in this pass.

--- a/Design Documents/Seeding/FutureMUD_Renaissance_Container_Service_Expansion_Catalogue_Liquid.md
+++ b/Design Documents/Seeding/FutureMUD_Renaissance_Container_Service_Expansion_Catalogue_Liquid.md
@@ -1,0 +1,58 @@
+# Domestic and trade liquid containers — Renaissance expansion section
+
+> Parent contract: [FutureMUD_Renaissance_Container_Service_Expansion_Catalogue.md](./FutureMUD_Renaissance_Container_Service_Expansion_Catalogue.md)
+
+This section contains **40 proposed prototypes**. Component codes, culture codes, tag codes, size/quality abbreviations, admission rules, and portability rules are defined by the parent index and the expansion manifest.
+
+## Domestic and trade liquid containers — 40
+
+Rows span 150 ml cups through 500 L vats. Ordinary vessels are finite and never use self-refilling `WaterSource` behaviour.
+
+```text
+renaissance_container_expansion_wer_liquid_drinking_beaker_02|a mould-blown glass wine drinking beaker|glass|VS/G|240/9|Holdable;Destroyable_Glassware;LContainer_DrinkingGlass|WER|DW-N,WATER,COURT|ordinary open drinking capacity; portable
+renaissance_container_expansion_wer_liquid_pouring_ewer_01|a riveted copper ale pouring ewer|copper|N/G|4450/63|Holdable;Destroyable_HeavyMetal;LContainer_PreIndustrial_Ewer_2L|WER|DW-N,WATER|2-litre pouring capacity; portable
+renaissance_container_expansion_iba_liquid_washing_basin_01|a cast copper olive-oil washing basin|copper|L/S|18060/93|Holdable;Destroyable_HeavyMetal;LContainer_PreIndustrial_Basin_5L|IBA|DW-N,WATER|5-litre open basin; portable
+renaissance_container_expansion_cen_liquid_medium_storage_jar_02|a stoneware beer medium storage jar|stoneware|L/S|12620/52|Holdable;Destroyable_Glassware;LContainer_PreIndustrial_StorageJar_12L|CEN|DW-N,WATER|12-litre closable storage jar; portable
+renaissance_container_expansion_cen_liquid_small_footed_cup_01|a glass vinegar small footed cup|glass|VS/G|250/11|Holdable;Destroyable_Glassware;LContainer_SmallWineGlass|CEN|DW-N,WATER|small footed drinking capacity; portable
+renaissance_container_expansion_nba_liquid_large_pitcher_01|a salt-glazed earthenware water large pitcher|earthenware|L/S|14570/44|Holdable;Destroyable_Glassware;LContainer_PreIndustrial_Pitcher_4L|NBA|DW-N,WATER,MARITIME|4-litre pouring capacity; portable
+renaissance_container_expansion_cef_liquid_small_footed_cup_01|a glass wine small footed cup|glass|VS/G|240/10|Holdable;Destroyable_Glassware;LContainer_SmallWineGlass|CEF|DW-N,WATER,COURT|small footed drinking capacity; portable
+renaissance_container_expansion_eon_liquid_small_footed_cup_01|a glass lamp-oil small footed cup|glass|VS/S|290/6|Holdable;Destroyable_Glassware;LContainer_SmallWineGlass|EON|DW-N,WATER|small footed drinking capacity; portable
+renaissance_container_expansion_ott_liquid_great_storage_vat_03|a copper rosewater great storage vat|copper|EN/S|381500/665|Destroyable_HeavyMetal;LContainer_PreIndustrial_Vat_500L|OTT|DW-N,WATER|500-litre fixed open vat; fixed fixture
+renaissance_container_expansion_ott_liquid_household_pot_01|a mould-blown glass rosewater household pot|glass|L/G|13340/113|Holdable;Destroyable_Glassware;LContainer_PreIndustrial_Pot_12L|OTT|DW-N,WATER|12-litre open pot; portable
+renaissance_container_expansion_ott_liquid_medium_storage_jar_02|a glass sherbet medium storage jar|glass|L/S|15190/76|Holdable;Destroyable_Glassware;LContainer_PreIndustrial_StorageJar_12L|OTT|DW-N,WATER,GUILD|12-litre closable storage jar; portable
+renaissance_container_expansion_sas_liquid_great_storage_vat_04|a teak oil great storage vat|teak|H/S|107600/343|Destroyable_Furniture;LContainer_PreIndustrial_Vat_500L|SAS|DW-N,WATER|500-litre fixed open vat; fixed fixture
+renaissance_container_expansion_sas_liquid_household_rundlet_02|a lacquered teak water household rundlet|teak|L/S|9140/73|Holdable;Destroyable_Furniture;LContainer_Rundlet|SAS|DW-N,WATER|small coopered liquid capacity; portable
+renaissance_container_expansion_sas_liquid_small_drinking_cup_01|a brass ghee small drinking cup|brass|VS/VG|280/19|Holdable;Destroyable_HeavyMetal;LContainer_PreIndustrial_Cup_150ml|SAS|DW-L,WATER|150-millilitre open cup; portable
+renaissance_container_expansion_sas_liquid_small_footed_cup_03|a glass ghee small footed cup|glass|T/SS|80/2|Holdable;Destroyable_Glassware;LContainer_SmallWineGlass|SAS|DW-S,WATER,RELIGIOUS|small footed drinking capacity; portable
+renaissance_container_expansion_eal_liquid_household_rundlet_03|a plain cypress wine household rundlet|cypress|L/S|7170/55|Holdable;Destroyable_Furniture;LContainer_Rundlet|EAL|DW-N,WATER|small coopered liquid capacity; portable
+renaissance_container_expansion_eal_liquid_medium_storage_jar_02|a porcelain tea medium storage jar|porcelain|L/S|13480/91|Holdable;Destroyable_Glassware;LContainer_PreIndustrial_StorageJar_12L|EAL|DW-N,WATER|12-litre closable storage jar; portable
+renaissance_container_expansion_eal_liquid_small_drinking_cup_01|a bamboo wine small drinking cup|bamboo|VS/G|100/4|Holdable;Destroyable_Furniture;LContainer_PreIndustrial_Cup_150ml|EAL|DW-N,WATER,GUILD|150-millilitre open cup; portable
+renaissance_container_expansion_jpn_liquid_pouring_ewer_01|a polished lacquer tea pouring ewer|lacquer|N/SS|2680/28|Holdable;Destroyable_Furniture;LContainer_PreIndustrial_Ewer_2L|JPN|DW-S,WATER,GUILD|2-litre pouring capacity; portable
+renaissance_container_expansion_jpn_liquid_stoppered_bottle_02|a wheel-cut glass vinegar stoppered bottle|glass|S/G|1180/26|Holdable;Destroyable_Glassware;LContainer_WineBottle|JPN|DW-N,WATER|bottle-sized closable liquid capacity; portable
+renaissance_container_expansion_mea_liquid_great_storage_vat_01|a cedar water great storage vat|cedar|EN/S|168600/433|Destroyable_Furniture;LContainer_PreIndustrial_Vat_500L|MEA|DW-N,WATER|500-litre fixed open vat; fixed fixture
+renaissance_container_expansion_mea_liquid_great_storage_vat_02|a cypress scent-water great storage vat|cypress|EN/S|179890/417|Destroyable_Furniture;LContainer_PreIndustrial_Vat_500L|MEA|DW-N,WATER|500-litre fixed open vat; fixed fixture
+renaissance_container_expansion_sem_liquid_stoppered_flask_01|a riveted bronze syrup stoppered flask|bronze|S/P|1180/10|Holdable;Destroyable_HeavyMetal;LContainer_Flask|SEM|DW-S,WATER|small closable liquid capacity; portable
+renaissance_container_expansion_stp_liquid_large_storage_jar_01|a brass fermented milk large storage jar|brass|VL/G|39270/437|Holdable;Destroyable_HeavyMetal;LContainer_PreIndustrial_StorageJar_30L|STP|DW-N,WATER|30-litre closable storage jar; portable
+renaissance_container_expansion_stp_liquid_small_drinking_cup_02|a copper oil small drinking cup|copper|VS/S|280/7|Holdable;Destroyable_HeavyMetal;LContainer_PreIndustrial_Cup_150ml|STP|DW-N,WATER|150-millilitre open cup; portable
+renaissance_container_expansion_aca_liquid_pouring_ewer_01|a glazed earthenware water pouring ewer|earthenware|N/S|4210/20|Holdable;Destroyable_Glassware;LContainer_PreIndustrial_Ewer_2L|ACA|DW-N,WATER|2-litre pouring capacity; portable
+renaissance_container_expansion_sai_liquid_great_storage_vat_01|a wood medicine great storage vat|wood|H/S|97150/254|Destroyable_Furniture;LContainer_PreIndustrial_Vat_500L|SAI|DW-N,WATER|500-litre fixed open vat; fixed fixture
+renaissance_container_expansion_rse_liquid_stoppered_flask_01|a burnished copper wine stoppered flask|copper|S/S|1170/17|Holdable;Destroyable_HeavyMetal;LContainer_Flask|RSE|DW-N,WATER,MARITIME|small closable liquid capacity; portable
+renaissance_container_expansion_ind_liquid_medium_storage_jar_01|an earthenware syrup medium storage jar|earthenware|L/S|15550/49|Holdable;Destroyable_Glassware;LContainer_PreIndustrial_StorageJar_12L|IND|DW-N,WATER,GUILD|12-litre closable storage jar; portable
+renaissance_container_expansion_mes_liquid_small_footed_cup_01|a wood water small footed cup|wood|T/S|50/2|Holdable;Destroyable_Furniture;LContainer_SmallWineGlass|MES|DW-N,WATER|small footed drinking capacity; portable
+renaissance_container_expansion_mes_liquid_washing_basin_02|a clay honey drink washing basin|clay|N/S|3640/13|Holdable;Destroyable_Glassware;LContainer_PreIndustrial_Basin_5L|MES|DW-N,WATER|5-litre open basin; portable
+renaissance_container_expansion_and_liquid_pouring_ewer_01|a wood herbal drink pouring ewer|wood|N/G|2150/36|Holdable;Destroyable_Furniture;LContainer_PreIndustrial_Ewer_2L|AND|DW-N,WATER,SERVICE|2-litre pouring capacity; portable
+renaissance_container_expansion_car_liquid_large_pitcher_02|a burnished clay cassava-drink large pitcher|clay|N/S|4170/15|Holdable;Destroyable_Glassware;LContainer_PreIndustrial_Pitcher_4L|CAR|DW-N,WATER|4-litre pouring capacity; portable
+renaissance_container_expansion_car_liquid_medium_storage_jar_01|an earthenware fruit drink medium storage jar|earthenware|L/G|13270/65|Holdable;Destroyable_Glassware;LContainer_PreIndustrial_StorageJar_12L|CAR|DW-N,WATER|12-litre closable storage jar; portable
+renaissance_container_expansion_nac_liquid_household_pot_02|a carved wood water household pot|wood|L/S|9510/61|Holdable;Destroyable_Furniture;LContainer_PreIndustrial_Pot_12L|NAC|DW-N,WATER|12-litre open pot; portable
+renaissance_container_expansion_nac_liquid_pouring_ewer_01|a plain wood water pouring ewer|wood|N/G|2210/36|Holdable;Destroyable_Furniture;LContainer_PreIndustrial_Ewer_2L|NAC|DW-N,WATER|2-litre pouring capacity; portable
+renaissance_container_expansion_col_liquid_large_storage_jar_01|a copper wine large storage jar|copper|VL/S|41170/183|Holdable;Destroyable_HeavyMetal;LContainer_PreIndustrial_StorageJar_30L|COL|DW-N,WATER,RELIGIOUS|30-litre closable storage jar; portable
+renaissance_container_expansion_col_liquid_washing_basin_02|a painted stoneware wine washing basin|stoneware|N/S|3520/21|Holdable;Destroyable_Glassware;LContainer_PreIndustrial_Basin_5L|COL|DW-N,WATER,RELIGIOUS|5-litre open basin; portable
+renaissance_container_expansion_mar_liquid_drinking_beaker_02|a wheel-cut glass wine drinking beaker|glass|S/G|1140/24|Holdable;Destroyable_Glassware;LContainer_DrinkingGlass|MAR|DW-N,WATER|ordinary open drinking capacity; portable
+renaissance_container_expansion_mar_liquid_small_drinking_cup_01|a wrought-iron wine small drinking cup|wrought iron|VS/P|280/3|Holdable;Destroyable_HeavyMetal;LContainer_PreIndustrial_Cup_150ml|MAR|DW-S,WATER|150-millilitre open cup; portable
+```
+
+## Section validation
+
+- 40 rows and 40 unique stable references.
+- Rows inherit `Era / Renaissance Era` and the exact culture tag identified by their culture code.
+- No full descriptions are supplied in this pass.

--- a/Design Documents/Seeding/FutureMUD_Renaissance_Container_Service_Expansion_Catalogue_Personal.md
+++ b/Design Documents/Seeding/FutureMUD_Renaissance_Container_Service_Expansion_Catalogue_Personal.md
@@ -1,0 +1,63 @@
+# Personal containers — Renaissance expansion section
+
+> Parent contract: [FutureMUD_Renaissance_Container_Service_Expansion_Catalogue.md](./FutureMUD_Renaissance_Container_Service_Expansion_Catalogue.md)
+
+This section contains **45 proposed prototypes**. Component codes, culture codes, tag codes, size/quality abbreviations, admission rules, and portability rules are defined by the parent index and the expansion manifest.
+
+## Personal containers — 45
+
+Rows vary worn position, rigid or soft construction, capacity, document/scroll specialisation, basket form, and finite liquid behaviour.
+
+```text
+renaissance_container_expansion_wer_personal_fitted_belt_case_02|a copper printed-sheet fitted belt case|copper|VS/G|250/10|Holdable;Destroyable_HeavyMetal;Container_Seal_Box;Beltable|WER|PC-N,SERVICE|rigid beltable fitted storage; portable
+renaissance_container_expansion_wer_personal_scroll_case_01|a brass-capped beech printed-sheet scroll case|beech|S/S|500/9|Holdable;Destroyable_Furniture;Container_Scroll_Tube;Wear_Shoulder|WER|PC-N,SERVICE|rigid shoulder-carried roll storage; portable
+renaissance_container_expansion_iba_personal_belt_pouch_02|a plain-woven canvas scent-bottle belt pouch|canvas|VS/G|70/3|Holdable;Destroyable_Misc;Container_Pouch;Beltable|IBA|PC-N,COURT|small belt-attached storage; portable
+renaissance_container_expansion_iba_personal_portable_writing_box_03|a chestnut cacao-sample portable writing box|chestnut|N/S|1940/20|Holdable;Destroyable_Furniture;Container_Archive_Box;Wear_Shoulder|IBA|PC-N,COURT|rigid shoulder-carried writing storage; portable
+renaissance_container_expansion_iba_personal_shoulder_basket_01|a close-woven willow mission-supply shoulder basket|willow|N/S|1200/12|Holdable;Destroyable_Furniture;Container_PreIndustrial_LiddedBasket;Wear_Shoulder|IBA|PC-N,POROUS|closable shoulder-carried basket; portable
+renaissance_container_expansion_cen_personal_waterskin_sling_01|a tooled leather medicine waterskin sling|leather|S/G|490/19|Holdable;Destroyable_Misc;LContainer_Waterskin;Wear_Shoulder|CEN|PC-N,WATER|wearable finite liquid container; portable
+renaissance_container_expansion_nba_personal_shoulder_satchel_01|a quilted leather wax-parcel shoulder satchel|leather|N/S|1870/22|Holdable;Destroyable_Misc;Container_Document_Satchel;Wear_Shoulder|NBA|PC-N|shoulder-carried papers and small goods; portable
+renaissance_container_expansion_cef_personal_portable_writing_box_01|a willow wax-seal portable writing box|willow|N/S|1250/13|Holdable;Destroyable_Furniture;Container_Archive_Box;Wear_Shoulder|CEF|PC-N|rigid shoulder-carried writing storage; portable
+renaissance_container_expansion_eon_personal_document_wallet_01|a waxed canvas chancery-paper document wallet|canvas|VS/S|80/3|Holdable;Destroyable_Misc;Container_Document_Pouch;Beltable|EON|PC-N|flat beltable document capacity; portable
+renaissance_container_expansion_eon_personal_shoulder_basket_02|a plaited wicker fur-parcel shoulder basket|wicker|N/GR|1280/34|Holdable;Destroyable_Furniture;Container_PreIndustrial_LiddedBasket;Wear_Shoulder|EON|PC-L,POROUS,COURT|closable shoulder-carried basket; portable
+renaissance_container_expansion_ott_personal_document_wallet_01|an embroidered leather perfume-vial document wallet|leather|S/GR|480/39|Holdable;Destroyable_Misc;Container_Document_Pouch;Beltable|OTT|PC-L|flat beltable document capacity; portable
+renaissance_container_expansion_ott_personal_fitted_belt_case_02|a cypress chancery-paper fitted belt case|cypress|VS/S|100/4|Holdable;Destroyable_Furniture;Container_Seal_Box;Beltable|OTT|PC-N,RELIGIOUS|rigid beltable fitted storage; portable
+renaissance_container_expansion_pip_personal_back_pack_03|a waxed leather seal-matrix back pack|leather|N/G|1980/42|Holdable;Destroyable_Misc;Container_Pack;Wear_Backpack|PIP|PC-N|large back-worn storage; portable
+renaissance_container_expansion_pip_personal_shoulder_satchel_02|a waxed leather carpet-sample shoulder satchel|leather|N/G|2210/37|Holdable;Destroyable_Misc;Container_Document_Satchel;Wear_Shoulder|PIP|PC-N,COURT|shoulder-carried papers and small goods; portable
+renaissance_container_expansion_pip_personal_waist_purse_01|a doubled leather pigment waist purse|leather|S/S|500/11|Holdable;Destroyable_Misc;Container_Purse;Wear_Waist|PIP|PC-N|directly worn small-value storage; portable
+renaissance_container_expansion_sas_personal_shoulder_bag_01|a corded cotton sandalwood shoulder bag|cotton|N/S|960/12|Holdable;Destroyable_Misc;Container_Tote;Wear_Shoulder|SAS|PC-N,SERVICE|soft shoulder-carried general storage; portable
+renaissance_container_expansion_eal_personal_portable_writing_box_02|a rattan medicine-packet portable writing box|rattan|N/S|1150/12|Holdable;Destroyable_Furniture;Container_Archive_Box;Wear_Shoulder|EAL|PC-N,RELIGIOUS|rigid shoulder-carried writing storage; portable
+renaissance_container_expansion_eal_personal_shoulder_basket_03|a close-woven bamboo porcelain-sample shoulder basket|bamboo|N/S|1190/12|Holdable;Destroyable_Furniture;Container_PreIndustrial_LiddedBasket;Wear_Shoulder|EAL|PC-N,POROUS|closable shoulder-carried basket; portable
+renaissance_container_expansion_eal_personal_shoulder_basket_04|an openwork rattan book-leaf shoulder basket|rattan|N/VG|1250/25|Holdable;Destroyable_Furniture;Container_PreIndustrial_LiddedBasket;Wear_Shoulder|EAL|PC-L,POROUS,GUILD|closable shoulder-carried basket; portable
+renaissance_container_expansion_eal_personal_waterskin_sling_01|a polished wood oil waterskin sling|wood|N/SS|1880/17|Holdable;Destroyable_Furniture;LContainer_Waterskin;Wear_Shoulder|EAL|PC-S,WATER,GUILD|wearable finite liquid container; portable
+renaissance_container_expansion_jpn_personal_back_pack_01|a quilted bamboo tea-utensil back pack|bamboo|L/S|4300/28|Holdable;Destroyable_Furniture;Container_Pack;Wear_Backpack|JPN|PC-N,COURT|large back-worn storage; portable
+renaissance_container_expansion_jpn_personal_fitted_belt_case_02|a cedar medicine-packet fitted belt case|cedar|VS/G|120/6|Holdable;Destroyable_Furniture;Container_Seal_Box;Beltable|JPN|PC-N,COURT|rigid beltable fitted storage; portable
+renaissance_container_expansion_jpn_personal_shoulder_satchel_03|a waxed wood sword-fitting shoulder satchel|wood|S/S|600/10|Holdable;Destroyable_Furniture;Container_Document_Satchel;Wear_Shoulder|JPN|PC-N|shoulder-carried papers and small goods; portable
+renaissance_container_expansion_mea_personal_portable_writing_box_01|a cypress tribute-paper portable writing box|cypress|N/SS|1760/14|Holdable;Destroyable_Furniture;Container_Archive_Box;Wear_Shoulder|MEA|PC-S,MARITIME|rigid shoulder-carried writing storage; portable
+renaissance_container_expansion_mea_personal_shoulder_basket_02|a lidded rattan lacquerware-sample shoulder basket|rattan|N/S|990/11|Holdable;Destroyable_Furniture;Container_PreIndustrial_LiddedBasket;Wear_Shoulder|MEA|PC-N,POROUS,COURT|closable shoulder-carried basket; portable
+renaissance_container_expansion_sem_personal_portable_writing_box_01|a rattan silk-pattern portable writing box|rattan|N/G|1080/20|Holdable;Destroyable_Furniture;Container_Archive_Box;Wear_Shoulder|SEM|PC-N|rigid shoulder-carried writing storage; portable
+renaissance_container_expansion_msea_personal_belt_pouch_01|an embroidered leather pepper-sample belt pouch|leather|VS/S|150/5|Holdable;Destroyable_Misc;Container_Pouch;Beltable|MSEA|PC-N|small belt-attached storage; portable
+renaissance_container_expansion_stp_personal_shoulder_basket_02|a reed-bound reed arrow-fitting shoulder basket|reed|N/G|1090/13|Holdable;Destroyable_Furniture;Container_PreIndustrial_LiddedBasket;Wear_Shoulder|STP|PC-N,POROUS,COURT|closable shoulder-carried basket; portable
+renaissance_container_expansion_stp_personal_waist_purse_01|a hide-reinforced felt medicine-packet waist purse|felt|S/G|270/11|Holdable;Destroyable_Misc;Container_Purse;Wear_Waist|STP|PC-N|directly worn small-value storage; portable
+renaissance_container_expansion_aca_personal_portable_writing_box_02|a brass ivory-parcel portable writing box|brass|S/S|1010/19|Holdable;Destroyable_HeavyMetal;Container_Archive_Box;Wear_Shoulder|ACA|PC-N|rigid shoulder-carried writing storage; portable
+renaissance_container_expansion_aca_personal_waist_purse_01|an embroidered leather metal-fitting waist purse|leather|VS/G|150/8|Holdable;Destroyable_Misc;Container_Purse;Wear_Waist|ACA|PC-N,COURT|directly worn small-value storage; portable
+renaissance_container_expansion_sai_personal_sample_roll_case_01|a cedar seal-matrix sample roll case|cedar|S/S|420/10|Holdable;Destroyable_Furniture;Container_Scroll_Tube;Wear_Shoulder|SAI|PC-N,RELIGIOUS|rolled pattern or sample storage; portable
+renaissance_container_expansion_rse_personal_sample_roll_case_01|a brass scent-vial sample roll case|brass|S/S|940/20|Holdable;Destroyable_HeavyMetal;Container_Scroll_Tube;Wear_Shoulder|RSE|PC-N|rolled pattern or sample storage; portable
+renaissance_container_expansion_ind_personal_back_pack_02|a corded leather bead-lot back pack|leather|N/G|2200/40|Holdable;Destroyable_Misc;Container_Pack;Wear_Backpack|IND|PC-N,MARITIME|large back-worn storage; portable
+renaissance_container_expansion_ind_personal_document_wallet_03|a quilted cotton bead-lot document wallet|cotton|VS/S|80/2|Holdable;Destroyable_Misc;Container_Document_Pouch;Beltable|IND|PC-N|flat beltable document capacity; portable
+renaissance_container_expansion_ind_personal_waterskin_sling_01|a tooled leather wine waterskin sling|leather|N/S|1980/28|Holdable;Destroyable_Misc;LContainer_Waterskin;Wear_Shoulder|IND|PC-N,WATER,MARITIME|wearable finite liquid container; portable
+renaissance_container_expansion_mes_personal_document_wallet_02|an embroidered hide obsidian-lot document wallet|animal skin|VS/G|130/5|Holdable;Destroyable_Misc;Container_Document_Pouch;Beltable|MES|PC-N,COURT|flat beltable document capacity; portable
+renaissance_container_expansion_mes_personal_scroll_case_01|a lacquered leather shell-ornament scroll case|leather|S/G|640/19|Holdable;Destroyable_Misc;Container_Scroll_Tube;Wear_Shoulder|MES|PC-N|rigid shoulder-carried roll storage; portable
+renaissance_container_expansion_and_personal_document_wallet_02|a plain-woven leather metal-ornament document wallet|leather|VS/G|120/7|Holdable;Destroyable_Misc;Container_Document_Pouch;Beltable|AND|PC-N|flat beltable document capacity; portable
+renaissance_container_expansion_and_personal_scroll_case_03|a plain leather metal-ornament scroll case|leather|N/G|1810/39|Holdable;Destroyable_Misc;Container_Scroll_Tube;Wear_Shoulder|AND|PC-N|rigid shoulder-carried roll storage; portable
+renaissance_container_expansion_and_personal_shoulder_satchel_01|a corded wool maize-measure shoulder satchel|wool|S/G|290/9|Holdable;Destroyable_Misc;Container_Document_Satchel;Wear_Shoulder|AND|PC-N,COURT|shoulder-carried papers and small goods; portable
+renaissance_container_expansion_car_personal_shoulder_bag_01|a quilted leather cotton-lot shoulder bag|leather|N/S|1910/23|Holdable;Destroyable_Misc;Container_Tote;Wear_Shoulder|CAR|PC-N|soft shoulder-carried general storage; portable
+renaissance_container_expansion_nac_personal_waterskin_sling_01|an incised gourd-shell oil waterskin sling|gourd shell|S/G|330/6|Holdable;Destroyable_Misc;LContainer_Waterskin;Wear_Shoulder|NAC|PC-N,WATER,GUILD|wearable finite liquid container; portable
+renaissance_container_expansion_col_personal_shoulder_bag_01|a plain-woven leather tobacco-lot shoulder bag|leather|N/VG|2320/66|Holdable;Destroyable_Misc;Container_Tote;Wear_Shoulder|COL|PC-L|soft shoulder-carried general storage; portable
+renaissance_container_expansion_mar_personal_sample_roll_case_01|an oak bottle-sample roll case|oak|S/S|570/11|Holdable;Destroyable_Furniture;Container_Scroll_Tube;Wear_Shoulder|MAR|PC-N|rolled pattern or sample storage; portable
+```
+
+## Section validation
+
+- 45 rows and 45 unique stable references.
+- Rows inherit `Era / Renaissance Era` and the exact culture tag identified by their culture code.
+- No full descriptions are supplied in this pass.

--- a/Design Documents/Seeding/FutureMUD_Renaissance_Container_Service_Expansion_Catalogue_Trade.md
+++ b/Design Documents/Seeding/FutureMUD_Renaissance_Container_Service_Expansion_Catalogue_Trade.md
@@ -1,0 +1,83 @@
+# Trade and institutional containers — Renaissance expansion section
+
+> Parent contract: [FutureMUD_Renaissance_Container_Service_Expansion_Catalogue.md](./FutureMUD_Renaissance_Container_Service_Expansion_Catalogue.md)
+
+This section contains **65 proposed prototypes**. Component codes, culture codes, tag codes, size/quality abbreviations, admission rules, and portability rules are defined by the parent index and the expansion manifest.
+
+## Trade and institutional containers — 65
+
+Specialised trade forms are retained only where capacity, fitted interior, sealing, built-in lock, transport technology, or commodity-handling role differs from a shared `preindustrial_trade_*` dependency.
+
+```text
+renaissance_container_expansion_wer_trade_large_trade_cask_06|a cedar apothecary-stock large trade cask|cedar|L/S|16120/71|Holdable;Destroyable_Furniture;Container_Drum|WER|TR-N|large coopered dry-goods capacity; portable
+renaissance_container_expansion_wer_trade_lidded_trade_basket_01|a willow cloth-sample lidded trade basket|willow|N/G|1910/31|Holdable;Destroyable_Furniture;Container_PreIndustrial_LiddedBasket|WER|TR-N,POROUS,GUILD|closable porous trade basket; portable
+renaissance_container_expansion_wer_trade_locking_trade_coffer_05|a beech seal-and-weight locking trade coffer|beech|L/VG|10170/230|Holdable;Destroyable_Furniture;LockingContainer_Footlocker|WER|TR-L|built-in-lock merchant storage; portable
+renaissance_container_expansion_wer_trade_marked_commodity_sack_02|a leather apothecary-stock marked commodity sack|leather|N/VG|2700/79|Holdable;Destroyable_Misc;Container_Sack|WER|TR-L,POROUS|soft bulk trade storage; portable
+renaissance_container_expansion_wer_trade_sealable_archive_coffer_04|a cedar silk-pattern wax-sealable archive coffer|cedar|N/SS|4760/20|Holdable;Destroyable_Furniture;Container_Archive_Chest;Sealable_Container_Wax|WER|TR-S|tamper-evident archive storage; portable
+renaissance_container_expansion_wer_trade_segmented_packing_crate_03|a wicker seal-and-weight segmented packing crate|wicker|L/S|6370/32|Holdable;Destroyable_Furniture;Container_Open_Bin|WER|TR-N,OPEN,GUILD|open divided transit capacity; portable
+renaissance_container_expansion_iba_trade_lidded_trade_basket_01|a wicker silver-parcel lidded trade basket|wicker|L/S|5760/36|Holdable;Destroyable_Furniture;Container_PreIndustrial_LiddedBasket|IBA|TR-N,POROUS,RELIGIOUS|closable porous trade basket; portable
+renaissance_container_expansion_iba_trade_marked_commodity_sack_03|a canvas dyestuff marked commodity sack|canvas|L/VG|5870/113|Holdable;Destroyable_Misc;Container_Sack|IBA|TR-L,POROUS,MARITIME|soft bulk trade storage; portable
+renaissance_container_expansion_iba_trade_strong_trade_chest_02|a cedar dyestuff strong trade chest|cedar|L/G|14520/169|Holdable;Destroyable_Furniture;LockingContainer_SafeChest|IBA|TR-N,RELIGIOUS|heavy built-in-lock high-value storage; portable
+renaissance_container_expansion_cen_trade_deep_trade_hamper_03|a wicker clock-part deep trade hamper|wicker|L/S|7050/40|Holdable;Destroyable_Furniture;Container_PreIndustrial_LiddedHamper|CEN|TR-N,POROUS,COURT|large closable porous hamper; portable
+renaissance_container_expansion_cen_trade_large_trade_cask_02|an ash guild-seal large trade cask|ash|L/S|17240/78|Holdable;Destroyable_Furniture;Container_Drum|CEN|TR-N,COURT|large coopered dry-goods capacity; portable
+renaissance_container_expansion_cen_trade_strong_trade_chest_01|a brass metal-sample strong trade chest|brass|L/S|30510/225|Holdable;Destroyable_HeavyMetal;LockingContainer_SafeChest|CEN|TR-N,COURT|heavy built-in-lock high-value storage; portable
+renaissance_container_expansion_nba_trade_locking_trade_coffer_02|an oak ship-paper locking trade coffer|oak|L/E|11610/572|Holdable;Destroyable_Furniture;LockingContainer_Footlocker|NBA|TR-L,GUILD|built-in-lock merchant storage; portable
+renaissance_container_expansion_nba_trade_strong_trade_chest_01|a copper tar-sample strong trade chest|copper|L/G|29630/252|Holdable;Destroyable_HeavyMetal;LockingContainer_SafeChest|NBA|TR-N,GUILD|heavy built-in-lock high-value storage; portable
+renaissance_container_expansion_cef_trade_lidded_trade_basket_03|a wicker cloth-sample lidded trade basket|wicker|L/VG|5650/89|Holdable;Destroyable_Furniture;Container_PreIndustrial_LiddedBasket|CEF|TR-L,POROUS|closable porous trade basket; portable
+renaissance_container_expansion_cef_trade_locking_trade_coffer_01|a pewter coin-weight locking trade coffer|pewter|N/S|5010/56|Holdable;Destroyable_HeavyMetal;LockingContainer_Footlocker|CEF|TR-N,COURT|built-in-lock merchant storage; portable
+renaissance_container_expansion_cef_trade_strong_trade_chest_02|a copper wax-seal strong trade chest|copper|L/G|37930/256|Holdable;Destroyable_HeavyMetal;LockingContainer_SafeChest|CEF|TR-N,COURT|heavy built-in-lock high-value storage; portable
+renaissance_container_expansion_eon_trade_document_coffer_01|a chased brass cloth-bolt document coffer|brass|N/G|9020/110|Holdable;Destroyable_HeavyMetal;Container_Archive_Chest|EON|TR-N|archive-shaped trade storage; portable
+renaissance_container_expansion_eon_trade_large_trade_cask_02|a pine salt-sample large trade cask|pine|L/S|13410/63|Holdable;Destroyable_Furniture;Container_Drum|EON|TR-N|large coopered dry-goods capacity; portable
+renaissance_container_expansion_ott_trade_large_trade_cask_01|a walnut ceramic-sample large trade cask|walnut|L/S|16250/115|Holdable;Destroyable_Furniture;Container_Drum|OTT|TR-N|large coopered dry-goods capacity; portable
+renaissance_container_expansion_ott_trade_large_transport_jar_04|a stoneware oil large transport jar|stoneware|VL/S|43550/168|Holdable;Destroyable_Glassware;LContainer_PreIndustrial_StorageJar_30L|OTT|TR-N,WATER|30-litre closable liquid capacity; portable
+renaissance_container_expansion_ott_trade_segmented_packing_crate_02|a wicker chancery-paper segmented packing crate|wicker|N/E|1930/77|Holdable;Destroyable_Furniture;Container_Open_Bin|OTT|TR-L,OPEN|open divided transit capacity; portable
+renaissance_container_expansion_ott_trade_segmented_packing_crate_03|a reed perfume-vial segmented packing crate|reed|N/S|1750/16|Holdable;Destroyable_Furniture;Container_Open_Bin|OTT|TR-N,OPEN|open divided transit capacity; portable
+renaissance_container_expansion_pip_trade_deep_trade_hamper_03|a wicker scent-vial deep trade hamper|wicker|L/G|6930/66|Holdable;Destroyable_Furniture;Container_PreIndustrial_LiddedHamper|PIP|TR-N,POROUS|large closable porous hamper; portable
+renaissance_container_expansion_pip_trade_sealable_archive_coffer_02|a copper carpet-sample wax-sealable archive coffer|copper|N/P|8180/29|Holdable;Destroyable_HeavyMetal;Container_Archive_Chest;Sealable_Container_Wax|PIP|TR-S,COURT|tamper-evident archive storage; portable
+renaissance_container_expansion_pip_trade_transit_trunk_01|a lacquered teak pigment transit trunk|teak|L/S|19150/106|Holdable;Destroyable_Furniture;Container_Trunk|PIP|TR-N|large protected transit storage; portable
+renaissance_container_expansion_sas_trade_large_transport_jar_02|a glass rice-wash large transport jar|glass|VL/G|47900/355|Holdable;Destroyable_Glassware;LContainer_PreIndustrial_StorageJar_30L|SAS|TR-N,WATER,RELIGIOUS|30-litre closable liquid capacity; portable
+renaissance_container_expansion_sas_trade_transit_trunk_01|a riveted bronze rice-measure transit trunk|bronze|L/S|34770/140|Holdable;Destroyable_HeavyMetal;Container_Trunk|SAS|TR-N|large protected transit storage; portable
+renaissance_container_expansion_eal_trade_document_coffer_02|a lattice-fronted walnut inkstick document coffer|walnut|L/S|19460/90|Holdable;Destroyable_Furniture;Container_Archive_Chest|EAL|TR-N|archive-shaped trade storage; portable
+renaissance_container_expansion_eal_trade_liquid_transport_rundlet_01|a walnut medicine liquid transport rundlet|walnut|L/S|11870/96|Holdable;Destroyable_Furniture;LContainer_Rundlet|EAL|TR-N,WATER|finite small-cask liquid capacity; portable
+renaissance_container_expansion_jpn_trade_sample_lockbox_01|a plain-joined cedar medicine-packet sample lockbox|cedar|S/S|790/17|Holdable;Destroyable_Furniture;LockingContainer_Lockbox|JPN|TR-N|small built-in-lock sample storage; portable
+renaissance_container_expansion_jpn_trade_transit_trunk_02|a low cedar sword-fitting transit trunk|cedar|L/S|14850/76|Holdable;Destroyable_Furniture;Container_Trunk|JPN|TR-N,RELIGIOUS|large protected transit storage; portable
+renaissance_container_expansion_mea_trade_deep_trade_hamper_01|a rattan ceramic-sample deep trade hamper|rattan|L/S|7070/37|Holdable;Destroyable_Furniture;Container_PreIndustrial_LiddedHamper|MEA|TR-N,POROUS,COURT|large closable porous hamper; portable
+renaissance_container_expansion_sem_trade_deep_trade_hamper_01|a bamboo lacquerware deep trade hamper|bamboo|L/P|6120/20|Holdable;Destroyable_Furniture;Container_PreIndustrial_LiddedHamper|SEM|TR-S,POROUS,RELIGIOUS|large closable porous hamper; portable
+renaissance_container_expansion_sem_trade_large_transport_jar_02|a copper water large transport jar|copper|VL/S|50440/295|Holdable;Destroyable_HeavyMetal;LContainer_PreIndustrial_StorageJar_30L|SEM|TR-N,WATER|30-litre closable liquid capacity; portable
+renaissance_container_expansion_msea_trade_large_transport_jar_03|a bronze palm-wine large transport jar|bronze|VL/P|54050/139|Holdable;Destroyable_HeavyMetal;LContainer_PreIndustrial_StorageJar_30L|MSEA|TR-S,WATER,GUILD|30-litre closable liquid capacity; portable
+renaissance_container_expansion_msea_trade_sealed_transport_jar_01|a glass water sealed transport jar|glass|L/VG|19050/216|Holdable;Destroyable_Glassware;LContainer_PreIndustrial_StorageJar_12L|MSEA|TR-L,WATER,MARITIME|12-litre closable liquid capacity; portable
+renaissance_container_expansion_msea_trade_transit_trunk_02|an iron-banded bronze ceramic-sample transit trunk|bronze|L/P|37970/71|Holdable;Destroyable_HeavyMetal;Container_Trunk|MSEA|TR-S,MARITIME|large protected transit storage; portable
+renaissance_container_expansion_stp_trade_locking_trade_coffer_01|a birch horse-gear locking trade coffer|birch|L/S|9750/81|Holdable;Destroyable_Furniture;LockingContainer_Footlocker|STP|TR-N|built-in-lock merchant storage; portable
+renaissance_container_expansion_aca_trade_locking_trade_coffer_02|an ebony textile-pattern locking trade coffer|ebony|L/S|11670/217|Holdable;Destroyable_Furniture;LockingContainer_Footlocker|ACA|TR-N|built-in-lock merchant storage; portable
+renaissance_container_expansion_aca_trade_small_trade_keg_01|a wood brassweight small trade keg|wood|L/G|9970/103|Holdable;Destroyable_Furniture;Container_Small_Drum|ACA|TR-N,GUILD|small coopered dry-goods capacity; portable
+renaissance_container_expansion_sai_trade_liquid_transport_rundlet_01|a cedar milk liquid transport rundlet|cedar|L/S|10020/75|Holdable;Destroyable_Furniture;LContainer_Rundlet|SAI|TR-N,WATER|finite small-cask liquid capacity; portable
+renaissance_container_expansion_rse_trade_large_trade_cask_02|a cedar salt-sample large trade cask|cedar|L/G|16320/102|Holdable;Destroyable_Furniture;Container_Drum|RSE|TR-N|large coopered dry-goods capacity; portable
+renaissance_container_expansion_rse_trade_sample_lockbox_01|a hammered copper cloth-pattern sample lockbox|copper|S/S|1760/37|Holdable;Destroyable_HeavyMetal;LockingContainer_Lockbox|RSE|TR-N|small built-in-lock sample storage; portable
+renaissance_container_expansion_rse_trade_strong_trade_chest_03|a wood ivory-parcel strong trade chest|wood|VL/S|44650/197|Holdable;Destroyable_Furniture;LockingContainer_SafeChest|RSE|TR-N|heavy built-in-lock high-value storage; portable
+renaissance_container_expansion_mes_trade_large_trade_cask_01|a cedar feather-lot large trade cask|cedar|L/G|17420/122|Holdable;Destroyable_Furniture;Container_Drum|MES|TR-N|large coopered dry-goods capacity; portable
+renaissance_container_expansion_and_trade_document_coffer_01|a lashed leather camelid-cloth document coffer|leather|L/GR|20500/282|Holdable;Destroyable_Misc;Container_Archive_Chest|AND|TR-L,SERVICE|archive-shaped trade storage; portable
+renaissance_container_expansion_and_trade_large_transport_jar_02|a clay medicine large transport jar|clay|VL/G|37690/142|Holdable;Destroyable_Glassware;LContainer_PreIndustrial_StorageJar_30L|AND|TR-N,WATER,COURT|30-litre closable liquid capacity; portable
+renaissance_container_expansion_car_trade_deep_trade_hamper_01|a cane contact-bead deep trade hamper|cane|L/VG|7070/86|Holdable;Destroyable_Furniture;Container_PreIndustrial_LiddedHamper|CAR|TR-L,POROUS,COURT|large closable porous hamper; portable
+renaissance_container_expansion_nac_trade_fitted_sample_case_01|a birch trade-cloth fitted sample case|birch|S/S|790/12|Holdable;Destroyable_Furniture;Container_PreIndustrial_CompartmentBox|NAC|TR-N,GUILD|fitted small-lot capacity; portable
+renaissance_container_expansion_nac_trade_segmented_packing_crate_02|a wood shell-bead segmented packing crate|wood|N/S|3460/35|Holdable;Destroyable_Furniture;Container_Open_Bin|NAC|TR-N,OPEN|open divided transit capacity; portable
+renaissance_container_expansion_col_trade_fitted_sample_case_01|an oak tobacco-lot fitted sample case|oak|S/SS|850/11|Holdable;Destroyable_Furniture;Container_PreIndustrial_CompartmentBox|COL|TR-S|fitted small-lot capacity; portable
+renaissance_container_expansion_col_trade_large_transport_jar_04|a glass water large transport jar|glass|VL/S|41570/208|Holdable;Destroyable_Glassware;LContainer_PreIndustrial_StorageJar_30L|COL|TR-N,WATER|30-litre closable liquid capacity; portable
+renaissance_container_expansion_col_trade_marked_commodity_sack_03|a leather sugar-sample marked commodity sack|leather|L/G|10740/129|Holdable;Destroyable_Misc;Container_Sack|COL|TR-N,POROUS,MARITIME|soft bulk trade storage; portable
+renaissance_container_expansion_col_trade_segmented_packing_crate_02|a pine iron-tool segmented packing crate|pine|N/VG|2530/61|Holdable;Destroyable_Furniture;Container_Open_Bin|COL|TR-L,OPEN,GUILD|open divided transit capacity; portable
+renaissance_container_expansion_mar_trade_fitted_sample_case_06|a pewter cloth-sample fitted sample case|pewter|N/S|5260/50|Holdable;Destroyable_HeavyMetal;Container_PreIndustrial_CompartmentBox|MAR|TR-N|fitted small-lot capacity; portable
+renaissance_container_expansion_mar_trade_large_trade_cask_09|an oak spice-sample large trade cask|oak|VL/G|44000/291|Holdable;Destroyable_Furniture;Container_Drum|MAR|TR-N,GUILD|large coopered dry-goods capacity; portable
+renaissance_container_expansion_mar_trade_large_trade_cask_10|a cedar bottle-sample large trade cask|cedar|VL/S|33470/167|Holdable;Destroyable_Furniture;Container_Drum|MAR|TR-N,GUILD|large coopered dry-goods capacity; portable
+renaissance_container_expansion_mar_trade_lidded_trade_basket_04|a close-woven willow cloth-sample lidded trade basket|willow|L/G|6780/64|Holdable;Destroyable_Furniture;Container_PreIndustrial_LiddedBasket|MAR|TR-N,POROUS|closable porous trade basket; portable
+renaissance_container_expansion_mar_trade_sealable_archive_coffer_07|a pine spice-sample wax-sealable archive coffer|pine|L/VG|14100/138|Holdable;Destroyable_Furniture;Container_Archive_Chest;Sealable_Container_Wax|MAR|TR-L|tamper-evident archive storage; portable
+renaissance_container_expansion_mar_trade_sealed_transport_jar_08|a brass wine sealed transport jar|brass|L/S|20600/151|Holdable;Destroyable_HeavyMetal;LContainer_PreIndustrial_StorageJar_12L|MAR|TR-N,WATER,GUILD|12-litre closable liquid capacity; portable
+renaissance_container_expansion_mar_trade_segmented_packing_crate_03|a pine ship-medicine segmented packing crate|pine|N/G|2680/40|Holdable;Destroyable_Furniture;Container_Open_Bin|MAR|TR-N,OPEN|open divided transit capacity; portable
+renaissance_container_expansion_mar_trade_small_trade_keg_01|a teak cloth-sample small trade keg|teak|L/G|11520/180|Holdable;Destroyable_Furniture;Container_Small_Drum|MAR|TR-N,GUILD|small coopered dry-goods capacity; portable
+renaissance_container_expansion_mar_trade_strong_trade_chest_05|a cedar spice-sample strong trade chest|cedar|L/G|16840/143|Holdable;Destroyable_Furniture;LockingContainer_SafeChest|MAR|TR-N|heavy built-in-lock high-value storage; portable
+renaissance_container_expansion_mar_trade_transit_trunk_02|a slotted leather chart-roll transit trunk|leather|L/S|18700/81|Holdable;Destroyable_Misc;Container_Trunk|MAR|TR-N|large protected transit storage; portable
+```
+
+## Section validation
+
+- 65 rows and 65 unique stable references.
+- Rows inherit `Era / Renaissance Era` and the exact culture tag identified by their culture code.
+- No full descriptions are supplied in this pass.

--- a/Design Documents/Seeding/FutureMUD_Renaissance_Household_Expansion_Dependency_Request.md
+++ b/Design Documents/Seeding/FutureMUD_Renaissance_Household_Expansion_Dependency_Request.md
@@ -1,0 +1,51 @@
+# FutureMUD Renaissance Household Expansion Dependency Request
+
+## Purpose
+
+This addendum records the new reusable item-component prototypes assumed by the 600-row Renaissance household expansion. The original household catalogue's fourteen requested component prototypes and four requested materials remain authoritative in `FutureMUD_Renaissance_PrimaryIndustry_UsefulSeeder_Impact_Reference.md`.
+
+No new runtime item-component type is required. Every row below is a new prototype of the existing `Container` component type, configured with a capacity, transparency, closure, and built-in-lock profile appropriate to pre-industrial furniture.
+
+## New component prototypes
+
+| Exact component name | Existing type | Required configuration | Catalogue use | Safe fallback before seeding |
+| --- | --- | --- | --- | --- |
+| `Container_PreIndustrial_Display_Plinth` | `Container` | Open surface; non-transparent; non-locking; normal-to-large supported-item capacity; no lid; intended for fixed or portable stands | Plinths, pedestals, urn stands, lamp stands, offering stands, and folding display supports | `Container_Side_Table` or `Container_Small_Table`, accepting table-oriented capacity and naming |
+| `LockingContainer_PreIndustrial_SmallCabinet` | `Container` | Small/normal opaque cabinet; openable; built-in lock; non-transparent | Lockable nightstands, wall cabinets, compact cupboards, and small garment cabinets | `LockingContainer_Lockbox`, accepting incorrect horizontal form and reduced furniture capacity |
+| `LockingContainer_PreIndustrial_LargeCabinet` | `Container` | Large/very-large opaque upright cabinet; openable; built-in lock; non-transparent | Lockable wardrobes, armoires, cupboards, armoury cabinets, and large institutional cabinets | `LockingContainer_Footlocker`, accepting incorrect chest orientation |
+| `LockingContainer_PreIndustrial_DrawerChest` | `Container` | Large opaque drawer-chest capacity; openable; built-in lock securing the unit; drawers represented as one logical inventory | Lockable chests of drawers, coin drawers, archive drawers, and specialist sorting cabinets | `LockingContainer_Footlocker`, losing drawer form |
+| `LockingContainer_PreIndustrial_DisplayCabinet` | `Container` | Large transparent cabinet; openable; built-in lock; transparent contents | Secured glass-front cabinets, specimen cases, plate cabinets, and court or guild display furniture | `Container_Display_Case`, losing built-in locking |
+| `LockingContainer_PreIndustrial_Desk` | `Container` | Normal/large opaque desk storage; openable; built-in lock; intended to coexist with a `Table_*` component | Lockable writing desks, counting desks, secretaries, and escritoires | `Container_Desk_Drawers` or `Container_Writing_Desk_Drawers`, losing built-in locking |
+
+## Existing dependencies reused by the expansion
+
+The expansion continues to presume the original component requests:
+
+```text
+CashRegister_PreIndustrial_TillChest
+Container_PreIndustrial_CompartmentBox
+Container_PreIndustrial_LiddedBasket
+Container_PreIndustrial_LiddedHamper
+LContainer_PreIndustrial_Cup_150ml
+LContainer_PreIndustrial_Bowl_750ml
+LContainer_PreIndustrial_Basin_5L
+LContainer_PreIndustrial_Ewer_2L
+LContainer_PreIndustrial_Pitcher_4L
+LContainer_PreIndustrial_Pot_12L
+LContainer_PreIndustrial_StorageJar_12L
+LContainer_PreIndustrial_StorageJar_30L
+LContainer_PreIndustrial_Vat_125L
+LContainer_PreIndustrial_Vat_500L
+```
+
+It also continues to presume the four previously requested materials `gourd shell`, `papier-mache`, `mother of pearl`, and `birch bark`. This expansion requests **no additional materials**.
+
+## Implementation and verification contract
+
+- Seed these six profiles before the expanded catalogue is implemented.
+- Each profile provides the sole `IContainer`/`IOpenable`/`ILockable` implementation on its item. Do not combine it with another dry, locking, or liquid-container provider.
+- The display cabinet must expose transparency; the other locking profiles remain opaque.
+- The drawer chest represents one logical inventory rather than independent per-drawer subcontainers.
+- `LockingContainer_PreIndustrial_Desk` may coexist with one `Table_*` component because table occupancy does not provide another container interface.
+- `Container_PreIndustrial_Display_Plinth` must be reusable on both fixed and genuinely portable display furniture; portability comes from the item prototype's `Holdable` component, not from this container profile.
+- Export the prototypes to `Design Documents/Data/Seeded_Item_Components.json` and add source-truth, exclusivity, and idempotency tests.

--- a/Design Documents/Seeding/FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_I.md
+++ b/Design Documents/Seeding/FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_I.md
@@ -1,0 +1,113 @@
+# FutureMUD Renaissance Household Furniture Expansion Catalogue Index — Volume I
+
+## Scope
+
+This index governs **200 proposed prototypes** and carries the shared row, component-code, tag-code, and culture-admission contract for its linked section catalogues. The item rows are split by furniture/container family for maintainability; together the linked sections are the complete volume.
+
+No row is omitted or duplicated by the split.
+## Row contract
+
+Rows are implementation-oriented catalogue targets rather than full descriptions. Every row inherits `Era / Renaissance Era` and the exact culture tag represented by its culture code. Public short descriptions remain form-based; the culture labels are builder-facing admission metadata.
+
+A row is:
+
+```text
+stable_reference|sdesc|material|size/quality|empty_weight_g/cost_farthings|component_code|culture_code|tag_codes|variation_basis
+```
+
+Portable folding furniture includes `Holdable`. Fixed furniture omits it. Each row has exactly one container provider; table and bench behaviour may coexist because they do not provide another container interface.
+
+Size codes: `T=Tiny`, `VS=VerySmall`, `S=Small`, `N=Normal`, `L=Large`, `VL=VeryLarge`, `H=Huge`, `EN=Enormous`.
+
+Quality codes: `P=Poor`, `SS=Substandard`, `S=Standard`, `G=Good`, `VG=VeryGood`, `GR=Great`, `E=Excellent`.
+
+Costs are in farthings and weights are empty grams.
+
+## Component codes
+
+| Code | Exact components | Intended behaviour |
+| --- | --- | --- |
+| `FX01` | `Destroyable_Furniture`; `Container_Wardrobe` | fixed wardrobe storage |
+| `FX02` | `Destroyable_Furniture`; `Container_Armoire` | fixed armoire storage |
+| `FX03` | `Destroyable_Furniture`; `LockingContainer_PreIndustrial_LargeCabinet` | fixed built-in-lock large cabinet |
+| `FX04` | `Destroyable_Furniture`; `Container_Armor_Stand` | fixed furniture-grade armour stand |
+| `FX05` | `Destroyable_WoodenHeavy`; `Container_Armor_Stand` | fixed heavy wooden armour stand |
+| `FX06` | `Destroyable_HeavyMetal`; `Container_Armor_Stand` | fixed heavy-metal armour stand |
+| `FX07` | `Destroyable_Furniture`; `Container_Weapon_Rack` | fixed furniture-grade weapon rack |
+| `FX08` | `Destroyable_WoodenHeavy`; `Container_Weapon_Rack` | fixed heavy wooden weapon rack |
+| `FX09` | `Destroyable_HeavyMetal`; `Container_Weapon_Rack` | fixed heavy-metal weapon rack |
+| `FX10` | `Destroyable_Furniture`; `LockingContainer_PreIndustrial_LargeCabinet` | fixed built-in-lock weapon cabinet |
+| `FX11` | `Destroyable_Furniture`; `Container_Display_Case` | fixed transparent display case |
+| `FX12` | `Destroyable_Furniture`; `Container_Glass_Cabinet` | fixed glass-fronted cabinet |
+| `FX13` | `Destroyable_Furniture`; `Container_Display_Shelves` | fixed open display shelving |
+| `FX14` | `Destroyable_Furniture`; `LockingContainer_PreIndustrial_DisplayCabinet` | fixed transparent built-in-lock display cabinet |
+| `FX26` | `Destroyable_Furniture`; `Container_Cupboard` | fixed cupboard storage |
+| `FX30` | `Destroyable_Furniture`; `Container_Large_Cabinet` | fixed large cabinet storage |
+| `FX31` | `Destroyable_Furniture`; `Container_Small_Cabinet` | fixed small cabinet storage |
+| `FX33` | `Destroyable_Furniture`; `LockingContainer_PreIndustrial_SmallCabinet` | fixed built-in-lock small cabinet |
+| `FX34` | `Holdable`; `Destroyable_Furniture`; `Container_Weapon_Rack` | portable weapon rack |
+| `FX35` | `Holdable`; `Destroyable_Furniture`; `Container_Armor_Stand` | portable armour stand |
+| `FX39` | `Holdable`; `Destroyable_Furniture`; `Container_Wardrobe` | portable wardrobe |
+
+## Tag codes
+
+| Code | Exact tags added by the row |
+| --- | --- |
+| `FU-S` | `Functions / Container`; `Functions / Household Items / Household Furniture`; `Market / Household Goods / Simple Furniture` |
+| `FU-N` | `Functions / Container`; `Functions / Household Items / Household Furniture`; `Market / Household Goods / Standard Furniture` |
+| `FU-L` | `Functions / Container`; `Functions / Household Items / Household Furniture`; `Market / Household Goods / Luxury Furniture` |
+| `TR-S` / `TR-N` / `TR-L` | Container plus simple, standard, or luxury household-wares market tag |
+| `PC-S` / `PC-N` / `PC-L` | Personal container plus simple, standard, or luxury household-wares market tag |
+| `DW-S` / `DW-N` / `DW-L` | Domestic container/ware plus simple, standard, or luxury household-wares market tag |
+| `OPEN` | `Functions / Container / Open Container` |
+| `WATER` | `Functions / Container / Watertight Container` |
+| `POROUS` | `Functions / Container / Porous Container` |
+| `MIL` | `Market / Military Goods` |
+| `COURT`, `RELIGIOUS`, `GUILD`, `MARITIME`, `PERFORMANCE`, `SERVICE` | Matching live `Institution / ...` tag |
+
+## Culture codes and admission
+
+| Code | Culture grouping | Exact inherited tag | Date gate | New rows |
+| --- | --- | --- | ---: | ---: |
+| `WER` | Western European Renaissance | `Culture / Renaissance / Shared / Western European Renaissance` | 1450-1600 | 37 |
+| `IBA` | Iberian Atlantic | `Culture / Renaissance / Shared / Iberian Atlantic` | 1450-1600 | 30 |
+| `CEN` | Central European | `Culture / Renaissance / Shared / Central European` | 1450-1600 | 29 |
+| `NBA` | Northern Baltic | `Culture / Renaissance / Shared / Northern Baltic` | 1450-1600 | 19 |
+| `CEF` | Central Eastern Frontier | `Culture / Renaissance / Shared / Central Eastern Frontier` | 1500-1600 | 19 |
+| `EON` | Eastern Orthodox Northern | `Culture / Renaissance / Shared / Eastern Orthodox Northern` | 1500-1600 | 19 |
+| `OTT` | Ottoman Islamicate | `Culture / Renaissance / Shared / Ottoman Islamicate` | 1450-1600 | 31 |
+| `PIP` | Persianate Indo-Persian | `Culture / Renaissance / Shared / Persianate Indo-Persian` | 1450-1600 | 28 |
+| `SAS` | South Asian | `Culture / Renaissance / Shared / South Asian` | 1450-1600 | 28 |
+| `EAL` | East Asian Literati | `Culture / Renaissance / Shared / East Asian Literati` | 1400-1600 | 33 |
+| `JPN` | Japanese | `Culture / Renaissance / Shared / Japanese` | 1450-1600 | 29 |
+| `MEA` | Maritime East Asian | `Culture / Renaissance / Shared / Maritime East Asian` | 1450-1600 | 18 |
+| `SEM` | South-east Asian Mainland | `Culture / Renaissance / Shared / South-east Asian Mainland` | 1450-1600 | 18 |
+| `MSEA` | Maritime South-east Asian | `Culture / Renaissance / Shared / Maritime South-east Asian` | 1450-1600 | 23 |
+| `STP` | Steppe and Caravan | `Culture / Renaissance / Shared / Steppe and Caravan` | 1450-1600 | 19 |
+| `ACA` | African Court Atlantic | `Culture / Renaissance / Shared / African Court Atlantic` | 1450-1600 | 23 |
+| `SAI` | Sahelian Islamic | `Culture / Renaissance / Shared / Sahelian Islamic` | 1450-1600 | 17 |
+| `RSE` | Red Sea | `Culture / Renaissance / Shared / Red Sea` | 1450-1600 | 17 |
+| `IND` | Indian Ocean | `Culture / Renaissance / Shared / Indian Ocean` | 1450-1600 | 23 |
+| `MES` | Mesoamerican | `Culture / Renaissance / Shared / Mesoamerican` | 1400-1600 | 19 |
+| `AND` | Andean | `Culture / Renaissance / Shared / Andean` | 1400-1600 | 19 |
+| `CAR` | Caribbean Contact | `Culture / Renaissance / Shared / Caribbean Contact` | 1450-1600 | 15 |
+| `NAC` | North American Contact | `Culture / Renaissance / Shared / North American Contact` | 1450-1600 | 15 |
+| `COL` | Colonial Atlantic | `Culture / Renaissance / Shared / Colonial Atlantic` | 1500-1600 | 28 |
+| `MAR` | Global Maritime | `Culture / Renaissance / Shared / Global Maritime` | 1450-1600 | 44 |
+
+## Catalogue sections
+
+| Section | Rows | File |
+| --- | ---: | --- |
+| Wardrobes, armoires, garment cabinets, and linen presses | 55 | [FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_I_Wardrobes.md](./FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_I_Wardrobes.md) |
+| Armour stands, armour trees, and harness supports | 45 | [FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_I_Armour_Stands.md](./FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_I_Armour_Stands.md) |
+| Weapon racks, shield racks, and lockable armoury cabinets | 45 | [FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_I_Weapon_Racks.md](./FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_I_Weapon_Racks.md) |
+| Display cabinets, cases, and open display shelving | 55 | [FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_I_Display.md](./FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_I_Display.md) |
+
+**Volume total: 200 rows.**
+
+## Index validation
+
+- The linked files contain exactly 200 rows in the declared family split.
+- Stable references and short descriptions are unique across the complete 600-row expansion.
+- Component codes, tag codes, culture codes, size codes, and quality codes resolve through this index.

--- a/Design Documents/Seeding/FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II.md
+++ b/Design Documents/Seeding/FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II.md
@@ -1,0 +1,115 @@
+# FutureMUD Renaissance Household Furniture Expansion Catalogue Index — Volume II
+
+## Scope
+
+This index governs **220 proposed prototypes** and carries the shared row, component-code, tag-code, and culture-admission contract for its linked section catalogues. The item rows are split by furniture/container family for maintainability; together the linked sections are the complete volume.
+
+No row is omitted or duplicated by the split.
+## Row contract
+
+Rows are implementation-oriented catalogue targets rather than full descriptions. Every row inherits `Era / Renaissance Era` and the exact culture tag represented by its culture code. Public short descriptions remain form-based; the culture labels are builder-facing admission metadata.
+
+A row is:
+
+```text
+stable_reference|sdesc|material|size/quality|empty_weight_g/cost_farthings|component_code|culture_code|tag_codes|variation_basis
+```
+
+Portable folding furniture includes `Holdable`. Fixed furniture omits it. Each row has exactly one container provider; table and bench behaviour may coexist because they do not provide another container interface.
+
+Size codes: `T=Tiny`, `VS=VerySmall`, `S=Small`, `N=Normal`, `L=Large`, `VL=VeryLarge`, `H=Huge`, `EN=Enormous`.
+
+Quality codes: `P=Poor`, `SS=Substandard`, `S=Standard`, `G=Good`, `VG=VeryGood`, `GR=Great`, `E=Excellent`.
+
+Costs are in farthings and weights are empty grams.
+
+## Component codes
+
+| Code | Exact components | Intended behaviour |
+| --- | --- | --- |
+| `FX15` | `Destroyable_Furniture`; `Container_Side_Table` | fixed side/end-table surface |
+| `FX16` | `Destroyable_Furniture`; `Container_Nightstand` | fixed nightstand storage |
+| `FX17` | `Destroyable_Furniture`; `LockingContainer_PreIndustrial_SmallCabinet` | fixed built-in-lock small cabinet |
+| `FX18` | `Destroyable_Furniture`; `Container_PreIndustrial_Display_Plinth` | fixed display plinth surface |
+| `FX19` | `Destroyable_HeavyMetal`; `Container_PreIndustrial_Display_Plinth` | fixed heavy-metal display plinth |
+| `FX20` | `Destroyable_Furniture`; `Container_Dresser` | fixed dresser/drawer storage |
+| `FX21` | `Destroyable_Furniture`; `LockingContainer_PreIndustrial_DrawerChest` | fixed built-in-lock drawer chest |
+| `FX22` | `Destroyable_Furniture`; `Container_Desk_Drawers`; `Table_Four` | fixed desk drawers with four table positions |
+| `FX23` | `Destroyable_Furniture`; `Container_Writing_Desk_Drawers`; `Table_Four` | fixed writing-desk drawers with four table positions |
+| `FX24` | `Destroyable_Furniture`; `Container_Desk_Surface`; `Table_Four` | fixed desk surface with four table positions |
+| `FX25` | `Destroyable_Furniture`; `LockingContainer_PreIndustrial_Desk`; `Table_Four` | fixed built-in-lock desk with four table positions |
+| `FX26` | `Destroyable_Furniture`; `Container_Cupboard` | fixed cupboard storage |
+| `FX27` | `Destroyable_Furniture`; `Container_Hutch` | fixed hutch storage |
+| `FX28` | `Destroyable_Furniture`; `Container_Bookcase_Shelves` | fixed open bookcase shelving |
+| `FX29` | `Destroyable_Furniture`; `Container_Document_Bookcase_Shelves` | fixed document-bookcase shelving |
+| `FX30` | `Destroyable_Furniture`; `Container_Large_Cabinet` | fixed large cabinet storage |
+| `FX31` | `Destroyable_Furniture`; `Container_Small_Cabinet` | fixed small cabinet storage |
+| `FX32` | `Destroyable_Furniture`; `LockingContainer_PreIndustrial_LargeCabinet` | fixed built-in-lock large cabinet |
+| `FX33` | `Destroyable_Furniture`; `LockingContainer_PreIndustrial_SmallCabinet` | fixed built-in-lock small cabinet |
+| `FX36` | `Holdable`; `Destroyable_Furniture`; `Container_Side_Table` | portable side/end table |
+| `FX37` | `Holdable`; `Destroyable_Furniture`; `Container_Desk_Drawers`; `Table_Four` | portable desk with drawers |
+| `FX38` | `Holdable`; `Destroyable_Furniture`; `Container_PreIndustrial_Display_Plinth` | portable display plinth |
+
+## Tag codes
+
+| Code | Exact tags added by the row |
+| --- | --- |
+| `FU-S` | `Functions / Container`; `Functions / Household Items / Household Furniture`; `Market / Household Goods / Simple Furniture` |
+| `FU-N` | `Functions / Container`; `Functions / Household Items / Household Furniture`; `Market / Household Goods / Standard Furniture` |
+| `FU-L` | `Functions / Container`; `Functions / Household Items / Household Furniture`; `Market / Household Goods / Luxury Furniture` |
+| `TR-S` / `TR-N` / `TR-L` | Container plus simple, standard, or luxury household-wares market tag |
+| `PC-S` / `PC-N` / `PC-L` | Personal container plus simple, standard, or luxury household-wares market tag |
+| `DW-S` / `DW-N` / `DW-L` | Domestic container/ware plus simple, standard, or luxury household-wares market tag |
+| `OPEN` | `Functions / Container / Open Container` |
+| `WATER` | `Functions / Container / Watertight Container` |
+| `POROUS` | `Functions / Container / Porous Container` |
+| `MIL` | `Market / Military Goods` |
+| `COURT`, `RELIGIOUS`, `GUILD`, `MARITIME`, `PERFORMANCE`, `SERVICE` | Matching live `Institution / ...` tag |
+
+## Culture codes and admission
+
+| Code | Culture grouping | Exact inherited tag | Date gate | New rows |
+| --- | --- | --- | ---: | ---: |
+| `WER` | Western European Renaissance | `Culture / Renaissance / Shared / Western European Renaissance` | 1450-1600 | 37 |
+| `IBA` | Iberian Atlantic | `Culture / Renaissance / Shared / Iberian Atlantic` | 1450-1600 | 30 |
+| `CEN` | Central European | `Culture / Renaissance / Shared / Central European` | 1450-1600 | 29 |
+| `NBA` | Northern Baltic | `Culture / Renaissance / Shared / Northern Baltic` | 1450-1600 | 19 |
+| `CEF` | Central Eastern Frontier | `Culture / Renaissance / Shared / Central Eastern Frontier` | 1500-1600 | 19 |
+| `EON` | Eastern Orthodox Northern | `Culture / Renaissance / Shared / Eastern Orthodox Northern` | 1500-1600 | 19 |
+| `OTT` | Ottoman Islamicate | `Culture / Renaissance / Shared / Ottoman Islamicate` | 1450-1600 | 31 |
+| `PIP` | Persianate Indo-Persian | `Culture / Renaissance / Shared / Persianate Indo-Persian` | 1450-1600 | 28 |
+| `SAS` | South Asian | `Culture / Renaissance / Shared / South Asian` | 1450-1600 | 28 |
+| `EAL` | East Asian Literati | `Culture / Renaissance / Shared / East Asian Literati` | 1400-1600 | 33 |
+| `JPN` | Japanese | `Culture / Renaissance / Shared / Japanese` | 1450-1600 | 29 |
+| `MEA` | Maritime East Asian | `Culture / Renaissance / Shared / Maritime East Asian` | 1450-1600 | 18 |
+| `SEM` | South-east Asian Mainland | `Culture / Renaissance / Shared / South-east Asian Mainland` | 1450-1600 | 18 |
+| `MSEA` | Maritime South-east Asian | `Culture / Renaissance / Shared / Maritime South-east Asian` | 1450-1600 | 23 |
+| `STP` | Steppe and Caravan | `Culture / Renaissance / Shared / Steppe and Caravan` | 1450-1600 | 19 |
+| `ACA` | African Court Atlantic | `Culture / Renaissance / Shared / African Court Atlantic` | 1450-1600 | 23 |
+| `SAI` | Sahelian Islamic | `Culture / Renaissance / Shared / Sahelian Islamic` | 1450-1600 | 17 |
+| `RSE` | Red Sea | `Culture / Renaissance / Shared / Red Sea` | 1450-1600 | 17 |
+| `IND` | Indian Ocean | `Culture / Renaissance / Shared / Indian Ocean` | 1450-1600 | 23 |
+| `MES` | Mesoamerican | `Culture / Renaissance / Shared / Mesoamerican` | 1400-1600 | 19 |
+| `AND` | Andean | `Culture / Renaissance / Shared / Andean` | 1400-1600 | 19 |
+| `CAR` | Caribbean Contact | `Culture / Renaissance / Shared / Caribbean Contact` | 1450-1600 | 15 |
+| `NAC` | North American Contact | `Culture / Renaissance / Shared / North American Contact` | 1450-1600 | 15 |
+| `COL` | Colonial Atlantic | `Culture / Renaissance / Shared / Colonial Atlantic` | 1500-1600 | 28 |
+| `MAR` | Global Maritime | `Culture / Renaissance / Shared / Global Maritime` | 1450-1600 | 44 |
+
+## Catalogue sections
+
+| Section | Rows | File |
+| --- | ---: | --- |
+| Side tables, end tables, nightstands, and compact lockable cabinets | 45 | [FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II_Side_Tables.md](./FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II_Side_Tables.md) |
+| Display plinths, pedestals, vessel stands, and offering stands | 40 | [FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II_Plinths.md](./FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II_Plinths.md) |
+| Chests of drawers, specialist drawers, and lockable drawer cabinets | 50 | [FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II_Drawers.md](./FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II_Drawers.md) |
+| Desks, writing tables, counting desks, and lockable escritoires | 50 | [FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II_Desks.md](./FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II_Desks.md) |
+| Cupboards, hutches, bookcases, and archive cabinets | 35 | [FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II_Cupboards.md](./FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II_Cupboards.md) |
+
+**Volume total: 220 rows.**
+
+## Index validation
+
+- The linked files contain exactly 220 rows in the declared family split.
+- Stable references and short descriptions are unique across the complete 600-row expansion.
+- Component codes, tag codes, culture codes, size codes, and quality codes resolve through this index.

--- a/Design Documents/Seeding/FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II_Cupboards.md
+++ b/Design Documents/Seeding/FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II_Cupboards.md
@@ -1,0 +1,53 @@
+# Cupboards, hutches, bookcases, and archive cabinets — Renaissance expansion section
+
+> Parent contract: [FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II.md](./FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II.md)
+
+This section contains **35 proposed prototypes**. Component codes, culture codes, tag codes, size/quality abbreviations, admission rules, and portability rules are defined by the parent index and the expansion manifest.
+
+## Cupboards, hutches, bookcases, and archive cabinets — 35
+
+Variations cover wall and corner storage, hutches, open book shelving, archive shelving, large cabinets, and built-in-lock cupboards.
+
+```text
+renaissance_furniture_expansion_wer_wall_cupboard_01|a tiered marquetry-fronted oak wall cupboard|oak|N/G|9300/74|FX31|WER|FU-N,GUILD|compact wall-mounted storage; fixed furniture
+renaissance_furniture_expansion_iba_archive_bookcase_01|a painted-panel oak archive bookcase|oak|VL/S|80850/219|FX29|IBA|FU-N,OPEN,COURT|document-specific shelving; fixed furniture
+renaissance_furniture_expansion_iba_wall_cupboard_02|a panelled oak wall cupboard|oak|L/S|31600/101|FX31|IBA|FU-N,MARITIME|compact wall-mounted storage; fixed furniture
+renaissance_furniture_expansion_cen_plate_hutch_01|a round-fronted painted ash plate hutch|ash|VL/S|82150/215|FX27|CEN|FU-N|service vessels and plate storage; fixed furniture
+renaissance_furniture_expansion_nba_bookcase_01|a carved pine bookcase|pine|H/G|124600/418|FX28|NBA|FU-N,OPEN,GUILD|open book shelving; fixed furniture
+renaissance_furniture_expansion_nba_household_cupboard_02|a high pale-boarded oak household cupboard|oak|VL/VG|78750/459|FX26|NBA|FU-L,GUILD|general enclosed household storage; fixed furniture
+renaissance_furniture_expansion_cef_household_cupboard_01|a low lattice-fronted walnut household cupboard|walnut|VL/SS|72100/158|FX26|CEF|FU-S,COURT|general enclosed household storage; fixed furniture
+renaissance_furniture_expansion_eon_bookcase_02|a recessed-panel pine bookcase|pine|VL/S|68000/156|FX28|EON|FU-N,OPEN,RELIGIOUS|open book shelving; fixed furniture
+renaissance_furniture_expansion_eon_household_cupboard_01|a plain-joined walnut household cupboard|walnut|L/G|32700/214|FX26|EON|FU-N,COURT|general enclosed household storage; fixed furniture
+renaissance_furniture_expansion_ott_service_hutch_01_lockable|an lock-fitted arched-top geometric-inlaid boxwood service hutch|boxwood|L/S|34750/106|FX33|OTT|FU-N,COURT|cupboard-and-display service storage; built-in lock
+renaissance_furniture_expansion_pip_wall_cupboard_01|an octagonal low walnut wall cupboard|walnut|L/VG|34650/331|FX31|PIP|FU-L,COURT|compact wall-mounted storage; fixed furniture
+renaissance_furniture_expansion_sas_large_storage_cabinet_01|a deep painted bamboo large storage cabinet|bamboo|H/G|86150/382|FX30|SAS|FU-N,SERVICE|high-capacity enclosed storage; fixed furniture
+renaissance_furniture_expansion_eal_archive_bookcase_03|a tall recessed-panel cypress archive bookcase|cypress|VL/G|67950/272|FX29|EAL|FU-N,OPEN,RELIGIOUS|document-specific shelving; fixed furniture
+renaissance_furniture_expansion_eal_hanging_cabinet_01_lockable|a lock-fitted broad lacquered lacquer hanging cabinet|lacquer|L/SS|31250/105|FX33|EAL|FU-S|small suspended cabinet; built-in lock
+renaissance_furniture_expansion_eal_lock_fitted_cupboard_02|a lattice-fronted bamboo lock-fitted cupboard|bamboo|VL/G|43050/173|FX32|EAL|FU-N,RELIGIOUS|built-in-lock household cupboard; built-in lock
+renaissance_furniture_expansion_jpn_household_cupboard_01|a compact slatted bamboo household cupboard|bamboo|L/P|18750/24|FX26|JPN|FU-S|general enclosed household storage; fixed furniture
+renaissance_furniture_expansion_mea_lock_fitted_cupboard_01|a narrow shell-faced teak lock-fitted cupboard|teak|L/G|34300/195|FX32|MEA|FU-N|built-in-lock household cupboard; built-in lock
+renaissance_furniture_expansion_sem_large_storage_cabinet_01|a lacquered lacquer large storage cabinet|lacquer|H/G|158150/821|FX30|SEM|FU-N,COURT|high-capacity enclosed storage; fixed furniture
+renaissance_furniture_expansion_msea_hanging_cabinet_02|a deep low rattan hanging cabinet|rattan|N/S|5650/23|FX31|MSEA|FU-N,RELIGIOUS|small suspended cabinet; fixed furniture
+renaissance_furniture_expansion_msea_large_storage_cabinet_01|a low rattan large storage cabinet|rattan|H/S|91100/185|FX30|MSEA|FU-N,RELIGIOUS|high-capacity enclosed storage; fixed furniture
+renaissance_furniture_expansion_stp_large_storage_cabinet_01|a low birch large storage cabinet|birch|VL/S|74050/139|FX30|STP|FU-N|high-capacity enclosed storage; fixed furniture
+renaissance_furniture_expansion_aca_lock_fitted_cupboard_01|a deep-carved wicker lock-fitted cupboard|wicker|L/G|17250/72|FX32|ACA|FU-N|built-in-lock household cupboard; built-in lock
+renaissance_furniture_expansion_sai_household_cupboard_02|a round-fronted reed-fronted wicker household cupboard|wicker|VL/G|41250/160|FX26|SAI|FU-N|general enclosed household storage; fixed furniture
+renaissance_furniture_expansion_sai_lock_fitted_cupboard_01|a high painted wood lock-fitted cupboard|wood|L/VG|37500/199|FX33|SAI|FU-L,GUILD|built-in-lock household cupboard; built-in lock
+renaissance_furniture_expansion_rse_large_storage_cabinet_01|a leather-covered olivewood large storage cabinet|olive wood|H/G|144800/711|FX30|RSE|FU-N,RELIGIOUS|high-capacity enclosed storage; fixed furniture
+renaissance_furniture_expansion_mes_bookcase_01|a tiered deep-carved wood bookcase|wood|VL/S|81450/210|FX28|MES|FU-N,OPEN,COURT|open book shelving; fixed furniture
+renaissance_furniture_expansion_car_archive_bookcase_01|a deep woven wicker archive bookcase|wicker|VL/S|46100/98|FX29|CAR|FU-N,OPEN,COURT|document-specific shelving; fixed furniture
+renaissance_furniture_expansion_nac_hanging_cabinet_02|a tall hide-covered birch hanging cabinet|birch|L/G|28650/121|FX31|NAC|FU-N,GUILD|small suspended cabinet; fixed furniture
+renaissance_furniture_expansion_nac_wall_cupboard_01|a bark-panelled wicker wall cupboard|wicker|L/S|19050/43|FX31|NAC|FU-N|compact wall-mounted storage; fixed furniture
+renaissance_furniture_expansion_col_bookcase_01|an arched-top heavy-framed oak bookcase|oak|VL/G|77950/381|FX28|COL|FU-N,OPEN|open book shelving; fixed furniture
+renaissance_furniture_expansion_col_corner_cupboard_02|a wide panelled pine corner cupboard|pine|VL/S|71050/164|FX31|COL|FU-N,RELIGIOUS|triangular room-corner storage; fixed furniture
+renaissance_furniture_expansion_mar_hanging_cabinet_04|a tar-darkened teak hanging cabinet|teak|N/SS|8650/37|FX31|MAR|FU-S,MARITIME|small suspended cabinet; fixed furniture
+renaissance_furniture_expansion_mar_large_storage_cabinet_02|a broad slotted cedar large storage cabinet|cedar|VL/VG|69600/451|FX30|MAR|FU-L|high-capacity enclosed storage; fixed furniture
+renaissance_furniture_expansion_mar_plate_hutch_03|a slender collapsible teak plate hutch|teak|L/SS|32150/99|FX27|MAR|FU-S,MARITIME|service vessels and plate storage; fixed furniture
+renaissance_furniture_expansion_mar_wall_cupboard_01|a tall plain-framed pine wall cupboard|pine|N/S|8850/34|FX31|MAR|FU-N,MARITIME|compact wall-mounted storage; fixed furniture
+```
+
+## Section validation
+
+- 35 rows and 35 unique stable references.
+- Rows inherit `Era / Renaissance Era` and the exact culture tag identified by their culture code.
+- No full descriptions are supplied in this pass.

--- a/Design Documents/Seeding/FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II_Desks.md
+++ b/Design Documents/Seeding/FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II_Desks.md
@@ -1,0 +1,68 @@
+# Desks, writing tables, counting desks, and lockable escritoires — Renaissance expansion section
+
+> Parent contract: [FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II.md](./FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II.md)
+
+This section contains **50 proposed prototypes**. Component codes, culture codes, tag codes, size/quality abbreviations, admission rules, and portability rules are defined by the parent index and the expansion manifest.
+
+## Desks, writing tables, counting desks, and lockable escritoires — 50
+
+Variations distinguish open writing surfaces, drawer desks, slant-front forms, map tables, campaign furniture, secretary cabinets, and locked writing storage.
+
+```text
+renaissance_furniture_expansion_wer_secretary_cabinet_01|a pilastered boxwood secretary cabinet|boxwood|VL/S|62000/172|FX23|WER|FU-N|tall writing cabinet and drawers; fixed furniture
+renaissance_furniture_expansion_wer_secretary_cabinet_03|a marquetry-fronted oak secretary cabinet|oak|H/P|128500/147|FX23|WER|FU-S|tall writing cabinet and drawers; fixed furniture
+renaissance_furniture_expansion_wer_slant_front_desk_02|a moulded chestnut slant-front desk|chestnut|VL/SS|65650/94|FX23|WER|FU-S,COURT|sloped writing front and drawers; fixed furniture
+renaissance_furniture_expansion_iba_campaign_desk_04|a narrow iron-bound olivewood campaign desk|olive wood|L/GR|17350/399|FX37|IBA|FU-L,RELIGIOUS|portable folding desk with drawers; portable/folding
+renaissance_furniture_expansion_iba_clerks_desk_02|a low leather-faced boxwood clerk's desk|boxwood|L/G|30050/133|FX22|IBA|FU-N|compact institutional desk storage; fixed furniture
+renaissance_furniture_expansion_iba_lock_fitted_desk_01|a carved cedar lock-fitted desk|cedar|L/VG|21900/178|FX25|IBA|FU-L,RELIGIOUS|built-in-lock writing storage; built-in lock
+renaissance_furniture_expansion_iba_slant_front_desk_03|a plain-joined boxwood slant-front desk|boxwood|L/SS|28300/74|FX23|IBA|FU-S,RELIGIOUS|sloped writing front and drawers; fixed furniture
+renaissance_furniture_expansion_cen_campaign_desk_01|a long painted beech campaign desk|beech|L/G|20850/102|FX37|CEN|FU-N|portable folding desk with drawers; portable/folding
+renaissance_furniture_expansion_cen_campaign_desk_03|a massive slatted linden campaign desk|linden|L/S|15000/63|FX37|CEN|FU-N,COURT|portable folding desk with drawers; portable/folding
+renaissance_furniture_expansion_cen_secretary_cabinet_02|a compact gabled beech secretary cabinet|beech|VL/VG|63100/325|FX23|CEN|FU-L,COURT|tall writing cabinet and drawers; fixed furniture
+renaissance_furniture_expansion_cen_writing_desk_04|a massive gabled linden writing desk|linden|L/SS|25150/49|FX22|CEN|FU-S|drawer-equipped writing surface; fixed furniture
+renaissance_furniture_expansion_nba_counting_desk_02|a deep pale-boarded oak counting desk|oak|L/S|30700/103|FX22|NBA|FU-N|merchant calculation and drawer storage; fixed furniture
+renaissance_furniture_expansion_nba_secretary_cabinet_01_lockable|a lock-fitted square stave-faced pine secretary cabinet|pine|VL/S|55800/130|FX25|NBA|FU-N,MARITIME|tall writing cabinet and drawers; built-in lock
+renaissance_furniture_expansion_eon_counting_desk_01|a birch-faced linden counting desk|linden|VL/S|61350/123|FX22|EON|FU-N,COURT|merchant calculation and drawer storage; fixed furniture
+renaissance_furniture_expansion_eon_map_desk_02_lockable|a lock-fitted massive carved ash map desk|ash|VL/S|61700/176|FX25|EON|FU-N,OPEN|broad map and chart surface; built-in lock
+renaissance_furniture_expansion_eon_secretary_cabinet_03|a plain-joined linden secretary cabinet|linden|VL/G|54250/195|FX23|EON|FU-N,RELIGIOUS|tall writing cabinet and drawers; fixed furniture
+renaissance_furniture_expansion_eon_slant_front_desk_05_lockable|a lock-fitted slatted pine slant-front desk|pine|L/VG|24250/154|FX25|EON|FU-L,COURT|sloped writing front and drawers; built-in lock
+renaissance_furniture_expansion_eon_writing_desk_04|a slender iron-bound oak writing desk|oak|VL/G|61300/317|FX22|EON|FU-N,RELIGIOUS|drawer-equipped writing surface; fixed furniture
+renaissance_furniture_expansion_pip_lock_fitted_desk_02|a lacquered sandalwood lock-fitted desk|sandalwood|VL/VG|63650/736|FX25|PIP|FU-L|built-in-lock writing storage; built-in lock
+renaissance_furniture_expansion_pip_writing_desk_01|a broad painted lacquer writing desk|lacquer|VL/E|69350/1158|FX22|PIP|FU-L,COURT|drawer-equipped writing surface; fixed furniture
+renaissance_furniture_expansion_sas_secretary_cabinet_01|an octagonal teak-framed teak secretary cabinet|teak|H/G|136150/732|FX23|SAS|FU-N,RELIGIOUS|tall writing cabinet and drawers; fixed furniture
+renaissance_furniture_expansion_eal_clerks_desk_03|a broad tiered cypress clerk's desk|cypress|L/S|25050/93|FX22|EAL|FU-N,RELIGIOUS|compact institutional desk storage; fixed furniture
+renaissance_furniture_expansion_eal_map_desk_01|an octagonal asymmetrical pine map desk|pine|VL/G|52700/205|FX24|EAL|FU-N,OPEN,COURT|broad map and chart surface; fixed furniture
+renaissance_furniture_expansion_eal_writing_table_02|a broad lacquered pine writing table|pine|L/G|25250/106|FX24|EAL|FU-N,OPEN,COURT|open writing surface; fixed furniture
+renaissance_furniture_expansion_jpn_map_desk_01|a small asymmetrical cedar map desk|cedar|VL/S|53050/165|FX24|JPN|FU-N,OPEN|broad map and chart surface; fixed furniture
+renaissance_furniture_expansion_jpn_writing_table_02|a tall black-lacquered bamboo writing table|bamboo|L/G|16450/83|FX24|JPN|FU-N,OPEN,GUILD|open writing surface; fixed furniture
+renaissance_furniture_expansion_mea_writing_desk_01|a small slatted bamboo writing desk|bamboo|L/G|14700/65|FX23|MEA|FU-N|drawer-equipped writing surface; fixed furniture
+renaissance_furniture_expansion_sem_writing_table_01|an openwork bamboo writing table|bamboo|VL/G|34150/127|FX24|SEM|FU-N,OPEN|open writing surface; fixed furniture
+renaissance_furniture_expansion_msea_counting_desk_01|a low rattan counting desk|rattan|L/S|17250/40|FX22|MSEA|FU-N,RELIGIOUS|merchant calculation and drawer storage; fixed furniture
+renaissance_furniture_expansion_stp_campaign_desk_01|an octagonal collapsible pine campaign desk|pine|L/G|16950/86|FX37|STP|FU-N,MARITIME|portable folding desk with drawers; portable/folding
+renaissance_furniture_expansion_aca_counting_desk_01|an arched-top studded mahogany counting desk|mahogany|L/S|30150/106|FX22|ACA|FU-N,GUILD|merchant calculation and drawer storage; fixed furniture
+renaissance_furniture_expansion_aca_lock_fitted_desk_03|a deep-carved mahogany lock-fitted desk|mahogany|L/G|30550/220|FX25|ACA|FU-N|built-in-lock writing storage; built-in lock
+renaissance_furniture_expansion_aca_writing_desk_02|a long deep-carved wood writing desk|wood|L/P|30000/35|FX22|ACA|FU-S,GUILD|drawer-equipped writing surface; fixed furniture
+renaissance_furniture_expansion_sai_slant_front_desk_01|a massive plain-joined wood slant-front desk|wood|L/S|31000/74|FX23|SAI|FU-N,GUILD|sloped writing front and drawers; fixed furniture
+renaissance_furniture_expansion_rse_campaign_desk_01|a compact leather-covered olivewood campaign desk|olive wood|L/GR|20100/377|FX37|RSE|FU-L,MARITIME|portable folding desk with drawers; portable/folding
+renaissance_furniture_expansion_rse_campaign_desk_03|a tall leather-covered olivewood campaign desk|olive wood|L/G|19800/162|FX37|RSE|FU-N|portable folding desk with drawers; portable/folding
+renaissance_furniture_expansion_rse_slant_front_desk_02|a cedar-framed cedar slant-front desk|cedar|L/S|22900/90|FX23|RSE|FU-N,MARITIME|sloped writing front and drawers; fixed furniture
+renaissance_furniture_expansion_ind_map_desk_01|an octagonal rattan-panelled rattan map desk|rattan|VL/GR|36900/284|FX24|IND|FU-L,OPEN,GUILD|broad map and chart surface; fixed furniture
+renaissance_furniture_expansion_ind_writing_desk_02|an octagonal plain-joined bamboo writing desk|bamboo|L/G|15550/81|FX22|IND|FU-N,MARITIME|drawer-equipped writing surface; fixed furniture
+renaissance_furniture_expansion_mes_writing_table_01|a plain-framed wood writing table|wood|L/VG|30000/206|FX24|MES|FU-L,OPEN,RELIGIOUS|open writing surface; fixed furniture
+renaissance_furniture_expansion_mes_writing_table_02|an octagonal raised wood writing table|wood|L/GR|27000/248|FX24|MES|FU-L,OPEN,COURT|open writing surface; fixed furniture
+renaissance_furniture_expansion_and_writing_table_01|a deep low wood writing table|wood|L/S|27550/76|FX24|AND|FU-N,OPEN,SERVICE|open writing surface; fixed furniture
+renaissance_furniture_expansion_and_writing_table_02|a raised wood writing table|wood|VL/VG|64900/339|FX24|AND|FU-L,OPEN,COURT|open writing surface; fixed furniture
+renaissance_furniture_expansion_and_writing_table_03|a round-fronted woven-panel wood writing table|wood|VL/VG|62750/387|FX24|AND|FU-L,OPEN,COURT|open writing surface; fixed furniture
+renaissance_furniture_expansion_car_map_desk_01|a square deep-carved wood map desk|wood|H/VG|126350/591|FX24|CAR|FU-L,OPEN,COURT|broad map and chart surface; fixed furniture
+renaissance_furniture_expansion_col_escritoire_01|a plain-joined pine escritoire|pine|L/SS|23050/36|FX23|COL|FU-S,MARITIME|compact enclosed writing furniture; fixed furniture
+renaissance_furniture_expansion_col_slant_front_desk_02|a tiered mission-made pine slant-front desk|pine|VL/G|59000/193|FX23|COL|FU-N,MARITIME|sloped writing front and drawers; fixed furniture
+renaissance_furniture_expansion_mar_escritoire_02|a long iron-bound cedar escritoire|cedar|L/VG|23650/168|FX23|MAR|FU-L,MARITIME|compact enclosed writing furniture; fixed furniture
+renaissance_furniture_expansion_mar_writing_desk_01|a massive slotted teak writing desk|teak|L/P|29300/54|FX22|MAR|FU-S,MARITIME|drawer-equipped writing surface; fixed furniture
+renaissance_furniture_expansion_mar_writing_desk_03|a broad plain-framed cedar writing desk|cedar|L/G|23450/139|FX23|MAR|FU-N,GUILD|drawer-equipped writing surface; fixed furniture
+```
+
+## Section validation
+
+- 50 rows and 50 unique stable references.
+- Rows inherit `Era / Renaissance Era` and the exact culture tag identified by their culture code.
+- No full descriptions are supplied in this pass.

--- a/Design Documents/Seeding/FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II_Drawers.md
+++ b/Design Documents/Seeding/FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II_Drawers.md
@@ -1,0 +1,68 @@
+# Chests of drawers, specialist drawers, and lockable drawer cabinets — Renaissance expansion section
+
+> Parent contract: [FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II.md](./FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II.md)
+
+This section contains **50 proposed prototypes**. Component codes, culture codes, tag codes, size/quality abbreviations, admission rules, and portability rules are defined by the parent index and the expansion manifest.
+
+## Chests of drawers, specialist drawers, and lockable drawer cabinets — 50
+
+Variations change drawer depth, orientation, specialist contents, cabinet height, and whether a built-in lock secures the whole unit.
+
+```text
+renaissance_furniture_expansion_wer_apothecary_drawers_03|a low arcaded cedar apothecary drawers|cedar|L/G|25700/126|FX20|WER|FU-N,COURT|small labelled ingredient drawers; fixed furniture
+renaissance_furniture_expansion_wer_coin_drawer_cabinet_02|a coffered walnut coin drawer cabinet|walnut|VL/S|68000/278|FX21|WER|FU-N,SERVICE|built-in-lock small-value drawers; built-in lock
+renaissance_furniture_expansion_wer_tall_drawer_cabinet_01|a low moulded walnut tall drawer cabinet|walnut|VL/S|78600/227|FX20|WER|FU-N,GUILD|narrow vertical drawer storage; fixed furniture
+renaissance_furniture_expansion_iba_lock_fitted_drawer_chest_02|a leather-faced walnut lock-fitted drawer chest|walnut|VL/GR|74250/760|FX21|IBA|FU-L,RELIGIOUS|built-in-lock drawer storage; built-in lock
+renaissance_furniture_expansion_iba_map_drawers_03|a star-pierced cedar map drawers|cedar|VL/VG|64300/385|FX20|IBA|FU-L,RELIGIOUS|broad shallow sheet storage; fixed furniture
+renaissance_furniture_expansion_iba_tall_drawer_cabinet_01|an octagonal panelled walnut tall drawer cabinet|walnut|H/SS|142250/304|FX20|IBA|FU-S,COURT|narrow vertical drawer storage; fixed furniture
+renaissance_furniture_expansion_cen_chest_of_drawers_03|an iron-strapped ash chest of drawers|ash|VL/G|70400/256|FX20|CEN|FU-N,GUILD|stacked household drawer storage; fixed furniture
+renaissance_furniture_expansion_cen_lock_fitted_drawer_chest_02|a tall carved beech lock-fitted drawer chest|beech|L/S|35600/83|FX21|CEN|FU-N,GUILD|built-in-lock drawer storage; built-in lock
+renaissance_furniture_expansion_cen_low_drawer_chest_01|a painted oak low drawer chest|oak|VL/SS|68550/140|FX20|CEN|FU-S,COURT|wide low drawer storage; fixed furniture
+renaissance_furniture_expansion_nba_chest_of_drawers_02|a long heavy-framed spruce chest of drawers|spruce|VL/SS|66200/92|FX20|NBA|FU-S|stacked household drawer storage; fixed furniture
+renaissance_furniture_expansion_nba_many_drawer_cabinet_01|a broad heavy-framed beech many-drawer cabinet|beech|L/G|31750/118|FX20|NBA|FU-N,MARITIME|many small sorting drawers; fixed furniture
+renaissance_furniture_expansion_cef_textile_drawers_01|an iron-bound pine textile drawers|pine|L/G|24900/105|FX20|CEF|FU-N,COURT|deep folded-textile storage; fixed furniture
+renaissance_furniture_expansion_cef_textile_drawers_02|an octagonal plain-joined beech textile drawers|beech|L/S|30150/82|FX20|CEF|FU-N,COURT|deep folded-textile storage; fixed furniture
+renaissance_furniture_expansion_eon_many_drawer_cabinet_01|an arched birch many-drawer cabinet|birch|L/S|25800/71|FX20|EON|FU-N,RELIGIOUS|many small sorting drawers; fixed furniture
+renaissance_furniture_expansion_ott_coin_drawer_cabinet_01|a compact low lacquer coin drawer cabinet|lacquer|L/S|33500/148|FX21|OTT|FU-N|built-in-lock small-value drawers; built-in lock
+renaissance_furniture_expansion_ott_low_drawer_chest_02|a broad recessed-panel lacquer low drawer chest|lacquer|VL/G|68450/384|FX20|OTT|FU-N,RELIGIOUS|wide low drawer storage; fixed furniture
+renaissance_furniture_expansion_ott_textile_drawers_03|a low cypress textile drawers|cypress|VL/S|58200/192|FX20|OTT|FU-N|deep folded-textile storage; fixed furniture
+renaissance_furniture_expansion_pip_chest_of_drawers_01|a painted teak chest of drawers|teak|L/S|29750/117|FX20|PIP|FU-N|stacked household drawer storage; fixed furniture
+renaissance_furniture_expansion_sas_lock_fitted_drawer_chest_04|a brass-studded bamboo lock-fitted drawer chest|bamboo|VL/G|38750/174|FX21|SAS|FU-N,SERVICE|built-in-lock drawer storage; built-in lock
+renaissance_furniture_expansion_sas_low_drawer_chest_03|a low teak low drawer chest|teak|L/G|30000/229|FX20|SAS|FU-N,RELIGIOUS|wide low drawer storage; fixed furniture
+renaissance_furniture_expansion_sas_tall_drawer_cabinet_01|an arched-top deep-carved bamboo tall drawer cabinet|bamboo|H/S|72050/237|FX20|SAS|FU-N,COURT|narrow vertical drawer storage; fixed furniture
+renaissance_furniture_expansion_sas_textile_drawers_02|a pierced sandalwood textile drawers|sandalwood|VL/VG|71500/854|FX20|SAS|FU-L,RELIGIOUS|deep folded-textile storage; fixed furniture
+renaissance_furniture_expansion_eal_chest_of_drawers_02|a plain-joined pine chest of drawers|pine|L/VG|25850/148|FX20|EAL|FU-L|stacked household drawer storage; fixed furniture
+renaissance_furniture_expansion_eal_document_drawers_01|a low open-backed lacquer document drawers|lacquer|L/G|31400/176|FX20|EAL|FU-N|shallow document storage; fixed furniture
+renaissance_furniture_expansion_jpn_document_drawers_01|a black-lacquered cedar document drawers|cedar|L/G|29800/140|FX20|JPN|FU-N|shallow document storage; fixed furniture
+renaissance_furniture_expansion_jpn_lock_fitted_drawer_chest_02|a wide low pine lock-fitted drawer chest|pine|VL/E|68650/712|FX21|JPN|FU-L,RELIGIOUS|built-in-lock drawer storage; built-in lock
+renaissance_furniture_expansion_jpn_textile_drawers_03|an asymmetrical cedar textile drawers|cedar|L/G|24900/123|FX20|JPN|FU-N,COURT|deep folded-textile storage; fixed furniture
+renaissance_furniture_expansion_mea_chest_of_drawers_03|a tiered low lacquer chest of drawers|lacquer|L/G|34450/197|FX20|MEA|FU-N|stacked household drawer storage; fixed furniture
+renaissance_furniture_expansion_mea_coin_drawer_cabinet_01|a round-fronted brass-mounted cedar coin drawer cabinet|cedar|VL/G|59900/244|FX21|MEA|FU-N,MARITIME|built-in-lock small-value drawers; built-in lock
+renaissance_furniture_expansion_mea_many_drawer_cabinet_02|a low brass-mounted bamboo many-drawer cabinet|bamboo|VL/SS|43050/69|FX20|MEA|FU-S|many small sorting drawers; fixed furniture
+renaissance_furniture_expansion_sem_chest_of_drawers_01|a lacquered lacquer chest of drawers|lacquer|VL/G|74800/399|FX20|SEM|FU-N|stacked household drawer storage; fixed furniture
+renaissance_furniture_expansion_msea_low_drawer_chest_01|a broad shell-inlaid teak low drawer chest|teak|L/GR|34750/476|FX20|MSEA|FU-L,MARITIME|wide low drawer storage; fixed furniture
+renaissance_furniture_expansion_stp_apothecary_drawers_02|a broad plain-framed pine apothecary drawers|pine|L/VG|24900/148|FX20|STP|FU-L,COURT|small labelled ingredient drawers; fixed furniture
+renaissance_furniture_expansion_stp_chest_of_drawers_01|a low cedar chest of drawers|cedar|VL/G|60550/313|FX20|STP|FU-N|stacked household drawer storage; fixed furniture
+renaissance_furniture_expansion_aca_coin_drawer_cabinet_02|a square ivory-inlaid mahogany coin drawer cabinet|mahogany|VL/S|71950/297|FX21|ACA|FU-N|built-in-lock small-value drawers; built-in lock
+renaissance_furniture_expansion_aca_low_drawer_chest_03|a long brass-faced mahogany low drawer chest|mahogany|VL/G|72200/487|FX20|ACA|FU-N|wide low drawer storage; fixed furniture
+renaissance_furniture_expansion_aca_textile_drawers_01|a brass-faced wood textile drawers|wood|VL/S|78000/168|FX20|ACA|FU-N,GUILD|deep folded-textile storage; fixed furniture
+renaissance_furniture_expansion_sai_chest_of_drawers_01|a high openwork wood chest of drawers|wood|L/S|29050/85|FX20|SAI|FU-N|stacked household drawer storage; fixed furniture
+renaissance_furniture_expansion_sai_coin_drawer_cabinet_02|a leather-covered cedar coin drawer cabinet|cedar|L/GR|27000/353|FX21|SAI|FU-L,GUILD|built-in-lock small-value drawers; built-in lock
+renaissance_furniture_expansion_ind_document_drawers_02|a slatted bamboo document drawers|bamboo|VL/S|39100/123|FX20|IND|FU-N,GUILD|shallow document storage; fixed furniture
+renaissance_furniture_expansion_ind_many_drawer_cabinet_01|a rattan-panelled bamboo many-drawer cabinet|bamboo|VL/S|38450/101|FX20|IND|FU-N|many small sorting drawers; fixed furniture
+renaissance_furniture_expansion_col_chest_of_drawers_03|a deep iron-bound pine chest of drawers|pine|VL/SS|68000/105|FX20|COL|FU-S,RELIGIOUS|stacked household drawer storage; fixed furniture
+renaissance_furniture_expansion_col_low_drawer_chest_02|an iron-bound oak low drawer chest|oak|VL/G|71900/310|FX20|COL|FU-N|wide low drawer storage; fixed furniture
+renaissance_furniture_expansion_col_map_drawers_01|a plain-joined oak map drawers|oak|L/VG|34050/212|FX20|COL|FU-L,MARITIME|broad shallow sheet storage; fixed furniture
+renaissance_furniture_expansion_mar_apothecary_drawers_02|a tar-darkened teak apothecary drawers|teak|L/G|33750/227|FX20|MAR|FU-N|small labelled ingredient drawers; fixed furniture
+renaissance_furniture_expansion_mar_apothecary_drawers_03|a round-fronted sea-braced cedar apothecary drawers|cedar|VL/G|67000/251|FX20|MAR|FU-N,GUILD|small labelled ingredient drawers; fixed furniture
+renaissance_furniture_expansion_mar_chest_of_drawers_04|an arched-top sea-braced oak chest of drawers|oak|VL/G|70350/328|FX20|MAR|FU-N,MARITIME|stacked household drawer storage; fixed furniture
+renaissance_furniture_expansion_mar_lock_fitted_drawer_chest_06|an arched-top bulkhead-fitted oak lock-fitted drawer chest|oak|VL/VG|68300/437|FX21|MAR|FU-L|built-in-lock drawer storage; built-in lock
+renaissance_furniture_expansion_mar_tall_drawer_cabinet_01|a bulkhead-fitted teak tall drawer cabinet|teak|VL/S|80350/287|FX20|MAR|FU-N,GUILD|narrow vertical drawer storage; fixed furniture
+renaissance_furniture_expansion_mar_tall_drawer_cabinet_05|a square plain-framed teak tall drawer cabinet|teak|H/G|132800/835|FX20|MAR|FU-N,GUILD|narrow vertical drawer storage; fixed furniture
+```
+
+## Section validation
+
+- 50 rows and 50 unique stable references.
+- Rows inherit `Era / Renaissance Era` and the exact culture tag identified by their culture code.
+- No full descriptions are supplied in this pass.

--- a/Design Documents/Seeding/FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II_Plinths.md
+++ b/Design Documents/Seeding/FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II_Plinths.md
@@ -1,0 +1,58 @@
+# Display plinths, pedestals, vessel stands, and offering stands — Renaissance expansion section
+
+> Parent contract: [FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II.md](./FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II.md)
+
+This section contains **40 proposed prototypes**. Component codes, culture codes, tag codes, size/quality abbreviations, admission rules, and portability rules are defined by the parent index and the expansion manifest.
+
+## Display plinths, pedestals, vessel stands, and offering stands — 40
+
+Variations change supported object scale, surface material, portability, institutional role, and pedestal geometry.
+
+```text
+renaissance_furniture_expansion_wer_armour_plinth_01|a moulded beech armour plinth|beech|L/G|25450/111|FX18|WER|FU-N,OPEN,GUILD|broad military display base; fixed furniture
+renaissance_furniture_expansion_wer_stepped_plinth_03|a low linenfold wrought-iron stepped plinth|wrought iron|VL/S|104100/253|FX19|WER|FU-N,OPEN,GUILD|multi-level object display; fixed furniture
+renaissance_furniture_expansion_wer_urn_stand_02|a linenfold marble urn stand|marble|L/SS|37900/102|FX18|WER|FU-S,OPEN,SERVICE|ringed storage-vessel support; fixed furniture
+renaissance_furniture_expansion_iba_offering_stand_02|a massive coffered chestnut offering stand|chestnut|N/S|6200/31|FX18|IBA|FU-N,OPEN,RELIGIOUS|small institutional display surface; fixed furniture
+renaissance_furniture_expansion_iba_vessel_stand_01|a tiered plain-joined chestnut vessel stand|chestnut|L/S|25600/73|FX18|IBA|FU-N,OPEN,RELIGIOUS|raised vessel support; fixed furniture
+renaissance_furniture_expansion_cen_folding_display_stand_01|a high many-panelled pine folding display stand|pine|L/G|13050/73|FX38|CEN|FU-N,OPEN|portable folding display; portable/folding
+renaissance_furniture_expansion_cef_urn_stand_01|a narrow studded ash urn stand|ash|N/S|6250/27|FX18|CEF|FU-N,OPEN|ringed storage-vessel support; fixed furniture
+renaissance_furniture_expansion_pip_folding_display_stand_01|a tiered brass-mounted brass folding display stand|brass|N/S|9200/62|FX38|PIP|FU-N,OPEN|portable folding display; portable/folding
+renaissance_furniture_expansion_pip_offering_stand_03|a square recessed-panel lacquer offering stand|lacquer|L/VG|22300/225|FX18|PIP|FU-L,OPEN,COURT|small institutional display surface; fixed furniture
+renaissance_furniture_expansion_pip_vessel_stand_02|a brass-mounted teak vessel stand|teak|L/G|21650/135|FX18|PIP|FU-N,OPEN|raised vessel support; fixed furniture
+renaissance_furniture_expansion_sas_folding_display_stand_01|a narrow deep-carved lacquer folding display stand|lacquer|N/S|4800/43|FX38|SAS|FU-N,OPEN,SERVICE|portable folding display; portable/folding
+renaissance_furniture_expansion_sas_folding_display_stand_03|a massive low teak folding display stand|teak|L/G|15150/141|FX38|SAS|FU-N,OPEN,SERVICE|portable folding display; portable/folding
+renaissance_furniture_expansion_sas_offering_stand_02|a teak-framed sandalwood offering stand|sandalwood|N/S|7200/64|FX18|SAS|FU-N,OPEN,COURT|small institutional display surface; fixed furniture
+renaissance_furniture_expansion_eal_folding_display_stand_05|an octagonal painted stone folding display stand|stone|L/G|27000/145|FX38|EAL|FU-N,OPEN,RELIGIOUS|portable folding display; portable/folding
+renaissance_furniture_expansion_eal_statue_pedestal_03|an asymmetrical cypress statue pedestal|cypress|VL/G|50850/250|FX18|EAL|FU-N,OPEN,RELIGIOUS|heavy sculpture support; fixed furniture
+renaissance_furniture_expansion_eal_stepped_plinth_04|a plain-joined bamboo stepped plinth|bamboo|L/G|13750/72|FX18|EAL|FU-N,OPEN,RELIGIOUS|multi-level object display; fixed furniture
+renaissance_furniture_expansion_eal_urn_stand_01|a lattice-fronted brass urn stand|brass|L/G|42500/239|FX19|EAL|FU-N,OPEN,GUILD|ringed storage-vessel support; fixed furniture
+renaissance_furniture_expansion_eal_vessel_stand_02|a long lattice-fronted walnut vessel stand|walnut|N/S|6600/43|FX18|EAL|FU-N,OPEN,GUILD|raised vessel support; fixed furniture
+renaissance_furniture_expansion_jpn_stepped_plinth_01|an asymmetrical pine stepped plinth|pine|L/S|21950/50|FX18|JPN|FU-N,OPEN|multi-level object display; fixed furniture
+renaissance_furniture_expansion_jpn_urn_stand_02|a low recessed-panel alabaster urn stand|alabaster|L/S|40350/119|FX18|JPN|FU-N,OPEN,COURT|ringed storage-vessel support; fixed furniture
+renaissance_furniture_expansion_mea_folding_display_stand_02|a compact lacquered cypress folding display stand|cypress|N/GR|3850/102|FX38|MEA|FU-L,OPEN|portable folding display; portable/folding
+renaissance_furniture_expansion_mea_lamp_stand_01|a tall shell-faced cypress lamp stand|cypress|N/S|6200/29|FX18|MEA|FU-N,OPEN|raised lamp support; fixed furniture
+renaissance_furniture_expansion_sem_armour_plinth_01|an openwork alabaster armour plinth|alabaster|L/S|37550/131|FX18|SEM|FU-N,OPEN,RELIGIOUS|broad military display base; fixed furniture
+renaissance_furniture_expansion_sem_display_plinth_02|a deep-carved lacquer display plinth|lacquer|VL/SS|61150/150|FX18|SEM|FU-S,OPEN|single-object display surface; fixed furniture
+renaissance_furniture_expansion_sem_statue_pedestal_03|a compact low lacquer statue pedestal|lacquer|VL/S|61300/163|FX18|SEM|FU-N,OPEN|heavy sculpture support; fixed furniture
+renaissance_furniture_expansion_sem_urn_stand_04|a lacquered stone urn stand|stone|N/S|11700/36|FX18|SEM|FU-N,OPEN|ringed storage-vessel support; fixed furniture
+renaissance_furniture_expansion_msea_folding_display_stand_01|a deep openwork rattan folding display stand|rattan|N/SS|2750/11|FX38|MSEA|FU-S,OPEN,RELIGIOUS|portable folding display; portable/folding
+renaissance_furniture_expansion_msea_folding_display_stand_02|a compact lacquered alabaster folding display stand|alabaster|L/SS|24250/72|FX38|MSEA|FU-S,OPEN|portable folding display; portable/folding
+renaissance_furniture_expansion_stp_statue_pedestal_01|a saddle-narrow pine statue pedestal|pine|H/S|81750/216|FX18|STP|FU-N,OPEN|heavy sculpture support; fixed furniture
+renaissance_furniture_expansion_aca_folding_display_stand_02|an octagonal pedestal alabaster folding display stand|alabaster|L/VG|28500/291|FX38|ACA|FU-L,OPEN,COURT|portable folding display; portable/folding
+renaissance_furniture_expansion_aca_statue_pedestal_01|an openwork wood statue pedestal|wood|VL/G|56550/202|FX18|ACA|FU-N,OPEN,COURT|heavy sculpture support; fixed furniture
+renaissance_furniture_expansion_rse_urn_stand_01|an octagonal leather-covered earthenware urn stand|earthenware|N/G|12150/36|FX18|RSE|FU-N,OPEN|ringed storage-vessel support; fixed furniture
+renaissance_furniture_expansion_ind_display_plinth_01|a narrow rattan-panelled bamboo display plinth|bamboo|N/SS|3500/12|FX18|IND|FU-S,OPEN|single-object display surface; fixed furniture
+renaissance_furniture_expansion_ind_statue_pedestal_02|a compact plain-joined rattan statue pedestal|rattan|L/S|14200/42|FX18|IND|FU-N,OPEN|heavy sculpture support; fixed furniture
+renaissance_furniture_expansion_mes_armour_plinth_04|a round-fronted raised earthenware armour plinth|earthenware|VL/S|85300/96|FX18|MES|FU-N,OPEN,RELIGIOUS|broad military display base; fixed furniture
+renaissance_furniture_expansion_mes_folding_display_stand_02|a plain-framed stone folding display stand|stone|N/S|7750/39|FX38|MES|FU-N,OPEN,COURT|portable folding display; portable/folding
+renaissance_furniture_expansion_mes_offering_stand_01|a woven-panel wicker offering stand|wicker|N/G|3450/22|FX18|MES|FU-N,OPEN,RELIGIOUS|small institutional display surface; fixed furniture
+renaissance_furniture_expansion_mes_offering_stand_03|a stepped stone offering stand|stone|L/VG|37100/186|FX18|MES|FU-L,OPEN|small institutional display surface; fixed furniture
+renaissance_furniture_expansion_car_urn_stand_01|a shell-inlaid wicker urn stand|wicker|L/G|13550/51|FX18|CAR|FU-N,OPEN,COURT|ringed storage-vessel support; fixed furniture
+renaissance_furniture_expansion_nac_armour_plinth_01|a low woven-panel wood armour plinth|wood|VL/SS|58650/96|FX18|NAC|FU-S,OPEN|broad military display base; fixed furniture
+```
+
+## Section validation
+
+- 40 rows and 40 unique stable references.
+- Rows inherit `Era / Renaissance Era` and the exact culture tag identified by their culture code.
+- No full descriptions are supplied in this pass.

--- a/Design Documents/Seeding/FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II_Side_Tables.md
+++ b/Design Documents/Seeding/FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II_Side_Tables.md
@@ -1,0 +1,63 @@
+# Side tables, end tables, nightstands, and compact lockable cabinets — Renaissance expansion section
+
+> Parent contract: [FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II.md](./FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II.md)
+
+This section contains **45 proposed prototypes**. Component codes, culture codes, tag codes, size/quality abbreviations, admission rules, and portability rules are defined by the parent index and the expansion manifest.
+
+## Side tables, end tables, nightstands, and compact lockable cabinets — 45
+
+Variations range from open lamp and corner tables to drawer nightstands, portable folding tables, and built-in-lock bedside cabinets.
+
+```text
+renaissance_furniture_expansion_wer_corner_table_01|a tiered marquetry-fronted beech corner table|beech|N/SS|4600/14|FX15|WER|FU-S,OPEN,COURT|triangular corner surface; fixed furniture
+renaissance_furniture_expansion_wer_end_table_02|a carved walnut end table|walnut|N/SS|4000/19|FX15|WER|FU-S,OPEN,SERVICE|compact end-of-seat surface; fixed furniture
+renaissance_furniture_expansion_wer_lamp_table_03|a tiered pilastered chestnut lamp table|chestnut|L/S|14900/41|FX15|WER|FU-N,OPEN,COURT|small lamp and vessel surface; fixed furniture
+renaissance_furniture_expansion_cen_drawer_nightstand_01|a small many-panelled brass drawer nightstand|brass|N/G|7900/72|FX16|CEN|FU-N|compact multi-drawer bedside storage; fixed furniture
+renaissance_furniture_expansion_cen_nightstand_03|a plain-joined ash nightstand|ash|L/S|15750/47|FX16|CEN|FU-N,GUILD|small bedside drawer storage; fixed furniture
+renaissance_furniture_expansion_cen_side_table_02|an octagonal slatted beech side table|beech|L/S|16000/46|FX15|CEN|FU-N,OPEN|small open furniture surface; fixed furniture
+renaissance_furniture_expansion_nba_lock_fitted_nightstand_01|a massive stave-faced pine lock-fitted nightstand|pine|N/VG|3550/34|FX17|NBA|FU-L,MARITIME|small built-in-lock bedside cabinet; built-in lock
+renaissance_furniture_expansion_nba_side_table_02|a stave-faced oak side table|oak|L/SS|16850/35|FX15|NBA|FU-S,OPEN|small open furniture surface; fixed furniture
+renaissance_furniture_expansion_ott_folding_side_table_03|a high lattice-fronted copper folding side table|copper|N/S|5950/31|FX36|OTT|FU-N,OPEN|portable folding surface; portable/folding
+renaissance_furniture_expansion_ott_lock_fitted_nightstand_01|a low brass-mounted boxwood lock-fitted nightstand|boxwood|L/G|16250/81|FX17|OTT|FU-N,COURT|small built-in-lock bedside cabinet; built-in lock
+renaissance_furniture_expansion_ott_nightstand_02|a brass-mounted cypress nightstand|cypress|N/VG|3850/43|FX16|OTT|FU-L,COURT|small bedside drawer storage; fixed furniture
+renaissance_furniture_expansion_pip_bedside_table_02|an arched teak bedside table|teak|L/S|15700/60|FX16|PIP|FU-N|bedside surface with storage; fixed furniture
+renaissance_furniture_expansion_pip_nightstand_01|a brass-mounted cedar nightstand|cedar|L/E|14150/221|FX16|PIP|FU-L|small bedside drawer storage; fixed furniture
+renaissance_furniture_expansion_sas_folding_side_table_01|a pierced brass folding side table|brass|N/S|5000/39|FX36|SAS|FU-N,OPEN|portable folding surface; portable/folding
+renaissance_furniture_expansion_eal_drawer_nightstand_01|a low asymmetrical pine drawer nightstand|pine|N/S|3950/13|FX16|EAL|FU-N,RELIGIOUS|compact multi-drawer bedside storage; fixed furniture
+renaissance_furniture_expansion_eal_side_table_02|an asymmetrical lacquer side table|lacquer|N/G|4450/46|FX15|EAL|FU-N,OPEN|small open furniture surface; fixed furniture
+renaissance_furniture_expansion_jpn_lamp_table_02|a plain-joined cedar lamp table|cedar|L/G|14350/77|FX15|JPN|FU-N,OPEN|small lamp and vessel surface; fixed furniture
+renaissance_furniture_expansion_jpn_nightstand_01|an octagonal stackable lacquer nightstand|lacquer|N/S|4000/26|FX16|JPN|FU-N|small bedside drawer storage; fixed furniture
+renaissance_furniture_expansion_mea_end_table_01|a tiered shell-faced lacquer end table|lacquer|N/S|4050/28|FX15|MEA|FU-N,OPEN,COURT|compact end-of-seat surface; fixed furniture
+renaissance_furniture_expansion_sem_lock_fitted_nightstand_01|a narrow deep-carved bamboo lock-fitted nightstand|bamboo|L/S|7750/24|FX17|SEM|FU-N|small built-in-lock bedside cabinet; built-in lock
+renaissance_furniture_expansion_msea_corner_table_03|a deep lacquered bronze corner table|bronze|L/G|30000/147|FX15|MSEA|FU-N,OPEN,GUILD|triangular corner surface; fixed furniture
+renaissance_furniture_expansion_msea_drawer_nightstand_01|an arched-top lacquered rattan drawer nightstand|rattan|N/VG|2550/22|FX16|MSEA|FU-L,MARITIME|compact multi-drawer bedside storage; fixed furniture
+renaissance_furniture_expansion_msea_end_table_02_lockable|a lock-fitted broad openwork brass end table|brass|L/G|30700/133|FX17|MSEA|FU-N,OPEN,MARITIME|compact end-of-seat surface; built-in lock
+renaissance_furniture_expansion_stp_end_table_01|an iron-bound cedar end table|cedar|L/G|12950/74|FX15|STP|FU-N,OPEN,COURT|compact end-of-seat surface; fixed furniture
+renaissance_furniture_expansion_stp_lock_fitted_nightstand_02|a collapsible wrought-iron lock-fitted nightstand|wrought iron|N/VG|7950/88|FX17|STP|FU-L,COURT|small built-in-lock bedside cabinet; built-in lock
+renaissance_furniture_expansion_aca_bedside_table_03|a pedestal bronze bedside table|bronze|L/S|25350/100|FX16|ACA|FU-N,GUILD|bedside surface with storage; fixed furniture
+renaissance_furniture_expansion_aca_corner_table_01_lockable|a lock-fitted low bronze corner table|bronze|L/G|26450/142|FX17|ACA|FU-N,OPEN|triangular corner surface; built-in lock
+renaissance_furniture_expansion_aca_lamp_table_02|a compact openwork wicker lamp table|wicker|N/G|2550/13|FX15|ACA|FU-N,OPEN,COURT|small lamp and vessel surface; fixed furniture
+renaissance_furniture_expansion_sai_corner_table_01|a brass-bound wicker corner table|wicker|N/S|2200/10|FX15|SAI|FU-N,OPEN,GUILD|triangular corner surface; fixed furniture
+renaissance_furniture_expansion_sai_nightstand_02|a reed-fronted wicker nightstand|wicker|N/S|2250/10|FX16|SAI|FU-N|small bedside drawer storage; fixed furniture
+renaissance_furniture_expansion_rse_corner_table_01|a leather-covered earthenware corner table|earthenware|L/G|23400/47|FX15|RSE|FU-N,OPEN,MARITIME|triangular corner surface; fixed furniture
+renaissance_furniture_expansion_rse_side_table_02|a square low olivewood side table|olive wood|L/G|14100/91|FX15|RSE|FU-N,OPEN,RELIGIOUS|small open furniture surface; fixed furniture
+renaissance_furniture_expansion_ind_folding_side_table_03|a lattice-fronted rattan folding side table|rattan|N/VG|1800/23|FX36|IND|FU-L,OPEN|portable folding surface; portable/folding
+renaissance_furniture_expansion_ind_nightstand_01|a slatted ceramic nightstand|ceramic|L/G|26150/79|FX16|IND|FU-N|small bedside drawer storage; fixed furniture
+renaissance_furniture_expansion_ind_side_table_02|a low rattan-panelled rattan side table|rattan|N/VG|2250/24|FX15|IND|FU-L,OPEN,MARITIME|small open furniture surface; fixed furniture
+renaissance_furniture_expansion_mes_lamp_table_01|a deep reed-bound reed lamp table|reed|L/VG|8350/51|FX15|MES|FU-L,OPEN|small lamp and vessel surface; fixed furniture
+renaissance_furniture_expansion_and_folding_side_table_01|a massive painted reed folding side table|reed|N/G|1750/15|FX36|AND|FU-N,OPEN|portable folding surface; portable/folding
+renaissance_furniture_expansion_and_side_table_02|a tall painted stone side table|stone|L/G|26150/88|FX15|AND|FU-N,OPEN,SERVICE|small open furniture surface; fixed furniture
+renaissance_furniture_expansion_car_side_table_01|a shell-inlaid cane side table|cane|L/GR|7850/97|FX15|CAR|FU-L,OPEN|small open furniture surface; fixed furniture
+renaissance_furniture_expansion_nac_lamp_table_02|a compact lashed wicker lamp table|wicker|N/S|2400/10|FX15|NAC|FU-N,OPEN,GUILD|small lamp and vessel surface; fixed furniture
+renaissance_furniture_expansion_nac_side_table_01|a tall bentwood cane side table|cane|L/S|9450/23|FX15|NAC|FU-N,OPEN|small open furniture surface; fixed furniture
+renaissance_furniture_expansion_col_drawer_nightstand_02|a wide painted cedar drawer nightstand|cedar|L/G|13250/63|FX16|COL|FU-N,GUILD|compact multi-drawer bedside storage; fixed furniture
+renaissance_furniture_expansion_col_end_table_01|a carved pine end table|pine|L/G|12200/47|FX15|COL|FU-N,OPEN|compact end-of-seat surface; fixed furniture
+renaissance_furniture_expansion_mar_nightstand_02|a broad slotted oak nightstand|oak|N/SS|4000/14|FX16|MAR|FU-S|small bedside drawer storage; fixed furniture
+renaissance_furniture_expansion_mar_side_table_01|a tiered collapsible teak side table|teak|L/VG|14500/141|FX15|MAR|FU-L,OPEN,MARITIME|small open furniture surface; fixed furniture
+```
+
+## Section validation
+
+- 45 rows and 45 unique stable references.
+- Rows inherit `Era / Renaissance Era` and the exact culture tag identified by their culture code.
+- No full descriptions are supplied in this pass.

--- a/Design Documents/Seeding/FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_I_Armour_Stands.md
+++ b/Design Documents/Seeding/FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_I_Armour_Stands.md
@@ -1,0 +1,63 @@
+# Armour stands, armour trees, and harness supports — Renaissance expansion section
+
+> Parent contract: [FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_I.md](./FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_I.md)
+
+This section contains **45 proposed prototypes**. Component codes, culture codes, tag codes, size/quality abbreviations, admission rules, and portability rules are defined by the parent index and the expansion manifest.
+
+## Armour stands, armour trees, and harness supports — 45
+
+Variations cover full harness, mail, lamellar, helmet-and-cuirass, saddle harness, metal display, and folding campaign support.
+
+```text
+renaissance_furniture_expansion_wer_campaign_armour_tree_03|an arcaded walnut campaign armour tree|walnut|L/VG|13900/170|FX35|WER|FU-L,OPEN,MIL,COURT|portable folding armour support; portable/folding
+renaissance_furniture_expansion_wer_harness_stand_01|a carved cedar harness stand|cedar|H/VG|70450/503|FX05|WER|FU-L,OPEN,MIL|full-height harness display; fixed furniture
+renaissance_furniture_expansion_wer_metal_armour_display_02|a high iron-bound walnut metal armour display|walnut|VL/VG|44850/328|FX05|WER|FU-L,OPEN,MIL,GUILD|rigid metal display support; fixed furniture
+renaissance_furniture_expansion_iba_campaign_armour_tree_02|a round-fronted plain-joined oak campaign armour tree|oak|L/S|14000/59|FX35|IBA|FU-N,OPEN,MIL|portable folding armour support; portable/folding
+renaissance_furniture_expansion_iba_harness_stand_01|an octagonal plain-joined boxwood harness stand|boxwood|VL/S|41800/137|FX04|IBA|FU-N,OPEN,MIL|full-height harness display; fixed furniture
+renaissance_furniture_expansion_iba_helmet_cuirass_stand_03|a small star-pierced boxwood helmet-and-cuirass stand|boxwood|L/SS|20650/42|FX04|IBA|FU-S,OPEN,MIL|combined helmet and torso-armour display; fixed furniture
+renaissance_furniture_expansion_cen_helmet_cuirass_stand_01|a low painted pine helmet-and-cuirass stand|pine|L/G|17850/70|FX04|CEN|FU-N,OPEN,MIL,GUILD|combined helmet and torso-armour display; fixed furniture
+renaissance_furniture_expansion_nba_harness_stand_01|a pale-boarded ash harness stand|ash|H/S|80950/190|FX05|NBA|FU-N,OPEN,MIL,MARITIME|full-height harness display; fixed furniture
+renaissance_furniture_expansion_cef_saddle_harness_stand_01|a wide leather-faced pine saddle-harness stand|pine|H/G|74650/214|FX05|CEF|FU-N,OPEN,MIL,COURT|open support for mounted harness and tack; fixed furniture
+renaissance_furniture_expansion_eon_lamellar_armour_stand_02|a wide slatted wrought-iron lamellar armour stand|wrought iron|L/G|39250/157|FX06|EON|FU-N,OPEN,MIL,COURT|wide support for laced armour; fixed furniture
+renaissance_furniture_expansion_eon_metal_armour_display_01|an arched-top slatted wrought-iron metal armour display|wrought iron|VL/S|81400/189|FX06|EON|FU-N,OPEN,MIL,RELIGIOUS|rigid metal display support; fixed furniture
+renaissance_furniture_expansion_ott_harness_stand_02|a painted boxwood harness stand|boxwood|VL/S|42250/127|FX05|OTT|FU-N,OPEN,MIL,COURT|full-height harness display; fixed furniture
+renaissance_furniture_expansion_ott_helmet_cuirass_stand_01|a broad lattice-fronted boxwood helmet-and-cuirass stand|boxwood|VL/S|50150/134|FX05|OTT|FU-N,OPEN,MIL,RELIGIOUS|combined helmet and torso-armour display; fixed furniture
+renaissance_furniture_expansion_pip_campaign_armour_tree_03|a tall mirror-inlaid cedar campaign armour tree|cedar|L/S|11200/53|FX35|PIP|FU-N,OPEN,MIL,COURT|portable folding armour support; portable/folding
+renaissance_furniture_expansion_pip_lamellar_armour_stand_02|a square low cedar lamellar armour stand|cedar|VL/S|37550/108|FX05|PIP|FU-N,OPEN,MIL|wide support for laced armour; fixed furniture
+renaissance_furniture_expansion_pip_metal_armour_display_01|a mirror-inlaid silver metal armour display|silver|L/G|34150/423|FX06|PIP|FU-N,OPEN,MIL|rigid metal display support; fixed furniture
+renaissance_furniture_expansion_sas_harness_stand_01|a small deep-carved bamboo harness stand|bamboo|H/S|46000/117|FX05|SAS|FU-N,OPEN,MIL,COURT|full-height harness display; fixed furniture
+renaissance_furniture_expansion_jpn_armour_tree_01|a recessed-panel wrought-iron armour tree|wrought iron|L/VG|35750/217|FX06|JPN|FU-L,OPEN,MIL,COURT|open support for a complete armour set; fixed furniture
+renaissance_furniture_expansion_jpn_armour_tree_02|a massive slatted cedar armour tree|cedar|L/S|16700/59|FX04|JPN|FU-N,OPEN,MIL|open support for a complete armour set; fixed furniture
+renaissance_furniture_expansion_jpn_helmet_cuirass_stand_03|a high slatted bamboo helmet-and-cuirass stand|bamboo|L/G|10200/60|FX05|JPN|FU-N,OPEN,MIL,COURT|combined helmet and torso-armour display; fixed furniture
+renaissance_furniture_expansion_jpn_mail_stand_04|an octagonal plain-joined lacquer mail stand|lacquer|VL/SS|47350/111|FX05|JPN|FU-S,OPEN,MIL|broad-shouldered mail support; fixed furniture
+renaissance_furniture_expansion_mea_campaign_armour_tree_01|a long shell-faced cypress campaign armour tree|cypress|L/GR|11050/205|FX35|MEA|FU-L,OPEN,MIL|portable folding armour support; portable/folding
+renaissance_furniture_expansion_sem_armour_tree_01|a gilded rattan armour tree|rattan|VL/S|23750/61|FX05|SEM|FU-N,OPEN,MIL|open support for a complete armour set; fixed furniture
+renaissance_furniture_expansion_msea_armour_tree_01|a painted brass armour tree|brass|VL/G|76950/371|FX06|MSEA|FU-N,OPEN,MIL,GUILD|open support for a complete armour set; fixed furniture
+renaissance_furniture_expansion_msea_harness_stand_02|a shell-inlaid bronze harness stand|bronze|H/S|168350/421|FX06|MSEA|FU-N,OPEN,MIL,GUILD|full-height harness display; fixed furniture
+renaissance_furniture_expansion_stp_armour_tree_04|a tiered felt-lined birch armour tree|birch|VL/G|41950/169|FX04|STP|FU-N,OPEN,MIL,MARITIME|open support for a complete armour set; fixed furniture
+renaissance_furniture_expansion_stp_campaign_armour_tree_02|a leather-covered cedar campaign armour tree|cedar|L/G|12400/84|FX35|STP|FU-N,OPEN,MIL,MARITIME|portable folding armour support; portable/folding
+renaissance_furniture_expansion_stp_mail_stand_01|a high saddle-narrow cedar mail stand|cedar|L/S|15450/48|FX05|STP|FU-N,OPEN,MIL|broad-shouldered mail support; fixed furniture
+renaissance_furniture_expansion_stp_mail_stand_03|a leather-covered pine mail stand|pine|VL/GR|37050/274|FX04|STP|FU-L,OPEN,MIL|broad-shouldered mail support; fixed furniture
+renaissance_furniture_expansion_sai_campaign_armour_tree_02|a painted brass campaign armour tree|brass|L/S|25900/123|FX35|SAI|FU-N,OPEN,MIL|portable folding armour support; portable/folding
+renaissance_furniture_expansion_sai_helmet_cuirass_stand_01|a deep-carved wood helmet-and-cuirass stand|wood|L/G|19450/75|FX04|SAI|FU-N,OPEN,MIL|combined helmet and torso-armour display; fixed furniture
+renaissance_furniture_expansion_ind_harness_stand_01|a slender teak-framed rattan harness stand|rattan|H/S|50050/102|FX05|IND|FU-N,OPEN,MIL|full-height harness display; fixed furniture
+renaissance_furniture_expansion_ind_harness_stand_03|a massive low bamboo harness stand|bamboo|H/G|47900/166|FX04|IND|FU-N,OPEN,MIL|full-height harness display; fixed furniture
+renaissance_furniture_expansion_ind_mail_stand_02|a compact slatted rattan mail stand|rattan|L/S|11450/34|FX04|IND|FU-N,OPEN,MIL|broad-shouldered mail support; fixed furniture
+renaissance_furniture_expansion_mes_armour_tree_01|a low openwork wood armour tree|wood|L/S|21650/62|FX05|MES|FU-N,OPEN,MIL,RELIGIOUS|open support for a complete armour set; fixed furniture
+renaissance_furniture_expansion_mes_helmet_cuirass_stand_02|a deep reed-bound wicker helmet-and-cuirass stand|wicker|VL/VG|25350/132|FX04|MES|FU-L,OPEN,MIL|combined helmet and torso-armour display; fixed furniture
+renaissance_furniture_expansion_and_campaign_armour_tree_01|a lashed reed campaign armour tree|reed|L/S|6700/27|FX35|AND|FU-N,OPEN,MIL|portable folding armour support; portable/folding
+renaissance_furniture_expansion_and_harness_stand_02|an arched-top plain-framed reed harness stand|reed|H/S|44350/103|FX05|AND|FU-N,OPEN,MIL|full-height harness display; fixed furniture
+renaissance_furniture_expansion_and_harness_stand_03|a square low reed harness stand|reed|VL/G|26650/67|FX05|AND|FU-N,OPEN,MIL,SERVICE|full-height harness display; fixed furniture
+renaissance_furniture_expansion_car_harness_stand_01|a narrow deep-carved reed harness stand|reed|H/G|43650/132|FX05|CAR|FU-N,OPEN,MIL,COURT|full-height harness display; fixed furniture
+renaissance_furniture_expansion_car_helmet_cuirass_stand_02|a long cane-framed reed helmet-and-cuirass stand|reed|L/G|11600/43|FX05|CAR|FU-N,OPEN,MIL|combined helmet and torso-armour display; fixed furniture
+renaissance_furniture_expansion_nac_helmet_cuirass_stand_01|a hide-covered wicker helmet-and-cuirass stand|wicker|L/S|10550/29|FX04|NAC|FU-N,OPEN,MIL,GUILD|combined helmet and torso-armour display; fixed furniture
+renaissance_furniture_expansion_col_lamellar_armour_stand_01|a slatted brass lamellar armour stand|brass|VL/P|85600/95|FX06|COL|FU-S,OPEN,MIL,RELIGIOUS|wide support for laced armour; fixed furniture
+renaissance_furniture_expansion_mar_helmet_cuirass_stand_02|an iron-bound cedar helmet-and-cuirass stand|cedar|VL/VG|41650/231|FX05|MAR|FU-L,OPEN,MIL,GUILD|combined helmet and torso-armour display; fixed furniture
+renaissance_furniture_expansion_mar_lamellar_armour_stand_01|a bolted wrought-iron lamellar armour stand|wrought iron|L/VG|32700/197|FX06|MAR|FU-L,OPEN,MIL,MARITIME|wide support for laced armour; fixed furniture
+```
+
+## Section validation
+
+- 45 rows and 45 unique stable references.
+- Rows inherit `Era / Renaissance Era` and the exact culture tag identified by their culture code.
+- No full descriptions are supplied in this pass.

--- a/Design Documents/Seeding/FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_I_Display.md
+++ b/Design Documents/Seeding/FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_I_Display.md
@@ -1,0 +1,73 @@
+# Display cabinets, cases, and open display shelving — Renaissance expansion section
+
+> Parent contract: [FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_I.md](./FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_I.md)
+
+This section contains **55 proposed prototypes**. Component codes, culture codes, tag codes, size/quality abbreviations, admission rules, and portability rules are defined by the parent index and the expansion manifest.
+
+## Display cabinets, cases, and open display shelving — 55
+
+Variations distinguish transparent cases, glass-front cabinets, open or lattice shelving, plate and porcelain storage, specimen/curiosity display, and built-in locks.
+
+```text
+renaissance_furniture_expansion_wer_lock_fitted_display_cabinet_02|a slender panelled oak lock-fitted display cabinet|oak|H/G|140900/649|FX14|WER|FU-N|transparent built-in-lock display; built-in lock
+renaissance_furniture_expansion_wer_plate_display_cabinet_01|a tall pilastered cedar plate display cabinet|cedar|L/G|24950/140|FX12|WER|FU-N,GUILD|shallow vessel and plate display; fixed furniture
+renaissance_furniture_expansion_wer_specimen_cabinet_03_lockable|a lock-fitted coffered oak specimen cabinet|oak|VL/E|78850/1260|FX14|WER|FU-L,COURT|small-object collection display; built-in lock
+renaissance_furniture_expansion_iba_specimen_cabinet_01|a coffered boxwood specimen cabinet|boxwood|VL/S|74350/241|FX11|IBA|FU-N|small-object collection display; fixed furniture
+renaissance_furniture_expansion_cen_porcelain_display_cabinet_01|a small heavy-framed linden porcelain display cabinet|linden|VL/G|64100/220|FX12|CEN|FU-N,GUILD|padded ceramic display; fixed furniture
+renaissance_furniture_expansion_cen_specimen_cabinet_02|a joined ash specimen cabinet|ash|VL/G|81650/286|FX11|CEN|FU-N,GUILD|small-object collection display; fixed furniture
+renaissance_furniture_expansion_cef_glazed_display_case_02|a low painted oak glazed display case|oak|L/G|32700/174|FX11|CEF|FU-N,GUILD|transparent enclosed display; fixed furniture
+renaissance_furniture_expansion_cef_specimen_cabinet_01|a wide carved beech specimen cabinet|beech|L/S|29350/90|FX11|CEF|FU-N|small-object collection display; fixed furniture
+renaissance_furniture_expansion_eon_open_display_shelves_01|a high slatted pine open display shelves|pine|VL/G|67900/233|FX13|EON|FU-N,OPEN|open tiered display; fixed furniture
+renaissance_furniture_expansion_ott_glazed_display_case_04|a narrow recessed-panel boxwood glazed display case|boxwood|VL/G|81350/383|FX11|OTT|FU-N,COURT|transparent enclosed display; fixed furniture
+renaissance_furniture_expansion_ott_lock_fitted_display_cabinet_05|an arcaded cypress lock-fitted display cabinet|cypress|H/S|123550/358|FX14|OTT|FU-N|transparent built-in-lock display; built-in lock
+renaissance_furniture_expansion_ott_open_display_shelves_01|a painted walnut open display shelves|walnut|VL/GR|82600/789|FX13|OTT|FU-L,OPEN|open tiered display; fixed furniture
+renaissance_furniture_expansion_ott_plate_display_cabinet_03|a deep geometric-inlaid cedar plate display cabinet|cedar|VL/G|60800/296|FX12|OTT|FU-N|shallow vessel and plate display; fixed furniture
+renaissance_furniture_expansion_ott_porcelain_display_cabinet_06|a high brass-mounted lacquer porcelain display cabinet|lacquer|L/G|29400/224|FX12|OTT|FU-N,COURT|padded ceramic display; fixed furniture
+renaissance_furniture_expansion_ott_scroll_display_cabinet_07|a slender lattice-fronted walnut scroll display cabinet|walnut|L/VG|32700/267|FX13|OTT|FU-L,OPEN,GUILD|open scroll and book display; fixed furniture
+renaissance_furniture_expansion_ott_vessel_display_stand_02|a painted boxwood vessel display stand|boxwood|VL/G|83650/327|FX13|OTT|FU-N,OPEN|open vessel display tiers; fixed furniture
+renaissance_furniture_expansion_pip_curiosity_case_02|a brass-mounted lacquer curiosity case|lacquer|L/G|32450/209|FX11|PIP|FU-N,GUILD|compartmented transparent collection case; fixed furniture
+renaissance_furniture_expansion_pip_glazed_display_case_01|a small pierced lacquer glazed display case|lacquer|VL/SS|73550/163|FX11|PIP|FU-S,GUILD|transparent enclosed display; fixed furniture
+renaissance_furniture_expansion_pip_open_display_cabinet_05|a pierced cedar open display cabinet|cedar|VL/SS|58100/110|FX13|PIP|FU-S,OPEN,COURT|open framed object display; fixed furniture
+renaissance_furniture_expansion_pip_scroll_display_cabinet_03|a deep painted cedar scroll display cabinet|cedar|L/E|24750/478|FX13|PIP|FU-L,OPEN,GUILD|open scroll and book display; fixed furniture
+renaissance_furniture_expansion_pip_stepped_display_shelves_04|a slender arched teak stepped display shelves|teak|VL/GR|79850/848|FX13|PIP|FU-L,OPEN|open graduated display tiers; fixed furniture
+renaissance_furniture_expansion_sas_scroll_display_cabinet_02_lockable|a lock-fitted pierced lacquer scroll display cabinet|lacquer|VL/GR|82400/1015|FX14|SAS|FU-L,OPEN,SERVICE|open scroll and book display; built-in lock
+renaissance_furniture_expansion_sas_stepped_display_shelves_03|a square deep-carved teak stepped display shelves|teak|VL/G|79700/400|FX13|SAS|FU-N,OPEN,COURT|open graduated display tiers; fixed furniture
+renaissance_furniture_expansion_sas_textile_display_case_01|a low bamboo textile display case|bamboo|VL/S|45200/118|FX11|SAS|FU-N,SERVICE|broad shallow textile display; fixed furniture
+renaissance_furniture_expansion_eal_lattice_display_cabinet_01|a narrow lacquered bamboo lattice display cabinet|bamboo|VL/GR|38500/422|FX13|EAL|FU-L,OPEN|screened open display; fixed furniture
+renaissance_furniture_expansion_eal_open_display_cabinet_02|an octagonal painted bamboo open display cabinet|bamboo|L/VG|16600/134|FX13|EAL|FU-L,OPEN,RELIGIOUS|open framed object display; fixed furniture
+renaissance_furniture_expansion_eal_plate_display_cabinet_04|a massive plain-joined cypress plate display cabinet|cypress|VL/G|68100/286|FX12|EAL|FU-N|shallow vessel and plate display; fixed furniture
+renaissance_furniture_expansion_eal_porcelain_display_cabinet_03|a lacquered walnut porcelain display cabinet|walnut|L/G|29600/186|FX12|EAL|FU-N,RELIGIOUS|padded ceramic display; fixed furniture
+renaissance_furniture_expansion_jpn_glass_front_cabinet_02|a slatted lacquer glass-front cabinet|lacquer|VL/G|82950/398|FX12|JPN|FU-N|tall transparent cabinet; fixed furniture
+renaissance_furniture_expansion_jpn_glass_front_cabinet_04|a small asymmetrical cypress glass-front cabinet|cypress|H/S|117750/416|FX12|JPN|FU-N|tall transparent cabinet; fixed furniture
+renaissance_furniture_expansion_jpn_open_display_cabinet_03|a wide red-lacquered pine open display cabinet|pine|L/VG|25350/153|FX13|JPN|FU-L,OPEN|open framed object display; fixed furniture
+renaissance_furniture_expansion_jpn_open_display_shelves_01|a tall low bamboo open display shelves|bamboo|L/GR|19350/181|FX13|JPN|FU-L,OPEN|open tiered display; fixed furniture
+renaissance_furniture_expansion_mea_scroll_display_cabinet_01|a low cedar scroll display cabinet|cedar|L/SS|28600/69|FX13|MEA|FU-S,OPEN|open scroll and book display; fixed furniture
+renaissance_furniture_expansion_mea_scroll_display_cabinet_02|a long shell-faced lacquer scroll display cabinet|lacquer|VL/SS|82700/200|FX13|MEA|FU-S,OPEN,MARITIME|open scroll and book display; fixed furniture
+renaissance_furniture_expansion_sem_glass_front_cabinet_01|an openwork rattan glass-front cabinet|rattan|VL/S|39800/101|FX12|SEM|FU-N|tall transparent cabinet; fixed furniture
+renaissance_furniture_expansion_sem_lattice_display_cabinet_02|a massive openwork lacquer lattice display cabinet|lacquer|VL/S|69850/267|FX13|SEM|FU-N,OPEN,RELIGIOUS|screened open display; fixed furniture
+renaissance_furniture_expansion_msea_stepped_display_shelves_01|a round-fronted low bamboo stepped display shelves|bamboo|VL/VG|37750/275|FX13|MSEA|FU-L,OPEN,MARITIME|open graduated display tiers; fixed furniture
+renaissance_furniture_expansion_aca_glass_front_cabinet_01|a painted wicker glass-front cabinet|wicker|VL/G|40700/131|FX12|ACA|FU-N|tall transparent cabinet; fixed furniture
+renaissance_furniture_expansion_sai_vessel_display_stand_01|a plain-joined wicker vessel display stand|wicker|VL/SS|43400/64|FX13|SAI|FU-S,OPEN,GUILD|open vessel display tiers; fixed furniture
+renaissance_furniture_expansion_rse_glass_front_cabinet_01|a square plain-joined cedar glass-front cabinet|cedar|VL/G|69850/294|FX12|RSE|FU-N|tall transparent cabinet; fixed furniture
+renaissance_furniture_expansion_rse_textile_display_case_02|a compact brass-bound wood textile display case|wood|L/S|32400/101|FX11|RSE|FU-N,MARITIME|broad shallow textile display; fixed furniture
+renaissance_furniture_expansion_and_lattice_display_cabinet_01|a stepped wicker lattice display cabinet|wicker|L/G|16050/71|FX13|AND|FU-N,OPEN,COURT|screened open display; fixed furniture
+renaissance_furniture_expansion_and_lattice_display_cabinet_02|a deep-carved wicker lattice display cabinet|wicker|L/S|17700/41|FX13|AND|FU-N,OPEN,COURT|screened open display; fixed furniture
+renaissance_furniture_expansion_car_stepped_display_shelves_01|a square deep-carved reed stepped display shelves|reed|VL/SS|45250/58|FX13|CAR|FU-S,OPEN,COURT|open graduated display tiers; fixed furniture
+renaissance_furniture_expansion_car_stepped_display_shelves_02|a low wood stepped display shelves|wood|L/S|33600/97|FX13|CAR|FU-N,OPEN,COURT|open graduated display tiers; fixed furniture
+renaissance_furniture_expansion_car_vessel_display_stand_03|a deep plain-framed cane vessel display stand|cane|L/G|19850/70|FX13|CAR|FU-N,OPEN|open vessel display tiers; fixed furniture
+renaissance_furniture_expansion_nac_open_display_cabinet_01|a lashed wicker open display cabinet|wicker|L/GR|16500/160|FX13|NAC|FU-L,OPEN|open framed object display; fixed furniture
+renaissance_furniture_expansion_nac_open_display_shelves_02|a tall deep-carved birch open display shelves|birch|VL/GR|71050/537|FX13|NAC|FU-L,OPEN|open tiered display; fixed furniture
+renaissance_furniture_expansion_col_glazed_display_case_01_lockable|a lock-fitted heavy-framed walnut glazed display case|walnut|L/VG|31100/287|FX14|COL|FU-L,GUILD|transparent enclosed display; built-in lock
+renaissance_furniture_expansion_col_textile_display_case_02|a wide slatted cedar textile display case|cedar|VL/GR|63350/699|FX11|COL|FU-L,GUILD|broad shallow textile display; fixed furniture
+renaissance_furniture_expansion_col_vessel_display_stand_03|an arched-top iron-bound pine vessel display stand|pine|VL/GR|62950/455|FX13|COL|FU-L,OPEN|open vessel display tiers; fixed furniture
+renaissance_furniture_expansion_mar_lock_fitted_display_cabinet_02|a plain-framed teak lock-fitted display cabinet|teak|H/G|145900/694|FX14|MAR|FU-N,GUILD|transparent built-in-lock display; built-in lock
+renaissance_furniture_expansion_mar_open_display_cabinet_03|a slotted oak open display cabinet|oak|L/VG|32550/274|FX13|MAR|FU-L,OPEN|open framed object display; fixed furniture
+renaissance_furniture_expansion_mar_open_display_shelves_01|a wide bolted cedar open display shelves|cedar|L/VG|30250/231|FX13|MAR|FU-L,OPEN,GUILD|open tiered display; fixed furniture
+renaissance_furniture_expansion_mar_vessel_display_stand_04|a narrow plain-framed teak vessel display stand|teak|L/S|32900/143|FX13|MAR|FU-N,OPEN,MARITIME|open vessel display tiers; fixed furniture
+```
+
+## Section validation
+
+- 55 rows and 55 unique stable references.
+- Rows inherit `Era / Renaissance Era` and the exact culture tag identified by their culture code.
+- No full descriptions are supplied in this pass.

--- a/Design Documents/Seeding/FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_I_Wardrobes.md
+++ b/Design Documents/Seeding/FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_I_Wardrobes.md
@@ -1,0 +1,73 @@
+# Wardrobes, armoires, garment cabinets, and linen presses — Renaissance expansion section
+
+> Parent contract: [FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_I.md](./FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_I.md)
+
+This section contains **55 proposed prototypes**. Component codes, culture codes, tag codes, size/quality abbreviations, admission rules, and portability rules are defined by the parent index and the expansion manifest.
+
+## Wardrobes, armoires, garment cabinets, and linen presses — 55
+
+Variations differ in hanging capacity, internal shelving, height, portability, cabinet form, and built-in locking behaviour.
+
+```text
+renaissance_furniture_expansion_wer_lock_fitted_armoire_02|a carved beech lock-fitted armoire|beech|VL/VG|84800/539|FX03|WER|FU-L|built-in-lock deep cabinet; built-in lock
+renaissance_furniture_expansion_wer_lock_fitted_wardrobe_03|a carved walnut lock-fitted wardrobe|walnut|VL/S|86700/326|FX03|WER|FU-N,SERVICE|built-in-lock garment storage; built-in lock
+renaissance_furniture_expansion_wer_robe_cabinet_01|a deep panelled oak robe cabinet|oak|L/G|41300/220|FX30|WER|FU-N,COURT|shelf-and-hanging robe storage; fixed furniture
+renaissance_furniture_expansion_wer_tall_wardrobe_04|a round-fronted pilastered walnut tall wardrobe|walnut|VL/S|94250/325|FX01|WER|FU-N,GUILD|full-height hanging storage; fixed furniture
+renaissance_furniture_expansion_wer_two_door_wardrobe_05|a low plain-joined chestnut two-door wardrobe|chestnut|H/G|184400/622|FX01|WER|FU-N|wide double-door garment storage; fixed furniture
+renaissance_furniture_expansion_iba_cloak_cupboard_04|an iron-bound olivewood cloak cupboard|olive wood|VL/S|83050/286|FX26|IBA|FU-N|narrow outer-garment cupboard; fixed furniture
+renaissance_furniture_expansion_iba_compact_garment_cabinet_05|a panelled olivewood compact garment cabinet|olive wood|L/S|39600/117|FX31|IBA|FU-N,MARITIME|small enclosed garment storage; fixed furniture
+renaissance_furniture_expansion_iba_lock_fitted_armoire_02|an octagonal painted-panel oak lock-fitted armoire|oak|VL/SS|87250/193|FX03|IBA|FU-S|built-in-lock deep cabinet; built-in lock
+renaissance_furniture_expansion_iba_tall_wardrobe_01|a compact iron-bound boxwood tall wardrobe|boxwood|H/G|152650/717|FX01|IBA|FU-N,MARITIME|full-height hanging storage; fixed furniture
+renaissance_furniture_expansion_iba_travelling_wardrobe_03|an arched-top arcaded oak travelling wardrobe|oak|VL/G|64300/398|FX39|IBA|FU-N,RELIGIOUS|portable campaign garment storage; portable/folding
+renaissance_furniture_expansion_cen_cloak_cupboard_02|a small joined beech cloak cupboard|beech|L/P|41050/41|FX26|CEN|FU-S|narrow outer-garment cupboard; fixed furniture
+renaissance_furniture_expansion_cen_lock_fitted_armoire_03|a gabled walnut lock-fitted armoire|walnut|H/G|176400/881|FX03|CEN|FU-N|built-in-lock deep cabinet; built-in lock
+renaissance_furniture_expansion_cen_lock_fitted_armoire_05|a deep joined oak lock-fitted armoire|oak|H/G|157450/757|FX03|CEN|FU-N|built-in-lock deep cabinet; built-in lock
+renaissance_furniture_expansion_cen_lock_fitted_wardrobe_01|a moulded walnut lock-fitted wardrobe|walnut|H/S|184300/486|FX03|CEN|FU-N,COURT|built-in-lock garment storage; built-in lock
+renaissance_furniture_expansion_cen_two_door_wardrobe_04|an arched-top carved ash two-door wardrobe|ash|H/G|161800/712|FX01|CEN|FU-N|wide double-door garment storage; fixed furniture
+renaissance_furniture_expansion_nba_linen_press_01|a pale-boarded ash linen press|ash|L/VG|35100/234|FX30|NBA|FU-L,MARITIME|shelved textile press; fixed furniture
+renaissance_furniture_expansion_cef_lock_fitted_armoire_02|a square lattice-fronted pine lock-fitted armoire|pine|VL/G|81850/220|FX03|CEF|FU-N,GUILD|built-in-lock deep cabinet; built-in lock
+renaissance_furniture_expansion_cef_lock_fitted_armoire_04|a slender painted beech lock-fitted armoire|beech|VL/GR|87000/686|FX03|CEF|FU-L,COURT|built-in-lock deep cabinet; built-in lock
+renaissance_furniture_expansion_cef_lock_fitted_wardrobe_01|a broad carved ash lock-fitted wardrobe|ash|H/G|170150/580|FX03|CEF|FU-N,COURT|built-in-lock garment storage; built-in lock
+renaissance_furniture_expansion_cef_tall_wardrobe_03|a deep painted pine tall wardrobe|pine|H/VG|130150/620|FX01|CEF|FU-L|full-height hanging storage; fixed furniture
+renaissance_furniture_expansion_eon_cloak_cupboard_01|a tall painted-panel ash cloak cupboard|ash|VL/G|96350/363|FX26|EON|FU-N|narrow outer-garment cupboard; fixed furniture
+renaissance_furniture_expansion_eon_garment_armoire_03|a recessed-panel walnut garment armoire|walnut|VL/G|93500/426|FX02|EON|FU-N,RELIGIOUS|deep enclosed garment storage; fixed furniture
+renaissance_furniture_expansion_eon_lock_fitted_wardrobe_02|a carved birch lock-fitted wardrobe|birch|VL/SS|82350/126|FX03|EON|FU-S,COURT|built-in-lock garment storage; built-in lock
+renaissance_furniture_expansion_ott_garment_armoire_01|a lattice-fronted cedar garment armoire|cedar|VL/G|70150/338|FX02|OTT|FU-N|deep enclosed garment storage; fixed furniture
+renaissance_furniture_expansion_ott_robe_cabinet_02|a compact recessed-panel lacquer robe cabinet|lacquer|VL/S|94950/271|FX30|OTT|FU-N,GUILD|shelf-and-hanging robe storage; fixed furniture
+renaissance_furniture_expansion_ott_travelling_wardrobe_03|a painted boxwood travelling wardrobe|boxwood|VL/G|66550/409|FX39|OTT|FU-N|portable campaign garment storage; portable/folding
+renaissance_furniture_expansion_pip_cloak_cupboard_01|a slender arched walnut cloak cupboard|walnut|L/S|41650/128|FX26|PIP|FU-N|narrow outer-garment cupboard; fixed furniture
+renaissance_furniture_expansion_sas_compact_garment_cabinet_04|a tall openwork sandalwood compact garment cabinet|sandalwood|L/S|37600/221|FX33|SAS|FU-N|small enclosed garment storage; fixed furniture
+renaissance_furniture_expansion_sas_linen_press_01|a narrow teak-framed teak linen press|teak|L/VG|40800/325|FX30|SAS|FU-L,RELIGIOUS|shelved textile press; fixed furniture
+renaissance_furniture_expansion_sas_tall_wardrobe_02|a low brass-studded lacquer tall wardrobe|lacquer|H/G|167650/926|FX01|SAS|FU-N,COURT|full-height hanging storage; fixed furniture
+renaissance_furniture_expansion_sas_travelling_wardrobe_03|a compact deep-carved lacquer travelling wardrobe|lacquer|L/S|24500/174|FX39|SAS|FU-N,RELIGIOUS|portable campaign garment storage; portable/folding
+renaissance_furniture_expansion_eal_linen_press_01|a massive lattice-fronted cypress linen press|cypress|L/VG|31400/264|FX30|EAL|FU-L|shelved textile press; fixed furniture
+renaissance_furniture_expansion_eal_two_door_wardrobe_02|a narrow asymmetrical cypress two-door wardrobe|cypress|H/S|137200/377|FX01|EAL|FU-N,COURT|wide double-door garment storage; fixed furniture
+renaissance_furniture_expansion_jpn_linen_press_01|a long recessed-panel cypress linen press|cypress|L/S|33950/119|FX30|JPN|FU-N,COURT|shelved textile press; fixed furniture
+renaissance_furniture_expansion_mea_lock_fitted_armoire_01|a painted cypress lock-fitted armoire|cypress|VL/E|82950/1303|FX03|MEA|FU-L,MARITIME|built-in-lock deep cabinet; built-in lock
+renaissance_furniture_expansion_mea_lock_fitted_wardrobe_02|a lacquered bamboo lock-fitted wardrobe|bamboo|VL/S|46000/127|FX03|MEA|FU-N,COURT|built-in-lock garment storage; built-in lock
+renaissance_furniture_expansion_sem_garment_armoire_01|a pierced bamboo garment armoire|bamboo|VL/G|51300/225|FX02|SEM|FU-N|deep enclosed garment storage; fixed furniture
+renaissance_furniture_expansion_msea_cloak_cupboard_02|a painted lacquer cloak cupboard|lacquer|L/G|36100/213|FX26|MSEA|FU-N,MARITIME|narrow outer-garment cupboard; fixed furniture
+renaissance_furniture_expansion_msea_tall_wardrobe_03|a slender rattan-framed lacquer tall wardrobe|lacquer|VL/VG|91750/779|FX01|MSEA|FU-L|full-height hanging storage; fixed furniture
+renaissance_furniture_expansion_msea_two_door_wardrobe_01|a shell-inlaid bamboo two-door wardrobe|bamboo|H/S|87950/241|FX01|MSEA|FU-N,MARITIME|wide double-door garment storage; fixed furniture
+renaissance_furniture_expansion_aca_compact_garment_cabinet_01|a studded mahogany compact garment cabinet|mahogany|L/VG|42200/408|FX33|ACA|FU-L,COURT|small enclosed garment storage; fixed furniture
+renaissance_furniture_expansion_aca_linen_press_02|a low brass-faced wood linen press|wood|L/S|35250/114|FX30|ACA|FU-N,COURT|shelved textile press; fixed furniture
+renaissance_furniture_expansion_sai_lock_fitted_wardrobe_01|a deep brass-bound cedar lock-fitted wardrobe|cedar|VL/VG|77000/469|FX03|SAI|FU-L|built-in-lock garment storage; built-in lock
+renaissance_furniture_expansion_rse_lock_fitted_wardrobe_01|a slender carved cedar lock-fitted wardrobe|cedar|H/VG|144600/826|FX03|RSE|FU-L,RELIGIOUS|built-in-lock garment storage; built-in lock
+renaissance_furniture_expansion_rse_travelling_wardrobe_02|a compact cedar-framed olivewood travelling wardrobe|olive wood|VL/G|58350/364|FX39|RSE|FU-N,RELIGIOUS|portable campaign garment storage; portable/folding
+renaissance_furniture_expansion_ind_compact_garment_cabinet_02|a massive teak-framed bamboo compact garment cabinet|bamboo|L/S|20400/61|FX33|IND|FU-N,MARITIME|small enclosed garment storage; fixed furniture
+renaissance_furniture_expansion_ind_tall_wardrobe_03|a low shell-inlaid wood tall wardrobe|wood|H/G|165150/551|FX01|IND|FU-N|full-height hanging storage; fixed furniture
+renaissance_furniture_expansion_ind_travelling_wardrobe_01|a shell-inlaid wood travelling wardrobe|wood|VL/SS|57000/170|FX39|IND|FU-S,GUILD|portable campaign garment storage; portable/folding
+renaissance_furniture_expansion_col_garment_armoire_02|a high mission-made cedar garment armoire|cedar|VL/G|82750/293|FX02|COL|FU-N,RELIGIOUS|deep enclosed garment storage; fixed furniture
+renaissance_furniture_expansion_col_lock_fitted_wardrobe_03|a slender carved walnut lock-fitted wardrobe|walnut|H/S|158800/485|FX03|COL|FU-N,RELIGIOUS|built-in-lock garment storage; built-in lock
+renaissance_furniture_expansion_col_robe_cabinet_01|a panelled pine robe cabinet|pine|L/GR|31800/307|FX30|COL|FU-L,RELIGIOUS|shelf-and-hanging robe storage; fixed furniture
+renaissance_furniture_expansion_mar_cloak_cupboard_01|an arched-top slotted pine cloak cupboard|pine|L/S|29150/83|FX26|MAR|FU-N,GUILD|narrow outer-garment cupboard; fixed furniture
+renaissance_furniture_expansion_mar_lock_fitted_wardrobe_02|a long slotted teak lock-fitted wardrobe|teak|VL/G|93900/418|FX03|MAR|FU-N,GUILD|built-in-lock garment storage; built-in lock
+renaissance_furniture_expansion_mar_lock_fitted_wardrobe_03|a tall bolted pine lock-fitted wardrobe|pine|H/S|157100/288|FX03|MAR|FU-N|built-in-lock garment storage; built-in lock
+renaissance_furniture_expansion_mar_robe_cabinet_04|a bolted oak robe cabinet|oak|L/G|35250/211|FX30|MAR|FU-N|shelf-and-hanging robe storage; fixed furniture
+```
+
+## Section validation
+
+- 55 rows and 55 unique stable references.
+- Rows inherit `Era / Renaissance Era` and the exact culture tag identified by their culture code.
+- No full descriptions are supplied in this pass.

--- a/Design Documents/Seeding/FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_I_Weapon_Racks.md
+++ b/Design Documents/Seeding/FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_I_Weapon_Racks.md
@@ -1,0 +1,63 @@
+# Weapon racks, shield racks, and lockable armoury cabinets — Renaissance expansion section
+
+> Parent contract: [FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_I.md](./FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_I.md)
+
+This section contains **45 proposed prototypes**. Component codes, culture codes, tag codes, size/quality abbreviations, admission rules, and portability rules are defined by the parent index and the expansion manifest.
+
+## Weapon racks, shield racks, and lockable armoury cabinets — 45
+
+Variations distinguish swords, spears, bows, shields, crossbows, matchlocks, mixed armoury stock, wall mounting, portability, and secured cabinet storage.
+
+```text
+renaissance_furniture_expansion_wer_campaign_weapon_rack_01|a square plain-joined wrought-iron campaign weapon rack|wrought iron|L/GR|25750/382|FX34|WER|FU-L,OPEN,MIL,SERVICE|portable folding weapon storage; portable/folding
+renaissance_furniture_expansion_wer_lock_fitted_weapon_cabinet_02|a square plain-joined beech lock-fitted weapon cabinet|beech|H/G|108350/342|FX10|WER|FU-N,MIL,GUILD|built-in-lock armoury cabinet; built-in lock
+renaissance_furniture_expansion_iba_campaign_weapon_rack_01|a star-pierced chestnut campaign weapon rack|chestnut|L/G|16300/94|FX34|IBA|FU-N,OPEN,MIL|portable folding weapon storage; portable/folding
+renaissance_furniture_expansion_cen_shield_rack_01|a gabled ash shield rack|ash|H/VG|98900/560|FX08|CEN|FU-L,OPEN,MIL,COURT|broad shield storage; fixed furniture
+renaissance_furniture_expansion_nba_bow_rack_04|an arched-top slatted birch bow rack|birch|VL/S|41950/107|FX07|NBA|FU-N,OPEN,MIL,MARITIME|curved-arm bow storage; fixed furniture
+renaissance_furniture_expansion_nba_freestanding_weapon_rack_01|a deep pale-boarded oak freestanding weapon rack|oak|VL/S|46900/126|FX08|NBA|FU-N,OPEN,MIL,MARITIME|open freestanding weapon storage; fixed furniture
+renaissance_furniture_expansion_nba_lock_fitted_weapon_cabinet_02|a compact plain-joined wrought-iron lock-fitted weapon cabinet|wrought iron|VL/GR|96400/693|FX10|NBA|FU-L,MIL,GUILD|built-in-lock armoury cabinet; built-in lock
+renaissance_furniture_expansion_nba_matchlock_rack_03|a slender plain-joined birch matchlock rack|birch|VL/S|44800/122|FX07|NBA|FU-N,OPEN,MIL,GUILD|long-gun storage; late regional admission; fixed furniture
+renaissance_furniture_expansion_cef_crossbow_rack_01|a small studded brass crossbow rack|brass|VL/S|102200/270|FX09|CEF|FU-N,OPEN,MIL,GUILD|deep crossbow storage; fixed furniture
+renaissance_furniture_expansion_cef_lock_fitted_weapon_cabinet_03|a studded walnut lock-fitted weapon cabinet|walnut|H/VG|106850/795|FX10|CEF|FU-L,MIL|built-in-lock armoury cabinet; built-in lock
+renaissance_furniture_expansion_cef_spear_rack_02|a broad-framed beech spear rack|beech|VL/S|56650/139|FX08|CEF|FU-N,OPEN,MIL,GUILD|tall polearm storage; fixed furniture
+renaissance_furniture_expansion_ott_crossbow_rack_02|a compact painted walnut crossbow rack|walnut|VL/S|52600/167|FX07|OTT|FU-N,OPEN,MIL|deep crossbow storage; fixed furniture
+renaissance_furniture_expansion_ott_lock_fitted_weapon_cabinet_01|a compact recessed-panel brass lock-fitted weapon cabinet|brass|VL/E|84950/1382|FX10|OTT|FU-L,MIL,COURT|built-in-lock armoury cabinet; built-in lock
+renaissance_furniture_expansion_pip_freestanding_weapon_rack_02|a square arched sandalwood freestanding weapon rack|sandalwood|VL/S|57800/252|FX08|PIP|FU-N,OPEN,MIL,GUILD|open freestanding weapon storage; fixed furniture
+renaissance_furniture_expansion_pip_matchlock_rack_01|a pierced walnut matchlock rack|walnut|VL/G|53300/251|FX08|PIP|FU-N,OPEN,MIL,COURT|long-gun storage; late regional admission; fixed furniture
+renaissance_furniture_expansion_sas_campaign_weapon_rack_01|an arched-top lattice-fronted brass campaign weapon rack|brass|VL/S|69750/304|FX34|SAS|FU-N,OPEN,MIL,COURT|portable folding weapon storage; portable/folding
+renaissance_furniture_expansion_sas_matchlock_rack_02|a pierced bronze matchlock rack|bronze|H/G|197700/648|FX09|SAS|FU-N,OPEN,MIL,COURT|long-gun storage; late regional admission; fixed furniture
+renaissance_furniture_expansion_eal_freestanding_weapon_rack_01|a wide asymmetrical bamboo freestanding weapon rack|bamboo|H/G|60800/193|FX07|EAL|FU-N,OPEN,MIL,COURT|open freestanding weapon storage; fixed furniture
+renaissance_furniture_expansion_eal_sword_rack_02|a tall tiered cypress sword rack|cypress|VL/G|48300/238|FX07|EAL|FU-N,OPEN,MIL,RELIGIOUS|slotted sword storage; fixed furniture
+renaissance_furniture_expansion_jpn_campaign_weapon_rack_02|a plain-joined cypress campaign weapon rack|cypress|VL/S|30550/128|FX34|JPN|FU-N,OPEN,MIL,GUILD|portable folding weapon storage; portable/folding
+renaissance_furniture_expansion_jpn_lock_fitted_weapon_cabinet_01|a high stackable lacquer lock-fitted weapon cabinet|lacquer|VL/VG|49900/465|FX10|JPN|FU-L,MIL,GUILD|built-in-lock armoury cabinet; built-in lock
+renaissance_furniture_expansion_sem_campaign_weapon_rack_01|a lacquered teak campaign weapon rack|teak|VL/S|34600/184|FX34|SEM|FU-N,OPEN,MIL|portable folding weapon storage; portable/folding
+renaissance_furniture_expansion_msea_spear_rack_01|a tall lacquered teak spear rack|teak|VL/S|53900/171|FX07|MSEA|FU-N,OPEN,MIL|tall polearm storage; fixed furniture
+renaissance_furniture_expansion_stp_freestanding_weapon_rack_03|a long plain-framed pine freestanding weapon rack|pine|VL/G|41350/161|FX08|STP|FU-N,OPEN,MIL,MARITIME|open freestanding weapon storage; fixed furniture
+renaissance_furniture_expansion_stp_lock_fitted_weapon_cabinet_02|an arched-top low brass lock-fitted weapon cabinet|brass|VL/G|102900/368|FX10|STP|FU-N,MIL|built-in-lock armoury cabinet; built-in lock
+renaissance_furniture_expansion_stp_wall_weapon_rack_01|an iron-bound birch wall weapon rack|birch|L/VG|17650/125|FX08|STP|FU-L,OPEN,MIL|wall-mounted mixed-weapon storage; fixed furniture
+renaissance_furniture_expansion_aca_sword_rack_01|a pedestal mahogany sword rack|mahogany|L/G|20950/158|FX08|ACA|FU-N,OPEN,MIL,COURT|slotted sword storage; fixed furniture
+renaissance_furniture_expansion_sai_campaign_weapon_rack_01|a slender brass-bound reed campaign weapon rack|reed|L/P|7550/13|FX34|SAI|FU-S,OPEN,MIL,GUILD|portable folding weapon storage; portable/folding
+renaissance_furniture_expansion_rse_matchlock_rack_01|a slender low wood matchlock rack|wood|VL/S|55950/119|FX07|RSE|FU-N,OPEN,MIL|long-gun storage; late regional admission; fixed furniture
+renaissance_furniture_expansion_ind_crossbow_rack_01|an arched-top plain-joined teak crossbow rack|teak|H/G|97200/519|FX08|IND|FU-N,OPEN,MIL,MARITIME|deep crossbow storage; fixed furniture
+renaissance_furniture_expansion_mes_campaign_weapon_rack_01|a low painted cedar campaign weapon rack|cedar|VL/S|33600/126|FX34|MES|FU-N,OPEN,MIL,COURT|portable folding weapon storage; portable/folding
+renaissance_furniture_expansion_mes_sword_rack_03|a painted cedar sword rack|cedar|L/G|18350/113|FX08|MES|FU-N,OPEN,MIL|slotted sword storage; fixed furniture
+renaissance_furniture_expansion_mes_wall_weapon_rack_02|an arched-top stepped reed wall weapon rack|reed|L/S|13750/25|FX08|MES|FU-N,OPEN,MIL,RELIGIOUS|wall-mounted mixed-weapon storage; fixed furniture
+renaissance_furniture_expansion_and_freestanding_weapon_rack_03|a plain-framed wicker freestanding weapon rack|wicker|VL/S|26750/57|FX07|AND|FU-N,OPEN,MIL,COURT|open freestanding weapon storage; fixed furniture
+renaissance_furniture_expansion_and_shield_rack_01|a woven-panel reed shield rack|reed|H/G|52900/161|FX08|AND|FU-N,OPEN,MIL|broad shield storage; fixed furniture
+renaissance_furniture_expansion_and_shield_rack_02|a lashed wood shield rack|wood|H/VG|97550/548|FX07|AND|FU-L,OPEN,MIL,SERVICE|broad shield storage; fixed furniture
+renaissance_furniture_expansion_car_spear_rack_01|a narrow lashed wood spear rack|wood|H/G|105450/341|FX07|CAR|FU-N,OPEN,MIL,COURT|tall polearm storage; fixed furniture
+renaissance_furniture_expansion_nac_bow_rack_01|a woven-panel reed bow rack|reed|VL/G|28900/87|FX08|NAC|FU-N,OPEN,MIL,GUILD|curved-arm bow storage; fixed furniture
+renaissance_furniture_expansion_nac_sword_rack_02|a lashed wood sword rack|wood|L/S|21650/59|FX08|NAC|FU-N,OPEN,MIL|slotted sword storage; fixed furniture
+renaissance_furniture_expansion_col_bow_rack_03|an iron-bound brass bow rack|brass|VL/S|98850/278|FX09|COL|FU-N,OPEN,MIL|curved-arm bow storage; fixed furniture
+renaissance_furniture_expansion_col_freestanding_weapon_rack_02|a plain-joined oak freestanding weapon rack|oak|H/S|91650/259|FX07|COL|FU-N,OPEN,MIL|open freestanding weapon storage; fixed furniture
+renaissance_furniture_expansion_col_sword_rack_01|a round-fronted heavy-framed oak sword rack|oak|VL/SS|47950/116|FX08|COL|FU-S,OPEN,MIL,MARITIME|slotted sword storage; fixed furniture
+renaissance_furniture_expansion_mar_bow_rack_02|a tall slotted wrought-iron bow rack|wrought iron|L/G|44550/187|FX09|MAR|FU-N,OPEN,MIL,GUILD|curved-arm bow storage; fixed furniture
+renaissance_furniture_expansion_mar_freestanding_weapon_rack_01|a low plain-framed teak freestanding weapon rack|teak|VL/S|55050/179|FX08|MAR|FU-N,OPEN,MIL|open freestanding weapon storage; fixed furniture
+renaissance_furniture_expansion_mar_matchlock_rack_03|an iron-bound cedar matchlock rack|cedar|VL/VG|41050/260|FX08|MAR|FU-L,OPEN,MIL|long-gun storage; late regional admission; fixed furniture
+```
+
+## Section validation
+
+- 45 rows and 45 unique stable references.
+- Rows inherit `Era / Renaissance Era` and the exact culture tag identified by their culture code.
+- No full descriptions are supplied in this pass.

--- a/Design Documents/Seeding/FutureMUD_Renaissance_Household_Urban_Trade_Expansion_Manifest.md
+++ b/Design Documents/Seeding/FutureMUD_Renaissance_Household_Urban_Trade_Expansion_Manifest.md
@@ -1,0 +1,148 @@
+# FutureMUD Renaissance Household, Urban, and Trade Expansion Manifest
+
+## Status
+
+This manifest governs the second-pass expansion of `FutureMUD_Renaissance_Household_Urban_Trade_Design_Reference.md`.
+
+The original authority document contains **400** proposed prototypes. The three expansion volumes add **600** distinct prototypes, bringing the combined Renaissance household, urban, trade, furniture, personal-container, domestic-service, and liquid-container catalogue to exactly **1,000 proposed item prototypes**.
+
+No original stable reference is replaced or renumbered.
+
+## Catalogue topology
+
+| Document | New rows | Primary coverage |
+| --- | ---: | --- |
+| `FutureMUD_Renaissance_Household_Urban_Trade_Design_Reference.md` | 400 | Original trade, furniture, personal, domestic, and liquid-container packages |
+| [Furniture Expansion Volume I](./FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_I.md) | 200 | Wardrobes/armoires, armour stands, weapon racks, display cabinets/cases/shelves |
+| [Furniture Expansion Volume II](./FutureMUD_Renaissance_Household_Furniture_Expansion_Catalogue_II.md) | 220 | End tables/nightstands, plinths/stands, drawers, desks/escritoires, cupboards/bookcases |
+| [Container and Service Expansion](./FutureMUD_Renaissance_Container_Service_Expansion_Catalogue.md) | 180 | Additional trade, personal, domestic dry-service, and finite liquid containers |
+| **Combined total** | **1,000** | Base catalogue plus expansion |
+| [Expansion dependency request](./FutureMUD_Renaissance_Household_Expansion_Dependency_Request.md) | — | Six reusable furniture-container component profiles |
+
+## Expansion design rule
+
+The expansion is not a one-per-type-per-culture matrix. Cultures receive uneven counts and different family mixtures according to household form, institution, mobility, trade role, military practice, and surviving production traditions. A new prototype is retained only when one or more of the following changes:
+
+1. container or surface component;
+2. capacity, supported-item scale, or installed/portable behaviour;
+3. open, transparent, sealed, or built-in-lock behaviour;
+4. major furniture silhouette or storage orientation;
+5. primary-material behaviour;
+6. quality band and construction sufficiently different to represent a separate production/market object rather than a skin;
+7. institution, military system, or contact/export form with a distinct gameplay role.
+
+Paint, heraldry, script, motifs, maker marks, exact local terminology, ordinary carving changes, and status presentation remain skins unless accompanied by one of those changes.
+
+## Expansion distribution
+
+### Furniture families
+
+| Furniture family | Count |
+| --- | ---: |
+| Wardrobes, armoires, garment cabinets, and linen presses | 55 |
+| Armour stands, armour trees, and harness supports | 45 |
+| Weapon racks, shield racks, and lockable armoury cabinets | 45 |
+| Display cabinets, cases, and open display shelving | 55 |
+| Side tables, end tables, nightstands, and compact lockable cabinets | 45 |
+| Display plinths, pedestals, vessel stands, and offering stands | 40 |
+| Chests of drawers, specialist drawers, and lockable drawer cabinets | 50 |
+| Desks, writing tables, counting desks, and lockable escritoires | 50 |
+| Cupboards, hutches, bookcases, and archive cabinets | 35 |
+
+### Non-furniture categories
+
+| Category | Count |
+| --- | ---: |
+| Trade and institutional containers | 65 |
+| Personal containers | 45 |
+| Domestic dry-service containers | 30 |
+| Liquid containers | 40 |
+
+### Quality variation
+
+| Quality | Count |
+| --- | ---: |
+| Poor | 14 |
+| Substandard | 43 |
+| Standard | 230 |
+| Good | 202 |
+| VeryGood | 73 |
+| Great | 29 |
+| Excellent | 9 |
+
+### Size variation
+
+| Size | Count |
+| --- | ---: |
+| Tiny | 2 |
+| VerySmall | 21 |
+| Small | 37 |
+| Normal | 90 |
+| Large | 226 |
+| VeryLarge | 169 |
+| Huge | 52 |
+| Enormous | 3 |
+
+The expansion uses **47 exact primary material names**, **73 built-in-lock rows**, **214 portable rows**, and **386 fixed-furniture or fixed-vat rows**.
+
+## Culture coverage
+
+Counts are intentionally uneven; every maintained Renaissance Shared culture family receives at least fifteen new rows.
+
+| Code | Culture grouping | Exact inherited tag | Date gate | New rows |
+| --- | --- | --- | ---: | ---: |
+| `WER` | Western European Renaissance | `Culture / Renaissance / Shared / Western European Renaissance` | 1450-1600 | 37 |
+| `IBA` | Iberian Atlantic | `Culture / Renaissance / Shared / Iberian Atlantic` | 1450-1600 | 30 |
+| `CEN` | Central European | `Culture / Renaissance / Shared / Central European` | 1450-1600 | 29 |
+| `NBA` | Northern Baltic | `Culture / Renaissance / Shared / Northern Baltic` | 1450-1600 | 19 |
+| `CEF` | Central Eastern Frontier | `Culture / Renaissance / Shared / Central Eastern Frontier` | 1500-1600 | 19 |
+| `EON` | Eastern Orthodox Northern | `Culture / Renaissance / Shared / Eastern Orthodox Northern` | 1500-1600 | 19 |
+| `OTT` | Ottoman Islamicate | `Culture / Renaissance / Shared / Ottoman Islamicate` | 1450-1600 | 31 |
+| `PIP` | Persianate Indo-Persian | `Culture / Renaissance / Shared / Persianate Indo-Persian` | 1450-1600 | 28 |
+| `SAS` | South Asian | `Culture / Renaissance / Shared / South Asian` | 1450-1600 | 28 |
+| `EAL` | East Asian Literati | `Culture / Renaissance / Shared / East Asian Literati` | 1400-1600 | 33 |
+| `JPN` | Japanese | `Culture / Renaissance / Shared / Japanese` | 1450-1600 | 29 |
+| `MEA` | Maritime East Asian | `Culture / Renaissance / Shared / Maritime East Asian` | 1450-1600 | 18 |
+| `SEM` | South-east Asian Mainland | `Culture / Renaissance / Shared / South-east Asian Mainland` | 1450-1600 | 18 |
+| `MSEA` | Maritime South-east Asian | `Culture / Renaissance / Shared / Maritime South-east Asian` | 1450-1600 | 23 |
+| `STP` | Steppe and Caravan | `Culture / Renaissance / Shared / Steppe and Caravan` | 1450-1600 | 19 |
+| `ACA` | African Court Atlantic | `Culture / Renaissance / Shared / African Court Atlantic` | 1450-1600 | 23 |
+| `SAI` | Sahelian Islamic | `Culture / Renaissance / Shared / Sahelian Islamic` | 1450-1600 | 17 |
+| `RSE` | Red Sea | `Culture / Renaissance / Shared / Red Sea` | 1450-1600 | 17 |
+| `IND` | Indian Ocean | `Culture / Renaissance / Shared / Indian Ocean` | 1450-1600 | 23 |
+| `MES` | Mesoamerican | `Culture / Renaissance / Shared / Mesoamerican` | 1400-1600 | 19 |
+| `AND` | Andean | `Culture / Renaissance / Shared / Andean` | 1400-1600 | 19 |
+| `CAR` | Caribbean Contact | `Culture / Renaissance / Shared / Caribbean Contact` | 1450-1600 | 15 |
+| `NAC` | North American Contact | `Culture / Renaissance / Shared / North American Contact` | 1450-1600 | 15 |
+| `COL` | Colonial Atlantic | `Culture / Renaissance / Shared / Colonial Atlantic` | 1500-1600 | 28 |
+| `MAR` | Global Maritime | `Culture / Renaissance / Shared / Global Maritime` | 1450-1600 | 44 |
+
+## Shared pre-industrial boundary
+
+All 147 non-regional `preindustrial_trade_*` aliases and the named global-trade packaging rows remain dependencies. The expansion does not recreate generic sacks, bales, crates, dry barrels, market baskets, merchant strongboxes, customs chests, tea chests, coffee/cacao sacks, tobacco bales, sugar hogsheads, indigo boxes, porcelain crates, bottle crates, silk bales, cotton bales, or spice chests merely for a new prefix.
+
+Rows in the expansion justify themselves through specialised interiors, different capacities, furniture orientation, display behaviour, wearable position, liquid mechanics, portability, installation, or built-in locks.
+
+## Validation summary
+
+The generated expansion passed the following catalogue checks:
+
+- 600 rows, 600 unique lowercase-snake-case stable references, and 600 unique short descriptions;
+- exact 200/220/180 volume split and exact family/category totals;
+- all 25 culture tags represented;
+- all materials resolve to maintained stock or the four already-recorded pending materials;
+- every existing component name resolves to maintained stock;
+- the only new component names are the six profiles in the dependency request;
+- exactly one dry, locking, or liquid-container provider per row;
+- fixed furniture and vats omit `Holdable`;
+- explicitly portable furniture and all ordinary portable wares include `Holdable`;
+- liquid vessels use finite liquid-container components and never self-refilling `WaterSource` components;
+- lockable variants use actual built-in-lock component profiles rather than unsupported prose.
+
+## Implementation order
+
+1. Seed and export the six component profiles in the dependency request.
+2. Resolve the original household catalogue's pending component and material requests.
+3. Implement Volume I, then Volume II, then the container/service volume.
+4. Add stable-reference, material, tag, component-exclusivity, portability, and rerun-idempotency tests.
+5. Add skins, full descriptions, crafts, shops, outfits/room packages, and culture/date admission manifests only after the prototype layer resolves.


### PR DESCRIPTION
## Summary

- preserves the existing 400-row Renaissance household, urban, trade, personal-container, domestic-service, and liquid-container authority without renumbering any stable reference;
- adds 600 distinct second-pass prototypes, bringing the combined catalogue to exactly 1,000 proposed items;
- replaces the earlier one-package-per-context emphasis with uneven, historically admitted variation across all 25 maintained Renaissance Shared culture families;
- adds materially and mechanically distinct wardrobes, armoires, linen presses, armour stands, weapon and shield racks, lockable armoury cabinets, display cabinets and cases, end tables, nightstands, plinths, pedestals, drawers, desks, escritoires, cupboards, hutches, bookcases, archive cabinets, trade containers, personal containers, domestic service containers, and finite liquid vessels;
- records a separate dependency request for six reusable pre-industrial furniture-container component prototypes and requests no new materials beyond the four already recorded by the original catalogue.

## Expansion totals

| Family | New rows |
| --- | ---: |
| Wardrobes and garment cabinets | 55 |
| Armour stands and harness supports | 45 |
| Weapon racks and armoury cabinets | 45 |
| Display cabinets/cases/shelves | 55 |
| Side tables and nightstands | 45 |
| Plinths, pedestals, and stands | 40 |
| Drawer furniture | 50 |
| Desks and escritoires | 50 |
| Cupboards, hutches, and bookcases | 35 |
| Trade and institutional containers | 65 |
| Personal containers | 45 |
| Domestic dry-service containers | 30 |
| Liquid containers | 40 |
| **Expansion** | **600** |
| **Combined with existing authority** | **1,000** |

## Variation and coverage

- 47 exact primary materials;
- eight size bands from Tiny through Enormous;
- seven quality bands from Poor through Excellent;
- 73 built-in-lock prototypes;
- 214 portable rows and 386 fixed furniture/vat rows;
- every maintained Renaissance Shared culture family receives at least 15 new rows, with intentionally uneven distributions rather than a rigid per-culture matrix.

## Shared baseline boundary

The expansion continues to reuse all 147 non-regional `preindustrial_trade_*` aliases and the named global-trade packaging rows. It creates no duplicate generic sack, bale, crate, barrel, market basket, merchant strongbox, customs chest, tea chest, coffee/cacao sack, tobacco bale, sugar hogshead, indigo box, porcelain crate, bottle crate, silk bale, cotton bale, or spice chest merely to obtain a Renaissance prefix.

## Dependencies

Six new component prototypes of the existing `Container` type are requested:

- `Container_PreIndustrial_Display_Plinth`
- `LockingContainer_PreIndustrial_SmallCabinet`
- `LockingContainer_PreIndustrial_LargeCabinet`
- `LockingContainer_PreIndustrial_DrawerChest`
- `LockingContainer_PreIndustrial_DisplayCabinet`
- `LockingContainer_PreIndustrial_Desk`

No new runtime component type is required. No additional material is requested.

## Validation

- 600 rows, 600 unique lowercase-snake-case stable references, and 600 unique short descriptions;
- exact 200/220/180 volume split and exact family/category totals;
- all 25 culture tags represented;
- all materials resolve to maintained stock or the four already-recorded pending materials;
- every live component name resolves to maintained stock; only the six explicitly requested profiles remain pending;
- exactly one dry, locking, or liquid-container provider per row;
- fixed furniture and vats omit `Holdable`; genuinely portable furniture and ordinary portable wares include it;
- liquid vessels use finite liquid-container components and never self-refilling `WaterSource` mechanics;
- lockable variants use actual built-in-lock component profiles rather than unsupported prose.