### PR TITLE
Fix spatial package imports and add multi-zone transfers

### DIFF
--- a/Design Documents/Building/Room_Building_Builder_Guide.md
+++ b/Design Documents/Building/Room_Building_Builder_Guide.md
@@ -97,19 +97,20 @@ The `rooms` command can filter by zone and by keywords. Use `+keyword` to requir
 
 ### Moving a Zone Between Installations
 
-Senior administrators can export an ordinary zone to a versioned spatial-area package and import it into another FutureMUD installation:
+Senior administrators can export one or more zones to a versioned spatial-area package and import them into another FutureMUD installation:
 
 ```text
 spatialpackage export zone "Harbour Ward" harbour-ward
+spatialpackage export zones harbour-district "Harbour Ward" "Warehouse Quarter"
 spatialpackage validate harbour-ward "Prime Material" "Imported Harbour Ward"
 spatialpackage import harbour-ward "Prime Material" confirm "Imported Harbour Ward"
 ```
 
 Copy the generated `.fmsa.json` file from the source server's `Spatial Packages` directory into the same directory on the target server. On the target installation, open or create an `Under Design` cell overlay package before validation or import.
 
-An import always creates a new zone and assigns new IDs to its rooms, cells, overlays, and exits. It never merges into an existing zone or overwrites unrelated content. Validation checks package integrity, all internal references, the target shard's clocks and timezones, and named dependencies such as terrain, atmosphere, hearing profiles, weather controllers, forage profiles, tags, covers, and magic resources.
+An import always creates new zones and assigns new IDs to its rooms, cells, overlays, route metadata, and exits. It never merges into an existing zone or overwrites unrelated content. A name override is only available for a single-zone package. Validation checks package integrity, all internal references, the target shard's clocks and timezones, and named dependencies such as terrain, atmosphere, hearing profiles, weather controllers, forage profiles, tags, covers, and magic resources.
 
-Package version 1 handles ordinary zone topology and each cell's active overlay. It deliberately refuses cells whose faithful transfer requires data it does not yet carry: route-cell geometry, hosted vehicle interiors, temporary rooms, agriculture fields, persisted cell effects, surface-liquid state, installed door items, and fall exits that lead outside the zone. Links crossing the zone boundary, cross-cutting `AREA` membership, characters, and items are omitted with explicit diagnostics.
+Package version 2 preserves route-cell geometry, landmarks, exit anchors, multiple zones, and exits linking any selected zones. Links to unselected zones, cross-cutting `AREA` membership, hooks, characters, and items are omitted and shown as an enumerated list by export, validation, and import. Empty legacy room records without cells are likewise skipped and reported. The exporter deliberately refuses cells whose faithful transfer requires data it does not carry: hosted vehicle interiors, temporary rooms, agriculture fields, persisted cell effects, surface-liquid state, installed door items, and fall exits that lead outside the selection. Version 1 packages remain importable.
 
 See [Spatial Area Transfer Packages](../World/Spatial_Area_Transfer_Packages.md) for format, validation, remapping, and extension details.
 

--- a/Design Documents/World/Spatial_Area_Transfer_Packages.md
+++ b/Design Documents/World/Spatial_Area_Transfer_Packages.md
@@ -2,16 +2,17 @@
 
 ## Purpose
 
-Spatial area transfer packages let a senior administrator export a self-contained ordinary zone from a running FutureMUD installation and recreate it in another installation. The workflow is intentionally conservative:
+Spatial area transfer packages let a senior administrator export one or more self-contained zones from a running FutureMUD installation and recreate them in another installation. The workflow is intentionally conservative:
 
 - the package is human-readable, versioned JSON;
 - every imported database identity is newly allocated;
 - references inside the package use deterministic local keys rather than source database IDs;
 - installation-owned dependencies resolve by exact name during preflight;
-- imports create a new zone and never merge with or overwrite existing spatial content;
-- unsupported state blocks export when silently dropping it would make the result misleading.
+- imports create new zones and never merge with or overwrite existing spatial content;
+- unsupported state blocks export when silently dropping it would make the result misleading;
+- every deliberate omission is retained in the package and shown in-game.
 
-The version 1 file suffix is `.fmsa.json`. Files are read and written only beneath the server's `Spatial Packages` directory. Package names cannot contain a path.
+The file suffix is `.fmsa.json`. Files are read and written only beneath the server's `Spatial Packages` directory. Package names cannot contain a path. Versions 1 and 2 are accepted.
 
 ## Builder Workflow
 
@@ -21,9 +22,10 @@ On the source installation:
 
 ```text
 spatialpackage export zone "Harbour Ward" harbour-ward
+spatialpackage export zones harbour-district "Harbour Ward" "Warehouse Quarter"
 ```
 
-Copy `Spatial Packages/harbour-ward.fmsa.json` to the corresponding directory on the target installation.
+The multi-zone form takes the package name first, followed by one or more quoted zone names or IDs. It preserves exits between every selected zone. Copy the generated `.fmsa.json` file into the target installation's corresponding directory.
 
 On the target installation:
 
@@ -33,29 +35,29 @@ spatialpackage validate harbour-ward "Prime Material" "Imported Harbour Ward"
 spatialpackage import harbour-ward "Prime Material" confirm "Imported Harbour Ward"
 ```
 
-The target overlay package must be `Under Design`. The target shard must already exist because shards own installation-level clocks, calendars, celestial objects, and sky configuration. The optional final argument overrides the imported zone name.
+The target overlay package must be `Under Design`. The target shard must already exist because shards own installation-level clocks, calendars, celestial objects, and sky configuration. The optional final argument overrides the imported name only for a single-zone package; multi-zone packages retain every packaged name.
 
-`validate` is read-only. `import` repeats the complete preflight and also requires the literal `confirm` keyword. The import uses a serializable database transaction and rechecks zone-name uniqueness inside that transaction.
+`validate` is read-only. `import` repeats the complete preflight and also requires the literal `confirm` keyword. All selected zones and their cross-zone links use one serializable transaction, with every zone name rechecked inside the transaction.
 
-## Version 1 Payload
-
-The top-level object contains:
+## Version 2 Payload
 
 | Field | Purpose |
 | --- | --- |
 | `format` | Constant `futuremud-spatial-area`. |
-| `version` | Schema version. Version 1 is currently accepted. |
+| `version` | Schema version. Versions 1 and 2 are accepted. |
 | `integritySha256` | SHA-256 of the canonical payload with this field empty. |
 | `createdUtc` | Export timestamp. |
-| `source` | Diagnostic source IDs and names for the zone, shard, and active overlay package. Source IDs are never reused on import. |
-| `zone` | Zone name, geography, ambient light, weather/forage dependencies, default-cell key, and clock/timezone aliases. |
-| `rooms` | Deterministic room keys, source IDs for diagnostics, and integer coordinates. |
-| `cells` | Deterministic cell keys, parent-room keys, active overlay data, explicit forage override, tags, local covers, and magic-resource amounts. |
-| `exits` | Internal exit endpoints and both directional sides, door capability, size limits, climb/fall state, travel multiplier, and blocked layers. |
+| `source` / `sourceZones` | Diagnostic source IDs and names for each zone, shard, and active overlay package. The singular field preserves version-1 context. Source IDs are never reused. |
+| `zone` / `zones` | Zone-local keys, names, geography, ambient light, weather/forage dependencies, default cells, and clock/timezone aliases. |
+| `rooms` | Deterministic room keys, diagnostic source IDs, owning zone keys, and integer coordinates. |
+| `cells` | Deterministic cell keys, parent rooms, active overlay data, route-cell data, explicit forage override, tags, local covers, and magic-resource amounts. |
+| `exits` | Every exit whose endpoints are both selected, including cross-zone links, with directional sides, door capability, size limits, climb/fall state, travel multiplier, and blocked layers. |
+| `omissions` | Structured codes and exact builder-facing descriptions of content deliberately excluded. |
 
 Each export assigns keys in stable source-ID order:
 
 ```text
+zone-00001
 room-00001
 cell-00001
 exit-00001
@@ -63,9 +65,11 @@ exit-00001
 
 References within the package use only these keys. Source database IDs remain diagnostic provenance and have no import semantics.
 
-## Overlay Behaviour
+Version 1 remains checksum-compatible and is upgraded logically while reading. A version-1 room record with no packaged cell is treated as stale source metadata: validation warns with `empty-room-skipped`, and import does not create it. Version-2 exports omit such a record and include a corresponding omission.
 
-Version 1 exports the currently active overlay for every cell, including:
+## Overlay and Route-Cell Behaviour
+
+The currently active overlay is exported for every cell, including:
 
 - cell name and description;
 - terrain;
@@ -74,9 +78,11 @@ Version 1 exports the currently active overlay for every cell, including:
 - atmosphere kind and name;
 - ambient and added light;
 - safe-quit state;
-- the exact internal exits active in that overlay.
+- the exact packaged exits active in that overlay.
 
-A zone may have cells whose active overlays came from different source overlay packages. Their active data is still exported independently. On import, all cells receive a new overlay in the builder's selected target package. Other historical or inactive source overlay revisions are not transferred.
+Cells may use active overlays from different source packages. Their active data is exported independently and imported into the builder's selected target package. Historical and inactive overlay revisions are not transferred.
+
+Version 2 also transfers route length, default coordinate, direction names, room-equivalent length, topology version, landmarks, and anchors for every packaged exit. An anchor for an omitted boundary exit is omitted together with that exit.
 
 ## Dependency Resolution
 
@@ -91,9 +97,7 @@ The target installation supplies engine-owned dependencies. Preflight resolves t
 - local ranged covers;
 - magic resources.
 
-Clock dependencies resolve by clock alias. A timezone resolves by alias or description on that clock. A source clock absent from the target shard is an error. A clock that exists only on the target shard is assigned its primary timezone with a warning.
-
-Dependency source IDs are never used as a fallback. This prevents a coincidentally reused ID from linking the imported zone to the wrong target object.
+Clock dependencies resolve by clock alias. A timezone resolves by alias or description on that clock. A source clock absent from the target shard is an error. A clock that exists only on the target shard receives its primary timezone with a warning. Dependency source IDs are never a fallback, preventing a coincidentally reused ID from linking to the wrong target object.
 
 ## Integrity and Validation
 
@@ -101,52 +105,51 @@ Validation occurs before any database write and checks:
 
 - file containment and the 16 MiB size limit;
 - strict JSON with unknown fields rejected;
-- package format, version, and SHA-256 integrity;
-- room, cell, and exit count limits;
+- package format, supported version, and SHA-256 integrity;
+- zone, room, cell, and exit count limits;
 - unique local keys;
-- room/cell/exit reference closure;
+- room-to-zone and cell/exit reference closure;
 - overlay-to-exit endpoint consistency;
-- valid default and fall cells;
+- valid per-zone default and fall cells;
+- valid route geometry, landmarks, and exit anchors;
 - finite geographic, light, resource, and travel values;
 - enum values known to the receiving engine;
 - cardinal versus non-cardinal exit-side consistency;
 - exact availability of every target dependency;
-- target zone-name uniqueness;
+- target name uniqueness for every packaged zone;
 - an open `Under Design` target overlay package.
 
-The importer allocates rows in dependency order: zone and rooms, cells, overlays, exits, overlay-exit links, then the zone default cell. All IDs are database-generated. Existing zones, rooms, cells, overlays, and exits are untouched.
+The importer allocates rows in dependency order: zones and non-empty rooms, cells, overlays and route geometry, exits, route anchors and overlay-exit links, then each zone's default cell. All IDs are database-generated. Existing spatial content is untouched.
 
-## Deliberate Version 1 Boundaries
+## Deliberate Boundaries and Diagnostics
 
-Export fails when a zone contains state that cannot yet be represented faithfully:
+Export fails when selected content contains state that cannot be represented faithfully:
 
-- route cells, including length, landmarks, and exit anchors;
-- room-scale hosted vehicle interiors;
+- hosted vehicle interiors;
 - temporary cells;
 - agriculture fields;
 - persisted cell effects;
 - persistent surface-liquid state;
 - installed door items;
-- fall exits whose destination is outside the exported zone.
+- fall exits whose destination is outside the selected zones.
 
-The following data is not spatial content and is omitted with diagnostics:
+The following content is omitted because it is not self-contained spatial topology:
 
 - characters and game items;
-- exits crossing the exported zone boundary;
-- membership in cross-cutting `AREA` groups.
-- cell event hooks, which are behavioural installation content rather than spatial topology.
+- exits whose other endpoint is in an unselected zone;
+- membership in cross-cutting `AREA` groups;
+- cell event hooks.
 
 Exit door capability and permitted door size are transferred, but an installed physical door item is not.
 
+Export, validation, and import enumerate omissions in the in-game result. A boundary-exit entry identifies the direction or verb, both source cell IDs and names, and the unselected destination zone. This lets builders distinguish expected boundary loss from unexpectedly incomplete selections.
+
 ## Planned Extensions
 
-A later schema version can add these independently without weakening version 1 validation:
-
-1. Route-cell definitions, landmarks, and per-exit anchors.
-2. Cross-zone `AREA` packages containing multiple zone fragments and area weather.
-3. Optional boundary-link manifests that a builder can explicitly reconnect after import.
-4. Installed door and selected static item packaging with their complete item-prototype dependency graphs.
-5. Agriculture, surface-liquid, ranged-cover state beyond local profile references, and selected portable effects.
-6. Additional overlay revisions and review history.
+1. Portable cross-cutting `AREA` definitions and area weather.
+2. Optional boundary-link manifests that a builder can explicitly reconnect after import.
+3. Installed door and selected static item packaging with their complete item-prototype dependency graphs.
+4. Agriculture, surface-liquid, ranged-cover state beyond local profile references, and selected portable effects.
+5. Additional overlay revisions and review history.
 
 Older servers must reject later schema versions until they explicitly implement them.

--- a/FutureMUDLibrary/Construction/ImportExport/ISpatialAreaTransferService.cs
+++ b/FutureMUDLibrary/Construction/ImportExport/ISpatialAreaTransferService.cs
@@ -23,9 +23,12 @@ public sealed class SpatialAreaTransferResult
 	public string Summary { get; init; } = string.Empty;
 	public string? PackagePath { get; init; }
 	public long? ImportedZoneId { get; init; }
+	public IReadOnlyList<long> ImportedZoneIds { get; init; } = [];
+	public int ZoneCount { get; init; }
 	public int RoomCount { get; init; }
 	public int CellCount { get; init; }
 	public int ExitCount { get; init; }
+	public IReadOnlyList<string> OmittedItems { get; init; } = [];
 	public IReadOnlyList<SpatialAreaTransferDiagnostic> Diagnostics { get; init; } =
 		[];
 }
@@ -38,6 +41,10 @@ public interface ISpatialAreaTransferService
 	string PackageDirectory { get; }
 
 	SpatialAreaTransferResult ExportZone(IZone zone, string packageFileName);
+
+	SpatialAreaTransferResult ExportZones(
+		IReadOnlyCollection<IZone> zones,
+		string packageFileName);
 
 	SpatialAreaTransferResult ValidateImport(
 		ICharacter actor,

--- a/MudSharpCore Unit Tests/Construction/ImportExport/SpatialAreaPackageSerializerTests.cs
+++ b/MudSharpCore Unit Tests/Construction/ImportExport/SpatialAreaPackageSerializerTests.cs
@@ -94,10 +94,125 @@ public class SpatialAreaPackageSerializerTests
 		Assert.IsTrue(path.StartsWith(Path.GetFullPath(root), StringComparison.OrdinalIgnoreCase));
 	}
 
+	[TestMethod]
+	public void Deserialize_Version1PackageWithEmptyRoom_WarnsAndRemainsImportable()
+	{
+		var package = CreateValidPackage();
+		package.Rooms.Add(new SpatialRoomDefinition
+		{
+			Key = "room-00003",
+			SourceId = 102,
+			X = 9
+		});
+
+		var json = SpatialAreaPackageSerializer.Serialize(package);
+		var result = SpatialAreaPackageSerializer.Deserialize(json);
+
+		Assert.IsTrue(result.Success);
+		Assert.IsNotNull(result.Package);
+		Assert.IsFalse(json.Contains("\"Zones\"", StringComparison.Ordinal));
+		Assert.IsTrue(result.Diagnostics.Any(x => x.Code == "empty-room-skipped"));
+	}
+
+	[TestMethod]
+	public void Validate_Version2MultiZonePackage_PreservesCrossZoneExit()
+	{
+		var package = CreateValidVersion2Package();
+		var secondZone = new SpatialZoneDefinition
+		{
+			Key = "zone-00002",
+			SourceId = 11,
+			Name = "Second Zone",
+			DefaultCellKey = "cell-00002",
+			TimeZones = package.Zone.TimeZones
+				.Select(x => new SpatialTimeZoneDefinition
+				{
+					ClockAlias = x.ClockAlias,
+					TimeZoneAlias = x.TimeZoneAlias,
+					TimeZoneDescription = x.TimeZoneDescription
+				})
+				.ToList()
+		};
+		package.Zones.Add(secondZone);
+		package.SourceZones.Add(new SpatialAreaPackageSource
+		{
+			ZoneName = secondZone.Name,
+			ZoneId = secondZone.SourceId,
+			ShardName = package.Source.ShardName,
+			ShardId = package.Source.ShardId,
+			OverlayPackageName = package.Source.OverlayPackageName,
+			OverlayPackageId = package.Source.OverlayPackageId,
+			OverlayPackageRevision = package.Source.OverlayPackageRevision
+		});
+		package.Rooms[1].ZoneKey = secondZone.Key;
+		package.Omissions.Add(new SpatialPackageOmission
+		{
+			Code = "boundary-exit",
+			Message = "A boundary exit was deliberately omitted."
+		});
+
+		var json = SpatialAreaPackageSerializer.Serialize(package);
+		var result = SpatialAreaPackageSerializer.Deserialize(json);
+
+		Assert.IsTrue(result.Success,
+			string.Join(Environment.NewLine, result.Diagnostics.Select(x => $"{x.Code}: {x.Message}")));
+		Assert.IsNotNull(result.Package);
+		Assert.AreEqual(2, result.Package.Zones.Count);
+		Assert.AreEqual("boundary-exit", result.Package.Omissions.Single().Code);
+		Assert.AreEqual("cell-00001", result.Package.Exits[0].Cell1Key);
+		Assert.AreEqual("cell-00002", result.Package.Exits[0].Cell2Key);
+	}
+
+	[TestMethod]
+	public void SerializeDeserialize_Version2RouteCell_RoundTripsGeometryAndAnchor()
+	{
+		var package = CreateValidVersion2Package();
+		package.Cells[0].RouteCell = new SpatialRouteCellDefinition
+		{
+			LengthMetres = 500.0,
+			DefaultPositionMetres = 125.0,
+			PositiveDirectionName = "eastbound",
+			NegativeDirectionName = "westbound",
+			MetresPerRoomEquivalent = 100.0,
+			TopologyVersion = 3,
+			Landmarks =
+			[
+				new SpatialRouteLandmarkDefinition
+				{
+					SourceId = 400,
+					Name = "Old Oak",
+					Keywords = "oak tree",
+					Description = "An old oak stands beside the road.",
+					PositionMetres = 200.0
+				}
+			],
+			ExitAnchors =
+			[
+				new SpatialRouteExitAnchorDefinition
+				{
+					ExitKey = "exit-00001",
+					MinimumPositionMetres = 100.0,
+					MaximumPositionMetres = 150.0,
+					ArrivalPositionMetres = 125.0
+				}
+			]
+		};
+
+		var json = SpatialAreaPackageSerializer.Serialize(package);
+		var result = SpatialAreaPackageSerializer.Deserialize(json);
+
+		Assert.IsTrue(result.Success,
+			string.Join(Environment.NewLine, result.Diagnostics.Select(x => $"{x.Code}: {x.Message}")));
+		Assert.IsNotNull(result.Package);
+		Assert.AreEqual(500.0, result.Package.Cells[0].RouteCell?.LengthMetres);
+		Assert.AreEqual("exit-00001", result.Package.Cells[0].RouteCell?.ExitAnchors.Single().ExitKey);
+	}
+
 	private static SpatialAreaPackage CreateValidPackage()
 	{
 		return new SpatialAreaPackage
 		{
+			Version = 1,
 			CreatedUtc = new DateTime(2026, 7, 24, 0, 0, 0, DateTimeKind.Utc),
 			Source = new SpatialAreaPackageSource
 			{
@@ -184,5 +299,21 @@ public class SpatialAreaPackageSerializerTests
 				}
 			]
 		};
+	}
+
+	private static SpatialAreaPackage CreateValidVersion2Package()
+	{
+		var package = CreateValidPackage();
+		package.Version = 2;
+		package.Zone.Key = "zone-00001";
+		package.Zone.SourceId = package.Source.ZoneId;
+		package.Zones = [package.Zone];
+		package.SourceZones = [package.Source];
+		foreach (var room in package.Rooms)
+		{
+			room.ZoneKey = package.Zone.Key;
+		}
+
+		return package;
 	}
 }

--- a/MudSharpCore/Commands/Modules/RoomBuilderModule.SpatialPackages.cs
+++ b/MudSharpCore/Commands/Modules/RoomBuilderModule.SpatialPackages.cs
@@ -14,15 +14,16 @@ internal partial class RoomBuilderModule
 	private const string SpatialPackageHelpText =
 		@"The #3SPATIALPACKAGE#0 command exports and imports portable, versioned spatial-area packages.
 
-Version 1 transfers a complete ordinary zone: room coordinates, cells, active overlays, internal exits, zone geography and environment, tags, local covers, and magic-resource state. Imports always create a new zone and remap all room, cell, overlay and exit IDs. They never merge into or overwrite existing spatial content.
+Version 2 transfers one or more zones: room coordinates, cells, active overlays, route-cell geometry, internal and selected cross-zone exits, zone geography and environment, tags, local covers, and magic-resource state. Imports always create new zones and remap all room, cell, overlay, route and exit IDs. They never merge into or overwrite existing spatial content. Version 1 packages remain importable.
 
 Files are read and written only inside the server's #6Spatial Packages#0 directory.
 
 	#3spatialpackage export zone <zone> <file>#0 - exports a zone; the .fmsa.json suffix is optional
+	#3spatialpackage export zones <file> <zone> [zone...]#0 - exports multiple zones and links between them
 	#3spatialpackage validate <file> <target shard> [new zone name]#0 - preflights integrity and dependencies
-	#3spatialpackage import <file> <target shard> confirm [new zone name]#0 - creates the validated zone
+	#3spatialpackage import <file> <target shard> confirm [new zone name]#0 - creates the validated zone(s)
 
-You must be editing an under-design #3CELL PACKAGE#0 to validate or import. Quote multi-word zone, shard and file arguments where required. Version 1 refuses route cells, hosted vehicle interiors, temporary cells, agriculture fields, persisted cell effects, surface liquids, installed door items, and external fall destinations rather than silently losing those dependencies.";
+You must be editing an under-design #3CELL PACKAGE#0 to validate or import. A new-name override is only valid for a single-zone package. Quote multi-word zone, shard and file arguments where required. Spatial packages refuse hosted vehicle interiors, temporary cells, agriculture fields, persisted cell effects, surface liquids, installed door items, and external fall destinations rather than silently losing those dependencies. Every deliberate omission is listed by export, validation and import.";
 
 	[PlayerCommand("SpatialPackage", "spatialpackage")]
 	[CommandPermission(PermissionLevel.SeniorAdmin)]
@@ -50,10 +51,17 @@ You must be editing an under-design #3CELL PACKAGE#0 to validate or import. Quot
 
 	private static void SpatialPackageExport(ICharacter actor, StringStack command)
 	{
-		if (!command.PopForSwitch().EqualTo("zone"))
+		var mode = command.PopForSwitch();
+		if (mode.EqualTo("zones"))
+		{
+			SpatialPackageExportZones(actor, command);
+			return;
+		}
+
+		if (!mode.EqualTo("zone"))
 		{
 			actor.OutputHandler.Send(
-				$"Version 1 exports whole zones. Use {"spatialpackage export zone <zone> <file>".ColourCommand()}.");
+				$"Use {"spatialpackage export zone <zone> <file>".ColourCommand()} or {"spatialpackage export zones <file> <zone> [zone...]".ColourCommand()}.");
 			return;
 		}
 
@@ -85,6 +93,45 @@ You must be editing an under-design #3CELL PACKAGE#0 to validate or import. Quot
 		}
 
 		var result = SpatialAreaTransferService.Instance.ExportZone(zone, fileName);
+		SendSpatialPackageResult(actor, result);
+	}
+
+	private static void SpatialPackageExportZones(ICharacter actor, StringStack command)
+	{
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("What file name should be used for the package?");
+			return;
+		}
+
+		var fileName = command.PopSpeech();
+		if (command.IsFinished)
+		{
+			actor.OutputHandler.Send("Which zones do you want to export?");
+			return;
+		}
+
+		var zones = new List<IZone>();
+		while (!command.IsFinished)
+		{
+			var zoneText = command.PopSpeech();
+			var zone = actor.Gameworld.Zones.GetByIdOrName(zoneText, false);
+			if (zone is null)
+			{
+				actor.OutputHandler.Send($"There is no zone identified by {zoneText.ColourCommand()}.");
+				return;
+			}
+
+			if (zones.Any(x => x.Id == zone.Id))
+			{
+				actor.OutputHandler.Send($"Zone {zone.Name.ColourName()} was specified more than once.");
+				return;
+			}
+
+			zones.Add(zone);
+		}
+
+		var result = SpatialAreaTransferService.Instance.ExportZones(zones, fileName);
 		SendSpatialPackageResult(actor, result);
 	}
 
@@ -168,13 +215,13 @@ You must be editing an under-design #3CELL PACKAGE#0 to validate or import. Quot
 			text.AppendLine($"Package: {result.PackagePath.ColourCommand()}");
 		}
 
-		if (result.RoomCount > 0 || result.CellCount > 0 || result.ExitCount > 0)
+		if (result.ZoneCount > 0 || result.RoomCount > 0 || result.CellCount > 0 || result.ExitCount > 0)
 		{
 			text.AppendLine(
-				$"Contents: {result.RoomCount.ToString("N0", actor).ColourValue()} room(s), {result.CellCount.ToString("N0", actor).ColourValue()} cell(s), {result.ExitCount.ToString("N0", actor).ColourValue()} internal exit(s)");
+				$"Contents: {result.ZoneCount.ToString("N0", actor).ColourValue()} zone(s), {result.RoomCount.ToString("N0", actor).ColourValue()} room(s), {result.CellCount.ToString("N0", actor).ColourValue()} cell(s), {result.ExitCount.ToString("N0", actor).ColourValue()} packaged exit(s)");
 		}
 
-		foreach (var diagnostic in result.Diagnostics)
+		foreach (var diagnostic in result.Diagnostics.Where(x => x.Code != "empty-room-skipped"))
 		{
 			var line = $"[{diagnostic.Code}] {diagnostic.Message}";
 			text.AppendLine(diagnostic.Severity switch
@@ -183,6 +230,16 @@ You must be editing an under-design #3CELL PACKAGE#0 to validate or import. Quot
 				SpatialAreaTransferDiagnosticSeverity.Warning => line.Colour(Telnet.Yellow),
 				_ => line
 			});
+		}
+
+		if (result.OmittedItems.Count > 0)
+		{
+			text.AppendLine();
+			text.AppendLine("The following items were not included and will not be imported:".Colour(Telnet.Yellow));
+			foreach (var (item, index) in result.OmittedItems.Select((value, index) => (value, index)))
+			{
+				text.AppendLine($"{(index + 1).ToString("N0", actor)}) {item}");
+			}
 		}
 
 		actor.OutputHandler.Send(text.ToString());

--- a/MudSharpCore/Construction/ImportExport/SpatialAreaPackageModels.cs
+++ b/MudSharpCore/Construction/ImportExport/SpatialAreaPackageModels.cs
@@ -1,11 +1,14 @@
 #nullable enable
 
+using System.Text.Json.Serialization;
+
 namespace MudSharp.Construction.ImportExport;
 
 public sealed class SpatialAreaPackage
 {
 	public const string CurrentFormat = "futuremud-spatial-area";
-	public const int CurrentVersion = 1;
+	public const int MinimumSupportedVersion = 1;
+	public const int CurrentVersion = 2;
 
 	public string Format { get; set; } = CurrentFormat;
 	public int Version { get; set; } = CurrentVersion;
@@ -13,9 +16,12 @@ public sealed class SpatialAreaPackage
 	public DateTime CreatedUtc { get; set; }
 	public SpatialAreaPackageSource Source { get; set; } = new();
 	public SpatialZoneDefinition Zone { get; set; } = new();
+	public List<SpatialAreaPackageSource> SourceZones { get; set; } = [];
+	public List<SpatialZoneDefinition> Zones { get; set; } = [];
 	public List<SpatialRoomDefinition> Rooms { get; set; } = [];
 	public List<SpatialCellDefinition> Cells { get; set; } = [];
 	public List<SpatialExitDefinition> Exits { get; set; } = [];
+	public List<SpatialPackageOmission> Omissions { get; set; } = [];
 }
 
 public sealed class SpatialAreaPackageSource
@@ -31,6 +37,12 @@ public sealed class SpatialAreaPackageSource
 
 public sealed class SpatialZoneDefinition
 {
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+	public string? Key { get; set; }
+
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+	public long SourceId { get; set; }
+
 	public string Name { get; set; } = string.Empty;
 	public double LatitudeRadians { get; set; }
 	public double LongitudeRadians { get; set; }
@@ -53,6 +65,8 @@ public sealed class SpatialRoomDefinition
 {
 	public string Key { get; set; } = string.Empty;
 	public long SourceId { get; set; }
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+	public string? ZoneKey { get; set; }
 	public int X { get; set; }
 	public int Y { get; set; }
 	public int Z { get; set; }
@@ -68,6 +82,8 @@ public sealed class SpatialCellDefinition
 	public List<SpatialNamedReference> Tags { get; set; } = [];
 	public List<SpatialNamedReference> RangedCovers { get; set; } = [];
 	public List<SpatialMagicResourceDefinition> MagicResources { get; set; } = [];
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+	public SpatialRouteCellDefinition? RouteCell { get; set; }
 }
 
 public sealed class SpatialCellOverlayDefinition
@@ -130,4 +146,40 @@ public sealed class SpatialExitSideDefinition
 	public string? InboundTarget { get; set; }
 	public string? OutboundDescription { get; set; }
 	public string? OutboundTarget { get; set; }
+}
+
+public sealed class SpatialRouteCellDefinition
+{
+	public double LengthMetres { get; set; }
+	public double DefaultPositionMetres { get; set; }
+	public string PositiveDirectionName { get; set; } = string.Empty;
+	public string NegativeDirectionName { get; set; } = string.Empty;
+	public double MetresPerRoomEquivalent { get; set; }
+	public long TopologyVersion { get; set; }
+	public List<SpatialRouteLandmarkDefinition> Landmarks { get; set; } = [];
+	public List<SpatialRouteExitAnchorDefinition> ExitAnchors { get; set; } = [];
+}
+
+public sealed class SpatialRouteLandmarkDefinition
+{
+	public long SourceId { get; set; }
+	public string Name { get; set; } = string.Empty;
+	public string Keywords { get; set; } = string.Empty;
+	public string Description { get; set; } = string.Empty;
+	public double PositionMetres { get; set; }
+	public int DisplayOrder { get; set; }
+}
+
+public sealed class SpatialRouteExitAnchorDefinition
+{
+	public string ExitKey { get; set; } = string.Empty;
+	public double MinimumPositionMetres { get; set; }
+	public double MaximumPositionMetres { get; set; }
+	public double ArrivalPositionMetres { get; set; }
+}
+
+public sealed class SpatialPackageOmission
+{
+	public string Code { get; set; } = string.Empty;
+	public string Message { get; set; } = string.Empty;
 }

--- a/MudSharpCore/Construction/ImportExport/SpatialAreaPackageSerializer.cs
+++ b/MudSharpCore/Construction/ImportExport/SpatialAreaPackageSerializer.cs
@@ -32,12 +32,25 @@ public static class SpatialAreaPackageSerializer
 		WriteIndented = true
 	};
 
+	private sealed class SpatialAreaPackageV1
+	{
+		public string Format { get; set; } = SpatialAreaPackage.CurrentFormat;
+		public int Version { get; set; } = 1;
+		public string IntegritySha256 { get; set; } = string.Empty;
+		public DateTime CreatedUtc { get; set; }
+		public SpatialAreaPackageSource Source { get; set; } = new();
+		public SpatialZoneDefinition Zone { get; set; } = new();
+		public List<SpatialRoomDefinition> Rooms { get; set; } = [];
+		public List<SpatialCellDefinition> Cells { get; set; } = [];
+		public List<SpatialExitDefinition> Exits { get; set; } = [];
+	}
+
 	public static string Serialize(SpatialAreaPackage package)
 	{
 		package.IntegritySha256 = string.Empty;
-		var canonicalJson = JsonSerializer.Serialize(package, Options);
+		var canonicalJson = SerializeForVersion(package);
 		package.IntegritySha256 = ComputeHash(canonicalJson);
-		return JsonSerializer.Serialize(package, Options);
+		return SerializeForVersion(package);
 	}
 
 	public static SpatialAreaPackageReadResult Deserialize(string json)
@@ -69,7 +82,7 @@ public static class SpatialAreaPackageSerializer
 
 		var suppliedHash = package.IntegritySha256;
 		package.IntegritySha256 = string.Empty;
-		var expectedHash = ComputeHash(JsonSerializer.Serialize(package, Options));
+		var expectedHash = ComputeHash(SerializeForVersion(package));
 		package.IntegritySha256 = suppliedHash;
 		if (string.IsNullOrWhiteSpace(suppliedHash) ||
 		    !CryptographicOperations.FixedTimeEquals(
@@ -99,16 +112,34 @@ public static class SpatialAreaPackageSerializer
 				$"Expected format '{SpatialAreaPackage.CurrentFormat}', but found '{package.Format}'."));
 		}
 
-		if (package.Version != SpatialAreaPackage.CurrentVersion)
+		if (package.Version is < SpatialAreaPackage.MinimumSupportedVersion or > SpatialAreaPackage.CurrentVersion)
 		{
 			diagnostics.Add(Error("unsupported-version",
-				$"Package version {package.Version:N0} is not supported; this server supports version {SpatialAreaPackage.CurrentVersion:N0}."));
+				$"Package version {package.Version:N0} is not supported; this server supports versions {SpatialAreaPackage.MinimumSupportedVersion:N0} through {SpatialAreaPackage.CurrentVersion:N0}."));
 		}
 
 		if (package.Rooms is null || package.Cells is null || package.Exits is null || package.Zone is null ||
-		    package.Source is null)
+		    package.Source is null || package.Omissions is null)
 		{
 			diagnostics.Add(Error("missing-sections", "The package is missing one or more required sections."));
+			return diagnostics;
+		}
+
+		if (package.Version >= 2 &&
+		    (package.Zones is null || package.SourceZones is null ||
+		     package.Zones.Count != package.SourceZones.Count))
+		{
+			diagnostics.Add(Error("invalid-zone-sources",
+				"Version 2 packages must contain one source entry for every zone definition."));
+			return diagnostics;
+		}
+
+		if (package.Version >= 2 &&
+		    (package.Zones.Cast<object?>().Any(x => x is null) ||
+		     package.SourceZones.Cast<object?>().Any(x => x is null)))
+		{
+			diagnostics.Add(Error("null-zone-entry",
+				"Zone and zone-source collections may not contain null entries."));
 			return diagnostics;
 		}
 
@@ -132,13 +163,29 @@ public static class SpatialAreaPackageSerializer
 
 		if (package.Rooms.Cast<object?>().Any(x => x is null) ||
 		    package.Cells.Cast<object?>().Any(x => x is null) ||
-		    package.Exits.Cast<object?>().Any(x => x is null))
+		    package.Exits.Cast<object?>().Any(x => x is null) ||
+		    package.Omissions.Cast<object?>().Any(x => x is null))
 		{
 			diagnostics.Add(Error("null-collection-entry",
-				"Room, cell, and exit collections may not contain null entries."));
+				"Room, cell, exit, and omission collections may not contain null entries."));
 			return diagnostics;
 		}
 
+		foreach (var omission in package.Omissions.Where(x =>
+			         string.IsNullOrWhiteSpace(x.Code) || string.IsNullOrWhiteSpace(x.Message)))
+		{
+			diagnostics.Add(Error("invalid-omission",
+				"Every package omission must contain both a code and a message."));
+		}
+
+		var zones = GetZoneDefinitions(package);
+		if (zones.Count == 0)
+		{
+			diagnostics.Add(Error("missing-zones", "The package does not contain a zone definition."));
+			return diagnostics;
+		}
+
+		ValidateUniqueKeys(zones.Select((zone, index) => ZoneKey(package, zone, index)), "zone", diagnostics);
 		ValidateUniqueKeys(package.Rooms.Select(x => x.Key), "room", diagnostics);
 		ValidateUniqueKeys(package.Cells.Select(x => x.Key), "cell", diagnostics);
 		ValidateUniqueKeys(package.Exits.Select(x => x.Key), "exit", diagnostics);
@@ -146,11 +193,24 @@ public static class SpatialAreaPackageSerializer
 		var roomKeys = package.Rooms.Select(x => x.Key).ToHashSet(StringComparer.Ordinal);
 		var cellKeys = package.Cells.Select(x => x.Key).ToHashSet(StringComparer.Ordinal);
 		var exitKeys = package.Exits.Select(x => x.Key).ToHashSet(StringComparer.Ordinal);
+		var zoneKeys = zones
+			.Select((zone, index) => ZoneKey(package, zone, index))
+			.ToHashSet(StringComparer.Ordinal);
 		foreach (var room in package.Rooms.Where(room =>
 			         package.Cells.All(cell => !string.Equals(cell.RoomKey, room.Key, StringComparison.Ordinal))))
 		{
-			diagnostics.Add(Error("empty-room",
-				$"Room '{room.Key}' does not contain a packaged cell."));
+			diagnostics.Add(Warning("empty-room-skipped",
+				$"Room '{room.Key}' (source #{room.SourceId:N0}) has no packaged cell and will be skipped."));
+		}
+
+		foreach (var room in package.Rooms)
+		{
+			var zoneKey = RoomZoneKey(package, room);
+			if (!zoneKeys.Contains(zoneKey))
+			{
+				diagnostics.Add(Error("orphan-room",
+					$"Room '{room.Key}' references missing zone '{zoneKey}'."));
+			}
 		}
 
 		foreach (var cell in package.Cells)
@@ -234,6 +294,8 @@ public static class SpatialAreaPackageSerializer
 						$"Cell '{cell.Key}' references missing exit '{exitKey}'."));
 				}
 			}
+
+			ValidateRouteCell(cell, exitKeys, diagnostics);
 		}
 
 		foreach (var exit in package.Exits)
@@ -326,58 +388,191 @@ public static class SpatialAreaPackageSerializer
 				$"Exit '{exit.Key}' is not active in any packaged cell overlay."));
 		}
 
-		if (!cellKeys.Contains(package.Zone.DefaultCellKey))
-		{
-			diagnostics.Add(Error("invalid-default-cell",
-				$"Zone default cell '{package.Zone.DefaultCellKey}' is not in the package."));
-		}
-
-		if (string.IsNullOrWhiteSpace(package.Zone.Name))
-		{
-			diagnostics.Add(Error("missing-zone-name", "The package zone must have a name."));
-		}
-
-		if (package.Zone.TimeZones is null)
-		{
-			diagnostics.Add(Error("missing-timezones", "The package zone is missing its timezone collection."));
-		}
-		else
-		{
-			if (package.Zone.TimeZones.Cast<object?>().Any(x => x is null))
-			{
-				diagnostics.Add(Error("null-timezone-reference",
-					"The package timezone collection may not contain null entries."));
-				return diagnostics;
-			}
-
-			var duplicateClock = package.Zone.TimeZones
-				.GroupBy(x => x.ClockAlias, StringComparer.InvariantCultureIgnoreCase)
-				.FirstOrDefault(x => x.Count() > 1);
-			if (duplicateClock is not null)
-			{
-				diagnostics.Add(Error("duplicate-clock-timezone",
-					$"The package contains more than one timezone for clock '{duplicateClock.Key}'."));
-			}
-
-			if (package.Zone.TimeZones.Any(x =>
-				    string.IsNullOrWhiteSpace(x.ClockAlias) ||
-				    string.IsNullOrWhiteSpace(x.TimeZoneAlias)))
-			{
-				diagnostics.Add(Error("invalid-timezone-reference",
-					"Every packaged timezone must identify both a clock alias and timezone alias."));
-			}
-		}
-
-		if ((package.Zone.ForagableProfile is not null &&
-		     string.IsNullOrWhiteSpace(package.Zone.ForagableProfile.Name)) ||
-		    (package.Zone.WeatherController is not null &&
-		     string.IsNullOrWhiteSpace(package.Zone.WeatherController.Name)))
-		{
-			diagnostics.Add(Error("invalid-zone-dependency",
-				"Zone dependency references must have non-empty names."));
-		}
+		ValidateZones(package, zones, cellKeys, diagnostics);
 
 		return diagnostics;
+	}
+
+	public static IReadOnlyList<SpatialZoneDefinition> GetZoneDefinitions(SpatialAreaPackage package)
+	{
+		return package.Version >= 2 && package.Zones is { Count: > 0 }
+			? package.Zones
+			: package.Zone is null ? [] : [package.Zone];
+	}
+
+	public static string ZoneKey(SpatialAreaPackage package, SpatialZoneDefinition zone, int index)
+	{
+		return package.Version >= 2
+			? zone.Key ?? string.Empty
+			: "zone-00001";
+	}
+
+	public static string RoomZoneKey(SpatialAreaPackage package, SpatialRoomDefinition room)
+	{
+		return package.Version >= 2
+			? room.ZoneKey ?? string.Empty
+			: "zone-00001";
+	}
+
+	private static void ValidateZones(
+		SpatialAreaPackage package,
+		IReadOnlyList<SpatialZoneDefinition> zones,
+		IReadOnlySet<string> cellKeys,
+		ICollection<SpatialAreaTransferDiagnostic> diagnostics)
+	{
+		var roomByKey = package.Rooms
+			.GroupBy(x => x.Key, StringComparer.Ordinal)
+			.ToDictionary(x => x.Key, x => x.First(), StringComparer.Ordinal);
+		foreach (var (zone, index) in zones.Select((value, index) => (value, index)))
+		{
+			var zoneKey = ZoneKey(package, zone, index);
+			if (!cellKeys.Contains(zone.DefaultCellKey))
+			{
+				diagnostics.Add(Error("invalid-default-cell",
+					$"Zone '{zoneKey}' default cell '{zone.DefaultCellKey}' is not in the package."));
+			}
+			else
+			{
+				var defaultCell = package.Cells.First(x => x.Key == zone.DefaultCellKey);
+				if (roomByKey.TryGetValue(defaultCell.RoomKey, out var defaultRoom) &&
+				    !RoomZoneKey(package, defaultRoom).Equals(zoneKey, StringComparison.Ordinal))
+				{
+					diagnostics.Add(Error("wrong-zone-default-cell",
+						$"Zone '{zoneKey}' default cell belongs to another packaged zone."));
+				}
+			}
+
+			if (string.IsNullOrWhiteSpace(zone.Name))
+			{
+				diagnostics.Add(Error("missing-zone-name", $"Package zone '{zoneKey}' must have a name."));
+			}
+
+			if (zone.TimeZones is null)
+			{
+				diagnostics.Add(Error("missing-timezones",
+					$"Package zone '{zoneKey}' is missing its timezone collection."));
+			}
+			else
+			{
+				if (zone.TimeZones.Cast<object?>().Any(x => x is null))
+				{
+					diagnostics.Add(Error("null-timezone-reference",
+						$"Package zone '{zoneKey}' timezone collection may not contain null entries."));
+					continue;
+				}
+
+				var duplicateClock = zone.TimeZones
+					.GroupBy(x => x.ClockAlias, StringComparer.InvariantCultureIgnoreCase)
+					.FirstOrDefault(x => x.Count() > 1);
+				if (duplicateClock is not null)
+				{
+					diagnostics.Add(Error("duplicate-clock-timezone",
+						$"Package zone '{zoneKey}' contains more than one timezone for clock '{duplicateClock.Key}'."));
+				}
+
+				if (zone.TimeZones.Any(x =>
+					    string.IsNullOrWhiteSpace(x.ClockAlias) ||
+					    string.IsNullOrWhiteSpace(x.TimeZoneAlias)))
+				{
+					diagnostics.Add(Error("invalid-timezone-reference",
+						$"Every timezone in package zone '{zoneKey}' must identify both a clock and timezone alias."));
+				}
+			}
+
+			if ((zone.ForagableProfile is not null &&
+			     string.IsNullOrWhiteSpace(zone.ForagableProfile.Name)) ||
+			    (zone.WeatherController is not null &&
+			     string.IsNullOrWhiteSpace(zone.WeatherController.Name)))
+			{
+				diagnostics.Add(Error("invalid-zone-dependency",
+					$"Package zone '{zoneKey}' dependency references must have non-empty names."));
+			}
+		}
+
+		var duplicateName = zones
+			.GroupBy(x => x.Name, StringComparer.InvariantCultureIgnoreCase)
+			.FirstOrDefault(x => x.Count() > 1);
+		if (duplicateName is not null)
+		{
+			diagnostics.Add(Error("duplicate-zone-name",
+				$"The package contains duplicate zone name '{duplicateName.Key}'."));
+		}
+	}
+
+	private static void ValidateRouteCell(
+		SpatialCellDefinition cell,
+		IReadOnlySet<string> exitKeys,
+		ICollection<SpatialAreaTransferDiagnostic> diagnostics)
+	{
+		var route = cell.RouteCell;
+		if (route is null)
+		{
+			return;
+		}
+
+		if (!double.IsFinite(route.LengthMetres) || route.LengthMetres <= 0.0 ||
+		    !double.IsFinite(route.DefaultPositionMetres) ||
+		    route.DefaultPositionMetres < 0.0 ||
+		    route.DefaultPositionMetres > route.LengthMetres ||
+		    !double.IsFinite(route.MetresPerRoomEquivalent) ||
+		    route.MetresPerRoomEquivalent <= 0.0 ||
+		    route.TopologyVersion < 1 ||
+		    string.IsNullOrWhiteSpace(route.PositiveDirectionName) ||
+		    string.IsNullOrWhiteSpace(route.NegativeDirectionName))
+		{
+			diagnostics.Add(Error("invalid-route-cell",
+				$"Cell '{cell.Key}' contains invalid route-cell geometry."));
+			return;
+		}
+
+		if (route.Landmarks is null || route.ExitAnchors is null)
+		{
+			diagnostics.Add(Error("missing-route-collections",
+				$"Cell '{cell.Key}' route-cell collections may not be null."));
+			return;
+		}
+
+		foreach (var landmark in route.Landmarks)
+		{
+			if (landmark is null ||
+			    string.IsNullOrWhiteSpace(landmark.Name) ||
+			    !double.IsFinite(landmark.PositionMetres) ||
+			    landmark.PositionMetres < 0.0 ||
+			    landmark.PositionMetres > route.LengthMetres)
+			{
+				diagnostics.Add(Error("invalid-route-landmark",
+					$"Cell '{cell.Key}' contains an invalid route landmark."));
+			}
+		}
+
+		foreach (var anchor in route.ExitAnchors)
+		{
+			if (anchor is null ||
+			    !exitKeys.Contains(anchor.ExitKey) ||
+			    !cell.Overlay.ExitKeys.Contains(anchor.ExitKey) ||
+			    !double.IsFinite(anchor.MinimumPositionMetres) ||
+			    !double.IsFinite(anchor.MaximumPositionMetres) ||
+			    !double.IsFinite(anchor.ArrivalPositionMetres) ||
+			    anchor.MinimumPositionMetres < 0.0 ||
+			    anchor.MaximumPositionMetres < anchor.MinimumPositionMetres ||
+			    anchor.MaximumPositionMetres > route.LengthMetres ||
+			    anchor.ArrivalPositionMetres < anchor.MinimumPositionMetres ||
+			    anchor.ArrivalPositionMetres > anchor.MaximumPositionMetres)
+			{
+				diagnostics.Add(Error("invalid-route-anchor",
+					$"Cell '{cell.Key}' contains an invalid route exit anchor."));
+			}
+		}
+
+		var duplicateAnchor = route.ExitAnchors
+			.Where(x => x is not null)
+			.GroupBy(x => x.ExitKey, StringComparer.Ordinal)
+			.FirstOrDefault(x => x.Count() > 1);
+		if (duplicateAnchor is not null)
+		{
+			diagnostics.Add(Error("duplicate-route-anchor",
+				$"Cell '{cell.Key}' contains more than one anchor for exit '{duplicateAnchor.Key}'."));
+		}
 	}
 
 	private static void ValidateUniqueKeys(
@@ -407,8 +602,34 @@ public static class SpatialAreaPackageSerializer
 		return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(text)));
 	}
 
+	private static string SerializeForVersion(SpatialAreaPackage package)
+	{
+		if (package.Version != 1)
+		{
+			return JsonSerializer.Serialize(package, Options);
+		}
+
+		return JsonSerializer.Serialize(new SpatialAreaPackageV1
+		{
+			Format = package.Format,
+			Version = package.Version,
+			IntegritySha256 = package.IntegritySha256,
+			CreatedUtc = package.CreatedUtc,
+			Source = package.Source,
+			Zone = package.Zone,
+			Rooms = package.Rooms,
+			Cells = package.Cells,
+			Exits = package.Exits
+		}, Options);
+	}
+
 	private static SpatialAreaTransferDiagnostic Error(string code, string message)
 	{
 		return new SpatialAreaTransferDiagnostic(SpatialAreaTransferDiagnosticSeverity.Error, code, message);
+	}
+
+	private static SpatialAreaTransferDiagnostic Warning(string code, string message)
+	{
+		return new SpatialAreaTransferDiagnostic(SpatialAreaTransferDiagnosticSeverity.Warning, code, message);
 	}
 }

--- a/MudSharpCore/Construction/ImportExport/SpatialAreaTransferService.Export.cs
+++ b/MudSharpCore/Construction/ImportExport/SpatialAreaTransferService.Export.cs
@@ -1,0 +1,487 @@
+#nullable enable
+
+using System.IO;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using MudSharp.Construction.Boundary;
+using MudSharp.Database;
+using MudSharp.Framework;
+
+namespace MudSharp.Construction.ImportExport;
+
+public sealed partial class SpatialAreaTransferService
+{
+	public SpatialAreaTransferResult ExportZones(
+		IReadOnlyCollection<IZone> zones,
+		string packageFileName)
+	{
+		var diagnostics = new List<SpatialAreaTransferDiagnostic>();
+		var omissions = new List<SpatialPackageOmission>();
+		var selectedZones = zones
+			.DistinctBy(x => x.Id)
+			.OrderBy(x => x.Id)
+			.ToList();
+		if (selectedZones.Count == 0)
+		{
+			return Failure("You must select at least one zone to export.", diagnostics, "no-zones");
+		}
+
+		if (!TryResolvePackagePath(PackageDirectory, packageFileName, out var packagePath, out var pathError))
+		{
+			return Failure(pathError, diagnostics, "invalid-package-name");
+		}
+
+		if (File.Exists(packagePath))
+		{
+			return Failure(
+				$"A package named '{Path.GetFileName(packagePath)}' already exists. Export never overwrites an existing package.",
+				diagnostics,
+				"package-exists");
+		}
+
+		var allRooms = selectedZones
+			.SelectMany(x => x.Rooms)
+			.DistinctBy(x => x.Id)
+			.OrderBy(x => x.Id)
+			.ToList();
+		var rooms = allRooms
+			.Where(x => x.Cells.Any())
+			.ToList();
+		foreach (var emptyRoom in allRooms.Except(rooms))
+		{
+			var omission = $"Room #{emptyRoom.Id:N0} at ({emptyRoom.X:N0}, {emptyRoom.Y:N0}, {emptyRoom.Z:N0}) " +
+			               $"in zone '{emptyRoom.Zone.Name}' was skipped because it contains no cells.";
+			omissions.Add(new SpatialPackageOmission { Code = "empty-room", Message = omission });
+		}
+
+		var cells = rooms
+			.SelectMany(x => x.Cells)
+			.DistinctBy(x => x.Id)
+			.OrderBy(x => x.Id)
+			.ToList();
+		if (rooms.Count == 0 || cells.Count == 0)
+		{
+			return Failure("The selected zones do not contain any exportable rooms and cells.", diagnostics, "empty-zone");
+		}
+
+		if (rooms.Count > SpatialAreaPackageSerializer.MaximumRooms ||
+		    cells.Count > SpatialAreaPackageSerializer.MaximumCells)
+		{
+			return Failure("The selected zones exceed the package safety limits.", diagnostics, "zone-too-large");
+		}
+
+		diagnostics.AddRange(ValidateExportableCells(cells));
+		if (diagnostics.Any(x => x.Severity == SpatialAreaTransferDiagnosticSeverity.Error))
+		{
+			return new SpatialAreaTransferResult
+			{
+				Summary = "The zones were not exported because they contain unsupported spatial state.",
+				Diagnostics = diagnostics,
+				ZoneCount = selectedZones.Count,
+				RoomCount = rooms.Count,
+				CellCount = cells.Count,
+				OmittedItems = omissions.Select(x => x.Message).ToList()
+			};
+		}
+
+		var zoneKeys = selectedZones
+			.Select((zone, index) => (zone.Id, Key: $"zone-{index + 1:D5}"))
+			.ToDictionary(x => x.Id, x => x.Key);
+		var roomKeys = rooms
+			.Select((room, index) => (room.Id, Key: $"room-{index + 1:D5}"))
+			.ToDictionary(x => x.Id, x => x.Key);
+		var cellKeys = cells
+			.Select((cell, index) => (cell.Id, Key: $"cell-{index + 1:D5}"))
+			.ToDictionary(x => x.Id, x => x.Key);
+		var cellIds = cellKeys.Keys.ToHashSet();
+
+		var allSeenExits = cells
+			.SelectMany(cell => cell.Gameworld.ExitManager.GetExitsFor(cell, cell.CurrentOverlay))
+			.Select(x => x.Exit)
+			.DistinctBy(x => x.Id)
+			.OrderBy(x => x.Id)
+			.ToList();
+		var missingExitIds = cells
+			.SelectMany(x => x.CurrentOverlay.ExitIDs)
+			.Distinct()
+			.Except(allSeenExits.Select(x => x.Id))
+			.ToList();
+		foreach (var missingExitId in missingExitIds)
+		{
+			diagnostics.Add(Error("missing-source-exit",
+				$"An active overlay references exit #{missingExitId:N0}, but that exit could not be loaded from the source database."));
+		}
+
+		if (missingExitIds.Count > 0)
+		{
+			return new SpatialAreaTransferResult
+			{
+				Summary = "The zones were not exported because their active topology contains invalid exit references.",
+				Diagnostics = diagnostics,
+				ZoneCount = selectedZones.Count,
+				RoomCount = rooms.Count,
+				CellCount = cells.Count,
+				OmittedItems = omissions.Select(x => x.Message).ToList()
+			};
+		}
+
+		var internalExits = allSeenExits
+			.Where(x => x.Cells.All(cell => cellIds.Contains(cell.Id)))
+			.ToList();
+		var boundaryExits = allSeenExits
+			.Where(x => x.Cells.Any(cell => !cellIds.Contains(cell.Id)))
+			.ToList();
+		if (internalExits.Count > SpatialAreaPackageSerializer.MaximumExits)
+		{
+			return Failure("The selected zones exceed the package exit safety limit.", diagnostics, "zone-too-large");
+		}
+
+		foreach (var exit in boundaryExits)
+		{
+			foreach (var origin in exit.Cells.Where(x => cellIds.Contains(x.Id)))
+			{
+				var destination = exit.Cells.First(x => x.Id != origin.Id);
+				var side = exit.CellExitFor(origin);
+				var name = side is INonCardinalCellExit nonCardinal
+					? nonCardinal.Verb
+					: side.OutboundDirection.DescribeEnum().ToLowerInvariant();
+				var message = $"Exit \"{name}\" from cell #{origin.Id:N0} ({origin.Name}) to cell " +
+				              $"#{destination.Id:N0} ({destination.Name}) was skipped because destination zone " +
+				              $"'{destination.Zone.Name}' was not selected.";
+				omissions.Add(new SpatialPackageOmission { Code = "boundary-exit", Message = message });
+			}
+		}
+
+		foreach (var exit in internalExits)
+		{
+			if (exit.Door is not null)
+			{
+				diagnostics.Add(Error("installed-door",
+					$"Exit #{exit.Id:N0} has an installed door item. Door items are not portable."));
+			}
+
+			if (exit.FallCell is not null && !cellIds.Contains(exit.FallCell.Id))
+			{
+				diagnostics.Add(Error("external-fall-cell",
+					$"Exit #{exit.Id:N0} falls to cell #{exit.FallCell.Id:N0}, which is outside the package."));
+			}
+		}
+
+		if (diagnostics.Any(x => x.Severity == SpatialAreaTransferDiagnosticSeverity.Error))
+		{
+			return new SpatialAreaTransferResult
+			{
+				Summary = "The zones were not exported because one or more exits require unsupported dependencies.",
+				Diagnostics = diagnostics,
+				ZoneCount = selectedZones.Count,
+				RoomCount = rooms.Count,
+				CellCount = cells.Count,
+				ExitCount = internalExits.Count,
+				OmittedItems = omissions.Select(x => x.Message).ToList()
+			};
+		}
+
+		AddNonSpatialOmissions(cells, omissions);
+		var exitKeys = internalExits
+			.Select((exit, index) => (exit.Id, Key: $"exit-{index + 1:D5}"))
+			.ToDictionary(x => x.Id, x => x.Key);
+		var package = BuildPackageVersion2(
+			selectedZones,
+			rooms,
+			cells,
+			internalExits,
+			zoneKeys,
+			roomKeys,
+			cellKeys,
+			exitKeys,
+			omissions,
+			diagnostics);
+		var json = SpatialAreaPackageSerializer.Serialize(package);
+		if (Encoding.UTF8.GetByteCount(json) > SpatialAreaPackageSerializer.MaximumPackageBytes)
+		{
+			return Failure("The serialized package exceeds the 16 MiB safety limit.", diagnostics, "package-too-large");
+		}
+
+		try
+		{
+			Directory.CreateDirectory(PackageDirectory);
+			using var stream = new FileStream(packagePath, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+			using var writer = new StreamWriter(stream, new UTF8Encoding(false));
+			writer.Write(json);
+		}
+		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+		{
+			return Failure($"The package could not be written: {ex.Message}", diagnostics, "package-write-failed");
+		}
+
+		return new SpatialAreaTransferResult
+		{
+			Success = true,
+			Summary = $"Exported {selectedZones.Count:N0} zone(s) as package version {SpatialAreaPackage.CurrentVersion:N0}.",
+			PackagePath = packagePath,
+			Diagnostics = diagnostics,
+			ZoneCount = selectedZones.Count,
+			RoomCount = rooms.Count,
+			CellCount = cells.Count,
+			ExitCount = internalExits.Count,
+			OmittedItems = omissions.Select(x => x.Message).ToList()
+		};
+	}
+
+	private static SpatialAreaPackage BuildPackageVersion2(
+		IReadOnlyList<IZone> zones,
+		IReadOnlyList<IRoom> rooms,
+		IReadOnlyList<ICell> cells,
+		IReadOnlyList<IExit> exits,
+		IReadOnlyDictionary<long, string> zoneKeys,
+		IReadOnlyDictionary<long, string> roomKeys,
+		IReadOnlyDictionary<long, string> cellKeys,
+		IReadOnlyDictionary<long, string> exitKeys,
+		IReadOnlyList<SpatialPackageOmission> omissions,
+		ICollection<SpatialAreaTransferDiagnostic> diagnostics)
+	{
+		var overlayPackages = cells
+			.Select(x => x.CurrentOverlay.Package)
+			.Distinct()
+			.ToList();
+		if (overlayPackages.Count > 1)
+		{
+			diagnostics.Add(Warning("mixed-overlays",
+				$"The selection uses {overlayPackages.Count:N0} different active overlay packages. Each cell's active overlay data will be imported into the selected target package."));
+		}
+
+		var sources = zones
+			.Select(zone => new SpatialAreaPackageSource
+			{
+				ZoneName = zone.Name,
+				ZoneId = zone.Id,
+				ShardName = zone.Shard.Name,
+				ShardId = zone.Shard.Id,
+				OverlayPackageName = overlayPackages.Count == 1 ? overlayPackages[0].Name : "Mixed Active Overlays",
+				OverlayPackageId = overlayPackages.Count == 1 ? overlayPackages[0].Id : 0,
+				OverlayPackageRevision = overlayPackages.Count == 1 ? overlayPackages[0].RevisionNumber : 0
+			})
+			.ToList();
+		var zoneDefinitions = zones
+			.Select(zone => new SpatialZoneDefinition
+			{
+				Key = zoneKeys[zone.Id],
+				SourceId = zone.Id,
+				Name = zone.Name,
+				LatitudeRadians = zone.Geography.Latitude,
+				LongitudeRadians = zone.Geography.Longitude,
+				ElevationMetres = zone.Geography.Elevation,
+				AmbientLightPollution = zone.AmbientLightPollution,
+				ForagableProfile = Reference(zone.ForagableProfile),
+				WeatherController = Reference(zone.WeatherController),
+				DefaultCellKey = cellKeys[zone.DefaultCell.Id],
+				TimeZones = zone.GetEditableZone.TimeZones
+					.OrderBy(x => x.Key.Alias)
+					.Select(x => new SpatialTimeZoneDefinition
+					{
+						ClockAlias = x.Key.Alias,
+						TimeZoneAlias = x.Value.Alias,
+						TimeZoneDescription = x.Value.Description
+					})
+					.ToList()
+			})
+			.ToList();
+
+		var explicitForagableProfiles = new Dictionary<long, long?>();
+		var routeCells = new Dictionary<long, Models.RouteCell>();
+		using (new FMDB())
+		{
+			foreach (var dbCell in FMDB.Context.Cells
+				         .Where(x => cellKeys.Keys.Contains(x.Id))
+				         .Select(x => new { x.Id, x.ForagableProfileId }))
+			{
+				explicitForagableProfiles[dbCell.Id] = dbCell.ForagableProfileId;
+			}
+
+			routeCells = FMDB.Context.RouteCells
+				.AsNoTracking()
+				.Where(x => cellKeys.Keys.Contains(x.CellId))
+				.Include(x => x.Landmarks)
+				.Include(x => x.ExitAnchors)
+				.ToDictionary(x => x.CellId);
+		}
+
+		var package = new SpatialAreaPackage
+		{
+			Version = SpatialAreaPackage.CurrentVersion,
+			CreatedUtc = DateTime.UtcNow,
+			Source = sources[0],
+			Zone = zoneDefinitions[0],
+			SourceZones = sources,
+			Zones = zoneDefinitions,
+			Omissions = omissions.ToList(),
+			Rooms = rooms
+				.OrderBy(x => x.Id)
+				.Select(x => new SpatialRoomDefinition
+				{
+					Key = roomKeys[x.Id],
+					SourceId = x.Id,
+					ZoneKey = zoneKeys[x.Zone.Id],
+					X = x.X,
+					Y = x.Y,
+					Z = x.Z
+				})
+				.ToList()
+		};
+
+		package.Cells = cells
+			.OrderBy(x => x.Id)
+			.Select(cell =>
+			{
+				var overlay = cell.CurrentOverlay;
+				var explicitForagable = explicitForagableProfiles.GetValueOrDefault(cell.Id);
+				return new SpatialCellDefinition
+				{
+					Key = cellKeys[cell.Id],
+					SourceId = cell.Id,
+					RoomKey = roomKeys[cell.Room.Id],
+					ForagableProfile = explicitForagable.HasValue
+						? Reference(cell.Gameworld.ForagableProfiles.Get(explicitForagable.Value))
+						: null,
+					Tags = cell.Tags.OrderBy(x => x.Name).Select(x => Reference(x)!).ToList(),
+					RangedCovers = cell.LocalCover.OrderBy(x => x.Name).Select(x => Reference(x)!).ToList(),
+					MagicResources = cell.MagicResourceAmounts
+						.OrderBy(x => x.Key.Name)
+						.Select(x => new SpatialMagicResourceDefinition
+						{
+							Resource = Reference(x.Key)!,
+							Amount = x.Value
+						})
+						.ToList(),
+					RouteCell = routeCells.TryGetValue(cell.Id, out var route)
+						? BuildRouteCellDefinition(route, exitKeys, overlay.ExitIDs)
+						: null,
+					Overlay = new SpatialCellOverlayDefinition
+					{
+						CellName = overlay.CellName,
+						CellDescription = overlay.CellDescription,
+						Terrain = Reference(overlay.Terrain)!,
+						HearingProfile = Reference(overlay.HearingProfile),
+						Atmosphere = FluidReference(overlay.Atmosphere),
+						OutdoorsType = (int)overlay.OutdoorsType,
+						AmbientLightFactor = overlay.AmbientLightFactor,
+						AddedLight = overlay.AddedLight,
+						SafeQuit = overlay.SafeQuit,
+						ExitKeys = overlay.ExitIDs
+							.Where(exitKeys.ContainsKey)
+							.Select(x => exitKeys[x])
+							.Order()
+							.ToList()
+					}
+				};
+			})
+			.ToList();
+
+		package.Exits = exits
+			.Select(exit =>
+			{
+				var endpoints = exit.Cells.ToList();
+				return new SpatialExitDefinition
+				{
+					Key = exitKeys[exit.Id],
+					SourceId = exit.Id,
+					Cell1Key = cellKeys[endpoints[0].Id],
+					Cell2Key = cellKeys[endpoints[1].Id],
+					Side1 = BuildExitSide(exit.CellExitFor(endpoints[0])),
+					Side2 = BuildExitSide(exit.CellExitFor(endpoints[1])),
+					TimeMultiplier = exit.TimeMultiplier,
+					AcceptsDoor = exit.AcceptsDoor,
+					DoorSize = (int)exit.DoorSize,
+					MaximumSizeToEnter = (int)exit.MaximumSizeToEnter,
+					MaximumSizeToEnterUpright = (int)exit.MaximumSizeToEnterUpright,
+					IsClimbExit = exit.IsClimbExit,
+					ClimbDifficulty = (int)exit.ClimbDifficulty,
+					FallCellKey = exit.FallCell is null ? null : cellKeys[exit.FallCell.Id],
+					BlockedLayers = exit.BlockedLayers.Select(x => (int)x).Order().ToList()
+				};
+			})
+			.ToList();
+		return package;
+	}
+
+	private static SpatialRouteCellDefinition BuildRouteCellDefinition(
+		Models.RouteCell route,
+		IReadOnlyDictionary<long, string> exitKeys,
+		IEnumerable<long> activeExitIds)
+	{
+		var activeExitIdSet = activeExitIds.ToHashSet();
+		return new SpatialRouteCellDefinition
+		{
+			LengthMetres = (double)route.LengthMetres,
+			DefaultPositionMetres = (double)route.DefaultPositionMetres,
+			PositiveDirectionName = route.PositiveDirectionName,
+			NegativeDirectionName = route.NegativeDirectionName,
+			MetresPerRoomEquivalent = (double)route.MetresPerRoomEquivalent,
+			TopologyVersion = route.TopologyVersion,
+			Landmarks = route.Landmarks
+				.OrderBy(x => x.DisplayOrder)
+				.ThenBy(x => x.PositionMetres)
+				.ThenBy(x => x.Id)
+				.Select(x => new SpatialRouteLandmarkDefinition
+				{
+					SourceId = x.Id,
+					Name = x.Name,
+					Keywords = x.Keywords,
+					Description = x.Description,
+					PositionMetres = (double)x.PositionMetres,
+					DisplayOrder = x.DisplayOrder
+				})
+				.ToList(),
+			ExitAnchors = route.ExitAnchors
+				.Where(x => exitKeys.ContainsKey(x.ExitId) && activeExitIdSet.Contains(x.ExitId))
+				.OrderBy(x => x.ExitId)
+				.Select(x => new SpatialRouteExitAnchorDefinition
+				{
+					ExitKey = exitKeys[x.ExitId],
+					MinimumPositionMetres = (double)x.MinimumPositionMetres,
+					MaximumPositionMetres = (double)x.MaximumPositionMetres,
+					ArrivalPositionMetres = (double)x.ArrivalPositionMetres
+				})
+				.ToList()
+		};
+	}
+
+	private static void AddNonSpatialOmissions(
+		IReadOnlyCollection<ICell> cells,
+		ICollection<SpatialPackageOmission> omissions)
+	{
+		foreach (var cell in cells)
+		{
+			foreach (var area in cell.Areas.OrderBy(x => x.Name))
+			{
+				omissions.Add(new SpatialPackageOmission
+				{
+					Code = "area-membership",
+					Message = $"Cell #{cell.Id:N0} ({cell.Name}) will not retain membership in area group '{area.Name}'."
+				});
+			}
+
+			var characterCount = cell.Characters.Count();
+			var itemCount = cell.GameItems.Count();
+			if (characterCount > 0 || itemCount > 0)
+			{
+				omissions.Add(new SpatialPackageOmission
+				{
+					Code = "live-contents",
+					Message = $"Cell #{cell.Id:N0} ({cell.Name}) contains {characterCount:N0} character(s) and " +
+					          $"{itemCount:N0} item(s); live contents are not included."
+				});
+			}
+
+			var hookCount = cell.Hooks.Count();
+			if (hookCount > 0)
+			{
+				omissions.Add(new SpatialPackageOmission
+				{
+					Code = "cell-hooks",
+					Message = $"Cell #{cell.Id:N0} ({cell.Name}) has {hookCount:N0} installed hook(s), which are not included."
+				});
+			}
+		}
+	}
+}

--- a/MudSharpCore/Construction/ImportExport/SpatialAreaTransferService.ImportV2.cs
+++ b/MudSharpCore/Construction/ImportExport/SpatialAreaTransferService.ImportV2.cs
@@ -1,0 +1,397 @@
+#nullable enable
+
+using System.Data;
+using Microsoft.EntityFrameworkCore;
+using MudSharp.Character;
+using MudSharp.Database;
+using MudSharp.Framework;
+using MudSharp.Models;
+
+namespace MudSharp.Construction.ImportExport;
+
+public sealed partial class SpatialAreaTransferService
+{
+	private SpatialAreaTransferResult ImportVersion2(
+		ICharacter actor,
+		IShard targetShard,
+		ImportPreflight preflight)
+	{
+		var package = preflight.Package;
+		var gameworld = actor.Gameworld;
+		var dbZones = new Dictionary<string, Models.Zone>(StringComparer.Ordinal);
+		var dbRooms = new Dictionary<string, Models.Room>(StringComparer.Ordinal);
+		var dbCells = new Dictionary<string, Models.Cell>(StringComparer.Ordinal);
+		var databaseCommitted = false;
+		try
+		{
+			using (new FMDB())
+			using (var transaction = FMDB.Context.Database.BeginTransaction(IsolationLevel.Serializable))
+			{
+				foreach (var targetName in preflight.ZoneNames.Values)
+				{
+					if (FMDB.Context.Zones.Any(x => x.Name == targetName))
+					{
+						return Failure(
+							$"A zone named '{targetName}' was created after validation. Nothing was imported.",
+							preflight.Diagnostics,
+							"zone-name-collision");
+					}
+				}
+
+				foreach (var (zone, index) in preflight.Zones.Select((value, index) => (value, index)))
+				{
+					var zoneKey = SpatialAreaPackageSerializer.ZoneKey(package, zone, index);
+					var dbZone = new Models.Zone
+					{
+						Name = preflight.ZoneNames[zoneKey],
+						ShardId = targetShard.Id,
+						Latitude = zone.LatitudeRadians,
+						Longitude = zone.LongitudeRadians,
+						Elevation = zone.ElevationMetres,
+						AmbientLightPollution = zone.AmbientLightPollution,
+						ForagableProfileId = zone.ForagableProfile is null
+							? null
+							: preflight.ForagableProfiles[zone.ForagableProfile.Name].Id,
+						WeatherControllerId = preflight.WeatherControllers[zoneKey]?.Id
+					};
+					foreach (var resolvedTimeZone in preflight.TimeZonesByZone[zoneKey].Values)
+					{
+						dbZone.ZonesTimezones.Add(new ZonesTimezones
+						{
+							Zone = dbZone,
+							ClockId = resolvedTimeZone.Clock.Id,
+							TimezoneId = resolvedTimeZone.TimeZone.Id
+						});
+					}
+
+					dbZones.Add(zoneKey, dbZone);
+					FMDB.Context.Zones.Add(dbZone);
+				}
+
+				var importedRoomKeys = package.Cells
+					.Select(x => x.RoomKey)
+					.ToHashSet(StringComparer.Ordinal);
+				foreach (var room in package.Rooms.Where(x => importedRoomKeys.Contains(x.Key)))
+				{
+					var zoneKey = SpatialAreaPackageSerializer.RoomZoneKey(package, room);
+					var dbRoom = new Models.Room
+					{
+						Zone = dbZones[zoneKey],
+						X = room.X,
+						Y = room.Y,
+						Z = room.Z
+					};
+					dbRooms.Add(room.Key, dbRoom);
+					FMDB.Context.Rooms.Add(dbRoom);
+				}
+
+				FMDB.Context.SaveChanges();
+
+				foreach (var cell in package.Cells)
+				{
+					var dbCell = new Models.Cell
+					{
+						Room = dbRooms[cell.RoomKey],
+						Temporary = false,
+						EffectData = "<Effects/>",
+						ForagableProfileId = cell.ForagableProfile is null
+							? null
+							: preflight.ForagableProfiles[cell.ForagableProfile.Name].Id
+					};
+					dbCells.Add(cell.Key, dbCell);
+					FMDB.Context.Cells.Add(dbCell);
+				}
+
+				FMDB.Context.SaveChanges();
+
+				var dbOverlays = new Dictionary<string, Models.CellOverlay>(StringComparer.Ordinal);
+				foreach (var cell in package.Cells)
+				{
+					var overlay = cell.Overlay;
+					var dbOverlay = new Models.CellOverlay
+					{
+						Cell = dbCells[cell.Key],
+						Name = preflight.OverlayPackage.Name,
+						CellName = overlay.CellName,
+						CellDescription = overlay.CellDescription,
+						CellOverlayPackageId = preflight.OverlayPackage.Id,
+						CellOverlayPackageRevisionNumber = preflight.OverlayPackage.RevisionNumber,
+						TerrainId = preflight.Terrains[overlay.Terrain.Name].Id,
+						HearingProfileId = overlay.HearingProfile is null
+							? null
+							: preflight.HearingProfiles[overlay.HearingProfile.Name].Id,
+						OutdoorsType = overlay.OutdoorsType,
+						AmbientLightFactor = overlay.AmbientLightFactor,
+						AddedLight = overlay.AddedLight,
+						AtmosphereId = overlay.Atmosphere is null
+							? null
+							: preflight.Fluids[FluidKey(overlay.Atmosphere)].Id,
+						AtmosphereType = overlay.Atmosphere?.Kind,
+						SafeQuit = overlay.SafeQuit
+					};
+					dbCells[cell.Key].CellOverlays.Add(dbOverlay);
+					dbOverlays.Add(cell.Key, dbOverlay);
+					FMDB.Context.CellOverlays.Add(dbOverlay);
+				}
+
+				FMDB.Context.SaveChanges();
+
+				var dbRouteCells = new Dictionary<string, Models.RouteCell>(StringComparer.Ordinal);
+				foreach (var cell in package.Cells)
+				{
+					var dbCell = dbCells[cell.Key];
+					dbCell.CurrentOverlay = dbOverlays[cell.Key];
+					foreach (var tag in cell.Tags)
+					{
+						dbCell.CellsTags.Add(new CellsTags
+						{
+							Cell = dbCell,
+							TagId = preflight.Tags[tag.Name].Id
+						});
+					}
+
+					foreach (var cover in cell.RangedCovers)
+					{
+						dbCell.CellsRangedCovers.Add(new CellsRangedCovers
+						{
+							Cell = dbCell,
+							RangedCoverId = preflight.RangedCovers[cover.Name].Id
+						});
+					}
+
+					foreach (var resource in cell.MagicResources)
+					{
+						dbCell.CellsMagicResources.Add(new CellMagicResource
+						{
+							Cell = dbCell,
+							MagicResourceId = preflight.MagicResources[resource.Resource.Name].Id,
+							Amount = resource.Amount
+						});
+					}
+
+					if (cell.RouteCell is null)
+					{
+						continue;
+					}
+
+					var route = cell.RouteCell;
+					var dbRoute = new Models.RouteCell
+					{
+						Cell = dbCell,
+						CellId = dbCell.Id,
+						LengthMetres = (decimal)route.LengthMetres,
+						DefaultPositionMetres = (decimal)route.DefaultPositionMetres,
+						PositiveDirectionName = route.PositiveDirectionName,
+						NegativeDirectionName = route.NegativeDirectionName,
+						MetresPerRoomEquivalent = (decimal)route.MetresPerRoomEquivalent,
+						TopologyVersion = route.TopologyVersion
+					};
+					foreach (var landmark in route.Landmarks)
+					{
+						dbRoute.Landmarks.Add(new Models.RouteCellLandmark
+						{
+							RouteCell = dbRoute,
+							Name = landmark.Name,
+							Keywords = landmark.Keywords,
+							Description = landmark.Description,
+							PositionMetres = (decimal)landmark.PositionMetres,
+							DisplayOrder = landmark.DisplayOrder
+						});
+					}
+
+					dbCell.RouteCell = dbRoute;
+					dbRouteCells.Add(cell.Key, dbRoute);
+					FMDB.Context.RouteCells.Add(dbRoute);
+				}
+
+				var dbExits = new Dictionary<string, Models.Exit>(StringComparer.Ordinal);
+				foreach (var exit in package.Exits)
+				{
+					var dbExit = new Models.Exit
+					{
+						CellId1 = dbCells[exit.Cell1Key].Id,
+						CellId2 = dbCells[exit.Cell2Key].Id,
+						Direction1 = exit.Side1.Direction,
+						Direction2 = exit.Side2.Direction,
+						TimeMultiplier = exit.TimeMultiplier,
+						AcceptsDoor = exit.AcceptsDoor,
+						DoorSize = exit.AcceptsDoor ? exit.DoorSize : null,
+						MaximumSizeToEnter = exit.MaximumSizeToEnter,
+						MaximumSizeToEnterUpright = exit.MaximumSizeToEnterUpright,
+						FallCell = exit.FallCellKey is null ? null : dbCells[exit.FallCellKey].Id,
+						IsClimbExit = exit.IsClimbExit,
+						ClimbDifficulty = exit.ClimbDifficulty,
+						BlockedLayers = string.Join(",", exit.BlockedLayers),
+						Keywords1 = exit.Side1.Keywords,
+						Keywords2 = exit.Side2.Keywords,
+						InboundDescription1 = exit.Side1.InboundDescription,
+						InboundDescription2 = exit.Side2.InboundDescription,
+						OutboundDescription1 = exit.Side1.OutboundDescription,
+						OutboundDescription2 = exit.Side2.OutboundDescription,
+						InboundTarget1 = exit.Side1.InboundTarget,
+						InboundTarget2 = exit.Side2.InboundTarget,
+						OutboundTarget1 = exit.Side1.OutboundTarget,
+						OutboundTarget2 = exit.Side2.OutboundTarget,
+						Verb1 = exit.Side1.Verb,
+						Verb2 = exit.Side2.Verb,
+						PrimaryKeyword1 = exit.Side1.PrimaryKeyword,
+						PrimaryKeyword2 = exit.Side2.PrimaryKeyword
+					};
+					dbExits.Add(exit.Key, dbExit);
+					FMDB.Context.Exits.Add(dbExit);
+				}
+
+				FMDB.Context.SaveChanges();
+
+				foreach (var cell in package.Cells)
+				{
+					foreach (var exitKey in cell.Overlay.ExitKeys)
+					{
+						dbOverlays[cell.Key].CellOverlaysExits.Add(new CellOverlayExit
+						{
+							CellOverlay = dbOverlays[cell.Key],
+							Exit = dbExits[exitKey]
+						});
+					}
+
+					if (cell.RouteCell is null)
+					{
+						continue;
+					}
+
+					var dbRoute = dbRouteCells[cell.Key];
+					foreach (var anchor in cell.RouteCell.ExitAnchors)
+					{
+						dbRoute.ExitAnchors.Add(new Models.RouteExitAnchor
+						{
+							RouteCell = dbRoute,
+							Exit = dbExits[anchor.ExitKey],
+							ExitId = dbExits[anchor.ExitKey].Id,
+							RouteCellId = dbRoute.CellId,
+							MinimumPositionMetres = (decimal)anchor.MinimumPositionMetres,
+							MaximumPositionMetres = (decimal)anchor.MaximumPositionMetres,
+							ArrivalPositionMetres = (decimal)anchor.ArrivalPositionMetres
+						});
+					}
+				}
+
+				foreach (var (zone, index) in preflight.Zones.Select((value, index) => (value, index)))
+				{
+					var zoneKey = SpatialAreaPackageSerializer.ZoneKey(package, zone, index);
+					dbZones[zoneKey].DefaultCell = dbCells[zone.DefaultCellKey];
+				}
+
+				FMDB.Context.SaveChanges();
+				transaction.Commit();
+				databaseCommitted = true;
+			}
+
+			var runtimeZones = new Dictionary<string, Zone>(StringComparer.Ordinal);
+			foreach (var (zone, index) in preflight.Zones.Select((value, index) => (value, index)))
+			{
+				var zoneKey = SpatialAreaPackageSerializer.ZoneKey(package, zone, index);
+				var runtimeZone = new Zone(dbZones[zoneKey], gameworld);
+				runtimeZones.Add(zoneKey, runtimeZone);
+				gameworld.Add(runtimeZone);
+			}
+
+			foreach (var (zone, index) in preflight.Zones.Select((value, index) => (value, index)))
+			{
+				var zoneKey = SpatialAreaPackageSerializer.ZoneKey(package, zone, index);
+				var runtimeZone = runtimeZones[zoneKey];
+				var defaultCell = package.Cells.First(x => x.Key == zone.DefaultCellKey);
+				var roomDefinitions = package.Rooms
+					.Where(x => dbRooms.ContainsKey(x.Key) &&
+					            SpatialAreaPackageSerializer.RoomZoneKey(package, x) == zoneKey)
+					.OrderByDescending(x => x.Key == defaultCell.RoomKey)
+					.ThenBy(x => x.Key);
+				foreach (var roomDefinition in roomDefinitions)
+				{
+					var newRoom = new Room(dbRooms[roomDefinition.Key], runtimeZone);
+					gameworld.Add(newRoom);
+					foreach (var cellDefinition in package.Cells
+						         .Where(x => x.RoomKey == roomDefinition.Key)
+						         .OrderByDescending(x => x.Key == zone.DefaultCellKey)
+						         .ThenBy(x => x.Key))
+					{
+						var newCell = new Cell(dbCells[cellDefinition.Key], newRoom);
+						gameworld.Add(newCell);
+					}
+				}
+
+			}
+
+			foreach (var runtimeZone in runtimeZones.Values)
+			{
+				runtimeZone.PostLoadSetup();
+			}
+
+			var importedZoneIds = runtimeZones.Values.Select(x => x.Id).ToList();
+			return new SpatialAreaTransferResult
+			{
+				Success = true,
+				Summary = $"Imported {runtimeZones.Count:N0} new zone(s): " +
+				          $"{runtimeZones.Values.Select(x => $"{x.Name} (#{x.Id:N0})").ListToString()}. " +
+				          "Existing spatial content was not modified.",
+				PackagePath = preflight.PackagePath,
+				ImportedZoneId = importedZoneIds[0],
+				ImportedZoneIds = importedZoneIds,
+				ZoneCount = runtimeZones.Count,
+				Diagnostics = preflight.Diagnostics,
+				RoomCount = PackagedRoomCount(package),
+				CellCount = package.Cells.Count,
+				ExitCount = package.Exits.Count,
+				OmittedItems = PackageOmissions(preflight)
+			};
+		}
+		catch (Exception ex)
+		{
+			if (databaseCommitted && dbZones.Count > 0)
+			{
+				var committedDiagnostics = preflight.Diagnostics.ToList();
+				var zoneIds = dbZones.Values.Select(x => x.Id).ToList();
+				committedDiagnostics.Add(Error("runtime-load-failed",
+					$"The database import committed as zone(s) {zoneIds.Select(x => $"#{x:N0}").ListToString()}, " +
+					$"but the live server could not register all content: {ex.Message}"));
+				return new SpatialAreaTransferResult
+				{
+					Summary = "The new zones were persisted but are not fully available in memory. Restart the server " +
+					          "before retrying or editing them; do not re-import the package.",
+					PackagePath = preflight.PackagePath,
+					ImportedZoneId = zoneIds[0],
+					ImportedZoneIds = zoneIds,
+					ZoneCount = zoneIds.Count,
+					Diagnostics = committedDiagnostics,
+					RoomCount = PackagedRoomCount(package),
+					CellCount = package.Cells.Count,
+					ExitCount = package.Exits.Count,
+					OmittedItems = PackageOmissions(preflight)
+				};
+			}
+
+			return Failure(
+				$"Import failed before commit: {ex.Message}. The database transaction was rolled back.",
+				preflight.Diagnostics,
+				"import-failed");
+		}
+	}
+
+	private static int PackagedRoomCount(SpatialAreaPackage package)
+	{
+		return package.Cells
+			.Select(x => x.RoomKey)
+			.Distinct(StringComparer.Ordinal)
+			.Count();
+	}
+
+	private static IReadOnlyList<string> PackageOmissions(ImportPreflight preflight)
+	{
+		return (preflight.Package.Omissions ?? [])
+			.Select(x => x.Message)
+			.Concat(preflight.Diagnostics
+				.Where(x => x.Code == "empty-room-skipped")
+				.Select(x => x.Message))
+			.Distinct(StringComparer.InvariantCultureIgnoreCase)
+			.ToList();
+	}
+}

--- a/MudSharpCore/Construction/ImportExport/SpatialAreaTransferService.cs
+++ b/MudSharpCore/Construction/ImportExport/SpatialAreaTransferService.cs
@@ -23,13 +23,15 @@ using MudSharp.Work.Foraging;
 
 namespace MudSharp.Construction.ImportExport;
 
-public sealed class SpatialAreaTransferService : ISpatialAreaTransferService
+public sealed partial class SpatialAreaTransferService : ISpatialAreaTransferService
 {
 	private sealed class ImportPreflight
 	{
 		public required SpatialAreaPackage Package { get; init; }
 		public required string PackagePath { get; init; }
 		public required string ZoneName { get; init; }
+		public required IReadOnlyList<SpatialZoneDefinition> Zones { get; init; }
+		public required IReadOnlyDictionary<string, string> ZoneNames { get; init; }
 		public required ICellOverlayPackage OverlayPackage { get; init; }
 		public required IReadOnlyDictionary<string, ITerrain> Terrains { get; init; }
 		public required IReadOnlyDictionary<string, IHearingProfile> HearingProfiles { get; init; }
@@ -39,6 +41,9 @@ public sealed class SpatialAreaTransferService : ISpatialAreaTransferService
 		public required IReadOnlyDictionary<string, IRangedCover> RangedCovers { get; init; }
 		public required IReadOnlyDictionary<string, IMagicResource> MagicResources { get; init; }
 		public required IReadOnlyDictionary<string, (IClock Clock, IMudTimeZone TimeZone)> TimeZones { get; init; }
+		public required IReadOnlyDictionary<string,
+			IReadOnlyDictionary<string, (IClock Clock, IMudTimeZone TimeZone)>> TimeZonesByZone { get; init; }
+		public required IReadOnlyDictionary<string, IWeatherController?> WeatherControllers { get; init; }
 		public IWeatherController? WeatherController { get; init; }
 		public List<SpatialAreaTransferDiagnostic> Diagnostics { get; } = [];
 	}
@@ -53,170 +58,7 @@ public sealed class SpatialAreaTransferService : ISpatialAreaTransferService
 
 	public SpatialAreaTransferResult ExportZone(IZone zone, string packageFileName)
 	{
-		var diagnostics = new List<SpatialAreaTransferDiagnostic>();
-		if (!TryResolvePackagePath(PackageDirectory, packageFileName, out var packagePath, out var pathError))
-		{
-			return Failure(pathError, diagnostics, "invalid-package-name");
-		}
-
-		if (File.Exists(packagePath))
-		{
-			return Failure(
-				$"A package named '{Path.GetFileName(packagePath)}' already exists. Export never overwrites an existing package.",
-				diagnostics,
-				"package-exists");
-		}
-
-		var rooms = zone.Rooms
-			.OrderBy(x => x.Id)
-			.ToList();
-		var cells = rooms
-			.SelectMany(x => x.Cells)
-			.OrderBy(x => x.Id)
-			.ToList();
-		if (rooms.Count == 0 || cells.Count == 0)
-		{
-			return Failure("The selected zone does not contain any rooms and cells.", diagnostics, "empty-zone");
-		}
-
-		if (rooms.Count > SpatialAreaPackageSerializer.MaximumRooms ||
-		    cells.Count > SpatialAreaPackageSerializer.MaximumCells)
-		{
-			return Failure("The selected zone exceeds the package safety limits.", diagnostics, "zone-too-large");
-		}
-
-		var unsupported = ValidateExportableCells(cells);
-		diagnostics.AddRange(unsupported);
-		if (diagnostics.Any(x => x.Severity == SpatialAreaTransferDiagnosticSeverity.Error))
-		{
-			return new SpatialAreaTransferResult
-			{
-				Summary = "The zone was not exported because it contains unsupported spatial state.",
-				Diagnostics = diagnostics,
-				RoomCount = rooms.Count,
-				CellCount = cells.Count
-			};
-		}
-
-		var roomKeys = rooms
-			.Select((room, index) => (room.Id, Key: $"room-{index + 1:D5}"))
-			.ToDictionary(x => x.Id, x => x.Key);
-		var cellKeys = cells
-			.Select((cell, index) => (cell.Id, Key: $"cell-{index + 1:D5}"))
-			.ToDictionary(x => x.Id, x => x.Key);
-		var cellIds = cellKeys.Keys.ToHashSet();
-
-		var allSeenExits = cells
-			.SelectMany(cell => cell.Gameworld.ExitManager.GetExitsFor(cell, cell.CurrentOverlay))
-			.Select(x => x.Exit)
-			.DistinctBy(x => x.Id)
-			.OrderBy(x => x.Id)
-			.ToList();
-		var missingExitIds = cells
-			.SelectMany(x => x.CurrentOverlay.ExitIDs)
-			.Distinct()
-			.Except(allSeenExits.Select(x => x.Id))
-			.ToList();
-		foreach (var missingExitId in missingExitIds)
-		{
-			diagnostics.Add(Error("missing-source-exit",
-				$"An active overlay references exit #{missingExitId:N0}, but that exit could not be loaded from the source database."));
-		}
-
-		if (missingExitIds.Count > 0)
-		{
-			return new SpatialAreaTransferResult
-			{
-				Summary = "The zone was not exported because its active topology contains invalid exit references.",
-				Diagnostics = diagnostics,
-				RoomCount = rooms.Count,
-				CellCount = cells.Count
-			};
-		}
-
-		var internalExits = allSeenExits
-			.Where(x => x.Cells.All(cell => cellIds.Contains(cell.Id)))
-			.ToList();
-		var boundaryExits = allSeenExits
-			.Where(x => x.Cells.Any(cell => !cellIds.Contains(cell.Id)))
-			.ToList();
-
-		if (internalExits.Count > SpatialAreaPackageSerializer.MaximumExits)
-		{
-			return Failure("The selected zone exceeds the package exit safety limit.", diagnostics, "zone-too-large");
-		}
-
-		if (boundaryExits.Count > 0)
-		{
-			diagnostics.Add(Warning("boundary-exits-omitted",
-				$"{boundaryExits.Count:N0} exit(s) crossing the zone boundary were deliberately omitted. The imported zone will not be linked to unrelated target content."));
-		}
-
-		foreach (var exit in internalExits)
-		{
-			if (exit.Door is not null)
-			{
-				diagnostics.Add(Error("installed-door",
-					$"Exit #{exit.Id:N0} has an installed door item. Door items are not portable in package version 1."));
-			}
-
-			if (exit.FallCell is not null && !cellIds.Contains(exit.FallCell.Id))
-			{
-				diagnostics.Add(Error("external-fall-cell",
-					$"Exit #{exit.Id:N0} falls to cell #{exit.FallCell.Id:N0}, which is outside the package."));
-			}
-		}
-
-		if (diagnostics.Any(x => x.Severity == SpatialAreaTransferDiagnosticSeverity.Error))
-		{
-			return new SpatialAreaTransferResult
-			{
-				Summary = "The zone was not exported because one or more exits require unsupported dependencies.",
-				Diagnostics = diagnostics,
-				RoomCount = rooms.Count,
-				CellCount = cells.Count,
-				ExitCount = internalExits.Count
-			};
-		}
-
-		var exitKeys = internalExits
-			.Select((exit, index) => (exit.Id, Key: $"exit-{index + 1:D5}"))
-			.ToDictionary(x => x.Id, x => x.Key);
-
-		var package = BuildPackage(zone, rooms, cells, internalExits, roomKeys, cellKeys, exitKeys, diagnostics);
-		var json = SpatialAreaPackageSerializer.Serialize(package);
-		if (Encoding.UTF8.GetByteCount(json) > SpatialAreaPackageSerializer.MaximumPackageBytes)
-		{
-			return Failure("The serialized package exceeds the 16 MiB safety limit.", diagnostics, "package-too-large");
-		}
-
-		try
-		{
-			Directory.CreateDirectory(PackageDirectory);
-			using var stream = new FileStream(
-				packagePath,
-				FileMode.CreateNew,
-				FileAccess.Write,
-				FileShare.None);
-			using var writer = new StreamWriter(stream, new UTF8Encoding(false));
-			writer.Write(json);
-		}
-		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-		{
-			return Failure($"The package could not be written: {ex.Message}", diagnostics, "package-write-failed");
-		}
-
-		return new SpatialAreaTransferResult
-		{
-			Success = true,
-			Summary =
-				$"Exported zone '{zone.Name}' as package version {SpatialAreaPackage.CurrentVersion:N0}.",
-			PackagePath = packagePath,
-			Diagnostics = diagnostics,
-			RoomCount = rooms.Count,
-			CellCount = cells.Count,
-			ExitCount = internalExits.Count
-		};
+		return ExportZones([zone], packageFileName);
 	}
 
 	public SpatialAreaTransferResult ValidateImport(
@@ -236,16 +78,19 @@ public sealed class SpatialAreaTransferService : ISpatialAreaTransferService
 			return failure!;
 		}
 
+		var zoneNames = preflight.ZoneNames.Values.ToList();
 		return new SpatialAreaTransferResult
 		{
 			Success = true,
 			Summary =
-				$"Package validation succeeded. Import will create a new zone named '{preflight.ZoneName}' and will not modify existing rooms or zones.",
+				$"Package validation succeeded. Import will create {zoneNames.Count:N0} new zone(s): {zoneNames.ListToString()}. Existing rooms and zones will not be modified.",
 			PackagePath = preflight.PackagePath,
 			Diagnostics = preflight.Diagnostics,
-			RoomCount = preflight.Package.Rooms.Count,
+			ZoneCount = zoneNames.Count,
+			RoomCount = PackagedRoomCount(preflight.Package),
 			CellCount = preflight.Package.Cells.Count,
-			ExitCount = preflight.Package.Exits.Count
+			ExitCount = preflight.Package.Exits.Count,
+			OmittedItems = PackageOmissions(preflight)
 		};
 	}
 
@@ -264,6 +109,11 @@ public sealed class SpatialAreaTransferService : ISpatialAreaTransferService
 		if (preflight is null)
 		{
 			return failure!;
+		}
+
+		if (preflight.Package.Version >= 2)
+		{
+			return ImportVersion2(actor, targetShard, preflight);
 		}
 
 		var package = preflight.Package;
@@ -310,7 +160,10 @@ public sealed class SpatialAreaTransferService : ISpatialAreaTransferService
 					});
 				}
 
-				foreach (var room in package.Rooms)
+				var importedRoomKeys = package.Cells
+					.Select(x => x.RoomKey)
+					.ToHashSet(StringComparer.Ordinal);
+				foreach (var room in package.Rooms.Where(x => importedRoomKeys.Contains(x.Key)))
 				{
 					var dbRoom = new Models.Room
 					{
@@ -465,7 +318,7 @@ public sealed class SpatialAreaTransferService : ISpatialAreaTransferService
 
 			var newZone = new Zone(dbZone, gameworld);
 			gameworld.Add(newZone);
-			foreach (var roomDefinition in package.Rooms)
+			foreach (var roomDefinition in package.Rooms.Where(x => dbRooms.ContainsKey(x.Key)))
 			{
 				var newRoom = new Room(dbRooms[roomDefinition.Key], newZone);
 				gameworld.Add(newRoom);
@@ -485,10 +338,13 @@ public sealed class SpatialAreaTransferService : ISpatialAreaTransferService
 					$"Imported package as new zone '{preflight.ZoneName}' (#{newZone.Id:N0}). Existing spatial content was not modified.",
 				PackagePath = preflight.PackagePath,
 				ImportedZoneId = newZone.Id,
+				ImportedZoneIds = [newZone.Id],
+				ZoneCount = 1,
 				Diagnostics = preflight.Diagnostics,
-				RoomCount = package.Rooms.Count,
+				RoomCount = PackagedRoomCount(package),
 				CellCount = package.Cells.Count,
-				ExitCount = package.Exits.Count
+				ExitCount = package.Exits.Count,
+				OmittedItems = PackageOmissions(preflight)
 			};
 		}
 		catch (Exception ex)
@@ -504,10 +360,13 @@ public sealed class SpatialAreaTransferService : ISpatialAreaTransferService
 						$"The new zone was persisted as #{dbZone.Id:N0}, but is not fully available in memory. Restart the server before retrying or editing it; do not re-import the package.",
 					PackagePath = preflight.PackagePath,
 					ImportedZoneId = dbZone.Id,
+					ImportedZoneIds = [dbZone.Id],
+					ZoneCount = 1,
 					Diagnostics = committedDiagnostics,
-					RoomCount = package.Rooms.Count,
+					RoomCount = PackagedRoomCount(package),
 					CellCount = package.Cells.Count,
-					ExitCount = package.Exits.Count
+					ExitCount = package.Exits.Count,
+					OmittedItems = PackageOmissions(preflight)
 				};
 			}
 
@@ -586,21 +445,44 @@ public sealed class SpatialAreaTransferService : ISpatialAreaTransferService
 		}
 
 		var package = readResult.Package;
-		var zoneName = string.IsNullOrWhiteSpace(zoneNameOverride)
-			? package.Zone.Name
-			: zoneNameOverride.Trim().TitleCase();
-		if (string.IsNullOrWhiteSpace(zoneName))
+		var zones = SpatialAreaPackageSerializer.GetZoneDefinitions(package);
+		if (!string.IsNullOrWhiteSpace(zoneNameOverride) && zones.Count != 1)
 		{
-			diagnostics.Add(Error("invalid-zone-name", "The imported zone must have a non-empty name."));
+			diagnostics.Add(Error("multi-zone-name-override",
+				"A zone-name override can only be used with a single-zone package."));
 		}
 
-		if (actor.Gameworld.Zones.Any(x => x.Name.Equals(zoneName, StringComparison.InvariantCultureIgnoreCase)))
+		var zoneNames = new Dictionary<string, string>(StringComparer.Ordinal);
+		foreach (var (zone, index) in zones.Select((value, index) => (value, index)))
 		{
-			diagnostics.Add(Error("zone-name-collision",
-				$"A zone named '{zoneName}' already exists. Imports never merge into or overwrite an existing zone."));
+			var key = SpatialAreaPackageSerializer.ZoneKey(package, zone, index);
+			var name = zones.Count == 1 && !string.IsNullOrWhiteSpace(zoneNameOverride)
+				? zoneNameOverride.Trim().TitleCase()
+				: zone.Name;
+			zoneNames[key] = name;
+			if (string.IsNullOrWhiteSpace(name))
+			{
+				diagnostics.Add(Error("invalid-zone-name", $"Imported zone '{key}' must have a non-empty name."));
+			}
+
+			if (actor.Gameworld.Zones.Any(x => x.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase)))
+			{
+				diagnostics.Add(Error("zone-name-collision",
+					$"A zone named '{name}' already exists. Imports never merge into or overwrite an existing zone."));
+			}
+
+			ValidateZoneNumbers(zone, diagnostics);
 		}
 
-		ValidateZoneNumbers(package.Zone, diagnostics);
+		var duplicateTargetName = zoneNames.Values
+			.GroupBy(x => x, StringComparer.InvariantCultureIgnoreCase)
+			.FirstOrDefault(x => x.Count() > 1);
+		if (duplicateTargetName is not null)
+		{
+			diagnostics.Add(Error("duplicate-target-zone-name",
+				$"More than one packaged zone would be imported as '{duplicateTargetName.Key}'."));
+		}
+
 		ValidateEnums(package, diagnostics);
 
 		var terrains = ResolveReferences(
@@ -618,7 +500,7 @@ public sealed class SpatialAreaTransferService : ISpatialAreaTransferService
 			diagnostics);
 		var foragableProfiles = ResolveReferences(
 			package.Cells.Select(x => x.ForagableProfile)
-				.Append(package.Zone.ForagableProfile)
+				.Concat(zones.Select(x => x.ForagableProfile))
 				.Where(x => x is not null)
 				.Select(x => x!),
 			actor.Gameworld.ForagableProfiles,
@@ -663,21 +545,38 @@ public sealed class SpatialAreaTransferService : ISpatialAreaTransferService
 			fluids[FluidKey(fluidReference)] = fluid;
 		}
 
-		IWeatherController? weatherController = null;
-		if (package.Zone.WeatherController is not null)
+		var weatherControllers = new Dictionary<string, IWeatherController?>(StringComparer.Ordinal);
+		foreach (var (zone, index) in zones.Select((value, index) => (value, index)))
 		{
-			weatherController = actor.Gameworld.WeatherControllers
-				.FirstOrDefault(x => x.Name.Equals(
-					package.Zone.WeatherController.Name,
-					StringComparison.InvariantCultureIgnoreCase));
-			if (weatherController is null)
+			var key = SpatialAreaPackageSerializer.ZoneKey(package, zone, index);
+			IWeatherController? weatherController = null;
+			if (zone.WeatherController is not null)
 			{
-				diagnostics.Add(Error("missing-weather-controller",
-					$"Required weather controller '{package.Zone.WeatherController.Name}' does not exist in the target installation."));
+				weatherController = actor.Gameworld.WeatherControllers
+					.FirstOrDefault(x => x.Name.Equals(
+						zone.WeatherController.Name,
+						StringComparison.InvariantCultureIgnoreCase));
+				if (weatherController is null)
+				{
+					diagnostics.Add(Error("missing-weather-controller",
+						$"Required weather controller '{zone.WeatherController.Name}' for zone '{zoneNames[key]}' does not exist in the target installation."));
+				}
 			}
+
+			weatherControllers[key] = weatherController;
 		}
 
-		var timeZones = ResolveTimeZones(package.Zone, targetShard, diagnostics);
+		var timeZonesByZone = zones
+			.Select((zone, index) =>
+			{
+				var key = SpatialAreaPackageSerializer.ZoneKey(package, zone, index);
+				return (key, value: (IReadOnlyDictionary<string, (IClock Clock, IMudTimeZone TimeZone)>)
+					ResolveTimeZones(zone, targetShard, diagnostics));
+			})
+			.ToDictionary(x => x.key, x => x.value, StringComparer.Ordinal);
+		var firstZoneKey = SpatialAreaPackageSerializer.ZoneKey(package, zones[0], 0);
+		var timeZones = timeZonesByZone[firstZoneKey];
+		var firstWeatherController = weatherControllers[firstZoneKey];
 		if (diagnostics.Any(x => x.Severity == SpatialAreaTransferDiagnosticSeverity.Error))
 		{
 			failure = new SpatialAreaTransferResult
@@ -685,9 +584,11 @@ public sealed class SpatialAreaTransferService : ISpatialAreaTransferService
 				Summary = "Package validation failed. Nothing was imported.",
 				PackagePath = packagePath,
 				Diagnostics = diagnostics,
-				RoomCount = package.Rooms.Count,
+				ZoneCount = zones.Count,
+				RoomCount = PackagedRoomCount(package),
 				CellCount = package.Cells.Count,
-				ExitCount = package.Exits.Count
+				ExitCount = package.Exits.Count,
+				OmittedItems = package.Omissions?.Select(x => x.Message).ToList() ?? []
 			};
 			return null;
 		}
@@ -696,7 +597,9 @@ public sealed class SpatialAreaTransferService : ISpatialAreaTransferService
 		{
 			Package = package,
 			PackagePath = packagePath,
-			ZoneName = zoneName,
+			ZoneName = zoneNames[firstZoneKey],
+			Zones = zones,
+			ZoneNames = zoneNames,
 			OverlayPackage = actor.CurrentOverlayPackage,
 			Terrains = terrains,
 			HearingProfiles = hearingProfiles,
@@ -706,164 +609,12 @@ public sealed class SpatialAreaTransferService : ISpatialAreaTransferService
 			RangedCovers = covers,
 			MagicResources = magicResources,
 			TimeZones = timeZones,
-			WeatherController = weatherController
+			TimeZonesByZone = timeZonesByZone,
+			WeatherController = firstWeatherController,
+			WeatherControllers = weatherControllers
 		};
 		preflight.Diagnostics.AddRange(diagnostics);
 		return preflight;
-	}
-
-	private static SpatialAreaPackage BuildPackage(
-		IZone zone,
-		IReadOnlyList<IRoom> rooms,
-		IReadOnlyList<ICell> cells,
-		IReadOnlyList<IExit> exits,
-		IReadOnlyDictionary<long, string> roomKeys,
-		IReadOnlyDictionary<long, string> cellKeys,
-		IReadOnlyDictionary<long, string> exitKeys,
-		ICollection<SpatialAreaTransferDiagnostic> diagnostics)
-	{
-		var overlayPackages = cells
-			.Select(x => x.CurrentOverlay.Package)
-			.Distinct()
-			.ToList();
-		if (overlayPackages.Count > 1)
-		{
-			diagnostics.Add(Warning("mixed-overlays",
-				$"The zone uses {overlayPackages.Count:N0} different active overlay packages. Version 1 exports each cell's active overlay data and imports all of it into the selected target package."));
-		}
-
-		var package = new SpatialAreaPackage
-		{
-			CreatedUtc = DateTime.UtcNow,
-			Source = new SpatialAreaPackageSource
-			{
-				ZoneName = zone.Name,
-				ZoneId = zone.Id,
-				ShardName = zone.Shard.Name,
-				ShardId = zone.Shard.Id,
-				OverlayPackageName = overlayPackages.Count == 1 ? overlayPackages[0].Name : "Mixed Active Overlays",
-				OverlayPackageId = overlayPackages.Count == 1 ? overlayPackages[0].Id : 0,
-				OverlayPackageRevision = overlayPackages.Count == 1 ? overlayPackages[0].RevisionNumber : 0
-			},
-			Zone = new SpatialZoneDefinition
-			{
-				Name = zone.Name,
-				LatitudeRadians = zone.Geography.Latitude,
-				LongitudeRadians = zone.Geography.Longitude,
-				ElevationMetres = zone.Geography.Elevation,
-				AmbientLightPollution = zone.AmbientLightPollution,
-				ForagableProfile = Reference(zone.ForagableProfile),
-				WeatherController = Reference(zone.WeatherController),
-				DefaultCellKey = cellKeys[zone.DefaultCell.Id],
-				TimeZones = zone.GetEditableZone.TimeZones
-					.OrderBy(x => x.Key.Alias)
-					.Select(x => new SpatialTimeZoneDefinition
-					{
-						ClockAlias = x.Key.Alias,
-						TimeZoneAlias = x.Value.Alias,
-						TimeZoneDescription = x.Value.Description
-					})
-					.ToList()
-			},
-			Rooms = rooms
-				.OrderByDescending(x => x.Id == zone.DefaultCell.Room.Id)
-				.ThenBy(x => x.Id)
-				.Select(x => new SpatialRoomDefinition
-				{
-					Key = roomKeys[x.Id],
-					SourceId = x.Id,
-					X = x.X,
-					Y = x.Y,
-					Z = x.Z
-				})
-				.ToList()
-		};
-
-		var explicitForagableProfiles = new Dictionary<long, long?>();
-		using (new FMDB())
-		{
-			foreach (var dbCell in FMDB.Context.Cells
-				         .Where(x => cellKeys.Keys.Contains(x.Id))
-				         .Select(x => new { x.Id, x.ForagableProfileId }))
-			{
-				explicitForagableProfiles[dbCell.Id] = dbCell.ForagableProfileId;
-			}
-		}
-
-		package.Cells = cells
-			.OrderByDescending(x => x.Id == zone.DefaultCell.Id)
-			.ThenBy(x => x.Id)
-			.Select(cell =>
-			{
-				var overlay = cell.CurrentOverlay;
-				var explicitForagable = explicitForagableProfiles.GetValueOrDefault(cell.Id);
-				return new SpatialCellDefinition
-				{
-					Key = cellKeys[cell.Id],
-					SourceId = cell.Id,
-					RoomKey = roomKeys[cell.Room.Id],
-					ForagableProfile = explicitForagable.HasValue
-						? Reference(cell.Gameworld.ForagableProfiles.Get(explicitForagable.Value))
-						: null,
-					Tags = cell.Tags.OrderBy(x => x.Name).Select(x => Reference(x)!).ToList(),
-					RangedCovers = cell.LocalCover.OrderBy(x => x.Name).Select(x => Reference(x)!).ToList(),
-					MagicResources = cell.MagicResourceAmounts
-						.OrderBy(x => x.Key.Name)
-						.Select(x => new SpatialMagicResourceDefinition
-						{
-							Resource = Reference(x.Key)!,
-							Amount = x.Value
-						})
-						.ToList(),
-					Overlay = new SpatialCellOverlayDefinition
-					{
-						CellName = overlay.CellName,
-						CellDescription = overlay.CellDescription,
-						Terrain = Reference(overlay.Terrain)!,
-						HearingProfile = Reference(overlay.HearingProfile),
-						Atmosphere = FluidReference(overlay.Atmosphere),
-						OutdoorsType = (int)overlay.OutdoorsType,
-						AmbientLightFactor = overlay.AmbientLightFactor,
-						AddedLight = overlay.AddedLight,
-						SafeQuit = overlay.SafeQuit,
-						ExitKeys = overlay.ExitIDs
-							.Where(exitKeys.ContainsKey)
-							.Select(x => exitKeys[x])
-							.Order()
-							.ToList()
-					}
-				};
-			})
-			.ToList();
-
-		package.Exits = exits
-			.Select(exit =>
-			{
-				var endpoints = exit.Cells.ToList();
-				var side1 = exit.CellExitFor(endpoints[0]);
-				var side2 = exit.CellExitFor(endpoints[1]);
-				return new SpatialExitDefinition
-				{
-					Key = exitKeys[exit.Id],
-					SourceId = exit.Id,
-					Cell1Key = cellKeys[endpoints[0].Id],
-					Cell2Key = cellKeys[endpoints[1].Id],
-					Side1 = BuildExitSide(side1),
-					Side2 = BuildExitSide(side2),
-					TimeMultiplier = exit.TimeMultiplier,
-					AcceptsDoor = exit.AcceptsDoor,
-					DoorSize = (int)exit.DoorSize,
-					MaximumSizeToEnter = (int)exit.MaximumSizeToEnter,
-					MaximumSizeToEnterUpright = (int)exit.MaximumSizeToEnterUpright,
-					IsClimbExit = exit.IsClimbExit,
-					ClimbDifficulty = (int)exit.ClimbDifficulty,
-					FallCellKey = exit.FallCell is null ? null : cellKeys[exit.FallCell.Id],
-					BlockedLayers = exit.BlockedLayers.Select(x => (int)x).Order().ToList()
-				};
-			})
-			.ToList();
-
-		return package;
 	}
 
 	private static SpatialExitSideDefinition BuildExitSide(ICellExit side)
@@ -904,12 +655,6 @@ public sealed class SpatialAreaTransferService : ISpatialAreaTransferService
 						$"Cell #{cell.Id:N0} is temporary and cannot be faithfully imported."));
 				}
 
-				if (cell.RouteDefinition is not null)
-				{
-					diagnostics.Add(Error("route-cell",
-						$"Cell #{cell.Id:N0} is a route cell. Route geometry and anchors are planned for package version 2."));
-				}
-
 				if (cell is Cell concreteCell &&
 				    (concreteCell.HostedVehicleId.HasValue || concreteCell.HostedVehicleCompartmentId.HasValue))
 				{
@@ -920,7 +665,7 @@ public sealed class SpatialAreaTransferService : ISpatialAreaTransferService
 				if (cell.AgricultureField is not null)
 				{
 					diagnostics.Add(Error("agriculture-field",
-						$"Cell #{cell.Id:N0} has an agriculture field, which package version 1 does not carry."));
+						$"Cell #{cell.Id:N0} has an agriculture field, which spatial packages do not carry."));
 				}
 
 				if (persistedCells.TryGetValue(cell.Id, out var dbCell))
@@ -928,13 +673,13 @@ public sealed class SpatialAreaTransferService : ISpatialAreaTransferService
 					if (HasPersistedEffects(dbCell.EffectData))
 					{
 						diagnostics.Add(Error("persisted-cell-effects",
-							$"Cell #{cell.Id:N0} has persisted effects. Version 1 refuses to discard effect state."));
+							$"Cell #{cell.Id:N0} has persisted effects. Spatial packages refuse to discard effect state."));
 					}
 
 					if (HasSurfaceLiquid(dbCell.SurfaceLiquidData))
 					{
 						diagnostics.Add(Error("surface-liquid",
-							$"Cell #{cell.Id:N0} has persistent surface-liquid state, which version 1 does not carry."));
+							$"Cell #{cell.Id:N0} has persistent surface-liquid state, which spatial packages do not carry."));
 					}
 				}
 			}


### PR DESCRIPTION
## Summary
- accept legacy version 1 spatial packages containing stale empty Room rows by warning and skipping those unreferenced rooms
- introduce version 2 multi-zone packages that preserve exits between selected zones with deterministic ID remapping and atomic create-only imports
- export and import route-cell geometry, landmarks, topology versions, and exit anchors
- retain structured omission diagnostics and enumerate omitted boundary exits and other excluded content in-game
- update the builder workflow and spatial-package format documentation

## Root cause verified
The supplied `Hellish_Plains.fmsa.json` contains 623 Room records but 622 Cells. `room-00001` (source Room #3) is an empty stale Room row that the version 1 exporter included before its own validator rejected it. The unchanged supplied package now passes serializer validation with `empty-room-skipped` as a warning.

## Validation
- `dotnet build MudSharpCore/MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510`
- focused `SpatialAreaPackageSerializerTests`: 9/9 passed
- `scripts/test-unit-core.ps1`: 1,996/1,996 passed
- exact attached Hellish Plains package compatibility probe: passed
- `git diff --check`: clean