### PR TITLE
Version update to 2.1.0

### DIFF
--- a/FutureMUD.Web/Content/PatchNotes/2026-07-25-engine-2-1-0.md
+++ b/FutureMUD.Web/Content/PatchNotes/2026-07-25-engine-2-1-0.md
@@ -1,0 +1,29 @@
+---
+title: FutureMUD Engine 2.1.0
+summary: Adds route-cell travel, scheduled vehicles and watercraft support, along with new spatial-area, combat, terrain and builder workflows.
+date: 2026-07-25
+tags: engine, release, upgrade
+---
+**Upgrade note:** Apply the normal database upgrades before starting Engine 2.1.0. This release keeps the .NET 10 and MySQL 8.0 requirements and the Windows x64, Linux x64 and Linux ARM64 package set from Engine 2.0.1.
+
+## Route Travel And Vehicles
+
+Engine 2.1.0 introduces route cells: a new spatial travel layer for roads, railways, waterways and other linear routes. Builders can define routes, landmarks and their connections to normal cells, while players and NPCs can travel along them with route-aware movement, pathfinding, perception and combat.
+
+- Added room-scale vehicle interiors, route-aware vehicles, services and schedules. This supports persistent journeys and platforms for vehicles such as wagons and trains, including safe recovery after a restart.
+- Added water-vehicle movement and propulsion options, including oars, outboard motors, operational checks and aquatic vehicle combat.
+- Added spatial-area transfer packages, so builders can export and import connected map areas with their cells, exits and associated data. Imports can now be applied across multiple zones where the package requires it.
+
+## Combat And Character Creation
+
+- Added multi-target combat actions, allowing appropriately configured attacks to affect more than one target while preserving the normal combat rules and builder configuration.
+- Added configurable suggested skills during character generation, so games can better guide new characters toward suitable choices.
+- Fixed armour condition tracking when an attack is completely absorbed, and fixed a null-result edge case in laser attacks.
+
+## Builder And World Improvements
+
+- Added rooftop-only terrain layers and clearer layer handling for layered locations.
+- Added bulk renaming support for item and NPC prototype unique names, making large builder maintenance changes safer and faster.
+- Expanded the route, vehicle, room-layer, combat and spatial-package builder documentation, together with stronger regression coverage for the new systems.
+
+See `/downloads` for release archives and checksums, `/getting-started` for installation requirements, and `/docs` for the published Engine reference.

--- a/MudSharpCore/MudSharpCore.csproj
+++ b/MudSharpCore/MudSharpCore.csproj
@@ -10,9 +10,9 @@
 	<Product>FutureMUD</Product>
 	<ApplicationIcon>FM Logo.ico</ApplicationIcon>
 	<AssemblyName>MudSharp</AssemblyName>
-	<Version>2.0.1</Version>
-	<AssemblyVersion>2.0.1</AssemblyVersion>
-	<FileVersion>2.0.1</FileVersion>
+	<Version>2.1.0</Version>
+	<AssemblyVersion>2.1.0</AssemblyVersion>
+	<FileVersion>2.1.0</FileVersion>
   </PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
## Summary
- updates the FutureMUD Engine version triplet to 2.1.0
- publishes the Engine 2.1.0 website patch note, including the database-upgrade requirement and supported runtime set

## Validation
- dotnet test 'MudSharpCore Unit Tests/MudSharpCore Unit Tests.csproj' -c Release -m:1 -p:RestoreBuildInParallel=false -p:NuGetAudit=false (2,024 passed)
- dotnet test FutureMUD.Web.Tests/FutureMUD.Web.Tests.csproj -c Release -m:1 -p:RestoreBuildInParallel=false -p:NuGetAudit=false (49 passed)
- Linux x64 framework-dependent, single-file representative publish
- database-free documentation catalogue export validated all five metadata families