### PR TITLE
Fix medical equipment persistence, mobility aids, and feedback

### DIFF
--- a/Design Documents/Health/Health_Adjacencies_and_Items.md
+++ b/Design Documents/Health/Health_Adjacencies_and_Items.md
@@ -112,6 +112,8 @@ Stock item content uses the `GameItem` health strategy seeded in `CoreDataSeeder
 | `ICorpse` and `CorpseGameItemComponent` | Turns items into corpses and severed remains with owner and decay context |
 | `ICannula` and `CannulaGameItemComponent` | Supports vascular access and cannulation procedures |
 | `IVBagGameItemComponent` | Supports infused liquids and IV-style medical logistics |
+| `IImmobilise` and `ImmobilisingGameItemComponent` | Associates a worn splint or cast with fractures beneath its active wear profile |
+| `ICrutch` and `CrutchGameItemComponent` | Lets a correctly side-aligned held or wielded mobility aid substitute for an unusable leg |
 | `IProvideGasForBreathing` and `RebreatherGameItemComponent` | Supplies breathable gas to bodies that need it |
 | `BreathingFilterGameItemComponent` | Modifies the breathing stream through equipment |
 | `IDefibrillator` and `DefibrillatorGameItemComponent` | Equipment-gated electrical rescue support |
@@ -120,7 +122,7 @@ Stock item content uses the `GameItem` health strategy seeded in `CoreDataSeeder
 | `IOrganImplant` and `ImplantOrganGameItemComponent` | Implanted artificial organs and organ augmentation |
 | `ImplantPowerPlantGameItemComponent`, `ImplantPowerRouterGameItemComponent`, `ImplantPowerSupplyGameItemComponent` | Power infrastructure for advanced implants |
 | `ImplantRadioGameItemComponent`, `ImplantTraitChangerGameItemComponent`, container-style implant components | Advanced implant payloads that sit adjacent to the health framework |
-| Prosthetic component prototypes in seeders | Replacement limbs and eyes that restore or replace severed functionality |
+| Prosthetic component prototypes in seeders | Replacement limbs and eyes that restore compatible severed functionality; functional exact-target prostheses do not disable their replacement bodypart |
 
 ### Design implication
 The item system makes health extensible without constantly adding new commands. Once the correct interfaces and components exist, bodies, surgeries, breathing, and treatment code can discover and use those items through shared contracts.

--- a/Design Documents/Health/Health_Core_Runtime.md
+++ b/Design Documents/Health/Health_Core_Runtime.md
@@ -83,6 +83,8 @@ The body runtime continuously tracks more than visible wounds:
 - internal bleeding and other hidden trauma
 - consequences of low circulation for prompts, health checks, and death
 
+Surface-liquid persistence permits blood records whose source race or blood type is no longer available. Those optional references serialize as zero rather than aborting the owning body's save; this is important because a failed body save would also lose unrelated inventory, implant, and cannula state from the same transaction.
+
 Temperature imbalance now participates in this same layer. Mild and moderate stages remain mostly symptomatic, but severe and especially critical hypothermia or hyperthermia apply organ-function penalties through the effect system. That means thermal injury is reversible while exposure is corrected, but can still become fatal if a body is left in critical extremes for long enough.
 
 This is why medical commands such as `vitals`, `triage`, and surgery are meaningful. They are reading and acting on underlying simulated state, not only on visible wound descriptions.
@@ -184,6 +186,7 @@ The wound model cares about sequence and local state. Examples:
 - Wounds with lodged objects block several other treatments until the object is removed.
 - Wounds must generally be trauma-controlled before they can be closed.
 - Bone fractures must be relocated before non-surgical immobilization is valid.
+- A worn immobilising component derives its active fracture association from the bones beneath its wear profile. Removing or changing the worn profile clears that association, while load-time inventory restoration recomputes it without a separate persistence record.
 - Robot wounds use fluid-leak and repair semantics rather than organic infection and antiseptic logic.
 - Robot wounds do not contribute pain, while robot status still hinges on organ function, stun, fluid loss, positronic-brain integrity, and power-core integrity.
 

--- a/Design Documents/Health/Health_Medical_Interactions.md
+++ b/Design Documents/Health/Health_Medical_Interactions.md
@@ -69,6 +69,8 @@ Common fracture sequence:
 2. Immobilize it with `Set`, or surgically reinforce it with `SurgicalSet`.
 3. Allow healing ticks to progress.
 
+Immobilisation is derived from actual wear state. A splint or cast only affects fractures whose bones lie beneath its selected wear profile, and taking it off removes the healing benefit. Failed relocation attempts report the failed treatment but do not claim an additional pain effect unless the runtime has actually applied one.
+
 Common robot sequence:
 
 1. Stabilize fluid leakage with `Trauma` or `repair`, depending on what the wound currently allows.
@@ -191,6 +193,8 @@ The defibrillator component checks for conditions such as:
 - whether heart function is in a state where defibrillation can help
 
 This is not a generic revive mechanic. It is a device-based attempt to restore a particular physiological failure mode.
+
+The operator receives a qualitative device report after each valid shock indicating whether the rhythm stabilised or showed no effective change. Chest obstruction reports each blocking garment once even when it covers several heart-bearing locations.
 
 ## Drugs
 ### Core model

--- a/FutureMUDLibrary Unit Tests/BloodLiquidInstanceTests.cs
+++ b/FutureMUDLibrary Unit Tests/BloodLiquidInstanceTests.cs
@@ -1,0 +1,25 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Form.Material;
+using MudSharp.Framework;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class BloodLiquidInstanceTests
+{
+	[TestMethod]
+	public void SaveToXml_AllowsUnknownRaceAndBloodType()
+	{
+		var liquid = new Mock<ILiquid>();
+		liquid.SetupGet(x => x.Id).Returns(42);
+		var gameworld = new Mock<IFuturemud>();
+		var instance = new BloodLiquidInstance(null, null, null, liquid.Object, gameworld.Object, 10.0);
+
+		var xml = instance.SaveToXml();
+
+		Assert.AreEqual("0", xml.Attribute("source")?.Value);
+		Assert.AreEqual("0", xml.Attribute("race")?.Value);
+		Assert.AreEqual("0", xml.Attribute("bloodtype")?.Value);
+	}
+}

--- a/FutureMUDLibrary/Form/Material/BloodLiquidInstance.cs
+++ b/FutureMUDLibrary/Form/Material/BloodLiquidInstance.cs
@@ -99,7 +99,7 @@ namespace MudSharp.Form.Material
             XElement root = base.SaveToXml();
             root.Add(new XAttribute("instancetype", "blood"));
             root.Add(new XAttribute("source", Source?.Id ?? 0));
-            root.Add(new XAttribute("race", Race.Id));
+            root.Add(new XAttribute("race", Race?.Id ?? 0));
             root.Add(new XAttribute("bloodtype", BloodType?.Id ?? 0));
             return root;
         }

--- a/MudSharpCore Unit Tests/MedicalOutputRegressionTests.cs
+++ b/MudSharpCore Unit Tests/MedicalOutputRegressionTests.cs
@@ -1,0 +1,73 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Body;
+using MudSharp.Body.Grouping;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class MedicalOutputRegressionTests
+{
+	[TestMethod]
+	public void DescribeGroups_IgnoresSuccessfulRulesThatMatchedNoBodyparts()
+	{
+		var thigh = new Mock<IBodypart>();
+		var emptyRule = new Mock<IBodypartGroupDescriber>();
+		emptyRule.Setup(x => x.Match(It.IsAny<IEnumerable<IBodypart>>()))
+		         .Returns(new BodypartGroupResult(true, 100, "head", [], [thigh.Object]));
+		var thighRule = new Mock<IBodypartGroupDescriber>();
+		thighRule.Setup(x => x.Match(It.IsAny<IEnumerable<IBodypart>>()))
+		         .Returns(new BodypartGroupResult(true, 50, "right thigh", [thigh.Object], []));
+
+		var result = BodypartGroupDescriber.DescribeGroups(
+			new[] { emptyRule.Object, thighRule.Object },
+			new[] { thigh.Object });
+
+		Assert.AreEqual("right thigh", result);
+	}
+
+	[TestMethod]
+	public void MedicalPlayerOutput_DoesNotContainObservedGrammarAndDescriptionDefects()
+	{
+		var healthModule = File.ReadAllText(GetSourcePath("MudSharpCore", "Commands", "Modules", "HealthModule.cs"));
+		var cleaning = File.ReadAllText(GetSourcePath("MudSharpCore", "Effects", "Concrete", "CleaningWounds.cs"));
+		var ivBag = File.ReadAllText(GetSourcePath("MudSharpCore", "GameItems", "Components", "IVBagGameItemComponent.cs"));
+		var wearable = File.ReadAllText(GetSourcePath("MudSharpCore", "GameItems", "Components", "WearableGameItemComponent.cs"));
+		var fracture = File.ReadAllText(GetSourcePath("MudSharpCore", "Health", "Wounds", "BoneFracture.cs"));
+
+		Assert.IsFalse(healthModule.Contains("can't see any wounds of", StringComparison.Ordinal));
+		StringAssert.Contains(healthModule, "@ begin|begins tending to @'s wounds.");
+		StringAssert.Contains(cleaning, "You require antiseptics to clean your wounds any further.");
+		StringAssert.Contains(ivBag, "{LiquidMixture.ColouredLiquidDescription} begins to flow into @");
+		StringAssert.Contains(wearable, "Profiles.Select(x => x.DesignedBody).Distinct()");
+		Assert.IsFalse(fracture.Contains("The pain levels in your", StringComparison.Ordinal));
+	}
+
+	[TestMethod]
+	public void DefibrillatorOutput_DeduplicatesObstructionsAndReportsShockResult()
+	{
+		var source = File.ReadAllText(GetSourcePath("MudSharpCore", "GameItems", "Components",
+			"DefibrillatorGameItemComponent.cs"));
+
+		StringAssert.Contains(source, ".Distinct()");
+		StringAssert.Contains(source, "You are conscious and therefore not in need of defibrillation.");
+		StringAssert.Contains(source, "reports that the heart rhythm has stabilised.");
+		StringAssert.Contains(source, "reports no effective change in heart rhythm.");
+	}
+
+	private static string GetSourcePath(params string[] parts)
+	{
+		return Path.GetFullPath(Path.Combine(
+			AppContext.BaseDirectory,
+			"..",
+			"..",
+			"..",
+			"..",
+			Path.Combine(parts)));
+	}
+}

--- a/MudSharpCore Unit Tests/MedicalRuntimeRegressionTests.cs
+++ b/MudSharpCore Unit Tests/MedicalRuntimeRegressionTests.cs
@@ -1,0 +1,90 @@
+#nullable enable
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MudSharp.Body;
+using MudSharp.Body.Implementations;
+using MudSharp.GameItems.Components;
+using MudSharp.GameItems.Interfaces;
+using MudSharp.GameItems.Inventory;
+using MudSharp.Health;
+using MudSharp.Health.Wounds;
+
+namespace MudSharp_Unit_Tests;
+
+[TestClass]
+public class MedicalRuntimeRegressionTests
+{
+	[TestMethod]
+	public void NonFunctionalProstheticDisablesBodypart_FunctionalExactTargetRemainsUsable()
+	{
+		var bodypart = new Mock<IBodypart>();
+		var prosthetic = new Mock<IProsthetic>();
+		prosthetic.SetupGet(x => x.TargetBodypart).Returns(bodypart.Object);
+		prosthetic.SetupGet(x => x.Functional).Returns(true);
+
+		Assert.IsFalse(Body.NonFunctionalProstheticDisablesBodypart(prosthetic.Object, bodypart.Object));
+
+		prosthetic.SetupGet(x => x.Functional).Returns(false);
+		Assert.IsTrue(Body.NonFunctionalProstheticDisablesBodypart(prosthetic.Object, bodypart.Object));
+	}
+
+	[TestMethod]
+	public void ProstheticTargetsBodypart_AcceptsCompatibleDerivedBodypart()
+	{
+		var canonical = new Mock<IBodypart>();
+		var derived = new Mock<IBodypart>();
+		derived.Setup(x => x.CountsAs(canonical.Object)).Returns(true);
+		var prosthetic = new Mock<IProsthetic>();
+		prosthetic.SetupGet(x => x.TargetBodypart).Returns(canonical.Object);
+
+		Assert.IsTrue(Body.ProstheticTargetsBodypart(prosthetic.Object, derived.Object));
+	}
+
+	[TestMethod]
+	public void CrutchMatchesLimb_UsesSideOfInventoryLocation()
+	{
+		var rightHand = new Mock<IBodypart>();
+		rightHand.SetupGet(x => x.Alignment).Returns(Alignment.Right);
+		var leftHand = new Mock<IBodypart>();
+		leftHand.SetupGet(x => x.Alignment).Returns(Alignment.Left);
+		var rightLegRoot = new Mock<IBodypart>();
+		rightLegRoot.SetupGet(x => x.Alignment).Returns(Alignment.Right);
+		var rightLeg = new Mock<ILimb>();
+		rightLeg.SetupGet(x => x.RootBodypart).Returns(rightLegRoot.Object);
+
+		Assert.IsTrue(Body.CrutchMatchesLimb(rightHand.Object, rightLeg.Object));
+		Assert.IsFalse(Body.CrutchMatchesLimb(leftHand.Object, rightLeg.Object));
+	}
+
+	[TestMethod]
+	public void WoundsCoveredByProfile_ReturnsFracturesUnderCoveredWearLocations()
+	{
+		var bone = new Mock<IBone>();
+		var wearLocation = new Mock<IWear>();
+		wearLocation.SetupGet(x => x.BoneInfo)
+		            .Returns(new Dictionary<IBone, BodypartInternalInfo>
+		            {
+			            [bone.Object] = new BodypartInternalInfo(1.0, true, "arm")
+		            });
+		var wearProfile = new Mock<IWearProfile>();
+		var body = new Mock<IBody>();
+		wearProfile.Setup(x => x.Profile(body.Object))
+		           .Returns(new Dictionary<IWear, IWearlocProfile>
+		           {
+			           [wearLocation.Object] = Mock.Of<IWearlocProfile>()
+		           });
+		var covered = new Mock<IImmobilisableWound>();
+		covered.SetupGet(x => x.Bodypart).Returns(bone.Object);
+		var uncovered = new Mock<IImmobilisableWound>();
+		uncovered.SetupGet(x => x.Bodypart).Returns(Mock.Of<IBone>());
+		body.SetupGet(x => x.Wounds).Returns(new IWound[] { covered.Object, uncovered.Object });
+
+		var result = ImmobilisingGameItemComponent.WoundsCoveredByProfile(body.Object, wearProfile.Object).ToList();
+
+		CollectionAssert.AreEqual(new[] { covered.Object }, result);
+	}
+
+}

--- a/MudSharpCore Unit Tests/MedicalRuntimeRegressionTests.cs
+++ b/MudSharpCore Unit Tests/MedicalRuntimeRegressionTests.cs
@@ -6,6 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using MudSharp.Body;
 using MudSharp.Body.Implementations;
+using MudSharp.GameItems;
 using MudSharp.GameItems.Components;
 using MudSharp.GameItems.Interfaces;
 using MudSharp.GameItems.Inventory;
@@ -85,6 +86,36 @@ public class MedicalRuntimeRegressionTests
 		var result = ImmobilisingGameItemComponent.WoundsCoveredByProfile(body.Object, wearProfile.Object).ToList();
 
 		CollectionAssert.AreEqual(new[] { covered.Object }, result);
+	}
+
+	[TestMethod]
+	public void FindReplacementImmobilisingItem_UsesAnotherWornSplintCoveringTheFracture()
+	{
+		var bone = new Mock<IBone>();
+		var wearLocation = new Mock<IWear>();
+		wearLocation.SetupGet(x => x.BoneInfo)
+		            .Returns(new Dictionary<IBone, BodypartInternalInfo>
+		            {
+			            [bone.Object] = new BodypartInternalInfo(1.0, true, "arm")
+		            });
+		var wearProfile = new Mock<IWearProfile>();
+		var body = new Mock<IBody>();
+		wearProfile.Setup(x => x.Profile(body.Object))
+		           .Returns(new Dictionary<IWear, IWearlocProfile>
+		           {
+			           [wearLocation.Object] = Mock.Of<IWearlocProfile>()
+		           });
+		var wound = new Mock<IImmobilisableWound>();
+		wound.SetupGet(x => x.Bodypart).Returns(bone.Object);
+		body.SetupGet(x => x.Wounds).Returns(new IWound[] { wound.Object });
+		var remainingSplint = Mock.Of<IGameItem>();
+
+		var result = ImmobilisingGameItemComponent.FindReplacementImmobilisingItem(
+			body.Object,
+			wound.Object,
+			new[] { (remainingSplint, wearProfile.Object) });
+
+		Assert.AreSame(remainingSplint, result);
 	}
 
 }

--- a/MudSharpCore/Body/Grouping/BodypartGroupDescriber.cs
+++ b/MudSharpCore/Body/Grouping/BodypartGroupDescriber.cs
@@ -31,7 +31,7 @@ public abstract class BodypartGroupDescriber : SaveableItem, IBodypartGroupDescr
         // Run the rule for the list of bodyparts and get a score. Higher scores at the start of the list.
         List<BodypartGroupResult> results =
             describers.Select(x => x.Match(bodyparts))
-                      .Where(x => x.IsMatch)
+                      .Where(x => x.IsMatch && (x.Matches?.Count ?? 0) > 0)
                       .OrderByDescending(x => x.MatchScore)
                       .ToList();
 

--- a/MudSharpCore/Body/Implementations/Body.cs
+++ b/MudSharpCore/Body/Implementations/Body.cs
@@ -907,21 +907,27 @@ public partial class Body : PerceiverItem, IBody
                      .Where(
                          x =>
                              SeveredRoots.All(y => !x.DownstreamOfPart(y)) ||
-                             Prosthetics.Any(y => x.DownstreamOfPart(y.TargetBodypart) && y.Functional))
+                             Prosthetics.Any(y => y.Functional &&
+                                                  (x.DownstreamOfPart(y.TargetBodypart) ||
+                                                   ProstheticTargetsBodypart(y, x))))
                      .ToList();
         _wieldLocs =
             Bodyparts.OfType<IWield>()
                      .Where(
                          x =>
                              SeveredRoots.All(y => !x.DownstreamOfPart(y)) ||
-                             Prosthetics.Any(y => x.DownstreamOfPart(y.TargetBodypart) && y.Functional))
+                             Prosthetics.Any(y => y.Functional &&
+                                                  (x.DownstreamOfPart(y.TargetBodypart) ||
+                                                   ProstheticTargetsBodypart(y, x))))
                      .ToList();
         _wearlocs =
             Bodyparts.OfType<IWear>()
                      .Where(
                          x =>
                              SeveredRoots.All(y => !x.DownstreamOfPart(y)) ||
-                             Prosthetics.Any(y => x.DownstreamOfPart(y.TargetBodypart) && y.Functional))
+                             Prosthetics.Any(y => y.Functional &&
+                                                  (x.DownstreamOfPart(y.TargetBodypart) ||
+                                                   ProstheticTargetsBodypart(y, x))))
                      .ToList();
         _limbs = Prototype.Limbs.Where(x => x.Parts.Any(y => Bodyparts.Contains(y))).ToList();
     }

--- a/MudSharpCore/Body/Implementations/BodyBiology.cs
+++ b/MudSharpCore/Body/Implementations/BodyBiology.cs
@@ -204,13 +204,12 @@ public partial class Body
 
         if (!ignoreAids)
         {
-            List<ICrutch> crutches = HeldItems.SelectNotNull(x => x.GetItemType<ICrutch>()).ToList();
+            List<ICrutch> crutches = HeldOrWieldedItems.SelectNotNull(x => x.GetItemType<ICrutch>()).ToList();
             foreach (ILimb limb in nonWorkingLimbs.ToArray())
             {
                 ICrutch matchingCrutch =
                     crutches.FirstOrDefault(x =>
-                        _heldItems.First(y => y.Item1 == x.Parent).Item2.Alignment.LeftRightOnly() ==
-                        limb.RootBodypart.Alignment.LeftRightOnly());
+                        CrutchMatchesLimb(BodypartLocationOfInventoryItem(x.Parent), limb));
                 if (matchingCrutch != null)
                 {
                     crutches.Remove(matchingCrutch);
@@ -241,13 +240,12 @@ public partial class Body
             ? Prototype.MinimumLegsToStand + 1
             : Prototype.MinimumLegsToStand;
 
-        List<ICrutch> crutches = HeldItems.SelectNotNull(x => x.GetItemType<ICrutch>()).ToList();
+        List<ICrutch> crutches = HeldOrWieldedItems.SelectNotNull(x => x.GetItemType<ICrutch>()).ToList();
         foreach (ILimb limb in nonWorkingLegs.ToArray())
         {
             ICrutch matchingCrutch =
                 crutches.FirstOrDefault(x =>
-                    _heldItems.First(y => y.Item1 == x.Parent).Item2.Alignment.LeftRightOnly() ==
-                    limb.RootBodypart.Alignment.LeftRightOnly());
+                    CrutchMatchesLimb(BodypartLocationOfInventoryItem(x.Parent), limb));
             if (matchingCrutch != null)
             {
                 crutches.Remove(matchingCrutch);
@@ -281,13 +279,12 @@ public partial class Body
             ? Prototype.MinimumLegsToStand + 1
             : Prototype.MinimumLegsToStand;
 
-        List<ICrutch> crutches = HeldItems.SelectNotNull(x => x.GetItemType<ICrutch>()).ToList();
+        List<ICrutch> crutches = HeldOrWieldedItems.SelectNotNull(x => x.GetItemType<ICrutch>()).ToList();
         foreach (ILimb limb in nonWorkingLegs.ToArray())
         {
             ICrutch matchingCrutch =
                 crutches.FirstOrDefault(x =>
-                    _heldItems.First(y => y.Item1 == x.Parent).Item2.Alignment.LeftRightOnly() ==
-                    limb.RootBodypart.Alignment.LeftRightOnly());
+                    CrutchMatchesLimb(BodypartLocationOfInventoryItem(x.Parent), limb));
             if (matchingCrutch != null)
             {
                 crutches.Remove(matchingCrutch);
@@ -306,6 +303,12 @@ public partial class Body
         (List<ILimb> workingLegs, List<ILimb> _) = GetLegInformation(true);
         (List<ILimb> workingArms, List<ILimb> _) = GetArmAndAppendagesInformation();
         return workingLegs.Count >= 1 || workingArms.Count >= 1;
+    }
+
+    internal static bool CrutchMatchesLimb(IBodypart crutchLocation, ILimb limb)
+    {
+        return crutchLocation is not null &&
+               crutchLocation.Alignment.LeftRightOnly() == limb.RootBodypart.Alignment.LeftRightOnly();
     }
 
     private readonly DoubleCounter<Type> _cachedOrganFunctionsByType = new();

--- a/MudSharpCore/Body/Implementations/BodyParts.cs
+++ b/MudSharpCore/Body/Implementations/BodyParts.cs
@@ -297,7 +297,7 @@ public partial class Body
                            .Where(x => x.Applies(Actor)).ToList();
 
         List<IBodypart> severedParts = _severedRoots
-                           .Where(x => Prosthetics.All(y => y.TargetBodypart != x))
+                           .Where(x => Prosthetics.All(y => !ProstheticTargetsBodypart(y, x)))
                            .Concat(merits.SelectMany(x => x.RemovedBodyparts(Actor)))
                            .Distinct()
                            .ToList();
@@ -358,6 +358,20 @@ public partial class Body
 
     public IEnumerable<IBodypart> SeveredRoots => _severedRoots;
 
+    internal static bool ProstheticTargetsBodypart(IProsthetic prosthetic, IBodypart bodypart)
+    {
+        return prosthetic.TargetBodypart == bodypart ||
+               prosthetic.TargetBodypart.CountsAs(bodypart) ||
+               bodypart.CountsAs(prosthetic.TargetBodypart);
+    }
+
+    internal static bool NonFunctionalProstheticDisablesBodypart(IProsthetic prosthetic, IBodypart bodypart)
+    {
+        return !prosthetic.Functional &&
+               (bodypart.DownstreamOfPart(prosthetic.TargetBodypart) ||
+                ProstheticTargetsBodypart(prosthetic, bodypart));
+    }
+
     public CanUseBodypartResult CanUseBodypart(IBodypart part)
     {
         CanUseLimbResult limbResult = CanUseLimb(GetLimbFor(part));
@@ -396,8 +410,7 @@ public partial class Body
             return CanUseBodypartResult.CantUsePartDamage;
         }
 
-        return Prosthetics.Any(
-            x => (!x.Functional && part.DownstreamOfPart(x.TargetBodypart)) || part == x.TargetBodypart)
+        return Prosthetics.Any(x => NonFunctionalProstheticDisablesBodypart(x, part))
             ? CanUseBodypartResult.CantUseNonFunctionalProsthetic
             : CanUseBodypartResult.CanUse;
 

--- a/MudSharpCore/Body/Implementations/BodyPerception.cs
+++ b/MudSharpCore/Body/Implementations/BodyPerception.cs
@@ -922,7 +922,7 @@ public partial class Body
                                               (y.Item1.GetItemType<IWearable>()?.GloballyTransparent ?? false) &&
                                               !y.Item2.HidesSeveredBodyparts) &&
                                  actor.Body.Prosthetics.All(y =>
-                                     x != y.TargetBodypart && !x.DownstreamOfPart(y.TargetBodypart)))
+                                     !ProstheticTargetsBodypart(y, x) && !x.DownstreamOfPart(y.TargetBodypart)))
                          .GroupBy(x => actor.Body.GetLimbFor(x))
                          .ToList();
                 foreach (IGrouping<ILimb, IBodypart> item in severs.OrderByDescending(x => x.Key != null))
@@ -944,7 +944,7 @@ public partial class Body
                     actor.Body.SeveredRoots.Where(
                         x =>
                             !(x is IOrganProto) &&
-                            !x.Significant && Prosthetics.All(y => x != y.TargetBodypart) &&
+                            !x.Significant && actor.Body.Prosthetics.All(y => !ProstheticTargetsBodypart(y, x)) &&
                             actor.Body.WornItemsProfilesFor(x).All(y => !y.Item2.HidesSeveredBodyparts)).ToList();
                 if (insignificantSevers.Any())
                 {

--- a/MudSharpCore/Commands/Modules/HealthModule.cs
+++ b/MudSharpCore/Commands/Modules/HealthModule.cs
@@ -552,7 +552,7 @@ Options:
                         }
 
                         actor.Send(
-                            $"You can't see any wounds of {target.HowSeen(actor, type: DescriptionType.Possessive)} that would benefit from further cleaning.");
+                            $"You can't see any of {target.HowSeen(actor, type: DescriptionType.Possessive)} wounds that would benefit from further cleaning.");
                     },
                     ExpireAction = () =>
                     {
@@ -587,7 +587,7 @@ Options:
         }
 
         actor.Send(
-            $"You can't see any wounds of {target.HowSeen(actor, type: DescriptionType.Possessive)} that would benefit from further cleaning.");
+            $"You can't see any of {target.HowSeen(actor, type: DescriptionType.Possessive)} wounds that would benefit from further cleaning.");
     }
 
     [PlayerCommand("Suture", "suture")]
@@ -828,8 +828,11 @@ Options:
             return;
         }
 
-        actor.OutputHandler.Handle(new EmoteOutput(new Emote("@ begin|begins tending to $1=0's wounds.", actor, actor,
-            target)));
+        actor.OutputHandler.Handle(new EmoteOutput(new Emote(
+            CharacterInstanceIdentityComparer.SamePhysicalInstance(actor, target)
+                ? "@ begin|begins tending to @'s wounds."
+                : "@ begin|begins tending to $1's wounds.",
+            actor, actor, target)));
         actor.AddEffect(new TendingWounds(actor, target), TendingWounds.EffectDuration);
     }
 

--- a/MudSharpCore/Effects/Concrete/CleaningWounds.cs
+++ b/MudSharpCore/Effects/Concrete/CleaningWounds.cs
@@ -1,4 +1,5 @@
 ﻿using MudSharp.Construction;
+using MudSharp.Character;
 using MudSharp.GameItems.Components;
 using MudSharp.GameItems.Inventory;
 using MudSharp.GameItems.Inventory.Plans;
@@ -190,7 +191,9 @@ public class CleaningWounds : CharacterActionWithTarget, IAffectProximity
         {
             CharacterOwner.OutputHandler.Handle(new EmoteOutput(new Emote("@ stop|stops cleaning $1's wounds.",
                 CharacterOwner, CharacterOwner, TargetCharacter)));
-            CharacterOwner.Send("You require antiseptics to treat your patient any further.".Colour(Telnet.Yellow));
+            CharacterOwner.Send((CharacterInstanceIdentityComparer.SamePhysicalInstance(CharacterOwner, TargetCharacter)
+                ? "You require antiseptics to clean your wounds any further."
+                : "You require antiseptics to treat your patient any further.").Colour(Telnet.Yellow));
             Owner.RemoveEffect(this, true);
             return;
         }
@@ -220,7 +223,9 @@ public class CleaningWounds : CharacterActionWithTarget, IAffectProximity
         {
             CharacterOwner.OutputHandler.Handle(new EmoteOutput(new Emote("@ stop|stops cleaning $1's wounds.",
                 CharacterOwner, CharacterOwner, TargetCharacter)));
-            CharacterOwner.Send("You require antiseptics to treat your patient any further.".Colour(Telnet.Yellow));
+            CharacterOwner.Send((CharacterInstanceIdentityComparer.SamePhysicalInstance(CharacterOwner, TargetCharacter)
+                ? "You require antiseptics to clean your wounds any further."
+                : "You require antiseptics to treat your patient any further.").Colour(Telnet.Yellow));
         }
         else
         {

--- a/MudSharpCore/GameItems/Components/DefibrillatorGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/DefibrillatorGameItemComponent.cs
@@ -55,12 +55,16 @@ public class DefibrillatorGameItemComponent : GameItemComponent, IDefibrillator
 
         if (CharacterState.Able.HasFlag(target.Actor.State))
         {
-            return $"{target.Actor.HowSeen(shocker, true)} is conscious and therefore not in need of defibrillation.";
+            return CharacterInstanceIdentityComparer.SamePhysicalInstance(shocker, target.Actor)
+                ? "You are conscious and therefore not in need of defibrillation."
+                : $"{target.Actor.HowSeen(shocker, true)} is conscious and therefore not in need of defibrillation.";
         }
 
         List<IBodypart> targetParts = target.Bodyparts.Where(x => x.Organs.Any(y => y is HeartProto)).ToList();
         List<IGameItem> preventingRemoval = targetParts.SelectMany(x =>
-            target.WornItemsProfilesFor(x).Where(y => y.Item2.PreventsRemoval).Select(y => y.Item1)).ToList();
+            target.WornItemsProfilesFor(x).Where(y => y.Item2.PreventsRemoval).Select(y => y.Item1))
+            .Distinct()
+            .ToList();
         if (preventingRemoval.Any())
         {
             return
@@ -114,10 +118,11 @@ public class DefibrillatorGameItemComponent : GameItemComponent, IDefibrillator
         CheckOutcome result = check.Check(shocker, Difficulty.Normal, target,
             externalBonus: StandardCheck.BonusesPerDifficultyLevel * ((int)Parent.Quality - 5));
 
-        if (RandomUtilities.DoubleRandom(0.0, 1.0) <= (1.0 + result.Outcome.CheckDegrees() * 0.15) *
+        bool successfulShock = RandomUtilities.DoubleRandom(0.0, 1.0) <= (1.0 + result.Outcome.CheckDegrees() * 0.15) *
             Gameworld.GetStaticDouble(heartFunction <= 0.0
                 ? "DefibrillatorReviveChance"
-                : "DefibrillatorStabiliseChance"))
+                : "DefibrillatorStabiliseChance");
+        if (successfulShock)
         {
             foreach (Tuple<HeartProto, double> heart in heartFunctions)
             {
@@ -135,6 +140,10 @@ public class DefibrillatorGameItemComponent : GameItemComponent, IDefibrillator
                 }
             }
         }
+
+        shocker.Send(successfulShock
+            ? $"{Parent.HowSeen(shocker, true)} reports that the heart rhythm has stabilised."
+            : $"{Parent.HowSeen(shocker, true)} reports no effective change in heart rhythm.");
     }
 
     public double PowerConsumptionInWatts => 0.0;

--- a/MudSharpCore/GameItems/Components/IVBagGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/IVBagGameItemComponent.cs
@@ -800,7 +800,7 @@ public class IVBagGameItemComponent : GameItemComponent, ILiquidContainer, ISwit
                     LiquidMixture.CanMerge(tch.Body.BloodLiquid))
                 {
                     tch.OutputHandler.Handle(new EmoteOutput(new Emote(
-                        $"{tch.Body.BloodLiquid.MaterialDescription.Colour(tch.Body.BloodLiquid.DisplayColour)} begins to flow into @ via $0 from $1.",
+                        $"{LiquidMixture.ColouredLiquidDescription} begins to flow into @ via $0 from $1.",
                         tch, cannula.Parent, Parent)));
                     _initialMessageSent = true;
                 }

--- a/MudSharpCore/GameItems/Components/ImmobilisingGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/ImmobilisingGameItemComponent.cs
@@ -32,5 +32,44 @@ public class ImmobilisingGameItemComponent : WearableGameItemComponent, IImmobil
         return new ImmobilisingGameItemComponent(this, newParent, temporary);
     }
 
+    public override void UpdateWear(IBody body, IWearProfile profile)
+    {
+        ClearImmobilisedWounds();
+        base.UpdateWear(body, profile);
+
+        if (body is null || profile is null)
+        {
+            return;
+        }
+
+        foreach (var wound in WoundsCoveredByProfile(body, profile))
+        {
+            wound.ImmobilisingItem ??= Parent;
+        }
+    }
+
+    internal static IEnumerable<IImmobilisableWound> WoundsCoveredByProfile(IBody body, IWearProfile profile)
+    {
+        var coveredBones = profile.Profile(body)
+                                  .SelectMany(x => x.Key.BoneInfo.Keys)
+                                  .ToHashSet();
+        return body.Wounds.OfType<IImmobilisableWound>()
+                   .Where(x => coveredBones.Contains(x.Bodypart));
+    }
+
+    private void ClearImmobilisedWounds()
+    {
+        if (WornBy is null)
+        {
+            return;
+        }
+
+        foreach (var wound in WornBy.Wounds.OfType<IImmobilisableWound>()
+                                    .Where(x => x.ImmobilisingItem == Parent))
+        {
+            wound.ImmobilisingItem = null;
+        }
+    }
+
     #endregion
 }

--- a/MudSharpCore/GameItems/Components/ImmobilisingGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/ImmobilisingGameItemComponent.cs
@@ -67,8 +67,22 @@ public class ImmobilisingGameItemComponent : WearableGameItemComponent, IImmobil
         foreach (var wound in WornBy.Wounds.OfType<IImmobilisableWound>()
                                     .Where(x => x.ImmobilisingItem == Parent))
         {
-            wound.ImmobilisingItem = null;
+            wound.ImmobilisingItem = FindReplacementImmobilisingItem(
+                WornBy,
+                wound,
+                WornBy.WornItems
+                      .Where(x => x != Parent && x.IsItemType<IImmobilise>())
+                      .Select(x => (Item: x, Profile: x.GetItemType<IWearable>()?.CurrentProfile))
+                      .Where(x => x.Profile is not null));
         }
+    }
+
+    internal static IGameItem FindReplacementImmobilisingItem(
+        IBody body,
+        IImmobilisableWound wound,
+        IEnumerable<(IGameItem Item, IWearProfile Profile)> candidates)
+    {
+        return candidates.FirstOrDefault(x => WoundsCoveredByProfile(body, x.Profile).Contains(wound)).Item;
     }
 
     #endregion

--- a/MudSharpCore/GameItems/Components/WearableGameItemComponent.cs
+++ b/MudSharpCore/GameItems/Components/WearableGameItemComponent.cs
@@ -291,7 +291,7 @@ public class WearableGameItemComponent : GameItemComponent, IWearable
 
                 return sb.ToString();
             case DescriptionType.Evaluate:
-                sb.AppendLine($"This is something that can be worn by those with a body type of {Profiles.Select(x => x.DesignedBody.Name.ColourValue()).ListToString(conjunction: "or ")}.");
+                sb.AppendLine($"This is something that can be worn by those with a body type of {Profiles.Select(x => x.DesignedBody).Distinct().Select(x => x.Name.ColourValue()).ListToString(conjunction: "or ")}.");
                 if (Bulky)
                 {
                     sb.AppendLine($"It is considered bulky, and cannot be worn over other bulky items.");

--- a/MudSharpCore/Health/Wounds/BoneFracture.cs
+++ b/MudSharpCore/Health/Wounds/BoneFracture.cs
@@ -1084,14 +1084,6 @@ public class BoneFracture : PerceivedItem, IImmobilisableWound
                                 $"$0's efforts to relocate {Describe(WoundExaminationType.Look, Outcome.MajorPass).Colour(Telnet.Cyan)} has been {(testOutcome == Outcome.MajorPass ? "majorly" : testOutcome == Outcome.Pass ? "" : "marginally")} unsuccessful.",
                                 treater, treater)));
                     }
-
-                    if (testOutcome != Outcome.MinorFail)
-                    {
-                        Parent.OutputHandler.Send(
-                            $"The pain levels in your {Bodypart.FullDescription()} shoot up {(testOutcome == Outcome.MajorFail ? "enormously" : "substantially")} due to the unsuccessful treatment."
-                                .Colour(Telnet.Red));
-                    }
-                    // TODO - temporary pain?
                 }
                 else
                 {


### PR DESCRIPTION
## Summary

Fixes the medical-runtime defects found while exercising the seeded medicine, IV, prosthetic, mobility-aid, fracture, and AED workflows.

The changes are deliberately narrow: they repair existing component contracts and output, without adding schema, replacing the implant persistence model, or changing medical difficulty tuning.

## Faults found

- **Body saves could fail while serialising blood contamination.** A `BloodLiquidInstance` with no race dereferenced `Race.Id`. Because surface liquids are saved as part of the body transaction, that exception also prevented unrelated body state such as an installed cannula and its item connections from being committed.
- **Functional prostheses could disable their own exact target.** Boolean precedence made an exact target count as non-functional even when the prosthesis was functional. Sever restoration and perception also used strict bodypart identity while the fitting procedure accepts compatible `CountsAs` bodyparts.
- **Worn immobilisers had no mechanical connection to fractures.** `IImmobilisableWound.ImmobilisingItem` was read by treatment and healing code, but a worn `ImmobilisingGameItemComponent` never assigned or cleared it.
- **Crutches only worked through held-item bookkeeping.** Correctly wielded crutches were ignored, and the side check reached directly into the held-item collection instead of using the body's inventory-location API.
- **Failed fracture relocation claimed an unimplemented pain increase.** The echo said pain had increased, but the adjacent code contained only a TODO and applied no such state.
- **Bodypart grouping accepted zero-part matches.** An optional group could win on score without consuming a bodypart, producing descriptions such as a unilateral thigh splint being worn on the head.
- **Wearable evaluation repeated the same designed body once per profile.**
- **Several medical echoes exposed grammar or semantic defects:** `wounds of your`, `yourself wounds`, self-cleaning referring to `your patient`, saline/dextrose IV drips being described as blood, and `You is conscious`.
- **AED obstruction output repeated one garment for every covered heart-bearing location.**
- **Valid AED shocks gave no direct qualitative result when breathing did not visibly restart.**

## Changes

- Serialise absent blood race references as zero, matching the existing optional source and blood-type behaviour.
- Use one compatibility predicate for fitted prosthetic targets across anatomy restoration, usability, inventory locations, and sever descriptions.
- Derive fracture immobilisation from the active worn profile and clear it on removal or profile change; load-time wear restoration recomputes it without new persisted state.
- Recognise held or wielded crutches and resolve their side through `BodypartLocationOfInventoryItem`.
- Ignore empty bodypart-group matches and deduplicate wearable body types.
- Correct the observed wound-care, IV, and defibrillator output.
- Deduplicate AED blocking garments and report either rhythm stabilisation or no effective rhythm change after a valid shock.
- Remove the false fracture-pain echo until a real pain effect exists.
- Update the health runtime documentation and add focused regressions.

## Verification

- `FutureMUDLibrary Unit Tests`: **417 passed**
- `MudSharpCore Unit Tests`: **2,074 passed**
- Focused medical regression tests: **7 passed**
- .NET 10 build completed successfully as part of the test runs.
- `git diff --check` passed.

## Deliberate exclusions

- No database or schema changes.
- No changes to seeded surgery emotes or medical check difficulties.
- No change to the `swap` command syntax.
- No duplicate implant/cannula persistence mechanism; fixing the body-save exception allows the existing implant and component-link persistence paths to complete.
