### PR TITLE
Document spatial area transfer packages

### DIFF
--- a/Design Documents/Building/Room_Building_Builder_Guide.md
+++ b/Design Documents/Building/Room_Building_Builder_Guide.md
@@ -95,6 +95,24 @@ rezone <zone>
 
 The `rooms` command can filter by zone and by keywords. Use `+keyword` to require text and `-keyword` to exclude text.
 
+### Moving a Zone Between Installations
+
+Senior administrators can export an ordinary zone to a versioned spatial-area package and import it into another FutureMUD installation:
+
+```text
+spatialpackage export zone "Harbour Ward" harbour-ward
+spatialpackage validate harbour-ward "Prime Material" "Imported Harbour Ward"
+spatialpackage import harbour-ward "Prime Material" confirm "Imported Harbour Ward"
+```
+
+Copy the generated `.fmsa.json` file from the source server's `Spatial Packages` directory into the same directory on the target server. On the target installation, open or create an `Under Design` cell overlay package before validation or import.
+
+An import always creates a new zone and assigns new IDs to its rooms, cells, overlays, and exits. It never merges into an existing zone or overwrites unrelated content. Validation checks package integrity, all internal references, the target shard's clocks and timezones, and named dependencies such as terrain, atmosphere, hearing profiles, weather controllers, forage profiles, tags, covers, and magic resources.
+
+Package version 1 handles ordinary zone topology and each cell's active overlay. It deliberately refuses cells whose faithful transfer requires data it does not yet carry: route-cell geometry, hosted vehicle interiors, temporary rooms, agriculture fields, persisted cell effects, surface-liquid state, installed door items, and fall exits that lead outside the zone. Links crossing the zone boundary, cross-cutting `AREA` membership, characters, and items are omitted with explicit diagnostics.
+
+See [Spatial Area Transfer Packages](../World/Spatial_Area_Transfer_Packages.md) for format, validation, remapping, and extension details.
+
 ### Rooms and Cells
 
 A cell is the concrete playable location. Rooms and cells are the same thing in the engine. They should be understood as synonyms.

--- a/Design Documents/README.md
+++ b/Design Documents/README.md
@@ -191,5 +191,6 @@ This folder is organised by subsystem so implementation notes, builder workflows
 - [Position State System](./World/Position_State_System.md)
 - [Room Layer System Primer](./World/Room_Layer_System_Primer.md)
 - [RouteCell Spatial System](./World/Route_Cell_System.md)
+- [Spatial Area Transfer Packages](./World/Spatial_Area_Transfer_Packages.md)
 - [Time and Date System](./World/Time_And_Date_System.md)
 - [Zero Gravity System](./World/Zero_Gravity_System.md)

--- a/Design Documents/World/Spatial_Area_Transfer_Packages.md
+++ b/Design Documents/World/Spatial_Area_Transfer_Packages.md
@@ -1,0 +1,152 @@
+# Spatial Area Transfer Packages
+
+## Purpose
+
+Spatial area transfer packages let a senior administrator export a self-contained ordinary zone from a running FutureMUD installation and recreate it in another installation. The workflow is intentionally conservative:
+
+- the package is human-readable, versioned JSON;
+- every imported database identity is newly allocated;
+- references inside the package use deterministic local keys rather than source database IDs;
+- installation-owned dependencies resolve by exact name during preflight;
+- imports create a new zone and never merge with or overwrite existing spatial content;
+- unsupported state blocks export when silently dropping it would make the result misleading.
+
+The version 1 file suffix is `.fmsa.json`. Files are read and written only beneath the server's `Spatial Packages` directory. Package names cannot contain a path.
+
+## Builder Workflow
+
+The command requires `SeniorAdmin` permission.
+
+On the source installation:
+
+```text
+spatialpackage export zone "Harbour Ward" harbour-ward
+```
+
+Copy `Spatial Packages/harbour-ward.fmsa.json` to the corresponding directory on the target installation.
+
+On the target installation:
+
+```text
+cell package new "Harbour Import"
+spatialpackage validate harbour-ward "Prime Material" "Imported Harbour Ward"
+spatialpackage import harbour-ward "Prime Material" confirm "Imported Harbour Ward"
+```
+
+The target overlay package must be `Under Design`. The target shard must already exist because shards own installation-level clocks, calendars, celestial objects, and sky configuration. The optional final argument overrides the imported zone name.
+
+`validate` is read-only. `import` repeats the complete preflight and also requires the literal `confirm` keyword. The import uses a serializable database transaction and rechecks zone-name uniqueness inside that transaction.
+
+## Version 1 Payload
+
+The top-level object contains:
+
+| Field | Purpose |
+| --- | --- |
+| `format` | Constant `futuremud-spatial-area`. |
+| `version` | Schema version. Version 1 is currently accepted. |
+| `integritySha256` | SHA-256 of the canonical payload with this field empty. |
+| `createdUtc` | Export timestamp. |
+| `source` | Diagnostic source IDs and names for the zone, shard, and active overlay package. Source IDs are never reused on import. |
+| `zone` | Zone name, geography, ambient light, weather/forage dependencies, default-cell key, and clock/timezone aliases. |
+| `rooms` | Deterministic room keys, source IDs for diagnostics, and integer coordinates. |
+| `cells` | Deterministic cell keys, parent-room keys, active overlay data, explicit forage override, tags, local covers, and magic-resource amounts. |
+| `exits` | Internal exit endpoints and both directional sides, door capability, size limits, climb/fall state, travel multiplier, and blocked layers. |
+
+Each export assigns keys in stable source-ID order:
+
+```text
+room-00001
+cell-00001
+exit-00001
+```
+
+References within the package use only these keys. Source database IDs remain diagnostic provenance and have no import semantics.
+
+## Overlay Behaviour
+
+Version 1 exports the currently active overlay for every cell, including:
+
+- cell name and description;
+- terrain;
+- hearing profile;
+- outdoors type;
+- atmosphere kind and name;
+- ambient and added light;
+- safe-quit state;
+- the exact internal exits active in that overlay.
+
+A zone may have cells whose active overlays came from different source overlay packages. Their active data is still exported independently. On import, all cells receive a new overlay in the builder's selected target package. Other historical or inactive source overlay revisions are not transferred.
+
+## Dependency Resolution
+
+The target installation supplies engine-owned dependencies. Preflight resolves them by exact, case-insensitive name:
+
+- terrain;
+- liquid or gas atmosphere, with the fluid kind checked;
+- hearing profile;
+- zone and explicit cell forage profiles;
+- weather controller;
+- cell tags;
+- local ranged covers;
+- magic resources.
+
+Clock dependencies resolve by clock alias. A timezone resolves by alias or description on that clock. A source clock absent from the target shard is an error. A clock that exists only on the target shard is assigned its primary timezone with a warning.
+
+Dependency source IDs are never used as a fallback. This prevents a coincidentally reused ID from linking the imported zone to the wrong target object.
+
+## Integrity and Validation
+
+Validation occurs before any database write and checks:
+
+- file containment and the 16 MiB size limit;
+- strict JSON with unknown fields rejected;
+- package format, version, and SHA-256 integrity;
+- room, cell, and exit count limits;
+- unique local keys;
+- room/cell/exit reference closure;
+- overlay-to-exit endpoint consistency;
+- valid default and fall cells;
+- finite geographic, light, resource, and travel values;
+- enum values known to the receiving engine;
+- cardinal versus non-cardinal exit-side consistency;
+- exact availability of every target dependency;
+- target zone-name uniqueness;
+- an open `Under Design` target overlay package.
+
+The importer allocates rows in dependency order: zone and rooms, cells, overlays, exits, overlay-exit links, then the zone default cell. All IDs are database-generated. Existing zones, rooms, cells, overlays, and exits are untouched.
+
+## Deliberate Version 1 Boundaries
+
+Export fails when a zone contains state that cannot yet be represented faithfully:
+
+- route cells, including length, landmarks, and exit anchors;
+- room-scale hosted vehicle interiors;
+- temporary cells;
+- agriculture fields;
+- persisted cell effects;
+- persistent surface-liquid state;
+- installed door items;
+- fall exits whose destination is outside the exported zone.
+
+The following data is not spatial content and is omitted with diagnostics:
+
+- characters and game items;
+- exits crossing the exported zone boundary;
+- membership in cross-cutting `AREA` groups.
+- cell event hooks, which are behavioural installation content rather than spatial topology.
+
+Exit door capability and permitted door size are transferred, but an installed physical door item is not.
+
+## Planned Extensions
+
+A later schema version can add these independently without weakening version 1 validation:
+
+1. Route-cell definitions, landmarks, and per-exit anchors.
+2. Cross-zone `AREA` packages containing multiple zone fragments and area weather.
+3. Optional boundary-link manifests that a builder can explicitly reconnect after import.
+4. Installed door and selected static item packaging with their complete item-prototype dependency graphs.
+5. Agriculture, surface-liquid, ranged-cover state beyond local profile references, and selected portable effects.
+6. Additional overlay revisions and review history.
+
+Older servers must reject later schema versions until they explicitly implement them.

--- a/FutureMUDLibrary/Construction/ImportExport/ISpatialAreaTransferService.cs
+++ b/FutureMUDLibrary/Construction/ImportExport/ISpatialAreaTransferService.cs
@@ -1,0 +1,53 @@
+#nullable enable
+
+using System.Collections.Generic;
+using MudSharp.Character;
+
+namespace MudSharp.Construction.ImportExport;
+
+public enum SpatialAreaTransferDiagnosticSeverity
+{
+	Information,
+	Warning,
+	Error
+}
+
+public sealed record SpatialAreaTransferDiagnostic(
+	SpatialAreaTransferDiagnosticSeverity Severity,
+	string Code,
+	string Message);
+
+public sealed class SpatialAreaTransferResult
+{
+	public bool Success { get; init; }
+	public string Summary { get; init; } = string.Empty;
+	public string? PackagePath { get; init; }
+	public long? ImportedZoneId { get; init; }
+	public int RoomCount { get; init; }
+	public int CellCount { get; init; }
+	public int ExitCount { get; init; }
+	public IReadOnlyList<SpatialAreaTransferDiagnostic> Diagnostics { get; init; } =
+		[];
+}
+
+/// <summary>
+/// Exports and imports versioned, portable spatial-area packages.
+/// </summary>
+public interface ISpatialAreaTransferService
+{
+	string PackageDirectory { get; }
+
+	SpatialAreaTransferResult ExportZone(IZone zone, string packageFileName);
+
+	SpatialAreaTransferResult ValidateImport(
+		ICharacter actor,
+		IShard targetShard,
+		string packageFileName,
+		string? zoneNameOverride = null);
+
+	SpatialAreaTransferResult ImportZone(
+		ICharacter actor,
+		IShard targetShard,
+		string packageFileName,
+		string? zoneNameOverride = null);
+}

--- a/MudSharpCore Unit Tests/Construction/ImportExport/SpatialAreaPackageSerializerTests.cs
+++ b/MudSharpCore Unit Tests/Construction/ImportExport/SpatialAreaPackageSerializerTests.cs
@@ -1,0 +1,188 @@
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudSharp.Construction;
+using MudSharp.Construction.ImportExport;
+
+namespace MudSharpCore_Unit_Tests.Construction.ImportExport;
+
+[TestClass]
+public class SpatialAreaPackageSerializerTests
+{
+	[TestMethod]
+	public void SerializeDeserialize_ValidPackage_RoundTripsWithIntegrity()
+	{
+		var package = CreateValidPackage();
+
+		var json = SpatialAreaPackageSerializer.Serialize(package);
+		var result = SpatialAreaPackageSerializer.Deserialize(json);
+
+		Assert.IsTrue(result.Success);
+		Assert.IsNotNull(result.Package);
+		Assert.AreEqual("Test Zone", result.Package.Zone.Name);
+		Assert.AreEqual(2, result.Package.Cells.Count);
+		Assert.AreEqual(1, result.Package.Exits.Count);
+		Assert.AreEqual(64, result.Package.IntegritySha256.Length);
+	}
+
+	[TestMethod]
+	public void Deserialize_TamperedPayload_RejectsIntegrity()
+	{
+		var json = SpatialAreaPackageSerializer.Serialize(CreateValidPackage())
+			.Replace("Second room", "Tampered room", StringComparison.Ordinal);
+
+		var result = SpatialAreaPackageSerializer.Deserialize(json);
+
+		Assert.IsFalse(result.Success);
+		Assert.IsNull(result.Package);
+		Assert.IsTrue(result.Diagnostics.Any(x => x.Code == "integrity-failed"));
+	}
+
+	[TestMethod]
+	public void Validate_OrphanedExitReference_ReportsActionableDiagnostics()
+	{
+		var package = CreateValidPackage();
+		package.Cells[0].Overlay.ExitKeys.Add("exit-missing");
+		package.Exits[0].Cell2Key = "cell-missing";
+
+		var diagnostics = SpatialAreaPackageSerializer.Validate(package);
+
+		Assert.IsTrue(diagnostics.Any(x => x.Code == "orphan-overlay-exit"));
+		Assert.IsTrue(diagnostics.Any(x => x.Code == "orphan-exit"));
+	}
+
+	[TestMethod]
+	public void Validate_DuplicateKeys_RejectsAmbiguousIdRemapping()
+	{
+		var package = CreateValidPackage();
+		package.Cells[1].Key = package.Cells[0].Key;
+
+		var diagnostics = SpatialAreaPackageSerializer.Validate(package);
+
+		Assert.IsTrue(diagnostics.Any(x => x.Code == "duplicate-cell-key"));
+	}
+
+	[TestMethod]
+	public void TryResolvePackagePath_TraversalName_IsRejected()
+	{
+		var root = Path.Combine(Path.GetTempPath(), "futuremud-spatial-package-tests");
+
+		var success = SpatialAreaTransferService.TryResolvePackagePath(
+			root,
+			"..\\outside",
+			out _,
+			out var error);
+
+		Assert.IsFalse(success);
+		StringAssert.Contains(error, "no path");
+	}
+
+	[TestMethod]
+	public void TryResolvePackagePath_SimpleName_AddsExpectedSuffix()
+	{
+		var root = Path.Combine(Path.GetTempPath(), "futuremud-spatial-package-tests");
+
+		var success = SpatialAreaTransferService.TryResolvePackagePath(
+			root,
+			"safe-zone",
+			out var path,
+			out _);
+
+		Assert.IsTrue(success);
+		Assert.AreEqual("safe-zone.fmsa.json", Path.GetFileName(path));
+		Assert.IsTrue(path.StartsWith(Path.GetFullPath(root), StringComparison.OrdinalIgnoreCase));
+	}
+
+	private static SpatialAreaPackage CreateValidPackage()
+	{
+		return new SpatialAreaPackage
+		{
+			CreatedUtc = new DateTime(2026, 7, 24, 0, 0, 0, DateTimeKind.Utc),
+			Source = new SpatialAreaPackageSource
+			{
+				ZoneName = "Test Zone",
+				ZoneId = 10,
+				ShardName = "Test Shard",
+				ShardId = 2,
+				OverlayPackageName = "Test Overlay",
+				OverlayPackageId = 4,
+				OverlayPackageRevision = 1
+			},
+			Zone = new SpatialZoneDefinition
+			{
+				Name = "Test Zone",
+				DefaultCellKey = "cell-00001",
+				TimeZones =
+				[
+					new SpatialTimeZoneDefinition
+					{
+						ClockAlias = "test-clock",
+						TimeZoneAlias = "utc",
+						TimeZoneDescription = "Universal"
+					}
+				]
+			},
+			Rooms =
+			[
+				new SpatialRoomDefinition
+				{
+					Key = "room-00001",
+					SourceId = 100
+				},
+				new SpatialRoomDefinition
+				{
+					Key = "room-00002",
+					SourceId = 101,
+					X = 1
+				}
+			],
+			Cells =
+			[
+				new SpatialCellDefinition
+				{
+					Key = "cell-00001",
+					SourceId = 200,
+					RoomKey = "room-00001",
+					Overlay = new SpatialCellOverlayDefinition
+					{
+						CellName = "First Room",
+						CellDescription = "The first room.",
+						Terrain = new SpatialNamedReference { SourceId = 1, Name = "Default" },
+						AmbientLightFactor = 1.0,
+						ExitKeys = ["exit-00001"]
+					}
+				},
+				new SpatialCellDefinition
+				{
+					Key = "cell-00002",
+					SourceId = 201,
+					RoomKey = "room-00002",
+					Overlay = new SpatialCellOverlayDefinition
+					{
+						CellName = "Second Room",
+						CellDescription = "Second room",
+						Terrain = new SpatialNamedReference { SourceId = 1, Name = "Default" },
+						AmbientLightFactor = 1.0,
+						ExitKeys = ["exit-00001"]
+					}
+				}
+			],
+			Exits =
+			[
+				new SpatialExitDefinition
+				{
+					Key = "exit-00001",
+					SourceId = 300,
+					Cell1Key = "cell-00001",
+					Cell2Key = "cell-00002",
+					Side1 = new SpatialExitSideDefinition { Direction = (int)CardinalDirection.East },
+					Side2 = new SpatialExitSideDefinition { Direction = (int)CardinalDirection.West },
+					TimeMultiplier = 1.0,
+					MaximumSizeToEnter = 12,
+					MaximumSizeToEnterUpright = 12
+				}
+			]
+		};
+	}
+}

--- a/MudSharpCore/Commands/Modules/RoomBuilderModule.SpatialPackages.cs
+++ b/MudSharpCore/Commands/Modules/RoomBuilderModule.SpatialPackages.cs
@@ -1,0 +1,190 @@
+#nullable enable
+
+using System.Text;
+using MudSharp.Accounts;
+using MudSharp.Character;
+using MudSharp.Construction;
+using MudSharp.Construction.ImportExport;
+using MudSharp.Framework;
+
+namespace MudSharp.Commands.Modules;
+
+internal partial class RoomBuilderModule
+{
+	private const string SpatialPackageHelpText =
+		@"The #3SPATIALPACKAGE#0 command exports and imports portable, versioned spatial-area packages.
+
+Version 1 transfers a complete ordinary zone: room coordinates, cells, active overlays, internal exits, zone geography and environment, tags, local covers, and magic-resource state. Imports always create a new zone and remap all room, cell, overlay and exit IDs. They never merge into or overwrite existing spatial content.
+
+Files are read and written only inside the server's #6Spatial Packages#0 directory.
+
+	#3spatialpackage export zone <zone> <file>#0 - exports a zone; the .fmsa.json suffix is optional
+	#3spatialpackage validate <file> <target shard> [new zone name]#0 - preflights integrity and dependencies
+	#3spatialpackage import <file> <target shard> confirm [new zone name]#0 - creates the validated zone
+
+You must be editing an under-design #3CELL PACKAGE#0 to validate or import. Quote multi-word zone, shard and file arguments where required. Version 1 refuses route cells, hosted vehicle interiors, temporary cells, agriculture fields, persisted cell effects, surface liquids, installed door items, and external fall destinations rather than silently losing those dependencies.";
+
+	[PlayerCommand("SpatialPackage", "spatialpackage")]
+	[CommandPermission(PermissionLevel.SeniorAdmin)]
+	[HelpInfo("spatialpackage", SpatialPackageHelpText, AutoHelp.HelpArgOrNoArg)]
+	protected static void SpatialPackage(ICharacter actor, string input)
+	{
+		var command = new StringStack(input.RemoveFirstWord());
+		switch (command.PopForSwitch())
+		{
+			case "export":
+				SpatialPackageExport(actor, command);
+				return;
+			case "validate":
+			case "check":
+				SpatialPackageValidate(actor, command);
+				return;
+			case "import":
+				SpatialPackageImport(actor, command);
+				return;
+			default:
+				actor.OutputHandler.Send(SpatialPackageHelpText.SubstituteANSIColour());
+				return;
+		}
+	}
+
+	private static void SpatialPackageExport(ICharacter actor, StringStack command)
+	{
+		if (!command.PopForSwitch().EqualTo("zone"))
+		{
+			actor.OutputHandler.Send(
+				$"Version 1 exports whole zones. Use {"spatialpackage export zone <zone> <file>".ColourCommand()}.");
+			return;
+		}
+
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which zone do you want to export?");
+			return;
+		}
+
+		var zoneText = command.PopSpeech();
+		var zone = actor.Gameworld.Zones.GetByIdOrName(zoneText, false);
+		if (zone is null)
+		{
+			actor.OutputHandler.Send($"There is no zone identified by {zoneText.ColourCommand()}.");
+			return;
+		}
+
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("What file name should be used for the package?");
+			return;
+		}
+
+		var fileName = command.PopSpeech();
+		if (!command.IsFinished)
+		{
+			actor.OutputHandler.Send("The file name must be one argument and may not contain a path.");
+			return;
+		}
+
+		var result = SpatialAreaTransferService.Instance.ExportZone(zone, fileName);
+		SendSpatialPackageResult(actor, result);
+	}
+
+	private static void SpatialPackageValidate(ICharacter actor, StringStack command)
+	{
+		if (!TryParseSpatialPackageTarget(actor, command, out var fileName, out var shard))
+		{
+			return;
+		}
+
+		var zoneNameOverride = command.IsFinished ? null : command.SafeRemainingArgument;
+		var result = SpatialAreaTransferService.Instance.ValidateImport(
+			actor,
+			shard!,
+			fileName!,
+			zoneNameOverride);
+		SendSpatialPackageResult(actor, result);
+	}
+
+	private static void SpatialPackageImport(ICharacter actor, StringStack command)
+	{
+		if (!TryParseSpatialPackageTarget(actor, command, out var fileName, out var shard))
+		{
+			return;
+		}
+
+		if (command.IsFinished || !command.PopForSwitch().EqualTo("confirm"))
+		{
+			actor.OutputHandler.Send(
+				$"Import requires the explicit {"confirm".ColourCommand()} keyword after the target shard. Run {"spatialpackage validate".ColourCommand()} first.");
+			return;
+		}
+
+		var zoneNameOverride = command.IsFinished ? null : command.SafeRemainingArgument;
+		var result = SpatialAreaTransferService.Instance.ImportZone(
+			actor,
+			shard!,
+			fileName!,
+			zoneNameOverride);
+		SendSpatialPackageResult(actor, result);
+	}
+
+	private static bool TryParseSpatialPackageTarget(
+		ICharacter actor,
+		StringStack command,
+		out string? fileName,
+		out IShard? shard)
+	{
+		fileName = null;
+		shard = null;
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which package file do you want to use?");
+			return false;
+		}
+
+		fileName = command.PopSpeech();
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Into which existing shard should the new zone be imported?");
+			return false;
+		}
+
+		var shardText = command.PopSpeech();
+		shard = actor.Gameworld.Shards.GetByIdOrName(shardText, false);
+		if (shard is null)
+		{
+			actor.OutputHandler.Send($"There is no shard identified by {shardText.ColourCommand()}.");
+			return false;
+		}
+
+		return true;
+	}
+
+	private static void SendSpatialPackageResult(ICharacter actor, SpatialAreaTransferResult result)
+	{
+		var text = new StringBuilder();
+		text.AppendLine(result.Success ? result.Summary.ColourValue() : result.Summary.ColourError());
+		if (result.PackagePath is not null)
+		{
+			text.AppendLine($"Package: {result.PackagePath.ColourCommand()}");
+		}
+
+		if (result.RoomCount > 0 || result.CellCount > 0 || result.ExitCount > 0)
+		{
+			text.AppendLine(
+				$"Contents: {result.RoomCount.ToString("N0", actor).ColourValue()} room(s), {result.CellCount.ToString("N0", actor).ColourValue()} cell(s), {result.ExitCount.ToString("N0", actor).ColourValue()} internal exit(s)");
+		}
+
+		foreach (var diagnostic in result.Diagnostics)
+		{
+			var line = $"[{diagnostic.Code}] {diagnostic.Message}";
+			text.AppendLine(diagnostic.Severity switch
+			{
+				SpatialAreaTransferDiagnosticSeverity.Error => line.ColourError(),
+				SpatialAreaTransferDiagnosticSeverity.Warning => line.Colour(Telnet.Yellow),
+				_ => line
+			});
+		}
+
+		actor.OutputHandler.Send(text.ToString());
+	}
+}

--- a/MudSharpCore/Construction/ImportExport/SpatialAreaPackageModels.cs
+++ b/MudSharpCore/Construction/ImportExport/SpatialAreaPackageModels.cs
@@ -1,0 +1,133 @@
+#nullable enable
+
+namespace MudSharp.Construction.ImportExport;
+
+public sealed class SpatialAreaPackage
+{
+	public const string CurrentFormat = "futuremud-spatial-area";
+	public const int CurrentVersion = 1;
+
+	public string Format { get; set; } = CurrentFormat;
+	public int Version { get; set; } = CurrentVersion;
+	public string IntegritySha256 { get; set; } = string.Empty;
+	public DateTime CreatedUtc { get; set; }
+	public SpatialAreaPackageSource Source { get; set; } = new();
+	public SpatialZoneDefinition Zone { get; set; } = new();
+	public List<SpatialRoomDefinition> Rooms { get; set; } = [];
+	public List<SpatialCellDefinition> Cells { get; set; } = [];
+	public List<SpatialExitDefinition> Exits { get; set; } = [];
+}
+
+public sealed class SpatialAreaPackageSource
+{
+	public string ZoneName { get; set; } = string.Empty;
+	public long ZoneId { get; set; }
+	public string ShardName { get; set; } = string.Empty;
+	public long ShardId { get; set; }
+	public string OverlayPackageName { get; set; } = string.Empty;
+	public long OverlayPackageId { get; set; }
+	public int OverlayPackageRevision { get; set; }
+}
+
+public sealed class SpatialZoneDefinition
+{
+	public string Name { get; set; } = string.Empty;
+	public double LatitudeRadians { get; set; }
+	public double LongitudeRadians { get; set; }
+	public double ElevationMetres { get; set; }
+	public double AmbientLightPollution { get; set; }
+	public SpatialNamedReference? ForagableProfile { get; set; }
+	public SpatialNamedReference? WeatherController { get; set; }
+	public string DefaultCellKey { get; set; } = string.Empty;
+	public List<SpatialTimeZoneDefinition> TimeZones { get; set; } = [];
+}
+
+public sealed class SpatialTimeZoneDefinition
+{
+	public string ClockAlias { get; set; } = string.Empty;
+	public string TimeZoneAlias { get; set; } = string.Empty;
+	public string TimeZoneDescription { get; set; } = string.Empty;
+}
+
+public sealed class SpatialRoomDefinition
+{
+	public string Key { get; set; } = string.Empty;
+	public long SourceId { get; set; }
+	public int X { get; set; }
+	public int Y { get; set; }
+	public int Z { get; set; }
+}
+
+public sealed class SpatialCellDefinition
+{
+	public string Key { get; set; } = string.Empty;
+	public long SourceId { get; set; }
+	public string RoomKey { get; set; } = string.Empty;
+	public SpatialCellOverlayDefinition Overlay { get; set; } = new();
+	public SpatialNamedReference? ForagableProfile { get; set; }
+	public List<SpatialNamedReference> Tags { get; set; } = [];
+	public List<SpatialNamedReference> RangedCovers { get; set; } = [];
+	public List<SpatialMagicResourceDefinition> MagicResources { get; set; } = [];
+}
+
+public sealed class SpatialCellOverlayDefinition
+{
+	public string CellName { get; set; } = string.Empty;
+	public string CellDescription { get; set; } = string.Empty;
+	public SpatialNamedReference Terrain { get; set; } = new();
+	public SpatialNamedReference? HearingProfile { get; set; }
+	public SpatialFluidReference? Atmosphere { get; set; }
+	public int OutdoorsType { get; set; }
+	public double AmbientLightFactor { get; set; }
+	public double AddedLight { get; set; }
+	public bool SafeQuit { get; set; }
+	public List<string> ExitKeys { get; set; } = [];
+}
+
+public sealed class SpatialMagicResourceDefinition
+{
+	public SpatialNamedReference Resource { get; set; } = new();
+	public double Amount { get; set; }
+}
+
+public class SpatialNamedReference
+{
+	public long SourceId { get; set; }
+	public string Name { get; set; } = string.Empty;
+}
+
+public sealed class SpatialFluidReference : SpatialNamedReference
+{
+	public string Kind { get; set; } = string.Empty;
+}
+
+public sealed class SpatialExitDefinition
+{
+	public string Key { get; set; } = string.Empty;
+	public long SourceId { get; set; }
+	public string Cell1Key { get; set; } = string.Empty;
+	public string Cell2Key { get; set; } = string.Empty;
+	public SpatialExitSideDefinition Side1 { get; set; } = new();
+	public SpatialExitSideDefinition Side2 { get; set; } = new();
+	public double TimeMultiplier { get; set; }
+	public bool AcceptsDoor { get; set; }
+	public int DoorSize { get; set; }
+	public int MaximumSizeToEnter { get; set; }
+	public int MaximumSizeToEnterUpright { get; set; }
+	public bool IsClimbExit { get; set; }
+	public int ClimbDifficulty { get; set; }
+	public string? FallCellKey { get; set; }
+	public List<int> BlockedLayers { get; set; } = [];
+}
+
+public sealed class SpatialExitSideDefinition
+{
+	public int Direction { get; set; }
+	public string? Verb { get; set; }
+	public string? PrimaryKeyword { get; set; }
+	public string? Keywords { get; set; }
+	public string? InboundDescription { get; set; }
+	public string? InboundTarget { get; set; }
+	public string? OutboundDescription { get; set; }
+	public string? OutboundTarget { get; set; }
+}

--- a/MudSharpCore/Construction/ImportExport/SpatialAreaPackageSerializer.cs
+++ b/MudSharpCore/Construction/ImportExport/SpatialAreaPackageSerializer.cs
@@ -1,0 +1,414 @@
+#nullable enable
+
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace MudSharp.Construction.ImportExport;
+
+public sealed class SpatialAreaPackageReadResult
+{
+	public SpatialAreaPackage? Package { get; init; }
+	public IReadOnlyList<SpatialAreaTransferDiagnostic> Diagnostics { get; init; } = [];
+	public bool Success => Package is not null &&
+	                       Diagnostics.All(x => x.Severity != SpatialAreaTransferDiagnosticSeverity.Error);
+}
+
+public static class SpatialAreaPackageSerializer
+{
+	public const long MaximumPackageBytes = 16L * 1024L * 1024L;
+	public const int MaximumRooms = 10_000;
+	public const int MaximumCells = 20_000;
+	public const int MaximumExits = 50_000;
+
+	private static readonly JsonSerializerOptions Options = new()
+	{
+		AllowTrailingCommas = false,
+		DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+		PropertyNameCaseInsensitive = false,
+		ReadCommentHandling = JsonCommentHandling.Disallow,
+		UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+		WriteIndented = true
+	};
+
+	public static string Serialize(SpatialAreaPackage package)
+	{
+		package.IntegritySha256 = string.Empty;
+		var canonicalJson = JsonSerializer.Serialize(package, Options);
+		package.IntegritySha256 = ComputeHash(canonicalJson);
+		return JsonSerializer.Serialize(package, Options);
+	}
+
+	public static SpatialAreaPackageReadResult Deserialize(string json)
+	{
+		var diagnostics = new List<SpatialAreaTransferDiagnostic>();
+		if (Encoding.UTF8.GetByteCount(json) > MaximumPackageBytes)
+		{
+			diagnostics.Add(Error("package-too-large",
+				$"The package exceeds the {MaximumPackageBytes:N0}-byte safety limit."));
+			return new SpatialAreaPackageReadResult { Diagnostics = diagnostics };
+		}
+
+		SpatialAreaPackage? package;
+		try
+		{
+			package = JsonSerializer.Deserialize<SpatialAreaPackage>(json, Options);
+		}
+		catch (JsonException ex)
+		{
+			diagnostics.Add(Error("invalid-json", $"The package is not valid versioned JSON: {ex.Message}"));
+			return new SpatialAreaPackageReadResult { Diagnostics = diagnostics };
+		}
+
+		if (package is null)
+		{
+			diagnostics.Add(Error("empty-package", "The package did not contain an object."));
+			return new SpatialAreaPackageReadResult { Diagnostics = diagnostics };
+		}
+
+		var suppliedHash = package.IntegritySha256;
+		package.IntegritySha256 = string.Empty;
+		var expectedHash = ComputeHash(JsonSerializer.Serialize(package, Options));
+		package.IntegritySha256 = suppliedHash;
+		if (string.IsNullOrWhiteSpace(suppliedHash) ||
+		    !CryptographicOperations.FixedTimeEquals(
+			    Encoding.ASCII.GetBytes(suppliedHash.ToLowerInvariant()),
+			    Encoding.ASCII.GetBytes(expectedHash)))
+		{
+			diagnostics.Add(Error("integrity-failed",
+				"The package SHA-256 integrity value does not match its contents."));
+		}
+
+		diagnostics.AddRange(Validate(package));
+		return new SpatialAreaPackageReadResult
+		{
+			Package = diagnostics.Any(x => x.Severity == SpatialAreaTransferDiagnosticSeverity.Error)
+				? null
+				: package,
+			Diagnostics = diagnostics
+		};
+	}
+
+	public static IReadOnlyList<SpatialAreaTransferDiagnostic> Validate(SpatialAreaPackage package)
+	{
+		var diagnostics = new List<SpatialAreaTransferDiagnostic>();
+		if (!string.Equals(package.Format, SpatialAreaPackage.CurrentFormat, StringComparison.Ordinal))
+		{
+			diagnostics.Add(Error("unsupported-format",
+				$"Expected format '{SpatialAreaPackage.CurrentFormat}', but found '{package.Format}'."));
+		}
+
+		if (package.Version != SpatialAreaPackage.CurrentVersion)
+		{
+			diagnostics.Add(Error("unsupported-version",
+				$"Package version {package.Version:N0} is not supported; this server supports version {SpatialAreaPackage.CurrentVersion:N0}."));
+		}
+
+		if (package.Rooms is null || package.Cells is null || package.Exits is null || package.Zone is null ||
+		    package.Source is null)
+		{
+			diagnostics.Add(Error("missing-sections", "The package is missing one or more required sections."));
+			return diagnostics;
+		}
+
+		if (package.Rooms.Count is < 1 or > MaximumRooms)
+		{
+			diagnostics.Add(Error("invalid-room-count",
+				$"The package must contain between 1 and {MaximumRooms:N0} rooms."));
+		}
+
+		if (package.Cells.Count is < 1 or > MaximumCells)
+		{
+			diagnostics.Add(Error("invalid-cell-count",
+				$"The package must contain between 1 and {MaximumCells:N0} cells."));
+		}
+
+		if (package.Exits.Count > MaximumExits)
+		{
+			diagnostics.Add(Error("invalid-exit-count",
+				$"The package may contain at most {MaximumExits:N0} exits."));
+		}
+
+		if (package.Rooms.Cast<object?>().Any(x => x is null) ||
+		    package.Cells.Cast<object?>().Any(x => x is null) ||
+		    package.Exits.Cast<object?>().Any(x => x is null))
+		{
+			diagnostics.Add(Error("null-collection-entry",
+				"Room, cell, and exit collections may not contain null entries."));
+			return diagnostics;
+		}
+
+		ValidateUniqueKeys(package.Rooms.Select(x => x.Key), "room", diagnostics);
+		ValidateUniqueKeys(package.Cells.Select(x => x.Key), "cell", diagnostics);
+		ValidateUniqueKeys(package.Exits.Select(x => x.Key), "exit", diagnostics);
+
+		var roomKeys = package.Rooms.Select(x => x.Key).ToHashSet(StringComparer.Ordinal);
+		var cellKeys = package.Cells.Select(x => x.Key).ToHashSet(StringComparer.Ordinal);
+		var exitKeys = package.Exits.Select(x => x.Key).ToHashSet(StringComparer.Ordinal);
+		foreach (var room in package.Rooms.Where(room =>
+			         package.Cells.All(cell => !string.Equals(cell.RoomKey, room.Key, StringComparison.Ordinal))))
+		{
+			diagnostics.Add(Error("empty-room",
+				$"Room '{room.Key}' does not contain a packaged cell."));
+		}
+
+		foreach (var cell in package.Cells)
+		{
+			if (!roomKeys.Contains(cell.RoomKey))
+			{
+				diagnostics.Add(Error("orphan-cell",
+					$"Cell '{cell.Key}' references missing room '{cell.RoomKey}'."));
+			}
+
+			if (cell.Overlay is null)
+			{
+				diagnostics.Add(Error("missing-overlay", $"Cell '{cell.Key}' has no overlay."));
+				continue;
+			}
+
+			if (string.IsNullOrWhiteSpace(cell.Overlay.CellName) ||
+			    string.IsNullOrWhiteSpace(cell.Overlay.CellDescription))
+			{
+				diagnostics.Add(Error("invalid-overlay-text",
+					$"Cell '{cell.Key}' must have both a name and description."));
+			}
+
+			if (!double.IsFinite(cell.Overlay.AmbientLightFactor) ||
+			    !double.IsFinite(cell.Overlay.AddedLight))
+			{
+				diagnostics.Add(Error("invalid-overlay-light",
+					$"Cell '{cell.Key}' contains a non-finite light value."));
+			}
+
+			if (cell.Overlay.Terrain is null || string.IsNullOrWhiteSpace(cell.Overlay.Terrain.Name))
+			{
+				diagnostics.Add(Error("missing-terrain",
+					$"Cell '{cell.Key}' does not identify a terrain dependency."));
+			}
+
+			if (cell.Tags is null || cell.RangedCovers is null || cell.MagicResources is null ||
+			    cell.Overlay.ExitKeys is null)
+			{
+				diagnostics.Add(Error("missing-cell-collections",
+					$"Cell '{cell.Key}' is missing one or more required collection fields."));
+				continue;
+			}
+
+			if (cell.Tags.Cast<object?>().Any(x => x is null) ||
+			    cell.RangedCovers.Cast<object?>().Any(x => x is null) ||
+			    cell.MagicResources.Cast<object?>().Any(x => x is null) ||
+			    cell.MagicResources.Any(x => x.Resource is null))
+			{
+				diagnostics.Add(Error("null-cell-dependency",
+					$"Cell '{cell.Key}' contains a null dependency entry."));
+				continue;
+			}
+
+			if (cell.Tags.Any(x => string.IsNullOrWhiteSpace(x.Name)) ||
+			    cell.RangedCovers.Any(x => string.IsNullOrWhiteSpace(x.Name)) ||
+			    cell.MagicResources.Any(x => string.IsNullOrWhiteSpace(x.Resource.Name)) ||
+			    (cell.ForagableProfile is not null &&
+			     string.IsNullOrWhiteSpace(cell.ForagableProfile.Name)) ||
+			    (cell.Overlay.HearingProfile is not null &&
+			     string.IsNullOrWhiteSpace(cell.Overlay.HearingProfile.Name)) ||
+			    (cell.Overlay.Atmosphere is not null &&
+			     (string.IsNullOrWhiteSpace(cell.Overlay.Atmosphere.Name) ||
+			      string.IsNullOrWhiteSpace(cell.Overlay.Atmosphere.Kind))))
+			{
+				diagnostics.Add(Error("invalid-cell-dependency",
+					$"Cell '{cell.Key}' contains a dependency without a name or kind."));
+			}
+
+			if (cell.Overlay.ExitKeys.Count != cell.Overlay.ExitKeys.Distinct(StringComparer.Ordinal).Count())
+			{
+				diagnostics.Add(Error("duplicate-overlay-exit",
+					$"Cell '{cell.Key}' lists the same exit more than once."));
+			}
+
+			foreach (var exitKey in cell.Overlay.ExitKeys ?? [])
+			{
+				if (!exitKeys.Contains(exitKey))
+				{
+					diagnostics.Add(Error("orphan-overlay-exit",
+						$"Cell '{cell.Key}' references missing exit '{exitKey}'."));
+				}
+			}
+		}
+
+		foreach (var exit in package.Exits)
+		{
+			if (exit.Side1 is null || exit.Side2 is null || exit.BlockedLayers is null)
+			{
+				diagnostics.Add(Error("missing-exit-fields",
+					$"Exit '{exit.Key}' is missing one or more required fields."));
+				continue;
+			}
+
+			if (!cellKeys.Contains(exit.Cell1Key) || !cellKeys.Contains(exit.Cell2Key))
+			{
+				diagnostics.Add(Error("orphan-exit",
+					$"Exit '{exit.Key}' references a cell outside the package."));
+			}
+
+			if (string.Equals(exit.Cell1Key, exit.Cell2Key, StringComparison.Ordinal))
+			{
+				diagnostics.Add(Error("self-exit", $"Exit '{exit.Key}' connects a cell to itself."));
+			}
+
+			if (exit.TimeMultiplier <= 0.0 || !double.IsFinite(exit.TimeMultiplier))
+			{
+				diagnostics.Add(Error("invalid-time-multiplier",
+					$"Exit '{exit.Key}' has an invalid travel-time multiplier."));
+			}
+
+			if (exit.FallCellKey is not null && !cellKeys.Contains(exit.FallCellKey))
+			{
+				diagnostics.Add(Error("orphan-fall-cell",
+					$"Exit '{exit.Key}' references missing fall cell '{exit.FallCellKey}'."));
+			}
+
+			if (exit.FallCellKey is not null &&
+			    !string.Equals(exit.FallCellKey, exit.Cell1Key, StringComparison.Ordinal) &&
+			    !string.Equals(exit.FallCellKey, exit.Cell2Key, StringComparison.Ordinal))
+			{
+				diagnostics.Add(Error("invalid-fall-cell",
+					$"Exit '{exit.Key}' fall cell must be one of its two endpoints."));
+			}
+
+			var side1NonCardinal = !string.IsNullOrWhiteSpace(exit.Side1.Verb);
+			var side2NonCardinal = !string.IsNullOrWhiteSpace(exit.Side2.Verb);
+			if (side1NonCardinal != side2NonCardinal)
+			{
+				diagnostics.Add(Error("asymmetric-exit-kind",
+					$"Exit '{exit.Key}' must be cardinal on both sides or non-cardinal on both sides."));
+			}
+
+			if (side1NonCardinal &&
+			    (string.IsNullOrWhiteSpace(exit.Side1.PrimaryKeyword) ||
+			     string.IsNullOrWhiteSpace(exit.Side2.PrimaryKeyword) ||
+			     string.IsNullOrWhiteSpace(exit.Side1.OutboundTarget) ||
+			     string.IsNullOrWhiteSpace(exit.Side2.OutboundTarget)))
+			{
+				diagnostics.Add(Error("incomplete-non-cardinal-exit",
+					$"Non-cardinal exit '{exit.Key}' is missing verbs, keywords, or targets."));
+			}
+		}
+
+		var exitsByKey = package.Exits
+			.Where(x => !string.IsNullOrWhiteSpace(x.Key))
+			.GroupBy(x => x.Key, StringComparer.Ordinal)
+			.ToDictionary(x => x.Key, x => x.First(), StringComparer.Ordinal);
+		var exitReferences = new Dictionary<string, int>(StringComparer.Ordinal);
+		foreach (var cell in package.Cells.Where(x => x.Overlay?.ExitKeys is not null))
+		{
+			foreach (var exitKey in cell.Overlay.ExitKeys)
+			{
+				if (!exitsByKey.TryGetValue(exitKey, out var exit))
+				{
+					continue;
+				}
+
+				if (!string.Equals(cell.Key, exit.Cell1Key, StringComparison.Ordinal) &&
+				    !string.Equals(cell.Key, exit.Cell2Key, StringComparison.Ordinal))
+				{
+					diagnostics.Add(Error("invalid-overlay-exit-endpoint",
+						$"Cell '{cell.Key}' lists exit '{exitKey}' but is not one of its endpoints."));
+				}
+
+				exitReferences[exitKey] = exitReferences.GetValueOrDefault(exitKey) + 1;
+			}
+		}
+
+		foreach (var exit in package.Exits.Where(x => !exitReferences.ContainsKey(x.Key)))
+		{
+			diagnostics.Add(Error("unreferenced-exit",
+				$"Exit '{exit.Key}' is not active in any packaged cell overlay."));
+		}
+
+		if (!cellKeys.Contains(package.Zone.DefaultCellKey))
+		{
+			diagnostics.Add(Error("invalid-default-cell",
+				$"Zone default cell '{package.Zone.DefaultCellKey}' is not in the package."));
+		}
+
+		if (string.IsNullOrWhiteSpace(package.Zone.Name))
+		{
+			diagnostics.Add(Error("missing-zone-name", "The package zone must have a name."));
+		}
+
+		if (package.Zone.TimeZones is null)
+		{
+			diagnostics.Add(Error("missing-timezones", "The package zone is missing its timezone collection."));
+		}
+		else
+		{
+			if (package.Zone.TimeZones.Cast<object?>().Any(x => x is null))
+			{
+				diagnostics.Add(Error("null-timezone-reference",
+					"The package timezone collection may not contain null entries."));
+				return diagnostics;
+			}
+
+			var duplicateClock = package.Zone.TimeZones
+				.GroupBy(x => x.ClockAlias, StringComparer.InvariantCultureIgnoreCase)
+				.FirstOrDefault(x => x.Count() > 1);
+			if (duplicateClock is not null)
+			{
+				diagnostics.Add(Error("duplicate-clock-timezone",
+					$"The package contains more than one timezone for clock '{duplicateClock.Key}'."));
+			}
+
+			if (package.Zone.TimeZones.Any(x =>
+				    string.IsNullOrWhiteSpace(x.ClockAlias) ||
+				    string.IsNullOrWhiteSpace(x.TimeZoneAlias)))
+			{
+				diagnostics.Add(Error("invalid-timezone-reference",
+					"Every packaged timezone must identify both a clock alias and timezone alias."));
+			}
+		}
+
+		if ((package.Zone.ForagableProfile is not null &&
+		     string.IsNullOrWhiteSpace(package.Zone.ForagableProfile.Name)) ||
+		    (package.Zone.WeatherController is not null &&
+		     string.IsNullOrWhiteSpace(package.Zone.WeatherController.Name)))
+		{
+			diagnostics.Add(Error("invalid-zone-dependency",
+				"Zone dependency references must have non-empty names."));
+		}
+
+		return diagnostics;
+	}
+
+	private static void ValidateUniqueKeys(
+		IEnumerable<string> keys,
+		string kind,
+		ICollection<SpatialAreaTransferDiagnostic> diagnostics)
+	{
+		var seen = new HashSet<string>(StringComparer.Ordinal);
+		foreach (var key in keys)
+		{
+			if (string.IsNullOrWhiteSpace(key))
+			{
+				diagnostics.Add(Error($"empty-{kind}-key", $"A {kind} has an empty package key."));
+				continue;
+			}
+
+			if (!seen.Add(key))
+			{
+				diagnostics.Add(Error($"duplicate-{kind}-key",
+					$"The package contains duplicate {kind} key '{key}'."));
+			}
+		}
+	}
+
+	private static string ComputeHash(string text)
+	{
+		return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(text)));
+	}
+
+	private static SpatialAreaTransferDiagnostic Error(string code, string message)
+	{
+		return new SpatialAreaTransferDiagnostic(SpatialAreaTransferDiagnosticSeverity.Error, code, message);
+	}
+}

--- a/MudSharpCore/Construction/ImportExport/SpatialAreaTransferService.cs
+++ b/MudSharpCore/Construction/ImportExport/SpatialAreaTransferService.cs
@@ -1,0 +1,1232 @@
+#nullable enable
+
+using System.Data;
+using System.IO;
+using System.Text;
+using System.Xml.Linq;
+using Microsoft.EntityFrameworkCore;
+using MudSharp.Character;
+using MudSharp.Climate;
+using MudSharp.Combat;
+using MudSharp.Construction.Boundary;
+using MudSharp.Database;
+using MudSharp.Form.Audio;
+using MudSharp.Form.Material;
+using MudSharp.Framework;
+using MudSharp.Framework.Revision;
+using MudSharp.GameItems;
+using MudSharp.Magic;
+using MudSharp.Models;
+using MudSharp.RPG.Checks;
+using MudSharp.TimeAndDate.Time;
+using MudSharp.Work.Foraging;
+
+namespace MudSharp.Construction.ImportExport;
+
+public sealed class SpatialAreaTransferService : ISpatialAreaTransferService
+{
+	private sealed class ImportPreflight
+	{
+		public required SpatialAreaPackage Package { get; init; }
+		public required string PackagePath { get; init; }
+		public required string ZoneName { get; init; }
+		public required ICellOverlayPackage OverlayPackage { get; init; }
+		public required IReadOnlyDictionary<string, ITerrain> Terrains { get; init; }
+		public required IReadOnlyDictionary<string, IHearingProfile> HearingProfiles { get; init; }
+		public required IReadOnlyDictionary<string, IFluid> Fluids { get; init; }
+		public required IReadOnlyDictionary<string, IForagableProfile> ForagableProfiles { get; init; }
+		public required IReadOnlyDictionary<string, ITag> Tags { get; init; }
+		public required IReadOnlyDictionary<string, IRangedCover> RangedCovers { get; init; }
+		public required IReadOnlyDictionary<string, IMagicResource> MagicResources { get; init; }
+		public required IReadOnlyDictionary<string, (IClock Clock, IMudTimeZone TimeZone)> TimeZones { get; init; }
+		public IWeatherController? WeatherController { get; init; }
+		public List<SpatialAreaTransferDiagnostic> Diagnostics { get; } = [];
+	}
+
+	public static SpatialAreaTransferService Instance { get; } = new();
+
+	private SpatialAreaTransferService()
+	{
+	}
+
+	public string PackageDirectory => Path.Combine(Directory.GetCurrentDirectory(), "Spatial Packages");
+
+	public SpatialAreaTransferResult ExportZone(IZone zone, string packageFileName)
+	{
+		var diagnostics = new List<SpatialAreaTransferDiagnostic>();
+		if (!TryResolvePackagePath(PackageDirectory, packageFileName, out var packagePath, out var pathError))
+		{
+			return Failure(pathError, diagnostics, "invalid-package-name");
+		}
+
+		if (File.Exists(packagePath))
+		{
+			return Failure(
+				$"A package named '{Path.GetFileName(packagePath)}' already exists. Export never overwrites an existing package.",
+				diagnostics,
+				"package-exists");
+		}
+
+		var rooms = zone.Rooms
+			.OrderBy(x => x.Id)
+			.ToList();
+		var cells = rooms
+			.SelectMany(x => x.Cells)
+			.OrderBy(x => x.Id)
+			.ToList();
+		if (rooms.Count == 0 || cells.Count == 0)
+		{
+			return Failure("The selected zone does not contain any rooms and cells.", diagnostics, "empty-zone");
+		}
+
+		if (rooms.Count > SpatialAreaPackageSerializer.MaximumRooms ||
+		    cells.Count > SpatialAreaPackageSerializer.MaximumCells)
+		{
+			return Failure("The selected zone exceeds the package safety limits.", diagnostics, "zone-too-large");
+		}
+
+		var unsupported = ValidateExportableCells(cells);
+		diagnostics.AddRange(unsupported);
+		if (diagnostics.Any(x => x.Severity == SpatialAreaTransferDiagnosticSeverity.Error))
+		{
+			return new SpatialAreaTransferResult
+			{
+				Summary = "The zone was not exported because it contains unsupported spatial state.",
+				Diagnostics = diagnostics,
+				RoomCount = rooms.Count,
+				CellCount = cells.Count
+			};
+		}
+
+		var roomKeys = rooms
+			.Select((room, index) => (room.Id, Key: $"room-{index + 1:D5}"))
+			.ToDictionary(x => x.Id, x => x.Key);
+		var cellKeys = cells
+			.Select((cell, index) => (cell.Id, Key: $"cell-{index + 1:D5}"))
+			.ToDictionary(x => x.Id, x => x.Key);
+		var cellIds = cellKeys.Keys.ToHashSet();
+
+		var allSeenExits = cells
+			.SelectMany(cell => cell.Gameworld.ExitManager.GetExitsFor(cell, cell.CurrentOverlay))
+			.Select(x => x.Exit)
+			.DistinctBy(x => x.Id)
+			.OrderBy(x => x.Id)
+			.ToList();
+		var missingExitIds = cells
+			.SelectMany(x => x.CurrentOverlay.ExitIDs)
+			.Distinct()
+			.Except(allSeenExits.Select(x => x.Id))
+			.ToList();
+		foreach (var missingExitId in missingExitIds)
+		{
+			diagnostics.Add(Error("missing-source-exit",
+				$"An active overlay references exit #{missingExitId:N0}, but that exit could not be loaded from the source database."));
+		}
+
+		if (missingExitIds.Count > 0)
+		{
+			return new SpatialAreaTransferResult
+			{
+				Summary = "The zone was not exported because its active topology contains invalid exit references.",
+				Diagnostics = diagnostics,
+				RoomCount = rooms.Count,
+				CellCount = cells.Count
+			};
+		}
+
+		var internalExits = allSeenExits
+			.Where(x => x.Cells.All(cell => cellIds.Contains(cell.Id)))
+			.ToList();
+		var boundaryExits = allSeenExits
+			.Where(x => x.Cells.Any(cell => !cellIds.Contains(cell.Id)))
+			.ToList();
+
+		if (internalExits.Count > SpatialAreaPackageSerializer.MaximumExits)
+		{
+			return Failure("The selected zone exceeds the package exit safety limit.", diagnostics, "zone-too-large");
+		}
+
+		if (boundaryExits.Count > 0)
+		{
+			diagnostics.Add(Warning("boundary-exits-omitted",
+				$"{boundaryExits.Count:N0} exit(s) crossing the zone boundary were deliberately omitted. The imported zone will not be linked to unrelated target content."));
+		}
+
+		foreach (var exit in internalExits)
+		{
+			if (exit.Door is not null)
+			{
+				diagnostics.Add(Error("installed-door",
+					$"Exit #{exit.Id:N0} has an installed door item. Door items are not portable in package version 1."));
+			}
+
+			if (exit.FallCell is not null && !cellIds.Contains(exit.FallCell.Id))
+			{
+				diagnostics.Add(Error("external-fall-cell",
+					$"Exit #{exit.Id:N0} falls to cell #{exit.FallCell.Id:N0}, which is outside the package."));
+			}
+		}
+
+		if (diagnostics.Any(x => x.Severity == SpatialAreaTransferDiagnosticSeverity.Error))
+		{
+			return new SpatialAreaTransferResult
+			{
+				Summary = "The zone was not exported because one or more exits require unsupported dependencies.",
+				Diagnostics = diagnostics,
+				RoomCount = rooms.Count,
+				CellCount = cells.Count,
+				ExitCount = internalExits.Count
+			};
+		}
+
+		var exitKeys = internalExits
+			.Select((exit, index) => (exit.Id, Key: $"exit-{index + 1:D5}"))
+			.ToDictionary(x => x.Id, x => x.Key);
+
+		var package = BuildPackage(zone, rooms, cells, internalExits, roomKeys, cellKeys, exitKeys, diagnostics);
+		var json = SpatialAreaPackageSerializer.Serialize(package);
+		if (Encoding.UTF8.GetByteCount(json) > SpatialAreaPackageSerializer.MaximumPackageBytes)
+		{
+			return Failure("The serialized package exceeds the 16 MiB safety limit.", diagnostics, "package-too-large");
+		}
+
+		try
+		{
+			Directory.CreateDirectory(PackageDirectory);
+			using var stream = new FileStream(
+				packagePath,
+				FileMode.CreateNew,
+				FileAccess.Write,
+				FileShare.None);
+			using var writer = new StreamWriter(stream, new UTF8Encoding(false));
+			writer.Write(json);
+		}
+		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+		{
+			return Failure($"The package could not be written: {ex.Message}", diagnostics, "package-write-failed");
+		}
+
+		return new SpatialAreaTransferResult
+		{
+			Success = true,
+			Summary =
+				$"Exported zone '{zone.Name}' as package version {SpatialAreaPackage.CurrentVersion:N0}.",
+			PackagePath = packagePath,
+			Diagnostics = diagnostics,
+			RoomCount = rooms.Count,
+			CellCount = cells.Count,
+			ExitCount = internalExits.Count
+		};
+	}
+
+	public SpatialAreaTransferResult ValidateImport(
+		ICharacter actor,
+		IShard targetShard,
+		string packageFileName,
+		string? zoneNameOverride = null)
+	{
+		var preflight = PreflightImport(
+			actor,
+			targetShard,
+			packageFileName,
+			zoneNameOverride,
+			out var failure);
+		if (preflight is null)
+		{
+			return failure!;
+		}
+
+		return new SpatialAreaTransferResult
+		{
+			Success = true,
+			Summary =
+				$"Package validation succeeded. Import will create a new zone named '{preflight.ZoneName}' and will not modify existing rooms or zones.",
+			PackagePath = preflight.PackagePath,
+			Diagnostics = preflight.Diagnostics,
+			RoomCount = preflight.Package.Rooms.Count,
+			CellCount = preflight.Package.Cells.Count,
+			ExitCount = preflight.Package.Exits.Count
+		};
+	}
+
+	public SpatialAreaTransferResult ImportZone(
+		ICharacter actor,
+		IShard targetShard,
+		string packageFileName,
+		string? zoneNameOverride = null)
+	{
+		var preflight = PreflightImport(
+			actor,
+			targetShard,
+			packageFileName,
+			zoneNameOverride,
+			out var failure);
+		if (preflight is null)
+		{
+			return failure!;
+		}
+
+		var package = preflight.Package;
+		var gameworld = actor.Gameworld;
+		Models.Zone? dbZone = null;
+		var dbRooms = new Dictionary<string, Models.Room>(StringComparer.Ordinal);
+		var dbCells = new Dictionary<string, Models.Cell>(StringComparer.Ordinal);
+		var databaseCommitted = false;
+		try
+		{
+			using (new FMDB())
+			using (var transaction = FMDB.Context.Database.BeginTransaction(IsolationLevel.Serializable))
+			{
+				if (FMDB.Context.Zones.Any(x => x.Name == preflight.ZoneName))
+				{
+					return Failure(
+						$"A zone named '{preflight.ZoneName}' was created after validation. Nothing was imported.",
+						preflight.Diagnostics,
+						"zone-name-collision");
+				}
+
+				dbZone = new Models.Zone
+				{
+					Name = preflight.ZoneName,
+					ShardId = targetShard.Id,
+					Latitude = package.Zone.LatitudeRadians,
+					Longitude = package.Zone.LongitudeRadians,
+					Elevation = package.Zone.ElevationMetres,
+					AmbientLightPollution = package.Zone.AmbientLightPollution,
+					ForagableProfileId = package.Zone.ForagableProfile is null
+						? null
+						: preflight.ForagableProfiles[package.Zone.ForagableProfile.Name].Id,
+					WeatherControllerId = preflight.WeatherController?.Id
+				};
+				FMDB.Context.Zones.Add(dbZone);
+
+				foreach (var resolvedTimeZone in preflight.TimeZones.Values)
+				{
+					dbZone.ZonesTimezones.Add(new ZonesTimezones
+					{
+						Zone = dbZone,
+						ClockId = resolvedTimeZone.Clock.Id,
+						TimezoneId = resolvedTimeZone.TimeZone.Id
+					});
+				}
+
+				foreach (var room in package.Rooms)
+				{
+					var dbRoom = new Models.Room
+					{
+						Zone = dbZone,
+						X = room.X,
+						Y = room.Y,
+						Z = room.Z
+					};
+					dbRooms.Add(room.Key, dbRoom);
+					FMDB.Context.Rooms.Add(dbRoom);
+				}
+
+				FMDB.Context.SaveChanges();
+
+				foreach (var cell in package.Cells)
+				{
+					var dbCell = new Models.Cell
+					{
+						Room = dbRooms[cell.RoomKey],
+						Temporary = false,
+						EffectData = "<Effects/>",
+						ForagableProfileId = cell.ForagableProfile is null
+							? null
+							: preflight.ForagableProfiles[cell.ForagableProfile.Name].Id
+					};
+					dbCells.Add(cell.Key, dbCell);
+					FMDB.Context.Cells.Add(dbCell);
+				}
+
+				FMDB.Context.SaveChanges();
+
+				var dbOverlays = new Dictionary<string, Models.CellOverlay>(StringComparer.Ordinal);
+				foreach (var cell in package.Cells)
+				{
+					var overlay = cell.Overlay;
+					var dbOverlay = new Models.CellOverlay
+					{
+						Cell = dbCells[cell.Key],
+						Name = preflight.OverlayPackage.Name,
+						CellName = overlay.CellName,
+						CellDescription = overlay.CellDescription,
+						CellOverlayPackageId = preflight.OverlayPackage.Id,
+						CellOverlayPackageRevisionNumber = preflight.OverlayPackage.RevisionNumber,
+						TerrainId = preflight.Terrains[overlay.Terrain.Name].Id,
+						HearingProfileId = overlay.HearingProfile is null
+							? null
+							: preflight.HearingProfiles[overlay.HearingProfile.Name].Id,
+						OutdoorsType = overlay.OutdoorsType,
+						AmbientLightFactor = overlay.AmbientLightFactor,
+						AddedLight = overlay.AddedLight,
+						AtmosphereId = overlay.Atmosphere is null
+							? null
+							: preflight.Fluids[FluidKey(overlay.Atmosphere)].Id,
+						AtmosphereType = overlay.Atmosphere?.Kind,
+						SafeQuit = overlay.SafeQuit
+					};
+					dbCells[cell.Key].CellOverlays.Add(dbOverlay);
+					dbOverlays.Add(cell.Key, dbOverlay);
+					FMDB.Context.CellOverlays.Add(dbOverlay);
+				}
+
+				FMDB.Context.SaveChanges();
+
+				foreach (var cell in package.Cells)
+				{
+					dbCells[cell.Key].CurrentOverlay = dbOverlays[cell.Key];
+					foreach (var tag in cell.Tags)
+					{
+						dbCells[cell.Key].CellsTags.Add(new CellsTags
+						{
+							Cell = dbCells[cell.Key],
+							TagId = preflight.Tags[tag.Name].Id
+						});
+					}
+
+					foreach (var cover in cell.RangedCovers)
+					{
+						dbCells[cell.Key].CellsRangedCovers.Add(new CellsRangedCovers
+						{
+							Cell = dbCells[cell.Key],
+							RangedCoverId = preflight.RangedCovers[cover.Name].Id
+						});
+					}
+
+					foreach (var resource in cell.MagicResources)
+					{
+						dbCells[cell.Key].CellsMagicResources.Add(new CellMagicResource
+						{
+							Cell = dbCells[cell.Key],
+							MagicResourceId = preflight.MagicResources[resource.Resource.Name].Id,
+							Amount = resource.Amount
+						});
+					}
+				}
+
+				var dbExits = new Dictionary<string, Models.Exit>(StringComparer.Ordinal);
+				foreach (var exit in package.Exits)
+				{
+					var dbExit = new Models.Exit
+					{
+						CellId1 = dbCells[exit.Cell1Key].Id,
+						CellId2 = dbCells[exit.Cell2Key].Id,
+						Direction1 = exit.Side1.Direction,
+						Direction2 = exit.Side2.Direction,
+						TimeMultiplier = exit.TimeMultiplier,
+						AcceptsDoor = exit.AcceptsDoor,
+						DoorSize = exit.AcceptsDoor ? exit.DoorSize : null,
+						MaximumSizeToEnter = exit.MaximumSizeToEnter,
+						MaximumSizeToEnterUpright = exit.MaximumSizeToEnterUpright,
+						FallCell = exit.FallCellKey is null ? null : dbCells[exit.FallCellKey].Id,
+						IsClimbExit = exit.IsClimbExit,
+						ClimbDifficulty = exit.ClimbDifficulty,
+						BlockedLayers = string.Join(",", exit.BlockedLayers),
+						Keywords1 = exit.Side1.Keywords,
+						Keywords2 = exit.Side2.Keywords,
+						InboundDescription1 = exit.Side1.InboundDescription,
+						InboundDescription2 = exit.Side2.InboundDescription,
+						OutboundDescription1 = exit.Side1.OutboundDescription,
+						OutboundDescription2 = exit.Side2.OutboundDescription,
+						InboundTarget1 = exit.Side1.InboundTarget,
+						InboundTarget2 = exit.Side2.InboundTarget,
+						OutboundTarget1 = exit.Side1.OutboundTarget,
+						OutboundTarget2 = exit.Side2.OutboundTarget,
+						Verb1 = exit.Side1.Verb,
+						Verb2 = exit.Side2.Verb,
+						PrimaryKeyword1 = exit.Side1.PrimaryKeyword,
+						PrimaryKeyword2 = exit.Side2.PrimaryKeyword
+					};
+					dbExits.Add(exit.Key, dbExit);
+					FMDB.Context.Exits.Add(dbExit);
+				}
+
+				FMDB.Context.SaveChanges();
+
+				foreach (var cell in package.Cells)
+				{
+					foreach (var exitKey in cell.Overlay.ExitKeys)
+					{
+						dbOverlays[cell.Key].CellOverlaysExits.Add(new CellOverlayExit
+						{
+							CellOverlay = dbOverlays[cell.Key],
+							Exit = dbExits[exitKey]
+						});
+					}
+				}
+
+				dbZone.DefaultCell = dbCells[package.Zone.DefaultCellKey];
+				FMDB.Context.SaveChanges();
+				transaction.Commit();
+				databaseCommitted = true;
+			}
+
+			var newZone = new Zone(dbZone, gameworld);
+			gameworld.Add(newZone);
+			foreach (var roomDefinition in package.Rooms)
+			{
+				var newRoom = new Room(dbRooms[roomDefinition.Key], newZone);
+				gameworld.Add(newRoom);
+				foreach (var cellDefinition in package.Cells.Where(x => x.RoomKey == roomDefinition.Key))
+				{
+					var newCell = new Cell(dbCells[cellDefinition.Key], newRoom);
+					gameworld.Add(newCell);
+				}
+			}
+
+			newZone.PostLoadSetup();
+
+			return new SpatialAreaTransferResult
+			{
+				Success = true,
+				Summary =
+					$"Imported package as new zone '{preflight.ZoneName}' (#{newZone.Id:N0}). Existing spatial content was not modified.",
+				PackagePath = preflight.PackagePath,
+				ImportedZoneId = newZone.Id,
+				Diagnostics = preflight.Diagnostics,
+				RoomCount = package.Rooms.Count,
+				CellCount = package.Cells.Count,
+				ExitCount = package.Exits.Count
+			};
+		}
+		catch (Exception ex)
+		{
+			if (databaseCommitted && dbZone is not null)
+			{
+				var committedDiagnostics = preflight.Diagnostics.ToList();
+				committedDiagnostics.Add(Error("runtime-load-failed",
+					$"The database import committed as zone #{dbZone.Id:N0}, but the live server could not register it: {ex.Message}"));
+				return new SpatialAreaTransferResult
+				{
+					Summary =
+						$"The new zone was persisted as #{dbZone.Id:N0}, but is not fully available in memory. Restart the server before retrying or editing it; do not re-import the package.",
+					PackagePath = preflight.PackagePath,
+					ImportedZoneId = dbZone.Id,
+					Diagnostics = committedDiagnostics,
+					RoomCount = package.Rooms.Count,
+					CellCount = package.Cells.Count,
+					ExitCount = package.Exits.Count
+				};
+			}
+
+			return Failure(
+				$"Import failed before commit: {ex.Message}. The database transaction was rolled back.",
+				preflight.Diagnostics,
+				"import-failed");
+		}
+	}
+
+	private ImportPreflight? PreflightImport(
+		ICharacter actor,
+		IShard targetShard,
+		string packageFileName,
+		string? zoneNameOverride,
+		out SpatialAreaTransferResult? failure)
+	{
+		failure = null;
+		var diagnostics = new List<SpatialAreaTransferDiagnostic>();
+		if (actor.CurrentOverlayPackage is null ||
+		    actor.CurrentOverlayPackage.Status != RevisionStatus.UnderDesign)
+		{
+			failure = Failure(
+				"You must be editing an under-design cell overlay package before validating or importing a spatial package.",
+				diagnostics,
+				"overlay-package-required");
+			return null;
+		}
+
+		if (!TryResolvePackagePath(PackageDirectory, packageFileName, out var packagePath, out var pathError))
+		{
+			failure = Failure(pathError, diagnostics, "invalid-package-name");
+			return null;
+		}
+
+		if (!File.Exists(packagePath))
+		{
+			failure = Failure(
+				$"There is no spatial package named '{Path.GetFileName(packagePath)}' in '{PackageDirectory}'.",
+				diagnostics,
+				"package-not-found");
+			return null;
+		}
+
+		string json;
+		try
+		{
+			var fileInfo = new FileInfo(packagePath);
+			if (fileInfo.Length > SpatialAreaPackageSerializer.MaximumPackageBytes)
+			{
+				failure = Failure("The package exceeds the 16 MiB safety limit.", diagnostics,
+					"package-too-large");
+				return null;
+			}
+
+			json = File.ReadAllText(packagePath, Encoding.UTF8);
+		}
+		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+		{
+			failure = Failure($"The package could not be read: {ex.Message}", diagnostics,
+				"package-read-failed");
+			return null;
+		}
+
+		var readResult = SpatialAreaPackageSerializer.Deserialize(json);
+		diagnostics.AddRange(readResult.Diagnostics);
+		if (!readResult.Success || readResult.Package is null)
+		{
+			failure = new SpatialAreaTransferResult
+			{
+				Summary = "Package validation failed.",
+				PackagePath = packagePath,
+				Diagnostics = diagnostics
+			};
+			return null;
+		}
+
+		var package = readResult.Package;
+		var zoneName = string.IsNullOrWhiteSpace(zoneNameOverride)
+			? package.Zone.Name
+			: zoneNameOverride.Trim().TitleCase();
+		if (string.IsNullOrWhiteSpace(zoneName))
+		{
+			diagnostics.Add(Error("invalid-zone-name", "The imported zone must have a non-empty name."));
+		}
+
+		if (actor.Gameworld.Zones.Any(x => x.Name.Equals(zoneName, StringComparison.InvariantCultureIgnoreCase)))
+		{
+			diagnostics.Add(Error("zone-name-collision",
+				$"A zone named '{zoneName}' already exists. Imports never merge into or overwrite an existing zone."));
+		}
+
+		ValidateZoneNumbers(package.Zone, diagnostics);
+		ValidateEnums(package, diagnostics);
+
+		var terrains = ResolveReferences(
+			package.Cells.Select(x => x.Overlay.Terrain),
+			actor.Gameworld.Terrains,
+			"terrain",
+			diagnostics);
+		var hearingProfiles = ResolveReferences(
+			package.Cells
+				.Select(x => x.Overlay.HearingProfile)
+				.Where(x => x is not null)
+				.Select(x => x!),
+			actor.Gameworld.HearingProfiles,
+			"hearing-profile",
+			diagnostics);
+		var foragableProfiles = ResolveReferences(
+			package.Cells.Select(x => x.ForagableProfile)
+				.Append(package.Zone.ForagableProfile)
+				.Where(x => x is not null)
+				.Select(x => x!),
+			actor.Gameworld.ForagableProfiles,
+			"foragable-profile",
+			diagnostics);
+		var tags = ResolveReferences(
+			package.Cells.SelectMany(x => x.Tags),
+			actor.Gameworld.Tags,
+			"tag",
+			diagnostics);
+		var covers = ResolveReferences(
+			package.Cells.SelectMany(x => x.RangedCovers),
+			actor.Gameworld.RangedCovers,
+			"ranged-cover",
+			diagnostics);
+		var magicResources = ResolveReferences(
+			package.Cells.SelectMany(x => x.MagicResources).Select(x => x.Resource),
+			actor.Gameworld.MagicResources,
+			"magic-resource",
+			diagnostics);
+
+		var fluids = new Dictionary<string, IFluid>(StringComparer.InvariantCultureIgnoreCase);
+		foreach (var fluidReference in package.Cells
+			         .Select(x => x.Overlay.Atmosphere)
+			         .Where(x => x is not null)
+			         .Select(x => x!)
+			         .DistinctBy(FluidKey))
+		{
+			IFluid? fluid = fluidReference.Kind.ToLowerInvariant() switch
+			{
+				"liquid" => actor.Gameworld.Liquids.GetByName(fluidReference.Name),
+				"gas" => actor.Gameworld.Gases.GetByName(fluidReference.Name),
+				_ => null
+			};
+			if (fluid is null)
+			{
+				diagnostics.Add(Error("missing-fluid",
+					$"Required {fluidReference.Kind} atmosphere '{fluidReference.Name}' does not exist in the target installation."));
+				continue;
+			}
+
+			fluids[FluidKey(fluidReference)] = fluid;
+		}
+
+		IWeatherController? weatherController = null;
+		if (package.Zone.WeatherController is not null)
+		{
+			weatherController = actor.Gameworld.WeatherControllers
+				.FirstOrDefault(x => x.Name.Equals(
+					package.Zone.WeatherController.Name,
+					StringComparison.InvariantCultureIgnoreCase));
+			if (weatherController is null)
+			{
+				diagnostics.Add(Error("missing-weather-controller",
+					$"Required weather controller '{package.Zone.WeatherController.Name}' does not exist in the target installation."));
+			}
+		}
+
+		var timeZones = ResolveTimeZones(package.Zone, targetShard, diagnostics);
+		if (diagnostics.Any(x => x.Severity == SpatialAreaTransferDiagnosticSeverity.Error))
+		{
+			failure = new SpatialAreaTransferResult
+			{
+				Summary = "Package validation failed. Nothing was imported.",
+				PackagePath = packagePath,
+				Diagnostics = diagnostics,
+				RoomCount = package.Rooms.Count,
+				CellCount = package.Cells.Count,
+				ExitCount = package.Exits.Count
+			};
+			return null;
+		}
+
+		var preflight = new ImportPreflight
+		{
+			Package = package,
+			PackagePath = packagePath,
+			ZoneName = zoneName,
+			OverlayPackage = actor.CurrentOverlayPackage,
+			Terrains = terrains,
+			HearingProfiles = hearingProfiles,
+			Fluids = fluids,
+			ForagableProfiles = foragableProfiles,
+			Tags = tags,
+			RangedCovers = covers,
+			MagicResources = magicResources,
+			TimeZones = timeZones,
+			WeatherController = weatherController
+		};
+		preflight.Diagnostics.AddRange(diagnostics);
+		return preflight;
+	}
+
+	private static SpatialAreaPackage BuildPackage(
+		IZone zone,
+		IReadOnlyList<IRoom> rooms,
+		IReadOnlyList<ICell> cells,
+		IReadOnlyList<IExit> exits,
+		IReadOnlyDictionary<long, string> roomKeys,
+		IReadOnlyDictionary<long, string> cellKeys,
+		IReadOnlyDictionary<long, string> exitKeys,
+		ICollection<SpatialAreaTransferDiagnostic> diagnostics)
+	{
+		var overlayPackages = cells
+			.Select(x => x.CurrentOverlay.Package)
+			.Distinct()
+			.ToList();
+		if (overlayPackages.Count > 1)
+		{
+			diagnostics.Add(Warning("mixed-overlays",
+				$"The zone uses {overlayPackages.Count:N0} different active overlay packages. Version 1 exports each cell's active overlay data and imports all of it into the selected target package."));
+		}
+
+		var package = new SpatialAreaPackage
+		{
+			CreatedUtc = DateTime.UtcNow,
+			Source = new SpatialAreaPackageSource
+			{
+				ZoneName = zone.Name,
+				ZoneId = zone.Id,
+				ShardName = zone.Shard.Name,
+				ShardId = zone.Shard.Id,
+				OverlayPackageName = overlayPackages.Count == 1 ? overlayPackages[0].Name : "Mixed Active Overlays",
+				OverlayPackageId = overlayPackages.Count == 1 ? overlayPackages[0].Id : 0,
+				OverlayPackageRevision = overlayPackages.Count == 1 ? overlayPackages[0].RevisionNumber : 0
+			},
+			Zone = new SpatialZoneDefinition
+			{
+				Name = zone.Name,
+				LatitudeRadians = zone.Geography.Latitude,
+				LongitudeRadians = zone.Geography.Longitude,
+				ElevationMetres = zone.Geography.Elevation,
+				AmbientLightPollution = zone.AmbientLightPollution,
+				ForagableProfile = Reference(zone.ForagableProfile),
+				WeatherController = Reference(zone.WeatherController),
+				DefaultCellKey = cellKeys[zone.DefaultCell.Id],
+				TimeZones = zone.GetEditableZone.TimeZones
+					.OrderBy(x => x.Key.Alias)
+					.Select(x => new SpatialTimeZoneDefinition
+					{
+						ClockAlias = x.Key.Alias,
+						TimeZoneAlias = x.Value.Alias,
+						TimeZoneDescription = x.Value.Description
+					})
+					.ToList()
+			},
+			Rooms = rooms
+				.OrderByDescending(x => x.Id == zone.DefaultCell.Room.Id)
+				.ThenBy(x => x.Id)
+				.Select(x => new SpatialRoomDefinition
+				{
+					Key = roomKeys[x.Id],
+					SourceId = x.Id,
+					X = x.X,
+					Y = x.Y,
+					Z = x.Z
+				})
+				.ToList()
+		};
+
+		var explicitForagableProfiles = new Dictionary<long, long?>();
+		using (new FMDB())
+		{
+			foreach (var dbCell in FMDB.Context.Cells
+				         .Where(x => cellKeys.Keys.Contains(x.Id))
+				         .Select(x => new { x.Id, x.ForagableProfileId }))
+			{
+				explicitForagableProfiles[dbCell.Id] = dbCell.ForagableProfileId;
+			}
+		}
+
+		package.Cells = cells
+			.OrderByDescending(x => x.Id == zone.DefaultCell.Id)
+			.ThenBy(x => x.Id)
+			.Select(cell =>
+			{
+				var overlay = cell.CurrentOverlay;
+				var explicitForagable = explicitForagableProfiles.GetValueOrDefault(cell.Id);
+				return new SpatialCellDefinition
+				{
+					Key = cellKeys[cell.Id],
+					SourceId = cell.Id,
+					RoomKey = roomKeys[cell.Room.Id],
+					ForagableProfile = explicitForagable.HasValue
+						? Reference(cell.Gameworld.ForagableProfiles.Get(explicitForagable.Value))
+						: null,
+					Tags = cell.Tags.OrderBy(x => x.Name).Select(x => Reference(x)!).ToList(),
+					RangedCovers = cell.LocalCover.OrderBy(x => x.Name).Select(x => Reference(x)!).ToList(),
+					MagicResources = cell.MagicResourceAmounts
+						.OrderBy(x => x.Key.Name)
+						.Select(x => new SpatialMagicResourceDefinition
+						{
+							Resource = Reference(x.Key)!,
+							Amount = x.Value
+						})
+						.ToList(),
+					Overlay = new SpatialCellOverlayDefinition
+					{
+						CellName = overlay.CellName,
+						CellDescription = overlay.CellDescription,
+						Terrain = Reference(overlay.Terrain)!,
+						HearingProfile = Reference(overlay.HearingProfile),
+						Atmosphere = FluidReference(overlay.Atmosphere),
+						OutdoorsType = (int)overlay.OutdoorsType,
+						AmbientLightFactor = overlay.AmbientLightFactor,
+						AddedLight = overlay.AddedLight,
+						SafeQuit = overlay.SafeQuit,
+						ExitKeys = overlay.ExitIDs
+							.Where(exitKeys.ContainsKey)
+							.Select(x => exitKeys[x])
+							.Order()
+							.ToList()
+					}
+				};
+			})
+			.ToList();
+
+		package.Exits = exits
+			.Select(exit =>
+			{
+				var endpoints = exit.Cells.ToList();
+				var side1 = exit.CellExitFor(endpoints[0]);
+				var side2 = exit.CellExitFor(endpoints[1]);
+				return new SpatialExitDefinition
+				{
+					Key = exitKeys[exit.Id],
+					SourceId = exit.Id,
+					Cell1Key = cellKeys[endpoints[0].Id],
+					Cell2Key = cellKeys[endpoints[1].Id],
+					Side1 = BuildExitSide(side1),
+					Side2 = BuildExitSide(side2),
+					TimeMultiplier = exit.TimeMultiplier,
+					AcceptsDoor = exit.AcceptsDoor,
+					DoorSize = (int)exit.DoorSize,
+					MaximumSizeToEnter = (int)exit.MaximumSizeToEnter,
+					MaximumSizeToEnterUpright = (int)exit.MaximumSizeToEnterUpright,
+					IsClimbExit = exit.IsClimbExit,
+					ClimbDifficulty = (int)exit.ClimbDifficulty,
+					FallCellKey = exit.FallCell is null ? null : cellKeys[exit.FallCell.Id],
+					BlockedLayers = exit.BlockedLayers.Select(x => (int)x).Order().ToList()
+				};
+			})
+			.ToList();
+
+		return package;
+	}
+
+	private static SpatialExitSideDefinition BuildExitSide(ICellExit side)
+	{
+		if (side is not INonCardinalCellExit nonCardinal)
+		{
+			return new SpatialExitSideDefinition { Direction = (int)side.OutboundDirection };
+		}
+
+		return new SpatialExitSideDefinition
+		{
+			Direction = (int)side.OutboundDirection,
+			Verb = nonCardinal.Verb,
+			PrimaryKeyword = nonCardinal.PrimaryKeyword,
+			Keywords = string.Join(" ", nonCardinal.Keywords),
+			InboundDescription = nonCardinal.InboundDescription,
+			InboundTarget = nonCardinal.InboundTarget,
+			OutboundDescription = nonCardinal.OutboundDescription,
+			OutboundTarget = nonCardinal.OutboundTarget
+		};
+	}
+
+	private static IReadOnlyList<SpatialAreaTransferDiagnostic> ValidateExportableCells(
+		IReadOnlyCollection<ICell> cells)
+	{
+		var diagnostics = new List<SpatialAreaTransferDiagnostic>();
+		using (new FMDB())
+		{
+			var ids = cells.Select(x => x.Id).ToList();
+			var persistedCells = FMDB.Context.Cells
+				.Where(x => ids.Contains(x.Id))
+				.ToDictionary(x => x.Id);
+			foreach (var cell in cells)
+			{
+				if (cell.Temporary)
+				{
+					diagnostics.Add(Error("temporary-cell",
+						$"Cell #{cell.Id:N0} is temporary and cannot be faithfully imported."));
+				}
+
+				if (cell.RouteDefinition is not null)
+				{
+					diagnostics.Add(Error("route-cell",
+						$"Cell #{cell.Id:N0} is a route cell. Route geometry and anchors are planned for package version 2."));
+				}
+
+				if (cell is Cell concreteCell &&
+				    (concreteCell.HostedVehicleId.HasValue || concreteCell.HostedVehicleCompartmentId.HasValue))
+				{
+					diagnostics.Add(Error("hosted-vehicle-cell",
+						$"Cell #{cell.Id:N0} is a hosted vehicle interior and cannot be detached from its vehicle."));
+				}
+
+				if (cell.AgricultureField is not null)
+				{
+					diagnostics.Add(Error("agriculture-field",
+						$"Cell #{cell.Id:N0} has an agriculture field, which package version 1 does not carry."));
+				}
+
+				if (persistedCells.TryGetValue(cell.Id, out var dbCell))
+				{
+					if (HasPersistedEffects(dbCell.EffectData))
+					{
+						diagnostics.Add(Error("persisted-cell-effects",
+							$"Cell #{cell.Id:N0} has persisted effects. Version 1 refuses to discard effect state."));
+					}
+
+					if (HasSurfaceLiquid(dbCell.SurfaceLiquidData))
+					{
+						diagnostics.Add(Error("surface-liquid",
+							$"Cell #{cell.Id:N0} has persistent surface-liquid state, which version 1 does not carry."));
+					}
+				}
+			}
+		}
+
+		var areaCount = cells
+			.SelectMany(x => x.Areas)
+			.Distinct()
+			.Count();
+		if (areaCount > 0)
+		{
+			diagnostics.Add(Warning("area-membership-omitted",
+				$"Membership in {areaCount:N0} cross-cutting area group(s) is not imported by package version 1."));
+		}
+
+		var characterCount = cells.Sum(x => x.Characters.Count());
+		var itemCount = cells.Sum(x => x.GameItems.Count());
+		if (characterCount > 0 || itemCount > 0)
+		{
+			diagnostics.Add(Warning("contents-omitted",
+				$"The source contains {characterCount:N0} character(s) and {itemCount:N0} item(s). Spatial packages never move live contents."));
+		}
+
+		var hookCount = cells.Sum(x => x.Hooks.Count());
+		if (hookCount > 0)
+		{
+			diagnostics.Add(Warning("hooks-omitted",
+				$"{hookCount:N0} installed cell hook reference(s) are not spatial topology and are not included in package version 1."));
+		}
+
+		return diagnostics;
+	}
+
+	private static bool HasPersistedEffects(string? effectData)
+	{
+		if (string.IsNullOrWhiteSpace(effectData))
+		{
+			return false;
+		}
+
+		try
+		{
+			return XElement.Parse(effectData).Elements().Any();
+		}
+		catch
+		{
+			return true;
+		}
+	}
+
+	private static bool HasSurfaceLiquid(string? surfaceLiquidData)
+	{
+		if (string.IsNullOrWhiteSpace(surfaceLiquidData))
+		{
+			return false;
+		}
+
+		try
+		{
+			var element = XElement.Parse(surfaceLiquidData);
+			return element.HasElements || !string.IsNullOrWhiteSpace(element.Value);
+		}
+		catch
+		{
+			return true;
+		}
+	}
+
+	private static Dictionary<string, T> ResolveReferences<T>(
+		IEnumerable<SpatialNamedReference> references,
+		IEnumerable<T> candidates,
+		string kind,
+		ICollection<SpatialAreaTransferDiagnostic> diagnostics)
+		where T : class, IFrameworkItem
+	{
+		var result = new Dictionary<string, T>(StringComparer.InvariantCultureIgnoreCase);
+		foreach (var reference in references
+			         .Where(x => x is not null)
+			         .DistinctBy(x => x.Name, StringComparer.InvariantCultureIgnoreCase))
+		{
+			var item = candidates.FirstOrDefault(x =>
+				x.Name.Equals(reference.Name, StringComparison.InvariantCultureIgnoreCase));
+			if (item is null)
+			{
+				diagnostics.Add(Error($"missing-{kind}",
+					$"Required {kind} '{reference.Name}' does not exist in the target installation."));
+				continue;
+			}
+
+			result[reference.Name] = item;
+		}
+
+		return result;
+	}
+
+	private static Dictionary<string, (IClock Clock, IMudTimeZone TimeZone)> ResolveTimeZones(
+		SpatialZoneDefinition zone,
+		IShard targetShard,
+		ICollection<SpatialAreaTransferDiagnostic> diagnostics)
+	{
+		var result =
+			new Dictionary<string, (IClock Clock, IMudTimeZone TimeZone)>(
+				StringComparer.InvariantCultureIgnoreCase);
+		foreach (var sourceTimeZone in zone.TimeZones)
+		{
+			var clock = targetShard.Clocks.FirstOrDefault(x =>
+				x.Alias.Equals(sourceTimeZone.ClockAlias, StringComparison.InvariantCultureIgnoreCase));
+			if (clock is null)
+			{
+				diagnostics.Add(Error("missing-clock",
+					$"Target shard '{targetShard.Name}' does not have required clock alias '{sourceTimeZone.ClockAlias}'."));
+				continue;
+			}
+
+			var timeZone = clock.Timezones.FirstOrDefault(x =>
+				x.Alias.Equals(sourceTimeZone.TimeZoneAlias, StringComparison.InvariantCultureIgnoreCase) ||
+				x.Description.Equals(sourceTimeZone.TimeZoneDescription, StringComparison.InvariantCultureIgnoreCase));
+			if (timeZone is null)
+			{
+				diagnostics.Add(Error("missing-timezone",
+					$"Clock '{clock.Alias}' does not have required timezone '{sourceTimeZone.TimeZoneAlias}'."));
+				continue;
+			}
+
+			result[clock.Alias] = (clock, timeZone);
+		}
+
+		foreach (var clock in targetShard.Clocks.Where(x => !result.ContainsKey(x.Alias)))
+		{
+			result[clock.Alias] = (clock, clock.PrimaryTimezone);
+			diagnostics.Add(Warning("target-clock-defaulted",
+				$"Target-only clock '{clock.Alias}' will use its primary timezone."));
+		}
+
+		return result;
+	}
+
+	private static void ValidateZoneNumbers(
+		SpatialZoneDefinition zone,
+		ICollection<SpatialAreaTransferDiagnostic> diagnostics)
+	{
+		if (!double.IsFinite(zone.LatitudeRadians) ||
+		    zone.LatitudeRadians is < -Math.PI / 2.0 or > Math.PI / 2.0)
+		{
+			diagnostics.Add(Error("invalid-latitude", "Zone latitude is outside the valid range."));
+		}
+
+		if (!double.IsFinite(zone.LongitudeRadians) ||
+		    zone.LongitudeRadians is < -Math.PI or > Math.PI)
+		{
+			diagnostics.Add(Error("invalid-longitude", "Zone longitude is outside the valid range."));
+		}
+
+		if (!double.IsFinite(zone.ElevationMetres))
+		{
+			diagnostics.Add(Error("invalid-elevation", "Zone elevation is not finite."));
+		}
+
+		if (!double.IsFinite(zone.AmbientLightPollution) || zone.AmbientLightPollution < 0.0)
+		{
+			diagnostics.Add(Error("invalid-ambient-light", "Zone ambient light must be finite and non-negative."));
+		}
+	}
+
+	private static void ValidateEnums(
+		SpatialAreaPackage package,
+		ICollection<SpatialAreaTransferDiagnostic> diagnostics)
+	{
+		foreach (var cell in package.Cells)
+		{
+			if (!Enum.IsDefined((CellOutdoorsType)cell.Overlay.OutdoorsType))
+			{
+				diagnostics.Add(Error("invalid-outdoors-type",
+					$"Cell '{cell.Key}' has an unknown outdoors type."));
+			}
+
+			foreach (var resource in cell.MagicResources.Where(x =>
+				         !double.IsFinite(x.Amount) || x.Amount < 0.0))
+			{
+				diagnostics.Add(Error("invalid-magic-resource",
+					$"Cell '{cell.Key}' has an invalid amount for magic resource '{resource.Resource.Name}'."));
+			}
+		}
+
+		foreach (var exit in package.Exits)
+		{
+			if (!Enum.IsDefined((CardinalDirection)exit.Side1.Direction) ||
+			    !Enum.IsDefined((CardinalDirection)exit.Side2.Direction) ||
+			    (exit.AcceptsDoor && !Enum.IsDefined((SizeCategory)exit.DoorSize)) ||
+			    !Enum.IsDefined((SizeCategory)exit.MaximumSizeToEnter) ||
+			    !Enum.IsDefined((SizeCategory)exit.MaximumSizeToEnterUpright) ||
+			    !Enum.IsDefined((Difficulty)exit.ClimbDifficulty) ||
+			    exit.BlockedLayers.Any(x => !Enum.IsDefined((RoomLayer)x)))
+			{
+				diagnostics.Add(Error("invalid-exit-enum",
+					$"Exit '{exit.Key}' contains an enum value unknown to this server."));
+			}
+
+			var side1NonCardinal = !string.IsNullOrWhiteSpace(exit.Side1.Verb);
+			var side2NonCardinal = !string.IsNullOrWhiteSpace(exit.Side2.Verb);
+			if (side1NonCardinal != ((CardinalDirection)exit.Side1.Direction == CardinalDirection.Unknown) ||
+			    side2NonCardinal != ((CardinalDirection)exit.Side2.Direction == CardinalDirection.Unknown))
+			{
+				diagnostics.Add(Error("invalid-exit-kind",
+					$"Exit '{exit.Key}' has inconsistent cardinal direction and non-cardinal verb data."));
+			}
+		}
+	}
+
+	public static bool TryResolvePackagePath(
+		string packageDirectory,
+		string packageFileName,
+		out string packagePath,
+		out string error)
+	{
+		packagePath = string.Empty;
+		error = string.Empty;
+		var fileName = packageFileName.Trim();
+		if (string.IsNullOrWhiteSpace(fileName))
+		{
+			error = "You must specify a package file name.";
+			return false;
+		}
+
+		if (!fileName.EndsWith(".fmsa.json", StringComparison.InvariantCultureIgnoreCase))
+		{
+			fileName += ".fmsa.json";
+		}
+
+		if (!Path.GetFileName(fileName).Equals(fileName, StringComparison.Ordinal) ||
+		    fileName.Any(x => !(char.IsLetterOrDigit(x) || x is '-' or '_' or '.')))
+		{
+			error = "Package names may contain only letters, digits, periods, hyphens, and underscores, with no path.";
+			return false;
+		}
+
+		var root = Path.GetFullPath(packageDirectory)
+			.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+		var candidate = Path.GetFullPath(Path.Combine(root, fileName));
+		if (!candidate.StartsWith(root, StringComparison.OrdinalIgnoreCase))
+		{
+			error = "The package path must remain inside the server's Spatial Packages directory.";
+			return false;
+		}
+
+		packagePath = candidate;
+		return true;
+	}
+
+	private static string FluidKey(SpatialFluidReference reference)
+	{
+		return $"{reference.Kind}:{reference.Name}";
+	}
+
+	private static SpatialNamedReference? Reference(IFrameworkItem? item)
+	{
+		return item is null ? null : new SpatialNamedReference { SourceId = item.Id, Name = item.Name };
+	}
+
+	private static SpatialFluidReference? FluidReference(IFluid? fluid)
+	{
+		return fluid is null
+			? null
+			: new SpatialFluidReference
+			{
+				SourceId = fluid.Id,
+				Name = fluid.Name,
+				Kind = fluid is ILiquid ? "liquid" : "gas"
+			};
+	}
+
+	private static SpatialAreaTransferResult Failure(
+		string message,
+		IEnumerable<SpatialAreaTransferDiagnostic> diagnostics,
+		string code)
+	{
+		var allDiagnostics = diagnostics.ToList();
+		allDiagnostics.Add(Error(code, message));
+		return new SpatialAreaTransferResult
+		{
+			Summary = message,
+			Diagnostics = allDiagnostics
+		};
+	}
+
+	private static SpatialAreaTransferDiagnostic Error(string code, string message)
+	{
+		return new SpatialAreaTransferDiagnostic(SpatialAreaTransferDiagnosticSeverity.Error, code, message);
+	}
+
+	private static SpatialAreaTransferDiagnostic Warning(string code, string message)
+	{
+		return new SpatialAreaTransferDiagnostic(SpatialAreaTransferDiagnosticSeverity.Warning, code, message);
+	}
+}


### PR DESCRIPTION
## Summary

- Document the spatial area transfer package format, validation, remapping, and extension model
- Add builder guidance for exporting and importing zones between installations
- Link the new world design document from the design document index

## Testing

Not run (not requested)