### PR TITLE
Add comprehensive command help metadata

### DIFF
--- a/MudSharpCore/Commands/Modules/BuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/BuilderModule.cs
@@ -1827,6 +1827,7 @@ You can use the following filters with #3wearprofile list#0:
 
     [PlayerCommand("WearProfile", "wearprofile", "wp")]
     [CommandPermission(PermissionLevel.HighAdmin)]
+    [HelpInfo("wearprofile", WearProfileHelp, AutoHelp.HelpArgOrNoArg)]
     protected static void WearProfile(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -2312,6 +2313,7 @@ The syntax for this command is as follows:
 
     [PlayerCommand("Gas", "gas")]
     [CommandPermission(PermissionLevel.Admin)]
+    [HelpInfo("gas", GasHelpText, AutoHelp.HelpArgOrNoArg)]
     protected static void Gas(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -2585,6 +2587,7 @@ The syntax for this command is as follows:
 
     [PlayerCommand("Liquid", "liquid")]
     [CommandPermission(PermissionLevel.Admin)]
+    [HelpInfo("liquid", LiquidHelpText, AutoHelp.HelpArgOrNoArg)]
     protected static void Liquid(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -4068,6 +4071,7 @@ You can use the following syntax with this command:
 	#3bodypartshape set name <name>#0 - renames a bodypart shape";
 
     [PlayerCommand("BodypartShape", "bodypartshapes", "bps", "shape")]
+    [HelpInfo("bodypartshape", BodypartShapesHelp, AutoHelp.HelpArgOrNoArg)]
     protected static void BodypartShape(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -4470,6 +4474,7 @@ The syntax for this command is as follows:
 	#3nph set text#0 - drops you into an editor to change the hint text";
 
     [PlayerCommand("NewPlayerHint", "newplayerhint", "nph")]
+    [HelpInfo("newplayerhint", NewPlayerHintHelp, AutoHelp.HelpArgOrNoArg)]
     protected static void NewPlayerHint(ICharacter actor, string input)
     {
         GenericBuildingCommand(actor, new StringStack(input.RemoveFirstWord()), EditableItemHelper.NewPlayerHintHelper);
@@ -5069,6 +5074,7 @@ You can also use the following filters with #3drug list#0:
 
     [PlayerCommand("Drug", "drug")]
     [CommandPermission(PermissionLevel.Admin)]
+    [HelpInfo("drug", DrugsHelp, AutoHelp.HelpArgOrNoArg)]
     protected static void Drug(ICharacter actor, string command)
     {
         GenericBuildingCommand(actor, new StringStack(command.RemoveFirstWord()), EditableItemHelper.DrugHelper);

--- a/MudSharpCore/Commands/Modules/CharacterInformation.cs
+++ b/MudSharpCore/Commands/Modules/CharacterInformation.cs
@@ -598,7 +598,13 @@ Additionally, admins can use the following options:
 
     [PlayerCommand("Consider", "consider", "con")]
     [RequiredCharacterState(CharacterState.Conscious)]
-    [HelpInfo("consider", @"The consider command is used to get key information about another character that might not be readily apparent from their description alone. This includes things like estimates of height, weight, ethnicity and key features. The syntax is simply #3consider <target>#0.", AutoHelp.HelpArgOrNoArg)]
+    [HelpInfo("consider", @"The #3consider#0 command gives you observational details about a visible character that may not be obvious from their description, including approximate height, weight, relative build, and—where your character can infer it—age or ethnicity.
+
+The syntax is:
+
+	#3consider <target>#0
+
+The alias #3con#0 works the same way.", AutoHelp.HelpArgOrNoArg)]
     protected static void Consider(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -641,9 +647,11 @@ Additionally, admins can use the following options:
     }
 
     [PlayerCommand("SkillCategories", "skillcategories")]
-    [HelpInfo("skillcategories",
-        "The SKILLCATEGORIES command allows you to view all of your skills and their current levels, but splits the output by categories.",
-        AutoHelp.HelpArg)]
+    [HelpInfo("skillcategories", @"The #3skillcategories#0 command lists your visible skills and current levels grouped by their skill category. It is useful for discovering the category names accepted by #3skills <category>#0.
+
+The syntax is:
+
+	#3skillcategories#0", AutoHelp.HelpArg)]
     protected static void SkillCategories(ICharacter actor, string input)
     {
         StringBuilder sb = new();
@@ -674,9 +682,15 @@ Additionally, admins can use the following options:
     }
 
     [PlayerCommand("Skills", "skills", "sk", "ski", "skil")]
-    [HelpInfo("skills",
-        "This command is used to view the current level of your skills. The most basic syntax is to simply type SKILLS with no arguments, which shows you all of your skills and their current level. Additionally, you can filter by categories by using SKILL <CATEGORY>. See the SKILLCATEGORIES command to see what categories of skills you have. Finally, administrators can specify a target for the SKILLS command to see someone else's skills.",
-        AutoHelp.HelpArg)]
+    [HelpInfo("skills", @"The #3skills#0 command lists your visible skills and their current levels. Use a category name to narrow the list; #3skillcategories#0 displays the available categories. Administrators may instead name a visible character to inspect that character's skills.
+
+The syntax is:
+
+	#3skills#0
+	#3skills <category>#0
+	#3skills <target>#0 - administrators only
+
+The aliases #3sk#0, #3ski#0 and #3skil#0 work the same way.", AutoHelp.HelpArg)]
     protected static void Skills(ICharacter actor, string input)
     {
         bool adminMode = actor.IsAdministrator();
@@ -755,9 +769,13 @@ Additionally, admins can use the following options:
     }
 
     [PlayerCommand("SkillAudit", "skillaudit", "saudit")]
-    [HelpInfo("skillaudit",
-        "This command is used to view detailed information about your skill levels and their prospects for improvement. The syntax is simply SKILLAUDIT.",
-        AutoHelp.HelpArg)]
+    [HelpInfo("skillaudit", @"The #3skillaudit#0 command gives a detailed report on each visible skill's current improvement prospects. It identifies the minimum practical and theoretical difficulties at which the skill can still improve, or reports when it cannot improve further.
+
+The syntax is:
+
+	#3skillaudit#0
+
+The alias #3saudit#0 works the same way.", AutoHelp.HelpArg)]
     protected static void SkillAudit(ICharacter actor, string input)
     {
         StringBuilder sb = new();
@@ -919,7 +937,11 @@ See {"help knowledges".Colour(Telnet.Yellow)} for more information.");
     }
 
     [PlayerCommand("Quirks", "merits", "flaws", "quirks")]
-    [HelpInfo("quirks", @"The quirks command allows you to view your own quirks (merits and flaws). It will also show you the status of those quirks and whether they currently apply or not, if they are conditional. The syntax is simply #3quirks#0.", AutoHelp.HelpArg,
+    [HelpInfo("quirks", @"The #3quirks#0 command lists your merits and flaws, including whether each conditional quirk currently applies. #3merits#0 and #3flaws#0 are aliases.
+
+The syntax is:
+
+	#3quirks#0", AutoHelp.HelpArg,
         @"The quirks command allows you to view yours or another's quirks (merits and flaws). It will also show you the status of those quirks and whether they currently apply or not, if they are conditional. 
 
 The syntax is as follows:
@@ -1572,8 +1594,16 @@ You can also use this command to test against someone else. This always echoes.
         }
     }
 
-    [PlayerCommand("Plan", "plan")]
-    protected static void Plan(ICharacter actor, string input)
+	[PlayerCommand("Plan", "plan")]
+	[HelpInfo("plan", @"The #3plan#0 command lets you record short- and long-term roleplay plans for your character. With no arguments it shows both plans. Giving #3short#0 or #3long#0 without text clears that plan; administrators may also view an online character's plans.
+
+	The syntax is:
+
+	#3plan#0
+	#3plan short [<plan text>]#0
+	#3plan long [<plan text>]#0
+	#3plan <online character>#0", AutoHelp.HelpArg)]
+	protected static void Plan(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
         if (ss.IsFinished)
@@ -1651,8 +1681,14 @@ You can also use this command to test against someone else. This always echoes.
         }
     }
 
-    [PlayerCommand("Dmote", "dmote")]
-    protected static void Dmote(ICharacter actor, string input)
+	[PlayerCommand("Dmote", "dmote")]
+	[HelpInfo("dmote", @"The #3dmote#0 command sets a personal description addition that other characters can see in your description. It is suitable for a temporary visible detail, not an action. Use #3dmote clear#0 to remove it.
+
+	The syntax is:
+
+	#3dmote <description text>#0
+	#3dmote clear#0", AutoHelp.HelpArgOrNoArg)]
+	protected static void Dmote(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
         if (ss.IsFinished)
@@ -1680,9 +1716,16 @@ You can also use this command to test against someone else. This always echoes.
         actor.Send("You set your dmote to: {0}", ss.SafeRemainingArgument.Colour(Telnet.Cyan));
     }
 
-    [PlayerCommand("Undub", "undub")]
-    [RequiredCharacterState(CharacterState.Conscious)]
-    protected static void UnDub(ICharacter actor, string command)
+	[PlayerCommand("Undub", "undub")]
+	[RequiredCharacterState(CharacterState.Conscious)]
+	[HelpInfo("undub", @"The #3undub#0 command removes one of your private dubs. Removing a character dub also removes that character's ally status, if any.
+
+	The syntax is:
+
+	#3undub <dub>#0
+
+	Use #3dubs#0 to review your existing dubs.", AutoHelp.HelpArgOrNoArg)]
+	protected static void UnDub(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
         if (ss.IsFinished)
@@ -1840,9 +1883,11 @@ Syntax:
 
     [PlayerCommand("DubName", "dubname")]
     [RequiredCharacterState(CharacterState.Conscious)]
-    [HelpInfo("dubname",
-        "This command allows you to manually set an introduced name for a character. You must first have given them a dub. The syntax is DUBNAME <person> <name>",
-        AutoHelp.HelpArgOrNoArg)]
+    [HelpInfo("dubname", @"The #3dubname#0 command records the name by which a character has introduced themself to you. You must already have an identity dub for that character; this changes the introduced-name field of that dub, not its targeting keywords.
+
+The syntax is:
+
+	#3dubname <person> <introduced name>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void DubName(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -1873,9 +1918,14 @@ Syntax:
             $"You update your dub name for {target.HowSeen(actor)} to {dub.IntroducedName.ColourName()}.");
     }
 
-    [PlayerCommand("Dubs", "dubs")]
-    [RequiredCharacterState(CharacterState.Conscious)]
-    protected static void Dubs(ICharacter actor, string command)
+	[PlayerCommand("Dubs", "dubs")]
+	[RequiredCharacterState(CharacterState.Conscious)]
+	[HelpInfo("dubs", @"The #3dubs#0 command lists your private recognition keywords, the last description recorded for each target, any introduced name, and character ally status. Optional words filter the list by a dub keyword or remembered description.
+
+	The syntax is:
+
+	#3dubs [<filter> ...]#0", AutoHelp.HelpArg)]
+	protected static void Dubs(ICharacter actor, string command)
     {
         if (!actor.Dubs.Any())
         {
@@ -1925,9 +1975,14 @@ Syntax:
         );
     }
 
-    [PlayerCommand("Allies", "allies")]
-    [RequiredCharacterState(CharacterState.Conscious)]
-    protected static void Allies(ICharacter actor, string input)
+	[PlayerCommand("Allies", "allies")]
+	[RequiredCharacterState(CharacterState.Conscious)]
+	[HelpInfo("allies", @"The #3allies#0 command lists the characters whom you have marked as allies. An ally must first be someone you have dubbed. The list shows whether each ally is trusted; trusted allies may be allowed to perform much more invasive actions on your character.
+
+	The syntax is:
+
+	#3allies#0", AutoHelp.HelpArg)]
+	protected static void Allies(ICharacter actor, string input)
     {
         if (!actor.AllyIDs.Any())
         {
@@ -1951,9 +2006,16 @@ Syntax:
         );
     }
 
-    [PlayerCommand("Ally", "ally")]
-    [RequiredCharacterState(CharacterState.Conscious)]
-    protected static void Ally(ICharacter actor, string input)
+	[PlayerCommand("Ally", "ally")]
+	[RequiredCharacterState(CharacterState.Conscious)]
+	[HelpInfo("ally", @"The #3ally#0 command marks a visible character whom you have already dubbed as an ally. Add #3trusted#0 only when you intend to let that person bypass many ordinary resistance checks; it is a deliberately high-trust setting.
+
+	The syntax is:
+
+	#3ally <target> [trusted]#0
+
+	Use #3unally#0 to remove the status and #3allies#0 to review it.", AutoHelp.HelpArg)]
+	protected static void Ally(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
         if (ss.IsFinished || ss.Peek().EqualTo("help") || ss.Peek().EqualTo("?"))
@@ -2005,9 +2067,15 @@ Syntax:
         }
     }
 
-    [PlayerCommand("Unally", "unally")]
-    [RequiredCharacterState(CharacterState.Conscious)]
-    protected static void Unally(ICharacter actor, string input)
+	[PlayerCommand("Unally", "unally")]
+	[RequiredCharacterState(CharacterState.Conscious)]
+	[HelpInfo("unally", @"The #3unally#0 command removes ally status from a character. You can target a visible character, or prefix one of your existing character dubs with #3*#0 when the person is not present.
+
+	The syntax is:
+
+	#3unally <target>#0
+	#3unally *<dub>#0", AutoHelp.HelpArg)]
+	protected static void Unally(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
         if (ss.IsFinished || ss.Peek().EqualTo("help") || ss.Peek().EqualTo("?"))
@@ -2931,9 +2999,11 @@ You can use the following options with this command:
 
     [PlayerCommand("Uncovered", "uncovered")]
     [RequiredCharacterState(CharacterState.Conscious)]
-    [HelpInfo("uncovered",
-        "The uncovered command allows you to view the bodyparts that are uncovered for a particular target, including yourself. The syntax is uncovered <target>.",
-        AutoHelp.HelpArgOrNoArg)]
+    [HelpInfo("uncovered", @"The #3uncovered#0 command shows which body parts on a visible character are currently uncovered by opaque worn items. It is useful when choosing locations for clothing, tattoos, scars, examinations or other body-targeted actions.
+
+The syntax is:
+
+	#3uncovered <target>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Uncovered(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());

--- a/MudSharpCore/Commands/Modules/ClanModule.cs
+++ b/MudSharpCore/Commands/Modules/ClanModule.cs
@@ -1781,9 +1781,12 @@ All of the following commands must happen with an edited clan selected:
     }
 
     [PlayerCommand("Clans", "clans")]
-    [HelpInfo("clan",
-        "This command is used to view clans that you are a member of, or template clans. The syntax is either CLANS or CLANS TEMPLATES",
-        AutoHelp.HelpArg)]
+    [HelpInfo("clans", @"The #3clans#0 command displays your current clan memberships, ranks, appointments, pay information and any accessible treasury information. The template form lists the clan templates available to use when creating a clan.
+
+The syntax is:
+
+	#3clans#0
+	#3clans templates#0", AutoHelp.HelpArg)]
     protected static void Clans(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -1883,9 +1886,11 @@ All of the following commands must happen with an edited clan selected:
     [NoCombatCommand]
     [NoHideCommand]
     [NoMovementCommand]
-    [HelpInfo("Payday",
-        "This command is used to check which paydays you have, how much backpay you are owed, and to collect your pay when in the presence of your clan's paymaster. The syntax is simply PAYDAY for all 3 scenarios.",
-        AutoHelp.HelpArg)]
+    [HelpInfo("payday", @"The #3payday#0 command reports your clan pay arrangements and unpaid backpay. When you are in the appropriate clan administrative location with an eligible paymaster, it also collects available pay.
+
+The syntax is:
+
+	#3payday#0", AutoHelp.HelpArg)]
     protected static void Payday(ICharacter actor, string command)
     {
         List<IClanMembership> memberships = actor.ClanMemberships.Where(x => x.Clan.AdministrationCells.Contains(actor.Location))
@@ -7699,9 +7704,11 @@ return 0",
     #endregion Clan Sub-Commands
 
     [PlayerCommand("Notables", "notables")]
-    [HelpInfo("notables",
-        "The notables command is used to view notable individuals that all people would be aware of in your society, like leaders and public figures. The syntax is simply NOTABLES.",
-        AutoHelp.HelpArg)]
+    [HelpInfo("notables", @"The #3notables#0 command lists public figures that your character would generally know about through the visible ranks and appointments of relevant clans in the current sphere.
+
+The syntax is:
+
+	#3notables#0", AutoHelp.HelpArg)]
     protected static void Notables(ICharacter actor, string command)
     {
         string sphere =

--- a/MudSharpCore/Commands/Modules/CombatModule.cs
+++ b/MudSharpCore/Commands/Modules/CombatModule.cs
@@ -1871,9 +1871,12 @@ Similarly to reverse the above you can use the following:
     [RequiredCharacterState(CharacterState.Able)]
     [NoMeleeCombatCommand]
     [NoHideCommand]
-    [HelpInfo("interpose",
-        "This command allows you to physically place yourself between a target and their ranged attackers, so that you are more likely to get hit than they. The syntax is #3INTERPOSE <target>#0, or #3INTERPOSE STOP#0 to stop. You can interpose more than one target at a time if they are substantially smaller than you.",
-        AutoHelp.HelpArgOrNoArg)]
+    [HelpInfo("interpose", @"The #3interpose#0 command makes you shield a nearby target from ranged attacks, increasing the chance that you are hit instead. You can protect multiple sufficiently small targets. Repeating the target removes that protection.
+
+The syntax is:
+
+	#3interpose <target>#0
+	#3interpose <stop|cancel|off|none>#0", AutoHelp.HelpArgOrNoArg)]
     [DelayBlock("general", "You must first stop {0} before you can fight.")]
     protected static void Interpose(ICharacter actor, string command)
     {
@@ -2504,6 +2507,11 @@ The syntax is as follows:
     [PlayerCommand("Unload", "unload")]
     [RequiredCharacterState(CharacterState.Able)]
     [DelayBlock("general", "You must first stop {0} before you can do that.")]
+    [HelpInfo("unload", @"The #3unload#0 command unloads a held or wielded ranged weapon, including an eligible attached weapon. With no target it chooses the first weapon you can unload.
+
+The syntax is:
+
+	#3unload [<ranged weapon>]#0", AutoHelp.HelpArg)]
     protected static void Unload(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -2542,6 +2550,11 @@ The syntax is as follows:
     [PlayerCommand("Ready", "ready")]
     [RequiredCharacterState(CharacterState.Able)]
     [DelayBlock("general", "You must first stop {0} before you can do that.")]
+    [HelpInfo("ready", @"The #3ready#0 command prepares a held or wielded ranged weapon for firing. With no target it chooses the first weapon you can ready. In combat it may be queued as your next action.
+
+The syntax is:
+
+	#3ready [<ranged weapon>]#0", AutoHelp.HelpArg)]
     protected static void Ready(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -2591,6 +2604,11 @@ The syntax is as follows:
     [PlayerCommand("Unready", "unready")]
     [RequiredCharacterState(CharacterState.Able)]
     [DelayBlock("general", "You must first stop {0} before you can do that.")]
+    [HelpInfo("unready", @"The #3unready#0 command returns a readied held or wielded ranged weapon to its unready state. With no target it chooses the first weapon you can unready.
+
+The syntax is:
+
+	#3unready [<ranged weapon>]#0", AutoHelp.HelpArg)]
     protected static void Unready(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -2630,6 +2648,13 @@ The syntax is as follows:
     [RequiredCharacterState(CharacterState.Able)]
     [NoMovementCommand]
     [DelayBlock("general", "You must first stop {0} before you can do that.")]
+    [HelpInfo("aim", @"The #3aim#0 command begins aiming a wielded ranged weapon at a target you can see or have seen at range. In melee combat, omitting arguments aims the first suitable weapon at your combat target. You can select a weapon explicitly, aim at #3sky#0 or #3air#0, and eligible weapons can be aimed at your own body part outside combat.
+
+The syntax is:
+
+	#3aim [<target>]#0
+	#3aim <weapon> <target|sky|air>#0
+	#3aim self <body part>#0", AutoHelp.HelpArg)]
     protected static void Aim(ICharacter actor, string command)
     {
         List<IRangedWeapon> weapons =
@@ -2869,6 +2894,11 @@ The syntax is as follows:
     [RequiredCharacterState(CharacterState.Able)]
     [NoMovementCommand]
     [DelayBlock("general", "aim", "You must first stop {0} before you can do that.")]
+    [HelpInfo("fire", @"The #3fire#0 command fires the ranged weapon that you have already aimed. First use #3aim#0; in combat, firing may be queued as your next combat action.
+
+The syntax is:
+
+	#3fire#0", AutoHelp.HelpArg)]
     protected static void Fire(ICharacter actor, string command)
     {
         if (actor.Aim != null && actor.Combat != null)
@@ -2972,6 +3002,13 @@ The syntax is as follows:
     [NoMovementCommand]
     [RequiredCharacterState(CharacterState.Able)]
     [DelayBlock("general", "aim", "You must first stop {0} before you can do that.")]
+    [HelpInfo("cover", @"The #3cover#0 command seeks protection from ranged attacks. With no argument it selects the best nearby cover; #3move#0 chooses the best cover that still permits movement, and a target selects a particular cover. Use #3stand self#0 to leave cover.
+
+The syntax is:
+
+	#3cover#0
+	#3cover move#0
+	#3cover <cover>#0", AutoHelp.HelpArg)]
     protected static void Cover(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -3077,6 +3114,11 @@ The syntax is as follows:
     [NoMovementCommand]
     [RequiredCharacterState(CharacterState.Able)]
     [DelayBlock("general", "aim", "You must first stop {0} before you can do that.")]
+    [HelpInfo("charge", @"The #3charge#0 command closes the distance to enter melee with a combat target. It is available only while in combat but outside melee range. With no argument it charges your current target; name another valid opponent to choose them instead.
+
+The syntax is:
+
+	#3charge [<target>]#0", AutoHelp.HelpArg)]
     protected static void Charge(ICharacter actor, string command)
     {
         if (actor.Combat == null)
@@ -3130,6 +3172,11 @@ The syntax is as follows:
     [NoMovementCommand]
     [RequiredCharacterState(CharacterState.Able)]
     [DelayBlock("general", "aim", "You must first stop {0} before you can do that.")]
+    [HelpInfo("engage", @"The #3engage#0 command moves you into melee range with a combat target without using a charge. It is available only while in combat but outside melee range. With no argument it uses your current target; name another valid opponent to choose them instead.
+
+The syntax is:
+
+	#3engage [<target>]#0", AutoHelp.HelpArg)]
     protected static void Engage(ICharacter actor, string command)
     {
         if (actor.Combat == null)

--- a/MudSharpCore/Commands/Modules/CommunicationsModule.cs
+++ b/MudSharpCore/Commands/Modules/CommunicationsModule.cs
@@ -27,6 +27,14 @@ internal class CommunicationsModule : Module<ICharacter>
 
     [PlayerCommand("Think", "think")]
     [RequiredCharacterState(CharacterState.SleepingOrBetter)]
+    [HelpInfo("think", @"The #3think#0 command lets you express an internal thought. It is normally private, but characters connected to you by an applicable telepathy effect may perceive it according to that effect's settings.
+
+You can attach a parenthetical emote before the thought to describe how you think it. Think text is normalised into a sentence before it is shown.
+
+The syntax is:
+
+	#3think <thought>#0
+	#3think (<emote>) <thought>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Think(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -72,6 +80,14 @@ internal class CommunicationsModule : Module<ICharacter>
 
     [PlayerCommand("Feel", "feel")]
     [RequiredCharacterState(CharacterState.SleepingOrBetter)]
+    [HelpInfo("feel", @"The #3feel#0 command expresses an internal feeling or emotional state. It is normally private, but characters connected to you by an applicable telepathy effect may perceive it according to that effect's settings.
+
+Use normal emote markup for the feeling itself. A parenthetical emote immediately after the command can describe the manner in which the feeling is experienced.
+
+The syntax is:
+
+	#3feel <emote text>#0
+	#3feel (<emote>) <emote text>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Feel(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -140,9 +156,11 @@ internal class CommunicationsModule : Module<ICharacter>
     }
 
     [PlayerCommand("Languages", "languages")]
-    [HelpInfo("languages",
-        "The languages command allows you to view which languages you know and how well you know them. The syntax is simply LANGUAGES.",
-        AutoHelp.HelpArg)]
+    [HelpInfo("languages", @"The #3languages#0 command lists every language known by your character and your current ability with each one. It is useful when choosing a language with #3speak#0 or checking whether you can understand another character.
+
+The syntax is:
+
+	#3languages#0", AutoHelp.HelpArg)]
     protected static void Languages(ICharacter actor, string input)
     {
         StringBuilder sb = new();
@@ -157,6 +175,13 @@ internal class CommunicationsModule : Module<ICharacter>
     }
 
     [PlayerCommand("PreferAccent", "preferaccent")]
+    [HelpInfo("preferaccent", @"The #3preferaccent#0 command selects the accent you prefer to use for a language. When you have several accents for the same language, this is the accent automatically selected by #3speak#0 unless you explicitly choose another one.
+
+You only need to include the language when you know accents with the same name in more than one language.
+
+The syntax is:
+
+	#3preferaccent <accent> [<language>]#0", AutoHelp.HelpArgOrNoArg)]
     protected static void PreferAccent(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -185,6 +210,14 @@ internal class CommunicationsModule : Module<ICharacter>
     }
 
     [PlayerCommand("Accents", "accents")]
+    [HelpInfo("accents", @"The #3accents#0 command lists accents known by your character, grouped by language. Your preferred accent is marked in the display; use #3preferaccent#0 to change it.
+
+Supplying a language narrows the list to accents for that language. The language name may be abbreviated when it remains unambiguous.
+
+The syntax is:
+
+	#3accents#0
+	#3accents <language>#0", AutoHelp.HelpArg)]
     protected static void Accents(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -307,6 +340,13 @@ The syntax is as follows:
     }
 
     [PlayerCommand("Semote", "semote")]
+    [HelpInfo("semote", @"The #3semote#0 command sends a silent emote. Use it for visible actions that do not themselves make an audible speech or sound echo.
+
+It uses the same emote markup as #3emote#0, including #6@#0 for yourself, #6~target#0 for characters and #6*target#0 for items.
+
+The syntax is:
+
+	#3semote <emote text>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Semote(ICharacter actor, string input)
     {
         if (string.IsNullOrWhiteSpace(input.RemoveFirstWord()))
@@ -320,6 +360,13 @@ The syntax is as follows:
     }
 
     [PlayerCommand("Hemote", "hemote")]
+    [HelpInfo("hemote", @"The #3hemote#0 command sends a hidden emote: observers must notice it before they receive the echo. Use it for subtle actions that may escape attention rather than for actions that should be openly visible.
+
+It uses the normal #3emote#0 markup rules, including #6@#0 for yourself, #6~target#0 for characters and #6*target#0 for items.
+
+The syntax is:
+
+	#3hemote <emote text>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Hemote(ICharacter actor, string input)
     {
         string message = input.RemoveFirstWord();
@@ -389,6 +436,15 @@ If you care about getting grammatically correct echoes to yourself (for log purp
 
     [PlayerCommand("Say", "say", ".")]
     [RequiredCharacterState(CharacterState.Conscious)]
+    [HelpInfo("say", @"The #3say#0 command speaks aloud to people who can hear you in your current location. Your selected language and accent, set with #3speak#0, determine how the speech is presented.
+
+You can put a parenthetical emote before the words to add accompanying action or delivery. The #3.#0 alias is equivalent to #3say#0.
+
+The syntax is:
+
+	#3say <message>#0
+	#3say (<emote>) <message>#0
+	#3. <message>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Say(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -419,6 +475,15 @@ If you care about getting grammatically correct echoes to yourself (for log purp
 
     [PlayerCommand("Sing", "sing")]
     [RequiredCharacterState(CharacterState.Conscious)]
+    [HelpInfo("sing", @"The #3sing#0 command sings aloud using your current language and accent. Separate verses or lines with #6/#0; each non-empty segment is presented as a separate sung line.
+
+You can put a parenthetical emote before the lyrics to describe your performance.
+
+The syntax is:
+
+	#3sing <lyrics>#0
+	#3sing <line one> / <line two>#0
+	#3sing (<emote>) <lyrics>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Sing(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -463,6 +528,15 @@ If you care about getting grammatically correct echoes to yourself (for log purp
 
     [PlayerCommand("SingTo", "singto")]
     [RequiredCharacterState(CharacterState.Conscious)]
+    [HelpInfo("singto", @"The #3singto#0 command sings to a particular visible person or object. The target receives the directed presentation while the song is still audible in the location.
+
+Separate lyric lines with #6/#0, and put an optional parenthetical emote after the target and before the lyrics.
+
+The syntax is:
+
+	#3singto <target> <lyrics>#0
+	#3singto <target> (<emote>) <lyrics>#0
+	#3singto <target> <line one> / <line two>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void SingTo(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -514,6 +588,16 @@ If you care about getting grammatically correct echoes to yourself (for log purp
     [PlayerCommand("Talk", "talk", "talkto")]
     [DisplayOptions(CommandDisplayOptions.DisplayCommandWords)]
     [RequiredCharacterState(CharacterState.SleepingOrBetter)]
+    [HelpInfo("talk", @"The #3talk#0 command is a conversational alternative to #3say#0. It uses your current language and accent, but has its own presentation style. Use #3talkto#0 when you want to direct the conversation at a visible person or object.
+
+An optional parenthetical emote goes before the message. #3talk#0 does not take a target; use the #3talkto#0 alias for that form.
+
+The syntax is:
+
+	#3talk <message>#0
+	#3talk (<emote>) <message>#0
+	#3talkto <target> <message>#0
+	#3talkto <target> (<emote>) <message>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Talk(ICharacter actor, string input)
     {
         StringStack ss = new(input);
@@ -563,6 +647,16 @@ If you care about getting grammatically correct echoes to yourself (for log purp
     [PlayerCommand("Transmit", "transmit", "transmitwith")]
     [DisplayOptions(CommandDisplayOptions.DisplayCommandWords)]
     [RequiredCharacterState(CharacterState.Able)]
+    [HelpInfo("transmit", @"The #3transmit#0 command sends speech through suitable transmitting equipment available to your character. It uses your current language and accent. Use #3transmitwith#0 to choose the specific item to operate when more than one transmitter is available.
+
+The selected item must be something you can manipulate and must support manual transmission. A parenthetical emote may be placed before the message.
+
+The syntax is:
+
+	#3transmit <message>#0
+	#3transmit (<emote>) <message>#0
+	#3transmitwith <item> <message>#0
+	#3transmitwith <item> (<emote>) <message>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Transmit(ICharacter actor, string input)
     {
         StringStack ss = new(input);
@@ -894,6 +988,15 @@ The syntax is:
     [PlayerCommand("Tell", "tell", "sayto")]
     [DisplayOptions(CommandDisplayOptions.DisplayCommandWords)]
     [RequiredCharacterState(CharacterState.Conscious)]
+    [HelpInfo("tell", @"The #3tell#0 command speaks directly to a visible person or object. It still uses ordinary speech, so others nearby may hear it; it is not a private communication channel.
+
+Use the #3sayto#0 alias for the same command. A parenthetical emote after the target can describe the delivery of the message.
+
+The syntax is:
+
+	#3tell <target> <message>#0
+	#3tell <target> (<emote>) <message>#0
+	#3sayto <target> <message>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Tell(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -933,6 +1036,16 @@ The syntax is:
     [PlayerCommand("Shout", "shout", "shoutat")]
     [DisplayOptions(CommandDisplayOptions.DisplayCommandWords)]
     [RequiredCharacterState(CharacterState.Conscious)]
+    [HelpInfo("shout", @"The #3shout#0 command sends forceful speech that carries farther than ordinary conversation. Use #3shoutat#0 to direct that shout at a visible person or object.
+
+Your current language and accent are used. A parenthetical emote can be placed before the shouted message.
+
+The syntax is:
+
+	#3shout <message>#0
+	#3shout (<emote>) <message>#0
+	#3shoutat <target> <message>#0
+	#3shoutat <target> (<emote>) <message>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Shout(ICharacter actor, string input)
     {
         StringStack ss = new(input);
@@ -1111,6 +1224,16 @@ Your in-room emote uses normal emote syntax. If you omit the #6@#0 token, your s
     [PlayerCommand("LoudSay", "loudsay", "loudtell")]
     [DisplayOptions(CommandDisplayOptions.DisplayCommandWords)]
     [RequiredCharacterState(CharacterState.Conscious)]
+    [HelpInfo("loudsay", @"The #3loudsay#0 command speaks loudly in your current location. It is useful when you want a more forceful delivery without using the longer-ranging #3shout#0 or #3yell#0 commands.
+
+Use #3loudtell#0 to direct the loud speech at a visible target. A parenthetical emote can describe the delivery.
+
+The syntax is:
+
+	#3loudsay <message>#0
+	#3loudsay (<emote>) <message>#0
+	#3loudtell <target> <message>#0
+	#3loudtell <target> (<emote>) <message>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void LoudSay(ICharacter actor, string input)
     {
         StringStack ss = new(input);
@@ -1160,6 +1283,16 @@ Your in-room emote uses normal emote syntax. If you omit the #6@#0 token, your s
     [PlayerCommand("Yell", "yell", "yellat")]
     [DisplayOptions(CommandDisplayOptions.DisplayCommandWords)]
     [RequiredCharacterState(CharacterState.Conscious)]
+    [HelpInfo("yell", @"The #3yell#0 command projects speech as a yell, carrying it farther than normal conversation. Use #3yellat#0 to direct the yell at a visible person or object.
+
+Your current language and accent apply. You can attach a parenthetical emote before the words to describe the action.
+
+The syntax is:
+
+	#3yell <message>#0
+	#3yell (<emote>) <message>#0
+	#3yellat <target> <message>#0
+	#3yellat <target> (<emote>) <message>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Yell(ICharacter actor, string input)
     {
         StringStack ss = new(input);
@@ -1209,6 +1342,16 @@ Your in-room emote uses normal emote syntax. If you omit the #6@#0 token, your s
     [PlayerCommand("Whisper", "whisper", "whisperto")]
     [DisplayOptions(CommandDisplayOptions.DisplayCommandWords)]
     [RequiredCharacterState(CharacterState.SleepingOrBetter)]
+    [HelpInfo("whisper", @"The #3whisper#0 command speaks quietly. Use #3whisperto#0 to direct the whisper at a visible person or object; nearby characters may still hear it according to the normal perception rules.
+
+Whispers use your current language and accent. A parenthetical emote can be placed before the whispered message.
+
+The syntax is:
+
+	#3whisper <message>#0
+	#3whisper (<emote>) <message>#0
+	#3whisperto <target> <message>#0
+	#3whisperto <target> (<emote>) <message>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Whisper(ICharacter actor, string input)
     {
         StringStack ss = new(input);
@@ -1742,7 +1885,11 @@ You can use the following syntax with this command:
 
     [PlayerCommand("Boards", "boards")]
     [CommandPermission(PermissionLevel.JuniorAdmin)]
-    [HelpInfo("boards", @"The #3boards#0 command is used to review which boards exist in the game, which you can interact with and edit with the related #3board#0 command. The syntax is simply #3boards#0.", AutoHelp.HelpArg)]
+    [HelpInfo("boards", @"The #3boards#0 command lists every discussion board configured in the game and the number of posts on each. It is an administrative overview; use #3board#0 to inspect or maintain individual boards and their posts.
+
+The syntax is:
+
+	#3boards#0", AutoHelp.HelpArg)]
     protected static void Boards(ICharacter actor, string input)
     {
         StringBuilder sb = new("There are the following boards available:\n");

--- a/MudSharpCore/Commands/Modules/CraftModule.cs
+++ b/MudSharpCore/Commands/Modules/CraftModule.cs
@@ -28,6 +28,11 @@ internal class CraftModule : Module<ICharacter>
     public static CraftModule Instance { get; } = new();
 
     [PlayerCommand("Crafts", "crafts")]
+    [HelpInfo("crafts", @"The #3crafts#0 command lists the crafts your character can perform. Supply category prefixes to narrow the list, #3+text#0 to require text in the craft name, or #3-text#0 to exclude it. You can combine filters.
+
+The syntax is:
+
+	#3crafts [<category>] [+<name text>] [-<name text>]#0", AutoHelp.HelpArg)]
     protected static void Crafts(ICharacter actor, string input)
     {
         List<ICraft> crafts = (actor.IsAdministrator()
@@ -466,9 +471,11 @@ The full list of filters for craft list is below:
     }
 
     [PlayerCommand("Materials", "materials")]
-    [HelpInfo("materials",
-        "This command is an alias for the CRAFT PREVIEW option. It shows a preview of what materials would be used if you were to execute the craft at the moment. The syntax is MATERIALS <craft>.",
-        AutoHelp.HelpArgOrNoArg)]
+    [HelpInfo("materials", @"The #3materials#0 command previews the tools and materials that would be consumed if you began a craft now. It is equivalent to the craft-preview option and does not begin the craft.
+
+The syntax is:
+
+	#3materials <craft>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Materials(ICharacter actor, string input)
     {
         CraftPreview(actor, new StringStack(input.RemoveFirstWord()));
@@ -666,9 +673,11 @@ You can use the following syntax:
     }
 
     [PlayerCommand("Projects", "projects")]
-    [HelpInfo("projects",
-        "This command shows you personal projects that you have in progress and projects in the local area.",
-        AutoHelp.HelpArg)]
+    [HelpInfo("projects", @"The #3projects#0 command lists projects you are working on and projects active in your local area. Use #3project#0 for detailed project actions such as starting, joining, supplying and claiming.
+
+The syntax is:
+
+	#3projects#0", AutoHelp.HelpArg)]
     protected static void Projects(ICharacter actor, string input)
     {
         StringBuilder sb = new();
@@ -824,6 +833,7 @@ You can use the following options with this command:
 Note: See the closely related #3projects#0 command for information about your current projects.";
 
     [PlayerCommand("Project", "project")]
+    [HelpInfo("project", ProjectPlayerHelp, AutoHelp.HelpArgOrNoArg, ProjectAdminHelp)]
     protected static void Project(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -1909,6 +1919,11 @@ Note: See the closely related #3projects#0 command for information about your cu
     [NoHideCommand]
     [NoMovementCommand]
     [DelayBlock("general", "You must first stop {0} before you can do that.")]
+    [HelpInfo("butcher", @"The #3butcher#0 command begins breaking down an organic corpse or body part into its configured products. Some creatures have product subcategories, which you can name to process only that portion. The required tools and the available products depend on the target's butchery profile.
+
+The syntax is:
+
+	#3butcher <corpse|body part> [<subcategory>]#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Butcher(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -2000,6 +2015,11 @@ Note: See the closely related #3projects#0 command for information about your cu
     [NoHideCommand]
     [NoMovementCommand]
     [DelayBlock("general", "You must first stop {0} before you can do that.")]
+    [HelpInfo("salvage", @"The #3salvage#0 command begins dismantling a non-organic wreck or part into its configured components. Some targets have product subcategories, which you can name to process only that portion. The required tools and results depend on the target's salvage profile.
+
+The syntax is:
+
+	#3salvage <wreck|part> [<subcategory>]#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Salvage(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -2092,6 +2112,11 @@ Note: See the closely related #3projects#0 command for information about your cu
     [NoHideCommand]
     [NoMovementCommand]
     [DelayBlock("general", "You must first stop {0} before you can do that.")]
+    [HelpInfo("skin", @"The #3skin#0 command removes an intact pelt, fur or skin from a whole corpse. The corpse must be suitable, not too decayed, not already skinned, and you must have any required tools.
+
+The syntax is:
+
+	#3skin <corpse>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Skin(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());

--- a/MudSharpCore/Commands/Modules/CrimeModule.cs
+++ b/MudSharpCore/Commands/Modules/CrimeModule.cs
@@ -1266,6 +1266,13 @@ There are the following syntaxes for this command:
     [PlayerCommand("TakeCustody", "takecustody")]
     [RequiredCharacterState(CharacterState.Able)]
     [MustBeAnEnforcer]
+    [HelpInfo("takecustody", @"The #3takecustody#0 command is used by an enforcer to place a nearby wanted person, or someone serving a custodial sentence, in their custody. If you enforce more than one applicable jurisdiction, you can name the jurisdiction; otherwise the command selects the most relevant one.
+
+The syntax is:
+
+	#3takecustody <target> [<jurisdiction>]#0
+
+The target must remain close to their custodian. Use #3transfercustody#0 to hand custody to another enforcer, or #3endcustody#0 to release it.", AutoHelp.HelpArgOrNoArg)]
     protected static void TakeCustody(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -1450,6 +1457,11 @@ The syntax is #3transfercustody <prisoner> <enforcer>#0.", AutoHelp.HelpArg)]
     [PlayerCommand("EndCustody", "endcustody")]
     [RequiredCharacterState(CharacterState.Able)]
     [MustBeAnEnforcer]
+    [HelpInfo("endcustody", @"The #3endcustody#0 command releases a nearby person from custody that you currently hold. Administrators can release custody held by another enforcer.
+
+The syntax is:
+
+	#3endcustody <target>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void EndCustody(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -1540,6 +1552,14 @@ The syntax is either #3patrols#0 or #3patrols <jurisdiction>#0 if you are an enf
 
     [PlayerCommand("PermitWork", "permitwork", "permitworkproperty")]
     [RequiredCharacterState(CharacterState.Able)]
+    [HelpInfo("permitwork", @"The #3permitwork#0 command grants a visible person temporary permission to work in the current area. The #3permitworkproperty#0 form is specifically for a property containing your current location. You must be authorised to grant that access.
+
+The syntax is:
+
+	#3permitwork <target> <duration>#0
+	#3permitworkproperty <target> <duration>#0
+
+Durations use ordinary time units such as #3hours#0, #3days#0 or #3weeks#0; months and years are not accepted.", AutoHelp.HelpArgOrNoArg)]
     protected static void PermitWork(ICharacter actor, string input)
     {
         StringStack ss = new(input);

--- a/MudSharpCore/Commands/Modules/EconomyModule.cs
+++ b/MudSharpCore/Commands/Modules/EconomyModule.cs
@@ -437,9 +437,11 @@ internal partial class EconomyModule : Module<ICharacter>
     [PlayerCommand("Count", "count")]
     [RequiredCharacterState(CharacterState.Conscious)]
     [NoCombatCommand]
-    [HelpInfo("count",
-        "The count command is used to take stock of the physical currency that you are carrying (including in containers), to help you understand how much money you have. It will also display a list of bank accounts that you own (though you need to go to a bank to see the balances of these).",
-        AutoHelp.HelpArg)]
+    [HelpInfo("count", @"The #3count#0 command totals physical currency carried on your person, including suitable containers, and lists bank accounts you own. It does not show bank balances; visit the relevant bank for those.
+
+The syntax is:
+
+	#3count#0", AutoHelp.HelpArg)]
     protected static void Count(ICharacter character, string command)
     {
         Dictionary<ICurrency, decimal> results = new();
@@ -10696,6 +10698,7 @@ The syntax for working with categories is as follows:
 
     [PlayerCommand("MarketCategory", "marketcategory", "mc")]
     [CommandPermission(PermissionLevel.Admin)]
+    [HelpInfo("marketcategory", MarketCategoryHelpText, AutoHelp.HelpArgOrNoArg)]
     protected static void MarketCategory(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -10939,6 +10942,7 @@ The syntax for this command is as follows:
 
     [PlayerCommand("Market", "market")]
     [CommandPermission(PermissionLevel.Admin)]
+    [HelpInfo("market", MarketHelpText, AutoHelp.HelpArgOrNoArg)]
     protected static void Market(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -11175,6 +11179,7 @@ The syntax for this command is as follows:
 
     [PlayerCommand("MarketPopulation", "marketpopulation", "mp")]
     [CommandPermission(PermissionLevel.Admin)]
+    [HelpInfo("marketpopulation", MarketPopulationHelpText, AutoHelp.HelpArgOrNoArg)]
     protected static void MarketPopulation(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());

--- a/MudSharpCore/Commands/Modules/GameModule.cs
+++ b/MudSharpCore/Commands/Modules/GameModule.cs
@@ -38,9 +38,11 @@ internal class GameModule : Module<ICharacter>
     public override int CommandsDisplayOrder => 0;
 
     [PlayerCommand("SkillLevels", "skilllevels")]
-    [HelpInfo("skilllevels",
-        @"This command allows you to see the skill level descriptors for one of your skills or stats, in the order that they appear. The syntax is SKILLLEVELS <skill/attribute>.",
-        AutoHelp.HelpArgOrNoArg)]
+    [HelpInfo("skilllevels", @"The #3skilllevels#0 command lists the named skill or attribute's descriptive level bands in order. Administrators can inspect any defined trait; other characters can inspect only their own traits.
+
+The syntax is:
+
+	#3skilllevels <skill|attribute>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void SkillLevels(ICharacter actor, string command)
     {
         string traitName = command.RemoveFirstWord();
@@ -84,9 +86,11 @@ internal class GameModule : Module<ICharacter>
     }
 
 	[PlayerCommand("Command", "command")]
-	[HelpInfo("command",
-		"This command is used to issue commands to NPCs and AI-controlled characters that you are authorised to issue commands to. Commands can be issued even when you can't see your target or are unconscious. The syntax is COMMAND <target> <input that you want them to enter>.",
-		AutoHelp.HelpArgOrNoArg)]
+	[HelpInfo("command", @"The #3command#0 command instructs an NPC or AI-controlled character that is configured to accept your orders. Eligibility is determined by that character's AI, and the target may be resolved even when ordinary sight or consciousness rules would prevent it.
+
+	The syntax is:
+
+	#3command <target> <command text>#0", AutoHelp.HelpArgOrNoArg)]
 	protected static void Command(ICharacter actor, string command)
 	{
         StringStack ss = new(command.RemoveFirstWord());
@@ -366,17 +370,25 @@ For a full list of combat flags, see #3SHOW COMBATFLAGS#0", AutoHelp.HelpArg)]
         actor.Send(sb.ToString());
     }
 
-    [PlayerCommand("More", "more")]
-    protected static void More(ICharacter actor, string input)
+	[PlayerCommand("More", "more")]
+	[HelpInfo("more", @"The #3more#0 command continues output that has been paused by the game's pager. It is most useful when a long list or report tells you that more text is available.
+
+	The syntax is:
+
+	#3more#0", AutoHelp.HelpArg)]
+	protected static void More(ICharacter actor, string input)
     {
         actor.OutputHandler.More();
     }
 
     [PlayerCommand("Keyword", "keyword")]
     [RequiredCharacterState(CharacterState.Conscious)]
-    [HelpInfo("keyword",
-        "The keyword command allows you to trial the results of using a particular keyword to target something. The syntax is KEYWORD <keyword>, or KEYWORD IN <container> <keyword> to test the contents of a container.",
-        AutoHelp.HelpArgOrNoArg)]
+    [HelpInfo("keyword", @"The #3keyword#0 command shows what visible people and items match a targeting keyword. Prefixing a keyword with a number follows normal target-selection numbering. Use the #3in#0 form to test only a container's visible contents.
+
+The syntax is:
+
+	#3keyword <keyword>[.<keyword> ...]#0
+	#3keyword in <container> <keyword>[.<keyword> ...]#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Keyword(ICharacter actor, string input)
     {
         input = input.RemoveFirstWord().ToLowerInvariant();
@@ -499,8 +511,13 @@ For a full list of combat flags, see #3SHOW COMBATFLAGS#0", AutoHelp.HelpArg)]
         actor.OutputHandler.Send(sb.ToString());
     }
 
-    [PlayerCommand("Statistics", "statistics", "stats")]
-    protected static void Statistics(ICharacter actor, string input)
+	[PlayerCommand("Statistics", "statistics", "stats")]
+	[HelpInfo("statistics", @"The #3statistics#0 command displays public information about the game, including its engine version, uptime, player-account activity, world size and record online population. The alias #3stats#0 is equivalent.
+
+	The syntax is:
+
+	#3statistics#0", AutoHelp.HelpArg)]
+	protected static void Statistics(ICharacter actor, string input)
     {
         StringBuilder sb = new();
         sb.AppendLine($"The following statistics are available regarding {actor.Gameworld.Name.Proper()}:");
@@ -564,8 +581,13 @@ For a full list of combat flags, see #3SHOW COMBATFLAGS#0", AutoHelp.HelpArg)]
         actor.AddEffect(new CommandDelay(actor, "Statistics"), TimeSpan.FromSeconds(10));
     }
 
-    [PlayerCommand("Who", "who")]
-    protected static void Who(ICharacter actor, string input)
+	[PlayerCommand("Who", "who")]
+	[HelpInfo("who", @"The #3who#0 command shows the current online population. Depending on the game's configuration, it can also identify active staff, meeting places, guests and groups to which your character belongs.
+
+	The syntax is:
+
+	#3who#0", AutoHelp.HelpArg)]
+	protected static void Who(ICharacter actor, string input)
     {
         List<ICharacter> whocharacters =
             actor.Gameworld.Characters
@@ -720,9 +742,15 @@ The syntax for this command is as follows:
         }
     }
 
-    [PlayerCommand("Stop", "stop")]
-    [RequiredCharacterState(CharacterState.Conscious)]
-    protected static void Stop(ICharacter actor, string input)
+	[PlayerCommand("Stop", "stop")]
+	[RequiredCharacterState(CharacterState.Conscious)]
+	[HelpInfo("stop", @"The #3stop#0 command cancels an action that your character is currently performing, where that action allows cancellation. Use #3stop playing#0 specifically to stop playing an instrument.
+
+	The syntax is:
+
+	#3stop#0
+	#3stop playing#0", AutoHelp.HelpArg)]
+	protected static void Stop(ICharacter actor, string input)
     {
         var ss = new StringStack(input.RemoveFirstWord());
         if (ss.SafeRemainingArgument.EqualTo("playing"))
@@ -741,16 +769,26 @@ The syntax for this command is as follows:
         actor.Stop(false);
     }
 
-    [PlayerCommand("Manifest", "manifest")]
-    [RequiredCharacterState(CharacterState.Conscious)]
-    protected static void Manifest(ICharacter actor, string input)
+	[PlayerCommand("Manifest", "manifest")]
+	[RequiredCharacterState(CharacterState.Conscious)]
+	[HelpInfo("manifest", @"The #3manifest#0 command makes your character physically present when an applicable planar state, effect or merit permits it. It has no effect for characters without a suitable manifestation state.
+
+	The syntax is:
+
+	#3manifest#0", AutoHelp.HelpArg)]
+	protected static void Manifest(ICharacter actor, string input)
     {
         ChangePlanarManifestation(actor, true);
     }
 
-    [PlayerCommand("Dissipate", "dissipate")]
-    [RequiredCharacterState(CharacterState.Conscious)]
-    protected static void Dissipate(ICharacter actor, string input)
+	[PlayerCommand("Dissipate", "dissipate")]
+	[RequiredCharacterState(CharacterState.Conscious)]
+	[HelpInfo("dissipate", @"The #3dissipate#0 command makes your character non-corporeal when an applicable planar state, effect or merit permits it. It is the counterpart to #3manifest#0.
+
+	The syntax is:
+
+	#3dissipate#0", AutoHelp.HelpArg)]
+	protected static void Dissipate(ICharacter actor, string input)
     {
         ChangePlanarManifestation(actor, false);
     }
@@ -1072,9 +1110,14 @@ The syntax is #3tagsearch <tag>#0.", AutoHelp.HelpArgOrNoArg)]
             flags: OutputFlags.SuppressObscured));
     }
 
-    [PlayerCommand("Learn", "learn")]
-    [CommandPermission(PermissionLevel.Player)]
-    protected static void Learn(ICharacter actor, string input)
+	[PlayerCommand("Learn", "learn")]
+	[CommandPermission(PermissionLevel.Player)]
+	[HelpInfo("learn", @"The #3learn#0 command reports your current learning state: learning fatigue, skill and knowledge progress, cooldowns, branch modifiers, and any accents for which you are not gaining familiarity. It is an information command; lessons are initiated by other gameplay actions such as teaching.
+
+	The syntax is:
+
+	#3learn#0", AutoHelp.HelpArg)]
+	protected static void Learn(ICharacter actor, string input)
     {
         LearningFatigueEffect fatigue = actor.EffectsOfType<LearningFatigueEffect>().FirstOrDefault();
         IncreasedBranchChance branch = actor.EffectsOfType<IncreasedBranchChance>().FirstOrDefault();
@@ -1196,12 +1239,17 @@ The syntax is #3tagsearch <tag>#0.", AutoHelp.HelpArgOrNoArg)]
         actor.OutputHandler.Send(sb.ToString());
     }
 
-    [PlayerCommand("Quit", "quit")]
-    [RequiredCharacterState(CharacterState.Quittable)]
-    [DelayBlock("general", "You must first stop {0} before you can quit.")]
-    [NoCombatCommand]
-    [NoMovementCommand]
-    protected static void Quit(ICharacter actor, string input)
+	[PlayerCommand("Quit", "quit")]
+	[RequiredCharacterState(CharacterState.Quittable)]
+	[DelayBlock("general", "You must first stop {0} before you can quit.")]
+	[NoCombatCommand]
+	[NoMovementCommand]
+	[HelpInfo("quit", @"The #3quit#0 command safely ends your current character session. You must type the full command word, be out of combat and movement, and normally be in a safe location. Effects or game rules may prevent quitting temporarily.
+
+	The syntax is:
+
+	#3quit#0", AutoHelp.HelpArg)]
+	protected static void Quit(ICharacter actor, string input)
     {
         if (actor is NPC.NPC)
         {
@@ -1664,9 +1712,17 @@ You can also type 'forage' on its own to see what kinds of yields you can search
         return matches.Single();
     }
 
-    [PlayerCommand("Implant", "implant")]
-    [RequiredCharacterState(CharacterState.Conscious)]
-    protected static void Implant(ICharacter actor, string input)
+	[PlayerCommand("Implant", "implant")]
+	[RequiredCharacterState(CharacterState.Conscious)]
+	[HelpInfo("implant", @"The #3implant#0 command sends a command through an installed, powered and connected direct neural interface implant. #3implant status#0 asks each connected interface to report its status. Otherwise, supply the implant command alias, its command, and any command-specific arguments.
+
+	The syntax is:
+
+	#3implant status#0
+	#3implant <alias> <command> [<arguments>]#0
+
+	The commands available through an implant depend on the installed implant type.", AutoHelp.HelpArgOrNoArg)]
+	protected static void Implant(ICharacter actor, string input)
     {
         if (!actor.Gameworld.GetStaticBool("ImplantCommandEnabled"))
         {
@@ -1730,9 +1786,11 @@ You can also type 'forage' on its own to see what kinds of yields you can search
     [NoHideCommand]
     [NoCombatCommand]
     [NoMovementCommand]
-    [HelpInfo("clean",
-        "The clean command allows you to clean items that have become dirty. You can clean a specific item, you can CLEAN MINE to clean all items on your person, and you can CLEAN ALL to clean all items on your person and in the vicinity. Note that with respect to items that you are wearing, you can only clean your external layers; if you want to clean your underpants, you must first remove your trousers. Also note that certain kinds of messes require specific liquids or solvents to remove.",
-        AutoHelp.HelpArg)]
+    [HelpInfo("clean", @"The #3clean#0 command removes dirt and other mess from items. With no argument, or #3all#0, it cleans accessible items on you and nearby; #3mine#0 limits it to your possessions. Worn items must be on an accessible outer layer, and some messes require a suitable solvent.
+
+The syntax is:
+
+	#3clean [<item>|all|mine]#0", AutoHelp.HelpArg)]
     protected static void Clean(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -1764,10 +1822,17 @@ You can also type 'forage' on its own to see what kinds of yields you can search
         CleanTarget(actor, target);
     }
 
-    [PlayerCommand("Accept", "accept", "decline", "abort")]
-    [DisplayOptions(CommandDisplayOptions.DisplayCommandWords)]
-    [RequiredCharacterState(CharacterState.Conscious)]
-    protected static void Accept(ICharacter actor, string input)
+	[PlayerCommand("Accept", "accept", "decline", "abort")]
+	[DisplayOptions(CommandDisplayOptions.DisplayCommandWords)]
+	[RequiredCharacterState(CharacterState.Conscious)]
+	[HelpInfo("accept", @"The #3accept#0, #3decline#0 and #3abort#0 commands resolve pending proposals such as transactions, offers and other consent-based actions. With no argument, they act on the first pending proposal; #3?#0 lists pending proposals, and #3all#0 affects each one. You may add a comment when choosing a specific proposal.
+
+	The syntax is:
+
+	#3accept|decline|abort [<proposal>] [<comment>]#0
+	#3accept|decline|abort all#0
+	#3accept|decline|abort ?#0", AutoHelp.HelpArg)]
+	protected static void Accept(ICharacter actor, string input)
     {
         StringStack ss = new(input);
         string cmd = ss.PopSpeech();
@@ -1971,8 +2036,13 @@ You can also type 'forage' on its own to see what kinds of yields you can search
                 return 1;
             });
 
-    [PlayerCommand("Commands", "commands")]
-    protected static void _Commands(ICharacter actor, string input)
+	[PlayerCommand("Commands", "commands")]
+	[HelpInfo("commands", @"The #3commands#0 command lists the player commands currently available to your character. Games may show the list in functional groups or as a single alphabetical list.
+
+	The syntax is:
+
+	#3commands#0", AutoHelp.HelpArg)]
+	protected static void _Commands(ICharacter actor, string input)
     {
         if (actor.Gameworld.GetStaticBool("SplitCommandsIntoGroups"))
         {

--- a/MudSharpCore/Commands/Modules/GuideModule.cs
+++ b/MudSharpCore/Commands/Modules/GuideModule.cs
@@ -101,6 +101,13 @@ The syntax to edit roles is as follows:
 
     [PlayerCommand("Available", "available")]
     [CommandPermission(PermissionLevel.Guide)]
+    [HelpInfo("available", @"The #3available#0 command toggles your player-guide availability flag. Players can use this flag to identify guides who are currently open to enquiries.
+
+Use the command again to remove the flag when you are no longer available.
+
+The syntax is:
+
+	#3available#0", AutoHelp.HelpArg)]
     protected static void Available(ICharacter actor, string input)
     {
         if (actor.AffectedBy<IAdminAvailableEffect>())
@@ -117,6 +124,13 @@ The syntax to edit roles is as follows:
 
     [PlayerCommand("Send", "send")]
     [CommandPermission(PermissionLevel.Guide)]
+    [HelpInfo("send", @"The #3send#0 command delivers a staff or player-guide message to a character. Player Guides can send to characters currently marked as new players; higher staff permissions may send to any connected character.
+
+The recipient may be identified by their account name, or by character name when your authority permits it.
+
+The syntax is:
+
+	#3send <account|character> <message>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Send(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -149,6 +163,13 @@ The syntax to edit roles is as follows:
 
     [PlayerCommand("Applications", "applications", "apps")]
     [CommandPermission(PermissionLevel.Guide)]
+    [HelpInfo("applications", @"The #3applications#0 command lists submitted character applications awaiting review. The list includes the application ID, account, proposed name, required approval authority and time spent in the queue.
+
+Use #3application view#0 or #3application review#0 with an application identifier to work on one entry.
+
+The syntax is:
+
+	#3applications#0", AutoHelp.HelpArg)]
     protected static void Applications(ICharacter character, string command)
     {
         using (new FMDB())
@@ -181,6 +202,15 @@ The syntax to edit roles is as follows:
 
     [PlayerCommand("Application", "application")]
     [CommandPermission(PermissionLevel.Guide)]
+    [HelpInfo("application", @"The #3application#0 command opens or reviews a submitted character application. Use the numeric application ID from #3applications#0, or an unambiguous beginning of the submitted character name.
+
+The list form is an alias for #3applications#0. The review workflow guides you through the available approval actions.
+
+The syntax is:
+
+	#3application list#0
+	#3application view <id|name>#0
+	#3application review <id|name>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Application(ICharacter character, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());

--- a/MudSharpCore/Commands/Modules/HealthModule.cs
+++ b/MudSharpCore/Commands/Modules/HealthModule.cs
@@ -37,6 +37,11 @@ internal class HealthModule : Module<ICharacter>
     [NoMeleeCombatCommand]
     [RequiredCharacterState(CharacterState.Able)]
     [DelayBlock("general", "You must first stop {0} before you can do that.")]
+    [HelpInfo("cpr", @"The #3cpr#0 command begins cardiopulmonary resuscitation on an unresponsive nearby character when CPR is enabled for the game. It is not for conscious or breathing patients.
+
+The syntax is:
+
+	#3cpr <target>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void CPR(ICharacter actor, string command)
     {
         if (!actor.Gameworld.GetStaticBool("CPRAllowed"))
@@ -94,6 +99,11 @@ internal class HealthModule : Module<ICharacter>
     [NoMeleeCombatCommand]
     [RequiredCharacterState(CharacterState.Able)]
     [NoMovementCommand]
+    [HelpInfo("defibrillate", @"The #3defibrillate#0 command uses a held defibrillator on a nearby character. The device controls the actual shock and its requirements.
+
+The syntax is:
+
+	#3defibrillate <target>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Defibrillate(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -125,6 +135,11 @@ internal class HealthModule : Module<ICharacter>
     [NoMovementCommand]
     [NoMeleeCombatCommand]
     [RequiredCharacterState(CharacterState.Able)]
+    [HelpInfo("vitals", @"The #3vitals#0 command checks breathing and pulse. With no target it checks your own vitals; checking a conscious other character requires their consent.
+
+The syntax is:
+
+	#3vitals [<target>]#0", AutoHelp.HelpArg)]
     protected static void Vitals(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -233,9 +248,11 @@ internal class HealthModule : Module<ICharacter>
     [NoMeleeCombatCommand]
     [RequiredCharacterState(CharacterState.Able)]
     [DelayBlock("general", "You must first stop {0} before you can do that.")]
-    [HelpInfo("relocate",
-        "This grizzly command allows you to relocate one of your own or another's bones or joints. The syntax to use this command is: relocate <target> <bodypart>.",
-        AutoHelp.HelpArgOrNoArg)]
+    [HelpInfo("relocate", @"The #3relocate#0 command attempts to set a dislocated bone or joint on yourself or a nearby patient. It requires a target and body part, and may require consent or medical equipment depending on the wound.
+
+The syntax is:
+
+	#3relocate <target> <bodypart>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Relocate(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -380,7 +397,11 @@ internal class HealthModule : Module<ICharacter>
     [NoHideCommand]
     [NoMeleeCombatCommand]
     [NoMovementCommand]
-    [HelpInfo("bind", "Bind bleeding wounds to stop the bleeding. Syntax: bind [<target>]", AutoHelp.HelpArg)]
+    [HelpInfo("bind", @"The #3bind#0 command applies immediate bandaging to visible bleeding wounds. With no target it treats your own wounds; treating a conscious patient may require consent and suitable bandages.
+
+The syntax is:
+
+	#3bind [<target>]#0", AutoHelp.HelpArg)]
     protected static void Bind(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -596,8 +617,11 @@ Options:
     [NoHideCommand]
     [NoMovementCommand]
     [NoMeleeCombatCommand]
-    [HelpInfo("suture", "Stitch up a wound to reduce its chance of reopening. Syntax: suture [<target>]",
-        AutoHelp.HelpArg)]
+    [HelpInfo("suture", @"The #3suture#0 command stitches suitable wounds to reduce their chance of reopening. With no target it treats your own wounds; treating a conscious patient may require consent and appropriate equipment.
+
+The syntax is:
+
+	#3suture [<target>]#0", AutoHelp.HelpArg)]
     protected static void Suture(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -747,9 +771,11 @@ Options:
     [NoHideCommand]
     [NoCombatCommand]
     [NoMovementCommand]
-    [HelpInfo("tend",
-        "Tend to a target's wounds so that they heal a little faster, or to apply anti-inflammatory care that reduces pain. Syntax: tend [<target>]",
-        AutoHelp.HelpArg)]
+    [HelpInfo("tend", @"The #3tend#0 command provides general wound care, improving recovery or reducing pain where the patient's wounds can benefit. With no target it tends your own wounds; treating a conscious patient may require consent.
+
+The syntax is:
+
+	#3tend [<target>]#0", AutoHelp.HelpArg)]
     protected static void Tend(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -1125,6 +1151,12 @@ The syntaxes available include:
     [NoHideCommand]
     [NoCombatCommand]
     [NoMovementCommand]
+    [HelpInfo("dislodge", @"The #3dislodge#0 command removes a visible lodged item from a wound, or uses an item's own dislodgement behaviour. With no target it examines your own lodged wounds. Some lodged items require surgery and cannot be removed this way.
+
+The syntax is:
+
+	#3dislodge [<character>] <lodged item>#0
+	#3dislodge <item> [<arguments>]#0", AutoHelp.HelpArg)]
     protected static void Dislodge(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -1607,6 +1639,11 @@ The syntax is as follows:
     [NoHideCommand]
     [NoMovementCommand]
     [NoMeleeCombatCommand]
+    [HelpInfo("triage", @"The #3triage#0 command begins the best triage procedure your character knows for a patient. With no target it triages yourself. A conscious patient must consent, and the procedure may have its own knowledge, tool and condition requirements.
+
+The syntax is:
+
+	#3triage [<target>]#0", AutoHelp.HelpArg)]
     protected static void Triage(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -1720,6 +1757,11 @@ The syntax is as follows:
     }
 
     [PlayerCommand("Wounds", "wounds")]
+    [HelpInfo("wounds", @"The #3wounds#0 command lists wounds visible to you on your own body, together with significant missing or severed body parts.
+
+The syntax is:
+
+	#3wounds#0", AutoHelp.HelpArg)]
     protected static void Wounds(ICharacter actor, string command)
     {
         StringBuilder sb = new();
@@ -2038,6 +2080,11 @@ The syntax is as follows:
 
     [PlayerCommand("Cure", "cure")]
     [CommandPermission(PermissionLevel.JuniorAdmin)]
+    [HelpInfo("cure", @"The #3cure#0 staff command heals a target's wounds. With no target it treats yourself. It can treat all wounds one stage, focus on a body part, restore blood, clear infections, advance bone-fracture healing, or fully clear wounds and related conditions with #3all#0.
+
+The syntax is:
+
+	#3cure [<target>] [<bodypart|all|blood|infections|bones>]#0", AutoHelp.HelpArg)]
     protected static void Cure(ICharacter actor, string command)
     {
         if (!actor.IsAdministrator())
@@ -2555,6 +2602,11 @@ Your options are to name the specific bodypart, #3random#0 for a random part, #3
     }
 
     [PlayerCommand("Health", "health")]
+    [HelpInfo("health", @"The #3health#0 command displays your health summary. Junior administrators and above receive a detailed diagnostic report and may name another woundable target.
+
+The syntax is:
+
+	#3health [<target>]#0", AutoHelp.HelpArg)]
     protected static void Health(ICharacter actor, string command)
     {
         if (!actor.IsAdministrator(PermissionLevel.JuniorAdmin))
@@ -2782,6 +2834,11 @@ Your options are to name the specific bodypart, #3random#0 for a random part, #3
 
     [PlayerCommand("Sever", "sever")]
     [CommandPermission(PermissionLevel.Admin)]
+    [HelpInfo("sever", @"The #3sever#0 staff command removes a specified body part or organ from a character or corpse, creating the severed item where appropriate.
+
+The syntax is:
+
+	#3sever <target> <bodypart|organ>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Sever(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -2869,6 +2926,11 @@ Your options are to name the specific bodypart, #3random#0 for a random part, #3
 
     [PlayerCommand("Unsever", "unsever")]
     [CommandPermission(PermissionLevel.Admin)]
+    [HelpInfo("unsever", @"The #3unsever#0 staff command restores a severed body part or organ. Use #3all#0 to restore every supported severed part, organ and bone.
+
+The syntax is:
+
+	#3unsever <target> <bodypart|organ|all>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Unsever(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -2944,6 +3006,11 @@ Your options are to name the specific bodypart, #3random#0 for a random part, #3
 
     [PlayerCommand("InstallImplant", "installimplant")]
     [CommandPermission(PermissionLevel.Admin)]
+    [HelpInfo("installimplant", @"The #3installimplant#0 staff command installs a held implant into a character or corpse. Some implants define their own target body part; otherwise name the body part explicitly.
+
+The syntax is:
+
+	#3installimplant <held implant> <target> [<bodypart>]#0", AutoHelp.HelpArgOrNoArg)]
     protected static void InstallImplant(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -3011,6 +3078,11 @@ Your options are to name the specific bodypart, #3random#0 for a random part, #3
 
     [PlayerCommand("PowerImplant", "powerimplant")]
     [CommandPermission(PermissionLevel.Admin)]
+    [HelpInfo("powerimplant", @"The #3powerimplant#0 staff command connects an installed powered implant to an installed implant power plant on the same target.
+
+The syntax is:
+
+	#3powerimplant <target> <powered implant> <power plant implant>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void PowerImplant(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -3069,6 +3141,11 @@ Your options are to name the specific bodypart, #3random#0 for a random part, #3
 
     [PlayerCommand("ConnectImplants", "connectimplant")]
     [CommandPermission(PermissionLevel.Admin)]
+    [HelpInfo("connectimplant", @"The #3connectimplant#0 staff command connects an installed implant to one of the target's neural-interface implants. Connecting it to a new neural interface removes any existing neural-interface connection for that implant.
+
+The syntax is:
+
+	#3connectimplant <target> <implant> <neural interface>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void ConnectImplant(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -3143,6 +3220,11 @@ Your options are to name the specific bodypart, #3random#0 for a random part, #3
 
     [PlayerCommand("Implants", "implants")]
     [CommandPermission(PermissionLevel.Admin)]
+    [HelpInfo("implants", @"The #3implants#0 staff command lists a character or corpse's installed implants, including their target body parts, power arrangements and neural-interface links.
+
+The syntax is:
+
+	#3implants <target>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Implants(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -3174,6 +3256,12 @@ Your options are to name the specific bodypart, #3random#0 for a random part, #3
 
     [PlayerCommand("Infect", "infect")]
     [CommandPermission(PermissionLevel.JuniorAdmin)]
+    [HelpInfo("infect", @"The #3infect#0 staff command creates an infection on a target wound or body part using the target location's infection settings. If you omit the final wound or body-part selection, it chooses an eligible one at random.
+
+The syntax is:
+
+	#3infect wound <target> [<wound>]#0
+	#3infect bodypart <target> [<bodypart|organ>]#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Infect(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -3265,9 +3353,11 @@ Your options are to name the specific bodypart, #3random#0 for a random part, #3
 
     [PlayerCommand("Exsanguinate", "exsanguinate")]
     [CommandPermission(PermissionLevel.JuniorAdmin)]
-    [HelpInfo("exsanguinate",
-        "This command allows you to change the current blood percentage of a character. The syntax is EXSANGUINATE <target> [<percentage>]. If you omit the percentage, it will set the blood to 0%.",
-        AutoHelp.HelpArgOrNoArg)]
+    [HelpInfo("exsanguinate", @"The #3exsanguinate#0 staff command sets a visible character's current blood volume as a percentage of their normal total. Omitting the percentage sets it to zero.
+
+The syntax is:
+
+	#3exsanguinate <target> [<percentage>]#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Exsanguinate(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());

--- a/MudSharpCore/Commands/Modules/HelpModule.cs
+++ b/MudSharpCore/Commands/Modules/HelpModule.cs
@@ -809,6 +809,16 @@ The syntax for this is as follows:
     }
 
     [PlayerCommand("Help", "help")]
+    [HelpInfo("help", @"The #3help#0 command searches the game's help files and built-in command help. With no arguments it lists available categories. Use #3help on#0 to browse a category, or provide a topic; quoted text is useful for multi-word names.
+
+The syntax is:
+
+	#3help#0
+	#3help <topic>#0
+	#3help <category> <topic>#0
+	#3help on <category>#0
+
+For example, #3help get#0 shows the help for getting items, and #3help on commands#0 lists built-in command help.", AutoHelp.HelpArg)]
     protected static void Help(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());

--- a/MudSharpCore/Commands/Modules/HeritageBuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/HeritageBuilderModule.cs
@@ -1491,6 +1491,7 @@ The correct syntax for this command is as follows:
 
     [PlayerCommand("Culture", "culture")]
     [CommandPermission(PermissionLevel.JuniorAdmin)]
+    [HelpInfo("culture", CultureHelp, AutoHelp.HelpArgOrNoArg)]
     protected static void Culture(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -1740,6 +1741,7 @@ The correct syntax for this command is as follows:
 
     [PlayerCommand("Ethnicity", "ethnicity")]
     [CommandPermission(PermissionLevel.JuniorAdmin)]
+    [HelpInfo("ethnicity", EthnicityHelp, AutoHelp.HelpArgOrNoArg)]
     protected static void Ethnicity(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());

--- a/MudSharpCore/Commands/Modules/ImplementorModule.cs
+++ b/MudSharpCore/Commands/Modules/ImplementorModule.cs
@@ -67,6 +67,11 @@ public class ImplementorModule : Module<ICharacter>
 
     [PlayerCommand("CommandLevels", "commandlevels")]
     [CommandPermission(PermissionLevel.Founder)]
+    [HelpInfo("commandlevels", @"The #3commandlevels#0 founder command lists registered commands grouped by their required permission level. With no argument it starts at the lowest permission level; supply a permission level to limit the report.
+
+The syntax is:
+
+	#3commandlevels [<permission level>]#0", AutoHelp.HelpArg)]
     protected static void CommandLevels(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -97,6 +102,12 @@ public class ImplementorModule : Module<ICharacter>
 
     [PlayerCommand("CurrencyTest", "currencytest")]
     [CommandPermission(PermissionLevel.HighAdmin)]
+    [HelpInfo("currencytest", @"The #3currencytest#0 diagnostic command shows how a numeric base-currency value is described in every configured currency and description pattern. The #3convert#0 form instead parses a currency amount using your current currency.
+
+The syntax is:
+
+	#3currencytest <base amount>#0
+	#3currencytest convert <currency amount>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void CurrencyTest(ICharacter actor, string input)
     {
         if (string.IsNullOrEmpty(input.RemoveFirstWord()))
@@ -150,6 +161,11 @@ public class ImplementorModule : Module<ICharacter>
 
     [PlayerCommand("TestMXP", "testmxp")]
     [CommandPermission(PermissionLevel.Founder)]
+    [HelpInfo("testmxp", @"The #3testmxp#0 founder diagnostic displays sample MXP formatting, links and image markup so that client support can be verified.
+
+The syntax is:
+
+	#3testmxp#0", AutoHelp.HelpArg)]
     protected static void Showoff(ICharacter actor, string input)
     {
         StringBuilder sb = new();
@@ -170,6 +186,11 @@ public class ImplementorModule : Module<ICharacter>
 
     [PlayerCommand("TestGPT", "testgpt")]
     [CommandPermission(PermissionLevel.Founder)]
+    [HelpInfo("testgpt", @"The #3testgpt#0 founder diagnostic sends a prompt to a configured GPT thread and displays the response. The thread can be named or identified by ID.
+
+The syntax is:
+
+	#3testgpt <thread|id> <prompt>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void TestGPT(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -217,6 +238,11 @@ public class ImplementorModule : Module<ICharacter>
 
     [PlayerCommand("TestAnthropic", "testanthropic")]
     [CommandPermission(PermissionLevel.Founder)]
+    [HelpInfo("testanthropic", @"The #3testanthropic#0 founder diagnostic sends a prompt using the selected GPT thread's configured prompt through the Anthropic provider. The thread can be named or identified by ID.
+
+The syntax is:
+
+	#3testanthropic <thread|id> <prompt>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void TestAnthropic(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -264,6 +290,11 @@ public class ImplementorModule : Module<ICharacter>
 
     [PlayerCommand("TestGemini", "testgemini")]
     [CommandPermission(PermissionLevel.Founder)]
+    [HelpInfo("testgemini", @"The #3testgemini#0 founder diagnostic sends a prompt using the selected GPT thread's configured prompt through the Gemini provider. The thread can be named or identified by ID.
+
+The syntax is:
+
+	#3testgemini <thread|id> <prompt>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void TestGemini(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -311,6 +342,11 @@ public class ImplementorModule : Module<ICharacter>
 
     [PlayerCommand("TestUnicode", "testunicode")]
     [CommandPermission(PermissionLevel.Founder)]
+    [HelpInfo("testunicode", @"The #3testunicode#0 founder diagnostic displays sample non-ASCII and combining-character text for client rendering checks.
+
+The syntax is:
+
+	#3testunicode#0", AutoHelp.HelpArg)]
     protected static void Unicode(ICharacter actor, string input)
     {
         actor.OutputHandler.Send("Здравствуйте, комраде! Я скажу в юникоде.");

--- a/MudSharpCore/Commands/Modules/InventoryModule.cs
+++ b/MudSharpCore/Commands/Modules/InventoryModule.cs
@@ -79,6 +79,13 @@ internal class InventoryModule : Module<ICharacter>
 
     [PlayerCommand("Inventory", "inventory", "inv", "i", "equipment")]
     [RequiredCharacterState(CharacterState.Conscious)]
+    [HelpInfo("inventory", @"The #3inventory#0 command displays the items you are carrying, wearing, holding and wielding. It is the quickest way to check both your equipment and the things available for ordinary inventory commands.
+
+The aliases #3inv#0, #3i#0 and #3equipment#0 all show the same display.
+
+The syntax is:
+
+	#3inventory#0", AutoHelp.HelpArg)]
     protected static void Inventory(ICharacter actor, string input)
     {
         actor.DisplayInventory();
@@ -432,6 +439,14 @@ The syntax is as follows:
 
     [PlayerCommand("Unwield", "unwield")]
     [RequiredCharacterState(CharacterState.Conscious)]
+    [HelpInfo("unwield", @"The #3unwield#0 command stops wielding a held weapon or other wielded item, leaving it held where possible. In combat, the action may be queued and completed according to the combat action rules.
+
+You can append a parenthetical emote to describe the action.
+
+The syntax is:
+
+	#3unwield <item>#0
+	#3unwield <item> (<emote>)#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Unwield(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -466,6 +481,16 @@ The syntax is as follows:
 
     [PlayerCommand("Wield", "wield")]
     [RequiredCharacterState(CharacterState.Conscious)]
+    [HelpInfo("wield", @"The #3wield#0 command prepares a held wieldable item for use. If your body has several wielding locations, you can name one; use the #3twohanded#0 form when you need to require a two-handed grip.
+
+The available hand or wielder descriptions are body-specific. In combat, wielding is handled as a combat action and may be queued.
+
+The syntax is:
+
+	#3wield <item>#0
+	#3wield <item> <wielder>#0
+	#3wield <item> twohanded [<wielder>]#0
+	#3wield <item> [<wielder>] [twohanded] (<emote>)#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Wield(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -572,9 +597,18 @@ The syntax is as follows:
         }
     }
 
-    [PlayerCommand("Put", "put", "pu")]
-    [RequiredCharacterState(CharacterState.Conscious)]
-    protected static void Put(ICharacter actor, string input)
+	[PlayerCommand("Put", "put", "pu")]
+	[RequiredCharacterState(CharacterState.Conscious)]
+	[HelpInfo("put", @"The #3put#0 command moves something you are holding into a container. You can name a container carried by another character when they permit you to manipulate their inventory. Use an optional parenthesised emote to describe the action.
+
+	The syntax is:
+
+	#3put [<quantity>] <item> [<container-owner>] <container> [(<emote>)]#0
+	#3put [exactly] <currency> [<container-owner>] <container> [(<emote>)]#0
+	#3put <weight> <commodity> [<container-owner>] <container> [(<emote>)]#0
+
+	For example, #3put 3 apple backpack#0, #3put exactly 5 silver purse#0, or #3put 2kg grain cart sack#0. Quantities and weights split stackable items or commodities where possible.", AutoHelp.HelpArgOrNoArg)]
+	protected static void Put(ICharacter actor, string input)
     {
         Match match = PutCommandRegex.Match(input.RemoveFirstWord());
         Match currencyMatch = PutCurrencyRegex.Match(input.RemoveFirstWord());
@@ -738,10 +772,17 @@ The syntax is as follows:
         }
     }
 
-    [PlayerCommand("Take", "take")]
-    [RequiredCharacterState(CharacterState.Conscious)]
-    [NoMeleeCombatCommand]
-    protected static void Take(ICharacter actor, string input)
+	[PlayerCommand("Take", "take")]
+	[RequiredCharacterState(CharacterState.Conscious)]
+	[NoMeleeCombatCommand]
+	[HelpInfo("take", @"The #3take#0 command removes an item directly from another character or corpse. If the item is inside an accessible external container, name that container after the target. This is distinct from #3get#0, which takes items from the room or your own containers.
+
+	The syntax is:
+
+	#3take [<quantity>] <item> <target> [<target-container>] [(<emote>)]#0
+
+	For example, #3take coin guard purse#0 takes a coin from the guard's purse, while #3take 2 bandage patient#0 takes two bandages directly from the patient. The target must permit inventory manipulation when a container is involved.", AutoHelp.HelpArgOrNoArg)]
+	protected static void Take(ICharacter actor, string input)
     {
         string text = input.RemoveFirstWord();
         if (string.IsNullOrEmpty(text))
@@ -868,9 +909,18 @@ The syntax is as follows:
         }
     }
 
-    [PlayerCommand("Get", "get", "ge", "g")]
-    [RequiredCharacterState(CharacterState.Conscious)]
-    protected static void Get(ICharacter actor, string input)
+	[PlayerCommand("Get", "get", "ge", "g")]
+	[RequiredCharacterState(CharacterState.Conscious)]
+	[HelpInfo("get", @"The #3get#0 command picks up an item from your location or removes one from a container that you can manipulate. The aliases #3ge#0 and #3g#0 work the same way. Append a parenthesised emote to describe the action.
+
+	The syntax is:
+
+	#3get [<quantity>] <item> [<container>] [(<emote>)]#0
+	#3get [exactly] <currency> [<container>] [(<emote>)]#0
+	#3get <weight> <commodity> [<container>] [(<emote>)]#0
+
+	For example, #3get sword#0, #3get 2 apple basket#0, or #3get 500g flour sack#0. If the named container is a corpse, the command follows the same rules as taking from a corpse.", AutoHelp.HelpArgOrNoArg)]
+	protected static void Get(ICharacter actor, string input)
     {
         if (new StringStack(input.RemoveFirstWord()).IsFinished)
         {
@@ -1093,9 +1143,18 @@ The syntax is as follows:
         }
     }
 
-    [PlayerCommand("Drop", "drop", "dro", "dr")]
-    [RequiredCharacterState(CharacterState.Conscious)]
-    protected static void Drop(ICharacter actor, string input)
+	[PlayerCommand("Drop", "drop", "dro", "dr")]
+	[RequiredCharacterState(CharacterState.Conscious)]
+	[HelpInfo("drop", @"The #3drop#0 command places a held item, some currency, or part of a commodity on the ground. The aliases #3dro#0 and #3dr#0 work the same way. Prefix the command with #3new#0 when you want the dropped items kept as a separate stack, and append a parenthesised emote when desired.
+
+	The syntax is:
+
+	#3drop [new] [<quantity>] <item> [(<emote>)]#0
+	#3drop [new] [exactly] <currency> [(<emote>)]#0
+	#3drop [new] <weight> <commodity> [(<emote>)]#0
+
+	For example, #3drop all#0 drops everything you are holding, #3drop new 3 arrow#0 keeps three arrows separate, and #3drop exactly 2 silver#0 drops that precise amount of currency.", AutoHelp.HelpArgOrNoArg)]
+	protected static void Drop(ICharacter actor, string input)
     {
         if (string.IsNullOrWhiteSpace(input.RemoveFirstWord()))
         {
@@ -1241,9 +1300,18 @@ The syntax is as follows:
         }
     }
 
-    [PlayerCommand("Give", "give")]
-    [RequiredCharacterState(CharacterState.Conscious)]
-    protected static void Give(ICharacter actor, string input)
+	[PlayerCommand("Give", "give")]
+	[RequiredCharacterState(CharacterState.Conscious)]
+	[HelpInfo("give", @"The #3give#0 command hands a held item, currency, or a measured part of a commodity to another character or a corpse. You can attach a parenthesised emote to describe the exchange.
+
+	The syntax is:
+
+	#3give [<quantity>] <item> <target> [(<emote>)]#0
+	#3give [exactly] <currency> <target> [(<emote>)]#0
+	#3give <weight> <commodity> <target> [(<emote>)]#0
+
+	For example, #3give 2 apple traveller#0, #3give exactly 5 silver merchant#0, or #3give 1kg grain horse#0. You cannot give items to non-allies while either of you is in combat.", AutoHelp.HelpArgOrNoArg)]
+	protected static void Give(ICharacter actor, string input)
     {
         Match match = GiveCommandRegex.Match(input.RemoveFirstWord());
         Match currencyMatch = GiveCurrencyRegex.Match(input.RemoveFirstWord());
@@ -1421,6 +1489,15 @@ The syntax is as follows:
 
     [PlayerCommand("Wear", "wear", "wea")]
     [RequiredCharacterState(CharacterState.Conscious)]
+    [HelpInfo("wear", @"The #3wear#0 command puts a held wearable item on your body. Some items support more than one wear profile; name the profile when you need a specific arrangement rather than the item's default.
+
+In combat, wearing is handled as a combat action and may be queued. You can append a parenthetical emote to describe the action.
+
+The syntax is:
+
+	#3wear <item>#0
+	#3wear <item> <profile>#0
+	#3wear <item> [<profile>] (<emote>)#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Wear(ICharacter actor, string input)
     {
         Match match = WearCommandRegex.Match(input.RemoveFirstWord());
@@ -1486,6 +1563,14 @@ The syntax is as follows:
 
     [PlayerCommand("Remove", "remove", "rem", "rm")]
     [RequiredCharacterState(CharacterState.Conscious)]
+    [HelpInfo("remove", @"The #3remove#0 command takes off an outermost worn item. You cannot remove an item that is covered by another garment until the covering item has been removed first.
+
+In combat, removal is handled as a combat action and may be queued. The aliases #3rem#0 and #3rm#0 are equivalent.
+
+The syntax is:
+
+	#3remove <item>#0
+	#3remove <item> (<emote>)#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Remove(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -1529,6 +1614,15 @@ The syntax is as follows:
     [PlayerCommand("Dress", "dress")]
     [NoMeleeCombatCommand]
     [RequiredCharacterState(CharacterState.Able)]
+    [HelpInfo("dress", @"The #3dress#0 command lets you put a held wearable item onto another character, with their consent where required. You cannot use it on yourself; use #3wear#0 and #3remove#0 for your own clothing.
+
+You can also grant a visible character ten minutes of consent to dress or undress you. Use #3dress me none#0 to withdraw every active consent early.
+
+The syntax is:
+
+	#3dress <person> <item> [<profile>] [(<emote>)]#0
+	#3dress me <person>#0
+	#3dress me none#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Dress(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -1686,6 +1780,16 @@ The syntax is as follows:
 
     [PlayerCommand("Sheathe", "sheathe")]
     [RequiredCharacterState(CharacterState.Conscious)]
+    [HelpInfo("sheathe", @"The #3sheathe#0 command puts a held item into a compatible sheath. If you omit the item or sheath, the body chooses an available compatible item or destination where possible.
+
+Use a parenthetical emote at the beginning, after the item, or after the sheath to describe the action.
+
+The syntax is:
+
+	#3sheathe#0
+	#3sheathe <item>#0
+	#3sheathe <item> <sheath>#0
+	#3sheathe [<item>] [<sheath>] (<emote>)#0", AutoHelp.HelpArg)]
     protected static void Sheath(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -1730,6 +1834,16 @@ The syntax is as follows:
 
     [PlayerCommand("Draw", "draw", "dra", "dr")]
     [RequiredCharacterState(CharacterState.Conscious)]
+    [HelpInfo("draw", @"The #3draw#0 command removes a wieldable item from a compatible sheath and readies it. With no item named, it attempts to draw the first available suitable item; you can also select a wielding location or require a two-handed grip.
+
+In combat, drawing is handled as a combat action and may be queued. The aliases #3dra#0 and #3dr#0 are equivalent.
+
+The syntax is:
+
+	#3draw#0
+	#3draw <item>#0
+	#3draw <item> <wielder>#0
+	#3draw [<item>] [<wielder>] [twohanded] [(<emote>)]#0", AutoHelp.HelpArg)]
     protected static void Draw(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -3014,6 +3128,13 @@ The valid syntaxes are:
     }
 
     [PlayerCommand("Outfits", "outfits")]
+    [HelpInfo("outfits", @"The #3outfits#0 command lists the saved outfits available to your character. The display shows how many garments each outfit contains and how much of it is currently worn or present nearby.
+
+Use #3outfit#0 to create, edit, wear or otherwise manage an individual saved outfit.
+
+The syntax is:
+
+	#3outfits#0", AutoHelp.HelpArg)]
     protected static void Outfits(ICharacter actor, string command)
     {
         OutfitList(actor, new StringStack(command.RemoveFirstWord()));

--- a/MudSharpCore/Commands/Modules/LegalModule.cs
+++ b/MudSharpCore/Commands/Modules/LegalModule.cs
@@ -1346,6 +1346,14 @@ The syntax is:
 
     [PlayerCommand("ShowPatrols", "showpatrols")]
     [CommandPermission(PermissionLevel.JuniorAdmin)]
+    [HelpInfo("showpatrols", @"The #3showpatrols#0 command is an administrative operational report for automatic law-enforcement patrols. It shows active patrol composition and state, along with inactive routes, their staffing requirements and any reason they cannot begin.
+
+With no argument it reports every legal authority. Supply a legal authority to restrict the report to that authority.
+
+The syntax is:
+
+	#3showpatrols#0
+	#3showpatrols <legal authority>#0", AutoHelp.HelpArg)]
     protected static void ShowPatrols(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());

--- a/MudSharpCore/Commands/Modules/MagicModule.cs
+++ b/MudSharpCore/Commands/Modules/MagicModule.cs
@@ -17,6 +17,20 @@ public class MagicModule : Module<ICharacter>
 
     public static MagicModule Instance { get; } = new();
 
+    private const string MagicHelp = @"The #3magic#0 command is the administrative entry point for authoring and inspecting the magic system. Each subcommand opens a dedicated builder workflow; use its own #3help#0 form for detailed syntax once you have selected the subsystem.
+
+The syntax is:
+
+	#3magic school#0 - edit magic schools
+	#3magic capability#0 - edit who can use magic
+	#3magic resource#0 - edit magic resources
+	#3magic regenerator#0 - edit resource regeneration rules
+	#3magic power#0 - edit hard-coded powers for a school
+	#3magic spell#0 - edit spell templates
+	#3magic portals#0 - inspect active transient portals
+	#3magic portalnetwork#0 - edit durable portal and rune topology
+	#3magic anchors [<tag>]#0 - inspect active magic-tag anchors";
+
     public static void EnsureMagicSchoolVerbRegistered(string verb)
     {
         var commandText = verb?.CollapseString().ToLowerInvariant();
@@ -244,6 +258,7 @@ public class MagicModule : Module<ICharacter>
 
     [PlayerCommand("Magic", "magic")]
     [CommandPermission(PermissionLevel.Admin)]
+    [HelpInfo("magic", MagicHelp, AutoHelp.HelpArg)]
     protected static void Magic(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -279,19 +294,7 @@ public class MagicModule : Module<ICharacter>
                 MagicSpell(actor, ss);
                 return;
             default:
-                actor.OutputHandler.Send(@"You can use the following sub commands to edit different components of the magic system. See individual commands for help on them:
-
-	#3magic school#0 - magic schools are types of magic
-	#3magic capability#0 - magic capabilities control who can use magic
-	#3magic resource#0 - magic resources are power for spells and abilities
-	#3magic regenerator#0 - magic regenerators produce magic resources based on rules
-	#3magic power#0 - magic powers are customisable hard-coded powers for a magic school
-	#3magic spell#0 - magic spells are completely flexible and editable templates for magical effects
-	#3magic portals#0 - inspects active transient magical portals
-	#3magic portalnetwork#0 - edits durable portal/rune topology
-	#3magic anchors [tag]#0 - inspects active magic-tag anchors on rooms and items
-
-#ENote - It's relatively easy to add new spell effect types. Reach out to Japheth on the FutureMUD discord if you want something added.#0".SubstituteANSIColour());
+                actor.OutputHandler.Send(MagicHelp.SubstituteANSIColour());
                 return;
         }
     }

--- a/MudSharpCore/Commands/Modules/ManipulationModule.cs
+++ b/MudSharpCore/Commands/Modules/ManipulationModule.cs
@@ -369,9 +369,11 @@ The syntax is #3seal <target> with <stamp> [using <medium>]#0.", AutoHelp.HelpAr
 	[DelayBlock("general", "You must first stop {0} before you can do that.")]
 	[NoCombatCommand]
 	[NoMovementCommand]
-	[HelpInfo("break seal",
-		"The #3break seal#0 command breaks the seal on a sealed item without otherwise opening, reading, or writing it. The syntax is #3break seal <target>#0.",
-		AutoHelp.HelpArgOrNoArg)]
+	[HelpInfo("break seal", @"The #3break seal#0 command breaks an item's seal without otherwise opening, reading or altering it. This may leave evidence through the item's seal state.
+
+	The syntax is:
+
+	#3break seal <sealed item>#0", AutoHelp.HelpArgOrNoArg)]
 	protected static void Break(ICharacter actor, string command)
 	{
 		var ss = new StringStack(command.RemoveFirstWord());
@@ -490,9 +492,11 @@ The syntax is #3seal <target> with <stamp> [using <medium>]#0.", AutoHelp.HelpAr
 	}
 
 	[PlayerCommand("Compare", "compare")]
-	[HelpInfo("compare",
-		"The #3compare seal#0 command compares a seal impression against a seal stamp or another sealed item. The syntax is #3compare seal <sealed item> with <stamp|sealed item>#0.",
-		AutoHelp.HelpArgOrNoArg)]
+	[HelpInfo("compare", @"The #3compare seal#0 command compares a sealed item's impression with a seal stamp or another sealed item to determine whether they match.
+
+	The syntax is:
+
+	#3compare seal <sealed item> with <stamp|sealed item>#0", AutoHelp.HelpArgOrNoArg)]
 	protected static void Compare(ICharacter actor, string command)
 	{
 		var ss = new StringStack(command.RemoveFirstWord());
@@ -558,9 +562,11 @@ The syntax is #3seal <target> with <stamp> [using <medium>]#0.", AutoHelp.HelpAr
 	[DelayBlock("general", "You must first stop {0} before you can do that.")]
 	[NoCombatCommand]
 	[NoMovementCommand]
-	[HelpInfo("weigh",
-		"The #3weigh#0 command weighs an item using a measuring instrument. The syntax is #3weigh <item> on <instrument>#0.",
-		AutoHelp.HelpArgOrNoArg)]
+	[HelpInfo("weigh", @"The #3weigh#0 command weighs an item using a suitable measuring instrument that you can manipulate.
+
+	The syntax is:
+
+	#3weigh <item> on <instrument>#0", AutoHelp.HelpArgOrNoArg)]
 	protected static void Weigh(ICharacter actor, string command)
 	{
 		var ss = new StringStack(command.RemoveFirstWord());
@@ -621,9 +627,11 @@ The syntax is #3seal <target> with <stamp> [using <medium>]#0.", AutoHelp.HelpAr
 	[DelayBlock("general", "You must first stop {0} before you can do that.")]
 	[NoCombatCommand]
 	[NoMovementCommand]
-	[HelpInfo("measure",
-		"The #3measure#0 command measures weight or liquid volume with a measuring instrument. Length measurement is not implemented in this pass. The syntax is #3measure <target> with <instrument>#0.",
-		AutoHelp.HelpArgOrNoArg)]
+	[HelpInfo("measure", @"The #3measure#0 command measures an item with a compatible instrument. Current instruments can report weight or fluid volume; length measurement is not available.
+
+	The syntax is:
+
+	#3measure <target> with <instrument>#0", AutoHelp.HelpArgOrNoArg)]
 	protected static void Measure(ICharacter actor, string command)
 	{
 		var ss = new StringStack(command.RemoveFirstWord());
@@ -3979,6 +3987,11 @@ The syntax is as follows:
     [RequiredCharacterState(CharacterState.Able)]
     [DelayBlock("general", "You must first stop {0} before you can do that.")]
     [NoHideCommand]
+    [HelpInfo("smoke", @"The #3smoke#0 command uses a held smokeable item. The item determines whether it must be lit, how it is consumed, and any effects it produces. You can attach a parenthesised emote.
+
+The syntax is:
+
+	#3smoke <item> [(<emote>)]#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Smoke(ICharacter character, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -4020,6 +4033,11 @@ The syntax is as follows:
     [RequiredCharacterState(CharacterState.Able)]
     [DelayBlock("general", "You must first stop {0} before you can do that.")]
     [NoHideCommand]
+    [HelpInfo("puff", @"The #3puff#0 command takes a puff from a held puffable item, such as a suitable pipe or electronic device. You can attach a parenthesised emote.
+
+The syntax is:
+
+	#3puff <item> [(<emote>)]#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Puff(ICharacter character, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -4220,6 +4238,11 @@ Use quotes around multi-word offering or focus names.", AutoHelp.HelpArg)]
     [DelayBlock("general", "You must first stop {0} before you can do that.")]
     [RequiredCharacterState(CharacterState.Able)]
     [NoHideCommand]
+    [HelpInfo("light", @"The #3light#0 command lights a lightable item. An ignition source is optional; whether one is required depends on the item. You can attach a parenthesised emote.
+
+The syntax is:
+
+	#3light <item> [<ignition source>] [(<emote>)]#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Light(ICharacter character, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -4277,6 +4300,11 @@ Use quotes around multi-word offering or focus names.", AutoHelp.HelpArg)]
     [DelayBlock("general", "You must first stop {0} before you can do that.")]
     [RequiredCharacterState(CharacterState.Able)]
     [NoHideCommand]
+    [HelpInfo("extinguish", @"The #3extinguish#0 command puts out a visible lightable item. You can attach a parenthesised emote.
+
+The syntax is:
+
+	#3extinguish <item> [(<emote>)]#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Extinguish(ICharacter character, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -4320,6 +4348,11 @@ Use quotes around multi-word offering or focus names.", AutoHelp.HelpArg)]
     [RequiredCharacterState(CharacterState.Able)]
     [NoHideCommand]
     [NoCombatCommand]
+    [HelpInfo("knock", @"The #3knock#0 command knocks on a door. You can name the exit direction or the installed door itself, and attach a parenthesised emote.
+
+The syntax is:
+
+	#3knock <exit|door> [(<emote>)]#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Knock(ICharacter character, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -5120,6 +5153,11 @@ The syntax is as follows:
     [DelayBlock("general", "You must first stop {0} before you can do that.")]
     [CommandPermission(PermissionLevel.NPC)]
     [RequiredCharacterState(CharacterState.Able)]
+    [HelpInfo("junk", @"The #3junk#0 command permanently destroys a held item, where game permissions allow it. You must type the full command word. Containers with contents require confirmation through #3accept#0.
+
+The syntax is:
+
+	#3junk <held item>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Junk(ICharacter character, string command)
     {
         if (!character.Gameworld.GetStaticBool("PlayersCanJunk") && !character.IsAdministrator())
@@ -5261,6 +5299,14 @@ The syntax is as follows:
     [PlayerCommand("Open", "open")]
     [DelayBlock("general", "You must first stop {0} before you can do that.")]
     [RequiredCharacterState(CharacterState.Able)]
+    [HelpInfo("open", @"The #3open#0 command opens a door, container, or other openable item that you can manipulate. You can name a door by exit, a door and exit together, an item, a permitted character's external item, or an automation service panel on an item.
+
+The common syntax is:
+
+	#3open <exit|item>#0
+	#3open <door> <exit>#0
+	#3open <character> <external item>#0
+	#3open <item|exit> <panel|housing>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Open(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -6130,6 +6176,14 @@ The syntax is as follows:
     [PlayerCommand("Close", "close", "cl", "clo")]
     [DelayBlock("general", "You must first stop {0} before you can do that.")]
     [RequiredCharacterState(CharacterState.Able)]
+    [HelpInfo("close", @"The #3close#0 command closes a door, container, or other closeable item that you can manipulate. The aliases #3cl#0 and #3clo#0 work the same way. It accepts the same door, item, permitted-inventory and automation-panel forms as #3open#0.
+
+The common syntax is:
+
+	#3close <exit|item>#0
+	#3close <door> <exit>#0
+	#3close <character> <external item>#0
+	#3close <item|exit> <panel|housing>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Close(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -6748,6 +6802,12 @@ The syntax for this command is as follows:
     [PlayerCommand("Connect", "connect")]
     [DelayBlock("general", "You must first stop {0} before you can do that.")]
     [RequiredCharacterState(CharacterState.Able)]
+    [HelpInfo("connect", @"The #3connect#0 command joins two compatible connectable items. The second item may be an external implant on a character; name the character and, when necessary, the implant. You can attach a parenthesised emote.
+
+The syntax is:
+
+	#3connect <item> <item> [(<emote>)]#0
+	#3connect <item> <character> [<external implant>] [(<emote>)]#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Connect(ICharacter? actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -6856,6 +6916,12 @@ The syntax for this command is as follows:
     [PlayerCommand("Disconnect", "disconnect")]
     [DelayBlock("general", "You must first stop {0} before you can do that.")]
     [RequiredCharacterState(CharacterState.Able)]
+    [HelpInfo("disconnect", @"The #3disconnect#0 command separates two connected compatible items. The second item may be an external implant on a character; name the character and, when necessary, the implant. You can attach a parenthesised emote.
+
+The syntax is:
+
+	#3disconnect <item> <item> [(<emote>)]#0
+	#3disconnect <item> <character> [<external implant>] [(<emote>)]#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Disconnect(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -6951,6 +7017,12 @@ The syntax for this command is as follows:
 
     [PlayerCommand("Select", "select")]
     [RequiredCharacterState(CharacterState.Able)]
+    [HelpInfo("select", @"The #3select#0 command chooses an option on a selectable item in your possession or nearby. If there is more than one selectable item, name the item first. You can attach a parenthesised emote.
+
+The syntax is:
+
+	#3select <option> [(<emote>)]#0
+	#3select <item> <option> [(<emote>)]#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Select(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -7032,6 +7104,11 @@ The syntax for this command is as follows:
 
     [PlayerCommand("Insert", "insert")]
     [RequiredCharacterState(CharacterState.Able)]
+    [HelpInfo("insert", @"The #3insert#0 command places a held insertable item into a nearby compatible receptacle. If there is exactly one suitable nearby receptacle, you may omit it. You can attach a parenthesised emote.
+
+The syntax is:
+
+	#3insert <held item> [<receptacle>] [(<emote>)]#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Insert(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -8047,6 +8124,11 @@ The syntax is as follows:
     #endregion
 
     [PlayerCommand("Sharpen", "sharpen")]
+    [HelpInfo("sharpen", @"The #3sharpen#0 command sharpens a held item using a visible sharpening tool that you can manipulate.
+
+The syntax is:
+
+	#3sharpen <held item> <sharpener>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Sharpen(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -8103,9 +8185,11 @@ The syntax is as follows:
     [PlayerCommand("Lob", "lob")]
     [RequiredCharacterState(CharacterState.Able)]
     [NoMovementCommand]
-    [HelpInfo("lob",
-        "The lob command allows you to lob an item into another room or layer. You can lob the item into the room without regard to where it lands, or you can specify a target in that room to try to lob it near. The syntax is LOB <item> <direction> [<target>] or LOB <item> <layer> [<target>].",
-        AutoHelp.HelpArgOrNoArg)]
+    [HelpInfo("lob", @"The #3lob#0 command throws a held item into an adjacent room or another room layer. You may specify a target to aim near and append a parenthesised emote. Closed doors block lobs unless they can be fired through.
+
+The syntax is:
+
+	#3lob <item> <direction|layer> [<target>] [(<emote>)]#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Lob(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -8362,6 +8446,11 @@ The syntax is as follows:
     [RequiredCharacterState(CharacterState.Able)]
     [NoMovementCommand]
     [NoMeleeCombatCommand]
+    [HelpInfo("bundle", @"The #3bundle#0 command combines two or more compatible local or held items into a single pile. Every named item must be bundleable and accessible.
+
+The syntax is:
+
+	#3bundle <item> <item> [<item> ...]#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Bundle(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -8437,6 +8526,11 @@ The syntax is as follows:
     [RequiredCharacterState(CharacterState.Able)]
     [NoMovementCommand]
     [NoMeleeCombatCommand]
+    [HelpInfo("roll", @"The #3roll#0 command rolls a held die or a bundle containing only dice. By default the dice are rolled onto the ground; name a compatible table to roll them onto it. You can attach a parenthesised emote.
+
+The syntax is:
+
+	#3roll <die|dice bundle> [<table>] [(<emote>)]#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Roll(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());

--- a/MudSharpCore/Commands/Modules/MovementModule.cs
+++ b/MudSharpCore/Commands/Modules/MovementModule.cs
@@ -25,6 +25,16 @@ internal partial class MovementModule : Module<ICharacter>
     [DelayBlock("movement", "You cannot move until you stop {0}.")]
     [RequiredCharacterState(CharacterState.Able)]
     [DisplayOptions(CommandDisplayOptions.DisplayCommandWords)]
+    [HelpInfo("move", @"Movement commands take you through an available exit in the named direction. The short compass forms such as #3n#0 and #3sw#0 are aliases for their full names. #3enter#0 and #3leave#0 use the corresponding available exit where one is present.
+
+You can attach a parenthetical emote to describe how you depart. While you are already moving, further movement commands may be queued; in melee combat you must first get out of melee range.
+
+The syntax is:
+
+	#3north#0, #3south#0, #3east#0, #3west#0, #3up#0 or #3down#0
+	#3northeast#0, #3northwest#0, #3southeast#0 or #3southwest#0
+	#3enter#0 or #3leave#0
+	#3<direction> (<emote>)#0", AutoHelp.HelpArg)]
     protected static void Move(ICharacter actor, string input)
     {
         if (actor.Combat != null && actor.MeleeRange)
@@ -507,6 +517,14 @@ The syntax for this command is as follows:
     }
 
     [PlayerCommand("Speed", "speed")]
+    [HelpInfo("speed", @"The #3speed#0 command shows or changes the pace you use when moving. Available speeds depend on your current body position, and the chosen speed is remembered separately for each position.
+
+Using the command by itself lists the speeds you can currently adopt. Choose one by name to use it for the position it belongs to.
+
+The syntax is:
+
+	#3speed#0
+	#3speed <speed>#0", AutoHelp.HelpArg)]
     protected static void Speed(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());

--- a/MudSharpCore/Commands/Modules/NPCOnlyModule.cs
+++ b/MudSharpCore/Commands/Modules/NPCOnlyModule.cs
@@ -26,6 +26,11 @@ The syntax is:
     public static NPCOnlyModule Instance { get; } = new();
 
     [PlayerCommand("Pause", "pause")]
+    [HelpInfo("pause", @"The NPC-only #3pause#0 command toggles whether the NPC's AI routines are paused. While paused, the NPC retains its state but does not continue its normal AI behaviour until you use the command again.
+
+The syntax is:
+
+	#3pause#0", AutoHelp.HelpArg)]
     protected static void Pause(ICharacter actor, string command)
     {
         if (actor.EffectsOfType<PauseAI>().Any())
@@ -40,6 +45,11 @@ The syntax is:
     }
 
     [PlayerCommand("Doorguard", "doorguard")]
+    [HelpInfo("doorguard", @"The NPC-only #3doorguard#0 command toggles door-guard mode. An NPC in this mode acts as a guard for the doorway according to the door-guard effect and associated AI behaviour.
+
+The syntax is:
+
+	#3doorguard#0", AutoHelp.HelpArg)]
     protected static void DoorGuard(ICharacter actor, string command)
     {
         if (actor.AffectedBy<IDoorguardModeEffect>())
@@ -122,6 +132,14 @@ The syntax is:
 	}
 
     [PlayerCommand("Enforcer", "enforcer")]
+    [HelpInfo("enforcer", @"The NPC-only #3enforcer#0 command toggles enforcement mode for an NPC with an Enforcer AI. When enabling it, name a legal authority only if the NPC is eligible to enforce more than one authority.
+
+Use the command again while it is active to leave enforcement mode.
+
+The syntax is:
+
+	#3enforcer#0
+	#3enforcer <legal authority>#0", AutoHelp.HelpArg)]
     protected static void Enforcer(ICharacter actor, string command)
     {
         if (actor.AffectedBy<EnforcerEffect>())
@@ -177,6 +195,13 @@ The syntax is:
     }
 
     [PlayerCommand("Bodyguard", "bodyguard")]
+    [HelpInfo("bodyguard", @"The NPC-only #3bodyguard#0 command shows or changes the character the NPC is assigned to protect. Clearing the assignment stops the NPC from bodyguarding anyone.
+
+The syntax is:
+
+	#3bodyguard#0
+	#3bodyguard <target>#0
+	#3bodyguard off#0", AutoHelp.HelpArg)]
     protected static void Bodyguard(ICharacter actor, string command)
     {
         INPC npc = (INPC)actor;
@@ -224,6 +249,11 @@ The syntax is:
     }
 
     [PlayerCommand("IgnoreForce", "ignoreforce")]
+    [HelpInfo("ignoreforce", @"The NPC-only #3ignoreforce#0 command toggles whether the NPC ignores staff #3force#0 commands. Use it to protect scripted or possessed NPC behaviour from accidental forced input; use it again to restore normal response to force.
+
+The syntax is:
+
+	#3ignoreforce#0", AutoHelp.HelpArg)]
     protected static void IgnoreForce(ICharacter actor, string command)
     {
         if (actor.AffectedBy<IgnoreForce>())
@@ -238,6 +268,11 @@ The syntax is:
     }
 
     [PlayerCommand("Return", "return")]
+    [HelpInfo("return", @"The #3return#0 command ends an administrator's possession of an NPC and returns control to the original character. It only works while you are currently possessing an NPC.
+
+The syntax is:
+
+	#3return#0", AutoHelp.HelpArg)]
     protected static void Return(ICharacter actor, string input)
     {
         Switched switched = actor.EffectsOfType<Switched>().FirstOrDefault();

--- a/MudSharpCore/Commands/Modules/PerceptionModule.cs
+++ b/MudSharpCore/Commands/Modules/PerceptionModule.cs
@@ -74,7 +74,11 @@ internal class PerceptionModule : Module<ICharacter>
 
     [PlayerCommand("Exits", "exits")]
     [RequiredCharacterState(CharacterState.Conscious)]
-    [HelpInfo("Exits", @"This command allows you to see what exits are present at the location you're in. The syntax is #3exits#0.", AutoHelp.HelpArg)]
+    [HelpInfo("Exits", @"The #3exits#0 command lists the exits available from your current location, including their directions and any information your character can perceive about them.
+
+The syntax is:
+
+	#3exits#0", AutoHelp.HelpArg)]
     protected static void Exits(ICharacter actor, string input)
     {
         List<ICellExit> exits = actor

--- a/MudSharpCore/Commands/Modules/PlayerOnlyModule.cs
+++ b/MudSharpCore/Commands/Modules/PlayerOnlyModule.cs
@@ -470,9 +470,11 @@ The syntax is:
     [NoCombatCommand]
     [NoMovementCommand]
     [CustomModuleName("Game")]
-    [HelpInfo("typo",
-        @"This command is used to report a typo in the world building, whether it be rooms, items, NPCs, echoes or whatever you have noticed that is off. Simply type #6typo#0 and you will be dropped into an editor where you can describe the typo that you saw. This command will record your current location so there is no need to include that information.",
-        AutoHelp.HelpArg)]
+    [HelpInfo("typo", @"The #3typo#0 command reports a text or world-building error for staff review. It opens an editor for the report and automatically records your current location, so describe what is wrong and the text you expected instead.
+
+The syntax is:
+
+	#3typo#0", AutoHelp.HelpArg)]
     protected static void Typo(ICharacter actor, string command)
     {
         actor.OutputHandler.Send("Describe the typo that you have observed in the text editor below.");
@@ -529,6 +531,12 @@ The syntax is:
 
     [PlayerCommand("Roles", "roles")]
     [CustomModuleName("Game")]
+    [HelpInfo("roles", @"The #3roles#0 command shows the character-creation roles that your character selected. Administrators may also inspect the roles selected by a visible target.
+
+The syntax is:
+
+	#3roles#0
+	#3roles <target>#0", AutoHelp.HelpArg)]
     protected static void Roles(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -607,7 +615,11 @@ See also the #3names#0 command and the #3introduce#0 command.";
     [PlayerCommand("Names", "names")]
     [RequiredCharacterState(CharacterState.Conscious)]
     [CustomModuleName("Game")]
-    [HelpInfo("names", @"The #3names#0 command is used to view your real name and any aliases. See also the #3alias#0 command and the #3introduce#0 command.", AutoHelp.HelpArg)]
+    [HelpInfo("names", @"The #3names#0 command lists your character's real name and any configured aliases. Use #3alias#0 to manage aliases and #3introduce#0 to share a name with another character.
+
+The syntax is:
+
+	#3names#0", AutoHelp.HelpArg)]
     protected static void Names(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -771,6 +783,13 @@ The syntax is #3INTRODUCE ME#0 or #3INTRODUCE <person>#0. You can append a brack
 
     [PlayerCommand("Social", "social")]
     [CustomModuleName("Game")]
+    [HelpInfo("social", @"The #3social#0 command displays the authored echoes and targeting forms for one social that your character can use. It is a reference command; enter the social's own name to perform it.
+
+Use #3socials#0 to list the socials currently available to you.
+
+The syntax is:
+
+	#3social <social>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Social(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -814,6 +833,13 @@ The syntax is #3INTRODUCE ME#0 or #3INTRODUCE <person>#0. You can append a brack
 
     [PlayerCommand("Socials", "socials")]
     [CustomModuleName("Game")]
+    [HelpInfo("socials", @"The #3socials#0 command lists the socials currently available to your character, including whether each social supports no target, a single target, multiple targets or a direction.
+
+Use #3social <social>#0 to inspect the exact echoes for a particular social.
+
+The syntax is:
+
+	#3socials#0", AutoHelp.HelpArg)]
     protected static void Socials(ICharacter actor, string command)
     {
         if (!actor.CommandTree.Commands.Socials.Any())
@@ -846,6 +872,11 @@ The syntax is #3INTRODUCE ME#0 or #3INTRODUCE <person>#0. You can append a brack
 
     [PlayerCommand("Save", "save")]
     [CustomModuleName("Game")]
+    [HelpInfo("save", @"The #3save#0 command saves your character's current persistent state. Most important state is also saved by normal gameplay, but this command lets you request an immediate save before ending a session or after making a meaningful change.
+
+The syntax is:
+
+	#3save#0", AutoHelp.HelpArg)]
     protected static void Save(ICharacter actor, string command)
     {
         actor.Send("Saving your character...");

--- a/MudSharpCore/Commands/Modules/PositionModule.cs
+++ b/MudSharpCore/Commands/Modules/PositionModule.cs
@@ -348,6 +348,11 @@ For example, if you set the omote of #2a white cotton shirt#0 to #6folded in a n
 
     [PlayerCommand("Tables", "tables")]
     [RequiredCharacterState(CharacterState.Awake)]
+    [HelpInfo("tables", @"The #3tables#0 command lists the tables in your current location, their associated chairs, and the people using them with their current positions.
+
+The syntax is:
+
+	#3tables#0", AutoHelp.HelpArg)]
     protected static void Tables(ICharacter character, string input)
     {
         StringBuilder sb = new();
@@ -1224,6 +1229,11 @@ For example:
     [RequiredCharacterState(CharacterState.Awake)]
     [NoCombatCommand]
     [NoMovementCommand]
+    [HelpInfo("sleep", @"The #3sleep#0 command puts your character to sleep when their current position and circumstances permit it. You may include a parenthesised emote to describe settling down.
+
+The syntax is:
+
+	#3sleep [(<emote>)]#0", AutoHelp.HelpArg)]
     protected static void Sleep(ICharacter actor, string input)
     {
         if (actor.EffectsOfType<IPreventSleepEffect>().FirstOrDefault() is { } sleepBlocker)
@@ -1252,6 +1262,11 @@ For example:
 
     [PlayerCommand("Wake", "wake")]
     [NoCombatCommand]
+    [HelpInfo("wake", @"The #3wake#0 command wakes your character from ordinary sleep. Magical sleep and other effects may prevent waking. You may include a parenthesised emote to describe waking.
+
+The syntax is:
+
+	#3wake [(<emote>)]#0", AutoHelp.HelpArg)]
     protected static void Wake(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -1289,6 +1304,11 @@ For example:
     [RequiredCharacterState(CharacterState.Able)]
     [NoMovementCommand]
     [NoMeleeCombatCommand]
+    [HelpInfo("fly", @"The #3fly#0 command begins flying when your character is capable of it. If you are already flying, the command can instead accept a normal position expression. Add a parenthesised emote when beginning flight.
+
+The syntax is:
+
+	#3fly [(<emote>)]#0", AutoHelp.HelpArg)]
     protected static void Fly(ICharacter actor, string input)
     {
         Match positionMatch = _positionRegex.Match(input);
@@ -1327,6 +1347,11 @@ For example:
     [RequiredCharacterState(CharacterState.Able)]
     [NoMovementCommand]
     [NoMeleeCombatCommand]
+    [HelpInfo("land", @"The #3land#0 command ends flight. When you are high in the air, use #3land !#0 to confirm that you intend to fall. You may include a parenthesised emote.
+
+The syntax is:
+
+	#3land [!] [(<emote>)]#0", AutoHelp.HelpArg)]
     protected static void Land(ICharacter actor, string input)
     {
         string playerEmote = new StringStack(input.RemoveFirstWord()).PopParentheses();
@@ -1352,6 +1377,11 @@ For example:
     [RequiredCharacterState(CharacterState.Able)]
     [NoMovementCommand]
     [NoMeleeCombatCommand]
+    [HelpInfo("dive", @"The #3dive#0 command moves your character downward while swimming or flying. #3descend#0 is an alias. You may include a parenthesised emote.
+
+The syntax is:
+
+	#3dive [(<emote>)]#0", AutoHelp.HelpArg)]
     protected static void Dive(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -1383,6 +1413,11 @@ For example:
     [RequiredCharacterState(CharacterState.Able)]
     [NoMovementCommand]
     [NoMeleeCombatCommand]
+    [HelpInfo("ascend", @"The #3ascend#0 command moves your character upward while swimming or flying. You may include a parenthesised emote.
+
+The syntax is:
+
+	#3ascend [(<emote>)]#0", AutoHelp.HelpArg)]
     protected static void Ascend(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -1414,6 +1449,11 @@ For example:
     [RequiredCharacterState(CharacterState.Able)]
     [NoMovementCommand]
     [NoMeleeCombatCommand]
+    [HelpInfo("swim", @"The #3swim#0 command changes your character into a swimming position when they are in an appropriate body of water.
+
+The syntax is:
+
+	#3swim#0", AutoHelp.HelpArg)]
     protected static void Swim(ICharacter actor, string command)
     {
         if (actor.PositionState == PositionSwimming.Instance)
@@ -1436,6 +1476,11 @@ For example:
     [RequiredCharacterState(CharacterState.Able)]
     [NoMovementCommand]
     [NoMeleeCombatCommand]
+    [HelpInfo("climb", @"The #3climb#0 command moves your character up or down a climbable route. The alias #3cli#0 works the same way. #3trees#0, #3roof#0 and #3rooftop#0 can be used as upward forms from ground level. You may add a parenthesised emote.
+
+The syntax is:
+
+	#3climb <up|down|trees|roof> [(<emote>)]#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Climb(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());

--- a/MudSharpCore/Commands/Modules/ProgModule.cs
+++ b/MudSharpCore/Commands/Modules/ProgModule.cs
@@ -3037,6 +3037,13 @@ You can use the following filters with #3hook list#0:
     #region Schedules
     [PlayerCommand("Schedules", "schedules")]
     [CommandPermission(PermissionLevel.Admin)]
+    [HelpInfo("schedules", @"The #3schedules#0 command lists every recurring FutureProg schedule in the game, showing the prog, in-game interval and next execution time. Use #3schedule#0 to create or remove an individual schedule.
+
+Schedules use in-character time rather than real time, so their apparent real-world interval depends on the game's time ratio.
+
+The syntax is:
+
+	#3schedules#0", AutoHelp.HelpArg)]
     protected static void Schedules(ICharacter actor, string input)
     {
         actor.Send(StringUtilities.GetTextTable(

--- a/MudSharpCore/Commands/Modules/PropertyModule.cs
+++ b/MudSharpCore/Commands/Modules/PropertyModule.cs
@@ -2420,6 +2420,13 @@ The following commands are specific to those who own a property (or who are mana
 
     [PlayerCommand("Properties", "properties")]
     [CustomModuleName("Economy")]
+    [HelpInfo("properties", @"The #3properties#0 command reports properties relevant to your current economic zone and your character. It lists nearby properties offered for sale or lease, followed by property that you own or in which you have an ownership interest.
+
+Use #3property#0 for the detailed ownership, sale, lease and management actions on an individual property.
+
+The syntax is:
+
+	#3properties#0", AutoHelp.HelpArg)]
     protected static void Properties(ICharacter actor, string command)
     {
         StringBuilder sb = new();

--- a/MudSharpCore/Commands/Modules/RidingModule.cs
+++ b/MudSharpCore/Commands/Modules/RidingModule.cs
@@ -14,7 +14,11 @@ public class RidingModule : Module<ICharacter>
     [RequiredCharacterState(CharacterState.Able)]
     [NoMovementCommand]
     [NoHideCommand]
-    [HelpInfo("mount", @"Use #3mount <mount>#0 to ride a mountable creature. Mounting bareback is allowed, but missing saddles, bridles, reins and similar tack make control and staying mounted harder.", AutoHelp.HelpArg)]
+    [HelpInfo("mount", @"The #3mount#0 command mounts a rideable creature. Bareback riding may be possible, but appropriate saddles, bridles, reins and other tack improve control and make staying mounted easier.
+
+The syntax is:
+
+	#3mount <mount>#0", AutoHelp.HelpArg)]
     protected static void Mount(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -81,7 +85,11 @@ public class RidingModule : Module<ICharacter>
     [RequiredCharacterState(CharacterState.Able)]
     [NoMovementCommand]
     [NoHideCommand]
-    [HelpInfo("dismount", @"Use #3dismount#0 to get off your current mount.", AutoHelp.HelpArg)]
+    [HelpInfo("dismount", @"The #3dismount#0 command gets your character off their current mount.
+
+The syntax is:
+
+	#3dismount#0", AutoHelp.HelpArg)]
     protected static void Dismount(ICharacter actor, string command)
     {
         if (actor.RidingMount is null)
@@ -98,7 +106,11 @@ public class RidingModule : Module<ICharacter>
     [RequiredCharacterState(CharacterState.Able)]
     [NoMovementCommand]
     [NoHideCommand]
-    [HelpInfo("buck", @"Use #3buck#0 to try to throw off your primary rider, or #3buck <rider>#0 to target a specific rider.", AutoHelp.HelpArg)]
+    [HelpInfo("buck", @"The #3buck#0 command makes a mount attempt to throw off a rider. With no argument it targets the primary rider; name a rider to target that rider instead.
+
+The syntax is:
+
+	#3buck [<rider>]#0", AutoHelp.HelpArg)]
     protected static void Buck(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());

--- a/MudSharpCore/Commands/Modules/RoomBuilderModule.cs
+++ b/MudSharpCore/Commands/Modules/RoomBuilderModule.cs
@@ -1053,6 +1053,11 @@ Enter your text below:");
 
     [PlayerCommand("Zones", "zones")]
     [CommandPermission(PermissionLevel.JuniorAdmin)]
+    [HelpInfo("zones", @"The #3zones#0 command lists every zone in the game, including its local time, local date, cell count and shard. Use #3zone#0 to create or edit zone definitions, and #3rezone#0 to move the current cell into a different zone.
+
+The syntax is:
+
+	#3zones#0", AutoHelp.HelpArg)]
     protected static void Zones(ICharacter actor, string command)
     {
         actor.OutputHandler.Send(
@@ -1173,9 +1178,11 @@ Possible filter options include:
 
     [PlayerCommand("Rezone", "rezone")]
     [CommandPermission(PermissionLevel.Admin)]
-    [HelpInfo("rezone",
-        "This command is used to change a room into a different zone. The usage is REZONE <new zone>. You must use this command from inside the room you want to rezone.",
-        AutoHelp.HelpArgOrNoArg)]
+    [HelpInfo("rezone", @"The #3rezone#0 builder command moves the current room into a different zone. Use it from the room whose zone you are changing; the target zone may be identified by ID or name.
+
+The syntax is:
+
+	#3rezone <zone|id>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Rezone(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -1778,6 +1785,13 @@ You can use the following subcommands:
 
     [PlayerCommand("Shards", "shards")]
     [CommandPermission(PermissionLevel.JuniorAdmin)]
+    [HelpInfo("shards", @"The #3shards#0 command lists all configured shards, including their calendars, clocks, celestial objects, sky templates and ambient illumination. A shard is the top-level world or realm grouping used by zones and cells.
+
+Use #3shard#0 to create or edit a specific shard.
+
+The syntax is:
+
+	#3shards#0", AutoHelp.HelpArg)]
     protected static void Shards(ICharacter actor, string input)
     {
         actor.OutputHandler.Send(

--- a/MudSharpCore/Commands/Modules/SharedModule.cs
+++ b/MudSharpCore/Commands/Modules/SharedModule.cs
@@ -34,6 +34,15 @@ public class SharedModule : Module<ICharacter>
     [PlayerCommand("Vis", "vis")]
     [DisplayOptions(CommandDisplayOptions.DisplayToAdminsAndNPCs)]
     [CustomModuleName("Storyteller")]
+    [HelpInfo("vis", @"The #3vis#0 command removes administrator invisibility from yourself or a visible target. The ordinary form produces the normal appearance echo; use the silent form when you only want administrators to see the change.
+
+Possessed NPCs may use this command, but unpossessed NPCs cannot. Supplying no target makes yourself visible.
+
+The syntax is:
+
+	#3vis#0
+	#3vis silent#0
+	#3vis <target>#0", AutoHelp.HelpArg)]
     protected static void Vis(ICharacter actor, string input)
     {
         if (actor is INPC)
@@ -100,6 +109,15 @@ public class SharedModule : Module<ICharacter>
     [CommandPermission(PermissionLevel.JuniorAdmin)]
     [DisplayOptions(CommandDisplayOptions.DisplayToAdminsAndNPCs)]
     [CustomModuleName("Storyteller")]
+    [HelpInfo("invis", @"The #3invis#0 command applies administrator invisibility to yourself or a visible target. Invisible administrators remain visible to the administrative audience, while ordinary characters do not receive the usual presence echoes.
+
+Use the silent form for a discrete transition visible only to administrators. Supplying no target makes yourself invisible.
+
+The syntax is:
+
+	#3invis#0
+	#3invis silent#0
+	#3invis <target>#0", AutoHelp.HelpArg)]
     protected static void Invis(ICharacter actor, string input)
     {
         if (actor is INPC)
@@ -283,6 +301,16 @@ This command is useful when you write-up a bunch of room creation commands in a 
     [PlayerCommand("Echo", "echo")]
     [DisplayOptions(CommandDisplayOptions.DisplayToAdminsAndNPCs)]
     [CustomModuleName("Storyteller")]
+    [HelpInfo("echo", @"The #3echo#0 command sends a staff-authored emote to everyone in your current location. Use normal emote markup, including #6@#0 for yourself, #6~target#0 for characters and #6*target#0 for items.
+
+You can make the echo require an auditory, visual, or both types of perception check by supplying an option and a difficulty before the echo text.
+
+The syntax is:
+
+	#3echo <emote text>#0
+	#3echo -a <difficulty> <emote text>#0
+	#3echo -v <difficulty> <emote text>#0
+	#3echo -av <difficulty> <emote text>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Echo(ICharacter actor, string input)
     {
         if (actor is INPC)
@@ -391,6 +419,13 @@ This command is useful when you write-up a bunch of room creation commands in a 
     [PlayerCommand("ZEcho", "zecho")]
     [DisplayOptions(CommandDisplayOptions.DisplayToAdminsAndNPCs)]
     [CustomModuleName("Storyteller")]
+    [HelpInfo("zecho", @"The #3zecho#0 command sends a staff-authored message to every character in your current zone. It is intended for zone-wide narration or coordination rather than a normal local echo.
+
+ANSI colour substitutions are supported, but this command sends a plain message rather than parsing player-emote target markup.
+
+The syntax is:
+
+	#3zecho <message>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void ZEcho(ICharacter actor, string input)
     {
         if (actor is INPC)
@@ -425,6 +460,14 @@ This command is useful when you write-up a bunch of room creation commands in a 
     [PlayerCommand("PEcho", "pecho")]
     [DisplayOptions(CommandDisplayOptions.DisplayToAdminsAndNPCs)]
     [CustomModuleName("Storyteller")]
+    [HelpInfo("pecho", @"The #3pecho#0 command sends an emote privately to one or more visible characters. Separate multiple targets with commas. Each recipient sees the emote as a personal echo, while you receive confirmation of what was sent.
+
+Use normal emote markup in the message. This is a staff-facing delivery tool and does not broadcast the echo to the room.
+
+The syntax is:
+
+	#3pecho <target> <emote text>#0
+	#3pecho <target one>,<target two> <emote text>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void PEcho(ICharacter actor, string input)
     {
         if (actor is INPC)

--- a/MudSharpCore/Commands/Modules/ShowModule.cs
+++ b/MudSharpCore/Commands/Modules/ShowModule.cs
@@ -188,8 +188,15 @@ public class ShowModule : Module<ICharacter>
 	#3weatherevent <id|name>#0 - shows a specific weather event
 	#3writingstyles#0 - shows writing styles";
 
+    private const string ShowHelpText = @"The #3show#0 command is the read-only catalogue browser for engine data. The available topics vary with your permissions; use it to inspect an individual object by ID or name where the listed topic accepts a #6<which>#0 argument.
+
+Using #3show#0 on its own displays the topic list appropriate to your current permission level. The administrative list below includes the full command surface.
+
+" + AdminShowDefaultText;
+
     [PlayerCommand("Show", "show")]
     [CustomModuleName("Game")]
+    [HelpInfo("show", ShowHelpText, AutoHelp.HelpArg)]
     protected static void Show(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());

--- a/MudSharpCore/Commands/Modules/StaffModule.cs
+++ b/MudSharpCore/Commands/Modules/StaffModule.cs
@@ -106,8 +106,11 @@ The syntax is simply #3testansi#0.", AutoHelp.HelpArg)]
     }
 
     [PlayerCommand("PartInfo", "partinfo")]
-    [HelpInfo("partinfo", "Full info report on a body's specific bodypart. Syntax: partinfo <target> <partName>",
-        AutoHelp.HelpArgOrNoArg)]
+    [HelpInfo("partinfo", @"The #3partinfo#0 staff command displays a detailed diagnostic report for one of a character's body parts or organs, including material, connections, hit values, modifiers, vital status and attached organs.
+
+The syntax is:
+
+	#3partinfo <target> <bodypart|organ>#0", AutoHelp.HelpArgOrNoArg)]
     [CommandPermission(PermissionLevel.JuniorAdmin)]
     protected static void PartInfo(ICharacter actor, string input)
     {
@@ -169,6 +172,11 @@ The syntax is simply #3testansi#0.", AutoHelp.HelpArg)]
 
     [PlayerCommand("SetHeight", "setheight")]
     [CommandPermission(PermissionLevel.JuniorAdmin)]
+    [HelpInfo("setheight", @"The #3setheight#0 staff command changes a visible character's height. It also recalculates that character's blood volume.
+
+The syntax is:
+
+	#3setheight <target> <height>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void SetHeight(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -208,6 +216,11 @@ The syntax is simply #3testansi#0.", AutoHelp.HelpArg)]
 
     [PlayerCommand("SetWeight", "setweight")]
     [CommandPermission(PermissionLevel.JuniorAdmin)]
+    [HelpInfo("setweight", @"The #3setweight#0 staff command changes a visible character's weight. It also recalculates that character's blood volume.
+
+The syntax is:
+
+	#3setweight <target> <weight>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void SetWeight(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -247,9 +260,11 @@ The syntax is simply #3testansi#0.", AutoHelp.HelpArg)]
 
     [PlayerCommand("SetCharacteristic", "setcharacteristic")]
     [CommandPermission(PermissionLevel.Admin)]
-    [HelpInfo("setcharacteristic",
-        "This command is used to set a characteristic for a character or item. The syntax is setcharacteristic <target> <definition> <value>.",
-        AutoHelp.HelpArgOrNoArg)]
+    [HelpInfo("setcharacteristic", @"The #3setcharacteristic#0 staff command sets a supported characteristic on a visible character or item. Definitions and values may be selected by ID or name.
+
+The syntax is:
+
+	#3setcharacteristic <target> <definition|id> <value|id>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void SetCharacteristic(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -306,6 +321,11 @@ The syntax is simply #3testansi#0.", AutoHelp.HelpArg)]
 
     [PlayerCommand("GiveAccent", "giveaccent")]
     [CommandPermission(PermissionLevel.Admin)]
+    [HelpInfo("giveaccent", @"The #3giveaccent#0 staff command grants a character an accent, selected by name or ID. You may give an optional difficulty that controls the accent's familiarity.
+
+The syntax is:
+
+	#3giveaccent <target> <accent|id> [<difficulty>]#0", AutoHelp.HelpArgOrNoArg)]
     protected static void GiveAccent(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -377,8 +397,11 @@ The syntax is simply #3testansi#0.", AutoHelp.HelpArg)]
 
     [PlayerCommand("GiveKnowledge", "giveknowledge")]
     [CommandPermission(PermissionLevel.Admin)]
-    [HelpInfo("giveknowledge", "Grant Knowledge to character via: giveknowledge <character> <knowledge>",
-        AutoHelp.HelpArgOrNoArg)]
+    [HelpInfo("giveknowledge", @"The #3giveknowledge#0 staff command grants a knowledge to a visible character.
+
+The syntax is:
+
+	#3giveknowledge <character> <knowledge>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void GiveKnowledge(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -423,8 +446,11 @@ The syntax is simply #3testansi#0.", AutoHelp.HelpArg)]
 
     [PlayerCommand("RemoveKnowledge", "removeknowledge")]
     [CommandPermission(PermissionLevel.Admin)]
-    [HelpInfo("removeknowledge", "Remove Knowledge from character via: removeknowledge <character> <knowledge>",
-        AutoHelp.HelpArgOrNoArg)]
+    [HelpInfo("removeknowledge", @"The #3removeknowledge#0 staff command removes a knowledge from a visible character.
+
+The syntax is:
+
+	#3removeknowledge <character> <knowledge>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void RemoveKnowledge(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -464,7 +490,11 @@ The syntax is simply #3testansi#0.", AutoHelp.HelpArg)]
 
     [PlayerCommand("GiveMerit", "givemerit")]
     [CommandPermission(PermissionLevel.Admin)]
-    [HelpInfo("givemerit", "Grant a merit. Syntax: givemerit <target> <meritname>", AutoHelp.HelpArgOrNoArg)]
+    [HelpInfo("givemerit", @"The #3givemerit#0 staff command grants a merit or flaw to a visible character. The merit must be valid for that character.
+
+The syntax is:
+
+	#3givemerit <target> <merit>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void GiveMerit(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -539,7 +569,11 @@ The syntax is simply #3testansi#0.", AutoHelp.HelpArg)]
 
     [PlayerCommand("RemoveMerit", "removemerit")]
     [CommandPermission(PermissionLevel.Admin)]
-    [HelpInfo("removemerit", "Remove a merit. Syntax: removemerit <target> <meritname>", AutoHelp.HelpArgOrNoArg)]
+    [HelpInfo("removemerit", @"The #3removemerit#0 staff command removes a merit or flaw from a visible character.
+
+The syntax is:
+
+	#3removemerit <target> <merit>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void RemoveMerit(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -605,8 +639,11 @@ The syntax is simply #3testansi#0.", AutoHelp.HelpArg)]
 
     [PlayerCommand("FinishTattoo", "finishtattoo")]
     [CommandPermission(PermissionLevel.JuniorAdmin)]
-    [HelpInfo("finishtattoo", "Finishes someone's unfinished tatoo. Syntax: finishtattoo <target> <tattoo>",
-        AutoHelp.HelpArgOrNoArg)]
+    [HelpInfo("finishtattoo", @"The #3finishtattoo#0 staff command immediately completes one of a character's unfinished tattoos.
+
+The syntax is:
+
+	#3finishtattoo <target> <tattoo>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void FinishTattoo(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -641,8 +678,11 @@ The syntax is simply #3testansi#0.", AutoHelp.HelpArg)]
 
     [PlayerCommand("GiveTattoo", "givetattoo")]
     [CommandPermission(PermissionLevel.JuniorAdmin)]
-    [HelpInfo("givetattoo", "Gives someone a tattoo. #3Syntax: givetattoo <target> <tattoo> <bodypart> [slot=text]#0",
-        AutoHelp.HelpArgOrNoArg)]
+    [HelpInfo("givetattoo", @"The #3givetattoo#0 staff command adds a tattoo to a target body part. Supply any tattoo pattern slots as #3slot=text#0 arguments.
+
+The syntax is:
+
+	#3givetattoo <target> <tattoo> <bodypart> [<slot>=<text> ...]#0", AutoHelp.HelpArgOrNoArg)]
     protected static void GiveTattoo(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -712,8 +752,11 @@ The syntax is simply #3testansi#0.", AutoHelp.HelpArg)]
 
     [PlayerCommand("GiveScar", "givescar")]
     [CommandPermission(PermissionLevel.JuniorAdmin)]
-    [HelpInfo("givescar", "Gives someone a generated scar. #3Syntax: givescar <target> <bodypart> <damage|surgery> <type> <severity>#0",
-        AutoHelp.HelpArgOrNoArg)]
+    [HelpInfo("givescar", @"The #3givescar#0 staff command creates a generated scar on a target body part, using the selected damage or surgery source, scar type and severity.
+
+The syntax is:
+
+	#3givescar <target> <bodypart> <damage|surgery> <type> <severity>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void GiveScar(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -797,8 +840,11 @@ The syntax is simply #3testansi#0.", AutoHelp.HelpArg)]
 
     [PlayerCommand("RemoveScar", "removescar")]
     [CommandPermission(PermissionLevel.JuniorAdmin)]
-    [HelpInfo("removescar", "Removes one of someone's scars. #3Syntax: removescar <target> <scar>#0",
-        AutoHelp.HelpArgOrNoArg)]
+    [HelpInfo("removescar", @"The #3removescar#0 staff command removes one of a visible character's scars.
+
+The syntax is:
+
+	#3removescar <target> <scar>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void RemoveScar(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -834,8 +880,11 @@ The syntax is simply #3testansi#0.", AutoHelp.HelpArg)]
 
     [PlayerCommand("SetGender", "setgender")]
     [CommandPermission(PermissionLevel.JuniorAdmin)]
-    [HelpInfo("setgender", "Sets gender of a target character. Syntax: #3setgender <target> <gender>#0",
-        AutoHelp.HelpArgOrNoArg)]
+    [HelpInfo("setgender", @"The #3setgender#0 staff command changes a visible character's gender.
+
+The syntax is:
+
+	#3setgender <target> <gender>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void SetGender(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -873,8 +922,11 @@ The syntax is simply #3testansi#0.", AutoHelp.HelpArg)]
 
     [PlayerCommand("SetAge", "setage")]
     [CommandPermission(PermissionLevel.JuniorAdmin)]
-    [HelpInfo("setage", "Sets age of a target character. Maintains existing birthday. Syntax: #3setage <target> <age>#0",
-        AutoHelp.HelpArgOrNoArg)]
+    [HelpInfo("setage", @"The #3setage#0 staff command changes a visible character's age while retaining their existing birthday relationship.
+
+The syntax is:
+
+	#3setage <target> <age>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void SetAge(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -912,8 +964,11 @@ The syntax is simply #3testansi#0.", AutoHelp.HelpArg)]
 
     [PlayerCommand("SetBirthday", "setbirthday")]
     [CommandPermission(PermissionLevel.JuniorAdmin)]
-    [HelpInfo("setbirthday", "Sets the birthday of a target character. Syntax: #3setbirthday <target> <date>#0",
-        AutoHelp.HelpArgOrNoArg)]
+    [HelpInfo("setbirthday", @"The #3setbirthday#0 staff command changes a visible character's birthday. The date must be valid in the character's game calendar and cannot be in the future.
+
+The syntax is:
+
+	#3setbirthday <target> <date>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void SetBirthday(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -948,6 +1003,11 @@ The syntax is simply #3testansi#0.", AutoHelp.HelpArg)]
 
     [PlayerCommand("ALock", "alock")]
     [CommandPermission(PermissionLevel.JuniorAdmin)]
+    [HelpInfo("alock", @"The #3alock#0 staff command toggles an administrator lock on a door, lockable item, or a particular lock installed in a lockable item. An administrator lock prevents ordinary manipulation.
+
+The syntax is:
+
+	#3alock <exit|item> [<lock>]#0", AutoHelp.HelpArg)]
     protected static void ALock(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -1030,6 +1090,11 @@ The syntax is simply #3testansi#0.", AutoHelp.HelpArg)]
 
     [PlayerCommand("Drugs", "drugs")]
     [CommandPermission(PermissionLevel.JuniorAdmin)]
+    [HelpInfo("drugs", @"The #3drugs#0 staff command reports a visible character's active and latent drug dosages.
+
+The syntax is:
+
+	#3drugs <target>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Drugs(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -1051,6 +1116,11 @@ The syntax is simply #3testansi#0.", AutoHelp.HelpArg)]
 
     [PlayerCommand("Sober", "sober")]
     [CommandPermission(PermissionLevel.JuniorAdmin)]
+    [HelpInfo("sober", @"The #3sober#0 staff command immediately clears intoxication and related bodily effects from a character or corpse body.
+
+The syntax is:
+
+	#3sober <target>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Sober(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -1073,9 +1143,12 @@ The syntax is simply #3testansi#0.", AutoHelp.HelpArg)]
 
     [PlayerCommand("Effect", "effect")]
     [CommandPermission(PermissionLevel.JuniorAdmin)]
-    [HelpInfo("effect",
-        "This command allows you to view effects on individuals or items, as well as remove those effects. You should be VERY careful when manually removing effects; some could have unintended consequences. The syntax is EFFECT LIST <target> [<subtarget>] or EFFECT REMOVE <target> [<subtarget>] <position>",
-        AutoHelp.HelpArgOrNoArg)]
+    [HelpInfo("effect", @"The #3effect#0 staff command lists effects on an individual or item and can remove a selected effect. Removing effects can break persistent state or active actions, so inspect the list and use removal only when you understand the effect.
+
+The syntax is:
+
+	#3effect list <target> [<subtarget>]#0
+	#3effect remove <target> [<subtarget>] <position>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Effect(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -1518,6 +1591,11 @@ Plane lists accept IDs, aliases, quoted names, or comma-separated tokens, e.g. #
 
     [PlayerCommand("Ban", "ban")]
     [CommandPermission(PermissionLevel.SeniorAdmin)]
+    [HelpInfo("ban", @"The #3ban#0 staff command suspends an account. After selecting the account, it opens an editor for the ban reason. You cannot ban yourself or an account with equal or greater authority.
+
+The syntax is:
+
+	#3ban <account>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Ban(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -1565,6 +1643,11 @@ Plane lists accept IDs, aliases, quoted names, or comma-separated tokens, e.g. #
 
     [PlayerCommand("Unban", "unban")]
     [CommandPermission(PermissionLevel.SeniorAdmin)]
+    [HelpInfo("unban", @"The #3unban#0 staff command removes an account suspension.
+
+The syntax is:
+
+	#3unban <account>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Unban(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -1603,6 +1686,11 @@ Plane lists accept IDs, aliases, quoted names, or comma-separated tokens, e.g. #
 
     [PlayerCommand("Siteban", "siteban")]
     [CommandPermission(PermissionLevel.SeniorAdmin)]
+    [HelpInfo("siteban", @"The #3siteban#0 staff command blocks an IP address or wildcard mask. Use #3!#0 for a permanent ban; otherwise supply a date and time in your local account format. Any remaining text records the reason.
+
+The syntax is:
+
+	#3siteban <ip-address|mask> <date-time|!> [<reason>]#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Siteban(ICharacter character, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -1657,6 +1745,11 @@ Plane lists accept IDs, aliases, quoted names, or comma-separated tokens, e.g. #
 
     [PlayerCommand("Unsiteban", "unsiteban")]
     [CommandPermission(PermissionLevel.SeniorAdmin)]
+    [HelpInfo("unsiteban", @"The #3unsiteban#0 staff command removes an active IP ban by its ID or exact mask. Use #3sitebans#0 to find the ID.
+
+The syntax is:
+
+	#3unsiteban <id|ip mask>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void Unsiteban(ICharacter character, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -1693,6 +1786,11 @@ Plane lists accept IDs, aliases, quoted names, or comma-separated tokens, e.g. #
 
     [PlayerCommand("Sitebans", "sitebans")]
     [CommandPermission(PermissionLevel.Admin)]
+    [HelpInfo("sitebans", @"The #3sitebans#0 staff command lists active IP bans, including their IDs, masks, issuing staff member, reason and expiry.
+
+The syntax is:
+
+	#3sitebans#0", AutoHelp.HelpArg)]
     protected static void Sitebans(ICharacter character, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -1721,6 +1819,11 @@ Plane lists accept IDs, aliases, quoted names, or comma-separated tokens, e.g. #
 
     [PlayerCommand("RandomNames", "randomnames")]
     [CommandPermission(PermissionLevel.JuniorAdmin)]
+    [HelpInfo("randomnames", @"The #3randomnames#0 staff command generates five sample names from a configured name culture and one of its random-name profiles. Each may be selected by name prefix or ID.
+
+The syntax is:
+
+	#3randomnames <culture|id> <profile|id>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void RandomNames(ICharacter actor, string input)
     {
         StringStack ss = new(input.RemoveFirstWord());
@@ -1783,6 +1886,11 @@ Plane lists accept IDs, aliases, quoted names, or comma-separated tokens, e.g. #
 
     [PlayerCommand("ResetPassword", "resetpassword")]
     [CommandPermission(PermissionLevel.HighAdmin)]
+    [HelpInfo("resetpassword", @"The #3resetpassword#0 staff command creates a new random password for an account and sends it to the account's email address. Founders also see the generated password in game.
+
+The syntax is:
+
+	#3resetpassword <account>#0", AutoHelp.HelpArgOrNoArg)]
     protected static void ResetPassword(ICharacter actor, string input)
     {
         string account = input.RemoveFirstWord();
@@ -2225,6 +2333,13 @@ The syntax is simply #3broadcast <message>#0.", AutoHelp.HelpArgOrNoArg)]
 
     [PlayerCommand("Wizlock", "wizlock")]
     [CommandPermission(PermissionLevel.SeniorAdmin)]
+    [HelpInfo("wizlock", @"The #3wizlock#0 command manages maintenance-mode restrictions. With no argument it toggles the normal maintenance set (login and chargen restrictions). #3status#0 reports the current flags, while #3login#0 and #3chargen#0 toggle those restrictions separately.
+
+The syntax is:
+
+	#3wizlock#0
+	#3wizlock status#0
+	#3wizlock <login|chargen>#0", AutoHelp.HelpArg)]
     protected static void Wizlock(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());
@@ -3182,7 +3297,7 @@ There are three ways to use this command:
         actor.OutputHandler.Send(sb.ToString());
     }
 
-    private static string GridHelpText =>
+    private const string GridHelpText =
         @"The #3grid#0 command is used to view, edit and create grids, which are ways in which certain resources (like electricity or water) are shared across multiple rooms with different inputs and outputs pulling dynamically from it.
 
 A room can only have one of each kind of grid at a time, and the grids must be added to rooms to apply there. Other items (like electrical sockets) can be connected to the grid once it's there.
@@ -3202,6 +3317,7 @@ You can use the following subcommands with the grid command:
 
     [PlayerCommand("Grid", "grid")]
     [CommandPermission(PermissionLevel.Admin)]
+    [HelpInfo("grid", GridHelpText, AutoHelp.HelpArg)]
     protected static void Grid(ICharacter actor, string command)
     {
         StringStack ss = new(command.RemoveFirstWord());

--- a/MudSharpCore/Commands/Modules/TimeModule.cs
+++ b/MudSharpCore/Commands/Modules/TimeModule.cs
@@ -24,6 +24,17 @@ internal class TimeModule : Module<ICharacter>
     [PlayerCommand("Time", "time")]
     [CustomModuleName("World")]
     [RequiredCharacterState(CharacterState.Conscious)]
+    [HelpInfo("time", @"The #3time#0 command reports what your character can determine about the current time, season, visible celestial objects and local calendars. The precision of the date and time shown depends on the relevant checks, while visible timepieces may provide their own readings.
+
+Administrators can also inspect the current mud instant or preview the next occurrence of supported astronomical events for a celestial object.
+
+The syntax is:
+
+	#3time#0
+	#3time instant#0
+	#3time event <sunrise|sunset|newmoon|fullmoon> <celestial> [<occurrence>]#0
+	#3time event solarlongitude <celestial> <degrees> [<occurrence>]#0
+	#3time event visiblecrescent <sun> <moon> [<occurrence>]#0", AutoHelp.HelpArg)]
     protected static void Time(ICharacter actor, string input)
     {
         var command = new StringStack(input.RemoveFirstWord());

--- a/MudSharpCore/Commands/Modules/VehicleModule.Player.cs
+++ b/MudSharpCore/Commands/Modules/VehicleModule.Player.cs
@@ -53,7 +53,12 @@ Syntax:
 		actor.OutputHandler.Send($"You take control of {vehicle.Name.ColourName()}.");
 	}
 
-	private const string VehicleStatusHelp = @"Use #3vehiclestatus#0 to see the condition and movement readiness of the vehicle you are aboard, or #3vehiclestatus <vehicle>#0 to inspect a vehicle exterior in your location.";
+	private const string VehicleStatusHelp = @"The #3vehiclestatus#0 command reports a vehicle's condition and readiness to move. With no argument it inspects the vehicle you are aboard; name a vehicle to inspect an exterior vehicle in your current location. #3vehiclecheck#0 is an alias.
+
+The syntax is:
+
+	#3vehiclestatus#0
+	#3vehiclestatus <vehicle>#0";
 
 	[PlayerCommand("VehicleStatus", "vehiclestatus", "vehiclecheck")]
 	[HelpInfo("vehiclestatus", VehicleStatusHelp, AutoHelp.HelpArg)]

--- a/MudSharpCore/Commands/Modules/VehicleModule.Routes.cs
+++ b/MudSharpCore/Commands/Modules/VehicleModule.Routes.cs
@@ -486,7 +486,13 @@ Schedules use #3<reference departure> | <recurrence>#0. Recurrences accept forms
 		actor.OutputHandler.Send($"Journey #{journey.Id.ToString("N0", actor)} has been asked to resume from its durable checkpoint.");
 	}
 
-	private const string TransitHelp = @"Use #3transit departures [destination]#0 to see upcoming departures at your location, #3transit services [destination]#0 to browse enabled services, or #3transit status <service|vehicle>#0 for live journey status.";
+	private const string TransitHelp = @"The #3transit#0 command provides timetable and live-status information for configured transport services. Filter departures or services by a destination, or inspect a service or vehicle's active journey status.
+
+The syntax is:
+
+	#3transit departures [<destination>]#0
+	#3transit services [<destination>]#0
+	#3transit status <service|vehicle>#0";
 
 	[PlayerCommand("Transit", "transit")]
 	[RequiredCharacterState(CharacterState.Able)]

--- a/MudSharpCore/Commands/Modules/VehicleModule.cs
+++ b/MudSharpCore/Commands/Modules/VehicleModule.cs
@@ -159,7 +159,11 @@ Syntax:
 	[RequiredCharacterState(CharacterState.Able)]
 	[NoMovementCommand]
 	[NoHideCommand]
-	[HelpInfo("disembark", "Use #3disembark#0 to leave the vehicle you are currently aboard. A room-scale vehicle requires an open docking exit from your current compartment and places you in that docking's exterior cell.", AutoHelp.HelpArg)]
+	[HelpInfo("disembark", @"The #3disembark#0 command leaves the vehicle you are aboard. For a room-scale vehicle, you must use an open docking exit from your current compartment; you appear in that docking's exterior cell.
+
+	The syntax is:
+
+	#3disembark#0", AutoHelp.HelpArg)]
 	protected static void Disembark(ICharacter actor, string input)
 	{
 		var vehicle = actor.Gameworld.Vehicles.FirstOrDefault(x => x.IsOccupant(actor));
@@ -445,7 +449,12 @@ Use #3vehiclepropulsion <selfpowered|rowed|sail|outboard|engine|externallypulled
 	[NoHideCommand]
 	[NoCombatCommand]
 	[NoMovementCommand]
-	[HelpInfo("hitch", "Use #3hitch <towpoint>@<vehicle> <towpoint>@<target> [with <hitch item>]#0 to link vehicles for towing, or #3hitch <character> <character|towpoint@vehicle> [with <hitch item>]#0 to hitch a character or mount to pull something. Non-direct tow point types require compatible hitch gear or a legacy drag aid; direct hand/manual/pull-style points do not.", AutoHelp.HelpArgOrNoArg)]
+	[HelpInfo("hitch", @"The #3hitch#0 command connects compatible vehicle tow points, or connects a character or mount to a tow point. Non-direct tow points require suitable hitch gear; direct hand/manual/pull points do not.
+
+	The syntax is:
+
+	#3hitch <towpoint>@<vehicle> <towpoint>@<target> [with <hitch item>]#0
+	#3hitch <character> <character|towpoint>@<vehicle> [with <hitch item>]#0", AutoHelp.HelpArgOrNoArg)]
 	protected static void Hitch(ICharacter actor, string input)
 	{
 		var ss = new StringStack(input.RemoveFirstWord());
@@ -665,7 +674,13 @@ Use #3vehiclepropulsion <selfpowered|rowed|sail|outboard|engine|externallypulled
 	[NoHideCommand]
 	[NoCombatCommand]
 	[NoMovementCommand]
-	[HelpInfo("unhitch", "Use #3unhitch <vehicle>#0, #3unhitch <towpoint>@<vehicle>#0, or #3unhitch <character>#0 to remove tow or character hitches and release any reserved hitch gear.", AutoHelp.HelpArgOrNoArg)]
+	[HelpInfo("unhitch", @"The #3unhitch#0 command removes a vehicle tow or character hitch and releases any reserved hitch gear.
+
+	The syntax is:
+
+	#3unhitch <vehicle>#0
+	#3unhitch <towpoint>@<vehicle>#0
+	#3unhitch <character>#0", AutoHelp.HelpArgOrNoArg)]
 	protected static void Unhitch(ICharacter actor, string input)
 	{
 		var ss = new StringStack(input.RemoveFirstWord());


### PR DESCRIPTION
## Summary
- Adds CommandHelpInfo coverage for every PlayerCommand registration.
- Replaces the initially terse entries with parser-faithful, player-facing help.
- Aligns automatic help behavior with whether the command's no-argument form is valid.

## Validation
- Full temporary audit: 0 PlayerCommand registrations missing help.
- dotnet build MudSharpCore/MudSharpCore.csproj -c Debug --no-restore -m:1 -p:NoWarn=NU1902%3BNU1510 -p:UseSharedCompilation=false (0 warnings, 0 errors).
- Focused CommandHelpInfoTests: 8 passed.

No permanent audit tests were added.