### PR TITLE
Fix ANSI colour reset handling

### DIFF
--- a/FutureMUDLibrary Unit Tests/StringColourExtensionsTests.cs
+++ b/FutureMUDLibrary Unit Tests/StringColourExtensionsTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MudSharp.Form.Colour;
 using MudSharp.Framework;
+using System.Linq;
 
 namespace MudSharp_Unit_Tests;
 
@@ -30,7 +31,7 @@ public class StringColourExtensionsTests
     {
         const string text = "test";
         string result = text.Colour(BasicColour.Red);
-        string expected = $"{Telnet.Black.BackgroundColour}{Telnet.Red.Name}{text}{Telnet.RESETALL}";
+        string expected = $"{Telnet.Black.BackgroundColour}{Telnet.Red.Colour}{text}{Telnet.RESETALL}";
         Assert.AreEqual(expected, result);
     }
 
@@ -125,7 +126,7 @@ public class StringColourExtensionsTests
     {
         const string text = "bold";
         string result = text.ColourBold(Telnet.Blue);
-        Assert.AreEqual($"{Telnet.Blue.Bold}{text}{Telnet.RESET}", result);
+        Assert.AreEqual($"{Telnet.Blue.Bold}{text}{Telnet.RESETBOLD}{Telnet.RESET}", result);
     }
 
     [TestMethod]
@@ -149,7 +150,7 @@ public class StringColourExtensionsTests
     {
         const string text = "resetcolour";
         string result = text.Colour(Telnet.Red, Telnet.Green);
-        Assert.AreEqual($"{Telnet.Red.Colour}{text}{Telnet.Green.Colour}", result);
+        Assert.AreEqual($"{Telnet.Red.Colour}{text}{Telnet.RESETBOLD}{Telnet.Green.Colour}", result);
     }
 
     [TestMethod]
@@ -157,7 +158,7 @@ public class StringColourExtensionsTests
     {
         const string text = "boldreset";
         string result = text.ColourBold(Telnet.Blue, Telnet.Green);
-        Assert.AreEqual($"{Telnet.Blue.Bold}{text}{Telnet.Green.Colour}", result);
+        Assert.AreEqual($"{Telnet.Blue.Bold}{text}{Telnet.RESETBOLD}{Telnet.Green.Colour}", result);
     }
 
     [TestMethod]
@@ -211,6 +212,35 @@ public class StringColourExtensionsTests
         const string text = "plain";
         string result = text.ColourIfNotColoured(Telnet.Red);
         Assert.AreEqual($"{Telnet.Red}{text}{Telnet.RESET}", result);
+    }
+
+    [TestMethod]
+    public void ColourIfNotColoured_LeavesTextWithEmbeddedAnsiSequence()
+    {
+        string coloured = $"pre{Telnet.Blue}coloured{Telnet.RESET}";
+        string result = coloured.ColourIfNotColoured(Telnet.Red);
+        Assert.AreEqual(coloured, result);
+    }
+
+    [TestMethod]
+    public void Colour_WithBoldColourAndResetColour_ResetsBoldBeforeRestoringForeground()
+    {
+        const string text = "boldcolour";
+        string result = text.Colour(Telnet.BoldRed, Telnet.Green);
+        Assert.AreEqual($"{Telnet.BoldRed.Colour}{text}{Telnet.RESETBOLD}{Telnet.Green.Colour}", result);
+    }
+
+    [TestMethod]
+    public void Telnet_ColourDefinitionsUseTheCorrectBoldBackgrounds()
+    {
+        Assert.AreEqual(Telnet.BOLDBLACKBACKGROUND, Telnet.Black.BoldBackgroundColour);
+        Assert.AreEqual(Telnet.VARIABLEGREENBACKGROUND, Telnet.VariableGreen.BoldBackgroundColour);
+    }
+
+    [TestMethod]
+    public void Telnet_ColourOptionsIncludeEveryNamedBoldColour()
+    {
+        CollectionAssert.Contains(Telnet.GetColourOptions.Select(x => x.StripANSIColour()).ToList(), "bold orange");
     }
 
     [TestMethod]

--- a/FutureMUDLibrary/Framework/StringColourExtensions.cs
+++ b/FutureMUDLibrary/Framework/StringColourExtensions.cs
@@ -141,7 +141,7 @@ namespace MudSharp.Framework
                     throw new ApplicationException("Unknown basic colour in Colour extension.");
             }
 
-            return $"{background.BackgroundColour}{colour.Name}{input}{Telnet.RESETALL}";
+            return $"{background.BackgroundColour}{colour.Colour}{input}{Telnet.RESETALL}";
         }
 
         public static string Colour(this string input, ANSIColour colour)
@@ -156,7 +156,7 @@ namespace MudSharp.Framework
 
         public static string ColourBold(this string input, ANSIColour colour)
         {
-            return colour == null ? input : colour.Bold + input + colour.Reset();
+            return colour == null ? input : colour.Bold + input + Telnet.RESETBOLD + colour.Reset();
         }
 
         public static string ColourBackground(this string input, ANSIColour colour)
@@ -171,12 +171,16 @@ namespace MudSharp.Framework
 
         public static string Colour(this string input, ANSIColour colour, ANSIColour resetcolour)
         {
-            return (colour == null) || (resetcolour == null) ? input : colour.Colour + input + resetcolour.Colour;
+            return (colour == null) || (resetcolour == null)
+                ? input
+                : colour.Colour + input + Telnet.RESETBOLD + resetcolour.Colour;
         }
 
         public static string ColourBold(this string input, ANSIColour colour, ANSIColour resetcolour)
         {
-            return (colour == null) || (resetcolour == null) ? input : colour.Bold + input + resetcolour.Colour;
+            return (colour == null) || (resetcolour == null)
+                ? input
+                : colour.Bold + input + Telnet.RESETBOLD + resetcolour.Colour;
         }
 
         public static string Colour(this string input, string foreground, string background)
@@ -201,8 +205,7 @@ namespace MudSharp.Framework
 
         public static string ColourIfNotColoured(this string input, ANSIColour colour)
         {
-            // TODO - if for some reason input starts with a TELNET.RESET this will incorrectly identify it as coloured. This seems like an unlikely scenario but eventually I should fix that in an efficient way.
-            if (!string.IsNullOrEmpty(input) && !input.StartsWith("\x1B[", StringComparison.InvariantCulture))
+            if (!string.IsNullOrEmpty(input) && !input.Contains("\x1B[", StringComparison.Ordinal))
             {
                 return input.Colour(colour);
             }

--- a/FutureMUDLibrary/Framework/Telnet.cs
+++ b/FutureMUDLibrary/Framework/Telnet.cs
@@ -37,6 +37,7 @@ namespace MudSharp.Framework
         public const string RESET = "\x1B[0;39m";
         public const string RESETBACKGROUND = "\x1B[49m";
         public const string RESETNEWLINE = "\x1B[39m\n";
+        public const string RESETBOLD = "\x1B[22m";
         public const string RESETUNDERLINE = "\x1B[24m";
         public const string UNDERLINE = "\x1B[4m";
         public const string RESETBLINK = "\x1B[25m";
@@ -196,7 +197,7 @@ namespace MudSharp.Framework
         public static readonly ANSIColour White = new("White", WHITE, BOLDWHITE, WHITEBACKGROUND,
             BOLDWHITEBACKGROUND);
 
-        public static readonly ANSIColour Black = new("Black", BLACK, BOLDBLACK, BLACKBACKGROUND, BLACKBACKGROUND);
+        public static readonly ANSIColour Black = new("Black", BLACK, BOLDBLACK, BLACKBACKGROUND, BOLDBLACKBACKGROUND);
 
         public static readonly ANSIColour Orange = new("Orange", ORANGE, BOLDORANGE, ORANGEBACKGROUND, BOLDORANGEBACKGROUND);
 
@@ -246,7 +247,7 @@ namespace MudSharp.Framework
             TEXTREDBACKGROUND);
 
         public static readonly ANSIColour VariableGreen = new("Variable Green", VARIABLEGREEN, VARIABLEGREEN,
-            VARIABLEGREENBACKGROUND, VARIABLECYANBACKGROUND);
+            VARIABLEGREENBACKGROUND, VARIABLEGREENBACKGROUND);
 
         public static string Reset(this ANSIColour colour)
         {
@@ -278,6 +279,7 @@ namespace MudSharp.Framework
             "bold magenta".Colour(BoldMagenta),
             "bold white".Colour(BoldWhite),
             "bold black".Colour(BoldBlack),
+            "bold orange".Colour(BoldOrange),
             "bold pink".Colour(BoldPink),
             "function yellow".Colour(FunctionYellow),
             "variable cyan".Colour(VariableCyan),


### PR DESCRIPTION
Fixes bold leakage after written-work titles by explicitly clearing SGR intensity before the existing reset. Also repairs BasicColour ANSI emission, incorrect bold-background registrations, missing bold-orange option, and embedded ANSI detection. Validation: FutureMUDLibrary build passed with 0 warnings and all 425 FutureMUDLibrary Unit Tests passed.