### PR TITLE
Fix interrupted MudClient Windows migrations

### DIFF
--- a/MudClient/DEPLOYMENT.md
+++ b/MudClient/DEPLOYMENT.md
@@ -33,12 +33,12 @@ Linux additionally requires systemd, bash, curl, unzip, and Caddy v2 managed by 
 
 MudClient 1.2.0 is the first release with a safe upgrade layout. Its release files are immutable under `releases/<version>`; `current`, `web`, and `proxy` stay at stable paths so an upgrade does not alter Caddy, DNS, TLS, firewall, MUD, or database configuration. Operator settings are moved to `/etc/mudclient` on Linux and `%ProgramData%\FutureMUD\MudClient` on Windows.
 
-To migrate an existing 1.0.1 or 1.1.0 Linux installation, download and extract the 1.2.3 archive once, then run the installer with the original archive:
+To migrate an existing 1.0.1 or 1.1.0 Linux installation, download and extract the 1.2.4 archive once, then run the installer with the original archive:
 
 ~~~bash
-unzip mudclient-1.2.3-linux-x64.zip -d /tmp/mudclient-1.2.3
-sudo bash /tmp/mudclient-1.2.3/mudclient-1.2.3-linux-x64/deploy/linux/install-mudclient.sh \
-  --archive "$PWD/mudclient-1.2.3-linux-x64.zip" --migrate
+unzip mudclient-1.2.4-linux-x64.zip -d /tmp/mudclient-1.2.4
+sudo bash /tmp/mudclient-1.2.4/mudclient-1.2.4-linux-x64/deploy/linux/install-mudclient.sh \
+  --archive "$PWD/mudclient-1.2.4-linux-x64.zip" --migrate
 ~~~
 
 The command keeps the old release as a rollback target, copies proxy and browser settings to durable locations, and retains the existing Caddy configuration. It briefly restarts only the private proxy, so connected browser sessions disconnect and can reconnect; the MUD itself is not restarted.
@@ -51,12 +51,14 @@ sudo /opt/mudclient/current/deploy/linux/update-mudclient.sh
 
 Use `--check` to inspect the signed latest manifest without changing files, or `--rollback` to activate the previous local release. The updater verifies an Ed25519-signed manifest and archive SHA-256 before staging, preserves two prior releases, and restores the prior release if the proxy health check fails.
 
-On Windows, extract the 1.2.3 archive once and run this from an elevated PowerShell window:
+On Windows, extract the 1.2.4 archive once and run this from an elevated PowerShell window:
 
 ~~~powershell
-& 'C:\staging\mudclient-1.2.3-win-x64\deploy\windows\Install-MudClient.ps1' `
-  -ArchivePath 'C:\Users\Administrator\Downloads\mudclient-1.2.3-win-x64.zip' -Migrate
+& 'C:\staging\mudclient-1.2.4-win-x64\deploy\windows\Install-MudClient.ps1' `
+  -ArchivePath 'C:\Users\Administrator\Downloads\mudclient-1.2.4-win-x64.zip' -Migrate
 ~~~
+
+Version 1.2.4 can resume an interrupted 1.2.0-1.2.3 migration. It completes a partially moved legacy `proxy`/`web` pair, reuses the preserved legacy release, and replaces an inactive staged copy of 1.2.4 before retrying. If activation still fails, rollback warnings are reported separately and the original activation error remains visible.
 
 If a failed earlier migration left stale `current`, `web`, or `proxy` links, stop the proxy and remove only those reparse points before retrying. This does not remove ordinary configuration directories:
 
@@ -85,16 +87,16 @@ Later Windows updates use:
 After verifying the website's published SHA-256 checksum, extract the downloaded package to `/opt/mudclient` and run the installer from that directory:
 
 ~~~bash
-unzip mudclient-1.2.3-linux-x64.zip -d /tmp/mudclient-package
-sudo bash /tmp/mudclient-package/mudclient-1.2.3-linux-x64/deploy/linux/install-mudclient.sh \
-  --archive "$PWD/mudclient-1.2.3-linux-x64.zip" --domain play.example.com
+unzip mudclient-1.2.4-linux-x64.zip -d /tmp/mudclient-package
+sudo bash /tmp/mudclient-package/mudclient-1.2.4-linux-x64/deploy/linux/install-mudclient.sh \
+  --archive "$PWD/mudclient-1.2.4-linux-x64.zip" --domain play.example.com
 ~~~
 
 The script creates the unprivileged proxy service, writes the exact trusted public origin, adds an isolated Caddy site fragment, validates Caddy before reload, and checks the private health endpoint. The selected domain must already resolve to the host. To connect to a MUD on a private network rather than the same machine:
 
 ~~~bash
-sudo bash /tmp/mudclient-package/mudclient-1.2.3-linux-x64/deploy/linux/install-mudclient.sh \
-  --archive "$PWD/mudclient-1.2.3-linux-x64.zip" --domain play.example.com --mud-host 10.0.0.20 --mud-port 4000
+sudo bash /tmp/mudclient-package/mudclient-1.2.4-linux-x64/deploy/linux/install-mudclient.sh \
+  --archive "$PWD/mudclient-1.2.4-linux-x64.zip" --domain play.example.com --mud-host 10.0.0.20 --mud-port 4000
 ~~~
 
 Use `CADDY_CONFIG` and `CADDY_FRAGMENTS_DIR` for nonstandard Caddyfile locations. The installer saves `.before-mudclient-install` backups of the files it changes; review those and take a normal deployment backup before upgrading an existing installation.
@@ -110,7 +112,7 @@ dotnet workload install wasm-tools
 ```
 
 ```powershell
-.\scripts\Publish-ProductPackage.ps1 -RuntimeIdentifier win-x64 -Version 1.2.3
+.\scripts\Publish-ProductPackage.ps1 -RuntimeIdentifier win-x64 -Version 1.2.4
 ```
 
 ```bash

--- a/MudClient/Deployment/Windows_AWS_Web_Client_Guide.md
+++ b/MudClient/Deployment/Windows_AWS_Web_Client_Guide.md
@@ -1,6 +1,6 @@
 # Windows and AWS Web Client Setup Guide
 
-This is a deliberately plain-English guide for installing FutureMUD Web MUD Client 1.2.3 on a Windows server hosted in AWS. It adds a small HTTPS website alongside an existing FutureMUD game, without changing the game itself or any other applications on the server.
+This is a deliberately plain-English guide for installing FutureMUD Web MUD Client 1.2.4 on a Windows server hosted in AWS. It adds a small HTTPS website alongside an existing FutureMUD game, without changing the game itself or any other applications on the server.
 
 The names and addresses below are examples. Before using a command, replace `play.example.com` with your own player-facing hostname. Do not put a live server's IP address, AWS instance ID, administrator account name, or credentials in a public guide or repository.
 
@@ -64,7 +64,7 @@ Name them clearly, for example `Web MUD Client HTTP` and `Web MUD Client HTTPS`.
 Open an **Administrator PowerShell** window on the Windows server and run the following. It creates a new, dedicated folder and does not overwrite the game installation.
 
 ```powershell
-$version = '1.2.3'
+$version = '1.2.4'
 $archive = "$env:USERPROFILE\Downloads\mudclient-$version-win-x64.zip"
 $staging = "C:\MudClient-$version"
 
@@ -89,7 +89,7 @@ C:\MudClient\web\wwwroot\index.html
 C:\MudClient\deploy\windows\Caddyfile
 ```
 
-For an existing 1.0.1 or 1.1.0 installation, use the same command with `-Migrate`. It preserves the old release and existing Caddyfile, moves proxy/browser settings to `%ProgramData%\FutureMUD\MudClient`, and replaces only the old proxy task with a Windows Service.
+For an existing 1.0.1 or 1.1.0 installation, use the same command with `-Migrate`. It preserves the old release and existing Caddyfile, moves proxy/browser settings to `%ProgramData%\FutureMUD\MudClient`, and replaces only the old proxy task with a Windows Service. Version 1.2.4 also resumes a partially completed 1.2.0-1.2.3 migration and reports the original activation error even if a rollback step has its own problem.
 
 After that one-time migration, an Administrator updates the client with one command:
 

--- a/MudClient/MudClientDeployment/MudClientDeployment.csproj
+++ b/MudClient/MudClientDeployment/MudClientDeployment.csproj
@@ -5,7 +5,7 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<Version>1.2.3</Version>
+		<Version>1.2.4</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/MudClient/MudClientTests/MudClientTests.csproj
+++ b/MudClient/MudClientTests/MudClientTests.csproj
@@ -26,4 +26,9 @@
     <Using Include="Xunit" />
   </ItemGroup>
 
+	<ItemGroup>
+		<None Include="..\deploy\windows\Install-MudClient.ps1" Link="DeploymentScripts\Install-MudClient.ps1" CopyToOutputDirectory="PreserveNewest" />
+		<None Include="..\deploy\windows\MudClientDeployment.Common.ps1" Link="DeploymentScripts\MudClientDeployment.Common.ps1" CopyToOutputDirectory="PreserveNewest" />
+	</ItemGroup>
+
 </Project>

--- a/MudClient/MudClientTests/WindowsInstallerRegressionTests.cs
+++ b/MudClient/MudClientTests/WindowsInstallerRegressionTests.cs
@@ -1,0 +1,88 @@
+namespace MudClientTests;
+
+public class WindowsInstallerRegressionTests
+{
+	private static string InstallerScript => File.ReadAllText(
+		Path.Combine(AppContext.BaseDirectory, "DeploymentScripts", "Install-MudClient.ps1"));
+	private static string CommonScriptPath => Path.Combine(
+		AppContext.BaseDirectory, "DeploymentScripts", "MudClientDeployment.Common.ps1");
+
+	[Fact]
+	public void RollbackGuardsOptionalPathsAndPreservesTheActivationError()
+	{
+		var script = InstallerScript;
+
+		Assert.Contains("$existingServiceInstaller = if ($previousTarget)", script, StringComparison.Ordinal);
+		Assert.Contains("if (-not [string]::IsNullOrWhiteSpace($existingServiceInstaller) -and (Test-Path -LiteralPath $existingServiceInstaller))", script, StringComparison.Ordinal);
+		Assert.Contains("Invoke-MudClientRollbackStep -Description 'Restoring the previous MudClientProxy service'", script, StringComparison.Ordinal);
+		Assert.Contains("throw $activationError", script, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void MigrationRecognisesAndCompletesAnInterruptedLegacyMove()
+	{
+		var script = File.ReadAllText(CommonScriptPath);
+
+		Assert.Contains("$resumableLegacyPath = $existingLegacyPaths", script, StringComparison.Ordinal);
+		Assert.Contains("($hasFlatProxy -or $hasLegacyProxy)", script, StringComparison.Ordinal);
+		Assert.Contains("($hasFlatWeb -or $hasLegacyWeb)", script, StringComparison.Ordinal);
+		Assert.Contains("The legacy installation is incomplete.", script, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void MigrationResumesAProxyMoveWhenTheWebFolderWasAlreadyPreserved()
+	{
+		if (!OperatingSystem.IsWindows()) { return; }
+
+		var testRoot = Path.Combine(Path.GetTempPath(), $"mudclient-migration-{Guid.NewGuid():N}");
+		var installRoot = Path.Combine(testRoot, "install");
+		var releaseRoot = Path.Combine(installRoot, "releases");
+		var legacyRoot = Path.Combine(releaseRoot, "legacy-20260804000000000");
+		Directory.CreateDirectory(Path.Combine(installRoot, "proxy"));
+		Directory.CreateDirectory(Path.Combine(legacyRoot, "web"));
+		File.WriteAllText(Path.Combine(installRoot, "proxy", "appsettings.json"), "proxy-settings");
+		File.WriteAllText(Path.Combine(legacyRoot, "web", "marker.txt"), "legacy-web");
+
+		try
+		{
+			var command = $". '{EscapePowerShell(CommonScriptPath)}'; " +
+				$"$result = Move-MudClientLegacyInstallation -InstallRoot '{EscapePowerShell(installRoot)}' -ReleaseRoot '{EscapePowerShell(releaseRoot)}' -Migrate; " +
+				"Write-Output $result";
+			var startInfo = new System.Diagnostics.ProcessStartInfo("powershell.exe")
+			{
+				RedirectStandardOutput = true,
+				RedirectStandardError = true,
+				UseShellExecute = false
+			};
+			startInfo.ArgumentList.Add("-NoProfile");
+			startInfo.ArgumentList.Add("-Command");
+			startInfo.ArgumentList.Add(command);
+			using var process = System.Diagnostics.Process.Start(startInfo)!;
+			var output = process.StandardOutput.ReadToEnd().Trim();
+			var error = process.StandardError.ReadToEnd();
+			process.WaitForExit();
+
+			Assert.True(process.ExitCode == 0, error);
+			Assert.Equal(legacyRoot, output, ignoreCase: true);
+			Assert.False(Directory.Exists(Path.Combine(installRoot, "proxy")));
+			Assert.Equal("proxy-settings", File.ReadAllText(Path.Combine(legacyRoot, "proxy", "appsettings.json")));
+			Assert.Equal("legacy-web", File.ReadAllText(Path.Combine(legacyRoot, "web", "marker.txt")));
+		}
+		finally
+		{
+			Directory.Delete(testRoot, recursive: true);
+		}
+	}
+
+	[Fact]
+	public void InstallerRestagesAnInactiveReleaseLeftByAFailedAttempt()
+	{
+		var script = InstallerScript;
+
+		Assert.Contains("throw \"Release $version is already active.\"", script, StringComparison.Ordinal);
+		Assert.Contains("Remove-MudClientPath -Path $releasePath", script, StringComparison.Ordinal);
+		Assert.DoesNotContain("throw \"Release $version is already staged.\"", script, StringComparison.Ordinal);
+	}
+
+	private static string EscapePowerShell(string value) => value.Replace("'", "''", StringComparison.Ordinal);
+}

--- a/MudClient/MudWebSocketProxy/MudWebSocketProxy.csproj
+++ b/MudClient/MudWebSocketProxy/MudWebSocketProxy.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-		<Version>1.2.3</Version>
+		<Version>1.2.4</Version>
   </PropertyGroup>
 
 </Project>

--- a/MudClient/deploy/windows/Install-MudClient.ps1
+++ b/MudClient/deploy/windows/Install-MudClient.ps1
@@ -26,6 +26,7 @@ $version = $Matches.version
 $runtime = $Matches.runtime
 $temporaryRoot = [System.IO.Path]::GetTempPath()
 if ([string]::IsNullOrWhiteSpace($temporaryRoot)) { throw 'Windows did not provide a temporary directory.' }
+. (Join-Path $PSScriptRoot 'MudClientDeployment.Common.ps1')
 
 function Remove-MudClientPath {
 	param([AllowNull()][AllowEmptyString()][string]$Path)
@@ -51,6 +52,20 @@ function Remove-MudClientFile {
 	if ([string]::IsNullOrWhiteSpace($Path)) { return }
 	if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return }
 	Remove-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue
+}
+
+function Invoke-MudClientRollbackStep {
+	param(
+		[Parameter(Mandatory = $true)][string]$Description,
+		[Parameter(Mandatory = $true)][scriptblock]$Action
+	)
+
+	try {
+		& $Action
+	}
+	catch {
+		Write-Warning "$Description failed: $($_.Exception.Message)"
+	}
 }
 
 function Wait-ForMudClientServiceRemoval {
@@ -114,6 +129,18 @@ $legacyProxy = Join-Path $InstallRoot 'proxy'
 $legacyWeb = Join-Path $InstallRoot 'web'
 $legacyReleasePath = $null
 $previousTarget = if (Test-Path -LiteralPath $currentPath) { [string](Get-Item -LiteralPath $currentPath).Target } else { $null }
+$existingServiceInstaller = if ($previousTarget) {
+	Join-Path $currentPath 'deploy\windows\install-mudclient-proxy.ps1'
+}
+else {
+	Join-Path $InstallRoot 'deploy\windows\install-mudclient-proxy.ps1'
+}
+$releaseServiceInstaller = Join-Path $releasePath 'deploy\windows\install-mudclient-proxy.ps1'
+$legacyTaskName = 'FutureMUD Mud WebSocket Proxy'
+$legacyTaskBackup = Join-Path $ConfigRoot 'legacy-proxy-task.xml'
+$serviceBackup = Join-Path $ConfigRoot 'mudclient-proxy-service.txt'
+$existingService = $null
+$legacyTask = $null
 $persistentCaddyfile = Join-Path $InstallRoot 'deploy\windows\Caddyfile'
 $caddyFileCreated = $false
 $createCaddyTask = $false
@@ -142,23 +169,23 @@ if ($CaddyExecutable) {
 }
 try {
 New-Item -ItemType Directory -Force -Path $releaseRoot, (Join-Path $ConfigRoot 'proxy'), (Join-Path $ConfigRoot 'web') | Out-Null
-if ((Test-Path -LiteralPath $legacyProxy) -and -not (Get-Item -LiteralPath $legacyProxy).LinkType) {
-	if (-not $Migrate) { throw 'A flat MudClient installation was found. Re-run with -Migrate.' }
-	$legacyPath = Join-Path $releaseRoot ("legacy-" + (Get-Date -Format 'yyyyMMddHHmmss'))
-	$legacyReleasePath = $legacyPath
+$legacyReleasePath = Move-MudClientLegacyInstallation -InstallRoot $InstallRoot -ReleaseRoot $releaseRoot -Migrate:$Migrate
+if ($legacyReleasePath) {
 	if (-not $previousTarget) { $previousTarget = $legacyReleasePath }
-	New-Item -ItemType Directory -Force -Path $legacyPath | Out-Null
-	Move-Item -LiteralPath $legacyProxy -Destination (Join-Path $legacyPath 'proxy')
-	Move-Item -LiteralPath $legacyWeb -Destination (Join-Path $legacyPath 'web')
 	if (-not (Test-Path -LiteralPath (Join-Path $ConfigRoot 'proxy\appsettings.json'))) {
-		Copy-Item -LiteralPath (Join-Path $legacyPath 'proxy\appsettings.json') -Destination (Join-Path $ConfigRoot 'proxy\appsettings.json')
+		Copy-Item -LiteralPath (Join-Path $legacyReleasePath 'proxy\appsettings.json') -Destination (Join-Path $ConfigRoot 'proxy\appsettings.json')
 	}
-	$legacyWebSettings = Join-Path $legacyPath 'web\wwwroot\appsettings.json'
+	$legacyWebSettings = Join-Path $legacyReleasePath 'web\wwwroot\appsettings.json'
 	if ((Test-Path -LiteralPath $legacyWebSettings) -and -not (Test-Path -LiteralPath (Join-Path $ConfigRoot 'web\appsettings.json'))) {
 		Copy-Item -LiteralPath $legacyWebSettings -Destination (Join-Path $ConfigRoot 'web\appsettings.json')
 	}
 }
-if (Test-Path -LiteralPath $releasePath) { throw "Release $version is already staged." }
+if (Test-Path -LiteralPath $releasePath) {
+	if ($previousTarget -and ([System.IO.Path]::GetFullPath($previousTarget) -eq [System.IO.Path]::GetFullPath($releasePath))) {
+		throw "Release $version is already active."
+	}
+	Remove-MudClientPath -Path $releasePath
+}
 Copy-Item -LiteralPath $packageRoot -Destination $releasePath -Recurse
 $proxySettings = Join-Path $ConfigRoot 'proxy\appsettings.json'
 $webSettings = Join-Path $ConfigRoot 'web\appsettings.json'
@@ -166,16 +193,6 @@ if (-not (Test-Path -LiteralPath $proxySettings)) { Copy-Item -LiteralPath (Join
 if (-not (Test-Path -LiteralPath $webSettings)) { Copy-Item -LiteralPath (Join-Path $releasePath 'web\wwwroot\appsettings.json') -Destination $webSettings }
 Copy-Item -LiteralPath $webSettings -Destination (Join-Path $releasePath 'web\wwwroot\appsettings.json') -Force
 
-$existingServiceInstaller = if (Test-Path -LiteralPath $currentPath) {
-	Join-Path $currentPath 'deploy\windows\install-mudclient-proxy.ps1'
-}
-else {
-	Join-Path $InstallRoot 'deploy\windows\install-mudclient-proxy.ps1'
-}
-$releaseServiceInstaller = Join-Path $releasePath 'deploy\windows\install-mudclient-proxy.ps1'
-$legacyTaskName = 'FutureMUD Mud WebSocket Proxy'
-$legacyTaskBackup = Join-Path $ConfigRoot 'legacy-proxy-task.xml'
-$serviceBackup = Join-Path $ConfigRoot 'mudclient-proxy-service.txt'
 $existingService = Get-Service -Name MudClientProxy -ErrorAction SilentlyContinue
 if ($existingService) { sc.exe qc MudClientProxy | Set-Content -LiteralPath $serviceBackup -Encoding UTF8 }
 $legacyTask = Get-ScheduledTask -TaskName $legacyTaskName -ErrorAction SilentlyContinue
@@ -208,30 +225,36 @@ if (Test-Path -LiteralPath $existingServiceInstaller) {
 }
 catch {
 	$activationError = $_
-	if ($releaseServiceInstaller -and (Test-Path -LiteralPath $releaseServiceInstaller)) { & $releaseServiceInstaller -Uninstall -ErrorAction SilentlyContinue }
-	try {
-		Wait-ForMudClientServiceRemoval
+	Invoke-MudClientRollbackStep -Description 'Removing the failed MudClientProxy service' -Action {
+		if (Test-Path -LiteralPath $releaseServiceInstaller) { & $releaseServiceInstaller -Uninstall -ErrorAction SilentlyContinue }
 	}
-	catch {
-		Write-Warning $_.Exception.Message
-	}
+	Invoke-MudClientRollbackStep -Description 'Waiting for the failed MudClientProxy service to stop' -Action { Wait-ForMudClientServiceRemoval }
 	if ($previousTarget) {
-		try {
+		Invoke-MudClientRollbackStep -Description 'Restoring the previous MudClient release' -Action {
 			Remove-MudClientPath -Path $currentPath
 			New-Item -ItemType SymbolicLink -Path $currentPath -Target $previousTarget | Out-Null
 		}
-		catch {
-			Write-Warning "Could not restore the previous current release: $($_.Exception.Message)"
-		}
 		foreach ($link in @('web', 'proxy')) {
-			$linkPath = Join-Path $InstallRoot $link
-			if (-not (Get-Item -LiteralPath $linkPath -Force -ErrorAction SilentlyContinue)) { New-Item -ItemType SymbolicLink -Path $linkPath -Target (Join-Path $currentPath $link) | Out-Null }
+			Invoke-MudClientRollbackStep -Description "Restoring the stable $link link" -Action {
+				$linkPath = Join-Path $InstallRoot $link
+				if (-not (Get-Item -LiteralPath $linkPath -Force -ErrorAction SilentlyContinue)) { New-Item -ItemType SymbolicLink -Path $linkPath -Target (Join-Path $currentPath $link) | Out-Null }
+			}
 		}
-		if (Test-Path -LiteralPath $existingServiceInstaller) { & $existingServiceInstaller -InstallRoot $InstallRoot }
+		Invoke-MudClientRollbackStep -Description 'Restoring the previous MudClientProxy service' -Action {
+			if (-not [string]::IsNullOrWhiteSpace($existingServiceInstaller) -and (Test-Path -LiteralPath $existingServiceInstaller)) {
+				& $existingServiceInstaller -InstallRoot $InstallRoot
+			}
+		}
 	}
-	if ($legacyTask -and (Test-Path -LiteralPath $legacyTaskBackup)) { schtasks.exe /Create /TN $legacyTaskName /XML $legacyTaskBackup /F | Out-Null }
-	if ($createCaddyTask) { Unregister-ScheduledTask -TaskName $CaddyTaskName -Confirm:$false -ErrorAction SilentlyContinue }
-	if ($caddyFileCreated) { Remove-MudClientFile -Path $persistentCaddyfile }
+	Invoke-MudClientRollbackStep -Description 'Restoring the legacy proxy scheduled task' -Action {
+		if ($legacyTask -and (Test-Path -LiteralPath $legacyTaskBackup)) { schtasks.exe /Create /TN $legacyTaskName /XML $legacyTaskBackup /F | Out-Null }
+	}
+	Invoke-MudClientRollbackStep -Description 'Removing the newly-created Caddy task' -Action {
+		if ($createCaddyTask) { Unregister-ScheduledTask -TaskName $CaddyTaskName -Confirm:$false -ErrorAction SilentlyContinue }
+	}
+	Invoke-MudClientRollbackStep -Description 'Removing the newly-created Caddyfile' -Action {
+		if ($caddyFileCreated) { Remove-MudClientFile -Path $persistentCaddyfile }
+	}
 	throw $activationError
 }
 $activeReleases = Get-ChildItem -LiteralPath $releaseRoot -Directory | Where-Object Name -notlike 'legacy-*' | Sort-Object { [version]$_.Name }

--- a/MudClient/deploy/windows/MudClientDeployment.Common.ps1
+++ b/MudClient/deploy/windows/MudClientDeployment.Common.ps1
@@ -1,0 +1,61 @@
+function Move-MudClientLegacyInstallation {
+	param(
+		[Parameter(Mandatory = $true)][string]$InstallRoot,
+		[Parameter(Mandatory = $true)][string]$ReleaseRoot,
+		[switch]$Migrate
+	)
+
+	$legacyProxy = Join-Path $InstallRoot 'proxy'
+	$legacyWeb = Join-Path $InstallRoot 'web'
+	$flatProxy = Get-Item -LiteralPath $legacyProxy -Force -ErrorAction SilentlyContinue
+	$flatWeb = Get-Item -LiteralPath $legacyWeb -Force -ErrorAction SilentlyContinue
+	$hasFlatProxy = $flatProxy -and (($flatProxy.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -eq 0)
+	$hasFlatWeb = $flatWeb -and (($flatWeb.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -eq 0)
+	$existingLegacyPaths = @(Get-ChildItem -LiteralPath $ReleaseRoot -Directory -Filter 'legacy-*' -ErrorAction SilentlyContinue |
+		Sort-Object Name -Descending |
+		Where-Object { (Test-Path -LiteralPath (Join-Path $_.FullName 'proxy')) -or (Test-Path -LiteralPath (Join-Path $_.FullName 'web')) })
+	$completeLegacyPath = $existingLegacyPaths |
+		Where-Object { (Test-Path -LiteralPath (Join-Path $_.FullName 'proxy')) -and (Test-Path -LiteralPath (Join-Path $_.FullName 'web')) } |
+		Select-Object -First 1
+
+	if (-not $hasFlatProxy -and -not $hasFlatWeb) {
+		if ($Migrate -and $completeLegacyPath) { return $completeLegacyPath.FullName }
+		return $null
+	}
+	if (-not $Migrate) { throw 'A flat MudClient installation was found. Re-run with -Migrate.' }
+
+	$resumableLegacyPath = $existingLegacyPaths |
+		Where-Object {
+			$hasLegacyProxy = Test-Path -LiteralPath (Join-Path $_.FullName 'proxy')
+			$hasLegacyWeb = Test-Path -LiteralPath (Join-Path $_.FullName 'web')
+			(-not ($hasFlatProxy -and $hasLegacyProxy)) -and
+			(-not ($hasFlatWeb -and $hasLegacyWeb)) -and
+			($hasFlatProxy -or $hasLegacyProxy) -and
+			($hasFlatWeb -or $hasLegacyWeb)
+		} |
+		Select-Object -First 1
+	$legacyPath = if ($resumableLegacyPath) {
+		$resumableLegacyPath.FullName
+	}
+	else {
+		Join-Path $ReleaseRoot ("legacy-" + (Get-Date -Format 'yyyyMMddHHmmssfff'))
+	}
+	New-Item -ItemType Directory -Force -Path $legacyPath | Out-Null
+
+	foreach ($legacyComponent in @(
+		@{ Name = 'proxy'; Source = $legacyProxy; Present = $hasFlatProxy },
+		@{ Name = 'web'; Source = $legacyWeb; Present = $hasFlatWeb }
+	)) {
+		if (-not $legacyComponent.Present) { continue }
+		$legacyDestination = Join-Path $legacyPath $legacyComponent.Name
+		if (Test-Path -LiteralPath $legacyDestination) {
+			throw "The interrupted migration contains both '$($legacyComponent.Source)' and '$legacyDestination'. Move one aside and retry."
+		}
+		Move-Item -LiteralPath $legacyComponent.Source -Destination $legacyDestination
+	}
+
+	if (-not (Test-Path -LiteralPath (Join-Path $legacyPath 'proxy')) -or -not (Test-Path -LiteralPath (Join-Path $legacyPath 'web'))) {
+		throw "The legacy installation is incomplete. Both '$legacyPath\proxy' and '$legacyPath\web' are required to resume migration."
+	}
+	return $legacyPath
+}


### PR DESCRIPTION
## Summary
- make Windows migration rollback preserve and rethrow the original activation error
- resume interrupted flat-to-versioned migrations when proxy or web was already moved
- safely replace an inactive staged release left by a failed attempt
- bump the MudClient release candidate and deployment guides to 1.2.4

## Validation
- Windows PowerShell 5.1 and current PowerShell parser validation for all Windows deployment scripts
- `dotnet test MudClient/MudClientTests/MudClientTests.csproj -c Release -m:1 -p:NuGetAudit=false` (119 passed)
- full, interrupted, and completed legacy migration filesystem fixtures
- representative win-x64 1.2.4 package built and inspected (179 entries; required scripts, tools, proxy, web settings, and updated guide present)