### PR TITLE
Fix full and full-brief health prompt grammar

### DIFF
--- a/MudSharpCore Unit Tests/RobotRuntimeTests.cs
+++ b/MudSharpCore Unit Tests/RobotRuntimeTests.cs
@@ -24,6 +24,22 @@ namespace MudSharp_Unit_Tests;
 public class RobotRuntimeTests
 {
     [TestMethod]
+    public void FormatFullPromptCondition_ComposesAllPresentClauseCombinations()
+    {
+        Assert.AreEqual(string.Empty, BaseHealthStrategy.FormatFullPromptCondition(null, null, null));
+        Assert.AreEqual("<You are currently in no pain>",
+            BaseHealthStrategy.FormatFullPromptCondition("no pain", null, null));
+        Assert.AreEqual("<You are currently dizzy>",
+            BaseHealthStrategy.FormatFullPromptCondition(null, "dizzy", null));
+        Assert.AreEqual("<You have very minor blood loss>",
+            BaseHealthStrategy.FormatFullPromptCondition(null, null, "very minor blood loss"));
+        Assert.AreEqual("<You are currently dizzy and have very minor blood loss>",
+            BaseHealthStrategy.FormatFullPromptCondition(null, "dizzy", "very minor blood loss"));
+        Assert.AreEqual("<You are currently in mild pain, dizzy and have very minor blood loss>",
+            BaseHealthStrategy.FormatFullPromptCondition("mild pain", "dizzy", "very minor blood loss"));
+    }
+
+    [TestMethod]
     public void IsOrgan_SensorArray_IsTreatedAsAnOrgan()
     {
         Assert.IsTrue(BodypartTypeEnum.SensorArray.IsOrgan());

--- a/MudSharpCore/Character/Character.cs
+++ b/MudSharpCore/Character/Character.cs
@@ -3212,11 +3212,6 @@ public partial class Character : PerceiverItem, ICharacter, ICharacterIdentity, 
             string healthString = HealthStrategy.ReportConditionPrompt(this, PromptType.FullBrief);
 
             StringBuilder sb = new();
-            if (!healthString.Equals(string.Empty))
-            {
-                healthString = "<" + healthString + ">";
-            }
-
             bool setStamina = false;
             if (staminaRatio < 0.8)
             {

--- a/MudSharpCore/Health/Strategies/BaseHealthStrategy.cs
+++ b/MudSharpCore/Health/Strategies/BaseHealthStrategy.cs
@@ -31,6 +31,30 @@ public abstract class BaseHealthStrategy : SaveableItem, IHealthStrategy
         "#3lodge <expression>#0 - sets the expression used for the 1d100 lodge check"
     ];
 
+    internal static string FormatFullPromptCondition(string? painDescription, string? stunDescription,
+        string? fluidLossDescription)
+    {
+        var sb = new StringBuilder();
+        if (!string.IsNullOrEmpty(painDescription))
+        {
+            sb.Append($"You are currently in {painDescription}");
+        }
+
+        if (!string.IsNullOrEmpty(stunDescription))
+        {
+            sb.Append(sb.Length > 0 ? ", " : "You are currently ");
+            sb.Append(stunDescription);
+        }
+
+        if (!string.IsNullOrEmpty(fluidLossDescription))
+        {
+            sb.Append(sb.Length > 0 ? " and have " : "You have ");
+            sb.Append(fluidLossDescription);
+        }
+
+        return sb.Length > 0 ? $"<{sb}>" : string.Empty;
+    }
+
     protected Expression LodgeDamageExpression = new("0");
     protected RankedRange<WoundSeverity> SeverityRanges = new();
     protected RankedRange<WoundSeverity> PercentageSeverityRanges = new();

--- a/MudSharpCore/Health/Strategies/ComplexLivingHealthStrategy.cs
+++ b/MudSharpCore/Health/Strategies/ComplexLivingHealthStrategy.cs
@@ -1130,139 +1130,90 @@ public class ComplexLivingHealthStrategy : BaseHealthStrategy
         double breathRatio, bool brief)
     {
         StringBuilder sb = new();
-        sb.Append("<");
-        double heartFactor =
-            charOwner.Body.OrganFunction<HeartProto>();
+        double heartFactor = charOwner.Body.OrganFunction<HeartProto>();
         if (heartFactor <= 0)
         {
-            sb.Append("*** YOU ARE IN CARDIAC ARREST! ***".Colour(Telnet.BoldRed));
-            sb.Append(">\n<");
+            sb.Append($"<{"*** YOU ARE IN CARDIAC ARREST! ***".Colour(Telnet.BoldRed)}>\n");
         }
         else if (heartFactor < HeartAttackThreshold)
         {
-            sb.Append("*** YOU ARE HAVING A HEART ATTACK! ***".Colour(Telnet.BoldRed));
-            sb.Append(">\n<");
+            sb.Append($"<{"*** YOU ARE HAVING A HEART ATTACK! ***".Colour(Telnet.BoldRed)}>\n");
         }
-        else
+        else if (charOwner.NeedsToBreathe && !charOwner.CanBreathe)
         {
-            if (charOwner.NeedsToBreathe && !charOwner.CanBreathe)
+            if (breathRatio > 0.0 && breathRatio < 1.0)
             {
-                if (breathRatio > 0.0 && breathRatio < 1.0)
-                {
-                    sb.Append("*** YOU ARE HOLDING YOUR BREATH! ***".Colour(Telnet.KeywordBlue));
-                    sb.Append(">\n<");
-                }
-                else if (charOwner.BreathingFluid is ILiquid)
-                {
-                    sb.Append("*** YOU ARE DROWNING! ***".Colour(Telnet.BoldCyan));
-                    sb.Append(">\n<");
-                }
-                else
-                {
-                    sb.Append("*** YOU ARE SUFFOCATING! ***".Colour(Telnet.BoldYellow));
-                    sb.Append(">\n<");
-                }
+                sb.Append($"<{"*** YOU ARE HOLDING YOUR BREATH! ***".Colour(Telnet.KeywordBlue)}>\n");
+            }
+            else if (charOwner.BreathingFluid is ILiquid)
+            {
+                sb.Append($"<{"*** YOU ARE DROWNING! ***".Colour(Telnet.BoldCyan)}>\n");
+            }
+            else
+            {
+                sb.Append($"<{"*** YOU ARE SUFFOCATING! ***".Colour(Telnet.BoldYellow)}>\n");
             }
         }
 
+        string painDescription = null;
         if (painRatio < 0.01)
         {
             if (!brief)
             {
-                sb.Append($"You are currently in {"no pain".Colour(Telnet.Green)}");
+                painDescription = "no pain".Colour(Telnet.Green);
             }
         }
         else if (painRatio < 0.2)
         {
-            sb.Append($"You are currently in {"mild pain".Colour(Telnet.Yellow)}");
+            painDescription = "mild pain".Colour(Telnet.Yellow);
         }
         else if (painRatio < 0.4)
         {
-            sb.Append($"You are currently in {"moderate pain".Colour(Telnet.Yellow)}");
+            painDescription = "moderate pain".Colour(Telnet.Yellow);
         }
         else if (painRatio < 0.6)
         {
-            sb.Append($"You are currently in {"severe pain".Colour(Telnet.Red)}");
+            painDescription = "severe pain".Colour(Telnet.Red);
         }
         else if (painRatio < 0.8)
         {
-            sb.Append($"You are currently in {"very severe pain".Colour(Telnet.Red)}");
+            painDescription = "very severe pain".Colour(Telnet.Red);
         }
         else if (painRatio < 1.0)
         {
-            sb.Append($"You are currently in {"agonising pain".Colour(Telnet.BoldRed)}");
+            painDescription = "agonising pain".Colour(Telnet.BoldRed);
         }
         else
         {
-            sb.Append($"You are currently in {"overwhelming pain".Colour(Telnet.BoldRed)}");
+            painDescription = "overwhelming pain".Colour(Telnet.BoldRed);
         }
 
-        if (stunRatio > 0.05)
+        var stunDescription = stunRatio switch
         {
-            if (stunRatio < 0.2)
-            {
-                sb.Append($", {"dizzy".Colour(Telnet.BoldCyan)}");
-            }
-            else if (stunRatio < 0.4)
-            {
-                sb.Append($", {"dazed".Colour(Telnet.BoldCyan)}");
-            }
-            else if (stunRatio < 0.6)
-            {
-                sb.Append($", {"stunned".Colour(Telnet.BoldBlue)}");
-            }
-            else if (stunRatio < 0.8)
-            {
-                sb.Append($", {"severly stunned".Colour(Telnet.BoldBlue)}");
-            }
-            else if (stunRatio < 1.0)
-            {
-                sb.Append($", {"practically catatonic".Colour(Telnet.BoldMagenta)}");
-            }
-            else
-            {
-                sb.Append($", {"knocked out".Colour(Telnet.BoldMagenta)}");
-            }
-        }
+            <= 0.05 => null,
+            < 0.2 => "dizzy".Colour(Telnet.BoldCyan),
+            < 0.4 => "dazed".Colour(Telnet.BoldCyan),
+            < 0.6 => "stunned".Colour(Telnet.BoldBlue),
+            < 0.8 => "severely stunned".Colour(Telnet.BoldBlue),
+            < 1.0 => "practically catatonic".Colour(Telnet.BoldMagenta),
+            _ => "knocked out".Colour(Telnet.BoldMagenta)
+        };
 
-        if (bloodlossRatio <= 0.98 && sb.Length != 0)
+        var bloodLossDescription = bloodlossRatio switch
         {
-            sb.Append(" and have ");
-        }
+            > 0.98 => null,
+            >= 0.94 => "very minor blood loss".Colour(Telnet.Yellow),
+            >= 0.90 => "minor blood loss".Colour(Telnet.Yellow),
+            >= 0.825 => "moderate blood loss".Colour(Telnet.Red),
+            >= 0.75 => "major blood loss".Colour(Telnet.Red),
+            >= 0.675 => "severe blood loss".Colour(Telnet.Red),
+            >= 0.6 => "very severe blood loss".Colour(Telnet.Red),
+            >= 0.5 => "critical blood loss".Colour(Telnet.Red),
+            _ => "life-threatening blood loss".Colour(Telnet.Red)
+        };
 
-        switch (bloodlossRatio)
-        {
-            case > 0.98:
-                break;
-            case >= 0.94:
-                sb.Append($"{"very minor blood loss".Colour(Telnet.Yellow)}");
-                break;
-            case >= 0.90:
-                sb.Append($"{"minor blood loss".Colour(Telnet.Yellow)}");
-                break;
-            case >= 0.825:
-                sb.Append($"{"moderate blood loss".Colour(Telnet.Red)}");
-                break;
-            case >= 0.75:
-                sb.Append($"{"major blood loss".Colour(Telnet.Red)}");
-                break;
-            case >= 0.675:
-                sb.Append($"{"severe blood loss".Colour(Telnet.Red)}");
-                break;
-            case >= 0.6:
-                sb.Append($"{"very severe blood loss".Colour(Telnet.Red)}");
-                break;
-            case >= 0.5:
-                sb.Append($"{"critical blood loss".Colour(Telnet.Red)}");
-                break;
-            default:
-                sb.Append($"{"life-threatening blood loss".Colour(Telnet.Red)}");
-                break;
-        }
-
-        sb.Append(">");
-
-        return sb.ToString();
+        sb.Append(FormatFullPromptCondition(painDescription, stunDescription, bloodLossDescription));
+        return sb.ToString().TrimEnd('\n');
     }
 
     private string ReportClassicPrompt(ICharacter charOwner, double stunRatio, double painRatio, double bloodlossRatio,

--- a/MudSharpCore/Health/Strategies/RobotHealthStrategy.cs
+++ b/MudSharpCore/Health/Strategies/RobotHealthStrategy.cs
@@ -433,76 +433,44 @@ public class RobotHealthStrategy : BaseHealthStrategy
         double breathRatio, bool brief)
     {
         StringBuilder sb = new();
-        sb.Append("<");
         double power = charOwner.Body.OrganFunction<PowerCore>();
         if (power < PowerCoreCriticalThreshold)
         {
-            sb.Append("*** YOUR POWER CORE IS CRITICAL! ***".Colour(Telnet.BoldRed));
-            sb.Append(">\n<");
+            sb.Append($"<{"*** YOUR POWER CORE IS CRITICAL! ***".Colour(Telnet.BoldRed)}>\n");
         }
 
         if (charOwner.NeedsToBreathe && !charOwner.CanBreathe)
         {
             if (breathRatio > 0.0)
             {
-                sb.Append("*** YOU ARE HOLDING YOUR BREATH! ***".Colour(Telnet.BoldBlue));
-                sb.Append(">\n<");
+                sb.Append($"<{"*** YOU ARE HOLDING YOUR BREATH! ***".Colour(Telnet.BoldBlue)}>\n");
             }
             else if (charOwner.BreathingFluid is ILiquid)
             {
-                sb.Append("*** YOU ARE DROWNING! ***".Colour(Telnet.BoldCyan));
-                sb.Append(">\n<");
+                sb.Append($"<{"*** YOU ARE DROWNING! ***".Colour(Telnet.BoldCyan)}>\n");
             }
             else
             {
-                sb.Append("*** YOU ARE SUFFOCATING! ***".Colour(Telnet.BoldYellow));
-                sb.Append(">\n<");
+                sb.Append($"<{"*** YOU ARE SUFFOCATING! ***".Colour(Telnet.BoldYellow)}>\n");
             }
         }
 
-        if (stunRatio > 0.05)
+        var stunDescription = stunRatio switch
         {
-            if (stunRatio < 0.2)
-            {
-                sb.Append($", {"dizzy".Colour(Telnet.BoldCyan)}");
-            }
-            else if (stunRatio < 0.4)
-            {
-                sb.Append($", {"dazed".Colour(Telnet.BoldCyan)}");
-            }
-            else if (stunRatio < 0.6)
-            {
-                sb.Append($", {"stunned".Colour(Telnet.BoldBlue)}");
-            }
-            else if (stunRatio < 0.8)
-            {
-                sb.Append($", {"severly stunned".Colour(Telnet.BoldBlue)}");
-            }
-            else if (stunRatio < 1.0)
-            {
-                sb.Append($", {"practically catatonic".Colour(Telnet.BoldMagenta)}");
-            }
-            else
-            {
-                sb.Append($", {"knocked out".Colour(Telnet.BoldMagenta)}");
-            }
-        }
-
-        if (bloodlossRatio <= 0.98 && sb.Length != 0)
-        {
-            sb.Append(" and have ");
-        }
+            <= 0.05 => null,
+            < 0.2 => "dizzy".Colour(Telnet.BoldCyan),
+            < 0.4 => "dazed".Colour(Telnet.BoldCyan),
+            < 0.6 => "stunned".Colour(Telnet.BoldBlue),
+            < 0.8 => "severely stunned".Colour(Telnet.BoldBlue),
+            < 1.0 => "practically catatonic".Colour(Telnet.BoldMagenta),
+            _ => "knocked out".Colour(Telnet.BoldMagenta)
+        };
 
         string fluidLossDescription = FluidLossDescriptionForPrompt(
             bloodlossRatio,
             charOwner.Race.BloodLiquid?.Name);
-        if (!string.IsNullOrEmpty(fluidLossDescription))
-        {
-            sb.Append(fluidLossDescription);
-        }
-
-        sb.Append(">");
-        return sb.ToString();
+        sb.Append(FormatFullPromptCondition(null, stunDescription, fluidLossDescription));
+        return sb.ToString().TrimEnd('\n');
     }
 
     private string ReportClassicPrompt(ICharacter charOwner, double stunRatio, double painRatio, double bloodlossRatio,


### PR DESCRIPTION
## Summary

- compose pain, stun, and blood/circulatory-fluid loss with valid subjects and conjunctions
- omit healthy full-brief condition lines and avoid trailing empty prompt lines after critical warnings
- stop the character prompt from double-wrapping already-delimited health output
- correct `severly stunned` to `severely stunned` in living and robot prompts

## Regression coverage

Adds focused tests for empty, pain-only, stun-only, fluid-loss-only, stun-plus-loss, and fully combined clauses.

## Validation

- `git diff --check` passed
- targeted static prompt checks passed
- targeted unit test command was attempted locally, but the checkout targets .NET 10 and the available SDK is 9.0.312 (`NETSDK1045`); CI must perform compilation and execution
