### PR TITLE
Fix MudClient Windows migration rollback

### DIFF
--- a/MudClient/DEPLOYMENT.md
+++ b/MudClient/DEPLOYMENT.md
@@ -33,12 +33,12 @@ Linux additionally requires systemd, bash, curl, unzip, and Caddy v2 managed by 
 
 MudClient 1.2.0 is the first release with a safe upgrade layout. Its release files are immutable under `releases/<version>`; `current`, `web`, and `proxy` stay at stable paths so an upgrade does not alter Caddy, DNS, TLS, firewall, MUD, or database configuration. Operator settings are moved to `/etc/mudclient` on Linux and `%ProgramData%\FutureMUD\MudClient` on Windows.
 
-To migrate an existing 1.0.1 or 1.1.0 Linux installation, download and extract the 1.2.1 archive once, then run the installer with the original archive:
+To migrate an existing 1.0.1 or 1.1.0 Linux installation, download and extract the 1.2.2 archive once, then run the installer with the original archive:
 
 ~~~bash
-unzip mudclient-1.2.1-linux-x64.zip -d /tmp/mudclient-1.2.1
-sudo bash /tmp/mudclient-1.2.1/mudclient-1.2.1-linux-x64/deploy/linux/install-mudclient.sh \
-  --archive "$PWD/mudclient-1.2.1-linux-x64.zip" --migrate
+unzip mudclient-1.2.2-linux-x64.zip -d /tmp/mudclient-1.2.2
+sudo bash /tmp/mudclient-1.2.2/mudclient-1.2.2-linux-x64/deploy/linux/install-mudclient.sh \
+  --archive "$PWD/mudclient-1.2.2-linux-x64.zip" --migrate
 ~~~
 
 The command keeps the old release as a rollback target, copies proxy and browser settings to durable locations, and retains the existing Caddy configuration. It briefly restarts only the private proxy, so connected browser sessions disconnect and can reconnect; the MUD itself is not restarted.
@@ -51,11 +51,11 @@ sudo /opt/mudclient/current/deploy/linux/update-mudclient.sh
 
 Use `--check` to inspect the signed latest manifest without changing files, or `--rollback` to activate the previous local release. The updater verifies an Ed25519-signed manifest and archive SHA-256 before staging, preserves two prior releases, and restores the prior release if the proxy health check fails.
 
-On Windows, extract the 1.2.1 archive once and run this from an elevated PowerShell window:
+On Windows, extract the 1.2.2 archive once and run this from an elevated PowerShell window:
 
 ~~~powershell
-& 'C:\staging\mudclient-1.2.1-win-x64\deploy\windows\Install-MudClient.ps1' `
-  -ArchivePath 'C:\Users\Administrator\Downloads\mudclient-1.2.1-win-x64.zip' -Migrate
+& 'C:\staging\mudclient-1.2.2-win-x64\deploy\windows\Install-MudClient.ps1' `
+  -ArchivePath 'C:\Users\Administrator\Downloads\mudclient-1.2.2-win-x64.zip' -Migrate
 ~~~
 
 Later Windows updates use:
@@ -71,16 +71,16 @@ Later Windows updates use:
 After verifying the website's published SHA-256 checksum, extract the downloaded package to `/opt/mudclient` and run the installer from that directory:
 
 ~~~bash
-unzip mudclient-1.2.1-linux-x64.zip -d /tmp/mudclient-package
-sudo bash /tmp/mudclient-package/mudclient-1.2.1-linux-x64/deploy/linux/install-mudclient.sh \
-  --archive "$PWD/mudclient-1.2.1-linux-x64.zip" --domain play.example.com
+unzip mudclient-1.2.2-linux-x64.zip -d /tmp/mudclient-package
+sudo bash /tmp/mudclient-package/mudclient-1.2.2-linux-x64/deploy/linux/install-mudclient.sh \
+  --archive "$PWD/mudclient-1.2.2-linux-x64.zip" --domain play.example.com
 ~~~
 
 The script creates the unprivileged proxy service, writes the exact trusted public origin, adds an isolated Caddy site fragment, validates Caddy before reload, and checks the private health endpoint. The selected domain must already resolve to the host. To connect to a MUD on a private network rather than the same machine:
 
 ~~~bash
-sudo bash /tmp/mudclient-package/mudclient-1.2.1-linux-x64/deploy/linux/install-mudclient.sh \
-  --archive "$PWD/mudclient-1.2.1-linux-x64.zip" --domain play.example.com --mud-host 10.0.0.20 --mud-port 4000
+sudo bash /tmp/mudclient-package/mudclient-1.2.2-linux-x64/deploy/linux/install-mudclient.sh \
+  --archive "$PWD/mudclient-1.2.2-linux-x64.zip" --domain play.example.com --mud-host 10.0.0.20 --mud-port 4000
 ~~~
 
 Use `CADDY_CONFIG` and `CADDY_FRAGMENTS_DIR` for nonstandard Caddyfile locations. The installer saves `.before-mudclient-install` backups of the files it changes; review those and take a normal deployment backup before upgrading an existing installation.
@@ -96,7 +96,7 @@ dotnet workload install wasm-tools
 ```
 
 ```powershell
-.\scripts\Publish-ProductPackage.ps1 -RuntimeIdentifier win-x64 -Version 1.2.1
+.\scripts\Publish-ProductPackage.ps1 -RuntimeIdentifier win-x64 -Version 1.2.2
 ```
 
 ```bash

--- a/MudClient/Deployment/Windows_AWS_Web_Client_Guide.md
+++ b/MudClient/Deployment/Windows_AWS_Web_Client_Guide.md
@@ -1,6 +1,6 @@
 # Windows and AWS Web Client Setup Guide
 
-This is a deliberately plain-English guide for installing FutureMUD Web MUD Client 1.2.1 on a Windows server hosted in AWS. It adds a small HTTPS website alongside an existing FutureMUD game, without changing the game itself or any other applications on the server.
+This is a deliberately plain-English guide for installing FutureMUD Web MUD Client 1.2.2 on a Windows server hosted in AWS. It adds a small HTTPS website alongside an existing FutureMUD game, without changing the game itself or any other applications on the server.
 
 The names and addresses below are examples. Before using a command, replace `play.example.com` with your own player-facing hostname. Do not put a live server's IP address, AWS instance ID, administrator account name, or credentials in a public guide or repository.
 
@@ -64,7 +64,7 @@ Name them clearly, for example `Web MUD Client HTTP` and `Web MUD Client HTTPS`.
 Open an **Administrator PowerShell** window on the Windows server and run the following. It creates a new, dedicated folder and does not overwrite the game installation.
 
 ```powershell
-$version = '1.2.1'
+$version = '1.2.2'
 $archive = "$env:USERPROFILE\Downloads\mudclient-$version-win-x64.zip"
 $staging = "C:\MudClient-$version"
 

--- a/MudClient/MudClientDeployment/MudClientDeployment.csproj
+++ b/MudClient/MudClientDeployment/MudClientDeployment.csproj
@@ -5,7 +5,7 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<Version>1.2.1</Version>
+		<Version>1.2.2</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/MudClient/MudWebSocketProxy/MudWebSocketProxy.csproj
+++ b/MudClient/MudWebSocketProxy/MudWebSocketProxy.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-		<Version>1.2.1</Version>
+		<Version>1.2.2</Version>
   </PropertyGroup>
 
 </Project>

--- a/MudClient/deploy/windows/Install-MudClient.ps1
+++ b/MudClient/deploy/windows/Install-MudClient.ps1
@@ -26,6 +26,57 @@ $version = $Matches.version
 $runtime = $Matches.runtime
 $temporaryRoot = [System.IO.Path]::GetTempPath()
 if ([string]::IsNullOrWhiteSpace($temporaryRoot)) { throw 'Windows did not provide a temporary directory.' }
+
+function Remove-MudClientPath {
+	param([Parameter(Mandatory = $true)][string]$Path)
+
+	$item = Get-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue
+	if (-not $item) { return }
+	if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -eq 0) {
+		Remove-Item -LiteralPath $Path -Recurse -Force
+		return
+	}
+
+	& cmd.exe /d /c "rmdir /q `"$Path`"" | Out-Null
+	if ($LASTEXITCODE -ne 0) {
+		throw "Windows could not remove the reparse point '$Path' (exit code $LASTEXITCODE)."
+	}
+}
+
+function Wait-ForMudClientServiceRemoval {
+	param([int]$TimeoutSeconds = 30)
+
+	$deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+	do {
+		$service = Get-Service -Name 'MudClientProxy' -ErrorAction SilentlyContinue
+		if (-not $service) { return }
+		if ($service.Status -ne 'Stopped') {
+			Stop-Service -Name 'MudClientProxy' -Force -ErrorAction SilentlyContinue
+		}
+		Start-Sleep -Milliseconds 500
+	} while ((Get-Date) -lt $deadline)
+
+	throw "The MudClientProxy service did not finish stopping before the activation timeout."
+}
+
+function Wait-ForMudClientHealth {
+	param([int]$TimeoutSeconds = 30)
+
+	$deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+	do {
+		try {
+			$response = Invoke-WebRequest -UseBasicParsing -TimeoutSec 2 -Uri 'http://127.0.0.1:5000/health'
+			if ($response.StatusCode -ge 200 -and $response.StatusCode -lt 300) { return }
+		}
+		catch {
+			# The service may still be starting. Retry until the bounded deadline.
+		}
+		Start-Sleep -Seconds 1
+	} while ((Get-Date) -lt $deadline)
+
+	throw "The MudClientProxy service did not become healthy within $TimeoutSeconds seconds."
+}
+
 $manifestPath = Join-Path $temporaryRoot "mudclient-update-manifest-$PID.json"
 $signaturePath = Join-Path $temporaryRoot "mudclient-update-manifest-$PID.sig"
 try {
@@ -128,15 +179,16 @@ if ($legacyTask) {
 if (Test-Path -LiteralPath $existingServiceInstaller) {
 	& $existingServiceInstaller -Uninstall -ErrorAction SilentlyContinue
 }
+	Wait-ForMudClientServiceRemoval
 	foreach ($link in @('current', 'web', 'proxy')) {
 		$linkPath = Join-Path $InstallRoot $link
-		if (Test-Path -LiteralPath $linkPath) { Remove-Item -LiteralPath $linkPath -Force }
+		Remove-MudClientPath -Path $linkPath
 	}
 		New-Item -ItemType SymbolicLink -Path $currentPath -Target $releasePath | Out-Null
 	New-Item -ItemType SymbolicLink -Path (Join-Path $InstallRoot 'web') -Target (Join-Path $InstallRoot 'current\web') | Out-Null
 	New-Item -ItemType SymbolicLink -Path (Join-Path $InstallRoot 'proxy') -Target (Join-Path $InstallRoot 'current\proxy') | Out-Null
 		& $releaseServiceInstaller -InstallRoot $InstallRoot -SettingsPath $proxySettings
-		Invoke-WebRequest http://127.0.0.1:5000/health | Out-Null
+		Wait-ForMudClientHealth
 		if ($createCaddyTask) {
 			$action = New-ScheduledTaskAction -Execute $CaddyExecutable -Argument "run --config `"$persistentCaddyfile`" --adapter caddyfile" -WorkingDirectory (Split-Path -Parent $CaddyExecutable)
 			$trigger = New-ScheduledTaskTrigger -AtStartup
@@ -147,20 +199,32 @@ if (Test-Path -LiteralPath $existingServiceInstaller) {
 		}
 }
 catch {
+	$activationError = $_
 	if ($releaseServiceInstaller -and (Test-Path -LiteralPath $releaseServiceInstaller)) { & $releaseServiceInstaller -Uninstall -ErrorAction SilentlyContinue }
+	try {
+		Wait-ForMudClientServiceRemoval
+	}
+	catch {
+		Write-Warning $_.Exception.Message
+	}
 	if ($previousTarget) {
-		Remove-Item -LiteralPath $currentPath -Force -ErrorAction SilentlyContinue
-		New-Item -ItemType SymbolicLink -Path $currentPath -Target $previousTarget | Out-Null
+		try {
+			Remove-MudClientPath -Path $currentPath
+			New-Item -ItemType SymbolicLink -Path $currentPath -Target $previousTarget | Out-Null
+		}
+		catch {
+			Write-Warning "Could not restore the previous current release: $($_.Exception.Message)"
+		}
 		foreach ($link in @('web', 'proxy')) {
 			$linkPath = Join-Path $InstallRoot $link
-			if (-not (Test-Path -LiteralPath $linkPath)) { New-Item -ItemType SymbolicLink -Path $linkPath -Target (Join-Path $currentPath $link) | Out-Null }
+			if (-not (Get-Item -LiteralPath $linkPath -Force -ErrorAction SilentlyContinue)) { New-Item -ItemType SymbolicLink -Path $linkPath -Target (Join-Path $currentPath $link) | Out-Null }
 		}
 		if (Test-Path -LiteralPath $existingServiceInstaller) { & $existingServiceInstaller -InstallRoot $InstallRoot }
 	}
 	if ($legacyTask -and (Test-Path -LiteralPath $legacyTaskBackup)) { schtasks.exe /Create /TN $legacyTaskName /XML $legacyTaskBackup /F | Out-Null }
 	if ($createCaddyTask) { Unregister-ScheduledTask -TaskName $CaddyTaskName -Confirm:$false -ErrorAction SilentlyContinue }
 	if ($caddyFileCreated) { Remove-Item -LiteralPath $persistentCaddyfile -Force -ErrorAction SilentlyContinue }
-	throw
+	throw $activationError
 }
 $activeReleases = Get-ChildItem -LiteralPath $releaseRoot -Directory | Where-Object Name -notlike 'legacy-*' | Sort-Object { [version]$_.Name }
 while ($activeReleases.Count -gt 3) {

--- a/MudClient/deploy/windows/Update-MudClient.ps1
+++ b/MudClient/deploy/windows/Update-MudClient.ps1
@@ -18,6 +18,56 @@ $currentPath = Join-Path $InstallRoot 'current'
 $deploymentTool = Join-Path $currentPath 'tools\MudClientDeployment.exe'
 if (-not (Test-Path -LiteralPath $deploymentTool)) { throw 'The deployed MudClient update verifier is unavailable.' }
 
+function Remove-MudClientPath {
+	param([Parameter(Mandatory = $true)][string]$Path)
+
+	$item = Get-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue
+	if (-not $item) { return }
+	if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -eq 0) {
+		Remove-Item -LiteralPath $Path -Recurse -Force
+		return
+	}
+
+	& cmd.exe /d /c "rmdir /q `"$Path`"" | Out-Null
+	if ($LASTEXITCODE -ne 0) {
+		throw "Windows could not remove the reparse point '$Path' (exit code $LASTEXITCODE)."
+	}
+}
+
+function Wait-ForMudClientServiceRemoval {
+	param([int]$TimeoutSeconds = 30)
+
+	$deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+	do {
+		$service = Get-Service -Name 'MudClientProxy' -ErrorAction SilentlyContinue
+		if (-not $service) { return }
+		if ($service.Status -ne 'Stopped') {
+			Stop-Service -Name 'MudClientProxy' -Force -ErrorAction SilentlyContinue
+		}
+		Start-Sleep -Milliseconds 500
+	} while ((Get-Date) -lt $deadline)
+
+	throw "The MudClientProxy service did not finish stopping before the activation timeout."
+}
+
+function Wait-ForMudClientHealth {
+	param([int]$TimeoutSeconds = 30)
+
+	$deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+	do {
+		try {
+			$response = Invoke-WebRequest -UseBasicParsing -TimeoutSec 2 -Uri 'http://127.0.0.1:5000/health'
+			if ($response.StatusCode -ge 200 -and $response.StatusCode -lt 300) { return }
+		}
+		catch {
+			# The service may still be starting. Retry until the bounded deadline.
+		}
+		Start-Sleep -Seconds 1
+	} while ((Get-Date) -lt $deadline)
+
+	throw "The MudClientProxy service did not become healthy within $TimeoutSeconds seconds."
+}
+
 function Get-SignedLatestManifest {
 	param([string]$Directory)
 	$manifestPath = Join-Path $Directory 'update-manifest.json'
@@ -62,16 +112,18 @@ if ($Rollback) {
 	$previous = $releases[$index - 1]
 	& (Join-Path $currentPath 'deploy\windows\install-mudclient-proxy.ps1') -Uninstall
 	try {
-		Remove-Item -LiteralPath $currentPath -Force
+		Remove-MudClientPath -Path $currentPath
 		New-Item -ItemType SymbolicLink -Path $currentPath -Target $previous.FullName | Out-Null
 		& (Join-Path $currentPath 'deploy\windows\install-mudclient-proxy.ps1') -InstallRoot $InstallRoot -SettingsPath (Join-Path $ConfigRoot 'proxy\appsettings.json')
-		Invoke-WebRequest http://127.0.0.1:5000/health | Out-Null
+		Wait-ForMudClientHealth
 	}
 	catch {
-		Remove-Item -LiteralPath $currentPath -Force -ErrorAction SilentlyContinue
+		$rollbackError = $_
+		try { Wait-ForMudClientServiceRemoval } catch { Write-Warning $_.Exception.Message }
+		try { Remove-MudClientPath -Path $currentPath } catch { Write-Warning "Could not restore the previous current release: $($_.Exception.Message)" }
 		New-Item -ItemType SymbolicLink -Path $currentPath -Target $originalTarget | Out-Null
 		& (Join-Path $currentPath 'deploy\windows\install-mudclient-proxy.ps1') -InstallRoot $InstallRoot -SettingsPath (Join-Path $ConfigRoot 'proxy\appsettings.json')
-		throw
+		throw $rollbackError
 	}
 	Write-Host "MudClient rolled back to $($previous.Name)."
 	return

--- a/MudClient/deploy/windows/install-mudclient-proxy.ps1
+++ b/MudClient/deploy/windows/install-mudclient-proxy.ps1
@@ -22,6 +22,13 @@ if ($Uninstall) {
 		}
 
 		sc.exe delete $ServiceName | Out-Null
+		$deadline = (Get-Date).AddSeconds(30)
+		do {
+			$remainingService = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
+			if (-not $remainingService) { break }
+			Start-Sleep -Milliseconds 500
+		} while ((Get-Date) -lt $deadline)
+		if ($remainingService) { throw "The service '$ServiceName' did not finish uninstalling." }
 		Write-Host "Removed service '$ServiceName'."
 	}
 	else {


### PR DESCRIPTION
## Summary
- remove Windows directory reparse points with rmdir instead of Remove-Item
- wait for proxy service removal and health readiness during activation and rollback
- preserve the original activation error when cleanup fails
- bump MudClient to 1.2.2 and update Windows/Linux deployment instructions

## Validation
- PowerShell parser validation passed
- MudClient tests: 111 passed with existing binaries
- MudClientDeployment Debug build passed with shared compilation disabled
- representative win-x64 1.2.2 package built and inspected
- directory junction removal exercised successfully