### PR TITLE
Improve MudClient output and input navigation

### DIFF
--- a/MudClient/MudClientBlazor/Pages/Index.razor
+++ b/MudClient/MudClientBlazor/Pages/Index.razor
@@ -12,7 +12,7 @@
 <div class="app-root" style="@GetClientStyle()">
 	<div class="app-grid">
 		<div class="play-surface">
-			<div class="message-container" @ref="MessageContainer">
+			<div class="message-container" @ref="MessageContainer" tabindex="0" role="region" aria-label="MUD output">
 				@foreach (var message in _transcript.RenderedEntries)
 				{
 					<div @key="message.Id">@(new MarkupString(message.Html))</div>
@@ -451,7 +451,6 @@
 		// Pass the object reference to JavaScript
 		await JSRuntime.InvokeVoidAsync("registerSendCommandHandler", _objectReference);
 		await JSRuntime.InvokeVoidAsync("mudClientHotkeys.register", _objectReference);
-		await JSRuntime.InvokeVoidAsync("mudClientInput.register", "userInput");
 		await LoadClientSettingsAsync();
 		await LoadHotkeySettingsAsync();
 		await LoadQuickAliasSettingsAsync();
@@ -469,6 +468,17 @@
 
 		// Connect to the local WebSocket proxy. The proxy then connects to the telnet MUD server.
 		await ConnectToWebSocketAsync(_webSocketEndpoint);
+	}
+
+	protected override async Task OnAfterRenderAsync(bool firstRender)
+	{
+		if (!firstRender)
+		{
+			return;
+		}
+
+		await JSRuntime.InvokeVoidAsync("mudClientInput.register", "userInput", _objectReference);
+		await JSRuntime.InvokeVoidAsync("mudClientTranscript.register", MessageContainer);
 	}
 
 	private IEnumerable<HotkeyBinding> DesktopHotkeyBindings => GetOrderedActiveHotkeyBindings(DesktopHotkeySortOrder);
@@ -1063,7 +1073,7 @@
 			_pendingServerText.Clear();
 			await _clientWebSocket.ConnectAsync(endpoint, _cancellationTokenSource.Token);
 			isConnected = true;
-			AddMessage($"Connected to WebSocket proxy at {EscapeHtml(endpoint.ToString())}.");
+			AddMessage(_ansiMxpParser.Parse("\x1B[92mConnected to the MUD.\x1B[0m\n"));
 			_ = ReceiveMessagesAsync(_clientWebSocket);
 			return true;
 		}
@@ -1193,7 +1203,6 @@
 
 		AddMessage(parsedMessage);
 		await InvokeAsync(StateHasChanged);
-		await JSRuntime.InvokeVoidAsync("scrollToBottomIfNearBottom", MessageContainer);
 	}
 
 	private async Task HandleTelnetNegotiationAsync(byte command, byte option)
@@ -1508,7 +1517,6 @@
 		}
 
 		await InvokeAsync(StateHasChanged);
-		await JSRuntime.InvokeVoidAsync("scrollToBottomIfNearBottom", MessageContainer);
 		return completed;
 	}
 
@@ -1582,66 +1590,38 @@
 			}
 
 			CommandHistoryIndex = CommandHistory.Count;
+		}
+	}
+
+	[JSInvokable]
+	public async Task NavigateCommandHistory(string direction, bool jumpToBoundary)
+	{
+		var historyDirection = direction.ToLowerInvariant() switch
+		{
+			"up" => CommandHistoryDirection.Up,
+			"down" => CommandHistoryDirection.Down,
+			_ => (CommandHistoryDirection?)null
+		};
+
+		if (historyDirection is null)
+		{
 			return;
 		}
 
-		if (e.Key == "ArrowUp")
+		var navigation = CommandHistoryNavigator.Navigate(
+			CommandHistory,
+			CommandHistoryIndex,
+			historyDirection.Value,
+			jumpToBoundary);
+		if (!navigation.HasChanged)
 		{
-			if (e.CtrlKey && CommandHistory.Count > 0)
-			{
-				CommandHistoryIndex = 0;
-				UserInput = CommandHistory[CommandHistoryIndex];
-			}
-			else if (CommandHistory.Count > 0 && CommandHistoryIndex > 0)
-			{
-				CommandHistoryIndex--;
-				UserInput = CommandHistory[CommandHistoryIndex];
-			}
-
-			await InvokeAsync(StateHasChanged);
-			await JSRuntime.InvokeVoidAsync("setSelectionRange", "userInput", UserInput.Length);
 			return;
 		}
 
-		if (e.Key == "ArrowDown")
-		{
-			if (e.CtrlKey && CommandHistory.Count > 0)
-			{
-				CommandHistoryIndex = CommandHistory.Count - 1;
-				UserInput = CommandHistory[CommandHistoryIndex];
-			}
-			else if (CommandHistoryIndex < CommandHistory.Count - 1)
-			{
-				CommandHistoryIndex++;
-				UserInput = CommandHistory[CommandHistoryIndex];
-			}
-			else
-			{
-				CommandHistoryIndex = CommandHistory.Count;
-				UserInput = string.Empty;
-			}
-
-			await InvokeAsync(StateHasChanged);
-			await JSRuntime.InvokeVoidAsync("setSelectionRange", "userInput", UserInput.Length);
-			return;
-		}
-
-		if (e.Key == "Home" && e.CtrlKey && CommandHistory.Count > 0)
-		{
-			CommandHistoryIndex = 0;
-			UserInput = CommandHistory[CommandHistoryIndex];
-			await InvokeAsync(StateHasChanged);
-			await JSRuntime.InvokeVoidAsync("setSelectionRange", "userInput", UserInput.Length);
-			return;
-		}
-
-		if (e.Key == "End" && e.CtrlKey)
-		{
-			CommandHistoryIndex = CommandHistory.Count;
-			UserInput = string.Empty;
-			await InvokeAsync(StateHasChanged);
-			await JSRuntime.InvokeVoidAsync("setSelectionRange", "userInput", 0);
-		}
+		CommandHistoryIndex = navigation.Index;
+		UserInput = navigation.Input!;
+		await InvokeAsync(StateHasChanged);
+		await JSRuntime.InvokeVoidAsync("setSelectionRange", "userInput", UserInput.Length);
 	}
 
 	private async Task LoadTextFileAsync(InputFileChangeEventArgs args)
@@ -1678,6 +1658,7 @@
 		{
 			await JSRuntime.InvokeVoidAsync("mudClientHotkeys.dispose");
 			await JSRuntime.InvokeVoidAsync("mudClientInput.dispose");
+			await JSRuntime.InvokeVoidAsync("mudClientTranscript.dispose");
 			await JSRuntime.InvokeVoidAsync("disposeSendCommandHandler");
 		}
 		catch (JSDisconnectedException)
@@ -1780,9 +1761,9 @@
 				AddMessage("Cannot reconnect because the WebSocket proxy endpoint is not configured.");
 				isConnected = false;
 			}
-			else if (await ConnectToWebSocketAsync(_webSocketEndpoint))
+			else
 			{
-				AddMessage("Reconnected to the MUD.");
+				await ConnectToWebSocketAsync(_webSocketEndpoint);
 			}
 
 			await InvokeAsync(StateHasChanged);

--- a/MudClient/MudClientBlazor/Services/CommandHistoryNavigator.cs
+++ b/MudClient/MudClientBlazor/Services/CommandHistoryNavigator.cs
@@ -1,0 +1,69 @@
+namespace MudClientBlazor.Services;
+
+public enum CommandHistoryDirection
+{
+	Up,
+	Down
+}
+
+public readonly record struct CommandHistoryNavigation(int Index, string? Input)
+{
+	public bool HasChanged => Input is not null;
+}
+
+public static class CommandHistoryNavigator
+{
+	public static CommandHistoryNavigation Navigate(
+		IReadOnlyList<string> commandHistory,
+		int currentIndex,
+		CommandHistoryDirection direction,
+		bool jumpToBoundary)
+	{
+		ArgumentNullException.ThrowIfNull(commandHistory);
+
+		if (commandHistory.Count == 0)
+		{
+			return new CommandHistoryNavigation(currentIndex, null);
+		}
+
+		var index = currentIndex < 0
+			? commandHistory.Count
+			: Math.Clamp(currentIndex, 0, commandHistory.Count);
+		return direction switch
+		{
+			CommandHistoryDirection.Up => NavigateUp(commandHistory, index, jumpToBoundary),
+			CommandHistoryDirection.Down => NavigateDown(commandHistory, index, jumpToBoundary),
+			_ => throw new ArgumentOutOfRangeException(nameof(direction), direction, null)
+		};
+	}
+
+	private static CommandHistoryNavigation NavigateUp(
+		IReadOnlyList<string> commandHistory,
+		int currentIndex,
+		bool jumpToBoundary)
+	{
+		if (currentIndex == 0)
+		{
+			return new CommandHistoryNavigation(currentIndex, null);
+		}
+
+		var nextIndex = jumpToBoundary ? 0 : currentIndex - 1;
+		return new CommandHistoryNavigation(nextIndex, commandHistory[nextIndex]);
+	}
+
+	private static CommandHistoryNavigation NavigateDown(
+		IReadOnlyList<string> commandHistory,
+		int currentIndex,
+		bool jumpToBoundary)
+	{
+		if (currentIndex >= commandHistory.Count)
+		{
+			return new CommandHistoryNavigation(currentIndex, null);
+		}
+
+		var nextIndex = jumpToBoundary ? commandHistory.Count - 1 : currentIndex + 1;
+		return nextIndex == commandHistory.Count
+			? new CommandHistoryNavigation(nextIndex, string.Empty)
+			: new CommandHistoryNavigation(nextIndex, commandHistory[nextIndex]);
+	}
+}

--- a/MudClient/MudClientBlazor/wwwroot/css/mudclient.css
+++ b/MudClient/MudClientBlazor/wwwroot/css/mudclient.css
@@ -116,6 +116,11 @@ textarea {
 	contain-intrinsic-size: auto 1.5em;
 }
 
+.message-container:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: -2px;
+}
+
 .message-container::-webkit-scrollbar,
 .hotkey-strip::-webkit-scrollbar,
 .input-field::-webkit-scrollbar {

--- a/MudClient/MudClientBlazor/wwwroot/js/mudclient.js
+++ b/MudClient/MudClientBlazor/wwwroot/js/mudclient.js
@@ -101,23 +101,42 @@
 	window.mudClientInput = (function () {
 		let element = null;
 		let handler = null;
+		let dotNetHelper = null;
+
+		function requestHistoryNavigation(event, direction) {
+			const selectionStart = element.selectionStart;
+			const selectionEnd = element.selectionEnd;
+			const jumpToBoundary = event.ctrlKey;
+			window.requestAnimationFrame(function () {
+				if (!element ||
+					element.selectionStart !== selectionStart ||
+					element.selectionEnd !== selectionEnd ||
+					!dotNetHelper) {
+					return;
+				}
+
+				dotNetHelper.invokeMethodAsync('NavigateCommandHistory', direction, jumpToBoundary);
+			});
+		}
 
 		return {
-			register: function (elementId) {
+			register: function (elementId, helper) {
 				this.dispose();
 				element = document.getElementById(elementId);
 				if (!element) {
 					return;
 				}
+				dotNetHelper = helper;
 
 				handler = function (event) {
-					const shouldPrevent =
-						(event.key === 'Enter' && !event.shiftKey) ||
-						event.key === 'ArrowUp' ||
-						event.key === 'ArrowDown' ||
-						(event.ctrlKey && (event.key === 'Home' || event.key === 'End'));
-					if (shouldPrevent) {
+					if (event.key === 'Enter' && !event.shiftKey) {
 						event.preventDefault();
+						return;
+					}
+
+					if (!event.shiftKey && !event.altKey && !event.metaKey &&
+						(event.key === 'ArrowUp' || event.key === 'ArrowDown')) {
+						requestHistoryNavigation(event, event.key === 'ArrowUp' ? 'up' : 'down');
 					}
 				};
 				element.addEventListener('keydown', handler);
@@ -129,26 +148,135 @@
 
 				element = null;
 				handler = null;
+				dotNetHelper = null;
 			}
 		};
 	})();
 
-	window.scrollToBottomIfNearBottom = function (element) {
-		if (!element) {
-			return;
+	window.mudClientTranscript = (function () {
+		let element = null;
+		let mutationObserver = null;
+		let scrollHandler = null;
+		let keydownHandler = null;
+		let isPinnedToBottom = true;
+		let scrollFrame = null;
+
+		function updatePinnedState() {
+			if (!element) {
+				return;
+			}
+
+			isPinnedToBottom = element.scrollTop + element.clientHeight >= element.scrollHeight - 2;
 		}
 
-		const previousHeight = Number.parseFloat(element.dataset.previousScrollHeight || '0');
-		const referenceHeight = previousHeight > 0 ? previousHeight : element.scrollHeight;
-		const wasNearBottom = referenceHeight - element.clientHeight - element.scrollTop < 160;
-		element.dataset.previousScrollHeight = String(element.scrollHeight);
-		if (wasNearBottom || previousHeight === 0) {
-			window.requestAnimationFrame(function () {
-				element.scrollTop = element.scrollHeight;
-				element.dataset.previousScrollHeight = String(element.scrollHeight);
+		function scrollToBottom() {
+			if (!element) {
+				return;
+			}
+
+			element.scrollTop = element.scrollHeight;
+			isPinnedToBottom = true;
+		}
+
+		function scheduleScrollToBottom() {
+			if (scrollFrame !== null || !isPinnedToBottom) {
+				return;
+			}
+
+			scrollFrame = window.requestAnimationFrame(function () {
+				scrollFrame = null;
+				if (isPinnedToBottom) {
+					scrollToBottom();
+				}
 			});
 		}
-	};
+
+		function scrollBy(amount) {
+			if (!element) {
+				return;
+			}
+
+			element.scrollTop += amount;
+			updatePinnedState();
+		}
+
+		function handleKeydown(event) {
+			if (!element || event.altKey || event.metaKey) {
+				return;
+			}
+
+			switch (event.key) {
+				case 'Home':
+					event.preventDefault();
+					element.scrollTop = 0;
+					updatePinnedState();
+					break;
+				case 'End':
+					event.preventDefault();
+					scrollToBottom();
+					break;
+				case 'PageUp':
+					event.preventDefault();
+					scrollBy(-element.clientHeight);
+					break;
+				case 'PageDown':
+					event.preventDefault();
+					scrollBy(element.clientHeight);
+					break;
+				case 'ArrowUp':
+					event.preventDefault();
+					scrollBy(-Math.max(24, parseFloat(getComputedStyle(element).lineHeight) || 24));
+					break;
+				case 'ArrowDown':
+					event.preventDefault();
+					scrollBy(Math.max(24, parseFloat(getComputedStyle(element).lineHeight) || 24));
+					break;
+			}
+		}
+
+		return {
+			register: function (outputElement) {
+				this.dispose();
+				element = outputElement;
+				if (!element) {
+					return;
+				}
+
+				updatePinnedState();
+				scrollToBottom();
+				scrollHandler = updatePinnedState;
+				keydownHandler = handleKeydown;
+				element.addEventListener('scroll', scrollHandler, { passive: true });
+				element.addEventListener('keydown', keydownHandler);
+				mutationObserver = new MutationObserver(scheduleScrollToBottom);
+				mutationObserver.observe(element, { childList: true, subtree: true });
+			},
+			dispose: function () {
+				if (element && scrollHandler) {
+					element.removeEventListener('scroll', scrollHandler);
+				}
+
+				if (element && keydownHandler) {
+					element.removeEventListener('keydown', keydownHandler);
+				}
+
+				if (mutationObserver) {
+					mutationObserver.disconnect();
+				}
+
+				if (scrollFrame !== null) {
+					window.cancelAnimationFrame(scrollFrame);
+				}
+
+				element = null;
+				mutationObserver = null;
+				scrollHandler = null;
+				keydownHandler = null;
+				isPinnedToBottom = true;
+				scrollFrame = null;
+			}
+		};
+	})();
 
 	window.getSelectionStart = function (elementId) {
 		const element = document.getElementById(elementId);

--- a/MudClient/MudClientTests/CommandHistoryNavigatorTests.cs
+++ b/MudClient/MudClientTests/CommandHistoryNavigatorTests.cs
@@ -1,0 +1,56 @@
+using MudClientBlazor.Services;
+
+namespace MudClientTests;
+
+public class CommandHistoryNavigatorTests
+{
+	private static readonly IReadOnlyList<string> History = ["look", "score", "inventory"];
+
+	[Fact]
+	public void Navigate_UpFromNewestEntry_ReturnsMostRecentCommand()
+	{
+		var result = CommandHistoryNavigator.Navigate(History, History.Count, CommandHistoryDirection.Up, false);
+
+		Assert.Equal(History.Count - 1, result.Index);
+		Assert.Equal("inventory", result.Input);
+	}
+
+	[Fact]
+	public void Navigate_UpAtOldestEntry_PreservesCurrentInput()
+	{
+		var result = CommandHistoryNavigator.Navigate(History, 0, CommandHistoryDirection.Up, false);
+
+		Assert.Equal(0, result.Index);
+		Assert.False(result.HasChanged);
+		Assert.Null(result.Input);
+	}
+
+	[Fact]
+	public void Navigate_DownFromNewestEntry_ReturnsBlankInput()
+	{
+		var result = CommandHistoryNavigator.Navigate(History, History.Count - 1, CommandHistoryDirection.Down, false);
+
+		Assert.Equal(History.Count, result.Index);
+		Assert.True(result.HasChanged);
+		Assert.Equal(string.Empty, result.Input);
+	}
+
+	[Fact]
+	public void Navigate_WithControlJump_MovesToRequestedHistoryBoundary()
+	{
+		var oldest = CommandHistoryNavigator.Navigate(History, History.Count, CommandHistoryDirection.Up, true);
+		var newest = CommandHistoryNavigator.Navigate(History, 0, CommandHistoryDirection.Down, true);
+
+		Assert.Equal((0, "look"), (oldest.Index, oldest.Input));
+		Assert.Equal((History.Count - 1, "inventory"), (newest.Index, newest.Input));
+	}
+
+	[Fact]
+	public void Navigate_WithoutHistory_LeavesInputUntouched()
+	{
+		var result = CommandHistoryNavigator.Navigate([], 0, CommandHistoryDirection.Down, false);
+
+		Assert.False(result.HasChanged);
+		Assert.Null(result.Input);
+	}
+}


### PR DESCRIPTION
## Summary
- simplify the connected status message and keep it coloured
- keep transcript output pinned while allowing deliberate scrollback review
- add focused output keyboard scrolling and boundary-aware multiline input history navigation

## Validation
- dotnet test MudClient/MudClientTests/MudClientTests.csproj -c Debug --no-restore -m:1 -p:UseSharedCompilation=false (111 passed)
- dotnet build MudClient/MudClientBlazor/MudClientBlazor.csproj -c Debug --no-restore -m:1 -p:UseSharedCompilation=false
- node --check MudClient/MudClientBlazor/wwwroot/js/mudclient.js
- live browser checks for transcript and textarea keyboard behaviour