### PR TITLE
Add configurable suggested skills to chargen

### DIFF
--- a/Design Documents/Characters/Character_Creation_Builder_Workflows.md
+++ b/Design Documents/Characters/Character_Creation_Builder_Workflows.md
@@ -79,6 +79,14 @@ Examples:
 
 This keeps the cost display and submit validation in sync.
 
+## Suggested Skills
+The `SkillPicker` storyboard can pre-select editable skill suggestions from earlier chargen choices. While editing that storyboard, use:
+
+- `chargen set suggestedskills <prog>` to configure a FutureProg returning a collection of traits from one `chargen` parameter
+- `chargen set suggestedskills none` to clear it
+
+Suggested skills are not free grants. They consume normal picks and resources and remain removable on the skill screen. Keep profession or background mapping in the prog; the screen itself only filters its results to distinct, currently selectable skills and applies them in returned order up to the pick limit.
+
 ## Resources
 Chargen resources are general-purpose account resources.
 

--- a/Design Documents/Characters/Character_Creation_Runtime.md
+++ b/Design Documents/Characters/Character_Creation_Runtime.md
@@ -66,6 +66,11 @@ Not every stage has only one possible screen type. The most important alternativ
 
 The screen treats free and earlier picks as already selected. It only shows the "already have" section when that list is non-empty, and available knowledge options are rendered as wrapped numbered rows so long medical or craft knowledge descriptions remain readable within the account line width.
 
+### Suggested Skill Selection
+`SkillPicker` can optionally execute a `SuggestedSkillsProg` with the signature `(chargen) -> collection of traits` when the screen opens. This is intended for earlier selections such as profession roles to recommend an initial skill package without granting those skills for free.
+
+Returned traits are considered in prog order. The screen ignores duplicates, free skills, hidden traits, non-skill traits, and skills that are not currently available in chargen, and stops accepting suggestions at the normal skill-pick limit. Accepted suggestions are ordinary selections: they count toward costs and the pick limit and can be removed or replaced by the player. A missing or zero prog leaves the existing manual-selection behaviour unchanged.
+
 ## Application Types
 Chargen tracks `ApplicationType` explicitly:
 - `Normal`

--- a/MudSharpCore Unit Tests/CharacterCreation/SkillPickerScreenTests.cs
+++ b/MudSharpCore Unit Tests/CharacterCreation/SkillPickerScreenTests.cs
@@ -1,0 +1,168 @@
+#nullable enable
+
+using System.Collections.Generic;
+using System.Reflection;
+using System.Xml.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Body.Traits;
+using MudSharp.Character;
+using MudSharp.CharacterCreation.Screens;
+using MudSharp.Framework;
+using MudSharp.Framework.Save;
+using MudSharp.FutureProg;
+using MudSharp.PerceptionEngine;
+
+namespace MudSharp_Unit_Tests.CharacterCreation;
+
+[TestClass]
+public class SkillPickerScreenTests
+{
+	[TestMethod]
+	public void CanSelectSuggestedSkill_ValidLanguageSkill_ReturnsTrue()
+	{
+		var skill = Skill(TraitType.Skill, false, "language");
+
+		var result = SkillPickerScreenStoryboard.SkillPickerScreen.CanSelectSuggestedSkill(
+			skill, [], [skill], [], 1.0);
+
+		Assert.IsTrue(result);
+	}
+
+	[TestMethod]
+	public void CanSelectSuggestedSkill_InvalidSuggestion_ReturnsFalse()
+	{
+		var freeSkill = Skill();
+		var hiddenSkill = Skill(hidden: true);
+		var attribute = Skill(TraitType.Attribute);
+		var unavailableSkill = Skill();
+		var selectedSkill = Skill();
+		var available = new[] { freeSkill, hiddenSkill, attribute, selectedSkill };
+
+		Assert.IsFalse(SkillPickerScreenStoryboard.SkillPickerScreen.CanSelectSuggestedSkill(
+			freeSkill, [freeSkill], available, [freeSkill], 2.0));
+		Assert.IsFalse(SkillPickerScreenStoryboard.SkillPickerScreen.CanSelectSuggestedSkill(
+			hiddenSkill, [], available, [], 2.0));
+		Assert.IsFalse(SkillPickerScreenStoryboard.SkillPickerScreen.CanSelectSuggestedSkill(
+			attribute, [], available, [], 2.0));
+		Assert.IsFalse(SkillPickerScreenStoryboard.SkillPickerScreen.CanSelectSuggestedSkill(
+			unavailableSkill, [], available, [], 2.0));
+		Assert.IsFalse(SkillPickerScreenStoryboard.SkillPickerScreen.CanSelectSuggestedSkill(
+			selectedSkill, [], available, [selectedSkill], 2.0));
+	}
+
+	[TestMethod]
+	public void CanSelectSuggestedSkill_ProgOrderAndPickLimit_SelectsFirstDistinctSkills()
+	{
+		var first = Skill();
+		var second = Skill();
+		var third = Skill();
+		var selected = new List<ITraitDefinition>();
+		var available = new[] { first, second, third };
+
+		foreach (var suggestion in new[] { first, first, second, third })
+		{
+			if (SkillPickerScreenStoryboard.SkillPickerScreen.CanSelectSuggestedSkill(
+					suggestion, [], available, selected, 2.0))
+			{
+				selected.Add(suggestion);
+			}
+		}
+
+		CollectionAssert.AreEqual(new[] { first, second }, selected);
+		selected.Remove(first);
+		Assert.IsTrue(SkillPickerScreenStoryboard.SkillPickerScreen.CanSelectSuggestedSkill(
+			first, [], available, selected, 2.0));
+	}
+
+	[TestMethod]
+	public void Storyboard_LegacyXml_LoadsAndSavesWithoutSuggestedProg()
+	{
+		foreach (var value in new string?[] { null, "0", "none" })
+		{
+			Assert.IsNull(StoryboardFixture(value).Storyboard.SuggestedSkillsProg);
+		}
+
+		var fixture = StoryboardFixture();
+		Assert.IsNull(fixture.Storyboard.SuggestedSkillsProg);
+		var saved = XElement.Parse(SaveDefinition(fixture.Storyboard));
+		Assert.AreEqual("0", saved.Element("SuggestedSkillsProg")?.Value);
+	}
+
+	[TestMethod]
+	public void Storyboard_SuggestedProg_RoundTripsThroughXml()
+	{
+		var fixture = StoryboardFixture("3");
+
+		Assert.AreSame(fixture.SuggestedProg, fixture.Storyboard.SuggestedSkillsProg);
+		var saved = XElement.Parse(SaveDefinition(fixture.Storyboard));
+		Assert.AreEqual("3", saved.Element("SuggestedSkillsProg")?.Value);
+	}
+
+	[TestMethod]
+	public void BuildingCommandSuggestedSkills_SetsAndClearsProg()
+	{
+		var fixture = StoryboardFixture();
+		var output = new Mock<IOutputHandler>();
+		var actor = new Mock<ICharacter>();
+		actor.SetupGet(x => x.OutputHandler).Returns(output.Object);
+		actor.Setup(x => x.IsAdministrator(It.IsAny<MudSharp.Accounts.PermissionLevel>())).Returns(true);
+
+		Assert.IsTrue(fixture.Storyboard.BuildingCommand(actor.Object,
+			new StringStack("suggestedskills SuggestedSkills")));
+		Assert.AreSame(fixture.SuggestedProg, fixture.Storyboard.SuggestedSkillsProg);
+		Assert.IsTrue(fixture.Storyboard.BuildingCommand(actor.Object,
+			new StringStack("suggestedskills none")));
+		Assert.IsNull(fixture.Storyboard.SuggestedSkillsProg);
+	}
+
+	private static ITraitDefinition Skill(TraitType type = TraitType.Skill, bool hidden = false, string group = "")
+	{
+		var skill = new Mock<ITraitDefinition>();
+		skill.SetupGet(x => x.TraitType).Returns(type);
+		skill.SetupGet(x => x.Hidden).Returns(hidden);
+		skill.SetupGet(x => x.Group).Returns(group);
+		return skill.Object;
+	}
+
+	private static (SkillPickerScreenStoryboard Storyboard, IFutureProg SuggestedProg) StoryboardFixture(
+		string? suggestedProgValue = null)
+	{
+		var picksProg = new Mock<IFutureProg>();
+		var freeSkillsProg = new Mock<IFutureProg>();
+		var suggestedProg = new Mock<IFutureProg>();
+		suggestedProg.SetupGet(x => x.Id).Returns(3);
+		suggestedProg.SetupGet(x => x.FunctionName).Returns("SuggestedSkills");
+		suggestedProg.SetupGet(x => x.ReturnType)
+			.Returns(ProgVariableTypes.Collection | ProgVariableTypes.Trait);
+		suggestedProg.Setup(x => x.MatchesParameters(It.IsAny<IEnumerable<ProgVariableTypes>>())).Returns(true);
+
+		var progs = new Mock<IUneditableAll<IFutureProg>>();
+		progs.Setup(x => x.Get(1)).Returns(picksProg.Object);
+		progs.Setup(x => x.Get(2)).Returns(freeSkillsProg.Object);
+		progs.Setup(x => x.Get(3)).Returns(suggestedProg.Object);
+		progs.Setup(x => x.GetByIdOrName("SuggestedSkills", It.IsAny<bool>())).Returns(suggestedProg.Object);
+		var gameworld = new Mock<IFuturemud>();
+		gameworld.SetupGet(x => x.FutureProgs).Returns(progs.Object);
+		gameworld.SetupGet(x => x.SaveManager).Returns(new Mock<ISaveManager>().Object);
+
+		var suggestedElement = suggestedProgValue is null
+			? ""
+			: $"<SuggestedSkillsProg>{suggestedProgValue}</SuggestedSkillsProg>";
+		var model = new MudSharp.Models.ChargenScreenStoryboard
+		{
+			Id = 1,
+			StageDefinition =
+				$"<Definition><Blurb><![CDATA[Test]]></Blurb><NumberOfSkillPicksProg>1</NumberOfSkillPicksProg><FreeSkillsProg>2</FreeSkillsProg>{suggestedElement}</Definition>"
+		};
+
+		return (new SkillPickerScreenStoryboard(gameworld.Object, model), suggestedProg.Object);
+	}
+
+	private static string SaveDefinition(SkillPickerScreenStoryboard storyboard)
+	{
+		return (string)typeof(SkillPickerScreenStoryboard)
+			.GetMethod("SaveDefinition", BindingFlags.Instance | BindingFlags.NonPublic)!
+			.Invoke(storyboard, null)!;
+	}
+}

--- a/MudSharpCore/CharacterCreation/Screens/SkillPickerScreen.cs
+++ b/MudSharpCore/CharacterCreation/Screens/SkillPickerScreen.cs
@@ -30,6 +30,17 @@ public class SkillPickerScreenStoryboard : ChargenScreenStoryboard
                 x =>
                     x.FunctionName.Equals(definition.Element("FreeSkillsProg").Value,
                         StringComparison.InvariantCultureIgnoreCase));
+        XElement suggestedSkillsProg = definition.Element("SuggestedSkillsProg");
+        if (suggestedSkillsProg is not null &&
+            !string.IsNullOrWhiteSpace(suggestedSkillsProg.Value) &&
+            !suggestedSkillsProg.Value.EqualTo("none"))
+        {
+            SuggestedSkillsProg = long.TryParse(suggestedSkillsProg.Value, out value)
+                ? Gameworld.FutureProgs.Get(value)
+                : Gameworld.FutureProgs.FirstOrDefault(
+                    x => x.FunctionName.Equals(suggestedSkillsProg.Value,
+                        StringComparison.InvariantCultureIgnoreCase));
+        }
     }
 
     protected SkillPickerScreenStoryboard(IFuturemud gameworld, IChargenScreenStoryboard storyboard) : base(gameworld,
@@ -63,6 +74,7 @@ public class SkillPickerScreenStoryboard : ChargenScreenStoryboard
 
     public IFutureProg NumberOfSkillPicksProg { get; protected set; }
     public IFutureProg FreeSkillsProg { get; protected set; }
+    public IFutureProg SuggestedSkillsProg { get; protected set; }
 
     public string Blurb { get; protected set; }
 
@@ -76,7 +88,8 @@ public class SkillPickerScreenStoryboard : ChargenScreenStoryboard
         return new XElement("Definition",
             new XElement("Blurb", new XCData(Blurb)),
             new XElement("NumberOfSkillPicksProg", NumberOfSkillPicksProg?.Id ?? 0),
-            new XElement("FreeSkillsProg", FreeSkillsProg?.Id ?? 0)
+            new XElement("FreeSkillsProg", FreeSkillsProg?.Id ?? 0),
+            new XElement("SuggestedSkillsProg", SuggestedSkillsProg?.Id ?? 0)
         ).ToString();
     }
 
@@ -92,6 +105,7 @@ public class SkillPickerScreenStoryboard : ChargenScreenStoryboard
                 .Wrap(voyeur.InnerLineFormatLength).ColourCommand());
         sb.AppendLine();
         sb.AppendLine($"Free Skills Prog: {FreeSkillsProg?.MXPClickableFunctionName() ?? "None".ColourError()}");
+        sb.AppendLine($"Suggested Skills Prog: {SuggestedSkillsProg?.MXPClickableFunctionName() ?? "None".ColourError()}");
         sb.AppendLine($"# Picks Prog: {NumberOfSkillPicksProg?.MXPClickableFunctionName() ?? "None".ColourError()}");
         sb.AppendLine();
         sb.AppendLine("Skill Blurb".GetLineWithTitle(voyeur, Telnet.Cyan, Telnet.BoldWhite));
@@ -153,7 +167,33 @@ public class SkillPickerScreenStoryboard : ChargenScreenStoryboard
                                 .ToList();
             Chargen.SelectedSkills.AddRange(FreeSkills);
             SetCurrentSelectables();
+            double maximumSkillPicks = Convert.ToDouble(storyboard.NumberOfSkillPicksProg.Execute(chargen));
+            foreach (ITraitDefinition skill in storyboard.SuggestedSkillsProg?.ExecuteCollection<ITraitDefinition>(chargen) ?? [])
+            {
+                if (!CanSelectSuggestedSkill(skill, FreeSkills, CurrentSelectables, Chargen.SelectedSkills,
+                        maximumSkillPicks))
+                {
+                    continue;
+                }
+
+                Chargen.SelectedSkills.Add(skill);
+                SetCurrentSelectables();
+            }
+
             LastCurrentSelectables = CurrentSelectables;
+        }
+
+        internal static bool CanSelectSuggestedSkill(ITraitDefinition skill,
+            IEnumerable<ITraitDefinition> freeSkills, IEnumerable<ITraitDefinition> currentSelectables,
+            IEnumerable<ITraitDefinition> selectedSkills, double maximumSkillPicks)
+        {
+            return skill is not null &&
+                   skill.TraitType == TraitType.Skill &&
+                   !skill.Hidden &&
+                   !freeSkills.Contains(skill) &&
+                   currentSelectables.Contains(skill) &&
+                   !selectedSkills.Contains(skill) &&
+                   selectedSkills.Except(freeSkills).Count() < maximumSkillPicks;
         }
 
         public override ChargenStage AssociatedStage => ChargenStage.SelectSkills;
@@ -344,6 +384,7 @@ Type the name of the skill you would like to select, or type {"done".Colour(Teln
     public override string HelpText => $@"{BaseHelpText}
 	#3blurb#0 - drops you into an editor to change the blurb
 	#3freeskills <prog>#0 - sets the free skills prog
+	#3suggestedskills <prog|none>#0 - sets or clears the suggested skills prog
 	#3picks <prog>#0 - sets a prog for how many skill picks the player gets";
 
     /// <inheritdoc />
@@ -362,6 +403,11 @@ Type the name of the skill you would like to select, or type {"done".Colour(Teln
             case "skillsprog":
             case "skillprog":
                 return BuildingCommandFreeSkills(actor, command);
+            case "suggestedskills":
+            case "suggestedskillsprog":
+            case "suggestedskill":
+            case "suggestedskillprog":
+                return BuildingCommandSuggestedSkills(actor, command);
         }
 
         return BuildingCommandFallback(actor, command.GetUndo());
@@ -415,6 +461,41 @@ Type the name of the skill you would like to select, or type {"done".Colour(Teln
         Changed = true;
         actor.OutputHandler.Send(
             $"The prog {prog.MXPClickableFunctionName()} will now be used to control which skills characters get for free.");
+        return true;
+    }
+
+    private bool BuildingCommandSuggestedSkills(ICharacter actor, StringStack command)
+    {
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send(
+                "Which prog should suggest initially selected skills? Use #3none#0 to clear."
+                    .SubstituteANSIColour());
+            return false;
+        }
+
+        if (command.SafeRemainingArgument.EqualToAny("none", "clear", "remove"))
+        {
+            SuggestedSkillsProg = null;
+            Changed = true;
+            actor.OutputHandler.Send("Characters will no longer have skills suggested on this screen.");
+            return true;
+        }
+
+        IFutureProg prog = new ProgLookupFromBuilderInput(Gameworld, actor, command.SafeRemainingArgument,
+            ProgVariableTypes.Collection | ProgVariableTypes.Trait, new List<ProgVariableTypes>
+            {
+                ProgVariableTypes.Chargen
+            }).LookupProg();
+        if (prog is null)
+        {
+            return false;
+        }
+
+        SuggestedSkillsProg = prog;
+        Changed = true;
+        actor.OutputHandler.Send(
+            $"The prog {prog.MXPClickableFunctionName()} will now suggest initially selected skills.");
         return true;
     }
 


### PR DESCRIPTION
## Summary

- add an optional `SuggestedSkillsProg` to the `SkillPicker` chargen storyboard
- pre-select valid returned skills as ordinary, editable picks
- add builder configuration, backward-compatible storyboard XML, focused tests, and chargen documentation

## Motivation

Worlds can now use earlier chargen choices, such as a profession role, to recommend an initial skill package without granting those skills for free or locking the player into those choices.

The prog signature is `(chargen) -> collection of traits`. Suggestions are processed in returned order and filtered against the current skill screen. Duplicate, free, hidden, non-skill, unavailable, and over-limit results are ignored. Accepted suggestions count toward normal pick limits and costs and remain removable.

## Builder configuration

```text
chargen set suggestedskills <prog>
chargen set suggestedskills none
```

Existing `SkillPicker` storyboard XML remains compatible: a missing, zero, or `none` `SuggestedSkillsProg` means no suggestions.

## Validation

- `dotnet build MudSharpCore/MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510` — passed
- targeted `SkillPickerScreenTests` — 6 passed
- `scripts/test-unit-core.ps1` — blocked by a pre-existing compile error on `origin/master`: `CombatStrategyRuntimeTests.cs` calls missing `GetCoreSourcePath` at lines 296–298

## Review focus

Please review the backward-compatible storyboard XML loading and the new `collection of traits (chargen)` FutureProg interface.