### PR TITLE
Version update to 1.1.0

### DIFF
--- a/FutureMUD.Web/Content/PatchNotes/2026-08-04-mudclient-1-1-0.md
+++ b/FutureMUD.Web/Content/PatchNotes/2026-08-04-mudclient-1-1-0.md
@@ -1,0 +1,16 @@
+---
+title: FutureMUD Web MUD Client 1.1.0
+summary: Improved output navigation and multiline command editing for the FutureMUD Web MUD Client.
+date: 2026-08-04
+tags: mudclient, release, web-client
+---
+
+FutureMUD Web MUD Client 1.1.0 improves the live terminal experience in the browser.
+
+## Highlights
+
+- Connection status now says `Connected to the MUD.` without exposing the WebSocket proxy endpoint.
+- Remote output remains pinned only while the reader is at the bottom, preserving deliberate scrollback review while resuming automatic scrolling when the reader returns to the bottom.
+- Focused output supports Home, End, Page Up, Page Down, and arrow-key navigation.
+- Multiline command input keeps native caret and line navigation; command history is recalled only when moving beyond the top or bottom of the current text.
+- Added focused regression coverage for command-history boundary behavior.

--- a/MudClient/DEPLOYMENT.md
+++ b/MudClient/DEPLOYMENT.md
@@ -34,8 +34,8 @@ Linux additionally requires systemd, bash, curl, unzip, and Caddy v2 managed by 
 After verifying the website's published SHA-256 checksum, extract the downloaded package to `/opt/mudclient` and run the installer from that directory:
 
 ~~~bash
-unzip mudclient-1.0.1-linux-x64.zip -d /tmp/mudclient-package
-sudo mv /tmp/mudclient-package/mudclient-1.0.1-linux-x64 /opt/mudclient
+unzip mudclient-1.1.0-linux-x64.zip -d /tmp/mudclient-package
+sudo mv /tmp/mudclient-package/mudclient-1.1.0-linux-x64 /opt/mudclient
 sudo bash /opt/mudclient/deploy/linux/install-mudclient.sh play.example.com
 ~~~
 
@@ -58,7 +58,7 @@ dotnet workload install wasm-tools
 ```
 
 ```powershell
-.\scripts\Publish-ProductPackage.ps1 -RuntimeIdentifier win-x64 -Version 1.0.1
+.\scripts\Publish-ProductPackage.ps1 -RuntimeIdentifier win-x64 -Version 1.1.0
 ```
 
 ```bash

--- a/MudClient/Deployment/Windows_AWS_Web_Client_Guide.md
+++ b/MudClient/Deployment/Windows_AWS_Web_Client_Guide.md
@@ -1,6 +1,6 @@
 # Windows and AWS Web Client Setup Guide
 
-This is a deliberately plain-English guide for installing FutureMUD Web MUD Client 1.0.1 on a Windows server hosted in AWS. It adds a small HTTPS website alongside an existing FutureMUD game, without changing the game itself or any other applications on the server.
+This is a deliberately plain-English guide for installing FutureMUD Web MUD Client 1.1.0 on a Windows server hosted in AWS. It adds a small HTTPS website alongside an existing FutureMUD game, without changing the game itself or any other applications on the server.
 
 The names and addresses below are examples. Before using a command, replace `play.example.com` with your own player-facing hostname. Do not put a live server's IP address, AWS instance ID, administrator account name, or credentials in a public guide or repository.
 
@@ -64,7 +64,7 @@ Name them clearly, for example `Web MUD Client HTTP` and `Web MUD Client HTTPS`.
 Open an **Administrator PowerShell** window on the Windows server and run the following. It creates a new, dedicated folder and does not overwrite the game installation.
 
 ```powershell
-$version = '1.0.1'
+$version = '1.1.0'
 $archive = "$env:USERPROFILE\Downloads\mudclient-$version-win-x64.zip"
 $staging = "C:\MudClient-$version"
 

--- a/MudClient/MudWebSocketProxy/MudWebSocketProxy.csproj
+++ b/MudClient/MudWebSocketProxy/MudWebSocketProxy.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- bump MudClient proxy/package version to 1.1.0
- update deployment documentation to the current package version
- add the 1.1.0 website patch note for output and multiline-input navigation

## Validation
- dotnet test MudClient/MudClientTests/MudClientTests.csproj -c Release --no-restore (111 passed)
- dotnet test FutureMUD.Web.Tests/FutureMUD.Web.Tests.csproj -c Release --no-restore (49 passed)
- Publish-ProductPackage.ps1 -RuntimeIdentifier win-x64 -Version 1.1.0 -Configuration Release -SkipTests (package created and inspected)
- git diff --check