### PR TITLE
Version update to 2.2.0

### DIFF
--- a/FutureMUD.Web/Content/PatchNotes/2026-08-01-engine-2-2-0.md
+++ b/FutureMUD.Web/Content/PatchNotes/2026-08-01-engine-2-2-0.md
@@ -1,0 +1,29 @@
+---
+title: FutureMUD Engine 2.2.0
+summary: Adds expanded vehicle propulsion, modern firearm support, richer combat targeting, and new FutureProg world-interaction hooks.
+date: 2026-08-01
+tags: engine, release, upgrade
+---
+**Upgrade note:** Apply the normal database upgrades before starting Engine 2.2.0. This release keeps the .NET 10 and MySQL 8.0 requirements and the Windows x64, Linux x64 and Linux ARM64 package set.
+
+## Combat And Firearms
+
+- Added firearm attachments, projectile ammunition, and impact detonator support.
+- Weapon attacks can now target bodypart shapes, and combat settings can configure whether characters prioritise staying upright or making an attack.
+
+## Vehicles
+
+- Expanded vehicle propulsion with terrestrial engines and rider-powered movement.
+- Added vehicle motive coordination, hitching, and operational-readiness handling for more reliable movement and route integration.
+
+## FutureProg And World Interaction
+
+- Added FutureProg hooks for exposing items and characters to liquids.
+- Added a FutureProg noise-emission hook for scripted world interactions.
+
+## Fixes
+
+- Corrected `apply` command emote references.
+- Fixed the grammar of the full-brief health prompt.
+
+See `/downloads` for release archives and checksums, `/getting-started` for installation requirements, and `/docs/commands` for the published Engine reference.

--- a/MudSharpCore/MudSharpCore.csproj
+++ b/MudSharpCore/MudSharpCore.csproj
@@ -10,9 +10,9 @@
 	<Product>FutureMUD</Product>
 	<ApplicationIcon>FM Logo.ico</ApplicationIcon>
 	<AssemblyName>MudSharp</AssemblyName>
-	<Version>2.1.1</Version>
-	<AssemblyVersion>2.1.1</AssemblyVersion>
-	<FileVersion>2.1.1</FileVersion>
+	<Version>2.2.0</Version>
+	<AssemblyVersion>2.2.0</AssemblyVersion>
+	<FileVersion>2.2.0</FileVersion>
   </PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
## Engine 2.2.0 release preparation\n\n- Bump MudSharpCore Version, AssemblyVersion, and FileVersion to 2.2.0.\n- Add the website patch note for Engine 2.2.0.\n- Release validation passed: 2,067 MudSharpCore Release tests, 49 FutureMUD.Web Release tests, Linux x64 framework-dependent single-file publish, and documentation catalogue validation.\n\nThis is the exact preparation commit for the Engine 2.2.0 release tag and website publication.