### PR TITLE
Harden MudClient 1.0.0 for public release

### DIFF
--- a/.github/workflows/publish-products.yml
+++ b/.github/workflows/publish-products.yml
@@ -288,6 +288,12 @@ jobs:
         if: needs.prepare.outputs.package_kind == 'mudclient'
         shell: pwsh
         run: dotnet workload install wasm-tools
+      - name: Audit Web MUD Client dependencies
+        if: needs.prepare.outputs.package_kind == 'mudclient'
+        shell: pwsh
+        run: |
+          dotnet restore MudClient/MudClientSolution.sln -m:1 -p:RestoreBuildInParallel=false -p:NuGetAudit=true -p:NuGetAuditMode=all "-p:WarningsAsErrors=NU1900;NU1901;NU1902;NU1903;NU1904"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
       - name: Run targeted tests
         if: needs.prepare.outputs.tests != ''
         shell: pwsh

--- a/MudClient/DEPLOYMENT.md
+++ b/MudClient/DEPLOYMENT.md
@@ -47,7 +47,7 @@ Use `CADDY_CONFIG` and `CADDY_FRAGMENTS_DIR` for nonstandard Caddyfile locations
 
 ## Build A Release
 
-The production release is created by an annotated `mudclient-v<version>` tag in the FutureMUD repository. The normal product workflow runs the client tests, produces self-contained Windows x64, Linux x64, and Linux ARM64 packages, smoke-publishes them to a temporary website host, and promotes the validated archives to futuremud.com.
+The production release is created by an annotated `mudclient-v<version>` tag in the FutureMUD repository. The normal product workflow installs the WebAssembly build tools, fails closed if NuGet advisory data is unavailable or any direct/transitive dependency is vulnerable, runs the client tests, produces self-contained Windows x64, Linux x64, and Linux ARM64 packages, smoke-publishes them to a temporary website host, and promotes the validated archives to futuremud.com.
 
 You can also build a local package from a machine with the .NET 10 SDK. For optimized Blazor WebAssembly output, install the WebAssembly build tools once before publishing:
 
@@ -77,9 +77,19 @@ Edit `proxy/appsettings.json`:
   },
   "WebSocketServer": {
     "Path": "/ws",
+	"RequireOrigin": true,
     "AllowedOrigins": [
       "https://play.example.com"
     ]
+	},
+	"ProxyLimits": {
+	  "MaximumConcurrentConnections": 200,
+	  "MaximumConnectionsPerIp": 20,
+	  "MaximumClientMessageBytes": 65536,
+	  "MaximumClientMessagesPerSecond": 30,
+	  "MaximumClientBytesPerSecond": 131072,
+	  "MaximumMudBytesPerSecond": 2097152,
+	  "MudConnectionTimeoutSeconds": 10
   }
 }
 ```
@@ -87,6 +97,8 @@ Edit `proxy/appsettings.json`:
 Set `MudServer` to the telnet address and port as seen from the web server. For the intended same-server install, keep `127.0.0.1`.
 
 Set `AllowedOrigins` to the exact public web origin. Use `http://...` only for local testing; production should be `https://...`.
+
+Keep `RequireOrigin` enabled in production. It rejects originless WebSocket upgrades as well as browser origins not listed in `AllowedOrigins`. The proxy also applies global and per-address connection ceilings, a MUD connect timeout, a maximum client message size, per-connection client message/byte rates, and a generous MUD-to-browser output ceiling. The packaged defaults accommodate normal play and the client's paced multi-line sender; raise them only after reviewing the public-edge capacity and abuse implications.
 
 The Blazor client defaults to:
 
@@ -99,6 +111,12 @@ The Blazor client defaults to:
 ```
 
 That is the easiest production setup because the browser automatically turns it into `wss://your-site/ws` when the page is served over HTTPS.
+
+The supplied Caddy and Nginx examples restrict framing and browser capabilities, set a no-referrer policy, prevent content-type sniffing, and use a Content Security Policy compatible with Blazor WebAssembly and FutureMUD ANSI/MXP output. Preserve those headers when integrating the client into an existing site. The proxy should remain bound to loopback so only the trusted local reverse proxy can supply forwarded client addresses.
+
+Quick Login usernames and aliases are browser-local preferences. Passwords are deliberately held only in the current tab's memory and are removed from older saved settings when loaded. Let the browser or a password manager retain credentials instead of weakening this boundary.
+
+The client can load a UTF-8 text file of up to 1 MiB into the command box for review. It never sends a selected file automatically. Newline stacking then sends at the configured pace (100 ms by default), while Quick Login retains a separate 750 ms prompt-transition delay. The client and proxy both cap batch/message sizes and rates; these are safety controls, not substitutes for normal FutureMUD account and command permissions.
 
 ## Linux Service
 

--- a/MudClient/MudClientBlazor/Pages/Index.razor
+++ b/MudClient/MudClientBlazor/Pages/Index.razor
@@ -13,9 +13,9 @@
 	<div class="app-grid">
 		<div class="play-surface">
 			<div class="message-container" @ref="MessageContainer">
-				@foreach (var message in Messages)
+				@foreach (var message in _transcript.RenderedEntries)
 				{
-					<div>@(new MarkupString(message))</div>
+					<div @key="message.Id">@(new MarkupString(message.Html))</div>
 				}
 			</div>
 
@@ -77,11 +77,17 @@
 					  @bind="UserInput"
 					  @bind:event="oninput"
 					  @onkeydown="HandleKeyDown"
-					  @onkeydown:preventDefault="true"
 					  class="input-field"
 					  placeholder="Type a command..."
 					  autocomplete="off">
 			</textarea>
+			<div class="input-toolbar">
+				<label class="client-button secondary-button file-input-button">
+					Load text file
+					<InputFile OnChange="LoadTextFileAsync" accept=".txt,text/plain" />
+				</label>
+				<span class="input-help">Loads up to 1 MiB into the command box for review; it is not sent automatically.</span>
+			</div>
 		</div>
 
 		@if (_hotkeySettingsOpen)
@@ -178,6 +184,11 @@
 							<input type="checkbox" checked="@ClientSettingsDraft.NewlineCommandStackingEnabled" @onchange="args => UpdateNewlineCommandStacking(args.Value)" />
 							<span>Split pasted new lines into commands</span>
 						</label>
+						<label>
+							<span>Delay between stacked commands (ms)</span>
+							<input class="settings-input" type="number" min="50" max="2000" step="25" value="@ClientSettingsDraft.StackedCommandDelayMs" @oninput="args => UpdateStackedCommandDelay(args.Value?.ToString())" aria-label="Delay between stacked commands in milliseconds" />
+							<small>100 ms is responsive while still pacing FutureMUD input. Quick Login keeps its safer prompt delay.</small>
+						</label>
 					</div>
 				</div>
 
@@ -206,6 +217,7 @@
 								   value="@QuickAliasDraft.Login.Password"
 								   @oninput="args => UpdateLoginPassword(args.Value?.ToString())"
 								   aria-label="Login password" />
+							<small>Kept only in this tab's memory and never saved to browser storage.</small>
 						</label>
 					</div>
 				</div>
@@ -307,6 +319,11 @@
 			</div>
 
 			<div class="button-container">
+				@if (_isSendingBatch)
+				{
+					<span class="batch-progress" role="status">@_batchProgressText</span>
+					<button type="button" class="client-button secondary-button" @onclick="CancelCommandBatch">Cancel Batch</button>
+				}
 				<button type="button" class="client-button primary-button" @onclick="ToggleConnection">@connectionButtonText</button>
 				<button type="button" class="client-button secondary-button" @onclick="SaveLog">Save Log</button>
 				<button type="button" class="client-button secondary-button" @onclick="ToggleHotkeySettings">Settings</button>
@@ -319,8 +336,12 @@
 	private const string HotkeyStorageKey = "MudClientBlazor.HotkeySettings.v1";
 	private const string QuickAliasStorageKey = "MudClientBlazor.QuickAliasSettings.v1";
 	private const string ClientSettingsStorageKey = "MudClientBlazor.ClientSettings.v1";
+	private const long MaximumTextFileBytes = 1_048_576;
+	private const int MaximumCommandsPerBatch = 5_000;
+	private const int MaximumCommandBytes = 16_384;
+	private const int MaximumWebSocketMessageBytes = 262_144;
+	private const int MaximumPendingServerCharacters = 1_000_000;
 	private static readonly TimeSpan LoginAliasStepDelay = TimeSpan.FromMilliseconds(750);
-	private static readonly TimeSpan StackedCommandDelay = TimeSpan.FromMilliseconds(750);
 	private static readonly JsonSerializerOptions HotkeyJsonOptions = new(JsonSerializerDefaults.Web)
 	{
 		WriteIndented = true
@@ -384,11 +405,17 @@
 		};
 
 	private string UserInput { get; set; } = string.Empty;
-	private List<string> Messages { get; set; } = new List<string>();
+	private readonly ClientTranscript _transcript = new();
 	private ClientWebSocket? _clientWebSocket;
-	private CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+	private CancellationTokenSource _cancellationTokenSource = new();
+	private CancellationTokenSource? _batchCancellationTokenSource;
+	private readonly SemaphoreSlim _sendSemaphore = new(1, 1);
+	private readonly SemaphoreSlim _commandSequenceSemaphore = new(1, 1);
+	private readonly TelnetStreamParser _telnetStreamParser = new();
+	private readonly Decoder _utf8Decoder = new UTF8Encoding(false, false).GetDecoder();
+	private readonly StringBuilder _pendingServerText = new();
 	private ElementReference MessageContainer;
-	private List<string> CommandHistory { get; set; } = new List<string>();
+	private List<string> CommandHistory { get; set; } = new();
 	private int CommandHistoryIndex { get; set; } = -1;
 	private AnsiMxpParser _ansiMxpParser = new AnsiMxpParser();
 	private Uri? _webSocketEndpoint;
@@ -403,6 +430,8 @@
 	private IReadOnlyList<string> ClientSettingsDraftErrors { get; set; } = [];
 	private string? HotkeySettingsError { get; set; }
 	private bool _hotkeySettingsOpen;
+	private bool _isSendingBatch;
+	private string _batchProgressText = string.Empty;
 
 
 	// Declare the object reference
@@ -422,6 +451,7 @@
 		// Pass the object reference to JavaScript
 		await JSRuntime.InvokeVoidAsync("registerSendCommandHandler", _objectReference);
 		await JSRuntime.InvokeVoidAsync("mudClientHotkeys.register", _objectReference);
+		await JSRuntime.InvokeVoidAsync("mudClientInput.register", "userInput");
 		await LoadClientSettingsAsync();
 		await LoadHotkeySettingsAsync();
 		await LoadQuickAliasSettingsAsync();
@@ -432,7 +462,7 @@
 		}
 		catch (Exception ex)
 		{
-			Messages.Add($"Client configuration error: {EscapeHtml(GetDetailedExceptionMessage(ex))}");
+			AddMessage($"Client configuration error: {EscapeHtml(GetDetailedExceptionMessage(ex))}");
 			isConnected = false;
 			return;
 		}
@@ -478,7 +508,7 @@
 		catch (Exception ex)
 		{
 			Logger.LogWarning(ex, "Unable to load client settings.");
-			Messages.Add("Could not load saved client settings; using defaults.");
+			AddMessage("Could not load saved client settings; using defaults.");
 		}
 
 		ApplyClientSettings(settings);
@@ -500,7 +530,7 @@
 		catch (Exception ex)
 		{
 			Logger.LogWarning(ex, "Unable to load hotkey settings.");
-			Messages.Add("Could not load saved hotkey settings; using defaults.");
+			AddMessage("Could not load saved hotkey settings; using defaults.");
 		}
 
 		ApplyHotkeySettings(settings);
@@ -517,13 +547,25 @@
 			if (!string.IsNullOrWhiteSpace(json))
 			{
 				var savedSettings = JsonSerializer.Deserialize<QuickAliasSettings>(json, HotkeyJsonOptions);
+				var hadPersistedPassword = !string.IsNullOrEmpty(savedSettings?.Login?.Password);
+				if (savedSettings?.Login != null)
+				{
+					savedSettings.Login.Password = string.Empty;
+				}
+
 				settings = QuickAliasSettings.Normalize(savedSettings);
+				if (hadPersistedPassword)
+				{
+					var sanitizedJson = JsonSerializer.Serialize(QuickAliasSettings.CreatePersistentCopy(settings), HotkeyJsonOptions);
+					await JSRuntime.InvokeVoidAsync("localStorage.setItem", QuickAliasStorageKey, sanitizedJson);
+					AddMessage("A previously saved Quick Login password was removed from browser storage.");
+				}
 			}
 		}
 		catch (Exception ex)
 		{
 			Logger.LogWarning(ex, "Unable to load quick alias settings.");
-			Messages.Add("Could not load saved quick alias settings; using defaults.");
+			AddMessage("Could not load saved quick alias settings; using defaults.");
 		}
 
 		ApplyQuickAliasSettings(settings);
@@ -574,7 +616,7 @@
 		{
 			var json = JsonSerializer.Serialize(settings, HotkeyJsonOptions);
 			await JSRuntime.InvokeVoidAsync("localStorage.setItem", HotkeyStorageKey, json);
-			var quickAliasJson = JsonSerializer.Serialize(quickAliasSettings, HotkeyJsonOptions);
+			var quickAliasJson = JsonSerializer.Serialize(QuickAliasSettings.CreatePersistentCopy(quickAliasSettings), HotkeyJsonOptions);
 			await JSRuntime.InvokeVoidAsync("localStorage.setItem", QuickAliasStorageKey, quickAliasJson);
 			var clientSettingsJson = JsonSerializer.Serialize(clientSettings, HotkeyJsonOptions);
 			await JSRuntime.InvokeVoidAsync("localStorage.setItem", ClientSettingsStorageKey, clientSettingsJson);
@@ -714,6 +756,16 @@
 		ClientSettingsDraft.NewlineCommandStackingEnabled = value is bool enabled && enabled;
 	}
 
+	private void UpdateStackedCommandDelay(string? value)
+	{
+		if (int.TryParse(value, out var parsed))
+		{
+			ClientSettingsDraft.StackedCommandDelayMs = parsed;
+		}
+
+		ValidateClientSettingsDraft();
+	}
+
 	private void UpdateDraftEnabled(HotkeyBinding binding, object? value)
 	{
 		binding.IsEnabled = value is bool enabled && enabled;
@@ -827,11 +879,15 @@
 
 			foreach (var step in LoginAliasCommandSequence.Build(CurrentQuickAliasSettings.Login))
 			{
-				await SendSingleCommandAsync(
+				var completed = await SendSingleCommandAsync(
 					step.Command,
 					step.EchoCommand,
 					step.LogCommandText,
 					step.AddToHistory);
+				if (!completed)
+				{
+					break;
+				}
 
 				if (step.DelayAfterCommand)
 				{
@@ -991,11 +1047,6 @@
 			"AltLeft" or "AltRight" or "MetaLeft" or "MetaRight";
 	}
 
-	private static bool HasHotkeyModifier(KeyboardEventArgs args)
-	{
-		return args.CtrlKey || args.AltKey || args.MetaKey || args.ShiftKey;
-	}
-
 	private async Task<bool> ConnectToWebSocketAsync(Uri endpoint)
 	{
 		if (_clientWebSocket?.State == WebSocketState.Open)
@@ -1005,18 +1056,21 @@
 
 		try
 		{
+			_clientWebSocket?.Dispose();
 			_clientWebSocket = new ClientWebSocket();
+			_telnetStreamParser.Reset();
+			_utf8Decoder.Reset();
+			_pendingServerText.Clear();
 			await _clientWebSocket.ConnectAsync(endpoint, _cancellationTokenSource.Token);
 			isConnected = true;
-			Messages.Add($"Connected to WebSocket proxy at {EscapeHtml(endpoint.ToString())}.");
-			Console.WriteLine($"Connected to WebSocket proxy at {endpoint}");
+			AddMessage($"Connected to WebSocket proxy at {EscapeHtml(endpoint.ToString())}.");
 			_ = ReceiveMessagesAsync(_clientWebSocket);
 			return true;
 		}
 		catch (Exception ex)
 		{
 			isConnected = false;
-			Messages.Add(
+			AddMessage(
 				$"Error connecting to WebSocket proxy at {EscapeHtml(endpoint.ToString())}: {EscapeHtml(GetDetailedExceptionMessage(ex))}. " +
 				"Make sure MudWebSocketProxy is running and listening on that endpoint.");
 			return false;
@@ -1025,23 +1079,48 @@
 
 	private async Task ReceiveMessagesAsync(ClientWebSocket webSocket)
 	{
-		var buffer = new byte[40960];
+		var buffer = new byte[40_960];
 
 		while (webSocket.State == WebSocketState.Open)
 		{
 			try
 			{
-				var result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), _cancellationTokenSource.Token);
-				if (result.MessageType == WebSocketMessageType.Close)
+				using var message = new MemoryStream();
+				WebSocketReceiveResult result;
+				do
 				{
-					Messages.Add("<font color='yellow'>The MUD has disconnected.</font>");
-					isConnected = false;
-					await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", CancellationToken.None);
-					await InvokeAsync(StateHasChanged);
-					break;
+					result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), _cancellationTokenSource.Token);
+					if (result.MessageType == WebSocketMessageType.Close)
+					{
+						await FlushPendingServerTextAsync();
+						AddMessage("<span style=\"color:yellow\">The MUD has disconnected.</span>");
+						isConnected = false;
+						await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", CancellationToken.None);
+						await InvokeAsync(StateHasChanged);
+						return;
+					}
+
+					if (message.Length + result.Count > MaximumWebSocketMessageBytes)
+					{
+						await webSocket.CloseAsync(WebSocketCloseStatus.MessageTooBig, "Proxy message is too large", CancellationToken.None);
+						AddMessage("The proxy sent an oversized message and the connection was closed.");
+						isConnected = false;
+						return;
+					}
+
+					message.Write(buffer, 0, result.Count);
 				}
-				Logger.LogInformation("Received telnet message.");
-				await ProcessReceivedData(buffer, result.Count);
+				while (!result.EndOfMessage);
+
+				var payload = message.ToArray();
+				if (result.MessageType == WebSocketMessageType.Text)
+				{
+					AddMessage(EscapeHtml(Encoding.UTF8.GetString(payload)));
+					await InvokeAsync(StateHasChanged);
+					continue;
+				}
+
+				await ProcessReceivedData(payload);
 			}
 			catch (Exception ex)
 			{
@@ -1051,138 +1130,70 @@
 				}
 
 				isConnected = false;
-				Messages.Add($"Error receiving message from WebSocket proxy: {EscapeHtml(GetDetailedExceptionMessage(ex))}");
+				AddMessage($"Error receiving message from WebSocket proxy: {EscapeHtml(GetDetailedExceptionMessage(ex))}");
+				await InvokeAsync(StateHasChanged);
 				break;
 			}
 		}
 	}
 
-	private async Task ProcessReceivedData(byte[] data, int length)
+	private async Task ProcessReceivedData(byte[] data)
 	{
-		Logger.LogInformation("Inside process receive data.");
-		int index = 0;
-		var outputBuffer = new List<byte>();
-
-		while (index < length)
+		var reachedRecordBoundary = false;
+		foreach (var telnetEvent in _telnetStreamParser.Feed(data))
 		{
-			byte b = data[index];
-
-			if (b == TelnetConstants.IAC)
+			switch (telnetEvent)
 			{
-				Logger.LogInformation("Received an IAC byte");
-				if (index + 1 < length && data[index + 1] == TelnetConstants.IAC)
+				case TelnetDataEvent dataEvent:
 				{
-					// Escaped IAC byte
-					outputBuffer.Add(TelnetConstants.IAC);
-					index += 2;
+					var characterCount = _utf8Decoder.GetCharCount(dataEvent.Data, 0, dataEvent.Data.Length, false);
+					var characters = new char[characterCount];
+					_utf8Decoder.GetChars(dataEvent.Data, 0, dataEvent.Data.Length, characters, 0, false);
+					_pendingServerText.Append(characters);
+					if (_pendingServerText.Length > MaximumPendingServerCharacters)
+					{
+						throw new InvalidDataException("MUD output exceeded the client record limit before a Telnet prompt boundary.");
+					}
+					break;
 				}
-				else
+				case TelnetNegotiationEvent negotiationEvent:
 				{
-					// Telnet command
-					int commandLength = await HandleTelnetCommandAsync(data, index, length);
-					index += commandLength;
+					await HandleTelnetNegotiationAsync(negotiationEvent.Command, negotiationEvent.Option);
+					break;
 				}
-			}
-			else
-			{
-				// Regular data, add to output buffer
-				outputBuffer.Add(b);
-				index++;
+				case TelnetSubnegotiationEvent subnegotiationEvent:
+					await HandleTelnetSubnegotiationAsync(subnegotiationEvent.Option, subnegotiationEvent.Data);
+					break;
+				case TelnetCommandEvent commandEvent:
+					HandleTelnetCommand(commandEvent.Command);
+					reachedRecordBoundary |= commandEvent.Command is TelnetConstants.GA or TelnetConstants.EOR;
+					break;
 			}
 		}
 
-		// Convert output buffer to string and process ANSI/ MXP
-		if (outputBuffer.Count > 0)
+		if (reachedRecordBoundary)
 		{
-			string message = Encoding.UTF8.GetString(outputBuffer.ToArray());
-			string parsedMessage = _ansiMxpParser.Parse(message);
-			if (string.IsNullOrWhiteSpace(parsedMessage))
-			{
-				return;
-			}
-			Messages.Add(parsedMessage);
-
-			// Invoke StateHasChanged to update the UI
-			await InvokeAsync(StateHasChanged);
-
-			// Wait for the UI to finish rendering
-			await InvokeAsync(() => { });
-
-			// Scroll to bottom using JavaScript Interop
-			await JSRuntime.InvokeVoidAsync("scrollToBottom", MessageContainer);
+			await FlushPendingServerTextAsync();
 		}
 	}
 
-	private async Task<int> HandleTelnetCommandAsync(byte[] data, int startIndex, int length)
+	private async Task FlushPendingServerTextAsync()
 	{
-		int index = startIndex;
-
-		if (index + 1 >= length)
+		if (_pendingServerText.Length == 0)
 		{
-			Logger.LogInformation("Incomplete telnet command received.");
-			return 1;
+			return;
 		}
 
-		byte command = data[index + 1];
-
-		if (command == TelnetConstants.IAC)
+		var parsedMessage = _ansiMxpParser.Parse(_pendingServerText.ToString());
+		_pendingServerText.Clear();
+		if (string.IsNullOrWhiteSpace(parsedMessage))
 		{
-			Logger.LogInformation("Escaped IAC byte detected.");
-			// This is an escaped IAC byte (255), should be treated as data
-			// We'll handle it in ProcessReceivedData by adding a single IAC byte
-			return 2;
+			return;
 		}
 
-		// Handle Telnet command
-		switch (command)
-		{
-			case TelnetConstants.WILL:
-			case TelnetConstants.WONT:
-			case TelnetConstants.DO:
-			case TelnetConstants.DONT:
-				if (index + 2 >= length)
-				{
-					Logger.LogInformation("Incomplete telnet negotiation command received.");
-					// Not enough data
-					return 1;
-				}
-				byte option = data[index + 2];
-				Logger.LogInformation($"Telnet negotiation command received: Command={command}, Option={option}");
-				await HandleTelnetNegotiationAsync(command, option);
-				return 3;
-
-			case TelnetConstants.SB:
-				// Handle subnegotiation
-				int endIndex = FindSubnegotiationEnd(data, index + 2, length);
-				if (endIndex == -1)
-				{
-					// SE not found, incomplete subnegotiation
-					Logger.LogInformation("Incomplete telnet subnegotiation received.");
-					return length - index;
-				}
-				var subnegotiationData = data.Skip(index + 2).Take(endIndex - (index + 2)).ToArray();
-				Logger.LogInformation($"Telnet subnegotiation received: Option={data[index + 2]}, Length={subnegotiationData.Length}");
-				await HandleTelnetSubnegotiationAsync(subnegotiationData);
-				return (endIndex - index) + 2; // +2 for IAC SE
-
-			default:
-				// Other commands like IAC GA or IAC EOR
-				Logger.LogInformation($"Telnet command received: Command={command}");
-				HandleTelnetCommand(command);
-				return 2;
-		}
-	}
-
-	private int FindSubnegotiationEnd(byte[] data, int startIndex, int length)
-	{
-		for (int i = startIndex; i < length - 1; i++)
-		{
-			if (data[i] == TelnetConstants.IAC && data[i + 1] == TelnetConstants.SE)
-			{
-				return i;
-			}
-		}
-		return -1; // Not found
+		AddMessage(parsedMessage);
+		await InvokeAsync(StateHasChanged);
+		await JSRuntime.InvokeVoidAsync("scrollToBottomIfNearBottom", MessageContainer);
 	}
 
 	private async Task HandleTelnetNegotiationAsync(byte command, byte option)
@@ -1192,31 +1203,33 @@
 			case TelnetConstants.TELOPT_CHARSET:
 				if (command == TelnetConstants.DO)
 				{
-					// Server asks us to enable CHARSET
 					await SendTelnetCommandAsync(TelnetConstants.WILL, TelnetConstants.TELOPT_CHARSET);
 				}
 				else if (command == TelnetConstants.WILL)
 				{
-					// Server will enable CHARSET
-					// Initiate subnegotiation to request UTF-8
-					await SendCharsetSubnegotiationAsync();
-				}
-				else if (command == TelnetConstants.DONT || command == TelnetConstants.WONT)
-				{
-					// Server refuses CHARSET, handle accordingly
+					await SendTelnetCommandAsync(TelnetConstants.DO, TelnetConstants.TELOPT_CHARSET);
 				}
 				break;
 
 			case TelnetConstants.TELOPT_MXP:
 				if (command == TelnetConstants.WILL)
 				{
-					// Server is offering MXP (IAC WILL TELOPT_MXP)
-					// We respond with IAC DO TELOPT_MXP
 					await SendTelnetCommandAsync(TelnetConstants.DO, TelnetConstants.TELOPT_MXP);
 				}
-				else if (command == TelnetConstants.DONT || command == TelnetConstants.WONT)
+				else if (command == TelnetConstants.DO)
 				{
-					// Server refuses MXP, handle accordingly
+					await SendTelnetCommandAsync(TelnetConstants.WILL, TelnetConstants.TELOPT_MXP);
+				}
+				break;
+
+			case TelnetConstants.TELOPT_EOR:
+				if (command == TelnetConstants.WILL)
+				{
+					await SendTelnetCommandAsync(TelnetConstants.DO, TelnetConstants.TELOPT_EOR);
+				}
+				else if (command == TelnetConstants.DO)
+				{
+					await SendTelnetCommandAsync(TelnetConstants.WILL, TelnetConstants.TELOPT_EOR);
 				}
 				break;
 
@@ -1236,66 +1249,48 @@
 		}
 	}
 
-	private async Task HandleTelnetSubnegotiationAsync(byte[] data)
+	private async Task HandleTelnetSubnegotiationAsync(byte option, byte[] data)
 	{
-		if (data == null || data.Length == 0)
-			return;
-
-		byte option = data[0];
-
 		switch (option)
 		{
 			case TelnetConstants.TELOPT_CHARSET:
-				await HandleCharsetSubnegotiationAsync(data.Skip(1).ToArray());
+				await HandleCharsetSubnegotiationAsync(data);
 				break;
 			case TelnetConstants.TELOPT_MXP:
 				// Server has initiated MXP subnegotiation
 				// We need to send the MXP initialization string
 				await SendMxpInitializationAsync();
 				break;
-			// Handle other subnegotiations if needed
-
 			default:
-				// Ignore unsupported subnegotiations
 				break;
 		}
 	}
 
 	private async Task SendMxpInitializationAsync()
 	{
-		// Send the MXP initialization string
 		string mxpInitString = "\x1B[1z<SUPPORTS +i +color +font +b +strong +ul +a +send +em +underline +u +italic>";
-
-		// Convert the string to bytes using the appropriate encoding
-		byte[] data = Encoding.UTF8.GetBytes(mxpInitString).Concat(new byte[] { 255, 239 });
+		byte[] data = Encoding.UTF8.GetBytes(mxpInitString).Concat([TelnetConstants.IAC, TelnetConstants.EOR]);
 
 		await SendBytesAsync(data);
 	}
 
 	private async Task HandleCharsetSubnegotiationAsync(byte[] data)
 	{
-		if (data.Length > 0)
+		if (data.Length < 3 || data[0] != 1)
 		{
-			byte command = data[0];
+			return;
+		}
 
-			if (command == 1) // CHARSET REQUEST
-			{
-				// Extract the list of supported charsets
-				var charsetList = Encoding.ASCII.GetString(data, 1, data.Length - 1);
-				var charsets = charsetList.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-
-				// Check if UTF-8 is supported
-				if (charsets.Contains("UTF-8", StringComparer.OrdinalIgnoreCase))
-				{
-					// Send CHARSET ACCEPT UTF-8
-					await SendCharsetAcceptAsync("UTF-8");
-				}
-				else
-				{
-					// Send CHARSET REJECT
-					await SendCharsetRejectAsync();
-				}
-			}
+		var separator = (char)data[1];
+		var charsetList = Encoding.ASCII.GetString(data, 2, data.Length - 2);
+		var charsets = charsetList.Split(separator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+		if (charsets.Contains("UTF-8", StringComparer.OrdinalIgnoreCase))
+		{
+			await SendCharsetAcceptAsync("UTF-8");
+		}
+		else
+		{
+			await SendCharsetRejectAsync();
 		}
 	}
 
@@ -1303,25 +1298,6 @@
 	{
 		var commandBytes = new byte[] { TelnetConstants.IAC, command, option };
 		await SendBytesAsync(commandBytes);
-	}
-
-	private async Task SendCharsetSubnegotiationAsync()
-	{
-		// Send IAC SB CHARSET REQUEST IAC SE
-		var data = new List<byte>
-		{
-			TelnetConstants.IAC,
-			TelnetConstants.SB,
-			TelnetConstants.TELOPT_CHARSET,
-			1  // CHARSET REQUEST
-		};
-		// List of charsets we support
-		string supportedCharsets = "UTF-8";
-		data.AddRange(Encoding.ASCII.GetBytes(supportedCharsets));
-		data.Add(TelnetConstants.IAC);
-		data.Add(TelnetConstants.SE);
-
-		await SendBytesAsync(data.ToArray());
 	}
 
 	private async Task SendCharsetAcceptAsync(string charset)
@@ -1379,28 +1355,43 @@
 
 	private async Task SendBytesAsync(byte[] data)
 	{
-		if (_clientWebSocket?.State == WebSocketState.Open)
+		await SendFrameAsync(data, _cancellationTokenSource.Token);
+	}
+
+	private async Task SendFrameAsync(byte[] data, CancellationToken cancellationToken)
+	{
+		await _sendSemaphore.WaitAsync(cancellationToken);
+		try
 		{
-			await _clientWebSocket.SendAsync(new ArraySegment<byte>(data), WebSocketMessageType.Binary, true, _cancellationTokenSource.Token);
+			if (_clientWebSocket?.State != WebSocketState.Open)
+			{
+				throw new WebSocketException("The WebSocket proxy connection is not open.");
+			}
+
+			await _clientWebSocket.SendAsync(new ArraySegment<byte>(data), WebSocketMessageType.Binary, true, cancellationToken);
+		}
+		finally
+		{
+			_sendSemaphore.Release();
 		}
 	}
 
 
-	private async Task SendMessageAsync(string inputMessage)
+	private async Task<bool> SendMessageAsync(string inputMessage)
 	{
-		await SendMessageAsync(inputMessage, echoCommand: true, logCommandText: true, addToHistory: true, splitCommands: true);
+		return await SendMessageAsync(inputMessage, echoCommand: true, logCommandText: true, addToHistory: true, splitCommands: true);
 	}
 
-	private async Task SendSingleCommandAsync(
+	private async Task<bool> SendSingleCommandAsync(
 		string inputMessage,
 		bool echoCommand,
 		bool logCommandText,
 		bool addToHistory)
 	{
-		await SendMessageAsync(inputMessage, echoCommand, logCommandText, addToHistory, splitCommands: false);
+		return await SendMessageAsync(inputMessage, echoCommand, logCommandText, addToHistory, splitCommands: false);
 	}
 
-	private async Task SendMessageAsync(
+	private async Task<bool> SendMessageAsync(
 		string inputMessage,
 		bool echoCommand,
 		bool logCommandText,
@@ -1409,9 +1400,9 @@
 	{
 		if (_clientWebSocket?.State != WebSocketState.Open)
 		{
-			Messages.Add("Not connected to the MUD. Start MudWebSocketProxy and use Reconnect.");
+			AddMessage("Not connected to the MUD. Start MudWebSocketProxy and use Reconnect.");
 			await InvokeAsync(StateHasChanged);
-			return;
+			return false;
 		}
 
 		if (addToHistory)
@@ -1420,59 +1411,115 @@
 		}
 
 		var commands = splitCommands ? CommandSplitter.Split(inputMessage, CurrentClientSettings) : [inputMessage];
-
-		for (var commandIndex = 0; commandIndex < commands.Count; commandIndex++)
+		if (commands.Count == 0)
 		{
-			var command = commands[commandIndex];
-			if (logCommandText)
+			commands = [string.Empty];
+		}
+
+		if (commands.Count > MaximumCommandsPerBatch)
+		{
+			AddMessage($"That input contains {commands.Count:N0} commands; the client limit is {MaximumCommandsPerBatch:N0} per batch.");
+			await InvokeAsync(StateHasChanged);
+			return false;
+		}
+
+		var isBatch = commands.Count > 1;
+		using var batchCancellation = isBatch
+			? CancellationTokenSource.CreateLinkedTokenSource(_cancellationTokenSource.Token)
+			: null;
+		var cancellationToken = batchCancellation?.Token ?? _cancellationTokenSource.Token;
+		var completed = true;
+
+		await _commandSequenceSemaphore.WaitAsync(cancellationToken);
+		try
+		{
+			if (isBatch)
 			{
-				Logger.LogInformation("Sending Command: {Command}", command);
-			}
-			else
-			{
-				Logger.LogInformation("Sending sensitive command.");
+				_batchCancellationTokenSource = batchCancellation;
+				_isSendingBatch = true;
 			}
 
-			if (string.IsNullOrWhiteSpace(command))
+			for (var commandIndex = 0; commandIndex < commands.Count; commandIndex++)
 			{
-				await _clientWebSocket.SendAsync(new ArraySegment<byte>([13, 255, 239]), WebSocketMessageType.Binary, true, _cancellationTokenSource.Token);
-				continue;
-			}
+				cancellationToken.ThrowIfCancellationRequested();
+				var command = commands[commandIndex];
+				var commandBytes = Encoding.UTF8.GetBytes(command);
+				if (commandBytes.Length > MaximumCommandBytes)
+				{
+					AddMessage($"Command {commandIndex + 1:N0} is larger than the {MaximumCommandBytes / 1024:N0} KiB client limit; the batch was stopped.");
+					completed = false;
+					break;
+				}
 
-			if (echoCommand)
-			{
-				string formattedCommand = $"\x1B[33m{EscapeHtml(command)}\x1B[0m";
-				Messages.Add(_ansiMxpParser.Parse(formattedCommand));
-			}
-			
+				if (logCommandText)
+				{
+					Logger.LogInformation("Sending command with {ByteCount} UTF-8 bytes.", commandBytes.Length);
+				}
+				else
+				{
+					Logger.LogInformation("Sending sensitive command.");
+				}
 
-			// Send the command to the server
-			var bytes = Encoding.UTF8.GetBytes(command).Concat(new byte[] { 13, 255, 239 });
-			await _clientWebSocket.SendAsync(new ArraySegment<byte>(bytes), WebSocketMessageType.Binary, true, _cancellationTokenSource.Token);
-			if (logCommandText)
-			{
-				Logger.LogInformation("Sent Command: {Command}", command);
-			}
-			else
-			{
-				Logger.LogInformation("Sent sensitive command.");
-			}
+				if (echoCommand && !string.IsNullOrWhiteSpace(command))
+				{
+					AddMessage(_ansiMxpParser.Parse($"\x1B[33m{command}\x1B[0m"));
+				}
 
-			// Give prompt-driven commands, especially login steps, time to advance before sending the next command.
-			if (commandIndex < commands.Count - 1)
-			{
-				await Task.Delay(StackedCommandDelay);
+				var payload = commandBytes.Concat(new byte[] { 13, TelnetConstants.IAC, TelnetConstants.EOR }).ToArray();
+				await SendFrameAsync(payload, cancellationToken);
+
+				if (isBatch)
+				{
+					_batchProgressText = $"Sending {commandIndex + 1:N0} of {commands.Count:N0}";
+					if (commandIndex % 10 == 0 || commandIndex == commands.Count - 1)
+					{
+						await InvokeAsync(StateHasChanged);
+					}
+				}
+
+				if (commandIndex < commands.Count - 1)
+				{
+					await Task.Delay(CurrentClientSettings.StackedCommandDelayMs, cancellationToken);
+				}
 			}
 		}
-		
-		// Invoke StateHasChanged to update the UI
+		catch (OperationCanceledException) when (isBatch && batchCancellation?.IsCancellationRequested == true)
+		{
+			completed = false;
+			AddMessage("Stacked command batch cancelled.");
+		}
+		catch (Exception ex) when (ex is WebSocketException or ObjectDisposedException or InvalidOperationException)
+		{
+			completed = false;
+			isConnected = false;
+			Logger.LogWarning(ex, "Command sending stopped because the proxy connection closed.");
+			AddMessage("Command sending stopped because the proxy connection closed.");
+		}
+		finally
+		{
+			if (isBatch)
+			{
+				_batchCancellationTokenSource = null;
+				_isSendingBatch = false;
+				_batchProgressText = string.Empty;
+			}
+
+			_commandSequenceSemaphore.Release();
+		}
+
 		await InvokeAsync(StateHasChanged);
+		await JSRuntime.InvokeVoidAsync("scrollToBottomIfNearBottom", MessageContainer);
+		return completed;
+	}
 
-		// Wait for the UI to finish rendering
-		await InvokeAsync(() => { });
+	private void CancelCommandBatch()
+	{
+		_batchCancellationTokenSource?.Cancel();
+	}
 
-		// Scroll to bottom using JavaScript Interop
-		await JSRuntime.InvokeVoidAsync("scrollToBottom", MessageContainer);
+	private void AddMessage(string html)
+	{
+		_transcript.Add(html);
 	}
 
 	private void AddToCommandHistory(string input)
@@ -1516,213 +1563,113 @@
 		return string.Join(" ", messages);
 	}
 
-	private async Task HandleKeyPress(KeyboardEventArgs e)
-	{
-		// Get the character corresponding to the key
-		string inputChar = e.Key;
-
-		// Handle special cases if necessary
-		if (e.Key == "Enter" || e.Key == "Tab")
-			return;
-
-		int selectionStart = await JSRuntime.InvokeAsync<int>("getSelectionStart", "userInput");
-		int selectionEnd = await JSRuntime.InvokeAsync<int>("getSelectionEnd", "userInput");
-
-		// Insert the character at the cursor position
-		UserInput = UserInput.Remove(selectionStart, selectionEnd - selectionStart)
-							 .Insert(selectionStart, inputChar);
-
-		await InvokeAsync(StateHasChanged);
-
-		// Move cursor position after the inserted character
-		await JSRuntime.InvokeVoidAsync("setSelectionRange", "userInput", selectionStart + inputChar.Length);
-	}
-
 	private async Task HandleKeyDown(KeyboardEventArgs e)
 	{
-		if (!_hotkeySettingsOpen &&
-		    !HasHotkeyModifier(e) &&
-		    HotkeyInputPolicy.ShouldSendHotkeyFromEditableField(e.Code, e.Key) &&
-		    HotkeyMap.TryGetCommand(e.Code, out var hotkeyCommand))
+		if (e.Key == "Enter" && !e.ShiftKey)
 		{
-			await SendMessageAsync(hotkeyCommand);
+			var completed = await SendMessageAsync(UserInput);
+			if (!completed)
+			{
+				return;
+			}
+			if (CurrentClientSettings.ClearInputAfterSend)
+			{
+				UserInput = string.Empty;
+			}
+			else
+			{
+				await JSRuntime.InvokeVoidAsync("setSelectionRange", "userInput", 0, UserInput.Length);
+			}
+
+			CommandHistoryIndex = CommandHistory.Count;
 			return;
 		}
 
-		int selectionStart = await JSRuntime.InvokeAsync<int>("getSelectionStart", "userInput");
-		int selectionEnd = await JSRuntime.InvokeAsync<int>("getSelectionEnd", "userInput");
+		if (e.Key == "ArrowUp")
+		{
+			if (e.CtrlKey && CommandHistory.Count > 0)
+			{
+				CommandHistoryIndex = 0;
+				UserInput = CommandHistory[CommandHistoryIndex];
+			}
+			else if (CommandHistory.Count > 0 && CommandHistoryIndex > 0)
+			{
+				CommandHistoryIndex--;
+				UserInput = CommandHistory[CommandHistoryIndex];
+			}
 
-		if (e.Key == "Enter")
-		{
-			if (e.ShiftKey)
-			{
-				// Insert a newline at the cursor position
-				UserInput = UserInput.Remove(selectionStart, selectionEnd - selectionStart)
-										.Insert(selectionStart, "\n");
-				await JSRuntime.InvokeVoidAsync("setSelectionRange", "userInput", selectionStart + 1);
-			}
-			else
-			{
-				// Send the message
-				await SendMessageAsync(UserInput);
-				if (CurrentClientSettings.ClearInputAfterSend)
-				{
-					UserInput = string.Empty;
-				}
-				else
-				{
-					await JSRuntime.InvokeVoidAsync("setSelectionRange", "userInput", 0, UserInput.Length);
-				}
-				CommandHistoryIndex = CommandHistory.Count;
-			}
+			await InvokeAsync(StateHasChanged);
+			await JSRuntime.InvokeVoidAsync("setSelectionRange", "userInput", UserInput.Length);
+			return;
 		}
-		else if (e.Key == "Backspace")
-		{
-			if (selectionStart > 0 || selectionEnd > selectionStart)
-			{
-				if (selectionEnd > selectionStart)
-				{
-					// Delete selected text
-					UserInput = UserInput.Remove(selectionStart, selectionEnd - selectionStart);
-				}
-				else
-				{
-					// Delete character before the cursor
-					UserInput = UserInput.Remove(selectionStart - 1, 1);
-					selectionStart--;
-				}
-				await JSRuntime.InvokeVoidAsync("setSelectionRange", "userInput", selectionStart);
-			}
-		}
-		else if (e.Key == "Delete")
-		{
-			if (selectionStart < UserInput.Length || selectionEnd > selectionStart)
-			{
-				if (selectionEnd > selectionStart)
-				{
-					// Delete selected text
-					UserInput = UserInput.Remove(selectionStart, selectionEnd - selectionStart);
-				}
-				else
-				{
-					// Delete character after the cursor
-					UserInput = UserInput.Remove(selectionStart, 1);
-				}
-				await JSRuntime.InvokeVoidAsync("setSelectionRange", "userInput", selectionStart);
-			}
-		}
-		else if (e.Key == "ArrowLeft")
-		{
-			// Move cursor left
-			selectionStart = Math.Max(selectionStart - 1, 0);
-			await JSRuntime.InvokeVoidAsync("setSelectionRange", "userInput", selectionStart);
-		}
-		else if (e.Key == "ArrowRight")
-		{
-			// Move cursor right
-			selectionStart = Math.Min(selectionStart + 1, UserInput.Length);
-			await JSRuntime.InvokeVoidAsync("setSelectionRange", "userInput", selectionStart);
-		}
-		else if (e.Key == "ArrowUp")
-		{
-			if (e.CtrlKey)
-			{
-				// Ctrl+ArrowUp moves to the first command in the history
-				if (CommandHistory.Count > 0)
-				{
-					CommandHistoryIndex = 0;
-					UserInput = CommandHistory[CommandHistoryIndex];
-					await InvokeAsync(StateHasChanged);
-					await JSRuntime.InvokeVoidAsync("setSelectionRange", "userInput", UserInput.Length);
-				}
-			}
-			else
-			{
-				// Navigate command history up
-				if (CommandHistory.Count > 0 && CommandHistoryIndex > 0)
-				{
-					CommandHistoryIndex--;
-					UserInput = CommandHistory[CommandHistoryIndex];
-					await InvokeAsync(StateHasChanged);
-					await JSRuntime.InvokeVoidAsync("setSelectionRange", "userInput", UserInput.Length);
-				}
-			}
-		}
-		else if (e.Key == "ArrowDown")
-		{if (e.CtrlKey)
-			{
-				// Ctrl+ArrowDown moves to the last command in the history
-				if (CommandHistory.Count > 0)
-				{
-					CommandHistoryIndex = CommandHistory.Count - 1;
-					UserInput = CommandHistory[CommandHistoryIndex];
-					await InvokeAsync(StateHasChanged);
-					await JSRuntime.InvokeVoidAsync("setSelectionRange", "userInput", UserInput.Length);
-				}
-			}
-			else
-			{
-				// Navigate command history down
-				if (CommandHistoryIndex < CommandHistory.Count - 1)
-				{
-					CommandHistoryIndex++;
-					UserInput = CommandHistory[CommandHistoryIndex];
-				}
-				else
-				{
-					CommandHistoryIndex = CommandHistory.Count;
-					UserInput = string.Empty;
-				}
 
-				await InvokeAsync(StateHasChanged);
-				await JSRuntime.InvokeVoidAsync("setSelectionRange", "userInput", UserInput.Length);
-			}
-		}
-		else if (e.Key == "Home")
+		if (e.Key == "ArrowDown")
 		{
-			if (e.CtrlKey)
+			if (e.CtrlKey && CommandHistory.Count > 0)
 			{
-				// Ctrl+Home: Move to the start of command history
-				if (CommandHistory.Count > 0)
-				{
-					CommandHistoryIndex = 0;
-					UserInput = CommandHistory[CommandHistoryIndex];
-					await InvokeAsync(StateHasChanged);
-					await JSRuntime.InvokeVoidAsync("setSelectionRange", "userInput", UserInput.Length);
-				}
+				CommandHistoryIndex = CommandHistory.Count - 1;
+				UserInput = CommandHistory[CommandHistoryIndex];
+			}
+			else if (CommandHistoryIndex < CommandHistory.Count - 1)
+			{
+				CommandHistoryIndex++;
+				UserInput = CommandHistory[CommandHistoryIndex];
 			}
 			else
 			{
-				// Move the cursor to the start of the input
-				await JSRuntime.InvokeVoidAsync("setSelectionRange", "userInput", 0);
-			}
-		}
-		else if (e.Key == "End")
-		{
-			if (e.CtrlKey)
-			{
-				// Ctrl+End: Move to the end of the command history (empty input)
 				CommandHistoryIndex = CommandHistory.Count;
 				UserInput = string.Empty;
-				await InvokeAsync(StateHasChanged);
-				await JSRuntime.InvokeVoidAsync("setSelectionRange", "userInput", 0);
 			}
-			else
-			{
-				// Move the cursor to the end of the input
-				await JSRuntime.InvokeVoidAsync("setSelectionRange", "userInput", UserInput.Length);
-			}
-		}
-		else if (e.Key.Length == 1 && !e.CtrlKey && !e.AltKey && !e.MetaKey)
-		{
-			// Handle character input
-			UserInput = UserInput.Remove(selectionStart, selectionEnd - selectionStart)
-									.Insert(selectionStart, e.Key);
-			selectionStart += e.Key.Length;
-			await JSRuntime.InvokeVoidAsync("setSelectionRange", "userInput", selectionStart);
+
+			await InvokeAsync(StateHasChanged);
+			await JSRuntime.InvokeVoidAsync("setSelectionRange", "userInput", UserInput.Length);
+			return;
 		}
 
-		await InvokeAsync(StateHasChanged);
+		if (e.Key == "Home" && e.CtrlKey && CommandHistory.Count > 0)
+		{
+			CommandHistoryIndex = 0;
+			UserInput = CommandHistory[CommandHistoryIndex];
+			await InvokeAsync(StateHasChanged);
+			await JSRuntime.InvokeVoidAsync("setSelectionRange", "userInput", UserInput.Length);
+			return;
+		}
+
+		if (e.Key == "End" && e.CtrlKey)
+		{
+			CommandHistoryIndex = CommandHistory.Count;
+			UserInput = string.Empty;
+			await InvokeAsync(StateHasChanged);
+			await JSRuntime.InvokeVoidAsync("setSelectionRange", "userInput", 0);
+		}
+	}
+
+	private async Task LoadTextFileAsync(InputFileChangeEventArgs args)
+	{
+		var file = args.File;
+		if (file.Size > MaximumTextFileBytes)
+		{
+			AddMessage($"{EscapeHtml(file.Name)} is larger than the 1 MiB text import limit.");
+			await InvokeAsync(StateHasChanged);
+			return;
+		}
+
+		try
+		{
+			await using var stream = file.OpenReadStream(MaximumTextFileBytes, _cancellationTokenSource.Token);
+			using var reader = new StreamReader(stream, Encoding.UTF8, true);
+			UserInput = await reader.ReadToEndAsync(_cancellationTokenSource.Token);
+			var lineCount = UserInput.Count(character => character == '\n') + (UserInput.Length > 0 ? 1 : 0);
+			AddMessage($"Loaded {EscapeHtml(file.Name)} ({file.Size:N0} bytes, {lineCount:N0} lines) for review.");
+			await InvokeAsync(StateHasChanged);
+			await JSRuntime.InvokeVoidAsync("setSelectionRange", "userInput", UserInput.Length);
+		}
+		catch (Exception ex) when (ex is IOException or InvalidOperationException)
+		{
+			Logger.LogWarning(ex, "Unable to load text file {FileName}.", file.Name);
+			AddMessage($"Could not load {EscapeHtml(file.Name)} as a UTF-8 text file.");
+			await InvokeAsync(StateHasChanged);
+		}
 	}
 
 	public async ValueTask DisposeAsync()
@@ -1730,6 +1677,8 @@
 		try
 		{
 			await JSRuntime.InvokeVoidAsync("mudClientHotkeys.dispose");
+			await JSRuntime.InvokeVoidAsync("mudClientInput.dispose");
+			await JSRuntime.InvokeVoidAsync("disposeSendCommandHandler");
 		}
 		catch (JSDisconnectedException)
 		{
@@ -1738,6 +1687,7 @@
 		{
 		}
 
+		_batchCancellationTokenSource?.Cancel();
 		_cancellationTokenSource.Cancel();
 
 		if (_clientWebSocket?.State is WebSocketState.Open or WebSocketState.CloseReceived)
@@ -1751,6 +1701,8 @@
 		}
 
 		_cancellationTokenSource.Dispose();
+		_sendSemaphore.Dispose();
+		_commandSequenceSemaphore.Dispose();
 		_objectReference?.Dispose();
 	}
 
@@ -1810,7 +1762,8 @@
 		if (_clientWebSocket?.State == WebSocketState.Open)
 		{
 			await _clientWebSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closed by user", CancellationToken.None);
-			Messages.Add("Disconnected from the MUD.");
+			await FlushPendingServerTextAsync();
+			AddMessage("Disconnected from the MUD.");
 		}
 
 		isConnected = false;
@@ -1824,12 +1777,12 @@
 		{
 			if (_webSocketEndpoint == null)
 			{
-				Messages.Add("Cannot reconnect because the WebSocket proxy endpoint is not configured.");
+				AddMessage("Cannot reconnect because the WebSocket proxy endpoint is not configured.");
 				isConnected = false;
 			}
 			else if (await ConnectToWebSocketAsync(_webSocketEndpoint))
 			{
-				Messages.Add("Reconnected to the MUD.");
+				AddMessage("Reconnected to the MUD.");
 			}
 
 			await InvokeAsync(StateHasChanged);
@@ -1865,14 +1818,14 @@
 
 		// Build the HTML log content with embedded CSS
 		var logContent = new StringBuilder();
-		logContent.Append("<html><head><title>MUD Log</title>");
+		logContent.Append("<html><head><meta charset='utf-8'><meta http-equiv='Content-Security-Policy' content=\"default-src 'none'; style-src 'unsafe-inline'; img-src https: data:;\"><title>MUD Log</title>");
 		logContent.Append(css);
 		logContent.Append("</head><body><div class='message-container'>");
 
 		// Loop through messages and add them to the log
-		foreach (var message in Messages)
+		foreach (var message in _transcript.LogEntries)
 		{
-			logContent.Append($"<div>{message}</div>");
+			logContent.Append($"<div>{message.Html}</div>");
 		}
 		logContent.Append("</div></body></html>");
 
@@ -1881,6 +1834,6 @@
 
 		// Trigger download in the browser
 		var jsContent = $"data:text/html;base64,{logBlob}";
-		await JSRuntime.InvokeVoidAsync("triggerDownload", $"mud_log_{DateTime.UtcNow:u}.html", jsContent);
+		await JSRuntime.InvokeVoidAsync("triggerDownload", $"mud-log-{DateTime.UtcNow:yyyyMMdd-HHmmss}.html", jsContent);
 	}
 }

--- a/MudClient/MudClientBlazor/Services/AnsiMxpParser.cs
+++ b/MudClient/MudClientBlazor/Services/AnsiMxpParser.cs
@@ -7,8 +7,11 @@ namespace MudClientBlazor.Services;
 
 public class AnsiMxpParser
 {
+	private const int MaximumSendCommands = 4_096;
+	private const int MaximumSendCommandLength = 16_384;
 	private int _sendButtonId;
 	private readonly Dictionary<int, string> _sendCommands = new();
+	private readonly Queue<int> _sendCommandOrder = new();
 
 	public bool TryGetSendCommand(int id, [NotNullWhen(true)] out string? command)
 	{
@@ -241,7 +244,7 @@ public class AnsiMxpParser
 				string? command = GetAttributeValue(attrs, "HREF");
 				string text = match.Groups["sendText"].Value;
 
-				if (string.IsNullOrWhiteSpace(command))
+				if (string.IsNullOrWhiteSpace(command) || command.Length > MaximumSendCommandLength)
 				{
 					output.Append(EscapeHtml(match.Value));
 					lastIndex = match.Index + match.Length;
@@ -250,11 +253,16 @@ public class AnsiMxpParser
 
 				int id = _sendButtonId++;
 				_sendCommands[id] = command;
+				_sendCommandOrder.Enqueue(id);
+				while (_sendCommandOrder.Count > MaximumSendCommands)
+				{
+					_sendCommands.Remove(_sendCommandOrder.Dequeue());
+				}
 
 				var hint = GetAttributeValue(attrs, "HINT");
 				var titleAttribute = string.IsNullOrWhiteSpace(hint) ? string.Empty : $" title=\"{EscapeHtml(hint)}\"";
 
-				output.Append($"<a class=\"mxp-send-link\" href=\"javascript:void(0)\" onclick=\"javascript:sendCommand({id}); return false;\"{titleAttribute}>");
+				output.Append($"<a class=\"mxp-send-link\" href=\"#\" data-mxp-command-id=\"{id}\"{titleAttribute}>");
 				AppendEscapedText(output, text, allowAutoLinks: false);
 				output.Append("</a>");
 			}
@@ -584,7 +592,7 @@ public class AnsiMxpParser
 			? fileName
 			: new Uri(safeSrc).Segments.LastOrDefault()?.Trim('/') ?? "MXP image";
 
-		markup = $"<img class=\"mxp-image\" src=\"{EscapeHtml(safeSrc)}\" alt=\"{EscapeHtml(alt)}\" loading=\"lazy\" />";
+		markup = $"<img class=\"mxp-image\" src=\"{EscapeHtml(safeSrc)}\" alt=\"{EscapeHtml(alt)}\" loading=\"lazy\" decoding=\"async\" referrerpolicy=\"no-referrer\" />";
 		return true;
 	}
 

--- a/MudClient/MudClientBlazor/Services/ClientSettings.cs
+++ b/MudClient/MudClientBlazor/Services/ClientSettings.cs
@@ -26,6 +26,7 @@ public sealed class ClientSettings
 	public bool SemicolonCommandStackingEnabled { get; set; } = true;
 	public string CommandStackingDelimiter { get; set; } = ";";
 	public bool NewlineCommandStackingEnabled { get; set; } = true;
+	public int StackedCommandDelayMs { get; set; } = 100;
 
 	public static IReadOnlyList<ClientFontOption> FontOptions => AvailableFonts;
 
@@ -44,7 +45,8 @@ public sealed class ClientSettings
 			ClearInputAfterSend = ClearInputAfterSend,
 			SemicolonCommandStackingEnabled = SemicolonCommandStackingEnabled,
 			CommandStackingDelimiter = CommandStackingDelimiter,
-			NewlineCommandStackingEnabled = NewlineCommandStackingEnabled
+			NewlineCommandStackingEnabled = NewlineCommandStackingEnabled,
+			StackedCommandDelayMs = StackedCommandDelayMs
 		};
 	}
 
@@ -70,6 +72,7 @@ public sealed class ClientSettings
 		normalized.MessageLineHeight = Math.Clamp(settings.MessageLineHeight, 1.0, 3.0);
 		normalized.MessageSpacingPx = Math.Clamp(settings.MessageSpacingPx, 0, 100);
 		normalized.CommandStackingDelimiter = NormalizeDelimiter(settings.CommandStackingDelimiter, defaults.CommandStackingDelimiter);
+		normalized.StackedCommandDelayMs = Math.Clamp(settings.StackedCommandDelayMs, 50, 2_000);
 		return normalized;
 	}
 

--- a/MudClient/MudClientBlazor/Services/ClientTranscript.cs
+++ b/MudClient/MudClientBlazor/Services/ClientTranscript.cs
@@ -1,0 +1,89 @@
+namespace MudClientBlazor.Services;
+
+public sealed record TranscriptEntry(long Id, string Html);
+
+public sealed class ClientTranscript
+{
+	public const int DefaultRenderedEntryLimit = 750;
+	public const int DefaultLogEntryLimit = 10_000;
+	public const int DefaultRenderedCharacterLimit = 1_000_000;
+	public const int DefaultLogCharacterLimit = 5_000_000;
+
+	private readonly int _renderedEntryLimit;
+	private readonly int _logEntryLimit;
+	private readonly int _renderedCharacterLimit;
+	private readonly int _logCharacterLimit;
+	private readonly List<TranscriptEntry> _renderedEntries = [];
+	private readonly List<TranscriptEntry> _logEntries = [];
+	private long _nextId;
+	private int _renderedCharacterCount;
+	private int _logCharacterCount;
+
+	public ClientTranscript(
+		int renderedEntryLimit = DefaultRenderedEntryLimit,
+		int logEntryLimit = DefaultLogEntryLimit,
+		int renderedCharacterLimit = DefaultRenderedCharacterLimit,
+		int logCharacterLimit = DefaultLogCharacterLimit)
+	{
+		if (renderedEntryLimit < 1)
+		{
+			throw new ArgumentOutOfRangeException(nameof(renderedEntryLimit));
+		}
+
+		if (logEntryLimit < renderedEntryLimit)
+		{
+			throw new ArgumentOutOfRangeException(nameof(logEntryLimit));
+		}
+
+		if (renderedCharacterLimit < 1)
+		{
+			throw new ArgumentOutOfRangeException(nameof(renderedCharacterLimit));
+		}
+
+		if (logCharacterLimit < renderedCharacterLimit)
+		{
+			throw new ArgumentOutOfRangeException(nameof(logCharacterLimit));
+		}
+
+		_renderedEntryLimit = renderedEntryLimit;
+		_logEntryLimit = logEntryLimit;
+		_renderedCharacterLimit = renderedCharacterLimit;
+		_logCharacterLimit = logCharacterLimit;
+	}
+
+	public IReadOnlyList<TranscriptEntry> RenderedEntries => _renderedEntries;
+	public IReadOnlyList<TranscriptEntry> LogEntries => _logEntries;
+
+	public void Add(string html)
+	{
+		ArgumentNullException.ThrowIfNull(html);
+
+		var entry = new TranscriptEntry(_nextId++, html);
+		_renderedEntries.Add(entry);
+		_logEntries.Add(entry);
+		_renderedCharacterCount += html.Length;
+		_logCharacterCount += html.Length;
+		TrimToLimit(_renderedEntries, _renderedEntryLimit, _renderedCharacterLimit, ref _renderedCharacterCount);
+		TrimToLimit(_logEntries, _logEntryLimit, _logCharacterLimit, ref _logCharacterCount);
+	}
+
+	private static void TrimToLimit(
+		List<TranscriptEntry> entries,
+		int entryLimit,
+		int characterLimit,
+		ref int characterCount)
+	{
+		var removeCount = 0;
+		while (removeCount < entries.Count &&
+		       (entries.Count - removeCount > entryLimit || characterCount > characterLimit))
+		{
+			characterCount -= entries[removeCount].Html.Length;
+			removeCount++;
+		}
+
+		if (removeCount > 0)
+		{
+			entries.RemoveRange(0, removeCount);
+		}
+	}
+}

--- a/MudClient/MudClientBlazor/Services/QuickAliasSettings.cs
+++ b/MudClient/MudClientBlazor/Services/QuickAliasSettings.cs
@@ -116,6 +116,15 @@ public sealed class QuickAliasSettings
 		return normalized;
 	}
 
+	public static QuickAliasSettings CreatePersistentCopy(QuickAliasSettings settings)
+	{
+		ArgumentNullException.ThrowIfNull(settings);
+
+		var persistent = Normalize(settings);
+		persistent.Login.Password = string.Empty;
+		return persistent;
+	}
+
 	private static LoginAliasSettings NormalizeLogin(LoginAliasSettings? savedLogin)
 	{
 		var defaultLogin = CreateDefaultLogin();

--- a/MudClient/MudClientBlazor/Services/TelnetStreamParser.cs
+++ b/MudClient/MudClientBlazor/Services/TelnetStreamParser.cs
@@ -1,0 +1,149 @@
+namespace MudClientBlazor.Services;
+
+public abstract record TelnetStreamEvent;
+
+public sealed record TelnetDataEvent(byte[] Data) : TelnetStreamEvent;
+
+public sealed record TelnetNegotiationEvent(byte Command, byte Option) : TelnetStreamEvent;
+
+public sealed record TelnetSubnegotiationEvent(byte Option, byte[] Data) : TelnetStreamEvent;
+
+public sealed record TelnetCommandEvent(byte Command) : TelnetStreamEvent;
+
+public sealed class TelnetStreamParser
+{
+	private const int MaximumSubnegotiationLength = 65_536;
+
+	private readonly List<byte> _subnegotiation = [];
+	private ParserState _state;
+	private byte _pendingNegotiationCommand;
+
+	public IReadOnlyList<TelnetStreamEvent> Feed(ReadOnlySpan<byte> input)
+	{
+		var events = new List<TelnetStreamEvent>();
+		var data = new List<byte>(input.Length);
+
+		foreach (var value in input)
+		{
+			switch (_state)
+			{
+				case ParserState.Data:
+					if (value == TelnetConstants.IAC)
+					{
+						FlushData(events, data);
+						_state = ParserState.Iac;
+					}
+					else
+					{
+						data.Add(value);
+					}
+					break;
+
+				case ParserState.Iac:
+					if (value == TelnetConstants.IAC)
+					{
+						data.Add(value);
+						_state = ParserState.Data;
+					}
+					else if (value is TelnetConstants.WILL or TelnetConstants.WONT or TelnetConstants.DO or TelnetConstants.DONT)
+					{
+						_pendingNegotiationCommand = value;
+						_state = ParserState.NegotiationOption;
+					}
+					else if (value == TelnetConstants.SB)
+					{
+						_subnegotiation.Clear();
+						_state = ParserState.Subnegotiation;
+					}
+					else
+					{
+						events.Add(new TelnetCommandEvent(value));
+						_state = ParserState.Data;
+					}
+					break;
+
+				case ParserState.NegotiationOption:
+					events.Add(new TelnetNegotiationEvent(_pendingNegotiationCommand, value));
+					_state = ParserState.Data;
+					break;
+
+				case ParserState.Subnegotiation:
+					if (value == TelnetConstants.IAC)
+					{
+						_state = ParserState.SubnegotiationIac;
+					}
+					else
+					{
+						AppendSubnegotiationByte(value);
+					}
+					break;
+
+				case ParserState.SubnegotiationIac:
+					if (value == TelnetConstants.SE)
+					{
+						if (_subnegotiation.Count > 0)
+						{
+							events.Add(new TelnetSubnegotiationEvent(
+								_subnegotiation[0],
+								_subnegotiation.Skip(1).ToArray()));
+						}
+
+						_subnegotiation.Clear();
+						_state = ParserState.Data;
+					}
+					else
+					{
+						AppendSubnegotiationByte(TelnetConstants.IAC);
+						if (value != TelnetConstants.IAC)
+						{
+							AppendSubnegotiationByte(value);
+						}
+
+						_state = ParserState.Subnegotiation;
+					}
+					break;
+			}
+		}
+
+		FlushData(events, data);
+		return events;
+	}
+
+	public void Reset()
+	{
+		_state = ParserState.Data;
+		_pendingNegotiationCommand = 0;
+		_subnegotiation.Clear();
+	}
+
+	private void AppendSubnegotiationByte(byte value)
+	{
+		if (_subnegotiation.Count >= MaximumSubnegotiationLength)
+		{
+			Reset();
+			throw new InvalidDataException("Telnet subnegotiation exceeded the supported size.");
+		}
+
+		_subnegotiation.Add(value);
+	}
+
+	private static void FlushData(ICollection<TelnetStreamEvent> events, List<byte> data)
+	{
+		if (data.Count == 0)
+		{
+			return;
+		}
+
+		events.Add(new TelnetDataEvent(data.ToArray()));
+		data.Clear();
+	}
+
+	private enum ParserState
+	{
+		Data,
+		Iac,
+		NegotiationOption,
+		Subnegotiation,
+		SubnegotiationIac
+	}
+}

--- a/MudClient/MudClientBlazor/TelnetConstants.cs
+++ b/MudClient/MudClientBlazor/TelnetConstants.cs
@@ -18,6 +18,7 @@ public static class TelnetConstants
 	public const byte TELOPT_STATUS = 5;
 	public const byte TELOPT_TIMING_MARK = 6;
 	public const byte TELOPT_TTYPE = 24;
+	public const byte TELOPT_EOR = 25;
 	public const byte TELOPT_NAWS = 31;
 	public const byte TELOPT_TERMINAL_SPEED = 32;
 	public const byte TELOPT_REMOTE_FLOW_CONTROL = 33;

--- a/MudClient/MudClientBlazor/wwwroot/css/mudclient.css
+++ b/MudClient/MudClientBlazor/wwwroot/css/mudclient.css
@@ -47,6 +47,8 @@ body {
 }
 
 button,
+input,
+select,
 textarea {
 	font: inherit;
 }
@@ -110,6 +112,8 @@ textarea {
 
 .message-container > div {
 	max-width: var(--client-message-wrap-width, none);
+	content-visibility: auto;
+	contain-intrinsic-size: auto 1.5em;
 }
 
 .message-container::-webkit-scrollbar,
@@ -403,9 +407,50 @@ textarea {
 }
 
 .input-container {
+	display: grid;
+	gap: 0.55rem;
 	padding: clamp(0.65rem, 1.15vw, 0.95rem);
 	background: var(--panel-bg);
 	border-bottom: 1px solid var(--border-subtle);
+}
+
+.input-toolbar {
+	display: flex;
+	align-items: center;
+	gap: 0.65rem;
+	min-width: 0;
+}
+
+.file-input-button {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 auto;
+	cursor: pointer;
+}
+
+.file-input-button input[type="file"] {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+
+.input-help,
+.batch-progress {
+	color: var(--text-muted);
+	font-size: 0.82rem;
+}
+
+.batch-progress {
+	display: inline-flex;
+	align-items: center;
+	white-space: nowrap;
 }
 
 .settings-panel {
@@ -893,6 +938,11 @@ a:hover {
 	}
 
 	.status-footer {
+		flex-direction: column;
+	}
+
+	.input-toolbar {
+		align-items: stretch;
 		flex-direction: column;
 	}
 

--- a/MudClient/MudClientBlazor/wwwroot/index.html
+++ b/MudClient/MudClientBlazor/wwwroot/index.html
@@ -4,7 +4,7 @@
 <head>
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-	<title>MudClientBlazor</title>
+	<title>FutureMUD Web Client</title>
 	<base href="/" />
 	<link rel="icon" type="image/png" href="icon-192.png" />
 	<link rel="stylesheet" href="css/app.css" />
@@ -12,125 +12,7 @@
 	<!-- If you add any scoped CSS files, uncomment the following to load them
 	<link href="MudClientBlazor.styles.css" rel="stylesheet" /> -->
 
-	<script>
-		window.registerSendCommandHandler = function (dotNetHelper) {
-			window.sendCommand = function (id) {
-				dotNetHelper.invokeMethodAsync('SendCommandById', id);
-			};
-		};
-
-		window.mudClientHotkeys = (function () {
-			let dotNetHelper = null;
-			let keydownHandler = null;
-			let enabled = true;
-			let boundCodes = new Set();
-
-			function isNumpadCode(code) {
-				return code && code.indexOf('Numpad') === 0;
-			}
-
-			function isPrintableKey(event) {
-				return typeof event.key === 'string' && event.key.length === 1;
-			}
-
-			function isEditableTarget(target) {
-				return !!(target && target.closest && target.closest('input, textarea, select, [contenteditable]'));
-			}
-
-			function shouldIgnoreEvent(event, code) {
-				if (!enabled ||
-					event.defaultPrevented ||
-					event.ctrlKey ||
-					event.altKey ||
-					event.metaKey ||
-					event.shiftKey) {
-					return true;
-				}
-
-				const target = event.target;
-				if (isEditableTarget(target) && isPrintableKey(event) && !isNumpadCode(code)) {
-					return true;
-				}
-
-				return !!(target && target.closest && target.closest('[data-hotkey-settings="true"]'));
-			}
-
-			function handleKeydown(event) {
-				const code = event.code || '';
-				if (!code || shouldIgnoreEvent(event, code) || !boundCodes.has(code)) {
-					return;
-				}
-
-				event.preventDefault();
-				event.stopPropagation();
-				if (event.stopImmediatePropagation) {
-					event.stopImmediatePropagation();
-				}
-
-				if (dotNetHelper) {
-					dotNetHelper.invokeMethodAsync('HandleHotkeyCode', code);
-				}
-			}
-
-			return {
-				register: function (helper) {
-					if (keydownHandler) {
-						document.removeEventListener('keydown', keydownHandler, true);
-					}
-
-					dotNetHelper = helper;
-					keydownHandler = handleKeydown;
-					document.addEventListener('keydown', keydownHandler, true);
-				},
-				setBoundCodes: function (codes) {
-					boundCodes = new Set(codes || []);
-				},
-				setEnabled: function (value) {
-					enabled = !!value;
-				},
-				dispose: function () {
-					if (keydownHandler) {
-						document.removeEventListener('keydown', keydownHandler, true);
-					}
-
-					keydownHandler = null;
-					dotNetHelper = null;
-					boundCodes = new Set();
-				}
-			};
-		})();
-
-		window.scrollToBottom = (element) => {
-			if (element) {
-				// Use requestAnimationFrame to ensure the DOM has updated
-				window.requestAnimationFrame(() => {
-					element.scrollTop = element.scrollHeight;
-				});
-			}
-		};
-
-		window.getSelectionStart = function (elementId) {
-			var element = document.getElementById(elementId);
-			return element.selectionStart;
-		};
-		window.getSelectionEnd = function (elementId) {
-			var element = document.getElementById(elementId);
-			return element.selectionEnd;
-		};
-		window.setSelectionRange = function (elementId, startPosition, endPosition) {
-			var element = document.getElementById(elementId);
-			element.focus();
-			var end = typeof endPosition === 'number' ? endPosition : startPosition;
-			element.setSelectionRange(startPosition, end);
-		};
-
-		window.triggerDownload = function (filename, dataUri) {
-			var link = document.createElement('a');
-			link.href = dataUri;
-			link.download = filename;
-			link.click();
-		};
-	</script>
+	<script src="js/mudclient.js"></script>
 
 </head>
 

--- a/MudClient/MudClientBlazor/wwwroot/js/mudclient.js
+++ b/MudClient/MudClientBlazor/wwwroot/js/mudclient.js
@@ -1,0 +1,180 @@
+(function () {
+	let sendCommandHelper = null;
+
+	window.registerSendCommandHandler = function (dotNetHelper) {
+		sendCommandHelper = dotNetHelper;
+	};
+
+	window.disposeSendCommandHandler = function () {
+		sendCommandHelper = null;
+	};
+
+	document.addEventListener('click', function (event) {
+		const link = event.target.closest && event.target.closest('[data-mxp-command-id]');
+		if (!link) {
+			return;
+		}
+
+		event.preventDefault();
+		const commandId = Number.parseInt(link.dataset.mxpCommandId, 10);
+		if (sendCommandHelper && Number.isInteger(commandId)) {
+			sendCommandHelper.invokeMethodAsync('SendCommandById', commandId);
+		}
+	});
+
+	window.mudClientHotkeys = (function () {
+		let dotNetHelper = null;
+		let keydownHandler = null;
+		let enabled = true;
+		let boundCodes = new Set();
+
+		function isNumpadCode(code) {
+			return code && code.indexOf('Numpad') === 0;
+		}
+
+		function isPrintableKey(event) {
+			return typeof event.key === 'string' && event.key.length === 1;
+		}
+
+		function isEditableTarget(target) {
+			return !!(target && target.closest && target.closest('input, textarea, select, [contenteditable]'));
+		}
+
+		function shouldIgnoreEvent(event, code) {
+			if (!enabled || event.defaultPrevented || event.ctrlKey || event.altKey || event.metaKey || event.shiftKey) {
+				return true;
+			}
+
+			const target = event.target;
+			if (isEditableTarget(target) && isPrintableKey(event) && !isNumpadCode(code)) {
+				return true;
+			}
+
+			return !!(target && target.closest && target.closest('[data-hotkey-settings="true"]'));
+		}
+
+		function handleKeydown(event) {
+			const code = event.code || '';
+			if (!code || shouldIgnoreEvent(event, code) || !boundCodes.has(code)) {
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+			if (event.stopImmediatePropagation) {
+				event.stopImmediatePropagation();
+			}
+
+			if (dotNetHelper) {
+				dotNetHelper.invokeMethodAsync('HandleHotkeyCode', code);
+			}
+		}
+
+		return {
+			register: function (helper) {
+				if (keydownHandler) {
+					document.removeEventListener('keydown', keydownHandler, true);
+				}
+
+				dotNetHelper = helper;
+				keydownHandler = handleKeydown;
+				document.addEventListener('keydown', keydownHandler, true);
+			},
+			setBoundCodes: function (codes) {
+				boundCodes = new Set(codes || []);
+			},
+			setEnabled: function (value) {
+				enabled = !!value;
+			},
+			dispose: function () {
+				if (keydownHandler) {
+					document.removeEventListener('keydown', keydownHandler, true);
+				}
+
+				keydownHandler = null;
+				dotNetHelper = null;
+				boundCodes = new Set();
+			}
+		};
+	})();
+
+	window.mudClientInput = (function () {
+		let element = null;
+		let handler = null;
+
+		return {
+			register: function (elementId) {
+				this.dispose();
+				element = document.getElementById(elementId);
+				if (!element) {
+					return;
+				}
+
+				handler = function (event) {
+					const shouldPrevent =
+						(event.key === 'Enter' && !event.shiftKey) ||
+						event.key === 'ArrowUp' ||
+						event.key === 'ArrowDown' ||
+						(event.ctrlKey && (event.key === 'Home' || event.key === 'End'));
+					if (shouldPrevent) {
+						event.preventDefault();
+					}
+				};
+				element.addEventListener('keydown', handler);
+			},
+			dispose: function () {
+				if (element && handler) {
+					element.removeEventListener('keydown', handler);
+				}
+
+				element = null;
+				handler = null;
+			}
+		};
+	})();
+
+	window.scrollToBottomIfNearBottom = function (element) {
+		if (!element) {
+			return;
+		}
+
+		const previousHeight = Number.parseFloat(element.dataset.previousScrollHeight || '0');
+		const referenceHeight = previousHeight > 0 ? previousHeight : element.scrollHeight;
+		const wasNearBottom = referenceHeight - element.clientHeight - element.scrollTop < 160;
+		element.dataset.previousScrollHeight = String(element.scrollHeight);
+		if (wasNearBottom || previousHeight === 0) {
+			window.requestAnimationFrame(function () {
+				element.scrollTop = element.scrollHeight;
+				element.dataset.previousScrollHeight = String(element.scrollHeight);
+			});
+		}
+	};
+
+	window.getSelectionStart = function (elementId) {
+		const element = document.getElementById(elementId);
+		return element ? element.selectionStart : 0;
+	};
+
+	window.getSelectionEnd = function (elementId) {
+		const element = document.getElementById(elementId);
+		return element ? element.selectionEnd : 0;
+	};
+
+	window.setSelectionRange = function (elementId, startPosition, endPosition) {
+		const element = document.getElementById(elementId);
+		if (!element) {
+			return;
+		}
+
+		element.focus();
+		const end = typeof endPosition === 'number' ? endPosition : startPosition;
+		element.setSelectionRange(startPosition, end);
+	};
+
+	window.triggerDownload = function (filename, dataUri) {
+		const link = document.createElement('a');
+		link.href = dataUri;
+		link.download = filename;
+		link.click();
+	};
+})();

--- a/MudClient/MudClientTests/AnsiMxpParserTests.cs
+++ b/MudClient/MudClientTests/AnsiMxpParserTests.cs
@@ -46,7 +46,7 @@ public class AnsiMxpParserTests
 		var result = new AnsiMxpParser().Parse(input);
 
 		Assert.Equal(
-			"<img class=\"mxp-image\" src=\"http://stream1.gifsoup.com/view3/3414762/batman-thumbs-up-o.gif\" alt=\"batman-thumbs-up-o.gif\" loading=\"lazy\" />",
+			"<img class=\"mxp-image\" src=\"http://stream1.gifsoup.com/view3/3414762/batman-thumbs-up-o.gif\" alt=\"batman-thumbs-up-o.gif\" loading=\"lazy\" decoding=\"async\" referrerpolicy=\"no-referrer\" />",
 			result);
 	}
 
@@ -59,8 +59,9 @@ public class AnsiMxpParserTests
 
 		// Since IDs are dynamic, we can't assert the exact output
 		Assert.Contains("class=\"mxp-send-link\"", result);
-		Assert.Contains("href=\"javascript:void(0)\"", result);
-		Assert.Contains("onclick=\"javascript:sendCommand(", result);
+		Assert.Contains("href=\"#\"", result);
+		Assert.Contains("data-mxp-command-id=\"0\"", result);
+		Assert.DoesNotContain("onclick", result, StringComparison.OrdinalIgnoreCase);
 		Assert.Contains("Look Around", result);
 		Assert.True(parser.TryGetSendCommand(0, out var command));
 		Assert.Equal("look", command);
@@ -75,7 +76,7 @@ public class AnsiMxpParserTests
 		var result = parser.Parse(input);
 
 		Assert.Equal(
-			"<a class=\"mxp-send-link\" href=\"javascript:void(0)\" onclick=\"javascript:sendCommand(0); return false;\" title=\"a pair of steel-capped, vivid indigo shoes\">(covered)</a>",
+			"<a class=\"mxp-send-link\" href=\"#\" data-mxp-command-id=\"0\" title=\"a pair of steel-capped, vivid indigo shoes\">(covered)</a>",
 			result);
 		Assert.True(parser.TryGetSendCommand(0, out var command));
 		Assert.Equal("look", command);
@@ -90,7 +91,7 @@ public class AnsiMxpParserTests
 		var result = parser.Parse(input);
 
 		Assert.Equal(
-			"<a class=\"mxp-send-link\" href=\"javascript:void(0)\" onclick=\"javascript:sendCommand(0); return false;\" title=\"look at &quot;shoes&quot;\">&lt;covered&gt;</a>",
+			"<a class=\"mxp-send-link\" href=\"#\" data-mxp-command-id=\"0\" title=\"look at &quot;shoes&quot;\">&lt;covered&gt;</a>",
 			result);
 		Assert.True(parser.TryGetSendCommand(0, out var command));
 		Assert.Equal("look shoes", command);

--- a/MudClient/MudClientTests/ClientSettingsTests.cs
+++ b/MudClient/MudClientTests/ClientSettingsTests.cs
@@ -15,6 +15,7 @@ public class ClientSettingsTests
 			MessageLeftOffsetPx = 900,
 			MessageLineHeight = 0.1,
 			MessageSpacingPx = 900,
+			StackedCommandDelayMs = 1,
 			CommandStackingDelimiter = "\\"
 		});
 
@@ -24,6 +25,7 @@ public class ClientSettingsTests
 		Assert.Equal(500, normalized.MessageLeftOffsetPx);
 		Assert.Equal(1.0, normalized.MessageLineHeight);
 		Assert.Equal(100, normalized.MessageSpacingPx);
+		Assert.Equal(50, normalized.StackedCommandDelayMs);
 		Assert.Equal(";", normalized.CommandStackingDelimiter);
 	}
 

--- a/MudClient/MudClientTests/ClientTranscriptTests.cs
+++ b/MudClient/MudClientTests/ClientTranscriptTests.cs
@@ -1,0 +1,37 @@
+using MudClientBlazor.Services;
+
+namespace MudClientTests;
+
+public class ClientTranscriptTests
+{
+	[Fact]
+	public void Add_BoundsRenderedAndSavedEntriesIndependently()
+	{
+		var transcript = new ClientTranscript(renderedEntryLimit: 2, logEntryLimit: 3);
+
+		transcript.Add("one");
+		transcript.Add("two");
+		transcript.Add("three");
+		transcript.Add("four");
+
+		Assert.Equal(["three", "four"], transcript.RenderedEntries.Select(entry => entry.Html));
+		Assert.Equal(["two", "three", "four"], transcript.LogEntries.Select(entry => entry.Html));
+		Assert.Equal([2, 3], transcript.RenderedEntries.Select(entry => entry.Id));
+	}
+
+	[Fact]
+	public void Add_BoundsTranscriptByCharacterCount()
+	{
+		var transcript = new ClientTranscript(
+			renderedEntryLimit: 10,
+			logEntryLimit: 10,
+			renderedCharacterLimit: 5,
+			logCharacterLimit: 8);
+
+		transcript.Add("1234");
+		transcript.Add("5678");
+
+		Assert.Equal(["5678"], transcript.RenderedEntries.Select(entry => entry.Html));
+		Assert.Equal(["1234", "5678"], transcript.LogEntries.Select(entry => entry.Html));
+	}
+}

--- a/MudClient/MudClientTests/ProxySecurityTests.cs
+++ b/MudClient/MudClientTests/ProxySecurityTests.cs
@@ -1,0 +1,92 @@
+using Microsoft.Extensions.Configuration;
+using MudWebSocketProxy.Security;
+
+namespace MudClientTests;
+
+public class ProxySecurityTests
+{
+	[Fact]
+	public void ConnectionLimiter_EnforcesPerAddressAndReleasesLease()
+	{
+		var limits = new ProxyLimits
+		{
+			MaximumConcurrentConnections = 2,
+			MaximumConnectionsPerIp = 1
+		};
+		var limiter = new ProxyConnectionLimiter(limits);
+
+		using var first = limiter.TryAcquire("192.0.2.1");
+		Assert.NotNull(first);
+		Assert.Null(limiter.TryAcquire("192.0.2.1"));
+
+		first.Dispose();
+		using var replacement = limiter.TryAcquire("192.0.2.1");
+		Assert.NotNull(replacement);
+	}
+
+	[Fact]
+	public void TrafficLimiter_EnforcesMessageAndByteRatesAndResetsWindow()
+	{
+		var limits = new ProxyLimits
+		{
+			MaximumClientMessagesPerSecond = 2,
+			MaximumClientBytesPerSecond = 10
+		};
+		var now = DateTimeOffset.UtcNow;
+		var limiter = new ClientTrafficLimiter(limits, now);
+
+		Assert.True(limiter.TryConsumeMessage(5, now));
+		Assert.True(limiter.TryConsumeMessage(5, now));
+		Assert.False(limiter.TryConsumeMessage(1, now));
+		Assert.True(limiter.TryConsumeMessage(10, now.AddSeconds(1)));
+	}
+
+	[Fact]
+	public void ByteTrafficLimiter_EnforcesAndResetsWindow()
+	{
+		var now = DateTimeOffset.UtcNow;
+		var limiter = new ByteTrafficLimiter(10, now);
+
+		Assert.True(limiter.TryConsume(6, now));
+		Assert.False(limiter.TryConsume(5, now));
+		Assert.True(limiter.TryConsume(10, now.AddSeconds(1)));
+	}
+
+	[Fact]
+	public void ProxyLimits_ClampsUnsafeConfigurationValues()
+	{
+		var configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?>
+			{
+				["ProxyLimits:MaximumConcurrentConnections"] = "0",
+				["ProxyLimits:MaximumClientMessageBytes"] = "99999999",
+				["ProxyLimits:MudConnectionTimeoutSeconds"] = "0"
+			})
+			.Build();
+
+		var limits = ProxyLimits.FromConfiguration(configuration);
+
+		Assert.Equal(1, limits.MaximumConcurrentConnections);
+		Assert.Equal(1_048_576, limits.MaximumClientMessageBytes);
+		Assert.Equal(TimeSpan.FromSeconds(1), limits.MudConnectionTimeout);
+	}
+
+	[Theory]
+	[InlineData("https://play.example.com", true)]
+	[InlineData("https://PLAY.example.com/", true)]
+	[InlineData("https://play.example.com:444", false)]
+	[InlineData("https://evil.example.com", false)]
+	public void OriginPolicy_RequiresAnExactConfiguredAuthority(string origin, bool expected)
+	{
+		Assert.Equal(
+			expected,
+			WebSocketOriginPolicy.IsAllowed(origin, true, ["https://play.example.com"]));
+	}
+
+	[Fact]
+	public void OriginPolicy_RejectsMissingOriginByDefault()
+	{
+		Assert.False(WebSocketOriginPolicy.IsAllowed(null, true, ["https://play.example.com"]));
+		Assert.True(WebSocketOriginPolicy.IsAllowed(null, false, ["https://play.example.com"]));
+	}
+}

--- a/MudClient/MudClientTests/QuickAliasSettingsTests.cs
+++ b/MudClient/MudClientTests/QuickAliasSettingsTests.cs
@@ -53,14 +53,16 @@ public class QuickAliasSettingsTests
 	}
 
 	[Fact]
-	public void LoginPassword_IsSerializedForLocalStorage()
+	public void CreatePersistentCopy_RemovesLoginPasswordFromLocalStoragePayload()
 	{
 		var settings = QuickAliasSettings.CreateDefault();
 		settings.Login.Password = "secret";
 
-		var json = JsonSerializer.Serialize(settings, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+		var json = JsonSerializer.Serialize(
+			QuickAliasSettings.CreatePersistentCopy(settings),
+			new JsonSerializerOptions(JsonSerializerDefaults.Web));
 
-		Assert.Contains("secret", json);
+		Assert.DoesNotContain("secret", json);
 		Assert.Contains("password", json, StringComparison.OrdinalIgnoreCase);
 	}
 

--- a/MudClient/MudClientTests/TelnetStreamParserTests.cs
+++ b/MudClient/MudClientTests/TelnetStreamParserTests.cs
@@ -1,0 +1,65 @@
+using MudClientBlazor;
+using MudClientBlazor.Services;
+
+namespace MudClientTests;
+
+public class TelnetStreamParserTests
+{
+	[Fact]
+	public void Feed_PreservesNegotiationSplitAcrossReads()
+	{
+		var parser = new TelnetStreamParser();
+
+		Assert.Empty(parser.Feed([TelnetConstants.IAC, TelnetConstants.WILL]));
+		var telnetEvent = Assert.Single(parser.Feed([TelnetConstants.TELOPT_MXP]));
+
+		var negotiation = Assert.IsType<TelnetNegotiationEvent>(telnetEvent);
+		Assert.Equal(TelnetConstants.WILL, negotiation.Command);
+		Assert.Equal(TelnetConstants.TELOPT_MXP, negotiation.Option);
+	}
+
+	[Fact]
+	public void Feed_PreservesSubnegotiationAndEscapedIacAcrossReads()
+	{
+		var parser = new TelnetStreamParser();
+
+		Assert.Empty(parser.Feed([
+			TelnetConstants.IAC,
+			TelnetConstants.SB,
+			TelnetConstants.TELOPT_CHARSET,
+			1,
+			(byte)' ',
+			(byte)'U',
+			TelnetConstants.IAC
+		]));
+
+		var telnetEvent = Assert.Single(parser.Feed([
+			TelnetConstants.IAC,
+			(byte)'8',
+			TelnetConstants.IAC,
+			TelnetConstants.SE
+		]));
+
+		var subnegotiation = Assert.IsType<TelnetSubnegotiationEvent>(telnetEvent);
+		Assert.Equal(TelnetConstants.TELOPT_CHARSET, subnegotiation.Option);
+		Assert.Equal([1, (byte)' ', (byte)'U', TelnetConstants.IAC, (byte)'8'], subnegotiation.Data);
+	}
+
+	[Fact]
+	public void Feed_EmitsDataAndPromptBoundaryInOrder()
+	{
+		var parser = new TelnetStreamParser();
+
+		var events = parser.Feed([
+			(byte)'O',
+			(byte)'K',
+			TelnetConstants.IAC,
+			TelnetConstants.EOR
+		]);
+
+		Assert.Collection(
+			events,
+			telnetEvent => Assert.Equal([(byte)'O', (byte)'K'], Assert.IsType<TelnetDataEvent>(telnetEvent).Data),
+			telnetEvent => Assert.Equal(TelnetConstants.EOR, Assert.IsType<TelnetCommandEvent>(telnetEvent).Command));
+	}
+}

--- a/MudClient/MudClientTests/WebSocketHandlerTests.cs
+++ b/MudClient/MudClientTests/WebSocketHandlerTests.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using MudWebSocketProxy.Handlers;
+using MudWebSocketProxy.Security;
 
 namespace MudClientTests;
 
@@ -49,7 +50,10 @@ public class WebSocketHandlerTests
 			.AddInMemoryCollection(values)
 			.Build();
 
-		return new WebSocketHandler(new TestLogger<WebSocketHandler>(), configuration);
+		return new WebSocketHandler(
+			new TestLogger<WebSocketHandler>(),
+			configuration,
+			ProxyLimits.FromConfiguration(configuration));
 	}
 
 	private static int GetUnusedTcpPort()

--- a/MudClient/MudWebSocketProxy/Handlers/WebSocketHandler.cs
+++ b/MudClient/MudWebSocketProxy/Handlers/WebSocketHandler.cs
@@ -1,10 +1,11 @@
-﻿using System.Net.Sockets;
+using System.Net.Sockets;
 using System.Net.WebSockets;
 using System.Text;
+using MudWebSocketProxy.Security;
 
 namespace MudWebSocketProxy.Handlers;
 
-public class WebSocketHandler
+public sealed class WebSocketHandler
 {
 	private const string ClientConfigurationErrorMessage =
 		"Proxy configuration error. Check the proxy logs for details.";
@@ -14,11 +15,16 @@ public class WebSocketHandler
 
 	private readonly ILogger<WebSocketHandler> _logger;
 	private readonly IConfiguration _configuration;
+	private readonly ProxyLimits _limits;
 
-	public WebSocketHandler(ILogger<WebSocketHandler> logger, IConfiguration configuration)
+	public WebSocketHandler(
+		ILogger<WebSocketHandler> logger,
+		IConfiguration configuration,
+		ProxyLimits limits)
 	{
 		_logger = logger;
 		_configuration = configuration;
+		_limits = limits;
 	}
 
 	public async Task HandleWebSocketAsync(HttpContext context, WebSocket webSocket)
@@ -28,7 +34,7 @@ public class WebSocketHandler
 
 		if (string.IsNullOrWhiteSpace(mudServerAddress) ||
 		    !int.TryParse(mudServerPortText, out var mudServerPort) ||
-		    mudServerPort is < 1 or > 65535)
+		    mudServerPort is < 1 or > 65_535)
 		{
 			_logger.LogError(
 				"Proxy configuration error: MudServer:Address and MudServer:Port must be configured before the proxy can connect to the MUD server.");
@@ -36,23 +42,55 @@ public class WebSocketHandler
 			return;
 		}
 
+		using var connectionCancellation = CancellationTokenSource.CreateLinkedTokenSource(context.RequestAborted);
 		try
 		{
 			using var tcpClient = new TcpClient();
-			await tcpClient.ConnectAsync(mudServerAddress, mudServerPort);
-			_logger.LogInformation("MUD connection established to {Address}:{Port}", mudServerAddress, mudServerPort);
-			using var networkStream = tcpClient.GetStream();
+			using (var connectTimeout = CancellationTokenSource.CreateLinkedTokenSource(connectionCancellation.Token))
+			{
+				connectTimeout.CancelAfter(_limits.MudConnectionTimeout);
+				await tcpClient.ConnectAsync(mudServerAddress, mudServerPort, connectTimeout.Token);
+			}
 
-			var receiveFromWebSocketTask = ReceiveFromWebSocketAsync(webSocket, networkStream);
-			var sendToWebSocketTask = SendToWebSocketAsync(webSocket, networkStream);
+			tcpClient.NoDelay = true;
+			_logger.LogInformation("MUD connection established to {Address}:{Port}", mudServerAddress, mudServerPort);
+			await using var networkStream = tcpClient.GetStream();
+
+			var receiveFromWebSocketTask = ReceiveFromWebSocketAsync(webSocket, networkStream, connectionCancellation.Token);
+			var sendToWebSocketTask = SendToWebSocketAsync(webSocket, networkStream, connectionCancellation.Token);
 
 			await Task.WhenAny(receiveFromWebSocketTask, sendToWebSocketTask);
+			await connectionCancellation.CancelAsync();
 
-			if (webSocket.State == WebSocketState.Open)
+			try
 			{
-				await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Connection closed", CancellationToken.None);
+				await Task.WhenAll(receiveFromWebSocketTask, sendToWebSocketTask);
 			}
-			_logger.LogInformation("MUD Connection Closed");
+			catch (OperationCanceledException) when (connectionCancellation.IsCancellationRequested)
+			{
+			}
+			catch (Exception ex) when (
+				connectionCancellation.IsCancellationRequested &&
+				ex is IOException or WebSocketException or ObjectDisposedException)
+			{
+				_logger.LogDebug("Proxy transport closed while its paired relay task was stopping.");
+			}
+
+			await CloseIfOpenAsync(webSocket, WebSocketCloseStatus.NormalClosure, "Connection closed");
+			_logger.LogInformation("MUD connection closed");
+		}
+		catch (OperationCanceledException) when (!context.RequestAborted.IsCancellationRequested)
+		{
+			_logger.LogWarning(
+				"Timed out connecting to MUD server {Address}:{Port} after {Timeout}.",
+				mudServerAddress,
+				mudServerPort,
+				_limits.MudConnectionTimeout);
+			await SendErrorAndCloseAsync(webSocket, ClientConnectionErrorMessage);
+		}
+		catch (OperationCanceledException)
+		{
+			_logger.LogDebug("WebSocket proxy connection was cancelled.");
 		}
 		catch (SocketException ex)
 		{
@@ -79,108 +117,112 @@ public class WebSocketHandler
 
 	private static async Task SendErrorAndCloseAsync(WebSocket webSocket, string message)
 	{
-		if (webSocket.State == WebSocketState.Open)
+		if (webSocket.State != WebSocketState.Open)
 		{
-			var bytes = Encoding.UTF8.GetBytes(message);
-			await webSocket.SendAsync(
-				new ArraySegment<byte>(bytes),
-				WebSocketMessageType.Text,
-				true,
-				CancellationToken.None);
-
-			await webSocket.CloseAsync(WebSocketCloseStatus.InternalServerError, "Proxy connection error", CancellationToken.None);
+			return;
 		}
+
+		var bytes = Encoding.UTF8.GetBytes(message);
+		await webSocket.SendAsync(
+			new ArraySegment<byte>(bytes),
+			WebSocketMessageType.Text,
+			true,
+			CancellationToken.None);
+
+		await webSocket.CloseOutputAsync(
+			WebSocketCloseStatus.InternalServerError,
+			"Proxy connection error",
+			CancellationToken.None);
 	}
 
-	private async Task ReceiveFromWebSocketAsync(WebSocket webSocket, NetworkStream networkStream)
+	private async Task ReceiveFromWebSocketAsync(
+		WebSocket webSocket,
+		NetworkStream networkStream,
+		CancellationToken cancellationToken)
 	{
-		try
+		var buffer = new byte[16_384];
+		var trafficLimiter = new ClientTrafficLimiter(_limits, DateTimeOffset.UtcNow);
+
+		while (webSocket.State == WebSocketState.Open && !cancellationToken.IsCancellationRequested)
 		{
-			var buffer = new byte[40960];
-
-			while (webSocket.State == WebSocketState.Open)
+			using var message = new MemoryStream();
+			WebSocketReceiveResult result;
+			do
 			{
-				var result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
-
+				result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), cancellationToken);
 				if (result.MessageType == WebSocketMessageType.Close)
 				{
-					break;
+					return;
 				}
 
-				if (result.MessageType == WebSocketMessageType.Binary)
+				if (result.MessageType != WebSocketMessageType.Binary)
 				{
-					await networkStream.WriteAsync(buffer, 0, result.Count);
-					await networkStream.FlushAsync();
+					await CloseIfOpenAsync(webSocket, WebSocketCloseStatus.InvalidMessageType, "Binary messages are required");
+					return;
 				}
-				else if (result.MessageType == WebSocketMessageType.Text)
+
+				if (message.Length + result.Count > _limits.MaximumClientMessageBytes)
 				{
-					// Optionally handle text messages if needed
-					_logger.LogWarning("Received Text message from client; expected Binary.");
+					await CloseIfOpenAsync(webSocket, WebSocketCloseStatus.MessageTooBig, "Client message is too large");
+					return;
 				}
-				else
-				{
-					_logger.LogWarning($"Received unsupported message type: {result.MessageType}");
-				}
+
+				message.Write(buffer, 0, result.Count);
 			}
-		}
-		catch (Exception ex)
-		{
-			_logger.LogError(ex, "An error occurred in ReceiveFromWebSocketAsync");
+			while (!result.EndOfMessage);
+
+			var messageLength = checked((int)message.Length);
+			if (!trafficLimiter.TryConsumeMessage(messageLength, DateTimeOffset.UtcNow))
+			{
+				await CloseIfOpenAsync(webSocket, WebSocketCloseStatus.PolicyViolation, "Client send rate exceeded");
+				return;
+			}
+
+			if (message.TryGetBuffer(out var segment))
+			{
+				await networkStream.WriteAsync(segment.AsMemory(0, messageLength), cancellationToken);
+			}
 		}
 	}
 
-	private async Task SendToWebSocketAsync(WebSocket webSocket, NetworkStream networkStream)
+	private async Task SendToWebSocketAsync(
+		WebSocket webSocket,
+		NetworkStream networkStream,
+		CancellationToken cancellationToken)
 	{
-		try
+		var buffer = new byte[40_960];
+		var trafficLimiter = new ByteTrafficLimiter(_limits.MaximumMudBytesPerSecond, DateTimeOffset.UtcNow);
+
+		while (webSocket.State == WebSocketState.Open && !cancellationToken.IsCancellationRequested)
 		{
-			var buffer = new byte[40960];
-
-			while (webSocket.State == WebSocketState.Open)
+			var bytesRead = await networkStream.ReadAsync(buffer, cancellationToken);
+			if (bytesRead == 0)
 			{
-				int bytesRead = 0;
-				try
-				{
-					bytesRead = await networkStream.ReadAsync(buffer, 0, buffer.Length);
-				}
-				catch (Exception ex)
-				{
-					_logger.LogError(ex, "Error reading from network stream.");
-					break;
-				}
-
-				if (bytesRead == 0)
-				{
-					// The MUD server closed the connection
-					_logger.LogInformation("MUD server closed the connection.");
-					break;
-				}
-
-				try
-				{
-					// Send the bytes directly to the WebSocket client as a binary message
-					await webSocket.SendAsync(
-						new ArraySegment<byte>(buffer, 0, bytesRead),
-						WebSocketMessageType.Binary,
-						true,
-						CancellationToken.None
-					);
-				}
-				catch (Exception ex)
-				{
-					_logger.LogError(ex, "Error sending message to WebSocket client.");
-					break;
-				}
+				return;
 			}
 
-			// Close the WebSocket connection if it's still open
-			if (webSocket.State == WebSocketState.Open)
+			if (!trafficLimiter.TryConsume(bytesRead, DateTimeOffset.UtcNow))
 			{
-				await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", CancellationToken.None);
+				await CloseIfOpenAsync(webSocket, WebSocketCloseStatus.PolicyViolation, "MUD output rate exceeded");
+				return;
 			}
+
+			await webSocket.SendAsync(
+				new ArraySegment<byte>(buffer, 0, bytesRead),
+				WebSocketMessageType.Binary,
+				true,
+				cancellationToken);
 		}
-		catch (Exception ex)
+	}
+
+	private static async Task CloseIfOpenAsync(
+		WebSocket webSocket,
+		WebSocketCloseStatus status,
+		string description)
+	{
+		if (webSocket.State == WebSocketState.Open)
 		{
-			_logger.LogError(ex, "An error occurred in SendToWebSocketAsync");
+			await webSocket.CloseOutputAsync(status, description, CancellationToken.None);
 		}
 	}
 }

--- a/MudClient/MudWebSocketProxy/Program.cs
+++ b/MudClient/MudWebSocketProxy/Program.cs
@@ -1,8 +1,11 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.WebSockets;
+using Microsoft.AspNetCore.HttpOverrides;
+using System.Net;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using MudWebSocketProxy.Handlers;
+using MudWebSocketProxy.Security;
 
 namespace MudWebSocketProxy;
 
@@ -42,11 +45,21 @@ public class Program
 		});
 
 		builder.Services.AddTransient<WebSocketHandler>();
+		builder.Services.AddSingleton(ProxyLimits.FromConfiguration(builder.Configuration));
+		builder.Services.AddSingleton<ProxyConnectionLimiter>();
 
 		builder.Logging.ClearProviders();
 		builder.Logging.AddConsole();
 
 		var app = builder.Build();
+		var forwardedHeadersOptions = new ForwardedHeadersOptions
+		{
+			ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto,
+			ForwardLimit = 1
+		};
+		forwardedHeadersOptions.KnownProxies.Add(IPAddress.Loopback);
+		forwardedHeadersOptions.KnownProxies.Add(IPAddress.IPv6Loopback);
+		app.UseForwardedHeaders(forwardedHeadersOptions);
 		app.UseCors();
 		app.UseWebSockets();
 
@@ -63,8 +76,17 @@ public class Program
 					return;
 				}
 
-				var webSocket = await context.WebSockets.AcceptWebSocketAsync();
+				var connectionLimiter = context.RequestServices.GetRequiredService<ProxyConnectionLimiter>();
+				var clientAddress = context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+				using var connectionLease = connectionLimiter.TryAcquire(clientAddress);
+				if (connectionLease == null)
+				{
+					context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+					await context.Response.WriteAsync("Too many active WebSocket connections.");
+					return;
+				}
 
+				var webSocket = await context.WebSockets.AcceptWebSocketAsync();
 				var webSocketHandler = context.RequestServices.GetRequiredService<WebSocketHandler>();
 				await webSocketHandler.HandleWebSocketAsync(context, webSocket);
 			}
@@ -90,28 +112,24 @@ public class Program
 	private static bool IsRequestOriginAllowed(HttpContext context, IConfiguration configuration)
 	{
 		var origin = context.Request.Headers.Origin.ToString();
-		return string.IsNullOrWhiteSpace(origin) || IsConfiguredOriginAllowed(origin, configuration);
+		var requireOrigin = configuration.GetValue("WebSocketServer:RequireOrigin", true);
+		return WebSocketOriginPolicy.IsAllowed(
+			origin,
+			requireOrigin,
+			configuration
+				.GetSection("WebSocketServer:AllowedOrigins")
+				.GetChildren()
+				.Select(section => section.Value));
 	}
 
 	private static bool IsConfiguredOriginAllowed(string origin, IConfiguration configuration)
 	{
-		var normalizedOrigin = NormalizeOrigin(origin);
-		return configuration
-			.GetSection("WebSocketServer:AllowedOrigins")
-			.GetChildren()
-			.Select(section => section.Value)
-			.Where(allowedOrigin => !string.IsNullOrWhiteSpace(allowedOrigin))
-			.Select(allowedOrigin => NormalizeOrigin(allowedOrigin!))
-			.Any(allowedOrigin => string.Equals(allowedOrigin, normalizedOrigin, StringComparison.OrdinalIgnoreCase));
-	}
-
-	private static string NormalizeOrigin(string origin)
-	{
-		if (Uri.TryCreate(origin, UriKind.Absolute, out var uri))
-		{
-			return uri.GetLeftPart(UriPartial.Authority).TrimEnd('/');
-		}
-
-		return origin.Trim().TrimEnd('/');
+		return WebSocketOriginPolicy.IsAllowed(
+			origin,
+			true,
+			configuration
+				.GetSection("WebSocketServer:AllowedOrigins")
+				.GetChildren()
+				.Select(section => section.Value));
 	}
 }

--- a/MudClient/MudWebSocketProxy/Security/ByteTrafficLimiter.cs
+++ b/MudClient/MudWebSocketProxy/Security/ByteTrafficLimiter.cs
@@ -1,0 +1,36 @@
+namespace MudWebSocketProxy.Security;
+
+public sealed class ByteTrafficLimiter
+{
+	private readonly int _maximumBytesPerSecond;
+	private DateTimeOffset _windowStarted;
+	private int _bytes;
+
+	public ByteTrafficLimiter(int maximumBytesPerSecond, DateTimeOffset now)
+	{
+		if (maximumBytesPerSecond < 1)
+		{
+			throw new ArgumentOutOfRangeException(nameof(maximumBytesPerSecond));
+		}
+
+		_maximumBytesPerSecond = maximumBytesPerSecond;
+		_windowStarted = now;
+	}
+
+	public bool TryConsume(int bytes, DateTimeOffset now)
+	{
+		if (now - _windowStarted >= TimeSpan.FromSeconds(1))
+		{
+			_windowStarted = now;
+			_bytes = 0;
+		}
+
+		if (bytes < 0 || _bytes + bytes > _maximumBytesPerSecond)
+		{
+			return false;
+		}
+
+		_bytes += bytes;
+		return true;
+	}
+}

--- a/MudClient/MudWebSocketProxy/Security/ClientTrafficLimiter.cs
+++ b/MudClient/MudWebSocketProxy/Security/ClientTrafficLimiter.cs
@@ -1,0 +1,36 @@
+namespace MudWebSocketProxy.Security;
+
+public sealed class ClientTrafficLimiter
+{
+	private readonly ProxyLimits _limits;
+	private DateTimeOffset _windowStarted;
+	private int _messages;
+	private int _bytes;
+
+	public ClientTrafficLimiter(ProxyLimits limits, DateTimeOffset now)
+	{
+		_limits = limits;
+		_windowStarted = now;
+	}
+
+	public bool TryConsumeMessage(int bytes, DateTimeOffset now)
+	{
+		if (now - _windowStarted >= TimeSpan.FromSeconds(1))
+		{
+			_windowStarted = now;
+			_messages = 0;
+			_bytes = 0;
+		}
+
+		if (bytes < 0 ||
+		    _messages + 1 > _limits.MaximumClientMessagesPerSecond ||
+		    _bytes + bytes > _limits.MaximumClientBytesPerSecond)
+		{
+			return false;
+		}
+
+		_messages++;
+		_bytes += bytes;
+		return true;
+	}
+}

--- a/MudClient/MudWebSocketProxy/Security/ProxyConnectionLimiter.cs
+++ b/MudClient/MudWebSocketProxy/Security/ProxyConnectionLimiter.cs
@@ -1,0 +1,62 @@
+using System.Collections.Concurrent;
+
+namespace MudWebSocketProxy.Security;
+
+public sealed class ProxyConnectionLimiter
+{
+	private readonly ProxyLimits _limits;
+	private readonly ConcurrentDictionary<string, int> _connectionsByAddress = new(StringComparer.Ordinal);
+	private int _totalConnections;
+
+	public ProxyConnectionLimiter(ProxyLimits limits)
+	{
+		_limits = limits;
+	}
+
+	public IDisposable? TryAcquire(string address)
+	{
+		address = string.IsNullOrWhiteSpace(address) ? "unknown" : address;
+
+		if (Interlocked.Increment(ref _totalConnections) > _limits.MaximumConcurrentConnections)
+		{
+			Interlocked.Decrement(ref _totalConnections);
+			return null;
+		}
+
+		var addressCount = _connectionsByAddress.AddOrUpdate(address, 1, static (_, current) => current + 1);
+		if (addressCount > _limits.MaximumConnectionsPerIp)
+		{
+			Release(address);
+			return null;
+		}
+
+		return new Lease(this, address);
+	}
+
+	private void Release(string address)
+	{
+		Interlocked.Decrement(ref _totalConnections);
+		_connectionsByAddress.AddOrUpdate(address, 0, static (_, current) => Math.Max(0, current - 1));
+		if (_connectionsByAddress.TryGetValue(address, out var count) && count == 0)
+		{
+			_connectionsByAddress.TryRemove(new KeyValuePair<string, int>(address, 0));
+		}
+	}
+
+	private sealed class Lease : IDisposable
+	{
+		private ProxyConnectionLimiter? _owner;
+		private readonly string _address;
+
+		public Lease(ProxyConnectionLimiter owner, string address)
+		{
+			_owner = owner;
+			_address = address;
+		}
+
+		public void Dispose()
+		{
+			Interlocked.Exchange(ref _owner, null)?.Release(_address);
+		}
+	}
+}

--- a/MudClient/MudWebSocketProxy/Security/ProxyLimits.cs
+++ b/MudClient/MudWebSocketProxy/Security/ProxyLimits.cs
@@ -1,0 +1,34 @@
+namespace MudWebSocketProxy.Security;
+
+public sealed class ProxyLimits
+{
+	public int MaximumConcurrentConnections { get; init; } = 200;
+	public int MaximumConnectionsPerIp { get; init; } = 20;
+	public int MaximumClientMessageBytes { get; init; } = 65_536;
+	public int MaximumClientMessagesPerSecond { get; init; } = 30;
+	public int MaximumClientBytesPerSecond { get; init; } = 131_072;
+	public int MaximumMudBytesPerSecond { get; init; } = 2_097_152;
+	public TimeSpan MudConnectionTimeout { get; init; } = TimeSpan.FromSeconds(10);
+
+	public static ProxyLimits FromConfiguration(IConfiguration configuration)
+	{
+		ArgumentNullException.ThrowIfNull(configuration);
+
+		return new ProxyLimits
+		{
+			MaximumConcurrentConnections = ReadBounded(configuration, "ProxyLimits:MaximumConcurrentConnections", 200, 1, 10_000),
+			MaximumConnectionsPerIp = ReadBounded(configuration, "ProxyLimits:MaximumConnectionsPerIp", 20, 1, 1_000),
+			MaximumClientMessageBytes = ReadBounded(configuration, "ProxyLimits:MaximumClientMessageBytes", 65_536, 1_024, 1_048_576),
+			MaximumClientMessagesPerSecond = ReadBounded(configuration, "ProxyLimits:MaximumClientMessagesPerSecond", 30, 1, 1_000),
+			MaximumClientBytesPerSecond = ReadBounded(configuration, "ProxyLimits:MaximumClientBytesPerSecond", 131_072, 1_024, 16_777_216),
+			MaximumMudBytesPerSecond = ReadBounded(configuration, "ProxyLimits:MaximumMudBytesPerSecond", 2_097_152, 4_096, 67_108_864),
+			MudConnectionTimeout = TimeSpan.FromSeconds(ReadBounded(configuration, "ProxyLimits:MudConnectionTimeoutSeconds", 10, 1, 120))
+		};
+	}
+
+	private static int ReadBounded(IConfiguration configuration, string key, int fallback, int minimum, int maximum)
+	{
+		var value = configuration.GetValue<int?>(key) ?? fallback;
+		return Math.Clamp(value, minimum, maximum);
+	}
+}

--- a/MudClient/MudWebSocketProxy/Security/WebSocketOriginPolicy.cs
+++ b/MudClient/MudWebSocketProxy/Security/WebSocketOriginPolicy.cs
@@ -1,0 +1,30 @@
+namespace MudWebSocketProxy.Security;
+
+public static class WebSocketOriginPolicy
+{
+	public static bool IsAllowed(string? origin, bool requireOrigin, IEnumerable<string?> allowedOrigins)
+	{
+		ArgumentNullException.ThrowIfNull(allowedOrigins);
+
+		if (string.IsNullOrWhiteSpace(origin))
+		{
+			return !requireOrigin;
+		}
+
+		var normalizedOrigin = Normalize(origin);
+		return allowedOrigins
+			.Where(allowedOrigin => !string.IsNullOrWhiteSpace(allowedOrigin))
+			.Select(allowedOrigin => Normalize(allowedOrigin!))
+			.Any(allowedOrigin => string.Equals(allowedOrigin, normalizedOrigin, StringComparison.OrdinalIgnoreCase));
+	}
+
+	private static string Normalize(string origin)
+	{
+		if (Uri.TryCreate(origin, UriKind.Absolute, out var uri))
+		{
+			return uri.GetLeftPart(UriPartial.Authority).TrimEnd('/');
+		}
+
+		return origin.Trim().TrimEnd('/');
+	}
+}

--- a/MudClient/MudWebSocketProxy/appsettings.json
+++ b/MudClient/MudWebSocketProxy/appsettings.json
@@ -12,9 +12,19 @@
   },
   "WebSocketServer": {
     "Path": "/ws",
+    "RequireOrigin": true,
     "AllowedOrigins": [
       "http://localhost:5002",
       "http://127.0.0.1:5002"
     ]
+  },
+  "ProxyLimits": {
+    "MaximumConcurrentConnections": 200,
+    "MaximumConnectionsPerIp": 20,
+    "MaximumClientMessageBytes": 65536,
+    "MaximumClientMessagesPerSecond": 30,
+    "MaximumClientBytesPerSecond": 131072,
+	"MaximumMudBytesPerSecond": 2097152,
+    "MudConnectionTimeoutSeconds": 10
   }
 }

--- a/MudClient/deploy/Caddyfile
+++ b/MudClient/deploy/Caddyfile
@@ -2,8 +2,16 @@
 play.example.com {
 	root * /opt/mudclient/web/wwwroot
 	encode gzip zstd
+	header {
+		Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' wss:; img-src 'self' https: data:; font-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'none'"
+		Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=()"
+		Referrer-Policy "no-referrer"
+		Strict-Transport-Security "max-age=31536000"
+		X-Content-Type-Options "nosniff"
+		X-Frame-Options "DENY"
+	}
 
-	handle /ws* {
+	handle /ws {
 		reverse_proxy 127.0.0.1:5000
 	}
 

--- a/MudClient/deploy/linux/install-mudclient.sh
+++ b/MudClient/deploy/linux/install-mudclient.sh
@@ -90,6 +90,7 @@ cat >"$config_path" <<EOF
   },
   "WebSocketServer": {
     "Path": "/ws",
+	"RequireOrigin": true,
     "AllowedOrigins": [
       "https://$domain"
     ]
@@ -110,7 +111,15 @@ cat >"$fragment_path" <<EOF
 $domain {
 	root * $install_root/web/wwwroot
 	encode gzip zstd
-	handle /ws* {
+	header {
+		Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' wss:; img-src 'self' https: data:; font-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'none'"
+		Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=()"
+		Referrer-Policy "no-referrer"
+		Strict-Transport-Security "max-age=31536000"
+		X-Content-Type-Options "nosniff"
+		X-Frame-Options "DENY"
+	}
+	handle /ws {
 		reverse_proxy 127.0.0.1:5000
 	}
 	try_files {path} {path}/ /index.html

--- a/MudClient/deploy/linux/nginx-mudclient.conf
+++ b/MudClient/deploy/linux/nginx-mudclient.conf
@@ -6,7 +6,13 @@ server {
     root /opt/mudclient/web/wwwroot;
     index index.html;
 
-    location /ws {
+	add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' wss:; img-src 'self' https: data:; font-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'none'" always;
+	add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=()" always;
+	add_header Referrer-Policy "no-referrer" always;
+	add_header X-Content-Type-Options "nosniff" always;
+	add_header X-Frame-Options "DENY" always;
+
+	location = /ws {
         proxy_pass http://127.0.0.1:5000/ws;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/MudClient/deploy/windows/Caddyfile
+++ b/MudClient/deploy/windows/Caddyfile
@@ -2,8 +2,16 @@
 play.example.com {
 	root * C:\MudClient\web\wwwroot
 	encode gzip zstd
+	header {
+		Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' wss:; img-src 'self' https: data:; font-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'none'"
+		Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=()"
+		Referrer-Policy "no-referrer"
+		Strict-Transport-Security "max-age=31536000"
+		X-Content-Type-Options "nosniff"
+		X-Frame-Options "DENY"
+	}
 
-	handle /ws* {
+	handle /ws {
 		reverse_proxy 127.0.0.1:5000
 	}
 

--- a/MudClient/scripts/Publish-ProductPackage.ps1
+++ b/MudClient/scripts/Publish-ProductPackage.ps1
@@ -51,7 +51,7 @@ Invoke-DotNet @(
 Invoke-DotNet @(
 	"publish", "MudWebSocketProxy/MudWebSocketProxy.csproj", "-c", $Configuration, "--no-restore",
 	"-r", $RuntimeIdentifier, "--self-contained", "true", "-p:PublishSingleFile=true",
-	"-p:IncludeNativeLibrariesForSelfExtract=true", "-p:Version=$Version",
+	"-p:IncludeNativeLibrariesForSelfExtract=true", "-p:DebugType=embedded", "-p:Version=$Version",
 	"-p:ContinuousIntegrationBuild=true", "-o", $proxyPublish)
 
 New-Item -ItemType Directory -Force -Path (Join-Path $packageRoot "web"), (Join-Path $packageRoot "proxy") | Out-Null

--- a/MudClient/scripts/publish-release.ps1
+++ b/MudClient/scripts/publish-release.ps1
@@ -72,7 +72,7 @@ if (-not $SkipTests) {
 }
 
 Invoke-DotNet @("publish", "MudClientBlazor/MudClientBlazor.csproj", "-c", $Configuration, "--no-restore", "-o", $webPublish)
-Invoke-DotNet @("publish", "MudWebSocketProxy/MudWebSocketProxy.csproj", "-c", $Configuration, "-r", $RuntimeIdentifier, "--self-contained", "true", "-p:PublishSingleFile=true", "-o", $proxyPublish)
+Invoke-DotNet @("publish", "MudWebSocketProxy/MudWebSocketProxy.csproj", "-c", $Configuration, "-r", $RuntimeIdentifier, "--self-contained", "true", "-p:PublishSingleFile=true", "-p:IncludeNativeLibrariesForSelfExtract=true", "-p:DebugType=embedded", "-o", $proxyPublish)
 
 New-Item -ItemType Directory -Force -Path (Join-Path $packageRoot "web"), (Join-Path $packageRoot "proxy") | Out-Null
 Copy-Item -Path (Join-Path $webPublish "*") -Destination (Join-Path $packageRoot "web") -Recurse -Force

--- a/MudClient/scripts/publish-release.sh
+++ b/MudClient/scripts/publish-release.sh
@@ -49,7 +49,7 @@ if [[ "$skip_tests" != "1" ]]; then
 fi
 
 dotnet publish MudClientBlazor/MudClientBlazor.csproj -c "$configuration" --no-restore -o "$web_publish"
-dotnet publish MudWebSocketProxy/MudWebSocketProxy.csproj -c "$configuration" -r "$runtime_identifier" --self-contained true -p:PublishSingleFile=true -o "$proxy_publish"
+dotnet publish MudWebSocketProxy/MudWebSocketProxy.csproj -c "$configuration" -r "$runtime_identifier" --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugType=embedded -o "$proxy_publish"
 
 mkdir -p "$package_root/web" "$package_root/proxy"
 cp -R "$web_publish"/. "$package_root/web/"


### PR DESCRIPTION
## Summary
- Harden the MudClient 1.0.0 public release across Telnet/ANSI handling, responsive UI, command batching, proxy security, packaging, and deployment guidance.
- Add regression coverage for stream parsing, bounded transcripts, client settings, and proxy security limits.
- Add a fail-closed dependency-audit gate to product publishing.

## Validation
- `dotnet test MudClient/MudClientTests/MudClientTests.csproj -c Debug --no-restore -m:1` (106 passed)
- `dotnet test MudClient/MudClientTests/MudClientTests.csproj -c Release --no-restore -m:1` (106 passed)
- Windows x64 package inspected; shell and PowerShell release scripts syntax-checked; `git diff --check` passed.
- Live FutureMUD browser verification on desktop, tablet, and phone.