### PR TITLE
MudClient 1.2.5: stop legacy proxy before migration

### DIFF
--- a/MudClient/DEPLOYMENT.md
+++ b/MudClient/DEPLOYMENT.md
@@ -33,12 +33,12 @@ Linux additionally requires systemd, bash, curl, unzip, and Caddy v2 managed by 
 
 MudClient 1.2.0 is the first release with a safe upgrade layout. Its release files are immutable under `releases/<version>`; `current`, `web`, and `proxy` stay at stable paths so an upgrade does not alter Caddy, DNS, TLS, firewall, MUD, or database configuration. Operator settings are moved to `/etc/mudclient` on Linux and `%ProgramData%\FutureMUD\MudClient` on Windows.
 
-To migrate an existing 1.0.1 or 1.1.0 Linux installation, download and extract the 1.2.4 archive once, then run the installer with the original archive:
+To migrate an existing 1.0.1 or 1.1.0 Linux installation, download and extract the 1.2.5 archive once, then run the installer with the original archive:
 
 ~~~bash
-unzip mudclient-1.2.4-linux-x64.zip -d /tmp/mudclient-1.2.4
-sudo bash /tmp/mudclient-1.2.4/mudclient-1.2.4-linux-x64/deploy/linux/install-mudclient.sh \
-  --archive "$PWD/mudclient-1.2.4-linux-x64.zip" --migrate
+unzip mudclient-1.2.5-linux-x64.zip -d /tmp/mudclient-1.2.5
+sudo bash /tmp/mudclient-1.2.5/mudclient-1.2.5-linux-x64/deploy/linux/install-mudclient.sh \
+  --archive "$PWD/mudclient-1.2.5-linux-x64.zip" --migrate
 ~~~
 
 The command keeps the old release as a rollback target, copies proxy and browser settings to durable locations, and retains the existing Caddy configuration. It briefly restarts only the private proxy, so connected browser sessions disconnect and can reconnect; the MUD itself is not restarted.
@@ -51,14 +51,14 @@ sudo /opt/mudclient/current/deploy/linux/update-mudclient.sh
 
 Use `--check` to inspect the signed latest manifest without changing files, or `--rollback` to activate the previous local release. The updater verifies an Ed25519-signed manifest and archive SHA-256 before staging, preserves two prior releases, and restores the prior release if the proxy health check fails.
 
-On Windows, extract the 1.2.4 archive once and run this from an elevated PowerShell window:
+On Windows, extract the 1.2.5 archive once and run this from an elevated PowerShell window:
 
 ~~~powershell
-& 'C:\staging\mudclient-1.2.4-win-x64\deploy\windows\Install-MudClient.ps1' `
-  -ArchivePath 'C:\Users\Administrator\Downloads\mudclient-1.2.4-win-x64.zip' -Migrate
+& 'C:\staging\mudclient-1.2.5-win-x64\deploy\windows\Install-MudClient.ps1' `
+  -ArchivePath 'C:\Users\Administrator\Downloads\mudclient-1.2.5-win-x64.zip' -Migrate
 ~~~
 
-Version 1.2.4 can resume an interrupted 1.2.0-1.2.3 migration. It completes a partially moved legacy `proxy`/`web` pair, reuses the preserved legacy release, and replaces an inactive staged copy of 1.2.4 before retrying. If activation still fails, rollback warnings are reported separately and the original activation error remains visible.
+Version 1.2.5 can resume an interrupted 1.2.0-1.2.4 migration. It stops the legacy proxy scheduled task and any remaining proxy process before moving the old directories, completes a partially moved legacy `proxy`/`web` pair, reuses the preserved legacy release, and replaces an inactive staged copy before retrying. If activation fails, the legacy task is restored to its previous running state, rollback warnings are reported separately, and the original activation error remains visible.
 
 If a failed earlier migration left stale `current`, `web`, or `proxy` links, stop the proxy and remove only those reparse points before retrying. This does not remove ordinary configuration directories:
 
@@ -87,16 +87,16 @@ Later Windows updates use:
 After verifying the website's published SHA-256 checksum, extract the downloaded package to `/opt/mudclient` and run the installer from that directory:
 
 ~~~bash
-unzip mudclient-1.2.4-linux-x64.zip -d /tmp/mudclient-package
-sudo bash /tmp/mudclient-package/mudclient-1.2.4-linux-x64/deploy/linux/install-mudclient.sh \
-  --archive "$PWD/mudclient-1.2.4-linux-x64.zip" --domain play.example.com
+unzip mudclient-1.2.5-linux-x64.zip -d /tmp/mudclient-package
+sudo bash /tmp/mudclient-package/mudclient-1.2.5-linux-x64/deploy/linux/install-mudclient.sh \
+  --archive "$PWD/mudclient-1.2.5-linux-x64.zip" --domain play.example.com
 ~~~
 
 The script creates the unprivileged proxy service, writes the exact trusted public origin, adds an isolated Caddy site fragment, validates Caddy before reload, and checks the private health endpoint. The selected domain must already resolve to the host. To connect to a MUD on a private network rather than the same machine:
 
 ~~~bash
-sudo bash /tmp/mudclient-package/mudclient-1.2.4-linux-x64/deploy/linux/install-mudclient.sh \
-  --archive "$PWD/mudclient-1.2.4-linux-x64.zip" --domain play.example.com --mud-host 10.0.0.20 --mud-port 4000
+sudo bash /tmp/mudclient-package/mudclient-1.2.5-linux-x64/deploy/linux/install-mudclient.sh \
+  --archive "$PWD/mudclient-1.2.5-linux-x64.zip" --domain play.example.com --mud-host 10.0.0.20 --mud-port 4000
 ~~~
 
 Use `CADDY_CONFIG` and `CADDY_FRAGMENTS_DIR` for nonstandard Caddyfile locations. The installer saves `.before-mudclient-install` backups of the files it changes; review those and take a normal deployment backup before upgrading an existing installation.
@@ -112,7 +112,7 @@ dotnet workload install wasm-tools
 ```
 
 ```powershell
-.\scripts\Publish-ProductPackage.ps1 -RuntimeIdentifier win-x64 -Version 1.2.4
+.\scripts\Publish-ProductPackage.ps1 -RuntimeIdentifier win-x64 -Version 1.2.5
 ```
 
 ```bash

--- a/MudClient/DEPLOYMENT.md
+++ b/MudClient/DEPLOYMENT.md
@@ -58,7 +58,7 @@ On Windows, extract the 1.2.5 archive once and run this from an elevated PowerSh
   -ArchivePath 'C:\Users\Administrator\Downloads\mudclient-1.2.5-win-x64.zip' -Migrate
 ~~~
 
-Version 1.2.5 can resume an interrupted 1.2.0-1.2.4 migration. It stops the legacy proxy scheduled task and any remaining proxy process before moving the old directories, completes a partially moved legacy `proxy`/`web` pair, reuses the preserved legacy release, and replaces an inactive staged copy before retrying. If activation fails, the legacy task is restored to its previous running state, rollback warnings are reported separately, and the original activation error remains visible.
+Version 1.2.5 can resume an interrupted 1.2.0-1.2.4 migration. It stops the legacy proxy scheduled task and any remaining proxy process before moving the old directories, completes a partially moved legacy `proxy`/`web` pair, reuses the preserved legacy release, and replaces an inactive staged copy before retrying. It also supplies the required .NET Windows Service lifetime for the native `MudClientProxy` service. If activation fails, the legacy task is restored to its previous running state, rollback warnings are reported separately, and the original activation error remains visible.
 
 If a failed earlier migration left stale `current`, `web`, or `proxy` links, stop the proxy and remove only those reparse points before retrying. This does not remove ordinary configuration directories:
 

--- a/MudClient/Deployment/Windows_AWS_Web_Client_Guide.md
+++ b/MudClient/Deployment/Windows_AWS_Web_Client_Guide.md
@@ -1,6 +1,6 @@
 # Windows and AWS Web Client Setup Guide
 
-This is a deliberately plain-English guide for installing FutureMUD Web MUD Client 1.2.4 on a Windows server hosted in AWS. It adds a small HTTPS website alongside an existing FutureMUD game, without changing the game itself or any other applications on the server.
+This is a deliberately plain-English guide for installing FutureMUD Web MUD Client 1.2.5 on a Windows server hosted in AWS. It adds a small HTTPS website alongside an existing FutureMUD game, without changing the game itself or any other applications on the server.
 
 The names and addresses below are examples. Before using a command, replace `play.example.com` with your own player-facing hostname. Do not put a live server's IP address, AWS instance ID, administrator account name, or credentials in a public guide or repository.
 
@@ -64,7 +64,7 @@ Name them clearly, for example `Web MUD Client HTTP` and `Web MUD Client HTTPS`.
 Open an **Administrator PowerShell** window on the Windows server and run the following. It creates a new, dedicated folder and does not overwrite the game installation.
 
 ```powershell
-$version = '1.2.4'
+$version = '1.2.5'
 $archive = "$env:USERPROFILE\Downloads\mudclient-$version-win-x64.zip"
 $staging = "C:\MudClient-$version"
 
@@ -89,7 +89,7 @@ C:\MudClient\web\wwwroot\index.html
 C:\MudClient\deploy\windows\Caddyfile
 ```
 
-For an existing 1.0.1 or 1.1.0 installation, use the same command with `-Migrate`. It preserves the old release and existing Caddyfile, moves proxy/browser settings to `%ProgramData%\FutureMUD\MudClient`, and replaces only the old proxy task with a Windows Service. Version 1.2.4 also resumes a partially completed 1.2.0-1.2.3 migration and reports the original activation error even if a rollback step has its own problem.
+For an existing 1.0.1 or 1.1.0 installation, use the same command with `-Migrate`. It preserves the old release and existing Caddyfile, moves proxy/browser settings to `%ProgramData%\FutureMUD\MudClient`, and replaces only the old proxy task with a Windows Service. Version 1.2.5 stops the old proxy task and any remaining proxy process before moving its directory, resumes a partially completed 1.2.0-1.2.4 migration, restores the old task if activation fails, and reports the original activation error even if a rollback step has its own problem.
 
 After that one-time migration, an Administrator updates the client with one command:
 

--- a/MudClient/Deployment/Windows_AWS_Web_Client_Guide.md
+++ b/MudClient/Deployment/Windows_AWS_Web_Client_Guide.md
@@ -89,7 +89,7 @@ C:\MudClient\web\wwwroot\index.html
 C:\MudClient\deploy\windows\Caddyfile
 ```
 
-For an existing 1.0.1 or 1.1.0 installation, use the same command with `-Migrate`. It preserves the old release and existing Caddyfile, moves proxy/browser settings to `%ProgramData%\FutureMUD\MudClient`, and replaces only the old proxy task with a Windows Service. Version 1.2.5 stops the old proxy task and any remaining proxy process before moving its directory, resumes a partially completed 1.2.0-1.2.4 migration, restores the old task if activation fails, and reports the original activation error even if a rollback step has its own problem.
+For an existing 1.0.1 or 1.1.0 installation, use the same command with `-Migrate`. It preserves the old release and existing Caddyfile, moves proxy/browser settings to `%ProgramData%\FutureMUD\MudClient`, and replaces only the old proxy task with a correctly hosted native Windows Service. Version 1.2.5 stops the old proxy task and any remaining proxy process before moving its directory, resumes a partially completed 1.2.0-1.2.4 migration, restores the old task if activation fails, and reports the original activation error even if a rollback step has its own problem.
 
 After that one-time migration, an Administrator updates the client with one command:
 

--- a/MudClient/MudClientDeployment/MudClientDeployment.csproj
+++ b/MudClient/MudClientDeployment/MudClientDeployment.csproj
@@ -5,7 +5,7 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<Version>1.2.4</Version>
+		<Version>1.2.5</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/MudClient/MudClientTests/MudClientTests.csproj
+++ b/MudClient/MudClientTests/MudClientTests.csproj
@@ -29,6 +29,8 @@
 	<ItemGroup>
 		<None Include="..\deploy\windows\Install-MudClient.ps1" Link="DeploymentScripts\Install-MudClient.ps1" CopyToOutputDirectory="PreserveNewest" />
 		<None Include="..\deploy\windows\MudClientDeployment.Common.ps1" Link="DeploymentScripts\MudClientDeployment.Common.ps1" CopyToOutputDirectory="PreserveNewest" />
+		<None Include="..\deploy\windows\install-mudclient-proxy.ps1" Link="DeploymentScripts\install-mudclient-proxy.ps1" CopyToOutputDirectory="PreserveNewest" />
+		<None Include="..\MudWebSocketProxy\Program.cs" Link="SourceFiles\MudWebSocketProxy.Program.cs" CopyToOutputDirectory="PreserveNewest" />
 	</ItemGroup>
 
 </Project>

--- a/MudClient/MudClientTests/ProxyStartupValidationTests.cs
+++ b/MudClient/MudClientTests/ProxyStartupValidationTests.cs
@@ -1,0 +1,31 @@
+using MudWebSocketProxy;
+
+namespace MudClientTests;
+
+public class ProxyStartupValidationTests
+{
+	[Fact]
+	public void ValidateSettingsModeChecksConfigurationWithoutStartingTheProxy()
+	{
+		var settingsPath = Path.Combine(Path.GetTempPath(), $"mudclient-settings-{Guid.NewGuid():N}.json");
+		File.WriteAllText(settingsPath, """
+		{
+		  "MudServer": { "Address": "127.0.0.1", "Port": 4000 },
+		  "WebSocketServer": {
+		    "Path": "/ws",
+		    "RequireOrigin": true,
+		    "AllowedOrigins": [ "https://play.example.com" ]
+		  }
+		}
+		""");
+
+		try
+		{
+			Program.Main(["--settings", settingsPath, "--validate-settings", "true"]);
+		}
+		finally
+		{
+			File.Delete(settingsPath);
+		}
+	}
+}

--- a/MudClient/MudClientTests/WindowsInstallerRegressionTests.cs
+++ b/MudClient/MudClientTests/WindowsInstallerRegressionTests.cs
@@ -6,6 +6,10 @@ public class WindowsInstallerRegressionTests
 		Path.Combine(AppContext.BaseDirectory, "DeploymentScripts", "Install-MudClient.ps1"));
 	private static string CommonScriptPath => Path.Combine(
 		AppContext.BaseDirectory, "DeploymentScripts", "MudClientDeployment.Common.ps1");
+	private static string ProxyProgram => File.ReadAllText(
+		Path.Combine(AppContext.BaseDirectory, "SourceFiles", "MudWebSocketProxy.Program.cs"));
+	private static string ProxyServiceInstaller => File.ReadAllText(
+		Path.Combine(AppContext.BaseDirectory, "DeploymentScripts", "install-mudclient-proxy.ps1"));
 
 	[Fact]
 	public void RollbackGuardsOptionalPathsAndPreservesTheActivationError()
@@ -98,6 +102,32 @@ public class WindowsInstallerRegressionTests
 		Assert.True(stopLegacyProcess > stopLegacyTask);
 		Assert.True(moveLegacyInstallation > stopLegacyProcess);
 		Assert.Contains("if ($legacyTaskWasRunning) { Start-ScheduledTask -TaskName $legacyTaskName }", script, StringComparison.Ordinal);
+		Assert.Contains("Register-ScheduledTask -TaskName $legacyTaskName -Xml $legacyTaskXml -Force", script, StringComparison.Ordinal);
+		Assert.DoesNotContain("schtasks.exe /Create", script, StringComparison.OrdinalIgnoreCase);
+	}
+
+	[Fact]
+	public void ProxyConfiguresTheWindowsServiceLifetimeAndEventLog()
+	{
+		var program = ProxyProgram;
+
+		Assert.Contains("builder.Services.AddWindowsService", program, StringComparison.Ordinal);
+		Assert.Contains("options.ServiceName = \"MudClientProxy\"", program, StringComparison.Ordinal);
+		Assert.Contains("logging.AddEventLog", program, StringComparison.Ordinal);
+		Assert.Contains("validateSettingsOnly", program, StringComparison.Ordinal);
+		Assert.Contains("MudClient proxy settings are valid.", program, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void ServiceInstallerValidatesSettingsBeforeRegisteringTheService()
+	{
+		var script = ProxyServiceInstaller;
+		var validation = script.IndexOf("--validate-settings true", StringComparison.Ordinal);
+		var registration = script.IndexOf("New-Service", StringComparison.Ordinal);
+
+		Assert.True(validation >= 0);
+		Assert.True(registration > validation);
+		Assert.Contains("Windows Application event log", script, StringComparison.Ordinal);
 	}
 
 	[Fact]

--- a/MudClient/MudClientTests/WindowsInstallerRegressionTests.cs
+++ b/MudClient/MudClientTests/WindowsInstallerRegressionTests.cs
@@ -84,5 +84,101 @@ public class WindowsInstallerRegressionTests
 		Assert.DoesNotContain("throw \"Release $version is already staged.\"", script, StringComparison.Ordinal);
 	}
 
+	[Fact]
+	public void InstallerStopsTheLegacyProxyBeforeMovingItsDirectory()
+	{
+		var script = InstallerScript;
+		var findLegacyTask = script.IndexOf("$legacyTask = Get-ScheduledTask", StringComparison.Ordinal);
+		var stopLegacyTask = script.IndexOf("Stop-ScheduledTask -TaskName $legacyTaskName", StringComparison.Ordinal);
+		var stopLegacyProcess = script.IndexOf("Stop-MudClientLegacyProxyProcess -ProxyRoot $legacyProxy", StringComparison.Ordinal);
+		var moveLegacyInstallation = script.IndexOf("$legacyReleasePath = Move-MudClientLegacyInstallation", StringComparison.Ordinal);
+
+		Assert.True(findLegacyTask >= 0);
+		Assert.True(stopLegacyTask > findLegacyTask);
+		Assert.True(stopLegacyProcess > stopLegacyTask);
+		Assert.True(moveLegacyInstallation > stopLegacyProcess);
+		Assert.Contains("if ($legacyTaskWasRunning) { Start-ScheduledTask -TaskName $legacyTaskName }", script, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void LegacyProxyStopHelperOnlyTargetsTheLegacyProxyDirectory()
+	{
+		var script = File.ReadAllText(CommonScriptPath);
+
+		Assert.Contains("Get-Process -Name 'MudWebSocketProxy'", script, StringComparison.Ordinal);
+		Assert.Contains("[System.StringComparison]::OrdinalIgnoreCase", script, StringComparison.Ordinal);
+		Assert.Contains("$legacyProcesses | Stop-Process -Force", script, StringComparison.Ordinal);
+		Assert.Contains("The legacy MudWebSocketProxy process did not release", script, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void LegacyProxyStopHelperTerminatesOnlyAProxyUnderTheMigratedDirectory()
+	{
+		if (!OperatingSystem.IsWindows()) { return; }
+
+		var testRoot = Path.Combine(Path.GetTempPath(), $"mudclient-proxy-stop-{Guid.NewGuid():N}");
+		var legacyProxyRoot = Path.Combine(testRoot, "install", "proxy");
+		var unrelatedProxyRoot = Path.Combine(testRoot, "unrelated", "proxy");
+		Directory.CreateDirectory(legacyProxyRoot);
+		Directory.CreateDirectory(unrelatedProxyRoot);
+		var commandProcessor = Environment.GetEnvironmentVariable("ComSpec") ?? Path.Combine(Environment.SystemDirectory, "cmd.exe");
+		var legacyExecutable = Path.Combine(legacyProxyRoot, "MudWebSocketProxy.exe");
+		var unrelatedExecutable = Path.Combine(unrelatedProxyRoot, "MudWebSocketProxy.exe");
+		File.Copy(commandProcessor, legacyExecutable);
+		File.Copy(commandProcessor, unrelatedExecutable);
+		using var legacyProcess = StartWaitingProcess(legacyExecutable);
+		using var unrelatedProcess = StartWaitingProcess(unrelatedExecutable);
+
+		try
+		{
+			var command = $". '{EscapePowerShell(CommonScriptPath)}'; " +
+				$"Stop-MudClientLegacyProxyProcess -ProxyRoot '{EscapePowerShell(legacyProxyRoot)}' -TimeoutSeconds 10";
+			var startInfo = new System.Diagnostics.ProcessStartInfo("powershell.exe")
+			{
+				RedirectStandardOutput = true,
+				RedirectStandardError = true,
+				UseShellExecute = false
+			};
+			startInfo.ArgumentList.Add("-NoProfile");
+			startInfo.ArgumentList.Add("-Command");
+			startInfo.ArgumentList.Add(command);
+			using var helperProcess = System.Diagnostics.Process.Start(startInfo)!;
+			var error = helperProcess.StandardError.ReadToEnd();
+			helperProcess.WaitForExit();
+
+			Assert.True(helperProcess.ExitCode == 0, error);
+			Assert.True(legacyProcess.WaitForExit(5_000));
+			Assert.False(unrelatedProcess.HasExited);
+		}
+		finally
+		{
+			StopProcess(unrelatedProcess);
+			StopProcess(legacyProcess);
+			Directory.Delete(testRoot, recursive: true);
+		}
+	}
+
+	private static System.Diagnostics.Process StartWaitingProcess(string executable)
+	{
+		var startInfo = new System.Diagnostics.ProcessStartInfo(executable)
+		{
+			CreateNoWindow = true,
+			RedirectStandardInput = true,
+			RedirectStandardOutput = true,
+			RedirectStandardError = true,
+			UseShellExecute = false
+		};
+		startInfo.ArgumentList.Add("/d");
+		startInfo.ArgumentList.Add("/q");
+		return System.Diagnostics.Process.Start(startInfo)!;
+	}
+
+	private static void StopProcess(System.Diagnostics.Process process)
+	{
+		if (process.HasExited) { return; }
+		process.Kill(entireProcessTree: true);
+		process.WaitForExit();
+	}
+
 	private static string EscapePowerShell(string value) => value.Replace("'", "''", StringComparison.Ordinal);
 }

--- a/MudClient/MudClientTests/WindowsInstallerRegressionTests.cs
+++ b/MudClient/MudClientTests/WindowsInstallerRegressionTests.cs
@@ -17,7 +17,7 @@ public class WindowsInstallerRegressionTests
 		var script = InstallerScript;
 
 		Assert.Contains("$existingServiceInstaller = if ($previousTarget)", script, StringComparison.Ordinal);
-		Assert.Contains("if (-not [string]::IsNullOrWhiteSpace($existingServiceInstaller) -and (Test-Path -LiteralPath $existingServiceInstaller))", script, StringComparison.Ordinal);
+		Assert.Contains("if ($existingService -and -not [string]::IsNullOrWhiteSpace($existingServiceInstaller) -and (Test-Path -LiteralPath $existingServiceInstaller))", script, StringComparison.Ordinal);
 		Assert.Contains("Invoke-MudClientRollbackStep -Description 'Restoring the previous MudClientProxy service'", script, StringComparison.Ordinal);
 		Assert.Contains("throw $activationError", script, StringComparison.Ordinal);
 	}

--- a/MudClient/MudWebSocketProxy/MudWebSocketProxy.csproj
+++ b/MudClient/MudWebSocketProxy/MudWebSocketProxy.csproj
@@ -7,4 +7,8 @@
 		<Version>1.2.5</Version>
   </PropertyGroup>
 
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.10" />
+	</ItemGroup>
+
 </Project>

--- a/MudClient/MudWebSocketProxy/MudWebSocketProxy.csproj
+++ b/MudClient/MudWebSocketProxy/MudWebSocketProxy.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-		<Version>1.2.4</Version>
+		<Version>1.2.5</Version>
   </PropertyGroup>
 
 </Project>

--- a/MudClient/MudWebSocketProxy/Program.cs
+++ b/MudClient/MudWebSocketProxy/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.WebSockets;
 using Microsoft.AspNetCore.HttpOverrides;
+using System.Runtime.Versioning;
 using System.Net;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -15,10 +16,15 @@ public class Program
 	public static void Main(string[] args)
 	{
 		var settingsPath = GetSettingsPath(args);
+		var validateSettingsOnly = args.Contains("--validate-settings", StringComparer.Ordinal);
 		var builder = WebApplication.CreateBuilder(new WebApplicationOptions
 		{
 			Args = args,
 			ContentRootPath = AppContext.BaseDirectory
+		});
+		builder.Services.AddWindowsService(options =>
+		{
+			options.ServiceName = "MudClientProxy";
 		});
 
 		// Add WebSocket support
@@ -39,6 +45,11 @@ public class Program
 			.AddEnvironmentVariables()
 			.AddCommandLine(args);
 		ProxyConfigurationValidator.Validate(builder.Configuration);
+		if (validateSettingsOnly)
+		{
+			Console.WriteLine("MudClient proxy settings are valid.");
+			return;
+		}
 
 		builder.Services.AddCors(options =>
 		{
@@ -57,6 +68,10 @@ public class Program
 
 		builder.Logging.ClearProviders();
 		builder.Logging.AddConsole();
+		if (OperatingSystem.IsWindows())
+		{
+			ConfigureWindowsEventLogging(builder.Logging);
+		}
 
 		var app = builder.Build();
 		var forwardedHeadersOptions = new ForwardedHeadersOptions
@@ -114,6 +129,15 @@ public class Program
 		}));
 
 		app.Run();
+	}
+
+	[SupportedOSPlatform("windows")]
+	private static void ConfigureWindowsEventLogging(ILoggingBuilder logging)
+	{
+		logging.AddEventLog(options =>
+		{
+			options.SourceName = "MudClientProxy";
+		});
 	}
 
 	private static bool IsRequestOriginAllowed(HttpContext context, IConfiguration configuration)

--- a/MudClient/deploy/windows/Install-MudClient.ps1
+++ b/MudClient/deploy/windows/Install-MudClient.ps1
@@ -248,7 +248,7 @@ catch {
 			}
 		}
 		Invoke-MudClientRollbackStep -Description 'Restoring the previous MudClientProxy service' -Action {
-			if (-not [string]::IsNullOrWhiteSpace($existingServiceInstaller) -and (Test-Path -LiteralPath $existingServiceInstaller)) {
+			if ($existingService -and -not [string]::IsNullOrWhiteSpace($existingServiceInstaller) -and (Test-Path -LiteralPath $existingServiceInstaller)) {
 				Unblock-File -LiteralPath $existingServiceInstaller -ErrorAction SilentlyContinue
 				& $existingServiceInstaller -InstallRoot $InstallRoot
 			}

--- a/MudClient/deploy/windows/Install-MudClient.ps1
+++ b/MudClient/deploy/windows/Install-MudClient.ps1
@@ -141,6 +141,7 @@ $legacyTaskBackup = Join-Path $ConfigRoot 'legacy-proxy-task.xml'
 $serviceBackup = Join-Path $ConfigRoot 'mudclient-proxy-service.txt'
 $existingService = $null
 $legacyTask = $null
+$legacyTaskWasRunning = $false
 $persistentCaddyfile = Join-Path $InstallRoot 'deploy\windows\Caddyfile'
 $caddyFileCreated = $false
 $createCaddyTask = $false
@@ -169,6 +170,20 @@ if ($CaddyExecutable) {
 }
 try {
 New-Item -ItemType Directory -Force -Path $releaseRoot, (Join-Path $ConfigRoot 'proxy'), (Join-Path $ConfigRoot 'web') | Out-Null
+$existingService = Get-Service -Name MudClientProxy -ErrorAction SilentlyContinue
+if ($existingService) { sc.exe qc MudClientProxy | Set-Content -LiteralPath $serviceBackup -Encoding UTF8 }
+$legacyTask = Get-ScheduledTask -TaskName $legacyTaskName -ErrorAction SilentlyContinue
+if ($legacyTask) {
+	$legacyTaskWasRunning = $legacyTask.State -eq 'Running'
+	Export-ScheduledTask -TaskName $legacyTaskName | Set-Content -LiteralPath $legacyTaskBackup -Encoding UTF8
+	Stop-ScheduledTask -TaskName $legacyTaskName -ErrorAction SilentlyContinue
+	Disable-ScheduledTask -TaskName $legacyTaskName | Out-Null
+}
+if (Test-Path -LiteralPath $existingServiceInstaller) {
+	& $existingServiceInstaller -Uninstall -ErrorAction SilentlyContinue
+}
+Wait-ForMudClientServiceRemoval
+Stop-MudClientLegacyProxyProcess -ProxyRoot $legacyProxy
 $legacyReleasePath = Move-MudClientLegacyInstallation -InstallRoot $InstallRoot -ReleaseRoot $releaseRoot -Migrate:$Migrate
 if ($legacyReleasePath) {
 	if (-not $previousTarget) { $previousTarget = $legacyReleasePath }
@@ -193,18 +208,6 @@ if (-not (Test-Path -LiteralPath $proxySettings)) { Copy-Item -LiteralPath (Join
 if (-not (Test-Path -LiteralPath $webSettings)) { Copy-Item -LiteralPath (Join-Path $releasePath 'web\wwwroot\appsettings.json') -Destination $webSettings }
 Copy-Item -LiteralPath $webSettings -Destination (Join-Path $releasePath 'web\wwwroot\appsettings.json') -Force
 
-$existingService = Get-Service -Name MudClientProxy -ErrorAction SilentlyContinue
-if ($existingService) { sc.exe qc MudClientProxy | Set-Content -LiteralPath $serviceBackup -Encoding UTF8 }
-$legacyTask = Get-ScheduledTask -TaskName $legacyTaskName -ErrorAction SilentlyContinue
-if ($legacyTask) {
-	Export-ScheduledTask -TaskName $legacyTaskName | Set-Content -LiteralPath $legacyTaskBackup -Encoding UTF8
-	Stop-ScheduledTask -TaskName $legacyTaskName -ErrorAction SilentlyContinue
-	Disable-ScheduledTask -TaskName $legacyTaskName | Out-Null
-}
-if (Test-Path -LiteralPath $existingServiceInstaller) {
-	& $existingServiceInstaller -Uninstall -ErrorAction SilentlyContinue
-}
-	Wait-ForMudClientServiceRemoval
 	foreach ($link in @('current', 'web', 'proxy')) {
 		$linkPath = Join-Path $InstallRoot $link
 		Remove-MudClientPath -Path $linkPath
@@ -247,7 +250,11 @@ catch {
 		}
 	}
 	Invoke-MudClientRollbackStep -Description 'Restoring the legacy proxy scheduled task' -Action {
-		if ($legacyTask -and (Test-Path -LiteralPath $legacyTaskBackup)) { schtasks.exe /Create /TN $legacyTaskName /XML $legacyTaskBackup /F | Out-Null }
+		if ($legacyTask -and (Test-Path -LiteralPath $legacyTaskBackup)) {
+			schtasks.exe /Create /TN $legacyTaskName /XML $legacyTaskBackup /F | Out-Null
+			if ($LASTEXITCODE -ne 0) { throw "The legacy proxy scheduled task could not be restored (exit code $LASTEXITCODE)." }
+			if ($legacyTaskWasRunning) { Start-ScheduledTask -TaskName $legacyTaskName }
+		}
 	}
 	Invoke-MudClientRollbackStep -Description 'Removing the newly-created Caddy task' -Action {
 		if ($createCaddyTask) { Unregister-ScheduledTask -TaskName $CaddyTaskName -Confirm:$false -ErrorAction SilentlyContinue }

--- a/MudClient/deploy/windows/Install-MudClient.ps1
+++ b/MudClient/deploy/windows/Install-MudClient.ps1
@@ -109,6 +109,7 @@ try {
 	Invoke-WebRequest https://futuremud.com/downloads/mudclient/latest/update-manifest.sig -OutFile $signaturePath
 	& (Join-Path $packageRoot 'tools\MudClientDeployment.exe') verify --manifest $manifestPath --signature $signaturePath --archive $ArchivePath --runtime $runtime --expected-version $version
 	if ($LASTEXITCODE -ne 0) { throw 'The archive did not pass signed release verification.' }
+	Get-ChildItem -LiteralPath $packageRoot -Recurse -File | Unblock-File -ErrorAction SilentlyContinue
 }
 finally {
 	foreach ($temporaryFile in @($manifestPath, $signaturePath)) {
@@ -175,12 +176,15 @@ if ($existingService) { sc.exe qc MudClientProxy | Set-Content -LiteralPath $ser
 $legacyTask = Get-ScheduledTask -TaskName $legacyTaskName -ErrorAction SilentlyContinue
 if ($legacyTask) {
 	$legacyTaskWasRunning = $legacyTask.State -eq 'Running'
-	Export-ScheduledTask -TaskName $legacyTaskName | Set-Content -LiteralPath $legacyTaskBackup -Encoding UTF8
+	$legacyTaskXml = Export-ScheduledTask -TaskName $legacyTaskName
+	[System.IO.File]::WriteAllText($legacyTaskBackup, $legacyTaskXml, [System.Text.UTF8Encoding]::new($false))
 	Stop-ScheduledTask -TaskName $legacyTaskName -ErrorAction SilentlyContinue
 	Disable-ScheduledTask -TaskName $legacyTaskName | Out-Null
 }
-if (Test-Path -LiteralPath $existingServiceInstaller) {
-	& $existingServiceInstaller -Uninstall -ErrorAction SilentlyContinue
+if ($existingService) {
+	if ($existingService.Status -ne 'Stopped') { Stop-Service -Name MudClientProxy -Force }
+	sc.exe delete MudClientProxy | Out-Null
+	if ($LASTEXITCODE -ne 0) { throw "The existing MudClientProxy service could not be removed (exit code $LASTEXITCODE)." }
 }
 Wait-ForMudClientServiceRemoval
 Stop-MudClientLegacyProxyProcess -ProxyRoot $legacyProxy
@@ -245,14 +249,15 @@ catch {
 		}
 		Invoke-MudClientRollbackStep -Description 'Restoring the previous MudClientProxy service' -Action {
 			if (-not [string]::IsNullOrWhiteSpace($existingServiceInstaller) -and (Test-Path -LiteralPath $existingServiceInstaller)) {
+				Unblock-File -LiteralPath $existingServiceInstaller -ErrorAction SilentlyContinue
 				& $existingServiceInstaller -InstallRoot $InstallRoot
 			}
 		}
 	}
 	Invoke-MudClientRollbackStep -Description 'Restoring the legacy proxy scheduled task' -Action {
 		if ($legacyTask -and (Test-Path -LiteralPath $legacyTaskBackup)) {
-			schtasks.exe /Create /TN $legacyTaskName /XML $legacyTaskBackup /F | Out-Null
-			if ($LASTEXITCODE -ne 0) { throw "The legacy proxy scheduled task could not be restored (exit code $LASTEXITCODE)." }
+			$legacyTaskXml = Get-Content -LiteralPath $legacyTaskBackup -Raw
+			Register-ScheduledTask -TaskName $legacyTaskName -Xml $legacyTaskXml -Force | Out-Null
 			if ($legacyTaskWasRunning) { Start-ScheduledTask -TaskName $legacyTaskName }
 		}
 	}

--- a/MudClient/deploy/windows/MudClientDeployment.Common.ps1
+++ b/MudClient/deploy/windows/MudClientDeployment.Common.ps1
@@ -59,3 +59,34 @@ function Move-MudClientLegacyInstallation {
 	}
 	return $legacyPath
 }
+
+function Stop-MudClientLegacyProxyProcess {
+	param(
+		[Parameter(Mandatory = $true)][string]$ProxyRoot,
+		[int]$TimeoutSeconds = 30
+	)
+
+	$normalisedProxyRoot = [System.IO.Path]::GetFullPath($ProxyRoot).TrimEnd('\') + '\'
+	$deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+	do {
+		$legacyProcesses = @(Get-Process -Name 'MudWebSocketProxy' -ErrorAction SilentlyContinue |
+			Where-Object {
+				try {
+					$executablePath = $_.Path
+					-not [string]::IsNullOrWhiteSpace($executablePath) -and
+						[System.IO.Path]::GetFullPath($executablePath).StartsWith(
+							$normalisedProxyRoot,
+							[System.StringComparison]::OrdinalIgnoreCase)
+				}
+				catch {
+					$false
+				}
+			})
+		if ($legacyProcesses.Count -eq 0) { return }
+
+		$legacyProcesses | Stop-Process -Force -ErrorAction SilentlyContinue
+		Start-Sleep -Milliseconds 500
+	} while ((Get-Date) -lt $deadline)
+
+	throw "The legacy MudWebSocketProxy process did not release '$ProxyRoot' within $TimeoutSeconds seconds."
+}

--- a/MudClient/deploy/windows/install-mudclient-proxy.ps1
+++ b/MudClient/deploy/windows/install-mudclient-proxy.ps1
@@ -42,6 +42,14 @@ $proxyExe = Join-Path $InstallRoot "proxy\MudWebSocketProxy.exe"
 if (-not (Test-Path $proxyExe)) {
 	throw "Could not find proxy executable at '$proxyExe'. Unzip the win-x64 release package to '$InstallRoot' first."
 }
+if (-not (Test-Path -LiteralPath $SettingsPath -PathType Leaf)) {
+	throw "Could not find proxy settings at '$SettingsPath'."
+}
+
+& $proxyExe --settings $SettingsPath --validate-settings true
+if ($LASTEXITCODE -ne 0) {
+	throw "The proxy settings at '$SettingsPath' did not pass startup validation."
+}
 
 $existing = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
 if ($existing) {
@@ -61,5 +69,10 @@ New-Service `
 	-Description "Local websocket-to-telnet proxy for the Blazor MUD client." `
 	-StartupType Automatic | Out-Null
 
-Start-Service -Name $ServiceName
+try {
+	Start-Service -Name $ServiceName
+}
+catch {
+	throw "The service '$ServiceName' was installed but could not start. Review the latest MudClientProxy entry in the Windows Application event log. $($_.Exception.Message)"
+}
 Write-Host "Installed and started '$ServiceName' on http://127.0.0.1:$Port."


### PR DESCRIPTION
## Summary
- stop and back up the legacy Windows proxy scheduled task before moving the flat proxy directory
- terminate only legacy MudWebSocketProxy processes running beneath the migration source path
- host the ASP.NET Core proxy with the required .NET Windows Service lifetime
- validate proxy settings before service registration and log service failures to the Windows Application log
- restore the legacy scheduled task through native PowerShell XML registration if activation rolls back
- release MudClient 1.2.5 and document recovery from interrupted 1.2.0-1.2.4 attempts

## Validation
- MudClient tests: 125 passed
- Windows PowerShell 5.1 parser: installer, proxy-service installer, common helper, updater passed
- real-process regression: path-scoped legacy proxy stopped; unrelated same-name process retained
- packaged proxy settings validation passed
- packaged proxy console-mode health check: HTTP 200
- representative win-x64 1.2.5 archive built and inspected
- git diff --check