### PR TITLE
Fix CombatSeeder musket cartridge bore matching

### DIFF
--- a/DatabaseSeeder Unit Tests/EraItemDependencyCompletionTests.cs
+++ b/DatabaseSeeder Unit Tests/EraItemDependencyCompletionTests.cs
@@ -451,10 +451,20 @@ public class EraItemDependencyCompletionTests
 	}
 
 	[TestMethod]
-	public void MusketPaperCartridgeUpsert_UsesMatchingChargeAndIsIdempotent()
+	public void MusketPaperCartridgeUpsert_UsesMatchingBarrelBoreAndIgnoresIncompleteMusketDefinitions()
 	{
 		using FuturemudDatabaseContext context = BuildCombatContext();
 		context.Tags.Add(new Tag { Id = 6, Name = "Paper Cartridges" });
+		context.GameItemComponentProtos.Add(new GameItemComponentProto
+		{
+			Id = 50,
+			RevisionNumber = 0,
+			Type = "Musket",
+			Name = "Incomplete Legacy Musket",
+			Description = "A legacy musket component without a barrel-bore value.",
+			Definition = "<Definition><PowderVolumePerShot>1</PowderVolumePerShot></Definition>",
+			EditableItem = CurrentEditableItem(50)
+		});
 		var bores = new[] { "0.45 Bore", "0.55 Bore", "0.6 Bore", "0.65 Bore", "0.7 Bore", "0.75 Bore", "0.8 Bore" };
 		for (var i = 0; i < bores.Length; i++)
 		{
@@ -478,7 +488,7 @@ public class EraItemDependencyCompletionTests
 				Name = $"TestMusket_{bores[i]}",
 				Description = "test musket",
 				Definition =
-					$"<Definition><BulletBore>{bore}</BulletBore><PowderVolumePerShot>{7.0 + i / 10.0}</PowderVolumePerShot></Definition>",
+					$"<Definition><BarrelBore>{bore}</BarrelBore><PowderVolumePerShot>{7.0 + i / 10.0}</PowderVolumePerShot></Definition>",
 				EditableItem = CurrentEditableItem(200 + i)
 			});
 		}

--- a/DatabaseSeeder/Seeders/CombatSeeder.EraDependencies.cs
+++ b/DatabaseSeeder/Seeders/CombatSeeder.EraDependencies.cs
@@ -485,13 +485,26 @@ public partial class CombatSeeder
 				var baseComponent = context.GameItemComponentProtos
 					.Single(x => x.Name == $"MusketCartridge_{boreName}" && x.EditableItem.RevisionStatus == 4);
 				var baseDefinition = XElement.Parse(baseComponent.Definition);
-				var bore = double.Parse(baseDefinition.Element("BulletBore")!.Value);
+				var bore = double.Parse(
+					baseDefinition.Element("BulletBore")?.Value ??
+					throw new InvalidOperationException(
+						$"Cannot seed MusketPaperCartridge_{boreName}: the base cartridge component has no BulletBore value."),
+					System.Globalization.CultureInfo.InvariantCulture);
 				var musketDefinition = context.GameItemComponentProtos
 					.Where(x => x.Type == "Musket")
 					.AsEnumerable()
 					.Select(x => XElement.Parse(x.Definition))
-					.First(x => Math.Abs(double.Parse(x.Element("BulletBore")!.Value) - bore) < 0.000001);
-				var powderMass = double.Parse(musketDefinition.Element("PowderVolumePerShot")!.Value);
+					.FirstOrDefault(x =>
+						double.TryParse(x.Element("BarrelBore")?.Value, System.Globalization.NumberStyles.Float,
+							System.Globalization.CultureInfo.InvariantCulture, out var musketBore) &&
+						Math.Abs(musketBore - bore) < 0.000001) ??
+					throw new InvalidOperationException(
+						$"Cannot seed MusketPaperCartridge_{boreName}: no Musket component has a matching BarrelBore value.");
+				var powderMass = double.Parse(
+					musketDefinition.Element("PowderVolumePerShot")?.Value ??
+					throw new InvalidOperationException(
+						$"Cannot seed MusketPaperCartridge_{boreName}: the matching Musket component has no PowderVolumePerShot value."),
+					System.Globalization.CultureInfo.InvariantCulture);
 				var definition = new XElement(baseDefinition);
 				definition.Add(new XElement("PowderMass", powderMass), new XElement("IncludesWad", true));
 				EnsureComponent("MusketCartridge", $"MusketPaperCartridge_{boreName}",

--- a/Design Documents/Seeding/FutureMUD_EarlyModern_Military_Firearms_Uniforms_Naval_Dependency_Ledger.md
+++ b/Design Documents/Seeding/FutureMUD_EarlyModern_Military_Firearms_Uniforms_Naval_Dependency_Ledger.md
@@ -218,7 +218,7 @@ Adds ignition- and form-specific muzzleloader components. These require the runt
 
 Adds paper-cartridge, buckshot, and buck-and-ball payload profiles using the existing musket-ammunition family after the payload extension described below.
 
-Implementation status: all seven single-projectile paper-cartridge rows are seeded with explicit charge and wad data. The four multi-projectile rows remain deferred.
+Implementation status: all seven single-projectile paper-cartridge rows are seeded with explicit charge and wad data. The updater matches each cartridge `BulletBore` to the source `Musket` component's `BarrelBore`, ignoring incomplete legacy `Musket` definitions that do not declare a bore. The four multi-projectile rows remain deferred.
 
 | Component prototype | Catalogue row uses | Purpose |
 |---|---:|---|


### PR DESCRIPTION
Summary:
- Match cartridge BulletBore values to Musket BarrelBore values, which fixes the null reference during musket seeding.
- Ignore incomplete legacy Musket definitions and report clear prerequisite errors.
- Add regression coverage and document the schema contract.

Validation:
- git diff --check passed.
- Targeted DatabaseSeeder test/build was attempted but could not complete because the active Visual Studio debugger held compiler output files; this is recorded for CI verification.