### PR TITLE
Fix apply command emote references

### DIFF
--- a/MudSharpCore/Commands/Modules/ManipulationModule.cs
+++ b/MudSharpCore/Commands/Modules/ManipulationModule.cs
@@ -1855,8 +1855,8 @@ The syntax is as follows:
                         }
 
                         character.OutputHandler.Handle(CharacterInstanceIdentityComparer.SamePhysicalInstance(character, targetCharacter)
-                                            ? new MixedEmoteOutput(new Emote($"@ apply|applies $1 to &0's {bodypart.FullDescription()}", character, item), flags: OutputFlags.SuppressObscured).Append(pemote)
-                                            : new MixedEmoteOutput(new Emote($"@ apply|applies $1 to $2's {bodypart.FullDescription()}", character, item, targetCharacter), flags: OutputFlags.SuppressObscured).Append(pemote));
+                                            ? new MixedEmoteOutput(new Emote($"@ apply|applies $1 to &0's {bodypart.FullDescription()}", character, character, item), flags: OutputFlags.SuppressObscured).Append(pemote)
+                                            : new MixedEmoteOutput(new Emote($"@ apply|applies $1 to $2's {bodypart.FullDescription()}", character, character, item, targetCharacter), flags: OutputFlags.SuppressObscured).Append(pemote));
                         applicable.Apply(targetCharacter.Body, bodypart, amount, character);
                     },
                     text =>
@@ -1873,8 +1873,8 @@ The syntax is as follows:
         }
 
         character.OutputHandler.Handle(CharacterInstanceIdentityComparer.SamePhysicalInstance(character, targetCharacter)
-                ? new MixedEmoteOutput(new Emote($"@ apply|applies $1 to &0's {bodypart.FullDescription()}", character, item), flags: OutputFlags.SuppressObscured).Append(pemote)
-                : new MixedEmoteOutput(new Emote($"@ apply|applies $1 to $2's {bodypart.FullDescription()}", character, item, targetCharacter), flags: OutputFlags.SuppressObscured).Append(pemote));
+                ? new MixedEmoteOutput(new Emote($"@ apply|applies $1 to &0's {bodypart.FullDescription()}", character, character, item), flags: OutputFlags.SuppressObscured).Append(pemote)
+                : new MixedEmoteOutput(new Emote($"@ apply|applies $1 to $2's {bodypart.FullDescription()}", character, character, item, targetCharacter), flags: OutputFlags.SuppressObscured).Append(pemote));
         applicable.Apply(targetCharacter.Body, bodypart, amount, character);
     }
 


### PR DESCRIPTION
## What changed

Pass the acting character as perceivable index 0 when constructing `apply` command emotes, in both immediate and accepted-proposal paths and for both self and other targets.

## Why

The emote templates reference the actor as `&0`, the applied item as `$1`, and (when applicable) the target as `$2`. The constructors previously omitted the actor from the perceivable arguments, leaving those indices out of range and producing an `Invalid emote` error even though the topical application still occurred.

This change corrects only the emote arguments. Dosing, quantities, consent, accessibility checks, and item-component behaviour are unchanged.

## Validation

- `git diff --check`
- Narrow source assertion confirmed two corrected self-target forms, two corrected other-target forms, and no old argument form
- Local compile could not start because the checkout targets .NET 10 while the available SDK is 9.0.312; CI should perform the .NET 10 build
