### PR TITLE
Version update to 2.3.0

### DIFF
--- a/FutureMUD.Web/Content/PatchNotes/2026-08-03-engine-2-3-0.md
+++ b/FutureMUD.Web/Content/PatchNotes/2026-08-03-engine-2-3-0.md
@@ -1,0 +1,25 @@
+---
+title: FutureMUD Engine 2.3.0
+summary: Improves medical and prosthetic behavior, corrects free-hand handling, and expands vehicle and command documentation.
+date: 2026-08-03
+tags: engine, release, upgrade
+---
+**Upgrade note:** Apply the normal database upgrades before starting Engine 2.3.0. This release keeps the .NET 10 and MySQL 8.0 requirements and the Windows x64, Linux x64 and Linux ARM64 package set.
+
+## Medical And Body Mechanics
+
+- Improved prosthetic and mobility-aid behavior so functional replacements, crutches and affected bodyparts are handled consistently.
+- Fixed immobilising medical equipment so overlapping fracture coverage is preserved and removing or changing a wearable clears only the wounds it owns.
+- Improved medical equipment feedback and fixed blood-liquid persistence when the source race is unavailable.
+
+## Inventory And Combat Handling
+
+- Fixed free-hand and wielding-location checks for inventory-model bodies, including ranged weapons, instruments and ammunition handling.
+- Corrected stamina and readiness checks so a readied weapon accounts for the weapon's occupied hand locations rather than rejecting valid configurations.
+
+## Vehicle And Command Help
+
+- Expanded vehicle administration and prototype-building help with clearer lifecycle guidance, diagnostics, access management, recovery, movement profiles and related commands.
+- Added richer built-in help metadata across player, builder and staff commands. The generated command reference now exposes more complete syntax and workflow guidance at `/docs/commands`.
+
+See `/downloads` for release archives and checksums, `/getting-started` for installation requirements, and `/docs/commands` for the published Engine reference.

--- a/MudSharpCore/MudSharpCore.csproj
+++ b/MudSharpCore/MudSharpCore.csproj
@@ -10,9 +10,9 @@
 	<Product>FutureMUD</Product>
 	<ApplicationIcon>FM Logo.ico</ApplicationIcon>
 	<AssemblyName>MudSharp</AssemblyName>
-	<Version>2.2.0</Version>
-	<AssemblyVersion>2.2.0</AssemblyVersion>
-	<FileVersion>2.2.0</FileVersion>
+	<Version>2.3.0</Version>
+	<AssemblyVersion>2.3.0</AssemblyVersion>
+	<FileVersion>2.3.0</FileVersion>
   </PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
## Summary
- bump MudSharpCore `Version`, `AssemblyVersion`, and `FileVersion` to 2.3.0
- add the Engine 2.3.0 website patch note covering medical/body mechanics, free-hand handling, vehicle workflows, and command documentation
- refresh three stale Antiquity DatabaseSeeder source assertions to match the current shared craft-name helper and `ResolveTrait` access-prog generation

## Validation
- `scripts\\test-unit.ps1` — 3,278 tests passed across all fast suites
- `dotnet test DatabaseSeeder Unit Tests/DatabaseSeeder Unit Tests.csproj -c Release` — 613 passed
- Engine Release tests — 2,078 passed
- Website Release tests — 49 passed
- Linux x64 framework-dependent single-file publish with native-library bundling and untrimmed settings — passed
- documentation export at the release preparation commit — Engine 2.3.0; 591 commands, 562 FutureProg functions, 286 FutureProg types, 13 collection extensions, 213 item components

This PR is the release preparation for the exact `engine-v2.3.0` tag after merge.