### PR TITLE
Version update to 1.0.1

### DIFF
--- a/.github/workflows/publish-products.yml
+++ b/.github/workflows/publish-products.yml
@@ -292,7 +292,7 @@ jobs:
         if: needs.prepare.outputs.package_kind == 'mudclient'
         shell: pwsh
         run: |
-          dotnet restore MudClient/MudClientSolution.sln -m:1 -p:RestoreBuildInParallel=false -p:NuGetAudit=true -p:NuGetAuditMode=all "-p:WarningsAsErrors=NU1900;NU1901;NU1902;NU1903;NU1904"
+          dotnet restore MudClient/MudClientSolution.sln -m:1 -p:RestoreBuildInParallel=false -p:NuGetAudit=true -p:NuGetAuditMode=all "-p:WarningsAsErrors=NU1900%3BNU1901%3BNU1902%3BNU1903%3BNU1904"
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
       - name: Run targeted tests
         if: needs.prepare.outputs.tests != ''

--- a/FutureMUD.Web/Content/PatchNotes/2026-08-03-mudclient-1-0-1.md
+++ b/FutureMUD.Web/Content/PatchNotes/2026-08-03-mudclient-1-0-1.md
@@ -1,0 +1,16 @@
+---
+title: FutureMUD Web MUD Client 1.0.1
+summary: First public release of the secure, responsive FutureMUD Web MUD Client.
+date: 2026-08-03
+tags: mudclient, release, web-client
+---
+FutureMUD Web MUD Client 1.0.1 is the first public release of the browser-based client and private WebSocket-to-Telnet proxy package.
+
+## Highlights
+
+- Responsive desktop, tablet and phone interface with native text entry, bounded scrollback and reliable long-session performance.
+- FutureMUD-aligned Telnet, ANSI, MXP, UTF-8 character-set and End-of-Record handling.
+- Configurable multi-line command pacing, cancellation and safe local text-file loading for reviewing large pasted content.
+- Origin validation, connection and traffic limits, private Telnet forwarding, hardened deployment examples and no persisted Quick Login passwords.
+
+Download Windows x64, Linux x64 or Linux ARM64 packages and matching SHA-256 checksums from `/downloads`. Each operator hosts the static client and proxy near their own MUD's private Telnet listener; see the included deployment guide for Caddy and Nginx examples.

--- a/MudClient/DEPLOYMENT.md
+++ b/MudClient/DEPLOYMENT.md
@@ -32,8 +32,8 @@ Linux additionally requires systemd, bash, curl, unzip, and Caddy v2 managed by 
 After verifying the website's published SHA-256 checksum, extract the downloaded package to `/opt/mudclient` and run the installer from that directory:
 
 ~~~bash
-unzip mudclient-1.0.0-linux-x64.zip -d /tmp/mudclient-package
-sudo mv /tmp/mudclient-package/mudclient-1.0.0-linux-x64 /opt/mudclient
+unzip mudclient-1.0.1-linux-x64.zip -d /tmp/mudclient-package
+sudo mv /tmp/mudclient-package/mudclient-1.0.1-linux-x64 /opt/mudclient
 sudo bash /opt/mudclient/deploy/linux/install-mudclient.sh play.example.com
 ~~~
 
@@ -56,7 +56,7 @@ dotnet workload install wasm-tools
 ```
 
 ```powershell
-.\scripts\Publish-ProductPackage.ps1 -RuntimeIdentifier win-x64 -Version 1.0.0
+.\scripts\Publish-ProductPackage.ps1 -RuntimeIdentifier win-x64 -Version 1.0.1
 ```
 
 ```bash

--- a/MudClient/MudWebSocketProxy/MudWebSocketProxy.csproj
+++ b/MudClient/MudWebSocketProxy/MudWebSocketProxy.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Correct the MudClient release dependency-audit MSBuild escaping so the intended NU1900-NU1904 gate executes rather than failing argument parsing.
- Bump the first publishable MudClient artifact to 1.0.1 because immutable `mudclient-v1.0.0` failed before publication and cannot be reused.
- Add the first public MudClient release note and update deployment examples.

## Validation
- `dotnet restore MudClient/MudClientSolution.sln -m:1 -p:RestoreBuildInParallel=false -p:NuGetAudit=false -p:WarningsAsErrors=NU1900%3BNU1901%3BNU1902%3BNU1903%3BNU1904`
- `dotnet test MudClient/MudClientTests/MudClientTests.csproj -c Release --no-restore -m:1` (106 passed)
- `git diff --check`