### PR TITLE
Version update to 1.2.3

### DIFF
--- a/MudClient/DEPLOYMENT.md
+++ b/MudClient/DEPLOYMENT.md
@@ -33,12 +33,12 @@ Linux additionally requires systemd, bash, curl, unzip, and Caddy v2 managed by 
 
 MudClient 1.2.0 is the first release with a safe upgrade layout. Its release files are immutable under `releases/<version>`; `current`, `web`, and `proxy` stay at stable paths so an upgrade does not alter Caddy, DNS, TLS, firewall, MUD, or database configuration. Operator settings are moved to `/etc/mudclient` on Linux and `%ProgramData%\FutureMUD\MudClient` on Windows.
 
-To migrate an existing 1.0.1 or 1.1.0 Linux installation, download and extract the 1.2.2 archive once, then run the installer with the original archive:
+To migrate an existing 1.0.1 or 1.1.0 Linux installation, download and extract the 1.2.3 archive once, then run the installer with the original archive:
 
 ~~~bash
-unzip mudclient-1.2.2-linux-x64.zip -d /tmp/mudclient-1.2.2
-sudo bash /tmp/mudclient-1.2.2/mudclient-1.2.2-linux-x64/deploy/linux/install-mudclient.sh \
-  --archive "$PWD/mudclient-1.2.2-linux-x64.zip" --migrate
+unzip mudclient-1.2.3-linux-x64.zip -d /tmp/mudclient-1.2.3
+sudo bash /tmp/mudclient-1.2.3/mudclient-1.2.3-linux-x64/deploy/linux/install-mudclient.sh \
+  --archive "$PWD/mudclient-1.2.3-linux-x64.zip" --migrate
 ~~~
 
 The command keeps the old release as a rollback target, copies proxy and browser settings to durable locations, and retains the existing Caddy configuration. It briefly restarts only the private proxy, so connected browser sessions disconnect and can reconnect; the MUD itself is not restarted.
@@ -51,11 +51,25 @@ sudo /opt/mudclient/current/deploy/linux/update-mudclient.sh
 
 Use `--check` to inspect the signed latest manifest without changing files, or `--rollback` to activate the previous local release. The updater verifies an Ed25519-signed manifest and archive SHA-256 before staging, preserves two prior releases, and restores the prior release if the proxy health check fails.
 
-On Windows, extract the 1.2.2 archive once and run this from an elevated PowerShell window:
+On Windows, extract the 1.2.3 archive once and run this from an elevated PowerShell window:
 
 ~~~powershell
-& 'C:\staging\mudclient-1.2.2-win-x64\deploy\windows\Install-MudClient.ps1' `
-  -ArchivePath 'C:\Users\Administrator\Downloads\mudclient-1.2.2-win-x64.zip' -Migrate
+& 'C:\staging\mudclient-1.2.3-win-x64\deploy\windows\Install-MudClient.ps1' `
+  -ArchivePath 'C:\Users\Administrator\Downloads\mudclient-1.2.3-win-x64.zip' -Migrate
+~~~
+
+If a failed earlier migration left stale `current`, `web`, or `proxy` links, stop the proxy and remove only those reparse points before retrying. This does not remove ordinary configuration directories:
+
+~~~powershell
+$installRoot = 'C:\MudClient'
+Stop-Service -Name MudClientProxy -Force -ErrorAction SilentlyContinue
+foreach ($name in @('current', 'web', 'proxy')) {
+  $path = Join-Path $installRoot $name
+  $item = Get-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue
+  if ($item -and (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
+    & cmd.exe /d /c "rmdir /q `"$path`""
+  }
+}
 ~~~
 
 Later Windows updates use:
@@ -71,16 +85,16 @@ Later Windows updates use:
 After verifying the website's published SHA-256 checksum, extract the downloaded package to `/opt/mudclient` and run the installer from that directory:
 
 ~~~bash
-unzip mudclient-1.2.2-linux-x64.zip -d /tmp/mudclient-package
-sudo bash /tmp/mudclient-package/mudclient-1.2.2-linux-x64/deploy/linux/install-mudclient.sh \
-  --archive "$PWD/mudclient-1.2.2-linux-x64.zip" --domain play.example.com
+unzip mudclient-1.2.3-linux-x64.zip -d /tmp/mudclient-package
+sudo bash /tmp/mudclient-package/mudclient-1.2.3-linux-x64/deploy/linux/install-mudclient.sh \
+  --archive "$PWD/mudclient-1.2.3-linux-x64.zip" --domain play.example.com
 ~~~
 
 The script creates the unprivileged proxy service, writes the exact trusted public origin, adds an isolated Caddy site fragment, validates Caddy before reload, and checks the private health endpoint. The selected domain must already resolve to the host. To connect to a MUD on a private network rather than the same machine:
 
 ~~~bash
-sudo bash /tmp/mudclient-package/mudclient-1.2.2-linux-x64/deploy/linux/install-mudclient.sh \
-  --archive "$PWD/mudclient-1.2.2-linux-x64.zip" --domain play.example.com --mud-host 10.0.0.20 --mud-port 4000
+sudo bash /tmp/mudclient-package/mudclient-1.2.3-linux-x64/deploy/linux/install-mudclient.sh \
+  --archive "$PWD/mudclient-1.2.3-linux-x64.zip" --domain play.example.com --mud-host 10.0.0.20 --mud-port 4000
 ~~~
 
 Use `CADDY_CONFIG` and `CADDY_FRAGMENTS_DIR` for nonstandard Caddyfile locations. The installer saves `.before-mudclient-install` backups of the files it changes; review those and take a normal deployment backup before upgrading an existing installation.
@@ -96,7 +110,7 @@ dotnet workload install wasm-tools
 ```
 
 ```powershell
-.\scripts\Publish-ProductPackage.ps1 -RuntimeIdentifier win-x64 -Version 1.2.2
+.\scripts\Publish-ProductPackage.ps1 -RuntimeIdentifier win-x64 -Version 1.2.3
 ```
 
 ```bash

--- a/MudClient/Deployment/Windows_AWS_Web_Client_Guide.md
+++ b/MudClient/Deployment/Windows_AWS_Web_Client_Guide.md
@@ -1,6 +1,6 @@
 # Windows and AWS Web Client Setup Guide
 
-This is a deliberately plain-English guide for installing FutureMUD Web MUD Client 1.2.2 on a Windows server hosted in AWS. It adds a small HTTPS website alongside an existing FutureMUD game, without changing the game itself or any other applications on the server.
+This is a deliberately plain-English guide for installing FutureMUD Web MUD Client 1.2.3 on a Windows server hosted in AWS. It adds a small HTTPS website alongside an existing FutureMUD game, without changing the game itself or any other applications on the server.
 
 The names and addresses below are examples. Before using a command, replace `play.example.com` with your own player-facing hostname. Do not put a live server's IP address, AWS instance ID, administrator account name, or credentials in a public guide or repository.
 
@@ -64,7 +64,7 @@ Name them clearly, for example `Web MUD Client HTTP` and `Web MUD Client HTTPS`.
 Open an **Administrator PowerShell** window on the Windows server and run the following. It creates a new, dedicated folder and does not overwrite the game installation.
 
 ```powershell
-$version = '1.2.2'
+$version = '1.2.3'
 $archive = "$env:USERPROFILE\Downloads\mudclient-$version-win-x64.zip"
 $staging = "C:\MudClient-$version"
 

--- a/MudClient/MudClientDeployment/MudClientDeployment.csproj
+++ b/MudClient/MudClientDeployment/MudClientDeployment.csproj
@@ -5,7 +5,7 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<Version>1.2.2</Version>
+		<Version>1.2.3</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/MudClient/MudWebSocketProxy/MudWebSocketProxy.csproj
+++ b/MudClient/MudWebSocketProxy/MudWebSocketProxy.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-		<Version>1.2.2</Version>
+		<Version>1.2.3</Version>
   </PropertyGroup>
 
 </Project>

--- a/MudClient/deploy/windows/Install-MudClient.ps1
+++ b/MudClient/deploy/windows/Install-MudClient.ps1
@@ -28,7 +28,9 @@ $temporaryRoot = [System.IO.Path]::GetTempPath()
 if ([string]::IsNullOrWhiteSpace($temporaryRoot)) { throw 'Windows did not provide a temporary directory.' }
 
 function Remove-MudClientPath {
-	param([Parameter(Mandatory = $true)][string]$Path)
+	param([AllowNull()][AllowEmptyString()][string]$Path)
+
+	if ([string]::IsNullOrWhiteSpace($Path)) { return }
 
 	$item = Get-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue
 	if (-not $item) { return }
@@ -41,6 +43,14 @@ function Remove-MudClientPath {
 	if ($LASTEXITCODE -ne 0) {
 		throw "Windows could not remove the reparse point '$Path' (exit code $LASTEXITCODE)."
 	}
+}
+
+function Remove-MudClientFile {
+	param([AllowNull()][AllowEmptyString()][string]$Path)
+
+	if ([string]::IsNullOrWhiteSpace($Path)) { return }
+	if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return }
+	Remove-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue
 }
 
 function Wait-ForMudClientServiceRemoval {
@@ -87,9 +97,7 @@ try {
 }
 finally {
 	foreach ($temporaryFile in @($manifestPath, $signaturePath)) {
-		if (-not [string]::IsNullOrWhiteSpace([string]$temporaryFile)) {
-			Remove-Item -LiteralPath $temporaryFile -Force -ErrorAction SilentlyContinue
-		}
+		Remove-MudClientFile -Path ([string]$temporaryFile)
 	}
 }
 
@@ -128,7 +136,7 @@ if ($CaddyExecutable) {
 		$createCaddyTask = $true
 	}
 	catch {
-		if ($caddyFileCreated) { Remove-Item -LiteralPath $persistentCaddyfile -Force -ErrorAction SilentlyContinue }
+		if ($caddyFileCreated) { Remove-MudClientFile -Path $persistentCaddyfile }
 		throw
 	}
 }
@@ -223,12 +231,15 @@ catch {
 	}
 	if ($legacyTask -and (Test-Path -LiteralPath $legacyTaskBackup)) { schtasks.exe /Create /TN $legacyTaskName /XML $legacyTaskBackup /F | Out-Null }
 	if ($createCaddyTask) { Unregister-ScheduledTask -TaskName $CaddyTaskName -Confirm:$false -ErrorAction SilentlyContinue }
-	if ($caddyFileCreated) { Remove-Item -LiteralPath $persistentCaddyfile -Force -ErrorAction SilentlyContinue }
+	if ($caddyFileCreated) { Remove-MudClientFile -Path $persistentCaddyfile }
 	throw $activationError
 }
 $activeReleases = Get-ChildItem -LiteralPath $releaseRoot -Directory | Where-Object Name -notlike 'legacy-*' | Sort-Object { [version]$_.Name }
 while ($activeReleases.Count -gt 3) {
-	Remove-Item -LiteralPath $activeReleases[0].FullName -Recurse -Force
+	$oldestRelease = $activeReleases | Select-Object -First 1
+	if ($oldestRelease -and -not [string]::IsNullOrWhiteSpace([string]$oldestRelease.FullName)) {
+		Remove-MudClientPath -Path $oldestRelease.FullName
+	}
 	$activeReleases = $activeReleases[1..($activeReleases.Count - 1)]
 }
 Write-Host "MudClient $version is active. Future upgrades: & '$InstallRoot\current\deploy\windows\Update-MudClient.ps1'"

--- a/MudClient/deploy/windows/Update-MudClient.ps1
+++ b/MudClient/deploy/windows/Update-MudClient.ps1
@@ -19,7 +19,9 @@ $deploymentTool = Join-Path $currentPath 'tools\MudClientDeployment.exe'
 if (-not (Test-Path -LiteralPath $deploymentTool)) { throw 'The deployed MudClient update verifier is unavailable.' }
 
 function Remove-MudClientPath {
-	param([Parameter(Mandatory = $true)][string]$Path)
+	param([AllowNull()][AllowEmptyString()][string]$Path)
+
+	if ([string]::IsNullOrWhiteSpace($Path)) { return }
 
 	$item = Get-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue
 	if (-not $item) { return }
@@ -32,6 +34,14 @@ function Remove-MudClientPath {
 	if ($LASTEXITCODE -ne 0) {
 		throw "Windows could not remove the reparse point '$Path' (exit code $LASTEXITCODE)."
 	}
+}
+
+function Remove-MudClientDirectory {
+	param([AllowNull()][AllowEmptyString()][string]$Path)
+
+	if ([string]::IsNullOrWhiteSpace($Path)) { return }
+	if (-not (Test-Path -LiteralPath $Path -PathType Container)) { return }
+	Remove-Item -LiteralPath $Path -Recurse -Force -ErrorAction SilentlyContinue
 }
 
 function Wait-ForMudClientServiceRemoval {
@@ -87,7 +97,7 @@ if ($Check) {
 		(Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json).version
 	}
 	finally {
-		Remove-Item -LiteralPath $temp -Recurse -Force -ErrorAction SilentlyContinue
+		Remove-MudClientDirectory -Path $temp
 	}
 	return
 }
@@ -150,5 +160,5 @@ try {
 	& (Join-Path $package 'deploy\windows\Install-MudClient.ps1') -ArchivePath $archive -InstallRoot $InstallRoot -ConfigRoot $ConfigRoot
 }
 finally {
-	Remove-Item -LiteralPath $temp -Recurse -Force -ErrorAction SilentlyContinue
+	Remove-MudClientDirectory -Path $temp
 }


### PR DESCRIPTION
## Summary\n- make Windows installer and updater cleanup null-safe\n- avoid null LiteralPath failures during rollback, Caddy cleanup, temporary cleanup, and release retention\n- document safe stale-reparse-point recovery for interrupted migrations\n\n## Validation\n- PowerShell parser validation\n- MudClient tests: 111 passed\n- representative win-x64 1.2.3 package built and inspected\n