### PR TITLE
Add vehicle seeder foundation and cross-era catalogue

### DIFF
--- a/DatabaseSeeder Unit Tests/VehicleSeederTests.cs
+++ b/DatabaseSeeder Unit Tests/VehicleSeederTests.cs
@@ -1,0 +1,173 @@
+#nullable enable
+
+using DatabaseSeeder.Seeders;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class VehicleSeederTests
+{
+	private static readonly string[] EraKeys =
+	[
+		"antiquity", "medieval", "renaissance", "earlymodern",
+		"revolution", "modern", "atomic", "computer"
+	];
+
+	[TestMethod]
+	public void VehicleExampleCatalogue_HasThirtyTwoUniqueCrossEraExamples()
+	{
+		var examples = ItemSeeder.VehicleExamplesForTesting;
+		Assert.AreEqual(32, examples.Count);
+		Assert.AreEqual(32, examples.Select(x => x.StableReference)
+			.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+
+		foreach (var era in EraKeys)
+		{
+			var rows = examples.Where(x => x.EraKey.Equals(era, StringComparison.OrdinalIgnoreCase)).ToArray();
+			Assert.AreEqual(4, rows.Length, $"{era} should contain four demonstration vehicles.");
+			Assert.AreEqual(2, rows.Count(x => x.Domain == "Terrestrial"), $"{era} terrestrial coverage");
+			Assert.AreEqual(2, rows.Count(x => x.Domain == "Aquatic"), $"{era} aquatic coverage");
+		}
+
+		foreach (var example in examples)
+		{
+			Assert.IsTrue(
+				Regex.IsMatch(example.StableReference,
+					"^vehicle_(antiquity|medieval|renaissance|earlymodern|revolution|modern|atomic|computer)_[a-z0-9_]+$"),
+				example.StableReference);
+		}
+	}
+
+	[TestMethod]
+	public void VehicleExampleCatalogue_PassesAuthoringValidation()
+	{
+		ItemSeeder.ValidateVehicleExamplesForTesting();
+	}
+
+	[TestMethod]
+	public void VehicleExampleCatalogue_ProvidesOperationalSkeletons()
+	{
+		foreach (var example in ItemSeeder.VehicleExamplesForTesting)
+		{
+			Assert.IsTrue(example.CompartmentCount >= 1, example.StableReference);
+			Assert.IsTrue(example.OccupantSlotCount >= 1, example.StableReference);
+			Assert.AreEqual(1, example.PrimaryControlStationCount, example.StableReference);
+			Assert.IsTrue(example.MovementProfileCount >= 1, example.StableReference);
+			Assert.IsTrue(example.HasDriverSlot, example.StableReference);
+
+			if (example.Domain == "Aquatic")
+			{
+				Assert.IsTrue(example.HasSurfaceWaterMovement, example.StableReference);
+				Assert.IsTrue(example.HasExplicitPropulsion, example.StableReference);
+			}
+			else
+			{
+				Assert.IsFalse(example.HasSurfaceWaterMovement, example.StableReference);
+				Assert.IsFalse(example.HasExplicitPropulsion, example.StableReference);
+			}
+		}
+	}
+
+	[TestMethod]
+	public void VehicleExampleCatalogue_DemonstratesProjectionAndMotorPatterns()
+	{
+		var examples = ItemSeeder.VehicleExamplesForTesting;
+		Assert.IsTrue(examples.Count(x => x.HasCargoProjection) >= 24);
+		Assert.IsTrue(examples.Count(x => x.HasAccessProjection) >= 16);
+
+		var motorExamples = examples.Where(x => x.HasMotorInstallation).ToArray();
+		Assert.AreEqual(4, motorExamples.Length);
+		Assert.IsTrue(motorExamples.All(x => x.Domain == "Aquatic"));
+		Assert.IsTrue(motorExamples.All(x => x.EraKey is "modern" or "atomic" or "computer"));
+	}
+
+	[TestMethod]
+	public void VehicleEraParser_NormalisesFiltersAndDeduplicates()
+	{
+		var parsed = ItemSeeder.ParseVehicleEraTokensForTesting(
+			"Antiquity, medieval medieval earlymodern unknown COMPUTER");
+		CollectionAssert.AreEquivalent(
+			new[] { "antiquity", "medieval", "earlymodern", "computer" },
+			parsed.ToArray());
+		Assert.AreEqual(0, ItemSeeder.ParseVehicleEraTokensForTesting(null).Count);
+		Assert.AreEqual(0, ItemSeeder.ParseVehicleEraTokensForTesting("unknown").Count);
+	}
+
+	[TestMethod]
+	public void VehicleSeeder_IsWiredIntoTheItemSeederHostPipeline()
+	{
+		var source = ReadSource("DatabaseSeeder", "Seeders", "ItemSeeder.Vehicles.Dispatch.cs");
+		StringAssert.Contains(source, "string IDatabaseSeeder.SeedData(");
+		Assert.AreEqual(1, Regex.Matches(source, @"\bSeedVehicleItemsAndPrototypes\(eras\);").Count,
+			"The IDatabaseSeeder host path should invoke the vehicle subcomponent exactly once.");
+	}
+
+	[TestMethod]
+	public void VehicleSeeder_SeedsRequiredSupportEquipmentPatterns()
+	{
+		var seederPath = Path.Combine(SourceRoot(), "DatabaseSeeder", "Seeders");
+		var source = string.Join("\n", Directory.GetFiles(seederPath, "ItemSeeder.Vehicles*.cs")
+			.Select(File.ReadAllText));
+		string[] requiredStableReferences =
+		[
+			"vehicle_preindustrial_wooden_oar",
+			"vehicle_modern_varnished_oar",
+			"vehicle_modern_petrol_outboard_motor",
+			"vehicle_preindustrial_draft_harness",
+			"vehicle_preindustrial_heavy_team_harness",
+			"vehicle_modern_rigid_tow_bar",
+			"vehicle_modern_heavy_rigid_tow_bar",
+			"vehicle_modern_petrol_drive_module",
+			"vehicle_modern_diesel_drive_module",
+			"vehicle_computer_electric_drive_module"
+		];
+		foreach (var stableReference in requiredStableReferences)
+		{
+			StringAssert.Contains(source, $"\"{stableReference}\"", stableReference);
+		}
+	}
+
+	[TestMethod]
+	public void VehicleSeederDesignReference_CoversTheBuilderContract()
+	{
+		var document = ReadSource("Design Documents", "Seeding", "Vehicle_Item_Seeder_Design_Reference.md");
+		string[] requiredHeadings =
+		[
+			"## Runtime Architecture",
+			"## Seeder API and Data Contract",
+			"## Units and Recommended Ranges",
+			"## Propulsion and Movement Patterns",
+			"## Idempotency and Stable Keys",
+			"## Edge Cases and Failure Modes",
+			"## Demonstration Catalogue",
+			"## Authoring Checklist"
+		];
+		foreach (var heading in requiredHeadings)
+		{
+			StringAssert.Contains(document, heading, heading);
+		}
+	}
+
+	private static string ReadSource(params string[] parts)
+	{
+		return File.ReadAllText(Path.Combine(new[] { SourceRoot() }.Concat(parts).ToArray()));
+	}
+
+	private static string SourceRoot()
+	{
+		var directory = new DirectoryInfo(AppContext.BaseDirectory);
+		while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "MudSharp.sln")))
+		{
+			directory = directory.Parent;
+		}
+
+		Assert.IsNotNull(directory, "Could not locate repository root from test output path.");
+		return directory.FullName;
+	}
+}

--- a/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.AdditionalSupport.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.AdditionalSupport.cs
@@ -1,0 +1,162 @@
+#nullable enable
+
+using MudSharp.GameItems;
+using MudSharp.GameItems.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Xml.Linq;
+
+namespace DatabaseSeeder.Seeders;
+
+public partial class ItemSeeder
+{
+	private void EnsureVehicleInstallationSupport(string mountType)
+	{
+		if (mountType.Equals(VehicleLandEngineMountType, StringComparison.OrdinalIgnoreCase))
+		{
+			EnsureVehicleFuelledDriveModules();
+			return;
+		}
+
+		if (mountType.Equals(VehicleElectricDriveMountType, StringComparison.OrdinalIgnoreCase))
+		{
+			EnsureVehicleElectricDriveModule();
+		}
+	}
+
+	private void EnsureVehicleFuelledDriveModules()
+	{
+		var installable = EnsureVehicleComponent(
+			"VehicleSeeder_Installable_LandEngine",
+			"Vehicle Installable",
+			"Turns an item into a removable fuelled drive module for a matching terrestrial vehicle engine bay.",
+			new XElement("Definition",
+				new XElement("MountType", VehicleLandEngineMountType),
+				new XElement("Role", VehiclePropulsionRole),
+				new XElement("MinimumFunctionalCondition", 0.2),
+				new XElement("MinimumMovementCondition", 0.35)).ToString());
+
+		UpsertVehicleEquipmentItem(
+			"vehicle_modern_petrol_drive_module",
+			new VehicleItemSeedSpec(
+				"engine",
+				"a compact petrol vehicle drive module",
+				"A compact cast-metal engine, gearbox and mounting cradle form a single removable drive module. Fuel lines and control linkages terminate in labelled couplings around the frame, while a small integral tank sits behind a guarded filler neck. The unit is arranged for installation in a compatible terrestrial vehicle rather than operation as a free-standing machine.",
+				SizeCategory.Huge,
+				ItemQuality.Standard,
+				185000.0,
+				14500.0m,
+				"mild steel",
+				"Destroyable_HeavyMetal",
+				true),
+			["Functions / Vehicles / Vehicle Equipment / Propulsion Equipment", "Market / Transportation / Vehicle Equipment"],
+			[installable],
+			["LContainer_FuelCan"]);
+
+		UpsertVehicleEquipmentItem(
+			"vehicle_modern_diesel_drive_module",
+			new VehicleItemSeedSpec(
+				"engine",
+				"a heavy diesel vehicle drive module",
+				"A long heavy engine block, reduction gearbox and reinforced mounting cradle are assembled as one removable drive module. Thick fuel lines, a guarded intake and substantial cooling fittings surround the dark-painted machinery. An integral service tank and plainly marked couplings prepare the unit for a compatible lorry, coach or other terrestrial vehicle.",
+				SizeCategory.Enormous,
+				ItemQuality.Standard,
+				620000.0,
+				32000.0m,
+				"mild steel",
+				"Destroyable_HeavyMetal",
+				true),
+			["Functions / Vehicles / Vehicle Equipment / Propulsion Equipment", "Market / Transportation / Vehicle Equipment"],
+			[installable],
+			["LContainer_FuelCan"]);
+	}
+
+	private void EnsureVehicleElectricDriveModule()
+	{
+		var installable = EnsureVehicleComponent(
+			"VehicleSeeder_Installable_ElectricDrive",
+			"Vehicle Installable",
+			"Turns an item into a removable electric drive module for a matching terrestrial vehicle drive bay.",
+			new XElement("Definition",
+				new XElement("MountType", VehicleElectricDriveMountType),
+				new XElement("Role", VehiclePropulsionRole),
+				new XElement("MinimumFunctionalCondition", 0.2),
+				new XElement("MinimumMovementCondition", 0.35)).ToString());
+
+		UpsertVehicleEquipmentItem(
+			"vehicle_computer_electric_drive_module",
+			new VehicleItemSeedSpec(
+				"drive module",
+				"a sealed electric vehicle drive module",
+				"A sealed aluminium housing contains an electric traction motor, reduction gearing and power-control electronics on a rigid mounting frame. Heavy insulated terminals, coolant couplings and a keyed control socket line one face, while a guarded output shaft projects from the other. A removable car battery pack supplies the module's stored electrical power when it is installed in a compatible vehicle.",
+				SizeCategory.Huge,
+				ItemQuality.Good,
+				165000.0,
+				26000.0m,
+				"aluminium",
+				"Destroyable_HeavyMetal",
+				true),
+			["Functions / Vehicles / Vehicle Equipment / Propulsion Equipment", "Market / Transportation / Vehicle Equipment"],
+			[installable],
+			["BatteryPowered_1xCarBattery"]);
+	}
+
+	private void EnsureVehicleTowSupport(VehicleTowPointSeedSpec point)
+	{
+		if (point.TowType.Equals("draft", StringComparison.OrdinalIgnoreCase) && point.MaximumTowedWeight > 5000000.0)
+		{
+			var heavyHarness = EnsureVehicleComponent(
+				"VehicleSeeder_Hitch_HeavyTeamHarness",
+				"HitchGear",
+				"Turns an item into heavy team harness, yoke and traces for large draft vehicles.",
+				new XElement("Definition",
+					new XElement("Roles", HitchGearRole.Yoke | HitchGearRole.Harness | HitchGearRole.Traces),
+					new XElement("MaximumUsers", 8),
+					new XElement("EffortMultiplier", 1.3),
+					new XElement("MaximumTowedWeight", 12000000.0)).ToString());
+			UpsertVehicleEquipmentItem(
+				"vehicle_preindustrial_heavy_team_harness",
+				new VehicleItemSeedSpec(
+					"harness",
+					"a heavy team harness, yoke and traces",
+					"A broad timber yoke, layered leather breast straps and several paired traces form a complete harness for a large draft team. Iron rings and buckles divide the strain among multiple animals, while thick padding protects the principal bearing surfaces. Every junction is overbuilt for slow work under loads too heavy for ordinary cart harness.",
+					SizeCategory.Large,
+					ItemQuality.Good,
+					34000.0,
+					950.0m,
+					"leather",
+					"Destroyable_Misc",
+					true),
+				["Functions / Vehicles / Vehicle Equipment / Hitching Equipment", "Market / Transportation / Vehicle Equipment"],
+				[heavyHarness]);
+		}
+
+		if (point.TowType.Equals("road", StringComparison.OrdinalIgnoreCase) && point.MaximumTowedWeight > 3500000.0)
+		{
+			var heavyTowBar = EnsureVehicleComponent(
+				"VehicleSeeder_Hitch_HeavyTowBar",
+				"HitchGear",
+				"Turns an item into a heavy rigid tow bar for large road vehicles.",
+				new XElement("Definition",
+					new XElement("Roles", HitchGearRole.TowBar),
+					new XElement("MaximumUsers", 2),
+					new XElement("EffortMultiplier", 1.0),
+					new XElement("MaximumTowedWeight", 25000000.0)).ToString());
+			UpsertVehicleEquipmentItem(
+				"vehicle_modern_heavy_rigid_tow_bar",
+				new VehicleItemSeedSpec(
+					"tow bar",
+					"a heavy articulated steel tow bar",
+					"Two deep steel draw arms converge on a massive towing eye through pinned articulated joints. Adjustable vehicle couplings, safety-chain lugs and locking collars are set into the reinforced ends, with load markings stamped beside each fastening. The bar is cumbersome but rated for coaches, lorries and other heavy road vehicles.",
+					SizeCategory.Huge,
+					ItemQuality.Good,
+					86000.0,
+					5600.0m,
+					"mild steel",
+					"Destroyable_HeavyMetal",
+					true),
+				["Functions / Vehicles / Vehicle Equipment / Hitching Equipment", "Market / Transportation / Vehicle Equipment"],
+				[heavyTowBar]);
+		}
+	}
+}

--- a/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Catalogue.Common.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Catalogue.Common.cs
@@ -72,12 +72,16 @@ public partial class ItemSeeder
 		string key,
 		string name,
 		bool requiresAccessClosed,
-		IReadOnlyCollection<VehiclePropulsionSeedSpec> propulsion)
+		IReadOnlyCollection<VehiclePropulsionSeedSpec> propulsion,
+		bool exposesOccupantsToWater = false)
 	{
 		return new VehicleMovementProfileSeedSpec(key, name, VehicleMovementProfileType.CellExit,
-			VehicleMovementEnvironment.SurfaceWater, true, true, 0.0, null, 0.0, string.Empty,
+			VehicleMovementEnvironment.SurfaceWater, exposesOccupantsToWater, true, 0.0, null, 0.0, string.Empty,
 			true, requiresAccessClosed, 0.0, RouteVehiclePropulsionMode.Powered, 0.0, 0.0, false, propulsion);
 	}
+
+	internal static bool WaterMovementProtectsOccupantsByDefaultForTesting =>
+		!WaterMovement("test", "test", false, []).ExposesOccupantsToWater;
 
 	private static VehiclePropulsionSeedSpec SelfPoweredProfile(bool isDefault)
 	{

--- a/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Catalogue.Common.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Catalogue.Common.cs
@@ -1,0 +1,180 @@
+#nullable enable
+
+using MudSharp.GameItems;
+using MudSharp.RPG.Checks;
+using MudSharp.Vehicles;
+using System;
+using System.Collections.Generic;
+
+namespace DatabaseSeeder.Seeders;
+
+public partial class ItemSeeder
+{
+	private static VehicleItemSeedSpec Exterior(
+		string noun,
+		string shortDescription,
+		string fullDescription,
+		SizeCategory size,
+		ItemQuality quality,
+		double weight,
+		decimal cost,
+		string material,
+		string destroyable,
+		bool portable)
+	{
+		return new VehicleItemSeedSpec(noun, shortDescription, fullDescription, size, quality, weight, cost, material,
+			destroyable, portable);
+	}
+
+	private static VehicleItemSeedSpec Projection(
+		string noun,
+		string shortDescription,
+		string fullDescription,
+		SizeCategory size,
+		string material,
+		string destroyable)
+	{
+		return new VehicleItemSeedSpec(noun, shortDescription, fullDescription, size, ItemQuality.Standard, 1.0, 0.0m,
+			material, destroyable, false, false, true);
+	}
+
+	private static VehicleMovementProfileSeedSpec LandMovement(
+		string key,
+		string name,
+		string? fuelLiquid,
+		double fuelPerMove,
+		double requiredPower,
+		string requiredRole,
+		bool requiresAccessClosed)
+	{
+		return new VehicleMovementProfileSeedSpec(key, name, VehicleMovementProfileType.CellExit,
+			VehicleMovementEnvironment.Unrestricted, false, true, requiredPower, fuelLiquid, fuelPerMove, requiredRole,
+			true, requiresAccessClosed, 0.0, RouteVehiclePropulsionMode.Powered, 0.0, 0.0, false, []);
+	}
+
+	private static VehicleMovementProfileSeedSpec RouteMovement(
+		string key,
+		string name,
+		RouteVehiclePropulsionMode mode,
+		double speedMetresPerSecond,
+		string? fuelLiquid,
+		double fuelPerMetre,
+		double powerDrawWatts,
+		bool automatic)
+	{
+		return new VehicleMovementProfileSeedSpec(key, name, VehicleMovementProfileType.Route,
+			VehicleMovementEnvironment.Unrestricted, false, true, 0.0, fuelLiquid, 0.0,
+			mode == RouteVehiclePropulsionMode.Powered ? VehiclePropulsionRole : string.Empty,
+			true, true, speedMetresPerSecond, mode, fuelPerMetre, powerDrawWatts, automatic, []);
+	}
+
+	private static VehicleMovementProfileSeedSpec WaterMovement(
+		string key,
+		string name,
+		bool requiresAccessClosed,
+		IReadOnlyCollection<VehiclePropulsionSeedSpec> propulsion)
+	{
+		return new VehicleMovementProfileSeedSpec(key, name, VehicleMovementProfileType.CellExit,
+			VehicleMovementEnvironment.SurfaceWater, true, true, 0.0, null, 0.0, string.Empty,
+			true, requiresAccessClosed, 0.0, RouteVehiclePropulsionMode.Powered, 0.0, 0.0, false, propulsion);
+	}
+
+	private static VehiclePropulsionSeedSpec SelfPoweredProfile(bool isDefault)
+	{
+		return new VehiclePropulsionSeedSpec(VehiclePropulsionType.SelfPowered, isDefault, 8500.0,
+			["Swimming", "Rowing", "Athletics"], Difficulty.Normal,
+			"1.0 + (0.15 * outcome)", "max(0.5, swimcost * (1.0 - (0.05 * outcome)))");
+	}
+
+	private static VehiclePropulsionSeedSpec RowedProfile(bool isDefault)
+	{
+		return new VehiclePropulsionSeedSpec(VehiclePropulsionType.Rowed, isDefault, 9000.0,
+			["Rowing", "Swimming", "Athletics"], Difficulty.Normal,
+			"1.0 + (0.15 * outcome)", "max(0.5, swimcost * (1.0 - (0.05 * outcome)))");
+	}
+
+	private static VehiclePropulsionSeedSpec SailProfile(bool isDefault)
+	{
+		return new VehiclePropulsionSeedSpec(VehiclePropulsionType.Sail, isDefault, 7800.0, [], Difficulty.Normal,
+			"0.4 + (0.2 * wind)", "0.0");
+	}
+
+	private static VehiclePropulsionSeedSpec OutboardProfile(bool isDefault)
+	{
+		return new VehiclePropulsionSeedSpec(VehiclePropulsionType.OutboardMotor, isDefault, 5200.0, [], Difficulty.Easy,
+			"max(0.25, output)", "0.0");
+	}
+
+	private static IReadOnlyCollection<VehicleDamageZoneSeedSpec> LandDamageZones(string movementKey, double massHint)
+	{
+		return
+		[
+			new VehicleDamageZoneSeedSpec("frame", "frame and body", "Damage to the principal frame can disable or destroy the whole vehicle.",
+				Math.Clamp(massHint / 10000.0, 120.0, 1200.0), 3.0, 0.65, 1.0, true, 0,
+				[new VehicleDamageEffectSeedSpec(VehicleDamageEffectTargetType.WholeVehicleMovement, null, VehicleSystemStatus.Disabled)]),
+			new VehicleDamageZoneSeedSpec("running_gear", "wheels and running gear", "Damage to the wheels, axle or running gear prevents controlled travel.",
+				Math.Clamp(massHint / 25000.0, 80.0, 500.0), 2.0, 0.55, 1.0, false, 1,
+				[new VehicleDamageEffectSeedSpec(VehicleDamageEffectTargetType.MovementProfile, movementKey, VehicleSystemStatus.Disabled)])
+		];
+	}
+
+	private static IReadOnlyCollection<VehicleDamageZoneSeedSpec> PoweredLandDamageZones(string movementKey, string installationKey)
+	{
+		return
+		[
+			new VehicleDamageZoneSeedSpec("body", "body and chassis", "Serious structural damage compromises the vehicle as a whole.",
+				500.0, 3.0, 0.7, 1.0, true, 0,
+				[new VehicleDamageEffectSeedSpec(VehicleDamageEffectTargetType.WholeVehicleMovement, null, VehicleSystemStatus.Disabled)]),
+			new VehicleDamageZoneSeedSpec("running_gear", "wheels and running gear", "Damage to wheels, suspension or steering prevents controlled road movement.",
+				300.0, 2.0, 0.55, 1.0, false, 1,
+				[new VehicleDamageEffectSeedSpec(VehicleDamageEffectTargetType.MovementProfile, movementKey, VehicleSystemStatus.Disabled)]),
+			new VehicleDamageZoneSeedSpec("drive", "drive module and mount", "Damage around the drive bay can disable the installed propulsion module.",
+				220.0, 1.5, 0.55, 1.0, false, 2,
+				[new VehicleDamageEffectSeedSpec(VehicleDamageEffectTargetType.InstallationPoint, installationKey, VehicleSystemStatus.Disabled)])
+		];
+	}
+
+	private static IReadOnlyCollection<VehicleDamageZoneSeedSpec> WaterDamageZones(string movementKey, string? installationKey)
+	{
+		IReadOnlyCollection<VehicleDamageEffectSeedSpec> installationEffects = string.IsNullOrWhiteSpace(installationKey)
+			? Array.Empty<VehicleDamageEffectSeedSpec>()
+			: [new VehicleDamageEffectSeedSpec(VehicleDamageEffectTargetType.InstallationPoint, installationKey, VehicleSystemStatus.Disabled)];
+		return
+		[
+			new VehicleDamageZoneSeedSpec("hull", "hull", "Hull damage threatens buoyancy and eventually prevents all movement.",
+				420.0, 4.0, 0.7, 1.0, true, 0,
+				[new VehicleDamageEffectSeedSpec(VehicleDamageEffectTargetType.WholeVehicleMovement, null, VehicleSystemStatus.Disabled)]),
+			new VehicleDamageZoneSeedSpec("propulsion", "propulsion fittings", "Damage to propulsion fittings prevents the selected movement system from working.",
+				180.0, 1.5, 0.55, 1.0, false, 1,
+				installationEffects.Count > 0
+					? installationEffects
+					: [new VehicleDamageEffectSeedSpec(VehicleDamageEffectTargetType.MovementProfile, movementKey, VehicleSystemStatus.Disabled)])
+		];
+	}
+
+	private static IReadOnlyCollection<VehicleDamageZoneSeedSpec> SailDamageZones(
+		string movementKey,
+		string accessKey,
+		string? cargoKey)
+	{
+		var holdEffects = new List<VehicleDamageEffectSeedSpec>
+		{
+			new(VehicleDamageEffectTargetType.AccessPoint, accessKey, VehicleSystemStatus.Disabled)
+		};
+		if (!string.IsNullOrWhiteSpace(cargoKey))
+		{
+			holdEffects.Add(new VehicleDamageEffectSeedSpec(VehicleDamageEffectTargetType.CargoSpace, cargoKey, VehicleSystemStatus.Disabled));
+		}
+		return
+		[
+			new VehicleDamageZoneSeedSpec("hull", "hull", "Serious hull damage compromises buoyancy and the vessel as a whole.",
+				900.0, 4.0, 0.7, 1.0, true, 0,
+				[new VehicleDamageEffectSeedSpec(VehicleDamageEffectTargetType.WholeVehicleMovement, null, VehicleSystemStatus.Disabled)]),
+			new VehicleDamageZoneSeedSpec("rig", "mast, sails and rigging", "Damage to the sailing rig prevents effective propulsion.",
+				420.0, 2.0, 0.55, 1.0, false, 1,
+				[new VehicleDamageEffectSeedSpec(VehicleDamageEffectTargetType.MovementProfile, movementKey, VehicleSystemStatus.Disabled)]),
+			new VehicleDamageZoneSeedSpec("hold", "hold and hatch", "Damage around the hold can jam its hatch or make cargo inaccessible.",
+				300.0, 1.0, 0.6, 1.0, false, 2, holdEffects)
+		];
+	}
+}

--- a/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Catalogue.Examples.Modern.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Catalogue.Examples.Modern.cs
@@ -1,0 +1,162 @@
+#nullable enable
+
+using MudSharp.GameItems;
+using MudSharp.RPG.Checks;
+using MudSharp.Vehicles;
+using System;
+using System.Collections.Generic;
+
+namespace DatabaseSeeder.Seeders;
+
+public partial class ItemSeeder
+{
+	private static IReadOnlyList<VehicleSeedSpec> RevolutionVehicleExamples()
+	{
+		return
+		[
+			CreateDraftCargoVehicle(
+				"vehicle_revolution_horse_tram", "revolution", "Horse Tramcar",
+				"A rail-guided passenger tramcar intended to be hauled by a horse or mule.",
+				"tramcar", "a varnished horse-drawn tramcar",
+				"A long enclosed passenger body stands on flanged iron wheels beneath a clerestory roof. Glazed windows line both sides, with narrow end platforms for the driver and conductor. A reinforced drawbar projects from the leading platform, allowing a horse or mule to haul the car steadily along prepared rails.",
+				SizeCategory.Gigantic, ItemQuality.Good, 3200000.0, 21000.0m, "oak", "Destroyable_WoodenHeavy",
+				VehicleScale.RoomContainer, 18, true, true, 7000000.0, 1.0,
+				"under-seat luggage bay", "A long shallow luggage space runs beneath the passenger benches.",
+				"HorseTram"),
+			CreateDraftCargoVehicle(
+				"vehicle_revolution_factory_delivery_wagon", "revolution", "Factory Delivery Wagon",
+				"A strong iron-braced wagon for regular commercial deliveries.",
+				"wagon", "an iron-braced factory delivery wagon",
+				"A rectangular plank body sits on a sprung four-wheel chassis strengthened with wrought-iron brackets. Hinged rear boards and a canvas tilt protect stacked crates while permitting rapid loading at a warehouse dock. The driver's bench, brake lever and paired draft shafts are worn smooth by repetitive commercial service.",
+				SizeCategory.Enormous, ItemQuality.Standard, 1350000.0, 7800.0m, "oak", "Destroyable_WoodenHeavy",
+				VehicleScale.RoomContainer, 2, true, false, 10000000.0, 1.0,
+				"delivery compartment", "The high-sided delivery body is covered by a canvas tilt and closed by hinged rear boards.",
+				"IndustrialWagon"),
+			CreatePaddleCraft(
+				"vehicle_revolution_canal_skiff", "revolution", "Canal Skiff",
+				"A flat-bottomed work skiff for canals, docks and sheltered rivers.",
+				"skiff", "a flat-bottomed canal skiff",
+				"A broad flat bottom and nearly vertical sides give this open skiff generous carrying room at shallow draught. Two rowing thwarts, iron rowlocks and a squared working bow suit quiet water and frequent contact with wharves. Tarred seams and replaceable rubbing boards emphasise durability over elegance.",
+				SizeCategory.Enormous, ItemQuality.Standard, 520000.0, 2600.0m, "pine", "Destroyable_WoodenHeavy",
+				VehicleScale.ItemScale, VehiclePropulsionType.Rowed, 1, 2, false, true, "CanalSkiff"),
+			CreateSailCraft(
+				"vehicle_revolution_sailing_cutter", "revolution", "Sailing Cutter",
+				"A fast fore-and-aft-rigged cutter for patrol, dispatch and pilotage.",
+				"cutter", "a sharp-lined sailing cutter",
+				"A deep narrow hull carries a tall mast, a long bowsprit and a powerful spread of fore-and-aft canvas. The deck is kept clear around a small hatch and low aft cabin, with running rigging led neatly to belaying points near the helm. Copper-toned sheathing at the waterline and a fine entry suggest sustained speed and hard coastal service.",
+				SizeCategory.Titanic, ItemQuality.Good, 7200000.0, 41000.0m, "oak", "Destroyable_WoodenHeavy",
+				VehicleScale.RoomContainer, 8, 4, true, "SailingCutter"),
+		];
+	}
+
+	private static IReadOnlyList<VehicleSeedSpec> ModernVehicleExamples()
+	{
+		return
+		[
+			CreatePoweredRoadVehicle(
+				"vehicle_modern_petrol_touring_car", "modern", "Petrol Touring Car",
+				"A steel-bodied touring car powered by a removable petrol drive module.",
+				"car", "a steel-bodied petrol touring car",
+				"A long bonnet, separate mudguards and a compact enclosed cabin define this early mass-produced touring car. Painted steel panels cover a ladder chassis, while broad running boards connect the front and rear doors. A steering wheel, mechanical controls and a rear luggage deck complete a practical road vehicle built for four occupants.",
+				SizeCategory.Gigantic, ItemQuality.Standard, 1250000.0, 18500.0m, "mild steel", "Destroyable_HeavyMetal",
+				VehicleScale.RoomContainer, 4, true, false, "gasoline", 0.18, 0.0, VehicleLandEngineMountType,
+				false, false, 0.0, 0.0, "TouringCar"),
+			CreatePoweredRoadVehicle(
+				"vehicle_modern_diesel_delivery_lorry", "modern", "Diesel Delivery Lorry",
+				"A rigid commercial lorry with an enclosed cargo body and diesel drive module.",
+				"lorry", "a box-bodied diesel delivery lorry",
+				"A forward steel cab sits ahead of a long rectangular cargo body on a heavy ladder frame. Twin rear wheels, leaf springs and a broad loading door reveal the vehicle's commercial purpose. The plain painted panels carry scuffs and repairs around the corners, while mirrors and lamps bracket the upright cab.",
+				SizeCategory.Titanic, ItemQuality.Standard, 5200000.0, 49000.0m, "mild steel", "Destroyable_HeavyMetal",
+				VehicleScale.RoomContainer, 2, true, false, "diesel", 0.5, 0.0, VehicleLandEngineMountType,
+				false, false, 0.0, 0.0, "DeliveryLorry"),
+			CreatePaddleCraft(
+				"vehicle_modern_aluminium_dinghy", "modern", "Aluminium Dinghy",
+				"A light riveted dinghy for rowing, fishing and short shore work.",
+				"dinghy", "a riveted aluminium dinghy",
+				"Pressed aluminium panels form a light open hull with a shallow vee and broad transom. Three bench seats brace the sides, while fitted rowlocks and a reinforced stern permit either oars or a small motor. Dull oxidation, shallow dents and replaceable rubbing strips give it the appearance of durable utility equipment.",
+				SizeCategory.Enormous, ItemQuality.Standard, 135000.0, 3400.0m, "aluminium", "Destroyable_Misc",
+				VehicleScale.ItemScale, VehiclePropulsionType.Rowed, 1, 2, false, true, "AluminiumDinghy"),
+			CreateMotorCraft(
+				"vehicle_modern_petrol_motor_launch", "modern", "Petrol Motor Launch",
+				"A compact open launch prepared for an outboard motor and sheltered-water service.",
+				"launch", "a compact petrol motor launch",
+				"A hard-chined painted hull surrounds an open cockpit with two bench seats and a small forward locker. The transom is heavily reinforced for an outboard motor, and simple wheel-and-cable steering leads to the stern. Cleats, grab rails and a low spray screen equip the launch for practical transport rather than luxury.",
+				SizeCategory.Gigantic, ItemQuality.Standard, 780000.0, 12500.0m, "mild steel", "Destroyable_HeavyMetal",
+				VehicleScale.RoomContainer, 5, true, "MotorLaunch"),
+		];
+	}
+
+	private static IReadOnlyList<VehicleSeedSpec> AtomicVehicleExamples()
+	{
+		return
+		[
+			CreatePoweredRoadVehicle(
+				"vehicle_atomic_family_saloon", "atomic", "Family Saloon",
+				"A rounded steel family saloon with a petrol drive module and enclosed boot.",
+				"car", "a rounded family saloon",
+				"Smooth pressed-steel panels enclose a broad passenger cabin beneath a single curved roof. Four doors, upholstered bench seats and a separate rear boot make the car plainly domestic, while chrome trim and a wide radiator grille provide restrained ornament. The suspension and controls favour easy road use over sporting performance.",
+				SizeCategory.Gigantic, ItemQuality.Good, 1420000.0, 23500.0m, "mild steel", "Destroyable_HeavyMetal",
+				VehicleScale.RoomContainer, 5, true, false, "gasoline", 0.16, 0.0, VehicleLandEngineMountType,
+				false, false, 0.0, 0.0, "FamilySaloon"),
+			CreatePoweredRoadVehicle(
+				"vehicle_atomic_intercity_coach", "atomic", "Intercity Coach",
+				"A long diesel passenger coach designed for scheduled route service.",
+				"coach", "a long diesel intercity coach",
+				"A monocoque steel body stretches over closely spaced passenger windows and two broad axles. Folding entry doors open beside the driver's position, while rows of high-backed seats stand above underfloor luggage lockers. Destination panels, roof vents and substantial bumpers identify a vehicle intended for repeated scheduled journeys.",
+				SizeCategory.Titanic, ItemQuality.Standard, 11800000.0, 98000.0m, "mild steel", "Destroyable_HeavyMetal",
+				VehicleScale.RoomContainer, 36, true, true, "diesel", 0.0, 0.0, VehicleLandEngineMountType,
+				false, true, 18.0, 0.00008, "IntercityCoach"),
+			CreateMotorCraft(
+				"vehicle_atomic_fiberglass_runabout", "atomic", "Fiberglass Runabout",
+				"A small planing runabout with a moulded hull and outboard mounting.",
+				"runabout", "a bright fiberglass runabout",
+				"A glossy moulded hull sweeps back from a flared bow to a reinforced outboard transom. A wraparound windscreen shelters the wheel and forward seats, with a padded bench spanning the cockpit behind them. Stainless fittings, vinyl upholstery and a shallow planing bottom give the craft a distinctly recreational character.",
+				SizeCategory.Gigantic, ItemQuality.Good, 720000.0, 16800.0m, "fiberglass", "Destroyable_Misc",
+				VehicleScale.RoomContainer, 5, false, "Runabout"),
+			CreateMotorCraft(
+				"vehicle_atomic_cabin_cruiser", "atomic", "Cabin Cruiser",
+				"A compact leisure cruiser with an enclosed cabin, cockpit and outboard installation.",
+				"cruiser", "a compact fiberglass cabin cruiser",
+				"A moulded white hull supports an open aft cockpit and a low enclosed cabin beneath a raked windscreen. Stainless rails follow the foredeck, while cushioned seating and a small covered berth make the boat suitable for overnight coastal trips. The broad stern carries a reinforced motor well and a narrow swim platform.",
+				SizeCategory.Titanic, ItemQuality.Good, 3400000.0, 52000.0m, "fiberglass", "Destroyable_Misc",
+				VehicleScale.RoomContainer, 7, true, "CabinCruiser"),
+		];
+	}
+
+	private static IReadOnlyList<VehicleSeedSpec> ComputerVehicleExamples()
+	{
+		return
+		[
+			CreatePoweredRoadVehicle(
+				"vehicle_computer_electric_city_car", "computer", "Electric City Car",
+				"A compact aluminium city car powered by a removable electric drive module.",
+				"car", "a compact electric city car",
+				"A short aluminium body encloses a tall four-seat cabin with a steep windscreen and minimal overhangs. Flush lamps, simple door handles and a sealed nose replace the openings expected on a combustion vehicle. A digital instrument panel faces the driver, while a rear hatch opens onto a small but regular load space.",
+				SizeCategory.Gigantic, ItemQuality.Good, 1380000.0, 42000.0m, "aluminium", "Destroyable_HeavyMetal",
+				VehicleScale.RoomContainer, 4, true, false, null, 0.0, 650.0, VehicleElectricDriveMountType,
+				false, false, 0.0, 0.0, "ElectricCityCar"),
+			CreatePoweredRoadVehicle(
+				"vehicle_computer_autonomous_shuttle", "computer", "Autonomous Shuttle",
+				"A low-speed electric passenger shuttle approved for automatic route operation.",
+				"shuttle", "a windowed autonomous electric shuttle",
+				"A boxy aluminium passenger pod rides on four small enclosed wheels beneath a roof crowded with cameras and range sensors. Wide sliding doors open onto a level floor and facing bench seats, with only a compact manual control console interrupting the cabin. External status lights and destination displays make its route-service role immediately apparent.",
+				SizeCategory.Titanic, ItemQuality.Good, 4200000.0, 86000.0m, "aluminium", "Destroyable_HeavyMetal",
+				VehicleScale.RoomContainer, 12, true, true, null, 0.0, 0.0, VehicleElectricDriveMountType,
+				true, true, 8.0, 35.0, "AutonomousShuttle"),
+			CreatePaddleCraft(
+				"vehicle_computer_recreational_kayak", "computer", "Recreational Kayak",
+				"A moulded sit-in kayak for one paddler and light personal gear.",
+				"kayak", "a moulded recreational kayak",
+				"A slender moulded hull surrounds a single keyhole cockpit with an adjustable seat and foot braces. Deck lines cross the pointed bow and stern, and a sealed hatch gives access to a small dry compartment. The shallow vee, modest rocker and scuffed underside suit calm rivers, lakes and sheltered coasts.",
+				SizeCategory.VeryLarge, ItemQuality.Good, 24000.0, 1800.0m, "fiberglass", "Destroyable_Misc",
+				VehicleScale.ItemScale, VehiclePropulsionType.SelfPowered, 1, 0, true, false, "Kayak"),
+			CreateMotorCraft(
+				"vehicle_computer_rescue_rib", "computer", "Rescue Rigid-Inflatable Boat",
+				"A fast rescue boat with a rigid hull, buoyant collar and outboard installation.",
+				"boat", "a high-visibility rescue rigid-inflatable boat",
+				"A deep-vee rigid hull is wrapped by a thick segmented buoyancy collar with grab lines along both sides. A central steering console, shock-mitigating seats and an open working deck leave room for crew and casualties. Reinforced lifting points, navigation lights and a broad outboard transom equip the craft for rapid rescue work in difficult water.",
+				SizeCategory.Titanic, ItemQuality.Good, 1850000.0, 76000.0m, "fiberglass", "Destroyable_Misc",
+				VehicleScale.RoomContainer, 8, true, "RescueRIB")
+		];
+	}
+}

--- a/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Catalogue.Examples.PreIndustrial.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Catalogue.Examples.PreIndustrial.cs
@@ -1,0 +1,188 @@
+#nullable enable
+
+using MudSharp.GameItems;
+using MudSharp.RPG.Checks;
+using MudSharp.Vehicles;
+using System;
+using System.Collections.Generic;
+
+namespace DatabaseSeeder.Seeders;
+
+public partial class ItemSeeder
+{
+	private const string VehicleLandEngineMountType = "land_engine";
+	private const string VehicleElectricDriveMountType = "electric_drive";
+
+	private static readonly IReadOnlyList<VehicleSeedSpec> VehicleExampleSpecs = BuildVehicleExampleSpecs();
+
+	private static IReadOnlyList<VehicleSeedSpec> BuildVehicleExampleSpecs()
+	{
+		return
+		[
+			.. AntiquityVehicleExamples(),
+			.. MedievalVehicleExamples(),
+			.. RenaissanceVehicleExamples(),
+			.. EarlyModernVehicleExamples(),
+			.. RevolutionVehicleExamples(),
+			.. ModernVehicleExamples(),
+			.. AtomicVehicleExamples(),
+			.. ComputerVehicleExamples()
+		];
+	}
+
+	private static IReadOnlyList<VehicleSeedSpec> AntiquityVehicleExamples()
+	{
+		return
+		[
+			CreateDraftCargoVehicle(
+				"vehicle_antiquity_two_wheeled_handcart", "antiquity", "Hand-Pulled Cart",
+				"A narrow two-wheeled cart built for a single porter or a small draft animal.",
+				"handcart", "a narrow two-wheeled handcart",
+				"A pair of tall wooden wheels flanks a narrow plank bed, with long shafts projecting forward for a porter or small draft animal. Pegged joints, rawhide lashings and a low rail keep modest loads secure without adding much weight. The axle and wheel hubs are darkened by grease and road dust.",
+				SizeCategory.Huge, ItemQuality.Standard, 95000.0, 420.0m, "oak", "Destroyable_WoodenHeavy",
+				VehicleScale.ItemScale, 0, false, false, 750000.0, 1.35,
+				"open load bed", "The cart's shallow plank bed is open above and bounded by low wooden rails.",
+				"OpenCart"),
+			CreateDraftCargoVehicle(
+				"vehicle_antiquity_heavy_ox_wagon", "antiquity", "Heavy Ox Wagon",
+				"A broad four-wheeled wagon intended for slow, heavy overland haulage.",
+				"wagon", "a broad timber ox wagon",
+				"Four thick wooden wheels support a broad, deeply railed wagon bed. A heavy pole and yoke fittings project from the front axle, while iron straps bind the most highly stressed joints. The body is deliberately massive and plain, suited to sacks, amphorae and timber rather than speed.",
+				SizeCategory.Enormous, ItemQuality.Standard, 650000.0, 2400.0m, "oak", "Destroyable_WoodenHeavy",
+				VehicleScale.RoomContainer, 2, false, false, 5000000.0, 1.1,
+				"wagon bed", "The wagon bed forms a broad open platform enclosed by waist-high slatted sides.",
+				"DraftWagon"),
+			CreatePaddleCraft(
+				"vehicle_antiquity_reed_coracle", "antiquity", "Reed Coracle",
+				"A light basket-framed coracle for sheltered water and river crossings.",
+				"coracle", "a round hide-covered reed coracle",
+				"A shallow round basket of bundled reeds and flexible ribs has been drawn tight beneath a dark waterproof hide. A simple thwart crosses the centre, leaving just enough room for one paddler and a compact bundle. The little craft is light enough to beach or carry, but its broad flat bottom promises lively handling in rough water.",
+				SizeCategory.VeryLarge, ItemQuality.Standard, 32000.0, 180.0m, "reed", "Destroyable_Misc",
+				VehicleScale.ItemScale, VehiclePropulsionType.SelfPowered, 1, 0, true, false, "PaddleCraft"),
+			CreateSailCraft(
+				"vehicle_antiquity_coastal_sailing_boat", "antiquity", "Coastal Sailing Boat",
+				"A broad-bellied coastal trader driven by a single square sail and steering oars.",
+				"boat", "a broad cedar coastal sailing boat",
+				"A high-sided cedar hull curves around a broad working deck, its seams packed and sealed beneath dark pitch. A single mast carries a square yard and a heavy woven sail, while paired steering oars project near the stern. The deep central hold and stout gunwales mark it as a practical coastal carrier rather than a racing craft.",
+				SizeCategory.Gigantic, ItemQuality.Good, 1800000.0, 9200.0m, "cedar", "Destroyable_WoodenHeavy",
+				VehicleScale.RoomContainer, 4, 2, true, "SailingTrader"),
+		];
+	}
+
+	private static IReadOnlyList<VehicleSeedSpec> MedievalVehicleExamples()
+	{
+		return
+		[
+			CreateDraftCargoVehicle(
+				"vehicle_medieval_market_cart", "medieval", "Market Cart",
+				"A compact two-wheeled market cart with removable sideboards.",
+				"cart", "a compact oak market cart",
+				"This compact cart rides on two iron-rimmed wheels beneath a shallow oak bed. Removable sideboards slot into upright stakes, allowing the same vehicle to carry baskets, firewood or loose produce. A pair of polished shafts and a simple hand brake show the care expected of a working town cart.",
+				SizeCategory.Huge, ItemQuality.Good, 140000.0, 850.0m, "oak", "Destroyable_WoodenHeavy",
+				VehicleScale.ItemScale, 1, false, false, 1200000.0, 1.25,
+				"market bed", "The shallow cart bed is enclosed by removable slatted sideboards.",
+				"MarketCart"),
+			CreateDraftCargoVehicle(
+				"vehicle_medieval_covered_wagon", "medieval", "Covered Road Wagon",
+				"A high-sided road wagon protected by a bowed canvas cover.",
+				"wagon", "a canvas-covered road wagon",
+				"A sturdy four-wheeled chassis carries a deep plank body beneath a series of bent ash hoops. Waxed canvas stretches over the hoops to form a weatherproof cover, with a laced flap closing the rear. A raised driving bench, iron-shod wheels and a long draft pole equip the wagon for sustained road travel.",
+				SizeCategory.Enormous, ItemQuality.Standard, 780000.0, 3900.0m, "oak", "Destroyable_WoodenHeavy",
+				VehicleScale.RoomContainer, 4, true, false, 6000000.0, 1.05,
+				"covered cargo bay", "The wagon's deep cargo bay lies beneath a bowed canvas cover and behind a laced rear flap.",
+				"CoveredWagon"),
+			CreatePaddleCraft(
+				"vehicle_medieval_clinker_rowboat", "medieval", "Clinker-Built Rowboat",
+				"A sturdy open rowboat assembled from overlapping oak strakes.",
+				"rowboat", "a clinker-built oak rowboat",
+				"Overlapping oak planks rise from a strong keel to form the flared sides of this open boat. Riveted seams, stout thwarts and worn wooden rowlocks give the hull a rugged, workmanlike character. A pointed bow and modest stern platform make it equally suited to fishing, ferrying and service beside a larger ship.",
+				SizeCategory.Enormous, ItemQuality.Good, 420000.0, 1800.0m, "oak", "Destroyable_WoodenHeavy",
+				VehicleScale.ItemScale, VehiclePropulsionType.Rowed, 1, 3, false, true, "Rowboat"),
+			CreateSailCraft(
+				"vehicle_medieval_trading_cog", "medieval", "Trading Cog",
+				"A bluff-bowed merchant cog with a single square sail and enclosed hold.",
+				"cog", "a bluff-bowed trading cog",
+				"A broad clinker-built hull rises to high castles at bow and stern around a deep central waist. One heavy mast bears a square sail, while a sternpost rudder hangs from stout iron fittings. A hatch-covered hold occupies much of the vessel's interior, and the thick rails and capacious body favour cargo and endurance over nimble handling.",
+				SizeCategory.Titanic, ItemQuality.Standard, 9500000.0, 46000.0m, "oak", "Destroyable_WoodenHeavy",
+				VehicleScale.RoomContainer, 8, 6, true, "SailingCargoShip"),
+		];
+	}
+
+	private static IReadOnlyList<VehicleSeedSpec> RenaissanceVehicleExamples()
+	{
+		return
+		[
+			CreateDraftCargoVehicle(
+				"vehicle_renaissance_city_carriage", "renaissance", "City Carriage",
+				"A compact enclosed carriage for prosperous urban passengers.",
+				"carriage", "a painted enclosed city carriage",
+				"A sprung four-wheeled chassis supports a compact enclosed body with glazed side openings and a padded bench within. Painted panels, turned corner posts and a small folding step lend the carriage a restrained elegance. The driver's raised seat and paired shafts are arranged for a light team on paved streets.",
+				SizeCategory.Enormous, ItemQuality.Good, 720000.0, 7200.0m, "oak", "Destroyable_WoodenHeavy",
+				VehicleScale.RoomContainer, 4, true, false, 4000000.0, 1.05,
+				"rear luggage rack", "A railed luggage platform is fixed behind the enclosed passenger body.",
+				"PassengerCarriage"),
+			CreateDraftCargoVehicle(
+				"vehicle_renaissance_artillery_wagon", "renaissance", "Artillery Wagon",
+				"A reinforced four-wheeled wagon for moving powder, shot and siege equipment.",
+				"wagon", "a reinforced artillery wagon",
+				"Heavy oak beams form a low, wide wagon chassis braced by iron straps and through-bolts. Deep sideboards restrain powder barrels, shot baskets and tools, while broad wheels spread the load over broken ground. Multiple hitch points and a stout rear drag shoe reflect the punishing work expected of the vehicle.",
+				SizeCategory.Enormous, ItemQuality.Standard, 1100000.0, 5600.0m, "oak", "Destroyable_WoodenHeavy",
+				VehicleScale.RoomContainer, 2, false, false, 8500000.0, 1.0,
+				"reinforced load bed", "The low wagon bed is strengthened with iron straps and deep removable sideboards.",
+				"MilitaryWagon"),
+			CreatePaddleCraft(
+				"vehicle_renaissance_ship_launch", "renaissance", "Ship's Launch",
+				"A broad pulling boat used to move people and stores between ship and shore.",
+				"launch", "a broad many-oared ship's launch",
+				"A long open hull encloses several rowing thwarts and a clear passage down the centre. Iron rowlocks line both gunwales, while lifting eyes and rubbing strakes show that the boat is meant to be hoisted aboard a larger vessel. The broad stern and capacious floor leave room for passengers, casks and bundled stores.",
+				SizeCategory.Gigantic, ItemQuality.Good, 960000.0, 4300.0m, "oak", "Destroyable_WoodenHeavy",
+				VehicleScale.RoomContainer, VehiclePropulsionType.Rowed, 1, 7, false, true, "ShipsLaunch"),
+			CreateSailCraft(
+				"vehicle_renaissance_lateen_pinnace", "renaissance", "Lateen-Rigged Pinnace",
+				"A light dispatch and trading vessel with a raking lateen sail.",
+				"pinnace", "a light lateen-rigged pinnace",
+				"A fine-lined wooden hull carries a low deck, a modest covered hold and a single mast raked to support a long lateen yard. The triangular sail and clean underwater shape promise better manoeuvrability than a broad cargo ship. A steering tiller, spare sweeps and neatly coiled running rigging make the vessel ready for coastal passages.",
+				SizeCategory.Gigantic, ItemQuality.Good, 2600000.0, 15800.0m, "pine", "Destroyable_WoodenHeavy",
+				VehicleScale.RoomContainer, 5, 3, true, "LateenSailcraft"),
+		];
+	}
+
+	private static IReadOnlyList<VehicleSeedSpec> EarlyModernVehicleExamples()
+	{
+		return
+		[
+			CreateDraftCargoVehicle(
+				"vehicle_earlymodern_stagecoach", "earlymodern", "Stagecoach",
+				"A substantial enclosed coach built for scheduled passenger travel.",
+				"stagecoach", "a high-bodied road stagecoach",
+				"A tall enclosed coach body hangs on leather thoroughbraces between high iron-rimmed wheels. Bench seats fill the cabin, luggage rails crown the roof and a folding step serves the side door. The driver's box, guard's perch and fittings for a four-horse team give the vehicle the purposeful appearance of regular long-distance service.",
+				SizeCategory.Gigantic, ItemQuality.Good, 1450000.0, 14500.0m, "oak", "Destroyable_WoodenHeavy",
+				VehicleScale.RoomContainer, 8, true, false, 8000000.0, 1.0,
+				"roof luggage rack", "A broad iron-railed rack spans the coach roof for trunks and mail sacks.",
+				"Stagecoach"),
+			CreateDraftCargoVehicle(
+				"vehicle_earlymodern_freight_dray", "earlymodern", "Freight Dray",
+				"A low heavy dray for casks and bulky goods on urban streets.",
+				"dray", "a low heavy freight dray",
+				"A long, low platform rests over four broad wheels, its stout oak beams left largely open for easy loading. Iron corner hoops, rope cleats and removable stakes secure barrels and bales without enclosing them. A compact driving board and short turning forecarriage suit slow work through crowded streets and yards.",
+				SizeCategory.Enormous, ItemQuality.Standard, 920000.0, 6100.0m, "oak", "Destroyable_WoodenHeavy",
+				VehicleScale.RoomContainer, 1, false, false, 9000000.0, 1.0,
+				"open freight platform", "The dray presents a broad, low platform fitted with cleats and removable cargo stakes.",
+				"FreightDray"),
+			CreatePaddleCraft(
+				"vehicle_earlymodern_whaleboat", "earlymodern", "Whaleboat",
+				"A long double-ended pulling boat made for rough water and rapid handling.",
+				"whaleboat", "a long double-ended whaleboat",
+				"A narrow double-ended hull rises sharply at bow and stern around a run of evenly spaced rowing thwarts. The light planking is reinforced at the gunwales, where sturdy rowlocks and line cleats stand ready for hard use. Its clean lines, open interior and steering oar favour speed, surf work and coordinated rowing.",
+				SizeCategory.Gigantic, ItemQuality.Good, 680000.0, 3900.0m, "pine", "Destroyable_WoodenHeavy",
+				VehicleScale.RoomContainer, VehiclePropulsionType.Rowed, 1, 5, false, true, "Whaleboat"),
+			CreateSailCraft(
+				"vehicle_earlymodern_coastal_sloop", "earlymodern", "Coastal Sloop",
+				"A handy single-masted sloop arranged for coastal trade and passenger work.",
+				"sloop", "a weathered coastal trading sloop",
+				"A full but clean-lined hull supports a single mast, fore-and-aft sails and a short bowsprit. The open working deck surrounds a hatch to a modest cargo hold, while a small stern shelter protects the tiller and charts. Tarred standing rigging, patched canvas and polished wear at the rail speak of regular coastal employment.",
+				SizeCategory.Titanic, ItemQuality.Standard, 5400000.0, 28000.0m, "oak", "Destroyable_WoodenHeavy",
+				VehicleScale.RoomContainer, 6, 4, true, "CoastalSloop"),
+		];
+	}
+}

--- a/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Catalogue.LandFactories.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Catalogue.LandFactories.cs
@@ -1,0 +1,166 @@
+#nullable enable
+
+using MudSharp.GameItems;
+using MudSharp.RPG.Checks;
+using MudSharp.Vehicles;
+using System;
+using System.Collections.Generic;
+
+namespace DatabaseSeeder.Seeders;
+
+public partial class ItemSeeder
+{
+	private static VehicleSeedSpec CreateDraftCargoVehicle(
+		string stableReference,
+		string eraKey,
+		string name,
+		string description,
+		string noun,
+		string shortDescription,
+		string fullDescription,
+		SizeCategory size,
+		ItemQuality quality,
+		double weight,
+		decimal cost,
+		string material,
+		string destroyable,
+		VehicleScale scale,
+		int passengerCapacity,
+		bool enclosed,
+		bool routeMovement,
+		double maximumTowedWeight,
+		double characterPullMultiplier,
+		string cargoName,
+		string cargoDescription,
+		string archetype)
+	{
+		var access = enclosed
+			? new VehicleAccessPointSeedSpec(
+				"rear_access", "rear access", "A closable rear opening provides access to the vehicle's interior.", "main",
+				VehicleAccessPointType.Door, false, true, 0,
+				Projection("door", $"the rear access of {shortDescription}",
+					$"This fitted rear closure belongs to {shortDescription}. Its hinges, fastenings and framing are integral to the vehicle.",
+					SizeCategory.Large, material, destroyable))
+			: null;
+		var movement = routeMovement
+			? RouteMovement("route", "guided route travel", RouteVehiclePropulsionMode.ExternallyPulled, 4.0, null, 0.0, 0.0, false)
+			: LandMovement("road", "ordinary road travel", null, 0.0, 0.0, string.Empty, false);
+		var passengerSlots = passengerCapacity > 0
+			? new[] { new VehicleOccupantSlotSeedSpec("passengers", "passenger places", "main", VehicleOccupantSlotType.Passenger, passengerCapacity, false, false) }
+			: [];
+		return new VehicleSeedSpec(
+			stableReference, eraKey, VehicleDomainTerrestrial, archetype, name, description, scale,
+			Exterior(noun, shortDescription, fullDescription, size, quality, weight, cost, material, destroyable, false),
+			[new VehicleCompartmentSeedSpec("main", enclosed ? "interior" : "platform", enclosed
+				? "The principal compartment is enclosed against weather and road dirt."
+				: "The principal compartment is an open working platform.", 0)],
+			[],
+			[
+				new VehicleOccupantSlotSeedSpec("driver", "driver's place", "main", VehicleOccupantSlotType.Driver, 1, true, false),
+				.. passengerSlots
+			],
+			[new VehicleControlStationSeedSpec("primary", enclosed ? "driver's box" : "driving position", "driver", true)],
+			[movement],
+			access is null ? [] : [access],
+			[
+				new VehicleCargoSpaceSeedSpec("cargo", cargoName, cargoDescription, "main", access is null ? null : "rear_access", 0,
+					enclosed ? "Container_Trunk" : "Container_Open_Bin",
+					Projection("cargo", $"the {cargoName} of {shortDescription}",
+						$"This cargo projection represents the {cargoName} built into {shortDescription}. It follows the dimensions and access of the vehicle rather than existing as a separate container.",
+						SizeCategory.Huge, material, destroyable))
+			],
+			[],
+			[
+				new VehicleTowPointSeedSpec("front_tow", "front draft point", "A reinforced forward draft point accepts compatible harness or traces.", null,
+					"draft", false, true, maximumTowedWeight, characterPullMultiplier, 0.8, 1.0, 0.2, 1.0, 0),
+				new VehicleTowPointSeedSpec("rear_tow", "rear tow point", "A reinforced rear point allows another light vehicle or load to be coupled behind.", null,
+					"draft", true, false, maximumTowedWeight * 0.75, 1.0, 0.8, 1.0, 0.2, 1.0, 1)
+			],
+			LandDamageZones(routeMovement ? "route" : "road", maximumTowedWeight),
+			passengerCapacity > 0, true,
+			"Externally pulled terrestrial example. Fit compatible hitch gear and pullers before movement; route variants require a RouteCell.");
+	}
+
+	private static VehicleSeedSpec CreatePoweredRoadVehicle(
+		string stableReference,
+		string eraKey,
+		string name,
+		string description,
+		string noun,
+		string shortDescription,
+		string fullDescription,
+		SizeCategory size,
+		ItemQuality quality,
+		double weight,
+		decimal cost,
+		string material,
+		string destroyable,
+		VehicleScale scale,
+		int passengerCapacity,
+		bool hasCargo,
+		bool routeMovement,
+		string? fuelLiquid,
+		double fuelPerMove,
+		double powerSpike,
+		string mountType,
+		bool automaticOperation,
+		bool serviceVehicle,
+		double routeSpeed,
+		double routeResourceRate,
+		string archetype)
+	{
+		var isElectric = string.IsNullOrWhiteSpace(fuelLiquid);
+		var movement = routeMovement
+			? RouteMovement("route", "powered route travel", RouteVehiclePropulsionMode.Powered, routeSpeed, fuelLiquid,
+				isElectric ? 0.0 : routeResourceRate, isElectric ? routeResourceRate : 0.0, automaticOperation)
+			: LandMovement("road", "powered road travel", fuelLiquid, fuelPerMove, powerSpike, VehiclePropulsionRole, true);
+		var access = new VehicleAccessPointSeedSpec(
+			"doors", "passenger doors", "The vehicle's fitted passenger doors open into the main cabin.", "cabin",
+			VehicleAccessPointType.Door, false, true, 0,
+			Projection("door", $"the passenger doors of {shortDescription}",
+				$"These fitted doors and their surrounding frame are integral to {shortDescription}. Handles, latches and seals are arranged for repeated passenger access.",
+				SizeCategory.Large, material, destroyable));
+		var cargo = hasCargo
+			? new[]
+			{
+				new VehicleCargoSpaceSeedSpec("cargo", serviceVehicle ? "service cargo bay" : "luggage compartment",
+					serviceVehicle
+						? "A large enclosed cargo bay occupies most of the vehicle behind the driving compartment."
+						: "A separate enclosed compartment carries luggage and small personal cargo.",
+					"cabin", "doors", 0, serviceVehicle ? "Container_Colossal" : "Container_Trunk",
+					Projection("cargo", $"the cargo compartment of {shortDescription}",
+						$"This hidden projection represents the built-in cargo compartment of {shortDescription}, including its fixed floor, sides and loading access.",
+						serviceVehicle ? SizeCategory.Enormous : SizeCategory.Huge, material, destroyable))
+			}
+			: [];
+		return new VehicleSeedSpec(
+			stableReference, eraKey, VehicleDomainTerrestrial, archetype, name, description, scale,
+			Exterior(noun, shortDescription, fullDescription, size, quality, weight, cost, material, destroyable, false),
+			[new VehicleCompartmentSeedSpec("cabin", "passenger cabin", "The main cabin contains the driving controls and occupied seating.", 0)],
+			[],
+			[
+				new VehicleOccupantSlotSeedSpec("driver", "driver's seat", "cabin", VehicleOccupantSlotType.Driver, 1, !automaticOperation, false),
+				new VehicleOccupantSlotSeedSpec("passengers", "passenger seats", "cabin", VehicleOccupantSlotType.Passenger, passengerCapacity, false, false)
+			],
+			[new VehicleControlStationSeedSpec("primary", automaticOperation ? "manual control console" : "driving controls", "driver", true)],
+			[movement],
+			[access],
+			cargo,
+			[
+				new VehicleInstallationPointSeedSpec("drive_module", isElectric ? "electric drive bay" : "engine bay",
+					isElectric ? "A protected bay accepts a compatible electric vehicle drive module." : "A protected bay accepts a compatible fuelled vehicle drive module.",
+					null, mountType, VehiclePropulsionRole, true, 0)
+			],
+			[
+				new VehicleTowPointSeedSpec("front_tow", "front recovery point", "A rated front recovery point accepts compatible towing gear.", null,
+					"road", false, true, weight * 2.0, 1.0, 0.85, 1.0, 0.15, 1.0, 0),
+				new VehicleTowPointSeedSpec("rear_tow", "rear towing point", "A rated rear towing point allows another compatible vehicle to be coupled.", null,
+					"road", true, false, weight * 1.5, 1.0, 0.85, 1.0, 0.15, 1.0, 1)
+			],
+			PoweredLandDamageZones(routeMovement ? "route" : "road", "drive_module"),
+			true, hasCargo,
+			isElectric
+				? "Install the seeded electric drive module and charge it with compatible batteries before movement."
+				: $"Install the seeded {fuelLiquid} drive module and fill its liquid container with {fuelLiquid} before movement.");
+	}
+}

--- a/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Catalogue.WaterFactories.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Catalogue.WaterFactories.cs
@@ -1,0 +1,208 @@
+#nullable enable
+
+using MudSharp.GameItems;
+using MudSharp.RPG.Checks;
+using MudSharp.Vehicles;
+using System;
+using System.Collections.Generic;
+
+namespace DatabaseSeeder.Seeders;
+
+public partial class ItemSeeder
+{
+	private static VehicleSeedSpec CreatePaddleCraft(
+		string stableReference,
+		string eraKey,
+		string name,
+		string description,
+		string noun,
+		string shortDescription,
+		string fullDescription,
+		SizeCategory size,
+		ItemQuality quality,
+		double weight,
+		decimal cost,
+		string material,
+		string destroyable,
+		VehicleScale scale,
+		VehiclePropulsionType propulsionType,
+		int driverCapacity,
+		int crewCapacity,
+		bool portable,
+		bool hasCargo,
+		string archetype)
+	{
+		var crewSlots = crewCapacity > 0
+			? new[] { new VehicleOccupantSlotSeedSpec("rowers", "rowing thwarts", "hull", VehicleOccupantSlotType.Crew, crewCapacity, false, true, Difficulty.Normal) }
+			: [];
+		var cargo = hasCargo
+			? new[]
+			{
+				new VehicleCargoSpaceSeedSpec("cargo", "open stowage", "Open floor space between the seats can hold modest cargo while keeping the craft balanced.",
+					"hull", null, 0, "Container_Open_Bin",
+					Projection("cargo", $"the open stowage of {shortDescription}",
+						$"This hidden projection represents the usable open stowage inside {shortDescription}.", SizeCategory.Huge, material, destroyable))
+			}
+			: [];
+		var propulsion = propulsionType == VehiclePropulsionType.SelfPowered
+			? SelfPoweredProfile(true)
+			: RowedProfile(true);
+		return new VehicleSeedSpec(
+			stableReference, eraKey, VehicleDomainAquatic, archetype, name, description, scale,
+			Exterior(noun, shortDescription, fullDescription, size, quality, weight, cost, material, destroyable, portable),
+			[new VehicleCompartmentSeedSpec("hull", "open hull", "The occupied space lies within the craft's open hull.", 0)],
+			[],
+			[
+				new VehicleOccupantSlotSeedSpec("driver", propulsionType == VehiclePropulsionType.SelfPowered ? "paddler's place" : "steersman's place",
+					"hull", VehicleOccupantSlotType.Driver, driverCapacity, true, propulsionType == VehiclePropulsionType.SelfPowered, Difficulty.Normal),
+				.. crewSlots
+			],
+			[new VehicleControlStationSeedSpec("primary", propulsionType == VehiclePropulsionType.SelfPowered ? "paddling position" : "steering position", "driver", true)],
+			[WaterMovement("water", "surface-water travel", false, [propulsion])],
+			[], cargo, [],
+			[
+				new VehicleTowPointSeedSpec("bow_tow", "bow towing eye", "A reinforced eye at the bow accepts a line for towing or recovery.", null,
+					"marine", true, true, Math.Max(weight * 3.0, 250000.0), 1.0, 0.85, 1.0, 0.15, 1.0, 0)
+			],
+			WaterDamageZones("water", null),
+			crewCapacity > 0, hasCargo,
+			propulsionType == VehiclePropulsionType.Rowed
+				? "Every rowing contributor must occupy a propulsion slot and hold a seeded vehicle oar."
+				: "The controller supplies self-powered aquatic propulsion; a Swimming, Rowing or Athletics trait must exist.");
+	}
+
+	private static VehicleSeedSpec CreateSailCraft(
+		string stableReference,
+		string eraKey,
+		string name,
+		string description,
+		string noun,
+		string shortDescription,
+		string fullDescription,
+		SizeCategory size,
+		ItemQuality quality,
+		double weight,
+		decimal cost,
+		string material,
+		string destroyable,
+		VehicleScale scale,
+		int passengerCapacity,
+		int crewCapacity,
+		bool hasCargo,
+		string archetype)
+	{
+		var access = new VehicleAccessPointSeedSpec(
+			"hold_hatch", "cargo hatch", "A stout deck hatch opens into the lower hold.", "hold",
+			VehicleAccessPointType.Hatch, false, true, 0,
+			Projection("hatch", $"the cargo hatch of {shortDescription}",
+				$"This heavy fitted hatch closes the cargo opening in {shortDescription}; its coaming, hinges and securing bars are part of the vessel.",
+				SizeCategory.VeryLarge, material, destroyable));
+		var cargo = hasCargo
+			? new[]
+			{
+				new VehicleCargoSpaceSeedSpec("hold", "cargo hold", "The lower hold provides broad stowage beneath the working deck.", "hold", "hold_hatch", 0,
+					"Container_Colossal",
+					Projection("hold", $"the cargo hold of {shortDescription}",
+						$"This hidden projection represents the fixed lower cargo hold of {shortDescription} and is accessed through its deck hatch.",
+						SizeCategory.Enormous, material, destroyable))
+			}
+			: [];
+		return new VehicleSeedSpec(
+			stableReference, eraKey, VehicleDomainAquatic, archetype, name, description, scale,
+			Exterior(noun, shortDescription, fullDescription, size, quality, weight, cost, material, destroyable, false),
+			[
+				new VehicleCompartmentSeedSpec("deck", "working deck", "The exposed working deck carries the helm, rigging and occupied stations.", 0),
+				new VehicleCompartmentSeedSpec("hold", "lower hold", "A lower enclosed compartment lies beneath the main deck.", 1)
+			],
+			[
+				new VehicleCompartmentLinkSeedSpec("deck_to_hold", "deck", "hold", "down", "up", "through the cargo hatch", "up through the cargo hatch")
+			],
+			[
+				new VehicleOccupantSlotSeedSpec("driver", "helm", "deck", VehicleOccupantSlotType.Driver, 1, true, false, Difficulty.Normal),
+				new VehicleOccupantSlotSeedSpec("crew", "working crew stations", "deck", VehicleOccupantSlotType.Crew, crewCapacity, false, true, Difficulty.Normal),
+				new VehicleOccupantSlotSeedSpec("passengers", "passenger places", "deck", VehicleOccupantSlotType.Passenger, passengerCapacity, false, false, Difficulty.Normal)
+			],
+			[new VehicleControlStationSeedSpec("primary", "helm", "driver", true)],
+			[WaterMovement("water", "sailing profile", true, [SailProfile(true), RowedProfile(false)])],
+			[access], cargo, [],
+			[
+				new VehicleTowPointSeedSpec("bow_tow", "bow towing bitt", "A strong forward bitt accepts towing hawsers and mooring lines.", null,
+					"marine", true, true, weight * 2.0, 1.0, 0.85, 1.0, 0.15, 1.0, 0),
+				new VehicleTowPointSeedSpec("stern_tow", "stern towing bitt", "A strong after bitt permits another vessel or floating load to be towed astern.", null,
+					"marine", true, true, weight * 1.5, 1.0, 0.85, 1.0, 0.15, 1.0, 1)
+			],
+			SailDamageZones("water", "hold_hatch", hasCargo ? "hold" : null),
+			true, hasCargo,
+			"Sail is the default propulsion mode and requires wind. Rowing is available as a fallback only when staffed propulsion slots have usable oars.");
+	}
+
+	private static VehicleSeedSpec CreateMotorCraft(
+		string stableReference,
+		string eraKey,
+		string name,
+		string description,
+		string noun,
+		string shortDescription,
+		string fullDescription,
+		SizeCategory size,
+		ItemQuality quality,
+		double weight,
+		decimal cost,
+		string material,
+		string destroyable,
+		VehicleScale scale,
+		int passengerCapacity,
+		bool hasCabin,
+		string archetype)
+	{
+		var access = hasCabin
+			? new VehicleAccessPointSeedSpec(
+				"cabin_door", "cabin door", "A fitted weatherproof door closes the vessel's small cabin.", "cabin",
+				VehicleAccessPointType.Door, false, true, 0,
+				Projection("door", $"the cabin door of {shortDescription}",
+					$"This fitted weatherproof door and frame are integral to the cabin of {shortDescription}.", SizeCategory.Large, material, destroyable))
+			: null;
+		var compartments = hasCabin
+			? new[]
+			{
+				new VehicleCompartmentSeedSpec("cockpit", "cockpit", "The open cockpit contains the helm and principal working space.", 0),
+				new VehicleCompartmentSeedSpec("cabin", "cabin", "A compact enclosed cabin provides sheltered seating and stowage.", 1)
+			}
+			: [new VehicleCompartmentSeedSpec("cockpit", "cockpit", "The open cockpit contains the helm, seating and working space.", 0)];
+		var links = hasCabin
+			? new[] { new VehicleCompartmentLinkSeedSpec("cockpit_to_cabin", "cockpit", "cabin", "forward", "aft", "through the cabin door", "out through the cabin door") }
+			: [];
+		var cargo = new[]
+		{
+			new VehicleCargoSpaceSeedSpec("locker", hasCabin ? "cabin locker" : "forward locker",
+				hasCabin ? "A built-in locker occupies part of the sheltered cabin." : "A lidded locker is built beneath the forward deck.",
+				hasCabin ? "cabin" : "cockpit", hasCabin ? "cabin_door" : null, 0, "Container_Trunk",
+				Projection("locker", $"the built-in locker of {shortDescription}",
+					$"This hidden projection represents the fixed storage locker built into {shortDescription}.", SizeCategory.Huge, material, destroyable))
+		};
+		return new VehicleSeedSpec(
+			stableReference, eraKey, VehicleDomainAquatic, archetype, name, description, scale,
+			Exterior(noun, shortDescription, fullDescription, size, quality, weight, cost, material, destroyable, false),
+			compartments, links,
+			[
+				new VehicleOccupantSlotSeedSpec("driver", "helm seat", "cockpit", VehicleOccupantSlotType.Driver, 1, true, false, Difficulty.Easy),
+				new VehicleOccupantSlotSeedSpec("rowers", "emergency rowing places", "cockpit", VehicleOccupantSlotType.Crew, 2, false, true, Difficulty.Normal),
+				new VehicleOccupantSlotSeedSpec("passengers", "passenger places", hasCabin ? "cabin" : "cockpit", VehicleOccupantSlotType.Passenger, passengerCapacity, false, false, Difficulty.Normal)
+			],
+			[new VehicleControlStationSeedSpec("primary", "helm controls", "driver", true)],
+			[WaterMovement("water", "motor and emergency rowing profile", true, [OutboardProfile(true), RowedProfile(false)])],
+			access is null ? [] : [access],
+			cargo,
+			[
+				new VehicleInstallationPointSeedSpec("outboard", "outboard transom mount", "A reinforced transom mount accepts a compatible outboard propulsion module.",
+					null, VehicleOutboardMountType, VehiclePropulsionRole, false, 0)
+			],
+			[
+				new VehicleTowPointSeedSpec("bow_tow", "bow towing eye", "A rated bow eye accepts recovery and towing lines.", null,
+					"marine", true, true, weight * 2.0, 1.0, 0.85, 1.0, 0.15, 1.0, 0)
+			],
+			WaterDamageZones("water", "outboard"),
+			true, true,
+			"Install the seeded outboard motor on the transom mount and fill it with gasoline. Emergency rowing remains selectable when staffed rowers hold vehicle oars.");
+	}
+}

--- a/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Children.Projections.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Children.Projections.cs
@@ -1,0 +1,305 @@
+#nullable enable
+
+using Microsoft.EntityFrameworkCore;
+using MudSharp.Models;
+using MudSharp.Vehicles;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace DatabaseSeeder.Seeders;
+
+public partial class ItemSeeder
+{
+	private VehicleAccessPointProto UpsertAccessPoint(
+		VehicleProto vehicle,
+		string vehicleReference,
+		VehicleAccessPointSeedSpec spec,
+		IReadOnlyDictionary<string, VehicleCompartmentProto> compartments)
+	{
+		var compartment = string.IsNullOrWhiteSpace(spec.CompartmentKey)
+			? null
+			: RequireKey(compartments, spec.CompartmentKey, vehicle.Name, "compartment");
+		var row = FindAccessPointByProjection(vehicle, vehicleReference, spec.Key) ??
+		          _context!.VehicleAccessPointProtos.Local.FirstOrDefault(x =>
+			          x.VehicleProtoId == vehicle.Id && x.VehicleProtoRevision == vehicle.RevisionNumber &&
+			          x.Name.Equals(spec.Name, StringComparison.OrdinalIgnoreCase)) ??
+		          _context.VehicleAccessPointProtos.AsEnumerable().FirstOrDefault(x =>
+			          x.VehicleProtoId == vehicle.Id && x.VehicleProtoRevision == vehicle.RevisionNumber &&
+			          x.Name.Equals(spec.Name, StringComparison.OrdinalIgnoreCase));
+		if (row is null)
+		{
+			row = new VehicleAccessPointProto
+			{
+				Id = NextVehicleChildId(_context!.VehicleAccessPointProtos, x => x.Id),
+				VehicleProto = vehicle,
+				VehicleProtoId = vehicle.Id,
+				VehicleProtoRevision = vehicle.RevisionNumber
+			};
+			_context.VehicleAccessPointProtos.Add(row);
+		}
+
+		row.VehicleCompartmentProto = compartment;
+		row.VehicleCompartmentProtoId = compartment?.Id;
+		row.Name = spec.Name;
+		row.Description = spec.Description;
+		row.AccessPointType = (int)spec.AccessPointType;
+		row.StartsOpen = spec.StartsOpen;
+		row.MustBeClosedForMovement = spec.MustBeClosedForMovement;
+		row.DisplayOrder = spec.DisplayOrder;
+		return row;
+	}
+
+	private VehicleAccessPointProto? FindAccessPointByProjection(VehicleProto vehicle, string vehicleReference, string key)
+	{
+		var stableReference = $"{vehicleReference}_access_{NormaliseKey(key)}";
+		if (!_items.TryGetValue(stableReference, out var projection))
+		{
+			return null;
+		}
+
+		return _context!.VehicleAccessPointProtos.Local.FirstOrDefault(x =>
+			       x.VehicleProtoId == vehicle.Id && x.VehicleProtoRevision == vehicle.RevisionNumber &&
+			       x.ProjectionItemProtoId == projection.Id && x.ProjectionItemProtoRevision == projection.RevisionNumber) ??
+		       _context.VehicleAccessPointProtos.FirstOrDefault(x =>
+			       x.VehicleProtoId == vehicle.Id && x.VehicleProtoRevision == vehicle.RevisionNumber &&
+			       x.ProjectionItemProtoId == projection.Id && x.ProjectionItemProtoRevision == projection.RevisionNumber);
+	}
+
+	private VehicleCargoSpaceProto UpsertCargoSpace(
+		VehicleProto vehicle,
+		string vehicleReference,
+		VehicleCargoSpaceSeedSpec spec,
+		IReadOnlyDictionary<string, VehicleCompartmentProto> compartments,
+		IReadOnlyDictionary<string, VehicleAccessPointProto> accessPoints)
+	{
+		var compartment = string.IsNullOrWhiteSpace(spec.CompartmentKey)
+			? null
+			: RequireKey(compartments, spec.CompartmentKey, vehicle.Name, "compartment");
+		var requiredAccess = string.IsNullOrWhiteSpace(spec.RequiredAccessPointKey)
+			? null
+			: RequireKey(accessPoints, spec.RequiredAccessPointKey, vehicle.Name, "access point");
+		var row = FindCargoSpaceByProjection(vehicle, vehicleReference, spec.Key) ??
+		          _context!.VehicleCargoSpaceProtos.Local.FirstOrDefault(x =>
+			          x.VehicleProtoId == vehicle.Id && x.VehicleProtoRevision == vehicle.RevisionNumber &&
+			          x.Name.Equals(spec.Name, StringComparison.OrdinalIgnoreCase)) ??
+		          _context.VehicleCargoSpaceProtos.AsEnumerable().FirstOrDefault(x =>
+			          x.VehicleProtoId == vehicle.Id && x.VehicleProtoRevision == vehicle.RevisionNumber &&
+			          x.Name.Equals(spec.Name, StringComparison.OrdinalIgnoreCase));
+		if (row is null)
+		{
+			row = new VehicleCargoSpaceProto
+			{
+				Id = NextVehicleChildId(_context!.VehicleCargoSpaceProtos, x => x.Id),
+				VehicleProto = vehicle,
+				VehicleProtoId = vehicle.Id,
+				VehicleProtoRevision = vehicle.RevisionNumber
+			};
+			_context.VehicleCargoSpaceProtos.Add(row);
+		}
+
+		row.VehicleCompartmentProto = compartment;
+		row.VehicleCompartmentProtoId = compartment?.Id;
+		row.RequiredAccessPointProto = requiredAccess;
+		row.RequiredAccessPointProtoId = requiredAccess?.Id;
+		row.Name = spec.Name;
+		row.Description = spec.Description;
+		row.DisplayOrder = spec.DisplayOrder;
+		return row;
+	}
+
+	private VehicleCargoSpaceProto? FindCargoSpaceByProjection(VehicleProto vehicle, string vehicleReference, string key)
+	{
+		var stableReference = $"{vehicleReference}_cargo_{NormaliseKey(key)}";
+		if (!_items.TryGetValue(stableReference, out var projection))
+		{
+			return null;
+		}
+
+		return _context!.VehicleCargoSpaceProtos.Local.FirstOrDefault(x =>
+			       x.VehicleProtoId == vehicle.Id && x.VehicleProtoRevision == vehicle.RevisionNumber &&
+			       x.ProjectionItemProtoId == projection.Id && x.ProjectionItemProtoRevision == projection.RevisionNumber) ??
+		       _context.VehicleCargoSpaceProtos.FirstOrDefault(x =>
+			       x.VehicleProtoId == vehicle.Id && x.VehicleProtoRevision == vehicle.RevisionNumber &&
+			       x.ProjectionItemProtoId == projection.Id && x.ProjectionItemProtoRevision == projection.RevisionNumber);
+	}
+
+	private VehicleInstallationPointProto UpsertInstallationPoint(
+		VehicleProto vehicle,
+		string vehicleReference,
+		VehicleInstallationPointSeedSpec spec,
+		IReadOnlyDictionary<string, VehicleAccessPointProto> accessPoints)
+	{
+		EnsureVehicleInstallationSupport(spec.MountType);
+		var requiredAccess = string.IsNullOrWhiteSpace(spec.RequiredAccessPointKey)
+			? null
+			: RequireKey(accessPoints, spec.RequiredAccessPointKey, vehicle.Name, "access point");
+		var row = _context!.VehicleInstallationPointProtos.Local.FirstOrDefault(x =>
+				x.VehicleProtoId == vehicle.Id && x.VehicleProtoRevision == vehicle.RevisionNumber &&
+				x.Name.Equals(spec.Name, StringComparison.OrdinalIgnoreCase)) ??
+		          _context.VehicleInstallationPointProtos.AsEnumerable().FirstOrDefault(x =>
+			          x.VehicleProtoId == vehicle.Id && x.VehicleProtoRevision == vehicle.RevisionNumber &&
+			          x.Name.Equals(spec.Name, StringComparison.OrdinalIgnoreCase));
+		if (row is null)
+		{
+			row = new VehicleInstallationPointProto
+			{
+				Id = NextVehicleChildId(_context.VehicleInstallationPointProtos, x => x.Id),
+				VehicleProto = vehicle,
+				VehicleProtoId = vehicle.Id,
+				VehicleProtoRevision = vehicle.RevisionNumber
+			};
+			_context.VehicleInstallationPointProtos.Add(row);
+		}
+
+		row.RequiredAccessPointProto = requiredAccess;
+		row.RequiredAccessPointProtoId = requiredAccess?.Id;
+		row.Name = spec.Name;
+		row.Description = spec.Description;
+		row.MountType = spec.MountType;
+		row.RequiredRole = spec.RequiredRole;
+		row.RequiredForMovement = spec.RequiredForMovement;
+		row.DisplayOrder = spec.DisplayOrder;
+		return row;
+	}
+
+	private VehicleTowPointProto UpsertTowPoint(
+		VehicleProto vehicle,
+		string vehicleReference,
+		VehicleTowPointSeedSpec spec,
+		IReadOnlyDictionary<string, VehicleAccessPointProto> accessPoints)
+	{
+		EnsureVehicleTowSupport(spec);
+		var requiredAccess = string.IsNullOrWhiteSpace(spec.RequiredAccessPointKey)
+			? null
+			: RequireKey(accessPoints, spec.RequiredAccessPointKey, vehicle.Name, "access point");
+		var row = _context!.VehicleTowPointProtos.Local.FirstOrDefault(x =>
+				x.VehicleProtoId == vehicle.Id && x.VehicleProtoRevision == vehicle.RevisionNumber &&
+				x.Name.Equals(spec.Name, StringComparison.OrdinalIgnoreCase)) ??
+		          _context.VehicleTowPointProtos.AsEnumerable().FirstOrDefault(x =>
+			          x.VehicleProtoId == vehicle.Id && x.VehicleProtoRevision == vehicle.RevisionNumber &&
+			          x.Name.Equals(spec.Name, StringComparison.OrdinalIgnoreCase));
+		if (row is null)
+		{
+			row = new VehicleTowPointProto
+			{
+				Id = NextVehicleChildId(_context.VehicleTowPointProtos, x => x.Id),
+				VehicleProto = vehicle,
+				VehicleProtoId = vehicle.Id,
+				VehicleProtoRevision = vehicle.RevisionNumber
+			};
+			_context.VehicleTowPointProtos.Add(row);
+		}
+
+		row.RequiredAccessPointProto = requiredAccess;
+		row.RequiredAccessPointProtoId = requiredAccess?.Id;
+		row.Name = spec.Name;
+		row.Description = spec.Description;
+		row.TowType = spec.TowType;
+		row.CanTow = spec.CanTow;
+		row.CanBeTowed = spec.CanBeTowed;
+		row.MaximumTowedWeight = spec.MaximumTowedWeight;
+		row.CharacterPullMultiplier = spec.CharacterPullMultiplier;
+		row.TowStressWarningRatio = spec.TowStressWarningRatio;
+		row.TowStressFailureStartRatio = spec.TowStressFailureStartRatio;
+		row.TowStressMaximumFailureChance = spec.TowStressMaximumFailureChance;
+		row.TowStressDamageMultiplier = spec.TowStressDamageMultiplier;
+		row.DisplayOrder = spec.DisplayOrder;
+		return row;
+	}
+
+	private VehicleDamageZoneProto UpsertDamageZone(
+		VehicleProto vehicle,
+		string vehicleReference,
+		VehicleDamageZoneSeedSpec spec)
+	{
+		var row = _context!.VehicleDamageZoneProtos.Local.FirstOrDefault(x =>
+				x.VehicleProtoId == vehicle.Id && x.VehicleProtoRevision == vehicle.RevisionNumber &&
+				x.Name.Equals(spec.Name, StringComparison.OrdinalIgnoreCase)) ??
+		          _context.VehicleDamageZoneProtos.AsEnumerable().FirstOrDefault(x =>
+			          x.VehicleProtoId == vehicle.Id && x.VehicleProtoRevision == vehicle.RevisionNumber &&
+			          x.Name.Equals(spec.Name, StringComparison.OrdinalIgnoreCase));
+		if (row is null)
+		{
+			row = new VehicleDamageZoneProto
+			{
+				Id = NextVehicleChildId(_context.VehicleDamageZoneProtos, x => x.Id),
+				VehicleProto = vehicle,
+				VehicleProtoId = vehicle.Id,
+				VehicleProtoRevision = vehicle.RevisionNumber
+			};
+			_context.VehicleDamageZoneProtos.Add(row);
+		}
+
+		row.Name = spec.Name;
+		row.Description = spec.Description;
+		row.MaximumDamage = spec.MaximumDamage;
+		row.HitWeight = spec.HitWeight;
+		row.DisabledThreshold = spec.DisabledThreshold;
+		row.DestroyedThreshold = spec.DestroyedThreshold;
+		row.DisablesMovement = spec.DisablesMovement;
+		row.DisplayOrder = spec.DisplayOrder;
+		return row;
+	}
+
+	private void UpsertDamageEffect(
+		VehicleDamageZoneProto damageZone,
+		VehicleDamageEffectSeedSpec spec,
+		IReadOnlyDictionary<string, VehicleMovementProfileProto> movements,
+		IReadOnlyDictionary<string, VehicleAccessPointProto> accessPoints,
+		IReadOnlyDictionary<string, VehicleCargoSpaceProto> cargoSpaces,
+		IReadOnlyDictionary<string, VehicleInstallationPointProto> installationPoints,
+		IReadOnlyDictionary<string, VehicleTowPointProto> towPoints)
+	{
+		var targetId = ResolveDamageEffectTargetId(spec, movements, accessPoints, cargoSpaces, installationPoints, towPoints);
+		var row = _context!.VehicleDamageZoneEffectProtos.Local.FirstOrDefault(x =>
+				x.VehicleDamageZoneProtoId == damageZone.Id && x.TargetType == (int)spec.TargetType &&
+				x.TargetProtoId == targetId) ??
+		          _context.VehicleDamageZoneEffectProtos.FirstOrDefault(x =>
+			          x.VehicleDamageZoneProtoId == damageZone.Id && x.TargetType == (int)spec.TargetType &&
+			          x.TargetProtoId == targetId);
+		if (row is null)
+		{
+			row = new VehicleDamageZoneEffectProto
+			{
+				Id = NextVehicleChildId(_context.VehicleDamageZoneEffectProtos, x => x.Id),
+				VehicleDamageZoneProto = damageZone,
+				VehicleDamageZoneProtoId = damageZone.Id
+			};
+			_context.VehicleDamageZoneEffectProtos.Add(row);
+		}
+
+		row.TargetType = (int)spec.TargetType;
+		row.TargetProtoId = targetId;
+		row.MinimumStatus = (int)spec.MinimumStatus;
+	}
+
+	private static long? ResolveDamageEffectTargetId(
+		VehicleDamageEffectSeedSpec spec,
+		IReadOnlyDictionary<string, VehicleMovementProfileProto> movements,
+		IReadOnlyDictionary<string, VehicleAccessPointProto> accessPoints,
+		IReadOnlyDictionary<string, VehicleCargoSpaceProto> cargoSpaces,
+		IReadOnlyDictionary<string, VehicleInstallationPointProto> installationPoints,
+		IReadOnlyDictionary<string, VehicleTowPointProto> towPoints)
+	{
+		if (spec.TargetType == VehicleDamageEffectTargetType.WholeVehicleMovement)
+		{
+			return null;
+		}
+		if (string.IsNullOrWhiteSpace(spec.TargetKey))
+		{
+			throw new InvalidOperationException($"Damage effect target {spec.TargetType} requires a target key.");
+		}
+
+		return spec.TargetType switch
+		{
+			VehicleDamageEffectTargetType.MovementProfile => RequireKey(movements, spec.TargetKey, "damage effect", "movement profile").Id,
+			VehicleDamageEffectTargetType.AccessPoint => RequireKey(accessPoints, spec.TargetKey, "damage effect", "access point").Id,
+			VehicleDamageEffectTargetType.CargoSpace => RequireKey(cargoSpaces, spec.TargetKey, "damage effect", "cargo space").Id,
+			VehicleDamageEffectTargetType.InstallationPoint => RequireKey(installationPoints, spec.TargetKey, "damage effect", "installation point").Id,
+			VehicleDamageEffectTargetType.TowPoint => RequireKey(towPoints, spec.TargetKey, "damage effect", "tow point").Id,
+			_ => throw new ArgumentOutOfRangeException(nameof(spec.TargetType), spec.TargetType, "Unsupported damage effect target type.")
+		};
+	}
+}

--- a/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Children.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Children.cs
@@ -1,0 +1,252 @@
+#nullable enable
+
+using Microsoft.EntityFrameworkCore;
+using MudSharp.Models;
+using MudSharp.Vehicles;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace DatabaseSeeder.Seeders;
+
+public partial class ItemSeeder
+{
+	private VehicleProto? FindVehiclePrototypeByExterior(GameItemProto exterior, string stableReference)
+	{
+		return _context!.VehicleProtos.Local.FirstOrDefault(x =>
+				x.ExteriorItemProtoId == exterior.Id && x.ExteriorItemProtoRevision == exterior.RevisionNumber) ??
+		       _context.VehicleProtos.FirstOrDefault(x =>
+			       x.ExteriorItemProtoId == exterior.Id && x.ExteriorItemProtoRevision == exterior.RevisionNumber);
+	}
+
+	private static long NextVehicleChildId<T>(DbSet<T> set, Func<T, long> selector) where T : class
+	{
+		var databaseMaximum = set.AsNoTracking().AsEnumerable().Select(selector).DefaultIfEmpty(0L).Max();
+		var localMaximum = set.Local.Select(selector).DefaultIfEmpty(0L).Max();
+		return Math.Max(databaseMaximum, localMaximum) + 1L;
+	}
+
+	private VehicleCompartmentProto UpsertCompartment(
+		VehicleProto vehicle,
+		string vehicleReference,
+		VehicleCompartmentSeedSpec spec)
+	{
+		var row = _context!.VehicleCompartmentProtos.Local.FirstOrDefault(x =>
+				x.VehicleProtoId == vehicle.Id && x.VehicleProtoRevision == vehicle.RevisionNumber &&
+				x.Name.Equals(spec.Name, StringComparison.OrdinalIgnoreCase)) ??
+		          _context.VehicleCompartmentProtos.AsEnumerable().FirstOrDefault(x =>
+			          x.VehicleProtoId == vehicle.Id && x.VehicleProtoRevision == vehicle.RevisionNumber &&
+			          x.Name.Equals(spec.Name, StringComparison.OrdinalIgnoreCase));
+		if (row is null)
+		{
+			row = new VehicleCompartmentProto
+			{
+				Id = NextVehicleChildId(_context.VehicleCompartmentProtos, x => x.Id),
+				VehicleProto = vehicle,
+				VehicleProtoId = vehicle.Id,
+				VehicleProtoRevision = vehicle.RevisionNumber
+			};
+			_context.VehicleCompartmentProtos.Add(row);
+		}
+
+		row.Name = spec.Name;
+		row.Description = spec.Description;
+		row.DisplayOrder = spec.DisplayOrder;
+		row.InteriorTerrainId = spec.InteriorTerrainId;
+		row.InteriorOutdoorsType = spec.InteriorOutdoorsType;
+		return row;
+	}
+
+	private VehicleCompartmentLinkProto UpsertCompartmentLink(
+		VehicleProto vehicle,
+		VehicleCompartmentLinkSeedSpec spec,
+		IReadOnlyDictionary<string, VehicleCompartmentProto> compartments)
+	{
+		var source = RequireKey(compartments, spec.SourceCompartmentKey, vehicle.Name, "compartment");
+		var destination = RequireKey(compartments, spec.DestinationCompartmentKey, vehicle.Name, "compartment");
+		var row = _context!.VehicleCompartmentLinkProtos.Local.FirstOrDefault(x =>
+				x.VehicleProtoId == vehicle.Id && x.VehicleProtoRevision == vehicle.RevisionNumber &&
+				x.SourceVehicleCompartmentProtoId == source.Id && x.DestinationVehicleCompartmentProtoId == destination.Id &&
+				x.OutboundDirection.Equals(spec.OutboundDirection, StringComparison.OrdinalIgnoreCase)) ??
+		          _context.VehicleCompartmentLinkProtos.AsEnumerable().FirstOrDefault(x =>
+			          x.VehicleProtoId == vehicle.Id && x.VehicleProtoRevision == vehicle.RevisionNumber &&
+			          x.SourceVehicleCompartmentProtoId == source.Id && x.DestinationVehicleCompartmentProtoId == destination.Id &&
+			          x.OutboundDirection.Equals(spec.OutboundDirection, StringComparison.OrdinalIgnoreCase));
+		if (row is null)
+		{
+			row = new VehicleCompartmentLinkProto
+			{
+				Id = NextVehicleChildId(_context.VehicleCompartmentLinkProtos, x => x.Id),
+				VehicleProto = vehicle,
+				VehicleProtoId = vehicle.Id,
+				VehicleProtoRevision = vehicle.RevisionNumber
+			};
+			_context.VehicleCompartmentLinkProtos.Add(row);
+		}
+
+		row.SourceVehicleCompartmentProto = source;
+		row.SourceVehicleCompartmentProtoId = source.Id;
+		row.DestinationVehicleCompartmentProto = destination;
+		row.DestinationVehicleCompartmentProtoId = destination.Id;
+		row.OutboundDirection = spec.OutboundDirection;
+		row.InboundDirection = spec.InboundDirection;
+		row.OutboundDescription = spec.OutboundDescription;
+		row.InboundDescription = spec.InboundDescription;
+		return row;
+	}
+
+	private VehicleOccupantSlotProto UpsertOccupantSlot(
+		VehicleProto vehicle,
+		VehicleOccupantSlotSeedSpec spec,
+		IReadOnlyDictionary<string, VehicleCompartmentProto> compartments)
+	{
+		var compartment = RequireKey(compartments, spec.CompartmentKey, vehicle.Name, "compartment");
+		var row = _context!.VehicleOccupantSlotProtos.Local.FirstOrDefault(x =>
+				x.VehicleProtoId == vehicle.Id && x.VehicleProtoRevision == vehicle.RevisionNumber &&
+				x.VehicleCompartmentProtoId == compartment.Id &&
+				x.Name.Equals(spec.Name, StringComparison.OrdinalIgnoreCase)) ??
+		          _context.VehicleOccupantSlotProtos.AsEnumerable().FirstOrDefault(x =>
+			          x.VehicleProtoId == vehicle.Id && x.VehicleProtoRevision == vehicle.RevisionNumber &&
+			          x.VehicleCompartmentProtoId == compartment.Id &&
+			          x.Name.Equals(spec.Name, StringComparison.OrdinalIgnoreCase));
+		if (row is null)
+		{
+			row = new VehicleOccupantSlotProto
+			{
+				Id = NextVehicleChildId(_context.VehicleOccupantSlotProtos, x => x.Id),
+				VehicleProto = vehicle,
+				VehicleProtoId = vehicle.Id,
+				VehicleProtoRevision = vehicle.RevisionNumber
+			};
+			_context.VehicleOccupantSlotProtos.Add(row);
+		}
+
+		row.VehicleCompartmentProto = compartment;
+		row.VehicleCompartmentProtoId = compartment.Id;
+		row.Name = spec.Name;
+		row.SlotType = (int)spec.SlotType;
+		row.Capacity = spec.Capacity;
+		row.RequiredForMovement = spec.RequiredForMovement;
+		row.ContributesToPropulsion = spec.ContributesToPropulsion;
+		row.BoatStabilityDifficulty = (int)spec.BoatStabilityDifficulty;
+		return row;
+	}
+
+	private VehicleControlStationProto UpsertControlStation(
+		VehicleProto vehicle,
+		VehicleControlStationSeedSpec spec,
+		IReadOnlyDictionary<string, VehicleOccupantSlotProto> slots)
+	{
+		var slot = RequireKey(slots, spec.OccupantSlotKey, vehicle.Name, "occupant slot");
+		var row = _context!.VehicleControlStationProtos.Local.FirstOrDefault(x =>
+				x.VehicleProtoId == vehicle.Id && x.VehicleProtoRevision == vehicle.RevisionNumber &&
+				x.VehicleOccupantSlotProtoId == slot.Id &&
+				x.Name.Equals(spec.Name, StringComparison.OrdinalIgnoreCase)) ??
+		          _context.VehicleControlStationProtos.AsEnumerable().FirstOrDefault(x =>
+			          x.VehicleProtoId == vehicle.Id && x.VehicleProtoRevision == vehicle.RevisionNumber &&
+			          x.VehicleOccupantSlotProtoId == slot.Id &&
+			          x.Name.Equals(spec.Name, StringComparison.OrdinalIgnoreCase));
+		if (row is null)
+		{
+			row = new VehicleControlStationProto
+			{
+				Id = NextVehicleChildId(_context.VehicleControlStationProtos, x => x.Id),
+				VehicleProto = vehicle,
+				VehicleProtoId = vehicle.Id,
+				VehicleProtoRevision = vehicle.RevisionNumber
+			};
+			_context.VehicleControlStationProtos.Add(row);
+		}
+
+		row.VehicleOccupantSlotProto = slot;
+		row.VehicleOccupantSlotProtoId = slot.Id;
+		row.Name = spec.Name;
+		row.IsPrimary = spec.IsPrimary;
+		return row;
+	}
+
+	private VehicleMovementProfileProto UpsertMovementProfile(
+		VehicleProto vehicle,
+		VehicleMovementProfileSeedSpec spec)
+	{
+		var row = _context!.VehicleMovementProfileProtos.Local.FirstOrDefault(x =>
+				x.VehicleProtoId == vehicle.Id && x.VehicleProtoRevision == vehicle.RevisionNumber &&
+				x.Name.Equals(spec.Name, StringComparison.OrdinalIgnoreCase)) ??
+		          _context.VehicleMovementProfileProtos.AsEnumerable().FirstOrDefault(x =>
+			          x.VehicleProtoId == vehicle.Id && x.VehicleProtoRevision == vehicle.RevisionNumber &&
+			          x.Name.Equals(spec.Name, StringComparison.OrdinalIgnoreCase));
+		if (row is null)
+		{
+			row = new VehicleMovementProfileProto
+			{
+				Id = NextVehicleChildId(_context.VehicleMovementProfileProtos, x => x.Id),
+				VehicleProto = vehicle,
+				VehicleProtoId = vehicle.Id,
+				VehicleProtoRevision = vehicle.RevisionNumber
+			};
+			_context.VehicleMovementProfileProtos.Add(row);
+		}
+
+		row.Name = spec.Name;
+		row.MovementType = (int)spec.MovementType;
+		row.MovementEnvironment = (int)spec.Environment;
+		row.ExposesOccupantsToWater = spec.ExposesOccupantsToWater;
+		row.IsDefault = spec.IsDefault;
+		row.RequiredPowerSpikeInWatts = spec.RequiredPowerSpikeInWatts;
+		row.FuelLiquidId = string.IsNullOrWhiteSpace(spec.FuelLiquid)
+			? null
+			: _liquids.TryGetValue(spec.FuelLiquid, out var liquid)
+				? liquid.Id
+				: throw new InvalidOperationException($"Vehicle movement profile {vehicle.Name}/{spec.Name} uses unknown liquid {spec.FuelLiquid}.");
+		row.FuelVolumePerMove = spec.FuelVolumePerMove;
+		row.RequiredInstalledRole = spec.RequiredInstalledRole;
+		row.RequiresTowLinksClosed = spec.RequiresTowLinksClosed;
+		row.RequiresAccessPointsClosed = spec.RequiresAccessPointsClosed;
+		row.RouteSpeedMetresPerSecond = spec.RouteSpeedMetresPerSecond;
+		row.RoutePropulsionMode = (int)spec.RoutePropulsionMode;
+		row.RouteFuelVolumePerMetre = spec.RouteFuelVolumePerMetre;
+		row.RoutePowerDrawWatts = spec.RoutePowerDrawWatts;
+		row.AutomaticOperationCapable = spec.AutomaticOperationCapable;
+		return row;
+	}
+
+	private void UpsertPropulsionProfile(
+		VehicleMovementProfileProto movement,
+		VehiclePropulsionSeedSpec spec)
+	{
+		var row = _context!.VehiclePropulsionProfileProtos.Local.FirstOrDefault(x =>
+				x.VehicleMovementProfileProtoId == movement.Id && x.PropulsionType == (int)spec.PropulsionType) ??
+		          _context.VehiclePropulsionProfileProtos.FirstOrDefault(x =>
+			          x.VehicleMovementProfileProtoId == movement.Id && x.PropulsionType == (int)spec.PropulsionType);
+		if (row is null)
+		{
+			row = new VehiclePropulsionProfileProto
+			{
+				Id = NextVehicleChildId(_context.VehiclePropulsionProfileProtos, x => x.Id),
+				VehicleMovementProfileProto = movement,
+				VehicleMovementProfileProtoId = movement.Id
+			};
+			_context.VehiclePropulsionProfileProtos.Add(row);
+		}
+
+		var trait = spec.TraitCandidates
+			.Select(candidate => _traits.TryGetValue(candidate, out var definition) ? definition : null)
+			.FirstOrDefault(x => x is not null);
+		if ((spec.PropulsionType is VehiclePropulsionType.SelfPowered or VehiclePropulsionType.Rowed) && trait is null)
+		{
+			throw new InvalidOperationException(
+				$"Vehicle propulsion profile {movement.Name}/{spec.PropulsionType} requires one of these traits: {string.Join(", ", spec.TraitCandidates)}.");
+		}
+
+		row.PropulsionType = (int)spec.PropulsionType;
+		row.IsDefault = spec.IsDefault;
+		row.BaseMoveTimeMilliseconds = spec.BaseMoveTimeMilliseconds;
+		row.PropulsionTraitDefinition = trait;
+		row.PropulsionTraitDefinitionId = trait?.Id;
+		row.CheckDifficulty = (int)spec.CheckDifficulty;
+		row.SpeedMultiplierExpression = spec.SpeedMultiplierExpression;
+		row.StaminaCostExpression = spec.StaminaCostExpression;
+	}
+
+}

--- a/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Dispatch.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Dispatch.cs
@@ -1,0 +1,30 @@
+#nullable enable
+
+using MudSharp.Database;
+using System.Collections.Generic;
+
+namespace DatabaseSeeder.Seeders;
+
+public partial class ItemSeeder
+{
+	/// <summary>
+	/// Runs the vehicle subcomponent after the established item pass has populated the shared
+	/// component, material, liquid, trait and item dictionaries it consumes. The database seeder
+	/// host invokes ItemSeeder through IDatabaseSeeder, so this explicit implementation preserves
+	/// the existing public seeding pipeline while giving the vehicle graph a deterministic final
+	/// phase without coupling it to any one era-specific catalogue method.
+	/// </summary>
+	string IDatabaseSeeder.SeedData(
+		FuturemudDatabaseContext context,
+		IReadOnlyDictionary<string, string> questionAnswers)
+	{
+		var result = SeedData(context, questionAnswers);
+		if (questionAnswers.TryGetValue("eras", out var eras))
+		{
+			SeedVehicleItemsAndPrototypes(eras);
+			context.SaveChanges();
+		}
+
+		return result;
+	}
+}

--- a/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Helpers.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Helpers.cs
@@ -52,17 +52,14 @@ public partial class ItemSeeder
 		return Regex.Replace(value.ToLowerInvariant(), "[^a-z0-9]+", "_").Trim('_');
 	}
 
-	private static string VehicleChildMarker(string vehicleReference, string kind, string key)
-	{
-		return $"[{VehicleSeederMarkerPrefix}: {vehicleReference}/{kind}/{NormaliseKey(key)}]";
-	}
-
+	// Kept as a compatibility shim for the first persistence draft. Seeder ownership is now
+	// represented by stable exterior/projection references and internal component names rather
+	// than by adding implementation markers to builder- or player-facing descriptions.
 	private static string WithVehicleSeederMarker(string description, string vehicleReference, string kind, string key)
 	{
-		var marker = VehicleChildMarker(vehicleReference, kind, key);
-		return description.Contains(marker, StringComparison.OrdinalIgnoreCase)
-			? description
-			: $"{description.Trim()}\n{marker}";
+		_ = vehicleReference;
+		_ = kind;
+		_ = key;
+		return description.Trim();
 	}
-
 }

--- a/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Helpers.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Helpers.cs
@@ -1,0 +1,68 @@
+#nullable enable
+
+using ExpressionEngine;
+using Microsoft.EntityFrameworkCore;
+using MudSharp.Construction;
+using MudSharp.Database;
+using MudSharp.Framework;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.Models;
+using MudSharp.RPG.Checks;
+using MudSharp.Vehicles;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace DatabaseSeeder.Seeders;
+
+
+public partial class ItemSeeder
+{
+	private static TValue RequireKey<TValue>(
+		IReadOnlyDictionary<string, TValue> dictionary,
+		string key,
+		string owner,
+		string kind)
+	{
+		return dictionary.TryGetValue(key, out var value)
+			? value
+			: throw new InvalidOperationException($"{owner} references missing {kind} key {key}.");
+	}
+
+	private long NextVehiclePrototypeId()
+	{
+		var existing = _context!.VehicleProtos.Any() ? _context.VehicleProtos.Max(x => x.Id) : 0L;
+		var local = _context.VehicleProtos.Local.Any() ? _context.VehicleProtos.Local.Max(x => x.Id) : 0L;
+		return Math.Max(existing, local) + 1L;
+	}
+
+	private static string ComponentName(string role, string stableReference, string? childKey = null)
+	{
+		var value = childKey is null
+			? $"VS_{role}_{stableReference}"
+			: $"VS_{role}_{stableReference}_{childKey}";
+		return Regex.Replace(value, "[^A-Za-z0-9_]+", "_");
+	}
+
+	private static string NormaliseKey(string value)
+	{
+		return Regex.Replace(value.ToLowerInvariant(), "[^a-z0-9]+", "_").Trim('_');
+	}
+
+	private static string VehicleChildMarker(string vehicleReference, string kind, string key)
+	{
+		return $"[{VehicleSeederMarkerPrefix}: {vehicleReference}/{kind}/{NormaliseKey(key)}]";
+	}
+
+	private static string WithVehicleSeederMarker(string description, string vehicleReference, string kind, string key)
+	{
+		var marker = VehicleChildMarker(vehicleReference, kind, key);
+		return description.Contains(marker, StringComparison.OrdinalIgnoreCase)
+			? description
+			: $"{description.Trim()}\n{marker}";
+	}
+
+}

--- a/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Persistence.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Persistence.cs
@@ -1,0 +1,347 @@
+#nullable enable
+
+using ExpressionEngine;
+using Microsoft.EntityFrameworkCore;
+using MudSharp.Construction;
+using MudSharp.Database;
+using MudSharp.Framework;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.Models;
+using MudSharp.RPG.Checks;
+using MudSharp.Vehicles;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace DatabaseSeeder.Seeders;
+
+
+public partial class ItemSeeder
+{
+	private void UpsertVehiclePrototype(VehicleSeedSpec spec)
+	{
+		var eraTag = VehicleEraTags[spec.EraKey];
+		var domainFunctionTag = spec.Domain.Equals(VehicleDomainAquatic, StringComparison.OrdinalIgnoreCase)
+			? "Functions / Vehicles / Aquatic Vehicles"
+			: "Functions / Vehicles / Terrestrial Vehicles";
+		var domainMarketTag = spec.Domain.Equals(VehicleDomainAquatic, StringComparison.OrdinalIgnoreCase)
+			? "Market / Transportation / Vehicles / Aquatic Vehicles"
+			: "Market / Transportation / Vehicles / Terrestrial Vehicles";
+		var tags = new List<string>
+		{
+			eraTag,
+			"Functions / Vehicles",
+			domainFunctionTag,
+			"Market / Transportation / Vehicles",
+			domainMarketTag
+		};
+		if (spec.ProvidesCargoService)
+		{
+			tags.Add("Market / Transportation / Cargo Transportation");
+		}
+		if (spec.ProvidesPassengerService)
+		{
+			tags.Add("Market / Transportation / Passenger Transportation");
+		}
+
+		var exteriorComponents = new List<string> { spec.ExteriorItem.DestroyableComponent };
+		if (spec.ExteriorItem.Portable)
+		{
+			exteriorComponents.Insert(0, "Holdable");
+		}
+		var exterior = UpsertVehicleItem(
+			$"{spec.StableReference}_exterior",
+			spec.ExteriorItem,
+			tags,
+			exteriorComponents,
+			$"Vehicle prototype stable reference: {spec.StableReference}. {spec.BuilderNotes}".Trim());
+
+		var vehicle = FindVehiclePrototypeByExterior(exterior, spec.StableReference);
+		if (vehicle is null)
+		{
+			vehicle = new VehicleProto
+			{
+				Id = NextVehiclePrototypeId(),
+				RevisionNumber = 0,
+				EditableItem = NewAntiquityEditableItem()
+			};
+		}
+		if (_context!.Entry(vehicle).State == EntityState.Detached)
+		{
+			_context.VehicleProtos.Add(vehicle);
+		}
+		vehicle.Name = spec.Name;
+		vehicle.Description = WithVehicleSeederMarker(spec.Description, spec.StableReference, "vehicle", "root");
+		vehicle.VehicleScale = (int)spec.Scale;
+		vehicle.ExteriorItemProto = exterior;
+		vehicle.ExteriorItemProtoId = exterior.Id;
+		vehicle.ExteriorItemProtoRevision = exterior.RevisionNumber;
+		_context.SaveChanges();
+
+		var exteriorComponent = EnsureVehicleComponent(
+			ComponentName("Exterior", spec.StableReference),
+			"Vehicle Exterior",
+			$"Internal projection component linking {spec.StableReference} to its exterior item.",
+			new XElement("Definition", new XElement("VehiclePrototypeId", vehicle.Id)).ToString());
+		EnsureItemHasComponent(exterior, exteriorComponent);
+
+		var compartments = spec.Compartments.ToDictionary(
+			x => x.Key,
+			x => UpsertCompartment(vehicle, spec.StableReference, x),
+			StringComparer.OrdinalIgnoreCase);
+		_context.SaveChanges();
+
+		foreach (var link in spec.CompartmentLinks)
+		{
+			UpsertCompartmentLink(vehicle, link, compartments);
+		}
+
+		var slots = spec.OccupantSlots.ToDictionary(
+			x => x.Key,
+			x => UpsertOccupantSlot(vehicle, x, compartments),
+			StringComparer.OrdinalIgnoreCase);
+		var movementProfiles = spec.MovementProfiles.ToDictionary(
+			x => x.Key,
+			x => UpsertMovementProfile(vehicle, x),
+			StringComparer.OrdinalIgnoreCase);
+		var accessPoints = spec.AccessPoints.ToDictionary(
+			x => x.Key,
+			x => UpsertAccessPoint(vehicle, spec.StableReference, x, compartments),
+			StringComparer.OrdinalIgnoreCase);
+		var damageZones = spec.DamageZones.ToDictionary(
+			x => x.Key,
+			x => UpsertDamageZone(vehicle, spec.StableReference, x),
+			StringComparer.OrdinalIgnoreCase);
+		_context.SaveChanges();
+
+		foreach (var station in spec.ControlStations)
+		{
+			UpsertControlStation(vehicle, station, slots);
+		}
+
+		foreach (var movementSpec in spec.MovementProfiles)
+		{
+			foreach (var propulsion in movementSpec.PropulsionProfiles)
+			{
+				UpsertPropulsionProfile(movementProfiles[movementSpec.Key], propulsion);
+			}
+		}
+
+		var cargoSpaces = spec.CargoSpaces.ToDictionary(
+			x => x.Key,
+			x => UpsertCargoSpace(vehicle, spec.StableReference, x, compartments, accessPoints),
+			StringComparer.OrdinalIgnoreCase);
+		var installationPoints = spec.InstallationPoints.ToDictionary(
+			x => x.Key,
+			x => UpsertInstallationPoint(vehicle, spec.StableReference, x, accessPoints),
+			StringComparer.OrdinalIgnoreCase);
+		var towPoints = spec.TowPoints.ToDictionary(
+			x => x.Key,
+			x => UpsertTowPoint(vehicle, spec.StableReference, x, accessPoints),
+			StringComparer.OrdinalIgnoreCase);
+		_context.SaveChanges();
+
+		foreach (var zoneSpec in spec.DamageZones)
+		{
+			foreach (var effectSpec in zoneSpec.Effects)
+			{
+				UpsertDamageEffect(
+					damageZones[zoneSpec.Key],
+					effectSpec,
+					movementProfiles,
+					accessPoints,
+					cargoSpaces,
+					installationPoints,
+					towPoints);
+			}
+		}
+
+		foreach (var accessSpec in spec.AccessPoints)
+		{
+			var access = accessPoints[accessSpec.Key];
+			var projection = UpsertVehicleProjectionItem(
+				$"{spec.StableReference}_access_{NormaliseKey(accessSpec.Key)}",
+				accessSpec.ProjectionItem,
+				eraTag,
+				[]);
+			var component = EnsureVehicleComponent(
+				ComponentName("Access", spec.StableReference, accessSpec.Key),
+				"Vehicle Access Point",
+				$"Internal projection component for {spec.StableReference} access point {accessSpec.Key}.",
+				new XElement("Definition",
+					new XElement("VehiclePrototypeId", vehicle.Id),
+					new XElement("AccessPointPrototypeId", access.Id)).ToString());
+			EnsureItemHasComponent(projection, component);
+			access.ProjectionItemProto = projection;
+			access.ProjectionItemProtoId = projection.Id;
+			access.ProjectionItemProtoRevision = projection.RevisionNumber;
+		}
+
+		foreach (var cargoSpec in spec.CargoSpaces)
+		{
+			var cargo = cargoSpaces[cargoSpec.Key];
+			var projection = UpsertVehicleProjectionItem(
+				$"{spec.StableReference}_cargo_{NormaliseKey(cargoSpec.Key)}",
+				cargoSpec.ProjectionItem,
+				eraTag,
+				[cargoSpec.ContainerComponent]);
+			var component = EnsureVehicleComponent(
+				ComponentName("Cargo", spec.StableReference, cargoSpec.Key),
+				"Vehicle Cargo Space",
+				$"Internal projection component for {spec.StableReference} cargo space {cargoSpec.Key}.",
+				new XElement("Definition",
+					new XElement("VehiclePrototypeId", vehicle.Id),
+					new XElement("CargoSpacePrototypeId", cargo.Id)).ToString());
+			EnsureItemHasComponent(projection, component);
+			cargo.ProjectionItemProto = projection;
+			cargo.ProjectionItemProtoId = projection.Id;
+			cargo.ProjectionItemProtoRevision = projection.RevisionNumber;
+		}
+
+		_context.SaveChanges();
+	}
+
+	private GameItemProto UpsertVehicleProjectionItem(
+		string stableReference,
+		VehicleItemSeedSpec spec,
+		string eraTag,
+		IEnumerable<string> extraComponents)
+	{
+		var components = new List<string> { spec.DestroyableComponent };
+		components.AddRange(extraComponents);
+		return UpsertVehicleItem(
+			stableReference,
+			spec with { Portable = false, Skinnable = false, HiddenFromPlayers = true },
+			[eraTag, "Functions / Vehicles / Projection Items"],
+			components,
+			"Internal vehicle projection item. Do not place or clone directly.");
+	}
+
+	private GameItemProto UpsertVehicleItem(
+		string stableReference,
+		VehicleItemSeedSpec spec,
+		IEnumerable<string> tags,
+		IEnumerable<string> ordinaryComponents,
+		string builderNotes)
+	{
+		if (!_materials.ContainsKey(spec.Material))
+		{
+			throw new InvalidOperationException($"Vehicle item {stableReference} uses unknown material {spec.Material}.");
+		}
+		foreach (var tag in tags)
+		{
+			EnsureAntiquityTagPath(tag);
+		}
+
+		var item = CreateItem(
+			stableReference,
+			spec.Noun,
+			spec.ShortDescription,
+			spec.LongDescription,
+			spec.FullDescription,
+			spec.Size,
+			spec.Quality,
+			spec.WeightInGrams,
+			spec.Cost,
+			spec.Skinnable,
+			spec.HiddenFromPlayers,
+			spec.Material,
+			tags,
+			ordinaryComponents,
+			null,
+			null,
+			null,
+			null,
+			builderNotes,
+			false) ?? throw new InvalidOperationException($"Unable to create vehicle item {stableReference}.");
+
+		item.Name = spec.Noun.ToLowerInvariant();
+		item.Keywords = new ExplodedString(spec.ShortDescription.Strip_A_An()).Words.Distinct().ListToCommaSeparatedValues(" ");
+		item.MaterialId = _materials[spec.Material].Id;
+		item.Size = (int)spec.Size;
+		item.Weight = spec.WeightInGrams;
+		item.LongDescription = spec.LongDescription;
+		item.BaseItemQuality = (int)spec.Quality;
+		item.ShortDescription = spec.ShortDescription;
+		item.FullDescription = spec.FullDescription;
+		item.PermitPlayerSkins = spec.Skinnable;
+		item.CostInBaseCurrency = spec.Cost;
+		item.IsHiddenFromPlayers = spec.HiddenFromPlayers;
+		item.ReadOnly = false;
+		ApplyReworkItemTags(item, tags);
+		foreach (var componentName in ordinaryComponents)
+		{
+			if (!_components.TryGetValue(componentName, out var component))
+			{
+				throw new InvalidOperationException($"Vehicle item {stableReference} uses unknown component {componentName}.");
+			}
+			EnsureItemHasComponent(item, component);
+		}
+		return item;
+	}
+
+	private GameItemComponentProto EnsureVehicleComponent(string name, string type, string description, string definition)
+	{
+		var component = _components.TryGetValue(name, out var cached)
+			? cached
+			: _context!.GameItemComponentProtos.Local.FirstOrDefault(x => x.Name.Equals(name, StringComparison.OrdinalIgnoreCase)) ??
+			  _context.GameItemComponentProtos.AsEnumerable()
+				  .FirstOrDefault(x => x.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+		if (component is null)
+		{
+			component = new GameItemComponentProto
+			{
+				Id = NextComponentId(),
+				Name = name,
+				Description = description,
+				Type = type,
+				RevisionNumber = 0,
+				Definition = definition,
+				EditableItem = NewAntiquityEditableItem()
+			};
+			_context!.GameItemComponentProtos.Add(component);
+		}
+		else
+		{
+			if (!component.Type.Equals(type, StringComparison.OrdinalIgnoreCase))
+			{
+				throw new InvalidOperationException(
+					$"Vehicle component {name} already exists as type {component.Type}, not {type}.");
+			}
+			component.Description = description;
+			component.Definition = definition;
+		}
+		_components[name] = component;
+		return component;
+	}
+
+	private void EnsureItemHasComponent(GameItemProto item, GameItemComponentProto component)
+	{
+		var exists = item.GameItemProtosGameItemComponentProtos.Any(x =>
+				x.GameItemComponentProtoId == component.Id && x.GameItemComponentRevision == component.RevisionNumber) ||
+			_context!.GameItemProtosGameItemComponentProtos.Local.Any(x =>
+				x.GameItemProtoId == item.Id && x.GameItemProtoRevision == item.RevisionNumber &&
+				x.GameItemComponentProtoId == component.Id && x.GameItemComponentRevision == component.RevisionNumber) ||
+			_context.GameItemProtosGameItemComponentProtos.Any(x =>
+				x.GameItemProtoId == item.Id && x.GameItemProtoRevision == item.RevisionNumber &&
+				x.GameItemComponentProtoId == component.Id && x.GameItemComponentRevision == component.RevisionNumber);
+		if (exists)
+		{
+			return;
+		}
+
+		_context.GameItemProtosGameItemComponentProtos.Add(new GameItemProtosGameItemComponentProtos
+		{
+			GameItemProtoId = item.Id,
+			GameItemProtoRevision = item.RevisionNumber,
+			GameItemComponentProtoId = component.Id,
+			GameItemComponentRevision = component.RevisionNumber,
+			GameItemProto = item,
+			GameItemComponent = component
+		});
+	}
+
+}

--- a/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Support.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Support.cs
@@ -1,0 +1,200 @@
+#nullable enable
+
+using ExpressionEngine;
+using Microsoft.EntityFrameworkCore;
+using MudSharp.Construction;
+using MudSharp.Database;
+using MudSharp.Framework;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.Models;
+using MudSharp.RPG.Checks;
+using MudSharp.Vehicles;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace DatabaseSeeder.Seeders;
+
+
+public partial class ItemSeeder
+{
+	private void SeedVehicleSupportItems(IReadOnlyCollection<string> selectedEras)
+	{
+		var allPreModern = selectedEras.Any(x => x is "antiquity" or "medieval" or "renaissance" or "earlymodern" or "revolution");
+		var allMechanical = selectedEras.Any(x => x is "modern" or "atomic" or "computer");
+		var allDraft = allPreModern;
+
+		if (allPreModern)
+		{
+			var oar = EnsureVehicleComponent(
+				"VehicleSeeder_Oar_Preindustrial",
+				"Vehicle Oar",
+				"Turns an item into a serviceable pre-industrial vehicle oar.",
+				new XElement("Definition", new XElement("EfficiencyMultiplier", 1.0)).ToString());
+			UpsertVehicleEquipmentItem(
+				"vehicle_preindustrial_wooden_oar",
+				new VehicleItemSeedSpec(
+					"oar",
+					"a long-bladed wooden oar",
+					"This long oar is shaped from a single length of close-grained timber. Its shaft is rounded smooth where hands and rowlocks bear upon it, while the broad blade thins towards a reinforced edge. Minor scrapes and water-darkening mark it as practical working equipment rather than decoration.",
+					SizeCategory.Large,
+					ItemQuality.Standard,
+					5200.0,
+					80.0m,
+					"ash",
+					"Destroyable_WoodenHeavy",
+					true),
+				["Functions / Vehicles / Vehicle Equipment / Propulsion Equipment", "Market / Transportation / Vehicle Equipment"],
+				[oar]);
+		}
+
+		if (allMechanical)
+		{
+			var oar = EnsureVehicleComponent(
+				"VehicleSeeder_Oar_Modern",
+				"Vehicle Oar",
+				"Turns an item into a durable modern vehicle oar.",
+				new XElement("Definition", new XElement("EfficiencyMultiplier", 1.1)).ToString());
+			UpsertVehicleEquipmentItem(
+				"vehicle_modern_varnished_oar",
+				new VehicleItemSeedSpec(
+					"oar",
+					"a varnished laminated oar",
+					"This oar has a straight laminated shaft and a broad, carefully balanced blade. Clear varnish seals the pale wood against spray, leaving the layered grain visible beneath a hard gloss. A shaped grip and a dark rubbing band at the rowlock make it suitable for repeated use in a small boat.",
+					SizeCategory.Large,
+					ItemQuality.Good,
+					4300.0,
+					240.0m,
+					"ash",
+					"Destroyable_WoodenHeavy",
+					true),
+				["Functions / Vehicles / Vehicle Equipment / Propulsion Equipment", "Market / Transportation / Vehicle Equipment"],
+				[oar]);
+
+			if (_liquids.TryGetValue("gasoline", out var gasoline))
+			{
+				var installable = EnsureVehicleComponent(
+					"VehicleSeeder_Installable_OutboardMotor",
+					"Vehicle Installable",
+					"Turns an item into an outboard-motor module for a matching vehicle installation point.",
+					new XElement("Definition",
+						new XElement("MountType", VehicleOutboardMountType),
+						new XElement("Role", VehiclePropulsionRole),
+						new XElement("MinimumFunctionalCondition", 0.2),
+						new XElement("MinimumMovementCondition", 0.35)).ToString());
+				var motor = EnsureVehicleComponent(
+					"VehicleSeeder_OutboardMotor_Petrol",
+					"Outboard Motor",
+					"Turns an item into a small fuelled outboard motor for surface-water vehicles.",
+					new XElement("Definition",
+						new XElement("EnergySource", OutboardMotorEnergySource.Fuelled),
+						new XElement("OutputMultiplier", 1.0),
+						new XElement("FuelLiquidId", gasoline.Id),
+						new XElement("FuelVolumePerMove", 0.15),
+						new XElement("RequiredPowerSpikeInWatts", 0.0)).ToString());
+				UpsertVehicleEquipmentItem(
+					"vehicle_modern_petrol_outboard_motor",
+					new VehicleItemSeedSpec(
+						"motor",
+						"a compact petrol outboard motor",
+						"A compact metal engine housing sits above a long drive leg and a guarded propeller. A clamp bracket, tiller handle and small integral fuel reservoir make the unit visibly intended to hang from a boat's transom. Painted panels protect most of the machinery, though control cables, fasteners and cooling-water passages remain accessible for maintenance.",
+						SizeCategory.Large,
+						ItemQuality.Standard,
+						42000.0,
+						4800.0m,
+						"mild steel",
+						"Destroyable_HeavyMetal",
+						true),
+					["Functions / Vehicles / Vehicle Equipment / Propulsion Equipment", "Market / Transportation / Vehicle Equipment"],
+					[installable, motor],
+					["LContainer_FuelCan"]);
+			}
+		}
+
+		if (allDraft)
+		{
+			var harness = EnsureVehicleComponent(
+				"VehicleSeeder_Hitch_DraftHarness",
+				"HitchGear",
+				"Turns an item into draft harness and traces suitable for linking pullers to a vehicle.",
+				new XElement("Definition",
+					new XElement("Roles", HitchGearRole.Yoke | HitchGearRole.Harness | HitchGearRole.Traces),
+					new XElement("MaximumUsers", 4),
+					new XElement("EffortMultiplier", 1.25),
+					new XElement("MaximumTowedWeight", 5000000.0)).ToString());
+			UpsertVehicleEquipmentItem(
+				"vehicle_preindustrial_draft_harness",
+				new VehicleItemSeedSpec(
+					"harness",
+					"a stout draft harness and traces",
+					"Broad leather straps, a padded breast band and paired traces form a practical set of draft harness. Reinforced rings and buckles distribute pulling force without relying on a single fastening. The pieces show the darkened polish and stretching expected of equipment made to work under steady load.",
+					SizeCategory.Normal,
+					ItemQuality.Standard,
+					11500.0,
+					260.0m,
+					"leather",
+					"Destroyable_Misc",
+					true),
+				["Functions / Vehicles / Vehicle Equipment / Hitching Equipment", "Market / Transportation / Vehicle Equipment"],
+				[harness]);
+		}
+
+		if (allMechanical)
+		{
+			var towBar = EnsureVehicleComponent(
+				"VehicleSeeder_Hitch_TowBar",
+				"HitchGear",
+				"Turns an item into a rigid tow bar for compatible road vehicles.",
+				new XElement("Definition",
+					new XElement("Roles", HitchGearRole.TowBar),
+					new XElement("MaximumUsers", 2),
+					new XElement("EffortMultiplier", 1.0),
+					new XElement("MaximumTowedWeight", 3500000.0)).ToString());
+			UpsertVehicleEquipmentItem(
+				"vehicle_modern_rigid_tow_bar",
+				new VehicleItemSeedSpec(
+					"towbar",
+					"a rigid steel tow bar",
+					"Two telescoping steel arms meet at a reinforced towing eye, with locking pins securing each joint. The opposite ends carry adjustable couplings intended to fasten to prepared towing points. Scraped paint around the pins and eyes reveals bright metal where the bar takes its working loads.",
+					SizeCategory.Large,
+					ItemQuality.Standard,
+					18500.0,
+					900.0m,
+					"mild steel",
+					"Destroyable_HeavyMetal",
+					true),
+				["Functions / Vehicles / Vehicle Equipment / Hitching Equipment", "Market / Transportation / Vehicle Equipment"],
+				[towBar]);
+		}
+	}
+
+	private void UpsertVehicleEquipmentItem(
+		string stableReference,
+		VehicleItemSeedSpec itemSpec,
+		IEnumerable<string> tags,
+		IEnumerable<GameItemComponentProto> generatedComponents,
+		IEnumerable<string>? ordinaryComponents = null)
+	{
+		var components = new List<string>();
+		if (itemSpec.Portable)
+		{
+			components.Add("Holdable");
+		}
+		components.Add(itemSpec.DestroyableComponent);
+		if (ordinaryComponents is not null)
+		{
+			components.AddRange(ordinaryComponents);
+		}
+
+		var item = UpsertVehicleItem(stableReference, itemSpec, tags, components,
+			"Seeder category: shared vehicle equipment.");
+		foreach (var component in generatedComponents)
+		{
+			EnsureItemHasComponent(item, component);
+		}
+	}
+
+}

--- a/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Support.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Support.cs
@@ -74,44 +74,47 @@ public partial class ItemSeeder
 				["Functions / Vehicles / Vehicle Equipment / Propulsion Equipment", "Market / Transportation / Vehicle Equipment"],
 				[oar]);
 
-			if (_liquids.TryGetValue("gasoline", out var gasoline))
+			if (!_liquids.TryGetValue("gasoline", out var gasoline))
 			{
-				var installable = EnsureVehicleComponent(
-					"VehicleSeeder_Installable_OutboardMotor",
-					"Vehicle Installable",
-					"Turns an item into an outboard-motor module for a matching vehicle installation point.",
-					new XElement("Definition",
-						new XElement("MountType", VehicleOutboardMountType),
-						new XElement("Role", VehiclePropulsionRole),
-						new XElement("MinimumFunctionalCondition", 0.2),
-						new XElement("MinimumMovementCondition", 0.35)).ToString());
-				var motor = EnsureVehicleComponent(
-					"VehicleSeeder_OutboardMotor_Petrol",
-					"Outboard Motor",
-					"Turns an item into a small fuelled outboard motor for surface-water vehicles.",
-					new XElement("Definition",
-						new XElement("EnergySource", OutboardMotorEnergySource.Fuelled),
-						new XElement("OutputMultiplier", 1.0),
-						new XElement("FuelLiquidId", gasoline.Id),
-						new XElement("FuelVolumePerMove", 0.15),
-						new XElement("RequiredPowerSpikeInWatts", 0.0)).ToString());
-				UpsertVehicleEquipmentItem(
-					"vehicle_modern_petrol_outboard_motor",
-					new VehicleItemSeedSpec(
-						"motor",
-						"a compact petrol outboard motor",
-						"A compact metal engine housing sits above a long drive leg and a guarded propeller. A clamp bracket, tiller handle and small integral fuel reservoir make the unit visibly intended to hang from a boat's transom. Painted panels protect most of the machinery, though control cables, fasteners and cooling-water passages remain accessible for maintenance.",
-						SizeCategory.Large,
-						ItemQuality.Standard,
-						42000.0,
-						4800.0m,
-						"mild steel",
-						"Destroyable_HeavyMetal",
-						true),
-					["Functions / Vehicles / Vehicle Equipment / Propulsion Equipment", "Market / Transportation / Vehicle Equipment"],
-					[installable, motor],
-					["LContainer_FuelCan"]);
+				throw new InvalidOperationException(
+					"The vehicle seeder requires the seeded liquid 'gasoline' to create the petrol outboard motor.");
 			}
+
+			var installable = EnsureVehicleComponent(
+				"VehicleSeeder_Installable_OutboardMotor",
+				"Vehicle Installable",
+				"Turns an item into an outboard-motor module for a matching vehicle installation point.",
+				new XElement("Definition",
+					new XElement("MountType", VehicleOutboardMountType),
+					new XElement("Role", VehiclePropulsionRole),
+					new XElement("MinimumFunctionalCondition", 0.2),
+					new XElement("MinimumMovementCondition", 0.35)).ToString());
+			var motor = EnsureVehicleComponent(
+				"VehicleSeeder_OutboardMotor_Petrol",
+				"Outboard Motor",
+				"Turns an item into a small fuelled outboard motor for surface-water vehicles.",
+				new XElement("Definition",
+					new XElement("EnergySource", OutboardMotorEnergySource.Fuelled),
+					new XElement("OutputMultiplier", 1.0),
+					new XElement("FuelLiquidId", gasoline.Id),
+					new XElement("FuelVolumePerMove", 0.15),
+					new XElement("RequiredPowerSpikeInWatts", 0.0)).ToString());
+			UpsertVehicleEquipmentItem(
+				"vehicle_modern_petrol_outboard_motor",
+				new VehicleItemSeedSpec(
+					"motor",
+					"a compact petrol outboard motor",
+					"A compact metal engine housing sits above a long drive leg and a guarded propeller. A clamp bracket, tiller handle and small integral fuel reservoir make the unit visibly intended to hang from a boat's transom. Painted panels protect most of the machinery, though control cables, fasteners and cooling-water passages remain accessible for maintenance.",
+					SizeCategory.Large,
+					ItemQuality.Standard,
+					42000.0,
+					4800.0m,
+					"mild steel",
+					"Destroyable_HeavyMetal",
+					true),
+				["Functions / Vehicles / Vehicle Equipment / Propulsion Equipment", "Market / Transportation / Vehicle Equipment"],
+				[installable, motor],
+				["LContainer_FuelCan"]);
 		}
 
 		if (allDraft)

--- a/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Validation.Details.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Validation.Details.cs
@@ -1,0 +1,274 @@
+#nullable enable
+
+using ExpressionEngine;
+using MudSharp.Vehicles;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace DatabaseSeeder.Seeders;
+
+public partial class ItemSeeder
+{
+	private static void ValidateMovementProfile(
+		VehicleSeedSpec owner,
+		VehicleMovementProfileSeedSpec movement,
+		IReadOnlySet<string> installationKeys)
+	{
+		RequireText(owner, movement.Name, $"movement profile {movement.Key} name");
+		RequireNonNegativeFinite(owner, movement.RequiredPowerSpikeInWatts, $"movement profile {movement.Key} required power spike");
+		RequireNonNegativeFinite(owner, movement.FuelVolumePerMove, $"movement profile {movement.Key} fuel volume per move");
+		RequireNonNegativeFinite(owner, movement.RouteSpeedMetresPerSecond, $"movement profile {movement.Key} route speed");
+		RequireNonNegativeFinite(owner, movement.RouteFuelVolumePerMetre, $"movement profile {movement.Key} route fuel use");
+		RequireNonNegativeFinite(owner, movement.RoutePowerDrawWatts, $"movement profile {movement.Key} route power draw");
+		if (movement.FuelVolumePerMove > 0.0 && string.IsNullOrWhiteSpace(movement.FuelLiquid))
+		{
+			throw VehicleValidation(owner, $"movement profile {movement.Key} consumes fuel per move but has no fuel liquid");
+		}
+		if (movement.MovementType == VehicleMovementProfileType.Route)
+		{
+			RequirePositiveFinite(owner, movement.RouteSpeedMetresPerSecond, $"route profile {movement.Key} speed");
+			if (movement.AutomaticOperationCapable && movement.RoutePropulsionMode != RouteVehiclePropulsionMode.Powered)
+			{
+				throw VehicleValidation(owner, $"route profile {movement.Key} cannot be automatic while externally pulled");
+			}
+			if (movement.RoutePropulsionMode == RouteVehiclePropulsionMode.Powered &&
+			    movement.RouteFuelVolumePerMetre <= 0.0 && movement.RoutePowerDrawWatts <= 0.0)
+			{
+				throw VehicleValidation(owner, $"powered route profile {movement.Key} must consume fuel or electrical power");
+			}
+		}
+		else if (movement.RouteSpeedMetresPerSecond != 0.0 || movement.RouteFuelVolumePerMetre != 0.0 ||
+		         movement.RoutePowerDrawWatts != 0.0 || movement.AutomaticOperationCapable)
+		{
+			throw VehicleValidation(owner, $"non-route profile {movement.Key} cannot use route-only values");
+		}
+
+		if (movement.Environment == VehicleMovementEnvironment.SurfaceWater)
+		{
+			if (movement.PropulsionProfiles.Count == 0 || movement.PropulsionProfiles.Count(x => x.IsDefault) != 1)
+			{
+				throw VehicleValidation(owner, $"surface-water profile {movement.Key} requires propulsion profiles and exactly one default");
+			}
+			var duplicate = movement.PropulsionProfiles.GroupBy(x => x.PropulsionType).FirstOrDefault(x => x.Count() > 1);
+			if (duplicate is not null)
+			{
+				throw VehicleValidation(owner, $"surface-water profile {movement.Key} repeats propulsion type {duplicate.Key}");
+			}
+			foreach (var propulsion in movement.PropulsionProfiles)
+			{
+				ValidatePropulsionProfile(owner, movement, propulsion);
+			}
+			if (movement.PropulsionProfiles.Any(x => x.PropulsionType == VehiclePropulsionType.Rowed) &&
+			    !owner.OccupantSlots.Any(x => x.ContributesToPropulsion))
+			{
+				throw VehicleValidation(owner, $"rowed profile {movement.Key} requires at least one propulsion-contributing occupant slot");
+			}
+			if (movement.PropulsionProfiles.Any(x => x.PropulsionType == VehiclePropulsionType.OutboardMotor) &&
+			    !owner.InstallationPoints.Any(x => x.MountType.Equals(VehicleOutboardMountType, StringComparison.OrdinalIgnoreCase) &&
+			                                       x.RequiredRole.Equals(VehiclePropulsionRole, StringComparison.OrdinalIgnoreCase)))
+			{
+				throw VehicleValidation(owner, $"outboard profile {movement.Key} requires an outboard_motor installation point with the propulsion role");
+			}
+		}
+		else if (movement.PropulsionProfiles.Count > 0)
+		{
+			throw VehicleValidation(owner, $"terrestrial profile {movement.Key} must use movement resources/towing rather than surface-water propulsion profiles");
+		}
+
+		if (!string.IsNullOrWhiteSpace(movement.RequiredInstalledRole) &&
+		    !owner.InstallationPoints.Any(x => x.RequiredRole.Equals(movement.RequiredInstalledRole, StringComparison.OrdinalIgnoreCase)))
+		{
+			throw VehicleValidation(owner, $"movement profile {movement.Key} requires role '{movement.RequiredInstalledRole}' but no installation point supplies it");
+		}
+	}
+
+	private static void ValidatePropulsionProfile(
+		VehicleSeedSpec owner,
+		VehicleMovementProfileSeedSpec movement,
+		VehiclePropulsionSeedSpec propulsion)
+	{
+		if (propulsion.PropulsionType == VehiclePropulsionType.None)
+		{
+			throw VehicleValidation(owner, $"movement profile {movement.Key} cannot seed propulsion type None");
+		}
+		RequirePositiveFinite(owner, propulsion.BaseMoveTimeMilliseconds,
+			$"movement profile {movement.Key}/{propulsion.PropulsionType} base move time");
+		if (propulsion.BaseMoveTimeMilliseconds < 250.0 || propulsion.BaseMoveTimeMilliseconds > 300000.0)
+		{
+			throw VehicleValidation(owner,
+				$"movement profile {movement.Key}/{propulsion.PropulsionType} base move time should be between 250 and 300000 milliseconds");
+		}
+		if ((propulsion.PropulsionType is VehiclePropulsionType.SelfPowered or VehiclePropulsionType.Rowed) &&
+		    propulsion.TraitCandidates.Count == 0)
+		{
+			throw VehicleValidation(owner, $"movement profile {movement.Key}/{propulsion.PropulsionType} needs trait candidates");
+		}
+		RequireText(owner, propulsion.SpeedMultiplierExpression,
+			$"movement profile {movement.Key}/{propulsion.PropulsionType} speed expression");
+		RequireText(owner, propulsion.StaminaCostExpression,
+			$"movement profile {movement.Key}/{propulsion.PropulsionType} stamina expression");
+		try
+		{
+			foreach (var outcome in Enumerable.Range(-3, 7))
+			{
+				var speed = new Expression(propulsion.SpeedMultiplierExpression).EvaluateDoubleWith(
+					("outcome", (double)outcome), ("wind", 4.0), ("output", 1.0), ("swimcost", 1.0));
+				var stamina = new Expression(propulsion.StaminaCostExpression).EvaluateDoubleWith(
+					("outcome", (double)outcome), ("wind", 4.0), ("output", 1.0), ("swimcost", 1.0));
+				if (!double.IsFinite(speed) || speed <= 0.0 || !double.IsFinite(stamina) || stamina < 0.0)
+				{
+					throw VehicleValidation(owner,
+						$"movement profile {movement.Key}/{propulsion.PropulsionType} expressions produce invalid values");
+				}
+			}
+		}
+		catch (InvalidOperationException)
+		{
+			throw;
+		}
+		catch (Exception ex)
+		{
+			throw VehicleValidation(owner,
+				$"movement profile {movement.Key}/{propulsion.PropulsionType} contains an invalid expression: {ex.Message}");
+		}
+	}
+
+	private static void ValidateVehicleItem(VehicleSeedSpec owner, VehicleItemSeedSpec item, string label, bool projection)
+	{
+		RequireText(owner, item.Noun, $"{label} noun");
+		RequireText(owner, item.ShortDescription, $"{label} short description");
+		RequireText(owner, item.FullDescription, $"{label} full description");
+		RequireText(owner, item.Material, $"{label} material");
+		RequireText(owner, item.DestroyableComponent, $"{label} destroyable component");
+		RequirePositiveFinite(owner, item.WeightInGrams, $"{label} weight");
+		if (item.Cost < 0.0m)
+		{
+			throw VehicleValidation(owner, $"{label} cost cannot be negative");
+		}
+		if (projection && (item.Portable || item.Skinnable || !item.HiddenFromPlayers))
+		{
+			throw VehicleValidation(owner, $"{label} must be hidden, non-portable and non-skinnable");
+		}
+	}
+
+	private static void ValidateDamageEffectReference(
+		VehicleSeedSpec owner,
+		VehicleDamageZoneSeedSpec zone,
+		VehicleDamageEffectSeedSpec effect,
+		IReadOnlySet<string> movementKeys,
+		IReadOnlySet<string> accessKeys,
+		IReadOnlySet<string> cargoKeys,
+		IReadOnlySet<string> installationKeys,
+		IReadOnlySet<string> towKeys)
+	{
+		if (effect.TargetType == VehicleDamageEffectTargetType.WholeVehicleMovement)
+		{
+			if (!string.IsNullOrWhiteSpace(effect.TargetKey))
+			{
+				throw VehicleValidation(owner, $"damage zone {zone.Key} whole-vehicle effect must not specify a target key");
+			}
+			return;
+		}
+		if (string.IsNullOrWhiteSpace(effect.TargetKey))
+		{
+			throw VehicleValidation(owner, $"damage zone {zone.Key} effect {effect.TargetType} requires a target key");
+		}
+
+		var keys = effect.TargetType switch
+		{
+			VehicleDamageEffectTargetType.MovementProfile => movementKeys,
+			VehicleDamageEffectTargetType.AccessPoint => accessKeys,
+			VehicleDamageEffectTargetType.CargoSpace => cargoKeys,
+			VehicleDamageEffectTargetType.InstallationPoint => installationKeys,
+			VehicleDamageEffectTargetType.TowPoint => towKeys,
+			_ => throw VehicleValidation(owner, $"damage zone {zone.Key} uses unsupported effect target {effect.TargetType}")
+		};
+		RequireReference(owner, keys, effect.TargetKey, $"damage zone {zone.Key} effect target");
+	}
+
+	private static void ValidateTowStress(VehicleSeedSpec owner, VehicleTowPointSeedSpec point)
+	{
+		var values = new[]
+		{
+			point.TowStressWarningRatio,
+			point.TowStressFailureStartRatio,
+			point.TowStressMaximumFailureChance,
+			point.TowStressDamageMultiplier
+		};
+		if (values.All(x => x is null))
+		{
+			return;
+		}
+		if (values.Any(x => x is null))
+		{
+			throw VehicleValidation(owner, $"tow point {point.Key} must specify either all or none of the tow-stress values");
+		}
+		if (!double.IsFinite(point.TowStressWarningRatio!.Value) || point.TowStressWarningRatio.Value <= 0.0 ||
+		    !double.IsFinite(point.TowStressFailureStartRatio!.Value) || point.TowStressFailureStartRatio.Value < point.TowStressWarningRatio.Value ||
+		    !double.IsFinite(point.TowStressMaximumFailureChance!.Value) || point.TowStressMaximumFailureChance.Value is < 0.0 or > 1.0 ||
+		    !double.IsFinite(point.TowStressDamageMultiplier!.Value) || point.TowStressDamageMultiplier.Value <= 0.0)
+		{
+			throw VehicleValidation(owner, $"tow point {point.Key} has invalid tow-stress values");
+		}
+	}
+
+	private static void ValidateUniqueKeys(VehicleSeedSpec owner, IEnumerable<string> keys, string label)
+	{
+		var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		foreach (var key in keys)
+		{
+			if (string.IsNullOrWhiteSpace(key) || !Regex.IsMatch(key, "^[a-z0-9_]+$") || !seen.Add(key))
+			{
+				throw VehicleValidation(owner, $"{label} keys must be unique lowercase underscore identifiers; invalid key '{key}'");
+			}
+		}
+	}
+
+	private static void ValidateUniqueIntegers(VehicleSeedSpec owner, IEnumerable<int> values, string label)
+	{
+		var array = values.ToArray();
+		if (array.Length != array.Distinct().Count())
+		{
+			throw VehicleValidation(owner, $"{label} values must be unique within the vehicle");
+		}
+	}
+
+	private static void RequireReference(VehicleSeedSpec owner, IReadOnlySet<string> keys, string key, string label)
+	{
+		if (!keys.Contains(key))
+		{
+			throw VehicleValidation(owner, $"{label} references missing key '{key}'");
+		}
+	}
+
+	private static void RequireText(VehicleSeedSpec owner, string? value, string label)
+	{
+		if (string.IsNullOrWhiteSpace(value))
+		{
+			throw VehicleValidation(owner, $"{label} is required");
+		}
+	}
+
+	private static void RequirePositiveFinite(VehicleSeedSpec owner, double value, string label)
+	{
+		if (!double.IsFinite(value) || value <= 0.0)
+		{
+			throw VehicleValidation(owner, $"{label} must be positive and finite");
+		}
+	}
+
+	private static void RequireNonNegativeFinite(VehicleSeedSpec owner, double value, string label)
+	{
+		if (!double.IsFinite(value) || value < 0.0)
+		{
+			throw VehicleValidation(owner, $"{label} must be non-negative and finite");
+		}
+	}
+
+	private static InvalidOperationException VehicleValidation(VehicleSeedSpec owner, string message)
+	{
+		return new InvalidOperationException($"Vehicle seed '{owner.StableReference}' is invalid: {message}.");
+	}
+}

--- a/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Validation.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.Validation.cs
@@ -1,0 +1,228 @@
+#nullable enable
+
+using ExpressionEngine;
+using MudSharp.Vehicles;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace DatabaseSeeder.Seeders;
+
+public partial class ItemSeeder
+{
+	private static void ValidateVehicleSeedSpec(VehicleSeedSpec spec)
+	{
+		if (!Regex.IsMatch(spec.StableReference, "^vehicle_(antiquity|medieval|renaissance|earlymodern|revolution|modern|atomic|computer)_[a-z0-9_]+$"))
+		{
+			throw VehicleValidation(spec, $"stable reference '{spec.StableReference}' must be lowercase underscore notation and begin with its era token");
+		}
+		if (!VehicleEraTags.ContainsKey(spec.EraKey) ||
+		    !spec.StableReference.StartsWith($"vehicle_{spec.EraKey}_", StringComparison.OrdinalIgnoreCase))
+		{
+			throw VehicleValidation(spec, $"era key '{spec.EraKey}' does not agree with the stable reference");
+		}
+		if (!spec.Domain.Equals(VehicleDomainTerrestrial, StringComparison.OrdinalIgnoreCase) &&
+		    !spec.Domain.Equals(VehicleDomainAquatic, StringComparison.OrdinalIgnoreCase))
+		{
+			throw VehicleValidation(spec, $"domain must be {VehicleDomainTerrestrial} or {VehicleDomainAquatic}");
+		}
+		RequireText(spec, spec.Name, "name");
+		RequireText(spec, spec.Description, "description");
+		RequireText(spec, spec.Archetype, "archetype");
+		ValidateVehicleItem(spec, spec.ExteriorItem, "exterior item", projection: false);
+		ValidateUniqueKeys(spec, spec.Compartments.Select(x => x.Key), "compartment");
+		ValidateUniqueKeys(spec, spec.CompartmentLinks.Select(x => x.Key), "compartment link");
+		ValidateUniqueKeys(spec, spec.OccupantSlots.Select(x => x.Key), "occupant slot");
+		ValidateUniqueKeys(spec, spec.ControlStations.Select(x => x.Key), "control station");
+		ValidateUniqueKeys(spec, spec.MovementProfiles.Select(x => x.Key), "movement profile");
+		ValidateUniqueKeys(spec, spec.AccessPoints.Select(x => x.Key), "access point");
+		ValidateUniqueKeys(spec, spec.CargoSpaces.Select(x => x.Key), "cargo space");
+		ValidateUniqueKeys(spec, spec.InstallationPoints.Select(x => x.Key), "installation point");
+		ValidateUniqueKeys(spec, spec.TowPoints.Select(x => x.Key), "tow point");
+		ValidateUniqueKeys(spec, spec.DamageZones.Select(x => x.Key), "damage zone");
+
+		if (spec.Compartments.Count == 0)
+		{
+			throw VehicleValidation(spec, "at least one compartment is required");
+		}
+		if (spec.Scale == VehicleScale.RoomScale && spec.Compartments.Any(x => x.InteriorTerrainId is null))
+		{
+			throw VehicleValidation(spec, "every RoomScale compartment requires an interior terrain id");
+		}
+		ValidateUniqueIntegers(spec, spec.Compartments.Select(x => x.DisplayOrder), "compartment display order");
+		foreach (var compartment in spec.Compartments)
+		{
+			RequireText(spec, compartment.Name, $"compartment {compartment.Key} name");
+			RequireText(spec, compartment.Description, $"compartment {compartment.Key} description");
+			if (compartment.InteriorTerrainId is <= 0)
+			{
+				throw VehicleValidation(spec, $"compartment {compartment.Key} has an invalid interior terrain id");
+			}
+		}
+
+		var compartmentKeys = spec.Compartments.Select(x => x.Key).ToHashSet(StringComparer.OrdinalIgnoreCase);
+		foreach (var link in spec.CompartmentLinks)
+		{
+			RequireReference(spec, compartmentKeys, link.SourceCompartmentKey, $"link {link.Key} source compartment");
+			RequireReference(spec, compartmentKeys, link.DestinationCompartmentKey, $"link {link.Key} destination compartment");
+			if (link.SourceCompartmentKey.Equals(link.DestinationCompartmentKey, StringComparison.OrdinalIgnoreCase))
+			{
+				throw VehicleValidation(spec, $"link {link.Key} cannot connect a compartment to itself");
+			}
+			RequireText(spec, link.OutboundDirection, $"link {link.Key} outbound direction");
+			RequireText(spec, link.InboundDirection, $"link {link.Key} inbound direction");
+			RequireText(spec, link.OutboundDescription, $"link {link.Key} outbound description");
+			RequireText(spec, link.InboundDescription, $"link {link.Key} inbound description");
+		}
+
+		if (!spec.OccupantSlots.Any(x => x.SlotType == VehicleOccupantSlotType.Driver))
+		{
+			throw VehicleValidation(spec, "at least one driver slot is required");
+		}
+		foreach (var slot in spec.OccupantSlots)
+		{
+			RequireReference(spec, compartmentKeys, slot.CompartmentKey, $"slot {slot.Key} compartment");
+			RequireText(spec, slot.Name, $"slot {slot.Key} name");
+			if (slot.Capacity <= 0)
+			{
+				throw VehicleValidation(spec, $"slot {slot.Key} capacity must be positive");
+			}
+			if (slot.SlotType == VehicleOccupantSlotType.Driver && slot.Capacity != 1)
+			{
+				throw VehicleValidation(spec, $"driver slot {slot.Key} must have capacity one");
+			}
+		}
+
+		var slotKeys = spec.OccupantSlots.Select(x => x.Key).ToHashSet(StringComparer.OrdinalIgnoreCase);
+		if (spec.ControlStations.Count(x => x.IsPrimary) != 1)
+		{
+			throw VehicleValidation(spec, "exactly one primary control station is required");
+		}
+		foreach (var station in spec.ControlStations)
+		{
+			RequireReference(spec, slotKeys, station.OccupantSlotKey, $"control station {station.Key} occupant slot");
+			RequireText(spec, station.Name, $"control station {station.Key} name");
+			var slot = spec.OccupantSlots.First(x => x.Key.Equals(station.OccupantSlotKey, StringComparison.OrdinalIgnoreCase));
+			if (station.IsPrimary && slot.SlotType != VehicleOccupantSlotType.Driver)
+			{
+				throw VehicleValidation(spec, $"primary control station {station.Key} must belong to a driver slot");
+			}
+		}
+
+		if (spec.MovementProfiles.Count == 0 || spec.MovementProfiles.Count(x => x.IsDefault) != 1)
+		{
+			throw VehicleValidation(spec, "at least one movement profile and exactly one default movement profile are required");
+		}
+		var installationKeys = spec.InstallationPoints.Select(x => x.Key).ToHashSet(StringComparer.OrdinalIgnoreCase);
+		foreach (var movement in spec.MovementProfiles)
+		{
+			ValidateMovementProfile(spec, movement, installationKeys);
+		}
+
+		ValidateUniqueIntegers(spec, spec.AccessPoints.Select(x => x.DisplayOrder), "access-point display order");
+		foreach (var access in spec.AccessPoints)
+		{
+			if (!string.IsNullOrWhiteSpace(access.CompartmentKey))
+			{
+				RequireReference(spec, compartmentKeys, access.CompartmentKey, $"access point {access.Key} compartment");
+			}
+			RequireText(spec, access.Name, $"access point {access.Key} name");
+			RequireText(spec, access.Description, $"access point {access.Key} description");
+			ValidateVehicleItem(spec, access.ProjectionItem, $"access point {access.Key} projection", projection: true);
+		}
+
+		var accessKeys = spec.AccessPoints.Select(x => x.Key).ToHashSet(StringComparer.OrdinalIgnoreCase);
+		ValidateUniqueIntegers(spec, spec.CargoSpaces.Select(x => x.DisplayOrder), "cargo-space display order");
+		foreach (var cargo in spec.CargoSpaces)
+		{
+			if (!string.IsNullOrWhiteSpace(cargo.CompartmentKey))
+			{
+				RequireReference(spec, compartmentKeys, cargo.CompartmentKey, $"cargo space {cargo.Key} compartment");
+			}
+			if (!string.IsNullOrWhiteSpace(cargo.RequiredAccessPointKey))
+			{
+				RequireReference(spec, accessKeys, cargo.RequiredAccessPointKey, $"cargo space {cargo.Key} required access point");
+			}
+			RequireText(spec, cargo.Name, $"cargo space {cargo.Key} name");
+			RequireText(spec, cargo.Description, $"cargo space {cargo.Key} description");
+			RequireText(spec, cargo.ContainerComponent, $"cargo space {cargo.Key} container component");
+			ValidateVehicleItem(spec, cargo.ProjectionItem, $"cargo space {cargo.Key} projection", projection: true);
+		}
+		if (spec.ProvidesCargoService && spec.CargoSpaces.Count == 0)
+		{
+			throw VehicleValidation(spec, "a vehicle marked as providing cargo service must define a cargo space");
+		}
+		if (spec.ProvidesPassengerService && !spec.OccupantSlots.Any(x => x.SlotType == VehicleOccupantSlotType.Passenger || x.SlotType == VehicleOccupantSlotType.Crew))
+		{
+			throw VehicleValidation(spec, "a vehicle marked as providing passenger service must define passenger or crew capacity");
+		}
+
+		ValidateUniqueIntegers(spec, spec.InstallationPoints.Select(x => x.DisplayOrder), "installation-point display order");
+		foreach (var point in spec.InstallationPoints)
+		{
+			if (!string.IsNullOrWhiteSpace(point.RequiredAccessPointKey))
+			{
+				RequireReference(spec, accessKeys, point.RequiredAccessPointKey, $"installation point {point.Key} required access point");
+			}
+			RequireText(spec, point.Name, $"installation point {point.Key} name");
+			RequireText(spec, point.Description, $"installation point {point.Key} description");
+			RequireText(spec, point.MountType, $"installation point {point.Key} mount type");
+			if (point.RequiredForMovement && string.IsNullOrWhiteSpace(point.RequiredRole))
+			{
+				throw VehicleValidation(spec, $"movement-required installation point {point.Key} must declare a required role");
+			}
+		}
+
+		ValidateUniqueIntegers(spec, spec.TowPoints.Select(x => x.DisplayOrder), "tow-point display order");
+		foreach (var point in spec.TowPoints)
+		{
+			if (!string.IsNullOrWhiteSpace(point.RequiredAccessPointKey))
+			{
+				RequireReference(spec, accessKeys, point.RequiredAccessPointKey, $"tow point {point.Key} required access point");
+			}
+			RequireText(spec, point.Name, $"tow point {point.Key} name");
+			RequireText(spec, point.Description, $"tow point {point.Key} description");
+			RequireText(spec, point.TowType, $"tow point {point.Key} tow type");
+			if (!point.CanTow && !point.CanBeTowed)
+			{
+				throw VehicleValidation(spec, $"tow point {point.Key} must either tow or be towable");
+			}
+			RequirePositiveFinite(spec, point.MaximumTowedWeight, $"tow point {point.Key} maximum towed weight");
+			RequirePositiveFinite(spec, point.CharacterPullMultiplier, $"tow point {point.Key} character pull multiplier");
+			ValidateTowStress(spec, point);
+		}
+
+		ValidateUniqueIntegers(spec, spec.DamageZones.Select(x => x.DisplayOrder), "damage-zone display order");
+		if (spec.DamageZones.Count == 0)
+		{
+			throw VehicleValidation(spec, "at least one damage zone is required");
+		}
+		var movementKeys = spec.MovementProfiles.Select(x => x.Key).ToHashSet(StringComparer.OrdinalIgnoreCase);
+		var cargoKeys = spec.CargoSpaces.Select(x => x.Key).ToHashSet(StringComparer.OrdinalIgnoreCase);
+		var towKeys = spec.TowPoints.Select(x => x.Key).ToHashSet(StringComparer.OrdinalIgnoreCase);
+		foreach (var zone in spec.DamageZones)
+		{
+			RequireText(spec, zone.Name, $"damage zone {zone.Key} name");
+			RequireText(spec, zone.Description, $"damage zone {zone.Key} description");
+			RequirePositiveFinite(spec, zone.MaximumDamage, $"damage zone {zone.Key} maximum damage");
+			RequirePositiveFinite(spec, zone.HitWeight, $"damage zone {zone.Key} hit weight");
+			if (!double.IsFinite(zone.DisabledThreshold) || !double.IsFinite(zone.DestroyedThreshold) ||
+			    zone.DisabledThreshold <= 0.0 || zone.DisabledThreshold >= zone.DestroyedThreshold || zone.DestroyedThreshold > 1.0)
+			{
+				throw VehicleValidation(spec, $"damage zone {zone.Key} thresholds must satisfy 0 < disabled < destroyed <= 1");
+			}
+			var effectKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+			foreach (var effect in zone.Effects)
+			{
+				ValidateDamageEffectReference(spec, zone, effect, movementKeys, accessKeys, cargoKeys, installationKeys, towKeys);
+				var identity = $"{effect.TargetType}:{effect.TargetKey ?? "<vehicle>"}";
+				if (!effectKeys.Add(identity))
+				{
+					throw VehicleValidation(spec, $"damage zone {zone.Key} repeats effect target {identity}");
+				}
+			}
+		}
+	}
+
+}

--- a/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.cs
+++ b/DatabaseSeeder/Seeders/ItemSeeder.Vehicles.cs
@@ -1,0 +1,308 @@
+#nullable enable
+
+using ExpressionEngine;
+using Microsoft.EntityFrameworkCore;
+using MudSharp.Construction;
+using MudSharp.Database;
+using MudSharp.Framework;
+using MudSharp.GameItems;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.Models;
+using MudSharp.RPG.Checks;
+using MudSharp.Vehicles;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace DatabaseSeeder.Seeders;
+
+
+public partial class ItemSeeder
+{
+	private const string VehicleSeederMarkerPrefix = "Item seeder vehicle key";
+	private const string VehicleDomainTerrestrial = "Terrestrial";
+	private const string VehicleDomainAquatic = "Aquatic";
+	private const string VehicleOutboardMountType = "outboard_motor";
+	private const string VehiclePropulsionRole = "propulsion";
+
+	private static readonly IReadOnlyDictionary<string, string> VehicleEraTags =
+		new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+		{
+			["antiquity"] = "Era / Antiquity Era",
+			["medieval"] = "Era / Medieval Era",
+			["renaissance"] = "Era / Renaissance Era",
+			["earlymodern"] = "Era / Early Modern Era",
+			["revolution"] = "Era / Industrial Era",
+			["modern"] = "Era / Modern Era",
+			["atomic"] = "Era / Nuclear Era",
+			["computer"] = "Era / Information Age Era"
+		};
+
+	private sealed record VehicleItemSeedSpec(
+		string Noun,
+		string ShortDescription,
+		string FullDescription,
+		SizeCategory Size,
+		ItemQuality Quality,
+		double WeightInGrams,
+		decimal Cost,
+		string Material,
+		string DestroyableComponent,
+		bool Portable,
+		bool Skinnable = true,
+		bool HiddenFromPlayers = false,
+		string? LongDescription = null);
+
+	private sealed record VehicleCompartmentSeedSpec(
+		string Key,
+		string Name,
+		string Description,
+		int DisplayOrder,
+		long? InteriorTerrainId = null,
+		int InteriorOutdoorsType = 0);
+
+	private sealed record VehicleCompartmentLinkSeedSpec(
+		string Key,
+		string SourceCompartmentKey,
+		string DestinationCompartmentKey,
+		string OutboundDirection,
+		string InboundDirection,
+		string OutboundDescription,
+		string InboundDescription);
+
+	private sealed record VehicleOccupantSlotSeedSpec(
+		string Key,
+		string Name,
+		string CompartmentKey,
+		VehicleOccupantSlotType SlotType,
+		int Capacity,
+		bool RequiredForMovement,
+		bool ContributesToPropulsion,
+		Difficulty BoatStabilityDifficulty = Difficulty.Normal);
+
+	private sealed record VehicleControlStationSeedSpec(
+		string Key,
+		string Name,
+		string OccupantSlotKey,
+		bool IsPrimary);
+
+	private sealed record VehiclePropulsionSeedSpec(
+		VehiclePropulsionType PropulsionType,
+		bool IsDefault,
+		double BaseMoveTimeMilliseconds,
+		IReadOnlyCollection<string> TraitCandidates,
+		Difficulty CheckDifficulty,
+		string SpeedMultiplierExpression,
+		string StaminaCostExpression);
+
+	private sealed record VehicleMovementProfileSeedSpec(
+		string Key,
+		string Name,
+		VehicleMovementProfileType MovementType,
+		VehicleMovementEnvironment Environment,
+		bool ExposesOccupantsToWater,
+		bool IsDefault,
+		double RequiredPowerSpikeInWatts,
+		string? FuelLiquid,
+		double FuelVolumePerMove,
+		string RequiredInstalledRole,
+		bool RequiresTowLinksClosed,
+		bool RequiresAccessPointsClosed,
+		double RouteSpeedMetresPerSecond,
+		RouteVehiclePropulsionMode RoutePropulsionMode,
+		double RouteFuelVolumePerMetre,
+		double RoutePowerDrawWatts,
+		bool AutomaticOperationCapable,
+		IReadOnlyCollection<VehiclePropulsionSeedSpec> PropulsionProfiles);
+
+	private sealed record VehicleAccessPointSeedSpec(
+		string Key,
+		string Name,
+		string Description,
+		string? CompartmentKey,
+		VehicleAccessPointType AccessPointType,
+		bool StartsOpen,
+		bool MustBeClosedForMovement,
+		int DisplayOrder,
+		VehicleItemSeedSpec ProjectionItem);
+
+	private sealed record VehicleCargoSpaceSeedSpec(
+		string Key,
+		string Name,
+		string Description,
+		string? CompartmentKey,
+		string? RequiredAccessPointKey,
+		int DisplayOrder,
+		string ContainerComponent,
+		VehicleItemSeedSpec ProjectionItem);
+
+	private sealed record VehicleInstallationPointSeedSpec(
+		string Key,
+		string Name,
+		string Description,
+		string? RequiredAccessPointKey,
+		string MountType,
+		string RequiredRole,
+		bool RequiredForMovement,
+		int DisplayOrder);
+
+	private sealed record VehicleTowPointSeedSpec(
+		string Key,
+		string Name,
+		string Description,
+		string? RequiredAccessPointKey,
+		string TowType,
+		bool CanTow,
+		bool CanBeTowed,
+		double MaximumTowedWeight,
+		double CharacterPullMultiplier,
+		double? TowStressWarningRatio,
+		double? TowStressFailureStartRatio,
+		double? TowStressMaximumFailureChance,
+		double? TowStressDamageMultiplier,
+		int DisplayOrder);
+
+	private sealed record VehicleDamageEffectSeedSpec(
+		VehicleDamageEffectTargetType TargetType,
+		string? TargetKey,
+		VehicleSystemStatus MinimumStatus);
+
+	private sealed record VehicleDamageZoneSeedSpec(
+		string Key,
+		string Name,
+		string Description,
+		double MaximumDamage,
+		double HitWeight,
+		double DisabledThreshold,
+		double DestroyedThreshold,
+		bool DisablesMovement,
+		int DisplayOrder,
+		IReadOnlyCollection<VehicleDamageEffectSeedSpec> Effects);
+
+	private sealed record VehicleSeedSpec(
+		string StableReference,
+		string EraKey,
+		string Domain,
+		string Archetype,
+		string Name,
+		string Description,
+		VehicleScale Scale,
+		VehicleItemSeedSpec ExteriorItem,
+		IReadOnlyCollection<VehicleCompartmentSeedSpec> Compartments,
+		IReadOnlyCollection<VehicleCompartmentLinkSeedSpec> CompartmentLinks,
+		IReadOnlyCollection<VehicleOccupantSlotSeedSpec> OccupantSlots,
+		IReadOnlyCollection<VehicleControlStationSeedSpec> ControlStations,
+		IReadOnlyCollection<VehicleMovementProfileSeedSpec> MovementProfiles,
+		IReadOnlyCollection<VehicleAccessPointSeedSpec> AccessPoints,
+		IReadOnlyCollection<VehicleCargoSpaceSeedSpec> CargoSpaces,
+		IReadOnlyCollection<VehicleInstallationPointSeedSpec> InstallationPoints,
+		IReadOnlyCollection<VehicleTowPointSeedSpec> TowPoints,
+		IReadOnlyCollection<VehicleDamageZoneSeedSpec> DamageZones,
+		bool ProvidesPassengerService,
+		bool ProvidesCargoService,
+		string? BuilderNotes = null);
+
+	internal sealed record VehicleExampleSummaryForTesting(
+		string StableReference,
+		string EraKey,
+		string Domain,
+		string Archetype,
+		VehicleScale Scale,
+		int CompartmentCount,
+		int OccupantSlotCount,
+		int PrimaryControlStationCount,
+		int MovementProfileCount,
+		bool HasDriverSlot,
+		bool HasSurfaceWaterMovement,
+		bool HasExplicitPropulsion,
+		bool HasMotorInstallation,
+		bool HasCargoProjection,
+		bool HasAccessProjection);
+
+	internal static IReadOnlyList<VehicleExampleSummaryForTesting> VehicleExamplesForTesting =>
+		VehicleExampleSpecs.Select(x => new VehicleExampleSummaryForTesting(
+			x.StableReference,
+			x.EraKey,
+			x.Domain,
+			x.Archetype,
+			x.Scale,
+			x.Compartments.Count,
+			x.OccupantSlots.Count,
+			x.ControlStations.Count(station => station.IsPrimary),
+			x.MovementProfiles.Count,
+			x.OccupantSlots.Any(slot => slot.SlotType == VehicleOccupantSlotType.Driver),
+			x.MovementProfiles.Any(profile => profile.Environment == VehicleMovementEnvironment.SurfaceWater),
+			x.MovementProfiles.SelectMany(profile => profile.PropulsionProfiles).Any(),
+			x.InstallationPoints.Any(point =>
+				point.MountType.Equals(VehicleOutboardMountType, StringComparison.OrdinalIgnoreCase)),
+			x.CargoSpaces.Any(),
+			x.AccessPoints.Any())).ToList();
+
+	internal static IReadOnlyCollection<string> ParseVehicleEraTokensForTesting(string? eras)
+	{
+		return ParseVehicleEraTokens(eras);
+	}
+
+	internal static void ValidateVehicleExamplesForTesting()
+	{
+		foreach (var spec in VehicleExampleSpecs)
+		{
+			ValidateVehicleSeedSpec(spec);
+		}
+	}
+
+	private static IReadOnlyCollection<string> ParseVehicleEraTokens(string? eras)
+	{
+		return string.IsNullOrWhiteSpace(eras)
+			? []
+			: eras.Split([' ', ','], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+				.Select(x => x.ToLowerInvariant())
+				.Where(VehicleEraTags.ContainsKey)
+				.ToHashSet(StringComparer.OrdinalIgnoreCase);
+	}
+
+	private void SeedVehicleItemsAndPrototypes(string eras)
+	{
+		var selectedEras = ParseVehicleEraTokens(eras);
+		if (selectedEras.Count == 0)
+		{
+			return;
+		}
+
+		EnsureVehicleSeederTags();
+		SeedVehicleSupportItems(selectedEras);
+		foreach (var spec in VehicleExampleSpecs.Where(x => selectedEras.Contains(x.EraKey)))
+		{
+			ValidateVehicleSeedSpec(spec);
+			UpsertVehiclePrototype(spec);
+		}
+	}
+
+	private void EnsureVehicleSeederTags()
+	{
+		string[] tags =
+		[
+			"Functions / Vehicles",
+			"Functions / Vehicles / Terrestrial Vehicles",
+			"Functions / Vehicles / Aquatic Vehicles",
+			"Functions / Vehicles / Projection Items",
+			"Functions / Vehicles / Vehicle Equipment",
+			"Functions / Vehicles / Vehicle Equipment / Propulsion Equipment",
+			"Functions / Vehicles / Vehicle Equipment / Hitching Equipment",
+			"Market / Transportation / Vehicles",
+			"Market / Transportation / Vehicles / Terrestrial Vehicles",
+			"Market / Transportation / Vehicles / Aquatic Vehicles",
+			"Market / Transportation / Vehicle Equipment",
+			"Market / Transportation / Cargo Transportation",
+			"Market / Transportation / Passenger Transportation"
+		];
+
+		foreach (var tag in tags.Concat(VehicleEraTags.Values))
+		{
+			EnsureAntiquityTagPath(tag);
+		}
+	}
+
+}

--- a/Design Documents/Seeding/Vehicle_Item_Seeder_Design_Reference.md
+++ b/Design Documents/Seeding/Vehicle_Item_Seeder_Design_Reference.md
@@ -108,7 +108,7 @@ Generated item references append a stable role suffix:
 - access: `<root>_access_<child_key>`
 - cargo: `<root>_cargo_<child_key>`
 
-Child keys are lowercase snake case and unique within their child family. Once a catalogue has been published, treat root references, child keys and child names as durable identities. A cosmetic rename of an existing key can create a second child rather than updating the original.
+Child keys are lowercase snake case and unique within their child family. Once a catalogue has been published, treat root references, child keys and child names as durable identities. A cosmetic rename of an existing key or persisted child name can create a second child rather than updating the original.
 
 ### Definition records
 
@@ -202,6 +202,10 @@ Carts, wagons, carriages and drays use ordinary terrestrial movement plus tow po
 
 The seeded harness items demonstrate ordinary and heavy-team ratings. A vehicle is not automatically harnessed, populated with draft animals or made ready to move.
 
+**V1 cell-exit limitation:** `CellExit` movement currently has no persisted `ExternallyPulled` propulsion mode equivalent to the one available for `Route` profiles. Character dragging and the hitch graph can move an ordinary cell-exit draft vehicle and its attached train, but the vehicle movement profile itself does not require a motive character or animal. Consequently, direct controlled movement is not mechanically prevented merely because no puller is attached. Treat this as a runtime boundary, not intended vehicle behaviour. Do not claim that the seeder enforces draft motive power, and explicitly test the hitch/drag workflow for these examples.
+
+Where a world requires strict enforcement rather than builder convention, extend the runtime movement contract before treating cell-exit draft vehicles as fully production-ready. Do not fake this with an unrelated installed-module role.
+
 ### Powered terrestrial cell-exit vehicles
 
 A powered road vehicle uses:
@@ -217,7 +221,7 @@ Fuelled modules carry a fuel liquid container. Electric modules carry the approp
 
 `Route` movement is for vehicles constrained to `RouteCell` topology.
 
-- `ExternallyPulled` route profiles depend on a valid towing arrangement.
+- `ExternallyPulled` route profiles require a valid motive-character hitch arrangement and pull capacity.
 - `Powered` route profiles must consume either fuel per metre or electrical power.
 - Automatic operation is valid only for a powered route profile.
 - Route speed must be positive.
@@ -288,7 +292,7 @@ Every vehicle has weighted damage zones. Thresholds satisfy:
 0 < disabled < destroyed <= 1
 ```
 
-Damage effects target stable child keys and may disable:
+In source definitions, damage effects target stable child keys. During persistence those keys are resolved to the corresponding scoped database ids. Effects may disable:
 
 - all vehicle movement;
 - one movement profile;
@@ -306,17 +310,19 @@ The pass is designed to be rerun.
 - Root ownership is resolved through the stable exterior item reference.
 - Access and cargo ownership is resolved through stable projection item references.
 - Generated component names are deterministic from root reference, role and child key.
-- Named child rows are updated in place within their vehicle and revision.
+- Named child rows are conservatively updated in place within their vehicle and revision.
 - Existing links are resolved by their scoped endpoints and direction.
 - Propulsion rows are resolved by movement profile and propulsion type.
 - Damage effects are resolved by zone, target type and target id.
+
+The database schema does not store every source-level child key. For non-projected children, a published name or scoped relationship therefore participates in persistence identity. Renaming such a child may add a replacement while leaving the previous row intact. This is safer than deleting a builder-extended row, but it makes names part of the migration contract.
 
 The seeder updates rows it can identify but does **not** delete omitted child rows. This is intentional: a builder may have extended a seeded vehicle after installation. Removing or structurally renaming a published child requires an explicit migration and a review of live instances.
 
 Practical rules:
 
 1. never recycle a root stable reference for a different vehicle;
-2. never casually rename a published child key or name;
+2. never casually rename a published child key or persisted child name;
 3. append new variants with new root references;
 4. use deterministic ordering and exact seeded dependency names; and
 5. test both a clean install and a rerun against the same database.
@@ -337,10 +343,11 @@ Practical rules:
 | Outboard mode has no compatible mount and role | Validation fails. |
 | Projection is visible, portable or skinnable | Validation fails. |
 | Installed module is absent, damaged, empty, unpowered or switched off | Live movement preflight fails and reports readiness reasons. |
-| Required access point or tow link is open | Departure fails when the movement profile requires closure. |
+| Required access point or tow link is open or disabled | Departure fails when the movement profile requires valid closures or links. |
 | Selected water propulsion becomes unavailable | Movement fails; no automatic fallback is chosen. |
 | Surface-water craft is on dry ground or the wrong ground layer | It can exist or be carried but cannot initiate surface-water travel. |
 | Route vehicle is outside valid route topology | Route operation cannot proceed. |
+| Cell-exit draft vehicle has no motive puller | The V1 movement profile does not itself enforce a puller. Use and test the hitch/drag path; do not represent this as enforced until the runtime is extended. |
 | A seeded child is removed from source | Existing database row remains. Use a deliberate migration if removal is required. |
 | Free-coordinate navigation, collision, signalling or dispatch is expected | Outside this first-pass seeder and current V1 movement boundary. Do not imply unsupported behaviour in descriptions. |
 
@@ -407,6 +414,7 @@ These are dependencies and templates. The seeder does not automatically install 
 - [ ] Root reference is globally unique, lowercase snake case and begins `vehicle_<era>_`.
 - [ ] Era key agrees with the root reference and intended era tag.
 - [ ] Child keys are unique, permanent lowercase identifiers.
+- [ ] Published child names are treated as durable persistence identities where the schema has no key column.
 - [ ] The variant represents a meaningful form or use difference rather than quota-filling duplication.
 
 ### Player-facing quality
@@ -435,6 +443,7 @@ These are dependencies and templates. The seeder does not automatically install 
 - [ ] Surface-water movement has explicit propulsion and exactly one default.
 - [ ] Rowed modes have contributor slots and credible oar supply.
 - [ ] Propulsion expressions use runtime-supported variables and remain finite.
+- [ ] A cell-exit draft vehicle's hitch/drag workflow and V1 puller-enforcement limitation are explicitly reviewed.
 
 ### Projections, towing and damage
 
@@ -452,6 +461,7 @@ These are dependencies and templates. The seeder does not automatically install 
 - [ ] Rerun the same era selection and confirm no duplicate root or child rows.
 - [ ] Create each changed vehicle and inspect `vehiclestatus`.
 - [ ] Test boarding, control, access, cargo, installation, fuel/power readiness, movement, propulsion selection, towing and damage as applicable.
+- [ ] For cell-exit draft examples, test ordinary hitching/dragging separately from direct controlled movement and record the runtime boundary.
 - [ ] Reload or restart after testing any new topology or generated component pattern.
 
 ## Current Boundaries and Future Extension
@@ -460,6 +470,7 @@ The first pass intentionally does not provide:
 
 - automatic installation, hitching, staffing, fuelling or charging;
 - automatic fallback between water propulsion modes;
+- dedicated externally-pulled enforcement for ordinary `CellExit` vehicle movement;
 - installation-specific room-scale terrain and interior-cell catalogues;
 - free-coordinate 2D/3D movement;
 - collision, signalling, dispatch or timetable systems; or

--- a/Design Documents/Seeding/Vehicle_Item_Seeder_Design_Reference.md
+++ b/Design Documents/Seeding/Vehicle_Item_Seeder_Design_Reference.md
@@ -1,0 +1,468 @@
+# FutureMUD Vehicle Item Seeder Design Reference
+
+## Purpose
+
+This document is the implementation and authoring contract for the vehicle subcomponent of `ItemSeeder`. It is intended for agents and builders who add vehicle catalogues, review vehicle data, or extend the helper layer.
+
+The first implementation provides:
+
+1. rerunnable insertion of FutureMUD's canonical vehicle prototype graph;
+2. safe creation of the exterior, access, cargo and equipment item prototypes associated with that graph;
+3. intent-level helpers for the principal vehicle patterns currently supported by the engine;
+4. validation of structural references, operational resources and plausible value ranges; and
+5. a demonstration catalogue containing two terrestrial and two aquatic vehicles in each item-seeder era.
+
+Read this document together with:
+
+- `Design Documents/Vehicle_System.md` for the runtime vehicle system;
+- `Item_Authoring_Guidelines.md` for player-facing item descriptions;
+- `FutureMUD_Item_Seeder_Working_Guidelines.md` for catalogue and rerun conventions;
+- `Seeded_Item_Components.json` for ordinary reusable item components;
+- `Seeded_Materials.json` and `Seeded_Liquids.json` for exact seeded resource names; and
+- `FutureMUDLibrary/Vehicles/VehicleEnums.cs` for persisted enum meanings.
+
+The demonstration catalogue is representative, not exhaustive. Later passes should add culturally and technologically specific vehicles where the differences affect form, capacity, access, propulsion, operation or use. Do not create nominal variants merely to satisfy a per-culture quota.
+
+## Runtime Architecture
+
+A FutureMUD vehicle is a hybrid canonical-domain object with ordinary item projections. It is not just a large item carrying one XML component.
+
+### Canonical vehicle graph
+
+`VehicleProto` is the revisioned root. Its child records describe actual vehicle behaviour:
+
+| Record | Responsibility |
+|---|---|
+| `VehicleCompartmentProto` | Logical occupied areas; for room-scale vehicles these correspond to persistent interior cells. |
+| `VehicleCompartmentLinkProto` | Directed movement links between compartments. |
+| `VehicleOccupantSlotProto` | Driver, crew and passenger capacity; required staffing; propulsion contributors. |
+| `VehicleControlStationProto` | Associates control authority with an occupant slot. |
+| `VehicleMovementProfileProto` | Cell-exit or route movement, environment, closure checks and resource requirements. |
+| `VehiclePropulsionProfileProto` | Selectable surface-water propulsion such as self-powered, rowed, sail or outboard. |
+| `VehicleAccessPointProto` | Doors, hatches, ramps, canopies and service openings. |
+| `VehicleCargoSpaceProto` | Canonical cargo areas represented to item systems by container projections. |
+| `VehicleInstallationPointProto` | Mount type and functional role accepted from an installed module. |
+| `VehicleTowPointProto` | Towing direction, type, rating, pull multiplier and stress behaviour. |
+| `VehicleDamageZoneProto` | Weighted damage areas, thresholds and whole-zone effects. |
+| `VehicleDamageZoneEffectProto` | Disables a movement profile, access point, cargo space, installation point, tow point or all movement. |
+
+### Item projections
+
+The vehicle graph is exposed to ordinary item commands through linked item prototypes:
+
+- The **exterior item** is the visible vehicle shell. Its generated `Vehicle Exterior` component identifies the canonical `VehicleProto`.
+- An **access projection** is a hidden item carrying a generated `Vehicle Access Point` component. The access component itself owns open, closed and lock behaviour; do not add an ordinary door component.
+- A **cargo projection** is a hidden item carrying both a generated `Vehicle Cargo Space` component and one ordinary container component. The vehicle owns the cargo-space state; the container component owns normal contents behaviour.
+- An **installed module** is an ordinary portable item with `Vehicle Installable` plus the machinery, battery, liquid-container or other components needed to operate it.
+
+Access and cargo projections must remain hidden, non-portable and non-skinnable. They are implementation projections, not goods that builders should place or clone directly.
+
+### Vehicle scales
+
+- `ItemScale`: occupants remain in the exterior item's ordinary cell. Appropriate for handcarts, coracles, kayaks, dinghies and comparable small vehicles.
+- `RoomContainer`: occupants remain in the exterior cell but are logically contained by vehicle compartments. This is appropriate for most carts, wagons, cars, coaches and non-room-scale vessels.
+- `RoomScale`: compartments are persistent interior cells. Every compartment requires a valid `InteriorTerrainId`. The seeder supports the data contract, but the first catalogue does not include a room-scale example because terrain and world-topology choices are installation-specific.
+
+Surface-water travel does not imply `RoomScale`. Item-scale and room-container craft use `CellExit` movement with `SurfaceWater` as their movement environment.
+
+## Seeder API and Data Contract
+
+### Dispatch and era selection
+
+The database-seeder host invokes `ItemSeeder` through `IDatabaseSeeder`. The vehicle dispatch file runs the established item pass first, then calls:
+
+```csharp
+SeedVehicleItemsAndPrototypes(eras);
+```
+
+This ordering is deliberate. Vehicle definitions resolve materials, liquids, traits, ordinary components, tags and previously seeded item prototypes from the caches populated by the ordinary item pass.
+
+The accepted era tokens and tags are:
+
+| Token | Era tag |
+|---|---|
+| `antiquity` | `Era / Antiquity Era` |
+| `medieval` | `Era / Medieval Era` |
+| `renaissance` | `Era / Renaissance Era` |
+| `earlymodern` | `Era / Early Modern Era` |
+| `revolution` | `Era / Industrial Era` |
+| `modern` | `Era / Modern Era` |
+| `atomic` | `Era / Nuclear Era` |
+| `computer` | `Era / Information Age Era` |
+
+Only selected eras are inserted. Shared operating equipment is inserted when the selected technology family requires it.
+
+### Stable references
+
+Root references must match:
+
+```text
+vehicle_<era>_<specific_name>
+```
+
+They are lowercase snake case and globally unique. Examples include `vehicle_medieval_trading_cog` and `vehicle_computer_electric_city_car`.
+
+Generated item references append a stable role suffix:
+
+- exterior: `<root>_exterior`
+- access: `<root>_access_<child_key>`
+- cargo: `<root>_cargo_<child_key>`
+
+Child keys are lowercase snake case and unique within their child family. Once a catalogue has been published, treat root references, child keys and child names as durable identities. A cosmetic rename of an existing key can create a second child rather than updating the original.
+
+### Definition records
+
+`VehicleSeedSpec` is the authoring boundary. It contains the root identity and all child collections. Dedicated records prevent raw table inserts from silently omitting required relationships:
+
+- `VehicleItemSeedSpec`
+- `VehicleCompartmentSeedSpec`
+- `VehicleCompartmentLinkSeedSpec`
+- `VehicleOccupantSlotSeedSpec`
+- `VehicleControlStationSeedSpec`
+- `VehicleMovementProfileSeedSpec`
+- `VehiclePropulsionSeedSpec`
+- `VehicleAccessPointSeedSpec`
+- `VehicleCargoSpaceSeedSpec`
+- `VehicleInstallationPointSeedSpec`
+- `VehicleTowPointSeedSpec`
+- `VehicleDamageZoneSeedSpec`
+- `VehicleDamageEffectSeedSpec`
+
+Use the intent-level factories wherever the topology fits:
+
+```csharp
+CreateDraftCargoVehicle(...)
+CreatePoweredRoadVehicle(...)
+CreatePaddleCraft(...)
+CreateSailCraft(...)
+CreateMotorCraft(...)
+```
+
+Write an explicit `VehicleSeedSpec` when the vehicle genuinely has different topology, such as multiple separately accessed cabins, several control stations, unusual tow geometry or a novel movement profile. Do not bypass validation merely because a vehicle is exceptional.
+
+### Minimum structural contract
+
+Every vehicle must contain:
+
+- one exterior item;
+- at least one compartment;
+- at least one driver slot;
+- exactly one primary control station attached to a driver slot;
+- at least one movement profile and exactly one default movement profile;
+- at least one damage zone;
+- unique keys and display orders within each child family; and
+- valid references between all child keys.
+
+A surface-water movement profile additionally requires at least one explicit propulsion row and exactly one default propulsion row.
+
+### Player-facing item contract
+
+Exterior and support items follow the ordinary item-authoring rules.
+
+- Use a compact singular noun.
+- Use a concise short description, normally beginning with `a` or `an`.
+- Write each full description individually. Describe visible construction, shape, finish, wear and obvious affordances.
+- Do not expose stable references, database terminology, component names or hidden mechanics in player-facing text.
+- Weight is empty inherent weight in grams. Cargo and installed module contents add their own weight.
+- The primary material must exactly match the seeded material name and should represent the main structural substance.
+- Portable support equipment includes `Holdable`; vehicle exteriors normally do not.
+- Finished exterior goods may be skinnable. Projections never are.
+- Cost uses the normal item-seeder base-currency convention.
+
+## Units and Recommended Ranges
+
+The validator enforces hard safety rules; the ranges below are authoring guidance. A value passing validation may still be implausible.
+
+| Value | Stored unit / hard rule | Recommended guidance |
+|---|---|---|
+| Item weight | grams; positive and finite | Start from plausible empty mass. Do not include cargo or fuel contents twice. |
+| Item cost | base-currency decimal; non-negative | Preserve broad relative value rather than false historical precision. |
+| Propulsion base move time | milliseconds; 250-300,000 | Usually 4,000-15,000 for small craft and 7,000-25,000 for heavy manual craft before runtime multipliers. |
+| Route speed | metres/second; positive for `Route` | About 1-4 for slow draft/industrial travel, 5-15 for urban service, and 15-35 for faster road or rail examples. |
+| Required power spike | watts; non-negative | Use for instantaneous cell-exit readiness only when an installed power producer is required. |
+| Route power draw | watts; non-negative | Use for continuous electric route consumption. A powered route must consume fuel or power. |
+| Fuel per cell exit | liquid volume; non-negative | Use for coarse cell-exit travel; calibrate against world cell scale. |
+| Fuel per route metre | liquid volume/metre; non-negative | Use only for route movement. Keep values small and test long journeys. |
+| Tow maximum | grams; positive and finite | Rate the tow point and available hitch gear together. The lower rating controls. |
+| Character pull multiplier | multiplier; positive and finite | Around 1.0 is neutral; increase only where shafts, harness or gearing improve effective pull. |
+| Tow warning ratio | ratio; positive | Commonly 0.75-0.9. Must not exceed failure-start ratio. |
+| Tow maximum failure chance | probability; 0-1 | Keep low enough to warn before catastrophic repeated failures. |
+| Damage maximum | abstract damage capacity; positive | Scale by structural importance and expected weapon/collision damage, not solely by mass. |
+| Damage hit weight | relative weight; positive | Larger exposed zones receive larger weights. |
+| Disabled threshold | fraction; `> 0` | Must be lower than destroyed threshold. |
+| Destroyed threshold | fraction; `<= 1` | Must be greater than disabled threshold. |
+
+Use finite values only. `NaN`, infinity and silent zero-speed route profiles are invalid.
+
+## Propulsion and Movement Patterns
+
+### Externally pulled terrestrial vehicles
+
+Carts, wagons, carriages and drays use ordinary terrestrial movement plus tow points. They do not receive surface-water propulsion rows. A forward point is normally towable by draft gear; a rear point may allow another load to be coupled behind.
+
+The seeded harness items demonstrate ordinary and heavy-team ratings. A vehicle is not automatically harnessed, populated with draft animals or made ready to move.
+
+### Powered terrestrial cell-exit vehicles
+
+A powered road vehicle uses:
+
+- a terrestrial `CellExit` movement profile;
+- a required installed role such as `propulsion`;
+- a compatible installation point such as `land_engine` or `electric_drive`; and
+- a separately seeded removable drive module.
+
+Fuelled modules carry a fuel liquid container. Electric modules carry the appropriate battery/power components. The seeder does not install, fill, switch on or charge a module automatically.
+
+### Route vehicles
+
+`Route` movement is for vehicles constrained to `RouteCell` topology.
+
+- `ExternallyPulled` route profiles depend on a valid towing arrangement.
+- `Powered` route profiles must consume either fuel per metre or electrical power.
+- Automatic operation is valid only for a powered route profile.
+- Route speed must be positive.
+
+World route topology, stops, signalling and scheduling are authored outside this item-seeder pass.
+
+### Self-powered watercraft
+
+`SelfPowered` is suitable for a coracle or kayak where the controller directly supplies effort. The profile resolves a suitable seeded trait from candidates such as Swimming, Rowing or Athletics. Speed and stamina expressions must remain finite over expected check outcomes.
+
+### Rowed watercraft
+
+`Rowed` requires one or more occupied slots marked `ContributesToPropulsion`. Every contributor must hold a usable item with the `Vehicle Oar` component. A nominal crew slot without an oar does not propel the vessel.
+
+### Sailing craft
+
+`Sail` speed uses the runtime `wind` variable. The demonstration sailing craft make sail the default and rowed propulsion a selectable fallback. Selection is explicit: the runtime does not silently switch from sail to oars when wind or staffing changes.
+
+### Outboard craft
+
+`OutboardMotor` uses the runtime `output` supplied by an installed functional motor. The vessel requires an `outboard_motor` installation point with the `propulsion` role. The seeded petrol outboard includes both `Vehicle Installable` and `Outboard Motor` components plus a fuel container.
+
+The demonstration motor craft also provide emergency rowed propulsion. Rowing still requires staffed contributor slots and vehicle oars.
+
+### Propulsion expressions
+
+Supported expression variables depend on the propulsion type. The supplied helpers use:
+
+- `outcome` for checked manual propulsion;
+- `swimcost` for baseline stamina cost;
+- `wind` for sail strength; and
+- `output` for outboard performance.
+
+Validation evaluates authored expressions across outcomes from -3 through +3 and requires positive finite speed and non-negative finite stamina cost. New variables are not created by naming them in a catalogue expression; the runtime must supply them first.
+
+## Access, Cargo, Installation, Towing and Damage
+
+### Access
+
+Use access points for a real closable boundary: door, hatch, ramp, canopy or service opening. Set `MustBeClosedForMovement` when departure with the opening unsecured would be unsafe or mechanically prohibited. A cargo space may require one access point before its projection can be used.
+
+### Cargo
+
+Each cargo space needs exactly one suitable ordinary container component. Select capacity and open/closed behaviour from `Seeded_Item_Components.json`; do not invent a component name in the vehicle catalogue. The hidden projection receives both the container and generated cargo-space component.
+
+### Installation points
+
+`MountType` answers “what physical interface fits here?” while `RequiredRole` answers “what function must the installed item provide?”. Both must agree with the `Vehicle Installable` component on the module.
+
+A movement-required installation point must declare a non-empty role. Damage can target the installation point and make an otherwise present module unusable.
+
+### Towing
+
+Tow points state whether they can tow, be towed, or both. `TowType` must be compatible at both ends. Hitch gear bridges users or vehicles to the tow system and imposes its own capacity.
+
+All four optional stress values are specified together or omitted together:
+
+- warning ratio;
+- failure-start ratio;
+- maximum failure chance; and
+- damage multiplier.
+
+### Damage
+
+Every vehicle has weighted damage zones. Thresholds satisfy:
+
+```text
+0 < disabled < destroyed <= 1
+```
+
+Damage effects target stable child keys and may disable:
+
+- all vehicle movement;
+- one movement profile;
+- an access point;
+- a cargo space;
+- an installation point; or
+- a tow point.
+
+Model an actual failure consequence. Do not add numerous cosmetic zones that have identical effects and no gameplay distinction.
+
+## Idempotency and Stable Keys
+
+The pass is designed to be rerun.
+
+- Root ownership is resolved through the stable exterior item reference.
+- Access and cargo ownership is resolved through stable projection item references.
+- Generated component names are deterministic from root reference, role and child key.
+- Named child rows are updated in place within their vehicle and revision.
+- Existing links are resolved by their scoped endpoints and direction.
+- Propulsion rows are resolved by movement profile and propulsion type.
+- Damage effects are resolved by zone, target type and target id.
+
+The seeder updates rows it can identify but does **not** delete omitted child rows. This is intentional: a builder may have extended a seeded vehicle after installation. Removing or structurally renaming a published child requires an explicit migration and a review of live instances.
+
+Practical rules:
+
+1. never recycle a root stable reference for a different vehicle;
+2. never casually rename a published child key or name;
+3. append new variants with new root references;
+4. use deterministic ordering and exact seeded dependency names; and
+5. test both a clean install and a rerun against the same database.
+
+## Edge Cases and Failure Modes
+
+| Condition | Expected result / author response |
+|---|---|
+| Unknown era token | Ignored; if no recognised token remains, the vehicle pass does nothing. |
+| Unknown material, liquid or ordinary component | Seeding fails with a specific dependency error. Add or correct the prerequisite rather than substituting silently. |
+| Missing compartment, slot, access, cargo, installation, tow or movement key | Validation fails before insertion. |
+| No driver or not exactly one primary station | Validation fails. |
+| Several default movement or propulsion rows | Validation fails. |
+| Powered route has neither fuel nor power consumption | Validation fails. |
+| Route profile has zero speed | Validation fails. |
+| Surface-water movement has no explicit propulsion | Validation fails. |
+| Rowed mode has no contributor slot | Validation fails. |
+| Outboard mode has no compatible mount and role | Validation fails. |
+| Projection is visible, portable or skinnable | Validation fails. |
+| Installed module is absent, damaged, empty, unpowered or switched off | Live movement preflight fails and reports readiness reasons. |
+| Required access point or tow link is open | Departure fails when the movement profile requires closure. |
+| Selected water propulsion becomes unavailable | Movement fails; no automatic fallback is chosen. |
+| Surface-water craft is on dry ground or the wrong ground layer | It can exist or be carried but cannot initiate surface-water travel. |
+| Route vehicle is outside valid route topology | Route operation cannot proceed. |
+| A seeded child is removed from source | Existing database row remains. Use a deliberate migration if removal is required. |
+| Free-coordinate navigation, collision, signalling or dispatch is expected | Outside this first-pass seeder and current V1 movement boundary. Do not imply unsupported behaviour in descriptions. |
+
+## Demonstration Catalogue
+
+Every era has two terrestrial and two aquatic examples.
+
+| Era | Stable reference | Pattern |
+|---|---|---|
+| Antiquity | `vehicle_antiquity_two_wheeled_handcart` | Item-scale externally pulled cart with open cargo. |
+| Antiquity | `vehicle_antiquity_heavy_ox_wagon` | Heavy room-container draft wagon. |
+| Antiquity | `vehicle_antiquity_reed_coracle` | Item-scale self-powered craft. |
+| Antiquity | `vehicle_antiquity_coastal_sailing_boat` | Sail default, rowed fallback, deck and hold. |
+| Medieval | `vehicle_medieval_market_cart` | Compact market cart. |
+| Medieval | `vehicle_medieval_covered_wagon` | Closable access and gated cargo. |
+| Medieval | `vehicle_medieval_clinker_rowboat` | Explicit rowed propulsion and oar dependency. |
+| Medieval | `vehicle_medieval_trading_cog` | Large sailing cargo vessel. |
+| Renaissance | `vehicle_renaissance_city_carriage` | Enclosed passenger carriage. |
+| Renaissance | `vehicle_renaissance_artillery_wagon` | High-rated military cargo wagon. |
+| Renaissance | `vehicle_renaissance_ship_launch` | Many-rower passenger and cargo launch. |
+| Renaissance | `vehicle_renaissance_lateen_pinnace` | Lateen sailcraft with rowing fallback. |
+| Early Modern | `vehicle_earlymodern_stagecoach` | High-capacity access-controlled coach. |
+| Early Modern | `vehicle_earlymodern_freight_dray` | Open urban freight platform. |
+| Early Modern | `vehicle_earlymodern_whaleboat` | Coordinated rough-water rowing craft. |
+| Early Modern | `vehicle_earlymodern_coastal_sloop` | Passenger and cargo sailing craft. |
+| Industrial | `vehicle_revolution_horse_tram` | Externally pulled route vehicle. |
+| Industrial | `vehicle_revolution_factory_delivery_wagon` | Heavy commercial draft transport. |
+| Industrial | `vehicle_revolution_canal_skiff` | Shallow-water rowed workboat. |
+| Industrial | `vehicle_revolution_sailing_cutter` | Faster sailing and cargo-hatch pattern. |
+| Modern | `vehicle_modern_petrol_touring_car` | Fuelled installed drive module and road movement. |
+| Modern | `vehicle_modern_diesel_delivery_lorry` | Heavy powered road vehicle with cargo bay. |
+| Modern | `vehicle_modern_aluminium_dinghy` | Light rowed metal craft. |
+| Modern | `vehicle_modern_petrol_motor_launch` | Outboard default and emergency rowing. |
+| Nuclear | `vehicle_atomic_family_saloon` | Enclosed fuelled passenger car. |
+| Nuclear | `vehicle_atomic_intercity_coach` | Powered fuelled route service. |
+| Nuclear | `vehicle_atomic_fiberglass_runabout` | Recreational outboard craft. |
+| Nuclear | `vehicle_atomic_cabin_cruiser` | Multi-compartment motor craft. |
+| Information Age | `vehicle_computer_electric_city_car` | Battery-powered installed drive module. |
+| Information Age | `vehicle_computer_autonomous_shuttle` | Automatic powered route service. |
+| Information Age | `vehicle_computer_recreational_kayak` | Modern self-powered item-scale craft. |
+| Information Age | `vehicle_computer_rescue_rib` | High-capacity outboard rescue craft. |
+
+### Shared support equipment
+
+The pass also seeds reusable operating examples:
+
+- pre-industrial wooden oar;
+- modern laminated oar;
+- petrol outboard motor;
+- ordinary draft harness and traces;
+- heavy team harness, yoke and traces;
+- ordinary rigid tow bar;
+- heavy articulated tow bar;
+- petrol terrestrial drive module;
+- diesel terrestrial drive module; and
+- battery-powered electric drive module.
+
+These are dependencies and templates. The seeder does not automatically install them in, attach them to, fuel or charge a vehicle.
+
+## Authoring Checklist
+
+### Identity and catalogue scope
+
+- [ ] Root reference is globally unique, lowercase snake case and begins `vehicle_<era>_`.
+- [ ] Era key agrees with the root reference and intended era tag.
+- [ ] Child keys are unique, permanent lowercase identifiers.
+- [ ] The variant represents a meaningful form or use difference rather than quota-filling duplication.
+
+### Player-facing quality
+
+- [ ] Noun, short description and full description follow the item-authoring guidance.
+- [ ] Full description is individually written and visually grounded.
+- [ ] No hidden component, database or seeder terminology appears to players.
+- [ ] Empty weight, size, quality, primary material and cost are plausible.
+- [ ] Every material, liquid and ordinary component exists under its exact seeded name.
+
+### Structure and service
+
+- [ ] At least one compartment, driver slot, primary station, default movement and damage zone exist.
+- [ ] Every child reference resolves.
+- [ ] Display orders are unique within each family.
+- [ ] Room-scale compartments have valid terrain ids.
+- [ ] Passenger and cargo service flags agree with actual slots and cargo spaces.
+
+### Movement and resources
+
+- [ ] Exactly one movement profile is default.
+- [ ] Route speed is positive and calibrated to intended topology.
+- [ ] Powered movement consumes declared fuel or power.
+- [ ] Every required installed role has a compatible mount and seeded module.
+- [ ] Automatic operation appears only on a powered route profile.
+- [ ] Surface-water movement has explicit propulsion and exactly one default.
+- [ ] Rowed modes have contributor slots and credible oar supply.
+- [ ] Propulsion expressions use runtime-supported variables and remain finite.
+
+### Projections, towing and damage
+
+- [ ] Access and cargo projections are hidden, non-portable and non-skinnable.
+- [ ] Every cargo projection has one suitable ordinary container component.
+- [ ] Closure requirements agree with visible design and safe operation.
+- [ ] Tow type, direction, rating and available hitch gear agree.
+- [ ] Damage thresholds satisfy `0 < disabled < destroyed <= 1`.
+- [ ] Every damage effect targets an existing child and models a real failure.
+
+### Verification
+
+- [ ] Run `ValidateVehicleExamplesForTesting()` and the database-seeder unit tests.
+- [ ] Seed each affected era into a fresh database.
+- [ ] Rerun the same era selection and confirm no duplicate root or child rows.
+- [ ] Create each changed vehicle and inspect `vehiclestatus`.
+- [ ] Test boarding, control, access, cargo, installation, fuel/power readiness, movement, propulsion selection, towing and damage as applicable.
+- [ ] Reload or restart after testing any new topology or generated component pattern.
+
+## Current Boundaries and Future Extension
+
+The first pass intentionally does not provide:
+
+- automatic installation, hitching, staffing, fuelling or charging;
+- automatic fallback between water propulsion modes;
+- installation-specific room-scale terrain and interior-cell catalogues;
+- free-coordinate 2D/3D movement;
+- collision, signalling, dispatch or timetable systems; or
+- aircraft-, submarine- or rail-consist-specific movement strategies that do not yet exist in the runtime.
+
+Add a new archetype helper when several future vehicles share a genuinely new topology, such as bicycles, coupled rail vehicles, room-scale ships or aircraft. Add a one-off explicit specification when a vehicle is exceptional. In both cases retain the validation boundary, add tests, update this document, seed all new support components through rerunnable helpers, and avoid claiming runtime behaviour the engine does not yet implement.

--- a/Design Documents/Seeding/Vehicle_Item_Seeder_Design_Reference.md
+++ b/Design Documents/Seeding/Vehicle_Item_Seeder_Design_Reference.md
@@ -34,7 +34,7 @@ A FutureMUD vehicle is a hybrid canonical-domain object with ordinary item proje
 | Record | Responsibility |
 |---|---|
 | `VehicleCompartmentProto` | Logical occupied areas; for room-scale vehicles these correspond to persistent interior cells. |
-| `VehicleCompartmentLinkProto` | Directed movement links between compartments. |
+| `VehicleCompartmentLinkProto` | Directed movement links between compartments; these become navigable interior links only for `RoomScale` vehicles. |
 | `VehicleOccupantSlotProto` | Driver, crew and passenger capacity; required staffing; propulsion contributors. |
 | `VehicleControlStationProto` | Associates control authority with an occupant slot. |
 | `VehicleMovementProfileProto` | Cell-exit or route movement, environment, closure checks and resource requirements. |
@@ -62,6 +62,8 @@ Access and cargo projections must remain hidden, non-portable and non-skinnable.
 - `ItemScale`: occupants remain in the exterior item's ordinary cell. Appropriate for handcarts, coracles, kayaks, dinghies and comparable small vehicles.
 - `RoomContainer`: occupants remain in the exterior cell but are logically contained by vehicle compartments. This is appropriate for most carts, wagons, cars, coaches and non-room-scale vessels.
 - `RoomScale`: compartments are persistent interior cells. Every compartment requires a valid `InteriorTerrainId`. The seeder supports the data contract, but the first catalogue does not include a room-scale example because terrain and world-topology choices are installation-specific.
+
+For `ItemScale` and `RoomContainer`, compartments organise occupancy, access and cargo but do not create separately navigable interior cells. Compartment links are retained as prototype topology but are not built as runtime exits. Do not model an internal corridor, stair or doorway with compartment links unless the vehicle is `RoomScale`.
 
 Surface-water travel does not imply `RoomScale`. Item-scale and room-container craft use `CellExit` movement with `SurfaceWater` as their movement environment.
 
@@ -217,6 +219,8 @@ A powered road vehicle uses:
 
 Fuelled modules carry a fuel liquid container. Electric modules carry the appropriate battery/power components. The seeder does not install, fill, switch on or charge a module automatically.
 
+**V1 terrain and timing limitation:** ordinary terrestrial `CellExit` profiles use the runtime's `Unrestricted` movement environment. They do not enforce road terrain, wheel clearance, gradient, axle load, traction or other land-suitability rules, and they do not store a physical land speed. Movement timing and fuel consumption are coarse per-exit values and must be calibrated against the world's cell scale. A world that requires enforced roads or terrain suitability should use `Route` topology where appropriate or extend the runtime contract; descriptions and builder notes must not imply enforcement that does not exist.
+
 ### Route vehicles
 
 `Route` movement is for vehicles constrained to `RouteCell` topology.
@@ -348,6 +352,8 @@ Practical rules:
 | Surface-water craft is on dry ground or the wrong ground layer | It can exist or be carried but cannot initiate surface-water travel. |
 | Route vehicle is outside valid route topology | Route operation cannot proceed. |
 | Cell-exit draft vehicle has no motive puller | The V1 movement profile does not itself enforce a puller. Use and test the hitch/drag path; do not represent this as enforced until the runtime is extended. |
+| Cell-exit terrestrial vehicle is off-road or on unsuitable terrain | The V1 `Unrestricted` environment does not enforce road or terrain suitability. Use world controls, `Route` topology or a runtime extension where this matters. |
+| Non-room-scale compartment links are expected to create interior exits | They do not. Only `RoomScale` vehicles build navigable compartment links; use logical compartments or adopt `RoomScale`. |
 | A seeded child is removed from source | Existing database row remains. Use a deliberate migration if removal is required. |
 | Free-coordinate navigation, collision, signalling or dispatch is expected | Outside this first-pass seeder and current V1 movement boundary. Do not imply unsupported behaviour in descriptions. |
 
@@ -431,6 +437,7 @@ These are dependencies and templates. The seeder does not automatically install 
 - [ ] Every child reference resolves.
 - [ ] Display orders are unique within each family.
 - [ ] Room-scale compartments have valid terrain ids.
+- [ ] Non-room-scale compartments are used as logical groupings only and do not imply navigable interiors.
 - [ ] Passenger and cargo service flags agree with actual slots and cargo spaces.
 
 ### Movement and resources
@@ -444,6 +451,7 @@ These are dependencies and templates. The seeder does not automatically install 
 - [ ] Rowed modes have contributor slots and credible oar supply.
 - [ ] Propulsion expressions use runtime-supported variables and remain finite.
 - [ ] A cell-exit draft vehicle's hitch/drag workflow and V1 puller-enforcement limitation are explicitly reviewed.
+- [ ] Terrestrial cell-exit timing, fuel use and suitability assumptions are reviewed against its coarse `Unrestricted` per-exit semantics.
 
 ### Projections, towing and damage
 
@@ -462,6 +470,7 @@ These are dependencies and templates. The seeder does not automatically install 
 - [ ] Create each changed vehicle and inspect `vehiclestatus`.
 - [ ] Test boarding, control, access, cargo, installation, fuel/power readiness, movement, propulsion selection, towing and damage as applicable.
 - [ ] For cell-exit draft examples, test ordinary hitching/dragging separately from direct controlled movement and record the runtime boundary.
+- [ ] Test terrestrial cell-exit examples on representative road and non-road cells and record any world-level restrictions used to compensate for the `Unrestricted` runtime environment.
 - [ ] Reload or restart after testing any new topology or generated component pattern.
 
 ## Current Boundaries and Future Extension
@@ -471,6 +480,8 @@ The first pass intentionally does not provide:
 - automatic installation, hitching, staffing, fuelling or charging;
 - automatic fallback between water propulsion modes;
 - dedicated externally-pulled enforcement for ordinary `CellExit` vehicle movement;
+- road, terrain, gradient, traction or physical-speed enforcement for terrestrial `CellExit` movement;
+- navigable compartment links outside `RoomScale` vehicles;
 - installation-specific room-scale terrain and interior-cell catalogues;
 - free-coordinate 2D/3D movement;
 - collision, signalling, dispatch or timetable systems; or


### PR DESCRIPTION
## Summary

Adds the first vehicle subcomponent to `ItemSeeder`, built against the existing canonical vehicle domain rather than treating vehicles as ordinary item components.

### Seeder infrastructure

- Adds typed `VehicleSeedSpec` and child definitions for compartments, links, occupant slots, control stations, movement/propulsion profiles, access points, cargo spaces, installation points, tow points, damage zones and damage effects.
- Adds deterministic, rerunnable root and child upserts.
- Creates linked exterior, access and cargo item projections with generated internal vehicle components.
- Preserves builder-added children by updating identifiable seeded rows without destructive reconciliation.
- Adds intent-level helpers for draft cargo vehicles, powered road vehicles, paddle/row craft, sailing craft and outboard craft.
- Adds validation for stable references, graph integrity, display ordering, resource requirements, route speeds, propulsion expressions, projections, towing stress and damage targeting.

### Operating equipment

Seeds reusable examples for oars, draft harness, heavy team harness, road tow bars, petrol/diesel terrestrial drive modules, a battery-powered electric drive module and a petrol outboard motor.

### Demonstration catalogue

Adds 32 examples: two terrestrial and two aquatic vehicles for each of Antiquity, Medieval, Renaissance, Early Modern, Industrial, Modern, Nuclear and Information Age selections.

### Documentation and tests

- Adds `Design Documents/Seeding/Vehicle_Item_Seeder_Design_Reference.md` as the implementation and builder/agent authoring contract.
- Adds source-level tests for catalogue count and era/domain coverage, validation, operational skeletons, projection patterns, support equipment, era parsing, dispatch wiring and documentation coverage.

## Important first-pass boundaries

- No automatic module installation, hitching, staffing, fuelling or charging.
- No automatic fallback between water propulsion modes.
- No installation-specific RoomScale interior terrain catalogue.
- No free-coordinate navigation, collision, signalling or dispatch systems.
- Land propulsion uses the existing movement/readiness and installed-module contracts; it does not invent surface-water propulsion rows.

## Verification requested

- Build `DatabaseSeeder` and `DatabaseSeeder Unit Tests`.
- Run the vehicle seeder unit tests.
- Seed at least one clean database for a pre-industrial and a powered era, then rerun the same selection to confirm idempotency.
