### PR TITLE
MudClient 1.2.1 Windows installer fix

### DIFF
--- a/MudClient/DEPLOYMENT.md
+++ b/MudClient/DEPLOYMENT.md
@@ -33,12 +33,12 @@ Linux additionally requires systemd, bash, curl, unzip, and Caddy v2 managed by 
 
 MudClient 1.2.0 is the first release with a safe upgrade layout. Its release files are immutable under `releases/<version>`; `current`, `web`, and `proxy` stay at stable paths so an upgrade does not alter Caddy, DNS, TLS, firewall, MUD, or database configuration. Operator settings are moved to `/etc/mudclient` on Linux and `%ProgramData%\FutureMUD\MudClient` on Windows.
 
-To migrate an existing 1.0.1 or 1.1.0 Linux installation, download and extract the 1.2.0 archive once, then run the installer with the original archive:
+To migrate an existing 1.0.1 or 1.1.0 Linux installation, download and extract the 1.2.1 archive once, then run the installer with the original archive:
 
 ~~~bash
-unzip mudclient-1.2.0-linux-x64.zip -d /tmp/mudclient-1.2.0
-sudo bash /tmp/mudclient-1.2.0/mudclient-1.2.0-linux-x64/deploy/linux/install-mudclient.sh \
-  --archive "$PWD/mudclient-1.2.0-linux-x64.zip" --migrate
+unzip mudclient-1.2.1-linux-x64.zip -d /tmp/mudclient-1.2.1
+sudo bash /tmp/mudclient-1.2.1/mudclient-1.2.1-linux-x64/deploy/linux/install-mudclient.sh \
+  --archive "$PWD/mudclient-1.2.1-linux-x64.zip" --migrate
 ~~~
 
 The command keeps the old release as a rollback target, copies proxy and browser settings to durable locations, and retains the existing Caddy configuration. It briefly restarts only the private proxy, so connected browser sessions disconnect and can reconnect; the MUD itself is not restarted.
@@ -51,11 +51,11 @@ sudo /opt/mudclient/current/deploy/linux/update-mudclient.sh
 
 Use `--check` to inspect the signed latest manifest without changing files, or `--rollback` to activate the previous local release. The updater verifies an Ed25519-signed manifest and archive SHA-256 before staging, preserves two prior releases, and restores the prior release if the proxy health check fails.
 
-On Windows, extract the 1.2.0 archive once and run this from an elevated PowerShell window:
+On Windows, extract the 1.2.1 archive once and run this from an elevated PowerShell window:
 
 ~~~powershell
-& 'C:\staging\mudclient-1.2.0-win-x64\deploy\windows\Install-MudClient.ps1' `
-  -ArchivePath 'C:\Users\Administrator\Downloads\mudclient-1.2.0-win-x64.zip' -Migrate
+& 'C:\staging\mudclient-1.2.1-win-x64\deploy\windows\Install-MudClient.ps1' `
+  -ArchivePath 'C:\Users\Administrator\Downloads\mudclient-1.2.1-win-x64.zip' -Migrate
 ~~~
 
 Later Windows updates use:
@@ -71,16 +71,16 @@ Later Windows updates use:
 After verifying the website's published SHA-256 checksum, extract the downloaded package to `/opt/mudclient` and run the installer from that directory:
 
 ~~~bash
-unzip mudclient-1.2.0-linux-x64.zip -d /tmp/mudclient-package
-sudo bash /tmp/mudclient-package/mudclient-1.2.0-linux-x64/deploy/linux/install-mudclient.sh \
-  --archive "$PWD/mudclient-1.2.0-linux-x64.zip" --domain play.example.com
+unzip mudclient-1.2.1-linux-x64.zip -d /tmp/mudclient-package
+sudo bash /tmp/mudclient-package/mudclient-1.2.1-linux-x64/deploy/linux/install-mudclient.sh \
+  --archive "$PWD/mudclient-1.2.1-linux-x64.zip" --domain play.example.com
 ~~~
 
 The script creates the unprivileged proxy service, writes the exact trusted public origin, adds an isolated Caddy site fragment, validates Caddy before reload, and checks the private health endpoint. The selected domain must already resolve to the host. To connect to a MUD on a private network rather than the same machine:
 
 ~~~bash
-sudo bash /tmp/mudclient-package/mudclient-1.2.0-linux-x64/deploy/linux/install-mudclient.sh \
-  --archive "$PWD/mudclient-1.2.0-linux-x64.zip" --domain play.example.com --mud-host 10.0.0.20 --mud-port 4000
+sudo bash /tmp/mudclient-package/mudclient-1.2.1-linux-x64/deploy/linux/install-mudclient.sh \
+  --archive "$PWD/mudclient-1.2.1-linux-x64.zip" --domain play.example.com --mud-host 10.0.0.20 --mud-port 4000
 ~~~
 
 Use `CADDY_CONFIG` and `CADDY_FRAGMENTS_DIR` for nonstandard Caddyfile locations. The installer saves `.before-mudclient-install` backups of the files it changes; review those and take a normal deployment backup before upgrading an existing installation.
@@ -96,7 +96,7 @@ dotnet workload install wasm-tools
 ```
 
 ```powershell
-.\scripts\Publish-ProductPackage.ps1 -RuntimeIdentifier win-x64 -Version 1.2.0
+.\scripts\Publish-ProductPackage.ps1 -RuntimeIdentifier win-x64 -Version 1.2.1
 ```
 
 ```bash

--- a/MudClient/Deployment/Windows_AWS_Web_Client_Guide.md
+++ b/MudClient/Deployment/Windows_AWS_Web_Client_Guide.md
@@ -1,6 +1,6 @@
 # Windows and AWS Web Client Setup Guide
 
-This is a deliberately plain-English guide for installing FutureMUD Web MUD Client 1.2.0 on a Windows server hosted in AWS. It adds a small HTTPS website alongside an existing FutureMUD game, without changing the game itself or any other applications on the server.
+This is a deliberately plain-English guide for installing FutureMUD Web MUD Client 1.2.1 on a Windows server hosted in AWS. It adds a small HTTPS website alongside an existing FutureMUD game, without changing the game itself or any other applications on the server.
 
 The names and addresses below are examples. Before using a command, replace `play.example.com` with your own player-facing hostname. Do not put a live server's IP address, AWS instance ID, administrator account name, or credentials in a public guide or repository.
 
@@ -64,7 +64,7 @@ Name them clearly, for example `Web MUD Client HTTP` and `Web MUD Client HTTPS`.
 Open an **Administrator PowerShell** window on the Windows server and run the following. It creates a new, dedicated folder and does not overwrite the game installation.
 
 ```powershell
-$version = '1.2.0'
+$version = '1.2.1'
 $archive = "$env:USERPROFILE\Downloads\mudclient-$version-win-x64.zip"
 $staging = "C:\MudClient-$version"
 

--- a/MudClient/MudClientDeployment/MudClientDeployment.csproj
+++ b/MudClient/MudClientDeployment/MudClientDeployment.csproj
@@ -5,7 +5,7 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<Version>1.2.0</Version>
+		<Version>1.2.1</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/MudClient/MudWebSocketProxy/MudWebSocketProxy.csproj
+++ b/MudClient/MudWebSocketProxy/MudWebSocketProxy.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-		<Version>1.2.0</Version>
+		<Version>1.2.1</Version>
   </PropertyGroup>
 
 </Project>

--- a/MudClient/deploy/windows/Install-MudClient.ps1
+++ b/MudClient/deploy/windows/Install-MudClient.ps1
@@ -3,13 +3,18 @@ param(
 	[Parameter(Mandatory = $true)][string]$ArchivePath,
 	[string]$InstallRoot = "C:\MudClient",
 	[switch]$Migrate,
-	[string]$ConfigRoot = "$env:ProgramData\FutureMUD\MudClient",
+	[string]$ConfigRoot,
 	[string]$CaddyExecutable,
 	[string]$CaddyDomain,
 	[string]$CaddyTaskName = 'FutureMUD Web Client HTTPS'
 )
 
 $ErrorActionPreference = 'Stop'
+$commonApplicationData = [Environment]::GetFolderPath([Environment+SpecialFolder]::CommonApplicationData)
+if ([string]::IsNullOrWhiteSpace($ConfigRoot)) {
+	if ([string]::IsNullOrWhiteSpace($commonApplicationData)) { throw 'Windows did not provide a common application-data directory.' }
+	$ConfigRoot = Join-Path $commonApplicationData 'FutureMUD\MudClient'
+}
 $principal = [Security.Principal.WindowsPrincipal]::new([Security.Principal.WindowsIdentity]::GetCurrent())
 if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) { throw 'Run from an elevated PowerShell prompt.' }
 if (-not (Test-Path -LiteralPath $ArchivePath)) { throw "Archive '$ArchivePath' was not found." }
@@ -19,8 +24,10 @@ $packageName = Split-Path -Leaf $packageRoot
 if ($packageName -notmatch '^mudclient-(?<version>\d+\.\d+\.\d+)-(?<runtime>win-x64)$') { throw 'The extracted package folder has an invalid name.' }
 $version = $Matches.version
 $runtime = $Matches.runtime
-$manifestPath = Join-Path $env:TEMP "mudclient-update-manifest-$PID.json"
-$signaturePath = Join-Path $env:TEMP "mudclient-update-manifest-$PID.sig"
+$temporaryRoot = [System.IO.Path]::GetTempPath()
+if ([string]::IsNullOrWhiteSpace($temporaryRoot)) { throw 'Windows did not provide a temporary directory.' }
+$manifestPath = Join-Path $temporaryRoot "mudclient-update-manifest-$PID.json"
+$signaturePath = Join-Path $temporaryRoot "mudclient-update-manifest-$PID.sig"
 try {
 	Invoke-WebRequest https://futuremud.com/downloads/mudclient/latest/update-manifest.json -OutFile $manifestPath
 	Invoke-WebRequest https://futuremud.com/downloads/mudclient/latest/update-manifest.sig -OutFile $signaturePath
@@ -28,7 +35,11 @@ try {
 	if ($LASTEXITCODE -ne 0) { throw 'The archive did not pass signed release verification.' }
 }
 finally {
-	Remove-Item -LiteralPath $manifestPath,$signaturePath -Force -ErrorAction SilentlyContinue
+	foreach ($temporaryFile in @($manifestPath, $signaturePath)) {
+		if (-not [string]::IsNullOrWhiteSpace([string]$temporaryFile)) {
+			Remove-Item -LiteralPath $temporaryFile -Force -ErrorAction SilentlyContinue
+		}
+	}
 }
 
 $releaseRoot = Join-Path $InstallRoot 'releases'

--- a/MudClient/deploy/windows/Update-MudClient.ps1
+++ b/MudClient/deploy/windows/Update-MudClient.ps1
@@ -1,12 +1,19 @@
 [CmdletBinding()]
 param(
 	[string]$InstallRoot = 'C:\MudClient',
-	[string]$ConfigRoot = "$env:ProgramData\FutureMUD\MudClient",
+	[string]$ConfigRoot,
 	[switch]$Check,
 	[switch]$Rollback
 )
 
 $ErrorActionPreference = 'Stop'
+$commonApplicationData = [Environment]::GetFolderPath([Environment+SpecialFolder]::CommonApplicationData)
+if ([string]::IsNullOrWhiteSpace($ConfigRoot)) {
+	if ([string]::IsNullOrWhiteSpace($commonApplicationData)) { throw 'Windows did not provide a common application-data directory.' }
+	$ConfigRoot = Join-Path $commonApplicationData 'FutureMUD\MudClient'
+}
+$temporaryRoot = [System.IO.Path]::GetTempPath()
+if ([string]::IsNullOrWhiteSpace($temporaryRoot)) { throw 'Windows did not provide a temporary directory.' }
 $currentPath = Join-Path $InstallRoot 'current'
 $deploymentTool = Join-Path $currentPath 'tools\MudClientDeployment.exe'
 if (-not (Test-Path -LiteralPath $deploymentTool)) { throw 'The deployed MudClient update verifier is unavailable.' }
@@ -23,7 +30,7 @@ function Get-SignedLatestManifest {
 }
 
 if ($Check) {
-	$temp = Join-Path $env:TEMP ("mudclient-update-check-" + [Guid]::NewGuid().ToString('N'))
+	$temp = Join-Path $temporaryRoot ("mudclient-update-check-" + [Guid]::NewGuid().ToString('N'))
 	New-Item -ItemType Directory -Path $temp | Out-Null
 	try {
 		$manifestPath = Get-SignedLatestManifest -Directory $temp
@@ -70,7 +77,7 @@ if ($Rollback) {
 	return
 }
 
-$temp = Join-Path $env:TEMP ("mudclient-update-" + [Guid]::NewGuid().ToString('N'))
+$temp = Join-Path $temporaryRoot ("mudclient-update-" + [Guid]::NewGuid().ToString('N'))
 New-Item -ItemType Directory -Path $temp | Out-Null
 try {
 	$manifestPath = Get-SignedLatestManifest -Directory $temp


### PR DESCRIPTION
## Summary
- make Windows installer and updater temp paths independent of a missing or malformed $env:TEMP
- resolve durable configuration through the common application-data directory when $env:ProgramData is unavailable
- guard installer temporary-file cleanup against null paths
- update MudClient deployment documentation and package versions for 1.2.1

## Validation
- MudClient tests: 115 passed
- Windows deployment scripts parsed with Windows PowerShell
- representative win-x64 1.2.1 archive built and inspected to contain the corrected scripts and deployment verifier

Fixes the reported 1.2.0 migration failure after signed archive verification.