### PR TITLE
Version update to 1.3.0

### DIFF
--- a/MudClient/DEPLOYMENT.md
+++ b/MudClient/DEPLOYMENT.md
@@ -33,12 +33,12 @@ Linux additionally requires systemd, bash, curl, unzip, and Caddy v2 managed by 
 
 MudClient 1.2.0 is the first release with a safe upgrade layout. Its release files are immutable under `releases/<version>`; `current`, `web`, and `proxy` stay at stable paths so an upgrade does not alter Caddy, DNS, TLS, firewall, MUD, or database configuration. Operator settings are moved to `/etc/mudclient` on Linux and `%ProgramData%\FutureMUD\MudClient` on Windows.
 
-To migrate an existing 1.0.1 or 1.1.0 Linux installation, download and extract the 1.2.5 archive once, then run the installer with the original archive:
+To migrate an existing 1.0.1 or 1.1.0 Linux installation, download and extract the 1.3.0 archive once, then run the installer with the original archive:
 
 ~~~bash
-unzip mudclient-1.2.5-linux-x64.zip -d /tmp/mudclient-1.2.5
-sudo bash /tmp/mudclient-1.2.5/mudclient-1.2.5-linux-x64/deploy/linux/install-mudclient.sh \
-  --archive "$PWD/mudclient-1.2.5-linux-x64.zip" --migrate
+unzip mudclient-1.3.0-linux-x64.zip -d /tmp/mudclient-1.3.0
+sudo bash /tmp/mudclient-1.3.0/mudclient-1.3.0-linux-x64/deploy/linux/install-mudclient.sh \
+  --archive "$PWD/mudclient-1.3.0-linux-x64.zip" --migrate
 ~~~
 
 The command keeps the old release as a rollback target, copies proxy and browser settings to durable locations, and retains the existing Caddy configuration. It briefly restarts only the private proxy, so connected browser sessions disconnect and can reconnect; the MUD itself is not restarted.
@@ -51,14 +51,14 @@ sudo /opt/mudclient/current/deploy/linux/update-mudclient.sh
 
 Use `--check` to inspect the signed latest manifest without changing files, or `--rollback` to activate the previous local release. The updater verifies an Ed25519-signed manifest and archive SHA-256 before staging, preserves two prior releases, and restores the prior release if the proxy health check fails.
 
-On Windows, extract the 1.2.5 archive once and run this from an elevated PowerShell window:
+On Windows, extract the 1.3.0 archive once and run this from an elevated PowerShell window:
 
 ~~~powershell
-& 'C:\staging\mudclient-1.2.5-win-x64\deploy\windows\Install-MudClient.ps1' `
-  -ArchivePath 'C:\Users\Administrator\Downloads\mudclient-1.2.5-win-x64.zip' -Migrate
+& 'C:\staging\mudclient-1.3.0-win-x64\deploy\windows\Install-MudClient.ps1' `
+  -ArchivePath 'C:\Users\Administrator\Downloads\mudclient-1.3.0-win-x64.zip' -Migrate
 ~~~
 
-Version 1.2.5 can resume an interrupted 1.2.0-1.2.4 migration. It stops the legacy proxy scheduled task and any remaining proxy process before moving the old directories, completes a partially moved legacy `proxy`/`web` pair, reuses the preserved legacy release, and replaces an inactive staged copy before retrying. It also supplies the required .NET Windows Service lifetime for the native `MudClientProxy` service. If activation fails, the legacy task is restored to its previous running state, rollback warnings are reported separately, and the original activation error remains visible.
+Version 1.3.0 can resume an interrupted 1.2.0-1.2.4 migration. It stops the legacy proxy scheduled task and any remaining proxy process before moving the old directories, completes a partially moved legacy `proxy`/`web` pair, reuses the preserved legacy release, and replaces an inactive staged copy before retrying. It also supplies the required .NET Windows Service lifetime for the native `MudClientProxy` service. If activation fails, the legacy task is restored to its previous running state, rollback warnings are reported separately, and the original activation error remains visible.
 
 If a failed earlier migration left stale `current`, `web`, or `proxy` links, stop the proxy and remove only those reparse points before retrying. This does not remove ordinary configuration directories:
 
@@ -87,16 +87,16 @@ Later Windows updates use:
 After verifying the website's published SHA-256 checksum, extract the downloaded package to `/opt/mudclient` and run the installer from that directory:
 
 ~~~bash
-unzip mudclient-1.2.5-linux-x64.zip -d /tmp/mudclient-package
-sudo bash /tmp/mudclient-package/mudclient-1.2.5-linux-x64/deploy/linux/install-mudclient.sh \
-  --archive "$PWD/mudclient-1.2.5-linux-x64.zip" --domain play.example.com
+unzip mudclient-1.3.0-linux-x64.zip -d /tmp/mudclient-package
+sudo bash /tmp/mudclient-package/mudclient-1.3.0-linux-x64/deploy/linux/install-mudclient.sh \
+  --archive "$PWD/mudclient-1.3.0-linux-x64.zip" --domain play.example.com
 ~~~
 
 The script creates the unprivileged proxy service, writes the exact trusted public origin, adds an isolated Caddy site fragment, validates Caddy before reload, and checks the private health endpoint. The selected domain must already resolve to the host. To connect to a MUD on a private network rather than the same machine:
 
 ~~~bash
-sudo bash /tmp/mudclient-package/mudclient-1.2.5-linux-x64/deploy/linux/install-mudclient.sh \
-  --archive "$PWD/mudclient-1.2.5-linux-x64.zip" --domain play.example.com --mud-host 10.0.0.20 --mud-port 4000
+sudo bash /tmp/mudclient-package/mudclient-1.3.0-linux-x64/deploy/linux/install-mudclient.sh \
+  --archive "$PWD/mudclient-1.3.0-linux-x64.zip" --domain play.example.com --mud-host 10.0.0.20 --mud-port 4000
 ~~~
 
 Use `CADDY_CONFIG` and `CADDY_FRAGMENTS_DIR` for nonstandard Caddyfile locations. The installer saves `.before-mudclient-install` backups of the files it changes; review those and take a normal deployment backup before upgrading an existing installation.
@@ -112,7 +112,7 @@ dotnet workload install wasm-tools
 ```
 
 ```powershell
-.\scripts\Publish-ProductPackage.ps1 -RuntimeIdentifier win-x64 -Version 1.2.5
+.\scripts\Publish-ProductPackage.ps1 -RuntimeIdentifier win-x64 -Version 1.3.0
 ```
 
 ```bash
@@ -167,6 +167,47 @@ The Blazor client defaults to:
 ```
 
 That is the easiest production setup because the browser automatically turns it into `wss://your-site/ws` when the page is served over HTTPS.
+
+### Custom title, icon, and styling
+
+Each deployment can brand the browser client without rebuilding it. Before the first install, edit `web/wwwroot/appsettings.json` in the extracted package:
+
+```json
+{
+  "ClientBranding": {
+    "Title": "Example MUD",
+    "IconUrl": "custom/example-icon.png",
+    "AboutText": "The official browser client for Example MUD."
+  },
+  "WebSocketServer": {
+    "Endpoint": "/ws"
+  }
+}
+```
+
+`Title` is used for the browser tab and About panel. `IconUrl` must be a local relative path; it is used for the browser icon and in the About panel. `AboutText` is plain text. Do not put passwords, tokens, private hostnames, or other secrets in this public browser configuration.
+
+Put the icon and any other branding images in `web/wwwroot/custom/`. Edit `web/wwwroot/custom/custom.css` to override the standard theme; that stylesheet loads after the normal client CSS. Images beside the stylesheet can be referenced with relative URLs such as `url("background.jpg")`. The included file has a commented background/theme example.
+
+The installers preserve these files across upgrades in:
+
+- Linux: `/etc/mudclient/web/appsettings.json` and `/etc/mudclient/web/custom/`
+- Windows: `%ProgramData%\FutureMUD\MudClient\web\appsettings.json` and `%ProgramData%\FutureMUD\MudClient\web\custom\`
+
+For an already active installation, edit the durable copies and then copy them into the active web root so the change takes effect immediately. Future upgrades will continue to start from the durable copies:
+
+```bash
+sudo cp -p /etc/mudclient/web/appsettings.json /opt/mudclient/web/wwwroot/appsettings.json
+sudo cp -a /etc/mudclient/web/custom/. /opt/mudclient/web/wwwroot/custom/
+```
+
+```powershell
+$config = "$env:ProgramData\FutureMUD\MudClient\web"
+Copy-Item -LiteralPath "$config\appsettings.json" -Destination 'C:\MudClient\web\wwwroot\appsettings.json' -Force
+Get-ChildItem -LiteralPath "$config\custom" -Force | Copy-Item -Destination 'C:\MudClient\web\wwwroot\custom' -Recurse -Force
+```
+
+Reload the browser client after changing the configuration or CSS. Use a hard refresh if the old icon or stylesheet is still cached.
 
 The supplied Caddy and Nginx examples restrict framing and browser capabilities, set a no-referrer policy, prevent content-type sniffing, and use a Content Security Policy compatible with Blazor WebAssembly and FutureMUD ANSI/MXP output. Preserve those headers when integrating the client into an existing site. The proxy should remain bound to loopback so only the trusted local reverse proxy can supply forwarded client addresses.
 

--- a/MudClient/Deployment/Windows_AWS_Web_Client_Guide.md
+++ b/MudClient/Deployment/Windows_AWS_Web_Client_Guide.md
@@ -1,6 +1,6 @@
 # Windows and AWS Web Client Setup Guide
 
-This is a deliberately plain-English guide for installing FutureMUD Web MUD Client 1.2.5 on a Windows server hosted in AWS. It adds a small HTTPS website alongside an existing FutureMUD game, without changing the game itself or any other applications on the server.
+This is a deliberately plain-English guide for installing FutureMUD Web MUD Client 1.3.0 on a Windows server hosted in AWS. It adds a small HTTPS website alongside an existing FutureMUD game, without changing the game itself or any other applications on the server.
 
 The names and addresses below are examples. Before using a command, replace `play.example.com` with your own player-facing hostname. Do not put a live server's IP address, AWS instance ID, administrator account name, or credentials in a public guide or repository.
 
@@ -64,7 +64,7 @@ Name them clearly, for example `Web MUD Client HTTP` and `Web MUD Client HTTPS`.
 Open an **Administrator PowerShell** window on the Windows server and run the following. It creates a new, dedicated folder and does not overwrite the game installation.
 
 ```powershell
-$version = '1.2.5'
+$version = '1.3.0'
 $archive = "$env:USERPROFILE\Downloads\mudclient-$version-win-x64.zip"
 $staging = "C:\MudClient-$version"
 
@@ -89,7 +89,7 @@ C:\MudClient\web\wwwroot\index.html
 C:\MudClient\deploy\windows\Caddyfile
 ```
 
-For an existing 1.0.1 or 1.1.0 installation, use the same command with `-Migrate`. It preserves the old release and existing Caddyfile, moves proxy/browser settings to `%ProgramData%\FutureMUD\MudClient`, and replaces only the old proxy task with a correctly hosted native Windows Service. Version 1.2.5 stops the old proxy task and any remaining proxy process before moving its directory, resumes a partially completed 1.2.0-1.2.4 migration, restores the old task if activation fails, and reports the original activation error even if a rollback step has its own problem.
+For an existing 1.0.1 or 1.1.0 installation, use the same command with `-Migrate`. It preserves the old release and existing Caddyfile, moves proxy/browser settings to `%ProgramData%\FutureMUD\MudClient`, and replaces only the old proxy task with a correctly hosted native Windows Service. Version 1.3.0 stops the old proxy task and any remaining proxy process before moving its directory, resumes a partially completed 1.2.0-1.2.4 migration, restores the old task if activation fails, and reports the original activation error even if a rollback step has its own problem.
 
 After that one-time migration, an Administrator updates the client with one command:
 

--- a/MudClient/MudClientBlazor/MudClientBlazor.csproj
+++ b/MudClient/MudClientBlazor/MudClientBlazor.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <Version>1.3.0</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/MudClient/MudClientBlazor/Pages/Index.razor
+++ b/MudClient/MudClientBlazor/Pages/Index.razor
@@ -9,10 +9,15 @@
 @inject ILogger<Index> Logger
 @inject IConfiguration Configuration
 
+<PageTitle>@Branding.Title</PageTitle>
+<HeadContent>
+	<link rel="icon" type="image/png" href="@Branding.IconUrl" />
+</HeadContent>
+
 <div class="app-root" style="@GetClientStyle()">
 	<div class="app-grid">
 		<div class="play-surface">
-			<div class="message-container" @ref="MessageContainer" tabindex="0" role="region" aria-label="MUD output">
+			<div class="@GetMessageContainerClass()" @ref="MessageContainer" tabindex="0" role="region" aria-label="MUD output">
 				@foreach (var message in _transcript.RenderedEntries)
 				{
 					<div @key="message.Id">@(new MarkupString(message.Html))</div>
@@ -148,6 +153,14 @@
 							<span>Wrap width (px)</span>
 							<input class="settings-input" type="number" min="0" max="3000" step="10" value="@ClientSettingsDraft.MessageWrapWidthPx" @oninput="args => UpdateMessageWrapWidth(args.Value?.ToString())" aria-label="Manual message wrap width in pixels" />
 							<small>0 uses the available width.</small>
+						</label>
+						<label>
+							<span>Wide text</span>
+							<select class="settings-input" value="@ClientSettingsDraft.OutputWidthBehavior.ToString()" @onchange="args => UpdateOutputWidthBehavior(args.Value?.ToString())" aria-label="Wide text behavior">
+								<option value="Wrap">Wrap to window</option>
+								<option value="HorizontalScroll">Scroll horizontally</option>
+							</select>
+							<small>Horizontal scrolling preserves MUD-formatted line widths on narrow screens.</small>
 						</label>
 						<label>
 							<span>Left offset (px)</span>
@@ -312,6 +325,22 @@
 			</section>
 		}
 		
+		@if (_aboutOpen)
+		{
+			<section class="about-panel" role="region" aria-labelledby="about-title">
+				<img class="about-icon" src="@Branding.IconUrl" alt="" />
+				<div class="about-copy">
+					<h2 id="about-title">@Branding.Title</h2>
+					<p>@Branding.AboutText</p>
+					<dl class="about-details">
+						<div><dt>Client</dt><dd>@ProductInformation.Name</dd></div>
+						<div><dt>Version</dt><dd>@ProductInformation.Version</dd></div>
+					</dl>
+				</div>
+				<button type="button" class="client-button secondary-button about-close" @onclick="ToggleAbout">Close</button>
+			</section>
+		}
+
 		<div class="status-footer">
 			<div class="connection-status" aria-live="polite">
 				<span class="connection-dot @(isConnected ? "is-connected" : "is-disconnected")" aria-hidden="true"></span>
@@ -327,6 +356,7 @@
 				<button type="button" class="client-button primary-button" @onclick="ToggleConnection">@connectionButtonText</button>
 				<button type="button" class="client-button secondary-button" @onclick="SaveLog">Save Log</button>
 				<button type="button" class="client-button secondary-button" @onclick="ToggleHotkeySettings">Settings</button>
+				<button type="button" class="client-button secondary-button" title="@AboutButtonTitle" aria-expanded="@_aboutOpen" @onclick="ToggleAbout">About</button>
 			</div>
 		</div>
 	</div>
@@ -405,6 +435,7 @@
 		};
 
 	private string UserInput { get; set; } = string.Empty;
+	private string _commandHistoryDraft = string.Empty;
 	private readonly ClientTranscript _transcript = new();
 	private ClientWebSocket? _clientWebSocket;
 	private CancellationTokenSource _cancellationTokenSource = new();
@@ -426,10 +457,13 @@
 	private QuickAliasSettings QuickAliasDraft { get; set; } = QuickAliasSettings.CreateDefault();
 	private ClientSettings CurrentClientSettings { get; set; } = ClientSettings.CreateDefault();
 	private ClientSettings ClientSettingsDraft { get; set; } = ClientSettings.CreateDefault();
+	private ClientBrandingOptions Branding { get; set; } = new();
+	private static ClientProductInformation ProductInformation => ClientProductInformation.Current;
 	private IReadOnlyList<string> HotkeyDraftErrors { get; set; } = [];
 	private IReadOnlyList<string> ClientSettingsDraftErrors { get; set; } = [];
 	private string? HotkeySettingsError { get; set; }
 	private bool _hotkeySettingsOpen;
+	private bool _aboutOpen;
 	private bool _isSendingBatch;
 	private string _batchProgressText = string.Empty;
 
@@ -445,6 +479,8 @@
 
 	protected override async Task OnInitializedAsync()
 	{
+		Branding = ClientBrandingOptions.FromConfiguration(Configuration);
+
 		// Create the object reference
 		_objectReference = DotNetObjectReference.Create(this);
 
@@ -494,6 +530,14 @@
 		 !string.IsNullOrEmpty(CurrentQuickAliasSettings.Login.Password));
 
 	private bool CanSaveHotkeySettings => HotkeyDraftErrors.Count == 0 && ClientSettingsDraftErrors.Count == 0;
+	private string AboutButtonTitle => $"About {ProductInformation.Name} {ProductInformation.Version}";
+
+	private string GetMessageContainerClass()
+	{
+		return CurrentClientSettings.OutputWidthBehavior == OutputWidthBehavior.HorizontalScroll
+			? "message-container output-scroll-horizontal"
+			: "message-container output-wrap";
+	}
 
 	private string GetClientStyle()
 	{
@@ -709,6 +753,16 @@
 		if (int.TryParse(value, out var parsed))
 		{
 			ClientSettingsDraft.MessageWrapWidthPx = parsed;
+		}
+
+		ValidateClientSettingsDraft();
+	}
+
+	private void UpdateOutputWidthBehavior(string? value)
+	{
+		if (Enum.TryParse<OutputWidthBehavior>(value, out var behavior))
+		{
+			ClientSettingsDraft.OutputWidthBehavior = behavior;
 		}
 
 		ValidateClientSettingsDraft();
@@ -1590,11 +1644,12 @@
 			}
 
 			CommandHistoryIndex = CommandHistory.Count;
+			_commandHistoryDraft = UserInput;
 		}
 	}
 
 	[JSInvokable]
-	public async Task NavigateCommandHistory(string direction, bool jumpToBoundary)
+	public async Task NavigateCommandHistory(string direction, bool jumpToBoundary, string currentInput)
 	{
 		var historyDirection = direction.ToLowerInvariant() switch
 		{
@@ -1608,11 +1663,18 @@
 			return;
 		}
 
+		UserInput = currentInput;
+		if (historyDirection == CommandHistoryDirection.Up && CommandHistoryIndex >= CommandHistory.Count)
+		{
+			_commandHistoryDraft = currentInput;
+		}
+
 		var navigation = CommandHistoryNavigator.Navigate(
 			CommandHistory,
 			CommandHistoryIndex,
 			historyDirection.Value,
-			jumpToBoundary);
+			jumpToBoundary,
+			_commandHistoryDraft);
 		if (!navigation.HasChanged)
 		{
 			return;
@@ -1622,6 +1684,11 @@
 		UserInput = navigation.Input!;
 		await InvokeAsync(StateHasChanged);
 		await JSRuntime.InvokeVoidAsync("setSelectionRange", "userInput", UserInput.Length);
+	}
+
+	private void ToggleAbout()
+	{
+		_aboutOpen = !_aboutOpen;
 	}
 
 	private async Task LoadTextFileAsync(InputFileChangeEventArgs args)

--- a/MudClient/MudClientBlazor/Services/ClientBrandingOptions.cs
+++ b/MudClient/MudClientBlazor/Services/ClientBrandingOptions.cs
@@ -1,0 +1,74 @@
+using Microsoft.Extensions.Configuration;
+
+namespace MudClientBlazor.Services;
+
+public sealed class ClientBrandingOptions
+{
+	public const string DefaultTitle = "FutureMUD Web Client";
+	public const string DefaultIconUrl = "icon-192.png";
+	public const string DefaultAboutText = "A browser-based ANSI, Telnet, and MXP client for FutureMUD.";
+
+	public string Title { get; set; } = DefaultTitle;
+	public string IconUrl { get; set; } = DefaultIconUrl;
+	public string AboutText { get; set; } = DefaultAboutText;
+
+	public static ClientBrandingOptions FromConfiguration(IConfiguration configuration)
+	{
+		ArgumentNullException.ThrowIfNull(configuration);
+
+		return Normalize(new ClientBrandingOptions
+		{
+			Title = configuration["ClientBranding:Title"] ?? DefaultTitle,
+			IconUrl = configuration["ClientBranding:IconUrl"] ?? DefaultIconUrl,
+			AboutText = configuration["ClientBranding:AboutText"] ?? DefaultAboutText
+		});
+	}
+
+	public static ClientBrandingOptions Normalize(ClientBrandingOptions? options)
+	{
+		var defaults = new ClientBrandingOptions();
+		if (options == null)
+		{
+			return defaults;
+		}
+
+		return new ClientBrandingOptions
+		{
+			Title = NormalizeText(options.Title, defaults.Title, 100),
+			IconUrl = IsSafeRelativeAssetUrl(options.IconUrl) ? options.IconUrl.Trim() : defaults.IconUrl,
+			AboutText = NormalizeText(options.AboutText, defaults.AboutText, 500)
+		};
+	}
+
+	private static string NormalizeText(string? text, string fallback, int maximumLength)
+	{
+		var normalized = text?.Trim();
+		if (string.IsNullOrWhiteSpace(normalized))
+		{
+			return fallback;
+		}
+
+		return normalized.Length <= maximumLength ? normalized : normalized[..maximumLength];
+	}
+
+	private static bool IsSafeRelativeAssetUrl(string? url)
+	{
+		if (string.IsNullOrWhiteSpace(url))
+		{
+			return false;
+		}
+
+		var normalized = url.Trim();
+		if (normalized.StartsWith("//", StringComparison.Ordinal) ||
+		    normalized.Contains('\\') ||
+		    normalized.Any(char.IsControl) ||
+		    !Uri.TryCreate(normalized, UriKind.Relative, out _))
+		{
+			return false;
+		}
+
+		var path = normalized.Split(['?', '#'], 2)[0];
+		return !path.Split('/', StringSplitOptions.RemoveEmptyEntries)
+			.Any(segment => segment is "." or "..");
+	}
+}

--- a/MudClient/MudClientBlazor/Services/ClientProductInformation.cs
+++ b/MudClient/MudClientBlazor/Services/ClientProductInformation.cs
@@ -1,0 +1,26 @@
+using System.Reflection;
+
+namespace MudClientBlazor.Services;
+
+public sealed record ClientProductInformation(string Name, string Version)
+{
+	public const string ProductName = "FutureMUD Web Client";
+
+	public static ClientProductInformation Current { get; } = FromAssembly(typeof(ClientProductInformation).Assembly);
+
+	public static ClientProductInformation FromAssembly(Assembly assembly)
+	{
+		ArgumentNullException.ThrowIfNull(assembly);
+
+		var informationalVersion = assembly
+			.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+			.InformationalVersion;
+		var version = informationalVersion?.Split('+', 2)[0];
+		if (string.IsNullOrWhiteSpace(version))
+		{
+			version = assembly.GetName().Version?.ToString(3) ?? "unknown";
+		}
+
+		return new ClientProductInformation(ProductName, version);
+	}
+}

--- a/MudClient/MudClientBlazor/Services/ClientSettings.cs
+++ b/MudClient/MudClientBlazor/Services/ClientSettings.cs
@@ -1,8 +1,14 @@
 namespace MudClientBlazor.Services;
 
+public enum OutputWidthBehavior
+{
+	Wrap,
+	HorizontalScroll
+}
+
 public sealed class ClientSettings
 {
-	public const int CurrentVersion = 1;
+	public const int CurrentVersion = 2;
 	public const string DefaultFontFamily = "Consolas, \"Cascadia Mono\", \"Courier New\", monospace";
 
 	private static readonly IReadOnlyList<ClientFontOption> AvailableFonts =
@@ -22,6 +28,7 @@ public sealed class ClientSettings
 	public int MessageLeftOffsetPx { get; set; }
 	public double MessageLineHeight { get; set; } = 1.48;
 	public int MessageSpacingPx { get; set; } = 6;
+	public OutputWidthBehavior OutputWidthBehavior { get; set; } = OutputWidthBehavior.Wrap;
 	public bool ClearInputAfterSend { get; set; } = true;
 	public bool SemicolonCommandStackingEnabled { get; set; } = true;
 	public string CommandStackingDelimiter { get; set; } = ";";
@@ -42,6 +49,7 @@ public sealed class ClientSettings
 			MessageLeftOffsetPx = MessageLeftOffsetPx,
 			MessageLineHeight = MessageLineHeight,
 			MessageSpacingPx = MessageSpacingPx,
+			OutputWidthBehavior = OutputWidthBehavior,
 			ClearInputAfterSend = ClearInputAfterSend,
 			SemicolonCommandStackingEnabled = SemicolonCommandStackingEnabled,
 			CommandStackingDelimiter = CommandStackingDelimiter,
@@ -71,6 +79,9 @@ public sealed class ClientSettings
 		normalized.MessageLeftOffsetPx = Math.Clamp(settings.MessageLeftOffsetPx, 0, 500);
 		normalized.MessageLineHeight = Math.Clamp(settings.MessageLineHeight, 1.0, 3.0);
 		normalized.MessageSpacingPx = Math.Clamp(settings.MessageSpacingPx, 0, 100);
+		normalized.OutputWidthBehavior = Enum.IsDefined(settings.OutputWidthBehavior)
+			? settings.OutputWidthBehavior
+			: defaults.OutputWidthBehavior;
 		normalized.CommandStackingDelimiter = NormalizeDelimiter(settings.CommandStackingDelimiter, defaults.CommandStackingDelimiter);
 		normalized.StackedCommandDelayMs = Math.Clamp(settings.StackedCommandDelayMs, 50, 2_000);
 		return normalized;

--- a/MudClient/MudClientBlazor/Services/CommandHistoryNavigator.cs
+++ b/MudClient/MudClientBlazor/Services/CommandHistoryNavigator.cs
@@ -17,7 +17,8 @@ public static class CommandHistoryNavigator
 		IReadOnlyList<string> commandHistory,
 		int currentIndex,
 		CommandHistoryDirection direction,
-		bool jumpToBoundary)
+		bool jumpToBoundary,
+		string draftInput = "")
 	{
 		ArgumentNullException.ThrowIfNull(commandHistory);
 
@@ -32,7 +33,7 @@ public static class CommandHistoryNavigator
 		return direction switch
 		{
 			CommandHistoryDirection.Up => NavigateUp(commandHistory, index, jumpToBoundary),
-			CommandHistoryDirection.Down => NavigateDown(commandHistory, index, jumpToBoundary),
+			CommandHistoryDirection.Down => NavigateDown(commandHistory, index, jumpToBoundary, draftInput),
 			_ => throw new ArgumentOutOfRangeException(nameof(direction), direction, null)
 		};
 	}
@@ -54,7 +55,8 @@ public static class CommandHistoryNavigator
 	private static CommandHistoryNavigation NavigateDown(
 		IReadOnlyList<string> commandHistory,
 		int currentIndex,
-		bool jumpToBoundary)
+		bool jumpToBoundary,
+		string draftInput)
 	{
 		if (currentIndex >= commandHistory.Count)
 		{
@@ -63,7 +65,7 @@ public static class CommandHistoryNavigator
 
 		var nextIndex = jumpToBoundary ? commandHistory.Count - 1 : currentIndex + 1;
 		return nextIndex == commandHistory.Count
-			? new CommandHistoryNavigation(nextIndex, string.Empty)
+			? new CommandHistoryNavigation(nextIndex, draftInput)
 			: new CommandHistoryNavigation(nextIndex, commandHistory[nextIndex]);
 	}
 }

--- a/MudClient/MudClientBlazor/wwwroot/appsettings.json
+++ b/MudClient/MudClientBlazor/wwwroot/appsettings.json
@@ -1,4 +1,9 @@
 {
+	"ClientBranding": {
+		"Title": "FutureMUD Web Client",
+		"IconUrl": "icon-192.png",
+		"AboutText": "A browser-based ANSI, Telnet, and MXP client for FutureMUD."
+	},
 	"WebSocketServer": {
 		"Endpoint": "/ws"
 	}

--- a/MudClient/MudClientBlazor/wwwroot/css/mudclient.css
+++ b/MudClient/MudClientBlazor/wwwroot/css/mudclient.css
@@ -100,10 +100,20 @@ textarea {
 	font-family: var(--client-font-family, Consolas, "Cascadia Mono", "Courier New", monospace);
 	font-size: var(--client-font-size, clamp(0.78rem, 0.72rem + 0.18vw, 0.95rem));
 	line-height: var(--client-message-line-height, 1.48);
-	white-space: pre-wrap;
-	overflow-wrap: anywhere;
 	scrollbar-color: var(--border-strong) transparent;
 	scrollbar-width: thin;
+}
+
+.message-container.output-wrap {
+	overflow-x: hidden;
+	white-space: pre-wrap;
+	overflow-wrap: anywhere;
+}
+
+.message-container.output-scroll-horizontal {
+	overflow-x: auto;
+	white-space: pre;
+	overflow-wrap: normal;
 }
 
 .message-container > div + div {
@@ -114,6 +124,12 @@ textarea {
 	max-width: var(--client-message-wrap-width, none);
 	content-visibility: auto;
 	contain-intrinsic-size: auto 1.5em;
+}
+
+.message-container.output-scroll-horizontal > div {
+	width: max-content;
+	min-width: 100%;
+	max-width: none;
 }
 
 .message-container:focus-visible {
@@ -701,6 +717,61 @@ textarea {
 		inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
+.about-panel {
+	display: grid;
+	grid-template-columns: auto minmax(0, 1fr) auto;
+	align-items: center;
+	gap: 0.85rem;
+	padding: clamp(0.65rem, 1.1vw, 0.9rem);
+	border-bottom: 1px solid var(--border-subtle);
+	background: #1b1f23;
+}
+
+.about-icon {
+	width: 3rem;
+	height: 3rem;
+	object-fit: contain;
+	border-radius: var(--radius);
+}
+
+.about-copy h2,
+.about-copy p,
+.about-details {
+	margin: 0;
+}
+
+.about-copy h2 {
+	font-size: 1rem;
+}
+
+.about-copy p {
+	margin-top: 0.2rem;
+	color: var(--text-muted);
+	font-size: 0.84rem;
+}
+
+.about-details {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.3rem 1rem;
+	margin-top: 0.45rem;
+	font-size: 0.78rem;
+}
+
+.about-details > div {
+	display: flex;
+	gap: 0.35rem;
+}
+
+.about-details dt {
+	color: var(--text-muted);
+}
+
+.about-details dd {
+	margin: 0;
+	font-family: var(--client-font-family, Consolas, "Cascadia Mono", "Courier New", monospace);
+}
+
 .status-footer {
 	display: flex;
 	align-items: center;
@@ -928,6 +999,7 @@ a:hover {
 
 	.input-container,
 	.settings-panel,
+	.about-panel,
 	.status-footer {
 		padding: 0.6rem;
 	}
@@ -953,6 +1025,15 @@ a:hover {
 
 	.settings-panel-header {
 		flex-direction: column;
+	}
+
+	.about-panel {
+		grid-template-columns: auto minmax(0, 1fr);
+	}
+
+	.about-close {
+		grid-column: 1 / -1;
+		width: 100%;
 	}
 
 	.client-settings-grid {

--- a/MudClient/MudClientBlazor/wwwroot/custom/custom.css
+++ b/MudClient/MudClientBlazor/wwwroot/custom/custom.css
@@ -1,0 +1,15 @@
+/*
+ * Per-deployment styles load after the standard MudClient theme.
+ * Operators can edit this durable file and place referenced images beside it.
+ *
+ * Example:
+ * :root {
+ *     --page-bg: #101820;
+ *     --accent: #d9a441;
+ * }
+ *
+ * .app-root {
+ *     background: linear-gradient(rgba(0, 0, 0, 0.55), rgba(0, 0, 0, 0.55)),
+ *         url("background.jpg") center / cover fixed;
+ * }
+ */

--- a/MudClient/MudClientBlazor/wwwroot/index.html
+++ b/MudClient/MudClientBlazor/wwwroot/index.html
@@ -9,6 +9,7 @@
 	<link rel="icon" type="image/png" href="icon-192.png" />
 	<link rel="stylesheet" href="css/app.css" />
 	<link href="css/mudclient.css" rel="stylesheet" />
+	<link href="custom/custom.css" rel="stylesheet" />
 	<!-- If you add any scoped CSS files, uncomment the following to load them
 	<link href="MudClientBlazor.styles.css" rel="stylesheet" /> -->
 

--- a/MudClient/MudClientBlazor/wwwroot/js/mudclient.js
+++ b/MudClient/MudClientBlazor/wwwroot/js/mudclient.js
@@ -103,20 +103,27 @@
 		let handler = null;
 		let dotNetHelper = null;
 
-		function requestHistoryNavigation(event, direction) {
-			const selectionStart = element.selectionStart;
-			const selectionEnd = element.selectionEnd;
-			const jumpToBoundary = event.ctrlKey;
-			window.requestAnimationFrame(function () {
-				if (!element ||
-					element.selectionStart !== selectionStart ||
-					element.selectionEnd !== selectionEnd ||
-					!dotNetHelper) {
-					return;
-				}
+		function isAtHistoryBoundary(direction) {
+			if (!element || element.selectionStart !== element.selectionEnd) {
+				return false;
+			}
 
-				dotNetHelper.invokeMethodAsync('NavigateCommandHistory', direction, jumpToBoundary);
-			});
+			const input = element.value || '';
+			if (direction === 'up') {
+				return input.lastIndexOf('\n', element.selectionStart - 1) === -1;
+			}
+
+			return input.indexOf('\n', element.selectionEnd) === -1;
+		}
+
+		function requestHistoryNavigation(event, direction) {
+			if (!isAtHistoryBoundary(direction) || !dotNetHelper) {
+				return;
+			}
+
+			event.preventDefault();
+			const jumpToBoundary = event.ctrlKey;
+			dotNetHelper.invokeMethodAsync('NavigateCommandHistory', direction, jumpToBoundary, element.value || '');
 		}
 
 		return {
@@ -158,15 +165,39 @@
 		let mutationObserver = null;
 		let scrollHandler = null;
 		let keydownHandler = null;
+		let interactionHandler = null;
+		let contentLoadHandler = null;
 		let isPinnedToBottom = true;
 		let scrollFrame = null;
+		let observedScrollHeight = 0;
+		let hasUserScrollIntent = false;
+
+		function isAtBottom() {
+			return !!element && element.scrollTop + element.clientHeight >= element.scrollHeight - 4;
+		}
 
 		function updatePinnedState() {
 			if (!element) {
 				return;
 			}
 
-			isPinnedToBottom = element.scrollTop + element.clientHeight >= element.scrollHeight - 2;
+			const currentScrollHeight = element.scrollHeight;
+			if (!hasUserScrollIntent && isPinnedToBottom && currentScrollHeight !== observedScrollHeight) {
+				scheduleScrollToBottom();
+				return;
+			}
+
+			isPinnedToBottom = isAtBottom();
+			observedScrollHeight = currentScrollHeight;
+			hasUserScrollIntent = false;
+		}
+
+		function noteUserScrollIntent() {
+			hasUserScrollIntent = true;
+			if (scrollFrame !== null) {
+				window.cancelAnimationFrame(scrollFrame);
+				scrollFrame = null;
+			}
 		}
 
 		function scrollToBottom() {
@@ -176,6 +207,8 @@
 
 			element.scrollTop = element.scrollHeight;
 			isPinnedToBottom = true;
+			observedScrollHeight = element.scrollHeight;
+			hasUserScrollIntent = false;
 		}
 
 		function scheduleScrollToBottom() {
@@ -196,6 +229,7 @@
 				return;
 			}
 
+			noteUserScrollIntent();
 			element.scrollTop += amount;
 			updatePinnedState();
 		}
@@ -208,6 +242,7 @@
 			switch (event.key) {
 				case 'Home':
 					event.preventDefault();
+					noteUserScrollIntent();
 					element.scrollTop = 0;
 					updatePinnedState();
 					break;
@@ -246,8 +281,14 @@
 				scrollToBottom();
 				scrollHandler = updatePinnedState;
 				keydownHandler = handleKeydown;
+				interactionHandler = noteUserScrollIntent;
+				contentLoadHandler = scheduleScrollToBottom;
 				element.addEventListener('scroll', scrollHandler, { passive: true });
 				element.addEventListener('keydown', keydownHandler);
+				element.addEventListener('wheel', interactionHandler, { passive: true });
+				element.addEventListener('touchstart', interactionHandler, { passive: true });
+				element.addEventListener('pointerdown', interactionHandler, { passive: true });
+				element.addEventListener('load', contentLoadHandler, true);
 				mutationObserver = new MutationObserver(scheduleScrollToBottom);
 				mutationObserver.observe(element, { childList: true, subtree: true });
 			},
@@ -258,6 +299,16 @@
 
 				if (element && keydownHandler) {
 					element.removeEventListener('keydown', keydownHandler);
+				}
+
+				if (element && interactionHandler) {
+					element.removeEventListener('wheel', interactionHandler);
+					element.removeEventListener('touchstart', interactionHandler);
+					element.removeEventListener('pointerdown', interactionHandler);
+				}
+
+				if (element && contentLoadHandler) {
+					element.removeEventListener('load', contentLoadHandler, true);
 				}
 
 				if (mutationObserver) {
@@ -272,8 +323,12 @@
 				mutationObserver = null;
 				scrollHandler = null;
 				keydownHandler = null;
+				interactionHandler = null;
+				contentLoadHandler = null;
 				isPinnedToBottom = true;
 				scrollFrame = null;
+				observedScrollHeight = 0;
+				hasUserScrollIntent = false;
 			}
 		};
 	})();

--- a/MudClient/MudClientDeployment/MudClientDeployment.csproj
+++ b/MudClient/MudClientDeployment/MudClientDeployment.csproj
@@ -5,7 +5,7 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<Version>1.2.5</Version>
+		<Version>1.3.0</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/MudClient/MudClientTests/ClientBrandingOptionsTests.cs
+++ b/MudClient/MudClientTests/ClientBrandingOptionsTests.cs
@@ -1,0 +1,42 @@
+using MudClientBlazor.Services;
+
+namespace MudClientTests;
+
+public class ClientBrandingOptionsTests
+{
+	[Fact]
+	public void Normalize_PreservesSafeDeploymentBranding()
+	{
+		var branding = ClientBrandingOptions.Normalize(new ClientBrandingOptions
+		{
+			Title = "  Example MUD  ",
+			IconUrl = "custom/example-icon.png",
+			AboutText = "  The official Example MUD client.  "
+		});
+
+		Assert.Equal("Example MUD", branding.Title);
+		Assert.Equal("custom/example-icon.png", branding.IconUrl);
+		Assert.Equal("The official Example MUD client.", branding.AboutText);
+	}
+
+	[Theory]
+	[InlineData("https://example.com/icon.png")]
+	[InlineData("//example.com/icon.png")]
+	[InlineData("../icon.png")]
+	[InlineData("custom\\icon.png")]
+	public void Normalize_ReplacesNonLocalIconUrls(string iconUrl)
+	{
+		var branding = ClientBrandingOptions.Normalize(new ClientBrandingOptions { IconUrl = iconUrl });
+
+		Assert.Equal(ClientBrandingOptions.DefaultIconUrl, branding.IconUrl);
+	}
+
+	[Fact]
+	public void ProductInformation_ReportsTheMudClientProductVersion()
+	{
+		var information = ClientProductInformation.Current;
+
+		Assert.Equal(ClientProductInformation.ProductName, information.Name);
+		Assert.Matches(@"^\d+\.\d+\.\d+$", information.Version);
+	}
+}

--- a/MudClient/MudClientTests/ClientSettingsTests.cs
+++ b/MudClient/MudClientTests/ClientSettingsTests.cs
@@ -15,6 +15,7 @@ public class ClientSettingsTests
 			MessageLeftOffsetPx = 900,
 			MessageLineHeight = 0.1,
 			MessageSpacingPx = 900,
+			OutputWidthBehavior = (OutputWidthBehavior)999,
 			StackedCommandDelayMs = 1,
 			CommandStackingDelimiter = "\\"
 		});
@@ -25,6 +26,7 @@ public class ClientSettingsTests
 		Assert.Equal(500, normalized.MessageLeftOffsetPx);
 		Assert.Equal(1.0, normalized.MessageLineHeight);
 		Assert.Equal(100, normalized.MessageSpacingPx);
+		Assert.Equal(OutputWidthBehavior.Wrap, normalized.OutputWidthBehavior);
 		Assert.Equal(50, normalized.StackedCommandDelayMs);
 		Assert.Equal(";", normalized.CommandStackingDelimiter);
 	}

--- a/MudClient/MudClientTests/CommandHistoryNavigatorTests.cs
+++ b/MudClient/MudClientTests/CommandHistoryNavigatorTests.cs
@@ -36,6 +36,20 @@ public class CommandHistoryNavigatorTests
 	}
 
 	[Fact]
+	public void Navigate_DownPastNewestEntry_RestoresDraftInput()
+	{
+		var result = CommandHistoryNavigator.Navigate(
+			History,
+			History.Count - 1,
+			CommandHistoryDirection.Down,
+			false,
+			"say unfinished thought");
+
+		Assert.Equal(History.Count, result.Index);
+		Assert.Equal("say unfinished thought", result.Input);
+	}
+
+	[Fact]
 	public void Navigate_WithControlJump_MovesToRequestedHistoryBoundary()
 	{
 		var oldest = CommandHistoryNavigator.Navigate(History, History.Count, CommandHistoryDirection.Up, true);

--- a/MudClient/MudClientTests/WindowsInstallerRegressionTests.cs
+++ b/MudClient/MudClientTests/WindowsInstallerRegressionTests.cs
@@ -107,6 +107,16 @@ public class WindowsInstallerRegressionTests
 	}
 
 	[Fact]
+	public void InstallerPreservesDeploymentBrandingAssetsAcrossReleases()
+	{
+		var script = InstallerScript;
+
+		Assert.Contains("$customWebAssets = Join-Path $ConfigRoot 'web\\custom'", script, StringComparison.Ordinal);
+		Assert.Contains("Get-ChildItem -LiteralPath $customWebAssets -Force | Copy-Item", script, StringComparison.Ordinal);
+		Assert.Contains("$legacyCustomAssets = Join-Path $legacyReleasePath 'web\\wwwroot\\custom'", script, StringComparison.Ordinal);
+	}
+
+	[Fact]
 	public void ProxyConfiguresTheWindowsServiceLifetimeAndEventLog()
 	{
 		var program = ProxyProgram;

--- a/MudClient/MudWebSocketProxy/MudWebSocketProxy.csproj
+++ b/MudClient/MudWebSocketProxy/MudWebSocketProxy.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-		<Version>1.2.5</Version>
+		<Version>1.3.0</Version>
   </PropertyGroup>
 
 	<ItemGroup>

--- a/MudClient/deploy/linux/install-mudclient.sh
+++ b/MudClient/deploy/linux/install-mudclient.sh
@@ -67,6 +67,7 @@ if [[ -e "$install_root/proxy" && ! -L "$install_root/proxy" ]]; then
 	mkdir -p "$config_root/proxy" "$config_root/web"
 	[[ -f "$config_root/proxy/appsettings.json" ]] || cp -p "$legacy/proxy/appsettings.json" "$config_root/proxy/appsettings.json"
 	[[ ! -f "$legacy/web/wwwroot/appsettings.json" || -f "$config_root/web/appsettings.json" ]] || cp -p "$legacy/web/wwwroot/appsettings.json" "$config_root/web/appsettings.json"
+	[[ ! -d "$legacy/web/wwwroot/custom" || -d "$config_root/web/custom" ]] || cp -a "$legacy/web/wwwroot/custom" "$config_root/web/custom"
 	had_proxy_settings=true
 fi
 
@@ -76,6 +77,7 @@ mkdir -p "$install_root/releases" "$config_root/proxy" "$config_root/web"
 cp -a "$package_root" "$release"
 [[ -f "$config_root/proxy/appsettings.json" ]] || cp -p "$release/proxy/appsettings.json" "$config_root/proxy/appsettings.json"
 [[ -f "$config_root/web/appsettings.json" ]] || cp -p "$release/web/wwwroot/appsettings.json" "$config_root/web/appsettings.json"
+[[ -d "$config_root/web/custom" ]] || cp -a "$release/web/wwwroot/custom" "$config_root/web/custom"
 if [[ -n "$domain" && "$had_proxy_settings" == false ]]; then
 	cat >"$config_root/proxy/appsettings.json" <<EOF
 {
@@ -88,6 +90,8 @@ if [[ -n "$domain" && "$had_proxy_settings" == false ]]; then
 EOF
 fi
 cp -p "$config_root/web/appsettings.json" "$release/web/wwwroot/appsettings.json"
+mkdir -p "$release/web/wwwroot/custom"
+cp -a "$config_root/web/custom/." "$release/web/wwwroot/custom/"
 chmod +x "$release/proxy/MudWebSocketProxy" "$release/tools/MudClientDeployment"
 
 if ! id -u mudclient >/dev/null 2>&1; then

--- a/MudClient/deploy/windows/Install-MudClient.ps1
+++ b/MudClient/deploy/windows/Install-MudClient.ps1
@@ -191,12 +191,17 @@ Stop-MudClientLegacyProxyProcess -ProxyRoot $legacyProxy
 $legacyReleasePath = Move-MudClientLegacyInstallation -InstallRoot $InstallRoot -ReleaseRoot $releaseRoot -Migrate:$Migrate
 if ($legacyReleasePath) {
 	if (-not $previousTarget) { $previousTarget = $legacyReleasePath }
+	$configWebRoot = Join-Path $ConfigRoot 'web'
 	if (-not (Test-Path -LiteralPath (Join-Path $ConfigRoot 'proxy\appsettings.json'))) {
 		Copy-Item -LiteralPath (Join-Path $legacyReleasePath 'proxy\appsettings.json') -Destination (Join-Path $ConfigRoot 'proxy\appsettings.json')
 	}
 	$legacyWebSettings = Join-Path $legacyReleasePath 'web\wwwroot\appsettings.json'
 	if ((Test-Path -LiteralPath $legacyWebSettings) -and -not (Test-Path -LiteralPath (Join-Path $ConfigRoot 'web\appsettings.json'))) {
 		Copy-Item -LiteralPath $legacyWebSettings -Destination (Join-Path $ConfigRoot 'web\appsettings.json')
+	}
+	$legacyCustomAssets = Join-Path $legacyReleasePath 'web\wwwroot\custom'
+	if ((Test-Path -LiteralPath $legacyCustomAssets) -and -not (Test-Path -LiteralPath (Join-Path $configWebRoot 'custom'))) {
+		Copy-Item -LiteralPath $legacyCustomAssets -Destination (Join-Path $configWebRoot 'custom') -Recurse
 	}
 }
 if (Test-Path -LiteralPath $releasePath) {
@@ -208,9 +213,14 @@ if (Test-Path -LiteralPath $releasePath) {
 Copy-Item -LiteralPath $packageRoot -Destination $releasePath -Recurse
 $proxySettings = Join-Path $ConfigRoot 'proxy\appsettings.json'
 $webSettings = Join-Path $ConfigRoot 'web\appsettings.json'
+$customWebAssets = Join-Path $ConfigRoot 'web\custom'
+$releaseCustomWebAssets = Join-Path $releasePath 'web\wwwroot\custom'
 if (-not (Test-Path -LiteralPath $proxySettings)) { Copy-Item -LiteralPath (Join-Path $releasePath 'proxy\appsettings.json') -Destination $proxySettings }
 if (-not (Test-Path -LiteralPath $webSettings)) { Copy-Item -LiteralPath (Join-Path $releasePath 'web\wwwroot\appsettings.json') -Destination $webSettings }
+if (-not (Test-Path -LiteralPath $customWebAssets)) { Copy-Item -LiteralPath $releaseCustomWebAssets -Destination $customWebAssets -Recurse }
 Copy-Item -LiteralPath $webSettings -Destination (Join-Path $releasePath 'web\wwwroot\appsettings.json') -Force
+New-Item -ItemType Directory -Force -Path $releaseCustomWebAssets | Out-Null
+Get-ChildItem -LiteralPath $customWebAssets -Force | Copy-Item -Destination $releaseCustomWebAssets -Recurse -Force
 
 	foreach ($link in @('current', 'web', 'proxy')) {
 		$linkPath = Join-Path $InstallRoot $link


### PR DESCRIPTION
## Summary\n- publish the Web Client scroll, history, draft restoration, width, branding, and deployment improvements\n- update MudClient project and deployment documentation versions to 1.3.0\n\n## Validation\n- dotnet test MudClient/MudClientTests/MudClientTests.csproj -c Debug --no-restore -m:1 -p:UseSharedCompilation=false (133 passed)\n- evaluated MudClient project Version properties (1.3.0)\n- no remaining 1.2.5 references