### PR TITLE
Allow weapon attacks to target bodypart shapes

### DIFF
--- a/Design Documents/Combat/Combat_Strategy_Runtime.md
+++ b/Design Documents/Combat/Combat_Strategy_Runtime.md
@@ -63,6 +63,8 @@ Melee-family strategies select active attacks through this order:
 3. Weighted attack-mode roll: weapon, natural weapon, magic, psychic, then auxiliary.
 4. Weapon/natural/magic attack selection constrained by combat settings, allowed classifications, preferred/forbidden intentions, stamina, target type, and current melee or clinch state.
 
+A weapon-associated attack may optionally specify a target bodypart shape. Such an attack is usable only against a body with an externally hittable part of that shape, and attack resolution selects one of those matching parts. Attack and defense checks, armour, damage, and recovery otherwise resolve normally.
+
 `SwordAndBoardOnly` is the engine's existing handedness term for weapon-and-shield fighting. A one-handed melee weapon can now select `SwordAndBoardOnly` attacks when the attacker also has a separately wielded shield, and ordinary `OneHandedOnly` attacks remain available in the same loadout. This is what lets shield-line spear attacks coexist with the normal spear thrust suite instead of replacing it.
 
 Auxiliary moves are selected by shared strategy code through `AttemptUseAuxilliaryAction`. The move list comes from the attacker's race combat actions and is filtered by position, intention requirements, forbidden intentions, usability prog, target, and stamina. If the selected channel has authored moves but the actor is too exhausted to pay for any of them, the strategy returns `TooExhaustedMove`.

--- a/MudSharpCore Unit Tests/WeaponAttackTargetingTests.cs
+++ b/MudSharpCore Unit Tests/WeaponAttackTargetingTests.cs
@@ -1,0 +1,56 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Body;
+using MudSharp.Character;
+using MudSharp.Combat;
+using MudSharp.Combat.Moves;
+using MudSharp.Form.Shape;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.RPG.Checks;
+using System.Reflection;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class WeaponAttackTargetingTests
+{
+	[TestMethod]
+	public void MeleeWeaponAttack_AuthoredTargetShape_SelectsMatchingBodypart()
+	{
+		Mock<IBodypartShape> targetShape = new();
+		Mock<IBodypartShape> otherShape = new();
+
+		Mock<IBodypart> matchingPart = new();
+		matchingPart.SetupGet(x => x.Shape).Returns(targetShape.Object);
+		matchingPart.SetupGet(x => x.RelativeHitChance).Returns(1.0);
+
+		Mock<IBodypart> otherPart = new();
+		otherPart.SetupGet(x => x.Shape).Returns(otherShape.Object);
+		otherPart.SetupGet(x => x.RelativeHitChance).Returns(1.0);
+
+		Mock<IBody> targetBody = new();
+		targetBody.SetupGet(x => x.Bodyparts).Returns(new[] { otherPart.Object, matchingPart.Object });
+
+		Mock<ICharacter> target = new();
+		target.SetupGet(x => x.Body).Returns(targetBody.Object);
+
+		Mock<ICharacter> attacker = new();
+		attacker.Setup(x => x.ColocatedWith(target.Object)).Returns(true);
+
+		Mock<IWeaponAttack> attack = new();
+		attack.SetupGet(x => x.BodypartShape).Returns(targetShape.Object);
+		Mock<IMeleeWeapon> weapon = new();
+
+		MeleeWeaponAttack move = new(attacker.Object, weapon.Object, attack.Object, target.Object);
+		Mock<ICombatMove> defense = new();
+		defense.SetupGet(x => x.Assailant).Returns(target.Object);
+
+		typeof(WeaponAttackMove)
+			.GetMethod("DetermineTargetBodypart", BindingFlags.Instance | BindingFlags.NonPublic)!
+			.Invoke(move, new object[] { defense.Object, Outcome.Pass });
+
+		Assert.AreSame(matchingPart.Object, move.TargetBodypart);
+	}
+}

--- a/MudSharpCore/Combat/Moves/WeaponAttackMove.cs
+++ b/MudSharpCore/Combat/Moves/WeaponAttackMove.cs
@@ -892,6 +892,14 @@ public abstract class WeaponAttackMove : CombatMoveBase, IWeaponAttackMove
             return;
         }
 
+        if (Weapon is not null && Attack.BodypartShape is not null)
+        {
+            TargetBodypart = target.Body.Bodyparts
+                                   .Where(x => x.Shape == Attack.BodypartShape && x.RelativeHitChance > 0.0)
+                                   .GetWeightedRandom(x => x.RelativeHitChance);
+            return;
+        }
+
         if (Assailant.TargettedBodypart is not null && !target.Body.Bodyparts.Contains(Assailant.TargettedBodypart))
         {
             Assailant.TargettedBodypart = null;

--- a/MudSharpCore/Combat/WeaponAttack.cs
+++ b/MudSharpCore/Combat/WeaponAttack.cs
@@ -126,6 +126,9 @@ public class WeaponAttack : CombatAction, IWeaponAttack
                (Intentions & (attacker as ICharacter)?.CombatSettings.ForbiddenIntentions ??
                 CombatMoveIntentions.None) == 0 &&
                (ignorePosition || RequiredPositionStates.Contains(attacker.PositionState)) &&
+               (target == null || weapon == null || BodypartShape == null ||
+                target is IHaveABody bodyOwner &&
+                bodyOwner.Body.Bodyparts.Any(x => x.Shape == BodypartShape && x.RelativeHitChance > 0.0)) &&
                (UsabilityProg?.ExecuteBool(attacker, weapon, target) ?? true);
     }
 
@@ -314,6 +317,7 @@ public class WeaponAttack : CombatAction, IWeaponAttack
 	#3prog <prog>#0 - a prog taking character, item, character as parameters and returning a boolean, to determine whether this attack can be used
 	#3onuse <prog|none>#0 - a prog taking character, item, character as parameters that fires when this attack is used
 	#3bodypart <part shape>#0 - sets a bodypart shape this attack is typically associated with, e.g. hand, teeth, etc
+	#3target <part shape|none>#0 - sets or clears the bodypart shape targeted by a weapon-associated attack
 	#3intention <intention1> [<intention2>...<intentionn>]#0 - toggles the specified attack intentions
 	#3damage <name|id>#0 - sets a nominated expression as the damage expression
 	#3stun <name|id>#0 - sets a nominated expression as the stun expression
@@ -349,6 +353,10 @@ public class WeaponAttack : CombatAction, IWeaponAttack
                 return BuildingCommandHandedness(actor, command);
             case "bodypart":
                 return BuildingCommandBodypart(actor, command);
+            case "target":
+            case "targetpart":
+            case "targetbodypart":
+                return BuildingCommandTargetBodypart(actor, command);
             case "damage":
                 return BuildingCommandDamage(actor, command);
             case "pain":
@@ -460,6 +468,45 @@ public class WeaponAttack : CombatAction, IWeaponAttack
         Changed = true;
         actor.OutputHandler.Send(
             $"This attack is now associated with the {shape.Name.Colour(Telnet.Green)} bodypart shape.");
+        return true;
+    }
+
+    private bool BuildingCommandTargetBodypart(ICharacter actor, StringStack command)
+    {
+        if (!Gameworld.WeaponTypes.Any(x => x.Attacks.Contains(this)))
+        {
+            actor.OutputHandler.Send(
+                "This option can only be used while this attack is associated with a weapon type.");
+            return false;
+        }
+
+        if (command.IsFinished)
+        {
+            actor.OutputHandler.Send("Which bodypart shape should this weapon attack target? Use none to clear it.");
+            return false;
+        }
+
+        if (command.PeekSpeech().EqualTo("none"))
+        {
+            BodypartShape = null;
+            Changed = true;
+            actor.OutputHandler.Send("This weapon attack will no longer target a specific bodypart shape.");
+            return true;
+        }
+
+        IBodypartShape shape = long.TryParse(command.PopSpeech(), out long value)
+            ? Gameworld.BodypartShapes.Get(value)
+            : Gameworld.BodypartShapes.GetByName(command.Last);
+        if (shape == null)
+        {
+            actor.OutputHandler.Send("There is no such bodypart shape.");
+            return false;
+        }
+
+        BodypartShape = shape;
+        Changed = true;
+        actor.OutputHandler.Send(
+            $"This weapon attack will now target bodyparts with the {shape.Name.Colour(Telnet.Green)} shape.");
         return true;
     }
 
@@ -835,6 +882,8 @@ public class WeaponAttack : CombatAction, IWeaponAttack
     public string ShowBuilder(ICharacter actor)
     {
         StringBuilder sb = new();
+        bool usesTargetBodypartShape = Gameworld.WeaponTypes.Any(x => x.Attacks.Contains(this)) &&
+                                       this is not IFixedBodypartWeaponAttack;
         sb.AppendLine($"Weapon Attack {Id.ToString("N0", actor)} - {Name}");
         sb.AppendLine($"Weapon Type: {Gameworld.WeaponTypes.FirstOrDefault(x => x.Attacks.Contains(this))?.Name.Colour(Telnet.Green) ?? "None".Colour(Telnet.Red)}");
         sb.AppendLine($"Move Type: {MoveType.Describe().Colour(Telnet.Green)}");
@@ -869,7 +918,7 @@ public class WeaponAttack : CombatAction, IWeaponAttack
         sb.AppendLineColumns((uint)actor.LineFormatLength, 3,
             $"Damage Type: {Enum.GetName(typeof(DamageType), Profile.DamageType).SplitCamelCase().Colour(Telnet.Green)}",
             $"Usability Prog: {(UsabilityProg != null ? $"{UsabilityProg.FunctionName}".FluentTagMXP("send", $"href='show futureprog {UsabilityProg.Id}'") : "None".Colour(Telnet.Red))}",
-            $"Bodypart: {BodypartShape?.Name.Colour(Telnet.Green) ?? "None".Colour(Telnet.Red)}"
+            $"{(usesTargetBodypartShape ? "Target Bodypart" : "Bodypart")}: {BodypartShape?.Name.Colour(Telnet.Green) ?? "None".Colour(Telnet.Red)}"
         );
         sb.AppendLine($"On Use Prog: {(OnUseAttackProg != null ? $"{OnUseAttackProg.FunctionName}".FluentTagMXP("send", $"href='show futureprog {OnUseAttackProg.Id}'") : "None".Colour(Telnet.Red))}");
 		sb.AppendLine($"Maximum Targets: {MaximumTargets.ToString("N0", actor).ColourValue()}");


### PR DESCRIPTION
## Summary

- let weapon-associated attacks optionally target an authored bodypart shape
- filter those attacks out when the target has no externally hittable matching part
- select a matching bodypart during ordinary weapon-attack resolution
- add `target <shape|none>` builder support and expose the target in builder output

## Why

Dead Harbour's Zombie Fighting techniques need special weapon moves that aim at a lethal location. In particular, the automatic level-50 technique dispatches a prone but still-active zombie, while the manual level-70 technique can attempt the same against an active opponent.

FutureMUD already stores an optional `BodypartShapeId` on every weapon attack, but weapon-associated attacks could neither configure nor use it as a target. Reusing that existing nullable field avoids a schema change and leaves its existing natural-attack meaning intact. `DownedMeleeAttack` inherits the updated weapon-attack resolution path, so no zombie-specific or move-specific engine branch is needed.

Targeting does not guarantee success or death: attack and defense rolls, armour, damage, wounds, and recovery continue through the normal combat pipeline.

## Validation

- `git diff --check` passes
- `MeleeWeaponAttack_AuthoredTargetShape_SelectsMatchingBodypart` passes on .NET SDK 10.0.302
- `dotnet build MudSharpCore/MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510` succeeds with 0 warnings and 0 errors
